### PR TITLE
fix(gastown): exclude type=molecule from mol-refinery-patrol find-work (tr-uswlk)

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -145,7 +145,7 @@ description = """
 Search for work beads assigned to you with branch metadata:
 ```bash
 WORK=$(gc bd list --assignee=$GC_AGENT --status=open \
-  --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
+  --exclude-type=epic,molecule --limit=1 --json | jq -r '.[0].id // empty')
 ```
 
 If found: read the bead metadata to confirm it has a branch:


### PR DESCRIPTION
mol-refinery-patrol's find-work step located the next work bead with
`gc bd list --assignee=$GC_AGENT --status=open --exclude-type=epic`.
The `--exclude-type=epic` was meant to keep the refinery's own patrol
wisp out of the result, but wisps poured via `gc bd mol wisp` have
issue_type `molecule`, not `epic`. On an empty merge queue the patrol
wisp self-matched the query: find-work returned the refinery's own
wisp instead of "no work found". That wisp has no metadata.branch, so
an agent applying the work-bead metadata contract mechanically would
run the rejection flow on its own patrol wisp.

Exclude `molecule` as well. Same find-work-surfaces-non-work class as
gc-rm0ha.38.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
