### PR TITLE
Add JSON summaries for graph/converge/order/formula actions

### DIFF
--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -47,6 +47,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 		title             string
 		evaluatePrompt    string
 		vars              []string
+		jsonOutput        bool
 	)
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -100,6 +101,14 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 				fmt.Fprintf(stderr, "gc converge create: parsing result: %v\n", err) //nolint:errcheck
 				return errExit
 			}
+			if jsonOutput {
+				_ = writeCLIJSONLine(stdout, convergeCreateJSONResult{
+					SchemaVersion: "1",
+					OK:            true,
+					BeadID:        result.BeadID,
+				})
+				return nil
+			}
 			fmt.Fprintln(stdout, result.BeadID) //nolint:errcheck
 			return nil
 		},
@@ -114,6 +123,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&title, "title", "", "Convergence loop title")
 	cmd.Flags().StringVar(&evaluatePrompt, "evaluate-prompt", "", "Custom evaluate prompt (overrides formula default)")
 	cmd.Flags().StringArrayVar(&vars, "var", nil, "Template variable (key=value, repeatable)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
 	_ = cmd.MarkFlagRequired("formula")
 	_ = cmd.MarkFlagRequired("target")
 	return cmd
@@ -190,36 +200,45 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func newConvergeApproveCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "approve <bead-id>",
 		Short: "Approve and close a convergence loop (manual gate)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return convergeSocketCmd(args[0], "approve", nil, stdout, stderr)
+			return convergeSocketCmd(args[0], "approve", nil, jsonOutput, stdout, stderr)
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
+	return cmd
 }
 
 func newConvergeIterateCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "iterate <bead-id>",
 		Short: "Force next iteration (manual gate)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return convergeSocketCmd(args[0], "iterate", nil, stdout, stderr)
+			return convergeSocketCmd(args[0], "iterate", nil, jsonOutput, stdout, stderr)
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
+	return cmd
 }
 
 func newConvergeStopCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "stop <bead-id>",
 		Short: "Stop a convergence loop",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return convergeSocketCmd(args[0], "stop", nil, stdout, stderr)
+			return convergeSocketCmd(args[0], "stop", nil, jsonOutput, stdout, stderr)
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
+	return cmd
 }
 
 func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -306,7 +325,8 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "test-gate <bead-id>",
 		Short: "Dry-run the gate condition (no state changes)",
 		Args:  cobra.ExactArgs(1),
@@ -337,10 +357,32 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 
 			if gateConfig.Mode == convergence.GateModeManual {
+				if jsonOutput {
+					_ = writeCLIJSONLine(stdout, convergeTestGateJSONResult{
+						SchemaVersion: "1",
+						OK:            true,
+						BeadID:        beadID,
+						Mode:          gateConfig.Mode,
+						Skipped:       true,
+						Reason:        "manual_gate",
+					})
+					return nil
+				}
 				fmt.Fprintln(stdout, "Gate mode is manual — no condition to test.") //nolint:errcheck
 				return nil
 			}
 			if gateConfig.Condition == "" {
+				if jsonOutput {
+					_ = writeCLIJSONLine(stdout, convergeTestGateJSONResult{
+						SchemaVersion: "1",
+						OK:            true,
+						BeadID:        beadID,
+						Mode:          gateConfig.Mode,
+						Skipped:       true,
+						Reason:        "missing_condition",
+					})
+					return nil
+				}
 				fmt.Fprintln(stdout, "No gate condition configured.") //nolint:errcheck
 				return nil
 			}
@@ -362,6 +404,21 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 				context.TODO(),
 				gateConfig.Condition, env, gateConfig.Timeout, 0,
 			)
+			if jsonOutput {
+				payload := convergeTestGateJSONResult{
+					SchemaVersion: "1",
+					OK:            true,
+					BeadID:        beadID,
+					Mode:          gateConfig.Mode,
+					Condition:     gateConfig.Condition,
+					Outcome:       result.Outcome,
+					ExitCode:      result.ExitCode,
+					Stdout:        result.Stdout,
+					Stderr:        result.Stderr,
+				}
+				_ = writeCLIJSONLine(stdout, payload)
+				return nil
+			}
 			fmt.Fprintf(stdout, "Outcome:  %s\n", result.Outcome) //nolint:errcheck
 			if result.ExitCode != nil {
 				fmt.Fprintf(stdout, "Exit:     %d\n", *result.ExitCode) //nolint:errcheck
@@ -375,10 +432,13 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
+	return cmd
 }
 
 func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 	var maxIterations int
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "retry <bead-id>",
 		Short: "Retry a terminated convergence loop",
