### PR TITLE
Version stored fingerprints and silently rebaseline legacy session hashes

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1198,7 +1198,27 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					agentCfg := sessionCoreConfigForHash(tp, *session)
 					currentHash := runtime.CoreFingerprint(agentCfg)
 					if storedHash != currentHash {
-						fmt.Fprintf(stderr, "config-drift %s: stored=%s current=%s cmd=%q\n", name, storedHash[:12], currentHash[:12], agentCfg.Command) //nolint:errcheck
+						// Stored hash has no version prefix or carries a
+						// different version than the current binary — silently
+						// rebaseline all four fingerprint fields rather than
+						// draining the session. The mismatch is a versioning
+						// artifact, not real config drift. See ga-s760 FRs 1-3.
+						if runtime.IsLegacyOrMismatchedVersion(storedHash) {
+							outcome := rebaselineLegacyHashOutcome(storedHash)
+							if err := silentRebaselineSessionHashes(session, store, agentCfg); err != nil {
+								fmt.Fprintf(stderr, "session reconciler: rebaselining legacy hash for %s: %v\n", name, err) //nolint:errcheck
+							} else {
+								fmt.Fprintf(stderr, "rebaselined legacy hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash)) //nolint:errcheck
+							}
+							if trace != nil {
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(outcome), traceRecordPayload{
+									"stored_hash":  storedHash,
+									"current_hash": currentHash,
+								}, nil, "")
+							}
+							continue
+						}
+						fmt.Fprintf(stderr, "config-drift %s: stored=%s current=%s cmd=%q\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash), agentCfg.Command) //nolint:errcheck
 						// Diagnostic: log per-field breakdown to identify the drifting field.
 						var storedBreakdown map[string]string
 						if raw := session.Metadata["core_hash_breakdown"]; raw != "" {
@@ -1350,6 +1370,23 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								"live_hash":         currentLive,
 								"started_live_hash": currentLive,
 							})
+						} else if runtime.IsLegacyOrMismatchedVersion(storedLive) {
+							// Stored live hash from a pre-versioning or
+							// version-mismatched binary — silently rebaseline
+							// all four fingerprint fields rather than running
+							// SessionLive again. ga-s760 FRs 1-3.
+							outcome := rebaselineLegacyHashOutcome(storedLive)
+							if err := silentRebaselineSessionHashes(session, store, agentCfg); err != nil {
+								fmt.Fprintf(stderr, "session reconciler: rebaselining legacy live hash for %s: %v\n", name, err) //nolint:errcheck
+							} else {
+								fmt.Fprintf(stderr, "rebaselined legacy live hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedLive), truncateHashForLog(currentLive)) //nolint:errcheck
+							}
+							if trace != nil {
+								trace.recordDecision("reconciler.session.live_drift", tp.TemplateName, name, "live_drift", string(outcome), traceRecordPayload{
+									"stored_hash":  storedLive,
+									"current_hash": currentLive,
+								}, nil, "")
+							}
 						} else {
 							fmt.Fprintf(stdout, "Live config changed for '%s', re-applying...\n", tp.DisplayName()) //nolint:errcheck
 							if err := sp.RunLive(name, agentCfg); err != nil {
@@ -1391,6 +1428,24 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					agentCfg := sessionCoreConfigForHash(tp, *session)
 					currentHash := runtime.CoreFingerprint(agentCfg)
 					if storedHash != currentHash {
+						// Stored hash carries no version prefix or a different
+						// version — silently rebaseline rather than treating
+						// the asleep named session as drifted. ga-s760 FRs 1-3.
+						if runtime.IsLegacyOrMismatchedVersion(storedHash) {
+							outcome := rebaselineLegacyHashOutcome(storedHash)
+							if err := silentRebaselineSessionHashes(session, store, agentCfg); err != nil {
+								fmt.Fprintf(stderr, "session reconciler: rebaselining legacy hash for %s: %v\n", name, err) //nolint:errcheck
+							} else {
+								fmt.Fprintf(stderr, "rebaselined legacy hash for %s (stored=%s current=%s)\n", name, truncateHashForLog(storedHash), truncateHashForLog(currentHash)) //nolint:errcheck
+							}
+							if trace != nil {
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(outcome), traceRecordPayload{
+									"stored_hash":  storedHash,
+									"current_hash": currentHash,
+								}, nil, "")
+							}
+							continue
+						}
 						var storedBreakdown map[string]string
 						if raw := session.Metadata["core_hash_breakdown"]; raw != "" {
 							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
@@ -2440,6 +2495,68 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 		}
 	}
 	return ""
+}
+
+// truncateHashForLog returns a short representation of a fingerprint hash
+// for log output. Preserves any v<digits>: prefix so the version stays
+// visible alongside the hex tail.
+func truncateHashForLog(h string) string {
+	if i := strings.IndexByte(h, ':'); i >= 0 {
+		end := i + 1 + 10
+		if end > len(h) {
+			end = len(h)
+		}
+		return h[:end]
+	}
+	if len(h) > 12 {
+		return h[:12]
+	}
+	return h
+}
+
+// rebaselineLegacyHashOutcome picks the trace outcome that matches a
+// stored hash about to be silently rebaselined.
+func rebaselineLegacyHashOutcome(stored string) TraceOutcomeCode {
+	if runtime.IsVersionMismatchedHash(stored) {
+		return TraceOutcomeRebaselinedVersionMismatch
+	}
+	return TraceOutcomeRebaselinedUnversioned
+}
+
+// silentRebaselineSessionHashes overwrites the four fingerprint metadata
+// fields (started_config_hash, started_live_hash, live_hash,
+// core_hash_breakdown) with values produced by the current binary. Used
+// when a stored hash carries no version prefix or a version prefix that
+// does not match runtime.FingerprintVersion. The reconciler invokes this
+// instead of draining the session — the hash mismatch is purely a
+// versioning artifact, not real config drift.
+func silentRebaselineSessionHashes(session *beads.Bead, store beads.Store, agentCfg runtime.Config) error {
+	if session == nil || store == nil {
+		return nil
+	}
+	coreHash := runtime.CoreFingerprint(agentCfg)
+	liveHash := runtime.LiveFingerprint(agentCfg)
+	breakdown := runtime.CoreFingerprintBreakdown(agentCfg)
+	breakdownJSON, err := json.Marshal(breakdown)
+	if err != nil {
+		return fmt.Errorf("marshaling core_hash_breakdown: %w", err)
+	}
+	patch := map[string]string{
+		"started_config_hash": coreHash,
+		"started_live_hash":   liveHash,
+		"live_hash":           liveHash,
+		"core_hash_breakdown": string(breakdownJSON),
+	}
+	if err := store.SetMetadataBatch(session.ID, patch); err != nil {
+		return fmt.Errorf("rebaselining hashes: %w", err)
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, len(patch))
+	}
+	for k, v := range patch {
+		session.Metadata[k] = v
+	}
+	return nil
 }
 
 // resolveSessionCommand returns the command to use when starting a session.

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2524,6 +2524,159 @@ func TestReconcileSessionBeads_NoDriftWhenHashMatches(t *testing.T) {
 	}
 }
 
