### PR TITLE
feat(events): wire rotation config plumbing

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -149,6 +149,9 @@ func isNonFatalLoadConfigWarning(warning string) bool {
 	if strings.Contains(warning, "attachment-list fields") {
 		return true
 	}
+	if strings.HasPrefix(warning, "events.rotation: warning:") {
+		return true
+	}
 	if !strings.Contains(warning, `" is not supported`) {
 		return false
 	}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -602,8 +602,8 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 
 	recorder := events.Discard
 	var eventProv events.Provider // nil when events disabled or FileRecorder fails
-	if fr, err := events.NewFileRecorder(
-		filepath.Join(cityPath, ".gc", "events.jsonl"), stderr); err == nil {
+	if fr, err := newFileEventsRecorder(
+		filepath.Join(cityPath, ".gc", "events.jsonl"), cfg.Events, stderr); err == nil {
 		recorder = fr
 		eventProv = fr
 	}

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -241,8 +241,8 @@ func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr i
 		}
 	}
 	recorder := events.Discard
-	if fr, err := events.NewFileRecorder(
-		filepath.Join(cityPath, ".gc", "events.jsonl"), stderr); err == nil {
+	if fr, err := newFileEventsRecorder(
+		filepath.Join(cityPath, ".gc", "events.jsonl"), cfg.Events, stderr); err == nil {
 		recorder = fr
 	}
 

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1438,7 +1438,7 @@ func reconcileCities(
 		rec := events.Discard
 		var eventProv events.Provider
 		evPath := filepath.Join(path, ".gc", "events.jsonl")
-		fr, frErr := events.NewFileRecorder(evPath, stderr)
+		fr, frErr := newFileEventsRecorder(evPath, cfg.Events, stderr)
 		if frErr == nil {
 			rec = fr
 			eventProv = fr

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -761,8 +761,12 @@ func openCityRecorder(stderr io.Writer) events.Recorder {
 }
 
 func openCityRecorderAt(cityPath string, stderr io.Writer) events.Recorder {
-	rec, err := events.NewFileRecorder(
-		filepath.Join(cityPath, ".gc", "events.jsonl"), stderr)
+	eventsCfg := config.EventsConfig{}
+	if cfg, err := loadCityConfig(cityPath, io.Discard); err == nil {
+		eventsCfg = cfg.Events
+	}
+	rec, err := newFileEventsRecorder(
+		filepath.Join(cityPath, ".gc", "events.jsonl"), eventsCfg, stderr)
 	if err != nil {
 		return events.Discard
 	}

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -703,15 +705,24 @@ func openCityMailProvider(stderr io.Writer, cmdName string) (mail.Provider, int)
 // eventsProviderName returns the events provider name.
 // Priority: GC_EVENTS env var → city.toml [events].provider → "" (default: file JSONL).
 func eventsProviderName() string {
-	if v := os.Getenv("GC_EVENTS"); v != "" {
-		return v
-	}
+	return eventsProviderConfig().Provider
+}
+
+func eventsProviderConfig() config.EventsConfig {
+	return eventsProviderConfigWithWarnings(io.Discard)
+}
+
+func eventsProviderConfigWithWarnings(w io.Writer) config.EventsConfig {
+	cfg := config.EventsConfig{}
 	if cp, err := resolveCity(); err == nil {
-		if cfg, err := loadCityConfig(cp, io.Discard); err == nil && cfg.Events.Provider != "" {
-			return cfg.Events.Provider
+		if cityCfg, err := loadCityConfig(cp, w); err == nil {
+			cfg = cityCfg.Events
 		}
 	}
-	return ""
+	if v := os.Getenv("GC_EVENTS"); v != "" {
+		cfg.Provider = v
+	}
+	return cfg
 }
 
 // fastEventsProviderName returns the events provider name for hook-driven
@@ -738,6 +749,10 @@ func fastEventsProviderName() string {
 //   - "exec:<script>" → user-supplied script (absolute path or PATH lookup)
 //   - default → file-backed JSONL provider
 func newEventsProviderForName(v, eventsPath string, stderr io.Writer) (events.Provider, error) {
+	return newEventsProviderForNameWithConfig(v, eventsPath, stderr, config.EventsConfig{})
+}
+
+func newEventsProviderForNameWithConfig(v, eventsPath string, stderr io.Writer, eventsCfg config.EventsConfig) (events.Provider, error) {
 	if strings.HasPrefix(v, "exec:") {
 		return eventsexec.NewProvider(strings.TrimPrefix(v, "exec:"), stderr), nil
 	}
@@ -747,14 +762,98 @@ func newEventsProviderForName(v, eventsPath string, stderr io.Writer) (events.Pr
 	case "fail":
 		return events.NewFailFake(), nil
 	default:
-		return events.NewFileRecorder(eventsPath, stderr)
+		return newFileEventsRecorder(eventsPath, eventsCfg, stderr)
 	}
+}
+
+type eventsRotationSettings struct {
+	enabled              bool
+	maxSizeBytes         int64
+	checkIntervalRecords int
+	checkInterval        time.Duration
+	archiveRetainAge     time.Duration
+}
+
+func eventsRotationSettingsFromConfig(eventsCfg config.EventsConfig, stderr io.Writer) eventsRotationSettings {
+	rot := eventsCfg.Rotation
+	settings := eventsRotationSettings{
+		enabled:              rot.EnabledOrDefault(),
+		maxSizeBytes:         rot.MaxSizeBytesOrDefault(),
+		checkIntervalRecords: rot.CheckIntervalRecordsOrDefault(),
+		checkInterval:        rot.CheckIntervalDurationOrDefault(),
+		archiveRetainAge:     rot.ArchiveRetainAgeDuration(),
+	}
+	if raw, ok := os.LookupEnv("GC_EVENTS_ROTATION_ENABLED"); ok {
+		if parsed, parseOK := parseEventsRotationEnabled(raw); parseOK {
+			settings.enabled = parsed
+		} else {
+			warnEventsRotation(stderr, "events.rotation: warning: ignoring invalid GC_EVENTS_ROTATION_ENABLED=%q\n", raw)
+		}
+	}
+	if raw, ok := os.LookupEnv("GC_EVENTS_ROTATION_MAX_SIZE_BYTES"); ok {
+		if n, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil {
+			settings.maxSizeBytes = n
+		} else {
+			warnEventsRotation(stderr, "events.rotation: warning: ignoring invalid GC_EVENTS_ROTATION_MAX_SIZE_BYTES=%q\n", raw)
+		}
+	}
+	if raw, ok := os.LookupEnv("GC_EVENTS_ROTATION_RETAIN_AGE"); ok {
+		if strings.TrimSpace(raw) == "" {
+			settings.archiveRetainAge = 0
+		} else if d, err := time.ParseDuration(raw); err == nil {
+			settings.archiveRetainAge = d
+			if d > 0 && d < 168*time.Hour {
+				warnEventsRotation(stderr, "events.rotation: warning: archive_retain_age=%s may delete recent archives\n", raw)
+			}
+		} else {
+			warnEventsRotation(stderr, "events.rotation: warning: ignoring invalid GC_EVENTS_ROTATION_RETAIN_AGE=%q\n", raw)
+		}
+	}
+	return settings
+}
+
+func parseEventsRotationEnabled(raw string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "t", "true", "y", "yes", "on", "enabled":
+		return true, true
+	case "0", "f", "false", "n", "no", "off", "disabled":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func warnEventsRotation(stderr io.Writer, format string, args ...any) {
+	if stderr == nil {
+		return
+	}
+	fmt.Fprintf(stderr, format, args...) //nolint:errcheck // best-effort operator warning
+}
+
+func eventsFileRecorderOptions(eventsCfg config.EventsConfig, stderr io.Writer) []events.FileRecorderOption {
+	settings := eventsRotationSettingsFromConfig(eventsCfg, stderr)
+	maxSize := settings.maxSizeBytes
+	if !settings.enabled {
+		maxSize = 0
+	}
+	return []events.FileRecorderOption{
+		events.WithMaxSize(maxSize),
+		events.WithRotationCheckRecords(settings.checkIntervalRecords),
+		events.WithRotationCheckInterval(settings.checkInterval),
+		events.WithArchiveRetainAge(settings.archiveRetainAge),
+	}
+}
+
+func newFileEventsRecorder(eventsPath string, eventsCfg config.EventsConfig, stderr io.Writer) (*events.FileRecorder, error) {
+	return events.NewFileRecorder(eventsPath, stderr, eventsFileRecorderOptions(eventsCfg, stderr)...)
 }
 
 // openCityEventsProvider resolves the city and returns an events.Provider.
 // Returns (nil, exitCode) on failure.
 func openCityEventsProvider(stderr io.Writer, cmdName string) (events.Provider, int) {
-	return openCityEventsProviderWithName(eventsProviderName, stderr, cmdName)
+	return openCityEventsProviderWithConfig(func() config.EventsConfig {
+		return eventsProviderConfigWithWarnings(stderr)
+	}, stderr, cmdName)
 }
 
 func openCityEventEmitProvider(stderr io.Writer, cmdName string) (events.Provider, int) {
@@ -762,10 +861,17 @@ func openCityEventEmitProvider(stderr io.Writer, cmdName string) (events.Provide
 }
 
 func openCityEventsProviderWithName(providerName func() string, stderr io.Writer, cmdName string) (events.Provider, int) {
+	return openCityEventsProviderWithConfig(func() config.EventsConfig {
+		return config.EventsConfig{Provider: providerName()}
+	}, stderr, cmdName)
+}
+
+func openCityEventsProviderWithConfig(providerConfig func() config.EventsConfig, stderr io.Writer, cmdName string) (events.Provider, int) {
 	// For exec: and test doubles, no city needed.
-	v := providerName()
+	eventsCfg := providerConfig()
+	v := eventsCfg.Provider
 	if strings.HasPrefix(v, "exec:") || v == "fake" || v == "fail" {
-		p, err := newEventsProviderForName(v, "", stderr)
+		p, err := newEventsProviderForNameWithConfig(v, "", stderr, eventsCfg)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
 			return nil, 1
@@ -779,7 +885,7 @@ func openCityEventsProviderWithName(providerName func() string, stderr io.Writer
 		return nil, 1
 	}
 	eventsPath := filepath.Join(cityPath, ".gc", "events.jsonl")
-	p, err := newEventsProviderForName(v, eventsPath, stderr)
+	p, err := newEventsProviderForNameWithConfig(v, eventsPath, stderr, eventsCfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
 		return nil, 1

--- a/cmd/gc/providers_events_rotation_test.go
+++ b/cmd/gc/providers_events_rotation_test.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+func TestEventsRotationSettingsFromConfigDefaults(t *testing.T) {
+	got := eventsRotationSettingsFromConfig(config.EventsConfig{}, io.Discard)
+	if !got.enabled {
+		t.Fatal("enabled = false, want true")
+	}
+	if got.maxSizeBytes != config.DefaultEventsRotationMaxSizeBytes {
+		t.Fatalf("maxSizeBytes = %d, want %d", got.maxSizeBytes, config.DefaultEventsRotationMaxSizeBytes)
+	}
+	if got.checkIntervalRecords != config.DefaultEventsRotationCheckIntervalRecords {
+		t.Fatalf("checkIntervalRecords = %d, want %d", got.checkIntervalRecords, config.DefaultEventsRotationCheckIntervalRecords)
+	}
+	if got.checkInterval != config.DefaultEventsRotationCheckInterval {
+		t.Fatalf("checkInterval = %v, want %v", got.checkInterval, config.DefaultEventsRotationCheckInterval)
+	}
+	if got.archiveRetainAge != 0 {
+		t.Fatalf("archiveRetainAge = %v, want 0", got.archiveRetainAge)
+	}
+}
+
+func TestEventsRotationSettingsEnvOverridesTOML(t *testing.T) {
+	enabled := false
+	maxSize := int64(999999)
+	checkRecords := 33
+	checkSeconds := 44
+	cfg := config.EventsConfig{
+		Rotation: config.EventsRotationConfig{
+			Enabled:              &enabled,
+			MaxSizeBytes:         &maxSize,
+			CheckIntervalRecords: &checkRecords,
+			CheckIntervalSeconds: &checkSeconds,
+			ArchiveRetainAge:     "720h",
+		},
+	}
+	t.Setenv("GC_EVENTS_ROTATION_ENABLED", "true")
+	t.Setenv("GC_EVENTS_ROTATION_MAX_SIZE_BYTES", "2048")
+	t.Setenv("GC_EVENTS_ROTATION_RETAIN_AGE", "24h")
+
+	var stderr strings.Builder
+	got := eventsRotationSettingsFromConfig(cfg, &stderr)
+	if !got.enabled {
+		t.Fatal("enabled = false, want env override true")
+	}
+	if got.maxSizeBytes != 2048 {
+		t.Fatalf("maxSizeBytes = %d, want env override 2048", got.maxSizeBytes)
+	}
+	if got.checkIntervalRecords != 33 {
+		t.Fatalf("checkIntervalRecords = %d, want TOML value 33", got.checkIntervalRecords)
+	}
+	if got.checkInterval != 44*time.Second {
+		t.Fatalf("checkInterval = %v, want TOML value 44s", got.checkInterval)
+	}
+	if got.archiveRetainAge != 24*time.Hour {
+		t.Fatalf("archiveRetainAge = %v, want env override 24h", got.archiveRetainAge)
+	}
+	wantWarning := "events.rotation: warning: archive_retain_age=24h may delete recent archives\n"
+	if stderr.String() != wantWarning {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), wantWarning)
+	}
+}
+
+func TestEventsRotationSettingsWarnsOnInvalidEnvOverrides(t *testing.T) {
+	t.Setenv("GC_EVENTS_ROTATION_ENABLED", "maybe")
+	t.Setenv("GC_EVENTS_ROTATION_MAX_SIZE_BYTES", "large")
+	t.Setenv("GC_EVENTS_ROTATION_RETAIN_AGE", "soon")
+
+	var stderr strings.Builder
+	got := eventsRotationSettingsFromConfig(config.EventsConfig{}, &stderr)
+	if !got.enabled {
+		t.Fatal("enabled = false, want default true after invalid env")
+	}
+	if got.maxSizeBytes != config.DefaultEventsRotationMaxSizeBytes {
+		t.Fatalf("maxSizeBytes = %d, want default %d after invalid env", got.maxSizeBytes, config.DefaultEventsRotationMaxSizeBytes)
+	}
+	if got.archiveRetainAge != 0 {
+		t.Fatalf("archiveRetainAge = %v, want default 0 after invalid env", got.archiveRetainAge)
+	}
+	for _, want := range []string{
+		`events.rotation: warning: ignoring invalid GC_EVENTS_ROTATION_ENABLED="maybe"`,
+		`events.rotation: warning: ignoring invalid GC_EVENTS_ROTATION_MAX_SIZE_BYTES="large"`,
+		`events.rotation: warning: ignoring invalid GC_EVENTS_ROTATION_RETAIN_AGE="soon"`,
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestNewEventsProviderForNameLegacyWrapper(t *testing.T) {
+	ep, err := newEventsProviderForName("fake", "", io.Discard)
+	if err != nil {
+		t.Fatalf("newEventsProviderForName: %v", err)
+	}
+	defer ep.Close() //nolint:errcheck // test cleanup
+	if _, err := ep.List(events.Filter{}); err != nil {
+		t.Fatalf("legacy wrapper did not create fake provider: %v", err)
+	}
+}
+
+func TestOpenCityEventsProviderAppliesRotationConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_EVENTS", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	oldCityFlag, oldRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = oldCityFlag
+		rigFlag = oldRigFlag
+	})
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "test-city"
+
+[events.rotation]
+max_size_bytes = 512
+check_interval_records = 1
+check_interval_seconds = 3600
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	var stderr strings.Builder
+	ep, code := openCityEventsProvider(&stderr, "test")
+	if code != 0 || ep == nil {
+		t.Fatalf("openCityEventsProvider() code = %d, provider nil = %t, stderr = %q", code, ep == nil, stderr.String())
+	}
+	rec, ok := ep.(*events.FileRecorder)
+	if !ok {
+		t.Fatalf("provider = %T, want *events.FileRecorder", ep)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	for i := 0; i < 40; i++ {
+		rec.Record(events.Event{Type: events.BeadCreated, Actor: "test", Subject: strings.Repeat("x", 80)})
+	}
+	rec.WaitForRotations()
+
+	if got := countEventArchives(t, filepath.Join(cityDir, ".gc")); got == 0 {
+		t.Fatal("expected configured small max_size_bytes to produce at least one archive")
+	}
+}
+
+func TestOpenCityEventsProviderEnvCanDisableRotation(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_EVENTS", "")
+	t.Setenv("GC_EVENTS_ROTATION_ENABLED", "false")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	oldCityFlag, oldRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = oldCityFlag
+		rigFlag = oldRigFlag
+	})
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "test-city"
+
+[events.rotation]
+max_size_bytes = 1
+check_interval_records = 1
+check_interval_seconds = 1
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	var stderr strings.Builder
+	ep, code := openCityEventsProvider(&stderr, "test")
+	if code != 0 || ep == nil {
+		t.Fatalf("openCityEventsProvider() code = %d, provider nil = %t, stderr = %q", code, ep == nil, stderr.String())
+	}
+	rec, ok := ep.(*events.FileRecorder)
+	if !ok {
+		t.Fatalf("provider = %T, want *events.FileRecorder", ep)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	for i := 0; i < 40; i++ {
+		rec.Record(events.Event{Type: events.BeadCreated, Actor: "test", Subject: strings.Repeat("x", 80)})
+	}
+	rec.WaitForRotations()
+
+	if got := countEventArchives(t, filepath.Join(cityDir, ".gc")); got != 0 {
+		t.Fatalf("archives = %d, want 0 when env disables rotation", got)
+	}
+}
+
+func TestOpenCityEventsProviderEmitsShortRetainAgeWarningFromConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_EVENTS", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	oldCityFlag, oldRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = oldCityFlag
+		rigFlag = oldRigFlag
+	})
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "test-city"
+
+[events.rotation]
+archive_retain_age = "24h"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	var stderr strings.Builder
+	ep, code := openCityEventsProvider(&stderr, "test")
+	if code != 0 || ep == nil {
+		t.Fatalf("openCityEventsProvider() code = %d, provider nil = %t, stderr = %q", code, ep == nil, stderr.String())
+	}
+	t.Cleanup(func() { _ = ep.Close() })
+
+	want := "events.rotation: warning: archive_retain_age=24h may delete recent archives\n"
+	if stderr.String() != want {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+}
+
+func countEventArchives(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q): %v", dir, err)
+	}
+	count := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, "events.jsonl.archive-") && strings.HasSuffix(name, ".gz") {
+			count++
+		}
+	}
+	return count
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1251,7 +1251,7 @@ gc help [command]
 
 Checks for available work using the agent's work_query config.
 
-Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
+Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -309,6 +309,19 @@ EventsConfig holds events provider settings.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `provider` | string |  |  | Provider selects the events backend: "fake", "fail", "exec:&lt;script&gt;", or "" (default: file-backed JSONL). |
+| `rotation` | EventsRotationConfig |  |  | Rotation configures file-backed JSONL rotation. Defaults are applied by EventsRotationConfig helper methods when this table is absent. |
+
+## EventsRotationConfig
+
+EventsRotationConfig holds file-backed events rotation settings.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `enabled` | boolean |  | `true` | Enabled controls automatic size-triggered rotation. Defaults to true. |
+| `max_size_bytes` | integer |  | `268435456` | MaxSizeBytes is the active events.jsonl size threshold. Defaults to DefaultEventsRotationMaxSizeBytes. |
+| `check_interval_records` | integer |  | `1024` | CheckIntervalRecords is the number of records between size checks. Defaults to DefaultEventsRotationCheckIntervalRecords. |
+| `check_interval_seconds` | integer |  | `60` | CheckIntervalSeconds is the time backstop between size checks. Defaults to DefaultEventsRotationCheckIntervalSeconds. |
+| `archive_retain_age` | string |  |  | ArchiveRetainAge is an optional Go duration. Empty keeps all archives. |
 
 ## FormulasConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1196,11 +1196,46 @@
         "provider": {
           "type": "string",
           "description": "Provider selects the events backend: \"fake\", \"fail\",\n\"exec:\u003cscript\u003e\", or \"\" (default: file-backed JSONL)."
+        },
+        "rotation": {
+          "$ref": "#/$defs/EventsRotationConfig",
+          "description": "Rotation configures file-backed JSONL rotation. Defaults are applied\nby EventsRotationConfig helper methods when this table is absent."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "EventsConfig holds events provider settings."
+    },
+    "EventsRotationConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled controls automatic size-triggered rotation. Defaults to true.",
+          "default": true
+        },
+        "max_size_bytes": {
+          "type": "integer",
+          "description": "MaxSizeBytes is the active events.jsonl size threshold. Defaults to\nDefaultEventsRotationMaxSizeBytes.",
+          "default": 268435456
+        },
+        "check_interval_records": {
+          "type": "integer",
+          "description": "CheckIntervalRecords is the number of records between size checks.\nDefaults to DefaultEventsRotationCheckIntervalRecords.",
+          "default": 1024
+        },
+        "check_interval_seconds": {
+          "type": "integer",
+          "description": "CheckIntervalSeconds is the time backstop between size checks. Defaults\nto DefaultEventsRotationCheckIntervalSeconds.",
+          "default": 60
+        },
+        "archive_retain_age": {
+          "type": "string",
+          "description": "ArchiveRetainAge is an optional Go duration. Empty keeps all archives."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "EventsRotationConfig holds file-backed events rotation settings."
     },
     "FormulasConfig": {
       "properties": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1196,11 +1196,46 @@
         "provider": {
           "type": "string",
           "description": "Provider selects the events backend: \"fake\", \"fail\",\n\"exec:\u003cscript\u003e\", or \"\" (default: file-backed JSONL)."
+        },
+        "rotation": {
+          "$ref": "#/$defs/EventsRotationConfig",
+          "description": "Rotation configures file-backed JSONL rotation. Defaults are applied\nby EventsRotationConfig helper methods when this table is absent."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "EventsConfig holds events provider settings."
+    },
+    "EventsRotationConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled controls automatic size-triggered rotation. Defaults to true.",
+          "default": true
+        },
+        "max_size_bytes": {
+          "type": "integer",
+          "description": "MaxSizeBytes is the active events.jsonl size threshold. Defaults to\nDefaultEventsRotationMaxSizeBytes.",
+          "default": 268435456
+        },
+        "check_interval_records": {
+          "type": "integer",
+          "description": "CheckIntervalRecords is the number of records between size checks.\nDefaults to DefaultEventsRotationCheckIntervalRecords.",
+          "default": 1024
+        },
+        "check_interval_seconds": {
+          "type": "integer",
+          "description": "CheckIntervalSeconds is the time backstop between size checks. Defaults\nto DefaultEventsRotationCheckIntervalSeconds.",
+          "default": 60
+        },
+        "archive_retain_age": {
+          "type": "string",
+          "description": "ArchiveRetainAge is an optional Go duration. Empty keeps all archives."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "EventsRotationConfig holds file-backed events rotation settings."
     },
     "FormulasConfig": {
       "properties": {

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -599,6 +599,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 
 	// Validate all duration strings in the fully-merged config.
 	prov.Warnings = append(prov.Warnings, ValidateDurations(root, path)...)
+	prov.Warnings = append(prov.Warnings, ValidateEventsRotation(root)...)
 
 	// Validate cross-entity semantic constraints.
 	prov.Warnings = append(prov.Warnings, ValidateSemantics(root, path)...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1326,6 +1326,86 @@ type EventsConfig struct {
 	// Provider selects the events backend: "fake", "fail",
 	// "exec:<script>", or "" (default: file-backed JSONL).
 	Provider string `toml:"provider,omitempty"`
+	// Rotation configures file-backed JSONL rotation. Defaults are applied
+	// by EventsRotationConfig helper methods when this table is absent.
+	Rotation EventsRotationConfig `toml:"rotation,omitempty"`
+}
+
+const (
+	// DefaultEventsRotationMaxSizeBytes is the default active events.jsonl
+	// size threshold before auto-rotation.
+	DefaultEventsRotationMaxSizeBytes int64 = 256 * 1024 * 1024
+	// DefaultEventsRotationCheckIntervalRecords is the default number of
+	// records between active file size checks.
+	DefaultEventsRotationCheckIntervalRecords = 1024
+	// DefaultEventsRotationCheckIntervalSeconds is the default time backstop
+	// between active file size checks.
+	DefaultEventsRotationCheckIntervalSeconds = 60
+	// DefaultEventsRotationCheckInterval is the default time backstop between
+	// active file size checks.
+	DefaultEventsRotationCheckInterval = time.Duration(DefaultEventsRotationCheckIntervalSeconds) * time.Second
+)
+
+// EventsRotationConfig holds file-backed events rotation settings.
+type EventsRotationConfig struct {
+	// Enabled controls automatic size-triggered rotation. Defaults to true.
+	Enabled *bool `toml:"enabled,omitempty" jsonschema:"default=true"`
+	// MaxSizeBytes is the active events.jsonl size threshold. Defaults to
+	// DefaultEventsRotationMaxSizeBytes.
+	MaxSizeBytes *int64 `toml:"max_size_bytes,omitempty" jsonschema:"default=268435456"`
+	// CheckIntervalRecords is the number of records between size checks.
+	// Defaults to DefaultEventsRotationCheckIntervalRecords.
+	CheckIntervalRecords *int `toml:"check_interval_records,omitempty" jsonschema:"default=1024"`
+	// CheckIntervalSeconds is the time backstop between size checks. Defaults
+	// to DefaultEventsRotationCheckIntervalSeconds.
+	CheckIntervalSeconds *int `toml:"check_interval_seconds,omitempty" jsonschema:"default=60"`
+	// ArchiveRetainAge is an optional Go duration. Empty keeps all archives.
+	ArchiveRetainAge string `toml:"archive_retain_age,omitempty"`
+}
+
+// EnabledOrDefault reports whether automatic rotation is enabled.
+func (c EventsRotationConfig) EnabledOrDefault() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// MaxSizeBytesOrDefault returns the configured active log size threshold.
+func (c EventsRotationConfig) MaxSizeBytesOrDefault() int64 {
+	if c.MaxSizeBytes == nil {
+		return DefaultEventsRotationMaxSizeBytes
+	}
+	return *c.MaxSizeBytes
+}
+
+// CheckIntervalRecordsOrDefault returns the configured record-count gate.
+func (c EventsRotationConfig) CheckIntervalRecordsOrDefault() int {
+	if c.CheckIntervalRecords == nil {
+		return DefaultEventsRotationCheckIntervalRecords
+	}
+	return *c.CheckIntervalRecords
+}
+
+// CheckIntervalDurationOrDefault returns the configured time gate.
+func (c EventsRotationConfig) CheckIntervalDurationOrDefault() time.Duration {
+	if c.CheckIntervalSeconds == nil {
+		return DefaultEventsRotationCheckInterval
+	}
+	return time.Duration(*c.CheckIntervalSeconds) * time.Second
+}
+
+// ArchiveRetainAgeDuration parses ArchiveRetainAge. Empty or invalid values
+// return zero, which keeps all archives.
+func (c EventsRotationConfig) ArchiveRetainAgeDuration() time.Duration {
+	if strings.TrimSpace(c.ArchiveRetainAge) == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(c.ArchiveRetainAge)
+	if err != nil {
+		return 0
+	}
+	return d
 }
 
 // DoltConfig holds optional dolt server overrides.

--- a/internal/config/events_rotation_test.go
+++ b/internal/config/events_rotation_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEventsRotationConfigRoundTrip(t *testing.T) {
+	enabled := false
+	maxSize := int64(123456)
+	checkRecords := 17
+	checkSeconds := 23
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Events: EventsConfig{
+			Provider: "file",
+			Rotation: EventsRotationConfig{
+				Enabled:              &enabled,
+				MaxSizeBytes:         &maxSize,
+				CheckIntervalRecords: &checkRecords,
+				CheckIntervalSeconds: &checkSeconds,
+				ArchiveRetainAge:     "720h",
+			},
+		},
+	}
+
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"[events.rotation]",
+		"enabled = false",
+		"max_size_bytes = 123456",
+		"check_interval_records = 17",
+		"check_interval_seconds = 23",
+		`archive_retain_age = "720h"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("marshaled config missing %q:\n%s", want, text)
+		}
+	}
+
+	decoded, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	rot := decoded.Events.Rotation
+	if rot.Enabled == nil || *rot.Enabled != false {
+		t.Fatalf("Enabled = %v, want explicit false", rot.Enabled)
+	}
+	if rot.MaxSizeBytes == nil || *rot.MaxSizeBytes != 123456 {
+		t.Fatalf("MaxSizeBytes = %v, want 123456", rot.MaxSizeBytes)
+	}
+	if rot.CheckIntervalRecords == nil || *rot.CheckIntervalRecords != 17 {
+		t.Fatalf("CheckIntervalRecords = %v, want 17", rot.CheckIntervalRecords)
+	}
+	if rot.CheckIntervalSeconds == nil || *rot.CheckIntervalSeconds != 23 {
+		t.Fatalf("CheckIntervalSeconds = %v, want 23", rot.CheckIntervalSeconds)
+	}
+	if rot.ArchiveRetainAge != "720h" {
+		t.Fatalf("ArchiveRetainAge = %q, want 720h", rot.ArchiveRetainAge)
+	}
+}
+
+func TestEventsRotationConfigDefaults(t *testing.T) {
+	var rot EventsRotationConfig
+	if !rot.EnabledOrDefault() {
+		t.Fatal("EnabledOrDefault() = false, want true")
+	}
+	if got := rot.MaxSizeBytesOrDefault(); got != DefaultEventsRotationMaxSizeBytes {
+		t.Fatalf("MaxSizeBytesOrDefault() = %d, want %d", got, DefaultEventsRotationMaxSizeBytes)
+	}
+	if got := rot.CheckIntervalRecordsOrDefault(); got != DefaultEventsRotationCheckIntervalRecords {
+		t.Fatalf("CheckIntervalRecordsOrDefault() = %d, want %d", got, DefaultEventsRotationCheckIntervalRecords)
+	}
+	if got := rot.CheckIntervalDurationOrDefault(); got != DefaultEventsRotationCheckInterval {
+		t.Fatalf("CheckIntervalDurationOrDefault() = %v, want %v", got, DefaultEventsRotationCheckInterval)
+	}
+	if got := rot.ArchiveRetainAgeDuration(); got != 0 {
+		t.Fatalf("ArchiveRetainAgeDuration() = %v, want 0", got)
+	}
+}
+
+func TestValidateEventsRotationWarnsOnShortRetainAge(t *testing.T) {
+	cfg := &City{Events: EventsConfig{Rotation: EventsRotationConfig{ArchiveRetainAge: "24h"}}}
+	warnings := ValidateEventsRotation(cfg)
+	if len(warnings) != 1 {
+		t.Fatalf("ValidateEventsRotation warnings = %d, want 1: %v", len(warnings), warnings)
+	}
+	want := "events.rotation: warning: archive_retain_age=24h may delete recent archives"
+	if warnings[0] != want {
+		t.Fatalf("warning = %q, want %q", warnings[0], want)
+	}
+}
+
+func TestValidateEventsRotationDoesNotWarnForSevenDaysOrUnset(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  *City
+	}{
+		{name: "unset", cfg: &City{}},
+		{name: "zero", cfg: &City{Events: EventsConfig{Rotation: EventsRotationConfig{ArchiveRetainAge: "0s"}}}},
+		{name: "seven days", cfg: &City{Events: EventsConfig{Rotation: EventsRotationConfig{ArchiveRetainAge: (168 * time.Hour).String()}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if warnings := ValidateEventsRotation(tc.cfg); len(warnings) != 0 {
+				t.Fatalf("ValidateEventsRotation() warnings = %v, want none", warnings)
+			}
+		})
+	}
+}

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -186,6 +186,7 @@ func knownTOMLKeys() []string {
 		reflect.TypeOf(SessionConfig{}),
 		reflect.TypeOf(MailConfig{}),
 		reflect.TypeOf(EventsConfig{}),
+		reflect.TypeOf(EventsRotationConfig{}),
 		reflect.TypeOf(DoltConfig{}),
 		reflect.TypeOf(FormulasConfig{}),
 		reflect.TypeOf(DaemonConfig{}),

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -52,6 +52,9 @@ func ValidateDurations(cfg *City, source string) []string {
 	// Orders config durations.
 	check("[orders]", "max_timeout", cfg.Orders.MaxTimeout)
 
+	// Events config durations.
+	check("[events.rotation]", "archive_retain_age", cfg.Events.Rotation.ArchiveRetainAge)
+
 	// Chat sessions config durations.
 	check("[chat_sessions]", "idle_timeout", cfg.ChatSessions.IdleTimeout)
 
@@ -76,4 +79,21 @@ func ValidateDurations(cfg *City, source string) []string {
 	}
 
 	return warnings
+}
+
+// ValidateEventsRotation returns non-fatal warnings for risky but intentional
+// events rotation settings.
+func ValidateEventsRotation(cfg *City) []string {
+	if cfg == nil {
+		return nil
+	}
+	raw := cfg.Events.Rotation.ArchiveRetainAge
+	if raw == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 || d >= 168*time.Hour {
+		return nil
+	}
+	return []string{fmt.Sprintf("events.rotation: warning: archive_retain_age=%s may delete recent archives", raw)}
 }

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -281,11 +281,28 @@ func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) 
 	return reversed, nil
 }
 
-// ReadLatestSeq returns the latest complete event Seq in the events file, or
-// 0 if the file is missing or empty. Event logs are append-only and sequence
-// numbers are monotonic, so this reads backward from the tail instead of
-// parsing historical events on every recorder open.
+// ReadLatestSeq returns the highest complete event Seq visible in the
+// active events file or any canonical sibling archive. Event logs are
+// append-only and sequence numbers are monotonic, so the active file
+// is read backward from the tail and archives contribute their
+// filename-encoded LastSeq without being gunzipped.
 func ReadLatestSeq(path string) (uint64, error) {
+	seq, err := readLatestActiveSeq(path)
+	if err != nil {
+		return 0, err
+	}
+	archives, err := archiveFilesIn(filepath.Dir(path))
+	if err == nil {
+		for _, info := range archives {
+			if info.LastSeq > seq {
+				seq = info.LastSeq
+			}
+		}
+	}
+	return seq, nil
+}
+
+func readLatestActiveSeq(path string) (uint64, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -50,6 +50,7 @@ type FileRecorder struct {
 	maxSize               int64
 	rotationCheckRecords  int
 	rotationCheckInterval time.Duration
+	archiveRetainAge      time.Duration
 	recordCount           uint64
 	lastSizeCheck         time.Time
 }
@@ -80,6 +81,13 @@ func WithRotationCheckRecords(n int) FileRecorderOption {
 // once per interval. Defaults to 60s.
 func WithRotationCheckInterval(d time.Duration) FileRecorderOption {
 	return func(r *FileRecorder) { r.rotationCheckInterval = d }
+}
+
+// WithArchiveRetainAge sets the maximum age of canonical archive
+// files kept after a successful rotation. A non-positive value keeps
+// all archives forever.
+func WithArchiveRetainAge(d time.Duration) FileRecorderOption {
+	return func(r *FileRecorder) { r.archiveRetainAge = d }
 }
 
 // RotationResult is returned by ForceRotate (and B-3's API endpoint)
@@ -146,19 +154,6 @@ func NewFileRecorder(path string, stderr io.Writer, opts ...FileRecorderOption) 
 		return nil, err
 	}
 
-	// Crash recovery: if a prior process rotated events into archives
-	// but the active log is empty or absent, ReadLatestSeq returns 0
-	// and new records would collide with seqs already written to disk.
-	// Take the max of the active tail and every archive's LastSeq so
-	// the next Record continues monotonically across rotations.
-	if archives, archErr := archiveFilesIn(filepath.Dir(path)); archErr == nil {
-		for _, info := range archives {
-			if info.LastSeq > maxSeq {
-				maxSeq = info.LastSeq
-			}
-		}
-	}
-
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("opening event log: %w", err)
@@ -218,7 +213,7 @@ func (r *FileRecorder) Record(e Event) {
 // flock. Returns an error on marshal or write failure; the caller
 // decides whether to log to stderr or surface it.
 func (r *FileRecorder) writeRecordLocked(e *Event) error {
-	if latest, err := ReadLatestSeq(r.path); err == nil && latest > r.seq {
+	if latest, err := readLatestActiveSeq(r.path); err == nil && latest > r.seq {
 		r.seq = latest
 	} else if err != nil {
 		return fmt.Errorf("latest seq: %w", err)
@@ -370,6 +365,7 @@ func (r *FileRecorder) rotateLocked() (RotationResult, error) {
 	}
 
 	done := make(chan struct{})
+	retainAge := r.archiveRetainAge
 	r.rotations.Add(1)
 	go func() {
 		defer r.rotations.Done()
@@ -377,6 +373,10 @@ func (r *FileRecorder) rotateLocked() (RotationResult, error) {
 		if err := gzipAndArchive(rotatingPath, archivePath, r.stderr); err != nil {
 			// gzipAndArchive already wrote to stderr.
 			_ = err
+			return
+		}
+		if err := reapExpiredArchives(dir, retainAge, r.stderr); err != nil {
+			fmt.Fprintf(r.stderr, "events: rotation: archive retention: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
 	}()
 

--- a/internal/events/rotation.go
+++ b/internal/events/rotation.go
@@ -135,6 +135,34 @@ func reapOrphanedRotatingFiles(dir string, stderr io.Writer) error {
 	return nil
 }
 
+// reapExpiredArchives removes canonical archive files older than
+// retainAge. A non-positive retainAge is a no-op. Archive age is
+// based on the UTC timestamp embedded in the canonical filename, so
+// pruning does not need to open or gunzip archive contents.
+func reapExpiredArchives(dir string, retainAge time.Duration, stderr io.Writer) error {
+	if retainAge <= 0 {
+		return nil
+	}
+	archives, err := archiveFilesIn(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	cutoff := time.Now().UTC().Add(-retainAge)
+	for _, info := range archives {
+		if !info.Timestamp.Before(cutoff) {
+			continue
+		}
+		path := filepath.Join(dir, info.Basename)
+		if err := os.Remove(path); err != nil {
+			fmt.Fprintf(stderr, "events: rotation: removing expired archive %q: %v\n", info.Basename, err) //nolint:errcheck // best-effort stderr
+		}
+	}
+	return nil
+}
+
 // archiveRotatingFile is the per-file branch of the reaper. The
 // rotating filename embeds the timestamp and seq window so the
 // archive name can be derived without scanning content. For legacy

--- a/internal/events/rotation_auto_test.go
+++ b/internal/events/rotation_auto_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestRecordAutoRotatesOnSizeThreshold drives the size-gated rotation
@@ -115,6 +116,38 @@ func TestRecordAutoRotateDisabledByZeroMaxSize(t *testing.T) {
 		if strings.HasPrefix(e.Name(), "events.jsonl.rotating-") {
 			t.Errorf("unexpected rotating file %q with MaxSize=0", e.Name())
 		}
+	}
+}
+
+func TestArchiveRetainAgePrunesOldArchivesAfterRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	oldArchive := filepath.Join(dir, formatArchiveBasename(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), 1, 1))
+	if err := os.WriteFile(oldArchive, []byte("stale archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr, WithArchiveRetainAge(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human"})
+	res, err := rec.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate: %v", err)
+	}
+	if res.Done != nil {
+		<-res.Done
+	}
+
+	if _, err := os.Stat(oldArchive); !os.IsNotExist(err) {
+		t.Fatalf("old archive should be pruned by retain age, stat err = %v", err)
+	}
+	if _, err := os.Stat(res.ArchivePath); err != nil {
+		t.Fatalf("fresh archive should remain after retention pruning: %v", err)
 	}
 }
 

--- a/internal/events/rotation_reader_test.go
+++ b/internal/events/rotation_reader_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // seedRecorderWithRotation creates a fresh recorder, writes recordsBefore
@@ -130,6 +131,33 @@ func TestReadFilteredAcrossArchivesAppliesLimit(t *testing.T) {
 	}
 	if got[0].Seq != 1 || got[1].Seq != 2 {
 		t.Errorf("got seqs = [%d,%d], want [1,2]", got[0].Seq, got[1].Seq)
+	}
+}
+
+func TestReadLatestSeqSpansArchiveOnlyLog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+
+	rotating := filepath.Join(dir, "events.jsonl.rotating-20260507T120000Z-seq-100-102")
+	const body = `{"seq":100,"type":"x"}
+{"seq":101,"type":"y"}
+{"seq":102,"type":"z"}
+`
+	if err := os.WriteFile(rotating, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(dir, formatArchiveBasename(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC), 100, 102))
+	var stderr bytes.Buffer
+	if err := gzipAndArchive(rotating, dest, &stderr); err != nil {
+		t.Fatalf("gzipAndArchive: %v", err)
+	}
+
+	seq, err := ReadLatestSeq(path)
+	if err != nil {
+		t.Fatalf("ReadLatestSeq: %v", err)
+	}
+	if seq != 102 {
+		t.Fatalf("ReadLatestSeq archive-only = %d, want 102", seq)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `[events.rotation]` config with defaults for enabled rotation, max size, check interval, and archive retention age.
- Wire rotation settings through file-backed event recorder construction for command recorder, provider, start, stop, and supervisor paths.
- Add env overrides for `GC_EVENTS_ROTATION_ENABLED`, `GC_EVENTS_ROTATION_MAX_SIZE_BYTES`, and `GC_EVENTS_ROTATION_RETAIN_AGE`, including warnings for invalid values and retain ages below 168h.
- Regenerate config schema/reference docs and add focused config/provider tests.

## Stack note
This PR is stacked on #2262 because the config plumbing uses the B-1 `events.WithArchiveRetainAge` recorder option. Until #2262 lands, this PR includes commit `b764ee799` from that branch plus the B-2 commit `692bc51c`.

## Validation
- `go test ./internal/config -run 'TestEventsRotation|TestValidateEventsRotation' -count=1`
- `go test ./cmd/gc -run 'TestEventsRotation|TestOpenCityEventsProvider' -count=1`
- `go test ./cmd/gc -run 'TestNewEventsProviderForNameLegacyWrapper|TestEventsRotationSettings' -count=1`
- `go test ./internal/config -count=1`
- `go test ./internal/events/... -count=1`
- `go test ./cmd/gc -run 'TestEventsProvider|TestOpenCityEventsProvider|TestEventsRotation|TestValidateDurations|TestLoadCityConfig' -count=1`
- `go test ./test/docsync -run TestSchemaFreshness -count=1`
- `make test-fast-parallel`
- `git diff --check`
- `go vet ./...`
- `go build ./...`
- pre-commit hook, including `scripts/go-test-observable test -- -p=4 -count=1 ./...` and `go test ./test/docsync`

`actual status` was attempted but the `actual` CLI is not installed in this worktree environment.
