### PR TITLE
Warn when remote pack bindings have stale local dirs

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -153,6 +153,7 @@ func doDoctor(fix, verbose, jsonOut bool, stdout, stderr io.Writer) int {
 		}
 		d.Register(doctor.NewConfigValidCheck(cfg))
 		d.Register(doctor.NewConfigRefsCheck(cfg, cityPath))
+		d.Register(doctor.NewStaleLocalPackDirCheck(cfg.Packs, cityPath))
 		d.Register(doctor.NewPreStartScriptsCheck(cfg))
 		d.Register(doctor.NewBuiltinPackFamilyCheck(cfg, cityPath))
 		d.Register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -153,7 +153,7 @@ func doDoctor(fix, verbose, jsonOut bool, stdout, stderr io.Writer) int {
 		}
 		d.Register(doctor.NewConfigValidCheck(cfg))
 		d.Register(doctor.NewConfigRefsCheck(cfg, cityPath))
-		d.Register(doctor.NewStaleLocalPackDirCheck(cfg.Packs, cityPath))
+		d.Register(doctor.NewStaleLocalPackDirCheck(cfg.Packs, cfg.Imports, cfg.DefaultRigImports, cityPath, cfg.Rigs...))
 		d.Register(doctor.NewPreStartScriptsCheck(cfg))
 		d.Register(doctor.NewBuiltinPackFamilyCheck(cfg, cityPath))
 		d.Register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -455,6 +455,40 @@ dolt_port = "3308"
 	}
 }
 
+func TestDoDoctorRegistersStaleLocalPackDirCheck(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "packs", "actual"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[packs.actual]
+source = "https://github.com/gastownhall/gc-actual-packs"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_DOLT", "skip")
+	cleanupManagedDoltTestCity(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, true, false, &stdout, &stderr)
+	out := stdout.String() + stderr.String()
+	if !strings.Contains(out, "stale-local-pack-dirs") {
+		t.Fatalf("doctor output missing stale-local-pack-dirs check:\n%s", out)
+	}
+	if !strings.Contains(out, "delete `packs/actual/` (it's stale); edits go via PR on gc-actual-packs") {
+		t.Fatalf("doctor output missing stale pack action:\n%s", out)
+	}
+}
+
 func TestDoDoctorReportsLegacyBDSplitStore(t *testing.T) {
 	cityDir := t.TempDir()
 	writeMinimalCityToml(t, cityDir)

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -489,6 +489,177 @@ source = "https://github.com/gastownhall/gc-actual-packs"
 	}
 }
 
