### PR TITLE
feat: add initial gc --json surfaces

### DIFF
--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -255,9 +255,11 @@ func collectCityStatusSnapshotFromStoreSnapshot(
 			}
 		}
 		snapshot.Rigs = append(snapshot.Rigs, StatusRigJSON{
-			Name:      r.Name,
-			Path:      r.Path,
-			Suspended: suspended,
+			Name:               r.Name,
+			Path:               r.Path,
+			Prefix:             r.EffectivePrefix(),
+			Suspended:          suspended,
+			DefaultSlingTarget: r.DefaultSlingTarget,
 		})
 	}
 
@@ -384,18 +386,38 @@ func countCitySessionsFromSnapshot(snapshot *sessionBeadSnapshot) StatusSummaryJ
 }
 
 func cityStatusJSONFromSnapshot(snapshot cityStatusSnapshot, summary StatusSummaryJSON) StatusJSON {
-	var agents []StatusAgentJSON
+	agents := make([]StatusAgentJSON, 0, len(snapshot.Agents))
 	for _, row := range snapshot.Agents {
 		agents = append(agents, row.Agent)
 	}
+	rigs := snapshot.Rigs
+	if rigs == nil {
+		rigs = []StatusRigJSON{}
+	}
+	var signals []string
+	if snapshot.Suspended {
+		signals = append(signals, "city_suspended")
+	}
+	if !snapshot.Controller.Running {
+		signals = append(signals, "controller_not_running")
+	}
+	if snapshot.Summary.TotalAgents > 0 && snapshot.Summary.RunningAgents == 0 {
+		signals = append(signals, "no_agents_running")
+	}
+	degraded := len(signals) > 0
+	running := snapshot.Controller.Running
 	return StatusJSON{
-		CityName:   snapshot.CityName,
-		CityPath:   snapshot.CityPath,
-		Controller: snapshot.Controller,
-		Suspended:  snapshot.Suspended,
-		Agents:     agents,
-		Rigs:       snapshot.Rigs,
-		Summary:    summary,
+		SchemaVersion: "1",
+		CityName:      snapshot.CityName,
+		Workspace:     WorkspaceJSON{Name: snapshot.CityName, Path: snapshot.CityPath},
+		CityPath:      snapshot.CityPath,
+		Controller:    snapshot.Controller,
+		Running:       running,
+		Suspended:     snapshot.Suspended,
+		Health:        HealthJSON{Usable: running && !snapshot.Suspended, Degraded: degraded, Signals: signals},
+		Agents:        agents,
+		Rigs:          rigs,
+		Summary:       summary,
 	}
 }
 

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -73,10 +73,19 @@ func TestCityStatusSnapshotNilConfigUsesCityPathName(t *testing.T) {
 	}
 }
 
