### PR TITLE
Treat identity.toml as the canonical project identity

### DIFF
--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -568,40 +568,35 @@ func verifyExternalDoltEndpoint(state contract.ConfigState, databaseScopeRoot, a
 		return fmt.Errorf("beads store not usable on external endpoint: %w", err)
 	}
 	if localProjectID == "" {
-		return fmt.Errorf("external endpoint identity unverifiable: local metadata.json is missing project_id; rerun with --adopt-unverified or repair the canonical metadata first")
+		return fmt.Errorf("external endpoint identity unverifiable: neither %s nor .beads/metadata.json carry a project_id; rerun with --adopt-unverified or seed the canonical identity first", projectIdentityDisplayPath)
 	}
 	if !ok {
 		return fmt.Errorf("external endpoint identity unverifiable: database %q is missing metadata _project_id; rerun with --adopt-unverified", strings.TrimSpace(database))
 	}
 	if localProjectID != databaseProjectID {
-		return fmt.Errorf("PROJECT IDENTITY MISMATCH — refusing to connect: local metadata.json project_id %q does not match database _project_id %q", localProjectID, databaseProjectID)
+		return fmt.Errorf(
+			"PROJECT IDENTITY MISMATCH — refusing to connect:\n"+
+				"  canonical local project_id    = %q   (from "+projectIdentityDisplayPath+" or metadata.json)\n"+
+				"  database metadata._project_id  = %q\n"+
+				"\n"+
+				"Inspect both values and resolve manually before reconnecting.",
+			localProjectID, databaseProjectID,
+		)
 	}
 	return nil
 }
 
 func readCanonicalProjectID(metadataPath string) (string, error) {
-	data, err := os.ReadFile(metadataPath)
+	scopeRoot, err := scopeRootFromMetadataPath(metadataPath)
 	if err != nil {
 		return "", err
 	}
-	var meta map[string]any
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return "", nil
-	}
-	raw, ok := meta["project_id"]
-	if !ok || raw == nil {
-		return "", nil
-	}
-	switch value := raw.(type) {
-	case string:
-		return strings.TrimSpace(value), nil
-	default:
-		projectID := strings.TrimSpace(fmt.Sprint(value))
-		if projectID == "" || projectID == "<nil>" || strings.EqualFold(projectID, "null") {
-			return "", nil
-		}
+	if projectID, ok, err := contract.ReadProjectIdentity(fsys.OSFS{}, scopeRoot); err != nil {
+		return "", err
+	} else if ok {
 		return projectID, nil
 	}
+	return readManagedMetadataProjectID(metadataPath)
 }
 
 func readDatabaseProjectID(ctx context.Context, db *sql.DB) (string, bool, error) {

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1190,6 +1190,53 @@ func TestCanonicalValidationPasswordUsesCredentialsFileOverride(t *testing.T) {
 	}
 }
 
+func TestReadCanonicalProjectIDReadsL1Authoritatively(t *testing.T) {
+	scopeRoot := t.TempDir()
+	writeRigEndpointMetadata(t, scopeRoot, "hq")
+	metadataPath := filepath.Join(scopeRoot, ".beads", "metadata.json")
+	writeMetadataProjectID(t, metadataPath, "legacy-l2")
+	if err := contract.WriteProjectIdentity(fsys.OSFS{}, scopeRoot, "canonical-l1"); err != nil {
+		t.Fatalf("WriteProjectIdentity: %v", err)
+	}
+
+	got, err := readCanonicalProjectID(metadataPath)
+	if err != nil {
+		t.Fatalf("readCanonicalProjectID: %v", err)
+	}
+	if got != "canonical-l1" {
+		t.Fatalf("readCanonicalProjectID() = %q, want canonical-l1", got)
+	}
+}
+
+func TestReadCanonicalProjectIDFallsBackToL2WhenL1Absent(t *testing.T) {
+	scopeRoot := t.TempDir()
+	writeRigEndpointMetadata(t, scopeRoot, "hq")
+	metadataPath := filepath.Join(scopeRoot, ".beads", "metadata.json")
+	writeMetadataProjectID(t, metadataPath, "legacy-l2")
+
+	got, err := readCanonicalProjectID(metadataPath)
+	if err != nil {
+		t.Fatalf("readCanonicalProjectID: %v", err)
+	}
+	if got != "legacy-l2" {
+		t.Fatalf("readCanonicalProjectID() = %q, want legacy-l2", got)
+	}
+}
+
+func TestReadCanonicalProjectIDReturnsEmptyWhenL1AndL2Missing(t *testing.T) {
+	scopeRoot := t.TempDir()
+	writeRigEndpointMetadata(t, scopeRoot, "hq")
+	metadataPath := filepath.Join(scopeRoot, ".beads", "metadata.json")
+
+	got, err := readCanonicalProjectID(metadataPath)
+	if err != nil {
+		t.Fatalf("readCanonicalProjectID: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("readCanonicalProjectID() = %q, want empty", got)
+	}
+}
+
 func TestVerifyExternalDoltEndpointRejectsEmptyExternalDoltDatabase(t *testing.T) {
 	skipSlowCmdGCTest(t, "requires a managed external dolt endpoint; run make test-cmd-gc-process for full coverage")
 	doltPath, err := exec.LookPath("dolt")
@@ -1298,8 +1345,9 @@ func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) 
 		t.Skip("dolt not installed")
 	}
 	bdPath := waitTestRealBDPath(t)
+	gcBin := currentGCBinaryForTests(t)
 	oldResolve := resolveProviderLifecycleGCBinary
-	resolveProviderLifecycleGCBinary = func() string { return currentGCBinaryForTests(t) }
+	resolveProviderLifecycleGCBinary = func() string { return gcBin }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
 	cityDir := t.TempDir()
@@ -1369,14 +1417,8 @@ func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) 
 	if _, err := db.ExecContext(ctx, "INSERT INTO metadata (`key`, value) VALUES ('_project_id', ?) ON DUPLICATE KEY UPDATE value = VALUES(value)", originalProjectID); err != nil {
 		t.Fatalf("seed database _project_id: %v", err)
 	}
