### PR TITLE
feat: add JSON for doctor diagnostics

### DIFF
--- a/cmd/gc/cmd_beads.go
+++ b/cmd/gc/cmd_beads.go
@@ -32,7 +32,7 @@ Subcommands for topology operations, health checking, and diagnostics.`,
 }
 
 func newBeadsHealthCmd(stdout, stderr io.Writer) *cobra.Command {
-	var quiet bool
+	var quiet, jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Check beads provider health",
@@ -44,10 +44,11 @@ and recovery internally. For the file provider, always succeeds (no-op).
 
 Also used by the beads-health system order for periodic monitoring.`,
 		Example: `  gc beads health
-  gc beads health --quiet`,
+  gc beads health --quiet
+  gc beads health --json`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if doBeadsHealth(quiet, stdout, stderr) != 0 {
+			if doBeadsHealth(quiet, jsonOut, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -55,12 +56,21 @@ Also used by the beads-health system order for periodic monitoring.`,
 	}
 	cmd.Flags().BoolVar(&quiet, "quiet", false,
 		"silent on success, stderr on failure")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON result")
 	return cmd
+}
+
+type beadsHealthJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	CityPath      string `json:"city_path"`
+	Provider      string `json:"provider"`
+	Status        string `json:"status"`
 }
 
 // doBeadsHealth runs the beads provider health check.
 // Returns 0 if healthy, 1 if unhealthy/recovery-failed.
