### PR TITLE
alerts: tune doctor/jsonl/dolt-health thresholds and deacon resume (tr-w4e)

### DIFF
--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -6293,6 +6293,97 @@ func TestOrderExecEnvSetsBeadsActorToOrderName(t *testing.T) {
 	}
 }
 
+// TestOrderExecEnvAppliesOrderEnvOverrides verifies that env entries
+// declared in `[order.env]` on the order TOML reach the dispatched
+// subprocess. This is the per-order tuning knob for threshold env vars
+// (GC_DOCTOR_LATENCY_WARN_S, GC_JSONL_SPIKE_THRESHOLD, etc.) that would
+// otherwise require editing the controller's parent environment.
+func TestOrderExecEnvAppliesOrderEnvOverrides(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("BEADS_ACTOR")
+
+	cityDir := t.TempDir()
+	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "pc"}
+	a := orders.Order{
+		Name:     "doctor",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "true",
+		Env: map[string]string{
+			"GC_DOCTOR_LATENCY_WARN_S": "5",
+			"CUSTOM_ORDER_FLAG":        "yes",
+		},
+	}
+
+	envSlice, err := orderExecEnvWithError(cityDir, nil, target, a)
+	if err != nil {
+		t.Fatalf("orderExecEnvWithError() error = %v", err)
+	}
+
+	wants := []string{
+		"GC_DOCTOR_LATENCY_WARN_S=5",
+		"CUSTOM_ORDER_FLAG=yes",
+	}
+	for _, want := range wants {
+		found := false
+		for _, entry := range envSlice {
+			if entry == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("orderExecEnv missing %q; env=%v", want, envSlice)
+		}
+	}
+}
+
+// TestOrderExecEnvOrderEnvOverridesProjectedDefaults verifies that
+// `[order.env]` wins over controller-derived defaults — the whole point
+// of per-order tuning is to override what the projection set up.
+func TestOrderExecEnvOrderEnvOverridesProjectedDefaults(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "pc"}
+	a := orders.Order{
+		Name:     "scoped-order",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "true",
+		Env: map[string]string{
+			// GC_STORE_SCOPE is set unconditionally to target.ScopeKind
+			// earlier in orderExecEnv; the override must win.
+			"GC_STORE_SCOPE": "overridden",
+		},
+	}
+
+	envSlice, err := orderExecEnvWithError(cityDir, nil, target, a)
+	if err != nil {
+		t.Fatalf("orderExecEnvWithError() error = %v", err)
+	}
+
+	want := "GC_STORE_SCOPE=overridden"
+	bad := "GC_STORE_SCOPE=city"
+	foundWant, foundBad := false, false
+	for _, entry := range envSlice {
+		switch entry {
+		case want:
+			foundWant = true
+		case bad:
+			foundBad = true
+		}
+	}
+	if !foundWant {
+		t.Errorf("orderExecEnv missing override %q; env=%v", want, envSlice)
+	}
+	if foundBad {
+		t.Errorf("orderExecEnv kept default %q despite override; env=%v", bad, envSlice)
+	}
+}
+
 // TestOrderExecEnvSkipsBeadsActorForUnnamedOrder guards against accidentally
 // emitting "BEADS_ACTOR=order:" (empty suffix) when an order has no name.
 // The conditional in orderExecEnv prevents that — verified here so future

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -155,6 +155,14 @@ func orderExecEnvWithError(cityPath string, cfg *config.City, target execStoreTa
 	applyOrderExecCanonicalDoltEnv(cityPath, target.ScopeRoot, env)
 	ensureProjectedDoltEnvExplicit(env)
 	ensureProjectedPostgresEnvExplicit(env)
+	// Order-supplied [order.env] entries take effect last so they can
+	// override the controller-derived projection. The intended use is
+	// per-order threshold tuning (e.g. raising GC_DOCTOR_LATENCY_WARN_S
+	// for a noisy city) without editing the order's shell scripts or
+	// the parent process environment.
+	for k, v := range a.Env {
+		env[k] = v
+	}
 	return mergeRuntimeEnv(nil, env), nil
 }
 

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -238,6 +238,12 @@ fi
 # Rig-local Dolt servers (configured via dolt.port in config.yaml)
 # are legitimate — exclude any PID listening on a known rig port.
 #
+# Foreign Dolt servers (managed by OTHER cities on the same host) are
+# also legitimate. We recognize them by parsing `--config <path>` from
+# the process command line and checking the sibling dolt.pid for a
+# self-reference. Without this, every patrol in every city flags the
+# others as zombies on shared dev hosts.
+#
 # GC_HEALTH_SKIP_ZOMBIE_SCAN is a test-only escape hatch. Zombie
 # enumeration spawns one `ps` per matching process, which on shared
 # dev machines with many accumulated dolt processes dominates the
