### PR TITLE
fix(reconciler): clear pending-create lease on stale-creating→asleep healing

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -881,6 +881,17 @@ func isPoolExcess(session beads.Bead, cfg *config.City, poolDesired map[string]i
 
 // healState updates advisory state metadata only when changed (dirty check).
 func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clock) {
+	healStateWithRollback(session, alive, store, clk, true)
+}
+
+// healStateWithRollback is the explicit-control variant of healState. When
+// rollbackAvailable is false (e.g. the reconciler short-circuited the
+// stale-pending-create rollback because storeQueryPartial=true) the heal path
+// preserves pending_create_claim so the next non-partial tick can do the
+// proper rollback. When true (default), healState clears the stale claim
+// in-line to break the state=creating ↔ state=asleep oscillation described
+// in ga-mf1.
+func healStateWithRollback(session *beads.Bead, alive bool, store beads.Store, clk clock.Clock, rollbackAvailable bool) {
 	if session == nil {
 		return
 	}
@@ -893,7 +904,7 @@ func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clo
 	if session.Status == "closed" {
 		return
 	}
-	batch := healStatePatch(*session, alive, clk)
+	batch := healStatePatchWithRollback(*session, alive, clk, rollbackAvailable)
 	if len(batch) == 0 {
 		return
 	}
@@ -909,6 +920,10 @@ func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clo
 }
 
 func healStatePatch(session beads.Bead, alive bool, clk clock.Clock) map[string]string {
+	return healStatePatchWithRollback(session, alive, clk, true)
+}
+
+func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock, rollbackAvailable bool) map[string]string {
 	meta := session.Metadata
 	if meta == nil {
 		meta = map[string]string{}
@@ -960,9 +975,29 @@ func healStatePatch(session beads.Bead, alive bool, clk clock.Clock) map[string]
 			return nil
 		}
 		target = string(sessionpkg.StateAsleep)
-		if strings.TrimSpace(meta["pending_create_claim"]) == "true" {
-			batch["pending_create_claim"] = ""
-			batch["pending_create_started_at"] = ""
+		clearPendingCreateLease(meta, batch)
+	}
+	// ga-mf1: stale-creating projects to ReconciledState=asleep once the
+	// pending_create lease has expired (creatingStateIsStale → true). Same
+	// reasoning as failed-create above: if we leave pending_create_claim=true
+	// in metadata, the next tick's projectWakeCauses re-emits
+	// WakeCausePendingCreate and projectRuntimeProjection's post-creating
+	// branch flips the projection back to StateCreating, ping-ponging the
+	// bead forever between creating and asleep+runtime-missing. Clearing the
+	// expired lease in the same heal batch lets the bead settle in asleep.
+	//
+	// Gate the clear on pendingCreateLeaseExpiredForRollback — the same
+	// predicate the orphan rollback path uses — so we honor the longer
+	// never-started lease (10 min) for beads that haven't yet had
+	// last_woke_at recorded. creatingStateIsStale alone fires at 60s and
+	// would race the rollback path's reservation.
+	//
+	// rollbackAvailable=false means the caller deferred the formal rollback
+	// (e.g. storeQueryPartial); preserve the claim so the next complete tick
+	// can drive attemptRollbackPendingCreate properly.
+	if rollbackAvailable && !alive && view.RuntimeProjection == sessionpkg.RuntimeProjectionStaleCreating {
+		if pendingCreateLeaseExpiredForRollback(session, clk, 0) {
+			clearPendingCreateLease(meta, batch)
 		}
 	}
 	if target == "" {
@@ -987,6 +1022,20 @@ func healStatePatch(session beads.Bead, alive bool, clk clock.Clock) map[string]
 		}
 	}
 	return emptyNil(batch)
