### PR TITLE
Version session fingerprints and document upgrade contract

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1198,7 +1198,27 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					agentCfg := sessionCoreConfigForHash(tp, *session)
 					currentHash := runtime.CoreFingerprint(agentCfg)
 					if storedHash != currentHash {
-						fmt.Fprintf(stderr, "config-drift %s: stored=%s current=%s cmd=%q\n", name, storedHash[:12], currentHash[:12], agentCfg.Command) //nolint:errcheck
+						// Stored hash has no version prefix or carries a
+						// different version than the current binary — silently
+						// rebaseline all four fingerprint fields rather than
+						// draining the session. The mismatch is a versioning
+						// artifact, not real config drift. See ga-s760 FRs 1-3.
+						if runtime.IsLegacyOrMismatchedVersion(storedHash) {
+							outcome := rebaselineLegacyHashOutcome(storedHash)
+							if err := silentRebaselineSessionHashes(session, store, agentCfg); err != nil {
+								fmt.Fprintf(stderr, "session reconciler: rebaselining legacy hash for %s: %v\n", name, err) //nolint:errcheck
+							} else {
+								fmt.Fprintf(stderr, "rebaselined legacy hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash)) //nolint:errcheck
+							}
+							if trace != nil {
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(outcome), traceRecordPayload{
+									"stored_hash":  storedHash,
+									"current_hash": currentHash,
+								}, nil, "")
+							}
+							continue
+						}
+						fmt.Fprintf(stderr, "config-drift %s: stored=%s current=%s cmd=%q\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash), agentCfg.Command) //nolint:errcheck
 						// Diagnostic: log per-field breakdown to identify the drifting field.
 						var storedBreakdown map[string]string
 						if raw := session.Metadata["core_hash_breakdown"]; raw != "" {
@@ -1350,6 +1370,23 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								"live_hash":         currentLive,
 								"started_live_hash": currentLive,
 							})
+						} else if runtime.IsLegacyOrMismatchedVersion(storedLive) {
+							// Stored live hash from a pre-versioning or
+							// version-mismatched binary — silently rebaseline
+							// all four fingerprint fields rather than running
+							// SessionLive again. ga-s760 FRs 1-3.
+							outcome := rebaselineLegacyHashOutcome(storedLive)
+							if err := silentRebaselineSessionHashes(session, store, agentCfg); err != nil {
+								fmt.Fprintf(stderr, "session reconciler: rebaselining legacy live hash for %s: %v\n", name, err) //nolint:errcheck
+							} else {
+								fmt.Fprintf(stderr, "rebaselined legacy live hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedLive), truncateHashForLog(currentLive)) //nolint:errcheck
+							}
+							if trace != nil {
+								trace.recordDecision("reconciler.session.live_drift", tp.TemplateName, name, "live_drift", string(outcome), traceRecordPayload{
+									"stored_hash":  storedLive,
+									"current_hash": currentLive,
+								}, nil, "")
+							}
 						} else {
 							fmt.Fprintf(stdout, "Live config changed for '%s', re-applying...\n", tp.DisplayName()) //nolint:errcheck
 							if err := sp.RunLive(name, agentCfg); err != nil {
@@ -1391,6 +1428,24 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					agentCfg := sessionCoreConfigForHash(tp, *session)
 					currentHash := runtime.CoreFingerprint(agentCfg)
 					if storedHash != currentHash {
+						// Stored hash carries no version prefix or a different
+						// version — silently rebaseline rather than treating
+						// the asleep named session as drifted. ga-s760 FRs 1-3.
+						if runtime.IsLegacyOrMismatchedVersion(storedHash) {
+							outcome := rebaselineLegacyHashOutcome(storedHash)
+							if err := silentRebaselineSessionHashes(session, store, agentCfg); err != nil {
+								fmt.Fprintf(stderr, "session reconciler: rebaselining legacy hash for %s: %v\n", name, err) //nolint:errcheck
+							} else {
+								fmt.Fprintf(stderr, "rebaselined legacy hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash)) //nolint:errcheck
+							}
+							if trace != nil {
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(outcome), traceRecordPayload{
+									"stored_hash":  storedHash,
+									"current_hash": currentHash,
+								}, nil, "")
+							}
+							continue
+						}
 						var storedBreakdown map[string]string
 						if raw := session.Metadata["core_hash_breakdown"]; raw != "" {
 							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
@@ -2440,6 +2495,68 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 		}
 	}
 	return ""
+}
+
+// truncateHashForLog returns a short representation of a fingerprint hash
+// for log output. Preserves any v<digits>: prefix so the version stays
+// visible alongside the hex tail.
+func truncateHashForLog(h string) string {
+	if i := strings.IndexByte(h, ':'); i >= 0 {
+		end := i + 1 + 10
+		if end > len(h) {
+			end = len(h)
+		}
+		return h[:end]
+	}
+	if len(h) > 12 {
+		return h[:12]
+	}
+	return h
+}
+
+// rebaselineLegacyHashOutcome picks the trace outcome that matches a
+// stored hash about to be silently rebaselined.
+func rebaselineLegacyHashOutcome(stored string) TraceOutcomeCode {
+	if runtime.IsVersionMismatchedHash(stored) {
+		return TraceOutcomeRebaselinedVersionMismatch
+	}
+	return TraceOutcomeRebaselinedUnversioned
+}
+
+// silentRebaselineSessionHashes overwrites the four fingerprint metadata
+// fields (started_config_hash, started_live_hash, live_hash,
+// core_hash_breakdown) with values produced by the current binary. Used
+// when a stored hash carries no version prefix or a version prefix that
+// does not match runtime.FingerprintVersion. The reconciler invokes this
+// instead of draining the session — the hash mismatch is purely a
+// versioning artifact, not real config drift.
+func silentRebaselineSessionHashes(session *beads.Bead, store beads.Store, agentCfg runtime.Config) error {
+	if session == nil || store == nil {
+		return nil
+	}
+	coreHash := runtime.CoreFingerprint(agentCfg)
+	liveHash := runtime.LiveFingerprint(agentCfg)
+	breakdown := runtime.CoreFingerprintBreakdown(agentCfg)
+	breakdownJSON, err := json.Marshal(breakdown)
+	if err != nil {
+		return fmt.Errorf("marshaling core_hash_breakdown: %w", err)
+	}
+	patch := map[string]string{
+		"started_config_hash": coreHash,
+		"started_live_hash":   liveHash,
+		"live_hash":           liveHash,
+		"core_hash_breakdown": string(breakdownJSON),
+	}
+	if err := store.SetMetadataBatch(session.ID, patch); err != nil {
+		return fmt.Errorf("rebaselining hashes: %w", err)
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, len(patch))
+	}
+	for k, v := range patch {
+		session.Metadata[k] = v
+	}
+	return nil
 }
 
 // resolveSessionCommand returns the command to use when starting a session.

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1363,14 +1363,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					storedLive := session.Metadata["started_live_hash"]
 					currentLive := runtime.LiveFingerprint(agentCfg)
 					if storedLive != currentLive {
-						if storedLive == "" && len(agentCfg.SessionLive) == 0 {
+						switch {
+						case storedLive == "" && len(agentCfg.SessionLive) == 0:
 							// No stored hash and no live config — silently
 							// backfill the hash without running anything.
 							_ = store.SetMetadataBatch(session.ID, map[string]string{
 								"live_hash":         currentLive,
 								"started_live_hash": currentLive,
 							})
-						} else if runtime.IsLegacyOrMismatchedVersion(storedLive) {
+						case runtime.IsLegacyOrMismatchedVersion(storedLive):
 							// Stored live hash from a pre-versioning or
 							// version-mismatched binary — silently rebaseline
 							// all four fingerprint fields rather than running
@@ -1387,7 +1388,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 									"current_hash": currentLive,
 								}, nil, "")
 							}
-						} else {
+						default:
 							fmt.Fprintf(stdout, "Live config changed for '%s', re-applying...\n", tp.DisplayName()) //nolint:errcheck
 							if err := sp.RunLive(name, agentCfg); err != nil {
 								fmt.Fprintf(stderr, "session reconciler: RunLive %s: %v\n", name, err) //nolint:errcheck

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2524,6 +2524,159 @@ func TestReconcileSessionBeads_NoDriftWhenHashMatches(t *testing.T) {
 	}
 }
 
+// TestReconcilerSilentRebaselineOnLegacyHash enforces ga-s760.1 FR-1, FR-3:
+// when a session's stored core hash carries no version prefix (a session
+// started by a binary released before fingerprint versioning), the
+// reconciler must silently overwrite all four hash/breakdown metadata
+// fields with current versioned values. No drain, no SessionDraining
+// event.
+func TestReconcilerSilentRebaselineOnLegacyHash(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	rec := events.NewFake()
+	env.rec = rec
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	// Legacy bare-hex values as written by the pre-versioning binary.
+	legacyCore := strings.Repeat("a", 64)
+	legacyLive := strings.Repeat("b", 64)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": legacyCore,
+		"started_live_hash":   legacyLive,
+		"live_hash":           legacyLive,
+		"core_hash_breakdown": `{"Command":"legacy","Env":"legacy"}`,
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("expected no drain on legacy hash silent rebaseline, got %+v; stderr=%s", ds, env.stderr.String())
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionDraining {
+			t.Errorf("unexpected SessionDraining event recorded for silent rebaseline: %+v", e)
+		}
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	expectedCore := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"})
+	expectedLive := runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"})
+	if got.Metadata["started_config_hash"] != expectedCore {
+		t.Errorf("started_config_hash = %q, want rebaseline to %q", got.Metadata["started_config_hash"], expectedCore)
+	}
+	if got.Metadata["started_live_hash"] != expectedLive {
+		t.Errorf("started_live_hash = %q, want rebaseline to %q", got.Metadata["started_live_hash"], expectedLive)
+	}
+	if got.Metadata["live_hash"] != expectedLive {
+		t.Errorf("live_hash = %q, want rebaseline to %q", got.Metadata["live_hash"], expectedLive)
+	}
+	if got.Metadata["core_hash_breakdown"] == `{"Command":"legacy","Env":"legacy"}` {
+		t.Errorf("core_hash_breakdown was not rebaselined, still: %q", got.Metadata["core_hash_breakdown"])
+	}
+	if got.Metadata["core_hash_breakdown"] == "" {
+		t.Errorf("core_hash_breakdown was cleared but should be rebaselined to current breakdown")
+	}
+}
+
+// TestReconcilerSilentRebaselineOnVersionMismatch enforces ga-s760.1 FR-2,
+// FR-3: when a session's stored core hash carries a version prefix from a
+// different binary (e.g., v0:), the reconciler must silently rebaseline
+// all four hash/breakdown fields. No drain, no SessionDraining event.
+func TestReconcilerSilentRebaselineOnVersionMismatch(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	rec := events.NewFake()
+	env.rec = rec
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	// Version-mismatched stored hashes (v0: prefix is from an older binary).
+	mismatchCore := "v0:" + strings.Repeat("a", 64)
+	mismatchLive := "v0:" + strings.Repeat("b", 64)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": mismatchCore,
+		"started_live_hash":   mismatchLive,
+		"live_hash":           mismatchLive,
+		"core_hash_breakdown": `{"version":"v0","fields":{"Command":"old"}}`,
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("expected no drain on version-mismatch silent rebaseline, got %+v; stderr=%s", ds, env.stderr.String())
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionDraining {
+			t.Errorf("unexpected SessionDraining event recorded for silent rebaseline: %+v", e)
+		}
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	expectedCore := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"})
+	expectedLive := runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"})
+	if got.Metadata["started_config_hash"] != expectedCore {
+		t.Errorf("started_config_hash = %q, want rebaseline to %q", got.Metadata["started_config_hash"], expectedCore)
+	}
+	if got.Metadata["started_live_hash"] != expectedLive {
+		t.Errorf("started_live_hash = %q, want rebaseline to %q", got.Metadata["started_live_hash"], expectedLive)
+	}
+	if got.Metadata["live_hash"] != expectedLive {
+		t.Errorf("live_hash = %q, want rebaseline to %q", got.Metadata["live_hash"], expectedLive)
+	}
+	if got.Metadata["core_hash_breakdown"] == `{"version":"v0","fields":{"Command":"old"}}` {
+		t.Errorf("core_hash_breakdown was not rebaselined, still: %q", got.Metadata["core_hash_breakdown"])
+	}
+	if got.Metadata["core_hash_breakdown"] == "" {
+		t.Errorf("core_hash_breakdown was cleared but should be rebaselined to current breakdown")
+	}
+}
+
+// TestReconcilerStillDrainsOnSameVersionRealDrift enforces ga-s760.1 FR-4:
+// the silent rebaseline path must NOT swallow real drift. When stored and
+// current hashes share the current version prefix but differ in the hex
+// tail, the reconciler still drains the session. This is the regression
+// guard against the rebaseline branch over-applying.
+func TestReconcilerStillDrainsOnSameVersionRealDrift(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	// Desired state has a different command than the bead.
+	env.addRunningWorkerDesiredWithNewConfig()
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	// Stored hash carries the current version prefix but a fabricated hex
+	// that differs from whatever the desired-state config currently hashes
+	// to. The shared prefix means the version gate sees same-version, so
+	// the drift handling proceeds to compare the hex tails and drain.
+	storedCore := runtime.FingerprintVersion + ":" + strings.Repeat("c", 64)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": storedCore,
+	})
+
+	currentHash := runtime.CoreFingerprint(runtime.Config{Command: "new-cmd"})
+	if storedCore == currentHash {
+		t.Fatalf("test setup: stored hash %q should differ from current %q", storedCore, currentHash)
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	ds := env.dt.get(session.ID)
+	if ds == nil {
+		t.Fatalf("expected drain to be initiated for same-version real drift (session.ID=%q, stderr=%s)", session.ID, env.stderr.String())
+	}
+	if ds.reason != "config-drift" {
+		t.Errorf("drain reason = %q, want %q", ds.reason, "config-drift")
+	}
+}
+
 // Regression test for #127: a freshly created session can be drained for
 // config-drift shortly after wake because the reconciler's drift check runs
 // before started_config_hash is written. The fix skips drift detection until

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -166,6 +166,15 @@ const (
 	TraceOutcomeStartCandidate          TraceOutcomeCode = "start_candidate"
 	TraceOutcomeRetry                   TraceOutcomeCode = "retry"
 	TraceOutcomeCancel                  TraceOutcomeCode = "cancel"
+	// TraceOutcomeRebaselinedUnversioned marks a silent rebaseline of a
+	// stored fingerprint hash that carried no version prefix (legacy
+	// pre-versioning binary or otherwise malformed). No drain, no event.
+	TraceOutcomeRebaselinedUnversioned TraceOutcomeCode = "rebaselined_unversioned"
+	// TraceOutcomeRebaselinedVersionMismatch marks a silent rebaseline of
+	// a stored fingerprint hash whose v<digits>: prefix did not match the
+	// current FingerprintVersion (older or future binary). No drain, no
+	// event.
+	TraceOutcomeRebaselinedVersionMismatch TraceOutcomeCode = "rebaselined_version_mismatch"
 )
 
 type TraceCompletionStatus string

