### PR TITLE
fix(dolt): harden compact remote repair

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -17,12 +17,15 @@
 #   1. Pre-flight: record row counts for all user tables.
 #   2. Soft-reset to the root commit; all data stays staged.
 #   3. Commit everything as a single "compaction: flatten history" commit.
-#   4. Re-check post-flatten row counts. Any mismatch fails the run before
-#      full GC unless the script can prove external-writer provenance.
+#   4. Re-check post-flatten row counts and database value hash. Row-count
+#      decreases fail before full GC. Row-count increases are held pending
+#      value-hash verification. Any value-hash drift is quarantined before
+#      full GC until preservation is proven.
 #   5. Run CALL DOLT_GC('--full') to reclaim chunks orphaned by the flatten.
 #
-# Concurrent writes are not accepted as an explanation for row-count drift
-# or value-hash drift unless the script can prove that provenance.
+# Remote push failures are recorded in compact-pending-push markers and do not
+# fail local compaction. Later runs retry those markers before threshold skips,
+# and unverified remote heads must become ancestry-verifiable before push.
 # Surgical mode (preserve recent N commits via interactive rebase) is
 # intentionally not implemented; flatten is sufficient for bloat recovery
 # and avoids the rebase-vs-concurrent-write hazards.
@@ -43,6 +46,9 @@
 #     (default: 120) — wall-clock bound for remote compare-and-push
 #                     after local compaction. Push failures are recorded for
 #                     repair but do not fail local compaction.
+#   GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS
+#     (default: 172800) — maximum age for automatic pending remote-push retry.
+#                       Older markers require manual review before push.
 #   GC_DOLT_COMPACT_REMOTE               (optional) — remote to fetch/push.
 #                                         Defaults to origin when present;
 #                                         ambiguous multi-remote stores fail.
@@ -120,6 +126,7 @@ host="${GC_DOLT_HOST:-127.0.0.1}"
 threshold_commits="${GC_DOLT_COMPACT_THRESHOLD_COMMITS:-2000}"
 call_timeout="${GC_DOLT_COMPACT_CALL_TIMEOUT_SECS:-1800}"
 push_timeout="${GC_DOLT_COMPACT_PUSH_TIMEOUT_SECS:-120}"
+pending_push_max_age_secs="${GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS:-172800}"
 compact_remote="${GC_DOLT_COMPACT_REMOTE:-}"
 dry_run="${GC_DOLT_COMPACT_DRY_RUN:-}"
 only_dbs="${GC_DOLT_COMPACT_ONLY_DBS:-}"
@@ -144,6 +151,14 @@ case "$push_timeout" in
   ''|*[!0-9]*|0)
     printf 'compact: invalid GC_DOLT_COMPACT_PUSH_TIMEOUT_SECS=%s (must be a positive integer)\n' \
       "$push_timeout" >&2
+    exit 2
+    ;;
+esac
+
+case "$pending_push_max_age_secs" in
+  ''|*[!0-9]*)
+    printf 'compact: invalid GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS=%s (must be a non-negative integer)\n' \
+      "$pending_push_max_age_secs" >&2
     exit 2
     ;;
 esac
@@ -534,24 +549,26 @@ preflight_counts() {
 }
 
 # verify_counts — re-count and compare against the pre-flight file.
