### PR TITLE
Avoid false runtime death classification

### DIFF
--- a/cmd/gc/adoption_barrier.go
+++ b/cmd/gc/adoption_barrier.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os/exec"
 	"regexp"
 	"strconv"
 
@@ -139,7 +140,8 @@ func runAdoptionBarrier(
 				isPoolInstance = true
 			}
 		}
-		alive, err := workerSessionTargetAliveWithConfig(nil, sp, nil, sessionName, processHints(cfgAgent))
+		processNames := processHints(cfg, cfgAgent)
+		alive, err := workerSessionTargetAliveWithConfig(nil, sp, nil, sessionName, processNames)
 		if err != nil || !alive {
 			result.Total--
 			continue
@@ -317,9 +319,9 @@ func parsePoolSlot(sessionName string) int {
 	return slot
 }
 
-func processHints(a *config.Agent) []string {
+func processHints(cfg *config.City, a *config.Agent) []string {
 	if a == nil {
 		return nil
 	}
-	return a.ProcessNames
+	return config.AgentProcessNames(cfg, *a, exec.LookPath)
 }

--- a/cmd/gc/adoption_barrier_test.go
+++ b/cmd/gc/adoption_barrier_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -16,12 +18,23 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+func putExecutableOnPath(t *testing.T, name string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	t.Setenv("PATH", dir)
+}
+
 // fakeAdoptionProvider implements runtime.Provider for adoption barrier tests.
 type fakeAdoptionProvider struct {
 	runtime.Provider
-	running []string
-	alive   map[string]bool
-	listErr error
+	running          []string
+	alive            map[string]bool
+	processNameCalls map[string][]string
+	listErr          error
 }
 
 type adoptionLockProbeStore struct {
@@ -100,7 +113,11 @@ func (f *fakeAdoptionProvider) IsRunning(name string) bool {
 	return false
 }
 
-func (f *fakeAdoptionProvider) ProcessAlive(name string, _ []string) bool {
+func (f *fakeAdoptionProvider) ProcessAlive(name string, processNames []string) bool {
+	if f.processNameCalls == nil {
+		f.processNameCalls = make(map[string][]string)
+	}
+	f.processNameCalls[name] = append([]string(nil), processNames...)
 	if f.alive == nil {
 		return true
 	}
@@ -509,9 +526,10 @@ func TestAdoptionBarrier_SkipsDeadSessions(t *testing.T) {
 		},
 	}
 	cfg := &config.City{
+		Workspace: config.Workspace{SessionTemplate: "{{.City}}-{{.Agent}}"},
 		Agents: []config.Agent{
-			{Name: "mayor", MaxActiveSessions: intPtr(1)},
-			{Name: "worker"},
+			{Name: "mayor", MaxActiveSessions: intPtr(1), ProcessNames: []string{"agent-cli"}},
+			{Name: "worker", ProcessNames: []string{"agent-cli"}},
 		},
 	}
 	var stderr bytes.Buffer
@@ -532,6 +550,75 @@ func TestAdoptionBarrier_SkipsDeadSessions(t *testing.T) {
 	}
 	if beadList[0].Metadata["session_name"] != "test-city-mayor" {
 		t.Fatalf("adopted bead = %q, want live mayor", beadList[0].Metadata["session_name"])
+	}
+}
+
+func TestAdoptionBarrier_UsesResolvedProviderProcessNames(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &fakeAdoptionProvider{
+		running: []string{"test-city-worker"},
+		alive: map[string]bool{
+			"test-city-worker": true,
+		},
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{
+			Provider:        "custom-provider",
+			SessionTemplate: "{{.City}}-{{.Agent}}",
+		},
+		Providers: map[string]config.ProviderSpec{
+			"custom-provider": {ProcessNames: []string{"custom-agent", "node"}},
+		},
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	var stderr bytes.Buffer
+
+	_, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	if !passed {
+		t.Fatalf("barrier should pass, stderr: %s", stderr.String())
+	}
+	got := sp.processNameCalls["test-city-worker"]
+	want := []string{"custom-agent", "node"}
+	if len(got) != len(want) {
+		t.Fatalf("process names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("process names = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestAdoptionBarrier_UsesProviderlessDetectedProcessNames(t *testing.T) {
+	putExecutableOnPath(t, "codex")
+	store := beads.NewMemStore()
+	sp := &fakeAdoptionProvider{
+		running: []string{"test-city-worker"},
+		alive: map[string]bool{
+			"test-city-worker": true,
+		},
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{
+			SessionTemplate: "{{.City}}-{{.Agent}}",
+		},
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	var stderr bytes.Buffer
+
+	_, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	if !passed {
+		t.Fatalf("barrier should pass, stderr: %s", stderr.String())
+	}
+	got := sp.processNameCalls["test-city-worker"]
+	want := []string{"codex"}
+	if len(got) != len(want) {
+		t.Fatalf("process names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("process names = %v, want %v", got, want)
+		}
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -929,9 +929,9 @@ func runPreparedStartCandidate(
 	// zero on the happy path.
 	if err != nil && errors.Is(err, sessionpkg.ErrStateSync) {
 		recoveryBegin := time.Now()
-		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
+		obs, runningErr := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
 		phases.StateSyncRecovery = time.Since(recoveryBegin)
-		if runningErr == nil && running {
+		if runningErr == nil && runtimeObservationLive(obs) {
 			err = nil
 		}
 	}
@@ -947,8 +947,7 @@ func runPreparedStartCandidate(
 		running := false
 		alive := false
 		if store == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
-			running = sp != nil && sp.IsRunning(item.candidate.name())
-			alive = running && (sp == nil || sp.ProcessAlive(item.candidate.name(), item.cfg.ProcessNames))
+			running, alive = observeRuntimeProviderLiveness(sp, item.candidate.name(), item.cfg.ProcessNames)
 		} else {
 			var obs worker.LiveObservation
 			obs, err = workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
@@ -992,16 +991,19 @@ func runPreparedStartCandidate(
 	case err == nil:
 		outcome = "success"
 	case errors.Is(err, runtime.ErrSessionExists):
-		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
+		obs, runningErr := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
 		switch {
-		case runningErr != nil || !running:
+		case runningErr != nil || !runtimeObservationLive(obs):
 			outcome = "provider_error"
 		case rollbackPending && !rateLimitScreen && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp):
 			outcome = "session_exists_converged"
 			err = nil
 			rollbackPending = false
+		case rollbackPending:
+			outcome = "session_exists"
 		default:
 			outcome = "session_exists"
+			err = nil
 		}
 	default:
 		outcome = "provider_error"
@@ -1333,8 +1335,18 @@ func startPreparedStartCandidate(
 	sp runtime.Provider,
 	cfg *config.City,
 ) (bool, error) {
-	if sp != nil && sp.IsRunning(item.candidate.name()) {
-		return false, nil
+	name := item.candidate.name()
+	if sp != nil {
+		running, alive := observeRuntimeProviderLiveness(sp, name, item.cfg.ProcessNames)
+		if running {
+			if shouldRollbackPendingCreate(item.candidate.session) && !runningSessionMatchesPendingCreate(item.candidate.session, name, sp) {
+				return false, fmt.Errorf("%w: session %q", runtime.ErrSessionExists, name)
+			}
+			if alive {
+				return false, nil
+			}
+			return false, fmt.Errorf("session %q died during startup", name)
+		}
 	}
 	if store == nil || item.candidate.session == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
 		handle, err := runtimeWorkerHandleWithConfig(
@@ -1342,8 +1354,8 @@ func startPreparedStartCandidate(
 			store,
 			sp,
 			cfg,
-			item.candidate.name(),
-			item.candidate.name(),
+			name,
+			name,
 			"",
 			nil,
 		)
@@ -1357,6 +1369,28 @@ func startPreparedStartCandidate(
 		return true, err
 	}
 	return true, handle.StartResolved(ctx, item.cfg.Command, item.cfg)
+}
+
+func runtimeObservationLive(obs worker.LiveObservation) bool {
+	return obs.Running && obs.Alive
+}
+
+func observeRuntimeProviderLiveness(sp runtime.Provider, name string, processNames []string) (running bool, alive bool) {
+	if sp == nil || strings.TrimSpace(name) == "" {
+		return false, false
+	}
+	return runtimeProviderLivenessFromRunning(sp, name, processNames, sp.IsRunning(name))
+}
+
+func runtimeProviderLivenessFromRunning(sp runtime.Provider, name string, processNames []string, running bool) (bool, bool) {
+	if len(processNames) == 0 {
+		return running, running
+	}
+	alive := sp.ProcessAlive(name, processNames)
+	if alive && !running {
+		running = true
+	}
+	return running, alive
 }
 
 func commitStartResult(

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -920,7 +920,7 @@ func runPreparedStartCandidate(
 	defer cancel()
 	var phases startPhaseTimings
 	startCallBegin := time.Now()
-	_, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
+	startedFresh, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
 	startCtxErr := startCtx.Err()
 	// Split start_call into provider.Start and the ErrStateSync recovery
 	// branch (gc-9ha). The recovery branch hits the worker observation
@@ -941,7 +941,7 @@ func runPreparedStartCandidate(
 	// likely references a conversation that no longer exists
 	// (e.g., "No conversation found"). Report as a failure so
 	// recordWakeFailure clears the key for the next attempt.
-	if err == nil && item.candidate.session != nil && item.candidate.session.Metadata["session_key"] != "" {
+	if startedFresh && err == nil && item.candidate.session != nil && item.candidate.session.Metadata["session_key"] != "" {
 		postStartBegin := time.Now()
 		time.Sleep(staleKeyDetectDelay)
 		running := false
@@ -1333,6 +1333,9 @@ func startPreparedStartCandidate(
 	sp runtime.Provider,
 	cfg *config.City,
 ) (bool, error) {
+	if sp != nil && sp.IsRunning(item.candidate.name()) {
+		return false, nil
+	}
 	if store == nil || item.candidate.session == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
 		handle, err := runtimeWorkerHandleWithConfig(
 			cityPath,

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -4904,6 +4904,73 @@ func (p *alreadyRunningThenFalseProvider) IsRunning(name string) bool {
 	return current
 }
 
+type falseNegativeAfterStartProvider struct {
+	*runtime.Fake
+	falseAfterStart map[string]bool
+}
+
+func (p *falseNegativeAfterStartProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	if err := p.Fake.Start(ctx, name, cfg); err != nil {
+		return err
+	}
+	if p.falseAfterStart == nil {
+		p.falseAfterStart = make(map[string]bool)
+	}
+	p.falseAfterStart[name] = true
+	return nil
+}
+
+func (p *falseNegativeAfterStartProvider) IsRunning(name string) bool {
+	if p.falseAfterStart[name] {
+		_ = p.Fake.IsRunning(name)
+		return false
+	}
+	return p.Fake.IsRunning(name)
+}
+
+type falseNegativeExistingProvider struct {
+	*runtime.Fake
+}
+
+func (p *falseNegativeExistingProvider) IsRunning(name string) bool {
+	_ = p.Fake.IsRunning(name)
+	return false
+}
+
+type existingProcessAliveSequenceProvider struct {
+	*runtime.Fake
+	alive map[string][]bool
+}
+
+func (p *existingProcessAliveSequenceProvider) IsRunning(name string) bool {
+	_ = p.Fake.IsRunning(name)
+	return false
+}
+
+func (p *existingProcessAliveSequenceProvider) ProcessAlive(name string, processNames []string) bool {
+	if len(processNames) == 0 {
+		return p.Fake.ProcessAlive(name, processNames)
+	}
+	sequence := p.alive[name]
+	if len(sequence) == 0 {
+		return p.Fake.ProcessAlive(name, processNames)
+	}
+	current := sequence[0]
+	p.alive[name] = sequence[1:]
+	_ = p.Fake.ProcessAlive(name, processNames)
+	return current
+}
+
+func fakeRuntimeCallCount(fake *runtime.Fake, method string) int {
+	count := 0
+	for _, call := range fake.Calls {
+		if call.Method == method {
+			count++
+		}
+	}
+	return count
+}
+
 func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	sp := &dieAfterStartProvider{Fake: runtime.NewFake()}
@@ -5067,6 +5134,306 @@ func TestExecutePreparedStartWave_SkipsStaleKeyProbeWhenSessionAlreadyRunning(t 
 	r := results[0]
 	if r.err != nil {
 		t.Fatalf("already-running session should not fail stale-key detection, got: %v", r.err)
+	}
+	if got := fakeRuntimeCallCount(sp.Fake, "Start"); got != 0 {
+		t.Fatalf("Start calls = %d, want 0", got)
+	}
+	if remaining := len(sp.isRunning["test-agent"]); remaining != 1 {
+		t.Fatalf("remaining scripted IsRunning results = %d, want 1", remaining)
+	}
+}
+
+func TestExecutePreparedStartWave_AlreadyRunningRequiresLiveProcess(t *testing.T) {
+	sp := &zombieAfterStartProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "test-agent", runtime.Config{ProcessNames: []string{"claude"}}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-101",
+				Metadata: map[string]string{
+					"session_name": "test-agent",
+					"session_key":  "still-valid-key",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude --resume still-valid-key",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude --resume still-valid-key",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err == nil {
+		t.Fatal("expected already-running dead agent process to fail liveness validation")
+	}
+	if !strings.Contains(r.err.Error(), "died during startup") {
+		t.Fatalf("unexpected error: %v", r.err)
+	}
+}
+
+func TestExecutePreparedStartWave_AlreadyRunningFalseNegativeUsesProcessAliveFallback(t *testing.T) {
+	sp := &falseNegativeExistingProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "test-agent", runtime.Config{ProcessNames: []string{"claude"}}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-102",
+				Metadata: map[string]string{
+					"session_name": "test-agent",
+					"session_key":  "still-valid-key",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude --resume still-valid-key",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude --resume still-valid-key",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err != nil {
+		t.Fatalf("process liveness fallback should recover already-running IsRunning false negative, got: %v", r.err)
+	}
+	if got := fakeRuntimeCallCount(sp.Fake, "Start"); got != 1 {
+		t.Fatalf("Start calls = %d, want 1 existing setup call only", got)
+	}
+}
+
+func TestExecutePreparedStartWave_ErrSessionExistsRecoveryUsesProcessAliveFallback(t *testing.T) {
+	sp := &existingProcessAliveSequenceProvider{
+		Fake: runtime.NewFake(),
+		alive: map[string][]bool{
+			"test-agent": {false, true},
+		},
+	}
+	if err := sp.Start(context.Background(), "test-agent", runtime.Config{ProcessNames: []string{"claude"}}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-103",
+				Metadata: map[string]string{
+					"session_name": "test-agent",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err != nil {
+		t.Fatalf("process liveness fallback should converge ErrSessionExists recovery, got: %v", r.err)
+	}
+	if r.outcome != "session_exists" {
+		t.Fatalf("outcome = %q, want session_exists", r.outcome)
+	}
+	if got := fakeRuntimeCallCount(sp.Fake, "Start"); got != 2 {
+		t.Fatalf("Start calls = %d, want setup plus recovery attempt", got)
+	}
+}
+
+func TestExecutePreparedStartWave_AlreadyRunningRejectsPendingCreateIdentityMismatch(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "test-agent", runtime.Config{}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	if err := sp.SetMeta("test-agent", "GC_INSTANCE_TOKEN", "tok-old"); err != nil {
+		t.Fatalf("SetMeta token: %v", err)
+	}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-creating",
+				Metadata: map[string]string{
+					"session_name":         "test-agent",
+					"template":             "worker",
+					"instance_token":       "tok-new",
+					"pending_create_claim": "true",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{Command: "claude"},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err == nil {
+		t.Fatal("expected pending-create identity mismatch to reject existing runtime")
+	}
+	if r.outcome != "session_exists" {
+		t.Fatalf("outcome = %q, want session_exists", r.outcome)
+	}
+	if !r.rollbackPending {
+		t.Fatal("rollbackPending = false, want true")
+	}
+}
+
+func TestExecutePreparedStartWave_AlreadyRunningRejectsPendingCreateSessionIDMismatch(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "test-agent", runtime.Config{}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	if err := sp.SetMeta("test-agent", "GC_SESSION_ID", "gc-different"); err != nil {
+		t.Fatalf("SetMeta session ID: %v", err)
+	}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-creating",
+				Metadata: map[string]string{
+					"session_name":         "test-agent",
+					"template":             "worker",
+					"instance_token":       "tok-new",
+					"pending_create_claim": "true",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{Command: "claude"},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err == nil {
+		t.Fatal("expected pending-create session ID mismatch to reject existing runtime")
+	}
+	if r.outcome != "session_exists" {
+		t.Fatalf("outcome = %q, want session_exists", r.outcome)
+	}
+	if !r.rollbackPending {
+		t.Fatal("rollbackPending = false, want true")
+	}
+}
+
+func TestExecutePreparedStartWave_RuntimeOnlyStaleKeyUsesProcessAliveFallback(t *testing.T) {
+	sp := &falseNegativeAfterStartProvider{
+		Fake:            runtime.NewFake(),
+		falseAfterStart: make(map[string]bool),
+	}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "",
+				Metadata: map[string]string{
+					"session_name": "test-agent",
+					"session_key":  "still-valid-key",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude --resume still-valid-key",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude --resume still-valid-key",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err != nil {
+		t.Fatalf("process liveness fallback should recover IsRunning false negative, got: %v", r.err)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -4889,6 +4889,21 @@ func (p *zombieAfterStartProvider) Start(ctx context.Context, name string, cfg r
 	return nil
 }
 
+type alreadyRunningThenFalseProvider struct {
+	*runtime.Fake
+	isRunning map[string][]bool
+}
+
+func (p *alreadyRunningThenFalseProvider) IsRunning(name string) bool {
+	sequence := p.isRunning[name]
+	if len(sequence) == 0 {
+		return p.Fake.IsRunning(name)
+	}
+	current := sequence[0]
+	p.isRunning[name] = sequence[1:]
+	return current
+}
+
 func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	sp := &dieAfterStartProvider{Fake: runtime.NewFake()}
@@ -4972,6 +4987,86 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetectedWhenPaneSurvives(t *tes
 	}
 	if !strings.Contains(r.err.Error(), "died during startup") {
 		t.Fatalf("unexpected error: %v", r.err)
+	}
+}
+
+func TestExecutePreparedStartWave_NoStaleCheckWithoutSessionKey(t *testing.T) {
+	sp := &dieAfterStartProvider{Fake: runtime.NewFake()}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-99",
+				Metadata: map[string]string{
+					"session_name": "test-agent",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{Command: "claude"},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err != nil {
+		t.Fatalf("session without session_key should not get stale key error, got: %v", r.err)
+	}
+}
+
+func TestExecutePreparedStartWave_SkipsStaleKeyProbeWhenSessionAlreadyRunning(t *testing.T) {
+	sp := &alreadyRunningThenFalseProvider{
+		Fake: runtime.NewFake(),
+		isRunning: map[string][]bool{
+			"test-agent": {true, false},
+		},
+	}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-100",
+				Metadata: map[string]string{
+					"session_name": "test-agent",
+					"session_key":  "still-valid-key",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude --resume still-valid-key",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{Command: "claude --resume still-valid-key"},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		10*time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err != nil {
+		t.Fatalf("already-running session should not fail stale-key detection, got: %v", r.err)
 	}
 }
 
@@ -5159,45 +5254,6 @@ func TestExecutePreparedStartWave_RateLimitPendingCreateDeathClearsClaim(t *test
 	}
 	if got.Metadata["last_woke_at"] != "" {
 		t.Fatalf("last_woke_at = %q, want cleared after rate-limit hold", got.Metadata["last_woke_at"])
-	}
-}
-
-func TestExecutePreparedStartWave_NoStaleCheckWithoutSessionKey(t *testing.T) {
-	// Session without a session_key should not trigger stale detection,
-	// even if the session dies after start.
-	sp := &dieAfterStartProvider{Fake: runtime.NewFake()}
-	item := preparedStart{
-		candidate: startCandidate{
-			session: &beads.Bead{
-				ID: "gc-99",
-				Metadata: map[string]string{
-					"session_name": "test-agent",
-					"template":     "worker",
-				},
-			},
-			tp: TemplateParams{
-				Command:      "claude",
-				SessionName:  "test-agent",
-				TemplateName: "worker",
-			},
-		},
-		cfg: runtime.Config{Command: "claude"},
-	}
-
-	results := executePreparedStartWave(
-		context.Background(),
-		[]preparedStart{item},
-		sp,
-		nil,
-		10*time.Second,
-	)
-
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
-	}
-	r := results[0]
-	if r.err != nil {
-		t.Fatalf("session without session_key should not get stale key error, got: %v", r.err)
 	}
 }
 

--- a/internal/api/handler_rigs.go
+++ b/internal/api/handler_rigs.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -42,11 +43,12 @@ func (s *Server) buildRigResponse(cfg *config.City, rig config.Rig, sp runtime.P
 		if workdirutil.ConfiguredRigName(cityPath, a, cfg.Rigs) != rig.Name {
 			continue
 		}
+		processNames := config.AgentProcessNames(cfg, a, exec.LookPath)
 		expanded := expandAgent(a, cityName, tmpl, sp)
 		for _, ea := range expanded {
 			agentCount++
 			sessionName := agent.SessionNameFor(cityName, ea.qualifiedName, tmpl)
-			obs := observeProviderSession(sp, sessionName, nil)
+			obs := observeProviderSession(sp, sessionName, processNames)
 			if obs.Running {
 				runningCount++
 			}
@@ -84,11 +86,12 @@ func (s *Server) rigSuspended(cfg *config.City, rig config.Rig, sp runtime.Provi
 		if workdirutil.ConfiguredRigName(cityPath, a, cfg.Rigs) != rig.Name {
 			continue
 		}
+		processNames := config.AgentProcessNames(cfg, a, exec.LookPath)
 		expanded := expandAgent(a, cityName, tmpl, sp)
 		for _, ea := range expanded {
 			agentCount++
 			sessionName := agent.SessionNameFor(cityName, ea.qualifiedName, tmpl)
-			obs := observeProviderSession(sp, sessionName, nil)
+			obs := observeProviderSession(sp, sessionName, processNames)
 			if obs.Suspended {
 				suspendedCount++
 			}

--- a/internal/api/handler_rigs_test.go
+++ b/internal/api/handler_rigs_test.go
@@ -5,11 +5,23 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
+
+func putExecutableOnPath(t *testing.T, name string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	t.Setenv("PATH", dir)
+}
 
 func TestRigList(t *testing.T) {
 	state := newFakeState(t)
@@ -83,6 +95,86 @@ func TestRigEnrichment(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&rig) //nolint:errcheck
 	if rig.AgentCount != 2 {
 		t.Errorf("AgentCount = %d, want 2", rig.AgentCount)
+	}
+	if rig.RunningCount != 1 {
+		t.Errorf("RunningCount = %d, want 1", rig.RunningCount)
+	}
+}
+
+type falseNegativeSessionProvider struct {
+	*runtime.Fake
+}
+
+func (p *falseNegativeSessionProvider) IsRunning(name string) bool {
+	_ = p.Fake.IsRunning(name)
+	return false
+}
+
+type sessionProviderOverrideState struct {
+	*fakeState
+	provider runtime.Provider
+}
+
+func (s *sessionProviderOverrideState) SessionProvider() runtime.Provider {
+	return s.provider
+}
+
+func TestRigEnrichmentUsesProcessNamesForRuntimeFalseNegative(t *testing.T) {
+	base := newFakeState(t)
+	base.cfg.Agents = []config.Agent{
+		{Name: "worker", Dir: "myrig", Provider: "test-agent", MaxActiveSessions: intPtr(1), ProcessNames: []string{"agent-cli"}},
+	}
+	sp := &falseNegativeSessionProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "myrig--worker", runtime.Config{ProcessNames: []string{"agent-cli"}}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	state := &sessionProviderOverrideState{
+		fakeState: base,
+		provider:  sp,
+	}
+	h := newTestCityHandler(t, state)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/rig/myrig"), nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var rig rigResponse
+	if err := json.NewDecoder(rec.Body).Decode(&rig); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rig.RunningCount != 1 {
+		t.Errorf("RunningCount = %d, want 1", rig.RunningCount)
+	}
+}
+
+func TestRigEnrichmentUsesProviderlessDetectedProcessNames(t *testing.T) {
+	putExecutableOnPath(t, "codex")
+	base := newFakeState(t)
+	base.cfg.Workspace.Provider = ""
+	base.cfg.Agents = []config.Agent{
+		{Name: "worker", Dir: "myrig", MaxActiveSessions: intPtr(1)},
+	}
+	sp := &falseNegativeSessionProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "myrig--worker", runtime.Config{ProcessNames: []string{"codex"}}); err != nil {
+		t.Fatalf("Start existing session: %v", err)
+	}
+	state := &sessionProviderOverrideState{
+		fakeState: base,
+		provider:  sp,
+	}
+	h := newTestCityHandler(t, state)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/rig/myrig"), nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var rig rigResponse
+	if err := json.NewDecoder(rec.Body).Decode(&rig); err != nil {
+		t.Fatalf("decode: %v", err)
 	}
 	if rig.RunningCount != 1 {
 		t.Errorf("RunningCount = %d, want 1", rig.RunningCount)

--- a/internal/api/runtime_observation.go
+++ b/internal/api/runtime_observation.go
@@ -23,10 +23,17 @@ func observeProviderSession(sp runtime.Provider, sessionName string, processName
 	if sessionID, err := sp.GetMeta(sessionName, "GC_SESSION_ID"); err == nil {
 		obs.RuntimeSessionID = strings.TrimSpace(sessionID)
 	}
+	if len(processNames) > 0 {
+		obs.Alive = sp.ProcessAlive(sessionName, processNames)
+		if obs.Alive && !obs.Running {
+			obs.Running = true
+		}
+	} else {
+		obs.Alive = obs.Running
+	}
 	if !obs.Running {
 		return obs
 	}
-	obs.Alive = sp.ProcessAlive(sessionName, processNames)
 	obs.Attached = sp.IsAttached(sessionName)
 	if lastActive, err := sp.GetLastActivity(sessionName); err == nil && !lastActive.IsZero() {
 		last := lastActive

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -103,6 +103,22 @@ func ResolveProvider(agent *Agent, ws *Workspace, cityProviders map[string]Provi
 	return resolved, nil
 }
 
+// AgentProcessNames resolves the process-name hints used to observe an agent's
+// runtime liveness, following the same provider resolution path as launch.
+func AgentProcessNames(cfg *City, agent Agent, lookPath LookPathFunc) []string {
+	if len(agent.ProcessNames) > 0 {
+		return append([]string(nil), agent.ProcessNames...)
+	}
+	if cfg == nil || lookPath == nil {
+		return nil
+	}
+	resolved, err := ResolveProvider(&agent, &cfg.Workspace, cfg.Providers, lookPath)
+	if err != nil || len(resolved.ProcessNames) == 0 {
+		return nil
+	}
+	return append([]string(nil), resolved.ProcessNames...)
+}
+
 // ResolveInstallHooks returns the hook providers to install for an agent.
 // Agent-level overrides workspace-level (replace, not additive).
 // Returns nil if neither specifies hooks.

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -138,6 +138,35 @@ func TestResolveProviderWorkspaceProvider(t *testing.T) {
 	}
 }
 
+func TestAgentProcessNamesResolvesProviderlessDetectedProvider(t *testing.T) {
+	cfg := &City{
+		Workspace: Workspace{Name: "city"},
+	}
+
+	got := AgentProcessNames(cfg, Agent{Name: "worker"}, lookPathOnly("codex"))
+	want := []string{"codex"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AgentProcessNames() = %v, want %v", got, want)
+	}
+}
+
+func TestAgentProcessNamesPrefersAgentOverride(t *testing.T) {
+	agent := Agent{Name: "worker", ProcessNames: []string{"custom-agent"}}
+	cfg := &City{
+		Workspace: Workspace{Name: "city", Provider: "codex"},
+	}
+
+	got := AgentProcessNames(cfg, agent, lookPathNone)
+	want := []string{"custom-agent"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AgentProcessNames() = %v, want %v", got, want)
+	}
+	got[0] = "mutated"
+	if agent.ProcessNames[0] != "custom-agent" {
+		t.Fatalf("agent process name mutated to %q", agent.ProcessNames[0])
+	}
+}
+
 func TestResolveProviderWorkspaceStartCommand(t *testing.T) {
 	agent := &Agent{Name: "worker"}
 	ws := &Workspace{Name: "city", StartCommand: "my-agent --flag"}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1182,13 +1182,19 @@ func (m *Manager) ObserveRuntimeForInfo(info Info, processNames []string) Runtim
 		return obs
 	}
 	obs.Running = m.sp.IsRunning(info.SessionName)
-	if !obs.Running {
-		return obs
+	if len(processNames) > 0 {
+		obs.Alive = m.sp.ProcessAlive(info.SessionName, processNames)
+		if obs.Alive && !obs.Running {
+			obs.Running = true
+		}
+	} else {
+		obs.Alive = obs.Running
 	}
-	obs.Alive = m.sp.ProcessAlive(info.SessionName, processNames)
-	obs.Attached = m.sp.IsAttached(info.SessionName)
-	if lastActive, err := m.sp.GetLastActivity(info.SessionName); err == nil {
-		obs.LastActive = lastActive
+	if obs.Running {
+		obs.Attached = m.sp.IsAttached(info.SessionName)
+		if lastActive, err := m.sp.GetLastActivity(info.SessionName); err == nil {
+			obs.LastActive = lastActive
+		}
 	}
 	return obs
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1946,6 +1946,51 @@ func TestPruneDetailedReportsWaitNudges(t *testing.T) {
 	}
 }
 
+type falseNegativeRuntimeProvider struct {
+	*runtime.Fake
+	falseNames map[string]bool
+}
+
+func (p *falseNegativeRuntimeProvider) IsRunning(name string) bool {
+	if p.falseNames[name] {
+		return false
+	}
+	return p.Fake.IsRunning(name)
+}
+
+func TestObserveRuntime_TreatsLiveProcessAsRunningWhenSessionProbeFalseNegatives(t *testing.T) {
+	base := runtime.NewFake()
+	mgr := NewManager(beads.NewMemStore(), &falseNegativeRuntimeProvider{
+		Fake:       base,
+		falseNames: map[string]bool{"runtime-worker": true},
+	})
+
+	info, err := mgr.Create(context.Background(), "worker", "runtime-worker", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	obs := mgr.ObserveRuntimeForInfo(info, []string{"claude"})
+	if !obs.Running || !obs.Alive {
+		t.Fatalf("ObserveRuntimeForInfo() = %#v, want running+alive true despite IsRunning false-negative", obs)
+	}
+}
+
+func TestObserveRuntime_WithoutProcessNamesTreatsRunningSessionAsAlive(t *testing.T) {
+	sp := runtime.NewFake()
+	mgr := NewManager(beads.NewMemStore(), sp)
+
+	info, err := mgr.Create(context.Background(), "worker", "runtime-worker", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	obs := mgr.ObserveRuntimeForInfo(info, nil)
+	if !obs.Running || !obs.Alive {
+		t.Fatalf("ObserveRuntimeForInfo() = %#v, want running+alive true when no process names are configured", obs)
+	}
+}
+
 func TestPruneUsesSuspendedAt(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/worker/handle_test.go
+++ b/internal/worker/handle_test.go
@@ -1334,6 +1334,71 @@ func TestRuntimeHandleLiveObservationUsesRuntimeMetadataAndLiveness(t *testing.T
 	}
 }
 
+type falseNegativeRuntimeProvider struct {
+	*runtime.Fake
+	falseNames map[string]bool
+}
+
+func (p *falseNegativeRuntimeProvider) IsRunning(name string) bool {
+	if p.falseNames[name] {
+		return false
+	}
+	return p.Fake.IsRunning(name)
+}
+
+func TestRuntimeHandleLiveObservationTreatsLiveProcessAsRunningWhenSessionProbeFalseNegatives(t *testing.T) {
+	base := runtime.NewFake()
+	if err := base.Start(context.Background(), "runtime-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sp := &falseNegativeRuntimeProvider{
+		Fake:       base,
+		falseNames: map[string]bool{"runtime-worker": true},
+	}
+
+	handle, err := NewRuntimeHandle(RuntimeHandleConfig{
+		Provider:     sp,
+		SessionName:  "runtime-worker",
+		ProviderName: "claude",
+		ProcessNames: []string{"claude"},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntimeHandle: %v", err)
+	}
+
+	obs, err := handle.LiveObservation(context.Background())
+	if err != nil {
+		t.Fatalf("LiveObservation: %v", err)
+	}
+	if !obs.Running || !obs.Alive {
+		t.Fatalf("LiveObservation() = %#v, want running+alive true despite IsRunning false-negative", obs)
+	}
+}
+
+func TestRuntimeHandleLiveObservationWithoutProcessNamesTreatsRunningSessionAsAlive(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "runtime-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	handle, err := NewRuntimeHandle(RuntimeHandleConfig{
+		Provider:     sp,
+		SessionName:  "runtime-worker",
+		ProviderName: "claude",
+	})
+	if err != nil {
+		t.Fatalf("NewRuntimeHandle: %v", err)
+	}
+
+	obs, err := handle.LiveObservation(context.Background())
+	if err != nil {
+		t.Fatalf("LiveObservation: %v", err)
+	}
+	if !obs.Running || !obs.Alive {
+		t.Fatalf("LiveObservation() = %#v, want running+alive true when no process names are configured", obs)
+	}
+}
+
 func TestRuntimeHandleStartResolvedStartsLegacyRuntimeSession(t *testing.T) {
 	sp := runtime.NewFake()
 

--- a/internal/worker/runtime_handle.go
+++ b/internal/worker/runtime_handle.go
@@ -342,8 +342,15 @@ func (h *RuntimeHandle) LiveObservation(_ context.Context) (LiveObservation, err
 	if sessionID, err := h.provider.GetMeta(h.sessionName, "GC_SESSION_ID"); err == nil {
 		obs.RuntimeSessionID = strings.TrimSpace(sessionID)
 	}
-	if obs.Running {
+	if len(h.processNames) > 0 {
 		obs.Alive = h.provider.ProcessAlive(h.sessionName, h.processNames)
+		if obs.Alive && !obs.Running {
+			obs.Running = true
+		}
+	} else {
+		obs.Alive = obs.Running
+	}
+	if obs.Running {
 		obs.Attached = h.provider.IsAttached(h.sessionName)
 		if last, err := h.provider.GetLastActivity(h.sessionName); err == nil && !last.IsZero() {
 			lastCopy := last


### PR DESCRIPTION
## Summary

This fixes several cases where a live session could be misclassified as dead during startup or observation.

## Problem

Runtime/lifecycle checks could produce false negatives in a few ways:
- startup stale-key probing still ran even when `StartResolved` was effectively a no-op because the session was already running
- observation treated `Alive` as false when `process_names` was empty
- a false-negative session probe could still report dead even when the underlying process probe was alive

These showed up as sessions being marked as having "died during startup" or otherwise treated as missing even though the runtime was still usable.

## Fix

- return `startedFresh=false` when startup sees the session is already running, and skip stale-key probing in that case
- in runtime/session observation, treat `running` as `alive` when no process names are configured
- when process liveness is positive, treat that as enough to recover from a false-negative `IsRunning` probe

## Tests

Added/updated regression coverage for:
- stale session-key detection on real startup death
- no stale-key failure when there is no session key
- skipping stale-key probing for already-running sessions
- manager/runtime-handle observation when `IsRunning` false-negatives
- manager/runtime-handle observation when `process_names` is empty

## Notes for Reviewers

This change is intentionally narrow: it does not loosen real startup failure detection, only the false-negative paths.

Refs azanar/gascity#18
