### PR TITLE
Pin start drift restart budgets per mode

### DIFF
--- a/release-gates/nfr2-per-mode-restart-budgets-gate.md
+++ b/release-gates/nfr2-per-mode-restart-budgets-gate.md
@@ -1,0 +1,32 @@
+# Release Gate: NFR-2 per-mode restart budgets
+
+Bead: ga-rv06grr
+Source bead: ga-06grr
+Branch: builder/ga-06grr-1
+Commit under review: 3f96fa0a5
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-rv06grr` notes contain `VERDICT: pass`; findings: none. |
+| 2 | Acceptance criteria met | PASS | Diff is limited to `test/integration/start_drift_test.go`; `driftRestartReadyBudget` and `assertRestartReadyDuration` have no hits; direct/systemd budgets are `10s` and `15s`; both call sites use `assertRestartDuration(t, out, budget, mode)`. |
+| 3 | Tests pass | PASS | `go test -tags integration -run TestStartDrift ./test/integration/...` PASS; `go vet ./...` PASS; `make test-fast-parallel` PASS. |
+| 4 | No high-severity review findings open | PASS | Review notes list `Findings: none`; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was clean before writing this gate artifact; the gate artifact is committed as the final branch change. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` completed with no conflicts. |
+
+## Acceptance Evidence
+
+- Changed files: `test/integration/start_drift_test.go` only.
+- Diff stat: 1 file changed, 12 insertions, 11 deletions.
+- `cmd/gc/cmd_start_drift.go` remains unchanged relative to `origin/main`.
+- `driftReadyTimeout` remains unchanged in production code.
+- Old NFR-2 log string forms `NFR-2 violated:` and `NFR-2 OK:` have no hits under `docs`, `engdocs`, or `test`.
+
+## Test Evidence
+
+- `go test -tags integration -run TestStartDrift ./test/integration/...`: PASS.
+- `go vet ./...`: PASS.
+- `make test-fast-parallel`: PASS.
+- `git diff --check origin/main...HEAD`: PASS.

--- a/test/integration/start_drift_test.go
+++ b/test/integration/start_drift_test.go
@@ -35,10 +35,11 @@ import (
 )
 
 const (
-	driftHappyOldCommit     = "deadbeefcafe1111"
-	driftHappyNewCommit     = "facefeed02222222"
-	driftReadyTimeout       = 15 * time.Second
-	driftRestartReadyBudget = 15 * time.Second
+	driftHappyOldCommit       = "deadbeefcafe1111"
+	driftHappyNewCommit       = "facefeed02222222"
+	driftReadyTimeout         = 15 * time.Second
+	driftDirectRestartBudget  = 10 * time.Second
+	driftSystemdRestartBudget = 15 * time.Second
 )
 
 // TestStartDrift_DirectLaunch_RestartsToNewBuildID exercises the direct
@@ -99,7 +100,7 @@ func TestStartDrift_DirectLaunch_RestartsToNewBuildID(t *testing.T) {
 	if gotID != driftHappyNewCommit {
 		t.Fatalf("post-restart /health build_id = %q, want %q", gotID, driftHappyNewCommit)
 	}
-	assertRestartReadyDuration(t, out)
+	assertRestartDuration(t, out, driftDirectRestartBudget, "direct")
 }
 
 // TestStartDrift_SystemdManaged_RestartsToNewBuildID is the systemd
@@ -146,7 +147,7 @@ func TestStartDrift_SystemdManaged_RestartsToNewBuildID(t *testing.T) {
 	if gotID != driftHappyNewCommit {
 		t.Fatalf("post-restart /health build_id = %q, want %q", gotID, driftHappyNewCommit)
 	}
-	assertRestartReadyDuration(t, out)
+	assertRestartDuration(t, out, driftSystemdRestartBudget, "systemd-managed")
 }
 
 // TestStartDrift_NoAutoRestart_ExitsNonZero pins the --no-auto-restart
@@ -854,18 +855,18 @@ func firstLine(s string) string {
 	return s
 }
 
-func assertRestartReadyDuration(t *testing.T, out string) {
+func assertRestartDuration(t *testing.T, out string, budget time.Duration, mode string) {
 	t.Helper()
 	d, ok := parseReadyDuration(out)
 	if !ok {
 		t.Errorf("could not parse ready-duration from output:\n%s", out)
 		return
 	}
-	if d > driftRestartReadyBudget {
-		t.Errorf("NFR-2 violated: restart took %s (>%s)", d, driftRestartReadyBudget)
-		return
+	if d > budget {
+		t.Errorf("NFR-2 violated (%s): restart took %s (>%s)", mode, d, budget)
+	} else {
+		t.Logf("NFR-2 OK (%s): restart took %s (budget %s)", mode, d, budget)
 	}
-	t.Logf("NFR-2 OK: restart took %s (budget %s)", d, driftRestartReadyBudget)
 }
 
 // parseReadyDuration extracts the wall-clock from a `Restarting


### PR DESCRIPTION
## What this changes

`gc start --drift=restart` integration coverage now has separate NFR-2 restart budgets for direct process restarts and systemd-managed restarts. The direct path stays at a 10 second budget, while the systemd-managed path gets a 15 second budget to reflect the extra handoff through `systemctl --user`.

The assertion helper now takes the mode name explicitly, so failures and logs tell an operator whether the direct or systemd-managed path exceeded its budget.

## Review notes

- Scope is limited to `test/integration/start_drift_test.go`; `cmd/gc/cmd_start_drift.go` is unchanged.
- `driftReadyTimeout` is preserved; only the restart-ready budget assertion was split by mode.
- The old generic NFR-2 log strings were replaced with mode-specific strings.

## Test plan

- [x] `go test -tags integration -run TestStartDrift ./test/integration/...`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/nfr2-per-mode-restart-budgets-gate.md`](release-gates/nfr2-per-mode-restart-budgets-gate.md)