### PR TITLE
docs(hooks): align event-vocabulary README with current copilot wiring (#672)

### DIFF
--- a/internal/hooks/config/README.md
+++ b/internal/hooks/config/README.md
@@ -30,7 +30,7 @@ the event, or it does but Gas City has not opted in yet).
 | Canonical event | claude | codex | cursor | copilot | gemini | opencode | omp | pi |
 |---|---|---|---|---|---|---|---|---|
 | session start    | `SessionStart` ✓ | `SessionStart` ✓ | `sessionStart` ✓ | `sessionStart` ✓ | `SessionStart` ✓ | `session.created` ✓ | `session_start` ✓ | `session_start` ✓ |
-| pre-compaction   | `PreCompact` ✓   | `PreCompact` ✓   | `preCompact` ✓   | — (gap, #672)    | `PreCompress` ✓  | `session.compacted` ✓ | `session_compact` ✓ | `session_compact` ✓ |
+| pre-compaction   | `PreCompact` ✓   | `PreCompact` ✓   | `preCompact` ✓   | `preCompact` ✓   | `PreCompress` ✓  | `session.compacted` ✓ | `session_compact` ✓ | `session_compact` ✓ |
 | user prompt submit | `UserPromptSubmit` ✓ | `UserPromptSubmit` ✓ | `beforeSubmitPrompt` ✓ | `userPromptSubmitted` ✓ | — | — | — | — |
 | before agent run | —                | —                | —                | —                | `BeforeAgent` ✓  | —                | `before_agent_start` ✓ | `before_agent_start` ✓ |
 
@@ -64,8 +64,9 @@ this README only documents the event vocabulary, not the command shape.
 
 ## Known gaps
 
-- **copilot pre-compaction** — GitHub Copilot's hook config currently
-  exposes `sessionStart` and `userPromptSubmitted` but no documented
-  pre-compaction event. Tracked under the parent audit (#672 gap 3,
-  bead `ga-10l`). If/when Copilot adds such an event, append a row here
-  and wire `gc handoff --auto` to it.
+- **kiro pre-compaction** — Kiro's hook config (under
+  `.kiro/agents/gascity.json`) wires `agentSpawn` and `userPromptSubmit`
+  but has no pre-compaction event. Kiro does not currently document a
+  hook fired before context compaction; add a row here and wire
+  `gc handoff --auto` if/when Kiro exposes one. Tracked under the parent
+  audit (#672 gap 3).


### PR DESCRIPTION
## Summary

Re-audited the still-open items from [`Rome-1/gastown`'s parity-audit
classification doc](https://github.com/Rome-1/gastown/blob/main/docs/research/w-7ed35a727f-parity-audit-classification.md)
(against gascity ed5bf5ce) against current main and discovered the
audit-era assumptions no longer match the tree. Most "open" gaps have
been closed by intervening work; the residual gap that is shippable as a
focused, non-design-touching change is the stale `internal/hooks/config/README.md`
— it still flags copilot's pre-compaction as a gap even though PR #2009
wired it.

This PR is a single doc commit. Other audit gaps either already shipped
or require design discussion and are deferred with follow-up beads
below.

### What this PR changes

- [x] **Gap 3 (residual docs)** — Update `internal/hooks/config/README.md`
      so the event-mapping table shows copilot's `preCompact` row as wired,
      and replace the obsolete "copilot pre-compaction" known-gap entry
      with the actual remaining residual: Kiro, whose
      `.kiro/agents/gascity.json` still has no pre-compaction event.
      Commit `4ae3f921`.

### Already done since the audit (no change needed in this PR)

- **Gap 3 (code)** — copilot `preCompact` wired in PR #2009
  (`internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json`).
  Codex `PreCompact` is wired at
  `internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json`.
  Both rows already wired in the file overlays; only the README was stale.
- **Gap 5** — Hook event vocabulary doc landed at
  `internal/hooks/config/README.md` (and is what this PR refreshes).
- **Gap 8 (partial)** — `internal/doctor/checks_provider_parity.go`
  (`ProviderParityCheck`) is registered in `cmd/gc/cmd_doctor.go` and
  flags providers used by configured agents that have neither
  `ResumeFlag` nor `ResumeCommand`. Full test coverage in
  `checks_provider_parity_test.go`.
- **Gap 1 (mostly)** — `internal/worker/builtin/profiles.go` now
  populates `ResumeFlag` for claude, codex, gemini, cursor, copilot,
  amp, opencode, auggie. Only kiro/pi/omp still leave it empty.

### Deferred — design discussion required (filed as beads)

- **Gap 2 (codex SessionIDFlag)** — *intentionally* not set: the existing
  `TestBuiltinProvidersSessionIDFlag` (`internal/config/provider_test.go`
  L299) pins codex to empty because populating it would emit
  `codex --session-id <key>` on first start, which codex's CLI rejects
  (`codex resume <id>` is a resume path, not a fresh-start path).
  Treating this as "open" would contradict a deliberate design decision
  documented in tree. Bead: `ga-bpq`.
- **Gap 4 (amp/auggie hooks)** — `internal/worker/builtin/profiles.go`
  L317-322 and L350-358 carry inline comments explaining the strategy
  gaps (amp: Gas Town has not wired the plugin model; auggie: user-global
  `~/.augment/settings.json` collides with per-workdir installation).
  Both explicitly deferred pending strategy design. Bead: `ga-8rg` for
  tracking the cross-cutting parity work.
- **Gap 7 (InstructionsFile materialization)** — needs a design call:
  copy `CLAUDE.md` to `AGENTS.md` at session start? Symlink? Per-provider
  conditional? The current default-to-`AGENTS.md` in
  `internal/config/resolve.go:561` already covers the *lookup* path; the
  *staging* path needs a primitive home (session-startup hook? overlay
  installer?).
- **Gap 8 (doctor breadth)** — extending the check to also flag
  `SupportsHooks: false`, missing overlay hook files, etc. is doable but
  the existing comment in `checks_provider_parity.go:22-23` explicitly
  notes that flagging `SupportsHooks: false` would be noise because
  several providers genuinely lack a hook surface and use the
  poller-based drain path. Any expansion needs the noise/signal call
  made explicitly. Bead: `ga-702`.

### Audit-doc claims that no longer match the gascity tree

Worth flagging for the doc's next refresh:

1. The "Detail by finding" section for Gap 3 still cites
   `internal/hooks/config/codex.json` and
   `internal/hooks/config/copilot.json` — those files no longer exist;
   per-provider hook configs moved to
   `internal/bootstrap/packs/core/overlay/per-provider/<provider>/...`
   (documented in `internal/hooks/config/README.md`'s "File layout"
   section).
2. Gap 1 says "every other builtin leaves `ResumeFlag` empty"; the
   present builtin map populates `ResumeFlag` for everything except
   kiro/pi/omp (verified at `internal/worker/builtin/profiles.go`).
3. Theme 2 references `ProviderSpec.NeedsNudgePoller` and
   `maybeStartNudgePoller`'s old shape; the dispatcher landscape now
   has both a supervisor-hosted dispatcher
   (`cmd/gc/cmd_nudge.go:nudgeDispatcherIsSupervisor`) and a per-session
   poller path (`maybeStartNudgePoller` at `cmd/gc/cmd_nudge.go:835`).

Closes part of wasteland `w-c243404137`; tracking under
gastownhall/gascity#672.

## Test plan

- [x] `go test ./internal/worker/builtin/... -count=1` clean.
- [x] `go vet ./internal/worker/builtin/... ./internal/config/...` clean.
- [x] Pre-commit hook ran on the README change (docsync test passed).
- [x] No production-code change; the doc edit is purely descriptive of
      the existing overlay state at
      `internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json`.