### PR TITLE
feat: add JSON for agent and rig routing inspection

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -423,7 +424,7 @@ have moved to "gc session" and "gc runtime".`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc agent: missing subcommand (add, suspend, resume)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintln(stderr, "gc agent: missing subcommand (add, list, suspend, resume)") //nolint:errcheck // best-effort stderr
 			} else {
 				fmt.Fprintf(stderr, "gc agent: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
 			}
@@ -432,10 +433,130 @@ have moved to "gc session" and "gc runtime".`,
 	}
 	cmd.AddCommand(
 		newAgentAddCmd(stdout, stderr),
+		newAgentListCmd(stdout, stderr),
 		newAgentResumeCmd(stdout, stderr),
 		newAgentSuspendCmd(stdout, stderr),
 	)
 	return cmd
+}
+
+func newAgentListCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List configured agents",
+		Long: `List configured agents from the resolved city configuration.
+
+Use --json to inspect agent routing fields, including effective work_query
+and sling_query values.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if cmdAgentList(jsonOutput, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
+}
+
+// AgentListJSON is the JSON output format for "gc agent list --json".
+type AgentListJSON struct {
+	SchemaVersion string          `json:"schema_version"`
+	CityPath      string          `json:"city_path"`
+	CityName      string          `json:"city_name"`
+	Agents        []AgentListItem `json:"agents"`
+}
+
+// AgentListItem is one configured agent in "gc agent list --json".
+type AgentListItem struct {
+	Name                 string    `json:"name"`
+	QualifiedName        string    `json:"qualified_name"`
+	Dir                  string    `json:"dir,omitempty"`
+	Scope                string    `json:"scope,omitempty"`
+	WorkDir              string    `json:"work_dir,omitempty"`
+	Provider             string    `json:"provider,omitempty"`
+	Session              string    `json:"session,omitempty"`
+	Suspended            bool      `json:"suspended"`
+	Pool                 *PoolJSON `json:"pool,omitempty"`
+	WorkQuery            string    `json:"work_query"`
+	SlingQuery           string    `json:"sling_query"`
+	ConfiguredWorkQuery  string    `json:"configured_work_query,omitempty"`
+	ConfiguredSlingQuery string    `json:"configured_sling_query,omitempty"`
+}
+
+func cmdAgentList(jsonOutput bool, stdout, stderr io.Writer) int {
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc agent list: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return doAgentList(fsys.OSFS{}, cityPath, jsonOutput, stdout, stderr)
+}
+
+func doAgentList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.Writer) int {
+	cfg, err := loadCityConfigFS(fs, filepath.Join(cityPath, "city.toml"), stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc agent list: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	items := agentListItems(cfg)
+	if jsonOutput {
+		if err := writeCLIJSONLine(stdout, AgentListJSON{
+			SchemaVersion: "1",
+			CityPath:      cityPath,
+			CityName:      cfg.EffectiveCityName(),
+			Agents:        items,
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc agent list: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return 0
+	}
+
+	fmt.Fprintf(stdout, "Agents in %s:\n", cityPath) //nolint:errcheck // best-effort stdout
+	for _, item := range items {
+		status := "active"
+		if item.Suspended {
+			status = "suspended"
+		}
+		fmt.Fprintf(stdout, "  %-24s %s\n", item.QualifiedName, status) //nolint:errcheck // best-effort stdout
+	}
+	return 0
+}
+
+func agentListItems(cfg *config.City) []AgentListItem {
+	if cfg == nil {
+		return nil
+	}
+	items := make([]AgentListItem, 0, len(cfg.Agents))
+	for i := range cfg.Agents {
+		a := cfg.Agents[i]
+		item := AgentListItem{
+			Name:                 a.Name,
+			QualifiedName:        a.QualifiedName(),
+			Dir:                  a.Dir,
+			Scope:                a.Scope,
+			WorkDir:              a.WorkDir,
+			Provider:             a.Provider,
+			Session:              a.Session,
+			Suspended:            a.Suspended,
+			WorkQuery:            a.EffectiveWorkQuery(),
+			SlingQuery:           a.EffectiveSlingQuery(),
+			ConfiguredWorkQuery:  a.WorkQuery,
+			ConfiguredSlingQuery: a.SlingQuery,
+		}
+		sp := scaleParamsFor(&a)
+		if sp.Min != 0 || sp.Max != 1 || strings.TrimSpace(sp.Check) != "" || a.SupportsInstanceExpansion() {
+			item.Pool = &PoolJSON{Min: sp.Min, Max: sp.Max}
+		}
+		items = append(items, item)
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].QualifiedName < items[j].QualifiedName
+	})
+	return items
 }
 
 func newAgentAddCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,56 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/molecule"
 )
+
+func TestDoAgentListJSON(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+max_active_sessions = 1
+
+[[agent]]
+name = "worker"
+dir = "frontend"
+suspended = true
+work_query = "bd ready --label=frontend"
+sling_query = "bd update {} --set-metadata gc.routed_to=frontend/worker"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentList(fs, "/city", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doAgentList --json = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1; stdout=%q", len(lines), stdout.String())
+	}
+	var result AgentListJSON
+	if err := json.Unmarshal([]byte(lines[0]), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.CityName != "test-city" || len(result.Agents) != 2 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	var worker AgentListItem
+	for _, item := range result.Agents {
+		if item.QualifiedName == "frontend/worker" {
+			worker = item
+		}
+	}
+	if worker.QualifiedName != "frontend/worker" || !worker.Suspended {
+		t.Fatalf("worker item = %+v, want suspended frontend/worker", worker)
+	}
+	if worker.WorkQuery != "bd ready --label=frontend" || worker.SlingQuery == "" {
+		t.Fatalf("worker routing fields = %+v", worker)
+	}
+}
 
 // ---------------------------------------------------------------------------
 // doAgentSuspend/Resume — bad config error path (no existing coverage)

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/worker"
 	"github.com/spf13/cobra"
 )
 
@@ -16,22 +18,25 @@ import (
 
 // newRigStatusCmd creates the "gc rig status <name>" subcommand.
 func newRigStatusCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "status [name]",
 		Short: "Show rig status and agent running state",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdRigStatus(args, stdout, stderr) != 0 {
+			if cmdRigStatus(args, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeRigNames,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
 }
 
 // cmdRigStatus is the CLI entry point for showing rig status.
-func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
+func cmdRigStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	ctx, err := resolveContext()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig status: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -85,7 +90,38 @@ func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
 	statusSnapshot := loadStatusSessionSnapshot(store, stderr)
 	sp := newStatusSessionProviderForCityWithSnapshot(cfg, cityPath, statusSnapshot)
 	dops := newDrainOps(sp)
-	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, rigAgents, cityPath, cityName, cfg.Workspace.SessionTemplate, cfg, store, statusSnapshot, stdout, stderr)
+	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, rigAgents, cityPath, cityName, cfg.Workspace.SessionTemplate, cfg, store, statusSnapshot, jsonOutput, stdout, stderr)
+}
+
+// RigStatusJSON is the JSON output format for "gc rig status --json".
+type RigStatusJSON struct {
+	SchemaVersion string           `json:"schema_version"`
+	CityPath      string           `json:"city_path"`
+	CityName      string           `json:"city_name"`
+	Rig           RigStatusRig     `json:"rig"`
+	Agents        []RigStatusAgent `json:"agents"`
+}
+
+// RigStatusRig describes the selected rig in "gc rig status --json".
+type RigStatusRig struct {
+	Name          string `json:"name"`
+	Path          string `json:"path"`
+	Prefix        string `json:"prefix"`
+	DefaultBranch string `json:"default_branch,omitempty"`
+	Suspended     bool   `json:"suspended"`
+	Beads         string `json:"beads"`
+}
+
+// RigStatusAgent describes an agent or concrete pool instance for a rig.
+type RigStatusAgent struct {
+	Name               string `json:"name"`
+	QualifiedName      string `json:"qualified_name"`
+	RuntimeSessionName string `json:"runtime_session_name"`
+	SessionID          string `json:"session_id,omitempty"`
+	Running            bool   `json:"running"`
+	Suspended          bool   `json:"suspended"`
+	Draining           bool   `json:"draining"`
+	Status             string `json:"status"`
 }
 
 func doRigStatusWithStoreAndSnapshot(
@@ -97,9 +133,13 @@ func doRigStatusWithStoreAndSnapshot(
 	cfg *config.City,
 	store beads.Store,
 	statusSnapshot *sessionBeadSnapshot,
+	jsonOutput bool,
 	stdout, stderr io.Writer,
 ) int {
 	registerStatusProviderACPRoutes(sp, statusSnapshot, cityName, cfg)
+	if jsonOutput {
+		return renderRigStatusJSON(sp, dops, rig, agents, cityPath, cityName, sessionTemplate, cfg, store, statusSnapshot, stdout, stderr)
+	}
 
 	suspStr := "no"
 	if rig.Suspended {
@@ -128,6 +168,79 @@ func doRigStatusWithStoreAndSnapshot(
 		}
 	}
 	return 0
+}
+
+func renderRigStatusJSON(
+	sp runtime.Provider,
+	dops drainOps,
+	rig config.Rig,
+	agents []config.Agent,
+	cityPath, cityName, sessionTemplate string,
+	cfg *config.City,
+	store beads.Store,
+	statusSnapshot *sessionBeadSnapshot,
+	stdout, stderr io.Writer,
+) int {
+	result := RigStatusJSON{
+		SchemaVersion: "1",
+		CityPath:      cityPath,
+		CityName:      cityName,
+		Rig: RigStatusRig{
+			Name:          rig.Name,
+			Path:          rig.Path,
+			Prefix:        rig.EffectivePrefix(),
+			DefaultBranch: rig.EffectiveDefaultBranch(),
+			Suspended:     rig.Suspended,
+			Beads:         rigBeadsStatus(fsys.OSFS{}, rig.Path),
+		},
+	}
+	for _, a := range agents {
+		sp0 := scaleParamsFor(&a)
+		if !a.SupportsInstanceExpansion() {
+			target := statusObservationTargetForIdentity(statusSnapshot, cityName, a.QualifiedName(), sessionTemplate)
+			obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, cfg, target, stderr)
+			result.Agents = append(result.Agents, rigStatusAgentJSON(a.Name, a.QualifiedName(), target, obs, dops, a.Suspended))
+			continue
+		}
+		for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, sessionTemplate, sp) {
+			target := statusObservationTargetForIdentity(statusSnapshot, cityName, qualifiedInstance, sessionTemplate)
+			obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, cfg, target, stderr)
+			result.Agents = append(result.Agents, rigStatusAgentJSON(a.Name, qualifiedInstance, target, obs, dops, a.Suspended))
+		}
+	}
+	if err := writeCLIJSONLine(stdout, result); err != nil {
+		fmt.Fprintf(stderr, "gc rig status: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return 0
+}
+
+func rigStatusAgentJSON(name, qualifiedName string, target statusObservationTarget, obs worker.LiveObservation, dops drainOps, agentSuspended bool) RigStatusAgent {
+	suspended := agentSuspended || obs.Suspended || target.suspended
+	draining := false
+	if obs.Running {
+		draining, _ = dops.isDraining(target.runtimeSessionName)
+	}
+	status := "stopped"
+	if obs.Running {
+		status = "running"
+		if draining {
+			status = "draining"
+		}
+	}
+	if suspended && !obs.Running {
+		status = "suspended"
+	}
+	return RigStatusAgent{
+		Name:               name,
+		QualifiedName:      qualifiedName,
+		RuntimeSessionName: target.runtimeSessionName,
+		SessionID:          target.sessionID,
+		Running:            obs.Running,
+		Suspended:          suspended,
+		Draining:           draining,
+		Status:             status,
+	}
 }
 
 // agentStatusLine returns a human-readable status string for an agent session.

--- a/cmd/gc/cmd_status_test.go
+++ b/cmd/gc/cmd_status_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
@@ -33,7 +34,17 @@ func runDoRigStatus(
 		}
 	}
 	statusSnapshot := loadStatusSessionSnapshot(store, stderr)
-	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, cityPath, "city", "", nil, store, statusSnapshot, stdout, stderr)
+	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, cityPath, "city", "", nil, store, statusSnapshot, false, stdout, stderr)
+}
+
+func runDoRigStatusJSON(
+	sp runtime.Provider,
+	dops drainOps,
+	rig config.Rig,
+	agents []config.Agent,
+	stdout, stderr io.Writer,
+) int {
+	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, "", "city", "", nil, nil, newSessionBeadSnapshot(nil), true, stdout, stderr)
 }
 
 func TestDoRigStatus(t *testing.T) {
@@ -74,6 +85,52 @@ func TestDoRigStatus(t *testing.T) {
 	}
 	if !strings.Contains(out, "worker") && !strings.Contains(out, "stopped") {
 		t.Errorf("stdout missing worker stopped status, got:\n%s", out)
+	}
+}
+
+func TestDoRigStatusJSON(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "frontend--worker-1", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+	dops := newFakeDrainOps()
+	dops.draining["frontend--worker-1"] = true
+	rig := config.Rig{Name: "frontend", Path: "/tmp/frontend", Prefix: "fe", DefaultBranch: "main"}
+	agents := []config.Agent{
+		{Name: "worker", Dir: "frontend", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(1), ScaleCheck: "echo 1"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDoRigStatusJSON(sp, dops, rig, agents, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigStatusWithStoreAndSnapshot --json = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1; stdout=%q", len(lines), stdout.String())
+	}
+	var result RigStatusJSON
+	if err := json.Unmarshal([]byte(lines[0]), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.Rig.Name != "frontend" || result.Rig.Prefix != "fe" {
+		t.Fatalf("unexpected rig status result: %+v", result)
+	}
+	if len(result.Agents) != 2 {
+		t.Fatalf("agents = %+v, want canonical worker plus stale numbered worker instance", result.Agents)
+	}
+	byName := map[string]RigStatusAgent{}
+	for _, agent := range result.Agents {
+		byName[agent.QualifiedName] = agent
+	}
+	if agent := byName["frontend/worker"]; agent.QualifiedName != "frontend/worker" || agent.Running || agent.Status != "stopped" {
+		t.Fatalf("canonical agent = %+v, want stopped frontend/worker", agent)
+	}
+	if agent := byName["frontend/worker-1"]; agent.QualifiedName != "frontend/worker-1" || !agent.Running || !agent.Draining || agent.Status != "draining" {
+		t.Fatalf("numbered agent = %+v, want running draining frontend/worker-1", agent)
 	}
 }
 

--- a/cmd/gc/command_context_test.go
+++ b/cmd/gc/command_context_test.go
@@ -229,7 +229,7 @@ func TestRigAnywhere_CmdRigStatusFromRigDir(t *testing.T) {
 			setCwd(t, fx.workDir)
 
 			var stdout, stderr bytes.Buffer
-			code := cmdRigStatus(nil, &stdout, &stderr)
+			code := cmdRigStatus(nil, false, &stdout, &stderr)
 			if code != 0 {
 				t.Fatalf("cmdRigStatus() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 			}

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -98,6 +99,37 @@ func TestJSONSchemaRoleSpecificResult(t *testing.T) {
 	}
 	if _, ok := schema["x-gc-jsonl"].(map[string]any); !ok {
 		t.Fatalf("schema missing x-gc-jsonl object: %+v", schema)
+	}
+}
+
+func TestJSONSchemaRoleSpecificResultForRigAgentRoutingCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"agent", "list", "--json-schema=result"},
+		{"rig", "status", "--json-schema=result"},
+	} {
+		t.Run(strings.Join(args[:len(args)-1], "_"), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%v) = %d, stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var schema struct {
+				Required   []string       `json:"required"`
+				Properties map[string]any `json:"properties"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+				t.Fatalf("result schema is not JSON: %v\n%s", err, stdout.String())
+			}
+			if !slices.Contains(schema.Required, "schema_version") {
+				t.Fatalf("required = %v, want schema_version", schema.Required)
+			}
+			if schema.Properties["schema_version"] == nil {
+				t.Fatalf("schema missing schema_version property: %+v", schema.Properties)
+			}
+		})
 	}
 }
 