@@ -416,17 +476,27 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 				fmt.Fprintf(stderr, "gc converge retry: parsing result: %v\n", err) //nolint:errcheck
 				return errExit
 			}
+			if jsonOutput {
+				_ = writeCLIJSONLine(stdout, convergeRetryJSONResult{
+					SchemaVersion: "1",
+					OK:            true,
+					SourceBeadID:  args[0],
+					NewBeadID:     result.NewBeadID,
+				})
+				return nil
+			}
 			fmt.Fprintln(stdout, result.NewBeadID) //nolint:errcheck
 			return nil
 		},
 	}
 	cmd.Flags().IntVar(&maxIterations, "max-iterations", 0, "Override max iterations (default: inherit from source)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
 	return cmd
 }
 
 // convergeSocketCmd sends a simple convergence command (approve, iterate, stop)
 // through the controller socket and prints the result.
-func convergeSocketCmd(beadID, command string, params map[string]string, stdout, stderr io.Writer) error {
+func convergeSocketCmd(beadID, command string, params map[string]string, jsonOutput bool, stdout, stderr io.Writer) error {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc converge %s: %v\n", command, err) //nolint:errcheck
@@ -450,8 +520,56 @@ func convergeSocketCmd(beadID, command string, params map[string]string, stdout,
 	}
 
 	var result convergence.HandlerResult
-	if err := json.Unmarshal(reply.Result, &result); err == nil {
-		fmt.Fprintf(stdout, "%s: %s\n", beadID, result.Action) //nolint:errcheck
+	if err := json.Unmarshal(reply.Result, &result); err != nil {
+		if jsonOutput {
+			fmt.Fprintf(stderr, "gc converge %s: parsing result: %v\n", command, err) //nolint:errcheck
+			return errExit
+		}
+		return nil
 	}
+	if jsonOutput {
+		_ = writeCLIJSONLine(stdout, convergeActionJSONResult{
+			SchemaVersion: "1",
+			OK:            true,
+			BeadID:        beadID,
+			Action:        string(result.Action),
+		})
+		return nil
+	}
+	fmt.Fprintf(stdout, "%s: %s\n", beadID, result.Action) //nolint:errcheck
 	return nil
+}
+
+type convergeCreateJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	BeadID        string `json:"bead_id"`
+}
+
+type convergeActionJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	BeadID        string `json:"bead_id"`
+	Action        string `json:"action"`
+}
+
+type convergeRetryJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	SourceBeadID  string `json:"source_bead_id"`
+	NewBeadID     string `json:"new_bead_id"`
+}
+
+type convergeTestGateJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	BeadID        string `json:"bead_id"`
+	Mode          string `json:"mode"`
+	Condition     string `json:"condition,omitempty"`
+	Outcome       string `json:"outcome,omitempty"`
+	ExitCode      *int   `json:"exit_code,omitempty"`
+	Stdout        string `json:"stdout,omitempty"`
+	Stderr        string `json:"stderr,omitempty"`
+	Skipped       bool   `json:"skipped,omitempty"`
+	Reason        string `json:"reason,omitempty"`
 }

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -269,6 +269,7 @@ func newFormulaCookCmd(stdout, stderr io.Writer) *cobra.Command {
 	var vars []string
 	var metadata []string
 	var attach string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "cook <formula-name>",
 		Short: "Instantiate a formula into the current bead store",
@@ -317,6 +318,20 @@ bead into a sub-workflow at runtime.`,
 					return err
 				}
 
+				if jsonOutput {
+					_ = writeCLIJSONLine(stdout, formulaCookJSONResult{
+						SchemaVersion:  "1",
+						OK:             true,
+						Formula:        args[0],
+						Mode:           "attach",
+						AttachBeadID:   attach,
+						RootID:         result.RootID,
+						WorkflowRootID: result.WorkflowRootID,
+						Created:        result.Created,
+					})
+					_ = pokeControlDispatch(cityPath)
+					return nil
+				}
 				_, _ = fmt.Fprintf(stdout, "Attached: %s -> %s (root: %s)\n", attach, result.RootID, result.WorkflowRootID)
 				_, _ = fmt.Fprintf(stdout, "Root: %s\n", result.RootID)
 				_, _ = fmt.Fprintf(stdout, "Created: %d\n", result.Created)
@@ -344,6 +359,18 @@ bead into a sub-workflow at runtime.`,
 				}
 			}
 
