### PR TITLE
feat(packs/dolt): port_resolve.sh helper kills :=3307 fallback (slice 1/3 of ga-lsois)

### DIFF
--- a/examples/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/dolt/assets/scripts/mol-dog-backup.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 
-PORT="${GC_DOLT_PORT:-3307}"
+PORT="$GC_DOLT_PORT"
 HOST="${GC_DOLT_HOST:-127.0.0.1}"
 USER="${GC_DOLT_USER:-root}"
 OFFSITE_PATH="${GC_BACKUP_OFFSITE_PATH:-}"

--- a/examples/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/dolt/assets/scripts/mol-dog-doctor.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 
-PORT="${GC_DOLT_PORT:-3307}"
+PORT="$GC_DOLT_PORT"
 HOST="${GC_DOLT_HOST:-127.0.0.1}"
 USER="${GC_DOLT_USER:-root}"
 LATENCY_WARN_S="${GC_DOCTOR_LATENCY_WARN_S:-1}"

--- a/examples/dolt/assets/scripts/port_resolve.sh
+++ b/examples/dolt/assets/scripts/port_resolve.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# port_resolve.sh — shared GC_DOLT_PORT discovery helper.
+#
+# Sourced by:
+#   .gc/system/packs/dolt/assets/scripts/runtime.sh
+#   .gc/system/packs/maintenance/assets/scripts/dolt-target.sh
+#
+# Defines:
+#   resolve_dolt_port_or_die  state_file  data_dir  city_path
+#
+# Preconditions (caller responsibilities):
+#   - managed_runtime_port is in scope (either from a sourced runtime.sh
+#     above this file in the source chain, or inlined in the caller, as
+#     dolt-target.sh currently inlines it).
+#   - GC_CITY_PATH is set; the caller enforces this at file head.
+#
+# POSIX /bin/sh only. No bash-isms.
+
+# resolve_dolt_port_or_die — print the discovered Dolt port to stdout, or
+# exit 78 with a structured stderr error if no port can be resolved.
+#
+# Arguments:
+#   $1  state_file  Absolute path to .gc/runtime/packs/dolt/dolt-state.json
+#                   (or the equivalent for the caller's pack layout).
+#   $2  data_dir    Absolute path the caller expects the running server to
+#                   be serving from (passed through to managed_runtime_port
+#                   for the data-dir-match guard).
+#   $3  city_path   Absolute path of the city root, used only in the error
+#                   message so the operator knows which city failed.
+#
+# Behavior:
+#   1. If GC_DOLT_PORT is non-empty in the caller's environment, the
+#      function echoes that value and returns 0 (operator override wins,
+#      per NFR-04 of ga-lsois).
+#   2. Otherwise, it calls managed_runtime_port "$state_file" "$data_dir"
+#      and, on a non-empty result, echoes the port and returns 0.
+#   3. Otherwise, it writes the §3 error template to stderr and exits 78.
+#
+# Preconditions (caller must arrange):
+#   - managed_runtime_port is in scope (sourced from runtime.sh, or inlined
+#     in dolt-target.sh per its existing layout).
+#   - GC_CITY_PATH is set (the helper does NOT default it; callers already
+#     enforce ': "${GC_CITY_PATH:?...}"' at file head).
+#
+# Output contract:
+#   - On success: exactly one line on stdout (the port, e.g. "47823").
+#                  Nothing on stderr. Exit 0.
+#   - On failure: nothing on stdout. Multi-line structured error on stderr
+#                  (§3 verbatim). Exit 78 (whole shell exits, not return).
+resolve_dolt_port_or_die() {
+    _rdp_state_file="$1"
+    _rdp_data_dir="$2"
+    _rdp_city_path="$3"
+
+    if [ -n "${GC_DOLT_PORT:-}" ]; then
+        printf '%s\n' "$GC_DOLT_PORT"
+        return 0
+    fi
+
+    _rdp_resolved=$(managed_runtime_port "$_rdp_state_file" "$_rdp_data_dir")
+    if [ -n "$_rdp_resolved" ]; then
+        printf '%s\n' "$_rdp_resolved"
+        return 0
+    fi
+
+    _rdp_state_status="missing"
+    if [ -f "$_rdp_state_file" ]; then
+        _rdp_state_status="present but not running"
+    fi
+
+    printf 'gc dolt: cannot resolve runtime port\n' >&2
+    printf '  state_file: %s (%s)\n' "$_rdp_state_file" "$_rdp_state_status" >&2
+    printf '  city_path:  %s\n' "$_rdp_city_path" >&2
+    printf '  consulted:  GC_DOLT_PORT (unset), GC_DOLT_STATE_FILE\n' >&2
+    printf '  remediation: run `gc start` to bring up the city, or set\n' >&2
+    printf '               GC_DOLT_PORT explicitly to an already-running\n' >&2
+    printf '               server.\n' >&2
+    exit 78
+}

