### PR TITLE
Back off cache reconcile errors and refresh stores on backend changes

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,26 +35,27 @@ import (
 // Protected by an RWMutex for hot-reload: readers take RLock,
 // the controller loop takes Lock when updating cfg/sp/stores.
 type controllerState struct {
-	mu            sync.RWMutex
-	cfg           *config.City
-	sp            runtime.Provider
-	cacheCtx      context.Context
-	beadStores    map[string]beads.Store
-	cityBeadStore beads.Store   // city-level store for session beads
-	cityMailProv  mail.Provider // city-level mail provider (all mail is city-scoped)
-	eventProv     events.Provider
-	editor        *configedit.Editor
-	cityName      string
-	cityPath      string
-	version       string
-	startedAt     time.Time
-	ct            crashTracker  // nil if crash tracking disabled
-	pokeCh        chan struct{} // nil when poke is not available; triggers immediate reconciler tick
-	configDirty   *atomic.Bool  // optional dirty flag shared with the reconciler reload path
-	services      workspacesvc.Registry
-	extmsgSvc     *extmsg.Services
-	adapterReg    *extmsg.AdapterRegistry
-	updateMu      sync.Mutex // serializes rebuild+swap so stale reloads cannot overtake newer mutations
+	mu                     sync.RWMutex
+	cfg                    *config.City
+	sp                     runtime.Provider
+	cacheCtx               context.Context
+	beadStores             map[string]beads.Store
+	cityBeadStore          beads.Store   // city-level store for session beads
+	cityMailProv           mail.Provider // city-level mail provider (all mail is city-scoped)
+	eventProv              events.Provider
+	editor                 *configedit.Editor
+	cityName               string
+	cityPath               string
+	version                string
+	startedAt              time.Time
+	storeMetadataSignature string
+	ct                     crashTracker  // nil if crash tracking disabled
+	pokeCh                 chan struct{} // nil when poke is not available; triggers immediate reconciler tick
+	configDirty            *atomic.Bool  // optional dirty flag shared with the reconciler reload path
+	services               workspacesvc.Registry
+	extmsgSvc              *extmsg.Services
+	adapterReg             *extmsg.AdapterRegistry
+	updateMu               sync.Mutex // serializes rebuild+swap so stale reloads cannot overtake newer mutations
 
 	// True after an API config mutation refreshes controller state ahead of the
 	// runtime reload loop. Runtime reloads from older revisions are ignored
@@ -106,6 +108,7 @@ func newControllerState(
 		svc := extmsg.NewServices(cs.cityBeadStore)
 		cs.extmsgSvc = &svc
 	}
+	cs.storeMetadataSignature = storeMetadataSignature(cityPath, cfg)
 	return cs
 }
 
@@ -342,6 +345,7 @@ func (cs *controllerState) update(cfg *config.City, sp runtime.Provider) {
 
 	// Build new stores outside the lock (may do file I/O / subprocess spawns).
 	stores := cs.buildStores(cfg)
+	storeSignature := storeMetadataSignature(cs.cityPath, cfg)
 	// Reopen city-level store for session beads and mail.
 	cityStore, err := openCityStoreAt(cs.cityPath)
 	if err != nil {
@@ -364,6 +368,7 @@ func (cs *controllerState) update(cfg *config.City, sp runtime.Provider) {
 	if cityStore != nil {
 		cs.cityBeadStore = cityStore
 		cs.cityMailProv = cityMailProv
+		cs.storeMetadataSignature = storeSignature
 	}
 	if extSvc != nil {
 		cs.extmsgSvc = extSvc
@@ -414,6 +419,7 @@ func (cs *controllerState) runtimeUpdateCanReuseCurrentStores(next *config.City)
 	cs.mu.RLock()
 	current := cs.cfg
 	cityStore := cs.cityBeadStore
+	storeSignature := cs.storeMetadataSignature
 	stores := make(map[string]beads.Store, len(cs.beadStores))
 	for name, store := range cs.beadStores {
 		stores[name] = store
@@ -421,6 +427,9 @@ func (cs *controllerState) runtimeUpdateCanReuseCurrentStores(next *config.City)
 	cs.mu.RUnlock()
 
 	if cityStore == nil || !sameStoreTopology(cs.cityPath, current, next) {
+		return false
+	}
+	if storeSignature != "" && storeSignature != storeMetadataSignature(cs.cityPath, next) {
 		return false
 	}
 	for _, rig := range next.Rigs {
@@ -432,6 +441,51 @@ func (cs *controllerState) runtimeUpdateCanReuseCurrentStores(next *config.City)
 		}
 	}
 	return true
+}
+
+func (cs *controllerState) storeMetadataChanged(next *config.City) bool {
+	cs.mu.RLock()
+	cityPath := cs.cityPath
+	storeSignature := cs.storeMetadataSignature
+	cs.mu.RUnlock()
+
+	return storeSignature != "" && storeSignature != storeMetadataSignature(cityPath, next)
+}
+
+func storeMetadataSignature(cityPath string, cfg *config.City) string {
+	if strings.TrimSpace(cityPath) == "" {
+		return ""
+	}
+	var b strings.Builder
+	appendScopeMetadataSignature := func(label, scopeRoot string) {
+		if strings.TrimSpace(scopeRoot) == "" {
+			scopeRoot = cityPath
+		}
+		scopeRoot = resolveStoreScopeRoot(cityPath, scopeRoot)
+		fmt.Fprintf(&b, "%s:%s:", label, filepath.Clean(scopeRoot))
+		data, err := os.ReadFile(scopeMetadataJSONPath(scopeRoot))
+		switch {
+		case err == nil:
+			sum := sha256.Sum256(data)
+			fmt.Fprintf(&b, "sha256=%x\n", sum)
+		case os.IsNotExist(err):
+			b.WriteString("missing\n")
+		default:
+			fmt.Fprintf(&b, "error=%T:%v\n", err, err)
+		}
+	}
+
+	appendScopeMetadataSignature("city", cityPath)
+	if cfg == nil {
+		return b.String()
+	}
+	for _, rig := range cfg.Rigs {
+		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		appendScopeMetadataSignature("rig:"+rig.Name, rig.Path)
+	}
+	return b.String()
 }
 
 func (cs *controllerState) runtimeUpdateDropsPendingRigs(next *config.City) bool {

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -523,6 +523,58 @@ func TestControllerStateRuntimeUpdatePreservesCurrentStoresWithoutPendingMutatio
 	}
 }
 
+func TestControllerStateRuntimeUpdateRebuildsStoresWhenBackendMetadataChanges(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	writeBackendMetadata(t, cityDir, `{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`)
+
+	current := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+	}
+	oldStore := beads.NewMemStore()
+	cs := &controllerState{
+		cfg:                    current,
+		sp:                     runtime.NewFake(),
+		beadStores:             map[string]beads.Store{},
+		cityBeadStore:          oldStore,
+		cityName:               "city1",
+		cityPath:               cityDir,
+		storeMetadataSignature: storeMetadataSignature(cityDir, current),
+	}
+	oldSignature := cs.storeMetadataSignature
+
+	if !cs.runtimeUpdateCanReuseCurrentStores(current) {
+		t.Fatal("precondition: matching metadata should allow store reuse")
+	}
+
+	writeBackendMetadata(t, cityDir, `{"database":"beads","backend":"postgres","postgres_host":"db.example.test","postgres_port":"5432","postgres_user":"bd","postgres_database":"beads_pg"}`)
+	nextProvider := runtime.NewFake()
+	cs.updateFromRuntime(current, nextProvider, "")
+
+	if got := cs.CityBeadStore(); got == oldStore {
+		t.Fatal("CityBeadStore() reused stale store after backend metadata changed")
+	}
+	if cs.SessionProvider() != nextProvider {
+		t.Fatal("SessionProvider() was not advanced after metadata-triggered update")
+	}
+	if cs.storeMetadataSignature == "" || cs.storeMetadataSignature == oldSignature {
+		t.Fatal("store metadata signature was not refreshed after backend metadata changed")
+	}
+}
+
+func writeBackendMetadata(t *testing.T, scopeRoot, data string) {
+	t.Helper()
+	dir := filepath.Join(scopeRoot, ".beads")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(data+"\n"), 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+}
+
 func TestControllerStateRuntimeUpdateIgnoresStaleRevisionWithoutPendingMutation(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1089,6 +1089,21 @@ func (cr *CityRuntime) reloadConfigTraced(
 		appendWarning(warning)
 	}
 	if cr.configRev != "" && result.Revision == cr.configRev {
+		if cr.cs != nil && cr.cs.storeMetadataChanged(result.Cfg) {
+			cr.cs.update(result.Cfg, cr.sp)
+			message := fmt.Sprintf("Config reloaded: bead store metadata changed (rev %s)", shortRev(result.Revision))
+			fmt.Fprintln(cr.stdout, message) //nolint:errcheck // best-effort stdout
+			if trace != nil {
+				trace.RecordConfigReload(cr.configRev, result.Revision, TraceOutcomeApplied, source, nil, nil, false, warnings, nil)
+			}
+			telemetry.RecordConfigReload(ctx, result.Revision, string(source), string(reloadOutcomeApplied), len(warnings), nil)
+			return reloadControlReply{
+				Outcome:  reloadOutcomeApplied,
+				Message:  message,
+				Revision: result.Revision,
+				Warnings: warnings,
+			}
+		}
 		if trace != nil {
 			trace.RecordConfigReload(cr.configRev, result.Revision, TraceOutcomeNoChange, source, nil, nil, false, warnings, nil)
 		}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -3468,6 +3468,56 @@ func TestCityRuntimeReloadSameRevisionIsNoOp(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeReloadSameRevisionRefreshesStoresWhenMetadataChanges(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+	writeBackendMetadata(t, cityPath, `{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`)
+
+	cfg, configRev := loadCityRuntimeControllerConfig(t, cityPath)
+	sp := runtime.NewFake()
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	oldStore := cs.CityBeadStore()
+	if oldStore == nil {
+		t.Fatal("precondition: controller state city store is nil")
+	}
+
+	var stdout bytes.Buffer
+	cr := newTestCityRuntime(t, CityRuntimeParams{
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		ConfigRev: configRev,
+		Cfg:       cfg,
+		SP:        sp,
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: &stdout,
+		Stderr: io.Discard,
+	})
+	cr.setControllerState(cs)
+
+	writeBackendMetadata(t, cityPath, `{"database":"beads","backend":"postgres","postgres_host":"db.example.test","postgres_port":"5432","postgres_user":"bd","postgres_database":"beads_pg"}`)
+	lastProviderName := "fake"
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, cityPath, nil, reloadSourceManual)
+
+	if reply.Outcome != reloadOutcomeApplied {
+		t.Fatalf("reply.Outcome = %q, want %q", reply.Outcome, reloadOutcomeApplied)
+	}
+	if got := cs.CityBeadStore(); got == oldStore {
+		t.Fatal("same-revision reload reused stale city store after metadata backend changed")
+	}
+	if cr.configRev != configRev {
+		t.Fatalf("configRev = %q, want same revision %q", cr.configRev, configRev)
+	}
+	if lastProviderName != "fake" {
+		t.Fatalf("lastProviderName = %q, want fake", lastProviderName)
+	}
+}
+
 func TestCityRuntimeReloadRetainsTimedOutDispatcherForShutdownDrain(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -47,6 +47,7 @@ type CachingStore struct {
 	onChange     func(eventType, beadID string, payload json.RawMessage)
 	cancelFn     context.CancelFunc
 	problemf     func(string)
+	problemLog   map[string]cacheProblemLogState
 
 	// latencyWindow holds the most recent reconciliation bd-list
 	// durations for adaptive cadence decisions. Bounded at
@@ -69,6 +70,11 @@ const (
 	cacheLive
 	cacheDegraded
 )
+
+type cacheProblemLogState struct {
+	lastAt     time.Time
+	suppressed int64
+}
 
 // CacheStats exposes cache freshness, reconciliation, and problem state.
 type CacheStats struct {
@@ -112,6 +118,8 @@ const (
 	cacheReconcileIntervalSmall  = 30 * time.Second
 	cacheReconcileIntervalMedium = 60 * time.Second
 	cacheReconcileIntervalLarge  = 120 * time.Second
+	cacheProblemLogWindow        = time.Minute
+	cacheReconcileFailureBackoff = time.Minute
 )
 
 // StaggerOption configures the deterministic startup stagger applied
@@ -218,6 +226,7 @@ func newCachingStore(backing Store, idPrefix string, onChange func(eventType, be
 		beadSeq:     make(map[string]uint64),
 		localBeadAt: make(map[string]time.Time),
 		deletedSeq:  make(map[string]uint64),
+		problemLog:  make(map[string]cacheProblemLogState),
 		onChange:    onChange,
 		problemf: func(msg string) {
 			log.Printf("beads cache: %s", msg)
@@ -523,12 +532,34 @@ func (c *CachingStore) recordProblemLocked(op string, err error) {
 		return
 	}
 	msg := fmt.Sprintf("%s: %v", op, err)
+	now := time.Now()
 	c.stats.ProblemCount++
-	c.stats.LastProblemAt = time.Now()
+	c.stats.LastProblemAt = now
 	c.stats.LastProblem = msg
 	if c.problemf != nil {
-		c.problemf(msg)
+		if logMsg, ok := c.problemLogMessageLocked(msg, now); ok {
+			c.problemf(logMsg)
+		}
 	}
+}
+
+func (c *CachingStore) problemLogMessageLocked(msg string, now time.Time) (string, bool) {
+	if c.problemLog == nil {
+		c.problemLog = make(map[string]cacheProblemLogState)
+	}
+	state := c.problemLog[msg]
+	if !state.lastAt.IsZero() && now.Sub(state.lastAt) < cacheProblemLogWindow {
+		state.suppressed++
+		c.problemLog[msg] = state
+		return "", false
+	}
+
+	logMsg := msg
+	if state.suppressed > 0 {
+		logMsg = fmt.Sprintf("%s (suppressed %d duplicate logs)", msg, state.suppressed)
+	}
+	c.problemLog[msg] = cacheProblemLogState{lastAt: now}
+	return logMsg, true
 }
 
 func (c *CachingStore) updateStatsLocked() {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -901,6 +901,55 @@ func TestCachingStoreRunReconciliationRecordsProblemAndDegrades(t *testing.T) {
 	}
 }
 
+func TestCachingStoreRunReconciliationSuppressesDuplicateProblemLogs(t *testing.T) {
+	t.Parallel()
+
+	backing := &listFailingStore{Store: NewMemStore()}
+	if _, err := backing.Create(Bead{Title: "Task"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	var logs []string
+	cache.problemf = func(msg string) {
+		logs = append(logs, msg)
+	}
+
+	backing.failList = true
+	for i := 0; i < maxCacheSyncFailures; i++ {
+		cache.runReconciliation()
+	}
+
+	stats := cache.Stats()
+	if stats.ProblemCount != int64(maxCacheSyncFailures) {
+		t.Fatalf("ProblemCount = %d, want %d", stats.ProblemCount, maxCacheSyncFailures)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("logged %d problem lines, want 1: %#v", len(logs), logs)
+	}
+	if delay := cache.nextReconcileDelay(time.Now()); delay <= cacheReconcilePollInterval {
+		t.Fatalf("nextReconcileDelay = %v, want sustained-failure backoff above poll interval", delay)
+	}
+
+	cache.mu.Lock()
+	state := cache.problemLog[stats.LastProblem]
+	state.lastAt = time.Now().Add(-cacheProblemLogWindow)
+	cache.problemLog[stats.LastProblem] = state
+	cache.mu.Unlock()
+
+	cache.runReconciliation()
+	if len(logs) != 2 {
+		t.Fatalf("logged %d problem lines after window expiry, want 2: %#v", len(logs), logs)
+	}
+	if !strings.Contains(logs[1], "suppressed 4 duplicate logs") {
+		t.Fatalf("second problem log = %q, want suppressed duplicate count", logs[1])
+	}
+}
+
 func TestCachingStorePrimeActiveUsesPartialResultRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -197,7 +197,19 @@ func (c *CachingStore) nextReconcileDelay(now time.Time) time.Duration {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	if c.state == cacheDegraded || c.lastFreshAt.IsZero() {
+	if c.syncFailures >= maxCacheSyncFailures && !c.stats.LastProblemAt.IsZero() {
+		dueAt := c.stats.LastProblemAt.Add(cacheReconcileFailureBackoff)
+		if !now.Before(dueAt) {
+			return 0
+		}
+		return dueAt.Sub(now)
+	}
+
+	if c.state == cacheDegraded {
+		return 0
+	}
+
+	if c.lastFreshAt.IsZero() {
 		return 0
 	}
 

--- a/release-gates/ga-ru5k3e-gate.md
+++ b/release-gates/ga-ru5k3e-gate.md
@@ -1,0 +1,32 @@
+# Release gate - cache reconcile error backoff (ga-smlafz / ga-ru5k3e)
+
+**Verdict:** FAIL
+
+- Deploy bead: `ga-smlafz`
+- Source bead: `ga-ru5k3e` (closed)
+- Branch: `quad341:builder/ga-ru5k3e-1`
+- HEAD: `893b9c2f7` (`fix(beads): back off repeated cache reconcile errors`)
+- Diff: 3 files, +95 / -3
+- Project manifest: `docs/PROJECT_MANIFEST.md` is not present in this checkout; gate uses the deployer prompt's release criteria.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` re-review verdict is PASS at `893b9c2f7`; previous rebase blocker is marked resolved. |
+| 2 | Acceptance criteria met | FAIL | The branch implements duplicate problem-log suppression and a one-minute sustained-failure backoff, but it does not implement or test the source bead's backend-flip criterion: after `metadata.json` changes from `backend=dolt` to `backend=postgres`, the running supervisor should stop trying to reach the irrelevant store within one reload cycle. No changed code reads backend metadata, reloads `BdStore`, or skips dolt-pinned subprocess args after a backend flip. |
+| 3 | Tests pass on final branch | PASS | Deployer re-ran focused cache tests, `go vet ./...`, and `make test-fast-parallel`; all passed. |
+| 4 | No high-severity review findings open | PASS | Re-review notes say "No New Findings"; no HIGH findings remain open. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before this gate file was added. |
+| 6 | Branch diverges cleanly from main | PASS | `origin/main` is an ancestor of `HEAD`; branch is 1 ahead / 0 behind. |
+
+## Validation
+
+- `go test ./internal/beads -run 'TestCachingStoreRunReconciliation(RecordsProblemAndDegrades|SuppressesDuplicateProblemLogs)|TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog' -count=1` - PASS
+- `go vet ./...` - PASS
+- `make test-fast-parallel` - PASS
+- `git config core.hooksPath` - `.githooks`
+
+## Handoff
+
+Route back to builder. Required fix: either implement the backend-flip behavior from `ga-ru5k3e` or update the source bead's acceptance criteria before re-review/re-deploy.

--- a/release-gates/ga-ru5k3e-gate.md
+++ b/release-gates/ga-ru5k3e-gate.md
@@ -1,32 +1,40 @@
-# Release gate - cache reconcile error backoff (ga-smlafz / ga-ru5k3e)
+# Release gate - supervisor cache reconcile backoff and metadata refresh (ga-b7u6z3 / ga-ru5k3e)
 
-**Verdict:** FAIL
+**Verdict:** PASS
 
-- Deploy bead: `ga-smlafz`
+- Deploy bead: `ga-b7u6z3`
 - Source bead: `ga-ru5k3e` (closed)
+- Prior review bead: `ga-smlafz`
 - Branch: `quad341:builder/ga-ru5k3e-1`
-- HEAD: `893b9c2f7` (`fix(beads): back off repeated cache reconcile errors`)
-- Diff: 3 files, +95 / -3
-- Project manifest: `docs/PROJECT_MANIFEST.md` is not present in this checkout; gate uses the deployer prompt's release criteria.
+- HEAD before gate commit: `d7010e1fb` (`fix(supervisor): refresh stores on backend metadata changes`)
+- Diff: 8 files, +318 / -23 before this PASS gate update
+- Project manifest: `docs/PROJECT_MANIFEST.md` is not present in this checkout; gate uses the deployer prompt's release criteria and the source bead done-when criteria.
 
 ## Criteria
 
 | # | Criterion | Verdict | Evidence |
 |---|-----------|---------|----------|
-| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` re-review verdict is PASS at `893b9c2f7`; previous rebase blocker is marked resolved. |
-| 2 | Acceptance criteria met | FAIL | The branch implements duplicate problem-log suppression and a one-minute sustained-failure backoff, but it does not implement or test the source bead's backend-flip criterion: after `metadata.json` changes from `backend=dolt` to `backend=postgres`, the running supervisor should stop trying to reach the irrelevant store within one reload cycle. No changed code reads backend metadata, reloads `BdStore`, or skips dolt-pinned subprocess args after a backend flip. |
-| 3 | Tests pass on final branch | PASS | Deployer re-ran focused cache tests, `go vet ./...`, and `make test-fast-parallel`; all passed. |
-| 4 | No high-severity review findings open | PASS | Re-review notes say "No New Findings"; no HIGH findings remain open. |
-| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before this gate file was added. |
-| 6 | Branch diverges cleanly from main | PASS | `origin/main` is an ancestor of `HEAD`; branch is 1 ahead / 0 behind. |
+| 1 | Reviewer PASS verdict in bead notes | PASS | `ga-b7u6z3` notes contain `Review Verdict: PASS` from `gascity/reviewer` for commit `d7010e1fb` on `fork/builder/ga-ru5k3e-1`. |
+| 2 | Acceptance criteria met | PASS | Log-volume ceiling is covered by `TestCachingStoreRunReconciliationSuppressesDuplicateProblemLogs`; sustained-failure backoff is covered by the same test and `TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog`; backend metadata flips now rebuild controller stores through `TestControllerStateRuntimeUpdateRebuildsStoresWhenBackendMetadataChanges` and `TestCityRuntimeReloadSameRevisionRefreshesStoresWhenMetadataChanges`; existing `internal/beads` tests pass. |
+| 3 | Tests pass on final branch | PASS | Focused acceptance tests, `go vet ./...`, `git diff --check origin/main...HEAD`, and `make test-fast-parallel` all passed on this branch. |
+| 4 | No high-severity review findings open | PASS | Review notes list only LOW findings and explicitly state no HIGH or MEDIUM findings. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` showed only `## deployer/ga-ru5k3e-gate...fork/builder/ga-ru5k3e-1` before this gate file update. A pre-existing empty root `.gitkeep` was preserved as a local ignored artifact and is not part of the release branch. |
+| 6 | Branch diverges cleanly from main | PASS | `git rev-list --left-right --count origin/main...HEAD` reported `7 3`; `git merge-tree --write-tree HEAD origin/main` completed successfully with tree `809e1edb993c3b9df87c765a019d0360f0614165`, indicating no merge conflicts with current `origin/main`. |
+
+## Acceptance Evidence
+
+| Source criterion | Verdict | Evidence |
+|---|---|---|
+| Supervisor log volume drops to at most once per minute under sustained reconciler errors. | PASS | `internal/beads.CachingStore` now suppresses duplicate exact problem logs for `cacheProblemLogWindow = time.Minute` while preserving problem stats; `TestCachingStoreRunReconciliationSuppressesDuplicateProblemLogs` passed. |
+| After metadata flips from `backend=dolt` to `backend=postgres`, the running supervisor stops using the stale store within at most one reload cycle. | PASS | `controllerState` tracks `.beads/metadata.json` signatures for city and rig stores, rejects store reuse when signatures change, and applies same-revision reloads when bead-store metadata changes; focused controller and runtime reload tests passed. |
+| Existing `internal/beads/caching_store_*_test.go` pass. | PASS | `go test ./internal/beads -run 'TestCachingStoreRunReconciliation(RecordsProblemAndDegrades|SuppressesDuplicateProblemLogs)|TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog' -count=1` passed; `make test-fast-parallel` passed. |
+| New regression test asserts log-volume ceiling under sustained errors. | PASS | `TestCachingStoreRunReconciliationSuppressesDuplicateProblemLogs` asserts one emitted line during repeated failures and a suppressed duplicate count after the window expires. |
 
 ## Validation
 
-- `go test ./internal/beads -run 'TestCachingStoreRunReconciliation(RecordsProblemAndDegrades|SuppressesDuplicateProblemLogs)|TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog' -count=1` - PASS
+- `go test ./cmd/gc -run 'TestControllerStateRuntimeUpdateRebuildsStoresWhenBackendMetadataChanges|TestCityRuntimeReloadSameRevisionRefreshesStoresWhenMetadataChanges|TestControllerStateRuntimeUpdatePreservesCurrentStoresWithoutPendingMutation|TestControllerStateRuntimeUpdateAfterMutationPreservesCurrentStores|TestCityRuntimeReloadSameRevisionIsNoOp' -count=1` - PASS (`ok github.com/gastownhall/gascity/cmd/gc 4.356s`)
+- `go test ./internal/beads -run 'TestCachingStoreRunReconciliation(RecordsProblemAndDegrades|SuppressesDuplicateProblemLogs)|TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog' -count=1` - PASS (`ok github.com/gastownhall/gascity/internal/beads 0.013s`)
 - `go vet ./...` - PASS
-- `make test-fast-parallel` - PASS
+- `git diff --check origin/main...HEAD` - PASS
+- `make test-fast-parallel` - PASS (`All fast jobs passed`)
 - `git config core.hooksPath` - `.githooks`
-
-## Handoff
-
-Route back to builder. Required fix: either implement the backend-flip behavior from `ga-ru5k3e` or update the source bead's acceptance criteria before re-review/re-deploy.


### PR DESCRIPTION
## What this changes

The supervisor's bead cache reconciler now suppresses repeated identical problem logs for one minute while still updating problem counters and timestamps for every failure. Once repeated reconciliation failures reach the sustained-failure threshold, the cache waits one minute before retrying instead of retrying on every poll tick.

The controller also tracks `.beads/metadata.json` for the city store and configured rig stores. If backend metadata changes, such as a Dolt-to-Postgres flip, the running supervisor rebuilds its bead stores even when `city.toml` itself has not changed, so it stops reusing stale store configuration on the next reload path.

## Review notes

- New store metadata signature logic lives in `cmd/gc/api_state.go` and participates in controller store reuse decisions.
- Same-revision config reloads remain no-ops unless bead-store metadata changed.
- Cache log suppression is log-only; `ProblemCount`, `LastProblemAt`, and `LastProblem` still update on every failure.
- No API schema, config shape, or dashboard changes are intended.

## Test plan

- [x] `go test ./cmd/gc -run 'TestControllerStateRuntimeUpdateRebuildsStoresWhenBackendMetadataChanges|TestCityRuntimeReloadSameRevisionRefreshesStoresWhenMetadataChanges|TestControllerStateRuntimeUpdatePreservesCurrentStoresWithoutPendingMutation|TestControllerStateRuntimeUpdateAfterMutationPreservesCurrentStores|TestCityRuntimeReloadSameRevisionIsNoOp' -count=1`
- [x] `go test ./internal/beads -run 'TestCachingStoreRunReconciliation(RecordsProblemAndDegrades|SuppressesDuplicateProblemLogs)|TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog' -count=1`
- [x] `go vet ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-ru5k3e-gate.md`](release-gates/ga-ru5k3e-gate.md)