### PR TITLE
fix(dolt-pack): always export DOLT_CLI_PASSWORD so non-interactive sql -q works

### DIFF
--- a/examples/dolt/commands/sql/run.sh
+++ b/examples/dolt/commands/sql/run.sh
@@ -36,9 +36,13 @@ if is_running; then
     host="127.0.0.1"
   fi
   args="--host $host --port $GC_DOLT_PORT --user $GC_DOLT_USER --no-tls"
-  if [ -n "$GC_DOLT_PASSWORD" ]; then
-    export DOLT_CLI_PASSWORD="$GC_DOLT_PASSWORD"
-  fi
+  # Always export DOLT_CLI_PASSWORD so dolt's credential parser skips
+  # the TTY password prompt. When GC_DOLT_PASSWORD is empty (the
+  # managed-local default — root has no password), an unset env var
+  # causes `dolt sql -q "..."` to fail with "inappropriate ioctl for
+  # device" under non-interactive callers (CI, scripts, automation).
+  # Exporting empty satisfies dolt without changing auth outcomes.
+  export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
   exec dolt $args sql "$@"
 else
   # Embedded mode — find first database directory.

--- a/examples/dolt/sql_test.go
+++ b/examples/dolt/sql_test.go
@@ -7,26 +7,70 @@
 package dolt_test
 
 import (
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 )
+
+// startAcceptingListener binds 127.0.0.1:0 and accepts connections in
+// a background goroutine until cleanup is invoked. The connections are
+// not used — the listener exists only so the wrapper script's
+// `is_running()` TCP probe (nc -z / /dev/tcp) succeeds, steering it
+// into the connected branch where the password-forwarding bug lives.
+func startAcceptingListener(t *testing.T) (port int, cleanup func()) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	port = l.Addr().(*net.TCPAddr).Port
+	cleanup = func() {
+		_ = l.Close()
+		wg.Wait()
+	}
+	return port, cleanup
+}
 
 const sqlScript = "commands/sql/run.sh"
 
 // writeFakeDolt installs a stub `dolt` binary in dir that records
