### PR TITLE
Fix post-merge JSON review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The built-in Claude provider's `model = "opus"` option now emits
   `claude-opus-4-7`. Cities that rely on the `opus` alias should expect the
   new model target after upgrading.
+- Several CLI/operator behaviors landed with the JSON-summary work and are now
+  explicit release-note items: generated init configs may include the new JSON
+  root-command support, prime hooks can infer the agent from `.gc/agents`
+  workdir layouts, and `gc hook` defensively filters future-deferred or
+  dependency-blocked candidates from JSON work-query output before surfacing
+  work to agents.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workdir layouts, and `gc hook` defensively filters future-deferred or
   dependency-blocked candidates from JSON work-query output before surfacing
   work to agents.
+- CLI JSON errors now use the shared one-object-per-line writer on stdout,
+  preserving literal `<`, `>`, and `&` characters; stderr still receives a
+  machine-readable diagnostic.
 
 ### Fixed
 

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -69,21 +69,23 @@ or ID. Subject is required unless --auto is set.`,
 			return cobra.RangeArgs(1, 2)(cmd, args)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			if jsonOut && hookFormat != "" {
+				fmt.Fprintln(stderr, "gc handoff: --json cannot be used with --hook-format") //nolint:errcheck // best-effort stderr
+				return errExit
+			}
 			out := stdout
 			if jsonOut {
 				out = io.Discard
 			}
-			if cmdHandoff(args, target, auto, hookFormat, out, stderr) != 0 {
+			outcome := cmdHandoffWithOutcome(args, target, auto, hookFormat, out, stderr)
+			if outcome.code != 0 {
 				return errExit
 			}
 			if jsonOut {
-				_ = writeCLIJSONLine(stdout, handoffJSONResult{
-					SchemaVersion: "1",
-					Mode:          handoffJSONMode(target, auto),
-					Target:        target,
-					Auto:          auto,
-					Subject:       handoffJSONSubject(args, auto),
-				})
+				if err := writeCLIJSONLine(stdout, handoffJSONFromOutcome(outcome)); err != nil {
+					fmt.Fprintf(stderr, "gc handoff: encode JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
+				}
 			}
 			return nil
 		},
@@ -96,57 +98,61 @@ or ID. Subject is required unless --auto is set.`,
 }
 
 type handoffJSONResult struct {
-	SchemaVersion string `json:"schema_version"`
-	Mode          string `json:"mode"`
-	Target        string `json:"target,omitempty"`
-	Auto          bool   `json:"auto"`
-	Subject       string `json:"subject,omitempty"`
+	SchemaVersion    string `json:"schema_version"`
+	OK               bool   `json:"ok"`
+	Mode             string `json:"mode"`
+	Target           string `json:"target,omitempty"`
+	Recipient        string `json:"recipient,omitempty"`
+	Auto             bool   `json:"auto"`
+	Subject          string `json:"subject,omitempty"`
+	MailBeadID       string `json:"mail_bead_id,omitempty"`
+	RestartRequested bool   `json:"restart_requested"`
+	Action           string `json:"action,omitempty"`
 }
 
-func handoffJSONMode(target string, auto bool) string {
-	if target != "" {
-		return "remote"
+func handoffJSONFromOutcome(outcome handoffOutcome) handoffJSONResult {
+	return handoffJSONResult{
+		SchemaVersion:    "1",
+		OK:               outcome.code == 0,
+		Mode:             outcome.mode,
+		Target:           outcome.target,
+		Recipient:        outcome.recipient,
+		Auto:             outcome.auto,
+		Subject:          outcome.subject,
+		MailBeadID:       outcome.mailBeadID,
+		RestartRequested: outcome.restartRequested,
+		Action:           outcome.action,
 	}
-	if auto {
-		return "auto"
-	}
-	return "self"
-}
-
-func handoffJSONSubject(args []string, auto bool) string {
-	if len(args) > 0 {
-		return args[0]
-	}
-	if auto {
-		return "context cycle"
-	}
-	return "HANDOFF: context cycle"
 }
 
 func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdout, stderr io.Writer) int {
+	return cmdHandoffWithOutcome(args, target, auto, hookFormat, stdout, stderr).code
+}
+
+func cmdHandoffWithOutcome(args []string, target string, auto bool, hookFormat string, stdout, stderr io.Writer) handoffOutcome {
 	if target != "" {
 		if auto {
 			fmt.Fprintln(stderr, "gc handoff: --auto cannot be used with --target") //nolint:errcheck // best-effort stderr
-			return 1
+			return handoffOutcome{code: 1}
 		}
-		return cmdHandoffRemote(args, target, stdout, stderr)
+		return cmdHandoffRemoteWithOutcome(args, target, stdout, stderr)
 	}
 
 	current, err := currentSessionRuntimeTarget()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1}
 	}
 
 	store, err := openCityStoreAt(current.cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err)                    //nolint:errcheck // best-effort stderr
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1}
 	}
 	rec := openCityRecorderAt(current.cityPath, stderr)
 	if auto {
-		return doHandoffAuto(store, rec, current.display, args, hookFormat, stdout, stderr)
+		return doHandoffAutoWithOutcome(store, rec, current.display, args, hookFormat, stdout, stderr)
 	}
 
 	sp := newSessionProvider()
