### PR TITLE
fix(beads): skip dolt auto-recover on ENOSPC to break disk-full cascade

### DIFF
--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2356,12 +2356,44 @@ op_probe() {
     exit 2
 }
 
+# recovery_should_skip_due_to_enospc returns 0 (true) when the recent
+# dolt server log shows disk-exhaustion (ENOSPC) signatures. Restarting
+# dolt under ENOSPC does not free disk space, and the recovery cycle
+# itself amplifies the failure: every restart triggers a fresh conjoin
+# that drops another partial nbs_table_* file in the backup remote,
+# accelerating the disk-full feedback loop. See gastownhall/gascity#2158.
+#
+# Returns 1 (false) when no ENOSPC signature is found in the recent log
+# tail, or when the log file cannot be read.
+recovery_should_skip_due_to_enospc() {
+    [ -n "$LOG_FILE" ] && [ -r "$LOG_FILE" ] || return 1
+    # Scan the recent log tail rather than the whole file; an old transient
+    # ENOSPC error from a since-resolved disk-pressure event should not
+    # block recovery indefinitely.
+    tail -n 1000 "$LOG_FILE" 2>/dev/null \
+        | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
+        || return 1
+    return 0
+}
+
 # op_recover stops the dolt server, restarts it, and verifies health.
 op_recover() {
     local read_only_status
 
     if is_remote; then
         die "recovery not supported for remote dolt servers"
+    fi
+
+    # Skip auto-recovery when dolt has been failing due to disk exhaustion.
+    # Restarting dolt does not free disk space, and the recovery cycle
+    # itself amplifies the failure: each restart triggers a conjoin/backup
+    # sync that writes another partial table file to the backup remote.
+    # Require manual intervention (free disk space) before recovery
+    # resumes. See gastownhall/gascity#2158.
+    if recovery_should_skip_due_to_enospc; then
+        echo "skipping dolt recovery: recent dolt log shows ENOSPC — manual intervention required" >&2
+        echo "  free disk space, then re-run health checks" >&2
+        die "dolt recovery skipped: ENOSPC detected"
     fi
 
     if load_recover_managed_from_gc; then


### PR DESCRIPTION
## Summary

Closes #2158.

When the managed dolt server fails with ENOSPC and `beads-health` triggers recovery, restarting dolt does not free disk space. Worse, the restart itself triggers another conjoin/backup-sync attempt that writes another partial `nbs_table_*` file to the backup remote, which in turn worsens disk pressure. Across a 30s health-check cadence this amplifies a single failing conjoin into a full-disk feedback loop until the volume hits 100%.

## Change

Add a defensive guard at the top of `op_recover` in `examples/bd/assets/scripts/gc-beads-bd.sh` that scans the recent dolt log tail for ENOSPC signatures (`no space left on device`, `copy_file_range:.*no space`, `ENOSPC`). When detected, the guard logs a clear message indicating manual intervention is required and exits non-zero. The order layer treats this as a transient failure rather than silently amplifying it on every tick.

The check only fires when ENOSPC is in the recent log tail (last 1000 lines). Once disk pressure clears and dolt returns to normal traffic, the ENOSPC trace ages out of the window and recovery resumes automatically — operators don't need to manually re-enable anything after freeing disk.

## Test plan

- bash -n syntax check passes on the modified script.
- Smoke tested the new `recovery_should_skip_due_to_enospc` helper against the actual dolt log from a real cascade incident:
  - Slice ending at the last ENOSPC entry: returns 0 (skip) ✓
  - Current tail after disk cleanup: returns 1 (proceed normally) ✓
- Happy to add an acceptance test under `test/acceptance/` if the desired pattern is specified.

## Residual scope

This PR closes #2158 as written (the gc-side auto-recover amplification). A separate, upstream bug at `dolthub/dolt` also drives the leak directly from the running dolt sql-server (its internal backup-sync runs independent of any gc order). This fix breaks the gc-side amplification cascade but cannot eliminate the underlying server-driven leak — that requires a Dolt-side fix and should be tracked separately.
