### PR TITLE
docs: clarify current gc JSON behavior

### DIFF
--- a/docs/guides/using-json-from-gc.md
+++ b/docs/guides/using-json-from-gc.md
@@ -1,15 +1,15 @@
 ---
 title: "Using JSON from the Gas City CLI (`gc`)"
-description: Use `gc --json` and JSON schemas from scripts, agents, tests, and other software.
+description: Use `gc --json` from scripts, agents, tests, and other software.
 ---
 
 Gas City's CLI is human-readable by default. When software calls `gc`, use
 `--json` on commands that support it so callers do not have to parse tables,
 status text, or progress messages.
 
-The standardized JSON contract is being rolled out across the CLI. Commands
-that support it should produce deterministic machine-readable output on stdout
-while preserving the normal human output when `--json` is not present.
+The standardized JSON contract is being rolled out across the CLI. This guide
+separates what works today from conventions that new and newly standardized
+commands should follow.
 
 ## Quick Start
 
@@ -21,9 +21,8 @@ gc session list --json
 gc rig list --json
 ```
 
-Treat stdout as JSONL: one complete JSON value per line. Most bounded commands
-emit exactly one record, so ordinary JSON parsers can read the whole stdout
-body as one JSON value after trimming the trailing newline.
+Most bounded commands emit one JSON value. Ordinary JSON parsers can read the
+whole stdout body after trimming the trailing newline.
 
 ```sh
 gc status --json | jq .
@@ -36,7 +35,7 @@ if out="$(gc status --json)"; then
   jq -r '.city_name' <<<"$out"
 else
   code=$?
-  jq -r '.error.message' <<<"$out" >&2
+  printf 'gc status failed with exit code %s\n' "$code" >&2
   exit "$code"
 fi
 ```
@@ -53,52 +52,41 @@ Stderr remains available for operational diagnostics. A caller should not need
 stderr to understand the successful result shape, but stderr may still contain
 human-readable details that help debug failures.
 
-## Failure Output
+## Failure Output Today
 
-When a supported JSON command fails, stdout should contain one structured JSON
-failure record and the process should return a nonzero exit code. The JSON
-failure record includes the same code:
-
-```json
-{
-  "schema_version": "1",
-  "ok": false,
-  "error": {
-    "code": "command_failed",
-    "message": "command failed; see stderr for diagnostics",
-    "exit_code": 1
-  }
-}
-```
+Current `gc --json` commands use the process exit code for shell
+success/failure logic. On failure, commands may write human-readable diagnostics
+to stderr and may write no JSON to stdout.
 
 Agents and scripts should:
 
-- parse stdout as the result or failure payload.
 - use the process exit code for shell success/failure logic.
-- expect `error.exit_code` to match the process exit code.
-- treat stderr as diagnostics, not as the result contract.
+- parse stdout as JSON only after a successful exit.
+- capture stderr separately when they need diagnostic text.
+- not assume every command emits a structured JSON failure payload yet.
 
 ## JSONL Framing
 
-The `gc --json` transport is JSONL. Each stdout line is one complete JSON
-record.
-
-For the common bounded-command case, the default contract is exactly one record.
-That single record should usually be a top-level object with fields such as
-`schema_version`, command data, warnings, and summary counts.
+For the common bounded-command case, stdout is one complete JSON value. That
+value may be pretty-printed across multiple physical lines, so do not treat each
+line as a standalone JSON record for bounded commands.
 
 Streaming commands may emit multiple records when their schema says so. For
-example, event streams naturally use one record per event.
+example, event streams naturally use one JSON value per event.
 
-## Discovering Schemas
+## Planned Schema Discovery
 
-Use `--json-schema` to discover the JSON contract for a command.
+The `--json-schema` flag is planned but is not implemented by the current `gc`
+binary. Until it ships, use command help, generated reference docs, and command
+source/tests to confirm exact JSON shapes.
+
+The planned discovery contract is:
 
 ```sh
 gc status --json-schema
 ```
 
-This prints one JSONL manifest record:
+It will print one manifest record:
 
 ```json
 {
@@ -119,14 +107,15 @@ This prints one JSONL manifest record:
 }
 ```
 
-Ask for a specific schema role when you only need that schema:
+Role-specific schema requests are also planned:
 
 ```sh
 gc status --json-schema=result
 gc status --json-schema=failure
 ```
 
-If a known command does not declare JSON support, `--json-schema` returns a
+When implemented, if a known command does not declare JSON support,
+`--json-schema` should return a
 manifest with `json_supported: false` and an empty `schemas` object:
 
 ```json