+func TestDoDoctorRegistersStaleLocalPackDirCheckForRemoteImport(t *testing.T) {
+	cityDir := t.TempDir()
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	source := "https://github.com/gastownhall/gc-actual-packs"
+	commit := writeDoctorRemotePackFixture(t, homeDir, source)
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "packs", "actual"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[imports.actual]
+source = "https://github.com/gastownhall/gc-actual-packs"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorPackLock(t, cityDir, source, commit)
+
+	out := runDoctorForStaleLocalPackDirTest(t, cityDir)
+	if !strings.Contains(out, "stale-local-pack-dirs") {
+		t.Fatalf("doctor output missing stale-local-pack-dirs check:\n%s", out)
+	}
+	if !strings.Contains(out, "packs/actual exists while [imports.actual] points at https://github.com/gastownhall/gc-actual-packs") {
+		t.Fatalf("doctor output missing remote import stale pack detail:\n%s", out)
+	}
+}
+
+func TestDoDoctorRegistersStaleLocalPackDirCheckForRigRemoteImport(t *testing.T) {
+	cityDir := t.TempDir()
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	source := "https://github.com/gastownhall/gc-actual-packs"
+	commit := writeDoctorRemotePackFixture(t, homeDir, source)
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "rig"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "packs", "actual"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "demo-rig"
+path = "rig"
+
+[rigs.imports.actual]
+source = "https://github.com/gastownhall/gc-actual-packs"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorPackLock(t, cityDir, source, commit)
+
+	out := runDoctorForStaleLocalPackDirTest(t, cityDir)
+	if !strings.Contains(out, "stale-local-pack-dirs") {
+		t.Fatalf("doctor output missing stale-local-pack-dirs check:\n%s", out)
+	}
+	if !strings.Contains(out, "packs/actual exists while [rigs.demo-rig.imports.actual] points at https://github.com/gastownhall/gc-actual-packs") {
+		t.Fatalf("doctor output missing rig remote import stale pack detail:\n%s", out)
+	}
+}
+
+func TestDoDoctorRegistersStaleLocalPackDirCheckForDefaultRigRemoteImport(t *testing.T) {
+	cityDir := t.TempDir()
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	source := "https://github.com/gastownhall/gc-actual-packs"
+	commit := writeDoctorRemotePackFixture(t, homeDir, source)
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "packs", "actual"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte(`[pack]
+name = "demo"
+schema = 2
+
+[defaults.rig.imports.actual]
+source = "https://github.com/gastownhall/gc-actual-packs"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorPackLock(t, cityDir, source, commit)
+
+	out := runDoctorForStaleLocalPackDirTest(t, cityDir)
+	if !strings.Contains(out, "stale-local-pack-dirs") {
+		t.Fatalf("doctor output missing stale-local-pack-dirs check:\n%s", out)
+	}
+	if !strings.Contains(out, "packs/actual exists while [defaults.rig.imports.actual] points at https://github.com/gastownhall/gc-actual-packs") {
+		t.Fatalf("doctor output missing default rig remote import stale pack detail:\n%s", out)
+	}
+}
+
+func writeDoctorRemotePackFixture(t *testing.T, homeDir, source string) string {
+	t.Helper()
+
+	repoDir := filepath.Join(t.TempDir(), "remote-pack")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "pack.toml"), []byte(`[pack]
+name = "actual"
+schema = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGitImport(t, repoDir, "init")
+	mustGitImport(t, repoDir, "add", ".")
+	mustGitImport(t, repoDir, "commit", "-m", "initial")
+	commit := gitOutputImport(t, repoDir, "rev-parse", "HEAD")
+	cacheDir := filepath.Join(homeDir, ".gc", "cache", "repos", config.RepoCacheKey(source, commit))
+	if err := os.MkdirAll(filepath.Dir(cacheDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(repoDir, cacheDir); err != nil {
+		t.Fatal(err)
+	}
+	return commit
+}
+
+func writeDoctorPackLock(t *testing.T, cityDir, source, commit string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(cityDir, "packs.lock"), []byte(`schema = 1
+
+[packs."`+source+`"]
+version = "1.0.0"
+commit = "`+commit+`"
+fetched = "2026-05-20T00:00:00Z"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runDoctorForStaleLocalPackDirTest(t *testing.T, cityDir string) string {
+	t.Helper()
+
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_DOLT", "skip")
+	cleanupManagedDoltTestCity(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, true, false, &stdout, &stderr)
+	return stdout.String() + stderr.String()
+}
+
 func TestDoDoctorReportsLegacyBDSplitStore(t *testing.T) {
 	cityDir := t.TempDir()
 	writeMinimalCityToml(t, cityDir)

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -204,11 +204,19 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
-		defaultRigIncludes, err := defaultRigIncludesFromPackDefaults(pc.Defaults, md)
+		defaultRigImports, err := defaultRigImportsFromPackDefaults(pc.Defaults, md)
 		if err != nil {
 			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
 		}
-		if len(defaultRigIncludes) > 0 {
+		if len(defaultRigImports) > 0 {
+			root.DefaultRigImports = make(map[string]Import, len(defaultRigImports))
+			root.DefaultRigImportOrder = make([]string, 0, len(defaultRigImports))
+			defaultRigIncludes := make([]string, 0, len(defaultRigImports))
+			for _, bound := range defaultRigImports {
+				root.DefaultRigImports[bound.Binding] = bound.Import
+				root.DefaultRigImportOrder = append(root.DefaultRigImportOrder, bound.Binding)
+				defaultRigIncludes = append(defaultRigIncludes, bound.Import.Source)
+			}
 			root.Workspace.SetLegacyDefaultRigIncludes(append(defaultRigIncludes, root.Workspace.LegacyDefaultRigIncludes()...))
 		}
 		if len(pc.Defaults.Rig.Imports) > 0 {
@@ -1339,18 +1347,6 @@ func defaultRigImportsFromPackDefaults(defaults PackDefaults, md toml.MetaData) 
 		imports = append(imports, BoundImport{Binding: name, Import: imp})
 	}
 	return imports, nil
-}
-
-func defaultRigIncludesFromPackDefaults(defaults PackDefaults, md toml.MetaData) ([]string, error) {
-	imports, err := defaultRigImportsFromPackDefaults(defaults, md)
-	if err != nil {
-		return nil, err
-	}
-	includes := make([]string, 0, len(imports))
-	for _, bound := range imports {
-		includes = append(includes, bound.Import.Source)
-	}
-	return includes, nil
 }
 
 func orderedDefaultRigImportNames(imports map[string]Import, md toml.MetaData) []string {

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -70,6 +70,7 @@ func TestLoadWithIncludes_RootPackDefaultRigImportsPreserveOrder(t *testing.T) {
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]
 name = "test"
+default_rig_includes = ["packs/city-local"]
 `)
 	fs.Files["/city/pack.toml"] = []byte(`
 [pack]
@@ -87,9 +88,15 @@ source = "packs/a-pack"
 	if err != nil {
 		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-	want := []string{"packs/z-pack", "packs/a-pack"}
+	want := []string{"packs/z-pack", "packs/a-pack", "packs/city-local"}
 	if got := cfg.Workspace.LegacyDefaultRigIncludes(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("DefaultRigIncludes = %v, want %v", got, want)
+	}
+	if got := cfg.DefaultRigImportOrder; !reflect.DeepEqual(got, []string{"z-pack", "a-pack"}) {
+		t.Fatalf("DefaultRigImportOrder = %v, want [z-pack a-pack]", got)
+	}
+	if got := cfg.DefaultRigImports["z-pack"].Source; got != "packs/z-pack" {
+		t.Fatalf("DefaultRigImports[z-pack].Source = %q, want packs/z-pack", got)
 	}
 }
 

--- a/internal/doctor/stale_local_pack_dir_check.go
+++ b/internal/doctor/stale_local_pack_dir_check.go
@@ -8,19 +8,23 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/remotesource"
 )
 
 // StaleLocalPackDirCheck warns when a remote pack binding has a same-named
 // local packs/<binding>/ directory that can mislead operators into editing a
 // stale copy instead of the configured remote pack source.
 type StaleLocalPackDirCheck struct {
-	packs    map[string]config.PackSource
+	bindings []staleLocalPackBinding
 	cityPath string
 }
 
 // NewStaleLocalPackDirCheck creates a stale local pack directory check.
-func NewStaleLocalPackDirCheck(packs map[string]config.PackSource, cityPath string) *StaleLocalPackDirCheck {
-	return &StaleLocalPackDirCheck{packs: packs, cityPath: cityPath}
+func NewStaleLocalPackDirCheck(packs map[string]config.PackSource, imports map[string]config.Import, defaultRigImports map[string]config.Import, cityPath string, rigs ...config.Rig) *StaleLocalPackDirCheck {
+	return &StaleLocalPackDirCheck{
+		bindings: staleLocalPackBindings(packs, imports, defaultRigImports, rigs),
+		cityPath: cityPath,
+	}
 }
 
 // Name returns the check identifier.
@@ -29,15 +33,17 @@ func (c *StaleLocalPackDirCheck) Name() string { return "stale-local-pack-dirs" 
 // Run checks for local packs/<binding>/ directories alongside remote bindings.
 func (c *StaleLocalPackDirCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
-	if len(c.packs) == 0 {
+	if len(c.bindings) == 0 {
 		r.Status = StatusOK
 		r.Message = "no remote pack bindings configured"
 		return r
 	}
 
 	var stale []staleLocalPackDir
-	for _, name := range sortedPackBindingNames(c.packs) {
-		rel, path, ok := localPackBindingPath(c.cityPath, name)
+	staleByRel := make(map[string]int)
+	var inspectErrors []string
+	for _, binding := range c.bindings {
+		rel, path, ok := localPackBindingPath(c.cityPath, binding.name)
 		if !ok {
 			continue
 		}
@@ -46,33 +52,40 @@ func (c *StaleLocalPackDirCheck) Run(_ *CheckContext) *CheckResult {
 			if os.IsNotExist(err) {
 				continue
 			}
-			r.Status = StatusWarning
-			r.Message = fmt.Sprintf("could not inspect local pack directory %s", rel)
-			r.Details = []string{err.Error()}
-			return r
+			inspectErrors = append(inspectErrors, fmt.Sprintf("could not inspect %s at %s: %v", binding.configRef, filepath.ToSlash(rel), err))
+			continue
 		}
 		if !info.IsDir() {
 			continue
 		}
+		if idx, ok := staleByRel[rel]; ok {
+			stale[idx].bindings = append(stale[idx].bindings, binding)
+			continue
+		}
+		staleByRel[rel] = len(stale)
 		stale = append(stale, staleLocalPackDir{
-			binding: name,
-			rel:     rel,
-			source:  c.packs[name],
+			bindings: []staleLocalPackBinding{binding},
+			rel:      rel,
 		})
 	}
 
-	if len(stale) == 0 {
+	if len(stale) == 0 && len(inspectErrors) == 0 {
 		r.Status = StatusOK
 		r.Message = "no stale local pack directories"
 		return r
 	}
 
 	r.Status = StatusWarning
+	r.Details = append(r.Details, inspectErrors...)
 	for _, hit := range stale {
-		r.Details = append(r.Details, fmt.Sprintf("%s exists while [packs.%s] points at %s", hit.rel, hit.binding, hit.source.Source))
+		r.Details = append(r.Details, hit.detail())
+	}
+	if len(stale) == 0 {
+		r.Message = fmt.Sprintf("could not inspect %d local pack %s", len(inspectErrors), localPackDirectoryNoun(len(inspectErrors)))
+		return r
 	}
 	if len(stale) == 1 {
-		r.Message = stale[0].operatorAction()
+		r.Message = fmt.Sprintf("stale local pack directory: %s", filepath.ToSlash(stale[0].rel))
 		r.FixHint = stale[0].operatorAction()
 		return r
 	}
@@ -92,22 +105,80 @@ func (c *StaleLocalPackDirCheck) Fix(_ *CheckContext) error { return nil }
 func (c *StaleLocalPackDirCheck) WarmupEligible() bool { return false }
 
 type staleLocalPackDir struct {
-	binding string
-	rel     string
-	source  config.PackSource
+	bindings []staleLocalPackBinding
+	rel      string
 }
 
 func (d staleLocalPackDir) operatorAction() string {
-	return fmt.Sprintf("delete `%s/` (it's stale); edits go via PR on %s", filepath.ToSlash(d.rel), packSourceRepoName(d.source))
+	source := ""
+	if len(d.bindings) > 0 {
+		source = d.bindings[0].source
+	}
+	return fmt.Sprintf("delete `%s/` (it's stale); edits go via PR on %s", filepath.ToSlash(d.rel), packSourceRepoName(source))
 }
 
-func sortedPackBindingNames(packs map[string]config.PackSource) []string {
-	names := make([]string, 0, len(packs))
-	for name := range packs {
-		names = append(names, name)
+func (d staleLocalPackDir) detail() string {
+	refs := make([]string, 0, len(d.bindings))
+	for _, binding := range d.bindings {
+		refs = append(refs, fmt.Sprintf("%s points at %s", binding.configRef, binding.source))
 	}
-	sort.Strings(names)
-	return names
+	return fmt.Sprintf("%s exists while %s", filepath.ToSlash(d.rel), strings.Join(refs, "; "))
+}
+
+type staleLocalPackBinding struct {
+	name      string
+	source    string
+	configRef string
+}
+
+func staleLocalPackBindings(packs map[string]config.PackSource, imports map[string]config.Import, defaultRigImports map[string]config.Import, rigs []config.Rig) []staleLocalPackBinding {
+	bindings := make([]staleLocalPackBinding, 0, len(packs)+len(imports)+len(defaultRigImports))
+	for name, src := range packs {
+		bindings = append(bindings, staleLocalPackBinding{
+			name:      name,
+			source:    src.Source,
+			configRef: fmt.Sprintf("[packs.%s]", name),
+		})
+	}
+	for name, imp := range imports {
+		if !remotesource.IsRemote(imp.Source) {
+			continue
+		}
+		bindings = append(bindings, staleLocalPackBinding{
+			name:      name,
+			source:    imp.Source,
+			configRef: fmt.Sprintf("[imports.%s]", name),
+		})
+	}
+	for name, imp := range defaultRigImports {
+		if !remotesource.IsRemote(imp.Source) {
+			continue
+		}
+		bindings = append(bindings, staleLocalPackBinding{
+			name:      name,
+			source:    imp.Source,
+			configRef: fmt.Sprintf("[defaults.rig.imports.%s]", name),
+		})
+	}
+	for _, rig := range rigs {
+		for name, imp := range rig.Imports {
+			if !remotesource.IsRemote(imp.Source) {
+				continue
+			}
+			bindings = append(bindings, staleLocalPackBinding{
+				name:      name,
+				source:    imp.Source,
+				configRef: fmt.Sprintf("[rigs.%s.imports.%s]", rig.Name, name),
+			})
+		}
+	}
+	sort.Slice(bindings, func(i, j int) bool {
+		if bindings[i].name == bindings[j].name {
+			return bindings[i].configRef < bindings[j].configRef
+		}
+		return bindings[i].name < bindings[j].name
+	})
+	return bindings
 }
 
 func localPackBindingPath(cityPath, binding string) (rel string, path string, ok bool) {
@@ -122,8 +193,8 @@ func localPackBindingPath(cityPath, binding string) (rel string, path string, ok
 	return rel, filepath.Join(cityPath, rel), true
 }
 
-func packSourceRepoName(src config.PackSource) string {
-	source := strings.TrimSuffix(strings.TrimRight(src.Source, "/"), ".git")
+func packSourceRepoName(src string) string {
+	source := strings.TrimSuffix(strings.TrimRight(src, "/"), ".git")
 	if source == "" {
 		return "the remote pack repository"
 	}
@@ -131,4 +202,11 @@ func packSourceRepoName(src config.PackSource) string {
 		return source[i+1:]
 	}
 	return source
+}
+
+func localPackDirectoryNoun(n int) string {
+	if n == 1 {
+		return "directory"
+	}
+	return "directories"
 }

--- a/internal/doctor/stale_local_pack_dir_check.go
+++ b/internal/doctor/stale_local_pack_dir_check.go
@@ -1,0 +1,134 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// StaleLocalPackDirCheck warns when a remote pack binding has a same-named
+// local packs/<binding>/ directory that can mislead operators into editing a
+// stale copy instead of the configured remote pack source.
+type StaleLocalPackDirCheck struct {
+	packs    map[string]config.PackSource
+	cityPath string
+}
+
+// NewStaleLocalPackDirCheck creates a stale local pack directory check.
+func NewStaleLocalPackDirCheck(packs map[string]config.PackSource, cityPath string) *StaleLocalPackDirCheck {
+	return &StaleLocalPackDirCheck{packs: packs, cityPath: cityPath}
+}
+
+// Name returns the check identifier.
+func (c *StaleLocalPackDirCheck) Name() string { return "stale-local-pack-dirs" }
+
+// Run checks for local packs/<binding>/ directories alongside remote bindings.
+func (c *StaleLocalPackDirCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if len(c.packs) == 0 {
+		r.Status = StatusOK
+		r.Message = "no remote pack bindings configured"
+		return r
+	}
+
+	var stale []staleLocalPackDir
+	for _, name := range sortedPackBindingNames(c.packs) {
+		rel, path, ok := localPackBindingPath(c.cityPath, name)
+		if !ok {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			r.Status = StatusWarning
+			r.Message = fmt.Sprintf("could not inspect local pack directory %s", rel)
+			r.Details = []string{err.Error()}
+			return r
+		}
+		if !info.IsDir() {
+			continue
+		}
+		stale = append(stale, staleLocalPackDir{
+			binding: name,
+			rel:     rel,
+			source:  c.packs[name],
+		})
+	}
+
+	if len(stale) == 0 {
+		r.Status = StatusOK
+		r.Message = "no stale local pack directories"
+		return r
+	}
+
+	r.Status = StatusWarning
+	for _, hit := range stale {
+		r.Details = append(r.Details, fmt.Sprintf("%s exists while [packs.%s] points at %s", hit.rel, hit.binding, hit.source.Source))
+	}
+	if len(stale) == 1 {
+		r.Message = stale[0].operatorAction()
+		r.FixHint = stale[0].operatorAction()
+		return r
+	}
+	r.Message = fmt.Sprintf("%d stale local pack directories", len(stale))
+	r.FixHint = "delete each stale packs/<binding>/ directory; edits go via PR on the corresponding remote pack repository"
+	return r
+}
+
+// CanFix returns false; deleting local pack directories is an operator choice.
+func (c *StaleLocalPackDirCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *StaleLocalPackDirCheck) Fix(_ *CheckContext) error { return nil }
+
+// WarmupEligible returns false; this guard is informational and not a startup
+// prerequisite.
+func (c *StaleLocalPackDirCheck) WarmupEligible() bool { return false }
+
+type staleLocalPackDir struct {
+	binding string
+	rel     string
+	source  config.PackSource
+}
+
+func (d staleLocalPackDir) operatorAction() string {
+	return fmt.Sprintf("delete `%s/` (it's stale); edits go via PR on %s", filepath.ToSlash(d.rel), packSourceRepoName(d.source))
+}
+
+func sortedPackBindingNames(packs map[string]config.PackSource) []string {
+	names := make([]string, 0, len(packs))
+	for name := range packs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func localPackBindingPath(cityPath, binding string) (rel string, path string, ok bool) {
+	if binding == "" || filepath.IsAbs(binding) {
+		return "", "", false
+	}
+	rel = filepath.Clean(filepath.Join("packs", filepath.FromSlash(binding)))
+	packRoot := "packs" + string(filepath.Separator)
+	if !strings.HasPrefix(rel, packRoot) {
+		return "", "", false
+	}
+	return rel, filepath.Join(cityPath, rel), true
+}
+
+func packSourceRepoName(src config.PackSource) string {
+	source := strings.TrimSuffix(strings.TrimRight(src.Source, "/"), ".git")
+	if source == "" {
+		return "the remote pack repository"
+	}
+	if i := strings.LastIndexAny(source, "/:"); i >= 0 && i+1 < len(source) {
+		return source[i+1:]
+	}
+	return source
+}

--- a/internal/doctor/stale_local_pack_dir_check_test.go
+++ b/internal/doctor/stale_local_pack_dir_check_test.go
@@ -1,0 +1,58 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestStaleLocalPackDirCheckWarnsForConfiguredActualBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "actual"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+
+	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
+		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
+	}, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; result=%+v", result.Status, result)
+	}
+	if !strings.Contains(result.Message, "delete `packs/actual/` (it's stale); edits go via PR on gc-actual-packs") {
+		t.Fatalf("message = %q, want operator action", result.Message)
+	}
+}
+
+func TestStaleLocalPackDirCheckOKWhenConfiguredActualBindingHasNoLocalDir(t *testing.T) {
+	cityPath := t.TempDir()
+
+	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
+		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
+	}, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; result=%+v", result.Status, result)
+	}
+}
+
+func TestStaleLocalPackDirCheckIgnoresActualDirWithoutConfiguredBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "actual"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+
+	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
+		"other": {Source: "https://github.com/gastownhall/other-packs"},
+	}, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; result=%+v", result.Status, result)
+	}
+}

--- a/internal/doctor/stale_local_pack_dir_check_test.go
+++ b/internal/doctor/stale_local_pack_dir_check_test.go
@@ -17,14 +17,17 @@ func TestStaleLocalPackDirCheckWarnsForConfiguredActualBinding(t *testing.T) {
 
 	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
 		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
-	}, cityPath)
+	}, nil, nil, cityPath)
 
 	result := check.Run(&CheckContext{})
 	if result.Status != StatusWarning {
 		t.Fatalf("status = %v, want warning; result=%+v", result.Status, result)
 	}
-	if !strings.Contains(result.Message, "delete `packs/actual/` (it's stale); edits go via PR on gc-actual-packs") {
-		t.Fatalf("message = %q, want operator action", result.Message)
+	if result.Message != "stale local pack directory: packs/actual" {
+		t.Fatalf("message = %q, want stale local pack directory summary", result.Message)
+	}
+	if !strings.Contains(result.FixHint, "delete `packs/actual/` (it's stale); edits go via PR on gc-actual-packs") {
+		t.Fatalf("fix hint = %q, want operator action", result.FixHint)
 	}
 }
 
@@ -33,7 +36,7 @@ func TestStaleLocalPackDirCheckOKWhenConfiguredActualBindingHasNoLocalDir(t *tes
 
 	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
 		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
-	}, cityPath)
+	}, nil, nil, cityPath)
 
 	result := check.Run(&CheckContext{})
 	if result.Status != StatusOK {
@@ -49,10 +52,217 @@ func TestStaleLocalPackDirCheckIgnoresActualDirWithoutConfiguredBinding(t *testi
 
 	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
 		"other": {Source: "https://github.com/gastownhall/other-packs"},
-	}, cityPath)
+	}, nil, nil, cityPath)
 
 	result := check.Run(&CheckContext{})
 	if result.Status != StatusOK {
 		t.Fatalf("status = %v, want OK; result=%+v", result.Status, result)
+	}
+}
+
+func TestStaleLocalPackDirCheckWarnsForRemoteImportBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "actual"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+
+	check := NewStaleLocalPackDirCheck(nil, map[string]config.Import{
+		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
+	}, nil, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; result=%+v", result.Status, result)
+	}
+	if result.Message != "stale local pack directory: packs/actual" {
+		t.Fatalf("message = %q, want stale local pack directory summary", result.Message)
+	}
+	if len(result.Details) != 1 || !strings.Contains(result.Details[0], "[imports.actual]") {
+		t.Fatalf("details = %#v, want import binding detail", result.Details)
+	}
+}
+
+func TestStaleLocalPackDirCheckWarnsForDefaultRigRemoteImportBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "actual"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+
+	check := NewStaleLocalPackDirCheck(nil, nil, map[string]config.Import{
+		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
+	}, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; result=%+v", result.Status, result)
+	}
+	if result.Message != "stale local pack directory: packs/actual" {
+		t.Fatalf("message = %q, want stale local pack directory summary", result.Message)
+	}
+	if len(result.Details) != 1 || !strings.Contains(result.Details[0], "[defaults.rig.imports.actual]") {
+		t.Fatalf("details = %#v, want default rig import binding detail", result.Details)
+	}
+}
+
+func TestStaleLocalPackDirCheckWarnsForRigRemoteImportBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "actual"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+
+	rig := config.Rig{
+		Name: "demo-rig",
+		Imports: map[string]config.Import{
+			"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
+		},
+	}
+	check := NewStaleLocalPackDirCheck(nil, nil, nil, cityPath, rig)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; result=%+v", result.Status, result)
+	}
+	if result.Message != "stale local pack directory: packs/actual" {
+		t.Fatalf("message = %q, want stale local pack directory summary", result.Message)
+	}
+	if len(result.Details) != 1 || !strings.Contains(result.Details[0], "[rigs.demo-rig.imports.actual]") {
+		t.Fatalf("details = %#v, want rig import binding detail", result.Details)
+	}
+}
+
+func TestStaleLocalPackDirCheckDedupesSameLocalPackDirForPackAndImport(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "actual"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+
+	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
+		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
+	}, map[string]config.Import{
+		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
+	}, nil, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; result=%+v", result.Status, result)
+	}
+	if result.Message != "stale local pack directory: packs/actual" {
+		t.Fatalf("message = %q, want single stale directory summary", result.Message)
+	}
+	if len(result.Details) != 1 {
+		t.Fatalf("details = %#v, want one entry for one physical directory", result.Details)
+	}
+	if !strings.Contains(result.Details[0], "[imports.actual]") || !strings.Contains(result.Details[0], "[packs.actual]") {
+		t.Fatalf("details = %#v, want both config references", result.Details)
+	}
+}
+
+func TestStaleLocalPackDirCheckIgnoresLocalImportBinding(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "actual"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+
+	check := NewStaleLocalPackDirCheck(nil, map[string]config.Import{
+		"actual": {Source: "./packs/actual"},
+	}, nil, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; result=%+v", result.Status, result)
+	}
+}
+
+func TestStaleLocalPackDirCheckReportsMultipleBindingsInSortedOrder(t *testing.T) {
+	cityPath := t.TempDir()
+	for _, name := range []string{"beta", "alpha"} {
+		if err := os.MkdirAll(filepath.Join(cityPath, "packs", name), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", name, err)
+		}
+	}
+
+	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
+		"beta":  {Source: "https://github.com/gastownhall/beta-packs"},
+		"alpha": {Source: "https://github.com/gastownhall/alpha-packs"},
+	}, nil, nil, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; result=%+v", result.Status, result)
+	}
+	if result.Message != "2 stale local pack directories" {
+		t.Fatalf("message = %q, want multi-binding summary", result.Message)
+	}
+	if len(result.Details) != 2 {
+		t.Fatalf("details = %#v, want two entries", result.Details)
+	}
+	if !strings.Contains(result.Details[0], "packs/alpha") || !strings.Contains(result.Details[1], "packs/beta") {
+		t.Fatalf("details = %#v, want sorted alpha then beta", result.Details)
+	}
+}
+
+func TestStaleLocalPackDirCheckIgnoresFileInsteadOfDirectory(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "packs", "actual"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("WriteFile(): %v", err)
+	}
+
+	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
+		"actual": {Source: "https://github.com/gastownhall/gc-actual-packs"},
+	}, nil, nil, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; result=%+v", result.Status, result)
+	}
+}
+
+func TestStaleLocalPackDirCheckIgnoresUnsafeBindingNames(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "actual"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+
+	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
+		"..":        {Source: "https://github.com/gastownhall/parent-packs"},
+		"../escape": {Source: "https://github.com/gastownhall/escape-packs"},
+		"/absolute": {Source: "https://github.com/gastownhall/absolute-packs"},
+		".":         {Source: "https://github.com/gastownhall/current-packs"},
+	}, nil, nil, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; result=%+v", result.Status, result)
+	}
+}
+
+func TestStaleLocalPackDirCheckContinuesAfterStatError(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, "packs", "zeta"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	tooLongBinding := strings.Repeat("a", 5000)
+
+	check := NewStaleLocalPackDirCheck(map[string]config.PackSource{
+		tooLongBinding: {Source: "https://github.com/gastownhall/too-long-packs"},
+		"zeta":         {Source: "https://github.com/gastownhall/zeta-packs"},
+	}, nil, nil, cityPath)
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusWarning {
+		t.Fatalf("status = %v, want warning; result=%+v", result.Status, result)
+	}
+	if result.Message != "stale local pack directory: packs/zeta" {
+		t.Fatalf("message = %q, want stale zeta summary", result.Message)
+	}
+	joined := strings.Join(result.Details, "\n")
+	if !strings.Contains(joined, "could not inspect [packs.") {
+		t.Fatalf("details = %#v, want inspection failure detail", result.Details)
+	}
+	if !strings.Contains(joined, "packs/zeta exists while [packs.zeta]") {
+		t.Fatalf("details = %#v, want stale zeta detail after stat failure", result.Details)
 	}
 }

--- a/release-gates/gc-doctor-stale-local-pack-dir-gate.md
+++ b/release-gates/gc-doctor-stale-local-pack-dir-gate.md
@@ -1,0 +1,30 @@
+# Release Gate: gc doctor stale local pack dir warning
+
+Bead: ga-s5j6n
+Source bead: ga-371q.8
+Branch: builder/ga-371q-8
+Commit under review: 1e9c161a6
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-s5j6n` notes contain `VERDICT: pass`; findings: none. |
+| 2 | Acceptance criteria met | PASS | `gc doctor` registers the stale local pack dir check; warning-only behavior, operator action text, configured clean state, and unconfigured local-dir state are covered by tests. |
+| 3 | Tests pass | PASS | `go test ./internal/doctor ./cmd/gc -run 'Doctor|PackCache|ConfigRefs|StaleLocalPackDir'` PASS; `go vet ./...` PASS; `make test-fast-parallel` PASS. |
+| 4 | No high-severity review findings open | PASS | Review notes list `Findings: none`; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was clean before writing this gate artifact; the gate artifact is committed as the final branch change. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` completed with no conflicts. |
+
+## Acceptance Evidence
+
+- Changed files: `cmd/gc/cmd_doctor.go`, `cmd/gc/cmd_doctor_test.go`, `internal/doctor/stale_local_pack_dir_check.go`, `internal/doctor/stale_local_pack_dir_check_test.go`.
+- The check fires only when a configured remote pack binding has a same-named local `packs/<binding>/` directory.
+- The result is a warning, not a fixable error, and the operator action tells users to delete the stale local directory and route edits through the remote pack repository.
+
+## Test Evidence
+
+- `go test ./internal/doctor ./cmd/gc -run 'Doctor|PackCache|ConfigRefs|StaleLocalPackDir'`: PASS.
+- `go vet ./...`: PASS.
+- `make test-fast-parallel`: PASS.
+- `git diff --check origin/main...HEAD`: PASS.

--- a/release-gates/gc-doctor-stale-local-pack-dir-gate.md
+++ b/release-gates/gc-doctor-stale-local-pack-dir-gate.md
@@ -3,28 +3,38 @@
 Bead: ga-s5j6n
 Source bead: ga-371q.8
 Branch: builder/ga-371q-8
-Commit under review: 1e9c161a6
+Commit under review: current PR HEAD after maintainer fixups. This file was
+refreshed in the maintainer fixup commit, so use `git show --name-status HEAD`
+for the exact reviewed tree.
+
+This gate began as author-provided release evidence. The PR-review workflow
+supersedes it: final approval requires a fresh synthesis and quality scorecard.
 
 ## Gate Checklist
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
-| 1 | Review PASS present | PASS | `bd show ga-s5j6n` notes contain `VERDICT: pass`; findings: none. |
-| 2 | Acceptance criteria met | PASS | `gc doctor` registers the stale local pack dir check; warning-only behavior, operator action text, configured clean state, and unconfigured local-dir state are covered by tests. |
-| 3 | Tests pass | PASS | `go test ./internal/doctor ./cmd/gc -run 'Doctor|PackCache|ConfigRefs|StaleLocalPackDir'` PASS; `go vet ./...` PASS; `make test-fast-parallel` PASS. |
-| 4 | No high-severity review findings open | PASS | Review notes list `Findings: none`; unresolved HIGH findings count is 0. |
-| 5 | Final branch is clean | PASS | `git status --short` was clean before writing this gate artifact; the gate artifact is committed as the final branch change. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` completed with no conflicts. |
+| 1 | Review evidence current | PENDING | Attempt 1 requested changes; maintainer fixups are local and require a fresh review pass. |
+| 2 | Acceptance criteria met | PASS | `gc doctor` registers the stale local pack dir check; warning-only behavior, operator action text, configured clean state, unconfigured local-dir state, city-level remote imports, rig-level remote imports, root default-rig remote imports, duplicate binding dedupe, and stat-error continuation are covered by tests. |
+| 3 | Validation evidence current | PASS | Current-tree targeted tests, `git diff --check`, `go vet ./...`, and `make test` passed after the maintainer fixups. |
+| 4 | No high-severity review findings open | PENDING | Attempt 1's major import-surface finding is fixed locally; the workflow must rerun synthesis before this can become PASS. |
+| 5 | Final branch is clean | PENDING | The stale claim that this gate was the final branch change is removed. The apply-fixes workflow verifies `git show --name-status HEAD` and `git status --short` after the maintainer fixup commit. |
+| 6 | Branch diverges cleanly from main | NOT RERUN | Merge-tree was not rerun during this maintainer fixup. |
 
 ## Acceptance Evidence
 
-- Changed files: `cmd/gc/cmd_doctor.go`, `cmd/gc/cmd_doctor_test.go`, `internal/doctor/stale_local_pack_dir_check.go`, `internal/doctor/stale_local_pack_dir_check_test.go`.
+- Changed files: `cmd/gc/cmd_doctor.go`, `cmd/gc/cmd_doctor_test.go`, `internal/config/compose.go`, `internal/config/compose_test.go`, `internal/doctor/stale_local_pack_dir_check.go`, `internal/doctor/stale_local_pack_dir_check_test.go`, `release-gates/gc-doctor-stale-local-pack-dir-gate.md`.
 - The check fires only when a configured remote pack binding has a same-named local `packs/<binding>/` directory.
+- City-level, rig-level, and root default-rig remote imports are inspected.
+- If legacy `[packs.<binding>]` and PackV2 `[imports.<binding>]` point at the same local `packs/<binding>/` directory, the warning counts one physical stale directory and preserves both config references in details.
 - The result is a warning, not a fixable error, and the operator action tells users to delete the stale local directory and route edits through the remote pack repository.
 
 ## Test Evidence
 
-- `go test ./internal/doctor ./cmd/gc -run 'Doctor|PackCache|ConfigRefs|StaleLocalPackDir'`: PASS.
+- `git diff --check`: PASS.
+- `go test ./internal/doctor -run 'TestStaleLocalPackDirCheck'`: PASS.
+- `go test ./internal/config -run 'TestLoadWithIncludes_RootPackDefaultRigImportsPreserveOrder'`: PASS.
+- `go test ./cmd/gc -run 'TestDoDoctorRegistersStaleLocalPackDirCheck'`: PASS.
+- `go test ./internal/doctor ./internal/config ./cmd/gc -run 'StaleLocalPackDir|TestDoDoctorRegistersStaleLocalPackDirCheck|RootPackDefaultRigImportsPreserveOrder'`: PASS.
 - `go vet ./...`: PASS.
-- `make test-fast-parallel`: PASS.
-- `git diff --check origin/main...HEAD`: PASS.
+- `make test`: PASS.


### PR DESCRIPTION
## What this changes

`gc doctor` now warns when a configured remote pack binding has a same-named local `packs/<binding>/` directory in the city workspace. That catches stale local pack directories that can mislead operators into editing files the system is no longer using as the source of truth.

The check is warning-only. It does not try to delete anything or mark the city unhealthy; it tells the operator to remove the stale local directory and route edits through the remote pack repository.

## Review notes

- The doctor check is registered through `cmd/gc/cmd_doctor.go` and implemented under `internal/doctor`.
- It only fires for configured pack bindings, so an unrelated local directory without a matching binding does not warn.
- Path handling rejects absolute or escaping binding paths before checking `packs/<binding>/`.

## Test plan

- [x] `go test ./internal/doctor ./cmd/gc -run 'Doctor|PackCache|ConfigRefs|StaleLocalPackDir'
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/gc-doctor-stale-local-pack-dir-gate.md`](release-gates/gc-doctor-stale-local-pack-dir-gate.md)