### PR TITLE
fix(status): restore rc=1 contract on degraded session snapshot (closes #2147)

### DIFF
--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -271,6 +271,11 @@ func doCityStatusWithStoreAndSnapshot(
 	snapshot := collectCityStatusSnapshotFromStoreSnapshot(sp, cfg, cityPath, store, statusSnapshot, stderr)
 	renderCityStatusText(snapshot, dops, stdout)
 
+	// Track session-snapshot degradation so we can render the textual report
+	// AND signal the failure via exit code. Restores the pre-#2005 contract
+	// that monitoring callers rely on (see #2147).
+	snapshotDegraded := statusSnapshot.LoadError() != nil
+
 	if store != nil {
 		sessions, err := collectCitySessionCounts(cityPath, store, sp, cfg, statusSnapshot)
 		if err != nil {
@@ -283,6 +288,9 @@ func doCityStatusWithStoreAndSnapshot(
 		}
 	}
 
+	if snapshotDegraded {
+		return 1
+	}
 	return 0
 }
 
@@ -310,6 +318,10 @@ func doCityStatusJSONWithStoreAndSnapshot(
 	stdout, stderr io.Writer,
 ) int {
 	snapshot := collectCityStatusSnapshotFromStoreSnapshot(sp, cfg, cityPath, store, statusSnapshot, stderr)
+	// Track session-snapshot degradation so we can emit the JSON payload AND
+	// signal the failure via exit code. Restores the pre-#2005 contract that
+	// monitoring callers rely on (see #2147).
+	snapshotDegraded := statusSnapshot.LoadError() != nil
 	if store != nil {
 		sessions, err := collectCitySessionCounts(cityPath, store, sp, cfg, statusSnapshot)
 		if err != nil {
@@ -327,6 +339,9 @@ func doCityStatusJSONWithStoreAndSnapshot(
 		return 1
 	}
 	fmt.Fprintln(stdout, string(data)) //nolint:errcheck // best-effort stdout
+	if snapshotDegraded {
+		return 1
+	}
 	return 0
 }
 

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -464,6 +464,39 @@ func TestCityStatusJSONReportsCatalogListError(t *testing.T) {
 	}
 }
 
+func TestCityStatusReportsCatalogListError(t *testing.T) {
+	sp := runtime.NewFake()
+	dops := newFakeDrainOps()
+	oldOpen := openCityStoreAtForStatus
+	openCityStoreAtForStatus = func(string) (beads.Store, error) {
+		return &listErrorStore{Store: beads.NewMemStore()}, nil
+	}
+	t.Cleanup(func() { openCityStoreAtForStatus = oldOpen })
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{
+			{Name: "status-checker", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.beads): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doCityStatus(sp, dops, cfg, cityPath, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 (degraded session snapshot); stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "gc status: loading session snapshot") || !strings.Contains(stderr.String(), "catalog unavailable") {
+		t.Fatalf("stderr = %q, want session snapshot warning", stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Agents:") || !strings.Contains(out, "status-checker") {
+		t.Fatalf("stdout = %q, want partial text status report", out)
+	}
+}
+
 func TestCityStatusSkipsStoreOpenWhenNoPersistedStoreExists(t *testing.T) {
 	sp := runtime.NewFake()
 	dops := newFakeDrainOps()

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -427,7 +427,13 @@ func TestCityStatusJSONReportsStoreOpenError(t *testing.T) {
 	}
 }
 
-func TestCityStatusJSONContinuesAfterSessionSnapshotListError(t *testing.T) {
+// TestCityStatusJSONReportsCatalogListError asserts the pre-#2005 contract:
+// when the bead store fails to list session beads, `gc status --json` still
+// emits the JSON payload (so callers can parse partial status) but exits
+// rc=1 so monitoring scripts using `$?` can detect the degraded state. See
+// #2147 for the regression history — PR #2005 inadvertently flipped this
+// from rc=1 to rc=0 along with renaming the test.
+func TestCityStatusJSONReportsCatalogListError(t *testing.T) {
 	sp := runtime.NewFake()
 	oldOpen := openCityStoreAtForStatus
 	openCityStoreAtForStatus = func(string) (beads.Store, error) {
@@ -444,12 +450,14 @@ func TestCityStatusJSONContinuesAfterSessionSnapshotListError(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := doCityStatusJSON(sp, cfg, cityPath, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("code = %d, want 0; stderr=%s", code, stderr.String())
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 (degraded session snapshot); stderr=%s", code, stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "gc status: loading session snapshot") || !strings.Contains(stderr.String(), "catalog unavailable") {
 		t.Fatalf("stderr = %q, want session snapshot warning", stderr.String())
 	}
+	// JSON payload must still be emitted so callers can parse the partial
+	// status — only the exit code signals the degraded state.
 	var status StatusJSON
 	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
 		t.Fatalf("unmarshal: %v; output: %s", err, stdout.String())


### PR DESCRIPTION
## Summary

Closes #2147. PR #2005 (*Fix broad gc command and hook hangs under large bead sets*) moved the session-bead `List` from the synchronous citystatus path into an async pre-load goroutine, but the error from that pre-load was no longer plumbed into the exit code. The same failure that previously exited \`rc=1\` with \`"building session catalog"\` on stderr started exiting \`rc=0\` with \`"loading session snapshot"\` on stderr — **silently breaking monitoring scripts, CI gates, and doctor wrappers that key on \`$?\`**. The PR also renamed the regression test and flipped its assertion from \`code != 1\` to \`code == 0\` without flagging the contract change.

## Fix

Plumb \`snapshot.LoadError()\` back into both citystatus exit paths:

- \`doCityStatusJSONWithStoreAndSnapshot\`: emit the JSON payload (so callers can still parse partial status), then return \`1\` if the snapshot was degraded.
- \`doCityStatusWithStoreAndSnapshot\`: render the textual report, then return \`1\` if the snapshot was degraded. Same rationale.

The pre-#2005 contract is restored: callers can both parse the JSON output AND detect the degraded state via exit code. Picked option (1) from the issue's fix candidates as the smallest, most-monitoring-friendly path.

## Test plan

- [x] Rename regression test back to \`TestCityStatusJSONReportsCatalogListError\` (pre-#2005 name) and restore \`code != 0\` assertion; still asserts the JSON payload is emitted on stderr-degraded path.
- [x] All 19 \`TestCityStatus*\` tests pass (\`go test ./cmd/gc/ -run TestCityStatus -count=1 -v\`).
- [x] Sibling \`TestCityStatusNamedSessionSurfacesLookupErrorWhenSnapshotDegraded\` (added for #2148) still passes — it exercises a different \`LoadError\` consumer (\`namedSessionStatusForCity\`) and is unaffected.
- [x] \`go vet ./cmd/gc/\` clean, \`gofumpt -l\` clean.
- [ ] CI runs the full gates.

## Surface

- \`cmd/gc/cmd_citystatus.go\` (both \`doCityStatus*WithStoreAndSnapshot\` paths)
- \`cmd/gc/cmd_citystatus_test.go\` (regression test rename + assertion restore)

## Related

- #2005 — the PR that introduced the regression
- #2148 — sibling regression from the same refactor (named-session lookup error visibility), already fixed via #2151
- \`ga-q42\` — pre-commit \`make test\` failures; committed with \`--no-verify\` per its documented workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)