### PR TITLE
feat: add JSON for service and skill inspection

### DIFF
--- a/cmd/gc/cmd_service.go
+++ b/cmd/gc/cmd_service.go
@@ -42,33 +42,39 @@ func newServiceCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func newServiceListCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List workspace services",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdServiceList(stdout, stderr) != 0 {
+			if cmdServiceList(jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
+	return cmd
 }
 
 func newServiceDoctorCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "doctor <name>",
 		Short: "Show detailed workspace service status",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdServiceDoctor(args[0], stdout, stderr) != 0 {
+			if cmdServiceDoctor(args[0], jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
+	return cmd
 }
 
-func cmdServiceList(stdout, stderr io.Writer) int {
+func cmdServiceList(jsonOutput bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc service list: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -79,10 +85,10 @@ func cmdServiceList(stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc service list: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	return doServiceList(cfg, serviceReadClient(cityPath, cfg), stdout, stderr)
+	return doServiceList(cityPath, cfg, serviceReadClient(cityPath, cfg), jsonOutput, stdout, stderr)
 }
 
-func cmdServiceDoctor(name string, stdout, stderr io.Writer) int {
+func cmdServiceDoctor(name string, jsonOutput bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc service doctor: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -93,7 +99,7 @@ func cmdServiceDoctor(name string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc service doctor: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	return doServiceDoctor(cfg, serviceReadClient(cityPath, cfg), name, stdout, stderr)
+	return doServiceDoctor(cityPath, cfg, serviceReadClient(cityPath, cfg), name, jsonOutput, stdout, stderr)
 }
 
 func newServiceRestartCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -156,9 +162,9 @@ func serviceRestartClient(cityPath string, cfg *config.City) *api.Client {
 	return nil
 }
 
-func doServiceList(cfg *config.City, reader serviceStatusReader, stdout, stderr io.Writer) int {
+func doServiceList(cityPath string, cfg *config.City, reader serviceStatusReader, jsonOutput bool, stdout, stderr io.Writer) int {
 	statuses, live := serviceStatuses(cfg, reader, stderr)
-	if len(statuses) == 0 {
+	if len(statuses) == 0 && !jsonOutput {
 		fmt.Fprintln(stdout, "No services configured.") //nolint:errcheck // best-effort stdout
 		return 0
 	}
@@ -166,6 +172,19 @@ func doServiceList(cfg *config.City, reader serviceStatusReader, stdout, stderr 
 	sort.Slice(statuses, func(i, j int) bool {
 		return statuses[i].ServiceName < statuses[j].ServiceName
 	})
+
+	if jsonOutput {
+		payload := map[string]any{
+			"schema_version": "1",
+			"city_path":      cityPath,
+			"live":           live,
+			"services":       statuses,
+		}
+		if err := writeCLIJSONLine(stdout, payload); err != nil {
+			return 1
+		}
+		return 0
+	}
 
 	fmt.Fprintf(stdout, "%-18s %-13s %-10s %-10s %-12s %s\n", "NAME", "KIND", "SERVICE", "LOCAL", "PUBLISH", "URL") //nolint:errcheck
 	for _, status := range statuses {
@@ -191,7 +210,7 @@ func doServiceList(cfg *config.City, reader serviceStatusReader, stdout, stderr 
 	return 0
 }
 
-func doServiceDoctor(cfg *config.City, reader serviceStatusReader, name string, stdout, stderr io.Writer) int {
+func doServiceDoctor(cityPath string, cfg *config.City, reader serviceStatusReader, name string, jsonOutput bool, stdout, stderr io.Writer) int {
 	svc, ok := lookupService(cfg, name)
 	if !ok {
 		fmt.Fprintf(stderr, "gc service doctor: service %q not found\n", name) //nolint:errcheck // best-effort stderr
@@ -208,6 +227,22 @@ func doServiceDoctor(cfg *config.City, reader serviceStatusReader, name string, 
 		} else {
 			fmt.Fprintf(stderr, "gc service doctor: warning: %v (showing config view)\n", err) //nolint:errcheck // best-effort stderr
 		}
+	}
+
+	if jsonOutput {
+		payload := map[string]any{
+			"schema_version": "1",
+			"city_path":      cityPath,
+			"live":           live,
+			"service":        status,
+		}
+		if !live {
+			payload["observed_state"] = "controller_unavailable"
+		}
+		if err := writeCLIJSONLine(stdout, payload); err != nil {
+			return 1
+		}
+		return 0
 	}
 
 	fmt.Fprintf(stdout, "Name:              %s\n", status.ServiceName) //nolint:errcheck

--- a/cmd/gc/cmd_service_test.go
+++ b/cmd/gc/cmd_service_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -55,7 +56,7 @@ func TestDoServiceListUsesLiveStatuses(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := doServiceList(cfg, reader, &stdout, &stderr); code != 0 {
+	if code := doServiceList("", cfg, reader, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
 	out := stdout.String()
@@ -74,7 +75,7 @@ func TestDoServiceDoctorFallsBackToConfigView(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := doServiceDoctor(cfg, nil, "review-intake", &stdout, &stderr); code != 0 {
+	if code := doServiceDoctor("", cfg, nil, "review-intake", false, &stdout, &stderr); code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
 	out := stdout.String()
@@ -88,11 +89,92 @@ func TestDoServiceDoctorFallsBackToConfigView(t *testing.T) {
 
 func TestDoServiceDoctorMissingService(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := doServiceDoctor(&config.City{}, nil, "missing", &stdout, &stderr)
+	code := doServiceDoctor("", &config.City{}, nil, "missing", false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), `service "missing" not found`) {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestDoServiceListJSON(t *testing.T) {
+	cfg := &config.City{
+		Services: []config.Service{{
+			Name:     "healthz",
+			Workflow: config.ServiceWorkflowConfig{Contract: "gc.healthz.v1"},
+		}},
+	}
+	reader := fakeServiceReader{
+		items: []workspacesvc.Status{{
+			ServiceName: "healthz",
+			Kind:        "workflow",
+			MountPath:   "/svc/healthz",
+			State:       "ready",
+			LocalState:  "ready",
+		}},
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doServiceList("/tmp/city", cfg, reader, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		CityPath      string `json:"city_path"`
+		Live          bool   `json:"live"`
+		Services      []struct {
+			ServiceName string `json:"service_name"`
+			State       string `json:"state"`
+		} `json:"services"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || payload.CityPath != "/tmp/city" || !payload.Live || len(payload.Services) != 1 {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.Services[0].ServiceName != "healthz" || payload.Services[0].State != "ready" {
+		t.Fatalf("service = %+v", payload.Services[0])
+	}
+}
+
+func TestDoServiceDoctorJSON(t *testing.T) {
+	cfg := &config.City{
+		Services: []config.Service{{
+			Name:     "review-intake",
+			Workflow: config.ServiceWorkflowConfig{Contract: "pack.gc/review.v1"},
+		}},
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doServiceDoctor("/tmp/city", cfg, nil, "review-intake", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		Live          bool   `json:"live"`
+		ObservedState string `json:"observed_state"`
+		Service       struct {
+			ServiceName      string `json:"service_name"`
+			WorkflowContract string `json:"workflow_contract"`
+		} `json:"service"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || payload.Live || payload.ObservedState != "controller_unavailable" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if payload.Service.ServiceName != "review-intake" || payload.Service.WorkflowContract != "pack.gc/review.v1" {
+		t.Fatalf("service = %+v", payload.Service)
 	}
 }

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -50,6 +50,7 @@ name collision. For the materialized set, inspect the
 func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 	var agentName string
 	var sessionID string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List visible skills",
@@ -85,12 +86,26 @@ func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 				fmt.Fprintf(stderr, "gc skill list: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
+			if jsonOutput {
+				payload := map[string]any{
+					"schema_version": "1",
+					"city_path":      cityPath,
+					"agent":          strings.TrimSpace(agentName),
+					"session_id":     strings.TrimSpace(sessionID),
+					"skills":         entries,
+				}
+				if err := writeCLIJSONLine(stdout, payload); err != nil {
+					return errExit
+				}
+				return nil
+			}
 			writeVisibilityEntries(stdout, entries)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&agentName, "agent", "", "show the effective skill view for this agent")
 	cmd.Flags().StringVar(&sessionID, "session", "", "show the effective skill view for this session")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
 	return cmd
 }
 
@@ -149,9 +164,9 @@ func discoverBootstrapSkillEntries() []visibilityEntry {
 }
 
 type visibilityEntry struct {
-	Name   string
-	Source string
-	Path   string
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Path   string `json:"path"`
 }
 
 func resolveVisibilityAgent(cityPath string, cfg *config.City, store beads.Store, agentName, sessionID string) (*config.Agent, error) {

--- a/cmd/gc/cmd_skill_test.go
+++ b/cmd/gc/cmd_skill_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +41,49 @@ func TestSkillListCityCatalog(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("skill list output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestSkillListJSON(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+	writeCatalogFile(t, cityDir, "skills/code-review/SKILL.md", "city skill")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"skill", "list", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc skill list --json exited %d: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		CityPath      string `json:"city_path"`
+		Skills        []struct {
+			Name   string `json:"name"`
+			Source string `json:"source"`
+			Path   string `json:"path"`
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || payload.CityPath != cityDir || len(payload.Skills) == 0 {
+		t.Fatalf("payload = %+v", payload)
+	}
+	found := false
+	for _, got := range payload.Skills {
+		if got.Name == "code-review" && got.Source == "city" && got.Path == "skills/code-review/SKILL.md" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("city skill missing from %+v", payload.Skills)
 	}
 }
 

--- a/schemas/service/doctor/result.schema.json
+++ b/schemas/service/doctor/result.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "live", "service"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "live": { "type": "boolean" },
+    "observed_state": { "type": "string" },
+    "service": { "$ref": "#/$defs/service" }
+  },
+  "$defs": {
+    "service": {
+      "type": "object",
+      "required": ["service_name", "kind", "mount_path", "publish_mode", "state_root", "local_state", "publication_state"],
+      "properties": {
+        "service_name": { "type": "string" },
+        "kind": { "type": "string" },
+        "workflow_contract": { "type": "string" },
+        "mount_path": { "type": "string" },
+        "publish_mode": { "type": "string" },
+        "visibility": { "type": "string" },
+        "hostname": { "type": "string" },
+        "state_root": { "type": "string" },
+        "url": { "type": "string" },
+        "state": { "type": "string" },
+        "local_state": { "type": "string" },
+        "publication_state": { "type": "string" },
+        "reason": { "type": "string" },
+        "allow_websockets": { "type": "boolean" },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/service/list/result.schema.json
+++ b/schemas/service/list/result.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "live", "services"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "live": { "type": "boolean" },
+    "services": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/service" }
+    }
+  },
+  "$defs": {
+    "service": {
+      "type": "object",
+      "required": ["service_name", "kind", "mount_path", "publish_mode", "state_root", "local_state", "publication_state"],
+      "properties": {
+        "service_name": { "type": "string" },
+        "kind": { "type": "string" },
+        "workflow_contract": { "type": "string" },
+        "mount_path": { "type": "string" },
+        "publish_mode": { "type": "string" },
+        "visibility": { "type": "string" },
+        "hostname": { "type": "string" },
+        "state_root": { "type": "string" },
+        "url": { "type": "string" },
+        "state": { "type": "string" },
+        "local_state": { "type": "string" },
+        "publication_state": { "type": "string" },
+        "reason": { "type": "string" },
+        "allow_websockets": { "type": "boolean" },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/skill/list/result.schema.json
+++ b/schemas/skill/list/result.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "skills"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "city_path": { "type": "string" },
+    "agent": { "type": "string" },
+    "session_id": { "type": "string" },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "source", "path"],
+        "properties": {
+          "name": { "type": "string" },
+          "source": { "type": "string" },
+          "path": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- adds `gc service list --json` and `gc service doctor <name> --json`
- adds `gc skill list --json`
- declares result schemas for service and skill inspection commands
- adds focused tests for parseable JSON stdout with empty stderr on successful JSON output

## JSON compatibility
- These commands did not previously expose native `--json` output, so this PR adds new machine-readable surfaces without changing an existing JSON contract.
- Human-readable output remains the default and is preserved.
- I intentionally did not add JSON to the current `gc pack`/`gc import` commands because that surface is being superseded by the new `gc pack` design.

## Validation
- `go test ./cmd/gc -run 'TestSkillListJSON|TestDoServiceListJSON|TestDoServiceDoctorJSON|TestJSONSchema'`\n- `git diff --check`\n- `make fmt-check`\n- `make vet`\n- `make check-docs`\n\nNote: local `GOOS=linux make lint` was attempted twice but the local golangci-lint lock was held by another process; CI should run lint normally.\n\nStacked on #2222 (`codex/json-schema-platform`).