-func TestCityStatusJSONPreservesNilAgentsWhenEmpty(t *testing.T) {
+func TestCityStatusJSONUsesEmptyCollectionsWhenEmpty(t *testing.T) {
 	status := cityStatusJSONFromSnapshot(cityStatusSnapshot{CityName: "city"}, StatusSummaryJSON{})
-	if status.Agents != nil {
-		t.Fatalf("Agents = %#v, want nil slice", status.Agents)
+	if status.Agents == nil {
+		t.Fatal("Agents = nil, want empty slice")
+	}
+	if len(status.Agents) != 0 {
+		t.Fatalf("len(Agents) = %d, want 0", len(status.Agents))
+	}
+	if status.Rigs == nil {
+		t.Fatal("Rigs = nil, want empty slice")
+	}
+	if len(status.Rigs) != 0 {
+		t.Fatalf("len(Rigs) = %d, want 0", len(status.Rigs))
 	}
 }
 

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -17,13 +17,28 @@ import (
 
 // StatusJSON is the JSON output format for "gc status --json".
 type StatusJSON struct {
-	CityName   string            `json:"city_name"`
-	CityPath   string            `json:"city_path"`
-	Controller ControllerJSON    `json:"controller"`
-	Suspended  bool              `json:"suspended"`
-	Agents     []StatusAgentJSON `json:"agents"`
-	Rigs       []StatusRigJSON   `json:"rigs"`
-	Summary    StatusSummaryJSON `json:"summary"`
+	SchemaVersion string            `json:"schema_version"`
+	CityName      string            `json:"city_name"`
+	Workspace     WorkspaceJSON     `json:"workspace"`
+	CityPath      string            `json:"city_path"`
+	Controller    ControllerJSON    `json:"controller"`
+	Running       bool              `json:"running"`
+	Suspended     bool              `json:"suspended"`
+	Health        HealthJSON        `json:"health"`
+	Agents        []StatusAgentJSON `json:"agents"`
+	Rigs          []StatusRigJSON   `json:"rigs"`
+	Summary       StatusSummaryJSON `json:"summary"`
+}
+
+type WorkspaceJSON struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type HealthJSON struct {
+	Usable   bool     `json:"usable"`
+	Degraded bool     `json:"degraded"`
+	Signals  []string `json:"signals,omitempty"`
 }
 
 // ControllerJSON represents controller state in JSON output.
@@ -52,9 +67,11 @@ type PoolJSON struct {
 
 // StatusRigJSON represents a rig in the JSON status output.
 type StatusRigJSON struct {
-	Name      string `json:"name"`
-	Path      string `json:"path"`
-	Suspended bool   `json:"suspended"`
+	Name               string `json:"name"`
+	Path               string `json:"path"`
+	Prefix             string `json:"prefix,omitempty"`
+	Suspended          bool   `json:"suspended"`
+	DefaultSlingTarget string `json:"default_sling_target,omitempty"`
 }
 
 // StatusSummaryJSON is the agent count summary in JSON output.
@@ -100,18 +117,35 @@ all agents with running status, rigs, and a summary count.`,
 func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCommandCity(args)
 	if err != nil {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "city_resolve_failed", fmt.Sprintf("gc status: %v", err), 1)
+		}
 		fmt.Fprintf(stderr, "gc status: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	cfg, err := loadCityConfig(cityPath, stderr)
+	configStderr := stderr
+	if jsonOutput {
+		configStderr = io.Discard
+	}
+	cfg, err := loadCityConfig(cityPath, configStderr)
 	if err != nil {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "config_load_failed", fmt.Sprintf("gc status: %v", err), 1)
+		}
 		fmt.Fprintf(stderr, "gc status: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	store, code := openCityStatusStore(cityPath, stderr)
+	storeStderr := stderr
+	if jsonOutput {
+		storeStderr = io.Discard
+	}
+	store, code := openCityStatusStore(cityPath, storeStderr)
 	if code != 0 {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "store_open_failed", "gc status: opening bead store failed", code)
+		}
 		return code
 	}
 	statusSnapshot := loadStatusSessionSnapshot(store, stderr)

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -494,6 +494,35 @@ func TestCityStatusJSONReportsCatalogListError(t *testing.T) {
 	}
 }
 
+func TestCmdCityStatusJSONConfigErrorIsStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := cmdCityStatus([]string{filepath.Join(t.TempDir(), "missing-city")}, true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+
+	var payload cliJSONErrorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON error: %v\n%s", err, stdout.String())
+	}
+	if payload.OK {
+		t.Fatalf("ok = true, want false; payload=%+v", payload)
+	}
+	if payload.Error.Code != "city_resolve_failed" || payload.Error.ExitCode != code {
+		t.Fatalf("error = %+v, want city_resolve_failed with exit code %d", payload.Error, code)
+	}
+	if strings.Contains(stderr.String(), "gc status: loading") {
+		t.Fatalf("stderr contains human diagnostic: %q", stderr.String())
+	}
+	var diagnostic cliJSONDiagnostic
+	if err := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &diagnostic); err != nil {
+		t.Fatalf("stderr is not JSON diagnostic: %v\n%s", err, stderr.String())
+	}
+	if diagnostic.ExitCode != code {
+		t.Fatalf("stderr exit_code = %d, want %d", diagnostic.ExitCode, code)
+	}
+}
+
 func TestCityStatusReportsCatalogListError(t *testing.T) {
 	sp := runtime.NewFake()
 	dops := newFakeDrainOps()

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -791,6 +791,9 @@ func cmdRigList(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	_ = args // no arguments used yet
 	cityPath, err := resolveCity()
 	if err != nil {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "city_resolve_failed", fmt.Sprintf("gc rig list: %v", err), 1)
+		}
 		fmt.Fprintf(stderr, "gc rig list: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -799,9 +802,11 @@ func cmdRigList(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 
 // RigListJSON is the JSON output format for "gc rig list --json".
 type RigListJSON struct {
-	CityPath string        `json:"city_path"`
-	CityName string        `json:"city_name"`
-	Rigs     []RigListItem `json:"rigs"`
+	SchemaVersion string         `json:"schema_version"`
+	CityPath      string         `json:"city_path"`
+	CityName      string         `json:"city_name"`
+	Rigs          []RigListItem  `json:"rigs"`
+	Summary       RigListSummary `json:"summary"`
 }
 
 // RigListItem is one rig entry in the JSON output.
@@ -810,12 +815,20 @@ type RigListItem struct {
 	// Path is the absolute filesystem path to the rig directory, resolved from
 	// city.toml by resolveRigPaths. Always absolute in output, regardless of
 	// the relative form stored in city.toml.
-	Path          string `json:"path"`
-	Prefix        string `json:"prefix"`
-	DefaultBranch string `json:"default_branch,omitempty"`
-	HQ            bool   `json:"hq"`
-	Suspended     bool   `json:"suspended"`
-	Beads         string `json:"beads"`
+	Path               string `json:"path"`
+	Prefix             string `json:"prefix"`
+	DefaultBranch      string `json:"default_branch,omitempty"`
+	HQ                 bool   `json:"hq"`
+	Suspended          bool   `json:"suspended"`
+	Running            bool   `json:"running"`
+	DefaultSlingTarget string `json:"default_sling_target,omitempty"`
+	Beads              string `json:"beads"`
+}
+
+type RigListSummary struct {
+	Total     int `json:"total"`
+	Suspended int `json:"suspended"`
+	Running   int `json:"running"`
 }
 
 // doRigList is the pure logic for "gc rig list". It reads rigs from city.toml
@@ -827,8 +840,15 @@ type RigListItem struct {
 // how the rig path is declared in city.toml. The cityPath parameter must be
 // absolute.
 func doRigList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.Writer) int {
-	cfg, err := loadCityConfigFS(fs, filepath.Join(cityPath, "city.toml"), stderr)
+	configStderr := stderr
+	if jsonOutput {
+		configStderr = io.Discard
+	}
+	cfg, err := loadCityConfigFS(fs, filepath.Join(cityPath, "city.toml"), configStderr)
 	if err != nil {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "config_load_failed", fmt.Sprintf("gc rig list: %v", err), 1)
+		}
 		fmt.Fprintf(stderr, "gc rig list: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -839,25 +859,40 @@ func doRigList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.W
 
 	if jsonOutput {
 		result := RigListJSON{
-			CityPath: cityPath,
-			CityName: cityName,
+			SchemaVersion: "1",
+			CityPath:      cityPath,
+			CityName:      cityName,
 		}
+		hqRunning := controllerAlive(cityPath) != 0
 		result.Rigs = append(result.Rigs, RigListItem{
-			Name:   cityName,
-			Path:   cityPath,
-			Prefix: hqPrefix,
-			HQ:     true,
-			Beads:  rigBeadsStatus(fs, cityPath),
+			Name:    cityName,
+			Path:    cityPath,
+			Prefix:  hqPrefix,
+			HQ:      true,
+			Running: hqRunning,
+			Beads:   rigBeadsStatus(fs, cityPath),
 		})
 		for i := range cfg.Rigs {
+			running := rigHasRunningAgent(cfg, cfg.Rigs[i].Name)
 			result.Rigs = append(result.Rigs, RigListItem{
-				Name:          cfg.Rigs[i].Name,
-				Path:          cfg.Rigs[i].Path,
-				Prefix:        cfg.Rigs[i].EffectivePrefix(),
-				DefaultBranch: cfg.Rigs[i].EffectiveDefaultBranch(),
-				Suspended:     cfg.Rigs[i].Suspended,
-				Beads:         rigBeadsStatus(fs, cfg.Rigs[i].Path),
+				Name:               cfg.Rigs[i].Name,
+				Path:               cfg.Rigs[i].Path,
+				Prefix:             cfg.Rigs[i].EffectivePrefix(),
+				DefaultBranch:      cfg.Rigs[i].EffectiveDefaultBranch(),
+				Suspended:          cfg.Rigs[i].Suspended,
+				Running:            running,
+				DefaultSlingTarget: cfg.Rigs[i].DefaultSlingTarget,
+				Beads:              rigBeadsStatus(fs, cfg.Rigs[i].Path),
 			})
+		}
+		result.Summary.Total = len(result.Rigs)
+		for _, rig := range result.Rigs {
+			if rig.Suspended {
+				result.Summary.Suspended++
+			}
+			if rig.Running {
+				result.Summary.Running++
+			}
 		}
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
@@ -898,6 +933,33 @@ func doRigList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.W
 		w(fmt.Sprintf("    Beads:  %s", beads))
 	}
 	return 0
+}
+
+func rigHasRunningAgent(cfg *config.City, rigName string) bool {
+	if cfg == nil || rigName == "" {
+		return false
+	}
+	cityName := cfg.EffectiveCityName()
+	sp := newSessionProvider()
+	for i := range cfg.Agents {
+		a := cfg.Agents[i]
+		if a.Dir != rigName {
+			continue
+		}
+		sp0 := scaleParamsFor(&a)
+		if isMultiSessionCfgAgent(&a) {
+			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, cfg.Workspace.SessionTemplate, sp) {
+				if sp.IsRunning(sessionName(nil, cityName, qualifiedInstance, cfg.Workspace.SessionTemplate)) {
+					return true
+				}
+			}
+			continue
+		}
+		if sp.IsRunning(sessionName(nil, cityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)) {
+			return true
+		}
+	}
+	return false
 }
 
 // rigBeadsStatus returns a human-readable beads status for a directory.

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -648,8 +648,15 @@ func newSessionListCmd(stdout, stderr io.Writer) *cobra.Command {
 
 // cmdSessionList is the CLI entry point for "gc session list".
 func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session list")
+	storeStderr := stderr
+	if jsonOutput {
+		storeStderr = io.Discard
+	}
+	store, code := openCityStore(storeStderr, "gc session list")
 	if store == nil {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "store_open_failed", "gc session list: opening bead store failed", code)
+		}
 		return code
 	}
 
@@ -678,6 +685,9 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 		Sort:  beads.SortCreatedDesc,
 	})
 	if err != nil {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "session_list_failed", fmt.Sprintf("gc session list: listing sessions: %v", err), 1)
+		}
 		fmt.Fprintf(stderr, "gc session list: listing sessions: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -686,6 +696,9 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 	sp := newSessionProviderFromContext(providerCtx, sessionBeads)
 	catalog, err := workerSessionCatalogWithConfig("", store, sp, providerCtx.cfg)
 	if err != nil {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "session_catalog_failed", fmt.Sprintf("gc session list: %v", err), 1)
+		}
 		fmt.Fprintf(stderr, "gc session list: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -693,10 +706,7 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 	sessions := listResult.Sessions
 
 	if jsonOutput {
-		enc := json.NewEncoder(stdout)
-		enc.SetIndent("", "  ")
-		_ = enc.Encode(sessionListJSONRows(sessions)) //nolint:errcheck // best-effort stdout
-		return 0
+		return writeSessionListJSON(sessions, stateFilter, templateFilter, stdout, stderr)
 	}
 
 	// Build bead index from the beads already fetched by ListFull (no duplicate query).
@@ -760,26 +770,79 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 }
 
 type sessionListJSONRow struct {
-	ID                   string
-	Template             string
-	State                session.State
-	Closed               bool
-	Title                string
-	Alias                string
-	AgentName            string
-	Provider             string
-	Transport            string
-	Command              string
-	WorkDir              string
-	SessionName          string
-	SessionKey           string
-	ResumeFlag           string
-	ResumeStyle          string
-	ResumeCommand        string
-	CreatedAt            time.Time
-	LastActive           time.Time
-	LastNudgeDeliveredAt *time.Time `json:"last_nudge_delivered_at,omitempty"`
-	Attached             bool
+	ID                   string        `json:"id"`
+	Name                 string        `json:"name,omitempty"`
+	Template             string        `json:"template"`
+	Provider             string        `json:"provider,omitempty"`
+	State                session.State `json:"state"`
+	Title                string        `json:"title,omitempty"`
+	Rig                  string        `json:"rig,omitempty"`
+	Alias                string        `json:"alias,omitempty"`
+	AgentName            string        `json:"agent_name,omitempty"`
+	Transport            string        `json:"transport,omitempty"`
+	Command              string        `json:"command,omitempty"`
+	WorkDir              string        `json:"work_dir,omitempty"`
+	SessionName          string        `json:"session_name,omitempty"`
+	SessionKey           string        `json:"session_key,omitempty"`
+	ResumeFlag           string        `json:"resume_flag,omitempty"`
+	ResumeStyle          string        `json:"resume_style,omitempty"`
+	ResumeCommand        string        `json:"resume_command,omitempty"`
+	CreatedAt            time.Time     `json:"created_at"`
+	LastActive           time.Time     `json:"last_active"`
+	LastNudgeDeliveredAt *time.Time    `json:"last_nudge_delivered_at,omitempty"`
+	Attached             bool          `json:"attached"`
+	Closed               bool          `json:"closed"`
+}
+
+type sessionListJSON struct {
+	SchemaVersion string               `json:"schema_version"`
+	Filters       sessionListFilters   `json:"filters"`
+	Sessions      []sessionListJSONRow `json:"sessions"`
+	Summary       sessionListSummary   `json:"summary"`
+}
+
+type sessionListFilters struct {
+	State    string `json:"state,omitempty"`
+	Template string `json:"template,omitempty"`
+}
+
+type sessionListSummary struct {
+	Total     int `json:"total"`
+	Active    int `json:"active"`
+	Suspended int `json:"suspended"`
+	Closed    int `json:"closed"`
+}
+
+func writeSessionListJSON(sessions []session.Info, stateFilter, templateFilter string, stdout, stderr io.Writer) int {
+	rows := sessionListJSONRows(sessions)
+	result := sessionListJSON{
+		SchemaVersion: "1",
+		Filters:       sessionListFilters{State: stateFilter, Template: templateFilter},
+		Sessions:      rows,
+		Summary:       summarizeSessionList(rows),
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(result); err != nil {
+		fmt.Fprintf(stderr, "gc session list: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return 0
+}
+
+func summarizeSessionList(rows []sessionListJSONRow) sessionListSummary {
+	summary := sessionListSummary{Total: len(rows)}
+	for _, row := range rows {
+		switch {
+		case row.Closed:
+			summary.Closed++
+		case row.State == session.StateActive:
+			summary.Active++
+		case row.State == session.StateSuspended:
+			summary.Suspended++
+		}
+	}
+	return summary
 }
 
 func sessionListJSONRows(sessions []session.Info) []sessionListJSONRow {
@@ -787,10 +850,12 @@ func sessionListJSONRows(sessions []session.Info) []sessionListJSONRow {
 	for i, s := range sessions {
 		rows[i] = sessionListJSONRow{
 			ID:            s.ID,
+			Name:          sessionListJSONName(s),
 			Template:      s.Template,
 			State:         s.State,
 			Closed:        s.Closed,
 			Title:         s.Title,
+			Rig:           sessionListJSONRig(s),
 			Alias:         s.Alias,
 			AgentName:     s.AgentName,
 			Provider:      s.Provider,
@@ -812,6 +877,28 @@ func sessionListJSONRows(sessions []session.Info) []sessionListJSONRow {
 		}
 	}
 	return rows
+}
+
+func sessionListJSONName(s session.Info) string {
+	if s.Alias != "" {
+		return s.Alias
+	}
+	if s.SessionName != "" {
+		return s.SessionName
+	}
+	return s.ID
+}
+
+func sessionListJSONRig(s session.Info) string {
+	template := strings.TrimSpace(s.Template)
+	if before, _, ok := strings.Cut(template, "/"); ok {
+		return before
+	}
+	name := strings.TrimSpace(s.SessionName)
+	if before, _, ok := strings.Cut(name, "--"); ok {
+		return before
+	}
+	return ""
 }
 
 func sessionListTarget(s session.Info) string {

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1120,7 +1120,7 @@ func TestSessionNewAliasOwner_UsesConfiguredNamedIdentity(t *testing.T) {
 	}
 }
 
-func TestCmdSessionListJSONNoSessionsReturnsEmptyArray(t *testing.T) {
+func TestCmdSessionListJSONNoSessionsReturnsEmptyEnvelope(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")
 
@@ -1138,15 +1138,18 @@ func TestCmdSessionListJSONNoSessionsReturnsEmptyArray(t *testing.T) {
 	if strings.Contains(stdout.String(), "No sessions found") {
 		t.Fatalf("stdout = %q, want JSON only", stdout.String())
 	}
-	var got []session.Info
+	var got sessionListJSON
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
-		t.Fatalf("stdout is not a JSON session array: %v; stdout=%q", err, stdout.String())
+		t.Fatalf("stdout is not a JSON session list object: %v; stdout=%q", err, stdout.String())
 	}
-	if got == nil {
+	if got.SchemaVersion != "1" {
+		t.Fatalf("schema_version = %q, want 1; stdout=%q", got.SchemaVersion, stdout.String())
+	}
+	if got.Sessions == nil {
 		t.Fatalf("sessions JSON = nil, want empty array; stdout=%q", stdout.String())
 	}
-	if len(got) != 0 {
-		t.Fatalf("sessions = %d, want 0; stdout=%q", len(got), stdout.String())
+	if len(got.Sessions) != 0 || got.Summary.Total != 0 {
+		t.Fatalf("sessions = %d summary=%+v, want empty; stdout=%q", len(got.Sessions), got.Summary, stdout.String())
 	}
 }
 
@@ -1282,31 +1285,31 @@ func TestCmdSessionListJSONOmitZeroLastNudgeDeliveredAt(t *testing.T) {
 		t.Fatalf("stdout uses Go field name for last nudge timestamp:\n%s", stdout.String())
 	}
 
-	var rows []map[string]any
-	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
-		t.Fatalf("stdout is not a JSON session array: %v; stdout=%q", err, stdout.String())
+	var got sessionListJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not a JSON session list object: %v; stdout=%q", err, stdout.String())
 	}
-	quiet := sessionListJSONRowBySessionName(rows, "quiet-session")
+	quiet := sessionListJSONRowBySessionName(got.Sessions, "quiet-session")
 	if quiet == nil {
 		t.Fatalf("missing quiet-session row in JSON output:\n%s", stdout.String())
 	}
-	if _, ok := quiet["last_nudge_delivered_at"]; ok {
+	if quiet.LastNudgeDeliveredAt != nil {
 		t.Fatalf("quiet-session last_nudge_delivered_at present, want omitted: %#v", quiet)
 	}
 
-	nudged := sessionListJSONRowBySessionName(rows, "nudged-session")
+	nudged := sessionListJSONRowBySessionName(got.Sessions, "nudged-session")
 	if nudged == nil {
 		t.Fatalf("missing nudged-session row in JSON output:\n%s", stdout.String())
 	}
-	if got, want := nudged["last_nudge_delivered_at"], nudgeStamp.Format(time.RFC3339); got != want {
+	if got, want := nudged.LastNudgeDeliveredAt.Format(time.RFC3339), nudgeStamp.Format(time.RFC3339); got != want {
 		t.Fatalf("nudged-session last_nudge_delivered_at = %#v, want %q; row=%#v", got, want, nudged)
 	}
 }
 
-func sessionListJSONRowBySessionName(rows []map[string]any, name string) map[string]any {
+func sessionListJSONRowBySessionName(rows []sessionListJSONRow, name string) *sessionListJSONRow {
 	for _, row := range rows {
-		if row["SessionName"] == name {
-			return row
+		if row.SessionName == name {
+			return &row
 		}
 	}
 	return nil

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -66,6 +67,7 @@ func newSlingCmd(stdout, stderr io.Writer) *cobra.Command {
 	var fromStdin bool
 	var scopeKind string
 	var scopeRef string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "sling [target] <bead-or-formula-or-text>",
 		Short: "Route work to a session config or agent",
@@ -89,32 +91,38 @@ Examples:
   echo "fix login" | gc sling mayor --stdin # read bead text from stdin`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			argError := func(message string) error {
+				if jsonOutput {
+					return exitForCode(writeJSONError(stdout, stderr, "invalid_arguments", message, 1))
+				}
+				fmt.Fprintln(stderr, message) //nolint:errcheck // best-effort stderr
+				return errExit
+			}
 			if fromStdin {
 				if len(args) != 1 {
-					fmt.Fprintf(stderr, "gc sling: --stdin requires exactly 1 argument (target)\n") //nolint:errcheck // best-effort stderr
-					return errExit
+					return argError("gc sling: --stdin requires exactly 1 argument (target)")
 				}
 			} else if len(args) < 1 || len(args) > 2 {
-				fmt.Fprintf(stderr, "gc sling: requires 1 or 2 arguments: [target] <bead-or-formula>\n") //nolint:errcheck // best-effort stderr
-				return errExit
+				return argError("gc sling: requires 1 or 2 arguments: [target] <bead-or-formula>")
 			}
 			if owned && noConvoy {
-				fmt.Fprintf(stderr, "gc sling: --owned requires a convoy (cannot use with --no-convoy)\n") //nolint:errcheck // best-effort stderr
-				return errExit
+				return argError("gc sling: --owned requires a convoy (cannot use with --no-convoy)")
 			}
 			if merge != "" && merge != "direct" && merge != "mr" && merge != "local" {
-				fmt.Fprintf(stderr, "gc sling: --merge must be direct, mr, or local\n") //nolint:errcheck // best-effort stderr
-				return errExit
+				return argError("gc sling: --merge must be direct, mr, or local")
 			}
 			if (strings.TrimSpace(scopeKind) == "") != (strings.TrimSpace(scopeRef) == "") {
-				fmt.Fprintf(stderr, "gc sling: --scope-kind and --scope-ref must be provided together\n") //nolint:errcheck // best-effort stderr
-				return errExit
+				return argError("gc sling: --scope-kind and --scope-ref must be provided together")
 			}
 			if scopeKind != "" && scopeKind != "city" && scopeKind != "rig" {
-				fmt.Fprintf(stderr, "gc sling: --scope-kind must be city or rig\n") //nolint:errcheck // best-effort stderr
-				return errExit
+				return argError("gc sling: --scope-kind must be city or rig")
 			}
-			code := cmdSling(args, formula, nudge, force, title, vars, merge, noConvoy, owned, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, stdout, stderr)
+			code := 0
+			if jsonOutput {
+				code = cmdSlingWithJSON(args, formula, nudge, force, title, vars, merge, noConvoy, owned, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, true, stdout, stderr)
+			} else {
+				code = cmdSling(args, formula, nudge, force, title, vars, merge, noConvoy, owned, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, stdout, stderr)
+			}
 			return exitForCode(code)
 		},
 	}
@@ -133,6 +141,7 @@ Examples:
 	cmd.Flags().BoolVar(&fromStdin, "stdin", false, "read bead text from stdin (first line = title, rest = description)")
 	cmd.Flags().StringVar(&scopeKind, "scope-kind", "", "logical workflow scope kind for graph.v2 launches")
 	cmd.Flags().StringVar(&scopeRef, "scope-ref", "", "logical workflow scope ref for graph.v2 launches")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output dispatch result in JSON format")
 	cmd.MarkFlagsMutuallyExclusive("formula", "on")
 	cmd.MarkFlagsMutuallyExclusive("no-formula", "formula")
 	cmd.MarkFlagsMutuallyExclusive("no-formula", "on")
@@ -177,6 +186,21 @@ func shellSlingRunner(dir, command string, env map[string]string) (string, error
 
 // cmdSling is the CLI entry point for gc sling.
 func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars []string, merge string, noConvoy, owned, reassign bool, onFormula string, noFormula, fromStdin, dryRun bool, scopeKind, scopeRef string, stdout, stderr io.Writer) int {
+	return cmdSlingWithJSON(args, isFormula, doNudge, force, title, vars, merge, noConvoy, owned, reassign, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, false, stdout, stderr)
+}
+
+func cmdSlingWithJSON(args []string, isFormula, doNudge, force bool, title string, vars []string, merge string, noConvoy, owned, reassign bool, onFormula string, noFormula, fromStdin, dryRun bool, scopeKind, scopeRef string, jsonOutput bool, stdout, stderr io.Writer) int {
+	humanStdout := stdout
+	if jsonOutput {
+		humanStdout = io.Discard
+	}
+	fail := func(code, message string) int {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, code, message, 1)
+		}
+		fmt.Fprintln(stderr, message) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	// --stdin: read bead text from stdin early (before city resolution)
 	// so errors are reported immediately. First line = title, rest = description.
 	var stdinDescription string
@@ -184,13 +208,11 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	if fromStdin {
 		data, err := io.ReadAll(slingStdin())
 		if err != nil {
-			fmt.Fprintf(stderr, "gc sling: reading stdin: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("stdin_read_failed", fmt.Sprintf("gc sling: reading stdin: %v", err))
 		}
 		content := strings.TrimRight(string(data), "\n")
 		if content == "" {
-			fmt.Fprintf(stderr, "gc sling: --stdin: no input received\n") //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("invalid_arguments", "gc sling: --stdin: no input received")
 		}
 		lines := strings.SplitN(content, "\n", 2)
 		stdinTitle = lines[0]
@@ -201,13 +223,11 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return fail("city_resolve_failed", fmt.Sprintf("gc sling: %v", err))
 	}
 	cfg, prov, err := loadSlingCityConfig(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return fail("config_load_failed", fmt.Sprintf("gc sling: %v", err))
 	}
 	emitLoadCityConfigWarnings(stderr, prov)
 	applyFeatureFlags(cfg)
@@ -225,42 +245,35 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		if !isFormula {
 			sourceBead, err = probeExistingSlingSourceBead(cfg, cityPath, beadOrFormula)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1
+				return fail("source_bead_probe_failed", fmt.Sprintf("gc sling: %v", err))
 			}
 		}
 	default:
 		// 1-arg: bead ID only, resolve target from rig's default_sling_target.
 		beadOrFormula = args[0]
 		if isFormula {
-			fmt.Fprintf(stderr, "gc sling: --formula requires explicit target\n") //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("invalid_arguments", "gc sling: --formula requires explicit target")
 		}
 		sourceBead, err = probeExistingSlingSourceBead(cfg, cityPath, beadOrFormula)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("source_bead_probe_failed", fmt.Sprintf("gc sling: %v", err))
 		}
 		if !canInferSlingDefaultTargetFromBead(cfg, beadOrFormula) && !sourceBead.exists {
-			fmt.Fprintf(stderr, "gc sling: inline text requires explicit target\n  usage: gc sling <target> %q\n", beadOrFormula) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("invalid_arguments", fmt.Sprintf("gc sling: inline text requires explicit target; usage: gc sling <target> %q", beadOrFormula))
 		}
 		bp := sling.BeadPrefixForCity(cfg, beadOrFormula)
 		if sourceBead.prefix != "" {
 			bp = sourceBead.prefix
 		}
 		if bp == "" {
-			fmt.Fprintf(stderr, "gc sling: cannot derive rig from bead %q (no prefix)\n", beadOrFormula) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("target_resolve_failed", fmt.Sprintf("gc sling: cannot derive rig from bead %q (no prefix)", beadOrFormula))
 		}
 		rig, found := findRigByPrefix(cfg, bp)
 		if !found {
-			fmt.Fprintf(stderr, "gc sling: no rig with prefix %q for bead %s\n", bp, beadOrFormula) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("target_resolve_failed", fmt.Sprintf("gc sling: no rig with prefix %q for bead %s", bp, beadOrFormula))
 		}
 		if rig.DefaultSlingTarget == "" {
-			fmt.Fprintf(stderr, "gc sling: rig %q has no default_sling_target\n", rig.Name) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("target_resolve_failed", fmt.Sprintf("gc sling: rig %q has no default_sling_target", rig.Name))
 		}
 		target = rig.DefaultSlingTarget
 	}
