### PR TITLE
fix(reload): address soft reload review findings

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -809,6 +809,12 @@ func (cr *CityRuntime) tick(
 		cr.stderr,
 	)
 
+	if manualReload != nil && manualReload.soft && manualReloadCompleted &&
+		(manualReply.Outcome == reloadOutcomeApplied || manualReply.Outcome == reloadOutcomeNoChange) {
+		cr.applySoftReloadAcceptance(&manualReply, result.State, sessionBeads)
+		sessionBeads = cr.loadSessionBeadSnapshot()
+	}
+
 	// Bead-driven reconciliation (requires bead store / drain tracker).
 	if cr.sessionDrains != nil {
 		cr.beadReconcileTick(ctx, result, sessionBeads, trace)
@@ -1229,18 +1235,6 @@ func (cr *CityRuntime) reloadConfigTraced(
 		trace.syncArms(time.Now().UTC(), nextCfg)
 	}
 
-	if cr.activeReload != nil && cr.activeReload.soft {
-		cityName := cr.cityName
-		if cityName == "" {
-			cityName = config.EffectiveCityName(nextCfg, "")
-		}
-		desired := buildDesiredState(cityName, cr.cityPath, time.Now().UTC(), nextCfg, cr.sp, cr.cityBeadStore(), cr.stderr)
-		accepted := acceptConfigDriftAcrossSessions(cr.cityBeadStore(), desired.State, cr.stderr)
-		if accepted > 0 {
-			fmt.Fprintf(cr.stdout, "%s: soft reload: accepted config drift on %d session(s)\n", cr.logPrefix, accepted) //nolint:errcheck // best-effort stdout
-		}
-	}
-
 	message := fmt.Sprintf("Config reloaded: %s (rev %s)",
 		configReloadSummary(oldAgentCount, oldRigCount, len(nextCfg.Agents), len(nextCfg.Rigs)),
 		shortRev(result.Revision))
@@ -1255,6 +1249,24 @@ func (cr *CityRuntime) reloadConfigTraced(
 		Revision: result.Revision,
 		Warnings: warnings,
 	}
+}
+
+func (cr *CityRuntime) applySoftReloadAcceptance(
+	reply *reloadControlReply,
+	desired map[string]TemplateParams,
+	sessionBeads *sessionBeadSnapshot,
+) {
+	if reply == nil {
+		return
+	}
+	result := acceptConfigDriftAcrossSessions(cr.cityBeadStore(), desired, sessionBeads, cr.sp, cr.sessionDrains, cr.stderr)
+	accepted := result.Updated
+	reply.AcceptedDriftCount = &accepted
+	for _, warning := range result.warnings() {
+		reply.Warnings = append(reply.Warnings, warning)
+		fmt.Fprintf(cr.stderr, "%s: warning: %s\n", cr.logPrefix, warning) //nolint:errcheck // best-effort stderr
+	}
+	fmt.Fprintf(cr.stdout, "%s: soft reload: accepted config drift on %d session(s)\n", cr.logPrefix, result.Updated) //nolint:errcheck // best-effort stdout
 }
 
 func lockedConfigName(cfg *config.City, cityPath string) string {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -3656,6 +3656,129 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeSoftReloadAcceptsDriftForAppliedAndNoChange(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		mutateConfig   bool
+		storedCommand  string
+		desiredCommand string
+		wantOutcome    reloadOutcome
+		wantAccepted   int
+	}{
+		{
+			name:           "applied",
+			mutateConfig:   true,
+			storedCommand:  "old-cmd",
+			desiredCommand: "new-cmd",
+			wantOutcome:    reloadOutcomeApplied,
+			wantAccepted:   1,
+		},
+		{
+			name:           "no-change-drift",
+			storedCommand:  "old-cmd",
+			desiredCommand: "new-cmd",
+			wantOutcome:    reloadOutcomeNoChange,
+			wantAccepted:   1,
+		},
+		{
+			name:           "no-change-clean",
+			storedCommand:  "old-cmd",
+			desiredCommand: "old-cmd",
+			wantOutcome:    reloadOutcomeNoChange,
+			wantAccepted:   0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			tomlPath := filepath.Join(cityPath, "city.toml")
+			writeCityRuntimeSoftReloadConfig(t, tomlPath, "")
+
+			cfg, configRev := loadCityRuntimeControllerConfig(t, cityPath)
+			if tc.mutateConfig {
+				writeCityRuntimeSoftReloadConfig(t, tomlPath, "1s")
+			}
+
+			store := beads.NewMemStore()
+			oldHash := runtime.CoreFingerprint(runtime.Config{Command: tc.storedCommand})
+			sessionBead, err := store.Create(beads.Bead{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name":        "worker",
+					"template":            "worker",
+					"started_config_hash": oldHash,
+					"generation":          "1",
+					"state":               "active",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create(session): %v", err)
+			}
+
+			sp := runtime.NewFake()
+			if err := sp.Start(context.Background(), "worker", runtime.Config{Command: tc.storedCommand}); err != nil {
+				t.Fatalf("Start(worker): %v", err)
+			}
+			doneCh := make(chan reloadControlReply, 1)
+			dirty := &atomic.Bool{}
+			dirty.Store(true)
+			var stdout, stderr bytes.Buffer
+			cr := newTestCityRuntime(t, CityRuntimeParams{
+				CityPath:    cityPath,
+				CityName:    "test-city",
+				TomlPath:    tomlPath,
+				ConfigRev:   configRev,
+				ConfigDirty: dirty,
+				Cfg:         cfg,
+				SP:          sp,
+				BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+					return DesiredStateResult{State: map[string]TemplateParams{
+						"worker": {Command: tc.desiredCommand, SessionName: "worker", TemplateName: "worker"},
+					}}
+				},
+				Dops:   newDrainOps(sp),
+				Rec:    events.Discard,
+				Stdout: &stdout,
+				Stderr: &stderr,
+			})
+			cr.od = nil
+			cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+			cs.cityBeadStore = store
+			cr.setControllerState(cs)
+			cr.sessionDrains = newDrainTracker()
+			cr.activeReload = &reloadRequest{soft: true, doneCh: doneCh}
+			lastProviderName := "fake"
+			var prevPoolRunning map[string]bool
+
+			cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "reload")
+
+			select {
+			case reply := <-doneCh:
+				if reply.Outcome != tc.wantOutcome {
+					t.Fatalf("reply.Outcome = %q, want %q; stderr=%s stdout=%s", reply.Outcome, tc.wantOutcome, stderr.String(), stdout.String())
+				}
+				if reply.AcceptedDriftCount == nil || *reply.AcceptedDriftCount != tc.wantAccepted {
+					t.Fatalf("AcceptedDriftCount = %v, want %d", reply.AcceptedDriftCount, tc.wantAccepted)
+				}
+			default:
+				t.Fatal("manual soft reload did not reply")
+			}
+			updated, err := store.Get(sessionBead.ID)
+			if err != nil {
+				t.Fatalf("Get(session): %v", err)
+			}
+			wantHash := runtime.CoreFingerprint(runtime.Config{Command: tc.desiredCommand})
+			if updated.Metadata["started_config_hash"] != wantHash {
+				t.Fatalf("started_config_hash = %q, want %q", updated.Metadata["started_config_hash"], wantHash)
+			}
+			if cr.activeReload != nil {
+				t.Fatal("activeReload was not cleared")
+			}
+		})
+	}
+}
+
 func TestCityRuntimeReloadRestartsConfigWatcherWithNewPackTargets(t *testing.T) {
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond
@@ -4606,6 +4729,44 @@ func writeCityRuntimeConfig(t *testing.T, tomlPath, provider string) {
 	t.Helper()
 	clearInheritedBeadsEnv(t)
 	writeCityRuntimeConfigNamed(t, tomlPath, "test-city", provider)
+}
+
+func writeCityRuntimeSoftReloadConfig(t *testing.T, tomlPath, shutdownTimeout string) {
+	t.Helper()
+	clearInheritedBeadsEnv(t)
+	requireNoLeakedDoltAfterForPaths(t, filepath.Dir(tomlPath))
+	skippedOrders := []string{
+		"beads-health",
+		"cross-rig-deps",
+		"gate-sweep",
+		"mol-dog-jsonl",
+		"mol-dog-reaper",
+		"order-tracking-sweep",
+		"orphan-sweep",
+		"prune-branches",
+		"spawn-storm-detect",
+		"wisp-compact",
+	}
+	var buf strings.Builder
+	buf.WriteString("[workspace]\nname = \"test-city\"\n\n")
+	buf.WriteString("[beads]\nprovider = \"file\"\n\n")
+	buf.WriteString("[session]\nprovider = \"fake\"\n\n")
+	buf.WriteString("[orders]\nskip = [")
+	for i, name := range skippedOrders {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(&buf, "%q", name)
+	}
+	buf.WriteString("]\n")
+	if shutdownTimeout != "" {
+		buf.WriteString("\n[daemon]\nshutdown_timeout = \"")
+		buf.WriteString(shutdownTimeout)
+		buf.WriteString("\"\n")
+	}
+	if err := os.WriteFile(tomlPath, []byte(buf.String()), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 }
 
 func loadCityRuntimeControllerConfig(t *testing.T, cityPath string) (*config.City, string) {

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -64,7 +64,9 @@ type reloadControlReply struct {
 	Message  string        `json:"message,omitempty"`
 	Revision string        `json:"revision,omitempty"`
 	Warnings []string      `json:"warnings,omitempty"`
-	Error    string        `json:"error,omitempty"`
+	// AcceptedDriftCount is set only for soft reload requests.
+	AcceptedDriftCount *int   `json:"accepted_drift_count,omitempty"`
+	Error              string `json:"error,omitempty"`
 }
 
 type reloadRequest struct {
@@ -92,12 +94,13 @@ config drift rules require them.
 With --soft, the controller accepts any detected per-session config
 drift instead of draining the drifted sessions: each open session's
 recorded config hash is updated to the hash the freshly reloaded
-config produces for it, so the immediately-following reconcile tick
-sees no drift and no config-drift drains fire. Useful when editing a
-running city's .gc/settings.json without disrupting in-flight work.
-Sessions whose template no longer maps to a configured agent are
-NOT updated; normal orphan/suspended drain handles them on the next
-tick.`,
+config produces for it, the matching hash breakdown is refreshed, and
+any already queued config-drift drain for that session is canceled. The
+immediately-following reconcile tick sees no drift and no config-drift
+drains fire. Useful when editing a running city's .gc/settings.json
+without disrupting in-flight work. Sessions whose template no longer
+maps to a configured agent are NOT updated; normal orphan/suspended
+drain handles them on the next tick.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			timeoutChanged := cmd.Flags().Changed("timeout")
@@ -155,6 +158,9 @@ func cmdReload(args []string, async bool, soft bool, timeoutValue string, timeou
 	case reloadOutcomeAccepted, reloadOutcomeApplied, reloadOutcomeNoChange:
 		if strings.TrimSpace(reply.Message) != "" {
 			fmt.Fprintln(stdout, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stdout
+		}
+		if soft && reply.AcceptedDriftCount != nil {
+			fmt.Fprintf(stdout, "soft reload: accepted config drift on %d session(s)\n", *reply.AcceptedDriftCount) //nolint:errcheck // best-effort stdout
 		}
 		for _, warning := range reply.Warnings {
 			fmt.Fprintf(stderr, "gc reload: warning: %s\n", warning) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -62,6 +62,57 @@ func TestCmdReloadApplied(t *testing.T) {
 	}
 }
 
+func TestCmdReloadSoftPrintsAcceptedDriftCount(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-soft-cli-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	accepted := 2
+	sendReloadControlRequestHook = func(cityPath string, req reloadControlRequest) (reloadControlReply, error) {
+		if !samePath(cityPath, dir) {
+			t.Fatalf("cityPath = %q, want %q", cityPath, canonicalTestPath(dir))
+		}
+		if !req.Soft {
+			t.Fatalf("req.Soft = false, want true")
+		}
+		return reloadControlReply{
+			Outcome:            reloadOutcomeApplied,
+			Message:            "Config reloaded: 1 agents, 0 rigs (rev abc123def456)",
+			Revision:           "abc123def4567890",
+			AcceptedDriftCount: &accepted,
+		}, nil
+	}
+	reloadUnavailableMessageHook = func(string) string { return "" }
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, true, "30s", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdReload = %d; stderr=%s", code, stderr.String())
+	}
+	wantStdout := "Config reloaded: 1 agents, 0 rigs (rev abc123def456)\nsoft reload: accepted config drift on 2 session(s)"
+	if got := strings.TrimSpace(stdout.String()); got != wantStdout {
+		t.Fatalf("stdout = %q, want %q", got, wantStdout)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestReloadControlReplyOmitsAcceptedDriftCountByDefault(t *testing.T) {
+	data, err := json.Marshal(reloadControlReply{})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "accepted_drift_count") {
+		t.Fatalf("zero-value reloadControlReply JSON = %s, want accepted_drift_count omitted", data)
+	}
+}
+
 func TestCmdReloadAsyncExplicitTimeoutInvalid(t *testing.T) {
 	dir := shortSocketTempDir(t, "gc-reload-flags-")
 	writeCityTOML(t, dir, "test", "mayor")
@@ -226,6 +277,39 @@ func TestHandleReloadSocketCmdAsyncAccepted(t *testing.T) {
 	}
 	if reply.Message != "Reload requested." {
 		t.Fatalf("reply.Message = %q", reply.Message)
+	}
+
+	client.Close() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload socket handler did not exit")
+	}
+}
+
+func TestHandleReloadSocketCmdPropagatesSoft(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	reloadReqCh := make(chan reloadRequest)
+	done := make(chan struct{})
+	go func() {
+		handleReloadSocketCmd(server, `{"wait":false,"soft":true}`, reloadReqCh)
+		close(done)
+	}()
+
+	req := <-reloadReqCh
+	if !req.soft {
+		t.Fatal("req.soft = false, want true")
+	}
+	req.acceptedCh <- reloadControlReply{
+		Outcome: reloadOutcomeAccepted,
+		Message: "Reload requested.",
+	}
+
+	reply := readReloadSocketReply(t, client)
+	if reply.Outcome != reloadOutcomeAccepted {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeAccepted)
 	}
 
 	client.Close() //nolint:errcheck

--- a/cmd/gc/session_hash.go
+++ b/cmd/gc/session_hash.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// sessionCoreConfigForHash builds the canonical config used for session
+// config-drift core hashes. Live drift detection, asleep named-session drift
+// detection, drift keys, and soft reload acceptance must use this helper so
+// template_overrides participate in the same fingerprint everywhere. Start
+// paths may keep their pre-start assembly inline when they need setup-specific
+// diagnostics before storing first-start metadata.
+func sessionCoreConfigForHash(tp TemplateParams, session beads.Bead) runtime.Config {
+	agentCfg := templateParamsToConfig(tp)
+	applyTemplateOverridesToConfig(&agentCfg, session, tp)
+	return agentCfg
+}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1176,7 +1176,7 @@ func commitAsyncStartResultWithContext(
 		return false
 	}
 	if sp != nil && refreshed.err == nil && refreshed.outcome != "session_initializing" {
-		clearReconcilerDrainAckMetadata(sp, refreshed.prepared.candidate.name())
+		_ = clearReconcilerDrainAckMetadata(sp, refreshed.prepared.candidate.name())
 	}
 	return commitStartResultTraced(refreshed, store, clk, rec, wave, stdout, stderr, trace)
 }
@@ -1893,7 +1893,7 @@ func executePlannedStartsTraced(
 					continue
 				}
 				if result.err == nil && result.outcome != "session_initializing" {
-					clearReconcilerDrainAckMetadata(sp, result.prepared.candidate.name())
+					_ = clearReconcilerDrainAckMetadata(sp, result.prepared.candidate.name())
 				}
 				if commitStartResultTraced(result, store, clk, rec, wave, stdout, stderr, trace) {
 					wakeCount++

--- a/cmd/gc/session_model_phase0_rare_state_spec_test.go
+++ b/cmd/gc/session_model_phase0_rare_state_spec_test.go
@@ -570,6 +570,69 @@ func TestPhase0ConfigDrift_AsleepNamedSessionRepairsInPlaceWithoutWaking(t *test
 	}
 }
 
+func TestPhase0ConfigDrift_AsleepNamedSessionAppliesTemplateOverrides(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Provider:          "custom",
+			StartCommand:      "agent --effort low",
+			MaxActiveSessions: intPtr(1),
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+	}
+
+	provider := &config.ResolvedProvider{
+		OptionsSchema: []config.ProviderOption{{
+			Key:  "effort",
+			Type: "select",
+			Choices: []config.OptionChoice{
+				{Value: "low", FlagArgs: []string{"--effort", "low"}},
+				{Value: "high", FlagArgs: []string{"--effort", "high"}},
+			},
+		}},
+		EffectiveDefaults: map[string]string{"effort": "low"},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		TemplateName:            "worker",
+		InstanceName:            "worker",
+		Alias:                   "worker",
+		Command:                 "agent --effort low",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "on_demand",
+		ResolvedProvider:        provider,
+	}
+
+	acceptedRuntime := runtime.Config{Command: "agent --effort high"}
+	session := env.createSessionBead(sessionName, "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"started_config_hash":        runtime.CoreFingerprint(acceptedRuntime),
+		"started_live_hash":          runtime.LiveFingerprint(acceptedRuntime),
+		"template_overrides":         `{"effort":"high"}`,
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["started_config_hash"] != runtime.CoreFingerprint(acceptedRuntime) {
+		t.Fatalf("started_config_hash = %q, want preserved override-aware hash", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] == "true" {
+		t.Fatal("asleep named session was repaired for drift even though template_overrides made the hash match")
+	}
+}
+
 func TestConfigDrift_AttachedSessionPersistsAcrossCycles(t *testing.T) {
 	// Config-drift deferral for attached sessions must persist across
 	// reconciler cycles — the session must never be killed while attached.

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -877,10 +877,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if dops != nil {
 			if acked, _ := dops.isDrainAcked(name); acked {
 				if !alive && staleOrLegacyDrainAckBeforeStart(*session, sp, name) {
-					clearReconcilerDrainAckMetadata(sp, name)
+					_ = clearReconcilerDrainAckMetadata(sp, name)
 				} else {
 					if staleReconcilerDrainAck(*session, sp, name) {
-						clearReconcilerDrainAckMetadata(sp, name)
+						_ = clearReconcilerDrainAckMetadata(sp, name)
 						if trace != nil {
 							trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "stale_generation", "clear", nil, nil, "")
 						}
@@ -901,7 +901,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							drainCancelled := cancelSessionConfigDriftDrain(*session, sp, dt)
 							if !drainCancelled {
-								clearReconcilerDrainAckMetadata(sp, name)
+								_ = clearReconcilerDrainAckMetadata(sp, name)
 							}
 							if trace != nil {
 								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "config_drift_attached", "cancel_reconciler_ack", traceRecordPayload{
@@ -913,7 +913,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						if driftKey != "" && recentlyDeferredSessionAttachedConfigDrift(*session, clk, driftKey) {
 							drainCancelled := cancelSessionConfigDriftDrain(*session, sp, dt)
 							if !drainCancelled {
-								clearReconcilerDrainAckMetadata(sp, name)
+								_ = clearReconcilerDrainAckMetadata(sp, name)
 							}
 							if trace != nil {
 								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "config_drift_recently_attached", "cancel_reconciler_ack", traceRecordPayload{
@@ -1111,11 +1111,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if template != "" && storedHash != "" {
 				cfgAgent := findAgentByTemplate(cfg, template)
 				if cfgAgent != nil {
-					agentCfg := templateParamsToConfig(tp)
-					// Apply template_overrides using the same resolution as
-					// prepareSessionStart: merge defaults + overrides, then
-					// replaceSchemaFlags to strip and re-add all schema flags.
-					applyTemplateOverridesToConfig(&agentCfg, *session, tp)
+					agentCfg := sessionCoreConfigForHash(tp, *session)
 					currentHash := runtime.CoreFingerprint(agentCfg)
 					if storedHash != currentHash {
 						fmt.Fprintf(stderr, "config-drift %s: stored=%s current=%s cmd=%q\n", name, storedHash[:12], currentHash[:12], agentCfg.Command) //nolint:errcheck
@@ -1299,7 +1295,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			storedHash := session.Metadata["started_config_hash"]
 			if template != "" && storedHash != "" {
 				if cfgAgent := findAgentByTemplate(cfg, template); cfgAgent != nil {
-					agentCfg := templateParamsToConfig(tp)
+					agentCfg := sessionCoreConfigForHash(tp, *session)
 					currentHash := runtime.CoreFingerprint(agentCfg)
 					if storedHash != currentHash {
 						var storedBreakdown map[string]string
@@ -2018,8 +2014,7 @@ func sessionConfigDriftKey(session beads.Bead, cfg *config.City, tp TemplatePara
 	if findAgentByTemplate(cfg, template) == nil {
 		return ""
 	}
-	agentCfg := templateParamsToConfig(tp)
-	applyTemplateOverridesToConfig(&agentCfg, session, tp)
+	agentCfg := sessionCoreConfigForHash(tp, session)
 	currentHash := runtime.CoreFingerprint(agentCfg)
 	if storedHash == currentHash {
 		return ""

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -198,26 +198,32 @@ func setReconcilerDrainAckMetadata(sp runtime.Provider, name string, ds *drainSt
 		return err
 	}
 	if err := sp.SetMeta(name, reconcilerDrainAckReasonKey, ds.reason); err != nil {
-		clearReconcilerDrainAckMetadata(sp, name)
+		_ = clearReconcilerDrainAckMetadata(sp, name)
 		return err
 	}
 	if err := sp.SetMeta(name, reconcilerDrainAckGenerationKey, strconv.Itoa(ds.generation)); err != nil {
-		clearReconcilerDrainAckMetadata(sp, name)
+		_ = clearReconcilerDrainAckMetadata(sp, name)
 		return err
 	}
 	if err := sp.SetMeta(name, "GC_DRAIN_ACK", "1"); err != nil {
-		clearReconcilerDrainAckMetadata(sp, name)
+		_ = clearReconcilerDrainAckMetadata(sp, name)
 		return err
 	}
 	return nil
 }
 
-func clearReconcilerDrainAckMetadata(sp runtime.Provider, name string) {
+func clearReconcilerDrainAckMetadata(sp runtime.Provider, name string) error {
+	if sp == nil {
+		return fmt.Errorf("session provider is nil")
+	}
+	var errs []error
 	for _, key := range []string{"GC_DRAIN_ACK", reconcilerDrainAckSourceKey, reconcilerDrainAckReasonKey, reconcilerDrainAckGenerationKey} {
 		if err := sp.RemoveMeta(name, key); err != nil {
 			log.Printf("session wake: clearing reconciler drain ack metadata %s for %s: %v", key, name, err)
+			errs = append(errs, fmt.Errorf("removing %s: %w", key, err))
 		}
 	}
+	return errors.Join(errs...)
 }
 
 // cancelSessionDrain removes a cancelable drain if wake reasons reappeared for
@@ -265,7 +271,7 @@ func cancelSessionDrainIf(session beads.Bead, sp runtime.Provider, dt *drainTrac
 		// Clear GC_DRAIN_ACK if it was set — prevents stale ack from
 		// killing the session on the next Phase 1 drain-ack check.
 		if ds.ackSet {
-			clearReconcilerDrainAckMetadata(sp, name)
+			_ = clearReconcilerDrainAckMetadata(sp, name)
 		}
 		telemetry.RecordDrainTransition(context.Background(), name, ds.reason, "cancel")
 		return true
@@ -348,7 +354,7 @@ func cancelRecoveredReconcilerAckedDrain(session beads.Bead, sp runtime.Provider
 	if !ok || !pendingDrainReasonCancelable(reason) {
 		return false
 	}
-	clearReconcilerDrainAckMetadata(sp, name)
+	_ = clearReconcilerDrainAckMetadata(sp, name)
 	telemetry.RecordDrainTransition(context.Background(), name, reason, "cancel")
 	return true
 }
@@ -358,7 +364,7 @@ func cancelRecoveredOrphanedDrainForAssignedWork(session beads.Bead, sp runtime.
 	if !ok || reason != "orphaned" {
 		return false
 	}
-	clearReconcilerDrainAckMetadata(sp, name)
+	_ = clearReconcilerDrainAckMetadata(sp, name)
 	telemetry.RecordDrainTransition(context.Background(), name, reason, "cancel")
 	return true
 }
@@ -433,7 +439,7 @@ func advanceSessionDrainsWithSessionsTraced(
 		if gen != ds.generation {
 			dt.clearIdleProbe(id)
 			if ds.ackSet {
-				clearReconcilerDrainAckMetadata(sp, name)
+				_ = clearReconcilerDrainAckMetadata(sp, name)
 			}
 			dt.remove(id)
 			if trace != nil {
@@ -497,7 +503,7 @@ func advanceSessionDrainsWithSessionsTraced(
 				// Clear GC_DRAIN_ACK if it was set — prevents stale ack
 				// from killing the session on the next Phase 1 check.
 				if ds.ackSet {
-					clearReconcilerDrainAckMetadata(sp, name)
+					_ = clearReconcilerDrainAckMetadata(sp, name)
 				}
 				dt.remove(id)
 				if trace != nil {

--- a/cmd/gc/soft_reload.go
+++ b/cmd/gc/soft_reload.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -8,6 +9,46 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
+
+type softReloadAcceptanceResult struct {
+	Updated        int
+	Failed         int
+	FailedSessions []string
+	CanceledDrains int
+	OpenSessions   int
+	DesiredEmpty   bool
+}
+
+func (r softReloadAcceptanceResult) warnings() []string {
+	var warnings []string
+	if r.Failed > 0 {
+		detail := formatSoftReloadFailedSessions(r.FailedSessions)
+		if detail != "" {
+			detail = " (" + detail + ")"
+		}
+		warnings = append(warnings, fmt.Sprintf("soft reload: failed to accept config drift on %d session(s)%s; affected sessions may still drain", r.Failed, detail))
+	}
+	if r.DesiredEmpty && r.OpenSessions > 0 {
+		warnings = append(warnings, fmt.Sprintf("soft reload: desired state is empty; %d open session(s) will not have config drift accepted", r.OpenSessions))
+	}
+	return warnings
+}
+
+func formatSoftReloadFailedSessions(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	const limit = 5
+	shown := names
+	if len(shown) > limit {
+		shown = shown[:limit]
+	}
+	detail := strings.Join(shown, ", ")
+	if extra := len(names) - len(shown); extra > 0 {
+		detail = fmt.Sprintf("%s, and %d more", detail, extra)
+	}
+	return detail
+}
 
 // acceptConfigDriftAcrossSessions writes the current per-session config
 // hash into every open session bead's started_config_hash metadata
@@ -33,33 +74,40 @@ import (
 //     next tick)
 //   - the recomputed current hash already equals the stored hash
 //
-// The hash computation mirrors the canonical reconciler path:
-// templateParamsToConfig → applyTemplateOverridesToConfig →
-// runtime.CoreFingerprint. Any future change to that sequence in the
-// reconciler must be mirrored here, otherwise --soft will write a
-// stale hash and the next tick will still detect drift.
+// The hash computation uses sessionCoreConfigForHash, the same canonical
+// reconciler drift-hash helper used by live and asleep drift detection.
 //
-// Returns the number of session beads whose started_config_hash was
-// updated.
+// Returns accepted-session, failed-session, stale-drain-cancelation, and
+// empty-desired-state diagnostics for the controller reply.
 func acceptConfigDriftAcrossSessions(
 	store beads.Store,
 	desired map[string]TemplateParams,
+	sessionBeads *sessionBeadSnapshot,
+	sp runtime.Provider,
+	dt *drainTracker,
 	stderr io.Writer,
-) int {
-	if store == nil || len(desired) == 0 {
-		return 0
+) softReloadAcceptanceResult {
+	result := softReloadAcceptanceResult{DesiredEmpty: len(desired) == 0}
+	if store == nil {
+		return result
 	}
-	sessionBeads, err := loadSessionBeadSnapshot(store)
-	if err != nil {
-		fmt.Fprintf(stderr, "soft reload: listing session beads: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 0
+	if sessionBeads == nil {
+		var err error
+		sessionBeads, err = loadSessionBeadSnapshot(store)
+		if err != nil {
+			fmt.Fprintf(stderr, "soft reload: listing session beads: %v\n", err) //nolint:errcheck // best-effort stderr
+			return result
+		}
 	}
 	open := sessionBeads.Open()
+	result.OpenSessions = len(open)
 	if len(open) == 0 {
-		return 0
+		return result
+	}
+	if len(desired) == 0 {
+		return result
 	}
 
-	updated := 0
 	for i := range open {
 		session := open[i]
 		if session.Status == "closed" {
@@ -77,17 +125,72 @@ func acceptConfigDriftAcrossSessions(
 		if !ok {
 			continue
 		}
-		agentCfg := templateParamsToConfig(tp)
-		applyTemplateOverridesToConfig(&agentCfg, session, tp)
+		agentCfg := sessionCoreConfigForHash(tp, session)
 		currentHash := runtime.CoreFingerprint(agentCfg)
 		if storedHash == currentHash {
 			continue
 		}
-		if err := store.SetMetadata(session.ID, "started_config_hash", currentHash); err != nil {
-			fmt.Fprintf(stderr, "soft reload: updating started_config_hash for %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+		if err := clearSoftReloadConfigDriftDrainAck(session, sp, dt); err != nil {
+			result.Failed++
+			result.FailedSessions = append(result.FailedSessions, name)
+			fmt.Fprintf(stderr, "soft reload: clearing config-drift drain ack metadata for %s: %v; leaving config hash unchanged\n", name, err) //nolint:errcheck // best-effort stderr
 			continue
 		}
-		updated++
+		metadata, err := softReloadAcceptedHashMetadata(agentCfg, currentHash)
+		if err != nil {
+			result.Failed++
+			result.FailedSessions = append(result.FailedSessions, name)
+			fmt.Fprintf(stderr, "soft reload: preparing config hash metadata for %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+			continue
+		}
+		if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
+			result.Failed++
+			result.FailedSessions = append(result.FailedSessions, name)
+			fmt.Fprintf(stderr, "soft reload: updating config hash metadata for %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+			continue
+		}
+		if cancelSoftReloadConfigDriftDrain(session, sp, dt) {
+			result.CanceledDrains++
+		}
+		result.Updated++
 	}
-	return updated
+	return result
+}
+
+func softReloadAcceptedHashMetadata(agentCfg runtime.Config, currentHash string) (map[string]string, error) {
+	breakdown, err := json.Marshal(runtime.CoreFingerprintBreakdown(agentCfg))
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"started_config_hash": currentHash,
+		"core_hash_breakdown": string(breakdown),
+	}, nil
+}
+
+func cancelSoftReloadConfigDriftDrain(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
+	if dt == nil {
+		return false
+	}
+	ds := dt.get(session.ID)
+	if ds == nil || ds.reason != "config-drift" {
+		return false
+	}
+	return cancelSessionConfigDriftDrain(session, sp, dt)
+}
+
+func clearSoftReloadConfigDriftDrainAck(session beads.Bead, sp runtime.Provider, dt *drainTracker) error {
+	if dt == nil {
+		return nil
+	}
+	ds := dt.get(session.ID)
+	if ds == nil || ds.reason != "config-drift" || !ds.ackSet {
+		return nil
+	}
+	name := strings.TrimSpace(session.Metadata["session_name"])
+	if err := clearReconcilerDrainAckMetadata(sp, name); err != nil {
+		return err
+	}
+	ds.ackSet = false
+	return nil
 }

--- a/cmd/gc/soft_reload_test.go
+++ b/cmd/gc/soft_reload_test.go
@@ -2,9 +2,16 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -37,9 +44,9 @@ func TestAcceptConfigDriftAcrossSessions_UpdatesStaleHash(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	got := acceptConfigDriftAcrossSessions(store, desired, &stderr)
-	if got != 1 {
-		t.Fatalf("updated = %d, want 1 (stderr=%s)", got, stderr.String())
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, nil, nil, &stderr)
+	if got.Updated != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", got.Updated, stderr.String())
 	}
 
 	updated, err := store.Get(sessionBead.ID)
@@ -48,6 +55,14 @@ func TestAcceptConfigDriftAcrossSessions_UpdatesStaleHash(t *testing.T) {
 	}
 	if updated.Metadata["started_config_hash"] != wantHash {
 		t.Errorf("started_config_hash = %q, want %q", updated.Metadata["started_config_hash"], wantHash)
+	}
+	var gotBreakdown map[string]string
+	if err := json.Unmarshal([]byte(updated.Metadata["core_hash_breakdown"]), &gotBreakdown); err != nil {
+		t.Fatalf("core_hash_breakdown is not valid JSON: %v", err)
+	}
+	wantBreakdown := runtime.CoreFingerprintBreakdown(runtime.Config{Command: "new-cmd"})
+	if gotBreakdown["Command"] != wantBreakdown["Command"] {
+		t.Errorf("core_hash_breakdown[Command] = %q, want %q", gotBreakdown["Command"], wantBreakdown["Command"])
 	}
 }
 
@@ -77,9 +92,9 @@ func TestAcceptConfigDriftAcrossSessions_SkipsUnstartedSessions(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	got := acceptConfigDriftAcrossSessions(store, desired, &stderr)
-	if got != 0 {
-		t.Fatalf("updated = %d, want 0 for unstarted session (stderr=%s)", got, stderr.String())
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, nil, nil, &stderr)
+	if got.Updated != 0 {
+		t.Fatalf("updated = %d, want 0 for unstarted session (stderr=%s)", got.Updated, stderr.String())
 	}
 
 	unchanged, err := store.Get(sessionBead.ID)
@@ -120,9 +135,9 @@ func TestAcceptConfigDriftAcrossSessions_SkipsOrphanedSessions(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	got := acceptConfigDriftAcrossSessions(store, desired, &stderr)
-	if got != 0 {
-		t.Fatalf("updated = %d, want 0 for orphaned session (stderr=%s)", got, stderr.String())
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, nil, nil, &stderr)
+	if got.Updated != 0 {
+		t.Fatalf("updated = %d, want 0 for orphaned session (stderr=%s)", got.Updated, stderr.String())
 	}
 
 	unchanged, err := store.Get(sessionBead.ID)
@@ -160,9 +175,9 @@ func TestAcceptConfigDriftAcrossSessions_LeavesNonDriftingSessionsAlone(t *testi
 	}
 
 	var stderr bytes.Buffer
-	got := acceptConfigDriftAcrossSessions(store, desired, &stderr)
-	if got != 0 {
-		t.Fatalf("updated = %d, want 0 (no drift) — stderr=%s", got, stderr.String())
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, nil, nil, &stderr)
+	if got.Updated != 0 {
+		t.Fatalf("updated = %d, want 0 (no drift) — stderr=%s", got.Updated, stderr.String())
 	}
 
 	unchanged, err := store.Get(sessionBead.ID)
@@ -172,4 +187,298 @@ func TestAcceptConfigDriftAcrossSessions_LeavesNonDriftingSessionsAlone(t *testi
 	if unchanged.Metadata["started_config_hash"] != matchingHash {
 		t.Errorf("started_config_hash rewritten unexpectedly = %q, want %q", unchanged.Metadata["started_config_hash"], matchingHash)
 	}
+}
+
+func TestAcceptConfigDriftAcrossSessions_CancelsExistingConfigDriftDrain(t *testing.T) {
+	store := beads.NewMemStore()
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"started_config_hash": oldHash,
+			"generation":          "7",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	sp := runtime.NewFake()
+	dt := newDrainTracker()
+	clk := &clock.Fake{Time: time.Unix(100, 0)}
+	if !beginSessionDrain(sessionBead, sp, dt, "config-drift", clk, time.Minute) {
+		t.Fatal("beginSessionDrain returned false")
+	}
+
+	desired := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, sp, dt, &stderr)
+	if got.Updated != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", got.Updated, stderr.String())
+	}
+	if got.CanceledDrains != 1 {
+		t.Fatalf("canceled drains = %d, want 1", got.CanceledDrains)
+	}
+	if drain := dt.get(sessionBead.ID); drain != nil {
+		t.Fatalf("config-drift drain still queued after soft acceptance: %+v", drain)
+	}
+}
+
+func TestAcceptConfigDriftAcrossSessions_FailsAckedDrainWithoutProviderBeforeMetadataWrite(t *testing.T) {
+	store := beads.NewMemStore()
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"started_config_hash": oldHash,
+			"generation":          "7",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	dt := newDrainTracker()
+	dt.set(sessionBead.ID, &drainState{
+		reason:     "config-drift",
+		generation: 7,
+		ackSet:     true,
+	})
+	desired := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, nil, dt, &stderr)
+	if got.Updated != 0 || got.Failed != 1 {
+		t.Fatalf("result = %+v, want updated=0 failed=1 (stderr=%s)", got, stderr.String())
+	}
+	if drain := dt.get(sessionBead.ID); drain == nil {
+		t.Fatal("config-drift drain was removed even though provider cancellation was unavailable")
+	}
+	unchanged, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if unchanged.Metadata["started_config_hash"] != oldHash {
+		t.Fatalf("started_config_hash = %q, want unchanged %q", unchanged.Metadata["started_config_hash"], oldHash)
+	}
+	warnings := strings.Join(got.warnings(), "\n")
+	if !strings.Contains(warnings, "worker") {
+		t.Fatalf("warnings = %q, want failed session name", warnings)
+	}
+}
+
+func TestAcceptConfigDriftAcrossSessions_FailsWhenAckMetadataClearFails(t *testing.T) {
+	store := beads.NewMemStore()
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "old-cmd"})
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"started_config_hash": oldHash,
+			"generation":          "7",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	sp := &removeMetaErrorProvider{Fake: runtime.NewFake(), err: errors.New("injected remove metadata failure")}
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "old-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	if err := setReconcilerDrainAckMetadata(sp.Fake, "worker", &drainState{reason: "config-drift", generation: 7}); err != nil {
+		t.Fatalf("set drain ack metadata: %v", err)
+	}
+	dt := newDrainTracker()
+	dt.set(sessionBead.ID, &drainState{
+		reason:     "config-drift",
+		generation: 7,
+		ackSet:     true,
+	})
+	desired := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, sp, dt, &stderr)
+	if got.Updated != 0 || got.Failed != 1 || got.CanceledDrains != 0 {
+		t.Fatalf("result = %+v, want updated=0 failed=1 canceled=0 (stderr=%s)", got, stderr.String())
+	}
+	if drain := dt.get(sessionBead.ID); drain == nil || !drain.ackSet {
+		t.Fatalf("config-drift drain = %+v, want acked drain retained", drain)
+	}
+	unchanged, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if unchanged.Metadata["started_config_hash"] != oldHash {
+		t.Fatalf("started_config_hash = %q, want unchanged %q", unchanged.Metadata["started_config_hash"], oldHash)
+	}
+	if gotAck, err := sp.GetMeta("worker", "GC_DRAIN_ACK"); err != nil || gotAck != "1" {
+		t.Fatalf("GC_DRAIN_ACK = %q, %v; want still set after injected remove failure", gotAck, err)
+	}
+	warnings := strings.Join(got.warnings(), "\n")
+	if !strings.Contains(warnings, "worker") {
+		t.Fatalf("warnings = %q, want failed session name", warnings)
+	}
+}
+
+func TestAcceptConfigDriftAcrossSessions_AppliesTemplateOverridesToHash(t *testing.T) {
+	store := beads.NewMemStore()
+	oldHash := runtime.CoreFingerprint(runtime.Config{Command: "agent --effort low"})
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"started_config_hash": oldHash,
+			"template_overrides":  `{"effort":"high"}`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	provider := &config.ResolvedProvider{
+		OptionsSchema: []config.ProviderOption{{
+			Key:  "effort",
+			Type: "select",
+			Choices: []config.OptionChoice{
+				{Value: "low", FlagArgs: []string{"--effort", "low"}},
+				{Value: "high", FlagArgs: []string{"--effort", "high"}},
+			},
+		}},
+		EffectiveDefaults: map[string]string{"effort": "low"},
+	}
+	desired := map[string]TemplateParams{
+		"worker": {
+			Command:          "agent --effort low",
+			SessionName:      "worker",
+			TemplateName:     "worker",
+			ResolvedProvider: provider,
+		},
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, nil, nil, &stderr)
+	if got.Updated != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", got.Updated, stderr.String())
+	}
+	updated, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	wantHash := runtime.CoreFingerprint(runtime.Config{Command: "agent --effort high"})
+	if updated.Metadata["started_config_hash"] != wantHash {
+		t.Fatalf("started_config_hash = %q, want override hash %q", updated.Metadata["started_config_hash"], wantHash)
+	}
+}
+
+func TestAcceptConfigDriftAcrossSessions_MetadataFailureReportsAndContinues(t *testing.T) {
+	base := beads.NewMemStore()
+	failing, err := base.Create(beads.Bead{
+		Title:  "failing",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "failing",
+			"template":            "failing",
+			"started_config_hash": "stale-failing",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(failing): %v", err)
+	}
+	succeeding, err := base.Create(beads.Bead{
+		Title:  "succeeding",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "succeeding",
+			"template":            "succeeding",
+			"started_config_hash": "stale-succeeding",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(succeeding): %v", err)
+	}
+
+	store := failingSetMetadataBatchStore{Store: base, failID: failing.ID}
+	desired := map[string]TemplateParams{
+		"failing":    {Command: "new-failing", SessionName: "failing", TemplateName: "failing"},
+		"succeeding": {Command: "new-succeeding", SessionName: "succeeding", TemplateName: "succeeding"},
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, nil, nil, nil, &stderr)
+	if got.Updated != 1 || got.Failed != 1 {
+		t.Fatalf("result = %+v, want updated=1 failed=1 (stderr=%s)", got, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "updating config hash metadata for failing") {
+		t.Fatalf("stderr = %q, want failing update error", stderr.String())
+	}
+	warnings := strings.Join(got.warnings(), "\n")
+	if !strings.Contains(warnings, "failing") {
+		t.Fatalf("warnings = %q, want failing session name", warnings)
+	}
+	updated, err := base.Get(succeeding.ID)
+	if err != nil {
+		t.Fatalf("Get(succeeding): %v", err)
+	}
+	wantHash := runtime.CoreFingerprint(runtime.Config{Command: "new-succeeding"})
+	if updated.Metadata["started_config_hash"] != wantHash {
+		t.Fatalf("succeeding started_config_hash = %q, want %q", updated.Metadata["started_config_hash"], wantHash)
+	}
+}
+
+func TestAcceptConfigDriftAcrossSessions_EmptyDesiredReportsOpenSessions(t *testing.T) {
+	store := beads.NewMemStore()
+	_, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"started_config_hash": "stale-hash",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, map[string]TemplateParams{}, nil, nil, nil, &stderr)
+	if !got.DesiredEmpty || got.OpenSessions != 1 {
+		t.Fatalf("result = %+v, want DesiredEmpty with one open session", got)
+	}
+}
+
+type failingSetMetadataBatchStore struct {
+	beads.Store
+	failID string
+}
+
+func (s failingSetMetadataBatchStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if id == s.failID {
+		return errors.New("injected metadata failure")
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
 }

--- a/docs/guides/gc-reload-design.md
+++ b/docs/guides/gc-reload-design.md
@@ -150,21 +150,25 @@ existing in-flight-work guards in place.
 2. The controller runs the normal config reload (remote pack fetch,
    parse, validation, apply). If that fails, `--soft` is a no-op —
    reload returns `failed` exactly as it would without `--soft`.
-3. Once the new config is live, the controller rebuilds desired state
-   and walks every open session bead. For each session whose
+3. Once the new config is live, the controller uses the desired-state
+   result already built for the same reconcile tick and walks every
+   open session bead. For each session whose
    `session_name` has a desired-state entry and whose recorded
    `started_config_hash` differs from the value the new config would
    produce, the controller writes the new hash into
-   `started_config_hash`. Sessions that have not yet stamped a
-   `started_config_hash` (still in the startup window) are skipped —
-   they will record the right value once they finish starting.
-   Sessions whose `session_name` has no desired-state entry are
-   skipped — the orphan/suspended drain handles them on the next tick.
+   `started_config_hash`, writes the matching `core_hash_breakdown`,
+   and cancels any already queued `config-drift` drain for that bead.
+   Sessions that have not yet stamped a `started_config_hash` (still
+   in the startup window) are skipped — they will record the right value
+   once they finish starting. Sessions whose `session_name` has no
+   desired-state entry are skipped — the orphan/suspended drain handles
+   them on the next tick.
 4. The immediately-following reconcile tick sees no drift on the
    updated sessions and does not fire `config-drift` drains for them.
 5. The CLI prints `soft reload: accepted config drift on N session(s)`
-   on stdout when one or more sessions were updated, alongside the
-   normal `Config reloaded: ...` line.
+   on stdout alongside the normal `Config reloaded: ...` line. If the
+   controller cannot update some session metadata, the CLI also prints a
+   warning because those sessions may still drain.
 
 Soft reload is **not** a substitute for restarting sessions when a
 config change requires a process restart to take effect (e.g.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1960,12 +1960,13 @@ config drift rules require them.
 With --soft, the controller accepts any detected per-session config
 drift instead of draining the drifted sessions: each open session's
 recorded config hash is updated to the hash the freshly reloaded
-config produces for it, so the immediately-following reconcile tick
-sees no drift and no config-drift drains fire. Useful when editing a
-running city's .gc/settings.json without disrupting in-flight work.
-Sessions whose template no longer maps to a configured agent are
-NOT updated; normal orphan/suspended drain handles them on the next
-tick.
+config produces for it, the matching hash breakdown is refreshed, and
+any already queued config-drift drain for that session is canceled. The
+immediately-following reconcile tick sees no drift and no config-drift
+drains fire. Useful when editing a running city's .gc/settings.json
+without disrupting in-flight work. Sessions whose template no longer
+maps to a configured agent are NOT updated; normal orphan/suspended
+drain handles them on the next tick.
 
 ```
 gc reload [path] [flags]


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/2024.

Original PR:
- Author: @realies
- Title: `feat(reload): add --soft to accept config drift without draining sessions`
- State: merged on 2026-05-13
- Configured base: `main`
- GitHub base: `main`
- Base mismatch: none

PR #2024 already landed on `main`. This follow-up carries the reviewed
maintainer fix commit only, on top of the current `main`, instead of replaying
the contributor commit that is already present via the squash merge.

Maintainer changes:
- Clear stale config-drift drain ack metadata before accepting soft reload
  drift, and report affected sessions as failed if the ack cannot be cleared.
- Surface the accepted drift count through the reload control reply and CLI.
- Add focused runtime, command, and reconciler regression coverage for applied
  and no-change soft reload paths.
- Refresh generated CLI documentation and reload design notes.

Validation:
- Pre-commit hook passed during cherry-pick finalization.
- `go test ./cmd/gc -run 'TestAcceptConfigDriftAcrossSessions|TestCityRuntimeSoftReloadAcceptsDriftForAppliedAndNoChange|TestCmdReloadSoftPrintsAcceptedDriftCount|TestReloadControlReplyOmitsAcceptedDriftCountByDefault|TestHandleReloadSocketCmdPropagatesSoft|TestSessionModelPhase0'`
- Adopt PR approval guard passed for workflow root `ga-34g4sdq`, attempt 4.
