### PR TITLE
feat: add gc JSON schema discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The built-in Claude provider's `model = "opus"` option now emits
   `claude-opus-4-7`. Cities that rely on the `opus` alias should expect the
   new model target after upgrading.
+- Several CLI/operator behaviors landed with the JSON-summary work and are now
+  explicit release-note items: generated init configs may include the new JSON
+  root-command support, prime hooks can infer the agent from `.gc/agents`
+  workdir layouts, and `gc hook` defensively filters future-deferred or
+  dependency-blocked candidates from JSON work-query output before surfacing
+  work to agents.
+- CLI JSON errors now use the shared one-object-per-line writer on stdout,
+  preserving literal `<`, `>`, and `&` characters; stderr still receives a
+  machine-readable diagnostic.
 
 ### Fixed
 

--- a/cmd/gc/cmd_build_image.go
+++ b/cmd/gc/cmd_build_image.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/buildimage"
@@ -18,6 +20,7 @@ func newBuildImageCmd(stdout, stderr io.Writer) *cobra.Command {
 		rigPaths    []string
 		push        bool
 		contextOnly bool
+		jsonOut     bool
 	)
 
 	cmd := &cobra.Command{
@@ -45,9 +48,42 @@ volume mounts at runtime.`,
   gc build-image ~/bright-lights --tag registry.io/my-city:latest --push`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			code := doBuildImage(args, tag, baseImage, rigPaths, push, contextOnly, stdout, stderr)
+			out := stdout
+			var bufferedOut bytes.Buffer
+			if jsonOut {
+				out = stderr
+				if contextOnly {
+					out = &bufferedOut
+				}
+			}
+			code := doBuildImage(args, tag, baseImage, rigPaths, push, contextOnly, out, stderr)
 			if code != 0 {
 				return errExit
+			}
+			contextDir := ""
+			if jsonOut {
+				if bufferedOut.Len() > 0 {
+					fmt.Fprint(stderr, bufferedOut.String()) //nolint:errcheck // best-effort stderr
+					contextDir = parseBuildImageContextDir(bufferedOut.String())
+				}
+				cityPath := ""
+				if len(args) > 0 {
+					if abs, err := filepath.Abs(args[0]); err == nil {
+						cityPath = abs
+					} else {
+						cityPath = args[0]
+					}
+				}
+				_ = writeCLIJSONLine(stdout, buildImageJSONResult{
+					SchemaVersion: "1",
+					CityPath:      cityPath,
+					Tag:           tag,
+					BaseImage:     baseImage,
+					ContextOnly:   contextOnly,
+					ContextDir:    contextDir,
+					Push:          push,
+					RigPathCount:  len(rigPaths),
+				})
 			}
 			return nil
 		},
