### PR TITLE
fix: address launch visibility review findings

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -40,19 +40,19 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 	}
 	if attempt.Status != "closed" {
 		if err := ensureBlockingDependency(store, bead.ID, attempt.ID); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: blocking on pending attempt %s: %w", bead.ID, attempt.ID, err)
 		}
 		if err := syncControlEpochToAttempt(store, bead, attempt); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: advancing recovered attempt epoch for %s: %w", bead.ID, attempt.ID, err)
 		}
 		if err := closeGeneratedSpecBeadsForAttempt(store, bead, attempt); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: closing generated spec beads for pending attempt %s: %w", bead.ID, attempt.ID, err)
@@ -81,7 +81,7 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing passed: %w", bead.ID, err)
 		}
-		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
 		}
@@ -100,7 +100,7 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing hard-failed: %w", bead.ID, err)
 		}
-		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
 		}
@@ -112,7 +112,7 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 			if err != nil {
 				return ControlResult{}, err
 			}
-			scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+			scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
 			if err != nil {
 				return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
 			}
@@ -124,14 +124,14 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		spawnMetadata := map[string]string{"gc.attempt_log": attemptLog}
 		clearControllerSpawnErrorMetadata(spawnMetadata)
 		if err := store.SetMetadataBatch(bead.ID, spawnMetadata); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
 		}
 		nextAttempt := attemptNum + 1
 		if err := spawnNextAttempt(context.Background(), store, bead, nextAttempt, opts); err != nil {
-			if markControllerSpawnError(store, bead.ID, err) {
+			if markControllerSpawnError(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: spawning attempt %d: %w", bead.ID, nextAttempt, err)
@@ -161,19 +161,19 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 	}
 	if iteration.Status != "closed" {
 		if err := ensureBlockingDependency(store, bead.ID, iteration.ID); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: blocking on pending iteration %s: %w", bead.ID, iteration.ID, err)
 		}
 		if err := syncControlEpochToAttempt(store, bead, iteration); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: advancing recovered iteration epoch for %s: %w", bead.ID, iteration.ID, err)
 		}
 		if err := closeGeneratedSpecBeadsForAttempt(store, bead, iteration); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: closing generated spec beads for pending iteration %s: %w", bead.ID, iteration.ID, err)
@@ -220,7 +220,7 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing passed: %w", bead.ID, err)
 		}
-		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
 		}
@@ -237,7 +237,7 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing exhausted: %w", bead.ID, err)
 		}
-		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
+		scopeResult, err := reconcileClosedScopeMemberWithOptions(store, bead.ID, opts)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: reconciling enclosing scope: %w", bead.ID, err)
 		}
@@ -248,14 +248,14 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 	spawnMetadata := map[string]string{"gc.attempt_log": attemptLog}
 	clearControllerSpawnErrorMetadata(spawnMetadata)
 	if err := store.SetMetadataBatch(bead.ID, spawnMetadata); err != nil {
-		if controllerSpawnBoundaryPending(store, bead.ID, err) {
+		if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 			return ControlResult{}, ErrControlPending
 		}
 		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
 	}
 	nextIteration := iterationNum + 1
 	if err := spawnNextAttempt(context.Background(), store, bead, nextIteration, opts); err != nil {
-		if markControllerSpawnError(store, bead.ID, err) {
+		if markControllerSpawnError(store, bead.ID, err, opts) {
 			return ControlResult{}, ErrControlPending
 		}
 		return ControlResult{}, fmt.Errorf("%s: spawning iteration %d: %w", bead.ID, nextIteration, err)
@@ -277,11 +277,11 @@ func ensureBlockingDependency(store beads.Store, issueID, dependsOnID string) er
 	return store.DepAdd(issueID, dependsOnID, "blocks")
 }
 
-func controllerSpawnBoundaryPending(store beads.Store, beadID string, err error) bool {
+func controllerSpawnBoundaryPending(store beads.Store, beadID string, err error, opts ProcessOptions) bool {
 	if err == nil {
 		return false
 	}
-	return markControllerSpawnError(store, beadID, err)
+	return markControllerSpawnError(store, beadID, err, opts)
 }
 
 func syncControlEpochToAttempt(store beads.Store, control, attempt beads.Bead) error {
@@ -296,7 +296,7 @@ func syncControlEpochToAttempt(store beads.Store, control, attempt beads.Bead) e
 	return store.SetMetadata(control.ID, "gc.control_epoch", strconv.Itoa(attemptNum))
 }
 
-func markControllerSpawnError(store beads.Store, beadID string, err error) bool {
+func markControllerSpawnError(store beads.Store, beadID string, err error, opts ProcessOptions) bool {
 	metadata := map[string]string{
 		"gc.controller_error": err.Error(),
 	}
@@ -314,7 +314,7 @@ func markControllerSpawnError(store beads.Store, beadID string, err error) bool 
 	_ = setOutcomeAndClose(store, beadID, "fail")
 	// Reconcile any enclosing scope so a controller_error terminal closure
 	// does not leave the scope body stalled.
-	_, _ = reconcileClosedScopeMember(store, beadID)
+	_, _ = reconcileClosedScopeMemberWithOptions(store, beadID, opts)
 	return false
 }
 

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -690,10 +691,21 @@ func TestProcessRetryControlControllerError(t *testing.T) {
 			"gc.root_bead_id":     root.ID,
 			"gc.step_ref":         "mol-test.review",
 			"gc.step_id":          "review",
+			"gc.scope_ref":        "review-scope",
+			"gc.scope_role":       "member",
 			"gc.max_attempts":     "3",
 			"gc.on_exhausted":     "hard_fail",
 			"gc.source_step_spec": `{not valid json`,
 			"gc.control_epoch":    "1",
+		},
+	})
+	body := mustCreate(t, store, beads.Bead{
+		Title: "review scope",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": root.ID,
+			"gc.scope_ref":    "review-scope",
+			"gc.scope_role":   "body",
 		},
 	})
 	attempt1 := mustCreate(t, store, beads.Bead{
@@ -710,7 +722,14 @@ func TestProcessRetryControlControllerError(t *testing.T) {
 	mustClose(t, store, attempt1.ID)
 	mustDep(t, store, control.ID, attempt1.ID, "blocks")
 
-	_, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	sawTrace := false
+	_, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{
+		Tracef: func(format string, args ...any) {
+			if strings.Contains(fmt.Sprintf(format, args...), "resolve-body") {
+				sawTrace = true
+			}
+		},
+	})
 	if err == nil {
 		t.Fatal("expected error from bad source_step_spec")
 	}
@@ -731,6 +750,13 @@ func TestProcessRetryControlControllerError(t *testing.T) {
 	}
 	if after.Metadata["gc.controller_retryable"] == "true" {
 		t.Fatalf("gc.controller_retryable = %q, want not retryable", after.Metadata["gc.controller_retryable"])
+	}
+	bodyAfter := mustGet(t, store, body.ID)
+	if bodyAfter.Status != "closed" || bodyAfter.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("scope body = status %q outcome %q, want closed/fail", bodyAfter.Status, bodyAfter.Metadata["gc.outcome"])
+	}
+	if !sawTrace {
+		t.Fatal("expected hard controller-error reconciliation to use ProcessOptions trace")
 	}
 }
 