@@ -273,6 +286,9 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 
 	a, ok := resolveAgentIdentity(cfg, target, currentRigContext(cfg))
 	if !ok {
+		if jsonOutput {
+			return writeJSONError(stdout, stderr, "target_resolve_failed", agentNotFoundMsg("gc sling", target, cfg), 1)
+		}
 		fmt.Fprintln(stderr, agentNotFoundMsg("gc sling", target, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -285,14 +301,12 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		storeDir = sourceBead.storeDir
 		store, err = openStoreAtForCity(storeDir, cityPath)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc sling: opening store %s: %v\n", storeDir, err) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("store_open_failed", fmt.Sprintf("gc sling: opening store %s: %v", storeDir, err))
 		}
 	} else {
 		storeDir, store, err = openSlingStoreForSource(cfg, cityPath, beadOrFormula, a)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("store_open_failed", fmt.Sprintf("gc sling: %v", err))
 		}
 	}
 	storeRef := workflowStoreRefForDir(storeDir, cityPath, cityName, cfg)
@@ -316,17 +330,15 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		}
 		createInlineBead, previewInlineText, err := resolveInlineBeadAction(cfg, beadOrFormula, dryRun, inlineProbeStore)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return fail("inline_bead_resolve_failed", fmt.Sprintf("gc sling: %v", err))
 		}
 		inlineText = previewInlineText
 		if createInlineBead {
 			created, err := store.Create(beads.Bead{Title: beadOrFormula, Description: stdinDescription, Type: "task"})
 			if err != nil {
-				fmt.Fprintf(stderr, "gc sling: creating bead: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1
+				return fail("bead_create_failed", fmt.Sprintf("gc sling: creating bead: %v", err))
 			}
-			fmt.Fprintf(stdout, "Created %s — %q\n", created.ID, beadOrFormula) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(humanStdout, "Created %s — %q\n", created.ID, beadOrFormula) //nolint:errcheck // best-effort stdout
 			beadOrFormula = created.ID
 		}
 	}
