### PR TITLE
Declare open JSON passthrough schemas

### DIFF
--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -191,6 +191,36 @@ func TestJSONContractAllowsBdPassthrough(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaManifestForBdPassthrough(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"bd", "--json-schema"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(bd --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var manifest struct {
+		Command       []string                   `json:"command"`
+		Transport     string                     `json:"transport"`
+		JSONSupported bool                       `json:"json_supported"`
+		Schemas       map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got := strings.Join(manifest.Command, " "); got != "bd" {
+		t.Fatalf("command = %q, want bd", got)
+	}
+	if !manifest.JSONSupported || manifest.Transport != "jsonl" {
+		t.Fatalf("manifest metadata = %+v", manifest)
+	}
+	if !json.Valid(manifest.Schemas["result"]) || !json.Valid(manifest.Schemas["failure"]) {
+		t.Fatalf("manifest schemas = %+v", manifest.Schemas)
+	}
+}
+
 func TestJSONContractResolvesCommandWithInterspersedBooleanFlags(t *testing.T) {
 	schemaDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(schemaDir, "result.schema.json"), []byte(`{

--- a/schemas/bd/result.schema.json
+++ b/schemas/bd/result.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Open schema for gc bd --json passthrough output. The payload is owned by the bd CLI, not gc.",
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- adds schema-level transport metadata so open schemas can mark JSON passthrough surfaces without command-specific hard-coding
- declares `gc bd --json` as an open external JSON passthrough schema discoverable via `--json-schema`
- pins discovered pack/custom command behavior for open passthrough schemas

## Validation
- `git diff --check`
- `go test ./cmd/gc -run '^TestJSON' -count=1`
- `make fmt-check`
- `make vet`
- `make check-docs`

## Skips / blocked
- `GOOS=linux make lint` was attempted three times but `golangci-lint` refused to run because another repo worker had an active parallel `golangci-lint run ./...` lock.

## Risks
- passthrough schemas intentionally leave stdout unbuffered so gc does not wrap external JSON failures and risk mixing envelopes with external output.
- pack/custom commands must still opt in with explicit `schemas/result.schema.json`; this does not auto-declare arbitrary custom commands as JSON-capable.

