### PR TITLE
Resolve live runtime targets before store lookups

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1168,6 +1168,13 @@ func (p *attachmentCachingProvider) IsAttached(name string) bool {
 	return p.Provider.IsAttached(name)
 }
 
+func (p *attachmentCachingProvider) IsRunning(name string) bool {
+	if p.Provider == nil {
+		return false
+	}
+	return p.Provider.IsRunning(name)
+}
+
 func (p *attachmentCachingProvider) SleepCapability(name string) runtime.SessionSleepCapability {
 	if scp, ok := p.Provider.(runtime.SleepCapabilityProvider); ok {
 		return scp.SleepCapability(name)

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -20,6 +20,36 @@ type explicitBeadIDStore interface {
 	IDPrefix() string
 }
 
+type sessionNameLookupResolver struct {
+	cityName        string
+	sessionTemplate string
+	sessionBeads    *sessionBeadSnapshot
+}
+
+func newSessionNameLookupResolver(store beads.Store, cityName, sessionTemplate string) sessionNameLookupResolver {
+	resolver := sessionNameLookupResolver{
+		cityName:        cityName,
+		sessionTemplate: sessionTemplate,
+	}
+	if store == nil {
+		return resolver
+	}
+	sessionBeads, err := loadSessionBeadSnapshot(store)
+	if err == nil {
+		resolver.sessionBeads = sessionBeads
+	}
+	return resolver
+}
+
+func (r sessionNameLookupResolver) Resolve(qualifiedName string) string {
+	if r.sessionBeads != nil {
+		if sn := r.sessionBeads.FindSessionNameByTemplate(qualifiedName); sn != "" {
+			return sn
+		}
+	}
+	return agent.SessionNameFor(r.cityName, qualifiedName, r.sessionTemplate)
+}
+
 type poolSessionCreateIdentity struct {
 	AgentName string
 	Alias     string
@@ -492,10 +522,7 @@ func lookupSessionName(store beads.Store, qualifiedName string) (string, bool) {
 // name. Tries the bead store first; falls back to the legacy SessionNameFor
 // function if no bead is found.
 func lookupSessionNameOrLegacy(store beads.Store, cityName, qualifiedName, sessionTemplate string) string {
-	if sn, ok := lookupSessionName(store, qualifiedName); ok {
-		return sn
-	}
-	return agent.SessionNameFor(cityName, qualifiedName, sessionTemplate)
+	return newSessionNameLookupResolver(store, cityName, sessionTemplate).Resolve(qualifiedName)
 }
 
 // lookupPoolSessionNames returns bead-backed session names for pool instances

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -539,13 +539,17 @@ func TestSessionNameLookupResolverReusesLoadedSnapshotAcrossLookups(t *testing.T
 	store := &countingSessionNameListStore{Store: base}
 
 	resolver := newSessionNameLookupResolver(store, "city", "")
+	loadCalls := store.listCalls
+	if loadCalls == 0 {
+		t.Fatal("newSessionNameLookupResolver did not load a session snapshot")
+	}
 	if got := resolver.Resolve("mayor"); got != "mayor" {
 		t.Fatalf("Resolve(mayor) = %q, want mayor", got)
 	}
 	if got := resolver.Resolve("worker"); got != "worker" {
 		t.Fatalf("Resolve(worker) = %q, want worker", got)
 	}
-	if store.listCalls != 1 {
-		t.Fatalf("store.List calls = %d, want 1", store.listCalls)
+	if store.listCalls != loadCalls {
+		t.Fatalf("store.List calls after Resolve = %d, want unchanged from initial load %d", store.listCalls, loadCalls)
 	}
 }

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
+type countingSessionNameListStore struct {
+	beads.Store
+	listCalls int
+}
+
+func (s *countingSessionNameListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls++
+	return s.Store.List(query)
+}
+
 func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
 	store := beads.NewMemStore()
 	now := time.Date(2026, 5, 1, 9, 15, 0, 0, time.UTC)
@@ -521,5 +531,21 @@ func TestDerivePoolSessionNameRejectsInvalidCollisionSuffix(t *testing.T) {
 	_, err := derivePoolSessionName(nil, nil, "crew", "gc-1", strings.Repeat("a", 64), snapshot)
 	if err == nil {
 		t.Fatal("derivePoolSessionName: want error when collision suffix would exceed explicit session name length")
+	}
+}
+
+func TestSessionNameLookupResolverReusesLoadedSnapshotAcrossLookups(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &countingSessionNameListStore{Store: base}
+
+	resolver := newSessionNameLookupResolver(store, "city", "")
+	if got := resolver.Resolve("mayor"); got != "mayor" {
+		t.Fatalf("Resolve(mayor) = %q, want mayor", got)
+	}
+	if got := resolver.Resolve("worker"); got != "worker" {
+		t.Fatalf("Resolve(worker) = %q, want worker", got)
+	}
+	if store.listCalls != 1 {
+		t.Fatalf("store.List calls = %d, want 1", store.listCalls)
 	}
 }

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -344,17 +344,26 @@ func workerHandleForSessionTargetWithRuntimeHintsWithConfig(cityPath string, sto
 	if err != nil {
 		return nil, err
 	}
+	if sp != nil {
+		if sessionID, metaErr := sp.GetMeta(target, "GC_SESSION_ID"); metaErr == nil && strings.TrimSpace(sessionID) != "" {
+			if store != nil {
+				return factory.HandleForTarget(strings.TrimSpace(sessionID), processNames)
+			}
+		}
+		if sp.IsRunning(target) {
+			providerName := target
+			if liveProvider, err := sp.GetMeta(target, "GC_PROVIDER"); err == nil && strings.TrimSpace(liveProvider) != "" {
+				providerName = strings.TrimSpace(liveProvider)
+			}
+			return factory.RuntimeHandle(target, providerName, "", processNames)
+		}
+	}
 	if store != nil {
 		if bead, _, err := session.ResolveSessionBeadByExactID(store, target); err == nil {
 			return factory.SessionByLoadedBead(bead)
 		}
 		if id, err := session.ResolveSessionID(store, target); err == nil {
-			return factory.SessionByID(id)
-		}
-		if sp != nil {
-			if sessionID, metaErr := sp.GetMeta(target, "GC_SESSION_ID"); metaErr == nil && strings.TrimSpace(sessionID) != "" {
-				return factory.SessionByID(strings.TrimSpace(sessionID))
-			}
+			return factory.HandleForTarget(id, processNames)
 		}
 	}
 	if sp == nil {

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -26,11 +26,6 @@ type countingSessionLookupStore struct {
 	listCalls int
 }
 
-type falseNegativeWorkerHandleProvider struct {
-	*runtime.Fake
-	falseNames map[string]bool
-}
-
 func (s *failingSessionLookupStore) Get(string) (beads.Bead, error) {
 	return beads.Bead{}, s.err
 }
@@ -47,13 +42,6 @@ func (s *countingSessionLookupStore) Get(string) (beads.Bead, error) {
 func (s *countingSessionLookupStore) List(beads.ListQuery) ([]beads.Bead, error) {
 	s.listCalls++
 	return nil, nil
-}
-
-func (p *falseNegativeWorkerHandleProvider) IsRunning(name string) bool {
-	if p.falseNames[name] {
-		return false
-	}
-	return p.Fake.IsRunning(name)
 }
 
 func TestWorkerHandleForSessionWithConfigUsesResolvedProviderOnFirstStart(t *testing.T) {

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -20,12 +20,40 @@ type failingSessionLookupStore struct {
 	err error
 }
 
+type countingSessionLookupStore struct {
+	beads.Store
+	getCalls  int
+	listCalls int
+}
+
+type falseNegativeWorkerHandleProvider struct {
+	*runtime.Fake
+	falseNames map[string]bool
+}
+
 func (s *failingSessionLookupStore) Get(string) (beads.Bead, error) {
 	return beads.Bead{}, s.err
 }
 
 func (s *failingSessionLookupStore) List(beads.ListQuery) ([]beads.Bead, error) {
 	return nil, s.err
+}
+
+func (s *countingSessionLookupStore) Get(string) (beads.Bead, error) {
+	s.getCalls++
+	return beads.Bead{}, beads.ErrNotFound
+}
+
+func (s *countingSessionLookupStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls++
+	return nil, nil
+}
+
+func (p *falseNegativeWorkerHandleProvider) IsRunning(name string) bool {
+	if p.falseNames[name] {
+		return false
+	}
+	return p.Fake.IsRunning(name)
 }
 
 func TestWorkerHandleForSessionWithConfigUsesResolvedProviderOnFirstStart(t *testing.T) {
@@ -1449,6 +1477,62 @@ func TestWorkerObserveSessionTargetWithConfigIgnoresStoreLookupFailuresForRuntim
 	}
 	if !obs.Running {
 		t.Fatalf("obs.Running = false, want true for %q when runtime session is live", target)
+	}
+}
+
+func TestWorkerObserveSessionTargetWithConfigIgnoresRuntimeSessionIDWithoutStore(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "mayor", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := sp.SetMeta("mayor", "GC_SESSION_ID", "ga-r"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{
+			{Name: "mayor", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	target := cliSessionName("/home/user/city", cfg.Workspace.Name, "mayor", cfg.Workspace.SessionTemplate)
+	obs, err := workerObserveSessionTargetWithConfig("/home/user/city", nil, sp, cfg, target)
+	if err != nil {
+		t.Fatalf("workerObserveSessionTargetWithConfig: %v", err)
+	}
+	if !obs.Running {
+		t.Fatalf("obs.Running = false, want true for %q when runtime session is live", target)
+	}
+}
+
+func TestWorkerObserveSessionTargetWithConfigSkipsSessionListForLiveRuntimeTarget(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "mayor", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{
+			{Name: "mayor", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	store := &countingSessionLookupStore{}
+	target := cliSessionName("/home/user/city", cfg.Workspace.Name, "mayor", cfg.Workspace.SessionTemplate)
+	obs, err := workerObserveSessionTargetWithConfig("/home/user/city", store, sp, cfg, target)
+	if err != nil {
+		t.Fatalf("workerObserveSessionTargetWithConfig: %v", err)
+	}
+	if !obs.Running {
+		t.Fatalf("obs.Running = false, want true for %q", target)
+	}
+	if store.getCalls != 0 {
+		t.Fatalf("store.Get calls = %d, want 0", store.getCalls)
+	}
+	if store.listCalls != 0 {
+		t.Fatalf("store.List calls = %d, want 0", store.listCalls)
 	}
 }
 

--- a/internal/worker/factory.go
+++ b/internal/worker/factory.go
@@ -98,21 +98,25 @@ func (f *Factory) Session(spec SessionSpec) (*SessionHandle, error) {
 // SessionByID rebuilds a session-backed worker handle from persisted session
 // metadata and the factory's optional resolved-runtime hook.
 func (f *Factory) SessionByID(id string) (Handle, error) {
+	return f.sessionByIDWithProcessNames(id, nil)
+}
+
+func (f *Factory) sessionByIDWithProcessNames(id string, processNames []string) (Handle, error) {
 	info, bead, err := f.manager.GetWithBead(id)
 	if err != nil {
 		return nil, err
 	}
-	return f.sessionFromInfoAndBead(info, bead)
+	return f.sessionFromInfoAndBead(info, bead, processNames)
 }
 
 // SessionByLoadedBead is like SessionByID but uses an already-loaded bead,
 // avoiding a redundant store.Get for callers that just resolved it (e.g.
 // via session.ResolveSessionBeadByExactID).
 func (f *Factory) SessionByLoadedBead(bead beads.Bead) (Handle, error) {
-	return f.sessionFromInfoAndBead(f.manager.SessionInfoFromBead(bead), bead)
+	return f.sessionFromInfoAndBead(f.manager.SessionInfoFromBead(bead), bead, nil)
 }
 
-func (f *Factory) sessionFromInfoAndBead(info sessionpkg.Info, bead beads.Bead) (Handle, error) {
+func (f *Factory) sessionFromInfoAndBead(info sessionpkg.Info, bead beads.Bead, processNames []string) (Handle, error) {
 	spec := SessionSpec{
 		ID:       info.ID,
 		Template: info.Template,
@@ -139,6 +143,9 @@ func (f *Factory) sessionFromInfoAndBead(info sessionpkg.Info, bead beads.Bead) 
 		}
 		applyResolvedRuntimeToSessionSpec(&spec, resolved)
 	}
+	if len(processNames) > 0 {
+		spec.Hints.ProcessNames = append([]string(nil), processNames...)
+	}
 	return f.Session(spec)
 }
 
@@ -149,21 +156,28 @@ func (f *Factory) HandleForTarget(target string, processNames []string) (Handle,
 	if target == "" {
 		return nil, sessionpkg.ErrSessionNotFound
 	}
+	if f.provider != nil {
+		if sessionID, err := f.provider.GetMeta(target, "GC_SESSION_ID"); err == nil && strings.TrimSpace(sessionID) != "" {
+			return f.sessionByIDWithProcessNames(strings.TrimSpace(sessionID), processNames)
+		}
+		if f.provider.IsRunning(target) {
+			providerName := strings.TrimSpace(target)
+			if liveProvider, err := f.provider.GetMeta(target, "GC_PROVIDER"); err == nil && strings.TrimSpace(liveProvider) != "" {
+				providerName = strings.TrimSpace(liveProvider)
+			}
+			return f.RuntimeHandle(target, providerName, "", processNames)
+		}
+	}
 	if f.store != nil {
 		if id, err := sessionpkg.ResolveSessionIDByExactID(f.store, target); err == nil {
-			return f.SessionByID(id)
+			return f.sessionByIDWithProcessNames(id, processNames)
 		} else if !errors.Is(err, sessionpkg.ErrSessionNotFound) {
 			return nil, err
 		}
 		if id, err := sessionpkg.ResolveSessionID(f.store, target); err == nil {
-			return f.SessionByID(id)
+			return f.sessionByIDWithProcessNames(id, processNames)
 		} else if !errors.Is(err, sessionpkg.ErrSessionNotFound) {
 			return nil, err
-		}
-		if f.provider != nil {
-			if sessionID, err := f.provider.GetMeta(target, "GC_SESSION_ID"); err == nil && strings.TrimSpace(sessionID) != "" {
-				return f.SessionByID(strings.TrimSpace(sessionID))
-			}
 		}
 	}
 	if f.provider == nil {

--- a/internal/worker/factory_test.go
+++ b/internal/worker/factory_test.go
@@ -394,6 +394,54 @@ func TestFactoryHandleForTargetResolvesRuntimeSessionMeta(t *testing.T) {
 	}
 }
 
+func TestFactoryHandleForTargetPropagatesProcessNamesThroughResolvedSessionID(t *testing.T) {
+	store := beads.NewMemStore()
+	base := runtime.NewFake()
+	sp := &falseNegativeRuntimeProvider{
+		Fake:       base,
+		falseNames: map[string]bool{"legacy-runtime-name": true},
+	}
+	manager := sessionpkg.NewManager(store, sp)
+
+	info, err := manager.Create(
+		context.Background(),
+		"worker",
+		"Probe",
+		"",
+		t.TempDir(),
+		"stub",
+		nil,
+		sessionpkg.ProviderResume{},
+		runtime.Config{},
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := sp.SetMeta("legacy-runtime-name", "GC_SESSION_ID", info.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	factory, err := NewFactory(FactoryConfig{
+		Store:    store,
+		Provider: sp,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+
+	handle, err := factory.HandleForTarget("legacy-runtime-name", []string{"stub"})
+	if err != nil {
+		t.Fatalf("HandleForTarget: %v", err)
+	}
+	sessionHandle, ok := handle.(*SessionHandle)
+	if !ok {
+		t.Fatalf("HandleForTarget returned %T, want *SessionHandle", handle)
+	}
+	if got, want := sessionHandle.session.Hints.ProcessNames, []string{"stub"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("session.Hints.ProcessNames = %v, want %v", got, want)
+	}
+}
+
 func TestFactoryHandleForTargetRuntimeFallbackPreservesRecorder(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()
@@ -446,8 +494,24 @@ type failingGetStore struct {
 	err error
 }
 
+type countingTargetLookupStore struct {
+	beads.Store
+	getCalls  int
+	listCalls int
+}
+
 func (s failingGetStore) Get(string) (beads.Bead, error) {
 	return beads.Bead{}, s.err
+}
+
+func (s *countingTargetLookupStore) Get(string) (beads.Bead, error) {
+	s.getCalls++
+	return beads.Bead{}, beads.ErrNotFound
+}
+
+func (s *countingTargetLookupStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	s.listCalls++
+	return nil, nil
 }
 
 func TestFactoryHandleForTargetPropagatesSessionResolutionError(t *testing.T) {
@@ -465,6 +529,63 @@ func TestFactoryHandleForTargetPropagatesSessionResolutionError(t *testing.T) {
 	_, err = factory.HandleForTarget("sess-1", nil)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("HandleForTarget error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestFactoryHandleForTargetSkipsExactIDLookupForRuntimeNames(t *testing.T) {
+	wantErr := errors.New("store boom")
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "legacy-runtime-name", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	factory, err := NewFactory(FactoryConfig{
+		Store: failingGetStore{
+			Store: beads.NewMemStore(),
+			err:   wantErr,
+		},
+		Provider: sp,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+
+	handle, err := factory.HandleForTarget("legacy-runtime-name", nil)
+	if err != nil {
+		t.Fatalf("HandleForTarget: %v", err)
+	}
+	if _, ok := handle.(*RuntimeHandle); !ok {
+		t.Fatalf("HandleForTarget returned %T, want *RuntimeHandle", handle)
+	}
+}
+
+func TestFactoryHandleForTargetSkipsSessionListForLiveRuntimeTarget(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "legacy-runtime-name", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	store := &countingTargetLookupStore{}
+
+	factory, err := NewFactory(FactoryConfig{
+		Store:    store,
+		Provider: sp,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+
+	handle, err := factory.HandleForTarget("legacy-runtime-name", nil)
+	if err != nil {
+		t.Fatalf("HandleForTarget: %v", err)
+	}
+	if _, ok := handle.(*RuntimeHandle); !ok {
+		t.Fatalf("HandleForTarget returned %T, want *RuntimeHandle", handle)
+	}
+	if store.getCalls != 0 {
+		t.Fatalf("store.Get calls = %d, want 0", store.getCalls)
+	}
+	if store.listCalls != 0 {
+		t.Fatalf("store.List calls = %d, want 0", store.listCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

This makes session-target resolution prefer live runtime identities before falling back to bead-store lookups.

## Problem

Several CLI and worker-boundary paths still treated every target as bead-first, even when the target was really a live runtime session name.

That caused two classes of problems:
- unnecessary store lookups and session-list scans for clearly live runtime targets
- loss of caller-supplied runtime hints (for example process names) when a runtime target resolved back to a session bead through `GC_SESSION_ID`

## Fix

- add a reusable session-name lookup resolver that snapshots the bead view once per status/lookup pass
- prefer live runtime resolution through provider metadata and `IsRunning` before store scans in worker target handling
- preserve caller-supplied process-name hints when exact-ID or `GC_SESSION_ID` resolution leads back to a session-backed handle

## Tests

Added regression coverage for:
- reusing a loaded bead snapshot across multiple session-name lookups
- skipping store scans for already-live runtime targets
- preserving process-name hints when a runtime target resolves through `GC_SESSION_ID`
- worker-factory runtime-target ordering and no-store-scan behavior

## Notes for Reviewers

This PR is intentionally about target resolution only. It does not change session liveness policy or stale-session cleanup.
