### PR TITLE
fix(events): harden legacy archive migration

### DIFF
--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -137,10 +137,11 @@ type RotationResult struct {
 //
 // On open, the constructor performs a one-shot sweep on the log
 // directory: legacy events.jsonl.archive-YYYYMMDD.gz files are
-// renamed to the seq-stamped convention, events.jsonl.rotating-* files
-// left from a crashed rotation are gzipped into canonical archive
-// names, and *.gz.tmp files are removed. Sweep failures are logged to
-// stderr and do not block the recorder from opening.
+// renamed to the seq-stamped convention using the migration time as
+// their retention timestamp, events.jsonl.rotating-* files left from a
+// crashed rotation are gzipped into canonical archive names, and
+// *.gz.tmp files are removed. Sweep failures are logged to stderr and
+// do not block the recorder from opening.
 func NewFileRecorder(path string, stderr io.Writer, opts ...FileRecorderOption) (*FileRecorder, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("creating event log directory: %w", err)

--- a/internal/events/rotation.go
+++ b/internal/events/rotation.go
@@ -132,8 +132,8 @@ func reapOrphanedRotatingFiles(dir string, stderr io.Writer) error {
 
 	sort.Strings(legacyArchives)
 	for _, base := range legacyArchives {
-		if err := migrateLegacyArchive(filepath.Join(dir, base), dir, base); err != nil {
-			fmt.Fprintf(stderr, "events: rotation: legacy archive %q: %v\n", filepath.Join(dir, base), err) //nolint:errcheck // best-effort stderr
+		if err := migrateLegacyArchive(filepath.Join(dir, base), dir, base, time.Now().UTC()); err != nil {
+			fmt.Fprintf(stderr, "events: rotation: legacy archive %q: %v\n", base, err) //nolint:errcheck // best-effort stderr
 		}
 	}
 
@@ -214,16 +214,20 @@ func archiveRotatingFile(src, dir, base string, stderr io.Writer) error {
 	return gzipAndArchive(src, dest, stderr)
 }
 
-func migrateLegacyArchive(src, dir, base string) error {
-	ts, err := parseLegacyArchiveBasename(base)
-	if err != nil {
+// migrateLegacyArchive renames a pre-rotation gzip archive into the
+// canonical seq-stamped archive convention. The canonical timestamp is
+// the migration time, not the legacy filename day, so retain-age pruning
+// gives operators a full retention window after the upgrade observes
+// previously invisible archives.
+func migrateLegacyArchive(src, dir, base string, migrationTime time.Time) error {
+	if _, err := parseLegacyArchiveBasename(base); err != nil {
 		return err
 	}
 	first, last, err := readGzipSeqWindow(src)
 	if err != nil {
 		return fmt.Errorf("reading seq window: %w", err)
 	}
-	dest := filepath.Join(dir, formatArchiveBasename(ts, first, last))
+	dest := filepath.Join(dir, formatArchiveBasename(migrationTime, first, last))
 	if _, err := os.Stat(dest); err == nil {
 		return fmt.Errorf("target archive %q already exists; leaving legacy archive in place", dest)
 	} else if !os.IsNotExist(err) {
@@ -311,6 +315,10 @@ func readSeqWindow(path string) (uint64, uint64, error) {
 	return first, last, nil
 }
 
+// readGzipSeqWindow returns the first and last Seq values stored in a
+// gzip-compressed JSONL events archive. Unlike readSeqWindow, it scans
+// the full stream forward because gzip streams do not support the
+// active-log tail seek used for plain JSONL files.
 func readGzipSeqWindow(path string) (uint64, uint64, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/events/rotation_archive.go
+++ b/internal/events/rotation_archive.go
@@ -107,6 +107,10 @@ func isLegacyArchiveBasename(name string) bool {
 	return legacyArchiveRE.MatchString(name)
 }
 
+// parseLegacyArchiveBasename validates a pre-rotation archive basename
+// and returns the legacy day it encoded. Migration callers use the day
+// only as validation input; canonical migrated archives are stamped with
+// migration time so retention policy does not immediately prune them.
 func parseLegacyArchiveBasename(name string) (time.Time, error) {
 	if !isLegacyArchiveBasename(name) {
 		return time.Time{}, fmt.Errorf("not a legacy events archive: %q", name)

--- a/internal/events/rotation_test.go
+++ b/internal/events/rotation_test.go
@@ -195,6 +195,7 @@ func TestNewFileRecorderMigratesLegacyArchiveOnOpen(t *testing.T) {
 `
 	writeGzipFile(t, legacyPath, body)
 
+	beforeMigration := time.Now().UTC().Add(-time.Second)
 	var stderr bytes.Buffer
 	rec, err := NewFileRecorder(path, &stderr)
 	if err != nil {
@@ -207,11 +208,15 @@ func TestNewFileRecorderMigratesLegacyArchiveOnOpen(t *testing.T) {
 	if stderr.Len() > 0 {
 		t.Errorf("unexpected stderr during legacy migration: %q", stderr.String())
 	}
+	afterMigration := time.Now().UTC().Add(time.Second)
 
-	canonicalBase := "events.jsonl.archive-20260416T000000Z-seq-10-12.gz"
-	canonicalPath := filepath.Join(dir, canonicalBase)
 	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
 		t.Errorf("legacy archive should be renamed away: %v", err)
+	}
+	canonicalPath, info := findArchiveBySeq(t, dir, 10, 12)
+	if info.Timestamp.Before(beforeMigration) || info.Timestamp.After(afterMigration) {
+		t.Errorf("migrated archive timestamp = %s, want between %s and %s",
+			info.Timestamp, beforeMigration, afterMigration)
 	}
 	if _, err := os.Stat(canonicalPath); err != nil {
 		t.Fatalf("canonical archive missing after migration: %v", err)
@@ -249,6 +254,80 @@ func TestNewFileRecorderMigratesLegacyArchiveOnOpen(t *testing.T) {
 	}
 }
 
+func TestNewFileRecorderMigratedLegacyArchiveSurvivesRetainAgeAfterRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	legacyBase := "events.jsonl.archive-20000101.gz"
+	legacyPath := filepath.Join(dir, legacyBase)
+	const body = `{"seq":10,"type":"bead.created","actor":"human","subject":"first"}
+{"seq":11,"type":"bead.updated","actor":"human","subject":"middle"}
+{"seq":12,"type":"bead.closed","actor":"human","subject":"last"}
+`
+	writeGzipFile(t, legacyPath, body)
+
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr, WithArchiveRetainAge(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "post-migration"})
+	res, err := rec.ForceRotate()
+	if err != nil {
+		t.Fatalf("ForceRotate: %v", err)
+	}
+	if res.Done != nil {
+		<-res.Done
+	}
+
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("legacy archive should be renamed away: %v", err)
+	}
+	canonicalPath, _ := findArchiveBySeq(t, dir, 10, 12)
+	if _, err := os.Stat(canonicalPath); err != nil {
+		t.Fatalf("migrated archive should survive first retain-age pruning: %v", err)
+	}
+	if _, err := os.Stat(res.ArchivePath); err != nil {
+		t.Fatalf("fresh rotation archive should remain after retention pruning: %v", err)
+	}
+}
+
+func TestMigrateLegacyArchiveCollisionLeavesSourceAndDestination(t *testing.T) {
+	dir := t.TempDir()
+	legacyBase := "events.jsonl.archive-20260416.gz"
+	legacyPath := filepath.Join(dir, legacyBase)
+	const body = `{"seq":1,"type":"bead.created","actor":"human","subject":"first"}
+{"seq":2,"type":"bead.closed","actor":"human","subject":"last"}
+`
+	writeGzipFile(t, legacyPath, body)
+
+	migrationTime := time.Date(2026, 5, 17, 16, 30, 0, 0, time.UTC)
+	canonicalPath := filepath.Join(dir, formatArchiveBasename(migrationTime, 1, 2))
+	const existing = "existing archive"
+	if err := os.WriteFile(canonicalPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := migrateLegacyArchive(legacyPath, dir, legacyBase, migrationTime)
+	if err == nil {
+		t.Fatal("expected collision error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("collision error = %v, want already exists", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy archive should remain after collision: %v", err)
+	}
+	got, err := os.ReadFile(canonicalPath)
+	if err != nil {
+		t.Fatalf("ReadFile canonical archive: %v", err)
+	}
+	if string(got) != existing {
+		t.Fatalf("canonical archive overwritten: got %q, want %q", string(got), existing)
+	}
+}
+
 func TestNewFileRecorderLeavesUnparseableLegacyArchive(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")
@@ -270,13 +349,32 @@ func TestNewFileRecorderLeavesUnparseableLegacyArchive(t *testing.T) {
 	if _, err := os.Stat(legacyPath); err != nil {
 		t.Fatalf("unparseable legacy archive should be left in place: %v", err)
 	}
-	canonicalBase := "events.jsonl.archive-20260416T000000Z-seq-1-1.gz"
-	if _, err := os.Stat(filepath.Join(dir, canonicalBase)); !os.IsNotExist(err) {
-		t.Errorf("unparseable legacy archive should not produce canonical archive: %v", err)
+	matches, err := filepath.Glob(filepath.Join(dir, "events.jsonl.archive-20260416T*-seq-*.gz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("unparseable legacy archive should not produce canonical archives, got %v", matches)
 	}
 	if !strings.Contains(stderr.String(), "legacy archive") || !strings.Contains(stderr.String(), legacyBase) {
 		t.Errorf("stderr should mention legacy archive %q, got %q", legacyBase, stderr.String())
 	}
+}
+
+func findArchiveBySeq(t *testing.T, dir string, first, last uint64) (string, archiveInfo) {
+	t.Helper()
+
+	archives, err := archiveFilesIn(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, info := range archives {
+		if info.FirstSeq == first && info.LastSeq == last {
+			return filepath.Join(dir, info.Basename), info
+		}
+	}
+	t.Fatalf("archive with seq window [%d,%d] not found in %v", first, last, archives)
+	return "", archiveInfo{}
 }
 
 func writeGzipFile(t *testing.T, path, body string) {

--- a/test/integration/start_drift_test.go
+++ b/test/integration/start_drift_test.go
@@ -573,6 +573,7 @@ func newDriftIsolatedEnvRoot(t *testing.T) (string, string, []string) {
 func buildGCBinaryWithCommit(t *testing.T, outPath, commitID string) {
 	t.Helper()
 	cmd := exec.Command("go", "build",
+		"-buildvcs=false",
 		"-ldflags", "-X main.commit="+commitID,
 		"-o", outPath,
 		"./cmd/gc",


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/2276 after the original PR merged before the reviewed maintainer-side hardening commit could be carried through the merge surface.

Original PR: https://github.com/gastownhall/gascity/pull/2276
Original title: feat(events): migrate legacy archives on recorder open
Original state: MERGED
Configured base: main
Original GitHub base: main
Base mismatch: none

This follow-up contains only the reviewed fix commit from the adopt-pr workflow:

- `835ac8d53 fix(events): harden legacy archive migration`

The patch makes migrated legacy archives retention-safe by stamping migrated canonical archives with migration time, preserves legacy sources on collision and corrupt-archive paths, and adds focused regression coverage for retention, collision, corrupt archives, and post-migration sequence continuity.

Review and validation:

- adopt-pr review attempt 2 approved the fix with no required changes
- base refresh replayed the patch from `696377df` onto current `main` at `cc1c29e` with the same stable patch-id
- `go test ./internal/events` passed locally

Remaining non-gating follow-up notes from review: auto-migration behavior is not yet documented in the changelog, mixed multi-legacy sweep interactions could use broader direct coverage later, and `parseLegacyArchiveBasename` would benefit from a localized parser table test.
