### PR TITLE
feat: add json summaries for convoy and mail actions

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -17,6 +17,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type convoyActionResult struct {
+	SchemaVersion string   `json:"schema_version"`
+	OK            bool     `json:"ok"`
+	Command       string   `json:"command"`
+	Action        string   `json:"action"`
+	ConvoyID      string   `json:"convoy_id,omitempty"`
+	Title         string   `json:"title,omitempty"`
+	IssueIDs      []string `json:"issue_ids,omitempty"`
+	Target        string   `json:"target,omitempty"`
+	Closed        *int     `json:"closed,omitempty"`
+	Stranded      *int     `json:"stranded,omitempty"`
+	TotalChildren *int     `json:"total_children,omitempty"`
+	OpenChildren  *int     `json:"open_children,omitempty"`
+	DryRun        bool     `json:"dry_run,omitempty"`
+	AlreadyClosed bool     `json:"already_closed,omitempty"`
+	Forced        bool     `json:"forced,omitempty"`
+	Notify        string   `json:"notify,omitempty"`
+}
+
+func intRef(value int) *int {
+	return &value
+}
+
 func newConvoyCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convoy",
@@ -59,7 +82,7 @@ type convoyCreateOptions struct {
 
 func newConvoyCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 	var owner, notify, merge, target string
-	var owned bool
+	var owned, jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "create <name> [issue-ids...]",
 		Short: "Create a convoy and optionally track issues",
@@ -82,7 +105,13 @@ the new convoy. Issues can also be added later with "gc convoy add".`,
 				},
 				Owned: owned,
 			}
-			if cmdConvoyCreateWithOptions(args, opts, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdConvoyCreateWithOptionsJSON(args, opts, true, stdout, stderr)
+			} else {
+				code = cmdConvoyCreateWithOptions(args, opts, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
@@ -93,10 +122,15 @@ the new convoy. Issues can also be added later with "gc convoy add".`,
 	cmd.Flags().StringVar(&merge, "merge", "", "merge strategy: direct, mr, local")
 	cmd.Flags().StringVar(&target, "target", "", "target branch inherited by child work beads")
 	cmd.Flags().BoolVar(&owned, "owned", false, "mark convoy as owned (manual lifecycle, no auto-close)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
 	return cmd
 }
 
 func cmdConvoyCreateWithOptions(args []string, opts convoyCreateOptions, stdout, stderr io.Writer) int {
+	return cmdConvoyCreateWithOptionsJSON(args, opts, false, stdout, stderr)
+}
+
+func cmdConvoyCreateWithOptionsJSON(args []string, opts convoyCreateOptions, jsonOut bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -132,13 +166,13 @@ func cmdConvoyCreateWithOptions(args []string, opts convoyCreateOptions, stdout,
 	}
 
 	rec := openCityRecorderAt(cityPath, stderr)
-	return doConvoyCreateWithOptions(store, cfg, cityPath, rec, args, opts, stdout, stderr)
+	return doConvoyCreateWithOptionsJSON(store, cfg, cityPath, rec, args, opts, jsonOut, stdout, stderr)
 }
 
 // doConvoyCreate creates a convoy bead and optionally adds issues to it.
 // When cfg/cityPath are nil/empty, all beads are assumed to be in the same store.
 func doConvoyCreate(store beads.Store, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
-	return doConvoyCreateWithOptions(store, nil, "", rec, args, convoyCreateOptions{}, stdout, stderr)
+	return doConvoyCreateWithOptions(store, rec, args, convoyCreateOptions{}, stdout, stderr)
 }
 
 func convoyCreateStoreRoot(cfg *config.City, cityPath, beadID string) string {
@@ -164,7 +198,11 @@ func validateConvoyCreateStoreScope(cfg *config.City, cityPath string, issueIDs 
 	return nil
 }
 
-func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath string, rec events.Recorder, args []string, opts convoyCreateOptions, stdout, stderr io.Writer) int {
+func doConvoyCreateWithOptions(store beads.Store, rec events.Recorder, args []string, opts convoyCreateOptions, stdout, stderr io.Writer) int {
+	return doConvoyCreateWithOptionsJSON(store, nil, "", rec, args, opts, false, stdout, stderr)
+}
+
+func doConvoyCreateWithOptionsJSON(store beads.Store, cfg *config.City, cityPath string, rec events.Recorder, args []string, opts convoyCreateOptions, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc convoy create: missing convoy name") //nolint:errcheck // best-effort stderr
 		return 1
@@ -226,9 +264,12 @@ func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath str
 		Message: name,
 	})
 
-	if len(issueIDs) > 0 {
+	switch {
+	case jsonOut:
+		_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.create", Action: "create", ConvoyID: convoy.ID, Title: name, IssueIDs: issueIDs})
+	case len(issueIDs) > 0:
 		fmt.Fprintf(stdout, "Created convoy %s %q tracking %d issue(s)\n", convoy.ID, name, len(issueIDs)) //nolint:errcheck // best-effort stdout
-	} else {
+	default:
 		fmt.Fprintf(stdout, "Created convoy %s %q\n", convoy.ID, name) //nolint:errcheck // best-effort stdout
 	}
 	return 0
@@ -589,7 +630,8 @@ func doConvoyStatus(store beads.Store, args []string, stdout, stderr io.Writer) 
 }
 
 func newConvoyTargetCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "target <convoy-id> <branch>",
 		Short: "Set the target branch on a convoy",
 		Long: `Set the target branch metadata on a convoy.
@@ -598,17 +640,29 @@ Child work beads can inherit this target branch when slung with
 feature-branch formulas such as mol-polecat-work.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdConvoyTarget(args, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdConvoyTargetJSON(args, true, stdout, stderr)
+			} else {
+				code = cmdConvoyTarget(args, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 func cmdConvoyTarget(args []string, stdout, stderr io.Writer) int {
+	return cmdConvoyTargetJSON(args, false, stdout, stderr)
+}
+
+func cmdConvoyTargetJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
-		return doConvoyTarget(nil, args, stdout, stderr)
+		return doConvoyTargetJSON(nil, args, jsonOut, stdout, stderr)
 	}
 	convoyID := ""
 	if len(args) > 0 {
@@ -618,10 +672,14 @@ func cmdConvoyTarget(args []string, stdout, stderr io.Writer) int {
 	if store == nil {
 		return code
 	}
-	return doConvoyTarget(store, args, stdout, stderr)
+	return doConvoyTargetJSON(store, args, jsonOut, stdout, stderr)
 }
 
 func doConvoyTarget(store beads.Store, args []string, stdout, stderr io.Writer) int {
+	return doConvoyTargetJSON(store, args, false, stdout, stderr)
+}
+
+func doConvoyTargetJSON(store beads.Store, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
 		fmt.Fprintln(stderr, "gc convoy target: missing convoy ID or branch") //nolint:errcheck // best-effort stderr
 		return 1
@@ -647,12 +705,17 @@ func doConvoyTarget(store beads.Store, args []string, stdout, stderr io.Writer) 
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "Set target of convoy %s to %s\n", id, target) //nolint:errcheck // best-effort stdout
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.target", Action: "target", ConvoyID: id, Target: target})
+	} else {
+		fmt.Fprintf(stdout, "Set target of convoy %s to %s\n", id, target) //nolint:errcheck // best-effort stdout
+	}
 	return 0
 }
 
 func newConvoyAddCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "add <convoy-id> <issue-id>",
 		Short: "Add an issue to a convoy",
 		Long: `Link an existing issue bead to a convoy.
@@ -661,18 +724,30 @@ Sets the issue's parent to the convoy ID, making it appear in the
 convoy's progress tracking.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdConvoyAdd(args, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdConvoyAddJSON(args, true, stdout, stderr)
+			} else {
+				code = cmdConvoyAdd(args, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 // cmdConvoyAdd is the CLI entry point for adding an issue to a convoy.
 func cmdConvoyAdd(args []string, stdout, stderr io.Writer) int {
+	return cmdConvoyAddJSON(args, false, stdout, stderr)
+}
+
+func cmdConvoyAddJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
-		return doConvoyAdd(nil, args, stdout, stderr)
+		return doConvoyAddJSON(nil, args, jsonOut, stdout, stderr)
 	}
 	convoyID := ""
 	if len(args) > 0 {
@@ -682,11 +757,15 @@ func cmdConvoyAdd(args []string, stdout, stderr io.Writer) int {
 	if store == nil {
 		return code
 	}
-	return doConvoyAdd(store, args, stdout, stderr)
+	return doConvoyAddJSON(store, args, jsonOut, stdout, stderr)
 }
 
 // doConvoyAdd adds an issue to a convoy by setting the issue's ParentID.
 func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int {
+	return doConvoyAddJSON(store, args, false, stdout, stderr)
+}
+
+func doConvoyAddJSON(store beads.Store, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
 		fmt.Fprintln(stderr, "gc convoy add: usage: gc convoy add <convoy-id> <issue-id>") //nolint:errcheck // best-effort stderr
 		return 1
@@ -714,12 +793,17 @@ func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "Added %s to convoy %s\n", issueID, convoyID) //nolint:errcheck // best-effort stdout
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.add", Action: "add", ConvoyID: convoyID, IssueIDs: []string{issueID}})
+	} else {
+		fmt.Fprintf(stdout, "Added %s to convoy %s\n", issueID, convoyID) //nolint:errcheck // best-effort stdout
+	}
 	return 0
 }
 
 func newConvoyCloseCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "close <id>",
 		Short: "Close a convoy",
 		Long: `Close a convoy bead manually.
@@ -728,18 +812,30 @@ Marks the convoy as closed regardless of child issue status. Use
 "gc convoy check" to auto-close convoys where all issues are resolved.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdConvoyClose(args, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdConvoyCloseJSON(args, true, stdout, stderr)
+			} else {
+				code = cmdConvoyClose(args, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 // cmdConvoyClose is the CLI entry point for closing a convoy.
 func cmdConvoyClose(args []string, stdout, stderr io.Writer) int {
+	return cmdConvoyCloseJSON(args, false, stdout, stderr)
+}
+
+func cmdConvoyCloseJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		return doConvoyClose(nil, events.Discard, args, stdout, stderr)
+		return doConvoyCloseJSON(nil, events.Discard, args, jsonOut, stdout, stderr)
 	}
 	convoyID := ""
 	if len(args) > 0 {
@@ -750,11 +846,15 @@ func cmdConvoyClose(args []string, stdout, stderr io.Writer) int {
 		return code
 	}
 	rec := openCityRecorder(stderr)
-	return doConvoyClose(store, rec, args, stdout, stderr)
+	return doConvoyCloseJSON(store, rec, args, jsonOut, stdout, stderr)
 }
 
 // doConvoyClose closes a convoy bead.
 func doConvoyClose(store beads.Store, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
+	return doConvoyCloseJSON(store, rec, args, false, stdout, stderr)
+}
+
+func doConvoyCloseJSON(store beads.Store, rec events.Recorder, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc convoy close: missing convoy ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -782,12 +882,17 @@ func doConvoyClose(store beads.Store, rec events.Recorder, args []string, stdout
 		Subject: id,
 	})
 
-	fmt.Fprintf(stdout, "Closed convoy %s\n", id) //nolint:errcheck // best-effort stdout
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.close", Action: "close", ConvoyID: id})
+	} else {
+		fmt.Fprintf(stdout, "Closed convoy %s\n", id) //nolint:errcheck // best-effort stdout
+	}
 	return 0
 }
 
 func newConvoyCheckCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Auto-close convoys where all issues are closed",
 		Long: `Scan open convoys and auto-close any where all child issues are resolved.