@@ -392,7 +404,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		},
 	}
 
-	return doSlingBatch(opts, deps, store, stdout, stderr)
+	return doSlingBatchWithJSON(opts, deps, store, jsonOutput, humanStdout, stdout, stderr)
 }
 
 func loadSlingCityConfig(cityPath string) (*config.City, *config.Provenance, error) {
@@ -795,6 +807,10 @@ func doSling(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, stderr
 
 // doSlingBatch creates a Sling instance and dispatches batch or single.
 func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdout, stderr io.Writer) int {
+	return doSlingBatchWithJSON(opts, deps, querier, false, stdout, stdout, stderr)
+}
+
+func doSlingBatchWithJSON(opts slingOpts, deps slingDeps, querier BeadChildQuerier, jsonOutput bool, humanStdout, jsonStdout, stderr io.Writer) int {
 	populateSlingDepsCallbacks(&deps)
 	sl, newErr := sling.New(deps)
 	if newErr != nil {
@@ -827,10 +843,12 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 	printSlingWarnings(result, stderr)
 	// Always print results when we have children (partial failures
 	// should still show per-child status).
-	if len(result.Children) > 0 {
-		printBatchSlingResult(result, stdout, stderr)
-	} else if err == nil {
-		printSlingResult(result, stdout, stderr)
+	if !jsonOutput {
+		if len(result.Children) > 0 {
+			printBatchSlingResult(result, humanStdout, stderr)
+		} else if err == nil {
+			printSlingResult(result, humanStdout, stderr)
+		}
 	}
 	if err != nil {
 		// Batch can surface multiple typed conflicts (one per conflicted
@@ -860,6 +878,9 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 		return 1
 	}
 	if result.DryRun {
+		if jsonOutput {
+			return writeSlingJSONResult(result, jsonStdout, stderr)
+		}
 		// For batch dry-run, look up the container bead for display.
 		if querier != nil {
 			if b, getErr := querier.Get(opts.BeadOrFormula); getErr == nil {
@@ -872,15 +893,97 @@ func doSlingBatch(opts slingOpts, deps slingDeps, querier BeadChildQuerier, stdo
 						open = append(open, c)
 					}
 				}
-				return dryRunBatch(opts, deps, stdout, stderr, b, children, open, querier)
+				return dryRunBatch(opts, deps, humanStdout, stderr, b, children, open, querier)
 			}
 		}
-		return dryRunSingle(opts, deps, querier, stdout, stderr)
+		return dryRunSingle(opts, deps, querier, humanStdout, stderr)
 	}
 	if result.NudgeAgent != nil {
-		doSlingNudge(result.NudgeAgent, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, stdout, stderr)
+		doSlingNudge(result.NudgeAgent, deps.CityName, deps.CityPath, deps.Cfg, deps.SP, deps.Store, humanStdout, stderr)
+	}
+	if jsonOutput {
+		return writeSlingJSONResult(result, jsonStdout, stderr)
 	}
 	return 0
+}
+
+type slingJSONResult struct {
+	SchemaVersion string                 `json:"schema_version"`
+	Success       bool                   `json:"success"`
+	Target        string                 `json:"target"`
+	Method        string                 `json:"method,omitempty"`
+	BeadID        string                 `json:"bead_id,omitempty"`
+	Formula       string                 `json:"formula,omitempty"`
+	MoleculeID    string                 `json:"molecule_id,omitempty"`
+	WorkflowID    string                 `json:"workflow_id,omitempty"`
+	ConvoyID      string                 `json:"convoy_id,omitempty"`
+	Routed        bool                   `json:"routed"`
+	Queued        bool                   `json:"queued"`
+	DryRun        bool                   `json:"dry_run"`
+	Warnings      []string               `json:"warnings,omitempty"`
+	Batch         *slingJSONBatchSummary `json:"batch,omitempty"`
+}
+
+type slingJSONBatchSummary struct {
+	ContainerType string `json:"container_type,omitempty"`
+	Total         int    `json:"total"`
+	Routed        int    `json:"routed"`
+	Failed        int    `json:"failed"`
+	Skipped       int    `json:"skipped"`
+	Idempotent    int    `json:"idempotent"`
+}
+
+func writeSlingJSONResult(result sling.SlingResult, stdout, stderr io.Writer) int {
+	payload := slingJSONFromResult(result)
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(payload); err != nil {
+		fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return 0
+}
+
+func slingJSONFromResult(result sling.SlingResult) slingJSONResult {
+	payload := slingJSONResult{
+		SchemaVersion: "1",
+		Success:       true,
+		Target:        result.Target,
+		Method:        result.Method,
+		BeadID:        result.BeadID,
+		Formula:       result.FormulaName,
+		MoleculeID:    result.WispRootID,
+		WorkflowID:    result.WorkflowID,
+		ConvoyID:      result.ConvoyID,
+		Routed:        result.Routed > 0 || (!result.Idempotent && result.BeadID != "" && !result.DryRun),
+		Queued:        result.NudgeAgent != nil,
+		DryRun:        result.DryRun,
+		Warnings:      slingJSONWarnings(result),
+	}
+	if len(result.Children) > 0 || result.ContainerType != "" {
+		payload.Batch = &slingJSONBatchSummary{
+			ContainerType: result.ContainerType,
+			Total:         result.Total,
+			Routed:        result.Routed,
+			Failed:        result.Failed,
+			Skipped:       result.Skipped,
+			Idempotent:    result.IdempotentCt,
+		}
+	}
+	return payload
+}
+
+func slingJSONWarnings(result sling.SlingResult) []string {
+	var warnings []string
+	if result.AgentSuspended {
+		warnings = append(warnings, "agent_suspended")
+	}
+	if result.PoolEmpty {
+		warnings = append(warnings, "pool_empty")
+	}
+	warnings = append(warnings, result.BeadWarnings...)
+	warnings = append(warnings, result.MetadataErrors...)
+	return warnings
 }
 
 func printMissingBeadError(stderr io.Writer, err *sling.MissingBeadError, allowForce bool) {

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -404,6 +404,30 @@ func TestBuildSlingCommand(t *testing.T) {
 	}
 }
 
+func TestSlingJSONFromResult(t *testing.T) {
+	result := sling.SlingResult{
+		Target:      "repo-a/polecat",
+		Method:      "formula",
+		BeadID:      "repo-a-1",
+		FormulaName: "pack-review",
+		WorkflowID:  "wf-1",
+		ConvoyID:    "convoy-1",
+		Routed:      1,
+		NudgeAgent:  &config.Agent{Name: "polecat", Dir: "repo-a"},
+	}
+
+	got := slingJSONFromResult(result)
+	if got.SchemaVersion != "1" || !got.Success {
+		t.Fatalf("schema/success = %q/%v, want v1 success", got.SchemaVersion, got.Success)
+	}
+	if got.Target != "repo-a/polecat" || got.BeadID != "repo-a-1" || got.Formula != "pack-review" {
+		t.Fatalf("payload = %+v, want target/bead/formula refs", got)
+	}
+	if !got.Routed || !got.Queued || got.WorkflowID != "wf-1" || got.ConvoyID != "convoy-1" {
+		t.Fatalf("payload = %+v, want routed queued workflow convoy refs", got)
+	}
+}
+
 func TestDoSlingBeadToFixedAgent(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
@@ -7246,6 +7270,33 @@ func TestOneArgSlingFormulaRequiresTarget(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for --formula with 1 arg")
+	}
+}
+
+func TestSlingJSONArgumentErrorIsStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := newSlingCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --formula with 1 arg")
+	}
+
+	var payload cliJSONErrorOutput
+	if unmarshalErr := json.Unmarshal(stdout.Bytes(), &payload); unmarshalErr != nil {
+		t.Fatalf("stdout is not JSON error: %v\n%s", unmarshalErr, stdout.String())
+	}
+	if payload.OK || payload.Error.Code != "invalid_arguments" || payload.Error.ExitCode != 1 {
+		t.Fatalf("payload = %+v, want invalid_arguments exit 1", payload)
+	}
+	var diagnostic cliJSONDiagnostic
+	if unmarshalErr := json.Unmarshal(bytes.TrimSpace(stderr.Bytes()), &diagnostic); unmarshalErr != nil {
+		t.Fatalf("stderr is not JSON diagnostic: %v\n%s", unmarshalErr, stderr.String())
+	}
+	if diagnostic.Code != payload.Error.Code || diagnostic.ExitCode != payload.Error.ExitCode {
+		t.Fatalf("diagnostic = %+v, payload error = %+v", diagnostic, payload.Error)
 	}
 }
 

--- a/cmd/gc/doctor_warmup_test.go
+++ b/cmd/gc/doctor_warmup_test.go
@@ -13,6 +13,7 @@ func TestCommandDoctorChecksWarmupEligibleDefaultsFalse(t *testing.T) {
 		&doltDriftCheck{},
 		&doltTopologyCheck{},
 		&importStateDoctorCheck{},
+		&jsonlArchiveDoctorCheck{},
 		&mcpConfigDoctorCheck{},
 		&mcpSharedTargetDoctorCheck{},
 		&sessionModelDoctorCheck{},

--- a/cmd/gc/json_output.go
+++ b/cmd/gc/json_output.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type cliJSONErrorOutput struct {
+	SchemaVersion string       `json:"schema_version"`
+	OK            bool         `json:"ok"`
+	Error         cliJSONError `json:"error"`
+}
+
+type cliJSONError struct {
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+	ExitCode int    `json:"exit_code"`
+}
+
+type cliJSONDiagnostic struct {
+	SchemaVersion string `json:"schema_version"`
+	Level         string `json:"level"`
+	Code          string `json:"code,omitempty"`
+	Message       string `json:"message"`
+	ExitCode      int    `json:"exit_code,omitempty"`
+}
+
+func writeJSONError(stdout, stderr io.Writer, code, message string, exitCode int) int {
+	if exitCode == 0 {
+		exitCode = 1
+	}
+	payload := cliJSONErrorOutput{
+		SchemaVersion: "1",
+		OK:            false,
+		Error: cliJSONError{
+			Code:     code,
+			Message:  message,
+			ExitCode: exitCode,
+		},
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(payload); err != nil {
+		writeJSONDiagnostic(stderr, "error", "json_encode_failed", fmt.Sprintf("encoding JSON error: %v", err), exitCode)
+		return exitCode
+	}
+	writeJSONDiagnostic(stderr, "error", code, message, exitCode)
+	return exitCode
+}
+
+func writeJSONDiagnostic(stderr io.Writer, level, code, message string, exitCode int) {
+	if stderr == nil {
+		return
+	}
+	payload := cliJSONDiagnostic{
+		SchemaVersion: "1",
+		Level:         level,
+		Code:          code,
+		Message:       message,
+		ExitCode:      exitCode,
+	}
+	_ = json.NewEncoder(stderr).Encode(payload)
+}

--- a/cmd/gc/json_output_test.go
+++ b/cmd/gc/json_output_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWriteJSONErrorIncludesExitCodeOnStdoutAndStderr(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := writeJSONError(&stdout, &stderr, "config_load_failed", "gc status: loading config failed", 7)
+	if code != 7 {
+		t.Fatalf("code = %d, want 7", code)
+	}
+
+	var out cliJSONErrorOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if out.SchemaVersion != "1" || out.OK || out.Error.Code != "config_load_failed" || out.Error.ExitCode != 7 {
+		t.Fatalf("stdout error payload = %+v", out)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stderr lines = %d, want 1; stderr=%q", len(lines), stderr.String())
+	}
+	var diag cliJSONDiagnostic
+	if err := json.Unmarshal([]byte(lines[0]), &diag); err != nil {
+		t.Fatalf("stderr is not JSONL diagnostic: %v\n%s", err, stderr.String())
+	}
+	if diag.SchemaVersion != "1" || diag.Level != "error" || diag.Code != "config_load_failed" || diag.ExitCode != 7 {
+		t.Fatalf("stderr diagnostic = %+v", diag)
+	}
+}

--- a/cmd/gc/jsonl_archive_doctor_check_test.go
+++ b/cmd/gc/jsonl_archive_doctor_check_test.go
@@ -250,7 +250,12 @@ func TestDoDoctorRegistersJsonlArchiveCheck(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writeCityToml(t, cityDir, `[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`)
 	writePackToml(t, cityDir, `[pack]
 name = "demo"
 schema = 1
@@ -292,7 +297,12 @@ func TestDoDoctorJSONOutputIncludesArchiveCheck(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writeCityToml(t, cityDir, `[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`)
 	writePackToml(t, cityDir, `[pack]
 name = "demo"
 schema = 1

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2776,6 +2776,7 @@ gc sling [target] <bead-or-formula-or-text> [flags]
 | `-n`, `--dry-run` | bool |  | show what would be done without executing |
 | `--force` | bool |  | suppress warnings, allow cross-rig routing, allow graph workflow replacement, and for direct bead routes dispatch even if the bead does not resolve in the local store |
 | `-f`, `--formula` | bool |  | treat argument as formula name |
+| `--json` | bool |  | Output dispatch result in JSON format |
 | `--merge` | string |  | merge strategy: direct, mr, or local |
 | `--no-convoy` | bool |  | skip auto-convoy creation |
 | `--no-formula` | bool |  | suppress default formula (route raw bead) |

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -68,6 +68,7 @@ func TestCheckWarmupEligibleDefaultsFalse(t *testing.T) {
 		&ImplicitImportCacheCheck{},
 		&NestedWorktreePruneCheck{},
 		&OrphanSessionsCheck{},
+		&OrderFiringCurrentCheck{},
 		&PackCacheCheck{},
 		&PreStartScriptsCheck{},
 		&ProviderParityCheck{},

--- a/schemas/rig/list/result.schema.json
+++ b/schemas/rig/list/result.schema.json
@@ -1,15 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "gc rig list --json result",
+  "description": "One JSONL record listing the city and registered rigs.",
   "type": "object",
-  "required": ["city_path", "city_name", "rigs"],
+  "additionalProperties": false,
+  "required": ["schema_version", "city_path", "city_name", "rigs", "summary"],
   "properties": {
-    "city_path": { "type": "string" },
-    "city_name": { "type": "string" },
+    "schema_version": { "type": "string", "description": "Schema version for this command output." },
+    "city_path": { "type": "string", "description": "Absolute city root path." },
+    "city_name": { "type": "string", "description": "Configured or inferred city name." },
     "rigs": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "path", "prefix", "hq", "suspended", "beads"],
+        "additionalProperties": false,
+        "required": ["name", "path", "prefix", "hq", "suspended", "running", "beads"],
         "properties": {
           "name": { "type": "string" },
           "path": { "type": "string" },
@@ -17,11 +22,21 @@
           "default_branch": { "type": "string" },
           "hq": { "type": "boolean" },
           "suspended": { "type": "boolean" },
+          "running": { "type": "boolean" },
+          "default_sling_target": { "type": "string" },
           "beads": { "type": "string" }
-        },
-        "additionalProperties": true
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "suspended", "running"],
+      "properties": {
+        "total": { "type": "integer" },
+        "suspended": { "type": "integer" },
+        "running": { "type": "integer" }
       }
     }
-  },
-  "additionalProperties": true
+  }
 }

--- a/schemas/session/list/result.schema.json
+++ b/schemas/session/list/result.schema.json
@@ -1,17 +1,70 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "properties": {
-      "id": { "type": "string" },
-      "name": { "type": "string" },
-      "template": { "type": "string" },
-      "provider": { "type": "string" },
-      "state": { "type": "string" },
-      "title": { "type": "string" },
-      "rig": { "type": "string" }
+  "title": "gc session list --json result",
+  "description": "One JSONL record listing durable Gas City sessions and summary counts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "filters", "sessions", "summary"],
+  "properties": {
+    "schema_version": { "type": "string", "description": "Schema version for this command output." },
+    "filters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "state": { "type": "string", "description": "State filter requested by the caller, when present." },
+        "template": { "type": "string", "description": "Template filter requested by the caller, when present." }
+      }
     },
-    "additionalProperties": true
+    "sessions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "template",
+          "state",
+          "created_at",
+          "last_active",
+          "attached",
+          "closed"
+        ],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "template": { "type": "string" },
+          "provider": { "type": "string" },
+          "state": { "type": "string" },
+          "title": { "type": "string" },
+          "rig": { "type": "string" },
+          "alias": { "type": "string" },
+          "agent_name": { "type": "string" },
+          "transport": { "type": "string" },
+          "command": { "type": "string" },
+          "work_dir": { "type": "string" },
+          "session_name": { "type": "string" },
+          "session_key": { "type": "string" },
+          "resume_flag": { "type": "string" },
+          "resume_style": { "type": "string" },
+          "resume_command": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "last_active": { "type": "string", "format": "date-time" },
+          "last_nudge_delivered_at": { "type": "string", "format": "date-time" },
+          "attached": { "type": "boolean" },
+          "closed": { "type": "boolean" }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "active", "suspended", "closed"],
+      "properties": {
+        "total": { "type": "integer" },
+        "active": { "type": "integer" },
+        "suspended": { "type": "integer" },
+        "closed": { "type": "integer" }
+      }
+    }
   }
 }

