### PR TITLE
Fix Codex hook doctor drift coverage

### DIFF
--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -250,6 +250,20 @@ func TestCmdHandoffAutoHookFormatCodex(t *testing.T) {
 	if !strings.Contains(payload.HookSpecificOutput.AdditionalContext, "Handoff: sent auto mail") {
 		t.Fatalf("additionalContext = %q, want handoff confirmation", payload.HookSpecificOutput.AdditionalContext)
 	}
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	all, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("open beads = %d, want handoff mail", len(all))
+	}
+	if !strings.Contains(payload.HookSpecificOutput.AdditionalContext, all[0].ID) {
+		t.Fatalf("additionalContext = %q, want handoff mail id %s", payload.HookSpecificOutput.AdditionalContext, all[0].ID)
+	}
 }
 
 func TestDoHandoffAutoReportsHookOutputWriteError(t *testing.T) {

--- a/cmd/gc/doctor_codex_hooks.go
+++ b/cmd/gc/doctor_codex_hooks.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/hooks"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
 type codexHooksDriftCheck struct {
@@ -19,36 +19,158 @@ type codexHooksDriftCheck struct {
 }
 
 func newCodexHooksDriftCheck(dirs []string) *codexHooksDriftCheck {
-	seen := map[string]struct{}{}
-	var cleaned []string
-	for _, dir := range dirs {
-		dir = strings.TrimSpace(dir)
-		if dir == "" {
-			continue
-		}
-		dir = filepath.Clean(dir)
-		if _, ok := seen[dir]; ok {
-			continue
-		}
-		seen[dir] = struct{}{}
-		cleaned = append(cleaned, dir)
-	}
-	sort.Strings(cleaned)
-	return &codexHooksDriftCheck{dirs: cleaned}
+	return &codexHooksDriftCheck{dirs: cleanCodexHookDirs(dirs)}
 }
 
 func codexHookWorkDirs(cityPath string, cfg *config.City) []string {
-	dirs := []string{cityPath}
+	var dirs []string
+	addCodexHookDir(&dirs, cityPath)
 	if cfg == nil {
 		return dirs
 	}
+	suspendedRigPaths := map[string]bool{}
 	for _, rig := range cfg.Rigs {
 		if rig.Suspended || strings.TrimSpace(rig.Path) == "" {
+			if rig.Suspended && strings.TrimSpace(rig.Path) != "" {
+				suspendedRigPaths[filepath.Clean(rig.Path)] = true
+			}
 			continue
 		}
-		dirs = append(dirs, rig.Path)
+		addCodexHookDir(&dirs, rig.Path)
+	}
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		if agent.Suspended || agentInSuspendedRig(cityPath, agent, cfg.Rigs, suspendedRigPaths) {
+			continue
+		}
+		if !agentUsesCodexHookSurface(cfg, agent) {
+			continue
+		}
+		addCodexHookAgentWorkDirs(&dirs, cityPath, cfg, agent)
 	}
 	return dirs
+}
+
+func cleanCodexHookDirs(dirs []string) []string {
+	var cleaned []string
+	for _, dir := range dirs {
+		addCodexHookDir(&cleaned, dir)
+	}
+	sort.Strings(cleaned)
+	return cleaned
+}
+
+func addCodexHookDir(dirs *[]string, dir string) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return
+	}
+	dir = filepath.Clean(dir)
+	for _, existing := range *dirs {
+		if existing == dir {
+			return
+		}
+	}
+	*dirs = append(*dirs, dir)
+}
+
+func agentUsesCodexHookSurface(cfg *config.City, agent *config.Agent) bool {
+	if cfg == nil || agent == nil {
+		return false
+	}
+	if codexHookProviderName(codexHookEffectiveAgentProvider(cfg, agent), cfg.Providers) {
+		return true
+	}
+	for _, provider := range config.ResolveInstallHooks(agent, &cfg.Workspace) {
+		if codexHookProviderName(provider, cfg.Providers) {
+			return true
+		}
+	}
+	return false
+}
+
+func codexHookEffectiveAgentProvider(cfg *config.City, agent *config.Agent) string {
+	if agent == nil {
+		return ""
+	}
+	if provider := strings.TrimSpace(agent.Provider); provider != "" {
+		return provider
+	}
+	if cfg != nil {
+		return strings.TrimSpace(cfg.Workspace.Provider)
+	}
+	return ""
+}
+
+func codexHookProviderName(name string, providers map[string]config.ProviderSpec) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	return name == "codex" || config.BuiltinFamily(name, providers) == "codex"
+}
+
+func addCodexHookAgentWorkDirs(dirs *[]string, cityPath string, cfg *config.City, agent *config.Agent) {
+	addCodexHookAgentWorkDir(dirs, cityPath, cfg, agent, agent.QualifiedName())
+	for _, slot := range codexHookPoolSlots(agent) {
+		instanceAgent, qualifiedInstance, _ := poolDesiredRequestIdentity(agent, slot)
+		if qualifiedInstance == agent.QualifiedName() {
+			continue
+		}
+		addCodexHookAgentWorkDir(dirs, cityPath, cfg, instanceAgent, qualifiedInstance)
+	}
+}
+
+func addCodexHookAgentWorkDir(dirs *[]string, cityPath string, cfg *config.City, agent *config.Agent, qualifiedName string) {
+	workDir, err := resolveCodexHookAgentWorkDir(cityPath, cfg, agent, qualifiedName)
+	if err != nil {
+		return
+	}
+	addCodexHookDir(dirs, workDir)
+}
+
+func resolveCodexHookAgentWorkDir(cityPath string, cfg *config.City, agent *config.Agent, qualifiedName string) (string, error) {
+	if agent == nil {
+		return "", nil
+	}
+	cityName := loadedCityName(cfg, cityPath)
+	var rigs []config.Rig
+	if cfg != nil {
+		rigs = cfg.Rigs
+	}
+	if strings.TrimSpace(qualifiedName) == "" {
+		qualifiedName = agent.QualifiedName()
+	}
+	workDir, err := workdirutil.ResolveWorkDirPathStrict(cityPath, cityName, qualifiedName, *agent, rigs)
+	if err != nil {
+		return "", err
+	}
+	if err := workdirutil.ValidateAncestorWorktreesNotStale(workDir); err != nil {
+		return "", err
+	}
+	return workDir, nil
+}
+
+func codexHookPoolSlots(agent *config.Agent) []int {
+	if agent == nil || !agent.SupportsInstanceExpansion() {
+		return nil
+	}
+	limit := 1
+	if len(agent.NamepoolNames) > 0 {
+		limit = len(agent.NamepoolNames)
+	} else if maxSessions := agent.EffectiveMaxActiveSessions(); maxSessions != nil {
+		if *maxSessions <= 1 {
+			return nil
+		}
+		limit = *maxSessions
+	} else if minSessions := agent.EffectiveMinActiveSessions(); minSessions > 1 {
+		limit = minSessions
+	}
+	slots := make([]int, 0, limit)
+	for slot := 1; slot <= limit; slot++ {
+		slots = append(slots, slot)
+	}
+	return slots
 }
 
 func (c *codexHooksDriftCheck) Name() string { return "codex-hooks-drift" }
