### PR TITLE
fix(sling): refuse cross-store routes that wedge scale_check (tr-6s7yx)

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -24,6 +24,50 @@ func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agen
 	return storeRefs[index] == assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
 }
 
+// agentReachesWorkflowStore reports whether the supervisor's scale_check
+// for agentCfg can read beads from the store identified by storeRef.
+// storeRef uses the workflowStoreRefForDir format ("city:<name>" for HQ,
+// "rig:<name>" for rig stores; empty when the store cannot be classified).
+//
+// A rig-scoped agent's scale_check runs in the rig's directory and queries
+// only that rig's bead store. An HQ-scoped agent's scale_check queries the
+// city store. A bead routed to an agent it cannot reach is invisible to
+// scale_check and silently wedges the pool (see tr-6s7yx).
+//
+// Returns true permissively when cfg or agentCfg is nil — callers should
+// only use this to refuse routes when both pieces of information are known.
+func agentReachesWorkflowStore(storeRef string, agentCfg *config.Agent, cityPath string, cfg *config.City) bool {
+	if cfg == nil || agentCfg == nil {
+		return true
+	}
+	agentRig := configuredRigName(cityPath, agentCfg, cfg.Rigs)
+	if agentRig == "" {
+		return strings.HasPrefix(storeRef, "city:")
+	}
+	return storeRef == "rig:"+agentRig
+}
+
+// agentReachableStoreLabel returns the workflowStoreRefForDir-formatted
+// label for the store an agent's scale_check can read. Used in error
+// messages from the cross-store sling guard so the label uses the same
+// shape as deps.StoreRef.
+//
+// Returns the empty string when cfg or agentCfg is nil.
+func agentReachableStoreLabel(agentCfg *config.Agent, cityPath, cityName string, cfg *config.City) string {
+	if cfg == nil || agentCfg == nil {
+		return ""
+	}
+	agentRig := configuredRigName(cityPath, agentCfg, cfg.Rigs)
+	if agentRig == "" {
+		cn := strings.TrimSpace(cityName)
+		if cn == "" {
+			cn = "city"
+		}
+		return "city:" + cn
+	}
+	return "rig:" + agentRig
+}
+
 func filterAssignedWorkBeadsForPoolDemand(
 	cfg *config.City,
 	cityPath string,

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -166,3 +166,68 @@ func TestSessionHasOpenAssignedWorkUsesOnlyReachableStore(t *testing.T) {
 		t.Fatal("rig-store assigned work should count for a rig-scoped session")
 	}
 }
