### PR TITLE
Dead-letter stale fenced queued nudges

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1479,12 +1479,6 @@ func queuedNudgeClaimableForTargetWithStore(store beads.Store, target nudgeTarge
 	return referenced.Status == "closed"
 }
 
-func claimDueQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge, error) {
-	return claimDueQueuedNudgesMatching(cityPath, now, func(item queuedNudge) bool {
-		return item.Agent == agentName
-	})
-}
-
 func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, error) {
 	store := openNudgeBeadStore(cityPath)
 	return claimDueQueuedNudgesMatching(cityPath, now, func(item queuedNudge) bool {

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1459,9 +1459,36 @@ func queuedNudgeClaimableForTarget(target nudgeTarget, item queuedNudge) bool {
 	return true
 }
 
-func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, error) {
+func queuedNudgeClaimableForTargetWithStore(store beads.Store, target nudgeTarget, item queuedNudge) bool {
+	if queuedNudgeClaimableForTarget(target, item) {
+		return true
+	}
+	if !target.matchesQueueAgent(item.Agent) {
+		return false
+	}
+	if item.SessionID == "" || target.sessionID == "" || item.SessionID == target.sessionID {
+		return false
+	}
+	if store == nil {
+		return false
+	}
+	referenced, err := store.Get(item.SessionID)
+	if err != nil {
+		return errors.Is(err, beads.ErrNotFound)
+	}
+	return referenced.Status == "closed"
+}
+
+func claimDueQueuedNudges(cityPath, agentName string, now time.Time) ([]queuedNudge, error) {
 	return claimDueQueuedNudgesMatching(cityPath, now, func(item queuedNudge) bool {
-		return queuedNudgeClaimableForTarget(target, item)
+		return item.Agent == agentName
+	})
+}
+
+func claimDueQueuedNudgesForTarget(cityPath string, target nudgeTarget, now time.Time) ([]queuedNudge, error) {
+	store := openNudgeBeadStore(cityPath)
+	return claimDueQueuedNudgesMatching(cityPath, now, func(item queuedNudge) bool {
+		return queuedNudgeClaimableForTargetWithStore(store, target, item)
 	})
 }
 

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -2667,6 +2667,81 @@ func TestTryDeliverQueuedNudgesByPollerReleasesClaimsWhenDeliveryDeclined(t *tes
 	}
 }
 
+func TestTryDeliverQueuedNudgesByPollerDeadLettersStaleSessionFence(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+	item := newQueuedNudgeWithOptions("worker", "stale session fence", "session", now, queuedNudgeOptions{
+		ID:                "n-stale-session",
+		SessionID:         "gc-old",
+		ContinuationEpoch: "1",
+	})
+	if err := enqueueQueuedNudge(dir, item); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+	info, err := mgr.Create(context.Background(), "worker", "Worker", "codex", dir, "codex", nil, session.ProviderResume{}, runtime.Config{WorkDir: dir})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Start(context.Background(), info.ID, "", runtime.Config{WorkDir: dir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	idleSince := time.Now().Add(-10 * time.Second)
+	fake.Activity = map[string]time.Time{info.SessionName: idleSince}
+
+	target := nudgeTarget{
+		cityPath:          dir,
+		agent:             config.Agent{Name: "worker"},
+		sessionID:         info.ID,
+		continuationEpoch: "2",
+		resolved:          &config.ResolvedProvider{Name: "codex"},
+		sessionName:       info.SessionName,
+	}
+	obs := worker.LiveObservation{Running: true, LastActivity: &idleSince}
+
+	delivered, err := tryDeliverQueuedNudgesByPoller(target, store, fake, 3*time.Second, obs)
+	if err != nil {
+		t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+	}
+	if delivered {
+		t.Fatal("delivered = true, want false for stale fenced nudge")
+	}
+
+	var nudgeCalls []runtime.Call
+	for _, call := range fake.Calls {
+		if call.Method == "Nudge" {
+			nudgeCalls = append(nudgeCalls, call)
+		}
+	}
+	if len(nudgeCalls) != 0 {
+		t.Fatalf("nudge calls = %d, want 0", len(nudgeCalls))
+	}
+
+	pending, inFlight, dead, err := listQueuedNudges(dir, "worker", time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending = %d, want 0", len(pending))
+	}
+	if len(inFlight) != 0 {
+		t.Fatalf("inFlight = %d, want 0", len(inFlight))
+	}
+	if len(dead) != 1 {
+		t.Fatalf("dead = %d, want 1", len(dead))
+	}
+	if dead[0].ID != item.ID {
+		t.Fatalf("dead[0].ID = %q, want %q", dead[0].ID, item.ID)
+	}
+	if dead[0].LastError != errNudgeSessionFenceMismatch.Error() {
+		t.Fatalf("dead[0].LastError = %q, want %q", dead[0].LastError, errNudgeSessionFenceMismatch.Error())
+	}
+}
+
 func TestTryDeliverQueuedNudgesByPollerDeliversDespiteStaleFenceBeadMarkFailure(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

This fixes queued nudges that remain pending forever after the fenced session they targeted has already been replaced.

## Problem

If a queued nudge was fenced to an older session bead and that bead was later closed/replaced, the current same-agent session would not claim it. The item could remain pending indefinitely.

## Fix

- allow target-claiming logic to claim a queued nudge fenced to another session bead when:
  - the agent identity still matches
  - the current session is different
  - the referenced fenced session bead is closed or gone
- once claimed, the existing fence-mismatch path dead-letters the item instead of trying to deliver it to the wrong runtime

## Tests

Added regression coverage for:
- stale same-session epoch handling
- poller-side dead-lettering of stale fenced queued nudges

## Review Order

This is the second PR in the queued-nudge follow-up sequence:
- base queue/poller alignment: #2164
- stale fenced nudge dead-lettering: #2165
- historical dead-letter bead repair: #2166

## Notes for Reviewers

This PR only addresses stale fence claim/dead-letter behavior. It does not change normal same-session fence matching.

Refs azanar/gascity#21
