### PR TITLE
fix(hooks): surface clear error for malformed Claude settings override (#2109)

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	iofs "io/fs"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -369,20 +368,32 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 	}
 
 	// Apply targeted in-place upgrades to legacy forms of managed gascity
-	// hook commands and matchers in the user's override before merging with
-	// the embedded base. Custom hook events and custom commands are
-	// preserved verbatim. The previous "use base instead" path discarded
-	// user customizations along with stale managed-hook bytes; this path
-	// patches the managed bytes while keeping customizations intact.
+	// hook commands and matchers in the user's override before merging
+	// with the embedded base. Custom hook events and custom commands are
+	// preserved semantically: command strings and hook entries are not
+	// modified, though MarshalCanonicalJSON may re-order keys or arrays
+	// when an upgrade rewrite is applied. The previous "use base instead"
+	// path discarded user customizations along with stale managed-hook
+	// bytes; this path patches the managed bytes while keeping
+	// customizations intact.
 	upgradedOverride, _, upgradeErr := upgradeClaudeFile(overrideData)
 	if upgradeErr != nil {
-		// Upgrade failure (e.g., malformed JSON) — fall back to original
-		// override; better to keep the user file as-is than fail install.
-		// Log so unexpected upgrade failures are discoverable rather than
-		// silent: a malformed user file is benign here, but a
-		// MarshalCanonicalJSON failure would indicate a gascity bug.
-		log.Printf("hooks: claude settings upgrade failed, using original override: %v", upgradeErr)
-		upgradedOverride = overrideData
+		// Distinguish a malformed user file from a gascity-side
+		// MarshalCanonicalJSON failure. JSON parse errors point at the
+		// user's override; the canonical recovery is to skip the merge
+		// and surface a clear, actionable error that names the file —
+		// previously this path silently re-assigned the malformed bytes
+		// and crashed downstream with a cryptic "merging ... : invalid
+		// character" error from MergeSettingsJSON. Marshal failures
+		// shouldn't happen on user data (we already parsed it
+		// successfully above) so they indicate a gascity bug worth
+		// surfacing too. See gastownhall/gascity#2109.
+		var syntaxErr *json.SyntaxError
+		var typeErr *json.UnmarshalTypeError
+		if errors.As(upgradeErr, &syntaxErr) || errors.As(upgradeErr, &typeErr) {
+			return nil, claudeSettingsSourceNone, fmt.Errorf("invalid JSON in Claude settings override at %s; fix or remove the file to proceed with install: %w", overridePath, upgradeErr)
+		}
+		return nil, claudeSettingsSourceNone, fmt.Errorf("upgrading Claude settings from %s: %w", overridePath, upgradeErr)
 	}
 
 	merged, err := overlay.MergeSettingsJSON(base, upgradedOverride)
@@ -742,7 +753,10 @@ func claudeFileNeedsUpgrade(existing []byte) bool {
 // known legacy forms of managed gascity hook commands and matchers to their
 // current shape. Walks the hook events so upgrades can be event-aware
 // (e.g. SessionStart matcher upgrade, PreCompact command upgrade); custom
-// hook events and custom commands are preserved verbatim.
+// hook events and custom commands are preserved semantically — their
+// command strings and entry contents are untouched, though
+// MarshalCanonicalJSON may reorder keys or arrays when an upgrade
+// rewrite is applied.
 //
 // Returns the (possibly re-marshaled) JSON bytes and whether any patch
 // was applied.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1340,7 +1340,11 @@ func TestInstallClaudeSurfacesEmptyPreferredOverride(t *testing.T) {
 
 // TestInstallClaudeSurfacesMalformedOverride verifies that a syntactically
 // invalid .claude/settings.json surfaces a descriptive error rather than
-// silently falling back to a legacy source or the embedded base.
+// silently falling back to a legacy source or the embedded base. The error
+// message must (a) name the offending path and (b) clearly identify the
+// file as having invalid JSON — previously this path surfaced a cryptic
+// "merging Claude settings from %s: invalid character ..." that obscured
+// the root cause. See gastownhall/gascity#2109.
 func TestInstallClaudeSurfacesMalformedOverride(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/.claude/settings.json"] = []byte(`{not valid json`)
@@ -1351,6 +1355,12 @@ func TestInstallClaudeSurfacesMalformedOverride(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), ".claude/settings.json") {
 		t.Errorf("error must name the offending path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Errorf("error must clearly identify the file as invalid JSON (not bury it in a generic merge error): %v", err)
+	}
+	if strings.Contains(err.Error(), "merging Claude settings") {
+		t.Errorf("error must not surface as a generic 'merging Claude settings' wrap — that hides the JSON-parse root cause from operators: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #2109. Follow-up to PR #2072 (JSON-aware Claude settings upgrade).

## Problem

When a user's `.claude/settings.json` contains invalid JSON, install crashes with a cryptic merge-error wrap:

```
merging Claude settings from <path>: invalid character ...
```

That message frames the problem as a merge failure, hiding the actual root cause (the user's override file is malformed). The fallback path at `internal/hooks/hooks.go:377-386` claimed in its comment that "a malformed user file is benign here" but actually re-assigned the malformed bytes to `upgradedOverride` and let `MergeSettingsJSON` crash downstream.

## Fix

Distinguish JSON parse errors (`json.SyntaxError`, `json.UnmarshalTypeError` — user-side problem) from `MarshalCanonicalJSON` failures (gascity-side problem). For the parse case, return an actionable error that names the root cause:

```
invalid JSON in Claude settings override at <path>; fix or remove the file to proceed with install: <underlying err>
```

Marshal failures continue to bubble with their own context since they should not happen against data we already parsed successfully — if they do, that's a gascity bug worth surfacing too.

The existing `TestInstallClaudeSurfacesMalformedOverride` encoded strict-fail design intent (install must surface a descriptive error, not silently degrade). This change preserves that contract while making the error message actually descriptive — extending the test to assert the new error format and to guard against regressing back to the generic merge-error wrap.

## Doc nit

The two "preservation" comments at `prepareClaudeSettings` (line 371-378) and `upgradeClaudeFile` (line 745) claimed customizations were "preserved verbatim." The upgrade path may re-marshal via `MarshalCanonicalJSON`, which can reorder keys and arrays. Reworded to "preserved semantically — command strings and entry contents untouched, though MarshalCanonicalJSON may reorder keys or arrays when an upgrade rewrite is applied."

(`internal/hooks/hooks.go:73` — `// name is used verbatim for the switch lookup` — and `:908` — `// requires that body to equal a known legacy form verbatim` — use "verbatim" correctly to mean exact-string match, not preservation. Left alone.)

## Gates

- `go build ./...` ✓
- `go vet ./...` ✓
- `make lint` (golangci-lint) → 0 issues
- `make test` (full fast sweep) ✓

The pre-existing `TestInstallClaudeSurfacesMalformedOverride` test passes with the new error format and the strengthened assertions catch any regression back to the cryptic wrap.