### PR TITLE
fix(cmd/gc): wake named-always sessions same-tick when restart_requested lands on a dead runtime (#2345)

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1122,7 +1122,18 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// builds a first-start command (--session-id <new_key>). Also set
 		// continuation_reset_pending so the next wake bumps the continuation
 		// epoch instead of silently reusing the prior continuation lineage.
-		// Then stop immediately; the next tick will re-create and re-wake.
+		//
+		// When the runtime is alive, stop it and yield this tick so the
+		// kill and the next wake run on separate reconciler passes; that
+		// keeps the start from racing the tmux alias release. When the
+		// runtime is already dead — for example, a named-always session
+		// whose tmux was killed by `gc handoff --target` before the bead's
+		// restart_requested flag was processed — there is no live runtime
+		// to stop. Apply the patch and fall through to the wake decision
+		// on this same tick instead of waiting for the next reconciler
+		// interval. The yield-a-tick rule existed to protect a live kill;
+		// extending it to the already-dead case is what caused the
+		// patrol_interval-sized post-handoff wake delay in #2345.
 		//
 		// Check both tmux metadata (dops) and bead metadata. The bead
 		// metadata flag survives tmux session death, so this works even
@@ -1168,8 +1179,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						_ = dops.clearRestartRequested(name)
 					}
 					fmt.Fprintf(stdout, "Stopped restart-requested session '%s'\n", name) //nolint:errcheck
+					// Yield this tick so the kill and the next wake run
+					// on separate reconciler passes; the new start should
+					// not race the tmux alias release.
+					continue
 				}
-				continue
+				// Runtime was already dead — no kill happened, no alias
+				// release to wait on. Fall through so the wake decision
+				// can pick up the freshly cleared metadata and emit a
+				// start_candidate on this same tick. See #2345.
 			}
 		}
 

--- a/cmd/gc/session_reconciler_restart_request_test.go
+++ b/cmd/gc/session_reconciler_restart_request_test.go
@@ -304,4 +304,73 @@ func TestReconcileSessionBeads_RestartRequestPreservesIntentWhenKillFails(t *tes
 	}
 }
 
+// TestReconcileSessionBeads_RestartRequestNamedAlwaysWakesSameTick guards the
+// fix for gastownhall/gascity#2345. A `mode = "always"` named session whose
+// tmux was killed out of band (for example, by `gc handoff --target`) before
+// the bead's restart_requested flag was processed must wake on the SAME
+// reconciler tick, not on the next patrol interval. Before this fix the
+// restart_requested branch unconditionally continued past the wake decision,
+// imposing a patrol_interval-sized post-handoff wake delay (and, combined
+// with watchdog-driven `gc session reset` calls during the gap, sometimes
+// multiple patrol cycles).
+func TestReconcileSessionBeads_RestartRequestNamedAlwaysWakesSameTick(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "worker",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"restart_requested":          "true",
+		"session_key":                "original-key",
+		"started_config_hash":        "hash-before-restart",
+	})
+
+	// Runtime is NOT started — the tmux session was killed externally
+	// (e.g., gc handoff --target) before this reconciler tick. The bead's
+	// restart_requested flag was set by `gc session reset` afterwards.
+	if env.sp.IsRunning(sessionName) {
+		t.Fatal("test fixture wrong: session should not be running")
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	// Same-tick wake: the wake decision must have fired and started the
+	// runtime on this same reconcile pass. Before the #2345 fix the
+	// restart_requested branch continued past the wake loop, so the fake
+	// provider would NOT be running here.
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatalf("session %q did not wake on the same reconciler tick; restart_requested branch skipped the wake decision", sessionName)
+	}
+
+	got, _ := env.store.Get(session.ID)
+	// The RestartRequestPatch must still run: session_key rotates,
+	// restart_requested clears. PreWakePatch (applied by the same-tick wake)
+	// subsequently writes last_woke_at and clears continuation_reset_pending,
+	// so we assert on the post-wake observable state.
+	if got.Metadata["session_key"] == "" || got.Metadata["session_key"] == "original-key" {
+		t.Fatalf("session_key = %q, want rotated key", got.Metadata["session_key"])
+	}
+	if got.Metadata["restart_requested"] != "" {
+		t.Fatalf("restart_requested = %q, want cleared after patch applied", got.Metadata["restart_requested"])
+	}
+	if got.Metadata["last_woke_at"] == "" {
+		t.Fatal("last_woke_at = empty, want timestamp from same-tick wake")
+	}
+}
+
 func restartRequestTestIntPtr(n int) *int { return &n }


### PR DESCRIPTION
## Summary
Fixes #2345 — named-always sessions take ~5 min to wake after `gc handoff --target` / `gc session kill`. This is the named-session leg of #1654 that PR #2132 left unaddressed (it only fixed the pool path).

## Root cause
`session_reconciler.go`'s `restart_requested` branch unconditionally `continue`d past the wake decision after applying `RestartRequestPatch`. When the runtime was already dead — tmux killed by `gc handoff --target` before `restart_requested` was processed — the bead yielded a full `patrol_interval` before wake could fire. With `patrol_interval=2m` plus watchdog-driven `gc session reset` calls during the gap, the post-handoff wake delay stretched to ~5 min.

## Fix
Make the post-`RestartRequestPatch` yield conditional on `alive`. When `alive=false`, fall through to the same-tick wake decision — the fresh metadata flows into `ComputeAwakeSet` + `start_candidate` naturally. The live-kill path keeps its yield to avoid the tmux alias-release race.

## Changes
- `cmd/gc/session_reconciler.go` (+20/-2) — conditional yield in the `restart_requested` branch
- `cmd/gc/session_reconciler_restart_request_test.go` (+69) — regression test `TestReconcileSessionBeads_RestartRequestNamedAlwaysWakesSameTick`

## Test
- `go build ./cmd/gc/` — pass
- `make test` — pass
- `make check` — pass
- The new regression test fails on `main` (proves the regression) and passes with the fix.

## Adjacent
Likely also resolves #2094 (named on-demand) and #2251 (pool scale-up) — same `restart_requested` gate.
