### PR TITLE
Add JSON output for session/order action commands

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -483,18 +483,18 @@ func shouldKeepNudgePollerAlive(target nudgeTarget, missingSince, now time.Time)
 	return now.Sub(missingSince) < defaultNudgePollStartGrace
 }
 
-func deliverSessionNudge(target nudgeTarget, message string, mode nudgeDeliveryMode, stdout, stderr io.Writer) int {
+func deliverSessionNudge(target nudgeTarget, message string, mode nudgeDeliveryMode, jsonOutput bool, stdout, stderr io.Writer) int {
 	store := openNudgeBeadStore(target.cityPath)
 	if store == nil {
 		fmt.Fprintf(stderr, "gc session nudge: opening city store for %q\n", target.agentKey()) //nolint:errcheck
 		return 1
 	}
-	return deliverSessionNudgeWithWorker(target, store, newSessionProvider(), message, mode, stdout, stderr)
+	return deliverSessionNudgeWithWorker(target, store, newSessionProvider(), message, mode, jsonOutput, stdout, stderr)
 }
 
-func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp runtime.Provider, message string, mode nudgeDeliveryMode, stdout, stderr io.Writer) int {
+func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp runtime.Provider, message string, mode nudgeDeliveryMode, jsonOutput bool, stdout, stderr io.Writer) int {
 	if mode == nudgeDeliveryQueue {
-		return queueSessionNudgeWithWorker(target, store, sp, message, stdout, stderr)
+		return queueSessionNudgeWithWorker(target, store, sp, message, mode, jsonOutput, stdout, stderr)
 	}
 	delivery, ok := workerNudgeDeliveryForMode(mode)
 	if !ok {
@@ -514,7 +514,7 @@ func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp run
 	if err != nil {
 		if errors.Is(err, runtime.ErrSessionNotFound) && target.sessionTransport() == "acp" {
 			if mode == nudgeDeliveryWaitIdle {
-				return queueSessionNudgeWithWorker(target, store, sp, message, stdout, stderr)
+				return queueSessionNudgeWithWorker(target, store, sp, message, mode, jsonOutput, stdout, stderr)
 			}
 			if mode == nudgeDeliveryImmediate {
 				fmt.Fprintf(stderr, "gc session nudge: live ACP delivery failed for %s because this process does not own the ACP connection; retry with --delivery=wait-idle or --delivery=queue so the queued dispatcher can deliver it\n", target.agentKey()) //nolint:errcheck
@@ -525,7 +525,20 @@ func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp run
 		return 1
 	}
 	if mode == nudgeDeliveryWaitIdle && !result.Delivered {
-		return queueSessionNudgeWithWorker(target, store, sp, message, stdout, stderr)
+		return queueSessionNudgeWithWorker(target, store, sp, message, mode, jsonOutput, stdout, stderr)
+	}
+	if jsonOutput {
+		_ = writeCLIJSONLine(stdout, sessionNudgeJSON{
+			SchemaVersion: "1",
+			OK:            true,
+			Target:        target.agentKey(),
+			SessionID:     target.sessionID,
+			SessionName:   target.sessionName,
+			Delivery:      string(mode),
+			Queued:        false,
+			Outcome:       "delivered",
+		}) //nolint:errcheck // best-effort stdout
+		return 0
 	}
 	fmt.Fprintf(stdout, "Nudged %s\n", target.agentKey()) //nolint:errcheck
 	return 0
@@ -555,16 +568,29 @@ func workerObserveNudgeTarget(target nudgeTarget, store beads.Store, sp runtime.
 }
 
 func deliverSessionNudgeWithProvider(target nudgeTarget, sp runtime.Provider, mode nudgeDeliveryMode, stdout, stderr io.Writer) int {
-	return deliverSessionNudgeWithWorker(target, nil, sp, "check deploy status", mode, stdout, stderr)
+	return deliverSessionNudgeWithWorker(target, nil, sp, "check deploy status", mode, false, stdout, stderr)
 }
 
-func queueSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp runtime.Provider, message string, stdout, stderr io.Writer) int {
+func queueSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp runtime.Provider, message string, mode nudgeDeliveryMode, jsonOutput bool, stdout, stderr io.Writer) int {
 	if err := enqueueQueuedNudge(target.cityPath, newQueuedNudgeWithOptions(target.agentKey(), message, "session", time.Now(), queuedNudgeOptionsFromTarget(target))); err != nil {
 		fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck
 		return 1
 	}
 	if obs, err := workerObserveNudgeTarget(target, store, sp); err == nil && obs.Running {
 		maybeStartNudgePoller(target)
+	}
+	if jsonOutput {
+		_ = writeCLIJSONLine(stdout, sessionNudgeJSON{
+			SchemaVersion: "1",
+			OK:            true,
+			Target:        target.agentKey(),
+			SessionID:     target.sessionID,
+			SessionName:   target.sessionName,
+			Delivery:      string(mode),
+			Queued:        true,
+			Outcome:       "queued",
+		}) //nolint:errcheck // best-effort stdout
+		return 0
 	}
 	fmt.Fprintf(stdout, "Queued nudge for %s\n", target.agentKey()) //nolint:errcheck
 	return 0

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -388,7 +388,7 @@ func TestDeliverSessionNudgeWithWorkerImmediateResumesSuspendedSession(t *testin
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryImmediate, &stdout, &stderr)
+	code := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryImmediate, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("deliverSessionNudgeWithWorker = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -441,7 +441,7 @@ func TestDeliverSessionNudgeWithWorkerWaitIdleResumesClaudeSession(t *testing.T)
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryWaitIdle, &stdout, &stderr)
+	code := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryWaitIdle, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("deliverSessionNudgeWithWorker = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -507,7 +507,7 @@ func TestDeliverSessionNudgeWithWorkerWaitIdleQueuesUnsupportedProviderAfterResu
 	t.Cleanup(func() { startNudgePoller = prev })
 
 	var stdout, stderr bytes.Buffer
-	code := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryWaitIdle, &stdout, &stderr)
+	code := deliverSessionNudgeWithWorker(target, store, fake, "check deploy status", nudgeDeliveryWaitIdle, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("deliverSessionNudgeWithWorker = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -2267,12 +2267,14 @@ start_command = "echo"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdSessionNudge([]string{"sess-worker", "check", "deploy"}, nudgeDeliveryQueue, &stdout, &stderr)
+	code := cmdSessionNudge([]string{"sess-worker", "check", "deploy"}, nudgeDeliveryQueue, true, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdSessionNudge = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Queued nudge for "+sessionBead.ID) {
-		t.Fatalf("stdout = %q, want queue confirmation", stdout.String())
+	for _, want := range []string{`"schema_version":"1"`, `"ok":true`, `"target":"` + sessionBead.ID + `"`, `"session_id":"` + sessionBead.ID + `"`, `"delivery":"queue"`, `"queued":true`, `"outcome":"queued"`} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %s", stdout.String(), want)
+		}
 	}
 
 	pending, inFlight, dead, err := listQueuedNudges(cityDir, sessionBead.ID, time.Now())

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -98,6 +98,7 @@ Use --rig to disambiguate same-name orders in different rigs.`,
 
 func newOrderRunCmd(stdout, stderr io.Writer) *cobra.Command {
 	var rig string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "run <name>",
 		Short: "Execute an order manually",
@@ -109,7 +110,7 @@ them outside their normal schedule.
 Use --rig to disambiguate same-name orders in different rigs.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdOrderRun(args[0], rig, stdout, stderr) != 0 {
+			if cmdOrderRun(args[0], rig, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -117,12 +118,14 @@ Use --rig to disambiguate same-name orders in different rigs.`,
 		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to disambiguate same-name orders")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
 	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	return cmd
 }
 
 func newOrderCheckCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Check which orders are due to run",
 		Long: `Evaluate trigger conditions for all orders and show which are due.
@@ -131,12 +134,14 @@ Prints a table with each order's trigger, due status, and reason. Returns
 exit code 0 if any order is due, 1 if none are due.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdOrderCheck(stdout, stderr) != 0 {
+			if cmdOrderCheck(jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
+	return cmd
 }
 
 func newOrderHistoryCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -471,7 +476,7 @@ func doOrderShow(aa []orders.Order, name, rig string, stdout, stderr io.Writer) 
 
 // --- gc order run ---
 
-func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
+func cmdOrderRun(name, rig string, jsonOutput bool, stdout, stderr io.Writer) int {
 	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order run")
 	if code != 0 {
 		return code
@@ -482,6 +487,10 @@ func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if a.IsExec() {
+		if jsonOutput {
+			fmt.Fprintln(stderr, "gc order run: --json is not supported for exec orders because the exec body may write arbitrary stdout") //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		if a.Trigger == "event" {
 			store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
 			if store == nil {
@@ -506,13 +515,29 @@ func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 		return epCode
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	return doOrderRun(aa, name, rig, cityPath, store, ep, stdout, stderr)
+	return doOrderRunWithJSON(aa, name, rig, cityPath, store, ep, jsonOutput, stdout, stderr)
 }
 
 // doOrderRun executes an order manually: instantiates a wisp from the
 // order's formula (or runs exec script directly) and routes it to the
 // configured target.
 func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store, ep events.Provider, stdout, stderr io.Writer) int {
+	return doOrderRunWithJSON(aa, name, rig, cityPath, store, ep, false, stdout, stderr)
+}
+
+type orderRunJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	Order         string `json:"order"`
+	Rig           string `json:"rig,omitempty"`
+	ScopedName    string `json:"scoped_name"`
+	Action        string `json:"action"`
+	WispID        string `json:"wisp_id"`
+	RoutedTo      string `json:"routed_to,omitempty"`
+	EventCursor   uint64 `json:"event_cursor,omitempty"`
+}
+
+func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store beads.Store, ep events.Provider, jsonOutput bool, stdout, stderr io.Writer) int {
 	a, ok := findOrder(aa, name, rig)
 	if !ok {
 		fmt.Fprintf(stderr, "gc order run: order %q not found\n", name) //nolint:errcheck // best-effort stderr
@@ -521,6 +546,10 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 
 	// Exec orders: run the script directly.
 	if a.IsExec() {
+		if jsonOutput {
+			fmt.Fprintln(stderr, "gc order run: --json is not supported for exec orders because the exec body may write arbitrary stdout") //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		cfg, cfgErr := loadCityConfig(cityPath, stderr)
 		if cfgErr != nil {
 			fmt.Fprintf(stderr, "gc order run: %v\n", cfgErr) //nolint:errcheck // best-effort stderr
@@ -611,6 +640,20 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 		return 1
 	}
 
+	if jsonOutput {
+		_ = writeCLIJSONLine(stdout, orderRunJSON{
+			SchemaVersion: "1",
+			OK:            true,
+			Order:         a.Name,
+			Rig:           a.Rig,
+			ScopedName:    scoped,
+			Action:        "formula",
+			WispID:        rootID,
+			RoutedTo:      pool,
+			EventCursor:   headSeq,
+		}) //nolint:errcheck // best-effort stdout
+		return 0
+	}
 	fmt.Fprintf(stdout, "Order %q executed: wisp %s", name, rootID) //nolint:errcheck
 	if a.Pool != "" {
 		fmt.Fprintf(stdout, " → gc.routed_to=%s", pool) //nolint:errcheck
@@ -711,7 +754,7 @@ func doOrderRunExecResult(a orders.Order, cityPath string, cfg *config.City, std
 
 // --- gc order check ---
 
-func cmdOrderCheck(stdout, stderr io.Writer) int {
+func cmdOrderCheck(jsonOutput bool, stdout, stderr io.Writer) int {
 	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order check")
 	if code != 0 {
 		return code
@@ -722,7 +765,7 @@ func cmdOrderCheck(stdout, stderr io.Writer) int {
 		return epCode
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	return doOrderCheckWithStoresResolverScoped(cityPath, cfg, aa, time.Now(), ep, cachedOrderStoresResolver(cityPath, cfg), stdout, stderr)
+	return doOrderCheckWithStoresResolverScopedJSON(cityPath, cfg, aa, time.Now(), ep, cachedOrderStoresResolver(cityPath, cfg), jsonOutput, stdout, stderr)
 }
 
 // orderLastRunFn returns a LastRunFunc that queries BdStore for the most
@@ -734,8 +777,70 @@ func orderLastRunFn(store beads.Store) orders.LastRunFunc {
 // doOrderCheck evaluates triggers for all orders and prints a table.
 // Returns 0 if any are due, 1 if none are due.
 func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc, stdout io.Writer) int {
+	return doOrderCheckJSON(aa, now, lastRunFn, false, stdout)
+}
+
+type orderCheckJSON struct {
+	SchemaVersion string              `json:"schema_version"`
+	OK            bool                `json:"ok"`
+	AnyDue        bool                `json:"any_due"`
+	OrdersTotal   int                 `json:"orders_total"`
+	DueTotal      int                 `json:"due_total"`
+	Orders        []orderCheckJSONRow `json:"orders"`
+}
+
+type orderCheckJSONRow struct {
+	Name       string `json:"name"`
+	Rig        string `json:"rig,omitempty"`
+	ScopedName string `json:"scoped_name"`
+	Trigger    string `json:"trigger"`
+	Due        bool   `json:"due"`
+	Reason     string `json:"reason"`
+}
+
+func doOrderCheckJSON(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc, jsonOutput bool, stdout io.Writer) int {
 	if len(aa) == 0 {
+		if jsonOutput {
+			_ = writeCLIJSONLine(stdout, orderCheckJSON{
+				SchemaVersion: "1",
+				OK:            true,
+				AnyDue:        false,
+				OrdersTotal:   0,
+				DueTotal:      0,
+				Orders:        []orderCheckJSONRow{},
+			}) //nolint:errcheck // best-effort stdout
+			return 1
+		}
 		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
+		return 1
+	}
+
+	if jsonOutput {
+		result := orderCheckJSON{
+			SchemaVersion: "1",
+			OK:            true,
+			OrdersTotal:   len(aa),
+			Orders:        make([]orderCheckJSONRow, 0, len(aa)),
+		}
+		for _, a := range aa {
+			check := orders.CheckTrigger(a, now, lastRunFn, nil, nil)
+			if check.Due {
+				result.AnyDue = true
+				result.DueTotal++
+			}
+			result.Orders = append(result.Orders, orderCheckJSONRow{
+				Name:       a.Name,
+				Rig:        a.Rig,
+				ScopedName: a.ScopedName(),
+				Trigger:    a.Trigger,
+				Due:        check.Due,
+				Reason:     check.Reason,
+			})
+		}
+		_ = writeCLIJSONLine(stdout, result) //nolint:errcheck // best-effort stdout
+		if result.AnyDue {
+			return 0
+		}
 		return 1
 	}
 
@@ -775,8 +880,86 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 }
 
 func doOrderCheckWithStoresResolverScoped(cityPath string, cfg *config.City, aa []orders.Order, now time.Time, ep events.Provider, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
+	return doOrderCheckWithStoresResolverScopedJSON(cityPath, cfg, aa, now, ep, resolveStores, false, stdout, stderr)
+}
+
+func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City, aa []orders.Order, now time.Time, ep events.Provider, resolveStores orderStoresResolver, jsonOutput bool, stdout, stderr io.Writer) int {
 	if len(aa) == 0 {
+		if jsonOutput {
+			_ = writeCLIJSONLine(stdout, orderCheckJSON{
+				SchemaVersion: "1",
+				OK:            true,
+				AnyDue:        false,
+				OrdersTotal:   0,
+				DueTotal:      0,
+				Orders:        []orderCheckJSONRow{},
+			}) //nolint:errcheck // best-effort stdout
+			return 1
+		}
 		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
+		return 1
+	}
+
+	if jsonOutput {
+		result := orderCheckJSON{
+			SchemaVersion: "1",
+			OK:            true,
+			OrdersTotal:   len(aa),
+			Orders:        make([]orderCheckJSONRow, 0, len(aa)),
+		}
+		for _, a := range aa {
+			stores, err := resolveStores(a)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			baseLastRunFn := orders.LastRunAcrossStores(stores...)
+			var lastRunErr error
+			lastRunFn := func(orderName string) (time.Time, error) {
+				last, err := baseLastRunFn(orderName)
+				if err != nil {
+					lastRunErr = err
+				}
+				return last, err
+			}
+			cursorFn := orders.CursorAcrossStores(stores...)
+			if a.Trigger == "event" {
+				cursor, err := bdCursorAcrossStores(a.ScopedName(), stores...)
+				if err != nil {
+					fmt.Fprintf(stderr, "gc order check: reading event cursor for %s: %v\n", a.ScopedName(), err) //nolint:errcheck // best-effort stderr
+					return 1
+				}
+				cursorFn = func(string) uint64 {
+					return cursor
+				}
+			}
+			triggerOpts, err := orderTriggerOptions(cityPath, cfg, a)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			check := orders.CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, triggerOpts)
+			if lastRunErr != nil {
+				fmt.Fprintf(stderr, "gc order check: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+			if check.Due {
+				result.AnyDue = true
+				result.DueTotal++
+			}
+			result.Orders = append(result.Orders, orderCheckJSONRow{
+				Name:       a.Name,
+				Rig:        a.Rig,
+				ScopedName: a.ScopedName(),
+				Trigger:    a.Trigger,
+				Due:        check.Due,
+				Reason:     check.Reason,
+			})
+		}
+		_ = writeCLIJSONLine(stdout, result) //nolint:errcheck // best-effort stdout
+		if result.AnyDue {
+			return 0
+		}
 		return 1
 	}
 

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -490,6 +490,26 @@ func TestOrderCheckNoneDue(t *testing.T) {
 	}
 }
 
+func TestOrderCheckJSONNoneDuePreservesSemanticExit(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "deploy", Trigger: "manual", Formula: "mol-deploy"},
+	}
+	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)
+	neverRan := func(_ string) (time.Time, error) { return time.Time{}, nil }
+
+	var stdout bytes.Buffer
+	code := doOrderCheckJSON(aa, now, neverRan, true, &stdout)
+	if code != 1 {
+		t.Fatalf("doOrderCheckJSON = %d, want 1 (none due)", code)
+	}
+	got := stdout.String()
+	for _, want := range []string{`"schema_version":"1"`, `"ok":true`, `"any_due":false`, `"orders_total":1`, `"due_total":0`, `"name":"deploy"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, missing %s", got, want)
+		}
+	}
+}
+
 func TestOrderCheckEmpty(t *testing.T) {
 	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)
 	neverRan := func(_ string) (time.Time, error) { return time.Time{}, nil }
@@ -747,6 +767,44 @@ func TestOrderRun(t *testing.T) {
 	}
 }
 
