### PR TITLE
fix: sanitize raw transcript SSE frames

### DIFF
--- a/internal/api/session_frame_types.go
+++ b/internal/api/session_frame_types.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -55,16 +56,71 @@ func wrapRawFrameBytes(values []json.RawMessage) []SessionRawMessageFrame {
 	return out
 }
 
-// MarshalJSON emits Raw verbatim if set; otherwise json.Marshal(Value).
-// Emits `null` when both are empty.
+// MarshalJSON emits valid Raw verbatim if set; otherwise json.Marshal(Value).
+// Some provider transcript sources have historically produced frames with
+// literal control characters inside JSON strings. Repair that producer bug at
+// the API boundary so SSE streams never emit malformed JSON. Emits `null`
+// when both are empty.
 func (f SessionRawMessageFrame) MarshalJSON() ([]byte, error) {
 	if len(f.Raw) > 0 {
-		return f.Raw, nil
+		if json.Valid(f.Raw) {
+			return f.Raw, nil
+		}
+		if repaired := escapeRawControlsInJSONStringLiterals(f.Raw); json.Valid(repaired) {
+			return repaired, nil
+		}
+		return nil, fmt.Errorf("invalid raw session frame JSON")
 	}
 	if f.Value == nil {
 		return []byte("null"), nil
 	}
 	return json.Marshal(f.Value)
+}
+
+func escapeRawControlsInJSONStringLiterals(raw []byte) []byte {
+	out := make([]byte, 0, len(raw))
+	inString := false
+	escaped := false
+
+	for _, b := range raw {
+		if inString {
+			if escaped {
+				escaped = false
+				out = append(out, b)
+				continue
+			}
+
+			switch b {
+			case '\\':
+				escaped = true
+				out = append(out, b)
+			case '"':
+				inString = false
+				out = append(out, b)
+			case '\n':
+				out = append(out, '\\', 'n')
+			case '\r':
+				out = append(out, '\\', 'r')
+			case '\t':
+				out = append(out, '\\', 't')
+			default:
+				if b < 0x20 {
+					const hex = "0123456789abcdef"
+					out = append(out, '\\', 'u', '0', '0', hex[b>>4], hex[b&0x0f])
+				} else {
+					out = append(out, b)
+				}
+			}
+			continue
+		}
+
+		if b == '"' {
+			inString = true
+		}
+		out = append(out, b)
+	}
+
+	return out
 }
 
 // UnmarshalJSON stashes the raw JSON into Raw so round-tripping

--- a/internal/api/session_frame_types_test.go
+++ b/internal/api/session_frame_types_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestSessionRawMessageFrameEscapesLiteralNewlinesInRawJSONStrings(t *testing.T) {
+	// The raw frame intentionally contains literal newline bytes inside the
+	// JSON string value — this is the malformed producer output we're repairing.
 	rawFrame := json.RawMessage("{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"line one\n\nline two\"}]}")
 
 	encoded, err := json.Marshal(SessionStreamRawMessageEvent{

--- a/internal/api/session_frame_types_test.go
+++ b/internal/api/session_frame_types_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSessionRawMessageFrameEscapesLiteralNewlinesInRawJSONStrings(t *testing.T) {
+	rawFrame := json.RawMessage("{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"line one\n\nline two\"}]}")
+
+	encoded, err := json.Marshal(SessionStreamRawMessageEvent{
+		ID:       "mc-test",
+		Template: "worker",
+		Provider: "claude",
+		Format:   "raw",
+		Messages: []SessionRawMessageFrame{{Raw: rawFrame}},
+	})
+	if err != nil {
+		t.Fatalf("Marshal SessionStreamRawMessageEvent: %v", err)
+	}
+
+	body := string(encoded)
+	if strings.Contains(body, "\n") {
+		t.Fatalf("encoded raw stream event contains physical newline: %q", body)
+	}
+	if !strings.Contains(body, `line one\n\nline two`) {
+		t.Fatalf("encoded raw stream event did not preserve escaped text newlines: %q", body)
+	}
+	if !json.Valid(encoded) {
+		t.Fatalf("encoded raw stream event is not valid JSON: %q", body)
+	}
+}


### PR DESCRIPTION
## Summary
- sanitize invalid raw transcript frames that contain literal control characters inside JSON strings before SSE encoding
- preserve valid raw frames unchanged
- add a regression test for newline-containing transcript text so raw session events stay valid JSON

## Tests
- go test ./internal/api -run TestSessionRawMessageFrameEscapesLiteralNewlinesInRawJSONStrings -count=1
- go test ./internal/api
- go test ./internal/sessionlog ./internal/worker ./internal/api
- git diff --check
- commit hook: go vet ./... and GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...