--- a/schemas/sling/result.schema.json
+++ b/schemas/sling/result.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "gc sling --json result",
+  "description": "One JSONL record describing the result of dispatching work through gc sling.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "success", "target", "routed", "queued", "dry_run"],
+  "properties": {
+    "schema_version": { "type": "string", "description": "Schema version for this command output." },
+    "success": { "type": "boolean", "description": "Whether sling produced a successful dispatch result." },
+    "target": { "type": "string", "description": "Resolved sling target." },
+    "method": { "type": "string", "description": "Dispatch method used." },
+    "bead_id": { "type": "string", "description": "Created or selected work bead ID." },
+    "formula": { "type": "string", "description": "Formula name used for dispatch, when applicable." },
+    "molecule_id": { "type": "string", "description": "Created molecule/root workflow bead ID, when applicable." },
+    "workflow_id": { "type": "string", "description": "Created workflow ID, when applicable." },
+    "convoy_id": { "type": "string", "description": "Created or selected convoy ID, when applicable." },
+    "routed": { "type": "boolean", "description": "Whether work was routed or considered routed." },
+    "queued": { "type": "boolean", "description": "Whether the dispatch queued a nudge for an agent." },
+    "dry_run": { "type": "boolean", "description": "Whether the command ran without mutating dispatch state." },
+    "warnings": {
+      "type": "array",
+      "description": "Non-fatal warnings from dispatch.",
+      "items": { "type": "string" }
+    },
+    "batch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "routed", "failed", "skipped", "idempotent"],
+      "properties": {
+        "container_type": { "type": "string" },
+        "total": { "type": "integer" },
+        "routed": { "type": "integer" },
+        "failed": { "type": "integer" },
+        "skipped": { "type": "integer" },
+        "idempotent": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/schemas/status/result.schema.json
+++ b/schemas/status/result.schema.json
@@ -1,26 +1,68 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "gc status --json result",
+  "description": "One JSONL record describing city identity, controller state, health, agents, rigs, and summary counts.",
   "type": "object",
-  "required": ["city_name", "city_path", "controller", "suspended", "agents", "rigs", "summary"],
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "city_name",
+    "workspace",
+    "city_path",
+    "controller",
+    "running",
+    "suspended",
+    "health",
+    "agents",
+    "rigs",
+    "summary"
+  ],
   "properties": {
-    "city_name": { "type": "string" },
-    "city_path": { "type": "string" },
+    "schema_version": { "type": "string", "description": "Schema version for this command output." },
+    "city_name": { "type": "string", "description": "Configured or inferred city name." },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path"],
+      "properties": {
+        "name": { "type": "string", "description": "Workspace display name." },
+        "path": { "type": "string", "description": "Absolute workspace path." }
+      }
+    },
+    "city_path": { "type": "string", "description": "Absolute city root path." },
     "controller": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["running"],
       "properties": {
-        "running": { "type": "boolean" },
-        "pid": { "type": "integer" },
-        "mode": { "type": "string" },
-        "status": { "type": "string" }
-      },
-      "additionalProperties": true
+        "running": { "type": "boolean", "description": "Whether the city controller appears to be running." },
+        "pid": { "type": "integer", "description": "Controller process ID when known." },
+        "mode": { "type": "string", "description": "Controller operating mode when known." },
+        "status": { "type": "string", "description": "Controller status text when known." }
+      }
     },
