### PR TITLE
fix(orders): preserve disabled-order management surfaces

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -695,8 +695,13 @@ func (cs *controllerState) CityBeadStore() beads.Store {
 	return cs.cityBeadStore
 }
 
-// Orders scans formula layers and returns all orders.
+// Orders scans formula layers and returns active orders.
 func (cs *controllerState) Orders() []orders.Order {
+	return orders.FilterEnabled(cs.OrdersAll())
+}
+
+// OrdersAll scans formula layers and returns all orders after overrides.
+func (cs *controllerState) OrdersAll() []orders.Order {
 	cs.mu.RLock()
 	cfg := cs.cfg
 	cs.mu.RUnlock()
@@ -707,7 +712,9 @@ func (cs *controllerState) Orders() []orders.Order {
 	}
 
 	if len(cfg.Orders.Overrides) > 0 {
-		orders.ApplyOverrides(allAA, convertOverrides(cfg.Orders.Overrides)) //nolint:errcheck // best-effort
+		if err := orders.ApplyOverrides(allAA, convertOverrides(cfg.Orders.Overrides)); err != nil {
+			log.Printf("gc api: applying order overrides for %s: %v", cs.cityPath, err)
+		}
 	}
 
 	return allAA

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -188,14 +188,30 @@ older than --stale-after so a fresh in-flight order is not interrupted.`,
 	return cmd
 }
 
-// loadOrders is the common preamble for order commands: resolve city,
-// load config, scan formula layers for all orders (city + rig).
+// loadOrders is the common preamble for active order commands: resolve city,
+// load config, scan formula layers, apply overrides, and filter disabled orders.
 func loadOrders(stderr io.Writer, cmdName string) ([]orders.Order, int) {
-	_, _, aa, code := loadOrdersWithCity(stderr, cmdName)
+	return loadActiveOrders(stderr, cmdName)
+}
+
+func loadActiveOrders(stderr io.Writer, cmdName string) ([]orders.Order, int) {
+	_, _, aa, code := loadActiveOrdersWithCity(stderr, cmdName)
 	return aa, code
 }
 
 func loadOrdersWithCity(stderr io.Writer, cmdName string) (string, *config.City, []orders.Order, int) {
+	return loadActiveOrdersWithCity(stderr, cmdName)
+}
+
+func loadActiveOrdersWithCity(stderr io.Writer, cmdName string) (string, *config.City, []orders.Order, int) {
+	cityPath, cfg, allAA, code := loadAllOrdersWithCity(stderr, cmdName)
+	if code != 0 {
+		return cityPath, cfg, allAA, code
+	}
+	return cityPath, cfg, orders.FilterEnabled(allAA), 0
+}
+
+func loadAllOrdersWithCity(stderr io.Writer, cmdName string) (string, *config.City, []orders.Order, int) {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
@@ -210,8 +226,9 @@ func loadOrdersWithCity(stderr io.Writer, cmdName string) (string, *config.City,
 	return cityPath, cfg, aa, code
 }
 
-// loadAllOrders scans city layers + per-rig exclusive layers for orders.
-// Rig orders get their Rig field stamped.
+// loadAllOrders scans city layers + per-rig exclusive layers for all orders
+// and applies configured overrides. Callers that execute or list active work
+// should use loadActiveOrders instead. Rig orders get their Rig field stamped.
 func loadAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName string) ([]orders.Order, int) {
 	allAA, err := scanAllOrders(cityPath, cfg, stderr, cmdName)
 	if err != nil {
@@ -227,7 +244,15 @@ func loadAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName 
 		}
 	}
 
-	return filterEnabledOrders(allAA), 0
+	return allAA, 0
+}
+
+func loadActiveOrdersForCity(cityPath string, cfg *config.City, stderr io.Writer, cmdName string) ([]orders.Order, int) {
+	allAA, code := loadAllOrders(cityPath, cfg, stderr, cmdName)
+	if code != 0 {
+		return allAA, code
+	}
+	return orders.FilterEnabled(allAA), 0
 }
 
 func scanAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName string) ([]orders.Order, error) {
@@ -261,19 +286,6 @@ func scanAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName 
 	allAA = append(allAA, cityAA...)
 	allAA = append(allAA, rigAA...)
 	return allAA, nil
-}
-
-func filterEnabledOrders(aa []orders.Order) []orders.Order {
-	if len(aa) == 0 {
-		return nil
-	}
-	filtered := aa[:0]
-	for _, a := range aa {
-		if a.IsEnabled() {
-			filtered = append(filtered, a)
-		}
-	}
-	return filtered
 }
 
 // cityFormulaLayers returns the formula directory layers for city-level order
@@ -401,7 +413,7 @@ func anyOrderHasRig(aa []orders.Order) bool {
 // --- gc order show ---
 
 func cmdOrderShow(name, rig string, stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order show")
+	_, _, aa, code := loadAllOrdersWithCity(stderr, "gc order show")
 	if code != 0 {
 		return code
 	}
@@ -815,7 +827,7 @@ func doOrderCheckWithStoresResolverScoped(cityPath string, cfg *config.City, aa 
 // --- gc order history ---
 
 func cmdOrderHistory(name, rig string, stdout, stderr io.Writer) int {
-	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order history")
+	cityPath, cfg, aa, code := loadAllOrdersWithCity(stderr, "gc order history")
 	if code != 0 {
 		return code
 	}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -175,7 +175,7 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 			logDispatchError(stderr, "gc start: order overrides: %v", err)
 		}
 	}
-	allAA = filterEnabledOrders(allAA)
+	allAA = orders.FilterEnabled(allAA)
 
 	// Filter out manual-trigger orders — they are never auto-dispatched.
 	var auto []orders.Order

--- a/cmd/gc/order_enabled_filter_test.go
+++ b/cmd/gc/order_enabled_filter_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestLoadActiveOrdersOverrideDisablesOrder(t *testing.T) {
+	cityDir, cfg := newOrderEnabledFilterCity(t)
+
+	var stderr bytes.Buffer
+	aa, code := loadActiveOrdersForCity(cityDir, cfg, &stderr, "gc order list")
+	if code != 0 {
+		t.Fatalf("loadActiveOrdersForCity returned code %d; stderr: %s", code, stderr.String())
+	}
+	requireOrderNames(t, aa, "keep")
+}
+
+func TestLoadAllOrdersPreservesOverrideDisabledOrder(t *testing.T) {
+	cityDir, cfg := newOrderEnabledFilterCity(t)
+
+	var stderr bytes.Buffer
+	aa, code := loadAllOrders(cityDir, cfg, &stderr, "gc order show")
+	if code != 0 {
+		t.Fatalf("loadAllOrders returned code %d; stderr: %s", code, stderr.String())
+	}
+	requireOrderEnabledState(t, aa, "keep", true)
+	requireOrderEnabledState(t, aa, "drop", false)
+}
+
+func TestBuildOrderDispatcherOverrideDisablesOrder(t *testing.T) {
+	cityDir, cfg := newOrderEnabledFilterCity(t)
+
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	if ad == nil {
+		t.Fatalf("buildOrderDispatcher returned nil; stderr: %s", stderr.String())
+	}
+	mad := ad.(*memoryOrderDispatcher)
+	requireOrderNames(t, mad.aa, "keep")
+}
+
+func TestControllerStateOrdersOverrideDisablesOrder(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	cityDir, cfg := newOrderEnabledFilterCity(t)
+
+	cs := newControllerState(context.Background(), cfg, runtime.NewFake(), events.NewFake(), "test-city", cityDir)
+	requireOrderNames(t, cs.Orders(), "keep")
+}
+
+func TestControllerStateOrdersDisableEnableRoundTrip(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	cityDir, cfg := newPersistedOrderEnabledFilterCity(t)
+
+	cs := newControllerState(context.Background(), cfg, runtime.NewFake(), events.NewFake(), "test-city", cityDir)
+	if err := cs.DisableOrder("keep", ""); err != nil {
+		t.Fatalf("DisableOrder: %v", err)
+	}
+	requireOrderAbsent(t, cs.Orders(), "keep")
+	requireOrderEnabledState(t, cs.OrdersAll(), "keep", false)
+
+	if err := cs.EnableOrder("keep", ""); err != nil {
+		t.Fatalf("EnableOrder: %v", err)
+	}
+	requireOrderEnabledState(t, cs.Orders(), "keep", true)
+	requireOrderEnabledState(t, cs.OrdersAll(), "keep", true)
+}
+
+func TestControllerStateOrdersAllLogsOverrideErrors(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	cityDir, cfg := newOrderEnabledFilterCity(t)
+	cfg.Orders.Overrides = []config.OrderOverride{{Name: "missing"}}
+
+	cs := newControllerState(context.Background(), cfg, runtime.NewFake(), events.NewFake(), "test-city", cityDir)
+	logs := captureCmdOrderLogs(t, func() {
+		_ = cs.OrdersAll()
+	})
+	if !strings.Contains(logs, "applying order overrides") || !strings.Contains(logs, "missing") {
+		t.Fatalf("logs = %q, want order override failure with missing order name", logs)
+	}
+}
+
+func TestCmdOrderShowIncludesOverrideDisabledOrder(t *testing.T) {
+	clearCityRigFlags(t)
+	cityDir, _ := newPersistedOrderEnabledFilterCity(t)
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdOrderShow("drop", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdOrderShow = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "drop") {
+		t.Fatalf("stdout missing disabled order name:\n%s", stdout.String())
+	}
+}
+
+func TestCmdOrderHistoryIncludesOverrideDisabledOrder(t *testing.T) {
+	clearCityRigFlags(t)
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	cityDir, _ := newPersistedOrderEnabledFilterCity(t)
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openScopeLocalFileStore(cityDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := store.Create(beads.Bead{Title: "drop run", Type: "task", Labels: []string{"order-run:drop"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdOrderHistory("drop", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdOrderHistory = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), run.ID) {
+		t.Fatalf("stdout missing disabled order run %q:\n%s", run.ID, stdout.String())
+	}
+}
+
+func newOrderEnabledFilterCity(t *testing.T) (string, *config.City) {
+	t.Helper()
+
+	cityDir := t.TempDir()
+	formulasDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulasDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas: %v", err)
+	}
+	writeOrderEnabledFilterFixture(t, cityDir, "keep")
+	writeOrderEnabledFilterFixture(t, cityDir, "drop")
+
+	enabled := false
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulasDir},
+		},
+		Orders: config.OrdersConfig{
+			Overrides: []config.OrderOverride{
+				{Name: "drop", Enabled: &enabled},
+			},
+		},
+	}
+	return cityDir, cfg
+}
+
+func newPersistedOrderEnabledFilterCity(t *testing.T) (string, *config.City) {
+	t.Helper()
+
+	cityDir, cfg := newOrderEnabledFilterCity(t)
+	writeProviderAwareTestCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[[orders.overrides]]
+name = "drop"
+enabled = false
+`)
+	return cityDir, cfg
+}
+
+func writeOrderEnabledFilterFixture(t *testing.T, cityDir, name string) {
+	t.Helper()
+
+	ordersDir := filepath.Join(cityDir, "orders")
+	if err := os.MkdirAll(ordersDir, 0o755); err != nil {
+		t.Fatalf("mkdir orders: %v", err)
+	}
+	content := `[order]
+exec = "scripts/` + name + `.sh"
+trigger = "cooldown"
+interval = "1m"
+`
+	if err := os.WriteFile(filepath.Join(ordersDir, name+".toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write order %q: %v", name, err)
+	}
+}
+
+func requireOrderEnabledState(t *testing.T, aa []orders.Order, name string, want bool) {
+	t.Helper()
+
+	for _, a := range aa {
+		if a.Name == name {
+			if got := a.IsEnabled(); got != want {
+				t.Fatalf("order %q enabled = %v, want %v; all orders: %#v", name, got, want, aa)
+			}
+			return
+		}
+	}
+	t.Fatalf("order %q not found in %#v", name, aa)
+}
+
+func requireOrderAbsent(t *testing.T, aa []orders.Order, name string) {
+	t.Helper()
+
+	for _, a := range aa {
+		if a.Name == name {
+			t.Fatalf("order %q unexpectedly present in %#v", name, aa)
+		}
+	}
+}
+
+func requireOrderNames(t *testing.T, aa []orders.Order, want ...string) {
+	t.Helper()
+
+	if len(aa) != len(want) {
+		t.Fatalf("orders = %#v, want names %v", aa, want)
+	}
+	for i, name := range want {
+		if aa[i].Name != name {
+			t.Fatalf("orders[%d].Name = %q, want %q; all orders: %#v", i, aa[i].Name, name, aa)
+		}
+	}
+}
+
+func clearCityRigFlags(t *testing.T) {
+	t.Helper()
+
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
+	})
+}

