### PR TITLE
fix: wrap tmux startup death sentinel

### DIFF
--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -751,7 +751,7 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 		return fmt.Errorf("verifying session: %w", err)
 	}
 	if !alive {
-		return fmt.Errorf("session %q died during startup", name)
+		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
 	}
 
 	// Step 5.5: Run session setup commands and script.

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -494,6 +494,9 @@ func TestDoStartSession_SessionDiesDuringStartup(t *testing.T) {
 	if !strings.Contains(err.Error(), "died during startup") {
 		t.Errorf("error = %q, want 'died during startup'", err)
 	}
+	if !errors.Is(err, runtime.ErrSessionDiedDuringStartup) {
+		t.Errorf("error = %v, want ErrSessionDiedDuringStartup", err)
+	}
 }
 
 func TestDoStartSession_HasSessionError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Wrap tmux startup-death failures with runtime.ErrSessionDiedDuringStartup.
- Assert the tmux startup path preserves that sentinel with errors.Is.

## RCA
The tmux provider returned plain text for sessions that died during startup, so higher-level recovery that checks errors.Is(runtime.ErrSessionDiedDuringStartup) could not classify the failure correctly.

## Tests
- go test ./internal/runtime/tmux -run TestDoStartSession_SessionDiesDuringStartup -count=1
- go test ./internal/session -run 'TestEnsureRunning_RetriesAfterStartupDeathError|TestEnsureRunning_StartupDeathWithoutStrippableResumeClearsMetadata' -count=1\n- repo pre-commit hook: golangci-lint fmt ./..., generated docs/schema checks, go vet ./..., GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...\n