### PR TITLE
test(integration): quarantine TestHumaBinary_CityUnregisterAsync (rest-full-6-of-16 anchor; tracks #2090)

### DIFF
--- a/test/integration/huma_binary_test.go
+++ b/test/integration/huma_binary_test.go
@@ -480,6 +480,17 @@ func TestHumaBinary_CityCreateAsync(t *testing.T) {
 //
 //	go test -tags=integration ./test/integration/ -run TestHumaBinary_CityUnregisterAsync
 func TestHumaBinary_CityUnregisterAsync(t *testing.T) {
+	// Quarantined: this test was the dominant trip on Integration / rest-full-6-of-16
+	// (13 hits in the 2026-05-15 → 2026-05-17 red-CI anchor window). Root cause is the
+	// supervisor's 5s shutdown grace expiring under CI load: when the mayor session
+	// is still starting (or another order is in flight) at unregister time, the
+	// supervisor force-shuts-down and emits request.failed(city.unregister), which the
+	// test treats as a hard fatal. Same 5s-budget root cause as #2090. Re-enable once
+	// either #2090 lands (the supervisor's shutdown budget is reshaped to tolerate
+	// in-flight work) or the test is restructured to wait for mayor-session-start
+	// completion (not just request.result.city.create) before issuing unregister.
+	t.Skip("flaky on CI under load — 5s supervisor shutdown budget races with in-flight mayor-session-start; tracked in #2090")
+
 	bin := buildGCBinary(t)
 
 	root := shortTempDir(t)


### PR DESCRIPTION
Quarantines the dominant trip on the `Integration / rest-full-6-of-16` CI shard.

## Root cause

`TestHumaBinary_CityUnregisterAsync` races between mayor-session-start completion and unregister. Under CI load the supervisor's 5s shutdown grace expires, the supervisor force-shuts-down and emits `request.failed(city.unregister)`, and the test's switch treats `request.failed` as a hard `t.Fatalf`. This is the same 5s shutdown-budget root cause tracked in #2090.

## Change

`t.Skip` with a tracking comment, 1 file, +11/-0. Re-enable once #2090 lands or the test is restructured to wait for mayor-session-start completion before issuing unregister.

## Test

`go vet`, `go build ./...` clean; `go test -tags=integration -run TestHumaBinary_CityUnregisterAsync ./test/integration/` emits SKIP as expected.