-# Count divergence fails unless the script can prove an external writer caused it.
+# Row-count decreases fail. Row-count increases are recorded as concurrent
+# writer evidence and allowed after the value-hash gate passes.
 verify_counts() {
   db="$1"
   preflight="$2"
   fail=0
+  verify_counts_saw_gain=0
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     t=${line%% *}
     expected=${line##* }
     if ! actual=$(row_count "$db" "$t"); then
       printf 'compact: db=%s post-flatten row count failed for table=%s\n' "$db" "$t" >&2
-      fail=1
+      fail=2
       continue
     fi
     case "$actual" in
       ''|*[!0-9]*)
         printf 'compact: db=%s post-flatten row count failed for table=%s\n' "$db" "$t" >&2
-        fail=1
+        fail=2
         continue
         ;;
     esac
@@ -559,10 +576,13 @@ verify_counts() {
       if [ "$actual" -lt "$expected" ]; then
         printf 'compact: db=%s row count decreased after flatten table=%s before=%s after=%s\n' \
           "$db" "$t" "$expected" "$actual" >&2
-        fail=1
+        if [ "$fail" -eq 0 ]; then
+          fail=1
+        fi
       else
-        printf 'compact: db=%s table=%s gained rows during flatten before=%s after=%s — concurrent write preserved\n' \
+        printf 'compact: db=%s table=%s gained rows during flatten before=%s after=%s — pending value-hash verification\n' \
           "$db" "$t" "$expected" "$actual"
+        verify_counts_saw_gain=1
       fi
     fi
   done < "$preflight"
@@ -594,6 +614,20 @@ write_compact_marker() {
   reason="$3"
   shift 3
 
+  marker_path=$(compact_marker_path "$dir" "$db")
+  created_at=""
+  if [ -f "$marker_path" ]; then
+    created_at=$(awk 'index($0, "created_at=") == 1 { print substr($0, 12); exit }' "$marker_path" || true)
+    case "$created_at" in
+      ''|*[!0-9TZ:.-]*)
+        created_at=""
+        ;;
+    esac
+  fi
+  if [ -z "$created_at" ]; then
+    created_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  fi
+
   old_umask=$(umask)
   umask 077
   if ! mkdir -p "$dir"; then
@@ -611,7 +645,7 @@ write_compact_marker() {
   {
     printf 'db=%s\n' "$db"
     printf 'reason=%s\n' "$reason"
-    printf 'created_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'created_at=%s\n' "$created_at"
     while [ "$#" -gt 0 ]; do
       printf '%s\n' "$1"
       shift
@@ -622,12 +656,69 @@ write_compact_marker() {
     return 1
   }
 
-  if ! mv -f "$tmp" "$(compact_marker_path "$dir" "$db")"; then
+  if ! mv -f "$tmp" "$marker_path"; then
     rm -f "$tmp"
     printf 'compact: db=%s unable to install marker in %s\n' "$db" "$dir" >&2
     return 1
   fi
   return 0
+}
+
+ensure_compact_marker_writable() {
+  dir="$1"
+  db="$2"
+
+  old_umask=$(umask)
+  umask 077
+  if ! mkdir -p "$dir"; then
+    umask "$old_umask"
+    printf 'compact: db=%s unable to create marker directory %s\n' "$db" "$dir" >&2
+    return 1
+  fi
+  probe=$(mktemp "$dir/$db.probe.XXXXXX") || {
+    umask "$old_umask"
+    printf 'compact: db=%s unable to create marker in %s\n' "$db" "$dir" >&2
+    return 1
+  }
+  umask "$old_umask"
+
+  if ! printf 'probe\n' > "$probe"; then
+    rm -f "$probe"
+    printf 'compact: db=%s unable to write marker probe %s\n' "$db" "$probe" >&2
+    return 1
+  fi
+  if ! rm -f "$probe"; then
+    printf 'compact: db=%s unable to remove marker probe %s\n' "$db" "$probe" >&2
+    return 1
+  fi
+  return 0
+}
+
+ensure_repair_marker_paths_writable() {
+  db="$1"
+  remote="$2"
+
+  ensure_compact_marker_writable "$quarantine_dir" "$db" || return 1
+  ensure_compact_marker_writable "$pending_gc_dir" "$db" || return 1
+  if [ -n "$remote" ]; then
+    ensure_compact_marker_writable "$pending_push_dir" "$db" || return 1
+  fi
+  return 0
+}
+
+write_pending_push_marker() {
+  db="$1"
+  remote="$2"
+  expected_remote_head="${3:-}"
+  expected_remote_head_verified="${4:-0}"
+  compacted_from_head="${5:-}"
+  reason="$6"
+
+  write_compact_marker "$pending_push_dir" "$db" "$reason" \
+    "remote=$remote" \
+    "expected_remote_head=$expected_remote_head" \
+    "expected_remote_head_verified=$expected_remote_head_verified" \
+    "compacted_from_head=$compacted_from_head"
 }
 
 compact_marker_value() {
@@ -637,6 +728,44 @@ compact_marker_value() {
   marker=$(compact_marker_path "$dir" "$db")
   [ -f "$marker" ] || return 1
   awk -v prefix="$key=" 'index($0, prefix) == 1 { print substr($0, length(prefix) + 1); exit }' "$marker"
+}
+
+compact_marker_created_at_epoch() {
+  dir="$1"
+  db="$2"
+  created_at=$(compact_marker_value "$dir" "$db" created_at || true)
+  [ -n "$created_at" ] || return 1
+  case "$created_at" in
+    *[!0-9TZ:.-]*)
+      return 1
+      ;;
+  esac
+  date -u -d "$created_at" +%s 2>/dev/null ||
+    date -ju -f "%Y-%m-%dT%H:%M:%SZ" "$created_at" +%s 2>/dev/null
+}
+
+ensure_remote_push_retry_fresh() {
+  dir="$1"
+  db="$2"
+  marker_label="$3"
+
+  created_epoch=$(compact_marker_created_at_epoch "$dir" "$db" || true)
+  if [ -z "$created_epoch" ]; then
+    printf 'compact: db=%s %s marker has missing or invalid created_at — manual review required before remote push retry\n' \
+      "$db" "$marker_label" >&2
+    return 1
+  fi
+  now_epoch=$(date -u +%s)
+  age_secs=$(( now_epoch - created_epoch ))
+  if [ "$age_secs" -lt 0 ]; then
+    age_secs=0
+  fi
+  if [ "$age_secs" -gt "$pending_push_max_age_secs" ]; then
+    printf 'compact: db=%s %s marker is stale age=%ss max_age=%ss — manual review required before remote push retry\n' \
+      "$db" "$marker_label" "$age_secs" "$pending_push_max_age_secs" >&2
+    return 1
+  fi
+  return 0
 }
 
 clear_compact_marker() {
@@ -674,7 +803,10 @@ run_full_gc() {
 push_remote_after_compaction() {
   db="$1"
   remote="$2"
-  expected_remote_head="$3"
+  expected_remote_head="${3:-}"
+  expected_remote_head_verified="${4:-0}"
+  push_context="${5:-initial}"
+  compacted_from_head="${6:-}"
   [ -n "$remote" ] || return 0
 
   fetch_rc=0
@@ -685,7 +817,8 @@ push_remote_after_compaction() {
       "$db" "$remote" "$fetch_rc" >&2
     emit_error_file "$db" "$fetch_err_tmp"
     rm -f "$fetch_err_tmp"
-    write_compact_marker "$pending_push_dir" "$db" "flatten and full GC succeeded but remote fetch before push failed" || true
+    write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+      "flatten and full GC succeeded but remote fetch before push failed" || return 1
     return 0
   fi
   rm -f "$fetch_err_tmp"
@@ -693,7 +826,8 @@ push_remote_after_compaction() {
   if ! latest_remote_head=$(remote_main_head "$db" "$remote"); then
     printf 'compact: db=%s remote=%s HEAD probe failed before push after local compaction\n' \
       "$db" "$remote" >&2
-    write_compact_marker "$pending_push_dir" "$db" "flatten and full GC succeeded but remote HEAD probe before push failed" || true
+    write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+      "flatten and full GC succeeded but remote HEAD probe before push failed" || return 1
     return 0
   fi
   if [ -n "$latest_remote_head" ]; then
@@ -701,16 +835,80 @@ push_remote_after_compaction() {
       *[!A-Za-z0-9]*)
         printf 'compact: db=%s remote=%s returned invalid HEAD=%s before push — fail\n' \
           "$db" "$remote" "$latest_remote_head" >&2
-        write_compact_marker "$pending_push_dir" "$db" "flatten and full GC succeeded but remote HEAD before push was invalid" || true
+        write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+          "flatten and full GC succeeded but remote HEAD before push was invalid" || return 1
         return 0
         ;;
     esac
   fi
   if [ "$latest_remote_head" != "$expected_remote_head" ]; then
-    printf 'compact: db=%s remote=%s HEAD changed before push expected_HEAD=%s got_HEAD=%s — leaving local compaction pending remote repair\n' \
-      "$db" "$remote" "${expected_remote_head:-<empty>}" "${latest_remote_head:-<empty>}" >&2
-    write_compact_marker "$pending_push_dir" "$db" "flatten and full GC succeeded but remote HEAD changed before push" || true
-    return 0
+    if [ -z "$expected_remote_head" ] && [ -n "$latest_remote_head" ]; then
+      printf 'compact: db=%s remote=%s recovered HEAD=%s after unknown preflight HEAD — verifying before push\n' \
+        "$db" "$remote" "$latest_remote_head"
+      expected_remote_head="$latest_remote_head"
+      expected_remote_head_verified=0
+    elif [ "$push_context" = "retry" ]; then
+      if [ -z "$latest_remote_head" ]; then
+        printf 'compact: db=%s remote=%s HEAD changed during pending push retry expected_HEAD=%s got_HEAD=<empty> — deferred for next run; manual reconciliation required if this persists\n' \
+          "$db" "$remote" "${expected_remote_head:-<empty>}" >&2
+        write_pending_push_marker "$db" "$remote" "" 0 "$compacted_from_head" \
+          "remote push retry deferred: remote HEAD changed during pending push retry" || return 1
+        return 1
+      fi
+      printf 'compact: db=%s remote=%s HEAD changed during pending push retry expected_HEAD=%s got_HEAD=%s — verifying latest remote HEAD\n' \
+        "$db" "$remote" "${expected_remote_head:-<empty>}" "$latest_remote_head" >&2
+      expected_remote_head="$latest_remote_head"
+      expected_remote_head_verified=0
+    else
+      printf 'compact: db=%s remote=%s HEAD changed before push expected_HEAD=%s got_HEAD=%s — leaving local compaction pending remote repair\n' \
+        "$db" "$remote" "${expected_remote_head:-<empty>}" "${latest_remote_head:-<empty>}" >&2
+      write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+        "flatten and full GC succeeded but remote HEAD changed before push" || return 1
+      return 0
+    fi
+  fi
+  if [ -n "$latest_remote_head" ] && [ "$expected_remote_head_verified" != "1" ]; then
+    if [ -n "$compacted_from_head" ] && [ "$latest_remote_head" = "$compacted_from_head" ]; then
+      expected_remote_head_verified=1
+      printf 'compact: db=%s remote=%s HEAD=%s matches compacted source head — retrying push\n' \
+        "$db" "$remote" "$latest_remote_head"
+    else
+      if ! in_local=$(commit_exists_in_local_log "$db" "$latest_remote_head"); then
+        printf 'compact: db=%s remote=%s HEAD=%s ancestry probe failed before push after local compaction\n' \
+          "$db" "$remote" "$latest_remote_head" >&2
+        write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+          "flatten and full GC succeeded but remote ancestry probe before push failed" || return 1
+        return 0
+      fi
+      case "$in_local" in
+        1)
+          expected_remote_head_verified=1
+          printf 'compact: db=%s remote=%s HEAD=%s is now verified in local history — retrying push\n' \
+            "$db" "$remote" "$latest_remote_head"
+          ;;
+        0)
+          if [ "$push_context" = "retry" ]; then
+            printf 'compact: db=%s remote=%s HEAD=%s remains absent from local history — deferred for next run; manual reconciliation required if this persists\n' \
+              "$db" "$remote" "$latest_remote_head" >&2
+            write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+              "remote push retry deferred: remote has unique commits not in local history" || return 1
+            return 1
+          fi
+          printf 'compact: db=%s remote=%s HEAD=%s was not verified in local history before flatten — leaving local compaction pending remote repair\n' \
+            "$db" "$remote" "$latest_remote_head" >&2
+          write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+            "flatten and full GC succeeded but remote has unique commits not in local history" || return 1
+          return 0
+          ;;
+        *)
+          printf 'compact: db=%s remote=%s ancestry probe returned invalid value=%s before push after local compaction\n' \
+            "$db" "$remote" "$in_local" >&2
+          write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+            "flatten and full GC succeeded but remote ancestry probe returned invalid result" || return 1
+          return 0
+          ;;
+      esac
+    fi
   fi
 
   push_rc=0
@@ -721,7 +919,8 @@ push_remote_after_compaction() {
       "$db" "$remote" "$push_rc" >&2
     emit_error_file "$db" "$push_err_tmp"
     rm -f "$push_err_tmp"
-    write_compact_marker "$pending_push_dir" "$db" "flatten and full GC succeeded but remote push failed" || true
+    write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
+      "flatten and full GC succeeded but remote push failed" || return 1
     return 0
   fi
   rm -f "$push_err_tmp"
@@ -780,7 +979,7 @@ restore_head_after_flatten_failure() {
 
 preserve_head_after_integrity_failure() {
   db="$1"
-  flatten_head="$3"
+  flatten_head="$2"
   current_head=$(head_commit "$db" || true)
   if [ -z "$current_head" ]; then
     current_head="$flatten_head"
@@ -792,6 +991,7 @@ preserve_head_after_integrity_failure() {
 
 flatten_database() {
   db="$1"
+  verify_counts_saw_gain=0
 
   if [ -n "$only_dbs" ]; then
     case ",$only_dbs," in
@@ -809,11 +1009,6 @@ flatten_database() {
     return 1
   fi
 
-  if has_compact_marker "$pending_push_dir" "$db"; then
-    printf 'compact: db=%s pending remote push marker exists — continuing local compaction; successful push will clear it\n' \
-      "$db"
-  fi
-
   if has_compact_marker "$pending_gc_dir" "$db"; then
     if [ -n "$dry_run" ]; then
       printf 'compact: db=%s pending_gc=present — dry-run (would retry DOLT_GC --full)\n' "$db"
@@ -821,6 +1016,8 @@ flatten_database() {
     fi
     pending_remote=$(compact_marker_value "$pending_gc_dir" "$db" remote || true)
     pending_expected_remote_head=$(compact_marker_value "$pending_gc_dir" "$db" expected_remote_head || true)
+    pending_expected_remote_head_verified=$(compact_marker_value "$pending_gc_dir" "$db" expected_remote_head_verified || true)
+    pending_compacted_from_head=$(compact_marker_value "$pending_gc_dir" "$db" compacted_from_head || true)
     if [ -n "$pending_remote" ] && ! valid_remote_name "$pending_remote"; then
       printf 'compact: db=%s pending_gc marker has invalid remote=%s — manual intervention required\n' \
         "$db" "$pending_remote" >&2
@@ -835,14 +1032,90 @@ flatten_database() {
           ;;
       esac
     fi
+    case "$pending_expected_remote_head_verified" in
+      ''|0|1)
+        ;;
+      *)
+        printf 'compact: db=%s pending_gc marker has invalid expected_remote_head_verified=%s — manual intervention required\n' \
+          "$db" "$pending_expected_remote_head_verified" >&2
+        return 1
+        ;;
+    esac
+    if [ -n "$pending_compacted_from_head" ]; then
+      case "$pending_compacted_from_head" in
+        *[!A-Za-z0-9]*)
+          printf 'compact: db=%s pending_gc marker has invalid compacted_from_head=%s — manual intervention required\n' \
+            "$db" "$pending_compacted_from_head" >&2
+          return 1
+          ;;
+      esac
+    fi
+    if [ -n "$pending_remote" ]; then
+      ensure_remote_push_retry_fresh "$pending_gc_dir" "$db" "pending_gc" || return 1
+    fi
     printf 'compact: db=%s pending_gc=present — retrying DOLT_GC --full\n' "$db"
     start=$(date +%s)
     if run_full_gc "$db" "pending-GC retry" "pending-GC retry" "$start"; then
-      clear_compact_marker "$pending_gc_dir" "$db"
-      push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head"
-      return $?
+      push_rc=0
+      push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head" || push_rc=$?
+      if [ "$push_rc" -eq 0 ] || { [ -n "$pending_remote" ] && has_compact_marker "$pending_push_dir" "$db"; }; then
+        clear_compact_marker "$pending_gc_dir" "$db"
+      fi
+      return "$push_rc"
     fi
     return 1
+  fi
+
+  if has_compact_marker "$pending_push_dir" "$db"; then
+    if [ -n "$dry_run" ]; then
+      printf 'compact: db=%s pending_push=present — dry-run (would retry remote push)\n' "$db"
+      return 0
+    fi
+    pending_remote=$(compact_marker_value "$pending_push_dir" "$db" remote || true)
+    pending_expected_remote_head=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head || true)
+    pending_expected_remote_head_verified=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head_verified || true)
+    pending_compacted_from_head=$(compact_marker_value "$pending_push_dir" "$db" compacted_from_head || true)
+    if [ -z "$pending_remote" ]; then
+      printf 'compact: db=%s pending_push marker is missing remote — manual intervention required\n' \
+        "$db" >&2
+      return 1
+    fi
+    if ! valid_remote_name "$pending_remote"; then
+      printf 'compact: db=%s pending_push marker has invalid remote=%s — manual intervention required\n' \
+        "$db" "$pending_remote" >&2
+      return 1
+    fi
+    if [ -n "$pending_expected_remote_head" ]; then
+      case "$pending_expected_remote_head" in
+        *[!A-Za-z0-9]*)
+          printf 'compact: db=%s pending_push marker has invalid expected_remote_head=%s — manual intervention required\n' \
+            "$db" "$pending_expected_remote_head" >&2
+          return 1
+          ;;
+      esac
+    fi
+    case "$pending_expected_remote_head_verified" in
+      ''|0|1)
+        ;;
+      *)
+        printf 'compact: db=%s pending_push marker has invalid expected_remote_head_verified=%s — manual intervention required\n' \
+          "$db" "$pending_expected_remote_head_verified" >&2
+        return 1
+        ;;
+    esac
+    if [ -n "$pending_compacted_from_head" ]; then
+      case "$pending_compacted_from_head" in
+        *[!A-Za-z0-9]*)
+          printf 'compact: db=%s pending_push marker has invalid compacted_from_head=%s — manual intervention required\n' \
+            "$db" "$pending_compacted_from_head" >&2
+          return 1
+          ;;
+      esac
+    fi
+    ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
+    printf 'compact: db=%s pending_push=present — retrying remote push before threshold check\n' "$db"
+    push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head"
+    return $?
   fi
 
   if ! count=$(commit_count "$db"); then
@@ -881,6 +1154,7 @@ flatten_database() {
     printf 'compact: db=%s HEAD commit probe returned empty value — fail\n' "$db" >&2
     return 1
   fi
+  compacted_from_head="$head"
 
   if [ -n "$dry_run" ]; then
     printf 'compact: db=%s commits=%s root=%s — dry-run (would flatten)\n' \
@@ -890,6 +1164,7 @@ flatten_database() {
 
   remote=""
   expected_remote_head=""
+  expected_remote_head_verified=0
   if probed_remote=$(select_remote "$db"); then
     remote="$probed_remote"
   else
@@ -930,20 +1205,36 @@ flatten_database() {
           return 1
         fi
         if [ "$in_local" != "1" ]; then
-          printf 'compact: db=%s remote=%s remote HEAD=%s is not in local history — proceeding from local source of truth\n' \
+          printf 'compact: db=%s remote=%s remote HEAD=%s is not in local history — proceeding from local source of truth; remote push will remain pending\n' \
             "$db" "$remote" "$remote_head" >&2
         else
+          expected_remote_head_verified=1
           printf 'compact: db=%s remote=%s fetch ok\n' "$db" "$remote"
         fi
-      else
+      elif [ "$remote_head" = "$head" ]; then
+        expected_remote_head_verified=1
         printf 'compact: db=%s remote=%s fetch ok\n' "$db" "$remote"
+      else
+        expected_remote_head_verified=0
+        printf 'compact: db=%s remote=%s fetch ok; remote HEAD empty — push will verify after local compaction\n' "$db" "$remote"
       fi
     fi
     rm -f "$fetch_err_tmp"
   fi
 
+  ensure_repair_marker_paths_writable "$db" "$remote" || return 1
+
   preflight_tmp=$(mktemp)
   if ! preflight_counts "$db" "$preflight_tmp"; then
+    rm -f "$preflight_tmp"
+    return 1
+  fi
+  if ! preflight_hash=$(db_value_hash "$db"); then
+    rm -f "$preflight_tmp"
+    return 1
+  fi
+  if [ -z "$preflight_hash" ]; then
+    printf 'compact: db=%s pre-flatten value hash probe returned empty value — fail\n' "$db" >&2
     rm -f "$preflight_tmp"
     return 1
   fi
@@ -978,18 +1269,87 @@ flatten_database() {
   if [ -z "$flatten_head" ]; then
     printf 'compact: db=%s post-flatten HEAD probe failed — quarantine and investigate before GC\n' \
       "$db" >&2
-    write_compact_marker "$quarantine_dir" "$db" "post-flatten HEAD probe failed" || true
+    write_compact_marker "$quarantine_dir" "$db" "post-flatten HEAD probe failed" || {
+      rm -f "$preflight_tmp"
+      return 1
+    }
     rm -f "$preflight_tmp"
     return 1
   fi
 
-  if ! verify_counts "$db" "$preflight_tmp"; then
-    printf 'compact: db=%s post-flatten INTEGRITY check failed — escalate (row counts decreased; investigate before re-running)\n' \
-      "$db" >&2
-    write_compact_marker "$quarantine_dir" "$db" "post-flatten row count decreased" || true
-    preserve_head_after_integrity_failure "$db" "$head" "$flatten_head" || true
+  verify_counts_rc=0
+  verify_counts "$db" "$preflight_tmp" || verify_counts_rc=$?
+  if [ "$verify_counts_rc" -ne 0 ]; then
+    if [ "$verify_counts_rc" -eq 2 ]; then
+      integrity_reason="post-flatten row count probe failed"
+      integrity_guidance="post-flatten row count probe failed; investigate before re-running"
+    else
+      integrity_reason="post-flatten row count decreased"
+      integrity_guidance="row counts decreased; investigate before re-running"
+    fi
+    printf 'compact: db=%s post-flatten INTEGRITY check failed — escalate (%s)\n' \
+      "$db" "$integrity_guidance" >&2
+    write_compact_marker "$quarantine_dir" "$db" "$integrity_reason" || {
+      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      rm -f "$preflight_tmp"
+      return 1
+    }
+    preserve_head_after_integrity_failure "$db" "$flatten_head" || true
     rm -f "$preflight_tmp"
     return 1
+  fi
+  if ! postflight_hash=$(db_value_hash "$db"); then
+    printf 'compact: db=%s post-flatten value hash probe failed — quarantine and investigate before GC\n' \
+      "$db" >&2
+    write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash probe failed" || {
+      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      rm -f "$preflight_tmp"
+      return 1
+    }
+    preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+    rm -f "$preflight_tmp"
+    return 1
+  fi
+  if [ -z "$postflight_hash" ]; then
+    printf 'compact: db=%s post-flatten value hash probe returned empty value — quarantine and investigate before GC\n' \
+      "$db" >&2
+    write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash probe returned empty value" || {
+      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      rm -f "$preflight_tmp"
+      return 1
+    }
+    preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+    rm -f "$preflight_tmp"
+    return 1
+  fi
+  if [ "$postflight_hash" != "$preflight_hash" ]; then
+    if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
+      printf 'compact: db=%s value hash changed with row-count increase before=%s after=%s — quarantine and defer full GC until preservation is proven\n' \
+        "$db" "$preflight_hash" "$postflight_hash" >&2
+      write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed with row-count increase" || {
+        preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+        rm -f "$preflight_tmp"
+        return 1
+      }
+      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      rm -f "$preflight_tmp"
+      return 1
+    else
+      printf 'compact: db=%s value hash changed after flatten before=%s after=%s — quarantine and investigate before GC\n' \
+        "$db" "$preflight_hash" "$postflight_hash" >&2
+      write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed without row-count increase" || {
+        preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+        rm -f "$preflight_tmp"
+        return 1
+      }
+      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      rm -f "$preflight_tmp"
+      return 1
+    fi
+  fi
+  if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
+    printf 'compact: db=%s row-count increase passed value-hash verification — concurrent write preserved\n' \
+      "$db"
   fi
   rm -f "$preflight_tmp"
 
@@ -1002,11 +1362,13 @@ flatten_database() {
   if run_full_gc "$db" "flatten ok commits=$count->${after_count:-?} but" \
     "commits=$count->${after_count:-?}" "$start"; then
     clear_compact_marker "$pending_gc_dir" "$db"
-    push_remote_after_compaction "$db" "$remote" "$expected_remote_head"
+    push_remote_after_compaction "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "initial" "$compacted_from_head"
     return $?
   fi
   write_compact_marker "$pending_gc_dir" "$db" "flatten succeeded but full GC failed" \
-    "remote=$remote" "expected_remote_head=$expected_remote_head" || true
+    "remote=$remote" "expected_remote_head=$expected_remote_head" \
+    "expected_remote_head_verified=$expected_remote_head_verified" \
+    "compacted_from_head=$compacted_from_head" || return 1
   return 1
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -190,6 +190,69 @@ func (f compactScriptFixture) run(t *testing.T, mode string, extraEnv ...string)
 	return string(out), err
 }
 
+func replaceCompactMarkerCreatedAt(t *testing.T, markerPath, createdAt string) {
+	t.Helper()
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("read compact marker: %v", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	replaced := false
+	for i, line := range lines {
+		if strings.HasPrefix(line, "created_at=") {
+			lines[i] = "created_at=" + createdAt
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		t.Fatalf("compact marker missing created_at:\n%s", data)
+	}
+	if err := os.WriteFile(markerPath, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+		t.Fatalf("rewrite compact marker: %v", err)
+	}
+}
+
+func compactMarkerValue(t *testing.T, markerPath, key string) string {
+	t.Helper()
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("read compact marker: %v", err)
+	}
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	t.Fatalf("compact marker missing %s:\n%s", key, data)
+	return ""
+}
+
+func writeBSDOnlyDate(t *testing.T, binDir string) {
+	t.Helper()
+	writeExecutable(t, filepath.Join(binDir, "date"), `#!/bin/sh
+case "$*" in
+  "-u +%Y-%m-%dT%H:%M:%SZ")
+    printf '2026-05-15T00:00:00Z\n'
+    ;;
+  "+%s"|"-u +%s")
+    printf '1778803200\n'
+    ;;
+  "-ju -f %Y-%m-%dT%H:%M:%SZ 2026-05-15T00:00:00Z +%s")
+    printf '1778803200\n'
+    ;;
+  "-u -d "*)
+    exit 1
+    ;;
+  *)
+    printf 'unexpected fake date args: %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+`)
+}
+
 func runCompactScriptCommand(t *testing.T, mode string) (string, string, error) {
 	t.Helper()
 	fixture := newCompactScriptFixture(t)
@@ -281,7 +344,7 @@ set_hash() {
 case "$query" in
   *"SELECT COUNT(*) FROM dolt_remotes WHERE name = 'origin'"*)
     case "$mode" in
-      remote_success|remote_ahead|remote_fetch_failure|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|multiple_remotes_with_origin)
+      remote_success|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|multiple_remotes_with_origin)
         print_cell 1
         ;;
       *)
@@ -303,7 +366,7 @@ case "$query" in
     ;;
   *"SELECT COUNT(*) FROM dolt_remotes"*)
     case "$mode" in
-      remote_success|remote_ahead|remote_fetch_failure|remote_push_failure|remote_advances_before_push|remote_gc_failure_once)
+      remote_success|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure)
         print_cell 1
         ;;
       multiple_remotes_with_origin|multiple_remotes_no_origin)