-// argv (one arg per line) to a file inside dir and exits 0. Returns
-// the argv-log path. Used to assert the wrapper script forwards args
-// verbatim without booting a real Dolt server.
+// argv (one arg per line) to argv.log and, when DOLT_CLI_PASSWORD is
+// exported (even to the empty string), creates a passwd_exported
+// marker file. Returns the argv-log path; pass it to readArgv. The
+// marker file path is `<dir>/passwd_exported` — tests that need to
+// assert password-env behavior stat it directly.
 func writeFakeDolt(t *testing.T, dir string) string {
 	t.Helper()
 	argvFile := filepath.Join(dir, "argv.log")
+	pwMarker := filepath.Join(dir, "passwd_exported")
+	// `${DOLT_CLI_PASSWORD+set}` expands to "set" iff the variable is
+	// defined (even when the value is empty). Distinguishing "exported
+	// to empty" from "unset" is the whole point of the marker — the
+	// password-prompt bug fires only in the unset case.
 	body := `#!/bin/sh
 for a in "$@"; do
   printf '%s\n' "$a"
 done > "` + argvFile + `"
+if [ "${DOLT_CLI_PASSWORD+set}" = "set" ]; then
+  : > "` + pwMarker + `"
+fi
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
@@ -135,5 +179,88 @@ func TestSQLScriptForwardsQueryArgs(t *testing.T) {
 	}
 	if argv[sqlIdx+1] != "-q" || argv[sqlIdx+2] != "SELECT 1" {
 		t.Fatalf("argv after `sql` = %v; want [-q, SELECT 1] (the wrapper is dropping trailing args)", argv[sqlIdx+1:])
+	}
+}
+
+// TestSQLScriptConnectedBranchExportsPassword pins the connected-branch
+// behavior under test: when GC_DOLT_PASSWORD is
+// empty (the managed-local-Dolt default — root has no password), the
+// wrapper must still export DOLT_CLI_PASSWORD so dolt's credential
+// parser does not fall back to a TTY password prompt. Without the
+// export, `gc dolt sql -q "..."` exits with "Failed to parse
+// credentials: inappropriate ioctl for device" and downstream
+// non-interactive callers fail.
+func TestSQLScriptConnectedBranchExportsPassword(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, sqlScript)
+
+	binDir := t.TempDir()
+	argvFile := writeFakeDolt(t, binDir)
+	pwMarker := filepath.Join(binDir, "passwd_exported")
+
+	port, stop := startAcceptingListener(t)
+	t.Cleanup(stop)
+
+	cityPath := t.TempDir()
+
+	// GC_DOLT_HOST forces the wrapper into the remote-probe branch
+	// where it sets --host/--port and (per the contract under test)
+	// must export DOLT_CLI_PASSWORD before exec. The TCP listener
+	// satisfies the nc -z probe so is_running() returns 0.
+	cmd := exec.Command("sh", script, "-q", "SELECT 1")
+	cmd.Env = append(filteredEnv("PATH",
+		"GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR",
+		"DOLT_CLI_PASSWORD",
+		"GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+strconv.Itoa(port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sql.sh exited non-zero: %v\noutput: %s", err, out)
+	}
+
+	argv := readArgv(t, argvFile)
+	if len(argv) == 0 {
+		t.Fatalf("fake dolt was never invoked; output: %s", out)
+	}
+
+	// Confirm we landed in the connected branch (--host before sql)
+	// before asserting on the password export — otherwise a probe
+	// regression that flips us back to embedded would silently make
+	// the password assertion meaningless.
+	hostIdx, sqlIdx := -1, -1
+	for i, a := range argv {
+		switch a {
+		case "--host":
+			if hostIdx == -1 {
+				hostIdx = i
+			}
+		case "sql":
+			if sqlIdx == -1 {
+				sqlIdx = i
+			}
+		}
+	}
+	if hostIdx == -1 || hostIdx >= sqlIdx {
+		t.Fatalf("argv did not exercise the connected branch (--host before sql): %v", argv)
+	}
+	if sqlIdx+2 >= len(argv) || argv[sqlIdx+1] != "-q" || argv[sqlIdx+2] != "SELECT 1" {
+		t.Fatalf("argv after `sql` = %v; want [-q, SELECT 1]", argv[sqlIdx+1:])
+	}
+
+	if _, err := os.Stat(pwMarker); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("DOLT_CLI_PASSWORD was not exported when GC_DOLT_PASSWORD is empty; dolt would fall back to a TTY password prompt and fail with 'inappropriate ioctl for device'")
+		}
+		t.Fatalf("stat password marker: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Maintainer follow-up for #2098. The original PR is an open cross-repository fork PR with maintainer edits disabled, so this workflow is carrying the approved change set through a maintainer-owned merge surface instead of mutating the contributor branch.

This preserves the contributor-authored fix for non-interactive `gc dolt sql -q` calls when the managed-local Dolt password is empty. The final reviewed patch always exports `DOLT_CLI_PASSWORD`, defaulting to an empty value, so Dolt does not fall back to a TTY password prompt in CI, scripts, or diagnostic tooling.

## Original PR

- Original PR: https://github.com/gastownhall/gascity/pull/2098
- Original title: fix(dolt-pack): always export DOLT_CLI_PASSWORD so non-interactive sql -q works
- Original state at adoption finalization: OPEN
- Configured base: `main`
- Original GitHub base: `main`
- Base mismatch: none
- Original contributor head: `78836e6342090faf471e613a1b152b57eb4408ff`
- Final reviewed head: `e8cb8447b6335e06e9a04c9b4a8803f2d2db2a12`

## Review And Validation

The adoption review approved the patch without required maintainer changes. It validated that the connected Dolt SQL path exports `DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"`, that the regression test forces the connected branch and strips ambient password state, and that the wrapper now matches the empty-export pattern used by sibling Dolt pack commands.

Pre-follow-up GitHub checks on the original PR head were visible and passing for the required CI surface, including CI, CodeQL, and Mac Regression. This follow-up PR should run the same visible checks on the maintainer-owned branch before merge-ready handoff.

## Authorship

The contributor commit author is preserved:

- `e8cb8447b6335e06e9a04c9b4a8803f2d2db2a12` — Zook Bot <275398848+zook-bot@users.noreply.github.com>

Adopted via `/adopt-pr` workflow for `ga-85qyzkp`.