+			if jsonOutput {
+				_ = writeCLIJSONLine(stdout, formulaCookJSONResult{
+					SchemaVersion: "1",
+					OK:            true,
+					Formula:       args[0],
+					Mode:          "cook",
+					RootID:        result.RootID,
+					Created:       result.Created,
+					IDMapping:     result.IDMapping,
+				})
+				return nil
+			}
 			_, _ = fmt.Fprintf(stdout, "Root: %s\n", result.RootID)
 			_, _ = fmt.Fprintf(stdout, "Created: %d\n", result.Created)
 			keys := make([]string, 0, len(result.IDMapping))
@@ -361,7 +388,20 @@ bead into a sub-workflow at runtime.`,
 	cmd.Flags().StringArrayVar(&vars, "var", nil, "variable substitution for formula (key=value, repeatable)")
 	cmd.Flags().StringArrayVar(&metadata, "meta", nil, "set root bead metadata after cook (key=value, repeatable)")
 	cmd.Flags().StringVar(&attach, "attach", "", "attach sub-DAG to existing bead (bead gains blocking dep on sub-DAG root)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output JSONL summary")
 	return cmd
+}
+
+type formulaCookJSONResult struct {
+	SchemaVersion  string            `json:"schema_version"`
+	OK             bool              `json:"ok"`
+	Formula        string            `json:"formula"`
+	Mode           string            `json:"mode"`
+	AttachBeadID   string            `json:"attach_bead_id,omitempty"`
+	RootID         string            `json:"root_id"`
+	WorkflowRootID string            `json:"workflow_root_id,omitempty"`
+	Created        int               `json:"created"`
+	IDMapping      map[string]string `json:"id_mapping,omitempty"`
 }
 
 func parseFormulaVars(varFlags []string) map[string]string {

--- a/cmd/gc/cmd_graph.go
+++ b/cmd/gc/cmd_graph.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newGraphCmd(stdout, stderr io.Writer) *cobra.Command {
-	var mermaid, tree bool
+	var mermaid, tree, jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "graph <bead-ids|convoy-id...>",
 		Short: "Show dependency graph for beads",
@@ -30,7 +30,7 @@ By default prints a table. Use --tree for a Unicode tree view or
   gc graph gc-42 --mermaid     # Mermaid.js diagram`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			opts := graphOpts{Mermaid: mermaid, Tree: tree}
+			opts := graphOpts{Mermaid: mermaid, Tree: tree, JSON: jsonOutput}
 			if cmdGraph(args, opts, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -39,7 +39,8 @@ By default prints a table. Use --tree for a Unicode tree view or
 	}
 	cmd.Flags().BoolVar(&mermaid, "mermaid", false, "output Mermaid.js flowchart")
 	cmd.Flags().BoolVar(&tree, "tree", false, "output Unicode dependency tree")
-	cmd.MarkFlagsMutuallyExclusive("mermaid", "tree")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output JSONL summary")
+	cmd.MarkFlagsMutuallyExclusive("mermaid", "tree", "json")
 	return cmd
 }
 