-	meta["project_id"] = "different-project-id"
-	patched, err := json.MarshalIndent(meta, "", "  ")
-	if err != nil {
-		t.Fatalf("MarshalIndent(metadata.json): %v", err)
-	}
-	patched = append(patched, '\n')
-	if err := os.WriteFile(metadataPath, patched, 0o644); err != nil {
-		t.Fatalf("WriteFile(metadata.json): %v", err)
+	if err := contract.WriteProjectIdentity(fsys.OSFS{}, cityDir, "different-project-id"); err != nil {
+		t.Fatalf("WriteProjectIdentity: %v", err)
 	}
 
 	state := contract.ConfigState{
@@ -1394,6 +1436,9 @@ func TestVerifyExternalDoltEndpointRejectsProjectIdentityMismatch(t *testing.T) 
 	if !strings.Contains(strings.ToLower(err.Error()), "project identity mismatch") {
 		t.Fatalf("verifyExternalDoltEndpoint() error = %v", err)
 	}
+	if !strings.Contains(err.Error(), "different-project-id") || !strings.Contains(err.Error(), originalProjectID) {
+		t.Fatalf("verifyExternalDoltEndpoint() error = %v, want both project ids", err)
+	}
 }
 
 func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
@@ -1403,8 +1448,9 @@ func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
 		t.Skip("dolt not installed")
 	}
 	bdPath := waitTestRealBDPath(t)
+	gcBin := currentGCBinaryForTests(t)
 	oldResolve := resolveProviderLifecycleGCBinary
-	resolveProviderLifecycleGCBinary = func() string { return currentGCBinaryForTests(t) }
+	resolveProviderLifecycleGCBinary = func() string { return gcBin }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
 	cityDir := t.TempDir()
@@ -1469,6 +1515,9 @@ func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
 	if err := os.WriteFile(metadataPath, patched, 0o644); err != nil {
 		t.Fatalf("WriteFile(metadata.json): %v", err)
 	}
