### PR TITLE
fix(cmd/gc): propagate agent session_live through worker handle hints

### DIFF
--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -211,6 +211,10 @@ func newWorkerSessionHandleForResolvedRuntimeWithConfig(
 	if err != nil {
 		return nil, err
 	}
+	var agentSessionLive []string
+	if agentCfg := findAgentByTemplate(cfg, template); agentCfg != nil {
+		agentSessionLive = append([]string(nil), agentCfg.SessionLive...)
+	}
 	sessionCfg, err := resolvedWorkerSessionConfigWithConfig(
 		command,
 		provider,
@@ -223,6 +227,7 @@ func newWorkerSessionHandleForResolvedRuntimeWithConfig(
 		resolved,
 		metadata,
 		mcpServers,
+		agentSessionLive,
 	)
 	if err != nil {
 		return nil, err
@@ -242,6 +247,7 @@ func resolvedWorkerSessionConfigWithConfig(
 	resolved *config.ResolvedProvider,
 	metadata map[string]string,
 	mcpServers []runtime.MCPServerConfig,
+	agentSessionLive []string,
 ) (worker.ResolvedSessionConfig, error) {
 	if resolved == nil {
 		return worker.ResolvedSessionConfig{}, fmt.Errorf("resolved provider is required")
@@ -293,6 +299,15 @@ func resolvedWorkerSessionConfigWithConfig(
 			Hints: func() runtime.Config {
 				hints := workerSessionCreateHints(resolved)
 				hints.MCPServers = mcpServers
+				// Agent-level startup fields (session_live, etc.) live on
+				// config.Agent and are not carried by ResolvedProvider. Without
+				// threading them in, doStartSession's runSessionLive short-
+				// circuits on its empty-SessionLive guard and tmux theming /
+				// keybindings never apply to sessions created through this
+				// path.
+				if len(agentSessionLive) > 0 {
+					hints.SessionLive = append([]string(nil), agentSessionLive...)
+				}
 				return hints
 			}(),
 		},
@@ -485,20 +500,30 @@ func resolvedWorkerRuntimeWithConfigAndMetadata(cityPath string, cfg *config.Cit
 	if err != nil {
 		return nil, err
 	}
+	hints := runtime.Config{
+		WorkDir:                workDir,
+		ReadyPromptPrefix:      resolved.ReadyPromptPrefix,
+		ReadyDelayMs:           resolved.ReadyDelayMs,
+		ProcessNames:           resolved.ProcessNames,
+		EmitsPermissionWarning: resolved.EmitsPermissionWarning,
+		AcceptStartupDialogs:   resolved.AcceptStartupDialogs,
+		MCPServers:             mcpServers,
+	}
+	// Agent-level startup fields (session_live, etc.) live on config.Agent,
+	// not on ResolvedProvider. The reconciler's templateParamsToConfig path
+	// carries them via StartupHints; the worker-handle resume path must do
+	// the same. Without this, doStartSession's runSessionLive short-circuits
+	// on its `len(cfg.SessionLive) == 0` guard and tmux theming/keybindings
+	// never apply when a session is brought up via `gc session attach`.
+	if agentCfg := findAgentByTemplate(cfg, info.Template); agentCfg != nil {
+		hints.SessionLive = append([]string(nil), agentCfg.SessionLive...)
+	}
 	return &worker.ResolvedRuntime{
 		Command:    command,
 		WorkDir:    workDir,
 		Provider:   firstNonEmptyGCString(info.Provider, resolved.Name),
 		SessionEnv: resolved.Env,
-		Hints: runtime.Config{
-			WorkDir:                workDir,
-			ReadyPromptPrefix:      resolved.ReadyPromptPrefix,
-			ReadyDelayMs:           resolved.ReadyDelayMs,
-			ProcessNames:           resolved.ProcessNames,
-			EmitsPermissionWarning: resolved.EmitsPermissionWarning,
-			AcceptStartupDialogs:   resolved.AcceptStartupDialogs,
-			MCPServers:             mcpServers,
-		},
+		Hints:      hints,
 		Resume: session.ProviderResume{
 			ResumeFlag:    firstNonEmptyGCString(resolved.ResumeFlag, info.ResumeFlag),
 			ResumeStyle:   firstNonEmptyGCString(resolved.ResumeStyle, info.ResumeStyle),

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -705,6 +705,87 @@ func TestResolvedWorkerRuntimeWithConfigFallsBackToStoredCommandWhenTemplateOver
 	}
 }
 
+// TestResolvedWorkerSessionConfigPropagatesAgentSessionLive ensures the
+// create-side helper threads agent-level session_live commands through to
+// the resolved session config. Without it, sessions created via the
+// session-create path produce runtime.Config{} hints with no SessionLive
+// and runSessionLive becomes a silent no-op at startup.
+func TestResolvedWorkerSessionConfigPropagatesAgentSessionLive(t *testing.T) {
+	cfg, err := resolvedWorkerSessionConfigWithConfig(
+		"/bin/echo",
+		"stub",
+		"/tmp/work",
+		"worker",
+		"",
+		"worker",
+		"Worker",
+		"",
+		&config.ResolvedProvider{Name: "stub", Command: "/bin/echo"},
+		map[string]string{"session_origin": "test"},
+		nil,
+		[]string{"tmux set -t {{.Session}} mouse on"},
+	)
+	if err != nil {
+		t.Fatalf("resolvedWorkerSessionConfigWithConfig: %v", err)
+	}
+	if got, want := len(cfg.Runtime.Hints.SessionLive), 1; got != want {
+		t.Fatalf("len(Hints.SessionLive) = %d, want %d (got %#v)", got, want, cfg.Runtime.Hints.SessionLive)
+	}
+	if got, want := cfg.Runtime.Hints.SessionLive[0], "tmux set -t {{.Session}} mouse on"; got != want {
+		t.Errorf("Hints.SessionLive[0] = %q, want %q", got, want)
+	}
+}
+
+// TestResolvedWorkerRuntimeWithConfigPopulatesSessionLive is a regression
+// test for the bug where `gc session attach` paths produce a runtime.Config
+// with empty SessionLive, causing runSessionLive at adapter.go to short-
+// circuit on its `len(cfg.SessionLive) == 0` guard and skip tmux theming /
+// keybindings hooks. The reconciler's templateParamsToConfig path
+// correctly carries SessionLive from the agent config; the worker handle's
+// resolved-runtime path must do the same so both create paths produce
+// identical effective Hints.
+func TestResolvedWorkerRuntimeWithConfigPopulatesSessionLive(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:     "worker",
+			Provider: "stub",
+			SessionLive: []string{
+				"tmux set -t {{.Session}} mouse on",
+				"tmux set -t {{.Session}} status-style bg=green",
+			},
+		}},
+		Providers: map[string]config.ProviderSpec{
+			"stub": {
+				Command:   "/bin/echo",
+				PathCheck: "true",
+			},
+		},
+	}
+
+	resolved, err := resolvedWorkerRuntimeWithConfigAndMetadata(cityDir, cfg, session.Info{
+		Template: "worker",
+		Command:  "/bin/echo",
+		WorkDir:  cityDir,
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("resolvedWorkerRuntimeWithConfigAndMetadata: %v", err)
+	}
+	if resolved == nil {
+		t.Fatal("resolvedWorkerRuntimeWithConfigAndMetadata() = nil")
+	}
+	if got, want := len(resolved.Hints.SessionLive), 2; got != want {
+		t.Fatalf("len(Hints.SessionLive) = %d, want %d (got %#v)", got, want, resolved.Hints.SessionLive)
+	}
+	if got, want := resolved.Hints.SessionLive[0], "tmux set -t {{.Session}} mouse on"; got != want {
+		t.Errorf("Hints.SessionLive[0] = %q, want %q", got, want)
+	}
+	if got, want := resolved.Hints.SessionLive[1], "tmux set -t {{.Session}} status-style bg=green"; got != want {
+		t.Errorf("Hints.SessionLive[1] = %q, want %q", got, want)
+	}
+}
+
 func TestWorkerHandleForSessionWithConfigUsesResolvedProviderOnResume(t *testing.T) {
 	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	cityDir := t.TempDir()
@@ -1045,6 +1126,7 @@ func TestResolvedWorkerSessionConfigWithConfigFallsBackToResolvedProviderNameFor
 		},
 		map[string]string{"session_origin": "test"},
 		nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("resolvedWorkerSessionConfigWithConfig: %v", err)
@@ -1068,6 +1150,7 @@ func TestResolvedWorkerSessionConfigWithConfigFallsBackToProviderArgForCommand(t
 		"Worker",
 		"",
 		&config.ResolvedProvider{},
+		nil,
 		nil,
 		nil,
 	)
@@ -1105,6 +1188,7 @@ func TestResolvedWorkerSessionConfigWithConfigPersistsStoredMCPMetadata(t *testi
 			Command:   "/bin/mcp",
 			Args:      []string{"--stdio"},
 		}},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("resolvedWorkerSessionConfigWithConfig: %v", err)
@@ -1134,6 +1218,7 @@ func TestResolvedWorkerSessionConfigWithConfigSkipsStoredMCPMetadataForTmuxTrans
 			"session_origin": "test",
 			"agent_name":     "myrig/worker-adhoc-123",
 		},
+		nil,
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
## What

When a tmux session is brought up via the worker-handle path (`gc session attach` and other worker-driven creates), the `runtime.Config` passed to `provider.Start` carries only the small `ResolvedProvider` subset of fields and omits `SessionLive`. The reconciler's lifecycle-parallel path uses `templateParamsToConfig` (`cmd/gc/template_resolve.go:615`), which threads agent-level `SessionLive` through `StartupHints`; the worker-handle path did not. `doStartSession`'s `runSessionLive` then short-circuits on its `len(cfg.SessionLive) == 0` guard (`internal/runtime/tmux/adapter.go:826`), so tmux theming, keybindings, and mouse hooks never apply to sessions created through this path.

The bug surfaces visibly: a configured-named session (e.g. mayor) brought up via `gc session attach` after a supervisor restart comes up with `mouse off`, default slate theme, and no prefix bindings, while sibling reconciler-created sessions come up correctly themed. The bead metadata signature is distinctive — `state_reason=creation_complete` with empty `started_config_hash`/`live_hash`/`started_live_hash` and a stale `creation_complete_at`, indicating `CommitStartedPatch` never ran for the start.

## Architectural principle

Cites **`engdocs/design/worker-conformance.md`** Section 1.2 Responsibility Matrix: agent-level session hints (`SessionLive`, `SessionSetup`, `PreStart`, etc.) are worker-behavioral contracts that must be preserved through the worker boundary, not regenerated from the smaller `ResolvedProvider` surface.

Also aligns with **`engdocs/contributors/worker-api-hardening-plan.md` Task 3** (Worker resolution glue, lines 79-158): `cmd/gc` should use Factory helpers instead of reconstructing worker session specs locally. This bug is exactly the anti-pattern Task 3 targets — `workerSessionCreateHints` and `resolvedWorkerRuntimeWithConfigAndMetadata` were reconstructing hints in cmd/gc without consulting the canonical agent config.

Frames as a concrete instance of the surface-conformance meta-pattern in **#1623 (Shift D: pack/CLI surface conformance to canonical SDK primitives)** — surface code (worker_handle.go) was re-deriving what the SDK already canonicalizes (`config.Agent.SessionLive`). The fix is local; it does not attempt the broader Shift-D agent-identity-resolver work.

## Fix

In both worker-handle resolution paths (`resolvedWorkerRuntimeWithConfigAndMetadata` for resume/attach, `resolvedWorkerSessionConfigWithConfig` for create), look up the agent config via `findAgentByTemplate(cfg, template)` and copy `agentCfg.SessionLive` into the `runtime.Config` hints. `runSessionLive` is documented idempotent, so re-firing on attach is harmless.

The new `agentSessionLive []string` parameter on `resolvedWorkerSessionConfigWithConfig` keeps existing callers explicit about whether they have agent-level hints to thread — a deliberate choice over implicit lookup so the function signature documents the dependency.

This is the minimal fix for the visible bug (SessionLive only). A broader follow-up could also thread `SessionSetup`, `SessionSetupScript`, `PreStart`, `Nudge`, `OverlayDir`, `CopyFiles` — but those have no observed failure today, so they're held back per smallest-PR-lands-faster.

## Test

Two new regression tests at the helper boundaries:

- `TestResolvedWorkerRuntimeWithConfigPopulatesSessionLive` covers the resume/attach path.
- `TestResolvedWorkerSessionConfigPropagatesAgentSessionLive` covers the create path.

Both fail without the fix (asserts `len(Hints.SessionLive) == N` finds `0`) and pass with it. Existing tests in the file (~ten `TestResolvedWorkerRuntime*` cases) continue to pass after the parameter addition.

## Watch list

- [ ] Maintainer "Approve and run workflows" click — fork-author PRs hit GitHub's first-time-contributor gate; required CI workflows do not run until then.
- [ ] CI green after maintainer approval
- [ ] Review feedback addressed
- [ ] Merge upstream → drop local divergence on next `carry/operational` rebase