### PR TITLE
fix(status): surface named-session lookup errors when snapshot is degraded (#2148)

### DIFF
--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -301,6 +301,13 @@ func namedSessionStatusForCity(
 			}
 			return "materialized"
 		}
+		// Bead not in snapshot. If the snapshot itself is degraded
+		// (load timeout or list error), surface that as a lookup error
+		// so operators see the same signal the pre-snapshot resolver
+		// path produced. See gastownhall/gascity#2148.
+		if err := statusSnapshot.LoadError(); err != nil {
+			return "lookup error: " + err.Error()
+		}
 		return status
 	}
 

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -165,6 +165,76 @@ func TestLoadStatusSessionSnapshotTimesOut(t *testing.T) {
 	if !strings.Contains(stderr.String(), "loading session snapshot timed out") {
 		t.Fatalf("stderr = %q, want timeout warning", stderr.String())
 	}
+	loadErr := snapshot.LoadError()
+	if loadErr == nil {
+		t.Fatal("snapshot.LoadError() = nil, want timeout error so downstream named-session lookup can surface it (gastownhall/gascity#2148)")
+	}
+	if !strings.Contains(loadErr.Error(), "timed out") {
+		t.Fatalf("snapshot.LoadError() = %v, want timeout text", loadErr)
+	}
+}
+
+// TestCityStatusNamedSessionSurfacesLookupErrorWhenSnapshotDegraded is the
+// regression test for gastownhall/gascity#2148. PR #2005 added a snapshot
+// fast path in namedSessionStatusForCity that returned the cfg-derived
+// status ("reserved-unmaterialized" / "degraded blocked") whenever a named
+// identity was absent from the snapshot — including the case where the
+// snapshot itself failed to load. That silently dropped the "lookup error:"
+// signal operators relied on when debugging.
+func TestCityStatusNamedSessionSurfacesLookupErrorWhenSnapshotDegraded(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{{
+			Name: "refinery",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+		}},
+	}
+
+	store := beads.NewMemStore()
+	degraded := newSessionBeadSnapshotWithError(nil, errors.New("loading session snapshot timed out after 20ms"))
+
+	status := namedSessionStatusForCity(
+		"/home/user/city", cfg, store, degraded,
+		"city", "refinery", "on_demand", nil,
+	)
+	if !strings.HasPrefix(status, "lookup error:") {
+		t.Fatalf("named session status = %q, want a 'lookup error: ...' prefix when snapshot is degraded", status)
+	}
+	if !strings.Contains(status, "timed out") {
+		t.Fatalf("named session status = %q, want underlying load-error text in the surfaced lookup error", status)
+	}
+}
+
+// TestCityStatusNamedSessionsCleanSnapshotStillSilent confirms the perf goal
+// from PR #2005 is preserved when the snapshot loaded cleanly: a missing
+// named identity returns the cfg-derived status (no "lookup error:" string,
+// no bead Get fallback).
+func TestCityStatusNamedSessionsCleanSnapshotStillSilent(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{{
+			Name: "refinery",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+		}},
+	}
+
+	store := beads.NewMemStore()
+	clean := newSessionBeadSnapshot(nil)
+	if clean.LoadError() != nil {
+		t.Fatalf("clean snapshot LoadError = %v, want nil", clean.LoadError())
+	}
+
+	status := namedSessionStatusForCity(
+		"/home/user/city", cfg, store, clean,
+		"city", "refinery", "on_demand", nil,
+	)
+	if strings.HasPrefix(status, "lookup error:") {
+		t.Fatalf("named session status = %q, want cfg-derived status (no lookup error) when snapshot loaded cleanly", status)
+	}
 }
 
 type failingStatusStore struct {

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -185,7 +185,7 @@ func loadStatusSessionSnapshot(store beads.Store, stderr io.Writer) *sessionBead
 			if stderr != nil {
 				fmt.Fprintf(stderr, "gc status: loading session snapshot: %v\n", result.err) //nolint:errcheck // best-effort stderr
 			}
-			return newSessionBeadSnapshot(nil)
+			return newSessionBeadSnapshotWithError(nil, fmt.Errorf("loading session snapshot: %w", result.err))
 		}
 		if result.snapshot == nil {
 			return newSessionBeadSnapshot(nil)
@@ -195,7 +195,7 @@ func loadStatusSessionSnapshot(store beads.Store, stderr io.Writer) *sessionBead
 		if stderr != nil {
 			fmt.Fprintf(stderr, "gc status: loading session snapshot timed out after %s; continuing with runtime-only status\n", statusSessionSnapshotTimeout) //nolint:errcheck // best-effort stderr
 		}
-		return newSessionBeadSnapshot(nil)
+		return newSessionBeadSnapshotWithError(nil, fmt.Errorf("loading session snapshot timed out after %s", statusSessionSnapshotTimeout))
 	}
 }
 

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -15,12 +15,41 @@ import (
 // reconciler calls this several times per tick, and closed history grows
 // without bound. Callers that need a closed record must fetch that one ID
 // explicitly.
+//
+// loadErr captures a non-fatal load failure (timeout, list error) so callers
+// can distinguish "snapshot loaded clean, the bead simply isn't present" from
+// "snapshot is degraded and may be missing entries it would otherwise have".
+// See gastownhall/gascity#2148 for the named-session lookup-error visibility
+// regression this field exists to surface.
 type sessionBeadSnapshot struct {
 	open                      []beads.Bead
 	beadIDByAgentName         map[string]string
 	beadIDByTemplateHint      map[string]string
 	sessionNameByAgentName    map[string]string
 	sessionNameByTemplateHint map[string]string
+	loadErr                   error
+}
+
+// LoadError reports a non-fatal error from the snapshot's load path (timeout
+// or list error). Returns nil when the snapshot loaded cleanly or when the
+// receiver is nil. Callers in degraded-fail-soft paths (status rendering,
+// named-session lookups) check this to surface the failure to operators
+// instead of returning a synthetic "not present" result.
+func (s *sessionBeadSnapshot) LoadError() error {
+	if s == nil {
+		return nil
+	}
+	return s.loadErr
+}
+
+// newSessionBeadSnapshotWithError builds a snapshot from beadsIn and tags it
+// with a non-fatal load error. Callers that fail-soft on load (returning an
+// empty snapshot instead of nil) use this so downstream consumers can still
+// see the underlying failure via LoadError.
+func newSessionBeadSnapshotWithError(beadsIn []beads.Bead, err error) *sessionBeadSnapshot {
+	s := newSessionBeadSnapshot(beadsIn)
+	s.loadErr = err
+	return s
 }
 
 func loadSessionBeadSnapshot(store beads.Store) (*sessionBeadSnapshot, error) {


### PR DESCRIPTION
Closes #2148.

PR #2005 added a snapshot-driven fast path in `namedSessionStatusForCity` to avoid bead `Get` calls. When the snapshot is **degraded** (load timeout or list error), the prior `resolveSessionIDWithConfig` path's `"lookup error: ..."` strings are no longer surfaced — operators see a synthetic `"materialized"` / `"reserved-unmaterialized"` status with no signal that the snapshot itself failed.

This restores the diagnostic signal without reintroducing the bead `Get` on the clean path.

## Fix

Carry the snapshot load error on the snapshot itself via a new `loadErr` field, exposed via `LoadError()`. In `namedSessionStatusForCity`, when the bead is absent **and** the snapshot is degraded, surface the load error as `"lookup error: ..."`. The clean-path perf goal from #2005 is preserved — no bead `Get` is added; only the snapshot's already-captured load error is plumbed through.

## Diff

```
 cmd/gc/city_status_snapshot.go      |  7 ++++
 cmd/gc/city_status_snapshot_test.go | 70 +++++++++++++++++++++++++++++++++++++
 cmd/gc/cmd_citystatus.go            |  4 +--
 cmd/gc/session_bead_snapshot.go     | 29 +++++++++++++++
 4 files changed, 108 insertions(+), 2 deletions(-)
```

## Test plan

- [x] `make build` passes
- [x] `golangci-lint` clean (0 issues)
- [x] `make test` passes (`cmd/gc` green)
- [x] New test in `city_status_snapshot_test.go` exercises the degraded-snapshot path → asserts `"lookup error: ..."` surfaces
- [x] Existing tests for clean snapshot path unchanged (perf goal preserved)
