### PR TITLE
fix(reaper): align dependencies queries with split schema

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -1199,7 +1199,7 @@ exit 0
 		purgeSQL := log[purgeIdx:]
 		if !strings.Contains(purgeSQL, "child_wisp.status IN ('open', 'hooked', 'in_progress')") ||
 			!strings.Contains(purgeSQL, "d.type = 'parent-child'") ||
-			!strings.Contains(purgeSQL, "d.depends_on_id IS NOT NULL") {
+			!strings.Contains(purgeSQL, "d.depends_on_wisp_id IS NOT NULL") {
 			t.Errorf("reaper purge can delete closed parents with non-closed children:\n%s", purgeSQL)
 		}
 	}

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -1070,6 +1070,9 @@ func TestReaperFormulaSQLReflectsCurrentSchema(t *testing.T) {
 		if strings.Contains(fence, "parent_id") {
 			t.Errorf("formula sql fence %d references parent_id (column does not exist in wisps):\n%s", i, fence)
 		}
+		if strings.Contains(fence, "depends_on_id") {
+			t.Errorf("formula sql fence %d references dependencies.depends_on_id instead of split target columns:\n%s", i, fence)
+		}
 		if strings.Contains(fence, "LEFT JOIN wisps parent ON") {
 			t.Errorf("formula sql fence %d still has the broken parent self-join:\n%s", i, fence)
 		}
@@ -1170,9 +1173,23 @@ exit 0
 	if strings.Contains(log, "parent_id") {
 		t.Errorf("reaper SQL references parent_id (column does not exist in wisps):\n%s", log)
 	}
+	if strings.Contains(log, "depends_on_id") {
+		t.Errorf("reaper SQL references dependencies.depends_on_id instead of split target columns:\n%s", log)
+	}
 	// mail was removed: not a SQL table; messages are beads with type=message.
 	if strings.Contains(log, ".mail") {
 		t.Errorf("reaper SQL references .mail table (does not exist in beads schema):\n%s", log)
+	}
+	for _, want := range []string{
+		"SHOW COLUMNS FROM `beads`.dependencies",
+		"SELECT DISTINCT d.depends_on_wisp_id",
+		"d.depends_on_wisp_id IS NOT NULL",
+		"SELECT DISTINCT d.depends_on_issue_id",
+		"d.depends_on_issue_id IS NOT NULL",
+	} {
+		if !strings.Contains(log, want) {
+			t.Errorf("reaper SQL missing %q:\n%s", want, log)
+		}
 	}
 	// DOLT_COMMIT must use CALL, not SELECT.
 	if strings.Contains(log, "SELECT DOLT_COMMIT") {
@@ -1210,6 +1227,55 @@ exit 0
 	}
 	if strings.Contains(string(gcData), "mail:") {
 		t.Errorf("reaper DOG_DONE still reports removed mail cleanup:\n%s", gcData)
+	}
+}
+
+func TestReaperSkipsDependencyQueriesWithoutSplitDependencyTargets(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":          doltLog,
+		"DOLT_DBS":               "beads",
+		"DOLT_DEPENDENCY_SCHEMA": "legacy",
+		"GC_CALL_LOG":            gcLog,
+		"GC_CITY":                cityDir,
+		"GC_CITY_PATH":           cityDir,
+		"GC_DOLT_HOST":           "127.0.0.1",
+		"GC_DOLT_PORT":           "3307",
+		"GC_DOLT_USER":           "root",
+		"GC_DOLT_PASSWORD":       "",
+		"PATH":                   binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "SHOW COLUMNS FROM `beads`.dependencies") {
+		t.Fatalf("reaper did not probe dependency target columns:\n%s", log)
+	}
+	if strings.Contains(log, "FROM `beads`.dependencies d") || strings.Contains(log, "JOIN `beads`.dependencies d") {
+		t.Fatalf("reaper ran dependency-aware queries against legacy dependency schema:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "dependencies table lacks split target columns") {
+		t.Fatalf("reaper did not surface legacy dependency schema anomaly:\n%s", gcData)
 	}
 }
 
