### PR TITLE
fix(bd): replace stale types.custom values in gc-beads-bd.sh (#2154)

### DIFF
--- a/cmd/gc/gc_beads_bd_yaml_test.go
+++ b/cmd/gc/gc_beads_bd_yaml_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestGcBeadsBdEnsureTypesCustomInYaml_ReplacesStaleValue pins the #2154
+// gascity-side fix: ensure_types_custom_in_yaml must overwrite an existing
+// stale types.custom line rather than skipping it.
+//
+// Pre-fix the function returned early on any `^types.custom:` match — so a
+// city whose .beads/config.yaml had a STALE types list (subset of the SDK's
+// required set, or an older format) silently kept the stale value and the
+// required types never landed. bd reads this YAML key as a fallback when the
+// database config table is unset, so a stale value here masks the types we
+// actually need to register.
+//
+// The fix changed the early-return guard to compare the FULL desired line
+// (grep -qxF) and to strip+re-append on mismatch.
+func TestGcBeadsBdEnsureTypesCustomInYaml_ReplacesStaleValue(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	yamlPath := filepath.Join(cityDir, ".beads", "config.yaml")
+	initial := "issue_prefix: gc\ntypes.custom: stale,old,values\n"
+	if err := os.WriteFile(yamlPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile(initial): %v", err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityDir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityDir)
+
+	desiredTypes := "alpha,beta,gamma"
+	// Source just the function definition out of the script and call it.
+	// We extract via awk rather than sourcing the whole file because the
+	// script's main block at the bottom runs unconditionally.
+	bashCmd := fmt.Sprintf(`
+set -e
+eval "$(awk '/^ensure_types_custom_in_yaml\(\)/,/^}/' %q)"
+ensure_types_custom_in_yaml %q %q
+`, script, cityDir, desiredTypes)
+
+	out, err := exec.Command("bash", "-c", bashCmd).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ensure_types_custom_in_yaml: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("ReadFile(after): %v", err)
+	}
+	want := "issue_prefix: gc\ntypes.custom: " + desiredTypes + "\n"
+	if string(data) != want {
+		t.Fatalf("config.yaml after stale-replace:\n%q\nwant:\n%q", string(data), want)
+	}
+}
+
+// TestGcBeadsBdEnsureTypesCustomInYaml_IdempotentWhenMatching pins the
+// other half of the contract: when the existing line matches the desired
+// value exactly, the function must be a no-op (no rewrite, no mtime change
+// noise that downstream watchers would interpret as a change).
+func TestGcBeadsBdEnsureTypesCustomInYaml_IdempotentWhenMatching(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	yamlPath := filepath.Join(cityDir, ".beads", "config.yaml")
+	desiredTypes := "alpha,beta,gamma"
+	initial := "issue_prefix: gc\ntypes.custom: " + desiredTypes + "\n"
+	if err := os.WriteFile(yamlPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile(initial): %v", err)
+	}
+	infoBefore, err := os.Stat(yamlPath)
+	if err != nil {
+		t.Fatalf("Stat(before): %v", err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityDir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityDir)
+
+	bashCmd := fmt.Sprintf(`
+set -e
+eval "$(awk '/^ensure_types_custom_in_yaml\(\)/,/^}/' %q)"
+ensure_types_custom_in_yaml %q %q
+`, script, cityDir, desiredTypes)
+
+	out, err := exec.Command("bash", "-c", bashCmd).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ensure_types_custom_in_yaml: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("ReadFile(after): %v", err)
+	}
+	if string(data) != initial {
+		t.Fatalf("config.yaml after idempotent call changed:\nbefore: %q\nafter:  %q", initial, string(data))
+	}
+	infoAfter, err := os.Stat(yamlPath)
+	if err != nil {
+		t.Fatalf("Stat(after): %v", err)
+	}
+	if !infoBefore.ModTime().Equal(infoAfter.ModTime()) {
+		t.Fatalf("config.yaml mtime changed on idempotent call (before=%v after=%v) — function should short-circuit when value matches",
+			infoBefore.ModTime(), infoAfter.ModTime())
+	}
+}

--- a/cmd/gc/gc_beads_bd_yaml_test.go
+++ b/cmd/gc/gc_beads_bd_yaml_test.go
@@ -5,29 +5,29 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// TestGcBeadsBdEnsureTypesCustomInYaml_ReplacesStaleValue pins the #2154
-// gascity-side fix: ensure_types_custom_in_yaml must overwrite an existing
-// stale types.custom line rather than skipping it.
-//
-// Pre-fix the function returned early on any `^types.custom:` match — so a
-// city whose .beads/config.yaml had a STALE types list (subset of the SDK's
-// required set, or an older format) silently kept the stale value and the
-// required types never landed. bd reads this YAML key as a fallback when the
-// database config table is unset, so a stale value here masks the types we
-// actually need to register.
-//
-// The fix changed the early-return guard to compare the FULL desired line
-// (grep -qxF) and to strip+re-append on mismatch.
-func TestGcBeadsBdEnsureTypesCustomInYaml_ReplacesStaleValue(t *testing.T) {
+// TestGcBeadsBdEnsureTypesCustomInYaml_MergesWithExistingValues pins the
+// gascity-side #2154 fix and the PR #2315 review followup: when the
+// existing types.custom line is a different set than the baseline being
+// installed, the function must MERGE the two sets (preserving existing
+// entries that may be pack/user-defined custom types) rather than overwrite.
+// The required baseline types must end up present after the call; the
+// existing entries must also remain.
+func TestGcBeadsBdEnsureTypesCustomInYaml_MergesWithExistingValues(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	yamlPath := filepath.Join(cityDir, ".beads", "config.yaml")
-	initial := "issue_prefix: gc\ntypes.custom: stale,old,values\n"
+	// Existing values represent extensions the operator/pack added beyond
+	// the SDK baseline — they must be preserved through the merge.
+	initial := "issue_prefix: gc\ntypes.custom: legacy_a,legacy_b,legacy_c\n"
 	if err := os.WriteFile(yamlPath, []byte(initial), 0o644); err != nil {
 		t.Fatalf("WriteFile(initial): %v", err)
 	}
@@ -56,9 +56,18 @@ ensure_types_custom_in_yaml %q %q
 	if err != nil {
 		t.Fatalf("ReadFile(after): %v", err)
 	}
-	want := "issue_prefix: gc\ntypes.custom: " + desiredTypes + "\n"
-	if string(data) != want {
-		t.Fatalf("config.yaml after stale-replace:\n%q\nwant:\n%q", string(data), want)
+	got := string(data)
+	// All baseline types must land.
+	for _, must := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("config.yaml missing required baseline type %q after merge:\n%s", must, got)
+		}
+	}
+	// All existing entries must be preserved.
+	for _, must := range []string{"legacy_a", "legacy_b", "legacy_c"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("config.yaml lost existing type %q after merge:\n%s", must, got)
+		}
 	}
 }
 
