### PR TITLE
Support rig-scoped named session resolution

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/configedit"
@@ -351,6 +352,9 @@ func findAgentByQualified(cfg *config.City, identity string) (config.Agent, bool
 		if config.AgentMatchesIdentity(&a, identity) {
 			return a, true
 		}
+	}
+	if a, ok := agentutil.ResolveQualifiedRigScopedTemplate(cfg, identity); ok {
+		return a, true
 	}
 	return config.Agent{}, false
 }

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -117,6 +117,23 @@ func buildAwakeInputFromReconciler(
 		input.SessionBeads = append(input.SessionBeads, bead)
 	}
 
+	// Preserve the reconciler's existing wake continuity for already-materialized
+	// on-demand named sessions: when work_query matched the backing template and
+	// the canonical bead still exists, carry an explicit named-session work-query
+	// signal rather than waking ordinary siblings from the generic WorkSet path.
+	for _, ns := range input.NamedSessions {
+		if ns.Mode != "on_demand" || !input.WorkSet[ns.Template] {
+			continue
+		}
+		if resolveNamedSessionBeadName(input.SessionBeads, ns) == "" {
+			continue
+		}
+		if input.NamedSessionWorkQ == nil {
+			input.NamedSessionWorkQ = make(map[string]bool)
+		}
+		input.NamedSessionWorkQ[ns.Identity] = true
+	}
+
 	// Runtime liveness comes from wakeTargets. Attachment is probed only when
 	// it can affect the awake decision; the common active desired-session path
 	// is already awake and has no idle reference to suppress.

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -147,6 +147,59 @@ func TestBuildAwakeInputFromReconcilerCarriesNamedSessionDemand(t *testing.T) {
 	}
 }
 
+func TestBuildAwakeInputFromReconciler_RigNamedWorkQueryDemandWakesCanonicalSession(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.City{
+		ResolvedWorkspaceName: "gc-test",
+		Agents: []config.Agent{
+			{Name: "worker", Scope: "rig", WorkQuery: "echo 1"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Name: "refinery", Template: "worker", Mode: "on_demand", Scope: "rig", Dir: "rig-a"},
+		},
+	}
+	identity := "rig-a/refinery"
+	runtimeName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, identity)
+	sessionBead := beads.Bead{
+		ID:     "mc-session-1",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"configured_named_session":  "true",
+			"state":                     "asleep",
+			"session_name":              runtimeName,
+			"template":                  "rig-a/worker",
+			"configured_named_identity": identity,
+			"configured_named_mode":     "on_demand",
+		},
+	}
+
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		[]beads.Bead{sessionBead},
+		nil,
+		nil,
+		map[string]bool{"rig-a/worker": true},
+		nil,
+		nil,
+		nil,
+		runtime.NewFake(),
+		now,
+	)
+
+	decisions := ComputeAwakeSet(input)
+	got, ok := decisions[runtimeName]
+	if !ok {
+		t.Fatal("decision for rig named session missing from awake set")
+	}
+	if !got.ShouldWake {
+		t.Fatalf("decision = %+v, want wake", got)
+	}
+	if got.Reason != "work-query" {
+		t.Fatalf("Reason = %q, want work-query", got.Reason)
+	}
+}
+
 // TestBuildAwakeInputFromReconcilerNamedAlwaysPostChurnRewakes pins the
 // contract for a mode=always named session that was put to sleep after churn:
 // if named-session metadata survives, the next awake-set pass must re-wake it.

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -24,6 +24,7 @@ type AwakeInput struct {
 	WorkBeads          []AwakeWorkBead // in_progress assigned work plus ready open assigned work
 	ScaleCheckCounts   map[string]int  // agent template → scale_check count
 	NamedSessionDemand map[string]bool // named-session identity → routed/assigned work demand
+	NamedSessionWorkQ  map[string]bool // named-session identity → bridge-carried work_query demand
 	WorkSet            map[string]bool // agent template → work_query found pending work
 	RunningSessions    map[string]bool // session name → tmux exists
 	AttachedSessions   map[string]bool // session name → user attached
@@ -163,9 +164,13 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 				desired[ns.Identity] = "named-always"
 			}
 		case "on_demand":
