### PR TITLE
Version fingerprints and enrich CopyFiles drift diagnostics

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -156,7 +156,7 @@ type preparedStart struct {
 	candidate     startCandidate
 	cfg           runtime.Config
 	coreHash      string
-	coreBreakdown map[string]string
+	coreBreakdown runtime.BreakdownV1
 	liveHash      string
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1220,12 +1220,8 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						}
 						fmt.Fprintf(stderr, "config-drift %s: stored=%s current=%s cmd=%q\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash), agentCfg.Command) //nolint:errcheck
 						// Diagnostic: log per-field breakdown to identify the drifting field.
-						var storedBreakdown map[string]string
-						if raw := session.Metadata["core_hash_breakdown"]; raw != "" {
-							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
-						}
-						driftedFields := runtime.CoreFingerprintDriftFields(storedBreakdown, agentCfg)
-						runtime.LogCoreFingerprintDrift(stderr, name, storedBreakdown, agentCfg)
+						driftedFields := runtime.CoreFingerprintDriftFieldsFromJSON(session.Metadata["core_hash_breakdown"], agentCfg)
+						runtime.LogCoreFingerprintDrift(stderr, name, session.Metadata["core_hash_breakdown"], agentCfg)
 						restartedInPlace := false
 						// Attached sessions never get config-drift restarts.
 						// The human will restart when ready; drift applies
@@ -1447,11 +1443,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							}
 							continue
 						}
-						var storedBreakdown map[string]string
-						if raw := session.Metadata["core_hash_breakdown"]; raw != "" {
-							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
-						}
-						driftedFields := runtime.CoreFingerprintDriftFields(storedBreakdown, agentCfg)
+						driftedFields := runtime.CoreFingerprintDriftFieldsFromJSON(session.Metadata["core_hash_breakdown"], agentCfg)
 						resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, false, "asleep", clk.Now().UTC(), stderr)
 						if trace != nil {
 							trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "repair_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")

--- a/cmd/gc/soft_reload_test.go
+++ b/cmd/gc/soft_reload_test.go
@@ -56,13 +56,13 @@ func TestAcceptConfigDriftAcrossSessions_UpdatesStaleHash(t *testing.T) {
 	if updated.Metadata["started_config_hash"] != wantHash {
 		t.Errorf("started_config_hash = %q, want %q", updated.Metadata["started_config_hash"], wantHash)
 	}
-	var gotBreakdown map[string]string
+	var gotBreakdown runtime.BreakdownV1
 	if err := json.Unmarshal([]byte(updated.Metadata["core_hash_breakdown"]), &gotBreakdown); err != nil {
 		t.Fatalf("core_hash_breakdown is not valid JSON: %v", err)
 	}
 	wantBreakdown := runtime.CoreFingerprintBreakdown(runtime.Config{Command: "new-cmd"})
-	if gotBreakdown["Command"] != wantBreakdown["Command"] {
-		t.Errorf("core_hash_breakdown[Command] = %q, want %q", gotBreakdown["Command"], wantBreakdown["Command"])
+	if gotBreakdown.Fields["Command"] != wantBreakdown.Fields["Command"] {
+		t.Errorf("core_hash_breakdown[Command] = %q, want %q", gotBreakdown.Fields["Command"], wantBreakdown.Fields["Command"])
 	}
 }
 

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -2,12 +2,34 @@ package runtime
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"hash"
 	"io"
 	"sort"
 	"strings"
 )
+
+// BreakdownV1 is the typed shape of `core_hash_breakdown` stored in
+// session metadata at start time and read back by the reconciler when
+// drift is detected. Versioned alongside the fingerprint hash so the
+// reconciler can distinguish a current-format breakdown from a legacy
+// `map[string]string` payload written by older binaries.
+type BreakdownV1 struct {
+	Version   string               `json:"version"`
+	Fields    map[string]string    `json:"fields"`
+	CopyFiles []BreakdownCopyEntry `json:"copy_files,omitempty"`
+}
+
+// BreakdownCopyEntry is the per-entry record for the CopyFiles slice in
+// BreakdownV1. Mirrors runtime.CopyEntry's fingerprint-relevant fields
+// so the reconciler can render a per-entry diff at drift time.
+type BreakdownCopyEntry struct {
+	RelDst      string `json:"rel_dst"`
+	Src         string `json:"src,omitempty"`
+	Probed      bool   `json:"probed"`
+	ContentHash string `json:"content_hash,omitempty"`
+}
 
 // FingerprintVersion namespaces the stored fingerprint hashes so the
 // reconciler can detect hashes written by older binaries (no prefix or a
@@ -333,15 +355,18 @@ func HashOverlayProviderNames(h io.Writer, providers []string) {
 }
 
 // CoreFingerprintBreakdown returns per-field hash components of the core
-// fingerprint. Used to diagnose config-drift by comparing breakdowns
-// from session start vs reconcile time.
-func CoreFingerprintBreakdown(cfg Config) map[string]string {
+// fingerprint plus a typed view of the CopyFiles slice. Used to diagnose
+// config-drift by comparing breakdowns from session start vs reconcile
+// time. The Version field carries the current FingerprintVersion so the
+// reconciler can detect a legacy `map[string]string` payload (no Version)
+// and fall back to the prior diff renderer.
+func CoreFingerprintBreakdown(cfg Config) BreakdownV1 {
 	fieldHash := func(fn func(h hash.Hash)) string {
 		h := sha256.New()
 		fn(h)
 		return fmt.Sprintf("%x", h.Sum(nil))[:16]
 	}
-	return map[string]string{
+	fields := map[string]string{
 		"Command": fieldHash(func(h hash.Hash) {
 			h.Write([]byte(cfg.Command))
 		}),
@@ -402,48 +427,73 @@ func CoreFingerprintBreakdown(cfg Config) map[string]string {
 			}
 		}),
 	}
+	var copyEntries []BreakdownCopyEntry
+	if len(cfg.CopyFiles) > 0 {
+		copyEntries = make([]BreakdownCopyEntry, 0, len(cfg.CopyFiles))
+		for _, cf := range cfg.CopyFiles {
+			copyEntries = append(copyEntries, BreakdownCopyEntry{
+				RelDst:      cf.RelDst,
+				Src:         cf.Src,
+				Probed:      cf.Probed,
+				ContentHash: cf.ContentHash,
+			})
+		}
+	}
+	return BreakdownV1{
+		Version:   FingerprintVersion,
+		Fields:    fields,
+		CopyFiles: copyEntries,
+	}
 }
 
 // CoreFingerprintDriftFields returns sorted core fingerprint field names whose
 // current hashes differ from the stored per-field breakdown.
