### PR TITLE
fix(provider): persist OMP session keys

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -526,7 +526,10 @@ func persistPrimeHookSessionID(sessionID string) {
 
 func persistPrimeHookProviderSessionKey() {
 	gcSessionID := strings.TrimSpace(os.Getenv("GC_SESSION_ID"))
-	providerSessionID := strings.TrimSpace(os.Getenv("GEMINI_SESSION_ID"))
+	providerSessionID := strings.TrimSpace(os.Getenv("GC_PROVIDER_SESSION_ID"))
+	if providerSessionID == "" {
+		providerSessionID = strings.TrimSpace(os.Getenv("GEMINI_SESSION_ID"))
+	}
 	if gcSessionID == "" || providerSessionID == "" || gcSessionID == providerSessionID {
 		return
 	}

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -491,8 +491,54 @@ module.exports = {
 	}
 }
 
+func TestMaterializeBuiltinPacksOmpHookPublishesProviderSessionID(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	data := readMaterializedOmpHook(t, dir)
+	for _, want := range []string{
+		`import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent"`,
+		`export default function gascityOmpExtension(pi: ExtensionAPI)`,
+		`pi.on("session_start"`,
+		`pi.on("session_compact"`,
+		`GC_PROVIDER_SESSION_ID`,
+		`getSessionId`,
+	} {
+		if !strings.Contains(data, want) {
+			t.Errorf("materialized OMP hook missing provider-session marker %q:\n%s", want, data)
+		}
+	}
+	for _, legacy := range []string{
+		"export default {",
+		`"session.created"`,
+		`"session.compacted"`,
+		`"experimental.chat.system.transform"`,
+	} {
+		if strings.Contains(data, legacy) {
+			t.Errorf("materialized OMP hook still contains legacy API marker %q:\n%s", legacy, data)
+		}
+	}
+}
+
 func materializedPiHookPath(dir string) string {
 	return filepath.Join(dir, citylayout.SystemPacksRoot, "core", "overlay", "per-provider", "pi", ".pi", "extensions", "gc-hooks.js")
+}
+
+func materializedOmpHookPath(dir string) string {
+	return filepath.Join(dir, citylayout.SystemPacksRoot, "core", "overlay", "per-provider", "omp", ".omp", "hooks", "gc-hook.ts")
+}
+
+func readMaterializedOmpHook(t *testing.T, dir string) string {
+	t.Helper()
+	path := materializedOmpHookPath(dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(data)
 }
 
 func readMaterializedPiHook(t *testing.T, dir string) string {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -6422,6 +6422,81 @@ prompt_template = "prompts/probe.md"
 	}
 }
 
+func TestDoPrimeHookPersistsGenericProviderSessionKey(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptsDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptsDir, "probe.md"), []byte("probe prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+provider = "omp"
+
+[[agent]]
+name = "probe"
+prompt_template = "prompts/probe.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openCityStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionBead, err := store.Create(beads.Bead{
+		Title: "probe",
+		Type:  "task",
+		Labels: []string{
+			"gc:session",
+			"template:probe",
+		},
+		Metadata: map[string]string{
+			"template":     "probe",
+			"provider":     "omp",
+			"session_name": "probe",
+			"state":        "active",
+			"work_dir":     dir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_AGENT", "probe")
+	t.Setenv("GC_SESSION_ID", sessionBead.ID)
+	t.Setenv("GC_PROVIDER_SESSION_ID", "omp-provider-session")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	updatedStore, err := openCityStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := updatedStore.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["session_key"]); got != "omp-provider-session" {
+		t.Fatalf("session_key = %q, want generic provider session id", got)
+	}
+}
+
 func TestDoPrimeHookFallsBackToGCTemplateForManualSessionAlias(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()

--- a/internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts
+++ b/internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts
@@ -1,45 +1,67 @@
 // Gas City hooks for Oh My Pi (OMP).
 // Installed by gc into {workDir}/.omp/hooks/gc-hook.ts
+// Managed by `gc hooks install`; put custom OMP hooks in separate extension
+// files so upgrades can replace this file safely.
 //
 // Events:
-//   session.created    → gc prime (load context)
-//   session.compacted  → gc prime (reload after compaction)
-//   chat.system.transform → gc nudge drain --inject + gc mail check --inject
+//   session_start       → gc prime --hook (load context side effects and capture OMP session id)
+//   session_compact     → gc prime --hook (reload after compaction)
+//   before_agent_start  → inject queued nudges + unread mail
 
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 
 const PATH_PREFIX =
-  `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
+  `/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
 
-function run(cmd: string): string {
+function run(args: string[], cwd?: string, extraEnv: Record<string, string> = {}): string {
   try {
-    return execSync(cmd, {
+    return execFileSync("gc", args, {
+      cwd: cwd || process.cwd(),
       encoding: "utf-8",
       timeout: 30000,
-      env: { ...process.env, PATH: PATH_PREFIX + (process.env.PATH || "") },
+      env: {
+        ...process.env,
+        ...extraEnv,
+        PATH: PATH_PREFIX + (process.env.PATH || ""),
+      },
     }).trim();
   } catch {
     return "";
   }
 }
 
-export default {
-  name: "gascity",
+function providerSessionEnv(ctx: { sessionManager?: { getSessionId?: () => string } }): Record<string, string> {
+  const sessionID = ctx.sessionManager?.getSessionId?.() || "";
+  if (!sessionID) {
+    return {};
+  }
+  return { GC_PROVIDER_SESSION_ID: sessionID };
+}
 
-  events: {
-    "session.created": () => run("gc prime --hook"),
-    "session.compacted": () => run("gc prime --hook"),
-  },
+function appendSystemPrompt(systemPrompt: string[], additions: string[]): string[] {
+  const extras = additions.filter(Boolean);
+  if (extras.length === 0) {
+    return systemPrompt;
+  }
+  return [...systemPrompt, extras.join("\n\n")];
+}
 
-  hooks: {
-    "experimental.chat.system.transform": (system: string): string => {
-      const nudges = run("gc nudge drain --inject");
-      const mail = run("gc mail check --inject");
-      const extras = [nudges, mail].filter(Boolean);
-      if (extras.length > 0) {
-        return system + "\n\n" + extras.join("\n\n");
-      }
-      return system;
-    },
-  },
-};
+export default function gascityOmpExtension(pi: ExtensionAPI) {
+  pi.on("session_start", (_event, ctx) => {
+    run(["prime", "--hook"], ctx.cwd, providerSessionEnv(ctx));
+  });
+
+  pi.on("session_compact", (_event, ctx) => {
+    run(["prime", "--hook"], ctx.cwd, providerSessionEnv(ctx));
+  });
+
+  pi.on("before_agent_start", (event, ctx) => {
+    const nudges = run(["nudge", "drain", "--inject"], ctx.cwd);
+    const mail = run(["mail", "check", "--inject"], ctx.cwd);
+    const systemPrompt = appendSystemPrompt(event.systemPrompt, [nudges, mail]);
+    if (systemPrompt !== event.systemPrompt) {
+      return { systemPrompt };
+    }
+  });
+}

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -345,6 +345,7 @@ func TestBuiltinProvidersResumeFlags(t *testing.T) {
 		{"amp", "threads continue", "subcommand"},
 		{"opencode", "--session", "flag"},
 		{"auggie", "--resume", "flag"},
+		{"omp", "--resume", "flag"},
 	}
 	providers := BuiltinProviders()
 	for _, tt := range tests {

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -440,6 +440,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		ProcessNames:     []string{"omp", "node", "bun"},
 		SupportsHooks:    true,
 		InstructionsFile: "AGENTS.md",
+		ResumeFlag:       "--resume",
+		ResumeStyle:      "flag",
 	},
 }
 


### PR DESCRIPTION
## Summary

- Teach the builtin OMP provider to resume with `omp --resume <session_key>`.
- Generalize `gc prime --hook` provider-session capture from Gemini-only `GEMINI_SESSION_ID` to provider-neutral `GC_PROVIDER_SESSION_ID`, while preserving the Gemini fallback.
- Update the OMP hook overlay to the current OMP extension API so `session_start` / `session_compact` pass `ctx.sessionManager.getSessionId()` into `gc prime --hook`.

Principle: this keeps session continuity in the Session primitive / provider transport layer. It does not add role awareness or policy; it just persists the provider's durable session identity in the existing bead `session_key` field.

Prior art: `engdocs/architecture/session.md` describes session resume/crash adoption as part of the Session primitive, and `engdocs/design/provider-inheritance.md` calls out missing `ResumeFlag` / `ResumeStyle` inheritance as a provider recovery failure mode.

Alternative considered: relying on OMP `autoResume`. Rejected because it is cwd/mtime based and does not bind a concrete provider conversation to the Gas City session bead.

## Testing

- [x] `go test ./internal/config -run 'TestBuiltinProviders(ResumeFlags|SessionIDFlag)$' -count=1`
- [x] `go test ./cmd/gc -run 'TestDoPrimeHookPersists(GenericProviderSessionKey|GeminiHookPersistsProviderSessionKey)$|TestMaterializeBuiltinPacksOmpHookPublishesProviderSessionID' -count=1`
- [x] `bun --check internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts`
- [x] `make build`
- [x] `make vet`
- [ ] `make check` — attempted on macOS; blocked by pre-existing upstream-main/carry failure in non-Linux lint/test surface (`cmd/gc/fs_pressure_other.go` unused lint, plus existing cmd/gc Darwin process tests). Targeted tests above cover this PR's changed behavior.

## Checklist

- [x] Linked an issue, or explained why one is not needed: no dedicated upstream issue; adjacent session-key continuity issues include #2112.
- [x] Added or updated tests for behavior changes.
- [x] Updated docs for user-facing changes: not needed; config schema unchanged and OMP support uses existing provider fields.
- [x] Called out breaking changes or migration notes: none. Existing Gemini capture remains supported.