-			// On-demand named sessions wake only from named demand that was
-			// resolved by the desired-state pass, not generic template demand.
-			if !input.NamedSessionDemand[ns.Identity] {
+			reason := ""
+			switch {
+			case input.NamedSessionDemand[ns.Identity]:
+				reason = "named-demand"
+			case input.NamedSessionWorkQ[ns.Identity]:
+				reason = "work-query"
+			default:
 				continue
 			}
 			if agent, ok := agentsByName[ns.Template]; ok && agent.Suspended {
@@ -174,10 +179,10 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			if sn := resolveNamedSessionBeadName(input.SessionBeads, ns); sn != "" {
 				bead := findBeadBySessionName(input.SessionBeads, sn)
 				if bead != nil && !bead.DependencyOnly && !bead.Drained && bead.State != "closed" {
-					desired[sn] = "named-demand"
+					desired[sn] = reason
 				}
 			} else {
-				desired[ns.Identity] = "named-demand"
+				desired[ns.Identity] = reason
 			}
 		}
 	}
@@ -220,37 +225,19 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	// When work_query sees pending work but ScaleCheckCounts hasn't caught up
 	// (count is 0 or absent), wake exactly one session to handle it. This
 	// avoids thundering herd — scale_check will catch up on the next tick.
-	//
-	// For on-demand named sessions, buildDesiredState already used the same
-	// work_query signal to materialize the canonical bead. Mirror that here
-	// so the newly materialized or retained named session actually wakes.
 	for template, hasWork := range input.WorkSet {
 		if !hasWork {
 			continue
 		}
-		if isNamedSessionTemplate(input.NamedSessions, template) {
-			agent, ok := lookupAgent(template)
-			if !ok || agent.Suspended {
-				continue
-			}
-			for _, ns := range input.NamedSessions {
-				if ns.Template != template || ns.Mode != "on_demand" {
-					continue
-				}
-				if sn := resolveNamedSessionBeadName(input.SessionBeads, ns); sn != "" {
-					desired[sn] = "work-query"
-				} else {
-					desired[ns.Identity] = "work-query"
-				}
-			}
-			continue
-		}
 		if input.ScaleCheckCounts[template] > 0 {
-			continue // ScaleCheck already covers ordinary pool templates
+			continue // ScaleCheck already covers this template
 		}
 		agent, ok := lookupAgent(template)
 		if !ok || agent.Suspended {
 			continue
+		}
+		if isNamedSessionTemplate(input.NamedSessions, template) {
+			continue // named sessions are handled in the named-session pass
 		}
 		// collectActiveBeads already excludes DependencyOnly and Drained
 		if active := collectActiveBeads(input.SessionBeads, template); len(active) > 0 {

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -98,8 +98,29 @@ type AwakeDecision struct {
 // executePlannedStarts handles it via wave-based starts.
 func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	agentsByName := make(map[string]AwakeAgent, len(input.Agents))
+	agentsByBaseName := make(map[string]AwakeAgent, len(input.Agents))
+	duplicateBaseNames := make(map[string]bool)
 	for _, a := range input.Agents {
 		agentsByName[a.QualifiedName] = a
+		base := awakeAgentBaseName(a.QualifiedName)
+		if existing, ok := agentsByBaseName[base]; ok && existing.QualifiedName != a.QualifiedName {
+			duplicateBaseNames[base] = true
+			continue
+		}
+		if !duplicateBaseNames[base] {
+			agentsByBaseName[base] = a
+		}
+	}
+	lookupAgent := func(name string) (AwakeAgent, bool) {
+		if agent, ok := agentsByName[name]; ok {
+			return agent, true
+		}
+		base := awakeAgentBaseName(name)
+		if duplicateBaseNames[base] {
+			return AwakeAgent{}, false
+		}
+		agent, ok := agentsByBaseName[base]
+		return agent, ok
 	}
 
 	// Step 1: Build desired set.
@@ -128,7 +149,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 
 	// Named sessions
 	for _, ns := range input.NamedSessions {
-		if agent, ok := agentsByName[ns.Identity]; ok && agent.Suspended {
+		if agent, ok := lookupAgent(ns.Identity); ok && agent.Suspended {
 			continue
 		}
 		switch ns.Mode {
@@ -166,7 +187,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		if count <= 0 {
 			continue
 		}
-		agent, ok := agentsByName[template]
+		agent, ok := lookupAgent(template)
 		if !ok || agent.Suspended {
 			continue
 		}
@@ -199,19 +220,37 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	// When work_query sees pending work but ScaleCheckCounts hasn't caught up
 	// (count is 0 or absent), wake exactly one session to handle it. This
 	// avoids thundering herd — scale_check will catch up on the next tick.
+	//
+	// For on-demand named sessions, buildDesiredState already used the same
+	// work_query signal to materialize the canonical bead. Mirror that here
+	// so the newly materialized or retained named session actually wakes.
 	for template, hasWork := range input.WorkSet {
 		if !hasWork {
 			continue
 		}
-		if input.ScaleCheckCounts[template] > 0 {
-			continue // ScaleCheck already covers this template
-		}
-		agent, ok := agentsByName[template]
-		if !ok || agent.Suspended {
+		if isNamedSessionTemplate(input.NamedSessions, template) {
+			agent, ok := lookupAgent(template)
+			if !ok || agent.Suspended {
+				continue
+			}
+			for _, ns := range input.NamedSessions {
+				if ns.Template != template || ns.Mode != "on_demand" {
+					continue
+				}
+				if sn := resolveNamedSessionBeadName(input.SessionBeads, ns); sn != "" {
+					desired[sn] = "work-query"
+				} else {
+					desired[ns.Identity] = "work-query"
+				}
+			}
 			continue
 		}
-		if isNamedSessionTemplate(input.NamedSessions, template) {
-			continue // named sessions are handled in the named-session pass
+		if input.ScaleCheckCounts[template] > 0 {
+			continue // ScaleCheck already covers ordinary pool templates
+		}
+		agent, ok := lookupAgent(template)
+		if !ok || agent.Suspended {
+			continue
 		}
 		// collectActiveBeads already excludes DependencyOnly and Drained
 		if active := collectActiveBeads(input.SessionBeads, template); len(active) > 0 {
@@ -241,7 +280,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		if bead.State == "closed" {
 			continue
 		}
-		if agent, ok := agentsByName[bead.Template]; ok && agent.Suspended {
+		if agent, ok := lookupAgent(bead.Template); ok && agent.Suspended {
 			continue
 		}
 		for _, wb := range input.WorkBeads {
@@ -313,7 +352,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// still respecting hard blockers applied below.
 		pinBlockedByState := bead.State == "suspended" || bead.State == "closed" || bead.Drained
 		if !decision.ShouldWake && bead.Pinned && !pinBlockedByState && !bead.DependencyOnly && !bead.WaitHold {
-			if agent, ok := agentsByName[bead.Template]; ok && !agent.Suspended {
+			if agent, ok := lookupAgent(bead.Template); ok && !agent.Suspended {
 				decision.ShouldWake = true
 				decision.Reason = "pin"
 			}
@@ -327,7 +366,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
 			!isAlwaysNamedSession(input.NamedSessions, bead) &&
 			desired[name] != "assigned-work" {
-			agent, hasAgent := agentsByName[bead.Template]
+			agent, hasAgent := lookupAgent(bead.Template)
 			var idleTimeout time.Duration
 			switch {
 			case bead.ManualSession && input.ChatIdleTimeout > 0:
@@ -366,6 +405,13 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	}
 
 	return result
+}
+
+func awakeAgentBaseName(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		return name[idx+1:]
+	}
+	return name
 }
 
 func findNamedSessionName(beads []AwakeSessionBead, identity string) string {

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1475,7 +1475,7 @@ func TestWorkSet_SkipsSuspendedAgent(t *testing.T) {
 	assertAsleep(t, result, "polecat-mc-1")
 }
 
-func TestWorkSet_WakesNamedSessionFromTemplateKey(t *testing.T) {
+func TestWorkSet_DoesNotWakeNamedSessionFromTemplateKey(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/worker"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/worker", Mode: "on_demand"}},
@@ -1483,11 +1483,10 @@ func TestWorkSet_WakesNamedSessionFromTemplateKey(t *testing.T) {
 		WorkSet:       map[string]bool{"hello-world/worker": true},
 		Now:           now,
 	})
-	assertAwake(t, result, "hello-world--refinery")
-	assertReason(t, result, "hello-world--refinery", "work-query")
+	assertAsleep(t, result, "hello-world--refinery")
 }
 
-func TestWorkSet_WakesRigScopedNamedSessionFromQualifiedTemplateKey(t *testing.T) {
+func TestWorkSet_DoesNotWakeRigScopedNamedSessionFromQualifiedTemplateKey(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{{QualifiedName: "rig-a/worker"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "rig-a/refinery", Template: "rig-a/worker", Mode: "on_demand"}},
@@ -1495,20 +1494,7 @@ func TestWorkSet_WakesRigScopedNamedSessionFromQualifiedTemplateKey(t *testing.T
 		WorkSet:       map[string]bool{"rig-a/worker": true},
 		Now:           now,
 	})
-	assertAwake(t, result, "gc-test--rig-a--refinery")
-	assertReason(t, result, "gc-test--rig-a--refinery", "work-query")
-}
-
-func TestWorkSet_WakesRigScopedNamedSessionWithGenericRigAgentEntry(t *testing.T) {
-	result := ComputeAwakeSet(AwakeInput{
-		Agents:        []AwakeAgent{{QualifiedName: "worker"}},
-		NamedSessions: []AwakeNamedSession{{Identity: "rig-a/refinery", Template: "rig-a/worker", Mode: "on_demand"}},
-		SessionBeads:  []AwakeSessionBead{{ID: "mc-1", SessionName: "gc-test--rig-a--refinery", Template: "rig-a/worker", State: "asleep", NamedIdentity: "rig-a/refinery"}},
-		WorkSet:       map[string]bool{"rig-a/worker": true},
-		Now:           now,
-	})
-	assertAwake(t, result, "gc-test--rig-a--refinery")
-	assertReason(t, result, "gc-test--rig-a--refinery", "work-query")
+	assertAsleep(t, result, "gc-test--rig-a--refinery")
 }
 
 func TestWorkSet_SkipsOrdinarySiblingForNamedTemplate(t *testing.T) {

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1475,7 +1475,7 @@ func TestWorkSet_SkipsSuspendedAgent(t *testing.T) {
 	assertAsleep(t, result, "polecat-mc-1")
 }
 
-func TestWorkSet_DoesNotWakeNamedSessionFromTemplateKey(t *testing.T) {
+func TestWorkSet_WakesNamedSessionFromTemplateKey(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/worker"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/worker", Mode: "on_demand"}},
@@ -1483,10 +1483,11 @@ func TestWorkSet_DoesNotWakeNamedSessionFromTemplateKey(t *testing.T) {
 		WorkSet:       map[string]bool{"hello-world/worker": true},
 		Now:           now,
 	})
-	assertAsleep(t, result, "hello-world--refinery")
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "work-query")
 }
 
-func TestWorkSet_DoesNotWakeRigScopedNamedSessionFromQualifiedTemplateKey(t *testing.T) {
+func TestWorkSet_WakesRigScopedNamedSessionFromQualifiedTemplateKey(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{{QualifiedName: "rig-a/worker"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "rig-a/refinery", Template: "rig-a/worker", Mode: "on_demand"}},
@@ -1494,7 +1495,20 @@ func TestWorkSet_DoesNotWakeRigScopedNamedSessionFromQualifiedTemplateKey(t *tes
 		WorkSet:       map[string]bool{"rig-a/worker": true},
 		Now:           now,
 	})
-	assertAsleep(t, result, "gc-test--rig-a--refinery")
+	assertAwake(t, result, "gc-test--rig-a--refinery")
+	assertReason(t, result, "gc-test--rig-a--refinery", "work-query")
+}
+
+func TestWorkSet_WakesRigScopedNamedSessionWithGenericRigAgentEntry(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "worker"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "rig-a/refinery", Template: "rig-a/worker", Mode: "on_demand"}},
+		SessionBeads:  []AwakeSessionBead{{ID: "mc-1", SessionName: "gc-test--rig-a--refinery", Template: "rig-a/worker", State: "asleep", NamedIdentity: "rig-a/refinery"}},
+		WorkSet:       map[string]bool{"rig-a/worker": true},
+		Now:           now,
+	})
+	assertAwake(t, result, "gc-test--rig-a--refinery")
+	assertReason(t, result, "gc-test--rig-a--refinery", "work-query")
 }
 
 func TestWorkSet_SkipsOrdinarySiblingForNamedTemplate(t *testing.T) {

--- a/internal/agentutil/resolve.go
+++ b/internal/agentutil/resolve.go
@@ -53,6 +53,9 @@ func ResolveAgent(cfg *config.City, input string, opts ResolveOpts) (config.Agen
 	if a, ok := findAgentByQualified(cfg, input); ok {
 		return a, true
 	}
+	if a, ok := ResolveQualifiedRigScopedTemplate(cfg, input); ok {
+		return a, true
+	}
 
 	// Step 2b: qualified pool instance — "rig/polecat-2" or
 	// "binding.polecat-2" matches the corresponding pool template.
@@ -91,6 +94,9 @@ func resolveTemplate(cfg *config.City, input string) (config.Agent, bool) {
 	if a, ok := findAgentByQualified(cfg, input); ok {
 		return a, true
 	}
+	if a, ok := ResolveQualifiedRigScopedTemplate(cfg, input); ok {
+		return a, true
+	}
 	if strings.Contains(input, "/") {
 		return config.Agent{}, false
 	}
@@ -114,6 +120,44 @@ func findAgentByQualified(cfg *config.City, identity string) (config.Agent, bool
 		}
 	}
 	return config.Agent{}, false
+}
+
+// ResolveQualifiedRigScopedTemplate resolves "rig/name" against a generic
+// scope="rig" template that applies to every configured rig. It returns a
+// synthetic rig-bound copy so downstream code sees the concrete identity.
+func ResolveQualifiedRigScopedTemplate(cfg *config.City, identity string) (config.Agent, bool) {
+	if cfg == nil || !strings.Contains(identity, "/") {
+		return config.Agent{}, false
+	}
+	dir, name := config.ParseQualifiedName(identity)
+	if dir == "" || name == "" || !hasRig(cfg, dir) {
+		return config.Agent{}, false
+	}
+
+	var match *config.Agent
+	for i := range cfg.Agents {
+		a := &cfg.Agents[i]
+		if a.Name != name || a.Dir != "" || a.Scope != "rig" {
+			continue
+		}
+		if match != nil {
+			return config.Agent{}, false
+		}
+		match = a
+	}
+	if match == nil {
+		return config.Agent{}, false
+	}
+	return DeepCopyAgent(match, match.Name, dir), true
+}
+
+func hasRig(cfg *config.City, name string) bool {
+	for _, rig := range cfg.Rigs {
+		if rig.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // resolvePoolInstanceQualified handles qualified pool instance names like

--- a/internal/agentutil/resolve_test.go
+++ b/internal/agentutil/resolve_test.go
@@ -172,6 +172,34 @@ func TestResolveAgentTemplateOnlyAcceptsTemplate(t *testing.T) {
 	}
 }
 
+func TestResolveAgentQualifiedGenericRigScopedTemplate(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "reviewer", Scope: "rig"},
+		},
+		Rigs: []config.Rig{
+			{Name: "alpha"},
+			{Name: "beta"},
+		},
+	}
+
+	a, ok := ResolveAgent(cfg, "alpha/reviewer", ResolveOpts{AllowPoolMembers: true})
+	if !ok {
+		t.Fatal("expected to resolve alpha/reviewer")
+	}
+	if got := a.QualifiedName(); got != "alpha/reviewer" {
+		t.Fatalf("QualifiedName() = %q, want %q", got, "alpha/reviewer")
+	}
+
+	template, ok := ResolveAgent(cfg, "beta/reviewer", ResolveOpts{TemplateOnly: true})
+	if !ok {
+		t.Fatal("expected TemplateOnly to resolve beta/reviewer")
+	}
+	if got := template.QualifiedName(); got != "beta/reviewer" {
+		t.Fatalf("TemplateOnly QualifiedName() = %q, want %q", got, "beta/reviewer")
+	}
+}
+
 func TestResolveAgentNotFound(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
@@ -262,6 +263,9 @@ func findAgent(cfg *config.City, name string) (config.Agent, bool) {
 				}
 			}
 		}
+	}
+	if a, ok := agentutil.ResolveQualifiedRigScopedTemplate(cfg, name); ok {
+		return a, true
 	}
 	return config.Agent{}, false
 }

--- a/internal/api/handler_agents_test.go
+++ b/internal/api/handler_agents_test.go
@@ -693,6 +693,26 @@ func TestFindAgentPoolMaxZero(t *testing.T) {
 	}
 }
 
+func TestFindAgent_QualifiedGenericRigScopedTemplate(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "reviewer", Scope: "rig"},
+		},
+		Rigs: []config.Rig{
+			{Name: "alpha"},
+			{Name: "beta"},
+		},
+	}
+
+	a, ok := findAgent(cfg, "alpha/reviewer")
+	if !ok {
+		t.Fatal("findAgent(alpha/reviewer) = false, want true")
+	}
+	if got := a.QualifiedName(); got != "alpha/reviewer" {
+		t.Fatalf("QualifiedName() = %q, want alpha/reviewer", got)
+	}
+}
+
 func TestAgentOutputNotRunning(t *testing.T) {
 	state := newFakeState(t)
 	srv := New(state)

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -608,6 +608,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	}
 	prov.Warnings = append(prov.Warnings, siteBindingWarnings...)
 
