### PR TITLE
fix(reconciler): two chronic claim-strip paths — idle-sleep gate + orphan-sweep jq shape (supersedes #1429)

### DIFF
--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -320,9 +320,23 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 
 		// Idle sleep: desired sessions idle too long should sleep.
-		// Attached, pinned, and mode=always named sessions are exempt.
+		// Attached, pinned, mode=always named, and sessions actively
+		// executing in_progress work are exempt. The in_progress
+		// exemption matters for pool workers in mid-task: a slow
+		// upstream API call between two of the agent's own bd writes
+		// can drive IdleSince past the threshold while the underlying
+		// CLI process is still alive. Without this exemption, the gate
+		// would flip ShouldWake back to false even though the
+		// assigned-work loop above tagged the session "must stay awake
+		// because it owns active work" — and downstream consumers (the
+		// session.stranded diagnostic and any witness-style recovery)
+		// would see a false positive. Queued ("open") work is
+		// intentionally not exempted: on-demand named sessions are
+		// allowed to idle-sleep with queued work and wake on the next
+		// on-demand trigger.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
-			!isAlwaysNamedSession(input.NamedSessions, bead) {
+			!isAlwaysNamedSession(input.NamedSessions, bead) &&
+			!sessionHasAssignedInProgressWork(input.WorkBeads, bead) {
 			agent, hasAgent := agentsByName[bead.Template]
 			var idleTimeout time.Duration
 			switch {
@@ -362,6 +376,35 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	}
 
 	return result
+}
+
+// sessionHasAssignedInProgressWork reports whether any in_progress work
+// bead in workBeads is assigned to the given session bead. Matches by
+// concrete bead ID, the session's current SessionName token, or its
+// configured NamedIdentity — the same set of acceptable assignee values
+// used by the assigned-work gate at compute_awake_set.go:230-254.
+//
+// Status is restricted to "in_progress" specifically (not "open"). An
+// open assigned bead is queued work the agent has not yet claimed; an
+// on-demand named session is allowed to idle-sleep with queued work
+// pending and wake on the next on-demand trigger. An in_progress
+// assigned bead means the agent is actively executing it, and the
+// session must not be classified as idle while that's true.
+func sessionHasAssignedInProgressWork(workBeads []AwakeWorkBead, bead AwakeSessionBead) bool {
+	for _, wb := range workBeads {
+		if wb.Status != "in_progress" {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if assignee == bead.ID || assignee == bead.SessionName ||
+			(bead.NamedIdentity != "" && assignee == bead.NamedIdentity) {
+			return true
+		}
+	}
+	return false
 }
 
 func findNamedSessionName(beads []AwakeSessionBead, identity string) string {

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1114,6 +1114,48 @@ func TestRegression_SessionWithWorkByAlias_DoesNotWake(t *testing.T) {
 // Asleep ephemeral with assigned work (e2e regression)
 // ---------------------------------------------------------------------------
 
+// TestRegression_IdleSleepDoesNotOverrideAssignedWork covers issue #1427:
+// a session that holds an open in_progress work bead must not be flipped
+// to ShouldWake=false / Reason="idle-sleep" by the idle-sleep gate, even
+// when its IdleSince is past the agent's SleepAfterIdle threshold.
+//
+// Production scenario: a pool worker is mid-task, blocked on a slow
+// upstream API response between two of its own bd writes. From the
+// outside, IdleSince walks past the threshold while the underlying CLI
+// process is still very much alive. The assigned-work gate marked it
+// "must stay awake because it owns active work"; the idle-sleep gate
+// then over-rode that and labeled the session asleep — handing
+// downstream recovery agents and #1425's session.stranded diagnostic a
+// false positive.
+func TestRegression_IdleSleepDoesNotOverrideAssignedWork(t *testing.T) {
+	idleTimeout := 10 * time.Minute
+	idleSince := now.Add(-(idleTimeout + time.Minute)) // 11 min ago: past threshold
+
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{
+			QualifiedName:  "hello-world/polecat",
+			SleepAfterIdle: idleTimeout,
+		}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:          "mc-sctve",
+			SessionName: "polecat-mc-sctve",
+			Template:    "hello-world/polecat",
+			State:       "active",
+			IdleSince:   idleSince,
+		}},
+		WorkBeads: []AwakeWorkBead{
+			{ID: "hw-8lb", Assignee: "mc-sctve", Status: "in_progress"},
+		},
+		ScaleCheckCounts: map[string]int{"hello-world/polecat": 0},
+		Now:              now,
+	})
+
+	assertAwake(t, result, "polecat-mc-sctve")
+	if got := result["polecat-mc-sctve"].Reason; got == "idle-sleep" {
+		t.Errorf("reason = %q, want non-idle-sleep — assigned-work must veto idle-sleep override", got)
+	}
+}
+
 func TestRegression_AsleepEphemeralWithAssignedWork_WakesViaAssignedWork(t *testing.T) {
 	// An asleep polecat that has in_progress work assigned to its bead ID
 	// must wake via the assigned-work path, even though scaleCheck alone

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -53,11 +53,17 @@ fi
 # that guard — an ephemeral assignee whose template-stripped form did not
 # match any agent name was incorrectly reset, racing against active polekitten
 # work and producing the false-orphan loop tracked in ga-nvx.
-SESSIONS_JSON=$(gc session list --json 2>/dev/null) || SESSIONS_JSON="[]"
+SESSIONS_JSON=$(gc session list --json 2>/dev/null) || SESSIONS_JSON='{"sessions":[]}'
+# Two bugs the chronic strip pattern (gastownhall/gascity#2363) revealed:
+# (1) The JSON shape is {"sessions":[...], "summary":..., "filters":..., "schema_version":...},
+#     so `.[]` iterated four top-level scalar keys instead of session objects.
+# (2) Field names are snake_case lower (.closed/.id/.session_name/.alias/.agent_name),
+#     not PascalCase. Combined, LIVE_SESSION_IDS was ALWAYS empty and every
+#     ephemeral assignee like gastown__polecat-gc-XXXXX got stripped on every tick.
 LIVE_SESSION_IDS=$(echo "$SESSIONS_JSON" | jq -r '
-    .[]
-    | select(.Closed == false)
-    | [.ID, .SessionName, .Alias, .AgentName]
+    .sessions[]?
+    | select(.closed == false)
+    | [.id, .session_name, .alias, .agent_name]
     | .[]
     | select(. != null and . != "")
 ' 2>/dev/null) || LIVE_SESSION_IDS=""


### PR DESCRIPTION
## Summary

Surgical fix in `cmd/gc/compute_awake_set.go` (≈50 lines): the idle-sleep gate now treats "session is actively executing assigned in_progress work" as an exemption alongside attached / pending / pinned / always-named.

**Supersedes #1429** — same change, rebased on current main. The original PR's branch has drifted 3+ weeks; this is a clean apply against the tip.

## Why this matters

Without the exemption, a pool worker mid-task gets idle-slept whenever a slow upstream API response sits between two of its own bd writes. Once slept, the bead's assignee dangles → the pool reconciler strips the claim → the pool either dual-claims the bead with another polecat or strands the work entirely. We observed this **chronically with latest main** during a single ~3-hour cashmaster session today (2026-05-19):

- `ca-5yrp81` — **triple-claim race** after furiosa was slept mid-investigation while holding 121→345 lines uncommitted. Witness escalated [HIGH].
- `ca-yboy7l` + `ca-srdkup` + `ca-cdbd32` — **three claims stripped in a single reconciler tick** at 15:21:45. Both alias-form (`cashmaster/gastown.furiosa`) and session-name-form (`gastown__polecat-gc-XXX`) assignees were stripped. Witness escalation explicitly disproved the earlier hypothesis that alias-form was immune.
- `ca-2500ok` — claim stripped while the rig was suspended; **suspend does not fully block the reconciler** for this code path.

The operator workarounds (suspend, pin, hand-walk each polecat through commit+push) cost ~30 minutes of mayor intervention across 6 beads that landed in the same window. Memory file `project_pool_reconciler_steals_in_progress.md` has been updated twice today against contradicting hypotheses; this fix removes the underlying cause.

## What changed

`cmd/gc/compute_awake_set.go:320-340`:
- Added `sessionHasAssignedInProgressWork(workBeads, bead)` helper using the same accept-set as the assigned-work gate (bead ID / SessionName / NamedIdentity)
- Added it to the idle-sleep exemption list
- Restricted to `status="in_progress"` (not `open`) so on-demand named sessions still idle-sleep with queued work and wake on the next trigger

`cmd/gc/compute_awake_set_test.go`:
- `TestRegression_IdleSleepDoesNotOverrideAssignedWork` covers the exact production scenario: IdleSince past `SleepAfterIdle` threshold + `in_progress` assigned work → must NOT flip to `Reason=idle-sleep`

## Related PRs (mostly OPEN, this fix unblocks them by addressing the root cause)

| # | title | status | relationship |
|---|---|---|---|
| #1429 | fix(reconciler): exempt sessions with in_progress work from idle-sleep override | OPEN (3+ weeks) | **superseded by this PR** |
| #1289 | feat(gastown): claim-first polecat + orphan-merge refinery + churn watcher | OPEN | complementary — pack-level fix for the downstream dual-claim cascade |
| #1425 | feat(reconciler): emit session.stranded when pool slot retains in-progress work after runtime exit | OPEN | fires false positives against the same gap this PR closes |
| #1736 | fix(sling): set bead assignee in addition to gc.routed_to metadata | OPEN | addresses the routing side of the same class of failure |
| #1523 | feat(gastown/polecat): default scale_check formula for parallel claims | OPEN | addresses spawn arbitration |

## Test plan
- [x] `go test ./cmd/gc/ -run 'TestRegression_IdleSleepDoesNotOverrideAssignedWork|TestRegression_SessionWithWork|TestRegression_AsleepEphemeral'` passes locally
- [ ] CI full suite (env-leak flakes in CityRuntime tests are known per ga-10qg; refinery validates in clean env)
- [ ] Operator validation: build local binary, run our chronic-trigger workload, verify zero claim strips against in_progress beads with assigned work

🤖 Generated with [Claude Code](https://claude.com/claude-code)