### PR TITLE
Fix wait cleanup and explicit session wake requests

### DIFF
--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -81,6 +81,8 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
 			"state_reason":              "",
 			"pending_create_claim":      "",
 			"pending_create_started_at": "",
+			"wake_request":              "",
+			"wake_requested_at":         "",
 		}); err != nil {
 			fmt.Fprintf(stderr, "gc session wake: updating metadata: %v\n", err) //nolint:errcheck
 			return 1

--- a/cmd/gc/cmd_session_wake_test.go
+++ b/cmd/gc/cmd_session_wake_test.go
@@ -22,6 +22,7 @@ func TestSessionWake_StateTransitionsAndMetadata(t *testing.T) {
 		wantState       string
 		wantSleepReason string
 		wantPending     string
+		wantWakeRequest string
 	}{
 		{
 			name: "suspended requests start",
@@ -31,9 +32,10 @@ func TestSessionWake_StateTransitionsAndMetadata(t *testing.T) {
 				"held_until":   future,
 				"sleep_reason": "user-hold",
 			},
-			wantState:       "creating",
+			wantState:       "asleep",
 			wantSleepReason: "",
-			wantPending:     "true",
+			wantPending:     "",
+			wantWakeRequest: "explicit",
 		},
 		{
 			name: "drained requests start",
@@ -42,9 +44,10 @@ func TestSessionWake_StateTransitionsAndMetadata(t *testing.T) {
 				"state":        "drained",
 				"sleep_reason": "drained",
 			},
-			wantState:       "creating",
+			wantState:       "asleep",
 			wantSleepReason: "",
-			wantPending:     "true",
+			wantPending:     "",
+			wantWakeRequest: "explicit",
 		},
 		{
 			name: "creating clears quarantine but stays creating",
@@ -58,6 +61,7 @@ func TestSessionWake_StateTransitionsAndMetadata(t *testing.T) {
 			wantState:       "creating",
 			wantSleepReason: "",
 			wantPending:     "",
+			wantWakeRequest: "explicit",
 		},
 		{
 			name: "active stays active",
@@ -69,6 +73,7 @@ func TestSessionWake_StateTransitionsAndMetadata(t *testing.T) {
 			wantState:       "active",
 			wantSleepReason: "idle",
 			wantPending:     "",
+			wantWakeRequest: "explicit",
 		},
 	}
 
@@ -100,6 +105,9 @@ func TestSessionWake_StateTransitionsAndMetadata(t *testing.T) {
 			}
 			if got := updated.Metadata["pending_create_claim"]; got != tt.wantPending {
 				t.Fatalf("pending_create_claim = %q, want %q", got, tt.wantPending)
+			}
+			if got := updated.Metadata["wake_request"]; got != tt.wantWakeRequest {
+				t.Fatalf("wake_request = %q, want %q", got, tt.wantWakeRequest)
 			}
 			if got := updated.Metadata["held_until"]; got != "" {
 				t.Fatalf("held_until = %q, want empty", got)
@@ -337,11 +345,14 @@ func TestCmdSessionWake_PokesManagedControllerAndRequestsSuspendedStart(t *testi
 	if err != nil {
 		t.Fatalf("store.Get(%s): %v", sessionID, err)
 	}
-	if got := updated.Metadata["state"]; got != "creating" {
-		t.Fatalf("state = %q, want creating", got)
+	if got := updated.Metadata["state"]; got != "asleep" {
+		t.Fatalf("state = %q, want asleep", got)
 	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want true", got)
+	if got := updated.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want empty", got)
+	}
+	if got := updated.Metadata["wake_request"]; got != "explicit" {
+		t.Fatalf("wake_request = %q, want explicit", got)
 	}
 	if got := updated.Metadata["held_until"]; got != "" {
 		t.Fatalf("held_until = %q, want empty", got)
@@ -446,10 +457,13 @@ func TestCmdSessionWake_RequestsStartForContinuityEligibleArchivedSessionID(t *t
 	if err != nil {
 		t.Fatalf("Get(%s): %v", sessionID, err)
 	}
-	if got := updated.Metadata["state"]; got != "creating" {
-		t.Fatalf("state = %q, want creating", got)
+	if got := updated.Metadata["state"]; got != "archived" {
+		t.Fatalf("state = %q, want archived", got)
 	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want true", got)
+	if got := updated.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want empty", got)
+	}
+	if got := updated.Metadata["wake_request"]; got != "explicit" {
+		t.Fatalf("wake_request = %q, want explicit", got)
 	}
 }

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -716,6 +716,16 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 			}
 			continue
 		}
+		if sessionBead.Status == "closed" {
+			if err := setWaitTerminalState(store, wait.ID, map[string]string{
+				"state":       waitStateCanceled,
+				"canceled_at": now.UTC().Format(time.RFC3339),
+				"last_error":  "session-closed",
+			}); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		if !ok {
 			continue
 		}

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -507,6 +507,71 @@ func TestPrepareWaitWakeState_MarksDepsReady(t *testing.T) {
 	}
 }
 
+func TestPrepareWaitWakeState_CancelsWaitForClosedSession(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"continuation_epoch": "1",
+			"provider":           "codex",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	dep, err := store.Create(beads.Bead{Title: "dep"})
+	if err != nil {
+		t.Fatalf("create dep bead: %v", err)
+	}
+	if err := store.Close(dep.ID); err != nil {
+		t.Fatalf("close dep bead: %v", err)
+	}
+	waitBead, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"dep_ids":          dep.ID,
+			"dep_mode":         "all",
+			"registered_epoch": "1",
+			"delivery_attempt": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+
+	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("prepareWaitWakeState: %v", err)
+	}
+	if readyWaitSet[sessionBead.ID] {
+		t.Fatalf("readyWaitSet unexpectedly contains closed session %s", sessionBead.ID)
+	}
+	updated, err := store.Get(waitBead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(wait): %v", err)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("wait status = %q, want closed", updated.Status)
+	}
+	if got := updated.Metadata["state"]; got != waitStateCanceled {
+		t.Fatalf("wait state = %q, want %q", got, waitStateCanceled)
+	}
+	if got := updated.Metadata["last_error"]; got != "session-closed" {
+		t.Fatalf("wait last_error = %q, want session-closed", got)
+	}
+}
+
 func TestPrepareWaitWakeState_FailsMissingDependencyWait(t *testing.T) {
 	store := beads.NewMemStore()
 	sessionBead, err := store.Create(beads.Bead{

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -98,6 +98,7 @@ func buildAwakeInputFromReconciler(
 			SleepReason:            b.Metadata["sleep_reason"],
 			ManualSession:          isManualSessionBead(*b),
 			PendingCreate:          lifecycle.HasWakeCause(session.WakeCausePendingCreate),
+			ExplicitWake:           lifecycle.HasWakeCause(session.WakeCauseExplicit),
 			DependencyOnly:         b.Metadata["dependency_only"] == "true",
 			NamedIdentity:          lifecycle.NamedIdentity,
 			ConfiguredNamedSession: isNamedSessionBead(*b),
@@ -147,6 +148,8 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 			switch d.Reason {
 			case "pending-create":
 				reasons = []WakeReason{WakeCreate}
+			case "explicit-wake":
+				reasons = []WakeReason{WakeConfig}
 			case "attached":
 				reasons = []WakeReason{WakeAttached}
 			case "pending":

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -56,6 +56,7 @@ type AwakeSessionBead struct {
 	SleepReason            string
 	ManualSession          bool
 	PendingCreate          bool      // controller claimed this bead for initial start
+	ExplicitWake           bool      // explicit durable wake request is pending
 	DependencyOnly         bool      // only wakeable via dependency gate
 	NamedIdentity          string    // non-empty for named session beads
 	ConfiguredNamedSession bool      // configured_named_session metadata is true
@@ -112,6 +113,14 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			continue
 		}
 		desired[bead.SessionName] = "pending-create"
+	}
+	for _, bead := range input.SessionBeads {
+		if !bead.ExplicitWake || bead.State == "closed" || bead.DependencyOnly {
+			continue
+		}
+		if agent, ok := agentsByName[bead.Template]; ok && !agent.Suspended {
+			desired[bead.SessionName] = "explicit-wake"
+		}
 	}
 
 	// Named sessions
@@ -261,7 +270,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// input stays asleep until either its durable wait becomes ready
 		// or it still needs its initial launch.
 		if reason, inDesired := desired[name]; inDesired {
-			if !bead.WaitHold || bead.PendingCreate {
+			if !bead.WaitHold || bead.PendingCreate || bead.ExplicitWake {
 				decision.ShouldWake = true
 				decision.Reason = reason
 			}

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -313,6 +313,25 @@ func TestNamedOnDemand_PendingCreateWakesWithoutDemand(t *testing.T) {
 	assertReason(t, result, "hello-world--refinery", "pending-create")
 }
 
+func TestNamedOnDemand_ExplicitWakeWakesWithoutDemand(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:            "mc-1",
+			SessionName:   "hello-world--refinery",
+			Template:      "hello-world/refinery",
+			State:         "asleep",
+			ExplicitWake:  true,
+			NamedIdentity: "hello-world/refinery",
+			WaitHold:      true,
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "explicit-wake")
+}
+
 func TestNamedOnDemand_WorkDone_StaysAwakeUntilIdle(t *testing.T) {
 	// On-demand session with work done: still running, no demand.
 	// Stays awake via on-demand:running override — drains only after

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1251,7 +1251,7 @@ gc help [command]
 
 Checks for available work using the agent's work_query config.
 
-Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
+Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.

--- a/internal/api/session_model_phase0_lifecycle_spec_test.go
+++ b/internal/api/session_model_phase0_lifecycle_spec_test.go
@@ -359,17 +359,14 @@ func TestPhase0HandleSessionWake_ContinuityEligibleArchivedBeadRequestsStart(t *
 	if err != nil {
 		t.Fatalf("Get(%s): %v", id, err)
 	}
-	switch got := updated.Metadata["state"]; got {
-	case "creating":
-		if claim := updated.Metadata["pending_create_claim"]; claim != "true" {
-			t.Fatalf("pending_create_claim = %q, want true while creating", claim)
-		}
-	case "active":
-		if claim := updated.Metadata["pending_create_claim"]; claim != "" {
-			t.Fatalf("pending_create_claim = %q, want cleared after active", claim)
-		}
-	default:
-		t.Fatalf("state = %q, want creating or active", got)
+	if got := updated.Metadata["state"]; got != "archived" {
+		t.Fatalf("state = %q, want archived before reconciler processes wake request", got)
+	}
+	if claim := updated.Metadata["pending_create_claim"]; claim != "" {
+		t.Fatalf("pending_create_claim = %q, want empty before reconciler claims start", claim)
+	}
+	if got := updated.Metadata["wake_request"]; got != "explicit" {
+		t.Fatalf("wake_request = %q, want explicit", got)
 	}
 	if got := updated.Metadata["archived_at"]; got != "" {
 		t.Fatalf("archived_at = %q, want cleared after continuity wake", got)

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -562,6 +562,9 @@ func projectWakeCauses(input LifecycleInput, meta map[string]string) []WakeCause
 	if strings.TrimSpace(meta["pending_create_claim"]) == "true" {
 		causes = appendUniqueWakeCause(causes, WakeCausePendingCreate)
 	}
+	if strings.TrimSpace(meta["wake_request"]) == string(WakeCauseExplicit) {
+		causes = appendUniqueWakeCause(causes, WakeCauseExplicit)
+	}
 	if strings.TrimSpace(meta["pin_awake"]) == "true" {
 		causes = appendUniqueWakeCause(causes, WakeCausePinned)
 	}

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -114,6 +114,20 @@ func TestProjectLifecycleDesiredStateAndBlockers(t *testing.T) {
 			wantCauses:  []WakeCause{WakeCausePendingCreate},
 		},
 		{
+			name: "explicit wake request is a durable wake cause",
+			input: LifecycleInput{
+				Status: "open",
+				Metadata: map[string]string{
+					"state":        "asleep",
+					"session_name": "s-worker",
+					"wake_request": "explicit",
+				},
+				Now: now,
+			},
+			wantDesired: DesiredStateRunning,
+			wantCauses:  []WakeCause{WakeCauseExplicit},
+		},
+		{
 			name: "future hold blocks an otherwise runnable create claim",
 			input: LifecycleInput{
 				Status: "open",

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -55,6 +55,19 @@ func pendingCreateStartedAt(now time.Time) string {
 	return now.UTC().Format(time.RFC3339)
 }
 
+// RequestExplicitWakePatch records durable wake intent without claiming a
+// concrete start. The reconciler consumes the request when it prepares the
+// runtime start.
+func RequestExplicitWakePatch(reason string, now time.Time) MetadataPatch {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return MetadataPatch{
+		"wake_request":      reason,
+		"wake_requested_at": now.UTC().Format(time.RFC3339),
+	}
+}
+
 // RequestWakePatch records a controller-owned one-shot create claim.
 func RequestWakePatch(reason string, now time.Time) MetadataPatch {
 	return MetadataPatch{
@@ -97,6 +110,8 @@ func PreWakePatch(input PreWakePatchInput) MetadataPatch {
 		"sleep_reason":               input.SleepReason,
 		"sleep_intent":               "",
 		"generation":                 fmt.Sprintf("%d", input.Generation),
+		"wake_request":               "",
+		"wake_requested_at":          "",
 	}
 	if input.FreshWake {
 		patch["session_key"] = ""

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -17,6 +17,14 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 		want  MetadataPatch
 	}{
 		{
+			name:  "request explicit wake",
+			patch: RequestExplicitWakePatch("explicit", now),
+			want: MetadataPatch{
+				"wake_request":      "explicit",
+				"wake_requested_at": now.UTC().Format(time.RFC3339),
+			},
+		},
+		{
 			name:  "request wake",
 			patch: RequestWakePatch("explicit", now),
 			want: MetadataPatch{
@@ -52,6 +60,8 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"sleep_reason":               "idle-timeout",
 				"sleep_intent":               "",
 				"generation":                 "3",
+				"wake_request":               "",
+				"wake_requested_at":          "",
 			},
 		},
 		{
@@ -72,6 +82,8 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"sleep_reason":               "",
 				"sleep_intent":               "",
 				"generation":                 "4",
+				"wake_request":               "",
+				"wake_requested_at":          "",
 				"session_key":                "",
 				"started_config_hash":        "",
 				"started_live_hash":          "",

--- a/internal/session/waits.go
+++ b/internal/session/waits.go
@@ -218,14 +218,10 @@ func WakeSession(store beads.Store, sessionBead beads.Bead, now time.Time) ([]st
 	}
 	state := State(strings.TrimSpace(sessionBead.Metadata["state"]))
 	batch := ClearWakeBlockersPatch(state, sessionBead.Metadata["sleep_reason"])
-	if state == StateSuspended || state == StateDrained {
-		for k, v := range RequestWakePatch(string(WakeCauseExplicit), now) {
-			batch[k] = v
-		}
+	for k, v := range RequestExplicitWakePatch(string(WakeCauseExplicit), now) {
+		batch[k] = v
 	}
 	if view.BaseState == BaseStateArchived && view.ContinuityEligible {
-		// RequestWakePatch clears wake blockers before claiming the start.
-		batch = RequestWakePatch(string(WakeCauseExplicit), now)
 		batch["archived_at"] = ""
 		batch["continuity_eligible"] = "true"
 	}

--- a/internal/session/waits_test.go
+++ b/internal/session/waits_test.go
@@ -207,8 +207,11 @@ func TestWakeSessionContinuesAfterWaitLookupLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get(session): %v", err)
 	}
-	if got := updatedSession.Metadata["state"]; got != string(StateCreating) {
-		t.Fatalf("state = %q, want creating", got)
+	if got := updatedSession.Metadata["state"]; got != string(StateAsleep) {
+		t.Fatalf("state = %q, want asleep", got)
+	}
+	if got := updatedSession.Metadata["wake_request"]; got != string(WakeCauseExplicit) {
+		t.Fatalf("wake_request = %q, want explicit", got)
 	}
 	if got := updatedSession.Metadata["wait_lookup_capped_label"]; got != "session:"+sessionBead.ID {
 		t.Fatalf("wait_lookup_capped_label = %q, want session label", got)
@@ -452,7 +455,7 @@ func TestCancelWaits_CancelsLegacyWaitBeadsWithoutLegacyTypeQuery(t *testing.T) 
 	}
 }
 
-func TestWakeSessionRequestsStartForSuspendedBead(t *testing.T) {
+func TestWakeSessionRecordsExplicitWakeForSuspendedBead(t *testing.T) {
 	store := beads.NewMemStore()
 	now := time.Date(2026, 5, 3, 8, 30, 0, 0, time.UTC)
 	sessionBead, err := store.Create(beads.Bead{
@@ -478,17 +481,23 @@ func TestWakeSessionRequestsStartForSuspendedBead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get(session): %v", err)
 	}
-	if got := updated.Metadata["state"]; got != string(StateCreating) {
-		t.Fatalf("state = %q, want creating", got)
+	if got := updated.Metadata["state"]; got != string(StateAsleep) {
+		t.Fatalf("state = %q, want asleep", got)
 	}
-	if got := updated.Metadata["state_reason"]; got != string(WakeCauseExplicit) {
-		t.Fatalf("state_reason = %q, want explicit", got)
+	if got := updated.Metadata["state_reason"]; got != "user-hold" {
+		t.Fatalf("state_reason = %q, want user-hold", got)
 	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want true", got)
+	if got := updated.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want empty", got)
 	}
-	if got, want := updated.Metadata["pending_create_started_at"], now.UTC().Format(time.RFC3339); got != want {
-		t.Fatalf("pending_create_started_at = %q, want %q", got, want)
+	if got := updated.Metadata["pending_create_started_at"]; got != "" {
+		t.Fatalf("pending_create_started_at = %q, want empty", got)
+	}
+	if got := updated.Metadata["wake_request"]; got != string(WakeCauseExplicit) {
+		t.Fatalf("wake_request = %q, want explicit", got)
+	}
+	if got, want := updated.Metadata["wake_requested_at"], now.UTC().Format(time.RFC3339); got != want {
+		t.Fatalf("wake_requested_at = %q, want %q", got, want)
 	}
 	for _, key := range []string{"held_until", "wait_hold", "sleep_reason"} {
 		if got := updated.Metadata[key]; got != "" {
@@ -543,7 +552,7 @@ func TestWakeSessionRejectsArchivedHistoricalBead(t *testing.T) {
 	}
 }
 
-func TestWakeSessionRequestsStartForContinuityEligibleArchivedBead(t *testing.T) {
+func TestWakeSessionRecordsExplicitWakeForContinuityEligibleArchivedBead(t *testing.T) {
 	store := beads.NewMemStore()
 	now := time.Date(2026, 5, 3, 8, 45, 0, 0, time.UTC)
 	sessionBead, err := store.Create(beads.Bead{
@@ -585,17 +594,23 @@ func TestWakeSessionRequestsStartForContinuityEligibleArchivedBead(t *testing.T)
 	if err != nil {
 		t.Fatalf("Get(session): %v", err)
 	}
-	if got := updated.Metadata["state"]; got != string(StateCreating) {
-		t.Fatalf("state = %q, want creating", got)
+	if got := updated.Metadata["state"]; got != "archived" {
+		t.Fatalf("state = %q, want archived", got)
 	}
-	if got := updated.Metadata["state_reason"]; got != "explicit" {
-		t.Fatalf("state_reason = %q, want explicit", got)
+	if got := updated.Metadata["state_reason"]; got != "quarantine-recovery" {
+		t.Fatalf("state_reason = %q, want quarantine-recovery", got)
 	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want true", got)
+	if got := updated.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want empty", got)
 	}
-	if got, want := updated.Metadata["pending_create_started_at"], now.UTC().Format(time.RFC3339); got != want {
-		t.Fatalf("pending_create_started_at = %q, want %q", got, want)
+	if got := updated.Metadata["pending_create_started_at"]; got != "" {
+		t.Fatalf("pending_create_started_at = %q, want empty", got)
+	}
+	if got := updated.Metadata["wake_request"]; got != string(WakeCauseExplicit) {
+		t.Fatalf("wake_request = %q, want explicit", got)
+	}
+	if got, want := updated.Metadata["wake_requested_at"], now.UTC().Format(time.RFC3339); got != want {
+		t.Fatalf("wake_requested_at = %q, want %q", got, want)
 	}
 	for _, key := range []string{"held_until", "quarantined_until", "wait_hold", "sleep_intent", "sleep_reason", "archived_at"} {
 		if got := updated.Metadata[key]; got != "" {


### PR DESCRIPTION
## Summary
- cancel ready waits whose target session bead is already closed so stale human-approval waits do not linger
- make explicit session wake persist a durable wake_request instead of directly claiming pending_create/creating
- teach lifecycle projection and awake-set calculation to let the reconciler own explicit wake starts

## Verification
- go test ./cmd/gc -run 'TestSessionWake_StateTransitionsAndMetadata|TestCmdSessionWake|TestPrepareWaitWakeState|TestNamedOnDemand_ExplicitWakeWakesWithoutDemand|TestBuildAwakeInput|TestAwakeSetToWakeEvals'
- go test ./internal/session -run 'TestWakeSession|TestProjectLifecycleDesiredStateAndBlockers|TestLifecycleTransitionPatchesSetCompleteMetadata|TestClearWakeBlockersPatch|TestRequestWakePatch'
- go test ./internal/api -run TestPhase0HandleSessionWake_ContinuityEligibleArchivedBeadRequestsStart
- pre-commit hook: lint-changed, generated docs, go vet ./..., GC_FAST_UNIT=1 go test ./..., go test ./test/docsync
- built and installed /home/ubuntu/go/bin/gc from this branch
- restarted maintainer-city supervisor; verified running PID 2018305 from /home/ubuntu/go/bin/gc
- verified gc status and gc wait list against maintainer-city after deploy