@@ -156,45 +162,50 @@ func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdo
 
 	outcome := doHandoffWithOutcome(store, rec, dops, persistRestart, current.display, current.sessionName, args, stdout, stderr)
 	if outcome.code != 0 {
-		return outcome.code
+		return outcome
 	}
 	if !outcome.restartRequested {
-		return 0
+		return outcome
 	}
 
 	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	return waitForControllerRestart(sigCtx, dops, current.sessionName, "gc handoff",
+	outcome.code = waitForControllerRestart(sigCtx, dops, current.sessionName, "gc handoff",
 		controllerRestartPollInterval, controllerRestartTimeout(cfg), stderr)
+	return outcome
 }
 
 // cmdHandoffRemote sends handoff mail to a remote session and kills its runtime.
 // Returns immediately (non-blocking). The reconciler restarts the target.
 func cmdHandoffRemote(args []string, target string, stdout, stderr io.Writer) int {
+	return cmdHandoffRemoteWithOutcome(args, target, stdout, stderr).code
+}
+
+func cmdHandoffRemoteWithOutcome(args []string, target string, stdout, stderr io.Writer) handoffOutcome {
 	targetInfo, err := resolveSessionRuntimeTarget(target, stderr)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1, mode: "remote", target: target}
 	}
 
 	store, code := openCityStore(stderr, "gc handoff")
 	if store == nil {
-		return code
+		return handoffOutcome{code: code, mode: "remote", target: targetInfo.display}
 	}
 	cityPath, err := resolveCity()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return handoffOutcome{code: 1, mode: "remote", target: targetInfo.display}
 	}
 	cfg, _ := loadCityConfig(cityPath, stderr)
 	sender, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc handoff")
 	if !ok {
-		return 1
+		return handoffOutcome{code: 1, mode: "remote", target: targetInfo.display}
 	}
 
 	sp := newSessionProvider()
 	rec := openCityRecorder(stderr)
-	return doHandoffRemote(store, rec, sp, targetInfo.sessionName, targetInfo.display, sender, args, stdout, stderr)
+	return doHandoffRemoteWithOutcome(store, rec, sp, targetInfo.sessionName, targetInfo.display, sender, args, stdout, stderr)
 }
 
 func sessionRestartPersister(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, target string) func() error {
@@ -213,6 +224,13 @@ func sessionRestartPersister(cityPath string, store beads.Store, sp runtime.Prov
 type handoffOutcome struct {
 	code             int
 	restartRequested bool
+	mode             string
+	target           string
+	recipient        string
+	auto             bool
+	subject          string
+	mailBeadID       string
+	action           string
 }
 
 // doHandoff sends a handoff mail to self and requests restart when the
@@ -228,26 +246,37 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 ) handoffOutcome {
 	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "HANDOFF: context cycle", stderr)
 	if !ok {
-		return handoffOutcome{code: 1}
+		return handoffOutcome{code: 1, mode: "self", recipient: sessionAddress}
+	}
+	outcome := handoffOutcome{
+		code:       0,
+		mode:       "self",
+		recipient:  sessionAddress,
+		subject:    b.Title,
+		mailBeadID: b.ID,
 	}
 
 	restartable, err := sessionRestartableByController(store, sessionName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
-		return handoffOutcome{code: 1}
+		outcome.code = 1
+		return outcome
 	}
 	if !restartable {
 		if err := clearRestartRequest(store, dops, sessionName); err != nil {
 			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
-			return handoffOutcome{code: 1}
+			outcome.code = 1
+			return outcome
 		}
 		fmt.Fprintf(stdout, "Handoff: sent mail %s (named session; restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
-		return handoffOutcome{code: 0}
+		outcome.action = "restart_skipped"
+		return outcome
 	}
 
 	if err := dops.setRestartRequested(sessionName); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: setting restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
-		return handoffOutcome{code: 1}
+		outcome.code = 1
+		return outcome
 	}
 	// Also persist the request through the worker boundary so it survives
 	// tmux session death. Non-fatal: the runtime flag above is primary.
@@ -264,21 +293,37 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 	})
 
 	fmt.Fprintf(stdout, "Handoff: sent mail %s, requesting restart...\n", b.ID) //nolint:errcheck // best-effort stdout