@@ -1871,6 +1937,9 @@ exit 0
 	}
 	if !strings.Contains(log, "dependencies d") || !strings.Contains(log, "d.type = 'parent-child'") {
 		t.Fatalf("reaper stale-wisp close path does not use parent-child dependencies:\n%s", log)
+	}
+	if !strings.Contains(log, "d.depends_on_wisp_id = parent_wisp.id") || !strings.Contains(log, "d.depends_on_issue_id = parent_issue.id") {
+		t.Fatalf("reaper stale-wisp close path does not use split dependency target columns:\n%s", log)
 	}
 	if strings.Contains(log, "parent_wisp.id IS NULL AND parent_issue.id IS NULL") {
 		t.Fatalf("reaper closes stale wisps when parent liveness is unresolved:\n%s", log)
@@ -3452,6 +3521,20 @@ case "$*" in
     esac
   done
   printf 'wisps\n'
+  ;;
+*"SHOW COLUMNS FROM"*"dependencies"*)
+  printf 'Field,Type,Null,Key,Default,Extra\n'
+  if [ "${DOLT_DEPENDENCY_SCHEMA:-split}" = "legacy" ]; then
+    printf 'issue_id,varchar,NO,,,\n'
+    printf 'depends_on_id,varchar,NO,,,\n'
+    printf 'type,varchar,NO,,,\n'
+  else
+    printf 'issue_id,varchar,NO,,,\n'
+    printf 'depends_on_issue_id,varchar,YES,,,\n'
+    printf 'depends_on_wisp_id,varchar,YES,,,\n'
+    printf 'depends_on_external,varchar,YES,,,\n'
+    printf 'type,varchar,NO,,,\n'
+  fi
   ;;
 *"SELECT *"*)
   printf '{"id":"ga-1","title":"sample"}\n'

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -337,8 +337,8 @@ while IFS= read -r DB; do
             INNER JOIN \`$DB\`.dependencies d
                 ON d.issue_id = w.id
                 AND d.type = 'parent-child'
-            LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
-            LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
+            LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
+            LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_issue_id = parent_issue.id
             WHERE w.status IN ('open', 'hooked', 'in_progress')
             AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
             AND (
@@ -361,8 +361,8 @@ while IFS= read -r DB; do
                     INNER JOIN \`$DB\`.dependencies d
                         ON d.issue_id = w.id
                         AND d.type = 'parent-child'
-                    LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
-                    LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
+                    LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
+                    LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_issue_id = parent_issue.id
                     WHERE w.status IN ('open', 'hooked', 'in_progress')
                     AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
                     AND (
@@ -391,10 +391,10 @@ while IFS= read -r DB; do
         WHERE status = 'closed'
         AND closed_at < DATE_SUB(NOW(), INTERVAL $PURGE_AGE_H HOUR)
         AND id NOT IN (
-            SELECT DISTINCT d.depends_on_id FROM \`$DB\`.dependencies d
+            SELECT DISTINCT d.depends_on_wisp_id FROM \`$DB\`.dependencies d
             INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
             WHERE d.type = 'parent-child'
-            AND d.depends_on_id IS NOT NULL
+            AND d.depends_on_wisp_id IS NOT NULL
             AND child_wisp.status IN ('open', 'hooked', 'in_progress')
         )
     "
@@ -406,10 +406,10 @@ while IFS= read -r DB; do
             WHERE status = 'closed'
             AND closed_at < DATE_SUB(NOW(), INTERVAL $PURGE_AGE_H HOUR)
             AND id NOT IN (
-                SELECT DISTINCT d.depends_on_id FROM \`$DB\`.dependencies d
+                SELECT DISTINCT d.depends_on_wisp_id FROM \`$DB\`.dependencies d
                 INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
                 WHERE d.type = 'parent-child'
-                AND d.depends_on_id IS NOT NULL
+                AND d.depends_on_wisp_id IS NOT NULL
                 AND child_wisp.status IN ('open', 'hooked', 'in_progress')
             )
         "; then
@@ -430,10 +430,10 @@ while IFS= read -r DB; do
         AND issue_type != 'epic'
         AND id NOT IN (
             SELECT DISTINCT d.issue_id FROM \`$DB\`.dependencies d
-            INNER JOIN \`$DB\`.issues i ON d.depends_on_id = i.id
+            INNER JOIN \`$DB\`.issues i ON d.depends_on_issue_id = i.id
             WHERE i.status IN ('open', 'in_progress')
             UNION
-            SELECT DISTINCT d.depends_on_id FROM \`$DB\`.dependencies d
+            SELECT DISTINCT d.depends_on_issue_id FROM \`$DB\`.dependencies d
             INNER JOIN \`$DB\`.issues i ON d.issue_id = i.id
             WHERE i.status IN ('open', 'in_progress')
         )

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -247,6 +247,24 @@ get_sql_rows() {
     SQL_ROWS_RESULT=$(printf '%s\n' "$output" | tail -n +2 | tr -d '\r')
 }
 
+has_split_dependency_target_columns() {
+    local db="$1"
+    local output
+    local fields
+
+    if ! output=$(dolt_sql -r csv -q "SHOW COLUMNS FROM \`$db\`.dependencies" 2>/dev/null); then
+        return 0
+    fi
+
+    fields=$(printf '%s\n' "$output" | tail -n +2 | cut -d, -f1 | tr -d '\r')
+    if [ -z "$fields" ]; then
+        return 0
+    fi
+
+    printf '%s\n' "$fields" | grep -qx 'depends_on_issue_id' || return 1
+    printf '%s\n' "$fields" | grep -qx 'depends_on_wisp_id' || return 1
+}
+
 SQL_CHANGE_ROWS_RESULT=0
 close_city_issue() {
     local issue_id="$1"
@@ -309,6 +327,10 @@ while IFS= read -r DB; do
         # Not a bd-managed bead store. Skip silently; recording an
         # anomaly here would just turn every schemaless DB on the
         # server into noise. See gastownhall/gascity#1816.
+        continue
+    fi
+    if ! has_split_dependency_target_columns "$DB"; then
+        record_anomaly "$DB" "dependencies table lacks split target columns; dependency-aware reaper queries skipped"
         continue
     fi
 
@@ -436,6 +458,7 @@ while IFS= read -r DB; do
             SELECT DISTINCT d.depends_on_issue_id FROM \`$DB\`.dependencies d
             INNER JOIN \`$DB\`.issues i ON d.issue_id = i.id
             WHERE i.status IN ('open', 'in_progress')
+            AND d.depends_on_issue_id IS NOT NULL
         )
     "
     STALE_IDS=$SQL_ROWS_RESULT

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -129,8 +129,8 @@ SELECT COUNT(DISTINCT w.id) FROM wisps w
 INNER JOIN dependencies d
   ON d.issue_id = w.id
   AND d.type = 'parent-child'
-LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
-LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
+LEFT JOIN wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
+LEFT JOIN issues parent_issue ON d.depends_on_issue_id = parent_issue.id
 WHERE w.status IN ('open', 'hooked', 'in_progress')
 AND w.created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
 AND (
@@ -145,10 +145,10 @@ SELECT COUNT(*) FROM wisps
 WHERE status = 'closed'
 AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
 AND id NOT IN (
-  SELECT DISTINCT d.depends_on_id FROM dependencies d
+  SELECT DISTINCT d.depends_on_wisp_id FROM dependencies d
   INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
   WHERE d.type = 'parent-child'
-  AND d.depends_on_id IS NOT NULL
+  AND d.depends_on_wisp_id IS NOT NULL
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
 );
 
@@ -204,8 +204,8 @@ AND id IN (
     INNER JOIN dependencies d
       ON d.issue_id = w.id
       AND d.type = 'parent-child'
-    LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
-    LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
+    LEFT JOIN wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
+    LEFT JOIN issues parent_issue ON d.depends_on_issue_id = parent_issue.id
     WHERE w.status IN ('open', 'hooked', 'in_progress')
     AND w.created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
     AND (
@@ -240,10 +240,10 @@ DELETE FROM wisps
 WHERE status = 'closed'
 AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
 AND id NOT IN (
-  SELECT DISTINCT d.depends_on_id FROM dependencies d
+  SELECT DISTINCT d.depends_on_wisp_id FROM dependencies d
   INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
   WHERE d.type = 'parent-child'
-  AND d.depends_on_id IS NOT NULL
+  AND d.depends_on_wisp_id IS NOT NULL
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
 );
 ```
