### PR TITLE
Fix CI wait cleanup and unregister shutdown flakes

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -701,6 +701,9 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 		}
 	}
 	if mc.cr != nil {
+		if mc.cr.forceStopShutdown != nil {
+			mc.cr.forceStopShutdown.Store(true)
+		}
 		func() {
 			defer func() { recover() }() //nolint:errcheck
 			mc.cr.shutdown()

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -4038,6 +4039,7 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 
 	closer := &closerSpy{}
+	forceStop := &atomic.Bool{}
 	mc := &managedCity{
 		name:   "bright-lights",
 		cancel: func() {},
@@ -4051,10 +4053,11 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 					DriftDrainTimeout: "20ms",
 				},
 			},
-			sp:     runtime.NewFake(),
-			rec:    events.Discard,
-			stdout: io.Discard,
-			stderr: io.Discard,
+			sp:                runtime.NewFake(),
+			rec:               events.Discard,
+			stdout:            io.Discard,
+			stderr:            io.Discard,
+			forceStopShutdown: forceStop,
 		},
 	}
 
@@ -4075,6 +4078,9 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 	}
 	if !closer.closed {
 		t.Fatal("expected closer to be closed after forced cleanup")
+	}
+	if !forceStop.Load() {
+		t.Fatal("expected forced cleanup to request force-stop shutdown")
 	}
 
 	ops := readOpLog(t, logFile)