+
+func TestAgentReachesWorkflowStore(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "alpha")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "alpha", Path: rigPath}},
+	}
+	hqAgent := &config.Agent{Name: "mayor"}
+	rigAgent := &config.Agent{Name: "polecat", Dir: "alpha"}
+
+	cases := []struct {
+		name     string
+		storeRef string
+		agent    *config.Agent
+		want     bool
+	}{
+		{name: "hq agent reaches city store", storeRef: "city:test-city", agent: hqAgent, want: true},
+		{name: "hq agent cannot reach rig store", storeRef: "rig:alpha", agent: hqAgent, want: false},
+		{name: "rig agent reaches own rig store", storeRef: "rig:alpha", agent: rigAgent, want: true},
+		{name: "rig agent cannot reach city store", storeRef: "city:test-city", agent: rigAgent, want: false},
+		{name: "rig agent cannot reach a different rig", storeRef: "rig:beta", agent: rigAgent, want: false},
+		{name: "empty storeRef is unreachable for rig agent", storeRef: "", agent: rigAgent, want: false},
+		{name: "empty storeRef is unreachable for hq agent", storeRef: "", agent: hqAgent, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := agentReachesWorkflowStore(tc.storeRef, tc.agent, cityPath, cfg); got != tc.want {
+				t.Fatalf("agentReachesWorkflowStore(%q, %q) = %v, want %v", tc.storeRef, tc.agent.Name, got, tc.want)
+			}
+		})
+	}
+
+	if !agentReachesWorkflowStore("city:test-city", nil, cityPath, cfg) {
+		t.Fatal("nil agent should permissively reach any store")
+	}
+	if !agentReachesWorkflowStore("rig:alpha", rigAgent, cityPath, nil) {
+		t.Fatal("nil cfg should permissively reach any store")
+	}
+}
+
+func TestAgentReachableStoreLabel(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "alpha")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "alpha", Path: rigPath}},
+	}
+	hqAgent := &config.Agent{Name: "mayor"}
+	rigAgent := &config.Agent{Name: "polecat", Dir: "alpha"}
+
+	if got := agentReachableStoreLabel(hqAgent, cityPath, "test-city", cfg); got != "city:test-city" {
+		t.Errorf("hq agent label = %q, want city:test-city", got)
+	}
+	if got := agentReachableStoreLabel(rigAgent, cityPath, "test-city", cfg); got != "rig:alpha" {
+		t.Errorf("rig agent label = %q, want rig:alpha", got)
+	}
+	if got := agentReachableStoreLabel(hqAgent, cityPath, "", cfg); got != "city:city" {
+		t.Errorf("hq agent label with empty cityName = %q, want city:city", got)
+	}
+	if got := agentReachableStoreLabel(nil, cityPath, "test-city", cfg); got != "" {
+		t.Errorf("nil agent label = %q, want empty", got)
+	}
+	if got := agentReachableStoreLabel(hqAgent, cityPath, "test-city", nil); got != "" {
+		t.Errorf("nil cfg label = %q, want empty", got)
+	}
+}

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -611,6 +611,18 @@ func (r cliBeadRouter) Route(_ context.Context, req sling.RouteRequest) error {
 	if r.deps.Store == nil {
 		return fmt.Errorf("built-in sling routing requires a store")
 	}
+	if r.deps.Cfg != nil {
+		if agentCfg, ok := findAgentByQualified(r.deps.Cfg, req.Target); ok {
+			if !agentReachesWorkflowStore(r.deps.StoreRef, &agentCfg, r.deps.CityPath, r.deps.Cfg) {
+				reachable := agentReachableStoreLabel(&agentCfg, r.deps.CityPath, r.deps.CityName, r.deps.Cfg)
+				return fmt.Errorf(
+					"gc sling: refusing cross-store route: bead %s lives in %s but target %q reads %s; "+
+						"re-file the bead in %s (or pick a target reachable from %s). "+
+						"Cross-store routes silently wedge pools — see tr-6s7yx",
+					req.BeadID, r.deps.StoreRef, req.Target, reachable, reachable, r.deps.StoreRef)
+			}
+		}
+	}
 	if err := r.deps.Store.SetMetadata(req.BeadID, "gc.routed_to", req.Target); err != nil {
 		return fmt.Errorf("setting gc.routed_to on %s: %w", req.BeadID, err)
 	}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -610,6 +610,125 @@ func TestDoSlingBeadToPool(t *testing.T) {
 	}
 }
 
