### PR TITLE
fix(test): cover controller dolt leak guards

### DIFF
--- a/cmd/gc/cityinit_impl_test.go
+++ b/cmd/gc/cityinit_impl_test.go
@@ -260,6 +260,7 @@ func TestCityInitServiceInitScaffoldsAndFinalizes(t *testing.T) {
 	configureTestDoltIdentityEnv(t)
 	configureRealBdAndDoltPath(t)
 	cityPath := filepath.Join(t.TempDir(), "init-city")
+	cleanupManagedDoltTestCity(t, cityPath)
 
 	result, err := mustNewCityInitService(t).Init(context.Background(), cityinit.InitRequest{
 		Dir:                   cityPath,

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -383,6 +383,7 @@ func TestSendControllerCommandWithTimeoutsTimesOutOnRead(t *testing.T) {
 func writeCityTOML(t *testing.T, dir string, cityName string, agentNames ...string) string {
 	t.Helper()
 	clearInheritedBeadsEnv(t)
+	requireNoLeakedDoltAfterForPaths(t, dir)
 	tomlPath := filepath.Join(dir, "city.toml")
 	var buf bytes.Buffer
 	buf.WriteString("[workspace]\nname = " + `"` + cityName + `"` + "\n\n")
@@ -400,6 +401,7 @@ func writeCityTOML(t *testing.T, dir string, cityName string, agentNames ...stri
 func writeControllerNamedSessionCityTOML(t *testing.T, dir, cityName, mode, idleTimeout string) string {
 	t.Helper()
 	clearInheritedBeadsEnv(t)
+	requireNoLeakedDoltAfterForPaths(t, dir)
 	tomlPath := filepath.Join(dir, "city.toml")
 	var buf bytes.Buffer
 	buf.WriteString("[workspace]\nname = " + `"` + cityName + `"` + "\n\n")

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -295,6 +295,8 @@ printf '%s\n' '{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstPar
 	originalCommandContext := providerProbeCommandContext
 	originalCache := providerProbeCache
 	originalCacheTTL := providerProbeCacheTTL
+	// This test mutates package probe globals; keep it serial and restore
+	// every override before returning.
 	providerProbePathEnv = binDir
 	providerProbeCommandContext = exec.CommandContext
 	providerProbeCache = newCachedProviderProbeStore()

--- a/release-gates/ga-vux42u-gate.md
+++ b/release-gates/ga-vux42u-gate.md
@@ -39,6 +39,14 @@ are reproduced on a clean `origin/main` worktree by the reviewer and are
 unrelated to this branch — none touch `path_helpers_test.go` or
 `dolt_leak_helper_test.go`.
 
+## Post-merge remediation note
+
+Post-merge review of PR #1815 found that the landed diff also changed
+`internal/api/handler_provider_readiness.go` by making `providerProbeCacheTTL`
+mutable. The production default remains `2 * time.Second`; mutability exists
+only so `TestHandleProviderReadinessReturnsConfiguredStatuses` can isolate and
+extend the probe cache during the test.
+
 ## Commits in scope
 
 ```


### PR DESCRIPTION
Post-merge remediation for #1815, preserving the landed contributor work and applying only maintainer fixups requested by review.

Changes:
- Add the current scoped Dolt leak guard, `requireNoLeakedDoltAfterForPaths`, to the controller `city.toml` test helpers after clearing inherited Beads env.
- Document the provider-readiness probe global override block as serial and fully restored.
- Add a durable release-gate note that `providerProbeCacheTTL` is mutable only for test injection; the production default remains unchanged.

Validation:
- `go test -count=1 -run 'TestRequireNoLeakedDolt|TestSnapshotDoltProcess|TestControllerReloadsConfig|TestControllerReloadsConfigImmediatelyOnWatchEvent|TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout|TestHandleProviderReadinessReturnsConfiguredStatuses' ./cmd/gc ./internal/api`
- `go vet ./cmd/gc/... ./internal/api/...`
- Pre-commit hook ran `lint-changed`, docs generation, `go vet ./...`, fast unit sweep, and `go test ./test/docsync` successfully.
