### PR TITLE
Fix review formula recovery and unregister shutdown flakes

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -672,6 +672,14 @@ func managedCityStopTimeout(mc *managedCity) time.Duration {
 	return mc.cr.cfg.Daemon.ShutdownTimeoutDuration()
 }
 
+func managedCityForcedStopTimeout(mc *managedCity) time.Duration {
+	timeout := managedCityStopTimeout(mc)
+	if timeout <= 0 {
+		return timeout
+	}
+	return timeout * 5
+}
+
 // stopManagedCity cancels a city's context, waits up to its configured
 // grace period for it to exit, forces shutdown if it doesn't, and then
 // closes the bead provider and file recorder. It returns a non-nil error
@@ -709,15 +717,16 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 			mc.cr.shutdown()
 		}()
 	}
-	if timeout > 0 {
+	forceTimeout := managedCityForcedStopTimeout(mc)
+	if forceTimeout > 0 {
 		select {
 		case <-mc.done:
 			// Forced shutdown completed before the second timeout — the
 			// city is out. Clear the pending error so we report success.
 			stopErr = nil
-		case <-time.After(timeout):
-			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, timeout) //nolint:errcheck
-			stopErr = fmt.Errorf("city %q did not exit within %s after forced shutdown", mc.name, timeout)
+		case <-time.After(forceTimeout):
+			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, forceTimeout) //nolint:errcheck
+			stopErr = fmt.Errorf("city %q did not exit within %s after forced shutdown", mc.name, forceTimeout)
 		}
 	}
 	if err := shutdownBeadsProvider(cityPath); err != nil {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -4087,6 +4087,57 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 	assertSingleStopWithBenignNoise(t, ops)
 }
 
+func TestStopManagedCityAllowsForcedShutdownToUnwind(t *testing.T) {
+	cityPath := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "ops.log")
+	script := writeSpyScript(t, logFile)
+	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+
+	done := make(chan struct{})
+	time.AfterFunc(60*time.Millisecond, func() {
+		close(done)
+	})
+	closer := &closerSpy{}
+	forceStop := &atomic.Bool{}
+	mc := &managedCity{
+		name:   "bright-lights",
+		cancel: func() {},
+		done:   done,
+		closer: closer,
+		cr: &CityRuntime{
+			cfg: &config.City{
+				Daemon: config.DaemonConfig{
+					ShutdownTimeout: "20ms",
+				},
+			},
+			sp:                runtime.NewFake(),
+			rec:               events.Discard,
+			stdout:            io.Discard,
+			stderr:            io.Discard,
+			forceStopShutdown: forceStop,
+		},
+	}
+
+	var stderr bytes.Buffer
+	err := stopManagedCity(mc, cityPath, &stderr)
+	if err != nil {
+		t.Fatalf("stopManagedCity: %v; stderr=%q", err, stderr.String())
+	}
+	if !forceStop.Load() {
+		t.Fatal("expected forced cleanup to request force-stop shutdown")
+	}
+	if !closer.closed {
+		t.Fatal("expected closer to be closed after forced cleanup")
+	}
+	if strings.Contains(stderr.String(), "after forced shutdown") {
+		t.Fatalf("stderr = %q, want no forced-shutdown timeout", stderr.String())
+	}
+
+	ops := readOpLog(t, logFile)
+	assertSingleStopWithBenignNoise(t, ops)
+}
+
 func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
 	cityPath := t.TempDir()
 	logFile := filepath.Join(t.TempDir(), "ops.log")

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -284,7 +284,7 @@ func TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash(t *testing.T) 
 	cityDir := setupReviewFormulaCity(t, "success", map[string]string{
 		"GC_GRAPH_TRANSIENT_ONCE_SUFFIXES":        "review.attempt.1",
 		"GC_GRAPH_EXIT_AFTER_CLAIM_ONCE_SUFFIXES": "review.attempt.2",
-	})
+	}, reviewFormulaCityOption{explicitPolecatScaleCheck: true})
 	writeLocalFormula(t, cityDir, "mol-retry-recovery-smoke", `description = """
 Minimal pooled retry workflow used to verify crash-before-result recovery.
 """
@@ -343,7 +343,11 @@ on_exhausted = "hard_fail"
 
 // --- helpers ---
 
-func setupReviewFormulaCity(t *testing.T, mode string, extraEnv map[string]string) string {
+type reviewFormulaCityOption struct {
+	explicitPolecatScaleCheck bool
+}
+
+func setupReviewFormulaCity(t *testing.T, mode string, extraEnv map[string]string, opts ...reviewFormulaCityOption) string {
 	t.Helper()
 	env := newIsolatedCommandEnv(t, true)
 
@@ -356,12 +360,19 @@ func setupReviewFormulaCity(t *testing.T, mode string, extraEnv map[string]strin
 	cityDir := filepath.Join(t.TempDir(), cityName)
 
 	startCommand := workflowAgentStartCommand(mode, extraEnv)
+	polecatScaleCheck := ""
+	for _, opt := range opts {
+		if opt.explicitPolecatScaleCheck {
+			check := `ready_json=$(bd ready --metadata-field gc.routed_to=polecat --unassigned --exclude-type=epic --json --limit=0) && printf '%s\n' "$ready_json" | jq 'length'`
+			polecatScaleCheck = fmt.Sprintf("scale_check = %q\n", check)
+		}
+	}
 	cityToml := fmt.Sprintf(
 		"[workspace]\nname = %q\n\n[session]\nprovider = \"subprocess\"\n\n[daemon]\nformula_v2 = true\npatrol_interval = \"100ms\"\n\n"+
 			"[[agent]]\nname = \"worker\"\nmax_active_sessions = 1\nstart_command = %q\n\n"+
 			"[[named_session]]\ntemplate = \"worker\"\nmode = \"always\"\n\n"+
-			"[[agent]]\nname = \"polecat\"\nstart_command = %q\nmin_active_sessions = 0\nmax_active_sessions = 3\n",
-		cityName, startCommand, startCommand,
+			"[[agent]]\nname = \"polecat\"\nstart_command = %q\nmin_active_sessions = 0\nmax_active_sessions = 3\n%s",
+		cityName, startCommand, startCommand, polecatScaleCheck,
 	)
 	configPath := filepath.Join(t.TempDir(), "review-formula.toml")
 	if err := os.WriteFile(configPath, []byte(cityToml), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- give forced city shutdown a longer post-force unwind window before reporting async unregister failure
- add unit coverage for the forced-shutdown unwind case
- make the pooled retry recovery fixture use an explicit live polecat scale_check so the test exercises retry recovery rather than cache-event timing

## Verification
- go test ./cmd/gc -run 'TestStopManagedCity|TestDefaultScaleCheckCountsUsesCachedReadyReadModel' -count=1\n- go test -tags=integration ./test/integration -run '^TestHumaBinary_CityUnregisterAsync$' -count=1 -v -timeout 5m\n- pooled retry local run: local harness killed the shell before Go printed PASS, but the temp-city trace showed polecat slot creation, attempt.1 transient close, attempt.2 crash after claim, resume, close pass, and workflow root closed with gc.outcome=pass; CI review-formulas recovery is the authoritative shard\n\nHooks remained disabled locally with core.hooksPath=/dev/null; no bd import hook was run.