### PR TITLE
feat: add JSON for wait inspection

### DIFF
--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -268,7 +268,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 }
 
 func cmdWaitList(stateFilter, sessionFilter string, jsonOutput bool, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc wait list")
+	store, cityPath, code := openCityStoreWithPath(stderr, "gc wait list")
 	if store == nil {
 		return code
 	}
@@ -295,8 +295,7 @@ func cmdWaitList(stateFilter, sessionFilter string, jsonOutput bool, stdout, std
 		filtered = append(filtered, item)
 	}
 	if jsonOutput {
-		cityPath, _ := resolveCity()
-		return writeWaitListJSON(stdout, cityPath, filtered)
+		return writeWaitListJSON(stdout, stderr, cityPath, filtered)
 	}
 	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "WAIT\tSESSION\tSTATE\tKIND\tNOTE") //nolint:errcheck
@@ -312,7 +311,7 @@ func cmdWaitList(stateFilter, sessionFilter string, jsonOutput bool, stdout, std
 }
 
 func cmdWaitInspect(waitID string, jsonOutput bool, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc wait inspect")
+	store, cityPath, code := openCityStoreWithPath(stderr, "gc wait inspect")
 	if store == nil {
 		return code
 	}
@@ -326,8 +325,7 @@ func cmdWaitInspect(waitID string, jsonOutput bool, stdout, stderr io.Writer) in
 		return 1
 	}
 	if jsonOutput {
-		cityPath, _ := resolveCity()
-		return writeWaitInspectJSON(stdout, cityPath, b)
+		return writeWaitInspectJSON(stdout, stderr, cityPath, b)
 	}
 	fmt.Fprintf(stdout, "Wait:       %s\n", b.ID)                                               //nolint:errcheck
 	fmt.Fprintf(stdout, "Session:    %s\n", b.Metadata["session_id"])                           //nolint:errcheck