@@ -67,6 +76,9 @@ ensure_types_custom_in_yaml %q %q
 // value exactly, the function must be a no-op (no rewrite, no mtime change
 // noise that downstream watchers would interpret as a change).
 func TestGcBeadsBdEnsureTypesCustomInYaml_IdempotentWhenMatching(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
@@ -112,5 +124,108 @@ ensure_types_custom_in_yaml %q %q
 	if !infoBefore.ModTime().Equal(infoAfter.ModTime()) {
 		t.Fatalf("config.yaml mtime changed on idempotent call (before=%v after=%v) — function should short-circuit when value matches",
 			infoBefore.ModTime(), infoAfter.ModTime())
+	}
+}
+
+// TestGcBeadsBdEnsureTypesCustomInYaml_PreservesCustomExtensions pins the
+// PR #2315 review fix: when the existing types.custom line contains
+// pack/user-defined types beyond the GC baseline (the desiredTypes the
+// caller passes), the function must MERGE — preserving the extensions —
+// not narrow the set to just the baseline. The previous behavior treated
+// any non-exact match as stale and rewrote with $types alone, silently
+// dropping pack/user types and breaking later bead creation for those
+// types. Mirrors mergeCustomTypes in
+// internal/doctor/checks_custom_types.go.
+func TestGcBeadsBdEnsureTypesCustomInYaml_PreservesCustomExtensions(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	yamlPath := filepath.Join(cityDir, ".beads", "config.yaml")
+	// Existing line: GC baseline + 2 pack-defined extensions.
+	initial := "issue_prefix: gc\ntypes.custom: alpha,beta,pack_custom_a,pack_custom_b\n"
+	if err := os.WriteFile(yamlPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile(initial): %v", err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityDir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityDir)
+
+	// Caller passes only the baseline. The merge must keep pack_custom_a
+	// and pack_custom_b — narrowing the set would defeat the doctor-merge
+	// contract internal/doctor/checks_custom_types.go encodes.
+	desiredTypes := "alpha,beta"
+	bashCmd := fmt.Sprintf(`
+set -e
+eval "$(awk '/^ensure_types_custom_in_yaml\(\)/,/^}/' %q)"
+ensure_types_custom_in_yaml %q %q
+`, script, cityDir, desiredTypes)
+
+	out, err := exec.Command("bash", "-c", bashCmd).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ensure_types_custom_in_yaml: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("ReadFile(after): %v", err)
+	}
+	got := string(data)
+	for _, must := range []string{"alpha", "beta", "pack_custom_a", "pack_custom_b"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("config.yaml lost custom type %q after merge:\n%s", must, got)
+		}
+	}
+}
+
+// TestGcBeadsBdEnsureTypesCustomInYaml_AddsMissingBaselineToCustomSet
+// pins the other half of the merge: a YAML containing ONLY pack/user
+// extensions (no overlap with the baseline) must end up with both the
+// extensions AND the baseline after a call with the GC types.
+func TestGcBeadsBdEnsureTypesCustomInYaml_AddsMissingBaselineToCustomSet(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	yamlPath := filepath.Join(cityDir, ".beads", "config.yaml")
+	initial := "issue_prefix: gc\ntypes.custom: pack_only_a,pack_only_b\n"
+	if err := os.WriteFile(yamlPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile(initial): %v", err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityDir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityDir)
+
+	desiredTypes := "alpha,beta,gamma"
+	bashCmd := fmt.Sprintf(`
+set -e
+eval "$(awk '/^ensure_types_custom_in_yaml\(\)/,/^}/' %q)"
+ensure_types_custom_in_yaml %q %q
+`, script, cityDir, desiredTypes)
+
+	out, err := exec.Command("bash", "-c", bashCmd).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ensure_types_custom_in_yaml: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("ReadFile(after): %v", err)
+	}
+	got := string(data)
+	for _, must := range []string{"alpha", "beta", "gamma", "pack_only_a", "pack_only_b"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("config.yaml missing expected type %q after merge:\n%s", must, got)
+		}
 	}
 }

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -492,24 +492,53 @@ wait_for_bd_runtime_schema() {
 # here registers the types without paying bd's per-command auto-migrate
 # cost (~50s on populated databases).
 #
-# Idempotent against the desired value: re-running with the SAME $types
-# is a no-op. If the YAML already has a STALE types.custom line (different
-# value from the one being installed), strip it and append the new value —
-# leaving a stale line in place would mask the types we actually need to
-# register, which is the failure mode #2154 surfaces on the gascity side.
+# Idempotent against the desired effective set: re-running with the SAME
+# baseline is a no-op. The rewrite NEVER narrows the type set: if the YAML
+# already contains pack-defined or user-defined custom types beyond $types
+# (the GC baseline), those extensions are preserved. This matches the
+# merge semantics of internal/doctor/checks_custom_types.go:mergeCustomTypes
+# and fixes the gascity-side failure surfaced in #2154 — a stale or partial
+# line is replaced with the union of existing and required entries, never
+# overwritten with just the baseline.
 ensure_types_custom_in_yaml() {
     local dir="$1"
     local types="$2"
     local config_yaml="$dir/.beads/config.yaml"
     [ -f "$config_yaml" ] || return 0
     [ -n "$types" ] || return 0
-    if grep -qxF "types.custom: $types" "$config_yaml" 2>/dev/null; then
+
+    local current
+    current=$(sed -n 's/^types\.custom: *//p' "$config_yaml" 2>/dev/null | head -1)
+
+    local merged
+    merged=$(printf '%s,%s' "$current" "$types" | awk -F, '
+        {
+            for (i = 1; i <= NF; i++) {
+                t = $i
+                sub(/^[ \t]+/, "", t)
+                sub(/[ \t]+$/, "", t)
+                if (t == "") continue
+                if (!(t in seen)) {
+                    seen[t] = 1
+                    out = (out == "" ? t : out "," t)
+                }
+            }
+            print out
+        }
+    ')
+
+    # Short-circuit when the merged set already equals what's on disk:
+    # avoids mtime churn that downstream watchers might misread as a real
+    # change. Includes the case where current is already a superset of
+    # the baseline (operator/pack types appended to the GC list).
+    if [ "$current" = "$merged" ]; then
         return 0
     fi
+
     local tmp
     tmp=$(mktemp "$config_yaml.tmp.XXXXXX") || return 0
     sed '/^types\.custom:/d' "$config_yaml" > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
-    printf 'types.custom: %s\n' "$types" >> "$tmp"
+    printf 'types.custom: %s\n' "$merged" >> "$tmp"
     mv -f "$tmp" "$config_yaml" || rm -f "$tmp"
 }
 

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -486,24 +486,29 @@ wait_for_bd_runtime_schema() {
     return 1
 }
 
-# ensure_types_custom_in_yaml writes types.custom to .beads/config.yaml when
-# the key is absent. bd reads this YAML key as a fallback when the database
-# config table is unset (see beads internal/config: GetCustomTypesFromYAML),
-# so writing here registers the types without paying bd's per-command
-# auto-migrate cost (~50s on populated databases). Idempotent: re-running
-# never appends duplicates.
+# ensure_types_custom_in_yaml writes types.custom to .beads/config.yaml.
+# bd reads this YAML key as a fallback when the database config table is
+# unset (see beads internal/config: GetCustomTypesFromYAML), so writing
+# here registers the types without paying bd's per-command auto-migrate
+# cost (~50s on populated databases).
+#
+# Idempotent against the desired value: re-running with the SAME $types
+# is a no-op. If the YAML already has a STALE types.custom line (different
+# value from the one being installed), strip it and append the new value —
+# leaving a stale line in place would mask the types we actually need to
+# register, which is the failure mode #2154 surfaces on the gascity side.
 ensure_types_custom_in_yaml() {
     local dir="$1"
     local types="$2"
     local config_yaml="$dir/.beads/config.yaml"
     [ -f "$config_yaml" ] || return 0
     [ -n "$types" ] || return 0
-    if grep -q "^types\.custom:" "$config_yaml" 2>/dev/null; then
+    if grep -qxF "types.custom: $types" "$config_yaml" 2>/dev/null; then
         return 0
     fi
     local tmp
     tmp=$(mktemp "$config_yaml.tmp.XXXXXX") || return 0
-    cat "$config_yaml" > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+    sed '/^types\.custom:/d' "$config_yaml" > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
     printf 'types.custom: %s\n' "$types" >> "$tmp"
     mv -f "$tmp" "$config_yaml" || rm -f "$tmp"
 }


### PR DESCRIPTION
Addresses the gascity-side gap for #2154.

## Problem

`gc-beads-bd.sh`'s `ensure_types_custom_in_yaml` used `grep -q '^types.custom:'` as its idempotency guard — it treated *any* existing `types.custom:` line as "already correct" and skipped. When the line was present but **stale** (a different value than desired), the required custom types were never written.

## Fix

- Idempotency guard changed from "a `types.custom:` line exists" (`grep -q`) to "the line exactly matches the desired value" (`grep -qxF`).
- When the existing line is stale, strip it (`sed '/^types\.custom:/d'`) before appending the correct one. `set -e` safe — `sed` exits 0 on no-match.

2 files, +129/-8 (`examples/bd/assets/scripts/gc-beads-bd.sh` +14/-7, new `cmd/gc/gc_beads_bd_yaml_test.go` +115).

## Test

- `TestGcBeadsBdEnsureTypesCustomInYaml_ReplacesStaleValue` — verified to fail pre-fix, pass post-fix.
- `TestGcBeadsBdEnsureTypesCustomInYaml_IdempotentWhenMatching` — asserts file content + mtime unchanged when the value already matches.
- `go vet ./cmd/gc/...`, `go build ./...` clean.

Note: #2154's server-side schema-validation half lives in `gastownhall/beads` and is tracked separately.
