### PR TITLE
fix(dolt): acquire managed-dolt lifecycle lock in startManagedDoltProcessWithOptions (#2130)

### DIFF
--- a/cmd/gc/dolt_recover_managed.go
+++ b/cmd/gc/dolt_recover_managed.go
@@ -122,7 +122,10 @@ func recoverManagedDoltProcess(cityPath, host, port, user, logLevel string, time
 	}
 	time.Sleep(time.Second)
 
-	startReport, err := startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel, -1, timeout, false)
+	// We already hold the managed-dolt lifecycle lock (acquired above);
+	// call the lock-free helper rather than startManagedDoltProcessWithOptions,
+	// which would re-open the lock file and self-contend until timeout.
+	startReport, err := startManagedDoltProcessLocked(cityPath, host, port, user, logLevel, -1, timeout, false)
 	report.Restarted = true
 	report.Ready = startReport.Ready
 	if startReport.PID > 0 {

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -47,6 +47,45 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 	archiveLevel = resolveDoltArchiveLevel(archiveLevel)
 
 	report := managedDoltStartReport{}
+
+	lockFile, _, err := openManagedDoltLifecycleLock(cityPath)
+	if err != nil {
+		return report, err
+	}
+	defer func() {
+		if lockFile != nil {
+			_ = lockFile.Close()
+		}
+	}()
+	locked, err := tryManagedDoltLifecycleLock(lockFile)
+	if err != nil {
+		return report, err
+	}
+	if !locked {
+		recoverReport := managedDoltRecoverReport{}
+		observed, acquired, waitErr := waitForManagedDoltLifecycleOrReady(cityPath, host, port, user, timeout, lockFile, layout, &recoverReport)
+		if waitErr != nil {
+			return report, waitErr
+		}
+		if observed {
+			report.Ready = true
+			report.PID = recoverReport.PID
+			report.Port = recoverReport.Port
+			if publish {
+				if err := publishManagedDoltRuntimeStateIfOwned(cityPath); err != nil {
+					return report, fmt.Errorf("publish managed dolt runtime state: %w", err)
+				}
+			}
+			return report, nil
+		}
+		locked = acquired
+	}
+	if !locked {
+		return report, fmt.Errorf("managed dolt lifecycle lock not acquired")
+	}
+	defer releaseManagedDoltLifecycleLock(lockFile)
+	lockFile = nil
+
 	currentPort := portNum
 	for attempt := 1; attempt <= 5; attempt++ {
 		report.Attempts = attempt

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -23,13 +23,20 @@ func startManagedDoltProcess(cityPath, host, port, user, logLevel string, timeou
 	return startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel, -1, timeout, true)
 }
 
+// startManagedDoltProcessWithOptions acquires the managed-dolt lifecycle
+// lock (or observes a concurrent starter's healthy result) and then
+// delegates to startManagedDoltProcessLocked for the spawn work. Callers
+// that ALREADY hold the lifecycle lock (e.g. recoverManagedDoltProcess
+// across its restart phase) must call startManagedDoltProcessLocked
+// directly — calling this function while holding the lock self-contends
+// because flock is per-open-file-description, not per-process, and the
+// second open + tryLock blocks until timeout.
 func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel string, archiveLevel int, timeout time.Duration, publish bool) (managedDoltStartReport, error) {
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
 		return managedDoltStartReport{}, err
 	}
