### PR TITLE
feat(dolt): per-DB push refspec in gc dolt sync

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -58,6 +58,12 @@
 #   GC_DOLT_COMPACT_ONLY_DBS              (optional) — comma-separated list of
 #                                         database names to compact. When set,
 #                                         all other databases are skipped.
+#   GC_DOLT_REFSPEC_<DB_UPPER>            (optional) — compact remote push
+#                                         refspec in <local>:<remote> form.
+#                                         DB name is uppercased with '-'
+#                                         replaced by '_' to derive the env
+#                                         key; DB names that differ only by
+#                                         '-' vs '_' share that key.
 set -eu
 
 : "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
@@ -287,6 +293,53 @@ valid_remote_name() {
   esac
 }
 
+valid_branch_name() {
+  branch_candidate="$1"
+  case "$branch_candidate" in
+    -*|.*|*..*|*@{*) return 1 ;;
+    [A-Za-z0-9_.-]*)
+      case "$branch_candidate" in
+        *[!A-Za-z0-9_./-]*) return 1 ;;
+        *) return 0 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+refspec_env_value() {
+  db="$1"
+  valid_database_name "$db" || return 1
+  key=$(printf '%s' "$db" | tr 'a-z-' 'A-Z_')
+  case "$key" in
+    *[!A-Z0-9_]*) return 0 ;;
+  esac
+  eval "printf '%s' \"\${GC_DOLT_REFSPEC_$key:-}\""
+}
+
+refspec_parts() {
+  rs="$1"
+  case "$rs" in
+    *:*)
+      local_branch=${rs%%:*}
+      remote_branch=${rs#*:}
+      ;;
+    *)
+      local_branch="$rs"
+      remote_branch="$rs"
+      ;;
+  esac
+  [ -z "$local_branch" ] && return 1
+  [ -z "$remote_branch" ] && return 1
+  valid_branch_name "$local_branch" || return 1
+  valid_branch_name "$remote_branch" || return 1
+  printf '%s\n%s\n' "$local_branch" "$remote_branch"
+}
+
+warn_refspec_fallback() {
+  printf 'compact: db=%s WARN: active branch unresolved; falling back to main\n' "$1" >&2
+}
+
 is_system_database() {
   system_candidate=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
   case "$system_candidate" in
@@ -365,7 +418,49 @@ query_single_cell() {
   rm -f "$out_tmp" "$err_tmp"
 }
 
-# commit_count — count of commits reachable from main. Bounded scan
+resolve_refspec_sql() {
+  db="$1"
+  if ! valid_database_name "$db"; then
+    printf 'compact: db=%s invalid database name — fail\n' "$db" >&2
+    return 1
+  fi
+
+  active=$(query_single_cell "$db" "active branch probe failed" "SELECT active_branch()" 2>/dev/null || true)
+  active_resolved=0
+  if [ -n "$active" ] && valid_branch_name "$active"; then
+    active_resolved=1
+  fi
+
+  override=$(refspec_env_value "$db") || return 1
+  if [ -n "$override" ]; then
+    parts=$(refspec_parts "$override") || {
+      printf 'compact: db=%s invalid refspec override=%s\n' "$db" "$override" >&2
+      return 1
+    }
+    local_branch=$(printf '%s\n' "$parts" | sed -n '1p')
+    if [ "$active_resolved" != "1" ]; then
+      printf 'compact: db=%s refspec override requires resolved active branch — fail\n' "$db" >&2
+      return 1
+    fi
+    if [ "$local_branch" != "$active" ]; then
+      printf 'compact: db=%s refspec override local branch=%s does not match active branch=%s — fail\n' \
+        "$db" "$local_branch" "$active" >&2
+      return 1
+    fi
+    printf '%s\n' "$parts"
+    return 0
+  fi
+
+  if [ "$active_resolved" = "1" ]; then
+    printf '%s\n%s\n' "$active" "$active"
+    return 0
+  fi
+
+  warn_refspec_fallback "$db"
+  printf 'main\nmain\n'
+}
+
+# commit_count — count of commits reachable from the current branch. Bounded scan
 # (LIMIT 200000) so a runaway DB doesn't tie up the connection.
 commit_count() {
   db="$1"
@@ -373,7 +468,7 @@ commit_count() {
     "SELECT COUNT(*) FROM (SELECT 1 FROM dolt_log LIMIT 200000) AS t"
 }
 
-# root_commit — earliest commit hash on the main branch.
+# root_commit — earliest commit hash on the current branch.
 root_commit() {
   db="$1"
   query_single_cell "$db" "root commit probe failed" \
@@ -486,11 +581,13 @@ fetch_remote() {
   dolt_query "$db" "CALL DOLT_FETCH('$remote')"
 }
 
-remote_main_head() {
+remote_branch_head() {
   db="$1"
   remote="$2"
+  branch="$3"
+  valid_branch_name "$branch" || return 1
   query_single_cell "$db" "remote HEAD probe failed" \
-    "SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/$remote/main'"
+    "SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/$remote/$branch'"
 }
 
 commit_exists_in_local_log() {
@@ -500,15 +597,22 @@ commit_exists_in_local_log() {
     "SELECT COUNT(*) FROM dolt_log WHERE commit_hash = '$hash'"
 }
 
-push_remote_main() {
+push_remote_refspec() {
   db="$1"
   remote="$2"
+  local_branch="$3"
+  remote_branch="$4"
+  if [ "$local_branch" = "$remote_branch" ]; then
+    refspec_arg="$local_branch"
+  else
+    refspec_arg="$local_branch:$remote_branch"
+  fi
   export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
   run_bounded "$push_timeout" \
     dolt --host "$host" --port "$GC_DOLT_PORT" \
     --user "$GC_DOLT_USER" --no-tls \
     --use-db "$db" \
-    sql -r tabular -q "CALL DOLT_PUSH('--force', '--set-upstream', '$remote', 'main')"
+    sql -r tabular -q "CALL DOLT_PUSH('--force', '--set-upstream', '$remote', '$refspec_arg')"
 }
 
 # preflight_counts — write "<table> <count>" lines for all user tables.
@@ -713,12 +817,16 @@ write_pending_push_marker() {
   expected_remote_head_verified="${4:-0}"
   compacted_from_head="${5:-}"
   reason="$6"
+  local_branch="${7:-main}"
+  remote_branch="${8:-$local_branch}"
 
   write_compact_marker "$pending_push_dir" "$db" "$reason" \
     "remote=$remote" \
     "expected_remote_head=$expected_remote_head" \
     "expected_remote_head_verified=$expected_remote_head_verified" \
-    "compacted_from_head=$compacted_from_head"
+    "compacted_from_head=$compacted_from_head" \
+    "local_branch=$local_branch" \
+    "remote_branch=$remote_branch"
 }
 
 compact_marker_value() {
@@ -807,7 +915,17 @@ push_remote_after_compaction() {
   expected_remote_head_verified="${4:-0}"
   push_context="${5:-initial}"
   compacted_from_head="${6:-}"
+  local_branch="${7:-main}"
+  remote_branch="${8:-$local_branch}"
   [ -n "$remote" ] || return 0
+  valid_branch_name "$local_branch" || {
+    printf 'compact: db=%s invalid local branch=%s before remote push\n' "$db" "$local_branch" >&2
+    return 1
+  }
+  valid_branch_name "$remote_branch" || {
+    printf 'compact: db=%s invalid remote branch=%s before remote push\n' "$db" "$remote_branch" >&2
+    return 1
+  }
 
   fetch_rc=0
   fetch_err_tmp=$(mktemp)
@@ -818,16 +936,16 @@ push_remote_after_compaction() {
     emit_error_file "$db" "$fetch_err_tmp"
     rm -f "$fetch_err_tmp"
     write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-      "flatten and full GC succeeded but remote fetch before push failed" || return 1
+      "flatten and full GC succeeded but remote fetch before push failed" "$local_branch" "$remote_branch" || return 1
     return 0
   fi
   rm -f "$fetch_err_tmp"
 
-  if ! latest_remote_head=$(remote_main_head "$db" "$remote"); then
+  if ! latest_remote_head=$(remote_branch_head "$db" "$remote" "$remote_branch"); then
     printf 'compact: db=%s remote=%s HEAD probe failed before push after local compaction\n' \
       "$db" "$remote" >&2
     write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-      "flatten and full GC succeeded but remote HEAD probe before push failed" || return 1
+      "flatten and full GC succeeded but remote HEAD probe before push failed" "$local_branch" "$remote_branch" || return 1
     return 0
   fi
   if [ -n "$latest_remote_head" ]; then
@@ -836,7 +954,7 @@ push_remote_after_compaction() {
         printf 'compact: db=%s remote=%s returned invalid HEAD=%s before push — fail\n' \
           "$db" "$remote" "$latest_remote_head" >&2
         write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-          "flatten and full GC succeeded but remote HEAD before push was invalid" || return 1
+          "flatten and full GC succeeded but remote HEAD before push was invalid" "$local_branch" "$remote_branch" || return 1
         return 0
         ;;
     esac
@@ -852,7 +970,7 @@ push_remote_after_compaction() {
         printf 'compact: db=%s remote=%s HEAD changed during pending push retry expected_HEAD=%s got_HEAD=<empty> — deferred for next run; manual reconciliation required if this persists\n' \
           "$db" "$remote" "${expected_remote_head:-<empty>}" >&2
         write_pending_push_marker "$db" "$remote" "" 0 "$compacted_from_head" \
-          "remote push retry deferred: remote HEAD changed during pending push retry" || return 1
+          "remote push retry deferred: remote HEAD changed during pending push retry" "$local_branch" "$remote_branch" || return 1
         return 1
       fi
       printf 'compact: db=%s remote=%s HEAD changed during pending push retry expected_HEAD=%s got_HEAD=%s — verifying latest remote HEAD\n' \
@@ -863,7 +981,7 @@ push_remote_after_compaction() {
       printf 'compact: db=%s remote=%s HEAD changed before push expected_HEAD=%s got_HEAD=%s — leaving local compaction pending remote repair\n' \
         "$db" "$remote" "${expected_remote_head:-<empty>}" "${latest_remote_head:-<empty>}" >&2
       write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-        "flatten and full GC succeeded but remote HEAD changed before push" || return 1
+        "flatten and full GC succeeded but remote HEAD changed before push" "$local_branch" "$remote_branch" || return 1
       return 0
     fi
   fi
@@ -877,7 +995,7 @@ push_remote_after_compaction() {
         printf 'compact: db=%s remote=%s HEAD=%s ancestry probe failed before push after local compaction\n' \
           "$db" "$remote" "$latest_remote_head" >&2
         write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-          "flatten and full GC succeeded but remote ancestry probe before push failed" || return 1
+          "flatten and full GC succeeded but remote ancestry probe before push failed" "$local_branch" "$remote_branch" || return 1
         return 0
       fi
       case "$in_local" in
@@ -891,20 +1009,20 @@ push_remote_after_compaction() {
             printf 'compact: db=%s remote=%s HEAD=%s remains absent from local history — deferred for next run; manual reconciliation required if this persists\n' \
               "$db" "$remote" "$latest_remote_head" >&2
             write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-              "remote push retry deferred: remote has unique commits not in local history" || return 1
+              "remote push retry deferred: remote has unique commits not in local history" "$local_branch" "$remote_branch" || return 1
             return 1
           fi
           printf 'compact: db=%s remote=%s HEAD=%s was not verified in local history before flatten — leaving local compaction pending remote repair\n' \
             "$db" "$remote" "$latest_remote_head" >&2
           write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-            "flatten and full GC succeeded but remote has unique commits not in local history" || return 1
+            "flatten and full GC succeeded but remote has unique commits not in local history" "$local_branch" "$remote_branch" || return 1
           return 0
           ;;
         *)
           printf 'compact: db=%s remote=%s ancestry probe returned invalid value=%s before push after local compaction\n' \
             "$db" "$remote" "$in_local" >&2
           write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-            "flatten and full GC succeeded but remote ancestry probe returned invalid result" || return 1
+            "flatten and full GC succeeded but remote ancestry probe returned invalid result" "$local_branch" "$remote_branch" || return 1
           return 0
           ;;
       esac
@@ -913,19 +1031,19 @@ push_remote_after_compaction() {
 
   push_rc=0
   push_err_tmp=$(mktemp)
-  push_remote_main "$db" "$remote" >/dev/null 2>"$push_err_tmp" || push_rc=$?
+  push_remote_refspec "$db" "$remote" "$local_branch" "$remote_branch" >/dev/null 2>"$push_err_tmp" || push_rc=$?
   if [ "$push_rc" -ne 0 ]; then
     printf 'compact: db=%s remote=%s push failed rc=%s after local compaction\n' \
       "$db" "$remote" "$push_rc" >&2
     emit_error_file "$db" "$push_err_tmp"
     rm -f "$push_err_tmp"
     write_pending_push_marker "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "$compacted_from_head" \
-      "flatten and full GC succeeded but remote push failed" || return 1
+      "flatten and full GC succeeded but remote push failed" "$local_branch" "$remote_branch" || return 1
     return 0
   fi
   rm -f "$push_err_tmp"
   clear_compact_marker "$pending_push_dir" "$db"
-  printf 'compact: db=%s remote=%s pushed compacted main\n' "$db" "$remote"
+  printf 'compact: db=%s remote=%s pushed compacted %s\n' "$db" "$remote" "$remote_branch"
   return 0
 }
 
@@ -1018,9 +1136,23 @@ flatten_database() {
     pending_expected_remote_head=$(compact_marker_value "$pending_gc_dir" "$db" expected_remote_head || true)
     pending_expected_remote_head_verified=$(compact_marker_value "$pending_gc_dir" "$db" expected_remote_head_verified || true)
     pending_compacted_from_head=$(compact_marker_value "$pending_gc_dir" "$db" compacted_from_head || true)
+    pending_local_branch=$(compact_marker_value "$pending_gc_dir" "$db" local_branch || true)
+    pending_remote_branch=$(compact_marker_value "$pending_gc_dir" "$db" remote_branch || true)
+    [ -n "$pending_local_branch" ] || pending_local_branch="main"
+    [ -n "$pending_remote_branch" ] || pending_remote_branch="$pending_local_branch"
     if [ -n "$pending_remote" ] && ! valid_remote_name "$pending_remote"; then
       printf 'compact: db=%s pending_gc marker has invalid remote=%s — manual intervention required\n' \
         "$db" "$pending_remote" >&2
+      return 1
+    fi
+    if ! valid_branch_name "$pending_local_branch"; then
+      printf 'compact: db=%s pending_gc marker has invalid local_branch=%s — manual intervention required\n' \
+        "$db" "$pending_local_branch" >&2
+      return 1
+    fi
+    if ! valid_branch_name "$pending_remote_branch"; then
+      printf 'compact: db=%s pending_gc marker has invalid remote_branch=%s — manual intervention required\n' \
+        "$db" "$pending_remote_branch" >&2
       return 1
     fi
     if [ -n "$pending_expected_remote_head" ]; then
@@ -1057,7 +1189,7 @@ flatten_database() {
     start=$(date +%s)
     if run_full_gc "$db" "pending-GC retry" "pending-GC retry" "$start"; then
       push_rc=0
-      push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head" || push_rc=$?
+      push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head" "$pending_local_branch" "$pending_remote_branch" || push_rc=$?
       if [ "$push_rc" -eq 0 ] || { [ -n "$pending_remote" ] && has_compact_marker "$pending_push_dir" "$db"; }; then
         clear_compact_marker "$pending_gc_dir" "$db"
       fi
@@ -1075,9 +1207,23 @@ flatten_database() {
     pending_expected_remote_head=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head || true)
     pending_expected_remote_head_verified=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head_verified || true)
     pending_compacted_from_head=$(compact_marker_value "$pending_push_dir" "$db" compacted_from_head || true)
+    pending_local_branch=$(compact_marker_value "$pending_push_dir" "$db" local_branch || true)
+    pending_remote_branch=$(compact_marker_value "$pending_push_dir" "$db" remote_branch || true)
+    [ -n "$pending_local_branch" ] || pending_local_branch="main"
+    [ -n "$pending_remote_branch" ] || pending_remote_branch="$pending_local_branch"
     if [ -z "$pending_remote" ]; then
       printf 'compact: db=%s pending_push marker is missing remote — manual intervention required\n' \
         "$db" >&2
+      return 1
+    fi
+    if ! valid_branch_name "$pending_local_branch"; then
+      printf 'compact: db=%s pending_push marker has invalid local_branch=%s — manual intervention required\n' \
+        "$db" "$pending_local_branch" >&2
+      return 1
+    fi
+    if ! valid_branch_name "$pending_remote_branch"; then
+      printf 'compact: db=%s pending_push marker has invalid remote_branch=%s — manual intervention required\n' \
+        "$db" "$pending_remote_branch" >&2
       return 1
     fi
     if ! valid_remote_name "$pending_remote"; then
@@ -1114,7 +1260,7 @@ flatten_database() {
     fi
     ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
     printf 'compact: db=%s pending_push=present — retrying remote push before threshold check\n' "$db"
-    push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head"
+    push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head" "$pending_local_branch" "$pending_remote_branch"
     return $?
   fi
 
@@ -1163,6 +1309,8 @@ flatten_database() {
   fi
 
   remote=""
+  local_branch="main"
+  remote_branch="main"
   expected_remote_head=""
   expected_remote_head_verified=0
   if probed_remote=$(select_remote "$db"); then
@@ -1177,6 +1325,10 @@ flatten_database() {
       return 1
     fi
 
+    refspec_pair=$(resolve_refspec_sql "$db") || return 1
+    local_branch=$(printf '%s\n' "$refspec_pair" | sed -n '1p')
+    remote_branch=$(printf '%s\n' "$refspec_pair" | sed -n '2p')
+
     printf 'compact: db=%s remote=%s — fetching before flatten...\n' "$db" "$remote"
     fetch_rc=0
     fetch_err_tmp=$(mktemp)
@@ -1186,7 +1338,7 @@ flatten_database() {
         "$db" "$remote" "$fetch_rc" >&2
       emit_error_file "$db" "$fetch_err_tmp"
     else
-      if ! remote_head=$(remote_main_head "$db" "$remote"); then
+      if ! remote_head=$(remote_branch_head "$db" "$remote" "$remote_branch"); then
         rm -f "$fetch_err_tmp"
         return 1
       fi
@@ -1362,13 +1514,15 @@ flatten_database() {
   if run_full_gc "$db" "flatten ok commits=$count->${after_count:-?} but" \
     "commits=$count->${after_count:-?}" "$start"; then
     clear_compact_marker "$pending_gc_dir" "$db"
-    push_remote_after_compaction "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "initial" "$compacted_from_head"
+    push_remote_after_compaction "$db" "$remote" "$expected_remote_head" "$expected_remote_head_verified" "initial" "$compacted_from_head" "$local_branch" "$remote_branch"
     return $?
   fi
   write_compact_marker "$pending_gc_dir" "$db" "flatten succeeded but full GC failed" \
     "remote=$remote" "expected_remote_head=$expected_remote_head" \
     "expected_remote_head_verified=$expected_remote_head_verified" \
-    "compacted_from_head=$compacted_from_head" || return 1
+    "compacted_from_head=$compacted_from_head" \
+    "local_branch=$local_branch" \
+    "remote_branch=$remote_branch" || return 1
   return 1
 }
 

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -3,10 +3,20 @@
 #
 # Uses the live Dolt SQL server when reachable so sync does not restart
 # active databases. Falls back to CLI mode only when no server is running.
-# Pushes committed `main` branch state only; it does not auto-commit working
+# Pushes committed branch state only; it does not auto-commit working
 # changes before pushing.
 # Use --gc to purge closed ephemeral beads before syncing.
 # Use --dry-run to preview without pushing.
+#
+# Refspec resolution (per database):
+#   1. GC_DOLT_REFSPEC_<DB_UPPER> env var override, in <local>:<remote> form
+#      (e.g. GC_DOLT_REFSPEC_GA=main:gascity-3). DB name is uppercased with
+#      '-' replaced by '_' to derive the env var key.
+#   2. Default: the database's active branch is pushed to a same-named branch
+#      on the remote (i.e. <active>:<active>). This works transparently for the
+#      common case where local and remote branch names match, including 'main'
+#      on legacy setups.
+#   3. Fallback when active_branch() cannot be resolved (or in CLI mode): 'main'.
 #
 # Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_USER, GC_DOLT_PASSWORD
 set -e
@@ -101,6 +111,48 @@ valid_remote_name() {
   esac
 }
 
+valid_branch_name() {
+  case "$1" in
+    [A-Za-z0-9_.-]*)
+      case "$1" in *[!A-Za-z0-9_./-]*) return 1 ;; *) return 0 ;; esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# refspec_env_value <db> — emit the GC_DOLT_REFSPEC_<DB_UPPER> override, if any.
+# DB name is uppercased and '-' is replaced with '_' to form a valid env key.
+refspec_env_value() {
+  db="$1"
+  key=$(printf '%s' "$db" | tr 'a-z-' 'A-Z_')
+  case "$key" in
+    *[!A-Z0-9_]*) return 0 ;;
+  esac
+  eval "printf '%s' \"\${GC_DOLT_REFSPEC_$key:-}\""
+}
+
+# refspec_parts <refspec> — split <local>:<remote> into two lines.
+# A bare <branch> expands to <branch>:<branch>. Returns 1 if either side is
+# empty or invalid.
+refspec_parts() {
+  rs="$1"
+  case "$rs" in
+    *:*)
+      l=${rs%%:*}
+      r=${rs#*:}
+      ;;
+    *)
+      l="$rs"
+      r="$rs"
+      ;;
+  esac
+  [ -z "$l" ] && return 1
+  [ -z "$r" ] && return 1
+  valid_branch_name "$l" || return 1
+  valid_branch_name "$r" || return 1
+  printf '%s\n%s\n' "$l" "$r"
+}
+
 dolt_sql() {
   query="$1"
   host="${GC_DOLT_HOST:-127.0.0.1}"
@@ -113,6 +165,54 @@ find_remote_sql() {
   db="$1"
   remote_csv=$(dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes LIMIT 1") || return 1
   printf '%s\n' "$remote_csv" | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
+}
+
+# resolve_refspec_sql <db> — emit two lines: local-branch and remote-branch.
+# Honors GC_DOLT_REFSPEC_<DB> first, then falls back to active_branch() over SQL,
+# then to 'main' if both fail.
+resolve_refspec_sql() {
+  db="$1"
+  override=$(refspec_env_value "$db")
+  if [ -n "$override" ]; then
+    parts=$(refspec_parts "$override") || {
+      echo "  $db: ERROR: invalid refspec override: $override" >&2
+      return 1
+    }
+    printf '%s\n' "$parts"
+    return 0
+  fi
+  active_csv=$(dolt_sql "USE \`$db\`; SELECT active_branch()" 2>/dev/null || true)
+  active=$(printf '%s\n' "$active_csv" | awk 'NR > 1 && $0 != "" {gsub(/^"|"$/, ""); print; exit}')
+  if [ -n "$active" ] && valid_branch_name "$active"; then
+    printf '%s\n%s\n' "$active" "$active"
+    return 0
+  fi
+  printf 'main\nmain\n'
+}
+
+# resolve_refspec_cli <db-dir> <db-name> — same as resolve_refspec_sql, but
+# resolves the active branch from repo_state.json when the SQL server is down.
+resolve_refspec_cli() {
+  d="$1"
+  db="$2"
+  override=$(refspec_env_value "$db")
+  if [ -n "$override" ]; then
+    parts=$(refspec_parts "$override") || {
+      echo "  $db: ERROR: invalid refspec override: $override" >&2
+      return 1
+    }
+    printf '%s\n' "$parts"
+    return 0
+  fi
+  state="$d/.dolt/repo_state.json"
+  if [ -f "$state" ]; then
+    head=$(sed -n 's/.*"head"[[:space:]]*:[[:space:]]*"refs\/heads\/\([^"]*\)".*/\1/p' "$state" | head -1)
+    if [ -n "$head" ] && valid_branch_name "$head"; then
+      printf '%s\n%s\n' "$head" "$head"
+      return 0
+    fi
+  fi
+  printf 'main\nmain\n'
 }
 
 sync_database_sql() {
@@ -137,18 +237,28 @@ sync_database_sql() {
     return 1
   fi
 
+  refspec_pair=$(resolve_refspec_sql "$name") || return 1
+  local_branch=$(printf '%s\n' "$refspec_pair" | sed -n '1p')
+  remote_branch=$(printf '%s\n' "$refspec_pair" | sed -n '2p')
+
   if [ "$dry_run" = true ]; then
-    echo "  $name: would push to $remote_url"
+    echo "  $name: would push $local_branch -> $remote_name:$remote_branch ($remote_url)"
     return 0
   fi
 
-  if [ "$force" = true ]; then
-    push_query="USE \`$name\`; CALL DOLT_PUSH('--force', '--set-upstream', '$remote_name', 'main')"
+  if [ "$local_branch" = "$remote_branch" ]; then
+    refspec_arg="$local_branch"
   else
-    push_query="USE \`$name\`; CALL DOLT_PUSH('$remote_name', 'main')"
+    refspec_arg="$local_branch:$remote_branch"
+  fi
+
+  if [ "$force" = true ]; then
+    push_query="USE \`$name\`; CALL DOLT_PUSH('--force', '--set-upstream', '$remote_name', '$refspec_arg')"
+  else
+    push_query="USE \`$name\`; CALL DOLT_PUSH('$remote_name', '$refspec_arg')"
   fi
   if dolt_sql "$push_query" >/dev/null 2>&1; then
-    echo "  $name: pushed to $remote_url"
+    echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote_url)"
     return 0
   fi
 
@@ -178,18 +288,28 @@ sync_database_cli() {
     return 1
   fi
 
+  refspec_pair=$(resolve_refspec_cli "$d" "$name") || return 1
+  local_branch=$(printf '%s\n' "$refspec_pair" | sed -n '1p')
+  remote_branch=$(printf '%s\n' "$refspec_pair" | sed -n '2p')
+
   if [ "$dry_run" = true ]; then
-    echo "  $name: would push to $remote"
+    echo "  $name: would push $local_branch -> $remote_name:$remote_branch ($remote)"
     return 0
   fi
 
+  if [ "$local_branch" = "$remote_branch" ]; then
+    refspec_arg="$local_branch"
+  else
+    refspec_arg="$local_branch:$remote_branch"
+  fi
+
   if [ "$force" = true ]; then
-    if (cd "$d" && dolt push --force --set-upstream "$remote_name" main 2>&1); then
-      echo "  $name: pushed to $remote"
+    if (cd "$d" && dolt push --force --set-upstream "$remote_name" "$refspec_arg" 2>&1); then
+      echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote)"
       return 0
     fi
-  elif (cd "$d" && dolt push "$remote_name" main 2>&1); then
-    echo "  $name: pushed to $remote"
+  elif (cd "$d" && dolt push "$remote_name" "$refspec_arg" 2>&1); then
+    echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote)"
     return 0
   fi
 

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -11,7 +11,8 @@
 # Refspec resolution (per database):
 #   1. GC_DOLT_REFSPEC_<DB_UPPER> env var override, in <local>:<remote> form
 #      (e.g. GC_DOLT_REFSPEC_GA=main:gascity-3). DB name is uppercased with
-#      '-' replaced by '_' to derive the env var key.
+#      '-' replaced by '_' to derive the env var key; database names that
+#      differ only by '-' vs '_' intentionally share the same env var key.
 #   2. Default: the database's active branch is pushed to a same-named branch
 #      on the remote (i.e. <active>:<active>). This works transparently for the
 #      common case where local and remote branch names match, including 'main'
@@ -113,6 +114,7 @@ valid_remote_name() {
 
 valid_branch_name() {
   case "$1" in
+    -*|.*|*..*|*@{*) return 1 ;;
     [A-Za-z0-9_.-]*)
       case "$1" in *[!A-Za-z0-9_./-]*) return 1 ;; *) return 0 ;; esac
       ;;
@@ -124,11 +126,16 @@ valid_branch_name() {
 # DB name is uppercased and '-' is replaced with '_' to form a valid env key.
 refspec_env_value() {
   db="$1"
+  valid_database_name "$db" || return 1
   key=$(printf '%s' "$db" | tr 'a-z-' 'A-Z_')
   case "$key" in
     *[!A-Z0-9_]*) return 0 ;;
   esac
   eval "printf '%s' \"\${GC_DOLT_REFSPEC_$key:-}\""
+}
+
+warn_refspec_fallback() {
+  printf '  %s: WARN: active branch unresolved; falling back to main\n' "$1" >&2
 }
 
 # refspec_parts <refspec> — split <local>:<remote> into two lines.
@@ -172,7 +179,11 @@ find_remote_sql() {
 # then to 'main' if both fail.
 resolve_refspec_sql() {
   db="$1"
-  override=$(refspec_env_value "$db")
+  if ! valid_database_name "$db"; then
+    echo "  $db: ERROR: invalid database name" >&2
+    return 1
+  fi
+  override=$(refspec_env_value "$db") || return 1
   if [ -n "$override" ]; then
     parts=$(refspec_parts "$override") || {
       echo "  $db: ERROR: invalid refspec override: $override" >&2
@@ -181,21 +192,53 @@ resolve_refspec_sql() {
     printf '%s\n' "$parts"
     return 0
   fi
-  active_csv=$(dolt_sql "USE \`$db\`; SELECT active_branch()" 2>/dev/null || true)
-  active=$(printf '%s\n' "$active_csv" | awk 'NR > 1 && $0 != "" {gsub(/^"|"$/, ""); print; exit}')
-  if [ -n "$active" ] && valid_branch_name "$active"; then
-    printf '%s\n%s\n' "$active" "$active"
-    return 0
+  if active_csv=$(dolt_sql "USE \`$db\`; SELECT active_branch()" 2>/dev/null); then
+    active=$(printf '%s\n' "$active_csv" | awk 'NR > 1 && $0 != "" {gsub(/^"|"$/, ""); print; exit}')
+    if [ -n "$active" ] && valid_branch_name "$active"; then
+      printf '%s\n%s\n' "$active" "$active"
+      return 0
+    fi
   fi
+  warn_refspec_fallback "$db"
   printf 'main\nmain\n'
 }
 
 # resolve_refspec_cli <db-dir> <db-name> — same as resolve_refspec_sql, but
 # resolves the active branch from repo_state.json when the SQL server is down.
+repo_state_active_branch() {
+  awk '
+    function emit(line) {
+      sub(/.*"head"[[:space:]]*:[[:space:]]*"refs\/heads\//, "", line)
+      sub(/".*/, "", line)
+      print line
+      exit
+    }
+    {
+      line = $0
+      if (depth == 1 && line ~ /^[[:space:]]*"head"[[:space:]]*:[[:space:]]*"refs\/heads\//) {
+        emit(line)
+      }
+      if (depth == 0 && line ~ /^[[:space:]]*\{[[:space:]]*"head"[[:space:]]*:[[:space:]]*"refs\/heads\//) {
+        emit(line)
+      }
+      opens = gsub(/\{/, "{", line)
+      closes = gsub(/\}/, "}", line)
+      depth += opens - closes
+      if (depth < 0) {
+        depth = 0
+      }
+    }
+  ' "$1"
+}
+
 resolve_refspec_cli() {
   d="$1"
   db="$2"
-  override=$(refspec_env_value "$db")
+  if ! valid_database_name "$db"; then
+    echo "  $db: ERROR: invalid database name" >&2
+    return 1
+  fi
+  override=$(refspec_env_value "$db") || return 1
   if [ -n "$override" ]; then
     parts=$(refspec_parts "$override") || {
       echo "  $db: ERROR: invalid refspec override: $override" >&2
@@ -206,12 +249,13 @@ resolve_refspec_cli() {
   fi
   state="$d/.dolt/repo_state.json"
   if [ -f "$state" ]; then
-    head=$(sed -n 's/.*"head"[[:space:]]*:[[:space:]]*"refs\/heads\/\([^"]*\)".*/\1/p' "$state" | head -1)
+    head=$(repo_state_active_branch "$state" | head -1)
     if [ -n "$head" ] && valid_branch_name "$head"; then
       printf '%s\n%s\n' "$head" "$head"
       return 0
     fi
   fi
+  warn_refspec_fallback "$db"
   printf 'main\nmain\n'
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -344,7 +344,7 @@ set_hash() {
 case "$query" in
   *"SELECT COUNT(*) FROM dolt_remotes WHERE name = 'origin'"*)
     case "$mode" in
-      remote_success|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|multiple_remotes_with_origin)
+      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|multiple_remotes_with_origin)
         print_cell 1
         ;;
       *)
@@ -366,7 +366,7 @@ case "$query" in
     ;;
   *"SELECT COUNT(*) FROM dolt_remotes"*)
     case "$mode" in
-      remote_success|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure)
+      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure)
         print_cell 1
         ;;
       multiple_remotes_with_origin|multiple_remotes_no_origin)
@@ -383,7 +383,7 @@ case "$query" in
     ;;
   *"SELECT name FROM dolt_remotes ORDER BY name LIMIT 1"*)
     case "$mode" in
-      remote_success|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|multiple_remotes_with_origin)
+      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|multiple_remotes_with_origin)
         print_cell origin
         ;;
       explicit_backup_remote)
@@ -418,6 +418,16 @@ case "$query" in
   *"DOLT_FETCH('backup')"*)
     exit 0
     ;;
+  *"SELECT active_branch()"*)
+    if [ "$mode" = "remote_active_branch" ]; then
+      print_cell gascity-3
+    elif [ "$mode" = "remote_invalid_active_branch" ]; then
+      print_cell --force
+    else
+      print_cell main
+    fi
+    exit 0
+    ;;
   *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/main'"*)
     if [ "$mode" = "remote_advances_before_push" ]; then
       calls_file="$state_file.remote-head-calls"
@@ -439,6 +449,14 @@ case "$query" in
     else
       print_cell headcommit
     fi
+    exit 0
+    ;;
+  *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/gascity-3'"*)
+    print_cell headcommit
+    exit 0
+    ;;
+  *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/trunk'"*)
+    print_cell headcommit
     exit 0
     ;;
   *"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/backup/main'"*)
@@ -610,6 +628,19 @@ case "$query" in
     fi
     exit 0
     ;;
+  *"DOLT_PUSH('--force', '--set-upstream', 'origin', 'gascity-3')"*)
+    exit 0
+    ;;
+  *"DOLT_PUSH('--force', '--set-upstream', 'origin', 'gascity-3:trunk')"*)
+    exit 0
+    ;;
+  *"DOLT_PUSH('--force', '--set-upstream', 'origin', 'main:gascity-3')"*)
+    if [ "$mode" = "remote_push_failure" ] || [ "$mode" = "remote_empty_head_push_failure" ]; then
+      printf 'push unavailable\n' >&2
+      exit 53
+    fi
+    exit 0
+    ;;
   *"DOLT_PUSH('--force', '--set-upstream', 'backup', 'main')"*)
     exit 0
     ;;
@@ -702,6 +733,119 @@ func TestCompactScriptRefetchesAndForcePushesRemote(t *testing.T) {
 	}
 	if strings.Count(log, "CALL DOLT_FETCH('origin')") < 2 {
 		t.Fatalf("compact should re-fetch immediately before remote push:\n%s", log)
+	}
+}
+
+func TestCompactScriptPushesActiveBranchToRemote(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_active_branch", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote=origin pushed compacted gascity-3") {
+		t.Fatalf("output missing active-branch remote push success:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{
+		"SELECT active_branch()",
+		"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/gascity-3'",
+		"CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'gascity-3')",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("dolt log missing %q:\n%s", want, log)
+		}
+	}
+	if strings.Contains(log, "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") {
+		t.Fatalf("compact must not hardcode main for non-main active branch:\n%s", log)
+	}
+}
+
+func TestCompactScriptUsesRefspecEnvOverrideForRemoteBranch(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_active_branch",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_REFSPEC_BEADS=gascity-3:trunk",
+	)
+	if err != nil {
+		t.Fatalf("compact failed with refspec override: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote=origin pushed compacted trunk") {
+		t.Fatalf("output missing refspec remote push success:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{
+		"SELECT active_branch()",
+		"SELECT hash FROM dolt_remote_branches WHERE name = 'remotes/origin/trunk'",
+		"CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'gascity-3:trunk')",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("dolt log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+func TestCompactScriptRejectsRefspecEnvOverrideForDifferentActiveBranch(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_active_branch",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_REFSPEC_BEADS=main:trunk",
+	)
+	if err == nil {
+		t.Fatalf("compact succeeded with mismatched refspec local branch:\n%s", out)
+	}
+	if !strings.Contains(out, "refspec override local branch=main does not match active branch=gascity-3") {
+		t.Fatalf("output missing mismatched refspec error:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	for _, forbidden := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_PUSH"} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("mismatched refspec must block compact before %s:\n%s", forbidden, log)
+		}
+	}
+}
+
+func TestCompactScriptRefspecOptionShapedOverrideFails(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_REFSPEC_BEADS=--force",
+	)
+	if err == nil {
+		t.Fatalf("compact succeeded with option-shaped refspec override:\n%s", out)
+	}
+	if !strings.Contains(out, "invalid refspec override") {
+		t.Fatalf("output missing invalid refspec override error:\n%s", out)
+	}
+}
+
+func TestCompactScriptWarnsWhenActiveBranchFallbacksToMain(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "remote_invalid_active_branch", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact failed after active-branch fallback: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "WARN: active branch unresolved; falling back to main") {
+		t.Fatalf("output missing active-branch fallback warning:\n%s", out)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") {
+		t.Fatalf("fallback should push main after warning:\n%s", log)
 	}
 }
 
@@ -947,6 +1091,45 @@ func TestCompactScriptRetriesPendingPushWhenRemoteHeadBecomesLocalLogAncestor(t 
 	}
 	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
 		t.Fatalf("successful self-healed retry should clear marker, stat err=%v", err)
+	}
+}
+
+func TestCompactScriptRetriesPendingPushWithRefspecRemoteBranch(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_REFSPEC_BEADS=main:gascity-3",
+	)
+	if err != nil {
+		t.Fatalf("initial compact should leave refspec remote push pending: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	marker, err := os.ReadFile(pendingPush)
+	if err != nil {
+		t.Fatalf("initial compact should write pending-push marker: %v", err)
+	}
+	if !strings.Contains(string(marker), "local_branch=main") ||
+		!strings.Contains(string(marker), "remote_branch=gascity-3") {
+		t.Fatalf("pending-push marker should preserve refspec branches:\n%s", marker)
+	}
+
+	secondOut, err := fixture.run(t, "remote_success", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("pending-push retry should use marker refspec: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_push=present") ||
+		!strings.Contains(secondOut, "pushed compacted gascity-3") {
+		t.Fatalf("retry missing refspec remote push explanation:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if !strings.Contains(string(logData), "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main:gascity-3')") {
+		t.Fatalf("pending-push retry should push stored refspec:\n%s", logData)
+	}
+	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
+		t.Fatalf("successful refspec retry should clear marker, stat err=%v", err)
 	}
 }
 

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -54,6 +54,27 @@ exit 0
 	return logPath
 }
 
+func writeSyncFakeDoltActiveBranch(t *testing.T, dir, activeBranch string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+    printf 'name,url\norigin,https://example.invalid/repo\n'
+    ;;
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\n` + activeBranch + `\n'
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return logPath
+}
+
 func writeSyncFakeDoltRemoteLookupFailure(t *testing.T, dir string) string {
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")
@@ -343,5 +364,252 @@ func TestSyncCLIFallbackPushesOriginMain(t *testing.T) {
 	log := string(data)
 	if !strings.Contains(log, "push origin main") {
 		t.Fatalf("CLI fallback should push explicit origin main\nlog:\n%s\noutput:\n%s", log, out)
+	}
+}
+
+// TestSyncPushesActiveBranchWhenSet verifies that when the live SQL server
+// reports a non-'main' active branch, gc dolt sync pushes that branch (to a
+// same-named remote ref) rather than the hardcoded 'main' fallback.
+func TestSyncPushesActiveBranchWhenSet(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltActiveBranch(t, binDir, "gascity-3")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "CALL DOLT_PUSH('origin', 'gascity-3')") {
+		t.Fatalf("expected push of active branch gascity-3, got:\n%s\noutput:\n%s", log, out)
+	}
+	if strings.Contains(log, "CALL DOLT_PUSH('origin', 'main')") {
+		t.Fatalf("unexpected fallback to main:\n%s", log)
+	}
+}
+
+// TestSyncRefspecEnvOverride verifies that GC_DOLT_REFSPEC_<DB> overrides the
+// active-branch default with a <local>:<remote> mapping.
+func TestSyncRefspecEnvOverride(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	// Active branch from SQL is "main"; the env override should win and map
+	// main -> gascity-3 on the remote.
+	doltLog := writeSyncFakeDoltActiveBranch(t, binDir, "main")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_DOLT_REFSPEC_APP=main:gascity-3",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "CALL DOLT_PUSH('origin', 'main:gascity-3')") {
+		t.Fatalf("expected refspec push main:gascity-3, got:\n%s\noutput:\n%s", log, out)
+	}
+}
+
+// TestSyncRefspecEnvOverrideHyphenInDBName verifies that DB names containing
+// hyphens are correctly translated to env-var keys (hyphens -> underscores,
+// lowercase -> uppercase). The DB "my-app" expects GC_DOLT_REFSPEC_MY_APP.
+func TestSyncRefspecEnvOverrideHyphenInDBName(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "my-app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltActiveBranch(t, binDir, "main")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "my-app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_DOLT_REFSPEC_MY_APP=feat-x:trunk",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "CALL DOLT_PUSH('origin', 'feat-x:trunk')") {
+		t.Fatalf("expected refspec push feat-x:trunk for my-app, got:\n%s\noutput:\n%s", log, out)
+	}
+}
+
+// TestSyncCLIFallbackReadsRepoStateForActiveBranch verifies that when the SQL
+// server is unreachable, the CLI fallback reads repo_state.json to determine
+// the active branch instead of defaulting to 'main'.
+func TestSyncCLIFallbackReadsRepoStateForActiveBranch(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	dbDir := filepath.Join(dataDir, "app")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
+		t.Fatalf("write remotes: %v", err)
+	}
+	repoState := `{"head":"refs/heads/gascity-3"}`
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "repo_state.json"), []byte(repoState), 0o644); err != nil {
+		t.Fatalf("write repo_state: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_PORT=1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "push origin gascity-3") {
+		t.Fatalf("CLI fallback should push the repo_state head 'gascity-3', got:\n%s\noutput:\n%s", log, out)
+	}
+}
+
+// TestSyncRefspecInvalidOverrideFails ensures that a malformed
+// GC_DOLT_REFSPEC_<DB> value (e.g. with shell-unsafe characters) causes sync
+// to fail loudly rather than silently fall back.
+func TestSyncRefspecInvalidOverrideFails(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_DOLT_REFSPEC_APP=main:bad branch", // space is invalid in branch name
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected sync to fail on invalid refspec override, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "invalid refspec override") {
+		t.Fatalf("expected error message about invalid refspec override, got:\n%s", out)
 	}
 }

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -75,6 +75,27 @@ exit 0
 	return logPath
 }
 
