### PR TITLE
fix(init): mention Claude setup-token in readiness hint

### DIFF
--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -344,7 +344,7 @@ func providerStatusFixHint(probeName, status string) string {
 	case "claude":
 		switch status {
 		case api.ProbeStatusNeedsAuth:
-			return "run `claude auth login`"
+			return "run `claude auth login`, or run `claude setup-token` and export `CLAUDE_CODE_OAUTH_TOKEN` for headless environments"
 		case api.ProbeStatusNotInstalled:
 			return "install Claude Code"
 		case api.ProbeStatusInvalidConfiguration:

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -117,6 +117,15 @@ func TestProviderStatusFixHintIncludesClaudeOAuthToken(t *testing.T) {
 	}
 }
 
+func TestProviderStatusFixHintIncludesClaudeSetupTokenForNeedsAuth(t *testing.T) {
+	got := providerStatusFixHint("claude", api.ProbeStatusNeedsAuth)
+	for _, want := range []string{"`claude auth login`", "`claude setup-token`", "`CLAUDE_CODE_OAUTH_TOKEN`"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("providerStatusFixHint = %q, want %s", got, want)
+		}
+	}
+}
+
 func TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
@@ -172,6 +181,9 @@ func TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration(t *test
 	}
 	if !strings.Contains(stderr.String(), "run `claude auth login`") {
 		t.Fatalf("stderr = %q, want Claude fix hint", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "`claude setup-token`") {
+		t.Fatalf("stderr = %q, want Claude setup-token hint", stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "Override: gc init --skip-provider-readiness") {
 		t.Fatalf("stderr = %q, want init override hint", stderr.String())


### PR DESCRIPTION
Follow-up to post-merge review for #1136.

Updates Claude `gc init` `needs_auth` hint to mention both interactive `claude auth login` and headless `claude setup-token` / `CLAUDE_CODE_OAUTH_TOKEN`.

Tests:
- `go test ./cmd/gc -run 'TestProviderStatusFixHintIncludesClaudeSetupTokenForNeedsAuth|TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration'`\n- `go test ./cmd/gc -run 'TestProviderStatusFixHintIncludesClaudeSetupTokenForNeedsAuth|TestProviderStatusFixHintIncludesClaudeOAuthToken|TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration'`\n- `go test ./cmd/gc ./internal/api -run 'TestProviderStatusFixHintIncludesClaudeSetupTokenForNeedsAuth|TestProviderStatusFixHintIncludesClaudeOAuthToken|TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration|TestClaudeProbeCommandEnvForwardsConfigDirAndOAuthToken|TestClaudeProbeCommandEnvOmitsUnsetValues|TestHandleReadinessDoesNotForwardClaudeTokenToGitHubCLIProbe|TestHandleProviderReadinessReturnsConfiguredForClaudeOAuthToken|TestHandleProviderReadinessReturnsInvalidConfigurationForClaudeNonFirstPartyProvider|TestHandleProviderReadinessReturnsInvalidConfigurationForClaudeUnknownAuthMethod'`\n- Pre-commit hook ran `go vet ./...` and `GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...`