-	return handoffOutcome{code: 0, restartRequested: true}
+	outcome.restartRequested = true
+	outcome.action = "restart_requested"
+	return outcome
 }
 
 // doHandoffAuto sends handoff mail to self without requesting restart.
 func doHandoffAuto(store beads.Store, rec events.Recorder, sessionAddress string, args []string, hookFormat string, stdout, stderr io.Writer) int {
+	return doHandoffAutoWithOutcome(store, rec, sessionAddress, args, hookFormat, stdout, stderr).code
+}
+
+func doHandoffAutoWithOutcome(store beads.Store, rec events.Recorder, sessionAddress string, args []string, hookFormat string, stdout, stderr io.Writer) handoffOutcome {
 	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "context cycle", stderr)
 	if !ok {
-		return 1
+		return handoffOutcome{code: 1, mode: "auto", auto: true, recipient: sessionAddress}
+	}
+	outcome := handoffOutcome{
+		code:       0,
+		mode:       "auto",
+		recipient:  sessionAddress,
+		auto:       true,
+		subject:    b.Title,
+		mailBeadID: b.ID,
+		action:     "restart_skipped",
 	}
 	message := fmt.Sprintf("Handoff: sent auto mail %s (restart skipped).\n", b.ID)
 	if err := writeProviderHookContextForEvent(stdout, hookFormat, "PreCompact", message); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: writing hook output: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		outcome.code = 1
+		return outcome
 	}
-	return 0
+	return outcome
 }
 
 func createHandoffMail(store beads.Store, rec events.Recorder, senderAddress, recipientAddress string, args []string, defaultSubject string, stderr io.Writer) (beads.Bead, bool) {
@@ -376,38 +421,58 @@ func clearRestartRequest(store beads.Store, dops drainOps, sessionName string) e
 func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider,
 	sessionName, targetAddress, sender string, args []string, stdout, stderr io.Writer,
 ) int {
+	return doHandoffRemoteWithOutcome(store, rec, sp, sessionName, targetAddress, sender, args, stdout, stderr).code
+}
+
+func doHandoffRemoteWithOutcome(store beads.Store, rec events.Recorder, sp runtime.Provider,
+	sessionName, targetAddress, sender string, args []string, stdout, stderr io.Writer,
+) handoffOutcome {
 	b, ok := createHandoffMail(store, rec, sender, targetAddress, args, "HANDOFF: context cycle", stderr)
 	if !ok {
-		return 1
+		return handoffOutcome{code: 1, mode: "remote", target: targetAddress, recipient: targetAddress}
+	}
+	outcome := handoffOutcome{
+		code:       0,
+		mode:       "remote",
+		target:     targetAddress,
+		recipient:  targetAddress,
+		subject:    b.Title,
+		mailBeadID: b.ID,
 	}
 
 	restartable, err := sessionRestartableByController(store, sessionName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		outcome.code = 1
+		return outcome
 	}
 	if !restartable {
 		if err := clearRestartRequest(store, newDrainOps(sp), sessionName); err != nil {
 			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
+			outcome.code = 1
+			return outcome
 		}
 		fmt.Fprintf(stdout, "Handoff: sent mail %s to %s (named session; kill skipped because the controller cannot restart it)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
-		return 0
+		outcome.action = "kill_skipped"
+		return outcome
 	}
 
 	// Kill target session (reconciler restarts it).
 	running, err := workerSessionTargetRunningWithConfig("", store, sp, nil, sessionName)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: observing %s: %v\n", targetAddress, err) //nolint:errcheck // best-effort stderr
-		return 1
+		outcome.code = 1
+		return outcome
 	}
 	if !running {
 		fmt.Fprintf(stdout, "Handoff: sent mail %s to %s (session not running; will be delivered on next start)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
-		return 0
+		outcome.action = "delivery_pending"
+		return outcome
 	}
 	if err := workerKillSessionTargetWithConfig("", store, sp, nil, sessionName); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: killing %s: %v\n", targetAddress, err) //nolint:errcheck // best-effort stderr
-		return 1
+		outcome.code = 1
+		return outcome
 	}
 	sessionID, resolveErr := resolveSessionID(store, sessionName)
 	if resolveErr != nil {
@@ -425,7 +490,8 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 	})
 
 	fmt.Fprintf(stdout, "Handoff: sent mail %s to %s, killed session (reconciler will restart)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
-	return 0
+	outcome.action = "killed"
+	return outcome
 }
 
 // handoffThreadID generates a unique thread ID for handoff messages.

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -324,6 +324,75 @@ func TestCmdHandoffAutoUsesDefaultSubject(t *testing.T) {
 	}
 }
 