@@ -47,6 +48,33 @@ By default prints a table. Use --tree for a Unicode tree view or
 type graphOpts struct {
 	Mermaid bool
 	Tree    bool
+	JSON    bool
+}
+
+type graphJSONResult struct {
+	SchemaVersion string           `json:"schema_version"`
+	OK            bool             `json:"ok"`
+	Input         []string         `json:"input"`
+	Nodes         []graphJSONNode  `json:"nodes"`
+	Summary       graphJSONSummary `json:"summary"`
+}
+
+type graphJSONNode struct {
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	Status       string   `json:"status"`
+	Type         string   `json:"type,omitempty"`
+	ParentID     string   `json:"parent_id,omitempty"`
+	BlockedBy    []string `json:"blocked_by"`
+	OpenBlockers []string `json:"open_blockers"`
+	Ready        bool     `json:"ready"`
+}
+
+type graphJSONSummary struct {
+	Total   int `json:"total"`
+	Closed  int `json:"closed"`
+	Ready   int `json:"ready"`
+	Blocked int `json:"blocked"`
 }
 
 // cmdGraph is the CLI entry point.
@@ -126,6 +154,16 @@ func doGraph(store beads.Store, args []string, opts graphOpts, stdout, stderr io
 		return 1
 	}
 	if len(resolved) == 0 {
+		if opts.JSON {
+			_ = writeCLIJSONLine(stdout, graphJSONResult{
+				SchemaVersion: "1",
+				OK:            true,
+				Input:         append([]string(nil), args...),
+				Nodes:         []graphJSONNode{},
+				Summary:       graphJSONSummary{},
+			})
+			return 0
+		}
 		fmt.Fprintln(stdout, "No beads to graph") //nolint:errcheck // best-effort stdout
 		return 0
 	}
@@ -170,6 +208,8 @@ func doGraph(store beads.Store, args []string, opts graphOpts, stdout, stderr io
 	}
 
 	switch {
+	case opts.JSON:
+		_ = writeCLIJSONLine(stdout, buildGraphJSONResult(args, nodes))
 	case opts.Mermaid:
 		printMermaid(nodes, stdout)
 	case opts.Tree:
@@ -178,6 +218,38 @@ func doGraph(store beads.Store, args []string, opts graphOpts, stdout, stderr io
 		printTable(nodes, stdout)
 	}
 	return 0
+}
+
+func buildGraphJSONResult(args []string, nodes []graphNode) graphJSONResult {
+	result := graphJSONResult{
+		SchemaVersion: "1",
+		OK:            true,
+		Input:         append([]string(nil), args...),
+		Nodes:         make([]graphJSONNode, 0, len(nodes)),
+	}
+	for _, n := range nodes {
+		ready := isBeadReady(n)
+		switch {
+		case n.bead.Status == "closed":
+			result.Summary.Closed++
+		case ready:
+			result.Summary.Ready++
+		default:
+			result.Summary.Blocked++
+		}
+		result.Nodes = append(result.Nodes, graphJSONNode{
+			ID:           n.bead.ID,
+			Title:        n.bead.Title,
+			Status:       n.bead.Status,
+			Type:         n.bead.Type,
+			ParentID:     n.bead.ParentID,
+			BlockedBy:    append([]string(nil), n.blockedBy...),
+			OpenBlockers: append([]string(nil), n.openBlocker...),
+			Ready:        ready,
+		})
+	}
+	result.Summary.Total = len(nodes)
+	return result
 }
 
 // resolveGraphInput expands convoy inputs to their children.

--- a/cmd/gc/cmd_graph_test.go
+++ b/cmd/gc/cmd_graph_test.go
@@ -55,6 +55,36 @@ func TestGraphTable(t *testing.T) {
 	}
 }
 
+func TestGraphJSON(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "setup DB"})      // gc-1
+	_, _ = store.Create(beads.Bead{Title: "add migration"}) // gc-2
+	_ = store.DepAdd("gc-2", "gc-1", "blocks")
+
+	var stdout, stderr bytes.Buffer
+	code := doGraph(store, []string{"gc-1", "gc-2"}, graphOpts{JSON: true}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doGraph --json = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var payload graphJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || !payload.OK {
+		t.Fatalf("payload metadata = %+v", payload)
+	}
+	if payload.Summary.Total != 2 || payload.Summary.Ready != 1 || payload.Summary.Blocked != 1 {
+		t.Fatalf("summary = %+v, want total=2 ready=1 blocked=1", payload.Summary)
+	}
+	if len(payload.Nodes) != 2 || payload.Nodes[1].ID != "gc-2" || len(payload.Nodes[1].OpenBlockers) != 1 {
+		t.Fatalf("nodes = %+v, want gc-2 with one open blocker", payload.Nodes)
+	}
+}
+
 func TestGraphMermaid(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{Title: "task A"}) // gc-1

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -141,6 +141,7 @@ exit code 0 if any order is due, 1 if none are due.`,
 
 func newOrderHistoryCmd(stdout, stderr io.Writer) *cobra.Command {
 	var rig string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "history [name]",
 		Short: "Show order execution history",
@@ -154,7 +155,7 @@ name. Use --rig to filter by rig.`,
 			if len(args) > 0 {
 				name = args[0]
 			}