--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -205,12 +205,12 @@ managed_runtime_port() (
   printf '%s\n' "$port"
 )
 
-# Resolve GC_DOLT_PORT if not already set by the caller.
-# Priority: env override > validated managed runtime state > default 3307.
-if [ -z "$GC_DOLT_PORT" ]; then
-  GC_DOLT_PORT=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR")
-  : "${GC_DOLT_PORT:=3307}"
-fi
+# Resolve GC_DOLT_PORT if not already set by the caller. The shared helper
+# below honors the env override, falls through to validated managed runtime
+# state, and exits 78 if neither yields a port — replacing the silent 3307
+# fallback removed for ga-lsois.
+. "${GC_PACK_DIR:-${GC_SYSTEM_PACKS_DIR:-$GC_CITY_PATH/.gc/system/packs}/dolt}/assets/scripts/port_resolve.sh"
+GC_DOLT_PORT=$(resolve_dolt_port_or_die "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" "$GC_CITY_PATH") || exit $?
 
 # Resolve a bounded-execution helper. Prefer gtimeout (coreutils on
 # macOS), fall back to timeout (coreutils on Linux), then to running

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -11,16 +11,10 @@
 # Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_USER, GC_DOLT_PASSWORD
 set -e
 
-: "${GC_DOLT_USER:=root}"
-PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
-. "$PACK_DIR/assets/scripts/runtime.sh"
-
 dry_run=false
 force=false
 do_gc=false
 db_filter=""
-beads_bd="$GC_BEADS_BD_SCRIPT"
-data_dir="$DOLT_DATA_DIR"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -50,6 +44,13 @@ case "$(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | t
   exit 1
   ;;
 esac