+func writeSyncFakeDoltInvalidActiveBranch(t *testing.T, dir string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+    printf 'name,url\norigin,https://example.invalid/repo\n'
+    ;;
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\n--force\n'
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return logPath
+}
+
 func writeSyncFakeDoltRemoteLookupFailure(t *testing.T, dir string) string {
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")
@@ -216,6 +237,139 @@ func TestSyncForceUsesSetUpstreamWithLiveSQL(t *testing.T) {
 	want := "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')"
 	if !strings.Contains(log, want) {
 		t.Fatalf("force sync should set upstream\nwant %q\nlog:\n%s\noutput:\n%s", want, log, out)
+	}
+}
+
+func TestSyncForceUsesResolvedActiveBranchWithLiveSQL(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltActiveBranch(t, binDir, "gascity-3")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app", "--force")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync --force failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	want := "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'gascity-3')"
+	if !strings.Contains(log, want) {
+		t.Fatalf("force sync should use resolved active branch\nwant %q\nlog:\n%s\noutput:\n%s", want, log, out)
+	}
+}
+
+func TestSyncForceUsesRefspecEnvOverrideWithLiveSQL(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltActiveBranch(t, binDir, "main")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app", "--force")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_DOLT_REFSPEC_APP=main:gascity-3",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync --force failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	want := "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main:gascity-3')"
+	if !strings.Contains(log, want) {
+		t.Fatalf("force sync should use refspec override\nwant %q\nlog:\n%s\noutput:\n%s", want, log, out)
+	}
+}
+
+func TestSyncDryRunShowsResolvedActiveBranch(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDoltActiveBranch(t, binDir, "gascity-3")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app", "--dry-run")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync --dry-run failed: %v\n%s", err, out)
+	}
+	want := "app: would push gascity-3 -> origin:gascity-3 (https://example.invalid/repo)"
+	if !strings.Contains(string(out), want) {
+		t.Fatalf("dry run output should show resolved refspec\nwant %q\ngot:\n%s", want, out)
 	}
 }
 
