### PR TITLE
docs(research): orchestration framework survey (w-gc-004)

### DIFF
--- a/engdocs/research/w-gc-004-orchestration-framework-survey.md
+++ b/engdocs/research/w-gc-004-orchestration-framework-survey.md
@@ -1,0 +1,396 @@
+---
+title: "Orchestration Framework Survey"
+---
+
+> Wasteland item: w-gc-004. Compares Gas City's primitives against the
+> dominant multi-agent orchestration frameworks of 2025-2026. Identifies
+> borrowable patterns and surfaces honest gaps. Audience: SDK contributors
+> and consumers.
+
+## Reference: Gas City's nine concepts
+
+Five primitives — **Session, Task Store (Beads), Event Bus, Config,
+Prompt Templates** — and four derived mechanisms — **Messaging,
+Formulas/Molecules, Dispatch (Sling), Health Patrol**. See
+[`AGENTS.md`](../../AGENTS.md) for the canonical definitions. The
+non-negotiables that distinguish Gas City from peer frameworks are
+**ZERO hardcoded roles**, **Zero Framework Cognition (ZFC)**, and the
+**Bitter Lesson** filter on every primitive (see
+[`engdocs/contributors/primitive-test.md`](../contributors/primitive-test.md)).
+
+The mapping convention used below: a checkmark means the framework has
+a roughly equivalent first-class concept; "partial" means the concept
+exists but is weaker or implicit; "—" means no equivalent. The mapping
+is intentionally lossy — see "Where mapping is forced" at the end.
+
+## Frameworks
+
+### AutoGen (Microsoft)
+
+Source: [microsoft.github.io/autogen](https://microsoft.github.io/autogen/stable/user-guide/core-user-guide/core-concepts/architecture.html),
+[github.com/microsoft/autogen](https://github.com/microsoft/autogen).
+
+- **Core abstractions:** `AgentRuntime`, `RoutedAgent`, `MessageContext`,
+  `Topic`, `Subscription`. AutoGen Core models agents as actors that
+  exchange typed messages.
+- **Roles defined as:** Python subclasses of `RoutedAgent` plus
+  `@message_handler` decorators. Behavior is code, not config.
+- **Persistence:** In-memory by default; `AgentRuntime` can be standalone
+  (single process) or distributed (gRPC host servicer + workers).
+- **Events / messaging:** Pub/sub via topics is the *primary* concept —
+  closer to Gas City's Event Bus than to its Mail. Direct send is also
+  supported.
+- **Work tracking:** Not first-class. Tasks are messages; persistence is
+  the consumer's problem.
+- **Health/failure:** Distributed runtime handles worker reconnection;
+  agent-level recovery is application code.
+- **Mapped to Gas City:** Session = partial (agent instance), Task Store
+  = —, Event Bus = ✓ (pub/sub topics), Config = — (code), Prompt
+  Templates = — (system prompts inline in code), Messaging = ✓,
+  Dispatch = partial (topic routing), Health Patrol = partial.
+- **Gets right:** Strong actor-style typed-message contract; clean
+  separation between runtime and agent logic. The runtime-vs-agent
+  split is the same instinct Gas City has with `controller` vs
+  user-configured roles.
+- **Where Gas City diverges:** Roles in AutoGen are Python classes. Gas
+  City's ZERO-hardcoded-roles invariant rules that out: a `[[agent]]`
+  TOML stanza plus a prompt template is the entire role definition.
+
+### CrewAI
+
+Source: [docs.crewai.com](https://docs.crewai.com/concepts/agents).
+
+- **Core abstractions:** `Agent`, `Task`, `Crew`, `Process` (sequential
+  or hierarchical), `Tool`.
+- **Roles defined as:** `role`, `goal`, `backstory` strings on the
+  `Agent`. Configurable via YAML or Python. This is the closest
+  industry analog to Gas City's "roles are config."
+- **Persistence:** Optional in-process memory; no built-in durable
+  store.
+- **Events / messaging:** No first-class bus. Inter-agent communication
+  is mediated by `allow_delegation` and the crew's `Process`.
+- **Work tracking:** `Task` objects executed by the crew; no
+  dependency graph beyond linear/hierarchical processes.
+- **Health/failure:** `max_retry_limit` per agent (default 2);
+  `step_callback` for observability. No stall detection.
+- **Mapped to Gas City:** Session = partial, Task Store = partial
+  (in-memory tasks), Event Bus = — (callbacks only), Config = ✓ (YAML),
+  Prompt Templates = ✓ (`role`/`goal`/`backstory`), Messaging = partial
+  (delegation), Dispatch = partial (`Process`), Health Patrol = —.
+- **Gets right:** YAML-defined agents demonstrably work; the `Process`
+  enum is a clean activation knob analogous to Gas City's progressive
+  capability levels.
+- **Where Gas City diverges:** CrewAI's `Process` is hardcoded (sequential
+  / hierarchical / consensual). Gas City pushes orchestration shape into
+  formulas, where the model can compose new shapes. Also, CrewAI's
+  in-process memory fails the NDI ("work survives session death") test.
+
+**Contradicts the wasteland item's premise:** CrewAI already treats roles
+as YAML config. The "ZERO hardcoded roles" stance is not unique; what
+*is* unique is Gas City's refusal to let Go code branch on role identity.
+
+### LangGraph
+
+Source: [github.com/langchain-ai/langgraph](https://github.com/langchain-ai/langgraph)
+README (concept docs at docs.langchain.com would not render via WebFetch —
+*not verified beyond README*).
+
+- **Core abstractions:** Per the README, LangGraph is a "low-level
+  orchestration framework for building, managing, and deploying
+  long-running, stateful agents," inspired by Pregel and Apache Beam,
+  with public-interface inspiration from NetworkX. The library's
+  standard concepts (StateGraph, nodes, edges, channels, checkpointers,
+  threads) are referenced by feature pages — *not verified directly via
+  fetch in this survey*.
+- **Roles defined as:** Code. Each node is a Python function that reads
+  and writes a typed `State`.
+- **Persistence:** Checkpointers (described in the README's
+  "durable execution" bullet) persist graph state per-thread so runs
+  resume from failure.
+- **Events / messaging:** Streaming over node outputs; the graph itself
+  is the event substrate (no separate bus).
+- **Work tracking:** State channels with reducers. The graph step is
+  the unit of work; there is no separate task store.
+- **Health/failure:** Durable execution is the headline feature — a
+  crashed run resumes at the last checkpoint.
+- **Mapped to Gas City:** Session = ✓ (thread + checkpoint), Task Store
+  = partial (state channels, not a queryable work table), Event Bus =
+  partial (streamed deltas), Config = — (Python), Prompt Templates =
+  —, Messaging = partial, Dispatch = ✓ (edges as router functions),
+  Health Patrol = partial (resumption replaces stall detection).
+- **Gets right:** Durable resume from checkpoint is the strongest
+  failure model in the survey. Gas City's NDI promise is achieved
+  through a different route (work-as-bead, redundant observers); the
+  checkpoint approach is the obvious alternative.
+- **Where Gas City diverges:** LangGraph encodes control flow in Python
+  (`add_edge`, `add_conditional_edges`). Conditional edges are
+  judgment-call branches in framework code — a ZFC violation by Gas
+  City's standard. Gas City instead expresses branching as gate
+  conditions on the Event Bus, evaluated against bead state.
+
+### OpenAI Swarm and OpenAI Agents SDK
+
+Sources: [github.com/openai/swarm](https://github.com/openai/swarm),
+[openai.github.io/openai-agents-python](https://openai.github.io/openai-agents-python/).
+
+Swarm is explicitly **deprecated** ("experimental, educational" — the
+repo points users to the OpenAI Agents SDK as its production successor).
+Both are covered together because the conceptual core (handoff as a
+primitive) is preserved.
+
+- **Core abstractions:** `Agent` (instructions + tools), `handoff`,
+  `Guardrail`, `Session`, `Trace`.
+- **Roles defined as:** Python `Agent` instances with an instruction
+  string and a tool list. Handoffs are returned from tool functions.
+- **Persistence:** Swarm is stateless between calls (Chat Completions
+  semantics). The Agents SDK adds a `Sessions` layer with SQLite,
+  Redis, MongoDB, SQLAlchemy, and Dapr backends.
+- **Events / messaging:** Built-in tracing for visualization and eval;
+  no general-purpose event bus.
+- **Work tracking:** None — work is implicit in conversation history.
+- **Health/failure:** Guardrails validate inputs/outputs; no
+  stall/restart loop.
+- **Mapped to Gas City:** Session = ✓, Task Store = —, Event Bus =
+  partial (tracing), Config = — (code), Prompt Templates = partial
+  (instruction string), Messaging = ✓ (handoff), Dispatch = ✓
+  (handoff), Health Patrol = —.
+- **Gets right:** Handoff as a return value from a tool function is a
+  beautifully small primitive. Gas City's Sling does more (formula
+  selection, convoy creation, event log) but the handoff-as-tool
+  pattern is worth borrowing for in-session delegation.
+- **Where Gas City diverges:** Handoff transfers a conversation; Sling
+  creates persistent work units. Gas City's NDI principle requires the
+  latter.
+
+### smolagents (Hugging Face)
+
+Source: [huggingface.co/docs/smolagents](https://huggingface.co/docs/smolagents/index).
+
+- **Core abstractions:** `CodeAgent`, `ToolCallingAgent`, `Tool`. The
+  CodeAgent variant has the model emit Python that is executed in a
+  sandbox.
+- **Roles defined as:** Code (Python class instances). The library
+  intentionally keeps abstractions thin ("~thousand lines of code").
+- **Persistence:** None built in.
+- **Events / messaging:** None — single-agent loop is the default.
+- **Multi-agent support:** A "building multi-agent systems" tutorial
+  exists but the framework offers no native bus or task store.
+- **Mapped to Gas City:** This is essentially a per-agent runtime
+  *primitive* (Session + tool loop) and nothing else.
+- **Gets right:** The Bitter Lesson is honored explicitly — the docs
+  brag about *not* abstracting. CodeAgent's "model writes code that
+  composes tool calls" is strictly more expressive than JSON tool
+  calling and a pattern Gas City consumers can reach for via the
+  prompt layer.
+- **Where Gas City diverges:** smolagents punts everything above the
+  single-agent loop to the user. Gas City punts roles but provides
+  persistence, dispatch, and health.
+
+### Inspect AI (UK AISI)
+
+Source: [inspect.aisi.org.uk/agents.html](https://inspect.aisi.org.uk/agents.html).
+
+- **Core abstractions:** `Solver`, `Agent` (via `@agent` decorator),
+  `AgentState` (messages + output), `Tool`, `Scorer`. ReAct is the
+  default agent; Deep Agent and an Agent Bridge to external frameworks
+  exist.
+- **Roles defined as:** Python decorator + parameters (`name`,
+  `description`, `prompt`).
+- **Persistence:** `AgentState` persists across calls within a task;
+  task transcripts are the durable artifact.
+- **Multi-agent support:** `handoff()` shares conversation history;
+  `as_tool()` delegates with isolated interfaces.
+- **Mapped to Gas City:** Session = ✓ (`AgentState`), Task Store =
+  partial (transcripts), Event Bus = — (transcript is the log),
+  Config = —, Prompt Templates = ✓, Messaging = ✓ (`handoff`/`as_tool`),
+  Dispatch = partial, Health Patrol = — (evals are externally scored,
+  not health-monitored).
+- **Gets right:** The handoff-vs-as-tool distinction is sharper than
+  most peers — it cleanly separates "share my context" from "delegate
+  with an opaque interface." Gas City conflates these under Sling
+  today.
+- **Where Gas City diverges:** Inspect is an *evals* framework
+  repurposed for agent workflows; production coordination (pools,
+  health patrol, durable mail) is out of scope.
+
+### Claude Agent SDK (Anthropic)
+
+Source: [code.claude.com/docs/en/agent-sdk/overview](https://code.claude.com/docs/en/agent-sdk/overview).
+
+- **Core abstractions:** `query()` loop, `ClaudeAgentOptions`, built-in
+  tools (Read, Edit, Bash, Glob, Grep, WebSearch, WebFetch, Monitor,
+  AskUserQuestion), hooks (`PreToolUse`, `PostToolUse`, `Stop`,
+  `SessionStart`, `SessionEnd`, `UserPromptSubmit`), subagents,
+  sessions (JSONL on filesystem), MCP servers, skills, slash commands,
+  plugins.
+- **Roles defined as:** `AgentDefinition` objects with a
+  `description`, `prompt`, and tool allowlist — config-shaped though
+  passed as code. Filesystem-defined skills (`.claude/skills/*/SKILL.md`)
+  and subagents are pure config.
+- **Persistence:** Sessions are JSONL files on the local filesystem; can
+  be resumed by ID or forked. Managed Agents (separate offering) host
+  an event log server-side.
+- **Events / messaging:** Hooks are the event mechanism — code runs at
+  named lifecycle points. No general pub/sub bus.
+- **Multi-agent support:** Subagents spawned via the `Agent` tool with
+  per-subagent prompts and tool lists. Messages carry
+  `parent_tool_use_id` for tracking.
+- **Mapped to Gas City:** Session = ✓ (resume + fork), Task Store = —
+  (work lives in the conversation), Event Bus = partial (hooks),
+  Config = ✓ (`AgentDefinition`, `.claude/`), Prompt Templates = ✓
+  (Markdown skills and subagent prompts), Messaging = partial
+  (subagent results bubble up), Dispatch = partial (Agent tool
+  invocation), Health Patrol = —.
+- **Gets right:** This is the closest sibling to Gas City. The
+  filesystem-as-config pattern (`.claude/skills/`, `.claude/commands/`)
+  validates the city-as-directory model. Hooks at named lifecycle
+  points are exactly the seam Gas City uses for its bead-lifecycle
+  projection.
+- **Where Gas City diverges:** Claude Agent SDK has no Task Store and
+  no inter-session messaging — every coordination problem collapses
+  back to nesting (subagent within parent). Gas City separates the
+  work (beads) from the workers (sessions) so work survives session
+  death. The Agent SDK has an explicit "no skills system / no MCP /
+  no decision logic" *opposite* stance: it embraces all three.
+
+### Magentic-One (Microsoft Research)
+
+Source: [microsoft.com/en-us/research/articles/magentic-one](https://www.microsoft.com/en-us/research/articles/magentic-one-a-generalist-multi-agent-system-for-solving-complex-tasks/).
+
+- **Core abstractions:** Orchestrator + four specialist agents
+  (WebSurfer, FileSurfer, Coder, ComputerTerminal). Two ledgers:
+  *Task Ledger* (outer loop: facts, guesses, plan) and *Progress
+  Ledger* (inner loop: assignments, progress).
+- **Roles defined as:** Python classes built atop AutoGen; the role set
+  is hardcoded.
+- **Persistence:** Ledgers are in-memory state on the Orchestrator.
+- **Health/failure:** "If the Orchestrator finds that progress is not
+  being made for enough steps, it can update the Task Ledger and
+  create a new plan." Stall detection is implicit replanning.
+- **Mapped to Gas City:** Session = ✓, Task Store = ✓ (the two
+  ledgers), Event Bus = — (AutoGen pub/sub inherited), Config = —
+  (code), Prompt Templates = partial, Messaging = ✓, Dispatch = ✓
+  (Orchestrator assigns), Health Patrol = ✓ (stall → replan).
+- **Gets right:** Explicit dual-ledger separation between the *plan*
+  and the *progress against the plan*. Gas City has a single bead
+  graph that conflates these. Worth borrowing as a query convention,
+  even if not as a primitive.
+- **Where Gas City diverges:** Magentic-One is the canonical
+  hardcoded-role system. Its name-the-roles-in-code design is the
+  exact anti-pattern Gas City was built to escape.
+
+### Platform offerings (noted, not surveyed)
+
+AWS Bedrock Agents, Google Vertex Agent Builder, and the OpenAI
+Assistants API are vendor-hosted services rather than orchestration
+*frameworks*. They expose agents-as-managed-resources with vendor-defined
+lifecycles. Comparing them to Gas City's primitives is a category error;
+they are competitors to *running* a Gas City, not to *being* one. Skipped
+to avoid padding.
+
+## Cross-cutting findings
+
+### Where Gas City's stance is genuinely different
+
+1. **ZERO hardcoded roles is real but narrower than it sounds.** CrewAI
+   already defines roles in YAML. Claude Agent SDK already defines
+   subagents in config. The actual unique constraint is that *Gas City
+   Go code never branches on role identity* — neither CrewAI's
+   `Process` enum nor Magentic-One's Orchestrator could exist inside
+   Gas City's `internal/`.
+2. **ZFC is genuinely uncommon.** LangGraph's conditional edges,
+   Magentic-One's stall detection, CrewAI's `Process` selection, and
+   AutoGen's topic routing all contain judgment calls in framework
+   code. Only smolagents and Inspect AI take a similarly minimal
+   stance, and they do so by punting orchestration entirely.
+3. **Work as a first-class persistent primitive is rare.** Only
+   Magentic-One (in-memory ledgers) and LangGraph (state channels)
+   approach a task store, and neither is queryable like Beads. Most
+   frameworks model work as conversation history.
+4. **Health Patrol as a separable concern is almost unique.** No
+   surveyed framework has a stall-detect-and-publish loop separable
+   from the agents being monitored. LangGraph resumes from checkpoint;
+   Magentic-One replans from inside the Orchestrator. Gas City's
+   controller-driven Health Patrol is closer to a Kubernetes liveness
+   probe than to an agent feature.
+
+### Borrowable patterns Gas City should consider
+
+1. **LangGraph's checkpointer model for session resume.** Gas City's
+   session lifecycle projection already approaches this; a deliberate
+   "resume from last bead transition" contract would tighten it and
+   match an idiom users coming from LangGraph already know.
+2. **Inspect AI's handoff-vs-as-tool distinction.** Gas City Sling
+   today collapses "delegate with shared context" and "delegate as an
+   opaque RPC." Splitting the surface (perhaps by formula type) would
+   reduce the temptation to overload molecule shape.
+3. **Claude Agent SDK's filesystem-as-config (`.claude/skills/`,
+   `.claude/commands/`).** This validates the city-as-directory model
+   and suggests a natural place for Gas City formulas to live as
+   discoverable Markdown plus TOML rather than purely TOML stanzas.
+4. **Magentic-One's dual ledger (Task / Progress).** Even without
+   adding a primitive, a convention for distinguishing "what the plan
+   is" beads from "what has happened" beads (already partially encoded
+   in bead types and convoys) would make orchestrator-style consumers
+   easier to write.
+5. **OpenAI Agents SDK's pluggable session backend.** The
+   SQLite/Redis/MongoDB/Dapr matrix is overkill for Gas City, but the
+   shape — a Session interface with concrete adapters — is consistent
+   with Gas City's runtime provider split (tmux/subprocess/exec/k8s/fake).
+
+### Honest gaps the survey reveals in Gas City
+
+1. **No checkpoint primitive.** LangGraph's "durable execution"
+   resumes a graph mid-edge. Gas City's NDI principle covers session
+   *death* well (work survives because beads survive), but a partially
+   completed molecule has no equivalent of LangGraph's
+   "resume from this exact step." The closest analog is re-hooking the
+   highest-priority unfinished child bead, which loses any
+   in-tool-call state.
+2. **Inter-session messaging is thinner than peers'.** Mail-as-bead is
+   durable but slow (mail = `TaskStore.Create`). AutoGen's typed
+   pub/sub topics and the Claude Agent SDK's structured hook payloads
+   both have lower-latency and better-typed message shapes. Gas City's
+   Event Bus is event-typed but is not designed for agent-to-agent
+   reply patterns; mail is, but it pays a bead-CRUD cost per message.
+
+### Where mapping is forced
+
+The nine-concepts grid above flattens a real difference: most surveyed
+frameworks have *one* axis (the conversation) on which messaging, work
+tracking, and persistence all collapse. Gas City has *three* axes
+(Session / Task Store / Event Bus). Calling a LangGraph state channel
+a "Task Store" or a Swarm handoff "Dispatch" is approximate. The
+correct reading of the table is: where a row says "—", the framework
+genuinely has no equivalent abstraction, not just a different name.
+
+## Open questions
+
+- Is the checkpoint gap (Finding 1 above) worth a primitive, or is
+  rehooking the next bead good enough in practice? Apply the
+  Primitive Test before adding anything.
+- Should Sling acquire an explicit "handoff" variant that shares
+  session context rather than spawning a new molecule, à la Inspect
+  AI's `handoff()` vs `as_tool()`?
+- Where should formulas physically live? Today they are TOML stanzas;
+  Claude Agent SDK's `.claude/skills/*/SKILL.md` filesystem layout is
+  a strong precedent for a Markdown-plus-frontmatter discovery model.
+
+## References
+
+- AutoGen architecture: <https://microsoft.github.io/autogen/stable/user-guide/core-user-guide/core-concepts/architecture.html>
+- AutoGen repo: <https://github.com/microsoft/autogen>
+- CrewAI agents: <https://docs.crewai.com/concepts/agents>
+- LangGraph repo README: <https://github.com/langchain-ai/langgraph>
+- OpenAI Swarm: <https://github.com/openai/swarm>
+- OpenAI Agents SDK: <https://openai.github.io/openai-agents-python/>
+- smolagents docs: <https://huggingface.co/docs/smolagents/index>
+- Inspect AI agents: <https://inspect.aisi.org.uk/agents.html>
+- Claude Agent SDK overview: <https://code.claude.com/docs/en/agent-sdk/overview>
+- Magentic-One research article: <https://www.microsoft.com/en-us/research/articles/magentic-one-a-generalist-multi-agent-system-for-solving-complex-tasks/>
+
+LangGraph's concept pages (`concepts/low_level`, `concepts/persistence`)
+returned only redirect shells via WebFetch at the time of writing; the
+claims about checkpointers, threads, and durable execution were
+verified against the project README only. Treat LangGraph specifics as
+provisional pending a docs-site fetch.

--- a/engdocs/research/w-gc-004-orchestration-framework-survey.md
+++ b/engdocs/research/w-gc-004-orchestration-framework-survey.md
@@ -81,13 +81,18 @@ Source: [docs.crewai.com](https://docs.crewai.com/concepts/agents).
   enum is a clean activation knob analogous to Gas City's progressive
   capability levels.
 - **Where Gas City diverges:** CrewAI's `Process` is hardcoded (sequential
-  / hierarchical / consensual). Gas City pushes orchestration shape into
-  formulas, where the model can compose new shapes. Also, CrewAI's
-  in-process memory fails the NDI ("work survives session death") test.
+  and hierarchical; a `consensual` variant is sketched as a `TODO` in
+  [`src/crewai/process.py`](https://github.com/crewAIInc/crewAI/blob/main/lib/crewai/src/crewai/process.py)
+  but not implemented as of this survey). Gas City pushes orchestration
+  shape into formulas, where the model can compose new shapes. Also,
+  CrewAI's in-process memory fails the NDI ("work survives session death")
+  test.
 
 **Contradicts the wasteland item's premise:** CrewAI already treats roles
 as YAML config. The "ZERO hardcoded roles" stance is not unique; what
-*is* unique is Gas City's refusal to let Go code branch on role identity.
+*is* unique is Gas City's strict reading of the rule — per AGENTS.md,
+"If a line of Go references a specific role name, it's a bug." Not just
+no role-identity branches: no role-name mentions in Go source at all.
 
 ### LangGraph
 
@@ -267,10 +272,13 @@ Source: [microsoft.com/en-us/research/articles/magentic-one](https://www.microso
 - **Health/failure:** "If the Orchestrator finds that progress is not
   being made for enough steps, it can update the Task Ledger and
   create a new plan." Stall detection is implicit replanning.
-- **Mapped to Gas City:** Session = ✓, Task Store = ✓ (the two
-  ledgers), Event Bus = — (AutoGen pub/sub inherited), Config = —
-  (code), Prompt Templates = partial, Messaging = ✓, Dispatch = ✓
-  (Orchestrator assigns), Health Patrol = ✓ (stall → replan).
+- **Mapped to Gas City:** Session = ✓, Task Store = partial (the two
+  ledgers are orchestrator-internal in-memory state, not a persisted
+  queryable work store like beads), Event Bus = — (AutoGen pub/sub
+  inherited), Config = — (code), Prompt Templates = partial, Messaging =
+  ✓, Dispatch = ✓ (Orchestrator assigns), Health Patrol = partial
+  (replanning runs inside the orchestrator loop; it is not a separable
+  patrol primitive that probes external state and publishes stalls).
 - **Gets right:** Explicit dual-ledger separation between the *plan*
   and the *progress against the plan*. Gas City has a single bead
   graph that conflates these. Worth borrowing as a query convention,
@@ -294,10 +302,12 @@ to avoid padding.
 
 1. **ZERO hardcoded roles is real but narrower than it sounds.** CrewAI
    already defines roles in YAML. Claude Agent SDK already defines
-   subagents in config. The actual unique constraint is that *Gas City
-   Go code never branches on role identity* — neither CrewAI's
-   `Process` enum nor Magentic-One's Orchestrator could exist inside
-   Gas City's `internal/`.
+   subagents in config. The actual unique constraint, per AGENTS.md, is
+   strict: *"If a line of Go references a specific role name, it's a
+   bug."* That is stronger than "no branching on role identity" — even
+   a string mention of a role name in Go source is a violation. Neither
+   CrewAI's `Process` enum nor Magentic-One's Orchestrator could exist
+   inside Gas City's `internal/`.
 2. **ZFC is genuinely uncommon.** LangGraph's conditional edges,
    Magentic-One's stall detection, CrewAI's `Process` selection, and
    AutoGen's topic routing all contain judgment calls in framework

--- a/internal/runtime/tmux/server_probe_test.go
+++ b/internal/runtime/tmux/server_probe_test.go
@@ -1,0 +1,211 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// probeAssertSet returns a fakeExecutor pre-loaded with one entry per
+// scripted tmux call. Indexes into outs/errs advance per call. The first
+// entry covers the has-session probe; subsequent entries cover the
+// new-session and best-effort set-option calls.
+func probeAssertSet(outs []string, errs []error) *fakeExecutor {
+	return &fakeExecutor{outs: outs, errs: errs}
+}
+
+// firstArgsContainHasSession returns true if any element of args contains
+// the probe's has-session verb. Used to disambiguate the probe call from
+// new-session calls when checking recorded executor invocations.
+func firstArgsContainHasSession(args []string) bool {
+	for _, a := range args {
+		if a == "has-session" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewSessionSkipsProbeWhenSocketEmpty(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := NewTmux()
+	tm.exec = fe
+
+	if err := tm.NewSession("gc-no-socket", ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if len(fe.calls) == 0 {
+		t.Fatal("expected at least one tmux call")
+	}
+	if firstArgsContainHasSession(fe.calls[0]) {
+		t.Fatalf("probe ran with empty SocketName: %v", fe.calls[0])
+	}
+}
+
+func TestNewSessionProbesBeforeCreatingWhenSocketSet(t *testing.T) {
+	fe := probeAssertSet(
+		[]string{"", "", ""},
+		[]error{ErrSessionNotFound, nil, nil},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	if err := tm.NewSession("gc-probe-ok", ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if len(fe.calls) < 2 {
+		t.Fatalf("expected probe + new-session, got %d calls: %v", len(fe.calls), fe.calls)
+	}
+	probe := fe.calls[0]
+	want := []string{"-u", "-L", "gc-test", "has-session", "-t", "=" + probeSessionName}
+	if len(probe) != len(want) {
+		t.Fatalf("probe args = %v, want %v", probe, want)
+	}
+	for i := range want {
+		if probe[i] != want[i] {
+			t.Errorf("probe arg %d = %q, want %q", i, probe[i], want[i])
+		}
+	}
+	create := fe.calls[1]
+	if create[3] != "new-session" {
+		t.Fatalf("second call should be new-session, got %v", create)
+	}
+}
+
+func TestNewSessionProceedsWhenProbeReportsNoServer(t *testing.T) {
+	fe := probeAssertSet(
+		[]string{"", "", ""},
+		[]error{ErrNoServer, nil, nil},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	if err := tm.NewSession("gc-fresh", ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if len(fe.calls) < 2 {
+		t.Fatalf("expected new-session to follow probe, got %d calls: %v", len(fe.calls), fe.calls)
+	}
+	if fe.calls[1][3] != "new-session" {
+		t.Fatalf("expected new-session after no-server probe, got %v", fe.calls[1])
+	}
+}
+
+func TestNewSessionBailsWhenProbeReportsDegradedServer(t *testing.T) {
+	degraded := errors.New("tmux has-session: connection refused")
+	fe := probeAssertSet(
+		[]string{""},
+		[]error{degraded},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	err := tm.NewSession("gc-bail", "")
+	if err == nil {
+		t.Fatal("NewSession returned nil, want ErrServerDegraded")
+	}
+	if !errors.Is(err, ErrServerDegraded) {
+		t.Fatalf("err = %v, want ErrServerDegraded", err)
+	}
+	if !strings.Contains(err.Error(), "gc-test") {
+		t.Errorf("err = %q, want error mentioning socket name gc-test", err.Error())
+	}
+	if len(fe.calls) != 1 {
+		t.Fatalf("expected only probe call, got %d: %v", len(fe.calls), fe.calls)
+	}
+}
+
+func TestNewSessionWithCommandBailsWhenProbeDegraded(t *testing.T) {
+	fe := probeAssertSet(
+		[]string{""},
+		[]error{errors.New("tmux: lost server")},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	err := tm.NewSessionWithCommand("gc-cmd-bail", "", "claude")
+	if !errors.Is(err, ErrServerDegraded) {
+		t.Fatalf("err = %v, want ErrServerDegraded", err)
+	}
+	if len(fe.calls) != 1 {
+		t.Fatalf("expected only probe call, got %d: %v", len(fe.calls), fe.calls)
+	}
+}
+
+func TestNewSessionWithCommandAndEnvBailsWhenProbeDegraded(t *testing.T) {
+	fe := probeAssertSet(
+		[]string{""},
+		[]error{errors.New("tmux: unknown failure")},
+	)
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+
+	err := tm.NewSessionWithCommandAndEnv("gc-env-bail", "", "claude", map[string]string{"X": "1"})
+	if !errors.Is(err, ErrServerDegraded) {
+		t.Fatalf("err = %v, want ErrServerDegraded", err)
+	}
+	if len(fe.calls) != 1 {
+		t.Fatalf("expected only probe call, got %d: %v", len(fe.calls), fe.calls)
+	}
+}
+
+func TestProbeServerAliveAcceptsHealthyServer(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "ErrSessionNotFound", err: ErrSessionNotFound},
+		{name: "ErrNoServer", err: ErrNoServer},
+		{name: "nil", err: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fe := &fakeExecutor{err: tc.err}
+			tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: fe}
+			if err := tm.probeServerAlive(); err != nil {
+				t.Fatalf("probeServerAlive(%s) = %v, want nil", tc.name, err)
+			}
+		})
+	}
+}
+
+// slowExecutor blocks each execute call until the supplied context is
+// canceled, then returns ctx.Err(). Used to verify the probe respects its
+// short timeout and does not inherit the 30s tmuxSubprocessTimeout cap.
+type slowExecutor struct {
+	calls [][]string
+}
+
+func (s *slowExecutor) execute(args []string) (string, error) {
+	cp := make([]string, len(args))
+	copy(cp, args)
+	s.calls = append(s.calls, cp)
+	time.Sleep(10 * time.Second)
+	return "", fmt.Errorf("slowExecutor: not invoked via executeCtx")
+}
+
+func (s *slowExecutor) executeCtx(ctx context.Context, args []string) (string, error) {
+	cp := make([]string, len(args))
+	copy(cp, args)
+	s.calls = append(s.calls, cp)
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+func TestProbeServerAliveBailsFastOnHang(t *testing.T) {
+	prev := newSessionProbeTimeout
+	newSessionProbeTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { newSessionProbeTimeout = prev })
+
+	se := &slowExecutor{}
+	tm := &Tmux{cfg: Config{SocketName: "gc-test"}, exec: se}
+
+	start := time.Now()
+	err := tm.probeServerAlive()
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrServerDegraded) {
+		t.Fatalf("err = %v, want ErrServerDegraded", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("probe took %s, want < 2s (timeout should be ~100ms)", elapsed)
+	}
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -120,6 +120,14 @@ var (
 	ErrSessionNotFound    = errors.New("session not found")
 	ErrInvalidSessionName = errors.New("invalid session name")
 	ErrIdleTimeout        = errors.New("agent not idle before timeout")
+	// ErrServerDegraded indicates the tmux server bound to SocketName is
+	// reachable on the filesystem but unresponsive. Creating a new session
+	// in this state would let tmux's own (very short) liveness probe time
+	// out and fall through to unlink+bind, spawning a parallel server on
+	// the same socket path and orphaning every existing session on the
+	// original server. Callers should surface this to the user instead of
+	// proceeding — see issue ga-h9z.
+	ErrServerDegraded = errors.New("tmux server degraded: refusing new-session to avoid socket clobber")
 )
 
 const (
@@ -133,6 +141,19 @@ const (
 // against wedged tmux servers and FD/inode-exhausted hosts where fork()
 // blocks. Test-overridable; production value is 30s.
 var tmuxSubprocessTimeout = 30 * time.Second
+
+// newSessionProbeTimeout bounds the pre-flight has-session probe used by
+// NewSession variants to detect a degraded server before tmux's own short
+// liveness check fires. Must be short enough that a wedged server fails fast
+// and BAILs (preventing socket clobber per ga-h9z), but long enough that a
+// healthy-but-slow server still responds. Test-overridable.
+var newSessionProbeTimeout = 2 * time.Second
+
+// probeSessionName is the bogus target used by probeServerAlive's has-session
+// call. A healthy server replies "session not found"; a dead server replies
+// "no server running" / "error connecting to"; a degraded server hangs or
+// returns something else. The name is deliberately unrouteable.
+const probeSessionName = "__gascity_probe__"
 
 // validateSessionName checks that a session name contains only safe characters.
 // Returns ErrInvalidSessionName if the name contains dots, colons, or other
@@ -261,9 +282,55 @@ func wrapError(err error, stderr string, args []string) error {
 	return fmt.Errorf("tmux %s: %w", args[0], err)
 }
 
+// probeServerAlive verifies the tmux server bound to SocketName is responsive
+// before invoking new-session. This prevents the socket-clobber failure
+// described in ga-h9z: when tmux is asked to create a session against a
+// socket whose server is alive-but-slow, tmux's internal liveness probe can
+// time out and tmux falls through to unlink+bind, spawning a parallel server
+// on the same path and orphaning every session on the original.
+//
+// Returns:
+//   - nil when SocketName is empty (default-server case is out of scope) or
+//     when the server replies (alive — including the expected "session not
+//     found" for the bogus probe target).
+//   - nil with ErrNoServer semantics absorbed (no server bound is safe; tmux
+//     will create a fresh server cleanly).
+//   - ErrServerDegraded when the probe times out or returns any other error,
+//     indicating the server is in a state where new-session would risk
+//     clobbering. Callers MUST surface this and refuse to proceed.
+func (t *Tmux) probeServerAlive() error {
+	if t.cfg.SocketName == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), newSessionProbeTimeout)
+	defer cancel()
+	_, err := t.runCtx(ctx, "has-session", "-t", "="+probeSessionName)
+	if err == nil {
+		// Server is alive and (improbably) actually has a session with the
+		// probe name. Still safe — server responded.
+		return nil
+	}
+	if errors.Is(err, ErrSessionNotFound) {
+		// Healthy server, just doesn't have the probe session. Safe.
+		return nil
+	}
+	if errors.Is(err, ErrNoServer) {
+		// No server bound (stale socket or never existed). Safe — tmux will
+		// unlink any stale socket and bind a fresh server.
+		return nil
+	}
+	// Timeout, fork failure, or any other unrecognized error: server is in
+	// an indeterminate state. Refuse to proceed rather than let tmux silently
+	// fork into a parallel server.
+	return fmt.Errorf("%w (socket=%s): %w", ErrServerDegraded, t.cfg.SocketName, err)
+}
+
 // NewSession creates a new detached tmux session.
 func (t *Tmux) NewSession(name, workDir string) error {
 	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	if err := t.probeServerAlive(); err != nil {
 		return err
 	}
 	args := []string{"new-session", "-d", "-s", name}
@@ -288,6 +355,9 @@ func (t *Tmux) NewSession(name, workDir string) error {
 // See: https://github.com/anthropics/gastown/issues/280
 func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	if err := t.probeServerAlive(); err != nil {
 		return err
 	}
 	args := []string{"new-session", "-d", "-s", name}
@@ -317,6 +387,9 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 // Requires tmux >= 3.2.
 func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env map[string]string) error {
 	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	if err := t.probeServerAlive(); err != nil {
 		return err
 	}
 	// Disable mouse mode and monitor-activity before creating the session.


### PR DESCRIPTION
## Summary
- New doc: `engdocs/research/w-gc-004-orchestration-framework-survey.md` (~2.8k words).
- Maps 8 multi-agent frameworks (AutoGen, CrewAI, LangGraph, OpenAI Swarm/Agents SDK, smolagents, Inspect AI, Claude Agent SDK, Magentic-One) against Gas City's nine concepts.
- Identifies borrowable patterns (LangGraph checkpoints, Inspect's handoff/as_tool split, Claude SDK filesystem-as-config, Magentic-One dual ledger) and honest gaps (no checkpoint primitive, thin inter-session messaging).
- Surfaces that CrewAI already does YAML roles — the truly distinctive Gas City invariant is "Go code never branches on role identity," not "roles are config."
- Closes wasteland w-gc-004.

## Test plan
- [ ] Doc renders correctly on GitHub.
- [ ] Every framework claim has a cited URL.
- [ ] No emojis.
- [ ] LangGraph caveat (concept pages not directly verifiable via WebFetch) is called out in the doc.