+
+: "${GC_DOLT_USER:=root}"
+PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
+. "$PACK_DIR/assets/scripts/runtime.sh"
+
+beads_bd="$GC_BEADS_BD_SCRIPT"
+data_dir="$DOLT_DATA_DIR"
 
 # Check if server is running.
 is_running() {

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -215,8 +215,9 @@ func TestHealthScriptDoesNotInvokeDoltLog(t *testing.T) {
 
 func TestRuntimeScriptPortPrecedence(t *testing.T) {
 	tests := []struct {
-		name  string
-		setup func(t *testing.T, cityPath string) string
+		name       string
+		setup      func(t *testing.T, cityPath string) string
+		wantExit78 bool
 	}{
 		{
 			name: "managed state beats compatibility port mirror",
@@ -239,7 +240,7 @@ func TestRuntimeScriptPortPrecedence(t *testing.T) {
 			},
 		},
 		{
-			name: "corrupt managed state ignores compatibility port mirror",
+			name: "corrupt managed state exits 78",
 			setup: func(t *testing.T, cityPath string) string {
 				t.Helper()
 				stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
@@ -255,8 +256,9 @@ func TestRuntimeScriptPortPrecedence(t *testing.T) {
 				if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt-server.port"), []byte("45785\n"), 0o644); err != nil {
 					t.Fatal(err)
 				}
-				return "3307"
+				return ""
 			},
+			wantExit78: true,
 		},
 	}
 
@@ -273,6 +275,10 @@ func TestRuntimeScriptPortPrecedence(t *testing.T) {
 				"GC_PACK_DIR="+root,
 			)
 			out, err := cmd.CombinedOutput()
+			if tt.wantExit78 {
+				assertRuntimePortExit78(t, err, out, filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt-state.json"), cityPath)
+				return
+			}
 			if err != nil {
 				t.Fatalf("runtime.sh failed: %v\n%s", err, out)
 			}
@@ -289,6 +295,7 @@ func TestRuntimeScriptPortPrecedenceToleratesInconclusiveLsof(t *testing.T) {
 		lsofBody    string
 		ncBody      func(port string) string
 		wantManaged bool
+		wantExit78  bool
 	}{
 		{
 			name:     "inconclusive lsof accepts reachable port",
@@ -313,7 +320,7 @@ exit 1
 exit 0
 `
 			},
-			wantManaged: false,
+			wantExit78: true,
 		},
 		{
 			name:     "inconclusive lsof with unreachable port still rejects port",
@@ -323,7 +330,7 @@ exit 0
 exit 1
 `
 			},
-			wantManaged: false,
+			wantExit78: true,
 		},
 	}
 
@@ -357,6 +364,10 @@ exit 1
 				"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 			)
 			out, err := cmd.CombinedOutput()
+			if tt.wantExit78 {
+				assertRuntimePortExit78(t, err, out, filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt-state.json"), cityPath)
+				return
+			}
 			if err != nil {
 				t.Fatalf("runtime.sh failed: %v\n%s", err, out)
 			}
@@ -364,6 +375,24 @@ exit 1
 				t.Fatalf("GC_DOLT_PORT = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func assertRuntimePortExit78(t *testing.T, err error, out []byte, stateFile, cityPath string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("runtime.sh exited 0, want exit 78\n%s", out)
+	}
+	exitErr := &exec.ExitError{}
+	ok := errors.As(err, &exitErr)
+	if !ok {
+		t.Fatalf("runtime.sh returned non-exit error: %v\n%s", err, out)
+	}
+	if exitErr.ExitCode() != 78 {
+		t.Fatalf("runtime.sh exit code = %d, want 78\n%s", exitErr.ExitCode(), out)
+	}
+	if got, want := string(out), expectedPortResolveError(stateFile, cityPath, "present but not running"); got != want {
+		t.Fatalf("runtime.sh output = %q, want %q", got, want)
 	}
 }
 

--- a/examples/dolt/port_resolve_test.go
+++ b/examples/dolt/port_resolve_test.go
@@ -1,0 +1,201 @@
+package dolt_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestPortResolveOrDieEnvOverride(t *testing.T) {
+	result := runPortResolveOrDie(t, portResolveCase{
+		stateFile: filepath.Join(t.TempDir(), "missing-state.json"),
+		dataDir:   filepath.Join(t.TempDir(), "data"),
+		cityPath:  t.TempDir(),
+		env:       []string{"GC_DOLT_PORT=4242"},
+	})
+
+	assertPortResolveResult(t, result, 0, "4242\n", "")
+}
+
+func TestPortResolveOrDieDiscoverySuccess(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "dolt-state.json")
+	dataDir := filepath.Join(t.TempDir(), "d")
+	cityPath := t.TempDir()
+	if err := os.WriteFile(stateFile, []byte(fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":47823,"data_dir":%q}`,
+		os.Getpid(),
+		dataDir,
+	)), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	result := runPortResolveOrDie(t, portResolveCase{
+		stateFile:   stateFile,
+		dataDir:     dataDir,
+		cityPath:    cityPath,
+		managedPort: "47823",
+	})
+
+	assertPortResolveResult(t, result, 0, "47823\n", "")
+}
+
+func TestPortResolveOrDieMissingState(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "dolt-state.json")
+	cityPath := t.TempDir()
+
+	result := runPortResolveOrDie(t, portResolveCase{
+		stateFile: stateFile,
+		dataDir:   filepath.Join(t.TempDir(), "data"),
+		cityPath:  cityPath,
+	})
+
+	assertPortResolveResult(t, result, 78, "", expectedPortResolveError(stateFile, cityPath, "missing"))
+}
+
+func TestPortResolveOrDieStatePresentNotRunning(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "dolt-state.json")
+	cityPath := t.TempDir()
+	if err := os.WriteFile(stateFile, []byte(`{"running":false}`), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	result := runPortResolveOrDie(t, portResolveCase{
+		stateFile: stateFile,
+		dataDir:   filepath.Join(t.TempDir(), "data"),
+		cityPath:  cityPath,
+	})
+
+	assertPortResolveResult(t, result, 78, "", expectedPortResolveError(stateFile, cityPath, "present but not running"))
+}
+
+func TestPortResolveOrDieExit78OnEmptyState(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "dolt-state.json")
+	dataDir := filepath.Join(t.TempDir(), "d")
+	cityPath := t.TempDir()
+	if err := os.WriteFile(stateFile, []byte(fmt.Sprintf(
+		`{"running":true,"pid":99999999,"port":47823,"data_dir":%q}`,
+		dataDir,
+	)), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	result := runPortResolveOrDie(t, portResolveCase{
+		stateFile: stateFile,
+		dataDir:   dataDir,
+		cityPath:  cityPath,
+	})
+
+	assertPortResolveResult(t, result, 78, "", expectedPortResolveError(stateFile, cityPath, "present but not running"))
+}
+
+func TestRuntimeShUsesPortResolve(t *testing.T) {
+	root := repoRoot(t)
+	assertScriptSourcesPortResolveOnce(t, filepath.Join(root, "assets", "scripts", "runtime.sh"))
+}
+
+func TestDoltTargetShUsesPortResolve(t *testing.T) {
+	root := filepath.Dir(repoRoot(t))
+	assertScriptSourcesPortResolveOnce(t, filepath.Join(root, "gastown", "packs", "maintenance", "assets", "scripts", "dolt-target.sh"))
+}
+
+type portResolveCase struct {
+	stateFile   string
+	dataDir     string
+	cityPath    string
+	managedPort string
+	env         []string
+}
+
+type portResolveResult struct {
+	code   int
+	stdout string
+	stderr string
+}
+
+func runPortResolveOrDie(t *testing.T, tc portResolveCase) portResolveResult {
+	t.Helper()
+	root := repoRoot(t)
+	driver := fmt.Sprintf(`
+managed_runtime_port() {
+    if [ -n "${TEST_MANAGED_PORT:-}" ]; then
+        printf '%%s\n' "$TEST_MANAGED_PORT"
+        return 0
+    fi
+    return 0
+}
+. %s
+resolve_dolt_port_or_die "$STATE_FILE" "$DATA_DIR" "$CITY_PATH"
+`, shellQuote(filepath.Join(root, "assets", "scripts", "port_resolve.sh")))
+
+	cmd := exec.Command("sh", "-c", driver)
+	cmd.Env = filteredEnv("GC_DOLT_PORT", "STATE_FILE", "DATA_DIR", "CITY_PATH", "TEST_MANAGED_PORT")
+	cmd.Env = append(cmd.Env,
+		"STATE_FILE="+tc.stateFile,
+		"DATA_DIR="+tc.dataDir,
+		"CITY_PATH="+tc.cityPath,
+		"TEST_MANAGED_PORT="+tc.managedPort,
+	)
+	cmd.Env = append(cmd.Env, tc.env...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		ok := errors.As(err, &exitErr)
+		if !ok {
+			t.Fatalf("port_resolve driver failed to run: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		code = exitErr.ExitCode()
+	}
+	return portResolveResult{
+		code:   code,
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+	}
+}
+
+func assertPortResolveResult(t *testing.T, got portResolveResult, wantCode int, wantStdout, wantStderr string) {
+	t.Helper()
+	if got.code != wantCode {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", got.code, wantCode, got.stdout, got.stderr)
+	}
+	if got.stdout != wantStdout {
+		t.Fatalf("stdout = %q, want %q\nstderr:\n%s", got.stdout, wantStdout, got.stderr)
+	}
+	if got.stderr != wantStderr {
+		t.Fatalf("stderr = %q, want %q", got.stderr, wantStderr)
+	}
+}
+
+func expectedPortResolveError(stateFile, cityPath, stateStatus string) string {
+	return fmt.Sprintf(`gc dolt: cannot resolve runtime port
+  state_file: %s (%s)
+  city_path:  %s
+  consulted:  GC_DOLT_PORT (unset), GC_DOLT_STATE_FILE
+  remediation: run `+"`"+`gc start`+"`"+` to bring up the city, or set
+               GC_DOLT_PORT explicitly to an already-running
+               server.
+`, stateFile, stateStatus, cityPath)
+}
+
+func assertScriptSourcesPortResolveOnce(t *testing.T, scriptPath string) {
+	t.Helper()
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", scriptPath, err)
+	}
+	re := regexp.MustCompile(`(?m)^\.\s+.*port_resolve\.sh`)
+	matches := re.FindAllString(string(data), -1)
+	if len(matches) != 1 {
+		t.Fatalf("%s port_resolve.sh source count = %d, want 1\nmatches: %s", scriptPath, len(matches), strings.Join(matches, "\n"))
+	}
+}

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2,6 +2,7 @@ package gastown_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -308,7 +309,7 @@ exit 1
 	}
 }
 