--- a/engdocs/architecture/session.md
+++ b/engdocs/architecture/session.md
@@ -3,7 +3,7 @@ title: "Session"
 ---
 
 
-> Last verified against code: 2026-04-25
+> Last verified against code: 2026-05-16
 
 ## Summary
 
@@ -191,6 +191,87 @@ Optional provider extensions also live in `runtime/runtime.go`:
 - `internal/session/manager_test.go` and `internal/session/manager_states_test.go`
   cover higher-level session bookkeeping layered on top of the runtime
 
+## Fingerprint Versioning
+
+### Versioning Model
+
+When the reconciler ticks, it compares the hash a session was started with
+against the hash the current binary produces from the session's resolved
+`runtime.Config`. A real same-version hash difference is config drift and can
+drain the session. A binary upgrade that changes the hash input set is not
+operator intent, so it must not mass-drain already-running sessions.
+
+Stored config hashes carry a `vN:` prefix. The version literal comes from
+`runtime.FingerprintVersion` in
+[`internal/runtime/fingerprint.go`](https://github.com/gastownhall/gascity/blob/main/internal/runtime/fingerprint.go).
+`ConfigFingerprint`, `CoreFingerprint`, and `LiveFingerprint` all emit
+`<FingerprintVersion>:<sha256-hex>`. The current version is `v1`.
+
+The reconciler treats two stored-hash cases as silent rebaseline rather than
+drift:
+
+1. The stored hash has no version prefix, which means it was written by a
+   pre-versioning binary.
+2. The stored hash has a prefix that differs from the current
+   `runtime.FingerprintVersion`.
+
+Silent rebaseline atomically overwrites `started_config_hash`,
+`started_live_hash`, `live_hash`, and `core_hash_breakdown` with values from
+the current binary. The session keeps running, no `SessionDraining` event is
+recorded, and the supervisor log shows one info line for the affected session.
+The `core_hash_breakdown` JSON shape is part of the same upgrade contract: a
+shape change must be paired with a fingerprint version bump.
+
+Implementation references:
+[`internal/runtime/fingerprint.go`](https://github.com/gastownhall/gascity/blob/main/internal/runtime/fingerprint.go)
+owns the version constant and hash helpers,
+[`cmd/gc/session_reconciler.go`](https://github.com/gastownhall/gascity/blob/main/cmd/gc/session_reconciler.go)
+owns the silent-rebaseline branches, and
+[`cmd/gc/build_desired_state_test.go`](https://github.com/gastownhall/gascity/blob/main/cmd/gc/build_desired_state_test.go)
+contains the cross-tick fingerprint stability gate.
+
+### When To Bump And When Not
+
+Rule: if the byte sequence written by `hashCoreFields`, `hashLiveFields`, or a
+helper they call would differ for any valid input, bump
+`runtime.FingerprintVersion`.
+
+Bump the version when a change:
+
+- Adds, removes, or reorders an input to `hashCoreFields`, `hashLiveFields`, or
+  `buildFingerprintExtra`.
+- Changes `envFingerprintAllow`.
+- Changes the on-disk JSON shape stored in `core_hash_breakdown`.
+- Changes the bytes emitted by an existing input, such as re-encoding
+  `CopyEntry` or changing the `HASH_UNAVAILABLE` sentinel used when probed
+  file hashing fails.
+
+Do not bump the version for:
+
+- Pure refactors that produce the same hash for the same input. Verify with the
+  cross-tick stability test for the affected surface.
+- Comments, tests, or documentation.
+- Changes to consumers such as `session_reconciler.go` or
+  `LogCoreFingerprintDrift` that do not change hash output.
+
+### PR Review Checklist
+
+For PRs that touch `internal/runtime/fingerprint.go`:
+
+- [ ] Does the change affect hash output for any valid input?
+      If unclear, compare the affected cross-tick stability fixture before and
+      after the change.
+- [ ] If yes, has `runtime.FingerprintVersion` been bumped?
+- [ ] If yes, is there a new row in the version changelog with the adoption
+      date and a one-line description?
+- [ ] Does the relevant cross-tick stability test still pass?
+
+### Version Changelog
+
+| Version | Adopted    | Change |
+|---|---|---|
+| `v1` | 2026-04-27 | Initial introduction of the `vN:` prefix. Pre-existing unversioned hashes are silently rebaselined to `v1` on the first reconciler tick after upgrade. |
+
 ## Known Limitations
 
 - Provider capabilities differ: interactive attach, idle waiting, and pending
@@ -203,5 +284,7 @@ Optional provider extensions also live in `runtime/runtime.go`:
 ## See Also
 
 - [Health Patrol](health-patrol.md) for liveness and drift handling
+- [Fingerprint Versioning](#fingerprint-versioning) for the version-bump and
+  silent-rebaseline contract
 - [Prompt Templates](prompt-templates.md) for what gets delivered into
   sessions once they start

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+// FingerprintVersion namespaces the stored fingerprint hashes so the
+// reconciler can detect hashes written by older binaries (no prefix or a
+// different prefix) and silently rebaseline them instead of triggering a
+// false-positive drain. Bump this constant whenever the inputs to or the
+// algorithm of any Fingerprint helper change.
+const FingerprintVersion = "v1"
+
 // ConfigFingerprint returns a deterministic hash of the Config fields that
 // define an agent's behavioral identity. Changes to these fields indicate
 // the agent should be restarted (via drain when drain ops are available).
@@ -20,31 +27,77 @@ import (
 // Excluded (observation-only hints): WorkDir, ReadyPromptPrefix,
 // ReadyDelayMs, ProcessNames, EmitsPermissionWarning.
 //
-// The hash is a hex-encoded SHA-256. Same config always produces the same
-// hash regardless of map iteration order.
+// The hash is a hex-encoded SHA-256 prefixed with FingerprintVersion. Same
+// config always produces the same hash regardless of map iteration order.
 func ConfigFingerprint(cfg Config) string {
 	h := sha256.New()
 	hashCoreFields(h, cfg)
 	hashLiveFields(h, cfg)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%s:%x", FingerprintVersion, h.Sum(nil))
 }
 
 // CoreFingerprint returns a hash of only the "core" config fields —
 // everything except SessionLive. A change to core fields triggers a
 // drain + restart. A change to only SessionLive triggers re-apply
-// without restart.
+// without restart. Output is prefixed with FingerprintVersion.
 func CoreFingerprint(cfg Config) string {
 	h := sha256.New()
 	hashCoreFields(h, cfg)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%s:%x", FingerprintVersion, h.Sum(nil))
 }
 
 // LiveFingerprint returns a hash of only the SessionLive fields.
-// Used by the reconciler to detect live-only drift.
+// Used by the reconciler to detect live-only drift. Output is prefixed
+// with FingerprintVersion.
 func LiveFingerprint(cfg Config) string {
 	h := sha256.New()
 	hashLiveFields(h, cfg)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%s:%x", FingerprintVersion, h.Sum(nil))
+}
+
+// IsLegacyOrMismatchedVersion reports whether the stored hash should
+// trigger a silent rebaseline rather than a drift drain. Returns true for
+// stored hashes with no version prefix (legacy bare hex) or a version
+// prefix that does not match FingerprintVersion. Returns false for empty
+// stored hashes (those are gated separately by the reconciler) and for
+// stored hashes that share the current version prefix.
+func IsLegacyOrMismatchedVersion(stored string) bool {
+	if stored == "" {
+		return false
+	}
+	colon := strings.IndexByte(stored, ':')
+	if colon < 0 {
+		// No colon: a bare hex hash from a pre-versioning binary, or an
+		// otherwise malformed value. Either way, treat as legacy.
+		return true
+	}
+	return stored[:colon] != FingerprintVersion
+}
+
+// IsVersionMismatchedHash reports whether the stored hash carries a
+// well-formed `v<digits>:` prefix that does not match FingerprintVersion.
+// Used to distinguish "another binary's version" from "no version prefix
+// at all" for trace-outcome reporting. Returns false for empty stored,
+// current-version stored, unversioned stored, and stored with a
+// non-`v<digits>:` prefix shape.
+func IsVersionMismatchedHash(stored string) bool {
+	colon := strings.IndexByte(stored, ':')
+	if colon < 1 {
+		return false
+	}
+	prefix := stored[:colon]
+	if prefix == FingerprintVersion {
+		return false
+	}
+	if prefix[0] != 'v' {
+		return false
+	}
+	for i := 1; i < len(prefix); i++ {
+		if prefix[i] < '0' || prefix[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // envFingerprintAllow is the set of env keys whose values define agent

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -711,6 +712,101 @@ func TestHashPathContentUnreadableChild(t *testing.T) {
 	h := HashPathContent(sub)
 	if h != "" {
 		t.Errorf("expected empty hash when child is unreadable, got %q", h)
+	}
+}
+
+// TestFingerprintVersionedOutputFormat enforces FR-5/FR-7 from ga-s760.1:
+// every fingerprint helper emits "<FingerprintVersion>:<hex>" so the
+// reconciler can tell which binary produced a stored hash.
+func TestFingerprintVersionedOutputFormat(t *testing.T) {
+	if FingerprintVersion == "" {
+		t.Fatal("FingerprintVersion constant must be set (FR-7)")
+	}
+	if !strings.HasPrefix(FingerprintVersion, "v") {
+		t.Errorf("FingerprintVersion = %q, want a 'v'-prefixed identifier", FingerprintVersion)
+	}
+	for _, r := range FingerprintVersion[1:] {
+		if r < '0' || r > '9' {
+			t.Errorf("FingerprintVersion = %q, want v<digits> shape", FingerprintVersion)
+			break
+		}
+	}
+
+	prefix := FingerprintVersion + ":"
+	cfg := Config{
+		Command: "claude --skip",
+		Env:     map[string]string{"GC_CITY": "/x", "GC_RIG": "r"},
+		SessionLive: []string{
+			"tmux set-option -t {{.Session}} remain-on-exit on",
+		},
+	}
+
+	cases := []struct {
+		name string
+		got  string
+	}{
+		{"ConfigFingerprint", ConfigFingerprint(cfg)},
+		{"CoreFingerprint", CoreFingerprint(cfg)},
+		{"LiveFingerprint", LiveFingerprint(cfg)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.HasPrefix(tc.got, prefix) {
+				t.Fatalf("%s = %q, want prefix %q", tc.name, tc.got, prefix)
+			}
+			tail := strings.TrimPrefix(tc.got, prefix)
+			if tail == "" {
+				t.Fatalf("%s = %q, no hex tail after prefix", tc.name, tc.got)
+			}
+			if strings.Contains(tail, ":") {
+				t.Errorf("%s = %q, hex tail must not contain ':'", tc.name, tc.got)
+			}
+			for _, r := range tail {
+				if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+					t.Errorf("%s = %q, non-hex character %q in tail", tc.name, tc.got, r)
+					break
+				}
+			}
+			// The previous bare-hex output was 64 chars (SHA-256). The
+			// versioned output keeps the same hex tail length.
+			if len(tail) != 64 {
+				t.Errorf("%s tail length = %d, want 64", tc.name, len(tail))
+			}
+		})
+	}
+}
+
+// TestIsLegacyOrMismatchedVersion enforces FR-1, FR-2: the reconciler
+// distinguishes legacy (no prefix) and mismatched-version stored hashes
+// from current-version hashes via this helper. Reconciler treats the
+// "true" cases as triggers for silent rebaseline (no drain, no event).
+func TestIsLegacyOrMismatchedVersion(t *testing.T) {
+	bareHex := strings.Repeat("a", 64)
+	current := FingerprintVersion + ":" + bareHex
+
+	cases := []struct {
+		name   string
+		stored string
+		want   bool
+	}{
+		{"bare hex (no prefix, legacy)", bareHex, true},
+		{"empty stored (handled by separate gate, not legacy/mismatch)", "", false},
+		{"current version prefix", current, false},
+		{"v0 prefix (older mismatched version)", "v0:" + bareHex, true},
+		{"v2 prefix (future mismatched version)", "v2:" + bareHex, true},
+		{"vX prefix (non-numeric, treated as legacy)", "vX:" + bareHex, true},
+		{"v01 prefix (different literal version, mismatch)", "v01:" + bareHex, true},
+		{"non-v prefix (e.g. xyz, treated as legacy)", "xyz:" + bareHex, true},
+		{"colon-only prefix (no version literal, legacy)", ":" + bareHex, true},
+		{"prefix without colon (looks like bare hex)", FingerprintVersion + bareHex, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsLegacyOrMismatchedVersion(tc.stored)
+			if got != tc.want {
+				t.Errorf("IsLegacyOrMismatchedVersion(%q) = %v, want %v", tc.stored, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -762,7 +762,7 @@ func TestFingerprintVersionedOutputFormat(t *testing.T) {
 				t.Errorf("%s = %q, hex tail must not contain ':'", tc.name, tc.got)
 			}
 			for _, r := range tail {
-				if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+				if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
 					t.Errorf("%s = %q, non-hex character %q in tail", tc.name, tc.got, r)
 					break
 				}

--- a/release-gates/ga-qqguy0-fingerprint-versioning-gate.md
+++ b/release-gates/ga-qqguy0-fingerprint-versioning-gate.md
@@ -1,0 +1,63 @@
+# Release gate - fingerprint versioning and engdocs (ga-qqguy0 / ga-s760.4)
+
+**Verdict:** PASS
+
+- Deploy bead: `ga-qqguy0` (review handoff for `ga-s760.4`)
+- Source bead: `ga-s760.4` - Engdocs: Fingerprint upgrade-compatibility contract
+- Stacked dependency included in branch: `ga-s760.1` - Hash versioning + drift-check upgrade-compat
+- Branch evaluated: `deployer/ga-qqguy0-gate`
+- Reviewed source branch: `fork/builder/ga-s760-4-1`
+- Final commits over `origin/main`:
+  - `a0e938ad1` - test(runtime,reconciler): hash versioning + silent rebaseline (ga-s760.1)
+  - `61e6e4b36` - feat(runtime,reconciler): version stored fingerprints and silently rebaseline legacy hashes (ga-s760.1)
+  - `6cc405a64` - docs(architecture): document fingerprint versioning contract
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS verdict in bead notes | PASS | `ga-qqguy0` notes contain `Review Verdict: PASS` from `gascity/reviewer`; reviewed commits are `a0e938ad1`, `61e6e4b36`, and `6cc405a64`. |
+| 2 | Acceptance criteria met | PASS | `ga-s760.1`: `runtime.FingerprintVersion` is the single version constant; `ConfigFingerprint`, `CoreFingerprint`, and `LiveFingerprint` emit `v1:<sha256>`; legacy or version-mismatched stored hashes rebaseline through `silentRebaselineSessionHashes`; same-version real drift still drains. `ga-s760.4`: the Fingerprint Versioning section is present in current `engdocs/architecture/session.md`, with the v1 changelog, PR review checklist, bump/not-bump rules, and See Also link. The original `agent-protocol.md` target was stale; `session.md` is the current architecture doc for this surface. |
+| 3 | Tests pass on final branch | PASS | `git diff --check origin/main..HEAD`; focused runtime/reconciler/docsync tests; `make test-fast-parallel`; and `go vet ./...` all passed. Full command list below. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list three INFO findings only; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | After the gate file was committed, `git status --porcelain=v1` was empty. This commit was amended only to record that evidence. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` completed with tree `ffd46f718b2b3beae7a069117a14e707877f1190` and no conflicts. |
+
+## Acceptance details
+
+### `ga-s760.1` - runtime and reconciler compatibility
+
+- New stored hashes carry the current version prefix from
+  `runtime.FingerprintVersion`.
+- `runtime.IsLegacyOrMismatchedVersion` classifies unversioned hashes and
+  different-version hashes as compatibility rebaseline cases.
+- Core-drift, live-drift, and asleep named-session drift paths call the
+  silent-rebaseline helper before any same-version drift handling.
+- `silentRebaselineSessionHashes` writes `started_config_hash`,
+  `started_live_hash`, `live_hash`, and `core_hash_breakdown`, then updates the
+  in-memory session metadata copy.
+- Same-version hash mismatches continue down the existing config-drift drain
+  path.
+
+### `ga-s760.4` - architecture documentation
+
+- `engdocs/architecture/session.md` now has a `## Fingerprint Versioning`
+  section between `## Testing` and `## Known Limitations`.
+- The section documents the versioning model, silent-rebaseline behavior,
+  version bump rules, non-bump cases, PR review checklist, and `v1` changelog.
+- The See Also footer links back to the new Fingerprint Versioning section.
+- The doc verification date is refreshed to `2026-05-16`.
+
+## Validation
+
+- `git diff --check origin/main..HEAD` - PASS
+- `go test ./internal/runtime -run 'TestFingerprintVersionedOutputFormat|TestIsLegacyOrMismatchedVersion' -count=1` - PASS
+- `go test ./cmd/gc -run 'TestReconcilerSilentRebaseline|TestReconcilerStillDrainsOnSameVersionRealDrift' -count=1` - PASS
+- `go test ./test/docsync -count=1` - PASS
+- `make test-fast-parallel` - PASS (`All fast jobs passed`)
+- `go vet ./...` - PASS
+
+## Push target
+
+`git push --dry-run origin HEAD` succeeded, so `PUSH_REMOTE=origin` for this
+release branch.


### PR DESCRIPTION
## What this changes

Session config fingerprints are now namespaced with `runtime.FingerprintVersion`, so new config/core/live hashes are stored as `v1:<sha256>` instead of bare hex. When the reconciler sees a stored hash with no version prefix, or a prefix from another fingerprint version, it silently rebaselines the stored fingerprint metadata instead of treating the upgrade as config drift and draining the session.

Same-version hash mismatches still use the existing config-drift path. The compatibility branch only handles version artifacts from binary upgrades, and trace/log output keeps enough detail to distinguish unversioned hashes from version mismatches.

The session architecture doc now has a Fingerprint Versioning section with the bump rules, PR review checklist, and the initial `v1` changelog entry.

## Review notes

- `internal/runtime/fingerprint.go` owns the version constant and hash-prefix helpers.
- `cmd/gc/session_reconciler.go` adds silent rebaseline handling for core drift, live-only drift, and asleep named-session drift.
- No migration command or per-version compatibility table is introduced; the version prefix is the compatibility boundary.
- `engdocs/architecture/session.md` is the current architecture surface for this material, replacing the old Agent Protocol doc target.

## Test plan

- [x] `git diff --check origin/main..HEAD`
- [x] `go test ./internal/runtime -run 'TestFingerprintVersionedOutputFormat|TestIsLegacyOrMismatchedVersion' -count=1`
- [x] `go test ./cmd/gc -run 'TestReconcilerSilentRebaseline|TestReconcilerStillDrainsOnSameVersionRealDrift' -count=1`
- [x] `go test ./test/docsync -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-qqguy0-fingerprint-versioning-gate.md`](release-gates/ga-qqguy0-fingerprint-versioning-gate.md)