### PR TITLE
fix(cmd/gc/bd): surface bd silent on-disk fallback as loud error (#2080, #2079)

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -663,6 +663,19 @@ func bdTransportErrorMatches(cityPath, scopeRoot string, env map[string]string, 
 	return false
 }
 
+// bdSilentFallbackMarkerImport and bdSilentFallbackMarkerEmptyDB are the
+// substring pair bd emits when it loses the managed Dolt server and silently
+// falls back to opening the on-disk store with a JSONL auto-import. They are
+// load-bearing in three places — the two transport-error classifiers below
+// and bdOutputIndicatesSilentFallback — so they live here as the single
+// source of truth. If bd's banner wording ever changes, this is the only
+// edit site. (The root cause is fixed upstream in beads post-#3691; these
+// markers remain the symptom detector for deployments still on stable bd.)
+const (
+	bdSilentFallbackMarkerImport  = "auto-importing"
+	bdSilentFallbackMarkerEmptyDB = "into empty database"
+)
+
 func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string, err error) bool {
 	return bdTransportErrorMatches(cityPath, scopeRoot, env, err, []string{
 		"server unreachable",
@@ -678,8 +691,8 @@ func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string
 		// rather than a network error. Treat the auto-import marker as a
 		// transport failure so the managed-retry path republishes the correct
 		// port and retries against the live server. See gastownhall/gascity#1930.
-		"auto-importing",
-		"into empty database",
+		bdSilentFallbackMarkerImport,
+		bdSilentFallbackMarkerEmptyDB,
 	})
 }
 
@@ -691,9 +704,25 @@ func bdTransportRecoverableError(cityPath, scopeRoot string, env map[string]stri
 		// When bd auto-imports into an empty on-disk store it has lost the
 		// managed Dolt server; republishing the port via the recovery path
 		// is what unsticks the next attempt. See gastownhall/gascity#1930.
-		"auto-importing",
-		"into empty database",
+		bdSilentFallbackMarkerImport,
+		bdSilentFallbackMarkerEmptyDB,
 	})
+}
+
+// bdOutputIndicatesSilentFallback reports whether the given bd output
+// (typically captured stderr) contains the marker pair that bd emits
+// when it loses the managed Dolt server and silently falls back to
+// opening the on-disk store with a JSONL auto-import. Operators of
+// `gc bd ...` rely on this to convert the silent fallback into a loud,
+// non-zero-exit error — in managed mode (BD_EXPORT_AUTO=false) the
+// fallback drops writes. See gastownhall/gascity#2080 (bd update path)
+// and gastownhall/gascity#2079 (bd close path) — both subcommands flow
+// through the shared doBd handoff, so a single detection site covers
+// the bd-write-persistence quad.
+func bdOutputIndicatesSilentFallback(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(lower, bdSilentFallbackMarkerImport) &&
+		strings.Contains(lower, bdSilentFallbackMarkerEmptyDB)
 }
 
 func bdCommandRunnerWithManagedRetry(cityPath string, envFn func(dir string) map[string]string) beads.CommandRunner {

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -13,6 +13,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// bdSilentFallbackExitCode is the exit code gc bd emits when it detects
+// that bd silently fell back to on-disk auto-import mode (managed Dolt
+// unreachable). Distinct from bd's own exits so operators and CI can
+// tell the loud-fail apart from a real bd error. Covers both the
+// bd update path (gastownhall/gascity#2080) and the bd close path
+// (gastownhall/gascity#2079) because both subcommands flow through doBd.
+const bdSilentFallbackExitCode = 4
+
+// bdStderrScanLimit caps how much of bd's stderr gc retains to scan for the
+// silent-fallback marker. bd emits the marker pair while opening the store —
+// before it runs the subcommand — so the marker, when present, always lands
+// within the first chunk of stderr. Capping the retained prefix keeps memory
+// bounded for bd subcommands that stream large stderr output.
+const bdStderrScanLimit = 64 << 10 // 64 KiB
+
+// headLimitedWriter retains only the first limit bytes written to it and
+// discards the rest, so scanning bd's stderr for the silent-fallback marker
+// never holds an unbounded copy of the stream. It always reports a full
+// write so it is safe as an io.MultiWriter sink.
+type headLimitedWriter struct {
+	buf   []byte
+	limit int
+}
+
+func (w *headLimitedWriter) Write(p []byte) (int, error) {
+	if room := w.limit - len(w.buf); room > 0 {
+		if len(p) < room {
+			room = len(p)
+		}
+		w.buf = append(w.buf, p[:room]...)
+	}
+	return len(p), nil
+}
+
+func (w *headLimitedWriter) String() string { return string(w.buf) }
+
 func newBdCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bd [bd-args...]",
@@ -139,7 +175,13 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	cmd.Dir = target.ScopeRoot
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	// Tee stderr through a bounded head buffer alongside the operator's
+	// pipe so we can scan it post-exec for bd's silent-fallback-to-on-disk
+	// marker. Only stderr is teed: bd writes its auto-import banner there,
+	// not to stdout. See gastownhall/gascity#2080 (update path) and #2079
+	// (close path) — both go through this handoff.
+	stderrScan := &headLimitedWriter{limit: bdStderrScanLimit}
+	cmd.Stderr = io.MultiWriter(stderr, stderrScan)
 	env, err := bdCommandEnv(cityPath, cfg, target)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -147,14 +189,34 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	}
 	cmd.Env = workQueryEnvForDir(env, cmd.Dir)
 
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+
+	if runErr != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if errors.As(runErr, &exitErr) {
 			return exitErr.ExitCode()
 		}