-func CoreFingerprintDriftFields(storedBreakdown map[string]string, current Config) []string {
-	if len(storedBreakdown) == 0 {
+func CoreFingerprintDriftFields(storedBreakdown BreakdownV1, current Config) []string {
+	if len(storedBreakdown.Fields) == 0 {
 		return nil
 	}
-	return coreFingerprintDriftFields(storedBreakdown, CoreFingerprintBreakdown(current))
+	return diffBreakdownFields(storedBreakdown.Fields, CoreFingerprintBreakdown(current).Fields)
 }
 
-func coreFingerprintDriftFields(storedBreakdown, currentBreakdown map[string]string) []string {
-	var diffs []string
-	for field, ch := range currentBreakdown {
-		sh := storedBreakdown[field]
-		if sh != ch {
-			diffs = append(diffs, field)
-		}
+// CoreFingerprintDriftFieldsFromJSON returns sorted drifted field names from a
+// JSON-encoded stored breakdown. It accepts both current BreakdownV1 payloads
+// and legacy map[string]string payloads.
+func CoreFingerprintDriftFieldsFromJSON(storedJSON string, current Config) []string {
+	storedFields, _, _ := parseStoredBreakdown(storedJSON)
+	if len(storedFields) == 0 {
+		return nil
 	}
-	sort.Strings(diffs)
-	return diffs
+	return diffBreakdownFields(storedFields, CoreFingerprintBreakdown(current).Fields)
 }
 
 // LogCoreFingerprintDrift writes diagnostic output when config-drift is
-// detected, showing per-field hash breakdown and values for the current
-// config. Compare against stored breakdown (from session start metadata)
-// to identify which field changed.
-func LogCoreFingerprintDrift(w io.Writer, name string, storedBreakdown map[string]string, current Config) {
-	currentBreakdown := CoreFingerprintBreakdown(current)
-	diffs := coreFingerprintDriftFields(storedBreakdown, currentBreakdown)
+// detected. The stored breakdown is supplied as a JSON-encoded string;
+// the renderer first attempts to decode it as a current-format
+// BreakdownV1, then falls back to a legacy map[string]string payload
+// when the decoded Version is empty. Both paths emit the same
+// per-field "drifted fields" / "stored-hash=/current-hash=" header. The
+// new path additionally renders a per-entry CopyFiles diff with
+// `[ ]`/`[~]`/`[+]`/`[-]` markers; the legacy path keeps the prior
+// `CopyFiles[N]:` per-entry format for byte-for-byte upgrade compat.
+func LogCoreFingerprintDrift(w io.Writer, name string, storedJSON string, current Config) {
+	currentBd := CoreFingerprintBreakdown(current)
+
+	storedFields, storedCopy, isV1 := parseStoredBreakdown(storedJSON)
+
+	diffs := diffBreakdownFields(storedFields, currentBd.Fields)
+
 	if len(diffs) == 0 {
-		// No stored breakdown available or all fields match — log full breakdown.
-		if len(storedBreakdown) == 0 {
-			fmt.Fprintf(w, "  config-drift-diag %s: no stored breakdown (pre-upgrade session); current field hashes: %v\n", name, currentBreakdown) //nolint:errcheck // best-effort diag
+		if len(storedFields) == 0 {
+			fmt.Fprintf(w, "  config-drift-diag %s: no stored breakdown (pre-upgrade session); current field hashes: %v\n", name, currentBd.Fields) //nolint:errcheck // best-effort diag
 		} else {
 			fmt.Fprintf(w, "  config-drift-diag %s: no per-field diff (possible sentinel/ordering issue)\n", name) //nolint:errcheck // best-effort diag
 		}
 		return
 	}
+
 	fmt.Fprintf(w, "  config-drift-diag %s: drifted fields: %s\n", name, strings.Join(diffs, ", ")) //nolint:errcheck // best-effort diag
 	for _, field := range diffs {
-		fmt.Fprintf(w, "    %s: stored-hash=%s current-hash=%s\n", field, storedBreakdown[field], currentBreakdown[field]) //nolint:errcheck // best-effort diag
+		fmt.Fprintf(w, "    %s: stored-hash=%s current-hash=%s\n", field, storedFields[field], currentBd.Fields[field]) //nolint:errcheck // best-effort diag
 		switch field {
 		case "Command":
 			fmt.Fprintf(w, "    Command: %q\n", current.Command) //nolint:errcheck // best-effort diag
@@ -464,11 +514,148 @@ func LogCoreFingerprintDrift(w io.Writer, name string, storedBreakdown map[strin
 		case "SessionSetupScript":
 			fmt.Fprintf(w, "    SessionSetupScript len: %d\n", len(current.SessionSetupScript)) //nolint:errcheck // best-effort diag
 		case "CopyFiles":
-			for i, cf := range current.CopyFiles {
-				fmt.Fprintf(w, "    CopyFiles[%d]: RelDst=%q ContentHash=%q\n", i, cf.RelDst, cf.ContentHash) //nolint:errcheck // best-effort diag
+			if isV1 {
+				logCopyFilesEntryDiff(w, storedCopy, currentBd.CopyFiles)
+			} else {
+				for i, cf := range current.CopyFiles {
+					fmt.Fprintf(w, "    CopyFiles[%d]: RelDst=%q ContentHash=%q\n", i, cf.RelDst, cf.ContentHash) //nolint:errcheck // best-effort diag
+				}
 			}
 		}
 	}
+}
+
+// parseStoredBreakdown decodes the JSON-encoded stored breakdown and
+// returns the per-field map, the typed CopyFiles entries, and a flag
+// indicating which format was used. If the JSON parses as a BreakdownV1
+// with a non-empty Version, the per-entry CopyFiles slice is returned
+// and isV1=true. If Version is empty (or the JSON is a bare
+// map[string]string), the map is returned and isV1=false. Empty input
+// yields an empty map and isV1=true (no CopyFiles to diff).
+func parseStoredBreakdown(stored string) (fields map[string]string, copyEntries []BreakdownCopyEntry, isV1 bool) {
+	stored = strings.TrimSpace(stored)
+	if stored == "" {
+		return nil, nil, true
+	}
+	var v1 BreakdownV1
+	if err := json.Unmarshal([]byte(stored), &v1); err == nil && v1.Version != "" {
+		if v1.Fields == nil {
+			v1.Fields = map[string]string{}
+		}
+		return v1.Fields, v1.CopyFiles, true
+	}
+	var legacy map[string]string
+	if err := json.Unmarshal([]byte(stored), &legacy); err == nil {
+		return legacy, nil, false
+	}
+	return nil, nil, false
+}
+
+// diffBreakdownFields returns the sorted list of field names where the
+// stored and current per-field hashes differ.
+func diffBreakdownFields(stored, current map[string]string) []string {
+	var diffs []string
+	for field, ch := range current {
+		if stored[field] != ch {
+			diffs = append(diffs, field)
+		}
+	}
+	sort.Strings(diffs)
+	return diffs
+}
+
+// logCopyFilesEntryDiff renders the per-entry CopyFiles diff block. Each
+// entry is keyed by RelDst; the union of stored and current RelDsts is
+// printed in alphabetical order with one of four markers:
+//
+//	[ ]  unchanged (Probed, ContentHash, Src all match)
+//	[~]  same RelDst, differing render (ContentHash, Probed flag, or Src)
+//	[+]  present in current but not in stored
+//	[-]  present in stored but not in current
+//
+// Format per line:
+//
+//	[<marker>] <RelDst>  stored=<rendered>  current=<rendered>
+//
+// Where each side is rendered as `(absent)`, `<8-char-hex> (probed)`,
+// `HASH_UNAVAILABLE (probed)` (when probed with empty hash), or
+// `src=<src>` (when non-probed). The two-space separator between the
+// stored and current columns is enforced by the validator regex.
+func logCopyFilesEntryDiff(w io.Writer, stored, current []BreakdownCopyEntry) {
+	storedByDst := make(map[string]BreakdownCopyEntry, len(stored))
+	for _, e := range stored {
+		storedByDst[e.RelDst] = e
+	}
+	currentByDst := make(map[string]BreakdownCopyEntry, len(current))
+	for _, e := range current {
+		currentByDst[e.RelDst] = e
+	}
+
+	keys := make([]string, 0, len(storedByDst)+len(currentByDst))
+	seen := make(map[string]bool, len(storedByDst)+len(currentByDst))
+	for k := range storedByDst {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	for k := range currentByDst {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	fmt.Fprintf(w, "    CopyFiles: stored=%d entries  current=%d entries\n", len(stored), len(current)) //nolint:errcheck // best-effort diag
+
+	for _, dst := range keys {
+		s, sOK := storedByDst[dst]
+		c, cOK := currentByDst[dst]
+		var marker string
+		switch {
+		case sOK && !cOK:
+			marker = "[-]"
+		case !sOK && cOK:
+			marker = "[+]"
+		case copyEntryEqual(s, c):
+			marker = "[ ]"
+		default:
+			marker = "[~]"
+		}
+		storedRender := "(absent)"
+		if sOK {
+			storedRender = renderCopyEntry(s)
+		}
+		currentRender := "(absent)"
+		if cOK {
+			currentRender = renderCopyEntry(c)
+		}
+		fmt.Fprintf(w, "    %s %s  stored=%s  current=%s\n", marker, dst, storedRender, currentRender) //nolint:errcheck // best-effort diag
+	}
+}
+
+// copyEntryEqual reports whether two entries have identical render-
+// affecting fields.
+func copyEntryEqual(a, b BreakdownCopyEntry) bool {
+	return a.Probed == b.Probed && a.ContentHash == b.ContentHash && a.Src == b.Src
+}
+
+// renderCopyEntry formats one side of a CopyFiles entry diff. Probed
+// entries render as `<8-char-hex> (probed)` (or the literal
+// `HASH_UNAVAILABLE (probed)` when ContentHash is empty); non-probed
+// entries render as `src=<src>`.
+func renderCopyEntry(e BreakdownCopyEntry) string {
+	if e.Probed {
+		hash := e.ContentHash
+		if hash == "" {
+			hash = "HASH_UNAVAILABLE"
+		} else if len(hash) > 8 {
+			hash = hash[:8]
+		}
+		return fmt.Sprintf("%s (probed)", hash)
+	}
+	return fmt.Sprintf("src=%s", e.Src)
 }
 
 // filteredEnv returns only the allow-listed env keys for diagnostic output.

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -591,8 +591,14 @@ func logCopyFilesEntryDiff(w io.Writer, stored, current []BreakdownCopyEntry) {
 		currentByDst[e.RelDst] = e
 	}
 
-	keys := make([]string, 0, len(storedByDst)+len(currentByDst))
-	seen := make(map[string]bool, len(storedByDst)+len(currentByDst))
+	// Guard the signed-int sum against CWE-190 wrap; len() inputs trace
+	// through parsed JSON to potentially-unbounded data.
+	totalCap := len(storedByDst) + len(currentByDst)
+	if totalCap < len(storedByDst) {
+		totalCap = 0
+	}
+	keys := make([]string, 0, totalCap)
+	seen := make(map[string]bool, totalCap)
 	for k := range storedByDst {
 		if !seen[k] {
 			seen[k] = true

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -591,14 +591,15 @@ func logCopyFilesEntryDiff(w io.Writer, stored, current []BreakdownCopyEntry) {
 		currentByDst[e.RelDst] = e
 	}
 
-	// Guard the signed-int sum against CWE-190 wrap; len() inputs trace
-	// through parsed JSON to potentially-unbounded data.
-	totalCap := len(storedByDst) + len(currentByDst)
-	if totalCap < len(storedByDst) {
-		totalCap = 0
+	// Size hint to the larger of the two inputs; map/slice grow as needed.
+	// Avoids len(a)+len(b) so the size computation can't overflow when the
+	// inputs trace back through parsed JSON metadata (CWE-190).
+	capHint := len(storedByDst)
+	if len(currentByDst) > capHint {
+		capHint = len(currentByDst)
 	}
-	keys := make([]string, 0, totalCap)
-	seen := make(map[string]bool, totalCap)
+	keys := make([]string, 0, capHint)
+	seen := make(map[string]bool, capHint)
 	for k := range storedByDst {
 		if !seen[k] {
 			seen[k] = true

--- a/internal/runtime/fingerprint_breakdown_v1_test.go
+++ b/internal/runtime/fingerprint_breakdown_v1_test.go
@@ -1,0 +1,447 @@
+package runtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestBreakdownV1MarshalRoundtrip enforces ga-s760.2 / MF-A: the
+// BreakdownV1 struct must JSON-roundtrip with all fields preserved
+// (Version, Fields, CopyFiles entries — including mixed probed and
+// non-probed entries). The supervisor stores this JSON in session
+// metadata under "core_hash_breakdown"; the reconciler reads it back
+// at drift-detection time.
+func TestBreakdownV1MarshalRoundtrip(t *testing.T) {
+	original := BreakdownV1{
+		Version: FingerprintVersion,
+		Fields: map[string]string{
+			"Command":            "abcdef0123456789",
+			"Env":                "1111111111111111",
+			"FPExtra":            "2222222222222222",
+			"PreStart":           "3333333333333333",
+			"SessionSetup":       "4444444444444444",
+			"SessionSetupScript": "5555555555555555",
+			"OverlayDir":         "6666666666666666",
+			"CopyFiles":          "7777777777777777",
+		},
+		CopyFiles: []BreakdownCopyEntry{
+			// Probed entry with a successful content hash.
+			{RelDst: ".gc/scripts", Probed: true, ContentHash: "abc12345"},
+			// Probed entry with no content hash (transient I/O error).
+			{RelDst: ".claude/skills.broken", Probed: true, ContentHash: ""},
+			// Config-derived (non-probed) entry — Src present, ContentHash empty.
+			{RelDst: "config.toml", Src: "/etc/agent.toml"},
+			// Mixed: another probed entry with a hash, to exercise sort/order
+			// preservation through the round trip.
+			{RelDst: ".claude/skills", Probed: true, ContentHash: "fed09876"},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal(BreakdownV1) failed: %v", err)
+	}
+
+	var decoded BreakdownV1
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(BreakdownV1) failed: %v\nJSON: %s", err, data)
+	}
+
+	if !reflect.DeepEqual(original, decoded) {
+		t.Errorf("BreakdownV1 round-trip mismatch:\noriginal=%+v\ndecoded =%+v\nJSON    =%s",
+			original, decoded, data)
+	}
+
+	// Verify Version is non-empty after round trip — the legacy fallback
+	// path in LogCoreFingerprintDrift uses an empty Version as the
+	// "treat as map[string]string" signal.
+	if decoded.Version == "" {
+		t.Error("decoded BreakdownV1.Version is empty; legacy fallback would mis-trigger")
+	}
+
+	// Verify per-entry fields survived: probed-with-hash, probed-no-hash,
+	// non-probed (Src), and the four-entry order.
+	if len(decoded.CopyFiles) != 4 {
+		t.Fatalf("decoded CopyFiles len=%d, want 4", len(decoded.CopyFiles))
+	}
+	if decoded.CopyFiles[0].RelDst != ".gc/scripts" || !decoded.CopyFiles[0].Probed || decoded.CopyFiles[0].ContentHash != "abc12345" {
+		t.Errorf("entry 0 corrupted: %+v", decoded.CopyFiles[0])
+	}
+	if decoded.CopyFiles[1].ContentHash != "" || !decoded.CopyFiles[1].Probed {
+		t.Errorf("entry 1 (probed-no-hash) corrupted: %+v", decoded.CopyFiles[1])
+	}
+	if decoded.CopyFiles[2].Src != "/etc/agent.toml" || decoded.CopyFiles[2].Probed {
+		t.Errorf("entry 2 (non-probed) corrupted: %+v", decoded.CopyFiles[2])
+	}
+}
+
+// TestLogDriftHandlesLegacyMapBreakdown enforces ga-s760.2 / MF-A's
+// upgrade-compat clause: when the stored breakdown JSON is a legacy
+// map[string]string (no Version field, no CopyFiles array), the
+// renderer must fall back to the existing per-field diff output —
+// no panic, no missing-field log, no [+]/[-]/[~]/[ ] markers, and no
+// "stored=<N> entries" line.
+//
+// During the upgrade window, both formats coexist in supervisor logs;
+// the legacy path must continue to emit byte-for-byte the same lines
+// it did before this bead.
+func TestLogDriftHandlesLegacyMapBreakdown(t *testing.T) {
+	// Build a legacy map[string]string with at least one field that
+	// will differ from the current config, so the diff path runs.
+	legacy := map[string]string{
+		"Command":            "old_command_hash",
+		"Env":                "old_env_hash",
+		"FPExtra":            "old_fpextra_hash",
+		"PreStart":           "old_prestart_hash",
+		"SessionSetup":       "old_sessionsetup_hash",
+		"SessionSetupScript": "old_setupscript_hash",
+		"OverlayDir":         "old_overlay_hash",
+		"CopyFiles":          "old_copyfiles_hash",
+	}
+	legacyJSON, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy map: %v", err)
+	}
+
+	current := Config{
+		Command:   "claude --new",
+		CopyFiles: []CopyEntry{{RelDst: "bar", Probed: true, ContentHash: "h1"}},
+	}
+
+	var buf bytes.Buffer
+	LogCoreFingerprintDrift(&buf, "legacy-agent", string(legacyJSON), current)
+	out := buf.String()
+
+	if out == "" {
+		t.Fatal("expected diagnostic output for legacy map breakdown, got empty")
+	}
+
+	// Legacy header still appears.
+	if !strings.Contains(out, "config-drift-diag legacy-agent") {
+		t.Errorf("missing config-drift-diag header in legacy output:\n%s", out)
+	}
+	if !strings.Contains(out, "drifted fields:") {
+		t.Errorf("missing drifted-fields line in legacy output:\n%s", out)
+	}
+	if !strings.Contains(out, "stored-hash=") || !strings.Contains(out, "current-hash=") {
+		t.Errorf("missing stored-hash/current-hash columns in legacy output:\n%s", out)
+	}
+
+	// Legacy MUST NOT emit any of the new BreakdownV1 markers — they
+	// are how operators distinguish the two formats at a glance
+	// (designer §4).
+	newMarkers := []string{
+		"[ ] ", "[~] ", "[+] ", "[-] ",
+		" entries  current=",
+	}
+	for _, m := range newMarkers {
+		if strings.Contains(out, m) {
+			t.Errorf("legacy fallback emitted new-format marker %q (should only appear with BreakdownV1):\n%s", m, out)
+		}
+	}
+
+	// Legacy CopyFiles diagnostic uses the existing "CopyFiles[N]:" prefix.
+	// (Per designer §4: this prefix is how the legacy path is recognized.)
+	if !regexp.MustCompile(`CopyFiles\[\d+\]:`).MatchString(out) {
+		t.Errorf("legacy fallback missing CopyFiles[N]: per-entry prefix:\n%s", out)
+	}
+}
+
+// TestLogDriftPrintsCopyFilesEntryDiff enforces ga-s760.2 / MF-A: when
+// the stored breakdown has three entries and the current config differs
+// in exactly one entry's ContentHash, the diff output must mark that
+// one entry with [~] and the other two with [ ]. This is the bug the
+// investigator hit — without per-entry diff, the operator could not
+// tell which CopyFiles entry was drifting when the aggregate hash
+// changed.
+func TestLogDriftPrintsCopyFilesEntryDiff(t *testing.T) {
+	// Three entries; one of them (.gc/settings.json) has a different
+	// ContentHash in stored vs current. The other two are identical.
+	storedEntries := []BreakdownCopyEntry{
+		{RelDst: ".claude/skills", Probed: true, ContentHash: "aaaa1111"},
+		{RelDst: ".gc/scripts", Probed: true, ContentHash: "bbbb2222"},
+		{RelDst: ".gc/settings.json", Probed: true, ContentHash: "cccc3333"},
+	}
+	currentCfg := Config{
+		Command: "claude",
+		CopyFiles: []CopyEntry{
+			{RelDst: ".claude/skills", Probed: true, ContentHash: "aaaa1111"},
+			{RelDst: ".gc/scripts", Probed: true, ContentHash: "bbbb2222"},
+			{RelDst: ".gc/settings.json", Probed: true, ContentHash: "DDDD4444"}, // differs
+		},
+	}
+
+	stored := buildStoredBreakdownForCopyFilesDiff(t, currentCfg, storedEntries)
+	storedJSON, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatalf("marshal stored breakdown: %v", err)
+	}
+
+	var buf bytes.Buffer
+	LogCoreFingerprintDrift(&buf, "agent", string(storedJSON), currentCfg)
+	out := buf.String()
+
+	if out == "" {
+		t.Fatal("expected diagnostic output for drift, got empty")
+	}
+
+	// Header signals CopyFiles is the drifted field.
+	if !strings.Contains(out, "drifted fields:") || !strings.Contains(out, "CopyFiles") {
+		t.Errorf("expected drifted-fields header naming CopyFiles:\n%s", out)
+	}
+
+	// Entry-count line (new format, per designer §3).
+	if !strings.Contains(out, "stored=3 entries") || !strings.Contains(out, "current=3 entries") {
+		t.Errorf("expected entry-count line 'stored=3 entries  current=3 entries':\n%s", out)
+	}
+
+	// Two unchanged entries get the [ ] marker.
+	if !containsLineWithBoth(out, "[ ]", ".claude/skills") {
+		t.Errorf("expected unchanged entry .claude/skills marked [ ]:\n%s", out)
+	}
+	if !containsLineWithBoth(out, "[ ]", ".gc/scripts") {
+		t.Errorf("expected unchanged entry .gc/scripts marked [ ]:\n%s", out)
+	}
+
+	// The one changed entry gets [~].
+	if !containsLineWithBoth(out, "[~]", ".gc/settings.json") {
+		t.Errorf("expected changed entry .gc/settings.json marked [~]:\n%s", out)
+	}
+
+	// The changed entry must NOT carry [ ]/[+]/[-] markers.
+	for _, badMarker := range []string{"[ ]", "[+]", "[-]"} {
+		if containsLineWithBoth(out, badMarker, ".gc/settings.json") {
+			t.Errorf("changed entry .gc/settings.json incorrectly marked %s:\n%s", badMarker, out)
+		}
+	}
+
+	// stored= and current= columns must show the differing hashes
+	// (truncated to 8 hex per designer §7 validation checklist).
+	settingsLine := lineContaining(out, ".gc/settings.json")
+	if settingsLine == "" {
+		t.Fatalf("could not locate .gc/settings.json line in output:\n%s", out)
+	}
+	if !strings.Contains(settingsLine, "stored=cccc3333") {
+		t.Errorf(".gc/settings.json line missing stored=cccc3333: %q", settingsLine)
+	}
+	if !strings.Contains(settingsLine, "current=DDDD4444") {
+		t.Errorf(".gc/settings.json line missing current=DDDD4444: %q", settingsLine)
+	}
+	if !strings.Contains(settingsLine, "(probed)") {
+		t.Errorf(".gc/settings.json line missing (probed) literal: %q", settingsLine)
+	}
+
+	// Designer §1: column separator between stored= and current= is
+	// exactly two spaces. Search for the two-space pattern in the
+	// changed line.
+	if !regexp.MustCompile(`stored=\S.*?  current=`).MatchString(settingsLine) {
+		t.Errorf(".gc/settings.json line missing two-space separator between stored= and current=: %q", settingsLine)
+	}
+}
+
+// TestLogDriftPrintsCopyFilesAddedAndRemovedEntries enforces ga-s760.2
+// / MF-A: when an entry exists in stored but not in current, it
+// renders with [-] and current=(absent); when an entry exists in
+// current but not in stored, it renders with [+] and stored=(absent).
+func TestLogDriftPrintsCopyFilesAddedAndRemovedEntries(t *testing.T) {
+	t.Run("added", func(t *testing.T) {
+		storedEntries := []BreakdownCopyEntry{
+			{RelDst: ".claude/skills", Probed: true, ContentHash: "aaaa1111"},
+			{RelDst: ".gc/scripts", Probed: true, ContentHash: "bbbb2222"},
+			{RelDst: ".gc/settings.json", Probed: true, ContentHash: "cccc3333"},
+		}
+		currentCfg := Config{
+			Command: "claude",
+			CopyFiles: []CopyEntry{
+				{RelDst: ".claude/skills", Probed: true, ContentHash: "aaaa1111"},
+				{RelDst: ".gc/scripts", Probed: true, ContentHash: "bbbb2222"},
+				{RelDst: ".gc/settings.json", Probed: true, ContentHash: "cccc3333"},
+				// New entry only present in current.
+				{RelDst: ".gc/added.toml", Probed: true, ContentHash: "eeee5555"},
+			},
+		}
+
+		stored := buildStoredBreakdownForCopyFilesDiff(t, currentCfg, storedEntries)
+		storedJSON, err := json.Marshal(stored)
+		if err != nil {
+			t.Fatalf("marshal stored breakdown: %v", err)
+		}
+
+		var buf bytes.Buffer
+		LogCoreFingerprintDrift(&buf, "agent-add", string(storedJSON), currentCfg)
+		out := buf.String()
+
+		if !strings.Contains(out, "stored=3 entries") || !strings.Contains(out, "current=4 entries") {
+			t.Errorf("expected entry-count 'stored=3 entries  current=4 entries':\n%s", out)
+		}
+
+		// Added entry marked [+], stored side is (absent).
+		if !containsLineWithBoth(out, "[+]", ".gc/added.toml") {
+			t.Errorf("expected new entry .gc/added.toml marked [+]:\n%s", out)
+		}
+		addedLine := lineContaining(out, ".gc/added.toml")
+		if addedLine == "" {
+			t.Fatalf("could not locate .gc/added.toml line in output:\n%s", out)
+		}
+		if !strings.Contains(addedLine, "stored=(absent)") {
+			t.Errorf("[+] entry must show stored=(absent): %q", addedLine)
+		}
+		if !strings.Contains(addedLine, "current=eeee5555") {
+			t.Errorf("[+] entry must show current=eeee5555 (probed): %q", addedLine)
+		}
+
+		// The unchanged entries should not be marked as added/removed.
+		for _, rel := range []string{".claude/skills", ".gc/scripts", ".gc/settings.json"} {
+			if containsLineWithBoth(out, "[+]", rel) {
+				t.Errorf("unchanged entry %s incorrectly marked [+]:\n%s", rel, out)
+			}
+			if containsLineWithBoth(out, "[-]", rel) {
+				t.Errorf("unchanged entry %s incorrectly marked [-]:\n%s", rel, out)
+			}
+		}
+	})
+
+	t.Run("removed", func(t *testing.T) {
+		storedEntries := []BreakdownCopyEntry{
+			{RelDst: ".claude/skills", Probed: true, ContentHash: "aaaa1111"},
+			{RelDst: ".gc/scripts", Probed: true, ContentHash: "bbbb2222"},
+			{RelDst: ".gc/skills.old", Probed: true, ContentHash: "cccc3333"},
+		}
+		currentCfg := Config{
+			Command: "claude",
+			CopyFiles: []CopyEntry{
+				{RelDst: ".claude/skills", Probed: true, ContentHash: "aaaa1111"},
+				{RelDst: ".gc/scripts", Probed: true, ContentHash: "bbbb2222"},
+			},
+		}
+
+		stored := buildStoredBreakdownForCopyFilesDiff(t, currentCfg, storedEntries)
+		storedJSON, err := json.Marshal(stored)
+		if err != nil {
+			t.Fatalf("marshal stored breakdown: %v", err)
+		}
+
+		var buf bytes.Buffer
+		LogCoreFingerprintDrift(&buf, "agent-remove", string(storedJSON), currentCfg)
+		out := buf.String()
+
+		if !strings.Contains(out, "stored=3 entries") || !strings.Contains(out, "current=2 entries") {
+			t.Errorf("expected entry-count 'stored=3 entries  current=2 entries':\n%s", out)
+		}
+
+		// Removed entry marked [-], current side is (absent).
+		if !containsLineWithBoth(out, "[-]", ".gc/skills.old") {
+			t.Errorf("expected removed entry .gc/skills.old marked [-]:\n%s", out)
+		}
+		removedLine := lineContaining(out, ".gc/skills.old")
+		if removedLine == "" {
+			t.Fatalf("could not locate .gc/skills.old line in output:\n%s", out)
+		}
+		if !strings.Contains(removedLine, "current=(absent)") {
+			t.Errorf("[-] entry must show current=(absent): %q", removedLine)
+		}
+		if !strings.Contains(removedLine, "stored=cccc3333") {
+			t.Errorf("[-] entry must show stored=cccc3333 (probed): %q", removedLine)
+		}
+	})
+}
+
+// TestLogDriftPrintsCopyFilesProbedFlagFlip enforces ga-s760.2 / MF-A:
+// when a stored entry was probed and the current entry for the same
+// RelDst is non-probed (or vice versa), the diff must mark the entry
+// with [~] and render the modes differently — `<hex> (probed)` on the
+// probed side and `src=<path>` on the non-probed side. This catches
+// the failure mode where probed entries silently fall back to
+// path-based hashing across restarts.
+func TestLogDriftPrintsCopyFilesProbedFlagFlip(t *testing.T) {
+	// Stored side: probed=true, with content hash.
+	// Current side: probed=false, with src path. Same RelDst.
+	storedEntries := []BreakdownCopyEntry{
+		{RelDst: "config/agent.toml", Probed: true, ContentHash: "11223344"},
+	}
+	currentCfg := Config{
+		Command: "claude",
+		CopyFiles: []CopyEntry{
+			{RelDst: "config/agent.toml", Src: "/etc/agent.toml", Probed: false},
+		},
+	}
+
+	stored := buildStoredBreakdownForCopyFilesDiff(t, currentCfg, storedEntries)
+	storedJSON, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatalf("marshal stored breakdown: %v", err)
+	}
+
+	var buf bytes.Buffer
+	LogCoreFingerprintDrift(&buf, "agent-flip", string(storedJSON), currentCfg)
+	out := buf.String()
+
+	if !containsLineWithBoth(out, "[~]", "config/agent.toml") {
+		t.Errorf("expected mode-flip entry config/agent.toml marked [~]:\n%s", out)
+	}
+
+	flipLine := lineContaining(out, "config/agent.toml")
+	if flipLine == "" {
+		t.Fatalf("could not locate config/agent.toml line in output:\n%s", out)
+	}
+	// Stored side: probed-with-hash → "11223344 (probed)"
+	if !strings.Contains(flipLine, "stored=11223344 (probed)") {
+		t.Errorf("expected stored side to render as '11223344 (probed)': %q", flipLine)
+	}
+	// Current side: non-probed → "src=/etc/agent.toml"
+	if !strings.Contains(flipLine, "current=src=/etc/agent.toml") {
+		t.Errorf("expected current side to render as 'src=/etc/agent.toml': %q", flipLine)
+	}
+}
+
+// buildStoredBreakdownForCopyFilesDiff constructs a BreakdownV1 that
+// matches `currentCfg`'s breakdown on every field EXCEPT `CopyFiles`,
+// then plants `entries` as the stored CopyFiles list. The resulting
+// stored breakdown forces `CopyFiles` (and only CopyFiles) into the
+// drifted-fields set, isolating the per-entry diff under test.
+//
+// Without this helper, every test would either need to compute the
+// current config's per-field hashes by hand or accept noisy output
+// from spurious drifts in unrelated fields.
+func buildStoredBreakdownForCopyFilesDiff(t *testing.T, currentCfg Config, entries []BreakdownCopyEntry) BreakdownV1 {
+	t.Helper()
+	currentBd := CoreFingerprintBreakdown(currentCfg)
+	stored := BreakdownV1{
+		Version:   FingerprintVersion,
+		Fields:    make(map[string]string, len(currentBd.Fields)),
+		CopyFiles: entries,
+	}
+	for k, v := range currentBd.Fields {
+		stored.Fields[k] = v
+	}
+	// Force CopyFiles into the drifted-fields set; any value other
+	// than the current's CopyFiles aggregate hash works.
+	stored.Fields["CopyFiles"] = "STORED_AGGREGATE_DIFFERS_FROM_CURRENT"
+	return stored
+}
+
+// containsLineWithBoth reports whether `out` contains a single line
+// (newline-separated) that includes both substrings.
+func containsLineWithBoth(out, a, b string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, a) && strings.Contains(line, b) {
+			return true
+		}
+	}
+	return false
+}
+
+// lineContaining returns the first line of `out` that contains
+// `substr`, or empty string if none.
+func lineContaining(out, substr string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -825,29 +824,6 @@ func TestIsLegacyOrMismatchedVersion(t *testing.T) {
 				t.Errorf("IsLegacyOrMismatchedVersion(%q) = %v, want %v", tc.stored, got, tc.want)
 			}
 		})
-	}
-}
-
-func TestLogCoreFingerprintDriftCopyFiles(t *testing.T) {
-	stored := map[string]string{
-		"CopyFiles": "oldhash",
-		"Command":   "samehash",
-	}
-	current := Config{
-		Command:   "claude",
-		CopyFiles: []CopyEntry{{RelDst: "bar", ContentHash: "h1"}},
-	}
-	var buf bytes.Buffer
-	LogCoreFingerprintDrift(&buf, "test-agent", stored, current)
-	out := buf.String()
-	if out == "" {
-		t.Fatal("expected diagnostic output")
-	}
-	if !bytes.Contains([]byte(out), []byte("CopyFiles")) {
-		t.Errorf("expected CopyFiles in drift output, got: %s", out)
-	}
-	if !bytes.Contains([]byte(out), []byte("RelDst")) {
-		t.Errorf("expected RelDst detail in CopyFiles drift output, got: %s", out)
 	}
 }
 

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -151,7 +151,7 @@ func TestConfigFingerprintIgnoresGCAlias(t *testing.T) {
 	if CoreFingerprint(base) != CoreFingerprint(withAlias) {
 		t.Error("GC_ALIAS should not affect core config fingerprint")
 	}
-	if CoreFingerprintBreakdown(base)["Env"] != CoreFingerprintBreakdown(withAlias)["Env"] {
+	if CoreFingerprintBreakdown(base).Fields["Env"] != CoreFingerprintBreakdown(withAlias).Fields["Env"] {
 		t.Error("GC_ALIAS should not affect core env fingerprint breakdown")
 	}
 }
@@ -437,8 +437,8 @@ func TestCoreFingerprintBreakdownConsistency(t *testing.T) {
 			}
 			// Core hashes differ — at least one breakdown field must differ.
 			anyDiff := false
-			for field, va := range bdA {
-				if va != bdB[field] {
+			for field, va := range bdA.Fields {
+				if va != bdB.Fields[field] {
 					anyDiff = true
 					break
 				}
@@ -833,14 +833,14 @@ func TestCoreFingerprintDriftFields(t *testing.T) {
 		CopyFiles: []CopyEntry{{RelDst: "bar", Probed: true, ContentHash: "newhash"}},
 	}
 	stored := CoreFingerprintBreakdown(current)
-	stored["CopyFiles"] = "oldhash"
+	stored.Fields["CopyFiles"] = "oldhash"
 
 	got := CoreFingerprintDriftFields(stored, current)
 	if len(got) != 1 || got[0] != "CopyFiles" {
 		t.Fatalf("CoreFingerprintDriftFields = %v, want [CopyFiles]", got)
 	}
 
-	if got := CoreFingerprintDriftFields(nil, current); len(got) != 0 {
+	if got := CoreFingerprintDriftFields(BreakdownV1{}, current); len(got) != 0 {
 		t.Fatalf("CoreFingerprintDriftFields with missing breakdown = %v, want empty", got)
 	}
 }

--- a/release-gates/ga-s760-2-gate.md
+++ b/release-gates/ga-s760-2-gate.md
@@ -1,0 +1,86 @@
+# Release Gate: ga-s760.2
+
+Bead: ga-it5y — Review: per-entry CopyFiles drift diff (ga-s760.2 / MF-A)
+Source bead: ga-s760.2 — Diagnostic enrichment: per-entry CopyFiles diff in drift dump (MF-A)
+Feature branch: builder/ga-s760-2
+Evaluated by: gascity/deployer
+Date: 2026-05-16
+
+## Gate Result
+
+PASS
+
+## Scope Note
+
+`builder/ga-s760-2` contains the required `ga-s760.1` prerequisite commits
+followed by the `ga-s760.2` diagnostic commits. `ga-s760.2` depends on the
+shared `runtime.FingerprintVersion` constant and the versioned breakdown shape,
+so the gate evaluated the combined branch as the PR surface.
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree; this gate uses the
+release criteria supplied by the deployer role prompt.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-it5y contains two `Reviewer verdict: PASS` notes. The prerequisite review bead ga-34pf also contains two PASS verdicts for the hash-versioning prerequisite. |
+| 2 | Acceptance criteria met | PASS | Code inspection found `runtime.FingerprintVersion`, versioned Config/Core/Live fingerprint output, legacy/version-mismatch classifiers, silent rebaseline at all three reconciler drift paths, typed `BreakdownV1` / `BreakdownCopyEntry`, raw JSON drift rendering, and per-entry CopyFiles diff rendering. Tests cover all named FR/NFR surfaces from ga-s760.1 and ga-s760.2. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed all 8 fast shards. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes list no unresolved HIGH findings. Both security reviews found no security-sensitive concerns. |
+| 5 | Final branch is clean | PASS | Worktree was clean before gate file creation; after the gate commit there are no uncommitted changes. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` completed without conflicts (`8f65485f363a095942eba2e44e020553903eab9c`). |
+
+## Commits Evaluated
+
+| Bead | Review | Commits |
+|------|--------|---------|
+| ga-s760.1 | PASS via ga-34pf | 18b75456d, d28426f54 |
+| ga-s760.2 | PASS via ga-it5y | 3c673da8, ba5cc2ad, c8643cdd3 |
+
+## Acceptance Evidence
+
+### ga-s760.1
+
+- `internal/runtime/fingerprint.go` defines `FingerprintVersion` and prefixes
+  Config/Core/Live fingerprints with the version.
+- `runtime.IsLegacyOrMismatchedVersion` and `runtime.IsVersionMismatchedHash`
+  distinguish legacy hashes from version mismatches.
+- `cmd/gc/session_reconciler.go` calls `silentRebaselineSessionHashes` in core
+  drift, live drift, and asleep named-session drift paths before the normal
+  drain path.
+- `silentRebaselineSessionHashes` writes `started_config_hash`,
+  `started_live_hash`, `live_hash`, and `core_hash_breakdown` together.
+- Tests present for versioned output, classifier behavior, silent rebaseline on
+  legacy/mismatched hashes, and same-version real drift draining.
+
+### ga-s760.2
+
+- `runtime.BreakdownV1` and `runtime.BreakdownCopyEntry` define the typed
+  versioned breakdown shape.
+- `runtime.CoreFingerprintBreakdown` returns `BreakdownV1` with
+  `Version = FingerprintVersion`.
+- `runtime.LogCoreFingerprintDrift` accepts stored breakdown JSON, supports
+  legacy map fallback, and renders per-entry CopyFiles diffs.
+- Reconciler call sites pass raw `core_hash_breakdown` metadata JSON into the
+  runtime drift renderer.
+- Tests cover JSON round-trip, legacy fallback, changed entries, added/removed
+  entries, probed flag flips, and the two-space stored/current column shape.
+
+## Test Evidence
+
+Commands run:
+
+```text
+make test-fast-parallel
+go vet ./...
+git merge-tree --write-tree HEAD origin/main
+```
+
+Results:
+
+```text
+make test-fast-parallel: PASS
+go vet ./...: PASS
+merge-tree with origin/main: PASS
+```


### PR DESCRIPTION
## What this changes

Runtime config fingerprints now carry an explicit version prefix. When the reconciler sees older unversioned metadata or metadata written by a different fingerprint version, it silently rebaselines the stored hashes instead of draining and restarting the session. Same-version real drift still follows the existing drain path.

Core fingerprint breakdown metadata now uses a versioned JSON shape, and config-drift diagnostics can show `CopyFiles` differences entry by entry. Operators get side-by-side stored/current output for changed, added, removed, and unchanged copy-file entries instead of only aggregate field hashes.

## Why one PR

The diagnostic format depends on the same `runtime.FingerprintVersion` contract as the upgrade-compat change. Shipping them together keeps the stored hash and stored breakdown formats aligned and avoids an intermediate release that writes one versioned surface without the other.

## Review notes

- New stored fingerprints use the `v1:<sha256>` format for config, core, and live hashes.
- Legacy or mismatched stored fingerprint versions rebaseline metadata without emitting a drain event.
- `core_hash_breakdown` remains backward compatible with existing map-shaped JSON through a legacy fallback.
- Drift logging changes are diagnostic only; there is no config migration command and no new operator-facing command.
- The release gate is in [`release-gates/ga-s760-2-gate.md`](release-gates/ga-s760-2-gate.md).

## Test plan

- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `git merge-tree --write-tree HEAD origin/main`
- [x] Release gate: [`release-gates/ga-s760-2-gate.md`](release-gates/ga-s760-2-gate.md)
