### PR TITLE
fix(supervisor): hard-exit on second destructive shutdown signal (tr-jv9xk)

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -209,6 +209,19 @@ var supervisorShutdownSettleDelay = 50 * time.Millisecond
 
 var supervisorSignalNotify = signal.Notify
 
+// supervisorHardExitCodeSecondSignal is the exit code for the second-signal
+// hard-exit path. 130 is the shell convention for "terminated by SIGINT,"
+// which lets operators distinguish this from clean exit (0) or
+// graceful-stop error (1).
+const supervisorHardExitCodeSecondSignal = 130
+
+// supervisorHardExit terminates the supervisor immediately, bypassing the
+// graceful-shutdown sequence. Overridable for tests.
+var supervisorHardExit = func(code int) {
+	fmt.Fprintln(os.Stderr, "gc supervisor: second shutdown signal received; exiting immediately") //nolint:errcheck
+	os.Exit(code)
+}
+
 func supervisorPreserveSessionsOnSignal() bool {
 	return os.Getenv(supervisorPreserveSessionsOnSignalEnv) == "1"
 }
@@ -284,6 +297,10 @@ func requestSupervisorShutdown(stderr io.Writer, rec events.Recorder, shutdownCt
 }
 
 func supervisorSignalLoop(sigCh <-chan os.Signal, done <-chan struct{}, requestShutdown func(supervisorShutdownMode, shutdownTrigger), requestReconcile func()) {
+	// Repeated destructive signals would otherwise be silently absorbed
+	// (shutdownCtl.request and cancel() are both idempotent), so a second
+	// SIGINT/SIGTERM escalates to a hard exit instead of looking ignored.
+	destructiveSignalCount := 0
 	for {
 		select {
 		case sig := <-sigCh:
@@ -294,7 +311,15 @@ func supervisorSignalLoop(sigCh <-chan os.Signal, done <-chan struct{}, requestS
 				requestReconcile()
 				continue
 			}
-			requestShutdown(supervisorShutdownModeForSignal(sig), shutdownTrigger{
+			mode := supervisorShutdownModeForSignal(sig)
+			if mode == supervisorShutdownDestructive {
+				destructiveSignalCount++
+				if destructiveSignalCount >= 2 {
+					supervisorHardExit(supervisorHardExitCodeSecondSignal)
+					return
+				}
+			}
+			requestShutdown(mode, shutdownTrigger{
 				Source: "signal",
 				Signal: sig.String(),
 			})

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -209,16 +209,20 @@ var supervisorShutdownSettleDelay = 50 * time.Millisecond
 
 var supervisorSignalNotify = signal.Notify
 
-// supervisorHardExitCodeSecondSignal is the exit code for the second-signal
-// hard-exit path. 130 is the shell convention for "terminated by SIGINT,"
-// which lets operators distinguish this from clean exit (0) or
-// graceful-stop error (1).
-const supervisorHardExitCodeSecondSignal = 130
+// supervisorHardExitCodeRepeatedShutdown is the exit code for repeated
+// destructive shutdown escalation. 130 approximates the shell SIGINT
+// convention; the supervisor does not retain which destructive signal caused
+// the escalation.
+const supervisorHardExitCodeRepeatedShutdown = 130
 
-// supervisorHardExit terminates the supervisor immediately, bypassing the
-// graceful-shutdown sequence. Overridable for tests.
-var supervisorHardExit = func(code int) {
-	fmt.Fprintln(os.Stderr, "gc supervisor: second shutdown signal received; exiting immediately") //nolint:errcheck
+// supervisorHardExit terminates the supervisor immediately. It intentionally
+// bypasses graceful cleanup and may leave managed sessions or child processes
+// alive for operator recovery. Overridable for tests.
+var supervisorHardExit = func(stderr io.Writer, code int) {
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	fmt.Fprintln(stderr, "gc supervisor: repeated shutdown request received; exiting immediately") //nolint:errcheck
 	os.Exit(code)
 }
 
@@ -266,7 +270,7 @@ func supervisorShutdownModeName(mode supervisorShutdownMode) string {
 	}
 }
 
-func requestSupervisorShutdown(stderr io.Writer, rec events.Recorder, shutdownCtl *supervisorShutdownController, cancel context.CancelFunc, mode supervisorShutdownMode, trigger shutdownTrigger) {
+func requestSupervisorShutdown(stderr io.Writer, rec events.Recorder, shutdownCtl *supervisorShutdownController, cancel context.CancelFunc, mode supervisorShutdownMode, trigger shutdownTrigger) bool {
 	modeName := supervisorShutdownModeName(mode)
 	// Plain-text breadcrumb to stderr -> ~/.gc/supervisor.log via the
 	// launchd/systemd-redirected stream. This is the canonical place
@@ -292,15 +296,14 @@ func requestSupervisorShutdown(stderr io.Writer, rec events.Recorder, shutdownCt
 			})
 		}
 	}
-	shutdownCtl.request(mode)
-	cancel()
+	repeatedDestructive := shutdownCtl.request(mode)
+	if !repeatedDestructive {
+		cancel()
+	}
+	return repeatedDestructive
 }
 
-func supervisorSignalLoop(sigCh <-chan os.Signal, done <-chan struct{}, requestShutdown func(supervisorShutdownMode, shutdownTrigger), requestReconcile func()) {
-	// Repeated destructive signals would otherwise be silently absorbed
-	// (shutdownCtl.request and cancel() are both idempotent), so a second
-	// SIGINT/SIGTERM escalates to a hard exit instead of looking ignored.
-	destructiveSignalCount := 0
+func supervisorSignalLoop(sigCh <-chan os.Signal, done <-chan struct{}, requestShutdown func(supervisorShutdownMode, shutdownTrigger) bool, requestReconcile func(), stderr io.Writer) {
 	for {
 		select {
 		case sig := <-sigCh:
@@ -312,37 +315,39 @@ func supervisorSignalLoop(sigCh <-chan os.Signal, done <-chan struct{}, requestS
 				continue
 			}
 			mode := supervisorShutdownModeForSignal(sig)
-			if mode == supervisorShutdownDestructive {
-				destructiveSignalCount++
-				if destructiveSignalCount >= 2 {
-					supervisorHardExit(supervisorHardExitCodeSecondSignal)
-					return
-				}
-			}
-			requestShutdown(mode, shutdownTrigger{
+			if requestShutdown(mode, shutdownTrigger{
 				Source: "signal",
 				Signal: sig.String(),
-			})
+			}) {
+				supervisorHardExit(stderr, supervisorHardExitCodeRepeatedShutdown)
+				return
+			}
 		case <-done:
 			return
 		}
 	}
 }
 
-func (c *supervisorShutdownController) request(mode supervisorShutdownMode) {
+// request records shutdown intent and reports whether this is a repeated
+// destructive shutdown request. Signal callers use a repeated destructive
+// request as the hard-exit trigger; socket callers keep the request local.
+func (c *supervisorShutdownController) request(mode supervisorShutdownMode) bool {
 	if mode == supervisorShutdownDestructive {
-		c.destructiveRequested.Store(true)
+		if !c.destructiveRequested.CompareAndSwap(false, true) {
+			return true
+		}
 		c.mode.Store(int32(supervisorShutdownDestructive))
 		c.destructiveOnce.Do(func() {
 			if c.destructiveCh != nil {
 				close(c.destructiveCh)
 			}
 		})
-		return
+		return false
 	}
 	if mode == supervisorShutdownPreserveSessions {
 		c.mode.CompareAndSwap(int32(supervisorShutdownNone), int32(supervisorShutdownPreserveSessions))
 	}
+	return false
 }
 
 func (c *supervisorShutdownController) preservesSessions() bool {
@@ -394,7 +399,7 @@ func (s *shutdownState) finish(err error) {
 	close(s.done)
 }
 
-func startSupervisorSocket(sockPath string, requestShutdown func(supervisorShutdownMode, shutdownTrigger), reconcileCh chan reconcileRequest, shut *shutdownState) (net.Listener, error) {
+func startSupervisorSocket(sockPath string, requestShutdown func(supervisorShutdownMode, shutdownTrigger) bool, reconcileCh chan reconcileRequest, shut *shutdownState) (net.Listener, error) {
 	os.Remove(sockPath) //nolint:errcheck // remove stale socket from previous crash
 	lis, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -426,7 +431,7 @@ func startSupervisorSocket(sockPath string, requestShutdown func(supervisorShutd
 // then — if the client keeps the connection open — blocks until shutdown
 // completes and sends a second line "done:ok\n" or "done:err:<detail>\n"
 // so --wait clients can distinguish clean shutdown from partial failure.
-func handleSupervisorConn(conn net.Conn, requestShutdown func(supervisorShutdownMode, shutdownTrigger), reconcileCh chan reconcileRequest, shut *shutdownState) {
+func handleSupervisorConn(conn net.Conn, requestShutdown func(supervisorShutdownMode, shutdownTrigger) bool, reconcileCh chan reconcileRequest, shut *shutdownState) {
 	defer conn.Close()                                     //nolint:errcheck
 	conn.SetReadDeadline(time.Now().Add(60 * time.Second)) //nolint:errcheck
 	scanner := bufio.NewScanner(conn)
@@ -437,7 +442,7 @@ func handleSupervisorConn(conn net.Conn, requestShutdown func(supervisorShutdown
 			if addr := conn.RemoteAddr(); addr != nil {
 				peer = addr.String()
 			}
-			requestShutdown(supervisorShutdownDestructive, shutdownTrigger{
+			_ = requestShutdown(supervisorShutdownDestructive, shutdownTrigger{
 				Source:     "socket_stop",
 				ClientAddr: peer,
 			})
@@ -909,8 +914,8 @@ func runSupervisor(stdout, stderr io.Writer) int {
 		registry.SetSupervisorRecorder(supFR)
 		defer supFR.Close() //nolint:errcheck
 	}
-	requestShutdown := func(mode supervisorShutdownMode, trigger shutdownTrigger) {
-		requestSupervisorShutdown(stderr, registry.SupervisorEventRecorder(), shutdownCtl, cancel, mode, trigger)
+	requestShutdown := func(mode supervisorShutdownMode, trigger shutdownTrigger) bool {
+		return requestSupervisorShutdown(stderr, registry.SupervisorEventRecorder(), shutdownCtl, cancel, mode, trigger)
 	}
 
 	// Reconcile channel — triggers immediate reconciliation from SIGHUP
@@ -929,7 +934,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 		case reconcileCh <- reconcileRequest{}:
 		default: // reconcile already pending
 		}
-	})
+	}, stderr)
 
 	// Load supervisor config.
 	supCfg, err := supervisor.LoadConfig(supervisor.ConfigPath())

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -4466,10 +4466,13 @@ func TestSupervisorSignalLoopKeepsLateDestructiveEscalationUntilShutdownDone(t *
 	var shutdownStartedOnce sync.Once
 	ctl := newSupervisorShutdownController()
 
-	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, _ shutdownTrigger) {
-		ctl.request(mode)
-		shutdownStartedOnce.Do(func() { close(shutdownStarted) })
-	}, func() {})
+	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, _ shutdownTrigger) bool {
+		repeatedDestructive := ctl.request(mode)
+		if !repeatedDestructive {
+			shutdownStartedOnce.Do(func() { close(shutdownStarted) })
+		}
+		return repeatedDestructive
+	}, func() {}, io.Discard)
 
 	sigCh <- syscall.SIGTERM
 	select {
@@ -4496,10 +4499,11 @@ func TestSupervisorSignalLoopRecordsSignalAttribution(t *testing.T) {
 
 	gotMode := make(chan supervisorShutdownMode, 1)
 	gotTrigger := make(chan shutdownTrigger, 1)
-	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, trigger shutdownTrigger) {
+	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, trigger shutdownTrigger) bool {
 		gotMode <- mode
 		gotTrigger <- trigger
-	}, func() {})
+		return false
+	}, func() {}, io.Discard)
 
 	sigCh <- syscall.SIGTERM
 	select {
@@ -4603,9 +4607,10 @@ func TestHandleSupervisorConnStopRecordsSocketAttribution(t *testing.T) {
 	handlerDone := make(chan struct{})
 	go func() {
 		defer close(handlerDone)
-		handleSupervisorConn(server, func(mode supervisorShutdownMode, trigger shutdownTrigger) {
+		handleSupervisorConn(server, func(mode supervisorShutdownMode, trigger shutdownTrigger) bool {
 			gotMode <- mode
 			gotTrigger <- trigger
+			return false
 		}, nil, nil)
 	}()
 
@@ -4679,7 +4684,7 @@ func installHardExitHook(t *testing.T) <-chan int {
 	t.Helper()
 	calls := make(chan int, 1)
 	prev := supervisorHardExit
-	supervisorHardExit = func(code int) {
+	supervisorHardExit = func(_ io.Writer, code int) {
 		select {
 		case calls <- code:
 		default:
@@ -4689,16 +4694,25 @@ func installHardExitHook(t *testing.T) <-chan int {
 	return calls
 }
 
+func recordingShutdownRequester(ctl *supervisorShutdownController, shutdowns chan<- supervisorShutdownMode) func(supervisorShutdownMode, shutdownTrigger) bool {
+	return func(mode supervisorShutdownMode, _ shutdownTrigger) bool {
+		repeatedDestructive := ctl.request(mode)
+		if !repeatedDestructive {
+			shutdowns <- mode
+		}
+		return repeatedDestructive
+	}
+}
+
 func TestSupervisorSignalLoopHardExitsOnSecondDestructiveSignal(t *testing.T) {
 	hardExitCalls := installHardExitHook(t)
 
 	sigCh := make(chan os.Signal, 2)
 	done := make(chan struct{})
 	shutdowns := make(chan supervisorShutdownMode, 4)
+	ctl := newSupervisorShutdownController()
 
-	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, _ shutdownTrigger) {
-		shutdowns <- mode
-	}, func() {})
+	go supervisorSignalLoop(sigCh, done, recordingShutdownRequester(ctl, shutdowns), func() {}, io.Discard)
 	defer close(done)
 
 	sigCh <- syscall.SIGTERM
@@ -4719,8 +4733,8 @@ func TestSupervisorSignalLoopHardExitsOnSecondDestructiveSignal(t *testing.T) {
 	sigCh <- syscall.SIGTERM
 	select {
 	case code := <-hardExitCalls:
-		if code != supervisorHardExitCodeSecondSignal {
-			t.Fatalf("hard exit code = %d, want %d", code, supervisorHardExitCodeSecondSignal)
+		if code != supervisorHardExitCodeRepeatedShutdown {
+			t.Fatalf("hard exit code = %d, want %d", code, supervisorHardExitCodeRepeatedShutdown)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("second SIGTERM did not trigger hard exit")
@@ -4732,6 +4746,34 @@ func TestSupervisorSignalLoopHardExitsOnSecondDestructiveSignal(t *testing.T) {
 	}
 }
 
+func TestSupervisorSignalLoopHardExitsAfterSocketShutdownThenDestructiveSignal(t *testing.T) {
+	hardExitCalls := installHardExitHook(t)
+	ctl := newSupervisorShutdownController()
+	ctl.request(supervisorShutdownDestructive)
+
+	sigCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	shutdowns := make(chan supervisorShutdownMode, 1)
+
+	go supervisorSignalLoop(sigCh, done, recordingShutdownRequester(ctl, shutdowns), func() {}, io.Discard)
+	defer close(done)
+
+	sigCh <- syscall.SIGTERM
+	select {
+	case code := <-hardExitCalls:
+		if code != supervisorHardExitCodeRepeatedShutdown {
+			t.Fatalf("hard exit code = %d, want %d", code, supervisorHardExitCodeRepeatedShutdown)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SIGTERM after socket shutdown did not trigger hard exit")
+	}
+	select {
+	case mode := <-shutdowns:
+		t.Fatalf("SIGTERM after socket shutdown should hard-exit before calling requestShutdown; got mode %v", mode)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestSupervisorSignalLoopHardExitsOnDestructiveAfterPreserveEscalation(t *testing.T) {
 	t.Setenv(supervisorPreserveSessionsOnSignalEnv, "1")
 	hardExitCalls := installHardExitHook(t)
@@ -4739,10 +4781,9 @@ func TestSupervisorSignalLoopHardExitsOnDestructiveAfterPreserveEscalation(t *te
 	sigCh := make(chan os.Signal, 3)
 	done := make(chan struct{})
 	shutdowns := make(chan supervisorShutdownMode, 4)
+	ctl := newSupervisorShutdownController()
 
-	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, _ shutdownTrigger) {
-		shutdowns <- mode
-	}, func() {})
+	go supervisorSignalLoop(sigCh, done, recordingShutdownRequester(ctl, shutdowns), func() {}, io.Discard)
 	defer close(done)
 
 	sigCh <- syscall.SIGTERM
@@ -4773,8 +4814,8 @@ func TestSupervisorSignalLoopHardExitsOnDestructiveAfterPreserveEscalation(t *te
 	sigCh <- syscall.SIGINT
 	select {
 	case code := <-hardExitCalls:
-		if code != supervisorHardExitCodeSecondSignal {
-			t.Fatalf("hard exit code = %d, want %d", code, supervisorHardExitCodeSecondSignal)
+		if code != supervisorHardExitCodeRepeatedShutdown {
+			t.Fatalf("hard exit code = %d, want %d", code, supervisorHardExitCodeRepeatedShutdown)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("second destructive signal after escalation did not trigger hard exit")
@@ -4788,12 +4829,11 @@ func TestSupervisorSignalLoopSIGHUPDoesNotCountTowardHardExit(t *testing.T) {
 	done := make(chan struct{})
 	shutdowns := make(chan supervisorShutdownMode, 4)
 	reconciles := make(chan struct{}, 4)
+	ctl := newSupervisorShutdownController()
 
-	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, _ shutdownTrigger) {
-		shutdowns <- mode
-	}, func() {
+	go supervisorSignalLoop(sigCh, done, recordingShutdownRequester(ctl, shutdowns), func() {
 		reconciles <- struct{}{}
-	})
+	}, io.Discard)
 	defer close(done)
 
 	sigCh <- syscall.SIGHUP

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -4672,6 +4672,161 @@ func TestSupervisorShutdownModeForSignalPreservesOnlySIGTERMWhenConfigured(t *te
 	}
 }
 
+// installHardExitHook replaces supervisorHardExit with a test hook that
+// records the exit code and signals via the returned channel instead of
+// terminating the test process. Restores the original on cleanup.
+func installHardExitHook(t *testing.T) <-chan int {
+	t.Helper()
+	calls := make(chan int, 1)
+	prev := supervisorHardExit
+	supervisorHardExit = func(code int) {
+		select {
+		case calls <- code:
+		default:
+		}
+	}
+	t.Cleanup(func() { supervisorHardExit = prev })
+	return calls
+}
+
+func TestSupervisorSignalLoopHardExitsOnSecondDestructiveSignal(t *testing.T) {
+	hardExitCalls := installHardExitHook(t)
+
+	sigCh := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	shutdowns := make(chan supervisorShutdownMode, 4)
+
+	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, _ shutdownTrigger) {
+		shutdowns <- mode
+	}, func() {})
+	defer close(done)
+
+	sigCh <- syscall.SIGTERM
+	select {
+	case mode := <-shutdowns:
+		if mode != supervisorShutdownDestructive {
+			t.Fatalf("first signal mode = %v, want destructive", mode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first SIGTERM did not trigger requestShutdown")
+	}
+	select {
+	case code := <-hardExitCalls:
+		t.Fatalf("hard exit fired after only one destructive signal, code=%d", code)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	sigCh <- syscall.SIGTERM
+	select {
+	case code := <-hardExitCalls:
+		if code != supervisorHardExitCodeSecondSignal {
+			t.Fatalf("hard exit code = %d, want %d", code, supervisorHardExitCodeSecondSignal)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second SIGTERM did not trigger hard exit")
+	}
+	select {
+	case mode := <-shutdowns:
+		t.Fatalf("second SIGTERM should hard-exit before calling requestShutdown; got mode %v", mode)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSupervisorSignalLoopHardExitsOnDestructiveAfterPreserveEscalation(t *testing.T) {
+	t.Setenv(supervisorPreserveSessionsOnSignalEnv, "1")
+	hardExitCalls := installHardExitHook(t)
+
+	sigCh := make(chan os.Signal, 3)
+	done := make(chan struct{})
+	shutdowns := make(chan supervisorShutdownMode, 4)
+
+	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, _ shutdownTrigger) {
+		shutdowns <- mode
+	}, func() {})
+	defer close(done)
+
+	sigCh <- syscall.SIGTERM
+	select {
+	case mode := <-shutdowns:
+		if mode != supervisorShutdownPreserveSessions {
+			t.Fatalf("first signal mode = %v, want preserve", mode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first SIGTERM did not trigger requestShutdown")
+	}
+
+	sigCh <- syscall.SIGINT
+	select {
+	case mode := <-shutdowns:
+		if mode != supervisorShutdownDestructive {
+			t.Fatalf("escalation mode = %v, want destructive", mode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SIGINT escalation did not trigger requestShutdown")
+	}
+	select {
+	case code := <-hardExitCalls:
+		t.Fatalf("hard exit fired during normal preserve→destructive escalation, code=%d", code)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	sigCh <- syscall.SIGINT
+	select {
+	case code := <-hardExitCalls:
+		if code != supervisorHardExitCodeSecondSignal {
+			t.Fatalf("hard exit code = %d, want %d", code, supervisorHardExitCodeSecondSignal)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second destructive signal after escalation did not trigger hard exit")
+	}
+}
+
+func TestSupervisorSignalLoopSIGHUPDoesNotCountTowardHardExit(t *testing.T) {
+	hardExitCalls := installHardExitHook(t)
+
+	sigCh := make(chan os.Signal, 4)
+	done := make(chan struct{})
+	shutdowns := make(chan supervisorShutdownMode, 4)
+	reconciles := make(chan struct{}, 4)
+
+	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode, _ shutdownTrigger) {
+		shutdowns <- mode
+	}, func() {
+		reconciles <- struct{}{}
+	})
+	defer close(done)
+
+	sigCh <- syscall.SIGHUP
+	sigCh <- syscall.SIGHUP
+	for i := 0; i < 2; i++ {
+		select {
+		case <-reconciles:
+		case <-time.After(time.Second):
+			t.Fatalf("SIGHUP %d did not trigger reconcile", i+1)
+		}
+	}
+	select {
+	case code := <-hardExitCalls:
+		t.Fatalf("SIGHUP triggered hard exit, code=%d", code)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	sigCh <- syscall.SIGTERM
+	select {
+	case mode := <-shutdowns:
+		if mode != supervisorShutdownDestructive {
+			t.Fatalf("SIGTERM after SIGHUPs mode = %v, want destructive", mode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SIGTERM after SIGHUPs did not trigger requestShutdown")
+	}
+	select {
+	case code := <-hardExitCalls:
+		t.Fatalf("first SIGTERM after SIGHUPs triggered hard exit, code=%d", code)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestStopSupervisorWithWaitStopsSystemdServiceAfterAckBeforeDone(t *testing.T) {
 	if goruntime.GOOS != "linux" {
 		t.Skip("systemd path only applies on linux")

--- a/test/acceptance/gastown_smoke_test.go
+++ b/test/acceptance/gastown_smoke_test.go
@@ -271,7 +271,7 @@ func TestGastownSmoke_WithRig(t *testing.T) {
 	c.InitFrom(filepath.Join(helpers.ExamplesDir(), "gastown"))
 
 	// Create a minimal git repo to serve as a rig.
-	rigDir := filepath.Join(t.TempDir(), "myrig")
+	rigDir := filepath.Join(helpers.TempDir(t), "myrig")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatalf("creating rig dir: %v", err)
 	}

--- a/test/acceptance/helpers/city.go
+++ b/test/acceptance/helpers/city.go
@@ -354,6 +354,12 @@ func acceptanceTempDir(t *testing.T) string {
 	return dir
 }
 
+// TempDir creates a retry-cleaned temp directory for acceptance test artifacts.
+func TempDir(t *testing.T) string {
+	t.Helper()
+	return acceptanceTempDir(t)
+}
+
 func removeAllWithRetry(t *testing.T, dir string, timeout, interval time.Duration) {
 	t.Helper()
 	if err := removeAllWithRetryFunc(dir, timeout, interval, os.RemoveAll); err != nil {

--- a/test/acceptance/rig_test.go
+++ b/test/acceptance/rig_test.go
@@ -21,7 +21,7 @@ import (
 // createGitRig creates a minimal git repo suitable for gc rig add.
 func createGitRig(t *testing.T) string {
 	t.Helper()
-	rigDir := filepath.Join(t.TempDir(), "testrig")
+	rigDir := filepath.Join(helpers.TempDir(t), "testrig")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatalf("creating rig dir: %v", err)
 	}


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery (gascity rig).

`gc supervisor stop` returned but the supervisor kept running, and
SIGTERM was ignored — only SIGKILL terminated it, losing in-flight
drain state. This restores graceful shutdown by hard-exiting on a
second destructive shutdown signal.

- Issue: tr-jv9xk
- Branch: polecat/tr-jv9xk
- Target: main