### PR TITLE
Fix formula attachment routing regression

### DIFF
--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -246,25 +246,7 @@ func slingOnFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, beadID 
 		}
 		result.WispRootID = wispRootID
 		result.FormulaName = opts.OnFormula
-		sr, err := finalize(opts, deps, beadID, method, result)
-		if err != nil {
-			return sr, err
-		}
-		if wispRootID != "" && deps.Router != nil {
-			rigDir := SlingDirForBead(deps.Cfg, deps.CityPath, wispRootID)
-			slingEnv := ResolveSlingEnv(a, deps, wispRootID)
-			req := RouteRequest{
-				BeadID:  wispRootID,
-				Target:  a.QualifiedName(),
-				WorkDir: rigDir,
-				Env:     slingEnv,
-			}
-			if routeErr := deps.Router.Route(context.Background(), req); routeErr != nil {
-				sr.MetadataErrors = append(sr.MetadataErrors,
-					fmt.Sprintf("routing molecule %s: %v", wispRootID, routeErr))
-			}
-		}
-		return sr, nil
+		return finalize(opts, deps, beadID, method, result)
 	}
 	runGraph := func() (pendingSourceWorkflowLaunch, error) {
 		mResult, err := InstantiateSlingFormula(context.Background(), opts.OnFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{
@@ -328,25 +310,7 @@ func slingDefaultFormula(opts SlingOpts, deps SlingDeps, querier BeadQuerier, be
 		}
 		result.WispRootID = wispRootID
 		result.FormulaName = defaultFormula
-		sr, err := finalize(opts, deps, beadID, method, result)
-		if err != nil {
-			return sr, err
-		}
-		if wispRootID != "" && deps.Router != nil {
-			rigDir := SlingDirForBead(deps.Cfg, deps.CityPath, wispRootID)
-			slingEnv := ResolveSlingEnv(a, deps, wispRootID)
-			req := RouteRequest{
-				BeadID:  wispRootID,
-				Target:  a.QualifiedName(),
-				WorkDir: rigDir,
-				Env:     slingEnv,
-			}
-			if routeErr := deps.Router.Route(context.Background(), req); routeErr != nil {
-				sr.MetadataErrors = append(sr.MetadataErrors,
-					fmt.Sprintf("routing molecule %s: %v", wispRootID, routeErr))
-			}
-		}
-		return sr, nil
+		return finalize(opts, deps, beadID, method, result)
 	}
 	runGraph := func() (pendingSourceWorkflowLaunch, error) {
 		mResult, err := InstantiateSlingFormula(context.Background(), defaultFormula, SlingFormulaSearchPaths(deps, a), molecule.Options{

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -1404,7 +1404,7 @@ func TestSlingRouteBeadWithTypedRouter(t *testing.T) {
 	}
 }
 
-func TestSlingAttachFormulaRoutesMoleculeRootWithTypedRouter(t *testing.T) {
+func TestSlingAttachFormulaRoutesSourceBeadWithTypedRouter(t *testing.T) {
 	router := &fakeBeadRouter{}
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
@@ -1422,18 +1422,25 @@ func TestSlingAttachFormulaRoutesMoleculeRootWithTypedRouter(t *testing.T) {
 		t.Fatalf("AttachFormula: %v", err)
 	}
 
-	if len(router.routed) != 2 {
-		t.Fatalf("got %d route calls, want 2", len(router.routed))
+	if result.WispRootID == "" {
+		t.Fatal("WispRootID is empty")
+	}
+	if len(router.routed) != 1 {
+		t.Fatalf("got %d route calls, want 1", len(router.routed))
 	}
 	if router.routed[0].BeadID != b.ID {
-		t.Fatalf("first routed BeadID = %q, want %q", router.routed[0].BeadID, b.ID)
+		t.Fatalf("routed BeadID = %q, want source bead %q", router.routed[0].BeadID, b.ID)
 	}
-	if router.routed[1].BeadID != result.WispRootID {
-		t.Fatalf("second routed BeadID = %q, want molecule root %q", router.routed[1].BeadID, result.WispRootID)
+	got, err := deps.Store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", b.ID, err)
+	}
+	if got.Metadata["molecule_id"] != result.WispRootID {
+		t.Fatalf("molecule_id metadata = %q, want %q", got.Metadata["molecule_id"], result.WispRootID)
 	}
 }
 
-func TestSlingRouteBeadDefaultFormulaRoutesMoleculeRootWithTypedRouter(t *testing.T) {
+func TestSlingRouteBeadDefaultFormulaRoutesSourceBeadWithTypedRouter(t *testing.T) {
 	router := &fakeBeadRouter{}
 	cfg := &config.City{Workspace: config.Workspace{Name: "test"}}
 	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
@@ -1451,14 +1458,21 @@ func TestSlingRouteBeadDefaultFormulaRoutesMoleculeRootWithTypedRouter(t *testin
 		t.Fatalf("RouteBead: %v", err)
 	}
 
-	if len(router.routed) != 2 {
-		t.Fatalf("got %d route calls, want 2", len(router.routed))
+	if result.WispRootID == "" {
+		t.Fatal("WispRootID is empty")
+	}
+	if len(router.routed) != 1 {
+		t.Fatalf("got %d route calls, want 1", len(router.routed))
 	}
 	if router.routed[0].BeadID != "BL-42" {
-		t.Fatalf("first routed BeadID = %q, want BL-42", router.routed[0].BeadID)
+		t.Fatalf("routed BeadID = %q, want source bead BL-42", router.routed[0].BeadID)
 	}
-	if router.routed[1].BeadID != result.WispRootID {
-		t.Fatalf("second routed BeadID = %q, want molecule root %q", router.routed[1].BeadID, result.WispRootID)
+	got, err := deps.Store.Get("BL-42")
+	if err != nil {
+		t.Fatalf("Get(BL-42): %v", err)
+	}
+	if got.Metadata["molecule_id"] != result.WispRootID {
+		t.Fatalf("molecule_id metadata = %q, want %q", got.Metadata["molecule_id"], result.WispRootID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate Gas Town routes/hooks the source task bead for formula-on-bead/default-formula attachment and stores the molecule root as attached metadata
- remove the extra molecule-root route added by PR #2177 for formula attachment paths
- add regression coverage that typed routing sees exactly the source bead and the source bead keeps molecule_id metadata

## Validation
- go test ./internal/sling -run 'TestSling(AttachFormulaRoutesSourceBeadWithTypedRouter|RouteBeadDefaultFormulaRoutesSourceBeadWithTypedRouter)' -count=1 failed before the fix with two route calls\n- go test ./internal/sling -count=1\n- go vet ./...\n\nNote: make test-fast-parallel exposed an unrelated/local Dolt preflight socket cleanup failure in TestDoltStatePreflightCleanCmdRemovesSocketsButPreservesDoltInternals; tracked as ga-noeirpi.