### PR TITLE
feat: add JSON for misc inspection commands

### DIFF
--- a/cmd/gc/cmd_mcp.go
+++ b/cmd/gc/cmd_mcp.go
@@ -40,6 +40,7 @@ the agent has a single deterministic projection target from config, or
 func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 	var agentName string
 	var sessionID string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Show projected MCP servers",
@@ -98,13 +99,117 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 
+			if jsonOutput {
+				if err := writeCLIJSONLine(stdout, projectedMCPJSONFromView(cityPath, view, agentName, sessionID)); err != nil {
+					fmt.Fprintf(stderr, "gc mcp list: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				return nil
+			}
 			writeProjectedMCPView(stdout, cityPath, view)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&agentName, "agent", "", "show the projected MCP config for this agent")
 	cmd.Flags().StringVar(&sessionID, "session", "", "show the projected MCP config for this session")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output one JSONL result record")
 	return cmd
+}
+
+type projectedMCPJSON struct {
+	SchemaVersion string                   `json:"schema_version"`
+	CityPath      string                   `json:"city_path"`
+	Query         projectedMCPQueryJSON    `json:"query"`
+	Projection    projectedMCPTargetJSON   `json:"projection"`
+	Servers       []projectedMCPServerJSON `json:"servers"`
+	Shadows       []projectedMCPShadowJSON `json:"shadows,omitempty"`
+}
+
+type projectedMCPQueryJSON struct {
+	Agent   string `json:"agent,omitempty"`
+	Session string `json:"session,omitempty"`
+}
+
+type projectedMCPTargetJSON struct {
+	Provider     string `json:"provider"`
+	Target       string `json:"target"`
+	WorkDir      string `json:"work_dir,omitempty"`
+	Delivery     string `json:"delivery,omitempty"`
+	ScopeRoot    string `json:"scope_root,omitempty"`
+	Identity     string `json:"identity,omitempty"`
+	ProviderKind string `json:"provider_kind,omitempty"`
+}
+
+type projectedMCPServerJSON struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Transport   string   `json:"transport"`
+	Command     string   `json:"command,omitempty"`
+	Args        []string `json:"args,omitempty"`
+	URL         string   `json:"url,omitempty"`
+	Source      string   `json:"source"`
+	Layer       string   `json:"layer,omitempty"`
+	Origin      string   `json:"origin,omitempty"`
+	Template    bool     `json:"template,omitempty"`
+	EnvKeys     []string `json:"env_keys,omitempty"`
+	HeaderKeys  []string `json:"header_keys,omitempty"`
+}
+
+type projectedMCPShadowJSON struct {
+	Name       string `json:"name"`
+	Winner     string `json:"winner"`
+	Loser      string `json:"loser"`
+	WinnerFile string `json:"winner_file"`
+	LoserFile  string `json:"loser_file"`
+}
+
+func projectedMCPJSONFromView(cityPath string, view resolvedMCPProjection, agentName, sessionID string) projectedMCPJSON {
+	servers := make([]projectedMCPServerJSON, 0, len(view.Catalog.Servers))
+	for _, server := range view.Catalog.Servers {
+		servers = append(servers, projectedMCPServerJSON{
+			Name:        server.Name,
+			Description: server.Description,
+			Transport:   string(server.Transport),
+			Command:     server.Command,
+			Args:        append([]string(nil), server.Args...),
+			URL:         server.URL,
+			Source:      displayMCPSourcePath(cityPath, server.SourceFile),
+			Layer:       server.Layer,
+			Origin:      server.Origin,
+			Template:    server.Template,
+			EnvKeys:     sortedMCPKeys(server.Env),
+			HeaderKeys:  sortedMCPKeys(server.Headers),
+		})
+	}
+	shadows := make([]projectedMCPShadowJSON, 0, len(view.Catalog.Shadows))
+	for _, shadow := range view.Catalog.Shadows {
+		shadows = append(shadows, projectedMCPShadowJSON{
+			Name:       shadow.Name,
+			Winner:     shadow.Winner,
+			Loser:      shadow.Loser,
+			WinnerFile: displayMCPSourcePath(cityPath, shadow.WinnerFile),
+			LoserFile:  displayMCPSourcePath(cityPath, shadow.LoserFile),
+		})
+	}
+	return projectedMCPJSON{
+		SchemaVersion: "1",
+		CityPath:      cityPath,
+		Query: projectedMCPQueryJSON{
+			Agent:   agentName,
+			Session: sessionID,
+		},
+		Projection: projectedMCPTargetJSON{
+			Provider:     view.Projection.Provider,
+			Target:       view.Projection.Target,
+			WorkDir:      view.WorkDir,
+			Delivery:     view.Delivery,
+			ScopeRoot:    view.ScopeRoot,
+			Identity:     view.Identity,
+			ProviderKind: view.ProviderKind,
+		},
+		Servers: servers,
+		Shadows: shadows,
+	}
 }
 
 func writeProjectedMCPView(w io.Writer, cityPath string, view resolvedMCPProjection) {
@@ -158,12 +263,16 @@ func formatMCPKeyNames(values map[string]string) string {
 	if len(values) == 0 {
 		return "-"
 	}
+	return strings.Join(sortedMCPKeys(values), ",")
+}
+
+func sortedMCPKeys(values map[string]string) []string {
 	keys := make([]string, 0, len(values))
 	for key := range values {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	return strings.Join(keys, ",")
+	return keys
 }
 
 func displayMCPSourcePath(cityPath, path string) string {

--- a/cmd/gc/cmd_mcp_test.go
+++ b/cmd/gc/cmd_mcp_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,12 +60,14 @@ provider = "tmux"
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
-name = "mayor"
-provider = "gemini"
-scope = "city"
 `)
+	agentDir := filepath.Join(cityDir, "agents", "mayor")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(agentDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("provider = \"gemini\"\nscope = \"city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(agent.toml): %v", err)
+	}
 	writeCatalogFile(t, cityDir, "mcp/notes.toml", `
 name = "notes"
 command = "npx"
@@ -94,6 +97,72 @@ API_TOKEN = "super-secret"
 	}
 	if strings.Contains(out, "super-secret") {
 		t.Fatalf("mcp list output leaked env value:\n%s", out)
+	}
+}
+
+func TestMcpListAgentJSON(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeProjectedMCPCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[session]
+provider = "tmux"
+
+[providers.gemini]
+command = "echo"
+prompt_mode = "none"
+`)
+	agentDir := filepath.Join(cityDir, "agents", "mayor")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(agentDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("provider = \"gemini\"\nscope = \"city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(agent.toml): %v", err)
+	}
+	writeCatalogFile(t, cityDir, "mcp/notes.toml", `
+name = "notes"
+command = "npx"
+args = ["@acme/notes"]
+
+[env]
+API_TOKEN = "super-secret"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"mcp", "list", "--agent", "mayor", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc mcp list --agent --json exited %d: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var got projectedMCPJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.CityPath != cityDir || got.Query.Agent != "mayor" {
+		t.Fatalf("metadata = %+v", got)
+	}
+	if got.Projection.Provider != "gemini" || got.Projection.Target == "" {
+		t.Fatalf("projection = %+v", got.Projection)
+	}
+	if len(got.Servers) != 1 {
+		t.Fatalf("servers len = %d, want 1: %+v", len(got.Servers), got.Servers)
+	}
+	if got.Servers[0].Name != "notes" || strings.Join(got.Servers[0].EnvKeys, ",") != "API_TOKEN" {
+		t.Fatalf("server = %+v", got.Servers[0])
+	}
+	if strings.Contains(stdout.String(), "super-secret") {
+		t.Fatalf("mcp list JSON leaked env value:\n%s", stdout.String())
 	}
 }
 

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -125,8 +125,9 @@ func doUnregister(args []string, stdout, stderr io.Writer) int {
 }
 
 func newCitiesCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOutput bool
 	runList := func(_ *cobra.Command, _ []string) error {
-		if doCities(stdout, stderr) != 0 {
+		if doCities(jsonOutput, stdout, stderr) != 0 {
 			return errExit
 		}
 		return nil
@@ -138,22 +139,56 @@ func newCitiesCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  runList,
 	}
-	cmd.AddCommand(&cobra.Command{
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output one JSONL result record")
+	listCmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List registered cities",
 		Aliases: []string{"ls"},
 		Args:    cobra.NoArgs,
 		RunE:    runList,
-	})
+	}
+	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output one JSONL result record")
+	cmd.AddCommand(listCmd)
 	return cmd
 }
 
