### PR TITLE
Preserve named-always session resume identity on heal

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -36,6 +36,8 @@ type wakeEvaluation struct {
 	ConfigSuppressed bool
 }
 
+const sleepReasonRuntimeMissing = "runtime-missing"
+
 // Deprecated: evaluateWakeReasons and wakeReasons are legacy functions
 // superseded by ComputeAwakeSet (compute_awake_set.go). The production
 // reconciler at session_reconciler.go:438 uses ComputeAwakeSet →
@@ -968,15 +970,20 @@ func healStatePatch(session beads.Bead, alive bool, clk clock.Clock) map[string]
 	}
 	if meta["state"] != target {
 		batch["state"] = target
+		if target == string(sessionpkg.StateAsleep) && view.ResetContinuation && strings.TrimSpace(meta["sleep_reason"]) == "" {
+			batch["sleep_reason"] = sleepReasonRuntimeMissing
+		}
 	}
 	if target == string(sessionpkg.StateAsleep) {
 		if strings.TrimSpace(meta["sleep_reason"]) == "" && strings.TrimSpace(meta["state"]) == "failed-create" {
 			batch["sleep_reason"] = "failed-create"
 		}
 		if view.ResetContinuation {
-			batch["session_key"] = ""
-			batch["started_config_hash"] = ""
-			batch["continuation_reset_pending"] = "true"
+			if !isNamedSessionBead(session) || namedSessionMode(session) != "always" {
+				batch["session_key"] = ""
+				batch["started_config_hash"] = ""
+				batch["continuation_reset_pending"] = "true"
+			}
 		}
 	}
 	return emptyNil(batch)

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1623,6 +1623,7 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 			}(),
 			want: map[string]string{
 				"state":                      "asleep",
+				"sleep_reason":               sleepReasonRuntimeMissing,
 				"session_key":                "",
 				"started_config_hash":        "",
 				"continuation_reset_pending": "true",
@@ -1682,6 +1683,34 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 	}
 }
 