--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -29,14 +29,16 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 			}
 			return ControlResult{}, fmt.Errorf("%s: resolving fanout outcome: %w", bead.ID, err)
 		}
-		if err := setOutcomeAndClose(store, bead.ID, outcome); err != nil {
+		closeMetadata := map[string]string{"gc.outcome": outcome}
+		clearControllerSpawnErrorMetadata(closeMetadata)
+		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing fanout: %w", bead.ID, err)
 		}
 		closedBead, err := store.Get(bead.ID)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: reloading closed fanout: %w", bead.ID, err)
 		}
-		scopeResult, err := reconcileTerminalScopedMember(store, closedBead)
+		scopeResult, err := reconcileTerminalScopedMemberWithOptions(store, closedBead, opts)
 		if err != nil {
 			return ControlResult{}, err
 		}
@@ -78,7 +80,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: reloading failed fanout: %w", bead.ID, err)
 		}
-		scopeResult, err := reconcileTerminalScopedMember(store, closedBead)
+		scopeResult, err := reconcileTerminalScopedMemberWithOptions(store, closedBead, opts)
 		if err != nil {
 			return ControlResult{}, err
 		}
@@ -97,7 +99,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: reloading empty fanout: %w", bead.ID, err)
 		}
-		scopeResult, err := reconcileTerminalScopedMember(store, closedBead)
+		scopeResult, err := reconcileTerminalScopedMemberWithOptions(store, closedBead, opts)
 		if err != nil {
 			return ControlResult{}, err
 		}
@@ -117,7 +119,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 	}
 	if strings.TrimSpace(bead.Metadata["gc.fanout_state"]) == "" {
 		if err := store.SetMetadataBatch(bead.ID, map[string]string{"gc.fanout_state": "spawning"}); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: recording fanout spawn start: %w", bead.ID, err)
@@ -171,7 +173,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 				ExternalDeps: externalDeps,
 			})
 			if err != nil {
-				if controllerSpawnBoundaryPending(store, bead.ID, err) {
+				if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 					return ControlResult{}, ErrControlPending
 				}
 				return ControlResult{}, fmt.Errorf("%s: instantiating fragment %d: %w", bead.ID, index+1, err)
@@ -183,7 +185,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		sinkIDs := mapStepIDs(fragment.Sinks, idMapping)
 		for _, sinkID := range sinkIDs {
 			if err := store.DepAdd(bead.ID, sinkID, "blocks"); err != nil {
-				if controllerSpawnBoundaryPending(store, bead.ID, err) {
+				if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 					return ControlResult{}, ErrControlPending
 				}
 				return ControlResult{}, fmt.Errorf("%s: wiring fanout blocker: %w", bead.ID, err)
@@ -200,7 +202,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 	}
 	clearControllerSpawnErrorMetadata(spawnedMetadata)
 	if err := store.SetMetadataBatch(bead.ID, spawnedMetadata); err != nil {
-		if controllerSpawnBoundaryPending(store, bead.ID, err) {
+		if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 			return ControlResult{}, ErrControlPending
 		}
 		return ControlResult{}, fmt.Errorf("%s: recording fanout state: %w", bead.ID, err)

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -94,7 +94,7 @@ func processRalphCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 			"gc.retry_state":  "spawning",
 			"gc.next_attempt": strconv.Itoa(nextAttempt),
 		}); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: recording retry spawn start: %w", bead.ID, err)
@@ -109,7 +109,7 @@ func processRalphCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 	if bead.Metadata["gc.retry_state"] != "spawned" {
 		opts.tracef("ralph retry-append-start bead=%s next=%d", bead.ID, nextAttempt)
 		if _, err := appendRalphRetry(store, logicalID, subject, bead, nextAttempt, opts); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: appending retry: %w", bead.ID, err)
@@ -121,7 +121,7 @@ func processRalphCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		}
 		clearControllerSpawnErrorMetadata(spawnedMetadata)
 		if err := store.SetMetadataBatch(bead.ID, spawnedMetadata); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: recording retry spawn complete: %w", bead.ID, err)

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -140,7 +140,7 @@ func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (
 			"gc.retry_state":  "spawning",
 			"gc.next_attempt": strconv.Itoa(nextAttempt),
 		}); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: recording retry spawn start: %w", bead.ID, err)