+func TestOrderRunJSONFormulaSummary(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h", Pool: "dog", FormulaLayer: sharedTestFormulaDir},
+	}
+
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunWithJSON(aa, "digest", "", "/city", store, nil, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRunWithJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	got := stdout.String()
+	for _, want := range []string{`"schema_version":"1"`, `"ok":true`, `"order":"digest"`, `"scoped_name":"digest"`, `"action":"formula"`, `"wisp_id":`, `"routed_to":"dog"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, missing %s", got, want)
+		}
+	}
+}
+
+func TestOrderRunJSONRejectsExecWithoutRunning(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "release-exec", Trigger: "manual", Exec: "printf unsafe"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRunWithJSON(aa, "release-exec", "", "/city", beads.NewMemStore(), nil, true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderRunWithJSON exec = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty stdout on unsupported exec JSON", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--json is not supported for exec orders") {
+		t.Fatalf("stderr = %q, want unsupported exec message", stderr.String())
+	}
+}
+
 func TestOrderRunEventExecAdvancesCursor(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
@@ -830,7 +888,7 @@ on = "bead.closed"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderRun("release-exec", "", &stdout, &stderr)
+	code := cmdOrderRun("release-exec", "", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdOrderRun = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -74,6 +74,7 @@ continuity.`,
 
 func newSessionSubmitCmd(stdout, stderr io.Writer) *cobra.Command {
 	var intent string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "submit <id-or-alias> <message...>",
 		Short: "Submit a message with semantic delivery intent",
@@ -91,7 +92,7 @@ according to the selected semantic intent.`,
 				fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
-			if cmdSessionSubmit(args, parsedIntent, stdout, stderr) != 0 {
+			if cmdSessionSubmit(args, parsedIntent, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -99,6 +100,7 @@ according to the selected semantic intent.`,
 		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().StringVar(&intent, "intent", string(session.SubmitIntentDefault), "submit intent: default, follow_up, or interrupt_now")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
 	return cmd
 }
 
@@ -108,6 +110,7 @@ func newSessionNewCmd(stdout, stderr io.Writer) *cobra.Command {
 	var alias string
 	var titleHint string
 	var noAttach bool
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "new <template>",
 		Short: "Create a new chat session from an agent template",
@@ -125,7 +128,7 @@ and refined by the title model in the background.`,
   gc session new helper --no-attach`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdSessionNew(args, alias, title, titleHint, noAttach, stdout, stderr) != 0 {
+			if cmdSessionNew(args, alias, title, titleHint, noAttach, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -135,6 +138,7 @@ and refined by the title model in the background.`,
 	cmd.Flags().StringVar(&title, "title", "", "human-readable session title")
 	cmd.Flags().StringVar(&titleHint, "title-hint", "", "text to auto-generate a session title from")
 	cmd.Flags().BoolVar(&noAttach, "no-attach", false, "create session without attaching")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
 	return cmd
 }
 
@@ -143,8 +147,12 @@ and refined by the title model in the background.`,
 // Phase 2: creates a session bead and pokes the controller. The reconciler
 // handles process lifecycle (start). If the controller is not running,
 // falls back to direct process start via the session manager.
-func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool, stdout, stderr io.Writer) int {
+func cmdSessionNew(args []string, alias, title, titleHint string, noAttach, jsonOutput bool, stdout, stderr io.Writer) int {
 	templateName := args[0]
+	if jsonOutput && !noAttach {
+		fmt.Fprintln(stderr, "gc session new: --json requires --no-attach because attaching is interactive") //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	cityPath, err := resolveCity()
 	if err != nil {
@@ -313,10 +321,25 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 			// Poke again after bead creation to trigger immediate reconciler tick.
 			_ = pokeController(cityPath)
 
-			fmt.Fprintf(stdout, "Session %s created from template %q (reconciler will start it).\n", info.ID, canonicalTemplate) //nolint:errcheck // best-effort stdout
+			if jsonOutput {
+				writeSessionNewJSON(stdout, sessionNewJSON{
+					SchemaVersion: "1",
+					OK:            true,
+					SessionID:     info.ID,
+					SessionName:   info.SessionName,
+					Alias:         info.Alias,
+					Template:      canonicalTemplate,
+					Transport:     sessionTransport,
+					WorkDir:       info.WorkDir,
+					DeferredStart: true,
+					Attached:      false,
+				})
+			} else {
+				fmt.Fprintf(stdout, "Session %s created from template %q (reconciler will start it).\n", info.ID, canonicalTemplate) //nolint:errcheck // best-effort stdout
+			}
 
 			if !shouldAttachNewSession(noAttach, sessionTransport) {
-				if sessionTransport == config.SessionTransportACP && !noAttach {
+				if sessionTransport == config.SessionTransportACP && !noAttach && !jsonOutput {
 					fmt.Fprintln(stdout, "Session uses ACP transport; not attaching.") //nolint:errcheck // best-effort stdout
 				}
 				return 0
@@ -407,10 +430,25 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	titleDone := maybeAutoTitle(store, info.ID, title, titleHint, titleProvider, info.WorkDir, stderr)
 	defer func() { <-titleDone }() // ensure title goroutine completes on all exit paths
 
-	fmt.Fprintf(stdout, "Session %s created from template %q.\n", info.ID, canonicalTemplate) //nolint:errcheck // best-effort stdout
+	if jsonOutput {
+		writeSessionNewJSON(stdout, sessionNewJSON{
+			SchemaVersion: "1",
+			OK:            true,
+			SessionID:     info.ID,
+			SessionName:   info.SessionName,
+			Alias:         info.Alias,
+			Template:      canonicalTemplate,
+			Transport:     sessionTransport,
+			WorkDir:       info.WorkDir,
+			DeferredStart: false,
+			Attached:      false,
+		})
+	} else {
+		fmt.Fprintf(stdout, "Session %s created from template %q.\n", info.ID, canonicalTemplate) //nolint:errcheck // best-effort stdout
+	}
 
 	if !shouldAttachNewSession(noAttach, sessionTransport) {
-		if sessionTransport == config.SessionTransportACP && !noAttach {
+		if sessionTransport == config.SessionTransportACP && !noAttach && !jsonOutput {
 			fmt.Fprintln(stdout, "Session uses ACP transport; not attaching.") //nolint:errcheck // best-effort stdout
 		}
 		return 0
@@ -843,6 +881,23 @@ func summarizeSessionList(rows []sessionListJSONRow) sessionListSummary {
 		}
 	}
 	return summary
+}
+
+type sessionNewJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	SessionID     string `json:"session_id"`
+	SessionName   string `json:"session_name"`
+	Alias         string `json:"alias,omitempty"`
+	Template      string `json:"template"`
+	Transport     string `json:"transport"`
+	WorkDir       string `json:"work_dir"`
+	DeferredStart bool   `json:"deferred_start"`
+	Attached      bool   `json:"attached"`
+}
+
+func writeSessionNewJSON(stdout io.Writer, result sessionNewJSON) {
+	_ = writeCLIJSONLine(stdout, result) //nolint:errcheck // best-effort stdout
 }
 
 func sessionListJSONRows(sessions []session.Info) []sessionListJSONRow {
@@ -1691,6 +1746,7 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer) int {
 // newSessionNudgeCmd creates the "gc session nudge <id-or-alias> <message>" command.
 func newSessionNudgeCmd(stdout, stderr io.Writer) *cobra.Command {
 	var delivery string
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "nudge <id-or-alias> <message...>",
 		Short: "Send a text message to a running session",
@@ -1708,7 +1764,7 @@ joined automatically.`,
 				fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
-			if cmdSessionNudge(args, mode, stdout, stderr) != 0 {
+			if cmdSessionNudge(args, mode, jsonOutput, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -1716,6 +1772,7 @@ joined automatically.`,
 		ValidArgsFunction: completeSessionIDs,
 	}
 	cmd.Flags().StringVar(&delivery, "delivery", string(nudgeDeliveryWaitIdle), "delivery mode: immediate, wait-idle, or queue")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
 	return cmd
 }
 
@@ -1732,7 +1789,16 @@ func parseSessionSubmitIntent(raw string) (session.SubmitIntent, error) {
 	}
 }
 
-func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr io.Writer) int {
+type sessionSubmitJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	Target        string `json:"target"`
+	Intent        string `json:"intent"`
+	Queued        bool   `json:"queued"`
+	Outcome       string `json:"outcome"`
+}
+
+func cmdSessionSubmit(args []string, intent session.SubmitIntent, jsonOutput bool, stdout, stderr io.Writer) int {
 	target := args[0]
 	message := strings.Join(args[1:], " ")
 
@@ -1745,7 +1811,7 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 	if c := apiClient(cityPath); c != nil {
 		resp, err := c.SubmitSession(target, message, intent)
 		if err == nil {
-			emitSessionSubmitResult(stdout, target, intent, resp.Queued)
+			emitSessionSubmitResult(stdout, target, intent, resp.Queued, jsonOutput)
 			return 0
 		}
 		if !api.ShouldFallback(err) {
@@ -1784,11 +1850,28 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	emitSessionSubmitResult(stdout, target, intent, outcome.Queued)
+	emitSessionSubmitResult(stdout, target, intent, outcome.Queued, jsonOutput)
 	return 0
 }
 
-func emitSessionSubmitResult(stdout io.Writer, target string, intent session.SubmitIntent, queued bool) {
+func emitSessionSubmitResult(stdout io.Writer, target string, intent session.SubmitIntent, queued, jsonOutput bool) {
+	if jsonOutput {
+		outcome := "submitted"
+		if queued {
+			outcome = "queued"
+		} else if intent == session.SubmitIntentInterruptNow {
+			outcome = "interrupted"
+		}
+		_ = writeCLIJSONLine(stdout, sessionSubmitJSON{
+			SchemaVersion: "1",
+			OK:            true,
+			Target:        target,
+			Intent:        string(intent),
+			Queued:        queued,
+			Outcome:       outcome,
+		}) //nolint:errcheck // best-effort stdout
+		return
+	}
 	switch {
 	case queued:
 		fmt.Fprintf(stdout, "Queued follow-up for %s\n", target) //nolint:errcheck // best-effort stdout
@@ -1801,8 +1884,19 @@ func emitSessionSubmitResult(stdout io.Writer, target string, intent session.Sub
 	}
 }
 
+type sessionNudgeJSON struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	Target        string `json:"target"`
+	SessionID     string `json:"session_id,omitempty"`
+	SessionName   string `json:"session_name,omitempty"`
+	Delivery      string `json:"delivery"`
+	Queued        bool   `json:"queued"`
+	Outcome       string `json:"outcome"`
+}
+
 // cmdSessionNudge is the CLI entry point for "gc session nudge".
-func cmdSessionNudge(args []string, delivery nudgeDeliveryMode, stdout, stderr io.Writer) int {
+func cmdSessionNudge(args []string, delivery nudgeDeliveryMode, jsonOutput bool, stdout, stderr io.Writer) int {
 	target := args[0]
 	message := strings.Join(args[1:], " ")
 
@@ -1811,7 +1905,7 @@ func cmdSessionNudge(args []string, delivery nudgeDeliveryMode, stdout, stderr i
 		fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	return deliverSessionNudge(targetInfo, message, delivery, stdout, stderr)
+	return deliverSessionNudge(targetInfo, message, delivery, jsonOutput, stdout, stderr)
 }
 
 // resolveWorkDir determines the working directory for a session based on the

--- a/cmd/gc/cmd_session_submit_test.go
+++ b/cmd/gc/cmd_session_submit_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestEmitSessionSubmitResultFollowUpQueued(t *testing.T) {
 	var stdout bytes.Buffer
-	emitSessionSubmitResult(&stdout, "mayor", session.SubmitIntentFollowUp, true)
+	emitSessionSubmitResult(&stdout, "mayor", session.SubmitIntentFollowUp, true, false)
 	if got := stdout.String(); !strings.Contains(got, "Queued follow-up for mayor") {
 		t.Fatalf("stdout = %q, want queued confirmation", got)
 	}
@@ -18,13 +18,24 @@ func TestEmitSessionSubmitResultFollowUpQueued(t *testing.T) {
 
 func TestEmitSessionSubmitResultFollowUpImmediate(t *testing.T) {
 	var stdout bytes.Buffer
-	emitSessionSubmitResult(&stdout, "mayor", session.SubmitIntentFollowUp, false)
+	emitSessionSubmitResult(&stdout, "mayor", session.SubmitIntentFollowUp, false, false)
 	got := stdout.String()
 	if strings.Contains(got, "Queued") {
 		t.Fatalf("stdout = %q, should not say Queued when message was delivered immediately", got)
 	}
 	if !strings.Contains(got, "Submitted follow-up to mayor") {
 		t.Fatalf("stdout = %q, want submitted follow-up confirmation", got)
+	}
+}
+
+func TestEmitSessionSubmitResultJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	emitSessionSubmitResult(&stdout, "mayor", session.SubmitIntentFollowUp, true, true)
+	got := stdout.String()
+	for _, want := range []string{`"schema_version":"1"`, `"ok":true`, `"target":"mayor"`, `"intent":"follow_up"`, `"queued":true`, `"outcome":"queued"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, missing %s", got, want)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -155,6 +155,20 @@ func TestParsePruneDuration(t *testing.T) {
 	}
 }
 
+func TestSessionNewJSONRequiresNoAttach(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := cmdSessionNew([]string{"worker"}, "", "", "", false, true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdSessionNew --json without --no-attach = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty stdout", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--json requires --no-attach") {
+		t.Fatalf("stderr = %q, want --no-attach rationale", stderr.String())
+	}
+}
+
 func TestResolveWorkDir(t *testing.T) {
 	cityPath := t.TempDir()
 	rigRoot := filepath.Join(t.TempDir(), "my-rig")
@@ -230,7 +244,7 @@ func TestCmdSessionNew_PoolTemplateUsesAliasBackedWorkDirIdentity(t *testing.T) 
 	for _, alias := range []string{"demo/ant-fenrir", "demo/ant-grendel"} {
 		stdout.Reset()
 		stderr.Reset()
-		if code := cmdSessionNew([]string{"demo/ant"}, alias, "", "", true, &stdout, &stderr); code != 0 {
+		if code := cmdSessionNew([]string{"demo/ant"}, alias, "", "", true, false, &stdout, &stderr); code != 0 {
 			t.Fatalf("cmdSessionNew(%q) = %d, want 0; stderr=%s", alias, code, stderr.String())
 		}
 	}
@@ -270,13 +284,13 @@ func TestCmdSessionNew_PoolTemplateCanonicalizesQualifiedAliasCollisions(t *test
 	writePoolSessionCityTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"demo/ant"}, "ant-fenrir", "", "", true, &stdout, &stderr); code != 0 {
+	if code := cmdSessionNew([]string{"demo/ant"}, "ant-fenrir", "", "", true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdSessionNew(first) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
 	stdout.Reset()
 	stderr.Reset()
-	if code := cmdSessionNew([]string{"demo/ant"}, "demo/ant-fenrir", "", "", true, &stdout, &stderr); code == 0 {
+	if code := cmdSessionNew([]string{"demo/ant"}, "demo/ant-fenrir", "", "", true, false, &stdout, &stderr); code == 0 {
 		t.Fatal("cmdSessionNew(second) = 0, want alias conflict")
 	}
 	if !strings.Contains(stderr.String(), session.ErrSessionAliasExists.Error()) {
@@ -301,7 +315,7 @@ func TestCmdSessionNew_PoolTemplateBareAliasStillResolves(t *testing.T) {
 	writePoolSessionCityTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"demo/ant"}, "ant-fenrir", "", "", true, &stdout, &stderr); code != 0 {
+	if code := cmdSessionNew([]string{"demo/ant"}, "ant-fenrir", "", "", true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdSessionNew = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
@@ -339,7 +353,7 @@ func TestCmdSessionNew_PoolTemplateWithoutAliasUsesGeneratedWorkDirIdentity(t *t
 	for i := 0; i < 2; i++ {
 		stdout.Reset()
 		stderr.Reset()
-		if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, &stdout, &stderr); code != 0 {
+		if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, false, &stdout, &stderr); code != 0 {
 			t.Fatalf("cmdSessionNew(aliasless #%d) = %d, want 0; stderr=%s", i+1, code, stderr.String())
 		}
 	}
@@ -443,7 +457,7 @@ args = ["{{.AgentName}}", "{{.WorkDir}}", "{{.TemplateName}}"]
 	}()
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, &stdout, &stderr); code != 0 {
+	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdSessionNew(acp) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
@@ -520,7 +534,7 @@ args = ["{{.AgentName}}", "{{.WorkDir}}", "{{.TemplateName}}"]
 `)
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, &stdout, &stderr); code != 0 {
+	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdSessionNew(custom provider acp default) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
@@ -550,7 +564,7 @@ func TestCmdSessionNewRejectsExplicitTmuxAgentWhenCitySessionProviderIsACP(t *te
 	writePoolACPCityExplicitTmuxAgentTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, &stdout, &stderr); code == 0 {
+	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, false, &stdout, &stderr); code == 0 {
 		t.Fatalf("cmdSessionNew(explicit tmux on ACP city) = %d, want failure", code)
 	}
 	if !strings.Contains(stderr.String(), "requires tmux transport") {
@@ -570,7 +584,7 @@ func TestCmdSessionNew_PoolTemplateRejectsAliasMatchingConcreteIdentity(t *testi
 	writePoolSessionCityTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, &stdout, &stderr); code != 0 {
+	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdSessionNew(aliasless) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
@@ -585,7 +599,7 @@ func TestCmdSessionNew_PoolTemplateRejectsAliasMatchingConcreteIdentity(t *testi
 
 	stdout.Reset()
 	stderr.Reset()
-	if code := cmdSessionNew([]string{"demo/ant"}, "demo/"+sessionName, "", "", true, &stdout, &stderr); code == 0 {
+	if code := cmdSessionNew([]string{"demo/ant"}, "demo/"+sessionName, "", "", true, false, &stdout, &stderr); code == 0 {
 		t.Fatal("cmdSessionNew(alias collision) = 0, want conflict")
 	}
 	if !strings.Contains(stderr.String(), session.ErrSessionAliasExists.Error()) {
@@ -1390,7 +1404,7 @@ func TestCmdSessionNew_AllowsReservedNamedAliasWithController(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", "", true, &stdout, &stderr); code != 0 {
+	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", "", true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdSessionNew(controller) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
@@ -1439,7 +1453,7 @@ func TestCmdSessionNew_AllowsReservedNamedAliasWithoutController(t *testing.T) {
 	writeNamedSessionCityTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", "", true, &stdout, &stderr); code != 0 {
+	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", "", true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdSessionNew(fallback) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
@@ -1490,7 +1504,7 @@ func TestCmdSessionNew_IgnoresUnmanagedSupervisorSocket(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", "", true, &stdout, &stderr); code != 0 {
+	if code := cmdSessionNew([]string{"mayor"}, "mayor", "", "", true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdSessionNew(unmanaged supervisor) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
@@ -1721,7 +1735,7 @@ func TestCmdSessionNew_AutoTitleFromMessage(t *testing.T) {
 	writeNamedSessionCityTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdSessionNew([]string{"mayor"}, "mayor", "", "fix the login redirect loop", true, &stdout, &stderr)
+	code := cmdSessionNew([]string{"mayor"}, "mayor", "", "fix the login redirect loop", true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdSessionNew = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -1746,7 +1760,7 @@ func TestCmdSessionNew_ExplicitTitlePreserved(t *testing.T) {
 	writeNamedSessionCityTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdSessionNew([]string{"mayor"}, "mayor", "my explicit title", "some message", true, &stdout, &stderr)
+	code := cmdSessionNew([]string{"mayor"}, "mayor", "my explicit title", "some message", true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdSessionNew = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -1767,7 +1781,7 @@ func TestCmdSessionNew_NoMessageKeepsTemplateName(t *testing.T) {
 	writeNamedSessionCityTOML(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdSessionNew([]string{"mayor"}, "mayor", "", "", true, &stdout, &stderr)
+	code := cmdSessionNew([]string{"mayor"}, "mayor", "", "", true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdSessionNew = %d, want 0; stderr=%s", code, stderr.String())
 	}

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -101,6 +101,36 @@ func TestJSONSchemaRoleSpecificResult(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaManifestForSessionOrderShardCommands(t *testing.T) {
+	commands := [][]string{
+		{"session", "new"},
+		{"session", "submit"},
+		{"session", "nudge"},
+		{"order", "check"},
+		{"order", "run"},
+	}
+	for _, command := range commands {
+		t.Run(strings.Join(command, " "), func(t *testing.T) {
+			args := append(append([]string{}, command...), "--json-schema=result")
+			var stdout, stderr bytes.Buffer
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("run(%v) = %d, stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var schema map[string]any
+			if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+				t.Fatalf("result schema is not JSON: %v\n%s", err, stdout.String())
+			}
+			if schema["$schema"] == "" {
+				t.Fatalf("schema missing $schema: %+v", schema)
+			}
+		})
+	}
+}
+
 func TestJSONSchemaRoleSpecificFailureUsesSharedDefault(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"events", "--json-schema", "failure"}, &stdout, &stderr)

--- a/cmd/gc/provider_store_resolution_test.go
+++ b/cmd/gc/provider_store_resolution_test.go
@@ -261,7 +261,7 @@ trigger = "manual"
 	chdirProviderAwareTest(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderRun("poll", "", &stdout, &stderr)
+	code := cmdOrderRun("poll", "", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdOrderRun(exec) = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -307,7 +307,7 @@ pool = "dog"
 	chdirProviderAwareTest(t, cityDir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderRun("digest", "", &stdout, &stderr)
+	code := cmdOrderRun("digest", "", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdOrderRun(formula) = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/session_model_phase0_cli_surface_spec_test.go
+++ b/cmd/gc/session_model_phase0_cli_surface_spec_test.go
@@ -69,7 +69,7 @@ func TestPhase0CLISessionTargetingSurfaces_RejectTemplateFactoryTargets(t *testi
 		{
 			name: "gc session nudge",
 			run: func(stdout, stderr *bytes.Buffer) int {
-				return cmdSessionNudge([]string{"template:worker", "hello"}, nudgeDeliveryImmediate, stdout, stderr)
+				return cmdSessionNudge([]string{"template:worker", "hello"}, nudgeDeliveryImmediate, false, stdout, stderr)
 			},
 		},
 	}
@@ -155,7 +155,7 @@ func TestPhase0CLISessionTargetingSurfaces_BareConfigNameDoesNotMaterializeOrdin
 		{
 			name: "gc session nudge",
 			run: func(stdout, stderr *bytes.Buffer) int {
-				return cmdSessionNudge([]string{"worker", "hello"}, nudgeDeliveryImmediate, stdout, stderr)
+				return cmdSessionNudge([]string{"worker", "hello"}, nudgeDeliveryImmediate, false, stdout, stderr)
 			},
 		},
 	}
@@ -571,7 +571,7 @@ mode = "on_demand"
 	t.Setenv("GC_DIR", t.TempDir())
 
 	var stdout, stderr bytes.Buffer
-	code := cmdSessionNew([]string{"worker"}, "", "", "", true, &stdout, &stderr)
+	code := cmdSessionNew([]string{"worker"}, "", "", "", true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdSessionNew(worker) = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}

--- a/schemas/order/check/result.schema.json
+++ b/schemas/order/check/result.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "any_due", "orders_total", "due_total", "orders"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "any_due": { "type": "boolean" },
+    "orders_total": { "type": "integer", "minimum": 0 },
+    "due_total": { "type": "integer", "minimum": 0 },
+    "orders": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "scoped_name", "trigger", "due", "reason"],
+        "properties": {
+          "name": { "type": "string" },
+          "rig": { "type": "string" },
+          "scoped_name": { "type": "string" },
+          "trigger": { "type": "string" },
+          "due": { "type": "boolean" },
+          "reason": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/order/run/result.schema.json
+++ b/schemas/order/run/result.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "order", "scoped_name", "action", "wisp_id"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "order": { "type": "string" },
+    "rig": { "type": "string" },
+    "scoped_name": { "type": "string" },
+    "action": { "const": "formula" },
+    "wisp_id": { "type": "string" },
+    "routed_to": { "type": "string" },
+    "event_cursor": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": true
+}

--- a/schemas/session/new/result.schema.json
+++ b/schemas/session/new/result.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "session_id", "session_name", "template", "transport", "work_dir", "deferred_start", "attached"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "session_id": { "type": "string" },
+    "session_name": { "type": "string" },
+    "alias": { "type": "string" },
+    "template": { "type": "string" },
+    "transport": { "type": "string" },
+    "work_dir": { "type": "string" },
+    "deferred_start": { "type": "boolean" },
+    "attached": { "type": "boolean" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/session/nudge/result.schema.json
+++ b/schemas/session/nudge/result.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "target", "delivery", "queued", "outcome"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "target": { "type": "string" },
+    "session_id": { "type": "string" },
+    "session_name": { "type": "string" },
+    "delivery": { "type": "string", "enum": ["immediate", "wait-idle", "queue"] },
+    "queued": { "type": "boolean" },
+    "outcome": { "type": "string", "enum": ["delivered", "queued"] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/session/submit/result.schema.json
+++ b/schemas/session/submit/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "target", "intent", "queued", "outcome"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "target": { "type": "string" },
+    "intent": { "type": "string" },
+    "queued": { "type": "boolean" },
+    "outcome": { "type": "string", "enum": ["submitted", "queued", "interrupted"] }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
- add deterministic `--json` result records and schemas for `session new`, `session submit`, `session nudge`, `order check`, and formula-backed `order run`
- preserve `order check` exit semantics: 0 when any order is due, 1 when none are due, while still emitting its result JSON
- reject `order run --json` for exec-backed orders before running them because exec bodies may write arbitrary stdout under gc control

## Safe subset / skip rationale
- `session new --json` requires `--no-attach`; attaching is interactive and can hand control to a provider/terminal, so it cannot guarantee JSON-only stdout. The JSON result is emitted only for non-attaching creation paths.
- `order run --json` supports formula orders only. Exec orders are intentionally unsupported in JSON mode because the configured shell body can write arbitrary stdout before or alongside gc summaries; wrapping that safely would require a separate captured-output contract that this shard did not introduce.

## Validation
- `go test ./cmd/gc -run '^(TestSessionNewJSONRequiresNoAttach|TestCmdSessionNudgeQueueResolvesSessionName|TestJSONSchemaManifestForSessionOrderShardCommands|TestJSONCommandAllowsNonzeroResultOnlyForOrderCheck|TestJSONExecutionFailureIsStructured|TestEmitSessionSubmitResultJSON|TestOrderCheckJSONNoneDuePreservesSemanticExit|TestOrderRunJSONFormulaSummary|TestOrderRunJSONRejectsExecWithoutRunning)$' -count=1 -timeout=90s`
- `git diff --check`
- `make fmt-check`
- `GOOS=linux make lint`
- `make vet`
- `make check-docs`

## Broader test note
- `go test ./cmd/gc -count=1 -timeout=5m` was attempted and hit unrelated existing heavy provider lifecycle failures/timeouts: `TestBdRuntimeEnvForRigFallsBackToManagedCityPort` expected `GC_DOLT_PORT`, then `TestGcBeadsBdInitRejectsManagedProbeDatabaseName` timed out.

## Risk
- JSON schemas are intentionally open with `additionalProperties: true` to allow future fields.
- The only nonzero JSON result carveout is scoped to `order check`; other JSON command failures continue using the shared platform failure envelope.