+	// Inline scope="rig" named sessions are generic declarations until the
+	// city's rig set is finalized. Stamp them after site bindings so the
+	// controller sees one concrete identity per rig.
+	ExpandGenericRigNamedSessions(root)
+
 	// Validate named session declarations after pack expansion and site
 	// binding resolution so stamped identities and deterministic runtime
 	// names reflect the effective workspace identity.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -436,6 +436,27 @@ func (s *NamedSession) ModeOrDefault() string {
 	return s.Mode
 }
 
+// ExpandGenericRigNamedSessions stamps inline scope="rig" named sessions that
+// omit Dir into one concrete identity per configured rig.
+func ExpandGenericRigNamedSessions(cfg *City) {
+	if cfg == nil || len(cfg.NamedSessions) == 0 {
+		return
+	}
+	expanded := make([]NamedSession, 0, len(cfg.NamedSessions))
+	for _, ns := range cfg.NamedSessions {
+		if ns.Scope == "rig" && ns.Dir == "" {
+			for _, rig := range cfg.Rigs {
+				stamped := ns
+				stamped.Dir = rig.Name
+				expanded = append(expanded, stamped)
+			}
+			continue
+		}
+		expanded = append(expanded, ns)
+	}
+	cfg.NamedSessions = expanded
+}
+
 // FormulaLayers holds resolved formula directories for symlink materialization.
 // Each slice is ordered lowest→highest priority; later entries shadow earlier
 // ones by filename.