@@ -58,8 +94,29 @@ volume mounts at runtime.`,
 	cmd.Flags().StringSliceVar(&rigPaths, "rig-path", nil, "rig name:path pairs (repeatable)")
 	cmd.Flags().BoolVar(&push, "push", false, "push image after building")
 	cmd.Flags().BoolVar(&contextOnly, "context-only", false, "write build context without running docker build")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
 
 	return cmd
+}
+
+type buildImageJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	CityPath      string `json:"city_path,omitempty"`
+	Tag           string `json:"tag,omitempty"`
+	BaseImage     string `json:"base_image"`
+	ContextOnly   bool   `json:"context_only"`
+	ContextDir    string `json:"context_dir,omitempty"`
+	Push          bool   `json:"push"`
+	RigPathCount  int    `json:"rig_path_count"`
+}
+
+func parseBuildImageContextDir(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "Build context written to: "); ok {
+			return rest
+		}
+	}
+	return ""
 }
 
 func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push, contextOnly bool, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_build_image.go
+++ b/cmd/gc/cmd_build_image.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -11,6 +10,12 @@ import (
 
 	"github.com/gastownhall/gascity/internal/buildimage"
 	"github.com/spf13/cobra"
+)
+
+var (
+	buildImageAssembleContext = buildimage.AssembleContext
+	buildImageBuild           = buildimage.Build
+	buildImagePush            = buildimage.Push
 )
 
 func newBuildImageCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -49,38 +54,21 @@ volume mounts at runtime.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			out := stdout
-			var bufferedOut bytes.Buffer
 			if jsonOut {
 				out = stderr
-				if contextOnly {
-					out = &bufferedOut
-				}
 			}
-			code := doBuildImage(args, tag, baseImage, rigPaths, push, contextOnly, out, stderr)
+			result, code := doBuildImageWithResult(args, tag, baseImage, rigPaths, push, contextOnly, out, stderr)
 			if code != 0 {
 				return errExit
 			}
-			contextDir := ""
 			if jsonOut {
-				if bufferedOut.Len() > 0 {
-					fmt.Fprint(stderr, bufferedOut.String()) //nolint:errcheck // best-effort stderr
-					contextDir = parseBuildImageContextDir(bufferedOut.String())
-				}
-				cityPath := ""
-				if len(args) > 0 {
-					if abs, err := filepath.Abs(args[0]); err == nil {
-						cityPath = abs
-					} else {
-						cityPath = args[0]
-					}
-				}
 				_ = writeCLIJSONLine(stdout, buildImageJSONResult{
 					SchemaVersion: "1",
-					CityPath:      cityPath,
+					CityPath:      result.CityPath,
 					Tag:           tag,
 					BaseImage:     baseImage,
 					ContextOnly:   contextOnly,
-					ContextDir:    contextDir,
+					ContextDir:    result.ContextDir,
 					Push:          push,
 					RigPathCount:  len(rigPaths),
 				})
@@ -110,19 +98,21 @@ type buildImageJSONResult struct {
 	RigPathCount  int    `json:"rig_path_count"`
 }
 
-func parseBuildImageContextDir(output string) string {
-	for _, line := range strings.Split(output, "\n") {
-		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "Build context written to: "); ok {
-			return rest
-		}
-	}
-	return ""
+type buildImageRunResult struct {
+	CityPath   string
+	ContextDir string
 }
 
-func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push, contextOnly bool, stdout, stderr io.Writer) int {
+func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push, contextOnly bool, stdout, stderr io.Writer) int { //nolint:unparam // preserved for existing tests; command path needs doBuildImageWithResult.
+	_, code := doBuildImageWithResult(args, tag, baseImage, rigPaths, push, contextOnly, stdout, stderr)
+	return code
+}
+
+func doBuildImageWithResult(args []string, tag, baseImage string, rigPaths []string, push, contextOnly bool, stdout, stderr io.Writer) (buildImageRunResult, int) {
+	result := buildImageRunResult{}
 	if !contextOnly && tag == "" {
 		fmt.Fprintln(stderr, "gc build-image: --tag is required (or use --context-only)") //nolint:errcheck // best-effort stderr
-		return 1
+		return result, 1
 	}
 
 	// Resolve city path.
@@ -134,8 +124,12 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 		cityPath, err = resolveCommandCity(nil)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return result, 1
 		}
+	}
+	result.CityPath = cityPath
+	if abs, err := filepath.Abs(cityPath); err == nil {
+		result.CityPath = abs
 	}
 
 	// Parse rig-path flags (name:path format).
@@ -144,7 +138,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 		name, path, ok := strings.Cut(rp, ":")
 		if !ok || name == "" || path == "" {
 			fmt.Fprintf(stderr, "gc build-image: invalid --rig-path %q (expected name:path)\n", rp) //nolint:errcheck // best-effort stderr
-			return 1
+			return result, 1
 		}
 		rigs[name] = path
 	}
@@ -153,7 +147,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 	outputDir, err := os.MkdirTemp("", "gc-build-image-*")
 	if err != nil {
 		fmt.Fprintf(stderr, "gc build-image: creating temp dir: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return result, 1
 	}
 	if !contextOnly {
 		defer func() { _ = os.RemoveAll(outputDir) }()
@@ -167,34 +161,35 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 		Tag:       tag,
 		RigPaths:  rigs,
 	}
-	if err := buildimage.AssembleContext(opts); err != nil {
+	if err := buildImageAssembleContext(opts); err != nil {
 		fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return result, 1
 	}
 
 	if contextOnly {
+		result.ContextDir = outputDir
 		fmt.Fprintf(stdout, "Build context written to: %s\n", outputDir) //nolint:errcheck // best-effort stdout
-		return 0
+		return result, 0
 	}
 
 	// Build image.
 	fmt.Fprintf(stdout, "Building image %s...\n", tag) //nolint:errcheck // best-effort stdout
 	ctx := context.Background()
-	if err := buildimage.Build(ctx, outputDir, tag, stdout, stderr); err != nil {
+	if err := buildImageBuild(ctx, outputDir, tag, stdout, stderr); err != nil {
 		fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return result, 1
 	}
 	fmt.Fprintf(stdout, "Image built: %s\n", tag) //nolint:errcheck // best-effort stdout
 
 	// Push if requested.
 	if push {
 		fmt.Fprintf(stdout, "Pushing %s...\n", tag) //nolint:errcheck // best-effort stdout
-		if err := buildimage.Push(ctx, tag, stdout, stderr); err != nil {
+		if err := buildImagePush(ctx, tag, stdout, stderr); err != nil {
 			fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return result, 1
 		}
 		fmt.Fprintf(stdout, "Pushed: %s\n", tag) //nolint:errcheck // best-effort stdout
 	}
 
-	return 0
+	return result, 0
 }

--- a/cmd/gc/cmd_event_emit.go
+++ b/cmd/gc/cmd_event_emit.go
@@ -27,8 +27,19 @@ func newEventCmd(stdout, stderr io.Writer) *cobra.Command {
 	return cmd
 }
 
-func newEventEmitCmd(_, stderr io.Writer) *cobra.Command {
+type eventEmitJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	EventType     string `json:"event_type"`
+	Actor         string `json:"actor"`
+	Subject       string `json:"subject,omitempty"`
+	Message       string `json:"message,omitempty"`
+	Payload       bool   `json:"payload"`
+	Recorded      bool   `json:"recorded"`
+}
+
+func newEventEmitCmd(stdout, stderr io.Writer) *cobra.Command {
 	var subject, message, actor, payload string
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "emit <type>",
@@ -39,7 +50,25 @@ Best-effort: always exits 0 so bead hooks never fail. Supports
 attaching arbitrary JSON payloads.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdEventEmit(args[0], subject, message, actor, payload, stderr) != 0 {
+			effectiveActor := actor
+			if effectiveActor == "" {
+				effectiveActor = eventActor()
+			}
+			recorded := false
+			if jsonOut {
+				recorded = cmdEventEmitRecorded(args[0], subject, message, effectiveActor, payload, stderr)
+				_ = writeCLIJSONLine(stdout, eventEmitJSONResult{
+					SchemaVersion: "1",
+					EventType:     args[0],
+					Actor:         effectiveActor,
+					Subject:       subject,
+					Message:       message,
+					Payload:       payload != "",
+					Recorded:      recorded,
+				})
+				return nil
+			}
+			if cmdEventEmit(args[0], subject, message, effectiveActor, payload, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -49,26 +78,31 @@ attaching arbitrary JSON payloads.`,
 	cmd.Flags().StringVar(&message, "message", "", "Event message")
 	cmd.Flags().StringVar(&actor, "actor", "", "Actor name (default: $GC_ALIAS, else $GC_AGENT, else $GC_SESSION_ID, else \"human\")")
 	cmd.Flags().StringVar(&payload, "payload", "", "JSON payload to attach to the event")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
 	return cmd
 }
 
 // cmdEventEmit records a single event to the city event log. Best-effort:
 // errors go to stderr but exit code is always 0 so bd hooks never fail.
 func cmdEventEmit(eventType, subject, message, actor, payload string, stderr io.Writer) int {
+	cmdEventEmitRecorded(eventType, subject, message, actor, payload, stderr)
+	return 0
+}
+
+func cmdEventEmitRecorded(eventType, subject, message, actor, payload string, stderr io.Writer) bool {
 	ep, code := openCityEventEmitProvider(stderr, "gc event emit")
 	if ep == nil {
 		// Best-effort: if we can't open the provider, still exit 0.
 		_ = code
-		return 0
+		return false
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	doEventEmit(ep, eventType, subject, message, actor, payload, stderr)
-	return 0
+	return doEventEmit(ep, eventType, subject, message, actor, payload, stderr)
 }
 
 // doEventEmit is the pure logic for "gc event emit". Accepts the provider
 // directly for testability. Best-effort: never fails.
-func doEventEmit(ep events.Provider, eventType, subject, message, actor, payload string, stderr io.Writer) {
+func doEventEmit(ep events.Provider, eventType, subject, message, actor, payload string, stderr io.Writer) bool {
 	if actor == "" {
 		actor = eventActor()
 	}
@@ -82,10 +116,11 @@ func doEventEmit(ep events.Provider, eventType, subject, message, actor, payload
 	if payload != "" {
 		if !json.Valid([]byte(payload)) {
 			fmt.Fprintf(stderr, "gc event emit: --payload is not valid JSON\n") //nolint:errcheck // best-effort stderr
-			return                                                              // best-effort — never fail
+			return false                                                        // best-effort — never fail
 		}
 		e.Payload = json.RawMessage(payload)
 	}
 
 	ep.Record(e)
+	return true
 }

--- a/cmd/gc/cmd_event_emit.go
+++ b/cmd/gc/cmd_event_emit.go
@@ -33,8 +33,8 @@ type eventEmitJSONResult struct {
 	Actor         string `json:"actor"`
 	Subject       string `json:"subject,omitempty"`
 	Message       string `json:"message,omitempty"`
-	Payload       bool   `json:"payload"`
-	Recorded      bool   `json:"recorded"`
+	HasPayload    bool   `json:"has_payload"`
+	Submitted     bool   `json:"submitted"`
 }
 
 func newEventEmitCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -47,24 +47,26 @@ func newEventEmitCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Record a custom event to the city event log.
 
 Best-effort: always exits 0 so bead hooks never fail. Supports
-attaching arbitrary JSON payloads.`,
+attaching arbitrary JSON payloads. JSON summaries report whether submission to
+the configured provider was attempted; the event bus does not acknowledge
+durable persistence.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			effectiveActor := actor
 			if effectiveActor == "" {
 				effectiveActor = eventActor()
 			}
-			recorded := false
+			submitted := false
 			if jsonOut {
-				recorded = cmdEventEmitRecorded(args[0], subject, message, effectiveActor, payload, stderr)
+				submitted = cmdEventEmitSubmitted(args[0], subject, message, effectiveActor, payload, stderr)
 				_ = writeCLIJSONLine(stdout, eventEmitJSONResult{
 					SchemaVersion: "1",
 					EventType:     args[0],
 					Actor:         effectiveActor,
 					Subject:       subject,
 					Message:       message,
-					Payload:       payload != "",
-					Recorded:      recorded,
+					HasPayload:    payload != "",
+					Submitted:     submitted,
 				})
 				return nil
 			}
@@ -85,11 +87,11 @@ attaching arbitrary JSON payloads.`,
 // cmdEventEmit records a single event to the city event log. Best-effort:
 // errors go to stderr but exit code is always 0 so bd hooks never fail.
 func cmdEventEmit(eventType, subject, message, actor, payload string, stderr io.Writer) int {
-	cmdEventEmitRecorded(eventType, subject, message, actor, payload, stderr)
+	cmdEventEmitSubmitted(eventType, subject, message, actor, payload, stderr)
 	return 0
 }
 
-func cmdEventEmitRecorded(eventType, subject, message, actor, payload string, stderr io.Writer) bool {
+func cmdEventEmitSubmitted(eventType, subject, message, actor, payload string, stderr io.Writer) bool {
 	ep, code := openCityEventEmitProvider(stderr, "gc event emit")
 	if ep == nil {
 		// Best-effort: if we can't open the provider, still exit 0.

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -69,21 +69,23 @@ or ID. Subject is required unless --auto is set.`,
 			return cobra.RangeArgs(1, 2)(cmd, args)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOut && hookFormat != "" {
+				fmt.Fprintln(stderr, "gc handoff: --json cannot be used with --hook-format") //nolint:errcheck // best-effort stderr
+				return errExit
+			}
 			out := stdout
 			if jsonOut {
 				out = io.Discard
 			}
-			if cmdHandoff(args, target, auto, hookFormat, out, stderr) != 0 {
+			outcome := cmdHandoffWithOutcome(args, target, auto, hookFormat, out, stderr)
+			if outcome.code != 0 {
 				return errExit
 			}
 			if jsonOut {
-				_ = writeCLIJSONLine(stdout, handoffJSONResult{
-					SchemaVersion: "1",
-					Mode:          handoffJSONMode(target, auto),
-					Target:        target,
-					Auto:          auto,
-					Subject:       handoffJSONSubject(args, auto),
-				})
+				if err := writeCLIJSONLine(stdout, handoffJSONFromOutcome(outcome)); err != nil {
+					fmt.Fprintf(stderr, "gc handoff: encode JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
 			}
 			return nil
 		},
@@ -96,57 +98,61 @@ or ID. Subject is required unless --auto is set.`,
 }
 
 type handoffJSONResult struct {
-	SchemaVersion string `json:"schema_version"`
-	Mode          string `json:"mode"`
-	Target        string `json:"target,omitempty"`
-	Auto          bool   `json:"auto"`
-	Subject       string `json:"subject,omitempty"`
+	SchemaVersion    string `json:"schema_version"`
+	OK               bool   `json:"ok"`
+	Mode             string `json:"mode"`
+	Target           string `json:"target,omitempty"`
+	Recipient        string `json:"recipient,omitempty"`
+	Auto             bool   `json:"auto"`
+	Subject          string `json:"subject,omitempty"`
+	MailBeadID       string `json:"mail_bead_id,omitempty"`
+	RestartRequested bool   `json:"restart_requested"`
+	Action           string `json:"action,omitempty"`
 }
 
-func handoffJSONMode(target string, auto bool) string {
-	if target != "" {
-		return "remote"
+func handoffJSONFromOutcome(outcome handoffOutcome) handoffJSONResult {
+	return handoffJSONResult{
+		SchemaVersion:    "1",
+		OK:               outcome.code == 0,
+		Mode:             outcome.mode,
+		Target:           outcome.target,
+		Recipient:        outcome.recipient,
+		Auto:             outcome.auto,
+		Subject:          outcome.subject,
+		MailBeadID:       outcome.mailBeadID,
+		RestartRequested: outcome.restartRequested,
+		Action:           outcome.action,
 	}
-	if auto {
-		return "auto"
-	}
-	return "self"
-}
-
-func handoffJSONSubject(args []string, auto bool) string {
-	if len(args) > 0 {
-		return args[0]
-	}
-	if auto {
-		return "context cycle"
-	}
-	return "HANDOFF: context cycle"
 }
 
 func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdout, stderr io.Writer) int {
+	return cmdHandoffWithOutcome(args, target, auto, hookFormat, stdout, stderr).code
+}
+
+func cmdHandoffWithOutcome(args []string, target string, auto bool, hookFormat string, stdout, stderr io.Writer) handoffOutcome {
 	if target != "" {
 		if auto {
 			fmt.Fprintln(stderr, "gc handoff: --auto cannot be used with --target") //nolint:errcheck // best-effort stderr
-			return 1
+			return handoffOutcome{code: 1}
 		}
-		return cmdHandoffRemote(args, target, stdout, stderr)
+		return cmdHandoffRemoteWithOutcome(args, target, stdout, stderr)
 	}
 
 	current, err := currentSessionRuntimeTarget()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1}
 	}
 
 	store, err := openCityStoreAt(current.cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err)                    //nolint:errcheck // best-effort stderr
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1}
 	}
 	rec := openCityRecorderAt(current.cityPath, stderr)
 	if auto {
-		return doHandoffAuto(store, rec, current.display, args, hookFormat, stdout, stderr)
+		return doHandoffAutoWithOutcome(store, rec, current.display, args, hookFormat, stdout, stderr)
 	}
 
 	sp := newSessionProvider()
@@ -156,45 +162,50 @@ func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdo
 
 	outcome := doHandoffWithOutcome(store, rec, dops, persistRestart, current.display, current.sessionName, args, stdout, stderr)
 	if outcome.code != 0 {
-		return outcome.code
+		return outcome
 	}
 	if !outcome.restartRequested {
-		return 0
+		return outcome
 	}
 
 	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	return waitForControllerRestart(sigCtx, dops, current.sessionName, "gc handoff",
+	outcome.code = waitForControllerRestart(sigCtx, dops, current.sessionName, "gc handoff",
 		controllerRestartPollInterval, controllerRestartTimeout(cfg), stderr)
+	return outcome
 }
 
 // cmdHandoffRemote sends handoff mail to a remote session and kills its runtime.
 // Returns immediately (non-blocking). The reconciler restarts the target.
 func cmdHandoffRemote(args []string, target string, stdout, stderr io.Writer) int {
+	return cmdHandoffRemoteWithOutcome(args, target, stdout, stderr).code
+}
+
+func cmdHandoffRemoteWithOutcome(args []string, target string, stdout, stderr io.Writer) handoffOutcome {
 	targetInfo, err := resolveSessionRuntimeTarget(target, stderr)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1, mode: "remote", target: target}
 	}
 
 	store, code := openCityStore(stderr, "gc handoff")
 	if store == nil {
-		return code
+		return handoffOutcome{code: code, mode: "remote", target: targetInfo.display}
 	}
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1, mode: "remote", target: targetInfo.display}
 	}
 	cfg, _ := loadCityConfig(cityPath, stderr)
 	sender, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc handoff")
 	if !ok {
-		return 1
+		return handoffOutcome{code: 1, mode: "remote", target: targetInfo.display}
 	}
 
 	sp := newSessionProvider()
 	rec := openCityRecorder(stderr)