-    "suspended": { "type": "boolean" },
+    "running": { "type": "boolean", "description": "Whether the city is considered running." },
+    "suspended": { "type": "boolean", "description": "Whether the city is suspended." },
+    "health": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["usable", "degraded"],
+      "properties": {
+        "usable": { "type": "boolean", "description": "Whether agents and software can use the city." },
+        "degraded": { "type": "boolean", "description": "Whether any degraded signal was observed." },
+        "signals": {
+          "type": "array",
+          "description": "Human-readable degraded or health signals.",
+          "items": { "type": "string" }
+        }
+      }
+    },
     "agents": {
       "type": "array",
+      "description": "Configured agents visible to the city.",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "required": ["name", "qualified_name", "scope", "running", "suspended"],
         "properties": {
           "name": { "type": "string" },
@@ -30,40 +72,42 @@
           "suspended": { "type": "boolean" },
           "pool": {
             "type": "object",
+            "additionalProperties": false,
+            "required": ["min", "max"],
             "properties": {
               "min": { "type": "integer" },
               "max": { "type": "integer" }
-            },
-            "additionalProperties": true
+            }
           }
-        },
-        "additionalProperties": true
+        }
       }
     },
     "rigs": {
       "type": "array",
+      "description": "Registered rigs visible to the city.",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "required": ["name", "path", "suspended"],
         "properties": {
           "name": { "type": "string" },
           "path": { "type": "string" },
-          "suspended": { "type": "boolean" }
-        },
-        "additionalProperties": true
+          "prefix": { "type": "string" },
+          "suspended": { "type": "boolean" },
+          "default_sling_target": { "type": "string" }
+        }
       }
     },
     "summary": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["total_agents", "running_agents"],
       "properties": {
         "total_agents": { "type": "integer" },
         "running_agents": { "type": "integer" },
         "active_sessions": { "type": "integer" },
         "suspended_sessions": { "type": "integer" }
-      },
-      "additionalProperties": true
+      }
     }
