### PR TITLE
feat(refinery): patrol lifecycle discipline + rescue order

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -254,7 +254,8 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		if isAgentEffectivelySuspended(cfg, &a) {
 			return 0
 		}
-		if resolved, rErr := config.ResolveProvider(&a, &cfg.Workspace, cfg.Providers, exec.LookPath); rErr == nil && hookMode {
+		resolved, rErr := config.ResolveProvider(&a, &cfg.Workspace, cfg.Providers, exec.LookPath)
+		if rErr == nil && hookMode {
 			sessionName := os.Getenv("GC_SESSION_NAME")
 			if sessionName == "" {
 				sessionName = cliSessionName(cityPath, cityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
@@ -272,7 +273,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		}
 		var ctx PromptContext
 		if a.PromptTemplate != "" || hookMode || sessionTemplateContext {
-			ctx = buildPrimeContext(cityPath, cityName, &a, cfg.Rigs, stderr)
+			ctx = buildPrimeContext(cityPath, cityName, &a, cfg.Rigs, resolved, cfg.Providers, stderr)
 		}
 		if a.PromptTemplate != "" {
 			fragments := effectivePromptFragments(
@@ -559,13 +560,15 @@ func findAgentByName(cfg *config.City, name string) (config.Agent, bool) {
 // buildPrimeContext constructs a PromptContext for gc prime. Uses GC_*
 // environment variables when running inside a managed session, falls back
 // to currentRigContext when run manually.
-func buildPrimeContext(cityPath, cityName string, a *config.Agent, rigs []config.Rig, stderr io.Writer) PromptContext {
+func buildPrimeContext(cityPath, cityName string, a *config.Agent, rigs []config.Rig, resolved *config.ResolvedProvider, cityProviders map[string]config.ProviderSpec, stderr io.Writer) PromptContext {
 	ctx := PromptContext{
-		CityRoot:      cityPath,
-		TemplateName:  a.Name,
-		BindingName:   a.BindingName,
-		BindingPrefix: a.BindingPrefix(),
-		Env:           a.Env,
+		CityRoot:            cityPath,
+		TemplateName:        a.Name,
+		BindingName:         a.BindingName,
+		BindingPrefix:       a.BindingPrefix(),
+		ProviderKey:         resolvedProviderLaunchFamily(resolved),
+		ProviderDisplayName: resolvedProviderDisplayName(resolved, cityProviders),
+		Env:                 a.Env,
 	}
 
 	// Agent identity: prefer GC_ALIAS, then GC_AGENT, else config.

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -20,7 +20,7 @@ func TestBuildPrimeContextFallsBackToConfiguredRigRoot(t *testing.T) {
 
 	ctx := buildPrimeContext("/city", "test-city", &config.Agent{Name: "polecat", Dir: "demo"}, []config.Rig{
 		{Name: "demo", Path: "/repos/demo", Prefix: "dm"},
-	}, nil)
+	}, nil, nil, nil)
 
 	if ctx.RigName != "demo" {
 		t.Fatalf("RigName = %q, want demo", ctx.RigName)
@@ -39,7 +39,7 @@ func TestBuildPrimeContextExpandsTemplateCommands(t *testing.T) {
 		Dir:        "demo",
 		WorkQuery:  "echo {{.CityName}} {{.Rig}} {{.AgentBase}}",
 		SlingQuery: "dispatch {} --route={{.Rig}}/{{.AgentBase}} --city={{.CityName}}",
-	}, rigs, nil)
+	}, rigs, nil, nil, nil)
 
 	if ctx.WorkQuery != "echo demo-city demo worker" {
 		t.Fatalf("WorkQuery = %q, want %q", ctx.WorkQuery, "echo demo-city demo worker")
@@ -56,7 +56,7 @@ func TestBuildPrimeContextLogsTemplateExpansionWarning(t *testing.T) {
 	ctx := buildPrimeContext(cityPath, "", &config.Agent{
 		Name:      "worker",
 		WorkQuery: "echo {{.Rig",
-	}, nil, &stderr)
+	}, nil, nil, nil, &stderr)
 
 	if ctx.WorkQuery != "echo {{.Rig" {
 		t.Fatalf("WorkQuery = %q, want raw command fallback", ctx.WorkQuery)
@@ -90,7 +90,7 @@ func TestBuildPrimeContextRendersBindingQualifiedRoute(t *testing.T) {
 		Name:        "polecat",
 		Dir:         "demo",
 		BindingName: "gastown",
-	}, []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}}, nil)
+	}, []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}}, nil, nil, nil)
 
 	if ctx.BindingName != "gastown" {
 		t.Fatalf("BindingName = %q, want gastown", ctx.BindingName)
@@ -151,7 +151,7 @@ func TestBuildPrimeContextPrefersGCAliasOverGCAgent(t *testing.T) {
 	t.Setenv("GC_DIR", "")
 	t.Setenv("GC_BRANCH", "")
 
-	ctx := buildPrimeContext("/city", "test-city", &config.Agent{Name: "mayor"}, nil, nil)
+	ctx := buildPrimeContext("/city", "test-city", &config.Agent{Name: "mayor"}, nil, nil, nil, nil)
 
 	if ctx.AgentName != "mayor" {
 		t.Errorf("AgentName = %q, want %q (should prefer GC_ALIAS over GC_AGENT)", ctx.AgentName, "mayor")
@@ -168,7 +168,7 @@ func TestBuildPrimeContextUsesAliasEvenWhenDifferentFromConfigName(t *testing.T)
 	t.Setenv("GC_DIR", "")
 	t.Setenv("GC_BRANCH", "")
 
-	ctx := buildPrimeContext("/city", "test-city", &config.Agent{Name: "mayor"}, nil, nil)
+	ctx := buildPrimeContext("/city", "test-city", &config.Agent{Name: "mayor"}, nil, nil, nil, nil)
 
 	if ctx.AgentName != "custom-alias" {
 		t.Errorf("AgentName = %q, want %q (should use GC_ALIAS even when it differs from config name)", ctx.AgentName, "custom-alias")
@@ -183,7 +183,7 @@ func TestBuildPrimeContextFallsBackToGCAgentWhenNoAlias(t *testing.T) {
 	t.Setenv("GC_DIR", "")
 	t.Setenv("GC_BRANCH", "")
 
-	ctx := buildPrimeContext("/city", "test-city", &config.Agent{Name: "mayor"}, nil, nil)
+	ctx := buildPrimeContext("/city", "test-city", &config.Agent{Name: "mayor"}, nil, nil, nil, nil)
 
 	if ctx.AgentName != "mayor" {
 		t.Errorf("AgentName = %q, want %q", ctx.AgentName, "mayor")

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -301,10 +301,15 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	}
 
 	// Guard: on a fresh add (not a re-add) without --adopt, refuse to run
-	// if .beads/ is already present. Without this, doRigAdd falls through
-	// to bd init against an existing Dolt store and typically dies with
-	// "bd init: signal: killed" after the probe times out — an unhelpful
-	// failure mode for the common "register existing store" workflow.
+	// if .beads/ already holds a beads store. Without this, doRigAdd falls
+	// through to bd init against an existing Dolt store and typically dies
+	// with "bd init: signal: killed" after the probe times out.
+	//
+	// We treat .beads/ as a store only when metadata.json or config.yaml is
+	// present. A directory that happens to be named .beads/ but contains
+	// only unrelated content (e.g. the beads project's own .beads/formulas/
+	// convention for formula source files) is not a store; bd init will
+	// add the missing files alongside without disturbing the existing ones.
 	if !reAdd && !adopt {
 		beadsPath := filepath.Join(rigPath, ".beads")
 		fi, err := fs.Stat(beadsPath)
@@ -312,9 +317,9 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", beadsPath, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		if err == nil && fi.IsDir() {
-			fmt.Fprintf(stderr, "gc rig add: %s/.beads already exists; "+ //nolint:errcheck // best-effort stderr
-				"use --adopt to register the existing store, or remove %s/.beads to reinitialize\n",
+		if err == nil && fi.IsDir() && beadsDirContainsStore(fs, beadsPath) {
+			fmt.Fprintf(stderr, "gc rig add: %s/.beads already contains a beads store; "+ //nolint:errcheck // best-effort stderr
+				"use --adopt to register it, or remove %s/.beads to reinitialize\n",
 				rigPath, rigPath)
 			return 1
 		}
@@ -1018,6 +1023,21 @@ func writeBeadsEnvGTRoot(fs fsys.FS, rigPath, cityPath string) error {
 		return fmt.Errorf("creating .beads dir: %w", err)
 	}
 	return fs.WriteFile(envPath, []byte(content), 0o644)
+}
+
+// beadsDirContainsStore reports whether beadsPath looks like an existing
+// beads store. A directory is treated as a store when it contains either
+// metadata.json or config.yaml — the two files bd init always writes.
+// Other contents (e.g. the beads project's own .beads/formulas/ convention
+// for formula source files) are not treated as a store, so gc rig add can
+// safely initialize alongside them.
+func beadsDirContainsStore(fs fsys.FS, beadsPath string) bool {
+	for _, name := range [...]string{"metadata.json", "config.yaml"} {
+		if _, err := fs.Stat(filepath.Join(beadsPath, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // readBeadsPrefix reads the issue_prefix from an existing .beads/config.yaml

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -353,8 +353,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		default:
 			if len(rootDefaultRigImports) > 0 {
 				w(fmt.Sprintf("  Import: %s (default)", formatBoundImports(rootDefaultRigImports)))
-			}
-			if len(defaultRigIncludes) > 0 {
+			} else if len(defaultRigIncludes) > 0 {
 				w(fmt.Sprintf("  Include: %s (default)", strings.Join(defaultRigIncludes, ", ")))
 			}
 		}
@@ -413,13 +412,11 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		case len(includes) > 0:
 			rig.Includes = slices.Clone(includes)
 		default:
-			if len(rootDefaultRigImports) > 0 {
-				rig.Imports = make(map[string]config.Import, len(rootDefaultRigImports))
-				for _, bound := range rootDefaultRigImports {
-					rig.Imports[bound.Binding] = bound.Import
-				}
-			}
-			if len(defaultRigIncludes) > 0 {
+			// V2: pack.toml's [defaults.rig.imports] is the single source
+			// of truth — applied to rigs at config-resolution time. Avoid
+			// duplicating them into city.toml's [rigs.imports.*], which
+			// would cause double-loading of the pack at runtime.
+			if len(rootDefaultRigImports) == 0 && len(defaultRigIncludes) > 0 {
 				rig.Includes = slices.Clone(defaultRigIncludes)
 			}
 		}

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1005,6 +1005,17 @@ source = "packs/a-pack"
 	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// Stub the referenced packs so LoadWithIncludes can resolve them.
+	for _, name := range []string{"z-pack", "a-pack"} {
+		dir := filepath.Join(cityPath, "packs", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stub := fmt.Sprintf("[pack]\nname = %q\nschema = 2\n", name)
+		if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(stub), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -1024,8 +1035,10 @@ source = "packs/a-pack"
 	if !strings.Contains(output, "Import: z-pack=packs/z-pack, a-pack=packs/a-pack (default)") {
 		t.Errorf("output missing root pack default imports in declaration order: %s", output)
 	}
-	if !strings.Contains(output, "Include: packs/city-pack (default)") {
-		t.Errorf("output missing legacy default include fallback: %s", output)
+	// pack.toml's [defaults.rig.imports] suppresses the legacy
+	// default_rig_includes fallback so we don't write redundant entries.
+	if strings.Contains(output, "Include: packs/city-pack (default)") {
+		t.Errorf("output should not show legacy include fallback when defaults.rig.imports is set: %s", output)
 	}
 
 	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
@@ -1035,17 +1048,29 @@ source = "packs/a-pack"
 	if len(cfg.Rigs) != 1 {
 		t.Fatalf("expected 1 rig, got %d", len(cfg.Rigs))
 	}
-	if want := []string{"packs/city-pack"}; !reflect.DeepEqual(cfg.Rigs[0].Includes, want) {
-		t.Errorf("rig includes = %v, want %v", cfg.Rigs[0].Includes, want)
+	// gc rig add no longer writes [rigs.imports.*] for entries already
+	// covered by pack.toml's [defaults.rig.imports]; defaults are applied
+	// to rigs at config-resolution time instead.
+	if got := cfg.Rigs[0].Imports; len(got) != 0 {
+		t.Errorf("rig imports = %#v, want empty (covered by defaults.rig.imports)", got)
 	}
-	if len(cfg.Rigs[0].Imports) != 2 {
-		t.Fatalf("len(rig imports) = %d, want 2", len(cfg.Rigs[0].Imports))
+	if got := cfg.Rigs[0].Includes; len(got) != 0 {
+		t.Errorf("rig includes = %v, want empty (defaults.rig.imports replaces legacy default_rig_includes)", got)
 	}
-	if got := cfg.Rigs[0].Imports["z-pack"].Source; got != "packs/z-pack" {
-		t.Errorf("rig imports[z-pack] = %q, want packs/z-pack", got)
+
+	// Defaults must be applied at runtime via LoadWithIncludes.
+	resolved, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-	if got := cfg.Rigs[0].Imports["a-pack"].Source; got != "packs/a-pack" {
-		t.Errorf("rig imports[a-pack] = %q, want packs/a-pack", got)
+	if got := resolved.Rigs[0].Imports; len(got) != 2 {
+		t.Fatalf("resolved rig imports = %#v, want 2 entries from defaults", got)
+	}
+	if got := resolved.Rigs[0].Imports["z-pack"].Source; got != "packs/z-pack" {
+		t.Errorf("resolved rig imports[z-pack] = %q, want packs/z-pack", got)
+	}
+	if got := resolved.Rigs[0].Imports["a-pack"].Source; got != "packs/a-pack" {
+		t.Errorf("resolved rig imports[a-pack] = %q, want packs/a-pack", got)
 	}
 }
 

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1249,10 +1249,10 @@ func TestDoRigAdd_DerivedPrefixConflictsWithExistingBeads(t *testing.T) {
 	}
 }
 
-// A fresh "gc rig add" against a pre-existing .beads/ directory must fail
-// fast and point the user at --adopt — even when the existing prefix would
-// have matched the derived one. Falling through to bd init on a populated
-// Dolt store produces confusing "signal: killed" failures (see fo-5zeij).
+// A fresh "gc rig add" against a pre-existing .beads/ store must fail fast
+// and point the user at --adopt — even when the existing prefix would have
+// matched the derived one. Falling through to bd init on a populated Dolt
+// store produces confusing "signal: killed" failures (see fo-5zeij).
 func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
@@ -1264,8 +1264,8 @@ func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	}
 
 	// Rig "alpha-beta" derives prefix "ab", and .beads already has "ab"
-	// — so the prefix-conflict guard does not trip and we reach the new
-	// "exists without --adopt" guard.
+	// — so the prefix-conflict guard does not trip and we reach the
+	// "store already exists without --adopt" guard.
 	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
 	beadsDir := filepath.Join(rigPath, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
@@ -1282,14 +1282,103 @@ func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
 	if code != 1 {
-		t.Fatalf("expected failure for pre-existing .beads/ without --adopt, got code %d; stdout: %s", code, stdout.String())
+		t.Fatalf("expected failure for pre-existing .beads/ store without --adopt, got code %d; stdout: %s", code, stdout.String())
 	}
 	errMsg := stderr.String()
-	if !strings.Contains(errMsg, ".beads already exists") {
-		t.Errorf("stderr should mention pre-existing .beads/: %s", errMsg)
+	if !strings.Contains(errMsg, "already contains a beads store") {
+		t.Errorf("stderr should identify existing store: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, "--adopt") {
 		t.Errorf("stderr should hint at --adopt: %s", errMsg)
+	}
+}
+
+// A .beads/ directory containing only metadata.json (no config.yaml) is
+// still recognized as an existing store — bd init creates both files,
+// and either one is sufficient evidence that a real store is present.
+func TestDoRigAdd_ExistingBeadsMetadataOnlyRequiresAdopt(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"),
+		[]byte(`{"name":"alpha-beta","issue_prefix":"ab"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected failure for pre-existing .beads/ store without --adopt, got code %d; stdout: %s", code, stdout.String())
+	}
+	errMsg := stderr.String()
+	if !strings.Contains(errMsg, "already contains a beads store") {
+		t.Errorf("stderr should identify existing store: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "--adopt") {
+		t.Errorf("stderr should hint at --adopt: %s", errMsg)
+	}
+}
+
+// A target directory whose .beads/ subdir contains only unrelated content
+// (no metadata.json or config.yaml) is NOT a beads store. Common in the
+// wild: the beads project itself uses .beads/formulas/ for unrelated
+// formula source files. gc rig add must proceed in this case, initializing
+// the store alongside the existing content without disturbing it.
+func TestDoRigAdd_BeadsDirWithUnrelatedContentSucceeds(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "beads-project")
+	formulasDir := filepath.Join(rigPath, ".beads", "formulas")
+	if err := os.MkdirAll(formulasDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	formulaPath := filepath.Join(formulasDir, "example.toml")
+	if err := os.WriteFile(formulaPath, []byte("# unrelated formula source\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd should succeed when .beads/ has only unrelated content, got code %d; stderr: %s", code, stderr.String())
+	}
+
+	// Pre-existing unrelated content must be left untouched.
+	if _, err := os.Stat(formulaPath); err != nil {
+		t.Errorf(".beads/formulas/example.toml should be preserved: %v", err)
+	}
+
+	// city.toml must list the new rig.
+	cityTomlBytes, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(cityTomlBytes), "beads-project") {
+		t.Errorf("city.toml should contain rig name: %s", cityTomlBytes)
 	}
 }
 

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -734,6 +734,32 @@ func resolvedProviderLaunchFamily(resolved *config.ResolvedProvider) string {
 	return strings.TrimSpace(resolved.Name)
 }
 
+// resolvedProviderDisplayName returns the human-readable name for a resolved
+// provider. Lookup order: the provider's own ProviderSpec.DisplayName (custom
+// providers declared in city.toml), then the builtin spec for the family,
+// then the launch family key itself. Empty resolved → empty string.
+func resolvedProviderDisplayName(resolved *config.ResolvedProvider, cityProviders map[string]config.ProviderSpec) string {
+	if resolved == nil {
+		return ""
+	}
+	if name := strings.TrimSpace(resolved.Name); name != "" {
+		if spec, ok := cityProviders[name]; ok {
+			if dn := strings.TrimSpace(spec.DisplayName); dn != "" {
+				return dn
+			}
+		}
+	}
+	family := resolvedProviderLaunchFamily(resolved)
+	if family != "" {
+		if spec, ok := config.BuiltinProviders()[family]; ok {
+			if dn := strings.TrimSpace(spec.DisplayName); dn != "" {
+				return dn
+			}
+		}
+	}
+	return family
+}
+
 func resolvedProviderFamilyMetadata(resolved *config.ResolvedProvider) string {
 	if resolved == nil {
 		return ""

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -140,7 +140,36 @@ func explicitAgents(agents []config.Agent) []config.Agent {
 	return out
 }
 
+// scrubAmbientGCBeadsEnv unsets every GC_*/BEADS_* env var inherited from
+// the host shell before tests run. A polecat session that exec's `go test`
+// in this package exports GC_BEADS=bd, BEADS_DIR=…, GC_CITY_PATH=…, etc.;
+// any in-process test that opens a city bead store (openCityStoreAt, the
+// caching reconciler in newControllerState, MaterializeBuiltinPacks +
+// ensureBeadsProvider) would otherwise read those via os.Getenv, switch to
+// the "bd" provider, and trigger the gc-beads-bd lifecycle script to spawn
+// a managed dolt sql-server pointed at the test's t.TempDir(). The dolt
+// child is detached via nohup, so when the test exits without a matching
+// stop the server reparents to systemd --user and lingers; sustained test
+// runs have accumulated 100+ orphans (~18 GB RSS) before manual cleanup.
+// The corresponding exec.Cmd path is already protected by
+// sanitizedBaseEnv; this closes the in-process leak. Tests that need a
+// specific value set it with t.Setenv (which restores after the test).
+// Regression for gastownhall/gascity#ga-7w42.
+func scrubAmbientGCBeadsEnv() {
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		name := kv[:eq]
+		if strings.HasPrefix(name, "GC_") || strings.HasPrefix(name, "BEADS_") {
+			_ = os.Unsetenv(name)
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
+	scrubAmbientGCBeadsEnv()
 	gcHome, err := os.MkdirTemp("", "gascity-gc-home-*")
 	if err != nil {
 		panic(err)
@@ -213,6 +242,46 @@ func newTestscriptParams(t *testing.T, files ...string) testscript.Params {
 		params.Files = append([]string(nil), files...)
 	}
 	return params
+}
+
+// TestMainScrubsAmbientGCBeadsEnv pins the TestMain invariant that all
+// GC_*/BEADS_* env vars inherited from the host shell are unset before any
+// test runs. Polecat sessions export GC_BEADS=bd, BEADS_DIR=…, etc., and
+// in-process callers of openCityStoreAt / ensureBeadsProvider read those via
+// os.Getenv. Without the scrub the bd provider wins over a test's explicit
+// city.toml provider="file", which spawns a dolt sql-server for the test's
+// t.TempDir() that nothing kills on test exit. Regression for ga-7w42.
+func TestMainScrubsAmbientGCBeadsEnv(t *testing.T) {
+	// GC_HOME is intentionally re-set by TestMain to an isolated temp dir,
+	// so exclude it from the scrubbed-set check.
+	for _, name := range []string{
+		"GC_BEADS",
+		"GC_BEADS_SCOPE_ROOT",
+		"GC_CITY",
+		"GC_CITY_PATH",
+		"GC_CITY_RUNTIME_DIR",
+		"GC_DIR",
+		"GC_DOLT_HOST",
+		"GC_DOLT_PORT",
+		"GC_DOLT_USER",
+		"GC_PACK_DIR",
+		"GC_PACK_NAME",
+		"GC_PACK_STATE_DIR",
+		"GC_RIG",
+		"GC_RIG_ROOT",
+		"GC_SESSION_ID",
+		"GC_SESSION_NAME",
+		"BEADS_DIR",
+		"BEADS_ACTOR",
+		"BEADS_DOLT_AUTO_START",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_SERVER_USER",
+	} {
+		if v := os.Getenv(name); v != "" {
+			t.Errorf("%s = %q after TestMain scrub, want empty (ambient env leak)", name, v)
+		}
+	}
 }
 
 // --- gc version ---

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -23,20 +23,22 @@ const (
 
 // PromptContext holds template data for prompt rendering.
 type PromptContext struct {
-	CityRoot      string
-	AgentName     string // qualified: "rig/polecat-1" or "mayor"
-	TemplateName  string // config name: "polecat" (template) or "mayor" (named backing template)
-	BindingName   string
-	BindingPrefix string
-	RigName       string
-	RigRoot       string
-	WorkDir       string
-	IssuePrefix   string
-	Branch        string
-	DefaultBranch string            // e.g. "main" — from git symbolic-ref origin/HEAD
-	WorkQuery     string            // command to find available work (from Agent.EffectiveWorkQuery)
-	SlingQuery    string            // command template to route work to this agent (from Agent.EffectiveSlingQuery)
-	Env           map[string]string // from Agent.Env — custom vars
+	CityRoot            string
+	AgentName           string // qualified: "rig/polecat-1" or "mayor"
+	TemplateName        string // config name: "polecat" (template) or "mayor" (named backing template)
+	BindingName         string
+	BindingPrefix       string
+	RigName             string
+	RigRoot             string
+	WorkDir             string
+	IssuePrefix         string
+	Branch              string
+	DefaultBranch       string // e.g. "main" — from git symbolic-ref origin/HEAD
+	ProviderKey         string // canonical provider family: "claude", "codex", "gemini", ...
+	ProviderDisplayName string // human-readable provider name: "Claude Code", "Codex CLI", ...
+	WorkQuery           string // command to find available work (from Agent.EffectiveWorkQuery)
+	SlingQuery          string // command template to route work to this agent (from Agent.EffectiveSlingQuery)
+	Env                 map[string]string
 }
 
 // renderPrompt reads a prompt template file and renders it with the given
@@ -67,8 +69,30 @@ func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx Promp
 		return raw
 	}
 
-	tmpl := template.New("prompt").
-		Funcs(promptFuncMap(cityName, sessionTemplate, store)).
+	// tmpl is captured by the templateFirst closure so it can look up
+	// sub-templates registered by {{ define }} blocks after Parse completes.
+	// Parse is single-receiver, so tmpl never moves once assigned below.
+	var tmpl *template.Template
+	funcs := promptFuncMap(cityName, sessionTemplate, store)
+	funcs["templateFirst"] = func(data any, names ...string) (string, error) {
+		if tmpl == nil {
+			return "", nil
+		}
+		for _, name := range names {
+			sub := tmpl.Lookup(name)
+			if sub == nil {
+				continue
+			}
+			var fb bytes.Buffer
+			if err := sub.Execute(&fb, data); err != nil {
+				return "", err
+			}
+			return fb.String(), nil
+		}
+		return "", nil
+	}
+	tmpl = template.New("prompt").
+		Funcs(funcs).
 		Option("missingkey=zero")
 
 	// Load shared templates from pack dirs (lower priority).
@@ -229,6 +253,8 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	m["IssuePrefix"] = ctx.IssuePrefix
 	m["Branch"] = ctx.Branch
 	m["DefaultBranch"] = ctx.DefaultBranch
+	m["ProviderKey"] = ctx.ProviderKey
+	m["ProviderDisplayName"] = ctx.ProviderDisplayName
 	m["WorkQuery"] = ctx.WorkQuery
 	m["SlingQuery"] = ctx.SlingQuery
 	return m

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -726,3 +726,80 @@ func TestEffectivePromptFragmentsDedupsAcrossLayers(t *testing.T) {
 		}
 	}
 }
+
+// Regression for ga-la9y: synthesized chat-agent prompts reference
+// `templateFirst`, `.ProviderKey`, and `.ProviderDisplayName`. Before this
+// fix, `templateFirst` was undefined, so the whole template failed to parse
+// and renderPrompt silently fell back to raw text — agents saw literal
+// `{{ .WorkDir }}` etc. in their system prompt.
+func TestRenderPromptTemplateFirstSelectsDefinedTemplate(t *testing.T) {
+	f := fsys.NewFake()
+	body := `{{ define "ux-claude" -}}claude branch{{- end }}
+{{ define "ux-codex" -}}codex branch{{- end }}
+{{ define "ux-default" -}}default branch{{- end }}
+[{{ templateFirst . (printf "ux-%s" .ProviderKey) "ux-default" }}]`
+	f.Files["/city/agents/chat/prompt.template.md"] = []byte(body)
+
+	ctx := PromptContext{ProviderKey: "claude"}
+	got := renderPrompt(f, "/city", "", "agents/chat/prompt.template.md", ctx, "", io.Discard, nil, nil, nil)
+	if !strings.Contains(got, "[claude branch]") {
+		t.Errorf("renderPrompt(templateFirst claude) = %q, want output containing %q", got, "[claude branch]")
+	}
+}
+
+func TestRenderPromptTemplateFirstFallsThroughToDefault(t *testing.T) {
+	f := fsys.NewFake()
+	body := `{{ define "ux-claude" -}}claude branch{{- end }}
+{{ define "ux-default" -}}default branch{{- end }}
+[{{ templateFirst . (printf "ux-%s" .ProviderKey) "ux-default" }}]`
+	f.Files["/city/agents/chat/prompt.template.md"] = []byte(body)
+
+	// ProviderKey = "gemini" — no ux-gemini define → falls through to ux-default.
+	ctx := PromptContext{ProviderKey: "gemini"}
+	got := renderPrompt(f, "/city", "", "agents/chat/prompt.template.md", ctx, "", io.Discard, nil, nil, nil)
+	if !strings.Contains(got, "[default branch]") {
+		t.Errorf("renderPrompt(templateFirst fallthrough) = %q, want output containing %q", got, "[default branch]")
+	}
+}
+
+func TestRenderPromptTemplateFirstNoMatchReturnsEmpty(t *testing.T) {
+	f := fsys.NewFake()
+	body := `[{{ templateFirst . "missing-a" "missing-b" }}]`
+	f.Files["/city/agents/chat/prompt.template.md"] = []byte(body)
+	var stderr strings.Builder
+	got := renderPrompt(f, "/city", "", "agents/chat/prompt.template.md", PromptContext{}, "", &stderr, nil, nil, nil)
+	// Both named templates are missing → templateFirst returns empty without error.
+	if got != "[]" {
+		t.Errorf("renderPrompt(templateFirst no match) = %q, want %q", got, "[]")
+	}
+	if strings.Contains(stderr.String(), "prompt template") {
+		t.Errorf("stderr emitted parse warning when templates were merely missing: %q", stderr.String())
+	}
+}
+
+func TestRenderPromptProviderKeyAndDisplayName(t *testing.T) {
+	f := fsys.NewFake()
+	body := "Provider: {{ .ProviderDisplayName }} (key={{ .ProviderKey }})"
+	f.Files["/city/agents/chat/prompt.template.md"] = []byte(body)
+	ctx := PromptContext{ProviderKey: "claude", ProviderDisplayName: "Claude Code"}
+	got := renderPrompt(f, "/city", "", "agents/chat/prompt.template.md", ctx, "", io.Discard, nil, nil, nil)
+	want := "Provider: Claude Code (key=claude)"
+	if got != want {
+		t.Errorf("renderPrompt(provider fields) = %q, want %q", got, want)
+	}
+}
+
+func TestBuildTemplateDataProviderFields(t *testing.T) {
+	ctx := PromptContext{
+		ProviderKey:         "claude",
+		ProviderDisplayName: "Claude Code",
+		Env:                 map[string]string{"ProviderKey": "env-override", "ProviderDisplayName": "env-override"},
+	}
+	data := buildTemplateData(ctx)
+	if data["ProviderKey"] != "claude" {
+		t.Errorf("ProviderKey = %q, want %q (SDK overrides Env)", data["ProviderKey"], "claude")
+	}
+	if data["ProviderDisplayName"] != "Claude Code" {
+		t.Errorf("ProviderDisplayName = %q, want %q (SDK overrides Env)", data["ProviderDisplayName"], "Claude Code")
+	}
+}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -272,20 +272,24 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		cfgAgent.InheritedAppendFragments,
 		p.appendFragments,
 	)
+	providerKey := resolvedProviderLaunchFamily(resolved)
+	providerDisplay := resolvedProviderDisplayName(resolved, p.providers)
 	prompt = renderPrompt(p.fs, p.cityPath, p.cityName, cfgAgent.PromptTemplate, PromptContext{
-		CityRoot:      p.cityPath,
-		AgentName:     qualifiedName,
-		TemplateName:  cfgAgent.Name,
-		BindingName:   cfgAgent.BindingName,
-		BindingPrefix: cfgAgent.BindingPrefix(),
-		RigName:       rigName,
-		RigRoot:       rigRoot,
-		WorkDir:       workDir,
-		IssuePrefix:   findRigPrefix(rigName, p.rigs),
-		DefaultBranch: defaultBranchFor(workDir),
-		WorkQuery:     expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "work_query", cfgAgent.EffectiveWorkQuery(), p.stderr),
-		SlingQuery:    expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "sling_query", cfgAgent.EffectiveSlingQuery(), p.stderr),
-		Env:           cfgAgent.Env,
+		CityRoot:            p.cityPath,
+		AgentName:           qualifiedName,
+		TemplateName:        cfgAgent.Name,
+		BindingName:         cfgAgent.BindingName,
+		BindingPrefix:       cfgAgent.BindingPrefix(),
+		RigName:             rigName,
+		RigRoot:             rigRoot,
+		WorkDir:             workDir,
+		IssuePrefix:         findRigPrefix(rigName, p.rigs),
+		DefaultBranch:       defaultBranchFor(workDir),
+		ProviderKey:         providerKey,
+		ProviderDisplayName: providerDisplay,
+		WorkQuery:           expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "work_query", cfgAgent.EffectiveWorkQuery(), p.stderr),
+		SlingQuery:          expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "sling_query", cfgAgent.EffectiveSlingQuery(), p.stderr),
+		Env:                 cfgAgent.Env,
 	}, p.sessionTemplate, p.stderr, p.packDirs, fragments, p.beadStore)
 	hasHooks := config.AgentHasHooks(cfgAgent, p.workspace, resolved.Name, p.providers)
 	beacon := runtime.FormatBeaconAt(p.cityName, qualifiedName, !hasHooks, p.beaconTime)

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -855,6 +855,120 @@ prompt_template = "agents/mayor/prompt.template.md"
 	}
 }
 
+// TestResolveTemplateChatAgentPromptRendersProviderVarsAndTemplateFirst is
+// the end-to-end regression for ga-la9y. Chat-agent prompts synthesized by
+// `gc prompt synth` reference `{{ .ProviderKey }}`, `{{ .ProviderDisplayName }}`,
+// and the `templateFirst` template function. Before the fix, `templateFirst`
+// was undefined so the whole template failed to parse and renderPrompt fell
+// back to raw text — agents saw literal `{{ }}` in their system prompt.
+func TestResolveTemplateChatAgentPromptRendersProviderVarsAndTemplateFirst(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+
+	agentDir := filepath.Join(cityPath, "agents", "chat-claude")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptBody := `# {{ .AgentName }}
+Provider: {{ .ProviderDisplayName }} (key={{ .ProviderKey }})
+
+{{ define "ux-claude" -}}claude-branch{{- end }}
+{{ define "ux-codex" -}}codex-branch{{- end }}
+{{ define "ux-default" -}}default-branch{{- end }}
+
+UX: [{{ templateFirst . (printf "ux-%s" .ProviderKey) "ux-default" }}]
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte(promptBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	params := &agentBuildParams{
+		cityName:  "city",
+		cityPath:  cityPath,
+		workspace: &config.Workspace{Provider: "claude"},
+		providers: map[string]config.ProviderSpec{
+			"claude": {Command: "echo", PromptMode: "none", DisplayName: "Claude Code"},
+		},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: testBeaconTime,
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	cfgAgent := &config.Agent{
+		Name:           "chat-claude",
+		Provider:       "claude",
+		PromptTemplate: filepath.Join(agentDir, "prompt.template.md"),
+	}
+	tp, err := resolveTemplate(params, cfgAgent, cfgAgent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if !strings.Contains(tp.Prompt, "Provider: Claude Code (key=claude)") {
+		t.Errorf("prompt missing rendered provider fields:\n%s", tp.Prompt)
+	}
+	// Beacon contains its own template-style markers, so check the body
+	// for raw {{ that the renderer should have substituted.
+	if strings.Contains(tp.Prompt, "{{ .ProviderKey }}") || strings.Contains(tp.Prompt, "{{ .ProviderDisplayName }}") {
+		t.Errorf("prompt contains unrendered template expressions:\n%s", tp.Prompt)
+	}
+	if !strings.Contains(tp.Prompt, "UX: [claude-branch]") {
+		t.Errorf("prompt missing templateFirst output:\n%s", tp.Prompt)
+	}
+}
+
+// TestResolveTemplateChatAgentPromptFallsThroughTemplateFirstDefault verifies
+// the fallthrough leg of templateFirst when no provider-specific subtemplate
+// is defined, and that DisplayName falls back to the builtin spec.
+func TestResolveTemplateChatAgentPromptFallsThroughTemplateFirstDefault(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+
+	agentDir := filepath.Join(cityPath, "agents", "chat-gemini")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptBody := `Provider: {{ .ProviderDisplayName }}
+{{ define "ux-claude" -}}claude-branch{{- end }}
+{{ define "ux-default" -}}default-branch{{- end }}
+UX: [{{ templateFirst . (printf "ux-%s" .ProviderKey) "ux-default" }}]
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte(promptBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "gemini"},
+		providers:  config.BuiltinProviders(),
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: testBeaconTime,
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	cfgAgent := &config.Agent{
+		Name:           "chat-gemini",
+		Provider:       "gemini",
+		PromptTemplate: filepath.Join(agentDir, "prompt.template.md"),
+	}
+	tp, err := resolveTemplate(params, cfgAgent, cfgAgent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if !strings.Contains(tp.Prompt, "Provider: Gemini CLI") {
+		t.Errorf("prompt missing builtin display name fallback:\n%s", tp.Prompt)
+	}
+	if !strings.Contains(tp.Prompt, "UX: [default-branch]") {
+		t.Errorf("prompt missing templateFirst fallthrough output:\n%s", tp.Prompt)
+	}
+}
+
 func TestResolveTemplateIncludingPackDefaultsDoNotBleedAcrossNestedImportBoundaries(t *testing.T) {
 	cityPath := t.TempDir()
 	write := func(rel, data string) {

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -36,6 +36,21 @@ Stay in your worktree. Install deps there if needed (`npm install`). Commit and 
 You are polecat **{{ basename .AgentName }}** — a worker agent in the {{ .RigName }} rig.
 You work on assigned issues and submit completed work to the Refinery merge queue.
 
+## Scope Discipline
+
+Stay strictly scoped to the bead you were assigned. When you find unrelated
+issues mid-work — pre-existing bugs, broken tests not caused by your change,
+formatting drift, stale comments, anything not in the bead's description:
+
+- File a follow-up bead with `gc bd create --rig {{ .RigName }} --type bug -d "..."`.
+- Continue with your assigned work.
+- Do not expand scope. Do not modify files outside the change you were asked
+  to make.
+
+The refinery expects your branch to contain ONE bead's worth of changes.
+Scope creep makes review harder, the merge more likely to fail, and the
+rejection (when it comes) wastes the work of everyone downstream.
+
 {{ template "architecture" . }}
 
 ## Work Bead Metadata Contract

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -26,6 +26,26 @@ on the work bead (`branch`, `target`), and assign it to you. You merge
 the branch or publish a PR based on `metadata.merge_strategy`, then close
 the bead. No separate MR beads.
 
+## Scope Discipline
+
+You merge polecat work into {{ .DefaultBranch }}. That is your scope. When
+you observe problems OUTSIDE the bead you are merging — malformed configs,
+pre-existing test failures, unrelated bugs, stale comments, anything:
+
+- File a follow-up bead with `gc bd create --rig {{ .RigName }} --type bug -d "..."`.
+- Return to your queue immediately. Do not ask permission. Do not pause.
+- "Should I also fix X?" — the answer is always no. File the follow-up.
+- "Want me to apply that workaround?" — no. File the follow-up.
+
+Only ask the user if:
+- The current merge has failed and you need a decision (proceed / skip / abort).
+- A bead's metadata is internally inconsistent (assignee mismatch, missing
+  `branch`, missing `target`).
+
+Permission requests for scope expansion are forbidden. They block the queue.
+Every minute you spend on a side concern is a minute the next polecat's
+branch waits to be merged.
+
 {{ template "architecture" . }}
 
 ## ZFC Compliance: Agent-Driven Decisions

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -66,6 +66,70 @@ Your formula: `mol-refinery-patrol`
 
 ---
 
+## Patrol Lifecycle Discipline
+
+Two rules govern your inter-wisp behavior. Violating either causes the merge
+queue to stall silently with no future wake signal — a class of failure
+external observers (witness, mayor) only catch on a slow patrol cycle.
+
+### 1. ALWAYS pour the next wisp before burning the current one
+
+```bash
+gc bd mol wisp mol-refinery-patrol --root-only \
+  --var target_branch={{ .DefaultBranch }} \
+  --var rig_name={{ .RigName }} \
+  --var binding_prefix={{ .BindingPrefix }}
+gc bd mol burn <wisp-id> --force
+```
+
+**This rule applies UNCONDITIONALLY, including when:**
+
+- The merge-queue scan returned zero beads at this wisp's scan time.
+- You feel "I'm done with the work" or "queue is empty, nothing to do".
+- Your session is approaching its context limit (handle that via Rule 2,
+  not by skipping the pour).
+
+The next wisp re-scans on its own wake. If the queue is genuinely empty,
+the next wisp returns early after a brief check — cheap. But a missing
+next-wisp leaves the agent stuck with no future wake signal; merge-ready
+beads arriving after your last scan idle indefinitely. Whole-rig merge
+throughput depends on this contract.
+
+**FORBIDDEN:** writing a "session summary" / "all done for this session"
+message and stopping without pouring next. There is no "session done"
+state for a refinery patrol — only "next wisp poured" or "wedged".
+
+### 2. Request restart on heavy context
+
+At the start of every wisp, before any merge work:
+
+```bash
+RSS=$(ps -o rss= -p $$ | tr -d ' ')
+RSS_MB=$((RSS / 1024))
+```
+
+If `RSS_MB > 1500`, or context feels heavy (multi-hour session, large
+recent diffs, you notice yourself taking shortcuts or summarizing
+prematurely), then **pour the next wisp first (per Rule 1), THEN
+request restart**:
+
+```bash
+gc bd mol wisp mol-refinery-patrol --root-only \
+  --var target_branch={{ .DefaultBranch }} \
+  --var rig_name={{ .RigName }} \
+  --var binding_prefix={{ .BindingPrefix }}
+gc runtime request-restart
+```
+
+`gc runtime request-restart` sets `GC_RESTART_REQUESTED` metadata and blocks
+forever. The controller kills and respawns this session fresh. The new
+agent wakes on the wisp you just poured and processes the queue with a
+clean context. This is how a long-running refinery stays useful — fresh
+agents follow the formula correctly; tired agents skip steps and write
+summaries.
+
+---
+
 ## Startup
 
 ```bash

--- a/examples/gastown/packs/maintenance/assets/scripts/refinery-rescue.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/refinery-rescue.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# refinery-rescue — wake refineries whose merge queue has work but
+# whose patrol wisp is absent.
+#
+# Symptom this catches: refinery agent processes its queue, decides
+# "done", stops pouring next wisp. Later, polecats finish more work and
+# route beads to the same refinery — but no in-progress patrol wisp
+# exists, so the agent never wakes to process them. The merge queue
+# stalls silently until external intervention.
+#
+# This order is the safety net. The primary fix is the refinery's own
+# Patrol Lifecycle Discipline (see gastown/agents/refinery/prompt.template.md):
+#   1. Always pour next wisp before burning current
+#   2. Request restart on heavy context
+# This script catches the case where (1) or (2) fail.
+#
+# Logic: for each rig with a default-named gastown refinery, count open
+# beads routed to that refinery. If > 0 and no in-progress patrol wisp,
+# nudge the refinery. Idempotent — re-nudging an already-awake agent
+# is cheap (one tmux keystroke, no state change).
+#
+# Runs as an exec order (no LLM, no agent, no wisp).
+
+set -euo pipefail
+
+CITY="${GC_CITY:-.}"
+
+# Enumerate every rig in this city. Each rig that imports the default
+# gastown pack exposes a canonical refinery at <rig>/gastown.refinery.
+# Rigs without a refinery return an empty queue and are silently skipped.
+RIGS=$(gc --city "$CITY" rig list --json 2>/dev/null | jq -r '.rigs[]?.name // empty')
+if [ -z "$RIGS" ]; then
+    exit 0
+fi
+
+NUDGED=0
+SCANNED=0
+while IFS= read -r rig; do
+    [ -z "$rig" ] && continue
+    SCANNED=$((SCANNED + 1))
+    refinery="${rig}/gastown.refinery"
+
+    # Open beads queued to this refinery? Use gc.routed_to as the
+    # canonical signal; an empty result here is the common path
+    # (refinery has no work, nothing to do).
+    queued=$(gc --city "$CITY" bd list --rig "$rig" --status=open \
+        --metadata-field "gc.routed_to=${refinery}" \
+        --json --limit=1 2>/dev/null || echo "[]")
+    [ "$queued" = "[]" ] && continue
+
+    # In-progress patrol wisp for this refinery? If yes, the refinery
+    # is mid-cycle and will pick up the queued bead on its next step
+    # or wake — no rescue needed.
+    patrol=$(gc --city "$CITY" bd list --rig "$rig" --status=in_progress \
+        --assignee "$refinery" \
+        --label "molecule:mol-refinery-patrol" \
+        --json --limit=1 2>/dev/null || echo "[]")
+    [ "$patrol" != "[]" ] && continue
+
+    # Gap: queued work + no in-progress patrol. Nudge the refinery to
+    # wake and pour a patrol wisp. Failure to nudge (e.g. refinery
+    # session doesn't exist yet) is non-fatal — the next cycle will
+    # retry.
+    count=$(printf '%s' "$queued" | jq 'length' 2>/dev/null || echo "?")
+    if gc --city "$CITY" session nudge "$refinery" \
+        "Rescue: ${count} bead(s) queued, no patrol wisp in flight. Pour mol-refinery-patrol and process the queue." \
+        >/dev/null 2>&1; then
+        NUDGED=$((NUDGED + 1))
+    fi
+done <<<"$RIGS"
+
+if [ "$NUDGED" -gt 0 ]; then
+    printf 'refinery-rescue: nudged %d refinery agent(s) across %d rig(s)\n' \
+        "$NUDGED" "$SCANNED"
+fi

--- a/examples/gastown/packs/maintenance/orders/refinery-rescue.toml
+++ b/examples/gastown/packs/maintenance/orders/refinery-rescue.toml
@@ -1,0 +1,12 @@
+# Refinery rescue: every 30min, nudge refineries that have queued beads
+# but no in-progress patrol wisp. Safety net for when the refinery's own
+# pour-next-wisp discipline (see gastown/agents/refinery/prompt.template.md)
+# fails — agent crash mid-cycle, controller respawn miss, or the agent
+# wrongly judging "queue empty, done" at the wrong moment.
+#
+# Runs as an exec order: no LLM, no agent, no wisp.
+[order]
+description = "Nudge refineries with queued beads but no in-progress patrol wisp"
+exec = "$PACK_DIR/assets/scripts/refinery-rescue.sh"
+trigger = "cooldown"
+interval = "30m"

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -311,6 +311,11 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		return false, err
 	}
 
+	repairedLines, repaired := repairMalformedConfigLines(strings.Split(string(data), "\n"))
+	if repaired {
+		data = []byte(strings.Join(repairedLines, "\n"))
+	}
+
 	prefix := strings.TrimSpace(state.IssuePrefix)
 	if prefix == "" {
 		if existing, ok := scanConfigLineValueFromData(data, "issue_prefix:", "issue-prefix:"); ok {
@@ -359,9 +364,11 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 	lines := strings.Split(string(data), "\n")
 	out := make([]string, 0, len(lines)+len(replacements))
 	seen := make(map[string]bool, len(replacements))
-	changed := false
+	changed := repaired
 
-	for _, line := range lines {
+	lastTopLevelIndex := lastTopLevelKeyIndex(lines)
+
+	for i, line := range lines {
 		key, _, ok := topLevelConfigLine(line)
 		if !ok {
 			out = append(out, line)
@@ -373,6 +380,13 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		}
 		want, manage := replacements[key]
 		if !manage {
+			// Per YAML semantics, last-write-wins for duplicate top-level
+			// keys. Drop earlier occurrences so the canonical writer
+			// converges on a single entry per key.
+			if i != lastTopLevelIndex[key] {
+				changed = true
+				continue
+			}
 			out = append(out, line)
 			continue
 		}
@@ -669,4 +683,106 @@ func trimmedString(value any) string {
 		return ""
 	}
 	return trimmed
+}
+
+// repairMalformedConfigLines splits top-level config lines that have been
+// glued together by an upstream writer that forgot a trailing newline.
+// Returns the (possibly-expanded) line slice and a flag indicating whether
+// any line was split.
+//
+// Concretely this handles the ga-um7 reproducer: `bd init` against a git
+// repo can leave a line like
+//
+//	sync.remote: "<url>"types.custom: <value>
+//
+// which would otherwise trip the YAML parser and survive the line-based
+// fallback unchanged.
+func repairMalformedConfigLines(lines []string) ([]string, bool) {
+	out := make([]string, 0, len(lines))
+	changed := false
+	for _, line := range lines {
+		parts := splitGluedConfigLine(line)
+		if len(parts) > 1 {
+			changed = true
+		}
+		out = append(out, parts...)
+	}
+	return out, changed
+}
+
+// splitGluedConfigLine recursively splits a top-level config line that
+// contains a quoted-string value immediately followed by another top-level
+// key. Returns the original line as a one-element slice when no split is
+// possible.
+func splitGluedConfigLine(line string) []string {
+	if strings.TrimLeft(line, " \t") != line {
+		return []string{line}
+	}
+	colon := strings.Index(line, ":")
+	if colon <= 0 {
+		return []string{line}
+	}
+	rest := line[colon+1:]
+	quoteStart := strings.Index(rest, `"`)
+	if quoteStart < 0 {
+		return []string{line}
+	}
+	quoteEnd := strings.Index(rest[quoteStart+1:], `"`)
+	if quoteEnd < 0 {
+		return []string{line}
+	}
+	afterQuote := quoteStart + 1 + quoteEnd + 1
+	tail := rest[afterQuote:]
+	if !looksLikeTopLevelKeyStart(tail) {
+		return []string{line}
+	}
+	head := line[:colon+1+afterQuote]
+	// The tail may itself glue another key; recurse so chains of
+	// missing-newline writes all get split apart.
+	return append([]string{head}, splitGluedConfigLine(tail)...)
+}
+
+// looksLikeTopLevelKeyStart reports whether s begins with a YAML-style
+// top-level key followed by a colon (e.g. `types.custom: value`).
+func looksLikeTopLevelKeyStart(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if r == ':' {
+			return i > 0
+		}
+		if !isYamlKeyRune(r) {
+			return false
+		}
+	}
+	return false
+}
+
+func isYamlKeyRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r == '.' || r == '-' || r == '_':
+		return true
+	default:
+		return false
+	}
+}
+
+// lastTopLevelKeyIndex returns a map from top-level key name to the index
+// of its final occurrence in lines. Used by the fallback writer to drop
+// earlier duplicates so YAML last-write-wins semantics survive a rewrite.
+func lastTopLevelKeyIndex(lines []string) map[string]int {
+	last := make(map[string]int, len(lines))
+	for i, line := range lines {
+		if key, _, ok := topLevelConfigLine(line); ok {
+			last[key] = i
+		}
+	}
+	return last
 }

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -298,6 +298,111 @@ func TestEnsureCanonicalConfigIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestEnsureCanonicalConfigRepairsGluedSyncRemoteLine guards against the
+// ga-um7 reproducer: `bd init` against a git repo with a remote can leave
+// `.beads/config.yaml` with the `sync.remote:` line lacking a trailing
+// newline, so the next emitted key gets glued onto its value. The next
+// EnsureCanonicalConfig call must restructure the file into valid YAML
+// rather than silently passing the corrupt line through.
+func TestEnsureCanonicalConfigRepairsGluedSyncRemoteLine(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue_prefix: si",
+		"issue-prefix: si",
+		"dolt.auto-start: false",
+		"export.auto: false",
+		"gc.endpoint_origin: inherited_city",
+		"gc.endpoint_status: verified",
+		"",
+		`sync.remote: "git+ssh://git@example.com/foo/service-inventory.git"types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step`,
+		"types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "si",
+		EndpointOrigin: EndpointOriginInheritedCity,
+		EndpointStatus: EndpointStatusVerified,
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalConfig() should report changes when repairing glued line")
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+
+	// The repaired file must parse as YAML.
+	if _, err := readConfigDoc(fs, path); err != nil {
+		t.Fatalf("repaired config must parse as YAML, got error %v\n%s", err, text)
+	}
+
+	// sync.remote line must be a standalone key/value, not glued to anything.
+	if !strings.Contains(text, `sync.remote: "git+ssh://git@example.com/foo/service-inventory.git"`+"\n") &&
+		!strings.Contains(text, "sync.remote: git+ssh://git@example.com/foo/service-inventory.git\n") {
+		t.Fatalf("sync.remote line must be standalone, got:\n%s", text)
+	}
+	if strings.Contains(text, `"types.custom`) {
+		t.Fatalf("types.custom must not be glued to a quoted value:\n%s", text)
+	}
+
+	// types.custom must appear at most once.
+	if got := countLineOccurrences(text, "types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step"); got != 1 {
+		t.Fatalf("types.custom should appear exactly once, found %d:\n%s", got, text)
+	}
+}
+
+// TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair ensures
+// that when fallback repairs are needed, duplicate top-level keys are
+// collapsed even when they aren't in the managed set. YAML semantics say
+// last-write-wins; the canonical writer should match.
+func TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	// Include a malformed marker so the fallback path runs.
+	input := strings.Join([]string{
+		"issue_prefix: gc",
+		"types.custom: first-value",
+		"types.custom: second-value",
+		": not yaml",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if strings.Contains(text, "types.custom: first-value") {
+		t.Fatalf("first duplicate value should be dropped:\n%s", text)
+	}
+	if count := countLineOccurrences(text, "types.custom: second-value"); count != 1 {
+		t.Fatalf("expected exactly one types.custom line, found %d:\n%s", count, text)
+	}
+}
+
 func TestEnsureCanonicalConfigFallsBackToLineRewriteOnMalformedYAML(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -119,12 +119,26 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
-		defaultRigIncludes, err := defaultRigIncludesFromPackDefaults(pc.Defaults, md)
+		defaultRigImports, err := defaultRigImportsFromPackDefaults(pc.Defaults, md)
 		if err != nil {
 			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
 		}
-		if len(defaultRigIncludes) > 0 {
+		if len(defaultRigImports) > 0 {
+			defaultRigIncludes := make([]string, 0, len(defaultRigImports))
+			for _, bound := range defaultRigImports {
+				defaultRigIncludes = append(defaultRigIncludes, bound.Import.Source)
+			}
 			root.Workspace.DefaultRigIncludes = append(defaultRigIncludes, root.Workspace.DefaultRigIncludes...)
+			if root.DefaultRigImports == nil {
+				root.DefaultRigImports = make(map[string]Import, len(defaultRigImports))
+			}
+			for _, bound := range defaultRigImports {
+				if _, ok := root.DefaultRigImports[bound.Binding]; ok {
+					continue
+				}
+				root.DefaultRigImports[bound.Binding] = bound.Import
+				root.DefaultRigImportOrder = append(root.DefaultRigImportOrder, bound.Binding)
+			}
 		}
 		// Merge pack.toml providers (pack is base, city wins).
 		if len(pc.Providers) > 0 {
@@ -405,6 +419,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	}
 
 	// Expand rig packs after patches (pack agents get rig overrides).
+	// Apply pack.toml [defaults.rig.imports] to rigs before checking
+	// HasPackRigs so rigs that rely solely on defaults still expand.
+	applyDefaultRigImports(root)
 	rigFormulaDirs := make(map[string][]string)
 	if HasPackRigs(root.Rigs) {
 		if err := expandPacks(root, fs, cityRoot, rigFormulaDirs, opts); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2382,11 +2382,15 @@ func configuredProviderOrder(providers map[string]ProviderSpec) []string {
 
 // ValidateAgents checks agent configurations for errors. It returns an error
 // if any agent is missing required fields, has duplicate identities, or has
-// invalid pool bounds. Uniqueness is keyed on (dir, name) — the same name
-// in different dirs is allowed.
+// invalid pool bounds. Uniqueness is keyed on (dir, binding, name) — the
+// same bare name in different dirs or under different import bindings is
+// allowed, because V2 imports can re-bind the same upstream pack under
+// different names (e.g., a chat pack imported directly AND transitively via
+// another pack produces two distinct qualified identities).
 func ValidateAgents(agents []Agent) error {
-	seen := make(map[agentKey]bool, len(agents))
-	sourceOf := make(map[agentKey]string, len(agents))
+	type validateKey struct{ dir, binding, name string }
+	seen := make(map[validateKey]bool, len(agents))
+	sourceOf := make(map[validateKey]string, len(agents))
 	for i, a := range agents {
 		if a.Name == "" {
 			return fmt.Errorf("agent[%d]: name is required", i)
@@ -2394,7 +2398,7 @@ func ValidateAgents(agents []Agent) error {
 		if !validAgentName.MatchString(a.Name) {
 			return fmt.Errorf("agent %q: name must match [a-zA-Z0-9][a-zA-Z0-9_-]* (no spaces, slashes, or dots)", a.Name)
 		}
-		key := agentKey{dir: a.Dir, name: a.Name}
+		key := validateKey{dir: a.Dir, binding: a.BindingName, name: a.Name}
 		if seen[key] {
 			prev := sourceOf[key]
 			curr := a.SourceDir

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2820,6 +2820,23 @@ func TestValidateAgentsSameNameSameDir(t *testing.T) {
 	}
 }
 
+func TestValidateAgentsSameNameDifferentBinding(t *testing.T) {
+	// Regression for ga-4i15: when the same upstream pack is imported under
+	// two different bindings (e.g., directly as "chat" and transitively
+	// re-bound to "idea-to-beads"), each binding produces a distinct
+	// qualified identity. Validation must NOT flag them as duplicates —
+	// the controller's config_reload path treats this as fatal and rejects
+	// the entire new config, which in turn orphan-closes the named
+	// sessions that depended on it.
+	agents := []Agent{
+		{Name: "chat-claude", Dir: "service-inventory", BindingName: "chat", SourceDir: "/cache/chat"},
+		{Name: "chat-claude", Dir: "service-inventory", BindingName: "idea-to-beads", SourceDir: "/cache/chat"},
+	}
+	if err := ValidateAgents(agents); err != nil {
+		t.Errorf("ValidateAgents: unexpected error for same name under different bindings: %v", err)
+	}
+}
+
 func TestValidateAgentsSameNameCityWide(t *testing.T) {
 	// Two city-wide agents with the same name should still be rejected.
 	agents := []Agent{

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -1892,6 +1892,111 @@ scope = "city"
 	}
 }
 
+// TestImport_RigImportOfPackWithPackLevelImportResolvesOwnNamedSession
+// reproduces ga-4i15. A rig imports Pack B; Pack B declares a pack-level
+// `[imports.chat]` AND its own `[[named_session]]` backed by an agent
+// discovered under `agents/orchestrator/`. The named session's backing
+// agent must resolve via FindAgent so the controller can materialize the
+// session — otherwise the session bead orphan-closes on first wake.
+func TestImport_RigImportOfPackWithPackLevelImportResolvesOwnNamedSession(t *testing.T) {
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	chatDir := filepath.Join(dir, "chat")
+	ideaDir := filepath.Join(dir, "idea")
+	chatAgent := filepath.Join(chatDir, "agents", "chat-claude")
+	ideaAgent := filepath.Join(ideaDir, "agents", "orchestrator")
+
+	for _, d := range []string{cityDir, chatDir, ideaDir, chatAgent, ideaAgent} {
+		mustMkdirAll(t, d, 0o755)
+	}
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "service-inventory"
+path = "/tmp/service-inventory"
+
+[rigs.imports.chat]
+source = "../chat"
+
+[rigs.imports.idea-to-beads]
+source = "../idea"
+`)
+
+	writeTestFile(t, chatDir, "pack.toml", `
+[pack]
+name = "chat"
+schema = 2
+
+[[named_session]]
+template = "chat-claude"
+scope = "rig"
+mode = "on_demand"
+`)
+	writeTestFile(t, chatAgent, "agent.toml", `
+scope = "rig"
+provider = "claude"
+`)
+	writeTestFile(t, chatAgent, "prompt.md", `chat-claude`)
+
+	writeTestFile(t, ideaDir, "pack.toml", `
+[pack]
+name = "idea-to-beads"
+schema = 2
+
+[imports.chat]
+source = "../chat"
+
+[[named_session]]
+template = "orchestrator"
+scope = "rig"
+mode = "on_demand"
+`)
+	writeTestFile(t, ideaAgent, "agent.toml", `
+scope = "rig"
+provider = "claude"
+`)
+	writeTestFile(t, ideaAgent, "prompt.md", `orchestrator`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	// The controller calls ValidateAgents during config reload. If that
+	// fails, the new config is rejected and the named session cannot
+	// materialize, leading to immediate orphan-close.
+	if err := ValidateAgents(cfg.Agents); err != nil {
+		var ids []string
+		for _, a := range cfg.Agents {
+			ids = append(ids, fmt.Sprintf("%s (BindingName=%q SourceDir=%q)", a.QualifiedName(), a.BindingName, a.SourceDir))
+		}
+		t.Fatalf("ValidateAgents: %v\nAgents:\n  %s", err, strings.Join(ids, "\n  "))
+	}
+
+	identity := "service-inventory/idea-to-beads.orchestrator"
+	named := FindNamedSession(cfg, identity)
+	if named == nil {
+		var ids []string
+		for _, ns := range cfg.NamedSessions {
+			ids = append(ids, ns.QualifiedName())
+		}
+		t.Fatalf("FindNamedSession(%q) = nil; got NamedSessions=%v", identity, ids)
+	}
+	if got := named.TemplateQualifiedName(); got != identity {
+		t.Fatalf("TemplateQualifiedName() = %q, want %q", got, identity)
+	}
+	if got := FindAgent(cfg, named.TemplateQualifiedName()); got == nil {
+		var ids []string
+		for _, a := range cfg.Agents {
+			ids = append(ids, a.QualifiedName())
+		}
+		t.Fatalf("FindAgent(%q) = nil; got Agents=%v", named.TemplateQualifiedName(), ids)
+	}
+}
+
 func TestImport_ReExportNestedPreservesInnerBinding(t *testing.T) {
 	// outer exports inner, inner imports util (not exported).
 	// Agents from inner should be flattened to outer's binding.

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2082,13 +2082,27 @@ func legacyPackDoctors(fs fsys.FS, entries []PackDoctorEntry, packDir, packName 
 
 // applyPackGlobals appends [global].session_live commands from packs
 // to matching agents. City-level globals affect ALL agents. Rig-level
-// globals affect only agents in that rig.
+// globals affect only agents in that rig. Each named pack contributes
+// at most once per agent: if the same pack is loaded at both city and
+// rig scope, its globals are not double-applied.
 func applyPackGlobals(cfg *City) {
+	applied := make([]map[string]bool, len(cfg.Agents))
+	apply := func(idx int, g ResolvedPackGlobal) {
+		if g.PackName != "" {
+			if applied[idx] == nil {
+				applied[idx] = make(map[string]bool)
+			}
+			if applied[idx][g.PackName] {
+				return
+			}
+			applied[idx][g.PackName] = true
+		}
+		cfg.Agents[idx].SessionLive = append(cfg.Agents[idx].SessionLive, g.SessionLive...)
+	}
 	// City-level globals → all agents.
 	for _, g := range cfg.PackGlobals {
 		for i := range cfg.Agents {
-			cfg.Agents[i].SessionLive = append(
-				cfg.Agents[i].SessionLive, g.SessionLive...)
+			apply(i, g)
 		}
 	}
 	// Rig-level globals → only that rig's agents.
@@ -2096,10 +2110,45 @@ func applyPackGlobals(cfg *City) {
 		for _, g := range globals {
 			for i := range cfg.Agents {
 				if cfg.Agents[i].Dir == rigName {
-					cfg.Agents[i].SessionLive = append(
-						cfg.Agents[i].SessionLive, g.SessionLive...)
+					apply(i, g)
 				}
 			}
+		}
+	}
+}
+
+// applyDefaultRigImports merges [defaults.rig.imports] entries into each
+// rig's Imports map for binding names the rig hasn't already declared
+// itself. The pack.toml [defaults.rig.imports] section is the single
+// source of truth for which packs apply to every rig — gc rig add no
+// longer needs to copy them into city.toml's [rigs.imports.*].
+//
+// A binding the rig already sets (with any source) wins, allowing per-rig
+// overrides. A binding that points at the same source path as the default
+// is treated as redundant declaration: the explicit entry stays, the
+// default is skipped, and downstream pack loading sees a single import.
+func applyDefaultRigImports(cfg *City) {
+	if len(cfg.DefaultRigImports) == 0 {
+		return
+	}
+	order := cfg.DefaultRigImportOrder
+	if len(order) == 0 {
+		order = make([]string, 0, len(cfg.DefaultRigImports))
+		for name := range cfg.DefaultRigImports {
+			order = append(order, name)
+		}
+		sort.Strings(order)
+	}
+	for i := range cfg.Rigs {
+		rig := &cfg.Rigs[i]
+		for _, name := range order {
+			if _, ok := rig.Imports[name]; ok {
+				continue
+			}
+			if rig.Imports == nil {
+				rig.Imports = make(map[string]Import)
+			}
+			rig.Imports[name] = cfg.DefaultRigImports[name]
 		}
 	}
 }

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3978,6 +3978,73 @@ session_live = ["echo global"]
 	}
 }
 
+// TestPackGlobal_DedupedAcrossScopes covers the case where a pack is loaded
+// at both city and rig scope (typical for packs with both city-scoped and
+// rig-scoped agents). Without dedup, applyPackGlobals would append the pack's
+// session_live twice to each rig agent — once for the city-level
+// PackGlobals entry, once for the rig-level RigPackGlobals entry.
+func TestPackGlobal_DedupedAcrossScopes(t *testing.T) {
+	cfg := &City{
+		PackGlobals: []ResolvedPackGlobal{
+			{PackName: "gastown", SessionLive: []string{"theme.sh", "keys.sh"}},
+		},
+		RigPackGlobals: map[string][]ResolvedPackGlobal{
+			"my-rig": {{PackName: "gastown", SessionLive: []string{"theme.sh", "keys.sh"}}},
+		},
+		Agents: []Agent{
+			{Name: "city-agent", Dir: ""},
+			{Name: "rig-agent", Dir: "my-rig"},
+		},
+	}
+	applyPackGlobals(cfg)
+	for _, a := range cfg.Agents {
+		if len(a.SessionLive) != 2 {
+			t.Errorf("agent %q: SessionLive = %v, want 2 entries (no dedup means double-application)", a.Name, a.SessionLive)
+		}
+	}
+}
+
+// TestApplyDefaultRigImports_AppliedToBareRigs verifies that
+// [defaults.rig.imports] entries get merged onto rigs that don't declare
+// the binding themselves.
+func TestApplyDefaultRigImports_AppliedToBareRigs(t *testing.T) {
+	cfg := &City{
+		DefaultRigImports: map[string]Import{
+			"gastown": {Source: "packs/gastown"},
+		},
+		DefaultRigImportOrder: []string{"gastown"},
+		Rigs: []Rig{
+			{Name: "alpha"},
+			{Name: "beta"},
+		},
+	}
+	applyDefaultRigImports(cfg)
+	for _, r := range cfg.Rigs {
+		if r.Imports["gastown"].Source != "packs/gastown" {
+			t.Errorf("rig %q: imports[gastown].Source = %q, want packs/gastown", r.Name, r.Imports["gastown"].Source)
+		}
+	}
+}
+
+// TestApplyDefaultRigImports_ExplicitWins verifies that an explicit
+// rig-level import overrides the default for the same binding name,
+// allowing per-rig overrides while preserving the dedup invariant.
+func TestApplyDefaultRigImports_ExplicitWins(t *testing.T) {
+	cfg := &City{
+		DefaultRigImports: map[string]Import{
+			"gastown": {Source: "packs/gastown-default"},
+		},
+		DefaultRigImportOrder: []string{"gastown"},
+		Rigs: []Rig{
+			{Name: "alpha", Imports: map[string]Import{"gastown": {Source: "packs/gastown-fork"}}},
+		},
+	}
+	applyDefaultRigImports(cfg)
+	if got := cfg.Rigs[0].Imports["gastown"].Source; got != "packs/gastown-fork" {
+		t.Errorf("explicit rig import overridden by default: got %q, want packs/gastown-fork", got)
+	}
+}
+
 func TestPackDefinesAgent_Found(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gastown/pack.toml", `


### PR DESCRIPTION
## Summary

Refinery agents observed sitting idle with queued beads after processing their initial queue. Root cause: agent processed all visible work, judged "session done", wrote a summary, and stopped without pouring next wisp. New beads routed to the refinery after that scan never triggered a wake — the merge queue stalls silently until external intervention (manual nudge from mayor / human).

This PR layers three fixes.

## Changes

### 1. Patrol Lifecycle Discipline (refinery prompt)

`examples/gastown/packs/gastown/agents/refinery/prompt.template.md`

Adds a new top-level section with two rules:

**Rule 1 — ALWAYS pour next wisp before burning current**, UNCONDITIONALLY — including when the queue scanned empty. The next wisp re-scans on its own wake; a missing next-wisp wedges the merge queue silently. Explicitly forbids "session summary" wrap-ups, which is what the wedged refinery had written.

**Rule 2 — Request restart on heavy context.** At start of every wisp, check process RSS / context heaviness. If heavy (`RSS_MB > 1500` or multi-hour session), pour next wisp first, then call `gc runtime request-restart`. Mirrors the proven self-restart pattern in `mol-deacon-patrol`. Long-running refineries skip discipline; fresh ones follow it.

### 2. Rescue order (maintenance pack)

`examples/gastown/packs/maintenance/orders/refinery-rescue.toml` + `assets/scripts/refinery-rescue.sh`

New exec order, `interval = "30m"`. For each rig with a default-named gastown refinery, if there are open beads routed to `<rig>/gastown.refinery` AND no in-progress `mol-refinery-patrol` wisp, the script nudges the refinery. Safety net for when prompt-level discipline (1) fails — agent crash mid-cycle, controller respawn miss, or prompt regression.

Idempotent: re-nudging an already-awake agent is a single tmux keystroke; no state change. Cheap.

## Why both layers

The discipline rules are the primary fix and handle the steady-state case. The rescue order is the backstop for the long tail (one-off failures, race conditions, prompt regressions). With only the discipline rules, a single missed pour wedges the queue indefinitely. With only the rescue order, every queue cycle pays a 30-minute discovery delay.

## Observed failure that triggered this

During a city session, refinery `mc-bxhp` (gascity rig) processed 4 merges, wrote `Total this session: 4 merges processed, 2 beads filed for pre-existing test failures, 1 config repair`, and stopped. Five new beads were subsequently routed to it (`gc.routed_to=gascity/gastown.refinery`) by polecats completing work. The agent never woke; the queue stalled for 11+ minutes until a manual `gc session nudge gascity/gastown.refinery` from the mayor restored it. By that point, session context was at 120.4k tokens (5h old, never recycled) — likely the underlying cause of the "session done, write summary, stop" judgment.

## Test plan

- [ ] `examples/gastown/packs/maintenance/orders/refinery-rescue.toml` parses cleanly (gc doctor on a city importing the pack).
- [ ] `refinery-rescue.sh` runs without error on a city with one rig (no refinery yet) — exits 0 silently.
- [ ] On a city with a refinery and queued work + no patrol wisp, the script emits the nudge log line and the refinery wakes.
- [ ] Manual: refinery agent reads the new prompt section, pours next wisp at end of an empty-scan cycle (look for `mol-refinery-patrol` wisp creation event in `gc events`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)