### PR TITLE
fix(tmux,test): guard degraded tmux sockets and widen supervisor fast-failure budget

### DIFF
--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -314,7 +314,18 @@ func TestRegisterCityWithSupervisorFailsFastWhenSupervisorStopsDuringWait(t *tes
 	if waitStarted.IsZero() {
 		t.Fatal("supervisor wait path was not reached")
 	}
-	if elapsed := time.Since(waitStarted); elapsed > 250*time.Millisecond {
+	// The fast-failure budget is intentionally generous (well under the test's
+	// 5s startup_timeout but well above the wait-loop's logical exit time).
+	// waitStarted is captured inside the first alive-hook callback, so the
+	// elapsed window measures everything from that point onward: the
+	// remaining ensureLegacyNamedPacksCached / MaterializeBuiltinPacks work,
+	// the wait-loop's first iteration, the error formatting, the
+	// keepRegisteredCity stderr writes, and the assertion itself. Under CPU
+	// contention or a GC pause these can balloon to several hundred ms on
+	// CI hosts (ga-q42 flake observations: up to 715ms). 2s preserves the
+	// "fails fast vs. polls until 5s startup_timeout" regression guard while
+	// no longer flaking on slow hosts.
+	if elapsed := time.Since(waitStarted); elapsed > 2*time.Second {
 		t.Fatalf("registerCityWithSupervisor took %v, want fast failure when supervisor stops", elapsed)
 	}
 	if !strings.Contains(stderr.String(), "keeping registration") {

--- a/internal/runtime/tmux/server_probe_test.go
+++ b/internal/runtime/tmux/server_probe_test.go
@@ -1,0 +1,211 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// probeAssertSet returns a fakeExecutor pre-loaded with one entry per
+// scripted tmux call. Indexes into outs/errs advance per call. The first
+// entry covers the has-session probe; subsequent entries cover the
+// new-session and best-effort set-option calls.
+func probeAssertSet(outs []string, errs []error) *fakeExecutor {
+	return &fakeExecutor{outs: outs, errs: errs}
+}
+
+// firstArgsContainHasSession returns true if any element of args contains
+// the probe's has-session verb. Used to disambiguate the probe call from
+// new-session calls when checking recorded executor invocations.
+func firstArgsContainHasSession(args []string) bool {
+	for _, a := range args {
+		if a == "has-session" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewSessionSkipsProbeWhenSocketEmpty(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := NewTmux()
+	tm.exec = fe
+
+	if err := tm.NewSession("gc-no-socket", ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if len(fe.calls) == 0 {
+		t.Fatal("expected at least one tmux call")
+	}
+	if firstArgsContainHasSession(fe.calls[0]) {
+		t.Fatalf("probe ran with empty SocketName: %v", fe.calls[0])
+	}
+}
+
+func TestNewSessionProbesBeforeCreatingWhenSocketSet(t *testing.T) {
+	fe := probeAssertSet(
+		[]string{"", "", ""},
+		[]error{ErrSessionNotFound, nil, nil},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	if err := tm.NewSession("gc-probe-ok", ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if len(fe.calls) < 2 {
+		t.Fatalf("expected probe + new-session, got %d calls: %v", len(fe.calls), fe.calls)
+	}
+	probe := fe.calls[0]
+	want := []string{"-u", "-L", "gc-test", "has-session", "-t", "=" + probeSessionName}
+	if len(probe) != len(want) {
+		t.Fatalf("probe args = %v, want %v", probe, want)
+	}
+	for i := range want {
+		if probe[i] != want[i] {
+			t.Errorf("probe arg %d = %q, want %q", i, probe[i], want[i])
+		}
+	}
+	create := fe.calls[1]
+	if create[3] != "new-session" {
+		t.Fatalf("second call should be new-session, got %v", create)
+	}
+}
+
+func TestNewSessionProceedsWhenProbeReportsNoServer(t *testing.T) {
+	fe := probeAssertSet(
+		[]string{"", "", ""},
+		[]error{ErrNoServer, nil, nil},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	if err := tm.NewSession("gc-fresh", ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if len(fe.calls) < 2 {
+		t.Fatalf("expected new-session to follow probe, got %d calls: %v", len(fe.calls), fe.calls)
+	}
+	if fe.calls[1][3] != "new-session" {
+		t.Fatalf("expected new-session after no-server probe, got %v", fe.calls[1])
+	}
+}
+
+func TestNewSessionBailsWhenProbeReportsDegradedServer(t *testing.T) {
+	degraded := errors.New("tmux has-session: connection refused")
+	fe := probeAssertSet(
+		[]string{""},
+		[]error{degraded},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	err := tm.NewSession("gc-bail", "")
+	if err == nil {
+		t.Fatal("NewSession returned nil, want ErrServerDegraded")
+	}
+	if !errors.Is(err, ErrServerDegraded) {
+		t.Fatalf("err = %v, want ErrServerDegraded", err)
+	}
+	if !strings.Contains(err.Error(), "gc-test") {
+		t.Errorf("err = %q, want error mentioning socket name gc-test", err.Error())
+	}
+	if len(fe.calls) != 1 {
+		t.Fatalf("expected only probe call, got %d: %v", len(fe.calls), fe.calls)
+	}
+}
+
+func TestNewSessionWithCommandBailsWhenProbeDegraded(t *testing.T) {
+	fe := probeAssertSet(
+		[]string{""},
+		[]error{errors.New("tmux: lost server")},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	err := tm.NewSessionWithCommand("gc-cmd-bail", "", "claude")
+	if !errors.Is(err, ErrServerDegraded) {
+		t.Fatalf("err = %v, want ErrServerDegraded", err)
+	}
+	if len(fe.calls) != 1 {
+		t.Fatalf("expected only probe call, got %d: %v", len(fe.calls), fe.calls)
+	}
+}
+
+func TestNewSessionWithCommandAndEnvBailsWhenProbeDegraded(t *testing.T) {
+	fe := probeAssertSet(
+		[]string{""},
+		[]error{errors.New("tmux: unknown failure")},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	err := tm.NewSessionWithCommandAndEnv("gc-env-bail", "", "claude", map[string]string{"X": "1"})
+	if !errors.Is(err, ErrServerDegraded) {
+		t.Fatalf("err = %v, want ErrServerDegraded", err)
+	}
+	if len(fe.calls) != 1 {
+		t.Fatalf("expected only probe call, got %d: %v", len(fe.calls), fe.calls)
+	}
+}
+
+func TestProbeServerAliveAcceptsHealthyServer(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "ErrSessionNotFound", err: ErrSessionNotFound},
+		{name: "ErrNoServer", err: ErrNoServer},
+		{name: "nil", err: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fe := &fakeExecutor{err: tc.err}
+			tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+			if err := tm.probeServerAlive(); err != nil {
+				t.Fatalf("probeServerAlive(%s) = %v, want nil", tc.name, err)
+			}
+		})
+	}
+}
+
+// slowExecutor blocks each execute call until the supplied context is
+// canceled, then returns ctx.Err(). Used to verify the probe respects its
+// short timeout and does not inherit the 30s tmuxSubprocessTimeout cap.
+type slowExecutor struct {
+	calls [][]string
+}
+
+func (s *slowExecutor) execute(args []string) (string, error) {
+	cp := make([]string, len(args))
+	copy(cp, args)
+	s.calls = append(s.calls, cp)
+	time.Sleep(10 * time.Second)
+	return "", fmt.Errorf("slowExecutor: not invoked via executeCtx")
+}
+
+func (s *slowExecutor) executeCtx(ctx context.Context, args []string) (string, error) {
+	cp := make([]string, len(args))
+	copy(cp, args)
+	s.calls = append(s.calls, cp)
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+func TestProbeServerAliveBailsFastOnHang(t *testing.T) {
+	prev := newSessionProbeTimeout
+	newSessionProbeTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { newSessionProbeTimeout = prev })
+
+	se := &slowExecutor{}
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: se}
+
+	start := time.Now()
+	err := tm.probeServerAlive()
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrServerDegraded) {
+		t.Fatalf("err = %v, want ErrServerDegraded", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("probe took %s, want < 2s (timeout should be ~100ms)", elapsed)
+	}
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -123,6 +123,14 @@ var (
 	ErrSessionNotFound    = errors.New("session not found")
 	ErrInvalidSessionName = errors.New("invalid session name")
 	ErrIdleTimeout        = errors.New("agent not idle before timeout")
+	// ErrServerDegraded indicates the tmux server bound to SocketName is
+	// reachable on the filesystem but unresponsive. Creating a new session
+	// in this state would let tmux's own (very short) liveness probe time
+	// out and fall through to unlink+bind, spawning a parallel server on
+	// the same socket path and orphaning every existing session on the
+	// original server. Callers should surface this to the user instead of
+	// proceeding — see issue ga-h9z.
+	ErrServerDegraded = errors.New("tmux server degraded: refusing new-session to avoid socket clobber")
 )
 
 const (
@@ -136,6 +144,19 @@ const (
 // against wedged tmux servers and FD/inode-exhausted hosts where fork()
 // blocks. Test-overridable; production value is 30s.
 var tmuxSubprocessTimeout = 30 * time.Second
+
+// newSessionProbeTimeout bounds the pre-flight has-session probe used by
+// NewSession variants to detect a degraded server before tmux's own short
+// liveness check fires. Must be short enough that a wedged server fails fast
+// and BAILs (preventing socket clobber per ga-h9z), but long enough that a
+// healthy-but-slow server still responds. Test-overridable.
+var newSessionProbeTimeout = 2 * time.Second
+
+// probeSessionName is the bogus target used by probeServerAlive's has-session
+// call. A healthy server replies "session not found"; a dead server replies
+// "no server running" / "error connecting to"; a degraded server hangs or
+// returns something else. The name is deliberately unrouteable.
+const probeSessionName = "__gascity_probe__"
 
 // validateSessionName checks that a session name contains only safe characters.
 // Returns ErrInvalidSessionName if the name contains dots, colons, or other
@@ -264,9 +285,55 @@ func wrapError(err error, stderr string, args []string) error {
 	return fmt.Errorf("tmux %s: %w", args[0], err)
 }
 
+// probeServerAlive verifies the tmux server bound to SocketName is responsive
+// before invoking new-session. This prevents the socket-clobber failure
+// described in ga-h9z: when tmux is asked to create a session against a
+// socket whose server is alive-but-slow, tmux's internal liveness probe can
+// time out and tmux falls through to unlink+bind, spawning a parallel server
+// on the same path and orphaning every session on the original.
+//
+// Returns:
+//   - nil when SocketName is empty (default-server case is out of scope) or
+//     when the server replies (alive — including the expected "session not
+//     found" for the bogus probe target).
+//   - nil with ErrNoServer semantics absorbed (no server bound is safe; tmux
+//     will create a fresh server cleanly).
+//   - ErrServerDegraded when the probe times out or returns any other error,
+//     indicating the server is in a state where new-session would risk
+//     clobbering. Callers MUST surface this and refuse to proceed.
+func (t *Tmux) probeServerAlive() error {
+	if t.cfg.SocketName == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), newSessionProbeTimeout)
+	defer cancel()
+	_, err := t.runCtx(ctx, "has-session", "-t", "="+probeSessionName)
+	if err == nil {
+		// Server is alive and (improbably) actually has a session with the
+		// probe name. Still safe — server responded.
+		return nil
+	}
+	if errors.Is(err, ErrSessionNotFound) {
+		// Healthy server, just doesn't have the probe session. Safe.
+		return nil
+	}
+	if errors.Is(err, ErrNoServer) {
+		// No server bound (stale socket or never existed). Safe — tmux will
+		// unlink any stale socket and bind a fresh server.
+		return nil
+	}
+	// Timeout, fork failure, or any other unrecognized error: server is in
+	// an indeterminate state. Refuse to proceed rather than let tmux silently
+	// fork into a parallel server.
+	return fmt.Errorf("%w (socket=%s): %w", ErrServerDegraded, t.cfg.SocketName, err)
+}
+
 // NewSession creates a new detached tmux session.
 func (t *Tmux) NewSession(name, workDir string) error {
 	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	if err := t.probeServerAlive(); err != nil {
 		return err
 	}
 	args := []string{"new-session", "-d", "-s", name}
@@ -291,6 +358,9 @@ func (t *Tmux) NewSession(name, workDir string) error {
 // See: https://github.com/anthropics/gastown/issues/280
 func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	if err := t.probeServerAlive(); err != nil {
 		return err
 	}
 	args := []string{"new-session", "-d", "-s", name}
@@ -320,6 +390,9 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 // Requires tmux >= 3.2.
 func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env map[string]string) error {
 	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	if err := t.probeServerAlive(); err != nil {
 		return err
 	}
 	// Disable mouse mode and monitor-activity before creating the session.


### PR DESCRIPTION
## Summary

This PR covers two independent fixes:

- Resolves `ga-h9z` by probing named tmux socket liveness before `new-session`, so Gas City refuses indeterminate/degraded socket states instead of letting tmux clobber a live server socket.
- Resolves another flake from the `ga-q42` list: `TestRegisterCityWithSupervisorFailsFastWhenSupervisorStopsDuringWait`.

## ga-h9z tmux socket guard

The tmux runtime now runs a bounded `has-session` probe before all named-socket session creation entrypoints. Healthy responses are treated as safe, missing sessions/no-server responses remain safe for normal creation, and degraded or timed-out probes return `ErrServerDegraded` instead of proceeding to `new-session`.

This keeps the default-tmux path unchanged and scopes the guard to configured named sockets.

## ga-q42 supervisor-stop flake

The supervisor-stop test asserts that `registerCityWithSupervisor` exits quickly when the supervisor dies mid-wait. The previous 250ms budget was too tight because `waitStarted` is captured inside the first `supervisorAliveHook` callback in `registerCityWithSupervisorNamed`, so the elapsed window includes everything from that hook through the wait loop's first iteration, error formatting, `keepRegisteredCity` stderr writes, and the assertion itself. Under CPU contention or a GC pause those can exceed 250ms while still representing fast-loop behavior.

## Reproducer before the test-budget fix

```
$ go test ./cmd/gc/ -run TestRegisterCityWithSupervisorFailsFastWhenSupervisorStopsDuringWait -count=200
    cmd_supervisor_city_test.go:318: registerCityWithSupervisor took 633.466018ms, want fast failure ...
    cmd_supervisor_city_test.go:318: registerCityWithSupervisor took 356.022464ms, want fast failure ...
    cmd_supervisor_city_test.go:318: registerCityWithSupervisor took 356.650993ms, want fast failure ...
    cmd_supervisor_city_test.go:318: registerCityWithSupervisor took 715.062622ms, want fast failure ...
FAIL  github.com/gastownhall/gascity/cmd/gc
```

4/200 failures locally. The actual elapsed times (356ms-715ms) all show fast-loop behavior; they were just over the artificially tight 250ms budget.

## Fix

- Add the named-socket tmux server probe and unit coverage for healthy, missing, degraded, and slow probe outcomes.
- Widen the supervisor-stop fast-failure budget to 2 seconds with an inline rationale.

The original supervisor regression guard is preserved: the "polls until the 5s `startup_timeout`" failure mode would take about 5s, well outside 2s, so the test still catches the failure mode it is meant to catch.

## Test plan

- [x] 200x sequential runs of the supervisor-stop target test, all green with the widened budget
- [x] tmux probe and `NewSession` focused tests
- [x] `go vet ./cmd/gc/` clean
- [ ] CI runs the full gates

## Scope

`ga-q42` still has a separate env-sensitive `internal/mail/exec` 600s timeout under concurrent load. That is not changed here.

## Note on hooks

Committed with `--no-verify` per the workaround documented in `ga-q42`.

Generated with Claude Code.