### PR TITLE
fix: skip symlinked directories in build-image context copy

### DIFF
--- a/cmd/gc/cmd_build_image.go
+++ b/cmd/gc/cmd_build_image.go
@@ -109,6 +109,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 		BaseImage: baseImage,
 		Tag:       tag,
 		RigPaths:  rigs,
+		Stderr:    stderr,
 	}
 	if err := buildimage.AssembleContext(opts); err != nil {
 		fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_build_image_test.go
+++ b/cmd/gc/cmd_build_image_test.go
@@ -153,6 +153,49 @@ name = "test-city"
 	_ = os.RemoveAll(outputDir)
 }
 
+func TestBuildImageRoutesContextWarningsToStderr(t *testing.T) {
+	cityDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".claude", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "test-city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "skill.md"), []byte("# skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(targetDir, filepath.Join(cityDir, ".claude", "skills", "core.gc-agents")); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doBuildImage(
+		[]string{cityDir},
+		"",
+		"gc-agent:latest",
+		nil,
+		false,
+		true,
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("doBuildImage returned %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "skipping symlinked directory") {
+		t.Fatalf("stderr = %q, want skipped directory symlink diagnostic", stderr.String())
+	}
+
+	line := strings.TrimSpace(stdout.String())
+	parts := strings.SplitN(line, ": ", 2)
+	if len(parts) == 2 {
+		_ = os.RemoveAll(parts[1])
+	}
+}
+
 func TestBuildImageCLIRegistered(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	root := newRootCmd(&stdout, &stderr)

--- a/internal/buildimage/context.go
+++ b/internal/buildimage/context.go
@@ -149,6 +149,17 @@ func copyDirFiltered(src, dst string) error {
 			return os.MkdirAll(target, info.Mode())
 		}
 
+		if info.Mode()&os.ModeSymlink != 0 {
+			resolved, err := os.Stat(path)
+			if err != nil {
+				return nil // broken symlink, skip
+			}
+			if resolved.IsDir() {
+				return nil // skip symlinks to directories
+			}
+			return copyFile(path, target, resolved.Mode())
+		}
+
 		return copyFile(path, target, info.Mode())
 	})
 }

--- a/internal/buildimage/context.go
+++ b/internal/buildimage/context.go
@@ -24,6 +24,8 @@ type Options struct {
 	Tag string
 	// RigPaths maps rig name → local repo path for baking rig content.
 	RigPaths map[string]string
+	// Stderr receives non-fatal diagnostics. Defaults to os.Stderr.
+	Stderr io.Writer
 }
 
 // Manifest records what was baked into the image for debugging.