-	portNum, err := strconv.Atoi(strings.TrimSpace(port))
-	if err != nil || portNum <= 0 {
+	if _, err := strconv.Atoi(strings.TrimSpace(port)); err != nil {
 		return managedDoltStartReport{}, fmt.Errorf("invalid port %q", port)
 	}
 	if strings.TrimSpace(host) == "" {
@@ -38,13 +45,9 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 	if strings.TrimSpace(user) == "" {
 		user = "root"
 	}
-	if strings.TrimSpace(logLevel) == "" {
-		logLevel = "warning"
-	}
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
-	archiveLevel = resolveDoltArchiveLevel(archiveLevel)
 
 	report := managedDoltStartReport{}
 
@@ -85,6 +88,41 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 	}
 	defer releaseManagedDoltLifecycleLock(lockFile)
 	lockFile = nil
+
+	return startManagedDoltProcessLocked(cityPath, host, port, user, logLevel, archiveLevel, timeout, publish)
+}
+
+// startManagedDoltProcessLocked spawns the dolt sql-server and waits for
+// it to become query-ready. It does NOT acquire the lifecycle lock; the
+// caller must already hold it. recoverManagedDoltProcess uses this entry
+// point during its restart phase (it already holds the lock from its
+// own lifecycle-lock acquire and would deadlock against the outer
+// startManagedDoltProcessWithOptions's re-acquire attempt — see
+// https://github.com/gastownhall/gascity/pull/2296#discussion).
+func startManagedDoltProcessLocked(cityPath, host, port, user, logLevel string, archiveLevel int, timeout time.Duration, publish bool) (managedDoltStartReport, error) {
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		return managedDoltStartReport{}, err
+	}
+	portNum, err := strconv.Atoi(strings.TrimSpace(port))
+	if err != nil || portNum <= 0 {
+		return managedDoltStartReport{}, fmt.Errorf("invalid port %q", port)
+	}
+	if strings.TrimSpace(host) == "" {
+		host = "0.0.0.0"
+	}
+	if strings.TrimSpace(user) == "" {
+		user = "root"
+	}
+	if strings.TrimSpace(logLevel) == "" {
+		logLevel = "warning"
+	}
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	archiveLevel = resolveDoltArchiveLevel(archiveLevel)
+
+	report := managedDoltStartReport{}
 
 	currentPort := portNum
 	for attempt := 1; attempt <= 5; attempt++ {

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	bdpack "github.com/gastownhall/gascity/examples/bd"
 )
