### PR TITLE
feat: add JSON for convoy inspection

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -235,7 +235,8 @@ func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath str
 }
 
 func newConvoyListCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List open convoys with progress",
 		Long: `List all open convoys with completion progress.
@@ -244,21 +245,23 @@ Shows each convoy's ID, title, and the number of closed vs total
 child issues.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdConvoyList(stdout, stderr) != 0 {
+			if cmdConvoyList(jsonOut, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 // cmdConvoyList is the CLI entry point for listing convoys.
-func cmdConvoyList(stdout, stderr io.Writer) int {
+func cmdConvoyList(jsonOut bool, stdout, stderr io.Writer) int {
 	stores, code := openAllConvoyStores(stderr, "gc convoy list")
 	if stores == nil {
 		return code
 	}
-	return doConvoyListAcrossStores(stores, stdout, stderr)
+	return doConvoyListAcrossStores(stores, jsonOut, stdout, stderr)
 }
 
 func convoyStoreCandidates(cfg *config.City, cityPath, beadID string) []string {
@@ -397,6 +400,62 @@ type convoyWithStore struct {
 	bead  beads.Bead
 }
 
+type convoyProgressJSON struct {
+	Closed int `json:"closed"`
+	Total  int `json:"total"`
+}
+
+type convoyFieldsJSON struct {
+	Owner  string `json:"owner,omitempty"`
+	Notify string `json:"notify,omitempty"`
+	Merge  string `json:"merge,omitempty"`
+	Target string `json:"target,omitempty"`
+}
+
+type convoySummaryJSON struct {
+	ID       string             `json:"id"`
+	Title    string             `json:"title"`
+	Status   string             `json:"status"`
+	Progress convoyProgressJSON `json:"progress"`
+	Owned    bool               `json:"owned"`
+	Fields   convoyFieldsJSON   `json:"fields,omitempty"`
+	ChildIDs []string           `json:"child_ids,omitempty"`
+}
+
+type convoyListSummaryJSON struct {
+	Total int `json:"total"`
+}
+
+type convoyListResultJSON struct {
+	SchemaVersion string                `json:"schema_version"`
+	Convoys       []convoySummaryJSON   `json:"convoys"`
+	Summary       convoyListSummaryJSON `json:"summary"`
+}
+
+type convoyChildJSON struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Status   string `json:"status"`
+	Type     string `json:"type"`
+	Assignee string `json:"assignee,omitempty"`
+}
+
+type convoyDetailJSON struct {
+	ID     string           `json:"id"`
+	Title  string           `json:"title"`
+	Status string           `json:"status"`
+	Owned  bool             `json:"owned"`
+	Fields convoyFieldsJSON `json:"fields,omitempty"`
+	Labels []string         `json:"labels,omitempty"`
+}
+
+type convoyStatusResultJSON struct {
+	SchemaVersion string             `json:"schema_version"`
+	Convoy        convoyDetailJSON   `json:"convoy"`
+	Progress      convoyProgressJSON `json:"progress"`
+	Children      []convoyChildJSON  `json:"children"`
+}
+
 func collectOpenConvoys(stores []convoyStoreView) ([]convoyWithStore, error) {
 	convoys := make([]convoyWithStore, 0)
 	for _, candidate := range stores {
@@ -442,7 +501,7 @@ func openConvoyStoreByID(convoyID string, stderr io.Writer, cmdName string) (bea
 
 // doConvoyList lists open convoys with progress counts.
 func doConvoyList(store beads.Store, stdout, stderr io.Writer) int {
-	return doConvoyListAcrossStores([]convoyStoreView{{store: store}}, stdout, stderr)
+	return doConvoyListAcrossStores([]convoyStoreView{{store: store}}, false, stdout, stderr)
 }
 
 func listConvoyChildren(store beads.Store, parentID string, includeClosed bool) ([]beads.Bead, error) {
@@ -453,11 +512,15 @@ func listConvoyChildren(store beads.Store, parentID string, includeClosed bool) 
 	})
 }
 
-func doConvoyListAcrossStores(stores []convoyStoreView, stdout, stderr io.Writer) int {
+func doConvoyListAcrossStores(stores []convoyStoreView, jsonOut bool, stdout, stderr io.Writer) int {
 	convoys, err := collectOpenConvoys(stores)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc convoy list: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+
+	if jsonOut {
+		return writeConvoyListJSON(convoys, stdout, stderr)
 	}
 
 	if len(convoys) == 0 {
@@ -485,8 +548,61 @@ func doConvoyListAcrossStores(stores []convoyStoreView, stdout, stderr io.Writer
 	return 0
 }
 
+func writeConvoyListJSON(convoys []convoyWithStore, stdout, stderr io.Writer) int {
+	items := make([]convoySummaryJSON, 0, len(convoys))
+	for _, c := range convoys {
+		children, err := listConvoyChildren(c.store, c.bead.ID, true)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc convoy list: children of %s: %v\n", c.bead.ID, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		item := convoySummaryFromBead(c.bead, children)
+		items = append(items, item)
+	}
+	if err := writeCLIJSONLine(stdout, convoyListResultJSON{
+		SchemaVersion: "1",
+		Convoys:       items,
+		Summary:       convoyListSummaryJSON{Total: len(items)},
+	}); err != nil {
+		fmt.Fprintf(stderr, "gc convoy list: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return 0
+}
+
+func convoySummaryFromBead(convoy beads.Bead, children []beads.Bead) convoySummaryJSON {
+	childIDs := make([]string, 0, len(children))
+	closed := 0
+	for _, ch := range children {
+		childIDs = append(childIDs, ch.ID)
+		if ch.Status == "closed" {
+			closed++
+		}
+	}
+	return convoySummaryJSON{
+		ID:       convoy.ID,
+		Title:    convoy.Title,
+		Status:   convoy.Status,
+		Progress: convoyProgressJSON{Closed: closed, Total: len(children)},
+		Owned:    hasLabel(convoy.Labels, "owned"),
+		Fields:   convoyFieldsFromBead(convoy),
+		ChildIDs: childIDs,
+	}
+}
+
+func convoyFieldsFromBead(convoy beads.Bead) convoyFieldsJSON {
+	fields := getConvoyFields(convoy)
+	return convoyFieldsJSON{
+		Owner:  fields.Owner,
+		Notify: fields.Notify,
+		Merge:  fields.Merge,
+		Target: fields.Target,
+	}
+}
+
 func newConvoyStatusCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "status <id>",
 		Short: "Show detailed convoy status",
 		Long: `Show detailed status of a convoy and all its child issues.
