### PR TITLE
test: trim personal review formula basic graph

### DIFF
--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -1889,6 +1889,47 @@ func TestCompileReviewWorkflowSkipGeminiFiltersExpansionLane(t *testing.T) {
 	}
 }
 
+func TestCompilePersonalWorkSkipGeminiKeepsBothReviewLoops(t *testing.T) {
+	enableV2ForTest(t)
+
+	dir := t.TempDir()
+	writePersonalWorkReviewWorkflowFixtures(t, dir)
+
+	recipe, err := Compile(context.Background(), "mol-personal-work-v2", []string{dir}, map[string]string{
+		"issue":       "GC-1",
+		"skip_gemini": "true",
+	})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	for _, step := range recipe.Steps {
+		if strings.Contains(step.ID, "gemini") {
+			t.Fatalf("compiled recipe unexpectedly retained Gemini lane with skip_gemini=true: %s", step.ID)
+		}
+	}
+	for _, dep := range recipe.Deps {
+		if strings.Contains(dep.StepID, "gemini") || strings.Contains(dep.DependsOnID, "gemini") {
+			t.Fatalf("compiled recipe unexpectedly retained Gemini dependency with skip_gemini=true: %+v", dep)
+		}
+	}
+
+	for _, want := range []string{
+		"mol-personal-work-v2.design-review-loop.iteration.1.design-review-pipeline.persona-gen-claude",
+		"mol-personal-work-v2.design-review-loop.iteration.1.design-review-pipeline.persona-gen-codex",
+		"mol-personal-work-v2.design-review-loop.iteration.1.design-review-pipeline.review-synthesis",
+		"mol-personal-work-v2.design-review-loop.iteration.1.apply-design-changes",
+		"mol-personal-work-v2.code-review-loop.iteration.1.review-pipeline.review-claude",
+		"mol-personal-work-v2.code-review-loop.iteration.1.review-pipeline.review-codex",
+		"mol-personal-work-v2.code-review-loop.iteration.1.review-pipeline.synthesize",
+		"mol-personal-work-v2.code-review-loop.iteration.1.apply-code-fixes",
+	} {
+		if recipe.StepByID(want) == nil {
+			t.Fatalf("compiled recipe missing expected step %q", want)
+		}
+	}
+}
+
 func TestCompileReviewWorkflowAnnotatesNestedReviewerRetries(t *testing.T) {
 	enableV2ForTest(t)
 
@@ -1941,6 +1982,19 @@ func writeReviewWorkflowFixtures(t *testing.T, dir string) {
 	for name, content := range map[string]string{
 		"expansion-review-pr.toml": reviewworkflows.ExpansionReviewPR,
 		"mol-adopt-pr-v2.toml":     reviewworkflows.AdoptPR,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+}
+
+func writePersonalWorkReviewWorkflowFixtures(t *testing.T, dir string) {
+	t.Helper()
+	for name, content := range map[string]string{
+		"expansion-review-pr.toml":     reviewworkflows.ExpansionReviewPR,
+		"expansion-design-review.toml": reviewworkflows.ExpansionDesignReview,
+		"mol-personal-work-v2.toml":    reviewworkflows.PersonalWork,
 	} {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
 			t.Fatalf("write %s: %v", name, err)

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -173,7 +173,7 @@ func TestPersonalWorkFormulaCompileAndRun(t *testing.T) {
 	issueID, workflowID := startReviewWorkflow(t, cityDir, "mol-personal-work-v2", map[string]string{
 		"issue":         "", // filled after create
 		"base_branch":   "main",
-		"skip_gemini":   "false",
+		"skip_gemini":   "true",
 		"setup_command": "true",
 		"test_command":  "true",
 	})


### PR DESCRIPTION
## Summary
- run the personal-work basic integration scenario with skip_gemini=true to avoid the oversized initial graph hitting Dolt/bd cycle-check timeouts
- add a compile guard proving the personal-work formula still keeps both design and code review loops plus non-Gemini review lanes when Gemini is skipped

## Verification
- go test ./internal/formula -run 'TestCompilePersonalWorkSkipGeminiKeepsBothReviewLoops|TestCompileReviewWorkflowSkipGeminiFiltersExpansionLane' -count=1
- setsid --wait go test -tags=integration ./test/integration -run '^TestPersonalWorkFormulaCompileAndRun$' -count=1 -v -timeout 20m
- setsid --wait env GO_TEST_COVERPROFILE=/tmp/gascity-review-basic-2-cover.txt ./scripts/test-integration-shard review-formulas-basic-2-of-2