-			if cmdOrderHistory(name, rig, stdout, stderr) != 0 {
+			if cmdOrderHistoryJSON(name, rig, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -162,6 +163,7 @@ name. Use --rig to filter by rig.`,
 		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to filter order history")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output JSONL summary")
 	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	return cmd
 }
@@ -848,11 +850,15 @@ func doOrderCheckWithStoresResolverScoped(cityPath string, cfg *config.City, aa 
 // --- gc order history ---
 
 func cmdOrderHistory(name, rig string, stdout, stderr io.Writer) int {
+	return cmdOrderHistoryJSON(name, rig, false, stdout, stderr)
+}
+
+func cmdOrderHistoryJSON(name, rig string, jsonOutput bool, stdout, stderr io.Writer) int {
 	cityPath, cfg, aa, code := loadAllOrdersWithCity(stderr, "gc order history")
 	if code != 0 {
 		return code
 	}
-	return doOrderHistoryWithStoresResolver(name, rig, aa, cachedOrderHistoryStoresResolver(cityPath, cfg, stderr), stdout, stderr)
+	return doOrderHistoryWithStoresResolverJSON(name, rig, aa, cachedOrderHistoryStoresResolver(cityPath, cfg, stderr), jsonOutput, stdout, stderr)
 }
 
 // doOrderHistory queries bead history for order runs and prints a table.
@@ -875,6 +881,10 @@ func doOrderHistoryWithStoreResolver(name, rig string, aa []orders.Order, resolv
 }
 
 func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
+	return doOrderHistoryWithStoresResolverJSON(name, rig, aa, resolveStores, false, stdout, stderr)
+}
+
+func doOrderHistoryWithStoresResolverJSON(name, rig string, aa []orders.Order, resolveStores orderStoresResolver, jsonOutput bool, stdout, stderr io.Writer) int {
 	// Filter orders if name or rig specified.
 	targets := aa
 	if name != "" || rig != "" {
@@ -942,6 +952,17 @@ func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resol
 	}
 
 	if len(entries) == 0 {
+		if jsonOutput {
+			_ = writeCLIJSONLine(stdout, orderHistoryJSONResult{
+				SchemaVersion: "1",
+				OK:            true,
+				Name:          name,
+				Rig:           rig,
+				Entries:       []orderHistoryJSONEntry{},
+				Summary:       orderHistoryJSONSummary{Total: 0},
+			})
+			return 0
+		}
 		if name != "" {
 			fmt.Fprintf(stdout, "No order history for %q.\n", name) //nolint:errcheck
 		} else {
@@ -953,6 +974,28 @@ func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resol
 	sort.SliceStable(entries, func(i, j int) bool {
 		return entries[i].createdAt.After(entries[j].createdAt)
 	})
+
+	if jsonOutput {
+		payload := orderHistoryJSONResult{
+			SchemaVersion: "1",
+			OK:            true,
+			Name:          name,
+			Rig:           rig,
+			Entries:       make([]orderHistoryJSONEntry, 0, len(entries)),
+			Summary:       orderHistoryJSONSummary{Total: len(entries)},
+		}
+		for _, e := range entries {
+			payload.Entries = append(payload.Entries, orderHistoryJSONEntry{
+				Order:     e.order,
+				Rig:       e.rig,
+				BeadID:    e.id,
+				Executed:  e.createdAt.Format(time.RFC3339),
+				CreatedAt: e.createdAt,
+			})
+		}
+		_ = writeCLIJSONLine(stdout, payload)
+		return 0
+	}
 
 	hasRig := false
 	for _, e := range entries {
@@ -978,6 +1021,27 @@ func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resol
 		}
 	}
 	return 0
+}
+
+type orderHistoryJSONResult struct {
+	SchemaVersion string                  `json:"schema_version"`
+	OK            bool                    `json:"ok"`
+	Name          string                  `json:"name,omitempty"`
+	Rig           string                  `json:"rig,omitempty"`
+	Entries       []orderHistoryJSONEntry `json:"entries"`
+	Summary       orderHistoryJSONSummary `json:"summary"`
+}
+
+type orderHistoryJSONEntry struct {
+	Order     string    `json:"order"`
+	Rig       string    `json:"rig,omitempty"`
+	BeadID    string    `json:"bead_id"`
+	Executed  string    `json:"executed"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type orderHistoryJSONSummary struct {
+	Total int `json:"total"`
 }
 
 // --- gc order sweep-tracking ---

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -1720,6 +1721,39 @@ func TestOrderHistory(t *testing.T) {
 	}
 	if !strings.Contains(out, "WP-99") {
 		t.Errorf("stdout missing 'WP-99':\n%s", out)
+	}
+}
+
+func TestOrderHistoryJSON(t *testing.T) {
+	store := beads.NewBdStore(t.TempDir(), func(_, _ string, args ...string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "--label=order-run:digest") {
+			return []byte(`[{"id":"WP-42","title":"digest wisp","status":"closed","issue_type":"task","created_at":"2026-02-27T10:00:00Z","labels":["order-run:digest"]}]`), nil
+		}
+		return []byte(`[]`), nil
+	})
+	aa := []orders.Order{{Name: "digest", Formula: "mol-digest"}}
+	resolver := func(orders.Order) ([]beads.Store, error) {
+		return []beads.Store{store}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderHistoryWithStoresResolverJSON("digest", "", aa, resolver, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderHistoryWithStoresResolverJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var payload orderHistoryJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || !payload.OK || payload.Summary.Total != 1 {
+		t.Fatalf("payload = %+v, want ok schema v1 with one entry", payload)
+	}
+	if len(payload.Entries) != 1 || payload.Entries[0].Order != "digest" || payload.Entries[0].BeadID != "WP-42" {
+		t.Fatalf("entries = %+v, want digest WP-42", payload.Entries)
 	}
 }
 

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -101,6 +101,44 @@ func TestJSONSchemaRoleSpecificResult(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaResultForGraphConvergeOrderFormulaActions(t *testing.T) {
+	commands := [][]string{
+		{"graph"},
+		{"converge", "create"},
+		{"converge", "approve"},
+		{"converge", "iterate"},
+		{"converge", "stop"},
+		{"converge", "test-gate"},
+		{"converge", "retry"},
+		{"formula", "cook"},
+		{"order", "history"},
+	}
+	for _, command := range commands {
+		t.Run(strings.Join(command, "_"), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			args := append(append([]string{}, command...), "--json-schema=result")
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%s --json-schema=result) = %d, stderr=%q stdout=%q", strings.Join(command, " "), code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var schema map[string]any
+			if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+				t.Fatalf("schema is not JSON: %v\n%s", err, stdout.String())
+			}
+			props, ok := schema["properties"].(map[string]any)
+			if !ok {
+				t.Fatalf("schema missing properties: %+v", schema)
+			}
+			if _, ok := props["schema_version"]; !ok {
+				t.Fatalf("schema missing schema_version property: %+v", schema)
+			}
+		})
+	}
+}
+
 func TestJSONSchemaRoleSpecificFailureUsesSharedDefault(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"events", "--json-schema", "failure"}, &stdout, &stderr)