--- a/internal/api/fake_state_test.go
+++ b/internal/api/fake_state_test.go
@@ -43,6 +43,7 @@ type fakeState struct {
 	startedAt     time.Time
 	quarantined   map[string]bool
 	autos         []orders.Order
+	allOrders     []orders.Order
 	services      workspacesvc.Registry
 	pokeCount     int
 	extmsgSvc     *extmsg.Services
@@ -90,15 +91,21 @@ func (f *fakeState) MailProviders() map[string]mail.Provider {
 	}
 	return map[string]mail.Provider{f.cityName: f.cityMailProv}
 }
-func (f *fakeState) EventProvider() events.Provider           { return f.eventProv }
-func (f *fakeState) CityName() string                         { return f.cityName }
-func (f *fakeState) CityPath() string                         { return f.cityPath }
-func (f *fakeState) Version() string                          { return "test" }
-func (f *fakeState) StartedAt() time.Time                     { return f.startedAt }
-func (f *fakeState) IsQuarantined(sessionName string) bool    { return f.quarantined[sessionName] }
-func (f *fakeState) ClearCrashHistory(sessionName string)     { delete(f.quarantined, sessionName) }
-func (f *fakeState) CityBeadStore() beads.Store               { return f.cityBeadStore }
-func (f *fakeState) Orders() []orders.Order                   { return f.autos }
+func (f *fakeState) EventProvider() events.Provider        { return f.eventProv }
+func (f *fakeState) CityName() string                      { return f.cityName }
+func (f *fakeState) CityPath() string                      { return f.cityPath }
+func (f *fakeState) Version() string                       { return "test" }
+func (f *fakeState) StartedAt() time.Time                  { return f.startedAt }
+func (f *fakeState) IsQuarantined(sessionName string) bool { return f.quarantined[sessionName] }
+func (f *fakeState) ClearCrashHistory(sessionName string)  { delete(f.quarantined, sessionName) }
+func (f *fakeState) CityBeadStore() beads.Store            { return f.cityBeadStore }
+func (f *fakeState) Orders() []orders.Order                { return f.autos }
+func (f *fakeState) OrdersAll() []orders.Order {
+	if f.allOrders != nil {
+		return f.allOrders
+	}
+	return f.autos
+}
 func (f *fakeState) Poke()                                    { f.pokeCount++ }
 func (f *fakeState) ServiceRegistry() workspacesvc.Registry   { return f.services }
 func (f *fakeState) ExtMsgServices() *extmsg.Services         { return f.extmsgSvc }

