### PR TITLE
fix(codex): clear inherited session context for managed sessions

### DIFF
--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -894,6 +894,19 @@ func TestPassthroughEnvClearsClaudeNestingUnconditionally(t *testing.T) {
 	}
 }
 
+func TestPassthroughEnvStripsCodexSessionContext(t *testing.T) {
+	t.Setenv("CODEX_THREAD_ID", "thread-123")
+	t.Setenv("CODEX_CI", "1")
+
+	got := passthroughEnv()
+
+	for _, key := range []string{"CODEX_THREAD_ID", "CODEX_CI"} {
+		if v, ok := got[key]; !ok || v != "" {
+			t.Errorf("%s should be present and empty, got ok=%v v=%q", key, ok, v)
+		}
+	}
+}
+
 func TestPassthroughEnvLANGFallback(t *testing.T) {
 	// When no locale is set (e.g. launchd supervisor), fall back to
 	// en_US.UTF-8 so TUI tools render UTF-8 glyphs correctly in managed

--- a/internal/processenv/provider.go
+++ b/internal/processenv/provider.go
@@ -157,5 +157,7 @@ func ProviderProcessPassthroughEnv() map[string]string {
 	}
 	m["CLAUDECODE"] = ""
 	m["CLAUDE_CODE_ENTRYPOINT"] = ""
+	m["CODEX_THREAD_ID"] = ""
+	m["CODEX_CI"] = ""
 	return m
 }

--- a/internal/processenv/provider_test.go
+++ b/internal/processenv/provider_test.go
@@ -54,6 +54,8 @@ func TestProviderProcessPassthroughEnvIncludesProviderAndRuntimeBaseline(t *test
 	t.Setenv("AWS_PAGER", "less")
 	t.Setenv("CLAUDECODE", "1")
 	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "nested")
+	t.Setenv("CODEX_THREAD_ID", "thread-123")
+	t.Setenv("CODEX_CI", "true")
 
 	got := ProviderProcessPassthroughEnv()
 
@@ -70,6 +72,8 @@ func TestProviderProcessPassthroughEnvIncludesProviderAndRuntimeBaseline(t *test
 		"AWS_ACCESS_KEY_ID":      "test-aws-key",
 		"CLAUDECODE":             "",
 		"CLAUDE_CODE_ENTRYPOINT": "",
+		"CODEX_THREAD_ID":        "",
+		"CODEX_CI":               "",
 	} {
 		if got[key] != want {
 			t.Errorf("ProviderProcessPassthroughEnv()[%s] = %q, want %q", key, got[key], want)


### PR DESCRIPTION
## Summary

Managed Codex sessions currently inherit the caller's Codex session context from the parent process.

This clears inherited:
- `CODEX_THREAD_ID`
- `CODEX_CI`

from the managed-session baseline env in `passthroughEnv()`.

## Why

Managed sessions should not bind themselves to the operator's active Codex thread or CI/session mode.

In practice, inheriting those vars can cause managed Codex roles to attach to the wrong session context or behave as if they are part of the caller's existing Codex run.

This is the same class of unconditional scrub we already apply for Claude nesting detection.

## Changes

- clear `CODEX_THREAD_ID`
- clear `CODEX_CI`
- add a regression test covering the scrub

## Testing

```bash
go test ./cmd/gc -run 'TestPassthroughEnv(StripsCodexSessionContext|StripsClaudeNesting|ClearsClaudeNestingUnconditionally)$' -count=1
```
