### PR TITLE
Add warmup eligibility contract for doctor checks

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -266,6 +266,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 				FixScript: entry.FixScript,
 				PackDir:   entry.PackDir,
 				PackName:  entry.PackName,
+				Warmup:    entry.Warmup,
 			})
 		}
 	}

--- a/cmd/gc/doctor_warmup_eligible.go
+++ b/cmd/gc/doctor_warmup_eligible.go
@@ -1,0 +1,61 @@
+package main
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *codexHooksDriftCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *doltDriftCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *doltTopologyCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *importStateDoctorCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (*mcpConfigDoctorCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (*mcpSharedTargetDoctorCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *sessionModelDoctorCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *v2RoutedToNamespaceCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (v2AgentFormatCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (v2DefaultRigImportFormatCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (v2ImportFormatCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (v2PromptTemplateSuffixCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (v2RigPathSiteBindingCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (v2ScriptsLayoutCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (v2WorkspaceNameCheck) WarmupEligible() bool { return false }

--- a/cmd/gc/doctor_warmup_test.go
+++ b/cmd/gc/doctor_warmup_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func TestCommandDoctorChecksWarmupEligibleDefaultsFalse(t *testing.T) {
+	checks := []doctor.Check{
+		&codexHooksDriftCheck{},
+		&doltDriftCheck{},
+		&doltTopologyCheck{},
+		&importStateDoctorCheck{},
+		&mcpConfigDoctorCheck{},
+		&mcpSharedTargetDoctorCheck{},
+		&sessionModelDoctorCheck{},
+		&v2RoutedToNamespaceCheck{},
+		v2AgentFormatCheck{},
+		v2DefaultRigImportFormatCheck{},
+		v2ImportFormatCheck{},
+		v2PromptTemplateSuffixCheck{},
+		v2RigPathSiteBindingCheck{},
+		v2ScriptsLayoutCheck{},
+		v2WorkspaceNameCheck{},
+	}
+
+	for _, c := range checks {
+		t.Run(fmt.Sprintf("%T", c), func(t *testing.T) {
+			if c.WarmupEligible() {
+				t.Errorf("%T.WarmupEligible() = true, want false", c)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -914,6 +914,10 @@ type PackDoctorEntry struct {
 	// Fix is an optional path to a remediation script, relative to the pack
 	// directory. When set, the check opts into `gc doctor --fix`.
 	Fix string `toml:"fix,omitempty"`
+	// Warmup, when true, includes this check in the `gc start` warm-up
+	// scan. Default false. The check still runs on demand via `gc doctor`
+	// regardless of this flag.
+	Warmup bool `toml:"warmup,omitempty"`
 }
 
 // PackCommandEntry declares a CLI subcommand provided by a pack.

--- a/internal/config/doctor_discovery.go
+++ b/internal/config/doctor_discovery.go
@@ -24,12 +24,16 @@ type DiscoveredDoctor struct {
 	PackDir     string
 	PackName    string
 	BindingName string
+	// Warmup mirrors `doctor.toml`'s `warmup` field. False by default.
+	Warmup bool
 }
 
 type doctorManifest struct {
 	Description string `toml:"description"`
 	Run         string `toml:"run"`
 	Fix         string `toml:"fix"`
+	// Warmup opts this check into the `gc start` warm-up scan. Default false.
+	Warmup bool `toml:"warmup"`
 }
 
 func resolveContainedDoctorPath(kind, packDir, checkDir, relPath string) (string, error) {
@@ -101,6 +105,7 @@ func discoveredDoctorFromDir(fs fsys.FS, packDir, checkDir, name, packName strin
 	runRel := "run.sh"
 	description := ""
 	fixRel := ""
+	warmup := false
 
 	manifestPath := filepath.Join(checkDir, "doctor.toml")
 	if data, err := fs.ReadFile(manifestPath); err == nil {
@@ -115,6 +120,7 @@ func discoveredDoctorFromDir(fs fsys.FS, packDir, checkDir, name, packName strin
 		if manifest.Fix != "" {
 			fixRel = manifest.Fix
 		}
+		warmup = manifest.Warmup
 	}
 
 	runPath, err := resolveContainedDoctorRunPath(packDir, checkDir, runRel)
@@ -162,5 +168,6 @@ func discoveredDoctorFromDir(fs fsys.FS, packDir, checkDir, name, packName strin
 		SourceDir:   checkDir,
 		PackDir:     packDir,
 		PackName:    packName,
+		Warmup:      warmup,
 	}, true, nil
 }

--- a/internal/config/doctor_discovery_test.go
+++ b/internal/config/doctor_discovery_test.go
@@ -56,6 +56,61 @@ run = "../../shared/check.sh"
 	}
 }
 
+func TestDoctorManifestWarmupFieldParses(t *testing.T) {
+	cases := []struct {
+		name       string
+		manifest   string
+		wantWarmup bool
+	}{
+		{
+			name: "explicit_true",
+			manifest: `
+description = "Check that X exists"
+run = "check-x.sh"
+warmup = true
+`,
+			wantWarmup: true,
+		},
+		{
+			name: "explicit_false",
+			manifest: `
+description = "Check that X exists"
+run = "check-x.sh"
+warmup = false
+`,
+			wantWarmup: false,
+		},
+		{
+			name: "default_omitted",
+			manifest: `
+description = "Check that X exists"
+run = "check-x.sh"
+`,
+			wantWarmup: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			packDir := filepath.Join(dir, "mypk")
+			writeTestFile(t, packDir, "doctor/check-x/doctor.toml", tc.manifest)
+			writeTestFile(t, packDir, "doctor/check-x/check-x.sh", "#!/bin/sh\nexit 0\n")
+
+			got, err := DiscoverPackDoctors(fsys.OSFS{}, packDir, "mypk")
+			if err != nil {
+				t.Fatalf("DiscoverPackDoctors: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d checks, want 1", len(got))
+			}
+			if got[0].Warmup != tc.wantWarmup {
+				t.Errorf("Warmup = %v, want %v", got[0].Warmup, tc.wantWarmup)
+			}
+		})
+	}
+}
+
 func TestDiscoverPackDoctors_RejectsEscapingOrAbsoluteRunPaths(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "mypk")

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2088,6 +2088,7 @@ func legacyPackDoctors(fs fsys.FS, entries []PackDoctorEntry, packDir, packName 
 			SourceDir:   packDir,
 			PackDir:     packDir,
 			PackName:    packName,
+			Warmup:      entry.Warmup,
 		})
 	}
 	return out, nil

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3450,6 +3450,82 @@ script = "doctor/check2.sh"
 	}
 }
 
+func TestPackDoctorWarmupFlagParses(t *testing.T) {
+	cases := []struct {
+		name       string
+		toml       string
+		wantWarmup bool
+	}{
+		{
+			name: "explicit_true",
+			toml: `
+[pack]
+name = "warmup-pack"
+schema = 1
+
+[[doctor]]
+name = "check-x"
+script = "doctor/check-x.sh"
+warmup = true
+`,
+			wantWarmup: true,
+		},
+		{
+			name: "explicit_false",
+			toml: `
+[pack]
+name = "warmup-pack"
+schema = 1
+
+[[doctor]]
+name = "check-x"
+script = "doctor/check-x.sh"
+warmup = false
+`,
+			wantWarmup: false,
+		},
+		{
+			name: "default_omitted",
+			toml: `
+[pack]
+name = "warmup-pack"
+schema = 1
+
+[[doctor]]
+name = "check-x"
+script = "doctor/check-x.sh"
+`,
+			wantWarmup: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "pack.toml", tc.toml)
+
+			entries := LoadPackDoctorEntries(fsys.OSFS{}, []string{dir})
+			if len(entries) != 1 {
+				t.Fatalf("got %d entries, want 1", len(entries))
+			}
+			if entries[0].Entry.Warmup != tc.wantWarmup {
+				t.Fatalf("Entry.Warmup = %v, want %v", entries[0].Entry.Warmup, tc.wantWarmup)
+			}
+
+			doctors, err := legacyPackDoctors(fsys.OSFS{}, []PackDoctorEntry{entries[0].Entry}, dir, entries[0].PackName)
+			if err != nil {
+				t.Fatalf("legacyPackDoctors: %v", err)
+			}
+			if len(doctors) != 1 {
+				t.Fatalf("got %d synthesized doctors, want 1", len(doctors))
+			}
+			if doctors[0].Warmup != tc.wantWarmup {
+				t.Errorf("DiscoveredDoctor.Warmup = %v, want %v", doctors[0].Warmup, tc.wantWarmup)
+			}
+		})
+	}
+}
+
 func TestLegacyPackDoctorsRejectsEscapingFixPaths(t *testing.T) {
 	dir := t.TempDir()
 	tests := []struct {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -38,6 +38,72 @@ func (m *mockCheck) Fix(_ *CheckContext) error {
 	return nil
 }
 
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (m *mockCheck) WarmupEligible() bool { return false }
+
+func TestCheckWarmupEligibleDefaultsFalse(t *testing.T) {
+	checks := []Check{
+		&AgentSessionsCheck{},
+		&BDSplitStoreCheck{},
+		&BeadsRoleCheck{},
+		&BeadsStoreCheck{},
+		&BinaryCheck{},
+		&BuiltinPackFamilyCheck{},
+		&CityConfigCheck{},
+		&CityStructureCheck{},
+		&ConfigRefsCheck{},
+		&ConfigSemanticsCheck{},
+		&ConfigValidCheck{},
+		&ControllerCheck{},
+		&CustomTypesCheck{},
+		&DeprecatedAttachmentFieldsCheck{},
+		&DoltConfigCheck{},
+		&DoltNomsSizeCheck{},
+		&DoltServerCheck{},
+		&DoltVersionCheck{},
+		&DurationRangeCheck{},
+		&EventLogSizeCheck{},
+		&EventsLogCheck{},
+		&ImplicitImportCacheCheck{},
+		&NestedWorktreePruneCheck{},
+		&OrphanSessionsCheck{},
+		&PackCacheCheck{},
+		&PreStartScriptsCheck{},
+		&ProviderParityCheck{},
+		&RigBeadsCheck{},
+		&RigDoltServerCheck{},
+		&RigGitCheck{},
+		&RigPathCheck{},
+		&SkillCollisionCheck{},
+		&WorktreeCheck{},
+		&WorktreeDiskSizeCheck{},
+		&ZombieSessionsCheck{},
+	}
+
+	for _, c := range checks {
+		t.Run(fmt.Sprintf("%T", c), func(t *testing.T) {
+			if c.WarmupEligible() {
+				t.Errorf("%T.WarmupEligible() = true, want false", c)
+			}
+		})
+	}
+
+	t.Run("pack_script_check_default_false", func(t *testing.T) {
+		c := &PackScriptCheck{CheckName: "x:y"}
+		if c.WarmupEligible() {
+			t.Error("zero-value PackScriptCheck.WarmupEligible() = true, want false")
+		}
+	})
+
+	t.Run("pack_script_check_opted_in", func(t *testing.T) {
+		c := &PackScriptCheck{CheckName: "x:y", Warmup: true}
+		if !c.WarmupEligible() {
+			t.Error("PackScriptCheck{Warmup: true}.WarmupEligible() = false, want true")
+		}
+	})
+}
+
 func TestDoctor_AllPass(t *testing.T) {
 	d := &Doctor{}
 	d.Register(&mockCheck{name: "a", status: StatusOK, msg: "ok"})
@@ -248,6 +314,10 @@ func (c *detailCheck) Run(_ *CheckContext) *CheckResult {
 func (c *detailCheck) CanFix() bool              { return false }
 func (c *detailCheck) Fix(_ *CheckContext) error { return nil }
 
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *detailCheck) WarmupEligible() bool { return false }
+
 // hintCheck returns a failing result with a FixHint.
 type hintCheck struct{}
 
@@ -263,6 +333,10 @@ func (c *hintCheck) Run(_ *CheckContext) *CheckResult {
 func (c *hintCheck) CanFix() bool              { return false }
 func (c *hintCheck) Fix(_ *CheckContext) error { return nil }
 
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *hintCheck) WarmupEligible() bool { return false }
+
 type unchangedFixCheck struct{}
 
 func (c *unchangedFixCheck) Name() string { return "unchanged-fix" }
@@ -275,3 +349,7 @@ func (c *unchangedFixCheck) Run(_ *CheckContext) *CheckResult {
 }
 func (c *unchangedFixCheck) CanFix() bool              { return true }
 func (c *unchangedFixCheck) Fix(_ *CheckContext) error { return nil }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *unchangedFixCheck) WarmupEligible() bool { return false }

--- a/internal/doctor/pack_checks.go
+++ b/internal/doctor/pack_checks.go
@@ -41,6 +41,10 @@ type PackScriptCheck struct {
 	PackDir string
 	// PackName is the logical pack name used for runtime env injection.
 	PackName string
+	// Warmup, when true, opts this check into the `gc start` warm-up scan.
+	// Populated from pack.toml `[[doctor]] warmup = true` or from
+	// `doctor.toml`'s `warmup` field. Default false.
+	Warmup bool
 }
 
 // Name returns the check's fully-qualified name.
@@ -50,6 +54,10 @@ func (c *PackScriptCheck) Name() string { return c.CheckName }
 // When true, `gc doctor --fix` will dispatch to FixScript after the
 // check returns a non-OK status.
 func (c *PackScriptCheck) CanFix() bool { return c.FixScript != "" }
+
+// WarmupEligible reports whether this check opts into the `gc start`
+// warm-up scan. Reflects the pack manifest's `warmup` field.
+func (c *PackScriptCheck) WarmupEligible() bool { return c.Warmup }
 
 // Fix runs the pack's fix script with the same environment contract as
 // Run. Returns nil on exit 0 (remediation succeeded); returns an error

--- a/internal/doctor/pack_checks_test.go
+++ b/internal/doctor/pack_checks_test.go
@@ -207,6 +207,22 @@ func TestPackScriptCheckCanFixWithoutScript(t *testing.T) {
 	}
 }
 
+func TestPackScriptCheckWarmupEligibleReflectsField(t *testing.T) {
+	t.Run("default_false", func(t *testing.T) {
+		c := &PackScriptCheck{CheckName: "topo:diag-only"}
+		if c.WarmupEligible() {
+			t.Error("WarmupEligible() = true, want false")
+		}
+	})
+
+	t.Run("explicit_true", func(t *testing.T) {
+		c := &PackScriptCheck{CheckName: "topo:startup", Warmup: true}
+		if !c.WarmupEligible() {
+			t.Error("WarmupEligible() = false, want true")
+		}
+	})
+}
+
 func TestPackScriptCheckCanFixWithScript(t *testing.T) {
 	dir := t.TempDir()
 	fix := writeFixScript(t, dir, "#!/bin/sh\nexit 0\n")

--- a/internal/doctor/types.go
+++ b/internal/doctor/types.go
@@ -29,6 +29,12 @@ type Check interface {
 	// Fix attempts to automatically remediate the issue found by Run.
 	// Only called when CanFix returns true and Run returned a non-OK status.
 	Fix(ctx *CheckContext) error
+	// WarmupEligible reports whether this check should be included in
+	// `gc start`'s warm-up scan (in addition to running on demand via
+	// `gc doctor`). Default for all in-tree checks is false; opt in by
+	// returning true. Pack-declared checks opt in via `warmup = true`
+	// on the pack.toml [[doctor]] entry or doctor.toml manifest.
+	WarmupEligible() bool
 }
 
 // CheckContext carries shared state for all checks during a doctor run.

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -1,0 +1,141 @@
+package doctor
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *AgentSessionsCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *BDSplitStoreCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *BeadsRoleCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *BeadsStoreCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *BinaryCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *BuiltinPackFamilyCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *CityConfigCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *CityStructureCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *ConfigRefsCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *ConfigSemanticsCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *ConfigValidCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *ControllerCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *CustomTypesCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *DeprecatedAttachmentFieldsCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *DoltConfigCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *DoltNomsSizeCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *DoltServerCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *DoltVersionCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *DurationRangeCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *EventLogSizeCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *EventsLogCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *ImplicitImportCacheCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *NestedWorktreePruneCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *OrphanSessionsCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *PackCacheCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *PreStartScriptsCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *ProviderParityCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *RigBeadsCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *RigDoltServerCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *RigGitCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *RigPathCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *SkillCollisionCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *WorktreeCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *WorktreeDiskSizeCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
+func (c *ZombieSessionsCheck) WarmupEligible() bool { return false }

--- a/release-gates/ga-r1iqmy-warmup-eligible-interface-gate.md
+++ b/release-gates/ga-r1iqmy-warmup-eligible-interface-gate.md
@@ -1,0 +1,45 @@
+# Release Gate: WarmupEligible interface and pack manifest warmup field
+
+- Deploy bead: `ga-87u29d`
+- Source bead: `ga-r1iqmy`
+- Review bead: `ga-7y3a9a`
+- Branch: `builder/ga-r1iqmy-1`
+- Remote branch: `fork/builder/ga-r1iqmy-1`
+- Reviewed commit: `6c45ac86a feat(doctor): add warmup eligibility contract`
+- Note: `docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer role criteria and the source bead acceptance checklist.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-7y3a9a` shows closed review bead with `Reviewer verdict: PASS`. |
+| 2 | Acceptance criteria met | PASS | Checked source bead acceptance against code and tests; details below. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` completed with `All fast jobs passed`; `go vet ./...` exited 0. |
+| 4 | No high-severity review findings open | PASS | Review notes list one LOW/STYLE finding about repetitive doc comments; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Branch was clean before gate creation; deployer rechecked clean status after committing this gate before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `dec2d8f2c8df5b72c8de9d88557aa76870728759`. |
+
+## Acceptance Evidence
+
+| Source criterion | Result | Evidence |
+|---|---|---|
+| `doctor.Check` interface has `WarmupEligible() bool` as its last method. | PASS | `internal/doctor/types.go` adds `WarmupEligible() bool` after `Fix(...)`. |
+| Every concrete in-tree `Check` implementation has the default-false method with the pinned comment. | PASS | `grep -rn 'func.*CanFix() bool' internal/doctor/ cmd/gc/` enumerated the production and test implementations; `internal/doctor/warmup_eligible.go`, `cmd/gc/doctor_warmup_eligible.go`, and updated test mocks provide the method. |
+| `PackScriptCheck.WarmupEligible()` returns `c.Warmup`. | PASS | `internal/doctor/pack_checks.go` implements `func (c *PackScriptCheck) WarmupEligible() bool { return c.Warmup }`. |
+| `PackScriptCheck` has new `Warmup bool` field, populated in `cmd/gc/cmd_doctor.go`. | PASS | `internal/doctor/pack_checks.go` adds `Warmup bool`; `cmd/gc/cmd_doctor.go` passes `Warmup: entry.Warmup`. |
+| `PackDoctorEntry`, `DiscoveredDoctor`, and `doctorManifest` have `Warmup bool` fields with the TOML tag. | PASS | `internal/config/config.go` adds `Warmup bool` with TOML tag `warmup,omitempty`; `internal/config/doctor_discovery.go` adds `Warmup bool` to `DiscoveredDoctor` and `doctorManifest` with TOML tag `warmup`. |
+| `legacyPackDoctors` copies the field through. | PASS | `internal/config/pack.go` copies `Warmup: entry.Warmup`. |
+| `TestCheckWarmupEligibleDefaultsFalse` exists with one subtest per concrete check type. | PASS | `internal/doctor/doctor_test.go` includes `TestCheckWarmupEligibleDefaultsFalse`. |
+| `TestPackDoctorWarmupFlagParses` exists with explicit true, explicit false, and omitted/default subtests. | PASS | `internal/config/pack_test.go` includes `TestPackDoctorWarmupFlagParses`. |
+| `TestDoctorManifestWarmupFieldParses` exists with explicit true, explicit false, and omitted/default subtests. | PASS | `internal/config/doctor_discovery_test.go` includes `TestDoctorManifestWarmupFieldParses`. |
+| `TestPackScriptCheckWarmupEligibleReflectsField` exists with default and opted-in subtests. | PASS | `internal/doctor/pack_checks_test.go` includes `TestPackScriptCheckWarmupEligibleReflectsField`. |
+| Broad tests pass. | PASS | `make test-fast-parallel` passed. This is the repo-documented broad local fast runner for this codebase. |
+| `go vet ./...` clean. | PASS | `go vet ./...` exited 0. |
+| No behavioral change to `gc doctor` or `gc start`. | PASS | Diff only adds the opt-in contract, manifest/config plumbing, and tests. No warmup runner or `gc start` behavior is wired in this slice. |
+
+## Reviewer Notes
+
+- New config surface: `warmup = true` on pack `[[doctor]]` entries and `doctor.toml` manifests.
+- Default remains false for all existing in-tree checks.
+- The only variable in-tree implementation is `PackScriptCheck`, which reflects the pack manifest field.
+- Follow-up slices are expected to consume this contract; this PR does not add the warmup runner or alerting behavior.


### PR DESCRIPTION
## What this changes

Doctor checks now expose a `WarmupEligible() bool` contract. Existing in-tree checks return false, so `gc doctor` and `gc start` keep their current behavior until later warmup runner work consumes the contract.

Pack-declared doctor checks can opt into future `gc start` warm-up scans with `warmup = true` in either `pack.toml [[doctor]]` or `doctor.toml`. That setting flows through config discovery into `PackScriptCheck.WarmupEligible()`.

## Why this shape

The contract is default-off and data-driven so the SDK can expose the warmup selection surface without adding startup behavior or hardcoded check decisions in this slice.

## Review notes

- New config surface is `warmup = true`; omitted and explicit false both remain non-warmup.
- The important plumbing paths are `internal/doctor/types.go`, `internal/doctor/pack_checks.go`, `internal/config/doctor_discovery.go`, `internal/config/pack.go`, and `cmd/gc/cmd_doctor.go`.
- This does not add warm-up execution, alerting, startup flags, or city config.

## Test plan

- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-r1iqmy-warmup-eligible-interface-gate.md`](release-gates/ga-r1iqmy-warmup-eligible-interface-gate.md)