### PR TITLE
Adopt PR #2288: feat: add JSON for native management actions

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -441,6 +441,7 @@ have moved to "gc session" and "gc runtime".`,
 func newAgentAddCmd(stdout, stderr io.Writer) *cobra.Command {
 	var name, promptTemplate, dir string
 	var suspended bool
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "add --name <name>",
 		Short: "Add an agent scaffold",
@@ -459,6 +460,19 @@ agent in a suspended state.`,
   gc agent add --name worker --prompt-template ./worker.md --suspended`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if jsonOutput {
+				if cmdAgentAdd(name, promptTemplate, dir, suspended, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				resultName, qualifiedName := agentJSONName(name, dir)
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:       commandName("agent", "add"),
+					Action:        "add",
+					Name:          resultName,
+					QualifiedName: qualifiedName,
+					Suspended:     managementBoolPtr(suspended),
+				})
+			}
 			if cmdAgentAdd(name, promptTemplate, dir, suspended, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -469,6 +483,7 @@ agent in a suspended state.`,
 	cmd.Flags().StringVar(&promptTemplate, "prompt-template", "", "Path to prompt template file (relative to city root)")
 	cmd.Flags().StringVar(&dir, "dir", "", "Working directory for the agent (relative to city root)")
 	cmd.Flags().BoolVar(&suspended, "suspended", false, "Register the agent in suspended state")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
 	return cmd
 }
 
@@ -564,7 +579,8 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 }
 
 func newAgentSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "suspend <name>",
 		Short: "Suspend an agent (reconciler will skip it)",
 		Long: `Suspend an agent by setting suspended=true in its durable config.
@@ -574,12 +590,26 @@ started or restarted. Existing sessions continue running but won't be
 replaced if they exit. Use "gc agent resume" to restore.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdAgentSuspend(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:       commandName("agent", "suspend"),
+					Action:        "suspend",
+					Name:          args[0],
+					QualifiedName: args[0],
+					Suspended:     managementBoolPtr(true),
+				})
+			}
 			if cmdAgentSuspend(args, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdAgentSuspend is the CLI entry point for suspending an agent.
@@ -618,7 +648,8 @@ func doAgentSuspend(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 }
 
 func newAgentResumeCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "resume <name>",
 		Short: "Resume a suspended agent",
 		Long: `Resume a suspended agent by clearing suspended in its durable config.
@@ -627,12 +658,26 @@ The reconciler will start the agent on its next tick. Supports bare
 names (resolved via rig context) and qualified names (e.g. "myrig/worker").`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdAgentResume(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:       commandName("agent", "resume"),
+					Action:        "resume",
+					Name:          args[0],
+					QualifiedName: args[0],
+					Suspended:     managementBoolPtr(false),
+				})
+			}
 			if cmdAgentResume(args, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdAgentResume is the CLI entry point for resuming a suspended agent.

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -594,11 +594,17 @@ replaced if they exit. Use "gc agent resume" to restore.`,
 				if cmdAgentSuspend(args, io.Discard, stderr) != 0 {
 					return errExit
 				}
+				cityPath, err := resolveCity()
+				if err != nil {
+					fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				name, qualifiedName := agentJSONIdentity(cityPath, args[0])
 				return writeManagementActionJSON(stdout, managementActionResult{
 					Command:       commandName("agent", "suspend"),
 					Action:        "suspend",
-					Name:          args[0],
-					QualifiedName: args[0],
+					Name:          name,
+					QualifiedName: qualifiedName,
 					Suspended:     managementBoolPtr(true),
 				})
 			}
@@ -662,11 +668,17 @@ names (resolved via rig context) and qualified names (e.g. "myrig/worker").`,
 				if cmdAgentResume(args, io.Discard, stderr) != 0 {
 					return errExit
 				}
+				cityPath, err := resolveCity()
+				if err != nil {
+					fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				name, qualifiedName := agentJSONIdentity(cityPath, args[0])
 				return writeManagementActionJSON(stdout, managementActionResult{
 					Command:       commandName("agent", "resume"),
 					Action:        "resume",
-					Name:          args[0],
-					QualifiedName: args[0],
+					Name:          name,
+					QualifiedName: qualifiedName,
 					Suspended:     managementBoolPtr(false),
 				})
 			}

--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -93,6 +93,7 @@ func addDiscoveredLeaf(root *cobra.Command, entry config.DiscoveredCommand, city
 		Use:                leafWord,
 		Short:              entry.Description,
 		Long:               readDiscoveredHelp(entry),
+		Annotations:        map[string]string{jsonSchemaDirAnnotation: filepath.Join(entry.SourceDir, "schemas")},
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if discoveredHelpRequested(args) {

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -115,10 +115,11 @@ Skips beads init; the git repo check remains informational.`,
 					fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
 					return errExit
 				}