--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -208,6 +208,35 @@ func TestHandleOrderGet_ScopedName(t *testing.T) {
 	}
 }
 
+func TestHandleOrderGetResolvesDisabledOrder(t *testing.T) {
+	fs := newFakeState(t)
+	enabled := false
+	fs.allOrders = []orders.Order{
+		{Name: "health", Exec: "echo ok", Trigger: "cooldown", Enabled: &enabled},
+	}
+	fs.autos = orders.FilterEnabled(fs.allOrders)
+	h := newTestCityHandler(t, fs)
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/order/health"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp orderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Name != "health" {
+		t.Errorf("name = %q, want %q", resp.Name, "health")
+	}
+	if resp.Enabled {
+		t.Error("enabled = true, want false")
+	}
+}
+
 func TestHandleOrderGet_NotFound(t *testing.T) {
 	fs := newFakeState(t)
 	h := newTestCityHandler(t, fs)
@@ -270,6 +299,45 @@ func TestHandleOrderEnable(t *testing.T) {
 	ov := fs.cfg.Orders.Overrides[0]
 	if ov.Enabled == nil || !*ov.Enabled {
 		t.Error("expected enabled=true")
+	}
+}
+
+func TestHandleOrderDisableThenEnableResolvesFilteredOrder(t *testing.T) {
+	fs := newFakeMutatorState(t)
+	fs.allOrders = []orders.Order{
+		{Name: "health", Exec: "echo ok", Trigger: "cooldown"},
+	}
+	fs.autos = orders.FilterEnabled(fs.allOrders)
+	h := newTestCityHandler(t, fs)
+
+	req := newPostRequest(cityURL(fs, "/order/health/disable"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("disable status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	enabled := false
+	fs.allOrders = []orders.Order{
+		{Name: "health", Exec: "echo ok", Trigger: "cooldown", Enabled: &enabled},
+	}
+	fs.autos = orders.FilterEnabled(fs.allOrders)
+
+	req = newPostRequest(cityURL(fs, "/order/health/enable"), nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("enable status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	if len(fs.cfg.Orders.Overrides) != 1 {
+		t.Fatalf("expected 1 override, got %d", len(fs.cfg.Orders.Overrides))
+	}
+	ov := fs.cfg.Orders.Overrides[0]
+	if ov.Enabled == nil || !*ov.Enabled {
+		t.Error("expected enabled=true after re-enable")
 	}
 }
 
@@ -1015,6 +1083,53 @@ func TestHandleOrderHistoryUsesRigStore(t *testing.T) {
 	}
 	if resp.Entries[0].Rig != "myrig" {
 		t.Fatalf("rig = %q, want myrig", resp.Entries[0].Rig)
+	}
+}
+
+func TestHandleOrderHistoryUsesAllOrdersForDisabledExecMetadata(t *testing.T) {
+	fs := newFakeState(t)
+	fs.cityBeadStore = beads.NewMemStore()
+	disabled := false
+	fs.allOrders = []orders.Order{
+		{Name: "nightly-review", Exec: "scripts/nightly.sh", Trigger: "cooldown", Interval: "1h", Enabled: &disabled},
+	}
+
+	run, err := fs.cityBeadStore.Create(beads.Bead{
+		Title:  "nightly-review run",
+		Status: "closed",
+		Labels: []string{"order-run:nightly-review", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create history bead: %v", err)
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Entries []struct {
+			BeadID        string `json:"bead_id"`
+			CaptureOutput bool   `json:"capture_output"`
+			HasOutput     bool   `json:"has_output"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(resp.Entries))
+	}
+	if resp.Entries[0].BeadID != run.ID {
+		t.Fatalf("bead_id = %q, want %q", resp.Entries[0].BeadID, run.ID)
+	}
+	if !resp.Entries[0].CaptureOutput || !resp.Entries[0].HasOutput {
+		t.Fatalf("entry = %+v, want disabled exec order output metadata", resp.Entries[0])
 	}
 }
 

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -42,7 +42,7 @@ func (s *Server) humaHandleOrderGet(_ context.Context, input *OrderGetInput) (*s
 	Body orderResponse
 }, error,
 ) {
-	a, err := resolveOrder(s.state.Orders(), input.Name)
+	a, err := resolveOrder(s.state.OrdersAll(), input.Name)
 	if err != nil {
 		if errors.Is(err, errOrderAmbiguous) {
 			return nil, huma.Error409Conflict(err.Error())
@@ -194,7 +194,7 @@ func (s *Server) humaHandleOrderHistory(_ context.Context, input *OrderHistoryIn
 		beforeTime = t
 	}
 
-	aa := s.state.Orders()
+	aa := s.state.OrdersAll()
 	var auto *orders.Order
 	var orderDef orders.Order
 	for i, a := range aa {
@@ -654,7 +654,7 @@ func (s *Server) setOrderEnabledHuma(name string, enabled bool) (*OKResponse, er
 		return nil, errMutationsNotSupported
 	}
 
-	a, err := resolveOrder(s.state.Orders(), name)
+	a, err := resolveOrder(s.state.OrdersAll(), name)
 	if err != nil {
 		if errors.Is(err, errOrderAmbiguous) {
 			return nil, huma.Error409Conflict(err.Error())

--- a/internal/api/orders_feed.go
+++ b/internal/api/orders_feed.go
@@ -292,8 +292,9 @@ func listActiveWorkflowProjectionBeads(store beads.Store) ([]beads.Bead, error) 
 
 func buildOrderRunFeedItems(state State, requestedScopeKind, requestedScopeRef string) (orderRunFeedResult, error) {
 	stores := workflowStores(state)
-	orderByScopedName := make(map[string]orders.Order, len(state.Orders()))
-	for _, order := range state.Orders() {
+	allOrders := state.OrdersAll()
+	orderByScopedName := make(map[string]orders.Order, len(allOrders))
+	for _, order := range allOrders {
 		orderByScopedName[order.ScopedName()] = order
 	}
 

--- a/internal/api/orders_feed_test.go
+++ b/internal/api/orders_feed_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/orders"
 )
 
 func TestParseOrdersFeedLimitCapsLargeValues(t *testing.T) {
@@ -98,6 +99,39 @@ func TestBuildWorkflowRunProjectionsKeepsInProgressChildrenOnHistoryFailure(t *t
 	}
 	if !got.Items[0].UpdatedAt.Equal(child.CreatedAt) {
 		t.Fatalf("updatedAt = %s, want %s", got.Items[0].UpdatedAt, child.CreatedAt)
+	}
+}
+
+func TestBuildOrderRunFeedItemsUsesAllOrdersForDisabledExecMetadata(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	disabled := false
+	state.allOrders = []orders.Order{
+		{Name: "digest", Exec: "scripts/digest.sh", Trigger: "cooldown", Interval: "1h", Enabled: &disabled},
+	}
+
+	tracking, err := state.cityBeadStore.Create(beads.Bead{
+		Title:  "order:digest",
+		Status: "closed",
+		Labels: []string{"order-tracking", "order-run:digest", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create tracking bead: %v", err)
+	}
+
+	got, err := buildOrderRunFeedItems(state, "city", "test-city")
+	if err != nil {
+		t.Fatalf("buildOrderRunFeedItems: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(got.Items))
+	}
+	item := got.Items[0]
+	if item.BeadID != tracking.ID {
+		t.Fatalf("bead_id = %q, want %q", item.BeadID, tracking.ID)
+	}
+	if item.Type != "exec" || item.Target != "exec" || !item.DetailAvailable || !item.RunDetailAvailable {
+		t.Fatalf("item = %+v, want disabled exec order metadata", item)
 	}
 }
 

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -70,9 +70,14 @@ type State interface {
 	// Returns nil if no store is available.
 	CityBeadStore() beads.Store
 
-	// Orders returns the current set of scanned orders.
+	// Orders returns the current active set of scanned orders.
 	// Returns nil if orders are not configured.
 	Orders() []orders.Order
+
+	// OrdersAll returns the current set of scanned orders after overrides,
+	// including disabled orders that management endpoints still need to address.
+	// Returns nil if orders are not configured.
+	OrdersAll() []orders.Order
 
 	// Poke signals the controller to trigger an immediate reconciler tick.
 	// Used after sling assigns work so WakeWork wakes the target without

--- a/internal/orders/filter.go
+++ b/internal/orders/filter.go
@@ -1,0 +1,15 @@
+package orders
+
+// FilterEnabled returns a slice containing only enabled orders without modifying aa.
+func FilterEnabled(aa []Order) []Order {
+	if len(aa) == 0 {
+		return aa
+	}
+	filtered := make([]Order, 0, len(aa))
+	for _, a := range aa {
+		if a.IsEnabled() {
+			filtered = append(filtered, a)
+		}
+	}
+	return filtered
+}

--- a/internal/orders/filter_test.go
+++ b/internal/orders/filter_test.go
@@ -1,0 +1,82 @@
+package orders
+
+import "testing"
+
+func TestFilterEnabled(t *testing.T) {
+	t.Parallel()
+
+	disabled := boolPtr(false)
+	enabled := boolPtr(true)
+
+	tests := []struct {
+		name  string
+		input []Order
+		want  []string
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty",
+			input: []Order{},
+			want:  []string{},
+		},
+		{
+			name: "keeps default and explicit enabled",
+			input: []Order{
+				{Name: "default"},
+				{Name: "enabled", Enabled: enabled},
+			},
+			want: []string{"default", "enabled"},
+		},
+		{
+			name: "drops disabled",
+			input: []Order{
+				{Name: "before"},
+				{Name: "disabled", Enabled: disabled},
+				{Name: "after"},
+			},
+			want: []string{"before", "after"},
+		},
+		{
+			name: "all disabled",
+			input: []Order{
+				{Name: "one", Enabled: disabled},
+				{Name: "two", Enabled: disabled},
+			},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			original := make([]Order, len(tt.input))
+			copy(original, tt.input)
+
+			got := FilterEnabled(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("FilterEnabled() returned %d orders, want %d: %#v", len(got), len(tt.want), got)
+			}
+			for i, want := range tt.want {
+				if got[i].Name != want {
+					t.Fatalf("FilterEnabled()[%d].Name = %q, want %q", i, got[i].Name, want)
+				}
+			}
+			if tt.input != nil && len(tt.input) == 0 && got == nil {
+				t.Fatal("FilterEnabled(empty) returned nil, want the empty input slice")
+			}
+			if len(tt.input) != len(original) {
+				t.Fatalf("input length changed to %d, want %d", len(tt.input), len(original))
+			}
+			for i := range original {
+				if tt.input[i].Name != original[i].Name {
+					t.Fatalf("FilterEnabled mutated input at %d: got %q, want %q", i, tt.input[i].Name, original[i].Name)
+				}
+			}
+		})
+	}
+}

--- a/internal/orders/override.go
+++ b/internal/orders/override.go
@@ -31,6 +31,8 @@ type Override struct {
 }
 
 // ApplyOverrides applies each override to the matching order in aa.
+// Callers that need an active-only view should call FilterEnabled after
+// applying overrides because overrides can change an order's Enabled state.
 //
 // Matching rules:
 //   - ov.Rig == "":  matches only city-level orders (those with no rig).


### PR DESCRIPTION
Follow-up to https://github.com/gastownhall/gascity/pull/2191.

Original PR: https://github.com/gastownhall/gascity/pull/2191
Original title: fix(orders): filter disabled orders after overrides
Original state: MERGED
Configured base: main
Original GitHub base: main
Base mismatch: none

## Summary

The original PR filtered disabled orders after overrides and has already merged. During maintainer adoption review, the fix loop found that some management and inspection surfaces still need an all-orders view so override-disabled orders remain addressable.

This follow-up carries only the maintainer-side fixup on top of current `main`:

- keep active execution/list/check paths filtered to enabled orders
- keep `gc order show`, `gc order history`, API get/enable/disable, and history/feed metadata able to resolve disabled orders
- log override application failures where all-order state is built
- add focused regression coverage for the disabled-order override paths

## Validation

- `go test ./cmd/gc ./internal/api ./internal/orders -run 'Test(LoadActiveOrdersOverrideDisablesOrder|LoadAllOrdersPreservesOverrideDisabledOrder|BuildOrderDispatcherOverrideDisablesOrder|ControllerStateOrdersOverrideDisablesOrder|ControllerStateOrdersDisableEnableRoundTrip|ControllerStateOrdersAllLogsOverrideErrors|CmdOrderShowIncludesOverrideDisabledOrder|CmdOrderHistoryIncludesOverrideDisabledOrder|HandleOrderGetResolvesDisabledOrder|HandleOrderDisableThenEnableResolvesFilteredOrder|BuildOrderRunFeedItemsUsesAllOrdersForDisabledExecMetadata|HandleOrderHistoryUsesAllOrdersForDisabledExecMetadata|FilterEnabled)$'`

Adopted from PR #2191 after review. The original contributor commit is already on `main`; this PR contains only the maintainer fixup needed to complete the reviewed behavior.
