### PR TITLE
fix(stop): allow supervisor stop with invalid config

### DIFF
--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -66,15 +66,15 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 		return 1
 	}
 
-	if handled, code := unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, "gc stop", supervisorUnregisterOptions{
-		Force:                 force,
-		WaitForControllerStop: false,
-	}); handled {
+	if handled, code := unregisterCityFromSupervisorWithForce(cityPath, stdout, stderr, "gc stop", force); handled {
 		if code != 0 {
 			return code
 		}
 		if supervisorAliveHook() != 0 {
-			stopCityManagedBeadsProviderIfRunning(cityPath, stderr)
+			if !stopCityManagedBeadsProviderAfterSuccessfulStop(cityPath, stderr) {
+				return 1
+			}
+			warnInvalidConfigAfterSuccessfulStop(cityPath, stderr)
 			fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
 			return 0
 		}
@@ -82,8 +82,8 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		if stopManagedRuntimeWithoutConfig(cityPath, stdout, stderr) {
-			return 0
+		if handled, code := stopManagedRuntimeWithoutConfig(cityPath, err, stdout, stderr, force); handled {
+			return code
 		}
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -110,38 +110,28 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 }
 
 func resolveStopCityPath(args []string) (string, error) {
-	if len(args) == 0 &&
-		strings.TrimSpace(cityFlag) == "" &&
-		strings.TrimSpace(os.Getenv("GC_CITY")) == "" &&
-		strings.TrimSpace(os.Getenv("GC_CITY_PATH")) == "" &&
-		strings.TrimSpace(os.Getenv("GC_CITY_ROOT")) == "" &&
-		strings.TrimSpace(os.Getenv("GC_DIR")) == "" {
+	if len(args) == 0 {
 		return resolveCommandCity(nil)
 	}
-	if len(args) > 0 {
-		abs, err := filepath.Abs(args[0])
-		if err != nil {
-			return "", err
-		}
-		if cityPath, err := validateCityPath(abs); err == nil {
-			return cityPath, nil
-		}
-		return findCity(abs)
-	}
-	if strings.TrimSpace(cityFlag) != "" {
-		return validateCityPath(cityFlag)
-	}
-	if gcCity, ok := resolveExplicitCityPathEnv(); ok {
-		return gcCity, nil
-	}
-	if gcDirCity, ok := resolveCityPathFromGCDir(); ok {
-		return gcDirCity, nil
-	}
-	cwd, err := os.Getwd()
+	abs, err := filepath.Abs(args[0])
 	if err != nil {
 		return "", err
 	}
-	return findCity(cwd)
+	if cityPath, err := validateCityPath(abs); err == nil {
+		return cityPath, nil
+	}
+	ctx, ok, rigErr := resolveRigPathToContext(abs)
+	if rigErr == nil && ok {
+		return ctx.CityPath, nil
+	}
+	cityPath, findErr := findCity(abs)
+	if findErr == nil {
+		return cityPath, nil
+	}
+	if rigErr != nil {
+		return "", rigErr
+	}
+	return "", findErr
 }
 
 // defaultStopWallClockTimeout returns the wall-clock cap used by cmdStop
@@ -223,7 +213,7 @@ func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr i
 			return 1
 		}
 		// Controller handled the shutdown — still stop bead store below.
-		if err := shutdownBeadsProvider(cityPath); err != nil {
+		if err := shutdownBeadsProviderForStop(cityPath); err != nil {
 			fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
 		fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
@@ -269,7 +259,7 @@ func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr i
 	stopOrphans(sp, desired, cfg, store, graceTimeout, recorder, stdout, stderr)
 
 	// Stop bead store's backing service after agents.
-	if err := shutdownBeadsProvider(cityPath); err != nil {
+	if err := shutdownBeadsProviderForStop(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort stderr
 		// Non-fatal warning.
 	}
@@ -300,25 +290,76 @@ func markCityStopSessionSleepReason(store beads.Store, stderr io.Writer) {
 	}
 }
 
-func stopCityManagedBeadsProviderIfRunning(cityPath string, stderr io.Writer) {
+func stopCityManagedBeadsProviderAfterSuccessfulStop(cityPath string, stderr io.Writer) bool {
+	_, err := stopCityManagedBeadsProvider(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort stderr
+		return false
+	}
+	return true
+}
+
+func stopCityManagedBeadsProvider(cityPath string) (bool, error) {
 	if rawBeadsProvider(cityPath) != "bd" {
-		return
+		return false, nil
 	}
 	if currentManagedDoltPort(cityPath) == "" {
-		return
+		return false, nil
 	}
-	if err := shutdownBeadsProvider(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort warning
+	return true, shutdownBeadsProviderForStop(cityPath)
+}
+
+var shutdownBeadsProviderForStop = shutdownBeadsProvider
+
+func stopManagedRuntimeWithoutConfig(cityPath string, cfgErr error, stdout, stderr io.Writer, force bool) (bool, int) {
+	controllerStopped, controllerErr := stopStandaloneControllerWithoutConfig(cityPath, stdout, force)
+	if controllerErr != nil {
+		fmt.Fprintf(stderr, "gc stop: %v\n", controllerErr) //nolint:errcheck // best-effort stderr
+		return true, 1
+	}
+	stopped, stopErr := stopCityManagedBeadsProvider(cityPath)
+	if stopErr != nil {
+		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", stopErr) //nolint:errcheck // best-effort stderr
+		return true, 1
+	}
+	if !controllerStopped && !stopped {
+		return false, 0
+	}
+	warnInvalidConfigStopSuccess(cfgErr, stderr)
+	fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
+	return true, 0
+}
+
+func stopStandaloneControllerWithoutConfig(cityPath string, stdout io.Writer, force bool) (bool, error) {
+	if tryStopControllerWithForce(cityPath, stdout, force) {
+		if err := waitForStandaloneControllerStop(cityPath, supervisorCityStopTimeout(cityPath)); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, ".gc")); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("probing standalone controller runtime dir: %w", err)
+	}
+	if err := waitForStandaloneControllerStop(cityPath, 0); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func warnInvalidConfigAfterSuccessfulStop(cityPath string, stderr io.Writer) {
+	if _, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard); err != nil {
+		warnInvalidConfigStopSuccess(err, stderr)
 	}
 }
 
-func stopManagedRuntimeWithoutConfig(cityPath string, stdout, stderr io.Writer) bool {
-	if currentManagedDoltPort(cityPath) == "" {
-		return false
+func warnInvalidConfigStopSuccess(err error, stderr io.Writer) {
+	if err == nil {
+		return
 	}
-	stopCityManagedBeadsProviderIfRunning(cityPath, stderr)
-	fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
-	return true
+	fmt.Fprintf(stderr, "gc stop: stopped city despite invalid config: %v\n", err) //nolint:errcheck // best-effort stderr
 }
 
 // stopOrphans stops sessions that are not in the desired set. Used by gc stop

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -59,13 +60,31 @@ const sleepReasonCityStop = "city-stop"
 // is used. force=true skips the interrupt grace period (gracefulStopAll
 // runs with timeout=0, going straight to kill).
 func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Duration, force bool) int {
-	cityPath, err := resolveCommandCity(args)
+	cityPath, err := resolveStopCityPath(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+
+	if handled, code := unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, "gc stop", supervisorUnregisterOptions{
+		Force:                 force,
+		WaitForControllerStop: false,
+	}); handled {
+		if code != 0 {
+			return code
+		}
+		if supervisorAliveHook() != 0 {
+			stopCityManagedBeadsProviderIfRunning(cityPath, stderr)
+			fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
+			return 0
+		}
+	}
+
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
+		if stopManagedRuntimeWithoutConfig(cityPath, stdout, stderr) {
+			return 0
+		}
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -88,6 +107,41 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 		fmt.Fprintf(stderr, "gc stop: timed out after %s; some sessions may not have stopped — retry with --force if stop is wedged, or raise --timeout for large stop sets\n", wallClockCap) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+}
+
+func resolveStopCityPath(args []string) (string, error) {
+	if len(args) == 0 &&
+		strings.TrimSpace(cityFlag) == "" &&
+		strings.TrimSpace(os.Getenv("GC_CITY")) == "" &&
+		strings.TrimSpace(os.Getenv("GC_CITY_PATH")) == "" &&
+		strings.TrimSpace(os.Getenv("GC_CITY_ROOT")) == "" &&
+		strings.TrimSpace(os.Getenv("GC_DIR")) == "" {
+		return resolveCommandCity(nil)
+	}
+	if len(args) > 0 {
+		abs, err := filepath.Abs(args[0])
+		if err != nil {
+			return "", err
+		}
+		if cityPath, err := validateCityPath(abs); err == nil {
+			return cityPath, nil
+		}
+		return findCity(abs)
+	}
+	if strings.TrimSpace(cityFlag) != "" {
+		return validateCityPath(cityFlag)
+	}
+	if gcCity, ok := resolveExplicitCityPathEnv(); ok {
+		return gcCity, nil
+	}
+	if gcDirCity, ok := resolveCityPathFromGCDir(); ok {
+		return gcDirCity, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return findCity(cwd)
 }
 
 // defaultStopWallClockTimeout returns the wall-clock cap used by cmdStop
@@ -158,17 +212,6 @@ func ceilDiv(n, d int) int {
 // can apply a wall-clock cap by running it in a goroutine.
 func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr io.Writer) int {
 	cityName := loadedCityName(cfg, cityPath)
-
-	if handled, code := unregisterCityFromSupervisorWithForce(cityPath, stdout, stderr, "gc stop", force); handled {
-		if code != 0 {
-			return code
-		}
-		if supervisorAliveHook() != 0 {
-			stopCityManagedBeadsProviderIfRunning(cityPath, stderr)
-			fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
-			return 0
-		}
-	}
 
 	store, _ := openCityStoreAt(cityPath)
 	markCityStopSessionSleepReason(store, stderr)
@@ -267,6 +310,15 @@ func stopCityManagedBeadsProviderIfRunning(cityPath string, stderr io.Writer) {
 	if err := shutdownBeadsProvider(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort warning
 	}
+}
+
+func stopManagedRuntimeWithoutConfig(cityPath string, stdout, stderr io.Writer) bool {
+	if currentManagedDoltPort(cityPath) == "" {
+		return false
+	}
+	stopCityManagedBeadsProviderIfRunning(cityPath, stderr)
+	fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
+	return true
 }
 
 // stopOrphans stops sessions that are not in the desired set. Used by gc stop

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -367,6 +367,395 @@ func TestCmdStopForceEscalatesInProgressControllerStop(t *testing.T) {
 	}
 }
 
+func TestCmdStopExplicitRegisteredRigPathUsesSharedResolver(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := setupCity(t, "stop-registered-rig")
+	rigDir := filepath.Join(t.TempDir(), "registered-rig")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toml := fmt.Sprintf("[workspace]\nname = \"stop-registered-rig\"\n\n[beads]\nprovider = \"file\"\n\n[[agent]]\nname = \"worker\"\n\n[[rigs]]\nname = \"registered-rig\"\npath = %q\n", rigDir)
+	writeRigAnywhereCityToml(t, cityDir, toml)
+	registerCityForRigResolution(t, gcHome, cityDir, "stop-registered-rig")
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 0 },
+		func(string) (bool, string, bool) { return false, "", false },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	var gotCityPath string
+	sessionProviderForStopCity = func(_ *config.City, cityPath string) runtime.Provider {
+		gotCityPath = cityPath
+		return runtime.NewFake()
+	}
+
+	var stdout, stderr lockedBuffer
+	code := cmdStop([]string{rigDir}, &stdout, &stderr, 0, false)
+	if code != 0 {
+		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	assertSameTestPath(t, gotCityPath, cityDir)
+}
+
+func TestCmdStopExplicitCityPathIgnoresUnrelatedRegisteredCityLoadErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		arg  func(string) string
+	}{
+		{
+			name: "city_root",
+			arg:  func(cityDir string) string { return cityDir },
+		},
+		{
+			name: "inside_city",
+			arg: func(cityDir string) string {
+				return filepath.Join(cityDir, "nested", "work")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags(t)
+			clearInheritedBeadsEnv(t)
+			gcHome := t.TempDir()
+			t.Setenv("GC_HOME", gcHome)
+			t.Setenv("GC_CITY", "")
+			t.Setenv("GC_CITY_PATH", "")
+			t.Setenv("GC_CITY_ROOT", "")
+			t.Setenv("GC_DIR", "")
+			t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+			cityDir := setupCity(t, "stop-explicit-city")
+			writeRigAnywhereCityToml(t, cityDir, "[workspace]\nname = \"stop-explicit-city\"\n\n[beads]\nprovider = \"file\"\n\n[[agent]]\nname = \"worker\"\n")
+			arg := tt.arg(cityDir)
+			if err := os.MkdirAll(arg, 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			badCity := setupCity(t, "broken-registered-city")
+			registerCityForRigResolution(t, gcHome, badCity, "broken-registered-city")
+			if err := os.WriteFile(filepath.Join(badCity, "city.toml"), []byte("[workspace\nname = \"broken\"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			withSupervisorTestHooks(
+				t,
+				func(_, _ io.Writer) int { return 0 },
+				func(_, _ io.Writer) int { return 0 },
+				func() int { return 0 },
+				func(string) (bool, string, bool) { return false, "", false },
+				20*time.Millisecond,
+				time.Millisecond,
+			)
+
+			oldFactory := sessionProviderForStopCity
+			t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+			var gotCityPath string
+			sessionProviderForStopCity = func(_ *config.City, cityPath string) runtime.Provider {
+				gotCityPath = cityPath
+				return runtime.NewFake()
+			}
+
+			var stdout, stderr lockedBuffer
+			code := cmdStop([]string{arg}, &stdout, &stderr, 0, false)
+			if code != 0 {
+				t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			assertSameTestPath(t, gotCityPath, cityDir)
+			if strings.Contains(stderr.String(), "loading registered city rig bindings") {
+				t.Fatalf("stderr = %q, want unrelated registered-city load error ignored for explicit city path", stderr.String())
+			}
+		})
+	}
+}
+
+func TestCmdStopSupervisorManagedInvalidCityTomlWaitsForControllerStop(t *testing.T) {
+	resetFlags(t)
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := filepath.Join(t.TempDir(), "invalid-supervisor-city")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace\nname = \"broken\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := registryAt(t, gcHome)
+	if err := reg.Register(cityDir, "invalid-supervisor-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", true },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+	var waitedPath string
+	waitForSupervisorControllerStopHook = func(path string, _ time.Duration) error {
+		waitedPath = path
+		return nil
+	}
+
+	var stdout, stderr lockedBuffer
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, time.Second, false)
+	if code != 0 {
+		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	assertSameTestPath(t, waitedPath, cityDir)
+	if !strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout missing city stopped message: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid config") {
+		t.Fatalf("stderr = %q, want invalid config warning", stderr.String())
+	}
+}
+
+func TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails(t *testing.T) {
+	resetFlags(t)
+	cityDir := setupInvalidConfigManagedRuntime(t)
+	gcHome := os.Getenv("GC_HOME")
+	reg := registryAt(t, gcHome)
+	if err := reg.Register(cityDir, "invalid-supervisor-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", true },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+	waitForSupervisorControllerStopHook = func(string, time.Duration) error {
+		return nil
+	}
+	overrideShutdownBeadsProviderForStop(t, func(path string) error {
+		assertSameTestPath(t, path, cityDir)
+		return fmt.Errorf("provider-stop-failed")
+	})
+
+	var stdout, stderr lockedBuffer
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, time.Second, false)
+	if code != 1 {
+		t.Fatalf("cmdStop() = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout = %q, did not want success message", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "bead store") || !strings.Contains(stderr.String(), "provider-stop-failed") {
+		t.Fatalf("stderr = %q, want bead-store shutdown error", stderr.String())
+	}
+}
+
+func TestCmdStopInvalidConfigManagedRuntimeStopsAfterVerifiedShutdown(t *testing.T) {
+	resetFlags(t)
+	cityDir := setupInvalidConfigManagedRuntime(t)
+	var shutdowns int
+	overrideShutdownBeadsProviderForStop(t, func(path string) error {
+		shutdowns++
+		assertSameTestPath(t, path, cityDir)
+		return nil
+	})
+
+	var stdout, stderr lockedBuffer
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, 0, false)
+	if code != 0 {
+		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout missing city stopped message: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid config") {
+		t.Fatalf("stderr = %q, want invalid config warning", stderr.String())
+	}
+	if shutdowns != 1 {
+		t.Fatalf("shutdown calls = %d, want 1", shutdowns)
+	}
+}
+
+func TestCmdStopInvalidConfigManagedRuntimeStopsStandaloneController(t *testing.T) {
+	resetFlags(t)
+	cityDir := setupInvalidConfigManagedRuntime(t)
+	stopCommands := startAcknowledgingStandaloneController(t, cityDir)
+	var shutdowns int
+	overrideShutdownBeadsProviderForStop(t, func(path string) error {
+		shutdowns++
+		assertSameTestPath(t, path, cityDir)
+		return nil
+	})
+
+	var stdout, stderr lockedBuffer
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, 0, false)
+	if code != 0 {
+		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	select {
+	case cmd := <-stopCommands:
+		if cmd != "stop" {
+			t.Fatalf("controller command = %q, want stop", cmd)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("controller did not receive stop command; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if shutdowns != 1 {
+		t.Fatalf("shutdown calls = %d, want 1", shutdowns)
+	}
+	if !strings.Contains(stdout.String(), "Controller stopping...") {
+		t.Fatalf("stdout missing controller stop message: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout missing city stopped message: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid config") {
+		t.Fatalf("stderr = %q, want invalid config warning", stderr.String())
+	}
+}
+
+func TestCmdStopInvalidConfigManagedRuntimeFailsWhenShutdownFails(t *testing.T) {
+	resetFlags(t)
+	cityDir := setupInvalidConfigManagedRuntime(t)
+	var shutdowns int
+	overrideShutdownBeadsProviderForStop(t, func(path string) error {
+		shutdowns++
+		assertSameTestPath(t, path, cityDir)
+		return fmt.Errorf("provider-stop-failed")
+	})
+
+	var stdout, stderr lockedBuffer
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, 0, false)
+	if code != 1 {
+		t.Fatalf("cmdStop() = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout = %q, did not want success message", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "bead store") || !strings.Contains(stderr.String(), "provider-stop-failed") {
+		t.Fatalf("stderr = %q, want bead-store shutdown error", stderr.String())
+	}
+	if shutdowns != 1 {
+		t.Fatalf("shutdown calls = %d, want 1", shutdowns)
+	}
+}
+
+func setupInvalidConfigManagedRuntime(t *testing.T) string {
+	t.Helper()
+
+	t.Setenv("GC_HOME", shortSocketTempDir(t, "gc-home-"))
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_DOLT", "")
+
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace\nname = \"broken\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	state := doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      ln.Addr().(*net.TCPAddr).Port,
+		DataDir:   filepath.Join(cityDir, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := writeDoltState(cityDir, state); err != nil {
+		t.Fatalf("writeDoltState: %v", err)
+	}
+
+	return cityDir
+}
+
+func overrideShutdownBeadsProviderForStop(t *testing.T, fn func(string) error) {
+	t.Helper()
+	old := shutdownBeadsProviderForStop
+	shutdownBeadsProviderForStop = fn
+	t.Cleanup(func() { shutdownBeadsProviderForStop = old })
+}
+
+func startAcknowledgingStandaloneController(t *testing.T, cityDir string) <-chan string {
+	t.Helper()
+
+	lock, err := acquireControllerLock(cityDir)
+	if err != nil {
+		t.Fatalf("acquireControllerLock: %v", err)
+	}
+	sockPath := controllerSocketPath(cityDir)
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen controller socket: %v", err)
+	}
+	commands := make(chan string, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := lis.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck // best-effort test cleanup
+		buf := make([]byte, 64)
+		n, err := conn.Read(buf)
+		if err != nil {
+			return
+		}
+		commands <- strings.TrimSpace(string(buf[:n]))
+		_, _ = conn.Write([]byte("ok\n"))
+		_ = lis.Close()
+		_ = os.Remove(sockPath)
+		_ = lock.Close()
+	}()
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = os.Remove(sockPath)
+		_ = lock.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+	})
+	return commands
+}
+
 func TestDefaultStopWallClockTimeoutScalesWithConfiguredStopTargets(t *testing.T) {
 	origStop := stopPerTargetTimeoutDefault
 	origMargin := interruptPerTargetTimeoutMargin
@@ -394,7 +783,7 @@ func TestDefaultStopWallClockTimeoutScalesWithConfiguredStopTargets(t *testing.T
 	}
 }
 
-func TestStopCityManagedBeadsProviderIfRunningStopsDefaultBD(t *testing.T) {
+func TestStopCityManagedBeadsProviderAfterSuccessfulStopStopsDefaultBD(t *testing.T) {
 	skipSlowCmdGCTest(t, "exercises managed bd provider shutdown; run make test-cmd-gc-process for full coverage")
 	t.Setenv("GC_BEADS", "bd")
 
@@ -437,7 +826,9 @@ func TestStopCityManagedBeadsProviderIfRunningStopsDefaultBD(t *testing.T) {
 	}
 
 	var stderr lockedBuffer
-	stopCityManagedBeadsProviderIfRunning(cityDir, &stderr)
+	if !stopCityManagedBeadsProviderAfterSuccessfulStop(cityDir, &stderr) {
+		t.Fatalf("stopCityManagedBeadsProviderAfterSuccessfulStop returned false; stderr=%q", stderr.String())
+	}
 	if stderr.String() != "" {
 		t.Fatalf("unexpected stderr: %q", stderr.String())
 	}

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -435,20 +435,16 @@ func statusDisplayText(status string) string {
 }
 
 type supervisorUnregisterOptions struct {
-	Force                 bool
-	WaitForControllerStop bool
+	Force bool
 }
 
 func unregisterCityFromSupervisor(cityPath string, stdout, stderr io.Writer) (bool, int) {
-	return unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, "gc unregister", supervisorUnregisterOptions{
-		WaitForControllerStop: true,
-	})
+	return unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, "gc unregister", supervisorUnregisterOptions{})
 }
 
 func unregisterCityFromSupervisorWithForce(cityPath string, stdout, stderr io.Writer, commandName string, force bool) (bool, int) {
 	return unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, commandName, supervisorUnregisterOptions{
-		Force:                 force,
-		WaitForControllerStop: true,
+		Force: force,
 	})
 }
 
@@ -502,9 +498,6 @@ func unregisterCityFromSupervisorWithOptions(cityPath string, stdout, stderr io.
 				fmt.Fprintf(stderr, "%s: %v; restored registration for '%s'\n", commandName, err, entry.EffectiveName()) //nolint:errcheck
 			}
 			return true, 1
-		}
-		if !opts.WaitForControllerStop {
-			return true, 0
 		}
 		if err := waitForSupervisorControllerStopHook(cityPath, supervisorCityStopTimeout(cityPath)); err != nil {
 			if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -434,11 +434,25 @@ func statusDisplayText(status string) string {
 	}
 }
 
+type supervisorUnregisterOptions struct {
+	Force                 bool
+	WaitForControllerStop bool
+}
+
 func unregisterCityFromSupervisor(cityPath string, stdout, stderr io.Writer) (bool, int) {
-	return unregisterCityFromSupervisorWithForce(cityPath, stdout, stderr, "gc unregister", false)
+	return unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, "gc unregister", supervisorUnregisterOptions{
+		WaitForControllerStop: true,
+	})
 }
 
 func unregisterCityFromSupervisorWithForce(cityPath string, stdout, stderr io.Writer, commandName string, force bool) (bool, int) {
+	return unregisterCityFromSupervisorWithOptions(cityPath, stdout, stderr, commandName, supervisorUnregisterOptions{
+		Force:                 force,
+		WaitForControllerStop: true,
+	})
+}
+
+func unregisterCityFromSupervisorWithOptions(cityPath string, stdout, stderr io.Writer, commandName string, opts supervisorUnregisterOptions) (bool, int) {
 	cityPath = normalizePathForCompare(cityPath)
 	entry, registered, err := registeredCityEntry(cityPath)
 	if err != nil {
@@ -450,7 +464,7 @@ func unregisterCityFromSupervisorWithForce(cityPath string, stdout, stderr io.Wr
 	}
 
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
-	if force && supervisorAliveHook() != 0 {
+	if opts.Force && supervisorAliveHook() != 0 {
 		tryStopControllerWithForce(cityPath, io.Discard, true)
 	}
 	if err := reg.Unregister(cityPath); err != nil {
@@ -488,6 +502,9 @@ func unregisterCityFromSupervisorWithForce(cityPath string, stdout, stderr io.Wr
 				fmt.Fprintf(stderr, "%s: %v; restored registration for '%s'\n", commandName, err, entry.EffectiveName()) //nolint:errcheck
 			}
 			return true, 1
+		}
+		if !opts.WaitForControllerStop {
+			return true, 0
 		}
 		if err := waitForSupervisorControllerStopHook(cityPath, supervisorCityStopTimeout(cityPath)); err != nil {
 			if reErr := reg.Register(entry.Path, entry.EffectiveName()); reErr != nil {


### PR DESCRIPTION
Lets gc stop unregister and stop managed runtime state before loading a broken city config, so bad configuration or cache state does not block cleanup of the city supervisor and managed Dolt runtime.