### PR TITLE
fix(orders): filter disabled orders after overrides

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -224,7 +224,7 @@ func loadAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName 
 		}
 	}
 
-	return allAA, 0
+	return filterEnabledOrders(allAA), 0
 }
 
 func scanAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName string) ([]orders.Order, error) {
@@ -258,6 +258,19 @@ func scanAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName 
 	allAA = append(allAA, cityAA...)
 	allAA = append(allAA, rigAA...)
 	return allAA, nil
+}
+
+func filterEnabledOrders(aa []orders.Order) []orders.Order {
+	if len(aa) == 0 {
+		return nil
+	}
+	filtered := aa[:0]
+	for _, a := range aa {
+		if a.IsEnabled() {
+			filtered = append(filtered, a)
+		}
+	}
+	return filtered
 }
 
 // cityFormulaLayers returns the formula directory layers for city-level order

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -175,6 +175,7 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 			logDispatchError(stderr, "gc start: order overrides: %v", err)
 		}
 	}
+	allAA = filterEnabledOrders(allAA)
 
 	// Filter out manual-trigger orders — they are never auto-dispatched.
 	var auto []orders.Order


### PR DESCRIPTION
Applies disabled-order filtering after config overrides are resolved, preventing overridden disabled orders from being considered runnable.