@@ -285,12 +285,13 @@ AND issue_type != 'epic'
 AND id NOT IN (
   -- Exclude issues with active dependencies
   SELECT DISTINCT d.issue_id FROM dependencies d
-  INNER JOIN issues i ON d.depends_on_id = i.id
+  INNER JOIN issues i ON d.depends_on_issue_id = i.id
   WHERE i.status IN ('open', 'in_progress')
   UNION
-  SELECT DISTINCT d.depends_on_id FROM dependencies d
+  SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
   INNER JOIN issues i ON d.issue_id = i.id
   WHERE i.status IN ('open', 'in_progress')
+  AND d.depends_on_issue_id IS NOT NULL
 )
 ```
 


### PR DESCRIPTION
## Summary

`dependencies.depends_on_id` was split into three columns
(`depends_on_wisp_id`, `depends_on_issue_id`, `depends_on_external`) with
`ck_dep_one_target` enforcing exactly one is set. The reaper script and
one purge assertion still referenced the old column, so the following
queries failed on every city DB:

- `closed wisp purge count` / DELETE
- `stale issue query`
- `schema-safe stale wisp count` / UPDATE

Effect in production: closed wisps could not be purged, stale issues
could not be auto-closed, and the witness escalated `Reaper anomalies
detected [MEDIUM]` on every run.

## Changes

`examples/gastown/packs/maintenance/assets/scripts/reaper.sh` — 10 sites
remapped by JOIN target:

| Context | Old | New |
|---|---|---|
| `LEFT JOIN wisps parent_wisp ON ...` | `d.depends_on_id` | `d.depends_on_wisp_id` |
| `LEFT JOIN issues parent_issue ON ...` | `d.depends_on_id` | `d.depends_on_issue_id` |
| `INNER JOIN issues i ON ...` (stale issue) | `d.depends_on_id` | `d.depends_on_issue_id` |
| Wisp purge subquery (`SELECT DISTINCT` + `IS NOT NULL`) | `d.depends_on_id` | `d.depends_on_wisp_id` |
| Stale-issue UNION subquery (`SELECT DISTINCT`) | `d.depends_on_id` | `d.depends_on_issue_id` |

`examples/gastown/maintenance_scripts_test.go:1202` — purge SQL
assertion updated to match (`d.depends_on_wisp_id IS NOT NULL`).

Issue and wisp id namespaces are disjoint (`gc-xxx` vs `gc-wisp-xxxxx`),
so the single-column replacement preserves the original semantics
without needing a UNION-style fallback.

## Verification

- `make lint`: 0 issues
- `make vet`: clean
- `make fmt-check`: clean
- `go test ./examples/gastown/ -run Reaper -count=1`: PASS
- `make test` (full): one unrelated timing flake
  (`TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates`,
  205ms vs 200ms ceiling) that passes on re-run; not in the diff scope.
- Pre-commit hook (lint + vet + test + genspec + genschema): green.
- Live verification against three production city DBs (hq / ggp / tga):
  `GC_REAPER_DRY_RUN=1 reaper.sh` exits clean (was failing on every run
  before the patch); each patched query also runs cleanly via direct
  `gc dolt sql` execution.

## Test plan

- [x] Lint / vet / fmt-check
- [x] Reaper unit tests
- [x] Pre-commit hook (full)
- [x] Live dry-run against three production city DBs
- [ ] CI green