-func doBeadsHealth(quiet bool, stdout, stderr io.Writer) int {
+func doBeadsHealth(quiet, jsonOut bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc beads health: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -70,6 +80,19 @@ func doBeadsHealth(quiet bool, stdout, stderr io.Writer) int {
 	if err := healthBeadsProvider(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc beads health: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if jsonOut {
+		if err := writeCLIJSONLine(stdout, beadsHealthJSONResult{
+			SchemaVersion: "1",
+			OK:            true,
+			CityPath:      cityPath,
+			Provider:      rawBeadsProvider(cityPath),
+			Status:        "healthy",
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc beads health: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return 0
 	}
 	if !quiet {
 		fmt.Fprintln(stdout, "Beads provider: healthy") //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_beads_test.go
+++ b/cmd/gc/cmd_beads_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,7 +19,7 @@ func TestDoBeadsHealth_FileProvider(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doBeadsHealth(false, &stdout, &stderr)
+	code := doBeadsHealth(false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Errorf("exit code = %d, want 0; stderr = %s", code, stderr.String())
 	}
@@ -37,12 +38,47 @@ func TestDoBeadsHealth_FileProviderQuiet(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doBeadsHealth(true, &stdout, &stderr)
+	code := doBeadsHealth(true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Errorf("exit code = %d, want 0", code)
 	}
 	if stdout.Len() != 0 {
 		t.Errorf("quiet mode should produce no stdout, got: %s", stdout.String())
+	}
+}
+
+func TestBeadsHealthJSONFileProvider(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", dir, "beads", "health", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc beads health --json = %d; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		OK            bool   `json:"ok"`
+		CityPath      string `json:"city_path"`
+		Provider      string `json:"provider"`
+		Status        string `json:"status"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || !payload.OK || payload.CityPath != dir || payload.Provider != "file" || payload.Status != "healthy" {
+		t.Fatalf("payload = %+v", payload)
 	}
 }
 
@@ -57,7 +93,7 @@ func TestDoBeadsHealth_ExecProviderHealthy(t *testing.T) {
 	t.Setenv("GC_BEADS", "exec:"+script)
 
 	var stdout, stderr bytes.Buffer
-	code := doBeadsHealth(false, &stdout, &stderr)
+	code := doBeadsHealth(false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Errorf("exit code = %d, want 0; stderr = %s", code, stderr.String())
 	}
@@ -78,7 +114,7 @@ func TestDoBeadsHealth_ExecProviderUnhealthy(t *testing.T) {
 	t.Setenv("GC_BEADS", "exec:"+script)
 
 	var stdout, stderr bytes.Buffer
-	code := doBeadsHealth(false, &stdout, &stderr)
+	code := doBeadsHealth(false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Errorf("exit code = %d, want 1", code)
 	}
@@ -99,7 +135,7 @@ func TestDoBeadsHealth_BdSkip(t *testing.T) {
 	t.Setenv("GC_DOLT", "skip")
 
 	var stdout, stderr bytes.Buffer
-	code := doBeadsHealth(false, &stdout, &stderr)
+	code := doBeadsHealth(false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Errorf("exit code = %d, want 0; stderr = %s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,55 @@ import (
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
+
+func prependDoctorJSONStubBinaries(t *testing.T, names ...string) {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("write stub %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestDoctorJSONSuccessIsParseableJSONOnly(t *testing.T) {
+	cityDir := t.TempDir()
+	writeMinimalCityToml(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityDir, "doctor", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc doctor --json = %d; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "✓") || strings.Contains(stdout.String(), "warnings") {
+		t.Fatalf("stdout contains human doctor output: %q", stdout.String())
+	}
+
+	var payload struct {
+		Passed  int `json:"passed"`
+		Failed  int `json:"failed"`
+		Results []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.Passed == 0 || payload.Failed != 0 || len(payload.Results) == 0 {
+		t.Fatalf("payload summary/results = %+v", payload)
+	}
+}
 
 func TestDoctorSkipsDoltChecksTreatsExecGcBeadsBdAsBdContract(t *testing.T) {
 	cityDir := t.TempDir()

--- a/schemas/beads/health/result.schema.json
+++ b/schemas/beads/health/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "required": ["schema_version", "ok", "city_path", "provider", "status"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "city_path": { "type": "string" },
+    "provider": { "type": "string" },
+    "status": { "const": "healthy" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/doctor/result.schema.json
+++ b/schemas/doctor/result.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "required": ["passed", "warned", "failed", "fixed", "results"],
+  "properties": {
+    "passed": { "type": "integer" },
+    "warned": { "type": "integer" },
+    "failed": { "type": "integer" },
+    "fixed": { "type": "integer" },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "status", "message"],
+        "properties": {
+          "name": { "type": "string" },
+          "status": { "enum": ["ok", "warning", "error", "unknown"] },
+          "message": { "type": "string" },
+          "fix_hint": { "type": "string" },
+          "details": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "fix_attempted": { "type": "boolean" },
+          "fix_error": { "type": "string" },
+          "fixed": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "error": { "type": "string" }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- adds `gc doctor --json` with a single JSONL diagnostic result record
- adds `gc beads health --json` with a single JSONL result record
- declares result schemas for both commands

## JSON compatibility
- These commands did not previously expose native success `--json` output, so this PR adds new machine-readable surfaces without changing an existing JSON contract.
- Human-readable output remains the default and is preserved.
- `doctor drift` is not a CLI command in this tree; it is a doctor check, so there is no separate command surface to JSON-enable here.
- `gc analyze reliability --json` already had JSON and schema support, so it is intentionally unchanged.

## Validation
- `git diff --check`
- `go test ./internal/doctor`
- `go test ./cmd/gc -run 'Test.*Doctor.*JSON|Test.*Beads.*Health.*JSON|TestJSONSchema|TestRunAnalyzeReliability' -count=1`\n- `GOOS=linux make lint`\n- `make fmt-check`\n- `make vet`\n- `make check-docs`\n\nNote: an exploratory broad `go test -timeout=5m ./cmd/gc ./internal/doctor` in the worker reported an environmental deprecated-config stderr from `/Users/dbox/repos/gc/city.toml` and then timed out in an unrelated Dolt wait-ready test. Focused shard validation and repo gates above pass.\n\nStacked on #2222 (`codex/json-schema-platform`).