-	return doHandoffRemote(store, rec, sp, targetInfo.sessionName, targetInfo.display, sender, args, stdout, stderr)
+	return doHandoffRemoteWithOutcome(store, rec, sp, targetInfo.sessionName, targetInfo.display, sender, args, stdout, stderr)
 }
 
 func sessionRestartPersister(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, target string) func() error {
@@ -213,6 +224,13 @@ func sessionRestartPersister(cityPath string, store beads.Store, sp runtime.Prov
 type handoffOutcome struct {
 	code             int
 	restartRequested bool
+	mode             string
+	target           string
+	recipient        string
+	auto             bool
+	subject          string
+	mailBeadID       string
+	action           string
 }
 
 // doHandoff sends a handoff mail to self and requests restart when the
@@ -228,26 +246,37 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 ) handoffOutcome {
 	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "HANDOFF: context cycle", stderr)
 	if !ok {
-		return handoffOutcome{code: 1}
+		return handoffOutcome{code: 1, mode: "self", recipient: sessionAddress}
+	}
+	outcome := handoffOutcome{
+		code:       0,
+		mode:       "self",
+		recipient:  sessionAddress,
+		subject:    b.Title,
+		mailBeadID: b.ID,
 	}
 
 	restartable, err := sessionRestartableByController(store, sessionName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
-		return handoffOutcome{code: 1}
+		outcome.code = 1
+		return outcome
 	}
 	if !restartable {
 		if err := clearRestartRequest(store, dops, sessionName); err != nil {
 			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
-			return handoffOutcome{code: 1}
+			outcome.code = 1
+			return outcome
 		}
 		fmt.Fprintf(stdout, "Handoff: sent mail %s (named session; restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
-		return handoffOutcome{code: 0}
+		outcome.action = "restart_skipped"
+		return outcome
 	}
 
 	if err := dops.setRestartRequested(sessionName); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: setting restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
-		return handoffOutcome{code: 1}
+		outcome.code = 1
+		return outcome
 	}
 	// Also persist the request through the worker boundary so it survives
 	// tmux session death. Non-fatal: the runtime flag above is primary.
@@ -264,21 +293,37 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 	})
 
 	fmt.Fprintf(stdout, "Handoff: sent mail %s, requesting restart...\n", b.ID) //nolint:errcheck // best-effort stdout
-	return handoffOutcome{code: 0, restartRequested: true}
+	outcome.restartRequested = true
+	outcome.action = "restart_requested"
+	return outcome
 }
 
 // doHandoffAuto sends handoff mail to self without requesting restart.
 func doHandoffAuto(store beads.Store, rec events.Recorder, sessionAddress string, args []string, hookFormat string, stdout, stderr io.Writer) int {
+	return doHandoffAutoWithOutcome(store, rec, sessionAddress, args, hookFormat, stdout, stderr).code
+}
+
+func doHandoffAutoWithOutcome(store beads.Store, rec events.Recorder, sessionAddress string, args []string, hookFormat string, stdout, stderr io.Writer) handoffOutcome {
 	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "context cycle", stderr)
 	if !ok {
-		return 1
+		return handoffOutcome{code: 1, mode: "auto", auto: true, recipient: sessionAddress}
+	}
+	outcome := handoffOutcome{
+		code:       0,
+		mode:       "auto",
+		recipient:  sessionAddress,
+		auto:       true,
+		subject:    b.Title,
+		mailBeadID: b.ID,
+		action:     "restart_skipped",
 	}
 	message := fmt.Sprintf("Handoff: sent auto mail %s (restart skipped).\n", b.ID)
 	if err := writeProviderHookContextForEvent(stdout, hookFormat, "PreCompact", message); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: writing hook output: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		outcome.code = 1
+		return outcome
 	}
-	return 0
+	return outcome
 }
 
 func createHandoffMail(store beads.Store, rec events.Recorder, senderAddress, recipientAddress string, args []string, defaultSubject string, stderr io.Writer) (beads.Bead, bool) {
@@ -376,38 +421,58 @@ func clearRestartRequest(store beads.Store, dops drainOps, sessionName string) e
 func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider,
 	sessionName, targetAddress, sender string, args []string, stdout, stderr io.Writer,
 ) int {
+	return doHandoffRemoteWithOutcome(store, rec, sp, sessionName, targetAddress, sender, args, stdout, stderr).code
+}
+
+func doHandoffRemoteWithOutcome(store beads.Store, rec events.Recorder, sp runtime.Provider,
+	sessionName, targetAddress, sender string, args []string, stdout, stderr io.Writer,
+) handoffOutcome {
 	b, ok := createHandoffMail(store, rec, sender, targetAddress, args, "HANDOFF: context cycle", stderr)
 	if !ok {
-		return 1
+		return handoffOutcome{code: 1, mode: "remote", target: targetAddress, recipient: targetAddress}
+	}
+	outcome := handoffOutcome{
+		code:       0,
+		mode:       "remote",
+		target:     targetAddress,
+		recipient:  targetAddress,
+		subject:    b.Title,
+		mailBeadID: b.ID,
 	}
 
 	restartable, err := sessionRestartableByController(store, sessionName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		outcome.code = 1
+		return outcome
 	}
 	if !restartable {
 		if err := clearRestartRequest(store, newDrainOps(sp), sessionName); err != nil {
 			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			outcome.code = 1
+			return outcome
 		}
 		fmt.Fprintf(stdout, "Handoff: sent mail %s to %s (named session; kill skipped because the controller cannot restart it)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
-		return 0
+		outcome.action = "kill_skipped"
+		return outcome
 	}
 
 	// Kill target session (reconciler restarts it).
 	running, err := workerSessionTargetRunningWithConfig("", store, sp, nil, sessionName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: observing %s: %v\n", targetAddress, err) //nolint:errcheck // best-effort stderr
-		return 1
+		outcome.code = 1
+		return outcome
 	}
 	if !running {
 		fmt.Fprintf(stdout, "Handoff: sent mail %s to %s (session not running; will be delivered on next start)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
-		return 0
+		outcome.action = "delivery_pending"
+		return outcome
 	}
 	if err := workerKillSessionTargetWithConfig("", store, sp, nil, sessionName); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: killing %s: %v\n", targetAddress, err) //nolint:errcheck // best-effort stderr
-		return 1
+		outcome.code = 1
+		return outcome
 	}
 	sessionID, resolveErr := resolveSessionID(store, sessionName)
 	if resolveErr != nil {
@@ -425,7 +490,8 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 	})
 
 	fmt.Fprintf(stdout, "Handoff: sent mail %s to %s, killed session (reconciler will restart)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
-	return 0
+	outcome.action = "killed"
+	return outcome
 }
 
 // handoffThreadID generates a unique thread ID for handoff messages.

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -22,6 +22,7 @@ func newHandoffCmd(stdout, stderr io.Writer) *cobra.Command {
 	var target string
 	var auto bool
 	var hookFormat string
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "handoff [subject] [message]",
 		Short: "Send handoff mail and restart controller-managed sessions",
@@ -68,8 +69,21 @@ or ID. Subject is required unless --auto is set.`,
 			return cobra.RangeArgs(1, 2)(cmd, args)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdHandoff(args, target, auto, hookFormat, stdout, stderr) != 0 {
+			out := stdout
+			if jsonOut {
+				out = io.Discard
+			}
+			if cmdHandoff(args, target, auto, hookFormat, out, stderr) != 0 {
 				return errExit
+			}
+			if jsonOut {
+				_ = writeCLIJSONLine(stdout, handoffJSONResult{
+					SchemaVersion: "1",
+					Mode:          handoffJSONMode(target, auto),
+					Target:        target,
+					Auto:          auto,
+					Subject:       handoffJSONSubject(args, auto),
+				})
 			}
 			return nil
 		},
@@ -77,7 +91,36 @@ or ID. Subject is required unless --auto is set.`,
 	cmd.Flags().StringVar(&target, "target", "", "Remote session alias or ID to handoff (kills only controller-restartable sessions)")
 	cmd.Flags().BoolVar(&auto, "auto", false, "Send handoff mail without requesting restart (for PreCompact hooks)")
 	cmd.Flags().StringVar(&hookFormat, "hook-format", "", "format hook output for a provider")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
 	return cmd
+}
+
+type handoffJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	Mode          string `json:"mode"`
+	Target        string `json:"target,omitempty"`
+	Auto          bool   `json:"auto"`
+	Subject       string `json:"subject,omitempty"`
+}
+
+func handoffJSONMode(target string, auto bool) string {
+	if target != "" {
+		return "remote"
+	}
+	if auto {
+		return "auto"
+	}
+	return "self"
+}
+
+func handoffJSONSubject(args []string, auto bool) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	if auto {
+		return "context cycle"
+	}
+	return "HANDOFF: context cycle"
 }
 
 func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -324,6 +324,143 @@ func TestCmdHandoffAutoUsesDefaultSubject(t *testing.T) {
 	}
 }
 