@@ -260,6 +266,18 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
     [ -n "$rig_pid" ] && rig_dolt_pids="$rig_dolt_pids $rig_pid "
   done < "$_meta_cache"
 
+  # Parse `--config <path>` (or `--config=<path>`) from a `ps` args line.
+  extract_config_path() {
+    printf '%s\n' "$1" | awk '
+      {
+        for (i = 1; i <= NF; i++) {
+          if ($i == "--config" && (i + 1) <= NF) { print $(i+1); exit }
+          if (index($i, "--config=") == 1) { print substr($i, 10); exit }
+        }
+      }
+    '
+  }
+
   for p in $(pgrep -x dolt 2>/dev/null || true); do
     [ "$p" = "$server_pid" ] && continue
     case "$rig_dolt_pids" in *" $p "*) continue ;; esac
@@ -268,6 +286,17 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
       *sql-server*) ;;
       *) continue ;;
     esac
+    # Foreign-managed check: if --config points at a yaml whose sibling
+    # dolt.pid claims this PID, the process is owned by another managed
+    # Dolt instance (another city on this host) — not a zombie.
+    config_path=$(extract_config_path "$cmd")
+    if [ -n "$config_path" ] && [ -f "$config_path" ]; then
+      foreign_pid_file="$(dirname "$config_path")/dolt.pid"
+      if [ -f "$foreign_pid_file" ]; then
+        recorded_pid=$(head -1 "$foreign_pid_file" 2>/dev/null | tr -d ' \t\r\n')
+        [ "$recorded_pid" = "$p" ] && continue
+      fi
+    fi
     zombie_count=$((zombie_count + 1))
     zombie_pids="$zombie_pids $p"
   done

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -878,6 +878,215 @@ func TestHealthScriptZombieScanExcludesRigLocalServers(t *testing.T) {
 	}
 }
 
