### PR TITLE
Emit bd.slow telemetry for long-running bd calls

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -36,6 +36,9 @@ var (
 	// bdGraphApplyCommandTimeout bounds atomic graph creation below callers'
 	// outer command budgets so transient Dolt stalls can retry or fall back.
 	bdGraphApplyCommandTimeout = 45 * time.Second
+	// bdSlowTelemetryThreshold is fixed in production via telemetry.BDSlowThreshold:
+	// high enough to avoid normal bd list calls, but below the wrapper timeout.
+	bdSlowTelemetryThreshold = telemetry.BDSlowThreshold
 )
 
 // ExecCommandRunner returns a CommandRunner that uses os/exec to run commands.
@@ -72,6 +75,15 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 		timeout := bdCommandTimeoutFor(name, args)
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
+		var slowTimer *time.Timer
+		if name == "bd" {
+			bdArgs := append([]string(nil), args...)
+			agentID := bdTelemetryAgentID(env)
+			slowTimer = time.AfterFunc(bdSlowTelemetryThreshold, func() {
+				telemetry.RecordBDSlow(ctx, bdArgs, dir, agentID)
+			})
+			defer slowTimer.Stop()
+		}
 		cmd := exec.CommandContext(ctx, name, args...)
 		cmd.WaitDelay = 2 * time.Second
 		prepareCommandForTimeout(cmd)
@@ -115,6 +127,20 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 		trace("done", err)
 		return out, err
 	}
+}
+
+func bdTelemetryAgentID(env map[string]string) string {
+	for _, key := range []string{"GC_ALIAS", "GC_AGENT"} {
+		if env != nil {
+			if value := strings.TrimSpace(env[key]); value != "" {
+				return value
+			}
+		}
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func bdCommandTimeoutFor(name string, args []string) time.Duration {

--- a/internal/beads/bdstore_exec_internal_test.go
+++ b/internal/beads/bdstore_exec_internal_test.go
@@ -3,14 +3,20 @@
 package beads
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
+
+	otellog "go.opentelemetry.io/otel/log"
+	otellogglobal "go.opentelemetry.io/otel/log/global"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
 // TestExecCommandRunnerTimesOut verifies the runner returns a "timed
@@ -52,6 +58,63 @@ func TestBDCommandTimeoutForReadCommands(t *testing.T) {
 func TestBDCommandTimeoutForGraphApply(t *testing.T) {
 	if got := bdCommandTimeoutFor("bd", []string{"create", "--graph", "/tmp/plan.json", "--json"}); got != bdGraphApplyCommandTimeout {
 		t.Fatalf("bd create --graph timeout = %s, want %s", got, bdGraphApplyCommandTimeout)
+	}
+}
+
+func TestExecCommandRunnerEmitsBDSlowForLongBDCommand(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh unavailable")
+	}
+
+	oldThreshold := bdSlowTelemetryThreshold
+	bdSlowTelemetryThreshold = 20 * time.Millisecond
+	t.Cleanup(func() { bdSlowTelemetryThreshold = oldThreshold })
+
+	exp := installBeadsRecordingLogExporter(t)
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+sleep 0.08
+printf '[]\n'
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_ALIAS", "test-agent-1")
+
+	if _, err := ExecCommandRunner()(t.TempDir(), "bd", "list", "--token", "sk-secret"); err != nil {
+		t.Fatalf("ExecCommandRunner bd: %v", err)
+	}
+
+	rec := exp.waitForBody(t, "bd.slow", time.Second)
+	attrs := beadsRecordAttrs(*rec)
+	if got := beadsLogValueStringSlice(attrs["args"]); strings.Join(got, " ") != "list --token <redacted>" {
+		t.Fatalf("bd.slow args = %#v, want token redacted", got)
+	}
+	if got := attrs["agent_id"].AsString(); got != "test-agent-1" {
+		t.Fatalf("bd.slow agent_id = %q, want test-agent-1", got)
+	}
+}
+
+func TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh unavailable")
+	}
+
+	oldThreshold := bdSlowTelemetryThreshold
+	bdSlowTelemetryThreshold = 30 * time.Millisecond
+	t.Cleanup(func() { bdSlowTelemetryThreshold = oldThreshold })
+
+	exp := installBeadsRecordingLogExporter(t)
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '[]\n'
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err := ExecCommandRunner()(t.TempDir(), "bd", "list"); err != nil {
+		t.Fatalf("ExecCommandRunner bd: %v", err)
+	}
+	time.Sleep(2 * bdSlowTelemetryThreshold)
+	if got := exp.countByBody("bd.slow"); got != 0 {
+		t.Fatalf("bd.slow records = %d, want 0 for fast bd command", got)
 	}
 }
 
@@ -131,4 +194,101 @@ func waitForNonEmptyFile(t *testing.T, path string, timeout time.Duration) strin
 	}
 	t.Fatalf("child pid was not written within %s", timeout)
 	return ""