-func TestMaintenanceDoltScriptsFallbackToManagedRuntimePorts(t *testing.T) {
+func TestMaintenanceDoltScriptsUseManagedRuntimePorts(t *testing.T) {
 	scripts := []struct {
 		name   string
 		script string
@@ -336,19 +337,6 @@ func TestMaintenanceDoltScriptsFallbackToManagedRuntimePorts(t *testing.T) {
 		setup func(t *testing.T, cityDir string) string
 	}{
 		{
-			name: "compatibility port mirror ignored without managed runtime state",
-			setup: func(t *testing.T, cityDir string) string {
-				t.Helper()
-				if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.WriteFile(filepath.Join(cityDir, ".beads", "dolt-server.port"), []byte("45781\n"), 0o644); err != nil {
-					t.Fatal(err)
-				}
-				return "3307"
-			},
-		},
-		{
 			name: "managed runtime state",
 			setup: func(t *testing.T, cityDir string) string {
 				t.Helper()
@@ -372,26 +360,6 @@ func TestMaintenanceDoltScriptsFallbackToManagedRuntimePorts(t *testing.T) {
 				port := listener.Addr().(*net.TCPAddr).Port
 				writeManagedRuntimeState(t, cityDir, port)
 				return strconv.Itoa(port)
-			},
-		},
-		{
-			name: "corrupt managed state ignores compatibility port mirror",
-			setup: func(t *testing.T, cityDir string) string {
-				t.Helper()
-				stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
-				if err := os.MkdirAll(stateDir, 0o755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(`not-json`), 0o644); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.WriteFile(filepath.Join(cityDir, ".beads", "dolt-server.port"), []byte("45785\n"), 0o644); err != nil {
-					t.Fatal(err)
-				}
-				return "3307"
 			},
 		},
 	}
@@ -479,6 +447,7 @@ func TestMaintenanceDoltScriptsFallbackToManagedRuntimePortsWithInconclusiveLsof
 		lsofBody    string
 		ncBody      func(port string) string
 		wantManaged bool
+		wantExit78  bool
 	}{
 		{
 			name:     "inconclusive lsof accepts reachable port",
@@ -503,7 +472,7 @@ exit 1
 exit 0
 `
 			},
-			wantManaged: false,
+			wantExit78: true,
 		},
 		{
 			name:     "inconclusive lsof with unreachable port still rejects port",
@@ -513,7 +482,7 @@ exit 0
 exit 1
 `
 			},
-			wantManaged: false,
+			wantExit78: true,
 		},
 	}
 
@@ -526,10 +495,7 @@ exit 1
 
 				listener := listenManagedDoltPort(t)
 				managedPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
-				wantPort := "3307"
-				if tc.wantManaged {
-					wantPort = managedPort
-				}
+				wantPort := managedPort
 				writeManagedRuntimeState(t, cityDir, listener.Addr().(*net.TCPAddr).Port)
 
 				writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
@@ -558,7 +524,13 @@ exit 0
 					env[key] = value
 				}
 
-				runScript(t, filepath.Join(exampleDir(), tt.script), env)
+				script := filepath.Join(exampleDir(), tt.script)
+				if tc.wantExit78 {
+					out, err := runScriptResult(t, script, env)
+					assertMaintenanceScriptExit78(t, err, out)
+					return
+				}
+				runScript(t, script, env)
 
 				logData, err := os.ReadFile(doltLog)
 				if err != nil {
@@ -576,6 +548,24 @@ exit 0
 				}
 			})
 		}
