### PR TITLE
feat: add JSON for runtime drain and nudge status

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -69,6 +69,25 @@ type nudgeTarget struct {
 	sessionName       string
 }
 
+type nudgeStatusJSON struct {
+	SchemaVersion string            `json:"schema_version"`
+	Command       string            `json:"command"`
+	CityPath      string            `json:"city_path"`
+	Agent         string            `json:"agent"`
+	Session       string            `json:"session"`
+	SessionID     string            `json:"session_id,omitempty"`
+	Counts        nudgeStatusCounts `json:"counts"`
+	Pending       []queuedNudge     `json:"pending"`
+	InFlight      []queuedNudge     `json:"in_flight"`
+	Dead          []queuedNudge     `json:"dead"`
+}
+
+type nudgeStatusCounts struct {
+	Pending  int `json:"pending"`
+	InFlight int `json:"in_flight"`
+	Dead     int `json:"dead"`
+}
+
 func (t nudgeTarget) agentKey() string {
 	if t.alias != "" {
 		return t.alias
@@ -172,7 +191,8 @@ was asleep or was not at a safe interactive boundary yet.`,
 }
 
 func newNudgeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "status [session]",
 		Short: "Show queued and dead-letter nudges for a session",
 		Long: `Show queued and dead-letter nudges for a session.
@@ -180,12 +200,14 @@ func newNudgeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 Defaults to $GC_ALIAS or $GC_SESSION_ID when run inside a session.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdNudgeStatus(args, stdout, stderr) != 0 {
+			if cmdNudgeStatus(args, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	return cmd
 }
 
 func newNudgeDrainCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -232,7 +254,7 @@ func newNudgePollCmd(stdout, stderr io.Writer) *cobra.Command {
 	return cmd
 }
 
-func cmdNudgeStatus(args []string, stdout, stderr io.Writer) int {
+func cmdNudgeStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	targetID := os.Getenv("GC_ALIAS")
 	if targetID == "" {
 		targetID = os.Getenv("GC_SESSION_ID")
@@ -255,6 +277,29 @@ func cmdNudgeStatus(args []string, stdout, stderr io.Writer) int {
 	if err != nil {
 		fmt.Fprintf(stderr, "gc nudge status: %v\n", err) //nolint:errcheck
 		return 1
+	}
+
+	if jsonOutput {
+		if err := writeCLIJSONLine(stdout, nudgeStatusJSON{
+			SchemaVersion: "1",
+			Command:       "nudge status",
+			CityPath:      target.cityPath,
+			Agent:         target.agentKey(),
+			Session:       target.sessionName,
+			SessionID:     target.sessionID,
+			Counts: nudgeStatusCounts{
+				Pending:  len(pending),
+				InFlight: len(inFlight),
+				Dead:     len(dead),
+			},
+			Pending:  nonNilQueuedNudges(pending),
+			InFlight: nonNilQueuedNudges(inFlight),
+			Dead:     nonNilQueuedNudges(dead),
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc nudge status: writing JSON: %v\n", err) //nolint:errcheck
+			return 1
+		}
+		return 0
 	}
 
 	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
@@ -285,6 +330,13 @@ func cmdNudgeStatus(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return 0
+}
+
+func nonNilQueuedNudges(items []queuedNudge) []queuedNudge {
+	if items == nil {
+		return []queuedNudge{}
+	}
+	return items
 }
 
 func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -1297,6 +1298,43 @@ dir = "myrig"
 	}
 	if target.continuationEpoch != "epoch-7" {
 		t.Fatalf("continuationEpoch = %q, want epoch-7", target.continuationEpoch)
+	}
+}
+
+func TestCmdNudgeStatusJSON(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	cityDir := t.TempDir()
+	writeNamedSessionCityTOML(t, cityDir)
+	t.Setenv("GC_CITY", cityDir)
+
+	now := time.Now().Add(-time.Minute)
+	if err := enqueueQueuedNudge(cityDir, newQueuedNudge("mayor", "review queued work", "session", now)); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdNudgeStatus([]string{"mayor"}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdNudgeStatus --json = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var result nudgeStatusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.Command != "nudge status" {
+		t.Fatalf("unexpected JSON result header: %+v", result)
+	}
+	if result.Agent != "mayor" || result.Counts.Pending != 1 || len(result.Pending) != 1 {
+		t.Fatalf("unexpected JSON status: %+v", result)
+	}
+	if result.Pending[0].Message != "review queued work" {
+		t.Fatalf("pending message = %q, want queued nudge message", result.Pending[0].Message)
+	}
+	if result.InFlight == nil || result.Dead == nil {
+		t.Fatalf("empty queues should encode as arrays, got in_flight=%#v dead=%#v", result.InFlight, result.Dead)
 	}
 }
 

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -37,6 +37,23 @@ type providerDrainOps struct {
 	sp runtime.Provider
 }
 
+type runtimeDrainCheckJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	Command       string `json:"command"`
+	Session       string `json:"session"`
+	Target        string `json:"target,omitempty"`
+	Draining      bool   `json:"draining"`
+}
+
+type runtimeActionJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	Command       string `json:"command"`
+	Action        string `json:"action"`
+	Session       string `json:"session"`
+	Target        string `json:"target,omitempty"`
+	Status        string `json:"status"`
+}
+
 func (o *providerDrainOps) setDrain(sessionName string) error {
 	return o.sp.SetMeta(sessionName, "GC_DRAIN", strconv.FormatInt(time.Now().Unix(), 10))
 }
@@ -140,7 +157,8 @@ func newDrainOps(sp runtime.Provider) drainOps {
 // ---------------------------------------------------------------------------
 
 func newRuntimeDrainCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "drain <name>",
 		Short: "Signal a session to drain (wind down gracefully)",
 		Long: `Signal a session to drain — wind down its current work gracefully.
@@ -151,15 +169,17 @@ its current task before exiting. Pass a session alias or ID. Use
 "gc runtime undrain" to cancel.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdRuntimeDrain(args, stdout, stderr) != 0 {
+			if cmdRuntimeDrain(args, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	return cmd
 }
 
-func cmdRuntimeDrain(args []string, stdout, stderr io.Writer) int {
+func cmdRuntimeDrain(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc runtime drain: missing session alias or ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -172,12 +192,12 @@ func cmdRuntimeDrain(args []string, stdout, stderr io.Writer) int {
 	sp := newSessionProvider()
 	dops := newDrainOps(sp)
 	rec := openCityRecorder(stderr)
-	return doRuntimeDrain(dops, sp, rec, target.display, target.sessionName, stdout, stderr)
+	return doRuntimeDrain(dops, sp, rec, target.display, target.sessionName, jsonOutput, stdout, stderr)
 }
 
 // doRuntimeDrain sets the drain signal on a session.
 func doRuntimeDrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
-	targetName, sn string, stdout, stderr io.Writer,
+	targetName, sn string, jsonOutput bool, stdout, stderr io.Writer,
 ) int {
 	running, err := workerSessionTargetRunningWithConfig("", nil, sp, nil, sn)
 	if err != nil {
@@ -197,6 +217,20 @@ func doRuntimeDrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 		Actor:   eventActor(),
 		Subject: targetName,
 	})
+	if jsonOutput {
+		if err := writeCLIJSONLine(stdout, runtimeActionJSON{
+			SchemaVersion: "1",
+			Command:       "runtime drain",
+			Action:        "drain",
+			Session:       sn,
+			Target:        targetName,
+			Status:        "draining",
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc runtime drain: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return 0
+	}
 	fmt.Fprintf(stdout, "Draining session '%s'\n", targetName) //nolint:errcheck // best-effort stdout
 	return 0
 }
@@ -206,7 +240,8 @@ func doRuntimeDrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 // ---------------------------------------------------------------------------
 
 func newRuntimeUndrainCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "undrain <name>",
 		Short: "Cancel drain on a session",
 		Long: `Cancel a pending drain signal on a session.
@@ -215,15 +250,17 @@ Clears the GC_DRAIN and GC_DRAIN_ACK metadata flags, allowing the
 session to continue normal operation. Pass a session alias or ID.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdRuntimeUndrain(args, stdout, stderr) != 0 {
+			if cmdRuntimeUndrain(args, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	return cmd
 }
 
-func cmdRuntimeUndrain(args []string, stdout, stderr io.Writer) int {
+func cmdRuntimeUndrain(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc runtime undrain: missing session alias or ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -236,12 +273,12 @@ func cmdRuntimeUndrain(args []string, stdout, stderr io.Writer) int {
 	sp := newSessionProvider()
 	dops := newDrainOps(sp)
 	rec := openCityRecorder(stderr)
-	return doRuntimeUndrain(dops, sp, rec, target.display, target.sessionName, stdout, stderr)
+	return doRuntimeUndrain(dops, sp, rec, target.display, target.sessionName, jsonOutput, stdout, stderr)
 }
 
 // doRuntimeUndrain clears the drain signal on a session.
 func doRuntimeUndrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
-	targetName, sn string, stdout, stderr io.Writer,
+	targetName, sn string, jsonOutput bool, stdout, stderr io.Writer,
 ) int {
 	running, err := workerSessionTargetRunningWithConfig("", nil, sp, nil, sn)
 	if err != nil {
@@ -261,6 +298,20 @@ func doRuntimeUndrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 		Actor:   eventActor(),
 		Subject: targetName,
 	})
+	if jsonOutput {
+		if err := writeCLIJSONLine(stdout, runtimeActionJSON{
+			SchemaVersion: "1",
+			Command:       "runtime undrain",
+			Action:        "undrain",
+			Session:       sn,
+			Target:        targetName,
+			Status:        "undrained",
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc runtime undrain: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return 0
+	}
 	fmt.Fprintf(stdout, "Undrained session '%s'\n", targetName) //nolint:errcheck // best-effort stdout
 	return 0
 }
@@ -270,8 +321,8 @@ func doRuntimeUndrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 // ---------------------------------------------------------------------------
 
 func newRuntimeDrainCheckCmd(stdout, stderr io.Writer) *cobra.Command {
-	_ = stdout // drain-check is silent on stdout
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "drain-check [name]",
 		Short: "Check if a session is draining (exit 0 = draining)",
 		Long: `Check if a session is currently draining.
@@ -281,15 +332,17 @@ conditionals: "if gc runtime drain-check; then finish-up; fi". Without
 arguments, uses the current session context.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdRuntimeDrainCheck(args, stderr) != 0 {
+			if cmdRuntimeDrainCheck(args, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	return cmd
 }
 
-func cmdRuntimeDrainCheck(args []string, stderr io.Writer) int {
+func cmdRuntimeDrainCheck(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	if len(args) > 0 {
 		target, err := resolveSessionRuntimeTarget(args[0], stderr)
 		if err != nil {
@@ -298,7 +351,7 @@ func cmdRuntimeDrainCheck(args []string, stderr io.Writer) int {
 		}
 		sp := newSessionProvider()
 		dops := newDrainOps(sp)
-		return doRuntimeDrainCheck(dops, target.sessionName)
+		return doRuntimeDrainCheck(dops, target.display, target.sessionName, jsonOutput, stdout, stderr)
 	}
 
 	current, err := currentSessionRuntimeTarget()
@@ -307,15 +360,27 @@ func cmdRuntimeDrainCheck(args []string, stderr io.Writer) int {
 	}
 	sp := newSessionProvider()
 	dops := newDrainOps(sp)
-	return doRuntimeDrainCheck(dops, current.sessionName)
+	return doRuntimeDrainCheck(dops, current.display, current.sessionName, jsonOutput, stdout, stderr)
 }
 
 // doRuntimeDrainCheck returns 0 if the session is draining, 1 otherwise.
 // Silent on stdout — designed for `if gc runtime drain-check; then ...`.
-func doRuntimeDrainCheck(dops drainOps, sn string) int {
+func doRuntimeDrainCheck(dops drainOps, targetName, sn string, jsonOutput bool, stdout, stderr io.Writer) int {
 	draining, err := dops.isDraining(sn)
 	if err != nil || !draining {
 		return 1
+	}
+	if jsonOutput {
+		if err := writeCLIJSONLine(stdout, runtimeDrainCheckJSON{
+			SchemaVersion: "1",
+			Command:       "runtime drain-check",
+			Session:       sn,
+			Target:        targetName,
+			Draining:      true,
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc runtime drain-check: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 	return 0
 }
@@ -325,7 +390,8 @@ func doRuntimeDrainCheck(dops drainOps, sn string) int {
 // ---------------------------------------------------------------------------
 
 func newRuntimeDrainAckCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "drain-ack [name]",
 		Short: "Acknowledge drain — signal the controller to stop this session",
 		Long: `Acknowledge a drain signal — tell the controller to stop this session.
@@ -335,15 +401,17 @@ the session on its next reconcile tick. Call this after the session has
 finished its current work in response to a drain signal.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdRuntimeDrainAck(args, stdout, stderr) != 0 {
+			if cmdRuntimeDrainAck(args, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	return cmd
 }
 
-func cmdRuntimeDrainAck(args []string, stdout, stderr io.Writer) int {
+func cmdRuntimeDrainAck(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	if len(args) > 0 {
 		target, err := resolveSessionRuntimeTarget(args[0], stderr)
 		if err != nil {
@@ -352,7 +420,7 @@ func cmdRuntimeDrainAck(args []string, stdout, stderr io.Writer) int {
 		}
 		sp := newSessionProvider()
 		dops := newDrainOps(sp)
-		return doRuntimeDrainAck(dops, target.sessionName, stdout, stderr)
+		return doRuntimeDrainAck(dops, target.display, target.sessionName, jsonOutput, stdout, stderr)
 	}
 
 	current, err := currentSessionRuntimeTarget()
@@ -362,7 +430,7 @@ func cmdRuntimeDrainAck(args []string, stdout, stderr io.Writer) int {
 	}
 	sp := newSessionProvider()
 	dops := newDrainOps(sp)
-	return doRuntimeDrainAck(dops, current.sessionName, stdout, stderr)
+	return doRuntimeDrainAck(dops, current.display, current.sessionName, jsonOutput, stdout, stderr)
 }
 
 // ---------------------------------------------------------------------------
@@ -536,10 +604,24 @@ func waitForControllerRestart(ctx context.Context, dops drainOps, sn, command st
 
 // doRuntimeDrainAck sets the drain-ack flag on the session. The controller
 // will stop the session on the next tick.
-func doRuntimeDrainAck(dops drainOps, sn string, stdout, stderr io.Writer) int {
+func doRuntimeDrainAck(dops drainOps, targetName, sn string, jsonOutput bool, stdout, stderr io.Writer) int {
 	if err := dops.setDrainAck(sn); err != nil {
 		fmt.Fprintf(stderr, "gc runtime drain-ack: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if jsonOutput {
+		if err := writeCLIJSONLine(stdout, runtimeActionJSON{
+			SchemaVersion: "1",
+			Command:       "runtime drain-ack",
+			Action:        "drain-ack",
+			Session:       sn,
+			Target:        targetName,
+			Status:        "acknowledged",
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc runtime drain-ack: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return 0
 	}
 	fmt.Fprintln(stdout, "Drain acknowledged. Controller will stop this session.") //nolint:errcheck // best-effort stdout
 	return 0

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -211,7 +212,7 @@ func TestDoRuntimeDrain(t *testing.T) {
 
 	rec := events.NewFake()
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeDrain(dops, sp, rec, "worker", "worker", &stdout, &stderr)
+	code := doRuntimeDrain(dops, sp, rec, "worker", "worker", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -234,7 +235,7 @@ func TestDoRuntimeDrainNotRunning(t *testing.T) {
 	sp := runtime.NewFake() // no sessions started
 
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeDrain(dops, sp, events.Discard, "worker", "worker", &stdout, &stderr)
+	code := doRuntimeDrain(dops, sp, events.Discard, "worker", "worker", false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
@@ -252,12 +253,36 @@ func TestDoRuntimeDrainSetError(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeDrain(dops, sp, events.Discard, "worker", "worker", &stdout, &stderr)
+	code := doRuntimeDrain(dops, sp, events.Discard, "worker", "worker", false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
 	if got := stderr.String(); got != "gc runtime drain: tmux borked\n" {
 		t.Errorf("stderr = %q", got)
+	}
+}
+
+func TestDoRuntimeDrainJSON(t *testing.T) {
+	dops := newFakeDrainOps()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRuntimeDrain(dops, sp, events.Discard, "worker", "worker", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var result runtimeActionJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.Command != "runtime drain" || result.Session != "worker" || result.Status != "draining" {
+		t.Fatalf("unexpected JSON result: %+v", result)
 	}
 }
 
@@ -275,7 +300,7 @@ func TestDoRuntimeUndrain(t *testing.T) {
 
 	rec := events.NewFake()
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeUndrain(dops, sp, rec, "worker", "worker", &stdout, &stderr)
+	code := doRuntimeUndrain(dops, sp, rec, "worker", "worker", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -295,12 +320,37 @@ func TestDoRuntimeUndrainNotRunning(t *testing.T) {
 	sp := runtime.NewFake()
 
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeUndrain(dops, sp, events.Discard, "worker", "worker", &stdout, &stderr)
+	code := doRuntimeUndrain(dops, sp, events.Discard, "worker", "worker", false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
 	if got := stderr.String(); got != "gc runtime undrain: session \"worker\" is not running\n" {
 		t.Errorf("stderr = %q", got)
+	}
+}
+
+func TestDoRuntimeUndrainJSON(t *testing.T) {
+	dops := newFakeDrainOps()
+	dops.draining["worker"] = true
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRuntimeUndrain(dops, sp, events.Discard, "worker", "worker", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var result runtimeActionJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.Command != "runtime undrain" || result.Session != "worker" || result.Status != "undrained" {
+		t.Fatalf("unexpected JSON result: %+v", result)
 	}
 }
 
@@ -312,7 +362,7 @@ func TestDoRuntimeDrainCheck(t *testing.T) {
 	dops := newFakeDrainOps()
 	dops.draining["worker"] = true
 
-	code := doRuntimeDrainCheck(dops, "worker")
+	code := doRuntimeDrainCheck(dops, "worker", "worker", false, &bytes.Buffer{}, &bytes.Buffer{})
 	if code != 0 {
 		t.Errorf("code = %d, want 0 (draining)", code)
 	}
@@ -321,7 +371,7 @@ func TestDoRuntimeDrainCheck(t *testing.T) {
 func TestDoRuntimeDrainCheckNotDraining(t *testing.T) {
 	dops := newFakeDrainOps()
 
-	code := doRuntimeDrainCheck(dops, "worker")
+	code := doRuntimeDrainCheck(dops, "worker", "worker", false, &bytes.Buffer{}, &bytes.Buffer{})
 	if code != 1 {
 		t.Errorf("code = %d, want 1 (not draining)", code)
 	}
@@ -331,9 +381,30 @@ func TestDoRuntimeDrainCheckError(t *testing.T) {
 	dops := newFakeDrainOps()
 	dops.err = errors.New("tmux gone")
 
-	code := doRuntimeDrainCheck(dops, "worker")
+	code := doRuntimeDrainCheck(dops, "worker", "worker", false, &bytes.Buffer{}, &bytes.Buffer{})
 	if code != 1 {
 		t.Errorf("code = %d, want 1 (error → not draining)", code)
+	}
+}
+
+func TestDoRuntimeDrainCheckJSON(t *testing.T) {
+	dops := newFakeDrainOps()
+	dops.draining["worker"] = true
+
+	var stdout, stderr bytes.Buffer
+	code := doRuntimeDrainCheck(dops, "worker", "worker", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var result runtimeDrainCheckJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.Command != "runtime drain-check" || !result.Draining || result.Session != "worker" {
+		t.Fatalf("unexpected JSON result: %+v", result)
 	}
 }
 
@@ -344,7 +415,7 @@ func TestDoRuntimeDrainCheckError(t *testing.T) {
 func TestDoRuntimeDrainAck(t *testing.T) {
 	dops := newFakeDrainOps()
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeDrainAck(dops, "worker", &stdout, &stderr)
+	code := doRuntimeDrainAck(dops, "worker", "worker", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -360,12 +431,31 @@ func TestDoRuntimeDrainAckError(t *testing.T) {
 	dops := newFakeDrainOps()
 	dops.err = errors.New("tmux borked")
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeDrainAck(dops, "worker", &stdout, &stderr)
+	code := doRuntimeDrainAck(dops, "worker", "worker", false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
 	if got := stderr.String(); got != "gc runtime drain-ack: tmux borked\n" {
 		t.Errorf("stderr = %q", got)
+	}
+}
+
+func TestDoRuntimeDrainAckJSON(t *testing.T) {
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+	code := doRuntimeDrainAck(dops, "worker", "worker", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var result runtimeActionJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.Command != "runtime drain-ack" || result.Session != "worker" || result.Status != "acknowledged" {
+		t.Fatalf("unexpected JSON result: %+v", result)
 	}
 }
 

--- a/schemas/nudge/status/result.schema.json
+++ b/schemas/nudge/status/result.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "command", "city_path", "agent", "session", "counts", "pending", "in_flight", "dead"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "command": { "const": "nudge status" },
+    "city_path": { "type": "string" },
+    "agent": { "type": "string" },
+    "session": { "type": "string" },
+    "session_id": { "type": "string" },
+    "counts": {
+      "type": "object",
+      "required": ["pending", "in_flight", "dead"],
+      "properties": {
+        "pending": { "type": "integer" },
+        "in_flight": { "type": "integer" },
+        "dead": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "pending": { "type": "array", "items": { "$ref": "#/$defs/nudge" } },
+    "in_flight": { "type": "array", "items": { "$ref": "#/$defs/nudge" } },
+    "dead": { "type": "array", "items": { "$ref": "#/$defs/nudge" } }
+  },
+  "$defs": {
+    "nudge": {
+      "type": "object",
+      "required": ["id", "agent", "source", "message", "created_at", "deliver_after", "expires_at"],
+      "properties": {
+        "id": { "type": "string" },
+        "bead_id": { "type": "string" },
+        "agent": { "type": "string" },
+        "session_id": { "type": "string" },
+        "continuation_epoch": { "type": "string" },
+        "source": { "type": "string" },
+        "message": { "type": "string" },
+        "reference": {
+          "type": "object",
+          "properties": {
+            "kind": { "type": "string" },
+            "id": { "type": "string" }
+          },
+          "additionalProperties": true
+        },
+        "created_at": { "type": "string", "format": "date-time" },
+        "deliver_after": { "type": "string", "format": "date-time" },
+        "expires_at": { "type": "string", "format": "date-time" },
+        "attempts": { "type": "integer" },
+        "last_attempt_at": { "type": "string", "format": "date-time" },
+        "last_error": { "type": "string" },
+        "claimed_at": { "type": "string", "format": "date-time" },
+        "lease_until": { "type": "string", "format": "date-time" },
+        "dead_at": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/runtime/drain-ack/result.schema.json
+++ b/schemas/runtime/drain-ack/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "command", "action", "session", "status"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "command": { "const": "runtime drain-ack" },
+    "action": { "const": "drain-ack" },
+    "session": { "type": "string" },
+    "target": { "type": "string" },
+    "status": { "const": "acknowledged" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/runtime/drain-check/result.schema.json
+++ b/schemas/runtime/drain-check/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "command", "session", "draining"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "command": { "const": "runtime drain-check" },
+    "session": { "type": "string" },
+    "target": { "type": "string" },
+    "draining": { "const": true }
+  },
+  "additionalProperties": true
+}

--- a/schemas/runtime/drain/result.schema.json
+++ b/schemas/runtime/drain/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "command", "action", "session", "status"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "command": { "const": "runtime drain" },
+    "action": { "const": "drain" },
+    "session": { "type": "string" },
+    "target": { "type": "string" },
+    "status": { "const": "draining" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/runtime/undrain/result.schema.json
+++ b/schemas/runtime/undrain/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "command", "action", "session", "status"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "command": { "const": "runtime undrain" },
+    "action": { "const": "undrain" },
+    "session": { "type": "string" },
+    "target": { "type": "string" },
+    "status": { "const": "undrained" }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- adds JSON summaries for runtime drain actions:
  - `gc runtime drain --json`
  - `gc runtime undrain --json`
  - `gc runtime drain-check --json`
  - `gc runtime drain-ack --json`
- adds `gc nudge status --json`
- declares result schemas for each command

## JSON compatibility
- Human output remains unchanged by default.
- `gc runtime drain-check` remains stdout-silent by default, but `--json` now emits one success JSONL record when draining.
- Runtime action commands with `--json` now emit one success JSONL summary rather than human text.
- `gc nudge status --json` emits one JSONL status object including queue counts and queue items.
- `gc runtime request-restart --json` is intentionally skipped because it blocks/waits by design. Hidden `gc nudge drain/poll` transport commands are intentionally skipped.

## Validation
- `go test ./cmd/gc -run 'TestDoRuntimeDrain|TestDoRuntimeUndrain|TestDoRuntimeDrainCheck|TestDoRuntimeDrainAck|TestProviderDrainOps|TestCmdNudgeStatusJSON|TestResolveNudgeTarget_MaterializesNamedSessionFromAlias|TestJSONSchema' -count=1`\n- `git diff --check`\n- `make fmt-check`\n- `make vet`\n- `make check-docs`\n- `GOOS=linux make lint`\n\nStacked on #2222 (`codex/json-schema-platform`).
