### PR TITLE
fix(reconciler): include typed session beads even when gc:session label is missing

### DIFF
--- a/cmd/gc/session_bead_snapshot_test.go
+++ b/cmd/gc/session_bead_snapshot_test.go
@@ -85,6 +85,87 @@ func BenchmarkLoadSessionBeadSnapshot_OpenOnlyBaseline(b *testing.B) {
 	}
 }
 
+// TestLoadSessionBeadSnapshot_IncludesTypedBeadsWithoutLabel guards against
+// the regression where canonical configured_named_session beads that have
+// lost their gc:session label (observed in production after crashes /
+// schema migrations) become invisible to the reconciler. Such beads still
+// carry issue_type=session and IsSessionBeadOrRepairable accepts them; the
+// snapshot loader must surface them so the reconciler can heal their
+// state=awake → state=asleep transition once the runtime is gone. Without
+// this, the bead lives forever holding its alias reservation and the pool
+// cannot materialize a fresh session for the same template ("alias …
+// already belongs to gm-XXXX").
+func TestLoadSessionBeadSnapshot_IncludesTypedBeadsWithoutLabel(t *testing.T) {
+	store := beads.NewMemStore()
+	// Bead with proper Type but NO labels — the production failure mode for
+	// canonical configured_named_session beads after a crash.
+	if _, err := store.Create(beads.Bead{
+		Title:  "beads/reviewer",
+		Type:   session.BeadType,
+		Labels: nil,
+		Metadata: map[string]string{
+			"session_name":              "beads--reviewer",
+			"template":                  "beads/reviewer",
+			"configured_named_session":  "true",
+			"configured_named_identity": "beads/reviewer",
+			"state":                     "awake",
+		},
+	}); err != nil {
+		t.Fatalf("seed labelless typed session bead: %v", err)
+	}
+	// Bead with the label set normally — control case to verify the loader
+	// still surfaces label-only beads.
+	if _, err := store.Create(beads.Bead{
+		Title:  "beads/builder",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "s-pool-builder",
+			"template":     "beads/builder",
+		},
+	}); err != nil {
+		t.Fatalf("seed labeled typed session bead: %v", err)
+	}
+
+	snap, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeadSnapshot: %v", err)
+	}
+	if got := len(snap.Open()); got != 2 {
+		t.Fatalf("Open()=%d, want 2 (labelless + labeled session beads)", got)
+	}
+	if got := snap.FindSessionNameByTemplate("beads/reviewer"); got != "beads--reviewer" {
+		t.Errorf("FindSessionNameByTemplate(beads/reviewer)=%q, want beads--reviewer — labelless typed bead must be visible", got)
+	}
+	if got := snap.FindSessionNameByTemplate("beads/builder"); got != "s-pool-builder" {
+		t.Errorf("FindSessionNameByTemplate(beads/builder)=%q, want s-pool-builder", got)
+	}
+}
+
+// TestLoadSessionBeadSnapshot_DeduplicatesAcrossQueries verifies a bead that
+// matches BOTH the Type and Label queries is included exactly once.
+func TestLoadSessionBeadSnapshot_DeduplicatesAcrossQueries(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "dual-match",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "s-dual",
+			"template":     "dual-match",
+		},
+	}); err != nil {
+		t.Fatalf("seed dual-match bead: %v", err)
+	}
+	snap, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeadSnapshot: %v", err)
+	}
+	if got := len(snap.Open()); got != 1 {
+		t.Fatalf("Open()=%d, want 1 — bead matching both queries must dedup", got)
+	}
+}
+
 func TestSessionBeadSnapshotIndexesCanonicalSingletonPoolManagedBead(t *testing.T) {
 	snapshot := newSessionBeadSnapshot([]beads.Bead{{
 		ID:     "refinery-session",


### PR DESCRIPTION
## Summary

`loadSessionBeadSnapshot` queried `beads.ListQuery{Label: sessionBeadLabel}` only. Canonical `configured_named_session` beads observed in production (`beads/reviewer`, `gascity/builder`, `MCDClient/builder`, …) had lost their `gc:session` label — likely during a past crash or schema migration — but still carried `issue_type=session`. The label-only query skipped them, so:

- They never entered the snapshot.
- The reconciler never ticked them.
- Their `state=awake` metadata never healed back to `asleep` after the runtime died.
- Their alias reservations lived forever.
- `createPoolSessionBead` failed every tick with `"alias … already belongs to gm-XXXX"` for every template that had a labelless canonical bead, and the pool spawned zero new workers.

## Real-world reproduction (2026-05-19)

After a hard system crash + reboot, on `gc-management`:

```
$ bd list --label gc:session
4 issues

$ bd list -t session
50 issues  (more available — limit hit)
```

The 46 missing beads were all canonical named-session beads with `labels: None` and `issue_type: session`. None had been touched by the reconciler since the previous boot. `poolDesired` stayed at 1 for 19 templates, but `createPoolSessionBead` failed on the held alias every tick.

## Fix

`loadSessionBeadSnapshot` now queries by **Type AND Label** — two indexed queries unioned and deduped, then filtered through the existing `IsSessionBeadOrRepairable`. `Type` is the primary signal (`issue_type=session` is the authoritative identity); `Label` stays as defense-in-depth so legacy repairable records (`Type="" + gc:session label`) still surface.

## Test plan

- [x] New `TestLoadSessionBeadSnapshot_IncludesTypedBeadsWithoutLabel` — labelless typed bead must surface (fails pre-fix, passes post-fix)
- [x] New `TestLoadSessionBeadSnapshot_DeduplicatesAcrossQueries` — bead matching both queries included exactly once
- [x] Updated `TestLoadSessionBeadSnapshotUsesActiveOnlyQuery` — now expects 2 queries (Type + Label); still guards `IncludeClosed=false` on both
- [x] Full `go test ./cmd/gc/... ./internal/session/...` passes (~205s + 6.7s)
- [x] Pre-commit hook ran `go test ./...` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)