### PR TITLE
Add JSON summaries for session mutation actions

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1283,7 +1283,8 @@ func buildResumeCommand(cityPath string, cfg *config.City, info session.Info, se
 
 // newSessionSuspendCmd creates the "gc session suspend <id-or-alias>" command.
 func newSessionSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "suspend <session-id-or-alias>",
 		Short: "Suspend a session (save state, free resources)",
 		Long: `Suspend an active session by stopping its runtime process.
@@ -1292,13 +1293,15 @@ The session bead persists and can be resumed later.
 Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionSuspend(args, stdout, stderr) != 0 {
+			if cmdSessionSuspend(args, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeSessionIDs,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
 }
 
 // cmdSessionSuspend is the CLI entry point for "gc session suspend".
@@ -1306,7 +1309,8 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 // Phase 2: sets held_until metadata on the session bead and pokes the
 // controller. The reconciler handles the actual process stop. Falls back
 // to direct suspend via the session manager if the controller isn't running.
-func cmdSessionSuspend(args []string, stdout, stderr io.Writer) int {
+func cmdSessionSuspend(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
 	store, code := openCityStore(stderr, "gc session suspend")
 	if store == nil {
 		return code
@@ -1341,6 +1345,15 @@ func cmdSessionSuspend(args []string, stdout, stderr io.Writer) int {
 			}
 			// Poke again to trigger immediate reconciler tick.
 			_ = pokeController(cityPath)
+			if asJSON {
+				writeSessionActionJSON(stdout, sessionActionResult{
+					Action:    "suspend",
+					SessionID: sessionID,
+					Mode:      "managed",
+					State:     "suspended",
+				})
+				return 0
+			}
 			fmt.Fprintf(stdout, "Session %s suspended. Resume with: gc session wake %s\n", sessionID, sessionID) //nolint:errcheck // best-effort stdout
 			return 0
 		}
@@ -1359,13 +1372,23 @@ func cmdSessionSuspend(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	if asJSON {
+		writeSessionActionJSON(stdout, sessionActionResult{
+			Action:    "suspend",
+			SessionID: sessionID,
+			Mode:      "direct",
+			State:     "suspended",
+		})
+		return 0
+	}
 	fmt.Fprintf(stdout, "Session %s suspended. Resume with: gc session attach %s\n", sessionID, sessionID) //nolint:errcheck // best-effort stdout
 	return 0
 }
 
 // newSessionCloseCmd creates the "gc session close <id-or-alias>" command.
 func newSessionCloseCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "close <session-id-or-alias>",
 		Short: "Close a session permanently",
 		Long: `End a conversation. Stops the runtime if active and closes the bead.
@@ -1373,17 +1396,20 @@ func newSessionCloseCmd(stdout, stderr io.Writer) *cobra.Command {
 Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionClose(args, stdout, stderr) != 0 {
+			if cmdSessionClose(args, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeSessionIDs,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
 }
 
 // cmdSessionClose is the CLI entry point for "gc session close".
-func cmdSessionClose(args []string, stdout, stderr io.Writer) int {
+func cmdSessionClose(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
 	store, code := openCityStore(stderr, "gc session close")
 	if store == nil {
 		return code
@@ -1417,28 +1443,41 @@ func cmdSessionClose(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
+	if asJSON {
+		writeSessionActionJSON(stdout, sessionActionResult{
+			Action:              "close",
+			SessionID:           sessionID,
+			State:               "closed",
+			WaitNudgesWithdrawn: len(closeResult.WaitNudgeIDs),
+		})
+		return 0
+	}
 	fmt.Fprintf(stdout, "Session %s closed.\n", sessionID) //nolint:errcheck // best-effort stdout
 	return 0
 }
 
 // newSessionRenameCmd creates the "gc session rename <id-or-alias> <title>" command.
 func newSessionRenameCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "rename <session-id-or-alias> <title>",
 		Short: "Rename a session",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionRename(args, stdout, stderr) != 0 {
+			if cmdSessionRename(args, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeSessionIDs,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
 }
 
 // cmdSessionRename is the CLI entry point for "gc session rename".
-func cmdSessionRename(args []string, stdout, stderr io.Writer) int {
+func cmdSessionRename(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
 	title := args[1]
 
 	store, code := openCityStore(stderr, "gc session rename")
@@ -1468,6 +1507,14 @@ func cmdSessionRename(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	if asJSON {
+		writeSessionActionJSON(stdout, sessionActionResult{
+			Action:    "rename",
+			SessionID: sessionID,
+			Title:     title,
+		})
+		return 0
+	}
 	fmt.Fprintf(stdout, "Session %s renamed to %q.\n", sessionID, title) //nolint:errcheck // best-effort stdout
 	return 0
 }
@@ -1475,6 +1522,7 @@ func cmdSessionRename(args []string, stdout, stderr io.Writer) int {
 // newSessionPruneCmd creates the "gc session prune" command.
 func newSessionPruneCmd(stdout, stderr io.Writer) *cobra.Command {
 	var beforeStr string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "prune",
 		Short: "Close old suspended sessions",
@@ -1484,18 +1532,20 @@ sessions are affected — active sessions are never pruned.`,
   gc session prune --before 24h`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdSessionPrune(beforeStr, stdout, stderr) != 0 {
+			if cmdSessionPrune(beforeStr, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&beforeStr, "before", "7d", "prune sessions older than this duration (e.g., 7d, 24h)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
 	return cmd
 }
 
 // cmdSessionPrune is the CLI entry point for "gc session prune".
-func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer) int {
+func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
 	dur, err := parsePruneDuration(beforeStr)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session prune: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1526,6 +1576,15 @@ func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer) int {
 		}
 	}
 
+	if asJSON {
+		writeSessionActionJSON(stdout, sessionActionResult{
+			Action: "prune",
+			Count:  &result.Count,
+			Before: beforeStr,
+			Cutoff: cutoff.UTC().Format(time.RFC3339),
+		})
+		return 0
+	}
 	if result.Count == 0 {
 		fmt.Fprintln(stdout, "No sessions to prune.") //nolint:errcheck // best-effort stdout
 	} else {
@@ -1621,7 +1680,8 @@ func cmdSessionPeek(args []string, lines int, stdout, stderr io.Writer) int {
 
 // newSessionKillCmd creates the "gc session kill <id-or-alias>" command.
 func newSessionKillCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "kill <session-id-or-alias>",
 		Short: "Force-kill session runtime (reconciler restarts)",
 		Long: `Force-kill the runtime process for a session without changing its bead state.
@@ -1633,17 +1693,20 @@ useful for unsticking a session without losing its conversation history.
 Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionKill(args, stdout, stderr) != 0 {
+			if cmdSessionKill(args, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeSessionIDs,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
 }
 
 // cmdSessionKill is the CLI entry point for "gc session kill".
-func cmdSessionKill(args []string, stdout, stderr io.Writer) int {
+func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
 	store, code := openCityStore(stderr, "gc session kill")
 	if store == nil {
 		return code
@@ -1684,6 +1747,13 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer) int {
 		Payload: api.SessionLifecyclePayloadJSON(sessionID, "", "killed"),
 	})
 
+	if asJSON {
+		writeSessionActionJSON(stdout, sessionActionResult{
+			Action:    "kill",
+			SessionID: sessionID,
+		})
+		return 0
+	}
 	fmt.Fprintf(stdout, "Session %s killed.\n", sessionID) //nolint:errcheck // best-effort stdout
 	return 0
 }

--- a/cmd/gc/cmd_session_pin.go
+++ b/cmd/gc/cmd_session_pin.go
@@ -10,7 +10,8 @@ import (
 )
 
 func newSessionPinCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "pin <session-id-or-alias>",
 		Short: "Keep a session awake",
 		Long: `Keep a session awake by setting its durable pin override.
@@ -20,17 +21,20 @@ a configured named session that has not been materialized yet, pin creates its
 canonical bead so the reconciler can start it when unblocked.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionPin(args, stdout, stderr) != 0 {
+			if cmdSessionPin(args, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeSessionIDs,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
 }
 
 func newSessionUnpinCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "unpin <session-id-or-alias>",
 		Short: "Remove a session awake pin",
 		Long: `Remove only the durable pin override from a session.
@@ -39,24 +43,27 @@ Unpinning does not force an immediate stop. The reconciler will apply the
 normal wake/sleep rules on its next pass.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionUnpin(args, stdout, stderr) != 0 {
+			if cmdSessionUnpin(args, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeSessionIDs,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
 }
 
-func cmdSessionPin(args []string, stdout, stderr io.Writer) int {
-	return cmdSessionSetPin(args, true, stdout, stderr)
+func cmdSessionPin(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	return cmdSessionSetPin(args, true, stdout, stderr, jsonOutput...)
 }
 
-func cmdSessionUnpin(args []string, stdout, stderr io.Writer) int {
-	return cmdSessionSetPin(args, false, stdout, stderr)
+func cmdSessionUnpin(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	return cmdSessionSetPin(args, false, stdout, stderr, jsonOutput...)
 }
 
-func cmdSessionSetPin(args []string, pinned bool, stdout, stderr io.Writer) int {
+func cmdSessionSetPin(args []string, pinned bool, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
 	action := "unpin"
 	if pinned {
 		action = "pin"
@@ -122,6 +129,15 @@ func cmdSessionSetPin(args []string, pinned bool, stdout, stderr io.Writer) int 
 	}
 	pokeSessionPinController(cityErr, cityPath)
 
+	if asJSON {
+		writeSessionActionJSON(stdout, sessionActionResult{
+			Action:            action,
+			SessionID:         id,
+			Pinned:            &pinned,
+			MaterializedNamed: materializedForPin,
+		})
+		return 0
+	}
 	if pinned {
 		fmt.Fprintf(stdout, "Session %s pinned awake.\n", id) //nolint:errcheck
 	} else {

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -10,7 +10,8 @@ import (
 
 // newSessionResetCmd creates the "gc session reset <id-or-alias>" command.
 func newSessionResetCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "reset <session-id-or-alias>",
 		Short: "Restart a session fresh while preserving the bead",
 		Long: `Request a fresh restart for an existing session without closing its bead.
@@ -24,13 +25,15 @@ the fresh restart.
 Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionReset(args, stdout, stderr) != 0 {
+			if cmdSessionReset(args, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeSessionIDs,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
 }
 
 // cmdSessionReset is the CLI entry point for "gc session reset".
@@ -38,7 +41,8 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 // This command intentionally requires a managed controller. The controller owns
 // the fresh restart lifecycle, including key rotation and immediate restart of
 // already-desired sessions.
-func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
+func cmdSessionReset(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
 	store, code := openCityStore(stderr, "gc session reset")
 	if store == nil {
 		return code
@@ -92,6 +96,14 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 
 	_ = pokeController(cityPath)
 
+	if asJSON {
+		writeSessionActionJSON(stdout, sessionActionResult{
+			Action:    "reset",
+			SessionID: sessionID,
+			Identity:  identity,
+		})
+		return 0
+	}
 	fmt.Fprintf(stdout, "Session %s reset requested. Controller will restart it fresh.\n", sessionID) //nolint:errcheck // best-effort stdout
 	return 0
 }

--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -14,7 +14,8 @@ import (
 
 // newSessionWakeCmd creates the "gc session wake <id-or-alias>" command.
 func newSessionWakeCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "wake <session-id-or-alias>",
 		Short: "Wake a session (request start and clear holds)",
 		Long: `Request wake for a session and release user hold or crash-loop quarantine metadata.
@@ -28,17 +29,20 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
   gc session wake mayor`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionWake(args, stdout, stderr) != 0 {
+			if cmdSessionWake(args, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 		ValidArgsFunction: completeSessionIDs,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
+	return cmd
 }
 
 // cmdSessionWake is the CLI entry point for "gc session wake".
-func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
+func cmdSessionWake(args []string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+	asJSON := sessionJSONRequested(jsonOutput)
 	store, code := openCityStore(stderr, "gc session wake")
 	if store == nil {
 		return code
@@ -99,6 +103,15 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
+	if asJSON {
+		writeSessionActionJSON(stdout, sessionActionResult{
+			Action:              "wake",
+			SessionID:           id,
+			State:               "wake_requested",
+			WaitNudgesWithdrawn: len(nudgeIDs),
+		})
+		return 0
+	}
 	fmt.Fprintf(stdout, "Session %s: wake requested.\n", id) //nolint:errcheck
 	return 0
 }

--- a/cmd/gc/session_action_json.go
+++ b/cmd/gc/session_action_json.go
@@ -1,0 +1,30 @@
+package main
+
+import "io"
+
+type sessionActionResult struct {
+	SchemaVersion       string `json:"schema_version"`
+	OK                  bool   `json:"ok"`
+	Action              string `json:"action"`
+	SessionID           string `json:"session_id,omitempty"`
+	State               string `json:"state,omitempty"`
+	Mode                string `json:"mode,omitempty"`
+	Title               string `json:"title,omitempty"`
+	Identity            string `json:"identity,omitempty"`
+	Before              string `json:"before,omitempty"`
+	Cutoff              string `json:"cutoff,omitempty"`
+	Count               *int   `json:"count,omitempty"`
+	WaitNudgesWithdrawn int    `json:"wait_nudges_withdrawn,omitempty"`
+	Pinned              *bool  `json:"pinned,omitempty"`
+	MaterializedNamed   bool   `json:"materialized_named,omitempty"`
+}
+
+func sessionJSONRequested(values []bool) bool {
+	return len(values) > 0 && values[0]
+}
+
+func writeSessionActionJSON(stdout io.Writer, result sessionActionResult) {
+	result.SchemaVersion = "1"
+	result.OK = true
+	_ = writeCLIJSONLine(stdout, result)
+}

--- a/cmd/gc/session_action_json_test.go
+++ b/cmd/gc/session_action_json_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSessionActionJSONLine(t *testing.T) {
+	var stdout bytes.Buffer
+	pinned := true
+	writeSessionActionJSON(&stdout, sessionActionResult{
+		Action:            "pin",
+		SessionID:         "gc-1",
+		Pinned:            &pinned,
+		MaterializedNamed: true,
+	})
+
+	if strings.Count(stdout.String(), "\n") != 1 {
+		t.Fatalf("stdout = %q, want exactly one JSONL record", stdout.String())
+	}
+	var got struct {
+		SchemaVersion     string `json:"schema_version"`
+		OK                bool   `json:"ok"`
+		Action            string `json:"action"`
+		SessionID         string `json:"session_id"`
+		Pinned            bool   `json:"pinned"`
+		MaterializedNamed bool   `json:"materialized_named"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || !got.OK || got.Action != "pin" || got.SessionID != "gc-1" || !got.Pinned || !got.MaterializedNamed {
+		t.Fatalf("payload = %+v", got)
+	}
+}
+
+func TestSessionMutationActionSchemasDeclared(t *testing.T) {
+	for _, args := range [][]string{
+		{"session", "wake", "--json-schema=result"},
+		{"session", "suspend", "--json-schema=result"},
+		{"session", "close", "--json-schema=result"},
+		{"session", "kill", "--json-schema=result"},
+		{"session", "rename", "--json-schema=result"},
+		{"session", "prune", "--json-schema=result"},
+		{"session", "reset", "--json-schema=result"},
+		{"session", "pin", "--json-schema=result"},
+		{"session", "unpin", "--json-schema=result"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%v) = %d; stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var schema struct {
+				XGCJSONL map[string]any `json:"x-gc-jsonl"`
+				Required []string       `json:"required"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+				t.Fatalf("schema is not JSON: %v\n%s", err, stdout.String())
+			}
+			if schema.XGCJSONL == nil {
+				t.Fatalf("schema missing x-gc-jsonl: %s", stdout.String())
+			}
+			if strings.Join(schema.Required, ",") == "" {
+				t.Fatalf("schema required is empty: %s", stdout.String())
+			}
+		})
+	}
+}

--- a/schemas/session/close/result.schema.json
+++ b/schemas/session/close/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "close" },
+    "session_id": { "type": "string", "minLength": 1 },
+    "state": { "type": "string" },
+    "wait_nudges_withdrawn": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["schema_version", "ok", "action", "session_id"],
+  "additionalProperties": false
+}

--- a/schemas/session/kill/result.schema.json
+++ b/schemas/session/kill/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "kill" },
+    "session_id": { "type": "string", "minLength": 1 }
+  },
+  "required": ["schema_version", "ok", "action", "session_id"],
+  "additionalProperties": false
+}

--- a/schemas/session/pin/result.schema.json
+++ b/schemas/session/pin/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "pin" },
+    "session_id": { "type": "string", "minLength": 1 },
+    "pinned": { "const": true },
+    "materialized_named": { "type": "boolean" }
+  },
+  "required": ["schema_version", "ok", "action", "session_id", "pinned"],
+  "additionalProperties": false
+}

--- a/schemas/session/prune/result.schema.json
+++ b/schemas/session/prune/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "prune" },
+    "count": { "type": "integer", "minimum": 0 },
+    "before": { "type": "string", "minLength": 1 },
+    "cutoff": { "type": "string", "format": "date-time" }
+  },
+  "required": ["schema_version", "ok", "action", "count", "before", "cutoff"],
+  "additionalProperties": false
+}

--- a/schemas/session/rename/result.schema.json
+++ b/schemas/session/rename/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "rename" },
+    "session_id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string" }
+  },
+  "required": ["schema_version", "ok", "action", "session_id", "title"],
+  "additionalProperties": false
+}