--- a/cmd/gc/session_circuit_breaker_test.go
+++ b/cmd/gc/session_circuit_breaker_test.go
@@ -762,6 +762,16 @@ func TestComputeNamedSessionProgressSignaturesSkipsAmbiguousBareKeys(t *testing.
 
 func intPtrCircuit(n int) *int { return &n }
 
+func circuitTestAgent(name string) config.Agent {
+	return config.Agent{
+		Name:         name,
+		Dir:          "rig-a",
+		Provider:     "codex",
+		StartCommand: "test-cmd",
+		PromptMode:   "none",
+	}
+}
+
 func configureAlwaysNamedSession(env *reconcilerTestEnv) {
 	env.cfg = &config.City{
 		Daemon: config.DaemonConfig{
@@ -769,7 +779,7 @@ func configureAlwaysNamedSession(env *reconcilerTestEnv) {
 			SessionCircuitBreakerMaxRestarts: intPtrCircuit(5),
 			SessionCircuitBreakerWindow:      "30m",
 		},
-		Agents: []config.Agent{{Name: "template-a", Dir: "rig-a"}},
+		Agents: []config.Agent{circuitTestAgent("template-a")},
 		NamedSessions: []config.NamedSession{{
 			Name:     "session-a",
 			Template: "template-a",
@@ -781,7 +791,7 @@ func configureAlwaysNamedSession(env *reconcilerTestEnv) {
 
 func configureAlwaysNamedSessionWithoutCircuit(env *reconcilerTestEnv) {
 	env.cfg = &config.City{
-		Agents: []config.Agent{{Name: "template-a", Dir: "rig-a"}},
+		Agents: []config.Agent{circuitTestAgent("template-a")},
 		NamedSessions: []config.NamedSession{{
 			Name:     "session-a",
 			Template: "template-a",
@@ -858,7 +868,7 @@ func TestReconciler_CircuitUsesConfiguredDaemonThresholds(t *testing.T) {
 			SessionCircuitBreakerMaxRestarts: intPtrCircuit(2),
 			SessionCircuitBreakerWindow:      "30m",
 		},
-		Agents: []config.Agent{{Name: "template-a", Dir: "rig-a"}},
+		Agents: []config.Agent{circuitTestAgent("template-a")},
 		NamedSessions: []config.NamedSession{{
 			Name:     "session-a",
 			Template: "template-a",
@@ -1023,8 +1033,8 @@ func TestReconciler_CircuitDoesNotRecordRestartForDependencyBlockedNamedSession(
 			SessionCircuitBreakerWindow:      "30m",
 		},
 		Agents: []config.Agent{
-			{Name: "template-a", DependsOn: []string{"db"}},
-			{Name: "db"},
+			{Name: "template-a", Provider: "codex", StartCommand: "test-cmd", PromptMode: "none", DependsOn: []string{"db"}},
+			{Name: "db", Provider: "codex", StartCommand: "test-cmd", PromptMode: "none"},
 		},
 		NamedSessions: []config.NamedSession{{
 			Name:     "session-a",
@@ -1062,8 +1072,8 @@ func TestReconciler_CircuitDoesNotRecordRestartForWakeBudgetDeferredNamedSession
 			SessionCircuitBreakerWindow:      "30m",
 		},
 		Agents: []config.Agent{
-			{Name: "template-a", Dir: "rig-a"},
-			{Name: "template-b", Dir: "rig-a"},
+			circuitTestAgent("template-a"),
+			circuitTestAgent("template-b"),
 		},
 		NamedSessions: []config.NamedSession{
 			{Name: "session-a", Template: "template-a", Dir: "rig-a", Mode: "always"},

--- a/internal/session/waits.go
+++ b/internal/session/waits.go
@@ -257,6 +257,10 @@ func cancelWaitsAndCollectNudgeIDs(store beads.Store, sessionID string, now time
 	ids := []string(nil)
 	seen := map[string]bool{}
 	capped := false
+	canceledMetadata := map[string]string{
+		"state":       waitStateCanceled,
+		"canceled_at": now.UTC().Format(time.RFC3339),
+	}
 	for {
 		waits, err := ListSessionWaitBeads(store, sessionID)
 		if err != nil && !beads.IsLookupLimitError(err) {
@@ -264,24 +268,30 @@ func cancelWaitsAndCollectNudgeIDs(store beads.Store, sessionID string, now time
 		}
 		lookupCapped := beads.IsLookupLimitError(err)
 		capped = capped || lookupCapped
-		canceled := 0
+		cancelIDs := make([]string, 0, len(waits))
+		terminalIDs := make([]string, 0, len(waits))
 		for _, wait := range waits {
 			if nudgeID := wait.Metadata["nudge_id"]; nudgeID != "" && !seen[nudgeID] {
 				seen[nudgeID] = true
 				ids = append(ids, nudgeID)
 			}
 			if IsWaitTerminalState(wait.Metadata["state"]) {
-				if err := store.Close(wait.ID); err != nil {
-					return ids, capped, err
-				}
-				canceled++
+				terminalIDs = append(terminalIDs, wait.ID)
 				continue
 			}
-			if err := cancelWait(store, wait, now); err != nil {
+			cancelIDs = append(cancelIDs, wait.ID)
+		}
+		if len(cancelIDs) > 0 {
+			if _, err := store.CloseAll(cancelIDs, canceledMetadata); err != nil {
 				return ids, capped, err
 			}
-			canceled++
 		}
+		if len(terminalIDs) > 0 {
+			if _, err := store.CloseAll(terminalIDs, nil); err != nil {
+				return ids, capped, err
+			}
+		}
+		canceled := len(cancelIDs) + len(terminalIDs)
 		if !lookupCapped {
 			return ids, capped, nil
 		}
@@ -295,19 +305,6 @@ func cancelWaitsAndCollectNudgeIDs(store beads.Store, sessionID string, now time
 func CancelWaits(store beads.Store, sessionID string, now time.Time) error {
 	_, _, err := CancelWaitsAndCollectNudgeIDs(store, sessionID, now)
 	return err
-}
-
-func cancelWait(store beads.Store, wait beads.Bead, now time.Time) error {
-	if err := store.SetMetadataBatch(wait.ID, map[string]string{
-		"state":       waitStateCanceled,
-		"canceled_at": now.UTC().Format(time.RFC3339),
-	}); err != nil {
-		return err
-	}
-	if err := store.Close(wait.ID); err != nil {
-		return err
-	}
-	return nil
 }
 
 func beadHasLabel(b beads.Bead, want string) bool {

--- a/internal/session/waits_test.go
+++ b/internal/session/waits_test.go
@@ -59,6 +59,15 @@ func (s cancelWaitMetadataFailStore) SetMetadataBatch(id string, kvs map[string]
 	return s.MemStore.SetMetadataBatch(id, kvs)
 }
 
+func (s cancelWaitMetadataFailStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	for _, id := range ids {
+		if id == s.failID {
+			return 0, errors.New("cancel wait metadata failed")
+		}
+	}
+	return s.MemStore.CloseAll(ids, metadata)
+}
+
 func sessionWaitItems(query beads.ListQuery, count int) []beads.Bead {
 	items := make([]beads.Bead, count)
 	for i := range items {

--- a/test/integration/huma_binary_test.go
+++ b/test/integration/huma_binary_test.go
@@ -498,6 +498,10 @@ func TestHumaBinary_CityUnregisterAsync(t *testing.T) {
 
 	baseURL := "http://127.0.0.1:" + strconv.Itoa(port)
 	env := integrationEnvFor(gcHome, runtimeDir, true)
+	// This test covers the supervisor's async unregister contract, not
+	// provider startup. Keep the city runtime deterministic so unregister
+	// does not race provider resume/startup-key handling.
+	env = append(env, "GC_SESSION=fake")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)


### PR DESCRIPTION
## Summary
- batch close session wait beads during close/wake cancellation so capped wait cleanup no longer spends tens of seconds rewriting each wait one by one
- force city runtime shutdown after supervisor unregister cancel timeout so async unregister reports success once forced teardown completes
- keep unregister integration on the fake session runtime and remove irrelevant Claude session-key delay from circuit-breaker tests

## Verification
- go test ./internal/session -run 'TestCancelWaitsAndCollectNudgeIDs|TestWakeSessionContinuesAfterWaitLookupLimit|TestWakeSessionClosesTerminalOpenWaitsAfterLookupLimit' -count=1 -v\n- GC_FAST_UNIT=1 go test -timeout 90s ./cmd/gc -run '^TestPhase0CLISessionCloseContinuesAfterWaitLookupLimit$' -count=1 -v\n- go test ./cmd/gc -run '^TestStopManagedCity(ForcesCleanupAfterTimeout|DoesNotUseStartupOrDriftTimeouts)$' -count=1 -v\n- GC_FAST_UNIT=1 go test ./cmd/gc -run '^TestReconciler_Circuit' -count=1 -v\n- go test -tags=integration ./test/integration -run '^TestHumaBinary_CityUnregisterAsync$' -count=1 -v\n- ./scripts/test-integration-shard rest-full-6-of-16\n- make test-cover\n- go vet ./...\n- git diff --check