### PR TITLE
feat: add JSON for native management actions

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -441,6 +441,7 @@ have moved to "gc session" and "gc runtime".`,
 func newAgentAddCmd(stdout, stderr io.Writer) *cobra.Command {
 	var name, promptTemplate, dir string
 	var suspended bool
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "add --name <name>",
 		Short: "Add an agent scaffold",
@@ -459,6 +460,19 @@ agent in a suspended state.`,
   gc agent add --name worker --prompt-template ./worker.md --suspended`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if jsonOutput {
+				if cmdAgentAdd(name, promptTemplate, dir, suspended, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				resultName, qualifiedName := agentJSONName(name, dir)
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:       commandName("agent", "add"),
+					Action:        "add",
+					Name:          resultName,
+					QualifiedName: qualifiedName,
+					Suspended:     managementBoolPtr(suspended),
+				})
+			}
 			if cmdAgentAdd(name, promptTemplate, dir, suspended, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -469,6 +483,7 @@ agent in a suspended state.`,
 	cmd.Flags().StringVar(&promptTemplate, "prompt-template", "", "Path to prompt template file (relative to city root)")
 	cmd.Flags().StringVar(&dir, "dir", "", "Working directory for the agent (relative to city root)")
 	cmd.Flags().BoolVar(&suspended, "suspended", false, "Register the agent in suspended state")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
 	return cmd
 }
 
@@ -564,7 +579,8 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 }
 
 func newAgentSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "suspend <name>",
 		Short: "Suspend an agent (reconciler will skip it)",
 		Long: `Suspend an agent by setting suspended=true in its durable config.
@@ -574,12 +590,26 @@ started or restarted. Existing sessions continue running but won't be
 replaced if they exit. Use "gc agent resume" to restore.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdAgentSuspend(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:       commandName("agent", "suspend"),
+					Action:        "suspend",
+					Name:          args[0],
+					QualifiedName: args[0],
+					Suspended:     managementBoolPtr(true),
+				})
+			}
 			if cmdAgentSuspend(args, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdAgentSuspend is the CLI entry point for suspending an agent.
@@ -618,7 +648,8 @@ func doAgentSuspend(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 }
 
 func newAgentResumeCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "resume <name>",
 		Short: "Resume a suspended agent",
 		Long: `Resume a suspended agent by clearing suspended in its durable config.
@@ -627,12 +658,26 @@ The reconciler will start the agent on its next tick. Supports bare
 names (resolved via rig context) and qualified names (e.g. "myrig/worker").`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdAgentResume(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:       commandName("agent", "resume"),
+					Action:        "resume",
+					Name:          args[0],
+					QualifiedName: args[0],
+					Suspended:     managementBoolPtr(false),
+				})
+			}
 			if cmdAgentResume(args, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdAgentResume is the CLI entry point for resuming a suspended agent.

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -594,11 +594,17 @@ replaced if they exit. Use "gc agent resume" to restore.`,
 				if cmdAgentSuspend(args, io.Discard, stderr) != 0 {
 					return errExit
 				}
+				cityPath, err := resolveCity()
+				if err != nil {
+					fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				name, qualifiedName := agentJSONIdentity(cityPath, args[0])
 				return writeManagementActionJSON(stdout, managementActionResult{
 					Command:       commandName("agent", "suspend"),
 					Action:        "suspend",
-					Name:          args[0],
-					QualifiedName: args[0],
+					Name:          name,
+					QualifiedName: qualifiedName,
 					Suspended:     managementBoolPtr(true),
 				})
 			}
@@ -662,11 +668,17 @@ names (resolved via rig context) and qualified names (e.g. "myrig/worker").`,
 				if cmdAgentResume(args, io.Discard, stderr) != 0 {
 					return errExit
 				}
+				cityPath, err := resolveCity()
+				if err != nil {
+					fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				name, qualifiedName := agentJSONIdentity(cityPath, args[0])
 				return writeManagementActionJSON(stdout, managementActionResult{
 					Command:       commandName("agent", "resume"),
 					Action:        "resume",
-					Name:          args[0],
-					QualifiedName: args[0],
+					Name:          name,
+					QualifiedName: qualifiedName,
 					Suspended:     managementBoolPtr(false),
 				})
 			}

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -65,6 +65,7 @@ func newRigAddCmd(stdout, stderr io.Writer) *cobra.Command {
 	var prefixFlag string
 	var defaultBranchFlag string
 	var adoptFlag bool
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "add <path>",
 		Short: "Register a project as a rig",
@@ -99,6 +100,26 @@ Skips beads init; the git repo check remains informational.`,
   gc rig add /path/to/existing --adopt`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				cityPath, err := resolveCity()
+				if err != nil {
+					fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				if len(args) < 1 {
+					fmt.Fprintln(stderr, "gc rig add: missing path") //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				rigPath, err := resolveRigAddPath(cityPath, args[0])
+				if err != nil {
+					fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				if doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, rigAddJSONSummary(cityPath, rigPath, nameFlag, prefixFlag))
+			}
 			if cmdRigAdd(args, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -111,6 +132,7 @@ Skips beads init; the git repo check remains informational.`,
 	cmd.Flags().StringVar(&defaultBranchFlag, "default-branch", "", "mainline branch (default: auto-detect from origin/HEAD or current branch)")
 	cmd.Flags().BoolVar(&startSuspended, "start-suspended", false, "add rig in suspended state (dormant-by-default)")
 	cmd.Flags().BoolVar(&adoptFlag, "adopt", false, "adopt existing .beads/ directory (skip init)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
 	return cmd
 }
 
@@ -972,7 +994,8 @@ func rigBeadsStatus(fs fsys.FS, dir string) string {
 }
 
 func newRigSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "suspend [name]",
 		Short: "Suspend a rig (reconciler will skip its agents)",
 		Long: `Suspend a rig by setting suspended=true in city.toml.
@@ -982,6 +1005,24 @@ the reconciler skips them and gc hook returns empty. The rig's beads
 database remains accessible. Use "gc rig resume" to restore.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				rigName := ""
+				if len(args) > 0 {
+					rigName = args[0]
+				} else if ctx, err := resolveContext(); err == nil {
+					rigName = ctx.RigName
+				}
+				if cmdRigSuspend(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:   commandName("rig", "suspend"),
+					Action:    "suspend",
+					Name:      rigName,
+					Rig:       rigName,
+					Suspended: managementBoolPtr(true),
+				})
+			}
 			if cmdRigSuspend(args, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -989,6 +1030,8 @@ database remains accessible. Use "gc rig resume" to restore.`,
 		},
 		ValidArgsFunction: completeRigNames,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdRigSuspend is the CLI entry point for suspending a rig.
@@ -1055,7 +1098,8 @@ func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer
 }
 
 func newRigResumeCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "resume [name]",
 		Short: "Resume a suspended rig",
 		Long: `Resume a suspended rig by clearing suspended in city.toml.
@@ -1063,6 +1107,24 @@ func newRigResumeCmd(stdout, stderr io.Writer) *cobra.Command {
 The reconciler will start the rig's agents on its next tick.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				rigName := ""
+				if len(args) > 0 {
+					rigName = args[0]
+				} else if ctx, err := resolveContext(); err == nil {
+					rigName = ctx.RigName
+				}
+				if cmdRigResume(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:   commandName("rig", "resume"),
+					Action:    "resume",
+					Name:      rigName,
+					Rig:       rigName,
+					Suspended: managementBoolPtr(false),
+				})
+			}
 			if cmdRigResume(args, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -1070,6 +1132,8 @@ The reconciler will start the rig's agents on its next tick.`,
 		},
 		ValidArgsFunction: completeRigNames,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdRigResume is the CLI entry point for resuming a suspended rig.
