### PR TITLE
ci(nightly): track .beads-src/go.mod for setup-go (red-CI anchor; Nightly 100% red since 2026-05-07)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -118,7 +118,7 @@ jobs:
           path: .beads-src
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.25.10"
+          go-version-file: .beads-src/go.mod
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
@@ -184,7 +184,7 @@ jobs:
           path: .beads-src
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.25.10"
+          go-version-file: .beads-src/go.mod
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
@@ -241,7 +241,7 @@ jobs:
           path: .beads-src
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.25.10"
+          go-version-file: .beads-src/go.mod
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"


### PR DESCRIPTION
Fixes the Nightly worker-inference trio, which has been 100% red since 2026-05-07.

## Root cause

All three `WorkerInference <provider>/tmux-cli` jobs (codex, claude, gemini) fail at the **Build bd** step:

```
go: go.mod requires go >= 1.26.2 (running go 1.25.10; GOTOOLCHAIN=local)
```

`nightly.yml` hardcodes `go-version: "1.25.10"` at three `setup-go` sites, but bd v1.0.4's `go.mod` declares `go 1.26.2`. `actions/setup-go` sets `GOTOOLCHAIN=local` by default, so the bd install exits 1 before any worker-inference test runs.

## Change

Replace all three `go-version: "1.25.10"` with `go-version-file: .beads-src/go.mod`, so the toolchain tracks bd's actual requirement and future `BD_REF` bumps automatically. Same pattern as `ci.yml`'s `go-version-file: go.mod`. The `.beads-src` checkout already runs immediately before each `setup-go`. 1 file, +3/-3.

gascity's own `go.mod` is `go 1.25.10`; the Go 1.26 toolchain is forward-compatible with 1.25 modules, so the subsequent WorkerInference compilation of gascity code stays correct.
