### PR TITLE
feat: add JSON for formula and order inspection

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -27,7 +28,8 @@ func newFormulaCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func newFormulaListCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available formulas",
 		Long: `List all formulas available in the city's formula search paths.
@@ -35,53 +37,37 @@ func newFormulaListCmd(stdout, stderr io.Writer) *cobra.Command {
 Formulas are discovered from city-level and rig-level formula directories
 configured via packs and formulas_dir settings.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			paths := allFormulaSearchPaths(stderr)
+			cityPath, paths, rows := listFormulaRows(stderr)
+			if jsonOutput {
+				return writeCLIJSONLine(stdout, formulaListJSON{
+					SchemaVersion: "1",
+					CityPath:      cityPath,
+					SearchPaths:   paths,
+					Formulas:      rows,
+					Summary:       formulaListSummaryJSON{Count: len(rows)},
+				})
+			}
 			if len(paths) == 0 {
 				_, _ = fmt.Fprintln(stdout, "No formula search paths configured.")
 				return nil
 			}
-
-			// Scan search paths for canonical and legacy formula TOML files,
-			// deduplicating by name (last path wins, matching formula layer
-			// resolution order).
-			winners := make(map[string]bool)
-			for _, dir := range paths {
-				entries, err := os.ReadDir(dir)
-				if err != nil {
-					continue
-				}
-				for _, e := range entries {
-					if e.IsDir() {
-						continue
-					}
-					name, ok := formula.TrimTOMLFilename(e.Name())
-					if !ok {
-						continue
-					}
-					winners[name] = true
-				}
-			}
-
-			if len(winners) == 0 {
+			if len(rows) == 0 {
 				_, _ = fmt.Fprintln(stdout, "No formulas found.")
 				return nil
 			}
 
-			names := make([]string, 0, len(winners))
-			for name := range winners {
-				names = append(names, name)
-			}
-			slices.Sort(names)
-
-			for _, name := range names {
-				_, _ = fmt.Fprintln(stdout, name)
+			for _, row := range rows {
+				_, _ = fmt.Fprintln(stdout, row.Name)
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
+	return cmd
 }
 
 func newFormulaShowCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "show <formula-name>",
 		Short: "Show a compiled formula recipe",
@@ -144,6 +130,10 @@ Examples:
 					&formula.Formula{Vars: recipe.Vars},
 					vars,
 				)
+			}
+
+			if jsonOutput {
+				return writeCLIJSONLine(stdout, formulaShowJSONFromRecipe(recipe, cityPath, scope, rigVars, vars, displayVars))
 			}
 
 			_, _ = fmt.Fprintf(stdout, "Formula: %s\n", recipe.Name)
@@ -261,7 +251,218 @@ Examples:
 	}
 
 	cmd.Flags().StringArray("var", nil, "variable substitution for preview (key=value)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
 	return cmd
+}
+
+type formulaListJSON struct {
+	SchemaVersion string                 `json:"schema_version"`
+	CityPath      string                 `json:"city_path,omitempty"`
+	SearchPaths   []string               `json:"search_paths"`
+	Formulas      []formulaListRowJSON   `json:"formulas"`
+	Summary       formulaListSummaryJSON `json:"summary"`
+	Warnings      []jsonContractWarning  `json:"warnings,omitempty"`
+}
+
+type formulaListRowJSON struct {
+	Name   string `json:"name"`
+	Source string `json:"source,omitempty"`
+}
+
+type formulaListSummaryJSON struct {
+	Count int `json:"count"`
+}
+
+type formulaShowJSON struct {
+	SchemaVersion string                `json:"schema_version"`
+	CityPath      string                `json:"city_path,omitempty"`
+	Name          string                `json:"name"`
+	Description   string                `json:"description,omitempty"`
+	Phase         string                `json:"phase,omitempty"`
+	Pour          bool                  `json:"pour,omitempty"`
+	RootOnly      bool                  `json:"root_only,omitempty"`
+	SearchPaths   []string              `json:"search_paths"`
+	Vars          []formulaVarJSON      `json:"vars,omitempty"`
+	Steps         []formulaStepJSON     `json:"steps"`
+	Deps          []formulaDepJSON      `json:"deps,omitempty"`
+	ProvidedVars  map[string]string     `json:"provided_vars,omitempty"`
+	Warnings      []jsonContractWarning `json:"warnings,omitempty"`
+}
+
+type formulaVarJSON struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Default     *string  `json:"default,omitempty"`
+	RigDefault  *string  `json:"rig_default,omitempty"`
+	Required    bool     `json:"required,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Pattern     string   `json:"pattern,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+}
+
+type formulaStepJSON struct {
+	ID          string            `json:"id"`
+	Title       string            `json:"title,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Notes       string            `json:"notes,omitempty"`
+	Type        string            `json:"type,omitempty"`
+	Priority    *int              `json:"priority,omitempty"`
+	Labels      []string          `json:"labels,omitempty"`
+	Assignee    string            `json:"assignee,omitempty"`
+	IsRoot      bool              `json:"is_root,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+type formulaDepJSON struct {
+	StepID      string `json:"step_id"`
+	DependsOnID string `json:"depends_on_id"`
+	Type        string `json:"type,omitempty"`
+	Metadata    string `json:"metadata,omitempty"`
+}
+
+type jsonContractWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func listFormulaRows(warningWriter ...io.Writer) (string, []string, []formulaListRowJSON) {
+	cityPath, err := resolveCity()
+	if err != nil {
+		return "", nil, nil
+	}
+	cfg, err := loadCityConfig(cityPath, warningWriter...)
+	if err != nil {
+		return cityPath, nil, nil
+	}
+	paths := formulaSearchPathsForList(cfg)
+
+	// Scan search paths for canonical and legacy formula TOML files,
+	// deduplicating by name (last path wins, matching formula layer
+	// resolution order).
+	winners := make(map[string]string)
+	for _, dir := range paths {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name, ok := formula.TrimTOMLFilename(e.Name())
+			if !ok {
+				continue
+			}
+			winners[name] = filepath.Join(dir, e.Name())
+		}
+	}
+
+	names := make([]string, 0, len(winners))
+	for name := range winners {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	rows := make([]formulaListRowJSON, 0, len(names))
+	for _, name := range names {
+		rows = append(rows, formulaListRowJSON{Name: name, Source: winners[name]})
+	}
+	return cityPath, paths, rows
+}
+
+func formulaSearchPathsForList(cfg *config.City) []string {
+	if cfg == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var all []string
+	add := func(paths []string) {
+		for _, p := range paths {
+			if _, ok := seen[p]; !ok {
+				seen[p] = struct{}{}
+				all = append(all, p)
+			}
+		}
+	}
+	add(cfg.FormulaLayers.City)
+	for _, layers := range cfg.FormulaLayers.Rigs {
+		add(layers)
+	}
+	return all
+}
+
+func formulaShowJSONFromRecipe(recipe *formula.Recipe, cityPath string, scope formulaScope, rigVars, providedVars, displayVars map[string]string) formulaShowJSON {
+	out := formulaShowJSON{
+		SchemaVersion: "1",
+		CityPath:      cityPath,
+		Name:          recipe.Name,
+		Description:   recipe.Description,
+		Phase:         recipe.Phase,
+		Pour:          recipe.Pour,
+		RootOnly:      recipe.RootOnly,
+		SearchPaths:   scope.searchPaths,
+		ProvidedVars:  providedVars,
+	}
+	if len(displayVars) > 0 {
+		out.Description = formula.Substitute(out.Description, displayVars)
+	}
+
+	names := recipe.VariableNames()
+	out.Vars = make([]formulaVarJSON, 0, len(names))
+	for _, name := range names {
+		def := recipe.Vars[name]
+		if def == nil {
+			out.Vars = append(out.Vars, formulaVarJSON{Name: name})
+			continue
+		}
+		row := formulaVarJSON{
+			Name:        name,
+			Description: def.Description,
+			Default:     def.Default,
+			Required:    def.Required,
+			Type:        def.Type,
+			Pattern:     def.Pattern,
+			Enum:        def.Enum,
+		}
+		if v, ok := rigVars[name]; ok {
+			rigDefault := v
+			row.RigDefault = &rigDefault
+		}
+		out.Vars = append(out.Vars, row)
+	}
+
+	out.Steps = make([]formulaStepJSON, 0, len(recipe.Steps))
+	for _, step := range recipe.Steps {
+		row := formulaStepJSON{
+			ID:          step.ID,
+			Title:       step.Title,
+			Description: step.Description,
+			Notes:       step.Notes,
+			Type:        step.Type,
+			Priority:    step.Priority,
+			Labels:      step.Labels,
+			Assignee:    step.Assignee,
+			IsRoot:      step.IsRoot,
+			Metadata:    step.Metadata,
+		}
+		if len(displayVars) > 0 {
+			row.Title = formula.Substitute(row.Title, displayVars)
+			row.Description = formula.Substitute(row.Description, displayVars)
+			row.Notes = formula.Substitute(row.Notes, displayVars)
+		}
+		out.Steps = append(out.Steps, row)
+	}
+
+	out.Deps = make([]formulaDepJSON, 0, len(recipe.Deps))
+	for _, dep := range recipe.Deps {
+		out.Deps = append(out.Deps, formulaDepJSON{
+			StepID:      dep.StepID,
+			DependsOnID: dep.DependsOnID,
+			Type:        dep.Type,
+			Metadata:    dep.Metadata,
+		})
+	}
+	return out
 }
 
 func newFormulaCookCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -665,32 +665,3 @@ func rigFormulaVarsForScope(cfg *config.City, cityPath string) map[string]string
 	}
 	return map[string]string{}
 }