@@ -139,14 +128,35 @@ manifest with `json_supported: false` and an empty `schemas` object:
 }
 ```
 
-Role-specific requests for unavailable schemas fail with the standard failure
-shape.
+Role-specific requests for unavailable schemas should fail with the standardized
+failure shape once that failure shape exists.
 
-## Record Counts
+## Planned Failure Shape
 
-JSON Schema describes one JSON value. For `gc --json`, each schema describes
-one JSONL record. Gas City uses an optional extension keyword to describe the
-record stream around that schema:
+New or newly standardized JSON commands should eventually return one structured
+JSON failure record on stdout when `--json` is passed and the command fails:
+
+```json
+{
+  "schema_version": "1",
+  "ok": false,
+  "error": {
+    "code": "command_failed",
+    "message": "command failed; see stderr for diagnostics",
+    "exit_code": 1
+  }
+}
+```
+
+That failure shape is not universal today. Compatibility notes for any PR that
+adopts it should call out which command changed and how existing callers should
+migrate.
+
+## Planned Record Counts
+
+JSON Schema describes one JSON value. The planned schema-discovery contract may
+use an optional extension keyword to describe the record stream around that
+schema:
 
 ```json
 {
@@ -158,8 +168,9 @@ record stream around that schema:
 }
 ```
 
-When `x-gc-jsonl` is absent, the command emits exactly one record. When it is
-present:
+This `x-gc-jsonl` vocabulary is planned; no current CLI tooling enforces it.
+When it is implemented, absence should mean the command emits exactly one
+record. When present:
 
 - `minRecords` is the minimum number of records. If omitted, the minimum is `0`.
 - `maxRecords` is the maximum number of records. If omitted, there is no maximum.
@@ -191,6 +202,11 @@ New or newly standardized JSON commands should use stable field names:
 
 Timestamps should be RFC3339 strings.
 
+Current commands do not all match these conventions. For example,
+`gc session list --json` currently emits Go struct field names such as `ID`,
+`State`, `CreatedAt`, and `SessionName`. Treat each existing command's actual
+output as authoritative until that command is explicitly standardized.
+
 Warnings that matter to software consumers should appear in structured JSON,
 for example:
 
@@ -214,7 +230,7 @@ and troubleshooting.
 Pack-defined commands can be scripts or external programs, so Gas City does not
 automatically make arbitrary pack command output JSON-safe.
 
-A pack command declares JSON support by placing a result schema next to the
+Planned schema discovery for pack-defined commands may use schemas next to the
 command implementation:
 
 ```text
@@ -226,12 +242,16 @@ commands/
         result.schema.json
 ```
 
-Nested command directories imply nested command paths. In the example above,
-the schema belongs to the pack command leaf represented by `commands/review/pr/`.
+Nested command directories would imply nested command paths. In the example
+above, the schema belongs to the pack command leaf represented by
+`commands/review/pr/`.
 
 `schemas/failure.schema.json` is optional. Use it only when the command has
 meaningful command-specific failure fields beyond the shared default failure
 shape.
+
+This convention is not loaded by current `gc` runtime code. Treat it as a design
+direction until pack command schema discovery is implemented.
 
 ## Passthrough Commands
 


### PR DESCRIPTION
## Summary

Follow-up to #2239 after the original docs PR was already merged. This carries only the maintainer-side fixup from the adoption workflow: clarifying which `gc --json` behaviors are available today and which schema/error-envelope pieces are planned.

## Original PR

- Original PR: https://github.com/gastownhall/gascity/pull/2239
- Original title: docs: add gc CLI JSON guide
- Original state at finalization: MERGED
- Configured workflow base: main
- Original GitHub base: main
- Final follow-up base: main
- Base mismatch: none

## Maintainer Follow-up Scope

The original contribution added the JSON CLI guide and navigation entry. The workflow review found that several sections described future schema and structured-failure behavior as if it already existed. This follow-up preserves the merged contributor work and adds the reviewed maintainer clarification commit only.

## Validation

- `git diff --check refs/adopt-pr/ga-vbm5mw7/latest-base..HEAD`
- `python3 -m json.tool docs/docs.json >/dev/null`
- `go test ./test/docsync/...`

Adoption workflow source: ga-vbm5mw7 / ga-ksf0u3e.