@@ -796,22 +901,34 @@ Evaluates each open convoy's children. If all children have status
 "closed", the convoy is automatically closed and an event is recorded.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdConvoyCheck(stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdConvoyCheckJSON(true, stdout, stderr)
+			} else {
+				code = cmdConvoyCheck(stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 // cmdConvoyCheck is the CLI entry point for auto-closing completed convoys.
 func cmdConvoyCheck(stdout, stderr io.Writer) int {
+	return cmdConvoyCheckJSON(false, stdout, stderr)
+}
+
+func cmdConvoyCheckJSON(jsonOut bool, stdout, stderr io.Writer) int {
 	stores, code := openAllConvoyStores(stderr, "gc convoy check")
 	if stores == nil {
 		return code
 	}
 	rec := openCityRecorder(stderr)
-	return doConvoyCheckAcrossStores(stores, rec, stdout, stderr)
+	return doConvoyCheckAcrossStoresJSON(stores, rec, jsonOut, stdout, stderr)
 }
 
 // hasLabel reports whether the labels slice contains the target label.
@@ -868,6 +985,10 @@ func doConvoyCheck(store beads.Store, rec events.Recorder, stdout, stderr io.Wri
 }
 
 func doConvoyCheckAcrossStores(stores []convoyStoreView, rec events.Recorder, stdout, stderr io.Writer) int {
+	return doConvoyCheckAcrossStoresJSON(stores, rec, false, stdout, stderr)
+}
+
+func doConvoyCheckAcrossStoresJSON(stores []convoyStoreView, rec events.Recorder, jsonOut bool, stdout, stderr io.Writer) int {
 	convoys, err := collectOpenConvoys(stores)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc convoy check: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -909,12 +1030,17 @@ func doConvoyCheckAcrossStores(stores []convoyStoreView, rec events.Recorder, st
 		}
 	}
 
-	fmt.Fprintf(stdout, "%d convoy(s) auto-closed\n", closed) //nolint:errcheck // best-effort stdout
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.check", Action: "check", Closed: intRef(closed)})
+	} else {
+		fmt.Fprintf(stdout, "%d convoy(s) auto-closed\n", closed) //nolint:errcheck // best-effort stdout
+	}
 	return 0
 }
 
 func newConvoyStrandedCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "stranded",
 		Short: "Find convoys with ready work but no workers",
 		Long: `Find open issues in convoys that have no assignee.
@@ -923,21 +1049,33 @@ Lists issues that are ready for work but not claimed by any agent.
 Useful for identifying bottlenecks in convoy processing.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdConvoyStranded(stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdConvoyStrandedJSON(true, stdout, stderr)
+			} else {
+				code = cmdConvoyStranded(stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 // cmdConvoyStranded is the CLI entry point for finding stranded convoys.
 func cmdConvoyStranded(stdout, stderr io.Writer) int {
+	return cmdConvoyStrandedJSON(false, stdout, stderr)
+}
+
+func cmdConvoyStrandedJSON(jsonOut bool, stdout, stderr io.Writer) int {
 	stores, code := openAllConvoyStores(stderr, "gc convoy stranded")
 	if stores == nil {
 		return code
 	}
-	return doConvoyStrandedAcrossStores(stores, stdout, stderr)
+	return doConvoyStrandedAcrossStoresJSON(stores, jsonOut, stdout, stderr)
 }
 
 // doConvoyStranded finds open convoys with open children that have no assignee.
@@ -946,6 +1084,10 @@ func doConvoyStranded(store beads.Store, stdout, stderr io.Writer) int {
 }
 
 func doConvoyStrandedAcrossStores(stores []convoyStoreView, stdout, stderr io.Writer) int {
+	return doConvoyStrandedAcrossStoresJSON(stores, false, stdout, stderr)
+}
+
+func doConvoyStrandedAcrossStoresJSON(stores []convoyStoreView, jsonOut bool, stdout, stderr io.Writer) int {
 	convoys, err := collectOpenConvoys(stores)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc convoy stranded: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -972,7 +1114,15 @@ func doConvoyStrandedAcrossStores(stores []convoyStoreView, stdout, stderr io.Wr
 	}
 
 	if len(items) == 0 {
-		fmt.Fprintln(stdout, "No stranded work") //nolint:errcheck // best-effort stdout
+		if jsonOut {
+			_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.stranded", Action: "stranded", Stranded: intRef(0)})
+		} else {
+			fmt.Fprintln(stdout, "No stranded work") //nolint:errcheck // best-effort stdout
+		}
+		return 0
+	}
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.stranded", Action: "stranded", Stranded: intRef(len(items))})
 		return 0
 	}
 
@@ -988,7 +1138,7 @@ func doConvoyStrandedAcrossStores(stores []convoyStoreView, stdout, stderr io.Wr
 // --- gc convoy land ---
 
 func newConvoyLandCmd(stdout, stderr io.Writer) *cobra.Command {
-	var force, dryRun bool
+	var force, dryRun, jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "land <convoy-id>",
 		Short: "Land an owned convoy (terminate + cleanup)",
@@ -1006,7 +1156,13 @@ via "gc sling --owned". It verifies all children are closed (or uses
 				Force:  force,
 				DryRun: dryRun,
 			}
-			if cmdConvoyLand(args, opts, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdConvoyLandJSON(args, opts, true, stdout, stderr)
+			} else {
+				code = cmdConvoyLand(args, opts, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
@@ -1014,6 +1170,7 @@ via "gc sling --owned". It verifies all children are closed (or uses
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "land even with open children")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what would happen")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
 	return cmd
 }
 
@@ -1025,8 +1182,12 @@ type landOpts struct {
 
 // cmdConvoyLand is the CLI entry point for landing a convoy.
 func cmdConvoyLand(args []string, opts landOpts, stdout, stderr io.Writer) int {
+	return cmdConvoyLandJSON(args, opts, false, stdout, stderr)
+}
+
+func cmdConvoyLandJSON(args []string, opts landOpts, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		return doConvoyLand(nil, events.Discard, args, opts, stdout, stderr)
+		return doConvoyLandJSON(nil, events.Discard, args, opts, jsonOut, stdout, stderr)
 	}
 	convoyID := ""
 	if len(args) > 0 {
@@ -1037,12 +1198,16 @@ func cmdConvoyLand(args []string, opts landOpts, stdout, stderr io.Writer) int {
 		return code
 	}
 	rec := openCityRecorder(stderr)
-	return doConvoyLand(store, rec, args, opts, stdout, stderr)
+	return doConvoyLandJSON(store, rec, args, opts, jsonOut, stdout, stderr)
 }
 
 // doConvoyLand verifies an owned convoy's children are closed, optionally
 // cleans up worktrees, closes the convoy bead, and records an event.
 func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts landOpts, stdout, stderr io.Writer) int {
+	return doConvoyLandJSON(store, rec, args, opts, false, stdout, stderr)
+}
+
+func doConvoyLandJSON(store beads.Store, rec events.Recorder, args []string, opts landOpts, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc convoy land: missing convoy ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1065,7 +1230,11 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 
 	// Already closed → idempotent success.
 	if convoy.Status == "closed" {
-		fmt.Fprintf(stdout, "Convoy %s already closed\n", convoyID) //nolint:errcheck // best-effort stdout
+		if jsonOut {
+			_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.land", Action: "land", ConvoyID: convoyID, Title: convoy.Title, AlreadyClosed: true, DryRun: opts.DryRun, Forced: opts.Force})
+		} else {
+			fmt.Fprintf(stdout, "Convoy %s already closed\n", convoyID) //nolint:errcheck // best-effort stdout
+		}
 		return 0
 	}
 
@@ -1094,8 +1263,12 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 
 	// Dry-run: preview what would happen.
 	if opts.DryRun {
-		fmt.Fprintf(stdout, "Would land convoy %s %q\n", convoyID, convoy.Title)                 //nolint:errcheck // best-effort stdout
-		fmt.Fprintf(stdout, "  Children: %d total, %d open\n", len(children), len(openChildren)) //nolint:errcheck // best-effort stdout
+		if jsonOut {
+			_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.land", Action: "land", ConvoyID: convoyID, Title: convoy.Title, TotalChildren: intRef(len(children)), OpenChildren: intRef(len(openChildren)), DryRun: true, Forced: opts.Force})
+		} else {
+			fmt.Fprintf(stdout, "Would land convoy %s %q\n", convoyID, convoy.Title)                 //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "  Children: %d total, %d open\n", len(children), len(openChildren)) //nolint:errcheck // best-effort stdout
+		}
 		return 0
 	}
 
@@ -1113,9 +1286,12 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 
 	// Notification.
 	fields := getConvoyFields(convoy)
-	if fields.Notify != "" {
+	switch {
+	case jsonOut:
+		_ = writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.land", Action: "land", ConvoyID: convoyID, Title: convoy.Title, TotalChildren: intRef(len(children)), OpenChildren: intRef(len(openChildren)), Forced: opts.Force, Notify: fields.Notify})
+	case fields.Notify != "":
 		fmt.Fprintf(stdout, "Landed convoy %s %q (notify: %s)\n", convoyID, convoy.Title, fields.Notify) //nolint:errcheck // best-effort stdout
-	} else {
+	default:
 		fmt.Fprintf(stdout, "Landed convoy %s %q\n", convoyID, convoy.Title) //nolint:errcheck // best-effort stdout
 	}
 	return 0

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -70,6 +71,31 @@ func TestConvoyCreateWithIssues(t *testing.T) {
 	}
 }
 
+func TestConvoyCreateJSON(t *testing.T) {
+	store := beads.NewMemStore()
+	issue, _ := store.Create(beads.Bead{Title: "fix auth"})
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyCreateWithOptionsJSON(store, nil, "", events.Discard,
+		[]string{"security fixes", issue.ID}, convoyCreateOptions{}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyCreateWithOptionsJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	var got struct {
+		SchemaVersion string   `json:"schema_version"`
+		OK            bool     `json:"ok"`
+		Command       string   `json:"command"`
+		ConvoyID      string   `json:"convoy_id"`
+		IssueIDs      []string `json:"issue_ids"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || !got.OK || got.Command != "convoy.create" || got.ConvoyID == "" || len(got.IssueIDs) != 1 {
+		t.Fatalf("payload = %+v", got)
+	}
+}
+
 func TestConvoyCreateMissingName(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -107,7 +133,7 @@ func TestConvoyCreateMultiRig(t *testing.T) {
 
 	// Test 1: single-store mode (cfg=nil) — all beads in same store.
 	var stdout, stderr bytes.Buffer
-	code := doConvoyCreateWithOptions(cityStore, nil, "", events.Discard,
+	code := doConvoyCreateWithOptions(cityStore, events.Discard,
 		[]string{"cross-rig batch", child1.ID, child2.ID}, convoyCreateOptions{}, &stdout, &stderr)
 	// Should fail because children are in rigStore, not cityStore.
 	if code != 1 {
@@ -119,7 +145,7 @@ func TestConvoyCreateMultiRig(t *testing.T) {
 	stderr.Reset()
 	child3, _ := cityStore.Create(beads.Bead{Title: "city task"})
 	child4, _ := cityStore.Create(beads.Bead{Title: "city task 2"})
-	code = doConvoyCreateWithOptions(cityStore, nil, "", events.Discard,
+	code = doConvoyCreateWithOptions(cityStore, events.Discard,
 		[]string{"same-store batch", child3.ID, child4.ID}, convoyCreateOptions{}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("same-store convoy failed: %s", stderr.String())
@@ -177,7 +203,7 @@ func TestConvoyCreateRigChildrenShareStore(t *testing.T) {
 	c3, _ := store.Create(beads.Bead{Title: "Haskell hello"})
 
 	var stdout, stderr bytes.Buffer
-	code := doConvoyCreateWithOptions(store, nil, "", events.Discard,
+	code := doConvoyCreateWithOptions(store, events.Discard,
 		[]string{"Hello World Variants", c1.ID, c2.ID, c3.ID}, convoyCreateOptions{}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("convoy create failed: %s", stderr.String())
@@ -1335,7 +1361,7 @@ func TestConvoyCreateWithFields(t *testing.T) {
 	fields := ConvoyFields{Owner: "mayor", Merge: "mr"}
 
 	var stdout, stderr bytes.Buffer
-	code := doConvoyCreateWithOptions(store, nil, "", events.Discard, []string{"deploy"}, convoyCreateOptions{Fields: fields}, &stdout, &stderr)
+	code := doConvoyCreateWithOptions(store, events.Discard, []string{"deploy"}, convoyCreateOptions{Fields: fields}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doConvoyCreateWithOptions = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1361,7 +1387,7 @@ func TestConvoyCreateWithOptionsOwnedAndTarget(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doConvoyCreateWithOptions(store, nil, "", events.Discard, []string{"deploy"}, opts, &stdout, &stderr)
+	code := doConvoyCreateWithOptions(store, events.Discard, []string{"deploy"}, opts, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doConvoyCreateWithOptions = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -35,6 +35,40 @@ const (
 	mailInjectPreviewScanSize = 4096
 )
 
+type mailActionResult struct {
+	SchemaVersion string               `json:"schema_version"`
+	OK            bool                 `json:"ok"`
+	Command       string               `json:"command"`
+	Action        string               `json:"action"`
+	ID            string               `json:"id,omitempty"`
+	Message       *mailMessageSummary  `json:"message,omitempty"`
+	Messages      []mailMessageSummary `json:"messages,omitempty"`
+	IDs           []string             `json:"ids,omitempty"`
+	Count         *int                 `json:"count,omitempty"`
+	AlreadyDone   bool                 `json:"already_done,omitempty"`
+	Notified      bool                 `json:"notified,omitempty"`
+}
+
+type mailMessageSummary struct {
+	ID       string `json:"id"`
+	From     string `json:"from,omitempty"`
+	To       string `json:"to,omitempty"`
+	Subject  string `json:"subject,omitempty"`
+	ThreadID string `json:"thread_id,omitempty"`
+	ReplyTo  string `json:"reply_to,omitempty"`
+}
+
+func summarizeMailMessage(m mail.Message) mailMessageSummary {
+	return mailMessageSummary{
+		ID:       m.ID,
+		From:     m.From,
+		To:       m.To,
+		Subject:  m.Subject,
+		ThreadID: m.ThreadID,
+		ReplyTo:  m.ReplyTo,
+	}
+}
+
 func newMailNudgeFunc(sender string) nudgeFunc {
 	return func(recipient string) error {
 		target, err := resolveNudgeTarget(recipient, io.Discard)
@@ -82,7 +116,8 @@ hooks to deliver mail notifications into agent prompts.`,
 }
 
 func newMailArchiveCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "archive <id>...",
 		Short: "Archive one or more messages without reading them",
 		Long: `Close one or more message beads without displaying their contents.
@@ -92,22 +127,34 @@ as closed and will no longer appear in mail check or inbox results. When
 multiple IDs are passed, they are archived in a single batch round-trip.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdMailArchive(args, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdMailArchiveJSON(args, true, stdout, stderr)
+			} else {
+				code = cmdMailArchive(args, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 // cmdMailArchive is the CLI entry point for archiving a message.
 func cmdMailArchive(args []string, stdout, stderr io.Writer) int {
+	return cmdMailArchiveJSON(args, false, stdout, stderr)
+}
+
+func cmdMailArchiveJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	mp, code := openCityMailProvider(stderr, "gc mail archive")
 	if mp == nil {
 		return code
 	}
 	rec := openCityRecorder(stderr)
-	return doMailArchive(mp, rec, args, stdout, stderr)
+	return doMailArchiveJSON(mp, rec, args, jsonOut, stdout, stderr)
 }
 
 // doMailArchive closes one or more message beads. For a single ID the
@@ -115,20 +162,38 @@ func cmdMailArchive(args []string, stdout, stderr io.Writer) int {
 // delegates to mp.ArchiveMany for a single-round-trip close and prints one
 // result line per id.
 func doMailArchive(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
+	return doMailArchiveJSON(mp, rec, args, false, stdout, stderr)
+}
+
+func doMailArchiveJSON(mp mail.Provider, rec events.Recorder, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc mail archive: missing message ID") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if len(args) == 1 {
+		if jsonOut {
+			return doMailArchiveSingleJSON(mp, rec, args[0], true, stdout, stderr)
+		}
 		return doMailArchiveSingle(mp, rec, args[0], stdout, stderr)
+	}
+	if jsonOut {
+		return doMailArchiveManyJSON(mp, rec, args, true, stdout, stderr)
 	}
 	return doMailArchiveMany(mp, rec, args, stdout, stderr)
 }
 
 func doMailArchiveSingle(mp mail.Provider, rec events.Recorder, id string, stdout, stderr io.Writer) int {
+	return doMailArchiveSingleJSON(mp, rec, id, false, stdout, stderr)
+}
+
+func doMailArchiveSingleJSON(mp mail.Provider, rec events.Recorder, id string, jsonOut bool, stdout, stderr io.Writer) int {
 	if err := mp.Archive(id); err != nil {
 		if errors.Is(err, mail.ErrAlreadyArchived) {
-			fmt.Fprintf(stdout, "Already archived %s\n", id) //nolint:errcheck // best-effort stdout
+			if jsonOut {
+				_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.archive", Action: "archive", ID: id, IDs: []string{id}, Count: intRef(0), AlreadyDone: true})
+			} else {
+				fmt.Fprintf(stdout, "Already archived %s\n", id) //nolint:errcheck // best-effort stdout
+			}
 			return 0
 		}
 		telemetry.RecordMailOp(context.Background(), "archive", err)
@@ -142,11 +207,19 @@ func doMailArchiveSingle(mp mail.Provider, rec events.Recorder, id string, stdou
 		Subject: id,
 		Payload: mailEventPayload(nil),
 	})
-	fmt.Fprintf(stdout, "Archived message %s\n", id) //nolint:errcheck // best-effort stdout
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.archive", Action: "archive", ID: id, IDs: []string{id}, Count: intRef(1)})
+	} else {
+		fmt.Fprintf(stdout, "Archived message %s\n", id) //nolint:errcheck // best-effort stdout
+	}
 	return 0
 }
 
 func doMailArchiveMany(mp mail.Provider, rec events.Recorder, ids []string, stdout, stderr io.Writer) int {
+	return doMailArchiveManyJSON(mp, rec, ids, false, stdout, stderr)
+}
+
+func doMailArchiveManyJSON(mp mail.Provider, rec events.Recorder, ids []string, jsonOut bool, stdout, stderr io.Writer) int {
 	results, err := mp.ArchiveMany(ids)
 	if err != nil {
 		telemetry.RecordMailOp(context.Background(), "archive", err)
@@ -154,9 +227,12 @@ func doMailArchiveMany(mp mail.Provider, rec events.Recorder, ids []string, stdo
 		return 1
 	}
 	exit := 0
+	archived := 0
+	already := 0
 	for _, r := range results {
 		switch {
 		case r.Err == nil:
+			archived++
 			telemetry.RecordMailOp(context.Background(), "archive", nil)
 			rec.Record(events.Event{
 				Type:    events.MailArchived,
@@ -164,14 +240,22 @@ func doMailArchiveMany(mp mail.Provider, rec events.Recorder, ids []string, stdo
 				Subject: r.ID,
 				Payload: mailEventPayload(nil),
 			})
-			fmt.Fprintf(stdout, "Archived message %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			if !jsonOut {
+				fmt.Fprintf(stdout, "Archived message %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			}
 		case errors.Is(r.Err, mail.ErrAlreadyArchived):
-			fmt.Fprintf(stdout, "Already archived %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			already++
+			if !jsonOut {
+				fmt.Fprintf(stdout, "Already archived %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			}
 		default:
 			telemetry.RecordMailOp(context.Background(), "archive", r.Err)
 			fmt.Fprintf(stderr, "gc mail archive %s: %v\n", r.ID, r.Err) //nolint:errcheck // best-effort stderr
 			exit = 1
 		}
+	}
+	if jsonOut && exit == 0 {
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.archive", Action: "archive", IDs: ids, Count: intRef(archived), AlreadyDone: already == len(ids)})
 	}
 	return exit
 }
@@ -915,6 +999,7 @@ func newMailSendCmd(stdout, stderr io.Writer) *cobra.Command {
 	var to string
 	var subject string
 	var message string
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "send [<to>] [<body>]",
 		Short: "Send a message to a session alias or human",
@@ -935,7 +1020,13 @@ Use --all to broadcast to all live sessions (excluding sender and "human").`,
   gc mail send --all "Status update: tests passing"`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdMailSend(args, notify, all, from, to, subject, message, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdMailSendJSON(args, notify, all, from, to, subject, message, true, stdout, stderr)
+			} else {
+				code = cmdMailSend(args, notify, all, from, to, subject, message, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
@@ -949,6 +1040,7 @@ Use --all to broadcast to all live sessions (excluding sender and "human").`,
 	cmd.Flags().StringVar(&to, "to", "", "recipient address (alternative to positional argument)")
 	cmd.Flags().StringVarP(&subject, "subject", "s", "", "message subject line")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "message body text")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
 	cmd.MarkFlagsMutuallyExclusive("to", "all")
 	return cmd
 }
@@ -1011,6 +1103,7 @@ func newMailReplyCmd(stdout, stderr io.Writer) *cobra.Command {
 	var subject string
 	var message string
 	var notify bool
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "reply <id> [-s subject] [-m body]",
 		Short: "Reply to a message",
@@ -1021,7 +1114,13 @@ Use --notify to nudge the recipient after replying.
 Use -s/--subject for the reply subject and -m/--message for the reply body.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdMailReply(args, subject, message, notify, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdMailReplyJSON(args, subject, message, notify, true, stdout, stderr)
+			} else {
+				code = cmdMailReply(args, subject, message, notify, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
@@ -1031,42 +1130,62 @@ Use -s/--subject for the reply subject and -m/--message for the reply body.`,
 	cmd.Flags().StringVarP(&message, "message", "m", "", "reply body text")
 	cmd.Flags().BoolVar(&notify, "notify", false, "nudge the recipient after replying")
 	cmd.Flags().BoolVar(&notify, "nudge", false, "alias for --notify")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
 	_ = cmd.Flags().MarkHidden("nudge")
 	return cmd
 }
 
 func newMailMarkReadCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "mark-read <id>",
 		Short: "Mark a message as read",
 		Long:  `Mark a message as read without displaying it. The message will no longer appear in inbox results.`,
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdMailMarkRead(args, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdMailMarkReadJSON(args, true, stdout, stderr)
+			} else {
+				code = cmdMailMarkRead(args, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 func newMailMarkUnreadCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "mark-unread <id>",
 		Short: "Mark a message as unread",
 		Long:  `Mark a message as unread. The message will appear again in inbox results.`,
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdMailMarkUnread(args, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdMailMarkUnreadJSON(args, true, stdout, stderr)
+			} else {
+				code = cmdMailMarkUnread(args, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 func newMailDeleteCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "delete <id>...",
 		Short: "Delete one or more messages (closes the beads)",
 		Long: `Delete one or more messages by closing the beads. Same effect as archive
@@ -1074,12 +1193,20 @@ but with different user intent. When multiple IDs are passed, they are
 deleted in a single batch round-trip.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdMailDelete(args, stdout, stderr) != 0 {
+			code := 0
+			if jsonOut {
+				code = cmdMailDeleteJSON(args, true, stdout, stderr)
+			} else {
+				code = cmdMailDelete(args, stdout, stderr)
+			}
+			if code != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	return cmd
 }
 
 func newMailThreadCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -1117,6 +1244,10 @@ The recipient defaults to $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human".`,
 // resolves session mailbox identities, and delegates to doMailSend.
 // The to parameter is the --to flag value (empty if not set).
 func cmdMailSend(args []string, notify bool, all bool, from string, to string, subject string, message string, stdout, stderr io.Writer) int {
+	return cmdMailSendJSON(args, notify, all, from, to, subject, message, false, stdout, stderr)
+}
+
+func cmdMailSendJSON(args []string, notify bool, all bool, from string, to string, subject string, message string, jsonOut bool, stdout, stderr io.Writer) int {
 	mp, code := openCityMailProvider(stderr, "gc mail send")
 	if mp == nil {
 		return code
@@ -1206,17 +1337,21 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 
 	if all {
 		rec := openCityRecorder(stderr)
-		return doMailSendAll(mp, rec, validRecipients, sender, args, nf, stdout, stderr)
+		return doMailSendAllJSON(mp, rec, validRecipients, sender, args, nf, jsonOut, stdout, stderr)
 	}
 
 	rec := openCityRecorder(stderr)
-	return doMailSend(mp, rec, validRecipients, sender, args, nf, stdout, stderr)
+	return doMailSendJSON(mp, rec, validRecipients, sender, args, nf, jsonOut, stdout, stderr)
 }
 
 // doMailSend creates a message addressed to a recipient. args is [to, subject, body]
 // or [to, body] (subject="" if no -s flag). When nudgeFn is non-nil, the
 // recipient is nudged after message creation (skipped for "human").
 func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, stdout, stderr io.Writer) int {
+	return doMailSendJSON(mp, rec, validRecipients, sender, args, nudgeFn, false, stdout, stderr)
+}
+
+func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
 		fmt.Fprintln(stderr, "gc mail send: usage: gc mail send <to> <body>  OR  gc mail send <to> -s <subject> [-m <body>]") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1251,20 +1386,33 @@ func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[strin
 		Message: to,
 		Payload: mailEventPayload(&m),
 	})
-	fmt.Fprintf(stdout, "Sent message %s to %s\n", m.ID, to) //nolint:errcheck // best-effort stdout
+	if !jsonOut {
+		fmt.Fprintf(stdout, "Sent message %s to %s\n", m.ID, to) //nolint:errcheck // best-effort stdout
+	}
 
 	// Nudge recipient if requested and recipient is not human.
+	notified := false
 	if nudgeFn != nil && to != "human" {
 		if err := nudgeFn(to); err != nil {
 			fmt.Fprintf(stderr, "gc mail send: nudge failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		} else {
+			notified = true
 		}
+	}
+	if jsonOut {
+		summary := summarizeMailMessage(m)
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.send", Action: "send", ID: m.ID, Message: &summary, Messages: []mailMessageSummary{summary}, Count: intRef(1), Notified: notified})
 	}
 	return 0
 }
 
 // doMailSendAll broadcasts a message to all live session mailboxes (excluding the
 // sender and "human"). With --all, args is [subject, body] or [body].
-func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, stdout, stderr io.Writer) int {
+func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, stdout, stderr io.Writer) int {
+	return doMailSendAllJSON(mp, rec, validRecipients, sender, args, nil, false, stdout, stderr)
+}
+
+func doMailSendAllJSON(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc mail send --all: usage: gc mail send --all <body>") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1293,6 +1441,8 @@ func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[st
 		return 1
 	}
 
+	var sent []mailMessageSummary
+	notified := false
 	for _, to := range recipients {
 		m, err := mp.Send(sender, to, subject, body)
 		if err != nil {
@@ -1306,13 +1456,21 @@ func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[st
 			Message: to,
 			Payload: mailEventPayload(&m),
 		})
-		fmt.Fprintf(stdout, "Sent message %s to %s\n", m.ID, to) //nolint:errcheck // best-effort stdout
+		sent = append(sent, summarizeMailMessage(m))
+		if !jsonOut {
+			fmt.Fprintf(stdout, "Sent message %s to %s\n", m.ID, to) //nolint:errcheck // best-effort stdout
+		}
 
 		if nudgeFn != nil {
 			if err := nudgeFn(to); err != nil {
 				fmt.Fprintf(stderr, "gc mail send --all: nudge %s failed: %v\n", to, err) //nolint:errcheck // best-effort stderr
+			} else {
+				notified = true
 			}
 		}
+	}
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.send", Action: "send", Messages: sent, Count: intRef(len(sent)), Notified: notified})
 	}
 	return 0
 }
@@ -1424,6 +1582,10 @@ func doMailPeek(mp mail.Provider, args []string, stdout, stderr io.Writer) int {
 
 // cmdMailReply replies to a message.
 func cmdMailReply(args []string, subject, message string, notify bool, stdout, stderr io.Writer) int {
+	return cmdMailReplyJSON(args, subject, message, notify, false, stdout, stderr)
+}
+
+func cmdMailReplyJSON(args []string, subject, message string, notify bool, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc mail reply: missing message ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1492,11 +1654,15 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 		fmt.Fprintf(stderr, "gc mail reply: --notify requested but no city store available; nudge skipped: %v\n", notifySetupErr) //nolint:errcheck // best-effort stderr
 	}
 
-	return doMailReply(mp, rec, args[0], sender, subject, body, nf, stdout, stderr)
+	return doMailReplyJSON(mp, rec, args[0], sender, subject, body, nf, jsonOut, stdout, stderr)
 }
 
 // doMailReply creates a reply to an existing message.
 func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, body string, nudgeFn nudgeFunc, stdout, stderr io.Writer) int {
+	return doMailReplyJSON(mp, rec, id, sender, subject, body, nudgeFn, false, stdout, stderr)
+}
+
+func doMailReplyJSON(mp mail.Provider, rec events.Recorder, id, sender, subject, body string, nudgeFn nudgeFunc, jsonOut bool, stdout, stderr io.Writer) int {
 	reply, err := mp.Reply(id, sender, subject, body)
 	telemetry.RecordMailOp(context.Background(), "reply", err)
 	if err != nil {
@@ -1510,28 +1676,45 @@ func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, bod
 		Message: reply.To,
 		Payload: mailEventPayload(&reply),
 	})
-	fmt.Fprintf(stdout, "Replied to %s — sent message %s to %s\n", id, reply.ID, reply.To) //nolint:errcheck // best-effort stdout
+	if !jsonOut {
+		fmt.Fprintf(stdout, "Replied to %s — sent message %s to %s\n", id, reply.ID, reply.To) //nolint:errcheck // best-effort stdout
+	}
 
+	notified := false
 	if nudgeFn != nil && reply.To != "human" {
 		if err := nudgeFn(reply.To); err != nil {
 			fmt.Fprintf(stderr, "gc mail reply: nudge failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		} else {
+			notified = true
 		}
+	}
+	if jsonOut {
+		summary := summarizeMailMessage(reply)
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.reply", Action: "reply", ID: reply.ID, Message: &summary, Messages: []mailMessageSummary{summary}, Count: intRef(1), Notified: notified})
 	}
 	return 0
 }
 
 // cmdMailMarkRead marks a message as read.
 func cmdMailMarkRead(args []string, stdout, stderr io.Writer) int {
+	return cmdMailMarkReadJSON(args, false, stdout, stderr)
+}
+
+func cmdMailMarkReadJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	mp, code := openCityMailProvider(stderr, "gc mail mark-read")
 	if mp == nil {
 		return code
 	}
 	rec := openCityRecorder(stderr)
-	return doMailMarkRead(mp, rec, args, stdout, stderr)
+	return doMailMarkReadJSON(mp, rec, args, jsonOut, stdout, stderr)
 }
 
 // doMailMarkRead marks a message as read.
 func doMailMarkRead(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
+	return doMailMarkReadJSON(mp, rec, args, false, stdout, stderr)
+}
+
+func doMailMarkReadJSON(mp mail.Provider, rec events.Recorder, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc mail mark-read: missing message ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1549,22 +1732,34 @@ func doMailMarkRead(mp mail.Provider, rec events.Recorder, args []string, stdout
 		Subject: id,
 		Payload: mailEventPayload(nil),
 	})
-	fmt.Fprintf(stdout, "Marked %s as read\n", id) //nolint:errcheck // best-effort stdout
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.mark-read", Action: "mark-read", ID: id, IDs: []string{id}, Count: intRef(1)})
+	} else {
+		fmt.Fprintf(stdout, "Marked %s as read\n", id) //nolint:errcheck // best-effort stdout
+	}
 	return 0
 }
 
 // cmdMailMarkUnread marks a message as unread.
 func cmdMailMarkUnread(args []string, stdout, stderr io.Writer) int {
+	return cmdMailMarkUnreadJSON(args, false, stdout, stderr)
+}
+
+func cmdMailMarkUnreadJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	mp, code := openCityMailProvider(stderr, "gc mail mark-unread")
 	if mp == nil {
 		return code
 	}
 	rec := openCityRecorder(stderr)
-	return doMailMarkUnread(mp, rec, args, stdout, stderr)
+	return doMailMarkUnreadJSON(mp, rec, args, jsonOut, stdout, stderr)
 }
 
 // doMailMarkUnread marks a message as unread.
 func doMailMarkUnread(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
+	return doMailMarkUnreadJSON(mp, rec, args, false, stdout, stderr)
+}
+
+func doMailMarkUnreadJSON(mp mail.Provider, rec events.Recorder, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc mail mark-unread: missing message ID") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1582,18 +1777,26 @@ func doMailMarkUnread(mp mail.Provider, rec events.Recorder, args []string, stdo
 		Subject: id,
 		Payload: mailEventPayload(nil),
 	})
-	fmt.Fprintf(stdout, "Marked %s as unread\n", id) //nolint:errcheck // best-effort stdout
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.mark-unread", Action: "mark-unread", ID: id, IDs: []string{id}, Count: intRef(1)})
+	} else {
+		fmt.Fprintf(stdout, "Marked %s as unread\n", id) //nolint:errcheck // best-effort stdout
+	}
 	return 0
 }
 
 // cmdMailDelete deletes a message.
 func cmdMailDelete(args []string, stdout, stderr io.Writer) int {
+	return cmdMailDeleteJSON(args, false, stdout, stderr)
+}
+
+func cmdMailDeleteJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	mp, code := openCityMailProvider(stderr, "gc mail delete")
 	if mp == nil {
 		return code
 	}
 	rec := openCityRecorder(stderr)
-	return doMailDelete(mp, rec, args, stdout, stderr)
+	return doMailDeleteJSON(mp, rec, args, jsonOut, stdout, stderr)
 }
 
 // doMailDelete closes one or more message beads (same as archive but
@@ -1601,20 +1804,38 @@ func cmdMailDelete(args []string, stdout, stderr io.Writer) int {
 // byte-for-byte; multi-id uses mp.DeleteMany to preserve provider delete
 // semantics.
 func doMailDelete(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
+	return doMailDeleteJSON(mp, rec, args, false, stdout, stderr)
+}
+
+func doMailDeleteJSON(mp mail.Provider, rec events.Recorder, args []string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc mail delete: missing message ID") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if len(args) == 1 {
+		if jsonOut {
+			return doMailDeleteSingleJSON(mp, rec, args[0], true, stdout, stderr)
+		}
 		return doMailDeleteSingle(mp, rec, args[0], stdout, stderr)
+	}
+	if jsonOut {
+		return doMailDeleteManyJSON(mp, rec, args, true, stdout, stderr)
 	}
 	return doMailDeleteMany(mp, rec, args, stdout, stderr)
 }
 
 func doMailDeleteSingle(mp mail.Provider, rec events.Recorder, id string, stdout, stderr io.Writer) int {
+	return doMailDeleteSingleJSON(mp, rec, id, false, stdout, stderr)
+}
+
+func doMailDeleteSingleJSON(mp mail.Provider, rec events.Recorder, id string, jsonOut bool, stdout, stderr io.Writer) int {
 	if err := mp.Delete(id); err != nil {
 		if errors.Is(err, mail.ErrAlreadyArchived) {
-			fmt.Fprintf(stdout, "Already deleted %s\n", id) //nolint:errcheck // best-effort stdout
+			if jsonOut {
+				_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.delete", Action: "delete", ID: id, IDs: []string{id}, Count: intRef(0), AlreadyDone: true})
+			} else {
+				fmt.Fprintf(stdout, "Already deleted %s\n", id) //nolint:errcheck // best-effort stdout
+			}
 			return 0
 		}
 		telemetry.RecordMailOp(context.Background(), "delete", err)
@@ -1628,11 +1849,19 @@ func doMailDeleteSingle(mp mail.Provider, rec events.Recorder, id string, stdout
 		Subject: id,
 		Payload: mailEventPayload(nil),
 	})
-	fmt.Fprintf(stdout, "Deleted message %s\n", id) //nolint:errcheck // best-effort stdout
+	if jsonOut {
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.delete", Action: "delete", ID: id, IDs: []string{id}, Count: intRef(1)})
+	} else {
+		fmt.Fprintf(stdout, "Deleted message %s\n", id) //nolint:errcheck // best-effort stdout
+	}
 	return 0
 }
 
 func doMailDeleteMany(mp mail.Provider, rec events.Recorder, ids []string, stdout, stderr io.Writer) int {
+	return doMailDeleteManyJSON(mp, rec, ids, false, stdout, stderr)
+}
+
+func doMailDeleteManyJSON(mp mail.Provider, rec events.Recorder, ids []string, jsonOut bool, stdout, stderr io.Writer) int {
 	results, err := mp.DeleteMany(ids)
 	if err != nil {
 		telemetry.RecordMailOp(context.Background(), "delete", err)
@@ -1640,9 +1869,12 @@ func doMailDeleteMany(mp mail.Provider, rec events.Recorder, ids []string, stdou
 		return 1
 	}
 	exit := 0
+	deleted := 0
+	already := 0
 	for _, r := range results {
 		switch {
 		case r.Err == nil:
+			deleted++
 			telemetry.RecordMailOp(context.Background(), "delete", nil)
 			rec.Record(events.Event{
 				Type:    events.MailDeleted,
@@ -1650,14 +1882,22 @@ func doMailDeleteMany(mp mail.Provider, rec events.Recorder, ids []string, stdou
 				Subject: r.ID,
 				Payload: mailEventPayload(nil),
 			})
-			fmt.Fprintf(stdout, "Deleted message %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			if !jsonOut {
+				fmt.Fprintf(stdout, "Deleted message %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			}
 		case errors.Is(r.Err, mail.ErrAlreadyArchived):
-			fmt.Fprintf(stdout, "Already deleted %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			already++
+			if !jsonOut {
+				fmt.Fprintf(stdout, "Already deleted %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			}
 		default:
 			telemetry.RecordMailOp(context.Background(), "delete", r.Err)
 			fmt.Fprintf(stderr, "gc mail delete %s: %v\n", r.ID, r.Err) //nolint:errcheck // best-effort stderr
 			exit = 1
 		}
+	}
+	if jsonOut && exit == 0 {
+		_ = writeCLIJSONLine(stdout, mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.delete", Action: "delete", IDs: ids, Count: intRef(deleted), AlreadyDone: already == len(ids)})
 	}
 	return exit
 }

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -109,6 +110,34 @@ func TestMailSendSuccess(t *testing.T) {
 	}
 	if b.Status != "open" {
 		t.Errorf("bead Status = %q, want %q", b.Status, "open")
+	}
+}
+
+func TestMailSendJSON(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	recipients := map[string]bool{"human": true, "mayor": true}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailSendJSON(mp, events.Discard, recipients, "human", []string{"mayor", "build is green"}, nil, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailSendJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	var got struct {
+		SchemaVersion string `json:"schema_version"`
+		OK            bool   `json:"ok"`
+		Command       string `json:"command"`
+		Count         int    `json:"count"`
+		Messages      []struct {
+			ID string `json:"id"`
+			To string `json:"to"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || !got.OK || got.Command != "mail.send" || got.Count != 1 || len(got.Messages) != 1 || got.Messages[0].To != "mayor" {
+		t.Fatalf("payload = %+v", got)
 	}
 }
 
@@ -2343,7 +2372,7 @@ func TestMailSendAll(t *testing.T) {
 	recipients := map[string]bool{"human": true, "coder": true, "committer": true, "tester": true}
 
 	var stdout, stderr bytes.Buffer
-	code := doMailSendAll(mp, events.Discard, recipients, "coder", []string{"status update: tests passing"}, nil, &stdout, &stderr)
+	code := doMailSendAll(mp, events.Discard, recipients, "coder", []string{"status update: tests passing"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doMailSendAll = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2373,7 +2402,7 @@ func TestMailSendAllMissingBody(t *testing.T) {
 	recipients := map[string]bool{"human": true, "coder": true}
 
 	var stderr bytes.Buffer
-	code := doMailSendAll(mp, events.Discard, recipients, "human", nil, nil, &bytes.Buffer{}, &stderr)
+	code := doMailSendAll(mp, events.Discard, recipients, "human", nil, &bytes.Buffer{}, &stderr)
 	if code != 1 {
 		t.Errorf("doMailSendAll = %d, want 1", code)
 	}
@@ -2389,7 +2418,7 @@ func TestMailSendAllNoRecipients(t *testing.T) {
 	recipients := map[string]bool{"human": true, "coder": true}
 
 	var stderr bytes.Buffer
-	code := doMailSendAll(mp, events.Discard, recipients, "coder", []string{"hello?"}, nil, &bytes.Buffer{}, &stderr)
+	code := doMailSendAll(mp, events.Discard, recipients, "coder", []string{"hello?"}, &bytes.Buffer{}, &stderr)
 	if code != 1 {
 		t.Errorf("doMailSendAll = %d, want 1", code)
 	}
@@ -2404,7 +2433,7 @@ func TestMailSendAllExcludesSender(t *testing.T) {
 	recipients := map[string]bool{"human": true, "alice": true, "bob": true}
 
 	var stdout bytes.Buffer
-	code := doMailSendAll(mp, events.Discard, recipients, "alice", []string{"broadcast"}, nil, &stdout, &bytes.Buffer{})
+	code := doMailSendAll(mp, events.Discard, recipients, "alice", []string{"broadcast"}, &stdout, &bytes.Buffer{})
 	if code != 0 {
 		t.Fatalf("doMailSendAll = %d, want 0", code)
 	}

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -50,6 +50,43 @@ func TestJSONSchemaManifestForSupportedCommand(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaManifestForActionSummaryCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"convoy", "create", "--json-schema"},
+		{"convoy", "land", "--json-schema"},
+		{"mail", "send", "--json-schema"},
+		{"mail", "delete", "--json-schema"},
+	} {
+		t.Run(strings.Join(args[:len(args)-1], " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%v) = %d, stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var manifest struct {
+				SchemaVersion string                     `json:"schema_version"`
+				JSONSupported bool                       `json:"json_supported"`
+				Schemas       map[string]json.RawMessage `json:"schemas"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+				t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+			}
+			if manifest.SchemaVersion != "1" || !manifest.JSONSupported {
+				t.Fatalf("manifest metadata = %+v", manifest)
+			}
+			if !json.Valid(manifest.Schemas["result"]) {
+				t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
+			}
+			if !json.Valid(manifest.Schemas["failure"]) {
+				t.Fatalf("failure schema missing or invalid: %s", manifest.Schemas["failure"])
+			}
+		})
+	}
+}
+
 func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"version", "--json-schema"}, &stdout, &stderr)

--- a/schemas/convoy/add/result.schema.json
+++ b/schemas/convoy/add/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "convoy_id", "issue_ids"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "convoy.add" },
+    "action": { "const": "add" },
+    "convoy_id": { "type": "string", "minLength": 1 },
+    "issue_ids": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+  },
+  "additionalProperties": false
+}

--- a/schemas/convoy/check/result.schema.json
+++ b/schemas/convoy/check/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "closed"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "convoy.check" },
+    "action": { "const": "check" },
+    "closed": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/convoy/close/result.schema.json
+++ b/schemas/convoy/close/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "convoy_id"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "convoy.close" },
+    "action": { "const": "close" },
+    "convoy_id": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/convoy/create/result.schema.json
+++ b/schemas/convoy/create/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "convoy_id", "title"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "convoy.create" },
+    "action": { "const": "create" },
+    "convoy_id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string" },
+    "issue_ids": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}

--- a/schemas/convoy/land/result.schema.json
+++ b/schemas/convoy/land/result.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "convoy_id", "title"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "convoy.land" },
+    "action": { "const": "land" },
+    "convoy_id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string" },
+    "total_children": { "type": "integer", "minimum": 0 },
+    "open_children": { "type": "integer", "minimum": 0 },
+    "dry_run": { "type": "boolean" },
+    "already_closed": { "type": "boolean" },
+    "forced": { "type": "boolean" },
+    "notify": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/convoy/stranded/result.schema.json
+++ b/schemas/convoy/stranded/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "stranded"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "convoy.stranded" },
+    "action": { "const": "stranded" },
+    "stranded": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/convoy/target/result.schema.json
+++ b/schemas/convoy/target/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "convoy_id", "target"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "convoy.target" },
+    "action": { "const": "target" },
+    "convoy_id": { "type": "string", "minLength": 1 },
+    "target": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/mail/archive/result.schema.json
+++ b/schemas/mail/archive/result.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "ids", "count"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "mail.archive" },
+    "action": { "const": "archive" },
+    "id": { "type": "string" },
+    "ids": { "type": "array", "items": { "type": "string" } },
+    "count": { "type": "integer", "minimum": 0 },
+    "already_done": { "type": "boolean" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/mail/delete/result.schema.json
+++ b/schemas/mail/delete/result.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "ids", "count"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "mail.delete" },
+    "action": { "const": "delete" },
+    "id": { "type": "string" },
+    "ids": { "type": "array", "items": { "type": "string" } },
+    "count": { "type": "integer", "minimum": 0 },
+    "already_done": { "type": "boolean" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/mail/mark-read/result.schema.json
+++ b/schemas/mail/mark-read/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "id", "ids", "count"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "mail.mark-read" },
+    "action": { "const": "mark-read" },
+    "id": { "type": "string", "minLength": 1 },
+    "ids": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "count": { "type": "integer", "minimum": 1 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/mail/mark-unread/result.schema.json
+++ b/schemas/mail/mark-unread/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "id", "ids", "count"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "mail.mark-unread" },
+    "action": { "const": "mark-unread" },
+    "id": { "type": "string", "minLength": 1 },
+    "ids": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "count": { "type": "integer", "minimum": 1 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/mail/reply/result.schema.json
+++ b/schemas/mail/reply/result.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "message": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "subject": { "type": "string" },
+        "thread_id": { "type": "string" },
+        "reply_to": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "id", "message", "messages", "count"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "mail.reply" },
+    "action": { "const": "reply" },
+    "id": { "type": "string", "minLength": 1 },
+    "message": { "$ref": "#/$defs/message" },
+    "messages": { "type": "array", "items": { "$ref": "#/$defs/message" } },
+    "count": { "type": "integer", "minimum": 1 },
+    "notified": { "type": "boolean" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/mail/send/result.schema.json
+++ b/schemas/mail/send/result.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "message": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "subject": { "type": "string" },
+        "thread_id": { "type": "string" },
+        "reply_to": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "messages", "count"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "mail.send" },
+    "action": { "const": "send" },
+    "id": { "type": "string" },
+    "message": { "$ref": "#/$defs/message" },
+    "messages": { "type": "array", "items": { "$ref": "#/$defs/message" } },
+    "count": { "type": "integer", "minimum": 0 },
+    "notified": { "type": "boolean" }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- Adds native bounded `--json` success summaries for convoy action commands: `create`, `target`, `add`, `close`, `check`, `stranded`, and `land`.
- Adds native bounded `--json` success summaries for mail mutation commands: `archive`, `send`, `reply`, `mark-read`, `mark-unread`, and `delete`.
- Adds JSON Schema 2020-12 result schemas under `schemas/<command-path>/result.schema.json`; failures use the shared `schemas/failure.schema.json` platform behavior.

## JSON shape notes
These are new native JSON shapes for commands that previously emitted human text only. They follow the rollout convention of one JSONL success record with `schema_version: "1"`, `ok: true`, `command`, and `action` fields. Action-specific identifiers/counts are included where useful:
- convoy records include `convoy_id`, `issue_ids`, `target`, `closed`, `stranded`, `total_children`, `open_children`, `dry_run`, `already_closed`, `forced`, and/or `notify` depending on the action.
- mail records include `id`, `ids`, `count`, `already_done`, `message`, `messages`, and/or `notified` depending on the action.

Rationale: these commands are bounded mutations or bounded summaries, so a single action-summary record gives automation a stable contract without changing default human output.

## Skips / scope
- Did not touch deprecated current `gc pack` / `gc import` commands.
- Skipped hidden `convoy autoclose` because it is hook/transport infrastructure and best-effort by design.
- Left list/status/read/peek/thread/count/events/trace outside this shard because they are covered by other rollout shards or explicitly out of scope.

## Validation
- `git diff --check`
- `jq empty` across new convoy/mail schemas
- `go test ./cmd/gc -run 'Test(JSONSchema|Mail(SendJSON|SendSuccess|Reply|MarkRead|MarkUnread|Delete|Archive|SendAll)|Convoy(Create|Target|Add|Close|Check|Stranded|Land))'`
- `go test ./cmd/gc -run 'TestJSONSchemaManifestForActionSummaryCommands|TestConvoyCreateJSON|TestMailSendJSON'`
- `make fmt-check`
- `GOOS=linux make lint`
- `make vet`
- `make check-docs`

## Risk
- Batch mail archive/delete JSON success records summarize successful operations; partial batch errors intentionally return nonzero and let the platform structured failure path own stdout.
- This PR is stacked on `codex/json-schema-platform` to keep the review limited to action-summary commands and schemas.