+func TestCmdHandoffAutoJSONReportsCreatedMail(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_NAME", "mayor")
+
+	var stdout, stderr bytes.Buffer
+	cmd := newHandoffCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--auto", "--json", "Reviewed handoff"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc handoff --auto --json failed: %v; stderr=%s", err, stderr.String())
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	all, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("open beads = %d, want handoff mail", len(all))
+	}
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		Mode          string `json:"mode"`
+		Auto          bool   `json:"auto"`
+		Subject       string `json:"subject"`
+		MailBeadID    string `json:"mail_bead_id"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.SchemaVersion != "1" || payload.Mode != "auto" || !payload.Auto {
+		t.Fatalf("handoff JSON envelope = %+v", payload)
+	}
+	if payload.Subject != all[0].Title {
+		t.Fatalf("subject = %q, want actual mail title %q", payload.Subject, all[0].Title)
+	}
+	if payload.MailBeadID != all[0].ID {
+		t.Fatalf("mail_bead_id = %q, want actual mail id %q", payload.MailBeadID, all[0].ID)
+	}
+}
+
+func TestCmdHandoffJSONRejectsHookFormat(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := newHandoffCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--auto", "--json", "--hook-format", "codex"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("gc handoff --json --hook-format succeeded, want conflict")
+	}
+	if !strings.Contains(stderr.String(), "--json cannot be used with --hook-format") {
+		t.Fatalf("stderr = %q, want json/hook-format conflict", stderr.String())
+	}
+}
+
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) {

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -358,17 +358,23 @@ func TestCmdHandoffAutoJSONReportsCreatedMail(t *testing.T) {
 	}
 
 	var payload struct {
-		SchemaVersion string `json:"schema_version"`
-		Mode          string `json:"mode"`
-		Auto          bool   `json:"auto"`
-		Subject       string `json:"subject"`
-		MailBeadID    string `json:"mail_bead_id"`
+		SchemaVersion    string `json:"schema_version"`
+		OK               bool   `json:"ok"`
+		Mode             string `json:"mode"`
+		Auto             bool   `json:"auto"`
+		Subject          string `json:"subject"`
+		MailBeadID       string `json:"mail_bead_id"`
+		RestartRequested bool   `json:"restart_requested"`
+		Action           string `json:"action"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
 	}