+	}
+}
+
+func assertMaintenanceScriptExit78(t *testing.T, err error, out []byte) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("maintenance script exited 0, want exit 78\n%s", out)
+	}
+	exitErr := &exec.ExitError{}
+	ok := errors.As(err, &exitErr)
+	if !ok {
+		t.Fatalf("maintenance script returned non-exit error: %v\n%s", err, out)
+	}
+	if exitErr.ExitCode() != 78 {
+		t.Fatalf("maintenance script exit code = %d, want 78\n%s", exitErr.ExitCode(), out)
+	}
+	if !strings.Contains(string(out), "gc dolt: cannot resolve runtime port") {
+		t.Fatalf("maintenance script output missing port-resolution error:\n%s", out)
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -142,23 +142,28 @@ managed_runtime_port() (
     printf '%s\n' "$port"
 )
 
-if [ -z "${GC_DOLT_PORT:-}" ]; then
-    if [ -n "${GC_DOLT_STATE_FILE:-}" ]; then
-        DOLT_STATE_FILE="$GC_DOLT_STATE_FILE"
+if [ -n "${GC_DOLT_STATE_FILE:-}" ]; then
+    DOLT_STATE_FILE="$GC_DOLT_STATE_FILE"
+else
+    DOLT_PACK_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}/packs/dolt"
+    if [ -f "$DOLT_PACK_DIR/dolt-state.json" ]; then
+        DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
+    elif [ -f "$DOLT_PACK_DIR/dolt-provider-state.json" ]; then
+        DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-provider-state.json"
     else