+}
+
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+type beadsRecordingLogExporter struct {
+	mu      sync.Mutex
+	records []sdklog.Record
+}
+
+func installBeadsRecordingLogExporter(t *testing.T) *beadsRecordingLogExporter {
+	t.Helper()
+	exp := &beadsRecordingLogExporter{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(exp)))
+	prev := otellogglobal.GetLoggerProvider()
+	otellogglobal.SetLoggerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otellogglobal.SetLoggerProvider(prev)
+	})
+	return exp
+}
+
+func (e *beadsRecordingLogExporter) Export(_ context.Context, records []sdklog.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, rec := range records {
+		e.records = append(e.records, rec.Clone())
+	}
+	return nil
+}
+
+func (e *beadsRecordingLogExporter) Shutdown(context.Context) error {
+	return nil
+}
+
+func (e *beadsRecordingLogExporter) ForceFlush(context.Context) error {
+	return nil
+}
+
+func (e *beadsRecordingLogExporter) waitForBody(t *testing.T, body string, timeout time.Duration) *sdklog.Record {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if rec := e.recordByBody(body); rec != nil {
+			return rec
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("log body %q did not arrive within %s", body, timeout)
+	return nil
+}
+
+func (e *beadsRecordingLogExporter) recordByBody(body string) *sdklog.Record {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for i := range e.records {
+		if e.records[i].Body().AsString() == body {
+			rec := e.records[i].Clone()
+			return &rec
+		}
+	}
+	return nil
+}
+
+func (e *beadsRecordingLogExporter) countByBody(body string) int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var count int
+	for i := range e.records {
+		if e.records[i].Body().AsString() == body {
+			count++
+		}
+	}
+	return count
+}
+
+func beadsRecordAttrs(rec sdklog.Record) map[string]otellog.Value {
+	attrs := make(map[string]otellog.Value)
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrs[kv.Key] = kv.Value
+		return true
+	})
+	return attrs
+}
+
+func beadsLogValueStringSlice(value otellog.Value) []string {
+	values := value.AsSlice()
+	out := make([]string, 0, len(values))
+	for _, item := range values {
+		out = append(out, item.AsString())
+	}
+	return out
 }

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 	"unicode/utf8"
 
 	"go.opentelemetry.io/otel"
@@ -22,6 +23,21 @@ const (
 	meterRecorderName = "github.com/gastownhall/gascity"
 	loggerName        = "gascity"
 )
+
+// BDSlowThreshold is the fixed wall-clock point where an in-flight bd
+// subprocess is reported as slow. It is intentionally well below the bd
+// wrapper timeout and not operator-tunable.
+const BDSlowThreshold = 30 * time.Second
+
+// BDSlowEvent describes the structured fields emitted with bd.slow telemetry.
+type BDSlowEvent struct {
+	Timestamp time.Time `json:"timestamp"`
+	Args      []string  `json:"args"`
+	Dir       string    `json:"dir"`
+	ElapsedMs int64     `json:"elapsed_ms"`
+	AgentID   string    `json:"agent_id,omitempty"`
+	Threshold int64     `json:"threshold_ms"`
+}
 
 // recorderInstruments holds all lazy-initialized OTel metric instruments.
 type recorderInstruments struct {
@@ -204,6 +220,40 @@ func truncateOutput(s string, limit int) string {
 		truncated = truncated[:len(truncated)-1]
 	}
 	return truncated + "…"
+}
+
+var bdSecretArgs = map[string]struct{}{
+	"--password":        {},
+	"--remote-password": {},
+	"--token":           {},
+	"--api-key":         {},
+	"--bearer":          {},
+}
+
+func sanitizeBDArgs(args []string) []string {
+	out := append([]string(nil), args...)
+	for i := 0; i < len(out); i++ {
+		arg := out[i]
+		if flag, _, ok := strings.Cut(arg, "="); ok {
+			if _, secret := bdSecretArgs[flag]; secret {
+				out[i] = flag + "=<redacted>"
+			}
+			continue
+		}
+		if _, secret := bdSecretArgs[arg]; secret && i+1 < len(out) {
+			i++
+			out[i] = "<redacted>"
+		}
+	}
+	return out
+}
+
+func logStringSlice(key string, values []string) otellog.KeyValue {
+	otelValues := make([]otellog.Value, 0, len(values))
+	for _, value := range values {
+		otelValues = append(otelValues, otellog.StringValue(value))
+	}
+	return otellog.Slice(key, otelValues...)
 }
 
 // RecordAgentStart records an agent session start (metrics + log event).