+}
+
+// clearPendingCreateLease writes empty-string clears for pending_create_claim
+// and pending_create_started_at into the heal batch when the metadata
+// currently carries a claim. Shared between the failed-create rollback path
+// and the stale-creating heal path so both finish the rollback the lifecycle
+// projection started, instead of letting the stale claim re-emit
+// WakeCausePendingCreate on the next tick and re-enter state=creating.
+func clearPendingCreateLease(meta, batch map[string]string) {
+	if strings.TrimSpace(meta["pending_create_claim"]) != "true" {
+		return
+	}
+	batch["pending_create_claim"] = ""
+	batch["pending_create_started_at"] = ""
 }
 
 func emptyNil(batch map[string]string) map[string]string {

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -881,7 +881,7 @@ func isPoolExcess(session beads.Bead, cfg *config.City, poolDesired map[string]i
 
 // healState updates advisory state metadata only when changed (dirty check).
 func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clock) {
-	healStateWithRollback(session, alive, store, clk, true)
+	healStateWithRollback(session, alive, store, clk, 0, true)
 }
 
 // healStateWithRollback is the explicit-control variant of healState. When
@@ -889,11 +889,11 @@ func healState(session *beads.Bead, alive bool, store beads.Store, clk clock.Clo
 // stale-pending-create rollback because storeQueryPartial=true) the heal path
 // preserves pending_create_claim so the next non-partial tick can do the
 // proper rollback. When true (default), healState clears the stale claim
-// in-line to break the state=creating ↔ state=asleep oscillation described
-// in ga-mf1.
-func healStateWithRollback(session *beads.Bead, alive bool, store beads.Store, clk clock.Clock, rollbackAvailable bool) {
+// in-line after startupTimeout has elapsed to break the state=creating ↔
+// state=asleep oscillation described in ga-mf1.
+func healStateWithRollback(session *beads.Bead, alive bool, store beads.Store, clk clock.Clock, startupTimeout time.Duration, rollbackAvailable bool) map[string]string {
 	if session == nil {
-		return
+		return nil
 	}
 	// healState is the third writer in the closed-bead flap cycle. The
 	// lifecycle projection still resolves to BaseStateDrained for closed
@@ -902,11 +902,11 @@ func healStateWithRollback(session *beads.Bead, alive bool, store beads.Store, c
 	// gc_swept / orphaned writes from the closeBead path. Closed beads
 	// are terminal; their advisory state metadata should not move.
 	if session.Status == "closed" {
-		return
+		return nil
 	}
-	batch := healStatePatchWithRollback(*session, alive, clk, rollbackAvailable)
+	batch := healStatePatchWithRollback(*session, alive, clk, startupTimeout, rollbackAvailable)
 	if len(batch) == 0 {
-		return
+		return nil
 	}
 	if session.Metadata == nil {
 		session.Metadata = make(map[string]string, len(batch))
@@ -917,13 +917,14 @@ func healStateWithRollback(session *beads.Bead, alive bool, store beads.Store, c
 	for k, v := range batch {
 		session.Metadata[k] = v
 	}
+	return batch
 }
 
 func healStatePatch(session beads.Bead, alive bool, clk clock.Clock) map[string]string {
-	return healStatePatchWithRollback(session, alive, clk, true)
+	return healStatePatchWithRollback(session, alive, clk, 0, true)
 }
 
-func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock, rollbackAvailable bool) map[string]string {
+func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock, startupTimeout time.Duration, rollbackAvailable bool) map[string]string {
 	meta := session.Metadata
 	if meta == nil {
 		meta = map[string]string{}
@@ -996,7 +997,7 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 	// (e.g. storeQueryPartial); preserve the claim so the next complete tick
 	// can drive attemptRollbackPendingCreate properly.
 	if rollbackAvailable && !alive && view.RuntimeProjection == sessionpkg.RuntimeProjectionStaleCreating {
-		if pendingCreateLeaseExpiredForRollback(session, clk, 0) {
+		if pendingCreateLeaseExpiredForRollback(session, clk, startupTimeout) {
 			clearPendingCreateLease(meta, batch)
 		}
 	}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1607,6 +1607,54 @@ func TestHealState_StaleCreatingPendingClaimDoesNotOscillateBackToCreating(t *te
 	}
 }
 
+func TestHealStatePatchWithRollbackHonorsConfiguredStartupTimeout(t *testing.T) {
+	now := time.Date(2026, 5, 19, 9, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	startupTimeout := 5 * time.Minute
+
+	inFlightAt := now.Add(-90 * time.Second)
+	inFlight := makeBead("b1", map[string]string{
+		"state":                     "creating",
+		"pending_create_claim":      "true",
+		"pending_create_started_at": inFlightAt.UTC().Format(time.RFC3339),
+		"last_woke_at":              inFlightAt.UTC().Format(time.RFC3339),
+		"session_key":               "in-flight-key",
+		"started_config_hash":       "in-flight-hash",
+	})
+	inFlight.CreatedAt = inFlightAt
+
+	if pendingCreateLeaseExpiredForRollback(inFlight, clk, startupTimeout) {
+		t.Fatal("configured startup lease reported expired while Start is still in flight")
+	}
+	got := healStatePatchWithRollback(inFlight, false, clk, startupTimeout, true)
+	if _, ok := got["pending_create_claim"]; ok {
+		t.Fatalf("healStatePatchWithRollback cleared pending_create_claim while configured startup lease is active: %#v", got)
+	}
+	if _, ok := got["pending_create_started_at"]; ok {
+		t.Fatalf("healStatePatchWithRollback cleared pending_create_started_at while configured startup lease is active: %#v", got)
+	}
+
+	expiredAt := now.Add(-(startupTimeout + staleKeyDetectDelay + 6*time.Second))
+	expired := makeBead("b1", map[string]string{
+		"state":                     "creating",
+		"pending_create_claim":      "true",
+		"pending_create_started_at": expiredAt.UTC().Format(time.RFC3339),
+		"last_woke_at":              expiredAt.UTC().Format(time.RFC3339),
+	})
+	expired.CreatedAt = expiredAt
+
+	if !pendingCreateLeaseExpiredForRollback(expired, clk, startupTimeout) {
+		t.Fatal("configured startup lease stayed active after startup timeout and stale-key delay elapsed")
+	}
+	got = healStatePatchWithRollback(expired, false, clk, startupTimeout, true)
+	if got["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim clear = %q, want empty after configured lease expiry", got["pending_create_claim"])
+	}
+	if got["pending_create_started_at"] != "" {
+		t.Fatalf("pending_create_started_at clear = %q, want empty after configured lease expiry", got["pending_create_started_at"])
+	}
+}
+
 func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 	now := time.Date(2026, 4, 15, 14, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1552,6 +1552,61 @@ func TestHealState_StaleCreatingWithoutPendingClaimHealsToAsleep(t *testing.T) {
 	}
 }
 
+// ga-mf1 regression: a session bead that enters state=creating with
+// pending_create_claim=true and a now-stale pending_create_started_at must
+// settle in state=asleep after one heal tick and NOT flip back to creating on
+// the next tick. Previously the first tick wrote state=asleep+runtime-missing
+// but left pending_create_claim=true, so projectWakeCauses re-emitted
+// WakeCausePendingCreate and projectRuntimeProjection's post-creating branch
+// flipped the projection back to StateCreating — ping-ponging forever.
+func TestHealState_StaleCreatingPendingClaimDoesNotOscillateBackToCreating(t *testing.T) {
+	store := newTestStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 19, 8, 0, 0, 0, time.UTC)}
+
+	// Past pendingCreateNeverStartedTimeout (10m) so the never-started lease
+	// has expired. Anything shorter and the rollback path correctly waits
+	// for it (see TestReconcileSessionBeads_*PendingCreate*NeverStartedLease).
+	stale := clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Minute))
+	session := makeBead("b1", map[string]string{
+		"state":                     "creating",
+		"pending_create_claim":      "true",
+		"pending_create_started_at": stale.UTC().Format(time.RFC3339),
+		// Prior failed start attempt left resume identity behind; this drives
+		// ResetContinuation=true so the heal writes sleep_reason=runtime-missing.
+		"session_key":         "prior-key",
+		"started_config_hash": "prior-hash",
+	})
+	session.CreatedAt = stale
+
+	// First tick: stale creating → asleep+runtime-missing, with stale
+	// pending_create lease cleared in the same batch.
+	healState(&session, false, store, clk)
+	if got := session.Metadata["state"]; got != "asleep" {
+		t.Fatalf("after first heal: state = %q, want asleep", got)
+	}
+	if got := session.Metadata["sleep_reason"]; got != sleepReasonRuntimeMissing {
+		t.Fatalf("after first heal: sleep_reason = %q, want %q", got, sleepReasonRuntimeMissing)
+	}
+	if got := session.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("after first heal: pending_create_claim = %q, want empty", got)
+	}
+	if got := session.Metadata["pending_create_started_at"]; got != "" {
+		t.Fatalf("after first heal: pending_create_started_at = %q, want empty", got)
+	}
+
+	// Second tick: with the lease cleared, nothing should pull the bead
+	// back into state=creating. Advance the clock slightly to simulate
+	// the next reconciler tick.
+	clk.Time = clk.Time.Add(30 * time.Second)
+	healState(&session, false, store, clk)
+	if got := session.Metadata["state"]; got != "asleep" {
+		t.Fatalf("after second heal: state = %q, want asleep (oscillation regression)", got)
+	}
+	if got := session.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("after second heal: pending_create_claim = %q, want empty (oscillation regression)", got)
+	}
+}
+
 func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 	now := time.Date(2026, 4, 15, 14, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}
@@ -1669,6 +1724,45 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 				"sleep_reason":              "failed-create",
 				"pending_create_claim":      "",
 				"pending_create_started_at": "",
+			},
+		},
+		{
+			// ga-mf1 regression: a state=creating bead with an expired
+			// pending_create lease (pending_create_started_at past
+			// staleCreatingStateTimeout) projects to RuntimeProjectionStaleCreating
+			// with ReconciledState=asleep. Previously healStatePatch wrote
+			// state=asleep (with continuation reset → sleep_reason=runtime-missing
+			// when prior session_key/started_config_hash were set) but left
+			// pending_create_claim=true and pending_create_started_at unchanged;
+			// the next tick's projectWakeCauses then re-emitted
+			// WakeCausePendingCreate and projectRuntimeProjection flipped the
+			// bead back to state=creating, ping-ponging forever. Clearing the
+			// stale lease in the same batch lets the bead settle in asleep.
+			name:  "stale-creating with stale pending_create_claim heals to asleep and clears claim",
+			alive: false,
+			session: func() beads.Bead {
+				// Past pendingCreateNeverStartedTimeout (10m) so the
+				// never-started lease has expired and the rollback path
+				// would clear the claim — heal mirrors that.
+				stale := now.Add(-(pendingCreateNeverStartedTimeout + time.Minute))
+				b := makeBead("b1", map[string]string{
+					"state":                     "creating",
+					"pending_create_claim":      "true",
+					"pending_create_started_at": stale.UTC().Format(time.RFC3339),
+					"session_key":               "stale-key",
+					"started_config_hash":       "stale-hash",
+				})
+				b.CreatedAt = stale
+				return b
+			}(),
+			want: map[string]string{
+				"state":                      "asleep",
+				"sleep_reason":               sleepReasonRuntimeMissing,
+				"session_key":                "",
+				"started_config_hash":        "",
+				"continuation_reset_pending": "true",
+				"pending_create_claim":       "",
+				"pending_create_started_at":  "",
 			},
 		},
 	}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -717,7 +717,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 			}
 			// Heal state using provider liveness, not agent membership.