@@ -320,7 +383,7 @@ case "$query" in
     ;;
   *"SELECT name FROM dolt_remotes ORDER BY name LIMIT 1"*)
     case "$mode" in
-      remote_success|remote_ahead|remote_fetch_failure|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|multiple_remotes_with_origin)
+      remote_success|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|multiple_remotes_with_origin)
         print_cell origin
         ;;
       explicit_backup_remote)
@@ -336,6 +399,19 @@ case "$query" in
     if [ "$mode" = "remote_fetch_failure" ]; then
       printf 'fetch unavailable\n' >&2
       exit 52
+    fi
+    if [ "$mode" = "remote_fetch_failure_once" ]; then
+      calls_file="$state_file.fetch-calls"
+      calls=0
+      if [ -f "$calls_file" ]; then
+        calls="$(cat "$calls_file")"
+      fi
+      calls=$((calls + 1))
+      printf '%%s\n' "$calls" > "$calls_file"
+      if [ "$calls" -eq 1 ]; then
+        printf 'fetch unavailable once\n' >&2
+        exit 52
+      fi
     fi
     exit 0
     ;;
@@ -356,7 +432,9 @@ case "$query" in
       else
         print_cell headcommit
       fi
-    elif [ "$mode" = "remote_ahead" ]; then
+    elif [ "$mode" = "remote_empty_head_push_failure" ]; then
+      print_cell ""
+    elif [ "$mode" = "remote_ahead" ] || [ "$mode" = "remote_ahead_reconciled" ] || [ "$mode" = "remote_ancestry_probe_failure" ]; then
       print_cell remotecommit
     else
       print_cell headcommit