+// TestReconcilerSilentRebaselineOnLegacyHash enforces ga-s760.1 FR-1, FR-3:
+// when a session's stored core hash carries no version prefix (a session
+// started by a binary released before fingerprint versioning), the
+// reconciler must silently overwrite all four hash/breakdown metadata
+// fields with current versioned values. No drain, no SessionDraining
+// event.
+func TestReconcilerSilentRebaselineOnLegacyHash(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	rec := events.NewFake()
+	env.rec = rec
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	// Legacy bare-hex values as written by the pre-versioning binary.
+	legacyCore := strings.Repeat("a", 64)
+	legacyLive := strings.Repeat("b", 64)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": legacyCore,
+		"started_live_hash":   legacyLive,
+		"live_hash":           legacyLive,
+		"core_hash_breakdown": `{"Command":"legacy","Env":"legacy"}`,
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("expected no drain on legacy hash silent rebaseline, got %+v; stderr=%s", ds, env.stderr.String())
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionDraining {
+			t.Errorf("unexpected SessionDraining event recorded for silent rebaseline: %+v", e)
+		}
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	expectedCore := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"})
+	expectedLive := runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"})
+	if got.Metadata["started_config_hash"] != expectedCore {
+		t.Errorf("started_config_hash = %q, want rebaseline to %q", got.Metadata["started_config_hash"], expectedCore)
+	}
+	if got.Metadata["started_live_hash"] != expectedLive {
+		t.Errorf("started_live_hash = %q, want rebaseline to %q", got.Metadata["started_live_hash"], expectedLive)
+	}
+	if got.Metadata["live_hash"] != expectedLive {
+		t.Errorf("live_hash = %q, want rebaseline to %q", got.Metadata["live_hash"], expectedLive)
+	}
+	if got.Metadata["core_hash_breakdown"] == `{"Command":"legacy","Env":"legacy"}` {
+		t.Errorf("core_hash_breakdown was not rebaselined, still: %q", got.Metadata["core_hash_breakdown"])
+	}
+	if got.Metadata["core_hash_breakdown"] == "" {
+		t.Errorf("core_hash_breakdown was cleared but should be rebaselined to current breakdown")
+	}
+}
+
+// TestReconcilerSilentRebaselineOnVersionMismatch enforces ga-s760.1 FR-2,
+// FR-3: when a session's stored core hash carries a version prefix from a
+// different binary (e.g., v0:), the reconciler must silently rebaseline
+// all four hash/breakdown fields. No drain, no SessionDraining event.
+func TestReconcilerSilentRebaselineOnVersionMismatch(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	rec := events.NewFake()
+	env.rec = rec
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	// Version-mismatched stored hashes (v0: prefix is from an older binary).
+	mismatchCore := "v0:" + strings.Repeat("a", 64)
+	mismatchLive := "v0:" + strings.Repeat("b", 64)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": mismatchCore,
+		"started_live_hash":   mismatchLive,
+		"live_hash":           mismatchLive,
+		"core_hash_breakdown": `{"version":"v0","fields":{"Command":"old"}}`,
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("expected no drain on version-mismatch silent rebaseline, got %+v; stderr=%s", ds, env.stderr.String())
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionDraining {
+			t.Errorf("unexpected SessionDraining event recorded for silent rebaseline: %+v", e)
+		}
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	expectedCore := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"})
+	expectedLive := runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"})
+	if got.Metadata["started_config_hash"] != expectedCore {
+		t.Errorf("started_config_hash = %q, want rebaseline to %q", got.Metadata["started_config_hash"], expectedCore)
+	}
+	if got.Metadata["started_live_hash"] != expectedLive {
+		t.Errorf("started_live_hash = %q, want rebaseline to %q", got.Metadata["started_live_hash"], expectedLive)
+	}
+	if got.Metadata["live_hash"] != expectedLive {
+		t.Errorf("live_hash = %q, want rebaseline to %q", got.Metadata["live_hash"], expectedLive)
+	}
+	if got.Metadata["core_hash_breakdown"] == `{"version":"v0","fields":{"Command":"old"}}` {
+		t.Errorf("core_hash_breakdown was not rebaselined, still: %q", got.Metadata["core_hash_breakdown"])
+	}
+	if got.Metadata["core_hash_breakdown"] == "" {
+		t.Errorf("core_hash_breakdown was cleared but should be rebaselined to current breakdown")
+	}
+}
+
+// TestReconcilerStillDrainsOnSameVersionRealDrift enforces ga-s760.1 FR-4:
+// the silent rebaseline path must NOT swallow real drift. When stored and
+// current hashes share the current version prefix but differ in the hex
+// tail, the reconciler still drains the session. This is the regression
+// guard against the rebaseline branch over-applying.
+func TestReconcilerStillDrainsOnSameVersionRealDrift(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	// Desired state has a different command than the bead.
+	env.addRunningWorkerDesiredWithNewConfig()
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	// Stored hash carries the current version prefix but a fabricated hex
+	// that differs from whatever the desired-state config currently hashes
+	// to. The shared prefix means the version gate sees same-version, so
+	// the drift handling proceeds to compare the hex tails and drain.
+	storedCore := runtime.FingerprintVersion + ":" + strings.Repeat("c", 64)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": storedCore,
+	})
+
+	currentHash := runtime.CoreFingerprint(runtime.Config{Command: "new-cmd"})
+	if storedCore == currentHash {
+		t.Fatalf("test setup: stored hash %q should differ from current %q", storedCore, currentHash)
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	ds := env.dt.get(session.ID)
+	if ds == nil {
+		t.Fatalf("expected drain to be initiated for same-version real drift (session.ID=%q, stderr=%s)", session.ID, env.stderr.String())
+	}
+	if ds.reason != "config-drift" {
+		t.Errorf("drain reason = %q, want %q", ds.reason, "config-drift")
+	}
+}
+
 // Regression test for #127: a freshly created session can be drained for
 // config-drift shortly after wake because the reconciler's drift check runs
 // before started_config_hash is written. The fix skips drift detection until

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -166,6 +166,15 @@ const (
 	TraceOutcomeStartCandidate          TraceOutcomeCode = "start_candidate"
 	TraceOutcomeRetry                   TraceOutcomeCode = "retry"
 	TraceOutcomeCancel                  TraceOutcomeCode = "cancel"
+	// TraceOutcomeRebaselinedUnversioned marks a silent rebaseline of a
+	// stored fingerprint hash that carried no version prefix (legacy
+	// pre-versioning binary or otherwise malformed). No drain, no event.
+	TraceOutcomeRebaselinedUnversioned TraceOutcomeCode = "rebaselined_unversioned"
+	// TraceOutcomeRebaselinedVersionMismatch marks a silent rebaseline of
+	// a stored fingerprint hash whose v<digits>: prefix did not match the
+	// current FingerprintVersion (older or future binary). No drain, no
+	// event.
+	TraceOutcomeRebaselinedVersionMismatch TraceOutcomeCode = "rebaselined_version_mismatch"
 )
 
 type TraceCompletionStatus string

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+// FingerprintVersion namespaces the stored fingerprint hashes so the
+// reconciler can detect hashes written by older binaries (no prefix or a
+// different prefix) and silently rebaseline them instead of triggering a
+// false-positive drain. Bump this constant whenever the inputs to or the
+// algorithm of any Fingerprint helper change.
+const FingerprintVersion = "v1"
+
 // ConfigFingerprint returns a deterministic hash of the Config fields that
 // define an agent's behavioral identity. Changes to these fields indicate
 // the agent should be restarted (via drain when drain ops are available).
