### PR TITLE
Add JSON output for session peek and logs

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1478,12 +1478,13 @@ func parsePruneDuration(s string) (time.Duration, error) {
 // newSessionPeekCmd creates the "gc session peek <id-or-alias>" command.
 func newSessionPeekCmd(stdout, stderr io.Writer) *cobra.Command {
 	var lines int
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "peek <session-id-or-alias>",
 		Short: "View session output without attaching",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionPeek(args, lines, stdout, stderr) != 0 {
+			if cmdSessionPeek(args, lines, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -1491,11 +1492,21 @@ func newSessionPeekCmd(stdout, stderr io.Writer) *cobra.Command {
 		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().IntVar(&lines, "lines", 50, "number of lines to capture")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL result")
 	return cmd
 }
 
+type sessionPeekJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	SessionID     string `json:"session_id"`
+	Target        string `json:"target"`
+	Lines         int    `json:"lines"`
+	LineCount     int    `json:"line_count"`
+	Output        string `json:"output"`
+}
+
 // cmdSessionPeek is the CLI entry point for "gc session peek".
-func cmdSessionPeek(args []string, lines int, stdout, stderr io.Writer) int {
+func cmdSessionPeek(args []string, lines int, jsonOutput bool, stdout, stderr io.Writer) int {
 	store, code := openCityStore(stderr, "gc session peek")
 	if store == nil {
 		return code
@@ -1525,11 +1536,37 @@ func cmdSessionPeek(args []string, lines int, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	if jsonOutput {
+		if err := writeCLIJSONLine(stdout, sessionPeekJSONResult{
+			SchemaVersion: "1",
+			SessionID:     sessionID,
+			Target:        args[0],
+			Lines:         lines,
+			LineCount:     outputLineCount(output),
+			Output:        output,
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc session peek: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return 0
+	}
+
 	fmt.Fprint(stdout, output) //nolint:errcheck // best-effort stdout
 	if !strings.HasSuffix(output, "\n") {
 		fmt.Fprintln(stdout) //nolint:errcheck // best-effort stdout
 	}
 	return 0
+}
+
+func outputLineCount(output string) int {
+	if output == "" {
+		return 0
+	}
+	count := strings.Count(output, "\n")
+	if !strings.HasSuffix(output, "\n") {
+		count++
+	}
+	return count
 }
 
 // newSessionKillCmd creates the "gc session kill <id-or-alias>" command.

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -21,6 +21,7 @@ import (
 func newSessionLogsCmd(stdout, stderr io.Writer) *cobra.Command {
 	var follow bool
 	var tail int
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "logs <session>",
 		Short: "Show session logs for a session",
@@ -48,7 +49,7 @@ Use -f to follow new messages as they arrive.`,
   gc session logs s-gc-123 -f`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionLogs(args, follow, tail, stdout, stderr) != 0 {
+			if cmdSessionLogs(args, follow, tail, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -57,11 +58,12 @@ Use -f to follow new messages as they arrive.`,
 	}
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow new messages as they arrive")
 	cmd.Flags().IntVar(&tail, "tail", 10, "Number of most recent transcript entries to show (0 = all; compact dividers count as entries)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL result for the bounded snapshot")
 	return cmd
 }
 
 // cmdSessionLogs is the CLI entry point for viewing session logs.
-func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writer) int {
+func cmdSessionLogs(args []string, follow bool, tail int, jsonOutput bool, stdout, stderr io.Writer) int {
 	identifier := args[0]
 
 	cityPath, err := resolveCity()
@@ -104,6 +106,9 @@ func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writ
 		return 1
 	}
 
+	if jsonOutput {
+		return doSessionLogsJSON(path, provider, identifier, follow, tail, stdout, stderr)
+	}
 	return doSessionLogs(path, provider, follow, tail, stdout, stderr)
 }
 
@@ -362,6 +367,107 @@ func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr 
 }
 
 type sessionLogsReader func(factory *worker.Factory, provider, path string) (*worker.TranscriptSession, error)
+
+type sessionLogsJSONResult struct {
+	SchemaVersion  string                `json:"schema_version"`
+	Target         string                `json:"target"`
+	Provider       string                `json:"provider,omitempty"`
+	TranscriptPath string                `json:"transcript_path"`
+	Tail           int                   `json:"tail"`
+	EntryCount     int                   `json:"entry_count"`
+	Entries        []sessionLogEntryJSON `json:"entries"`
+}
+
+type sessionLogEntryJSON struct {
+	UUID            string                          `json:"uuid,omitempty"`
+	ParentUUID      string                          `json:"parent_uuid,omitempty"`
+	Type            string                          `json:"type"`
+	Subtype         string                          `json:"subtype,omitempty"`
+	Role            string                          `json:"role,omitempty"`
+	Timestamp       string                          `json:"timestamp,omitempty"`
+	CompactBoundary bool                            `json:"compact_boundary,omitempty"`
+	Text            string                          `json:"text,omitempty"`
+	Blocks          []worker.TranscriptContentBlock `json:"blocks,omitempty"`
+	Message         json.RawMessage                 `json:"message,omitempty"`
+}
+
+func doSessionLogsJSON(path, provider, target string, follow bool, tail int, stdout, stderr io.Writer) int {
+	if follow {
+		fmt.Fprintln(stderr, "gc session logs: --json is only supported for bounded snapshots; omit --follow") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if tail < 0 {
+		fmt.Fprintln(stderr, "gc session logs: --tail must be >= 0") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	factory, err := worker.NewFactory(worker.FactoryConfig{})
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session logs: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return runSessionLogsJSON(factory, provider, path, target, tail, stdout, stderr, readSessionFile)
+}
+
+func runSessionLogsJSON(factory *worker.Factory, provider, path, target string, tail int, stdout, stderr io.Writer, read sessionLogsReader) int {
+	sess, readErr := read(factory, provider, path)
+	if readErr != nil {
+		fmt.Fprintf(stderr, "gc session logs: %v\n", readErr) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	messages := tailMessages(sess.Messages, tail)
+	entries := make([]sessionLogEntryJSON, 0, len(messages))
+	for _, msg := range messages {
+		entries = append(entries, sessionLogEntryToJSON(msg))
+	}
+	if err := writeCLIJSONLine(stdout, sessionLogsJSONResult{
+		SchemaVersion:  "1",
+		Target:         target,
+		Provider:       provider,
+		TranscriptPath: path,
+		Tail:           tail,
+		EntryCount:     len(entries),
+		Entries:        entries,
+	}); err != nil {
+		fmt.Fprintf(stderr, "gc session logs: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return 0
+}
+
+func sessionLogEntryToJSON(e *worker.TranscriptEntry) sessionLogEntryJSON {
+	if e == nil {
+		return sessionLogEntryJSON{}
+	}
+	entry := sessionLogEntryJSON{
+		UUID:            e.UUID,
+		ParentUUID:      e.ParentUUID,
+		Type:            e.Type,
+		Subtype:         e.Subtype,
+		CompactBoundary: e.IsCompactBoundary(),
+	}
+	if !e.Timestamp.IsZero() {
+		entry.Timestamp = e.Timestamp.Format(time.RFC3339Nano)
+	}
+	if len(e.Message) > 0 {
+		entry.Message = e.Message
+	}
+	mc := resolveMessage(e.Message)
+	if mc == nil {
+		return entry
+	}
+	entry.Role = mc.Role
+	var text string
+	if json.Unmarshal(mc.Content, &text) == nil {
+		entry.Text = text
+		return entry
+	}
+	var blocks []worker.TranscriptContentBlock
+	if json.Unmarshal(mc.Content, &blocks) == nil && len(blocks) > 0 {
+		entry.Blocks = blocks
+	}
+	return entry
+}
 
 func runSessionLogs(factory *worker.Factory, provider, path string, follow bool, tail int, stdout, stderr io.Writer, sleep func(time.Duration), read sessionLogsReader) int {
 	// Always read the full session; apply tail trimming locally so semantics

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -617,6 +618,87 @@ func TestDoSessionLogsFollowTailShowsOnlyNewMessagesOnReadErrorExit(t *testing.T
 	}
 	if !strings.Contains(stderr.String(), "5 consecutive read errors") {
 		t.Fatalf("stderr should report the injected termination condition, got: %s", stderr.String())
+	}
+}
+
+func TestCmdSessionLogsJSONSuccessIsJSONOnly(t *testing.T) {
+	clearGCEnv(t)
+	clearInheritedCityRoutingEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	searchBase := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(fmt.Sprintf(`[workspace]
+name = "test"
+
+[daemon]
+observe_paths = [%q]
+`, searchBase)), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(%q): %v", cityDir, err)
+	}
+	b, err := store.Create(beads.Bead{
+		Title:  "json logs session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "runtime-session",
+			"session_key":  "known-session",
+			"provider":     "claude",
+			"template":     "worker",
+			"state":        "asleep",
+			"work_dir":     workDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session): %v", err)
+	}
+	writeNamedTestSession(t, searchBase, workDir, "known-session.jsonl",
+		`{"uuid":"1","parentUuid":"","type":"user","message":{"role":"user","content":"older"},"timestamp":"2025-01-01T00:00:00Z"}`,
+		`{"uuid":"2","parentUuid":"1","type":"assistant","message":{"role":"assistant","content":"newer"},"timestamp":"2025-01-01T00:00:01Z"}`,
+	)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionLogs([]string{b.ID}, false, 1, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionLogs(--json) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1 JSONL record: %q", len(lines), stdout.String())
+	}
+	var got sessionLogsJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not parseable JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.Target != b.ID || got.Tail != 1 || got.EntryCount != 1 {
+		t.Fatalf("logs JSON metadata = %+v", got)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].Text != "newer" || got.Entries[0].Role != "assistant" {
+		t.Fatalf("logs JSON entries = %+v", got.Entries)
+	}
+}
+
+func TestDoSessionLogsJSONRejectsFollow(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := doSessionLogsJSON("/ignored", "claude", "worker", true, 10, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doSessionLogsJSON(follow) = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--json is only supported for bounded snapshots") {
+		t.Fatalf("stderr = %q, want bounded snapshot diagnostic", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1303,6 +1303,63 @@ func TestCmdSessionListJSONOmitZeroLastNudgeDeliveredAt(t *testing.T) {
 	}
 }
 
+func TestCmdSessionPeekJSONSuccessIsJSONOnly(t *testing.T) {
+	clearGCEnv(t)
+	clearInheritedCityRoutingEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+
+	fakeProvider := runtime.NewFake()
+	fakeProvider.SetPeekOutput("runtime-session", "hello\nworld\n")
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(%q): %v", cityDir, err)
+	}
+	b, err := store.Create(beads.Bead{
+		Title:  "json peek session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "runtime-session",
+			"template":     "worker",
+			"state":        "awake",
+			"work_dir":     cityDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionPeek([]string{b.ID}, 2, true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionPeek(--json) = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1 JSONL record: %q", len(lines), stdout.String())
+	}
+	var got sessionPeekJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not parseable JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.SessionID != b.ID || got.Output != "hello\nworld\n" || got.LineCount != 2 {
+		t.Fatalf("peek JSON = %+v", got)
+	}
+}
+
 func sessionListJSONRowBySessionName(rows []map[string]any, name string) map[string]any {
 	for _, row := range rows {
 		if row["SessionName"] == name {

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -53,6 +53,41 @@ func TestJSONSchemaManifestForSupportedCommand(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaManifestForSessionDetailCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"session", "peek", "example", "--json-schema"},
+		{"session", "logs", "example", "--json-schema"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%v) = %d, stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var manifest struct {
+				SchemaVersion string                     `json:"schema_version"`
+				JSONSupported bool                       `json:"json_supported"`
+				Schemas       map[string]json.RawMessage `json:"schemas"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+				t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+			}
+			if manifest.SchemaVersion != "1" || !manifest.JSONSupported {
+				t.Fatalf("manifest metadata = %+v", manifest)
+			}
+			if !json.Valid(manifest.Schemas["result"]) {
+				t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
+			}
+			if !json.Valid(manifest.Schemas["failure"]) {
+				t.Fatalf("failure schema missing or invalid: %s", manifest.Schemas["failure"])
+			}
+		})
+	}
+}
+
 func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"version", "--json-schema"}, &stdout, &stderr)

--- a/schemas/session/logs/result.schema.json
+++ b/schemas/session/logs/result.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": true,
+  "type": "object",
+  "required": ["schema_version", "target", "transcript_path", "tail", "entry_count", "entries"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "target": { "type": "string" },
+    "provider": { "type": "string" },
+    "transcript_path": { "type": "string" },
+    "tail": { "type": "integer", "minimum": 0 },
+    "entry_count": { "type": "integer", "minimum": 0 },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "uuid": { "type": "string" },
+          "parent_uuid": { "type": "string" },
+          "type": { "type": "string" },
+          "subtype": { "type": "string" },
+          "role": { "type": "string" },
+          "timestamp": { "type": "string" },
+          "compact_boundary": { "type": "boolean" },
+          "text": { "type": "string" },
+          "blocks": { "type": "array" },
+          "message": true
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/session/peek/result.schema.json
+++ b/schemas/session/peek/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": true,
+  "type": "object",
+  "required": ["schema_version", "session_id", "target", "lines", "line_count", "output"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "session_id": { "type": "string" },
+    "target": { "type": "string" },
+    "lines": { "type": "integer" },
+    "line_count": { "type": "integer", "minimum": 0 },
+    "output": { "type": "string" }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- add JSONL result output for `gc session peek <id> --json`
- add bounded snapshot JSONL output for `gc session logs <id> --json`
- declare result schemas for both session detail commands

## JSON compatibility
- `gc session peek <id> --json` is newly supported and emits one JSONL result record with `schema_version: "1"`.
- `gc session logs <id> --json` is newly supported only for bounded non-follow snapshots and emits one JSONL result record with `schema_version: "1"`.
- `gc session logs <id> --json --follow` is intentionally unsupported because follow mode is unbounded; it exits with the platform failure JSON path.
- Human output remains the default for both commands.

## Validation
- `go test ./cmd/gc -run 'Test(CmdSessionPeekJSONSuccessIsJSONOnly|CmdSessionLogsJSONSuccessIsJSONOnly|DoSessionLogsJSONRejectsFollow|DoSessionLogs|JSONSchema)'`\n- `git diff --check`\n- `make fmt-check`\n- `make vet`\n- `make check-docs`\n- `GOOS=linux make lint`\n\nNote: an extra exploratory `go test ./cmd/gc` run ended with tool session code `-1` and no Go output before completion; the required focused and repo gates above passed.