+func TestCliBeadRouterRefusesCrossStoreRoute(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "alpha")
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "alpha", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			Dir:               "alpha",
+			MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+		}},
+	}
+	store := newSlingTestStore()
+	if _, err := store.Create(beads.Bead{ID: "HQ-1", Type: "task", Status: "open"}); err != nil {
+		t.Fatalf("seed HQ-1: %v", err)
+	}
+	deps := &slingDeps{
+		CityName: "test-city",
+		CityPath: cityPath,
+		Cfg:      cfg,
+		Store:    store,
+		StoreRef: "city:test-city",
+	}
+	router := cliBeadRouter{deps: deps}
+
+	err := router.Route(context.Background(), sling.RouteRequest{
+		BeadID: "HQ-1",
+		Target: "alpha/polecat",
+	})
+	if err == nil {
+		t.Fatal("expected cross-store route to be refused, got nil error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"refusing cross-store route", "city:test-city", "rig:alpha", "alpha/polecat", "tr-6s7yx"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+
+	// Verify the bead's metadata was NOT mutated.
+	bead, err := store.Get("HQ-1")
+	if err != nil {
+		t.Fatalf("store.Get(HQ-1): %v", err)
+	}
+	if bead.Metadata["gc.routed_to"] != "" {
+		t.Errorf("guard did not block SetMetadata: gc.routed_to = %q", bead.Metadata["gc.routed_to"])
+	}
+}
+
+func TestCliBeadRouterAllowsSameStoreRoute(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "alpha")
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "alpha", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			Dir:               "alpha",
+			MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+		}},
+	}
+	store := newSlingTestStore()
+	if _, err := store.Create(beads.Bead{ID: "RIG-1", Type: "task", Status: "open"}); err != nil {
+		t.Fatalf("seed RIG-1: %v", err)
+	}
+	deps := &slingDeps{
+		CityName: "test-city",
+		CityPath: cityPath,
+		Cfg:      cfg,
+		Store:    store,
+		StoreRef: "rig:alpha",
+	}
+	router := cliBeadRouter{deps: deps}
+
+	if err := router.Route(context.Background(), sling.RouteRequest{
+		BeadID: "RIG-1",
+		Target: "alpha/polecat",
+	}); err != nil {
+		t.Fatalf("same-store route should succeed, got: %v", err)
+	}
+	bead, err := store.Get("RIG-1")
+	if err != nil {
+		t.Fatalf("store.Get(RIG-1): %v", err)
+	}
+	if bead.Metadata["gc.routed_to"] != "alpha/polecat" {
+		t.Errorf("gc.routed_to = %q, want alpha/polecat", bead.Metadata["gc.routed_to"])
+	}
+}
+
+func TestCliBeadRouterAllowsHQTargetFromHQStore(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+	store := newSlingTestStore()
+	if _, err := store.Create(beads.Bead{ID: "HQ-2", Type: "task", Status: "open"}); err != nil {
+		t.Fatalf("seed HQ-2: %v", err)
+	}
+	deps := &slingDeps{
+		CityName: "test-city",
+		CityPath: cityPath,
+		Cfg:      cfg,
+		Store:    store,
+		StoreRef: "city:test-city",
+	}
+	router := cliBeadRouter{deps: deps}
+
+	if err := router.Route(context.Background(), sling.RouteRequest{
+		BeadID: "HQ-2",
+		Target: "mayor",
+	}); err != nil {
+		t.Fatalf("HQ->HQ route should succeed, got: %v", err)
+	}
+}
+
 func TestDoSlingFormulaToAgent(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
@@ -947,6 +1066,11 @@ func TestBuiltInSlingPoolRouteContractUsesMetadataOnly(t *testing.T) {
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
 	store := newSlingTestStore()
 	deps.Store = store
+	// The bead lives in the saitoc rig store (single physical store reused
+	// below as both source and rig store for the scale_check probe), so
+	// align StoreRef accordingly. Without this, the cross-store guard
+	// added in tr-6s7yx refuses the HQ-store → rig-pool route.
+	deps.StoreRef = "rig:saitoc"
 
 	created, err := store.Create(beads.Bead{Title: "route contract work", Type: "task"})
 	if err != nil {
@@ -1727,7 +1851,16 @@ func TestResolveInlineBeadActionMultiDashStoreErrorSurfaces(t *testing.T) {
 	}
 }
 
-func TestCmdSlingConfiguredPrefixAllAlphaExistingBeadUsesPrefixStore(t *testing.T) {
+// TestCmdSlingConfiguredPrefixAllAlphaCrossRigRouteRefused verifies that
+// `gc sling` refuses a route whose source bead and target agent live in
+// different stores. Cross-store routes silently wedge pools because the
+// supervisor's scale_check is single-store (see tr-6s7yx).
+//
+// Previously this scenario was permitted with the assumption that
+// "routing = metadata only, keep the bead in its source store." That
+// assumption created the wedge; the guard now refuses the route up
+// front.
+func TestCmdSlingConfiguredPrefixAllAlphaCrossRigRouteRefused(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_BEADS", "file")
 
@@ -1791,11 +1924,13 @@ dir = "orders"
 		"", "",
 		&stdout, &stderr,
 	)
-	if code != 0 {
-		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code == 0 {
+		t.Fatalf("cmdSling returned 0, want non-zero refusal; stdout=%s stderr=%s", stdout.String(), stderr.String())
 	}
-	if strings.Contains(stdout.String(), "Created ") {
-		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	for _, want := range []string{"refusing cross-store route", "tr-6s7yx"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr missing %q: %s", want, stderr.String())
+		}
 	}
 
 	frontendStore, err := openStoreAtForCity(frontendDir, cityDir)
@@ -1806,8 +1941,8 @@ dir = "orders"
 	if err != nil {
 		t.Fatalf("frontendStore.Get(FE-abcde): %v", err)
 	}
-	if routed.Metadata["gc.routed_to"] != "orders/worker" {
-		t.Fatalf("frontend bead gc.routed_to = %q, want orders/worker", routed.Metadata["gc.routed_to"])
+	if got := routed.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("refused route mutated metadata: gc.routed_to = %q, want empty", got)
 	}
 
 	ordersStore, err := openStoreAtForCity(ordersDir, cityDir)
@@ -1901,7 +2036,11 @@ func TestCmdSlingOneArgHyphenatedPrefixMultiDashExistingBeadUsesDefaultTarget(t 
 	assertHyphenatedRigBeadRoutedWithoutInlineOrphan(t, cityDir, rigDir, beadID, "agent-diagnostics/worker")
 }
 
-func TestCmdSlingCrossRigHyphenatedPrefixMultiDashExistingBeadUsesPrefixStore(t *testing.T) {
+// TestCmdSlingCrossRigHyphenatedPrefixMultiDashRouteRefused verifies the
+// cross-store guard fires for a hyphenated-prefix rig bead routed to an
+// agent in a different rig (see tr-6s7yx). Refusal is up-front: no
+// metadata mutation, no orphan creation in the target store.
+func TestCmdSlingCrossRigHyphenatedPrefixMultiDashRouteRefused(t *testing.T) {
 	beadID := "agent-diagnostics-spawn-storm"
 	cityDir, rigDir, otherDir := setupCmdSlingHyphenatedRigPrefixBeadFixture(t, beadID, "other")
 
@@ -1915,15 +2054,40 @@ func TestCmdSlingCrossRigHyphenatedPrefixMultiDashExistingBeadUsesPrefixStore(t 
 		"", "",
 		&stdout, &stderr,
 	)
-	if code != 0 {
-		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code == 0 {
+		t.Fatalf("cmdSling returned 0, want non-zero refusal; stdout=%s stderr=%s", stdout.String(), stderr.String())
 	}
-	if strings.Contains(stdout.String(), "Created ") {
-		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	for _, want := range []string{"refusing cross-store route", "tr-6s7yx"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr missing %q: %s", want, stderr.String())
+		}
 	}
 
-	assertHyphenatedRigBeadRoutedWithoutInlineOrphan(t, cityDir, rigDir, beadID, "other/worker")
+	assertHyphenatedRigBeadNotMutatedAndNoOrphan(t, cityDir, rigDir, beadID)
 	assertStoreHasNoBeadTitle(t, cityDir, otherDir, beadID)
+}
+
+// assertHyphenatedRigBeadNotMutatedAndNoOrphan verifies a refused cross-rig
+// route left the bead's metadata untouched in its source rig store and
+// did not create an orphan in the city store. Mirrors
+// assertHyphenatedRigBeadRoutedWithoutInlineOrphan but for the refusal
+// path.
+func assertHyphenatedRigBeadNotMutatedAndNoOrphan(t *testing.T, cityDir, rigDir, beadID string) {
+	t.Helper()
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	routed, err := rigStore.Get(beadID)
+	if err != nil {
+		t.Fatalf("rigStore.Get(%s): %v", beadID, err)
+	}
+	if got := routed.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("refused route mutated rig bead: gc.routed_to = %q, want empty", got)
+	}
+
+	assertStoreHasNoBeadTitle(t, cityDir, cityDir, beadID)
 }
 
 func setupCmdSlingHyphenatedRigPrefixBeadFixture(t *testing.T, beadID, agentDir string) (cityDir, rigDir, otherDir string) {
@@ -2359,7 +2523,11 @@ func TestCmdSlingOneArgMultiDashExistingBeadUsesDefaultTarget(t *testing.T) {
 	}
 }
 
-func TestCmdSlingCrossRigMultiDashExistingBeadUsesPrefixStore(t *testing.T) {
+// TestCmdSlingCrossRigMultiDashRouteRefused verifies the cross-store
+// guard fires for a multi-dash-prefix rig bead routed across rigs (see
+// tr-6s7yx). The bead remains in its source rig with no metadata
+// mutation; the target rig store stays empty.
+func TestCmdSlingCrossRigMultiDashRouteRefused(t *testing.T) {
 	cityDir, rigDir := setupCmdSlingMultiDashBeadFixture(t, false)
 	ordersDir := filepath.Join(cityDir, "orders")
 	if err := os.MkdirAll(ordersDir, 0o755); err != nil {
@@ -2399,14 +2567,13 @@ dir = "orders"
 		"", "",
 		&stdout, &stderr,
 	)
-	if code != 0 {
-		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code == 0 {
+		t.Fatalf("cmdSling returned 0, want non-zero refusal; stdout=%s stderr=%s", stdout.String(), stderr.String())
 	}
-	if strings.Contains(stdout.String(), "Created ") {
-		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), "found existing bead") {
-		t.Errorf("stderr = %q, want existing-bead routing breadcrumb", stderr.String())
+	for _, want := range []string{"refusing cross-store route", "tr-6s7yx"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr missing %q: %s", want, stderr.String())
+		}
 	}
 
 	rigStore, err := openStoreAtForCity(rigDir, cityDir)
@@ -2417,8 +2584,8 @@ dir = "orders"
 	if err != nil {
 		t.Fatalf("rigStore.Get(fo-spawn-storm): %v", err)
 	}
-	if routed.Metadata["gc.routed_to"] != "orders/worker" {
-		t.Fatalf("rig bead gc.routed_to = %q, want orders/worker", routed.Metadata["gc.routed_to"])
+	if got := routed.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("refused route mutated rig bead: gc.routed_to = %q, want empty", got)
 	}
 	all, err := rigStore.List(beads.ListQuery{AllowScan: true})
 	if err != nil {


### PR DESCRIPTION
## Summary

`gc sling <target> <bead>` previously allowed routes where the bead's source store and the target agent's reachable store disagreed. That created silent unservable demand: the route stamped `gc.routed_to` on the source-store bead, but a rig-scoped pool's supervisor runs its default `scale_check` from the rig directory, so it never sees HQ-stored work and the pool stays at zero.

This PR refuses known cross-store routes before any route mutation or custom `sling_query` dispatch. The guard now covers the production entry points that can create this wedge:

- direct CLI bead routes in `gc sling`
- direct API sling routes, with a typed `urn:gascity:error:sling-cross-store` Problem Details response
- graph workflow route decoration for non-topology steps
- manual `gc order run` graph dispatch
- controller order-dispatch graph wisps

The error names the source store, target, reachable store, and `tr-6s7yx` so operators can re-file the bead/workflow in the store the target can actually read, or pick a reachable target.

`--force` intentionally does not bypass cross-store reachability. The API request docs and CLI help now say that explicitly.

## Implementation notes

- `internal/agentutil` owns the shared agent resolution, reachable-store predicate, canonical empty-city fallback, and cross-store route error contract.
- `internal/sling` exposes the direct-route validation wrapper used by CLI/API sling callers.
- `internal/graphroute` uses the same shared cross-store error contract for graph step validation instead of defining a parallel error type.
- Order-dispatch keeps existing best-effort behavior for unrelated graph decoration failures, but treats cross-store refusals as hard route failures.

## Discovery

A `gascity_packs/gastown.polecat` pool sat wedged for 24h+ with routed HQ-stored beads that never became visible to the rig supervisor's `scale_check`. From the city root, `bd ready --metadata-field gc.routed_to=...` found the demand; from the rig directory, the same query returned no work. The supervisor trace therefore kept `scale_check_counts[...] = 0` even though demand existed.

Root cause: the supervisor's default `scale_check` is single-store. Cross-store routed demand is invisible to the target pool.

A sibling local YAML/config issue also masked the symptom during investigation, but fixing YAML alone did not unwedge the pool; re-filing demand into the rig store did.

## Test changes

New and updated tests cover:

- direct CLI/API refusal before side effects, including custom `sling_query`
- same-store direct route allow cases for HQ and rig agents
- qualified pool-instance reachability checks
- graph workflow cross-store refusal and direct-session exemptions
- manual order-run and controller order-dispatch cross-store graph failures
- generated API Problem Details documentation
- an end-to-end same-rig prefixed-bead `cmdSling` route so valid prefix-store routing remains covered while cross-store prefixed routes are refused

The adoption branch also keeps a small test-only stabilization in `TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates`: the old strict half-serial wall-clock bound failed locally at ~204ms against a 200ms ceiling even though creates overlapped. The test now asserts observed overlap directly and keeps only a loose wall-clock sanity bound.

## Follow-up

- `ga-080ftm0` tracks bounding repeated `OrderFailed` emissions and failed tracking-bead churn for permanent cross-store graph-order misconfigurations. The current PR is still an improvement over the silent wedge because the misconfiguration becomes explicit; the follow-up limits repeated patrol noise.

## Related beads

- `tr-6s7yx` - cross-store route wedge design context
- `tr-m5fqd` - investigation that uncovered the wedge
- `tr-ht80e` - sibling YAML bug in `gc rig add`
- `tr-hndhm` - sibling caller-side scope bug at config-validation layer

## Test plan

- [x] Focused sling/router/API/graph/order tests pass in review artifacts
- [x] `make dashboard-check` passes in review artifacts for generated API changes
- [x] `go vet ./...` passed in the original PR test plan
- [ ] CI green