### PR TITLE
feat: add lifecycle action JSON summaries

### DIFF
--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -16,6 +16,7 @@ import (
 
 func newRegisterCmd(stdout, stderr io.Writer) *cobra.Command {
 	var nameFlag string
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "register [path]",
 		Short: "Register a city with the machine-wide supervisor",
@@ -31,13 +32,14 @@ Registration is idempotent — registering the same city twice is a no-op.
 The supervisor is started if needed and immediately reconciles the city.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if doRegisterWithOptions(args, nameFlag, stdout, stderr) != 0 {
+			if doRegisterWithOptionsJSON(args, nameFlag, jsonOut, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&nameFlag, "name", "", "machine-local alias for this city registration")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	return cmd
 }
 
@@ -46,6 +48,10 @@ func doRegister(args []string, stdout, stderr io.Writer) int {
 }
 
 func doRegisterWithOptions(args []string, nameOverride string, stdout, stderr io.Writer) int {
+	return doRegisterWithOptionsJSON(args, nameOverride, false, stdout, stderr)
+}
+
+func doRegisterWithOptionsJSON(args []string, nameOverride string, jsonOut bool, stdout, stderr io.Writer) int {
 	var cityPath string
 	var err error
 	if len(args) > 0 {
@@ -68,7 +74,22 @@ func doRegisterWithOptions(args []string, nameOverride string, stdout, stderr io
 		fmt.Fprintf(stderr, "gc register: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	return registerCityWithSupervisorNamed(cityPath, registerName, stdout, stderr, "gc register", true)
+	registerStdout := stdout
+	if jsonOut {
+		registerStdout = io.Discard
+	}
+	code := registerCityWithSupervisorNamed(cityPath, registerName, registerStdout, stderr, "gc register", true)
+	if code != 0 || !jsonOut {
+		return code
+	}
+	_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+		Command:  "register",
+		Action:   "register",
+		Message:  "City registered.",
+		CityName: registerName,
+		CityPath: cityPath,
+	})
+	return 0
 }
 
 // resolveRegistrationName returns the machine-local alias to store in the
@@ -87,6 +108,7 @@ func resolveRegistrationName(cityPath, nameOverride string) (string, error) {
 }
 
 func newUnregisterCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "unregister [path]",
 		Short: "Remove a city from the machine-wide supervisor",
@@ -96,16 +118,21 @@ If no path is given, unregisters the current city (discovered from cwd).
 If the supervisor is running, it immediately stops managing the city.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if doUnregister(args, stdout, stderr) != 0 {
+			if doUnregisterJSON(args, jsonOut, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	return cmd
 }
 
 func doUnregister(args []string, stdout, stderr io.Writer) int {
+	return doUnregisterJSON(args, false, stdout, stderr)
+}
+
+func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	var cityPath string
 	var err error
 	if len(args) > 0 {
@@ -120,7 +147,26 @@ func doUnregister(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc unregister: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	_, code := unregisterCityFromSupervisor(cityPath, stdout, stderr)
+	entry, registered, _ := registeredCityEntry(cityPath)
+	unregisterStdout := stdout
+	if jsonOut {
+		unregisterStdout = io.Discard
+	}
+	_, code := unregisterCityFromSupervisor(cityPath, unregisterStdout, stderr)
+	if code != 0 || !jsonOut {
+		return code
+	}
+	cityName := ""
+	if registered {
+		cityName = entry.EffectiveName()
+	}
+	_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+		Command:  "unregister",
+		Action:   "unregister",
+		Message:  "City unregistered.",
+		CityName: cityName,
+		CityPath: cityPath,
+	})
 	return code
 }
 

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -80,6 +80,7 @@ type reloadRequest struct {
 func newReloadCmd(stdout, stderr io.Writer) *cobra.Command {
 	var async bool
 	var soft bool
+	var jsonOut bool
 	var timeoutValue string
 	cmd := &cobra.Command{
 		Use:   "reload [path]",
@@ -104,7 +105,7 @@ drain handles them on the next tick.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			timeoutChanged := cmd.Flags().Changed("timeout")
-			if cmdReload(args, async, soft, timeoutValue, timeoutChanged, stdout, stderr) != 0 {
+			if cmdReload(args, async, soft, jsonOut, timeoutValue, timeoutChanged, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -112,11 +113,12 @@ drain handles them on the next tick.`,
 	}
 	cmd.Flags().BoolVar(&async, "async", false, "Return after the controller accepts the reload request")
 	cmd.Flags().BoolVar(&soft, "soft", false, "Accept config drift on open sessions instead of draining them")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	cmd.Flags().StringVar(&timeoutValue, "timeout", "5m", "How long to wait for reload completion")
 	return cmd
 }
 
-func cmdReload(args []string, async bool, soft bool, timeoutValue string, timeoutChanged bool, stdout, stderr io.Writer) int {
+func cmdReload(args []string, async bool, soft bool, jsonOut bool, timeoutValue string, timeoutChanged bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCommandCity(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -156,10 +158,22 @@ func cmdReload(args []string, async bool, soft bool, timeoutValue string, timeou
 
 	switch reply.Outcome {
 	case reloadOutcomeAccepted, reloadOutcomeApplied, reloadOutcomeNoChange:
-		if strings.TrimSpace(reply.Message) != "" {
+		message := strings.TrimSpace(reply.Message)
+		if jsonOut {
+			_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+				Command:  "reload",
+				Action:   "reload",
+				Message:  message,
+				CityPath: cityPath,
+				Async:    lifecycleBoolPtr(async),
+				Soft:     lifecycleBoolPtr(soft),
+				Outcome:  string(reply.Outcome),
+				Revision: reply.Revision,
+			})
+		} else if message != "" {
 			fmt.Fprintln(stdout, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stdout
 		}
-		if soft && reply.AcceptedDriftCount != nil {
+		if !jsonOut && soft && reply.AcceptedDriftCount != nil {
 			fmt.Fprintf(stdout, "soft reload: accepted config drift on %d session(s)\n", *reply.AcceptedDriftCount) //nolint:errcheck // best-effort stdout
 		}
 		for _, warning := range reply.Warnings {

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -75,7 +75,7 @@ func TestCmdReloadJSONApplied(t *testing.T) {
 		reloadUnavailableMessageHook = oldUnavailable
 	})
 
-	sendReloadControlRequestHook = func(cityPath string, req reloadControlRequest) (reloadControlReply, error) {
+	sendReloadControlRequestHook = func(_ string, _ reloadControlRequest) (reloadControlReply, error) {
 		return reloadControlReply{
 			Outcome:  reloadOutcomeApplied,
 			Message:  "Config reloaded",

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -53,7 +53,7 @@ func TestCmdReloadApplied(t *testing.T) {
 	reloadUnavailableMessageHook = func(string) string { return "" }
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, false, "30s", true, &stdout, &stderr); code != 0 {
+	if code := cmdReload([]string{dir}, false, false, false, "30s", true, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdReload = %d; stderr=%s", code, stderr.String())
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "Config reloaded: 1 agents, 0 rigs (rev abc123def456)" {
@@ -61,6 +61,45 @@ func TestCmdReloadApplied(t *testing.T) {
 	}
 	if got := strings.TrimSpace(stderr.String()); got != "gc reload: warning: service reload: boom" {
 		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestCmdReloadJSONApplied(t *testing.T) {
+	dir := shortSocketTempDir(t, "gc-reload-json-cli-")
+	writeCityTOML(t, dir, "test", "mayor")
+
+	oldSend := sendReloadControlRequestHook
+	oldUnavailable := reloadUnavailableMessageHook
+	t.Cleanup(func() {
+		sendReloadControlRequestHook = oldSend
+		reloadUnavailableMessageHook = oldUnavailable
+	})
+
+	sendReloadControlRequestHook = func(cityPath string, req reloadControlRequest) (reloadControlReply, error) {
+		return reloadControlReply{
+			Outcome:  reloadOutcomeApplied,
+			Message:  "Config reloaded",
+			Revision: "abc123def4567890",
+		}, nil
+	}
+	reloadUnavailableMessageHook = func(string) string { return "" }
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdReload([]string{dir}, false, false, true, "30s", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdReload = %d; stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	var got lifecycleActionJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || !got.OK || got.Command != "reload" || got.Outcome != "applied" || got.Revision != "abc123def4567890" {
+		t.Fatalf("payload = %+v", got)
+	}
+	if got.Async == nil || *got.Async || got.Soft == nil || *got.Soft {
+		t.Fatalf("async/soft = %v/%v, want false/false", got.Async, got.Soft)
 	}
 }
 
@@ -93,7 +132,7 @@ func TestCmdReloadSoftPrintsAcceptedDriftCount(t *testing.T) {
 	reloadUnavailableMessageHook = func(string) string { return "" }
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, true, "30s", true, &stdout, &stderr); code != 0 {
+	if code := cmdReload([]string{dir}, false, true, false, "30s", true, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdReload = %d; stderr=%s", code, stderr.String())
 	}
 	wantStdout := "Config reloaded: 1 agents, 0 rigs (rev abc123def456)\nsoft reload: accepted config drift on 2 session(s)"
@@ -120,7 +159,7 @@ func TestCmdReloadAsyncExplicitTimeoutInvalid(t *testing.T) {
 	writeCityTOML(t, dir, "test", "mayor")
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, true, false, "30s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, true, false, false, "30s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), "--async and --timeout cannot be used together") {
@@ -152,7 +191,7 @@ func TestCmdReloadControllerUnavailableUsesRicherMessage(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, false, "5s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, false, false, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if got := strings.TrimSpace(stderr.String()); got != "gc reload: city failed to start under supervisor: fetching packs: auth denied: connecting to controller: dial failed" {
@@ -183,7 +222,7 @@ func TestCmdReloadControllerUnresponsiveUsesRicherMessage(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, false, "5s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, false, false, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if got := strings.TrimSpace(stderr.String()); got != "gc reload: controller is running but not responding: reading response: i/o timeout" {
@@ -210,7 +249,7 @@ func TestCmdReloadPreservesProtocolErrors(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, false, "5s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, false, false, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if got := strings.TrimSpace(stderr.String()); got != "gc reload: parsing response: invalid character 'o' in literal null" {
@@ -241,7 +280,7 @@ func TestCmdReloadFailedReplyPrintsWarnings(t *testing.T) {
 	reloadUnavailableMessageHook = func(string) string { return "" }
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, false, "5s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, false, false, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	got := stderr.String()

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -34,11 +34,6 @@ immediate reconcile.`,
 	return cmd
 }
 
-// cmdRestart stops the city, then re-starts it under the supervisor.
-func cmdRestart(args []string, stdout, stderr io.Writer) int {
-	return cmdRestartJSON(args, stdout, stderr, false)
-}
-
 func cmdRestartJSON(args []string, stdout, stderr io.Writer, jsonOut bool) int {
 	nameOverride, err := restartRegistrationName(args)
 	if err != nil {

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -13,7 +13,8 @@ import (
 
 // newRestartCmd creates the top-level "gc restart" command.
 func newRestartCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "restart [path]",
 		Short: "Restart all agent sessions in the city",
 		Long: `Restart the city by stopping it then starting it again.
@@ -23,25 +24,52 @@ mode this unregisters the city, then re-registers it and triggers an
 immediate reconcile.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdRestart(args, stdout, stderr) != 0 {
+			if cmdRestartJSON(args, stdout, stderr, jsonOut) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
+	return cmd
 }
 
 // cmdRestart stops the city, then re-starts it under the supervisor.
 func cmdRestart(args []string, stdout, stderr io.Writer) int {
+	return cmdRestartJSON(args, stdout, stderr, false)
+}
+
+func cmdRestartJSON(args []string, stdout, stderr io.Writer, jsonOut bool) int {
 	nameOverride, err := restartRegistrationName(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc restart: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if code := cmdStop(args, stdout, stderr, 0, false); code != 0 {
+	restartStdout := stdout
+	if jsonOut {
+		restartStdout = io.Discard
+	}
+	if code := cmdStop(args, restartStdout, stderr, 0, false); code != 0 {
 		return code
 	}
-	return doStartWithNameOverride(args, false /*controllerMode*/, stdout, stderr, nameOverride)
+	code := doStartWithNameOverride(args, false /*controllerMode*/, restartStdout, stderr, nameOverride)
+	if code != 0 || !jsonOut {
+		return code
+	}
+	cityPath := ""
+	if dir, err := resolveStartDir(args); err == nil {
+		if resolved, err := requireBootstrappedCity(dir); err == nil {
+			cityPath = resolved
+		}
+	}
+	_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+		Command:  "restart",
+		Action:   "restart",
+		Message:  "City restarted under supervisor.",
+		CityName: nameOverride,
+		CityPath: cityPath,
+	})
+	return 0
 }
 
 func restartRegistrationName(args []string) (string, error) {

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -287,6 +287,7 @@ func buildMaxSessionAgeTracker(cfg *config.City, cityName string, sp runtime.Pro
 
 func newStartCmd(stdout, stderr io.Writer) *cobra.Command {
 	var foregroundMode bool
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "start [path]",
 		Short: "Start the city under the machine-wide supervisor",
@@ -302,7 +303,11 @@ Use "gc supervisor run" for foreground operation.`,
   gc supervisor run`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if doStart(args, foregroundMode, stdout, stderr) != 0 {
+			if jsonOut && (foregroundMode || dryRunMode) {
+				fmt.Fprintln(stderr, "gc start: --json is only supported for supervisor-managed start") //nolint:errcheck // best-effort stderr
+				return errExit
+			}
+			if doStartJSON(args, foregroundMode, jsonOut, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -324,6 +329,7 @@ Use "gc supervisor run" for foreground operation.`,
 		"preview what agents would start without starting them")
 	cmd.Flags().BoolVar(&noAutoRestartMode, "no-auto-restart", false,
 		"detect supervisor binary drift but do not auto-restart; exits non-zero on drift")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	return cmd
 }
 
@@ -331,7 +337,18 @@ func doStart(args []string, controllerMode bool, stdout, stderr io.Writer) int {
 	return doStartWithNameOverride(args, controllerMode, stdout, stderr, "")
 }
 
+func doStartJSON(args []string, controllerMode bool, jsonOut bool, stdout, stderr io.Writer) int {
+	if !jsonOut {
+		return doStart(args, controllerMode, stdout, stderr)
+	}
+	return doStartWithNameOverrideJSON(args, controllerMode, stdout, stderr, "", true)
+}
+
 func doStartWithNameOverride(args []string, controllerMode bool, stdout, stderr io.Writer, nameOverride string) int {
+	return doStartWithNameOverrideJSON(args, controllerMode, stdout, stderr, nameOverride, false)
+}
+
+func doStartWithNameOverrideJSON(args []string, controllerMode bool, stdout, stderr io.Writer, nameOverride string, jsonOut bool) int {
 	// --foreground / --controller bypass the supervisor entirely (legacy
 	// standalone reconciler). No drift to check.
 	if controllerMode {
@@ -393,8 +410,26 @@ func doStartWithNameOverride(args []string, controllerMode bool, stdout, stderr 
 		printDoltAuthorIdentityBlock(stderr, "gc start", status)
 		return 1
 	}
-	if code := registerCityWithSupervisorNamed(cityPath, nameOverride, stdout, stderr, "gc start", true); code != 0 {
+	startStdout := stdout
+	if jsonOut {
+		startStdout = io.Discard
+	}
+	if code := registerCityWithSupervisorNamed(cityPath, nameOverride, startStdout, stderr, "gc start", true); code != 0 {
 		return code
+	}
+	if jsonOut {
+		cityName := nameOverride
+		if entry, registered, err := registeredCityEntry(cityPath); err == nil && registered {
+			cityName = entry.EffectiveName()
+		}
+		_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+			Command:  "start",
+			Action:   "start",
+			Message:  "City started under supervisor.",
+			CityName: cityName,
+			CityPath: cityPath,
+		})
+		return 0
 	}
 	fmt.Fprintln(stdout, "City started under supervisor.") //nolint:errcheck // best-effort stdout
 	return 0

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -20,6 +20,7 @@ import (
 func newStopCmd(stdout, stderr io.Writer) *cobra.Command {
 	var wallClockTimeout time.Duration
 	var force bool
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "stop [path]",
 		Short: "Stop all agent sessions in the city",
@@ -37,7 +38,7 @@ cleanup pass. Use --force to skip the interrupt grace period and go
 straight to kill.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdStop(args, stdout, stderr, wallClockTimeout, force) != 0 {
+			if cmdStopJSON(args, stdout, stderr, wallClockTimeout, force, jsonOut) != 0 {
 				return errExit
 			}
 			return nil
@@ -45,6 +46,7 @@ straight to kill.`,
 	}
 	cmd.Flags().DurationVar(&wallClockTimeout, "timeout", 0, "wall-clock cap for the stop sequence (0 = derive from city config)")
 	cmd.Flags().BoolVar(&force, "force", false, "skip the interrupt grace period and force-kill all sessions immediately")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	return cmd
 }
 
@@ -60,13 +62,22 @@ const sleepReasonCityStop = "city-stop"
 // is used. force=true skips the interrupt grace period (gracefulStopAll
 // runs with timeout=0, going straight to kill).
 func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Duration, force bool) int {
+	return cmdStopJSON(args, stdout, stderr, wallClockTimeout, force, false)
+}
+
+func cmdStopJSON(args []string, stdout, stderr io.Writer, wallClockTimeout time.Duration, force bool, jsonOut bool) int {
 	cityPath, err := resolveStopCityPath(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	if handled, code := unregisterCityFromSupervisorWithForce(cityPath, stdout, stderr, "gc stop", force); handled {
+	stopStdout := stdout
+	if jsonOut {
+		stopStdout = io.Discard
+	}
+
+	if handled, code := unregisterCityFromSupervisorWithForce(cityPath, stopStdout, stderr, "gc stop", force); handled {
 		if code != 0 {
 			return code
 		}
@@ -75,6 +86,9 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 				return 1
 			}
 			warnInvalidConfigAfterSuccessfulStop(cityPath, stderr)
+			if jsonOut {
+				return writeCityStopSuccess(stdout, cityPath, force)
+			}
 			fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
 			return 0
 		}
@@ -82,7 +96,10 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		if handled, code := stopManagedRuntimeWithoutConfig(cityPath, err, stdout, stderr, force); handled {
+		if handled, code := stopManagedRuntimeWithoutConfig(cityPath, err, stopStdout, stderr, force); handled {
+			if code == 0 && jsonOut {
+				return writeCityStopSuccess(stdout, cityPath, force)
+			}
 			return code
 		}
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -97,16 +114,30 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 	type stopOutcome struct{ code int }
 	doneCh := make(chan stopOutcome, 1)
 	go func() {
-		doneCh <- stopOutcome{code: cmdStopBody(cityPath, cfg, force, stdout, stderr)}
+		doneCh <- stopOutcome{code: cmdStopBody(cityPath, cfg, force, stopStdout, stderr)}
 	}()
 
 	select {
 	case out := <-doneCh:
+		if out.code == 0 && jsonOut {
+			return writeCityStopSuccess(stdout, cityPath, force)
+		}
 		return out.code
 	case <-time.After(wallClockCap):
 		fmt.Fprintf(stderr, "gc stop: timed out after %s; some sessions may not have stopped — retry with --force if stop is wedged, or raise --timeout for large stop sets\n", wallClockCap) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+}
+
+func writeCityStopSuccess(stdout io.Writer, cityPath string, force bool) int {
+	_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+		Command:  "stop",
+		Action:   "stop",
+		Message:  "City stopped.",
+		CityPath: cityPath,
+		Force:    lifecycleBoolPtr(force),
+	})
+	return 0
 }
 
 func resolveStopCityPath(args []string) (string, error) {

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -61,6 +61,7 @@ to add cities.`,
 }
 
 func newSupervisorStartCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the machine-wide supervisor in the background",
@@ -69,18 +70,20 @@ func newSupervisorStartCmd(stdout, stderr io.Writer) *cobra.Command {
 This forks "gc supervisor run", verifies it became ready, and returns.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if doSupervisorStart(stdout, stderr) != 0 {
+			if doSupervisorStartJSON(stdout, stderr, jsonOut) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	return cmd
 }
 
 func newSupervisorStopCmd(stdout, stderr io.Writer) *cobra.Command {
 	var wait bool
 	var waitTimeout time.Duration
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop the machine-wide supervisor",
@@ -94,7 +97,7 @@ tests that then expect to remove temp directories without racing
 against lingering supervisor / controller subprocesses).`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if stopSupervisorWithWait(stdout, stderr, wait, waitTimeout) != 0 {
+			if stopSupervisorWithWaitJSON(stdout, stderr, wait, waitTimeout, jsonOut) != 0 {
 				return errExit
 			}
 			return nil
@@ -102,6 +105,7 @@ against lingering supervisor / controller subprocesses).`,
 	}
 	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the supervisor to finish stopping all managed cities and release its socket before returning")
 	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Second, "Maximum time to wait when --wait is set")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	return cmd
 }
 
@@ -475,6 +479,10 @@ func stopSupervisor(stdout, stderr io.Writer) int {
 // the supervisor acknowledges the destructive socket stop, so launchd/systemd
 // will not restart it when the process exits.
 func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout time.Duration) int {
+	return stopSupervisorWithWaitJSON(stdout, stderr, wait, waitTimeout, false)
+}
+
+func stopSupervisorWithWaitJSON(stdout, stderr io.Writer, wait bool, waitTimeout time.Duration, jsonOut bool) int {
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
 		fmt.Fprintln(stderr, "gc supervisor stop: supervisor is not running") //nolint:errcheck
@@ -494,9 +502,14 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 		fmt.Fprintln(stderr, "gc supervisor stop: no acknowledgment from supervisor") //nolint:errcheck
 		return 1
 	}
-	fmt.Fprintln(stdout, "Supervisor stopping...") //nolint:errcheck
+	if !jsonOut {
+		fmt.Fprintln(stdout, "Supervisor stopping...") //nolint:errcheck
+	}
 	unloadSupervisorService()
 	if !wait {
+		if jsonOut {
+			return writeSupervisorStopSuccess(stdout, wait)
+		}
 		return 0
 	}
 	if waitTimeout <= 0 {
@@ -519,6 +532,9 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 			if err := waitForSupervisorExitUntil(sockPath, time.Now().Add(5*time.Second)); err != nil {
 				fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
 				return 1
+			}
+			if jsonOut {
+				return writeSupervisorStopSuccess(stdout, wait)
 			}
 			fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
 			return 0
@@ -547,7 +563,20 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 		fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
 		return 1
 	}
+	if jsonOut {
+		return writeSupervisorStopSuccess(stdout, wait)
+	}
 	fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
+	return 0
+}
+
+func writeSupervisorStopSuccess(stdout io.Writer, wait bool) int {
+	_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+		Command: "supervisor stop",
+		Action:  "stop",
+		Message: "Supervisor stopped.",
+		Wait:    lifecycleBoolPtr(wait),
+	})
 	return 0
 }
 
@@ -602,6 +631,7 @@ func supervisorStatusWithOptions(stdout, _ io.Writer, asJSON bool) int {
 }
 
 func newSupervisorReloadCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "reload",
 		Short: "Trigger immediate reconciliation of all cities",
@@ -611,17 +641,22 @@ after killing a child process to force the supervisor to detect the
 change and restart it without waiting for the next patrol tick.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if reloadSupervisor(stdout, stderr) != 0 {
+			if reloadSupervisorJSON(stdout, stderr, jsonOut) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
 	return cmd
 }
 
 // reloadSupervisor sends a reload command to the running supervisor.
 func reloadSupervisor(stdout, stderr io.Writer) int {
+	return reloadSupervisorJSON(stdout, stderr, false)
+}
+
+func reloadSupervisorJSON(stdout, stderr io.Writer, jsonOut bool) int {
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
 		fmt.Fprintln(stderr, "gc supervisor reload: supervisor is not running; start it with 'gc supervisor start'") //nolint:errcheck
@@ -640,6 +675,14 @@ func reloadSupervisor(stdout, stderr io.Writer) int {
 	resp := strings.TrimSpace(string(buf[:n]))
 	switch resp {
 	case "ok":
+		if jsonOut {
+			_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+				Command: "supervisor reload",
+				Action:  "reload",
+				Message: "Reconciliation triggered.",
+			})
+			return 0
+		}
 		fmt.Fprintln(stdout, "Reconciliation triggered.") //nolint:errcheck
 		return 0
 	case "busy":

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -418,6 +418,10 @@ func defaultSupervisorBeadsActor() {
 }
 
 func doSupervisorStart(stdout, stderr io.Writer) int {
+	return doSupervisorStartJSON(stdout, stderr, false)
+}
+
+func doSupervisorStartJSON(stdout, stderr io.Writer, jsonOut bool) int {
 	if msg, blocked := platformSupervisorHomeOverrideError(); blocked {
 		fmt.Fprintf(stderr, "gc supervisor start: %s\n", msg) //nolint:errcheck // best-effort stderr
 		return 1
@@ -467,6 +471,15 @@ func doSupervisorStart(stdout, stderr io.Writer) int {
 	deadline := time.Now().Add(supervisorReadyTimeout)
 	for time.Now().Before(deadline) {
 		if pid := supervisorAliveHook(); pid != 0 {
+			if jsonOut {
+				_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+					Command:       "supervisor start",
+					Action:        "start",
+					Message:       "Supervisor started.",
+					SupervisorPID: pid,
+				})
+				return 0
+			}
 			fmt.Fprintf(stdout, "Supervisor started (PID %d)\n", pid) //nolint:errcheck // best-effort stdout
 			return 0
 		}

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -15,7 +15,8 @@ import (
 
 // newSuspendCmd creates the "gc suspend [path]" command.
 func newSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "suspend [path]",
 		Short: "Suspend the city (all agents effectively suspended)",
 		Long: `Suspends the city by setting workspace.suspended = true in city.toml.
@@ -27,17 +28,20 @@ The reconciler won't spawn agents, gc hook/prime return empty.
 Use "gc resume" to restore.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSuspend(args, stdout, stderr) != 0 {
+			if cmdSuspend(args, jsonOut, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
+	return cmd
 }
 
 // newResumeCmd creates the "gc resume [path]" command.
 func newResumeCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "resume [path]",
 		Short: "Resume a suspended city",
 		Long: `Resume a suspended city by clearing workspace.suspended in city.toml.
@@ -47,16 +51,18 @@ gc hook/prime will return work. Use "gc agent resume" to resume
 individual agents, or "gc rig resume" for rigs.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdResume(args, stdout, stderr) != 0 {
+			if cmdResume(args, jsonOut, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL summary")
+	return cmd
 }
 
 // cmdSuspend is the CLI entry point for suspending the city.
-func cmdSuspend(args []string, stdout, stderr io.Writer) int {
+func cmdSuspend(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveSuspendDir(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc suspend: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -65,7 +71,7 @@ func cmdSuspend(args []string, stdout, stderr io.Writer) int {
 	if c := apiClient(cityPath); c != nil {
 		err := c.SuspendCity()
 		if err == nil {
-			fmt.Fprintf(stdout, "City suspended (%s)\n", cityPath) //nolint:errcheck // best-effort stdout
+			writeCitySuspensionSuccess(stdout, cityPath, true, jsonOut)
 			return 0
 		}
 		if !api.ShouldFallback(err) {
@@ -74,11 +80,11 @@ func cmdSuspend(args []string, stdout, stderr io.Writer) int {
 		}
 		// Connection error — fall through to direct mutation.
 	}
-	return doSuspendCity(fsys.OSFS{}, cityPath, true, stdout, stderr)
+	return doSuspendCity(fsys.OSFS{}, cityPath, true, jsonOut, stdout, stderr)
 }
 
 // cmdResume is the CLI entry point for resuming the city.
-func cmdResume(args []string, stdout, stderr io.Writer) int {
+func cmdResume(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveSuspendDir(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc resume: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -87,7 +93,7 @@ func cmdResume(args []string, stdout, stderr io.Writer) int {
 	if c := apiClient(cityPath); c != nil {
 		err := c.ResumeCity()
 		if err == nil {
-			fmt.Fprintf(stdout, "City resumed (%s)\n", cityPath) //nolint:errcheck // best-effort stdout
+			writeCitySuspensionSuccess(stdout, cityPath, false, jsonOut)
 			return 0
 		}
 		if !api.ShouldFallback(err) {
@@ -96,7 +102,7 @@ func cmdResume(args []string, stdout, stderr io.Writer) int {
 		}
 		// Connection error — fall through to direct mutation.
 	}
-	return doSuspendCity(fsys.OSFS{}, cityPath, false, stdout, stderr)
+	return doSuspendCity(fsys.OSFS{}, cityPath, false, jsonOut, stdout, stderr)
 }
 
 // resolveSuspendDir resolves the city directory from args or the current city.
@@ -107,7 +113,7 @@ func resolveSuspendDir(args []string) (string, error) {
 // doSuspendCity sets or clears workspace.suspended in city.toml.
 // The flag inherits downward: when true, all agents are effectively
 // suspended via isAgentEffectivelySuspended and computeSuspendedNames.
-func doSuspendCity(fs fsys.FS, cityPath string, suspend bool, stdout, stderr io.Writer) int {
+func doSuspendCity(fs fsys.FS, cityPath string, suspend bool, jsonOut bool, stdout, stderr io.Writer) int {
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cmd := "gc suspend"
 	if !suspend {
@@ -132,15 +138,37 @@ func doSuspendCity(fs fsys.FS, cityPath string, suspend bool, stdout, stderr io.
 			Type:  events.CitySuspended,
 			Actor: eventActor(),
 		})
-		fmt.Fprintf(stdout, "City suspended (%s)\n", cityPath) //nolint:errcheck // best-effort stdout
 	} else {
 		rec.Record(events.Event{
 			Type:  events.CityResumed,
 			Actor: eventActor(),
 		})
-		fmt.Fprintf(stdout, "City resumed (%s)\n", cityPath) //nolint:errcheck // best-effort stdout
 	}
+	writeCitySuspensionSuccess(stdout, cityPath, suspend, jsonOut)
 	return 0
+}
+
+func writeCitySuspensionSuccess(stdout io.Writer, cityPath string, suspend bool, jsonOut bool) {
+	if jsonOut {
+		action := "resume"
+		message := "City resumed."
+		if suspend {
+			action = "suspend"
+			message = "City suspended."
+		}
+		_ = writeLifecycleActionJSON(stdout, lifecycleActionJSON{
+			Command:  action,
+			Action:   action,
+			Message:  message,
+			CityPath: cityPath,
+		})
+		return
+	}
+	if suspend {
+		fmt.Fprintf(stdout, "City suspended (%s)\n", cityPath) //nolint:errcheck // best-effort stdout
+		return
+	}
+	fmt.Fprintf(stdout, "City resumed (%s)\n", cityPath) //nolint:errcheck // best-effort stdout
 }
 
 // citySuspended checks whether the city is suspended. Returns true if

--- a/cmd/gc/cmd_suspend_test.go
+++ b/cmd/gc/cmd_suspend_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,7 +25,7 @@ func TestSuspendResume(t *testing.T) {
 
 	// Suspend.
 	var stdout, stderr bytes.Buffer
-	code := doSuspendCity(f, cityPath, true, &stdout, &stderr)
+	code := doSuspendCity(f, cityPath, true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("suspend code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -48,7 +49,7 @@ func TestSuspendResume(t *testing.T) {
 	// Resume.
 	stdout.Reset()
 	stderr.Reset()
-	code = doSuspendCity(f, cityPath, false, &stdout, &stderr)
+	code = doSuspendCity(f, cityPath, false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("resume code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -70,6 +71,33 @@ func TestSuspendResume(t *testing.T) {
 	}
 }
 
+func TestSuspendJSON(t *testing.T) {
+	f := fsys.NewFake()
+	cfg := config.DefaultCity("bright-lights")
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cityPath := "/city"
+	f.Files[filepath.Join(cityPath, "city.toml")] = data
+
+	var stdout, stderr bytes.Buffer
+	code := doSuspendCity(f, cityPath, true, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("suspend code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	var got lifecycleActionJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || !got.OK || got.Command != "suspend" || got.CityPath != cityPath {
+		t.Fatalf("payload = %+v", got)
+	}
+}
+
 func TestSuspendAlreadySuspended(t *testing.T) {
 	f := fsys.NewFake()
 	cfg := config.City{
@@ -83,7 +111,7 @@ func TestSuspendAlreadySuspended(t *testing.T) {
 	f.Files[filepath.Join("/city", "city.toml")] = data
 
 	var stdout, stderr bytes.Buffer
-	code := doSuspendCity(f, "/city", true, &stdout, &stderr)
+	code := doSuspendCity(f, "/city", true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("suspend code = %d, want 0 (idempotent)", code)
 	}
@@ -99,7 +127,7 @@ func TestResumeAlreadyResumed(t *testing.T) {
 	f.Files[filepath.Join("/city", "city.toml")] = data
 
 	var stdout, stderr bytes.Buffer
-	code := doSuspendCity(f, "/city", false, &stdout, &stderr)
+	code := doSuspendCity(f, "/city", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("resume code = %d, want 0 (idempotent)", code)
 	}
@@ -123,7 +151,7 @@ dir = "myrig"
 `)
 
 	var stdout, stderr bytes.Buffer
-	code := doSuspendCity(f, "/city", true, &stdout, &stderr)
+	code := doSuspendCity(f, "/city", true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("suspend code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -142,7 +170,7 @@ dir = "myrig"
 	// Resume should also preserve.
 	stdout.Reset()
 	stderr.Reset()
-	code = doSuspendCity(f, "/city", false, &stdout, &stderr)
+	code = doSuspendCity(f, "/city", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("resume code = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -50,41 +50,6 @@ func TestJSONSchemaManifestForSupportedCommand(t *testing.T) {
 	}
 }
 
-func TestJSONSchemaManifestForSessionDetailCommands(t *testing.T) {
-	for _, args := range [][]string{
-		{"session", "peek", "example", "--json-schema"},
-		{"session", "logs", "example", "--json-schema"},
-	} {
-		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
-			var stdout, stderr bytes.Buffer
-			code := run(args, &stdout, &stderr)
-			if code != 0 {
-				t.Fatalf("run(%v) = %d, stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
-			}
-			if stderr.Len() != 0 {
-				t.Fatalf("stderr = %q, want empty", stderr.String())
-			}
-			var manifest struct {
-				SchemaVersion string                     `json:"schema_version"`
-				JSONSupported bool                       `json:"json_supported"`
-				Schemas       map[string]json.RawMessage `json:"schemas"`
-			}
-			if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
-				t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
-			}
-			if manifest.SchemaVersion != "1" || !manifest.JSONSupported {
-				t.Fatalf("manifest metadata = %+v", manifest)
-			}
-			if !json.Valid(manifest.Schemas["result"]) {
-				t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
-			}
-			if !json.Valid(manifest.Schemas["failure"]) {
-				t.Fatalf("failure schema missing or invalid: %s", manifest.Schemas["failure"])
-			}
-		})
-	}
-}
-
 func TestJSONSchemaManifestForLifecycleActionCommands(t *testing.T) {
 	commands := [][]string{
 		{"start"},

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -50,6 +50,87 @@ func TestJSONSchemaManifestForSupportedCommand(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaManifestForSessionDetailCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"session", "peek", "example", "--json-schema"},
+		{"session", "logs", "example", "--json-schema"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%v) = %d, stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var manifest struct {
+				SchemaVersion string                     `json:"schema_version"`
+				JSONSupported bool                       `json:"json_supported"`
+				Schemas       map[string]json.RawMessage `json:"schemas"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+				t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+			}
+			if manifest.SchemaVersion != "1" || !manifest.JSONSupported {
+				t.Fatalf("manifest metadata = %+v", manifest)
+			}
+			if !json.Valid(manifest.Schemas["result"]) {
+				t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
+			}
+			if !json.Valid(manifest.Schemas["failure"]) {
+				t.Fatalf("failure schema missing or invalid: %s", manifest.Schemas["failure"])
+			}
+		})
+	}
+}
+
+func TestJSONSchemaManifestForLifecycleActionCommands(t *testing.T) {
+	commands := [][]string{
+		{"start"},
+		{"stop"},
+		{"restart"},
+		{"reload"},
+		{"suspend"},
+		{"resume"},
+		{"register"},
+		{"unregister"},
+		{"supervisor", "start"},
+		{"supervisor", "stop"},
+		{"supervisor", "reload"},
+	}
+	for _, command := range commands {
+		t.Run(strings.Join(command, " "), func(t *testing.T) {
+			args := append(append([]string{}, command...), "--json-schema")
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%v) = %d, stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var manifest struct {
+				SchemaVersion string                     `json:"schema_version"`
+				JSONSupported bool                       `json:"json_supported"`
+				Schemas       map[string]json.RawMessage `json:"schemas"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+				t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+			}
+			if manifest.SchemaVersion != "1" || !manifest.JSONSupported {
+				t.Fatalf("manifest metadata = %+v", manifest)
+			}
+			if !json.Valid(manifest.Schemas["result"]) {
+				t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
+			}
+			if !json.Valid(manifest.Schemas["failure"]) {
+				t.Fatalf("failure schema missing or invalid: %s", manifest.Schemas["failure"])
+			}
+		})
+	}
+}
+
 func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"version", "--json-schema"}, &stdout, &stderr)

--- a/cmd/gc/lifecycle_action_json.go
+++ b/cmd/gc/lifecycle_action_json.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"io"
+)
+
+type lifecycleActionJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	Command       string `json:"command"`
+	Action        string `json:"action"`
+	Message       string `json:"message,omitempty"`
+	CityName      string `json:"city_name,omitempty"`
+	CityPath      string `json:"city_path,omitempty"`
+	SupervisorPID int    `json:"supervisor_pid,omitempty"`
+	Wait          *bool  `json:"wait,omitempty"`
+	Force         *bool  `json:"force,omitempty"`
+	Async         *bool  `json:"async,omitempty"`
+	Soft          *bool  `json:"soft,omitempty"`
+	Outcome       string `json:"outcome,omitempty"`
+	Revision      string `json:"revision,omitempty"`
+}
+
+func writeLifecycleActionJSON(stdout io.Writer, payload lifecycleActionJSON) error {
+	payload.SchemaVersion = "1"
+	payload.OK = true
+	return writeCLIJSONLine(stdout, payload)
+}
+
+func lifecycleBoolPtr(v bool) *bool {
+	return &v
+}

--- a/schemas/register/result.schema.json
+++ b/schemas/register/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message", "city_name", "city_path"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "register" },
+    "action": { "const": "register" },
+    "message": { "type": "string" },
+    "city_name": { "type": "string" },
+    "city_path": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/reload/result.schema.json
+++ b/schemas/reload/result.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "city_path", "async", "soft", "outcome"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "reload" },
+    "action": { "const": "reload" },
+    "message": { "type": "string" },
+    "city_path": { "type": "string" },
+    "async": { "type": "boolean" },
+    "soft": { "type": "boolean" },
+    "outcome": { "enum": ["accepted", "applied", "no_change"] },
+    "revision": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/restart/result.schema.json
+++ b/schemas/restart/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message", "city_path"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "restart" },
+    "action": { "const": "restart" },
+    "message": { "type": "string" },
+    "city_name": { "type": "string" },
+    "city_path": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/resume/result.schema.json
+++ b/schemas/resume/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message", "city_path"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "resume" },
+    "action": { "const": "resume" },
+    "message": { "type": "string" },
+    "city_path": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/start/result.schema.json
+++ b/schemas/start/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message", "city_path"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "start" },
+    "action": { "const": "start" },
+    "message": { "type": "string" },
+    "city_name": { "type": "string" },
+    "city_path": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/stop/result.schema.json
+++ b/schemas/stop/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message", "city_path"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "stop" },
+    "action": { "const": "stop" },
+    "message": { "type": "string" },
+    "city_path": { "type": "string" },
+    "force": { "type": "boolean" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/supervisor/reload/result.schema.json
+++ b/schemas/supervisor/reload/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "supervisor reload" },
+    "action": { "const": "reload" },
+    "message": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/supervisor/start/result.schema.json
+++ b/schemas/supervisor/start/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message", "supervisor_pid"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "supervisor start" },
+    "action": { "const": "start" },
+    "message": { "type": "string" },
+    "supervisor_pid": { "type": "integer" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/supervisor/stop/result.schema.json
+++ b/schemas/supervisor/stop/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "supervisor stop" },
+    "action": { "const": "stop" },
+    "message": { "type": "string" },
+    "wait": { "type": "boolean" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/suspend/result.schema.json
+++ b/schemas/suspend/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message", "city_path"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "suspend" },
+    "action": { "const": "suspend" },
+    "message": { "type": "string" },
+    "city_path": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/unregister/result.schema.json
+++ b/schemas/unregister/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "message", "city_path"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "unregister" },
+    "action": { "const": "unregister" },
+    "message": { "type": "string" },
+    "city_name": { "type": "string" },
+    "city_path": { "type": "string" }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- Add native `--json` success summaries for bounded lifecycle city actions: `gc start`, `gc stop`, `gc restart`, `gc reload`, `gc suspend`, `gc resume`, `gc register`, and `gc unregister`.
- Add native `--json` success summaries for bounded supervisor actions: `gc supervisor start`, `gc supervisor stop`, and `gc supervisor reload`.
- Add JSON Schema 2020-12 result schemas for each covered command path; failures continue to use the shared `schemas/failure.schema.json` platform behavior.

## JSON shape notes
- These commands did not previously declare native `--json` success contracts, so this PR introduces new one-record JSONL result shapes rather than changing an existing JSON shape.
- Common fields: `schema_version: "1"`, `ok: true`, `command`, `action`, and a human-readable `message` when the action has one.
- City actions include `city_path` and, when resolved, `city_name`; option-specific fields are included where useful (`force`, `async`, `soft`, `outcome`, `revision`).
- Supervisor actions include action-specific fields such as `supervisor_pid` for start and `wait` for stop.

## Validation
- `go test ./cmd/gc -run 'TestCmdReload|TestSuspend|TestResume'`
- `go test ./cmd/gc -run 'TestJSONSchemaManifestForLifecycleActionCommands|TestJSONSchemaRoleSpecificFailureUsesSharedDefault|TestJSONUnsupportedCommandFailureIsStructured'`
- `go test ./cmd/gc -run '^$'`
- `find schemas/start schemas/stop schemas/restart schemas/reload schemas/suspend schemas/resume schemas/register schemas/unregister schemas/supervisor -name 'result.schema.json' -print -exec jq empty {} \;`
- `git diff --check`
- `make fmt-check`
- `make vet`
- `make check-docs`

## Skips / caveats
- `GOOS=linux make lint` was attempted twice but golangci-lint refused to run because another golangci-lint process already held its parallel-run lock.
- A full `go test ./cmd/gc` run was attempted but sat silent for several minutes, so I stopped the lingering `go test` processes and kept validation to focused lifecycle/schema tests plus compile-only package coverage.
- Deprecated `gc pack` / `gc import` surfaces were not touched.
- Unbounded/foreground surfaces remain out of scope: `gc start --foreground --json` and `gc start --dry-run --json` fail through the platform structured failure path instead of emitting human text on stdout.

