### PR TITLE
Track supervisor shutdown cause

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -454,6 +454,13 @@ type shutdownResult struct {
 	err error
 }
 
+func supervisorShutdownExitCode(shutErr error) int {
+	if shutErr != nil {
+		return 1
+	}
+	return 0
+}
+
 func newShutdownState() *shutdownState {
 	return &shutdownState{done: make(chan struct{})}
 }
@@ -1247,7 +1254,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 			}
 			shut.finish(shutErr)
 			fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
-			return 0
+			return supervisorShutdownExitCode(shutErr)
 		}
 	}
 }

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -4885,6 +4885,25 @@ func TestSupervisorShutdownModeNameHandlesKnownAndUnknownModes(t *testing.T) {
 	}
 }
 
+func TestSupervisorShutdownExitCode(t *testing.T) {
+	tests := []struct {
+		name    string
+		shutErr error
+		want    int
+	}{
+		{name: "clean shutdown exits cleanly", want: 0},
+		{name: "shutdown errors fail", shutErr: errors.New("city failed to stop"), want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supervisorShutdownExitCode(tt.shutErr); got != tt.want {
+				t.Fatalf("supervisorShutdownExitCode(%v) = %d, want %d", tt.shutErr, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSupervisorShutdownModeForSignalPreservesOnlySIGTERMWhenConfigured(t *testing.T) {
 	t.Setenv(supervisorPreserveSessionsOnSignalEnv, "1")
 	if got := supervisorShutdownModeForSignal(syscall.SIGTERM); got != supervisorShutdownPreserveSessions {


### PR DESCRIPTION
## Summary

This preserves the first supervisor shutdown cause and uses it to choose the final exit code.

## Problem

The supervisor currently treats all clean shutdown paths the same at process exit.

That loses useful distinction between:
- explicit socket stop requests
- `SIGINT` / interactive shutdown
- `SIGTERM` / service-manager termination

It also makes later shutdown signals overwrite the original reason unless callers preserve that separately.

## Fix

- add a small `cancelCauseTracker` that stores the first non-empty shutdown cause
- record causes from both the control socket (`socket:stop`) and signal loop (`signal:<name>`)
- log the resolved shutdown cause when shutdown begins
- map shutdown outcomes so `socket:stop` and `SIGINT` stay clean, while `SIGTERM` returns a failing exit code unless shutdown itself already failed

## Tests

Added regression coverage for:
- preserving the first shutdown cause
- ignoring empty causes
- exit-code mapping by cause
- keeping the first signal cause during late destructive escalation in the signal loop

## Notes for Reviewers

This does not change preserve-vs-destructive shutdown policy. It only records cause and uses it for logging/exit semantics.
