### PR TITLE
feat(dispatcher): treat gc.run_target as fallback routing key for open agent-routed wisp beads

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -7,6 +7,18 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
+// effectiveRoutingTarget returns the agent/named-session identifier the bead
+// should route to. gc.routed_to wins when set (explicit dispatcher routing);
+// otherwise gc.run_target is consulted (the convergence-reconciler wisp step
+// shape — unassigned, Status="open"). Whitespace is trimmed at the boundary
+// so downstream callers never need to think about it.
+func effectiveRoutingTarget(b beads.Bead) string {
+	if routed := strings.TrimSpace(b.Metadata["gc.routed_to"]); routed != "" {
+		return routed
+	}
+	return strings.TrimSpace(b.Metadata["gc.run_target"])
+}
+
 func assignedWorkStoreRefForAgent(cityPath string, cfg *config.City, agentCfg *config.Agent) string {
 	if cfg == nil || agentCfg == nil {
 		return ""
@@ -56,7 +68,7 @@ func filterAssignedWorkBeadsForPoolDemand(
 	}
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
 	for i, wb := range assignedWorkBeads {
-		template := strings.TrimSpace(wb.Metadata["gc.routed_to"])
+		template := effectiveRoutingTarget(wb)
 		if template == "" {
 			if sessionBeadID := assigneeToSessionBeadID[strings.TrimSpace(wb.Assignee)]; sessionBeadID != "" {
 				template = sessionBeadTemplate[sessionBeadID]
@@ -69,6 +81,14 @@ func filterAssignedWorkBeadsForPoolDemand(
 			continue
 		}
 		agentCfg := findAgentByTemplate(cfg, template)
+		if agentCfg == nil {
+			// Identity may name a named-session (e.g. pack.scope-locked-editor)
+			// rather than a bare agent template. Resolve through the named-session
+			// spec to recover the backing agent for reachability checks.
+			if spec, ok := findNamedSessionSpec(cfg, "", template); ok {
+				agentCfg = spec.Agent
+			}
+		}
 		if agentCfg == nil {
 			continue
 		}

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -112,6 +112,75 @@ func TestFilterAssignedWorkBeadsForPoolDemandDropsDirectAssigneeFromUnreachableS
 	}
 }
 
+func TestFilterAssignedWorkBeadsForPoolDemandHonorsRunTargetForWispStep(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "grader"}},
+	}
+	// Wisp step shape from the convergence reconciler:
+	// Status=open, unassigned, gc.run_target set, gc.routed_to absent.
+	work := []beads.Bead{{
+		ID:     "wisp-step-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.run_target": "grader",
+		},
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+
+	if len(got) != 1 || got[0].ID != "wisp-step-1" {
+		t.Fatalf("filtered work = %#v, want wisp-step-1 retained via gc.run_target fallback", got)
+	}
+}
+
+func TestFilterAssignedWorkBeadsForPoolDemandRoutedToWinsOverRunTarget(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "grader"},
+			{Name: "reviewer"},
+		},
+	}
+	// Explicit gc.routed_to must be honored when both keys are present.
+	work := []beads.Bead{{
+		ID:     "explicit-route",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.routed_to":  "reviewer",
+			"gc.run_target": "grader",
+		},
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+
+	if len(got) != 1 {
+		t.Fatalf("filtered work len = %d, want 1: %#v", len(got), got)
+	}
+}
+
+func TestFilterAssignedWorkBeadsForPoolDemandResolvesRunTargetToNamedSession(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "editor"}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "scope-locked-editor",
+			Template: "editor",
+			Mode:     "on_demand",
+		}},
+	}
+	work := []beads.Bead{{
+		ID:     "wisp-step-named",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.run_target": "scope-locked-editor",
+		},
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", nil, work, []string{""})
+
+	if len(got) != 1 || got[0].ID != "wisp-step-named" {
+		t.Fatalf("filtered work = %#v, want wisp-step-named retained via named-session run_target", got)
+	}
+}
+
 func TestSessionHasOpenAssignedWorkUsesOnlyReachableStore(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "riga")

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -877,7 +877,7 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
-			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
+			template := effectiveRoutingTarget(b)
 			if _, ok := group.templates[template]; ok {
 				counts[template]++
 			}
@@ -956,7 +956,7 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
-			routedTo := strings.TrimSpace(b.Metadata["gc.routed_to"])
+			routedTo := effectiveRoutingTarget(b)
 			if routedTo == "" {
 				continue
 			}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -640,6 +640,20 @@ func collectAssignedWorkBeadsWithStores(
 					appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
 				}
 			}
