### PR TITLE
docs(templates): explain auto_gc_behavior=false in dolt-config templates (#2156)

### DIFF
--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -142,6 +142,8 @@ listener:
 
 data_dir: %q
 
+# auto_gc is disabled — dolt#10944 load-avg gating means upstream auto-GC effectively never fires.
+# Compaction-driven scheduled GC replaces it. See gastownhall/gascity#1918, #1200, #1977 for context.
 behavior:
   auto_gc_behavior:
     enable: false

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1010,6 +1010,8 @@ listener:
 
 data_dir: "$DATA_DIR"
 
+# auto_gc is disabled — dolt#10944 load-avg gating means upstream auto-GC effectively never fires.
+# Compaction-driven scheduled GC replaces it. See gastownhall/gascity#1918, #1200, #1977 for context.
 behavior:
   auto_gc_behavior:
     enable: false


### PR DESCRIPTION
Closes #2156. Comment-only follow-up to #1977 (closed as already-fixed-by-#1918).

Adds a two-line comment above the `auto_gc_behavior` block in both `dolt-config.yaml` templates pointing at the upstream + downstream issue chain so future maintainers don't accidentally flip `enable: false` back to `true` without context.

## Surface

- `cmd/gc/cmd_dolt_config.go` (managed-runtime template, +2 LOC)
- `examples/bd/assets/scripts/gc-beads-bd.sh` (pack-side template, +2 LOC)

No test changes — comment-only.

## Why

- `internal/doctor/checks.go` enforces `enable: false` as the canonical value, but a future maintainer editing the template directly might not see the doctor check.
- The dolt#10944 context (load-avg gating breaking upstream auto-GC) lives in PR description text that's easy to lose.
- Trivial addition with high anti-regression value.

## Gates

- `go build ./...` ✓
- `go vet ./...` ✓
- `make lint` (golangci-lint) → 0 issues
- `make test` full fast sweep ✓