### PR TITLE
fix(events): complete archive rotation retention gaps

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1251,7 +1251,7 @@ gc help [command]
 
 Checks for available work using the agent's work_query config.
 
-Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
+Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -281,11 +281,28 @@ func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) 
 	return reversed, nil
 }
 
-// ReadLatestSeq returns the latest complete event Seq in the events file, or
-// 0 if the file is missing or empty. Event logs are append-only and sequence
-// numbers are monotonic, so this reads backward from the tail instead of
-// parsing historical events on every recorder open.
+// ReadLatestSeq returns the highest complete event Seq visible in the
+// active events file or any canonical sibling archive. Event logs are
+// append-only and sequence numbers are monotonic, so the active file
+// is read backward from the tail and archives contribute their
+// filename-encoded LastSeq without being gunzipped.
 func ReadLatestSeq(path string) (uint64, error) {
+	seq, err := readLatestActiveSeq(path)
+	if err != nil {
+		return 0, err
+	}
+	archives, err := archiveFilesIn(filepath.Dir(path))
+	if err == nil {
+		for _, info := range archives {
+			if info.LastSeq > seq {
+				seq = info.LastSeq
+			}
+		}
+	}
+	return seq, nil
+}
+
+func readLatestActiveSeq(path string) (uint64, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -50,6 +50,7 @@ type FileRecorder struct {
 	maxSize               int64
 	rotationCheckRecords  int
 	rotationCheckInterval time.Duration
+	archiveRetainAge      time.Duration
 	recordCount           uint64
 	lastSizeCheck         time.Time
 }
@@ -80,6 +81,13 @@ func WithRotationCheckRecords(n int) FileRecorderOption {
 // once per interval. Defaults to 60s.
 func WithRotationCheckInterval(d time.Duration) FileRecorderOption {
 	return func(r *FileRecorder) { r.rotationCheckInterval = d }
+}
+
+// WithArchiveRetainAge sets the maximum age of canonical archive
+// files kept after a successful rotation. A non-positive value keeps
+// all archives forever.
+func WithArchiveRetainAge(d time.Duration) FileRecorderOption {
+	return func(r *FileRecorder) { r.archiveRetainAge = d }
 }
 
 // RotationResult is returned by ForceRotate (and B-3's API endpoint)
@@ -146,19 +154,6 @@ func NewFileRecorder(path string, stderr io.Writer, opts ...FileRecorderOption) 
 		return nil, err
 	}
 
-	// Crash recovery: if a prior process rotated events into archives
-	// but the active log is empty or absent, ReadLatestSeq returns 0
-	// and new records would collide with seqs already written to disk.
-	// Take the max of the active tail and every archive's LastSeq so
-	// the next Record continues monotonically across rotations.
-	if archives, archErr := archiveFilesIn(filepath.Dir(path)); archErr == nil {
-		for _, info := range archives {
-			if info.LastSeq > maxSeq {
-				maxSeq = info.LastSeq
-			}
-		}
-	}
-
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("opening event log: %w", err)
@@ -218,7 +213,7 @@ func (r *FileRecorder) Record(e Event) {
 // flock. Returns an error on marshal or write failure; the caller
 // decides whether to log to stderr or surface it.
 func (r *FileRecorder) writeRecordLocked(e *Event) error {
-	if latest, err := ReadLatestSeq(r.path); err == nil && latest > r.seq {
+	if latest, err := readLatestActiveSeq(r.path); err == nil && latest > r.seq {
 		r.seq = latest
 	} else if err != nil {
 		return fmt.Errorf("latest seq: %w", err)
@@ -370,6 +365,7 @@ func (r *FileRecorder) rotateLocked() (RotationResult, error) {
 	}
 
 	done := make(chan struct{})
+	retainAge := r.archiveRetainAge
 	r.rotations.Add(1)
 	go func() {
 		defer r.rotations.Done()
@@ -377,6 +373,10 @@ func (r *FileRecorder) rotateLocked() (RotationResult, error) {
 		if err := gzipAndArchive(rotatingPath, archivePath, r.stderr); err != nil {
 			// gzipAndArchive already wrote to stderr.
 			_ = err
+			return
+		}
+		if err := reapExpiredArchives(dir, retainAge, r.stderr); err != nil {
+			fmt.Fprintf(r.stderr, "events: rotation: archive retention: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
 	}()
 

--- a/internal/events/rotation.go
+++ b/internal/events/rotation.go
@@ -135,6 +135,34 @@ func reapOrphanedRotatingFiles(dir string, stderr io.Writer) error {
 	return nil
 }
 
+// reapExpiredArchives removes canonical archive files older than
+// retainAge. A non-positive retainAge is a no-op. Archive age is
+// based on the UTC timestamp embedded in the canonical filename, so
+// pruning does not need to open or gunzip archive contents.
+func reapExpiredArchives(dir string, retainAge time.Duration, stderr io.Writer) error {
+	if retainAge <= 0 {
+		return nil
+	}
+	archives, err := archiveFilesIn(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	cutoff := time.Now().UTC().Add(-retainAge)
+	for _, info := range archives {
+		if !info.Timestamp.Before(cutoff) {
+			continue
+		}
+		path := filepath.Join(dir, info.Basename)
+		if err := os.Remove(path); err != nil {
+			fmt.Fprintf(stderr, "events: rotation: removing expired archive %q: %v\n", info.Basename, err) //nolint:errcheck // best-effort stderr
+		}
+	}
+	return nil
+}
+
 // archiveRotatingFile is the per-file branch of the reaper. The
 // rotating filename embeds the timestamp and seq window so the
 // archive name can be derived without scanning content. For legacy

--- a/internal/events/rotation_auto_test.go
+++ b/internal/events/rotation_auto_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestRecordAutoRotatesOnSizeThreshold drives the size-gated rotation
@@ -115,6 +116,38 @@ func TestRecordAutoRotateDisabledByZeroMaxSize(t *testing.T) {
 		if strings.HasPrefix(e.Name(), "events.jsonl.rotating-") {
 			t.Errorf("unexpected rotating file %q with MaxSize=0", e.Name())
 		}
+	}
+}
+
+func TestArchiveRetainAgePrunesOldArchivesAfterRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	oldArchive := filepath.Join(dir, formatArchiveBasename(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), 1, 1))
+	if err := os.WriteFile(oldArchive, []byte("stale archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr, WithArchiveRetainAge(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human"})
+	res, err := rec.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate: %v", err)
+	}
+	if res.Done != nil {
+		<-res.Done
+	}
+
+	if _, err := os.Stat(oldArchive); !os.IsNotExist(err) {
+		t.Fatalf("old archive should be pruned by retain age, stat err = %v", err)
+	}
+	if _, err := os.Stat(res.ArchivePath); err != nil {
+		t.Fatalf("fresh archive should remain after retention pruning: %v", err)
 	}
 }
 

--- a/internal/events/rotation_reader_test.go
+++ b/internal/events/rotation_reader_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // seedRecorderWithRotation creates a fresh recorder, writes recordsBefore
@@ -130,6 +131,33 @@ func TestReadFilteredAcrossArchivesAppliesLimit(t *testing.T) {
 	}
 	if got[0].Seq != 1 || got[1].Seq != 2 {
 		t.Errorf("got seqs = [%d,%d], want [1,2]", got[0].Seq, got[1].Seq)
+	}
+}
+
+func TestReadLatestSeqSpansArchiveOnlyLog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+
+	rotating := filepath.Join(dir, "events.jsonl.rotating-20260507T120000Z-seq-100-102")
+	const body = `{"seq":100,"type":"x"}
+{"seq":101,"type":"y"}
+{"seq":102,"type":"z"}
+`
+	if err := os.WriteFile(rotating, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(dir, formatArchiveBasename(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC), 100, 102))
+	var stderr bytes.Buffer
+	if err := gzipAndArchive(rotating, dest, &stderr); err != nil {
+		t.Fatalf("gzipAndArchive: %v", err)
+	}
+
+	seq, err := ReadLatestSeq(path)
+	if err != nil {
+		t.Fatalf("ReadLatestSeq: %v", err)
+	}
+	if seq != 102 {
+		t.Fatalf("ReadLatestSeq archive-only = %d, want 102", seq)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add WithArchiveRetainAge and prune expired canonical event archives after successful gzip rotation
- make public ReadLatestSeq archive-aware while keeping Record() on the active-file tail path
- cover archive-only latest-seq reads and age-based archive retention with focused tests

## Validation
- go test ./internal/events -run 'TestReadLatestSeqSpansArchiveOnlyLog|TestArchiveRetainAgePrunesOldArchivesAfterRotation' -count=1\n- go test ./internal/events/... -count=1\n- go test ./internal/events -run '^$' -bench '^BenchmarkRecord$' -benchtime=1000x\n- go test ./internal/api -run TestEveryKnownEventTypeHasRegisteredPayload -count=1\n- go test ./internal/events/... -count=1 -race\n- git diff --check\n- go vet ./...\n- go build ./...\n- make test-fast-parallel\n- .githooks/pre-commit (includes observable go test ./...)\n\nNote: actual status could not be run in this worktree because the actual CLI was not installed.