@@ -3362,10 +3383,6 @@ func validateNamedSessions(cfg *City, requireBackingTemplate bool) error {
 	seen := make(map[sessionKey]bool, len(cfg.NamedSessions))
 	reservedAliases := make(map[string]string, len(cfg.NamedSessions))
 	reservedSessionNames := make(map[string]string, len(cfg.NamedSessions))
-	agentsByTemplate := make(map[string]*Agent, len(cfg.Agents))
-	for i := range cfg.Agents {
-		agentsByTemplate[cfg.Agents[i].QualifiedName()] = &cfg.Agents[i]
-	}
 	alwaysByTemplate := make(map[string]int)
 	for i := range cfg.NamedSessions {
 		s := &cfg.NamedSessions[i]
@@ -3395,7 +3412,7 @@ func validateNamedSessions(cfg *City, requireBackingTemplate bool) error {
 			return fmt.Errorf("named_session %q: duplicate identity", s.QualifiedName())
 		}
 		seen[key] = true
-		agent := agentsByTemplate[s.TemplateQualifiedName()]
+		agent := FindAgent(cfg, s.TemplateQualifiedName())
 		if agent == nil {
 			if requireBackingTemplate {
 				return fmt.Errorf("named_session %q: referenced template not found after pack expansion", s.QualifiedName())

--- a/internal/config/named_sessions.go
+++ b/internal/config/named_sessions.go
@@ -54,7 +54,39 @@ func FindAgent(cfg *City, identity string) *Agent {
 			return &cfg.Agents[i]
 		}
 	}
-	return nil
+	dir, name := ParseQualifiedName(identity)
+	if dir == "" || name == "" {
+		return nil
+	}
+	if !hasRigNamed(cfg, dir) {
+		return nil
+	}
+	var match *Agent
+	for i := range cfg.Agents {
+		a := &cfg.Agents[i]
+		if a.Name != name || a.Dir != "" || a.Scope != "rig" {
+			continue
+		}
+		if match != nil {
+			return nil
+		}
+		match = a
+	}
+	if match == nil {
+		return nil
+	}
+	synth := *match
+	synth.Dir = dir
+	return &synth
+}
+
+func hasRigNamed(cfg *City, name string) bool {
+	for _, rig := range cfg.Rigs {
+		if rig.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // EffectiveCityName returns the name used for deterministic runtime naming.

--- a/internal/config/session_model_phase0_spec_test.go
+++ b/internal/config/session_model_phase0_spec_test.go
@@ -39,9 +39,9 @@ template = "reviewer"
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 
-	cfg, err := Load(fsys.OSFS{}, cityPath)
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
 	if err != nil {
-		t.Fatalf("Load(city.toml): %v", err)
+		t.Fatalf("LoadWithIncludes(city.toml): %v", err)
 	}
 	if len(cfg.NamedSessions) != 2 {
 		t.Fatalf("len(NamedSessions) = %d, want 2", len(cfg.NamedSessions))
@@ -198,14 +198,61 @@ template = "reviewer"
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 
-	cfg, err := Load(fsys.OSFS{}, cityPath)
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
 	if err != nil {
-		t.Fatalf("Load(city.toml): %v", err)
+		t.Fatalf("LoadWithIncludes(city.toml): %v", err)
 	}
 	if len(cfg.NamedSessions) != 1 {
 		t.Fatalf("len(NamedSessions) = %d, want 1", len(cfg.NamedSessions))
 	}
 	if got := cfg.NamedSessions[0].QualifiedName(); got != "reviewer" {
 		t.Fatalf("QualifiedName = %q, want compatibility default reviewer", got)
+	}
+}
+
+func TestPhase0NamedSessionConfig_ExpandsGenericRigScopedNamedSessionsPerRig(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "city.toml")
+	configText := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "reviewer"
+scope = "rig"
+start_command = "true"
+
+[[named_session]]
+template = "reviewer"
+scope = "rig"
+
+[[rigs]]
+name = "alpha"
+path = "/tmp/alpha"
+
+[[rigs]]
+name = "beta"
+path = "/tmp/beta"
+`
+	if err := os.WriteFile(cityPath, []byte(configText), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes(city.toml): %v", err)
+	}
+	if len(cfg.NamedSessions) != 2 {
+		t.Fatalf("len(NamedSessions) = %d, want 2", len(cfg.NamedSessions))
+	}
+	if got := cfg.NamedSessions[0].QualifiedName(); got != "alpha/reviewer" {
+		t.Fatalf("NamedSessions[0] = %q, want alpha/reviewer", got)
+	}
+	if got := cfg.NamedSessions[1].QualifiedName(); got != "beta/reviewer" {
+		t.Fatalf("NamedSessions[1] = %q, want beta/reviewer", got)
+	}
+	if got := cfg.NamedSessions[0].TemplateQualifiedName(); got != "alpha/reviewer" {
+		t.Fatalf("TemplateQualifiedName() = %q, want alpha/reviewer", got)
+	}
+	if agent := FindAgent(cfg, "alpha/reviewer"); agent == nil {
+		t.Fatal("FindAgent(alpha/reviewer) = nil, want backing template")
 	}
 }


### PR DESCRIPTION
## Summary

This fixes rig-scoped named session resolution so the same identity works consistently across config load, CLI/API lookup, and awake-set demand handling.

## Problem

Rig-scoped generic templates and named sessions could resolve inconsistently depending on the code path.

Symptoms included:
- config load accepting a rig-scoped named session shape but not expanding it into concrete per-rig identities
- CLI/API lookup failing to resolve `rig/name` against a generic `scope="rig"` template
- awake-set logic skipping work-query wakeups for rig-scoped named sessions when only the generic rig template existed in config

## Fix

- expand inline `scope="rig"` named sessions into concrete per-rig identities during config composition
- teach config/agent resolution to synthesize a rig-qualified view from generic rig-scoped templates
- make CLI/API lookup use the same rig-qualified fallback
- make awake-set demand lookup fall back by base template name so rig-scoped named sessions can wake from `work_query`

## Tests

Added/updated regression coverage for:
- rig-qualified generic template resolution
- named-session expansion per rig during config load
- API lookup for qualified rig-scoped identities
- awake-set wake behavior for rig-scoped named sessions
- reconciler bridge handling for rig-scoped named-session work-query demand

## Notes for Reviewers

The intent here is consistency:
- one config shape
- one identity model
- one resolution story across all surfaces

Refs azanar/gascity#17