+func TestCmdHandoffAutoJSONReportsCreatedMail(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_NAME", "mayor")
+
+	var stdout, stderr bytes.Buffer
+	cmd := newHandoffCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--auto", "--json", "Reviewed handoff"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc handoff --auto --json failed: %v; stderr=%s", err, stderr.String())
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	all, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("open beads = %d, want handoff mail", len(all))
+	}
+
+	var payload struct {
+		SchemaVersion    string `json:"schema_version"`
+		OK               bool   `json:"ok"`
+		Mode             string `json:"mode"`
+		Auto             bool   `json:"auto"`
+		Subject          string `json:"subject"`
+		MailBeadID       string `json:"mail_bead_id"`
+		RestartRequested bool   `json:"restart_requested"`
+		Action           string `json:"action"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || !payload.OK || payload.Mode != "auto" || !payload.Auto {
+		t.Fatalf("handoff JSON envelope = %+v", payload)
+	}
+	if payload.RestartRequested || payload.Action != "restart_skipped" {
+		t.Fatalf("handoff JSON restart fields = %+v", payload)
+	}
+	if payload.Subject != all[0].Title {
+		t.Fatalf("subject = %q, want actual mail title %q", payload.Subject, all[0].Title)
+	}
+	if payload.MailBeadID != all[0].ID {
+		t.Fatalf("mail_bead_id = %q, want actual mail id %q", payload.MailBeadID, all[0].ID)
+	}
+}
+
+func TestHandoffJSONSelfReportsRestartRequest(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	outcome := doHandoffWithOutcome(store, rec, dops, nil, "worker-1", "worker-1",
+		[]string{"HANDOFF: context full"}, &stdout, &stderr)
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	payload := encodeHandoffJSONForTest(t, outcome)
+	if !payload.OK || payload.Mode != "self" || payload.Recipient != "worker-1" {
+		t.Fatalf("handoff JSON envelope = %+v", payload)
+	}
+	if !payload.RestartRequested || payload.Action != "restart_requested" {
+		t.Fatalf("handoff JSON restart fields = %+v", payload)
+	}
+	if payload.MailBeadID == "" || payload.Subject != "HANDOFF: context full" {
+		t.Fatalf("handoff JSON mail fields = %+v", payload)
+	}
+}
+
+func TestHandoffJSONRemoteReportsKilledTarget(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker-2", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+
+	outcome := doHandoffRemoteWithOutcome(store, rec, sp, "worker-2", "worker-2", "worker-1",
+		[]string{"Context refresh"}, &stdout, &stderr)
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	payload := encodeHandoffJSONForTest(t, outcome)
+	if !payload.OK || payload.Mode != "remote" || payload.Target != "worker-2" || payload.Recipient != "worker-2" {
+		t.Fatalf("handoff JSON envelope = %+v", payload)
+	}
+	if payload.RestartRequested || payload.Action != "killed" {
+		t.Fatalf("handoff JSON remote action fields = %+v", payload)
+	}
+	if payload.MailBeadID == "" || payload.Subject != "Context refresh" {
+		t.Fatalf("handoff JSON mail fields = %+v", payload)
+	}
+}
+
+func encodeHandoffJSONForTest(t *testing.T, outcome handoffOutcome) handoffJSONResult {
+	t.Helper()
+	var stdout bytes.Buffer
+	if err := writeCLIJSONLine(&stdout, handoffJSONFromOutcome(outcome)); err != nil {
+		t.Fatalf("writeCLIJSONLine: %v", err)
+	}
+	var payload handoffJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not handoff JSON: %v\n%s", err, stdout.String())
+	}
+	return payload
+}
+
+func TestCmdHandoffJSONRejectsHookFormat(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := newHandoffCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--auto", "--json", "--hook-format", "codex"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("gc handoff --json --hook-format succeeded, want conflict")
+	}
+	if !strings.Contains(stderr.String(), "--json cannot be used with --hook-format") {
+		t.Fatalf("stderr = %q, want json/hook-format conflict", stderr.String())
+	}
+}
+
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -244,7 +244,9 @@ func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, 
 
 	output, err := runner(workQuery, dir)
 	if err != nil {
-		if normalized := normalizeWorkQueryOutput(strings.TrimSpace(output)); normalized != "" {
+		normalized := normalizeWorkQueryOutput(strings.TrimSpace(output))
+		normalized = filterUnreadyHookCandidatesWithDiagnostics(normalized, time.Now(), stderr)
+		if normalized != "" {
 			fmt.Fprint(stdout, normalized) //nolint:errcheck // best-effort stdout
 		}
 		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -253,7 +255,7 @@ func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, 
 
 	trimmed := strings.TrimSpace(output)
 	normalized := normalizeWorkQueryOutput(trimmed)
-	normalized = filterUnreadyHookCandidates(normalized, time.Now())
+	normalized = filterUnreadyHookCandidatesWithDiagnostics(normalized, time.Now(), stderr)
 	hasWork := workQueryHasReadyWork(normalized)
 
 	// Non-inject mode: print normalized, ready-only output. Return 0 only when work exists.
@@ -290,18 +292,18 @@ func workQueryHasReadyWork(output string) bool {
 	return true
 }
 
-// filterUnreadyHookCandidates strips beads from work_query output that fail
-// bd ready semantics: future defer_until, or any open blocking dep in the
-// row's blocked_by array. The work_query is expected to gate these, but
-// defensive filtering here prevents a single broken query from cascading
-// into agent action on a bead it cannot progress.
-// Pure function over JSON; takes time.Time so tests stay deterministic.
-func filterUnreadyHookCandidates(output string, now time.Time) string {
+// filterUnreadyHookCandidatesWithDiagnostics strips beads from work_query
+// output that fail bd ready semantics: future defer_until, or any open
+// blocking dep in the row's blocked_by array. The work_query is expected to
+// gate these, but defensive filtering here prevents a single broken query from
+// cascading into agent action on a bead it cannot progress.
+func filterUnreadyHookCandidatesWithDiagnostics(output string, now time.Time, stderr io.Writer) string {
 	if output == "" {
 		return output
 	}
 	var decoded any
 	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		warnUnfilteredHookJSON(output, err, stderr)
 		return output
 	}
 	arr, ok := decoded.([]any)
@@ -325,9 +327,21 @@ func filterUnreadyHookCandidates(output string, now time.Time) string {
 	}
 	reencoded, err := json.Marshal(filtered)
 	if err != nil {
+		warnUnfilteredHookJSON(output, err, stderr)
 		return output
 	}
 	return string(reencoded)
+}
+
+func warnUnfilteredHookJSON(output string, err error, stderr io.Writer) {
+	if stderr == nil {
+		return
+	}
+	trimmed := strings.TrimSpace(output)
+	if !strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "{") {
+		return
+	}
+	fmt.Fprintf(stderr, "gc hook: warning: cannot filter work query JSON: %v\n", err) //nolint:errcheck // best-effort stderr
 }
 
 func isFutureDeferredHookCandidate(item map[string]any, now time.Time) bool {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -237,6 +237,7 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 	var bootstrapProfileFlag string
 	var skipProviderReadiness bool
 	var preserveExisting bool
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "init [path]",
 		Short: "Initialize a new city",
@@ -261,13 +262,26 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
   gc init --file city.toml --preserve-existing .`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			out := stdout
+			if jsonOut {
+				out = io.Discard
+			}
+			mode := "default"
 			if fromFlag != "" {
-				return exitForCode(cmdInitFromDirWithOptions(fromFlag, args, nameFlag, stdout, stderr, skipProviderReadiness))
+				mode = "from"
+				code := cmdInitFromDirWithOptions(fromFlag, args, nameFlag, out, stderr, skipProviderReadiness)
+				return writeInitJSONOrExit(code, jsonOut, args, nameFlag, providerFlag, bootstrapProfileFlag, mode, stdout)
 			}
 			if fileFlag != "" {
-				return exitForCode(cmdInitFromFileWithOptions(fileFlag, args, nameFlag, stdout, stderr, skipProviderReadiness, preserveExisting))
+				mode = "file"
+				code := cmdInitFromFileWithOptions(fileFlag, args, nameFlag, out, stderr, skipProviderReadiness, preserveExisting)
+				return writeInitJSONOrExit(code, jsonOut, args, nameFlag, providerFlag, bootstrapProfileFlag, mode, stdout)
 			}
-			return exitForCode(cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, nameFlag, stdout, stderr, skipProviderReadiness, preserveExisting))
+			if providerFlag != "" || bootstrapProfileFlag != "" {
+				mode = "provider"
+			}
+			code := cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, nameFlag, out, stderr, skipProviderReadiness, preserveExisting)
+			return writeInitJSONOrExit(code, jsonOut, args, nameFlag, providerFlag, bootstrapProfileFlag, mode, stdout)
 		},
 	}
 	cmd.Flags().StringVar(&fileFlag, "file", "", "path to a TOML file to use as city.toml")
@@ -277,12 +291,50 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 	cmd.Flags().StringVar(&bootstrapProfileFlag, "bootstrap-profile", "", "bootstrap profile to apply for hosted/container defaults")
 	cmd.Flags().BoolVar(&skipProviderReadiness, "skip-provider-readiness", false, "skip provider login/readiness checks during init and continue startup")
 	cmd.Flags().BoolVar(&preserveExisting, "preserve-existing", false, "keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
 	cmd.MarkFlagsMutuallyExclusive("file", "from")
 	cmd.MarkFlagsMutuallyExclusive("provider", "file")
 	cmd.MarkFlagsMutuallyExclusive("provider", "from")
 	cmd.MarkFlagsMutuallyExclusive("bootstrap-profile", "file")
 	cmd.MarkFlagsMutuallyExclusive("bootstrap-profile", "from")
 	return cmd
+}
+
+type initJSONResult struct {
+	SchemaVersion    string `json:"schema_version"`
+	CityPath         string `json:"city_path"`
+	CityName         string `json:"city_name"`
+	Mode             string `json:"mode"`
+	Provider         string `json:"provider,omitempty"`
+	BootstrapProfile string `json:"bootstrap_profile,omitempty"`
+}
+
+func writeInitJSONOrExit(code int, jsonOut bool, args []string, nameOverride, provider, bootstrapProfile, mode string, stdout io.Writer) error {
+	if code != 0 {
+		return exitForCode(code)
+	}
+	if !jsonOut {
+		return nil
+	}
+	cityPath, err := initTargetPath(args)
+	if err != nil {
+		return err
+	}
+	return writeCLIJSONLine(stdout, initJSONResult{
+		SchemaVersion:    "1",
+		CityPath:         cityPath,
+		CityName:         resolveCityName(nameOverride, "", cityPath),
+		Mode:             mode,
+		Provider:         strings.TrimSpace(provider),
+		BootstrapProfile: strings.TrimSpace(bootstrapProfile),
+	})
+}
+
+func initTargetPath(args []string) (string, error) {
+	if len(args) > 0 {
+		return filepath.Abs(args[0])
+	}
+	return os.Getwd()
 }
 
 // cmdInit initializes a new city at the given path (or cwd if no path given).

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -95,6 +95,8 @@ func isTerminal(f *os.File) bool {
 	return fi.Mode()&os.ModeCharDevice != 0
 }
 
+var isTerminalFunc = isTerminal
+
 // readLine reads a single line from br and returns it trimmed.
 // Returns empty string on EOF or error.
 func readLine(br *bufio.Reader) string {
@@ -280,7 +282,7 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 			if providerFlag != "" || bootstrapProfileFlag != "" {
 				mode = "provider"
 			}
-			code := cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, nameFlag, out, stderr, skipProviderReadiness, preserveExisting)
+			code := cmdInitWithOptionsInternal(args, providerFlag, bootstrapProfileFlag, nameFlag, out, stderr, skipProviderReadiness, preserveExisting, jsonOut)
 			return writeInitJSONOrExit(code, jsonOut, args, nameFlag, providerFlag, bootstrapProfileFlag, mode, stdout)
 		},
 	}
@@ -346,6 +348,10 @@ func cmdInit(args []string, providerFlag, bootstrapProfileFlag string, stdout, s
 }
 
 func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
+	return cmdInitWithOptionsInternal(args, providerFlag, bootstrapProfileFlag, nameOverride, stdout, stderr, skipProviderReadiness, preserveExisting, false)
+}
+
+func cmdInitWithOptionsInternal(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool, forceDefaultWizard bool) int {
 	var cityPath string
 	if len(args) > 0 {
 		var err error
@@ -374,7 +380,9 @@ func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameO
 			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-	case isTerminal(os.Stdin):
+	case forceDefaultWizard:
+		wiz = defaultWizardConfig()
+	case isTerminalFunc(os.Stdin):
 		wiz = runWizard(os.Stdin, stdout)
 		maybePrintWizardProviderGuidance(wiz, stdout)
 	default:

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -61,6 +61,7 @@ func newPrimeCmd(stdout, stderr io.Writer) *cobra.Command {
 	var hookMode bool
 	var hookFormat string
 	var strictMode bool
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "prime [agent-name]",
 		Short: "Output the behavioral prompt for an agent",
@@ -92,6 +93,29 @@ to empty output from valid conditional logic, or on suspended states
 		Args: cobra.MaximumNArgs(1),
 	}
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
+		if jsonOut {
+			var buf strings.Builder
+			if doPrimeWithHookFormat(args, &buf, stderr, hookMode, hookFormat, strictMode) != 0 {
+				return errExit
+			}
+			agentName := ""
+			if len(args) > 0 {
+				agentName = args[0]
+			} else if v := strings.TrimSpace(os.Getenv("GC_ALIAS")); v != "" {
+				agentName = v
+			} else {
+				agentName = strings.TrimSpace(os.Getenv("GC_AGENT"))
+			}
+			_ = writeCLIJSONLine(stdout, primeJSONResult{
+				SchemaVersion: "1",
+				Agent:         agentName,
+				Hook:          hookMode,
+				HookFormat:    hookFormat,
+				Content:       buf.String(),
+				Bytes:         buf.Len(),
+			})
+			return nil
+		}
 		if doPrimeWithHookFormat(args, stdout, stderr, hookMode, hookFormat, strictMode) != 0 {
 			return errExit
 		}
@@ -100,7 +124,17 @@ to empty output from valid conditional logic, or on suspended states
 	cmd.Flags().BoolVar(&hookMode, "hook", false, "compatibility mode for runtime hook invocations")
 	cmd.Flags().StringVar(&hookFormat, "hook-format", "", "format hook output for a provider")
 	cmd.Flags().BoolVar(&strictMode, "strict", false, "fail on missing city, missing or unknown agent, or unreadable prompt_template instead of falling back to the default prompt")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
 	return cmd
+}
+
+type primeJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	Agent         string `json:"agent,omitempty"`
+	Hook          bool   `json:"hook"`
+	HookFormat    string `json:"hook_format,omitempty"`
+	Content       string `json:"content"`
+	Bytes         int    `json:"bytes"`
 }
 
 // doPrime exists as the public non-strict entry point so callers don't

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -98,14 +98,7 @@ to empty output from valid conditional logic, or on suspended states
 			if doPrimeWithHookFormat(args, &buf, stderr, hookMode, hookFormat, strictMode) != 0 {
 				return errExit
 			}
