### PR TITLE
feat: add JSON for config and supervisor status

### DIFF
--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -93,6 +93,7 @@ func addDiscoveredLeaf(root *cobra.Command, entry config.DiscoveredCommand, city
 		Use:                leafWord,
 		Short:              entry.Description,
 		Long:               readDiscoveredHelp(entry),
+		Annotations:        map[string]string{jsonSchemaDirAnnotation: filepath.Join(entry.SourceDir, "schemas")},
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if discoveredHelpRequested(args) {

--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -89,11 +89,16 @@ func addDiscoveredLeaf(root *cobra.Command, entry config.DiscoveredCommand, city
 		return
 	}
 
+	annotations := map[string]string{}
+	if strings.TrimSpace(entry.SourceDir) != "" {
+		annotations[jsonSchemaDirAnnotation] = filepath.Join(entry.SourceDir, "schemas")
+	}
+
 	leaf := &cobra.Command{
 		Use:                leafWord,
 		Short:              entry.Description,
 		Long:               readDiscoveredHelp(entry),
-		Annotations:        map[string]string{jsonSchemaDirAnnotation: filepath.Join(entry.SourceDir, "schemas")},
+		Annotations:        annotations,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if discoveredHelpRequested(args) {

--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -143,7 +143,13 @@ func doConfigShow(validate, showProvenance, asJSON bool, stdout, stderr io.Write
 
 	if validate {
 		if asJSON {
-			return writeConfigShowJSON(stdout, cityPath, cfg, compositionWarnings, validationWarnings, validationErrors, nil)
+			if code := writeConfigShowJSON(stdout, cityPath, cfg, compositionWarnings, validationWarnings, validationErrors, nil); code != 0 {
+				return code
+			}
+			if len(validationErrors) > 0 {
+				return 1
+			}
+			return 0
 		}
 		for _, w := range validationWarnings {
 			fmt.Fprintf(stderr, "gc config show: warning: %s\n", w) //nolint:errcheck // best-effort stderr
@@ -200,11 +206,11 @@ func writeConfigShowJSON(stdout io.Writer, cityPath string, cfg *config.City, wa
 		"schema_version": "1",
 		"city_path":      cityPath,
 		"config":         configForDisplay(cfg),
-		"warnings":       warnings,
+		"warnings":       nonNilStrings(warnings),
 		"validation": map[string]any{
 			"ok":       len(validationErrors) == 0,
-			"warnings": validationWarnings,
-			"errors":   validationErrors,
+			"warnings": nonNilStrings(validationWarnings),
+			"errors":   nonNilStrings(validationErrors),
 		},
 	}
 	if provenance != nil {
@@ -214,6 +220,13 @@ func writeConfigShowJSON(stdout io.Writer, cityPath string, cfg *config.City, wa
 		return 1
 	}
 	return 0
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
 }
 
 func configForDisplay(cfg *config.City) *config.City {

--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -67,6 +67,7 @@ config and "explain" to see where each value originated.`,
 func newConfigShowCmd(stdout, stderr io.Writer) *cobra.Command {
 	var validate bool
 	var showProvenance bool
+	var asJSON bool
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Dump the resolved city configuration as TOML",
@@ -79,10 +80,11 @@ config element. Use -f to layer additional config files.`,
 		Example: `  gc config show
   gc config show --validate
   gc config show --provenance
+  gc config show --json
   gc config show -f overlay.toml`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if doConfigShow(validate, showProvenance, stdout, stderr) != 0 {
+			if doConfigShow(validate, showProvenance, asJSON, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -90,6 +92,7 @@ config element. Use -f to layer additional config files.`,
 	}
 	cmd.Flags().BoolVar(&validate, "validate", false, "validate config and exit (0 = valid, 1 = errors)")
 	cmd.Flags().BoolVar(&showProvenance, "provenance", false, "show where each config element originated")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON")
 	cmd.Flags().StringArrayVarP(&extraConfigFiles, "file", "f", nil,
 		"additional config files to layer (can be repeated)")
 	return cmd
@@ -97,7 +100,7 @@ config element. Use -f to layer additional config files.`,
 
 // doConfigShow loads city.toml (with includes) and dumps the resolved
 // config, validates it, or shows provenance.
-func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
+func doConfigShow(validate, showProvenance, asJSON bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc config show: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -115,9 +118,11 @@ func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// Composition warnings.
-	for _, w := range prov.Warnings {
-		fmt.Fprintf(stderr, "gc config show: warning: %s\n", w) //nolint:errcheck // best-effort stderr
+	compositionWarnings := append([]string(nil), prov.Warnings...)
+	if !asJSON {
+		for _, w := range compositionWarnings {
+			fmt.Fprintf(stderr, "gc config show: warning: %s\n", w) //nolint:errcheck // best-effort stderr
+		}
 	}
 
 	// Run validation.
@@ -137,6 +142,9 @@ func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 	validationWarnings := singletonSessionMigrationWarnings(cfg)
 
 	if validate {
+		if asJSON {
+			return writeConfigShowJSON(stdout, cityPath, cfg, compositionWarnings, validationWarnings, validationErrors, nil)
+		}
 		for _, w := range validationWarnings {
 			fmt.Fprintf(stderr, "gc config show: warning: %s\n", w) //nolint:errcheck // best-effort stderr
 		}
@@ -148,6 +156,14 @@ func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 		}
 		fmt.Fprintln(stdout, "Config valid.") //nolint:errcheck // best-effort stdout
 		return 0
+	}
+
+	if asJSON {
+		var provenance any
+		if showProvenance {
+			provenance = prov
+		}
+		return writeConfigShowJSON(stdout, cityPath, cfg, compositionWarnings, validationWarnings, validationErrors, provenance)
 	}
 
 	// Print validation warnings even in show mode.
@@ -176,6 +192,27 @@ func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 		fmt.Fprint(stdout, annotations) //nolint:errcheck // best-effort stdout
 	}
 	fmt.Fprint(stdout, string(data)) //nolint:errcheck // best-effort stdout
+	return 0
+}
+
+func writeConfigShowJSON(stdout io.Writer, cityPath string, cfg *config.City, warnings, validationWarnings, validationErrors []string, provenance any) int {
+	payload := map[string]any{
+		"schema_version": "1",
+		"city_path":      cityPath,
+		"config":         configForDisplay(cfg),
+		"warnings":       warnings,
+		"validation": map[string]any{
+			"ok":       len(validationErrors) == 0,
+			"warnings": validationWarnings,
+			"errors":   validationErrors,
+		},
+	}
+	if provenance != nil {
+		payload["provenance"] = provenance
+	}
+	if err := writeCLIJSONLine(stdout, payload); err != nil {
+		return 1
+	}
 	return 0
 }
 

--- a/cmd/gc/cmd_config_test.go
+++ b/cmd/gc/cmd_config_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 func TestDoConfigShowMissingRemoteImportSuggestsInstall(t *testing.T) {
@@ -55,13 +57,16 @@ func TestConfigShowJSON(t *testing.T) {
 	var payload struct {
 		SchemaVersion string `json:"schema_version"`
 		CityPath      string `json:"city_path"`
+		Warnings      []string
 		Config        struct {
 			Workspace struct {
 				Name string
 			}
 		}
 		Validation struct {
-			OK bool `json:"ok"`
+			OK       bool `json:"ok"`
+			Warnings []string
+			Errors   []string
 		} `json:"validation"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
@@ -69,5 +74,67 @@ func TestConfigShowJSON(t *testing.T) {
 	}
 	if payload.SchemaVersion != "1" || payload.CityPath != dir || payload.Config.Workspace.Name != "demo" || !payload.Validation.OK {
 		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.Warnings == nil || payload.Validation.Warnings == nil || payload.Validation.Errors == nil {
+		t.Fatalf("warnings/errors must be JSON arrays, got %+v", payload)
+	}
+	validateConfigShowJSONSchema(t, stdout.Bytes())
+}
+
+func TestConfigShowValidateJSONReturnsNonzeroForInvalidConfig(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll(".gc", 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n\n[[rigs]]\nname = \"broken\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"config", "show", "--validate", "--json"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run(config show --validate --json) = 0, want nonzero; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	var payload struct {
+		Validation struct {
+			OK     bool     `json:"ok"`
+			Errors []string `json:"errors"`
+		} `json:"validation"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if payload.Validation.OK || len(payload.Validation.Errors) == 0 {
+		t.Fatalf("validation payload = %+v, want ok=false with errors", payload.Validation)
+	}
+	validateConfigShowJSONSchema(t, stdout.Bytes())
+}
+
+func validateConfigShowJSONSchema(t *testing.T, data []byte) {
+	t.Helper()
+
+	rawSchema, err := readBuiltinSchema([]string{"config", "show"}, jsonSchemaResultRole)
+	if err != nil {
+		t.Fatalf("read config show schema: %v", err)
+	}
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(rawSchema))
+	if err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("config-show.schema.json", schemaDoc); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	schema, err := compiler.Compile("config-show.schema.json")
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if err := schema.Validate(doc); err != nil {
+		t.Fatalf("payload does not match config show schema: %v\n%s", err, string(data))
 	}
 }

--- a/cmd/gc/cmd_config_test.go
+++ b/cmd/gc/cmd_config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"testing"
 )
@@ -24,11 +25,49 @@ version = "^1.4"
 `)
 
 	var stdout, stderr bytes.Buffer
-	code := doConfigShow(false, false, &stdout, &stderr)
+	code := doConfigShow(false, false, false, &stdout, &stderr)
 	if code == 0 {
 		t.Fatal("expected failure for missing remote import")
 	}
 	if got := stderr.String(); !bytes.Contains([]byte(got), []byte(`run "gc import install"`)) {
 		t.Fatalf("stderr = %q, want install remediation", got)
+	}
+}
+
+func TestConfigShowJSON(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll(".gc", 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"config", "show", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(config show --json) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		CityPath      string `json:"city_path"`
+		Config        struct {
+			Workspace struct {
+				Name string
+			}
+		}
+		Validation struct {
+			OK bool `json:"ok"`
+		} `json:"validation"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || payload.CityPath != dir || payload.Config.Workspace.Name != "demo" || !payload.Validation.OK {
+		t.Fatalf("payload = %+v", payload)
 	}
 }

--- a/cmd/gc/cmd_dolt_cleanup_test.go
+++ b/cmd/gc/cmd_dolt_cleanup_test.go
@@ -77,6 +77,22 @@ func TestDoltCleanupCmdRejectsNegativeMaxOrphanDBsBeforeCityResolution(t *testin
 	}
 }
 
+func TestRunDoltCleanupJSONFailurePreservesCommandPayload(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-cleanup", "--json", "--max-orphan-dbs", "-1"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run(dolt-cleanup --json --max-orphan-dbs -1) = 0, want nonzero")
+	}
+	if strings.Contains(stdout.String(), `"code":"command_failed"`) {
+		t.Fatalf("stdout used generic failure instead of command payload:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"kind":"invalid-max-orphan-dbs"`) {
+		t.Fatalf("stdout missing command-authored cleanup payload:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+}
+
 func TestRunDoltCleanupRejectsNegativeMaxOrphanDBs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	opts := cleanupOptions{

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -106,17 +106,19 @@ against lingering supervisor / controller subprocesses).`,
 }
 
 func newSupervisorStatusCmd(stdout, stderr io.Writer) *cobra.Command {
+	var asJSON bool
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Check if the supervisor is running",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if supervisorStatus(stdout, stderr) != 0 {
+			if supervisorStatusWithOptions(stdout, stderr, asJSON) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON")
 	return cmd
 }
 
@@ -576,9 +578,21 @@ func waitForSupervisorExitUntil(sockPath string, deadline time.Time) error {
 	}
 }
 
-// supervisorStatus checks and reports whether the supervisor is running.
-func supervisorStatus(stdout, _ io.Writer) int {
-	pid := supervisorAlive()
+func supervisorStatusWithOptions(stdout, _ io.Writer, asJSON bool) int {
+	sockPath, pid := runningSupervisorSocket()
+	if asJSON {
+		payload := map[string]any{
+			"schema_version": "1",
+			"running":        pid > 0,
+			"pid":            pid,
+			"socket_path":    sockPath,
+			"checked_paths":  supervisorSocketPathCandidates(),
+		}
+		if err := writeCLIJSONLine(stdout, payload); err != nil {
+			return 1
+		}
+		return 0
+	}
 	if pid > 0 {
 		fmt.Fprintf(stdout, "Supervisor is running (PID %d)\n", pid) //nolint:errcheck
 		return 0

--- a/cmd/gc/cmd_supervisor_status_json_test.go
+++ b/cmd/gc/cmd_supervisor_status_json_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestSupervisorStatusJSON(t *testing.T) {
+	clearGCEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"supervisor", "status", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(supervisor status --json) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string   `json:"schema_version"`
+		Running       bool     `json:"running"`
+		PID           int      `json:"pid"`
+		SocketPath    string   `json:"socket_path"`
+		CheckedPaths  []string `json:"checked_paths"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" {
+		t.Fatalf("schema_version = %q, want 1", payload.SchemaVersion)
+	}
+	if len(payload.CheckedPaths) == 0 {
+		t.Fatalf("checked_paths empty: %+v", payload)
+	}
+	if !payload.Running && payload.PID != 0 {
+		t.Fatalf("not running with pid = %d", payload.PID)
+	}
+}

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -148,6 +148,11 @@ func TestMaterializeBuiltinPacks(t *testing.T) {
 		t.Errorf("dolt assets/scripts/runtime.sh not executable: mode %v", info.Mode())
 	}
 
+	healthSchema := filepath.Join(cmds, "health", "schemas", "result.schema.json")
+	if _, err := os.Stat(healthSchema); err != nil {
+		t.Errorf("dolt command health result schema missing: %v", err)
+	}
+
 	// Verify formulas exist.
 	formulasDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "formulas")
 	if _, err := os.Stat(formulasDir); err != nil {

--- a/cmd/gc/json_schema.go
+++ b/cmd/gc/json_schema.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	gascity "github.com/gastownhall/gascity"
+	"github.com/spf13/cobra"
+)
+
+const (
+	jsonSchemaDirAnnotation = "gc.json.schema_dir"
+	jsonSchemaManifestRole  = "manifest"
+	jsonSchemaResultRole    = "result"
+	jsonSchemaFailureRole   = "failure"
+)
+
+type jsonSchemaManifest struct {
+	SchemaVersion string                     `json:"schema_version"`
+	Command       []string                   `json:"command"`
+	Transport     string                     `json:"transport"`
+	JSONSupported bool                       `json:"json_supported"`
+	Schemas       map[string]json.RawMessage `json:"schemas"`
+}
+
+type jsonSchemaErrorPayload struct {
+	SchemaVersion string                `json:"schema_version"`
+	OK            bool                  `json:"ok"`
+	Error         jsonSchemaErrorDetail `json:"error"`
+}
+
+type jsonSchemaErrorDetail struct {
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+	ExitCode int    `json:"exit_code"`
+}
+
+func configureJSONSchemaFlag(root *cobra.Command) {
+	root.PersistentFlags().String("json-schema", "", "emit JSON Schema for this command; optional value: result or failure")
+	if flag := root.PersistentFlags().Lookup("json-schema"); flag != nil {
+		flag.NoOptDefVal = jsonSchemaManifestRole
+	}
+}
+
+func handleJSONSchemaRequest(root *cobra.Command, args []string, stdout io.Writer) (bool, int) {
+	request, ok := parseJSONSchemaRequest(args)
+	if !ok {
+		return false, 0
+	}
+
+	cmd, _, err := root.Find(request.commandArgs)
+	if err != nil || cmd == nil {
+		return true, writeJSONSchemaUnavailable(stdout, "json_schema_command_not_found",
+			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
+	}
+	if cmd == root && len(request.commandArgs) > 0 {
+		return true, writeJSONSchemaUnavailable(stdout, "json_schema_command_not_found",
+			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
+	}
+
+	commandPath := commandPathWords(cmd)
+	if request.role == "" || request.role == jsonSchemaManifestRole {
+		if err := writeJSONSchemaManifest(stdout, cmd, commandPath); err != nil {
+			return true, 1
+		}
+		return true, 0
+	}
+
+	schema, err := schemaForRole(cmd, commandPath, request.role)
+	if err != nil {
+		return true, writeJSONSchemaUnavailable(stdout, "json_schema_unavailable", err.Error())
+	}
+	if err := writeRawJSONLine(stdout, schema); err != nil {
+		return true, 1
+	}
+	return true, 0
+}
+
+type jsonSchemaRequest struct {
+	role        string
+	commandArgs []string
+}
+
+func parseJSONSchemaRequest(args []string) (jsonSchemaRequest, bool) {
+	var request jsonSchemaRequest
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			request.commandArgs = append(request.commandArgs, args[i:]...)
+			break
+		}
+		switch {
+		case arg == "--json-schema":
+			request.role = jsonSchemaManifestRole
+			if i+1 < len(args) && isJSONSchemaRole(args[i+1]) {
+				request.role = args[i+1]
+				i++
+			}
+		case strings.HasPrefix(arg, "--json-schema="):
+			request.role = strings.TrimPrefix(arg, "--json-schema=")
+			if request.role == "" {
+				request.role = jsonSchemaManifestRole
+			}
+		case arg == "--city" || arg == "--rig":
+			i++
+		case strings.HasPrefix(arg, "--city=") || strings.HasPrefix(arg, "--rig="):
+			continue
+		default:
+			request.commandArgs = append(request.commandArgs, arg)
+		}
+	}
+	if request.role == "" {
+		return jsonSchemaRequest{}, false
+	}
+	return request, true
+}
+
+func isJSONSchemaRole(value string) bool {
+	return value == jsonSchemaManifestRole || value == jsonSchemaResultRole || value == jsonSchemaFailureRole
+}
+
+func commandPathWords(cmd *cobra.Command) []string {
+	var reversed []string
+	for c := cmd; c != nil && c.HasParent(); c = c.Parent() {
+		reversed = append(reversed, c.Name())
+	}
+	slices.Reverse(reversed)
+	return reversed
+}
+
+func writeJSONSchemaManifest(stdout io.Writer, cmd *cobra.Command, commandPath []string) error {
+	schemas := map[string]json.RawMessage{}
+	resultSchema, resultErr := readCommandSchema(cmd, commandPath, jsonSchemaResultRole)
+	if resultErr == nil {
+		schemas[jsonSchemaResultRole] = resultSchema
+		if failureSchema, err := schemaForRole(cmd, commandPath, jsonSchemaFailureRole); err == nil {
+			schemas[jsonSchemaFailureRole] = failureSchema
+		}
+	}
+
+	return writeCLIJSONLine(stdout, jsonSchemaManifest{
+		SchemaVersion: "1",
+		Command:       commandPath,
+		Transport:     "jsonl",
+		JSONSupported: resultErr == nil,
+		Schemas:       schemas,
+	})
+}
+
+func schemaForRole(cmd *cobra.Command, commandPath []string, role string) (json.RawMessage, error) {
+	if role != jsonSchemaResultRole && role != jsonSchemaFailureRole {
+		return nil, fmt.Errorf("unsupported schema role %q", role)
+	}
+	if _, err := readCommandSchema(cmd, commandPath, jsonSchemaResultRole); err != nil {
+		return nil, fmt.Errorf("command %q does not declare JSON support", strings.Join(commandPath, " "))
+	}
+	if role == jsonSchemaFailureRole {
+		if schema, err := readCommandSchema(cmd, commandPath, jsonSchemaFailureRole); err == nil {
+			return schema, nil
+		}
+		return readSharedFailureSchema()
+	}
+	return readCommandSchema(cmd, commandPath, role)
+}
+
+func readCommandSchema(cmd *cobra.Command, commandPath []string, role string) (json.RawMessage, error) {
+	if cmd != nil {
+		if schemaDir := strings.TrimSpace(cmd.Annotations[jsonSchemaDirAnnotation]); schemaDir != "" {
+			return readLocalSchema(filepath.Join(schemaDir, role+".schema.json"))
+		}
+	}
+	return readBuiltinSchema(commandPath, role)
+}
+
+func readBuiltinSchema(commandPath []string, role string) (json.RawMessage, error) {
+	if len(commandPath) == 0 {
+		return nil, fmt.Errorf("root command does not declare JSON support")
+	}
+	parts := append([]string{"schemas"}, commandPath...)
+	parts = append(parts, role+".schema.json")
+	return readEmbeddedSchema(filepath.ToSlash(filepath.Join(parts...)))
+}
+
+func readSharedFailureSchema() (json.RawMessage, error) {
+	return readEmbeddedSchema("schemas/failure.schema.json")
+}
+
+func readLocalSchema(path string) (json.RawMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("%s is not valid JSON", path)
+	}
+	return json.RawMessage(data), nil
+}
+
+func readEmbeddedSchema(path string) (json.RawMessage, error) {
+	data, err := gascity.BuiltinSchemas.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("%s is not valid JSON", path)
+	}
+	return json.RawMessage(data), nil
+}
+
+func writeJSONSchemaUnavailable(stdout io.Writer, code, message string) int {
+	const exitCode = 1
+	_ = writeCLIJSONLine(stdout, jsonSchemaErrorPayload{
+		SchemaVersion: "1",
+		OK:            false,
+		Error: jsonSchemaErrorDetail{
+			Code:     code,
+			Message:  message,
+			ExitCode: exitCode,
+		},
+	})
+	return exitCode
+}
+
+func writeCLIJSONLine(stdout io.Writer, value any) error {
+	enc := json.NewEncoder(stdout)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(value)
+}
+
+func writeRawJSONLine(stdout io.Writer, raw json.RawMessage) error {
+	_, err := stdout.Write(raw)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(stdout, "\n")
+	return err
+}

--- a/cmd/gc/json_schema.go
+++ b/cmd/gc/json_schema.go
@@ -81,9 +81,80 @@ func handleJSONSchemaRequest(root *cobra.Command, args []string, stdout io.Write
 	return true, 0
 }
 
+func handleJSONContractRequest(root *cobra.Command, args []string, stdout io.Writer) (bool, int) {
+	request, ok := parseJSONRequest(args)
+	if !ok {
+		return false, 0
+	}
+
+	cmd, _, err := root.Find(request.commandArgs)
+	if err != nil || cmd == nil {
+		return true, writeJSONSchemaUnavailable(stdout, "json_command_not_found",
+			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
+	}
+	if cmd == root && len(request.commandArgs) > 0 {
+		return true, writeJSONSchemaUnavailable(stdout, "json_command_not_found",
+			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
+	}
+
+	commandPath := commandPathWords(cmd)
+	if len(commandPath) > 0 && commandPath[0] == "bd" {
+		return false, 0
+	}
+	if _, err := readCommandSchema(cmd, commandPath, jsonSchemaResultRole); err != nil {
+		return true, writeJSONSchemaUnavailable(stdout, "json_unsupported",
+			fmt.Sprintf("command %q does not declare JSON support", strings.Join(commandPath, " ")))
+	}
+	return false, 0
+}
+
+func shouldBufferJSONExecution(args []string) bool {
+	request, ok := parseJSONRequest(args)
+	if !ok {
+		return false
+	}
+	return len(request.commandArgs) == 0 || request.commandArgs[0] != "bd"
+}
+
 type jsonSchemaRequest struct {
 	role        string
 	commandArgs []string
+}
+
+type jsonRequest struct {
+	commandArgs []string
+}
+
+func parseJSONRequest(args []string) (jsonRequest, bool) {
+	var request jsonRequest
+	jsonRequested := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		switch {
+		case arg == "--json":
+			jsonRequested = true
+		case strings.HasPrefix(arg, "--json="):
+			value := strings.TrimPrefix(arg, "--json=")
+			jsonRequested = value == "" || value == "true" || value == "1"
+		case arg == "--city" || arg == "--rig":
+			i++
+		case strings.HasPrefix(arg, "--city=") || strings.HasPrefix(arg, "--rig="):
+			continue
+		case strings.HasPrefix(arg, "-"):
+			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				i++
+			}
+		default:
+			request.commandArgs = append(request.commandArgs, arg)
+		}
+	}
+	if !jsonRequested {
+		return jsonRequest{}, false
+	}
+	return request, true
 }
 
 func parseJSONSchemaRequest(args []string) (jsonSchemaRequest, bool) {
@@ -214,7 +285,12 @@ func readEmbeddedSchema(path string) (json.RawMessage, error) {
 
 func writeJSONSchemaUnavailable(stdout io.Writer, code, message string) int {
 	const exitCode = 1
-	_ = writeCLIJSONLine(stdout, jsonSchemaErrorPayload{
+	_ = writeJSONFailure(stdout, code, message, exitCode)
+	return exitCode
+}
+
+func writeJSONFailure(stdout io.Writer, code, message string, exitCode int) error {
+	return writeCLIJSONLine(stdout, jsonSchemaErrorPayload{
 		SchemaVersion: "1",
 		OK:            false,
 		Error: jsonSchemaErrorDetail{
@@ -223,7 +299,6 @@ func writeJSONSchemaUnavailable(stdout io.Writer, code, message string) int {
 			ExitCode: exitCode,
 		},
 	})
-	return exitCode
 }
 
 func writeCLIJSONLine(stdout io.Writer, value any) error {

--- a/cmd/gc/json_schema.go
+++ b/cmd/gc/json_schema.go
@@ -81,14 +81,14 @@ func handleJSONSchemaRequest(root *cobra.Command, args []string, stdout io.Write
 	return true, 0
 }
 
-func handleJSONContractRequest(root *cobra.Command, args []string, stdout io.Writer) (bool, int) {
-	request, ok := parseJSONRequest(args)
+func handleJSONContractRequest(root *cobra.Command, args []string, stdout, stderr io.Writer) (bool, int) {
+	request, ok := resolveJSONRequest(root, args)
 	if !ok {
 		return false, 0
 	}
 
-	cmd, _, err := root.Find(request.commandArgs)
-	if err != nil || cmd == nil {
+	cmd := request.cmd
+	if request.findErr != nil || cmd == nil {
 		return true, writeJSONSchemaUnavailable(stdout, "json_command_not_found",
 			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
 	}
@@ -98,22 +98,37 @@ func handleJSONContractRequest(root *cobra.Command, args []string, stdout io.Wri
 	}
 
 	commandPath := commandPathWords(cmd)
-	if len(commandPath) > 0 && commandPath[0] == "bd" {
+	if isBDCommandPath(commandPath) {
 		return false, 0
 	}
 	if _, err := readCommandSchema(cmd, commandPath, jsonSchemaResultRole); err != nil {
+		if allowMissingLocalJSONSchemaPassthrough(cmd, err) {
+			fmt.Fprintf(stderr, "gc: warning: command %q does not declare JSON support; allowing --json pass-through during schema rollout (set GC_JSON_CONTRACT_STRICT=1 to enforce)\n", strings.Join(commandPath, " ")) //nolint:errcheck
+			return false, 0
+		}
 		return true, writeJSONSchemaUnavailable(stdout, "json_unsupported",
 			fmt.Sprintf("command %q does not declare JSON support", strings.Join(commandPath, " ")))
 	}
 	return false, 0
 }
 
-func shouldBufferJSONExecution(args []string) bool {
-	request, ok := parseJSONRequest(args)
+func shouldBufferJSONExecution(root *cobra.Command, args []string) bool {
+	request, ok := resolveJSONRequest(root, args)
 	if !ok {
 		return false
 	}
-	return len(request.commandArgs) == 0 || request.commandArgs[0] != "bd"
+	if request.findErr != nil || request.cmd == nil {
+		return true
+	}
+	commandPath := commandPathWords(request.cmd)
+	if isBDCommandPath(commandPath) {
+		return false
+	}
+	schema, err := readCommandSchema(request.cmd, commandPath, jsonSchemaResultRole)
+	if err != nil {
+		return !allowMissingLocalJSONSchemaPassthrough(request.cmd, err)
+	}
+	return !schemaDeclaresJSONL(schema)
 }
 
 type jsonSchemaRequest struct {
@@ -122,15 +137,37 @@ type jsonSchemaRequest struct {
 }
 
 type jsonRequest struct {
+	cmd         *cobra.Command
 	commandArgs []string
+	findErr     error
 }
 
-func parseJSONRequest(args []string) (jsonRequest, bool) {
-	var request jsonRequest
+func resolveJSONRequest(root *cobra.Command, args []string) (jsonRequest, bool) {
+	filteredArgs, jsonRequested := filterJSONFlag(args)
+	if !jsonRequested {
+		return jsonRequest{}, false
+	}
+	cmd, _, err := root.Find(filteredArgs)
+	request := jsonRequest{
+		cmd:         cmd,
+		commandArgs: fallbackCommandArgs(filteredArgs),
+		findErr:     err,
+	}
+	if cmd != nil {
+		if commandPath := commandPathWords(cmd); len(commandPath) > 0 {
+			request.commandArgs = commandPath
+		}
+	}
+	return request, true
+}
+
+func filterJSONFlag(args []string) ([]string, bool) {
+	filtered := make([]string, 0, len(args))
 	jsonRequested := false
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
+			filtered = append(filtered, args[i:]...)
 			break
 		}
 		switch {
@@ -139,22 +176,33 @@ func parseJSONRequest(args []string) (jsonRequest, bool) {
 		case strings.HasPrefix(arg, "--json="):
 			value := strings.TrimPrefix(arg, "--json=")
 			jsonRequested = value == "" || value == "true" || value == "1"
-		case arg == "--city" || arg == "--rig":
-			i++
-		case strings.HasPrefix(arg, "--city=") || strings.HasPrefix(arg, "--rig="):
-			continue
-		case strings.HasPrefix(arg, "-"):
-			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				i++
-			}
 		default:
-			request.commandArgs = append(request.commandArgs, arg)
+			filtered = append(filtered, arg)
 		}
 	}
-	if !jsonRequested {
-		return jsonRequest{}, false
+	return filtered, jsonRequested
+}
+
+func fallbackCommandArgs(args []string) []string {
+	var words []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		if strings.HasPrefix(arg, "--city=") || strings.HasPrefix(arg, "--rig=") {
+			continue
+		}
+		if arg == "--city" || arg == "--rig" {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		words = append(words, arg)
 	}
-	return request, true
+	return words
 }
 
 func parseJSONSchemaRequest(args []string) (jsonSchemaRequest, bool) {
@@ -202,6 +250,38 @@ func commandPathWords(cmd *cobra.Command) []string {
 	}
 	slices.Reverse(reversed)
 	return reversed
+}
+
+func isBDCommandPath(commandPath []string) bool {
+	return len(commandPath) > 0 && commandPath[0] == "bd"
+}
+
+func schemaDeclaresJSONL(schema json.RawMessage) bool {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(schema, &object); err != nil {
+		return false
+	}
+	_, ok := object["x-gc-jsonl"]
+	return ok
+}
+
+func allowMissingLocalJSONSchemaPassthrough(cmd *cobra.Command, err error) bool {
+	if cmd == nil || !os.IsNotExist(err) {
+		return false
+	}
+	if strings.TrimSpace(cmd.Annotations[jsonSchemaDirAnnotation]) == "" {
+		return false
+	}
+	return !strictPackJSONSchemaContract()
+}
+
+func strictPackJSONSchemaContract() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("GC_JSON_CONTRACT_STRICT"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func writeJSONSchemaManifest(stdout io.Writer, cmd *cobra.Command, commandPath []string) error {

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestJSONSchemaManifestForSupportedCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"events", "--json-schema"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(events --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var manifest struct {
+		SchemaVersion string                     `json:"schema_version"`
+		Command       []string                   `json:"command"`
+		Transport     string                     `json:"transport"`
+		JSONSupported bool                       `json:"json_supported"`
+		Schemas       map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+	}
+	if manifest.SchemaVersion != "1" || manifest.Transport != "jsonl" || !manifest.JSONSupported {
+		t.Fatalf("manifest metadata = %+v", manifest)
+	}
+	if got := strings.Join(manifest.Command, " "); got != "events" {
+		t.Fatalf("command = %q, want events", got)
+	}
+	if !json.Valid(manifest.Schemas["result"]) {
+		t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
+	}
+	if !json.Valid(manifest.Schemas["failure"]) {
+		t.Fatalf("failure schema missing or invalid: %s", manifest.Schemas["failure"])
+	}
+}
+
+func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--json-schema"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(version --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var manifest struct {
+		Command       []string                   `json:"command"`
+		JSONSupported bool                       `json:"json_supported"`
+		Schemas       map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got := strings.Join(manifest.Command, " "); got != "version" {
+		t.Fatalf("command = %q, want version", got)
+	}
+	if manifest.JSONSupported {
+		t.Fatalf("json_supported = true, want false")
+	}
+	if len(manifest.Schemas) != 0 {
+		t.Fatalf("schemas = %+v, want empty", manifest.Schemas)
+	}
+}
+
+func TestJSONSchemaRoleSpecificResult(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", "/tmp/example-city", "events", "--json-schema=result"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(events --json-schema=result) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+		t.Fatalf("result schema is not JSON: %v\n%s", err, stdout.String())
+	}
+	if schema["$schema"] == "" {
+		t.Fatalf("schema missing $schema: %+v", schema)
+	}
+	if _, ok := schema["x-gc-jsonl"].(map[string]any); !ok {
+		t.Fatalf("schema missing x-gc-jsonl object: %+v", schema)
+	}
+}
+
+func TestJSONSchemaRoleSpecificFailureUsesSharedDefault(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"events", "--json-schema", "failure"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(events --json-schema failure) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var schema struct {
+		Required             []string `json:"required"`
+		AdditionalProperties bool     `json:"additionalProperties"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+		t.Fatalf("failure schema is not JSON: %v\n%s", err, stdout.String())
+	}
+	if !schema.AdditionalProperties {
+		t.Fatalf("additionalProperties = false, want true")
+	}
+	if strings.Join(schema.Required, ",") != "schema_version,ok,error" {
+		t.Fatalf("required = %v", schema.Required)
+	}
+}
+
+func TestJSONSchemaUnavailableRoleFailureIsStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--json-schema=result"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run(version --json-schema=result) = 0, want nonzero")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		OK            bool   `json:"ok"`
+		Error         struct {
+			Code     string `json:"code"`
+			Message  string `json:"message"`
+			ExitCode int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("failure payload is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.OK || payload.Error.ExitCode != code || payload.Error.Code == "" {
+		t.Fatalf("payload = %+v, code=%d", payload, code)
+	}
+}
+
+func TestJSONSchemaManifestForDiscoveredPackCommand(t *testing.T) {
+	dir := t.TempDir()
+	commandDir := filepath.Join(dir, "commands", "review", "pr")
+	if err := os.MkdirAll(filepath.Join(commandDir, "schemas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commandDir, "schemas", "result.schema.json"), []byte(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": { "ok": { "type": "boolean" } },
+  "required": ["ok"]
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := &cobra.Command{Use: "gc"}
+	configureJSONSchemaFlag(root)
+	var stdout, stderr bytes.Buffer
+	addDiscoveredCommandsToRoot(root, []config.DiscoveredCommand{{
+		Command:     []string{"review", "pr"},
+		Description: "Review a PR",
+		SourceDir:   commandDir,
+		PackDir:     dir,
+		PackName:    "tools",
+		BindingName: "tools",
+	}}, dir, "testcity", &stdout, &stderr, true)
+
+	handled, code := handleJSONSchemaRequest(root, []string{"tools", "review", "pr", "--json-schema"}, &stdout)
+	if !handled || code != 0 {
+		t.Fatalf("handled=%v code=%d stderr=%q stdout=%q", handled, code, stderr.String(), stdout.String())
+	}
+
+	var manifest struct {
+		Command       []string                   `json:"command"`
+		JSONSupported bool                       `json:"json_supported"`
+		Schemas       map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got := strings.Join(manifest.Command, " "); got != "tools review pr" {
+		t.Fatalf("command = %q, want tools review pr", got)
+	}
+	if !manifest.JSONSupported || !json.Valid(manifest.Schemas["result"]) || !json.Valid(manifest.Schemas["failure"]) {
+		t.Fatalf("manifest = %+v", manifest)
+	}
+}

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -153,6 +153,69 @@ func TestJSONSchemaUnavailableRoleFailureIsStructured(t *testing.T) {
 	}
 }
 
+func TestJSONUnsupportedCommandFailureIsStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--json"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run(version --json) = 0, want nonzero")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		OK            bool   `json:"ok"`
+		Error         struct {
+			Code     string `json:"code"`
+			Message  string `json:"message"`
+			ExitCode int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("failure payload is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.OK || payload.Error.ExitCode != code || payload.Error.Code != "json_unsupported" {
+		t.Fatalf("payload = %+v, code=%d", payload, code)
+	}
+}
+
+func TestJSONContractAllowsBdPassthrough(t *testing.T) {
+	root := &cobra.Command{Use: "gc"}
+	root.AddCommand(&cobra.Command{Use: "bd [bd-args...]"})
+
+	var stdout bytes.Buffer
+	handled, code := handleJSONContractRequest(root, []string{"bd", "list", "--json"}, &stdout)
+	if handled || code != 0 {
+		t.Fatalf("handled=%v code=%d stdout=%q", handled, code, stdout.String())
+	}
+}
+
+func TestJSONExecutionFailureIsStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"config", "explain", "--json"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run(config explain --json) = 0, want nonzero")
+	}
+	if stderr.Len() == 0 {
+		t.Fatalf("stderr empty, want command diagnostics")
+	}
+
+	var payload struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Code     string `json:"code"`
+			ExitCode int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("failure payload is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.OK || payload.Error.Code != "command_failed" || payload.Error.ExitCode != code {
+		t.Fatalf("payload = %+v, code=%d", payload, code)
+	}
+}
+
 func TestJSONSchemaManifestForDiscoveredPackCommand(t *testing.T) {
 	dir := t.TempDir()
 	commandDir := filepath.Join(dir, "commands", "review", "pr")

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -184,10 +184,89 @@ func TestJSONContractAllowsBdPassthrough(t *testing.T) {
 	root := &cobra.Command{Use: "gc"}
 	root.AddCommand(&cobra.Command{Use: "bd [bd-args...]"})
 
-	var stdout bytes.Buffer
-	handled, code := handleJSONContractRequest(root, []string{"bd", "list", "--json"}, &stdout)
+	var stdout, stderr bytes.Buffer
+	handled, code := handleJSONContractRequest(root, []string{"bd", "list", "--json"}, &stdout, &stderr)
 	if handled || code != 0 {
 		t.Fatalf("handled=%v code=%d stdout=%q", handled, code, stdout.String())
+	}
+}
+
+func TestJSONContractResolvesCommandWithInterspersedBooleanFlags(t *testing.T) {
+	schemaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(schemaDir, "result.schema.json"), []byte(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object"
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := &cobra.Command{Use: "gc"}
+	parent := &cobra.Command{Use: "tools"}
+	parent.PersistentFlags().Bool("verbose", false, "verbose output")
+	leaf := &cobra.Command{
+		Use:         "run",
+		Annotations: map[string]string{jsonSchemaDirAnnotation: schemaDir},
+	}
+	parent.AddCommand(leaf)
+	root.AddCommand(parent)
+
+	var stdout, stderr bytes.Buffer
+	handled, code := handleJSONContractRequest(root, []string{"tools", "--verbose", "run", "--json"}, &stdout, &stderr)
+	if handled || code != 0 {
+		t.Fatalf("handled=%v code=%d stdout=%q stderr=%q", handled, code, stdout.String(), stderr.String())
+	}
+}
+
+func TestJSONContractMissingPackSchemaWarnsBeforeStrictRollout(t *testing.T) {
+	t.Setenv("GC_JSON_CONTRACT_STRICT", "0")
+
+	root := &cobra.Command{Use: "gc"}
+	root.AddCommand(&cobra.Command{
+		Use:         "packcmd",
+		Annotations: map[string]string{jsonSchemaDirAnnotation: filepath.Join(t.TempDir(), "schemas")},
+	})
+
+	var stdout, stderr bytes.Buffer
+	handled, code := handleJSONContractRequest(root, []string{"packcmd", "--json"}, &stdout, &stderr)
+	if handled || code != 0 {
+		t.Fatalf("handled=%v code=%d stdout=%q stderr=%q", handled, code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "does not declare JSON support") {
+		t.Fatalf("stderr = %q, want missing-schema warning", stderr.String())
+	}
+}
+
+func TestJSONContractMissingPackSchemaCanBeStrict(t *testing.T) {
+	t.Setenv("GC_JSON_CONTRACT_STRICT", "1")
+
+	root := &cobra.Command{Use: "gc"}
+	root.AddCommand(&cobra.Command{
+		Use:         "packcmd",
+		Annotations: map[string]string{jsonSchemaDirAnnotation: filepath.Join(t.TempDir(), "schemas")},
+	})
+
+	var stdout, stderr bytes.Buffer
+	handled, code := handleJSONContractRequest(root, []string{"packcmd", "--json"}, &stdout, &stderr)
+	if !handled || code == 0 {
+		t.Fatalf("handled=%v code=%d stdout=%q stderr=%q", handled, code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"code":"json_unsupported"`) {
+		t.Fatalf("stdout = %q, want json_unsupported", stdout.String())
+	}
+}
+
+func TestJSONExecutionDoesNotBufferJSONLCommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	root := newRootCmd(&stdout, &stderr)
+
+	for _, args := range [][]string{
+		{"events", "--json"},
+		{"events", "--follow", "--json"},
+		{"events", "--watch", "--json"},
+	} {
+		if shouldBufferJSONExecution(root, args) {
+			t.Fatalf("shouldBufferJSONExecution(%v) = true, want false for JSONL command", args)
+		}
 	}
 }
 

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -114,6 +114,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
+	if handled, code := handleJSONSchemaRequest(root, args, stdout); handled {
+		return code
+	}
 	if err := root.Execute(); err != nil {
 		return commandExitCode(err)
 	}
@@ -150,6 +153,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		"path to the city directory (default: walk up from cwd)")
 	root.PersistentFlags().StringVar(&rigFlag, "rig", "",
 		"rig name or path (default: discover from cwd)")
+	configureJSONSchemaFlag(root)
 	_ = root.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	root.AddCommand(
 		newStartCmd(stdout, stderr),

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -107,18 +108,37 @@ func run(args []string, stdout, stderr io.Writer) int {
 		telemetry.SetProcessOTELAttrs()
 	}
 
-	root := newRootCmd(stdout, stderr)
+	jsonExecution := shouldBufferJSONExecution(args)
+	execStdout := stdout
+	var jsonStdout bytes.Buffer
+	if jsonExecution {
+		execStdout = &jsonStdout
+	}
+
+	root := newRootCmd(execStdout, stderr)
 	if args == nil {
 		args = []string{}
 	}
 	root.SetArgs(args)
-	root.SetOut(stdout)
+	root.SetOut(execStdout)
 	root.SetErr(stderr)
 	if handled, code := handleJSONSchemaRequest(root, args, stdout); handled {
 		return code
 	}
+	if handled, code := handleJSONContractRequest(root, args, stdout); handled {
+		return code
+	}
 	if err := root.Execute(); err != nil {
-		return commandExitCode(err)
+		code := commandExitCode(err)
+		if jsonExecution {
+			_ = writeJSONFailure(stdout, "command_failed", "command failed; see stderr for diagnostics", code)
+		}
+		return code
+	}
+	if jsonExecution {
+		if _, err := io.Copy(stdout, &jsonStdout); err != nil {
+			return 1
+		}
 	}
 	return 0
 }

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -38,6 +38,17 @@ type commandExitError struct {
 	code int
 }
 
+type switchableWriter struct {
+	target io.Writer
+}
+
+func (w *switchableWriter) Write(p []byte) (int, error) {
+	if w == nil || w.target == nil {
+		return 0, io.ErrClosedPipe
+	}
+	return w.target.Write(p)
+}
+
 func (e *commandExitError) Error() string {
 	if e == nil {
 		return "exit"
@@ -108,16 +119,15 @@ func run(args []string, stdout, stderr io.Writer) int {
 		telemetry.SetProcessOTELAttrs()
 	}
 
-	jsonExecution := shouldBufferJSONExecution(args)
-	execStdout := stdout
+	execStdout := &switchableWriter{target: stdout}
 	var jsonStdout bytes.Buffer
-	if jsonExecution {
-		execStdout = &jsonStdout
-	}
-
 	root := newRootCmd(execStdout, stderr)
 	if args == nil {
 		args = []string{}
+	}
+	jsonExecution := shouldBufferJSONExecution(root, args)
+	if jsonExecution {
+		execStdout.target = &jsonStdout
 	}
 	root.SetArgs(args)
 	root.SetOut(execStdout)
@@ -125,13 +135,19 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if handled, code := handleJSONSchemaRequest(root, args, stdout); handled {
 		return code
 	}
-	if handled, code := handleJSONContractRequest(root, args, stdout); handled {
+	if handled, code := handleJSONContractRequest(root, args, stdout, stderr); handled {
 		return code
 	}
 	if err := root.Execute(); err != nil {
 		code := commandExitCode(err)
 		if jsonExecution {
-			_ = writeJSONFailure(stdout, "command_failed", "command failed; see stderr for diagnostics", code)
+			if len(bytes.TrimSpace(jsonStdout.Bytes())) > 0 {
+				if _, copyErr := io.Copy(stdout, &jsonStdout); copyErr != nil {
+					return 1
+				}
+			} else {
+				_ = writeJSONFailure(stdout, "command_failed", commandFailureMessage(err), code)
+			}
 		}
 		return code
 	}
@@ -141,6 +157,17 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return 0
+}
+
+func commandFailureMessage(err error) string {
+	if err == nil {
+		return "command failed"
+	}
+	msg := strings.TrimSpace(err.Error())
+	if msg == "" || errors.Is(err, errExit) {
+		return "command failed; see stderr for diagnostics"
+	}
+	return msg
 }
 
 // newRootCmd creates the root cobra command with all subcommands.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,6 +7,7 @@
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--city` | string |  | path to the city directory (default: walk up from cwd) |
+| `--json-schema` | string |  | emit JSON Schema for this command; optional value: result or failure |
 | `--rig` | string |  | rig name or path (default: discover from cwd) |
 
 ## gc
@@ -556,12 +557,14 @@ gc config show [flags]
 gc config show
   gc config show --validate
   gc config show --provenance
+  gc config show --json
   gc config show -f overlay.toml
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `-f`, `--file` | stringArray |  | additional config files to layer (can be repeated) |
+| `--json` | bool |  | emit JSON |
 | `--provenance` | bool |  | show where each config element originated |
 | `--validate` | bool |  | validate config and exit (0 = valid, 1 = errors) |
 
@@ -2935,8 +2938,12 @@ gc supervisor start
 Check if the supervisor is running
 
 ```
-gc supervisor status
+gc supervisor status [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | emit JSON |
 
 ## gc supervisor stop
 

--- a/examples/dolt/commands/health/schemas/result.schema.json
+++ b/examples/dolt/commands/health/schemas/result.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["timestamp", "server", "databases", "backups", "orphans", "processes"],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "server": {
+      "type": "object",
+      "required": ["running", "reachable", "pid", "port", "latency_ms"],
+      "properties": {
+        "running": {
+          "type": "boolean"
+        },
+        "reachable": {
+          "type": "boolean"
+        },
+        "pid": {
+          "type": "integer"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "latency_ms": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true
+    },
+    "databases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "commits", "open_beads"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "commits": {
+            "type": "integer"
+          },
+          "open_beads": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "backups": {
+      "type": "object",
+      "required": ["dolt_freshness", "dolt_age_sec", "dolt_stale"],
+      "properties": {
+        "dolt_freshness": {
+          "type": "string"
+        },
+        "dolt_age_sec": {
+          "type": "integer"
+        },
+        "dolt_stale": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "orphans": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "size"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "processes": {
+      "type": "object",
+      "required": ["zombie_count", "zombie_pids"],
+      "properties": {
+        "zombie_count": {
+          "type": "integer"
+        },
+        "zombie_pids": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/analyze/reliability/result.schema.json
+++ b/schemas/analyze/reliability/result.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["groups", "total", "skipped", "ambiguous_aliases", "instrumentation"],
+  "properties": {
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["key", "sessions", "crashed", "quarantined", "idle_killed", "drained", "unhealthy_total"],
+        "properties": {
+          "key": { "type": "object", "additionalProperties": true },
+          "sessions": { "type": "integer" },
+          "crashed": { "type": "integer" },
+          "quarantined": { "type": "integer" },
+          "idle_killed": { "type": "integer" },
+          "drained": { "type": "integer" },
+          "unhealthy_total": { "type": "integer" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "total": { "type": "object", "additionalProperties": true },
+    "skipped": { "type": "integer" },
+    "ambiguous_aliases": { "type": "integer" },
+    "instrumentation": { "type": "object", "additionalProperties": true }
+  },
+  "additionalProperties": true
+}

--- a/schemas/config/explain/result.schema.json
+++ b/schemas/config/explain/result.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["name", "chain", "resolved", "provenance"],
+  "properties": {
+    "name": { "type": "string" },
+    "builtin_ancestor": { "type": "string" },
+    "chain": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "name"],
+        "properties": {
+          "kind": { "type": "string" },
+          "name": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "resolved": { "type": "object", "additionalProperties": true },
+    "provenance": {
+      "type": "object",
+      "properties": {
+        "field_layer": { "type": "object", "additionalProperties": { "type": "string" } },
+        "map_key_layer": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/config/show/result.schema.json
+++ b/schemas/config/show/result.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "config", "warnings", "validation"],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "city_path": {
+      "type": "string"
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "validation": {
+      "type": "object",
+      "required": ["ok", "warnings", "errors"],
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "provenance": {
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/converge/list/result.schema.json
+++ b/schemas/converge/list/result.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "state", "iteration", "gate", "formula", "target", "title"],
+    "properties": {
+      "id": { "type": "string" },
+      "state": { "type": "string" },
+      "iteration": { "type": "string" },
+      "gate": { "type": "string" },
+      "formula": { "type": "string" },
+      "target": { "type": "string" },
+      "title": { "type": "string" }
+    },
+    "additionalProperties": true
+  }
+}

--- a/schemas/converge/status/result.schema.json
+++ b/schemas/converge/status/result.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": { "type": "string" }
+}

--- a/schemas/dolt-cleanup/result.schema.json
+++ b/schemas/dolt-cleanup/result.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema", "port", "rigs_protected", "force_blockers", "dropped", "purge", "reaped", "summary", "errors"],
+  "properties": {
+    "schema": { "const": "gc.dolt.cleanup.v1" },
+    "port": {
+      "type": "object",
+      "required": ["resolved", "source", "fallback"],
+      "properties": {
+        "resolved": { "type": "integer" },
+        "source": { "type": "string" },
+        "fallback": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "rigs_protected": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "force_blockers": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "dropped": { "type": "object", "additionalProperties": true },
+    "purge": { "type": "object", "additionalProperties": true },
+    "reaped": { "type": "object", "additionalProperties": true },
+    "summary": {
+      "type": "object",
+      "required": ["bytes_freed_disk", "bytes_freed_rss", "errors_total"],
+      "properties": {
+        "bytes_freed_disk": { "type": "integer" },
+        "bytes_freed_rss": { "type": "integer" },
+        "errors_total": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "errors": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+  },
+  "additionalProperties": true
+}

--- a/schemas/events/result.schema.json
+++ b/schemas/events/result.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "actor": {
+      "type": "string"
+    },
+    "city": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    },
+    "payload": true,
+    "seq": {
+      "type": "integer"
+    },
+    "subject": {
+      "type": "string"
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    }
+  },
+  "required": ["actor", "seq", "ts", "type"],
+  "additionalProperties": true
+}

--- a/schemas/failure.schema.json
+++ b/schemas/failure.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "error"],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "ok": {
+      "const": false
+    },
+    "error": {
+      "type": "object",
+      "required": ["code", "message", "exit_code"],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "exit_code": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/list/result.schema.json
+++ b/schemas/rig/list/result.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["city_path", "city_name", "rigs"],
+  "properties": {
+    "city_path": { "type": "string" },
+    "city_name": { "type": "string" },
+    "rigs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "path", "prefix", "hq", "suspended", "beads"],
+        "properties": {
+          "name": { "type": "string" },
+          "path": { "type": "string" },
+          "prefix": { "type": "string" },
+          "default_branch": { "type": "string" },
+          "hq": { "type": "boolean" },
+          "suspended": { "type": "boolean" },
+          "beads": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/session/list/result.schema.json
+++ b/schemas/session/list/result.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string" },
+      "name": { "type": "string" },
+      "template": { "type": "string" },
+      "provider": { "type": "string" },
+      "state": { "type": "string" },
+      "title": { "type": "string" },
+      "rig": { "type": "string" }
+    },
+    "additionalProperties": true
+  }
+}

--- a/schemas/status/result.schema.json
+++ b/schemas/status/result.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["city_name", "city_path", "controller", "suspended", "agents", "rigs", "summary"],
+  "properties": {
+    "city_name": { "type": "string" },
+    "city_path": { "type": "string" },
+    "controller": {
+      "type": "object",
+      "required": ["running"],
+      "properties": {
+        "running": { "type": "boolean" },
+        "pid": { "type": "integer" },
+        "mode": { "type": "string" },
+        "status": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "suspended": { "type": "boolean" },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "qualified_name", "scope", "running", "suspended"],
+        "properties": {
+          "name": { "type": "string" },
+          "qualified_name": { "type": "string" },
+          "scope": { "type": "string" },
+          "running": { "type": "boolean" },
+          "suspended": { "type": "boolean" },
+          "pool": {
+            "type": "object",
+            "properties": {
+              "min": { "type": "integer" },
+              "max": { "type": "integer" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "rigs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "path", "suspended"],
+        "properties": {
+          "name": { "type": "string" },
+          "path": { "type": "string" },
+          "suspended": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_agents", "running_agents"],
+      "properties": {
+        "total_agents": { "type": "integer" },
+        "running_agents": { "type": "integer" },
+        "active_sessions": { "type": "integer" },
+        "suspended_sessions": { "type": "integer" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/supervisor/status/result.schema.json
+++ b/schemas/supervisor/status/result.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "running", "pid", "socket_path", "checked_paths"],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "running": {
+      "type": "boolean"
+    },
+    "pid": {
+      "type": "integer"
+    },
+    "socket_path": {
+      "type": "string"
+    },
+    "checked_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/trace/show/result.schema.json
+++ b/schemas/trace/show/result.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "schema_version": { "type": "integer" },
+      "trace_id": { "type": "string" },
+      "tick_id": { "type": "string" },
+      "type": { "type": "string" },
+      "reason": { "type": "string" },
+      "created_at": { "type": "string", "format": "date-time" }
+    },
+    "additionalProperties": true
+  }
+}

--- a/schemas_embed.go
+++ b/schemas_embed.go
@@ -1,3 +1,4 @@
+// Package gascity provides repository-level embedded assets shared by CLI packages.
 package gascity
 
 import "embed"

--- a/schemas_embed.go
+++ b/schemas_embed.go
@@ -1,0 +1,11 @@
+package gascity
+
+import "embed"
+
+// BuiltinSchemas embeds the checked-in CLI JSON schemas.
+//
+// Logical schema paths are rooted at schemas/, for example:
+// schemas/events/result.schema.json
+//
+//go:embed schemas/**
+var BuiltinSchemas embed.FS


### PR DESCRIPTION
## Summary
- adds `gc config show --json` with schema, validation state, and machine-readable composition warnings
- adds `gc supervisor status --json` with schema, running state, PID, and checked socket paths
- preserves existing human output by default

## JSON compatibility notes
- `gc config show` did not previously accept `--json`; this adds a new JSON shape rather than changing existing JSON output.
- `gc supervisor status` did not previously accept `--json`; JSON mode returns a successful inspection document even when the supervisor is not running, while human mode keeps its existing nonzero status behavior.
- `gc config show --json` moves composition warnings into the JSON payload and suppresses those human warning lines on stderr so agent consumers get deterministic stdout and no duplicated diagnostics.

## Validation
- `go test ./cmd/gc -run 'TestConfigShowJSON|TestSupervisorStatusJSON|TestJSONSchema'`\n- `GOOS=linux make lint`\n- `make fmt-check`\n- `make vet`\n- `make check-docs`\n- smoke against `/Users/dbox/repos/gc/gc4gc`: `config show --json`, `supervisor status --json`, and both result schema probes\n\nStacked on #2222.