-	if payload.SchemaVersion != "1" || payload.Mode != "auto" || !payload.Auto {
+	if payload.SchemaVersion != "1" || !payload.OK || payload.Mode != "auto" || !payload.Auto {
 		t.Fatalf("handoff JSON envelope = %+v", payload)
+	}
+	if payload.RestartRequested || payload.Action != "restart_skipped" {
+		t.Fatalf("handoff JSON restart fields = %+v", payload)
 	}
 	if payload.Subject != all[0].Title {
 		t.Fatalf("subject = %q, want actual mail title %q", payload.Subject, all[0].Title)
@@ -376,6 +382,68 @@ func TestCmdHandoffAutoJSONReportsCreatedMail(t *testing.T) {
 	if payload.MailBeadID != all[0].ID {
 		t.Fatalf("mail_bead_id = %q, want actual mail id %q", payload.MailBeadID, all[0].ID)
 	}
+}
+
+func TestHandoffJSONSelfReportsRestartRequest(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	outcome := doHandoffWithOutcome(store, rec, dops, nil, "worker-1", "worker-1",
+		[]string{"HANDOFF: context full"}, &stdout, &stderr)
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	payload := encodeHandoffJSONForTest(t, outcome)
+	if !payload.OK || payload.Mode != "self" || payload.Recipient != "worker-1" {
+		t.Fatalf("handoff JSON envelope = %+v", payload)
+	}
+	if !payload.RestartRequested || payload.Action != "restart_requested" {
+		t.Fatalf("handoff JSON restart fields = %+v", payload)
+	}
+	if payload.MailBeadID == "" || payload.Subject != "HANDOFF: context full" {
+		t.Fatalf("handoff JSON mail fields = %+v", payload)
+	}
+}
+
+func TestHandoffJSONRemoteReportsKilledTarget(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker-2", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+
+	outcome := doHandoffRemoteWithOutcome(store, rec, sp, "worker-2", "worker-2", "worker-1",
+		[]string{"Context refresh"}, &stdout, &stderr)
+	if outcome.code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
+	}
+	payload := encodeHandoffJSONForTest(t, outcome)
+	if !payload.OK || payload.Mode != "remote" || payload.Target != "worker-2" || payload.Recipient != "worker-2" {
+		t.Fatalf("handoff JSON envelope = %+v", payload)
+	}
+	if payload.RestartRequested || payload.Action != "killed" {
+		t.Fatalf("handoff JSON remote action fields = %+v", payload)
+	}
+	if payload.MailBeadID == "" || payload.Subject != "Context refresh" {
+		t.Fatalf("handoff JSON mail fields = %+v", payload)
+	}
+}
+
+func encodeHandoffJSONForTest(t *testing.T, outcome handoffOutcome) handoffJSONResult {
+	t.Helper()
+	var stdout bytes.Buffer
+	if err := writeCLIJSONLine(&stdout, handoffJSONFromOutcome(outcome)); err != nil {
+		t.Fatalf("writeCLIJSONLine: %v", err)
+	}
+	var payload handoffJSONResult
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not handoff JSON: %v\n%s", err, stdout.String())
+	}
+	return payload
 }
 
 func TestCmdHandoffJSONRejectsHookFormat(t *testing.T) {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -253,7 +253,7 @@ func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, 
 
 	trimmed := strings.TrimSpace(output)
 	normalized := normalizeWorkQueryOutput(trimmed)
-	normalized = filterUnreadyHookCandidates(normalized, time.Now())
+	normalized = filterUnreadyHookCandidatesWithDiagnostics(normalized, time.Now(), stderr)
 	hasWork := workQueryHasReadyWork(normalized)
 
 	// Non-inject mode: print normalized, ready-only output. Return 0 only when work exists.
@@ -290,18 +290,18 @@ func workQueryHasReadyWork(output string) bool {
 	return true
 }
 
-// filterUnreadyHookCandidates strips beads from work_query output that fail
-// bd ready semantics: future defer_until, or any open blocking dep in the
-// row's blocked_by array. The work_query is expected to gate these, but
-// defensive filtering here prevents a single broken query from cascading
-// into agent action on a bead it cannot progress.
-// Pure function over JSON; takes time.Time so tests stay deterministic.
-func filterUnreadyHookCandidates(output string, now time.Time) string {
+// filterUnreadyHookCandidatesWithDiagnostics strips beads from work_query
+// output that fail bd ready semantics: future defer_until, or any open
+// blocking dep in the row's blocked_by array. The work_query is expected to
+// gate these, but defensive filtering here prevents a single broken query from
+// cascading into agent action on a bead it cannot progress.
+func filterUnreadyHookCandidatesWithDiagnostics(output string, now time.Time, stderr io.Writer) string {
 	if output == "" {
 		return output
 	}
 	var decoded any
 	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		warnUnfilteredHookJSON(output, err, stderr)
 		return output
 	}
 	arr, ok := decoded.([]any)
@@ -325,9 +325,21 @@ func filterUnreadyHookCandidates(output string, now time.Time) string {
 	}
 	reencoded, err := json.Marshal(filtered)
 	if err != nil {
+		warnUnfilteredHookJSON(output, err, stderr)
 		return output
 	}
 	return string(reencoded)
+}
+
+func warnUnfilteredHookJSON(output string, err error, stderr io.Writer) {
+	if stderr == nil {
+		return
+	}
+	trimmed := strings.TrimSpace(output)
+	if !strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "{") {
+		return
+	}
+	fmt.Fprintf(stderr, "gc hook: warning: cannot filter work query JSON: %v\n", err) //nolint:errcheck // best-effort stderr
 }
 
 func isFutureDeferredHookCandidate(item map[string]any, now time.Time) bool {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -244,7 +244,9 @@ func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, 
 
 	output, err := runner(workQuery, dir)
 	if err != nil {
-		if normalized := normalizeWorkQueryOutput(strings.TrimSpace(output)); normalized != "" {
+		normalized := normalizeWorkQueryOutput(strings.TrimSpace(output))
+		normalized = filterUnreadyHookCandidatesWithDiagnostics(normalized, time.Now(), stderr)
+		if normalized != "" {
 			fmt.Fprint(stdout, normalized) //nolint:errcheck // best-effort stdout
 		}
 		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/hook_defer_blocked_test.go
+++ b/cmd/gc/hook_defer_blocked_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -48,6 +49,35 @@ func TestDoHookFiltersDepBlockedBeads(t *testing.T) {
 	}
 	if !strings.Contains(out, "clear-1") {
 		t.Errorf("clear bead missing from hook output: %s", out)
+	}
+}
+
+func TestDoHookFiltersUnreadyPartialOutputOnCommandError(t *testing.T) {
+	future := "2099-01-01T00:00:00Z"
+	runner := func(_, _ string) (string, error) {
+		return `[
+			{"id":"deferred-1","status":"open","defer_until":"` + future + `"},
+			{"id":"blocked-1","status":"open","blocked_by":[{"id":"blocker-1","status":"open"}]},
+			{"id":"ready-1","status":"open"}
+		]`, fmt.Errorf("timed out after 15s with partial stdout")
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doHook() = %d, want 1 on command error", code)
+	}
+	out := stdout.String()
+	for _, blocked := range []string{"deferred-1", "blocked-1"} {
+		if strings.Contains(out, blocked) {
+			t.Errorf("unready bead %q surfaced in hook partial output: %s", blocked, out)
+		}
+	}
+	if !strings.Contains(out, "ready-1") {
+		t.Errorf("ready bead missing from hook partial output: %s", out)
+	}
+	if !strings.Contains(stderr.String(), "partial stdout") {
+		t.Fatalf("stderr = %q, want command error diagnostic", stderr.String())
 	}
 }
 

--- a/cmd/gc/hook_defer_blocked_test.go
+++ b/cmd/gc/hook_defer_blocked_test.go
@@ -72,3 +72,21 @@ func TestDoHookKeepsPastDeferredAndClosedBlockers(t *testing.T) {
 		}
 	}
 }