@@ -368,11 +446,23 @@ case "$query" in
     exit 0
     ;;
   *"SELECT COUNT(*) FROM dolt_log WHERE commit_hash = 'remotecommit'"*)
-    print_cell 0
+    if [ "$mode" = "remote_ancestry_probe_failure" ]; then
+      printf 'ancestry probe unavailable\n' >&2
+      exit 54
+    fi
+    if [ "$mode" = "remote_ahead_reconciled" ]; then
+      print_cell 1
+    else
+      print_cell 0
+    fi
     exit 0
     ;;
   *"SELECT COUNT(*) FROM dolt_log WHERE commit_hash = 'headcommit'"*)
-    print_cell 1
+    if [ "$(current_head)" = "headcommit" ]; then
+      print_cell 1
+    else
+      print_cell 0
+    fi
     exit 0
     ;;
   *"SELECT COUNT(*) FROM (SELECT 1 FROM dolt_log"*)
@@ -403,6 +493,14 @@ case "$query" in
     if [ "$mode" = "db_hash_failure" ]; then
       printf 'db hash exploded\n' >&2
       exit 48
+    fi
+    if [ "$mode" = "db_hash_empty" ]; then
+      print_cell ""
+      exit 0
+    fi
+    if [ "$mode" = "db_hash_empty_after_flatten" ] && [ "$(current_head)" = "compactcommit" ]; then
+      print_cell ""
+      exit 0
     fi
     print_cell "$(current_hash)"
     exit 0