@@ -1136,7 +1200,8 @@ func doRigResume(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer)
 }
 
 func newRigRemoveCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "remove <name>",
 		Short: "Remove a rig from the city",
 		Long: `Remove a rig from the current city's configuration.
@@ -1146,6 +1211,17 @@ binding from .gc/site.toml.`,
 		Example: `  gc rig remove myrig`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdRigRemove(args[0], io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command: commandName("rig", "remove"),
+					Action:  "remove",
+					Name:    args[0],
+					Rig:     args[0],
+				})
+			}
 			if cmdRigRemove(args[0], stdout, stderr) != 0 {
 				return errExit
 			}
@@ -1153,6 +1229,8 @@ binding from .gc/site.toml.`,
 		},
 		ValidArgsFunction: completeRigNames,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdRigRemove removes a rig from the current city and its local site binding.

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -115,10 +115,11 @@ Skips beads init; the git repo check remains informational.`,
 					fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
 					return errExit
 				}
-				if doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, io.Discard, stderr) != 0 {
+				rig, code := doRigAddWithResult(fsys.OSFS{}, cityPath, rigPath, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, io.Discard, stderr)
+				if code != 0 {
 					return errExit
 				}
-				return writeManagementActionJSON(stdout, rigAddJSONSummary(cityPath, rigPath, nameFlag, prefixFlag))
+				return writeManagementActionJSON(stdout, rigAddJSONSummary(rigPath, rig))
 			}
 			if cmdRigAdd(args, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, stdout, stderr) != 0 {
 				return errExit
@@ -202,6 +203,11 @@ func resolveRigAddPath(cityPath, rigArg string) (string, error) {
 // This prevents partial-state bugs where city.toml lists a rig but the rig's
 // infrastructure (beads, routes) was never created.
 func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverride, prefixOverride, defaultBranchOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) int {
+	_, code := doRigAddWithResult(fs, cityPath, rigPath, includes, nameOverride, prefixOverride, defaultBranchOverride, startSuspended, adopt, stdout, stderr)
+	return code
+}
+
+func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverride, prefixOverride, defaultBranchOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) (config.Rig, int) {
 	// Trim and drop empty --include entries so `--include=` or `--include " "`
 	// doesn't persist a blank pack path that downstream resolution reads
 	// as the city root.
@@ -217,15 +223,15 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if fi, err := fs.Stat(rigPath); err != nil {
 		if adopt {
 			fmt.Fprintf(stderr, "gc rig add: --adopt requires an existing directory: %s\n", rigPath) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		if !os.IsNotExist(err) {
 			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", rigPath, err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 	} else if !fi.IsDir() {
 		fmt.Fprintf(stderr, "gc rig add: %s is not a directory\n", rigPath) //nolint:errcheck // best-effort stderr
-		return 1
+		return config.Rig{}, 1
 	} else {
 		rigPathExists = true
 	}
@@ -247,7 +253,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig add: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return config.Rig{}, 1
 	}
 	explicitRigImports := boundImportsFromLegacySources(includes, cfg.Packs)
 	if cityUsesBdStoreContract(cityPath) && cityDoltConfigHasLifecycleFields(cfg.Dolt) {
@@ -275,7 +281,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		}
 		if filepath.Clean(existPath) != filepath.Clean(rigPath) {
 			fmt.Fprintf(stderr, "gc rig add: rig %q already registered at %s (not %s)\n", name, r.Path, rigPath) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		reAdd = true
 		break
@@ -295,12 +301,12 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		prefixKey := strings.ToLower(prefix)
 		if prefixKey == strings.ToLower(config.EffectiveHQPrefix(cfg)) {
 			fmt.Fprintf(stderr, "gc rig add: rig %q: prefix %q collides with HQ. Use --prefix to specify a different prefix.\n", name, prefixKey) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		for _, rig := range cfg.Rigs {
 			if prefixKey == strings.ToLower(rig.EffectivePrefix()) {
 				fmt.Fprintf(stderr, "gc rig add: rig %q: prefix %q collides with %s. Use --prefix to specify a different prefix.\n", name, prefixKey, rig.Name) //nolint:errcheck // best-effort stderr
-				return 1
+				return config.Rig{}, 1
 			}
 		}
 	}
@@ -340,7 +346,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 			rootDefaultRigImports, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
 			if err != nil {
 				fmt.Fprintf(stderr, "gc rig add: loading root pack defaults: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1
+				return config.Rig{}, 1
 			}
 			defaultRigImports = composeDefaultRigImports(rootDefaultRigImports, cfg.Workspace.LegacyDefaultRigIncludes(), cfg.Packs)
 			if len(defaultRigImports) > 0 {
@@ -354,14 +360,14 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if needsValidation {
 		if err := config.ValidateRigs(nextCfg.Rigs, config.EffectiveHQPrefix(nextCfg)); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 
 	if !rigPathExists {
 		if err := fs.MkdirAll(rigPath, 0o755); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: creating %s: %v\n", rigPath, err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 
@@ -369,11 +375,11 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		metaPath := filepath.Join(rigPath, ".beads", "metadata.json")
 		if _, err := fs.Stat(metaPath); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: --adopt requires .beads/metadata.json in %s\n", rigPath) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		if _, ok := readBeadsPrefix(fs, rigPath); !ok {
 			fmt.Fprintf(stderr, "gc rig add: --adopt requires a valid issue_prefix in .beads/config.yaml in %s\n", rigPath) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 
@@ -397,7 +403,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 				"use --prefix %s to match, or remove %s/.beads to reinitialize\n",
 				name, existingPrefix, prefix, existingPrefix, rigPath)
 		}
-		return 1
+		return config.Rig{}, 1
 	}
 
 	// Guard: on a fresh add (not a re-add) without --adopt, refuse to run
@@ -410,13 +416,13 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		fi, err := fs.Stat(beadsPath)
 		if err != nil && !os.IsNotExist(err) {
 			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", beadsPath, err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		if err == nil && fi.IsDir() {
 			fmt.Fprintf(stderr, "gc rig add: %s/.beads already exists; "+ //nolint:errcheck // best-effort stderr
 				"use --adopt to register the existing store, or remove %s/.beads to reinitialize\n",
 				rigPath, rigPath)
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 
@@ -468,7 +474,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if adopt {
 		if err := prepareRigAdoptProviderState(cityPath, rigPath); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: prepare adopted rig store: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		w("  Adopted existing beads database")
 	}
@@ -478,7 +484,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		deferred, err = initDirIfReady(cityPath, rigPath, prefix)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		if deferred {
 			if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
@@ -496,17 +502,17 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	snapshots, err := snapshotRigAddTopologyFiles(fs, cityPath, nextCfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig add: snapshot canonical files: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return config.Rig{}, 1
 	}
 	if !reAdd || reAddNeedsConfigWrite {
 		if err := normalizeCanonicalBdScopeFiles(cityPath, nextCfg, io.Discard); err != nil {
 			writeRigAddRollbackError(fs, stderr, snapshots, "canonicalizing rig topology", err)
-			return 1
+			return config.Rig{}, 1
 		}
 
 		if err := writeCityConfigForEditFS(fs, tomlPath, nextCfg); err != nil {
 			writeRigAddRollbackError(fs, stderr, snapshots, "writing config", err)
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 	cfg = nextCfg
@@ -514,7 +520,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	allRigs := collectRigRoutes(cityPath, cfg)
 	if err := writeAllRigRoutes(allRigs); err != nil {
 		writeRigAddRollbackError(fs, stderr, snapshots, "writing routes", err)
-		return 1
+		return config.Rig{}, 1
 	}
 	w("  Generated routes.jsonl for cross-rig routing")
 
@@ -565,7 +571,18 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	default:
 		w("Rig added.")
 	}
-	return 0
+	for _, rig := range cfg.Rigs {
+		if rig.Name == name {
+			return rig, 0
+		}
+	}
+	return config.Rig{
+		Name:          name,
+		Path:          rigPath,
+		Prefix:        strings.ToLower(prefixOverride),
+		DefaultBranch: resolvedDefaultBranch,
+		Suspended:     startSuspended,
+	}, 0
 }
 
 func formatBoundImports(imports []config.BoundImport) string {

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -39,6 +39,7 @@ var verifyRigExternalEndpoint = verifyExternalDoltEndpoint
 
 func newRigSetEndpointCmd(stdout, stderr io.Writer) *cobra.Command {
 	var opts rigEndpointOptions
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "set-endpoint <rig>",
 		Short: "Set the canonical endpoint ownership for a rig",
@@ -59,6 +60,19 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
   gc rig set-endpoint frontend --inherit --dry-run`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdRigSetEndpoint(args[0], opts, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:  commandName("rig", "set-endpoint"),
+					Action:   "set-endpoint",
+					Name:     args[0],
+					Rig:      args[0],
+					DryRun:   opts.DryRun,
+					Endpoint: rigEndpointJSONFromOptions(opts),
+				})
+			}
 			if cmdRigSetEndpoint(args[0], opts, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -75,6 +89,7 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 	cmd.Flags().StringVar(&opts.User, "user", "", "external Dolt user")
 	cmd.Flags().BoolVar(&opts.AdoptUnverified, "adopt-unverified", false, "record the endpoint without live validation")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "show the canonical changes without writing files")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
 	return cmd
 }
 

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -61,7 +61,8 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
-				if cmdRigSetEndpoint(args[0], opts, io.Discard, stderr) != 0 {
+				endpointState, code := cmdRigSetEndpointWithResult(args[0], opts, io.Discard, stderr)
+				if code != 0 {
 					return errExit
 				}
 				return writeManagementActionJSON(stdout, managementActionResult{
@@ -69,8 +70,8 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 					Action:   "set-endpoint",
 					Name:     args[0],
 					Rig:      args[0],
-					DryRun:   opts.DryRun,
-					Endpoint: rigEndpointJSONFromOptions(opts),
+					DryRun:   managementBoolPtr(opts.DryRun),
+					Endpoint: rigEndpointJSONFromState(opts, endpointState),
 				})
 			}
 			if cmdRigSetEndpoint(args[0], opts, stdout, stderr) != 0 {
@@ -94,26 +95,37 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 }
 
 func cmdRigSetEndpoint(rigName string, opts rigEndpointOptions, stdout, stderr io.Writer) int {
+	_, code := cmdRigSetEndpointWithResult(rigName, opts, stdout, stderr)
+	return code
+}
+
+func cmdRigSetEndpointWithResult(rigName string, opts rigEndpointOptions, stdout, stderr io.Writer) (contract.ConfigState, int) {
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
-	return doRigSetEndpoint(fsys.OSFS{}, cityPath, rigName, opts, stdout, stderr)
+	return doRigSetEndpointWithResult(fsys.OSFS{}, cityPath, rigName, opts, stdout, stderr)
 }
 
 //nolint:unparam // FS seam is intentional for command tests
 func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOptions, stdout, stderr io.Writer) int {
+	_, code := doRigSetEndpointWithResult(fs, cityPath, rigName, opts, stdout, stderr)
+	return code
+}
+
+//nolint:unparam // FS seam is intentional for command tests
+func doRigSetEndpointWithResult(fs fsys.FS, cityPath, rigName string, opts rigEndpointOptions, stdout, stderr io.Writer) (contract.ConfigState, int) {
 	if err := validateRigEndpointOptions(opts); err != nil {
 		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig set-endpoint: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 	persistCfg := *cfg
 	persistCfg.Rigs = append([]config.Rig(nil), cfg.Rigs...)
@@ -122,7 +134,7 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 	rig, ok := rigByName(cfg, rigName)
 	if !ok {
 		fmt.Fprintln(stderr, rigNotFoundMsg("gc rig set-endpoint", rigName, cfg)) //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 	if strings.TrimSpace(rig.Path) == "" {
 		// Unbound rig: the downstream helpers join paths against rig.Path
@@ -131,40 +143,40 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 		// relative `.beads/...` writes under the current working directory
 		// instead of erroring cleanly.
 		fmt.Fprintf(stderr, "gc rig set-endpoint: rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it before setting its endpoint\n", rig.Name, rig.Name) //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 	if !scopeUsesManagedBdStoreContract(cityPath, rig.Path) {
 		fmt.Fprintln(stderr, "gc rig set-endpoint: only supported for bd-backed beads providers") //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 
 	cityState, err := resolveOwnerCityConfigState(cityPath, cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 	currentState, err := resolveOwnerRigConfigState(cityPath, rig, cityState)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 
 	targetState := requestedRigEndpointState(rig, currentState, cityState, opts)
 
 	if opts.Self && cityState.EndpointOrigin == contract.EndpointOriginManagedCity && !opts.Force {
 		fmt.Fprintf(stderr, "gc rig set-endpoint: --self conflicts with managed_city: the rig's .beads/dolt-server.port mirror will stop tracking the managed city Dolt and any rig-local Dolt must be started and managed independently of `gc start`. Re-run with --force to acknowledge.\n") //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 
 	if opts.DryRun {
 		printRigEndpointDryRun(stdout, rig, currentState, targetState)
-		return 0
+		return targetState, 0
 	}
 
 	if opts.Inherit && cityState.EndpointOrigin == contract.EndpointOriginManagedCity {
 		if _, err := readManagedRuntimePublishedPort(cityPath); err != nil {
 			fmt.Fprintf(stderr, "gc rig set-endpoint: managed city endpoint unavailable: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return contract.ConfigState{}, 1
 		}
 	}
 
@@ -172,7 +184,7 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 		if err := verifyRigExternalEndpoint(targetState, rig.Path, rig.Path); err != nil {
 			fmt.Fprintf(stderr, "gc rig set-endpoint: validate endpoint: %v\n", err)                                               //nolint:errcheck // best-effort stderr
 			fmt.Fprintf(stderr, "gc rig set-endpoint: rerun with --adopt-unverified to record this endpoint without validation\n") //nolint:errcheck // best-effort stderr
-			return 1
+			return contract.ConfigState{}, 1
 		}
 		targetState.EndpointStatus = contract.EndpointStatusVerified
 	}
@@ -184,27 +196,27 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 	snapshots, err := snapshotRigEndpointFiles(fs, cityPath, rig.Path)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig set-endpoint: snapshot canonical files: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return contract.ConfigState{}, 1
 	}
 	if err := ensureCanonicalScopeMetadataIfPresent(fs, rig.Path); err != nil {
 		writeRigEndpointRollbackError(fs, stderr, snapshots, "canonicalizing metadata", err)
-		return 1
+		return contract.ConfigState{}, 1
 	}
 	if err := ensureCanonicalScopeConfig(fs, rig.Path, targetState); err != nil {
 		writeRigEndpointRollbackError(fs, stderr, snapshots, "writing canonical config", err)
-		return 1
+		return contract.ConfigState{}, 1
 	}
 	if err := syncRigEndpointCompatConfig(fs, cityPath, &persistCfg, rigName, targetState); err != nil {
 		writeRigEndpointRollbackError(fs, stderr, snapshots, "syncing compat city config", err)
-		return 1
+		return contract.ConfigState{}, 1
 	}
 	if err := syncRigManagedPortArtifact(cityPath, rig.Path, cityState, targetState); err != nil {
 		writeRigEndpointRollbackError(fs, stderr, snapshots, "syncing managed port artifact", err)
-		return 1
+		return contract.ConfigState{}, 1
 	}
 
 	printRigEndpointResult(stdout, rig, targetState)
-	return 0
+	return targetState, 0
 }
 
 func validateRigEndpointOptions(opts rigEndpointOptions) error {

--- a/cmd/gc/cmd_service.go
+++ b/cmd/gc/cmd_service.go
@@ -97,7 +97,8 @@ func cmdServiceDoctor(name string, stdout, stderr io.Writer) int {
 }
 
 func newServiceRestartCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "restart <name>",
 		Short: "Restart a workspace service",
 		Long: `Stop and restart a workspace service by name.
@@ -106,12 +107,24 @@ The controller closes the current service process and starts a fresh one.
 Useful after updating pack scripts without a full city restart.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdServiceRestart(args[0], io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command: commandName("service", "restart"),
+					Action:  "restart",
+					Name:    args[0],
+				})
+			}
 			if cmdServiceRestart(args[0], stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 func cmdServiceRestart(name string, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -110,31 +110,59 @@ func newWaitInspectCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func newWaitCancelCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "cancel <wait-id>",
 		Short: "Cancel a wait",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdWaitSetState(args[0], waitStateCanceled, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command: commandName("wait", "cancel"),
+					Action:  "cancel",
+					Name:    args[0],
+					State:   waitStateCanceled,
+				})
+			}
 			if cmdWaitSetState(args[0], waitStateCanceled, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 func newWaitReadyCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "ready <wait-id>",
 		Short: "Manually mark a wait ready",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdWaitSetState(args[0], waitStateReady, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command: commandName("wait", "ready"),
+					Action:  "ready",
+					Name:    args[0],
+					State:   waitStateReady,
+				})
+			}
 			if cmdWaitSetState(args[0], waitStateReady, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep bool, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -34,6 +34,13 @@ const (
 	waitStateFailed   = "failed"
 )
 
+type waitSetStateResult struct {
+	WaitID      string
+	ReadyWaitID string
+	Retried     bool
+	RetriedFrom string
+}
+
 func newWaitCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wait",
@@ -117,13 +124,14 @@ func newWaitCancelCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
-				if cmdWaitSetState(args[0], waitStateCanceled, io.Discard, stderr) != 0 {
+				result, code := cmdWaitSetStateResult(args[0], waitStateCanceled, io.Discard, stderr)
+				if code != 0 {
 					return errExit
 				}
 				return writeManagementActionJSON(stdout, managementActionResult{
 					Command: commandName("wait", "cancel"),
 					Action:  "cancel",
-					Name:    args[0],
+					Name:    result.WaitID,
 					State:   waitStateCanceled,
 				})
 			}
@@ -145,15 +153,22 @@ func newWaitReadyCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
-				if cmdWaitSetState(args[0], waitStateReady, io.Discard, stderr) != 0 {
+				result, code := cmdWaitSetStateResult(args[0], waitStateReady, io.Discard, stderr)
+				if code != 0 {
 					return errExit
 				}
-				return writeManagementActionJSON(stdout, managementActionResult{
+				payload := managementActionResult{
 					Command: commandName("wait", "ready"),
 					Action:  "ready",
-					Name:    args[0],
+					Name:    result.WaitID,
 					State:   waitStateReady,
-				})
+				}
+				if result.Retried {
+					payload.Retried = managementBoolPtr(true)
+					payload.RetriedFrom = result.RetriedFrom
+					payload.ReadyWaitID = result.ReadyWaitID
+				}
+				return writeManagementActionJSON(stdout, payload)
 			}
 			if cmdWaitSetState(args[0], waitStateReady, stdout, stderr) != 0 {
 				return errExit
@@ -458,23 +473,29 @@ func writeWaitInspectJSON(stdout, stderr io.Writer, cityPath string, wait beads.
 }
 
 func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
+	_, code := cmdWaitSetStateResult(waitID, state, stdout, stderr)
+	return code
+}
+
+func cmdWaitSetStateResult(waitID, state string, stdout, stderr io.Writer) (waitSetStateResult, int) {
+	result := waitSetStateResult{WaitID: waitID}
 	store, code := openCityStore(stderr, "gc wait")
 	if store == nil {
-		return code
+		return result, code
 	}
 	b, err := store.Get(waitID)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-		return 1
+		return result, 1
 	}
 	if !sessionpkg.IsWaitBead(b) {
 		fmt.Fprintf(stderr, "gc wait: %s is not a wait\n", waitID) //nolint:errcheck
-		return 1
+		return result, 1
 	}
 	if state == waitStateReady {
 		if err := waitLifecycleEnabled(); err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-			return 1
+			return result, 1
 		}
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -482,10 +503,14 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 		retried, err := retryClosedWait(store, b, now)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-			return 1
+			return result, 1
 		}
 		fmt.Fprintf(stdout, "Retried wait %s as %s.\n", waitID, retried.ID) //nolint:errcheck
-		return 0
+		result.WaitID = retried.ID
+		result.ReadyWaitID = retried.ID
+		result.Retried = true
+		result.RetriedFrom = waitID
+		return result, 0
 	}
 	batch := map[string]string{"state": state}
 	switch state {
@@ -494,7 +519,7 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 		nextAttempt, err := nextWaitDeliveryAttempt(store, b)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-			return 1
+			return result, 1
 		}
 		if nextAttempt != "" {
 			batch["delivery_attempt"] = nextAttempt
@@ -517,22 +542,22 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 	}
 	if err := apply(waitID, batch); err != nil {
 		fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-		return 1
+		return result, 1
 	}
 	if state == waitStateCanceled {
 		if cityPath, err := resolveCity(); err == nil {
 			if err := withdrawQueuedWaitNudges(cityPath, []string{b.Metadata["nudge_id"]}); err != nil {
 				fmt.Fprintf(stderr, "gc wait: withdrawing queued nudge: %v\n", err) //nolint:errcheck
-				return 1
+				return result, 1
 			}
 		}
 		if err := clearSessionWaitHoldIfIdle(store, b.Metadata["session_id"]); err != nil {
 			fmt.Fprintf(stderr, "gc wait: clearing session wait hold: %v\n", err) //nolint:errcheck
-			return 1
+			return result, 1
 		}
 	}
 	fmt.Fprintf(stdout, "Updated wait %s to %s.\n", waitID, state) //nolint:errcheck
-	return 0
+	return result, 0
 }
 
 func loadWaitBeads(store beads.Store) ([]beads.Bead, error) {

--- a/cmd/gc/management_json.go
+++ b/cmd/gc/management_json.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+type managementActionResult struct {
+	SchemaVersion string           `json:"schema_version"`
+	OK            bool             `json:"ok"`
+	Command       string           `json:"command"`
+	Action        string           `json:"action"`
+	Name          string           `json:"name,omitempty"`
+	QualifiedName string           `json:"qualified_name,omitempty"`
+	Rig           string           `json:"rig,omitempty"`
+	Path          string           `json:"path,omitempty"`
+	Prefix        string           `json:"prefix,omitempty"`
+	DefaultBranch string           `json:"default_branch,omitempty"`
+	Suspended     *bool            `json:"suspended,omitempty"`
+	State         string           `json:"state,omitempty"`
+	DryRun        bool             `json:"dry_run,omitempty"`
+	Endpoint      *rigEndpointJSON `json:"endpoint,omitempty"`
+}
+
+type rigEndpointJSON struct {
+	Mode            string `json:"mode"`
+	Host            string `json:"host,omitempty"`
+	Port            string `json:"port,omitempty"`
+	User            string `json:"user,omitempty"`
+	AdoptUnverified bool   `json:"adopt_unverified,omitempty"`
+}
+
+func writeManagementActionJSON(stdout io.Writer, result managementActionResult) error {
+	result.SchemaVersion = "1"
+	result.OK = true
+	return writeCLIJSONLine(stdout, result)
+}
+
+func managementBoolPtr(v bool) *bool {
+	return &v
+}
+
+func commandName(parts ...string) string {
+	return strings.Join(parts, " ")
+}
+
+func agentJSONName(input, dir string) (name, qualified string) {
+	inputDir, inputName := config.ParseQualifiedName(input)
+	if inputDir != "" {
+		dir = inputDir
+		name = inputName
+	} else {
+		name = input
+	}
+	if strings.TrimSpace(dir) != "" {
+		qualified = dir + "/" + name
+	} else {
+		qualified = name
+	}
+	return name, qualified
+}
+
+func rigAddJSONSummary(cityPath, rigPath, nameOverride, prefixOverride string) managementActionResult {
+	name := strings.TrimSpace(nameOverride)
+	if name == "" {
+		name = filepath.Base(rigPath)
+	}
+	result := managementActionResult{
+		Command: commandName("rig", "add"),
+		Action:  "add",
+		Name:    name,
+		Rig:     name,
+		Path:    rigPath,
+		Prefix:  strings.ToLower(strings.TrimSpace(prefixOverride)),
+	}
+	if cfg, err := loadCityConfigForEditFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); err == nil {
+		for _, rig := range cfg.Rigs {
+			if rig.Name != name {
+				continue
+			}
+			result.Prefix = rig.EffectivePrefix()
+			result.DefaultBranch = rig.EffectiveDefaultBranch()
+			result.Suspended = managementBoolPtr(rig.Suspended)
+			break
+		}
+	}
+	if result.Prefix == "" {
+		result.Prefix = config.DeriveBeadsPrefix(name)
+	}
+	return result
+}
+
+func rigEndpointJSONFromOptions(opts rigEndpointOptions) *rigEndpointJSON {
+	endpoint := &rigEndpointJSON{AdoptUnverified: opts.AdoptUnverified}
+	switch {
+	case opts.Inherit:
+		endpoint.Mode = "inherit"
+	case opts.Self:
+		endpoint.Mode = "self"
+		endpoint.Host = "127.0.0.1"
+		endpoint.Port = strings.TrimSpace(opts.Port)
+	case opts.External:
+		endpoint.Mode = "external"
+		endpoint.Host = strings.TrimSpace(opts.Host)
+		endpoint.Port = strings.TrimSpace(opts.Port)
+		endpoint.User = strings.TrimSpace(opts.User)
+	}
+	return endpoint
+}

--- a/cmd/gc/management_json.go
+++ b/cmd/gc/management_json.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 type managementActionResult struct {
@@ -22,7 +22,10 @@ type managementActionResult struct {
 	DefaultBranch string           `json:"default_branch,omitempty"`
 	Suspended     *bool            `json:"suspended,omitempty"`
 	State         string           `json:"state,omitempty"`
-	DryRun        bool             `json:"dry_run,omitempty"`
+	Retried       *bool            `json:"retried,omitempty"`
+	RetriedFrom   string           `json:"retried_from_wait,omitempty"`
+	ReadyWaitID   string           `json:"ready_wait_id,omitempty"`
+	DryRun        *bool            `json:"dry_run,omitempty"`
 	Endpoint      *rigEndpointJSON `json:"endpoint,omitempty"`
 }
 
@@ -64,29 +67,24 @@ func agentJSONName(input, dir string) (name, qualified string) {
 	return name, qualified
 }
 
-func rigAddJSONSummary(cityPath, rigPath, nameOverride, prefixOverride string) managementActionResult {
-	name := strings.TrimSpace(nameOverride)
+func agentJSONIdentity(cityPath, input string) (name, qualified string) {
+	return agentJSONName(resolveAgentForAPI(cityPath, input), "")
+}
+
+func rigAddJSONSummary(rigPath string, rig config.Rig) managementActionResult {
+	name := strings.TrimSpace(rig.Name)
 	if name == "" {
 		name = filepath.Base(rigPath)
 	}
 	result := managementActionResult{
-		Command: commandName("rig", "add"),
-		Action:  "add",
-		Name:    name,
-		Rig:     name,
-		Path:    rigPath,
-		Prefix:  strings.ToLower(strings.TrimSpace(prefixOverride)),
-	}
-	if cfg, err := loadCityConfigForEditFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); err == nil {
-		for _, rig := range cfg.Rigs {
-			if rig.Name != name {
-				continue
-			}
-			result.Prefix = rig.EffectivePrefix()
-			result.DefaultBranch = rig.EffectiveDefaultBranch()
-			result.Suspended = managementBoolPtr(rig.Suspended)
-			break
-		}
+		Command:       commandName("rig", "add"),
+		Action:        "add",
+		Name:          name,
+		Rig:           name,
+		Path:          rigPath,
+		Prefix:        rig.EffectivePrefix(),
+		DefaultBranch: rig.EffectiveDefaultBranch(),
+		Suspended:     managementBoolPtr(rig.Suspended),
 	}
 	if result.Prefix == "" {
 		result.Prefix = config.DeriveBeadsPrefix(name)
@@ -94,20 +92,22 @@ func rigAddJSONSummary(cityPath, rigPath, nameOverride, prefixOverride string) m
 	return result
 }
 
-func rigEndpointJSONFromOptions(opts rigEndpointOptions) *rigEndpointJSON {
-	endpoint := &rigEndpointJSON{AdoptUnverified: opts.AdoptUnverified}
+func rigEndpointJSONFromState(opts rigEndpointOptions, state contract.ConfigState) *rigEndpointJSON {
+	endpoint := &rigEndpointJSON{
+		AdoptUnverified: state.EndpointStatus == contract.EndpointStatusUnverified,
+	}
 	switch {
-	case opts.Inherit:
+	case opts.Inherit || state.EndpointOrigin == contract.EndpointOriginInheritedCity:
 		endpoint.Mode = "inherit"
 	case opts.Self:
 		endpoint.Mode = "self"
-		endpoint.Host = "127.0.0.1"
-		endpoint.Port = strings.TrimSpace(opts.Port)
-	case opts.External:
+	default:
 		endpoint.Mode = "external"
-		endpoint.Host = strings.TrimSpace(opts.Host)
-		endpoint.Port = strings.TrimSpace(opts.Port)
-		endpoint.User = strings.TrimSpace(opts.User)
+	}
+	if endpoint.Mode != "inherit" {
+		endpoint.Host = strings.TrimSpace(state.DoltHost)
+		endpoint.Port = strings.TrimSpace(state.DoltPort)
+		endpoint.User = strings.TrimSpace(state.DoltUser)
 	}
 	return endpoint
 }

--- a/cmd/gc/management_json_test.go
+++ b/cmd/gc/management_json_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManagementJSONTestCity(t *testing.T, cityPath string, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCityToml(t, cityPath, body)
+	writePackToml(t, cityPath, "[pack]\nname = \"test-city\"\nschema = 2\n")
+}
+
+func decodeOneJSONLine(t *testing.T, stdout *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	return payload
+}
+
+func TestAgentAddJSONEmitsOnlySummary(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityPath, "agent", "add", "--name", "worker", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run agent add --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	payload := decodeOneJSONLine(t, &stdout)
+	if payload["schema_version"] != "1" || payload["ok"] != true || payload["command"] != "agent add" || payload["name"] != "worker" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if strings.Contains(stdout.String(), "Scaffolded agent") {
+		t.Fatalf("stdout contains human text: %q", stdout.String())
+	}
+}
+
+func TestRigSuspendResumeRemoveJSONEmitOnlySummaries(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"frontend\"\nprefix = \"fe\"\n")
+
+	for _, tc := range []struct {
+		args      []string
+		command   string
+		action    string
+		suspended any
+	}{
+		{[]string{"rig", "suspend", "frontend", "--json"}, "rig suspend", "suspend", true},
+		{[]string{"rig", "resume", "frontend", "--json"}, "rig resume", "resume", false},
+		{[]string{"rig", "remove", "frontend", "--json"}, "rig remove", "remove", nil},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := run(append([]string{"--city", cityPath}, tc.args...), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run %v = %d; stderr=%q stdout=%q", tc.args, code, stderr.String(), stdout.String())
+		}
+		payload := decodeOneJSONLine(t, &stdout)
+		if payload["schema_version"] != "1" || payload["ok"] != true || payload["command"] != tc.command || payload["action"] != tc.action || payload["rig"] != "frontend" {
+			t.Fatalf("%v payload = %+v", tc.args, payload)
+		}
+		if tc.suspended != nil && payload["suspended"] != tc.suspended {
+			t.Fatalf("%v suspended = %v, want %v", tc.args, payload["suspended"], tc.suspended)
+		}
+	}
+}
+
+func TestRigAddJSONEmitsOnlySummary(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+	rigPath := filepath.Join(t.TempDir(), "frontend")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityPath, "rig", "add", rigPath, "--prefix", "fe", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run rig add --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	payload := decodeOneJSONLine(t, &stdout)
+	if payload["schema_version"] != "1" || payload["ok"] != true || payload["command"] != "rig add" || payload["rig"] != "frontend" || payload["prefix"] != "fe" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if strings.Contains(stdout.String(), "Adding rig") || strings.Contains(stdout.String(), "Rig added") {
+		t.Fatalf("stdout contains human text: %q", stdout.String())
+	}
+}
+
+func TestManagementJSONSchemasDeclared(t *testing.T) {
+	commands := [][]string{
+		{"agent", "add"},
+		{"agent", "suspend"},
+		{"agent", "resume"},
+		{"rig", "add"},
+		{"rig", "suspend"},
+		{"rig", "resume"},
+		{"rig", "remove"},
+		{"rig", "set-endpoint"},
+		{"wait", "cancel"},
+		{"wait", "ready"},
+		{"service", "restart"},
+	}
+	for _, command := range commands {
+		args := append(append([]string{}, command...), "--json-schema=result")
+		var stdout, stderr bytes.Buffer
+		code := run(args, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run %v = %d; stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+			t.Fatalf("%v schema is not JSON: %v\n%s", command, err, stdout.String())
+		}
+		if schema["$schema"] == "" {
+			t.Fatalf("%v schema missing $schema: %+v", command, schema)
+		}
+	}
+}

--- a/cmd/gc/management_json_test.go
+++ b/cmd/gc/management_json_test.go
@@ -3,10 +3,18 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 func writeManagementJSONTestCity(t *testing.T, cityPath string, body string) {
@@ -31,6 +39,50 @@ func decodeOneJSONLine(t *testing.T, stdout *bytes.Buffer) map[string]any {
 	return payload
 }
 
+func validateManagementJSONPayload(t *testing.T, command []string, stdout *bytes.Buffer) map[string]any {
+	t.Helper()
+	payload := decodeOneJSONLine(t, stdout)
+	schemaRaw, err := readBuiltinSchema(command, jsonSchemaResultRole)
+	if err != nil {
+		t.Fatalf("read schema for %v: %v", command, err)
+	}
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaRaw))
+	if err != nil {
+		t.Fatalf("parse schema for %v: %v", command, err)
+	}
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Fatalf("parse payload for %v: %v\n%s", command, err, stdout.String())
+	}
+	compiler := jsonschema.NewCompiler()
+	schemaURL := strings.Join(command, "/") + "/result.schema.json"
+	if err := compiler.AddResource(schemaURL, schemaDoc); err != nil {
+		t.Fatalf("add schema resource for %v: %v", command, err)
+	}
+	compiled, err := compiler.Compile(schemaURL)
+	if err != nil {
+		t.Fatalf("compile schema for %v: %v", command, err)
+	}
+	if err := compiled.Validate(instance); err != nil {
+		t.Fatalf("payload for %v does not validate: %v\n%s", command, err, stdout.String())
+	}
+	return payload
+}
+
+func runManagementJSONPayload(t *testing.T, cityPath string, args ...string) map[string]any {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := run(append([]string{"--city", cityPath}, args...), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run %v = %d; stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+	}
+	if len(args) < 2 {
+		t.Fatalf("management JSON command needs at least two command words: %v", args)
+	}
+	command := args[:2]
+	return validateManagementJSONPayload(t, command, &stdout)
+}
+
 func TestAgentAddJSONEmitsOnlySummary(t *testing.T) {
 	clearGCEnv(t)
 	cityPath := t.TempDir()
@@ -47,6 +99,246 @@ func TestAgentAddJSONEmitsOnlySummary(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "Scaffolded agent") {
 		t.Fatalf("stdout contains human text: %q", stdout.String())
+	}
+}
+
+func TestManagementJSONSuccessPayloadsValidateDeclaredSchemas(t *testing.T) {
+	type testCase struct {
+		name  string
+		setup func(t *testing.T) (cityPath string, args []string)
+		check func(t *testing.T, payload map[string]any)
+	}
+	tests := []testCase{
+		{
+			name: "agent add",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := t.TempDir()
+				writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+				return cityPath, []string{"agent", "add", "--name", "worker", "--json"}
+			},
+		},
+		{
+			name: "agent suspend",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONAgentCity(t, false)
+				return cityPath, []string{"agent", "suspend", "frontend/worker", "--json"}
+			},
+		},
+		{
+			name: "agent resume",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONAgentCity(t, true)
+				return cityPath, []string{"agent", "resume", "frontend/worker", "--json"}
+			},
+		},
+		{
+			name: "rig add",
+			setup: func(t *testing.T) (string, []string) {
+				t.Setenv("GC_DOLT", "skip")
+				t.Setenv("GC_BEADS", "bd")
+				cityPath := t.TempDir()
+				writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+				return cityPath, []string{"rig", "add", filepath.Join(t.TempDir(), "frontend"), "--prefix", "fe", "--json"}
+			},
+		},
+		{
+			name: "rig suspend",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONRigCity(t)
+				return cityPath, []string{"rig", "suspend", "frontend", "--json"}
+			},
+		},
+		{
+			name: "rig resume",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONRigCity(t)
+				return cityPath, []string{"rig", "resume", "frontend", "--json"}
+			},
+		},
+		{
+			name: "rig remove",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONRigCity(t)
+				return cityPath, []string{"rig", "remove", "frontend", "--json"}
+			},
+		},
+		{
+			name: "rig set-endpoint",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONRigEndpointCity(t)
+				return cityPath, []string{"rig", "set-endpoint", "frontend", "--self", "--port", "28232", "--force", "--json"}
+			},
+			check: func(t *testing.T, payload map[string]any) {
+				if got, ok := payload["dry_run"].(bool); !ok || got {
+					t.Fatalf("dry_run = %#v, want false", payload["dry_run"])
+				}
+			},
+		},
+		{
+			name: "wait cancel",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath, waitID := writeManagementJSONWaitCity(t, waitStatePending)
+				return cityPath, []string{"wait", "cancel", waitID, "--json"}
+			},
+		},
+		{
+			name: "wait ready",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath, waitID := writeManagementJSONWaitCity(t, waitStatePending)
+				return cityPath, []string{"wait", "ready", waitID, "--json"}
+			},
+		},
+		{
+			name: "service restart",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONServiceCity(t)
+				return cityPath, []string{"service", "restart", "review-intake", "--json"}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearGCEnv(t)
+			cityPath, args := tt.setup(t)
+			payload := runManagementJSONPayload(t, cityPath, args...)
+			if tt.check != nil {
+				tt.check(t, payload)
+			}
+		})
+	}
+}
+
+func TestAgentSuspendResumeJSONReportsResolvedIdentity(t *testing.T) {
+	tests := []struct {
+		name             string
+		action           string
+		input            string
+		initialSuspended bool
+		chdirRig         bool
+		wantName         string
+		wantQualified    string
+	}{
+		{
+			name:          "qualified input keeps leaf name",
+			action:        "suspend",
+			input:         "frontend/worker",
+			wantName:      "worker",
+			wantQualified: "frontend/worker",
+		},
+		{
+			name:             "bare input with rig context qualifies",
+			action:           "resume",
+			input:            "worker",
+			initialSuspended: true,
+			chdirRig:         true,
+			wantName:         "worker",
+			wantQualified:    "frontend/worker",
+		},
+		{
+			name:             "unqualified city agent remains city scoped",
+			action:           "resume",
+			input:            "citywide",
+			initialSuspended: true,
+			wantName:         "citywide",
+			wantQualified:    "citywide",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearGCEnv(t)
+			cityPath := writeManagementJSONAgentCity(t, tt.initialSuspended)
+			if tt.chdirRig {
+				t.Chdir(filepath.Join(cityPath, "frontend"))
+			}
+			payload := runManagementJSONPayload(t, cityPath, "agent", tt.action, tt.input, "--json")
+			if payload["name"] != tt.wantName || payload["qualified_name"] != tt.wantQualified {
+				t.Fatalf("identity = (%#v, %#v), want (%q, %q): %+v",
+					payload["name"], payload["qualified_name"], tt.wantName, tt.wantQualified, payload)
+			}
+		})
+	}
+}
+
+func TestWaitReadyJSONReportsClosedWaitRetryIdentity(t *testing.T) {
+	clearGCEnv(t)
+	cityPath, waitID := writeManagementJSONWaitCity(t, waitStateCanceled)
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	if err := store.Close(waitID); err != nil {
+		t.Fatalf("close wait: %v", err)
+	}
+
+	payload := runManagementJSONPayload(t, cityPath, "wait", "ready", waitID, "--json")
+	if payload["retried"] != true {
+		t.Fatalf("retried = %#v, want true: %+v", payload["retried"], payload)
+	}
+	replacement, ok := payload["ready_wait_id"].(string)
+	if !ok || replacement == "" || replacement == waitID {
+		t.Fatalf("ready_wait_id = %#v, want replacement different from %q: %+v", payload["ready_wait_id"], waitID, payload)
+	}
+	if payload["name"] != replacement {
+		t.Fatalf("name = %#v, want replacement %q: %+v", payload["name"], replacement, payload)
+	}
+	original, err := store.Get(waitID)
+	if err != nil {
+		t.Fatalf("get original wait: %v", err)
+	}
+	if original.Status != "closed" {
+		t.Fatalf("original status = %q, want closed", original.Status)
+	}
+	created, err := store.Get(replacement)
+	if err != nil {
+		t.Fatalf("get replacement wait %q: %v", replacement, err)
+	}
+	if created.Metadata["state"] != waitStateReady || created.Metadata["retried_from_wait"] != waitID {
+		t.Fatalf("replacement metadata = %+v", created.Metadata)
+	}
+}
+
+func TestRigSetEndpointJSONReportsResolvedExistingUser(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(t.TempDir(), "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRigEndpointCityConfig(t, cityPath, rigPath)
+	writePackToml(t, cityPath, "[pack]\nname = \"test-city\"\nschema = 2\n")
+	writeRigEndpointMetadata(t, cityPath, "hq")
+	writeRigEndpointMetadata(t, rigPath, "fe")
+	writeRigEndpointRuntimeState(t, cityPath, 3311)
+	writeRigEndpointCanonicalConfig(t, rigPath, contract.ConfigState{
+		IssuePrefix:    "fe",
+		EndpointOrigin: contract.EndpointOriginExplicit,
+		EndpointStatus: contract.EndpointStatusVerified,
+		DoltHost:       "old-db.example.com",
+		DoltPort:       "3307",
+		DoltUser:       "rig-user",
+	})
+
+	origVerify := verifyRigExternalEndpoint
+	t.Cleanup(func() { verifyRigExternalEndpoint = origVerify })
+	verifyRigExternalEndpoint = func(state contract.ConfigState, _, _ string) error {
+		if state.DoltUser != "rig-user" {
+			t.Fatalf("state.DoltUser = %q, want %q", state.DoltUser, "rig-user")
+		}
+		return nil
+	}
+
+	payload := runManagementJSONPayload(t, cityPath, "rig", "set-endpoint", "frontend", "--external", "--host", "new-db.example.com", "--port", "4406", "--json")
+	endpoint, ok := payload["endpoint"].(map[string]any)
+	if !ok {
+		t.Fatalf("endpoint = %#v, want object: %+v", payload["endpoint"], payload)
+	}
+	if endpoint["mode"] != "external" || endpoint["host"] != "new-db.example.com" || endpoint["port"] != "4406" || endpoint["user"] != "rig-user" {
+		t.Fatalf("endpoint = %+v, want resolved persisted endpoint with user", endpoint)
+	}
+	if got := readRigEndpointConfigState(t, rigPath).DoltUser; got != "rig-user" {
+		t.Fatalf("persisted DoltUser = %q, want %q", got, "rig-user")
 	}
 }
 
@@ -82,6 +374,145 @@ func TestRigSuspendResumeRemoveJSONEmitOnlySummaries(t *testing.T) {
 			t.Fatalf("%v suspended = %v, want %v", tc.args, payload["suspended"], tc.suspended)
 		}
 	}
