### PR TITLE
fix: clear stale blockers when reopening named sessions

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -444,10 +444,22 @@ func reopenClosedConfiguredNamedSessionBead(
 			batch[session.PrimedAtMetadataKey] = ""
 			batch[session.PrimingAttemptedAtMetadataKey] = ""
 			batch[session.PromptHashMetadataKey] = ""
+			// A fresh spawn must clear the same advisory wake blockers and
+			// crash-accrual counters the canonical wake patches reset -- a
+			// stale hold/quarantine, sleep_intent, or wake/churn counter would
+			// otherwise keep gating wake or re-quarantine the reopened runtime
+			// on its first failure. Compose ClearWakeBlockersPatch so this path
+			// tracks that full set (including sleep_intent, wake_attempts, and
+			// churn_count) by construction instead of hand-listing a subset
+			// that drifts from the canonical contract.
+			blockers := session.ClearWakeBlockersPatch(session.State(state), bead.Metadata["sleep_reason"])
+			delete(blockers, "state") // the reopen owns the target state set above.
+			for k, v := range blockers {
+				batch[k] = v
+			}
+			// ClearWakeBlockersPatch only drops sleep_reason for its recognized
+			// reasons; a fresh spawn always clears it, matching RequestWakePatch.
 			batch["sleep_reason"] = ""
-			batch["quarantined_until"] = ""
-			batch["held_until"] = ""
-			batch["wait_hold"] = ""
 		} else {
 			batch["pending_create_started_at"] = ""
 		}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -444,6 +444,10 @@ func reopenClosedConfiguredNamedSessionBead(
 			batch[session.PrimedAtMetadataKey] = ""
 			batch[session.PrimingAttemptedAtMetadataKey] = ""
 			batch[session.PromptHashMetadataKey] = ""
+			batch["sleep_reason"] = ""
+			batch["quarantined_until"] = ""
+			batch["held_until"] = ""
+			batch["wait_hold"] = ""
 		} else {
 			batch["pending_create_started_at"] = ""
 		}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -1204,6 +1204,10 @@ func TestReopenClosedConfiguredNamedSessionBeadClearsStaleStartMarkersWhenRecrea
 			"started_live_hash":          "old-live",
 			"live_hash":                  "old-runtime",
 			"startup_dialog_verified":    "true",
+			"sleep_reason":               "context-churn",
+			"quarantined_until":          now.Add(-5 * time.Minute).UTC().Format(time.RFC3339),
+			"held_until":                 now.Add(-4 * time.Minute).UTC().Format(time.RFC3339),
+			"wait_hold":                  "true",
 			namedSessionMetadataKey:      "true",
 			namedSessionIdentityMetadata: "mayor",
 			namedSessionModeMetadata:     "always",
@@ -1233,6 +1237,10 @@ func TestReopenClosedConfiguredNamedSessionBeadClearsStaleStartMarkersWhenRecrea
 		"started_live_hash",
 		"live_hash",
 		"startup_dialog_verified",
+		"sleep_reason",
+		"quarantined_until",
+		"held_until",
+		"wait_hold",
 	} {
 		if got := reopened.Metadata[key]; got != "" {
 			t.Fatalf("%s = %q, want empty on recreate", key, got)

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -1188,26 +1188,40 @@ func TestReopenClosedConfiguredNamedSessionBeadClearsStaleStartMarkersWhenRecrea
 		},
 	}
 	sessionName := config.NamedSessionRuntimeName(cfg.Workspace.Name, cfg.Workspace, "mayor")