@@ -444,7 +542,11 @@ case "$query" in
     if [ -n "$count_file" ]; then
       printf '%%s\n' "$calls" > "$count_file"
     fi
-    if [ "$mode" = "row_count_diverges" ] && [ "$calls" -gt 1 ]; then
+    if [ "$mode" = "row_count_failure_after_flatten" ] && [ "$calls" -gt 1 ]; then
+      printf 'row count exploded after flatten\n' >&2
+      exit 47
+    fi
+    if { [ "$mode" = "row_count_diverges" ] || [ "$mode" = "row_count_and_hash_diverges" ]; } && [ "$calls" -gt 1 ]; then
       print_cell 11
     elif [ "$mode" = "row_count_decreases" ] && [ "$calls" -gt 1 ]; then
       print_cell 9
@@ -476,6 +578,9 @@ case "$query" in
     if [ "$mode" = "same_row_count_writer" ]; then
       set_hash hash-after-writer
     fi
+    if [ "$mode" = "row_count_and_hash_diverges" ]; then
+      set_hash hash-after-writer
+    fi
     exit 0
     ;;
   *"DOLT_GC"*)
@@ -499,7 +604,7 @@ case "$query" in
     exit 0
     ;;
   *"DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')"*)
-    if [ "$mode" = "remote_push_failure" ]; then
+    if [ "$mode" = "remote_push_failure" ] || [ "$mode" = "remote_empty_head_push_failure" ]; then
       printf 'push unavailable\n' >&2
       exit 53
     fi
