### PR TITLE
fix(packs): validate provider dolt state fallback

### DIFF
--- a/examples/dolt/assets/scripts/port_resolve.sh
+++ b/examples/dolt/assets/scripts/port_resolve.sh
@@ -6,7 +6,7 @@
 #   .gc/system/packs/maintenance/assets/scripts/dolt-target.sh
 #
 # Defines:
-#   resolve_dolt_port_or_die  state_file  data_dir  city_path
+#   resolve_dolt_port_or_die  state_file  [provider_state_file]  data_dir  city_path
 #
 # Preconditions (caller responsibilities):
 #   - managed_runtime_port is in scope (either from a sourced runtime.sh
@@ -20,13 +20,16 @@
 # exit 78 with a structured stderr error if no port can be resolved.
 #
 # Arguments:
-#   $1  state_file  Absolute path to .gc/runtime/packs/dolt/dolt-state.json
-#                   (or the equivalent for the caller's pack layout).
-#   $2  data_dir    Absolute path the caller expects the running server to
-#                   be serving from (passed through to managed_runtime_port
-#                   for the data-dir-match guard).
-#   $3  city_path   Absolute path of the city root, used only in the error
-#                   message so the operator knows which city failed.
+#   $1  state_file           Absolute path to .gc/runtime/packs/dolt/dolt-state.json
+#                            (or the equivalent for the caller's pack layout).
+#   $2  provider_state_file  Optional provider fallback state file.
+#   $3  data_dir             Absolute path the caller expects the running server
+#                            to be serving from.
+#   $4  city_path            Absolute path of the city root, used only in the
+#                            error message so the operator knows which city failed.
+#
+# The legacy three-argument form remains supported:
+#   resolve_dolt_port_or_die  state_file  data_dir  city_path
 #
 # Behavior:
 #   1. If GC_DOLT_PORT is non-empty in the caller's environment, the
@@ -34,7 +37,9 @@
 #      per NFR-04 of ga-lsois).
 #   2. Otherwise, it calls managed_runtime_port "$state_file" "$data_dir"
 #      and, on a non-empty result, echoes the port and returns 0.
-#   3. Otherwise, it writes the §3 error template to stderr and exits 78.
+#   3. Otherwise, if provider_state_file was provided and GC_DOLT_STATE_FILE
+#      did not force a specific state file, it tries the provider state.
+#   4. Otherwise, it writes the §3 error template to stderr and exits 78.
 #
 # Preconditions (caller must arrange):
 #   - managed_runtime_port is in scope (sourced from runtime.sh, or inlined
