### PR TITLE
Fix managed Dolt test process leaks

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1807,6 +1807,14 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 		env = removeEnvKey(env, "GC_BIN")
 		env = append(env, "GC_BIN="+gcBin)
 	}
+	if managedDoltTestModeEnabled() {
+		env = removeEnvKey(env, managedDoltTestModeEnv)
+		env = removeEnvKey(env, managedDoltTestParentPIDEnv)
+		env = append(env,
+			managedDoltTestModeEnv+"=1",
+			managedDoltTestParentPIDEnv+"="+managedDoltTestParentPIDString(),
+		)
+	}
 	// Propagate archive_level from city config so the managed dolt
 	// server inherits it without shell-script changes.
 	if v, ok := cityDoltConfigs.Load(cityPath); ok {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -113,6 +113,25 @@ func TestProviderLifecycleProcessEnvProjectsCanonicalDoltPaths(t *testing.T) {
 	}
 }
 
+func TestProviderLifecycleProcessEnvPropagatesManagedDoltTestMode(t *testing.T) {
+	cityPath := t.TempDir()
+	envEntries := mustProviderLifecycleProcessEnv(t, cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	env := map[string]string{}
+	for _, entry := range envEntries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+
+	if got := env[managedDoltTestModeEnv]; got != "1" {
+		t.Fatalf("providerLifecycleProcessEnv()[%s] = %q, want 1", managedDoltTestModeEnv, got)
+	}
+	if got := env[managedDoltTestParentPIDEnv]; got == "" {
+		t.Fatalf("providerLifecycleProcessEnv()[%s] missing", managedDoltTestParentPIDEnv)
+	}
+}
+
 func TestProviderLifecycleProcessEnvCanonicalizesSymlinkedCityPath(t *testing.T) {
 	root := t.TempDir()
 	realParent := filepath.Join(root, "real")

--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -502,7 +502,10 @@ func revalidateReapTarget(report *CleanupReport, discover func() ([]DoltProcInfo
 }
 
 func sameReapProcessIdentity(target ReapTarget, proc DoltProcInfo) bool {
-	return target.StartTimeTicks != 0 && proc.StartTimeTicks == target.StartTimeTicks
+	if target.StartTimeTicks != 0 {
+		return proc.StartTimeTicks == target.StartTimeTicks
+	}
+	return target.StartIdentity != "" && proc.StartIdentity == target.StartIdentity
 }
 
 func recordReapRevalidationError(report *CleanupReport, signalName string, err error) {

--- a/cmd/gc/dolt_cleanup_discovery.go
+++ b/cmd/gc/dolt_cleanup_discovery.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -45,18 +46,14 @@ func loadRigDoltPorts(rigs []resolverRig, fs fsys.FS) map[int]string {
 // kernel thread or hung process can't make the reaper hang.
 const procEnumerationTimeout = 2 * time.Second
 
-// discoverDoltProcesses walks /proc to find live `dolt sql-server` processes
-// and reports their argv and listening ports. Returns nil + nil on hosts
-// without /proc (the reaper degrades to "no candidates found", which is
-// indistinguishable from a healthy host with no orphans).
-//
-// The function is intentionally Linux-specific. macOS/BSD hosts would need
-// `ps -ax -o pid,command` and `lsof -i -P -nFn` — left as future work since
-// the architect's spec scopes this to Linux test infrastructure.
+// discoverDoltProcesses finds live `dolt sql-server` processes and reports
+// their argv and listening ports. Linux uses /proc for argv, ports, RSS, and
+// start ticks. Hosts without /proc (including Darwin/macOS) fall back to ps for
+// process enumeration and lsof for best-effort listening ports.
 func discoverDoltProcesses() ([]DoltProcInfo, error) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
-		return nil, nil
+		return discoverDoltProcessesFromPS()
 	}
 
 	pidPorts := portsByPID()
@@ -85,10 +82,27 @@ func discoverDoltProcesses() ([]DoltProcInfo, error) {
 	return out, nil
 }
 
+func discoverDoltProcessesFromPS() ([]DoltProcInfo, error) {
+	lines, err := psLStartCommandLines()
+	if err != nil {
+		return nil, err
+	}
+	pidPorts := portsByPID()
+	var out []DoltProcInfo
+	for _, line := range lines {
+		proc, ok := parseDoltPSLine(line, pidPorts)
+		if !ok {
+			continue
+		}
+		out = append(out, proc)
+	}
+	return out, nil
+}
+
 func discoverActiveTestRoots(homeDir, tempDir string) []string {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
-		return nil
+		return discoverActiveTestRootsFromPS(homeDir, tempDir)
 	}
 	seen := map[string]struct{}{}
 	var roots []string
@@ -106,6 +120,33 @@ func discoverActiveTestRoots(homeDir, tempDir string) []string {
 		}
 		argv := splitCmdline(data)
 		if looksLikeDoltSQLServer(argv) {
+			continue
+		}
+		for _, arg := range argv {
+			root, ok := activeTestRootFromPath(arg, homeDir, tempDir)
+			if !ok {
+				continue
+			}
+			if _, exists := seen[root]; exists {
+				continue
+			}
+			seen[root] = struct{}{}
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}
+
+func discoverActiveTestRootsFromPS(homeDir, tempDir string) []string {
+	lines, err := psLStartCommandLines()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var roots []string
+	for _, line := range lines {
+		argv, ok := argvFromPSLine(line)
+		if !ok || looksLikeDoltSQLServer(argv) {
 			continue
 		}
 		for _, arg := range argv {
@@ -218,6 +259,152 @@ func readDoltSQLServerArgv(pid int) ([]string, bool) {
 	return argv, true
 }
 
+func psLStartCommandLines() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), procEnumerationTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ps", "-ax", "-o", "pid=,rss=,lstart=,command=")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	lines := make([]string, 0, 64)
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines, nil
+}
+
+func parseDoltPSLine(line string, pidPorts map[int][]int) (DoltProcInfo, bool) {
+	fields, command := consumeLeadingFields(line, 7)
+	if len(fields) != 7 || command == "" {
+		return DoltProcInfo{}, false
+	}
+	pid, err := strconv.Atoi(fields[0])
+	if err != nil || pid <= 0 {
+		return DoltProcInfo{}, false
+	}
+	rssKB, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil || rssKB < 0 {
+		rssKB = 0
+	}
+	argv := parseDoltPSCommandLine(command)
+	if !looksLikeDoltSQLServer(argv) {
+		return DoltProcInfo{}, false
+	}
+	return DoltProcInfo{
+		PID:           pid,
+		Argv:          argv,
+		Ports:         pidPorts[pid],
+		RSSBytes:      rssKB * 1024,
+		StartIdentity: strings.Join(fields[2:7], " "),
+	}, true
+}
+
+func argvFromPSLine(line string) ([]string, bool) {
+	_, command := consumeLeadingFields(line, 7)
+	if command == "" {
+		return nil, false
+	}
+	return parseDoltPSCommandLine(command), true
+}
+
+func consumeLeadingFields(s string, n int) ([]string, string) {
+	rest := strings.TrimSpace(s)
+	fields := make([]string, 0, n)
+	for len(fields) < n {
+		if rest == "" {
+			return fields, ""
+		}
+		i := strings.IndexFunc(rest, func(r rune) bool { return r == ' ' || r == '\t' })
+		if i < 0 {
+			fields = append(fields, rest)
+			return fields, ""
+		}
+		fields = append(fields, rest[:i])
+		rest = strings.TrimLeft(rest[i:], " \t")
+	}
+	return fields, rest
+}
+
+func parseDoltPSCommandLine(command string) []string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return nil
+	}
+	if len(fields) < 2 || filepath.Base(fields[0]) != "dolt" || fields[1] != "sql-server" {
+		return fields
+	}
+	argv := []string{fields[0], fields[1]}
+	if cfg, ok := configPathFromPSCommandLine(command); ok {
+		argv = append(argv, "--config", cfg)
+	}
+	return argv
+}
+
+func configPathFromPSCommandLine(command string) (string, bool) {
+	spans := commandFieldSpans(command)
+	for i, span := range spans {
+		field := command[span.start:span.end]
+		if strings.HasPrefix(field, "--config=") {
+			value := strings.TrimSpace(strings.TrimPrefix(field, "--config="))
+			if value == "" {
+				return "", false
+			}
+			return trimPSConfigValue(value), true
+		}
+		if field == "--config" {
+			if i+1 >= len(spans) {
+				return "", false
+			}
+			value := strings.TrimSpace(command[spans[i+1].start:])
+			if value == "" {
+				return "", false
+			}
+			return trimPSConfigValue(value), true
+		}
+	}
+	return "", false
+}
+
+type commandFieldSpan struct {
+	start int
+	end   int
+}
+
+func commandFieldSpans(s string) []commandFieldSpan {
+	var spans []commandFieldSpan
+	inField := false
+	start := 0
+	for i, r := range s {
+		if r == ' ' || r == '\t' {
+			if inField {
+				spans = append(spans, commandFieldSpan{start: start, end: i})
+				inField = false
+			}
+			continue
+		}
+		if !inField {
+			start = i
+			inField = true
+		}
+	}
+	if inField {
+		spans = append(spans, commandFieldSpan{start: start, end: len(s)})
+	}
+	return spans
+}
+
+func trimPSConfigValue(value string) string {
+	for _, sep := range []string{" --", "\t--"} {
+		if i := strings.Index(value, sep); i >= 0 {
+			value = value[:i]
+		}
+	}
+	return strings.TrimSpace(value)
+}
+
 // splitCmdline parses a /proc/<pid>/cmdline blob (NUL-separated argv with
 // trailing NUL) into a string slice. Empty trailing element is dropped.
 func splitCmdline(data []byte) []string {
@@ -247,9 +434,12 @@ func looksLikeDoltSQLServer(argv []string) bool {
 // only protection).
 func portsByPID() map[int][]int {
 	out := map[int][]int{}
-	listenInodes := listenInodesByPort()
+	listenInodes, checkedProcNet := listenInodesByPortChecked()
 	if len(listenInodes) == 0 {
-		return out
+		if checkedProcNet {
+			return out
+		}
+		return portsByPIDFromLsof()
 	}
 	inodeToPort := map[string]int{}
 	for port, inodes := range listenInodes {
@@ -292,17 +482,75 @@ func portsByPID() map[int][]int {
 	return out
 }
 
+func portsByPIDFromLsof() map[int][]int {
+	out := map[int][]int{}
+	if _, err := exec.LookPath("lsof"); err != nil {
+		return out
+	}
+	data, err := lsofOutput("-nP", "-iTCP", "-sTCP:LISTEN")
+	if err != nil {
+		return out
+	}
+	return parseListeningPortsByPIDFromLsof(string(data))
+}
+
+func parseListeningPortsByPIDFromLsof(output string) map[int][]int {
+	out := map[int][]int{}
+	for _, line := range strings.Split(output, "\n") {
+		pid, port, ok := parseListeningPortLsofLine(line)
+		if !ok {
+			continue
+		}
+		out[pid] = appendUniqueInt(out[pid], port)
+	}
+	return out
+}
+
+func parseListeningPortLsofLine(line string) (int, int, bool) {
+	if !strings.Contains(line, "(LISTEN)") {
+		return 0, 0, false
+	}
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0, 0, false
+	}
+	pid, err := strconv.Atoi(fields[1])
+	if err != nil || pid <= 0 {
+		return 0, 0, false
+	}
+	listenIdx := strings.Index(line, "(LISTEN)")
+	beforeListen := strings.TrimSpace(line[:listenIdx])
+	colon := strings.LastIndex(beforeListen, ":")
+	if colon < 0 || colon+1 >= len(beforeListen) {
+		return 0, 0, false
+	}
+	portText := beforeListen[colon+1:]
+	portText = strings.TrimRightFunc(portText, func(r rune) bool { return r < '0' || r > '9' })
+	port, err := strconv.Atoi(portText)
+	if err != nil || !validDoltPort(port) {
+		return 0, 0, false
+	}
+	return pid, port, true
+}
+
 // listenInodesByPort reads /proc/net/tcp{,6} and returns a port → []inode map
 // for sockets in LISTEN state (TCP state 0A). Each inode is a unique kernel
 // socket identifier that appears as the target of a /proc/<pid>/fd/<n>
 // symlink ("socket:[<inode>]"); cross-referencing those gives port→pid.
 func listenInodesByPort() map[int][]string {
+	out, _ := listenInodesByPortChecked()
+	return out
+}
+
+func listenInodesByPortChecked() (map[int][]string, bool) {
 	out := map[int][]string{}
+	checked := false
 	for _, path := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}
+		checked = true
 		for _, line := range strings.Split(string(data), "\n") {
 			fields := strings.Fields(line)
 			if len(fields) < 10 || fields[3] != "0A" {
@@ -319,7 +567,7 @@ func listenInodesByPort() map[int][]string {
 			out[int(port)] = appendUniqueString(out[int(port)], fields[9])
 		}
 	}
-	return out
+	return out, checked
 }
 
 func appendUniqueInt(s []int, v int) []int {

--- a/cmd/gc/dolt_cleanup_discovery.go
+++ b/cmd/gc/dolt_cleanup_discovery.go
@@ -533,15 +533,6 @@ func parseListeningPortLsofLine(line string) (int, int, bool) {
 	return pid, port, true
 }
 
-// listenInodesByPort reads /proc/net/tcp{,6} and returns a port → []inode map
-// for sockets in LISTEN state (TCP state 0A). Each inode is a unique kernel
-// socket identifier that appears as the target of a /proc/<pid>/fd/<n>
-// symlink ("socket:[<inode>]"); cross-referencing those gives port→pid.
-func listenInodesByPort() map[int][]string {
-	out, _ := listenInodesByPortChecked()
-	return out
-}
-
 func listenInodesByPortChecked() (map[int][]string, bool) {
 	out := map[int][]string{}
 	checked := false

--- a/cmd/gc/dolt_cleanup_discovery_test.go
+++ b/cmd/gc/dolt_cleanup_discovery_test.go
@@ -130,3 +130,70 @@ func TestLooksLikeDoltSQLServer(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDoltPSLine_DoltSQLServer(t *testing.T) {
+	line := "  78306  65392 Sun May 17 09:31:24 2026 /usr/local/bin/dolt sql-server --config /tmp/TestGcBeadsBdStartUsesRootBeadsDataDir802378814/001/.gc/runtime/packs/dolt/dolt-config.yaml --host 127.0.0.1"
+	got, ok := parseDoltPSLine(line, map[int][]int{78306: {3306}})
+	if !ok {
+		t.Fatal("parseDoltPSLine did not recognize dolt sql-server")
+	}
+	if got.PID != 78306 {
+		t.Fatalf("PID = %d, want 78306", got.PID)
+	}
+	if got.RSSBytes != 65392*1024 {
+		t.Fatalf("RSSBytes = %d, want %d", got.RSSBytes, int64(65392*1024))
+	}
+	if !reflect.DeepEqual(got.Ports, []int{3306}) {
+		t.Fatalf("Ports = %v, want [3306]", got.Ports)
+	}
+	if got.StartIdentity != "Sun May 17 09:31:24 2026" {
+		t.Fatalf("StartIdentity = %q", got.StartIdentity)
+	}
+	if cfg := extractConfigPath(got.Argv); cfg != "/tmp/TestGcBeadsBdStartUsesRootBeadsDataDir802378814/001/.gc/runtime/packs/dolt/dolt-config.yaml" {
+		t.Fatalf("config = %q", cfg)
+	}
+}
+
+func TestParseDoltPSLine_PreservesSpacedConfigPath(t *testing.T) {
+	line := "12345 1024 Sun May 17 09:31:24 2026 dolt sql-server --config /tmp/Test With Space/config.yaml --port 3306"
+	got, ok := parseDoltPSLine(line, nil)
+	if !ok {
+		t.Fatal("parseDoltPSLine did not recognize dolt sql-server")
+	}
+	if cfg := extractConfigPath(got.Argv); cfg != "/tmp/Test With Space/config.yaml" {
+		t.Fatalf("config = %q", cfg)
+	}
+}
+
+func TestParseDoltPSLine_IgnoresNonDolt(t *testing.T) {
+	line := "12345 1024 Sun May 17 09:31:24 2026 mysqld --config /tmp/TestX/config.yaml"
+	if got, ok := parseDoltPSLine(line, nil); ok {
+		t.Fatalf("parseDoltPSLine = %+v, want ignored", got)
+	}
+}
+
+func TestParseListeningPortsByPIDFromLsof(t *testing.T) {
+	output := `COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+dolt    78306 dbox   11u  IPv4 0x0000000000000000      0t0  TCP 127.0.0.1:3306 (LISTEN)
+dolt    78306 dbox   12u  IPv6 0x0000000000000000      0t0  TCP [::1]:3307 (LISTEN)
+dolt    99999 dbox   12u  IPv4 0x0000000000000000      0t0  TCP 127.0.0.1:70000 (LISTEN)
+`
+	got := parseListeningPortsByPIDFromLsof(output)
+	want := map[int][]int{78306: {3306, 3307}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseListeningPortsByPIDFromLsof = %v, want %v", got, want)
+	}
+}
+
+func TestSameReapProcessIdentity_UsesPSStartIdentityFallback(t *testing.T) {
+	target := ReapTarget{PID: 42, StartIdentity: "Sun May 17 09:31:24 2026"}
+	same := DoltProcInfo{PID: 42, StartIdentity: "Sun May 17 09:31:24 2026"}
+	reused := DoltProcInfo{PID: 42, StartIdentity: "Sun May 17 09:32:00 2026"}
+
+	if !sameReapProcessIdentity(target, same) {
+		t.Fatal("sameReapProcessIdentity should accept matching ps start identity")
+	}
+	if sameReapProcessIdentity(target, reused) {
+		t.Fatal("sameReapProcessIdentity should reject mismatched ps start identity")
+	}
+}

--- a/cmd/gc/dolt_cleanup_reaper.go
+++ b/cmd/gc/dolt_cleanup_reaper.go
@@ -14,13 +14,15 @@ import (
 // dolt servers so the reaper never touches a production server. RSSBytes is
 // the best-effort resident set size used for operator cleanup summaries.
 // StartTimeTicks is /proc/<pid>/stat field 22 and lets force-mode revalidation
-// detect PID reuse before sending a signal.
+// detect PID reuse before sending a signal. StartIdentity is a portable
+// fallback populated by ps-based discovery on hosts without /proc.
 type DoltProcInfo struct {
 	PID            int
 	Argv           []string
 	Ports          []int
 	RSSBytes       int64
 	StartTimeTicks uint64
+	StartIdentity  string
 }
 
 // reapClassification is the per-process decision produced by classifyDoltProcess.
@@ -40,6 +42,7 @@ type ReapTarget struct {
 	ConfigPath     string
 	RSSBytes       int64
 	StartTimeTicks uint64
+	StartIdentity  string
 }
 
 // ProtectedProcess is a single PID that the reaper refused to kill, with the
@@ -98,6 +101,7 @@ func isTestConfigPath(p, homeDir, tempDir string) bool {
 func testConfigPathPrefixes() []string {
 	return []string{
 		"Test",
+		"gctest-",
 		"gc-state-runtime-builtin-",
 		"gc-state-mutation-builtin-",
 		"gc-supervisor-city-",
@@ -204,6 +208,7 @@ func planOrphanReap(procs []DoltProcInfo, rigPortByPort map[int]string, homeDir,
 				ConfigPath:     c.ConfigPath,
 				RSSBytes:       p.RSSBytes,
 				StartTimeTicks: p.StartTimeTicks,
+				StartIdentity:  p.StartIdentity,
 			})
 		default:
 			plan.Protected = append(plan.Protected, ProtectedProcess{PID: p.PID, Reason: c.Reason})

--- a/cmd/gc/dolt_cleanup_reaper_test.go
+++ b/cmd/gc/dolt_cleanup_reaper_test.go
@@ -47,6 +47,12 @@ func TestIsTestConfigPath_TmpTestPrefix(t *testing.T) {
 	}
 }
 
+func TestIsTestConfigPath_CmdGCTestPrefix(t *testing.T) {
+	if !isTestConfigPath("/tmp/gctest-123/TestCase/001/.gc/runtime/packs/dolt/dolt-config.yaml", "/home/u", "") {
+		t.Error("expected /tmp/gctest-* to be a test path")
+	}
+}
+
 func TestIsTestConfigPath_HomeGotmpTestPrefix(t *testing.T) {
 	if !isTestConfigPath("/home/u/.gotmp/TestFuzz/config.yaml", "/home/u", "") {
 		t.Error("expected $HOME/.gotmp/Test* to be a test path")

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -290,6 +291,108 @@ func TestRequireNoLeakedDoltAfterWithFilterIgnoresUnownedTempPID(t *testing.T) {
 	}
 	if strings.Contains(msg, "1002") {
 		t.Fatalf("error included unowned leaked PID 1002; got %q", msg)
+	}
+}
+
+func TestRequireNoLeakedDoltAfterWithFilterReportsAndKillsOwnedPID(t *testing.T) {
+	ownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "owned-city")
+	owned := DoltProcInfo{
+		PID: 1001,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join(ownedRoot, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+	unowned := DoltProcInfo{
+		PID: 1002,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join("/tmp", "TestDoltLeakHelper", "other-city", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+	enumerate := scriptedDoltEnumerator(t,
+		nil,
+		[]DoltProcInfo{owned, unowned},
+	)
+	type killCall struct {
+		pid int
+		sig syscall.Signal
+	}
+	var killed []killCall
+	inner := &recordingTB{}
+	requireNoLeakedDoltAfterWithFilterAndKiller(inner, enumerate, func(configPath string) bool {
+		return samePath(configPath, ownedRoot) || strings.HasPrefix(configPath, ownedRoot+string(filepath.Separator))
+	}, func(pid int, sig syscall.Signal) error {
+		killed = append(killed, killCall{pid: pid, sig: sig})
+		return nil
+	})
+	inner.runCleanups()
+
+	if !inner.failed() {
+		t.Fatalf("expected leak Errorf for owned PID; nothing recorded")
+	}
+	wantKilled := []killCall{
+		{pid: 1001, sig: syscall.SIGTERM},
+		{pid: 1001, sig: syscall.SIGKILL},
+	}
+	if fmt.Sprint(killed) != fmt.Sprint(wantKilled) {
+		t.Fatalf("killed = %v, want %v", killed, wantKilled)
+	}
+	msg := strings.Join(inner.errors, "\n")
+	if !strings.Contains(msg, "1001") {
+		t.Fatalf("error missing owned leaked PID 1001; got %q", msg)
+	}
+	if strings.Contains(msg, "1002") {
+		t.Fatalf("error included unowned leaked PID 1002; got %q", msg)
+	}
+}
+
+func TestRequireNoLeakedDoltAfterWithFilterReportsKillErrors(t *testing.T) {
+	ownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "owned-city")
+	owned := DoltProcInfo{
+		PID: 1001,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join(ownedRoot, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+	enumerate := scriptedDoltEnumerator(t, nil, []DoltProcInfo{owned})
+	inner := &recordingTB{}
+	requireNoLeakedDoltAfterWithFilterAndKiller(inner, enumerate, func(configPath string) bool {
+		return samePath(configPath, ownedRoot) || strings.HasPrefix(configPath, ownedRoot+string(filepath.Separator))
+	}, func(pid int, sig syscall.Signal) error {
+		if sig == syscall.SIGTERM {
+			return errors.New("synthetic kill failure")
+		}
+		return nil
+	})
+	inner.runCleanups()
+
+	msg := strings.Join(inner.errors, "\n")
+	if !strings.Contains(msg, "test leaked 1 dolt sql-server") {
+		t.Fatalf("error missing leak report; got %q", msg)
+	}
+	if !strings.Contains(msg, "SIGTERM pid 1001") || !strings.Contains(msg, "synthetic kill failure") {
+		t.Fatalf("error missing kill failure; got %q", msg)
+	}
+}
+
+func TestIsStaleCmdGCTestConfigPathSkipsActiveRoot(t *testing.T) {
+	activeRoot := filepath.Join("/tmp", "gctest-active")
+	activeConfig := filepath.Join(activeRoot, "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	if isStaleCmdGCTestConfigPath(activeConfig, activeRoot) {
+		t.Fatalf("active config path %q classified as stale", activeConfig)
+	}
+
+	staleConfig := filepath.Join("/tmp", "gctest-stale", "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	if !isStaleCmdGCTestConfigPath(staleConfig, activeRoot) {
+		t.Fatalf("stale config path %q not classified as stale", staleConfig)
 	}
 }
 

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -366,7 +367,7 @@ func TestRequireNoLeakedDoltAfterWithFilterReportsKillErrors(t *testing.T) {
 	inner := &recordingTB{}
 	requireNoLeakedDoltAfterWithFilterAndKiller(inner, enumerate, func(configPath string) bool {
 		return samePath(configPath, ownedRoot) || strings.HasPrefix(configPath, ownedRoot+string(filepath.Separator))
-	}, func(pid int, sig syscall.Signal) error {
+	}, func(_ int, sig syscall.Signal) error {
 		if sig == syscall.SIGTERM {
 			return errors.New("synthetic kill failure")
 		}
@@ -386,13 +387,40 @@ func TestRequireNoLeakedDoltAfterWithFilterReportsKillErrors(t *testing.T) {
 func TestIsStaleCmdGCTestConfigPathSkipsActiveRoot(t *testing.T) {
 	activeRoot := filepath.Join("/tmp", "gctest-active")
 	activeConfig := filepath.Join(activeRoot, "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
-	if isStaleCmdGCTestConfigPath(activeConfig, activeRoot) {
+	if isStaleCmdGCTestConfigPath(activeConfig, []string{activeRoot}, "/tmp") {
 		t.Fatalf("active config path %q classified as stale", activeConfig)
 	}
 
-	staleConfig := filepath.Join("/tmp", "gctest-stale", "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
-	if !isStaleCmdGCTestConfigPath(staleConfig, activeRoot) {
+	staleRoot := filepath.Join("/tmp", fmt.Sprintf("%s%d-stale", testCmdGCTempRootPrefix, nonLivePID(t)))
+	staleConfig := filepath.Join(staleRoot, "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	if !isStaleCmdGCTestConfigPath(staleConfig, []string{activeRoot}, "/tmp") {
 		t.Fatalf("stale config path %q not classified as stale", staleConfig)
+	}
+}
+
+func TestIsStaleCmdGCTestConfigPathSkipsActiveSiblingRoot(t *testing.T) {
+	activeRoot := filepath.Join("/tmp", "gctest-sibling")
+	activeConfig := filepath.Join(activeRoot, "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+
+	if isStaleCmdGCTestConfigPath(activeConfig, []string{activeRoot}, "/tmp") {
+		t.Fatalf("active sibling config path %q classified as stale", activeConfig)
+	}
+}
+
+func TestIsStaleCmdGCTestConfigPathSkipsLivePeerOwnerPIDRoot(t *testing.T) {
+	peerRoot := filepath.Join("/tmp", fmt.Sprintf("%s%d-peer", testCmdGCTempRootPrefix, os.Getpid()))
+	peerConfig := filepath.Join(peerRoot, "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+
+	if isStaleCmdGCTestConfigPath(peerConfig, nil, "/tmp") {
+		t.Fatalf("live peer config path %q classified as stale", peerConfig)
+	}
+}
+
+func TestIsStaleCmdGCTestConfigPathSkipsLegacyUnownedRoot(t *testing.T) {
+	legacyConfig := filepath.Join("/tmp", "gctest-legacy", "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+
+	if isStaleCmdGCTestConfigPath(legacyConfig, nil, "/tmp") {
+		t.Fatalf("legacy unowned config path %q classified as stale", legacyConfig)
 	}
 }
 

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -91,7 +91,7 @@ func TestFileOpenedByAnyProcessBoundsLsof(t *testing.T) {
 }
 
 func TestFileOpenedByAnyProcessUsesUnixSocketTableForStaleSocket(t *testing.T) {
-	socketPath := filepath.Join(t.TempDir(), "dolt.sock")
+	socketPath := shortUnixSocketPath(t)
 	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
 		t.Fatalf("socket(AF_UNIX): %v", err)

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/pidutil"
 )
 
 type managedDoltStartReport struct {
@@ -17,6 +23,33 @@ type managedDoltStartReport struct {
 	Port         int
 	AddressInUse bool
 	Attempts     int
+}
+
+type managedDoltStartedProcess struct {
+	CityPath    string
+	PID         int
+	WatchdogPID int
+	DisarmFile  string
+	DisarmReady bool
+}
+
+const (
+	managedDoltTestModeEnv      = "GC_MANAGED_DOLT_TEST_MODE"
+	managedDoltTestParentPIDEnv = "GC_MANAGED_DOLT_TEST_PARENT_PID"
+	managedDoltTestWatchdogArg  = "__gc-managed-dolt-test-watchdog"
+)
+
+var (
+	managedDoltTestMode             = isTestBinary
+	managedDoltTestProcessRegistry  sync.Map
+	managedDoltTestTerminateProcess = terminateManagedDoltTestPID
+)
+
+func init() {
+	if len(os.Args) < 2 || os.Args[1] != managedDoltTestWatchdogArg {
+		return
+	}
+	os.Exit(runManagedDoltTestWatchdog(os.Args[2:], os.Stdout, os.Stderr))
 }
 
 func startManagedDoltProcess(cityPath, host, port, user, logLevel string, timeout time.Duration) (managedDoltStartReport, error) {
@@ -69,41 +102,36 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 			return report, fmt.Errorf("open log file: %w", err)
 		}
 
-		cmd := exec.Command("dolt", "sql-server", "--config", layout.ConfigFile)
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
-		cmd.Stdin = nil
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-		cmd.Env = doltServerEnv(os.Environ())
-		if err := cmd.Start(); err != nil {
+		started, err := startManagedDoltSQLServer(cityPath, layout.ConfigFile, layout.LogFile, logFile)
+		if err != nil {
 			_ = logFile.Close()
-			return report, fmt.Errorf("start dolt sql-server: %w", err)
+			return report, err
 		}
 		_ = logFile.Close()
 
-		report.PID = cmd.Process.Pid
+		report.PID = started.PID
 		report.Port = currentPort
 		if err := os.MkdirAll(filepath.Dir(layout.PIDFile), 0o755); err != nil {
-			_ = terminateManagedDoltPID(cityPath, cmd.Process.Pid)
+			terminateManagedDoltStartedProcess(started)
 			return report, fmt.Errorf("create pid dir: %w", err)
 		}
-		if err := os.WriteFile(layout.PIDFile, []byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o644); err != nil {
-			_ = terminateManagedDoltPID(cityPath, cmd.Process.Pid)
+		if err := os.WriteFile(layout.PIDFile, []byte(strconv.Itoa(started.PID)+"\n"), 0o644); err != nil {
+			terminateManagedDoltStartedProcess(started)
 			return report, fmt.Errorf("write pid file: %w", err)
 		}
 		if err := writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
 			Running:   true,
-			PID:       cmd.Process.Pid,
+			PID:       started.PID,
 			Port:      currentPort,
 			DataDir:   layout.DataDir,
 			StartedAt: time.Now().UTC().Format(time.RFC3339),
 		}); err != nil {
-			_ = terminateManagedDoltPID(cityPath, cmd.Process.Pid)
+			terminateManagedDoltStartedProcess(started)
 			_ = os.Remove(layout.PIDFile)
 			return report, fmt.Errorf("write provider state: %w", err)
 		}
 
-		readyReport, readyErr := waitForManagedDoltReady(cityPath, host, strconv.Itoa(currentPort), user, cmd.Process.Pid, timeout, false)
+		readyReport, readyErr := waitForManagedDoltReady(cityPath, host, strconv.Itoa(currentPort), user, started.PID, timeout, false)
 		if readyErr == nil && readyReport.Ready {
 			report.Ready = true
 			if publish {
@@ -111,11 +139,12 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 					return report, fmt.Errorf("publish managed dolt runtime state: %w", err)
 				}
 			}
+			disarmManagedDoltStartedProcess(started)
 			return report, nil
 		}
 
 		if readyReport.PIDAlive {
-			_ = terminateManagedDoltPID(cityPath, cmd.Process.Pid)
+			terminateManagedDoltStartedProcess(started)
 			_ = os.Remove(layout.PIDFile)
 			_ = writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
 				Running:   false,
@@ -124,7 +153,7 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 				DataDir:   layout.DataDir,
 				StartedAt: time.Now().UTC().Format(time.RFC3339),
 			})
-			return report, fmt.Errorf("dolt server started (pid %d) but did not become query-ready within %s (check %s)", cmd.Process.Pid, timeout, layout.LogFile)
+			return report, fmt.Errorf("dolt server started (pid %d) but did not become query-ready within %s (check %s)", started.PID, timeout, layout.LogFile)
 		}
 
 		_ = os.Remove(layout.PIDFile)
@@ -150,6 +179,194 @@ func startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel str
 	}
 
 	return report, fmt.Errorf("dolt server could not find a free port after repeated address-in-use failures (last port %d)", report.Port)
+}
+
+func startManagedDoltSQLServer(cityPath, configFile, logFilePath string, logFile *os.File) (managedDoltStartedProcess, error) {
+	if managedDoltTestWatchdogEnabled() {
+		return startManagedDoltSQLServerWithTestWatchdog(cityPath, configFile, logFilePath, logFile)
+	}
+	cmd := exec.Command("dolt", "sql-server", "--config", configFile)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Stdin = nil
+	cmd.SysProcAttr = managedDoltSQLServerSysProcAttr()
+	cmd.Env = doltServerEnv(os.Environ())
+	if err := cmd.Start(); err != nil {
+		return managedDoltStartedProcess{}, fmt.Errorf("start dolt sql-server: %w", err)
+	}
+	return managedDoltStartedProcess{CityPath: cityPath, PID: cmd.Process.Pid}, nil
+}
+
+func startManagedDoltSQLServerWithTestWatchdog(cityPath, configFile, logFilePath string, logFile *os.File) (managedDoltStartedProcess, error) {
+	disarmFile, err := managedDoltTestWatchdogDisarmFile(logFilePath)
+	if err != nil {
+		return managedDoltStartedProcess{}, err
+	}
+	cmd := exec.Command(os.Args[0], managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile)
+	cmd.Stderr = logFile
+	cmd.Stdin = nil
+	cmd.Env = doltServerEnv(os.Environ())
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = os.Remove(disarmFile)
+		return managedDoltStartedProcess{}, fmt.Errorf("prepare dolt test watchdog: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = os.Remove(disarmFile)
+		return managedDoltStartedProcess{}, fmt.Errorf("start dolt test watchdog: %w", err)
+	}
+	pid, err := readManagedDoltTestWatchdogPID(stdout, cmd.Process.Pid)
+	if err != nil {
+		_ = terminateManagedDoltPID(cityPath, cmd.Process.Pid)
+		_ = cmd.Wait()
+		_ = os.Remove(disarmFile)
+		return managedDoltStartedProcess{}, err
+	}
+	go func() { _ = cmd.Wait() }()
+	started := managedDoltStartedProcess{
+		CityPath:    cityPath,
+		PID:         pid,
+		WatchdogPID: cmd.Process.Pid,
+		DisarmFile:  disarmFile,
+		DisarmReady: managedDoltTestDisarmOnReady(),
+	}
+	registerManagedDoltTestProcess(started)
+	return started, nil
+}
+
+func managedDoltTestWatchdogDisarmFile(logFilePath string) (string, error) {
+	dir := filepath.Dir(logFilePath)
+	file, err := os.CreateTemp(dir, ".dolt-watchdog-disarm-*")
+	if err != nil {
+		return "", fmt.Errorf("create dolt test watchdog disarm file: %w", err)
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("close dolt test watchdog disarm file: %w", err)
+	}
+	if err := os.Remove(path); err != nil {
+		return "", fmt.Errorf("remove dolt test watchdog disarm file: %w", err)
+	}
+	return path, nil
+}
+
+func readManagedDoltTestWatchdogPID(r io.Reader, watchdogPID int) (int, error) {
+	type result struct {
+		line string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		line, err := bufio.NewReader(r).ReadString('\n')
+		ch <- result{line: line, err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			return 0, fmt.Errorf("read dolt test watchdog pid: %w", res.err)
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(res.line))
+		if err != nil || pid <= 0 {
+			return 0, fmt.Errorf("read dolt test watchdog pid: invalid pid %q", strings.TrimSpace(res.line))
+		}
+		return pid, nil
+	case <-time.After(5 * time.Second):
+		return 0, fmt.Errorf("dolt test watchdog pid timed out (watchdog pid %d)", watchdogPID)
+	}
+}
+
+func managedDoltSQLServerSysProcAttr() *syscall.SysProcAttr {
+	if managedDoltTestModeEnabled() {
+		return nil
+	}
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+func managedDoltTestWatchdogEnabled() bool {
+	return managedDoltTestModeEnabled() && os.Getenv("GC_MANAGED_DOLT_TEST_WATCHDOG") != "0"
+}
+
+func managedDoltTestModeEnabled() bool {
+	return managedDoltTestMode() || os.Getenv(managedDoltTestModeEnv) == "1"
+}
+
+func managedDoltTestModeFromEnvOnly() bool {
+	return !managedDoltTestMode() && os.Getenv(managedDoltTestModeEnv) == "1"
+}
+
+func managedDoltTestParentPID() int {
+	raw := strings.TrimSpace(os.Getenv(managedDoltTestParentPIDEnv))
+	if raw != "" {
+		if pid, err := strconv.Atoi(raw); err == nil && pid > 0 {
+			return pid
+		}
+	}
+	return os.Getpid()
+}
+
+func managedDoltTestParentPIDString() string {
+	return strconv.Itoa(managedDoltTestParentPID())
+}
+
+func managedDoltTestHasExternalParent() bool {
+	raw := strings.TrimSpace(os.Getenv(managedDoltTestParentPIDEnv))
+	if raw == "" {
+		return false
+	}
+	pid, err := strconv.Atoi(raw)
+	return err == nil && pid > 0 && pid != os.Getpid()
+}
+
+func managedDoltTestDisarmOnReady() bool {
+	return managedDoltTestModeFromEnvOnly() && !managedDoltTestHasExternalParent()
+}
+
+func terminateManagedDoltStartedProcess(started managedDoltStartedProcess) {
+	_ = terminateManagedDoltPID(started.CityPath, started.PID)
+	if started.WatchdogPID > 0 {
+		_ = terminateManagedDoltPID(started.CityPath, started.WatchdogPID)
+	}
+	if started.DisarmFile != "" {
+		_ = os.Remove(started.DisarmFile)
+	}
+}
+
+func terminateManagedDoltTestPID(pid int) error {
+	return terminateManagedDoltPID("", pid)
+}
+
+func disarmManagedDoltStartedProcess(started managedDoltStartedProcess) {
+	if started.DisarmFile == "" || !started.DisarmReady {
+		return
+	}
+	_ = os.WriteFile(started.DisarmFile, []byte("ready\n"), 0o644)
+}
+
+func registerManagedDoltTestProcess(started managedDoltStartedProcess) {
+	if started.PID <= 0 || !managedDoltTestModeEnabled() {
+		return
+	}
+	managedDoltTestProcessRegistry.Store(started.PID, started)
+}
+
+func reapManagedDoltTestProcesses() {
+	managedDoltTestProcessRegistry.Range(func(key, value any) bool {
+		started, ok := value.(managedDoltStartedProcess)
+		if !ok {
+			managedDoltTestProcessRegistry.Delete(key)
+			return true
+		}
+		if started.PID > 0 && pidAlive(started.PID) {
+			_ = managedDoltTestTerminateProcess(started.PID)
+		}
+		if started.WatchdogPID > 0 && pidAlive(started.WatchdogPID) {
+			_ = managedDoltTestTerminateProcess(started.WatchdogPID)
+		}
+		managedDoltTestProcessRegistry.Delete(key)
+		return true
+	})
 }
 
 func managedDoltStartFields(report managedDoltStartReport) []string {
@@ -237,6 +454,76 @@ func terminateManagedDoltPID(cityPath string, pid int) error {
 	_ = process.Signal(syscall.SIGKILL)
 	time.Sleep(250 * time.Millisecond)
 	return nil
+}
+
+func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
+	if !managedDoltTestModeEnabled() {
+		fmt.Fprintln(stderr, "managed dolt test watchdog is only available in managed Dolt test mode") //nolint:errcheck
+		return 2
+	}
+	if len(args) != 4 {
+		fmt.Fprintf(stderr, "usage: %s <parent-pid> <config-file> <log-file> <disarm-file>\n", managedDoltTestWatchdogArg) //nolint:errcheck
+		return 2
+	}
+	parentPID, err := strconv.Atoi(args[0])
+	if err != nil || parentPID <= 0 {
+		fmt.Fprintf(stderr, "invalid parent pid %q\n", args[0]) //nolint:errcheck
+		return 2
+	}
+	configFile := args[1]
+	logFilePath := args[2]
+	disarmFile := args[3]
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		fmt.Fprintf(stderr, "open dolt log: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	defer logFile.Close() //nolint:errcheck
+
+	cmd := exec.Command("dolt", "sql-server", "--config", configFile)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Stdin = nil
+	cmd.SysProcAttr = nil
+	cmd.Env = doltServerEnv(os.Environ())
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(stderr, "start dolt sql-server: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintf(stdout, "%d\n", cmd.Process.Pid) //nolint:errcheck
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(signals)
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-signals:
+			_ = terminateManagedDoltPID("", cmd.Process.Pid)
+			<-done
+			return 0
+		case <-ticker.C:
+			if _, err := os.Stat(disarmFile); err == nil {
+				_ = os.Remove(disarmFile)
+				return 0
+			}
+			if !pidutil.Alive(parentPID) {
+				_ = terminateManagedDoltPID("", cmd.Process.Pid)
+				<-done
+				return 0
+			}
+		case err := <-done:
+			if err != nil {
+				return 1
+			}
+			return 0
+		}
+	}
 }
 
 // doltServerEnv returns the environment applied to every managed dolt

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -40,12 +40,15 @@ const (
 )
 
 var (
-	managedDoltTestMode             = isTestBinary
-	managedDoltTestProcessRegistry  sync.Map
-	managedDoltTestTerminateProcess = terminateManagedDoltTestPID
+	managedDoltTestMode               = isTestBinary
+	managedDoltTestExecutable         = os.Executable
+	managedDoltTestWatchdogPIDTimeout = 5 * time.Second
+	managedDoltTestProcessRegistry    sync.Map
+	managedDoltTestTerminateProcess   = terminateManagedDoltTestPID
 )
 
 func init() {
+	// Test watchdog re-exec runs before normal command dispatch.
 	if len(os.Args) < 2 || os.Args[1] != managedDoltTestWatchdogArg {
 		return
 	}
@@ -202,7 +205,12 @@ func startManagedDoltSQLServerWithTestWatchdog(cityPath, configFile, logFilePath
 	if err != nil {
 		return managedDoltStartedProcess{}, err
 	}
-	cmd := exec.Command(os.Args[0], managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile)
+	watchdogExecutable, err := managedDoltTestWatchdogExecutable()
+	if err != nil {
+		_ = os.Remove(disarmFile)
+		return managedDoltStartedProcess{}, err
+	}
+	cmd := exec.Command(watchdogExecutable, managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile)
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
 	cmd.Env = doltServerEnv(os.Environ())
@@ -232,6 +240,28 @@ func startManagedDoltSQLServerWithTestWatchdog(cityPath, configFile, logFilePath
 	}
 	registerManagedDoltTestProcess(started)
 	return started, nil
+}
+
+func managedDoltTestWatchdogExecutable() (string, error) {
+	executable, executableErr := managedDoltTestExecutable()
+	if executableErr == nil && strings.TrimSpace(executable) != "" {
+		return executable, nil
+	}
+	fallback := strings.TrimSpace(os.Args[0])
+	if fallback == "" {
+		if executableErr != nil {
+			return "", fmt.Errorf("resolve dolt test watchdog executable: os.Executable: %w", executableErr)
+		}
+		return "", fmt.Errorf("resolve dolt test watchdog executable: os.Executable returned empty path")
+	}
+	if filepath.IsAbs(fallback) {
+		return fallback, nil
+	}
+	abs, err := filepath.Abs(fallback)
+	if err != nil {
+		return "", fmt.Errorf("resolve dolt test watchdog executable from argv %q: %w", fallback, err)
+	}
+	return abs, nil
 }
 
 func managedDoltTestWatchdogDisarmFile(logFilePath string) (string, error) {
@@ -272,7 +302,7 @@ func readManagedDoltTestWatchdogPID(r io.Reader, watchdogPID int) (int, error) {
 			return 0, fmt.Errorf("read dolt test watchdog pid: invalid pid %q", strings.TrimSpace(res.line))
 		}
 		return pid, nil
-	case <-time.After(5 * time.Second):
+	case <-time.After(managedDoltTestWatchdogPIDTimeout):
 		return 0, fmt.Errorf("dolt test watchdog pid timed out (watchdog pid %d)", watchdogPID)
 	}
 }
@@ -324,6 +354,7 @@ func managedDoltTestDisarmOnReady() bool {
 }
 
 func terminateManagedDoltStartedProcess(started managedDoltStartedProcess) {
+	unregisterManagedDoltStartedProcess(started)
 	_ = terminateManagedDoltPID(started.CityPath, started.PID)
 	if started.WatchdogPID > 0 {
 		_ = terminateManagedDoltPID(started.CityPath, started.WatchdogPID)
@@ -331,6 +362,11 @@ func terminateManagedDoltStartedProcess(started managedDoltStartedProcess) {
 	if started.DisarmFile != "" {
 		_ = os.Remove(started.DisarmFile)
 	}
+}
+
+func unregisterManagedDoltStartedProcess(started managedDoltStartedProcess) {
+	unregisterManagedDoltTestProcess(started.PID)
+	unregisterManagedDoltTestProcess(started.WatchdogPID)
 }
 
 func terminateManagedDoltTestPID(pid int) error {
@@ -341,7 +377,10 @@ func disarmManagedDoltStartedProcess(started managedDoltStartedProcess) {
 	if started.DisarmFile == "" || !started.DisarmReady {
 		return
 	}
-	_ = os.WriteFile(started.DisarmFile, []byte("ready\n"), 0o644)
+	if err := os.WriteFile(started.DisarmFile, []byte("ready\n"), 0o644); err != nil {
+		return
+	}
+	unregisterManagedDoltTestProcess(started.PID)
 }
 
 func registerManagedDoltTestProcess(started managedDoltStartedProcess) {
@@ -349,6 +388,13 @@ func registerManagedDoltTestProcess(started managedDoltStartedProcess) {
 		return
 	}
 	managedDoltTestProcessRegistry.Store(started.PID, started)
+}
+
+func unregisterManagedDoltTestProcess(pid int) {
+	if pid <= 0 {
+		return
+	}
+	managedDoltTestProcessRegistry.Delete(pid)
 }
 
 func reapManagedDoltTestProcesses() {

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -222,6 +223,86 @@ func TestManagedDoltTestWatchdogCanBeDisabledByEnv(t *testing.T) {
 	}
 }
 
+func TestManagedDoltTestWatchdogExecutableUsesOSExecutable(t *testing.T) {
+	oldExecutable := managedDoltTestExecutable
+	t.Cleanup(func() { managedDoltTestExecutable = oldExecutable })
+	want := filepath.Join(t.TempDir(), "gc-test-binary")
+	managedDoltTestExecutable = func() (string, error) {
+		return want, nil
+	}
+
+	got, err := managedDoltTestWatchdogExecutable()
+	if err != nil {
+		t.Fatalf("managedDoltTestWatchdogExecutable: %v", err)
+	}
+	if got != want {
+		t.Fatalf("managedDoltTestWatchdogExecutable() = %q, want %q", got, want)
+	}
+}
+
+type blockingWatchdogPIDReader struct {
+	started chan struct{}
+	unblock chan struct{}
+	done    chan struct{}
+}
+
+func newBlockingWatchdogPIDReader() *blockingWatchdogPIDReader {
+	return &blockingWatchdogPIDReader{
+		started: make(chan struct{}, 1),
+		unblock: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+func (r *blockingWatchdogPIDReader) Read(_ []byte) (int, error) {
+	defer close(r.done)
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-r.unblock
+	return 0, io.EOF
+}
+
+func (r *blockingWatchdogPIDReader) Close() {
+	close(r.unblock)
+}
+
+func TestReadManagedDoltTestWatchdogPIDTimeoutUnblocksReaderAfterClose(t *testing.T) {
+	oldTimeout := managedDoltTestWatchdogPIDTimeout
+	managedDoltTestWatchdogPIDTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { managedDoltTestWatchdogPIDTimeout = oldTimeout })
+
+	reader := newBlockingWatchdogPIDReader()
+	done := make(chan error, 1)
+	go func() {
+		_, err := readManagedDoltTestWatchdogPID(reader, 12345)
+		done <- err
+	}()
+
+	select {
+	case <-reader.started:
+	case <-time.After(time.Second):
+		t.Fatal("reader did not start")
+	}
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("readManagedDoltTestWatchdogPID error = %v, want timeout", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("readManagedDoltTestWatchdogPID did not time out")
+	}
+
+	reader.Close()
+	select {
+	case <-reader.done:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog PID reader goroutine stayed blocked after close")
+	}
+}
+
 func TestManagedDoltTestModeEnabledHonorsEnv(t *testing.T) {
 	withManagedDoltTestMode(t, false)
 	t.Setenv("GC_MANAGED_DOLT_TEST_MODE", "1")
@@ -267,6 +348,92 @@ func TestManagedDoltTestDisarmOnReadyForEnvOnlyHelperWithoutParent(t *testing.T)
 
 	if !managedDoltTestDisarmOnReady() {
 		t.Fatal("managedDoltTestDisarmOnReady() = false, want true without external parent")
+	}
+}
+
+func TestDisarmManagedDoltStartedProcessUnregistersReadyProcess(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+	clearManagedDoltTestProcessRegistry(t)
+	t.Cleanup(func() {
+		clearManagedDoltTestProcessRegistry(t)
+	})
+
+	pid := os.Getpid()
+	disarmFile := filepath.Join(t.TempDir(), "disarm-ready")
+	started := managedDoltStartedProcess{
+		PID:         pid,
+		WatchdogPID: pid,
+		DisarmFile:  disarmFile,
+		DisarmReady: true,
+	}
+	registerManagedDoltTestProcess(started)
+
+	disarmManagedDoltStartedProcess(started)
+
+	data, err := os.ReadFile(disarmFile)
+	if err != nil {
+		t.Fatalf("read disarm file: %v", err)
+	}
+	if string(data) != "ready\n" {
+		t.Fatalf("disarm file = %q, want ready marker", string(data))
+	}
+	var remaining int
+	managedDoltTestProcessRegistry.Range(func(_, _ any) bool {
+		remaining++
+		return true
+	})
+	if remaining != 0 {
+		t.Fatalf("registry still has %d entries after disarm", remaining)
+	}
+}
+
+func TestTerminateManagedDoltStartedProcessUnregistersFailedStartup(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+	clearManagedDoltTestProcessRegistry(t)
+	t.Cleanup(func() {
+		clearManagedDoltTestProcessRegistry(t)
+	})
+
+	startChild := func(name string) *exec.Cmd {
+		t.Helper()
+		cmd := exec.Command("sleep", "60")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start %s child: %v", name, err)
+		}
+		t.Cleanup(func() {
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			_ = cmd.Wait()
+		})
+		return cmd
+	}
+
+	dolt := startChild("dolt")
+	watchdog := startChild("watchdog")
+	disarmFile := filepath.Join(t.TempDir(), "disarm")
+	if err := os.WriteFile(disarmFile, []byte("ready\n"), 0o644); err != nil {
+		t.Fatalf("write disarm file: %v", err)
+	}
+	started := managedDoltStartedProcess{
+		PID:         dolt.Process.Pid,
+		WatchdogPID: watchdog.Process.Pid,
+		DisarmFile:  disarmFile,
+	}
+	registerManagedDoltTestProcess(started)
+
+	terminateManagedDoltStartedProcess(started)
+
+	var remaining int
+	managedDoltTestProcessRegistry.Range(func(_, _ any) bool {
+		remaining++
+		return true
+	})
+	if remaining != 0 {
+		t.Fatalf("registry still has %d entries after startup-failure terminate", remaining)
+	}
+	if _, err := os.Stat(disarmFile); !os.IsNotExist(err) {
+		t.Fatalf("disarm file still exists after terminate: %v", err)
 	}
 }
 

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -173,6 +174,130 @@ func TestManagedDoltStartFields(t *testing.T) {
 		if fields[i] != w {
 			t.Errorf("fields[%d] = %q, want %q", i, fields[i], w)
 		}
+	}
+}
+
+func withManagedDoltTestMode(t *testing.T, enabled bool) {
+	t.Helper()
+	old := managedDoltTestMode
+	managedDoltTestMode = func() bool { return enabled }
+	t.Cleanup(func() { managedDoltTestMode = old })
+}
+
+func clearManagedDoltTestProcessRegistry(t *testing.T) {
+	t.Helper()
+	managedDoltTestProcessRegistry.Range(func(key, _ any) bool {
+		managedDoltTestProcessRegistry.Delete(key)
+		return true
+	})
+}
+
+func TestManagedDoltSQLServerSysProcAttrProductionDetaches(t *testing.T) {
+	withManagedDoltTestMode(t, false)
+	t.Setenv(managedDoltTestModeEnv, "")
+
+	attr := managedDoltSQLServerSysProcAttr()
+
+	if attr == nil || !attr.Setpgid {
+		t.Fatalf("production managed Dolt must keep detached process-group behavior, got %#v", attr)
+	}
+}
+
+func TestManagedDoltSQLServerSysProcAttrTestModeDoesNotDetach(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+
+	attr := managedDoltSQLServerSysProcAttr()
+
+	if attr != nil {
+		t.Fatalf("test-mode managed Dolt must stay in the test process group, got %#v", attr)
+	}
+}
+
+func TestManagedDoltTestWatchdogCanBeDisabledByEnv(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+	t.Setenv("GC_MANAGED_DOLT_TEST_WATCHDOG", "0")
+
+	if managedDoltTestWatchdogEnabled() {
+		t.Fatalf("managedDoltTestWatchdogEnabled() = true, want false when GC_MANAGED_DOLT_TEST_WATCHDOG=0")
+	}
+}
+
+func TestManagedDoltTestModeEnabledHonorsEnv(t *testing.T) {
+	withManagedDoltTestMode(t, false)
+	t.Setenv("GC_MANAGED_DOLT_TEST_MODE", "1")
+
+	if !managedDoltTestModeEnabled() {
+		t.Fatalf("managedDoltTestModeEnabled() = false, want true when GC_MANAGED_DOLT_TEST_MODE=1")
+	}
+	if !managedDoltTestModeFromEnvOnly() {
+		t.Fatalf("managedDoltTestModeFromEnvOnly() = false, want true for built helper test mode")
+	}
+}
+
+func TestManagedDoltTestModeFromEnvOnlyFalseForTestBinary(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+	t.Setenv("GC_MANAGED_DOLT_TEST_MODE", "1")
+
+	if managedDoltTestModeFromEnvOnly() {
+		t.Fatalf("managedDoltTestModeFromEnvOnly() = true, want false for the test binary itself")
+	}
+}
+
+func TestManagedDoltTestParentPIDHonorsEnv(t *testing.T) {
+	t.Setenv(managedDoltTestParentPIDEnv, "12345")
+
+	if got := managedDoltTestParentPID(); got != 12345 {
+		t.Fatalf("managedDoltTestParentPID() = %d, want 12345", got)
+	}
+}
+
+func TestManagedDoltTestDisarmOnReadyStaysArmedForExternalParent(t *testing.T) {
+	withManagedDoltTestMode(t, false)
+	t.Setenv(managedDoltTestModeEnv, "1")
+	t.Setenv(managedDoltTestParentPIDEnv, strconv.Itoa(os.Getpid()+1))
+
+	if managedDoltTestDisarmOnReady() {
+		t.Fatal("managedDoltTestDisarmOnReady() = true, want false with external parent")
+	}
+}
+
+func TestManagedDoltTestDisarmOnReadyForEnvOnlyHelperWithoutParent(t *testing.T) {
+	withManagedDoltTestMode(t, false)
+	t.Setenv(managedDoltTestModeEnv, "1")
+
+	if !managedDoltTestDisarmOnReady() {
+		t.Fatal("managedDoltTestDisarmOnReady() = false, want true without external parent")
+	}
+}
+
+func TestReapManagedDoltTestProcessesTerminatesRegisteredChildren(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+	clearManagedDoltTestProcessRegistry(t)
+	t.Cleanup(func() {
+		clearManagedDoltTestProcessRegistry(t)
+	})
+	oldTerminate := managedDoltTestTerminateProcess
+	var terminated []int
+	managedDoltTestTerminateProcess = func(pid int) error {
+		terminated = append(terminated, pid)
+		return nil
+	}
+	t.Cleanup(func() { managedDoltTestTerminateProcess = oldTerminate })
+
+	pid := os.Getpid()
+	registerManagedDoltTestProcess(managedDoltStartedProcess{PID: pid, WatchdogPID: pid})
+	reapManagedDoltTestProcesses()
+
+	if len(terminated) != 2 || terminated[0] != pid || terminated[1] != pid {
+		t.Fatalf("terminated = %v, want child and watchdog pid %d", terminated, pid)
+	}
+	var remaining int
+	managedDoltTestProcessRegistry.Range(func(_, _ any) bool {
+		remaining++
+		return true
+	})
+	if remaining != 0 {
+		t.Fatalf("registry still has %d entries after reap", remaining)
 	}
 }
 

--- a/cmd/gc/fast_loop_helpers_env_test.go
+++ b/cmd/gc/fast_loop_helpers_env_test.go
@@ -28,7 +28,7 @@ func TestSanitizedBaseEnv_StripsGCPrefixed(t *testing.T) {
 	env := sanitizedBaseEnv()
 
 	for _, kv := range env {
-		if strings.HasPrefix(kv, "GC_") {
+		if strings.HasPrefix(kv, "GC_") && !isSanitizedBaseEnvTestControl(kv) {
 			t.Errorf("sanitizedBaseEnv leaked GC_* var: %q", kv)
 		}
 	}
@@ -152,7 +152,10 @@ func TestSanitizedBaseEnv_MatchesExactlyGCAndBEADSPrefixes(t *testing.T) {
 
 	env := sanitizedBaseEnv()
 	for _, kv := range env {
-		if strings.HasPrefix(kv, "GC_") || strings.HasPrefix(kv, "BEADS_") {
+		if strings.HasPrefix(kv, "BEADS_") {
+			t.Errorf("sanitizedBaseEnv kept %q; BEADS_* must be filtered", kv)
+		}
+		if strings.HasPrefix(kv, "GC_") && !isSanitizedBaseEnvTestControl(kv) {
 			t.Errorf("sanitizedBaseEnv kept %q; both GC_* and BEADS_* must be filtered", kv)
 		}
 	}
@@ -170,4 +173,27 @@ func TestSanitizedBaseEnv_MatchesExactlyGCAndBEADSPrefixes(t *testing.T) {
 	if !found {
 		t.Error("sanitizedBaseEnv stripped a var whose key merely contained GC_ as a substring")
 	}
+}
+
+func TestSanitizedBaseEnv_AddsManagedDoltTestControl(t *testing.T) {
+	env := sanitizedBaseEnv()
+	values := map[string]string{}
+	for _, kv := range env {
+		key, value, ok := strings.Cut(kv, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+
+	if got := values[managedDoltTestModeEnv]; got != "1" {
+		t.Fatalf("%s = %q, want 1", managedDoltTestModeEnv, got)
+	}
+	if got := values[managedDoltTestParentPIDEnv]; got == "" {
+		t.Fatalf("%s missing from sanitizedBaseEnv", managedDoltTestParentPIDEnv)
+	}
+}
+
+func isSanitizedBaseEnvTestControl(kv string) bool {
+	return strings.HasPrefix(kv, managedDoltTestModeEnv+"=") ||
+		strings.HasPrefix(kv, managedDoltTestParentPIDEnv+"=")
 }

--- a/cmd/gc/fast_loop_helpers_test.go
+++ b/cmd/gc/fast_loop_helpers_test.go
@@ -38,6 +38,10 @@ func sanitizedBaseEnv(extra ...string) []string {
 		}
 		filtered = append(filtered, kv)
 	}
+	filtered = append(filtered,
+		managedDoltTestModeEnv+"=1",
+		managedDoltTestParentPIDEnv+"="+strconv.Itoa(os.Getpid()),
+	)
 	return append(filtered, extra...)
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -170,6 +170,12 @@ func TestMain(m *testing.M) {
 	if !isTestscriptCommandInvocation(os.Args[0]) {
 		clearProcessLiveEnvForTests()
 	}
+	if err := os.Setenv(managedDoltTestModeEnv, "1"); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv(managedDoltTestParentPIDEnv, fmt.Sprintf("%d", os.Getpid())); err != nil {
+		panic(err)
+	}
 	testTempRoot, err := os.MkdirTemp("/tmp", "gctest-")
 	if err != nil {
 		panic(err)

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -176,7 +176,7 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv(managedDoltTestParentPIDEnv, fmt.Sprintf("%d", os.Getpid())); err != nil {
 		panic(err)
 	}
-	testTempRoot, err := os.MkdirTemp("/tmp", "gctest-")
+	testTempRoot, err := os.MkdirTemp("/tmp", pidPrefixedTempPattern(testCmdGCTempRootPrefix))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -94,6 +96,10 @@ func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...s
 }
 
 func (g *doltLeakGuardedTestingM) Run() int {
+	_ = g.sweepStaleCmdGCTestDoltProcesses("startup")
+	stopSignalHandler := g.installSignalHandler()
+	defer stopSignalHandler()
+
 	initial, initialErr := snapshotDoltProcessesForConfigRoot(discoverDoltProcesses, g.tempRoot)
 	if initialErr != nil {
 		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: initial scan failed: %v\n", initialErr) //nolint:errcheck
@@ -115,15 +121,101 @@ func (g *doltLeakGuardedTestingM) Run() int {
 		}
 	}
 
+	g.cleanupTemporaryPaths()
+	reapManagedDoltTestProcesses()
+	if guardFailed && code == 0 {
+		return 1
+	}
+	return code
+}
+
+func (g *doltLeakGuardedTestingM) installSignalHandler() func() {
+	signals := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		select {
+		case sig := <-signals:
+			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: received %s; sweeping test dolt processes before exit\n", sig) //nolint:errcheck
+			_ = g.reapDoltProcessesUnderRoot("signal")
+			g.cleanupTemporaryPaths()
+			signal.Stop(signals)
+			if s, ok := sig.(syscall.Signal); ok {
+				signal.Reset(s)
+				_ = syscall.Kill(os.Getpid(), s)
+			}
+		case <-done:
+		}
+	}()
+	return func() {
+		signal.Stop(signals)
+		close(done)
+	}
+}
+
+func (g *doltLeakGuardedTestingM) cleanupTemporaryPaths() {
 	for _, path := range g.cleanupPaths {
 		if path != "" {
 			_ = os.RemoveAll(path)
 		}
 	}
-	if guardFailed && code == 0 {
-		return 1
+}
+
+func (g *doltLeakGuardedTestingM) reapDoltProcessesUnderRoot(label string) bool {
+	procs, err := snapshotDoltProcessesForConfigRoot(discoverDoltProcesses, g.tempRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s scan failed: %v\n", label, err) //nolint:errcheck
+		return true
 	}
-	return code
+	if len(procs) == 0 {
+		return false
+	}
+	leaked := make([]DoltProcInfo, 0, len(procs))
+	for _, proc := range procs {
+		leaked = append(leaked, proc)
+	}
+	sort.Slice(leaked, func(i, j int) bool {
+		return leaked[i].PID < leaked[j].PID
+	})
+	fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s sweep reaping %d dolt sql-server process(es) under %s\n", label, len(leaked), g.tempRoot) //nolint:errcheck
+	writeDoltLeakReport(os.Stderr, leaked)
+	reapDoltLeakProcesses(leaked)
+	return true
+}
+
+func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string) bool {
+	procs, err := discoverDoltProcesses()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s stale scan failed: %v\n", label, err) //nolint:errcheck
+		return true
+	}
+	var leaked []DoltProcInfo
+	for _, proc := range procs {
+		if !isStaleCmdGCTestConfigPath(extractConfigPath(proc.Argv), g.tempRoot) {
+			continue
+		}
+		leaked = append(leaked, proc)
+	}
+	if len(leaked) == 0 {
+		return false
+	}
+	sort.Slice(leaked, func(i, j int) bool {
+		return leaked[i].PID < leaked[j].PID
+	})
+	fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s sweep reaping %d stale cmd/gc test dolt sql-server process(es)\n", label, len(leaked)) //nolint:errcheck
+	writeDoltLeakReport(os.Stderr, leaked)
+	reapDoltLeakProcesses(leaked)
+	return true
+}
+
+func isStaleCmdGCTestConfigPath(configPath, activeRoot string) bool {
+	if configPath == "" || activeRoot == "" {
+		return false
+	}
+	if pathutil.PathWithin(activeRoot, configPath) {
+		return false
+	}
+	return hasTestChildPrefix(filepath.Clean(configPath), filepath.Dir(filepath.Clean(activeRoot)), []string{"gctest-"})
 }
 
 func snapshotDoltProcessesForConfigRoot(enumerate func() ([]DoltProcInfo, error), root string) (map[int]DoltProcInfo, error) {
@@ -163,13 +255,31 @@ func writeDoltLeakReport(w io.Writer, leaked []DoltProcInfo) {
 }
 
 func reapDoltLeakProcesses(leaked []DoltProcInfo) {
+	_ = reapDoltLeakProcessesWithKiller(leaked, killProcess)
+}
+
+func reapDoltLeakProcessesWithKiller(leaked []DoltProcInfo, killFn func(int, syscall.Signal) error) []error {
+	pids := make([]int, 0, len(leaked))
 	for _, proc := range leaked {
-		_ = killProcess(proc.PID, syscall.SIGTERM)
+		pids = append(pids, proc.PID)
+	}
+	return reapDoltLeakPIDsWithKiller(pids, killFn)
+}
+
+func reapDoltLeakPIDsWithKiller(pids []int, killFn func(int, syscall.Signal) error) []error {
+	var errs []error
+	for _, pid := range pids {
+		if err := killFn(pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+			errs = append(errs, fmt.Errorf("SIGTERM pid %d: %w", pid, err))
+		}
 	}
 	time.Sleep(250 * time.Millisecond)
-	for _, proc := range leaked {
-		_ = killProcess(proc.PID, syscall.SIGKILL)
+	for _, pid := range pids {
+		if err := killFn(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+			errs = append(errs, fmt.Errorf("SIGKILL pid %d: %w", pid, err))
+		}
 	}
+	return errs
 }
 
 // requireNoLeakedDoltAfterWith is the testReporter+injectable-enumerator
@@ -187,6 +297,10 @@ func requireNoLeakedDoltAfterWith(t testReporter, enumerate func() ([]DoltProcIn
 }
 
 func requireNoLeakedDoltAfterWithFilter(t testReporter, enumerate func() ([]DoltProcInfo, error), includeConfigPath func(string) bool) {
+	requireNoLeakedDoltAfterWithFilterAndKiller(t, enumerate, includeConfigPath, killProcess)
+}
+
+func requireNoLeakedDoltAfterWithFilterAndKiller(t testReporter, enumerate func() ([]DoltProcInfo, error), includeConfigPath func(string) bool, killFn func(int, syscall.Signal) error) {
 	t.Helper()
 	initial := snapshotDoltProcessPIDsWithFilter(t, enumerate, includeConfigPath)
 	t.Cleanup(func() {
@@ -208,6 +322,9 @@ func requireNoLeakedDoltAfterWithFilter(t testReporter, enumerate func() ([]Dolt
 		}
 		t.Errorf("test leaked %d dolt sql-server process(es); ensure cleanup paths reach shutdownBeadsProvider, or call clearInheritedBeadsEnv to prevent inherited GC_BEADS=bd from triggering gc-beads-bd.sh:\n%s",
 			len(leaked), strings.Join(rep, "\n"))
+		for _, err := range reapDoltLeakPIDsWithKiller(pids, killFn) {
+			t.Errorf("test leaked dolt cleanup failed: %v", err)
+		}
 	})
 }
 

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -107,6 +108,9 @@ func (g *doltLeakGuardedTestingM) Run() int {
 
 	code := g.m.Run()
 
+	g.cleanupTemporaryPaths()
+	reapManagedDoltTestProcesses()
+
 	guardFailed := initialErr != nil
 	if initialErr == nil {
 		final, finalErr := snapshotDoltProcessesForConfigRoot(discoverDoltProcesses, g.tempRoot)
@@ -121,8 +125,6 @@ func (g *doltLeakGuardedTestingM) Run() int {
 		}
 	}
 
-	g.cleanupTemporaryPaths()
-	reapManagedDoltTestProcesses()
 	if guardFailed && code == 0 {
 		return 1
 	}
@@ -189,9 +191,11 @@ func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string)
 		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: %s stale scan failed: %v\n", label, err) //nolint:errcheck
 		return true
 	}
+	activeRoots := cmdGCTestActiveRoots(g.tempRoot)
+	tempParent := filepath.Dir(filepath.Clean(g.tempRoot))
 	var leaked []DoltProcInfo
 	for _, proc := range procs {
-		if !isStaleCmdGCTestConfigPath(extractConfigPath(proc.Argv), g.tempRoot) {
+		if !isStaleCmdGCTestConfigPath(extractConfigPath(proc.Argv), activeRoots, tempParent) {
 			continue
 		}
 		leaked = append(leaked, proc)
@@ -208,14 +212,51 @@ func (g *doltLeakGuardedTestingM) sweepStaleCmdGCTestDoltProcesses(label string)
 	return true
 }
 
-func isStaleCmdGCTestConfigPath(configPath, activeRoot string) bool {
-	if configPath == "" || activeRoot == "" {
+func cmdGCTestActiveRoots(currentRoot string) []string {
+	roots := discoverActiveTestRoots("", os.TempDir())
+	if currentRoot != "" {
+		roots = append(roots, currentRoot)
+	}
+	cleaned := make([]string, 0, len(roots))
+	seen := make(map[string]struct{}, len(roots))
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		clean := filepath.Clean(root)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		cleaned = append(cleaned, clean)
+	}
+	return cleaned
+}
+
+func isStaleCmdGCTestConfigPath(configPath string, activeRoots []string, tempParent string) bool {
+	return isStaleCmdGCTestConfigPathWithPIDCheck(configPath, activeRoots, tempParent, pidAlive)
+}
+
+func isStaleCmdGCTestConfigPathWithPIDCheck(configPath string, activeRoots []string, tempParent string, pidAliveFn func(int) bool) bool {
+	if configPath == "" || tempParent == "" {
 		return false
 	}
-	if pathutil.PathWithin(activeRoot, configPath) {
+	if configUnderActiveTestRoot(configPath, activeRoots) {
 		return false
 	}
-	return hasTestChildPrefix(filepath.Clean(configPath), filepath.Dir(filepath.Clean(activeRoot)), []string{"gctest-"})
+	ownerPID, ok := cmdGCTestConfigOwnerPID(configPath, tempParent)
+	if !ok {
+		return false
+	}
+	return !pidAliveFn(ownerPID)
+}
+
+func cmdGCTestConfigOwnerPID(configPath string, tempParent string) (int, bool) {
+	root, ok := activeTestRootUnder(filepath.Clean(configPath), filepath.Clean(tempParent), []string{testCmdGCTempRootPrefix})
+	if !ok {
+		return 0, false
+	}
+	return pidFromPrefixedDirName(filepath.Base(root), testCmdGCTempRootPrefix)
 }
 
 func snapshotDoltProcessesForConfigRoot(enumerate func() ([]DoltProcInfo, error), root string) (map[int]DoltProcInfo, error) {
@@ -269,13 +310,13 @@ func reapDoltLeakProcessesWithKiller(leaked []DoltProcInfo, killFn func(int, sys
 func reapDoltLeakPIDsWithKiller(pids []int, killFn func(int, syscall.Signal) error) []error {
 	var errs []error
 	for _, pid := range pids {
-		if err := killFn(pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+		if err := killFn(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
 			errs = append(errs, fmt.Errorf("SIGTERM pid %d: %w", pid, err))
 		}
 	}
 	time.Sleep(250 * time.Millisecond)
 	for _, pid := range pids {
-		if err := killFn(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		if err := killFn(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
 			errs = append(errs, fmt.Errorf("SIGKILL pid %d: %w", pid, err))
 		}
 	}

--- a/cmd/gc/test_gc_binary_test.go
+++ b/cmd/gc/test_gc_binary_test.go
@@ -24,17 +24,28 @@ func currentGCBinaryForTests(t *testing.T) string {
 			testGCBinaryErr = fmt.Errorf("mktemp gc binary dir: %w", err)
 			return
 		}
+		realBinPath := filepath.Join(buildDir, "gc-real")
 		binPath := filepath.Join(buildDir, "gc")
 		wd, err := os.Getwd()
 		if err != nil {
 			testGCBinaryErr = fmt.Errorf("getwd: %w", err)
 			return
 		}
-		cmd := exec.Command("go", "build", "-o", binPath, ".")
+		cmd := exec.Command("go", "build", "-o", realBinPath, ".")
 		cmd.Dir = wd
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			testGCBinaryErr = fmt.Errorf("go build -o %s .: %w\n%s", binPath, err, string(out))
+			testGCBinaryErr = fmt.Errorf("go build -o %s .: %w\n%s", realBinPath, err, string(out))
+			return
+		}
+		wrapper := fmt.Sprintf("#!/bin/sh\nexport %s=1\nif [ -z \"${%s:-}\" ]; then\n  export %s=$PPID\nfi\nexec %q \"$@\"\n",
+			managedDoltTestModeEnv,
+			managedDoltTestParentPIDEnv,
+			managedDoltTestParentPIDEnv,
+			realBinPath,
+		)
+		if err := os.WriteFile(binPath, []byte(wrapper), 0o755); err != nil {
+			testGCBinaryErr = fmt.Errorf("write gc test wrapper: %w", err)
 			return
 		}
 		testGCBinaryPath = binPath

--- a/cmd/gc/test_orphan_sweep_branches_test.go
+++ b/cmd/gc/test_orphan_sweep_branches_test.go
@@ -22,6 +22,19 @@ func pidPrefixedTestDir(root, prefix string, pid int) string {
 	return filepath.Join(root, prefix+strconv.Itoa(pid)+"-fixture")
 }
 
+func TestCmdGCTempRootPrefixKeepsControllerSocketLegacy(t *testing.T) {
+	root, err := os.MkdirTemp("/tmp", pidPrefixedTempPattern(testCmdGCTempRootPrefix))
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+
+	sockPath := filepath.Join(root, "gc-testscript-1234567890", "script-controller", "ctrl-city", ".gc", "controller.sock")
+	if len(sockPath) > controllerSocketPathLimit {
+		t.Fatalf("controller test socket path length = %d, want <= %d: %s", len(sockPath), controllerSocketPathLimit, sockPath)
+	}
+}
+
 func TestSweepOrphanSkipsNonDirectories(t *testing.T) {
 	root := t.TempDir()
 	// A regular file whose name matches the prefix+PID pattern must not be removed.
@@ -170,12 +183,13 @@ func TestSweepOrphanIsIdempotent(t *testing.T) {
 	}
 }
 
-// TestSweepOrphanAllSixPrefixesStabilize verifies that sweepOrphanPIDPrefixedDirs
-// removes stale dirs and preserves current-PID dirs for all six test-fixture
+// TestSweepOrphanAllPrefixesStabilize verifies that sweepOrphanPIDPrefixedDirs
+// removes stale dirs and preserves current-PID dirs for all test-fixture
 // prefixes used by cmd/gc's shared fixtures.
-func TestSweepOrphanAllSixPrefixesStabilize(t *testing.T) {
+func TestSweepOrphanAllPrefixesStabilize(t *testing.T) {
 	prefixes := []string{
 		testGCBinaryDirPrefix,
+		testCmdGCTempRootPrefix,
 		testSlingFormulaDirPrefix,
 		testSlingCityDirPrefix,
 		testGCHomeDirPrefix,

--- a/cmd/gc/test_orphan_sweep_test.go
+++ b/cmd/gc/test_orphan_sweep_test.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	testGCBinaryDirPrefix     = "gc-test-binary-pid"
-	testCmdGCTempRootPrefix   = "gctest-pid"
+	testCmdGCTempRootPrefix   = "gct"
 	testSlingFormulaDirPrefix = "gc-sling-test-formulas-pid"
 	testSlingCityDirPrefix    = "gc-sling-test-city-pid"
 	testGCHomeDirPrefix       = "gascity-gc-home-pid"

--- a/cmd/gc/test_orphan_sweep_test.go
+++ b/cmd/gc/test_orphan_sweep_test.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	testGCBinaryDirPrefix     = "gc-test-binary-pid"
+	testCmdGCTempRootPrefix   = "gctest-pid"
 	testSlingFormulaDirPrefix = "gc-sling-test-formulas-pid"
 	testSlingCityDirPrefix    = "gc-sling-test-city-pid"
 	testGCHomeDirPrefix       = "gascity-gc-home-pid"

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -116,6 +116,8 @@ func liveEnvKeysForTests() []string {
 
 func preserveTestControlEnv(key string) bool {
 	return key == "GC_FAST_UNIT" ||
+		key == managedDoltTestModeEnv ||
+		key == managedDoltTestParentPIDEnv ||
 		key == "GC_DOLT_REAL_BINARY" ||
 		strings.HasPrefix(key, "GC_LIVE_") ||
 		strings.HasPrefix(key, "GC_SESSION_CHAOS_") ||

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -58,11 +58,14 @@ var testRuntimeDir string
 
 var cityCommandEnv sync.Map
 
+var runIntegrationSupervisorStopCommand = exec.CommandContext
+
 const (
-	integrationGCCommandTimeout     = 60 * time.Second
-	integrationGCLifecycleTimeout   = 120 * time.Second
-	integrationGCDoltCommandTimeout = 120 * time.Second
-	integrationBDCommandTimeout     = 15 * time.Second
+	integrationGCCommandTimeout      = 60 * time.Second
+	integrationGCLifecycleTimeout    = 120 * time.Second
+	integrationGCDoltCommandTimeout  = 120 * time.Second
+	integrationBDCommandTimeout      = 15 * time.Second
+	integrationSupervisorStopTimeout = 10 * time.Second
 )
 
 const (
@@ -79,6 +82,10 @@ const (
 
 // TestMain builds the gc binary and runs pre/post sweeps of orphan sessions.
 func TestMain(m *testing.M) {
+	if os.Getenv("GC_INTEGRATION_SUPERVISOR_STOP_HELPER") == "1" {
+		select {}
+	}
+
 	subprocess := os.Getenv("GC_SESSION") == "subprocess"
 
 	// Tmux check: skip all tests if tmux not available AND not using subprocess.
@@ -189,11 +196,7 @@ func TestMain(m *testing.M) {
 	// Use --wait so the sweep blocks until the supervisor and its managed
 	// cities have actually shut down, avoiding a race with process-table
 	// cleanup below.
-	if gcBinary != "" {
-		stopCmd := exec.Command(gcBinary, "supervisor", "stop", "--wait")
-		stopCmd.Env = integrationEnv()
-		_ = stopCmd.Run()
-	}
+	stopIntegrationSupervisorWithTimeout(integrationSupervisorStopTimeout)
 
 	// Post-sweep: clean up any sessions that survived individual test cleanup.
 	if !subprocess {
@@ -228,16 +231,71 @@ func installIntegrationSignalSweeper(subprocess bool) func() {
 }
 
 func sweepIntegrationProcesses(subprocess bool) {
-	if gcBinary != "" {
-		stopCmd := exec.Command(gcBinary, "supervisor", "stop", "--wait")
-		stopCmd.Env = integrationEnv()
-		_ = stopCmd.Run()
-	}
+	stopIntegrationSupervisorWithTimeout(integrationSupervisorStopTimeout)
 	if !subprocess {
 		tmuxtest.KillAllTestSessions(&mainTB{})
 		return
 	}
 	sweepSubprocessTestProcesses()
+}
+
+func stopIntegrationSupervisorWithTimeout(timeout time.Duration) {
+	if gcBinary == "" {
+		return
+	}
+	if timeout <= 0 {
+		timeout = integrationSupervisorStopTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	stopCmd := runIntegrationSupervisorStopCommand(ctx, gcBinary, "supervisor", "stop", "--wait")
+	stopCmd.Env = integrationEnv()
+	out, err := stopCmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		fmt.Fprintf(os.Stderr, "integration cleanup: supervisor stop timed out after %s; continuing cleanup\n%s", timeout, string(out)) //nolint:errcheck
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "integration cleanup: supervisor stop failed: %v; continuing cleanup\n%s", err, string(out)) //nolint:errcheck
+	}
+}
+
+func TestIntegrationSupervisorStopHelperProcess(t *testing.T) {
+	if os.Getenv("GC_INTEGRATION_SUPERVISOR_STOP_HELPER") != "1" {
+		return
+	}
+	select {}
+}
+
+func TestStopIntegrationSupervisorWithTimeoutReturnsAfterDeadline(t *testing.T) {
+	oldRunner := runIntegrationSupervisorStopCommand
+	oldGCBinary := gcBinary
+	oldGCHome := testGCHome
+	oldRuntimeDir := testRuntimeDir
+	oldToolBin := integrationToolBinDir
+	oldRealBD := realBDBinary
+	t.Cleanup(func() {
+		runIntegrationSupervisorStopCommand = oldRunner
+		gcBinary = oldGCBinary
+		testGCHome = oldGCHome
+		testRuntimeDir = oldRuntimeDir
+		integrationToolBinDir = oldToolBin
+		realBDBinary = oldRealBD
+	})
+
+	t.Setenv("GC_INTEGRATION_SUPERVISOR_STOP_HELPER", "1")
+	gcBinary = os.Args[0]
+	testGCHome = t.TempDir()
+	testRuntimeDir = t.TempDir()
+	integrationToolBinDir = filepath.Dir(os.Args[0])
+	realBDBinary = "bd"
+	runIntegrationSupervisorStopCommand = exec.CommandContext
+
+	start := time.Now()
+	stopIntegrationSupervisorWithTimeout(10 * time.Millisecond)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("stopIntegrationSupervisorWithTimeout took %s, want bounded return", elapsed)
+	}
 }
 
 func binaryOverride(envName string) (string, bool, error) {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -69,6 +70,8 @@ const (
 	integrationRealBDBinaryEnv = "GC_INTEGRATION_REAL_BD"
 	integrationDoltBinaryEnv   = "GC_INTEGRATION_DOLT_BINARY"
 	integrationDoltIdentityEnv = "GC_INTEGRATION_DOLT_IDENTITY_MODE"
+	managedDoltTestModeEnv     = "GC_MANAGED_DOLT_TEST_MODE"
+	managedDoltTestParentEnv   = "GC_MANAGED_DOLT_TEST_PARENT_PID"
 	doltIdentityModeIsolated   = "isolated"
 	doltIdentityModeGlobal     = "global"
 	doltIdentityModeSkip       = "skip"
@@ -90,6 +93,8 @@ func TestMain(m *testing.M) {
 		// their descendant pollers from prior interrupted runs.
 		sweepSubprocessTestProcesses()
 	}
+	stopSignalSweeper := installIntegrationSignalSweeper(subprocess)
+	defer stopSignalSweeper()
 
 	// Build gc binary to a temp directory.
 	tmpDir, err := os.MkdirTemp("", "gc-integration-*")
@@ -198,6 +203,41 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(code)
+}
+
+func installIntegrationSignalSweeper(subprocess bool) func() {
+	signals := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		select {
+		case sig := <-signals:
+			sweepIntegrationProcesses(subprocess)
+			signal.Stop(signals)
+			if s, ok := sig.(syscall.Signal); ok {
+				signal.Reset(s)
+				_ = syscall.Kill(os.Getpid(), s)
+			}
+		case <-done:
+		}
+	}()
+	return func() {
+		signal.Stop(signals)
+		close(done)
+	}
+}
+
+func sweepIntegrationProcesses(subprocess bool) {
+	if gcBinary != "" {
+		stopCmd := exec.Command(gcBinary, "supervisor", "stop", "--wait")
+		stopCmd.Env = integrationEnv()
+		_ = stopCmd.Run()
+	}
+	if !subprocess {
+		tmuxtest.KillAllTestSessions(&mainTB{})
+		return
+	}
+	sweepSubprocessTestProcesses()
 }
 
 func binaryOverride(envName string) (string, bool, error) {
@@ -759,6 +799,8 @@ func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env = filterEnv(env, "GC_DOLT_PORT")
 	env = filterEnv(env, "GC_DOLT_USER")
 	env = filterEnv(env, "GC_DOLT_PASSWORD")
+	env = filterEnv(env, managedDoltTestModeEnv)
+	env = filterEnv(env, managedDoltTestParentEnv)
 	env = filterEnv(env, "BEADS_DOLT_SERVER_HOST")
 	env = filterEnv(env, "BEADS_DOLT_SERVER_PORT")
 	env = filterEnv(env, "BEADS_DOLT_SERVER_USER")
@@ -782,6 +824,8 @@ func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	}
 	env = append(env, "GC_HOME="+gcHome)
 	env = append(env, "XDG_RUNTIME_DIR="+runtimeDir)
+	env = append(env, managedDoltTestModeEnv+"=1")
+	env = append(env, managedDoltTestParentEnv+"="+strconv.Itoa(os.Getpid()))
 	env = append(env, integrationRealBDBinaryEnv+"="+realBDBinary)
 	env = append(env, "DOLT_ROOT_PATH="+gcHome)
 	env = append(env, "PATH="+prependPath(integrationToolBinDir, os.Getenv("PATH")))


### PR DESCRIPTION
## Summary

Fixes #2306.

- Fix managed Dolt leaks from interrupted tests by keeping test-started servers under a watchdog.
- Propagate the root test parent PID through gc test helpers, wrappers, lifecycle env, and integration env.
- Add Darwin-compatible Dolt process discovery and portable process identity revalidation for cleanup safety.
- Add cmd/gc and integration test cleanup hooks so leaked test-origin Dolt processes are reported and reaped.

This intentionally does not add a user-facing `gc doctor` remediation path. The fix is in the test/process lifecycle.

## Verification

~~~sh
go test ./cmd/gc -run 'Test(ParseDoltPSLine|ParseListeningPortsByPIDFromLsof|SameReapProcessIdentity|ParseProcStartTimeTicks|SplitCmdline|LooksLikeDoltSQLServer|LoadRigDoltPorts|IsTestConfigPath|RequireNoLeakedDoltAfter|SnapshotDolt|DiffDolt|IsStaleCmdGCTestConfigPath)'

go test ./cmd/gc -run 'TestManagedDolt(SQLServerSysProcAttr|TestWatchdog|TestMode|StartFields|LogSize|LogSuffix)|TestReapManagedDoltTestProcesses|TestProviderLifecycleProcessEnv(ProjectsCanonicalDoltPaths|PropagatesManagedDoltTestMode)|TestSanitizedBaseEnv'

go test -tags=integration ./test/integration -run '^$'

git diff --check
~~~

Manual SIGKILL repro also passed: started `gc-beads-bd` with managed Dolt, observed Dolt and watchdog PIDs, killed the parent with `SIGKILL`, and verified neither process survived.

## Notes

Broad `go test ./cmd/gc` exposes an unrelated Darwin socket-path failure in `TestFileOpenedByAnyProcessUsesUnixSocketTableForStaleSocket`; tracked separately as #2312.
