### PR TITLE
Prune closed session beads in Gastown maintenance reaper

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1251,7 +1251,7 @@ gc help [command]
 
 Checks for available work using the agent's work_query config.
 
-Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
+Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -1178,6 +1178,276 @@ exit 0
 	}
 }
 
+func TestReaperPrunesClosedSessionBeadsWithBdPrune(t *testing.T) {
+	cityDir := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(cityDir); err == nil {
+		cityDir = resolved
+	}
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	canonicalCityDir, err := filepath.EvalSymlinks(cityDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(city dir): %v", err)
+	}
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"BD_CALL_LOG":      bdLog,
+		"BD_PRUNE_COUNT":   "7",
+		"DOLT_ARGS_LOG":    doltLog,
+		"DOLT_DBS":         "beads",
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	bdLogText := string(bdData)
+	wantArgs := "args=prune --pattern gm-* --older-than 720h --force --json"
+	if !strings.Contains(bdLogText, wantArgs) {
+		t.Fatalf("reaper did not call bd prune with the gm session-bead retention args %q:\n%s", wantArgs, bdLogText)
+	}
+	if got := strings.Count(bdLogText, "args=prune "); got != 1 {
+		t.Fatalf("reaper called bd prune %d times, want once:\n%s", got, bdLogText)
+	}
+	if !strings.Contains(bdLogText, "pwd="+canonicalCityDir) {
+		t.Fatalf("reaper did not run bd prune from the city dir:\n%s", bdLogText)
+	}
+	if !strings.Contains(bdLogText, "beads="+filepath.Join(canonicalCityDir, ".beads")) {
+		t.Fatalf("reaper did not scope bd prune to the city beads dir:\n%s", bdLogText)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "sessions-pruned:7") {
+		t.Fatalf("reaper summary did not report pruned sessions:\n%s", gcData)
+	}
+}
+
+func TestReaperSessionPruneDryRunOmitsForce(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"BD_CALL_LOG":                 bdLog,
+		"BD_PRUNE_COUNT":              "3",
+		"DOLT_ARGS_LOG":               doltLog,
+		"DOLT_DBS":                    "beads",
+		"GC_CALL_LOG":                 gcLog,
+		"GC_CITY":                     cityDir,
+		"GC_CITY_PATH":                cityDir,
+		"GC_DOLT_HOST":                "127.0.0.1",
+		"GC_DOLT_PORT":                "3307",
+		"GC_DOLT_USER":                "root",
+		"GC_DOLT_PASSWORD":            "",
+		"GC_REAPER_DRY_RUN":           "1",
+		"GC_REAPER_SESSION_PURGE_AGE": "24h",
+		"PATH":                        binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	bdLogText := string(bdData)
+	wantArgs := "args=prune --pattern gm-* --older-than 24h --json"
+	if !strings.Contains(bdLogText, wantArgs) {
+		t.Fatalf("reaper dry-run did not call bd prune with preview args %q:\n%s", wantArgs, bdLogText)
+	}
+	if strings.Contains(bdLogText, "--force") {
+		t.Fatalf("reaper dry-run passed --force to bd prune:\n%s", bdLogText)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "sessions-pruned:3") || !strings.Contains(gcLogText, "(dry run)") {
+		t.Fatalf("reaper dry-run summary did not report session prune preview count:\n%s", gcLogText)
+	}
+}
+
+func TestReaperSessionPruneAnomalyEscalates(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"BD_CALL_LOG":      bdLog,
+		"BD_PRUNE_COUNT":   "1500",
+		"DOLT_ARGS_LOG":    doltLog,
+		"DOLT_DBS":         "beads",
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION: Reaper anomalies detected [MEDIUM]") {
+		t.Fatalf("reaper did not send escalation mail for session-prune anomaly:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "gm: 1500 closed session beads pruned in one run (threshold: 1000)") {
+		t.Fatalf("reaper escalation did not include session-prune anomaly:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "sessions-pruned:1500") {
+		t.Fatalf("reaper summary did not include anomalous session-prune count:\n%s", gcLogText)
+	}
+}
+
+func TestReaperSessionPruneMissingBdDegradesToZero(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"DOLT_DBS":         "beads",
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + "/usr/bin:/bin",
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if strings.Contains(gcLogText, "ESCALATION") {
+		t.Fatalf("reaper escalated missing bd binary instead of degrading:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "sessions-pruned:0") {
+		t.Fatalf("reaper summary did not report zero pruned sessions without bd:\n%s", gcLogText)
+	}
+}
+
+func TestReaperSessionPruneRunsWhenNoDoltDatabases(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\n'
+    ;;
+esac
+exit 0
+`)
+	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"BD_CALL_LOG":       bdLog,
+		"BD_PRUNE_COUNT":    "0",
+		"DOLT_ARGS_LOG":     doltLog,
+		"GC_CALL_LOG":       gcLog,
+		"GC_CITY":           cityDir,
+		"GC_CITY_PATH":      cityDir,
+		"GC_DOLT_HOST":      "127.0.0.1",
+		"GC_DOLT_PORT":      "3307",
+		"GC_DOLT_USER":      "root",
+		"GC_DOLT_PASSWORD":  "",
+		"GC_REAPER_DRY_RUN": "1",
+		"PATH":              binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if !strings.Contains(string(bdData), "args=prune --pattern gm-* --older-than 720h --json") {
+		t.Fatalf("reaper did not run session prune when Dolt had no databases:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "sessions-pruned:0") {
+		t.Fatalf("reaper summary did not report zero session prune count without Dolt databases:\n%s", gcData)
+	}
+}
+
 func TestReaperClosesStaleWispChainsToFixpoint(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
@@ -3161,6 +3431,19 @@ case "$*" in
 *"SELECT id"*)
   printf 'id\n'
   ;;
+esac
+exit 0
+`)
+}
+
+func writeMaintenanceBdStub(t *testing.T, path string) {
+	t.Helper()
+	writeExecutable(t, path, `#!/bin/sh
+printf 'pwd=%s beads=%s args=%s\n' "$PWD" "${BEADS_DIR:-}" "$*" >> "$BD_CALL_LOG"
+case "$1" in
+  prune)
+    printf '{"pruned_count":%s}\n' "${BD_PRUNE_COUNT:-0}"
+    ;;
 esac
 exit 0
 `)

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -18,6 +18,7 @@ CITY_BEADS_DIR="$CITY_ABS/.beads"
 MAX_AGE="${GC_REAPER_MAX_AGE:-24h}"
 PURGE_AGE="${GC_REAPER_PURGE_AGE:-168h}"
 STALE_ISSUE_AGE="${GC_REAPER_STALE_ISSUE_AGE:-720h}"
+SESSION_PURGE_AGE="${GC_REAPER_SESSION_PURGE_AGE:-720h}"
 ALERT_THRESHOLD="${GC_REAPER_ALERT_THRESHOLD:-500}"
 DRY_RUN="${GC_REAPER_DRY_RUN:-}"
 
@@ -103,9 +104,11 @@ DATABASES=$(
         fi
     done < <(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2)
 )
+HAD_DATABASES=1
 if [ -z "$DATABASES" ]; then
-    # No databases accessible — nothing to do.
-    exit 0
+    # The Dolt-backed cleanup loop has no work, but the session-bead
+    # prune below still operates through bd's configured task store.
+    HAD_DATABASES=0
 fi
 
 TOTAL_STALE_WISPS=0
@@ -113,6 +116,8 @@ TOTAL_CLOSED_WISPS=0
 TOTAL_PURGED=0
 TOTAL_ISSUES_CLOSED=0
 TOTAL_STALE_ISSUES_SKIPPED=0
+TOTAL_SESSIONS_PRUNED=0
+SESSION_PRUNE_ATTEMPTED=0
 ANOMALIES=""
 
 sanitize_output() {
@@ -494,13 +499,41 @@ done <<EOF
 $DATABASES
 EOF
 
+# Step 6: prune closed gm session beads from the city's primary bead store.
+if [ -d "$CITY_BEADS_DIR" ] && command -v bd >/dev/null 2>&1; then
+    SESSION_PRUNE_ATTEMPTED=1
+    BD_PRUNE_ARGS=(prune --pattern 'gm-*' --older-than "$SESSION_PURGE_AGE")
+    if [ -z "$DRY_RUN" ]; then
+        BD_PRUNE_ARGS+=(--force)
+    fi
+    BD_PRUNE_ARGS+=(--json)
+
+    if PRUNE_JSON=$((
+        cd "$CITY_ABS" && BEADS_DIR="$CITY_BEADS_DIR" bd "${BD_PRUNE_ARGS[@]}"
+    ) 2>/dev/null); then
+        :
+    else
+        PRUNE_JSON='{"pruned_count":0}'
+    fi
+    PRUNE_COUNT=$(printf '%s' "$PRUNE_JSON" | sed -n 's/.*"pruned_count"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)
+    [ -z "$PRUNE_COUNT" ] && PRUNE_COUNT=0
+    TOTAL_SESSIONS_PRUNED=$PRUNE_COUNT
+    if [ "$PRUNE_COUNT" -gt 1000 ]; then
+        record_anomaly "gm" "$PRUNE_COUNT closed session beads pruned in one run (threshold: 1000)"
+    fi
+fi
+
+if [ "$HAD_DATABASES" -eq 0 ] && [ "$SESSION_PRUNE_ATTEMPTED" -eq 0 ]; then
+    exit 0
+fi
+
 # Report.
 if [ -n "$ANOMALIES" ]; then
     gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
         -m "$ANOMALIES" 2>/dev/null || true
 fi
 
-SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, closed:$TOTAL_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED"
+SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED"
 if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY (dry run)"
 fi

--- a/release-gates/ga-6zig-session-prune-gate.md
+++ b/release-gates/ga-6zig-session-prune-gate.md
@@ -1,0 +1,62 @@
+# Release gate - session-bead prune reaper step (ga-6zig)
+
+Date: 2026-05-16
+
+## Scope
+
+- Source bead: `ga-6zig` - Add session-bead prune step to reaper.sh (gm DB, 30d, bd prune)
+- Review bead: `ga-rblaak` - Review: session-bead prune reaper step
+- Branch under gate: `builder/ga-6zig-session-prune`
+- Builder commit: `99e10caa1d193c9b6710d15e03d76ba2205fddf1`
+- Change surface:
+  - `examples/gastown/packs/maintenance/assets/scripts/reaper.sh`
+  - `examples/gastown/maintenance_scripts_test.go`
+  - `docs/reference/cli.md`
+
+Note: `docs/PROJECT_MANIFEST.md` is not present on this branch. This gate uses
+the deployer role's release criteria plus the repository testing guidance in
+`TESTING.md`.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-rblaak` notes include `REVIEWER VERDICT: PASS` for builder commit `99e10caa1`. Single-pass review is sufficient while the gemini second-pass is disabled. |
+| 2 | Acceptance criteria met | PASS | The reaper script defines `GC_REAPER_SESSION_PURGE_AGE` defaulting to `720h`, calls `bd prune --pattern gm-* --older-than ... --json` from the city root with `BEADS_DIR` scoped to the city bead store, omits `--force` in dry-run mode, records an anomaly above 1000 pruned sessions, degrades to `sessions-pruned:0` when `bd` is missing, and includes `sessions-pruned:N` in the summary. Tests cover normal prune, dry-run preview, anomaly escalation, missing `bd`, and no-Dolt-database execution. |
+| 3 | Tests pass | PASS | `bash -n examples/gastown/packs/maintenance/assets/scripts/reaper.sh`; `go test ./examples/gastown -run 'TestReaperSessionPruneRunsWhenNoDoltDatabases|TestReaperSessionPrune|TestReaperPrunesClosedSessionBeadsWithBdPrune'`; `go test ./examples/gastown/...`; `make test-fast-parallel`; `go vet ./...`; manual dry run `GC_REAPER_DRY_RUN=1 GC_CITY_PATH=/home/jaword/projects/gc-management examples/gastown/packs/maintenance/assets/scripts/reaper.sh` exited 0 and printed `sessions-pruned:0`. |
+| 4 | No high-severity review findings open | PASS | `ga-rblaak` review notes list security/spec/coverage checks and only two non-blocking minor observations. No unresolved HIGH findings are present. |
+| 5 | Final branch is clean | PASS | After the gate commit, `git status --porcelain=v1 --branch` reported a clean tree on `deployer/ga-6zig-session-prune...origin/builder/ga-6zig-session-prune [ahead 1]`. |
+| 6 | Branch diverges cleanly from main | PASS | After the gate commit, `git merge-tree --write-tree origin/main HEAD` exited 0 with no conflict output. |
+
+## Acceptance Evidence
+
+| Requirement | Evidence |
+|-------------|----------|
+| `go test ./examples/gastown/...` passes | PASS: package sweep completed in 24.253s. |
+| `go vet ./...` clean | PASS: `go vet ./...` exited 0. |
+| Manual dry-run succeeds and reports `sessions-pruned:0` | PASS: dry run exited 0 and printed `reaper - stale_wisps:0, closed_wisps:0, purged:0, sessions-pruned:0, closed:0, skipped_non_city_issues:0 (dry run)`. |
+| Summary output includes `sessions-pruned:N` | PASS: tests assert `sessions-pruned:7`, `sessions-pruned:3`, `sessions-pruned:1500`, and `sessions-pruned:0`; manual dry run also reported `sessions-pruned:0`. |
+
+## Test Output Summary
+
+```text
+bash -n examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+PASS
+
+go test ./examples/gastown -run 'TestReaperSessionPruneRunsWhenNoDoltDatabases|TestReaperSessionPrune|TestReaperPrunesClosedSessionBeadsWithBdPrune'
+ok  	github.com/gastownhall/gascity/examples/gastown	0.239s
+
+go test ./examples/gastown/...
+ok  	github.com/gastownhall/gascity/examples/gastown	24.253s
+?   	github.com/gastownhall/gascity/examples/gastown/packs/gastown	[no test files]
+?   	github.com/gastownhall/gascity/examples/gastown/packs/maintenance	[no test files]
+
+make test-fast-parallel
+All fast jobs passed
+
+go vet ./...
+PASS
+
+GC_REAPER_DRY_RUN=1 GC_CITY_PATH=/home/jaword/projects/gc-management examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+reaper: reaper - stale_wisps:0, closed_wisps:0, purged:0, sessions-pruned:0, closed:0, skipped_non_city_issues:0 (dry run)
+```


### PR DESCRIPTION
## What this changes

The Gastown maintenance reaper now prunes closed session beads named `gm-*` from the city's primary bead store once per run. It uses `bd prune --pattern gm-* --older-than ${GC_REAPER_SESSION_PURGE_AGE:-720h}` and adds `sessions-pruned:N` to the reaper summary so operators can see retention activity in the existing maintenance signal.

Dry-run mode previews the prune count without passing `--force`. If `bd` is unavailable or the city bead store is missing, the reaper degrades to `sessions-pruned:0` instead of failing the whole maintenance cycle.

The implementation shells through `bd prune` instead of deleting bead rows directly, keeping retention behavior inside the bead tool. The target pattern stays hardcoded to `gm-*` so this remains a narrow storage-hygiene step, not a generalized cleanup policy.

## Review notes

- Main behavior is in `examples/gastown/packs/maintenance/assets/scripts/reaper.sh`; the new step runs after the per-database cleanup loop and before anomaly reporting.
- `GC_REAPER_SESSION_PURGE_AGE` is the only new operator knob; it defaults to `720h` and does not add a config schema field.
- Pruning more than 1000 closed session beads in one run uses the existing reaper anomaly path.
- This does not change `gc session prune`; it only affects the Gastown maintenance reaper script.

## Test plan

- [x] `bash -n examples/gastown/packs/maintenance/assets/scripts/reaper.sh`
- [x] `go test ./examples/gastown -run 'TestReaperSessionPruneRunsWhenNoDoltDatabases|TestReaperSessionPrune|TestReaperPrunesClosedSessionBeadsWithBdPrune'`
- [x] `go test ./examples/gastown/...`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Manual dry run with `GC_REAPER_DRY_RUN=1 GC_CITY_PATH=/home/jaword/projects/gc-management examples/gastown/packs/maintenance/assets/scripts/reaper.sh` reports `sessions-pruned:0`
- [x] Release gate: [`release-gates/ga-6zig-session-prune-gate.md`](release-gates/ga-6zig-session-prune-gate.md)