### PR TITLE
fix: surface non-object Claude settings override errors

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -389,8 +389,7 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 		// successfully above) so they indicate a gascity bug worth
 		// surfacing too. See gastownhall/gascity#2109.
 		var syntaxErr *json.SyntaxError
-		var typeErr *json.UnmarshalTypeError
-		if errors.As(upgradeErr, &syntaxErr) || errors.As(upgradeErr, &typeErr) {
+		if errors.As(upgradeErr, &syntaxErr) {
 			return nil, claudeSettingsSourceNone, fmt.Errorf("invalid JSON in Claude settings override at %s; fix or remove the file to proceed with install: %w", overridePath, upgradeErr)
 		}
 		return nil, claudeSettingsSourceNone, fmt.Errorf("upgrading Claude settings from %s: %w", overridePath, upgradeErr)
@@ -398,6 +397,9 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 
 	merged, err := overlay.MergeSettingsJSON(base, upgradedOverride)
 	if err != nil {
+		if overlay.IsOverlayObjectShapeError(err) {
+			return nil, claudeSettingsSourceNone, fmt.Errorf("invalid JSON in Claude settings override at %s; expected a JSON object; fix or remove the file to proceed with install: %w", overridePath, err)
+		}
 		return nil, claudeSettingsSourceNone, fmt.Errorf("merging Claude settings from %s: %w", overridePath, err)
 	}
 	return merged, sourceKind, nil

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1385,6 +1385,46 @@ func TestInstallClaudeSurfacesMalformedOverride(t *testing.T) {
 	}
 }
 
+// TestInstallClaudeSurfacesNonObjectOverride verifies that a valid JSON
+// value with the wrong top-level shape is reported as an invalid Claude
+// settings override, not as a generic merge failure.
+func TestInstallClaudeSurfacesNonObjectOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "array", data: []byte(`["not", "an", "object"]`)},
+		{name: "string", data: []byte(`"not an object"`)},
+		{name: "number", data: []byte(`42`)},
+		{name: "bool", data: []byte(`true`)},
+		{name: "null", data: []byte(`null`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := fsys.NewFake()
+			fs.Files["/city/.claude/settings.json"] = tt.data
+
+			err := Install(fs, "/city", "/work", []string{"claude"})
+			if err == nil {
+				t.Fatal("Install must surface non-object .claude/settings.json as an error")
+			}
+			if !strings.Contains(err.Error(), ".claude/settings.json") {
+				t.Errorf("error must name the offending path: %v", err)
+			}
+			if !strings.Contains(err.Error(), "invalid JSON") {
+				t.Errorf("error must clearly identify the file as invalid JSON (not bury it in a generic merge error): %v", err)
+			}
+			if !strings.Contains(err.Error(), "expected a JSON object") {
+				t.Errorf("error must explain the expected top-level shape: %v", err)
+			}
+			if strings.Contains(err.Error(), "merging Claude settings") {
+				t.Errorf("error must not surface as a generic 'merging Claude settings' wrap: %v", err)
+			}
+		})
+	}
+}
+
 // TestInstallOverlayManagedProviders verifies that overlay-managed providers
 // are materialized from the embedded core pack overlay into the workdir.
 func TestInstallOverlayManagedProviders(t *testing.T) {

--- a/internal/overlay/merge.go
+++ b/internal/overlay/merge.go
@@ -4,6 +4,7 @@ package overlay
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 )
@@ -18,6 +19,17 @@ var mergeablePaths = map[string]bool{
 	filepath.Join(".github", "hooks", "gascity.json"): true,
 }
 
