### PR TITLE
fix(cmd/gc): parallelize pool session bead creates (#2319)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1540,6 +1540,30 @@ func desiredHasCanonicalNonExpandingPoolSession(desired map[string]TemplateParam
 	return false
 }
 
+// poolRealizeParallelism caps the number of concurrent pool session bead
+// creates inside realizePoolDesiredSessions. Each create acquires a per-alias
+// session lock + commits to dolt; with N>cap pending creates the work pool
+// drains in O(ceil(N/cap) × commit-latency) wall time instead of the prior
+// O(N × commit-latency). The cap is intentionally modest: dolt commit
+// contention and per-city alias-lock churn put a ceiling on useful
+// parallelism even when many distinct aliases are pending. See
+// gastownhall/gascity#2319.
+const poolRealizeParallelism = 8
+
+// poolRealizeWorkItem holds the per-request state threaded across the
+// three-phase realizePoolDesiredSessions pipeline. Phase A (serial) populates
+// either sessionBead+slot (reuse path) or plan+slot (create path); Phase B
+// (parallel-bounded) materializes plans into sessionBead/createErr; Phase C
+// (serial) resolves the template and installs side effects.
+type poolRealizeWorkItem struct {
+	request     SessionRequest
+	skip        bool
+	plan        *poolSessionCreatePlan
+	sessionBead beads.Bead
+	slot        int
+	createErr   error
+}
+
 func realizePoolDesiredSessions(
 	bp *agentBuildParams,
 	cfgAgent *config.Agent,
@@ -1554,30 +1578,122 @@ func realizePoolDesiredSessions(
 	}
 	used := make(map[string]bool)
 	usedSlots := make(map[int]bool)
+
+	// Phase A (serial, fast): select an existing session bead to reuse OR
+	// reserve an (alias, slot) for a fresh create. Mutates used/usedSlots
+	// under serial control so dedup and slot allocation remain deterministic.
+	items := make([]poolRealizeWorkItem, 0, len(poolState.Requests))
 	for _, request := range poolState.Requests {
-		var prefer *beads.Bead
-		if request.SessionBeadID != "" {
-			if bead, ok := findOpenSessionBeadByID(bp.sessionBeads, request.SessionBeadID); ok {
-				// Defense in depth: ComputePoolDesiredStates filters out
-				// named-session beads from pool resume requests. If one
-				// slipped through, materializing it here would create a
-				// phantom "{name}-N" sibling to the canonical named session.
-				if isNamedSessionBead(bead) {
-					fmt.Fprintf(stderr, "buildDesiredState: pool %q: refusing to materialize named-session bead %s as pool instance (would create phantom %q-N sibling)\n", qualifiedName, bead.ID, cfgAgent.Name) //nolint:errcheck
-					continue
+		// planItem runs the per-request selection and returns the work item;
+		// any early-out (skip path) sets item.skip and returns. The single
+		// append below keeps slice growth in one place.
+		planItem := func() poolRealizeWorkItem {
+			item := poolRealizeWorkItem{request: request}
+			var prefer *beads.Bead
+			if request.SessionBeadID != "" {
+				if bead, ok := findOpenSessionBeadByID(bp.sessionBeads, request.SessionBeadID); ok {
+					// Defense in depth: ComputePoolDesiredStates filters out
+					// named-session beads from pool resume requests. If one
+					// slipped through, materializing it here would create a
+					// phantom "{name}-N" sibling to the canonical named session.
+					if isNamedSessionBead(bead) {
+						fmt.Fprintf(stderr, "buildDesiredState: pool %q: refusing to materialize named-session bead %s as pool instance (would create phantom %q-N sibling)\n", qualifiedName, bead.ID, cfgAgent.Name) //nolint:errcheck
+						item.skip = true
+						return item
+					}
+					prefer = &bead
 				}
-				prefer = &bead
 			}
+			sessionBead, slot, plan, err := selectOrPlanPoolSessionBead(bp, cfgAgent, qualifiedName, prefer, used, usedSlots)
+			if err != nil {
+				fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
+				item.skip = true
+				return item
+			}
+			if plan != nil {
+				item.plan = plan
+				item.slot = plan.poolSlot
+				return item
+			}
+			if used[sessionBead.ID] {
+				item.skip = true
+				return item
+			}
+			used[sessionBead.ID] = true
+			item.sessionBead = sessionBead
+			item.slot = slot
+			return item
 		}
-		sessionBead, slot, err := selectOrCreatePoolSessionBead(bp, cfgAgent, qualifiedName, prefer, used, usedSlots)
-		if err != nil {
-			fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
+		items = append(items, planItem())
+	}
+
+	// Phase B (parallel, bounded): materialize planned creates. Per-alias
+	// session locks serialize same-alias calls; distinct aliases proceed in
+	// parallel up to poolRealizeParallelism workers. The store write and
+	// alias-conflict bookkeeping happen here.
+	pending := make([]int, 0, len(items))
+	for idx := range items {
+		if items[idx].plan != nil {
+			pending = append(pending, idx)
+		}
+	}
+	if len(pending) > 0 {
+		workerCount := poolRealizeParallelism
+		if workerCount > len(pending) {
+			workerCount = len(pending)
+		}
+		jobs := make(chan int)
+		var wg sync.WaitGroup
+		for w := 0; w < workerCount; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for idx := range jobs {
+					plan := *items[idx].plan
+					bead, err := executePlannedPoolSessionBeadCreate(bp, cfgAgent, qualifiedName, plan)
+					if err != nil {
+						items[idx].createErr = err
+						continue
+					}
+					items[idx].sessionBead = bead
+				}
+			}()
+		}
+		for _, idx := range pending {
+			jobs <- idx
+		}
+		close(jobs)
+		wg.Wait()
+	}
+
+	// Phase C (serial, fast): finalize results in original request order.
+	// Failed creates release their reserved slot here, at end-of-cycle —
+	// unlike the original serial loop, which freed a failed slot before the
+	// next request was planned, letting a same-tick later request reclaim it.
+	// With Phase A planning all requests up front, that intra-tick reuse no
+	// longer happens: a failed create leaves a slot gap for this cycle and the
+	// slot is reclaimed on the next build tick. The pool's active-session
+	// count converges identically; only the transient slot numbering differs.
+	// Template resolution + installAgentSideEffects (hooks.InstallWithResolver
+	// + autoSP.RouteACP) remain serial pending an audit of their thread-safety.
+	for i := range items {
+		item := &items[i]
+		if item.skip {
 			continue
 		}
-		if used[sessionBead.ID] {
-			continue
+		if item.plan != nil {
+			if item.createErr != nil {
+				fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, item.createErr) //nolint:errcheck
+				delete(usedSlots, item.plan.slot)
+				continue
+			}
+			if used[item.sessionBead.ID] {
+				continue
+			}
+			used[item.sessionBead.ID] = true
 		}
-		used[sessionBead.ID] = true
+		sessionBead := item.sessionBead
+		slot := item.slot
 		manualSession := isManualSessionBeadForAgent(sessionBead, cfgAgent)
 		var (
 			resolveAgent      *config.Agent
@@ -2147,6 +2263,17 @@ func findOpenSessionBeadByID(sessionBeads *sessionBeadSnapshot, id string) (bead
 	return beads.Bead{}, false
 }
 
+// poolSessionCreatePlan describes a fresh pool session bead that has been
+// selected for creation by the planning phase. Materializing the plan via
+// executePlannedPoolSessionBeadCreate performs the slow per-alias-locked
+// dolt write and is safe to call concurrently across distinct
+// qualifiedInstance values.
+type poolSessionCreatePlan struct {
+	qualifiedInstance string
+	slot              int
+	poolSlot          int
+}
+
 func selectOrCreatePoolSessionBead(
 	bp *agentBuildParams,
 	cfgAgent *config.Agent,
@@ -2155,28 +2282,64 @@ func selectOrCreatePoolSessionBead(
 	used map[string]bool,
 	usedSlots map[int]bool,
 ) (beads.Bead, int, error) {
+	bead, slot, plan, err := selectOrPlanPoolSessionBead(bp, cfgAgent, template, preferred, used, usedSlots)
+	if err != nil {
+		return beads.Bead{}, 0, err
+	}
+	if plan == nil {
+		return bead, slot, nil
+	}
+	bead, err = executePlannedPoolSessionBeadCreate(bp, cfgAgent, template, *plan)
+	if err != nil {
+		delete(usedSlots, plan.slot)
+		return bead, 0, err
+	}
+	return bead, plan.poolSlot, nil
+}
+
+// selectOrPlanPoolSessionBead performs the in-memory selection phase of pool
+// session provisioning. It returns one of:
+//   - reuse: (bead, slot, nil, nil) where bead is an existing session bead to
+//     reuse for this request.
+//   - plan:  (zero bead, 0, *plan, nil) where plan describes a fresh bead to
+//     be materialized by executePlannedPoolSessionBeadCreate.
+//   - error: (zero bead, 0, nil, err) when selection fails (e.g., concrete
+//     slot already claimed).
+//
+// Callers MUST serialize calls that share the same used / usedSlots maps; the
+// function mutates both. The plan path defers the slow per-alias-locked dolt
+// write to a subsequent (possibly parallel) step so realizePoolDesiredSessions
+// can drive distinct aliases concurrently.
+func selectOrPlanPoolSessionBead(
+	bp *agentBuildParams,
+	cfgAgent *config.Agent,
+	template string,
+	preferred *beads.Bead,
+	used map[string]bool,
+	usedSlots map[int]bool,
+) (beads.Bead, int, *poolSessionCreatePlan, error) {
 	if cfgAgent == nil {
 		cfgAgent = findAgentByTemplate(&config.City{Agents: bp.agents}, template)
 	}
 	if cfgAgent == nil {
-		return beads.Bead{}, 0, fmt.Errorf("pool template %q has no configured agent", template)
+		return beads.Bead{}, 0, nil, fmt.Errorf("pool template %q has no configured agent", template)
 	}
 	// Resume tier: reuse the session that has in-progress work assigned.
 	if preferred != nil && preferred.ID != "" && !used[preferred.ID] && !isFailedCreateSessionBead(*preferred) {
 		slot := claimDesiredPoolSlot(bp.city, cfgAgent, *preferred, usedSlots)
 		if slot == 0 && !cfgAgent.UsesCanonicalSingletonPoolIdentity() {
-			return beads.Bead{}, 0, fmt.Errorf("pool session %s concrete slot already claimed", preferred.ID)
+			return beads.Bead{}, 0, nil, fmt.Errorf("pool session %s concrete slot already claimed", preferred.ID)
 		}
 		if isManualSessionBeadForAgent(*preferred, cfgAgent) {
-			return *preferred, slot, nil
+			return *preferred, slot, nil, nil
 		}
 		bead, err := normalizeNonExpandingPoolSessionBeadForSelection(bp, cfgAgent, *preferred)
-		return bead, slot, err
+		return bead, slot, nil, err
 	}
 	if canonical, ok := findReusableCanonicalNonExpandingPoolSessionBead(bp, cfgAgent, template, used); ok {
 		slot := claimDesiredPoolSlot(bp.city, cfgAgent, canonical, usedSlots)
 		bead, err := normalizeNonExpandingPoolSessionBeadForSelection(bp, cfgAgent, canonical)
-		return bead, slot, err
+		return bead, slot, nil, err
 	}
 	// Reuse an existing active/creating session bead. Skip drained, closed,
 	// and asleep — asleep ephemerals are not restarted; a fresh session is
@@ -2188,17 +2351,31 @@ func selectOrCreatePoolSessionBead(
 				continue
 			}
 			bead, err := normalizeNonExpandingPoolSessionBeadForSelection(bp, cfgAgent, bead)
-			return bead, slot, err
+			return bead, slot, nil, err
 		}
 	}
 	slot := claimDesiredPoolSlot(bp.city, cfgAgent, beads.Bead{}, usedSlots)
 	_, qualifiedInstance, poolSlot := poolDesiredRequestIdentity(cfgAgent, slot)
-	bead, err := createPoolSessionBeadWithGuardedAlias(bp, cfgAgent, template, qualifiedInstance, slot)
-	if err != nil {
-		delete(usedSlots, slot)
-		return bead, 0, err
+	plan := &poolSessionCreatePlan{
+		qualifiedInstance: qualifiedInstance,
+		slot:              slot,
+		poolSlot:          poolSlot,
 	}
-	return bead, poolSlot, nil
+	return beads.Bead{}, 0, plan, nil
+}
+
+// executePlannedPoolSessionBeadCreate materializes a pool session bead from a
+// plan produced by selectOrPlanPoolSessionBead. The underlying call is
+// createPoolSessionBeadWithGuardedAlias, whose per-alias session lock makes
+// concurrent invocations safe across distinct qualifiedInstance values. Calls
+// with the same qualifiedInstance are still serialized by the alias lock.
+func executePlannedPoolSessionBeadCreate(
+	bp *agentBuildParams,
+	cfgAgent *config.Agent,
+	template string,
+	plan poolSessionCreatePlan,
+) (beads.Bead, error) {
+	return createPoolSessionBeadWithGuardedAlias(bp, cfgAgent, template, plan.qualifiedInstance, plan.slot)
 }
 
 func claimDesiredPoolSlot(cfg *config.City, cfgAgent *config.Agent, sessionBead beads.Bead, used map[int]bool) int {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3197,6 +3197,95 @@ func TestSelectOrCreatePoolSessionBead_SerializesAliasCheckAndCreate(t *testing.
 	}
 }
 
+// delayingPoolCreateStore sleeps for `delay` on every session-bead create so
+// tests can measure whether realizePoolDesiredSessions runs distinct-alias
+// creates in parallel or serializes them. Wraps MemStore for all other ops.
+type delayingPoolCreateStore struct {
+	*beads.MemStore
+	delay time.Duration
+}
+
+func (s *delayingPoolCreateStore) Create(bead beads.Bead) (beads.Bead, error) {
+	if bead.Type == sessionBeadType {
+		time.Sleep(s.delay)
+	}
+	return s.MemStore.Create(bead)
+}
+
+// TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates verifies
+// that the three-phase pipeline drives distinct-alias pool creates in parallel
+// rather than serializing them one-per-tick. Issue #2319 reported O(N) wall
+// time on pool fanouts because each create acquired a per-alias session lock
+// + dolt commit in a tight serial loop. With bounded-parallel phase B, wall
+// time should collapse to roughly ceil(N/poolRealizeParallelism) × delay.
+//
+// The assertion bounds elapsed strictly below half the serial floor so a
+// regression that re-serializes the loop (e.g., a future refactor that
+// accidentally holds a mutex across the create call) fails this test before
+// it ships.
+func TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates(t *testing.T) {
+	const (
+		requestCount = 8
+		createDelay  = 50 * time.Millisecond
+	)
+	store := &delayingPoolCreateStore{MemStore: beads.NewMemStore(), delay: createDelay}
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "claude",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(requestCount),
+		}},
+	}
+	var stderr bytes.Buffer
+	bp := newAgentBuildParams("test-city", cityPath, cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+	bp.sessionBeads = &sessionBeadSnapshot{}
+	desired := map[string]TemplateParams{}
+
+	requests := make([]SessionRequest, 0, requestCount)
+	for i := 0; i < requestCount; i++ {
+		requests = append(requests, SessionRequest{Template: "claude", Tier: "new"})
+	}
+	state := PoolDesiredState{Template: "claude", Requests: requests}
+
+	start := time.Now()
+	realizePoolDesiredSessions(bp, &cfg.Agents[0], state, desired, &stderr)
+	elapsed := time.Since(start)
+
+	if got := len(desired); got != requestCount {
+		t.Fatalf("desired count = %d, want %d; stderr=%q", got, requestCount, stderr.String())
+	}
+
+	serialFloor := time.Duration(requestCount) * createDelay
+	parallelCeiling := serialFloor / 2
+	if elapsed >= parallelCeiling {
+		t.Fatalf("realizePoolDesiredSessions ran in %s for %d creates × %s delay; serial floor = %s, parallel ceiling = %s — the refactor did not parallelize", elapsed, requestCount, createDelay, serialFloor, parallelCeiling)
+	}
+
+	aliases := make(map[string]bool, requestCount)
+	sessionNames := make(map[string]bool, requestCount)
+	slots := make(map[int]bool, requestCount)
+	for name, tp := range desired {
+		if sessionNames[name] {
+			t.Fatalf("duplicate desired session name %q across pool entries", name)
+		}
+		sessionNames[name] = true
+		if tp.Alias == "" {
+			t.Fatalf("desired entry %q has empty alias; want unique per-slot alias", name)
+		}
+		if aliases[tp.Alias] {
+			t.Fatalf("duplicate alias %q across desired entries (session %q)", tp.Alias, name)
+		}
+		aliases[tp.Alias] = true
+		if slots[tp.PoolSlot] {
+			t.Fatalf("duplicate pool_slot %d across desired entries (session %q)", tp.PoolSlot, name)
+		}
+		slots[tp.PoolSlot] = true
+	}
+}
+
 func TestCreatePoolSessionBeadWithGuardedAlias_LogsAliasLockSetupFailure(t *testing.T) {
 	store := beads.NewMemStore()
 	cityPath := filepath.Join(t.TempDir(), "city-file")

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -337,9 +337,10 @@ func observedACPSessionNames(snapshot *sessionBeadSnapshot, cfg *config.City) []
 	if snapshot == nil {
 		return nil
 	}
-	names := make([]string, 0, len(snapshot.open))
-	seen := make(map[string]bool, len(snapshot.open))
-	for _, bead := range snapshot.Open() {
+	open := snapshot.Open()
+	names := make([]string, 0, len(open))
+	seen := make(map[string]bool, len(open))
+	for _, bead := range open {
 		if !beadUsesACPTransport(bead, cfg) {
 			continue
 		}

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -22,6 +23,12 @@ import (
 // See gastownhall/gascity#2148 for the named-session lookup-error visibility
 // regression this field exists to surface.
 type sessionBeadSnapshot struct {
+	// mu guards open + the four lookup maps. add() (called from inside
+	// createPoolSessionBead) can fire from multiple goroutines when
+	// realizePoolDesiredSessions parallelizes pool session bead creates
+	// across distinct aliases — see gastownhall/gascity#2319. All read
+	// methods take RLock; add() takes Lock.
+	mu                        sync.RWMutex
 	open                      []beads.Bead
 	beadIDByAgentName         map[string]string
 	beadIDByTemplateHint      map[string]string
@@ -39,6 +46,8 @@ func (s *sessionBeadSnapshot) LoadError() error {
 	if s == nil {
 		return nil
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.loadErr
 }
 
@@ -48,6 +57,9 @@ func (s *sessionBeadSnapshot) LoadError() error {
 // see the underlying failure via LoadError.
 func newSessionBeadSnapshotWithError(beadsIn []beads.Bead, err error) *sessionBeadSnapshot {
 	s := newSessionBeadSnapshot(beadsIn)
+	// loadErr is set during construction, before s is published to any other
+	// goroutine, so no s.mu lock is needed here even though LoadError() reads
+	// it under RLock.
 	s.loadErr = err
 	return s
 }
@@ -134,33 +146,35 @@ func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
 	}
 }
 
-func (s *sessionBeadSnapshot) replaceOpen(open []beads.Bead) {
-	if s == nil {
-		return
-	}
+// replaceOpenLocked replaces the snapshot's open set and rebuilt lookup maps
+// from `open`. Callers must hold s.mu.
+func (s *sessionBeadSnapshot) replaceOpenLocked(open []beads.Bead) {
 	rebuilt := newSessionBeadSnapshot(open)
-	if rebuilt == nil {
-		s.open = nil
-		s.sessionNameByAgentName = nil
-		s.sessionNameByTemplateHint = nil
-		return
-	}
-	*s = *rebuilt
+	s.open = rebuilt.open
+	s.beadIDByAgentName = rebuilt.beadIDByAgentName
+	s.beadIDByTemplateHint = rebuilt.beadIDByTemplateHint
+	s.sessionNameByAgentName = rebuilt.sessionNameByAgentName
+	s.sessionNameByTemplateHint = rebuilt.sessionNameByTemplateHint
 }
 
 func (s *sessionBeadSnapshot) add(bead beads.Bead) {
 	if s == nil {
 		return
 	}
-	open := s.Open()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	open := make([]beads.Bead, 0, len(s.open)+1)
+	open = append(open, s.open...)
 	open = append(open, bead)
-	s.replaceOpen(open)
+	s.replaceOpenLocked(open)
 }
 
 func (s *sessionBeadSnapshot) Open() []beads.Bead {
 	if s == nil {
 		return nil
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	result := make([]beads.Bead, len(s.open))
 	copy(result, s.open)
 	return result
@@ -170,6 +184,8 @@ func (s *sessionBeadSnapshot) FindSessionNameByTemplate(template string) string 
 	if s == nil {
 		return ""
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if sn := s.sessionNameByAgentName[template]; sn != "" {
 		return sn
 	}
@@ -180,11 +196,13 @@ func (s *sessionBeadSnapshot) FindSessionBeadByTemplate(template string) (beads.
 	if s == nil {
 		return beads.Bead{}, false
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if id := s.beadIDByAgentName[template]; id != "" {
-		return s.FindByID(id)
+		return s.findByIDLocked(id)
 	}
 	if id := s.beadIDByTemplateHint[template]; id != "" {
-		return s.FindByID(id)
+		return s.findByIDLocked(id)
 	}
 	return beads.Bead{}, false
 }
@@ -193,6 +211,13 @@ func (s *sessionBeadSnapshot) FindByID(id string) (beads.Bead, bool) {
 	if s == nil || strings.TrimSpace(id) == "" {
 		return beads.Bead{}, false
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.findByIDLocked(id)
+}
+
+// findByIDLocked is the inner lookup; callers must hold at least s.mu.RLock.
+func (s *sessionBeadSnapshot) findByIDLocked(id string) (beads.Bead, bool) {
 	for _, bead := range s.open {
 		if bead.ID == id {
 			return bead, true
@@ -213,6 +238,8 @@ func (s *sessionBeadSnapshot) FindSessionBeadByNamedIdentity(identity string) (b
 	if s == nil || strings.TrimSpace(identity) == "" {
 		return beads.Bead{}, false
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	for _, bead := range s.open {
 		if strings.TrimSpace(bead.Metadata["configured_named_identity"]) != identity {
 			continue


### PR DESCRIPTION
## Summary

`realizePoolDesiredSessions` serialized session-bead creates in an O(N) loop. Each `createPoolSessionBeadWithGuardedAlias` acquires a per-alias session lock and commits to dolt (~3–4s per request), so a pool fanout of N items took ~N × commit-latency wall time even though distinct aliases can run concurrently. At N=6 the user-visible symptom was a verify gate escalating while items were still waiting to be materialized (#2319).

## Change

Split the loop into a three-phase pipeline:

- **Phase A** (serial, fast) — pure in-memory selection: pick a reusable session bead OR reserve an `(alias, slot)` for a fresh create. Slot allocation stays deterministic under serial control.
- **Phase B** (parallel, bounded to 8 workers) — materialize planned creates. The per-alias session lock already serializes same-alias creates; distinct aliases proceed in parallel.
- **Phase C** (serial, fast) — `resolveTemplateForSessionBead` + `installAgentSideEffects` remain serial pending a thread-safety audit. Failed creates release their reserved slot here.

`selectOrCreatePoolSessionBead` stays as a thin wrapper (phase A then phase B inline) so existing direct callers and the alias-lock serialization contract are preserved unchanged.

## Thread-safety

`sessionBeadSnapshot.add` was unsynchronized and raced under `-race` once phase B drove multiple distinct-alias creates concurrently. Added a `sync.RWMutex` — writes take the write lock, reads take the read lock.

## Tests

`TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates` drives 8 fresh creates against a delay-instrumented `MemStore` and asserts wall time strictly below half the serial floor — a future re-serialization fails this test before it ships. The existing same-alias contention test continues to pass under `-race`.

Closes #2319
