### PR TITLE
fix(cursor): make MCP approval explicit

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -167,24 +167,29 @@ the flock requirement entirely.
 
 ## Cursor MCP Tools Still Prompt or Appear Unavailable
 
-The built-in `cursor` provider starts `cursor-agent` with
-`-f --approve-mcps`. Cursor loads MCP servers from `.cursor/mcp.json` in the
-workspace, including files projected from Gas City's MCP catalog. The
-`--approve-mcps` flag approves every server visible to Cursor from that file
-or from `~/.cursor/mcp.json`.
+The built-in `cursor` provider starts `cursor-agent` with `-f` and leaves
+Cursor's MCP approval prompt enabled by default. This avoids silently approving
+user or global MCP servers that Cursor can also see through `~/.cursor/mcp.json`.
 
-If you override Cursor `args` in `city.toml`, the override replaces the
-built-in args. Include both flags yourself:
+For unattended Cursor pool workers, opt in only after confirming that every
+workspace and user/global MCP server visible to Cursor is trusted. The
+`--approve-mcps` flag approves every visible server, including servers projected
+from Gas City's catalog into `.cursor/mcp.json` and servers from
+`~/.cursor/mcp.json`.
 
 ```toml
-[providers.cursor]
-args = ["-f", "--approve-mcps"]
+[providers.cursor.option_defaults]
+mcp_approval = "approve"
 ```
 
