### PR TITLE
fix(cmd/gc): prefer findCity over GC_CITY env in cityForStoreDir

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -999,11 +999,17 @@ func mirrorBeadsDoltEnv(env map[string]string) {
 }
 
 func cityForStoreDir(dir string) string {
-	if cityPath, ok := resolveExplicitCityPathEnv(); ok {
-		return cityPath
-	}
+	// Walk up from the explicit dir first. When the caller knows the
+	// store path (e.g. an --city flag), a dir-discovered city is more
+	// authoritative than an inherited GC_CITY env. Env-first was
+	// silently swapping cityRoot/scopeRoot when an agent inherited
+	// GC_CITY from a different city, producing "managed_city endpoint
+	// origin is invalid for rig scope".
 	if p, err := findCity(dir); err == nil {
 		return p
+	}
+	if cityPath, ok := resolveExplicitCityPathEnv(); ok {
+		return cityPath
 	}
 	return dir
 }

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2406,6 +2406,42 @@ func TestCityForStoreDirHonoursGCCity(t *testing.T) {
 	}
 }
 
+func TestCityForStoreDirPrefersDiscoveredCityOverGCCity(t *testing.T) {
+	// Regression: when an explicit dir resolves via findCity to a city
+	// AND GC_CITY env points to a different city, the dir-discovered
+	// city wins. Otherwise an explicit --city flag whose value differs
+	// from an inherited GC_CITY env gets silently swapped at the bd
+	// runtime env layer, producing
+	// "managed_city endpoint origin is invalid for rig scope" because
+	// downstream resolution pairs the dir's config with the env city's
+	// scope.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+	envCity := filepath.Join(homeDir, "envcity")
+	if err := os.MkdirAll(filepath.Join(envCity, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(envCity, "city.toml"), []byte("[workspace]\nname = \"env\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", envCity)
+
+	dirCity := filepath.Join(homeDir, "dircity")
+	if err := os.MkdirAll(filepath.Join(dirCity, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirCity, "city.toml"), []byte("[workspace]\nname = \"dir\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := cityForStoreDir(dirCity)
+	if canonicalTestPath(got) != canonicalTestPath(dirCity) {
+		t.Errorf("cityForStoreDir(%q) = %q, want %q (dir-discovered city must win over GC_CITY=%q)", dirCity, got, dirCity, envCity)
+	}
+}
+
 func TestCityForStoreDirFallsBackToFindCity(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)


### PR DESCRIPTION
## Summary

`cityForStoreDir` (cmd/gc/bd_env.go) read `GC_CITY` / `GC_CITY_PATH` / `GC_CITY_ROOT` before trying `findCity(dir)`. When an agent inherits a stray `GC_CITY` pointing to a different city than `--city` / cwd actually targets, the env value wins and downstream callers pair the dir's config with the env city's scope. `contract.ResolveScopeConfigState` then runs the target city's HQ config through rig-scope validation and trips `internal/beads/contract/connection.go:429`:

```
bd list: invalid canonical endpoint state in <city>/.beads/config.yaml:
managed_city endpoint origin is invalid for rig scope
```

This is the normal state for any agent running a cross-city `gc` command, since each agent inherits `GC_CITY` from its supervisor's env (set to the supervisor's own city). The bug surfaces as "supervisor never spawns agents in newly-created cities" or, equivalently, as bd ops failing against any city you `--city`-flag to that differs from the inherited env.

Two-line priority swap: try `findCity(dir)` first; fall back to env only when path-based discovery fails. The `dir` argument is more authoritative than an inherited env. Env is still honored as a fallback hint when the caller passes an unrelated dir — preserves existing `TestCityForStoreDirHonoursGCCity` semantics.

Verified end-to-end against both reproducible triggers (both fail on stock binary, pass on patched):

```
GC_CITY=gascity-city gc --city test-engineering-standards-city status
GC_CITY=gascity-city gc --city wiki-pilot-sandbox session list
```

Bead: tr-hndhm.

## Testing

- [x] Targeted: `TestCityForStoreDir*` (4 tests), `TestBdRuntimeEnv*`, `TestOpenStoreAt*`, `TestCanonicalScope*`, `TestApplyResolvedRig*` — 35+ tests, all green.
- [x] Fast unit baseline: `GC_FAST_UNIT=1 go test ./cmd/gc/` — clean.
- [ ] `make check` — not run (per local convention; CI is the gate).
- [ ] `make check-docs` — not applicable, no docs/navigation/links changed.
- [ ] `make test-integration` — not applicable, no runtime/controller/workflow behavior changed (only env-resolver priority swap).

## Checklist

- [x] Linked an issue (`tr-hndhm`, gascity rig bead).
- [x] Added regression test (`TestCityForStoreDirPrefersDiscoveredCityOverGCCity`).
- [ ] Updated docs — not applicable.
- [ ] Breaking changes — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)