-				if doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, io.Discard, stderr) != 0 {
+				rig, code := doRigAddWithResult(fsys.OSFS{}, cityPath, rigPath, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, io.Discard, stderr)
+				if code != 0 {
 					return errExit
 				}
-				return writeManagementActionJSON(stdout, rigAddJSONSummary(cityPath, rigPath, nameFlag, prefixFlag))
+				return writeManagementActionJSON(stdout, rigAddJSONSummary(rigPath, rig))
 			}
 			if cmdRigAdd(args, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, stdout, stderr) != 0 {
 				return errExit
@@ -202,6 +203,11 @@ func resolveRigAddPath(cityPath, rigArg string) (string, error) {
 // This prevents partial-state bugs where city.toml lists a rig but the rig's
 // infrastructure (beads, routes) was never created.
 func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverride, prefixOverride, defaultBranchOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) int {
+	_, code := doRigAddWithResult(fs, cityPath, rigPath, includes, nameOverride, prefixOverride, defaultBranchOverride, startSuspended, adopt, stdout, stderr)
+	return code
+}
+
+func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverride, prefixOverride, defaultBranchOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) (config.Rig, int) {
 	// Trim and drop empty --include entries so `--include=` or `--include " "`
 	// doesn't persist a blank pack path that downstream resolution reads
 	// as the city root.
@@ -217,15 +223,15 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if fi, err := fs.Stat(rigPath); err != nil {
 		if adopt {
 			fmt.Fprintf(stderr, "gc rig add: --adopt requires an existing directory: %s\n", rigPath) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		if !os.IsNotExist(err) {
 			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", rigPath, err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 	} else if !fi.IsDir() {
 		fmt.Fprintf(stderr, "gc rig add: %s is not a directory\n", rigPath) //nolint:errcheck // best-effort stderr
-		return 1
+		return config.Rig{}, 1
 	} else {
 		rigPathExists = true
 	}
@@ -247,7 +253,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig add: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return config.Rig{}, 1
 	}
 	explicitRigImports := boundImportsFromLegacySources(includes, cfg.Packs)
 	if cityUsesBdStoreContract(cityPath) && cityDoltConfigHasLifecycleFields(cfg.Dolt) {
@@ -275,7 +281,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		}
 		if filepath.Clean(existPath) != filepath.Clean(rigPath) {
 			fmt.Fprintf(stderr, "gc rig add: rig %q already registered at %s (not %s)\n", name, r.Path, rigPath) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		reAdd = true
 		break
@@ -295,12 +301,12 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		prefixKey := strings.ToLower(prefix)
 		if prefixKey == strings.ToLower(config.EffectiveHQPrefix(cfg)) {
 			fmt.Fprintf(stderr, "gc rig add: rig %q: prefix %q collides with HQ. Use --prefix to specify a different prefix.\n", name, prefixKey) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		for _, rig := range cfg.Rigs {
 			if prefixKey == strings.ToLower(rig.EffectivePrefix()) {
 				fmt.Fprintf(stderr, "gc rig add: rig %q: prefix %q collides with %s. Use --prefix to specify a different prefix.\n", name, prefixKey, rig.Name) //nolint:errcheck // best-effort stderr
-				return 1
+				return config.Rig{}, 1
 			}
 		}
 	}
@@ -340,7 +346,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 			rootDefaultRigImports, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
 			if err != nil {
 				fmt.Fprintf(stderr, "gc rig add: loading root pack defaults: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1
+				return config.Rig{}, 1
 			}
 			defaultRigImports = composeDefaultRigImports(rootDefaultRigImports, cfg.Workspace.LegacyDefaultRigIncludes(), cfg.Packs)
 			if len(defaultRigImports) > 0 {
@@ -354,14 +360,14 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if needsValidation {
 		if err := config.ValidateRigs(nextCfg.Rigs, config.EffectiveHQPrefix(nextCfg)); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 
 	if !rigPathExists {
 		if err := fs.MkdirAll(rigPath, 0o755); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: creating %s: %v\n", rigPath, err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 
@@ -369,11 +375,11 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		metaPath := filepath.Join(rigPath, ".beads", "metadata.json")
 		if _, err := fs.Stat(metaPath); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: --adopt requires .beads/metadata.json in %s\n", rigPath) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		if _, ok := readBeadsPrefix(fs, rigPath); !ok {
 			fmt.Fprintf(stderr, "gc rig add: --adopt requires a valid issue_prefix in .beads/config.yaml in %s\n", rigPath) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 
@@ -397,7 +403,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 				"use --prefix %s to match, or remove %s/.beads to reinitialize\n",
 				name, existingPrefix, prefix, existingPrefix, rigPath)
 		}
-		return 1
+		return config.Rig{}, 1
 	}
 
 	// Guard: on a fresh add (not a re-add) without --adopt, refuse to run
@@ -410,13 +416,13 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		fi, err := fs.Stat(beadsPath)
 		if err != nil && !os.IsNotExist(err) {
 			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", beadsPath, err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		if err == nil && fi.IsDir() {
 			fmt.Fprintf(stderr, "gc rig add: %s/.beads already exists; "+ //nolint:errcheck // best-effort stderr
 				"use --adopt to register the existing store, or remove %s/.beads to reinitialize\n",
 				rigPath, rigPath)
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 
@@ -468,7 +474,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if adopt {
 		if err := prepareRigAdoptProviderState(cityPath, rigPath); err != nil {
 			fmt.Fprintf(stderr, "gc rig add: prepare adopted rig store: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		w("  Adopted existing beads database")
 	}
@@ -478,7 +484,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		deferred, err = initDirIfReady(cityPath, rigPath, prefix)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			return config.Rig{}, 1
 		}
 		if deferred {
 			if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
@@ -496,17 +502,17 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	snapshots, err := snapshotRigAddTopologyFiles(fs, cityPath, nextCfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc rig add: snapshot canonical files: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return config.Rig{}, 1
 	}
 	if !reAdd || reAddNeedsConfigWrite {
 		if err := normalizeCanonicalBdScopeFiles(cityPath, nextCfg, io.Discard); err != nil {
 			writeRigAddRollbackError(fs, stderr, snapshots, "canonicalizing rig topology", err)
-			return 1
+			return config.Rig{}, 1
 		}
 
 		if err := writeCityConfigForEditFS(fs, tomlPath, nextCfg); err != nil {
 			writeRigAddRollbackError(fs, stderr, snapshots, "writing config", err)
-			return 1
+			return config.Rig{}, 1
 		}
 	}
 	cfg = nextCfg
@@ -514,7 +520,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	allRigs := collectRigRoutes(cityPath, cfg)
 	if err := writeAllRigRoutes(allRigs); err != nil {
 		writeRigAddRollbackError(fs, stderr, snapshots, "writing routes", err)
-		return 1
+		return config.Rig{}, 1
 	}
 	w("  Generated routes.jsonl for cross-rig routing")
 
@@ -565,7 +571,18 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	default:
 		w("Rig added.")
 	}
-	return 0
+	for _, rig := range cfg.Rigs {
+		if rig.Name == name {
+			return rig, 0
+		}
+	}
+	return config.Rig{
+		Name:          name,
+		Path:          rigPath,
+		Prefix:        strings.ToLower(prefixOverride),
+		DefaultBranch: resolvedDefaultBranch,
+		Suspended:     startSuspended,
+	}, 0
 }
 
 func formatBoundImports(imports []config.BoundImport) string {

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -65,6 +65,7 @@ func newRigAddCmd(stdout, stderr io.Writer) *cobra.Command {
 	var prefixFlag string
 	var defaultBranchFlag string
 	var adoptFlag bool
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "add <path>",
 		Short: "Register a project as a rig",
@@ -99,6 +100,26 @@ Skips beads init; the git repo check remains informational.`,
   gc rig add /path/to/existing --adopt`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				cityPath, err := resolveCity()
+				if err != nil {
+					fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				if len(args) < 1 {
+					fmt.Fprintln(stderr, "gc rig add: missing path") //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				rigPath, err := resolveRigAddPath(cityPath, args[0])
+				if err != nil {
+					fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
+				if doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, rigAddJSONSummary(cityPath, rigPath, nameFlag, prefixFlag))
+			}
 			if cmdRigAdd(args, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -111,6 +132,7 @@ Skips beads init; the git repo check remains informational.`,
 	cmd.Flags().StringVar(&defaultBranchFlag, "default-branch", "", "mainline branch (default: auto-detect from origin/HEAD or current branch)")
 	cmd.Flags().BoolVar(&startSuspended, "start-suspended", false, "add rig in suspended state (dormant-by-default)")
 	cmd.Flags().BoolVar(&adoptFlag, "adopt", false, "adopt existing .beads/ directory (skip init)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
 	return cmd
 }
 
@@ -910,7 +932,8 @@ func rigBeadsStatus(fs fsys.FS, dir string) string {
 }
 
 func newRigSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "suspend [name]",
 		Short: "Suspend a rig (reconciler will skip its agents)",
 		Long: `Suspend a rig by setting suspended=true in city.toml.
@@ -920,6 +943,24 @@ the reconciler skips them and gc hook returns empty. The rig's beads
 database remains accessible. Use "gc rig resume" to restore.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				rigName := ""
+				if len(args) > 0 {
+					rigName = args[0]
+				} else if ctx, err := resolveContext(); err == nil {
+					rigName = ctx.RigName
+				}
+				if cmdRigSuspend(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:   commandName("rig", "suspend"),
+					Action:    "suspend",
+					Name:      rigName,
+					Rig:       rigName,
+					Suspended: managementBoolPtr(true),
+				})
+			}
 			if cmdRigSuspend(args, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -927,6 +968,8 @@ database remains accessible. Use "gc rig resume" to restore.`,
 		},
 		ValidArgsFunction: completeRigNames,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdRigSuspend is the CLI entry point for suspending a rig.
@@ -993,7 +1036,8 @@ func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer
 }
 
 func newRigResumeCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "resume [name]",
 		Short: "Resume a suspended rig",
 		Long: `Resume a suspended rig by clearing suspended in city.toml.
@@ -1001,6 +1045,24 @@ func newRigResumeCmd(stdout, stderr io.Writer) *cobra.Command {
 The reconciler will start the rig's agents on its next tick.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				rigName := ""
+				if len(args) > 0 {
+					rigName = args[0]
+				} else if ctx, err := resolveContext(); err == nil {
+					rigName = ctx.RigName
+				}
+				if cmdRigResume(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:   commandName("rig", "resume"),
+					Action:    "resume",
+					Name:      rigName,
+					Rig:       rigName,
+					Suspended: managementBoolPtr(false),
+				})
+			}
 			if cmdRigResume(args, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -1008,6 +1070,8 @@ The reconciler will start the rig's agents on its next tick.`,
 		},
 		ValidArgsFunction: completeRigNames,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdRigResume is the CLI entry point for resuming a suspended rig.
@@ -1074,7 +1138,8 @@ func doRigResume(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer)
 }
 
 func newRigRemoveCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "remove <name>",
 		Short: "Remove a rig from the city",
 		Long: `Remove a rig from the current city's configuration.
@@ -1084,6 +1149,17 @@ binding from .gc/site.toml.`,
 		Example: `  gc rig remove myrig`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdRigRemove(args[0], io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command: commandName("rig", "remove"),
+					Action:  "remove",
+					Name:    args[0],
+					Rig:     args[0],
+				})
+			}
 			if cmdRigRemove(args[0], stdout, stderr) != 0 {
 				return errExit
 			}
@@ -1091,6 +1167,8 @@ binding from .gc/site.toml.`,
 		},
 		ValidArgsFunction: completeRigNames,
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 // cmdRigRemove removes a rig from the current city and its local site binding.

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -69,7 +69,7 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 					Action:   "set-endpoint",
 					Name:     args[0],
 					Rig:      args[0],
-					DryRun:   opts.DryRun,
+					DryRun:   managementBoolPtr(opts.DryRun),
 					Endpoint: rigEndpointJSONFromOptions(opts),
 				})
 			}

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -39,6 +39,7 @@ var verifyRigExternalEndpoint = verifyExternalDoltEndpoint
 
 func newRigSetEndpointCmd(stdout, stderr io.Writer) *cobra.Command {
 	var opts rigEndpointOptions
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "set-endpoint <rig>",
 		Short: "Set the canonical endpoint ownership for a rig",
@@ -59,6 +60,19 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
   gc rig set-endpoint frontend --inherit --dry-run`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdRigSetEndpoint(args[0], opts, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command:  commandName("rig", "set-endpoint"),
+					Action:   "set-endpoint",
+					Name:     args[0],
+					Rig:      args[0],
+					DryRun:   opts.DryRun,
+					Endpoint: rigEndpointJSONFromOptions(opts),
+				})
+			}
 			if cmdRigSetEndpoint(args[0], opts, stdout, stderr) != 0 {
 				return errExit
 			}
@@ -75,6 +89,7 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 	cmd.Flags().StringVar(&opts.User, "user", "", "external Dolt user")
 	cmd.Flags().BoolVar(&opts.AdoptUnverified, "adopt-unverified", false, "record the endpoint without live validation")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "show the canonical changes without writing files")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
 	return cmd
 }
 

