### PR TITLE
test(beads): per-field coverage + dedup-skip note for updateMatchesCached (#2199)

### DIFF
--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -298,6 +298,15 @@ func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error 
 // metadataAlreadyMatchesCached but covers the full UpdateOpts surface
 // (Title, Status, Type, Priority, Description, ParentID, Assignee, Metadata,
 // Labels, RemoveLabels). See gastownhall/gascity#1978 Phase 1.
+//
+// The short-circuit path skips the deduplication that
+// applyUpdateOptsToBead performs on the non-short-circuit pass. Cached
+// bead labels come from bd/dolt's canonical state, which never produces
+// duplicates, so a Labels-equal match here is a Labels-equal match in
+// the store after applyUpdateOptsToBead would have run. If a future
+// path injects duplicate labels into the cache, this short-circuit
+// would skip the dedup-fixup — file an issue rather than relaxing the
+// invariant here.
 func (c *CachingStore) updateMatchesCached(id string, opts UpdateOpts) bool {
 	if id == "" {
 		return false
@@ -346,6 +355,11 @@ func (c *CachingStore) updateMatchesCached(id string, opts UpdateOpts) bool {
 		}
 	}
 	if len(opts.Labels) > 0 || len(opts.RemoveLabels) > 0 {
+		// Set-equality check: opts.Labels ⊆ existing AND
+		// (opts.RemoveLabels ∩ existing) = ∅ implies the final label set
+		// after applyUpdateOptsToBead equals the current set. We skip
+		// that function's dedup pass here — see the doc comment above
+		// for why that's safe under bd/dolt's canonical labels.
 		existing := make(map[string]struct{}, len(b.Labels))
 		for _, l := range b.Labels {
 			existing[l] = struct{}{}

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -418,3 +418,190 @@ func TestCachingStoreCloseFallsThroughOnCacheMiss(t *testing.T) {
 			backing.closeCalls)
 	}
 }
+
+// TestCachingStoreUpdateSkipsBackingPerFieldMatch is the per-field
+// short-circuit coverage requested in gastownhall/gascity#2199. The original
+// PR #2159 exercised Assignee + Labels-mismatch + cache-miss only; the
+// remaining 6 field branches in updateMatchesCached were asserted by
+// inspection. This table-driven test pins the short-circuit behavior for
+// each field independently so a future refactor of any single check
+// surfaces in CI.
+func TestCachingStoreUpdateSkipsBackingPerFieldMatch(t *testing.T) {
+	t.Parallel()
+
+	type fieldCase struct {
+		name string
+		seed Bead
+		opts UpdateOpts
+	}
+	strPtr := func(s string) *string { return &s }
+	intPtr := func(i int) *int { return &i }
+
+	cases := []fieldCase{
+		{
+			name: "Title",
+			seed: Bead{Title: "pinned"},
+			opts: UpdateOpts{Title: strPtr("pinned")},
+		},
+		{
+			name: "Status",
+			seed: Bead{Title: "x", Status: "open"},
+			opts: UpdateOpts{Status: strPtr("open")},
+		},
+		{
+			name: "Type",
+			seed: Bead{Title: "x", Type: "task"},
+			opts: UpdateOpts{Type: strPtr("task")},
+		},
+		{
+			name: "Priority",
+			seed: Bead{Title: "x", Priority: intPtr(2)},
+			opts: UpdateOpts{Priority: intPtr(2)},
+		},
+		{
+			name: "Description",
+			seed: Bead{Title: "x", Description: "body"},
+			opts: UpdateOpts{Description: strPtr("body")},
+		},
+		{
+			name: "ParentID",
+			seed: Bead{Title: "x", ParentID: "gc-parent"},
+			opts: UpdateOpts{ParentID: strPtr("gc-parent")},
+		},
+		{
+			name: "Metadata",
+			seed: Bead{Title: "x", Metadata: map[string]string{"k": "v"}},
+			opts: UpdateOpts{Metadata: map[string]string{"k": "v"}},
+		},
+		{
+			name: "Labels-present",
+			seed: Bead{Title: "x", Labels: []string{"a", "b"}},
+			opts: UpdateOpts{Labels: []string{"a"}},
+		},
+		{
+			name: "RemoveLabels-absent",
+			seed: Bead{Title: "x", Labels: []string{"a"}},
+			opts: UpdateOpts{RemoveLabels: []string{"z"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			backing := &countingBackingStore{Store: NewMemStore()}
+			bead, err := backing.Create(tc.seed)
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			cache := NewCachingStoreForTest(backing, nil)
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+			backing.updateCalls = 0
+
+			if err := cache.Update(bead.ID, tc.opts); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if backing.updateCalls != 0 {
+				t.Errorf("backing.Update called %d times; want 0 (%s value-match must short-circuit)",
+					backing.updateCalls, tc.name)
+			}
+		})
+	}
+}
+
+// TestCachingStoreUpdateFallsThroughPerFieldMismatch is the mismatch-side
+// companion to TestCachingStoreUpdateSkipsBackingPerFieldMatch. Each
+// subtest asserts that a real change in the named field forces the
+// backing call — guarding the matcher against accidentally returning true
+// when a single field actually differs.
+func TestCachingStoreUpdateFallsThroughPerFieldMismatch(t *testing.T) {
+	t.Parallel()
+
+	type fieldCase struct {
+		name string
+		seed Bead
+		opts UpdateOpts
+	}
+	strPtr := func(s string) *string { return &s }
+	intPtr := func(i int) *int { return &i }
+
+	cases := []fieldCase{
+		{
+			name: "Title",
+			seed: Bead{Title: "before"},
+			opts: UpdateOpts{Title: strPtr("after")},
+		},
+		{
+			name: "Status",
+			seed: Bead{Title: "x", Status: "open"},
+			opts: UpdateOpts{Status: strPtr("closed")},
+		},
+		{
+			name: "Type",
+			seed: Bead{Title: "x", Type: "task"},
+			opts: UpdateOpts{Type: strPtr("epic")},
+		},
+		{
+			name: "Priority",
+			seed: Bead{Title: "x", Priority: intPtr(2)},
+			opts: UpdateOpts{Priority: intPtr(3)},
+		},
+		{
+			name: "Priority-nil-cached",
+			seed: Bead{Title: "x"},
+			opts: UpdateOpts{Priority: intPtr(2)},
+		},
+		{
+			name: "Description",
+			seed: Bead{Title: "x", Description: "before"},
+			opts: UpdateOpts{Description: strPtr("after")},
+		},
+		{
+			name: "ParentID",
+			seed: Bead{Title: "x", ParentID: "gc-a"},
+			opts: UpdateOpts{ParentID: strPtr("gc-b")},
+		},
+		{
+			name: "Metadata-value",
+			seed: Bead{Title: "x", Metadata: map[string]string{"k": "old"}},
+			opts: UpdateOpts{Metadata: map[string]string{"k": "new"}},
+		},
+		{
+			name: "Metadata-missing-key",
+			seed: Bead{Title: "x"},
+			opts: UpdateOpts{Metadata: map[string]string{"k": "v"}},
+		},
+		{
+			name: "RemoveLabels-present",
+			seed: Bead{Title: "x", Labels: []string{"a", "b"}},
+			opts: UpdateOpts{RemoveLabels: []string{"a"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			backing := &countingBackingStore{Store: NewMemStore()}
+			bead, err := backing.Create(tc.seed)
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			cache := NewCachingStoreForTest(backing, nil)
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+			backing.updateCalls = 0
+
+			if err := cache.Update(bead.ID, tc.opts); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if backing.updateCalls != 1 {
+				t.Errorf("backing.Update called %d times; want 1 (%s real change must propagate)",
+					backing.updateCalls, tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2199. Hygiene follow-up to PR #2159 (#1978 Phase 1).

## What

PR #2159 introduced `updateMatchesCached` with checks for 9 field categories. The merged regression tests exercised `Assignee` + `Labels` mismatch + cache-miss only; the remaining 6 field branches were asserted by inspection.

Add per-field coverage via two table-driven tests:

- **`TestCachingStoreUpdateSkipsBackingPerFieldMatch`** — 9 subtests for the positive short-circuit (`Title`, `Status`, `Type`, `Priority`, `Description`, `ParentID`, `Metadata`, `Labels-present`, `RemoveLabels-absent`).
- **`TestCachingStoreUpdateFallsThroughPerFieldMismatch`** — 10 subtests for the mismatch branches that must propagate, including the `Priority-nil-cached` and `Metadata-missing-key` edge cases the inspection-only review didn't formally pin.

Also clarify the dedup-skip behavior the matcher relies on:

- Extend the function doc comment on `updateMatchesCached` to call out that the short-circuit path skips `applyUpdateOptsToBead`'s dedup pass, and document the cached-labels-are-canonical invariant the skip relies on.
- Add an inline comment on the label-block setting out the set-equality semantics so a future reader sees the contract without chasing into `applyUpdateOptsToBead`.

## Out of scope

- Cache hit-rate observability — tracked in #2153 (Phase 2 of #1978), not duplicated here.

## Gates

- `go build ./...` ✓
- `go vet ./...` ✓
- `make lint` (golangci-lint) → 0 issues
- `make test` full fast sweep ✓ (all 19 new subtests pass)