### PR TITLE
fix(maintenance): scrub order:* and convoy sling-* from jsonl-export

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3619,6 +3619,9 @@ func writeMultiRecordDoltStub(t *testing.T, binDir string, currentCount int) {
 func writeIssuesPayloadDoltStub(t *testing.T, binDir, issuesPayload string) {
 	t.Helper()
 	body := "#!/bin/sh\n" +
+		"if [ -n \"${DOLT_ARGS_LOG:-}\" ]; then\n" +
+		"  printf '%s\\n' \"$*\" >> \"$DOLT_ARGS_LOG\"\n" +
+		"fi\n" +
 		"case \"$*\" in\n" +
 		"  *\"SHOW TABLES FROM\"*\"LIKE 'wisps'\"*)\n" +
 		"    printf 'Tables_in_db\\nwisps\\n'\n" +
@@ -4026,22 +4029,57 @@ func TestJsonlExportScrubTrueFiltersRowsWithoutDroppingWholePayload(t *testing.T
 	stateDir := t.TempDir()
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	doltLog := filepath.Join(t.TempDir(), "dolt.log")
 	archiveRepo := filepath.Join(cityDir, "archive")
 
 	initSeedArchive(t, archiveRepo, 12)
-	rows := make([]string, 0, 13)
-	rows = append(rows, `{"id":"bd-100","title":"real-leading-prefix"}`)
-	for i := 1; i < 12; i++ {
-		rows = append(rows, fmt.Sprintf(`{"id":"prod-%d","title":"real-%d"}`, i, i))
+	rows := []string{
+		`{"id":"bd-100","title":"real-leading-prefix","issue_type":"task"}`,
+		`{"id":"prod-gc-near","title":"agc:kept","issue_type":"task"}`,
+		`{"id":"prod-order-near","title":"preorder:kept","issue_type":"task"}`,
+		`{"id":"prod-sling-task","title":"sling-ga-user-task","issue_type":"task"}`,
+		`{"id":"prod-manual-convoy","title":"manual-convoy","issue_type":"convoy"}`,
 	}
-	rows = append(rows, `{"id":"prod-test","title":"Test Issue 99"}`)
+	for i := 1; i <= 7; i++ {
+		rows = append(rows, fmt.Sprintf(`{"id":"prod-%d","title":"real-%d","issue_type":"task"}`, i, i))
+	}
+	rows = append(rows,
+		`{"id":"prod-test","title":"Test Issue 99","issue_type":"task"}`,
+		`{"id":"sys-gc","title":"gc:status","issue_type":"task"}`,
+		`{"id":"sys-order","title":"order:beads-health","issue_type":"task"}`,
+		`{"id":"sys-auto-convoy","title":"sling-ga-auto","issue_type":"convoy"}`,
+		`{"id":"sys-message","title":"message-row","issue_type":"message"}`,
+		`{"id":"sys-event","title":"event-row","issue_type":"event"}`,
+		`{"id":"sys-wisp","title":"wisp-row","issue_type":"wisp"}`,
+		`{"id":"sys-agent","title":"agent-row","issue_type":"agent"}`,
+	)
+	if len(rows) != 20 {
+		t.Fatalf("test fixture row count drifted: got %d, want 20", len(rows))
+	}
 	writeIssueRowsDoltStub(t, binDir, rows)
 	writeJsonlExportGCStub(t, binDir)
 
 	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
 	env["GC_JSONL_SCRUB"] = "true"
+	env["DOLT_ARGS_LOG"] = doltLog
 
 	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+
+	doltData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	doltSQL := string(doltData)
+	for _, want := range []string{
+		"issue_type NOT IN ('message', 'event', 'wisp', 'agent')",
+		"title NOT LIKE 'gc:%'",
+		"title NOT LIKE 'order:%'",
+		"NOT (issue_type = 'convoy' AND title LIKE 'sling-%')",
+	} {
+		if !strings.Contains(doltSQL, want) {
+			t.Fatalf("expected scrub SQL to contain %q, got:\n%s", want, doltSQL)
+		}
+	}
 
 	mailData, err := os.ReadFile(mailLog)
 	if err != nil && !os.IsNotExist(err) {
@@ -4061,8 +4099,24 @@ func TestJsonlExportScrubTrueFiltersRowsWithoutDroppingWholePayload(t *testing.T
 	if !strings.Contains(string(exported), `"id":"bd-100"`) {
 		t.Fatalf("expected scrubbed export to preserve the legitimate bd-100 row, got:\n%s", exported)
 	}
-	if strings.Contains(string(exported), "Test Issue 99") {
-		t.Fatalf("expected scrubbed export to remove the test row, got:\n%s", exported)
+	for _, want := range []string{"prod-gc-near", "prod-order-near", "prod-sling-task", "prod-manual-convoy"} {
+		if !strings.Contains(string(exported), want) {
+			t.Fatalf("expected scrubbed export to preserve near-miss row %q, got:\n%s", want, exported)
+		}
+	}
+	for _, unwanted := range []string{
+		"Test Issue 99",
+		"sys-gc",
+		"sys-order",
+		"sys-auto-convoy",
+		"sys-message",
+		"sys-event",
+		"sys-wisp",
+		"sys-agent",
+	} {
+		if strings.Contains(string(exported), unwanted) {
+			t.Fatalf("expected scrubbed export to remove %q, got:\n%s", unwanted, exported)
+		}
 	}
 
 	legacyExported, err := os.ReadFile(filepath.Join(archiveRepo, "beads.jsonl"))
@@ -4075,8 +4129,24 @@ func TestJsonlExportScrubTrueFiltersRowsWithoutDroppingWholePayload(t *testing.T
 	if !strings.Contains(string(legacyExported), `"id":"bd-100"`) {
 		t.Fatalf("expected legacy flat export to preserve the legitimate bd-100 row, got:\n%s", legacyExported)
 	}
-	if strings.Contains(string(legacyExported), "Test Issue 99") {
-		t.Fatalf("expected legacy flat export to remove the test row, got:\n%s", legacyExported)
+	for _, want := range []string{"prod-gc-near", "prod-order-near", "prod-sling-task", "prod-manual-convoy"} {
+		if !strings.Contains(string(legacyExported), want) {
+			t.Fatalf("expected legacy flat export to preserve near-miss row %q, got:\n%s", want, legacyExported)
+		}
+	}
+	for _, unwanted := range []string{
+		"Test Issue 99",
+		"sys-gc",
+		"sys-order",
+		"sys-auto-convoy",
+		"sys-message",
+		"sys-event",
+		"sys-wisp",
+		"sys-agent",
+	} {
+		if strings.Contains(string(legacyExported), unwanted) {
+			t.Fatalf("expected legacy flat export to remove %q, got:\n%s", unwanted, legacyExported)
+		}
 	}
 
 	gcData, err := os.ReadFile(gcLog)

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -41,9 +41,14 @@ count_jsonl_rows() {
     jq -s -r 'if length == 0 then 0 else ((.[0].rows // []) | length) end' || echo "0"
 }
 
-# Scrub test-only rows while preserving the JSON export structure and legitimate
-# rows in the same payload. The input is one JSON object with a .rows array, not
-# newline-delimited JSON, so row-level filtering must happen inside jq.
+# Scrub test-only rows and ephemeral system rows while preserving the JSON
+# export structure and legitimate rows in the same payload. The input is one
+# JSON object with a .rows array, not newline-delimited JSON, so row-level
+# filtering must happen inside jq.
+#
+# Mirrors the SQL SCRUB_FILTER built below so post-export validation matches
+# the pre-export filter — any system issue_type or system-task title pattern
+# that slips past the SQL filter is still removed here.
 scrub_exported_issues() {
     jq -c '
         if (.rows? | type) == "array" then
@@ -56,7 +61,9 @@ scrub_exported_issues() {
                             (.id // "") == "bd-abc12" or
                             ((.id // "") | test("^(testdb_|beads_t)"))
                         ) | not
-                    )
+                    ) and
+                    ((.issue_type // "") | test("^(message|event|wisp|agent)$") | not) and
+                    ((.title // "") | test("^(gc:|order:|convoy sling-)") | not)
                 )
             )
         else
@@ -692,7 +699,7 @@ fi
 # Build scrub filter for the issues table.
 SCRUB_FILTER=""
 if [ "$SCRUB" = "true" ]; then
-    SCRUB_FILTER="WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%'"
+    SCRUB_FILTER="WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%' AND title NOT LIKE 'order:%' AND title NOT LIKE 'convoy sling-%'"
 fi
 
 TOTAL_EXPORTED=0

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -47,8 +47,8 @@ count_jsonl_rows() {
 # filtering must happen inside jq.
 #
 # Mirrors the SQL SCRUB_FILTER built below so post-export validation matches
-# the pre-export filter — any system issue_type or system-task title pattern
-# that slips past the SQL filter is still removed here.
+# the pre-export filter — any system issue_type, system-task title pattern, or
+# scoped auto-convoy that slips past the SQL filter is still removed here.
 scrub_exported_issues() {
     jq -c '
         if (.rows? | type) == "array" then
@@ -63,7 +63,8 @@ scrub_exported_issues() {
                         ) | not
                     ) and
                     ((.issue_type // "") | test("^(message|event|wisp|agent)$") | not) and
-                    ((.title // "") | test("^(gc:|order:|convoy sling-)") | not)
+                    ((.title // "") | test("^(gc:|order:)") | not) and
+                    ((((.issue_type // "") == "convoy") and ((.title // "") | test("^sling-"))) | not)
                 )
             )
         else
@@ -699,7 +700,7 @@ fi
 # Build scrub filter for the issues table.
 SCRUB_FILTER=""
 if [ "$SCRUB" = "true" ]; then
-    SCRUB_FILTER="WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%' AND title NOT LIKE 'order:%' AND title NOT LIKE 'convoy sling-%'"
+    SCRUB_FILTER="WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%' AND title NOT LIKE 'order:%' AND NOT (issue_type = 'convoy' AND title LIKE 'sling-%')"
 fi
 
 TOTAL_EXPORTED=0

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
@@ -7,7 +7,8 @@ git repository, and pushes to origin. This provides a human-readable,
 git-versioned backup of all durable work product.
 
 Current behavior:
-- Exports issues table with scrub filter (excludes messages, events, wisps, etc.)
+- Exports issues table with scrub filter (excludes messages, events, wisps,
+  agents, gc:/order: system titles, and auto-convoys titled sling-*)
 - Exports supplemental tables (comments, config, dependencies, labels, metadata)
 - Writes per-database subdirectories + legacy flat files
 - Commits with counts and pushes to git remote
@@ -96,10 +97,13 @@ needs = ["export"]
 description = """
 Verify export integrity before committing.
 
-**1. Filter test pollution:**
-Remove records matching test patterns from exported JSONL:
+**1. Filter test pollution and ephemeral system rows:**
+Remove records matching test and system patterns from exported JSONL:
 - Titles starting with "Test Issue" or "test_"
 - IDs matching test patterns: bd-1, bd-abc12, testdb_*, beads_t*, etc.
+- Issue types message, event, wisp, and agent
+- System task titles starting with "gc:" or "order:"
+- Auto-convoy rows with issue_type "convoy" and titles starting with "sling-"
 
 **2. Spike detection:**
 Compare current export record counts against previous commit.


### PR DESCRIPTION
## Summary

- Extend `SCRUB_FILTER` in `jsonl-export.sh` to exclude `order:%` and `convoy sling-%` title patterns in addition to the existing `gc:%` exclusion.
- Update the post-export `scrub_exported_issues` jq helper to mirror the SQL pre-filter (issue_type system rows + all title patterns), so post-export validation matches what the SQL filter removes.

## Problem

The maintenance pack's JSONL spike-detection runs every 15 minutes and HALT/ESCALATEs to the Mayor when a database's row count drops more than 20%. Today at `2026-05-16T19:29:55Z` the `pa` db dropped from 401 -> 58 records (-85%), triggering an unnecessary HIGH escalation.

Investigation showed all 401 pre-drop IDs were ephemeral `task`-type beads with high-churn system titles like `order:gate-sweep:rig:partcl`, `order:order-tracking-sweep:rig:partcl`, `order:orphan-sweep:rig:partcl`, `convoy sling-pa-*`, etc. These are created and pruned within minutes by normal maintenance, so the JSONL row count was being dominated by churn rather than real user beads. No data loss — just noise.

The SCRUB_FILTER (jsonl-export.sh:614 in current HEAD) excluded `gc:%` titled tasks but not `order:%` or `convoy sling-%`.

## Fix

```diff
-    SCRUB_FILTER="WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%'"
+    SCRUB_FILTER="WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%' AND title NOT LIKE 'order:%' AND title NOT LIKE 'convoy sling-%'"
```

And mirror the SQL exclusions in the post-export jq helper so the two filter layers stay in sync:

```diff
                     ) and
+                    ((.issue_type // "") | test("^(message|event|wisp|agent)$") | not) and
+                    ((.title // "") | test("^(gc:|order:|convoy sling-)") | not)
```

After this change, JSONL row counts reflect only durable user beads (bugs, features, real tasks), not the system-order churn — eliminating the spurious HIGH escalations.

## Test plan

- [x] `bash -n` on the modified script
- [x] Smoke-test `scrub_exported_issues` against synthetic rows covering: real bugs/features (kept), `gc:` / `order:` / `convoy sling-` prefixed titles (removed), `message` issue_type (removed), test fixtures `bd-1` / `Test Issue:` (removed by existing logic), `order management` (kept — prefix anchor requires colon).
- [x] Edge cases: `{}` (dolt empty payload, PR #1908 fix), `{"rows":[]}`, rows missing `id`/`title`/`issue_type` fields — all handled cleanly.
- [ ] Validated against a live `pa` db export after merge: row count should reflect only user-created beads, no `order:*` / `convoy sling-*` rows.

## References

- Last HALT commit in `.gc/runtime/packs/maintenance/jsonl-archive`: `f035847`
- Related: #1908 (validate empty `{}`), #1848 (SCRUB_FILTER issue_type column fix), #1800 (auto-detect archive mode), #1819 (skip non-bd databases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)