--- a/cmd/gc/cmd_service.go
+++ b/cmd/gc/cmd_service.go
@@ -97,7 +97,8 @@ func cmdServiceDoctor(name string, stdout, stderr io.Writer) int {
 }
 
 func newServiceRestartCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "restart <name>",
 		Short: "Restart a workspace service",
 		Long: `Stop and restart a workspace service by name.
@@ -106,12 +107,24 @@ The controller closes the current service process and starts a fresh one.
 Useful after updating pack scripts without a full city restart.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdServiceRestart(args[0], io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command: commandName("service", "restart"),
+					Action:  "restart",
+					Name:    args[0],
+				})
+			}
 			if cmdServiceRestart(args[0], stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 func cmdServiceRestart(name string, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -34,6 +34,13 @@ const (
 	waitStateFailed   = "failed"
 )
 
+type waitSetStateResult struct {
+	WaitID      string
+	ReadyWaitID string
+	Retried     bool
+	RetriedFrom string
+}
+
 func newWaitCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wait",
@@ -112,13 +119,14 @@ func newWaitCancelCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
-				if cmdWaitSetState(args[0], waitStateCanceled, io.Discard, stderr) != 0 {
+				result, code := cmdWaitSetStateResult(args[0], waitStateCanceled, io.Discard, stderr)
+				if code != 0 {
 					return errExit
 				}
 				return writeManagementActionJSON(stdout, managementActionResult{
 					Command: commandName("wait", "cancel"),
 					Action:  "cancel",
-					Name:    args[0],
+					Name:    result.WaitID,
 					State:   waitStateCanceled,
 				})
 			}
@@ -140,15 +148,22 @@ func newWaitReadyCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
-				if cmdWaitSetState(args[0], waitStateReady, io.Discard, stderr) != 0 {
+				result, code := cmdWaitSetStateResult(args[0], waitStateReady, io.Discard, stderr)
+				if code != 0 {
 					return errExit
 				}
-				return writeManagementActionJSON(stdout, managementActionResult{
+				payload := managementActionResult{
 					Command: commandName("wait", "ready"),
 					Action:  "ready",
-					Name:    args[0],
+					Name:    result.WaitID,
 					State:   waitStateReady,
-				})
+				}
+				if result.Retried {
+					payload.Retried = managementBoolPtr(true)
+					payload.RetriedFrom = result.RetriedFrom
+					payload.ReadyWaitID = result.ReadyWaitID
+				}
+				return writeManagementActionJSON(stdout, payload)
 			}
 			if cmdWaitSetState(args[0], waitStateReady, stdout, stderr) != 0 {
 				return errExit
@@ -353,23 +368,29 @@ func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
 }
 
 func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
+	_, code := cmdWaitSetStateResult(waitID, state, stdout, stderr)
+	return code
+}
+
+func cmdWaitSetStateResult(waitID, state string, stdout, stderr io.Writer) (waitSetStateResult, int) {
+	result := waitSetStateResult{WaitID: waitID}
 	store, code := openCityStore(stderr, "gc wait")
 	if store == nil {
-		return code
+		return result, code
 	}
 	b, err := store.Get(waitID)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-		return 1
+		return result, 1
 	}
 	if !sessionpkg.IsWaitBead(b) {
 		fmt.Fprintf(stderr, "gc wait: %s is not a wait\n", waitID) //nolint:errcheck
-		return 1
+		return result, 1
 	}
 	if state == waitStateReady {
 		if err := waitLifecycleEnabled(); err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-			return 1
+			return result, 1
 		}
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -377,10 +398,14 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 		retried, err := retryClosedWait(store, b, now)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-			return 1
+			return result, 1
 		}
 		fmt.Fprintf(stdout, "Retried wait %s as %s.\n", waitID, retried.ID) //nolint:errcheck
-		return 0
+		result.WaitID = retried.ID
+		result.ReadyWaitID = retried.ID
+		result.Retried = true
+		result.RetriedFrom = waitID
+		return result, 0
 	}
 	batch := map[string]string{"state": state}
 	switch state {
@@ -389,7 +414,7 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 		nextAttempt, err := nextWaitDeliveryAttempt(store, b)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-			return 1
+			return result, 1
 		}
 		if nextAttempt != "" {
 			batch["delivery_attempt"] = nextAttempt
@@ -412,22 +437,22 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 	}
 	if err := apply(waitID, batch); err != nil {
 		fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
-		return 1
+		return result, 1
 	}
 	if state == waitStateCanceled {
 		if cityPath, err := resolveCity(); err == nil {
 			if err := withdrawQueuedWaitNudges(cityPath, []string{b.Metadata["nudge_id"]}); err != nil {
 				fmt.Fprintf(stderr, "gc wait: withdrawing queued nudge: %v\n", err) //nolint:errcheck
-				return 1
+				return result, 1
 			}
 		}
 		if err := clearSessionWaitHoldIfIdle(store, b.Metadata["session_id"]); err != nil {
 			fmt.Fprintf(stderr, "gc wait: clearing session wait hold: %v\n", err) //nolint:errcheck
-			return 1
+			return result, 1
 		}
 	}
 	fmt.Fprintf(stdout, "Updated wait %s to %s.\n", waitID, state) //nolint:errcheck
-	return 0
+	return result, 0
 }
 
 func loadWaitBeads(store beads.Store) ([]beads.Bead, error) {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -105,31 +105,59 @@ func newWaitInspectCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func newWaitCancelCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "cancel <wait-id>",
 		Short: "Cancel a wait",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdWaitSetState(args[0], waitStateCanceled, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command: commandName("wait", "cancel"),
+					Action:  "cancel",
+					Name:    args[0],
+					State:   waitStateCanceled,
+				})
+			}
 			if cmdWaitSetState(args[0], waitStateCanceled, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 func newWaitReadyCmd(stdout, stderr io.Writer) *cobra.Command {
-	return &cobra.Command{
+	var jsonOutput bool
+	cmd := &cobra.Command{
 		Use:   "ready <wait-id>",
 		Short: "Manually mark a wait ready",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOutput {
+				if cmdWaitSetState(args[0], waitStateReady, io.Discard, stderr) != 0 {
+					return errExit
+				}
+				return writeManagementActionJSON(stdout, managementActionResult{
+					Command: commandName("wait", "ready"),
+					Action:  "ready",
+					Name:    args[0],
+					State:   waitStateReady,
+				})
+			}
 			if cmdWaitSetState(args[0], waitStateReady, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
+	return cmd
 }
 
 func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep bool, stdout, stderr io.Writer) int {

--- a/cmd/gc/doctor_warmup_eligible.go
+++ b/cmd/gc/doctor_warmup_eligible.go
@@ -18,6 +18,10 @@ func (c *importStateDoctorCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *jsonlArchiveDoctorCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (*mcpConfigDoctorCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the

--- a/cmd/gc/doctor_warmup_test.go
+++ b/cmd/gc/doctor_warmup_test.go
@@ -13,6 +13,7 @@ func TestCommandDoctorChecksWarmupEligibleDefaultsFalse(t *testing.T) {
 		&doltDriftCheck{},
 		&doltTopologyCheck{},
 		&importStateDoctorCheck{},
+		&jsonlArchiveDoctorCheck{},
 		&mcpConfigDoctorCheck{},
 		&mcpSharedTargetDoctorCheck{},
 		&sessionModelDoctorCheck{},

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -148,6 +148,11 @@ func TestMaterializeBuiltinPacks(t *testing.T) {
 		t.Errorf("dolt assets/scripts/runtime.sh not executable: mode %v", info.Mode())
 	}
 
+	healthSchema := filepath.Join(cmds, "health", "schemas", "result.schema.json")
+	if _, err := os.Stat(healthSchema); err != nil {
+		t.Errorf("dolt command health result schema missing: %v", err)
+	}
+
 	// Verify formulas exist.
 	formulasDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "formulas")
 	if _, err := os.Stat(formulasDir); err != nil {

--- a/cmd/gc/json_schema.go
+++ b/cmd/gc/json_schema.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	gascity "github.com/gastownhall/gascity"
+	"github.com/spf13/cobra"
+)
+
+const (
+	jsonSchemaDirAnnotation = "gc.json.schema_dir"
+	jsonSchemaManifestRole  = "manifest"
+	jsonSchemaResultRole    = "result"
+	jsonSchemaFailureRole   = "failure"
+)
+
+type jsonSchemaManifest struct {
+	SchemaVersion string                     `json:"schema_version"`
+	Command       []string                   `json:"command"`
+	Transport     string                     `json:"transport"`
+	JSONSupported bool                       `json:"json_supported"`
+	Schemas       map[string]json.RawMessage `json:"schemas"`
+}
+
+type jsonSchemaErrorPayload struct {
+	SchemaVersion string                `json:"schema_version"`
+	OK            bool                  `json:"ok"`
+	Error         jsonSchemaErrorDetail `json:"error"`
+}
+
+type jsonSchemaErrorDetail struct {
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+	ExitCode int    `json:"exit_code"`
+}
+
+func configureJSONSchemaFlag(root *cobra.Command) {
+	root.PersistentFlags().String("json-schema", "", "emit JSON Schema for this command; optional value: result or failure")
+	if flag := root.PersistentFlags().Lookup("json-schema"); flag != nil {
+		flag.NoOptDefVal = jsonSchemaManifestRole
+	}
+}
+
+func handleJSONSchemaRequest(root *cobra.Command, args []string, stdout io.Writer) (bool, int) {
+	request, ok := parseJSONSchemaRequest(args)
+	if !ok {
+		return false, 0
+	}
+
+	cmd, _, err := root.Find(request.commandArgs)
+	if err != nil || cmd == nil {
+		return true, writeJSONSchemaUnavailable(stdout, "json_schema_command_not_found",
+			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
+	}
+	if cmd == root && len(request.commandArgs) > 0 {
+		return true, writeJSONSchemaUnavailable(stdout, "json_schema_command_not_found",
+			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
+	}
+
+	commandPath := commandPathWords(cmd)
+	if request.role == "" || request.role == jsonSchemaManifestRole {
+		if err := writeJSONSchemaManifest(stdout, cmd, commandPath); err != nil {
+			return true, 1
+		}
+		return true, 0
+	}
+
+	schema, err := schemaForRole(cmd, commandPath, request.role)
+	if err != nil {
+		return true, writeJSONSchemaUnavailable(stdout, "json_schema_unavailable", err.Error())
+	}
+	if err := writeRawJSONLine(stdout, schema); err != nil {
+		return true, 1
+	}
+	return true, 0
+}
+
+type jsonSchemaRequest struct {
+	role        string
+	commandArgs []string
+}
+
+func parseJSONSchemaRequest(args []string) (jsonSchemaRequest, bool) {
+	var request jsonSchemaRequest
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			request.commandArgs = append(request.commandArgs, args[i:]...)
+			break
+		}
+		switch {
+		case arg == "--json-schema":
+			request.role = jsonSchemaManifestRole
+			if i+1 < len(args) && isJSONSchemaRole(args[i+1]) {
+				request.role = args[i+1]
+				i++
+			}
+		case strings.HasPrefix(arg, "--json-schema="):
+			request.role = strings.TrimPrefix(arg, "--json-schema=")
+			if request.role == "" {
+				request.role = jsonSchemaManifestRole
+			}
+		case arg == "--city" || arg == "--rig":
+			i++
+		case strings.HasPrefix(arg, "--city=") || strings.HasPrefix(arg, "--rig="):
+			continue
+		default:
+			request.commandArgs = append(request.commandArgs, arg)
+		}
+	}
+	if request.role == "" {
+		return jsonSchemaRequest{}, false
+	}
+	return request, true
+}
+
+func isJSONSchemaRole(value string) bool {
+	return value == jsonSchemaManifestRole || value == jsonSchemaResultRole || value == jsonSchemaFailureRole
+}
+
+func commandPathWords(cmd *cobra.Command) []string {
+	var reversed []string
+	for c := cmd; c != nil && c.HasParent(); c = c.Parent() {
+		reversed = append(reversed, c.Name())
+	}
+	slices.Reverse(reversed)
+	return reversed
+}
+
+func writeJSONSchemaManifest(stdout io.Writer, cmd *cobra.Command, commandPath []string) error {
+	schemas := map[string]json.RawMessage{}
+	resultSchema, resultErr := readCommandSchema(cmd, commandPath, jsonSchemaResultRole)
+	if resultErr == nil {
+		schemas[jsonSchemaResultRole] = resultSchema
+		if failureSchema, err := schemaForRole(cmd, commandPath, jsonSchemaFailureRole); err == nil {
+			schemas[jsonSchemaFailureRole] = failureSchema
+		}
+	}
+
+	return writeCLIJSONLine(stdout, jsonSchemaManifest{
+		SchemaVersion: "1",
+		Command:       commandPath,
+		Transport:     "jsonl",
+		JSONSupported: resultErr == nil,
+		Schemas:       schemas,
+	})
+}
+
+func schemaForRole(cmd *cobra.Command, commandPath []string, role string) (json.RawMessage, error) {
+	if role != jsonSchemaResultRole && role != jsonSchemaFailureRole {
+		return nil, fmt.Errorf("unsupported schema role %q", role)
+	}
+	if _, err := readCommandSchema(cmd, commandPath, jsonSchemaResultRole); err != nil {
+		return nil, fmt.Errorf("command %q does not declare JSON support", strings.Join(commandPath, " "))
+	}
+	if role == jsonSchemaFailureRole {
+		if schema, err := readCommandSchema(cmd, commandPath, jsonSchemaFailureRole); err == nil {
+			return schema, nil
+		}
+		return readSharedFailureSchema()
+	}
+	return readCommandSchema(cmd, commandPath, role)
+}
+
+func readCommandSchema(cmd *cobra.Command, commandPath []string, role string) (json.RawMessage, error) {
+	if cmd != nil {
+		if schemaDir := strings.TrimSpace(cmd.Annotations[jsonSchemaDirAnnotation]); schemaDir != "" {
+			return readLocalSchema(filepath.Join(schemaDir, role+".schema.json"))
+		}
+	}
+	return readBuiltinSchema(commandPath, role)
+}
+
+func readBuiltinSchema(commandPath []string, role string) (json.RawMessage, error) {
+	if len(commandPath) == 0 {
+		return nil, fmt.Errorf("root command does not declare JSON support")
+	}
+	parts := append([]string{"schemas"}, commandPath...)
+	parts = append(parts, role+".schema.json")
+	return readEmbeddedSchema(filepath.ToSlash(filepath.Join(parts...)))
+}
+
+func readSharedFailureSchema() (json.RawMessage, error) {
+	return readEmbeddedSchema("schemas/failure.schema.json")
+}
+
+func readLocalSchema(path string) (json.RawMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("%s is not valid JSON", path)
+	}
+	return json.RawMessage(data), nil
+}
+
+func readEmbeddedSchema(path string) (json.RawMessage, error) {
+	data, err := gascity.BuiltinSchemas.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("%s is not valid JSON", path)
+	}
+	return json.RawMessage(data), nil
+}
+
+func writeJSONSchemaUnavailable(stdout io.Writer, code, message string) int {
+	const exitCode = 1
+	_ = writeCLIJSONLine(stdout, jsonSchemaErrorPayload{
+		SchemaVersion: "1",
+		OK:            false,
+		Error: jsonSchemaErrorDetail{
+			Code:     code,
+			Message:  message,
+			ExitCode: exitCode,
+		},
+	})
+	return exitCode
+}
+
+func writeCLIJSONLine(stdout io.Writer, value any) error {
+	enc := json.NewEncoder(stdout)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(value)
+}
+
+func writeRawJSONLine(stdout io.Writer, raw json.RawMessage) error {
+	_, err := stdout.Write(raw)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(stdout, "\n")
+	return err
+}

--- a/cmd/gc/json_schema.go
+++ b/cmd/gc/json_schema.go
@@ -81,9 +81,80 @@ func handleJSONSchemaRequest(root *cobra.Command, args []string, stdout io.Write
 	return true, 0
 }
 
+func handleJSONContractRequest(root *cobra.Command, args []string, stdout io.Writer) (bool, int) {
+	request, ok := parseJSONRequest(args)
+	if !ok {
+		return false, 0
+	}
+
+	cmd, _, err := root.Find(request.commandArgs)
+	if err != nil || cmd == nil {
+		return true, writeJSONSchemaUnavailable(stdout, "json_command_not_found",
+			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
+	}
+	if cmd == root && len(request.commandArgs) > 0 {
+		return true, writeJSONSchemaUnavailable(stdout, "json_command_not_found",
+			fmt.Sprintf("command %q was not found", strings.Join(request.commandArgs, " ")))
+	}
+
+	commandPath := commandPathWords(cmd)
+	if len(commandPath) > 0 && commandPath[0] == "bd" {
+		return false, 0
+	}
+	if _, err := readCommandSchema(cmd, commandPath, jsonSchemaResultRole); err != nil {
+		return true, writeJSONSchemaUnavailable(stdout, "json_unsupported",
+			fmt.Sprintf("command %q does not declare JSON support", strings.Join(commandPath, " ")))
+	}
+	return false, 0
+}
+
+func shouldBufferJSONExecution(args []string) bool {
+	request, ok := parseJSONRequest(args)
+	if !ok {
+		return false
+	}
+	return len(request.commandArgs) == 0 || request.commandArgs[0] != "bd"
+}
+
 type jsonSchemaRequest struct {
 	role        string
 	commandArgs []string
+}
+
+type jsonRequest struct {
+	commandArgs []string
+}
+
+func parseJSONRequest(args []string) (jsonRequest, bool) {
+	var request jsonRequest
+	jsonRequested := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		switch {
+		case arg == "--json":
+			jsonRequested = true
+		case strings.HasPrefix(arg, "--json="):
+			value := strings.TrimPrefix(arg, "--json=")
+			jsonRequested = value == "" || value == "true" || value == "1"
+		case arg == "--city" || arg == "--rig":
+			i++
+		case strings.HasPrefix(arg, "--city=") || strings.HasPrefix(arg, "--rig="):
+			continue
+		case strings.HasPrefix(arg, "-"):
+			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				i++
+			}
+		default:
+			request.commandArgs = append(request.commandArgs, arg)
+		}
+	}
+	if !jsonRequested {
+		return jsonRequest{}, false
+	}
+	return request, true
 }
 
 func parseJSONSchemaRequest(args []string) (jsonSchemaRequest, bool) {
@@ -214,7 +285,12 @@ func readEmbeddedSchema(path string) (json.RawMessage, error) {
 
 func writeJSONSchemaUnavailable(stdout io.Writer, code, message string) int {
 	const exitCode = 1
-	_ = writeCLIJSONLine(stdout, jsonSchemaErrorPayload{
+	_ = writeJSONFailure(stdout, code, message, exitCode)
+	return exitCode
+}
+
+func writeJSONFailure(stdout io.Writer, code, message string, exitCode int) error {
+	return writeCLIJSONLine(stdout, jsonSchemaErrorPayload{
 		SchemaVersion: "1",
 		OK:            false,
 		Error: jsonSchemaErrorDetail{
@@ -223,7 +299,6 @@ func writeJSONSchemaUnavailable(stdout io.Writer, code, message string) int {
 			ExitCode: exitCode,
 		},
 	})
-	return exitCode
 }
 
 func writeCLIJSONLine(stdout io.Writer, value any) error {

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestJSONSchemaManifestForSupportedCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"events", "--json-schema"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(events --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var manifest struct {
+		SchemaVersion string                     `json:"schema_version"`
+		Command       []string                   `json:"command"`
+		Transport     string                     `json:"transport"`
+		JSONSupported bool                       `json:"json_supported"`
+		Schemas       map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+	}
+	if manifest.SchemaVersion != "1" || manifest.Transport != "jsonl" || !manifest.JSONSupported {
+		t.Fatalf("manifest metadata = %+v", manifest)
+	}
+	if got := strings.Join(manifest.Command, " "); got != "events" {
+		t.Fatalf("command = %q, want events", got)
+	}
+	if !json.Valid(manifest.Schemas["result"]) {
+		t.Fatalf("result schema missing or invalid: %s", manifest.Schemas["result"])
+	}
+	if !json.Valid(manifest.Schemas["failure"]) {
+		t.Fatalf("failure schema missing or invalid: %s", manifest.Schemas["failure"])
+	}
+}
+
+func TestJSONSchemaManifestForUnsupportedCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--json-schema"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(version --json-schema) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var manifest struct {
+		Command       []string                   `json:"command"`
+		JSONSupported bool                       `json:"json_supported"`
+		Schemas       map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got := strings.Join(manifest.Command, " "); got != "version" {
+		t.Fatalf("command = %q, want version", got)
+	}
+	if manifest.JSONSupported {
+		t.Fatalf("json_supported = true, want false")
+	}
+	if len(manifest.Schemas) != 0 {
+		t.Fatalf("schemas = %+v, want empty", manifest.Schemas)
+	}
+}
+
+func TestJSONSchemaRoleSpecificResult(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", "/tmp/example-city", "events", "--json-schema=result"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(events --json-schema=result) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+		t.Fatalf("result schema is not JSON: %v\n%s", err, stdout.String())
+	}
+	if schema["$schema"] == "" {
+		t.Fatalf("schema missing $schema: %+v", schema)
+	}
+	if _, ok := schema["x-gc-jsonl"].(map[string]any); !ok {
+		t.Fatalf("schema missing x-gc-jsonl object: %+v", schema)
+	}
+}
+
+func TestJSONSchemaRoleSpecificFailureUsesSharedDefault(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"events", "--json-schema", "failure"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(events --json-schema failure) = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var schema struct {
+		Required             []string `json:"required"`
+		AdditionalProperties bool     `json:"additionalProperties"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+		t.Fatalf("failure schema is not JSON: %v\n%s", err, stdout.String())
+	}
+	if !schema.AdditionalProperties {
+		t.Fatalf("additionalProperties = false, want true")
+	}
+	if strings.Join(schema.Required, ",") != "schema_version,ok,error" {
+		t.Fatalf("required = %v", schema.Required)
+	}
+}
+
+func TestJSONSchemaUnavailableRoleFailureIsStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--json-schema=result"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run(version --json-schema=result) = 0, want nonzero")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		OK            bool   `json:"ok"`
+		Error         struct {
+			Code     string `json:"code"`
+			Message  string `json:"message"`
+			ExitCode int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("failure payload is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.OK || payload.Error.ExitCode != code || payload.Error.Code == "" {
+		t.Fatalf("payload = %+v, code=%d", payload, code)
+	}
+}
+
+func TestJSONSchemaManifestForDiscoveredPackCommand(t *testing.T) {
+	dir := t.TempDir()
+	commandDir := filepath.Join(dir, "commands", "review", "pr")
+	if err := os.MkdirAll(filepath.Join(commandDir, "schemas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commandDir, "schemas", "result.schema.json"), []byte(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": { "ok": { "type": "boolean" } },
+  "required": ["ok"]
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := &cobra.Command{Use: "gc"}
+	configureJSONSchemaFlag(root)
+	var stdout, stderr bytes.Buffer
+	addDiscoveredCommandsToRoot(root, []config.DiscoveredCommand{{
+		Command:     []string{"review", "pr"},
+		Description: "Review a PR",
+		SourceDir:   commandDir,
+		PackDir:     dir,
+		PackName:    "tools",
+		BindingName: "tools",
+	}}, dir, "testcity", &stdout, &stderr, true)
+
+	handled, code := handleJSONSchemaRequest(root, []string{"tools", "review", "pr", "--json-schema"}, &stdout)
+	if !handled || code != 0 {
+		t.Fatalf("handled=%v code=%d stderr=%q stdout=%q", handled, code, stderr.String(), stdout.String())
+	}
+
+	var manifest struct {
+		Command       []string                   `json:"command"`
+		JSONSupported bool                       `json:"json_supported"`
+		Schemas       map[string]json.RawMessage `json:"schemas"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatalf("manifest is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got := strings.Join(manifest.Command, " "); got != "tools review pr" {
+		t.Fatalf("command = %q, want tools review pr", got)
+	}
+	if !manifest.JSONSupported || !json.Valid(manifest.Schemas["result"]) || !json.Valid(manifest.Schemas["failure"]) {
+		t.Fatalf("manifest = %+v", manifest)
+	}
+}

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -153,6 +153,69 @@ func TestJSONSchemaUnavailableRoleFailureIsStructured(t *testing.T) {
 	}
 }
 
+func TestJSONUnsupportedCommandFailureIsStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--json"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run(version --json) = 0, want nonzero")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		OK            bool   `json:"ok"`
+		Error         struct {
+			Code     string `json:"code"`
+			Message  string `json:"message"`
+			ExitCode int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("failure payload is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.OK || payload.Error.ExitCode != code || payload.Error.Code != "json_unsupported" {
+		t.Fatalf("payload = %+v, code=%d", payload, code)
+	}
+}
+
+func TestJSONContractAllowsBdPassthrough(t *testing.T) {
+	root := &cobra.Command{Use: "gc"}
+	root.AddCommand(&cobra.Command{Use: "bd [bd-args...]"})
+
+	var stdout bytes.Buffer
+	handled, code := handleJSONContractRequest(root, []string{"bd", "list", "--json"}, &stdout)
+	if handled || code != 0 {
+		t.Fatalf("handled=%v code=%d stdout=%q", handled, code, stdout.String())
+	}
+}
+
+func TestJSONExecutionFailureIsStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"config", "explain", "--json"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run(config explain --json) = 0, want nonzero")
+	}
+	if stderr.Len() == 0 {
+		t.Fatalf("stderr empty, want command diagnostics")
+	}
+
+	var payload struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Code     string `json:"code"`
+			ExitCode int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("failure payload is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.OK || payload.Error.Code != "command_failed" || payload.Error.ExitCode != code {
+		t.Fatalf("payload = %+v, code=%d", payload, code)
+	}
+}
+
 func TestJSONSchemaManifestForDiscoveredPackCommand(t *testing.T) {
 	dir := t.TempDir()
 	commandDir := filepath.Join(dir, "commands", "review", "pr")

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -114,6 +114,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
+	if handled, code := handleJSONSchemaRequest(root, args, stdout); handled {
+		return code
+	}
 	if err := root.Execute(); err != nil {
 		return commandExitCode(err)
 	}
@@ -150,6 +153,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		"path to the city directory (default: walk up from cwd)")
 	root.PersistentFlags().StringVar(&rigFlag, "rig", "",
 		"rig name or path (default: discover from cwd)")
+	configureJSONSchemaFlag(root)
 	_ = root.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
 	root.AddCommand(
 		newStartCmd(stdout, stderr),

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -107,18 +108,37 @@ func run(args []string, stdout, stderr io.Writer) int {
 		telemetry.SetProcessOTELAttrs()
 	}
 
-	root := newRootCmd(stdout, stderr)
+	jsonExecution := shouldBufferJSONExecution(args)
+	execStdout := stdout
+	var jsonStdout bytes.Buffer
+	if jsonExecution {
+		execStdout = &jsonStdout
+	}
+
+	root := newRootCmd(execStdout, stderr)
 	if args == nil {
 		args = []string{}
 	}
 	root.SetArgs(args)
-	root.SetOut(stdout)
+	root.SetOut(execStdout)
 	root.SetErr(stderr)
 	if handled, code := handleJSONSchemaRequest(root, args, stdout); handled {
 		return code
 	}
+	if handled, code := handleJSONContractRequest(root, args, stdout); handled {
+		return code
+	}
 	if err := root.Execute(); err != nil {
-		return commandExitCode(err)
+		code := commandExitCode(err)
+		if jsonExecution {
+			_ = writeJSONFailure(stdout, "command_failed", "command failed; see stderr for diagnostics", code)
+		}
+		return code
+	}
+	if jsonExecution {
+		if _, err := io.Copy(stdout, &jsonStdout); err != nil {
+			return 1
+		}
 	}
 	return 0
 }

--- a/cmd/gc/management_json.go
+++ b/cmd/gc/management_json.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 type managementActionResult struct {
@@ -22,7 +21,10 @@ type managementActionResult struct {
 	DefaultBranch string           `json:"default_branch,omitempty"`
 	Suspended     *bool            `json:"suspended,omitempty"`
 	State         string           `json:"state,omitempty"`
-	DryRun        bool             `json:"dry_run,omitempty"`
+	Retried       *bool            `json:"retried,omitempty"`
+	RetriedFrom   string           `json:"retried_from_wait,omitempty"`
+	ReadyWaitID   string           `json:"ready_wait_id,omitempty"`
+	DryRun        *bool            `json:"dry_run,omitempty"`
 	Endpoint      *rigEndpointJSON `json:"endpoint,omitempty"`
 }
 
@@ -64,29 +66,24 @@ func agentJSONName(input, dir string) (name, qualified string) {
 	return name, qualified
 }
 
-func rigAddJSONSummary(cityPath, rigPath, nameOverride, prefixOverride string) managementActionResult {
-	name := strings.TrimSpace(nameOverride)
+func agentJSONIdentity(cityPath, input string) (name, qualified string) {
+	return agentJSONName(resolveAgentForAPI(cityPath, input), "")
+}
+
+func rigAddJSONSummary(rigPath string, rig config.Rig) managementActionResult {
+	name := strings.TrimSpace(rig.Name)
 	if name == "" {
 		name = filepath.Base(rigPath)
 	}
 	result := managementActionResult{
-		Command: commandName("rig", "add"),
-		Action:  "add",
-		Name:    name,
-		Rig:     name,
-		Path:    rigPath,
-		Prefix:  strings.ToLower(strings.TrimSpace(prefixOverride)),
-	}
-	if cfg, err := loadCityConfigForEditFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); err == nil {
-		for _, rig := range cfg.Rigs {
-			if rig.Name != name {
-				continue
-			}
-			result.Prefix = rig.EffectivePrefix()
-			result.DefaultBranch = rig.EffectiveDefaultBranch()
-			result.Suspended = managementBoolPtr(rig.Suspended)
-			break
-		}
+		Command:       commandName("rig", "add"),
+		Action:        "add",
+		Name:          name,
+		Rig:           name,
+		Path:          rigPath,
+		Prefix:        rig.EffectivePrefix(),
+		DefaultBranch: rig.EffectiveDefaultBranch(),
+		Suspended:     managementBoolPtr(rig.Suspended),
 	}
 	if result.Prefix == "" {
 		result.Prefix = config.DeriveBeadsPrefix(name)

--- a/cmd/gc/management_json.go
+++ b/cmd/gc/management_json.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+type managementActionResult struct {
+	SchemaVersion string           `json:"schema_version"`
+	OK            bool             `json:"ok"`
+	Command       string           `json:"command"`
+	Action        string           `json:"action"`
+	Name          string           `json:"name,omitempty"`
+	QualifiedName string           `json:"qualified_name,omitempty"`
+	Rig           string           `json:"rig,omitempty"`
+	Path          string           `json:"path,omitempty"`
+	Prefix        string           `json:"prefix,omitempty"`
+	DefaultBranch string           `json:"default_branch,omitempty"`
+	Suspended     *bool            `json:"suspended,omitempty"`
+	State         string           `json:"state,omitempty"`
+	DryRun        bool             `json:"dry_run,omitempty"`
+	Endpoint      *rigEndpointJSON `json:"endpoint,omitempty"`
+}
+
+type rigEndpointJSON struct {
+	Mode            string `json:"mode"`
+	Host            string `json:"host,omitempty"`
+	Port            string `json:"port,omitempty"`
+	User            string `json:"user,omitempty"`
+	AdoptUnverified bool   `json:"adopt_unverified,omitempty"`
+}
+
+func writeManagementActionJSON(stdout io.Writer, result managementActionResult) error {
+	result.SchemaVersion = "1"
+	result.OK = true
+	return writeCLIJSONLine(stdout, result)
+}
+
+func managementBoolPtr(v bool) *bool {
+	return &v
+}
+
+func commandName(parts ...string) string {
+	return strings.Join(parts, " ")
+}
+
+func agentJSONName(input, dir string) (name, qualified string) {
+	inputDir, inputName := config.ParseQualifiedName(input)
+	if inputDir != "" {
+		dir = inputDir
+		name = inputName
+	} else {
+		name = input
+	}
+	if strings.TrimSpace(dir) != "" {
+		qualified = dir + "/" + name
+	} else {
+		qualified = name
+	}
+	return name, qualified
+}
+
+func rigAddJSONSummary(cityPath, rigPath, nameOverride, prefixOverride string) managementActionResult {
+	name := strings.TrimSpace(nameOverride)
+	if name == "" {
+		name = filepath.Base(rigPath)
+	}
+	result := managementActionResult{
+		Command: commandName("rig", "add"),
+		Action:  "add",
+		Name:    name,
+		Rig:     name,
+		Path:    rigPath,
+		Prefix:  strings.ToLower(strings.TrimSpace(prefixOverride)),
+	}
+	if cfg, err := loadCityConfigForEditFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); err == nil {
+		for _, rig := range cfg.Rigs {
+			if rig.Name != name {
+				continue
+			}
+			result.Prefix = rig.EffectivePrefix()
+			result.DefaultBranch = rig.EffectiveDefaultBranch()
+			result.Suspended = managementBoolPtr(rig.Suspended)
+			break
+		}
+	}
+	if result.Prefix == "" {
+		result.Prefix = config.DeriveBeadsPrefix(name)
+	}
+	return result
+}
+
+func rigEndpointJSONFromOptions(opts rigEndpointOptions) *rigEndpointJSON {
+	endpoint := &rigEndpointJSON{AdoptUnverified: opts.AdoptUnverified}
+	switch {
+	case opts.Inherit:
+		endpoint.Mode = "inherit"
+	case opts.Self:
+		endpoint.Mode = "self"
+		endpoint.Host = "127.0.0.1"
+		endpoint.Port = strings.TrimSpace(opts.Port)
+	case opts.External:
+		endpoint.Mode = "external"
+		endpoint.Host = strings.TrimSpace(opts.Host)
+		endpoint.Port = strings.TrimSpace(opts.Port)
+		endpoint.User = strings.TrimSpace(opts.User)
+	}
+	return endpoint
+}

--- a/cmd/gc/management_json_test.go
+++ b/cmd/gc/management_json_test.go
@@ -3,10 +3,18 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 func writeManagementJSONTestCity(t *testing.T, cityPath string, body string) {
@@ -31,6 +39,50 @@ func decodeOneJSONLine(t *testing.T, stdout *bytes.Buffer) map[string]any {
 	return payload
 }
 
+func validateManagementJSONPayload(t *testing.T, command []string, stdout *bytes.Buffer) map[string]any {
+	t.Helper()
+	payload := decodeOneJSONLine(t, stdout)
+	schemaRaw, err := readBuiltinSchema(command, jsonSchemaResultRole)
+	if err != nil {
+		t.Fatalf("read schema for %v: %v", command, err)
+	}
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaRaw))
+	if err != nil {
+		t.Fatalf("parse schema for %v: %v", command, err)
+	}
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Fatalf("parse payload for %v: %v\n%s", command, err, stdout.String())
+	}
+	compiler := jsonschema.NewCompiler()
+	schemaURL := strings.Join(command, "/") + "/result.schema.json"
+	if err := compiler.AddResource(schemaURL, schemaDoc); err != nil {
+		t.Fatalf("add schema resource for %v: %v", command, err)
+	}
+	compiled, err := compiler.Compile(schemaURL)
+	if err != nil {
+		t.Fatalf("compile schema for %v: %v", command, err)
+	}
+	if err := compiled.Validate(instance); err != nil {
+		t.Fatalf("payload for %v does not validate: %v\n%s", command, err, stdout.String())
+	}
+	return payload
+}
+
+func runManagementJSONPayload(t *testing.T, cityPath string, args ...string) map[string]any {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := run(append([]string{"--city", cityPath}, args...), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run %v = %d; stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+	}
+	if len(args) < 2 {
+		t.Fatalf("management JSON command needs at least two command words: %v", args)
+	}
+	command := args[:2]
+	return validateManagementJSONPayload(t, command, &stdout)
+}
+
 func TestAgentAddJSONEmitsOnlySummary(t *testing.T) {
 	clearGCEnv(t)
 	cityPath := t.TempDir()
@@ -47,6 +99,201 @@ func TestAgentAddJSONEmitsOnlySummary(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "Scaffolded agent") {
 		t.Fatalf("stdout contains human text: %q", stdout.String())
+	}
+}
+
+func TestManagementJSONSuccessPayloadsValidateDeclaredSchemas(t *testing.T) {
+	type testCase struct {
+		name  string
+		setup func(t *testing.T) (cityPath string, args []string)
+		check func(t *testing.T, payload map[string]any)
+	}
+	tests := []testCase{
+		{
+			name: "agent add",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := t.TempDir()
+				writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+				return cityPath, []string{"agent", "add", "--name", "worker", "--json"}
+			},
+		},
+		{
+			name: "agent suspend",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONAgentCity(t, false)
+				return cityPath, []string{"agent", "suspend", "frontend/worker", "--json"}
+			},
+		},
+		{
+			name: "agent resume",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONAgentCity(t, true)
+				return cityPath, []string{"agent", "resume", "frontend/worker", "--json"}
+			},
+		},
+		{
+			name: "rig add",
+			setup: func(t *testing.T) (string, []string) {
+				t.Setenv("GC_DOLT", "skip")
+				t.Setenv("GC_BEADS", "bd")
+				cityPath := t.TempDir()
+				writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+				return cityPath, []string{"rig", "add", filepath.Join(t.TempDir(), "frontend"), "--prefix", "fe", "--json"}
+			},
+		},
+		{
+			name: "rig suspend",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONRigCity(t)
+				return cityPath, []string{"rig", "suspend", "frontend", "--json"}
+			},
+		},
+		{
+			name: "rig resume",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONRigCity(t)
+				return cityPath, []string{"rig", "resume", "frontend", "--json"}
+			},
+		},
+		{
+			name: "rig remove",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONRigCity(t)
+				return cityPath, []string{"rig", "remove", "frontend", "--json"}
+			},
+		},
+		{
+			name: "rig set-endpoint",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONRigEndpointCity(t)
+				return cityPath, []string{"rig", "set-endpoint", "frontend", "--self", "--port", "28232", "--force", "--json"}
+			},
+			check: func(t *testing.T, payload map[string]any) {
+				if got, ok := payload["dry_run"].(bool); !ok || got {
+					t.Fatalf("dry_run = %#v, want false", payload["dry_run"])
+				}
+			},
+		},
+		{
+			name: "wait cancel",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath, waitID := writeManagementJSONWaitCity(t, waitStatePending)
+				return cityPath, []string{"wait", "cancel", waitID, "--json"}
+			},
+		},
+		{
+			name: "wait ready",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath, waitID := writeManagementJSONWaitCity(t, waitStatePending)
+				return cityPath, []string{"wait", "ready", waitID, "--json"}
+			},
+		},
+		{
+			name: "service restart",
+			setup: func(t *testing.T) (string, []string) {
+				cityPath := writeManagementJSONServiceCity(t)
+				return cityPath, []string{"service", "restart", "review-intake", "--json"}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearGCEnv(t)
+			cityPath, args := tt.setup(t)
+			payload := runManagementJSONPayload(t, cityPath, args...)
+			if tt.check != nil {
+				tt.check(t, payload)
+			}
+		})
+	}
+}
+
+func TestAgentSuspendResumeJSONReportsResolvedIdentity(t *testing.T) {
+	tests := []struct {
+		name             string
+		action           string
+		input            string
+		initialSuspended bool
+		chdirRig         bool
+		wantName         string
+		wantQualified    string
+	}{
+		{
+			name:          "qualified input keeps leaf name",
+			action:        "suspend",
+			input:         "frontend/worker",
+			wantName:      "worker",
+			wantQualified: "frontend/worker",
+		},
+		{
+			name:             "bare input with rig context qualifies",
+			action:           "resume",
+			input:            "worker",
+			initialSuspended: true,
+			chdirRig:         true,
+			wantName:         "worker",
+			wantQualified:    "frontend/worker",
+		},
+		{
+			name:             "unqualified city agent remains city scoped",
+			action:           "resume",
+			input:            "citywide",
+			initialSuspended: true,
+			wantName:         "citywide",
+			wantQualified:    "citywide",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearGCEnv(t)
+			cityPath := writeManagementJSONAgentCity(t, tt.initialSuspended)
+			if tt.chdirRig {
+				t.Chdir(filepath.Join(cityPath, "frontend"))
+			}
+			payload := runManagementJSONPayload(t, cityPath, "agent", tt.action, tt.input, "--json")
+			if payload["name"] != tt.wantName || payload["qualified_name"] != tt.wantQualified {
+				t.Fatalf("identity = (%#v, %#v), want (%q, %q): %+v",
+					payload["name"], payload["qualified_name"], tt.wantName, tt.wantQualified, payload)
+			}
+		})
+	}
+}
+
+func TestWaitReadyJSONReportsClosedWaitRetryIdentity(t *testing.T) {
+	clearGCEnv(t)
+	cityPath, waitID := writeManagementJSONWaitCity(t, waitStateCanceled)
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	if err := store.Close(waitID); err != nil {
+		t.Fatalf("close wait: %v", err)
+	}
+
+	payload := runManagementJSONPayload(t, cityPath, "wait", "ready", waitID, "--json")
+	if payload["retried"] != true {
+		t.Fatalf("retried = %#v, want true: %+v", payload["retried"], payload)
+	}
+	replacement, ok := payload["ready_wait_id"].(string)
+	if !ok || replacement == "" || replacement == waitID {
+		t.Fatalf("ready_wait_id = %#v, want replacement different from %q: %+v", payload["ready_wait_id"], waitID, payload)
+	}
+	if payload["name"] != replacement {
+		t.Fatalf("name = %#v, want replacement %q: %+v", payload["name"], replacement, payload)
+	}
+	original, err := store.Get(waitID)
+	if err != nil {
+		t.Fatalf("get original wait: %v", err)
+	}
+	if original.Status != "closed" {
+		t.Fatalf("original status = %q, want closed", original.Status)
+	}
+	created, err := store.Get(replacement)
+	if err != nil {
+		t.Fatalf("get replacement wait %q: %v", replacement, err)
+	}
+	if created.Metadata["state"] != waitStateReady || created.Metadata["retried_from_wait"] != waitID {
+		t.Fatalf("replacement metadata = %+v", created.Metadata)
 	}
 }
 
@@ -82,6 +329,145 @@ func TestRigSuspendResumeRemoveJSONEmitOnlySummaries(t *testing.T) {
 			t.Fatalf("%v suspended = %v, want %v", tc.args, payload["suspended"], tc.suspended)
 		}
 	}
+}
+
+func writeManagementJSONAgentCity(t *testing.T, workerSuspended bool) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workerSuspendedLine := ""
+	if workerSuspended {
+		workerSuspendedLine = "suspended = true\n"
+	}
+	writeManagementJSONTestCity(t, cityPath, fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "frontend"
+path = %q
+prefix = "fe"
+
+[[agent]]
+name = "worker"
+dir = "frontend"
+%s
+[[agent]]
+name = "citywide"
+%s`, rigPath, workerSuspendedLine, workerSuspendedLine))
+	return cityPath
+}
+
+func writeManagementJSONRigCity(t *testing.T) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeManagementJSONTestCity(t, cityPath, fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "frontend"
+path = %q
+prefix = "fe"
+`, rigPath))
+	return cityPath
+}
+
+func writeManagementJSONRigEndpointCity(t *testing.T) string {
+	t.Helper()
+	t.Setenv("GC_BEADS", "bd")
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(t.TempDir(), "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRigEndpointCityConfig(t, cityPath, rigPath)
+	writePackToml(t, cityPath, "[pack]\nname = \"test-city\"\nschema = 2\n")
+	writeRigEndpointMetadata(t, cityPath, "hq")
+	writeRigEndpointMetadata(t, rigPath, "fe")
+	writeRigEndpointRuntimeState(t, cityPath, 3311)
+	writeRigEndpointCanonicalConfig(t, rigPath, contract.ConfigState{
+		IssuePrefix:    "fe",
+		EndpointOrigin: contract.EndpointOriginInheritedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "dolt-server.port"), []byte("3311\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	origVerify := verifyRigExternalEndpoint
+	t.Cleanup(func() { verifyRigExternalEndpoint = origVerify })
+	verifyRigExternalEndpoint = func(contract.ConfigState, string, string) error { return nil }
+	return cityPath
+}
+
+func writeManagementJSONWaitCity(t *testing.T, state string) (string, string) {
+	t.Helper()
+	t.Setenv("GC_BEADS", "file")
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+	if err := ensurePersistedScopeLocalFileStore(cityPath); err != nil {
+		t.Fatalf("initialize file store: %v", err)
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	wait, err := store.Create(beads.Bead{
+		Title:       "wait:test-session",
+		Type:        waitBeadType,
+		Description: "test wait",
+		Labels:      []string{waitBeadLabel},
+		Metadata: map[string]string{
+			"session_id":       "",
+			"kind":             "deps",
+			"state":            state,
+			"dep_ids":          "dep-test",
+			"dep_mode":         "all",
+			"delivery_attempt": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+	return cityPath, wait.ID
+}
+
+func writeManagementJSONServiceCity(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v0/city/test-city/service/review-intake/restart" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","action":"restart","service":"review-intake"}`))
+	}))
+	t.Cleanup(server.Close)
+	host, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split test server address: %v", err)
+	}
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[api]
+bind = %q
+port = %s
+
+[[service]]
+name = "review-intake"
+
+[service.workflow]
+contract = "gc.healthz.v1"
+`, host, port))
+	startFakeControllerSocket(t, cityPath, "1234\n")
+	return cityPath
 }
 
 func TestRigAddJSONEmitsOnlySummary(t *testing.T) {

--- a/cmd/gc/management_json_test.go
+++ b/cmd/gc/management_json_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManagementJSONTestCity(t *testing.T, cityPath string, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCityToml(t, cityPath, body)
+	writePackToml(t, cityPath, "[pack]\nname = \"test-city\"\nschema = 2\n")
+}
+
+func decodeOneJSONLine(t *testing.T, stdout *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want 1: %q", len(lines), stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	return payload
+}
+
+func TestAgentAddJSONEmitsOnlySummary(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityPath, "agent", "add", "--name", "worker", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run agent add --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	payload := decodeOneJSONLine(t, &stdout)
+	if payload["schema_version"] != "1" || payload["ok"] != true || payload["command"] != "agent add" || payload["name"] != "worker" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if strings.Contains(stdout.String(), "Scaffolded agent") {
+		t.Fatalf("stdout contains human text: %q", stdout.String())
+	}
+}
+
+func TestRigSuspendResumeRemoveJSONEmitOnlySummaries(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"frontend\"\nprefix = \"fe\"\n")
+
+	for _, tc := range []struct {
+		args      []string
+		command   string
+		action    string
+		suspended any
+	}{
+		{[]string{"rig", "suspend", "frontend", "--json"}, "rig suspend", "suspend", true},
+		{[]string{"rig", "resume", "frontend", "--json"}, "rig resume", "resume", false},
+		{[]string{"rig", "remove", "frontend", "--json"}, "rig remove", "remove", nil},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := run(append([]string{"--city", cityPath}, tc.args...), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run %v = %d; stderr=%q stdout=%q", tc.args, code, stderr.String(), stdout.String())
+		}
+		payload := decodeOneJSONLine(t, &stdout)
+		if payload["schema_version"] != "1" || payload["ok"] != true || payload["command"] != tc.command || payload["action"] != tc.action || payload["rig"] != "frontend" {
+			t.Fatalf("%v payload = %+v", tc.args, payload)
+		}
+		if tc.suspended != nil && payload["suspended"] != tc.suspended {
+			t.Fatalf("%v suspended = %v, want %v", tc.args, payload["suspended"], tc.suspended)
+		}
+	}
+}
+
+func TestRigAddJSONEmitsOnlySummary(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+	rigPath := filepath.Join(t.TempDir(), "frontend")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityPath, "rig", "add", rigPath, "--prefix", "fe", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run rig add --json = %d; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	payload := decodeOneJSONLine(t, &stdout)
+	if payload["schema_version"] != "1" || payload["ok"] != true || payload["command"] != "rig add" || payload["rig"] != "frontend" || payload["prefix"] != "fe" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if strings.Contains(stdout.String(), "Adding rig") || strings.Contains(stdout.String(), "Rig added") {
+		t.Fatalf("stdout contains human text: %q", stdout.String())
+	}
+}
+
+func TestManagementJSONSchemasDeclared(t *testing.T) {
+	commands := [][]string{
+		{"agent", "add"},
+		{"agent", "suspend"},
+		{"agent", "resume"},
+		{"rig", "add"},
+		{"rig", "suspend"},
+		{"rig", "resume"},
+		{"rig", "remove"},
+		{"rig", "set-endpoint"},
+		{"wait", "cancel"},
+		{"wait", "ready"},
+		{"service", "restart"},
+	}
+	for _, command := range commands {
+		args := append(append([]string{}, command...), "--json-schema=result")
+		var stdout, stderr bytes.Buffer
+		code := run(args, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run %v = %d; stderr=%q stdout=%q", args, code, stderr.String(), stdout.String())
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(stdout.Bytes(), &schema); err != nil {
+			t.Fatalf("%v schema is not JSON: %v\n%s", command, err, stdout.String())
+		}
+		if schema["$schema"] == "" {
+			t.Fatalf("%v schema missing $schema: %+v", command, schema)
+		}
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,6 +7,7 @@
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--city` | string |  | path to the city directory (default: walk up from cwd) |
+| `--json-schema` | string |  | emit JSON Schema for this command; optional value: result or failure |
 | `--rig` | string |  | rig name or path (default: discover from cwd) |
 
 ## gc
