### PR TITLE
fix(preflight): require and validate repo_state.json in managed-dolt healthy check (#2022)

### DIFF
--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1364,6 +1364,13 @@ func TestDoltStatePreflightCleanCmdRemovesStaleArtifacts(t *testing.T) {
 	if err := os.WriteFile(healthyManifest, []byte("ok\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// repo_state.json sits alongside noms/manifest in every real managed-dolt
+	// database (see e.g. gascity's own hq dir). Preflight now requires both
+	// files; absence of repo_state.json is itself a quarantine reason.
+	healthyRepoState := filepath.Join(layout.DataDir, "healthy", ".dolt", "repo_state.json")
+	if err := os.WriteFile(healthyRepoState, []byte(`{"head":"refs/heads/main","remotes":{},"backups":{},"branches":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	socketPath := filepath.Join("/tmp", "dolt-gc-preflight-"+strconv.FormatInt(time.Now().UnixNano(), 10)+".sock")
 	staleSocket := startUnixSocketProcess(t, socketPath)
@@ -1396,6 +1403,48 @@ func TestDoltStatePreflightCleanCmdRemovesStaleArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(layout.DataDir, "healthy", ".dolt", "noms", "manifest")); err != nil {
 		t.Fatalf("healthy manifest removed unexpectedly: %v", err)
+	}
+}
+
+// TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase verifies that a
+// managed-dolt directory containing only .dolt/noms/manifest (no
+// repo_state.json) is quarantined. This is the exact shape of the malformed
+// "healthy" fixture deposited into a live city on 2026-05-12 when the
+// existing TestDoltStatePreflightCleanCmdRemovesStaleArtifacts test ran with
+// GC_DOLT_DATA_DIR inherited from the developer's shell (see
+// dolt_runtime_layout.go:37). Dolt sql-server's data_dir scan then aborts on
+// the first such directory with bare "EOF", killing the entire server and
+// every other database on it.
+func TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not installed")
+	}
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+
+	manifestOnly := filepath.Join(layout.DataDir, "manifest_only", ".dolt", "noms", "manifest")
+	if err := os.MkdirAll(filepath.Dir(manifestOnly), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestOnly, []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "preflight-clean", "--city", cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+
+	quarantined, err := filepath.Glob(filepath.Join(layout.DataDir, ".quarantine", "*-manifest_only*"))
+	if err != nil {
+		t.Fatalf("Glob(quarantine): %v", err)
+	}
+	if len(quarantined) != 1 {
+		t.Fatalf("quarantined manifest-only databases = %d, want 1 (%v)", len(quarantined), quarantined)
 	}
 }
 

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1448,6 +1448,49 @@ func TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase(t *testing.T) {
 	}
 }
 
+// TestDoltStatePreflightCleanQuarantinesMalformedRepoStateDatabase verifies
+// that a managed-dolt directory with both .dolt/noms/manifest AND
+// .dolt/repo_state.json present is still quarantined when repo_state.json
+// fails to parse as JSON. Partial or corrupted repo_state.json writes (e.g.
+// from a crashed dolt commit operation) fail dolt-server load the same way
+// a missing repo_state.json does, so the file-existence check is not enough
+// on its own.
+func TestDoltStatePreflightCleanQuarantinesMalformedRepoStateDatabase(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not installed")
+	}
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+
+	doltDir := filepath.Join(layout.DataDir, "malformed_repo_state", ".dolt")
+	if err := os.MkdirAll(filepath.Join(doltDir, "noms"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, "noms", "manifest"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, "repo_state.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "preflight-clean", "--city", cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+
+	quarantined, err := filepath.Glob(filepath.Join(layout.DataDir, ".quarantine", "*-malformed_repo_state*"))
+	if err != nil {
+		t.Fatalf("Glob(quarantine): %v", err)
+	}
+	if len(quarantined) != 1 {
+		t.Fatalf("quarantined malformed-repo-state databases = %d, want 1 (%v)", len(quarantined), quarantined)
+	}
+}
+
 func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
 	skipSlowCmdGCTest(t, "spawns managed dolt holder processes; run make test-cmd-gc-process for full coverage")
 	if _, err := exec.LookPath("lsof"); err != nil {

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1419,6 +1419,7 @@ func TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase(t *testing.T) {
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
+	clearManagedDoltEnv(t)
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -1459,6 +1460,7 @@ func TestDoltStatePreflightCleanQuarantinesMalformedRepoStateDatabase(t *testing
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
+	clearManagedDoltEnv(t)
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -1496,6 +1498,7 @@ func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
+	clearManagedDoltEnv(t)
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -1507,6 +1510,15 @@ func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(liveManifest, []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// repo_state.json must accompany the manifest so the tightened
+	// quarantine check (require valid repo_state.json) treats this
+	// fixture as a healthy database. Without this, preflight quarantines
+	// the live dir and the assertions below (LOCK + socket preserved)
+	// fail under process-shard tests.
+	liveRepoState := filepath.Join(layout.DataDir, "live", ".dolt", "repo_state.json")
+	if err := os.WriteFile(liveRepoState, []byte(`{"head":"refs/heads/main","remotes":{},"backups":{},"branches":{}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	liveLock := filepath.Join(layout.DataDir, "live", ".dolt", "noms", "LOCK")
@@ -3320,5 +3332,26 @@ func writeFakeDoltSQLBinary(t *testing.T, binDir, invocationFile, body string) {
 	path := filepath.Join(binDir, "dolt")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("WriteFile(fake dolt): %v", err)
+	}
+}
+
+// clearManagedDoltEnv pins resolveManagedDoltRuntimeLayout to the
+// city-relative default by clearing every GC_DOLT_* override that the
+// developer's shell may have set. Tests that build fixtures under
+// layout.DataDir MUST call this — otherwise a dev with GC_DOLT_DATA_DIR
+// exported drops fixtures into their live dolt data dir and corrupts
+// the running server (the 2026-05-12 incident this whole regression
+// suite is meant to prevent).
+func clearManagedDoltEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"GC_DOLT_DATA_DIR",
+		"GC_DOLT_LOG_FILE",
+		"GC_DOLT_STATE_FILE",
+		"GC_DOLT_PID_FILE",
+		"GC_DOLT_LOCK_FILE",
+		"GC_DOLT_CONFIG_FILE",
+	} {
+		t.Setenv(key, "")
 	}
 }

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -129,13 +130,19 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 				// directory servable: dolt sql-server's data_dir scan aborts
 				// with bare "EOF" on the first directory whose .dolt/ is
 				// missing repo_state.json, killing every other database on
-				// the same server. Require repo_state.json as well.
+				// the same server. Require repo_state.json as well, and
+				// require it to parse as JSON — a partially-written or
+				// otherwise corrupted repo_state.json fails dolt-server load
+				// the same way a missing one does.
 				reason = "missing repo_state.json"
 				repoState := filepath.Join(doltDir, "repo_state.json")
-				if _, err := os.Stat(repoState); err != nil {
+				repoStateData, err := os.ReadFile(repoState)
+				if err != nil {
 					if !os.IsNotExist(err) {
 						return err
 					}
+				} else if !json.Valid(repoStateData) {
+					reason = "malformed repo_state.json"
 				} else {
 					continue
 				}

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -137,14 +137,14 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 				reason = "missing repo_state.json"
 				repoState := filepath.Join(doltDir, "repo_state.json")
 				repoStateData, err := os.ReadFile(repoState)
-				if err != nil {
-					if !os.IsNotExist(err) {
-						return err
-					}
-				} else if !json.Valid(repoStateData) {
-					reason = "malformed repo_state.json"
-				} else {
+				switch {
+				case err != nil && !os.IsNotExist(err):
+					return err
+				case err == nil && json.Valid(repoStateData):
 					continue
+				case err == nil && !json.Valid(repoStateData):
+					reason = "malformed repo_state.json"
+					// default: file missing — keep reason = "missing repo_state.json"
 				}
 			}
 		}

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -120,10 +120,25 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		if !retiredManagedDoltDatabaseName(entry.Name()) {
 			reason = "missing noms/manifest"
 			manifest := filepath.Join(doltDir, "noms", "manifest")
-			if _, err := os.Stat(manifest); err == nil {
-				continue
-			} else if !os.IsNotExist(err) {
-				return err
+			if _, err := os.Stat(manifest); err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+			} else {
+				// A noms/manifest alone is not enough to deem a managed-dolt
+				// directory servable: dolt sql-server's data_dir scan aborts
+				// with bare "EOF" on the first directory whose .dolt/ is
+				// missing repo_state.json, killing every other database on
+				// the same server. Require repo_state.json as well.
+				reason = "missing repo_state.json"
+				repoState := filepath.Join(doltDir, "repo_state.json")
+				if _, err := os.Stat(repoState); err != nil {
+					if !os.IsNotExist(err) {
+						return err
+					}
+				} else {
+					continue
+				}
 			}
 		}
 		if err := os.MkdirAll(quarantineRoot, 0o755); err != nil {

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -134,17 +134,41 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 				// require it to parse as JSON — a partially-written or
 				// otherwise corrupted repo_state.json fails dolt-server load
 				// the same way a missing one does.
+				//
+				// Size-cap the read at 512 KB so an attacker-influenced
+				// file cannot OOM the preflight sweep. Treat permission
+				// errors like missing files (quarantine with explicit
+				// reason) rather than aborting the whole sweep — an
+				// unreadable repo_state.json is at least as broken as a
+				// missing one from dolt-server's perspective.
 				reason = "missing repo_state.json"
 				repoState := filepath.Join(doltDir, "repo_state.json")
-				repoStateData, err := os.ReadFile(repoState)
+				const maxRepoStateSize int64 = 512 * 1024
+				info, statErr := os.Stat(repoState)
 				switch {
-				case err != nil && !os.IsNotExist(err):
-					return err
-				case err == nil && json.Valid(repoStateData):
-					continue
-				case err == nil && !json.Valid(repoStateData):
-					reason = "malformed repo_state.json"
-					// default: file missing — keep reason = "missing repo_state.json"
+				case statErr != nil && os.IsNotExist(statErr):
+					// file missing — reason already set; fall through to quarantine
+				case statErr != nil && os.IsPermission(statErr):
+					reason = "unreadable repo_state.json (permission denied)"
+				case statErr != nil:
+					return statErr
+				case info.Size() > maxRepoStateSize:
+					reason = "oversized repo_state.json"
+				default:
+					repoStateData, readErr := os.ReadFile(repoState)
+					switch {
+					case readErr != nil && os.IsNotExist(readErr):
+						// race: file vanished between Stat and ReadFile;
+						// keep reason = "missing repo_state.json"
+					case readErr != nil && os.IsPermission(readErr):
+						reason = "unreadable repo_state.json (permission denied)"
+					case readErr != nil:
+						return readErr
+					case json.Valid(repoStateData):
+						continue
+					default:
+						reason = "malformed repo_state.json"
+					}
 				}
 			}
 		}

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -108,11 +108,17 @@ func TestRemoveStaleManagedDoltLocksWithoutLsofUsesAvailableState(t *testing.T) 
 
 func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t *testing.T) {
 	dataDir := t.TempDir()
+	// healthy fixtures need both noms/manifest and repo_state.json — preflight
+	// now requires both to deem a non-retired managed-dolt directory servable.
+	healthyRepoState := []byte(`{"head":"refs/heads/main","remotes":{},"backups":{},"branches":{}}`)
 	activeManifest := filepath.Join(dataDir, "ga", ".dolt", "noms", "manifest")
 	if err := os.MkdirAll(filepath.Dir(activeManifest), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(activeManifest, []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "ga", ".dolt", "repo_state.json"), healthyRepoState, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	retiredManifest := filepath.Join(dataDir, "ga.replaced-20260428T100722Z", ".dolt", "noms", "manifest")
@@ -127,6 +133,9 @@ func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t 
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(replacementLikeManifest, []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "ga.replaced-pending", ".dolt", "repo_state.json"), healthyRepoState, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -963,9 +963,30 @@ retired_replacement_db_name() {
     esac
 }
 
+# repo_state_is_valid_json checks that a file parses as valid JSON.
+# Prefers jq if available; falls back to python3 -m json.tool. If neither
+# tool is on PATH, returns success — the Go preflight path is authoritative
+# and a worse-fit shell mirror should not falsely quarantine healthy DBs.
+repo_state_is_valid_json() {
+    local file="$1"
+    if command -v jq >/dev/null 2>&1; then
+        jq -e . "$file" >/dev/null 2>&1
+        return $?
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$file" >/dev/null 2>&1
+        return $?
+    fi
+    return 0
+}
+
 # quarantine_phantom_dbs moves unservable database dirs to quarantine.
-# This includes missing-manifest phantom dirs and Dolt-retired replacement
-# dirs that still have manifests but are no longer the active database.
+# Mirrors the Go preflight check in cmd/gc/dolt_preflight_cleanup.go:
+# quarantine dirs that are retired replacements, missing noms/manifest,
+# missing repo_state.json, or have malformed repo_state.json. Without
+# both the manifest AND a valid repo_state.json, dolt sql-server's
+# data_dir scan aborts with bare "EOF" on the first unservable
+# directory, killing every other database on the same server.
 quarantine_phantom_dbs() {
     [ -d "$DATA_DIR" ] || return 0
     local dir
@@ -979,6 +1000,10 @@ quarantine_phantom_dbs() {
             reason="retired replacement"
         elif [ ! -f "$dir/.dolt/noms/manifest" ]; then
             reason="missing noms/manifest"
+        elif [ ! -f "$dir/.dolt/repo_state.json" ]; then
+            reason="missing repo_state.json"
+        elif ! repo_state_is_valid_json "$dir/.dolt/repo_state.json"; then
+            reason="malformed repo_state.json"
         else
             continue
         fi


### PR DESCRIPTION
## Problem
The managed-dolt preflight "healthy" check passed even when
`repo_state.json` was missing or failed to parse — a clean preflight
could green-light a dolt state that is actually broken.

## Fix
- Require `repo_state.json` to be present for the managed-dolt healthy
  check (`cmd/gc/dolt_preflight_cleanup.go`).
- Reject a `repo_state.json` that fails to parse instead of treating it
  as healthy.
- Update the shell mirror (`examples/bd/assets/scripts/gc-beads-bd.sh`)
  to match the Go check.

## Test
+134 lines covering the missing-file, unparseable, and valid-fixture
cases.

Closes #2022.
