### PR TITLE
Add gc doctor order-firing-current check

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -152,6 +152,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewDurationRangeCheck(cfg))
 		d.Register(doctor.NewProviderParityCheck(cfg))
 		d.Register(doctor.NewSkillCollisionCheck(cfg, cityPath))
+		d.Register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath))
 		d.Register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))
 		d.Register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))
 		d.Register(newMCPSharedTargetDoctorCheck(cityPath, cfg, exec.LookPath))

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -1,0 +1,502 @@
+package doctor
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+const (
+	orderFiringCurrentName    = "order-firing-current"
+	orderFiringInspectHintFmt = "Inspect with: gc order check && gc order history %s"
+)
+
+// OrderFiringCurrentCheck reports scheduled orders whose last firing is stale.
+type OrderFiringCurrentCheck struct {
+	cfg      *config.City
+	cityPath string
+	clock    func() time.Time
+}
+
+// NewOrderFiringCurrentCheck creates a check for cron and cooldown order freshness.
+func NewOrderFiringCurrentCheck(cfg *config.City, cityPath string) *OrderFiringCurrentCheck {
+	return &OrderFiringCurrentCheck{
+		cfg:      cfg,
+		cityPath: cityPath,
+		clock:    time.Now,
+	}
+}
+
+// Name returns the check identifier shown by gc doctor.
+func (c *OrderFiringCurrentCheck) Name() string { return orderFiringCurrentName }
+
+// CanFix reports whether the check can repair stale order firing state.
+func (c *OrderFiringCurrentCheck) CanFix() bool { return false }
+
+// Fix is a no-op because stale order remediation depends on the root cause.
+func (c *OrderFiringCurrentCheck) Fix(_ *CheckContext) error { return nil }
+
+// Run compares each cron or cooldown order with its order.fired history.
+func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
+	result := &CheckResult{Name: c.Name()}
+	if c.cfg == nil {
+		result.Status = StatusOK
+		result.Message = "no city config loaded"
+		return result
+	}
+
+	cityPath := c.cityPath
+	if cityPath == "" && ctx != nil {
+		cityPath = ctx.CityPath
+	}
+	if cityPath == "" {
+		result.Status = StatusError
+		result.Message = "city path unavailable"
+		return result
+	}
+
+	allOrders, err := scanOrderFiringCurrentOrders(cityPath, c.cfg)
+	if err != nil {
+		result.Status = StatusError
+		result.Message = fmt.Sprintf("scan orders: %v", err)
+		return result
+	}
+
+	eventPath := filepath.Join(cityPath, citylayout.RuntimeRoot, "events.jsonl")
+	firedEvents, err := events.ReadFiltered(eventPath, events.Filter{Type: events.OrderFired})
+	if err != nil {
+		result.Status = StatusError
+		result.Message = fmt.Sprintf("read order firing events: %v", err)
+		return result
+	}
+	startedAt, err := latestControllerStartedAt(eventPath)
+	if err != nil {
+		result.Status = StatusError
+		result.Message = fmt.Sprintf("read controller start events: %v", err)
+		return result
+	}
+
+	now := c.clock()
+	if now.IsZero() {
+		now = time.Now()
+	}
+	cronIntervals := map[string]time.Duration{}
+	worst := StatusOK
+	monitored := 0
+	var firstNonOK string
+
+	for _, order := range allOrders {
+		if order.Trigger != "cron" && order.Trigger != "cooldown" {
+			continue
+		}
+		monitored++
+		expected, err := expectedIntervalForOrder(order, cronIntervals)
+		if err != nil {
+			worst = worseStatus(worst, StatusError)
+			result.Details = append(result.Details, fmt.Sprintf("%s: cannot compute expected interval: %v", orderDisplayName(order), err))
+			if firstNonOK == "" {
+				firstNonOK = orderHistoryHintTarget(order)
+			}
+			continue
+		}
+		status, detail := classifyOrderFiring(order, now, expected, latestOrderFiredAt(firedEvents, order.ScopedName()), startedAt)
+		worst = worseStatus(worst, status)
+		result.Details = append(result.Details, detail)
+		if status != StatusOK && firstNonOK == "" {
+			firstNonOK = orderHistoryHintTarget(order)
+		}
+	}
+
+	if monitored == 0 {
+		result.Status = StatusOK
+		result.Message = "no cron or cooldown orders"
+		return result
+	}
+
+	result.Status = worst
+	switch worst {
+	case StatusOK:
+		result.Message = "all scheduled orders are current"
+	case StatusWarning:
+		result.Message = "scheduled orders are overdue"
+	case StatusError:
+		result.Message = "scheduled orders are stale"
+	}
+	if firstNonOK != "" {
+		result.FixHint = fmt.Sprintf(orderFiringInspectHintFmt, firstNonOK)
+	}
+	return result
+}
+
+func scanOrderFiringCurrentOrders(cityPath string, cfg *config.City) ([]orders.Order, error) {
+	cityLayers := orderFiringCityFormulaLayers(cityPath, cfg)
+	cityOrders, err := orders.ScanRoots(fsys.OSFS{}, orderFiringCityOrderRoots(cityPath, cfg), cfg.Orders.Skip)
+	if err != nil {
+		return nil, err
+	}
+
+	var rigOrders []orders.Order
+	rigNames := make([]string, 0, len(cfg.FormulaLayers.Rigs))
+	for rigName := range cfg.FormulaLayers.Rigs {
+		rigNames = append(rigNames, rigName)
+	}
+	sort.Strings(rigNames)
+	for _, rigName := range rigNames {
+		exclusive := orderFiringRigExclusiveLayers(cfg.FormulaLayers.Rigs[rigName], cityLayers)
+		if len(exclusive) == 0 {
+			continue
+		}
+		aa, err := orders.ScanRoots(fsys.OSFS{}, orderFiringRigOrderRoots(exclusive), cfg.Orders.Skip)
+		if err != nil {
+			return nil, fmt.Errorf("rig %s: %w", rigName, err)
+		}
+		for i := range aa {
+			aa[i].Rig = rigName
+		}
+		rigOrders = append(rigOrders, aa...)
+	}
+
+	allOrders := make([]orders.Order, 0, len(cityOrders)+len(rigOrders))
+	allOrders = append(allOrders, cityOrders...)
+	allOrders = append(allOrders, rigOrders...)
+	if len(cfg.Orders.Overrides) > 0 {
+		if err := orders.ApplyOverrides(allOrders, orderFiringOverrides(cfg.Orders.Overrides)); err != nil {
+			return nil, err
+		}
+	}
+	return orders.FilterEnabled(allOrders), nil
+}
+
+func orderFiringCityFormulaLayers(cityPath string, cfg *config.City) []string {
+	if len(cfg.FormulaLayers.City) > 0 {
+		return cfg.FormulaLayers.City
+	}
+	return []string{citylayout.ResolveFormulasDir(cityPath, cfg.FormulasDir())}
+}
+
+func orderFiringCityOrderRoots(cityPath string, cfg *config.City) []orders.ScanRoot {
+	formulaLayers := orderFiringCityFormulaLayers(cityPath, cfg)
+	localFormulas := citylayout.ResolveFormulasDir(cityPath, cfg.FormulasDir())
+	roots := make([]orders.ScanRoot, 0, len(formulaLayers))
+	seen := make(map[string]bool, len(formulaLayers))
+	for _, layer := range formulaLayers {
+		root := orders.ScanRoot{
+			Dir:          filepath.Join(filepath.Dir(layer), "orders"),
+			FormulaLayer: layer,
+		}
+		if layer == localFormulas {
+			root.Dir = citylayout.OrdersPath(cityPath)
+		}
+		key := filepath.Clean(root.Dir) + "\n" + filepath.Clean(root.FormulaLayer)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+func orderFiringRigOrderRoots(formulaLayers []string) []orders.ScanRoot {
+	roots := make([]orders.ScanRoot, 0, len(formulaLayers))
+	for _, layer := range formulaLayers {
+		roots = append(roots, orders.ScanRoot{
+			Dir:          filepath.Join(filepath.Dir(layer), "orders"),
+			FormulaLayer: layer,
+		})
+	}
+	return roots
+}
+
+func orderFiringRigExclusiveLayers(rigLayers, cityLayers []string) []string {
+	if len(rigLayers) <= len(cityLayers) {
+		return nil
+	}
+	return rigLayers[len(cityLayers):]
+}
+
+func orderFiringOverrides(cfgOverrides []config.OrderOverride) []orders.Override {
+	out := make([]orders.Override, len(cfgOverrides))
+	for i, override := range cfgOverrides {
+		out[i] = orders.Override{
+			Name:     override.Name,
+			Rig:      override.Rig,
+			Enabled:  override.Enabled,
+			Trigger:  override.Trigger,
+			Interval: override.Interval,
+			Schedule: override.Schedule,
+			Check:    override.Check,
+			On:       override.On,
+			Pool:     override.Pool,
+			Timeout:  override.Timeout,
+		}
+	}
+	return out
+}
+
+func expectedIntervalForOrder(order orders.Order, cronCache map[string]time.Duration) (time.Duration, error) {
+	switch order.Trigger {
+	case "cooldown":
+		interval, err := time.ParseDuration(order.Interval)
+		if err != nil {
+			return 0, fmt.Errorf("parse cooldown interval %q: %w", order.Interval, err)
+		}
+		if interval <= 0 {
+			return 0, fmt.Errorf("cooldown interval %q must be positive", order.Interval)
+		}
+		return interval, nil
+	case "cron":
+		if cached, ok := cronCache[order.Schedule]; ok {
+			return cached, nil
+		}
+		interval, err := computeExpectedIntervalForCronSchedule(order.Schedule)
+		if err != nil {
+			return 0, err
+		}
+		cronCache[order.Schedule] = interval
+		return interval, nil
+	default:
+		return 0, fmt.Errorf("unsupported trigger %q", order.Trigger)
+	}
+}
+
+func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, error) {
+	fields := strings.Fields(schedule)
+	if len(fields) != 5 {
+		return 0, fmt.Errorf("invalid cron schedule: want 5 fields, got %d", len(fields))
+	}
+
+	const day = 24 * time.Hour
+	base := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	matches := make([]time.Time, 0, 1440)
+	for i := 0; i < 1440; i++ {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		matched, err := cronScheduleMatchesAt(fields, ts)
+		if err != nil {
+			return 0, err
+		}
+		if matched {
+			matches = append(matches, ts)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return 0, fmt.Errorf("cron schedule %q has no firing minutes in a 24h window", schedule)
+	case 1:
+		return day, nil
+	}
+
+	minGap := day
+	for i := 1; i < len(matches); i++ {
+		gap := matches[i].Sub(matches[i-1])
+		if gap < minGap {
+			minGap = gap
+		}
+	}
+	wrapGap := matches[0].Add(day).Sub(matches[len(matches)-1])
+	if wrapGap < minGap {
+		minGap = wrapGap
+	}
+	return minGap, nil
+}
+
+func cronScheduleMatchesAt(fields []string, ts time.Time) (bool, error) {
+	specs := []struct {
+		name     string
+		field    string
+		value    int
+		min, max int
+	}{
+		{name: "minute", field: fields[0], value: ts.Minute(), min: 0, max: 59},
+		{name: "hour", field: fields[1], value: ts.Hour(), min: 0, max: 23},
+		{name: "day-of-month", field: fields[2], value: ts.Day(), min: 1, max: 31},
+		{name: "month", field: fields[3], value: int(ts.Month()), min: 1, max: 12},
+		{name: "day-of-week", field: fields[4], value: int(ts.Weekday()), min: 0, max: 6},
+	}
+	for _, spec := range specs {
+		matched, err := cronFieldMatchesForDoctor(spec.field, spec.value, spec.min, spec.max)
+		if err != nil {
+			return false, fmt.Errorf("invalid cron schedule: cannot parse %s field %q", spec.name, spec.field)
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func cronFieldMatchesForDoctor(field string, value, lowerBound, upperBound int) (bool, error) {
+	if strings.TrimSpace(field) == "" {
+		return false, fmt.Errorf("empty field")
+	}
+	for _, rawPart := range strings.Split(field, ",") {
+		part := strings.TrimSpace(rawPart)
+		matched, err := cronPartMatchesForDoctor(part, value, lowerBound, upperBound)
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func cronPartMatchesForDoctor(part string, value, lowerBound, upperBound int) (bool, error) {
+	if part == "" {
+		return false, fmt.Errorf("empty part")
+	}
+	rangePart, stepPart, hasStep := strings.Cut(part, "/")
+	step := 1
+	if hasStep {
+		parsed, err := strconv.Atoi(strings.TrimSpace(stepPart))
+		if err != nil || parsed <= 0 {
+			return false, fmt.Errorf("invalid step")
+		}
+		step = parsed
+	}
+
+	lo, hi, err := cronRangeForDoctor(strings.TrimSpace(rangePart), lowerBound, upperBound)
+	if err != nil {
+		return false, err
+	}
+	if value < lo || value > hi {
+		return false, nil
+	}
+	return (value-lo)%step == 0, nil
+}
+
+func cronRangeForDoctor(rangePart string, lowerBound, upperBound int) (int, int, error) {
+	switch {
+	case rangePart == "*":
+		return lowerBound, upperBound, nil
+	case strings.Contains(rangePart, "-"):
+		start, end, ok := strings.Cut(rangePart, "-")
+		if !ok {
+			return 0, 0, fmt.Errorf("invalid range")
+		}
+		lo, err := strconv.Atoi(strings.TrimSpace(start))
+		if err != nil {
+			return 0, 0, err
+		}
+		hi, err := strconv.Atoi(strings.TrimSpace(end))
+		if err != nil {
+			return 0, 0, err
+		}
+		if lo < lowerBound || hi > upperBound || lo > hi {
+			return 0, 0, fmt.Errorf("range out of bounds")
+		}
+		return lo, hi, nil
+	default:
+		value, err := strconv.Atoi(rangePart)
+		if err != nil {
+			return 0, 0, err
+		}
+		if value < lowerBound || value > upperBound {
+			return 0, 0, fmt.Errorf("value out of bounds")
+		}
+		return value, value, nil
+	}
+}
+
+func latestControllerStartedAt(eventPath string) (time.Time, error) {
+	startEvents, err := events.ReadFiltered(eventPath, events.Filter{Type: events.ControllerStarted})
+	if err != nil {
+		return time.Time{}, err
+	}
+	var latest time.Time
+	for _, event := range startEvents {
+		if event.Ts.After(latest) {
+			latest = event.Ts
+		}
+	}
+	return latest, nil
+}
+
+func latestOrderFiredAt(evts []events.Event, subject string) time.Time {
+	var latest time.Time
+	for _, event := range evts {
+		if event.Subject != subject {
+			continue
+		}
+		if event.Ts.After(latest) {
+			latest = event.Ts
+		}
+	}
+	return latest
+}
+
+func classifyOrderFiring(order orders.Order, now time.Time, expected time.Duration, lastFired, controllerStarted time.Time) (CheckStatus, string) {
+	name := orderDisplayName(order)
+	if lastFired.IsZero() {
+		if controllerStarted.IsZero() {
+			return StatusOK, fmt.Sprintf("%s: never fired (controller start unknown)", name)
+		}
+		uptime := nonNegativeDuration(now.Sub(controllerStarted))
+		if uptime >= expected+expected/2 {
+			return StatusError, fmt.Sprintf("%s: never fired since controller start %s ago", name, formatOrderFiringDuration(uptime))
+		}
+		return StatusOK, fmt.Sprintf("%s: never fired (controller running %s, within first cycle)", name, formatOrderFiringDuration(uptime))
+	}
+
+	age := nonNegativeDuration(now.Sub(lastFired))
+	switch {
+	case age >= expected*3:
+		return StatusError, fmt.Sprintf("%s: last fired %s ago, expected every %s (CRITICAL: stale)", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
+	case age >= expected+expected/2:
+		return StatusWarning, fmt.Sprintf("%s: last fired %s ago, expected every %s (overdue)", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
+	default:
+		return StatusOK, fmt.Sprintf("%s: last fired %s ago, expected every %s", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
+	}
+}
+
+func orderDisplayName(order orders.Order) string {
+	if order.Rig == "" {
+		return order.Name
+	}
+	return order.ScopedName()
+}
+
+func orderHistoryHintTarget(order orders.Order) string {
+	if order.Rig != "" {
+		return fmt.Sprintf("%s --rig %s", order.Name, order.Rig)
+	}
+	return order.Name
+}
+
+func worseStatus(a, b CheckStatus) CheckStatus {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+func nonNegativeDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+func formatOrderFiringDuration(d time.Duration) string {
+	d = d.Round(time.Minute)
+	if d == 0 {
+		return "0s"
+	}
+	if d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	if d%time.Minute == 0 {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	return d.String()
+}

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -1,0 +1,219 @@
+package doctor
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+func TestOrderFiringCurrent_NeverFired_BeyondUptime(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-stale-db", "cron", "0 */4 * * *")
+	writeOrderFiringTestEvents(t, cityPath, events.Event{
+		Type: events.ControllerStarted,
+		Ts:   now.Add(-8 * time.Hour),
+	})
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusError {
+		t.Fatalf("status = %v, want error; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if !strings.Contains(strings.Join(result.Details, "\n"), "never fired since controller start") {
+		t.Fatalf("details = %v, want never-fired controller-start message", result.Details)
+	}
+	if result.FixHint != "Inspect with: gc order check && gc order history mol-dog-stale-db" {
+		t.Fatalf("FixHint = %q, want inspect hint for order", result.FixHint)
+	}
+}
+
+func TestOrderFiringCurrent_NeverFired_WithinFirstCycle(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-stale-db", "cron", "0 */4 * * *")
+	writeOrderFiringTestEvents(t, cityPath, events.Event{
+		Type: events.ControllerStarted,
+		Ts:   now.Add(-30 * time.Minute),
+	})
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if !strings.Contains(strings.Join(result.Details, "\n"), "within first cycle") {
+		t.Fatalf("details = %v, want within-first-cycle message", result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_FiredRecently(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-stale-db", "cron", "0 */4 * * *")
+	writeOrderFiringTestOrder(t, cityPath, "cleanup-cooldown", "cooldown", "4h")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-8 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "mol-dog-stale-db", Ts: now.Add(-1 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "cleanup-cooldown", Ts: now.Add(-1 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if !strings.Contains(strings.Join(result.Details, "\n"), "last fired 1h ago, expected every 4h") {
+		t.Fatalf("details = %v, want recent-fire detail", result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_Overdue(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-stale-db", "cron", "0 */4 * * *")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-8 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "mol-dog-stale-db", Ts: now.Add(-7 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if !strings.Contains(strings.Join(result.Details, "\n"), "(overdue)") {
+		t.Fatalf("details = %v, want overdue detail", result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_Stale(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-stale-db", "cron", "0 */4 * * *")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "mol-dog-stale-db", Ts: now.Add(-13 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusError {
+		t.Fatalf("status = %v, want error; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if !strings.Contains(strings.Join(result.Details, "\n"), "(CRITICAL: stale)") {
+		t.Fatalf("details = %v, want stale detail", result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_IgnoresManualAndEventTriggers(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "manual-maintenance", "manual", "")
+	writeOrderFiringTestOrder(t, cityPath, "convoy-check", "event", "bead.closed")
+	writeOrderFiringTestOrder(t, cityPath, "condition-check", "condition", "")
+	writeOrderFiringTestEvents(t, cityPath, events.Event{
+		Type: events.ControllerStarted,
+		Ts:   now.Add(-8 * time.Hour),
+	})
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if len(result.Details) != 0 {
+		t.Fatalf("details = %v, want no rows for manual/event triggers", result.Details)
+	}
+}
+
+func TestComputeExpectedIntervalForCronSchedules(t *testing.T) {
+	tests := []struct {
+		schedule string
+		want     time.Duration
+	}{
+		{"0 */4 * * *", 4 * time.Hour},
+		{"*/15 * * * *", 15 * time.Minute},
+		{"0 3 * * *", 24 * time.Hour},
+		{"0 9-17 * * *", time.Hour},
+	}
+	for _, tt := range tests {
+		got, err := computeExpectedIntervalForCronSchedule(tt.schedule)
+		if err != nil {
+			t.Fatalf("computeExpectedIntervalForCronSchedule(%q): %v", tt.schedule, err)
+		}
+		if got != tt.want {
+			t.Fatalf("computeExpectedIntervalForCronSchedule(%q) = %s, want %s", tt.schedule, got, tt.want)
+		}
+	}
+}
+
+func orderFiringTestCity(t *testing.T) (string, *config.City) {
+	t.Helper()
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "orders"), 0o755); err != nil {
+		t.Fatalf("creating orders dir: %v", err)
+	}
+	formulasDir := filepath.Join(cityPath, "formulas")
+	return cityPath, &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulasDir},
+		},
+	}
+}
+
+func writeOrderFiringTestOrder(t *testing.T, cityPath, name, trigger, timing string) {
+	t.Helper()
+	var body string
+	switch trigger {
+	case "cron":
+		body = `[order]
+exec = "true"
+trigger = "cron"
+schedule = "` + timing + `"
+`
+	case "cooldown":
+		body = `[order]
+exec = "true"
+trigger = "cooldown"
+interval = "` + timing + `"
+`
+	case "event":
+		body = `[order]
+exec = "true"
+trigger = "event"
+on = "` + timing + `"
+`
+	default:
+		body = `[order]
+exec = "true"
+trigger = "` + trigger + `"
+`
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "orders", name+".toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing order %s: %v", name, err)
+	}
+}
+
+func writeOrderFiringTestEvents(t *testing.T, cityPath string, evts ...events.Event) {
+	t.Helper()
+	rec, err := events.NewFileRecorder(filepath.Join(cityPath, ".gc", "events.jsonl"), io.Discard)
+	if err != nil {
+		t.Fatalf("NewFileRecorder: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rec.Close(); err != nil {
+			t.Fatalf("closing FileRecorder: %v", err)
+		}
+	})
+	for _, e := range evts {
+		rec.Record(e)
+	}
+}
+
+func runOrderFiringCurrentTest(t *testing.T, cfg *config.City, cityPath string, now time.Time) *CheckResult {
+	t.Helper()
+	check := NewOrderFiringCurrentCheck(cfg, cityPath)
+	check.clock = func() time.Time { return now }
+	return check.Run(&CheckContext{CityPath: cityPath})
+}

--- a/release-gates/order-firing-current-gate.md
+++ b/release-gates/order-firing-current-gate.md
@@ -1,0 +1,47 @@
+# Release Gate: order-firing-current
+
+- Date: 2026-05-17
+- Shape: single-bead PR
+- Deploy bead: ga-8p06rl — Review: order-firing-current doctor check
+- Source bead: ga-hlhxo7 — Add gc doctor 'order-firing-current' check (silent-failure backstop for cron/cooldown orders)
+- Branch: builder/ga-hlhxo7-1
+- Source commit: 3c451855f feat(doctor): add order firing freshness check
+- Release criteria source: deployer Release Gate Criteria. `docs/PROJECT_MANIFEST.md` is not present in this repository worktree.
+
+## Gate Summary
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Deploy bead notes contain `Claude Review — pass` and `Verdict: PASS`. |
+| 2 | Acceptance criteria met | PASS | `OrderFiringCurrentCheck` exists, exposes the required doctor check surface, registers as `order-firing-current`, monitors cron/cooldown orders, skips manual/event/condition triggers, reads `order.fired` and controller-start events, classifies OK/warning/error thresholds, and provides the requested inspection hint. Tests cover the seven named scenarios plus cooldown freshness. |
+| 3 | Tests pass | PASS | `go test ./internal/doctor/...` PASS; `go test ./cmd/gc -run ^$` PASS; `go vet ./...` PASS; `make test-fast-parallel` PASS. |
+| 4 | No high-severity review findings open | PASS | Review notes list one LOW code-smell finding and one LOW coverage gap. Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean on `builder/ga-hlhxo7-1` before adding this gate file; pre-commit is active via `core.hooksPath=.githooks`. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` returned 0 and `git merge-tree --write-tree HEAD origin/main` returned a tree without conflicts. |
+
+## Acceptance Evidence
+
+| Acceptance area | Evidence |
+|-----------------|----------|
+| Check shape | `internal/doctor/checks_order_firing.go` defines `OrderFiringCurrentCheck`, `NewOrderFiringCurrentCheck`, `Name`, `CanFix`, `Fix`, and `Run`; `cmd/gc/cmd_doctor.go` registers the check. |
+| Trigger filtering | `Run` monitors only `cron` and `cooldown`; `TestOrderFiringCurrent_IgnoresManualAndEventTriggers` covers manual, event, and condition triggers. |
+| Expected interval | Cron schedules are sampled over a 24-hour minute window with per-run schedule caching; cooldown intervals use `time.ParseDuration`. |
+| Event history | The check reads `order.fired` events and the latest `controller.started` event from `.gc/events.jsonl`. |
+| Classification | Tests cover never-fired beyond uptime, never-fired within first cycle, recently fired, overdue, stale, ignored triggers, and cron interval computation. |
+| Remediation surface | Non-OK results set `FixHint` to `Inspect with: gc order check && gc order history <name>`. |
+
+## Test Output Summary
+
+```text
+go test ./internal/doctor/...        PASS
+go test ./cmd/gc -run ^$             PASS
+go vet ./...                         PASS
+make test-fast-parallel              PASS
+```
+
+## Review Findings
+
+| Severity | Finding | Gate impact |
+|----------|---------|-------------|
+| LOW | Cron interval computation samples a fixed 2026-05-12 day, so month/day-constrained schedules may report a diagnostic error. | Non-blocking; current intended schedules are daily or more frequent. |
+| LOW | No test for month/day-constrained cron schedules. | Non-blocking; follow-up bead ga-gse1pe exists for order scanning cleanup and reviewer accepted this coverage shape. |


### PR DESCRIPTION
## What this changes

Adds a new `gc doctor` check named `order-firing-current` that scans enabled cron and cooldown orders, compares each order's latest `order.fired` event with its expected firing interval, and reports scheduled orders that have never fired, are overdue, or are critically stale.

Operators get per-order details and an inspection hint using `gc order check` and `gc order history <name>`. The check is read-only: it surfaces stale order symptoms without guessing at remediation.

## Review notes

- The check uses existing `order.fired` and controller-start events; it does not add a new event type.
- Manual, event, and condition-triggered orders are intentionally ignored.
- Cron interval estimation samples a 24-hour window, which is suitable for the current daily-or-more-frequent schedules but can report a diagnostic error for month/day-constrained cron schedules.
- `Fix()` remains a no-op because the root cause could be parser behavior, suspended pools, missing handlers, or other operator-specific state.

## Test plan

- [x] `go test ./internal/doctor/...`
- [x] `go test ./cmd/gc -run ^$`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/order-firing-current-gate.md`](release-gates/order-firing-current-gate.md)