@@ -114,6 +115,7 @@ gc agent add --name mayor
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--dir` | string |  | Working directory for the agent (relative to city root) |
+| `--json` | bool |  | Output in JSONL format |
 | `--name` | string |  | Name of the agent |
 | `--prompt-template` | string |  | Path to prompt template file (relative to city root) |
 | `--suspended` | bool |  | Register the agent in suspended state |
@@ -126,8 +128,12 @@ The reconciler will start the agent on its next tick. Supports bare
 names (resolved via rig context) and qualified names (e.g. "myrig/worker").
 
 ```
-gc agent resume <name>
+gc agent resume <name> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc agent suspend
 
@@ -138,8 +144,12 @@ started or restarted. Existing sessions continue running but won't be
 replaced if they exit. Use "gc agent resume" to restore.
 
 ```
-gc agent suspend <name>
+gc agent suspend <name> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc analyze
 
@@ -2085,6 +2095,7 @@ gc rig add /path/to/project
 | `--adopt` | bool |  | adopt existing .beads/ directory (skip init) |
 | `--default-branch` | string |  | mainline branch (default: auto-detect from origin/HEAD or current branch) |
 | `--include` | stringArray |  | pack source for rig agents (repeatable; writes canonical rig imports) |
+| `--json` | bool |  | Output in JSONL format |
 | `--name` | string |  | rig name (default: directory basename) |
 | `--prefix` | string |  | bead ID prefix (default: derived from name) |
 | `--start-suspended` | bool |  | add rig in suspended state (dormant-by-default) |
@@ -2113,7 +2124,7 @@ Removes the rig entry from city.toml and removes its machine-local path
 binding from .gc/site.toml.
 
 ```
