### PR TITLE
Repair missing terminal nudge bead records

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1504,6 +1504,17 @@ func failedQueuedNudge(item queuedNudge, cause error, now time.Time) (queuedNudg
 	return item, false
 }
 
+func terminalStateForDeadQueuedNudge(item queuedNudge) string {
+	switch strings.TrimSpace(item.LastError) {
+	case "expired":
+		return "expired"
+	case "superseded":
+		return "superseded"
+	default:
+		return "failed"
+	}
+}
+
 func pruneExpiredQueuedNudges(state *nudgeQueueState, store beads.Store, now time.Time) error {
 	filtered := state.Pending[:0]
 	for _, item := range state.Pending {
@@ -1559,7 +1570,7 @@ func pruneDeadQueuedNudges(state *nudgeQueueState, store beads.Store, now time.T
 	cutoff := now.Add(-defaultQueuedNudgeDeadRetention)
 	filtered := state.Dead[:0]
 	for _, item := range state.Dead {
-		if !item.DeadAt.IsZero() && item.DeadAt.Before(cutoff) && item.BeadID != "" {
+		if item.BeadID != "" {
 			if store == nil {
 				// No store available — retain the item to avoid data loss.
 				filtered = append(filtered, item)
@@ -1573,12 +1584,30 @@ func pruneDeadQueuedNudges(state *nudgeQueueState, store beads.Store, now time.T
 				continue
 			}
 			if !ok || !isTerminalNudgeState(b.Metadata["state"]) {
-				// Terminal bead not confirmed — retain the queue entry.
-				filtered = append(filtered, item)
+				// Repair historical dead-letter entries whose queue state was
+				// durable but whose backing bead never received terminal state.
+				reason := strings.TrimSpace(item.LastError)
+				if reason == "" {
+					reason = "failed"
+				}
+				terminalAt := now
+				if !item.DeadAt.IsZero() {
+					terminalAt = item.DeadAt
+				}
+				if err := markQueuedNudgeTerminal(store, item, terminalStateForDeadQueuedNudge(item), reason, "", terminalAt); err != nil {
+					filtered = append(filtered, item)
+					continue
+				}
+				b, ok, err = findAnyQueuedNudgeBead(store, item.ID)
+				if err != nil || !ok || !isTerminalNudgeState(b.Metadata["state"]) {
+					filtered = append(filtered, item)
+					continue
+				}
+			}
+			if !item.DeadAt.IsZero() && item.DeadAt.Before(cutoff) {
+				// Terminal bead confirmed in store — safe to prune once past retention.
 				continue
 			}
-			// Terminal bead confirmed in store — safe to prune.
-			continue
 		}
 		filtered = append(filtered, item)
 	}

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -229,6 +229,49 @@ func TestPruneExpiredQueuedNudgesIgnoresMissingTerminalBead(t *testing.T) {
 	}
 }
 
+func TestPruneDeadQueuedNudgesRepairsMissingTerminalBeadRecord(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	now := time.Now().UTC()
+	item := newQueuedNudgeWithOptions("worker", "stale dead letter", "session", now.Add(-2*time.Minute), queuedNudgeOptions{
+		ID:        "n-dead-repair",
+		SessionID: "gc-worker",
+	})
+	beadID, created, err := ensureQueuedNudgeBead(store, item)
+	if err != nil {
+		t.Fatalf("ensureQueuedNudgeBead: %v", err)
+	}
+	if !created {
+		t.Fatal("expected backing nudge bead to be created")
+	}
+	item.BeadID = beadID
+	item.LastError = "expired"
+	item.DeadAt = now.Add(-30 * time.Minute)
+
+	state := &nudgeQueueState{Dead: []queuedNudge{item}}
+	if err := pruneDeadQueuedNudges(state, store, now); err != nil {
+		t.Fatalf("pruneDeadQueuedNudges: %v", err)
+	}
+	if len(state.Dead) != 1 {
+		t.Fatalf("dead = %d, want 1 before retention cutoff", len(state.Dead))
+	}
+
+	bead, err := store.Get(beadID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", beadID, err)
+	}
+	if bead.Status != "closed" {
+		t.Fatalf("bead.Status = %q, want closed", bead.Status)
+	}
+	if bead.Metadata["state"] != "expired" {
+		t.Fatalf("state = %q, want expired", bead.Metadata["state"])
+	}
+	if bead.Metadata["terminal_reason"] != "expired" {
+		t.Fatalf("terminal_reason = %q, want expired", bead.Metadata["terminal_reason"])
+	}
+}
+
 func TestMarkQueuedNudgeTerminalHandlesAmbiguousBeadID(t *testing.T) {
 	store := &ambiguousNudgeBeadStore{MemStore: beads.NewMemStore(), ambiguousID: "gc-17"}
 	item := queuedNudge{


### PR DESCRIPTION
## Summary

This repairs historical dead-letter queue entries whose backing `nudge:*` bead never reached terminal state in the bead store.

## Problem

Queue state could say a nudge was dead-lettered, but the backing bead could still remain open or non-terminal. That leaves inconsistent history and prevents clean pruning.

## Fix

- add a helper to infer the terminal bead state from a dead queue entry
- during dead-entry pruning, if the queue entry is dead but the backing bead is not terminal:
  - write the missing terminal bead state
  - re-check terminalization
  - only prune after retention once the backing bead is confirmed terminal

## Tests

Added regression coverage for:
- pruning dead entries when the terminal bead is missing
- repairing the backing bead to `expired`/terminal before retention-based pruning

## Review Order

This is the third PR in the queued-nudge follow-up sequence:
- base queue/poller alignment: #2164
- stale fenced nudge dead-lettering: #2165
- historical dead-letter bead repair: #2166

## Notes for Reviewers

This is a repair path for historical inconsistency. It does not alter the normal happy-path queue ack flow.

Refs azanar/gascity#22
