### PR TITLE
Add BdStore metadata fallback for import-loop wedges

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -37,7 +37,9 @@ func bdStoreForCity(dir, cityPath string) *beads.BdStore {
 	if err != nil {
 		cfg = nil
 	}
-	return beads.NewBdStoreWithPrefix(dir, bdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
+	store := beads.NewBdStoreWithPrefix(dir, bdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
+	configureBdStoreMetadataFallback(store, dir, bdRuntimeEnv(cityPath))
+	return store
 }
 
 // bdStoreForRig opens a bead store at rigDir using rig-level Dolt config
@@ -53,7 +55,9 @@ func bdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...str
 			}
 		}
 	}
-	return beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+	store := beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+	configureBdStoreMetadataFallback(store, rigDir, bdRuntimeEnvForRig(cityPath, cfg, rigDir))
+	return store
 }
 
 func controlBdStoreForCity(dir, cityPath string, cfg *config.City) *beads.BdStore {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2610,6 +2610,68 @@ func TestBdTransportRetryableErrorDoesNotTreatCommandTimeoutAsTransportFailure(t
 	}
 }
 
+func TestConfigureBdStoreMetadataFallbackUsesManagedLocalPortWithoutHost(t *testing.T) {
+	scopeRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(scopeRoot, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scopeRoot, ".beads", "metadata.json"), []byte(`{"dolt_database":"ga"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewBdStore(scopeRoot, func(_, _ string, _ ...string) ([]byte, error) {
+		return nil, fmt.Errorf("timed out after 120s: auto-importing 1 bytes from issues.jsonl into empty database...")
+	})
+
+	origWrite := writeBdMetadataDirectFunc
+	t.Cleanup(func() {
+		writeBdMetadataDirectFunc = origWrite
+	})
+
+	var got struct {
+		host string
+		port string
+		db   string
+		id   string
+		kvs  map[string]string
+	}
+	writeBdMetadataDirectFunc = func(host, port, user, password, database, id string, kvs map[string]string) error {
+		got.host = host
+		got.port = port
+		got.db = database
+		got.id = id
+		got.kvs = map[string]string{}
+		for k, v := range kvs {
+			got.kvs[k] = v
+		}
+		return nil
+	}
+
+	configureBdStoreMetadataFallback(store, scopeRoot, map[string]string{
+		"GC_DOLT_PORT": "35852",
+		"GC_DOLT_USER": "root",
+	})
+
+	if err := store.SetMetadata("ga-ji9zdi", "state", "awake"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	if got.host != "" {
+		t.Fatalf("fallback host = %q, want empty managed-local host", got.host)
+	}
+	if got.port != "35852" {
+		t.Fatalf("fallback port = %q, want 35852", got.port)
+	}
+	if got.db != "ga" {
+		t.Fatalf("fallback database = %q, want ga", got.db)
+	}
+	if got.id != "ga-ji9zdi" {
+		t.Fatalf("fallback id = %q, want ga-ji9zdi", got.id)
+	}
+	if got.kvs["state"] != "awake" {
+		t.Fatalf("fallback metadata = %#v, want state=awake", got.kvs)
+	}
+}
+
 func TestBdTransportTransientDisconnectDoesNotTriggerManagedRecovery(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2620,7 +2620,7 @@ func TestConfigureBdStoreMetadataFallbackUsesManagedLocalPortWithoutHost(t *test
 	}
 
 	store := beads.NewBdStore(scopeRoot, func(_, _ string, _ ...string) ([]byte, error) {
-		return nil, fmt.Errorf("timed out after 120s: auto-importing 1 bytes from issues.jsonl into empty database...")
+		return nil, fmt.Errorf("timed out after 120s: auto-importing 1 bytes from issues.jsonl into empty database")
 	})
 
 	origWrite := writeBdMetadataDirectFunc
@@ -2635,7 +2635,7 @@ func TestConfigureBdStoreMetadataFallbackUsesManagedLocalPortWithoutHost(t *test
 		id   string
 		kvs  map[string]string
 	}
-	writeBdMetadataDirectFunc = func(host, port, user, password, database, id string, kvs map[string]string) error {
+	writeBdMetadataDirectFunc = func(host, port, _, _, database, id string, kvs map[string]string) error {
 		got.host = host
 		got.port = port
 		got.db = database

--- a/cmd/gc/bd_metadata_fallback.go
+++ b/cmd/gc/bd_metadata_fallback.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+var writeBdMetadataDirectFunc = writeBdMetadataDirect
+
+func configureBdStoreMetadataFallback(store *beads.BdStore, scopeRoot string, env map[string]string) {
+	if store == nil {
+		return
+	}
+	scopeRoot = strings.TrimSpace(scopeRoot)
+	if scopeRoot == "" {
+		return
+	}
+	host := strings.TrimSpace(env["GC_DOLT_HOST"])
+	port := strings.TrimSpace(env["GC_DOLT_PORT"])
+	user := strings.TrimSpace(env["GC_DOLT_USER"])
+	password := env["GC_DOLT_PASSWORD"]
+	database := readDeferredManagedDoltDatabase(filepath.Join(scopeRoot, ".beads", "metadata.json"), "")
+	if port == "" || database == "" {
+		return
+	}
+	store.SetMetadataFallback(func(id string, kvs map[string]string) error {
+		return writeBdMetadataDirectFunc(host, port, user, password, database, id, kvs)
+	})
+}
+
+func writeBdMetadataDirect(host, port, user, password, database, id string, kvs map[string]string) error {
+	if strings.TrimSpace(id) == "" || len(kvs) == 0 {
+		return nil
+	}
+	db, err := openManagedDoltDatabaseWithPassword(host, port, user, password, database)
+	if err != nil {
+		return err
+	}
+	defer db.Close() //nolint:errcheck
+
+	keys := make([]string, 0, len(kvs))
+	for key := range kvs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var query strings.Builder
+	query.WriteString("UPDATE issues SET metadata = JSON_SET(COALESCE(metadata, JSON_OBJECT())")
+	args := make([]any, 0, len(keys)*2+1)
+	for _, key := range keys {
+		query.WriteString(", ?, ?")
+		args = append(args, metadataJSONPath(key), kvs[key])
+	}
+	query.WriteString(") WHERE id = ?")
+	args = append(args, id)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := db.ExecContext(ctx, query.String(), args...)
+	if err != nil {
+		return err
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows > 0 {
+		return nil
+	}
+
+	var exists int
+	switch err := db.QueryRowContext(ctx, "SELECT 1 FROM issues WHERE id = ?", id).Scan(&exists); err {
+	case nil:
+		return nil
+	case sql.ErrNoRows:
+		return beads.ErrNotFound
+	default:
+		return err
+	}
+}
+
+func metadataJSONPath(key string) string {
+	key = strings.ReplaceAll(key, `\`, `\\`)
+	key = strings.ReplaceAll(key, `"`, `\"`)
+	return `$."` + key + `"`
+}
+
+func openManagedDoltDatabaseWithPassword(host, port, user, password, database string) (*sql.DB, error) {
+	host = managedDoltConnectHost(host)
+	port = strings.TrimSpace(port)
+	if port == "" {
+		return nil, fmt.Errorf("missing port")
+	}
+	user = strings.TrimSpace(user)
+	if user == "" {
+		user = "root"
+	}
+	database = strings.TrimSpace(database)
+	if database == "" {
+		return nil, fmt.Errorf("missing database")
+	}
+	cfg := mysql.NewConfig()
+	cfg.User = user
+	cfg.Passwd = password
+	cfg.Net = "tcp"
+	cfg.Addr = host + ":" + port
+	cfg.DBName = database
+	cfg.Timeout = 5 * time.Second
+	cfg.ReadTimeout = 5 * time.Second
+	cfg.WriteTimeout = 5 * time.Second
+	cfg.AllowNativePasswords = true
+	return sql.Open("mysql", cfg.FormatDSN())
+}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -155,13 +155,18 @@ type PurgeResult struct {
 	Purged int
 }
 
+// MetadataFallbackFunc optionally applies metadata writes when the bd CLI
+// metadata path is wedged but the underlying store remains directly writable.
+type MetadataFallbackFunc func(id string, kvs map[string]string) error
+
 // BdStore implements Store by shelling out to the bd CLI (beads v0.55.1+).
 // It delegates all persistence to bd's embedded Dolt database.
 type BdStore struct {
-	dir         string          // city root directory (where .beads/ lives)
-	runner      CommandRunner   // injectable for testing
-	purgeRunner PurgeRunnerFunc // injectable for testing; nil uses exec default
-	idPrefix    string          // bead ID prefix owned by this store, without trailing "-"
+	dir              string               // city root directory (where .beads/ lives)
+	runner           CommandRunner        // injectable for testing
+	purgeRunner      PurgeRunnerFunc      // injectable for testing; nil uses exec default
+	idPrefix         string               // bead ID prefix owned by this store, without trailing "-"
+	metadataFallback MetadataFallbackFunc // optional direct metadata writer
 }
 
 const bdTransientWriteAttempts = 3
@@ -174,6 +179,12 @@ func NewBdStore(dir string, runner CommandRunner) *BdStore {
 // NewBdStoreWithPrefix creates a BdStore with an explicit owned bead ID prefix.
 func NewBdStoreWithPrefix(dir string, runner CommandRunner, idPrefix string) *BdStore {
 	return &BdStore{dir: dir, runner: runner, idPrefix: normalizeIDPrefix(idPrefix)}
+}
+
+// SetMetadataFallback installs an optional direct metadata writer used only
+// when the bd CLI metadata path is clearly wedged.
+func (s *BdStore) SetMetadataFallback(fn MetadataFallbackFunc) {
+	s.metadataFallback = fn
 }
 
 // IDPrefix returns the bead ID prefix owned by this store, without trailing "-".
@@ -794,6 +805,14 @@ func (s *BdStore) SetMetadata(id, key, value string) error {
 		if isBdNotFound(err) {
 			return fmt.Errorf("setting metadata on %q: %w", id, ErrNotFound)
 		}
+		if used, fbErr := s.applyMetadataFallback(err, id, map[string]string{key: value}); used && fbErr == nil {
+			return nil
+		} else if used && fbErr != nil {
+			if errors.Is(fbErr, ErrNotFound) {
+				return fmt.Errorf("setting metadata on %q: %w", id, ErrNotFound)
+			}
+			return fmt.Errorf("setting metadata on %q: %w", id, fbErr)
+		}
 		return fmt.Errorf("setting metadata on %q: %w", id, err)
 	}
 	return nil
@@ -820,9 +839,35 @@ func (s *BdStore) SetMetadataBatch(id string, kvs map[string]string) error {
 		if isBdNotFound(err) {
 			return fmt.Errorf("setting metadata on %q: %w", id, ErrNotFound)
 		}
+		if used, fbErr := s.applyMetadataFallback(err, id, kvs); used && fbErr == nil {
+			return nil
+		} else if used && fbErr != nil {
+			if errors.Is(fbErr, ErrNotFound) {
+				return fmt.Errorf("setting metadata on %q: %w", id, ErrNotFound)
+			}
+			return fmt.Errorf("setting metadata on %q: %w", id, fbErr)
+		}
 		return fmt.Errorf("setting metadata on %q: %w", id, err)
 	}
 	return nil
+}
+
+func shouldUseMetadataFallback(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "auto-importing") ||
+		strings.Contains(msg, "empty database") ||
+		strings.Contains(msg, "auto-import from") ||
+		strings.Contains(msg, "query error: context canceled")
+}
+
+func (s *BdStore) applyMetadataFallback(err error, id string, kvs map[string]string) (bool, error) {
+	if s.metadataFallback == nil || !shouldUseMetadataFallback(err) {
+		return false, nil
+	}
+	return true, s.metadataFallback(id, kvs)
 }
 
 func (s *BdStore) runBDTransientWrite(args ...string) error {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2030,6 +2030,56 @@ func TestBdStoreSetMetadataCLINotFound(t *testing.T) {
 	}
 }
 