--- a/schemas/converge/approve/result.schema.json
+++ b/schemas/converge/approve/result.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "bead_id", "action"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "bead_id": { "type": "string" },
+    "action": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/converge/create/result.schema.json
+++ b/schemas/converge/create/result.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "bead_id"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "bead_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/converge/iterate/result.schema.json
+++ b/schemas/converge/iterate/result.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "bead_id", "action"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "bead_id": { "type": "string" },
+    "action": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/converge/retry/result.schema.json
+++ b/schemas/converge/retry/result.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "source_bead_id", "new_bead_id"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "source_bead_id": { "type": "string" },
+    "new_bead_id": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/converge/stop/result.schema.json
+++ b/schemas/converge/stop/result.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "bead_id", "action"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "bead_id": { "type": "string" },
+    "action": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/converge/test-gate/result.schema.json
+++ b/schemas/converge/test-gate/result.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "bead_id", "mode"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "bead_id": { "type": "string" },
+    "mode": { "type": "string" },
+    "condition": { "type": "string" },
+    "outcome": { "type": "string" },
+    "exit_code": { "type": "integer" },
+    "stdout": { "type": "string" },
+    "stderr": { "type": "string" },
+    "skipped": { "type": "boolean" },
+    "reason": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/formula/cook/result.schema.json
+++ b/schemas/formula/cook/result.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "formula", "mode", "root_id", "created"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "formula": { "type": "string" },
+    "mode": { "enum": ["cook", "attach"] },
+    "attach_bead_id": { "type": "string" },
+    "root_id": { "type": "string" },
+    "workflow_root_id": { "type": "string" },
+    "created": { "type": "integer" },
+    "id_mapping": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/graph/result.schema.json
+++ b/schemas/graph/result.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "input", "nodes", "summary"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "input": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "status", "blocked_by", "open_blockers", "ready"],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "status": { "type": "string" },
+          "type": { "type": "string" },
+          "parent_id": { "type": "string" },
+          "blocked_by": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "open_blockers": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "ready": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total", "closed", "ready", "blocked"],
+      "properties": {
+        "total": { "type": "integer" },
+        "closed": { "type": "integer" },
+        "ready": { "type": "integer" },
+        "blocked": { "type": "integer" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/order/history/result.schema.json
+++ b/schemas/order/history/result.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "entries", "summary"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["order", "bead_id", "executed", "created_at"],
+        "properties": {
+          "order": { "type": "string" },
+          "rig": { "type": "string" },
+          "bead_id": { "type": "string" },
+          "executed": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total"],
+      "properties": {
+        "total": { "type": "integer" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- Add native `--json` success summaries for bounded graph/converge/formula/order surfaces:
  - `gc graph --json`
  - `gc converge create|approve|iterate|stop|retry|test-gate --json`
  - `gc formula cook --json`
  - `gc order history --json`
- Add JSON Schema 2020-12 result schemas for each new JSON surface; failures use the shared `schemas/failure.schema.json` platform behavior.
- Add focused tests for graph/order JSONL shape and schema discoverability.

## JSON shape notes
These are new native JSON surfaces, so no pre-existing JSON shapes were changed. Each successful bounded command emits one JSONL record with `schema_version: "1"` and `ok: true`.

## Skips / rationale
- Skipped `gc order check --json`: today it intentionally returns exit code 1 for the non-error "no orders due" state, which needs an explicit JSON contract decision before routing it through the native failure wrapper.
- Skipped `gc order run --json`: exec-backed orders can write arbitrary command output to stdout, so a safe JSON-only stdout contract needs a separate design.
- Did not touch deprecated `gc pack` / `gc import` surfaces.
- Did not change already-covered `gc converge list/status --json` shapes.

## Validation
- `go test ./cmd/gc -run 'TestJSONSchemaResultForGraphConvergeOrderFormulaActions|TestGraphJSON|TestOrderHistoryJSON|TestJSONExecutionFailureIsStructured'`
- `go test ./cmd/gc -run 'TestJSONSchema|TestJSONUnsupportedCommandFailureIsStructured|TestJSONExecutionFailureIsStructured'`
- `go test ./cmd/gc -run 'Test(Graph|OrderHistory)'`
- `go test ./test/docsync ./test/acceptance -run 'TestConverge|TestOrder|TestFormula|TestGraph|JSON|Schema'`
- `git diff --check`
- `make fmt-check`
- `GOOS=linux make lint`
- `make vet`
- `make check-docs`

## Risks
- Convergence action JSON depends on the controller returning the same success payloads used by human output; unparsable success payloads now produce a structured JSON failure for `--json` callers.
- `gc formula cook --json` for `--attach` still pokes the dispatcher like human output does, but suppresses the human attachment lines.