-Agent-level `args` overrides behave the same way. Existing Cursor sessions keep
-the command they were created with, so stop and restart those sessions to pick
-up the new built-in default. Operators who want Cursor's MCP approval prompt
-can intentionally omit `--approve-mcps` in an explicit override.
+If you override Cursor `args` directly, the override replaces the built-in
+args. Include `-f` yourself and add `--approve-mcps` only for the same explicit
+trust decision. Agent-level `args` overrides behave the same way.
+
+Existing Cursor sessions keep the command fingerprint they were created with.
+The supervisor reconciler restarts sessions automatically after the fingerprint
+changes. Drain the pool first when you need a controlled handoff rather than
+waiting for the next automatic restart.
 
 ## `gc version` Prints Unexpected Output
 

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -145,11 +145,35 @@ func TestBuiltinProvidersCursor(t *testing.T) {
 	if p.Command != "cursor-agent" {
 		t.Errorf("Command = %q, want %q", p.Command, "cursor-agent")
 	}
-	if !reflect.DeepEqual(p.Args, []string{"-f", "--approve-mcps"}) {
-		t.Errorf("Args = %v, want [-f --approve-mcps]", p.Args)
+	if !reflect.DeepEqual(p.Args, []string{"-f"}) {
+		t.Errorf("Args = %v, want [-f]", p.Args)
 	}
-	if got := (&ResolvedProvider{Command: p.Command, Args: p.Args}).CommandString(); got != "cursor-agent -f --approve-mcps" {
-		t.Errorf("CommandString() = %q, want %q", got, "cursor-agent -f --approve-mcps")
+	rp := &ResolvedProvider{
+		Command:           p.Command,
+		Args:              p.Args,
+		OptionsSchema:     p.OptionsSchema,
+		EffectiveDefaults: ComputeEffectiveDefaults(p.OptionsSchema, p.OptionDefaults, nil),
+	}
+	if got := rp.CommandString(); got != "cursor-agent -f" {
+		t.Errorf("CommandString() = %q, want %q", got, "cursor-agent -f")
+	}
+	if got := rp.ResolveDefaultArgs(); len(got) != 0 {
+		t.Errorf("ResolveDefaultArgs() = %v, want no MCP approval args by default", got)
+	}
+	mcpApproval := findOption(p.OptionsSchema, "mcp_approval")
+	if mcpApproval == nil {
+		t.Fatal("OptionsSchema missing mcp_approval")
+	}
+	if mcpApproval.Default != "prompt" {
+		t.Errorf("mcp_approval default = %q, want prompt", mcpApproval.Default)
+	}
+	approve := findChoice(mcpApproval.Choices, "approve")
+	if approve == nil || !reflect.DeepEqual(approve.FlagArgs, []string{"--approve-mcps"}) {
+		t.Fatalf("mcp_approval approve choice = %+v, want --approve-mcps", approve)
+	}
+	rp.EffectiveDefaults = ComputeEffectiveDefaults(p.OptionsSchema, map[string]string{"mcp_approval": "approve"}, nil)
+	if got := rp.ResolveDefaultArgs(); !reflect.DeepEqual(got, []string{"--approve-mcps"}) {
+		t.Errorf("ResolveDefaultArgs(opt-in) = %v, want [--approve-mcps]", got)
 	}
 	if p.PromptMode != "arg" {
 		t.Errorf("PromptMode = %q, want %q", p.PromptMode, "arg")

--- a/internal/materialize/mcp_project.go
+++ b/internal/materialize/mcp_project.go
@@ -113,6 +113,9 @@ func (p MCPProjection) ApplyWithStderr(fs fsys.FS, stderr io.Writer) error {
 }
 
 func (p MCPProjection) applyWithStderr(fs fsys.FS, stderr io.Writer) error {
+	if err := p.validateProviderContract(); err != nil {
+		return err
+	}
 	if err := ensureNotSymlink(fs, p); err != nil {
 		return err
 	}
@@ -310,7 +313,7 @@ func (p MCPProjection) applyCursor(fs fsys.FS) error {
 			return removeManagedMCPFile(fs, p.markerPath())
 		}
 	} else {
-		doc["mcpServers"] = p.claudeServersDoc()
+		doc["mcpServers"] = p.cursorServersDoc()
 	}
 	data, err := marshalJSONDoc(doc)
 	if err != nil {
@@ -323,6 +326,24 @@ func (p MCPProjection) applyCursor(fs fsys.FS) error {
 		return removeManagedMCPFile(fs, p.markerPath())
 	}
 	return p.writeManagedMarker(fs)
+}
+
+func (p MCPProjection) validateProviderContract() error {
+	if p.Provider != MCPProviderCursor {
+		return nil
+	}
+	for _, server := range p.Servers {
+		switch server.Transport {
+		case MCPTransportStdio:
+		case MCPTransportHTTP, MCPTransportSSE:
+			return fmt.Errorf(
+				"cursor MCP projection does not support %s server %q: Cursor's HTTP/SSE mcpServers wire contract is not verified",
+				server.Transport,
+				server.Name,
+			)
+		}
+	}
+	return nil
 }
 
 func (p MCPProjection) claudeServersDoc() map[string]any {
@@ -343,6 +364,24 @@ func (p MCPProjection) claudeServersDoc() map[string]any {
 			entry["url"] = server.URL
 			if len(server.Headers) > 0 {
 				entry["headers"] = cloneStringMap(server.Headers)
+			}
+		}
+		out[server.Name] = entry
+	}
+	return out
+}
+
+func (p MCPProjection) cursorServersDoc() map[string]any {
+	out := make(map[string]any, len(p.Servers))
+	for _, server := range p.Servers {
+		entry := map[string]any{}
+		if server.Transport == MCPTransportStdio {
+			entry["command"] = server.Command
+			if len(server.Args) > 0 {
+				entry["args"] = append([]string(nil), server.Args...)
+			}
+			if len(server.Env) > 0 {
+				entry["env"] = cloneStringMap(server.Env)
 			}
 		}
 		out[server.Name] = entry

--- a/internal/materialize/mcp_project_test.go
+++ b/internal/materialize/mcp_project_test.go
@@ -175,12 +175,6 @@ func TestApplyMCPProjectionCursorWritesManagedFile(t *testing.T) {
 			Args:      []string{"pkg"},
 			Env:       map[string]string{"TOKEN": "secret"},
 		},
-		{
-			Name:      "remote",
-			Transport: MCPTransportHTTP,
-			URL:       "https://mcp.example.com",
-			Headers:   map[string]string{"Authorization": "Bearer token"},
-		},
 	})
 	if err != nil {
 		t.Fatalf("BuildMCPProjection: %v", err)
@@ -201,9 +195,6 @@ func TestApplyMCPProjectionCursorWritesManagedFile(t *testing.T) {
 	}
 	if _, ok := doc.MCPServers["alpha"]["command"]; !ok {
 		t.Fatalf("stdio server missing command: %+v", doc.MCPServers["alpha"])
-	}
-	if got := doc.MCPServers["remote"]["type"]; got != "http" {
-		t.Fatalf("remote type = %v, want http", got)
 	}
 
 	info, err := os.Stat(filepath.Join(dir, ".cursor", "mcp.json"))
@@ -232,6 +223,46 @@ func TestApplyMCPProjectionCursorWritesManagedFile(t *testing.T) {
 	}
 }
 
+func TestApplyMCPProjectionCursorRejectsUnverifiedRemoteTransport(t *testing.T) {
+	for _, transport := range []MCPTransport{MCPTransportHTTP, MCPTransportSSE} {
+		t.Run(string(transport), func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, ".cursor", "mcp.json")
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			existing := []byte(`{"mcpServers":{"user-authored":{"command":"custom"}}}` + "\n")
+			if err := os.WriteFile(target, existing, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			proj, err := BuildMCPProjection(MCPProviderCursor, dir, []MCPServer{
+				{Name: "remote", Transport: transport, URL: "https://mcp.example.com"},
+			})
+			if err != nil {
+				t.Fatalf("BuildMCPProjection: %v", err)
+			}
+			err = proj.Apply(fsys.OSFS{})
+			if err == nil {
+				t.Fatal("expected Cursor remote transport rejection, got nil")
+			}
+			if !strings.Contains(err.Error(), "Cursor's HTTP/SSE mcpServers wire contract is not verified") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			data, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatalf("ReadFile(target): %v", err)
+			}
+			if !reflect.DeepEqual(data, existing) {
+				t.Fatalf("target should not be rewritten on validation failure\n got: %q\nwant: %q", data, existing)
+			}
+			if _, err := os.Stat(filepath.Join(dir, ".gc", "mcp-adopted", "cursor")); !os.IsNotExist(err) {
+				t.Fatalf("validation failure must not create adoption snapshot, stat err = %v", err)
+			}
+		})
+	}
+}
+
 func TestApplyMCPProjectionCursorPreservesNonMCPSettings(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, ".cursor", "mcp.json")
@@ -252,9 +283,10 @@ func TestApplyMCPProjectionCursorPreservesNonMCPSettings(t *testing.T) {
 
 	proj, err := BuildMCPProjection(MCPProviderCursor, dir, []MCPServer{
 		{
-			Name:      "remote",
-			Transport: MCPTransportHTTP,
-			URL:       "https://mcp.example.com",
+			Name:      "alpha",
+			Transport: MCPTransportStdio,
+			Command:   "uvx",
+			Args:      []string{"pkg"},
 		},
 	})
 	if err != nil {
@@ -282,12 +314,12 @@ func TestApplyMCPProjectionCursorPreservesNonMCPSettings(t *testing.T) {
 	if _, ok := mcpServers["stale"]; ok {
 		t.Fatalf("stale server remained after projection: %+v", mcpServers)
 	}
-	remote, ok := mcpServers["remote"].(map[string]any)
+	alpha, ok := mcpServers["alpha"].(map[string]any)
 	if !ok {
-		t.Fatalf("remote server missing: %+v", mcpServers)
+		t.Fatalf("alpha server missing: %+v", mcpServers)
 	}
-	if got := remote["type"]; got != "http" {
-		t.Fatalf("remote.type = %v, want http", got)
+	if got := alpha["command"]; got != "uvx" {
+		t.Fatalf("alpha.command = %v, want uvx", got)
 	}
 
 	empty, err := BuildMCPProjection(MCPProviderCursor, dir, nil)
@@ -742,6 +774,73 @@ func TestApplyMCPProjectionSnapshotsExistingContentBeforeFirstAdoption(t *testin
 	}
 
 	// The stderr warning must name both paths so operators can recover.
+	warning := stderr.String()
+	if !strings.Contains(warning, "adopting provider-native MCP at "+target) {
+		t.Fatalf("stderr missing target path: %q", warning)
+	}
+	if !strings.Contains(warning, "snapshotted to ") {
+		t.Fatalf("stderr missing snapshot path: %q", warning)
+	}
+}
+
+func TestApplyMCPProjectionCursorAdoptsExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".cursor", "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := []byte(`{"mcpServers":{"user-authored":{"command":"custom"}}}` + "\n")
+	if err := os.WriteFile(target, existing, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr strings.Builder
+	restore := SetAdoptionStderr(&stderr)
+	defer restore()
+
+	proj, err := BuildMCPProjection(MCPProviderCursor, dir, []MCPServer{
+		{Name: "alpha", Transport: MCPTransportStdio, Command: "uvx"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	adoptedDir := filepath.Join(dir, ".gc", "mcp-adopted", "cursor")
+	entries, err := os.ReadDir(adoptedDir)
+	if err != nil {
+		t.Fatalf("ReadDir(adopted): %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 adoption snapshot, got %d: %v", len(entries), entries)
+	}
+	snapshot, err := os.ReadFile(filepath.Join(adoptedDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile(snapshot): %v", err)
+	}
+	if !reflect.DeepEqual(snapshot, existing) {
+		t.Fatalf("snapshot content mismatch\n  got:  %q\n  want: %q", snapshot, existing)
+	}
+
+	proj2, err := BuildMCPProjection(MCPProviderCursor, dir, []MCPServer{
+		{Name: "beta", Transport: MCPTransportStdio, Command: "uvx"},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(second): %v", err)
+	}
+	if err := proj2.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(second): %v", err)
+	}
+	entries2, err := os.ReadDir(adoptedDir)
+	if err != nil {
+		t.Fatalf("ReadDir(adopted) second pass: %v", err)
+	}
+	if len(entries2) != 1 {
+		t.Fatalf("adoption snapshot must only be taken once; got %d: %v", len(entries2), entries2)
+	}
+
 	warning := stderr.String()
 	if !strings.Contains(warning, "adopting provider-native MCP at "+target) {
 		t.Fatalf("stderr missing target path: %q", warning)

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -279,13 +279,9 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		ACPArgs:          []string{"acp", "--agent", "gascity"},
 	},
 	"cursor": {
-		DisplayName: "Cursor Agent",
-		Command:     "cursor-agent",
-		// --approve-mcps is required for non-interactive sessions: without it,
-		// cursor-agent gates MCP tool use behind an approval prompt that pool
-		// workers cannot answer, causing MCPs projected to or configured in
-		// .cursor/mcp.json to appear unavailable.
-		Args:              []string{"-f", "--approve-mcps"},
+		DisplayName:       "Cursor Agent",
+		Command:           "cursor-agent",
+		Args:              []string{"-f"},
 		PromptMode:        "arg",
 		ReadyPromptPrefix: "\u2192 ",
 		ReadyDelayMs:      10000,
@@ -294,6 +290,18 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		InstructionsFile:  "AGENTS.md",
 		ResumeFlag:        "--resume",
 		ResumeStyle:       "flag",
+		OptionsSchema: []BuiltinProviderOption{
+			{
+				Key:     "mcp_approval",
+				Label:   "MCP Approval",
+				Type:    "select",
+				Default: "prompt",
+				Choices: []BuiltinOptionChoice{
+					{Value: "prompt", Label: "Prompt for MCP approval"},
+					{Value: "approve", Label: "Approve visible MCP servers", FlagArgs: []string{"--approve-mcps"}},
+				},
+			},
+		},
 	},
 	"copilot": {
 		DisplayName: "GitHub Copilot",


### PR DESCRIPTION
Remediates post-merge review findings from #1176.

Changes:
- Makes Cursor MCP approval explicit: built-in Cursor now runs `cursor-agent -f` by default, with opt-in `[providers.cursor.option_defaults] mcp_approval = "approve"` adding `--approve-mcps`.
- Rejects Cursor HTTP/SSE MCP projection until Cursor's remote `mcpServers` wire contract is verified.
- Keeps Cursor MCP projection stdio-only, with adoption/idempotency coverage for existing `.cursor/mcp.json` files.
- Corrects troubleshooting docs to explain the opt-in approval risk and automatic fingerprint reconciliation.

Validation:
- `go test ./internal/materialize ./internal/config ./internal/worker/builtin`
- `go test ./cmd/gc -run 'TestInternalProjectMCPProjectsCursorConfig|TestResolveTemplateMCPIntegration|TestMCPConfigDoctor' -count=1`
- `go vet ./...`
- `git diff --check`

Broad gate note:
- `.githooks/pre-commit` was run and failed in its embedded full `make test`/`go test ./...` sweep with `cmd/gc` package-level failures unrelated to this patch.
- A representative failing test also fails on clean current `origin/main`: `go test ./cmd/gc -run '^TestControllerStateCreateRigPokesReconciler$' -count=1` fails with `bd schema not visible for ri after init`.