### PR TITLE
Retry source workflow launch visibility

### DIFF
--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -63,6 +63,8 @@ var (
 const (
 	maxSourceChainHops               = 32
 	maxWorkflowFinalizeErrorMetadata = 512
+	scopeBodyResolveAttempts         = 5
+	scopeBodyResolveRetryDelay       = 100 * time.Millisecond
 )
 
 const workflowFinalizeErrorMetadataKey = "gc.last_finalize_error"
@@ -1071,6 +1073,21 @@ func resolveBlockingSubjectID(store beads.Store, beadID string) (string, error) 
 }
 
 func resolveScopeBody(store beads.Store, rootID, scopeRef string) (beads.Bead, error) {
+	var lastErr error
+	for attempt := 1; attempt <= scopeBodyResolveAttempts; attempt++ {
+		bead, err := resolveScopeBodyOnce(store, rootID, scopeRef)
+		if err == nil || !errors.Is(err, errScopeBodyMissing) {
+			return bead, err
+		}
+		lastErr = err
+		if attempt < scopeBodyResolveAttempts {
+			time.Sleep(scopeBodyResolveRetryDelay)
+		}
+	}
+	return beads.Bead{}, lastErr
+}
+
+func resolveScopeBodyOnce(store beads.Store, rootID, scopeRef string) (beads.Bead, error) {
 	if bead, ok, err := resolveScopeBodyByRole(store, rootID, scopeRef, false); err != nil {
 		return beads.Bead{}, err
 	} else if ok {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -641,6 +641,76 @@ func TestProcessScopeCheckReturnsMalformedWhenScopeBodyMissing(t *testing.T) {
 	}
 }
 
+func TestProcessScopeCheckRetriesTransientMissingScopeBody(t *testing.T) {
+	t.Parallel()
+
+	mem := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, mem, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	body := mustCreateWorkflowBead(t, mem, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	step := mustCreateWorkflowBead(t, mem, beads.Bead{
+		Title:  "preflight",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "pass",
+		},
+	})
+	control := mustCreateWorkflowBead(t, mem, beads.Bead{
+		Title: "Finalize scope for preflight",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	mustDepAdd(t, mem, control.ID, step.ID, "blocks")
+
+	store := &transientMissingScopeBodyStore{
+		MemStore:  mem,
+		bodyID:    body.ID,
+		rootID:    workflow.ID,
+		hideReads: 3,
+	}
+	result, err := ProcessControl(store, control, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if result.Action != "scope-pass" {
+		t.Fatalf("action = %q, want scope-pass", result.Action)
+	}
+	if store.hiddenReads != 3 {
+		t.Fatalf("hiddenReads = %d, want 3", store.hiddenReads)
+	}
+	bodyAfter := mustGetBead(t, mem, body.ID)
+	if bodyAfter.Status != "closed" {
+		t.Fatalf("body status = %q, want closed", bodyAfter.Status)
+	}
+	if got := bodyAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("body outcome = %q, want pass", got)
+	}
+}
+
 func TestProcessFanoutReturnsMalformedWhenScopeBodyMissing(t *testing.T) {
 	t.Parallel()
 
@@ -939,6 +1009,14 @@ type scopeBodyVanishAfterFirstResolveStore struct {
 	resolved bool
 }
 
+type transientMissingScopeBodyStore struct {
+	*beads.MemStore
+	bodyID      string
+	rootID      string
+	hideReads   int
+	hiddenReads int
+}
+
 type workflowFinalizeCloseFailStore struct {
 	beads.Store
 	finalizerID string
@@ -971,8 +1049,24 @@ func (s *scopeBodyVanishAfterFirstResolveStore) List(query beads.ListQuery) ([]b
 	return filterBeadID(result, s.bodyID), nil
 }
 
+func (s *transientMissingScopeBodyStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	result, err := s.MemStore.List(query)
+	if err != nil {
+		return nil, err
+	}
+	if !canResolveScopeBodyQuery(query, s.rootID) || !containsBeadID(result, s.bodyID) || s.hiddenReads >= s.hideReads {
+		return result, nil
+	}
+	s.hiddenReads++
+	return filterBeadID(result, s.bodyID), nil
+}
+
 func (s *scopeBodyVanishAfterFirstResolveStore) canResolveScopeBody(query beads.ListQuery) bool {
-	if query.Metadata["gc.root_bead_id"] != s.rootID {
+	return canResolveScopeBodyQuery(query, s.rootID)
+}
+
+func canResolveScopeBodyQuery(query beads.ListQuery, rootID string) bool {
+	if query.Metadata["gc.root_bead_id"] != rootID {
 		return false
 	}
 	if query.Metadata["gc.kind"] == "scope" && query.Metadata["gc.scope_role"] == "body" {

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -14,6 +15,11 @@ import (
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 	"github.com/gastownhall/gascity/internal/telemetry"
+)
+
+const (
+	sourceWorkflowLaunchVisibilityAttempts   = 5
+	sourceWorkflowLaunchVisibilityRetryDelay = 100 * time.Millisecond
 )
 
 func depsTracef(deps SlingDeps, format string, args ...any) {
@@ -696,7 +702,7 @@ func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBea
 			}
 			return err
 		}
-		roots, err = listSourceWorkflowRoots(deps, sourceBeadID)
+		roots, err = waitForSourceWorkflowLaunchVisible(ctx, deps, sourceBeadID, result.WorkflowID, launch.storeRef)
 		if err != nil {
 			// A transient store error while re-listing is recoverable:
 			// the finalize already succeeded, the lock is still held, and
@@ -706,9 +712,7 @@ func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBea
 				fmt.Sprintf("verify live workflows for %s: %v", sourceBeadID, err))
 			return nil
 		}
-		if !slices.ContainsFunc(roots, func(root sourceWorkflowRoot) bool {
-			return sameWorkflowRoot(root, result.WorkflowID, launch.storeRef)
-		}) {
+		if roots == nil {
 			// Under the held lock, a successful finalize that is not
 			// visible via ListLiveRoots is an invariant violation: either
 			// the new root was never persisted or it no longer matches
@@ -729,6 +733,58 @@ func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBea
 		return nil
 	})
 	return result, err
+}
+
+func waitForSourceWorkflowLaunchVisible(ctx context.Context, deps SlingDeps, sourceBeadID, workflowID, storeRef string) ([]sourceWorkflowRoot, error) {
+	var roots []sourceWorkflowRoot
+	for attempt := 1; attempt <= sourceWorkflowLaunchVisibilityAttempts; attempt++ {
+		var err error
+		roots, err = listSourceWorkflowRoots(deps, sourceBeadID)
+		if err != nil {
+			return nil, err
+		}
+		if slices.ContainsFunc(roots, func(root sourceWorkflowRoot) bool {
+			return sameWorkflowRoot(root, workflowID, storeRef)
+		}) {
+			return roots, nil
+		}
+		if ok, err := launchedWorkflowRootMatchesSource(deps, sourceBeadID, workflowID, storeRef); err != nil {
+			return nil, err
+		} else if ok {
+			return []sourceWorkflowRoot{{
+				root:     beads.Bead{ID: workflowID},
+				store:    deps.Store,
+				storeRef: strings.TrimSpace(storeRef),
+			}}, nil
+		}
+		if attempt == sourceWorkflowLaunchVisibilityAttempts {
+			return nil, nil
+		}
+		timer := time.NewTimer(sourceWorkflowLaunchVisibilityRetryDelay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil, nil
+}
+
+func launchedWorkflowRootMatchesSource(deps SlingDeps, sourceBeadID, workflowID, storeRef string) (bool, error) {
+	root, err := deps.Store.Get(workflowID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !sourceworkflow.IsWorkflowRoot(root) {
+		return false, nil
+	}
+	return sourceworkflow.WorkflowMatchesSource(root, sourceBeadID, storeRef, storeRef), nil
 }
 
 // attachBatchFormula launches one batch-child formula. The caller passes the

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -51,6 +51,25 @@ type closeAllFailMemStore struct {
 	failSetMetadataCall int
 }
 
+type staleSourceWorkflowListStore struct {
+	beads.Store
+	sourceID      string
+	hiddenReads   int
+	hideReadLimit int
+}
+
+func (s *staleSourceWorkflowListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	items, err := s.Store.List(query)
+	if err != nil {
+		return nil, err
+	}
+	if query.Metadata["gc.source_bead_id"] == s.sourceID && len(items) > 0 && s.hiddenReads < s.hideReadLimit {
+		s.hiddenReads++
+		return nil, nil
+	}
+	return items, nil
+}
+
 func (s *closeAllFailMemStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
 	if s.failCloseAllCalls > 0 {
 		s.failCloseAllCalls--
@@ -1615,6 +1634,130 @@ title = "Do work"
 	}
 	if conflictErr.SourceBeadID != source.ID {
 		t.Fatalf("SourceBeadID = %q, want %q", conflictErr.SourceBeadID, source.ID)
+	}
+}
+
+func TestSlingAttachGraphFormulaRetriesLaunchVisibilityAfterStaleList(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	formulatest.EnableV2ForTest(t)
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleStore := &staleSourceWorkflowListStore{
+		Store:         deps.Store,
+		sourceID:      source.ID,
+		hideReadLimit: 1,
+	}
+	deps.Store = staleStore
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+	if staleStore.hiddenReads != 1 {
+		t.Fatalf("hiddenReads = %d, want 1", staleStore.hiddenReads)
+	}
+	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("ListLiveRoots: %v", err)
+	}
+	if len(roots) != 1 || roots[0].ID != result.WorkflowID {
+		t.Fatalf("live roots = %#v, want [%s]", roots, result.WorkflowID)
+	}
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != result.WorkflowID {
+		t.Fatalf("source workflow_id = %q, want %q", got, result.WorkflowID)
+	}
+}
+
+func TestSlingAttachGraphFormulaAcceptsDirectRootWhenLaunchListStaysStale(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	formulatest.EnableV2ForTest(t)
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleStore := &staleSourceWorkflowListStore{
+		Store:         deps.Store,
+		sourceID:      source.ID,
+		hideReadLimit: 99,
+	}
+	deps.Store = staleStore
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+	if staleStore.hiddenReads == 0 {
+		t.Fatal("hiddenReads = 0, want stale list path exercised")
+	}
+	root, err := deps.Store.Get(result.WorkflowID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if !sourceworkflow.WorkflowMatchesSource(root, source.ID, deps.StoreRef, deps.StoreRef) {
+		t.Fatalf("root metadata = %#v, want workflow to match source %s", root.Metadata, source.ID)
+	}
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != result.WorkflowID {
+		t.Fatalf("source workflow_id = %q, want %q", got, result.WorkflowID)
 	}
 }
 

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -142,6 +142,35 @@ type testNotifier struct{}
 func (testNotifier) PokeController(_ string)      {}
 func (testNotifier) PokeControlDispatch(_ string) {}
 
+type closeLaunchedWorkflowNotifier struct {
+	store    beads.Store
+	sourceID string
+	storeRef string
+	once     sync.Once
+	closed   int
+	err      error
+}
+
+func (n *closeLaunchedWorkflowNotifier) PokeController(_ string) {
+	n.once.Do(func() {
+		roots, err := sourceworkflow.ListLiveRoots(n.store, n.sourceID, n.storeRef, n.storeRef)
+		if err != nil {
+			n.err = err
+			return
+		}
+		closedStatus := "closed"
+		for _, root := range roots {
+			if err := n.store.Update(root.ID, beads.UpdateOpts{Status: &closedStatus}); err != nil {
+				n.err = err
+				return
+			}
+			n.closed++
+		}
+	})
+}
+
+func (*closeLaunchedWorkflowNotifier) PokeControlDispatch(_ string) {}
+
 func testDeps(cfg *config.City, sp runtime.Provider, runner SlingRunner) SlingDeps {
 	if cfg != nil && len(cfg.FormulaLayers.City) == 0 {
 		cfg.FormulaLayers.City = []string{sharedTestFormulaDir}
@@ -1751,6 +1780,81 @@ title = "Do work"
 	}
 	if !sourceworkflow.WorkflowMatchesSource(root, source.ID, deps.StoreRef, deps.StoreRef) {
 		t.Fatalf("root metadata = %#v, want workflow to match source %s", root.Metadata, source.ID)
+	}
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != result.WorkflowID {
+		t.Fatalf("source workflow_id = %q, want %q", got, result.WorkflowID)
+	}
+}
+
+func TestSlingAttachGraphFormulaAcceptsRootClosedBeforeVisibilityCheck(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	formulatest.EnableV2ForTest(t)
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	notifier := &closeLaunchedWorkflowNotifier{
+		store:    deps.Store,
+		sourceID: source.ID,
+		storeRef: deps.StoreRef,
+	}
+	deps.Notify = notifier
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula: %v", err)
+	}
+	if notifier.err != nil {
+		t.Fatalf("notifier close: %v", notifier.err)
+	}
+	if notifier.closed != 1 {
+		t.Fatalf("notifier closed = %d, want 1", notifier.closed)
+	}
+	root, err := deps.Store.Get(result.WorkflowID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if root.Status != "closed" {
+		t.Fatalf("root status = %q, want closed", root.Status)
+	}
+	if !sourceworkflow.WorkflowMatchesSource(root, source.ID, deps.StoreRef, deps.StoreRef) {
+		t.Fatalf("root metadata = %#v, want workflow to match source %s", root.Metadata, source.ID)
+	}
+	liveRoots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("ListLiveRoots: %v", err)
+	}
+	if len(liveRoots) != 0 {
+		t.Fatalf("live roots = %#v, want none after notifier closes root", liveRoots)
 	}
 	updatedSource, err := deps.Store.Get(source.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- retry the post-launch source workflow visibility check before treating a launched graph workflow as missing
- accept a direct root lookup when the source-workflow list path stays stale but the launched root itself matches the source
- retry transient missing scope-body reads before quarantining a control bead as malformed
- add sling and dispatch unit regressions for stale post-write graph reads

## Validation
- go test ./internal/dispatch ./internal/sling -count=1
- go test ./internal/beads ./internal/molecule ./internal/sling ./internal/dispatch -run 'TestBdStoreDepAddRetriesTransientDoltConnectionError|TestInstantiateRetriesTransientGraphApplyBeforeFallback|TestSlingAttachGraphFormulaRetriesLaunchVisibilityAfterStaleList|TestSlingAttachGraphFormulaAcceptsDirectRootWhenLaunchListStaysStale|TestProcessScopeCheckRetriesTransientMissingScopeBody' -count=1
- go test -tags integration ./test/integration -run '^$' -count=1