### PR TITLE
test(acceptance): scaffold selfhost UX umbrella coverage

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1251,7 +1251,7 @@ gc help [command]
 
 Checks for available work using the agent's work_query config.
 
-Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
+Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.

--- a/release-gates/ga-il4xof-selfhost-ux-acceptance-scaffold-gate.md
+++ b/release-gates/ga-il4xof-selfhost-ux-acceptance-scaffold-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: ga-ycw6.1 - selfhost UX acceptance scaffold
+
+**Deploy bead:** ga-il4xof
+**Originating bead:** ga-ycw6.1
+**Branch:** `builder/ga-ycw6-1` (fork: `quad341/gascity`)
+**PR:** https://github.com/gastownhall/gascity/pull/2260
+**Commit:** 1e5f29a1956b343e2fc4dffd63fbe67d93c2f0ce
+**Evaluated:** 2026-05-17T00:59:22Z
+**Verdict:** PASS
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this worktree. This gate
+uses the deployer role's six release criteria plus the originating bead's
+verification gates.
+
+## Criteria
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-il4xof notes contain `Review verdict: PASS` from `gascity/reviewer` for commit `1e5f29a1956b343e2fc4dffd63fbe67d93c2f0ce`. |
+| 2 | Acceptance criteria met | PASS | `test/acceptance/integration_selfhost_ux_test.go` adds the `acceptance_a` selfhost UX scaffold, active `gc stop` bypass and op-init fast-path checks, architecture-approved skips for the two prerequisite-dependent tests, and placeholder tests for the remaining follow-up beads. `test/acceptance/helpers/city.go` adds `WriteV1AgentBlock`, `WriteV2AgentDir`, and `StartExpectingFatal` with both `FATAL:` and `gc-fatal:` prefix support. |
+| 3 | Tests pass | PASS | `go test -tags=acceptance_a -run TestSelfhostUX ./test/acceptance/...` PASS; `make test-fast-parallel` PASS; `go vet ./...` PASS; `go build ./...` PASS; `git diff --check origin/main...HEAD` PASS. GitHub PR checks are also green on PR #2260. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list "Findings: none blocking" and contain no unresolved HIGH findings. |
+| 5 | Final branch is clean | PASS | Branch was clean before adding this gate; final cleanliness is verified after the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` returned 0 before the gate commit, and GitHub reports PR #2260 merge state `CLEAN`. |
+
+## Changed Files
+
+| Path | Gate note |
+|------|-----------|
+| `test/acceptance/integration_selfhost_ux_test.go` | New selfhost UX umbrella acceptance scaffold with two active tests, two guarded tests, and discoverable placeholders. |
+| `test/acceptance/helpers/city.go` | Adds City DSL helpers for v1/v2 agent fixtures and fatal-start assertions. |
+| `docs/reference/cli.md` | Generated CLI reference sync from the pre-commit hook. |
+
+## Local Commands
+
+```text
+go test -tags=acceptance_a -run TestSelfhostUX ./test/acceptance/...
+make test-fast-parallel
+go vet ./...
+go build ./...
+git diff --check origin/main...HEAD
+```

--- a/test/acceptance/helpers/city.go
+++ b/test/acceptance/helpers/city.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -129,6 +130,65 @@ func (c *City) WriteConfig(toml string) {
 	}
 }
 
+// WriteV1AgentBlock appends a legacy [[agent]] block to the city root pack.toml.
+func (c *City) WriteV1AgentBlock(name string, fields ...string) {
+	c.t.Helper()
+	var b strings.Builder
+	b.WriteString("\n[[agent]]\n")
+	fmt.Fprintf(&b, "name = %q\n", name)
+	if !hasTOMLFieldKey(fields, "scope") {
+		b.WriteString("scope = \"city\"\n")
+	}
+	writeTOMLFields(&b, fields)
+
+	packPath := filepath.Join(c.Dir, "pack.toml")
+	f, err := os.OpenFile(packPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		c.t.Fatalf("opening pack.toml: %v", err)
+	}
+	defer f.Close() //nolint:errcheck // test helper failure is already captured on write
+	if _, err := f.WriteString(b.String()); err != nil {
+		c.t.Fatalf("appending v1 agent block to pack.toml: %v", err)
+	}
+}
+
+// WriteV2AgentDir writes a convention-discovered agent under the city root pack.
+func (c *City) WriteV2AgentDir(name string, fields ...string) {
+	c.t.Helper()
+	agentDir := filepath.Join(c.Dir, "agents", name)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		c.t.Fatalf("creating agents/%s: %v", name, err)
+	}
+
+	var b strings.Builder
+	if !hasTOMLFieldKey(fields, "scope") {
+		b.WriteString("scope = \"city\"\n")
+	}
+	writeTOMLFields(&b, fields)
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(b.String()), 0o644); err != nil {
+		c.t.Fatalf("writing agents/%s/agent.toml: %v", name, err)
+	}
+
+	prompt := fmt.Sprintf("# %s\n\nYou are the %s test agent.\n", name, name)
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte(prompt), 0o644); err != nil {
+		c.t.Fatalf("writing agents/%s/prompt.template.md: %v", name, err)
+	}
+}
+
+// StartExpectingFatal runs gc start and returns its captured failure output.
+func (c *City) StartExpectingFatal(t *testing.T) string {
+	t.Helper()
+	out, err := c.GC("start", c.Dir)
+	if err == nil {
+		t.Fatalf("gc start succeeded; want fatal failure\n%s", out)
+	}
+	last := lastVisuallyDistinctLine(out)
+	if !fatalLinePrefixRE.MatchString(last) {
+		t.Fatalf("last visually distinct line = %q, want fatal prefix; full output:\n%s", last, out)
+	}
+	return out
+}
+
 // Stop runs gc stop.
 func (c *City) Stop() {
 	if !c.started {
@@ -235,6 +295,43 @@ func parseKeyValues(s string) map[string]string {
 		}
 	}
 	return m
+}
+
+var (
+	ansiEscapeRE      = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+	fatalLinePrefixRE = regexp.MustCompile(`^(FATAL:|gc-fatal:)`)
+)
+
+func hasTOMLFieldKey(fields []string, key string) bool {
+	for _, field := range fields {
+		k, _, ok := strings.Cut(strings.TrimSpace(field), "=")
+		if ok && strings.TrimSpace(k) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func writeTOMLFields(b *strings.Builder, fields []string) {
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		b.WriteString(field)
+		b.WriteByte('\n')
+	}
+}
+
+func lastVisuallyDistinctLine(out string) string {
+	var last string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(ansiEscapeRE.ReplaceAllString(line, ""))
+		if line != "" {
+			last = line
+		}
+	}
+	return last
 }
 
 func uniqueName() string {

--- a/test/acceptance/integration_selfhost_ux_test.go
+++ b/test/acceptance/integration_selfhost_ux_test.go
@@ -1,0 +1,128 @@
+//go:build acceptance_a
+
+package acceptance_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+func TestSelfhostUX_PackV1V2Collision(t *testing.T) {
+	t.Skip("pending ga-cwdaqv: supervised gc start does not validate config pre-registration")
+
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+	c.WriteV1AgentBlock("worker")
+	c.WriteV2AgentDir("worker")
+
+	start := time.Now()
+	out := c.StartExpectingFatal(t)
+	if elapsed := time.Since(start); elapsed > durationFromEnv(t, "GC_TEST_GC_START_BUDGET", 30*time.Second) {
+		t.Fatalf("gc start fatal path took %s; output:\n%s", elapsed, out)
+	}
+	for _, want := range []string{
+		"pack v1/v2 layout collision",
+		"pack.toml ([[agent]] worker)",
+		"agents/worker/agent.toml",
+		"docs/packv2/migration.mdx",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("gc start fatal output missing %q:\n%s", want, out)
+		}
+	}
+	// TODO(ga-q0bf.1): assert structured trailing line once the gc-start summary ships.
+}
+
+func TestSelfhostUX_GcStopBypassValidation(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+	c.WriteV1AgentBlock("worker")
+	c.WriteV2AgentDir("worker")
+
+	out, err := c.GC("stop", c.Dir)
+	if err != nil {
+		t.Fatalf("gc stop should bypass broken config validation: %v\n%s", err, out)
+	}
+}
+
+func TestSelfhostUX_BinaryDriftRestart(t *testing.T) {
+	t.Skip("pending merge of builder/ga-xxqx-1 (PR#2219): drift auto-restart not on origin/main")
+
+	c := helpers.NewCity(t, testEnv)
+	c.Init("claude")
+
+	initialBinary, err := helpers.ResolveGCPath(testEnv)
+	if err != nil {
+		t.Fatalf("resolve initial gc binary: %v", err)
+	}
+	initialOut, err := c.GC("start", c.Dir)
+	if err != nil {
+		t.Fatalf("initial gc start: %v\n%s", err, initialOut)
+	}
+
+	rebuiltBinary := helpers.BuildGC(t.TempDir())
+	if rebuiltBinary == initialBinary {
+		t.Fatalf("rebuilt binary path should differ from initial path %q", initialBinary)
+	}
+	driftEnv := helpers.NewEnv(rebuiltBinary, testEnv.Get("GC_HOME"), testEnv.Get("XDG_RUNTIME_DIR"))
+	out, err := helpers.RunGC(driftEnv, c.Dir, "start", c.Dir)
+	if err != nil {
+		t.Fatalf("gc start after binary drift: %v\n%s", err, out)
+	}
+	for _, want := range []string{"binary drift", rebuiltBinary, "Supervisor:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("binary drift restart output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSelfhostUX_OpInitFastPath(t *testing.T) {
+	budget := durationFromEnv(t, "GC_TEST_GC_INIT_FAST_BUDGET", 5*time.Second)
+	c := helpers.NewCity(t, testEnv)
+
+	start := time.Now()
+	c.Init("claude")
+	if elapsed := time.Since(start); elapsed > budget {
+		t.Fatalf("gc init took %s, want <= %s", elapsed, budget)
+	}
+}
+
+func TestSelfhostUX_Composed(t *testing.T) {
+	t.Skip("placeholder for ga-q0bf.1, ga-r8iz.1, ga-6wrr.1, and post-PR#2219 assertions")
+}
+
+func TestSelfhostUX_StructuredStartSummaryPlaceholder(t *testing.T) {
+	t.Skip("placeholder for ga-q0bf.1")
+}
+
+func TestSelfhostUX_StopBypassDetailsPlaceholder(t *testing.T) {
+	t.Skip("placeholder for ga-r8iz.1")
+}
+
+func TestSelfhostUX_MigrationGuideURLPlaceholder(t *testing.T) {
+	t.Skip("placeholder for ga-6wrr.1")
+}
+
+func TestSelfhostUX_BinaryDriftPostMergePlaceholder(t *testing.T) {
+	t.Skip("placeholder for ga-xxqx")
+}
+
+func durationFromEnv(t *testing.T, name string, fallback time.Duration) time.Duration {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		t.Fatalf("parse %s=%q: %v", name, raw, err)
+	}
+	if d <= 0 {
+		t.Fatalf("%s must be positive, got %s", name, d)
+	}
+	return d
+}


### PR DESCRIPTION
## What this changes

This adds an acceptance scaffold for the 1.1.0 selfhost UX regression suite under `test/acceptance`. The new `acceptance_a` umbrella test file includes active checks for `gc stop` bypassing invalid city config and `gc init` fast-path timing, plus discoverable skipped placeholders for the remaining selfhost assertions that depend on separate prerequisites.

The acceptance City DSL now has helpers for building legacy `[[agent]]` fixtures, convention-discovered `agents/<name>/agent.toml` fixtures, and fatal-start assertions that work with both terminal and non-terminal fatal prefixes.

## Review notes

- No production behavior changes; this PR touches acceptance tests/helpers plus generated CLI reference output.
- Two scaffold tests are intentionally skipped until the config pre-registration and binary-drift restart prerequisites are available on `main`.
- `docs/reference/cli.md` is generated output from the pre-commit hook.

## Test plan

- [x] `go test -tags=acceptance_a -run TestSelfhostUX ./test/acceptance/...`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] Release gate: [`release-gates/ga-il4xof-selfhost-ux-acceptance-scaffold-gate.md`](release-gates/ga-il4xof-selfhost-ux-acceptance-scaffold-gate.md)
