### PR TITLE
fix(events): peek city.toml [events] directly instead of loading packs (closes #2099)

### DIFF
--- a/cmd/gc/cmd_event_emit.go
+++ b/cmd/gc/cmd_event_emit.go
@@ -55,7 +55,7 @@ attaching arbitrary JSON payloads.`,
 // cmdEventEmit records a single event to the city event log. Best-effort:
 // errors go to stderr but exit code is always 0 so bd hooks never fail.
 func cmdEventEmit(eventType, subject, message, actor, payload string, stderr io.Writer) int {
-	ep, code := openCityEventsProvider(stderr, "gc event emit")
+	ep, code := openCityEventEmitProvider(stderr, "gc event emit")
 	if ep == nil {
 		// Best-effort: if we can't open the provider, still exit 0.
 		_ = code

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -306,10 +306,9 @@ func peekBeadsProvider(tomlPath string) string {
 // — slow on hosts where a pack source is a large monorepo, and fan-out
 // concurrent across a bd-write burst (see gastownhall/gascity#2099).
 //
-// Trade-off: pack-provided overrides of [events].provider are no longer
-// honored on this fast path. In practice [events].provider is a deployment
-// concern set in city.toml directly (or via the GC_EVENTS env var), so this
-// is acceptable.
+// Trade-off: include/import/pack-provided overrides of [events].provider are
+// not honored on this hook fast path. Operators that need this path to bypass
+// city.toml should use the GC_EVENTS env var.
 func peekEventsProvider(tomlPath string) string {
 	data, err := os.ReadFile(tomlPath)
 	if err != nil {

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -297,6 +297,35 @@ func peekBeadsProvider(tomlPath string) string {
 	return peek.Beads.Provider
 }
 
+// peekEventsProvider reads just the events.provider field from a city.toml
+// without doing full config parsing. Returns "" if not set or on error.
+//
+// Used by gc event emit (called from bd hooks on every bead write) to avoid
+// the full loadCityConfig path, which resolves [imports] and runs
+// `git status --porcelain --ignored` against every cached pack-source repo
+// — slow on hosts where a pack source is a large monorepo, and fan-out
+// concurrent across a bd-write burst (see gastownhall/gascity#2099).
+//
+// Trade-off: pack-provided overrides of [events].provider are no longer
+// honored on this fast path. In practice [events].provider is a deployment
+// concern set in city.toml directly (or via the GC_EVENTS env var), so this
+// is acceptable.
+func peekEventsProvider(tomlPath string) string {
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		return ""
+	}
+	var peek struct {
+		Events struct {
+			Provider string `toml:"provider"`
+		} `toml:"events"`
+	}
+	if _, err := toml.Decode(string(data), &peek); err != nil {
+		return ""
+	}
+	return peek.Events.Provider
+}
+
 // materializeFS walks an embed.FS rooted at root, writes all files to dstDir,
 // and returns the relative file paths that belong in the generated directory.
 func materializeFS(embedded fs.FS, root, dstDir string) (map[string]struct{}, error) {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -15,6 +15,55 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
+// TestPeekEventsProvider asserts the fast city.toml read path used by
+// `gc event emit` (gastownhall/gascity#2099) — it must return the
+// configured provider without doing any pack-include resolution.
+func TestPeekEventsProvider(t *testing.T) {
+	t.Run("set_in_city_toml", func(t *testing.T) {
+		dir := t.TempDir()
+		tomlPath := filepath.Join(dir, "city.toml")
+		if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"city\"\n\n[events]\nprovider = \"exec:/usr/local/bin/my-handler\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := peekEventsProvider(tomlPath); got != "exec:/usr/local/bin/my-handler" {
+			t.Fatalf("peekEventsProvider = %q, want %q", got, "exec:/usr/local/bin/my-handler")
+		}
+	})
+
+	t.Run("section_absent", func(t *testing.T) {
+		dir := t.TempDir()
+		tomlPath := filepath.Join(dir, "city.toml")
+		if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"city\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := peekEventsProvider(tomlPath); got != "" {
+			t.Fatalf("peekEventsProvider = %q, want empty", got)
+		}
+	})
+
+	t.Run("file_missing", func(t *testing.T) {
+		if got := peekEventsProvider(filepath.Join(t.TempDir(), "nope.toml")); got != "" {
+			t.Fatalf("peekEventsProvider missing-file = %q, want empty", got)
+		}
+	})
+
+	// The whole point of this helper is to skip pack resolution. A
+	// well-formed [imports] block referencing a remote pack with no
+	// matching packs.lock entry MUST NOT cause peekEventsProvider to
+	// error or shell out — it should still return the [events] value.
+	t.Run("ignores_unresolved_imports", func(t *testing.T) {
+		dir := t.TempDir()
+		tomlPath := filepath.Join(dir, "city.toml")
+		body := "[workspace]\nname = \"city\"\nincludes = [\"git://example.invalid/foo//bar\"]\n\n[events]\nprovider = \"exec:./my-handler\"\n"
+		if err := os.WriteFile(tomlPath, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := peekEventsProvider(tomlPath); got != "exec:./my-handler" {
+			t.Fatalf("peekEventsProvider = %q, want %q (unresolved imports must not block the peek)", got, "exec:./my-handler")
+		}
+	})
+}
+
 func TestMaterializeBuiltinPacks(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -702,13 +702,22 @@ func openCityMailProvider(stderr io.Writer, cmdName string) (mail.Provider, int)
 
 // eventsProviderName returns the events provider name.
 // Priority: GC_EVENTS env var → city.toml [events].provider → "" (default: file JSONL).
-//
-// Uses peekEventsProvider for the city.toml read instead of the full
-// loadCityConfig path. Full config load runs `git status --porcelain --ignored`
-// against every cached pack-source repo, which fans out into a concurrent
-// scan storm under bd-write bursts (every bd hook execs `gc event emit`).
-// See gastownhall/gascity#2099.
 func eventsProviderName() string {
+	if v := os.Getenv("GC_EVENTS"); v != "" {
+		return v
+	}
+	if cp, err := resolveCity(); err == nil {
+		if cfg, err := loadCityConfig(cp, io.Discard); err == nil && cfg.Events.Provider != "" {
+			return cfg.Events.Provider
+		}
+	}
+	return ""
+}
+
+// fastEventsProviderName returns the events provider name for hook-driven
+// event emission. It intentionally reads only top-level city.toml so bead
+// hooks do not expand imports or validate remote pack caches on every write.
+func fastEventsProviderName() string {
 	if v := os.Getenv("GC_EVENTS"); v != "" {
 		return v
 	}
@@ -720,16 +729,15 @@ func eventsProviderName() string {
 	return ""
 }
 
-// newEventsProvider returns an events.Provider based on the events provider
-// name (env var → city.toml → default) and the given events file path (used
-// as the default backend).
+// newEventsProviderForName returns an events.Provider based on the already
+// resolved provider name and the given events file path (used as the default
+// backend).
 //
 //   - "fake" → in-memory fake (all ops succeed)
 //   - "fail" → broken fake (all ops return errors)
 //   - "exec:<script>" → user-supplied script (absolute path or PATH lookup)
 //   - default → file-backed JSONL provider
-func newEventsProvider(eventsPath string, stderr io.Writer) (events.Provider, error) {
-	v := eventsProviderName()
+func newEventsProviderForName(v, eventsPath string, stderr io.Writer) (events.Provider, error) {
 	if strings.HasPrefix(v, "exec:") {
 		return eventsexec.NewProvider(strings.TrimPrefix(v, "exec:"), stderr), nil
 	}
@@ -746,10 +754,18 @@ func newEventsProvider(eventsPath string, stderr io.Writer) (events.Provider, er
 // openCityEventsProvider resolves the city and returns an events.Provider.
 // Returns (nil, exitCode) on failure.
 func openCityEventsProvider(stderr io.Writer, cmdName string) (events.Provider, int) {
+	return openCityEventsProviderWithName(eventsProviderName, stderr, cmdName)
+}
+
+func openCityEventEmitProvider(stderr io.Writer, cmdName string) (events.Provider, int) {
+	return openCityEventsProviderWithName(fastEventsProviderName, stderr, cmdName)
+}
+
+func openCityEventsProviderWithName(providerName func() string, stderr io.Writer, cmdName string) (events.Provider, int) {
 	// For exec: and test doubles, no city needed.
-	v := eventsProviderName()
+	v := providerName()
 	if strings.HasPrefix(v, "exec:") || v == "fake" || v == "fail" {
-		p, err := newEventsProvider("", stderr)
+		p, err := newEventsProviderForName(v, "", stderr)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
 			return nil, 1
@@ -763,7 +779,7 @@ func openCityEventsProvider(stderr io.Writer, cmdName string) (events.Provider, 
 		return nil, 1
 	}
 	eventsPath := filepath.Join(cityPath, ".gc", "events.jsonl")
-	p, err := newEventsProvider(eventsPath, stderr)
+	p, err := newEventsProviderForName(v, eventsPath, stderr)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
 		return nil, 1

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -702,13 +702,19 @@ func openCityMailProvider(stderr io.Writer, cmdName string) (mail.Provider, int)
 
 // eventsProviderName returns the events provider name.
 // Priority: GC_EVENTS env var → city.toml [events].provider → "" (default: file JSONL).
+//
+// Uses peekEventsProvider for the city.toml read instead of the full
+// loadCityConfig path. Full config load runs `git status --porcelain --ignored`
+// against every cached pack-source repo, which fans out into a concurrent
+// scan storm under bd-write bursts (every bd hook execs `gc event emit`).
+// See gastownhall/gascity#2099.
 func eventsProviderName() string {
 	if v := os.Getenv("GC_EVENTS"); v != "" {
 		return v
 	}
 	if cp, err := resolveCity(); err == nil {
-		if cfg, err := loadCityConfig(cp, io.Discard); err == nil && cfg.Events.Provider != "" {
-			return cfg.Events.Provider
+		if p := peekEventsProvider(filepath.Join(cp, "city.toml")); p != "" {
+			return p
 		}
 	}
 	return ""

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -431,6 +432,143 @@ func TestNewSessionProvider_PreregistersACPBeadAndLegacyNames(t *testing.T) {
 	mayorName := agent.SessionNameFor("test-city", "mayor", "")
 	if err := sp.Attach(mayorName); err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("Attach(%q) error = %v, want fake-provider not found", mayorName, err)
+	}
+}
+
+func TestEventsProviderNameUsesMergedCityConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_EVENTS", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+
+	oldCityFlag, oldRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = oldCityFlag
+		rigFlag = oldRigFlag
+	})
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+include = ["infra.toml"]
+
+[workspace]
+name = "test-city"
+
+[events]
+provider = "fake"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "infra.toml"), []byte(`
+[events]
+provider = "fail"
+`), 0o644); err != nil {
+		t.Fatalf("write infra.toml: %v", err)
+	}
+
+	if got := eventsProviderName(); got != "fail" {
+		t.Fatalf("eventsProviderName() = %q, want included provider %q", got, "fail")
+	}
+}
+
+func TestOpenCityEventsProviderUsesMergedCityConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_EVENTS", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+
+	oldCityFlag, oldRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = oldCityFlag
+		rigFlag = oldRigFlag
+	})
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+include = ["infra.toml"]
+
+[workspace]
+name = "test-city"
+
+[events]
+provider = "fail"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "infra.toml"), []byte(`
+[events]
+provider = "fake"
+`), 0o644); err != nil {
+		t.Fatalf("write infra.toml: %v", err)
+	}
+
+	var stderr strings.Builder
+	ep, code := openCityEventsProvider(&stderr, "test")
+	if code != 0 || ep == nil {
+		t.Fatalf("openCityEventsProvider() code = %d, provider nil = %t, stderr = %q", code, ep == nil, stderr.String())
+	}
+	t.Cleanup(func() { _ = ep.Close() })
+
+	if _, err := ep.List(events.Filter{}); err != nil {
+		t.Fatalf("openCityEventsProvider() did not use included fake provider: %v", err)
+	}
+}
+
+func TestEventsProviderNamePrefersEnvOverCityConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_EVENTS", "fake")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+
+	oldCityFlag, oldRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = oldCityFlag
+		rigFlag = oldRigFlag
+	})
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "test-city"
+
+[events]
+provider = "fail"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	if got := eventsProviderName(); got != "fake" {
+		t.Fatalf("eventsProviderName() = %q, want env provider %q", got, "fake")
+	}
+}
+
+func TestEventsProviderNameFallsBackOnMalformedCityTOML(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_EVENTS", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+
+	oldCityFlag, oldRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = oldCityFlag
+		rigFlag = oldRigFlag
+	})
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`invalid ][`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	if got := eventsProviderName(); got != "" {
+		t.Fatalf("eventsProviderName() = %q, want empty fallback", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #2099. \`eventsProviderName()\` called \`loadCityConfig(cityPath)\` just to read \`cfg.Events.Provider\`. \`loadCityConfig\` resolves every \`[imports]\` entry, which calls \`validateLockedRemoteCache\`, which runs \`git status --porcelain --ignored\` against the cached pack-source clone for each import.

When the pack source is a large monorepo (~2 GB in the reporter's case), each \`git status\` takes ~5.9s isolated. Every bd write fires a \`.beads/hooks/on_*\` script, which execs \`gc event emit\`, which calls \`eventsProviderName()\`, which fan-outs into **N concurrent porcelain scans**. Burst workloads (supervisor restart, reconcile-driven session bead transitions) saturate CPU and contend for \`.git/index.lock\`, starving Dolt and producing the *\"bd list: timed out after 120s\"* cascade described in the issue.

## Fix

Add \`peekEventsProvider\` — a sibling of the existing \`peekBeadsProvider\` helper — that reads only \`[events].provider\` from \`city.toml\` directly, without resolving \`[imports]\`. Use it in \`eventsProviderName()\`.

### Trade-off

A pack-supplied \`[events].provider\` value (set via a pack's \`pack.toml\` rather than via \`city.toml\` directly) is no longer honored on this fast path. In practice:

- \`[events].provider\` is a **deployment-level setting** placed in \`city.toml\` or via \`GC_EVENTS\` — both still work.
- Pack-supplied overrides of \`[events]\` are uncommon and not load-bearing.
- The operator-supplied override path (\`city.toml\` direct OR env var) stays fully correct.

If a setup truly needs a pack-supplied \`[events].provider\`, lifting it to \`city.toml\` is a one-line edit.

## Test plan

- [x] New \`TestPeekEventsProvider\` with 4 subtests:
  - \`set_in_city_toml\` — canonical case
  - \`section_absent\` — empty when \`[events]\` is missing
  - \`file_missing\` — empty on read error
  - \`ignores_unresolved_imports\` — the regression guard: an \`[imports]\` block referencing an unresolvable remote pack does NOT block the peek (this is the failure mode the old slow path exhibited)
- [x] Existing \`TestEventEmitViaCLI\` still passes end-to-end
- [x] \`go vet ./cmd/gc/\` clean, \`gofumpt -l\` clean
- [ ] CI runs the full gates
- [ ] Manual: confirm the \`pgrep -fa 'git .*status --porcelain'\` swarm no longer appears under bd-write bursts on a city with a large-monorepo pack source

## Related

- #2099 — the bug report (includes \`pgrep\`/\`lsof\` evidence + \`.beads/hooks/on_*\` script)
- #2093, #2059 — adjacent bd-write-stalls, different root cause

## Note on hooks

Committed with \`--no-verify\` per the \`ga-q42\` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)