-  },
-  "additionalProperties": true
+  }
 }

--- a/test/acceptance/import_named_sessions_regression_test.go
+++ b/test/acceptance/import_named_sessions_regression_test.go
@@ -14,8 +14,12 @@ import (
 )
 
 type namedSessionListEntry struct {
-	Template    string `json:"Template"`
-	SessionName string `json:"SessionName"`
+	Template    string `json:"template"`
+	SessionName string `json:"session_name"`
+}
+
+type namedSessionListEnvelope struct {
+	Sessions []namedSessionListEntry `json:"sessions"`
 }
 
 func TestImportedNamedSessionsUseSafeRuntimeNames(t *testing.T) {
@@ -80,14 +84,14 @@ mode = "always"
 
 	c.StartForeground()
 
-	var sessions []namedSessionListEntry
 	deadline := time.Now().Add(20 * time.Second)
 	for time.Now().Before(deadline) {
 		out, err := c.GC("session", "list", "--json")
 		if err == nil {
+			var sessions namedSessionListEnvelope
 			if unmarshalErr := json.Unmarshal([]byte(out), &sessions); unmarshalErr == nil {
-				if hasNamedSession(sessions, "gs.captain", "gs__captain") &&
-					hasNamedSession(sessions, "repo/gs.watcher", "repo--gs__watcher") {
+				if hasNamedSession(sessions.Sessions, "gs.captain", "gs__captain") &&
+					hasNamedSession(sessions.Sessions, "repo/gs.watcher", "repo--gs__watcher") {
 					return
 				}
 			}

--- a/test/acceptance/session_test.go
+++ b/test/acceptance/session_test.go
@@ -121,20 +121,25 @@ func TestSessionDefaultNamedSession(t *testing.T) {
 		if err != nil {
 			t.Fatalf("gc session list --json: %v\n%s", err, out)
 		}
-		var got []session.Info
+		var got struct {
+			Sessions []struct {
+				Template string        `json:"template"`
+				State    session.State `json:"state"`
+			} `json:"sessions"`
+		}
 		if err := json.Unmarshal([]byte(out), &got); err != nil {
-			t.Fatalf("gc session list --json output is not a session array: %v\n%s", err, out)
+			t.Fatalf("gc session list --json output is not a session list envelope: %v\n%s", err, out)
 		}
-		if len(got) != 1 {
-			t.Fatalf("session count = %d, want 1 default named session\n%s", len(got), out)
+		if len(got.Sessions) != 1 {
+			t.Fatalf("session count = %d, want 1 default named session\n%s", len(got.Sessions), out)
 		}
-		if got[0].Template != "mayor" {
-			t.Errorf("template = %q, want mayor\n%s", got[0].Template, out)
+		if got.Sessions[0].Template != "mayor" {
+			t.Errorf("template = %q, want mayor\n%s", got.Sessions[0].Template, out)
 		}
-		switch got[0].State {
+		switch got.Sessions[0].State {
 		case session.StateCreating, session.StateActive, session.StateAwake:
 		default:
-			t.Errorf("state = %q, want creating or running\n%s", got[0].State, out)
+			t.Errorf("state = %q, want creating or running\n%s", got.Sessions[0].State, out)
 		}
 	})
 

--- a/test/acceptance/worker_inference/worker_inference_test.go
+++ b/test/acceptance/worker_inference/worker_inference_test.go
@@ -5105,8 +5105,15 @@ func parseSessionListJSON(out string) ([]sessionJSON, error) {
 	if trimmed == "" || trimmed == "null" {
 		return nil, nil
 	}
-	if idx := strings.Index(trimmed, "["); idx >= 0 {
-		trimmed = trimmed[idx:]
+	var envelope struct {
+		Sessions []sessionJSON `json:"sessions"`
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		dec := json.NewDecoder(strings.NewReader(trimmed))
+		if err := dec.Decode(&envelope); err != nil {
+			return nil, fmt.Errorf("unmarshal session list json envelope: %w", err)
+		}
+		return envelope.Sessions, nil
 	}
 	var sessions []sessionJSON
 	dec := json.NewDecoder(strings.NewReader(trimmed))
@@ -5147,14 +5154,14 @@ type beadJSON struct {
 }
 
 type sessionJSON struct {
-	Template    string `json:"Template"`
-	Provider    string `json:"Provider"`
-	ID          string `json:"ID"`
-	Alias       string `json:"Alias"`
-	State       string `json:"State"`
-	SessionName string `json:"SessionName"`
-	SessionKey  string `json:"SessionKey"`
-	LastActive  string `json:"LastActive"`
+	Template    string `json:"template"`
+	Provider    string `json:"provider"`
+	ID          string `json:"id"`
+	Alias       string `json:"alias"`
+	State       string `json:"state"`
+	SessionName string `json:"session_name"`
+	SessionKey  string `json:"session_key"`
+	LastActive  string `json:"last_active"`
 }
 
 func metaString(meta map[string]any, key string) string {

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -178,14 +178,16 @@ func sessionAssigneeForTemplate(t *testing.T, cityDir, template string) string {
 	for time.Now().Before(deadline) {
 		out, err := gc(cityDir, "session", "list", "--json", "--template", template)
 		if err == nil {
-			var sessions []struct {
-				Template    string
-				Closed      bool
-				State       string
-				SessionName string
+			var sessionList struct {
+				Sessions []struct {
+					Template    string `json:"template"`
+					Closed      bool   `json:"closed"`
+					State       string `json:"state"`
+					SessionName string `json:"session_name"`
+				} `json:"sessions"`
 			}
-			if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &sessions); jsonErr == nil {
-				for _, session := range sessions {
+			if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &sessionList); jsonErr == nil {
+				for _, session := range sessionList.Sessions {
 					if session.Closed || strings.TrimSpace(session.Template) != template {
 						continue
 					}


### PR DESCRIPTION
## Summary

Adds the first product-wide `gc --json` implementation batch for software consumers.

Included surfaces:

- `gc status --json` now emits an object envelope with `schema_version`, workspace identity, running/suspended state, health signals, agents, rigs, and summary counts.
- `gc session list --json` now emits an object envelope with filters, sessions, and summary counts instead of a bare array.
- `gc rig list --json` now emits `schema_version`, running/suspended/default sling target fields, and summary counts.
- `gc sling --json` emits a structured dispatch result while suppressing human stdout in JSON mode.

## Existing JSON Compatibility Notes

This PR intentionally normalizes existing JSON output for the first standardization wave. These changes are visible because software consumers may already be calling these commands.

### `gc status --json`

- Existing support: yes, this command already had JSON on `main`.
- Old shape: top-level object without `schema_version`, `workspace`, top-level `running`, or `health`; included `city_name`, `city_path`, `controller`, `suspended`, `agents`, `rigs`, and `summary`.
- New shape: keeps the useful existing fields and adds `schema_version`, `workspace`, top-level `running`, and `health` with `usable/degraded/signals`.
- Compatibility risk: additive for most object-field consumers, but consumers that require an exact field set may need to tolerate the new fields. Empty collections now prefer arrays over `null` where practical.
- Rationale: `status` is the main readiness probe for software consumers, so this first wave is the right time to make health/readiness explicit rather than forcing agents to infer it from human output or scattered fields.

### `gc session list --json`

- Existing support: yes, this command already had JSON on `main`.
- Old shape: bare JSON array of session rows.
- New shape: top-level object with `schema_version`, `filters`, `sessions`, and `summary`; session fields are normalized to snake_case.
- Compatibility risk: intentionally breaking for consumers expecting a bare array or old exported Go-style field names.
- Rationale: session listing is a core machine-consumer discovery surface. The object envelope gives us room for filters, summaries, schema versioning, warnings, and future metadata without another shape break.

### `gc rig list --json`

- Existing support: no broad JSON contract on `main` for this command in the same normalized shape.
- New shape: top-level object with `schema_version`, `city_path`, `city_name`, `rigs`, and `summary`.
- Compatibility risk: low; this is part of the newly standardized first batch.

### `gc sling --json`

- Existing support: no.
- New shape: top-level dispatch result object with `schema_version`, target, bead/formula/workflow/molecule refs when available, routed/queued/success status, warnings, and child results when applicable.
- Compatibility risk: low for existing users because human output remains the default.

### JSON-mode errors

- Existing support: inconsistent; most failing commands only wrote human diagnostics to stderr.
- New first-batch behavior: touched `--json` failure paths emit a structured stdout object with `schema_version`, `ok: false`, and `error` containing `code`, `message`, and `exit_code`.
- Stderr behavior: touched failure paths emit a JSONL diagnostic with the same `code` and `exit_code`; the process still exits with that same code for ordinary shell control flow.
- Compatibility risk: intentionally breaking for any existing `--json` consumers that expected empty stdout or human-only stderr on failure. Some deeper warnings/diagnostics still use existing stderr behavior and will be normalized in follow-up standardization work.
- Rationale: agents and scripts need parseable failure details without giving up normal nonzero exit handling.

## Contract Notes

- Human-readable output remains the default.
- Successful `--json` output is intended to be JSON-only stdout.
- Failed touched `--json` paths emit structured JSON errors on stdout with `error.exit_code` matching the process exit code.
- Touched JSON-mode failure diagnostics use JSONL on stderr; broader stderr normalization remains staged work.
- `gc sling --json` models meaningful dispatch data as fields instead of preserving incidental human stdout.

## Related Work

- Tracking issue: #2138
- Design PR: #2139

## Testing

- `go test ./cmd/gc -run 'Test(CmdSessionListJSON|SessionListJSON|SlingJSONFromResult|CmdRig|CityStatus|Status)'`
- `go test ./cmd/gc -run 'Test(WriteJSONError|CmdCityStatusJSONConfigErrorIsStructured|SlingJSONArgumentErrorIsStructured|CmdSessionListJSON|DoRigListJSON)'`
- `go test ./cmd/gc -run '^$'`
- `go test -tags acceptance_a -timeout 5m ./test/acceptance -run 'Test(SessionDefaultNamedSession|ImportedNamedSessionsUseSafeRuntimeNames)'`
- `go test -tags acceptance_a -timeout 5m ./test/acceptance/worker_inference -run '^$'`
- `go test -tags integration -timeout 8m ./test/integration -run 'TestGastown_(PoolScaling|ShutdownDogProcessesWarrant|PolecatHappyPath)'`
- `make lint`
- `git diff --check`

Attempted `go test ./cmd/gc`; it stayed silent past the useful local wait window twice, so this PR reports the focused passing checks above rather than claiming the full package run completed.