@@ -571,6 +725,65 @@ func TestSyncCLIFallbackReadsRepoStateForActiveBranch(t *testing.T) {
 	}
 }
 
+func TestSyncCLIFallbackIgnoresNestedRepoStateHead(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	dbDir := filepath.Join(dataDir, "app")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
+		t.Fatalf("write remotes: %v", err)
+	}
+	repoState := `{
+  "working": {
+    "head": "refs/heads/wrong"
+  },
+  "head": "refs/heads/gascity-3"
+}`
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "repo_state.json"), []byte(repoState), 0o644); err != nil {
+		t.Fatalf("write repo_state: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_PORT=1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "push origin gascity-3") {
+		t.Fatalf("CLI fallback should push top-level repo_state head, got:\n%s\noutput:\n%s", log, out)
+	}
+	if strings.Contains(log, "push origin wrong") {
+		t.Fatalf("CLI fallback must ignore nested repo_state head, got:\n%s\noutput:\n%s", log, out)
+	}
+}
+
 // TestSyncRefspecInvalidOverrideFails ensures that a malformed
 // GC_DOLT_REFSPEC_<DB> value (e.g. with shell-unsafe characters) causes sync
 // to fail loudly rather than silently fall back.
@@ -611,5 +824,92 @@ func TestSyncRefspecInvalidOverrideFails(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "invalid refspec override") {
 		t.Fatalf("expected error message about invalid refspec override, got:\n%s", out)
+	}
+}
+
+func TestSyncRefspecOptionShapedOverrideFails(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_DOLT_REFSPEC_APP=--force",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected sync to fail on option-shaped refspec override, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "invalid refspec override") {
+		t.Fatalf("expected invalid refspec override message, got:\n%s", out)
+	}
+}
+
+func TestSyncWarnsWhenActiveBranchFallbacksToMain(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltInvalidActiveBranch(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "WARN: active branch unresolved; falling back to main") {
+		t.Fatalf("expected fallback warning, got:\n%s", out)
+	}
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "CALL DOLT_PUSH('origin', 'main')") {
+		t.Fatalf("fallback should push main after warning\nlog:\n%s\noutput:\n%s", log, out)
 	}
 }