+func TestHealStatePatch_NamedAlwaysAwakeFlapsToAsleepWithoutReasonOnAliveFalse(t *testing.T) {
+	now := time.Date(2026, 5, 12, 22, 16, 55, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	session := makeBead("mayor-adhoc-b76ba59d39", map[string]string{
+		"state":                      "awake",
+		"session_key":                "active-session-abc",
+		"started_config_hash":        "current-core-hash",
+		"started_live_hash":          "current-live-hash",
+		"sleep_reason":               "",
+		"template":                   "mayor",
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "mayor",
+		namedSessionModeMetadata:     "always",
+	})
+
+	patch := healStatePatch(session, false, clk)
+	if patch["state"] != "asleep" {
+		t.Fatalf("baseline: expected state=asleep on heal-from-awake when !alive, got %q (patch=%#v)", patch["state"], patch)
+	}
+
+	sleepReasonSet := strings.TrimSpace(patch["sleep_reason"]) != ""
+	resumeWiped := patch["session_key"] == "" || patch["started_config_hash"] == ""
+	if !sleepReasonSet && resumeWiped {
+		t.Fatalf("named-always heal-to-asleep produced empty sleep_reason and wiped resume identity in one tick: patch=%#v", patch)
+	}
+}
+
 func TestHealStatePatchNilClockKeepsCreatingFresh(t *testing.T) {
 	session := makeBead("b1", map[string]string{
 		"state": "creating",
@@ -1728,6 +1757,7 @@ func TestHealState_ClearsStaleResumeMetadata(t *testing.T) {
 		wakeMode               string
 		sessionKey             string
 		startedConfigHash      string
+		namedAlways            bool
 		wantKeyCleared         bool
 		wantStartedHashCleared bool
 	}{
@@ -1859,6 +1889,16 @@ func TestHealState_ClearsStaleResumeMetadata(t *testing.T) {
 			wantKeyCleared:         false,
 			wantStartedHashCleared: true,
 		},
+		{
+			name:                   "named-always awake with no drain reason — resume metadata preserved",
+			prevState:              "awake",
+			sleepReason:            "",
+			sessionKey:             "abc-123",
+			startedConfigHash:      "hash-before",
+			namedAlways:            true,
+			wantKeyCleared:         false,
+			wantStartedHashCleared: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1872,6 +1912,11 @@ func TestHealState_ClearsStaleResumeMetadata(t *testing.T) {
 				"session_key":         tt.sessionKey,
 				"started_config_hash": tt.startedConfigHash,
 			})
+			if tt.namedAlways {
+				session.Metadata[namedSessionMetadataKey] = "true"
+				session.Metadata[namedSessionIdentityMetadata] = "mayor"
+				session.Metadata[namedSessionModeMetadata] = "always"
+			}
 			healState(&session, false, store, clk)
 			keyAfter := session.Metadata["session_key"]
 			startedHashAfter := session.Metadata["started_config_hash"]

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -43,7 +43,7 @@ func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	}
 	reason := strings.TrimSpace(session.Metadata["sleep_reason"])
 	switch reason {
-	case "idle", "idle-timeout", "failed-create":
+	case "idle", "idle-timeout", "failed-create", sleepReasonRuntimeMissing:
 		return true
 	}
 	return false

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -21,6 +21,7 @@ func TestIsPoolSessionSlotFreeable_Matrix(t *testing.T) {
 		{"asleep+idle", map[string]string{"state": "asleep", "sleep_reason": "idle"}, true},
 		{"asleep+idle-timeout", map[string]string{"state": "asleep", "sleep_reason": "idle-timeout"}, true},
 		{"asleep+failed-create", map[string]string{"state": "asleep", "sleep_reason": "failed-create"}, true},
+		{"asleep+runtime-missing", map[string]string{"state": "asleep", "sleep_reason": sleepReasonRuntimeMissing}, true},
 		{"asleep+empty-reason", map[string]string{"state": "asleep", "sleep_reason": ""}, false},
 		{"asleep+missing-reason", map[string]string{"state": "asleep"}, false},
 		{"asleep+wait-hold", map[string]string{"state": "asleep", "sleep_reason": "wait-hold"}, false},

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -548,7 +548,7 @@ func shouldResetContinuation(base BaseState, meta map[string]string, sleepReason
 		return false
 	}
 	switch strings.TrimSpace(sleepReason) {
-	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained", "city-stop", "user-hold", "wait-hold", "rate_limit":
+	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained", "city-stop", "user-hold", "wait-hold", "rate_limit", "runtime-missing":
 		return false
 	}
 	return base == BaseStateActive || base == BaseStateCreating

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -395,6 +395,23 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 			wantReconciledState: StateAsleep,
 		},
 		{
+			name: "dead active runtime with runtime-missing reason preserves resume identity",
+			input: LifecycleInput{
+				Status: "open",
+				Metadata: map[string]string{
+					"state":               "active",
+					"session_name":        "s-worker",
+					"session_key":         "provider-conversation",
+					"started_config_hash": "config",
+					"sleep_reason":        "runtime-missing",
+				},
+				Runtime: RuntimeFacts{Observed: true, Alive: false},
+				Now:     now,
+			},
+			wantRuntime:         RuntimeProjectionMissing,
+			wantReconciledState: StateAsleep,
+		},
+		{
 			name: "fresh creating state stays creating after restart",
 			input: LifecycleInput{
 				Status: "open",

--- a/release-gates/ga-12t89g-gate.md
+++ b/release-gates/ga-12t89g-gate.md
@@ -1,0 +1,41 @@
+# Release Gate: ga-12t89g
+
+Status: PASS
+
+Source bead: ga-12t89g
+Deploy bead: ga-c5plul
+Branch: builder/ga-12t89g-1
+Commit: a0f7c00075fe93736c9bfb9b44f6d2129c81ffe3
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses
+the deployer role's release criteria table plus the repo testing policy in
+`TESTING.md`.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-c5plul` contains `REVIEW VERDICT: PASS` for branch `builder/ga-12t89g-1`. |
+| 2 | Acceptance criteria met | PASS | The branch implements the named-always heal exception, stamps `runtime-missing`, preserves existing ordinary/pool reset behavior, adds `runtime-missing` lifecycle/freeable handling, and covers the requested cmd/gc and internal/session cases. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestHealStatePatch_NamedAlwaysAwakeFlapsToAsleepWithoutReasonOnAliveFalse|TestHealState_ClearsStaleResumeMetadata|TestHealStatePatchProjectsRuntimeLiveness|TestIsPoolSessionSlotFreeable_Matrix' -count=3` passed; `go test ./internal/session -run 'TestProjectLifecycleRuntimeProjection|TestProjectLifecycle|TestLifecycle' -count=3` passed; `make test-fast-parallel` ended with `All fast jobs passed`; `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes list one MEDIUM, one LOW, and one INFO finding; no HIGH or CRITICAL findings are present. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` reports `## builder/ga-12t89g-1...fork/builder/ga-12t89g-1` with no file changes. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed and `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` reported no conflicts. |
+
+## Acceptance Evidence
+
+- `cmd/gc/session_reconcile.go` sets `sleep_reason=runtime-missing` when a
+  dead-runtime heal path transitions to asleep with empty sleep reason and
+  reset-worthy stale continuation metadata.
+- `cmd/gc/session_reconcile.go` skips clearing `session_key` and
+  `started_config_hash` when the bead is a configured named session in
+  `mode=always`.
+- `internal/session/lifecycle_projection.go` excludes `runtime-missing` from
+  continuation reset decisions, so the next projection tick does not undo the
+  preservation.
+- `cmd/gc/session_state_helpers.go` treats asleep + `runtime-missing` as a
+  freeable pool slot while preserving deny-by-default behavior for missing or
+  unknown reasons.
+- Regression coverage is present in `cmd/gc/session_reconcile_test.go`,
+  `cmd/gc/session_state_helpers_test.go`, and
+  `internal/session/lifecycle_projection_test.go`.


### PR DESCRIPTION
## What this changes

When a configured named session in `mode=always` is observed with a missing runtime, the heal path can still move the bead to `asleep`, but it no longer clears the provider resume identity in the same tick. The heal now records `sleep_reason=runtime-missing`, so the next lifecycle projection preserves the resume metadata instead of treating it as stale continuation state.

Ordinary and pool sessions keep the existing stale-resume reset behavior. Pool slots that land in `asleep` with `runtime-missing` are still freeable, so dead runtime cleanup does not strand capacity.

## Review notes

- The behavior change is in `cmd/gc/session_reconcile.go`; the exception is limited to configured named sessions whose mode is `always`.
- `runtime-missing` is added to the lifecycle projection reset exemptions and the pool-slot freeable allowlist.
- There are no new config fields, endpoints, migrations, or generated API/dashboard changes.

## Test plan

- [x] `go test ./cmd/gc -run 'TestHealStatePatch_NamedAlwaysAwakeFlapsToAsleepWithoutReasonOnAliveFalse|TestHealState_ClearsStaleResumeMetadata|TestHealStatePatchProjectsRuntimeLiveness|TestIsPoolSessionSlotFreeable_Matrix' -count=3`
- [x] `go test ./internal/session -run 'TestProjectLifecycleRuntimeProjection|TestProjectLifecycle|TestLifecycle' -count=3`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-12t89g-gate.md`](release-gates/ga-12t89g-gate.md)