@@ -403,6 +453,7 @@ func RecordBDCall(ctx context.Context, args []string, durationMs float64, err er
 	if len(args) > 0 {
 		subcommand = args[0]
 	}
+	sanitizedArgs := sanitizeBDArgs(args)
 	status := statusStr(err)
 	attrs := metric.WithAttributes(
 		attribute.String("status", status),
@@ -412,7 +463,7 @@ func RecordBDCall(ctx context.Context, args []string, durationMs float64, err er
 	inst.bdDurationHist.Record(ctx, durationMs, attrs)
 	kvs := []otellog.KeyValue{
 		otellog.String("subcommand", subcommand),
-		otellog.String("args", strings.Join(args, " ")),
+		otellog.String("args", strings.Join(sanitizedArgs, " ")),
 		otellog.Float64("duration_ms", durationMs),
 		otellog.String("status", status),
 		errKV(err),
@@ -425,6 +476,30 @@ func RecordBDCall(ctx context.Context, args []string, durationMs float64, err er
 		)
 	}
 	emit(ctx, "bd.call", severity(err), kvs...)
+}
+
+// RecordBDSlow records a bd CLI invocation that is still running after the
+// fixed slow-call threshold.
+func RecordBDSlow(ctx context.Context, args []string, dir, agentID string) {
+	event := BDSlowEvent{
+		Timestamp: time.Now().UTC(),
+		Args:      sanitizeBDArgs(args),
+		Dir:       strings.TrimSpace(dir),
+		ElapsedMs: BDSlowThreshold.Milliseconds(),
+		AgentID:   strings.TrimSpace(agentID),
+		Threshold: BDSlowThreshold.Milliseconds(),
+	}
+	kvs := []otellog.KeyValue{
+		otellog.String("timestamp", event.Timestamp.Format(time.RFC3339Nano)),
+		logStringSlice("args", event.Args),
+		otellog.String("dir", event.Dir),
+		otellog.Int64("elapsed_ms", event.ElapsedMs),
+		otellog.Int64("threshold_ms", event.Threshold),
+	}
+	if event.AgentID != "" {
+		kvs = append(kvs, otellog.String("agent_id", event.AgentID))
+	}
+	emit(ctx, "bd.slow", otellog.SeverityWarn, kvs...)
 }
 
 // ── Phase 2 recording functions ──────────────────────────────────────────

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -3,10 +3,13 @@ package telemetry
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 
 	otellog "go.opentelemetry.io/otel/log"
+	otellogglobal "go.opentelemetry.io/otel/log/global"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
 // resetInstruments resets the sync.Once so initInstruments re-runs against
@@ -169,10 +172,155 @@ func TestRecordBDCall_TruncatesLongOutput(t *testing.T) {
 	RecordBDCall(ctx, []string{"cmd"}, 1.0, nil, bigStdout, bigStderr)
 }
 
+func TestSanitizeBDArgsRedactsSecretFlags(t *testing.T) {
+	in := []string{
+		"config", "set",
+		"--token", "sk-secret",
+		"--api-key=api-secret",
+		"--password", "pw-secret",
+		"--remote-password=remote-secret",
+		"--bearer", "bearer-secret",
+		"--not-token", "visible",
+	}
+	original := append([]string(nil), in...)
+
+	got := sanitizeBDArgs(in)
+	want := []string{
+		"config", "set",
+		"--token", "<redacted>",
+		"--api-key=<redacted>",
+		"--password", "<redacted>",
+		"--remote-password=<redacted>",
+		"--bearer", "<redacted>",
+		"--not-token", "visible",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sanitizeBDArgs() = %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(in, original) {
+		t.Fatalf("sanitizeBDArgs mutated input: got %#v, want %#v", in, original)
+	}
+}
+
+func TestRecordBDCallSanitizesArgs(t *testing.T) {
+	resetInstruments(t)
+	exp := installRecordingLogExporter(t)
+
+	RecordBDCall(context.Background(), []string{"config", "set", "--token", "sk-secret"}, 12.5, nil, nil, "")
+
+	rec := exp.recordByBody("bd.call")
+	if rec == nil {
+		t.Fatal("RecordBDCall did not emit bd.call")
+	}
+	attrs := recordAttrs(*rec)
+	if got := attrs["args"].AsString(); got != "config set --token <redacted>" {
+		t.Fatalf("bd.call args = %q, want token redacted", got)
+	}
+}
+
+func TestRecordBDSlowEmitsSanitizedWarnEvent(t *testing.T) {
+	resetInstruments(t)
+	exp := installRecordingLogExporter(t)
+
+	RecordBDSlow(context.Background(), []string{"config", "set", "--token", "sk-secret"}, "/tmp/city", "test-agent-1")
+
+	rec := exp.recordByBody("bd.slow")
+	if rec == nil {
+		t.Fatal("RecordBDSlow did not emit bd.slow")
+	}
+	if got := rec.Severity(); got != otellog.SeverityWarn {
+		t.Fatalf("bd.slow severity = %v, want WARN", got)
+	}
+	attrs := recordAttrs(*rec)
+	if got := logValueStringSlice(attrs["args"]); !reflect.DeepEqual(got, []string{"config", "set", "--token", "<redacted>"}) {
+		t.Fatalf("bd.slow args = %#v, want token redacted", got)
+	}
+	if got := attrs["dir"].AsString(); got != "/tmp/city" {
+		t.Fatalf("bd.slow dir = %q, want /tmp/city", got)
+	}
+	if got := attrs["agent_id"].AsString(); got != "test-agent-1" {
+		t.Fatalf("bd.slow agent_id = %q, want test-agent-1", got)
+	}
+	if got := attrs["elapsed_ms"].AsInt64(); got != BDSlowThreshold.Milliseconds() {
+		t.Fatalf("bd.slow elapsed_ms = %d, want %d", got, BDSlowThreshold.Milliseconds())
+	}
+	if got := attrs["threshold_ms"].AsInt64(); got != BDSlowThreshold.Milliseconds() {
+		t.Fatalf("bd.slow threshold_ms = %d, want %d", got, BDSlowThreshold.Milliseconds())
+	}
+	if got := attrs["timestamp"].AsString(); got == "" {
+		t.Fatal("bd.slow timestamp is empty")
+	}
+}
+
 func TestRecordBeadStoreHealth(t *testing.T) {
 	resetInstruments(t)
 	ctx := context.Background()
 
 	RecordBeadStoreHealth(ctx, "test-city", true)
 	RecordBeadStoreHealth(ctx, "test-city", false)
+}
+
+type recordingLogExporter struct {
+	mu      sync.Mutex
+	records []sdklog.Record
+}
+
+func installRecordingLogExporter(t *testing.T) *recordingLogExporter {
+	t.Helper()
+	exp := &recordingLogExporter{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(exp)))
+	prev := otellogglobal.GetLoggerProvider()
+	otellogglobal.SetLoggerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otellogglobal.SetLoggerProvider(prev)
+	})
+	return exp
+}
+
+func (e *recordingLogExporter) Export(_ context.Context, records []sdklog.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, rec := range records {
+		e.records = append(e.records, rec.Clone())
+	}
+	return nil
+}
+
+func (e *recordingLogExporter) Shutdown(context.Context) error {
+	return nil
+}
+
+func (e *recordingLogExporter) ForceFlush(context.Context) error {
+	return nil
+}
+
+func (e *recordingLogExporter) recordByBody(body string) *sdklog.Record {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for i := range e.records {
+		if e.records[i].Body().AsString() == body {
+			rec := e.records[i].Clone()
+			return &rec
+		}
+	}
+	return nil
+}
+
+func recordAttrs(rec sdklog.Record) map[string]otellog.Value {
+	attrs := make(map[string]otellog.Value)
+	rec.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrs[kv.Key] = kv.Value
+		return true
+	})
+	return attrs
+}
+
+func logValueStringSlice(value otellog.Value) []string {
+	values := value.AsSlice()
+	out := make([]string, 0, len(values))
+	for _, item := range values {
+		out = append(out, item.AsString())
+	}
+	return out
 }

