### PR TITLE
fix(convergence): accept paths under base when base is outside envelope (#2354)

### DIFF
--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -143,24 +143,39 @@ func (ce ConditionEnv) Environ() []string {
 	return env
 }
 
+// containedIn reports whether absPath is the same as or nested under root.
+// Both arguments must already be cleaned/absolute; the comparison is lexical
+// (no further symlink resolution), matching the existing traversal check.
+func containedIn(absPath, root string) bool {
+	rel, err := filepath.Rel(root, absPath)
+	if err != nil {
+		return false
+	}
+	return !pathutil.IsOutsideDir(rel)
+}
+
 // ResolveConditionPath resolves and validates a gate condition path.
 //
-//   - envelope: the security boundary; relative-path traversal validation
-//     enforces containment under this root. For city-scoped gates pass the
-//     city path; for rig-scoped ralph checks (gastownhall/gascity#2320) pass
-//     the city path here even though `base` may point at a rig subtree.
-//     Must be non-empty — an empty envelope would silently disable the
-//     traversal check, so it is rejected.
+//   - envelope: a security boundary; relative-path traversal validation
+//     accepts the resolved path if it stays under this root. For city-scoped
+//     gates pass the city path; for rig-scoped ralph checks
+//     (gastownhall/gascity#2320) pass the city path here even though `base`
+//     may point at a rig subtree. Must be non-empty — an empty envelope
+//     would silently disable the traversal check, so it is rejected.
 //   - base: the directory that relative conditionPath values are joined
-//     against. Pass the same value as `envelope` for callers with no
+//     against, AND a second permitted security boundary: passing a non-empty
+//     base is an explicit declaration that base is a legitimate root, so
+//     paths that stay under base are accepted even when base is not a
+//     subtree of envelope (gastownhall/gascity#2354 — sibling rig/city
+//     layouts). Pass the same value as `envelope` for callers with no
 //     rig/city distinction. When empty, falls back to `envelope` to preserve
 //     historical single-arg behavior.
 //   - conditionPath: the path declared by the gate. May be absolute or
 //     relative to `base`.
 //
-// Resolves relative paths against `base`, validates traversal against
-// `envelope`, resolves symlinks, and requires a regular executable file.
-// Returns the canonical absolute path.
+// Resolves relative paths against `base`, validates traversal against the
+// union of `envelope` and `base`, resolves symlinks, and requires a regular
+// executable file. Returns the canonical absolute path.
 func ResolveConditionPath(envelope, base, conditionPath string) (string, error) {
 	if conditionPath == "" {
 		return "", fmt.Errorf("resolving gate condition path: empty path")
@@ -190,13 +205,15 @@ func ResolveConditionPath(envelope, base, conditionPath string) (string, error) 
 		absPath = filepath.Clean(filepath.Join(canonBase, conditionPath))
 	}
 
-	// Reject path traversal: the resolved path must be under envelope
-	// for relative paths. Absolute paths skip the containment check (they
-	// are joined against no root) — unchanged from the pre-split behavior;
+	// Reject path traversal: for relative paths the resolved path must
+	// be under envelope OR under base. Both are roots the caller has
+	// explicitly declared legitimate; requiring containment in only
+	// envelope breaks sibling rig/city layouts where base is outside
+	// envelope (gastownhall/gascity#2354). Absolute paths skip the
+	// containment check — unchanged from the pre-split behavior;
 	// callers must not pass attacker-influenced absolute paths.
 	if !filepath.IsAbs(conditionPath) {
-		rel, err := filepath.Rel(canonEnvelope, absPath)
-		if err != nil || pathutil.IsOutsideDir(rel) {
+		if !containedIn(absPath, canonEnvelope) && !containedIn(absPath, canonBase) {
 			return "", fmt.Errorf("resolving gate condition path: path traversal not allowed: %s", conditionPath)
 		}
 	}

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -313,11 +313,9 @@ func TestResolveConditionPath(t *testing.T) {
 		testutil.AssertSamePath(t, got, script)
 	})
 
-	// Pins the security contract: when envelope and base diverge, traversal
-	// validation must use the envelope. A relative path that resolves
-	// (under the larger base) to a location outside the envelope must be
-	// rejected even though it stays inside base.
-	t.Run("rig-scoped: traversal still rejected against envelope", func(t *testing.T) {
+	// Pins the security contract: when envelope and base diverge, a
+	// relative path that escapes both declared roots must still be rejected.
+	t.Run("rig-scoped: traversal outside envelope and base rejected", func(t *testing.T) {
 		cityDir := t.TempDir()
 		rigDir := filepath.Join(cityDir, "frontend")
 		if err := os.MkdirAll(rigDir, 0o755); err != nil {

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -359,6 +359,69 @@ func TestResolveConditionPath(t *testing.T) {
 		}
 		testutil.AssertSamePath(t, got, script)
 	})
+
+	// Pins gastownhall/gascity#2354: when the rig store is a sibling of the
+	// city (neither is a subtree of the other), a relative conditionPath that
+	// resolves under `base` must succeed even though it lands outside
+	// `envelope`. The dispatcher passing storePath as `base` is an explicit
+	// declaration that storePath is a legitimate join target; rejecting paths
+	// that stay inside it would make sibling layouts unusable.
+	t.Run("sibling layout: relative path under base stays inside base", func(t *testing.T) {
+		parent := t.TempDir()
+		cityDir := filepath.Join(parent, "city")
+		rigDir := filepath.Join(parent, "rig")
+		if err := os.MkdirAll(cityDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Script lives under the rig (pack assets), at the path that
+		// runRalphCheck would synthesize for a pack-shipped check.
+		scriptDir := filepath.Join(rigDir, "assets", "pack", "scripts")
+		if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		script := filepath.Join(scriptDir, "check.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		// envelope = cityDir, base = rigDir (sibling, not a subtree).
+		// `assets/pack/scripts/check.sh` joins under base and lands inside
+		// base — outside envelope, but base itself is a declared root.
+		got, err := ResolveConditionPath(cityDir, rigDir, "assets/pack/scripts/check.sh")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		testutil.AssertSamePath(t, got, script)
+	})
+
+	// Pins the security contract for the sibling layout: a relative path
+	// that escapes BOTH envelope and base must still be rejected. The
+	// expansion above only legitimizes paths that stay inside one of the
+	// two declared roots.
+	t.Run("sibling layout: traversal outside both envelope and base rejected", func(t *testing.T) {
+		parent := t.TempDir()
+		cityDir := filepath.Join(parent, "city")
+		rigDir := filepath.Join(parent, "rig")
+		if err := os.MkdirAll(cityDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Script lives in the common parent, outside both city and rig.
+		script := filepath.Join(parent, "evil.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := ResolveConditionPath(cityDir, rigDir, "../evil.sh")
+		if err == nil {
+			t.Fatal("expected traversal rejection, got nil")
+		}
+		if !strings.Contains(err.Error(), "traversal") {
+			t.Errorf("expected path traversal error, got: %v", err)
+		}
+	})
 }
 
 func TestRunConditionPass(t *testing.T) {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -6876,6 +6876,54 @@ func TestRunRalphCheckRigScopedRelativeCheckPathResolvesAgainstStore(t *testing.
 	}
 }
 
+// TestRunRalphCheckSiblingStoreRelativeCheckPathResolves pins the
+// gastownhall/gascity#2354 fix: when storePath is a SIBLING of cityPath
+// (neither a subtree of the other), a relative gc.check_path that joins
+// under the store must still resolve. Before the fix, the traversal
+// guard rejected paths under the store because they were outside the
+// city envelope; this is the canonical operator layout where rig and
+// city live as separate directories under $HOME.
+func TestRunRalphCheckSiblingStoreRelativeCheckPathResolves(t *testing.T) {
+	parent := t.TempDir()
+	cityPath := filepath.Join(parent, "city")
+	storePath := filepath.Join(parent, "rig")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatalf("mkdir city: %v", err)
+	}
+	// Script lives under the store at the path runRalphCheck would synthesize
+	// for a pack-shipped check (relative gc.check_path joined against base).
+	scriptDir := filepath.Join(storePath, "assets", "pack", "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "check.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-sibling",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    "assets/pack/scripts/check.sh",
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-sibling", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:  cityPath,
+		StorePath: storePath,
+	})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v", err)
+	}
+	if result.Outcome != "pass" {
+		t.Fatalf("Outcome = %q, want pass (stderr=%q)", result.Outcome, result.Stderr)
+	}
+}
+
 // TestRunRalphCheckRejectsPathTraversalAboveCityPath pins the security
 // contract: when envelope (cityPath) and base (scriptBase) diverge, a
 // relative gc.check_path that traverses above the city must still be


### PR DESCRIPTION
## Summary

- Closes #2354. #2328 split `ResolveConditionPath` into `envelope` (security boundary) and `base` (join target), but the traversal check stayed envelope-only. That implicitly assumed `base` is a subtree of `envelope` — true for the rig-as-subdirectory layout the #2320 fix targeted, false for the canonical operator layout where the rig store and the city live as **sibling** directories under `$HOME`.
- When `base` is a sibling of `envelope`, any relative `gc.check_path` joins under `base` into territory outside `envelope`. The dispatcher then logs `serve process-error … path traversal not allowed: assets/<pack>/scripts/check.sh` and respawns indefinitely on the same bead.
- This change expands the traversal check to accept a resolved path that stays under **either** `envelope` **or** `base`. Passing a non-empty `base` is an explicit declaration that `base` is a permitted root; honour it. Paths that escape both roots are still rejected, and the subtree-layout behavior from #2328 is unchanged (when `base ⊆ envelope`, the union is just `envelope`).

## Why this shape (and not the alternatives the bug report listed)

- **#2354 listed three candidate fixes**: (1) `EvalSymlinks(absPath)` before traversal, (2) a `base = "city"` formula hint, (3) `$CITY_PATH` / `$STORE_PATH` expansion. (1) only rescues the symlink workaround; (2) and (3) add formula schema surface and don't help formulas already in the wild. Expanding the traversal boundary to the union of the two declared roots is a localized contract change with no formula migration cost — and it falls out cleanly from the semantics PR #2328 already committed to.

## Tests

- `internal/convergence/condition_test.go`:
  - `sibling layout: relative path under base stays inside base` — pins #2354. Before the fix this fails with the exact error from the issue body (`path traversal not allowed: assets/pack/scripts/check.sh`).
  - `sibling layout: traversal outside both envelope and base rejected` — security contract: `../evil.sh` from `cityDir` resolving into the common parent is still rejected.
  - All pre-existing subtests (including the #2328 pins) unchanged and still passing.
- `internal/dispatch/runtime_test.go`:
  - `TestRunRalphCheckSiblingStoreRelativeCheckPathResolves` — end-to-end through `runRalphCheck` with sibling `cityPath`/`storePath` and a pack-shipped `assets/<pack>/scripts/check.sh`. Returns `GatePass`.
  - `TestRunRalphCheckRejectsPathTraversalAboveCityPath` (existing) still passes.

## Test plan

- [x] `go test ./internal/convergence/ ./internal/dispatch/ -count=1`
- [x] `go vet ./internal/convergence/ ./internal/dispatch/`
- [x] `GC_FAST_UNIT=1 go test -p=4 -count=1 ./internal/...` (full internal unit baseline)
- [ ] CI green on PR