-func doCities(stdout, stderr io.Writer) int {
-	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+type citiesListJSON struct {
+	SchemaVersion string             `json:"schema_version"`
+	RegistryPath  string             `json:"registry_path"`
+	Cities        []cityRegistryJSON `json:"cities"`
+}
+
+type cityRegistryJSON struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+func doCities(jsonOutput bool, stdout, stderr io.Writer) int {
+	registryPath := supervisor.RegistryPath()
+	reg := supervisor.NewRegistry(registryPath)
 	entries, err := reg.List()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc cities: %v\n", err) //nolint:errcheck
 		return 1
+	}
+
+	if jsonOutput {
+		cities := make([]cityRegistryJSON, 0, len(entries))
+		for _, e := range entries {
+			cities = append(cities, cityRegistryJSON{
+				Name: e.EffectiveName(),
+				Path: e.Path,
+			})
+		}
+		if err := writeCLIJSONLine(stdout, citiesListJSON{
+			SchemaVersion: "1",
+			RegistryPath:  registryPath,
+			Cities:        cities,
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc cities: writing JSON: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		return 0
 	}
 
 	if len(entries) == 0 {

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -414,7 +415,7 @@ func TestDoCities(t *testing.T) {
 
 	// Empty list.
 	var stdout, stderr bytes.Buffer
-	code := doCities(&stdout, &stderr)
+	code := doCities(false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("expected exit 0, got %d", code)
 	}
@@ -437,12 +438,36 @@ func TestDoCities(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code = doCities(&stdout, &stderr)
+	code = doCities(false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("expected exit 0, got %d", code)
 	}
 	if !strings.Contains(stdout.String(), "bright-lights") {
 		t.Errorf("expected 'bright-lights' in output, got: %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = run([]string{"cities", "list", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc cities list --json exit %d: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var got citiesListJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" {
+		t.Fatalf("schema_version = %q, want 1", got.SchemaVersion)
+	}
+	if len(got.Cities) != 1 || got.Cities[0].Name != "bright-lights" || got.Cities[0].Path != cityPath {
+		t.Fatalf("cities = %+v, want bright-lights at %s", got.Cities, cityPath)
 	}
 }
 

--- a/cmd/gc/cmd_shell.go
+++ b/cmd/gc/cmd_shell.go
@@ -68,18 +68,19 @@ func newShellRemoveCmd(stdout, stderr io.Writer) *cobra.Command {
 	}
 }
 
-func newShellStatusCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+func newShellStatusCmd(stdout, _ io.Writer) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show shell integration status",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdShellStatus(stdout, stderr) != 0 {
-				return errExit
-			}
+			cmdShellStatus(jsonOutput, stdout)
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output one JSONL result record")
+	return cmd
 }
 
 // detectShell returns "bash", "zsh", or "fish" from the SHELL env var.
@@ -321,8 +322,25 @@ func cmdShellRemove(stdout, stderr io.Writer) int {
 	return 0
 }
 
-func cmdShellStatus(stdout, _ io.Writer) int {
+type shellStatusJSON struct {
+	SchemaVersion string                 `json:"schema_version"`
+	Installed     bool                   `json:"installed"`
+	Shells        []shellStatusShellJSON `json:"shells"`
+}
+
+type shellStatusShellJSON struct {
+	Shell                  string `json:"shell"`
+	Status                 string `json:"status"`
+	Installed              bool   `json:"installed"`
+	CompletionScriptPath   string `json:"completion_script_path"`
+	CompletionScriptExists bool   `json:"completion_script_exists"`
+	RCPath                 string `json:"rc_path"`
+	RCHookPresent          bool   `json:"rc_hook_present"`
+}
+
+func cmdShellStatus(jsonOutput bool, stdout io.Writer) {
 	found := false
+	statuses := make([]shellStatusShellJSON, 0, 3)
 	for _, sh := range []string{"bash", "zsh", "fish"} {
 		compFile, err := completionFile(sh)
 		if err != nil {
@@ -359,16 +377,45 @@ func cmdShellStatus(stdout, _ io.Writer) int {
 			} else if !hasScript && hasHook {
 				status = "RC hook present but completion script missing"
 			}
+			statuses = append(statuses, shellStatusShellJSON{
+				Shell:                  sh,
+				Status:                 status,
+				Installed:              hasScript && hasHook,
+				CompletionScriptPath:   compFile,
+				CompletionScriptExists: hasScript,
+				RCPath:                 rcFile,
+				RCHookPresent:          hasHook,
+			})
+			if jsonOutput {
+				continue
+			}
 			fmt.Fprintf(stdout, "%s: %s\n", sh, status)     //nolint:errcheck // best-effort stdout
 			fmt.Fprintf(stdout, "  script: %s\n", compFile) //nolint:errcheck // best-effort stdout
 			fmt.Fprintf(stdout, "  rc:     %s\n", rcFile)   //nolint:errcheck // best-effort stdout
+		} else {
+			statuses = append(statuses, shellStatusShellJSON{
+				Shell:                  sh,
+				Status:                 "not installed",
+				Installed:              false,
+				CompletionScriptPath:   compFile,
+				CompletionScriptExists: false,
+				RCPath:                 rcFile,
+				RCHookPresent:          false,
+			})
 		}
+	}
+	if jsonOutput {
+		_ = writeCLIJSONLine(stdout, shellStatusJSON{
+			SchemaVersion: "1",
+			Installed:     found,
+			Shells:        statuses,
+		})
+		return
 	}
 	if !found {
 		fmt.Fprintln(stdout, "Shell integration is not installed.") //nolint:errcheck // best-effort stdout
 		fmt.Fprintln(stdout, "Run: gc shell install")               //nolint:errcheck // best-effort stdout
 	}
-	return 0
 }
 
 // ── RC file manipulation ────────────────────────────────────────────────

--- a/cmd/gc/cmd_shell_test.go
+++ b/cmd/gc/cmd_shell_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -303,11 +304,8 @@ func TestShellStatusTracksBashProfileInstall(t *testing.T) {
 	// Simulate a later shell session creating .bashrc after install.
 	shellTestWriteFile(t, filepath.Join(home, ".bashrc"), "# created later\n")
 
-	var stdout, stderr bytes.Buffer
-	code = cmdShellStatus(&stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("status exit %d: %s", code, stderr.String())
-	}
+	var stdout bytes.Buffer
+	cmdShellStatus(false, &stdout)
 
 	out := stdout.String()
 	if !strings.Contains(out, "bash: installed") {
@@ -464,11 +462,8 @@ func TestShellStatus_NotInstalled(t *testing.T) {
 	shellTestMkdirAll(t, filepath.Join(home, ".config", "fish"))
 	shellTestWriteFile(t, filepath.Join(home, ".config", "fish", "config.fish"), "")
 
-	var stdout, stderr bytes.Buffer
-	code := cmdShellStatus(&stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit %d: %s", code, stderr.String())
-	}
+	var stdout bytes.Buffer
+	cmdShellStatus(false, &stdout)
 	if !strings.Contains(stdout.String(), "not installed") {
 		t.Errorf("expected 'not installed', got: %s", stdout.String())
 	}
@@ -485,14 +480,46 @@ func TestShellStatus_Installed(t *testing.T) {
 	rc := filepath.Join(home, ".zshrc")
 	shellTestWriteFile(t, rc, shellHookMarkerBegin+"\nsource foo\n"+shellHookMarkerEnd+"\n")
 
-	var stdout, stderr bytes.Buffer
-	code := cmdShellStatus(&stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit %d: %s", code, stderr.String())
-	}
+	var stdout bytes.Buffer
+	cmdShellStatus(false, &stdout)
 	out := stdout.String()
 	if !strings.Contains(out, "zsh: installed") {
 		t.Errorf("expected 'zsh: installed', got: %s", out)
+	}
+}
+
+func TestShellStatusJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	shellTestWriteFile(t, filepath.Join(home, ".bashrc"), "")
+	shellTestWriteFile(t, filepath.Join(home, ".zshrc"), "")
+	shellTestMkdirAll(t, filepath.Join(home, ".config", "fish"))
+	shellTestWriteFile(t, filepath.Join(home, ".config", "fish", "config.fish"), "")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"shell", "status", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var got shellStatusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" {
+		t.Fatalf("schema_version = %q, want 1", got.SchemaVersion)
+	}
+	if got.Installed {
+		t.Fatalf("installed = true, want false")
+	}
+	if len(got.Shells) != 3 {
+		t.Fatalf("shells len = %d, want 3", len(got.Shells))
 	}
 }
 

--- a/cmd/gc/cmd_version.go
+++ b/cmd/gc/cmd_version.go
@@ -86,6 +86,7 @@ func normalizeVersion(v string) string {
 
 func newVersionCmd(stdout io.Writer) *cobra.Command {
 	var longOutput bool
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print gc version",
@@ -94,6 +95,15 @@ func newVersionCmd(stdout io.Writer) *cobra.Command {
 Use --long to include git commit and build date metadata.`,
 		Args: cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
+			if jsonOutput {
+				_ = writeCLIJSONLine(stdout, versionJSON{
+					SchemaVersion: "1",
+					Version:       version,
+					Commit:        commit,
+					Date:          date,
+				})
+				return
+			}
 			if longOutput {
 				fmt.Fprintf(stdout, "%s (commit: %s, built: %s)\n", version, commit, date) //nolint:errcheck // best-effort stdout
 				return
@@ -102,5 +112,13 @@ Use --long to include git commit and build date metadata.`,
 		},
 	}
 	cmd.Flags().BoolVarP(&longOutput, "long", "l", false, "Include git commit and build date metadata")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output one JSONL result record")
 	return cmd
+}
+
+type versionJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	Version       string `json:"version"`
+	Commit        string `json:"commit"`
+	Date          string `json:"date"`
 }

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -52,7 +52,7 @@ func TestJSONSchemaManifestForSupportedCommand(t *testing.T) {
 
 func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"version", "--json-schema"}, &stdout, &stderr)
+	code := run([]string{"shell", "remove", "--json-schema"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("run(version --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -68,8 +68,8 @@ func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
 		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
 	}
-	if got := strings.Join(manifest.Command, " "); got != "version" {
-		t.Fatalf("command = %q, want version", got)
+	if got := strings.Join(manifest.Command, " "); got != "shell remove" {
+		t.Fatalf("command = %q, want shell remove", got)
 	}
 	if manifest.JSONSupported {
 		t.Fatalf("json_supported = true, want false")
@@ -128,7 +128,7 @@ func TestJSONSchemaRoleSpecificFailureUsesSharedDefault(t *testing.T) {
 
 func TestJSONSchemaUnavailableRoleFailureIsStructured(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"version", "--json-schema=result"}, &stdout, &stderr)
+	code := run([]string{"shell", "remove", "--json-schema=result"}, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("run(version --json-schema=result) = 0, want nonzero")
 	}
@@ -155,7 +155,7 @@ func TestJSONSchemaUnavailableRoleFailureIsStructured(t *testing.T) {
 
 func TestJSONUnsupportedCommandFailureIsStructured(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"version", "--json"}, &stdout, &stderr)
+	code := run([]string{"shell", "remove", "--json"}, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("run(version --json) = 0, want nonzero")
 	}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -275,6 +275,27 @@ func TestVersion(t *testing.T) {
 	if !strings.Contains(longOut, "built:") {
 		t.Errorf("stdout missing 'built:': %q", longOut)
 	}
+
+	stdout.Reset()
+	stderr := bytes.Buffer{}
+	code = run([]string{"version", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run([version --json]) = %d, stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var got versionJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || got.Version != "dev" || got.Commit == "" || got.Date == "" {
+		t.Fatalf("version JSON = %+v", got)
+	}
 }
 
 func TestConfigureTestscriptEnvDefaultsSetsMissingValues(t *testing.T) {

--- a/schemas/cities/list/result.schema.json
+++ b/schemas/cities/list/result.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "required": ["schema_version", "registry_path", "cities"],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1" },
+    "registry_path": { "type": "string" },
+    "cities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "path"],
+        "properties": {
+          "name": { "type": "string" },
+          "path": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/cities/result.schema.json
+++ b/schemas/cities/result.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "required": ["schema_version", "registry_path", "cities"],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1" },
+    "registry_path": { "type": "string" },
+    "cities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "path"],
+        "properties": {
+          "name": { "type": "string" },
+          "path": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/mcp/list/result.schema.json
+++ b/schemas/mcp/list/result.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "required": ["schema_version", "city_path", "query", "projection", "servers"],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1" },
+    "city_path": { "type": "string" },
+    "query": {
+      "type": "object",
+      "properties": {
+        "agent": { "type": "string" },
+        "session": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "projection": {
+      "type": "object",
+      "required": ["provider", "target"],
+      "properties": {
+        "provider": { "type": "string" },
+        "target": { "type": "string" },
+        "work_dir": { "type": "string" },
+        "delivery": { "type": "string" },
+        "scope_root": { "type": "string" },
+        "identity": { "type": "string" },
+        "provider_kind": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "transport", "source"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "transport": { "type": "string" },
+          "command": { "type": "string" },
+          "args": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "url": { "type": "string" },
+          "source": { "type": "string" },
+          "layer": { "type": "string" },
+          "origin": { "type": "string" },
+          "template": { "type": "boolean" },
+          "env_keys": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "header_keys": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "shadows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "winner", "loser", "winner_file", "loser_file"],
+        "properties": {
+          "name": { "type": "string" },
+          "winner": { "type": "string" },
+          "loser": { "type": "string" },
+          "winner_file": { "type": "string" },
+          "loser_file": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/shell/status/result.schema.json
+++ b/schemas/shell/status/result.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "required": ["schema_version", "installed", "shells"],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1" },
+    "installed": { "type": "boolean" },
+    "shells": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "shell",
+          "status",
+          "installed",
+          "completion_script_path",
+          "completion_script_exists",
+          "rc_path",
+          "rc_hook_present"
+        ],
+        "properties": {
+          "shell": { "type": "string" },
+          "status": { "type": "string" },
+          "installed": { "type": "boolean" },
+          "completion_script_path": { "type": "string" },
+          "completion_script_exists": { "type": "boolean" },
+          "rc_path": { "type": "string" },
+          "rc_hook_present": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/version/result.schema.json
+++ b/schemas/version/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "required": ["schema_version", "version", "commit", "date"],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1" },
+    "version": { "type": "string" },
+    "commit": { "type": "string" },
+    "date": { "type": "string" }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- adds `gc version --json`
- adds `gc shell status --json`
- adds `gc cities --json` and `gc cities list --json`
- adds `gc mcp list --agent ... --json` and `gc mcp list --session ... --json`
- declares result schemas for each command

## JSON compatibility
- These commands did not previously expose native success `--json` output, so this PR adds new machine-readable surfaces without changing an existing JSON contract.
- Human-readable output remains the default and is preserved.

## Validation
- `go test ./cmd/gc -run 'TestVersion|TestShellStatus|TestShellStatusJSON|TestDoCities|TestMcpListAgentJSON|TestJSONSchema'`\n- `git diff --check`\n- `make fmt-check`\n- `make vet`\n- `make check-docs`\n- `GOOS=linux make lint`\n\nStacked on #2222 (`codex/json-schema-platform`).