+	// churn_count and wake_attempts are the crash/churn accrual counters a
+	// closed session carries into reopen, and production never writes them
+	// alone: ChurnAccrualPatch pairs churn_count with sleep_reason=context-churn
+	// and WakeFailureAccrualPatch increments wake_attempts. Derive the seed
+	// values from those real writers (instead of an impossible partial state)
+	// so this test exercises the full stale set and stays honest if the
+	// counter keys or quarantine thresholds ever change.
+	staleChurnCount := session.ChurnAccrualPatch(defaultMaxChurnCycles-1, defaultMaxChurnCycles, now).Patch["churn_count"]
+	staleWakeAttempts := session.WakeFailureAccrualPatch(defaultMaxWakeAttempts-1, defaultMaxWakeAttempts, now).Patch["wake_attempts"]
 	closed, err := store.Create(beads.Bead{
 		Title:  "mayor",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel},
 		Metadata: map[string]string{
-			"session_name":               sessionName,
-			"alias":                      "mayor",
-			"template":                   "mayor",
-			"state":                      "suspended",
-			"close_reason":               "suspended",
-			"creation_complete_at":       now.Add(-10 * time.Minute).UTC().Format(time.RFC3339),
-			"last_woke_at":               now.Add(-10 * time.Minute).UTC().Format(time.RFC3339),
-			"started_config_hash":        "old-config",
-			"started_live_hash":          "old-live",
-			"live_hash":                  "old-runtime",
-			"startup_dialog_verified":    "true",
-			"sleep_reason":               "context-churn",
-			"quarantined_until":          now.Add(-5 * time.Minute).UTC().Format(time.RFC3339),
-			"held_until":                 now.Add(-4 * time.Minute).UTC().Format(time.RFC3339),
-			"wait_hold":                  "true",
+			"session_name":            sessionName,
+			"alias":                   "mayor",
+			"template":                "mayor",
+			"state":                   "suspended",
+			"close_reason":            "suspended",
+			"creation_complete_at":    now.Add(-10 * time.Minute).UTC().Format(time.RFC3339),
+			"last_woke_at":            now.Add(-10 * time.Minute).UTC().Format(time.RFC3339),
+			"started_config_hash":     "old-config",
+			"started_live_hash":       "old-live",
+			"live_hash":               "old-runtime",
+			"startup_dialog_verified": "true",
+			"sleep_reason":            "context-churn",
+			"churn_count":             staleChurnCount,
+			"quarantined_until":       now.Add(-5 * time.Minute).UTC().Format(time.RFC3339),
+			"wake_attempts":           staleWakeAttempts,
+			"held_until":              now.Add(-4 * time.Minute).UTC().Format(time.RFC3339),
+			// Store.SetWaitHold co-writes wait_hold and sleep_intent with the
+			// same reason, so seed them as the real paired blocker/intent state.
+			"wait_hold":                  "wait",
+			"sleep_intent":               "wait",
 			namedSessionMetadataKey:      "true",
 			namedSessionIdentityMetadata: "mayor",
 			namedSessionModeMetadata:     "always",
@@ -1241,9 +1255,18 @@ func TestReopenClosedConfiguredNamedSessionBeadClearsStaleStartMarkersWhenRecrea
 		"quarantined_until",
 		"held_until",
 		"wait_hold",
+		"sleep_intent",
 	} {
 		if got := reopened.Metadata[key]; got != "" {
 			t.Fatalf("%s = %q, want empty on recreate", key, got)
+		}
+	}
+	// The crash/churn accrual counters reset to "0" (not cleared to empty), so
+	// the reopened fresh runtime is not left one failure away from immediate
+	// re-quarantine.
+	for _, key := range []string{"wake_attempts", "churn_count"} {
+		if got := reopened.Metadata[key]; got != "0" {
+			t.Fatalf("%s = %q, want %q on recreate", key, got, "0")
 		}
 	}
 }


### PR DESCRIPTION
## Summary

When a closed configured named-session bead is reopened for a fresh create, clear stale start/quarantine metadata from the prior incarnation.

## Why

Reopening a previously running named-session bead into pending create can currently preserve contradictory stale metadata, including:
- prior start markers like `creation_complete_at`, `last_woke_at`, and started/live hashes
- stale blockers like `sleep_reason`, `quarantined_until`, `held_until`, and `wait_hold`

That can leave the reopened bead simultaneously claiming:
- it is pending create
- but it already completed startup
- or it is still suppressed by stale quarantine/sleep state from the old incarnation

This patch makes reopen-for-create behave like a fresh incarnation rather than a partially resurrected prior one.

## Changes

When reopening a closed configured named-session bead into a non-active state:
- clear `state_reason`
- clear old start markers:
  - `creation_complete_at`
  - `last_woke_at`
  - `started_config_hash`
  - `started_live_hash`
  - `live_hash`
  - `startup_dialog_verified`
- clear stale blockers:
  - `sleep_reason`
  - `quarantined_until`
  - `held_until`
  - `wait_hold`

## Testing

Added regressions for:
- stale startup markers being cleared on reopen
- stale quarantine/sleep blockers being cleared on reopen

```bash
go test ./cmd/gc -run 'TestReopenClosedConfiguredNamedSessionBead_(ClearsStaleStartMarkersWhenRecreating|ClearsStaleQuarantineWhenRecreating)$' -count=1
```


<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2714 — clears stale suppression blockers (sleep_reason, quarantined_until, held_until, wait_hold) when reopening a closed named-session bead for recreation, removing one way a reopened named session stays suppressed by old-incarnation state and won't revive.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