-        DOLT_PACK_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}/packs/dolt"
-        if [ -f "$DOLT_PACK_DIR/dolt-state.json" ]; then
-            DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
-        elif [ -f "$DOLT_PACK_DIR/dolt-provider-state.json" ]; then
-            DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-provider-state.json"
-        else
-            DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
-        fi
+        DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
     fi
-    GC_DOLT_PORT="$(managed_runtime_port "$DOLT_STATE_FILE" "$GC_CITY_PATH/.beads/dolt")"
 fi
 
-: "${GC_DOLT_PORT:=3307}"
+DOLT_PORT_RESOLVE_SCRIPT="${GC_SYSTEM_PACKS_DIR:-$GC_CITY_PATH/.gc/system/packs}/dolt/assets/scripts/port_resolve.sh"
+if [ ! -f "$DOLT_PORT_RESOLVE_SCRIPT" ] && [ -n "${SCRIPT_DIR:-}" ]; then
+    DOLT_SOURCE_SCRIPT_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/../../../../../dolt/assets/scripts" 2>/dev/null && pwd || true)
+    if [ -n "$DOLT_SOURCE_SCRIPT_DIR" ]; then
+        DOLT_PORT_RESOLVE_SCRIPT="$DOLT_SOURCE_SCRIPT_DIR/port_resolve.sh"
+    fi
+fi
+. "${DOLT_PORT_RESOLVE_SCRIPT:?port_resolve.sh not resolved}"
+GC_DOLT_PORT="$(resolve_dolt_port_or_die "$DOLT_STATE_FILE" "$GC_CITY_PATH/.beads/dolt" "$GC_CITY_PATH")" || exit $?
 
 case "$GC_DOLT_PORT" in
     ''|*[!0-9]*)

--- a/release-gates/ga-rq2e5a-dolt-port-resolve-helper-gate.md
+++ b/release-gates/ga-rq2e5a-dolt-port-resolve-helper-gate.md
@@ -17,8 +17,8 @@ Verdict: PASS
 | 2 | Acceptance criteria met | PASS | The helper `examples/dolt/assets/scripts/port_resolve.sh` exists with `resolve_dolt_port_or_die`; `runtime.sh` and maintenance `dolt-target.sh` route through it; current source-closure script `GC_DOLT_PORT.*3307` fallbacks were removed; packlint and helper tests cover the pinned behavior; `gc dolt sync --db` reserved-name validation still runs before runtime port resolution. |
 | 3 | Tests pass | PASS | Focused acceptance tests, shell syntax checks, `go vet ./...`, `go build ./...`, and `make test-fast-parallel` passed on the PR branch. |
 | 4 | No high-severity review findings open | PASS | Review notes contain five informational findings and no HIGH findings. |
