### PR TITLE
fix: retire legacy core implicit imports

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -42,6 +42,7 @@ var BootstrapPacks []Entry
 // wrote into ~/.gc/implicit-import.toml. EnsureBootstrap prunes matching
 // entries so upgraded installs stop carrying stale launch-only state forever.
 var RetiredBootstrapPacks = []Entry{
+	{Name: "core", Source: "github.com/gastownhall/gc-core"},
 	{Name: "import", Source: "github.com/gastownhall/gc-import"},
 	{Name: "registry", Source: "github.com/gastownhall/gc-registry"},
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -28,6 +28,11 @@ source = "github.com/gastownhall/gc-import"
 version = "0.2.0"
 commit = "abc123"
 
+[imports.core]
+source = "github.com/gastownhall/gc-core"
+version = "0.1.0"
+commit = "beef123"
+
 [imports.registry]
 source = "github.com/gastownhall/gc-registry"
 version = "0.1.0"
@@ -52,6 +57,9 @@ commit = "deadbeef"
 	text := string(data)
 	if strings.Contains(text, "[imports.import]") {
 		t.Fatalf("retired import entry should be pruned:\n%s", text)
+	}
+	if strings.Contains(text, "[imports.core]") {
+		t.Fatalf("retired core entry should be pruned:\n%s", text)
 	}
 	if strings.Contains(text, "[imports.registry]") {
 		t.Fatalf("retired registry entry should be pruned:\n%s", text)

--- a/internal/doctor/implicit_import_cache_check.go
+++ b/internal/doctor/implicit_import_cache_check.go
@@ -31,12 +31,6 @@ func (c *ImplicitImportCacheCheck) Name() string { return "implicit-import-cache
 // Run checks bootstrap-managed implicit import cache paths.
 func (c *ImplicitImportCacheCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
-	if len(bootstrap.BootstrapPacks) == 0 {
-		r.Status = StatusOK
-		r.Message = "no bootstrap implicit imports configured"
-		return r
-	}
-
 	imports, implicitPath, err := config.ReadImplicitImports()
 	if err != nil {
 		r.Status = StatusError
@@ -46,6 +40,20 @@ func (c *ImplicitImportCacheCheck) Run(_ *CheckContext) *CheckResult {
 	if implicitPath == "" {
 		r.Status = StatusOK
 		r.Message = "implicit import home unavailable"
+		return r
+	}
+
+	retired := inspectRetiredBootstrapImplicitImports(imports)
+	if len(bootstrap.BootstrapPacks) == 0 {
+		if len(retired) == 0 {
+			r.Status = StatusOK
+			r.Message = "no bootstrap implicit imports configured"
+			return r
+		}
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("%d retired bootstrap implicit %s", len(retired), pluralEntry(len(retired)))
+		r.Details = retired
+		r.FixHint = `run "gc doctor --fix" to prune retired bootstrap implicit imports`
 		return r
 	}
 
@@ -84,9 +92,6 @@ func (c *ImplicitImportCacheCheck) CanFix() bool { return true }
 // Fix re-materializes bootstrap-managed implicit imports and prunes stale
 // legacy-key cache directories when a canonical cache is present.
 func (c *ImplicitImportCacheCheck) Fix(_ *CheckContext) error {
-	if len(bootstrap.BootstrapPacks) == 0 {
-		return nil
-	}
 	importsBefore, implicitPath, err := config.ReadImplicitImports()
 	if err != nil {
 		return err
@@ -99,6 +104,9 @@ func (c *ImplicitImportCacheCheck) Fix(_ *CheckContext) error {
 	issuesBefore := inspectBootstrapImplicitImportCaches(gcHome, importsBefore)
 	if err := ensureBootstrapForDoctor(gcHome); err != nil {
 		return err
+	}
+	if len(bootstrap.BootstrapPacks) == 0 {
+		return nil
 	}
 
 	importsAfter, implicitPathAfter, err := config.ReadImplicitImports()
@@ -128,6 +136,25 @@ func (c *ImplicitImportCacheCheck) Fix(_ *CheckContext) error {
 	}
 
 	return nil
+}
+
+func inspectRetiredBootstrapImplicitImports(imports map[string]config.ImplicitImport) []string {
+	if len(imports) == 0 {
+		return nil
+	}
+	var details []string
+	for _, entry := range bootstrap.RetiredBootstrapPacks {
+		imp, ok := imports[entry.Name]
+		if !ok {
+			continue
+		}
+		if config.NormalizeRemoteSource(entry.Source) != config.NormalizeRemoteSource(imp.Source) {
+			continue
+		}
+		details = append(details, fmt.Sprintf("implicit import %q is retired", entry.Name))
+	}
+	sort.Strings(details)
+	return details
 }
 
 func inspectBootstrapImplicitImportCaches(gcHome string, imports map[string]config.ImplicitImport) []implicitImportCacheIssue {

--- a/internal/doctor/implicit_import_cache_check_test.go
+++ b/internal/doctor/implicit_import_cache_check_test.go
@@ -23,10 +23,17 @@ commit = "abc123"
 
 	check := &ImplicitImportCacheCheck{}
 	result := check.Run(&CheckContext{})
-	if result.Status != StatusOK {
-		t.Fatalf("status = %v, want OK; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; msg = %s; details = %v", result.Status, result.Message, result.Details)
 	}
 	if err := check.Fix(&CheckContext{}); err != nil {
 		t.Fatalf("Fix(): %v", err)
+	}
+	data, err := os.ReadFile(implicitPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", implicitPath, err)
+	}
+	if string(data) != "schema = 1\n" {
+		t.Fatalf("implicit import file after Fix() = %q, want only schema", string(data))
 	}
 }


### PR DESCRIPTION
## Summary

- stop seeding the legacy core implicit import in bootstrap
- prune retired implicit imports during the doctor implicit-import cache check

## Compatibility

This does not use unreleased Beads CLI/API flags. Denylist scan passed for --ephemeral, --include-ephemeral, --no-history, and --no-cycle-check.

## Tests

- go test ./internal/bootstrap ./internal/doctor -run 'Test.*Implicit|Test.*Builtin|Test.*Legacy'