### PR TITLE
Add adaptive cadence telemetry to the beads cache reconciler

### DIFF
--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -570,6 +570,7 @@ func (c *CachingStore) updateStatsLocked() {
 	}
 	c.stats.TotalDeps = totalDeps
 	c.stats.SyncFailures = c.syncFailures
+	c.updateCadenceStatsLocked()
 }
 
 func beadIDs(beadMap map[string]Bead) []string {

--- a/internal/beads/caching_store_cadence_internal_test.go
+++ b/internal/beads/caching_store_cadence_internal_test.go
@@ -156,6 +156,26 @@ func TestAdaptiveCadenceLowLatencyKeepsSmall(t *testing.T) {
 	}
 }
 
+func TestUpdateStatsPopulatesCadenceDiagnostics(t *testing.T) {
+	cs := newPrimedCacheForCadenceTest(t)
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	cs.updateStatsLocked()
+
+	if cs.stats.CurrentReconcileInterval != cacheReconcileIntervalSmall {
+		t.Errorf("stats.CurrentReconcileInterval = %v, want %v",
+			cs.stats.CurrentReconcileInterval, cacheReconcileIntervalSmall)
+	}
+	if cs.stats.LatencyP95Ms != 0 {
+		t.Errorf("stats.LatencyP95Ms = %v before full window, want 0",
+			cs.stats.LatencyP95Ms)
+	}
+	if cs.stats.CadenceDriver != "default" {
+		t.Errorf("stats.CadenceDriver = %q, want default", cs.stats.CadenceDriver)
+	}
+}
+
 func TestAdaptiveCadenceDemotesAfterHysteresisWindow(t *testing.T) {
 	cs := newPrimedCacheForCadenceTest(t)
 	cs.mu.Lock()
@@ -361,8 +381,8 @@ func TestAdaptiveCadenceLogsOnceOnDemote(t *testing.T) {
 	if nl := strings.IndexByte(demoteLine, '\n'); nl >= 0 {
 		demoteLine = demoteLine[:nl]
 	}
-	if !strings.Contains(demoteLine, "driver=default") {
-		t.Errorf("demote log missing driver=default; line=%q", demoteLine)
+	if !strings.Contains(demoteLine, "driver=latency") {
+		t.Errorf("demote log missing driver=latency; line=%q output=%q", demoteLine, out)
 	}
 }
 

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -128,6 +128,20 @@ func (c *CachingStore) latencyP95Locked() (time.Duration, bool) {
 	return sorted[idx], true
 }
 
+// updateCadenceStatsLocked refreshes the diagnostic cadence fields
+// without mutating hysteresis state or emitting transition logs. Caller
+// must hold c.mu.
+func (c *CachingStore) updateCadenceStatsLocked() {
+	p95, samplesEnough := c.latencyP95Locked()
+	var p95ms float64
+	if samplesEnough {
+		p95ms = float64(p95.Milliseconds())
+	}
+	c.stats.CurrentReconcileInterval = effectiveCadence(len(c.beads), c.latencyDriverActive)
+	c.stats.LatencyP95Ms = p95ms
+	c.stats.CadenceDriver = cadenceDriver(len(c.beads), c.latencyDriverActive)
+}
+
 // recomputeCadenceLocked updates the latency-driver hysteresis state
 // based on the current P95, recomposes the effective cadence, refreshes
 // the diagnostic CacheStats fields, and emits a single transition log
@@ -140,7 +154,12 @@ func (c *CachingStore) latencyP95Locked() (time.Duration, bool) {
 // One spike anywhere in that drain pushes P95 back up and re-arms the
 // driver, preventing thrash.
 func (c *CachingStore) recomputeCadenceLocked() {
-	prev := effectiveCadence(len(c.beads), c.latencyDriverActive)
+	prev := c.stats.CurrentReconcileInterval
+	hadPrev := prev != 0
+	prevDriver := c.stats.CadenceDriver
+	if prevDriver == "" {
+		prevDriver = cadenceDriver(len(c.beads), c.latencyDriverActive)
+	}
 
 	p95, samplesEnough := c.latencyP95Locked()
 	if samplesEnough {
@@ -153,28 +172,20 @@ func (c *CachingStore) recomputeCadenceLocked() {
 		}
 	}
 
-	next := effectiveCadence(len(c.beads), c.latencyDriverActive)
-	driver := cadenceDriver(len(c.beads), c.latencyDriverActive)
+	c.updateCadenceStatsLocked()
+	next := c.stats.CurrentReconcileInterval
+	driver := cadenceTransitionDriver(prevDriver, c.stats.CadenceDriver)
 
-	var p95ms float64
-	if samplesEnough {
-		p95ms = float64(p95.Milliseconds())
-	}
-
-	if prev != next {
+	if hadPrev && prev != next {
 		switch {
 		case prev == cacheReconcileIntervalSmall && next == cacheReconcileIntervalMedium:
 			log.Printf("beads cache: cadence promoted small→medium driver=%s p95=%.0fms window=%d",
-				driver, p95ms, cacheLatencyWindowSize)
+				driver, c.stats.LatencyP95Ms, cacheLatencyWindowSize)
 		case prev == cacheReconcileIntervalMedium && next == cacheReconcileIntervalSmall:
 			log.Printf("beads cache: cadence demoted medium→small driver=%s p95=%.0fms window=%d",
-				driver, p95ms, cacheLatencyWindowSize)
+				driver, c.stats.LatencyP95Ms, cacheLatencyWindowSize)
 		}
 	}
-
-	c.stats.CurrentReconcileInterval = next
-	c.stats.LatencyP95Ms = p95ms
-	c.stats.CadenceDriver = driver
 }
 
 // cadenceDriver classifies which input(s) are driving the current
@@ -188,6 +199,19 @@ func cadenceDriver(beadCount int, latencyDriverActive bool) string {
 		return "bead-count"
 	case latencyDriverActive:
 		return "latency"
+	default:
+		return "default"
+	}
+}
+
+func cadenceTransitionDriver(prevDriver, nextDriver string) string {
+	switch {
+	case prevDriver == "both" || nextDriver == "both":
+		return "both"
+	case nextDriver != "" && nextDriver != "default":
+		return nextDriver
+	case prevDriver != "" && prevDriver != "default":
+		return prevDriver
 	default:
 		return "default"
 	}

--- a/release-gates/ga-70nf-adaptive-cadence-gate.md
+++ b/release-gates/ga-70nf-adaptive-cadence-gate.md
@@ -1,12 +1,12 @@
 # Release gate — adaptive reconciler cadence + telemetry (ga-70nf, AD-03 part 3)
 
-**Verdict:** PASS (with maintainer-side fixup)
+**Verdict:** PASS (with maintainer-side and builder-side fixups)
 
 - Bead: `ga-70nf` (AD-03 part 3, deferred from ga-zor1n2 stagger gate)
 - Branch: `quad341:builder/ga-70nf-1`
-- HEAD: `27965cfe` after maintainer fixup (was `5df84922` at original gate review)
+- HEAD: branch tip after maintainer P95 fixup and builder cadence-diagnostics fixup
 - PR: [gastownhall/gascity#1820](https://github.com/gastownhall/gascity/pull/1820)
-- Diff (post-fixup): 2 files, +579 / -1 production + +N / 0 maintainer fixup; 14 unit tests + 1 end-to-end
+- Diff (post-fixup): cadence implementation, cadence unit coverage, and this release-gate note
 
 ## Criteria
 
@@ -25,6 +25,14 @@
 
 - `go build ./internal/beads/...` — clean
 - `go test ./internal/beads/ -run 'TestLatency|TestCadence|TestRecompute' -count=1` — PASS
+- `go test ./internal/beads/... -count=1` — PASS
+- `go test -race ./internal/beads/ -count=1` — PASS
+- `go vet ./...` — PASS
+
+## Builder follow-up fixup
+
+- `updateStatsLocked` now populates `CurrentReconcileInterval`, `LatencyP95Ms`, and `CadenceDriver` on every stats refresh, not only after reconcile cadence recomputation.
+- Demotion transition logs now report the transition cause (`driver=latency`) instead of the post-demotion steady-state driver (`default`).
 
 ## Open items deferred to follow-up
 

--- a/release-gates/ga-70nf-adaptive-cadence-gate.md
+++ b/release-gates/ga-70nf-adaptive-cadence-gate.md
@@ -1,44 +1,44 @@
-# Release gate — adaptive reconciler cadence + telemetry (ga-70nf, AD-03 part 3)
+# Release Gate: Adaptive Reconciler Cadence + Telemetry
 
-**Verdict:** PASS (with maintainer-side and builder-side fixups)
+Verdict: PASS
 
-- Bead: `ga-70nf` (AD-03 part 3, deferred from ga-zor1n2 stagger gate)
+- Deploy bead: `ga-6ndh55` (conflict-fix review for `ga-70nf`)
+- Source bead: `ga-70nf` (Adaptive cadence + telemetry in gascity reconciler, AD-03 part 3)
+- Original review bead: `ga-4vq2er`
 - Branch: `quad341:builder/ga-70nf-1`
-- HEAD: branch tip after maintainer P95 fixup and builder cadence-diagnostics fixup
-- PR: [gastownhall/gascity#1820](https://github.com/gastownhall/gascity/pull/1820)
-- Diff (post-fixup): cadence implementation, cadence unit coverage, and this release-gate note
+- Candidate HEAD before gate commit: `63fd74b2b6867de60bcfbe271c8ec74175da59b2`
+- Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this checklist uses the deployer release criteria from the active role prompt.
 
-## Criteria
+## Release Criteria
 
 | # | Criterion | Verdict | Evidence |
 |---|-----------|---------|----------|
-| 1 | Latency-driven promotion to MEDIUM cadence | PASS | `recomputeCadenceLocked` flips `latencyDriverActive` when nearest-rank P95 exceeds `cacheLatencyHighWaterMark`; verified by `TestAdaptiveCadencePromotesOnHighLatency`. |
-| 2 | Hysteresis demotion via window-drain | PASS | Window must fully drain to demote (N=`cacheLatencyWindowSize` consecutive low samples); verified by `TestAdaptiveCadenceDemotesAfterHysteresisWindow`. The spike-reset property — one slow scan during the drain re-arms the driver — is verified by `TestAdaptiveCadenceSpikeResetsHysteresisCounter`. |
-| 3 | Composes with bead-count cadence | PASS | `effectiveCadence` returns the slower of the two drivers; verified by `TestAdaptiveCadenceCompositionBeadCountAlone` and `TestAdaptiveCadenceCompositionBoth`. |
-| 4 | LARGE preserved via bead count only | PASS | `beadCountCadence(>=5000)` returns LARGE regardless of latency state; verified by `TestAdaptiveCadencePreservesLargeInterval`. |
-| 5 | Single transition log per ↕ change | PASS | `recomputeCadenceLocked` only logs on transition edges; verified by `TestAdaptiveCadenceLogsOnceOnPromote` and `TestAdaptiveCadenceLogsOnceOnDemote`. |
-| 6 | End-to-end: real reconciler feeds the latency window | PASS | `TestRunReconciliationFeedsLatencyWindow` exercises the full path. |
-| 7 | Race-free | PASS | `go test -race ./internal/beads/` — clean. |
-| 8 | Nearest-rank P95 generalizes beyond N=10 | PASS (after fixup) | Reviewer flagged that the original `sorted[len-1]` was P100 not P95; correct only by coincidence at N=10. Maintainer fixup replaces with `int(math.Ceil(0.95*N))-1`, which equals `len-1` for N=10 (preserves current behavior bit-for-bit) but stays P95 if `cacheLatencyWindowSize` is raised. |
+| 1 | Review PASS present | PASS | `ga-6ndh55` notes contain `REVIEW VERDICT: PASS` from `gascity/reviewer` for branch `builder/ga-70nf-1 @ 63fd74b2b`. The original implementation review bead `ga-4vq2er` also contains `REVIEW VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | The original review verified all 8 source-bead acceptance criteria. Deployer rechecked the implementation surfaces and reran the focused tests listed below on the rebased branch. |
+| 3 | Tests pass | PASS | `go test ./internal/beads/... -count=1`, `go test -race ./internal/beads/ -count=1`, `go vet ./...`, and `make test-fast-parallel` all passed on `deploy/ga-6ndh55-release`. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-6ndh55` list one LOW style finding only (`cadenceTransitionDriver` doc comment). Unresolved HIGH findings: 0. |
+| 5 | Final branch is clean | PASS | After committing this gate file, `git status --short --branch` showed no uncommitted changes. |
+| 6 | Branch diverges cleanly from main | PASS | After committing this gate file, `git merge-tree --write-tree HEAD origin/main` exited 0. |
 
-## Validation (post-fixup)
+## Acceptance Criteria Evidence
 
-- `go build ./internal/beads/...` — clean
-- `go test ./internal/beads/ -run 'TestLatency|TestCadence|TestRecompute' -count=1` — PASS
-- `go test ./internal/beads/... -count=1` — PASS
-- `go test -race ./internal/beads/ -count=1` — PASS
-- `go vet ./...` — PASS
+| # | Source-bead acceptance criterion | Evidence |
+|---|----------------------------------|----------|
+| 1 | Synthetic high `bd list` latency promotes reconciler to 60s cadence within 10 reconciliations. | `TestAdaptiveCadencePromotesOnHighLatency`; implementation flips the latency driver when nearest-rank P95 exceeds `cacheLatencyHighWaterMark`. |
+| 2 | Removing the delay demotes back to 30s within 10 reconciliations. | `TestAdaptiveCadenceDemotesAfterHysteresisWindow`; `TestAdaptiveCadenceSpikeResetsHysteresisCounter` verifies a slow scan during the drain re-arms the driver. |
+| 3 | `CacheStats.LatencyP95Ms` is populated after 10 samples and 0 before. | `TestLatencyP95FullWindowReturnsValue`; `updateStatsLocked` calls `updateCadenceStatsLocked` so diagnostics refresh on every stats update. |
+| 4 | `CacheStats.CadenceDriver` reflects the current cadence input. | Cadence-driver coverage in `internal/beads/caching_store_cadence_internal_test.go`; `cadenceTransitionDriver` preserves the transition cause for log lines. |
+| 5 | Promotion and demotion log lines fire exactly once per transition with the specified format. | `TestAdaptiveCadenceLogsOnceOnPromote` and `TestAdaptiveCadenceLogsOnceOnDemote`; demotion now reports `driver=latency` for the transition. |
+| 6 | Bead-count promotion to MEDIUM is preserved. | `TestAdaptiveCadenceCompositionBeadCountAlone` and `TestAdaptiveCadenceCompositionBoth`; effective cadence is the slower of bead-count and latency drivers. |
+| 7 | `cacheReconcileIntervalLarge` is not touched. | `TestAdaptiveCadencePreservesLargeInterval`; LARGE remains bead-count driven for >=5000 beads. |
+| 8 | Existing tests pass. | Focused package tests, race test, vet, and fast sharded baseline passed on the release branch. |
 
-## Builder follow-up fixup
+## Verification Commands
 
-- `updateStatsLocked` now populates `CurrentReconcileInterval`, `LatencyP95Ms`, and `CadenceDriver` on every stats refresh, not only after reconcile cadence recomputation.
-- Demotion transition logs now report the transition cause (`driver=latency`) instead of the post-demotion steady-state driver (`default`).
-
-## Open items deferred to follow-up
-
-- **`sort.Slice` allocation per `recomputeCadenceLocked` call** is unnecessary at N=10; could be replaced with a streaming max or pre-sorted insert. Not a correctness issue; bounded allocation cost. File as `ga-70nf-followup` if follow-up is desired.
-
-## Notes
-
-- Maintainer fixup commit: nearest-rank P95 generalization. Behavior at the current window size is unchanged; the fix is forward-looking.
-- This gate file lands as part of the maintainer fixup commit so the PR includes the gate doc per the convention established by `ga-zor1n2`.
+| Command | Result |
+|---------|--------|
+| `git merge-tree --write-tree HEAD origin/main` | PASS |
+| `go test ./internal/beads/... -count=1` | PASS |
+| `go test -race ./internal/beads/ -count=1` | PASS |
+| `go vet ./...` | PASS |
+| `make test-fast-parallel` | PASS (`All fast jobs passed`) |


### PR DESCRIPTION
## What this changes

The beads caching reconciler now adapts its reconcile cadence when wrapper-observed `bd list` latency stays high. It promotes from the normal 30 second cadence to 60 seconds under sustained latency, then demotes after a 10-sample calm window so a single fast scan does not hide continued pressure.

Operators also get diagnostic visibility through `CacheStats.CurrentReconcileInterval`, `CacheStats.LatencyP95Ms`, and `CacheStats.CadenceDriver`, plus one transition log line per cadence change. The existing bead-count cadence behavior is preserved, including the 120 second LARGE interval for very large bead sets.

## Review notes

- The latency window and state machine live in `internal/beads/caching_store_reconcile.go`; no telemetry package, API schema, CLI, or config surface changes are introduced.
- `CacheStats` additions are diagnostic-only; no caller should depend on them for control flow.
- The effective cadence is the slower of bead-count and latency drivers, so latency cannot shorten a cadence that bead count already stretched.
- The release gate is recorded in [`release-gates/ga-70nf-adaptive-cadence-gate.md`](release-gates/ga-70nf-adaptive-cadence-gate.md).

## Test plan

- [x] `go test ./internal/beads/... -count=1`
- [x] `go test -race ./internal/beads/ -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Mergeability check against `origin/main`