@@ -495,18 +611,20 @@ Displays the convoy's ID, title, status, completion progress, and a
 table of all child issues with their status and assignee.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdConvoyStatus(args, stdout, stderr) != 0 {
+			if cmdConvoyStatus(args, jsonOut, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 // cmdConvoyStatus is the CLI entry point for convoy status.
-func cmdConvoyStatus(args []string, stdout, stderr io.Writer) int {
+func cmdConvoyStatus(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		return doConvoyStatus(nil, args, stdout, stderr)
+		return doConvoyStatusWithJSON(nil, args, jsonOut, stdout, stderr)
 	}
 	convoyID := ""
 	if len(args) > 0 {
@@ -516,11 +634,15 @@ func cmdConvoyStatus(args []string, stdout, stderr io.Writer) int {
 	if store == nil {
 		return code
 	}
-	return doConvoyStatus(store, args, stdout, stderr)
+	return doConvoyStatusWithJSON(store, args, jsonOut, stdout, stderr)
 }
 
 // doConvoyStatus shows detailed status of a convoy and its children.
 func doConvoyStatus(store beads.Store, args []string, stdout, stderr io.Writer) int {
+	return doConvoyStatusWithJSON(store, args, false, stdout, stderr)
+}
+
+func doConvoyStatusWithJSON(store beads.Store, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc convoy status: missing convoy ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -548,6 +670,10 @@ func doConvoyStatus(store beads.Store, args []string, stdout, stderr io.Writer) 
 		if ch.Status == "closed" {
 			closed++
 		}
+	}
+
+	if jsonOut {
+		return writeConvoyStatusJSON(convoy, children, closed, stdout, stderr)
 	}
 
 	w := func(s string) { fmt.Fprintln(stdout, s) } //nolint:errcheck // best-effort stdout
@@ -584,6 +710,36 @@ func doConvoyStatus(store beads.Store, args []string, stdout, stderr io.Writer) 
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", ch.ID, ch.Title, ch.Status, assignee) //nolint:errcheck // best-effort stdout
 		}
 		tw.Flush() //nolint:errcheck // best-effort stdout
+	}
+	return 0
+}
+
+func writeConvoyStatusJSON(convoy beads.Bead, children []beads.Bead, closed int, stdout, stderr io.Writer) int {
+	childItems := make([]convoyChildJSON, 0, len(children))
+	for _, ch := range children {
+		childItems = append(childItems, convoyChildJSON{
+			ID:       ch.ID,
+			Title:    ch.Title,
+			Status:   ch.Status,
+			Type:     ch.Type,
+			Assignee: ch.Assignee,
+		})
+	}
+	if err := writeCLIJSONLine(stdout, convoyStatusResultJSON{
+		SchemaVersion: "1",
+		Convoy: convoyDetailJSON{
+			ID:     convoy.ID,
+			Title:  convoy.Title,
+			Status: convoy.Status,
+			Owned:  hasLabel(convoy.Labels, "owned"),
+			Fields: convoyFieldsFromBead(convoy),
+			Labels: convoy.Labels,
+		},
+		Progress: convoyProgressJSON{Closed: closed, Total: len(children)},
+		Children: childItems,
+	}); err != nil {
+		fmt.Fprintf(stderr, "gc convoy status: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
 	}
 	return 0
 }

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -278,7 +279,7 @@ func TestConvoyListAcrossStores(t *testing.T) {
 	_, _ = rigStore.Create(beads.Bead{Title: "rig task", ParentID: "gc-1"})
 
 	var stdout, stderr bytes.Buffer
-	code := doConvoyListAcrossStores([]convoyStoreView{{store: cityStore}, {store: rigStore}}, &stdout, &stderr)
+	code := doConvoyListAcrossStores([]convoyStoreView{{store: cityStore}, {store: rigStore}}, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doConvoyListAcrossStores = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -287,6 +288,76 @@ func TestConvoyListAcrossStores(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("stdout missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestConvoyListJSON(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{
+		Title:    "batch 1",
+		Type:     "convoy",
+		Labels:   []string{"owned"},
+		Metadata: map[string]string{"target": "integration/gc-1"},
+	})
+	_, _ = store.Create(beads.Bead{Title: "fix auth", ParentID: "gc-1"})
+	_, _ = store.Create(beads.Bead{Title: "fix logs", ParentID: "gc-1", Assignee: "worker"})
+	_ = store.Close("gc-3")
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyListAcrossStores([]convoyStoreView{{store: store}}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyListAcrossStores --json = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want one JSONL record: %q", len(lines), stdout.String())
+	}
+	var result convoyListResultJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" {
+		t.Fatalf("schema_version = %q, want 1", result.SchemaVersion)
+	}
+	if result.Summary.Total != 1 || len(result.Convoys) != 1 {
+		t.Fatalf("result summary/items = %+v/%+v, want one convoy", result.Summary, result.Convoys)
+	}
+	got := result.Convoys[0]
+	if got.ID != "gc-1" || got.Title != "batch 1" || !got.Owned {
+		t.Fatalf("convoy summary = %+v, want gc-1 batch 1 owned", got)
+	}
+	if got.Progress.Closed != 1 || got.Progress.Total != 2 {
+		t.Fatalf("progress = %+v, want 1/2", got.Progress)
+	}
+	if got.Fields.Target != "integration/gc-1" {
+		t.Fatalf("target = %q, want integration/gc-1", got.Fields.Target)
+	}
+}
+
+func TestConvoyListJSONEmpty(t *testing.T) {
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyListAcrossStores([]convoyStoreView{{store: store}}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyListAcrossStores --json = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "No open convoys") {
+		t.Fatalf("json stdout contains human message: %q", stdout.String())
+	}
+	var result convoyListResultJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.Summary.Total != 0 || len(result.Convoys) != 0 {
+		t.Fatalf("result = %+v, want empty v1 list", result)
 	}
 }
 
@@ -325,6 +396,106 @@ func TestConvoyStatus(t *testing.T) {
 			t.Errorf("stdout missing %q:\n%s", want, out)
 		}
 	}
+}
+
+func TestConvoyStatusJSON(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{
+		Title:    "deploy",
+		Type:     "convoy",
+		Labels:   []string{"owned"},
+		Metadata: map[string]string{"target": "integration/gc-1", "convoy.owner": "mayor"},
+	})
+	_, _ = store.Create(beads.Bead{Title: "task A", ParentID: "gc-1"})
+	_, _ = store.Create(beads.Bead{Title: "task B", ParentID: "gc-1", Assignee: "worker"})
+	_ = store.Close("gc-2")
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyStatusWithJSON(store, []string{"gc-1"}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyStatus --json = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want one JSONL record: %q", len(lines), stdout.String())
+	}
+	var result convoyStatusResultJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" {
+		t.Fatalf("schema_version = %q, want 1", result.SchemaVersion)
+	}
+	if result.Convoy.ID != "gc-1" || result.Convoy.Title != "deploy" || !result.Convoy.Owned {
+		t.Fatalf("convoy = %+v, want owned gc-1 deploy", result.Convoy)
+	}
+	if result.Convoy.Fields.Target != "integration/gc-1" || result.Convoy.Fields.Owner != "mayor" {
+		t.Fatalf("fields = %+v, want target and owner", result.Convoy.Fields)
+	}
+	if result.Progress.Closed != 1 || result.Progress.Total != 2 {
+		t.Fatalf("progress = %+v, want 1/2", result.Progress)
+	}
+	if len(result.Children) != 2 || result.Children[1].Assignee != "worker" {
+		t.Fatalf("children = %+v, want two children with second assigned", result.Children)
+	}
+}
+
+func TestConvoyListAndStatusJSONCommands(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	_, _ = store.Create(beads.Bead{Title: "release train", Type: "convoy"})
+	_, _ = store.Create(beads.Bead{Title: "ship docs", ParentID: "gc-1"})
+
+	t.Run("list", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := run([]string{"convoy", "list", "--json"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run convoy list --json = %d; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		}
+		if stderr.Len() != 0 {
+			t.Fatalf("stderr = %q, want empty", stderr.String())
+		}
+		var result convoyListResultJSON
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+		}
+		if result.SchemaVersion != "1" || len(result.Convoys) != 1 {
+			t.Fatalf("result = %+v, want one v1 convoy", result)
+		}
+	})
+
+	t.Run("status", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := run([]string{"convoy", "status", "gc-1", "--json"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run convoy status --json = %d; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		}
+		if stderr.Len() != 0 {
+			t.Fatalf("stderr = %q, want empty", stderr.String())
+		}
+		var result convoyStatusResultJSON
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+		}
+		if result.SchemaVersion != "1" || result.Convoy.ID != "gc-1" || len(result.Children) != 1 {
+			t.Fatalf("result = %+v, want gc-1 with one child", result)
+		}
+	})
 }
 
 func TestConvoyTarget(t *testing.T) {

--- a/schemas/convoy/list/result.schema.json
+++ b/schemas/convoy/list/result.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "convoys", "summary"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "convoys": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "status", "progress", "owned"],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "status": { "type": "string" },
+          "progress": {
+            "type": "object",
+            "required": ["closed", "total"],
+            "properties": {
+              "closed": { "type": "integer" },
+              "total": { "type": "integer" }
+            },
+            "additionalProperties": true
+          },
+          "owned": { "type": "boolean" },
+          "fields": {
+            "type": "object",
+            "properties": {
+              "owner": { "type": "string" },
+              "notify": { "type": "string" },
+              "merge": { "type": "string" },
+              "target": { "type": "string" }
+            },
+            "additionalProperties": true
+          },
+          "child_ids": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total"],
+      "properties": {
+        "total": { "type": "integer" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/convoy/status/result.schema.json
+++ b/schemas/convoy/status/result.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "convoy", "progress", "children"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "convoy": {
+      "type": "object",
+      "required": ["id", "title", "status", "owned"],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "status": { "type": "string" },
+        "owned": { "type": "boolean" },
+        "fields": {
+          "type": "object",
+          "properties": {
+            "owner": { "type": "string" },
+            "notify": { "type": "string" },
+            "merge": { "type": "string" },
+            "target": { "type": "string" }
+          },
+          "additionalProperties": true
+        },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "progress": {
+      "type": "object",
+      "required": ["closed", "total"],
+      "properties": {
+        "closed": { "type": "integer" },
+        "total": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "children": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "status", "type"],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "status": { "type": "string" },
+          "type": { "type": "string" },
+          "assignee": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- adds `gc convoy list --json`
- adds `gc convoy status <id> --json`
- declares result schemas for both convoy inspection commands
- adds focused tests for parseable one-record JSONL stdout with empty stderr on successful JSON output

## JSON compatibility
- These commands did not previously expose native success `--json` output, so this PR adds new machine-readable surfaces without changing an existing JSON contract.
- Human-readable output remains the default and is preserved.
- `gc workflow` is not included here because it is currently a hidden deprecated alias exposing mutating recovery commands rather than bounded read/list/show surfaces.

## Validation
- `go test ./cmd/gc -run 'TestConvoy(List|Status|Store|Create|Add|Close|Check|Autoclose|Stranded|Target|HasLabel|Resolve).*|TestJSONSchema|TestJSONUnsupported'`\n- `git diff --check`\n- `make fmt-check`\n- `make vet`\n- `make check-docs`\n- `GOOS=linux make lint`\n\nStacked on #2222 (`codex/json-schema-platform`).
