### PR TITLE
Make reconciler label-blind for skipped labels

### DIFF
--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -326,7 +326,7 @@ func (c *CachingStore) PrimeActive() error {
 				continue
 			}
 		}
-		if _, keep := c.recentLocalBeadConflictLocked(b.ID, b, now); keep {
+		if _, keep := c.recentLocalBeadConflictLocked(b.ID, b, now, false); keep {
 			continue
 		}
 		c.beads[b.ID] = cloneBead(b)
@@ -362,7 +362,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	var err error
 	var partialErr error
 	for attempt := 1; attempt <= 3; attempt++ {
-		all, err = c.backing.List(ListQuery{AllowScan: true}) // active beads only (default)
+		all, err = c.backing.List(ListQuery{AllowScan: true, SkipLabels: true}) // active beads only (default)
 		if err == nil {
 			break
 		}
@@ -405,7 +405,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 				if recentLocalMutation(c.localBeadAt[id], now) {
 					c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
 				}
-				if _, keep := c.recentLocalBeadConflictLocked(id, fresh, now); keep {
+				if _, keep := c.recentLocalBeadConflictLocked(id, fresh, now, true); keep {
 					nextBeads[id] = cloneBead(current)
 					if deps, ok := c.deps[id]; ok {
 						nextDeps[id] = cloneDeps(deps)

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -121,7 +121,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		dependencyConflict := cacheEventDependencyConflict(currentDeps, depsKnown, patch, fields)
 		if fieldConflict || dependencyConflict {
 			if eventType == "bead.closed" {
-				if !verifiedConflict || beadChanged(current, verifiedClosedBase) {
+				if !verifiedConflict || beadChanged(current, verifiedClosedBase, false) {
 					return
 				}
 			} else {
@@ -132,7 +132,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 					return
 				}
 				if recentLocalMutation(c.localBeadAt[patch.ID], time.Now()) &&
-					(!verifiedRecentLocal || beadChanged(current, verifiedRecentLocalBase)) {
+					(!verifiedRecentLocal || beadChanged(current, verifiedRecentLocalBase, false)) {
 					return
 				}
 			}
@@ -154,7 +154,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		mutated = true
 	case "bead.updated":
 		existing, cached := c.beads[b.ID]
-		if !cached || beadChanged(existing, b) {
+		if !cached || beadChanged(existing, b, false) {
 			c.noteMutationLocked(b.ID)
 			c.beads[b.ID] = cloneBead(b)
 			delete(c.dirty, b.ID)
@@ -378,7 +378,7 @@ func recentLocalMutation(mutatedAt time.Time, now time.Time) bool {
 	return !mutatedAt.IsZero() && now.Sub(mutatedAt) <= 5*time.Second
 }
 
-func (c *CachingStore) recentLocalBeadConflictLocked(id string, fresh Bead, now time.Time) (Bead, bool) {
+func (c *CachingStore) recentLocalBeadConflictLocked(id string, fresh Bead, now time.Time, skipLabels bool) (Bead, bool) {
 	current, ok := c.beads[id]
 	if !ok {
 		return Bead{}, false
@@ -386,7 +386,7 @@ func (c *CachingStore) recentLocalBeadConflictLocked(id string, fresh Bead, now 
 	if !recentLocalMutation(c.localBeadAt[id], now) {
 		return Bead{}, false
 	}
-	if !beadChanged(current, fresh) {
+	if !beadChanged(current, fresh, skipLabels) {
 		return Bead{}, false
 	}
 	return cloneBead(current), true
@@ -479,7 +479,7 @@ func (c *CachingStore) notifyChanges(notifications []cacheNotification) {
 	}
 }
 
-func beadChanged(old, fresh Bead) bool {
+func beadChanged(old, fresh Bead, skipLabels bool) bool {
 	if old.ID != fresh.ID ||
 		old.Title != fresh.Title ||
 		old.Status != fresh.Status ||
@@ -496,7 +496,7 @@ func beadChanged(old, fresh Bead) bool {
 	if !maps.Equal(old.Metadata, fresh.Metadata) {
 		return true
 	}
-	if !slices.Equal(old.Labels, fresh.Labels) {
+	if !skipLabels && !slices.Equal(old.Labels, fresh.Labels) {
 		return true
 	}
 	if !slices.Equal(old.Needs, fresh.Needs) {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -43,6 +43,73 @@ func TestCachingStoreRunReconciliationDetectsLabelContentChanges(t *testing.T) {
 	}
 }
 
+func TestCachingStoreRunReconciliationSkipLabelsSuppressesLabelOnlyUpdates(t *testing.T) {
+	t.Parallel()
+
+	backing := &skipLabelsRecordingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "Task", Labels: []string{"foo"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if got := backing.lastListQuery(t); !got.SkipLabels {
+		t.Fatalf("Prime List query SkipLabels = false, want true")
+	}
+
+	backing.dropLabels = true
+	cache.runReconciliation()
+	if got := backing.lastListQuery(t); !got.SkipLabels {
+		t.Fatalf("reconcile List query SkipLabels = false, want true")
+	}
+	if len(events) != 0 {
+		t.Fatalf("events after label-only reconcile = %v, want none", events)
+	}
+
+	status := "in_progress"
+	if err := backing.Update(bead.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update backing status: %v", err)
+	}
+	cache.runReconciliation()
+	if len(events) != 1 || events[0] != "bead.updated:"+bead.ID {
+		t.Fatalf("events after status reconcile = %v, want [bead.updated:%s]", events, bead.ID)
+	}
+}
+
+type skipLabelsRecordingStore struct {
+	Store
+	dropLabels  bool
+	listQueries []ListQuery
+}
+
+func (s *skipLabelsRecordingStore) List(query ListQuery) ([]Bead, error) {
+	s.listQueries = append(s.listQueries, query)
+	rows, err := s.Store.List(query)
+	if err != nil || !query.SkipLabels || !s.dropLabels {
+		return rows, err
+	}
+	out := make([]Bead, len(rows))
+	for i, row := range rows {
+		out[i] = cloneBead(row)
+		out[i].Labels = nil
+	}
+	return out, nil
+}
+
+func (s *skipLabelsRecordingStore) lastListQuery(t *testing.T) ListQuery {
+	t.Helper()
+	if len(s.listQueries) == 0 {
+		t.Fatal("no List query recorded")
+	}
+	return s.listQueries[len(s.listQueries)-1]
+}
+
 func TestCachingStoreListInProgressUsesCacheByDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -169,7 +169,7 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 			}
 			continue
 		}
-		if current, keep := c.recentLocalBeadConflictLocked(item.ID, item, now); keep {
+		if current, keep := c.recentLocalBeadConflictLocked(item.ID, item, now, false); keep {
 			if query.Matches(current) {
 				refreshed = append(refreshed, current)
 			}
@@ -197,7 +197,7 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
 			continue
 		}
-		if _, keep := c.recentLocalBeadConflictLocked(id, bead, now); keep {
+		if _, keep := c.recentLocalBeadConflictLocked(id, bead, now, false); keep {
 			continue
 		}
 		c.beads[id] = bead

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -232,7 +232,7 @@ func (c *CachingStore) runReconciliation() {
 	c.mu.RUnlock()
 
 	bdStart := time.Now()
-	fresh, err := c.backing.List(ListQuery{AllowScan: true})
+	fresh, err := c.backing.List(ListQuery{AllowScan: true, SkipLabels: true})
 	bdLatency := time.Since(bdStart)
 	if err != nil {
 		c.mu.Lock()
@@ -277,7 +277,7 @@ func (c *CachingStore) runReconciliation() {
 				}
 				continue
 			}
-			if _, keep := c.recentLocalBeadConflictLocked(id, freshBead, now); keep {
+			if _, keep := c.recentLocalBeadConflictLocked(id, freshBead, now, true); keep {
 				if _, ok := c.deps[id]; !ok {
 					nextDepsComplete = false
 				}
@@ -293,7 +293,7 @@ func (c *CachingStore) runReconciliation() {
 					eventType: "bead.created",
 					bead:      cloneBead(freshBead),
 				})
-			case beadChanged(old, freshBead):
+			case beadChanged(old, freshBead, true):
 				updates++
 				notifications = append(notifications, cacheNotification{
 					eventType: "bead.updated",
@@ -379,7 +379,7 @@ func (c *CachingStore) runReconciliation() {
 		if recentLocalMutation(c.localBeadAt[id], now) {
 			c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
 		}
-		if current, keep := c.recentLocalBeadConflictLocked(id, freshBead, now); keep {
+		if current, keep := c.recentLocalBeadConflictLocked(id, freshBead, now, true); keep {
 			beadForCache = current
 			preservedRecentLocal = true
 		}
@@ -395,7 +395,7 @@ func (c *CachingStore) runReconciliation() {
 				eventType: "bead.created",
 				bead:      cloneBead(beadForCache),
 			})
-		case !preservedRecentLocal && beadChanged(old, freshBead):
+		case !preservedRecentLocal && beadChanged(old, freshBead, true):
 			updates++
 			notifications = append(notifications, cacheNotification{
 				eventType: "bead.updated",

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -71,6 +71,10 @@ type ListQuery struct {
 	Limit         int
 	IncludeClosed bool
 	AllowScan     bool
+	// SkipLabels tells backing stores and cache reconciliation that the
+	// caller does not need labels for change detection. Stores that cannot
+	// omit labels may ignore it.
+	SkipLabels bool
 	// Live bypasses CachingStore and reads from the backing store. Other Store
 	// implementations ignore it. Use it only for lifecycle gates that must
 	// observe external mutations immediately.

--- a/release-gates/ga-7gpo-reconciler-skip-labels-phase-1-gate.md
+++ b/release-gates/ga-7gpo-reconciler-skip-labels-phase-1-gate.md
@@ -1,0 +1,54 @@
+# Release gate - reconciler skip-labels phase 1
+
+- Review bead: `ga-tp47gr`
+- Source bead: `ga-7gpo`
+- Branch: `builder/ga-7gpo-1`
+- Reviewed commit: `8ca3919fc8510a9835df7f662573d8a6d8f711bf`
+- Gate date: 2026-05-15
+- Gate source: deployer prompt release criteria. `docs/PROJECT_MANIFEST.md` is
+  not present in this checkout.
+
+## Release Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-tp47gr` contains `Review Verdict: PASS` from `gascity/reviewer` on 2026-05-15. |
+| 2 | Acceptance criteria met | PASS | Phase 1 ACs are satisfied: `ListQuery.SkipLabels` is added; `Prime` and `runReconciliation` request skipped-label semantics; reconciler comparisons are label-blind only when `skipLabels=true`; non-reconciler paths pass `false`; no `BdStore` argv wiring or `--no-labels` usage was added. |
+| 3 | Tests pass | PASS | `go test ./internal/beads/... -count=1`; `go vet ./internal/beads/...`; `make test-fast-parallel`; and `go vet ./...` all passed on the final branch before this gate commit. |
+| 4 | No high-severity review findings open | PASS | The review notes list only non-blocking observations; no HIGH or blocking findings are open. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed a clean `builder/ga-7gpo-1...fork/builder/ga-7gpo-1` branch. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` completed without conflicts and returned tree `cea5fdec2759e1c1dea76a361594b657f1344d48`. |
+
+## Acceptance Evidence
+
+- AC-1 (`bd list --skip-labels` argv): deferred to Phase 2 (`ga-z0pc4k`) by the source bead and review. This gate confirms Phase 1 does not add `BdStore` argv wiring.
+- AC-2 (label-only change does not emit `bead.updated`): `beadChanged(old, fresh, true)` skips only the label comparison, and `TestCachingStoreRunReconciliationSkipLabelsSuppressesLabelOnlyUpdates` covers label-only suppression.
+- AC-3 (status change still emits `bead.updated`): the same regression test changes status after the label-only pass and verifies one `bead.updated` notification.
+- AC-4 (label-skipped response regression): the test primes a cached bead with labels, injects a backing response with labels dropped when `SkipLabels=true`, runs reconciliation, and verifies zero update events for the label-only delta.
+- AC-5 (call sites updated): `rg -n "SkipLabels|beadChanged|runReconciliation|Prime\\(" internal/beads` shows reconciler paths pass `true` and event/live-read paths pass `false`.
+
+## Test Evidence
+
+```text
+go test ./internal/beads/... -count=1
+ok  	github.com/gastownhall/gascity/internal/beads	3.735s
+?   	github.com/gastownhall/gascity/internal/beads/beadstest	[no test files]
+?   	github.com/gastownhall/gascity/internal/beads/closeorder	[no test files]
+ok  	github.com/gastownhall/gascity/internal/beads/contract	0.318s
+ok  	github.com/gastownhall/gascity/internal/beads/exec	6.751s
+```
+
+```text
+go vet ./internal/beads/...
+PASS
+```
+
+```text
+make test-fast-parallel
+All fast jobs passed
+```
+
+```text
+go vet ./...
+PASS
+```


### PR DESCRIPTION
## What this changes

Cache priming and full reconciliation now carry an internal `ListQuery.SkipLabels` hint for paths that do not need labels for change detection. When that hint is active, the reconciler ignores label-only differences so it does not emit noisy `bead.updated` events for changes that are irrelevant to reconciliation.

Status and other bead field changes still emit updates. Live-read and event-stream paths remain label-aware, so this narrows only the bulk reconciliation behavior that was producing spurious update traffic.

## Why it is built this way

This is the correctness phase only. The `bd list --skip-labels` projection is not available to this repo yet, so `BdStore.List` intentionally does not add a CLI flag; labels are still fetched, but the reconciler stops using them as a change signal on the opted-in paths.

## Review notes

- The changed surface is limited to `internal/beads`.
- There is no CLI, API, config, or wire-format change.
- `--no-labels` is intentionally not used; it is a filter, not the future projection flag.
- A follow-up can wire `BdStore.List` to `--skip-labels` after the real bd projection flag exists.

## Test plan

- [x] `go test ./internal/beads/... -count=1`
- [x] `go vet ./internal/beads/...`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-7gpo-reconciler-skip-labels-phase-1-gate.md`](release-gates/ga-7gpo-reconciler-skip-labels-phase-1-gate.md)
