### PR TITLE
test: shrink personal work review formula fixture

### DIFF
--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -1931,6 +1931,33 @@ func TestCompilePersonalWorkSkipGeminiFiltersExpansionLanes(t *testing.T) {
 	}
 }
 
+func TestCompilePersonalWorkHappyPathDoesNotAddRetryWrappers(t *testing.T) {
+	enableV2ForTest(t)
+
+	dir := t.TempDir()
+	writeReviewWorkflowFixtures(t, dir)
+
+	recipe, err := Compile(context.Background(), "mol-personal-work-v2", []string{dir}, map[string]string{
+		"issue":         "GC-1",
+		"base_branch":   "main",
+		"skip_gemini":   "true",
+		"setup_command": "true",
+		"test_command":  "true",
+	})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	for _, step := range recipe.Steps {
+		if got := step.Metadata["gc.kind"]; got == "retry" {
+			t.Fatalf("personal-work happy path should not add retry control step %q", step.ID)
+		}
+		if strings.Contains(step.ID, ".attempt.") {
+			t.Fatalf("personal-work happy path should not add retry attempt step %q", step.ID)
+		}
+	}
+}
+
 func TestCompileReviewWorkflowAnnotatesNestedReviewerRetries(t *testing.T) {
 	enableV2ForTest(t)
 

--- a/internal/testfixtures/reviewworkflows/fixtures.go
+++ b/internal/testfixtures/reviewworkflows/fixtures.go
@@ -404,20 +404,12 @@ id = "load-context"
 title = "Load context"
 description = "Inspect the assigned work bead."
 
-[steps.retry]
-max_attempts = 1
-on_exhausted = "hard_fail"
-
 [[steps]]
 id = "workspace-setup"
 title = "Prepare worktree"
 needs = ["load-context"]
 description = "Prepare worktree metadata for the workflow."
 metadata = { "gc.scope_ref" = "body", "gc.scope_role" = "setup", "gc.on_fail" = "abort_scope" }
-
-[steps.retry]
-max_attempts = 1
-on_exhausted = "hard_fail"
 
 [[steps]]
 id = "design-review-loop"
@@ -445,20 +437,12 @@ title = "Apply design changes"
 needs = ["design-review-pipeline"]
 description = "Apply design review feedback and mark the Check verdict."
 
-[steps.children.retry]
-max_attempts = 1
-on_exhausted = "hard_fail"
-
 [[steps]]
 id = "implement"
 title = "Implement"
 needs = ["design-review-loop"]
 description = "Perform the main work."
 metadata = { "gc.scope_ref" = "body", "gc.scope_role" = "member", "gc.on_fail" = "abort_scope" }
-
-[steps.retry]
-max_attempts = 1
-on_exhausted = "hard_fail"
 
 [[steps]]
 id = "code-review-loop"
@@ -486,10 +470,6 @@ title = "Apply code fixes"
 needs = ["review-pipeline"]
 description = "Apply code review feedback and mark the Check verdict."
 
-[steps.children.retry]
-max_attempts = 1
-on_exhausted = "hard_fail"
-
 [compose]
 [[compose.expand]]
 target = "design-review-pipeline"
@@ -506,18 +486,10 @@ needs = ["code-review-loop"]
 description = "Finalize the work item."
 metadata = { "gc.scope_ref" = "body", "gc.scope_role" = "member", "gc.on_fail" = "abort_scope" }
 
-[steps.retry]
-max_attempts = 1
-on_exhausted = "hard_fail"
-
 [[steps]]
 id = "cleanup-worktree"
 title = "Cleanup worktree"
 needs = ["body"]
 description = "Teardown after the body reaches terminal state."
 metadata = { "gc.kind" = "cleanup", "gc.scope_ref" = "body", "gc.scope_role" = "teardown" }
-
-[steps.retry]
-max_attempts = 1
-on_exhausted = "hard_fail"
 `


### PR DESCRIPTION
## Summary
- remove max_attempts=1 retry wrappers from the personal-work happy-path fixture
- add a compile test that rejects retry controls/attempt steps in that fixture
- keep retry behavior covered by the adopt-pr review formula scenarios

## Verification
- go test ./internal/formula -run 'TestCompilePersonalWork(SkipGeminiFiltersExpansionLanes|HappyPathDoesNotAddRetryWrappers)$' -count=1
- GO_TEST_COVERPROFILE=/tmp/gascity-review-basic-2-cover-no-retries-rebased.txt ./scripts/test-integration-shard review-formulas-basic-2-of-2