### PR TITLE
Validate CityRoot pre_start scripts in doctor check

### DIFF
--- a/internal/doctor/pre_start_scripts_check.go
+++ b/internal/doctor/pre_start_scripts_check.go
@@ -11,10 +11,10 @@ import (
 )
 
 // PreStartScriptsCheck verifies that script paths referenced via
-// {{.ConfigDir}} in any agent's pre_start command exist on disk.
+// {{.ConfigDir}} or {{.CityRoot}} in any agent's pre_start command exist on disk.
 // Missing scripts cause "exit status 127" at runtime when the
 // reconciler tries to start the agent. Only checks resolvable static
-// references — commands without {{.ConfigDir}}, or whose first token
+// references — commands without either template, or whose first token
 // still contains other unresolved templates after substitution, are
 // skipped because they require runtime context to evaluate.
 type PreStartScriptsCheck struct {
@@ -38,23 +38,27 @@ func (c *PreStartScriptsCheck) CanFix() bool { return false }
 func (c *PreStartScriptsCheck) Fix(_ *CheckContext) error { return nil }
 
 // Run iterates each pack agent's pre_start commands and warns when a
-// {{.ConfigDir}}-relative script is missing on disk.
-func (c *PreStartScriptsCheck) Run(_ *CheckContext) *CheckResult {
+// {{.ConfigDir}}- or {{.CityRoot}}-relative script is missing on disk.
+func (c *PreStartScriptsCheck) Run(ctx *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
 	if c.cfg == nil {
 		r.Status = StatusOK
 		r.Message = "no city config loaded"
 		return r
 	}
+	cityPath := ""
+	if ctx != nil {
+		cityPath = ctx.CityPath
+	}
 	var issues []string
 	for _, a := range c.cfg.Agents {
 		// Inline (city.toml) agents have no SourceDir to resolve
-		// {{.ConfigDir}} against — skip them.
+		// {{.ConfigDir}} against; pack-shipped scripts still require it.
 		if a.SourceDir == "" {
 			continue
 		}
 		for _, cmd := range a.PreStart {
-			scriptPath, ok := resolvePreStartScript(cmd, a.SourceDir)
+			scriptPath, ok := resolvePreStartScript(cmd, a.SourceDir, cityPath)
 			if !ok {
 				continue
 			}
@@ -63,39 +67,54 @@ func (c *PreStartScriptsCheck) Run(_ *CheckContext) *CheckResult {
 			} else if !os.IsNotExist(err) {
 				continue
 			}
-			rel, relErr := filepath.Rel(a.SourceDir, scriptPath)
-			if relErr != nil {
-				rel = scriptPath
+			rel := scriptPath
+			if rr, err := filepath.Rel(a.SourceDir, scriptPath); err == nil && !strings.HasPrefix(rr, "..") {
+				rel = rr
+			} else if cityPath != "" {
+				if rr, err := filepath.Rel(cityPath, scriptPath); err == nil && !strings.HasPrefix(rr, "..") {
+					rel = rr
+				}
 			}
 			issues = append(issues, fmt.Sprintf("agent %q: pre_start script %q not found", a.QualifiedName(), rel))
 		}
 	}
 	if len(issues) == 0 {
 		r.Status = StatusOK
-		r.Message = "all pre_start scripts referenced via {{.ConfigDir}} exist"
+		r.Message = "all pre_start scripts referenced via {{.ConfigDir}} or {{.CityRoot}} exist"
 		return r
 	}
 	sort.Strings(issues)
 	r.Status = StatusWarning
 	r.Message = fmt.Sprintf("%d pre_start script(s) missing on disk", len(issues))
-	r.FixHint = "ship the missing script with the pack, or remove the pre_start reference"
+	r.FixHint = "ship the missing script with the pack, or add it to <city>/scripts/, or remove the pre_start reference"
 	r.Details = issues
 	return r
 }
 
 // resolvePreStartScript extracts the absolute script path from a
-// pre_start command if it references {{.ConfigDir}} cleanly. Returns
-// (path, true) when the first whitespace-separated token resolves to
-// an absolute path with no remaining template placeholders. Otherwise
-// returns ("", false) so the caller can skip the command — either it
-// is not a {{.ConfigDir}} reference, or it depends on runtime context
-// (rig, work_dir, agent identity) that doctor cannot statically
-// resolve.
-func resolvePreStartScript(cmd, sourceDir string) (string, bool) {
-	if !strings.Contains(cmd, "{{.ConfigDir}}") {
+// pre_start command if it references {{.ConfigDir}} or {{.CityRoot}}
+// cleanly. Returns (path, true) when the first whitespace-separated
+// token resolves to an absolute path with no remaining template
+// placeholders. Otherwise returns ("", false) so the caller can skip
+// the command because it references neither template or depends on
+// runtime context that doctor cannot statically resolve.
+//
+// Both templates may appear in the same command; both are substituted.
+// Only the first token is validated, so trailing runtime-only template
+// arguments are allowed.
+func resolvePreStartScript(cmd, sourceDir, cityPath string) (string, bool) {
+	hasConfigDir := strings.Contains(cmd, "{{.ConfigDir}}")
+	hasCityRoot := strings.Contains(cmd, "{{.CityRoot}}")
+	if !hasConfigDir && !hasCityRoot {
 		return "", false
 	}
-	expanded := strings.ReplaceAll(cmd, "{{.ConfigDir}}", sourceDir)
+	expanded := cmd
+	if hasConfigDir {
+		expanded = strings.ReplaceAll(expanded, "{{.ConfigDir}}", sourceDir)
+	}
+	if hasCityRoot {
+		expanded = strings.ReplaceAll(expanded, "{{.CityRoot}}", cityPath)
+	}
 	fields := strings.Fields(expanded)
 	if len(fields) == 0 {
 		return "", false

--- a/internal/doctor/pre_start_scripts_check_test.go
+++ b/internal/doctor/pre_start_scripts_check_test.go
@@ -49,6 +49,34 @@ func TestPreStartScriptsCheck_ScriptExists(t *testing.T) {
 	}
 }
 
+func TestPreStartScriptsCheck_CityRoot_ScriptExists(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "scripts", "worktree-setup.sh"), []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pack := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "builder",
+				SourceDir: pack,
+				PreStart:  []string{"{{.CityRoot}}/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}}"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+	if !strings.Contains(r.Message, "{{.ConfigDir}}") || !strings.Contains(r.Message, "{{.CityRoot}}") {
+		t.Errorf("message = %q; want both supported templates mentioned", r.Message)
+	}
+}
+
 func TestPreStartScriptsCheck_ScriptMissing(t *testing.T) {
 	pack := t.TempDir()
 	cfg := &config.City{
@@ -73,6 +101,67 @@ func TestPreStartScriptsCheck_ScriptMissing(t *testing.T) {
 	}
 	if r.FixHint == "" {
 		t.Error("expected FixHint to be set on warning")
+	}
+}
+
+func TestPreStartScriptsCheck_CityRoot_ScriptMissing(t *testing.T) {
+	cityPath := t.TempDir()
+	pack := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "builder",
+				SourceDir: pack,
+				PreStart:  []string{"{{.CityRoot}}/scripts/worktree-setup.sh args"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %v", len(r.Details), r.Details)
+	}
+	want := `agent "builder": pre_start script "scripts/worktree-setup.sh" not found`
+	if r.Details[0] != want {
+		t.Errorf("detail = %q; want %q", r.Details[0], want)
+	}
+	if !strings.Contains(r.FixHint, "<city>/scripts/") || !strings.Contains(r.FixHint, "pack") {
+		t.Errorf("FixHint = %q; want city and pack repair options", r.FixHint)
+	}
+}
+
+func TestPreStartScriptsCheck_BothTemplates_OneMissing(t *testing.T) {
+	cityPath := t.TempDir()
+	packA := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(packA, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packA, "scripts", "A.sh"), []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	packB := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "agent-a", SourceDir: packA, PreStart: []string{"{{.ConfigDir}}/scripts/A.sh"}},
+			{Name: "agent-b", SourceDir: packB, PreStart: []string{"{{.CityRoot}}/scripts/B.sh"}},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], "agent-b") || !strings.Contains(r.Details[0], "scripts/B.sh") {
+		t.Errorf("detail = %q; want second agent and CityRoot missing script", r.Details[0])
+	}
+	if strings.Contains(r.Details[0], "agent-a") {
+		t.Errorf("detail = %q; ConfigDir script that exists should not be reported", r.Details[0])
 	}
 }
 
@@ -124,6 +213,25 @@ func TestPreStartScriptsCheck_OtherTemplateInScriptPath(t *testing.T) {
 	}
 	c := NewPreStartScriptsCheck(cfg)
 	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("script paths with unresolved templates should be skipped; status = %d, details = %v", r.Status, r.Details)
+	}
+}
+
+func TestPreStartScriptsCheck_CityRoot_OtherTemplateInPath(t *testing.T) {
+	cityPath := t.TempDir()
+	pack := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "agent",
+				SourceDir: pack,
+				PreStart:  []string{"{{.CityRoot}}/scripts/{{.AgentBase}}/setup.sh"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{CityPath: cityPath})
 	if r.Status != StatusOK {
 		t.Errorf("script paths with unresolved templates should be skipped; status = %d, details = %v", r.Status, r.Details)
 	}
@@ -197,5 +305,82 @@ func TestPreStartScriptsCheck_QualifiedNameInDetail(t *testing.T) {
 	want := "wren.runner"
 	if !strings.Contains(r.Details[0], want) {
 		t.Errorf("detail = %q; want it to contain qualified name %q", r.Details[0], want)
+	}
+}
+
+func TestResolvePreStartScript_TableDriven(t *testing.T) {
+	tests := []struct {
+		name      string
+		cmd       string
+		sourceDir string
+		cityPath  string
+		wantOK    bool
+		wantPath  string
+	}{
+		{
+			name:      "config dir",
+			cmd:       "{{.ConfigDir}}/scripts/x.sh",
+			sourceDir: "/p/a",
+			cityPath:  "/c",
+			wantOK:    true,
+			wantPath:  "/p/a/scripts/x.sh",
+		},
+		{
+			name:      "city root",
+			cmd:       "{{.CityRoot}}/scripts/x.sh",
+			sourceDir: "/p/a",
+			cityPath:  "/c",
+			wantOK:    true,
+			wantPath:  "/c/scripts/x.sh",
+		},
+		{
+			name:      "city root with trailing runtime template arg",
+			cmd:       "{{.CityRoot}}/scripts/x.sh {{.RigRoot}}",
+			sourceDir: "/p/a",
+			cityPath:  "/c",
+			wantOK:    true,
+			wantPath:  "/c/scripts/x.sh",
+		},
+		{
+			name:      "both templates substituted",
+			cmd:       "{{.ConfigDir}}/scripts/{{.CityRoot}}/x.sh",
+			sourceDir: "/p/a",
+			cityPath:  "/c",
+			wantOK:    true,
+			wantPath:  "/p/a/scripts/c/x.sh",
+		},
+		{
+			name:      "rig root skipped",
+			cmd:       "{{.RigRoot}}/x.sh",
+			sourceDir: "/p/a",
+			cityPath:  "/c",
+			wantOK:    false,
+		},
+		{
+			name:      "relative skipped",
+			cmd:       "relative/x.sh",
+			sourceDir: "/p/a",
+			cityPath:  "/c",
+			wantOK:    false,
+		},
+		{
+			name:      "unresolved first token skipped",
+			cmd:       "{{.CityRoot}}/{{.AgentBase}}/x.sh",
+			sourceDir: "/p/a",
+			cityPath:  "/c",
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolvePreStartScript(tt.cmd, tt.sourceDir, tt.cityPath)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v; path = %q", ok, tt.wantOK, got)
+			}
+			if got != tt.wantPath {
+				t.Errorf("path = %q, want %q", got, tt.wantPath)
+			}
+		})
 	}
 }

--- a/release-gates/ga-qsmaw2-pr1-gate.md
+++ b/release-gates/ga-qsmaw2-pr1-gate.md
@@ -1,0 +1,46 @@
+# Release gate - CityRoot pre_start doctor check (ga-gqhfxj / ga-qsmaw2)
+
+**Verdict:** PASS
+
+- Deploy bead: `ga-gqhfxj`
+- Source bead: `ga-qsmaw2`
+- Review bead: `ga-wsn3qp`
+- Branch: `builder/ga-qsmaw2-pr1`
+- Implementation commit: `029a764a9af240c9a03549bf3c0c439fd68e88fa`
+- Base checked: `origin/main` at `3ef98456b154fbf32f83c09c2e547fda1df286f7`
+- Push target: `origin` (`git push --dry-run origin HEAD` succeeded)
+- Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this repo; this gate uses the deployer prompt criteria and the source bead acceptance criteria.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-wsn3qp` is closed and includes `VERDICT: pass` for commit `029a764a9`. |
+| 2 | Acceptance criteria met | PASS | `resolvePreStartScript(cmd, sourceDir, cityPath string)` is present; `{{.CityRoot}}` and `{{.ConfigDir}}` are both substituted; commands with neither still skip; `Run(ctx)` passes `ctx.CityPath`; new CityRoot tests and the 7-case resolver table exist; `cmd/gc/cmd_doctor.go` is unchanged. The PR body will reference design bead `ga-x0pq6s` as required by the source acceptance criteria. |
+| 3 | Tests pass | PASS | Deployer re-ran focused doctor tests, `make test-fast-parallel`, `go vet ./...`, and `make lint`; all passed. |
+| 4 | No high-severity review findings open | PASS | Review notes report no security concerns and no blocking findings; no HIGH findings are present in the review bead. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before this markdown-only gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree `056d1d59051dc32387854d2d47023790a502ec08`; PR-style diff is limited to `internal/doctor/pre_start_scripts_check.go` and `internal/doctor/pre_start_scripts_check_test.go`. |
+
+## Acceptance Evidence
+
+- Helper signature: `func resolvePreStartScript(cmd, sourceDir, cityPath string) (string, bool)`.
+- CityRoot substitution is implemented with `strings.ReplaceAll(expanded, "{{.CityRoot}}", cityPath)`.
+- ConfigDir substitution is preserved with `strings.ReplaceAll(expanded, "{{.ConfigDir}}", sourceDir)`.
+- First-token validation still rejects unresolved templates and relative paths.
+- `PreStartScriptsCheck.Run(ctx)` reads `ctx.CityPath` and passes it to the resolver.
+- New tests present:
+  - `TestPreStartScriptsCheck_CityRoot_ScriptExists`
+  - `TestPreStartScriptsCheck_CityRoot_ScriptMissing`
+  - `TestPreStartScriptsCheck_BothTemplates_OneMissing`
+  - `TestPreStartScriptsCheck_CityRoot_OtherTemplateInPath`
+  - `TestResolvePreStartScript_TableDriven`
+
+## Deployer Validation
+
+- `go test ./internal/doctor/... -run 'TestPreStartScriptsCheck|TestResolvePreStartScript_TableDriven'` - PASS
+- `make test-fast-parallel` - PASS
+- `go vet ./...` - PASS
+- `make lint` - PASS (`0 issues.`)
+- `git diff --check origin/main...HEAD` - PASS
+- `gh pr list --repo gastownhall/gascity --head quad341:builder/ga-qsmaw2-pr1 --state all` - no existing PR found before deployer push


### PR DESCRIPTION
## What this changes

`gc doctor` now recognizes `{{.CityRoot}}` in agent `pre_start` commands when it statically checks that referenced scripts exist on disk. This lets packs move shared scripts under a city-level `scripts/` directory while keeping the missing-script warning active.

Existing `{{.ConfigDir}}` support is preserved. Runtime-only templates such as `{{.RigRoot}}`, `{{.WorkDir}}`, and `{{.AgentBase}}` are still skipped by the static check when they appear in the script path, because the doctor check does not have enough runtime context to resolve them safely.

## Review notes

- Main behavior is in `internal/doctor/pre_start_scripts_check.go`.
- Coverage is in `internal/doctor/pre_start_scripts_check_test.go`, including CityRoot success/failure cases, mixed ConfigDir/CityRoot coverage, unresolved-template skip behavior, and the resolver table.
- No CLI wiring changes: `cmd/gc/cmd_doctor.go` is unchanged.
- Design reference: `ga-x0pq6s`.

## Test plan

- [x] `go test ./internal/doctor/... -run 'TestPreStartScriptsCheck|TestResolvePreStartScript_TableDriven'`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `make lint`
- [x] Release gate: [`release-gates/ga-qsmaw2-pr1-gate.md`](release-gates/ga-qsmaw2-pr1-gate.md)