@@ -688,8 +793,42 @@ func TestCompactScriptRecordsPendingPushWhenRemoteHeadChangesAfterCompaction(t *
 		t.Fatalf("remote HEAD drift must block push:\n%s", log)
 	}
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
-	if _, err := os.Stat(marker); err != nil {
+	markerData, err := os.ReadFile(marker)
+	if err != nil {
 		t.Fatalf("remote drift after compaction should write pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(markerData), "remote=origin") ||
+		!strings.Contains(string(markerData), "expected_remote_head=headcommit") ||
+		!strings.Contains(string(markerData), "expected_remote_head_verified=1") ||
+		!strings.Contains(string(markerData), "compacted_from_head=headcommit") {
+		t.Fatalf("pending-push marker should preserve pre-drift remote contract:\n%s", markerData)
+	}
+}
+
+func TestCompactScriptPushesWhenPreflightFetchFailsOnceThenRemoteHeadIsLocal(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_fetch_failure_once", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact should self-heal when post-compaction fetch recovers to a local remote HEAD: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote=origin fetch failed") ||
+		!strings.Contains(out, "pushed compacted main") {
+		t.Fatalf("output should show fetch recovery and push:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	if strings.Count(log, "CALL DOLT_FETCH('origin')") < 2 {
+		t.Fatalf("compact should retry fetch before push:\n%s", log)
+	}
+	if !strings.Contains(log, "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") {
+		t.Fatalf("recovered fetch should allow remote push:\n%s", log)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("successful recovered fetch should not leave pending-push marker, stat err=%v", err)
 	}
 }
 
@@ -707,10 +846,107 @@ func TestCompactScriptCompactsFromLocalSourceOfTruthWhenRemoteAheadIsUnknown(t *
 		t.Fatalf("read dolt log: %v", err)
 	}
 	log := string(data)
-	for _, want := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_GC", "DOLT_PUSH"} {
+	for _, want := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_GC"} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("remote divergence should not block local compaction; missing %s:\n%s", want, log)
 		}
+	}
+	if strings.Contains(log, "DOLT_PUSH") {
+		t.Fatalf("remote-only commits must block force push:\n%s", log)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	markerData, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("remote divergence should write pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(markerData), "expected_remote_head=remotecommit") ||
+		!strings.Contains(string(markerData), "expected_remote_head_verified=0") ||
+		!strings.Contains(string(markerData), "compacted_from_head=headcommit") {
+		t.Fatalf("pending-push marker should preserve unsafe remote contract:\n%s", markerData)
+	}
+}
+
+func TestCompactScriptFailsRetryWhenPendingPushRemoteHeadRemainsUnverified(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should leave unverified remote push pending: %v\n%s", err, firstOut)
+	}
+
+	secondOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("pending-push retry succeeded despite still-unverified remote HEAD:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push=present") ||
+		!strings.Contains(secondOut, "manual reconciliation required") {
+		t.Fatalf("retry should surface a terminal manual-reconciliation state:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Count(log, "DOLT_RESET") != 1 {
+		t.Fatalf("pending-push retry must not flatten again:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_PUSH") {
+		t.Fatalf("unverified remote retry must not force-push:\n%s", log)
+	}
+}
+
+func TestCompactScriptKeepsRetryDeferredWhenPendingPushAncestryProbeFails(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should leave unverified remote push pending: %v\n%s", err, firstOut)
+	}
+
+	secondOut, err := fixture.run(t, "remote_ancestry_probe_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("pending-push retry should remain deferred when ancestry probe fails: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push=present") ||
+		!strings.Contains(secondOut, "ancestry probe failed") {
+		t.Fatalf("retry missing deferred ancestry-probe explanation:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Count(log, "DOLT_RESET") != 1 {
+		t.Fatalf("pending-push retry must not flatten again:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_PUSH") {
+		t.Fatalf("failed ancestry probe must not force-push:\n%s", log)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(pendingPush); err != nil {
+		t.Fatalf("deferred ancestry-probe retry should keep pending-push marker: %v", err)
+	}
+}
+
+func TestCompactScriptRetriesPendingPushWhenRemoteHeadBecomesLocalLogAncestor(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should leave unverified remote push pending: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(pendingPush); err != nil {
+		t.Fatalf("initial compact should write pending-push marker: %v", err)
+	}
+
+	secondOut, err := fixture.run(t, "remote_ahead_reconciled", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("pending-push retry should self-heal once remote HEAD is in local history: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "is now verified in local history") ||
+		!strings.Contains(secondOut, "pushed compacted main") {
+		t.Fatalf("retry missing self-heal push explanation:\n%s", secondOut)
+	}
+	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
+		t.Fatalf("successful self-healed retry should clear marker, stat err=%v", err)
 	}
 }
 
@@ -755,8 +991,122 @@ func TestCompactScriptCompactsFromLocalSourceOfTruthWhenRemoteFetchFails(t *test
 		}
 	}
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
-	if _, err := os.Stat(marker); err != nil {
+	markerData, err := os.ReadFile(marker)
+	if err != nil {
 		t.Fatalf("fetch failure before post-compaction push should write pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(markerData), "remote=origin") ||
+		!strings.Contains(string(markerData), "expected_remote_head=\n") ||
+		!strings.Contains(string(markerData), "expected_remote_head_verified=0") ||
+		!strings.Contains(string(markerData), "compacted_from_head=headcommit") {
+		t.Fatalf("pending-push marker should preserve unknown remote contract:\n%s", markerData)
+	}
+}
+
+func TestCompactScriptRetriesPendingPushWhenRemoteHeadEqualsCompactedSource(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should leave fetch-failure push pending: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	firstMarker, err := os.ReadFile(pendingPush)
+	if err != nil {
+		t.Fatalf("initial fetch failure should write pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(firstMarker), "expected_remote_head=\n") {
+		t.Fatalf("initial marker should record unknown expected remote head:\n%s", firstMarker)
+	}
+	if !strings.Contains(string(firstMarker), "compacted_from_head=headcommit") {
+		t.Fatalf("initial marker should record compacted source head:\n%s", firstMarker)
+	}
+
+	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("pending-push retry should self-heal when remote fetch recovers: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push=present") ||
+		!strings.Contains(secondOut, "matches compacted source head") ||
+		!strings.Contains(secondOut, "pushed compacted main") {
+		t.Fatalf("retry missing recovered-fetch self-heal explanation:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "SELECT COUNT(*) FROM dolt_log WHERE commit_hash = 'headcommit'") {
+		t.Fatalf("compacted-source-head retry should not depend on post-flatten local log ancestry:\n%s", logData)
+	}
+	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
+		t.Fatalf("successful recovered retry should clear marker, stat err=%v", err)
+	}
+}
+
+func TestCompactScriptPreservesPendingPushCreatedAtAcrossUnresolvedRetries(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should leave unverified remote push pending: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	createdAt := compactMarkerValue(t, pendingPush, "created_at")
+
+	time.Sleep(1100 * time.Millisecond)
+	secondOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("second retry should remain manually deferred while remote HEAD is unverified:\n%s", secondOut)
+	}
+	if got := compactMarkerValue(t, pendingPush, "created_at"); got != createdAt {
+		t.Fatalf("unresolved retry refreshed pending-push marker age: before=%s after=%s\n%s", createdAt, got, secondOut)
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+	thirdOut, err := fixture.run(t, "remote_ancestry_probe_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("ancestry-probe failure should keep retry deferred with marker intact: %v\n%s", err, thirdOut)
+	}
+	if got := compactMarkerValue(t, pendingPush, "created_at"); got != createdAt {
+		t.Fatalf("deferred ancestry-probe retry refreshed pending-push marker age: before=%s after=%s\n%s", createdAt, got, thirdOut)
+	}
+}
+
+func TestCompactScriptParsesPendingPushCreatedAtWithBSDDateFallback(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	writeBSDOnlyDate(t, fixture.binDir)
+	firstOut, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should leave fetch-failure push pending: %v\n%s", err, firstOut)
+	}
+
+	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("pending-push retry should parse marker age with BSD date fallback: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "matches compacted source head") ||
+		!strings.Contains(secondOut, "pushed compacted main") {
+		t.Fatalf("retry missing compacted-source self-heal explanation:\n%s", secondOut)
+	}
+}
+
+func TestCompactScriptRecordsUnverifiedPendingPushWhenRemoteHeadIsEmpty(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_empty_head_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact should keep local compaction successful despite remote push failure: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote=origin push failed") {
+		t.Fatalf("output missing push failure:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	markerData, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("empty remote-head push failure should write pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(markerData), "remote=origin") ||
+		!strings.Contains(string(markerData), "expected_remote_head=\n") ||
+		!strings.Contains(string(markerData), "expected_remote_head_verified=0") ||
+		!strings.Contains(string(markerData), "compacted_from_head=headcommit") {
+		t.Fatalf("pending-push marker should preserve unverified empty remote contract:\n%s", markerData)
 	}
 }
 
@@ -780,8 +1130,213 @@ func TestCompactScriptRecordsPendingPushWhenRemotePushFails(t *testing.T) {
 		}
 	}
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
-	if _, err := os.Stat(marker); err != nil {
+	markerData, err := os.ReadFile(marker)
+	if err != nil {
 		t.Fatalf("push failure should write pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(markerData), "remote=origin") ||
+		!strings.Contains(string(markerData), "expected_remote_head=headcommit") ||
+		!strings.Contains(string(markerData), "expected_remote_head_verified=1") ||
+		!strings.Contains(string(markerData), "compacted_from_head=headcommit") {
+		t.Fatalf("pending-push marker should preserve remote push contract:\n%s", markerData)
+	}
+}
+
+func TestCompactScriptBlocksStalePendingPushRetryBeforeForcePush(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("first compact should succeed locally despite remote push failure: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	replaceCompactMarkerCreatedAt(t, pendingPush, "1970-01-01T00:00:00Z")
+
+	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stale pending-push retry succeeded without manual review:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push marker is stale") ||
+		!strings.Contains(secondOut, "manual review required") {
+		t.Fatalf("retry missing stale-marker manual-review explanation:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Count(string(logData), "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") != 1 {
+		t.Fatalf("stale pending-push retry must not attempt another force push:\n%s", logData)
+	}
+	if _, err := os.Stat(pendingPush); err != nil {
+		t.Fatalf("stale retry should keep pending-push marker: %v", err)
+	}
+}
+
+func TestCompactScriptFailsRetryWhenPendingPushRemoteHeadChangesAgain(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_advances_before_push", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("initial compact should leave changed remote push pending: %v\n%s", err, firstOut)
+	}
+
+	secondOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("pending-push retry succeeded despite still-unverified changed remote HEAD:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push=present") ||
+		!strings.Contains(secondOut, "manual reconciliation required") {
+		t.Fatalf("retry should surface manual reconciliation for changed remote HEAD:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Count(log, "DOLT_RESET") != 1 {
+		t.Fatalf("pending-push retry must not flatten again:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_PUSH") {
+		t.Fatalf("unverified changed remote retry must not force-push:\n%s", log)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	markerData, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("failed retry should keep pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(markerData), "expected_remote_head=remotecommit") ||
+		!strings.Contains(string(markerData), "expected_remote_head_verified=0") ||
+		!strings.Contains(string(markerData), "compacted_from_head=headcommit") {
+		t.Fatalf("failed retry should update marker to latest known remote head:\n%s", markerData)
+	}
+}
+
+func TestCompactScriptRetriesPendingPushBeforeBelowThresholdSkip(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("first compact should succeed locally despite remote push failure: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	marker, err := os.ReadFile(pendingPush)
+	if err != nil {
+		t.Fatalf("push failure should write pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(marker), "remote=origin") ||
+		!strings.Contains(string(marker), "expected_remote_head=headcommit") ||
+		!strings.Contains(string(marker), "expected_remote_head_verified=1") ||
+		!strings.Contains(string(marker), "compacted_from_head=headcommit") {
+		t.Fatalf("pending-push marker should preserve remote push contract:\n%s", marker)
+	}
+
+	secondOut, err := fixture.run(t, "below_threshold")
+	if err != nil {
+		t.Fatalf("below-threshold compact should retry pending remote push: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push=present") ||
+		!strings.Contains(secondOut, "pushed compacted main") {
+		t.Fatalf("second compact missing pending-push retry explanation:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Count(log, "DOLT_RESET") != 1 {
+		t.Fatalf("below-threshold pending-push retry must not flatten again:\n%s", log)
+	}
+	if strings.Count(log, "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") < 2 {
+		t.Fatalf("pending-push retry should attempt the deferred remote push:\n%s", log)
+	}
+	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
+		t.Fatalf("successful pending-push retry should clear marker, stat err=%v", err)
+	}
+}
+
+func TestCompactScriptFailsBeforeFlattenWhenPendingPushMarkerCannotBeWritten(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	pendingPushDir := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push")
+	if err := os.MkdirAll(filepath.Dir(pendingPushDir), 0o755); err != nil {
+		t.Fatalf("mkdir compact state dir: %v", err)
+	}
+	if err := os.WriteFile(pendingPushDir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write marker-dir blocker: %v", err)
+	}
+
+	out, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite required pending-push marker write failure:\n%s", out)
+	}
+	if !strings.Contains(out, "unable to create marker directory") {
+		t.Fatalf("output missing marker write failure:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	for _, forbidden := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_GC", "DOLT_PUSH"} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("marker write failure must fail before local mutation; saw %s:\n%s", forbidden, log)
+		}
+	}
+	secondOut, secondErr := fixture.run(t, "below_threshold")
+	if secondErr != nil {
+		t.Fatalf("below-threshold follow-up should not need hidden remote repair after preflight failure: %v\n%s", secondErr, secondOut)
+	}
+	if !strings.Contains(secondOut, "below_threshold") {
+		t.Fatalf("follow-up run should make an explicit threshold decision:\n%s", secondOut)
+	}
+}
+
+func TestCompactScriptFailsBeforeFlattenWhenPendingGCMarkerCannotBeWritten(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	pendingGCDir := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc")
+	if err := os.MkdirAll(filepath.Dir(pendingGCDir), 0o755); err != nil {
+		t.Fatalf("mkdir compact state dir: %v", err)
+	}
+	if err := os.WriteFile(pendingGCDir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write marker-dir blocker: %v", err)
+	}
+
+	out, err := fixture.run(t, "gc_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite required pending-GC marker write failure:\n%s", out)
+	}
+	if !strings.Contains(out, "unable to create marker directory") {
+		t.Fatalf("output missing marker write failure:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_RESET") {
+		t.Fatalf("pending-GC marker path failure must fail before flatten:\n%s", logData)
+	}
+}
+
+func TestCompactScriptFailsBeforeFlattenWhenQuarantineMarkerCannotBeWritten(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	quarantineDir := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine")
+	if err := os.MkdirAll(filepath.Dir(quarantineDir), 0o755); err != nil {
+		t.Fatalf("mkdir compact state dir: %v", err)
+	}
+	if err := os.WriteFile(quarantineDir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write marker-dir blocker: %v", err)
+	}
+
+	out, err := fixture.run(t, "row_count_decreases", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite required quarantine marker write failure:\n%s", out)
+	}
+	if !strings.Contains(out, "unable to create marker directory") {
+		t.Fatalf("output missing marker write failure:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_RESET") {
+		t.Fatalf("quarantine marker path failure must fail before flatten:\n%s", logData)
 	}
 }
 
@@ -831,8 +1386,10 @@ func TestCompactScriptAllowsRowCountIncreaseDuringFlatten(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compact should allow concurrent row-count increase: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "gained rows during flatten") {
-		t.Fatalf("output missing concurrent-write preservation notice:\n%s", out)
+	if !strings.Contains(out, "gained rows during flatten") ||
+		!strings.Contains(out, "pending value-hash verification") ||
+		!strings.Contains(out, "row-count increase passed value-hash verification") {
+		t.Fatalf("output missing row-count gain verification notices:\n%s", out)
 	}
 	data, err := os.ReadFile(fixture.doltLog)
 	if err != nil {
@@ -840,6 +1397,35 @@ func TestCompactScriptAllowsRowCountIncreaseDuringFlatten(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "DOLT_GC") {
 		t.Fatalf("row-count increase should still run full GC:\n%s", data)
+	}
+}
+
+func TestCompactScriptQuarantinesRowCountGainWithValueHashDriftBeforeFullGC(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "row_count_and_hash_diverges", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite row-count gain with value-hash drift:\n%s", out)
+	}
+	if !strings.Contains(out, "value hash changed with row-count increase") {
+		t.Fatalf("output missing row-count-gain hash drift warning:\n%s", out)
+	}
+	if strings.Contains(out, "concurrent write preserved") {
+		t.Fatalf("hash-drifted row-count gain must not claim preservation before quarantine:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "DOLT_HASHOF_DB") {
+		t.Fatalf("row-count-gain hash drift test should probe database value hash:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_GC") {
+		t.Fatalf("row-count-gain value-hash drift must defer full GC:\n%s", log)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("row-count-gain value-hash drift should write quarantine marker: %v", err)
 	}
 }
 
@@ -868,18 +1454,91 @@ func TestCompactScriptFailsOnRowCountDecreaseBeforeGC(t *testing.T) {
 	}
 }
 
-func TestCompactScriptAllowsSameRowCountWriter(t *testing.T) {
+func TestCompactScriptReportsPostFlattenRowCountProbeFailureSeparately(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "row_count_failure_after_flatten", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite post-flatten row count probe failure:\n%s", out)
+	}
+	if !strings.Contains(out, "post-flatten row count probe failed") {
+		t.Fatalf("output missing post-flatten row-count probe failure:\n%s", out)
+	}
+	if strings.Contains(out, "row counts decreased; investigate before re-running") {
+		t.Fatalf("probe failure must not be reported as a row-count decrease:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten row count probe failed" {
+		t.Fatalf("quarantine reason should identify probe failure, got %q", reason)
+	}
+}
+
+func TestCompactScriptQuarantinesSameRowCountWriterBeforeFullGC(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	out, err := fixture.run(t, "same_row_count_writer", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
-	if err != nil {
-		t.Fatalf("compact should tolerate same-row-count live writer: %v\n%s", err, out)
+	if err == nil {
+		t.Fatalf("compact succeeded despite same-row-count value-hash drift:\n%s", out)
+	}
+	if !strings.Contains(out, "value hash changed after flatten") {
+		t.Fatalf("output missing value-hash drift warning:\n%s", out)
 	}
 	logData, err := os.ReadFile(fixture.doltLog)
 	if err != nil {
 		t.Fatalf("read dolt log: %v", err)
 	}
-	if !strings.Contains(string(logData), "DOLT_GC") {
-		t.Fatalf("same-row-count writer should still run full GC:\n%s", logData)
+	log := string(logData)
+	if !strings.Contains(log, "DOLT_HASHOF_DB") {
+		t.Fatalf("same-row-count writer test should probe database value hash:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_GC") {
+		t.Fatalf("same-row-count value-hash drift must block full GC:\n%s", log)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("same-row-count value-hash drift should write quarantine marker: %v", err)
+	}
+}
+
+func TestCompactScriptFailsOnEmptyPreflightValueHash(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "db_hash_empty", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite empty preflight value hash:\n%s", out)
+	}
+	if !strings.Contains(out, "pre-flatten value hash probe returned empty value") {
+		t.Fatalf("output missing empty preflight hash failure:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_RESET") {
+		t.Fatalf("empty preflight hash must fail before flatten:\n%s", logData)
+	}
+}
+
+func TestCompactScriptQuarantinesEmptyPostflightValueHashBeforeFullGC(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "db_hash_empty_after_flatten", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite empty postflight value hash:\n%s", out)
+	}
+	if !strings.Contains(out, "post-flatten value hash probe returned empty value") {
+		t.Fatalf("output missing empty postflight hash failure:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "DOLT_RESET") {
+		t.Fatalf("postflight hash test should flatten before detecting empty hash:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_GC") {
+		t.Fatalf("empty postflight hash must block full GC:\n%s", log)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("empty postflight hash should write quarantine marker: %v", err)
 	}
 }
 
@@ -1036,6 +1695,16 @@ func TestCompactScriptRetriesFullGCForBelowThresholdPendingMarker(t *testing.T) 
 	if err == nil {
 		t.Fatalf("first compact succeeded despite DOLT_GC failure:\n%s", firstOut)
 	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	marker, err := os.ReadFile(pendingGC)
+	if err != nil {
+		t.Fatalf("GC failure should write pending-GC marker: %v", err)
+	}
+	if !strings.Contains(string(marker), "expected_remote_head_verified=0") ||
+		!strings.Contains(string(marker), "compacted_from_head=headcommit") {
+		t.Fatalf("pending-GC marker should preserve unverified empty remote contract:\n%s", marker)
+	}
+
 	secondOut, err := fixture.run(t, "below_threshold")
 	if err != nil {
 		t.Fatalf("second compact should retry pending-GC path:\n%s", secondOut)
@@ -1054,8 +1723,7 @@ func TestCompactScriptRetriesFullGCForBelowThresholdPendingMarker(t *testing.T) 
 	if strings.Count(log, "DOLT_RESET") != 1 {
 		t.Fatalf("below-threshold retry must not flatten again:\n%s", log)
 	}
-	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
-	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+	if _, err := os.Stat(pendingGC); !os.IsNotExist(err) {
 		t.Fatalf("successful pending-GC retry should clear marker, stat err=%v", err)
 	}
 }
@@ -1073,7 +1741,9 @@ func TestCompactScriptRetriesPendingGCThenPushesRemote(t *testing.T) {
 		t.Fatalf("GC failure should write pending-GC marker: %v", err)
 	}
 	if !strings.Contains(string(marker), "remote=origin") ||
-		!strings.Contains(string(marker), "expected_remote_head=headcommit") {
+		!strings.Contains(string(marker), "expected_remote_head=headcommit") ||
+		!strings.Contains(string(marker), "expected_remote_head_verified=1") ||
+		!strings.Contains(string(marker), "compacted_from_head=headcommit") {
 		t.Fatalf("pending-GC marker should preserve remote push contract:\n%s", marker)
 	}
 
@@ -1105,6 +1775,37 @@ func TestCompactScriptRetriesPendingGCThenPushesRemote(t *testing.T) {
 	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
 	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
 		t.Fatalf("successful pending-GC retry should not leave pending-push marker, stat err=%v", err)
+	}
+}
+
+func TestCompactScriptKeepsPendingGCWhenPendingPushHandoffCannotBeWritten(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+
+	firstOut, err := fixture.run(t, "remote_gc_failure_once", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("first compact should fail after writing pending-GC marker:\n%s", firstOut)
+	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if _, err := os.Stat(pendingGC); err != nil {
+		t.Fatalf("GC failure should write pending-GC marker: %v", err)
+	}
+	pendingPushDir := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push")
+	if err := os.RemoveAll(pendingPushDir); err != nil {
+		t.Fatalf("remove pending-push dir before blocker install: %v", err)
+	}
+	if err := os.WriteFile(pendingPushDir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write pending-push dir blocker: %v", err)
+	}
+
+	secondOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("pending-GC retry should fail when replacement pending-push marker cannot be written:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "unable to create marker directory") {
+		t.Fatalf("retry missing pending-push marker write failure:\n%s", secondOut)
+	}
+	if _, err := os.Stat(pendingGC); err != nil {
+		t.Fatalf("failed pending-push handoff should keep pending-GC marker: %v\n%s", err, secondOut)
 	}
 }
 


### PR DESCRIPTION
Maintainer follow-up for #1957.

Original PR: https://github.com/gastownhall/gascity/pull/1957
Original title: fix(dolt): let 24h compact finish despite remote drift
Original state: merged
Configured base: main
Original GitHub base: main
Base mismatch: none

This follow-up carries the maintainer-side hardening from the adoption review after the original PR was already merged. It preserves the original contribution and adds the review fixes needed for remote drift handling, pending repair markers, freshness checks, and Dolt compaction safety.

Changes in this follow-up:

- Harden remote repair so force pushes are contained by verified source heads, ancestry checks, or explicit manual review.
- Preserve pending marker age across unresolved retries and make stale repair markers require review instead of silently authorizing automatic pushes.
- Make pending-GC to pending-push handoff durable before clearing the old recovery state.
- Add regression coverage for BSD/GNU timestamp parsing, compacted source-head recovery, marker content, probe failures, and remote drift cases.

Validation and review:

- Adoption review reached approval on attempt 7 with no required changes remaining.
- Local review artifacts validated the Dolt compaction repair paths and focused `examples/dolt` coverage.
- Final diff over current `main`: 2 files changed, 1122 insertions, 59 deletions.

Adopted via `/adopt-pr` workflow. Original contributor work from #1957 was already merged; this PR contains the maintainer hardening follow-up only.