-
-// allFormulaSearchPaths returns the deduplicated union of formula search
-// paths across city and all rigs. Used by gc formula list to discover
-// every available formula regardless of scope.
-func allFormulaSearchPaths(warningWriter ...io.Writer) []string {
-	cityPath, err := resolveCity()
-	if err != nil {
-		return nil
-	}
-	cfg, err := loadCityConfig(cityPath, warningWriter...)
-	if err != nil {
-		return nil
-	}
-	seen := make(map[string]struct{})
-	var all []string
-	add := func(paths []string) {
-		for _, p := range paths {
-			if _, ok := seen[p]; !ok {
-				seen[p] = struct{}{}
-				all = append(all, p)
-			}
-		}
-	}
-	add(cfg.FormulaLayers.City)
-	for _, layers := range cfg.FormulaLayers.Rigs {
-		add(layers)
-	}
-	return all
-}

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -8,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
 )
 
 // TestResolveFormulaScope_RigFlagWins verifies that an explicit --rig flag
@@ -243,5 +246,69 @@ func TestResolveFormulaScope_RigFallsBackToCityLayers(t *testing.T) {
 	want := []string{"/city/formulas"}
 	if !reflect.DeepEqual(scope.searchPaths, want) {
 		t.Errorf("searchPaths = %v, want %v (city fallback)", scope.searchPaths, want)
+	}
+}
+
+func TestFormulaShowJSONFromRecipe(t *testing.T) {
+	defaultValue := "main"
+	priority := 1
+	recipe := &formula.Recipe{
+		Name:        "mol-build",
+		Description: "Build {{branch}}",
+		Phase:       "liquid",
+		Vars: map[string]*formula.VarDef{
+			"branch": {
+				Description: "branch to build",
+				Default:     &defaultValue,
+			},
+			"target": {
+				Description: "target name",
+				Required:    true,
+			},
+		},
+		Steps: []formula.RecipeStep{
+			{ID: "mol-build", Title: "Build", Type: "molecule", IsRoot: true},
+			{ID: "mol-build.test", Title: "Test {{target}}", Type: "task", Priority: &priority, Labels: []string{"ci"}},
+		},
+		Deps: []formula.RecipeDep{{StepID: "mol-build.test", DependsOnID: "mol-build", Type: "parent-child"}},
+	}
+
+	var stdout bytes.Buffer
+	payload := formulaShowJSONFromRecipe(
+		recipe,
+		"/city",
+		formulaScope{searchPaths: []string{"/city/formulas"}},
+		map[string]string{"target": "fast"},
+		map[string]string{"target": "unit"},
+		map[string]string{"branch": "main", "target": "unit"},
+	)
+	if err := writeCLIJSONLine(&stdout, payload); err != nil {
+		t.Fatalf("writeCLIJSONLine: %v", err)
+	}
+
+	var got struct {
+		SchemaVersion string `json:"schema_version"`
+		Name          string `json:"name"`
+		Description   string `json:"description"`
+		Vars          []struct {
+			Name       string  `json:"name"`
+			RigDefault *string `json:"rig_default"`
+		} `json:"vars"`
+		Steps []struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		} `json:"steps"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("formula show JSON is invalid: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.Name != "mol-build" || got.Description != "Build main" {
+		t.Fatalf("payload = %+v", got)
+	}
+	if len(got.Vars) != 2 || got.Vars[1].Name != "target" || got.Vars[1].RigDefault == nil || *got.Vars[1].RigDefault != "fast" {
+		t.Fatalf("vars = %+v", got.Vars)
+	}
+	if len(got.Steps) != 2 || got.Steps[1].Title != "Test unit" {
+		t.Fatalf("steps = %+v", got.Steps)
 	}
 }

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -55,7 +55,8 @@ tick and dispatches work when a trigger opens.`,
 }
 
 func newOrderListCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available orders",
 		Long: `List all available orders with their trigger type, schedule, and target.
@@ -64,16 +65,19 @@ Scans orders/ directories for flat .toml files defining trigger conditions,
 scheduling parameters, and target pools.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdOrderList(stdout, stderr) != 0 {
+			if cmdOrderListWithOptions(stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
+	return cmd
 }
 
 func newOrderShowCmd(stdout, stderr io.Writer) *cobra.Command {
 	var rig string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "show <name>",
 		Short: "Show details of an order",
@@ -84,7 +88,7 @@ scheduling parameters, check command, target, and source file.
 Use --rig to disambiguate same-name orders in different rigs.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdOrderShow(args[0], rig, stdout, stderr) != 0 {
+			if cmdOrderShowWithOptions(args[0], rig, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
@@ -92,6 +96,7 @@ Use --rig to disambiguate same-name orders in different rigs.`,
 		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to disambiguate same-name orders")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
 	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	return cmd
 }