@@ -342,32 +340,48 @@ func cmdWaitInspect(waitID string, jsonOutput bool, stdout, stderr io.Writer) in
 }
 
 type waitJSON struct {
-	ID          string            `json:"id"`
-	SessionID   string            `json:"session_id"`
-	SessionName string            `json:"session_name,omitempty"`
-	State       string            `json:"state"`
-	Kind        string            `json:"kind"`
-	DepIDs      []string          `json:"dep_ids,omitempty"`
-	DepMode     string            `json:"dep_mode,omitempty"`
-	Note        string            `json:"note,omitempty"`
-	Status      string            `json:"status"`
-	CreatedAt   string            `json:"created_at,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	ID              string   `json:"id"`
+	SessionID       string   `json:"session_id"`
+	SessionName     string   `json:"session_name,omitempty"`
+	State           string   `json:"state"`
+	Kind            string   `json:"kind"`
+	DepIDs          []string `json:"dep_ids,omitempty"`
+	DepMode         string   `json:"dep_mode,omitempty"`
+	RegisteredEpoch string   `json:"registered_epoch,omitempty"`
+	DeliveryAttempt string   `json:"delivery_attempt,omitempty"`
+	NudgeID         string   `json:"nudge_id,omitempty"`
+	Note            string   `json:"note,omitempty"`
+	Status          string   `json:"status"`
+	CreatedAt       string   `json:"created_at,omitempty"`
+}
+
+type waitListJSONEnvelope struct {
+	SchemaVersion string     `json:"schema_version"`
+	CityPath      string     `json:"city_path"`
+	Waits         []waitJSON `json:"waits"`
+}
+
+type waitInspectJSONEnvelope struct {
+	SchemaVersion string   `json:"schema_version"`
+	CityPath      string   `json:"city_path"`
+	Wait          waitJSON `json:"wait"`
 }
 
 func waitJSONFromBead(b beads.Bead) waitJSON {
 	return waitJSON{
-		ID:          b.ID,
-		SessionID:   b.Metadata["session_id"],
-		SessionName: b.Metadata["session_name"],
-		State:       b.Metadata["state"],
-		Kind:        b.Metadata["kind"],
-		DepIDs:      splitWaitIDs(b.Metadata["dep_ids"]),
-		DepMode:     b.Metadata["dep_mode"],
-		Note:        b.Description,
-		Status:      b.Status,
-		CreatedAt:   formatOptionalTime(b.CreatedAt),
-		Metadata:    cloneStringMap(b.Metadata),
+		ID:              b.ID,
+		SessionID:       b.Metadata["session_id"],
+		SessionName:     b.Metadata["session_name"],
+		State:           b.Metadata["state"],
+		Kind:            b.Metadata["kind"],
+		DepIDs:          splitWaitIDs(b.Metadata["dep_ids"]),
+		DepMode:         b.Metadata["dep_mode"],
+		RegisteredEpoch: b.Metadata["registered_epoch"],
+		DeliveryAttempt: b.Metadata["delivery_attempt"],
+		NudgeID:         b.Metadata["nudge_id"],
+		Note:            b.Description,
+		Status:          b.Status,
+		CreatedAt:       formatOptionalTime(b.CreatedAt),
 	}
 }
 
@@ -385,29 +399,31 @@ func splitWaitIDs(value string) []string {
 	return out
 }
 
-func writeWaitListJSON(stdout io.Writer, cityPath string, waits []beads.Bead) int {
+func writeWaitListJSON(stdout, stderr io.Writer, cityPath string, waits []beads.Bead) int {
 	rows := make([]waitJSON, 0, len(waits))
 	for _, wait := range waits {
 		rows = append(rows, waitJSONFromBead(wait))
 	}
-	payload := map[string]any{
-		"schema_version": "1",
-		"city_path":      cityPath,
-		"waits":          rows,
+	payload := waitListJSONEnvelope{
+		SchemaVersion: "1",
+		CityPath:      cityPath,
+		Waits:         rows,
 	}
 	if err := writeCLIJSONLine(stdout, payload); err != nil {
+		fmt.Fprintf(stderr, "gc wait list: encode JSON: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	return 0
 }
 
-func writeWaitInspectJSON(stdout io.Writer, cityPath string, wait beads.Bead) int {
-	payload := map[string]any{
-		"schema_version": "1",
-		"city_path":      cityPath,
-		"wait":           waitJSONFromBead(wait),
+func writeWaitInspectJSON(stdout, stderr io.Writer, cityPath string, wait beads.Bead) int {
+	payload := waitInspectJSONEnvelope{
+		SchemaVersion: "1",
+		CityPath:      cityPath,
+		Wait:          waitJSONFromBead(wait),
 	}
 	if err := writeCLIJSONLine(stdout, payload); err != nil {
+		fmt.Fprintf(stderr, "gc wait inspect: encode JSON: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	return 0

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -75,11 +75,12 @@ func newSessionWaitCmd(stdout, stderr io.Writer) *cobra.Command {
 func newWaitListCmd(stdout, stderr io.Writer) *cobra.Command {
 	var stateFilter string
 	var sessionFilter string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List durable waits",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdWaitList(stateFilter, sessionFilter, stdout, stderr) != 0 {
+			if cmdWaitList(stateFilter, sessionFilter, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -87,21 +88,25 @@ func newWaitListCmd(stdout, stderr io.Writer) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&stateFilter, "state", "", "filter by wait state")
 	cmd.Flags().StringVar(&sessionFilter, "session", "", "filter by session ID")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
 	return cmd
 }
 
 func newWaitInspectCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "inspect <wait-id>",
 		Short: "Show details for a wait",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdWaitInspect(args[0], stdout, stderr) != 0 {
+			if cmdWaitInspect(args[0], jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
+	return cmd
 }
 
 func newWaitCancelCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -262,7 +267,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 	return 0
 }
 
-func cmdWaitList(stateFilter, sessionFilter string, stdout, stderr io.Writer) int {
+func cmdWaitList(stateFilter, sessionFilter string, jsonOutput bool, stdout, stderr io.Writer) int {
 	store, code := openCityStore(stderr, "gc wait list")
 	if store == nil {
 		return code
@@ -282,12 +287,20 @@ func cmdWaitList(stateFilter, sessionFilter string, stdout, stderr io.Writer) in
 		fmt.Fprintf(stderr, "gc wait list: %v; showing capped results\n", err) //nolint:errcheck
 	}
 	sort.SliceStable(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
-	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "WAIT\tSESSION\tSTATE\tKIND\tNOTE") //nolint:errcheck
+	filtered := make([]beads.Bead, 0, len(items))
 	for _, item := range items {
 		if stateFilter != "" && item.Metadata["state"] != stateFilter {
 			continue
 		}
+		filtered = append(filtered, item)
+	}
+	if jsonOutput {
+		cityPath, _ := resolveCity()
+		return writeWaitListJSON(stdout, cityPath, filtered)
+	}
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "WAIT\tSESSION\tSTATE\tKIND\tNOTE") //nolint:errcheck
+	for _, item := range filtered {
 		note := item.Description
 		if note == "" {
 			note = "-"
@@ -298,7 +311,7 @@ func cmdWaitList(stateFilter, sessionFilter string, stdout, stderr io.Writer) in
 	return 0
 }
 
-func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
+func cmdWaitInspect(waitID string, jsonOutput bool, stdout, stderr io.Writer) int {
 	store, code := openCityStore(stderr, "gc wait inspect")
 	if store == nil {
 		return code
@@ -312,6 +325,10 @@ func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc wait inspect: %s is not a wait\n", waitID) //nolint:errcheck
 		return 1
 	}
+	if jsonOutput {
+		cityPath, _ := resolveCity()
+		return writeWaitInspectJSON(stdout, cityPath, b)
+	}
 	fmt.Fprintf(stdout, "Wait:       %s\n", b.ID)                                               //nolint:errcheck
 	fmt.Fprintf(stdout, "Session:    %s\n", b.Metadata["session_id"])                           //nolint:errcheck
 	fmt.Fprintf(stdout, "State:      %s\n", b.Metadata["state"])                                //nolint:errcheck
@@ -321,6 +338,78 @@ func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "Attempt:    %s\n", b.Metadata["delivery_attempt"])                     //nolint:errcheck
 	fmt.Fprintf(stdout, "Nudge:      %s\n", b.Metadata["nudge_id"])                             //nolint:errcheck
 	fmt.Fprintf(stdout, "Note:       %s\n", b.Description)                                      //nolint:errcheck
+	return 0
+}
+
+type waitJSON struct {
+	ID          string            `json:"id"`
+	SessionID   string            `json:"session_id"`
+	SessionName string            `json:"session_name,omitempty"`
+	State       string            `json:"state"`
+	Kind        string            `json:"kind"`
+	DepIDs      []string          `json:"dep_ids,omitempty"`
+	DepMode     string            `json:"dep_mode,omitempty"`
+	Note        string            `json:"note,omitempty"`
+	Status      string            `json:"status"`
+	CreatedAt   string            `json:"created_at,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+func waitJSONFromBead(b beads.Bead) waitJSON {
+	return waitJSON{
+		ID:          b.ID,
+		SessionID:   b.Metadata["session_id"],
+		SessionName: b.Metadata["session_name"],
+		State:       b.Metadata["state"],
+		Kind:        b.Metadata["kind"],
+		DepIDs:      splitWaitIDs(b.Metadata["dep_ids"]),
+		DepMode:     b.Metadata["dep_mode"],
+		Note:        b.Description,
+		Status:      b.Status,
+		CreatedAt:   formatOptionalTime(b.CreatedAt),
+		Metadata:    cloneStringMap(b.Metadata),
+	}
+}
+
+func splitWaitIDs(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func writeWaitListJSON(stdout io.Writer, cityPath string, waits []beads.Bead) int {
+	rows := make([]waitJSON, 0, len(waits))
+	for _, wait := range waits {
+		rows = append(rows, waitJSONFromBead(wait))
+	}
+	payload := map[string]any{
+		"schema_version": "1",
+		"city_path":      cityPath,
+		"waits":          rows,
+	}
+	if err := writeCLIJSONLine(stdout, payload); err != nil {
+		return 1
+	}
+	return 0
+}
+
+func writeWaitInspectJSON(stdout io.Writer, cityPath string, wait beads.Bead) int {
+	payload := map[string]any{
+		"schema_version": "1",
+		"city_path":      cityPath,
+		"wait":           waitJSONFromBead(wait),
+	}
+	if err := writeCLIJSONLine(stdout, payload); err != nil {
+		return 1
+	}
 	return 0
 }
 

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -64,6 +65,115 @@ func setWaitTestFileBeads(t *testing.T) {
 	t.Helper()
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+}
+
+func TestWaitListJSON(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeCityToml(t, cityDir, "[workspace]\nname = \"wait-json\"\n")
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	wait := createTestWaitBead(t, store)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWaitList("", "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWaitList(--json) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		CityPath      string `json:"city_path"`
+		Waits         []struct {
+			ID        string   `json:"id"`
+			SessionID string   `json:"session_id"`
+			State     string   `json:"state"`
+			DepIDs    []string `json:"dep_ids"`
+		} `json:"waits"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || payload.CityPath != cityDir || len(payload.Waits) != 1 {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if got := payload.Waits[0]; got.ID != wait.ID || got.SessionID != "session-1" || got.State != waitStatePending || len(got.DepIDs) != 2 {
+		t.Fatalf("wait row = %+v, source=%+v", got, wait)
+	}
+}
+
+func TestWaitInspectJSON(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeCityToml(t, cityDir, "[workspace]\nname = \"wait-json\"\n")
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	wait := createTestWaitBead(t, store)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWaitInspect(wait.ID, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWaitInspect(--json) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		Wait          struct {
+			ID       string            `json:"id"`
+			Kind     string            `json:"kind"`
+			Note     string            `json:"note"`
+			Metadata map[string]string `json:"metadata"`
+		} `json:"wait"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || payload.Wait.ID != wait.ID || payload.Wait.Kind != "deps" || payload.Wait.Note != "wait for deps" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.Wait.Metadata["dep_mode"] != "all" {
+		t.Fatalf("metadata = %+v", payload.Wait.Metadata)
+	}
+}
+
+func createTestWaitBead(t *testing.T, store beads.Store) beads.Bead {
+	t.Helper()
+	wait, err := store.Create(beads.Bead{
+		Title:       "wait:demo",
+		Type:        waitBeadType,
+		Status:      "open",
+		Description: "wait for deps",
+		Labels:      []string{waitBeadLabel, "session:session-1"},
+		Metadata: map[string]string{
+			"session_id":       "session-1",
+			"session_name":     "demo",
+			"kind":             "deps",
+			"state":            waitStatePending,
+			"dep_ids":          "bead-1,bead-2",
+			"dep_mode":         "all",
+			"registered_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(wait): %v", err)
+	}
+	return wait
 }
 
 func (s waitNudgeMetadataFailStore) SetMetadata(id, key, value string) error {
@@ -292,7 +402,7 @@ provider = "file"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdWaitList("", "target-session", &stdout, &stderr)
+	code := cmdWaitList("", "target-session", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdWaitList = %d, want 0; stderr=%s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -68,17 +68,7 @@ func setWaitTestFileBeads(t *testing.T) {
 }
 
 func TestWaitListJSON(t *testing.T) {
-	clearGCEnv(t)
-	t.Setenv("GC_BEADS", "file")
-
-	cityDir := t.TempDir()
-	t.Setenv("GC_CITY", cityDir)
-	writeCityToml(t, cityDir, "[workspace]\nname = \"wait-json\"\n")
-
-	store, err := openCityStoreAt(cityDir)
-	if err != nil {
-		t.Fatalf("openCityStoreAt: %v", err)
-	}
+	cityDir, store := setupWaitJSONTestCity(t)
 	wait := createTestWaitBead(t, store)
 
 	var stdout, stderr bytes.Buffer
@@ -93,10 +83,12 @@ func TestWaitListJSON(t *testing.T) {
 		SchemaVersion string `json:"schema_version"`
 		CityPath      string `json:"city_path"`
 		Waits         []struct {
-			ID        string   `json:"id"`
-			SessionID string   `json:"session_id"`
-			State     string   `json:"state"`
-			DepIDs    []string `json:"dep_ids"`
+			ID              string            `json:"id"`
+			SessionID       string            `json:"session_id"`
+			State           string            `json:"state"`
+			DepIDs          []string          `json:"dep_ids"`
+			RegisteredEpoch string            `json:"registered_epoch"`
+			Metadata        map[string]string `json:"metadata"`
 		} `json:"waits"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
@@ -108,20 +100,16 @@ func TestWaitListJSON(t *testing.T) {
 	if got := payload.Waits[0]; got.ID != wait.ID || got.SessionID != "session-1" || got.State != waitStatePending || len(got.DepIDs) != 2 {
 		t.Fatalf("wait row = %+v, source=%+v", got, wait)
 	}
+	if got := payload.Waits[0].RegisteredEpoch; got != "1" {
+		t.Fatalf("registered_epoch = %q, want 1", got)
+	}
+	if payload.Waits[0].Metadata != nil {
+		t.Fatalf("metadata = %+v, want omitted", payload.Waits[0].Metadata)
+	}
 }
 
 func TestWaitInspectJSON(t *testing.T) {
-	clearGCEnv(t)
-	t.Setenv("GC_BEADS", "file")
-
-	cityDir := t.TempDir()
-	t.Setenv("GC_CITY", cityDir)
-	writeCityToml(t, cityDir, "[workspace]\nname = \"wait-json\"\n")
-
-	store, err := openCityStoreAt(cityDir)
-	if err != nil {
-		t.Fatalf("openCityStoreAt: %v", err)
-	}
+	_, store := setupWaitJSONTestCity(t)
 	wait := createTestWaitBead(t, store)
 
 	var stdout, stderr bytes.Buffer
@@ -135,10 +123,12 @@ func TestWaitInspectJSON(t *testing.T) {
 	var payload struct {
 		SchemaVersion string `json:"schema_version"`
 		Wait          struct {
-			ID       string            `json:"id"`
-			Kind     string            `json:"kind"`
-			Note     string            `json:"note"`
-			Metadata map[string]string `json:"metadata"`
+			ID              string            `json:"id"`
+			Kind            string            `json:"kind"`
+			Note            string            `json:"note"`
+			DepMode         string            `json:"dep_mode"`
+			RegisteredEpoch string            `json:"registered_epoch"`
+			Metadata        map[string]string `json:"metadata"`
 		} `json:"wait"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
@@ -147,33 +137,216 @@ func TestWaitInspectJSON(t *testing.T) {
 	if payload.SchemaVersion != "1" || payload.Wait.ID != wait.ID || payload.Wait.Kind != "deps" || payload.Wait.Note != "wait for deps" {
 		t.Fatalf("payload = %+v", payload)
 	}
-	if payload.Wait.Metadata["dep_mode"] != "all" {
-		t.Fatalf("metadata = %+v", payload.Wait.Metadata)
+	if payload.Wait.DepMode != "all" || payload.Wait.RegisteredEpoch != "1" {
+		t.Fatalf("wait = %+v", payload.Wait)
+	}
+	if payload.Wait.Metadata != nil {
+		t.Fatalf("metadata = %+v, want omitted", payload.Wait.Metadata)
 	}
 }
 
+func TestWaitListJSONFiltersState(t *testing.T) {
+	_, store := setupWaitJSONTestCity(t)
+	pending := createTestWaitBead(t, store)
+	ready := createTestWaitBeadForSession(t, store, "session-2", waitStateReady)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWaitList(waitStatePending, "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWaitList(--json --state pending) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	payload := decodeWaitListJSON(t, stdout.Bytes())
+	if len(payload.Waits) != 1 || payload.Waits[0].ID != pending.ID {
+		t.Fatalf("waits = %+v, want only %s; filtered ready=%s", payload.Waits, pending.ID, ready.ID)
+	}
+}
+
+func TestWaitListJSONFiltersSessionWithSessionScopedLookup(t *testing.T) {
+	_, store := setupWaitJSONTestCity(t)
+	targetWait := createTestWaitBeadForSession(t, store, "target-session", waitStatePending)
+	for i := 0; i < waitLookupLimit; i++ {
+		createTestWaitBeadForSession(t, store, "other-session", waitStatePending)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWaitList("", "target-session", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWaitList(--json --session target-session) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	payload := decodeWaitListJSON(t, stdout.Bytes())
+	if len(payload.Waits) != 1 || payload.Waits[0].ID != targetWait.ID || payload.Waits[0].SessionID != "target-session" {
+		t.Fatalf("waits = %+v, want only target %s", payload.Waits, targetWait.ID)
+	}
+}
+
+func TestWaitListJSONEmptyListUsesArray(t *testing.T) {
+	_, _ = setupWaitJSONTestCity(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWaitList("", "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWaitList(--json empty) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	payload := decodeWaitListJSON(t, stdout.Bytes())
+	if payload.Waits == nil {
+		t.Fatalf("waits decoded as nil; stdout=%s", stdout.String())
+	}
+	if len(payload.Waits) != 0 {
+		t.Fatalf("waits = %+v, want empty", payload.Waits)
+	}
+}
+
+func TestWaitInspectJSONFailuresUseCommandFailureEnvelope(t *testing.T) {
+	cases := []struct {
+		name       string
+		waitID     func(t *testing.T, store beads.Store) string
+		stderrWant string
+	}{
+		{
+			name:       "missing",
+			waitID:     func(_ *testing.T, _ beads.Store) string { return "missing-wait" },
+			stderrWant: "gc wait inspect:",
+		},
+		{
+			name: "non_wait",
+			waitID: func(t *testing.T, store beads.Store) string {
+				t.Helper()
+				b, err := store.Create(beads.Bead{Title: "not a wait", Type: "task"})
+				if err != nil {
+					t.Fatalf("Create(non-wait): %v", err)
+				}
+				return b.ID
+			},
+			stderrWant: "is not a wait",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, store := setupWaitJSONTestCity(t)
+			waitID := tt.waitID(t, store)
+
+			var stdout, stderr bytes.Buffer
+			code := run([]string{"wait", "inspect", waitID, "--json"}, &stdout, &stderr)
+			if code == 0 {
+				t.Fatalf("run(wait inspect %s --json) = 0, want failure; stdout=%q stderr=%q", waitID, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tt.stderrWant) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tt.stderrWant)
+			}
+			var failure jsonSchemaErrorPayload
+			if err := json.Unmarshal(stdout.Bytes(), &failure); err != nil {
+				t.Fatalf("stdout is not JSON failure: %v\n%s", err, stdout.String())
+			}
+			if failure.OK || failure.Error.Code != "command_failed" || failure.Error.ExitCode != code {
+				t.Fatalf("failure = %+v, exit code %d", failure, code)
+			}
+		})
+	}
+}
+
+func TestWaitJSONEncoderErrorsWriteDiagnostics(t *testing.T) {
+	var stderr bytes.Buffer
+	if code := writeWaitListJSON(failingWriter{}, &stderr, "/city", nil); code != 1 {
+		t.Fatalf("writeWaitListJSON = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "gc wait list: encode JSON: write failed") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+
+	stderr.Reset()
+	if code := writeWaitInspectJSON(failingWriter{}, &stderr, "/city", beads.Bead{}); code != 1 {
+		t.Fatalf("writeWaitInspectJSON = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "gc wait inspect: encode JSON: write failed") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestWaitJSONSchemasDoNotExposeRawMetadata(t *testing.T) {
+	for _, path := range []string{
+		filepath.Join("..", "..", "schemas", "wait", "list", "result.schema.json"),
+		filepath.Join("..", "..", "schemas", "wait", "inspect", "result.schema.json"),
+	} {
+		t.Run(path, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile(%s): %v", path, err)
+			}
+			if bytes.Contains(data, []byte(`"metadata"`)) {
+				t.Fatalf("%s exposes raw metadata:\n%s", path, string(data))
+			}
+		})
+	}
+}
+
+type waitListJSONTestPayload struct {
+	Waits []struct {
+		ID        string `json:"id"`
+		SessionID string `json:"session_id"`
+		State     string `json:"state"`
+	} `json:"waits"`
+}
+
+func setupWaitJSONTestCity(t *testing.T) (string, beads.Store) {
+	t.Helper()
+	clearGCEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeCityToml(t, cityDir, "[workspace]\nname = \"wait-json\"\n")
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	return cityDir, store
+}
+
+func decodeWaitListJSON(t *testing.T, data []byte) waitListJSONTestPayload {
+	t.Helper()
+	var payload waitListJSONTestPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, string(data))
+	}
+	return payload
+}
+
 func createTestWaitBead(t *testing.T, store beads.Store) beads.Bead {
+	t.Helper()
+	return createTestWaitBeadForSession(t, store, "session-1", waitStatePending)
+}
+
+func createTestWaitBeadForSession(t *testing.T, store beads.Store, sessionID, state string) beads.Bead {
 	t.Helper()
 	wait, err := store.Create(beads.Bead{
 		Title:       "wait:demo",
 		Type:        waitBeadType,
 		Status:      "open",
 		Description: "wait for deps",
-		Labels:      []string{waitBeadLabel, "session:session-1"},
+		Labels:      []string{waitBeadLabel, "session:" + sessionID},
 		Metadata: map[string]string{
-			"session_id":       "session-1",
+			"session_id":       sessionID,
 			"session_name":     "demo",
 			"kind":             "deps",
-			"state":            waitStatePending,
+			"state":            state,
 			"dep_ids":          "bead-1,bead-2",
 			"dep_mode":         "all",
 			"registered_epoch": "1",
+			"delivery_attempt": "1",
+			"nudge_id":         "nudge-1",
 		},
 	})
 	if err != nil {
 		t.Fatalf("store.Create(wait): %v", err)
 	}
 	return wait
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
 }
 
 func (s waitNudgeMetadataFailStore) SetMetadata(id, key, value string) error {

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -851,18 +851,25 @@ func eventActor() string {
 // Store using the configured provider. On error it writes to stderr and returns
 // nil plus an exit code.
 func openCityStore(stderr io.Writer, cmdName string) (beads.Store, int) {
+	store, _, code := openCityStoreWithPath(stderr, cmdName)
+	return store, code
+}
+
+// openCityStoreWithPath locates the city root and opens its Store, returning
+// the resolved city path used for the store.
+func openCityStoreWithPath(stderr io.Writer, cmdName string) (beads.Store, string, int) {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
-		return nil, 1
+		return nil, "", 1
 	}
 	store, err := openCityStoreAt(cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
-		return nil, 1
+		return nil, "", 1
 	}
-	return store, 0
+	return store, cityPath, 0
 }
 
 // openCityStoreAt opens a bead store at the given city path.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3158,8 +3158,12 @@ gc wait cancel <wait-id>
 Show details for a wait
 
 ```
-gc wait inspect <wait-id>
+gc wait inspect <wait-id> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | emit JSON |
 
 ## gc wait list
 
@@ -3171,6 +3175,7 @@ gc wait list [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--json` | bool |  | emit JSON |
 | `--session` | string |  | filter by session ID |
 | `--state` | string |  | filter by wait state |
 

--- a/schemas/wait/inspect/result.schema.json
+++ b/schemas/wait/inspect/result.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "wait"],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "city_path": {
+      "type": "string"
+    },
+    "wait": {
+      "type": "object",
+      "required": ["id", "session_id", "state", "kind", "status"],
+      "properties": {
+        "id": { "type": "string" },
+        "session_id": { "type": "string" },
+        "session_name": { "type": "string" },
+        "state": { "type": "string" },
+        "kind": { "type": "string" },
+        "dep_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "dep_mode": { "type": "string" },
+        "note": { "type": "string" },
+        "status": { "type": "string" },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/wait/inspect/result.schema.json
+++ b/schemas/wait/inspect/result.schema.json
@@ -23,15 +23,14 @@
           "items": { "type": "string" }
         },
         "dep_mode": { "type": "string" },
+        "registered_epoch": { "type": "string" },
+        "delivery_attempt": { "type": "string" },
+        "nudge_id": { "type": "string" },
         "note": { "type": "string" },
         "status": { "type": "string" },
         "created_at": {
           "type": "string",
           "format": "date-time"
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": { "type": "string" }
         }
       },
       "additionalProperties": true

--- a/schemas/wait/list/result.schema.json
+++ b/schemas/wait/list/result.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "waits"],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "city_path": {
+      "type": "string"
+    },
+    "waits": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/wait"
+      }
+    }
+  },
+  "$defs": {
+    "wait": {
+      "type": "object",
+      "required": ["id", "session_id", "state", "kind", "status"],
+      "properties": {
+        "id": { "type": "string" },
+        "session_id": { "type": "string" },
+        "session_name": { "type": "string" },
+        "state": { "type": "string" },
+        "kind": { "type": "string" },
+        "dep_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "dep_mode": { "type": "string" },
+        "note": { "type": "string" },
+        "status": { "type": "string" },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/wait/list/result.schema.json
+++ b/schemas/wait/list/result.schema.json
@@ -31,15 +31,14 @@
           "items": { "type": "string" }
         },
         "dep_mode": { "type": "string" },
+        "registered_epoch": { "type": "string" },
+        "delivery_attempt": { "type": "string" },
+        "nudge_id": { "type": "string" },
         "note": { "type": "string" },
         "status": { "type": "string" },
         "created_at": {
           "type": "string",
           "format": "date-time"
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": { "type": "string" }
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
## Summary
- adds `gc wait list --json` and `gc wait inspect <wait-id> --json`
- declares result schemas for `wait/list` and `wait/inspect`
- adds focused tests for parseable JSON stdout with empty stderr on successful JSON output

## JSON compatibility
- These commands did not previously expose native `--json` output, so this PR adds new machine-readable surfaces without changing an existing JSON contract.
- Human-readable output remains the default and is preserved.

## Validation
- `go test ./cmd/gc -run 'TestWaitListJSON|TestWaitInspectJSON|TestJSONSchema'`\n- `git diff --check`\n- `go run ./cmd/gc --city /Users/dbox/repos/gc/gc4gc wait list --json` parsed with `jq`\n- `go run ./cmd/gc --city /Users/dbox/repos/gc/gc4gc wait list --json-schema=result` parsed with `jq`\n\nStacked on #2222 (`codex/json-schema-platform`).