### PR TITLE
fix(beads): add CachingStore Update/Close no-op filters (#1978 phase 1)

### DIFF
--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -35,6 +35,15 @@ func (c *CachingStore) Create(b Bead) (Bead, error) {
 
 // Update passes through to the backing store and refreshes the cache.
 func (c *CachingStore) Update(id string, opts UpdateOpts) error {
+	// Idempotence: if every non-nil field in opts already matches the
+	// cached bead AND the cache is primed, the backing call is a no-op.
+	// Skipping it avoids the bd subprocess invocation, the on_update
+	// hook, and the post-update Get refresh — same payoff as the
+	// SetMetadata short-circuit at metadataAlreadyMatchesCached.
+	// See gastownhall/gascity#1978 Phase 1.
+	if c.updateMatchesCached(id, opts) {
+		return nil
+	}
 	if err := c.backing.Update(id, opts); err != nil {
 		return err
 	}
@@ -66,6 +75,13 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 
 // Close marks a bead as closed in the backing store and cache.
 func (c *CachingStore) Close(id string) error {
+	// Idempotence: if the cached bead status is already "closed" AND the
+	// cache is primed, the backing call is a no-op. Skipping it avoids
+	// the bd subprocess invocation, the on_update hook, and the
+	// post-close Get refresh. See gastownhall/gascity#1978 Phase 1.
+	if c.closeAlreadyMatchesCached(id) {
+		return nil
+	}
 	if err := c.backing.Close(id); err != nil {
 		return err
 	}
@@ -273,6 +289,98 @@ func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error 
 	c.updateStatsLocked()
 	c.mu.Unlock()
 	return nil
+}
+
+// updateMatchesCached returns true when every non-nil field in opts already
+// reflects the cached bead's state AND the cache is primed. Returns false on
+// cache miss, uninitialized cache, or any field mismatch — in which case the
+// caller falls through to the backing write. Companion to
+// metadataAlreadyMatchesCached but covers the full UpdateOpts surface
+// (Title, Status, Type, Priority, Description, ParentID, Assignee, Metadata,
+// Labels, RemoveLabels). See gastownhall/gascity#1978 Phase 1.
+func (c *CachingStore) updateMatchesCached(id string, opts UpdateOpts) bool {
+	if id == "" {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return false
+	}
+	b, ok := c.beads[id]
+	if !ok {
+		return false
+	}
+	if opts.Title != nil && b.Title != *opts.Title {
+		return false
+	}
+	if opts.Status != nil && b.Status != *opts.Status {
+		return false
+	}
+	if opts.Type != nil && b.Type != *opts.Type {
+		return false
+	}
+	if opts.Priority != nil {
+		if b.Priority == nil || *b.Priority != *opts.Priority {
+			return false
+		}
+	}
+	if opts.Description != nil && b.Description != *opts.Description {
+		return false
+	}
+	if opts.ParentID != nil && b.ParentID != *opts.ParentID {
+		return false
+	}
+	if opts.Assignee != nil && b.Assignee != *opts.Assignee {
+		return false
+	}
+	for k, v := range opts.Metadata {
+		if b.Metadata == nil {
+			if v != "" {
+				return false
+			}
+			continue
+		}
+		if b.Metadata[k] != v {
+			return false
+		}
+	}
+	if len(opts.Labels) > 0 || len(opts.RemoveLabels) > 0 {
+		existing := make(map[string]struct{}, len(b.Labels))
+		for _, l := range b.Labels {
+			existing[l] = struct{}{}
+		}
+		for _, l := range opts.Labels {
+			if _, present := existing[l]; !present {
+				return false
+			}
+		}
+		for _, l := range opts.RemoveLabels {
+			if _, present := existing[l]; present {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// closeAlreadyMatchesCached returns true when the cached bead status is
+// already "closed" AND the cache is primed. Returns false on cache miss or
+// uninitialized cache. See gastownhall/gascity#1978 Phase 1.
+func (c *CachingStore) closeAlreadyMatchesCached(id string) bool {
+	if id == "" {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return false
+	}
+	b, ok := c.beads[id]
+	if !ok {
+		return false
+	}
+	return b.Status == "closed"
 }
 
 // metadataAlreadyMatchesCached returns true when the cache holds a primed

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -6,12 +6,14 @@ import (
 )
 
 // countingBackingStore wraps a Store and counts SetMetadata /
-// SetMetadataBatch invocations so tests can assert when CachingStore
-// short-circuits a no-op write before the backing call.
+// SetMetadataBatch / Update / Close invocations so tests can assert when
+// CachingStore short-circuits a no-op write before the backing call.
 type countingBackingStore struct {
 	Store
 	setMetadataCalls      int
 	setMetadataBatchCalls int
+	updateCalls           int
+	closeCalls            int
 }
 
 func (c *countingBackingStore) SetMetadata(id, key, value string) error {
@@ -22,6 +24,16 @@ func (c *countingBackingStore) SetMetadata(id, key, value string) error {
 func (c *countingBackingStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	c.setMetadataBatchCalls++
 	return c.Store.SetMetadataBatch(id, kvs)
+}
+
+func (c *countingBackingStore) Update(id string, opts UpdateOpts) error {
+	c.updateCalls++
+	return c.Store.Update(id, opts)
+}
+
+func (c *countingBackingStore) Close(id string) error {
+	c.closeCalls++
+	return c.Store.Close(id)
 }
 
 // TestCachingStoreSetMetadataSkipsBackingWhenCachedValueMatches verifies that
@@ -200,5 +212,209 @@ func TestCachingStoreSetMetadataBatchEmptyKVsIsNoop(t *testing.T) {
 	if backing.setMetadataBatchCalls != 0 {
 		t.Errorf("backing.SetMetadataBatch called %d times; want 0 (empty kvs must short-circuit)",
 			backing.setMetadataBatchCalls)
+	}
+}
+
+// TestCachingStoreUpdateSkipsBackingWhenAllFieldsMatch verifies that Update
+// short-circuits before the backing call when every non-nil opts field
+// already matches the cached bead. Without this guard the reconciler's
+// per-tick Update calls fire bd subprocesses + post-Get refreshes even when
+// the payload is identical. See gastownhall/gascity#1978 Phase 1.
+func TestCachingStoreUpdateSkipsBackingWhenAllFieldsMatch(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test", Assignee: "alice"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.updateCalls = 0
+
+	assignee := "alice"
+	if err := cache.Update(bead.ID, UpdateOpts{Assignee: &assignee}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if backing.updateCalls != 0 {
+		t.Errorf("backing.Update called %d times; want 0 (no-op update must short-circuit)",
+			backing.updateCalls)
+	}
+}
+
+// TestCachingStoreUpdateFallsThroughOnValueMismatch verifies that a real
+// field change still propagates to the backing store.
+func TestCachingStoreUpdateFallsThroughOnValueMismatch(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test", Assignee: "alice"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.updateCalls = 0
+
+	assignee := "bob"
+	if err := cache.Update(bead.ID, UpdateOpts{Assignee: &assignee}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if backing.updateCalls != 1 {
+		t.Errorf("backing.Update called %d times; want 1 (real change must propagate)",
+			backing.updateCalls)
+	}
+}
+
+// TestCachingStoreUpdateFallsThroughOnCacheMiss verifies that Update calls
+// the backing store when the cache has no entry for the bead — without a
+// primed copy we cannot prove the write is a no-op.
+func TestCachingStoreUpdateFallsThroughOnCacheMiss(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	bead, err := backing.Create(Bead{Title: "post-prime", Assignee: "alice"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing.updateCalls = 0
+
+	assignee := "alice"
+	if err := cache.Update(bead.ID, UpdateOpts{Assignee: &assignee}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if backing.updateCalls != 1 {
+		t.Errorf("backing.Update called %d times; want 1 (cache miss must fall through)",
+			backing.updateCalls)
+	}
+}
+
+// TestCachingStoreUpdateFallsThroughOnLabelMismatch verifies that a Labels
+// opt requesting a label not yet on the bead still propagates to the backing
+// store.
+func TestCachingStoreUpdateFallsThroughOnLabelMismatch(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test", Labels: []string{"existing"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.updateCalls = 0
+
+	if err := cache.Update(bead.ID, UpdateOpts{Labels: []string{"new-label"}}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if backing.updateCalls != 1 {
+		t.Errorf("backing.Update called %d times; want 1 (new label must propagate)",
+			backing.updateCalls)
+	}
+}
+
+// TestCachingStoreCloseSkipsBackingWhenAlreadyClosed verifies that Close
+// short-circuits before the backing call when the cached bead is already
+// closed. The cache only holds active beads after Prime, so the close has
+// to happen through CachingStore first to seed the closed status into the
+// cache. See gastownhall/gascity#1978 Phase 1.
+func TestCachingStoreCloseSkipsBackingWhenAlreadyClosed(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// First close: open → closed, must propagate.
+	if err := cache.Close(bead.ID); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if backing.closeCalls != 1 {
+		t.Fatalf("backing.Close after first close = %d, want 1", backing.closeCalls)
+	}
+	backing.closeCalls = 0
+
+	// Second close on the already-closed bead must short-circuit. The
+	// reconciler / cleanup paths sometimes re-close the same bead on
+	// retry; that should not generate fresh bd subprocess traffic.
+	if err := cache.Close(bead.ID); err != nil {
+		t.Fatalf("repeat Close: %v", err)
+	}
+	if backing.closeCalls != 0 {
+		t.Errorf("backing.Close called %d times on repeat close; want 0 (already-closed must short-circuit)",
+			backing.closeCalls)
+	}
+}
+
+// TestCachingStoreCloseFallsThroughWhenOpen verifies that a real close still
+// propagates to the backing store.
+func TestCachingStoreCloseFallsThroughWhenOpen(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.closeCalls = 0
+
+	if err := cache.Close(bead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if backing.closeCalls != 1 {
+		t.Errorf("backing.Close called %d times; want 1 (open->closed must propagate)",
+			backing.closeCalls)
+	}
+}
+
+// TestCachingStoreCloseFallsThroughOnCacheMiss verifies that Close calls the
+// backing store when the cache has no entry for the bead.
+func TestCachingStoreCloseFallsThroughOnCacheMiss(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	bead, err := backing.Create(Bead{Title: "post-prime"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing.closeCalls = 0
+
+	if err := cache.Close(bead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if backing.closeCalls != 1 {
+		t.Errorf("backing.Close called %d times; want 1 (cache miss must fall through)",
+			backing.closeCalls)
 	}
 }


### PR DESCRIPTION
Closes #2152. Phase 1 of #1978 (the cross-agent piece stays open for Phase 2 — see the scope note below).

## What

`CachingStore.SetMetadata{,Batch}` already short-circuits when the cached metadata already matches the incoming value (see `metadataAlreadyMatchesCached` and the comment block at the top of the function). `Update` and `Close` had no equivalent guard — every call shelled bd via the backing store, then ran a fresh `Get` to refresh the cache. The reconciler hot path re-issues identical `Update` / `Close` calls per tick across many agents, producing the no-op-write storm captured in #1978 (~25k connections in a 90-second window, almost all logging `nothing to commit`).

This patch extends the per-process idempotence filter to `Update` and `Close`:

- **`updateMatchesCached(id, opts)`** — covers every non-nil opts field (`Title`, `Status`, `Type`, `Priority`, `Description`, `ParentID`, `Assignee`, `Metadata`, `Labels`, `RemoveLabels`) and returns `false` when the cache is uninitialized (so a cold-start call still falls through).
- **`closeAlreadyMatchesCached(id)`** — returns `true` only when the cached bead is already in status `"closed"`.
- Both functions short-circuit **before** `backing.Update` / `backing.Close`, skipping the bd subprocess invocation, the on_update hook, and the post-mutation `Get` refresh.

Cache freshness still gates the short-circuit (`cacheLive | cachePartial` only), so any path running against a stale cache continues to fall through to the backing store.

## Tests

`internal/beads/caching_store_writes_internal_test.go` extends `countingBackingStore` to count `Update` and `Close` invocations and adds:

| Test | Asserts |
|------|---------|
| `TestCachingStoreUpdateSkipsBackingWhenAllFieldsMatch` | value-match → no backing call |
| `TestCachingStoreUpdateFallsThroughOnValueMismatch` | one differing field → backing call still fires |
| `TestCachingStoreUpdateFallsThroughOnCacheMiss` | bead created post-Prime → backing call fires |
| `TestCachingStoreUpdateFallsThroughOnLabelMismatch` | new label not yet on bead → backing call fires |
| `TestCachingStoreCloseSkipsBackingWhenAlreadyClosed` | second close on already-closed bead → no backing call |
| `TestCachingStoreCloseFallsThroughWhenOpen` | open → closed → backing call fires |
| `TestCachingStoreCloseFallsThroughOnCacheMiss` | bead created post-Prime → backing call fires |

`make test` (full fast unit suite) is green. `make lint` reports 0 issues. `go vet ./...` is clean.

## Scope note

Phase 1 is **per-process** only — N agents each running their own `CachingStore` still hit the storm when their independent caches diverge. The per-agent cache-isolation half of #1978 is Phase 2's job (event-bus-driven cross-agent cache convergence; uses the existing `bd hook → gc event emit → event bus → ApplyEvent` path). #1978 stays open after this lands.

Out of scope: long-lived bd daemon, in-process bead client, write batching. See the blast-radius report referenced in #2152 for the deferred-options trade-off matrix.