### PR TITLE
fix(convergence,dispatch): split ResolveConditionPath envelope from join base (#2320)

### DIFF
--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -139,32 +139,58 @@ func (ce ConditionEnv) Environ() []string {
 }
 
 // ResolveConditionPath resolves and validates a gate condition path.
-// - Resolves relative paths against cityPath
-// - Rejects symlinks (EvalSymlinks must equal cleaned path)
-// - Returns the canonical absolute path
-func ResolveConditionPath(cityPath, conditionPath string) (string, error) {
+//
+//   - envelope: the security boundary; relative-path traversal validation
+//     enforces containment under this root. For city-scoped gates pass the
+//     city path; for rig-scoped ralph checks (gastownhall/gascity#2320) pass
+//     the city path here even though `base` may point at a rig subtree.
+//     Must be non-empty — an empty envelope would silently disable the
+//     traversal check, so it is rejected.
+//   - base: the directory that relative conditionPath values are joined
+//     against. Pass the same value as `envelope` for callers with no
+//     rig/city distinction. When empty, falls back to `envelope` to preserve
+//     historical single-arg behavior.
+//   - conditionPath: the path declared by the gate. May be absolute or
+//     relative to `base`.
+//
+// Resolves relative paths against `base`, validates traversal against
+// `envelope`, resolves symlinks, and requires a regular executable file.
+// Returns the canonical absolute path.
+func ResolveConditionPath(envelope, base, conditionPath string) (string, error) {
 	if conditionPath == "" {
 		return "", fmt.Errorf("resolving gate condition path: empty path")
 	}
+	if envelope == "" {
+		return "", fmt.Errorf("resolving gate condition path: empty envelope")
+	}
+	if base == "" {
+		base = envelope
+	}
 
-	// Canonicalize cityPath first so that symlinked workspace roots
+	// Canonicalize envelope first so that symlinked workspace roots
 	// (e.g., /tmp → /private/tmp on macOS) don't cause false rejections.
-	canonCity, err := filepath.EvalSymlinks(cityPath)
+	canonEnvelope, err := filepath.EvalSymlinks(envelope)
 	if err != nil {
-		canonCity = filepath.Clean(cityPath) // best-effort if city doesn't exist yet
+		canonEnvelope = filepath.Clean(envelope) // best-effort if envelope doesn't exist yet
+	}
+	canonBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		canonBase = filepath.Clean(base) // best-effort if base doesn't exist yet
 	}
 
 	var absPath string
 	if filepath.IsAbs(conditionPath) {
 		absPath = filepath.Clean(conditionPath)
 	} else {
-		absPath = filepath.Clean(filepath.Join(canonCity, conditionPath))
+		absPath = filepath.Clean(filepath.Join(canonBase, conditionPath))
 	}
 
-	// Reject path traversal: the resolved path must be under cityPath
-	// for relative paths.
+	// Reject path traversal: the resolved path must be under envelope
+	// for relative paths. Absolute paths skip the containment check (they
+	// are joined against no root) — unchanged from the pre-split behavior;
+	// callers must not pass attacker-influenced absolute paths.
 	if !filepath.IsAbs(conditionPath) {
-		rel, err := filepath.Rel(canonCity, absPath)
+		rel, err := filepath.Rel(canonEnvelope, absPath)
 		if err != nil || pathutil.IsOutsideDir(rel) {
 			return "", fmt.Errorf("resolving gate condition path: path traversal not allowed: %s", conditionPath)
 		}

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -203,7 +203,7 @@ func TestResolveConditionPath(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		got, err := ResolveConditionPath("/some/city", script)
+		got, err := ResolveConditionPath("/some/city", "/some/city", script)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -220,7 +220,7 @@ func TestResolveConditionPath(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		got, err := ResolveConditionPath(dir, "gates/check.sh")
+		got, err := ResolveConditionPath(dir, dir, "gates/check.sh")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -239,7 +239,7 @@ func TestResolveConditionPath(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		got, err := ResolveConditionPath(dir, "link.sh")
+		got, err := ResolveConditionPath(dir, dir, "link.sh")
 		if err != nil {
 			t.Fatalf("unexpected error for symlink: %v", err)
 		}
@@ -256,7 +256,7 @@ func TestResolveConditionPath(t *testing.T) {
 		}
 		defer func() { _ = os.Remove(script) }()
 
-		_, err := ResolveConditionPath(dir, "../outside.sh")
+		_, err := ResolveConditionPath(dir, dir, "../outside.sh")
 		if err == nil {
 			t.Fatal("expected error for path traversal, got nil")
 		}
@@ -266,17 +266,97 @@ func TestResolveConditionPath(t *testing.T) {
 	})
 
 	t.Run("empty path", func(t *testing.T) {
-		_, err := ResolveConditionPath("/some/city", "")
+		_, err := ResolveConditionPath("/some/city", "/some/city", "")
 		if err == nil {
 			t.Fatal("expected error for empty path, got nil")
 		}
 	})
 
 	t.Run("nonexistent file", func(t *testing.T) {
-		_, err := ResolveConditionPath("/some/city", "/nonexistent/file.sh")
+		_, err := ResolveConditionPath("/some/city", "/some/city", "/nonexistent/file.sh")
 		if err == nil {
 			t.Fatal("expected error for nonexistent file, got nil")
 		}
+	})
+
+	// Pins gastownhall/gascity#2320: a relative path that escapes the base
+	// (the rig subtree) upward but stays inside the envelope (the city tree)
+	// must resolve successfully. This is the exact case the envelope/base
+	// split fixes — and the only one that genuinely distinguishes the new
+	// behavior from the old single-arg API. Pre-fix, base and envelope were
+	// the same value (the rig), so `../scripts/check.sh` was validated
+	// against the rig and the traversal check wrongly rejected it.
+	t.Run("rig-scoped: relative path escapes base but stays inside envelope", func(t *testing.T) {
+		cityDir := t.TempDir()
+		rigDir := filepath.Join(cityDir, "frontend")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Script lives under the city tree, not under the rig base.
+		scriptDir := filepath.Join(cityDir, "scripts")
+		if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		script := filepath.Join(scriptDir, "check.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		// envelope = cityDir (security boundary), base = rigDir (join target).
+		// `../scripts/check.sh` climbs out of base into the city tree; it
+		// stays inside envelope, so it resolves.
+		got, err := ResolveConditionPath(cityDir, rigDir, "../scripts/check.sh")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		testutil.AssertSamePath(t, got, script)
+	})
+
+	// Pins the security contract: when envelope and base diverge, traversal
+	// validation must use the envelope. A relative path that resolves
+	// (under the larger base) to a location outside the envelope must be
+	// rejected even though it stays inside base.
+	t.Run("rig-scoped: traversal still rejected against envelope", func(t *testing.T) {
+		cityDir := t.TempDir()
+		rigDir := filepath.Join(cityDir, "frontend")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Script lives outside both envelope and base; traversal should reject.
+		parent := filepath.Dir(cityDir)
+		script := filepath.Join(parent, "outside.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = os.Remove(script) }()
+
+		_, err := ResolveConditionPath(cityDir, rigDir, "../../outside.sh")
+		if err == nil {
+			t.Fatal("expected traversal rejection, got nil")
+		}
+		if !strings.Contains(err.Error(), "traversal") {
+			t.Errorf("expected path traversal error, got: %v", err)
+		}
+	})
+
+	// Empty base falls back to envelope for backward compatibility with
+	// callers that have no rig/city distinction to make.
+	t.Run("empty base falls back to envelope", func(t *testing.T) {
+		dir := t.TempDir()
+		scriptDir := filepath.Join(dir, "gates")
+		if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		script := filepath.Join(scriptDir, "check.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := ResolveConditionPath(dir, "", "gates/check.sh")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		testutil.AssertSamePath(t, got, script)
 	})
 }
 

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -175,7 +175,11 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	if resolvedWorkDir != "" {
 		scriptBase = resolvedWorkDir
 	}
-	scriptPath, err := convergence.ResolveConditionPath(scriptBase, checkPath)
+	// Pass cityPath and scriptBase as distinct envelope/base roles: in
+	// gastownhall/gascity#2320 storePath (a rig subtree) was passed as both,
+	// causing relative gc.check_path values to be looked up under the rig
+	// tree even when the script lives in the city tree.
+	scriptPath, err := convergence.ResolveConditionPath(cityPath, scriptBase, checkPath)
 	if err != nil {
 		return convergence.GateResult{}, fmt.Errorf("%s: resolving check path: %w", bead.ID, err)
 	}

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -6618,7 +6618,16 @@ func TestRunRalphCheckTimeoutMetadataPrecedence(t *testing.T) {
 
 func TestRunRalphCheckUsesStorePathForRelativeCheckAndSubjectEnv(t *testing.T) {
 	cityPath := t.TempDir()
-	storePath := t.TempDir()
+	// storePath models a rig store living as a subtree of the city, matching
+	// the production rig layout. The disjoint-tempdir construction this test
+	// previously used was unrealistic and obscured the gastownhall/gascity#2320
+	// envelope/base distinction: relative gc.check_path now resolves under
+	// storePath (the join base) but containment is validated against cityPath
+	// (the security envelope).
+	storePath := filepath.Join(cityPath, "rig-store")
+	if err := os.MkdirAll(storePath, 0o755); err != nil {
+		t.Fatalf("mkdir rig-store: %v", err)
+	}
 	workDir := filepath.Join(storePath, "frontend")
 	checkDir := filepath.Join(workDir, "checks")
 	if err := os.MkdirAll(checkDir, 0o755); err != nil {
@@ -6668,6 +6677,99 @@ func TestRunRalphCheckUsesStorePathForRelativeCheckAndSubjectEnv(t *testing.T) {
 		if !strings.Contains(result.Stdout, want) {
 			t.Fatalf("stdout = %q, want to contain %q", result.Stdout, want)
 		}
+	}
+}
+
+// TestRunRalphCheckRigScopedRelativeCheckPathResolvesAgainstStore pins the
+// gastownhall/gascity#2320 fix: a ralph check bead with a relative
+// gc.check_path and a storePath that is a SUBTREE of cityPath. The
+// gc.check_path here (`../scripts/check.sh`) deliberately escapes the store
+// (the join base) upward into the city tree (the security envelope) — the
+// exact shape that fails pre-fix. Before the envelope/base split,
+// ResolveConditionPath conflated the two roles, so this relative path was
+// validated against storePath and the traversal check rejected it even
+// though the script is comfortably inside the city envelope.
+func TestRunRalphCheckRigScopedRelativeCheckPathResolvesAgainstStore(t *testing.T) {
+	cityPath := t.TempDir()
+	storePath := filepath.Join(cityPath, "rig-frontend")
+	if err := os.MkdirAll(storePath, 0o755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	// Script lives under the city tree, NOT under the store. A relative
+	// gc.check_path must climb out of the store to reach it.
+	scriptDir := filepath.Join(cityPath, "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "check.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-rig",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    "../scripts/check.sh",
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-rig", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:  cityPath,
+		StorePath: storePath,
+	})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v", err)
+	}
+	if result.Outcome != "pass" {
+		t.Fatalf("Outcome = %q, want pass (stderr=%q)", result.Outcome, result.Stderr)
+	}
+}
+
+// TestRunRalphCheckRejectsPathTraversalAboveCityPath pins the security
+// contract: when envelope (cityPath) and base (scriptBase) diverge, a
+// relative gc.check_path that traverses above the city must still be
+// rejected even though it might otherwise resolve via the join base.
+func TestRunRalphCheckRejectsPathTraversalAboveCityPath(t *testing.T) {
+	parent := t.TempDir()
+	cityPath := filepath.Join(parent, "city")
+	storePath := filepath.Join(cityPath, "rig-frontend")
+	if err := os.MkdirAll(storePath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Outside script lives above cityPath — must be rejected by the envelope.
+	outsideDir := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	outsideScript := filepath.Join(outsideDir, "check.sh")
+	if err := os.WriteFile(outsideScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-evil",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    "../../outside/check.sh",
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-evil", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:  cityPath,
+		StorePath: storePath,
+	})
+	if err == nil {
+		t.Fatalf("expected traversal rejection, got outcome=%q stdout=%q", result.Outcome, result.Stdout)
+	}
+	if !strings.Contains(err.Error(), "traversal") {
+		t.Errorf("expected traversal error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`convergence.ResolveConditionPath` conflated two distinct roles in a single `cityPath` argument: the security envelope for path-traversal validation, and the directory that relative `gc.check_path` values are joined against. For rig-scoped ralph gates — where the bead store lives in a rig subtree but the check script lives in the city tree — a legitimate relative check path was validated against the rig subtree and rejected by the traversal guard.

This splits the argument into `ResolveConditionPath(envelope, base, conditionPath)`:

- `envelope` — the security boundary; relative-path traversal containment is enforced against this root.
- `base` — the directory relative `conditionPath` values join against. Falls back to `envelope` when empty (preserves single-arg behavior for callers with no rig/city distinction). An empty `envelope` is now rejected — it would silently disable the traversal check.

The sole production caller, `runRalphCheck`, now passes `cityPath` as the envelope and the rig store / work dir as the base. The absolute-path and symlink-resolution contracts are unchanged.

## Tests

- Unit: a relative path that escapes `base` upward but stays inside `envelope` resolves (the case that genuinely distinguishes the new behavior from the old single-arg API); traversal still rejected against `envelope`; empty-base fallback; empty-envelope rejection.
- End-to-end: `runRalphCheck` with a rig-subtree store and a `../`-relative `gc.check_path`, plus a traversal-above-city rejection case.

Closes #2320