+var (
+	errBaseNotObject    = errors.New("base JSON is not an object")
+	errOverlayNotObject = errors.New("overlay JSON is not an object")
+)
+
+// IsOverlayObjectShapeError reports whether err indicates an overlay document
+// was syntactically valid JSON but not a top-level object.
+func IsOverlayObjectShapeError(err error) bool {
+	return errors.Is(err, errOverlayNotObject)
+}
+
 // IsMergeablePath reports whether relPath is a known settings/hooks file
 // that should be JSON-merged rather than overwritten.
 func IsMergeablePath(relPath string) bool {
@@ -25,6 +37,7 @@ func IsMergeablePath(relPath string) bool {
 }
 
 // MergeSettingsJSON performs a deep merge of base and overlay JSON documents.
+// Both documents must be top-level JSON objects.
 //
 // Merge semantics:
 //   - Non-hook top-level keys: last writer (overlay) wins.
@@ -39,12 +52,13 @@ func IsMergeablePath(relPath string) bool {
 //
 // Returns pretty-printed JSON.
 func MergeSettingsJSON(base, overlay []byte) ([]byte, error) {
-	var baseDoc, overDoc map[string]any
-	if err := json.Unmarshal(base, &baseDoc); err != nil {
-		return nil, fmt.Errorf("merge: parsing base: %w", err)
+	baseDoc, err := parseSettingsObject("base", base, errBaseNotObject)
+	if err != nil {
+		return nil, err
 	}
-	if err := json.Unmarshal(overlay, &overDoc); err != nil {
-		return nil, fmt.Errorf("merge: parsing overlay: %w", err)
+	overDoc, err := parseSettingsObject("overlay", overlay, errOverlayNotObject)
+	if err != nil {
+		return nil, err
 	}
 
 	// Start with a copy of base, then apply overlay on top.
@@ -69,6 +83,18 @@ func MergeSettingsJSON(base, overlay []byte) ([]byte, error) {
 		return nil, fmt.Errorf("merge: marshaling result: %w", err)
 	}
 	return out, nil
+}
+
+func parseSettingsObject(label string, data []byte, shapeErr error) (map[string]any, error) {
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("merge: parsing %s: %w", label, err)
+	}
+	obj, ok := doc.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("merge: parsing %s: expected JSON object: %w", label, shapeErr)
+	}
+	return obj, nil
 }
 
 // CanonicalJSON parses and re-emits a JSON document with stable formatting.

--- a/internal/overlay/merge_test.go
+++ b/internal/overlay/merge_test.go
@@ -296,6 +296,16 @@ func TestMergeSettingsJSON_InvalidOverlay(t *testing.T) {
 	}
 }
 
+func TestMergeSettingsJSON_NullOverlayIsNotObject(t *testing.T) {
+	_, err := MergeSettingsJSON([]byte(`{}`), []byte(`null`))
+	if err == nil {
+		t.Fatal("expected error for null overlay JSON")
+	}
+	if !IsOverlayObjectShapeError(err) {
+		t.Fatalf("expected overlay object-shape error, got %v", err)
+	}
+}
+
 func TestMergeSettingsJSON_WitnessScenario(t *testing.T) {
 	// Full witness scenario: base has 4 default hooks, overlay adds PreToolUse only.
 	base := `{


### PR DESCRIPTION
Follow-up to #2244.

Original PR URL: https://github.com/gastownhall/gascity/pull/2244
Original PR title: fix(hooks): surface clear error for malformed Claude settings override (#2109)
Original PR state: MERGED
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

This follow-up carries only the maintainer-side fixes produced by the adoption review after #2244 had already merged. The contributor's original commit remains credited in #2244; this branch adds the reviewed maintainer fix for the non-object Claude settings override gap.

Review summary:
- The review found that valid-but-non-object `.claude/settings.json` values still reached the generic merge-error path.
- The final patch rejects array, string, number, bool, and null overrides with a path-specific "expected JSON object" diagnostic.
- The overlay merge layer now uses an overlay-specific object-shape sentinel so user override errors are classified without mis-attributing trusted base settings.

Validation:
- `go test ./internal/hooks ./internal/overlay`
- `adopt_pr_approval_summary.py --issue ga-bzy8h1i --repo-slug gastownhall/gascity --pr-number 2244 --root-id ga-wisp-6npgw05`
- `adopt_pr_base_refresh.py --issue ga-bzy8h1i --repo-slug gastownhall/gascity --pr-number 2244 --base-branch main --upstream-url https://github.com/gastownhall/gascity.git`