+
+func TestDoHookWarnsWhenJSONLikeOutputCannotBeFiltered(t *testing.T) {
+	runner := func(_, _ string) (string, error) {
+		return `[{"id":"ready-1"}`, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHook() = %d, want 0 for legacy fail-open behavior; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cannot filter work query JSON") {
+		t.Fatalf("stderr = %q, want filter diagnostic", stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "ready-1") {
+		t.Fatalf("stdout = %q, want original output preserved", got)
+	}
+}

--- a/cmd/gc/json_output.go
+++ b/cmd/gc/json_output.go
@@ -39,9 +39,7 @@ func writeJSONError(stdout, stderr io.Writer, code, message string, exitCode int
 			ExitCode: exitCode,
 		},
 	}
-	enc := json.NewEncoder(stdout)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(payload); err != nil {
+	if err := writeCLIJSONLine(stdout, payload); err != nil {
 		writeJSONDiagnostic(stderr, "error", "json_encode_failed", fmt.Sprintf("encoding JSON error: %v", err), exitCode)
 		return exitCode
 	}

--- a/cmd/gc/json_output_test.go
+++ b/cmd/gc/json_output_test.go
@@ -21,6 +21,9 @@ func TestWriteJSONErrorIncludesExitCodeOnStdoutAndStderr(t *testing.T) {
 	if out.SchemaVersion != "1" || out.OK || out.Error.Code != "config_load_failed" || out.Error.ExitCode != 7 {
 		t.Fatalf("stdout error payload = %+v", out)
 	}
+	if lines := strings.Split(strings.TrimSpace(stdout.String()), "\n"); len(lines) != 1 {
+		t.Fatalf("stdout lines = %d, want one JSON line; stdout=%q", len(lines), stdout.String())
+	}
 
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
 	if len(lines) != 1 {

--- a/cmd/gc/json_output_test.go
+++ b/cmd/gc/json_output_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestWriteJSONErrorIncludesExitCodeOnStdoutAndStderr(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := writeJSONError(&stdout, &stderr, "config_load_failed", "gc status: loading config failed", 7)
+	code := writeJSONError(&stdout, &stderr, "config_load_failed", "gc status: loading <config>&failed", 7)
 	if code != 7 {
 		t.Fatalf("code = %d, want 7", code)
 	}
@@ -23,6 +23,9 @@ func TestWriteJSONErrorIncludesExitCodeOnStdoutAndStderr(t *testing.T) {
 	}
 	if lines := strings.Split(strings.TrimSpace(stdout.String()), "\n"); len(lines) != 1 {
 		t.Fatalf("stdout lines = %d, want one JSON line; stdout=%q", len(lines), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "<config>&failed") || strings.Contains(stdout.String(), `\u003cconfig\u003e\u0026failed`) {
+		t.Fatalf("stdout = %q, want unescaped CLI JSON text", stdout.String())
 	}
 
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")

--- a/schemas/handoff/result.schema.json
+++ b/schemas/handoff/result.schema.json
@@ -1,13 +1,27 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": ["schema_version", "mode", "auto"],
+  "required": ["schema_version", "ok", "mode", "auto", "restart_requested"],
   "properties": {
     "schema_version": { "type": "string" },
-    "mode": { "type": "string" },
+    "ok": { "type": "boolean" },
+    "mode": { "type": "string", "enum": ["self", "auto", "remote"] },
     "target": { "type": "string" },
+    "recipient": { "type": "string" },
     "auto": { "type": "boolean" },
-    "subject": { "type": "string" }
+    "subject": { "type": "string" },
+    "mail_bead_id": { "type": "string" },
+    "restart_requested": { "type": "boolean" },
+    "action": {
+      "type": "string",
+      "enum": [
+        "restart_requested",
+        "restart_skipped",
+        "kill_skipped",
+        "delivery_pending",
+        "killed"
+      ]
+    }
   },
   "additionalProperties": true
 }


### PR DESCRIPTION
Follow-up for post-merge review of #2289.\n\nFixes:\n- report the real handoff mail bead id and resolved subject in gc handoff --json\n- reject --json with --hook-format so provider hook payloads are not silently discarded\n- emit JSON error stdout as one compact JSON line\n- warn when gc hook receives JSON-like work-query output that cannot be defensively filtered\n- document non-JSON behavior changes from the JSON-summary work\n\nValidation:\n- go test ./cmd/gc -run 'TestWriteJSONErrorIncludesExitCodeOnStdoutAndStderr|TestCmdHandoffAutoJSONReportsCreatedMail|TestCmdHandoffJSONRejectsHookFormat|TestDoHookWarnsWhenJSONLikeOutputCannotBeFiltered'\n- go test ./cmd/gc -run 'TestCmdHandoff|TestDoHandoff|TestHandoff|TestWriteJSONError|TestDoHook|TestBuildPrimeContext|TestDoPrimeWithHook'\n- go test ./cmd/gc -run 'TestOddballRootJSONSchemaManifests|TestJSONSchemaManifestForSupportedCommand|TestJSONSchemaRoleSpecificResult|TestJSONSchemaRoleSpecificFailureUsesSharedDefault'\n- go test ./cmd/gc\n- go test ./cmd/gc -run 'TestOddballRootJSON|TestJSON|TestVersion|TestBuildImage|TestPrime|TestSkill|TestDoHookFilters|TestDoHookKeepsPastDeferred|TestWriteJSONError|TestHandoff'\n- make test-fast-parallel\n- go vet ./...\n- pre-commit hook (lint-changed, generated docs/schema freshness, go vet ./..., GC_FAST_UNIT=1 observable test, docsync)