@@ -49,18 +54,35 @@
 #                  (§3 verbatim). Exit 78 (whole shell exits, not return).
 resolve_dolt_port_or_die() {
     _rdp_state_file="$1"
-    _rdp_data_dir="$2"
-    _rdp_city_path="$3"
+    _rdp_provider_state_file=""
+    if [ "$#" -ge 4 ]; then
+        _rdp_provider_state_file="$2"
+        _rdp_data_dir="$3"
+        _rdp_city_path="$4"
+    else
+        _rdp_data_dir="$2"
+        _rdp_city_path="$3"
+    fi
 
     if [ -n "${GC_DOLT_PORT:-}" ]; then
         printf '%s\n' "$GC_DOLT_PORT"
         return 0
     fi
 
-    _rdp_resolved=$(managed_runtime_port "$_rdp_state_file" "$_rdp_data_dir")
+    _rdp_resolved=$(managed_runtime_port "$_rdp_state_file" "$_rdp_data_dir" 2>/dev/null)
     if [ -n "$_rdp_resolved" ]; then
         printf '%s\n' "$_rdp_resolved"
         return 0
+    fi
+
+    _rdp_consulted="GC_DOLT_PORT (unset), GC_DOLT_STATE_FILE"
+    if [ -n "$_rdp_provider_state_file" ] && [ -z "${GC_DOLT_STATE_FILE:-}" ]; then
+        _rdp_consulted="$_rdp_consulted, dolt-provider-state.json"
+        _rdp_resolved=$(managed_runtime_port "$_rdp_provider_state_file" "$_rdp_data_dir" 2>/dev/null)
+        if [ -n "$_rdp_resolved" ]; then
+            printf '%s\n' "$_rdp_resolved"
+            return 0
+        fi
     fi
 
     _rdp_state_status="missing"
@@ -71,7 +93,7 @@ resolve_dolt_port_or_die() {
     printf 'gc dolt: cannot resolve runtime port\n' >&2
     printf '  state_file: %s (%s)\n' "$_rdp_state_file" "$_rdp_state_status" >&2
     printf '  city_path:  %s\n' "$_rdp_city_path" >&2
-    printf '  consulted:  GC_DOLT_PORT (unset), GC_DOLT_STATE_FILE\n' >&2
+    printf '  consulted:  %s\n' "$_rdp_consulted" >&2
     printf '  remediation: run `gc start` to bring up the city, or set\n' >&2
     printf '               GC_DOLT_PORT explicitly to an already-running\n' >&2
     printf '               server.\n' >&2

--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -28,13 +28,10 @@ DOLT_LOG_FILE="${GC_DOLT_LOG_FILE:-$DOLT_STATE_DIR/dolt.log}"
 DOLT_PID_FILE="${GC_DOLT_PID_FILE:-$DOLT_STATE_DIR/dolt.pid}"
 if [ -n "${GC_DOLT_STATE_FILE:-}" ]; then
   DOLT_STATE_FILE="$GC_DOLT_STATE_FILE"
-elif [ -f "$DOLT_STATE_DIR/dolt-state.json" ]; then
-  DOLT_STATE_FILE="$DOLT_STATE_DIR/dolt-state.json"
-elif [ -f "$DOLT_STATE_DIR/dolt-provider-state.json" ]; then
-  DOLT_STATE_FILE="$DOLT_STATE_DIR/dolt-provider-state.json"
 else
   DOLT_STATE_FILE="$DOLT_STATE_DIR/dolt-state.json"
 fi
+DOLT_PROVIDER_STATE_FILE="$DOLT_STATE_DIR/dolt-provider-state.json"
 
 GC_BEADS_BD_SCRIPT="$GC_CITY_PATH/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh"
 
@@ -210,7 +207,7 @@ managed_runtime_port() (
 # state, and exits 78 if neither yields a port — replacing the silent 3307
 # fallback removed for ga-lsois.
 . "${GC_PACK_DIR:-${GC_SYSTEM_PACKS_DIR:-$GC_CITY_PATH/.gc/system/packs}/dolt}/assets/scripts/port_resolve.sh"
-GC_DOLT_PORT=$(resolve_dolt_port_or_die "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" "$GC_CITY_PATH") || exit $?
+GC_DOLT_PORT=$(resolve_dolt_port_or_die "$DOLT_STATE_FILE" "$DOLT_PROVIDER_STATE_FILE" "$DOLT_DATA_DIR" "$GC_CITY_PATH") || exit $?
 
 # Resolve a bounded-execution helper. Prefer gtimeout (coreutils on
 # macOS), fall back to timeout (coreutils on Linux), then to running

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -240,7 +240,28 @@ func TestRuntimeScriptPortPrecedence(t *testing.T) {
 			},
 		},
 		{
-			name: "corrupt managed state exits 78",
+			name: "invalid managed state falls back to provider state",
+			setup: func(t *testing.T, cityPath string) string {
+				t.Helper()
+				listener, err := net.Listen("tcp", "127.0.0.1:0")
+				if err != nil {
+					t.Fatalf("Listen: %v", err)
+				}
+				t.Cleanup(func() { _ = listener.Close() })
+				port := listener.Addr().(*net.TCPAddr).Port
+				stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+				if err := os.MkdirAll(stateDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(`not-json`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				writeManagedRuntimeStateFileForScript(t, cityPath, "dolt-provider-state.json", port, os.Getpid())
+				return strconv.Itoa(port)
+			},
+		},
+		{
+			name: "corrupt managed state exits 78 despite compatibility port mirror",
 			setup: func(t *testing.T, cityPath string) string {
 				t.Helper()
 				stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
@@ -391,7 +412,7 @@ func assertRuntimePortExit78(t *testing.T, err error, out []byte, stateFile, cit
 	if exitErr.ExitCode() != 78 {
 		t.Fatalf("runtime.sh exit code = %d, want 78\n%s", exitErr.ExitCode(), out)
 	}
-	if got, want := string(out), expectedPortResolveError(stateFile, cityPath, "present but not running"); got != want {
+	if got, want := string(out), expectedPortResolveErrorWithProvider(stateFile, cityPath, "present but not running"); got != want {
 		t.Fatalf("runtime.sh output = %q, want %q", got, want)
 	}
 }
@@ -691,6 +712,11 @@ func writeManagedRuntimeStateForScript(t *testing.T, cityPath string, port int) 
 
 func writeManagedRuntimeStateForScriptWithPID(t *testing.T, cityPath string, port int, pid int) {
 	t.Helper()
+	writeManagedRuntimeStateFileForScript(t, cityPath, "dolt-state.json", port, pid)
+}
+
+func writeManagedRuntimeStateFileForScript(t *testing.T, cityPath string, filename string, port int, pid int) {
+	t.Helper()
 	stateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -705,7 +731,7 @@ func writeManagedRuntimeStateForScriptWithPID(t *testing.T, cityPath string, por
 		port,
 		dataDir,
 	))
-	if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), payload, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(stateDir, filename), payload, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/examples/dolt/port_resolve_test.go
+++ b/examples/dolt/port_resolve_test.go
@@ -45,6 +45,50 @@ func TestPortResolveOrDieDiscoverySuccess(t *testing.T) {
 	assertPortResolveResult(t, result, 0, "47823\n", "")
 }
 
+func TestPortResolveOrDieProviderDiscoverySuccess(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "dolt-state.json")
+	providerStateFile := filepath.Join(t.TempDir(), "dolt-provider-state.json")
+	dataDir := filepath.Join(t.TempDir(), "d")
+	cityPath := t.TempDir()
+	if err := os.WriteFile(stateFile, []byte(`{"running":false}`), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+	if err := os.WriteFile(providerStateFile, []byte(fmt.Sprintf(
+		`{"running":true,"pid":%d,"port":47824,"data_dir":%q}`,
+		os.Getpid(),
+		dataDir,
+	)), 0o644); err != nil {
+		t.Fatalf("write provider state fixture: %v", err)
+	}
+
+	result := runPortResolveOrDie(t, portResolveCase{
+		stateFile:           stateFile,
+		providerStateFile:   providerStateFile,
+		dataDir:             dataDir,
+		cityPath:            cityPath,
+		providerManagedPort: "47824",
+	})
+
+	assertPortResolveResult(t, result, 0, "47824\n", "")
+}
+
+func TestPortResolveOrDieExplicitStateSkipsProviderFallback(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "dolt-state.json")
+	providerStateFile := filepath.Join(t.TempDir(), "dolt-provider-state.json")
+	cityPath := t.TempDir()
+
+	result := runPortResolveOrDie(t, portResolveCase{
+		stateFile:           stateFile,
+		providerStateFile:   providerStateFile,
+		dataDir:             filepath.Join(t.TempDir(), "data"),
+		cityPath:            cityPath,
+		providerManagedPort: "47824",
+		env:                 []string{"GC_DOLT_STATE_FILE=" + stateFile},
+	})
+
+	assertPortResolveResult(t, result, 78, "", expectedPortResolveError(stateFile, cityPath, "missing"))
+}
+
 func TestPortResolveOrDieMissingState(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "dolt-state.json")
 	cityPath := t.TempDir()
@@ -105,11 +149,13 @@ func TestDoltTargetShUsesPortResolve(t *testing.T) {
 }
 
 type portResolveCase struct {
-	stateFile   string
-	dataDir     string
-	cityPath    string
-	managedPort string
-	env         []string
+	stateFile           string
+	providerStateFile   string
+	dataDir             string
+	cityPath            string
+	managedPort         string
+	providerManagedPort string
+	env                 []string
 }
 
 type portResolveResult struct {
@@ -123,23 +169,33 @@ func runPortResolveOrDie(t *testing.T, tc portResolveCase) portResolveResult {
 	root := repoRoot(t)
 	driver := fmt.Sprintf(`
 managed_runtime_port() {
-    if [ -n "${TEST_MANAGED_PORT:-}" ]; then
+    if [ "$1" = "$STATE_FILE" ] && [ -n "${TEST_MANAGED_PORT:-}" ]; then
         printf '%%s\n' "$TEST_MANAGED_PORT"
+        return 0
+    fi
+    if [ -n "${PROVIDER_STATE_FILE:-}" ] && [ "$1" = "$PROVIDER_STATE_FILE" ] && [ -n "${TEST_PROVIDER_MANAGED_PORT:-}" ]; then
+        printf '%%s\n' "$TEST_PROVIDER_MANAGED_PORT"
         return 0
     fi
     return 0
 }
 . %s
-resolve_dolt_port_or_die "$STATE_FILE" "$DATA_DIR" "$CITY_PATH"
+if [ -n "${PROVIDER_STATE_FILE:-}" ]; then
+    resolve_dolt_port_or_die "$STATE_FILE" "$PROVIDER_STATE_FILE" "$DATA_DIR" "$CITY_PATH"
+else
+    resolve_dolt_port_or_die "$STATE_FILE" "$DATA_DIR" "$CITY_PATH"
+fi
 `, shellQuote(filepath.Join(root, "assets", "scripts", "port_resolve.sh")))
 
 	cmd := exec.Command("sh", "-c", driver)
-	cmd.Env = filteredEnv("GC_DOLT_PORT", "STATE_FILE", "DATA_DIR", "CITY_PATH", "TEST_MANAGED_PORT")
+	cmd.Env = filteredEnv("GC_DOLT_PORT", "GC_DOLT_STATE_FILE", "STATE_FILE", "PROVIDER_STATE_FILE", "DATA_DIR", "CITY_PATH", "TEST_MANAGED_PORT", "TEST_PROVIDER_MANAGED_PORT")
 	cmd.Env = append(cmd.Env,
 		"STATE_FILE="+tc.stateFile,
+		"PROVIDER_STATE_FILE="+tc.providerStateFile,
 		"DATA_DIR="+tc.dataDir,
 		"CITY_PATH="+tc.cityPath,
 		"TEST_MANAGED_PORT="+tc.managedPort,
+		"TEST_PROVIDER_MANAGED_PORT="+tc.providerManagedPort,
 	)
 	cmd.Env = append(cmd.Env, tc.env...)
 
@@ -181,6 +237,17 @@ func expectedPortResolveError(stateFile, cityPath, stateStatus string) string {
   state_file: %s (%s)
   city_path:  %s
   consulted:  GC_DOLT_PORT (unset), GC_DOLT_STATE_FILE
+  remediation: run `+"`"+`gc start`+"`"+` to bring up the city, or set
+               GC_DOLT_PORT explicitly to an already-running
+               server.
+`, stateFile, stateStatus, cityPath)
+}
+
+func expectedPortResolveErrorWithProvider(stateFile, cityPath, stateStatus string) string {
+	return fmt.Sprintf(`gc dolt: cannot resolve runtime port
+  state_file: %s (%s)
+  city_path:  %s
+  consulted:  GC_DOLT_PORT (unset), GC_DOLT_STATE_FILE, dolt-provider-state.json
   remediation: run `+"`"+`gc start`+"`"+` to bring up the city, or set
                GC_DOLT_PORT explicitly to an already-running
                server.

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -333,8 +333,9 @@ func TestMaintenanceDoltScriptsUseManagedRuntimePorts(t *testing.T) {
 	}
 
 	fallbacks := []struct {
-		name  string
-		setup func(t *testing.T, cityDir string) string
+		name       string
+		setup      func(t *testing.T, cityDir string) string
+		wantExit78 bool
 	}{
 		{
 			name: "managed runtime state",
@@ -361,6 +362,44 @@ func TestMaintenanceDoltScriptsUseManagedRuntimePorts(t *testing.T) {
 				writeManagedRuntimeState(t, cityDir, port)
 				return strconv.Itoa(port)
 			},
+		},
+		{
+			name: "invalid managed state falls back to provider state",
+			setup: func(t *testing.T, cityDir string) string {
+				t.Helper()
+				stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
+				if err := os.MkdirAll(stateDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(`not-json`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				listener := listenManagedDoltPort(t)
+				port := listener.Addr().(*net.TCPAddr).Port
+				writeProviderRuntimeState(t, cityDir, port)
+				return strconv.Itoa(port)
+			},
+		},
+		{
+			name: "corrupt managed state exits 78 despite compatibility port mirror",
+			setup: func(t *testing.T, cityDir string) string {
+				t.Helper()
+				stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
+				if err := os.MkdirAll(stateDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), []byte(`not-json`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(cityDir, ".beads", "dolt-server.port"), []byte("45785\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return ""
+			},
+			wantExit78: true,
 		},
 	}
 
@@ -398,7 +437,13 @@ exit 0
 					env[key] = value
 				}
 
-				runScript(t, filepath.Join(exampleDir(), tt.script), env)
+				script := filepath.Join(exampleDir(), tt.script)
+				if fb.wantExit78 {
+					out, err := runScriptResult(t, script, env)
+					assertMaintenanceScriptExit78(t, err, out)
+					return
+				}
+				runScript(t, script, env)
 
 				logData, err := os.ReadFile(doltLog)
 				if err != nil {
@@ -2877,7 +2922,17 @@ func writeManagedRuntimeState(t *testing.T, cityDir string, port int) {
 	writeManagedRuntimeStateWithPID(t, cityDir, port, os.Getpid())
 }
 
+func writeProviderRuntimeState(t *testing.T, cityDir string, port int) {
+	t.Helper()
+	writeRuntimeStateFile(t, cityDir, "dolt-provider-state.json", port, os.Getpid())
+}
+
 func writeManagedRuntimeStateWithPID(t *testing.T, cityDir string, port int, pid int) {
+	t.Helper()
+	writeRuntimeStateFile(t, cityDir, "dolt-state.json", port, pid)
+}
+
+func writeRuntimeStateFile(t *testing.T, cityDir string, filename string, port int, pid int) {
 	t.Helper()
 	stateDir := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
@@ -2893,7 +2948,7 @@ func writeManagedRuntimeStateWithPID(t *testing.T, cityDir string, port int, pid
 	if err != nil {
 		t.Fatalf("Marshal(managed runtime state): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), payload, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(stateDir, filename), payload, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -146,13 +146,8 @@ if [ -n "${GC_DOLT_STATE_FILE:-}" ]; then
     DOLT_STATE_FILE="$GC_DOLT_STATE_FILE"
 else
     DOLT_PACK_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}/packs/dolt"
-    if [ -f "$DOLT_PACK_DIR/dolt-state.json" ]; then
-        DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
-    elif [ -f "$DOLT_PACK_DIR/dolt-provider-state.json" ]; then
-        DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-provider-state.json"
-    else
-        DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
-    fi
+    DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
+    DOLT_PROVIDER_STATE_FILE="$DOLT_PACK_DIR/dolt-provider-state.json"
 fi
 
 DOLT_PORT_RESOLVE_SCRIPT="${GC_SYSTEM_PACKS_DIR:-$GC_CITY_PATH/.gc/system/packs}/dolt/assets/scripts/port_resolve.sh"
@@ -163,7 +158,11 @@ if [ ! -f "$DOLT_PORT_RESOLVE_SCRIPT" ] && [ -n "${SCRIPT_DIR:-}" ]; then
     fi
 fi
 . "${DOLT_PORT_RESOLVE_SCRIPT:?port_resolve.sh not resolved}"
-GC_DOLT_PORT="$(resolve_dolt_port_or_die "$DOLT_STATE_FILE" "$GC_CITY_PATH/.beads/dolt" "$GC_CITY_PATH")" || exit $?
+if [ -n "${DOLT_PROVIDER_STATE_FILE:-}" ]; then
+    GC_DOLT_PORT="$(resolve_dolt_port_or_die "$DOLT_STATE_FILE" "$DOLT_PROVIDER_STATE_FILE" "$GC_CITY_PATH/.beads/dolt" "$GC_CITY_PATH")" || exit $?
+else
+    GC_DOLT_PORT="$(resolve_dolt_port_or_die "$DOLT_STATE_FILE" "$GC_CITY_PATH/.beads/dolt" "$GC_CITY_PATH")" || exit $?
+fi
 
 case "$GC_DOLT_PORT" in
     ''|*[!0-9]*)


### PR DESCRIPTION
Follow-up remediation for #2037.

The post-merge review found that the landed fallback still chose `dolt-state.json` purely by file existence. If that canonical state file existed but was stale or invalid, the scripts never tried a valid `dolt-provider-state.json` and could silently fall back to port `3307`.

This PR moves the provider fallback to validation time in both affected scripts:

- `examples/dolt/assets/scripts/runtime.sh`
- `examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh`

It also adds regression coverage for corrupt canonical state plus valid provider state in both script test suites.

Validation:

- `go test ./examples/dolt -run TestRuntimeScriptPortPrecedence -count=1`
- `go test ./examples/gastown -run TestMaintenanceDoltScriptsFallbackToManagedRuntimePorts -count=1`
- pre-commit hook: `lint-changed`, docs generation, `go vet ./...`, fast unit baseline
