### PR TITLE
Add live-session fail-closed guard to dolt cleanup

### DIFF
--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -131,6 +131,11 @@ const (
 	cleanupErrorKindInvalidMaxOrphanDBs = "invalid-max-orphan-dbs"
 	cleanupErrorKindMaxOrphanRefusal    = "max-orphan-refusal"
 	cleanupErrorKindRigProtection       = "rig-protection"
+	// cleanupErrorKindLiveSessionProbeFailed marks that the SHOW
+	// PROCESSLIST probe could not complete (timeout, auth, network,
+	// malformed result). FAIL-CLOSED: --force refuses to drop ANY DB
+	// when this kind is recorded.
+	cleanupErrorKindLiveSessionProbeFailed = "live-session-probe-failed"
 )
 
 // MarshalJSON ensures slices serialize as `[]` rather than `null` for empty
@@ -298,6 +303,9 @@ func runDoltCleanup(opts cleanupOptions, stdout, stderr io.Writer) int {
 
 	emitReport(report, resolution, opts, stdout, stderr)
 	if opts.DoltClientOpenErr != nil {
+		return 1
+	}
+	if opts.Force && hasFatalForceBlocker(&report) {
 		return 1
 	}
 	return 0
@@ -949,6 +957,21 @@ func recordUnsafeRigDatabaseNames(report *CleanupReport) {
 func hasRigProtectionError(report *CleanupReport) bool {
 	for _, e := range report.Errors {
 		if e.Kind == cleanupErrorKindRigProtection || e.Stage == "rig" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasFatalForceBlocker reports whether a force-blocker has been
+// recorded that requires runDoltCleanup to exit non-zero in --force
+// mode. Currently only cleanupErrorKindLiveSessionProbeFailed counts;
+// rig-protection refusals are signaled via the Errors slice
+// (hasRigProtectionError), and max-orphan-refusal historically returns
+// exit 0 with the report (existing behavior preserved).
+func hasFatalForceBlocker(report *CleanupReport) bool {
+	for _, b := range report.ForceBlockers {
+		if b.Kind == cleanupErrorKindLiveSessionProbeFailed {
 			return true
 		}
 	}

--- a/cmd/gc/dolt_cleanup_drop.go
+++ b/cmd/gc/dolt_cleanup_drop.go
@@ -22,6 +22,14 @@ type CleanupDoltClient interface {
 	// against the given rig database. The dolt server's purge routine is
 	// per-database — caller iterates over each rig DB it wants reclaimed.
 	PurgeDroppedDatabases(ctx context.Context, rigDB string) error
+	// ProbeLiveSessions returns the set of databases with at least one
+	// active session at probe time, keyed on database name with the
+	// thread count as the value. The probe issues
+	// cleanupLiveSessionProbeQuery against the same Dolt server the
+	// drop stage targets. Errors (timeout, auth, network, malformed
+	// result) propagate verbatim — the runner converts them into a
+	// FAIL-CLOSED force-blocker (architect FR-05).
+	ProbeLiveSessions(ctx context.Context) (map[string]int, error)
 	Close() error
 }
 
@@ -32,6 +40,23 @@ const cleanupDropTimeout = 30 * time.Second
 
 // cleanupListTimeout caps SHOW DATABASES.
 const cleanupListTimeout = 30 * time.Second
+
+// cleanupLiveSessionProbeQuery is the verbatim SQL the probe issues.
+// It scans the live processlist on the same Dolt server cleanup is
+// targeting and aggregates one row per database with at least one
+// active session. The schema is stable across all Dolt versions
+// gascity targets (information_schema.processlist is MySQL-compat).
+const cleanupLiveSessionProbeQuery = "SELECT db, COUNT(*) FROM information_schema.processlist WHERE db IS NOT NULL AND db != '' GROUP BY db"
+
+// cleanupLiveSessionProbeTimeout caps SHOW PROCESSLIST. NFR-01 of
+// ga-nw4z6: the query is expected to complete in well under 1 second
+// on a healthy Dolt server; 2 s is the FAIL-CLOSED threshold.
+//
+// Declared as var (not const) so TestProbeLiveSessions_TimesOut can
+// shrink it to keep CI wall time under 250 ms while still exercising
+// the timeout wiring. Production never mutates it; the assertion in
+// TestProbeLiveSessions_FailClosed pins the live value at 2*time.Second.
+var cleanupLiveSessionProbeTimeout = 2 * time.Second
 
 // runDropStage discovers all databases on the resolved Dolt server,
 // classifies them with planDoltDrops against the protection list, and (when
@@ -69,6 +94,30 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) bool {
 	}
 
 	plan := planDoltDrops(all, stalePrefixes, protected)
+
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), cleanupLiveSessionProbeTimeout)
+	liveSessions, probeErr := opts.DoltClient.ProbeLiveSessions(probeCtx)
+	probeCancel()
+
+	if probeErr != nil {
+		recordCleanupForceBlocker(report, cleanupErrorKindLiveSessionProbeFailed, "", probeErr)
+		if opts.Force {
+			recordCleanupErrorKind(report, "drop", cleanupErrorKindLiveSessionProbeFailed, "", probeErr)
+			report.Dropped.Skipped = append([]DoltDropSkip{}, plan.Skipped...)
+			for _, skipped := range plan.Skipped {
+				if skipped.Reason == DropSkipReasonInvalidIdentifier {
+					recordCleanupError(report, "drop", skipped.Name, fmt.Errorf("invalid database identifier %q", skipped.Name))
+				}
+			}
+			return false
+		}
+		// Dry-run continues; report renders the planned ToDrop as if the
+		// probe had returned empty — operator sees what WOULD have been
+		// dropped, plus the visible ForceBlocker.
+	} else {
+		plan = applyLiveSessionsToPlan(plan, liveSessions)
+	}
+
 	report.Dropped.Skipped = append([]DoltDropSkip{}, plan.Skipped...)
 	for _, skipped := range plan.Skipped {
 		if skipped.Reason == DropSkipReasonInvalidIdentifier {
@@ -184,6 +233,30 @@ func (c *sqlCleanupDoltClient) PurgeDroppedDatabases(ctx context.Context, rigDB 
 		return err
 	}
 	return nil
+}
+
+func (c *sqlCleanupDoltClient) ProbeLiveSessions(ctx context.Context) (map[string]int, error) {
+	rows, err := c.db.QueryContext(ctx, cleanupLiveSessionProbeQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	out := map[string]int{}
+	for rows.Next() {
+		var (
+			name    string
+			threads int
+		)
+		if err := rows.Scan(&name, &threads); err != nil {
+			return nil, err
+		}
+		out[name] = threads
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *sqlCleanupDoltClient) Close() error {

--- a/cmd/gc/dolt_cleanup_drop_planner.go
+++ b/cmd/gc/dolt_cleanup_drop_planner.go
@@ -62,6 +62,42 @@ const DropSkipReasonRigProtected = "rig-protected"
 // destructive DROP DATABASE targets.
 const DropSkipReasonInvalidIdentifier = "invalid-identifier"
 
+// DropSkipReasonLiveSession marks a stale-matched DB held back because
+// information_schema.processlist reported at least one live session
+// against it at probe time. Third oracle in the three-signal safety
+// contract (architect §"Three-layer protection contract").
+const DropSkipReasonLiveSession = "live-session"
+
+// applyLiveSessionsToPlan removes any name in liveSessions from the
+// caller's ToDrop slice and appends a Skipped entry with reason
+// DropSkipReasonLiveSession for each removed name. Order of remaining
+// ToDrop names and order of new Skipped entries follows the input
+// ToDrop order, so human-readable rendering stays predictable.
+//
+// liveSessions is map[dbName]threadCount. Only the keys are consulted
+// here; thread counts are preserved by the runner for audit/logging
+// in a future slice.
+func applyLiveSessionsToPlan(plan DoltDropPlan, liveSessions map[string]int) DoltDropPlan {
+	if len(liveSessions) == 0 {
+		return plan
+	}
+	out := DoltDropPlan{
+		Protected: plan.Protected,
+		Skipped:   append([]DoltDropSkip{}, plan.Skipped...),
+	}
+	for _, name := range plan.ToDrop {
+		if _, live := liveSessions[name]; live {
+			out.Skipped = append(out.Skipped, DoltDropSkip{
+				Name:   name,
+				Reason: DropSkipReasonLiveSession,
+			})
+			continue
+		}
+		out.ToDrop = append(out.ToDrop, name)
+	}
+	return out
+}
+
 // planDoltDrops classifies the names returned by SHOW DATABASES against the
 // stale-prefix list and the rig-protection list. The protection check wins
 // over the stale-prefix match: a registered rig DB is never a drop target,

--- a/cmd/gc/dolt_cleanup_drop_test.go
+++ b/cmd/gc/dolt_cleanup_drop_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/fsys"
 )
@@ -20,6 +22,13 @@ type fakeCleanupDoltClient struct {
 	dropped   []string
 	purged    int
 	dropErr   map[string]error
+
+	// Slice 2 (ga-9h05hk): live-session probe fields. Defaults to
+	// empty/nil so existing tests retain their semantics — an
+	// uninitialized fake reports no live sessions and no probe error.
+	liveSessions    map[string]int
+	liveSessionsErr error
+	probeCalls      int
 }
 
 func (f *fakeCleanupDoltClient) ListDatabases(_ context.Context) ([]string, error) {
@@ -47,6 +56,18 @@ func (f *fakeCleanupDoltClient) DropDatabase(_ context.Context, name string) err
 func (f *fakeCleanupDoltClient) PurgeDroppedDatabases(_ context.Context, _ string) error {
 	f.purged++
 	return nil
+}
+
+func (f *fakeCleanupDoltClient) ProbeLiveSessions(_ context.Context) (map[string]int, error) {
+	f.probeCalls++
+	if f.liveSessionsErr != nil {
+		return nil, f.liveSessionsErr
+	}
+	out := map[string]int{}
+	for k, v := range f.liveSessions {
+		out[k] = v
+	}
+	return out, nil
 }
 
 func (f *fakeCleanupDoltClient) Close() error { return nil }
@@ -294,5 +315,279 @@ func TestRunDoltCleanup_ForceRecordsDropFailureAndContinues(t *testing.T) {
 	}
 	if !strings.Contains(r.Dropped.Failed[0].Error, "boom") {
 		t.Errorf("failure error = %q, want to contain 'boom'", r.Dropped.Failed[0].Error)
+	}
+}
+
+// blockingProbeCleanupDoltClient overrides ProbeLiveSessions to block on
+// the caller's context until cancellation, returning ctx.Err(). Used by
+// TestProbeLiveSessions_TimesOut to exercise the FAIL-CLOSED wiring
+// without sleeping for the full cleanupLiveSessionProbeTimeout in CI.
+type blockingProbeCleanupDoltClient struct {
+	fakeCleanupDoltClient
+}
+
+func (b *blockingProbeCleanupDoltClient) ProbeLiveSessions(ctx context.Context) (map[string]int, error) {
+	b.probeCalls++
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestProbeLiveSessions_HealthyServer(t *testing.T) {
+	// Direct unit on applyLiveSessionsToPlan: pure function asserts.
+	inputPlan := DoltDropPlan{
+		ToDrop: []string{"testdb_a", "testdb_busy", "doctest_y", "testdb_c"},
+	}
+	sessions := map[string]int{"testdb_busy": 3, "doctest_y": 1}
+
+	result := applyLiveSessionsToPlan(inputPlan, sessions)
+
+	for _, name := range result.ToDrop {
+		if name == "testdb_busy" || name == "doctest_y" {
+			t.Errorf("ToDrop contains live-session DB %q; want it removed", name)
+		}
+	}
+	wantSkipped := []DoltDropSkip{
+		{Name: "testdb_busy", Reason: "live-session"},
+		{Name: "doctest_y", Reason: "live-session"},
+	}
+	if len(result.Skipped) != len(wantSkipped) {
+		t.Fatalf("Skipped len = %d, want %d; got=%+v", len(result.Skipped), len(wantSkipped), result.Skipped)
+	}
+	for i, want := range wantSkipped {
+		if result.Skipped[i] != want {
+			t.Errorf("Skipped[%d] = %+v, want %+v", i, result.Skipped[i], want)
+		}
+	}
+	if DropSkipReasonLiveSession != "live-session" {
+		t.Errorf("DropSkipReasonLiveSession = %q, want %q", DropSkipReasonLiveSession, "live-session")
+	}
+
+	// Drive runDoltCleanup to verify the fake's ProbeLiveSessions is
+	// called exactly once.
+	client := &fakeCleanupDoltClient{
+		databases:    []string{"hq", "testdb_a", "testdb_busy", "doctest_y", "testdb_c"},
+		liveSessions: sessions,
+	}
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		FS:                fsys.NewFake(),
+		JSON:              true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+	}
+	if code := runDoltCleanup(opts, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	if client.probeCalls != 1 {
+		t.Errorf("probeCalls = %d, want 1", client.probeCalls)
+	}
+}
+
+func TestProbeLiveSessions_TimesOut(t *testing.T) {
+	// Shrink the probe deadline so the test does not sleep for the full
+	// 2 s production value. The wiring is what we are exercising — the
+	// value is pinned by TestProbeLiveSessions_FailClosed.
+	oldTimeout := cleanupLiveSessionProbeTimeout
+	cleanupLiveSessionProbeTimeout = 50 * time.Millisecond
+	defer func() { cleanupLiveSessionProbeTimeout = oldTimeout }()
+
+	client := &blockingProbeCleanupDoltClient{
+		fakeCleanupDoltClient: fakeCleanupDoltClient{
+			databases: []string{"testdb_a", "testdb_b"},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		FS:                fsys.NewFake(),
+		JSON:              true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+	}
+
+	start := time.Now()
+	runDoltCleanup(opts, &stdout, &stderr)
+	elapsed := time.Since(start)
+	if elapsed >= 250*time.Millisecond {
+		t.Errorf("wall time = %v, want < 250ms", elapsed)
+	}
+
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(r.ForceBlockers) != 1 {
+		t.Fatalf("ForceBlockers = %+v, want exactly one entry", r.ForceBlockers)
+	}
+	if r.ForceBlockers[0].Kind != "live-session-probe-failed" {
+		t.Errorf("ForceBlockers[0].Kind = %q, want %q", r.ForceBlockers[0].Kind, "live-session-probe-failed")
+	}
+	if r.ForceBlockers[0].Name != "" {
+		t.Errorf("ForceBlockers[0].Name = %q, want \"\"", r.ForceBlockers[0].Name)
+	}
+	if !strings.Contains(r.ForceBlockers[0].Error, "context deadline exceeded") {
+		t.Errorf("ForceBlockers[0].Error = %q, want contains %q", r.ForceBlockers[0].Error, "context deadline exceeded")
+	}
+	if len(client.dropped) != 0 {
+		t.Errorf("DropDatabase called %d times, want 0", len(client.dropped))
+	}
+}
+
+func TestProbeLiveSessions_FailClosed(t *testing.T) {
+	// Pin the production deadline value here. Other tests may override
+	// cleanupLiveSessionProbeTimeout, but the live constant must be 2 s.
+	if cleanupLiveSessionProbeTimeout != 2*time.Second {
+		t.Errorf("cleanupLiveSessionProbeTimeout = %v, want %v", cleanupLiveSessionProbeTimeout, 2*time.Second)
+	}
+
+	client := &fakeCleanupDoltClient{
+		databases:       []string{"testdb_a", "testdb_b", "doctest_c"},
+		liveSessionsErr: errors.New("connection reset by peer"),
+	}
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		FS:                fsys.NewFake(),
+		JSON:              true,
+		Force:             true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+		ReapGracePeriod:   1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit=%d, want 1 (force + probe failure); stderr=%q", code, stderr.String())
+	}
+
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(r.ForceBlockers) != 1 {
+		t.Fatalf("ForceBlockers = %+v, want exactly one entry", r.ForceBlockers)
+	}
+	if r.ForceBlockers[0].Kind != "live-session-probe-failed" {
+		t.Errorf("ForceBlockers[0].Kind = %q, want %q", r.ForceBlockers[0].Kind, "live-session-probe-failed")
+	}
+	if r.ForceBlockers[0].Error != "connection reset by peer" {
+		t.Errorf("ForceBlockers[0].Error = %q, want %q", r.ForceBlockers[0].Error, "connection reset by peer")
+	}
+
+	probeErrors := 0
+	for _, e := range r.Errors {
+		if e.Kind == "live-session-probe-failed" {
+			probeErrors++
+			if e.Stage != "drop" {
+				t.Errorf("Errors[].Stage = %q, want %q", e.Stage, "drop")
+			}
+			if e.Name != "" {
+				t.Errorf("Errors[].Name = %q, want \"\"", e.Name)
+			}
+			if e.Error != "connection reset by peer" {
+				t.Errorf("Errors[].Error = %q, want %q", e.Error, "connection reset by peer")
+			}
+		}
+	}
+	if probeErrors != 1 {
+		t.Errorf("Errors with kind=live-session-probe-failed: %d, want 1; errors=%+v", probeErrors, r.Errors)
+	}
+
+	if len(client.dropped) != 0 {
+		t.Errorf("DropDatabase called %d times, want 0; got %v", len(client.dropped), client.dropped)
+	}
+	if client.purged != 0 {
+		t.Errorf("PurgeDroppedDatabases called %d times, want 0", client.purged)
+	}
+}
+
+func TestProbeLiveSessions_DryRunSurvivesFailure(t *testing.T) {
+	client := &fakeCleanupDoltClient{
+		databases:       []string{"testdb_a", "testdb_b", "doctest_c"},
+		liveSessionsErr: errors.New("connection reset by peer"),
+	}
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		FS:                fsys.NewFake(),
+		JSON:              true,
+		Force:             false,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0 (dry-run + probe failure); stderr=%q", code, stderr.String())
+	}
+
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(r.ForceBlockers) != 1 {
+		t.Fatalf("ForceBlockers = %+v, want exactly one entry", r.ForceBlockers)
+	}
+	if r.ForceBlockers[0].Kind != "live-session-probe-failed" {
+		t.Errorf("ForceBlockers[0].Kind = %q, want %q", r.ForceBlockers[0].Kind, "live-session-probe-failed")
+	}
+	for _, e := range r.Errors {
+		if e.Kind == "live-session-probe-failed" {
+			t.Errorf("dry-run promoted probe failure into Errors: %+v", e)
+		}
+	}
+	wantDropped := []string{"testdb_a", "testdb_b", "doctest_c"}
+	if !equalStringSlice(r.Dropped.Names, wantDropped) {
+		t.Errorf("Dropped.Names = %v, want %v (would-be plan visible)", r.Dropped.Names, wantDropped)
+	}
+	if len(client.dropped) != 0 {
+		t.Errorf("DropDatabase called %d times, want 0 in dry-run", len(client.dropped))
+	}
+}
+
+func TestProbeLiveSessions_RemovesFromToDrop(t *testing.T) {
+	client := &fakeCleanupDoltClient{
+		databases:    []string{"hq", "beads", "testdb_a", "testdb_b", "doctest_c"},
+		liveSessions: map[string]int{"testdb_a": 1, "doctest_c": 2, "beads": 5},
+	}
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		FS:                fsys.NewFake(),
+		JSON:              true,
+		Force:             true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+		ReapGracePeriod:   1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+
+	wantDropped := []string{"testdb_b"}
+	if !equalStringSlice(r.Dropped.Names, wantDropped) {
+		t.Errorf("Dropped.Names = %v, want %v", r.Dropped.Names, wantDropped)
+	}
+
+	wantSkipped := []DoltDropSkip{
+		{Name: "testdb_a", Reason: "live-session"},
+		{Name: "doctest_c", Reason: "live-session"},
+	}
+	if len(r.Dropped.Skipped) != len(wantSkipped) {
+		t.Fatalf("Dropped.Skipped len = %d, want %d; got=%+v", len(r.Dropped.Skipped), len(wantSkipped), r.Dropped.Skipped)
+	}
+	for i, want := range wantSkipped {
+		if r.Dropped.Skipped[i] != want {
+			t.Errorf("Dropped.Skipped[%d] = %+v, want %+v", i, r.Dropped.Skipped[i], want)
+		}
+	}
+	for _, s := range r.Dropped.Skipped {
+		if s.Name == "beads" {
+			t.Errorf("Skipped contains 'beads' which was never in ToDrop: %+v", s)
+		}
+	}
+
+	if !equalStringSlice(client.dropped, []string{"testdb_b"}) {
+		t.Errorf("DropDatabase called with %v, want [testdb_b]", client.dropped)
 	}
 }

--- a/cmd/gc/dolt_cleanup_human_test.go
+++ b/cmd/gc/dolt_cleanup_human_test.go
@@ -222,7 +222,10 @@ func (e *erroringCleanupClient) DropDatabase(_ context.Context, _ string) error 
 	return errBoom("drop-boom")
 }
 func (e *erroringCleanupClient) PurgeDroppedDatabases(_ context.Context, _ string) error { return nil }
-func (e *erroringCleanupClient) Close() error                                            { return nil }
+func (e *erroringCleanupClient) ProbeLiveSessions(_ context.Context) (map[string]int, error) {
+	return map[string]int{}, nil
+}
+func (e *erroringCleanupClient) Close() error { return nil }
 
 type errBoom string
 

--- a/cmd/gc/dolt_cleanup_purge_test.go
+++ b/cmd/gc/dolt_cleanup_purge_test.go
@@ -767,6 +767,10 @@ func (f *fakeCleanupDoltClientCustomPurge) PurgeDroppedDatabases(_ context.Conte
 	return nil
 }
 
+func (f *fakeCleanupDoltClientCustomPurge) ProbeLiveSessions(_ context.Context) (map[string]int, error) {
+	return map[string]int{}, nil
+}
+
 func (f *fakeCleanupDoltClientCustomPurge) Close() error { return nil }
 
 type purgeConnRecord struct {

--- a/docs/plans/dolt-cleanup-live-session-probe.md
+++ b/docs/plans/dolt-cleanup-live-session-probe.md
@@ -1,0 +1,187 @@
+# Plan: live-session SHOW PROCESSLIST probe + fail-closed (ga-nw4z6 slice 2/5)
+
+> **Status:** decomposing — 2026-05-11
+> **Parent architecture:** `ga-nw4z6` — P0 DATA LOSS: `gc dolt cleanup`
+> marks the live `beads` DB as orphan.
+> **Designer spec:** `ga-lyv6d4` — pins SQL string verbatim, 2-second
+> deadline, `live-session` Skipped reason, `live-session-probe-failed`
+> ForceBlocker kind, 5 verbatim test names, interface extension on
+> `CleanupDoltClient`, `applyLiveSessionsToPlan` + `hasFatalForceBlocker`
+> helpers, `runDropStage` wiring, `--force` exit-1 rule.
+> **Branch:** `local/integration-2026-04-30` (rig root
+> `/home/jaword/projects/gascity`). Slice 1 (`ga-0txff0`, closed
+> 2026-05-11) already landed the Go runner on this branch.
+> **Sibling slices:** `ga-78stvc` (slice 3, bash forwarder),
+> `ga-endmgy` (slice 4, audit log), `ga-qg23tv` (slice 5, regression
+> test).
+> **Decomposed into:** 1 builder bead (see Children below)
+
+## Context
+
+`gc dolt cleanup` today operates on a two-signal contract: stale
+prefix match + rig-protection. Slice 2 introduces the **third**
+oracle — a `SHOW PROCESSLIST` cross-check against the live Dolt
+server. The probe runs once per cleanup, bounded by 2 s. Its job
+is binary: any DB that has a live session at probe time is held
+back from the DROP loop with `Skipped[reason=live-session]`. If
+the probe itself fails (timeout / auth / network / malformed
+result), the runner records a `ForceBlocker[kind=live-session-probe-failed]`
+and — under `--force` only — exits 1 with no DROPs, no purge,
+no reap (FAIL-CLOSED).
+
+Dry-run survives a probe failure: the report renders the would-be
+ToDrop set plus the visible ForceBlocker, exit 0. The architect
+explicitly bound this asymmetry (`ga-nw4z6` §"In dry-run mode,
+the report is emitted with the blocker visible, but the exit code
+stays 0").
+
+The designer (ga-lyv6d4) pinned every literal string and signature:
+
+- Exact SQL (`SELECT db, COUNT(*) FROM information_schema.processlist
+  WHERE db IS NOT NULL AND db != '' GROUP BY db`).
+- Exact deadline (`2 * time.Second`).
+- Exact reason / kind strings (`live-session` /
+  `live-session-probe-failed`).
+- Exact interface method signature
+  (`ProbeLiveSessions(ctx) (map[string]int, error)`).
+- Exact helper bodies (`applyLiveSessionsToPlan`,
+  `hasFatalForceBlocker`).
+- Exact `runDropStage` wiring (probe AFTER `planDoltDrops`, BEFORE
+  the dry-run / drop branches).
+- Five verbatim `Test*` names — no paraphrasing, no abbreviation.
+
+## Why a single builder bead
+
+The work touches four files in `cmd/gc/` that share one test
+surface (`dolt_cleanup_drop_test.go`) and one interface
+(`CleanupDoltClient`). Splitting interface, implementation,
+helpers, and tests into separate beads would force one of them
+to land in an inconsistent state (e.g., interface method declared
+but no implementation, or fake gains `ProbeLiveSessions` before
+the production type does). The design body is fully verbatim;
+the builder has no judgment calls to spread. One PR, four files,
+five new tests, ~150 LOC net. One bead.
+
+## Children
+
+| ID            | Title                                                                                  | Routing label    | Routes to         | Depends on |
+|---------------|----------------------------------------------------------------------------------------|------------------|-------------------|------------|
+| `ga-9h05hk`   | feat(dolt-cleanup): live-session SHOW PROCESSLIST probe + fail-closed (ga-nw4z6 slice 2/5) | `ready-to-build` | `gascity/builder` | (none; slice 1 closed) |
+
+## Acceptance for the parent (ga-lyv6d4)
+
+Met when `ga-9h05hk` closes and all of the following hold (these
+mirror the designer's §8 acceptance checklist):
+
+- [ ] `cleanupLiveSessionProbeQuery` constant in
+      `cmd/gc/dolt_cleanup_drop.go` byte-equals ga-lyv6d4 §2.1 SQL.
+- [ ] `cleanupLiveSessionProbeTimeout = 2 * time.Second` in
+      `cmd/gc/dolt_cleanup_drop.go`.
+- [ ] `DropSkipReasonLiveSession = "live-session"` exported in
+      `cmd/gc/dolt_cleanup_drop_planner.go`.
+- [ ] `cleanupErrorKindLiveSessionProbeFailed = "live-session-probe-failed"`
+      (unexported) in `cmd/gc/cmd_dolt_cleanup.go`.
+- [ ] `CleanupDoltClient` gains
+      `ProbeLiveSessions(ctx) (map[string]int, error)` between
+      `PurgeDroppedDatabases` and `Close` per ga-lyv6d4 §4.1.
+- [ ] `*sqlCleanupDoltClient.ProbeLiveSessions` body matches
+      ga-lyv6d4 §4.2 verbatim.
+- [ ] `applyLiveSessionsToPlan` helper matches ga-lyv6d4 §4.3
+      verbatim (pure, no context, no I/O).
+- [ ] `hasFatalForceBlocker(report)` matches ga-lyv6d4 §4.4 verbatim.
+- [ ] `runDropStage` wires the probe AFTER `planDoltDrops` and
+      BEFORE the dry-run / drop branches per ga-lyv6d4 §5.1.
+- [ ] `runDoltCleanup` exits 1 under `--force` iff
+      `hasFatalForceBlocker(&report)` per ga-lyv6d4 §5.2.
+- [ ] All 5 tests `TestProbeLiveSessions_HealthyServer`,
+      `TestProbeLiveSessions_TimesOut`,
+      `TestProbeLiveSessions_FailClosed`,
+      `TestProbeLiveSessions_DryRunSurvivesFailure`,
+      `TestProbeLiveSessions_RemovesFromToDrop` exist and pass.
+- [ ] `fakeCleanupDoltClient` gains `liveSessions`,
+      `liveSessionsErr`, `probeCalls` fields + `ProbeLiveSessions`
+      method per ga-lyv6d4 §6.6.
+- [ ] All existing `TestRunDoltCleanup_*` tests pass without
+      modification — the fake's empty-default `liveSessions`
+      yields no live sessions, preserving existing semantics.
+- [ ] `go test ./cmd/gc/... -count=1` green; `go vet ./...` clean.
+- [ ] No `CleanupReport.LiveSessions []` field added (ga-lyv6d4 §3.3).
+
+## Notes for the builder
+
+- **Read ga-lyv6d4 in full.** The design body is the contract;
+  the bead body in `ga-9h05hk` is a high-level summary. The
+  five tests' assertions are pinned to literal strings — tests
+  must assert on equality, not substring.
+- **2-second deadline is part of the contract, not a wall-clock
+  reality.** `TestProbeLiveSessions_TimesOut` uses a 50 ms
+  override to keep CI fast; `TestProbeLiveSessions_FailClosed`
+  pins the literal constant value via direct reference. Both
+  patterns ship.
+- **Fake defaults to no-op.** Existing
+  `TestRunDoltCleanup_*` tests MUST keep working without
+  modification. Do not add a default `liveSessions` value to any
+  existing test fixture — only the new five tests set the field
+  explicitly.
+- **No human-rendering changes.** `emitForceBlockersSection`
+  already prints `kind` + `error`; the new kind needs no
+  special-case rendering. Resist the urge to add one — the
+  architect kept human format generic intentionally.
+- **No JSON envelope additions.** `CleanupReport` stays as-is.
+  Slice 4 (`ga-endmgy`) owns audit-log; a hypothetical
+  `LiveSessions []` field can land then if needed.
+- **`hasFatalForceBlocker` keeps it surgical.** Only the new
+  kind triggers exit 1 in --force; rig-protection and
+  max-orphan-refusal keep their existing behavior (the architect
+  did not authorize a sweeping exit-code overhaul).
+
+## Out of scope
+
+These belong to siblings of `ga-nw4z6` and must not creep into
+this slice:
+
+- Bash forwarder + dog formula changes → slice 3 / `ga-78stvc`.
+- `cleanup-audit.log` writes → slice 4 / `ga-endmgy`.
+- `TestDoltCleanupRefusesLiveBeadsDatabase` regression test →
+  slice 5 / `ga-qg23tv` (already declared via Blocks edge on
+  `ga-lyv6d4`).
+- Adding `CleanupReport.LiveSessions []` field → permanently
+  out of scope per ga-lyv6d4 §3.3.
+- Retry / cancellation logic — single shot, single deadline,
+  fail-closed (architect risk-table).
+
+## Validation gates
+
+- `go test ./cmd/gc -run TestProbeLiveSessions -count=1` green.
+- `go test ./cmd/gc -count=1` green (all existing
+  `TestRunDoltCleanup_*` keep passing without edits).
+- `go vet ./...` clean.
+- `git diff` confined to: `cmd/gc/dolt_cleanup_drop.go`,
+  `cmd/gc/dolt_cleanup_drop_planner.go`,
+  `cmd/gc/cmd_dolt_cleanup.go`,
+  `cmd/gc/dolt_cleanup_drop_test.go`. No other files modified.
+- Typed wire: no `map[string]any` or `json.RawMessage` introduced
+  on wire types (the `map[string]int` is internal to the probe
+  return; it never crosses an HTTP/SSE boundary).
+- ZFC: no role names in the diff.
+
+## Risks and unknowns
+
+- **`liveSessions` map preserves thread-count.** Slice 2 does
+  not USE the thread count yet — the architect and designer
+  agreed to keep the data flowing end-to-end in case slice 4's
+  audit log wants it without re-probing. The builder MUST NOT
+  drop the count to simplify the helper signature; preserving it
+  is part of the contract.
+- **System databases are never in ToDrop.** `information_schema`,
+  `mysql`, `performance_schema`, `sys`, `dolt_cluster`,
+  `__gc_probe` may appear in the probe's result map but never
+  trigger spurious Skipped entries because the planner's
+  `systemDatabaseNames` already excludes them from ToDrop
+  candidates. `TestProbeLiveSessions_RemovesFromToDrop` has a
+  case (`beads` in live set but not in ToDrop) verifying this.
+- **`probeCancel()` placement.** The designer placed
+  `probeCancel()` immediately after the `ProbeLiveSessions`
+  call (not deferred to the function end) — the context is
+  for the probe alone, not the surrounding stage. Keep this
+  shape.

--- a/docs/plans/dolt-port-resolve-helper.md
+++ b/docs/plans/dolt-port-resolve-helper.md
@@ -1,0 +1,149 @@
+# Plan: shared `port_resolve.sh` helper kills :=3307 fallback (ga-lsois slice 1/3)
+
+> **Status:** decomposing — 2026-05-11
+> **Parent architecture:** `ga-lsois` (closed) — *Dog/maintenance
+> scripts default `GC_DOLT_PORT=3307` → CRITICAL alarm fatigue.*
+> **Designer spec:** `ga-u0lx9p` — full design body (684 lines, 3
+> graphviz visuals); pins function body, stderr template, exit
+> code, source-line edits, lint test, and the 8 builder tests.
+> **Sibling slices (independent):** `ga-nptxjv` (slice 2, formula
+> rewrites), `ga-kylssb` (slice 3, doctor severity).
+> **Decomposed into:** 1 builder bead (see Children below)
+
+## Context
+
+Slice 1 of architect ga-lsois deletes the silent `:=3307` /
+`:-3307` fallback from both `runtime.sh` (dolt pack) and
+`dolt-target.sh` (maintenance pack) and replaces it with a shared
+`resolve_dolt_port_or_die` helper that emits a structured stderr
+error and exits **78** (`EX_CONFIG`). Operator overrides via
+`GC_DOLT_PORT` still take precedence.
+
+The designer (ga-u0lx9p) pinned every byte the builder needs:
+
+- Helper file path: `.gc/system/packs/dolt/assets/scripts/port_resolve.sh`.
+- Function signature + body (POSIX `/bin/sh`, ~80 LOC).
+- Stderr template: 6 lines, plain ASCII, no ANSI, ≤79 cols.
+- Source-line edits at `runtime.sh:200-205` (-6/+5) and
+  `dolt-target.sh:145-150` (-6/+3).
+- CI lint at `test/packlint/no_dolt_3307_fallback_test.go` with
+  the verbatim test body, regex `GC_DOLT_PORT.*3307`, and an
+  allowlist for `mol-dog-reaper.formula.toml` (slice 2 removes it).
+- 8 builder-test cases (env override, discovery success, missing
+  state, present-but-not-running, runtime sources helper,
+  dolt-target sources helper, exit 78 on empty state, lint
+  regression).
+- Pinned answer to NFR-07: `var.dolt_port.default = "3307"` →
+  REMOVE (slice 2 executes; this slice allowlists the file).
+
+## Why a single builder bead
+
+Per the design's §13: one PR, ~+346/-12 lines across 5 files —
+1 new helper + 2 source-line edits + 1 lint + 1 test driver.
+The work is tightly coupled (the source-line edits depend on the
+helper existing; the lint depends on the edits removing the
+fallback) and the design body is fully verbatim, leaving no
+judgment calls to spread across multiple builders. Mirroring the
+prior single-builder-bead decompositions (ga-h0pyln,
+ga-a75ro.1, ga-vt6q), this is one bead's worth of work.
+
+## Children
+
+| ID            | Title                                                                                       | Routing label    | Routes to         | Depends on |
+|---------------|---------------------------------------------------------------------------------------------|------------------|-------------------|------------|
+| `ga-rq2e5a`   | feat(packs/dolt): port_resolve.sh helper kills :=3307 fallback (ga-lsois slice 1/3)         | `ready-to-build` | `gascity/builder` | (none; design closed) |
+
+## Acceptance for the parent (ga-u0lx9p)
+
+Met when `ga-rq2e5a` closes and all of the following hold (these
+mirror the designer's §8 acceptance checklist):
+
+- [ ] New file `.gc/system/packs/dolt/assets/scripts/port_resolve.sh`
+      with `resolve_dolt_port_or_die` body verbatim from ga-u0lx9p §1.
+- [ ] `runtime.sh:200-205` replaced per ga-u0lx9p §5.1 (-6/+5 lines).
+- [ ] `dolt-target.sh:145-150` replaced per ga-u0lx9p §5.2 (-6/+3 lines).
+- [ ] `test/packlint/no_dolt_3307_fallback_test.go::TestNoDolt3307FallbackInScripts`
+      passes, walks `.gc/system/packs/`, matches regex
+      `GC_DOLT_PORT.*3307`, allowlists only
+      `.gc/system/packs/maintenance/formulas/mol-dog-reaper.formula.toml`.
+- [ ] All 8 tests from ga-u0lx9p §10 implemented and passing.
+- [ ] `go test ./...` green; `go vet ./...` clean.
+- [ ] No new env vars introduced. POSIX `/bin/sh` only in the
+      helper (no `[[ ]]`, no `local`, no arrays).
+- [ ] Stderr template byte-for-byte matches ga-u0lx9p §3; downstream
+      substring match points (`gc dolt: cannot resolve runtime port`,
+      `(missing)`, `(present but not running)`, `remediation:`)
+      preserved for ga-kylssb's classifier.
+- [ ] `mol-dog-reaper.formula.toml`'s `var.dolt_port.default = "3307"`
+      is NOT touched in this PR (slice 2 / ga-nptxjv owns it).
+- [ ] The duplicated inline `managed_runtime_port` in
+      `dolt-target.sh:114-144` is preserved (follow-on bead per
+      ga-u0lx9p §11).
+
+## Notes for the builder
+
+- **Read ga-u0lx9p in full.** The design body is the contract;
+  the bead body in `ga-rq2e5a` is a high-level summary, not a
+  substitute. Every byte of the helper, the stderr message, and
+  the lint code is pinned in the design.
+- **POSIX scoping.** Use the `_rdp_` prefix for locals — the
+  helper must `exit` (not `return`) on failure, so the `( ... )`
+  subshell idiom does not apply here.
+- **`|| exit $?` after both call sites.** Without it, the
+  command-substitution failure leaves `$?` non-zero but the
+  caller continues with an empty port. This is the standard
+  POSIX guard.
+- **Lint regex is intentionally broad.** `GC_DOLT_PORT.*3307`
+  catches every variant the operator might re-introduce. False
+  positives are easier to allowlist than false negatives are to
+  catch.
+- **Allowlist comment.** The lint comment names slice 2
+  (`ga-nptxjv`) so the dependency is searchable when slice 2
+  shrinks the allowlist to empty.
+
+## Out of scope
+
+These belong to siblings of `ga-lsois` and must not creep into
+this slice:
+
+- Formula rewrites (`mol-dog-reaper.formula.toml`,
+  `mol-doctor.formula.toml`, prompt files) → slice 2 / `ga-nptxjv`.
+- Doctor WARNING-vs-CRITICAL severity classification keyed on
+  exit code 78 → slice 3 / `ga-kylssb`.
+- Deduplicating `managed_runtime_port` between `runtime.sh:165`
+  and `dolt-target.sh:114` → P3 follow-on bead (designer noted
+  the skeleton in ga-u0lx9p §11).
+- Supervisor-side env injection (`gc start` exports
+  `GC_DOLT_PORT` into agent envs) → architect explicit deferral.
+- Migrating runtime state to a one-int-per-line format → architect
+  explicit deferral.
+- Localizing the stderr message → project-wide concern.
+
+## Validation gates
+
+- `go test ./test/packlint -run TestNoDolt3307FallbackInScripts -count=1` green.
+- The 8 builder tests from ga-u0lx9p §10 all green; shell tests
+  use `t.TempDir()` for state-file fixtures; stderr asserted
+  byte-stable.
+- `git diff` confined to: `.gc/system/packs/dolt/assets/scripts/port_resolve.sh`
+  (new), `runtime.sh`, `dolt-target.sh`, `test/packlint/no_dolt_3307_fallback_test.go`
+  (new), and the new helper test driver. No other files modified.
+- ZFC: no role names in the diff.
+- No new third-party Go modules; no new env vars.
+- POSIX `/bin/sh` discipline (CI shellcheck pass).
+
+## Risks and unknowns
+
+- **Cross-pack source path.** `dolt-target.sh` (maintenance pack)
+  sources from `dolt/assets/scripts/port_resolve.sh`. This is
+  unusual but acceptable — the dolt pack owns the runtime
+  concept; maintenance is a consumer. The `${GC_SYSTEM_PACKS_DIR:-...}`
+  pattern matches the existing path-discipline at the top of
+  `runtime.sh`.
+- **Re-sourcing the helper.** `port_resolve.sh` may be sourced
+  more than once per process if both consumers run in the same
+  shell. Function redefinition is idempotent on identical bodies,
+  so this is safe; the architect explicitly allowed it (§5.1).
+- **`echo` vs `printf`.** Uniformly `printf '%s\n'` — `echo` on
+  POSIX mishandles `-` prefixes and backslashes. Drift here is
+  the kind of thing the design pinning catches.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -566,7 +566,7 @@ func isNil(v any) bool {
 		return true
 	}
 	rv := reflect.ValueOf(v)
-	return rv.Kind() == reflect.Ptr && rv.IsNil()
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
 }
 
 // pdOf extracts the generated client's decoded Problem Details pointer
@@ -585,7 +585,7 @@ func pdOf(resp any) *genclient.ErrorModel {
 		return nil
 	}
 	rv := reflect.ValueOf(resp)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
 			return nil
 		}

--- a/internal/api/response_cache.go
+++ b/internal/api/response_cache.go
@@ -92,7 +92,7 @@ func collectCacheKeyParts(v reflect.Value, parts *[]string) {
 			continue
 		}
 		fv := v.Field(i)
-		if fv.Kind() == reflect.Ptr {
+		if fv.Kind() == reflect.Pointer {
 			if fv.IsNil() {
 				continue
 			}

--- a/release-gates/ga-wm69vw-gate.md
+++ b/release-gates/ga-wm69vw-gate.md
@@ -1,0 +1,77 @@
+# Release Gate: ga-wm69vw
+
+Bead: `ga-wm69vw` - Review: live-session SHOW PROCESSLIST probe + fail-closed (`ga-9h05hk` slice 2/5)
+
+Branch: `builder/ga-9h05hk-1`
+
+Base checked: `origin/main` at `2a1185fc6b1c364cb9beb70dfd64fb042ef9d920`
+
+Head checked before gate commit: `e40471397f70044024db76aea0ea19b28f002bf6`
+
+Project manifest note: `docs/PROJECT_MANIFEST.md` is not present in this repository or the city management repo. This gate applies the deployer prompt's six release criteria plus the repo guidance in `TESTING.md`.
+
+## Gate Summary
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-wm69vw` notes contain reviewer verdict `PASS - routing to gascity/deployer`. Review findings are informational only. |
+| 2 | Acceptance criteria met | PASS | Source bead `ga-9h05hk` is closed. Pinned SQL, timeout value, skip reason, force-blocker kind, interface method, production probe, pure planner helper, fatal blocker helper, run-stage wiring, and all five test names are present. Documented deviations were reviewer-approved: timeout is a test-overridable `var`, two compile-only fake methods were added, and two `internal/api` lint fixes are included. |
+| 3 | Tests pass | PASS | Focused cleanup tests, `internal/api`, vet, build, dashboard check, and the sharded fast baseline passed. See test evidence below. |
+| 4 | No high-severity review findings open | PASS | Review notes list only `info` observations; no HIGH or request-changes findings are open. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` showed only `## builder/ga-9h05hk-1...fork/builder/ga-9h05hk-1` before adding this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` exited 0 and produced tree `12171949ef15327b233f0d8b6114e1f2476d60cf`. Diff against `origin/main...HEAD` is the expected 10 files / 774 insertions / 4 deletions. |
+
+## Acceptance Evidence
+
+- `cleanupLiveSessionProbeQuery` exists in `cmd/gc/dolt_cleanup_drop.go` and matches the pinned SQL string exactly.
+- `cleanupLiveSessionProbeTimeout` is `2 * time.Second`; reviewer accepted `var` instead of `const` so the timeout test can run quickly.
+- `DropSkipReasonLiveSession = "live-session"` exists in `cmd/gc/dolt_cleanup_drop_planner.go`.
+- `cleanupErrorKindLiveSessionProbeFailed = "live-session-probe-failed"` exists in `cmd/gc/cmd_dolt_cleanup.go`.
+- `CleanupDoltClient` includes `ProbeLiveSessions(ctx context.Context) (map[string]int, error)`.
+- `*sqlCleanupDoltClient.ProbeLiveSessions` issues the pinned query and returns `map[string]int`.
+- `applyLiveSessionsToPlan` is pure and rewrites `ToDrop` into `Skipped[reason=live-session]` in input order.
+- `hasFatalForceBlocker` gates the `--force` exit-1 path for live-session probe failure.
+- `runDropStage` probes after `planDoltDrops` and before dry-run/drop branches.
+- All five pinned tests exist and pass:
+  - `TestProbeLiveSessions_HealthyServer`
+  - `TestProbeLiveSessions_TimesOut`
+  - `TestProbeLiveSessions_FailClosed`
+  - `TestProbeLiveSessions_DryRunSurvivesFailure`
+  - `TestProbeLiveSessions_RemovesFromToDrop`
+- Out-of-scope surfaces remain absent: no `CleanupReport.LiveSessions`, no audit-log writes, no bash forwarder changes, no human-rendering special case, and no slice-5 regression test.
+
+## Test Evidence
+
+| Command | Result | Notes |
+|---------|--------|-------|
+| `go test ./cmd/gc -run 'TestProbeLiveSessions|TestRunDoltCleanup|TestPlanDoltDrops' -count=1` | PASS | `ok github.com/gastownhall/gascity/cmd/gc 1.986s` |
+| `go test ./internal/api/... -count=1` | PASS | `internal/api` and `internal/api/genclient` passed. |
+| `go vet ./...` | PASS | No output. |
+| `go build ./...` | PASS | No output. |
+| `make dashboard-check` | PASS | OpenAPI TS generation, Vite build, typecheck, and dashboard package tests passed; no generated-file drift. |
+| `make test-fast-parallel` | PASS | All fast jobs passed: `unit-core`, `unit-cmd-gc-1-of-6` through `unit-cmd-gc-6-of-6`, and `fsys-darwin-compile`. |
+
+Diagnostic note: a raw non-sharded `go test -timeout=240s ./cmd/gc/... ./internal/api/... -count=1` timed out in `TestCmdStopMarginExhaustion`. The isolated test passed immediately with `go test ./cmd/gc -run '^TestCmdStopMarginExhaustion$' -count=1 -v` (`PASS`, 1.59s). `TESTING.md` directs broad local sweeps to `make test-fast-parallel`, which passed.
+
+## Branch Evidence
+
+- `git diff --name-only origin/main...HEAD`:
+  - `cmd/gc/cmd_dolt_cleanup.go`
+  - `cmd/gc/dolt_cleanup_drop.go`
+  - `cmd/gc/dolt_cleanup_drop_planner.go`
+  - `cmd/gc/dolt_cleanup_drop_test.go`
+  - `cmd/gc/dolt_cleanup_human_test.go`
+  - `cmd/gc/dolt_cleanup_purge_test.go`
+  - `docs/plans/dolt-cleanup-live-session-probe.md`
+  - `docs/plans/dolt-port-resolve-helper.md`
+  - `internal/api/client.go`
+  - `internal/api/response_cache.go`
+
+- Commits before this gate:
+  - `0b4ab5b6f` docs(plans): decompose ga-u0lx9p + ga-lyv6d4 into builder beads (ga-rq2e5a, ga-9h05hk)
+  - `d2e707aa9` fix(lint): inline reflect.Ptr -> reflect.Pointer (govet)
+  - `e40471397` feat(dolt-cleanup): live-session SHOW PROCESSLIST probe + fail-closed (ga-nw4z6 slice 2/5)
+
+## Result
+
+PASS. The branch is ready for PR creation.


### PR DESCRIPTION
## What this changes

`gc dolt-cleanup` now checks Dolt's `information_schema.processlist` before it performs destructive cleanup. A stale-looking database with an active session is removed from the drop list and reported as skipped with reason `live-session`, so an operator can see that the database was protected by the live-session oracle.

When the live-session probe fails in `--force` mode, cleanup fails closed: it records a `live-session-probe-failed` force blocker, skips drop/purge/reap, and exits non-zero. Dry-run mode still shows the would-be drop plan plus the visible blocker, without performing destructive work.

## Review notes

- No new `CleanupReport.LiveSessions` JSON field, audit-log writes, bash forwarder behavior, or human-renderer special case are included here.
- The probe timeout remains `2 * time.Second`; it is test-overridable so the timeout test can run quickly, and the fail-closed test pins the production value.
- The small `internal/api` changes are vet/lint cleanups from `reflect.Ptr` to `reflect.Pointer`; they do not change API routes or schema.
- The release gate records the full acceptance checklist and branch/test evidence.

## Test plan

- [x] `go test ./cmd/gc -run 'TestProbeLiveSessions|TestRunDoltCleanup|TestPlanDoltDrops' -count=1`
- [x] `go test ./internal/api/... -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make dashboard-check`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-wm69vw-gate.md`](release-gates/ga-wm69vw-gate.md)