+func TestBdStoreSetMetadataFallsBackOnImportLoop(t *testing.T) {
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		return nil, fmt.Errorf("timed out after 120s: auto-importing 15176999 bytes from /city/.beads/issues.jsonl into empty database...")
+	}
+	s := beads.NewBdStore("/city", runner)
+	var gotID string
+	var gotKVs map[string]string
+	s.SetMetadataFallback(func(id string, kvs map[string]string) error {
+		gotID = id
+		gotKVs = kvs
+		return nil
+	})
+	if err := s.SetMetadata("bd-42", "key", "value"); err != nil {
+		t.Fatalf("SetMetadata fallback err = %v, want nil", err)
+	}
+	if gotID != "bd-42" {
+		t.Fatalf("fallback id = %q, want %q", gotID, "bd-42")
+	}
+	if gotKVs["key"] != "value" {
+		t.Fatalf("fallback kvs = %#v, want key=value", gotKVs)
+	}
+}
+
+func TestBdStoreSetMetadataBatchFallsBackOnImportLoop(t *testing.T) {
+	runner := func(_, _ string, _ ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 1: auto-import from /city/.beads/issues.jsonl failed: query error: context canceled")
+	}
+	s := beads.NewBdStore("/city", runner)
+	var gotID string
+	var gotKVs map[string]string
+	s.SetMetadataFallback(func(id string, kvs map[string]string) error {
+		gotID = id
+		gotKVs = map[string]string{}
+		for k, v := range kvs {
+			gotKVs[k] = v
+		}
+		return nil
+	})
+	want := map[string]string{"a": "1", "b": "2"}
+	if err := s.SetMetadataBatch("bd-42", want); err != nil {
+		t.Fatalf("SetMetadataBatch fallback err = %v, want nil", err)
+	}
+	if gotID != "bd-42" {
+		t.Fatalf("fallback id = %q, want %q", gotID, "bd-42")
+	}
+	if len(gotKVs) != len(want) || gotKVs["a"] != "1" || gotKVs["b"] != "2" {
+		t.Fatalf("fallback kvs = %#v, want %#v", gotKVs, want)
+	}
+}
+
 func TestBdStoreSetMetadataBatchCLINotFound(t *testing.T) {
 	runner := func(_, _ string, _ ...string) ([]byte, error) {
 		return nil, fmt.Errorf("exit status 1: Error updating x: no issue found matching \"bd-42\"")

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2032,7 +2032,7 @@ func TestBdStoreSetMetadataCLINotFound(t *testing.T) {
 
 func TestBdStoreSetMetadataFallsBackOnImportLoop(t *testing.T) {
 	runner := func(_, _ string, _ ...string) ([]byte, error) {
-		return nil, fmt.Errorf("timed out after 120s: auto-importing 15176999 bytes from /city/.beads/issues.jsonl into empty database...")
+		return nil, fmt.Errorf("timed out after 120s: auto-importing 15176999 bytes from /city/.beads/issues.jsonl into empty database")
 	}
 	s := beads.NewBdStore("/city", runner)
 	var gotID string


### PR DESCRIPTION
## Summary

This adds a narrow metadata-write fallback for `BdStore` when the `bd` CLI wedges in the import-loop / empty-database path.

## Problem

In some managed-Dolt states, `bd update --set-metadata` can wedge or fail while trying to auto-import from `issues.jsonl` into an empty database.

That leaves GC unable to write routine metadata transitions even though the underlying Dolt store is still directly reachable.

## Fix

- add an optional metadata fallback hook to `internal/beads.BdStore`
- use that fallback in `SetMetadata` and `SetMetadataBatch` when the CLI error clearly matches the import-loop / empty-db wedge path
- wire the fallback into `bdStoreForCity` and `bdStoreForRig` using the already-resolved Dolt environment and scope metadata database

## Tests

Added regression coverage for:
- `BdStore.SetMetadata` using the fallback on import-loop errors
- `BdStore.SetMetadataBatch` using the fallback on import-loop errors
- GC wiring of the fallback with a managed-local Dolt port and metadata database

## Notes for Reviewers

This PR is intentionally limited to metadata writes. It does not add create/close fallback behavior.
