### PR TITLE
Route molecule roots in formula sling paths

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -246,7 +246,25 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 		}
 		result.WispRootID = wispRootID
 		result.FormulaName = opts.OnFormula
-		return finalize(opts, deps, beadID, method, result)
+		sr, err := finalize(opts, deps, beadID, method, result)
+		if err != nil {
+			return sr, err
+		}
+		if wispRootID != "" && deps.Router != nil {
+			rigDir := SlingDirForBead(deps.Cfg, deps.CityPath, wispRootID)
+			slingEnv := ResolveSlingEnv(a, deps, wispRootID)
+			req := RouteRequest{
+				BeadID:  wispRootID,
+				Target:  a.QualifiedName(),
+				WorkDir: rigDir,
+				Env:     slingEnv,
+			}
+			if routeErr := deps.Router.Route(context.Background(), req); routeErr != nil {
+				sr.MetadataErrors = append(sr.MetadataErrors,
+					fmt.Sprintf("routing molecule %s: %v", wispRootID, routeErr))
+			}
+		}
+		return sr, nil
 	}
 	runGraph := func() (pendingSourceWorkflowLaunch, error) {
 		mResult, err := InstantiateSlingFormula(context.Background(), opts.OnFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
@@ -310,7 +328,25 @@ func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 		}
 		result.WispRootID = wispRootID
 		result.FormulaName = defaultFormula
-		return finalize(opts, deps, beadID, method, result)
+		sr, err := finalize(opts, deps, beadID, method, result)
+		if err != nil {
+			return sr, err
+		}
+		if wispRootID != "" && deps.Router != nil {
+			rigDir := SlingDirForBead(deps.Cfg, deps.CityPath, wispRootID)
+			slingEnv := ResolveSlingEnv(a, deps, wispRootID)
+			req := RouteRequest{
+				BeadID:  wispRootID,
+				Target:  a.QualifiedName(),
+				WorkDir: rigDir,
+				Env:     slingEnv,
+			}
+			if routeErr := deps.Router.Route(context.Background(), req); routeErr != nil {
+				sr.MetadataErrors = append(sr.MetadataErrors,
+					fmt.Sprintf("routing molecule %s: %v", wispRootID, routeErr))
+			}
+		}
+		return sr, nil
 	}
 	runGraph := func() (pendingSourceWorkflowLaunch, error) {
 		mResult, err := InstantiateSlingFormula(context.Background(), defaultFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -1404,6 +1404,64 @@ func TestSlingRouteBeadWithTypedRouter(t *testing.T) {
 	}
 }
 
+func TestSlingAttachFormulaRoutesMoleculeRootWithTypedRouter(t *testing.T) {
+	router := &fakeBeadRouter{}
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.Router = router
+	b, _ := deps.Store.Create(beads.Bead{Title: "work", Type: "task"})
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+	result, err := s.AttachFormula(context.Background(), "code-review", b.ID, a, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+
+	if len(router.routed) != 2 {
+		t.Fatalf("got %d route calls, want 2", len(router.routed))
+	}
+	if router.routed[0].BeadID != b.ID {
+		t.Fatalf("first routed BeadID = %q, want %q", router.routed[0].BeadID, b.ID)
+	}
+	if router.routed[1].BeadID != result.WispRootID {
+		t.Fatalf("second routed BeadID = %q, want molecule root %q", router.routed[1].BeadID, result.WispRootID)
+	}
+}
+
+func TestSlingRouteBeadDefaultFormulaRoutesMoleculeRootWithTypedRouter(t *testing.T) {
+	router := &fakeBeadRouter{}
+	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.Router = router
+	deps.Store = seededStore("BL-42")
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := config.Agent{Name: "mayor", DefaultSlingFormula: stringPtr("code-review"), MaxActiveSessions: intPtr(1)}
+	result, err := s.RouteBead(context.Background(), "BL-42", a, RouteOpts{})
+	if err != nil {
+		t.Fatalf("RouteBead: %v", err)
+	}
+
+	if len(router.routed) != 2 {
+		t.Fatalf("got %d route calls, want 2", len(router.routed))
+	}
+	if router.routed[0].BeadID != "BL-42" {
+		t.Fatalf("first routed BeadID = %q, want BL-42", router.routed[0].BeadID)
+	}
+	if router.routed[1].BeadID != result.WispRootID {
+		t.Fatalf("second routed BeadID = %q, want molecule root %q", router.routed[1].BeadID, result.WispRootID)
+	}
+}
+
 // --- Missing coverage tests ---
 
 func TestSlingAttachFormula(t *testing.T) {


### PR DESCRIPTION
## Summary

This routes the created molecule root as well as the source bead when sling attaches a formula.

## Problem

Formula sling paths currently route the source bead but leave the created molecule root without `gc.routed_to` metadata.

That means workers that discover work via routed molecule roots can miss the newly created formula attachment even though the source bead was routed correctly.

## Fix

- keep the normal finalize path for the source bead
- after a successful non-graph formula attachment, route the created molecule root through the typed router too
- apply the same behavior to both explicit `AttachFormula(..., onFormula)` and `RouteBead` via `DefaultSlingFormula`

## Tests

Added regression coverage for:
- `AttachFormula` with a typed router
- `RouteBead` using `DefaultSlingFormula` with a typed router

Both now assert that two route calls occur: the source bead and the created molecule root.

## Notes for Reviewers

This is intentionally limited to the non-graph formula sling paths. Graph workflow launch behavior is unchanged.
