### PR TITLE
feat(packman): allow user gitconfig credentials for remote network ops

### DIFF
--- a/docs/packv2/doc-packman.md
+++ b/docs/packv2/doc-packman.md
@@ -104,6 +104,30 @@ Common source forms:
 - `ssh://...`
 - `git@...`
 - bare `github.com/org/repo`
+- GitHub `/tree/<ref>/<subpath>` or `/blob/<ref>/<subpath>/pack.toml` URL
+
+### Subpath-of-repo sources
+
+A single repository may publish multiple packs at distinct paths.
+Address a subdirectory with a **double-slash** separator between the
+repo URL and the subpath:
+
+```toml
+[imports.pack-author]
+source = "github.com/enthought/gascity_packs//pack-author"
+
+[imports.llm-wiki]
+source = "github.com/enthought/gascity_packs//llm-wiki"
+version = "^1.0"
+```
+
+Both imports clone `enthought/gascity_packs` once into the shared cache
+and resolve their respective subdirectories from that clone. A GitHub
+`tree`/`blob` URL is parsed equivalently and may be pasted directly.
+
+The single-slash form `github.com/org/repo/subpath` is **not**
+supported and will fail to clone — without the `//` separator the
+loader treats the entire string as the repo URL.
 
 Resolution rules:
 
@@ -117,6 +141,31 @@ Resolution rules:
 Remote imports that need reproducible restore semantics must resolve to
 entries in `packs.lock`. Local-path imports remain valid authoring
 surfaces, but they are not a substitute for committed remote lock state.
+
+### Authenticating to private remotes
+
+`gc import install` shells out to `git` for `clone`, `fetch`, and
+`ls-remote`. Those network operations read credential configuration
+from the user's `~/.gitconfig`, so any credential helper installed by
+the operator applies. Common setups:
+
+- **GitHub CLI (HTTPS):** run `gh auth login` then
+  `gh auth setup-git`. This writes a credential helper to
+  `~/.gitconfig` that supplies a fresh token on every git network call.
+- **SSH:** declare imports with an `ssh://git@github.com/...` or
+  `git@github.com:...` source. SSH agents and `~/.ssh/config` are
+  used as-is.
+- **Personal access token in URL:** not recommended — tokens land in
+  `packs.lock` and process listings.
+
+Operations inside a cached repository (`checkout`, `reset`, `status`,
+`clean`) intentionally run with `GIT_CONFIG_NOSYSTEM=1` and
+`GIT_CONFIG_GLOBAL=/dev/null` so global config cannot alter cache
+state. Only the network-facing subcommands consult the user's
+`~/.gitconfig`. If `gc import install` fails to clone a private
+repository with an authentication error, verify that
+`git clone <source>` works from the same shell — `gc` uses the same
+credential path.
 
 ## Lock file contract
 

