### PR TITLE
fix(scripts): make scripts/go-test-observable portable to bash 3.2 (Mac / make test red-CI anchor)

### DIFF
--- a/scripts/go-test-observable
+++ b/scripts/go-test-observable
@@ -30,7 +30,13 @@ print_failure_details() {
 
   echo "observable go test: failure details from $log" >&2
 
-  mapfile -t failed_tests < <(jq -r 'select(.Action == "fail" and .Test != null) | .Test' "$log" | sort -u)
+  # Portable across bash 3.2 (macOS default) and bash 4+. mapfile/readarray
+  # are bash 4+ only — using them on macOS runners exits 127 (command not
+  # found) and red-runs the entire Mac/make test job.
+  failed_tests=()
+  while IFS= read -r failed_test_name; do
+    failed_tests+=("$failed_test_name")
+  done < <(jq -r 'select(.Action == "fail" and .Test != null) | .Test' "$log" | sort -u)
   if [ "${#failed_tests[@]}" -gt 0 ]; then
     for test_name in "${failed_tests[@]}"; do
       echo "observable go test: failed test: $test_name" >&2

--- a/scripts/go-test-observable
+++ b/scripts/go-test-observable
@@ -32,7 +32,7 @@ print_failure_details() {
 
   # Portable across bash 3.2 (macOS default) and bash 4+. mapfile/readarray
   # are bash 4+ only — using them on macOS runners exits 127 (command not
-  # found) and red-runs the entire Mac/make test job.
+  # found) and fails the entire Mac/make test job.
   failed_tests=()
   while IFS= read -r failed_test_name; do
     failed_tests+=("$failed_test_name")


### PR DESCRIPTION
Fixes the `Mac / make test` red-CI anchor — the chief macOS offender across RC Gate (8 hits) and Mac Regression (4 hits).

## Root cause

`scripts/go-test-observable` uses `mapfile`, a bash 4+ builtin. macOS ships `/bin/bash` as 3.2.x (Apple froze it pre-GPLv3). The GitHub macOS runner's default bash exits 127 (`command not found`) on that line, and `make: *** [test] Error 127` follows. The `fail github.com/gastownhall/gascity/cmd/gc` line in the CI log is the observable script's own status output emitted just before `mapfile` blows up the make-test step — it is not a real test failure.

## Change

Replace the single `mapfile -t failed_tests < <(...)` with a portable `while read` loop that works on bash 3.2 and bash 4+. Only `mapfile`/`readarray` site in the repo's shell scripts. 1 file, +7/-1.

## Test

`bash -n` parses; behavioral simulation with a JSONL fixture confirms the loop populates the array identically (sorted, unique). Cannot fully reproduce a Mac runner on Linux — the workflow change exercises on the first Mac CI run.