--- a/release-gates/ga-x4m5zv-bd-slow-telemetry-gate.md
+++ b/release-gates/ga-x4m5zv-bd-slow-telemetry-gate.md
@@ -1,0 +1,64 @@
+# Release Gate: bd.slow telemetry on bd-wrapper
+
+Bead: `ga-x4m5zv`
+Source bead: `ga-2k9m`
+Branch: `builder/ga-2k9m-1`
+Commit under review: `ab76170ef`
+Gate run: 2026-05-15 22:11 America/Los_Angeles
+
+## Summary
+
+PASS. The reviewed branch adds `bd.slow` telemetry for long-running `bd`
+subprocesses, sanitizes sensitive `bd` arguments, and includes focused tests for
+slow-call emission, fast-call suppression, and redaction.
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the
+release criteria supplied to the deployer role and the repository testing rules in
+`TESTING.md`.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-x4m5zv` notes contain `Review Verdict: PASS` from `gascity/reviewer`. |
+| 2 | Acceptance criteria met | PASS | Each acceptance criterion is covered by code and tests listed below. |
+| 3 | Tests pass | PASS | `make test` completed with `observable go test: PASS`; `go vet ./...` completed cleanly. |
+| 4 | No high-severity review findings open | PASS | Review notes list only INFO findings; no HIGH, CRITICAL, FAIL, or request-changes findings are present. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before the gate file was added; final clean status is rechecked after committing this gate. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` reported no conflicts. `git diff --check origin/main...HEAD` reported no whitespace errors. |
+
+## Acceptance Criteria Evidence
+
+| Acceptance criterion | Result | Evidence |
+|---------------------|--------|----------|
+| Slow `bd list` emits `bd.slow` at the threshold | PASS | `TestExecCommandRunnerEmitsBDSlowForLongBDCommand` installs a fake `bd` that sleeps past a lowered threshold and asserts a `bd.slow` log record. |
+| Fast `bd list` emits no `bd.slow` event | PASS | `TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand` runs a fast fake `bd`, waits past the lowered threshold, and asserts zero `bd.slow` records. |
+| Secret args are redacted | PASS | `TestSanitizeBDArgsRedactsSecretFlags`, `TestRecordBDCallSanitizesArgs`, and `TestRecordBDSlowEmitsSanitizedWarnEvent` cover `--flag value` and `--flag=value` redaction without mutating caller args. |
+| Fast path adds only timer schedule and stop | PASS | Implementation wires `time.AfterFunc` only for `name == "bd"` and defers `slowTimer.Stop()`; no synchronous telemetry work is added to the successful fast path. |
+
+## Changed Files Reviewed
+
+- `internal/beads/bdstore.go`
+- `internal/beads/bdstore_exec_internal_test.go`
+- `internal/telemetry/recorder.go`
+- `internal/telemetry/recorder_test.go`
+
+## Commands Run
+
+```text
+gc hook gascity/deployer
+bd show ga-x4m5zv
+bd show ga-2k9m
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main
+make test
+go vet ./...
+gh pr list --head quad341:builder/ga-2k9m-1 --state all --json number,url,state,title,headRefName,baseRefName
+```
+
+## Notes
+
+- No existing PR was found for `quad341:builder/ga-2k9m-1`.
+- `origin/main` is not an ancestor of the feature branch, but the branch merges
+  cleanly with current `origin/main`; no deployer-side rebase was performed.


### PR DESCRIPTION
## What this changes

`bd` subprocess calls now emit a WARN-level `bd.slow` telemetry record when a call is still running after the fixed 30 second threshold. The record includes timing, working directory, sanitized arguments, and the current agent identity when one is available.

The same argument sanitizer now also protects existing `bd.call` telemetry, so secret-bearing flags such as `--token`, `--api-key`, and `--password` are redacted before telemetry leaves the wrapper.

## Why this design

The change stays on the existing OpenTelemetry log sink used by `bd.call` instead of adding a new event-bus bridge in this slice. That keeps the implementation limited to the wrapper and telemetry package while still giving operators an early signal before the 120 second wrapper timeout.

## Review notes

- `BDSlowThreshold` is a fixed production constant, not a config knob.
- Sanitization uses a curated flag list and covers both `--flag value` and `--flag=value` forms.
- The slow timer is scheduled only for `bd` subprocesses and is stopped for fast calls.
- This does not add a `gc events` renderer for OpenTelemetry-only records.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] Focused tests cover slow-call emission, fast-call suppression, and secret redaction.
- [x] Release gate: [`release-gates/ga-x4m5zv-bd-slow-telemetry-gate.md`](release-gates/ga-x4m5zv-bd-slow-telemetry-gate.md)