--- a/schemas/agent/list/result.schema.json
+++ b/schemas/agent/list/result.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "city_name", "agents"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "city_path": { "type": "string" },
+    "city_name": { "type": "string" },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "qualified_name", "suspended", "work_query", "sling_query"],
+        "properties": {
+          "name": { "type": "string" },
+          "qualified_name": { "type": "string" },
+          "dir": { "type": "string" },
+          "scope": { "type": "string" },
+          "work_dir": { "type": "string" },
+          "provider": { "type": "string" },
+          "session": { "type": "string" },
+          "suspended": { "type": "boolean" },
+          "pool": {
+            "type": "object",
+            "required": ["min", "max"],
+            "properties": {
+              "min": { "type": "integer" },
+              "max": { "type": "integer" }
+            },
+            "additionalProperties": true
+          },
+          "work_query": { "type": "string" },
+          "sling_query": { "type": "string" },
+          "configured_work_query": { "type": "string" },
+          "configured_sling_query": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/status/result.schema.json
+++ b/schemas/rig/status/result.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "city_path", "city_name", "rig", "agents"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "city_path": { "type": "string" },
+    "city_name": { "type": "string" },
+    "rig": {
+      "type": "object",
+      "required": ["name", "path", "prefix", "suspended", "beads"],
+      "properties": {
+        "name": { "type": "string" },
+        "path": { "type": "string" },
+        "prefix": { "type": "string" },
+        "default_branch": { "type": "string" },
+        "suspended": { "type": "boolean" },
+        "beads": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "qualified_name", "runtime_session_name", "running", "suspended", "draining", "status"],
+        "properties": {
+          "name": { "type": "string" },
+          "qualified_name": { "type": "string" },
+          "runtime_session_name": { "type": "string" },
+          "session_id": { "type": "string" },
+          "running": { "type": "boolean" },
+          "suspended": { "type": "boolean" },
+          "draining": { "type": "boolean" },
+          "status": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- adds `gc agent list --json` for configured agents and routing query inspection
- adds `gc rig status --json` for selected rig metadata and per-agent runtime status
- declares result schemas for both commands
- adds focused tests for schema discovery and JSON output

## JSON compatibility
- `gc agent list` and `gc rig status` did not previously expose native success `--json` output, so this PR adds new machine-readable surfaces without changing an existing JSON contract.
- Existing `gc rig list --json` is intentionally unchanged.
- Human-readable output remains the default and is preserved.

## Validation
- `go test ./cmd/gc -run 'TestDoAgentListJSON|TestDoRigStatusJSON|TestJSONSchema'`\n- `go test ./cmd/gc -run 'TestDoAgent|TestDoRigStatus|TestRigAnywhere_CmdRigStatusFromRigDir|TestJSONSchema'`\n- `go test ./cmd/gc -run 'TestDoAgentListJSON|TestDoRigStatusJSON|TestJSONSchemaRoleSpecificResultForRigAgentRoutingCommands'`\n- `make fmt-check`\n- `make vet`\n- `make check-docs`\n- `GOOS=linux make lint`\n- `git diff --check`\n\nStacked on #2222 (`codex/json-schema-platform`).