+}
+
+func writeManagementJSONAgentCity(t *testing.T, workerSuspended bool) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workerSuspendedLine := ""
+	if workerSuspended {
+		workerSuspendedLine = "suspended = true\n"
+	}
+	writeManagementJSONTestCity(t, cityPath, fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "frontend"
+path = %q
+prefix = "fe"
+
+[[agent]]
+name = "worker"
+dir = "frontend"
+%s
+[[agent]]
+name = "citywide"
+%s`, rigPath, workerSuspendedLine, workerSuspendedLine))
+	return cityPath
+}
+
+func writeManagementJSONRigCity(t *testing.T) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeManagementJSONTestCity(t, cityPath, fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "frontend"
+path = %q
+prefix = "fe"
+`, rigPath))
+	return cityPath
+}
+
+func writeManagementJSONRigEndpointCity(t *testing.T) string {
+	t.Helper()
+	t.Setenv("GC_BEADS", "bd")
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(t.TempDir(), "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRigEndpointCityConfig(t, cityPath, rigPath)
+	writePackToml(t, cityPath, "[pack]\nname = \"test-city\"\nschema = 2\n")
+	writeRigEndpointMetadata(t, cityPath, "hq")
+	writeRigEndpointMetadata(t, rigPath, "fe")
+	writeRigEndpointRuntimeState(t, cityPath, 3311)
+	writeRigEndpointCanonicalConfig(t, rigPath, contract.ConfigState{
+		IssuePrefix:    "fe",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "dolt-server.port"), []byte("3311\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	origVerify := verifyRigExternalEndpoint
+	t.Cleanup(func() { verifyRigExternalEndpoint = origVerify })
+	verifyRigExternalEndpoint = func(contract.ConfigState, string, string) error { return nil }
+	return cityPath
+}
+
+func writeManagementJSONWaitCity(t *testing.T, state string) (string, string) {
+	t.Helper()
+	t.Setenv("GC_BEADS", "file")
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+	if err := ensurePersistedScopeLocalFileStore(cityPath); err != nil {
+		t.Fatalf("initialize file store: %v", err)
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	wait, err := store.Create(beads.Bead{
+		Title:       "wait:test-session",
+		Type:        waitBeadType,
+		Description: "test wait",
+		Labels:      []string{waitBeadLabel},
+		Metadata: map[string]string{
+			"session_id":       "",
+			"kind":             "deps",
+			"state":            state,
+			"dep_ids":          "dep-test",
+			"dep_mode":         "all",
+			"delivery_attempt": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+	return cityPath, wait.ID
+}
+
+func writeManagementJSONServiceCity(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v0/city/test-city/service/review-intake/restart" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","action":"restart","service":"review-intake"}`))
+	}))
+	t.Cleanup(server.Close)
+	host, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split test server address: %v", err)
+	}
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[api]
+bind = %q
+port = %s
+
+[[service]]
+name = "review-intake"
+
+[service.workflow]
+contract = "gc.healthz.v1"
+`, host, port))
+	startFakeControllerSocket(t, cityPath, "1234\n")
+	return cityPath
 }
 
 func TestRigAddJSONEmitsOnlySummary(t *testing.T) {

--- a/contrib/k8s/Dockerfile.mail
+++ b/contrib/k8s/Dockerfile.mail
@@ -16,7 +16,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
+    libcap2 \
     libnghttp2-14 \
+    libsystemd0 \
+    libudev1 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY .github/requirements/mcp-agent-mail.txt /tmp/requirements-mcp-agent-mail.txt

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -115,6 +115,7 @@ gc agent add --name mayor
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--dir` | string |  | Working directory for the agent (relative to city root) |
+| `--json` | bool |  | Output in JSONL format |
 | `--name` | string |  | Name of the agent |
 | `--prompt-template` | string |  | Path to prompt template file (relative to city root) |
 | `--suspended` | bool |  | Register the agent in suspended state |
@@ -127,8 +128,12 @@ The reconciler will start the agent on its next tick. Supports bare
 names (resolved via rig context) and qualified names (e.g. "myrig/worker").
 
 ```
-gc agent resume <name>
+gc agent resume <name> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc agent suspend
 
@@ -139,8 +144,12 @@ started or restarted. Existing sessions continue running but won't be
 replaced if they exit. Use "gc agent resume" to restore.
 
 ```
-gc agent suspend <name>
+gc agent suspend <name> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc analyze
 
@@ -2088,6 +2097,7 @@ gc rig add /path/to/project
 | `--adopt` | bool |  | adopt existing .beads/ directory (skip init) |
 | `--default-branch` | string |  | mainline branch (default: auto-detect from origin/HEAD or current branch) |
 | `--include` | stringArray |  | pack source for rig agents (repeatable; writes canonical rig imports) |
+| `--json` | bool |  | Output in JSONL format |
 | `--name` | string |  | rig name (default: directory basename) |
 | `--prefix` | string |  | bead ID prefix (default: derived from name) |
 | `--start-suspended` | bool |  | add rig in suspended state (dormant-by-default) |
@@ -2116,7 +2126,7 @@ Removes the rig entry from city.toml and removes its machine-local path
 binding from .gc/site.toml.
 
 ```
-gc rig remove <name>
+gc rig remove <name> [flags]
 ```
 
 **Example:**
@@ -2124,6 +2134,10 @@ gc rig remove <name>
 ```
 gc rig remove myrig
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc rig restart
 
@@ -2143,8 +2157,12 @@ Resume a suspended rig by clearing suspended in city.toml.
 The reconciler will start the rig's agents on its next tick.
 
 ```
-gc rig resume [name]
+gc rig resume [name] [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc rig set-endpoint
 
@@ -2181,6 +2199,7 @@ gc rig set-endpoint frontend --inherit
 | `--force` | bool |  | acknowledge conflicting managed-city state when using --self |
 | `--host` | string |  | external Dolt host |
 | `--inherit` | bool |  | inherit the city endpoint |
+| `--json` | bool |  | Output in JSONL format |
 | `--port` | string |  | external Dolt port (required with --external or --self) |
 | `--self` | bool |  | mark the rig as running its own local Dolt on 127.0.0.1 |
 | `--user` | string |  | external Dolt user |
@@ -2202,8 +2221,12 @@ the reconciler skips them and gc hook returns empty. The rig's beads
 database remains accessible. Use "gc rig resume" to restore.
 
 ```
-gc rig suspend [name]
+gc rig suspend [name] [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc runtime
 
@@ -2339,8 +2362,12 @@ The controller closes the current service process and starts a fresh one.
 Useful after updating pack scripts without a full city restart.
 
 ```
-gc service restart <name>
+gc service restart <name> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc session
 
@@ -3151,8 +3178,12 @@ gc wait
 Cancel a wait
 
 ```
-gc wait cancel <wait-id>
+gc wait cancel <wait-id> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc wait inspect
 
@@ -3185,5 +3216,9 @@ gc wait list [flags]
 Manually mark a wait ready
 
 ```
-gc wait ready <wait-id>
+gc wait ready <wait-id> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pb33f/libopenapi v0.36.1
 	github.com/pb33f/libopenapi-validator v0.13.4
 	github.com/rogpeppe/go-internal v1.14.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -65,7 +66,6 @@ require (
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/schemas/agent/add/result.schema.json
+++ b/schemas/agent/add/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "qualified_name", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "agent add" },
+    "action": { "const": "add" },
+    "name": { "type": "string" },
+    "qualified_name": { "type": "string" },
+    "suspended": { "type": "boolean" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/agent/resume/result.schema.json
+++ b/schemas/agent/resume/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "qualified_name", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "agent resume" },
+    "action": { "const": "resume" },
+    "name": { "type": "string" },
+    "qualified_name": { "type": "string" },
+    "suspended": { "const": false }
+  },
+  "additionalProperties": true
+}

--- a/schemas/agent/suspend/result.schema.json
+++ b/schemas/agent/suspend/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "qualified_name", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "agent suspend" },
+    "action": { "const": "suspend" },
+    "name": { "type": "string" },
+    "qualified_name": { "type": "string" },
+    "suspended": { "const": true }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/add/result.schema.json
+++ b/schemas/rig/add/result.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig", "path", "prefix"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig add" },
+    "action": { "const": "add" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "path": { "type": "string" },
+    "prefix": { "type": "string" },
+    "default_branch": { "type": "string" },
+    "suspended": { "type": "boolean" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/remove/result.schema.json
+++ b/schemas/rig/remove/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig remove" },
+    "action": { "const": "remove" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/resume/result.schema.json
+++ b/schemas/rig/resume/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig resume" },
+    "action": { "const": "resume" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "suspended": { "const": false }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/set-endpoint/result.schema.json
+++ b/schemas/rig/set-endpoint/result.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig", "dry_run", "endpoint"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig set-endpoint" },
+    "action": { "const": "set-endpoint" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "dry_run": { "type": "boolean" },
+    "endpoint": {
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "mode": { "enum": ["inherit", "external", "self"] },
+        "host": { "type": "string" },
+        "port": { "type": "string" },
+        "user": { "type": "string" },
+        "adopt_unverified": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/suspend/result.schema.json
+++ b/schemas/rig/suspend/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig suspend" },
+    "action": { "const": "suspend" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "suspended": { "const": true }
+  },
+  "additionalProperties": true
+}

--- a/schemas/service/restart/result.schema.json
+++ b/schemas/service/restart/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "service restart" },
+    "action": { "const": "restart" },
+    "name": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/wait/cancel/result.schema.json
+++ b/schemas/wait/cancel/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "state"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "wait cancel" },
+    "action": { "const": "cancel" },
+    "name": { "type": "string" },
+    "state": { "const": "canceled" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/wait/ready/result.schema.json
+++ b/schemas/wait/ready/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "state"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "wait ready" },
+    "action": { "const": "ready" },
+    "name": { "type": "string" },
+    "state": { "const": "ready" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/wait/ready/result.schema.json
+++ b/schemas/wait/ready/result.schema.json
@@ -8,6 +8,9 @@
     "command": { "const": "wait ready" },
     "action": { "const": "ready" },
     "name": { "type": "string" },
+    "retried": { "type": "boolean" },
+    "retried_from_wait": { "type": "string" },
+    "ready_wait_id": { "type": "string" },
     "state": { "const": "ready" }
   },
   "additionalProperties": true


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- add bounded `--json` success summaries for native management actions: `agent add/suspend/resume`, `rig add/suspend/resume/remove/set-endpoint`, `wait cancel/ready`, and `service restart`
- add result schemas under `schemas/<command-path>/result.schema.json`, using the shared failure schema
- keep default human output on the existing command paths by routing JSON mode through thin wrappers around the same command behavior

## Coverage
- JSON stdout-only summary tests for `agent add`, `rig add`, and `rig suspend/resume/remove`
- schema declaration coverage for all touched command paths
- existing JSON schema platform tests included in targeted run

## Skips / posture
- No target command was skipped. `rig set-endpoint --dry-run` is treated as bounded and returns a dry-run JSON summary; failures still use the platform structured failure behavior.

## Validation
- `git diff --check`
- `make fmt-check`
- `go test ./cmd/gc -run 'TestAgentAddJSON|TestRigAddJSON|TestRigSuspendResumeRemoveJSON|TestManagementJSONSchemasDeclared|TestJSON'`
- `make vet`
- `make check-docs`
- `GOOS=linux make lint`

## Risks
- Success summaries are intentionally compact and open-schema; they report the bounded action result, not full post-mutation resource snapshots.