@@ -20,31 +27,77 @@ import (
 // Excluded (observation-only hints): WorkDir, ReadyPromptPrefix,
 // ReadyDelayMs, ProcessNames, EmitsPermissionWarning.
 //
-// The hash is a hex-encoded SHA-256. Same config always produces the same
-// hash regardless of map iteration order.
+// The hash is a hex-encoded SHA-256 prefixed with FingerprintVersion. Same
+// config always produces the same hash regardless of map iteration order.
 func ConfigFingerprint(cfg Config) string {
 	h := sha256.New()
 	hashCoreFields(h, cfg)
 	hashLiveFields(h, cfg)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%s:%x", FingerprintVersion, h.Sum(nil))
 }
 
 // CoreFingerprint returns a hash of only the "core" config fields —
 // everything except SessionLive. A change to core fields triggers a
 // drain + restart. A change to only SessionLive triggers re-apply
-// without restart.
+// without restart. Output is prefixed with FingerprintVersion.
 func CoreFingerprint(cfg Config) string {
 	h := sha256.New()
 	hashCoreFields(h, cfg)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%s:%x", FingerprintVersion, h.Sum(nil))
 }
 
 // LiveFingerprint returns a hash of only the SessionLive fields.
-// Used by the reconciler to detect live-only drift.
+// Used by the reconciler to detect live-only drift. Output is prefixed
+// with FingerprintVersion.
 func LiveFingerprint(cfg Config) string {
 	h := sha256.New()
 	hashLiveFields(h, cfg)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%s:%x", FingerprintVersion, h.Sum(nil))
+}
+
+// IsLegacyOrMismatchedVersion reports whether the stored hash should
+// trigger a silent rebaseline rather than a drift drain. Returns true for
+// stored hashes with no version prefix (legacy bare hex) or a version
+// prefix that does not match FingerprintVersion. Returns false for empty
+// stored hashes (those are gated separately by the reconciler) and for
+// stored hashes that share the current version prefix.
+func IsLegacyOrMismatchedVersion(stored string) bool {
+	if stored == "" {
+		return false
+	}
+	colon := strings.IndexByte(stored, ':')
+	if colon < 0 {
+		// No colon: a bare hex hash from a pre-versioning binary, or an
+		// otherwise malformed value. Either way, treat as legacy.
+		return true
+	}
+	return stored[:colon] != FingerprintVersion
+}
+
+// IsVersionMismatchedHash reports whether the stored hash carries a
+// well-formed `v<digits>:` prefix that does not match FingerprintVersion.
+// Used to distinguish "another binary's version" from "no version prefix
+// at all" for trace-outcome reporting. Returns false for empty stored,
+// current-version stored, unversioned stored, and stored with a
+// non-`v<digits>:` prefix shape.
+func IsVersionMismatchedHash(stored string) bool {
+	colon := strings.IndexByte(stored, ':')
+	if colon < 1 {
+		return false
+	}
+	prefix := stored[:colon]
+	if prefix == FingerprintVersion {
+		return false
+	}
+	if prefix[0] != 'v' {
+		return false
+	}
+	for i := 1; i < len(prefix); i++ {
+		if prefix[i] < '0' || prefix[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // envFingerprintAllow is the set of env keys whose values define agent

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -729,6 +730,101 @@ func TestHashPathContentUnreadableChild(t *testing.T) {
 	h := HashPathContent(sub)
 	if h != "" {
 		t.Errorf("expected empty hash when child is unreadable, got %q", h)
+	}
+}
+
+// TestFingerprintVersionedOutputFormat enforces FR-5/FR-7 from ga-s760.1:
+// every fingerprint helper emits "<FingerprintVersion>:<hex>" so the
+// reconciler can tell which binary produced a stored hash.
+func TestFingerprintVersionedOutputFormat(t *testing.T) {
+	if FingerprintVersion == "" {
+		t.Fatal("FingerprintVersion constant must be set (FR-7)")
+	}
+	if !strings.HasPrefix(FingerprintVersion, "v") {
+		t.Errorf("FingerprintVersion = %q, want a 'v'-prefixed identifier", FingerprintVersion)
+	}
+	for _, r := range FingerprintVersion[1:] {
+		if r < '0' || r > '9' {
+			t.Errorf("FingerprintVersion = %q, want v<digits> shape", FingerprintVersion)
+			break
+		}
+	}
+
+	prefix := FingerprintVersion + ":"
+	cfg := Config{
+		Command: "claude --skip",
+		Env:     map[string]string{"GC_CITY": "/x", "GC_RIG": "r"},
+		SessionLive: []string{
+			"tmux set-option -t {{.Session}} remain-on-exit on",
+		},
+	}
+
+	cases := []struct {
+		name string
+		got  string
+	}{
+		{"ConfigFingerprint", ConfigFingerprint(cfg)},
+		{"CoreFingerprint", CoreFingerprint(cfg)},
+		{"LiveFingerprint", LiveFingerprint(cfg)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.HasPrefix(tc.got, prefix) {
+				t.Fatalf("%s = %q, want prefix %q", tc.name, tc.got, prefix)
+			}
+			tail := strings.TrimPrefix(tc.got, prefix)
+			if tail == "" {
+				t.Fatalf("%s = %q, no hex tail after prefix", tc.name, tc.got)
+			}
+			if strings.Contains(tail, ":") {
+				t.Errorf("%s = %q, hex tail must not contain ':'", tc.name, tc.got)
+			}
+			for _, r := range tail {
+				if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+					t.Errorf("%s = %q, non-hex character %q in tail", tc.name, tc.got, r)
+					break
+				}
+			}
+			// The previous bare-hex output was 64 chars (SHA-256). The
+			// versioned output keeps the same hex tail length.
+			if len(tail) != 64 {
+				t.Errorf("%s tail length = %d, want 64", tc.name, len(tail))
+			}
+		})
+	}
+}
+
+// TestIsLegacyOrMismatchedVersion enforces FR-1, FR-2: the reconciler
+// distinguishes legacy (no prefix) and mismatched-version stored hashes
+// from current-version hashes via this helper. Reconciler treats the
+// "true" cases as triggers for silent rebaseline (no drain, no event).
+func TestIsLegacyOrMismatchedVersion(t *testing.T) {
+	bareHex := strings.Repeat("a", 64)
+	current := FingerprintVersion + ":" + bareHex
+
+	cases := []struct {
+		name   string
+		stored string
+		want   bool
+	}{
+		{"bare hex (no prefix, legacy)", bareHex, true},
+		{"empty stored (handled by separate gate, not legacy/mismatch)", "", false},
+		{"current version prefix", current, false},
+		{"v0 prefix (older mismatched version)", "v0:" + bareHex, true},
+		{"v2 prefix (future mismatched version)", "v2:" + bareHex, true},
+		{"vX prefix (non-numeric, treated as legacy)", "vX:" + bareHex, true},
+		{"v01 prefix (different literal version, mismatch)", "v01:" + bareHex, true},
+		{"non-v prefix (e.g. xyz, treated as legacy)", "xyz:" + bareHex, true},
+		{"colon-only prefix (no version literal, legacy)", ":" + bareHex, true},
+		{"prefix without colon (looks like bare hex)", FingerprintVersion + bareHex, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsLegacyOrMismatchedVersion(tc.stored)
+			if got != tc.want {
+				t.Errorf("IsLegacyOrMismatchedVersion(%q) = %v, want %v", tc.stored, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/release-gates/ga-s760-1-gate.md
+++ b/release-gates/ga-s760-1-gate.md
@@ -1,0 +1,97 @@
+# Release Gate: ga-s760.1 hash versioning + silent rebaseline
+
+Generated: 2026-05-16T15:45:05Z
+
+Branch under gate: `deploy/ga-s760-1` from `fork/builder/ga-s760-1`
+
+Source branch head: `501a6674205a`
+
+Base: `origin/main` at `d24018969552`
+
+Review bead: `ga-34pf`
+
+Source bead: `ga-s760.1`
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this repository or on
+`origin/main`; this gate uses the release criteria from the deployer prompt.
+
+## Gate Summary
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-34pf` notes contain `Reviewer verdict: PASS` and `Reviewer verdict (gascity/reviewer, 2026-04-30): PASS`. |
+| 2 | Acceptance criteria met | PASS | FR/NFR mapping below verified against code and validator tests. |
+| 3 | Tests pass | PASS | Targeted validator/regression command PASS; `make test-fast-parallel` PASS; `go vet ./...` PASS; `go build ./...` PASS. |
+| 4 | No high-severity review findings open | PASS | Review notes list no HIGH findings; only accepted non-blocking coverage notes and a previously fixed gate failure. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before gate generation; this gate file is committed as the release-gate commit and final clean status is rechecked before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git rev-list --left-right --count origin/main...HEAD` returned `0 2`; `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` produced no conflicts. |
+
+## Change Set
+
+| Commit | Purpose |
+|--------|---------|
+| `1ea9e069b` | Validator tests for versioned fingerprint output, version mismatch classification, silent rebaseline, and same-version real drift. |
+| `501a66742` | Implementation: version stored fingerprints and silently rebaseline legacy/version-mismatched session hashes. |
+
+Touched files:
+
+- `internal/runtime/fingerprint.go`
+- `internal/runtime/fingerprint_test.go`
+- `cmd/gc/session_reconciler.go`
+- `cmd/gc/session_reconciler_test.go`
+- `cmd/gc/session_reconciler_trace_types.go`
+
+## Acceptance Criteria Evidence
+
+| Requirement | Result | Evidence |
+|-------------|--------|----------|
+| FR-1: legacy unversioned stored hash must not drain | PASS | `runtime.IsLegacyOrMismatchedVersion` classifies bare hashes as rebaseline candidates; `TestReconcilerSilentRebaselineOnLegacyHash` asserts no `SessionDraining` event and no drain. |
+| FR-2: version-mismatched stored hash must not drain | PASS | `runtime.IsLegacyOrMismatchedVersion` classifies `v0:`/other version prefixes as mismatched; `TestReconcilerSilentRebaselineOnVersionMismatch` asserts no drain. |
+| FR-3: rebaseline writes four metadata fields atomically | PASS | `silentRebaselineSessionHashes` builds one `MetadataPatch` for `started_config_hash`, `started_live_hash`, `live_hash`, and `core_hash_breakdown`, then calls `SetMetadataBatch`; both rebaseline tests assert the fields are refreshed. |
+| FR-4: same-version real drift still drains | PASS | `TestReconcilerStillDrainsOnSameVersionRealDrift` asserts existing config-drift drain behavior remains active for same-version hash drift. |
+| FR-5: newly committed hashes are versioned | PASS | `ConfigFingerprint`, `CoreFingerprint`, and `LiveFingerprint` return `FingerprintVersion + ":" + sha256`; `TestFingerprintVersionedOutputFormat` covers all three. |
+| FR-6: breakdown version tag | PASS | Source bead explicitly defers structural breakdown versioning to MF-A (`ga-s760.2`); this bead rebaselines `core_hash_breakdown` to the current breakdown when legacy/mismatch hashes are detected. |
+| FR-7: single version constant | PASS | `runtime.FingerprintVersion` is the only source of the current `v1` namespace; `TestFingerprintVersionedOutputFormat` enforces shape and use. |
+| NFR-1: no extra reconciler I/O | PASS | Version classification is string inspection of already-loaded metadata before the existing hash drift path. |
+| NFR-2: existing fingerprint callers remain comparable | PASS | Existing fingerprint tests continue to compare outputs from the same versioned helpers; full fast unit baseline passed. |
+| NFR-3: version bump is one-line constant edit | PASS | Current version is isolated to `internal/runtime/fingerprint.go` as `const FingerprintVersion = "v1"`. |
+| NFR-4: no regex in hot path | PASS | `IsVersionMismatchedHash` uses direct string/digit scanning. |
+
+## Test Evidence
+
+Commands run on `deploy/ga-s760-1`:
+
+```text
+go test ./internal/runtime ./cmd/gc -run 'TestFingerprintVersionedOutputFormat|TestIsLegacyOrMismatchedVersion|TestReconcilerSilentRebaseline|TestReconcilerStillDrainsOnSameVersionRealDrift|TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag' -count=1
+ok  	github.com/gastownhall/gascity/internal/runtime	0.004s
+ok  	github.com/gastownhall/gascity/cmd/gc	0.127s
+
+make test-fast-parallel
+All fast jobs passed
+
+go vet ./...
+PASS
+
+go build ./...
+PASS
+```
+
+## Review Findings
+
+Unresolved HIGH findings: 0
+
+The review notes call out only non-blocking accepted coverage gaps:
+
+- live-only drift branch and asleep-named branch mirror the tested core branch;
+- trace outcome split is deterministic but not directly asserted;
+- hash truncation helper is used by exercised code paths but not directly unit-tested.
+
+## Branch Evidence
+
+```text
+git rev-list --left-right --count origin/main...HEAD
+0	2
+
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main
+<no output>
+```


### PR DESCRIPTION
## What this changes

Session fingerprint hashes now carry an explicit version prefix, starting with `v1:<sha256>`. When the reconciler sees an older unversioned stored hash, or a stored hash from a different fingerprint version, it silently refreshes the session metadata instead of draining and restarting the session.

Real same-version config drift is unchanged: if a stored `v1:` hash differs from the current `v1:` hash for the same fingerprint version, the existing config-drift drain path still runs. The visible operator impact is that upgrades which only change the hash namespace stop causing unnecessary session restarts.

The rebaseline path updates the core hash, live hash, started live hash, and core hash breakdown together, and records distinct trace outcomes for unversioned legacy hashes versus version-mismatched hashes.

## Review notes

- `internal/runtime/fingerprint.go` is the version boundary: `FingerprintVersion`, versioned fingerprint output, and legacy/version-mismatch classifiers.
- `cmd/gc/session_reconciler.go` adds the silent rebaseline guard before the existing drain logic in the core, live, and asleep named-session drift paths.
- No user config, CLI flags, API endpoints, or migration command are added.
- Same-version real drift remains intentionally restart-capable; the new behavior only covers missing or mismatched fingerprint versions.

## Test plan

- [x] `go test ./internal/runtime ./cmd/gc -run 'TestFingerprintVersionedOutputFormat|TestIsLegacyOrMismatchedVersion|TestReconcilerSilentRebaseline|TestReconcilerStillDrainsOnSameVersionRealDrift|TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] Release gate: [`release-gates/ga-s760-1-gate.md`](release-gates/ga-s760-1-gate.md)