-| 5 | Final branch is clean | PASS | `git status --porcelain=v1` was empty before writing this checklist; the checklist is committed as the only deployer delta before push and status is rechecked after the gate commit. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` returned 0 before the gate commit; PR #2282 reports `mergeStateStatus: CLEAN`. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v1` was empty before the gate commits and rechecked clean after push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` returned 0 after the gate commit; `git merge-tree` conflict scan found no conflict markers; PR #2282 reports `mergeable: MERGEABLE`. GitHub `mergeStateStatus: BLOCKED` is from queued/in-progress CI and branch protection, not a merge conflict. |
 
 ## Acceptance Evidence
 

--- a/release-gates/ga-rq2e5a-dolt-port-resolve-helper-gate.md
+++ b/release-gates/ga-rq2e5a-dolt-port-resolve-helper-gate.md
@@ -1,0 +1,48 @@
+# Release gate - Dolt port resolve helper (ga-rq2e5a / ga-5ju0nf)
+
+Verdict: PASS
+
+- Source bead: `ga-rq2e5a` - `feat(packs/dolt): port_resolve.sh helper kills :=3307 fallback (ga-lsois slice 1/3)`
+- Review bead: `ga-5ju0nf` - `Review: Dolt port resolve helper (ga-rq2e5a)`
+- PR: https://github.com/gastownhall/gascity/pull/2282
+- Branch: `quad341:builder/ga-rq2e5a-1`
+- Source commit: `2d9681ac35d8c1045ff3745fc6dc7f7151e51f39`
+- Release criteria source: deployer prompt criteria. `docs/PROJECT_MANIFEST.md` was not present in this repository snapshot.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-5ju0nf` contains `Review verdict: PASS`. Reviewer synthesis lists findings F1-F5 as informational only. |
+| 2 | Acceptance criteria met | PASS | The helper `examples/dolt/assets/scripts/port_resolve.sh` exists with `resolve_dolt_port_or_die`; `runtime.sh` and maintenance `dolt-target.sh` route through it; current source-closure script `GC_DOLT_PORT.*3307` fallbacks were removed; packlint and helper tests cover the pinned behavior; `gc dolt sync --db` reserved-name validation still runs before runtime port resolution. |
+| 3 | Tests pass | PASS | Focused acceptance tests, shell syntax checks, `go vet ./...`, `go build ./...`, and `make test-fast-parallel` passed on the PR branch. |
+| 4 | No high-severity review findings open | PASS | Review notes contain five informational findings and no HIGH findings. |
+| 5 | Final branch is clean | PASS | `git status --porcelain=v1` was empty before writing this checklist; the checklist is committed as the only deployer delta before push and status is rechecked after the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` returned 0 before the gate commit; PR #2282 reports `mergeStateStatus: CLEAN`. |
+
+## Acceptance Evidence
+
+- Source bead acceptance required all ga-u0lx9p helper cases, packlint coverage, clean vet, and broad tests.
+- `go test ./test/packlint -run TestNoDolt3307FallbackInScripts -count=1` - PASS
+- `go test ./examples/dolt -run 'TestPortResolveOrDie|TestRuntimeShUsesPortResolve|TestDoltTargetShUsesPortResolve|TestRuntimeScriptPortPrecedence' -count=1` - PASS
+- `go test ./examples/gastown -run 'TestMaintenanceDoltScriptsUseManagedRuntimePorts|TestMaintenanceDoltScriptsFallbackToManagedRuntimePortsWithInconclusiveLsof|TestMaintenanceDoltScriptsUsePsConfirmedManagedRuntimePorts' -count=1` - PASS
+- `sh -n examples/dolt/assets/scripts/port_resolve.sh examples/dolt/assets/scripts/runtime.sh examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh examples/dolt/assets/scripts/mol-dog-backup.sh examples/dolt/assets/scripts/mol-dog-doctor.sh examples/dolt/commands/sync/run.sh` - PASS
+- `go test ./cmd/gc -run 'TestEmbed|TestBuiltin|TestMaterialize|TestFormulasUseGcDoltSqlNotRawPort|TestDoltSyncRejectsManagedProbeDatabaseFilter' -count=1` - PASS
+- `go test ./examples/dolt -run 'TestPortResolveOrDie|TestRuntimeShUsesPortResolve|TestRuntimeScriptPortPrecedence|TestDoltSync' -count=1` - PASS
+- `go vet ./...` - PASS
+- `go build ./...` - PASS
+- `make test-fast-parallel` - PASS (`All fast jobs passed`)
+
+## Review Findings
+
+| Finding | Severity | Gate disposition |
+|---------|----------|------------------|
+| F1 | Informational | Spec path correction accepted: lint targets source pack directories under `examples/`. |
+| F2 | Informational | Extra allowlist entry accepted because both formula literals are sibling-slice scope. |
+| F3 | Informational | Unit isolation accepted; managed runtime fixtures are already exercised in `health_test.go`. |
+| F4 | Informational | Companion validation reorder accepted and covered by `TestDoltSyncRejectsManagedProbeDatabaseFilter`. |
+| F5 | Informational | Test-only `$SCRIPT_DIR` fallback accepted; production path still uses `GC_SYSTEM_PACKS_DIR`. |
+
+## Push Target
+
+PR #2282 already exists with head `quad341:builder/ga-rq2e5a-1`. The gate commit is pushed to `fork` so the open PR head updates directly.

--- a/test/packlint/no_dolt_3307_fallback_test.go
+++ b/test/packlint/no_dolt_3307_fallback_test.go
@@ -1,0 +1,77 @@
+package packlint
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestNoDolt3307FallbackInScripts guards ga-lsois: the silent
+// :=3307 / :-3307 fallback was deleted from pack scripts and formulas
+// because nothing listens on 3307 in any gc-managed city. The lint
+// fires the build if a regression re-introduces a literal 3307 in the
+// authoritative bundled pack sources, except for the explicit allowlist
+// below (which slice 2 of ga-lsois — bead ga-nptxjv — will shrink).
+func TestNoDolt3307FallbackInScripts(t *testing.T) {
+	root := repoRoot()
+	packDirs := []string{
+		filepath.Join(root, "examples", "dolt"),
+		filepath.Join(root, "examples", "gastown", "packs", "maintenance"),
+	}
+
+	// Formula literals are owned by slice 2 (ga-nptxjv). When slice 2 lands,
+	// this list shrinks to nil and this comment is removed.
+	allowlist := map[string]struct{}{
+		filepath.Join(root, "examples", "gastown", "packs", "maintenance", "formulas", "mol-dog-jsonl.toml"):  {},
+		filepath.Join(root, "examples", "gastown", "packs", "maintenance", "formulas", "mol-dog-reaper.toml"): {},
+	}
+
+	// Matches GC_DOLT_PORT.*3307 on a single line in source files. The
+	// regex is deliberately broad: it catches `:-3307`, `:=3307`,
+	// `default = "3307"` on GC_DOLT_PORT lines, and any future variation
+	// operators might re-introduce. False positives are easier to
+	// allowlist than false negatives are to catch.
+	re := regexp.MustCompile(`GC_DOLT_PORT.*3307`)
+
+	var hits []string
+	for _, packsDir := range packDirs {
+		err := filepath.WalkDir(packsDir, func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext != ".sh" && ext != ".toml" && ext != ".md" {
+				return nil
+			}
+			if _, ok := allowlist[path]; ok {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", path, err)
+			}
+			for lineNo, line := range strings.Split(string(data), "\n") {
+				if re.MatchString(line) {
+					rel, _ := filepath.Rel(root, path)
+					hits = append(hits, fmt.Sprintf("%s:%d: %s", rel, lineNo+1, strings.TrimSpace(line)))
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", packsDir, err)
+		}
+	}
+
+	if len(hits) > 0 {
+		t.Fatalf("found %d disallowed GC_DOLT_PORT/3307 fallback(s); ga-lsois removed this fallback. Re-introduce only by allowlisting in this test (and explaining why):\n  %s",
+			len(hits), strings.Join(hits, "\n  "))
+	}
+}


### PR DESCRIPTION
## What this changes

This adds a shared Dolt `port_resolve.sh` helper for pack scripts that need the live Dolt runtime port. Scripts now honor `GC_DOLT_PORT` when it is set, otherwise read the managed runtime state, and fail with exit 78 plus clear remediation text instead of silently falling back to port 3307.

The Dolt runtime path and the Gas Town maintenance `dolt-target.sh` path both use the helper. The current script-level 3307 fallbacks in backup and doctor scripts are removed, while formula literals remain unchanged for the sibling formula-cleanup slice.

`gc dolt sync --db ...` keeps reserved database validation before runtime-port lookup, so invalid database names still produce the intended validation error even when Dolt runtime state is missing.

## Review notes

- Review the shell boundary in `examples/dolt/assets/scripts/port_resolve.sh`, `runtime.sh`, and `examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh`.
- `GC_DOLT_PORT` remains the explicit override; no new config key is introduced.
- Missing or not-running managed runtime state now fails closed instead of assuming 3307.
- `test/packlint/no_dolt_3307_fallback_test.go` guards against reintroducing script-level `GC_DOLT_PORT.*3307` fallbacks.
- Formula TOML references are intentionally out of scope for this slice.

## Test plan

- [x] `go test ./test/packlint -run TestNoDolt3307FallbackInScripts -count=1`
- [x] `go test ./examples/dolt -run 'TestPortResolveOrDie|TestRuntimeShUsesPortResolve|TestDoltTargetShUsesPortResolve|TestRuntimeScriptPortPrecedence' -count=1`
- [x] `go test ./examples/gastown -run 'TestMaintenanceDoltScriptsUseManagedRuntimePorts|TestMaintenanceDoltScriptsFallbackToManagedRuntimePortsWithInconclusiveLsof|TestMaintenanceDoltScriptsUsePsConfirmedManagedRuntimePorts' -count=1`
- [x] `go test ./cmd/gc -run 'TestEmbed|TestBuiltin|TestMaterialize|TestFormulasUseGcDoltSqlNotRawPort|TestDoltSyncRejectsManagedProbeDatabaseFilter' -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-rq2e5a-dolt-port-resolve-helper-gate.md`](release-gates/ga-rq2e5a-dolt-port-resolve-helper-gate.md)
