### PR TITLE
fix(orders): count wisps with open steps as in-flight (tr-kds01)

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -168,23 +169,31 @@ name. Use --rig to filter by rig.`,
 
 func newOrderSweepTrackingCmd(stdout, stderr io.Writer) *cobra.Command {
 	staleAfter := defaultOrderTrackingSweepStaleAfter
+	includeWisps := false
 	quiet := false
 	cmd := &cobra.Command{
-		Use:   "sweep-tracking",
+		Use:   "sweep-tracking [order ...]",
 		Short: "Close stale order-tracking beads",
 		Long: `Close stale open order-tracking beads.
 
 This is intended for maintenance exec orders. It only closes tracking beads
-older than --stale-after so a fresh in-flight order is not interrupted.`,
-		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdOrderSweepTracking(staleAfter, quiet, stdout, stderr) != 0 {
+older than --stale-after so a fresh in-flight order is not interrupted.
+
+Use --include-wisps for operator recovery of abandoned order-run wisp
+subtrees whose open descendants are also older than --stale-after. Pass one
+or more scoped order names when --include-wisps is set; wisp recovery is
+order-scoped to avoid scanning unrelated beads.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if cmdOrderSweepTracking(staleAfter, includeWisps, quiet, args, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
+		ValidArgsFunction: completeOrderNames,
 	}
 	cmd.Flags().DurationVar(&staleAfter, "stale-after", defaultOrderTrackingSweepStaleAfter, "minimum age for an open tracking bead to be closed")
+	cmd.Flags().BoolVar(&includeWisps, "include-wisps", false, "also close stale order-run wisp subtrees with open descendants")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress success output")
 	return cmd
 }
@@ -986,7 +995,7 @@ func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resol
 
 // --- gc order sweep-tracking ---
 
-func cmdOrderSweepTracking(staleAfter time.Duration, quiet bool, stdout, stderr io.Writer) int {
+func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, orderNames []string, stdout, stderr io.Writer) int {
 	if staleAfter <= 0 {
 		fmt.Fprintln(stderr, "gc order sweep-tracking: --stale-after must be positive") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1001,15 +1010,37 @@ func cmdOrderSweepTracking(staleAfter time.Duration, quiet bool, stdout, stderr 
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	closed, err := sweepStaleOrderTracking(store, time.Now(), staleAfter, nil, orderTrackingSweepMetadataInitiator)
+	result, err := sweepStaleOrderTrackingWithOptions(store, time.Now(), staleAfter, orderNameFilter(orderNames), orderTrackingSweepMetadataInitiator, includeWisps)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if !quiet {
-		fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s)\n", closed) //nolint:errcheck // best-effort stdout
+		if includeWisps {
+			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), %d stale order wisp bead(s)\n", result.trackingClosed, result.wispClosed) //nolint:errcheck // best-effort stdout
+		} else {
+			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s)\n", result.trackingClosed) //nolint:errcheck // best-effort stdout
+		}
 	}
 	return 0
+}
+
+func orderNameFilter(orderNames []string) map[string]struct{} {
+	if len(orderNames) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(orderNames))
+	for _, name := range orderNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // findOrder looks up an order by name and optional rig.

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -983,18 +983,26 @@ func (m *memoryOrderDispatcher) rigSuspendedByName(rigName string) bool {
 	return false
 }
 
-// hasOpenWorkStrict reports whether an open tracking bead exists for this
-// order — i.e. a dispatchOne goroutine is still in flight. Tracking beads
-// carry both "order-run:<scoped>" and labelOrderTracking; dispatchOne closes
-// them via defer when dispatch returns.
+// hasOpenWorkStrict reports whether any in-flight work exists for this
+// order — either a dispatchOne goroutine still running, or a wisp whose
+// step beads have not all been completed by the pool agent.
 //
-// Wisp root beads also carry "order-run:<scoped>" (so gc order history and
-// the orders API feed can attribute the wisp to its order), but molecule
-// roots never auto-close when their step beads finish. A leftover open
-// root is not in-flight work and must not block re-dispatch — counting it
-// caused ga-jra/ga-lo8c, where formula+pool orders stalled indefinitely
-// after a city restart because the first auto-fire's wisp root permanently
-// tripped this check.
+// Tracking beads carry both "order-run:<scoped>" and labelOrderTracking;
+// dispatchOne closes them via defer when dispatch returns. An open
+// tracking bead means a dispatchOne goroutine is in flight.
+//
+// Wisp root beads also carry "order-run:<scoped>" (so gc order history
+// and the orders API feed can attribute the wisp to its order) but never
+// carry labelOrderTracking. Molecule roots never auto-close when their
+// step beads finish, so a leftover open root with all-closed children is
+// orphan state — counting it would permanently block re-dispatch
+// (ga-jra/ga-lo8c, where formula+pool orders stalled after a city restart
+// because the first auto-fire's wisp root tripped this check). But a
+// wisp root whose child step beads are still open IS in-flight work: the
+// pool agent has not yet executed the wisp. Counting those prevents the
+// cooldown gate from pouring duplicate wisps when the pool stalls
+// (tr-kds01, where 24h-interval digest wisps accumulated because the
+// pool never picked them up).
 func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
 	results, err := store.List(beads.ListQuery{
 		Label:    "order-run:" + scopedName,
@@ -1008,10 +1016,35 @@ func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName 
 		if b.Status == "closed" {
 			continue
 		}
-		for _, lbl := range b.Labels {
-			if lbl == labelOrderTracking {
-				return true, nil
-			}
+		if beadLabelsContain(b.Labels, labelOrderTracking) {
+			return true, nil
+		}
+		hasOpenChildren, err := storeHasOpenChildren(store, b.ID)
+		if err != nil {
+			return false, fmt.Errorf("checking open children of wisp %s: %w", b.ID, err)
+		}
+		if hasOpenChildren {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// storeHasOpenChildren reports whether any non-closed beads name parentID
+// as their ParentID. Filters status in Go (not just via IncludeClosed)
+// so a misbehaving store wrapper that leaks closed beads cannot fool the
+// caller's in-flight check.
+func storeHasOpenChildren(store beads.Store, parentID string) (bool, error) {
+	children, err := store.List(beads.ListQuery{
+		ParentID: parentID,
+		TierMode: beads.TierBoth,
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, c := range children {
+		if c.Status != "closed" {
+			return true, nil
 		}
 	}
 	return false, nil

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/closeorder"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/execenv"
@@ -62,6 +63,7 @@ const (
 	// watchdog retries every 30s, and the order-firing pipeline silently
 	// wedges (no bead.created/closed events, only metadata churn).
 	staleOrderTrackingCloseReason = "order-tracking sweep: stale tracking bead exceeded retention window"
+	staleOrderWispCloseReason     = "order-tracking sweep: stale order wisp subtree exceeded retention window"
 
 	completedOrderTrackingCloseReason = "order dispatch completed: tracking bead lifecycle finished"
 )
@@ -1005,8 +1007,10 @@ func (m *memoryOrderDispatcher) rigSuspendedByName(rigName string) bool {
 // pool never picked them up).
 func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
 	results, err := store.List(beads.ListQuery{
-		Label:    "order-run:" + scopedName,
-		Sort:     beads.SortCreatedDesc,
+		Label: "order-run:" + scopedName,
+		Sort:  beads.SortCreatedDesc,
+		// Tracking beads are ephemeral while wisp roots are issue-tier, so
+		// the single-flight gate must union both tiers.
 		TierMode: beads.TierBoth,
 	})
 	if err != nil {
@@ -1019,32 +1023,64 @@ func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName 
 		if beadLabelsContain(b.Labels, labelOrderTracking) {
 			return true, nil
 		}
-		hasOpenChildren, err := storeHasOpenChildren(store, b.ID)
-		if err != nil {
-			return false, fmt.Errorf("checking open children of wisp %s: %w", b.ID, err)
+		if !isOrderWispRootCandidate(b) {
+			continue
 		}
-		if hasOpenChildren {
+		if isOrderRootOnlyWispCandidate(b) {
+			return true, nil
+		}
+		hasOpenDescendants, err := storeHasOpenDescendants(store, b.ID)
+		if err != nil {
+			return false, fmt.Errorf("checking open descendants of wisp %s: %w", b.ID, err)
+		}
+		if hasOpenDescendants {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-// storeHasOpenChildren reports whether any non-closed beads name parentID
-// as their ParentID. Filters status in Go (not just via IncludeClosed)
-// so a misbehaving store wrapper that leaks closed beads cannot fool the
-// caller's in-flight check.
-func storeHasOpenChildren(store beads.Store, parentID string) (bool, error) {
-	children, err := store.List(beads.ListQuery{
-		ParentID: parentID,
-		TierMode: beads.TierBoth,
-	})
-	if err != nil {
-		return false, err
+func isOrderWispRootCandidate(b beads.Bead) bool {
+	if beads.IsMoleculeType(b.Type) {
+		return true
 	}
-	for _, c := range children {
-		if c.Status != "closed" {
-			return true, nil
+	return b.Metadata["gc.kind"] == "workflow" || b.Metadata["gc.kind"] == "wisp"
+}
+
+func isOrderRootOnlyWispCandidate(b beads.Bead) bool {
+	return b.Metadata["gc.kind"] == "wisp" && !beads.IsMoleculeType(b.Type)
+}
+
+// storeHasOpenDescendants reports whether any transitive child of parentID is
+// non-closed. It includes closed intermediate nodes so nested molecule work
+// remains visible after a direct child step has completed.
+func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
+	seen := map[string]struct{}{parentID: {}}
+	queue := []string{parentID}
+	for len(queue) > 0 {
+		parentID := queue[0]
+		queue = queue[1:]
+
+		children, err := store.List(beads.ListQuery{
+			ParentID:      parentID,
+			IncludeClosed: true,
+			TierMode:      beads.TierBoth,
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, c := range children {
+			if c.ID == "" {
+				continue
+			}
+			if _, ok := seen[c.ID]; ok {
+				continue
+			}
+			seen[c.ID] = struct{}{}
+			if c.Status != "closed" {
+				return true, nil
+			}
+			queue = append(queue, c.ID)
 		}
 	}
 	return false, nil
@@ -1108,19 +1144,33 @@ func beadLabelsContain(labels []string, want string) bool {
 	return false
 }
 
+type orderTrackingSweepResult struct {
+	trackingClosed int
+	wispClosed     int
+}
+
 // sweepStaleOrderTracking closes open order-tracking beads whose creation
 // timestamp is older than staleAfter. When onlyOrders is non-empty, it only
 // closes tracking beads for those scoped order names.
 func sweepStaleOrderTracking(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string) (int, error) {
+	result, err := sweepStaleOrderTrackingWithOptions(store, now, staleAfter, onlyOrders, initiator, false)
+	return result.trackingClosed, err
+}
+
+func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
-		return 0, fmt.Errorf("stale-after must be positive")
+		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")
+	}
+	if includeWispSubtrees && len(onlyOrders) == 0 {
+		return orderTrackingSweepResult{}, fmt.Errorf("include-wisps requires at least one order name")
 	}
 	all, err := store.ListByLabel(labelOrderTracking, 0, beads.WithBothTiers)
 	if err != nil {
-		return 0, fmt.Errorf("listing order-tracking beads: %w", err)
+		return orderTrackingSweepResult{}, fmt.Errorf("listing order-tracking beads: %w", err)
 	}
 
 	cutoff := now.Add(-staleAfter)
+	result := orderTrackingSweepResult{}
 	var ids []string
 	for _, b := range all {
 		if len(onlyOrders) > 0 {
@@ -1138,20 +1188,218 @@ func sweepStaleOrderTracking(store beads.Store, now time.Time, staleAfter time.D
 		ids = append(ids, b.ID)
 	}
 	if len(ids) == 0 {
+		if !includeWispSubtrees {
+			return result, nil
+		}
+	} else {
+		metadata := map[string]string{
+			"order_tracking_sweep": orderTrackingSweepMetadataReason,
+			"close_reason":         staleOrderTrackingCloseReason,
+		}
+		if initiator != "" {
+			metadata["order_tracking_sweep_by"] = initiator
+		}
+		n, err := store.CloseAll(ids, metadata)
+		result.trackingClosed = n
+		if err != nil {
+			return result, fmt.Errorf("closing stale order-tracking beads: %w", err)
+		}
+	}
+
+	if includeWispSubtrees {
+		n, err := sweepStaleOrderWispSubtrees(store, cutoff, onlyOrders, initiator)
+		result.wispClosed = n
+		if err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string) (int, error) {
+	roots, err := staleOrderWispRoots(store, cutoff, onlyOrders)
+	if err != nil {
+		return 0, err
+	}
+	ids := make([]string, 0, len(roots))
+	seen := make(map[string]struct{}, len(roots))
+	for _, root := range roots {
+		if root.ID == "" || root.Status == "closed" {
+			continue
+		}
+		if beadLabelsContain(root.Labels, labelOrderTracking) {
+			continue
+		}
+		if !isOrderWispRootCandidate(root) {
+			continue
+		}
+		if !isOrderRootOnlyWispCandidate(root) {
+			openDescendants, err := storeHasOpenDescendants(store, root.ID)
+			if err != nil {
+				return 0, fmt.Errorf("checking stale wisp descendants of %s: %w", root.ID, err)
+			}
+			if !openDescendants {
+				continue
+			}
+		}
+		subtree, err := collectOrderWispSubtree(store, root)
+		if err != nil {
+			return 0, fmt.Errorf("collecting stale wisp subtree %s: %w", root.ID, err)
+		}
+		if !openSubtreeOlderThan(subtree, cutoff) {
+			continue
+		}
+		for _, id := range staleOrderWispSubtreeCloseIDs(subtree) {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
 		return 0, nil
+	}
+	ordered, err := closeorder.Order(store, ids)
+	if err != nil {
+		return 0, fmt.Errorf("ordering stale order wisp closes: %w", err)
 	}
 	metadata := map[string]string{
 		"order_tracking_sweep": orderTrackingSweepMetadataReason,
-		"close_reason":         staleOrderTrackingCloseReason,
+		"order_wisp_sweep":     "stale-order-wisp",
+		"close_reason":         staleOrderWispCloseReason,
 	}
 	if initiator != "" {
 		metadata["order_tracking_sweep_by"] = initiator
 	}
-	n, err := store.CloseAll(ids, metadata)
+	n, err := store.CloseAll(ordered, metadata)
 	if err != nil {
-		return n, fmt.Errorf("closing stale order-tracking beads: %w", err)
+		return n, fmt.Errorf("closing stale order wisp subtrees: %w", err)
 	}
 	return n, nil
+}
+
+func staleOrderWispRoots(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}) ([]beads.Bead, error) {
+	if len(onlyOrders) == 0 {
+		return nil, fmt.Errorf("include-wisps requires at least one order name")
+	}
+	var roots []beads.Bead
+	for orderName := range onlyOrders {
+		matches, err := store.List(beads.ListQuery{
+			Label:         "order-run:" + orderName,
+			CreatedBefore: cutoff,
+			TierMode:      beads.TierBoth,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing stale order wisps for %s: %w", orderName, err)
+		}
+		roots = append(roots, matches...)
+	}
+	return roots, nil
+}
+
+func collectOrderWispSubtree(store beads.Store, root beads.Bead) ([]beads.Bead, error) {
+	if root.ID == "" {
+		return nil, nil
+	}
+	seen := map[string]struct{}{root.ID: {}}
+	out := []beads.Bead{root}
+	queue := []string{root.ID}
+	for len(queue) > 0 {
+		parentID := queue[0]
+		queue = queue[1:]
+
+		children, err := store.List(beads.ListQuery{
+			ParentID:      parentID,
+			IncludeClosed: true,
+			TierMode:      beads.TierBoth,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children {
+			if child.ID == "" {
+				continue
+			}
+			if _, ok := seen[child.ID]; ok {
+				continue
+			}
+			seen[child.ID] = struct{}{}
+			out = append(out, child)
+			queue = append(queue, child.ID)
+		}
+	}
+	return out, nil
+}
+
+func staleOrderWispSubtreeCloseIDs(subtree []beads.Bead) []string {
+	if len(subtree) == 0 {
+		return nil
+	}
+	byID := make(map[string]beads.Bead, len(subtree))
+	for _, bead := range subtree {
+		if bead.ID != "" {
+			byID[bead.ID] = bead
+		}
+	}
+	depthMemo := make(map[string]int, len(subtree))
+	const visitingDepth = -1
+	var depth func(string) int
+	depth = func(id string) int {
+		if d, ok := depthMemo[id]; ok {
+			if d == visitingDepth {
+				return 0
+			}
+			return d
+		}
+		bead, ok := byID[id]
+		if !ok {
+			return 0
+		}
+		parentID := strings.TrimSpace(bead.ParentID)
+		if parentID == "" || parentID == id {
+			depthMemo[id] = 0
+			return 0
+		}
+		parent, ok := byID[parentID]
+		if !ok || parent.ID == "" {
+			depthMemo[id] = 0
+			return 0
+		}
+		depthMemo[id] = visitingDepth
+		d := depth(parentID) + 1
+		depthMemo[id] = d
+		return d
+	}
+
+	ordered := append([]beads.Bead(nil), subtree...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if da, db := depth(ordered[i].ID), depth(ordered[j].ID); da != db {
+			return da > db
+		}
+		return ordered[i].ID < ordered[j].ID
+	})
+
+	ids := make([]string, 0, len(ordered))
+	for _, bead := range ordered {
+		if bead.ID == "" || bead.Status == "closed" {
+			continue
+		}
+		ids = append(ids, bead.ID)
+	}
+	return ids
+}
+
+func openSubtreeOlderThan(subtree []beads.Bead, cutoff time.Time) bool {
+	for _, b := range subtree {
+		if b.Status == "closed" {
+			continue
+		}
+		if b.CreatedAt.IsZero() || !b.CreatedAt.Before(cutoff) {
+			return false
+		}
+	}
+	return true
 }
 
 func orderNameFromTrackingBead(b beads.Bead) (string, bool) {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -3167,6 +3167,418 @@ func TestSweepStaleOrderTracking_ClosesOnlyOldOpenTrackingBeads(t *testing.T) {
 	}
 }
 
+func orderFilterForTest(names ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		out[name] = struct{}{}
+	}
+	return out
+}
+
+type parentLastCloseStore struct {
+	beads.Store
+}
+
+func (s parentLastCloseStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	closed := 0
+	for _, id := range ids {
+		bead, err := s.Get(id)
+		if err != nil {
+			return closed, err
+		}
+		if bead.Status == "closed" {
+			continue
+		}
+		children, err := s.List(beads.ListQuery{ParentID: id, TierMode: beads.TierBoth})
+		if err != nil {
+			return closed, err
+		}
+		for _, child := range children {
+			if child.Status != "closed" {
+				return closed, fmt.Errorf("cannot close %s before open child %s", id, child.ID)
+			}
+		}
+		n, err := s.Store.CloseAll([]string{id}, metadata)
+		closed += n
+		if err != nil {
+			return closed, err
+		}
+	}
+	return closed, nil
+}
+
+type depListFailStore struct {
+	beads.Store
+	failID string
+}
+
+func (s depListFailStore) DepList(id, direction string) ([]beads.Dep, error) {
+	if id == s.failID {
+		return nil, fmt.Errorf("dependency list unavailable for %s", id)
+	}
+	return s.Store.DepList(id, direction)
+}
+
+func TestSweepStaleOrderTrackingWithWispsRequiresOrderFilter(t *testing.T) {
+	store := beads.NewMemStore()
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		time.Now(),
+		time.Minute,
+		nil,
+		orderTrackingSweepMetadataInitiator,
+		true,
+	)
+	if err == nil {
+		t.Fatal("sweepStaleOrderTrackingWithOptions err = nil, want order-filter error")
+	}
+	if !strings.Contains(err.Error(), "requires at least one order name") {
+		t.Fatalf("err = %q, want order-filter context", err)
+	}
+	if result.trackingClosed != 0 || result.wispClosed != 0 {
+		t.Fatalf("result = %+v, want no partial closes", result)
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsClosesOldOpenWispSubtree(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "draft-digest",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	closedChild, err := store.Create(beads.Bead{
+		Title:    "prepare-submolecule",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(closed child): %v", err)
+	}
+	if err := store.Close(closedChild.ID); err != nil {
+		t.Fatalf("Close(closed child): %v", err)
+	}
+	grandchild, err := store.Create(beads.Bead{
+		Title:    "nested-step-still-running",
+		ParentID: closedChild.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(grandchild): %v", err)
+	}
+	otherRoot, err := store.Create(beads.Bead{
+		Title:  "mol-other-order",
+		Type:   "molecule",
+		Labels: []string{"order-run:other"},
+	})
+	if err != nil {
+		t.Fatalf("Create(other root): %v", err)
+	}
+	otherChild, err := store.Create(beads.Bead{
+		Title:    "other-step",
+		ParentID: otherRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(other child): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		time.Minute,
+		orderFilterForTest("digest"),
+		orderTrackingSweepMetadataInitiator,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.trackingClosed != 0 {
+		t.Fatalf("trackingClosed = %d, want 0", result.trackingClosed)
+	}
+	if result.wispClosed != 3 {
+		t.Fatalf("wispClosed = %d, want 3", result.wispClosed)
+	}
+
+	for _, id := range []string{wispRoot.ID, child.ID, grandchild.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+		if got.Metadata["close_reason"] != staleOrderWispCloseReason {
+			t.Fatalf("%s close_reason = %q, want %q", id, got.Metadata["close_reason"], staleOrderWispCloseReason)
+		}
+		if got.Metadata["order_tracking_sweep"] != orderTrackingSweepMetadataReason {
+			t.Fatalf("%s order_tracking_sweep = %q, want %q", id, got.Metadata["order_tracking_sweep"], orderTrackingSweepMetadataReason)
+		}
+	}
+	for _, id := range []string{otherRoot.ID, otherChild.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("unscoped wisp %s status = %q, want open", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingWithoutWispsLeavesOpenWispSubtree(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "draft-digest",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		time.Minute,
+		nil,
+		orderTrackingSweepMetadataInitiator,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 0 {
+		t.Fatalf("wispClosed = %d, want 0", result.wispClosed)
+	}
+	gotChild, err := store.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if gotChild.Status != "open" {
+		t.Fatalf("child status = %q, want open", gotChild.Status)
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsClosesDeepestFirst(t *testing.T) {
+	base := beads.NewMemStore()
+	store := parentLastCloseStore{Store: base}
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	child, err := base.Create(beads.Bead{
+		Title:    "draft-digest",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	grandchild, err := base.Create(beads.Bead{
+		Title:    "nested-step-still-running",
+		ParentID: child.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(grandchild): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		time.Minute,
+		orderFilterForTest("digest"),
+		orderTrackingSweepMetadataInitiator,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 3 {
+		t.Fatalf("wispClosed = %d, want 3", result.wispClosed)
+	}
+
+	for _, id := range []string{wispRoot.ID, child.ID, grandchild.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsClosesRootOnlyWisp(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "vapor-order-root",
+		Type:   "task",
+		Labels: []string{"order-run:digest"},
+		Metadata: map[string]string{
+			"gc.kind": "wisp",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		time.Minute,
+		orderFilterForTest("digest"),
+		orderTrackingSweepMetadataInitiator,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 1 {
+		t.Fatalf("wispClosed = %d, want 1", result.wispClosed)
+	}
+	got, err := store.Get(wispRoot.ID)
+	if err != nil {
+		t.Fatalf("Get(wisp root): %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("wisp root status = %q, want closed", got.Status)
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsSkipsFreshOpenDescendant(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	child, err := store.Create(beads.Bead{
+		Title:    "fresh-step",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	cutoff := wispRoot.CreatedAt.Add(child.CreatedAt.Sub(wispRoot.CreatedAt) / 2)
+
+	closed, err := sweepStaleOrderWispSubtrees(store, cutoff, orderFilterForTest("digest"), orderTrackingSweepMetadataInitiator)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderWispSubtrees: %v", err)
+	}
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+	for _, id := range []string{wispRoot.ID, child.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status = %q, want open", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsPropagatesDescendantListError(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	store := parentListFailStore{
+		Store:        base,
+		failParentID: wispRoot.ID,
+		err:          fmt.Errorf("child list unavailable"),
+	}
+
+	closed, err := sweepStaleOrderWispSubtrees(
+		store,
+		wispRoot.CreatedAt.Add(time.Minute),
+		orderFilterForTest("digest"),
+		orderTrackingSweepMetadataInitiator,
+	)
+	if err == nil {
+		t.Fatal("sweepStaleOrderWispSubtrees err = nil, want descendant-list error")
+	}
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+	if !strings.Contains(err.Error(), "checking stale wisp descendants") {
+		t.Fatalf("err = %q, want descendant context", err)
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsPropagatesCloseOrderError(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	child, err := base.Create(beads.Bead{
+		Title:    "draft-digest",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	store := depListFailStore{Store: base, failID: child.ID}
+
+	closed, err := sweepStaleOrderWispSubtrees(
+		store,
+		wispRoot.CreatedAt.Add(time.Minute),
+		orderFilterForTest("digest"),
+		orderTrackingSweepMetadataInitiator,
+	)
+	if err == nil {
+		t.Fatal("sweepStaleOrderWispSubtrees err = nil, want close-order error")
+	}
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+	if !strings.Contains(err.Error(), "ordering stale order wisp closes") {
+		t.Fatalf("err = %q, want close-order context", err)
+	}
+}
+
 func TestStartupSweepThenBuildDispatcher(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -4851,6 +5263,7 @@ func TestOrderDispatchOpenWispRootDoesNotBlockRedispatch(t *testing.T) {
 	// root remains open because nothing in the dispatch path closes it.
 	wispRoot, err := store.Create(beads.Bead{
 		Title:  "mol-formula-pool-work",
+		Type:   "molecule",
 		Labels: []string{"order-run:my-pool-order"},
 	})
 	if err != nil {
@@ -4942,6 +5355,7 @@ func TestHasOpenWorkStrictBlocksOnWispWithOpenChildren(t *testing.T) {
 
 	wispRoot, err := store.Create(beads.Bead{
 		Title:  "mol-digest-generate",
+		Type:   "molecule",
 		Labels: []string{"order-run:digest"},
 	})
 	if err != nil {
@@ -4966,6 +5380,147 @@ func TestHasOpenWorkStrictBlocksOnWispWithOpenChildren(t *testing.T) {
 	}
 }
 
+func TestHasOpenWorkStrictBlocksOnWispWithPartiallyClosedChildren(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	closedChild, err := store.Create(beads.Bead{
+		Title:    "determine-period",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(closedChild.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "draft-digest",
+		ParentID: wispRoot.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if !has {
+		t.Fatal("wisp root with a remaining open child step must count as in-flight work")
+	}
+}
+
+func TestHasOpenWorkStrictBlocksOnWispWithOpenDescendant(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	closedChild, err := store.Create(beads.Bead{
+		Title:    "prepare-submolecule",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(closedChild.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "nested-step-still-running",
+		ParentID: closedChild.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if !has {
+		t.Fatal("wisp root with an open nested descendant must count as in-flight work")
+	}
+}
+
+func TestHasOpenWorkStrictBlocksOnGraphWorkflowWispWithOpenDescendant(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "graph-workflow-digest",
+		Type:   "task",
+		Labels: []string{"order-run:digest"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	closedChild, err := store.Create(beads.Bead{
+		Title:    "prepare-graph-step",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(closedChild.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "graph-step-still-running",
+		ParentID: closedChild.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if !has {
+		t.Fatal("graph workflow wisp with an open nested descendant must count as in-flight work")
+	}
+}
+
+func TestHasOpenWorkStrictBlocksOnRootOnlyWisp(t *testing.T) {
+	store := beads.NewMemStore()
+
+	if _, err := store.Create(beads.Bead{
+		Title:  "vapor-order-root",
+		Type:   "task",
+		Labels: []string{"order-run:digest"},
+		Metadata: map[string]string{
+			"gc.kind": "wisp",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if !has {
+		t.Fatal("open root-only gc.kind=wisp bead must count as in-flight order work")
+	}
+}
+
 // TestHasOpenWorkStrictAllowsWispWithAllChildrenClosed protects the
 // ga-jra/ga-lo8c invariant after the tr-kds01 fix. A wisp root whose step
 // beads are ALL closed represents work that completed (or was hand-cleaned)
@@ -4976,6 +5531,7 @@ func TestHasOpenWorkStrictAllowsWispWithAllChildrenClosed(t *testing.T) {
 
 	wispRoot, err := store.Create(beads.Bead{
 		Title:  "mol-digest-generate",
+		Type:   "molecule",
 		Labels: []string{"order-run:digest"},
 	})
 	if err != nil {
@@ -5003,6 +5559,49 @@ func TestHasOpenWorkStrictAllowsWispWithAllChildrenClosed(t *testing.T) {
 	}
 }
 
+type parentListFailStore struct {
+	beads.Store
+	failParentID string
+	err          error
+}
+
+func (s parentListFailStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.ParentID == s.failParentID {
+		return nil, s.err
+	}
+	return s.Store.List(q)
+}
+
+func TestHasOpenWorkStrictPropagatesWispChildListError(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := parentListFailStore{
+		Store:        base,
+		failParentID: wispRoot.ID,
+		err:          fmt.Errorf("children tier unavailable"),
+	}
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err == nil {
+		t.Fatal("hasOpenWorkStrict err = nil, want child-list error")
+	}
+	if has {
+		t.Fatal("hasOpenWorkStrict returned true with child-list error; caller must fail closed on the error")
+	}
+	if !strings.Contains(err.Error(), "checking open descendants of wisp") {
+		t.Fatalf("hasOpenWorkStrict err = %q, want wisp descendant context", err)
+	}
+}
+
 // TestOrderDispatchOpenWispWithOpenStepsBlocksRedispatch is the
 // integration-level guard for tr-kds01. The scenario: a periodic
 // formula+pool order whose first dispatch's step beads were never picked
@@ -5013,6 +5612,7 @@ func TestOrderDispatchOpenWispWithOpenStepsBlocksRedispatch(t *testing.T) {
 
 	wispRoot, err := store.Create(beads.Bead{
 		Title:  "mol-digest-generate",
+		Type:   "molecule",
 		Labels: []string{"order-run:my-pool-order"},
 	})
 	if err != nil {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4930,6 +4930,125 @@ func TestHasOpenWorkStrictSkipsClosedTrackingBead(t *testing.T) {
 	}
 }
 
+// TestHasOpenWorkStrictBlocksOnWispWithOpenChildren is the regression guard
+// for tr-kds01: the deacon's cooldown gate fired a new digest wisp every 24h
+// even when the prior wisp's step beads had never been picked up by the pool
+// agent. The leftover open wisp root (no labelOrderTracking) is normally
+// treated as orphan state (ga-jra/ga-lo8c). But when the wisp's child step
+// beads are still open, the wisp is in-flight work — the pool agent simply
+// hasn't completed it yet — and the gate must block.
+func TestHasOpenWorkStrictBlocksOnWispWithOpenChildren(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Step bead still open — pool agent hasn't picked it up yet.
+	if _, err := store.Create(beads.Bead{
+		Title:    "determine-period",
+		ParentID: wispRoot.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if !has {
+		t.Fatal("wisp root with open child step beads must count as in-flight; " +
+			"the gate ignored them and the next cooldown tick poured a duplicate wisp (tr-kds01)")
+	}
+}
+
+// TestHasOpenWorkStrictAllowsWispWithAllChildrenClosed protects the
+// ga-jra/ga-lo8c invariant after the tr-kds01 fix. A wisp root whose step
+// beads are ALL closed represents work that completed (or was hand-cleaned)
+// but whose root was never auto-closed — molecule roots never close
+// themselves. Such a root must not permanently block re-dispatch.
+func TestHasOpenWorkStrictAllowsWispWithAllChildrenClosed(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "determine-period",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(child.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if has {
+		t.Fatal("wisp root with all children closed is leftover state, not in-flight work; " +
+			"counting it would permanently block re-dispatch (ga-jra/ga-lo8c)")
+	}
+}
+
+// TestOrderDispatchOpenWispWithOpenStepsBlocksRedispatch is the
+// integration-level guard for tr-kds01. The scenario: a periodic
+// formula+pool order whose first dispatch's step beads were never picked
+// up by the pool agent. The wisp root and its step beads sit open. The
+// next cooldown tick MUST NOT fire another wisp.
+func TestOrderDispatchOpenWispWithOpenStepsBlocksRedispatch(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Labels: []string{"order-run:my-pool-order"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Step bead still open — pool never picked up the prior wisp's work.
+	if _, err := store.Create(beads.Bead{
+		Title:    "determine-period",
+		ParentID: wispRoot.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ran := false
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		ran = true
+		return nil, nil
+	}
+
+	aa := []orders.Order{{
+		Name:     "my-pool-order",
+		Trigger:  "cooldown",
+		Interval: "1s",
+		Exec:     "scripts/run.sh",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now().Add(5*time.Second))
+	ad.drain(context.Background())
+
+	if ran {
+		t.Fatal("exec must NOT run — prior wisp has open step beads, " +
+			"the cooldown gate must treat it as in-flight (tr-kds01)")
+	}
+}
+
 // Unused but keep for future event assertion tests.
 var (
 	_ = (*memRecorder).hasSubject

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1771,12 +1771,18 @@ Close stale open order-tracking beads.
 This is intended for maintenance exec orders. It only closes tracking beads
 older than --stale-after so a fresh in-flight order is not interrupted.
 
+Use --include-wisps for operator recovery of abandoned order-run wisp
+subtrees whose open descendants are also older than --stale-after. Pass one
+or more scoped order names when --include-wisps is set; wisp recovery is
+order-scoped to avoid scanning unrelated beads.
+
 ```
-gc order sweep-tracking [flags]
+gc order sweep-tracking [order ...] [flags]
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--include-wisps` | bool |  | also close stale order-run wisp subtrees with open descendants |
 | `--quiet` | bool |  | suppress success output |
 | `--stale-after` | duration | `10m0s` | minimum age for an open tracking bead to be closed |
 


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery (gascity rig).

The `mol-digest-generate` cooldown trigger re-poured a periodic
formula every 24h even when the prior run's molecule was still open,
leaking one orphan molecule tree per day. This counts wisps with open
steps as in-flight so the trigger holds off until the prior run
finishes.

- Issue: tr-kds01
- Branch: polecat/tr-kds01
- Target: main