+// TestHealthScriptZombieScanExcludesForeignManagedServers verifies that
+// Dolt servers managed by OTHER cities on the same host are not flagged
+// as zombies. Regression guard for the bug where deacon patrol in every
+// city on a shared dev host counted the other cities' Dolt servers as
+// zombies, because the rig-local PID filter only sees rigs of the calling
+// city. The script now reads `--config <path>` from `ps -p $pid -o args=`
+// and checks for a sibling `dolt.pid` claiming the PID — the same shape
+// gc itself uses when it manages Dolt for any city.
+func TestHealthScriptZombieScanExcludesForeignManagedServers(t *testing.T) {
+	cityPath := t.TempDir()
+	foreignCityPath := t.TempDir()
+	fakeBin := t.TempDir()
+
+	mainPort := "19903"
+	mainPID := "424301"
+	foreignPID := "424302"
+	zombiePID := "424303"
+
+	// Foreign city: dolt-config.yaml + dolt.pid sibling claiming foreignPID.
+	foreignDoltDir := filepath.Join(foreignCityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(foreignDoltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreignConfigPath := filepath.Join(foreignDoltDir, "dolt-config.yaml")
+	if err := os.WriteFile(foreignConfigPath, []byte("# foreign city dolt config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreignDoltDir, "dolt.pid"),
+		[]byte(foreignPID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// City .beads directory with metadata.
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"dolt_database":"city"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake gc: fail so metadata_files() falls back to find.
+	writeExecutable(t, filepath.Join(fakeBin, "gc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake pgrep: returns main PID, foreign PID, and a true zombie PID.
+	writeExecutable(t, filepath.Join(fakeBin, "pgrep"),
+		fmt.Sprintf("#!/bin/sh\necho %s\necho %s\necho %s\n", mainPID, foreignPID, zombiePID))
+
+	// Fake lsof: maps main port to mainPID.
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"),
+		fmt.Sprintf(`#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    -iTCP:%s) echo %s; exit 0 ;;
+  esac
+done
+exit 1
+`, mainPort, mainPID))
+
+	// Fake ps: differentiates foreign PID (has --config) from zombie PID.
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "-p" ] && [ "$3" = "-o" ]; then
+  case "$4" in
+    pid=) printf ' %%s\n' "$2"; exit 0 ;;
+    args=)
+      case "$2" in
+        %s) echo "dolt sql-server --config %s"; exit 0 ;;
+        *)  echo "dolt sql-server"; exit 0 ;;
+      esac
+      ;;
+  esac
+fi
+exit 1
+`, foreignPID, foreignConfigPath))
+
+	// Fake nc: unreachable (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake dolt: SELECT 1 fails (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(
+		filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT",
+			"GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+mainPort,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
+	}
+	output := string(out)
+
+	// Only the true zombie (424303) should be counted; foreign-managed is excluded.
+	if !strings.Contains(output, `"zombie_count": 1`) {
+		t.Errorf("expected zombie_count 1; got:\n%s", output)
+	}
+	if strings.Contains(output, foreignPID) {
+		t.Errorf("foreign-managed Dolt PID %s should not be in zombie_pids; got:\n%s", foreignPID, output)
+	}
+	if !strings.Contains(output, zombiePID) {
+		t.Errorf("true zombie PID %s should be in zombie_pids; got:\n%s", zombiePID, output)
+	}
+}
+
+// TestHealthScriptZombieScanFlagsMismatchedForeignPidFile verifies that
+// when a foreign --config exists but the sibling dolt.pid does NOT match
+// the candidate PID (the recorded process died, a stranger reused the
+// PID, etc.), the candidate is still treated as a zombie. The foreign
+// recognition logic must self-validate against the sibling pid file
+// rather than trust the config-file path alone.
+func TestHealthScriptZombieScanFlagsMismatchedForeignPidFile(t *testing.T) {
+	cityPath := t.TempDir()
+	foreignCityPath := t.TempDir()
+	fakeBin := t.TempDir()
+
+	mainPort := "19904"
+	mainPID := "424401"
+	suspectPID := "424402"
+	// dolt.pid records a different PID — the sibling claim doesn't match
+	// the candidate, so the candidate is still a zombie.
+	recordedPID := "424499"
+
+	foreignDoltDir := filepath.Join(foreignCityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(foreignDoltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreignConfigPath := filepath.Join(foreignDoltDir, "dolt-config.yaml")
+	if err := os.WriteFile(foreignConfigPath, []byte("# foreign city dolt config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreignDoltDir, "dolt.pid"),
+		[]byte(recordedPID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"dolt_database":"city"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeExecutable(t, filepath.Join(fakeBin, "gc"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(fakeBin, "pgrep"),
+		fmt.Sprintf("#!/bin/sh\necho %s\necho %s\n", mainPID, suspectPID))
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"),
+		fmt.Sprintf(`#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    -iTCP:%s) echo %s; exit 0 ;;
+  esac
+done
+exit 1
+`, mainPort, mainPID))
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "-p" ] && [ "$3" = "-o" ]; then
+  case "$4" in
+    pid=) printf ' %%s\n' "$2"; exit 0 ;;
+    args=)
+      case "$2" in
+        %s) echo "dolt sql-server --config %s"; exit 0 ;;
+        *)  echo "dolt sql-server"; exit 0 ;;
+      esac
+      ;;
+  esac
+fi
+exit 1
+`, suspectPID, foreignConfigPath))
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(
+		filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT",
+			"GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+mainPort,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
+	}
+	output := string(out)
+
+	if !strings.Contains(output, `"zombie_count": 1`) {
+		t.Errorf("expected zombie_count 1 (PID-mismatched config does not protect from zombie status); got:\n%s", output)
+	}
+	if !strings.Contains(output, suspectPID) {
+		t.Errorf("suspect PID %s with mismatched dolt.pid should still be flagged as zombie; got:\n%s", suspectPID, output)
+	}
+}
+
 // TestHealthScriptJSONAlwaysExitsZero guards the JSON-mode exit
 // contract. Automation consumers (notably the deacon patrol formula)
 // parse the JSON payload and key health decisions off `server.reachable`.

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -66,7 +66,7 @@ gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
 NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+gc bd update "$NEW_WISP" --assignee="$GC_ALIAS" --status=in_progress
 
 # Step 4: Read the formula recipe — these are the steps to execute
 # (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -26,8 +26,11 @@ LEGACY_STATE_FILE="$CITY/.gc/jsonl-export-state.json"
 # Configurable via environment (defaults match the old formula).
 SPIKE_THRESHOLD="${GC_JSONL_SPIKE_THRESHOLD:-20}"  # percentage (0-100)
 # Skip the percentage spike check when the previous record count is below