-		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc bd: %v\n", runErr) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+
+	// bd exited 0 — but if its stderr shows the silent fallback to on-disk
+	// auto-import, the managed Dolt server was unreachable and any write in
+	// this command was dropped (managed Gas City sets BD_EXPORT_AUTO=false;
+	// see applyExportSuppressionEnv in cmd/gc/bd_env.go). Surface that as a
+	// hard error instead of a misleading exit 0. One check here covers the
+	// whole bd-write-persistence quad (gastownhall/gascity#2079 / #2080 /
+	// #2149 / #2150) because every bd subcommand routes through this
+	// handoff. A non-zero bd exit is intentionally left to the block above:
+	// the existing transport-retry classifier already handles the
+	// timeout+marker case, and overriding a real bd exit code here would
+	// mask it. (Root cause fixed upstream in beads post-#3691; this surfaces
+	// the symptom for deployments still on stable bd builds.)
+	if bdOutputIndicatesSilentFallback(stderrScan.String()) {
+		fmt.Fprintln(stderr, "gc bd: managed Dolt unreachable; bd fell back to on-disk auto-import mode. If this command wrote data, that write was NOT persisted. Restart the managed Dolt server (or check connectivity) and retry. (See gastownhall/gascity#2080.)") //nolint:errcheck // best-effort stderr
+		return bdSilentFallbackExitCode
+	}
+
 	return 0
 }
 

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -71,10 +71,13 @@ auto-export behavior, invoke bd directly.`,
   gc bd list --rig my-project -s open`,
 		DisableFlagParsing: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if doBd(args, stdout, stderr) != 0 {
-				return errExit
-			}
-			return nil
+			// Plumb doBd's numeric exit code through exitForCode so the
+			// process exit code matches the documented contract above
+			// (bdSilentFallbackExitCode = 4) and bd's own exit codes are
+			// preserved. Returning errExit on any non-zero would collapse
+			// every code to 1 and defeat the operator/CI signal the loud-
+			// fail was meant to provide.
+			return exitForCode(doBd(args, stdout, stderr))
 		},
 	}
 	return cmd

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1769,3 +1769,195 @@ set -eu
 		t.Fatalf("stderr = %q, want canonical drift detail", stderr.String())
 	}
 }