--- a/schemas/session/reset/result.schema.json
+++ b/schemas/session/reset/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "reset" },
+    "session_id": { "type": "string", "minLength": 1 },
+    "identity": { "type": "string" }
+  },
+  "required": ["schema_version", "ok", "action", "session_id"],
+  "additionalProperties": false
+}

--- a/schemas/session/suspend/result.schema.json
+++ b/schemas/session/suspend/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "suspend" },
+    "session_id": { "type": "string", "minLength": 1 },
+    "state": { "type": "string" },
+    "mode": { "enum": ["managed", "direct"] }
+  },
+  "required": ["schema_version", "ok", "action", "session_id"],
+  "additionalProperties": false
+}

--- a/schemas/session/unpin/result.schema.json
+++ b/schemas/session/unpin/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "unpin" },
+    "session_id": { "type": "string", "minLength": 1 },
+    "pinned": { "const": false }
+  },
+  "required": ["schema_version", "ok", "action", "session_id", "pinned"],
+  "additionalProperties": false
+}

--- a/schemas/session/wake/result.schema.json
+++ b/schemas/session/wake/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "action": { "const": "wake" },
+    "session_id": { "type": "string", "minLength": 1 },
+    "state": { "type": "string" },
+    "wait_nudges_withdrawn": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["schema_version", "ok", "action", "session_id"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- Adds native `--json` success summaries for bounded session mutation/action commands: `wake`, `suspend`, `close`, `kill`, `rename`, `prune`, `reset`, `pin`, and `unpin`.
- Adds JSON Schema 2020-12 result schemas under `schemas/session/<command>/result.schema.json` for each covered command.
- Adds focused tests for the shared session action JSONL helper and schema discovery.

## JSON shape notes
- These commands had no prior native JSON success shape, so this introduces one JSONL object per successful bounded command.
- Success records use `schema_version: "1"`, `ok: true`, `action`, and command-specific fields such as `session_id`, `state`, `mode`, `title`, `count`, `cutoff`, `pinned`, and `materialized_named` where applicable.
- Human output remains the default and is unchanged outside the new `--json` path.

## Deferred surface
- Deferred `gc session new` because the default attach behavior and provider start path deserve a separate, more careful JSON contract.
- Deferred `submit` and `nudge` because they cross API/provider delivery paths and queue/immediate delivery semantics.
- Existing list/peek/logs surfaces were intentionally left alone as already covered or out of this shard.

## Validation
- `go test ./cmd/gc -run 'TestSessionActionJSONLine|TestSessionMutationActionSchemasDeclared|TestJSONSchema|TestPhase2CmdSessionPin|TestCmdSessionWake|TestSessionReset'`
- `git diff --check`
- `make fmt-check`
- `go test ./cmd/gc -run 'TestSessionActionJSONLine|TestSessionMutationActionSchemasDeclared|TestJSONSchema'`
- `GOOS=linux make lint`
- `make vet`
- `make check-docs`

## Risks
- `reset`, `suspend`, `close`, `kill`, and `rename` still rely on their existing provider/controller side effects before emitting JSON; failures use the platform structured failure wrapper.
- `prune` emits `cutoff` based on current time, so callers should treat it as an execution summary rather than stable fixture data.

