### PR TITLE
docs: narrow csells code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,5 +17,8 @@
 /cmd/gc/dashboard/web/package.json @gastownhall/gascity-admin
 /cmd/gc/dashboard/web/package-lock.json @gastownhall/gascity-admin
 
-# Public docs are owned by csells.
-/docs/ @csells
+# Selected public docs areas are owned by csells.
+/docs/getting-started/ @csells
+/docs/guides/ @csells
+/docs/troubleshooting/ @csells
+/docs/tutorials/ @csells

--- a/.github/workflows/docs-title-review.yml
+++ b/.github/workflows/docs-title-review.yml
@@ -1,0 +1,59 @@
+name: Request docs title owner review
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  request-docs-review:
+    # pull_request_target is safe here because this job never checks out or runs
+    # pull request code; it only requests review from trusted event metadata.
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request csells review for docs PR titles
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const reviewer = 'csells';
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) {
+              core.setFailed('Unable to determine pull request payload');
+              return;
+            }
+
+            if (pullRequest.draft) {
+              console.log(`Skipping draft PR #${pullRequest.number}`);
+              return;
+            }
+
+            if (!/^docs(?::|\([^)]*\):?)/.test(pullRequest.title)) {
+              console.log(`Skipping non-docs title for PR #${pullRequest.number}`);
+              return;
+            }
+
+            if (pullRequest.user.login === reviewer) {
+              console.log(`Skipping self-review request for PR #${pullRequest.number}`);
+              return;
+            }
+
+            const current = await github.rest.pulls.listRequestedReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+            });
+            if (current.data.users.some(user => user.login === reviewer)) {
+              console.log(`Review already requested from ${reviewer} on PR #${pullRequest.number}`);
+              return;
+            }
+
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              reviewers: [reviewer],
+            });
+            console.log(`Requested review from ${reviewer} on PR #${pullRequest.number}`);


### PR DESCRIPTION
## Summary
- Narrow csells CODEOWNERS coverage from all docs to selected public docs areas.
- Add a metadata-only workflow to request csells review for PR titles starting with docs: or scoped docs(...).

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs-title-review.yml
- node regex check for docs title matching
- make test-fast-parallel
- go vet ./...
- .githooks/pre-commit