@@ -356,6 +361,17 @@ func rigOrderRoots(_ string, _ *config.City, formulaLayers []string) []orders.Sc
 // --- gc order list ---
 
 func cmdOrderList(stdout, stderr io.Writer) int {
+	return cmdOrderListWithOptions(stdout, stderr, false)
+}
+
+func cmdOrderListWithOptions(stdout, stderr io.Writer, jsonOutput bool) int {
+	if jsonOutput {
+		cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order list")
+		if code != 0 {
+			return code
+		}
+		return doOrderListJSON(cityPath, cfg, aa, stdout)
+	}
 	aa, code := loadOrders(stderr, "gc order list")
 	if code != 0 {
 		return code
@@ -408,6 +424,116 @@ func doOrderList(aa []orders.Order, stdout io.Writer) int {
 	return 0
 }
 
+type orderListJSON struct {
+	SchemaVersion string                `json:"schema_version"`
+	CityPath      string                `json:"city_path,omitempty"`
+	CityName      string                `json:"city_name,omitempty"`
+	Orders        []orderJSON           `json:"orders"`
+	Summary       orderListSummaryJSON  `json:"summary"`
+	Warnings      []jsonContractWarning `json:"warnings,omitempty"`
+}
+
+type orderListSummaryJSON struct {
+	Count int `json:"count"`
+}
+
+type orderShowJSON struct {
+	SchemaVersion string                `json:"schema_version"`
+	CityPath      string                `json:"city_path,omitempty"`
+	CityName      string                `json:"city_name,omitempty"`
+	Order         orderJSON             `json:"order"`
+	Warnings      []jsonContractWarning `json:"warnings,omitempty"`
+}
+
+type orderJSON struct {
+	Name         string `json:"name"`
+	ScopedName   string `json:"scoped_name"`
+	Rig          string `json:"rig,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Type         string `json:"type"`
+	Formula      string `json:"formula,omitempty"`
+	Exec         string `json:"exec,omitempty"`
+	Trigger      string `json:"trigger"`
+	Interval     string `json:"interval,omitempty"`
+	Schedule     string `json:"schedule,omitempty"`
+	Check        string `json:"check,omitempty"`
+	On           string `json:"on,omitempty"`
+	Target       string `json:"target,omitempty"`
+	Timeout      string `json:"timeout,omitempty"`
+	Enabled      bool   `json:"enabled"`
+	Source       string `json:"source,omitempty"`
+	FormulaLayer string `json:"formula_layer,omitempty"`
+}
+
+func doOrderListJSON(cityPath string, cfg *config.City, aa []orders.Order, stdout io.Writer) int {
+	rows := make([]orderJSON, 0, len(aa))
+	for _, a := range aa {
+		rows = append(rows, orderToJSON(a))
+	}
+	payload := orderListJSON{
+		SchemaVersion: "1",
+		CityPath:      cityPath,
+		CityName:      effectiveJSONCityName(cfg, cityPath),
+		Orders:        rows,
+		Summary:       orderListSummaryJSON{Count: len(rows)},
+	}
+	if err := writeCLIJSONLine(stdout, payload); err != nil {
+		return 1
+	}
+	return 0
+}
+
+func doOrderShowJSON(cityPath string, cfg *config.City, aa []orders.Order, name, rig string, stdout, stderr io.Writer) int {
+	a, ok := findOrder(aa, name, rig)
+	if !ok {
+		fmt.Fprintf(stderr, "gc order show: order %q not found\n", name) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	payload := orderShowJSON{
+		SchemaVersion: "1",
+		CityPath:      cityPath,
+		CityName:      effectiveJSONCityName(cfg, cityPath),
+		Order:         orderToJSON(a),
+	}
+	if err := writeCLIJSONLine(stdout, payload); err != nil {
+		return 1
+	}
+	return 0
+}
+
+func effectiveJSONCityName(cfg *config.City, cityPath string) string {
+	if cfg == nil {
+		return ""
+	}
+	return config.EffectiveCityName(cfg, filepath.Base(cityPath))
+}
+
+func orderToJSON(a orders.Order) orderJSON {
+	typ := "formula"
+	if a.IsExec() {
+		typ = "exec"
+	}
+	return orderJSON{
+		Name:         a.Name,
+		ScopedName:   a.ScopedName(),
+		Rig:          a.Rig,
+		Description:  a.Description,
+		Type:         typ,
+		Formula:      a.Formula,
+		Exec:         a.Exec,
+		Trigger:      a.Trigger,
+		Interval:     a.Interval,
+		Schedule:     a.Schedule,
+		Check:        a.Check,
+		On:           a.On,
+		Target:       a.Pool,
+		Timeout:      a.Timeout,
+		Enabled:      a.IsEnabled(),
+		Source:       a.Source,
+		FormulaLayer: a.FormulaLayer,
+	}
+}
+
 // anyOrderHasRig returns true if any order in the list has a non-empty Rig.
 func anyOrderHasRig(aa []orders.Order) bool {
 	for _, a := range aa {
@@ -421,9 +547,16 @@ func anyOrderHasRig(aa []orders.Order) bool {
 // --- gc order show ---
 
 func cmdOrderShow(name, rig string, stdout, stderr io.Writer) int {
-	_, _, aa, code := loadAllOrdersWithCity(stderr, "gc order show")
+	return cmdOrderShowWithOptions(name, rig, stdout, stderr, false)
+}
+
+func cmdOrderShowWithOptions(name, rig string, stdout, stderr io.Writer, jsonOutput bool) int {
+	cityPath, cfg, aa, code := loadAllOrdersWithCity(stderr, "gc order show")
 	if code != 0 {
 		return code
+	}
+	if jsonOutput {
+		return doOrderShowJSON(cityPath, cfg, aa, name, rig, stdout, stderr)
 	}
 	return doOrderShow(aa, name, rig, stdout, stderr)
 }

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -358,12 +358,6 @@ func rigOrderRoots(_ string, _ *config.City, formulaLayers []string) []orders.Sc
 	return roots
 }
 
-// --- gc order list ---
-
-func cmdOrderList(stdout, stderr io.Writer) int {
-	return cmdOrderListWithOptions(stdout, stderr, false)
-}
-
 func cmdOrderListWithOptions(stdout, stderr io.Writer, jsonOutput bool) int {
 	if jsonOutput {
 		cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order list")

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -70,6 +71,46 @@ func TestOrderList(t *testing.T) {
 	}
 }
 
+func TestOrderListJSON(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "digest", Trigger: "cooldown", Interval: "24h", Pool: "dog", Formula: "mol-digest", Source: "/city/orders/digest.toml"},
+		{Name: "poll", Trigger: "condition", Check: "bd ready --json", Exec: "scripts/poll.sh", Rig: "frontend"},
+	}
+
+	var stdout bytes.Buffer
+	code := doOrderListJSON("/city", &config.City{Workspace: config.Workspace{Name: "bright-lights"}}, aa, &stdout)
+	if code != 0 {
+		t.Fatalf("doOrderListJSON = %d, want 0", code)
+	}
+
+	var got struct {
+		SchemaVersion string `json:"schema_version"`
+		CityName      string `json:"city_name"`
+		Orders        []struct {
+			Name       string `json:"name"`
+			ScopedName string `json:"scoped_name"`
+			Type       string `json:"type"`
+			Target     string `json:"target"`
+			Enabled    bool   `json:"enabled"`
+		} `json:"orders"`
+		Summary struct {
+			Count int `json:"count"`
+		} `json:"summary"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("order list JSON invalid: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.CityName != "bright-lights" || got.Summary.Count != 2 {
+		t.Fatalf("payload = %+v", got)
+	}
+	if got.Orders[0].Name != "digest" || got.Orders[0].Type != "formula" || got.Orders[0].Target != "dog" || !got.Orders[0].Enabled {
+		t.Fatalf("first order = %+v", got.Orders[0])
+	}
+	if got.Orders[1].ScopedName != "poll:rig:frontend" || got.Orders[1].Type != "exec" {
+		t.Fatalf("second order = %+v", got.Orders[1])
+	}
+}
+
 func TestOrderListExecType(t *testing.T) {
 	aa := []orders.Order{
 		{Name: "poll", Trigger: "cooldown", Interval: "2m", Exec: "scripts/poll.sh"},
@@ -87,6 +128,61 @@ func TestOrderListExecType(t *testing.T) {
 	}
 	if !strings.Contains(out, "formula") {
 		t.Errorf("stdout missing 'formula' type:\n%s", out)
+	}
+}
+
+func TestOrderShowJSON(t *testing.T) {
+	aa := []orders.Order{{
+		Name:         "digest",
+		Description:  "nightly digest",
+		Formula:      "mol-digest",
+		Trigger:      "cron",
+		Schedule:     "0 3 * * *",
+		Pool:         "dog",
+		Source:       "/city/orders/digest.toml",
+		FormulaLayer: "/city/formulas",
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderShowJSON("/city", &config.City{Workspace: config.Workspace{Name: "bright-lights"}}, aa, "digest", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderShowJSON = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	var got struct {
+		SchemaVersion string `json:"schema_version"`
+		Order         struct {
+			Name         string `json:"name"`
+			Description  string `json:"description"`
+			Formula      string `json:"formula"`
+			Trigger      string `json:"trigger"`
+			Schedule     string `json:"schedule"`
+			Target       string `json:"target"`
+			FormulaLayer string `json:"formula_layer"`
+		} `json:"order"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("order show JSON invalid: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.Order.Name != "digest" || got.Order.Target != "dog" || got.Order.FormulaLayer != "/city/formulas" {
+		t.Fatalf("payload = %+v", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestOrderShowJSONMissingOrderKeepsHumanError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := doOrderShowJSON("/city", nil, nil, "missing", "", &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("doOrderShowJSON missing order = 0, want nonzero")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty before global JSON failure wrapper", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `order "missing" not found`) {
+		t.Fatalf("stderr = %q, want missing order diagnostic", stderr.String())
 	}
 }
 

--- a/schemas/formula/list/result.schema.json
+++ b/schemas/formula/list/result.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "formulas", "summary"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "search_paths": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "formulas": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "source": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["count"],
+      "properties": {
+        "count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/formula/show/result.schema.json
+++ b/schemas/formula/show/result.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "name", "search_paths", "steps"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "phase": { "type": "string" },
+    "pour": { "type": "boolean" },
+    "root_only": { "type": "boolean" },
+    "search_paths": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "vars": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "default": { "type": "string" },
+          "rig_default": { "type": "string" },
+          "required": { "type": "boolean" },
+          "type": { "type": "string" },
+          "pattern": { "type": "string" },
+          "enum": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "notes": { "type": "string" },
+          "type": { "type": "string" },
+          "priority": { "type": "integer" },
+          "labels": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "assignee": { "type": "string" },
+          "is_root": { "type": "boolean" },
+          "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
+        },
+        "additionalProperties": true
+      }
+    },
+    "deps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["step_id", "depends_on_id"],
+        "properties": {
+          "step_id": { "type": "string" },
+          "depends_on_id": { "type": "string" },
+          "type": { "type": "string" },
+          "metadata": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "provided_vars": { "type": "object", "additionalProperties": { "type": "string" } },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/order/list/result.schema.json
+++ b/schemas/order/list/result.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "orders", "summary"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "city_name": { "type": "string" },
+    "orders": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/order" }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["count"],
+      "properties": {
+        "count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    }
+  },
+  "$defs": {
+    "order": {
+      "type": "object",
+      "required": ["name", "scoped_name", "type", "trigger", "enabled"],
+      "properties": {
+        "name": { "type": "string" },
+        "scoped_name": { "type": "string" },
+        "rig": { "type": "string" },
+        "description": { "type": "string" },
+        "type": { "type": "string", "enum": ["formula", "exec"] },
+        "formula": { "type": "string" },
+        "exec": { "type": "string" },
+        "trigger": { "type": "string" },
+        "interval": { "type": "string" },
+        "schedule": { "type": "string" },
+        "check": { "type": "string" },
+        "on": { "type": "string" },
+        "target": { "type": "string" },
+        "timeout": { "type": "string" },
+        "enabled": { "type": "boolean" },
+        "source": { "type": "string" },
+        "formula_layer": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/order/show/result.schema.json
+++ b/schemas/order/show/result.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "order"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "city_name": { "type": "string" },
+    "order": {
+      "type": "object",
+      "required": ["name", "scoped_name", "type", "trigger", "enabled"],
+      "properties": {
+        "name": { "type": "string" },
+        "scoped_name": { "type": "string" },
+        "rig": { "type": "string" },
+        "description": { "type": "string" },
+        "type": { "type": "string", "enum": ["formula", "exec"] },
+        "formula": { "type": "string" },
+        "exec": { "type": "string" },
+        "trigger": { "type": "string" },
+        "interval": { "type": "string" },
+        "schedule": { "type": "string" },
+        "check": { "type": "string" },
+        "on": { "type": "string" },
+        "target": { "type": "string" },
+        "timeout": { "type": "string" },
+        "enabled": { "type": "boolean" },
+        "source": { "type": "string" },
+        "formula_layer": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary

Adds read-only Wave 2 JSON support on top of the JSON schema platform branch:

- `gc formula list --json`
- `gc formula show <name> --json`
- `gc order list --json`
- `gc order show <name> --json`

Also adds result schemas for each command under the platform schema convention.

## Why This Is Stacked

This PR is based on `codex/json-schema-platform` / #2222 and should be reviewed as a follow-on to that platform work. It intentionally does not wait for #2222 to merge so the CLI surface-area sweep can continue in parallel.

## JSON Contract Notes

These commands did not previously have native `--json` support, so this is additive behavior. Human-readable output remains the default.

The new outputs follow the Wave 2 read/inspect convention:

- JSONL transport with one result record for bounded commands.
- `schema_version: "1"` on each result record.
- Object envelopes rather than bare arrays.
- Explicit IDs/names/paths/source fields where available.
- Schemas discoverable through `--json-schema=result`.

This PR does not add `gc order run --json`; mutating order execution needs a separate result/failure contract.

## Validation

- `gofmt -w cmd/gc/cmd_formula.go cmd/gc/cmd_formula_test.go cmd/gc/cmd_order.go cmd/gc/cmd_order_test.go`
- `go test ./cmd/gc -run 'TestJSONSchema|TestFormulaShowJSON|TestOrderList|TestOrderShowJSON|TestResolveFormulaScope|TestRigFormulaVars'`
- `find schemas/formula schemas/order -type f -name '*.schema.json' -print | sort | xargs -n1 jq -e . >/dev/null`
- `go run ./cmd/gc --city /Users/dbox/repos/gc/gc4gc formula list --json`
- `go run ./cmd/gc --city /Users/dbox/repos/gc/gc4gc formula show gc-json-audit --json | jq -e '.schema_version == "1" and .name == "gc-json-audit" and (.steps | length) > 0'`
- `go run ./cmd/gc --city /Users/dbox/repos/gc/gc4gc order list --json`
- `go run ./cmd/gc --city /Users/dbox/repos/gc/gc4gc order show cross-rig-deps --json | jq -e '.schema_version == "1" and .order.name == "cross-rig-deps"'`
- `go run ./cmd/gc --city /Users/dbox/repos/gc/gc4gc formula list --json-schema=result | jq -e . >/dev/null`
- `go run ./cmd/gc --city /Users/dbox/repos/gc/gc4gc order list --json-schema=result | jq -e . >/dev/null`

