### PR TITLE
test: extend review formula sling launch timeout

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -387,8 +387,12 @@ func gc(dir string, args ...string) (string, error) {
 // supervisor state, but without forcing GC_DOLT=skip. Use this for tests that
 // need the real bd+dolt-backed bead store.
 func gcDolt(dir string, args ...string) (string, error) {
+	return gcDoltWithTimeout(dir, integrationGCDoltCommandTimeout, args...)
+}
+
+func gcDoltWithTimeout(dir string, timeout time.Duration, args ...string) (string, error) {
 	envDir := commandCityDirForArgs(dir, args)
-	return runCommand(dir, commandEnvForDir(envDir, true), integrationGCDoltCommandTimeout, gcBinary, args...)
+	return runCommand(dir, commandEnvForDir(envDir, true), timeout, gcBinary, args...)
 }
 
 // bd runs the bd binary with the given args. If dir is non-empty, it sets

--- a/test/integration/review_formula_test.go
+++ b/test/integration/review_formula_test.go
@@ -24,6 +24,11 @@ import (
 // contention without letting a genuinely stuck workflow loiter.
 const reviewWorkflowTimeout = 18 * time.Minute
 
+// reviewWorkflowSlingTimeout only covers formula instantiation and source
+// routing. The personal-work graph is large enough that bd-backed graph apply
+// can exceed the generic 2-minute Dolt command budget on busy CI runners.
+const reviewWorkflowSlingTimeout = 5 * time.Minute
+
 const testAdoptPRReviewCheck = `#!/usr/bin/env bash
 set -euo pipefail
 
@@ -463,8 +468,9 @@ func startReviewWorkflow(t *testing.T, cityDir, formula string, vars map[string]
 	for k, v := range vars {
 		args = append(args, "--var", k+"="+v)
 	}
-	out, err = gcDolt(cityDir, args...)
+	out, err = gcDoltWithTimeout(cityDir, reviewWorkflowSlingTimeout, args...)
 	if err != nil {
+		dumpReviewFormulaCityState(t, cityDir)
 		t.Fatalf("gc sling failed: %v\noutput: %s", err, out)
 	}
 	slingOutput := out
@@ -531,6 +537,11 @@ func traceShowsSameAttemptTransientRetry(trace, stepRef string) bool {
 }
 
 func dumpWorkflowState(t *testing.T, cityDir, workflowID string) {
+	t.Helper()
+	dumpReviewFormulaCityState(t, cityDir)
+}
+
+func dumpReviewFormulaCityState(t *testing.T, cityDir string) {
 	t.Helper()
 	out, _ := bdDolt(cityDir, "list", "--json", "--all", "--limit=0")
 	t.Logf("all beads:\n%s", out)


### PR DESCRIPTION
## Summary
- add a scoped longer timeout for review-formula gc sling launches
- dump partial review formula city state when sling launch fails
- keep the default gcDolt command timeout unchanged for other integration helpers

## Verification
- go test -tags=integration ./test/integration -run '^TestPersonalWorkFormulaCompileAndRun$' -count=1 -v -timeout 20m
- GO_TEST_COVERPROFILE=/tmp/gascity-review-basic-2-cover-timeout.txt ./scripts/test-integration-shard review-formulas-basic-2-of-2