-			healState(session, providerAlive, store, clk)
+			// rollbackAvailable mirrors the rollback gate at line ~639: when
+			// storeQueryPartial=true the formal rollback is deferred, so the
+			// heal path must also preserve pending_create_claim to avoid a
+			// half-applied rollback that races the next complete tick.
+			healStateWithRollback(session, providerAlive, store, clk, !storeQueryPartial)
 			switch {
 			case preserveNamed:
 				template := normalizedSessionTemplate(*session, cfg)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -481,6 +481,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			apply(&reconcileOpts)
 		}
 	}
+	if startupTimeout <= 0 && cfg != nil {
+		startupTimeout = cfg.Session.StartupTimeoutDuration()
+	}
 	maxAgeTr := reconcileOpts.maxSessionAgeTr
 	deps := buildDepsMap(cfg)
 	if cityName == "" {
@@ -721,7 +724,22 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// storeQueryPartial=true the formal rollback is deferred, so the
 			// heal path must also preserve pending_create_claim to avoid a
 			// half-applied rollback that races the next complete tick.
-			healStateWithRollback(session, providerAlive, store, clk, !storeQueryPartial)
+			stateBeforeHeal := strings.TrimSpace(session.Metadata["state"])
+			pendingCreateStartedAtBeforeHeal := strings.TrimSpace(session.Metadata["pending_create_started_at"])
+			lastWokeAtBeforeHeal := strings.TrimSpace(session.Metadata["last_woke_at"])
+			healBatch := healStateWithRollback(session, providerAlive, store, clk, startupTimeout, !storeQueryPartial)
+			traceHealClearedPendingCreateLease(
+				trace,
+				*session,
+				cfg,
+				"",
+				name,
+				stateBeforeHeal,
+				pendingCreateStartedAtBeforeHeal,
+				lastWokeAtBeforeHeal,
+				providerAlive,
+				healBatch,
+			)
 			switch {
 			case preserveNamed:
 				template := normalizedSessionTemplate(*session, cfg)
@@ -1133,7 +1151,21 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		// Heal advisory state metadata.
 		stateBeforeHeal := sessionpkg.State(strings.TrimSpace(session.Metadata["state"]))
-		healState(session, alive, store, clk)
+		pendingCreateStartedAtBeforeHeal := strings.TrimSpace(session.Metadata["pending_create_started_at"])
+		lastWokeAtBeforeHeal := strings.TrimSpace(session.Metadata["last_woke_at"])
+		healBatch := healStateWithRollback(session, alive, store, clk, startupTimeout, true)
+		traceHealClearedPendingCreateLease(
+			trace,
+			*session,
+			cfg,
+			tp.TemplateName,
+			name,
+			string(stateBeforeHeal),
+			pendingCreateStartedAtBeforeHeal,
+			lastWokeAtBeforeHeal,
+			alive,
+			healBatch,
+		)
 		if recoverPendingIdleSleep(session, store, running, clk) {
 			alive = false
 		}
@@ -2306,6 +2338,44 @@ func configDriftTracePayload(storedHash, currentHash string, driftedFields []str
 	payload["current_hash"] = currentHash
 	payload["drifted_fields"] = fields
 	return payload
+}
+
+func traceHealClearedPendingCreateLease(
+	trace *sessionReconcilerTraceCycle,
+	session beads.Bead,
+	cfg *config.City,
+	template string,
+	name string,
+	stateBeforeHeal string,
+	pendingCreateStartedAtBeforeHeal string,
+	lastWokeAtBeforeHeal string,
+	providerAlive bool,
+	batch map[string]string,
+) {
+	if trace == nil || strings.TrimSpace(stateBeforeHeal) != string(sessionpkg.StateCreating) {
+		return
+	}
+	if cleared, ok := batch["pending_create_claim"]; !ok || cleared != "" {
+		return
+	}
+	template = strings.TrimSpace(template)
+	if template == "" {
+		template = normalizedSessionTemplate(session, cfg)
+	}
+	if template == "" {
+		template = session.Metadata["template"]
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = session.Metadata["session_name"]
+	}
+	trace.recordDecision("reconciler.session.pending_create", template, name, "heal_cleared_stale_lease", string(TraceOutcomeApplied), traceRecordPayload{
+		"last_woke_at":              lastWokeAtBeforeHeal,
+		"pending_create_started_at": pendingCreateStartedAtBeforeHeal,
+		"provider_alive":            providerAlive,
+		"state_after":               session.Metadata["state"],
+		"state_before":              stateBeforeHeal,
+	}, nil, "")
 }
 
 func applyTemplateOverridesToConfig(agentCfg *runtime.Config, session beads.Bead, tp TemplateParams) {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -4563,6 +4563,69 @@ func TestPendingCreateLeaseExpiredForRollbackFallsBackToStaleWindowForInvalidLas
 	}
 }
 
+func TestTraceHealClearedPendingCreateLeaseRecordsDecision(t *testing.T) {
+	trace := &sessionReconcilerTraceCycle{
+		tracer: &SessionReconcilerTracer{
+			detail: map[string]TraceSource{"helper": TraceSourceManual},
+		},
+		dropReasons:       map[string]int{},
+		pendingDetail:     map[string][]SessionReconcilerTraceRecord{},
+		pendingDropped:    map[string]int{},
+		templatesTouched:  map[string]struct{}{},
+		detailedTemplates: map[string]struct{}{},
+		decisionCounts:    map[string]int{},
+		operationCounts:   map[string]int{},
+		mutationCounts:    map[string]int{},
+		reasonCounts:      map[string]int{},
+		outcomeCounts:     map[string]int{},
+	}
+	session := makeBead("b1", map[string]string{
+		"session_name": "helper",
+		"state":        "asleep",
+		"template":     "helper",
+	})
+
+	traceHealClearedPendingCreateLease(
+		trace,
+		session,
+		&config.City{Agents: []config.Agent{{Name: "helper"}}},
+		"",
+		"",
+		"creating",
+		"2026-05-19T08:58:30Z",
+		"2026-05-19T08:58:30Z",
+		false,
+		map[string]string{
+			"pending_create_claim":      "",
+			"pending_create_started_at": "",
+			"state":                     "asleep",
+		},
+	)
+
+	if len(trace.records) != 1 {
+		t.Fatalf("trace records = %d, want 1", len(trace.records))
+	}
+	rec := trace.records[0]
+	if rec.RecordType != TraceRecordDecision {
+		t.Fatalf("record type = %q, want decision", rec.RecordType)
+	}
+	if rec.SiteCode != TraceSiteReconcilerPendingCreate {
+		t.Fatalf("site = %q, want %q", rec.SiteCode, TraceSiteReconcilerPendingCreate)
+	}
+	if rec.OutcomeCode != TraceOutcomeApplied {
+		t.Fatalf("outcome = %q, want %q", rec.OutcomeCode, TraceOutcomeApplied)
+	}
+	if got := rec.Fields["raw_reason_code"]; got != "heal_cleared_stale_lease" {
+		t.Fatalf("raw_reason_code = %#v, want heal_cleared_stale_lease", got)
+	}
+	if got := rec.Fields["state_before"]; got != "creating" {
+		t.Fatalf("state_before = %#v, want creating", got)
+	}
+	if got := rec.Fields["state_after"]; got != "asleep" {
+		t.Fatalf("state_after = %#v, want asleep", got)
+	}
+}
+
 func TestReconcileSessionBeads_RollsBackPendingCreateWhenConflictingRuntimeAlreadyRunning(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary

When a session bead enters `state=creating` with `pending_create_claim=true` and `pending_create_started_at` past the never-started lease window, the lifecycle projection returns `(RuntimeProjectionStaleCreating, StateAsleep)` and `healState` writes `state=asleep+sleep_reason=runtime-missing` — but previously left `pending_create_claim=true` untouched.

On the next tick `projectWakeCauses` re-emits `WakeCausePendingCreate`, `projectRuntimeProjection`'s post-creating branch flips the projection back to `StateCreating`, and the bead ping-pongs forever between creating and asleep+runtime-missing until the slower `attemptRollbackPendingCreate` path eventually catches it (after `startupTimeout`).

This fix mirrors the failed-create rollback precedent at `session_reconcile.go:951-967`: a shared `clearPendingCreateLease` helper clears the stale claim in the same heal batch. The new stale-creating clear is gated on `pendingCreateLeaseExpiredForRollback(session, clk, 0)` (matching the orphan rollback path, which honors the longer 10-minute never-started lease) and on a new `rollbackAvailable` parameter (so `storeQueryPartial=true` ticks still defer to the next complete tick).

## Real-world evidence (ga-mf1, 2026-05-19)

Two session beads on a production city oscillated this way for ~10 minutes before the slower rollback path caught them:

```
07:57:56  state=creating, pending_create_claim=true, started_at=07:57:55
08:00:10  state=asleep, sleep_reason=runtime-missing, session_key=""  ← claim still =true
08:01:26  state=creating                                              ← claim re-emits wake cause
08:02:44  state=asleep
08:03:59  state=creating
08:05:18  state=asleep
08:06:30  state=creating
08:07:43  state=asleep
```

Same pattern observed on April 19 and April 25 (3rd recurrence of ga-mf1).

## Test plan

- [x] New test `TestHealStatePatchProjectsRuntimeLiveness/stale-creating_with_stale_pending_create_claim_heals_to_asleep_and_clears_claim` — fails pre-fix, passes post-fix
- [x] New regression test `TestHealState_StaleCreatingPendingClaimDoesNotOscillateBackToCreating` — simulates two consecutive heal ticks; second tick must not flip the bead back to creating
- [x] Full `go test ./cmd/gc/... ./internal/session/...` passes (~205s)
- [x] Pre-commit hook ran `go test ./...` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)