### PR TITLE
Protect fresh pool beads after startup

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -160,6 +160,12 @@ var (
 
 const cityRuntimeReloadLifecycleRetryLimit = 2
 
+// postCreateProtectionTimeout protects freshly-started pool beads from the
+// first steady-state sweep even after wake bookkeeping metadata lands.
+// It is intentionally longer than staleCreatingStateTimeout because startup
+// plus the first patrol can legitimately exceed one minute.
+const postCreateProtectionTimeout = 2 * time.Minute
+
 // newCityRuntime creates a CityRuntime, building internal components
 // (crash tracker, idle tracker, wisp GC, order dispatcher) from the
 // provided parameters.
@@ -1697,11 +1703,13 @@ func sweepUndesiredPoolSessionBeads(
 		// the state transition by CommitStartedPatch / ConfirmStartedPatch
 		// and restamped by recoverRunningPendingCreate on heal. A bead
 		// is protected while creation_complete_at is recent (within
-		// staleCreatingStateTimeout) AND last_woke_at is still empty —
-		// crash/churn paths do not touch creation_complete_at, so a
-		// post-crash bead whose last successful start was longer than
-		// the timeout ago is sweepable even when wake_attempts or
-		// churn_count are non-zero. The age bound mirrors
+		// postCreateProtectionTimeout). The guard intentionally ignores
+		// last_woke_at: wake bookkeeping can land before the first steady-state
+		// patrol, and a just-started bead must not become sweepable simply
+		// because that field was already populated. crash/churn paths do not
+		// touch creation_complete_at, so a post-crash bead whose last
+		// successful start was longer than the timeout ago is sweepable even
+		// when wake_attempts or churn_count are non-zero. The age bound mirrors
 		// staleCreatingState: a missing or zero creation_complete_at is
 		// treated as stale (sweepable) so beads without the per-start
 		// marker (older builds, manually repaired) stay recoverable.
@@ -1716,10 +1724,9 @@ func sweepUndesiredPoolSessionBeads(
 		// binds within a single binary (writers and sweep are the same
 		// process); the rollout needs no cross-version coordination.
 		if state := strings.TrimSpace(bead.Metadata["state"]); (state == "active" || state == "awake") &&
-			strings.TrimSpace(bead.Metadata["last_woke_at"]) == "" &&
 			strings.TrimSpace(bead.Metadata["state_reason"]) == "creation_complete" {
 			if creationCompleteAt, ok := parseRFC3339Metadata(bead.Metadata["creation_complete_at"]); ok &&
-				time.Since(creationCompleteAt) < staleCreatingStateTimeout {
+				time.Since(creationCompleteAt) < postCreateProtectionTimeout {
 				continue
 			}
 		}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1323,8 +1323,8 @@ func TestSweepUndesiredPoolSessionBeads_SweepsStaleCreatingState(t *testing.T) {
 	}
 }
 
-// Stale post-creating beads (state=active, last_woke_at="",
-// creation_complete_at older than staleCreatingStateTimeout) MUST be
+// Stale post-creating beads (state=active,
+// creation_complete_at older than postCreateProtectionTimeout) MUST be
 // sweepable. Without this, the grace window would never expire.
 func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *testing.T) {
 	store := beads.NewMemStore()
@@ -1340,7 +1340,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *test
 			poolManagedMetadataKey: boolMetadata(true),
 			"state":                "active",
 			"state_reason":         "creation_complete",
-			"creation_complete_at": time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
+			"creation_complete_at": time.Now().Add(-3 * time.Minute).UTC().Format(time.RFC3339),
 			"continuation_epoch":   "1",
 			"generation":           "1",
 		},
@@ -1360,7 +1360,46 @@ func TestSweepUndesiredPoolSessionBeads_SweepsLongStuckActiveWithoutWake(t *test
 		false,
 	)
 	if closed != 1 {
-		t.Fatalf("closed = %d, want 1 — bead beyond staleCreatingStateTimeout must be sweepable", closed)
+		t.Fatalf("closed = %d, want 1 — bead beyond postCreateProtectionTimeout must be sweepable", closed)
+	}
+}
+
+func TestSweepUndesiredPoolSessionBeads_SkipsRecentCreationCompleteAfterWakeRecorded(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-recent-awake",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "awake",
+			"state_reason":         "creation_complete",
+			"creation_complete_at": time.Now().Add(-70 * time.Second).UTC().Format(time.RFC3339),
+			"last_woke_at":         time.Now().Add(-80 * time.Second).UTC().Format(time.RFC3339),
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		nil,
+		sessionBeads,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — bead within postCreateProtectionTimeout must survive even after wake bookkeeping lands", closed)
 	}
 }
 


### PR DESCRIPTION
## Summary

This keeps freshly-started pool session beads from being reaped immediately after startup just because wake bookkeeping has already been recorded.

## Problem

The post-start sweep currently protects recent `creation_complete_at` beads only while `last_woke_at` is still empty.

In practice that is too narrow:
- wake bookkeeping can land before the first steady-state patrol
- startup plus the first patrol can exceed the one-minute stale-creating timeout

That lets a just-started bead get swept as undesired even though it is still in its intended post-create grace window.

## Fix

- add a dedicated `postCreateProtectionTimeout` that is longer than `staleCreatingStateTimeout`
- make the post-create sweep guard depend on recent `creation_complete_at` plus `state_reason=creation_complete`
- stop requiring `last_woke_at` to remain empty for the guard to apply

## Tests

Added/updated regression coverage for:
- sweeping genuinely stale post-create beads beyond the protection window
- preserving recently created beads even after `last_woke_at` has been recorded

## Notes for Reviewers

This does not loosen stale-creating cleanup generally. It only widens the narrow post-start protection window used by the first steady-state sweep.
