### PR TITLE
Clear stale lifecycle state reasons on sleep

### DIFF
--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -236,6 +236,7 @@ func BeginDrainPatch(now time.Time, reason string) MetadataPatch {
 func SleepPatch(now time.Time, reason string) MetadataPatch {
 	return MetadataPatch{
 		"state":                     string(StateAsleep),
+		"state_reason":              "",
 		"sleep_reason":              reason,
 		"last_woke_at":              "",
 		"pending_create_claim":      "",
@@ -251,6 +252,7 @@ func SleepPatch(now time.Time, reason string) MetadataPatch {
 func AcknowledgeDrainPatch(freshWake bool) MetadataPatch {
 	patch := MetadataPatch{
 		"state":                     string(StateDrained),
+		"state_reason":              "",
 		"last_woke_at":              "",
 		"pending_create_claim":      "",
 		"pending_create_started_at": "",

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -105,6 +105,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			patch: SleepPatch(now, "idle-timeout"),
 			want: MetadataPatch{
 				"state":                     string(StateAsleep),
+				"state_reason":              "",
 				"sleep_reason":              "idle-timeout",
 				"last_woke_at":              "",
 				"pending_create_claim":      "",
@@ -118,6 +119,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			patch: AcknowledgeDrainPatch(false),
 			want: MetadataPatch{
 				"state":                     "drained",
+				"state_reason":              "",
 				"last_woke_at":              "",
 				"pending_create_claim":      "",
 				"pending_create_started_at": "",
@@ -128,6 +130,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			patch: AcknowledgeDrainPatch(true),
 			want: MetadataPatch{
 				"state":                      "drained",
+				"state_reason":               "",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
 				"pending_create_started_at":  "",
@@ -144,6 +147,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			patch: CompleteDrainPatch(now, "idle", true),
 			want: MetadataPatch{
 				"state":                      string(StateAsleep),
+				"state_reason":               "",
 				"sleep_reason":               "idle",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
@@ -633,6 +637,26 @@ func TestReactivatePatchDoesNotForceHistoricalBeadEligible(t *testing.T) {
 	}
 	if merged["continuity_eligible"] != "false" {
 		t.Fatalf("continuity_eligible = %q, want false", merged["continuity_eligible"])
+	}
+}
+
+func TestSleepPatchClearsStaleStateReasonOnApply(t *testing.T) {
+	merged := SleepPatch(time.Date(2026, 5, 14, 16, 0, 0, 0, time.UTC), "idle-timeout").Apply(map[string]string{
+		"state":        string(StateDraining),
+		"state_reason": "creation_complete",
+	})
+	if got := merged["state_reason"]; got != "" {
+		t.Fatalf("state_reason = %q, want cleared", got)
+	}
+}
+
+func TestAcknowledgeDrainPatchClearsStaleStateReasonOnApply(t *testing.T) {
+	merged := AcknowledgeDrainPatch(false).Apply(map[string]string{
+		"state":        string(StateDraining),
+		"state_reason": "creation_complete",
+	})
+	if got := merged["state_reason"]; got != "" {
+		t.Fatalf("state_reason = %q, want cleared", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

This clears stale `state_reason` metadata when a session transitions into `asleep` or `drained`.

## Problem

A session could end up with state like:
- `state=asleep`
- `state_reason=creation_complete`

That metadata combination is misleading and leaks an old startup-only reason into a later lifecycle phase.

## Fix

- clear `state_reason` in `SleepPatch`
- clear `state_reason` in `AcknowledgeDrainPatch`

## Tests

Added/updated regression coverage for:
- expected metadata emitted by lifecycle transition patches
- applying sleep/drain patches over a bead carrying stale `state_reason`

## Notes for Reviewers

This is metadata hygiene only. It does not change wake/sleep policy, only the persisted transition fields.

Refs azanar/gascity#19