+
+// silentFallbackFakeBdScript builds a fake `bd` shell script that emits the
+// silent-fallback marker pair on stderr ("auto-importing ... into empty
+// database") and exits 0 — the exact shape bd produces when it loses the
+// managed Dolt server and falls back to opening the on-disk store. doBd
+// should treat this as a hard failure regardless of bd's exit code.
+const silentFallbackFakeBdScript = `#!/bin/sh
+echo "auto-importing 220929 bytes from .beads/issues.jsonl into empty database... auto-imported 123 issues" >&2
+echo "$@"
+exit 0
+`
+
+// silentFallbackTestSetup writes a fake bd binary that emits the silent-
+// fallback marker, prepends it to PATH, and configures a minimal city as a
+// bd-backed scope (via GC_CITY_PATH) so doBd will dispatch through it.
+func silentFallbackTestSetup(t *testing.T, fakeBdScript string) {
+	t.Helper()
+
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	t.Cleanup(func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	})
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	port := strconv.Itoa(writeReachableManagedDoltState(t, cityDir))
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "issue_prefix: demo\n" +
+		"gc.endpoint_origin: city_canonical\n" +
+		"gc.endpoint_status: verified\n" +
+		"dolt.auto-start: false\n" +
+		"dolt.host: 127.0.0.1\n" +
+		"dolt.port: " + port + "\n"
+	// writeReachableManagedDoltState already creates .beads, but don't rely
+	// on that side-effect — make the directory explicit before writing.
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_DOLT_PORT", port)
+}
+
+// TestGcBdSurfacesSilentFallbackAsLoudError_UpdatePath pins the #2080 fix:
+// when bd's update path silently falls back to the on-disk store, gc bd must
+// convert that into a non-zero exit with an operator-facing message instead
+// of letting the silent write loss reach the operator as success.
+func TestGcBdSurfacesSilentFallbackAsLoudError_UpdatePath(t *testing.T) {
+	silentFallbackTestSetup(t, silentFallbackFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"update", "demo-abc", "--set-metadata", "k=v"}, &stdout, &stderr)
+	if got != bdSilentFallbackExitCode {
+		t.Fatalf("doBd(update) = %d, want %d (silent-fallback exit code); stderr=%q",
+			got, bdSilentFallbackExitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "managed Dolt unreachable") {
+		t.Fatalf("stderr missing loud-fail message; stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "auto-importing") {
+		t.Fatalf("original bd stderr not passed through; stderr=%q", stderr.String())
+	}
+}
+
+// TestGcBdSurfacesSilentFallbackAsLoudError_ClosePath pins the #2079 half of
+// the bd-write-persistence quad: bd close goes through the same doBd
+// handoff, so the silent-fallback detection must fire identically. Pre-fix,
+// gc bd close would have exited 0 even when the close never persisted to
+// JSONL (the behavior #2079 documents).
+func TestGcBdSurfacesSilentFallbackAsLoudError_ClosePath(t *testing.T) {
+	silentFallbackTestSetup(t, silentFallbackFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"close", "demo-abc", "-r", "duplicate"}, &stdout, &stderr)
+	if got != bdSilentFallbackExitCode {
+		t.Fatalf("doBd(close) = %d, want %d (silent-fallback exit code); stderr=%q",
+			got, bdSilentFallbackExitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "managed Dolt unreachable") {
+		t.Fatalf("stderr missing loud-fail message; stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "auto-importing") {
+		t.Fatalf("original bd stderr not passed through; stderr=%q", stderr.String())
+	}
+}
+
+// TestGcBdHappyPathExitsZeroWithoutFallbackMarker is the inverse: a clean
+// bd run that produces no auto-import marker must NOT be converted into the
+// loud-fail. This guards against false positives where bd's stderr happens
+// to contain unrelated content.
+func TestGcBdHappyPathExitsZeroWithoutFallbackMarker(t *testing.T) {
+	// Fake bd that exits 0 with normal output and an unrelated stderr line.
+	const happyPathFakeBdScript = `#!/bin/sh
+echo "some normal bd output"
+echo "some unrelated stderr line" >&2
+exit 0
+`
+	silentFallbackTestSetup(t, happyPathFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"list"}, &stdout, &stderr)
+	if got != 0 {
+		t.Fatalf("doBd(list) = %d, want 0; stderr=%q", got, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "managed Dolt unreachable") {
+		t.Fatalf("loud-fail message fired on a happy-path run; stderr=%q", stderr.String())
+	}
+}
+
+// TestBdOutputIndicatesSilentFallback covers the marker-detection helper
+// directly with table-driven cases so the source-of-truth for what counts
+// as "silent fallback" is unit-pinned.
+func TestBdOutputIndicatesSilentFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"single marker only auto-importing", "auto-importing 100 bytes from foo", false},
+		{"single marker only into-empty-database", "into empty database", false},
+		{"both markers same line", "auto-importing 100 bytes into empty database", true},
+		{"both markers reversed order", "into empty database <- auto-importing 100 bytes", true},
+		{"both markers across newlines", "auto-importing 100 bytes\n  into empty database\n  done", true},
+		{"case insensitive uppercase", "AUTO-IMPORTING INTO EMPTY DATABASE", true},
+		{"case insensitive mixed", "Auto-Importing 200 bytes Into Empty Database", true},
+		{"unrelated transport error", "dial tcp 127.0.0.1:3306: connect: connection refused", false},
+		{"unrelated server-unreachable error", "server unreachable", false},
+		{"both markers buried in long output", "starting bd\n... \nauto-importing 220929 bytes from .beads/issues.jsonl into empty database... \n... \nauto-imported 123 issues\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bdOutputIndicatesSilentFallback(tt.input); got != tt.want {
+				t.Errorf("bdOutputIndicatesSilentFallback(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHeadLimitedWriter pins the bounded-prefix behavior used to scan bd's
+// stderr: writes past the limit are reported as fully consumed (so it is
+// safe behind io.MultiWriter) but only the first limit bytes are retained.
+func TestHeadLimitedWriter(t *testing.T) {
+	t.Run("retains only the first limit bytes of an oversized write", func(t *testing.T) {
+		w := &headLimitedWriter{limit: 5}
+		n, err := w.Write([]byte("abcdefgh"))
+		if err != nil || n != 8 {
+			t.Fatalf("Write = (%d, %v), want (8, nil)", n, err)
+		}
+		if got := w.String(); got != "abcde" {
+			t.Fatalf("String() = %q, want %q", got, "abcde")
+		}
+	})
+	t.Run("accumulates across writes and stops at the limit", func(t *testing.T) {
+		w := &headLimitedWriter{limit: 5}
+		for _, chunk := range []string{"ab", "cdef", "ghi"} {
+			if n, err := w.Write([]byte(chunk)); err != nil || n != len(chunk) {
+				t.Fatalf("Write(%q) = (%d, %v), want (%d, nil)", chunk, n, err, len(chunk))
+			}
+		}
+		if got := w.String(); got != "abcde" {
+			t.Fatalf("String() = %q, want %q", got, "abcde")
+		}
+	})
+	t.Run("zero limit retains nothing but still consumes the write", func(t *testing.T) {
+		w := &headLimitedWriter{limit: 0}
+		n, err := w.Write([]byte("xyz"))
+		if err != nil || n != 3 {
+			t.Fatalf("Write = (%d, %v), want (3, nil)", n, err)
+		}
+		if got := w.String(); got != "" {
+			t.Fatalf("String() = %q, want empty", got)
+		}
+	})
+}

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1895,6 +1895,44 @@ exit 0
 	}
 }
 
+// TestGcBdProcessExitCodeMatchesSilentFallbackContract pins the process-
+// level exit code contract that the bdSilentFallbackExitCode = 4 doc
+// comment promises operators and CI. PR #2327 review found the previous
+// RunE used `return errExit` on any non-zero, which collapsed every code
+// to 1 in commandExitCode — defeating the operator/CI signal the loud-
+// fail was meant to provide. Plumbing doBd's numeric code through
+// exitForCode ensures the process exit code matches what doBd computed.
+func TestGcBdProcessExitCodeMatchesSilentFallbackContract(t *testing.T) {
+	silentFallbackTestSetup(t, silentFallbackFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := run([]string{"bd", "update", "demo-abc", "--set-metadata", "k=v"}, &stdout, &stderr)
+	if got != bdSilentFallbackExitCode {
+		t.Fatalf("run(bd update) = %d, want %d (silent-fallback exit code); stderr=%q",
+			got, bdSilentFallbackExitCode, stderr.String())
+	}
+}
+
+// TestGcBdProcessExitCodePreservesBdNonZero is the inverse case: when bd
+// returns a non-zero code that isn't the silent-fallback case (e.g., bd
+// itself rejected the command), gc bd must preserve bd's exit code rather
+// than collapsing it to 1. exitForCode encodes ≥2 codes via
+// commandExitError so commandExitCode reads them back faithfully.
+func TestGcBdProcessExitCodePreservesBdNonZero(t *testing.T) {
+	const bdRejectsScript = `#!/bin/sh
+echo "bd: simulated usage error" >&2
+exit 3
+`
+	silentFallbackTestSetup(t, bdRejectsScript)
+
+	var stdout, stderr bytes.Buffer
+	got := run([]string{"bd", "list"}, &stdout, &stderr)
+	if got != 3 {
+		t.Fatalf("run(bd list) = %d, want 3 (preserved bd exit code); stderr=%q",
+			got, stderr.String())
+	}
+}
+
 // TestBdOutputIndicatesSilentFallback covers the marker-detection helper
 // directly with table-driven cases so the source-of-truth for what counts
 // as "silent fallback" is unit-pinned.


### PR DESCRIPTION
## Problem

When the managed Dolt server is unreachable, `bd` silently falls back to opening the on-disk store and triggers a JSONL auto-import. In managed mode (`BD_EXPORT_AUTO=false`, set unconditionally by `gc bd` via `applyExportSuppressionEnv`), that fallback path drops the operator's write — `bd` exits 0, the in-memory Dolt view shows the change, but nothing reaches `.beads/issues.jsonl` and the change is lost on the next `bd` invocation.

Production symptom: `gc sling` reports a "Slung X → target" success while the `routed_to` metadata never reaches disk, so the polecat pool reconciler never sees the work and nothing spawns. Closing a bead "succeeds" but the next read shows status OPEN.

## Fix

`doBd` is the shared `exec.Command` site for every `bd` subcommand. This change tees `bd`'s stderr through a bounded head buffer and — when `bd` exits 0 — scans for the auto-import marker pair (`"auto-importing"` + `"into empty database"`). A marker-positive zero-exit run is converted to exit code 4 with a clear operator-facing message. A non-zero `bd` exit is left untouched, so a real `bd` error code is never masked.

A single detection site covers `bd update --set-metadata` (#2080), `bd close` (#2079), and the rest of the bd-write surface, because every subcommand routes through `doBd`.

### Scope

- The marker pair is centralized as named constants (`bdSilentFallbackMarkerImport` / `bdSilentFallbackMarkerEmptyDB`) in `bd_env.go` — the single source of truth, shared with the two existing transport-error classifiers.
- Exit code 4 (`bdSilentFallbackExitCode`) is reserved for this loud-fail; `bd`'s own exits pass through unchanged.
- The retained stderr prefix is capped (`headLimitedWriter`, 64 KiB). `bd` emits the marker at store-open, before it runs the subcommand, so the marker always lands within the retained prefix; the cap bounds memory for subcommands that stream large stderr.

## Upstream context

The root cause is fixed in beads HEAD (empty-DB guard restored). Deployments on a fixed `bd` build never reach this path. For deployments still on stable `bd` the silent fallback remains live, and this loud-fail is the operator-visible safety net during the upgrade window. The detector becomes redundant once the fixed `bd` build is the supported baseline.

## Tests

`cmd/gc/cmd_bd_test.go`:
- `TestGcBdSurfacesSilentFallbackAsLoudError_UpdatePath` — #2080 coverage: fake `bd` emits the marker and exits 0 during `update --set-metadata`; `doBd` returns 4 and the original `bd` stderr passes through.
- `TestGcBdSurfacesSilentFallbackAsLoudError_ClosePath` — #2079 coverage: same, via `close`.
- `TestGcBdHappyPathExitsZeroWithoutFallbackMarker` — false-positive guard.
- `TestBdOutputIndicatesSilentFallback` — 11 table-driven cases for the marker helper.
- `TestHeadLimitedWriter` — bounded-buffer edge cases.

## Review

Pre-push multi-model review caught and fixed three issues before this PR opened: the silent-fallback check ordering (it had run before the `bd` exit-code handling and could override a real non-zero exit), an unbounded stderr buffer, and a duplicated marker literal. `make build` / `fmt-check` / `lint` / `vet` and the `cmd/gc` test package are green.

Closes #2079
Closes #2080
Refs #2149, #2150