--- a/internal/packman/cache.go
+++ b/internal/packman/cache.go
@@ -248,6 +248,14 @@ func normalizeRemoteSource(source string) remoteSource {
 }
 
 func defaultRunGit(dir string, args ...string) (string, error) {
+	env := hermeticGitEnv()
+	if len(args) > 0 && needsCredentials(args[0]) {
+		env = credentialAwareGitEnv()
+	}
+	return runGitWithEnv(dir, env, args...)
+}
+
+func runGitWithEnv(dir string, env []string, args ...string) (string, error) {
 	cmdArgs := append([]string{
 		"-c", "core.fsmonitor=false",
 		"-c", "core.hooksPath=/dev/null",
@@ -257,18 +265,52 @@ func defaultRunGit(dir string, args ...string) (string, error) {
 	if dir != "" {
 		cmd.Dir = dir
 	}
-	for _, e := range os.Environ() {
-		if k, _, ok := strings.Cut(e, "="); ok && fetchGitEnvBlacklist[k] {
-			continue
-		}
-		cmd.Env = append(cmd.Env, e)
-	}
-	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// needsCredentials reports whether a git subcommand may need credential
+// helpers from the user's global gitconfig. Network operations on remotes
+// (clone, fetch, ls-remote, push) require user-configured credentials to
+// access private repositories; local repo operations do not.
+func needsCredentials(subcommand string) bool {
+	switch subcommand {
+	case "clone", "fetch", "ls-remote", "push":
+		return true
+	}
+	return false
+}
+
+// sanitizedGitEnv returns os.Environ() with dangerous GIT_* overrides removed.
+// This is the shared base for both hermetic and credential-aware invocations.
+func sanitizedGitEnv() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if k, _, ok := strings.Cut(e, "="); ok && fetchGitEnvBlacklist[k] {
+			continue
+		}
+		env = append(env, e)
+	}
+	return env
+}
+
+// hermeticGitEnv returns an environment that silences global and system
+// gitconfig. Use this for operations within a cache repo where determinism
+// matters and credentials are unnecessary.
+func hermeticGitEnv() []string {
+	return append(sanitizedGitEnv(), "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+}
+
+// credentialAwareGitEnv returns an environment that allows the user's
+// ~/.gitconfig (including credential helpers installed by `gh auth setup-git`
+// or similar) to apply. Use this only for network operations that need to
+// authenticate to private remotes — clone, fetch, ls-remote, push.
+func credentialAwareGitEnv() []string {
+	return sanitizedGitEnv()
 }
 
 var fetchGitEnvBlacklist = map[string]bool{

--- a/internal/packman/cache_test.go
+++ b/internal/packman/cache_test.go
@@ -386,3 +386,59 @@ func TestEnsureRepoInCacheReclonesCacheFileWithoutGit(t *testing.T) {
 		t.Fatalf("EnsureRepoInCache path = %q, want %q", got, path)
 	}
 }
+
+func TestNeedsCredentialsCoversNetworkSubcommands(t *testing.T) {
+	for _, sub := range []string{"clone", "fetch", "ls-remote", "push"} {
+		if !needsCredentials(sub) {
+			t.Errorf("needsCredentials(%q) = false, want true", sub)
+		}
+	}
+	for _, sub := range []string{"checkout", "reset", "clean", "status", "rev-parse", "merge", "rebase"} {
+		if needsCredentials(sub) {
+			t.Errorf("needsCredentials(%q) = true, want false", sub)
+		}
+	}
+}
+
+func TestHermeticGitEnvSilencesGlobalConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	env := hermeticGitEnv()
+	if !containsEnv(env, "GIT_CONFIG_NOSYSTEM=1") {
+		t.Errorf("hermeticGitEnv() missing GIT_CONFIG_NOSYSTEM=1; env=%v", env)
+	}
+	if !containsEnv(env, "GIT_CONFIG_GLOBAL=/dev/null") {
+		t.Errorf("hermeticGitEnv() missing GIT_CONFIG_GLOBAL=/dev/null; env=%v", env)
+	}
+}
+
+func TestCredentialAwareGitEnvAllowsGlobalConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	env := credentialAwareGitEnv()
+	for _, banned := range []string{"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null"} {
+		if containsEnv(env, banned) {
+			t.Errorf("credentialAwareGitEnv() set %q; credential helpers would not apply", banned)
+		}
+	}
+}
+
+func TestSanitizedGitEnvDropsDangerousOverrides(t *testing.T) {
+	t.Setenv("GIT_DIR", "/tmp/should-not-leak")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/tmp/poisoned-config")
+	env := sanitizedGitEnv()
+	for _, banned := range []string{"GIT_DIR=", "GIT_CONFIG_GLOBAL="} {
+		for _, e := range env {
+			if strings.HasPrefix(e, banned) {
+				t.Errorf("sanitizedGitEnv() inherited %q from caller environment", e)
+			}
+		}
+	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- `defaultRunGit` in `internal/packman/cache.go` now splits its env between a hermetic mode (used for in-cache git operations) and a credential-aware mode (used for `clone`, `fetch`, `ls-remote`, `push`). The credential-aware mode no longer silences `~/.gitconfig`, so credential helpers installed via `gh auth setup-git` (or SSH agents) authenticate to private remotes such as `enthought/gascity_packs`.
- `docs/packv2/doc-packman.md` documents the **canonical double-slash subpath form** (`github.com/org/repo//subpath`) and a new **Authenticating to private remotes** section explaining the credential-helper setup and the hermetic-vs-network split.
- Adds unit coverage in `internal/packman/cache_test.go` for `needsCredentials`, `hermeticGitEnv`, `credentialAwareGitEnv`, and `sanitizedGitEnv`.

## Why

Cross-city packs in `gascity_packs` (private) cannot be imported today: `defaultRunGit` set `GIT_CONFIG_NOSYSTEM=1` and `GIT_CONFIG_GLOBAL=/dev/null` on every git call, so `gh auth setup-git`'s credential helper never fired for `clone`/`ls-remote`. This blocked Phase 1 of `gc-vgs6u` (migrating pack-author to `gascity_packs`).

The hermetic env still applies to in-cache ops (`checkout`, `reset`, `clean`, `status`, …) so global config can never mutate cached checkouts.

This addresses Phases 1-3 of `gc-vgs6u.4` (`tr-gepwb`). Phase 4 — switching `cities/gascity-city/pack.toml` from local-path imports to remote `github.com/enthought/gascity_packs//<pack>` imports — is downstream consumer work in a different repo.

## Test plan

- [x] `go test ./internal/packman/...` — full suite green (`0.776s`)
- [x] `go test ./internal/remotesource/...` — green
- [x] `go test ./internal/config/...` — green (`7.115s`)
- [x] `go vet ./internal/packman/... ./internal/remotesource/... ./internal/config/...` — clean
- [x] Pre-commit hook (`lint-changed` + scoped `vet`/`test` on `./internal/packman`) — green
- [x] `gofmt -l` on modified Go files — no output
- [ ] Manual verification on a fresh machine: `gh auth login && gh auth setup-git`, declare `source = "github.com/enthought/gascity_packs//pack-author"`, run `gc import install` — should clone successfully (not yet exercised; covered by Phase 4 work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)