@@ -89,52 +211,5 @@ func codexHooksMissingPreCompact(path string) bool {
 	if err != nil {
 		return false
 	}
-	var doc map[string]any
-	if err := json.Unmarshal(data, &doc); err != nil {
-		return false
-	}
-	hooksMap, ok := doc["hooks"].(map[string]any)
-	if !ok {
-		return false
-	}
-	if _, ok := hooksMap["PreCompact"]; ok {
-		return false
-	}
-	return codexHookDocHasManagedCommand(doc)
-}
-
-func codexHookDocHasManagedCommand(v any) bool {
-	switch node := v.(type) {
-	case map[string]any:
-		if command, ok := node["command"].(string); ok && codexHookCommandLooksManaged(command) {
-			return true
-		}
-		for _, val := range node {
-			if codexHookDocHasManagedCommand(val) {
-				return true
-			}
-		}
-	case []any:
-		for _, val := range node {
-			if codexHookDocHasManagedCommand(val) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func codexHookCommandLooksManaged(command string) bool {
-	for _, needle := range []string{
-		"gc prime --hook",
-		"gc nudge drain --inject",
-		"gc mail check --inject",
-		"gc hook --inject",
-		"gc handoff --auto",
-	} {
-		if strings.Contains(command, needle) {
-			return true
-		}
-	}
-	return false
+	return hooks.CodexHooksMissingManagedPreCompact(data)
 }

--- a/cmd/gc/doctor_codex_hooks_test.go
+++ b/cmd/gc/doctor_codex_hooks_test.go
@@ -144,6 +144,58 @@ func TestCodexHookWorkDirsIncludesActiveRigPaths(t *testing.T) {
 	}
 }
 
+func TestCodexHookWorkDirsIncludesResolvedAgentWorkDirs(t *testing.T) {
+	cityDir := t.TempDir()
+	activeRig := filepath.Join(cityDir, "rigs", "active")
+	suspendedRig := filepath.Join(cityDir, "rigs", "suspended")
+	agentWorkDir := filepath.Join(cityDir, ".gc", "agents", "reviewer")
+	cfg := &config.City{
+		Workspace: config.Workspace{InstallAgentHooks: []string{"codex"}},
+		Rigs: []config.Rig{
+			{Name: "active", Path: activeRig},
+			{Name: "suspended", Path: suspendedRig, Suspended: true},
+		},
+		Agents: []config.Agent{
+			{Name: "reviewer", Dir: "active", WorkDir: agentWorkDir},
+			{Name: "gemini", Dir: "active", InstallAgentHooks: []string{"gemini"}, WorkDir: filepath.Join(cityDir, ".gc", "agents", "gemini")},
+			{Name: "parked", Dir: "active", WorkDir: filepath.Join(cityDir, ".gc", "agents", "parked"), Suspended: true},
+			{Name: "codex", Dir: "suspended", WorkDir: filepath.Join(cityDir, ".gc", "agents", "suspended")},
+		},
+	}
+
+	got := codexHookWorkDirs(cityDir, cfg)
+
+	assertDoctorPathPresent(t, got, cityDir)
+	assertDoctorPathPresent(t, got, activeRig)
+	assertDoctorPathPresent(t, got, agentWorkDir)
+	assertDoctorPathAbsent(t, got, suspendedRig)
+	assertDoctorPathAbsent(t, got, filepath.Join(cityDir, ".gc", "agents", "gemini"))
+	assertDoctorPathAbsent(t, got, filepath.Join(cityDir, ".gc", "agents", "parked"))
+	assertDoctorPathAbsent(t, got, filepath.Join(cityDir, ".gc", "agents", "suspended"))
+}
+
+func TestCodexHookWorkDirsIncludesBoundedPoolInstanceWorkDirs(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "active")
+	maxSessions := 2
+	cfg := &config.City{
+		Workspace: config.Workspace{InstallAgentHooks: []string{"codex"}},
+		Rigs:      []config.Rig{{Name: "active", Path: rigDir}},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "active",
+			WorkDir:           filepath.Join(".gc", "worktrees", "{{.Rig}}", "{{.AgentBase}}"),
+			MaxActiveSessions: &maxSessions,
+		}},
+	}
+
+	got := codexHookWorkDirs(cityDir, cfg)
+
+	assertDoctorPathPresent(t, got, filepath.Join(cityDir, ".gc", "worktrees", "active", "worker"))
+	assertDoctorPathPresent(t, got, filepath.Join(cityDir, ".gc", "worktrees", "active", "worker-1"))
+	assertDoctorPathPresent(t, got, filepath.Join(cityDir, ".gc", "worktrees", "active", "worker-2"))
+}
+
 func TestCodexHooksMissingPreCompactRejectsUnreadableAndMalformedFiles(t *testing.T) {
 	dir := t.TempDir()
 	missingPath := filepath.Join(dir, ".codex", "hooks.json")
@@ -179,8 +231,26 @@ func TestCodexHooksMissingPreCompactRequiresManagedCommand(t *testing.T) {
 	if codexHooksMissingPreCompact(path) {
 		t.Fatal("custom-only hooks reported as missing managed PreCompact")
 	}
-	if codexHookCommandLooksManaged("printf custom") {
-		t.Fatal("custom command detected as managed")
+}
+
+func assertDoctorPathPresent(t *testing.T, paths []string, want string) {
+	t.Helper()
+	want = filepath.Clean(want)
+	for _, path := range paths {
+		if filepath.Clean(path) == want {
+			return
+		}
+	}
+	t.Fatalf("paths = %#v, want %s present", paths, want)
+}
+
+func assertDoctorPathAbsent(t *testing.T, paths []string, want string) {
+	t.Helper()
+	want = filepath.Clean(want)
+	for _, path := range paths {
+		if filepath.Clean(path) == want {
+			t.Fatalf("paths = %#v, want %s absent", paths, want)
+		}
 	}
 }
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -524,6 +524,16 @@ func normalizeCodexHookCommands(existing []byte) ([]byte, bool, error) {
 	return data, changed, nil
 }
 
+// CodexHooksMissingManagedPreCompact reports whether data is a Gas City
+// managed Codex hooks document that can be upgraded with a PreCompact hook.
+func CodexHooksMissingManagedPreCompact(data []byte) bool {
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false
+	}
+	return codexHookDocCanAddPreCompact(root)
+}
+
 func codexHookValueHasManagedCommand(v any) bool {
 	switch node := v.(type) {
 	case map[string]any:

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -434,6 +434,27 @@ func TestInstallCodexIsByteStableAcrossRepeatedInstalls(t *testing.T) {
 	}
 }
 
+func TestCodexHooksMissingManagedPreCompact(t *testing.T) {
+	staleManaged := []byte(`{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"gc prime --hook --hook-format codex"}]}]}}`)
+	if !CodexHooksMissingManagedPreCompact(staleManaged) {
+		t.Fatal("managed Codex hooks without PreCompact were not reported stale")
+	}
+
+	currentManaged := []byte(`{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"gc prime --hook --hook-format codex"}]}],"PreCompact":[{"hooks":[{"type":"command","command":"gc handoff --auto --hook-format codex"}]}]}}`)
+	if CodexHooksMissingManagedPreCompact(currentManaged) {
+		t.Fatal("managed Codex hooks with PreCompact were reported stale")
+	}
+
+	customOnly := []byte(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"printf custom"}]}]}}`)
+	if CodexHooksMissingManagedPreCompact(customOnly) {
+		t.Fatal("custom-only Codex hooks were reported stale")
+	}
+
+	if CodexHooksMissingManagedPreCompact([]byte(`{not-json`)) {
+		t.Fatal("malformed Codex hooks were reported stale")
+	}
+}
+
 func TestInstallCodexPreservesCustomOnlyHooksByteForByte(t *testing.T) {
 	fs := fsys.NewFake()
 	custom := []byte(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"command":"printf custom-codex-hook","type":"command"}]}]}}`)


### PR DESCRIPTION
Follow-up remediation for post-merge review of #1811. Original PR author credit remains with @osamu2001; this maintainer PR only addresses the required review findings after merge.

## Summary
- Expand the Codex hook doctor target set to include resolved Codex-family agent workdirs and bounded pool instance workdirs, while still including city and rig roots.
- Move managed Codex hook missing-PreCompact detection into `internal/hooks` so doctor and installer share the same managed-command ownership.
- Strengthen the Codex auto-handoff hook test to assert the generated mail bead ID is present in Codex `additionalContext`.

## Verification
- `go test ./cmd/gc -run 'TestCmdHandoffAutoHookFormatCodex|TestDoHandoffAutoReportsHookOutputWriteError|TestCodexHooksDriftCheck|TestCodexHookWorkDirs|TestCodexHooksMissingPreCompact'`
- `go test ./internal/hooks -run 'TestCodexHooksMissingManagedPreCompact|TestInstallCodex|TestUpgradeCodexHooks|TestAddCodexPreCompactHook|TestDesiredCodexPreCompactHook|TestInstallOverlayManagedProviders'`
- `go test ./cmd/gc ./internal/hooks`
- `git diff --check`
- `go vet ./...`
- `make test-fast-parallel`