@@ -172,7 +172,7 @@ func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (
 
 	if bead.Metadata["gc.retry_state"] != "spawned" {
 		if err := appendRetryAttempt(store, logicalID, subject, bead, nextAttempt, opts.CityPath); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: appending retry attempt: %w", bead.ID, err)
@@ -183,7 +183,7 @@ func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (
 		}
 		clearControllerSpawnErrorMetadata(spawnedMetadata)
 		if err := store.SetMetadataBatch(bead.ID, spawnedMetadata); err != nil {
-			if controllerSpawnBoundaryPending(store, bead.ID, err) {
+			if controllerSpawnBoundaryPending(store, bead.ID, err, opts) {
 				return ControlResult{}, ErrControlPending
 			}
 			return ControlResult{}, fmt.Errorf("%s: recording retry spawn complete: %w", bead.ID, err)

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -1,6 +1,7 @@
 package dispatch
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -31,6 +32,8 @@ type SourceWorkflowStore struct {
 
 // ProcessOptions provides control-dispatcher execution context.
 type ProcessOptions struct {
+	// Context optionally cancels bounded retry waits inside ProcessControl.
+	Context            context.Context
 	CityPath           string
 	StorePath          string
 	FormulaSearchPaths []string
@@ -63,8 +66,12 @@ var (
 const (
 	maxSourceChainHops               = 32
 	maxWorkflowFinalizeErrorMetadata = 512
-	scopeBodyResolveAttempts         = 5
-	scopeBodyResolveRetryDelay       = 100 * time.Millisecond
+	// Keep this retry window short and bounded while covering common
+	// sub-second Dolt read-after-write visibility lag for newly created scope
+	// bodies. When ProcessOptions.Context is set, retry waits exit promptly
+	// on cancellation.
+	scopeBodyResolveAttempts   = 5
+	scopeBodyResolveRetryDelay = 100 * time.Millisecond
 )
 
 const workflowFinalizeErrorMetadataKey = "gc.last_finalize_error"
@@ -173,7 +180,7 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		return ControlResult{}, fmt.Errorf("%s: missing gc.scope_ref", bead.ID)
 	}
 	body, err := tracePhase(opts, bead.ID, "resolve-body", func() (beads.Bead, error) {
-		return resolveScopeBody(store, rootID, scopeRef)
+		return resolveScopeBody(store, rootID, scopeRef, bead.ID, opts)
 	})
 	if err != nil {
 		if errors.Is(err, errScopeBodyMissing) {
@@ -338,9 +345,6 @@ func loadScopeSnapshotForControl(store beads.Store, rootID, scopeRef string, bod
 		return loadScopeSnapshotWithBody(store, rootID, scopeRef, body)
 	})
 	if err != nil {
-		if errors.Is(err, errScopeBodyMissing) {
-			return scopeSnapshot{}, fmt.Errorf("%w: %w", ErrControlGraphMalformed, err)
-		}
 		return scopeSnapshot{}, fmt.Errorf("%s: loading scope snapshot for %s: %w", controlID, scopeRef, err)
 	}
 	opts.tracef("scope-check bead=%s snapshot root=%s scope=%s all=%d members=%d body=%s subject=%s outcome=%s",
@@ -984,6 +988,10 @@ func truncateWorkflowFinalizeErrorMetadata(reason string) string {
 }
 
 func reconcileTerminalScopedMember(store beads.Store, bead beads.Bead) (ControlResult, error) {
+	return reconcileTerminalScopedMemberWithOptions(store, bead, ProcessOptions{})
+}
+
+func reconcileTerminalScopedMemberWithOptions(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, error) {
 	scopeRef := bead.Metadata["gc.scope_ref"]
 	if scopeRef == "" {
 		return ControlResult{}, nil
@@ -992,7 +1000,7 @@ func reconcileTerminalScopedMember(store beads.Store, bead beads.Bead) (ControlR
 	if rootID == "" {
 		return ControlResult{}, fmt.Errorf("%s: missing gc.root_bead_id", bead.ID)
 	}
-	body, err := resolveScopeBody(store, rootID, scopeRef)
+	body, err := resolveScopeBody(store, rootID, scopeRef, bead.ID, opts)
 	if err != nil {
 		if errors.Is(err, errScopeBodyMissing) {
 			return ControlResult{}, fmt.Errorf("%w: %w", ErrControlGraphMalformed, err)
@@ -1072,18 +1080,40 @@ func resolveBlockingSubjectID(store beads.Store, beadID string) (string, error) 
 	return "", fmt.Errorf("no blocking dependency")
 }
 
-func resolveScopeBody(store beads.Store, rootID, scopeRef string) (beads.Bead, error) {
+func resolveScopeBody(store beads.Store, rootID, scopeRef, traceID string, opts ProcessOptions) (beads.Bead, error) {
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var lastErr error
 	for attempt := 1; attempt <= scopeBodyResolveAttempts; attempt++ {
 		bead, err := resolveScopeBodyOnce(store, rootID, scopeRef)
-		if err == nil || !errors.Is(err, errScopeBodyMissing) {
+		if err == nil {
+			opts.tracef("scope-check bead=%s resolve-body attempt=%d root=%s scope=%s result=ok body=%s", traceID, attempt, rootID, scopeRef, bead.ID)
+			return bead, nil
+		}
+		if !errors.Is(err, errScopeBodyMissing) {
+			opts.tracef("scope-check bead=%s resolve-body attempt=%d root=%s scope=%s result=error err=%v", traceID, attempt, rootID, scopeRef, err)
 			return bead, err
 		}
+		opts.tracef("scope-check bead=%s resolve-body attempt=%d root=%s scope=%s result=retry reason=missing_body err=%v", traceID, attempt, rootID, scopeRef, err)
 		lastErr = err
 		if attempt < scopeBodyResolveAttempts {
-			time.Sleep(scopeBodyResolveRetryDelay)
+			timer := time.NewTimer(scopeBodyResolveRetryDelay)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				return beads.Bead{}, ctx.Err()
+			case <-timer.C:
+			}
 		}
 	}
+	opts.tracef("scope-check bead=%s resolve-body attempts=%d root=%s scope=%s result=exhausted err=%v", traceID, scopeBodyResolveAttempts, rootID, scopeRef, lastErr)
 	return beads.Bead{}, lastErr
 }
 
@@ -1245,6 +1275,10 @@ func setOutcomeAndClose(store beads.Store, beadID, outcome string) error {
 // consistent (true for MemStore today). If a future store becomes eventually
 // consistent, pass the in-memory closed bead directly instead of re-reading.
 func reconcileClosedScopeMember(store beads.Store, beadID string) (ControlResult, error) {
+	return reconcileClosedScopeMemberWithOptions(store, beadID, ProcessOptions{})
+}
+
+func reconcileClosedScopeMemberWithOptions(store beads.Store, beadID string, opts ProcessOptions) (ControlResult, error) {
 	closedBead, err := store.Get(beadID)
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: reloading closed scoped member: %w", beadID, err)
@@ -1252,7 +1286,7 @@ func reconcileClosedScopeMember(store beads.Store, beadID string) (ControlResult
 	if closedBead.Status != "closed" {
 		return ControlResult{}, nil
 	}
-	return reconcileTerminalScopedMember(store, closedBead)
+	return reconcileTerminalScopedMemberWithOptions(store, closedBead, opts)
 }
 
 func matchesScopeRef(bead beads.Bead, scopeRef string) bool {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -692,15 +692,26 @@ func TestProcessScopeCheckRetriesTransientMissingScopeBody(t *testing.T) {
 		rootID:    workflow.ID,
 		hideReads: 3,
 	}
-	result, err := ProcessControl(store, control, ProcessOptions{})
+	var trace bytes.Buffer
+	result, err := ProcessControl(store, control, ProcessOptions{
+		Tracef: func(format string, args ...any) {
+			fmt.Fprintf(&trace, format+"\n", args...) //nolint:errcheck // test buffer
+		},
+	})
 	if err != nil {
 		t.Fatalf("ProcessControl: %v", err)
 	}
 	if result.Action != "scope-pass" {
 		t.Fatalf("action = %q, want scope-pass", result.Action)
 	}
-	if store.hiddenReads != 3 {
-		t.Fatalf("hiddenReads = %d, want 3", store.hiddenReads)
+	if store.hiddenReads == 0 {
+		t.Fatal("hiddenReads = 0, want transient missing-body path exercised")
+	}
+	traceText := trace.String()
+	if !strings.Contains(traceText, "resolve-body attempt=") ||
+		!strings.Contains(traceText, "reason=missing_body") ||
+		!strings.Contains(traceText, "result=ok") {
+		t.Fatalf("trace = %q, want per-attempt missing-body retry and success", traceText)
 	}
 	bodyAfter := mustGetBead(t, mem, body.ID)
 	if bodyAfter.Status != "closed" {
@@ -708,6 +719,46 @@ func TestProcessScopeCheckRetriesTransientMissingScopeBody(t *testing.T) {
 	}
 	if got := bodyAfter.Metadata["gc.outcome"]; got != "pass" {
 		t.Fatalf("body outcome = %q, want pass", got)
+	}
+}
+
+func TestResolveScopeBodyStopsRetryWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	mem := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, mem, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	body := mustCreateWorkflowBead(t, mem, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	store := &transientMissingScopeBodyStore{
+		MemStore:  mem,
+		bodyID:    body.ID,
+		rootID:    workflow.ID,
+		hideReads: scopeBodyResolveAttempts,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := resolveScopeBody(store, workflow.ID, "body", "control", ProcessOptions{Context: ctx})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("resolveScopeBody error = %v, want context.Canceled", err)
+	}
+	if store.hiddenReads == 0 || store.hiddenReads >= store.hideReads {
+		t.Fatalf("hiddenReads = %d, want cancellation before exhausting %d hidden reads", store.hiddenReads, store.hideReads)
 	}
 }
 
@@ -3824,13 +3875,16 @@ needs = ["{target}.review"]
 		Title: "Expand fanout for survey",
 		Type:  "task",
 		Metadata: map[string]string{
-			"gc.kind":         "fanout",
-			"gc.root_bead_id": workflow.ID,
-			"gc.control_for":  "demo.survey",
-			"gc.for_each":     "output.items",
-			"gc.bond":         "expansion-review",
-			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
-			"gc.fanout_mode":  "parallel",
+			"gc.kind":                   "fanout",
+			"gc.root_bead_id":           workflow.ID,
+			"gc.control_for":            "demo.survey",
+			"gc.for_each":               "output.items",
+			"gc.bond":                   "expansion-review",
+			"gc.bond_vars":              `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":            "parallel",
+			"gc.controller_error":       "previous invalid connection",
+			"gc.controller_error_class": "transient",
+			"gc.controller_retryable":   "true",
 		},
 	})
 	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
@@ -3903,6 +3957,11 @@ needs = ["{target}.review"]
 	fanoutClosed := mustGetBead(t, store, fanout.ID)
 	if fanoutClosed.Status != "closed" || fanoutClosed.Metadata["gc.outcome"] != "pass" {
 		t.Fatalf("fanout = status %q outcome %q, want closed/pass", fanoutClosed.Status, fanoutClosed.Metadata["gc.outcome"])
+	}
+	if fanoutClosed.Metadata["gc.controller_error"] != "" ||
+		fanoutClosed.Metadata["gc.controller_error_class"] != "" ||
+		fanoutClosed.Metadata["gc.controller_retryable"] != "" {
+		t.Fatalf("controller error metadata = %#v, want cleared", fanoutClosed.Metadata)
 	}
 }
 

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -18,6 +18,9 @@ import (
 )
 
 const (
+	// Dolt-backed stores can briefly lag across connections after graph root
+	// creation. Keep the verification retry bounded while covering the common
+	// sub-second read-after-write delay observed by workflow launch paths.
 	sourceWorkflowLaunchVisibilityAttempts   = 5
 	sourceWorkflowLaunchVisibilityRetryDelay = 100 * time.Millisecond
 )
@@ -660,11 +663,23 @@ func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBea
 			return fmt.Errorf("list live workflows for %s: %w", sourceBeadID, err)
 		}
 		blockingRoots := append([]sourceWorkflowRoot(nil), roots...)
-		if len(roots) > 0 {
+		if len(blockingRoots) == 0 && previousWorkflowID != "" {
+			root, ok, reason, err := sourceWorkflowRootByID(deps, sourceBeadID, previousWorkflowID, deps.StoreRef)
+			if err != nil {
+				return fmt.Errorf("get previous workflow %s for %s: %w", previousWorkflowID, sourceBeadID, err)
+			}
+			if ok {
+				depsTracef(deps, "source-workflow prelaunch-direct-match source=%s workflow=%s store=%s", sourceBeadID, previousWorkflowID, root.storeRef)
+				blockingRoots = append(blockingRoots, root)
+			} else {
+				depsTracef(deps, "source-workflow prelaunch-direct-skip source=%s workflow=%s reason=%s", sourceBeadID, previousWorkflowID, reason)
+			}
+		}
+		if len(blockingRoots) > 0 {
 			if !force {
 				return &sourceworkflow.ConflictError{
 					SourceBeadID: sourceBeadID,
-					WorkflowIDs:  blockingWorkflowIDs(roots),
+					WorkflowIDs:  blockingWorkflowIDs(blockingRoots),
 				}
 			}
 		}
@@ -725,6 +740,7 @@ func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBea
 			// system in a worse state than the one the invariant check
 			// was supposed to catch.
 			invariantErr := fmt.Errorf("workflow %s not visible for source bead %s after launch", result.WorkflowID, sourceBeadID)
+			result = SlingResult{}
 			if rollbackErr := rollbackSourceWorkflowReplacement(launch, deps.Store, sourceBeadID, previousWorkflowID, restoreState); rollbackErr != nil {
 				return errors.Join(invariantErr, rollbackErr)
 			}
@@ -746,17 +762,19 @@ func waitForSourceWorkflowLaunchVisible(ctx context.Context, deps SlingDeps, sou
 		if slices.ContainsFunc(roots, func(root sourceWorkflowRoot) bool {
 			return sameWorkflowRoot(root, workflowID, storeRef)
 		}) {
+			depsTracef(deps, "source-workflow launch-visibility attempt=%d source=%s workflow=%s result=list-match roots=%d", attempt, sourceBeadID, workflowID, len(roots))
 			return roots, nil
 		}
-		if ok, err := launchedWorkflowRootMatchesSource(deps, sourceBeadID, workflowID, storeRef); err != nil {
+		root, ok, reason, err := sourceWorkflowRootByID(deps, sourceBeadID, workflowID, storeRef)
+		if err != nil {
+			depsTracef(deps, "source-workflow launch-visibility attempt=%d source=%s workflow=%s result=direct-error err=%v", attempt, sourceBeadID, workflowID, err)
 			return nil, err
-		} else if ok {
-			return []sourceWorkflowRoot{{
-				root:     beads.Bead{ID: workflowID},
-				store:    deps.Store,
-				storeRef: strings.TrimSpace(storeRef),
-			}}, nil
 		}
+		if ok {
+			depsTracef(deps, "source-workflow launch-visibility attempt=%d source=%s workflow=%s result=direct-match roots=%d", attempt, sourceBeadID, workflowID, len(roots))
+			return []sourceWorkflowRoot{root}, nil
+		}
+		depsTracef(deps, "source-workflow launch-visibility attempt=%d source=%s workflow=%s result=retry roots=%d direct=%s", attempt, sourceBeadID, workflowID, len(roots), reason)
 		if attempt == sourceWorkflowLaunchVisibilityAttempts {
 			return nil, nil
 		}
@@ -764,7 +782,10 @@ func waitForSourceWorkflowLaunchVisible(ctx context.Context, deps SlingDeps, sou
 		select {
 		case <-ctx.Done():
 			if !timer.Stop() {
-				<-timer.C
+				select {
+				case <-timer.C:
+				default:
+				}
 			}
 			return nil, ctx.Err()
 		case <-timer.C:
@@ -773,18 +794,67 @@ func waitForSourceWorkflowLaunchVisible(ctx context.Context, deps SlingDeps, sou
 	return nil, nil
 }
 
-func launchedWorkflowRootMatchesSource(deps SlingDeps, sourceBeadID, workflowID, storeRef string) (bool, error) {
-	root, err := deps.Store.Get(workflowID)
+func sourceWorkflowRootByID(deps SlingDeps, sourceBeadID, workflowID, sourceStoreRef string) (sourceWorkflowRoot, bool, string, error) {
+	workflowID = strings.TrimSpace(workflowID)
+	if workflowID == "" {
+		return sourceWorkflowRoot{}, false, "empty_workflow_id", nil
+	}
+	sourceStoreRef = strings.TrimSpace(sourceStoreRef)
+	if deps.SourceWorkflowStores == nil {
+		return sourceWorkflowRootByIDInStore(deps.Store, sourceBeadID, workflowID, sourceStoreRef, sourceStoreRef)
+	}
+	stores, err := deps.SourceWorkflowStores()
+	if err != nil {
+		return sourceWorkflowRoot{}, false, "stores_error", err
+	}
+	reason := "not_found"
+	for _, info := range stores {
+		if info.Store == nil {
+			continue
+		}
+		rootStoreRef := strings.TrimSpace(info.StoreRef)
+		root, ok, storeReason, err := sourceWorkflowRootByIDInStore(info.Store, sourceBeadID, workflowID, sourceStoreRef, rootStoreRef)
+		if err != nil {
+			return sourceWorkflowRoot{}, false, storeReason, err
+		}
+		if ok {
+			return root, true, storeReason, nil
+		}
+		if storeReason != "not_found" {
+			reason = storeReason
+		}
+	}
+	return sourceWorkflowRoot{}, false, reason, nil
+}
+
+func sourceWorkflowRootByIDInStore(store beads.Store, sourceBeadID, workflowID, sourceStoreRef, rootStoreRef string) (sourceWorkflowRoot, bool, string, error) {
+	if store == nil {
+		return sourceWorkflowRoot{}, false, "not_found", nil
+	}
+	root, err := store.Get(workflowID)
 	if err != nil {
 		if errors.Is(err, beads.ErrNotFound) {
-			return false, nil
+			return sourceWorkflowRoot{}, false, "not_found", nil
 		}
-		return false, err
+		return sourceWorkflowRoot{}, false, "get_error", err
+	}
+	// The launch boundary protects a live-workflow singleton invariant. A
+	// closed root may prove that creation happened, but it is not a live root
+	// and must not leave source.workflow_id pointing at completed graph state.
+	if root.Status == "closed" {
+		return sourceWorkflowRoot{}, false, "closed", nil
 	}
 	if !sourceworkflow.IsWorkflowRoot(root) {
-		return false, nil
+		return sourceWorkflowRoot{}, false, "not_workflow_root", nil
 	}
-	return sourceworkflow.WorkflowMatchesSource(root, sourceBeadID, storeRef, storeRef), nil
+	if !sourceworkflow.WorkflowMatchesSource(root, sourceBeadID, sourceStoreRef, rootStoreRef) {
+		return sourceWorkflowRoot{}, false, "source_mismatch", nil
+	}
+	return sourceWorkflowRoot{
+		root:     root,
+		store:    store,
+		storeRef: strings.TrimSpace(rootStoreRef),
+	}, true, "matched", nil
 }
 
 // attachBatchFormula launches one batch-child formula. The caller passes the

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -53,9 +54,13 @@ type closeAllFailMemStore struct {
 
 type staleSourceWorkflowListStore struct {
 	beads.Store
-	sourceID      string
+	sourceID string
+	// These tests drive the wrapper from one goroutine; plain counters keep
+	// the fixtures easy to read.
 	hiddenReads   int
 	hideReadLimit int
+	hiddenGets    int
+	hideGetLimit  int
 }
 
 func (s *staleSourceWorkflowListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
@@ -68,6 +73,21 @@ func (s *staleSourceWorkflowListStore) List(query beads.ListQuery) ([]beads.Bead
 		return nil, nil
 	}
 	return items, nil
+}
+
+func (s *staleSourceWorkflowListStore) Get(id string) (beads.Bead, error) {
+	item, err := s.Store.Get(id)
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	if sourceworkflow.IsWorkflowRoot(item) &&
+		sourceworkflow.WorkflowMatchesSource(item, s.sourceID, "", "") &&
+		s.hiddenReads > 0 &&
+		s.hiddenGets < s.hideGetLimit {
+		s.hiddenGets++
+		return beads.Bead{}, fmt.Errorf("getting bead %q: %w", id, beads.ErrNotFound)
+	}
+	return item, nil
 }
 
 func (s *closeAllFailMemStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
@@ -143,12 +163,13 @@ func (testNotifier) PokeController(_ string)      {}
 func (testNotifier) PokeControlDispatch(_ string) {}
 
 type closeLaunchedWorkflowNotifier struct {
-	store    beads.Store
-	sourceID string
-	storeRef string
-	once     sync.Once
-	closed   int
-	err      error
+	store        beads.Store
+	sourceID     string
+	storeRef     string
+	once         sync.Once
+	closed       int
+	closedRootID string
+	err          error
 }
 
 func (n *closeLaunchedWorkflowNotifier) PokeController(_ string) {
@@ -164,6 +185,7 @@ func (n *closeLaunchedWorkflowNotifier) PokeController(_ string) {
 				n.err = err
 				return
 			}
+			n.closedRootID = root.ID
 			n.closed++
 		}
 	})
@@ -1666,7 +1688,7 @@ title = "Do work"
 	}
 }
 
-func TestSlingAttachGraphFormulaRetriesLaunchVisibilityAfterStaleList(t *testing.T) {
+func TestSlingAttachGraphFormulaRetriesLaunchVisibilityWhenListAndGetAreStale(t *testing.T) {
 	formulaDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
 formula = "graph-work"
@@ -1697,7 +1719,8 @@ title = "Do work"
 	staleStore := &staleSourceWorkflowListStore{
 		Store:         deps.Store,
 		sourceID:      source.ID,
-		hideReadLimit: 1,
+		hideReadLimit: 2,
+		hideGetLimit:  2,
 	}
 	deps.Store = staleStore
 
@@ -1709,8 +1732,11 @@ title = "Do work"
 	if err != nil {
 		t.Fatalf("AttachFormula: %v", err)
 	}
-	if staleStore.hiddenReads != 1 {
-		t.Fatalf("hiddenReads = %d, want 1", staleStore.hiddenReads)
+	if staleStore.hiddenReads == 0 || staleStore.hiddenReads > sourceWorkflowLaunchVisibilityAttempts {
+		t.Fatalf("hiddenReads = %d, want retry path exercised within %d attempts", staleStore.hiddenReads, sourceWorkflowLaunchVisibilityAttempts)
+	}
+	if staleStore.hiddenGets == 0 || staleStore.hiddenGets > sourceWorkflowLaunchVisibilityAttempts {
+		t.Fatalf("hiddenGets = %d, want direct-get retry path exercised within %d attempts", staleStore.hiddenGets, sourceWorkflowLaunchVisibilityAttempts)
 	}
 	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
 	if err != nil {
@@ -1725,6 +1751,97 @@ title = "Do work"
 	}
 	if got := updatedSource.Metadata["workflow_id"]; got != result.WorkflowID {
 		t.Fatalf("source workflow_id = %q, want %q", got, result.WorkflowID)
+	}
+}
+
+func TestSlingAttachGraphFormulaRollsBackWhenLaunchVisibilityNeverConverges(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	formulatest.EnableV2ForTest(t)
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleStore := &staleSourceWorkflowListStore{
+		Store:         deps.Store,
+		sourceID:      source.ID,
+		hideReadLimit: sourceWorkflowLaunchVisibilityAttempts,
+		hideGetLimit:  sourceWorkflowLaunchVisibilityAttempts,
+	}
+	deps.Store = staleStore
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err == nil {
+		t.Fatal("AttachFormula error = nil, want launch visibility invariant error")
+	}
+	if !strings.Contains(err.Error(), "not visible for source bead") {
+		t.Fatalf("AttachFormula error = %v, want launch visibility invariant error", err)
+	}
+	if result.WorkflowID != "" {
+		t.Fatalf("WorkflowID = %q, want empty result on launch visibility error", result.WorkflowID)
+	}
+	if staleStore.hiddenReads != sourceWorkflowLaunchVisibilityAttempts {
+		t.Fatalf("hiddenReads = %d, want %d", staleStore.hiddenReads, sourceWorkflowLaunchVisibilityAttempts)
+	}
+	if staleStore.hiddenGets != sourceWorkflowLaunchVisibilityAttempts {
+		t.Fatalf("hiddenGets = %d, want %d", staleStore.hiddenGets, sourceWorkflowLaunchVisibilityAttempts)
+	}
+	closedRoots, err := staleStore.Store.List(beads.ListQuery{
+		IncludeClosed: true,
+		Metadata: map[string]string{
+			"gc.source_bead_id": source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("List(closed roots): %v", err)
+	}
+	closedRoots = slices.DeleteFunc(closedRoots, func(root beads.Bead) bool {
+		return !sourceworkflow.IsWorkflowRoot(root)
+	})
+	if len(closedRoots) != 1 {
+		t.Fatalf("closed roots = %#v, want one rolled-back workflow root", closedRoots)
+	}
+	root := closedRoots[0]
+	if root.Status != "closed" {
+		t.Fatalf("root status = %q, want closed after rollback", root.Status)
+	}
+	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("ListLiveRoots: %v", err)
+	}
+	if len(roots) != 0 {
+		t.Fatalf("live roots = %#v, want none after rollback", roots)
+	}
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != "" {
+		t.Fatalf("source workflow_id = %q, want restored empty workflow_id", got)
 	}
 }
 
@@ -1790,7 +1907,74 @@ title = "Do work"
 	}
 }
 
-func TestSlingAttachGraphFormulaAcceptsRootClosedBeforeVisibilityCheck(t *testing.T) {
+func TestSlingAttachGraphFormulaForceReplacesSequentialLaunchWhenLaunchListStaysStale(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	formulatest.EnableV2ForTest(t)
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleStore := &staleSourceWorkflowListStore{
+		Store:         deps.Store,
+		sourceID:      source.ID,
+		hideReadLimit: 99,
+	}
+	deps.Store = staleStore
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err != nil {
+		t.Fatalf("AttachFormula(first): %v", err)
+	}
+
+	second, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{Force: true})
+	if err != nil {
+		t.Fatalf("AttachFormula(second force): %v", err)
+	}
+	if second.WorkflowID == "" || second.WorkflowID == first.WorkflowID {
+		t.Fatalf("second WorkflowID = %q, want new workflow distinct from %q", second.WorkflowID, first.WorkflowID)
+	}
+	firstRoot, err := staleStore.Store.Get(first.WorkflowID)
+	if err != nil {
+		t.Fatalf("Get(first root): %v", err)
+	}
+	if firstRoot.Status != "closed" {
+		t.Fatalf("first root status = %q, want closed after force replacement", firstRoot.Status)
+	}
+	roots, err := sourceworkflow.ListLiveRoots(staleStore.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("ListLiveRoots(underlying): %v", err)
+	}
+	if len(roots) != 1 || roots[0].ID != second.WorkflowID {
+		t.Fatalf("underlying live roots = %#v, want [%s]", roots, second.WorkflowID)
+	}
+}
+
+func TestSlingAttachGraphFormulaRejectsRootClosedBeforeVisibilityCheck(t *testing.T) {
 	formulaDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
 formula = "graph-work"
@@ -1830,8 +2014,11 @@ title = "Do work"
 		t.Fatal(err)
 	}
 	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
-	if err != nil {
-		t.Fatalf("AttachFormula: %v", err)
+	if err == nil {
+		t.Fatal("AttachFormula error = nil, want launch visibility invariant error")
+	}
+	if !strings.Contains(err.Error(), "not visible for source bead") {
+		t.Fatalf("AttachFormula error = %v, want launch visibility invariant error", err)
 	}
 	if notifier.err != nil {
 		t.Fatalf("notifier close: %v", notifier.err)
@@ -1839,7 +2026,10 @@ title = "Do work"
 	if notifier.closed != 1 {
 		t.Fatalf("notifier closed = %d, want 1", notifier.closed)
 	}
-	root, err := deps.Store.Get(result.WorkflowID)
+	if result.WorkflowID != "" {
+		t.Fatalf("WorkflowID = %q, want empty result on launch visibility error", result.WorkflowID)
+	}
+	root, err := deps.Store.Get(notifier.closedRootID)
 	if err != nil {
 		t.Fatalf("Get(root): %v", err)
 	}
@@ -1860,8 +2050,8 @@ title = "Do work"
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := updatedSource.Metadata["workflow_id"]; got != result.WorkflowID {
-		t.Fatalf("source workflow_id = %q, want %q", got, result.WorkflowID)
+	if got := updatedSource.Metadata["workflow_id"]; got != "" {
+		t.Fatalf("source workflow_id = %q, want restored empty workflow_id", got)
 	}
 }
 
@@ -1933,6 +2123,89 @@ title = "Do work"
 	}
 	if len(conflictErr.WorkflowIDs) != 1 || conflictErr.WorkflowIDs[0] != root.ID {
 		t.Fatalf("WorkflowIDs = %#v, want [%s]", conflictErr.WorkflowIDs, root.ID)
+	}
+}
+
+func TestSlingAttachGraphFormulaRejectsPreviousWorkflowAcrossStoresWhenListStale(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	formulatest.EnableV2ForTest(t)
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherBase := beads.NewMemStoreFrom(100, nil, nil)
+	root, err := otherBase.Create(beads.Bead{
+		ID:     "wf-other",
+		Title:  "cross-store workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.formula_contract":                    "graph.v2",
+			"gc.source_bead_id":                      source.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: deps.StoreRef,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.Store.SetMetadata(source.ID, "workflow_id", root.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	staleOtherStore := &staleSourceWorkflowListStore{
+		Store:         otherBase,
+		sourceID:      source.ID,
+		hideReadLimit: 99,
+	}
+	deps.SourceWorkflowStores = func() ([]SourceWorkflowStore, error) {
+		return []SourceWorkflowStore{
+			{Store: deps.Store, StoreRef: deps.StoreRef},
+			{Store: staleOtherStore, StoreRef: "rig:alpha"},
+		}, nil
+	}
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{})
+	if err == nil {
+		t.Fatal("AttachFormula error = nil, want conflict")
+	}
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("AttachFormula error = %v, want ConflictError", err)
+	}
+	if len(conflictErr.WorkflowIDs) != 1 || conflictErr.WorkflowIDs[0] != root.ID {
+		t.Fatalf("WorkflowIDs = %#v, want [%s]", conflictErr.WorkflowIDs, root.ID)
+	}
+	cityRoots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("ListLiveRoots(city): %v", err)
+	}
+	if len(cityRoots) != 0 {
+		t.Fatalf("city live roots = %#v, want no duplicate launch", cityRoots)
 	}
 }
 
@@ -2018,6 +2291,103 @@ title = "Do work"
 		t.Fatalf("other root status = %q, want closed", updatedOtherRoot.Status)
 	}
 
+	updatedSource, err := deps.Store.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := updatedSource.Metadata["workflow_id"]; got != result.WorkflowID {
+		t.Fatalf("source workflow_id = %q, want %q", got, result.WorkflowID)
+	}
+}
+
+func TestSlingAttachGraphFormulaForceReplacesPreviousWorkflowAcrossStoresWhenListStale(t *testing.T) {
+	formulaDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{formulaDir},
+		},
+	}
+	formulatest.EnableV2ForTest(t)
+	config.InjectImplicitAgents(cfg)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	source, err := deps.Store.Create(beads.Bead{ID: "BL-42", Title: "work", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherBase := beads.NewMemStoreFrom(100, nil, nil)
+	root, err := otherBase.Create(beads.Bead{
+		ID:     "wf-other",
+		Title:  "cross-store workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.formula_contract":                    "graph.v2",
+			"gc.source_bead_id":                      source.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: deps.StoreRef,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deps.Store.SetMetadata(source.ID, "workflow_id", root.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	staleOtherStore := &staleSourceWorkflowListStore{
+		Store:         otherBase,
+		sourceID:      source.ID,
+		hideReadLimit: 99,
+	}
+	deps.SourceWorkflowStores = func() ([]SourceWorkflowStore, error) {
+		return []SourceWorkflowStore{
+			{Store: deps.Store, StoreRef: deps.StoreRef},
+			{Store: staleOtherStore, StoreRef: "rig:alpha"},
+		}, nil
+	}
+
+	s, err := New(deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.AttachFormula(context.Background(), "graph-work", source.ID, config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}, FormulaOpts{Force: true})
+	if err != nil {
+		t.Fatalf("AttachFormula force: %v", err)
+	}
+	if result.WorkflowID == "" || result.WorkflowID == root.ID {
+		t.Fatalf("WorkflowID = %q, want new workflow root distinct from %q", result.WorkflowID, root.ID)
+	}
+	if staleOtherStore.hiddenReads == 0 {
+		t.Fatal("hiddenReads = 0, want stale cross-store list path exercised")
+	}
+
+	updatedOtherRoot, err := otherBase.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(other root): %v", err)
+	}
+	if updatedOtherRoot.Status != "closed" {
+		t.Fatalf("other root status = %q, want closed after force replacement", updatedOtherRoot.Status)
+	}
+	roots, err := sourceworkflow.ListLiveRoots(deps.Store, source.ID, deps.StoreRef, deps.StoreRef)
+	if err != nil {
+		t.Fatalf("ListLiveRoots(city): %v", err)
+	}
+	if len(roots) != 1 || roots[0].ID != result.WorkflowID {
+		t.Fatalf("city live roots = %#v, want [%s]", roots, result.WorkflowID)
+	}
 	updatedSource, err := deps.Store.Get(source.ID)
 	if err != nil {
 		t.Fatalf("Get(source): %v", err)


### PR DESCRIPTION
Follow-up to https://github.com/gastownhall/gascity/pull/2279.

Original PR: #2279, "Retry source workflow launch visibility"
Original PR state: MERGED
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

This follow-up carries only the reviewed maintainer-side fixes that were approved after the original PR had already merged. The original contributor commits from #2279 remain in main; this branch is based on current main and adds the reviewed launch-visibility hardening and regression coverage while preserving contributor authorship.

Summary:
- reject closed workflow roots during launch visibility verification
- add direct previous-workflow lookup coverage for stale source-root listings
- clear rolled-back workflow IDs from partial results while preserving diagnostic error details
- make dispatch and sling retry paths cancellation-aware where review requested it
- add stale-list, cross-store, rollback, and controller metadata cleanup coverage

Validation:
- go test ./internal/dispatch ./internal/sling
- GitHub Actions CI, CodeQL, and Mac Regression passed for final head b8cd6be215b26b8c1ae8fc979995d9f86f694acf

Adopt workflow context:
- Review root: ga-wisp-d3nutfe
- Source bead: ga-ta2exkd
- Final reviewed head: b8cd6be215b26b8c1ae8fc979995d9f86f694acf