### PR TITLE
Add pool-label fallback to default work query

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1831,7 +1831,8 @@ type Agent struct {
 	// If unset, Gas City uses a three-tier default query:
 	//   1. in_progress work assigned to this session/alias (crash recovery)
 	//   2. ready work assigned to this session/alias (pre-assigned work)
-	//   3. ready unassigned work with gc.routed_to=<qualified-name>
+	//   3. ready unassigned work with gc.routed_to=<qualified-name>, with a
+	//      fallback to pool:<qualified-name> labels for manually labeled work
 	// When the controller probes for demand without session context, only the
 	// routed_to tier applies. Override to integrate with external task systems.
 	WorkQuery string `toml:"work_query,omitempty"`
@@ -2188,6 +2189,9 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
 			` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			`r=$(bd ready --label pool:` + target +
+			` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`printf "[]"'`
 	}
 	return `sh -c '` +
@@ -2221,6 +2225,9 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`*) exit 0 ;; ` +
 		`esac; ` +
 		`r=$(bd ready --metadata-field gc.routed_to=` + target +
+		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`r=$(bd ready --label pool:` + target +
 		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`bd ready --metadata-field gc.routed_to=` + legacyTarget +

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1455,6 +1455,9 @@ func TestEffectiveWorkQueryDefault(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=mayor --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
+	if !strings.Contains(got, "bd ready --label pool:mayor --unassigned --exclude-type=epic --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback: %q", got)
+	}
 	if !strings.Contains(got, `"$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"`) {
 		t.Errorf("EffectiveWorkQuery() missing multi-identifier resolution: %q", got)
 	}
@@ -1475,6 +1478,9 @@ func TestEffectiveWorkQueryWithDir(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/polecat --unassigned --exclude-type=epic --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback: %q", got)
+	}
 }
 
 func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
@@ -1482,6 +1488,9 @@ func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 	got := a.EffectiveWorkQuery()
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/polecat --unassigned --exclude-type=epic --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback: %q", got)
 	}
 	if strings.Contains(got, "--type=molecule") {
 		t.Errorf("EffectiveWorkQuery() should not route molecule containers: %q", got)
@@ -1536,6 +1545,9 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to with pool name: %q", got)
 	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/dog --unassigned --exclude-type=epic --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback with pool name: %q", got)
+	}
 	if strings.Contains(got, "--type=molecule") {
 		t.Errorf("EffectiveWorkQuery() should not route molecule containers with pool name: %q", got)
 	}
@@ -1546,6 +1558,9 @@ func TestEffectiveWorkQueryPoolNoPoolName(t *testing.T) {
 	got := a.EffectiveWorkQuery()
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+	}
+	if !strings.Contains(got, "bd ready --label pool:hello-world/dog --unassigned --exclude-type=epic --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3.5 label fallback: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

This adds a `pool:<target>` label fallback to the default `work_query` for routed work.

## Problem

The default `work_query` only looks for unassigned work routed via `gc.routed_to=<target>` metadata.

That misses work that was routed by label instead, for example via:

```sh
bd update <id> --add-label pool:<target>
```

In that case the target session can stay idle even though the bead was intentionally routed to its pool.

## Fix

- keep the existing metadata-based routed-work query
- add a fallback query for unassigned beads labeled `pool:<target>`
- apply the fallback to both the normal and legacy workflow-control default query shapes

## Tests

Added regression coverage for the default `EffectiveWorkQuery` output for:
- unscoped agents
- rig-scoped agents
- pooled agents
- pool-name override cases

## Notes for Reviewers

This is limited to the generated default `work_query`. It does not change custom `work_query` behavior.
