### PR TITLE
Skip churn counts for pending creates

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -705,6 +705,12 @@ func checkChurn(session *beads.Bead, cfg *config.City, alive bool, dt *drainTrac
 	if alive {
 		return false
 	}
+	// Pending-create sessions have not completed startup yet. A stale create
+	// lease should trigger a retried wake, not a churn increment that blocks
+	// the retry before start execution.
+	if session != nil && strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" {
+		return false
+	}
 	// Subprocess sessions exit intentionally — not churn.
 	if cfg != nil && cfg.Session.Provider == "subprocess" {
 		return false

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1015,6 +1015,25 @@ func TestCheckStability_PendingCreateInFlightNotCounted(t *testing.T) {
 	}
 }
 
+func TestCheckStability_PendingCreateClaimNotCountedAfterStartupLeaseExpires(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":         now.Add(-90 * time.Second).Format(time.RFC3339),
+		"pending_create_claim": "true",
+		"wake_attempts":        "0",
+	})
+
+	if checkStability(&session, nil, false, dt, store, clk, nil) {
+		t.Fatal("pending_create_claim should suppress stability counting until create recovery clears the claim")
+	}
+	if got := session.Metadata["wake_attempts"]; got != "0" {
+		t.Fatalf("wake_attempts = %q, want 0", got)
+	}
+}
+
 func TestCheckStability_DrainingNotCounted(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}
@@ -2095,6 +2114,25 @@ func TestCheckChurn_RapidExitIgnored(t *testing.T) {
 
 	if checkChurn(&session, nil, false, dt, store, clk) {
 		t.Error("rapid exit should not trigger churn (handled by checkStability)")
+	}
+}
+
+func TestCheckChurn_PendingCreateClaimNotCountedAfterStartupLeaseExpires(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":         now.Add(-90 * time.Second).Format(time.RFC3339),
+		"pending_create_claim": "true",
+		"churn_count":          "0",
+	})
+
+	if checkChurn(&session, nil, false, dt, store, clk) {
+		t.Fatal("pending_create_claim should suppress churn counting until create recovery clears the claim")
+	}
+	if got := session.Metadata["churn_count"]; got != "0" {
+		t.Fatalf("churn_count = %q, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

This keeps sessions with an outstanding `pending_create_claim` off the churn path.

## Problem

A session can still carry `pending_create_claim=true` after the initial startup lease window expires.

In that state the reconciler should retry the create/wake path, but `checkChurn` can instead classify the dead session as a non-productive wake and increment `churn_count`. That makes startup recovery harder and can block retries prematurely.

## Fix

- in `checkChurn`, short-circuit when `pending_create_claim=true`
- leave the session on the pending-create recovery path until the claim is cleared explicitly

## Tests

Added regression coverage for:
- a pending-create session whose startup lease has already expired should still not increment churn
- the matching stability regression stays green alongside it

## Notes for Reviewers

This does not change how stale pending-create leases are healed. It only prevents churn accounting from firing before that recovery path finishes.