-gc rig remove <name>
+gc rig remove <name> [flags]
 ```
 
 **Example:**
@@ -2121,6 +2132,10 @@ gc rig remove <name>
 ```
 gc rig remove myrig
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc rig restart
 
@@ -2140,8 +2155,12 @@ Resume a suspended rig by clearing suspended in city.toml.
 The reconciler will start the rig's agents on its next tick.
 
 ```
-gc rig resume [name]
+gc rig resume [name] [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc rig set-endpoint
 
@@ -2178,6 +2197,7 @@ gc rig set-endpoint frontend --inherit
 | `--force` | bool |  | acknowledge conflicting managed-city state when using --self |
 | `--host` | string |  | external Dolt host |
 | `--inherit` | bool |  | inherit the city endpoint |
+| `--json` | bool |  | Output in JSONL format |
 | `--port` | string |  | external Dolt port (required with --external or --self) |
 | `--self` | bool |  | mark the rig as running its own local Dolt on 127.0.0.1 |
 | `--user` | string |  | external Dolt user |
@@ -2199,8 +2219,12 @@ the reconciler skips them and gc hook returns empty. The rig's beads
 database remains accessible. Use "gc rig resume" to restore.
 
 ```
-gc rig suspend [name]
+gc rig suspend [name] [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc runtime
 
@@ -2336,8 +2360,12 @@ The controller closes the current service process and starts a fresh one.
 Useful after updating pack scripts without a full city restart.
 
 ```
-gc service restart <name>
+gc service restart <name> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc session
 
@@ -3142,8 +3170,12 @@ gc wait
 Cancel a wait
 
 ```
-gc wait cancel <wait-id>
+gc wait cancel <wait-id> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |
 
 ## gc wait inspect
 
@@ -3171,5 +3203,9 @@ gc wait list [flags]
 Manually mark a wait ready
 
 ```
-gc wait ready <wait-id>
+gc wait ready <wait-id> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output in JSONL format |

--- a/examples/dolt/commands/health/schemas/result.schema.json
+++ b/examples/dolt/commands/health/schemas/result.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["timestamp", "server", "databases", "backups", "orphans", "processes"],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "server": {
+      "type": "object",
+      "required": ["running", "reachable", "pid", "port", "latency_ms"],
+      "properties": {
+        "running": {
+          "type": "boolean"
+        },
+        "reachable": {
+          "type": "boolean"
+        },
+        "pid": {
+          "type": "integer"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "latency_ms": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true
+    },
+    "databases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "commits", "open_beads"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "commits": {
+            "type": "integer"
+          },
+          "open_beads": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "backups": {
+      "type": "object",
+      "required": ["dolt_freshness", "dolt_age_sec", "dolt_stale"],
+      "properties": {
+        "dolt_freshness": {
+          "type": "string"
+        },
+        "dolt_age_sec": {
+          "type": "integer"
+        },
+        "dolt_stale": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "orphans": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "size"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "processes": {
+      "type": "object",
+      "required": ["zombie_count", "zombie_pids"],
+      "properties": {
+        "zombie_count": {
+          "type": "integer"
+        },
+        "zombie_pids": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pb33f/libopenapi v0.36.1
 	github.com/pb33f/libopenapi-validator v0.13.4
 	github.com/rogpeppe/go-internal v1.14.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -65,7 +66,6 @@ require (
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -68,6 +68,7 @@ func TestCheckWarmupEligibleDefaultsFalse(t *testing.T) {
 		&ImplicitImportCacheCheck{},
 		&NestedWorktreePruneCheck{},
 		&OrphanSessionsCheck{},
+		&OrderFiringCurrentCheck{},
 		&PackCacheCheck{},
 		&PreStartScriptsCheck{},
 		&ProviderParityCheck{},

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -98,6 +98,10 @@ func (c *OrphanSessionsCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *OrderFiringCurrentCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *PackCacheCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the

--- a/schemas/agent/add/result.schema.json
+++ b/schemas/agent/add/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "qualified_name", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "agent add" },
+    "action": { "const": "add" },
+    "name": { "type": "string" },
+    "qualified_name": { "type": "string" },
+    "suspended": { "type": "boolean" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/agent/resume/result.schema.json
+++ b/schemas/agent/resume/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "qualified_name", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "agent resume" },
+    "action": { "const": "resume" },
+    "name": { "type": "string" },
+    "qualified_name": { "type": "string" },
+    "suspended": { "const": false }
+  },
+  "additionalProperties": true
+}

--- a/schemas/agent/suspend/result.schema.json
+++ b/schemas/agent/suspend/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "qualified_name", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "agent suspend" },
+    "action": { "const": "suspend" },
+    "name": { "type": "string" },
+    "qualified_name": { "type": "string" },
+    "suspended": { "const": true }
+  },
+  "additionalProperties": true
+}

--- a/schemas/analyze/reliability/result.schema.json
+++ b/schemas/analyze/reliability/result.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["groups", "total", "skipped", "ambiguous_aliases", "instrumentation"],
+  "properties": {
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["key", "sessions", "crashed", "quarantined", "idle_killed", "drained", "unhealthy_total"],
+        "properties": {
+          "key": { "type": "object", "additionalProperties": true },
+          "sessions": { "type": "integer" },
+          "crashed": { "type": "integer" },
+          "quarantined": { "type": "integer" },
+          "idle_killed": { "type": "integer" },
+          "drained": { "type": "integer" },
+          "unhealthy_total": { "type": "integer" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "total": { "type": "object", "additionalProperties": true },
+    "skipped": { "type": "integer" },
+    "ambiguous_aliases": { "type": "integer" },
+    "instrumentation": { "type": "object", "additionalProperties": true }
+  },
+  "additionalProperties": true
+}

--- a/schemas/config/explain/result.schema.json
+++ b/schemas/config/explain/result.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["name", "chain", "resolved", "provenance"],
+  "properties": {
+    "name": { "type": "string" },
+    "builtin_ancestor": { "type": "string" },
+    "chain": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "name"],
+        "properties": {
+          "kind": { "type": "string" },
+          "name": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "resolved": { "type": "object", "additionalProperties": true },
+    "provenance": {
+      "type": "object",
+      "properties": {
+        "field_layer": { "type": "object", "additionalProperties": { "type": "string" } },
+        "map_key_layer": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/converge/list/result.schema.json
+++ b/schemas/converge/list/result.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "state", "iteration", "gate", "formula", "target", "title"],
+    "properties": {
+      "id": { "type": "string" },
+      "state": { "type": "string" },
+      "iteration": { "type": "string" },
+      "gate": { "type": "string" },
+      "formula": { "type": "string" },
+      "target": { "type": "string" },
+      "title": { "type": "string" }
+    },
+    "additionalProperties": true
+  }
+}

--- a/schemas/converge/status/result.schema.json
+++ b/schemas/converge/status/result.schema.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": { "type": "string" }
+}

--- a/schemas/dolt-cleanup/result.schema.json
+++ b/schemas/dolt-cleanup/result.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema", "port", "rigs_protected", "force_blockers", "dropped", "purge", "reaped", "summary", "errors"],
+  "properties": {
+    "schema": { "const": "gc.dolt.cleanup.v1" },
+    "port": {
+      "type": "object",
+      "required": ["resolved", "source", "fallback"],
+      "properties": {
+        "resolved": { "type": "integer" },
+        "source": { "type": "string" },
+        "fallback": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "rigs_protected": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "force_blockers": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "dropped": { "type": "object", "additionalProperties": true },
+    "purge": { "type": "object", "additionalProperties": true },
+    "reaped": { "type": "object", "additionalProperties": true },
+    "summary": {
+      "type": "object",
+      "required": ["bytes_freed_disk", "bytes_freed_rss", "errors_total"],
+      "properties": {
+        "bytes_freed_disk": { "type": "integer" },
+        "bytes_freed_rss": { "type": "integer" },
+        "errors_total": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "errors": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+  },
+  "additionalProperties": true
+}

--- a/schemas/events/result.schema.json
+++ b/schemas/events/result.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-gc-jsonl": {},
+  "type": "object",
+  "properties": {
+    "actor": {
+      "type": "string"
+    },
+    "city": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    },
+    "payload": true,
+    "seq": {
+      "type": "integer"
+    },
+    "subject": {
+      "type": "string"
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    }
+  },
+  "required": ["actor", "seq", "ts", "type"],
+  "additionalProperties": true
+}

--- a/schemas/failure.schema.json
+++ b/schemas/failure.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "error"],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "ok": {
+      "const": false
+    },
+    "error": {
+      "type": "object",
+      "required": ["code", "message", "exit_code"],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "exit_code": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/add/result.schema.json
+++ b/schemas/rig/add/result.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig", "path", "prefix"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig add" },
+    "action": { "const": "add" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "path": { "type": "string" },
+    "prefix": { "type": "string" },
+    "default_branch": { "type": "string" },
+    "suspended": { "type": "boolean" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/list/result.schema.json
+++ b/schemas/rig/list/result.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["city_path", "city_name", "rigs"],
+  "properties": {
+    "city_path": { "type": "string" },
+    "city_name": { "type": "string" },
+    "rigs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "path", "prefix", "hq", "suspended", "beads"],
+        "properties": {
+          "name": { "type": "string" },
+          "path": { "type": "string" },
+          "prefix": { "type": "string" },
+          "default_branch": { "type": "string" },
+          "hq": { "type": "boolean" },
+          "suspended": { "type": "boolean" },
+          "beads": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/remove/result.schema.json
+++ b/schemas/rig/remove/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig remove" },
+    "action": { "const": "remove" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/resume/result.schema.json
+++ b/schemas/rig/resume/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig resume" },
+    "action": { "const": "resume" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "suspended": { "const": false }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/set-endpoint/result.schema.json
+++ b/schemas/rig/set-endpoint/result.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig", "dry_run", "endpoint"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig set-endpoint" },
+    "action": { "const": "set-endpoint" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "dry_run": { "type": "boolean" },
+    "endpoint": {
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "mode": { "enum": ["inherit", "external", "self"] },
+        "host": { "type": "string" },
+        "port": { "type": "string" },
+        "user": { "type": "string" },
+        "adopt_unverified": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/rig/suspend/result.schema.json
+++ b/schemas/rig/suspend/result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "rig", "suspended"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "rig suspend" },
+    "action": { "const": "suspend" },
+    "name": { "type": "string" },
+    "rig": { "type": "string" },
+    "suspended": { "const": true }
+  },
+  "additionalProperties": true
+}

--- a/schemas/service/restart/result.schema.json
+++ b/schemas/service/restart/result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "service restart" },
+    "action": { "const": "restart" },
+    "name": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/session/list/result.schema.json
+++ b/schemas/session/list/result.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string" },
+      "name": { "type": "string" },
+      "template": { "type": "string" },
+      "provider": { "type": "string" },
+      "state": { "type": "string" },
+      "title": { "type": "string" },
+      "rig": { "type": "string" }
+    },
+    "additionalProperties": true
+  }
+}

--- a/schemas/status/result.schema.json
+++ b/schemas/status/result.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["city_name", "city_path", "controller", "suspended", "agents", "rigs", "summary"],
+  "properties": {
+    "city_name": { "type": "string" },
+    "city_path": { "type": "string" },
+    "controller": {
+      "type": "object",
+      "required": ["running"],
+      "properties": {
+        "running": { "type": "boolean" },
+        "pid": { "type": "integer" },
+        "mode": { "type": "string" },
+        "status": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "suspended": { "type": "boolean" },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "qualified_name", "scope", "running", "suspended"],
+        "properties": {
+          "name": { "type": "string" },
+          "qualified_name": { "type": "string" },
+          "scope": { "type": "string" },
+          "running": { "type": "boolean" },
+          "suspended": { "type": "boolean" },
+          "pool": {
+            "type": "object",
+            "properties": {
+              "min": { "type": "integer" },
+              "max": { "type": "integer" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "rigs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "path", "suspended"],
+        "properties": {
+          "name": { "type": "string" },
+          "path": { "type": "string" },
+          "suspended": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_agents", "running_agents"],
+      "properties": {
+        "total_agents": { "type": "integer" },
+        "running_agents": { "type": "integer" },
+        "active_sessions": { "type": "integer" },
+        "suspended_sessions": { "type": "integer" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/trace/show/result.schema.json
+++ b/schemas/trace/show/result.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "schema_version": { "type": "integer" },
+      "trace_id": { "type": "string" },
+      "tick_id": { "type": "string" },
+      "type": { "type": "string" },
+      "reason": { "type": "string" },
+      "created_at": { "type": "string", "format": "date-time" }
+    },
+    "additionalProperties": true
+  }
+}

--- a/schemas/wait/cancel/result.schema.json
+++ b/schemas/wait/cancel/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "state"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "wait cancel" },
+    "action": { "const": "cancel" },
+    "name": { "type": "string" },
+    "state": { "const": "canceled" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/wait/ready/result.schema.json
+++ b/schemas/wait/ready/result.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "command", "action", "name", "state"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "command": { "const": "wait ready" },
+    "action": { "const": "ready" },
+    "name": { "type": "string" },
+    "state": { "const": "ready" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/wait/ready/result.schema.json
+++ b/schemas/wait/ready/result.schema.json
@@ -8,6 +8,9 @@
     "command": { "const": "wait ready" },
     "action": { "const": "ready" },
     "name": { "type": "string" },
+    "retried": { "type": "boolean" },
+    "retried_from_wait": { "type": "string" },
+    "ready_wait_id": { "type": "string" },
     "state": { "const": "ready" }
   },
   "additionalProperties": true

--- a/schemas_embed.go
+++ b/schemas_embed.go
@@ -1,3 +1,4 @@
+// Package gascity provides repository-level embedded assets shared by CLI packages.
 package gascity
 
 import "embed"

--- a/schemas_embed.go
+++ b/schemas_embed.go
@@ -1,0 +1,11 @@
+package gascity
+
+import "embed"
+
+// BuiltinSchemas embeds the checked-in CLI JSON schemas.
+//
+// Logical schema paths are rooted at schemas/, for example:
+// schemas/events/result.schema.json
+//
+//go:embed schemas/**
+var BuiltinSchemas embed.FS


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has been superseded by #2349, the consolidated `gc --json` / `--json-schema` rollout PR.
> Please review and merge #2349 instead of this feeder PR. This PR remains open only as provenance until #2349 lands.

## Summary
This maintainer follow-up carries forward https://github.com/gastownhall/gascity/pull/2288 (`feat: add JSON for native management actions`) through the adoption workflow.

Original PR state: OPEN
Configured base branch: `main`
Original GitHub base branch: `codex/json-schema-platform`
Base mismatch: the original PR was stacked on `codex/json-schema-platform`, while the adoption workflow reviewed and replayed the change set against `main`. After the reviewed head was pushed back to the original same-repository branch, GitHub reported that original PR as conflicting with the old stacked base and did not expose the normal CI workflow on the refreshed head. This follow-up gives the reviewed patch a clean `main` merge surface with visible CI.

## Contributor Work Preserved
The contributor-authored commits from PR #2288 are preserved in this branch, including the JSON schema platform work and native management action JSON support. The maintainer adoption commit repairs the reviewed JSON result contract gaps found during the workflow.

## Maintainer Fixes
- `fix: repair management json result contracts`
- Final diff against the reviewed `main` base: 38 files changed, 2168 insertions(+), 53 deletions(-)

## Validation
- Adopt PR approval guard passed after base refresh.
- Base refresh replayed cleanly onto latest `main` with patch-id preserved.
- Focused local tests passed: `go test ./cmd/gc -run 'Test(JSON|Management|AgentSuspendResumeJSON|WaitReadyJSON|RigAddJSON|RigSuspendResumeRemoveJSON)'`.

This PR is the final merge surface for the adoption workflow; PR #2288 will be closed as superseded after this follow-up has visible passing CI and the public adoption review comment is posted.