+			// Open, unassigned, agent-routed wisp step beads (gc.run_target set
+			// but no gc.routed_to and no assignee). These are the convergence
+			// reconciler shape: dispatcher must see them so it can spawn the
+			// target agent/session. Without this pass, the dispatcher would
+			// only see Status=in_progress beads and miss freshly created
+			// wisp steps until something else routed them first.
+			if open, err := listForControllerDemand(source.store, beads.ListQuery{Status: "open"}); err == nil {
+				appendOpenAgentRoutedWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, open, seen, source.store, source.ref)
+			} else {
+				errs = append(errs, fmt.Errorf("List(open): %w", err))
+				if beads.IsPartialResult(err) && len(open) > 0 {
+					appendOpenAgentRoutedWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, open, seen, source.store, source.ref)
+				}
+			}
 			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, storeRefs: resultStoreRefs, errs: errs}
 		}()
 	}
@@ -1157,6 +1171,41 @@ func appendInProgressWorkUnique(cfg *config.City, dst *[]beads.Bead, stores *[]b
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" && !isRecoverableUnassignedInProgressPoolWork(cfg, b) {
 			continue
+		}
+		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
+	}
+}
+
+// appendOpenAgentRoutedWorkUnique includes Status=open, unassigned beads that
+// carry an agent/named-session routing key via gc.run_target. These are the
+// wisp step beads emitted by the convergence reconciler: they have no
+// gc.routed_to and no assignee, so the in-progress scan would skip them. The
+// dispatcher needs to see them so it can spawn the target agent or wake the
+// named session and route the work.
+func appendOpenAgentRoutedWorkUnique(cfg *config.City, dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
+	for _, b := range beadList {
+		if b.Status != "open" {
+			continue
+		}
+		if strings.TrimSpace(b.Assignee) != "" {
+			continue
+		}
+		if strings.TrimSpace(b.Metadata["gc.routed_to"]) != "" {
+			// Already explicitly routed; the dispatcher's normal handoff
+			// probes (Ready queries) cover this case.
+			continue
+		}
+		target := strings.TrimSpace(b.Metadata["gc.run_target"])
+		if target == "" {
+			continue
+		}
+		// Only emit if the target resolves to a known agent template or
+		// named-session identity. Unknown targets are left for other
+		// reconcilers to surface as misconfigurations.
+		if findAgentByTemplate(cfg, target) == nil {
+			if _, ok := findNamedSessionSpec(cfg, "", target); !ok {
+				continue
+			}
 		}
 		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
 	}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -703,6 +703,102 @@ func TestCollectAssignedWorkBeads_ExcludesRoutedToMetadataWithoutAssignee(t *tes
 	}
 }
 