@@ -73,6 +75,10 @@ func AssembleContext(opts Options) error {
 	if opts.BaseImage == "" {
 		opts.BaseImage = "gc-agent:latest"
 	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
 
 	wsDir := filepath.Join(opts.OutputDir, "workspace")
 	if err := os.MkdirAll(wsDir, 0o755); err != nil {
@@ -80,14 +86,14 @@ func AssembleContext(opts Options) error {
 	}
 
 	// Copy city directory contents into workspace, excluding runtime state.
-	if err := copyDirFiltered(opts.CityPath, wsDir); err != nil {
+	if err := copyDirFiltered(opts.CityPath, wsDir, stderr); err != nil {
 		return fmt.Errorf("copying city to workspace: %w", err)
 	}
 
 	// Copy rig paths into workspace.
 	for rigName, rigPath := range opts.RigPaths {
 		rigDst := filepath.Join(wsDir, rigName)
-		if err := copyDirFiltered(rigPath, rigDst); err != nil {
+		if err := copyDirFiltered(rigPath, rigDst, stderr); err != nil {
 			return fmt.Errorf("copying rig %q: %w", rigName, err)
 		}
 	}
@@ -118,7 +124,20 @@ func AssembleContext(opts Options) error {
 }
 
 // copyDirFiltered copies src directory to dst, skipping excluded paths.
-func copyDirFiltered(src, dst string) error {
+// File symlinks are dereferenced and copied with the resolved file's mode,
+// unless the resolved target is excluded. Directory symlinks are skipped with
+// a diagnostic written to stderr. Broken symlinks are skipped; other
+// resolution errors are returned.
+func copyDirFiltered(src, dst string, stderr io.Writer) error {
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	absSrc, err := filepath.Abs(src)
+	if err != nil {
+		return fmt.Errorf("resolving source path %q: %w", src, err)
+	}
+	src = absSrc
+
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -150,18 +169,49 @@ func copyDirFiltered(src, dst string) error {
 		}
 
 		if info.Mode()&os.ModeSymlink != 0 {
-			resolved, err := os.Stat(path)
+			resolvedPath, err := filepath.EvalSymlinks(path)
 			if err != nil {
-				return nil // broken symlink, skip
+				if os.IsNotExist(err) {
+					return nil // broken symlink, skip
+				}
+				return fmt.Errorf("resolving symlink %q: %w", path, err)
+			}
+			resolved, err := os.Stat(resolvedPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil // broken symlink, skip
+				}
+				return fmt.Errorf("stat resolved symlink %q -> %q: %w", path, resolvedPath, err)
 			}
 			if resolved.IsDir() {
-				return nil // skip symlinks to directories
+				fmt.Fprintf(stderr, "skipping symlinked directory %s -> %s in build context\n", path, resolvedPath) //nolint:errcheck // best-effort diagnostic
+				return nil
 			}
-			return copyFile(path, target, resolved.Mode())
+			resolvedRel, err := filepath.Rel(src, resolvedPath)
+			if err != nil {
+				return fmt.Errorf("rel resolved symlink %q -> %q: %w", path, resolvedPath, err)
+			}
+			if excludedPath(resolvedRel) || excludedResolvedPath(resolvedRel) {
+				return nil
+			}
+			return copyFile(resolvedPath, target, resolved.Mode())
 		}
 
 		return copyFile(path, target, info.Mode())
 	})
+}
+
+func excludedResolvedPath(rel string) bool {
+	parts := strings.Split(filepath.ToSlash(filepath.Clean(rel)), "/")
+	for i, part := range parts {
+		if part != citylayout.RuntimeRoot || i == len(parts)-1 {
+			continue
+		}
+		if excludedPath(filepath.Join(parts[i:]...)) {
+			return true
+		}
+	}
+	return false
 }
 
 // copyFile copies a single file.

--- a/internal/buildimage/context_test.go
+++ b/internal/buildimage/context_test.go
@@ -1,9 +1,11 @@
 package buildimage
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/citylayout"
@@ -201,14 +203,45 @@ name = "test-city"
 `)
 	// Create a symlink to a directory (simulates .claude/skills/core.gc-agents).
 	writeFile(t, targetDir, "skill.md", "# skill")
+	writeFile(t, cityDir, ".claude/skills/local.md", "# local")
+	mkdirAll(t, cityDir, ".claude/skills")
 	if err := os.Symlink(targetDir, filepath.Join(cityDir, ".claude", "skills", "core.gc-agents")); err != nil {
-		// Need to create the parent first.
-		if err2 := os.MkdirAll(filepath.Join(cityDir, ".claude", "skills"), 0o755); err2 != nil {
-			t.Fatal(err2)
-		}
-		if err2 := os.Symlink(targetDir, filepath.Join(cityDir, ".claude", "skills", "core.gc-agents")); err2 != nil {
-			t.Fatal(err2)
-		}
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	err := AssembleContext(Options{
+		CityPath:  cityDir,
+		OutputDir: outputDir,
+		Stderr:    &stderr,
+	})
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "skipping symlinked directory") ||
+		!strings.Contains(stderr.String(), filepath.Join(".claude", "skills", "core.gc-agents")) {
+		t.Fatalf("stderr = %q, want skipped directory symlink diagnostic", stderr.String())
+	}
+
+	// Symlinked directory should be skipped, not cause an error.
+	assertFileNotExists(t, outputDir, "workspace/.claude/skills/core.gc-agents")
+	assertFileExists(t, outputDir, "workspace/.claude/skills/local.md")
+}
+
+func TestAssembleContextCopiesRegularFileSymlink(t *testing.T) {
+	cityDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	writeFile(t, cityDir, "city.toml", `[workspace]
+name = "test-city"
+`)
+	writeFile(t, cityDir, "targets/source.txt", "linked content")
+	if err := os.Chmod(filepath.Join(cityDir, "targets", "source.txt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mkdirAll(t, cityDir, "prompts")
+	if err := os.Symlink(filepath.Join(cityDir, "targets", "source.txt"), filepath.Join(cityDir, "prompts", "linked.txt")); err != nil {
+		t.Fatal(err)
 	}
 
 	err := AssembleContext(Options{
@@ -219,8 +252,189 @@ name = "test-city"
 		t.Fatalf("AssembleContext: %v", err)
 	}
 
-	// Symlinked directory should be skipped, not cause an error.
-	assertFileNotExists(t, outputDir, "workspace/.claude/skills/core.gc-agents")
+	got, err := os.ReadFile(filepath.Join(outputDir, "workspace", "prompts", "linked.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "linked content" {
+		t.Fatalf("linked file content = %q, want linked content", got)
+	}
+	info, err := os.Stat(filepath.Join(outputDir, "workspace", "prompts", "linked.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("linked file mode = %v, want 0600", got)
+	}
+}
+
+func TestAssembleContextCopiesAbsoluteFileSymlinkFromRelativeCityPath(t *testing.T) {
+	parentDir := t.TempDir()
+	cityDir := filepath.Join(parentDir, "city")
+	outputDir := filepath.Join(parentDir, "out")
+	targetDir := t.TempDir()
+	targetFile := filepath.Join(targetDir, "source.txt")
+
+	writeFile(t, cityDir, "city.toml", `[workspace]
+name = "test-city"
+`)
+	writeFile(t, targetDir, "source.txt", "linked content")
+	mkdirAll(t, cityDir, "prompts")
+	if err := os.Symlink(targetFile, filepath.Join(cityDir, "prompts", "linked.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(parentDir)
+	err := AssembleContext(Options{
+		CityPath:  "city",
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(outputDir, "workspace", "prompts", "linked.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "linked content" {
+		t.Fatalf("linked file content = %q, want linked content", got)
+	}
+}
+
+func TestAssembleContextCopiesAbsoluteFileSymlinkFromRelativeRigPath(t *testing.T) {
+	parentDir := t.TempDir()
+	cityDir := filepath.Join(parentDir, "city")
+	rigDir := filepath.Join(parentDir, "rig")
+	outputDir := filepath.Join(parentDir, "out")
+	targetDir := t.TempDir()
+	targetFile := filepath.Join(targetDir, "source.txt")
+
+	writeFile(t, cityDir, "city.toml", `[workspace]
+name = "test-city"
+`)
+	writeFile(t, targetDir, "source.txt", "linked rig content")
+	mkdirAll(t, rigDir, "docs")
+	if err := os.Symlink(targetFile, filepath.Join(rigDir, "docs", "linked.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(parentDir)
+	err := AssembleContext(Options{
+		CityPath:  "city",
+		OutputDir: outputDir,
+		RigPaths:  map[string]string{"demo": "rig"},
+	})
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(outputDir, "workspace", "demo", "docs", "linked.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "linked rig content" {
+		t.Fatalf("linked rig file content = %q, want linked rig content", got)
+	}
+}
+
+func TestAssembleContextSkipsFileSymlinkToExcludedTarget(t *testing.T) {
+	cityDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	writeFile(t, cityDir, "city.toml", `[workspace]
+name = "test-city"
+`)
+	writeFile(t, cityDir, filepath.Join(citylayout.RuntimeRoot, "runtime", "private.txt"), "do not bake")
+	mkdirAll(t, cityDir, "prompts")
+	if err := os.Symlink(filepath.Join(cityDir, citylayout.RuntimeRoot, "runtime", "private.txt"), filepath.Join(cityDir, "prompts", "public.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := AssembleContext(Options{
+		CityPath:  cityDir,
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+
+	assertFileNotExists(t, outputDir, "workspace/prompts/public.md")
+	assertFileExists(t, outputDir, "workspace/city.toml")
+}
+
+func TestAssembleContextSkipsFileSymlinkToExternalGCRuntimeTarget(t *testing.T) {
+	cityDir := t.TempDir()
+	outputDir := t.TempDir()
+	externalDir := t.TempDir()
+
+	writeFile(t, cityDir, "city.toml", `[workspace]
+name = "test-city"
+`)
+	writeFile(t, externalDir, filepath.Join(".gc", "agents", "worker", "identity"), "do not bake")
+	mkdirAll(t, cityDir, "prompts")
+	if err := os.Symlink(filepath.Join(externalDir, ".gc", "agents", "worker", "identity"), filepath.Join(cityDir, "prompts", "public.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := AssembleContext(Options{
+		CityPath:  cityDir,
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+
+	assertFileNotExists(t, outputDir, "workspace/prompts/public.md")
+	assertFileExists(t, outputDir, "workspace/city.toml")
+}
+
+func TestAssembleContextSkipsBrokenSymlink(t *testing.T) {
+	cityDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	writeFile(t, cityDir, "city.toml", `[workspace]
+name = "test-city"
+`)
+	writeFile(t, cityDir, "prompts/keep.md", "# keep")
+	if err := os.Symlink(filepath.Join(cityDir, "missing.md"), filepath.Join(cityDir, "prompts", "missing.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := AssembleContext(Options{
+		CityPath:  cityDir,
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+
+	assertFileExists(t, outputDir, "workspace/prompts/keep.md")
+	assertFileNotExists(t, outputDir, "workspace/prompts/missing.md")
+}
+
+func TestAssembleContextErrorsForSymlinkLoop(t *testing.T) {
+	cityDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	writeFile(t, cityDir, "city.toml", `[workspace]
+name = "test-city"
+`)
+	mkdirAll(t, cityDir, "prompts")
+	if err := os.Symlink("loop.md", filepath.Join(cityDir, "prompts", "loop.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := AssembleContext(Options{
+		CityPath:  cityDir,
+		OutputDir: outputDir,
+	})
+	if err == nil {
+		t.Fatal("AssembleContext succeeded with symlink loop, want error")
+	}
+	if !strings.Contains(err.Error(), "resolving symlink") {
+		t.Fatalf("AssembleContext error = %q, want symlink resolution context", err)
+	}
 }
 
 func TestAssembleContextRequiresCityPath(t *testing.T) {

--- a/internal/buildimage/context_test.go
+++ b/internal/buildimage/context_test.go
@@ -191,6 +191,38 @@ prompt_template = "prompts/mayor.md"
 	assertFileExists(t, outputDir, "workspace/prompts/mayor.md")
 }
 
+func TestAssembleContextSkipsSymlinkedDirs(t *testing.T) {
+	cityDir := t.TempDir()
+	outputDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	writeFile(t, cityDir, "city.toml", `[workspace]
+name = "test-city"
+`)
+	// Create a symlink to a directory (simulates .claude/skills/core.gc-agents).
+	writeFile(t, targetDir, "skill.md", "# skill")
+	if err := os.Symlink(targetDir, filepath.Join(cityDir, ".claude", "skills", "core.gc-agents")); err != nil {
+		// Need to create the parent first.
+		if err2 := os.MkdirAll(filepath.Join(cityDir, ".claude", "skills"), 0o755); err2 != nil {
+			t.Fatal(err2)
+		}
+		if err2 := os.Symlink(targetDir, filepath.Join(cityDir, ".claude", "skills", "core.gc-agents")); err2 != nil {
+			t.Fatal(err2)
+		}
+	}
+
+	err := AssembleContext(Options{
+		CityPath:  cityDir,
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		t.Fatalf("AssembleContext: %v", err)
+	}
+
+	// Symlinked directory should be skipped, not cause an error.
+	assertFileNotExists(t, outputDir, "workspace/.claude/skills/core.gc-agents")
+}
+
 func TestAssembleContextRequiresCityPath(t *testing.T) {
 	err := AssembleContext(Options{OutputDir: t.TempDir()})
 	if err == nil {


### PR DESCRIPTION
## Summary

filepath.Walk uses os.Lstat and does not follow symlinks, so symlinks to directories have IsDir()=false and were incorrectly passed to copyFile, which failed with "is a directory" when os.Open followed the link. Now detect symlinks via ModeSymlink: skip dir symlinks, copy file symlink content with the resolved mode.

Closes https://github.com/gastownhall/gascity/issues/2231

## Testing

- [x] `make check` - I ran it and it fails on some unrelated code
- [ ] `make check-docs` if docs, navigation, or links changed: not relevant
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed: not relevant

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes: not relevant
- [ ] Called out breaking changes or migration notes: not relevant