### PR DESCRIPTION
## Summary

- `gc dolt sync` previously hardcoded `main` as the push refspec, so shared DoltLab repos that hold each city on its own branch (e.g. `gascity-3`) silently failed every 15-minute patrol with `non-fast-forward` or `no common ancestor`. The patrol is the primary live-sync to DoltLab for managed cities, so this left those rigs without a working push path.
- Resolution is now per-database, in this order:
  1. `GC_DOLT_REFSPEC_<DB_UPPER>` env override in `<local>:<remote>` form (e.g. `GC_DOLT_REFSPEC_GA=main:gascity-3`). DB name is uppercased with `-` translated to `_`.
  2. **Default**: push the DB's active branch to a same-named remote ref. The common case where you rename local to match the remote branch (`gascity-3` -> `gascity-3`) now works without any configuration.
  3. **Fallback** when the active branch can't be resolved (or in CLI mode without a `repo_state.json`): the historical `main`. Cities where the active branch is `main` see no behavior change.

The Dolt `dolt backup sync` primitive does not support refspecs (it mirrors all local refs), so `mol-dog-backup.sh` is unchanged — having the local branch match the desired remote name (option 2 above) is the supported way to use `mol-dog-backup` against shared repos.

## Test plan

- [x] Existing tests still pass:
  - `TestSyncUsesLiveSQLWhenManagedServerReachable`
  - `TestSyncForceUsesSetUpstreamWithLiveSQL`
  - `TestSyncSkipsDatabasesWithNoSyncMarker`
  - `TestSyncReportsLiveSQLRemoteLookupFailure`
  - `TestSyncCLIFallbackPushesOriginMain`
- [x] New tests added:
  - `TestSyncPushesActiveBranchWhenSet` — non-`main` active branch reaches the remote
  - `TestSyncRefspecEnvOverride` — `<local>:<remote>` mapping wins over active branch
  - `TestSyncRefspecEnvOverrideHyphenInDBName` — DB names with `-` map correctly to env keys
  - `TestSyncCLIFallbackReadsRepoStateForActiveBranch` — CLI fallback reads `repo_state.json` head
  - `TestSyncRefspecInvalidOverrideFails` — refspecs containing shell-unsafe characters are rejected

Run: `go test -count=1 -run TestSync ./examples/dolt/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)