+// Wisp step beads emitted by the convergence reconciler are Status=open,
+// unassigned, and carry gc.run_target (no gc.routed_to). The dispatcher must
+// surface them so the target agent or named session can be spawned and the
+// work routed.
+func TestCollectAssignedWorkBeads_IncludesOpenAgentRoutedRunTargetWispStep(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "grader"}},
+	}
+	wisp, err := store.Create(beads.Bead{
+		Title:    "grade-output",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.run_target": "grader"},
+	})
+	if err != nil {
+		t.Fatalf("create wisp step bead: %v", err)
+	}
+	// Unknown run_target — must NOT be surfaced.
+	if _, err := store.Create(beads.Bead{
+		Title:    "unknown-target",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.run_target": "ghost-agent"},
+	}); err != nil {
+		t.Fatalf("create unknown-target bead: %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(cfg, store)
+	if len(got) != 1 {
+		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 1 (the agent-routed wisp step): %#v", len(got), got)
+	}
+	if got[0].ID != wisp.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %q, want %q", got[0].ID, wisp.ID)
+	}
+}
+
+// Named-session identities (e.g. scope-locked-editor) must also be recognized
+// as routing targets via gc.run_target so on_demand sessions can be woken.
+func TestCollectAssignedWorkBeads_IncludesOpenRunTargetForNamedSession(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "editor"}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "scope-locked-editor",
+			Template: "editor",
+			Mode:     "on_demand",
+		}},
+	}
+	wisp, err := store.Create(beads.Bead{
+		Title:    "patch-file",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.run_target": "scope-locked-editor"},
+	})
+	if err != nil {
+		t.Fatalf("create wisp step bead: %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(cfg, store)
+	if len(got) != 1 || got[0].ID != wisp.ID {
+		t.Fatalf("collectAssignedWorkBeads = %#v, want named-session wisp %s", got, wisp.ID)
+	}
+}
+
+// Confirm gc.routed_to remains the dominant routing key: when both are set,
+// the existing dispatcher paths (Ready handoff or in_progress) handle it, and
+// the new open-scan must not double-emit the bead.
+func TestCollectAssignedWorkBeads_RunTargetDoesNotDoubleEmitRoutedBead(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "grader"}},
+	}
+	routed, err := store.Create(beads.Bead{
+		Title:    "explicit-route",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "grader",
+		Metadata: map[string]string{
+			"gc.routed_to":  "grader",
+			"gc.run_target": "grader",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create routed bead: %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(cfg, store)
+	if len(got) != 1 || got[0].ID != routed.ID {
+		t.Fatalf("collectAssignedWorkBeads = %#v, want single emission of %s", got, routed.ID)
+	}
+}
+
 func TestCollectAssignedWorkBeads_ExcludesSessionBeads(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -267,11 +267,16 @@ func isRecoverableUnassignedInProgressPoolWork(cfg *config.City, wb beads.Bead) 
 	if wb.Status != "in_progress" || strings.TrimSpace(wb.Assignee) != "" {
 		return false
 	}
-	template := strings.TrimSpace(wb.Metadata["gc.routed_to"])
+	template := effectiveRoutingTarget(wb)
 	if template == "" {
 		return false
 	}
 	agentCfg := findAgentByTemplate(cfg, template)
+	if agentCfg == nil {
+		if spec, ok := findNamedSessionSpec(cfg, "", template); ok {
+			agentCfg = spec.Agent
+		}
+	}
 	return agentCfg != nil && agentCfg.SupportsGenericEphemeralSessions()
 }
 


### PR DESCRIPTION
## Summary

In a multi-agent orchestration deployment, the dispatcher's demand path emits `assignedWorkBeads: 0 beads (rigStores=0)` for wisp step beads, even though `workflow-step-runner` correctly spawns them with `gc.run_target` metadata. Result: on-demand agent sessions stay reserved-unmaterialized; convergences appear to progress (precheck + validate beads close) without any LLM work running. Stale-reaper later force-closes the orphaned step beads.

## Root cause

The dispatcher demand path only honors `gc.routed_to` as the routing key:

* `cmd/gc/build_desired_state.go`: `readyAssignedWorkAssignees` matches `Assignee` only
* `cmd/gc/build_desired_state.go`: `appendInProgressWorkUnique` requires `Status=in_progress` AND `gc.routed_to`
* `cmd/gc/assigned_work_scope.go`: `filterAssignedWorkBeadsForPoolDemand` honors only `gc.routed_to`
* `cmd/gc/assigned_work_scope.go`: `isRecoverableUnassignedInProgressPoolWork` requires `gc.routed_to`

Wisp step beads created by the convergence reconciler have `gc.run_target` set + `Status=open` + no `gc.routed_to`. None of the four sites match → 0 demand → on-demand sessions never materialize.

## Fix

Treat `gc.run_target` as a fallback routing key with `gc.routed_to` precedence preserved:

1. `effectiveRoutingTarget` helper returns `routed_to` if set, else `run_target` (`assigned_work_scope.go`).
2. `appendOpenAgentRoutedWorkUnique` surfaces `Status=open` agent-routed wisp beads. Skips beads with `gc.routed_to` to avoid double-emit (handoff path remains single emission site).
3. Named-session fallback added at three sites — both agent-template targets and named-session targets are common wisp targets; handling agents only would have shipped half-broken.

## Tests (all new)

* `TestFilterAssignedWorkBeadsForPoolDemandHonorsRunTargetForWispStep`
* `TestFilterAssignedWorkBeadsForPoolDemandRoutedToWinsOverRunTarget`
* `TestFilterAssignedWorkBeadsForPoolDemandResolvesRunTargetToNamedSession`
* `TestCollectAssignedWorkBeads_IncludesOpenAgentRoutedRunTargetWispStep`
* `TestCollectAssignedWorkBeads_IncludesOpenRunTargetForNamedSession`
* `TestCollectAssignedWorkBeads_RunTargetDoesNotDoubleEmitRoutedBead`

`go test ./cmd/gc/` — 5339 passed, 0 failed. `go vet ./cmd/gc/... ./internal/...` clean.

## Side effect: stuck `continuation_reset_pending` sessions also recover

Sessions blocked with `continuation_reset_pending=true` and `wake_attempts=0` recover automatically once the routing fix is in — wake demand is now computed for unrouted wisp beads, the materialization path runs, and the pending flag clears via the existing reset path.

## Files (LOC delta)

```
cmd/gc/assigned_work_scope.go        +21 / -1
cmd/gc/pool_session_name.go           +6 / -1
cmd/gc/build_desired_state.go        +51 / -2
cmd/gc/assigned_work_scope_test.go   +69 / -0
cmd/gc/build_desired_state_test.go   +96 / -0
```

Total: +243 / -4 (148 prod + 165 test). 3 commits, one per logical change.