-			agentName := ""
-			if len(args) > 0 {
-				agentName = args[0]
-			} else if v := strings.TrimSpace(os.Getenv("GC_ALIAS")); v != "" {
-				agentName = v
-			} else {
-				agentName = strings.TrimSpace(os.Getenv("GC_AGENT"))
-			}
+			agentName, _ := primeInvocationAgentName(args)
 			_ = writeCLIJSONLine(stdout, primeJSONResult{
 				SchemaVersion: "1",
 				Agent:         agentName,
@@ -161,7 +154,7 @@ func doPrimeWithMode(args []string, stdout, stderr io.Writer, hookMode, strictMo
 	return doPrimeWithHookFormat(args, stdout, stderr, hookMode, "", strictMode)
 }
 
-func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode bool, hookFormat string, strictMode bool) int {
+func primeInvocationAgentName(args []string) (string, bool) {
 	agentName := os.Getenv("GC_ALIAS")
 	if agentName == "" {
 		agentName = os.Getenv("GC_AGENT")
@@ -179,6 +172,11 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	if len(args) > 0 {
 		agentName = args[0]
 	}
+	return strings.TrimSpace(agentName), sessionTemplateContext
+}
+
+func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode bool, hookFormat string, strictMode bool) int {
+	agentName, sessionTemplateContext := primeInvocationAgentName(args)
 	hookContext := primeHookContext{}
 	suppressHookPrompt := false
 	if hookMode {

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1565,12 +1565,13 @@ func parsePruneDuration(s string) (time.Duration, error) {
 // newSessionPeekCmd creates the "gc session peek <id-or-alias>" command.
 func newSessionPeekCmd(stdout, stderr io.Writer) *cobra.Command {
 	var lines int
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "peek <session-id-or-alias>",
 		Short: "View session output without attaching",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionPeek(args, lines, stdout, stderr) != 0 {
+			if cmdSessionPeek(args, lines, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -1578,11 +1579,21 @@ func newSessionPeekCmd(stdout, stderr io.Writer) *cobra.Command {
 		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().IntVar(&lines, "lines", 50, "number of lines to capture")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL result")
 	return cmd
 }
 
+type sessionPeekJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	SessionID     string `json:"session_id"`
+	Target        string `json:"target"`
+	Lines         int    `json:"lines"`
+	LineCount     int    `json:"line_count"`
+	Output        string `json:"output"`
+}
+
 // cmdSessionPeek is the CLI entry point for "gc session peek".
-func cmdSessionPeek(args []string, lines int, stdout, stderr io.Writer) int {
+func cmdSessionPeek(args []string, lines int, jsonOutput bool, stdout, stderr io.Writer) int {
 	store, code := openCityStore(stderr, "gc session peek")
 	if store == nil {
 		return code
@@ -1612,11 +1623,37 @@ func cmdSessionPeek(args []string, lines int, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	if jsonOutput {
+		if err := writeCLIJSONLine(stdout, sessionPeekJSONResult{
+			SchemaVersion: "1",
+			SessionID:     sessionID,
+			Target:        args[0],
+			Lines:         lines,
+			LineCount:     outputLineCount(output),
+			Output:        output,
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc session peek: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return 0
+	}
+
 	fmt.Fprint(stdout, output) //nolint:errcheck // best-effort stdout
 	if !strings.HasSuffix(output, "\n") {
 		fmt.Fprintln(stdout) //nolint:errcheck // best-effort stdout
 	}
 	return 0
+}
+
+func outputLineCount(output string) int {
+	if output == "" {
+		return 0
+	}
+	count := strings.Count(output, "\n")
+	if !strings.HasSuffix(output, "\n") {
+		count++
+	}
+	return count
 }
 
 // newSessionKillCmd creates the "gc session kill <id-or-alias>" command.

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -21,6 +21,7 @@ import (
 func newSessionLogsCmd(stdout, stderr io.Writer) *cobra.Command {
 	var follow bool
 	var tail int
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "logs <session>",
 		Short: "Show session logs for a session",
@@ -48,7 +49,7 @@ Use -f to follow new messages as they arrive.`,
   gc session logs s-gc-123 -f`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionLogs(args, follow, tail, stdout, stderr) != 0 {
+			if cmdSessionLogs(args, follow, tail, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -57,11 +58,12 @@ Use -f to follow new messages as they arrive.`,
 	}
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow new messages as they arrive")
 	cmd.Flags().IntVar(&tail, "tail", 10, "Number of most recent transcript entries to show (0 = all; compact dividers count as entries)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL result for the bounded snapshot")
 	return cmd
 }
 
 // cmdSessionLogs is the CLI entry point for viewing session logs.
-func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writer) int {
+func cmdSessionLogs(args []string, follow bool, tail int, jsonOutput bool, stdout, stderr io.Writer) int {
 	identifier := args[0]
 
 	cityPath, err := resolveCity()
@@ -104,6 +106,9 @@ func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writ
 		return 1
 	}
 
+	if jsonOutput {
+		return doSessionLogsJSON(path, provider, identifier, follow, tail, stdout, stderr)
+	}
 	return doSessionLogs(path, provider, follow, tail, stdout, stderr)
 }
 
@@ -362,6 +367,107 @@ func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr 
 }
 
 type sessionLogsReader func(factory *worker.Factory, provider, path string) (*worker.TranscriptSession, error)
+
+type sessionLogsJSONResult struct {
+	SchemaVersion  string                `json:"schema_version"`
+	Target         string                `json:"target"`
+	Provider       string                `json:"provider,omitempty"`
+	TranscriptPath string                `json:"transcript_path"`
+	Tail           int                   `json:"tail"`
+	EntryCount     int                   `json:"entry_count"`
+	Entries        []sessionLogEntryJSON `json:"entries"`
+}
+
+type sessionLogEntryJSON struct {
+	UUID            string                          `json:"uuid,omitempty"`
+	ParentUUID      string                          `json:"parent_uuid,omitempty"`
+	Type            string                          `json:"type"`
+	Subtype         string                          `json:"subtype,omitempty"`
+	Role            string                          `json:"role,omitempty"`
+	Timestamp       string                          `json:"timestamp,omitempty"`
+	CompactBoundary bool                            `json:"compact_boundary,omitempty"`
+	Text            string                          `json:"text,omitempty"`
+	Blocks          []worker.TranscriptContentBlock `json:"blocks,omitempty"`
+	Message         json.RawMessage                 `json:"message,omitempty"`
+}
+
+func doSessionLogsJSON(path, provider, target string, follow bool, tail int, stdout, stderr io.Writer) int {
+	if follow {
+		fmt.Fprintln(stderr, "gc session logs: --json is only supported for bounded snapshots; omit --follow") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if tail < 0 {
+		fmt.Fprintln(stderr, "gc session logs: --tail must be >= 0") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	factory, err := worker.NewFactory(worker.FactoryConfig{})
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session logs: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return runSessionLogsJSON(factory, provider, path, target, tail, stdout, stderr, readSessionFile)
+}
+
+func runSessionLogsJSON(factory *worker.Factory, provider, path, target string, tail int, stdout, stderr io.Writer, read sessionLogsReader) int {
+	sess, readErr := read(factory, provider, path)
+	if readErr != nil {
+		fmt.Fprintf(stderr, "gc session logs: %v\n", readErr) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	messages := tailMessages(sess.Messages, tail)
+	entries := make([]sessionLogEntryJSON, 0, len(messages))
+	for _, msg := range messages {
+		entries = append(entries, sessionLogEntryToJSON(msg))
+	}
+	if err := writeCLIJSONLine(stdout, sessionLogsJSONResult{
+		SchemaVersion:  "1",
+		Target:         target,
+		Provider:       provider,
+		TranscriptPath: path,
+		Tail:           tail,
+		EntryCount:     len(entries),
+		Entries:        entries,
+	}); err != nil {
+		fmt.Fprintf(stderr, "gc session logs: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return 0
+}
+
+func sessionLogEntryToJSON(e *worker.TranscriptEntry) sessionLogEntryJSON {
+	if e == nil {
+		return sessionLogEntryJSON{}
+	}
+	entry := sessionLogEntryJSON{
+		UUID:            e.UUID,
+		ParentUUID:      e.ParentUUID,
+		Type:            e.Type,
+		Subtype:         e.Subtype,
+		CompactBoundary: e.IsCompactBoundary(),
+	}
+	if !e.Timestamp.IsZero() {
+		entry.Timestamp = e.Timestamp.Format(time.RFC3339Nano)
+	}
+	if len(e.Message) > 0 {
+		entry.Message = e.Message
+	}
+	mc := resolveMessage(e.Message)
+	if mc == nil {
+		return entry
+	}
+	entry.Role = mc.Role
+	var text string
+	if json.Unmarshal(mc.Content, &text) == nil {
+		entry.Text = text
+		return entry
+	}
+	var blocks []worker.TranscriptContentBlock
+	if json.Unmarshal(mc.Content, &blocks) == nil && len(blocks) > 0 {
+		entry.Blocks = blocks
+	}
+	return entry
+}
 
 func runSessionLogs(factory *worker.Factory, provider, path string, follow bool, tail int, stdout, stderr io.Writer, sleep func(time.Duration), read sessionLogsReader) int {
 	// Always read the full session; apply tail trimming locally so semantics

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -617,6 +618,87 @@ func TestDoSessionLogsFollowTailShowsOnlyNewMessagesOnReadErrorExit(t *testing.T
 	}
 	if !strings.Contains(stderr.String(), "5 consecutive read errors") {
 		t.Fatalf("stderr should report the injected termination condition, got: %s", stderr.String())
+	}
+}
+
+func TestCmdSessionLogsJSONSuccessIsJSONOnly(t *testing.T) {
+	clearGCEnv(t)
+	clearInheritedCityRoutingEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	searchBase := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(fmt.Sprintf(`[workspace]
+name = "test"
+
+[daemon]
+observe_paths = [%q]
+`, searchBase)), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(%q): %v", cityDir, err)
+	}
+	b, err := store.Create(beads.Bead{
+		Title:  "json logs session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "runtime-session",
+			"session_key":  "known-session",
+			"provider":     "claude",
+			"template":     "worker",
+			"state":        "asleep",
+			"work_dir":     workDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session): %v", err)
+	}
+	writeNamedTestSession(t, searchBase, workDir, "known-session.jsonl",
+		`{"uuid":"1","parentUuid":"","type":"user","message":{"role":"user","content":"older"},"timestamp":"2025-01-01T00:00:00Z"}`,
+		`{"uuid":"2","parentUuid":"1","type":"assistant","message":{"role":"assistant","content":"newer"},"timestamp":"2025-01-01T00:00:01Z"}`,
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionLogs([]string{b.ID}, false, 1, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionLogs(--json) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1 JSONL record: %q", len(lines), stdout.String())
+	}
+	var got sessionLogsJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not parseable JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.Target != b.ID || got.Tail != 1 || got.EntryCount != 1 {
+		t.Fatalf("logs JSON metadata = %+v", got)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].Text != "newer" || got.Entries[0].Role != "assistant" {
+		t.Fatalf("logs JSON entries = %+v", got.Entries)
+	}
+}
+
+func TestDoSessionLogsJSONRejectsFollow(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := doSessionLogsJSON("/ignored", "claude", "worker", true, 10, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doSessionLogsJSON(follow) = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--json is only supported for bounded snapshots") {
+		t.Fatalf("stderr = %q, want bounded snapshot diagnostic", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1306,6 +1306,63 @@ func TestCmdSessionListJSONOmitZeroLastNudgeDeliveredAt(t *testing.T) {
 	}
 }
 
+func TestCmdSessionPeekJSONSuccessIsJSONOnly(t *testing.T) {
+	clearGCEnv(t)
+	clearInheritedCityRoutingEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+
+	fakeProvider := runtime.NewFake()
+	fakeProvider.SetPeekOutput("runtime-session", "hello\nworld\n")
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(%q): %v", cityDir, err)
+	}
+	b, err := store.Create(beads.Bead{
+		Title:  "json peek session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "runtime-session",
+			"template":     "worker",
+			"state":        "awake",
+			"work_dir":     cityDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionPeek([]string{b.ID}, 2, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionPeek(--json) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1 JSONL record: %q", len(lines), stdout.String())
+	}
+	var got sessionPeekJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not parseable JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.SessionID != b.ID || got.Output != "hello\nworld\n" || got.LineCount != 2 {
+		t.Fatalf("peek JSON = %+v", got)
+	}
+}
+
 func sessionListJSONRowBySessionName(rows []sessionListJSONRow, name string) *sessionListJSONRow {
 	for _, row := range rows {
 		if row.SessionName == name {

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -50,6 +50,7 @@ name collision. For the materialized set, inspect the
 func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 	var agentName string
 	var sessionID string
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List visible skills",
@@ -85,13 +86,32 @@ func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 				fmt.Fprintf(stderr, "gc skill list: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
+			if jsonOut {
+				_ = writeCLIJSONLine(stdout, skillListJSONResult{
+					SchemaVersion: "1",
+					Agent:         strings.TrimSpace(agentName),
+					Session:       strings.TrimSpace(sessionID),
+					Count:         len(entries),
+					Entries:       entries,
+				})
+				return nil
+			}
 			writeVisibilityEntries(stdout, entries)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&agentName, "agent", "", "show the effective skill view for this agent")
 	cmd.Flags().StringVar(&sessionID, "session", "", "show the effective skill view for this session")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
 	return cmd
+}
+
+type skillListJSONResult struct {
+	SchemaVersion string            `json:"schema_version"`
+	Agent         string            `json:"agent,omitempty"`
+	Session       string            `json:"session,omitempty"`
+	Count         int               `json:"count"`
+	Entries       []visibilityEntry `json:"entries"`
 }
 
 func listVisibleSkillEntries(cityPath string, cfg *config.City, store beads.Store, agentName, sessionID string) ([]visibilityEntry, error) {
@@ -149,9 +169,9 @@ func discoverBootstrapSkillEntries() []visibilityEntry {
 }
 
 type visibilityEntry struct {
-	Name   string
-	Source string
-	Path   string
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Path   string `json:"path"`
 }
 
 func resolveVisibilityAgent(cityPath string, cfg *config.City, store beads.Store, agentName, sessionID string) (*config.Agent, error) {

--- a/cmd/gc/cmd_version.go
+++ b/cmd/gc/cmd_version.go
@@ -86,6 +86,7 @@ func normalizeVersion(v string) string {
 
 func newVersionCmd(stdout io.Writer) *cobra.Command {
 	var longOutput bool
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print gc version",
@@ -94,6 +95,16 @@ func newVersionCmd(stdout io.Writer) *cobra.Command {
 Use --long to include git commit and build date metadata.`,
 		Args: cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
+			if jsonOut {
+				_ = writeCLIJSONLine(stdout, versionJSONResult{
+					SchemaVersion: "1",
+					Version:       version,
+					Commit:        commit,
+					Date:          date,
+					Long:          longOutput,
+				})
+				return
+			}
 			if longOutput {
 				fmt.Fprintf(stdout, "%s (commit: %s, built: %s)\n", version, commit, date) //nolint:errcheck // best-effort stdout
 				return
@@ -102,5 +113,14 @@ Use --long to include git commit and build date metadata.`,
 		},
 	}
 	cmd.Flags().BoolVarP(&longOutput, "long", "l", false, "Include git commit and build date metadata")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
 	return cmd
+}
+
+type versionJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	Version       string `json:"version"`
+	Commit        string `json:"commit"`
+	Date          string `json:"date"`
+	Long          bool   `json:"long"`
 }

--- a/cmd/gc/hook_defer_blocked_test.go
+++ b/cmd/gc/hook_defer_blocked_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -51,6 +52,35 @@ func TestDoHookFiltersDepBlockedBeads(t *testing.T) {
 	}
 }
 
+func TestDoHookFiltersUnreadyPartialOutputOnCommandError(t *testing.T) {
+	future := "2099-01-01T00:00:00Z"
+	runner := func(_, _ string) (string, error) {
+		return `[
+			{"id":"deferred-1","status":"open","defer_until":"` + future + `"},
+			{"id":"blocked-1","status":"open","blocked_by":[{"id":"blocker-1","status":"open"}]},
+			{"id":"ready-1","status":"open"}
+		]`, fmt.Errorf("timed out after 15s with partial stdout")
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doHook() = %d, want 1 on command error", code)
+	}
+	out := stdout.String()
+	for _, blocked := range []string{"deferred-1", "blocked-1"} {
+		if strings.Contains(out, blocked) {
+			t.Errorf("unready bead %q surfaced in hook partial output: %s", blocked, out)
+		}
+	}
+	if !strings.Contains(out, "ready-1") {
+		t.Errorf("ready bead missing from hook partial output: %s", out)
+	}
+	if !strings.Contains(stderr.String(), "partial stdout") {
+		t.Fatalf("stderr = %q, want command error diagnostic", stderr.String())
+	}
+}
+
 func TestDoHookKeepsPastDeferredAndClosedBlockers(t *testing.T) {
 	past := "2000-01-01T00:00:00Z"
 	runner := func(_, _ string) (string, error) {
@@ -70,5 +100,23 @@ func TestDoHookKeepsPastDeferredAndClosedBlockers(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("ready bead %q missing from hook output: %s", want, out)
 		}
+	}
+}
+
+func TestDoHookWarnsWhenJSONLikeOutputCannotBeFiltered(t *testing.T) {
+	runner := func(_, _ string) (string, error) {
+		return `[{"id":"ready-1"}`, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHook() = %d, want 0 for legacy fail-open behavior; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cannot filter work query JSON") {
+		t.Fatalf("stderr = %q, want filter diagnostic", stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "ready-1") {
+		t.Fatalf("stdout = %q, want original output preserved", got)
 	}
 }

--- a/cmd/gc/json_oddball_root_test.go
+++ b/cmd/gc/json_oddball_root_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func requireSingleJSONLine(t *testing.T, stdout *bytes.Buffer) map[string]any {
+	t.Helper()
+	out := strings.TrimSuffix(stdout.String(), "\n")
+	if out == "" {
+		t.Fatalf("stdout empty, want JSON line")
+	}
+	if strings.Contains(out, "\n") {
+		t.Fatalf("stdout has multiple lines, want one JSON line:\n%s", stdout.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got["schema_version"] != "1" {
+		t.Fatalf("schema_version = %v, want 1 in %v", got["schema_version"], got)
+	}
+	return got
+}
+
+func TestOddballRootJSONPrimeNoCity(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"prime", "worker", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run prime --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["agent"] != "worker" || got["content"] == "" {
+		t.Fatalf("prime JSON = %+v", got)
+	}
+}
+
+func TestOddballRootJSONEventEmitBestEffort(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"event", "emit", "custom.test", "--subject", "thing", "--message", "hello", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run event emit --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["event_type"] != "custom.test" || got["subject"] != "thing" {
+		t.Fatalf("event emit JSON = %+v", got)
+	}
+}
+
+func TestOddballRootJSONVersion(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run version --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["version"] == "" || got["commit"] == "" || got["date"] == "" {
+		t.Fatalf("version JSON = %+v", got)
+	}
+}
+
+func TestOddballRootJSONInitSkillListAndBuildImageContext(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cityPath := filepath.Join(t.TempDir(), "city")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, "skills", "sample"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "skills", "sample", "SKILL.md"), []byte("# Sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var skillOut, skillErr bytes.Buffer
+	code := run([]string{"--city", cityPath, "skill", "list", "--json"}, &skillOut, &skillErr)
+	if code != 0 {
+		t.Fatalf("run skill list --json = %d; stderr=%q stdout=%q", code, skillErr.String(), skillOut.String())
+	}
+	skillJSON := requireSingleJSONLine(t, &skillOut)
+	if _, ok := skillJSON["entries"].([]any); !ok {
+		t.Fatalf("skill JSON missing entries array: %+v", skillJSON)
+	}
+
+	var buildOut, buildErr bytes.Buffer
+	code = run([]string{"build-image", cityPath, "--context-only", "--json"}, &buildOut, &buildErr)
+	if code != 0 {
+		t.Fatalf("run build-image --json = %d; stderr=%q stdout=%q", code, buildErr.String(), buildOut.String())
+	}
+	buildJSON := requireSingleJSONLine(t, &buildOut)
+	if buildJSON["context_only"] != true {
+		t.Fatalf("build-image JSON = %+v", buildJSON)
+	}
+}
+
+func TestOddballRootJSONInitSummaryWriter(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "city")
+	var stdout bytes.Buffer
+	err := writeInitJSONOrExit(0, true, []string{cityPath}, "custom-name", "codex", "k8s-cell", "provider", &stdout)
+	if err != nil {
+		t.Fatalf("writeInitJSONOrExit: %v", err)
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["city_path"] != cityPath || got["city_name"] != "custom-name" || got["provider"] != "codex" {
+		t.Fatalf("init JSON = %+v", got)
+	}
+}
+
+func TestOddballRootJSONSchemaManifests(t *testing.T) {
+	for _, args := range [][]string{
+		{"init", "--json-schema"},
+		{"event", "emit", "--json-schema"},
+		{"prime", "--json-schema"},
+		{"handoff", "--json-schema"},
+		{"skill", "list", "--json-schema"},
+		{"build-image", "--json-schema"},
+		{"version", "--json-schema"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := run(args, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run %v = %d; stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+		}
+		got := requireSingleJSONLine(t, &stdout)
+		if got["json_supported"] != true {
+			t.Fatalf("%v json_supported = %v, want true: %+v", args, got["json_supported"], got)
+		}
+	}
+}

--- a/cmd/gc/json_oddball_root_test.go
+++ b/cmd/gc/json_oddball_root_test.go
@@ -62,8 +62,9 @@ func TestOddballRootJSONPrimeUsesSessionTemplateIdentity(t *testing.T) {
 
 func TestOddballRootJSONEventEmitBestEffort(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
+	cityPath := writeOddballMinimalCity(t, "city")
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"event", "emit", "custom.test", "--subject", "thing", "--message", "hello", "--json"}, &stdout, &stderr)
+	code := run([]string{"--city", cityPath, "event", "emit", "custom.test", "--subject", "thing", "--message", "hello", "--json"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("run event emit --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}

--- a/cmd/gc/json_oddball_root_test.go
+++ b/cmd/gc/json_oddball_root_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,8 +43,25 @@ func TestOddballRootJSONPrimeNoCity(t *testing.T) {
 	}
 }
 
+func TestOddballRootJSONPrimeUsesSessionTemplateIdentity(t *testing.T) {
+	t.Setenv("GC_ALIAS", "rigrepo/furiosa")
+	t.Setenv("GC_AGENT", "rigrepo/furiosa")
+	t.Setenv("GC_TEMPLATE", "rigrepo/polecat")
+	t.Setenv("GC_SESSION_NAME", "rigrepo--furiosa")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"prime", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run prime --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["agent"] != "rigrepo/polecat" {
+		t.Fatalf("agent = %v, want GC_TEMPLATE identity in %+v", got["agent"], got)
+	}
+}
+
 func TestOddballRootJSONEventEmitBestEffort(t *testing.T) {
-	t.Setenv("GC_HOME", t.TempDir())
+	configureIsolatedRuntimeEnv(t)
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"event", "emit", "custom.test", "--subject", "thing", "--message", "hello", "--json"}, &stdout, &stderr)
 	if code != 0 {
@@ -50,6 +70,48 @@ func TestOddballRootJSONEventEmitBestEffort(t *testing.T) {
 	got := requireSingleJSONLine(t, &stdout)
 	if got["event_type"] != "custom.test" || got["subject"] != "thing" {
 		t.Fatalf("event emit JSON = %+v", got)
+	}
+	if got["submitted"] != true || got["has_payload"] != false {
+		t.Fatalf("event emit best-effort JSON = %+v", got)
+	}
+	if _, ok := got["recorded"]; ok {
+		t.Fatalf("event emit JSON still exposes recorded: %+v", got)
+	}
+	if _, ok := got["payload"]; ok {
+		t.Fatalf("event emit JSON still exposes ambiguous payload boolean: %+v", got)
+	}
+}
+
+func TestOddballRootJSONEventEmitOpenFailure(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	missingCity := filepath.Join(t.TempDir(), "missing-city")
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", missingCity, "event", "emit", "custom.test", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run event emit open failure --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["submitted"] != false {
+		t.Fatalf("event emit open-failure JSON = %+v", got)
+	}
+	if stderr.Len() == 0 {
+		t.Fatalf("stderr empty, want provider-open diagnostic")
+	}
+}
+
+func TestOddballRootJSONEventEmitInvalidPayload(t *testing.T) {
+	t.Setenv("GC_EVENTS", "fake")
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"event", "emit", "custom.test", "--payload", "{not json", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run event emit invalid payload --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["submitted"] != false || got["has_payload"] != true {
+		t.Fatalf("event emit invalid-payload JSON = %+v", got)
+	}
+	if !strings.Contains(stderr.String(), "not valid JSON") {
+		t.Fatalf("stderr = %q, want invalid JSON diagnostic", stderr.String())
 	}
 }
 
@@ -67,13 +129,7 @@ func TestOddballRootJSONVersion(t *testing.T) {
 
 func TestOddballRootJSONInitSkillListAndBuildImageContext(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir())
-	cityPath := filepath.Join(t.TempDir(), "city")
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"city\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	cityPath := writeOddballMinimalCity(t, "city")
 	if err := os.MkdirAll(filepath.Join(cityPath, "skills", "sample"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -100,6 +156,42 @@ func TestOddballRootJSONInitSkillListAndBuildImageContext(t *testing.T) {
 	if buildJSON["context_only"] != true {
 		t.Fatalf("build-image JSON = %+v", buildJSON)
 	}
+	contextDir, ok := buildJSON["context_dir"].(string)
+	if !ok || contextDir == "" {
+		t.Fatalf("build-image JSON missing context_dir: %+v", buildJSON)
+	}
+	if _, err := os.Stat(contextDir); err != nil {
+		t.Fatalf("context_dir %q is not a real directory: %v", contextDir, err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(contextDir) })
+}
+
+func TestOddballRootJSONBuildImageNonContextOnly(t *testing.T) {
+	cityPath := writeOddballMinimalCity(t, "city")
+	oldBuild := buildImageBuild
+	buildImageBuild = func(_ context.Context, _ string, tag string, stdout, _ io.Writer) error {
+		fmt.Fprintf(stdout, "docker build for %s\n", tag) //nolint:errcheck // test writer is bytes.Buffer
+		return nil
+	}
+	t.Cleanup(func() { buildImageBuild = oldBuild })
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"build-image", cityPath, "--tag", "example:test", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run build-image non-context --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["tag"] != "example:test" || got["context_only"] != false {
+		t.Fatalf("build-image JSON = %+v", got)
+	}
+	if _, ok := got["context_dir"]; ok {
+		t.Fatalf("non-context build-image JSON should omit deleted context_dir: %+v", got)
+	}
+	for _, want := range []string{"Building image example:test", "docker build for example:test", "Image built: example:test"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
 }
 
 func TestOddballRootJSONInitSummaryWriter(t *testing.T) {
@@ -112,6 +204,58 @@ func TestOddballRootJSONInitSummaryWriter(t *testing.T) {
 	got := requireSingleJSONLine(t, &stdout)
 	if got["city_path"] != cityPath || got["city_name"] != "custom-name" || got["provider"] != "codex" {
 		t.Fatalf("init JSON = %+v", got)
+	}
+}
+
+func TestOddballRootJSONInitFromFileRun(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	source := filepath.Join(t.TempDir(), "source-city.toml")
+	if err := os.WriteFile(source, []byte("[workspace]\nname = \"source\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityPath := filepath.Join(t.TempDir(), "city")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", "--file", source, "--skip-provider-readiness", cityPath, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run init --file --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["mode"] != "file" || got["city_path"] != cityPath {
+		t.Fatalf("init --file JSON = %+v", got)
+	}
+}
+
+func TestOddballRootJSONInitDefaultSkipsTTYWizard(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	oldIsTerminal := isTerminalFunc
+	isTerminalFunc = func(*os.File) bool { return true }
+	t.Cleanup(func() { isTerminalFunc = oldIsTerminal })
+
+	stdin := writeTempInput(t, "\n\n")
+	oldStdin := os.Stdin
+	os.Stdin = stdin
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = stdin.Close()
+	})
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"init", "--skip-provider-readiness", cityPath, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run init default --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := requireSingleJSONLine(t, &stdout)
+	if got["mode"] != "default" || got["provider"] != nil {
+		t.Fatalf("init default JSON = %+v", got)
+	}
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "provider =") {
+		t.Fatalf("init --json used the interactive provider wizard; city.toml:\n%s", string(data))
 	}
 }
 
@@ -135,4 +279,31 @@ func TestOddballRootJSONSchemaManifests(t *testing.T) {
 			t.Fatalf("%v json_supported = %v, want true: %+v", args, got["json_supported"], got)
 		}
 	}
+}
+
+func writeOddballMinimalCity(t *testing.T, name string) string {
+	t.Helper()
+	cityPath := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \""+name+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cityPath
+}
+
+func writeTempInput(t *testing.T, content string) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "stdin-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	return f
 }

--- a/cmd/gc/json_output.go
+++ b/cmd/gc/json_output.go
@@ -39,9 +39,7 @@ func writeJSONError(stdout, stderr io.Writer, code, message string, exitCode int
 			ExitCode: exitCode,
 		},
 	}
-	enc := json.NewEncoder(stdout)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(payload); err != nil {
+	if err := writeCLIJSONLine(stdout, payload); err != nil {
 		writeJSONDiagnostic(stderr, "error", "json_encode_failed", fmt.Sprintf("encoding JSON error: %v", err), exitCode)
 		return exitCode
 	}

--- a/cmd/gc/json_output_test.go
+++ b/cmd/gc/json_output_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestWriteJSONErrorIncludesExitCodeOnStdoutAndStderr(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := writeJSONError(&stdout, &stderr, "config_load_failed", "gc status: loading config failed", 7)
+	code := writeJSONError(&stdout, &stderr, "config_load_failed", "gc status: loading <config>&failed", 7)
 	if code != 7 {
 		t.Fatalf("code = %d, want 7", code)
 	}
@@ -20,6 +20,12 @@ func TestWriteJSONErrorIncludesExitCodeOnStdoutAndStderr(t *testing.T) {
 	}
 	if out.SchemaVersion != "1" || out.OK || out.Error.Code != "config_load_failed" || out.Error.ExitCode != 7 {
 		t.Fatalf("stdout error payload = %+v", out)
+	}
+	if lines := strings.Split(strings.TrimSpace(stdout.String()), "\n"); len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want one JSON line; stdout=%q", len(lines), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "<config>&failed") || strings.Contains(stdout.String(), `\u003cconfig\u003e\u0026failed`) {
+		t.Fatalf("stdout = %q, want unescaped CLI JSON text", stdout.String())
 	}
 
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -50,6 +50,41 @@ func TestJSONSchemaManifestForSupportedCommand(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaManifestForSessionDetailCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"session", "peek", "example", "--json-schema"},
+		{"session", "logs", "example", "--json-schema"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%v) = %d, stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var manifest struct {
+				SchemaVersion string                     `json:"schema_version"`
+				JSONSupported bool                       `json:"json_supported"`
+				Schemas       map[string]json.RawMessage `json:"schemas"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+				t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+			}
+			if manifest.SchemaVersion != "1" || !manifest.JSONSupported {
+				t.Fatalf("manifest metadata = %+v", manifest)
+			}
+			if !json.Valid(manifest.Schemas["result"]) {
+				t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
+			}
+			if !json.Valid(manifest.Schemas["failure"]) {
+				t.Fatalf("failure schema missing or invalid: %s", manifest.Schemas["failure"])
+			}
+		})
+	}
+}
+
 func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"version", "--json-schema"}, &stdout, &stderr)

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -87,9 +87,9 @@ func TestJSONSchemaManifestForSessionDetailCommands(t *testing.T) {
 
 func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"version", "--json-schema"}, &stdout, &stderr)
+	code := run([]string{"dashboard", "--json-schema"}, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("run(version --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+		t.Fatalf("run(dashboard --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
@@ -103,8 +103,8 @@ func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
 		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
 	}
-	if got := strings.Join(manifest.Command, " "); got != "version" {
-		t.Fatalf("command = %q, want version", got)
+	if got := strings.Join(manifest.Command, " "); got != "dashboard" {
+		t.Fatalf("command = %q, want dashboard", got)
 	}
 	if manifest.JSONSupported {
 		t.Fatalf("json_supported = true, want false")
@@ -163,9 +163,9 @@ func TestJSONSchemaRoleSpecificFailureUsesSharedDefault(t *testing.T) {
 
 func TestJSONSchemaUnavailableRoleFailureIsStructured(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"version", "--json-schema=result"}, &stdout, &stderr)
+	code := run([]string{"dashboard", "--json-schema=result"}, &stdout, &stderr)
 	if code == 0 {
-		t.Fatalf("run(version --json-schema=result) = 0, want nonzero")
+		t.Fatalf("run(dashboard --json-schema=result) = 0, want nonzero")
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
@@ -190,9 +190,9 @@ func TestJSONSchemaUnavailableRoleFailureIsStructured(t *testing.T) {
 
 func TestJSONUnsupportedCommandFailureIsStructured(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"version", "--json"}, &stdout, &stderr)
+	code := run([]string{"dashboard", "--json"}, &stdout, &stderr)
 	if code == 0 {
-		t.Fatalf("run(version --json) = 0, want nonzero")
+		t.Fatalf("run(dashboard --json) = 0, want nonzero")
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2463,6 +2463,7 @@ gc session logs mayor
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `-f`, `--follow` | bool |  | Follow new messages as they arrive |
+| `--json` | bool |  | emit JSONL result for the bounded snapshot |
 | `--tail` | int | `10` | Number of most recent transcript entries to show (0 = all; compact dividers count as entries) |
 
 ## gc session new
@@ -2524,6 +2525,7 @@ gc session peek <session-id-or-alias> [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--json` | bool |  | emit JSONL result |
 | `--lines` | int | `50` | number of lines to capture |
 
 ## gc session pin

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -338,6 +338,7 @@ gc build-image [city-path] [flags]
 |------|------|---------|-------------|
 | `--base-image` | string | `gc-agent:latest` | base Docker image |
 | `--context-only` | bool |  | write build context without running docker build |
+| `--json` | bool |  | emit JSON summary |
 | `--push` | bool |  | push image after building |
 | `--rig-path` | stringSlice |  | rig name:path pairs (repeatable) |
 | `--tag` | string |  | image tag (required unless --context-only) |
@@ -1040,7 +1041,9 @@ gc event
 Record a custom event to the city event log.
 
 Best-effort: always exits 0 so bead hooks never fail. Supports
-attaching arbitrary JSON payloads.
+attaching arbitrary JSON payloads. JSON summaries report whether submission to
+the configured provider was attempted; the event bus does not acknowledge
+durable persistence.
 
 ```
 gc event emit <type> [flags]
@@ -1049,6 +1052,7 @@ gc event emit <type> [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--actor` | string |  | Actor name (default: $GC_ALIAS, else $GC_AGENT, else $GC_SESSION_ID, else "human") |
+| `--json` | bool |  | emit JSON summary |
 | `--message` | string |  | Event message |
 | `--payload` | string |  | JSON payload to attach to the event |
 | `--subject` | string |  | Event subject (e.g. bead ID) |
@@ -1268,6 +1272,7 @@ gc handoff [subject] [message] [flags]
 |------|------|---------|-------------|
 | `--auto` | bool |  | Send handoff mail without requesting restart (for PreCompact hooks) |
 | `--hook-format` | string |  | format hook output for a provider |
+| `--json` | bool |  | emit JSON summary |
 | `--target` | string |  | Remote session alias or ID to handoff (kills only controller-restartable sessions) |
 
 ## gc help
@@ -1415,6 +1420,7 @@ gc init
 | `--bootstrap-profile` | string |  | bootstrap profile to apply for hosted/container defaults |
 | `--file` | string |  | path to a TOML file to use as city.toml |
 | `--from` | string |  | path to an example city directory to copy |
+| `--json` | bool |  | emit JSON summary |
 | `--name` | string |  | workspace name (default: target directory basename) |
 | `--preserve-existing` | bool |  | keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them |
 | `--provider` | string |  | built-in workspace provider to use for the default mayor config |
@@ -1853,6 +1859,7 @@ gc prime [agent-name] [flags]
 |------|------|---------|-------------|
 | `--hook` | bool |  | compatibility mode for runtime hook invocations |
 | `--hook-format` | string |  | format hook output for a provider |
+| `--json` | bool |  | emit JSON summary |
 | `--strict` | bool |  | fail on missing city, missing or unknown agent, or unreadable prompt_template instead of falling back to the default prompt |
 
 ## gc prompt
@@ -2746,6 +2753,7 @@ gc skill list [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--agent` | string |  | show the effective skill view for this agent |
+| `--json` | bool |  | emit JSON summary |
 | `--session` | string |  | show the effective skill view for this session |
 
 ## gc sling
@@ -3130,6 +3138,7 @@ gc version [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--json` | bool |  | emit JSON summary |
 | `-l`, `--long` | bool |  | Include git commit and build date metadata |
 
 ## gc wait

--- a/schemas/build-image/result.schema.json
+++ b/schemas/build-image/result.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "base_image", "context_only", "push", "rig_path_count"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "tag": { "type": "string" },
+    "base_image": { "type": "string" },
+    "context_only": { "type": "boolean" },
+    "context_dir": { "type": "string" },
+    "push": { "type": "boolean" },
+    "rig_path_count": { "type": "integer" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/build-image/result.schema.json
+++ b/schemas/build-image/result.schema.json
@@ -8,7 +8,10 @@
     "tag": { "type": "string" },
     "base_image": { "type": "string" },
     "context_only": { "type": "boolean" },
-    "context_dir": { "type": "string" },
+    "context_dir": {
+      "type": "string",
+      "description": "Temporary build context directory retained only when context_only is true; build progress streams to stderr when JSON output is enabled."
+    },
     "push": { "type": "boolean" },
     "rig_path_count": { "type": "integer" }
   },

--- a/schemas/event/emit/result.schema.json
+++ b/schemas/event/emit/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "event_type", "actor", "payload", "recorded"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "event_type": { "type": "string" },
+    "actor": { "type": "string" },
+    "subject": { "type": "string" },
+    "message": { "type": "string" },
+    "payload": { "type": "boolean" },
+    "recorded": { "type": "boolean" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/event/emit/result.schema.json
+++ b/schemas/event/emit/result.schema.json
@@ -1,15 +1,18 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": ["schema_version", "event_type", "actor", "payload", "recorded"],
+  "required": ["schema_version", "event_type", "actor", "has_payload", "submitted"],
   "properties": {
     "schema_version": { "type": "string" },
     "event_type": { "type": "string" },
     "actor": { "type": "string" },
     "subject": { "type": "string" },
     "message": { "type": "string" },
-    "payload": { "type": "boolean" },
-    "recorded": { "type": "boolean" }
+    "has_payload": { "type": "boolean" },
+    "submitted": {
+      "type": "boolean",
+      "description": "True when the event was submitted to the configured provider; this is not a durable persistence acknowledgement."
+    }
   },
   "additionalProperties": true
 }

--- a/schemas/handoff/result.schema.json
+++ b/schemas/handoff/result.schema.json
@@ -1,13 +1,27 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": ["schema_version", "mode", "auto"],
+  "required": ["schema_version", "ok", "mode", "auto", "restart_requested"],
   "properties": {
     "schema_version": { "type": "string" },
-    "mode": { "type": "string" },
+    "ok": { "type": "boolean" },
+    "mode": { "type": "string", "enum": ["self", "auto", "remote"] },
     "target": { "type": "string" },
+    "recipient": { "type": "string" },
     "auto": { "type": "boolean" },
-    "subject": { "type": "string" }
+    "subject": { "type": "string" },
+    "mail_bead_id": { "type": "string" },
+    "restart_requested": { "type": "boolean" },
+    "action": {
+      "type": "string",
+      "enum": [
+        "restart_requested",
+        "restart_skipped",
+        "kill_skipped",
+        "delivery_pending",
+        "killed"
+      ]
+    }
   },
   "additionalProperties": true
 }

--- a/schemas/handoff/result.schema.json
+++ b/schemas/handoff/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "mode", "auto"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "mode": { "type": "string" },
+    "target": { "type": "string" },
+    "auto": { "type": "boolean" },
+    "subject": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/init/result.schema.json
+++ b/schemas/init/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "city_name", "mode"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "city_name": { "type": "string" },
+    "mode": { "type": "string" },
+    "provider": { "type": "string" },
+    "bootstrap_profile": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/prime/result.schema.json
+++ b/schemas/prime/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "hook", "content", "bytes"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "agent": { "type": "string" },
+    "hook": { "type": "boolean" },
+    "hook_format": { "type": "string" },
+    "content": { "type": "string" },
+    "bytes": { "type": "integer" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/session/logs/result.schema.json
+++ b/schemas/session/logs/result.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": true,
+  "type": "object",
+  "required": ["schema_version", "target", "transcript_path", "tail", "entry_count", "entries"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "target": { "type": "string" },
+    "provider": { "type": "string" },
+    "transcript_path": { "type": "string" },
+    "tail": { "type": "integer", "minimum": 0 },
+    "entry_count": { "type": "integer", "minimum": 0 },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "uuid": { "type": "string" },
+          "parent_uuid": { "type": "string" },
+          "type": { "type": "string" },
+          "subtype": { "type": "string" },
+          "role": { "type": "string" },
+          "timestamp": { "type": "string" },
+          "compact_boundary": { "type": "boolean" },
+          "text": { "type": "string" },
+          "blocks": { "type": "array" },
+          "message": true
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/session/peek/result.schema.json
+++ b/schemas/session/peek/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": true,
+  "type": "object",
+  "required": ["schema_version", "session_id", "target", "lines", "line_count", "output"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "session_id": { "type": "string" },
+    "target": { "type": "string" },
+    "lines": { "type": "integer" },
+    "line_count": { "type": "integer", "minimum": 0 },
+    "output": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/skill/list/result.schema.json
+++ b/schemas/skill/list/result.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "count", "entries"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "agent": { "type": "string" },
+    "session": { "type": "string" },
+    "count": { "type": "integer" },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "source", "path"],
+        "properties": {
+          "name": { "type": "string" },
+          "source": { "type": "string" },
+          "path": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/version/result.schema.json
+++ b/schemas/version/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "version", "commit", "date", "long"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "version": { "type": "string" },
+    "commit": { "type": "string" },
+    "date": { "type": "string" },
+    "long": { "type": "boolean" }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary

Adds the first platform layer for command-local JSON schema discovery and enforcement:

- adds `--json-schema[=result|failure]` as a persistent CLI flag
- emits a JSONL manifest for `gc <command> --json-schema`
- returns `json_supported:false` with an empty schema map for known commands without `result.schema.json`
- emits role-specific JSON Schema for `result` and `failure`
- provides a shared default failure schema with `additionalProperties:true`
- embeds checked-in built-in schemas from `schemas/`
- lets discovered pack commands expose adjacent `schemas/result.schema.json` and optional `schemas/failure.schema.json`
- declares schemas for native commands that already had `--json` support: `status`, `rig list`, `session list`, `events`, `trace show`, `analyze reliability`, `config explain --provider`, `converge status`, `converge list`, and `dolt-cleanup`
- enforces that native `--json` commands must have a declared result schema before execution
- buffers native `--json` stdout until success so failures emit one structured JSON failure record on stdout while preserving the command exit code and stderr diagnostics

This follows the design direction in #2139. `result.schema.json` is the opt-in for JSON support; command-specific `failure.schema.json` is optional because the shared default failure schema covers the common case.

## Compatibility Notes

This intentionally changes the behavior of native commands that receive `--json` without a declared result schema: they now fail before command execution with a structured JSON failure record on stdout. That is the guardrail that keeps newly-added or partially-converted native JSON output from becoming an undocumented machine contract.

For commands that already had `--json` support in this branch, this PR adds result schemas and preserves their current successful output shapes. Some existing result schemas are deliberately permissive in nested fields so the platform can land before later command-specific tightening.

Runtime failures for native `--json` commands now discard partial stdout and emit a shared structured failure envelope to stdout. Human diagnostics remain on stderr, and the process still exits with the same nonzero code.

`gc bd ... --json` is intentionally exempted because it is a passthrough into the bead CLI rather than a native `gc` JSON contract.

For discovered pack commands, this PR exposes schema discovery for adjacent schema files. Pack-command `--json` behavior remains command-owned; full pack command contract enforcement can follow once pack authors have the convention available.

## Verification

- `go test ./cmd/gc -run 'TestJSONSchema|TestJSONUnsupported|TestJSONContract|TestJSONExecution'`\n- schema manifest probe for: `status`, `rig list`, `session list`, `analyze reliability`, `config explain`, `converge status`, `converge list`, `dolt-cleanup`, `trace show`, `events`\n- `find schemas -type f -name '*.schema.json' -maxdepth 4 -print | sort | xargs -n1 jq -e .`\n- `git diff --check`\n\nI also ran full `go test ./cmd/gc`; it failed in unrelated existing long-running areas (`TestAutoSuspendChatSessions`, init/provider readiness, and order execution noise). The focused JSON/schema tests above passed after the enforcement changes.\n