-# this absolute floor — small-N percentages are noise. Set to 0 to disable.
-MIN_PREV_FOR_SPIKE_CHECK="${GC_JSONL_MIN_PREV_FOR_SPIKE:-10}"
+# this absolute floor — small-N percentages are noise. A fresh bead store
+# growing 10→309 records during stand-up legitimately trips a 20% delta on
+# every cycle; raising the floor to 100 keeps the check meaningful on real
+# data while suppressing stand-up flares. Set to 0 to disable.
+MIN_PREV_FOR_SPIKE_CHECK="${GC_JSONL_MIN_PREV_FOR_SPIKE:-100}"
 MAX_PUSH_FAILURES="${GC_JSONL_MAX_PUSH_FAILURES:-3}"
 PUSH_RETRY_DELAY_MIN="${GC_JSONL_PUSH_RETRY_DELAY_MIN:-1}"
 PUSH_RETRY_DELAY_SPAN="${GC_JSONL_PUSH_RETRY_DELAY_SPAN:-4}"

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -42,6 +42,14 @@ type Order struct {
 	Timeout string `toml:"timeout,omitempty"`
 	// Enabled controls whether the order is active. Defaults to true.
 	Enabled *bool `toml:"enabled,omitempty"`
+	// Env is a map of environment variables exported into an exec
+	// order's child process. Use the `[order.env]` TOML table to
+	// override thresholds (e.g. GC_DOCTOR_LATENCY_WARN_S) without
+	// editing the order's shell scripts or the controller's parent
+	// environment. Overrides are applied last and win over the
+	// controller-derived projection. Not currently plumbed for
+	// wisp dispatch.
+	Env map[string]string `toml:"env,omitempty"`
 	// Source is the absolute file path to the discovered order file (set by scanner, not from TOML).
 	Source string `toml:"-"`
 	// FormulaLayer is the formula layer directory this order was
@@ -62,18 +70,19 @@ func (a *Order) ScopedName() string {
 }
 
 type orderDecode struct {
-	Description string `toml:"description,omitempty"`
-	Formula     string `toml:"formula,omitempty"`
-	Exec        string `toml:"exec,omitempty"`
-	Trigger     string `toml:"trigger,omitempty"`
-	Gate        string `toml:"gate,omitempty"`
-	Interval    string `toml:"interval,omitempty"`
-	Schedule    string `toml:"schedule,omitempty"`
-	Check       string `toml:"check,omitempty"`
-	On          string `toml:"on,omitempty"`
-	Pool        string `toml:"pool,omitempty"`
-	Timeout     string `toml:"timeout,omitempty"`
-	Enabled     *bool  `toml:"enabled,omitempty"`
+	Description string            `toml:"description,omitempty"`
+	Formula     string            `toml:"formula,omitempty"`
+	Exec        string            `toml:"exec,omitempty"`
+	Trigger     string            `toml:"trigger,omitempty"`
+	Gate        string            `toml:"gate,omitempty"`
+	Interval    string            `toml:"interval,omitempty"`
+	Schedule    string            `toml:"schedule,omitempty"`
+	Check       string            `toml:"check,omitempty"`
+	On          string            `toml:"on,omitempty"`
+	Pool        string            `toml:"pool,omitempty"`
+	Timeout     string            `toml:"timeout,omitempty"`
+	Enabled     *bool             `toml:"enabled,omitempty"`
+	Env         map[string]string `toml:"env,omitempty"`
 }
 
 func (d orderDecode) normalized() Order {
@@ -93,6 +102,7 @@ func (d orderDecode) normalized() Order {
 		Pool:        d.Pool,
 		Timeout:     d.Timeout,
 		Enabled:     d.Enabled,
+		Env:         d.Env,
 	}
 }
 

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -328,3 +328,41 @@ interval = "24h"
 		t.Fatalf("Trigger = %q, want %q", a.Trigger, "cron")
 	}
 }
+
+func TestParseEnv(t *testing.T) {
+	data := []byte(`
+[order]
+exec = "scripts/doctor.sh"
+trigger = "cooldown"
+interval = "5m"
+
+[order.env]
+GC_DOCTOR_LATENCY_WARN_S = "3"
+GC_JSONL_SPIKE_THRESHOLD = "30"
+`)
+	a, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if a.Env["GC_DOCTOR_LATENCY_WARN_S"] != "3" {
+		t.Errorf("Env[GC_DOCTOR_LATENCY_WARN_S] = %q, want %q", a.Env["GC_DOCTOR_LATENCY_WARN_S"], "3")
+	}
+	if a.Env["GC_JSONL_SPIKE_THRESHOLD"] != "30" {
+		t.Errorf("Env[GC_JSONL_SPIKE_THRESHOLD] = %q, want %q", a.Env["GC_JSONL_SPIKE_THRESHOLD"], "30")
+	}
+}
+
+func TestParseEnvAbsent(t *testing.T) {
+	data := []byte(`
+[order]
+formula = "mol-test"
+trigger = "manual"
+`)
+	a, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(a.Env) != 0 {
+		t.Errorf("Env = %v, want empty when absent", a.Env)
+	}
+}


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery (gascity rig).

Alert-hygiene work surfaced during gascity-city stand-up: doctor
latency threshold, JSONL spike absolute-count floor, backup advisory
tolerance, order TOML env override, zombie cross-city false-positive,
CLI/JSON orphan reporting, and deacon resume protocol for open wisps.

- Issue: tr-w4e
- Branch: polecat/tr-w4e
- Target: main