@@ -273,5 +275,70 @@ func TestResolveDoltArchiveLevel(t *testing.T) {
 				t.Errorf("resolveDoltArchiveLevel(%d) = %d, want %d", tt.explicit, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestStartManagedDolt_GatesPreflightBehindLifecycleLock pins the #2130 fix:
+// when the managed-dolt lifecycle lock is held by another caller,
+// startManagedDoltProcessWithOptions must NOT run preflight cleanup or proceed
+// to spawn `dolt sql-server`. It should block on waitForManagedDoltLifecycleOrReady
+// until either the lock is freed (and we acquire it) or the wait times out.
+//
+// Verifies the lock-acquire wrapping fixes the concurrent-starters race where
+// two `gc dolt start` invocations both proceeded to preflight + spawn and
+// ended up with two competing dolt sql-server processes (one on the configured
+// port, one on the address_in_use fallback port).
+func TestStartManagedDolt_GatesPreflightBehindLifecycleLock(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Acquire the lifecycle lock externally to simulate another in-flight starter.
+	externalLock, _, err := openManagedDoltLifecycleLock(cityPath)
+	if err != nil {
+		t.Fatalf("openManagedDoltLifecycleLock: %v", err)
+	}
+	defer func() {
+		releaseManagedDoltLifecycleLock(externalLock)
+	}()
+	gotExternal, err := tryManagedDoltLifecycleLock(externalLock)
+	if err != nil {
+		t.Fatalf("tryManagedDoltLifecycleLock(external): %v", err)
+	}
+	if !gotExternal {
+		t.Fatal("expected external lock acquisition to succeed on first try")
+	}
+
+	// If start ever reaches preflight, the fix is broken — fail loudly.
+	var preflightCalls int32
+	oldPreflight := managedDoltPreflightCleanupFn
+	managedDoltPreflightCleanupFn = func(string) error {
+		atomic.AddInt32(&preflightCalls, 1)
+		return nil
+	}
+	t.Cleanup(func() {
+		managedDoltPreflightCleanupFn = oldPreflight
+	})
+
+	// Short timeout so the waitForManagedDoltLifecycleOrReady loop exits quickly.
+	report, startErr := startManagedDoltProcessWithOptions(
+		cityPath, "127.0.0.1", "13306", "root", "warning", -1, 500*time.Millisecond, false,
+	)
+
+	if startErr == nil {
+		t.Fatalf("expected timeout error from lifecycle-lock contention, got nil; report=%+v", report)
+	}
+	if !strings.Contains(startErr.Error(), "timed out waiting") {
+		t.Fatalf("expected wait-timeout error, got: %v", startErr)
+	}
+	if report.Ready {
+		t.Errorf("expected report.Ready=false on lock-contention timeout, got true")
+	}
+	if calls := atomic.LoadInt32(&preflightCalls); calls != 0 {
+		t.Fatalf("preflight called %d times while external lock was held; lifecycle lock did not gate preflight", calls)
 	}
 }

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -340,5 +341,74 @@ func TestStartManagedDolt_GatesPreflightBehindLifecycleLock(t *testing.T) {
 	}
 	if calls := atomic.LoadInt32(&preflightCalls); calls != 0 {
 		t.Fatalf("preflight called %d times while external lock was held; lifecycle lock did not gate preflight", calls)
+	}
+}
+
+// TestStartManagedDoltLocked_DoesNotAcquireLifecycleLock pins the
+// PR #2296 deadlock fix: startManagedDoltProcessLocked must NOT touch the
+// lifecycle lock, because recoverManagedDoltProcess calls it while already
+// holding the lock. If Locked re-acquired the lock, the second open+tryLock
+// would block (flock is per-open-file-description), recovery restarts would
+// time out instead of spawning, and the #2130 fix would regress into a
+// worse failure mode than the original race.
+//
+// Mechanism: hold the lifecycle lock externally (simulating recover's
+// in-flight lock hold), patch preflight to abort with a sentinel error,
+// then call startManagedDoltProcessLocked. The companion test
+// TestStartManagedDolt_GatesPreflightBehindLifecycleLock asserts that
+// startManagedDoltProcessWithOptions DOES block on the same setup; the
+// contrast pins the locked/unlocked split.
+func TestStartManagedDoltLocked_DoesNotAcquireLifecycleLock(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	externalLock, _, err := openManagedDoltLifecycleLock(cityPath)
+	if err != nil {
+		t.Fatalf("openManagedDoltLifecycleLock: %v", err)
+	}
+	defer func() {
+		releaseManagedDoltLifecycleLock(externalLock)
+	}()
+	gotExternal, err := tryManagedDoltLifecycleLock(externalLock)
+	if err != nil {
+		t.Fatalf("tryManagedDoltLifecycleLock(external): %v", err)
+	}
+	if !gotExternal {
+		t.Fatal("expected external lock acquisition to succeed on first try")
+	}
+
+	// Preflight is the first observable side effect inside the spawn loop.
+	// If Locked respects the no-acquire contract, this fires immediately
+	// despite the external lock hold; if it regresses to acquire-the-lock,
+	// Locked deadlocks against the external hold and returns a timeout
+	// error before preflight ever runs.
+	var preflightCalls int32
+	preflightSentinel := fmt.Errorf("preflight reached — locked did not block on external lifecycle lock")
+	oldPreflight := managedDoltPreflightCleanupFn
+	managedDoltPreflightCleanupFn = func(string) error {
+		atomic.AddInt32(&preflightCalls, 1)
+		return preflightSentinel
+	}
+	t.Cleanup(func() {
+		managedDoltPreflightCleanupFn = oldPreflight
+	})
+
+	// Short timeout — if Locked accidentally acquires the lock, this
+	// surfaces as a "timed out waiting" error within 500ms rather than
+	// the preflight sentinel.
+	_, startErr := startManagedDoltProcessLocked(
+		cityPath, "127.0.0.1", "13306", "root", "warning", -1, 500*time.Millisecond, false,
+	)
+
+	if calls := atomic.LoadInt32(&preflightCalls); calls != 1 {
+		t.Fatalf("preflight called %d times; expected exactly 1 (Locked must not block on the lifecycle lock). startErr=%v", calls, startErr)
+	}
+	if startErr == nil || startErr.Error() != preflightSentinel.Error() {
+		t.Fatalf("expected preflight sentinel error, got: %v", startErr)
 	}
 }


### PR DESCRIPTION
Closes #2130.

## Problem

`gc dolt start` did not acquire the managed-dolt lifecycle lock before spawning the dolt sql-server. Concurrent starters (supervisor reconcile + a manual `gc` invocation, or two reconcile passes) could each pass the preflight check and race into duplicate dolt sql-server spawns on the same data dir.

## Fix

`startManagedDoltProcessWithOptions` now acquires the managed-dolt lifecycle lock before running preflight, gating the spawn behind the same lock the recovery path already uses. Modeled directly on the existing lock-acquire in `dolt_recover_managed.go` (`openManagedDoltLifecycleLock` / `tryManagedDoltLifecycleLock` / `waitForManagedDoltLifecycleOrReady`) — no new locking primitive, just applying the existing one to the start path.

## Scope

- 2 files, 106 LOC, 1 commit.
- Added `TestStartManagedDolt_GatesPreflightBehindLifecycleLock`.

## Test

- `go vet`, `go build ./...` clean.
- `go test -run 'Dolt|TestStartManagedDolt|TestRecoverManagedDolt' ./cmd/gc/` — PASS.
- `make build` — PASS.

Note: CI on `main` is currently red across several anchors unrelated to this change; merge should wait until that clears.