+	if err := os.Remove(contract.ProjectIdentityPath(cityDir)); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("Remove(identity.toml): %v", err)
+	}
 
 	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%s)/hq", port))
 	if err != nil {
@@ -1493,7 +1542,7 @@ func TestVerifyExternalDoltEndpointRejectsMissingLocalProjectID(t *testing.T) {
 	if err == nil {
 		t.Fatal("verifyExternalDoltEndpoint() unexpectedly succeeded for missing local project_id")
 	}
-	if !strings.Contains(strings.ToLower(err.Error()), "missing project_id") {
+	if !strings.Contains(err.Error(), "neither .beads/identity.toml nor .beads/metadata.json carry a project_id") {
 		t.Fatalf("verifyExternalDoltEndpoint() error = %v", err)
 	}
 }
@@ -1581,6 +1630,24 @@ func writeRigEndpointMetadata(t *testing.T, dir, doltDatabase string) {
 		DoltMode:     "server",
 		DoltDatabase: doltDatabase,
 	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMetadataProjectID(t *testing.T, metadataPath string, projectID string) {
+	t.Helper()
+	data := mustReadFile(t, metadataPath)
+	var meta map[string]any
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatal(err)
+	}
+	meta["project_id"] = projectID
+	encoded, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(metadataPath, encoded, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/gc/dolt_project_id.go
+++ b/cmd/gc/dolt_project_id.go
@@ -9,19 +9,59 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/fsys"
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 )
 
 type managedDoltProjectIDReport struct {
-	ProjectID       string
-	MetadataUpdated bool
-	DatabaseUpdated bool
-	Source          string
+	ProjectID           string
+	MetadataUpdated     bool
+	DatabaseUpdated     bool
+	IdentityFileUpdated bool
+	Source              string
+	Layer               string
+}
+
+var (
+	projectIdentityDisplayPath  = filepath.ToSlash(contract.ProjectIdentityPath(""))
+	projectIdentityProjectIDRef = projectIdentityDisplayPath + "#project.id"
+)
+
+type reconcileAction int
+
+const (
+	actionNoOp reconcileAction = iota
+	actionRefuseL1L3Mismatch
+	actionRepairL2
+	actionSeedL3
+	actionRepairL2SeedL3
+	actionSeedL2
+	actionSeedL2L3
+	actionMigrateFromL2
+	actionRefuseLegacyMismatch
+	actionMigrateL1SeedL3
+	actionAdoptFromL3SeedL2
+	actionGenerate
+)
+
+type reconcileDecision struct {
+	Action     reconcileAction
+	ResolvedID string
+	L1ID       string
+	L2ID       string
+	L3ID       string
+	Source     string
+	Layer      string
+	WriteL1    bool
+	WriteL2    bool
+	WriteL3    bool
 }
 
 func newEnsureProjectIDCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -68,15 +108,26 @@ func ensureManagedDoltProjectID(metadataPath, host, port, user, database string)
 	if metadataPath == "" {
 		return managedDoltProjectIDReport{}, fmt.Errorf("missing metadata path")
 	}
+	scopeRoot, err := scopeRootFromMetadataPath(metadataPath)
+	if err != nil {
+		return managedDoltProjectIDReport{}, err
+	}
 	database = strings.TrimSpace(database)
 	if database == "" {
 		return managedDoltProjectIDReport{}, fmt.Errorf("missing database")
+	}
+
+	fs := fsys.OSFS{}
+	identityProjectID, identityOK, err := contract.ReadProjectIdentity(fs, scopeRoot)
+	if err != nil {
+		return managedDoltProjectIDReport{}, err
 	}
 
 	metadataProjectID, err := readManagedMetadataProjectID(metadataPath)
 	if err != nil {
 		return managedDoltProjectIDReport{}, err
 	}
+	metadataOK := metadataProjectID != ""
 
 	db, err := managedDoltOpenDatabase(host, port, user, database)
 	if err != nil {
@@ -95,52 +146,8 @@ func ensureManagedDoltProjectID(metadataPath, host, port, user, database string)
 		return managedDoltProjectIDReport{}, err
 	}
 
-	report := managedDoltProjectIDReport{}
-	switch {
-	case metadataProjectID != "" && ok:
-		if metadataProjectID != databaseProjectID {
-			return managedDoltProjectIDReport{}, fmt.Errorf("metadata project_id %q does not match database _project_id %q", metadataProjectID, databaseProjectID)
-		}
-		report.ProjectID = metadataProjectID
-		report.Source = "existing"
-		return report, nil
-	case metadataProjectID != "":
-		updated, err := seedDatabaseProjectID(ctx, db, metadataProjectID)
-		if err != nil {
-			return managedDoltProjectIDReport{}, err
-		}
-		report.ProjectID = metadataProjectID
-		report.DatabaseUpdated = updated
-		report.Source = "metadata"
-		return report, nil
-	case ok:
-		updated, err := writeManagedMetadataProjectID(metadataPath, databaseProjectID)
-		if err != nil {
-			return managedDoltProjectIDReport{}, err
-		}
-		report.ProjectID = databaseProjectID
-		report.MetadataUpdated = updated
-		report.Source = "database"
-		return report, nil
-	default:
-		projectID, err := generateLocalProjectID()
-		if err != nil {
-			return managedDoltProjectIDReport{}, err
-		}
-		metaUpdated, err := writeManagedMetadataProjectID(metadataPath, projectID)
-		if err != nil {
-			return managedDoltProjectIDReport{}, err
-		}
-		dbUpdated, err := seedDatabaseProjectID(ctx, db, projectID)
-		if err != nil {
-			return managedDoltProjectIDReport{}, err
-		}
-		report.ProjectID = projectID
-		report.MetadataUpdated = metaUpdated
-		report.DatabaseUpdated = dbUpdated
-		report.Source = "generated"
-		return report, nil
-	}
+	decision := decideReconcile(identityProjectID, identityOK, metadataProjectID, metadataOK, databaseProjectID, ok)
+	return applyReconcileDecision(ctx, fs, scopeRoot, metadataPath, db, decision)
 }
 
 func managedDoltProjectIDFields(report managedDoltProjectIDReport) []string {
@@ -149,7 +156,252 @@ func managedDoltProjectIDFields(report managedDoltProjectIDReport) []string {
 		"metadata_updated\t" + strconv.FormatBool(report.MetadataUpdated),
 		"database_updated\t" + strconv.FormatBool(report.DatabaseUpdated),
 		"source\t" + report.Source,
+		"identity_file_updated\t" + strconv.FormatBool(report.IdentityFileUpdated),
+		"layer\t" + report.Layer,
 	}
+}
+
+func scopeRootFromMetadataPath(metadataPath string) (string, error) {
+	cleaned := filepath.Clean(strings.TrimSpace(metadataPath))
+	if filepath.Base(cleaned) != "metadata.json" || filepath.Base(filepath.Dir(cleaned)) != ".beads" {
+		return "", fmt.Errorf("metadata path %q is not <scope>/.beads/metadata.json", metadataPath)
+	}
+	return filepath.Dir(filepath.Dir(cleaned)), nil
+}
+
+func decideReconcile(l1 string, l1ok bool, l2 string, l2ok bool, l3 string, l3ok bool) reconcileDecision {
+	if l1ok {
+		switch {
+		case l2ok && l3ok:
+			switch {
+			case l1 == l2 && l2 == l3:
+				return reconcileDecision{Action: actionNoOp, ResolvedID: l1, Source: "match", Layer: "l1"}
+			case l1 == l2 && l1 != l3:
+				return reconcileDecision{Action: actionRefuseL1L3Mismatch, L1ID: l1, L2ID: l2, L3ID: l3}
+			case l1 != l2 && l1 == l3:
+				return reconcileDecision{Action: actionRepairL2, ResolvedID: l1, L1ID: l1, L2ID: l2, L3ID: l3, Source: "l2-repair", Layer: "l1", WriteL2: true}
+			default:
+				return reconcileDecision{Action: actionRefuseL1L3Mismatch, L1ID: l1, L2ID: l2, L3ID: l3}
+			}
+		case l2ok && !l3ok:
+			if l1 == l2 {
+				return reconcileDecision{Action: actionSeedL3, ResolvedID: l1, L1ID: l1, L2ID: l2, Source: "l3-seed", Layer: "l1", WriteL3: true}
+			}
+			return reconcileDecision{Action: actionRepairL2SeedL3, ResolvedID: l1, L1ID: l1, L2ID: l2, Source: "l2-repair-l3-seed", Layer: "l1", WriteL2: true, WriteL3: true}
+		case !l2ok && l3ok:
+			if l1 == l3 {
+				return reconcileDecision{Action: actionSeedL2, ResolvedID: l1, L1ID: l1, L3ID: l3, Source: "l2-seed", Layer: "l1", WriteL2: true}
+			}
+			return reconcileDecision{Action: actionRefuseL1L3Mismatch, L1ID: l1, L3ID: l3}
+		default:
+			return reconcileDecision{Action: actionSeedL2L3, ResolvedID: l1, L1ID: l1, Source: "l2-l3-seed", Layer: "l1", WriteL2: true, WriteL3: true}
+		}
+	}
+
+	switch {
+	case l2ok && l3ok:
+		if l2 == l3 {
+			return reconcileDecision{Action: actionMigrateFromL2, ResolvedID: l2, L2ID: l2, L3ID: l3, Source: "l1-migrate-from-l2", Layer: "l2", WriteL1: true}
+		}
+		return reconcileDecision{Action: actionRefuseLegacyMismatch, L2ID: l2, L3ID: l3}
+	case l2ok && !l3ok:
+		return reconcileDecision{Action: actionMigrateL1SeedL3, ResolvedID: l2, L2ID: l2, Source: "l1-migrate-l3-seed", Layer: "l2", WriteL1: true, WriteL3: true}
+	case !l2ok && l3ok:
+		return reconcileDecision{Action: actionAdoptFromL3SeedL2, ResolvedID: l3, L3ID: l3, Source: "l1-adopt-l2-seed", Layer: "l3", WriteL1: true, WriteL2: true}
+	default:
+		return reconcileDecision{Action: actionGenerate, Source: "generated", Layer: "generated", WriteL1: true, WriteL2: true, WriteL3: true}
+	}
+}
+
+func applyReconcileDecision(ctx context.Context, fs fsys.FS, scopeRoot string, metadataPath string, db *sql.DB, decision reconcileDecision) (managedDoltProjectIDReport, error) {
+	report := managedDoltProjectIDReport{
+		ProjectID: decision.ResolvedID,
+		Source:    decision.Source,
+		Layer:     decision.Layer,
+	}
+
+	switch decision.Action {
+	case actionNoOp:
+		return report, nil
+	case actionRefuseL1L3Mismatch:
+		return managedDoltProjectIDReport{}, formatL1L3MismatchError(decision.L1ID, decision.L3ID)
+	case actionRefuseLegacyMismatch:
+		return managedDoltProjectIDReport{}, formatLegacyL2L3MismatchError(decision.L2ID, decision.L3ID)
+	case actionRepairL2:
+		// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event with
+		// source="l2-repair", before=l2ID, after=l1ID, layers_updated=[l2].
+		updated, err := writeManagedMetadataProjectID(metadataPath, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.MetadataUpdated = updated
+		return report, nil
+	case actionSeedL3:
+		// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event with
+		// source="l3-seed", before="", after=l1ID, layers_updated=[l3].
+		updated, err := seedDatabaseProjectID(ctx, db, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.DatabaseUpdated = updated
+		return report, nil
+	case actionRepairL2SeedL3:
+		// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event with
+		// source="l2-repair-l3-seed", before=l2ID, after=l1ID, layers_updated=[l2,l3].
+		metaUpdated, err := writeManagedMetadataProjectID(metadataPath, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		dbUpdated, err := seedDatabaseProjectID(ctx, db, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.MetadataUpdated = metaUpdated
+		report.DatabaseUpdated = dbUpdated
+		return report, nil
+	case actionSeedL2:
+		// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event with
+		// source="l2-seed", before="", after=l1ID, layers_updated=[l2].
+		updated, err := writeManagedMetadataProjectID(metadataPath, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.MetadataUpdated = updated
+		return report, nil
+	case actionSeedL2L3:
+		// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event with
+		// source="l2-l3-seed", before="", after=l1ID, layers_updated=[l2,l3].
+		metaUpdated, err := writeManagedMetadataProjectID(metadataPath, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		dbUpdated, err := seedDatabaseProjectID(ctx, db, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.MetadataUpdated = metaUpdated
+		report.DatabaseUpdated = dbUpdated
+		return report, nil
+	case actionMigrateFromL2:
+		// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event with
+		// source="l1-migrate-from-l2", before="", after=l2ID, layers_updated=[l1].
+		updated, err := writeProjectIdentityIfNeeded(fs, scopeRoot, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.IdentityFileUpdated = updated
+		return report, nil
+	case actionMigrateL1SeedL3:
+		// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event with
+		// source="l1-migrate-l3-seed", before="", after=l2ID, layers_updated=[l1,l3].
+		identityUpdated, err := writeProjectIdentityIfNeeded(fs, scopeRoot, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		dbUpdated, err := seedDatabaseProjectID(ctx, db, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.IdentityFileUpdated = identityUpdated
+		report.DatabaseUpdated = dbUpdated
+		return report, nil
+	case actionAdoptFromL3SeedL2:
+		// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event with
+		// source="l1-adopt-l2-seed", before="", after=l3ID, layers_updated=[l1,l2].
+		identityUpdated, err := writeProjectIdentityIfNeeded(fs, scopeRoot, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		metaUpdated, err := writeManagedMetadataProjectID(metadataPath, decision.ResolvedID)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.IdentityFileUpdated = identityUpdated
+		report.MetadataUpdated = metaUpdated
+		return report, nil
+	case actionGenerate:
+		projectID, err := generateLocalProjectID()
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		identityUpdated, metaUpdated, dbUpdated, err := writeProjectIdentityToAllLayers(ctx, fs, scopeRoot, db, projectID, decision.Source)
+		if err != nil {
+			return managedDoltProjectIDReport{}, err
+		}
+		report.ProjectID = projectID
+		report.IdentityFileUpdated = identityUpdated
+		report.MetadataUpdated = metaUpdated
+		report.DatabaseUpdated = dbUpdated
+		return report, nil
+	default:
+		return managedDoltProjectIDReport{}, fmt.Errorf("unknown project identity reconcile action %d", decision.Action)
+	}
+}
+
+func writeProjectIdentityIfNeeded(fs fsys.FS, scopeRoot string, id string) (bool, error) {
+	existing, ok, err := contract.ReadProjectIdentity(fs, scopeRoot)
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		if existing == id {
+			return false, nil
+		}
+		return false, fmt.Errorf("identity %s already has project.id %q, refusing to overwrite with %q", contract.ProjectIdentityPath(scopeRoot), existing, id)
+	}
+	if err := contract.WriteProjectIdentity(fs, scopeRoot, id); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func writeProjectIdentityToAllLayers(ctx context.Context, fs fsys.FS, scopeRoot string, db *sql.DB, id string, source string) (l1Updated, l2Updated, l3Updated bool, err error) {
+	l1Updated, err = writeProjectIdentityIfNeeded(fs, scopeRoot, id)
+	if err != nil {
+		return false, false, false, err
+	}
+	metadataPath := filepath.Join(scopeRoot, ".beads", "metadata.json")
+	l2Updated, err = writeManagedMetadataProjectID(metadataPath, id)
+	if err != nil {
+		return l1Updated, false, false, err
+	}
+	l3Updated, err = seedDatabaseProjectID(ctx, db, id)
+	if err != nil {
+		return l1Updated, l2Updated, false, err
+	}
+	// TODO(ga-3ski1 child C / ga-ue241): emit project.identity.stamped event here,
+	// payload {scope, source, before, after, layers_updated: [l1,l2,l3]}.
+	_ = source
+	return l1Updated, l2Updated, l3Updated, nil
+}
+
+func formatL1L3MismatchError(l1, l3 string) error {
+	return fmt.Errorf(
+		"PROJECT IDENTITY MISMATCH — refusing to connect:\n"+
+			"  canonical "+projectIdentityProjectIDRef+" = %q\n"+
+			"  database metadata._project_id              = %q\n"+
+			"\n"+
+			"The git-tracked identity does not match the database stamp. "+
+			"The database may belong to a different rig, or the identity "+
+			"file may have been changed without re-stamping the database. "+
+			"Inspect both values and resolve manually before reconnecting.",
+		l1, l3,
+	)
+}
+
+func formatLegacyL2L3MismatchError(l2, l3 string) error {
+	return fmt.Errorf(
+		"LEGACY PROJECT IDENTITY MISMATCH — refusing to connect:\n"+
+			"  metadata.json project_id      = %q\n"+
+			"  database metadata._project_id  = %q\n"+
+			"\n"+
+			"This rig predates the canonical "+projectIdentityDisplayPath+" file. "+
+			"The two legacy storage layers disagree, so we cannot safely "+
+			"seed the canonical layer from either one. Inspect both values "+
+			"and decide which is correct, then create "+projectIdentityDisplayPath+" "+
+			"with the chosen value to unblock reconcile.",
+		l2, l3,
+	)
 }
 
 func managedDoltOpenDatabase(host, port, user, database string) (*sql.DB, error) {

--- a/cmd/gc/dolt_project_id_decide_test.go
+++ b/cmd/gc/dolt_project_id_decide_test.go
@@ -1,0 +1,198 @@
+package main
+
+import "testing"
+
+func TestReconcileDecisionTable(t *testing.T) {
+	cases := []struct {
+		name         string
+		l1           string
+		l1ok         bool
+		l2           string
+		l2ok         bool
+		l3           string
+		l3ok         bool
+		wantAction   reconcileAction
+		wantResolved string
+		wantSource   string
+		wantLayer    string
+		wantWriteL1  bool
+		wantWriteL2  bool
+		wantWriteL3  bool
+	}{
+		{
+			name:         "R1_L1L2L3_AllMatch_NoOp",
+			l1:           "id-a",
+			l1ok:         true,
+			l2:           "id-a",
+			l2ok:         true,
+			l3:           "id-a",
+			l3ok:         true,
+			wantAction:   actionNoOp,
+			wantResolved: "id-a",
+			wantSource:   "match",
+			wantLayer:    "l1",
+		},
+		{
+			name:       "R2_L1L2L3_L1eqL2_L3Differs_RefuseL1L3",
+			l1:         "id-a",
+			l1ok:       true,
+			l2:         "id-a",
+			l2ok:       true,
+			l3:         "id-b",
+			l3ok:       true,
+			wantAction: actionRefuseL1L3Mismatch,
+		},
+		{
+			name:         "R3_L1L2L3_L2Wrong_L1eqL3_RepairL2",
+			l1:           "id-a",
+			l1ok:         true,
+			l2:           "id-b",
+			l2ok:         true,
+			l3:           "id-a",
+			l3ok:         true,
+			wantAction:   actionRepairL2,
+			wantResolved: "id-a",
+			wantSource:   "l2-repair",
+			wantLayer:    "l1",
+			wantWriteL2:  true,
+		},
+		{
+			name:       "R4_L1L2L3_BothWrong_RefuseL1L3",
+			l1:         "id-a",
+			l1ok:       true,
+			l2:         "id-b",
+			l2ok:       true,
+			l3:         "id-c",
+			l3ok:       true,
+			wantAction: actionRefuseL1L3Mismatch,
+		},
+		{
+			name:         "R5_L1L2_NoL3_L1eqL2_SeedL3",
+			l1:           "id-a",
+			l1ok:         true,
+			l2:           "id-a",
+			l2ok:         true,
+			wantAction:   actionSeedL3,
+			wantResolved: "id-a",
+			wantSource:   "l3-seed",
+			wantLayer:    "l1",
+			wantWriteL3:  true,
+		},
+		{
+			name:         "R6_L1L2_NoL3_L2Wrong_RepairL2SeedL3",
+			l1:           "id-a",
+			l1ok:         true,
+			l2:           "id-b",
+			l2ok:         true,
+			wantAction:   actionRepairL2SeedL3,
+			wantResolved: "id-a",
+			wantSource:   "l2-repair-l3-seed",
+			wantLayer:    "l1",
+			wantWriteL2:  true,
+			wantWriteL3:  true,
+		},
+		{
+			name:         "R7_L1NoL2_L3_L1eqL3_SeedL2",
+			l1:           "id-a",
+			l1ok:         true,
+			l3:           "id-a",
+			l3ok:         true,
+			wantAction:   actionSeedL2,
+			wantResolved: "id-a",
+			wantSource:   "l2-seed",
+			wantLayer:    "l1",
+			wantWriteL2:  true,
+		},
+		{
+			name:       "R8_L1NoL2_L3_L1neqL3_RefuseL1L3",
+			l1:         "id-a",
+			l1ok:       true,
+			l3:         "id-b",
+			l3ok:       true,
+			wantAction: actionRefuseL1L3Mismatch,
+		},
+		{
+			name:         "R9_L1Only_SeedL2L3",
+			l1:           "id-a",
+			l1ok:         true,
+			wantAction:   actionSeedL2L3,
+			wantResolved: "id-a",
+			wantSource:   "l2-l3-seed",
+			wantLayer:    "l1",
+			wantWriteL2:  true,
+			wantWriteL3:  true,
+		},
+		{
+			name:         "R10_NoL1_L2eqL3_MigrateL1FromL2",
+			l2:           "id-a",
+			l2ok:         true,
+			l3:           "id-a",
+			l3ok:         true,
+			wantAction:   actionMigrateFromL2,
+			wantResolved: "id-a",
+			wantSource:   "l1-migrate-from-l2",
+			wantLayer:    "l2",
+			wantWriteL1:  true,
+		},
+		{
+			name:       "R11_NoL1_L2neqL3_RefuseLegacy",
+			l2:         "id-a",
+			l2ok:       true,
+			l3:         "id-b",
+			l3ok:       true,
+			wantAction: actionRefuseLegacyMismatch,
+		},
+		{
+			name:         "R12_NoL1_L2Only_MigrateL1SeedL3",
+			l2:           "id-a",
+			l2ok:         true,
+			wantAction:   actionMigrateL1SeedL3,
+			wantResolved: "id-a",
+			wantSource:   "l1-migrate-l3-seed",
+			wantLayer:    "l2",
+			wantWriteL1:  true,
+			wantWriteL3:  true,
+		},
+		{
+			name:         "R13_NoL1NoL2_L3Only_AdoptL1SeedL2",
+			l3:           "id-a",
+			l3ok:         true,
+			wantAction:   actionAdoptFromL3SeedL2,
+			wantResolved: "id-a",
+			wantSource:   "l1-adopt-l2-seed",
+			wantLayer:    "l3",
+			wantWriteL1:  true,
+			wantWriteL2:  true,
+		},
+		{
+			name:        "R14_AllAbsent_Generate",
+			wantAction:  actionGenerate,
+			wantSource:  "generated",
+			wantLayer:   "generated",
+			wantWriteL1: true,
+			wantWriteL2: true,
+			wantWriteL3: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideReconcile(tc.l1, tc.l1ok, tc.l2, tc.l2ok, tc.l3, tc.l3ok)
+			if got.Action != tc.wantAction {
+				t.Fatalf("Action = %v, want %v", got.Action, tc.wantAction)
+			}
+			if got.ResolvedID != tc.wantResolved {
+				t.Fatalf("ResolvedID = %q, want %q", got.ResolvedID, tc.wantResolved)
+			}
+			if got.Source != tc.wantSource {
+				t.Fatalf("Source = %q, want %q", got.Source, tc.wantSource)
+			}
+			if got.Layer != tc.wantLayer {
+				t.Fatalf("Layer = %q, want %q", got.Layer, tc.wantLayer)
+			}
+			if got.WriteL1 != tc.wantWriteL1 || got.WriteL2 != tc.wantWriteL2 || got.WriteL3 != tc.wantWriteL3 {
+				t.Fatalf("writes = (L1:%v L2:%v L3:%v), want (L1:%v L2:%v L3:%v)", got.WriteL1, got.WriteL2, got.WriteL3, tc.wantWriteL1, tc.wantWriteL2, tc.wantWriteL3)
+			}
+		})
+	}
+}

--- a/cmd/gc/dolt_project_id_test.go
+++ b/cmd/gc/dolt_project_id_test.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabaseMissing(t *testing.T) {
@@ -88,6 +91,9 @@ func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabase
 	if err := os.WriteFile(metadataPath, patched, 0o644); err != nil {
 		t.Fatalf("WriteFile(metadata.json): %v", err)
 	}
+	if err := os.Remove(contract.ProjectIdentityPath(cityDir)); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("Remove(identity.toml): %v", err)
+	}
 
 	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%s)/hq", port))
 	if err != nil {
@@ -113,6 +119,12 @@ func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabase
 	if !report.DatabaseUpdated {
 		t.Fatal("report.DatabaseUpdated = false, want true")
 	}
+	if !report.IdentityFileUpdated {
+		t.Fatal("report.IdentityFileUpdated = false, want true")
+	}
+	if report.Layer != "generated" {
+		t.Fatalf("report.Layer = %q, want generated", report.Layer)
+	}
 	if !strings.HasPrefix(report.ProjectID, "gc-local-") {
 		t.Fatalf("report.ProjectID = %q, want gc-local-*", report.ProjectID)
 	}
@@ -137,6 +149,254 @@ func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWhenMetadataAndDatabase
 	}
 	if got := strings.TrimSpace(databaseProjectID); got != report.ProjectID {
 		t.Fatalf("database _project_id = %q, want %q", got, report.ProjectID)
+	}
+
+	identityProjectID, ok, err := contract.ReadProjectIdentity(fsys.OSFS{}, cityDir)
+	if err != nil {
+		t.Fatalf("ReadProjectIdentity: %v", err)
+	}
+	if !ok {
+		t.Fatal("identity project id missing")
+	}
+	if identityProjectID != report.ProjectID {
+		t.Fatalf("identity project_id = %q, want %q", identityProjectID, report.ProjectID)
+	}
+}
+
+func TestEnsureManagedDoltProjectIDLegacyMigration(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
+	scopeRoot := t.TempDir()
+	metadataPath := writeProjectIDMetadataFile(t, scopeRoot, "legacy-id")
+	port, cleanup := startProjectIDTestServer(t)
+	defer cleanup()
+
+	report, err := ensureManagedDoltProjectID(metadataPath, "127.0.0.1", port, "root", "hq")
+	if err != nil {
+		t.Fatalf("ensureManagedDoltProjectID: %v", err)
+	}
+	if report.ProjectID != "legacy-id" || report.Source != "l1-migrate-l3-seed" || report.Layer != "l2" {
+		t.Fatalf("report = %+v, want l2 migration", report)
+	}
+	if !report.IdentityFileUpdated || report.MetadataUpdated || !report.DatabaseUpdated {
+		t.Fatalf("report updates = %+v, want identity+database only", report)
+	}
+	assertProjectIdentityFile(t, scopeRoot, "legacy-id")
+	assertMetadataProjectID(t, metadataPath, "legacy-id")
+	assertDatabaseProjectID(t, port, "legacy-id")
+}
+
+func TestEnsureManagedDoltProjectIDDBReseed(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
+	scopeRoot := t.TempDir()
+	metadataPath := writeProjectIDMetadataFile(t, scopeRoot, "canonical-id")
+	if err := contract.WriteProjectIdentity(fsys.OSFS{}, scopeRoot, "canonical-id"); err != nil {
+		t.Fatalf("WriteProjectIdentity: %v", err)
+	}
+	port, cleanup := startProjectIDTestServer(t)
+	defer cleanup()
+
+	report, err := ensureManagedDoltProjectID(metadataPath, "127.0.0.1", port, "root", "hq")
+	if err != nil {
+		t.Fatalf("ensureManagedDoltProjectID: %v", err)
+	}
+	if report.ProjectID != "canonical-id" || report.Source != "l3-seed" || report.Layer != "l1" {
+		t.Fatalf("report = %+v, want l3 seed from l1", report)
+	}
+	if report.IdentityFileUpdated || report.MetadataUpdated || !report.DatabaseUpdated {
+		t.Fatalf("report updates = %+v, want database only", report)
+	}
+	assertProjectIdentityFile(t, scopeRoot, "canonical-id")
+	assertMetadataProjectID(t, metadataPath, "canonical-id")
+	assertDatabaseProjectID(t, port, "canonical-id")
+}
+
+func TestEnsureManagedDoltProjectIDHotPathNoOp(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
+	scopeRoot := t.TempDir()
+	metadataPath := writeProjectIDMetadataFile(t, scopeRoot, "canonical-id")
+	if err := contract.WriteProjectIdentity(fsys.OSFS{}, scopeRoot, "canonical-id"); err != nil {
+		t.Fatalf("WriteProjectIdentity: %v", err)
+	}
+	port, cleanup := startProjectIDTestServer(t, seedDatabaseProjectIDQueries("canonical-id")...)
+	defer cleanup()
+	beforeIdentity := mustReadFile(t, contract.ProjectIdentityPath(scopeRoot))
+	beforeMetadata := mustReadFile(t, metadataPath)
+
+	report, err := ensureManagedDoltProjectID(metadataPath, "127.0.0.1", port, "root", "hq")
+	if err != nil {
+		t.Fatalf("ensureManagedDoltProjectID: %v", err)
+	}
+	if report.ProjectID != "canonical-id" || report.Source != "match" || report.Layer != "l1" {
+		t.Fatalf("report = %+v, want hot-path match", report)
+	}
+	if report.IdentityFileUpdated || report.MetadataUpdated || report.DatabaseUpdated {
+		t.Fatalf("report updates = %+v, want no updates", report)
+	}
+	if got := mustReadFile(t, contract.ProjectIdentityPath(scopeRoot)); string(got) != string(beforeIdentity) {
+		t.Fatalf("identity changed on hot path:\n%s", got)
+	}
+	if got := mustReadFile(t, metadataPath); string(got) != string(beforeMetadata) {
+		t.Fatalf("metadata changed on hot path:\n%s", got)
+	}
+	assertDatabaseProjectID(t, port, "canonical-id")
+}
+
+func TestEnsureManagedDoltProjectIDRefusesL1L3Mismatch(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
+	scopeRoot := t.TempDir()
+	metadataPath := writeProjectIDMetadataFile(t, scopeRoot, "metadata-id")
+	if err := contract.WriteProjectIdentity(fsys.OSFS{}, scopeRoot, "identity-id"); err != nil {
+		t.Fatalf("WriteProjectIdentity: %v", err)
+	}
+	beforeMetadata := mustReadFile(t, metadataPath)
+	port, cleanup := startProjectIDTestServer(t, seedDatabaseProjectIDQueries("database-id")...)
+	defer cleanup()
+
+	_, err := ensureManagedDoltProjectID(metadataPath, "127.0.0.1", port, "root", "hq")
+	if err == nil {
+		t.Fatal("ensureManagedDoltProjectID unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "PROJECT IDENTITY MISMATCH") || !strings.Contains(err.Error(), "identity-id") || !strings.Contains(err.Error(), "database-id") {
+		t.Fatalf("ensureManagedDoltProjectID error = %v, want L1/L3 mismatch with both ids", err)
+	}
+	if got := mustReadFile(t, metadataPath); string(got) != string(beforeMetadata) {
+		t.Fatalf("metadata changed on refusal:\n%s", got)
+	}
+	assertProjectIdentityFile(t, scopeRoot, "identity-id")
+	assertDatabaseProjectID(t, port, "database-id")
+}
+
+func TestEnsureManagedDoltProjectIDRepairsL2Drift(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
+	scopeRoot := t.TempDir()
+	metadataPath := writeProjectIDMetadataFile(t, scopeRoot, "wrong-l2")
+	if err := contract.WriteProjectIdentity(fsys.OSFS{}, scopeRoot, "canonical-id"); err != nil {
+		t.Fatalf("WriteProjectIdentity: %v", err)
+	}
+	port, cleanup := startProjectIDTestServer(t, seedDatabaseProjectIDQueries("canonical-id")...)
+	defer cleanup()
+
+	report, err := ensureManagedDoltProjectID(metadataPath, "127.0.0.1", port, "root", "hq")
+	if err != nil {
+		t.Fatalf("ensureManagedDoltProjectID: %v", err)
+	}
+	if report.ProjectID != "canonical-id" || report.Source != "l2-repair" || report.Layer != "l1" {
+		t.Fatalf("report = %+v, want l2 repair", report)
+	}
+	if report.IdentityFileUpdated || !report.MetadataUpdated || report.DatabaseUpdated {
+		t.Fatalf("report updates = %+v, want metadata only", report)
+	}
+	assertProjectIdentityFile(t, scopeRoot, "canonical-id")
+	assertMetadataProjectID(t, metadataPath, "canonical-id")
+	assertDatabaseProjectID(t, port, "canonical-id")
+}
+
+func TestEnsureManagedDoltProjectIDAdoptsFromL3(t *testing.T) {
+	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
+	scopeRoot := t.TempDir()
+	metadataPath := writeProjectIDMetadataFile(t, scopeRoot, "")
+	port, cleanup := startProjectIDTestServer(t, seedDatabaseProjectIDQueries("database-id")...)
+	defer cleanup()
+
+	report, err := ensureManagedDoltProjectID(metadataPath, "127.0.0.1", port, "root", "hq")
+	if err != nil {
+		t.Fatalf("ensureManagedDoltProjectID: %v", err)
+	}
+	if report.ProjectID != "database-id" || report.Source != "l1-adopt-l2-seed" || report.Layer != "l3" {
+		t.Fatalf("report = %+v, want l3 adoption", report)
+	}
+	if !report.IdentityFileUpdated || !report.MetadataUpdated || report.DatabaseUpdated {
+		t.Fatalf("report updates = %+v, want identity+metadata only", report)
+	}
+	assertProjectIdentityFile(t, scopeRoot, "database-id")
+	assertMetadataProjectID(t, metadataPath, "database-id")
+	assertDatabaseProjectID(t, port, "database-id")
+}
+
+func writeProjectIDMetadataFile(t *testing.T, scopeRoot string, projectID string) string {
+	t.Helper()
+	beadsDir := filepath.Join(scopeRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	meta := map[string]any{
+		"backend":       "dolt",
+		"database":      "dolt",
+		"dolt_database": "hq",
+		"dolt_mode":     "server",
+	}
+	if projectID != "" {
+		meta["project_id"] = projectID
+	}
+	encoded, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded = append(encoded, '\n')
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	if err := os.WriteFile(metadataPath, encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return metadataPath
+}
+
+func startProjectIDTestServer(t *testing.T, setupQueries ...string) (string, func()) {
+	t.Helper()
+	repoDir := filepath.Join(t.TempDir(), "hq")
+	_, port, _, cleanup := startPasswordedDoltServer(t, repoDir, setupQueries...)
+	return fmt.Sprintf("%d", port), cleanup
+}
+
+func seedDatabaseProjectIDQueries(projectID string) []string {
+	return []string{
+		"CREATE TABLE IF NOT EXISTS metadata (`key` VARCHAR(255) PRIMARY KEY, value LONGTEXT)",
+		fmt.Sprintf("INSERT INTO metadata (`key`, value) VALUES ('_project_id', '%s') ON DUPLICATE KEY UPDATE value = VALUES(value)", projectID),
+	}
+}
+
+func assertProjectIdentityFile(t *testing.T, scopeRoot string, want string) {
+	t.Helper()
+	got, ok, err := contract.ReadProjectIdentity(fsys.OSFS{}, scopeRoot)
+	if err != nil {
+		t.Fatalf("ReadProjectIdentity: %v", err)
+	}
+	if !ok {
+		t.Fatal("identity project id missing")
+	}
+	if got != want {
+		t.Fatalf("identity project_id = %q, want %q", got, want)
+	}
+}
+
+func assertMetadataProjectID(t *testing.T, metadataPath string, want string) {
+	t.Helper()
+	got, err := readManagedMetadataProjectID(metadataPath)
+	if err != nil {
+		t.Fatalf("readManagedMetadataProjectID: %v", err)
+	}
+	if got != want {
+		t.Fatalf("metadata project_id = %q, want %q", got, want)
+	}
+}
+
+func assertDatabaseProjectID(t *testing.T, port string, want string) {
+	t.Helper()
+	db, err := managedDoltOpenDatabase("127.0.0.1", port, "root", "hq")
+	if err != nil {
+		t.Fatalf("managedDoltOpenDatabase: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, ok, err := readDatabaseProjectID(ctx, db)
+	if err != nil {
+		t.Fatalf("readDatabaseProjectID: %v", err)
+	}
+	if !ok {
+		t.Fatal("database project id missing")
+	}
+	if got != want {
+		t.Fatalf("database _project_id = %q, want %q", got, want)
 	}
 }
 
@@ -346,12 +606,16 @@ func TestEnsureManagedDoltProjectIDGeneratesLocalIdentityWithPasswordedServer(t 
 	if report.Source != "generated" {
 		t.Fatalf("report.Source = %q, want generated", report.Source)
 	}
-	if !report.MetadataUpdated || !report.DatabaseUpdated {
-		t.Fatalf("report = %+v, want both metadata and database updated", report)
+	if !report.MetadataUpdated || !report.DatabaseUpdated || !report.IdentityFileUpdated {
+		t.Fatalf("report = %+v, want identity, metadata, and database updated", report)
+	}
+	if report.Layer != "generated" {
+		t.Fatalf("report.Layer = %q, want generated", report.Layer)
 	}
 	if !strings.HasPrefix(report.ProjectID, "gc-local-") {
 		t.Fatalf("report.ProjectID = %q, want gc-local-*", report.ProjectID)
 	}
+	assertProjectIdentityFile(t, cityDir, report.ProjectID)
 
 	var databaseProjectID string
 	if err := db.QueryRow("SELECT value FROM metadata WHERE `key` = '_project_id'").Scan(&databaseProjectID); err != nil {

--- a/release-gates/ga-eop74m-gate.md
+++ b/release-gates/ga-eop74m-gate.md
@@ -1,0 +1,55 @@
+# Release Gate: ga-eop74m
+
+Generated: 2026-05-15T12:47:50-07:00
+
+## Scope
+
+- Deploy bead: `ga-eop74m` - Review: L1-authoritative project identity reconcile
+- Source feature bead: `ga-h0pyln` - L1-authoritative reconcile flow + endpoint validator
+- Parent design bead: `ga-a75ro`
+- Release branch: `release/ga-eop74m`
+- Source branch: `origin/builder/ga-h0pyln-2`
+- Source commit: `e9c226da3`
+- Base checked: `origin/main`
+
+`docs/PROJECT_MANIFEST.md` is not present in this repository at this branch. This gate applies the deployer release-gate criteria plus the acceptance criteria from `ga-h0pyln` and the refined parent design in `ga-a75ro`.
+
+## Gate Criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `ga-eop74m` notes contain `REVIEW VERDICT: PASS` from `gascity/reviewer`, naming commit `e9c226da3` on `builder/ga-h0pyln-2`. |
+| 2 | Acceptance criteria met | PASS | Acceptance trace below. The apparent `gc bd doctor --reseed-identity` mismatch is stale in the build bead; `ga-a75ro` section 7.1 explicitly says that command does not exist yet and replaces it with manual-resolution wording for this child. |
+| 3 | Tests pass | PASS | Focused `cmd/gc` identity tests passed; `internal/beads/contract` passed; `go vet ./...` passed; `make test-fast-parallel` passed after clearing stale `/tmp` quota and rerunning with short `TMPDIR=/tmp`. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for `ga-eop74m` report PASS, "No security concerns", and no request-changes/high-severity findings. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` returned only `## release/ga-eop74m...origin/builder/ga-h0pyln-2` before writing this gate file. Clean status is rechecked after the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0; `git diff --check origin/main...HEAD` exited 0. |
+
+## Acceptance Trace
+
+| Acceptance item | Status | Evidence |
+|---|---|---|
+| `ensureManagedDoltProjectID` reads L1 first via `contract.ReadProjectIdentity`. | PASS | `cmd/gc/dolt_project_id.go:121` reads L1 before L2/L3. |
+| Reconcile table covers all required L1/L2/L3 states. | PASS | `cmd/gc/dolt_project_id_decide_test.go:5` defines `TestReconcileDecisionTable`; rows R1-R14 cover all presence/value combinations. |
+| Generate fresh only when L1, L2, and L3 are all absent. | PASS | R14 in `TestReconcileDecisionTable`; generated-path assertions in `cmd/gc/dolt_project_id_test.go` verify `Source == "generated"`, `Layer == "generated"`, and all layers are written. |
+| `readCanonicalProjectID` reads L1 first and falls back to L2. | PASS | `cmd/gc/cmd_rig_endpoint.go:594`; tests at `cmd/gc/cmd_rig_endpoint_test.go:1193`, `:1211`, and `:1226`. |
+| Mismatch wording follows the refined design and reports both IDs. | PASS | `cmd/gc/dolt_project_id.go:380` and `cmd/gc/cmd_rig_endpoint.go:578` print both canonical/local and database project IDs. `ga-a75ro` section 7.1 explicitly defers `--reseed-identity` to child D. |
+| `seedDatabaseProjectID` L3 clobber refusal preserved. | PASS | L1/L3 mismatch paths refuse through `formatL1L3MismatchError`; `TestEnsureManagedDoltProjectIDRefusesL1L3Mismatch` asserts no writes happen. |
+| Diff is scoped to intended surfaces. | PASS | `git diff --name-only origin/main...HEAD` lists only `cmd/gc/cmd_rig_endpoint.go`, `cmd/gc/cmd_rig_endpoint_test.go`, `cmd/gc/dolt_project_id.go`, `cmd/gc/dolt_project_id_decide_test.go`, and `cmd/gc/dolt_project_id_test.go`. |
+| ZFC and role-name constraints. | PASS | Diff is identity reconciliation and endpoint validation code; no role names or SDK role behavior added. |
+
+## Test Evidence
+
+| Command | Result |
+|---|---|
+| `env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deploy-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deploy-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deploy-go-tmp go test ./cmd/gc -run 'Test(EnsureManagedDoltProjectID|ReconcileDecision|RigEndpoint|ReadCanonicalProjectID).*' -count=1` | PASS: `ok github.com/gastownhall/gascity/cmd/gc 0.024s` |
+| `env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deploy-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deploy-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deploy-go-tmp go test ./internal/beads/contract -count=1` | PASS: `ok github.com/gastownhall/gascity/internal/beads/contract 2.129s` |
+| `env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deploy-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deploy-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deploy-go-tmp go vet ./...` | PASS |
+| `env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deploy-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deploy-go-tmp TMPDIR=/tmp make test-fast-parallel` | PASS: all fast jobs passed |
+| `git diff --check origin/main...HEAD` | PASS |
+| `git merge-tree --write-tree origin/main HEAD` | PASS |
+
+## Notes
+
+- First `make test-fast-parallel` attempt failed before producing valid gate evidence because `/tmp` was at the user quota limit and the temporary root was too long for `TestStartLongSocketPathUsesShortSocketName`. After removing stale, user-owned test temp directories older than one day and rerunning with `TMPDIR=/tmp`, all fast jobs passed.
+- `ga-ue02fr` / `builder/ga-qku0jy` is stacked on this change and should deploy after this PR merges.


### PR DESCRIPTION
## What this changes

Gas City now treats `.beads/identity.toml` as the canonical project identity for managed Dolt reconciliation. Startup reconciliation reads that L1 file first, repairs the gitignored metadata cache when it drifts, seeds or reseeds the database stamp only when safe, and refuses L1/database mismatches with both IDs printed instead of guessing.

External Dolt endpoint validation now uses the same L1-first lookup while keeping the legacy `.beads/metadata.json#project_id` fallback for rigs that have not written `identity.toml` yet.

## Review notes

- The reconcile decision table is intentionally explicit: `cmd/gc/dolt_project_id_decide_test.go` covers all L1/L2/L3 presence and mismatch rows.
- The mismatch recovery text intentionally says to resolve manually. The future `gc bd doctor --reseed-identity` command is deferred to a later child and is not shipped here.
- `managedDoltProjectIDReport` adds `identity_file_updated` and `layer` TSV fields. No HTTP API, OpenAPI, dashboard, or generated client surface changes are included.

## Test plan

- [x] `go test ./cmd/gc -run 'Test(EnsureManagedDoltProjectID|ReconcileDecision|RigEndpoint|ReadCanonicalProjectID).*' -count=1`
- [x] `go test ./internal/beads/contract -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-eop74m-gate.md`](release-gates/ga-eop74m-gate.md)
