### PR TITLE
fix(session-reset): clear session_key for wake_mode=resume sessions on RequestFreshRestart

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,6 @@
+issue_prefix: ga
+issue-prefix: ga
+dolt.auto-start: false
+export.auto: false
+gc.endpoint_origin: inherited_city
+gc.endpoint_status: verified

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,9 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_port": 50215,
+  "dolt_database": "ga",
+  "project_id": "3ed8713c-bf6e-49cc-89ba-2824ac5c2df8"
+}

--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -29,6 +29,7 @@ type agentBuildParams struct {
 	sessionTemplate string
 	beaconTime      time.Time
 	packDirs        []string
+	rigPackDirs     map[string][]string
 	packOverlayDirs []string
 	rigOverlayDirs  map[string][]string
 	globalFragments []string
@@ -99,6 +100,7 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 		sessionTemplate: cfg.Workspace.SessionTemplate,
 		beaconTime:      beaconTime,
 		packDirs:        cfg.PackDirs,
+		rigPackDirs:     cfg.RigPackDirs,
 		packOverlayDirs: cfg.PackOverlayDirs,
 		rigOverlayDirs:  cfg.RigOverlayDirs,
 		globalFragments: cfg.Workspace.GlobalFragments,
@@ -208,6 +210,29 @@ func (p *agentBuildParams) sharedSkillCatalogSnapshotForAgent(agent *config.Agen
 // effectiveOverlayDirs merges city-level and rig-level pack overlay dirs.
 // City dirs come first (lower priority), then rig-specific dirs.
 func effectiveOverlayDirs(cityDirs []string, rigDirs map[string][]string, rigName string) []string {
+	rigSpecific := rigDirs[rigName]
+	if len(rigSpecific) == 0 {
+		return cityDirs
+	}
+	if len(cityDirs) == 0 {
+		return rigSpecific
+	}
+	merged := make([]string, 0, len(cityDirs)+len(rigSpecific))
+	merged = append(merged, cityDirs...)
+	merged = append(merged, rigSpecific...)
+	return merged
+}
+
+// effectivePackDirs merges city-level and rig-level pack directories so
+// prompt rendering can discover template-fragments/ and prompts/shared/
+// inside packs imported only by a single rig. City dirs come first (lower
+// priority), then rig-specific dirs (higher priority — rig imports override
+// city imports on name collision), mirroring effectiveOverlayDirs.
+//
+// Returns city dirs unchanged when the rig has no extra imports and rig
+// dirs alone when no city-level packs are configured. Empty rigName
+// (city-only render) returns city dirs.
+func effectivePackDirs(cityDirs []string, rigDirs map[string][]string, rigName string) []string {
 	rigSpecific := rigDirs[rigName]
 	if len(rigSpecific) == 0 {
 		return cityDirs

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -663,6 +663,19 @@ func bdTransportErrorMatches(cityPath, scopeRoot string, env map[string]string, 
 	return false
 }
 
+// bdSilentFallbackMarkerImport and bdSilentFallbackMarkerEmptyDB are the
+// substring pair bd emits when it loses the managed Dolt server and silently
+// falls back to opening the on-disk store with a JSONL auto-import. They are
+// load-bearing in three places — the two transport-error classifiers below
+// and bdOutputIndicatesSilentFallback — so they live here as the single
+// source of truth. If bd's banner wording ever changes, this is the only
+// edit site. (The root cause is fixed upstream in beads post-#3691; these
+// markers remain the symptom detector for deployments still on stable bd.)
+const (
+	bdSilentFallbackMarkerImport  = "auto-importing"
+	bdSilentFallbackMarkerEmptyDB = "into empty database"
+)
+
 func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string, err error) bool {
 	return bdTransportErrorMatches(cityPath, scopeRoot, env, err, []string{
 		"server unreachable",
@@ -678,8 +691,8 @@ func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string
 		// rather than a network error. Treat the auto-import marker as a
 		// transport failure so the managed-retry path republishes the correct
 		// port and retries against the live server. See gastownhall/gascity#1930.
-		"auto-importing",
-		"into empty database",
+		bdSilentFallbackMarkerImport,
+		bdSilentFallbackMarkerEmptyDB,
 	})
 }
 
@@ -691,9 +704,25 @@ func bdTransportRecoverableError(cityPath, scopeRoot string, env map[string]stri
 		// When bd auto-imports into an empty on-disk store it has lost the
 		// managed Dolt server; republishing the port via the recovery path
 		// is what unsticks the next attempt. See gastownhall/gascity#1930.
-		"auto-importing",
-		"into empty database",
+		bdSilentFallbackMarkerImport,
+		bdSilentFallbackMarkerEmptyDB,
 	})
+}
+
+// bdOutputIndicatesSilentFallback reports whether the given bd output
+// (typically captured stderr) contains the marker pair that bd emits
+// when it loses the managed Dolt server and silently falls back to
+// opening the on-disk store with a JSONL auto-import. Operators of
+// `gc bd ...` rely on this to convert the silent fallback into a loud,
+// non-zero-exit error — in managed mode (BD_EXPORT_AUTO=false) the
+// fallback drops writes. See gastownhall/gascity#2080 (bd update path)
+// and gastownhall/gascity#2079 (bd close path) — both subcommands flow
+// through the shared doBd handoff, so a single detection site covers
+// the bd-write-persistence quad.
+func bdOutputIndicatesSilentFallback(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(lower, bdSilentFallbackMarkerImport) &&
+		strings.Contains(lower, bdSilentFallbackMarkerEmptyDB)
 }
 
 func bdCommandRunnerWithManagedRetry(cityPath string, envFn func(dir string) map[string]string) beads.CommandRunner {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -871,13 +871,20 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			}
 		}
 		for _, b := range ready {
-			if strings.TrimSpace(b.Assignee) != "" {
+			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
+			if _, ok := group.templates[template]; !ok {
 				continue
 			}
-			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
-			if _, ok := group.templates[template]; ok {
-				counts[template]++
+			assignee := strings.TrimSpace(b.Assignee)
+			// Beads assigned to a specific session belong to that session.
+			// Beads with an empty assignee or parked on the pool template name
+			// (the placeholder pattern that hides them from --unassigned)
+			// remain pool demand — without this the scaler stops spawning
+			// for legitimate routed work and the bead never gets claimed (ga-2pz).
+			if assignee != "" && assignee != template {
+				continue
 			}
+			counts[template]++
 		}
 	}
 	return counts, partialTemplates, errs

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -387,6 +387,80 @@ func TestDefaultScaleCheckCountsUsesCachedReadyReadModel(t *testing.T) {
 	}
 }
 
+// TestDefaultScaleCheckCountsTreatsPoolPlaceholderAssigneeAsDemand verifies
+// that the scaler counts beads parked on the pool template name (assignee ==
+// gc.routed_to) as new demand, not as already-claimed work. Without this, a
+// bead routed via `bd update --assignee=<pool> --set-metadata gc.routed_to=<pool>`
+// would never trigger a pool spawn even with zero polecats running (ga-2pz).
+func TestDefaultScaleCheckCountsTreatsPoolPlaceholderAssigneeAsDemand(t *testing.T) {
+	backing := &readyFailStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "parked on template",
+		Type:   "task",
+		Status: "open",
+		// Placeholder pattern: assignee mirrors gc.routed_to. This is the
+		// shape ga-2pz observed when mayor (or any caller) used
+		// `bd update --assignee=<pool>` to reserve work for a pool.
+		Assignee: "gascity/workflows.codex-min",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-min",
+		},
+	}); err != nil {
+		t.Fatalf("create placeholder-assigned bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-min",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-min"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want 1 (placeholder-assigned bead must count as demand)", got)
+	}
+}
+
+// TestDefaultScaleCheckCountsIgnoresSpecificSessionAssignee verifies that the
+// scaler still treats beads claimed by a specific session as non-demand —
+// only the pool-template placeholder and the empty assignee count.
+func TestDefaultScaleCheckCountsIgnoresSpecificSessionAssignee(t *testing.T) {
+	backing := &readyFailStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "claimed by session",
+		Type:   "task",
+		Status: "open",
+		// Concrete session name, not the pool template — already claimed.
+		Assignee: "gastown__polecat-pe-abcd",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-min",
+		},
+	}); err != nil {
+		t.Fatalf("create session-assigned bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-min",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-min"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want 0 (session-assigned bead must NOT count as new demand)", got)
+	}
+}
+
 func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
 	backing := &demandListCountingStore{Store: beads.NewMemStore()}
 	if _, err := backing.Create(beads.Bead{

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -13,6 +13,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// bdSilentFallbackExitCode is the exit code gc bd emits when it detects
+// that bd silently fell back to on-disk auto-import mode (managed Dolt
+// unreachable). Distinct from bd's own exits so operators and CI can
+// tell the loud-fail apart from a real bd error. Covers both the
+// bd update path (gastownhall/gascity#2080) and the bd close path
+// (gastownhall/gascity#2079) because both subcommands flow through doBd.
+const bdSilentFallbackExitCode = 4
+
+// bdStderrScanLimit caps how much of bd's stderr gc retains to scan for the
+// silent-fallback marker. bd emits the marker pair while opening the store —
+// before it runs the subcommand — so the marker, when present, always lands
+// within the first chunk of stderr. Capping the retained prefix keeps memory
+// bounded for bd subcommands that stream large stderr output.
+const bdStderrScanLimit = 64 << 10 // 64 KiB
+
+// headLimitedWriter retains only the first limit bytes written to it and
+// discards the rest, so scanning bd's stderr for the silent-fallback marker
+// never holds an unbounded copy of the stream. It always reports a full
+// write so it is safe as an io.MultiWriter sink.
+type headLimitedWriter struct {
+	buf   []byte
+	limit int
+}
+
+func (w *headLimitedWriter) Write(p []byte) (int, error) {
+	if room := w.limit - len(w.buf); room > 0 {
+		if len(p) < room {
+			room = len(p)
+		}
+		w.buf = append(w.buf, p[:room]...)
+	}
+	return len(p), nil
+}
+
+func (w *headLimitedWriter) String() string { return string(w.buf) }
+
 func newBdCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bd [bd-args...]",
@@ -35,10 +71,13 @@ auto-export behavior, invoke bd directly.`,
   gc bd list --rig my-project -s open`,
 		DisableFlagParsing: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if doBd(args, stdout, stderr) != 0 {
-				return errExit
-			}
-			return nil
+			// Plumb doBd's numeric exit code through exitForCode so the
+			// process exit code matches the documented contract above
+			// (bdSilentFallbackExitCode = 4) and bd's own exit codes are
+			// preserved. Returning errExit on any non-zero would collapse
+			// every code to 1 and defeat the operator/CI signal the loud-
+			// fail was meant to provide.
+			return exitForCode(doBd(args, stdout, stderr))
 		},
 	}
 	return cmd
@@ -139,7 +178,13 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	cmd.Dir = target.ScopeRoot
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	// Tee stderr through a bounded head buffer alongside the operator's
+	// pipe so we can scan it post-exec for bd's silent-fallback-to-on-disk
+	// marker. Only stderr is teed: bd writes its auto-import banner there,
+	// not to stdout. See gastownhall/gascity#2080 (update path) and #2079
+	// (close path) — both go through this handoff.
+	stderrScan := &headLimitedWriter{limit: bdStderrScanLimit}
+	cmd.Stderr = io.MultiWriter(stderr, stderrScan)
 	env, err := bdCommandEnv(cityPath, cfg, target)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -147,14 +192,34 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	}
 	cmd.Env = workQueryEnvForDir(env, cmd.Dir)
 
-	if err := cmd.Run(); err != nil {
+	runErr := cmd.Run()
+
+	if runErr != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if errors.As(runErr, &exitErr) {
 			return exitErr.ExitCode()
 		}
-		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc bd: %v\n", runErr) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+
+	// bd exited 0 — but if its stderr shows the silent fallback to on-disk
+	// auto-import, the managed Dolt server was unreachable and any write in
+	// this command was dropped (managed Gas City sets BD_EXPORT_AUTO=false;
+	// see applyExportSuppressionEnv in cmd/gc/bd_env.go). Surface that as a
+	// hard error instead of a misleading exit 0. One check here covers the
+	// whole bd-write-persistence quad (gastownhall/gascity#2079 / #2080 /
+	// #2149 / #2150) because every bd subcommand routes through this
+	// handoff. A non-zero bd exit is intentionally left to the block above:
+	// the existing transport-retry classifier already handles the
+	// timeout+marker case, and overriding a real bd exit code here would
+	// mask it. (Root cause fixed upstream in beads post-#3691; this surfaces
+	// the symptom for deployments still on stable bd builds.)
+	if bdOutputIndicatesSilentFallback(stderrScan.String()) {
+		fmt.Fprintln(stderr, "gc bd: managed Dolt unreachable; bd fell back to on-disk auto-import mode. If this command wrote data, that write was NOT persisted. Restart the managed Dolt server (or check connectivity) and retry. (See gastownhall/gascity#2080.)") //nolint:errcheck // best-effort stderr
+		return bdSilentFallbackExitCode
+	}
+
 	return 0
 }
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -277,6 +277,47 @@ func TestResolveBdScopeTargetUsesRedirectedWorktreeRig(t *testing.T) {
 	}
 }
 
+// TestResolveBdScopeTargetUsesGitWorktreeFallbackForCreate verifies that
+// `gc bd create` (no --rig, no bead ID in args) routes to the rig scope when
+// cwd is a polecat-style worktree whose .beads/redirect is missing. Without
+// the git-based fallback, the call falls through to the city HQ target and
+// the bead lands in the wrong rig — the failure mode ga-cuk addresses.
+func TestResolveBdScopeTargetUsesGitWorktreeFallbackForCreate(t *testing.T) {
+	rigRoot := filepath.Join(t.TempDir(), "frontend-rig")
+	cityDir := t.TempDir()
+	worktreeDir := filepath.Join(cityDir, ".gc", "worktrees", "frontend", "polecats", "polecat-1")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktreeDir): %v", err)
+	}
+	// Deliberately no .beads/redirect — the worktree-setup hook's drift
+	// or a manually-cleaned worktree is the scenario we are fixing.
+
+	prev := gitCommonDirForDir
+	t.Cleanup(func() { gitCommonDirForDir = prev })
+	gitCommonDirForDir = func(string) (string, bool) {
+		return filepath.Join(rigRoot, ".git"), true
+	}
+
+	setCwd(t, worktreeDir)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "gascity"},
+		Rigs:      []config.Rig{{Name: "frontend", Path: rigRoot, Prefix: "fr"}},
+	}
+	got, err := resolveBdScopeTarget(cfg, cityDir, "", []string{"create", "new bead title", "-t", "task"})
+	if err != nil {
+		t.Fatalf("resolveBdScopeTarget() error = %v", err)
+	}
+	want := execStoreTarget{
+		ScopeRoot: rigRoot,
+		ScopeKind: "rig",
+		Prefix:    "fr",
+		RigName:   "frontend",
+	}
+	if got != want {
+		t.Fatalf("resolveBdScopeTarget() = %#v, want %#v", got, want)
+	}
+}
+
 func TestResolveBdScopeTargetErrorsOnForeignRedirect(t *testing.T) {
 	cityDir := t.TempDir()
 	worktreeDir := filepath.Join(cityDir, ".gc", "worktrees", "frontend", "polecats", "polecat-1")

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1810,3 +1810,233 @@ set -eu
 		t.Fatalf("stderr = %q, want canonical drift detail", stderr.String())
 	}
 }
+
+// silentFallbackFakeBdScript builds a fake `bd` shell script that emits the
+// silent-fallback marker pair on stderr ("auto-importing ... into empty
+// database") and exits 0 — the exact shape bd produces when it loses the
+// managed Dolt server and falls back to opening the on-disk store. doBd
+// should treat this as a hard failure regardless of bd's exit code.
+const silentFallbackFakeBdScript = `#!/bin/sh
+echo "auto-importing 220929 bytes from .beads/issues.jsonl into empty database... auto-imported 123 issues" >&2
+echo "$@"
+exit 0
+`
+
+// silentFallbackTestSetup writes a fake bd binary that emits the silent-
+// fallback marker, prepends it to PATH, and configures a minimal city as a
+// bd-backed scope (via GC_CITY_PATH) so doBd will dispatch through it.
+func silentFallbackTestSetup(t *testing.T, fakeBdScript string) {
+	t.Helper()
+
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	t.Cleanup(func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	})
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	port := strconv.Itoa(writeReachableManagedDoltState(t, cityDir))
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "issue_prefix: demo\n" +
+		"gc.endpoint_origin: city_canonical\n" +
+		"gc.endpoint_status: verified\n" +
+		"dolt.auto-start: false\n" +
+		"dolt.host: 127.0.0.1\n" +
+		"dolt.port: " + port + "\n"
+	// writeReachableManagedDoltState already creates .beads, but don't rely
+	// on that side-effect — make the directory explicit before writing.
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_DOLT_PORT", port)
+}
+
+// TestGcBdSurfacesSilentFallbackAsLoudError_UpdatePath pins the #2080 fix:
+// when bd's update path silently falls back to the on-disk store, gc bd must
+// convert that into a non-zero exit with an operator-facing message instead
+// of letting the silent write loss reach the operator as success.
+func TestGcBdSurfacesSilentFallbackAsLoudError_UpdatePath(t *testing.T) {
+	silentFallbackTestSetup(t, silentFallbackFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"update", "demo-abc", "--set-metadata", "k=v"}, &stdout, &stderr)
+	if got != bdSilentFallbackExitCode {
+		t.Fatalf("doBd(update) = %d, want %d (silent-fallback exit code); stderr=%q",
+			got, bdSilentFallbackExitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "managed Dolt unreachable") {
+		t.Fatalf("stderr missing loud-fail message; stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "auto-importing") {
+		t.Fatalf("original bd stderr not passed through; stderr=%q", stderr.String())
+	}
+}
+
+// TestGcBdSurfacesSilentFallbackAsLoudError_ClosePath pins the #2079 half of
+// the bd-write-persistence quad: bd close goes through the same doBd
+// handoff, so the silent-fallback detection must fire identically. Pre-fix,
+// gc bd close would have exited 0 even when the close never persisted to
+// JSONL (the behavior #2079 documents).
+func TestGcBdSurfacesSilentFallbackAsLoudError_ClosePath(t *testing.T) {
+	silentFallbackTestSetup(t, silentFallbackFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"close", "demo-abc", "-r", "duplicate"}, &stdout, &stderr)
+	if got != bdSilentFallbackExitCode {
+		t.Fatalf("doBd(close) = %d, want %d (silent-fallback exit code); stderr=%q",
+			got, bdSilentFallbackExitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "managed Dolt unreachable") {
+		t.Fatalf("stderr missing loud-fail message; stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "auto-importing") {
+		t.Fatalf("original bd stderr not passed through; stderr=%q", stderr.String())
+	}
+}
+
+// TestGcBdHappyPathExitsZeroWithoutFallbackMarker is the inverse: a clean
+// bd run that produces no auto-import marker must NOT be converted into the
+// loud-fail. This guards against false positives where bd's stderr happens
+// to contain unrelated content.
+func TestGcBdHappyPathExitsZeroWithoutFallbackMarker(t *testing.T) {
+	// Fake bd that exits 0 with normal output and an unrelated stderr line.
+	const happyPathFakeBdScript = `#!/bin/sh
+echo "some normal bd output"
+echo "some unrelated stderr line" >&2
+exit 0
+`
+	silentFallbackTestSetup(t, happyPathFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := doBd([]string{"list"}, &stdout, &stderr)
+	if got != 0 {
+		t.Fatalf("doBd(list) = %d, want 0; stderr=%q", got, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "managed Dolt unreachable") {
+		t.Fatalf("loud-fail message fired on a happy-path run; stderr=%q", stderr.String())
+	}
+}
+
+// TestGcBdProcessExitCodeMatchesSilentFallbackContract pins the process-
+// level exit code contract that the bdSilentFallbackExitCode = 4 doc
+// comment promises operators and CI. PR #2327 review found the previous
+// RunE used `return errExit` on any non-zero, which collapsed every code
+// to 1 in commandExitCode — defeating the operator/CI signal the loud-
+// fail was meant to provide. Plumbing doBd's numeric code through
+// exitForCode ensures the process exit code matches what doBd computed.
+func TestGcBdProcessExitCodeMatchesSilentFallbackContract(t *testing.T) {
+	silentFallbackTestSetup(t, silentFallbackFakeBdScript)
+
+	var stdout, stderr bytes.Buffer
+	got := run([]string{"bd", "update", "demo-abc", "--set-metadata", "k=v"}, &stdout, &stderr)
+	if got != bdSilentFallbackExitCode {
+		t.Fatalf("run(bd update) = %d, want %d (silent-fallback exit code); stderr=%q",
+			got, bdSilentFallbackExitCode, stderr.String())
+	}
+}
+
+// TestGcBdProcessExitCodePreservesBdNonZero is the inverse case: when bd
+// returns a non-zero code that isn't the silent-fallback case (e.g., bd
+// itself rejected the command), gc bd must preserve bd's exit code rather
+// than collapsing it to 1. exitForCode encodes ≥2 codes via
+// commandExitError so commandExitCode reads them back faithfully.
+func TestGcBdProcessExitCodePreservesBdNonZero(t *testing.T) {
+	const bdRejectsScript = `#!/bin/sh
+echo "bd: simulated usage error" >&2
+exit 3
+`
+	silentFallbackTestSetup(t, bdRejectsScript)
+
+	var stdout, stderr bytes.Buffer
+	got := run([]string{"bd", "list"}, &stdout, &stderr)
+	if got != 3 {
+		t.Fatalf("run(bd list) = %d, want 3 (preserved bd exit code); stderr=%q",
+			got, stderr.String())
+	}
+}
+
+// TestBdOutputIndicatesSilentFallback covers the marker-detection helper
+// directly with table-driven cases so the source-of-truth for what counts
+// as "silent fallback" is unit-pinned.
+func TestBdOutputIndicatesSilentFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"single marker only auto-importing", "auto-importing 100 bytes from foo", false},
+		{"single marker only into-empty-database", "into empty database", false},
+		{"both markers same line", "auto-importing 100 bytes into empty database", true},
+		{"both markers reversed order", "into empty database <- auto-importing 100 bytes", true},
+		{"both markers across newlines", "auto-importing 100 bytes\n  into empty database\n  done", true},
+		{"case insensitive uppercase", "AUTO-IMPORTING INTO EMPTY DATABASE", true},
+		{"case insensitive mixed", "Auto-Importing 200 bytes Into Empty Database", true},
+		{"unrelated transport error", "dial tcp 127.0.0.1:3306: connect: connection refused", false},
+		{"unrelated server-unreachable error", "server unreachable", false},
+		{"both markers buried in long output", "starting bd\n... \nauto-importing 220929 bytes from .beads/issues.jsonl into empty database... \n... \nauto-imported 123 issues\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bdOutputIndicatesSilentFallback(tt.input); got != tt.want {
+				t.Errorf("bdOutputIndicatesSilentFallback(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHeadLimitedWriter pins the bounded-prefix behavior used to scan bd's
+// stderr: writes past the limit are reported as fully consumed (so it is
+// safe behind io.MultiWriter) but only the first limit bytes are retained.
+func TestHeadLimitedWriter(t *testing.T) {
+	t.Run("retains only the first limit bytes of an oversized write", func(t *testing.T) {
+		w := &headLimitedWriter{limit: 5}
+		n, err := w.Write([]byte("abcdefgh"))
+		if err != nil || n != 8 {
+			t.Fatalf("Write = (%d, %v), want (8, nil)", n, err)
+		}
+		if got := w.String(); got != "abcde" {
+			t.Fatalf("String() = %q, want %q", got, "abcde")
+		}
+	})
+	t.Run("accumulates across writes and stops at the limit", func(t *testing.T) {
+		w := &headLimitedWriter{limit: 5}
+		for _, chunk := range []string{"ab", "cdef", "ghi"} {
+			if n, err := w.Write([]byte(chunk)); err != nil || n != len(chunk) {
+				t.Fatalf("Write(%q) = (%d, %v), want (%d, nil)", chunk, n, err, len(chunk))
+			}
+		}
+		if got := w.String(); got != "abcde" {
+			t.Fatalf("String() = %q, want %q", got, "abcde")
+		}
+	})
+	t.Run("zero limit retains nothing but still consumes the write", func(t *testing.T) {
+		w := &headLimitedWriter{limit: 0}
+		n, err := w.Write([]byte("xyz"))
+		if err != nil || n != 3 {
+			t.Fatalf("Write = (%d, %v), want (3, nil)", n, err)
+		}
+		if got := w.String(); got != "" {
+			t.Fatalf("String() = %q, want empty", got)
+		}
+	})
+}

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -656,6 +656,33 @@ func appendUniqueStrings(dst []string, items ...string) []string {
 	return dst
 }
 
+// resolveInitFormulas materializes formula symlinks for every pack layer
+// visible to the city. Loads the just-written city.toml via LoadWithIncludes
+// so pack-imported formula layers are included alongside the city-local
+// formulas dir, then delegates to ResolveFormulas.
+//
+// Best-effort: silently returns when the config cannot be loaded or yields no
+// formula layers. Resolution errors are reported to stderr but do not abort
+// init.
+//
+// History: an earlier version of cmd_init called ResolveFormulas with only
+// the city-local formulas dir. That caused cleanStaleFormulaSymlinks to treat
+// every pack-imported symlink in .beads/formulas/ as stale and delete it,
+// breaking pack-imported formulas city-wide until the next `gc start`. See
+// ga-kd2 / pe-mcpb.
+func resolveInitFormulas(cityPath string, stderr io.Writer) {
+	expandedCfg, _, loadErr := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if loadErr != nil {
+		return
+	}
+	if len(expandedCfg.FormulaLayers.City) == 0 {
+		return
+	}
+	if rfErr := ResolveFormulas(cityPath, expandedCfg.FormulaLayers.City); rfErr != nil {
+		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
+	}
+}
+
 func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
 	var cityPath string
 	if len(args) > 0 {
@@ -751,11 +778,6 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		fmt.Fprintln(stdout, "Preserved existing pack.toml.") //nolint:errcheck // best-effort stdout
 	}
 
-	formulasInitDir := filepath.Join(cityPath, citylayout.FormulasRoot)
-	if rfErr := ResolveFormulas(cityPath, []string{formulasInitDir}); rfErr != nil {
-		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
-	}
-
 	// Re-marshal so the name and rewritten prompt paths are updated.
 	content, err := cityCfg.Marshal()
 	if err != nil {
@@ -791,6 +813,8 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 			return 1
 		}
 	}
+
+	resolveInitFormulas(cityPath, stderr)
 
 	fmt.Fprintf(stdout, "Welcome to Gas City!\n")                                           //nolint:errcheck // best-effort stdout
 	fmt.Fprintf(stdout, "Initialized city %q from %s.\n", cityName, filepath.Base(tomlSrc)) //nolint:errcheck // best-effort stdout
@@ -872,11 +896,6 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		return code
 	}
 
-	formulasDir := filepath.Join(cityPath, citylayout.FormulasRoot)
-	if err := ResolveFormulas(cityPath, []string{formulasDir}); err != nil {
-		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", err) //nolint:errcheck // best-effort stderr
-	}
-
 	// Write city.toml — wizard path gets one agent + provider/startCommand;
 	// --provider path gets the same city shape non-interactively;
 	// custom path gets one mayor + no provider (user configures manually).
@@ -929,6 +948,8 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 			return 1
 		}
 	}
+
+	resolveInitFormulas(cityPath, stderr)
 
 	switch {
 	case wiz.interactive:

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -115,6 +115,39 @@ func (s *rollbackCloseFailStore) Close(string) error {
 	return s.closeErr
 }
 
+// TestEnsureQueuedNudgeBeadStampsRoutedToTarget pins the rule that the
+// nudge bead carries gc.routed_to=<target-agent>. Without it, the per-rig
+// auto-route order treats the freshly-created nudge bead as ready,
+// unrouted, work-type work and re-routes it to the host rig's polecat
+// pool — surfacing as phantom work for an unrelated rig (see ga-0qf).
+// The route value must match item.Agent so consumers reading the bead
+// can recover the intended target from the metadata alone.
+func TestEnsureQueuedNudgeBeadStampsRoutedToTarget(t *testing.T) {
+	store := beads.NewMemStore()
+	item := queuedNudge{
+		ID:        "nudge-routed-target",
+		Agent:     "gas-ui/gastown.refinery",
+		SessionID: "mc-routed",
+		Source:    "session",
+		Message:   "follow up",
+		CreatedAt: time.Now().Add(-time.Minute).UTC(),
+	}
+	createdID, created, err := ensureQueuedNudgeBead(store, item)
+	if err != nil {
+		t.Fatalf("ensureQueuedNudgeBead: %v", err)
+	}
+	if !created {
+		t.Fatal("expected ensureQueuedNudgeBead to create a backing nudge bead")
+	}
+	bead, err := store.Get(createdID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", createdID, err)
+	}
+	if got := bead.Metadata["gc.routed_to"]; got != item.Agent {
+		t.Fatalf("bead.Metadata[gc.routed_to] = %q, want %q (auto-route claims unrouted nudge beads as phantom polecat work)", got, item.Agent)
+	}
+}
+
 func TestMarkQueuedNudgeTerminalFallsBackWhenStoredBeadIDEmpty(t *testing.T) {
 	store := beads.NewMemStore()
 	item := queuedNudge{

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -286,7 +286,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 				cfg.AgentDefaults.AppendFragments,
 			)
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, stderr,
-				cfg.PackDirs, fragments, nil)
+				effectivePackDirs(cfg.PackDirs, cfg.RigPackDirs, ctx.RigName), fragments, nil)
 			if prompt != "" {
 				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat, suppressHookPrompt)
 				return 0

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1035,8 +1035,13 @@ func TestBuiltInSlingPoolRouteContractUsesMetadataOnly(t *testing.T) {
 	if got := counts["saitoc/polecat"]; got != 0 {
 		t.Fatalf("polecat scale count after refinery handoff with stale pool label = %d, want 0", got)
 	}
-	if got := counts["saitoc/refinery"]; got != 0 {
-		t.Fatalf("refinery generic scale count for assigned handoff = %d, want 0", got)
+	// Polecat handoff sets assignee == gc.routed_to == "saitoc/refinery". With
+	// no refinery session running, this placeholder assignee is pool demand:
+	// the scaler must wake/spawn a refinery to claim it. Asserting count == 0
+	// here was the ga-2pz bug — beads parked on the pool template name sat
+	// invisible to both the scaler and every work_query.
+	if got := counts["saitoc/refinery"]; got != 1 {
+		t.Fatalf("refinery scale count for placeholder-assignee handoff = %d, want 1", got)
 	}
 }
 

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -8882,12 +8882,20 @@ export interface operations {
                 cursor?: string;
                 /** @description Maximum number of results to return. 0 = server default. */
                 limit?: number;
-                /** @description Filter by agent name. */
+                /** @description Filter by recipient (mailbox). */
                 agent?: string;
-                /** @description Filter by status (unread, all). */
+                /** @description Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads. */
                 status?: string;
                 /** @description Filter by rig name. */
                 rig?: string;
+                /** @description Filter by sender (metadata.from / Bead.From). Empty = no sender constraint. */
+                from?: string;
+                /** @description Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint. */
+                label?: string;
+                /** @description Convenience filter for the per-viewer archive model: equivalent to label='archived:<viewer>' with read messages included. Conflicts with 'label'. */
+                archived_for?: string;
+                /** @description Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics. */
+                include_closed?: boolean;
             };
             header?: never;
             path: {

--- a/cmd/gc/idle_renudge.go
+++ b/cmd/gc/idle_renudge.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// idleRenudgeMinAge is the minimum time a session must have been alive
+// (or quiet since its last re-nudge) before detectIdleReloadSurvivors
+// will return it as a target. The same value is used as the cooldown
+// between successive re-nudges, so a busy reconciler tick cannot spam
+// the same session every few seconds.
+//
+// 5 minutes leaves plenty of room for the spawn-time nudge to land,
+// for the LLM to issue its first tool call, and for the work_query
+// loop to claim a bead — typical fresh-spawn timelines are well under
+// a minute. Reload-survivor sessions sit at the prompt indefinitely,
+// so a longer threshold here is fine and avoids re-nudge noise on
+// healthy-but-quiet workers.
+const idleRenudgeMinAge = 5 * time.Minute
+
+// idleRenudgeLastAtKey is the session bead metadata field that records
+// the most recent idle re-nudge timestamp (RFC3339). The detector
+// treats this and last_woke_at as equivalent anchors when computing
+// session age, so successive ticks cannot fire faster than
+// idleRenudgeMinAge apart.
+const idleRenudgeLastAtKey = "last_idle_renudge_at"
+
+// idleRenudgeTarget identifies an alive pool session that should be
+// re-nudged because it appears idle while routed pool work waits.
+type idleRenudgeTarget struct {
+	SessionID   string
+	SessionName string
+	Template    string
+	NudgeText   string
+}
+
+// detectIdleReloadSurvivors returns the alive ephemeral pool sessions
+// that should be re-nudged this tick.
+//
+// The reload-survivor failure mode (ga-2ph follow-up): a polecat
+// session was alive before a prompt-template update, so its on-spawn
+// nudge fired against the old prompt and the LLM produced
+// "Session started. Ready..." text instead of running gc hook. The
+// supervisor cannot tell from session liveness alone that the LLM is
+// idle — the tmux session is up, scale_check sees a slot occupied,
+// and no work-aware code path nudges it. Detection criteria:
+//
+//   - state=active (alive in metadata; healState keeps this honest)
+//   - ephemeral pool session (not named/manual/dependency-only)
+//   - not held, quarantined, draining, or pending-create
+//   - the agent has a Nudge string configured
+//   - routed pool work for the agent's template (workSet[template])
+//   - no open/in_progress work bead assigned by ID or session_name
+//   - age >= idleRenudgeMinAge from the more recent of last_woke_at
+//     or last_idle_renudge_at (so the spawn-time nudge has had its
+//     chance and successive re-nudges respect a cooldown)
+//
+// Returns nil when the workSet has no entries — the common case on a
+// reconciler tick with an empty queue, where the detector does no
+// per-session work at all.
+func detectIdleReloadSurvivors(
+	sessions []beads.Bead,
+	cfg *config.City,
+	assignedWorkBeads []beads.Bead,
+	workSet map[string]bool,
+	clk clock.Clock,
+) []idleRenudgeTarget {
+	if cfg == nil || clk == nil || len(sessions) == 0 || len(workSet) == 0 {
+		return nil
+	}
+	now := clk.Now()
+
+	var targets []idleRenudgeTarget
+	for _, session := range sessions {
+		template, nudgeText, ok := idleRenudgeSessionEligible(session, cfg, workSet, now)
+		if !ok {
+			continue
+		}
+		if sessionHasInProgressAssignment(session, assignedWorkBeads) {
+			continue
+		}
+		name := strings.TrimSpace(session.Metadata["session_name"])
+		if name == "" {
+			continue
+		}
+		targets = append(targets, idleRenudgeTarget{
+			SessionID:   session.ID,
+			SessionName: name,
+			Template:    template,
+			NudgeText:   nudgeText,
+		})
+	}
+	return targets
+}
+
+// idleRenudgeSessionEligible reports whether session passes every
+// non-assignment-related precondition. Returns (template, nudgeText,
+// true) when eligible so callers don't have to re-derive either.
+func idleRenudgeSessionEligible(
+	session beads.Bead,
+	cfg *config.City,
+	workSet map[string]bool,
+	now time.Time,
+) (string, string, bool) {
+	if session.Status == "closed" {
+		return "", "", false
+	}
+	if sessionMetadataState(session) != "active" {
+		return "", "", false
+	}
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" {
+		return "", "", false
+	}
+	if isDrainedSessionBead(session) {
+		return "", "", false
+	}
+	if isNamedSessionBead(session) || isManualSessionBead(session) {
+		return "", "", false
+	}
+	if !isEphemeralSessionBead(session) {
+		return "", "", false
+	}
+	if session.Metadata["wait_hold"] != "" {
+		return "", "", false
+	}
+	if held := session.Metadata["held_until"]; held != "" {
+		if t, err := time.Parse(time.RFC3339, held); err == nil && now.Before(t) {
+			return "", "", false
+		}
+	}
+	if q := session.Metadata["quarantined_until"]; q != "" {
+		if t, err := time.Parse(time.RFC3339, q); err == nil && now.Before(t) {
+			return "", "", false
+		}
+	}
+
+	template := normalizedSessionTemplate(session, cfg)
+	if template == "" || !workSet[template] {
+		return "", "", false
+	}
+	agent := findAgentByTemplate(cfg, template)
+	if agent == nil || strings.TrimSpace(agent.Nudge) == "" {
+		return "", "", false
+	}
+
+	last := idleRenudgeLastActivity(session)
+	if last.IsZero() {
+		return "", "", false
+	}
+	if now.Sub(last) < idleRenudgeMinAge {
+		return "", "", false
+	}
+	return template, agent.Nudge, true
+}
+
+// idleRenudgeLastActivity returns the most recent of last_woke_at and
+// last_idle_renudge_at as the session's "age anchor." Either value
+// alone is sufficient; both being zero means the session has never
+// reported activity (e.g., a half-initialized bead) and is not a
+// re-nudge candidate.
+func idleRenudgeLastActivity(session beads.Bead) time.Time {
+	var last time.Time
+	if v := strings.TrimSpace(session.Metadata["last_woke_at"]); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil && t.After(last) {
+			last = t
+		}
+	}
+	if v := strings.TrimSpace(session.Metadata[idleRenudgeLastAtKey]); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil && t.After(last) {
+			last = t
+		}
+	}
+	return last
+}
+
+// sessionHasInProgressAssignment reports whether any open or
+// in_progress work bead is assigned to the given session (by bead ID
+// or session_name). Closed beads do not count: a polecat that just
+// finished work and drained-acked has no active assignment.
+func sessionHasInProgressAssignment(session beads.Bead, workBeads []beads.Bead) bool {
+	name := strings.TrimSpace(session.Metadata["session_name"])
+	for _, wb := range workBeads {
+		if wb.Status != "open" && wb.Status != "in_progress" {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if assignee == session.ID || (name != "" && assignee == name) {
+			return true
+		}
+	}
+	return false
+}
+
+// renudgeIdleSessions delivers the configured nudge text to each target
+// and stamps idleRenudgeLastAtKey on the bead so the cooldown applies.
+// A Nudge failure is logged and the metadata is intentionally left
+// unchanged so the next reconciler tick retries — a missing tmux
+// session, for example, will heal to state=asleep on the same tick and
+// drop out of detector candidates organically.
+func renudgeIdleSessions(
+	ctx context.Context,
+	targets []idleRenudgeTarget,
+	sp runtime.Provider,
+	store beads.Store,
+	clk clock.Clock,
+	stderr io.Writer,
+) {
+	if len(targets) == 0 || sp == nil || store == nil || clk == nil {
+		return
+	}
+	nowStr := clk.Now().UTC().Format(time.RFC3339)
+	for _, t := range targets {
+		if ctx != nil && ctx.Err() != nil {
+			return
+		}
+		if err := sp.Nudge(t.SessionName, runtime.TextContent(t.NudgeText)); err != nil {
+			if stderr != nil {
+				fmt.Fprintf(stderr, "idle re-nudge: deliver %s (%s): %v\n", t.SessionName, t.Template, err) //nolint:errcheck // best-effort stderr
+			}
+			continue
+		}
+		if err := store.SetMetadata(t.SessionID, idleRenudgeLastAtKey, nowStr); err != nil {
+			if stderr != nil {
+				fmt.Fprintf(stderr, "idle re-nudge: record %s on %s: %v\n", idleRenudgeLastAtKey, t.SessionID, err) //nolint:errcheck // best-effort stderr
+			}
+		}
+	}
+}

--- a/cmd/gc/idle_renudge_test.go
+++ b/cmd/gc/idle_renudge_test.go
@@ -16,7 +16,11 @@ import (
 
 // makeAliveEphemeralPoolBead builds a session bead that looks like a live
 // pool worker. Tests tweak individual fields after construction to cover
-// the eligibility predicates.
+// the eligibility predicates. The template parameter is retained for
+// call-site clarity even though current tests always pass "polecat";
+// future eligibility tests may vary it.
+//
+//nolint:unparam // template kept as a parameter intentionally; see above.
 func makeAliveEphemeralPoolBead(id, sessionName, template, lastWokeAt string) beads.Bead {
 	return beads.Bead{
 		ID:     id,
@@ -176,39 +180,39 @@ func TestDetectIdleReloadSurvivors_SkipsNonAliveOrSuppressed(t *testing.T) {
 	wokenLongAgo := now.Add(-1 * time.Hour).Format(time.RFC3339)
 
 	cases := []struct {
-		name  string
+		name   string
 		mutate func(b *beads.Bead)
 	}{
 		{
-			name: "state=asleep",
+			name:   "state=asleep",
 			mutate: func(b *beads.Bead) { b.Metadata["state"] = "asleep" },
 		},
 		{
-			name: "state=drained",
+			name:   "state=drained",
 			mutate: func(b *beads.Bead) { b.Metadata["state"] = "drained" },
 		},
 		{
-			name: "state=creating",
+			name:   "state=creating",
 			mutate: func(b *beads.Bead) { b.Metadata["state"] = "creating" },
 		},
 		{
-			name: "pending_create_claim=true",
+			name:   "pending_create_claim=true",
 			mutate: func(b *beads.Bead) { b.Metadata["pending_create_claim"] = "true" },
 		},
 		{
-			name: "status=closed",
+			name:   "status=closed",
 			mutate: func(b *beads.Bead) { b.Status = "closed" },
 		},
 		{
-			name: "held_until in future",
+			name:   "held_until in future",
 			mutate: func(b *beads.Bead) { b.Metadata["held_until"] = now.Add(time.Hour).Format(time.RFC3339) },
 		},
 		{
-			name: "quarantined_until in future",
+			name:   "quarantined_until in future",
 			mutate: func(b *beads.Bead) { b.Metadata["quarantined_until"] = now.Add(time.Hour).Format(time.RFC3339) },
 		},
 		{
-			name: "wait_hold set",
+			name:   "wait_hold set",
 			mutate: func(b *beads.Bead) { b.Metadata["wait_hold"] = "true" },
 		},
 		{

--- a/cmd/gc/idle_renudge_test.go
+++ b/cmd/gc/idle_renudge_test.go
@@ -1,0 +1,547 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// makeAliveEphemeralPoolBead builds a session bead that looks like a live
+// pool worker. Tests tweak individual fields after construction to cover
+// the eligibility predicates.
+func makeAliveEphemeralPoolBead(id, sessionName, template, lastWokeAt string) beads.Bead {
+	return beads.Bead{
+		ID:     id,
+		Status: "open",
+		Metadata: map[string]string{
+			"template":       template,
+			"session_name":   sessionName,
+			"pool_slot":      "1",
+			"session_origin": "ephemeral",
+			"state":          "active",
+			"last_woke_at":   lastWokeAt,
+		},
+	}
+}
+
+// polecatPoolCfg returns a config with one pool agent whose nudge text
+// matches the polecat agent.toml.
+func polecatPoolCfg() *config.City {
+	return &config.City{
+		Agents: []config.Agent{
+			{
+				Name:              "polecat",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "echo 1",
+				Nudge:             "Run gc hook; it checks assigned work first, then routed pool work.",
+			},
+		},
+	}
+}
+
+func TestDetectIdleReloadSurvivors_HappyPath(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	session := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat",
+		now.Add(-10*time.Minute).Format(time.RFC3339))
+	workSet := map[string]bool{"polecat": true}
+
+	got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, nil, workSet, clk)
+	if len(got) != 1 {
+		t.Fatalf("want 1 target, got %d: %+v", len(got), got)
+	}
+	if got[0].SessionID != "b1" || got[0].SessionName != "pol-1" || got[0].Template != "polecat" {
+		t.Errorf("target fields mismatch: %+v", got[0])
+	}
+	if got[0].NudgeText != cfg.Agents[0].Nudge {
+		t.Errorf("nudge text = %q; want %q", got[0].NudgeText, cfg.Agents[0].Nudge)
+	}
+}
+
+func TestDetectIdleReloadSurvivors_SkipsWhenAssignedWorkInProgress(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	session := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat",
+		now.Add(-10*time.Minute).Format(time.RFC3339))
+	workSet := map[string]bool{"polecat": true}
+
+	// Work assigned to this session (by bead ID): not idle.
+	workAssignedByID := beads.Bead{ID: "w1", Status: "in_progress", Assignee: "b1"}
+	if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, []beads.Bead{workAssignedByID}, workSet, clk); len(got) != 0 {
+		t.Errorf("assigned by ID should skip, got %+v", got)
+	}
+
+	// Work assigned to this session (by session_name): not idle.
+	workAssignedByName := beads.Bead{ID: "w2", Status: "open", Assignee: "pol-1"}
+	if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, []beads.Bead{workAssignedByName}, workSet, clk); len(got) != 0 {
+		t.Errorf("assigned by name should skip, got %+v", got)
+	}
+
+	// Closed work doesn't count — session still idle.
+	workClosed := beads.Bead{ID: "w3", Status: "closed", Assignee: "pol-1"}
+	if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, []beads.Bead{workClosed}, workSet, clk); len(got) != 1 {
+		t.Errorf("closed work should not block re-nudge, got %+v", got)
+	}
+}
+
+func TestDetectIdleReloadSurvivors_SkipsWhenNoRoutedPoolWork(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	session := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat",
+		now.Add(-10*time.Minute).Format(time.RFC3339))
+
+	// Empty workSet → no work routed → nothing to do.
+	if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, nil, nil, clk); len(got) != 0 {
+		t.Errorf("empty workSet should not re-nudge, got %+v", got)
+	}
+
+	// workSet for a different template → still nothing.
+	if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, nil, map[string]bool{"refinery": true}, clk); len(got) != 0 {
+		t.Errorf("mismatched workSet should not re-nudge, got %+v", got)
+	}
+}
+
+func TestDetectIdleReloadSurvivors_RespectsMinAge(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	workSet := map[string]bool{"polecat": true}
+
+	// Just-woken session (well under threshold) → skip.
+	freshSession := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat",
+		now.Add(-1*time.Minute).Format(time.RFC3339))
+	if got := detectIdleReloadSurvivors([]beads.Bead{freshSession}, cfg, nil, workSet, clk); len(got) != 0 {
+		t.Errorf("fresh session (under threshold) should not re-nudge, got %+v", got)
+	}
+
+	// At threshold exactly → eligible (>=).
+	atThreshold := makeAliveEphemeralPoolBead("b2", "pol-2", "polecat",
+		now.Add(-idleRenudgeMinAge).Format(time.RFC3339))
+	if got := detectIdleReloadSurvivors([]beads.Bead{atThreshold}, cfg, nil, workSet, clk); len(got) != 1 {
+		t.Errorf("session at threshold should re-nudge, got %+v", got)
+	}
+
+	// Missing last_woke_at → skip (no anchor for age).
+	noAnchor := makeAliveEphemeralPoolBead("b3", "pol-3", "polecat", "")
+	if got := detectIdleReloadSurvivors([]beads.Bead{noAnchor}, cfg, nil, workSet, clk); len(got) != 0 {
+		t.Errorf("missing last_woke_at should skip, got %+v", got)
+	}
+}
+
+func TestDetectIdleReloadSurvivors_HonorsCooldownAfterPreviousRenudge(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	workSet := map[string]bool{"polecat": true}
+
+	// Session woken long ago, but re-nudged 1 minute ago → cooldown blocks.
+	session := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat",
+		now.Add(-1*time.Hour).Format(time.RFC3339))
+	session.Metadata[idleRenudgeLastAtKey] = now.Add(-1 * time.Minute).Format(time.RFC3339)
+
+	if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, nil, workSet, clk); len(got) != 0 {
+		t.Errorf("cooldown should block re-nudge, got %+v", got)
+	}
+
+	// Cooldown elapsed → eligible again.
+	session.Metadata[idleRenudgeLastAtKey] = now.Add(-idleRenudgeMinAge).Format(time.RFC3339)
+	if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, nil, workSet, clk); len(got) != 1 {
+		t.Errorf("elapsed cooldown should allow re-nudge, got %+v", got)
+	}
+}
+
+func TestDetectIdleReloadSurvivors_SkipsNonAliveOrSuppressed(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	workSet := map[string]bool{"polecat": true}
+	wokenLongAgo := now.Add(-1 * time.Hour).Format(time.RFC3339)
+
+	cases := []struct {
+		name  string
+		mutate func(b *beads.Bead)
+	}{
+		{
+			name: "state=asleep",
+			mutate: func(b *beads.Bead) { b.Metadata["state"] = "asleep" },
+		},
+		{
+			name: "state=drained",
+			mutate: func(b *beads.Bead) { b.Metadata["state"] = "drained" },
+		},
+		{
+			name: "state=creating",
+			mutate: func(b *beads.Bead) { b.Metadata["state"] = "creating" },
+		},
+		{
+			name: "pending_create_claim=true",
+			mutate: func(b *beads.Bead) { b.Metadata["pending_create_claim"] = "true" },
+		},
+		{
+			name: "status=closed",
+			mutate: func(b *beads.Bead) { b.Status = "closed" },
+		},
+		{
+			name: "held_until in future",
+			mutate: func(b *beads.Bead) { b.Metadata["held_until"] = now.Add(time.Hour).Format(time.RFC3339) },
+		},
+		{
+			name: "quarantined_until in future",
+			mutate: func(b *beads.Bead) { b.Metadata["quarantined_until"] = now.Add(time.Hour).Format(time.RFC3339) },
+		},
+		{
+			name: "wait_hold set",
+			mutate: func(b *beads.Bead) { b.Metadata["wait_hold"] = "true" },
+		},
+		{
+			name: "asleep+sleep_reason=drained",
+			mutate: func(b *beads.Bead) {
+				b.Metadata["state"] = "asleep"
+				b.Metadata["sleep_reason"] = "drained"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			session := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat", wokenLongAgo)
+			tc.mutate(&session)
+			if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, nil, workSet, clk); len(got) != 0 {
+				t.Errorf("%s should skip, got %+v", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestDetectIdleReloadSurvivors_SkipsNonEphemeralSessions(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	workSet := map[string]bool{"polecat": true}
+	wokenLongAgo := now.Add(-1 * time.Hour).Format(time.RFC3339)
+
+	// Named session → skip.
+	named := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat", wokenLongAgo)
+	named.Metadata["session_origin"] = "named"
+	named.Metadata["named_session"] = "true"
+	delete(named.Metadata, "pool_slot")
+	if got := detectIdleReloadSurvivors([]beads.Bead{named}, cfg, nil, workSet, clk); len(got) != 0 {
+		t.Errorf("named session should skip, got %+v", got)
+	}
+
+	// Manual session → skip.
+	manual := makeAliveEphemeralPoolBead("b2", "pol-2", "polecat", wokenLongAgo)
+	manual.Metadata["session_origin"] = "manual"
+	delete(manual.Metadata, "pool_slot")
+	if got := detectIdleReloadSurvivors([]beads.Bead{manual}, cfg, nil, workSet, clk); len(got) != 0 {
+		t.Errorf("manual session should skip, got %+v", got)
+	}
+}
+
+func TestDetectIdleReloadSurvivors_SkipsWhenAgentHasNoNudge(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	cfg.Agents[0].Nudge = "" // remove configured nudge text
+	workSet := map[string]bool{"polecat": true}
+
+	session := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat",
+		now.Add(-1*time.Hour).Format(time.RFC3339))
+
+	if got := detectIdleReloadSurvivors([]beads.Bead{session}, cfg, nil, workSet, clk); len(got) != 0 {
+		t.Errorf("agent without nudge text should skip, got %+v", got)
+	}
+}
+
+func TestDetectIdleReloadSurvivors_HandlesMultipleSessionsDeterministically(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	cfg := polecatPoolCfg()
+	workSet := map[string]bool{"polecat": true}
+	wokenLongAgo := now.Add(-1 * time.Hour).Format(time.RFC3339)
+
+	idleA := makeAliveEphemeralPoolBead("b1", "pol-1", "polecat", wokenLongAgo)
+	idleC := makeAliveEphemeralPoolBead("b3", "pol-3", "polecat", wokenLongAgo)
+
+	// Mix in one busy session and one fresh session.
+	busy := makeAliveEphemeralPoolBead("b2", "pol-2", "polecat", wokenLongAgo)
+	fresh := makeAliveEphemeralPoolBead("b4", "pol-4", "polecat",
+		now.Add(-30*time.Second).Format(time.RFC3339))
+
+	workBeads := []beads.Bead{{ID: "w1", Status: "in_progress", Assignee: "pol-2"}}
+
+	got := detectIdleReloadSurvivors([]beads.Bead{idleA, busy, idleC, fresh}, cfg, workBeads, workSet, clk)
+	if len(got) != 2 {
+		t.Fatalf("want 2 idle targets, got %d: %+v", len(got), got)
+	}
+	ids := []string{got[0].SessionID, got[1].SessionID}
+	sort.Strings(ids)
+	if ids[0] != "b1" || ids[1] != "b3" {
+		t.Errorf("targets = %v; want [b1 b3]", ids)
+	}
+}
+
+// stubNudgeProvider records every Nudge() call. Other Provider methods
+// are not exercised by renudgeIdleSessions, so this struct deliberately
+// embeds runtime.Provider via a nil interface and only implements Nudge.
+type stubNudgeProvider struct {
+	runtime.Provider
+	calls []nudgeCall
+	err   error
+}
+
+type nudgeCall struct {
+	name string
+	text string
+}
+
+func (p *stubNudgeProvider) Nudge(name string, content []runtime.ContentBlock) error {
+	p.calls = append(p.calls, nudgeCall{name: name, text: runtime.FlattenText(content)})
+	return p.err
+}
+
+func TestRenudgeIdleSessions_DeliversAndRecordsTimestamp(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	sp := &stubNudgeProvider{}
+	store := newTestStore()
+
+	targets := []idleRenudgeTarget{
+		{SessionID: "b1", SessionName: "pol-1", Template: "polecat", NudgeText: "Run gc hook"},
+		{SessionID: "b2", SessionName: "pol-2", Template: "polecat", NudgeText: "Run gc hook"},
+	}
+
+	var stderr bytes.Buffer
+	renudgeIdleSessions(context.Background(), targets, sp, store, clk, &stderr)
+
+	if len(sp.calls) != 2 {
+		t.Fatalf("want 2 nudge calls, got %d: %+v", len(sp.calls), sp.calls)
+	}
+	if sp.calls[0].name != "pol-1" || sp.calls[1].name != "pol-2" {
+		t.Errorf("nudge call names = %+v", sp.calls)
+	}
+	if sp.calls[0].text != "Run gc hook" {
+		t.Errorf("nudge text = %q", sp.calls[0].text)
+	}
+
+	wantTs := now.UTC().Format(time.RFC3339)
+	if got := store.metadata["b1"][idleRenudgeLastAtKey]; got != wantTs {
+		t.Errorf("b1 timestamp = %q; want %q", got, wantTs)
+	}
+	if got := store.metadata["b2"][idleRenudgeLastAtKey]; got != wantTs {
+		t.Errorf("b2 timestamp = %q; want %q", got, wantTs)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("expected no stderr output on success, got %q", stderr.String())
+	}
+}
+
+func TestRenudgeIdleSessions_NudgeFailureDoesNotUpdateTimestamp(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	sp := &stubNudgeProvider{err: errors.New("session not found")}
+	store := newTestStore()
+
+	targets := []idleRenudgeTarget{
+		{SessionID: "b1", SessionName: "pol-1", Template: "polecat", NudgeText: "Run gc hook"},
+	}
+
+	var stderr bytes.Buffer
+	renudgeIdleSessions(context.Background(), targets, sp, store, clk, &stderr)
+
+	if _, ok := store.metadata["b1"]; ok {
+		t.Errorf("failed nudge should not write metadata, got %+v", store.metadata)
+	}
+	if stderr.Len() == 0 {
+		t.Errorf("expected stderr log on failure")
+	}
+}
+
+func TestRenudgeIdleSessions_RespectsCanceledContext(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	sp := &stubNudgeProvider{}
+	store := newTestStore()
+
+	targets := []idleRenudgeTarget{
+		{SessionID: "b1", SessionName: "pol-1", Template: "polecat", NudgeText: "Run gc hook"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	renudgeIdleSessions(ctx, targets, sp, store, clk, nil)
+
+	if len(sp.calls) != 0 {
+		t.Errorf("canceled context should skip nudge calls, got %+v", sp.calls)
+	}
+}
+
+// TestReconcileSessionBeads_IdleReloadSurvivorIsRenudged is the end-to-end
+// proof for ga-6lj: a reconciler tick handed an alive ephemeral pool session
+// with no in-progress work, routed pool work, and last_woke_at past the
+// re-nudge threshold must fire sp.Nudge with the configured agent text and
+// stamp idleRenudgeLastAtKey on the bead.
+func TestReconcileSessionBeads_IdleReloadSurvivorIsRenudged(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.clk = &clock.Fake{Time: time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)}
+	const nudgeText = "Run gc hook; it checks assigned work first, then routed pool work."
+	env.cfg = &config.City{
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 1",
+			Nudge:             nudgeText,
+		}},
+	}
+	env.addDesired("polecat-1", "polecat", true)
+
+	session := env.createSessionBead("polecat-1", "polecat")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		"pool_slot":      "1",
+		"session_origin": "ephemeral",
+		// Survived past the re-nudge threshold without claiming work.
+		"last_woke_at": env.clk.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
+	})
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"polecat": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		newFakeDrainOps(),
+		nil, // assignedWorkBeads — none, the polecat is idle
+		nil, // rigStores
+		nil,
+		env.dt,
+		map[string]int{"polecat": 1},
+		false,
+		map[string]bool{"polecat": true}, // workSet — routed pool work waiting
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	var nudgeCalls []runtime.Call
+	for _, c := range env.sp.Calls {
+		if c.Method == "Nudge" && c.Name == "polecat-1" {
+			nudgeCalls = append(nudgeCalls, c)
+		}
+	}
+	if len(nudgeCalls) != 1 {
+		t.Fatalf("want 1 Nudge to polecat-1, got %d (all calls: %+v)", len(nudgeCalls), env.sp.Calls)
+	}
+	if nudgeCalls[0].Message != nudgeText {
+		t.Errorf("Nudge text = %q; want %q", nudgeCalls[0].Message, nudgeText)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata[idleRenudgeLastAtKey] == "" {
+		t.Errorf("expected %s to be stamped on session bead, got metadata=%+v", idleRenudgeLastAtKey, got.Metadata)
+	}
+}
+
+// TestReconcileSessionBeads_IdleReloadSurvivor_SkipsWhenAssigned proves the
+// idempotence contract: an alive polecat with open work assigned to it must
+// NOT be re-nudged, even if everything else looks idle. This is the
+// "session is now working" exemption from the ga-6lj acceptance criteria.
+func TestReconcileSessionBeads_IdleReloadSurvivor_SkipsWhenAssigned(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.clk = &clock.Fake{Time: time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)}
+	env.cfg = &config.City{
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "echo 1",
+			Nudge:             "Run gc hook",
+		}},
+	}
+	env.addDesired("polecat-1", "polecat", true)
+
+	session := env.createSessionBead("polecat-1", "polecat")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		"pool_slot":      "1",
+		"session_origin": "ephemeral",
+		"last_woke_at":   env.clk.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
+	})
+
+	// Work bead assigned to this session — session is busy, not idle.
+	workBead := beads.Bead{
+		ID:       "w1",
+		Status:   "in_progress",
+		Assignee: "polecat-1",
+	}
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"polecat": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		newFakeDrainOps(),
+		[]beads.Bead{workBead},
+		nil,
+		nil,
+		env.dt,
+		map[string]int{"polecat": 1},
+		false,
+		map[string]bool{"polecat": true},
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	for _, c := range env.sp.Calls {
+		if c.Method == "Nudge" && c.Name == "polecat-1" {
+			t.Errorf("session with assigned work must not be re-nudged, got %+v", c)
+		}
+	}
+}

--- a/cmd/gc/init_formulas_resolve_test.go
+++ b/cmd/gc/init_formulas_resolve_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// TestResolveInitFormulas_PreservesPackImportSymlinks is a regression for
+// ga-kd2 / pe-mcpb. Earlier, cmd_init passed only the city-local formulas dir
+// to ResolveFormulas, so pack-imported formula symlinks placed in
+// .beads/formulas/ by a prior `gc start` were treated as stale and removed by
+// cleanStaleFormulaSymlinks. resolveInitFormulas must load the full pack
+// layer set and keep those symlinks.
+func TestResolveInitFormulas_PreservesPackImportSymlinks(t *testing.T) {
+	rootDir := t.TempDir()
+	cityPath := filepath.Join(rootDir, "city")
+	packDir := filepath.Join(rootDir, "packs", "mypack")
+
+	if err := os.MkdirAll(filepath.Join(packDir, "formulas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(packDir, "pack.toml"), `[pack]
+name = "mypack"
+schema = 2
+`)
+	formulaSrc := filepath.Join(packDir, "formulas", "mol-pack-formula.toml")
+	writeFile(t, formulaSrc, `formula = "mol-pack-formula"
+`)
+
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityPath, "city.toml"), `[workspace]
+name = "testcity"
+`)
+	writeFile(t, filepath.Join(cityPath, "pack.toml"), `[pack]
+name = "testcity"
+schema = 2
+
+[imports.mypack]
+source = "../packs/mypack"
+`)
+
+	symlinkDir := filepath.Join(cityPath, ".beads", "formulas")
+	if err := os.MkdirAll(symlinkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canonicalLink := filepath.Join(symlinkDir, "mol-pack-formula.toml")
+	legacyLink := filepath.Join(symlinkDir, "mol-pack-formula.formula.toml")
+	for _, link := range []string{canonicalLink, legacyLink} {
+		if err := os.Symlink(formulaSrc, link); err != nil {
+			t.Fatalf("creating symlink %q: %v", link, err)
+		}
+	}
+
+	var stderr bytes.Buffer
+	resolveInitFormulas(cityPath, &stderr)
+	if stderr.Len() > 0 {
+		t.Fatalf("resolveInitFormulas stderr: %s", stderr.String())
+	}
+
+	for _, link := range []string{canonicalLink, legacyLink} {
+		fi, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("expected symlink %q to exist after resolveInitFormulas, got: %v", link, err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("expected %q to be a symlink, got mode %v", link, fi.Mode())
+		}
+		target, err := os.Readlink(link)
+		if err != nil {
+			t.Fatalf("Readlink(%q): %v", link, err)
+		}
+		if target != formulaSrc {
+			t.Fatalf("symlink %q points at %q, want %q", link, target, formulaSrc)
+		}
+	}
+}
+
+// TestResolveInitFormulas_CreatesPackImportSymlinks verifies the positive
+// case: a fresh city that imports a pack with formulas gets the pack's
+// formula symlinks materialized in .beads/formulas/ by init. With the bug,
+// only city-local formulas were resolved, so pack-imported formulas were
+// invisible to bd until the next `gc start`.
+func TestResolveInitFormulas_CreatesPackImportSymlinks(t *testing.T) {
+	rootDir := t.TempDir()
+	cityPath := filepath.Join(rootDir, "city")
+	packDir := filepath.Join(rootDir, "packs", "mypack")
+
+	if err := os.MkdirAll(filepath.Join(packDir, "formulas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(packDir, "pack.toml"), `[pack]
+name = "mypack"
+schema = 2
+`)
+	formulaSrc := filepath.Join(packDir, "formulas", "mol-pack-formula.toml")
+	writeFile(t, formulaSrc, `formula = "mol-pack-formula"
+`)
+
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityPath, "city.toml"), `[workspace]
+name = "testcity"
+`)
+	writeFile(t, filepath.Join(cityPath, "pack.toml"), `[pack]
+name = "testcity"
+schema = 2
+
+[imports.mypack]
+source = "../packs/mypack"
+`)
+
+	var stderr bytes.Buffer
+	resolveInitFormulas(cityPath, &stderr)
+	if stderr.Len() > 0 {
+		t.Fatalf("resolveInitFormulas stderr: %s", stderr.String())
+	}
+
+	for _, name := range []string{"mol-pack-formula.toml", "mol-pack-formula.formula.toml"} {
+		link := filepath.Join(cityPath, ".beads", "formulas", name)
+		fi, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("expected symlink %q to be created by resolveInitFormulas, got: %v", link, err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("expected %q to be a symlink, got mode %v", link, fi.Mode())
+		}
+		target, err := os.Readlink(link)
+		if err != nil {
+			t.Fatalf("Readlink(%q): %v", link, err)
+		}
+		if target != formulaSrc {
+			t.Fatalf("symlink %q points at %q, want %q", link, target, formulaSrc)
+		}
+	}
+}
+
+// TestResolveInitFormulas_NoConfigFileIsSilentNoop verifies that
+// resolveInitFormulas does not panic or write to stderr when there is no
+// city.toml yet. This matters because the init paths that previously called
+// the buggy ResolveFormulas directly were tolerant of partial scaffolds.
+func TestResolveInitFormulas_NoConfigFileIsSilentNoop(t *testing.T) {
+	cityPath := t.TempDir()
+	var stderr bytes.Buffer
+	resolveInitFormulas(cityPath, &stderr)
+	if stderr.Len() > 0 {
+		t.Fatalf("expected silent no-op when city.toml is missing; stderr: %s", stderr.String())
+	}
+}
+
+// TestCmdInitFromTOMLFileWithOptions_PreservesPackFormulaSymlinks exercises
+// the cmd_init.go:cmdInitFromTOMLFileWithOptions call site end-to-end and
+// asserts that pre-existing pack formula symlinks survive an init re-run
+// with --preserve-existing. Regression for ga-kd2.
+func TestCmdInitFromTOMLFileWithOptions_PreservesPackFormulaSymlinks(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	disableBootstrapForTests(t)
+
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = func(_ string, _ string, _ io.Writer, _ io.Writer) (bool, int) {
+		return true, 0
+	}
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+	stubInitDependencyChecks(t)
+	stubInitDoltAuthorIdentity(t, map[string]string{
+		"user.name":  "Tester",
+		"user.email": "tester@example.com",
+	})
+
+	rootDir := t.TempDir()
+	cityPath := filepath.Join(rootDir, "city")
+	packDir := filepath.Join(rootDir, "packs", "mypack")
+
+	if err := os.MkdirAll(filepath.Join(packDir, "formulas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(packDir, "pack.toml"), `[pack]
+name = "mypack"
+schema = 2
+`)
+	formulaSrc := filepath.Join(packDir, "formulas", "mol-pack-formula.toml")
+	writeFile(t, formulaSrc, `formula = "mol-pack-formula"
+`)
+
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityPath, "city.toml"), `[workspace]
+name = "testcity"
+`)
+	writeFile(t, filepath.Join(cityPath, "pack.toml"), `[pack]
+name = "testcity"
+schema = 2
+
+[imports.mypack]
+source = "../packs/mypack"
+`)
+	symlinkDir := filepath.Join(cityPath, ".beads", "formulas")
+	if err := os.MkdirAll(symlinkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canonicalLink := filepath.Join(symlinkDir, "mol-pack-formula.toml")
+	legacyLink := filepath.Join(symlinkDir, "mol-pack-formula.formula.toml")
+	for _, link := range []string{canonicalLink, legacyLink} {
+		if err := os.Symlink(formulaSrc, link); err != nil {
+			t.Fatalf("creating symlink %q: %v", link, err)
+		}
+	}
+
+	srcToml := filepath.Join(rootDir, "source.toml")
+	writeFile(t, srcToml, `[workspace]
+name = "testcity"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, srcToml, cityPath, "", &stdout, &stderr, true, true)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d; stderr: %s", code, stderr.String())
+	}
+
+	for _, link := range []string{canonicalLink, legacyLink} {
+		fi, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("expected symlink %q to survive init, got: %v", link, err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("expected %q to be a symlink, got mode %v", link, fi.Mode())
+		}
+	}
+}
+
+// TestDoInit_CreatesPackFormulaSymlinksFromExistingPackToml exercises the
+// cmd_init.go:doInit call site end-to-end. Pre-creates a pack.toml with an
+// import so the wizard path preserves it under --preserve-existing, then
+// asserts pack formula symlinks are materialized after doInit. Regression
+// for ga-kd2.
+func TestDoInit_CreatesPackFormulaSymlinksFromExistingPackToml(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	disableBootstrapForTests(t)
+
+	rootDir := t.TempDir()
+	cityPath := filepath.Join(rootDir, "city")
+	packDir := filepath.Join(rootDir, "packs", "mypack")
+
+	if err := os.MkdirAll(filepath.Join(packDir, "formulas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(packDir, "pack.toml"), `[pack]
+name = "mypack"
+schema = 2
+`)
+	formulaSrc := filepath.Join(packDir, "formulas", "mol-pack-formula.toml")
+	writeFile(t, formulaSrc, `formula = "mol-pack-formula"
+`)
+
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityPath, "pack.toml"), `[pack]
+name = "testcity"
+schema = 2
+
+[imports.mypack]
+source = "../packs/mypack"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doInit(fsys.OSFS{}, cityPath, defaultWizardConfig(), "", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("doInit = %d; stderr: %s", code, stderr.String())
+	}
+
+	for _, name := range []string{"mol-pack-formula.toml", "mol-pack-formula.formula.toml"} {
+		link := filepath.Join(cityPath, ".beads", "formulas", name)
+		fi, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("expected symlink %q after doInit, got: %v", link, err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("expected %q to be a symlink, got mode %v", link, fi.Mode())
+		}
+	}
+}

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -117,6 +117,13 @@ func ensureQueuedNudgeBead(store beads.Store, item queuedNudge) (string, bool, e
 		"terminal_reason":    "",
 		"commit_boundary":    "",
 		"terminal_at":        "",
+		// gc.routed_to points the nudge bead at the delivery target so
+		// per-rig auto-route orders skip it. Without this stamp the chore-
+		// typed bead looks like ready unrouted work and gets slung into
+		// whichever rig's polecat pool owns the store the bead landed in
+		// (e.g. the city's HQ rig when the emitter is cross-rig). See
+		// ga-0qf for the phantom-work fallout that motivates this.
+		"gc.routed_to": item.Agent,
 	}
 	created, err := store.Create(beads.Bead{
 		Title: "nudge:" + item.ID,

--- a/cmd/gc/rig_scope_resolution.go
+++ b/cmd/gc/rig_scope_resolution.go
@@ -1,13 +1,21 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/git"
 )
+
+// gitCommonDirLookupTimeout caps the subprocess git call used by
+// rigFromGitWorktree so a hung git invocation cannot stall every
+// `gc bd` command. Resolution falls back to the city scope on timeout.
+const gitCommonDirLookupTimeout = 2 * time.Second
 
 func rigForDir(cfg *config.City, cityPath, dir string) (config.Rig, bool) {
 	rig, ok, _ := resolveRigForDir(cfg, cityPath, dir)
@@ -26,7 +34,10 @@ func resolveRigForDir(cfg *config.City, cityPath, dir string) (config.Rig, bool,
 			return rig, true, nil
 		}
 	}
-	return rigFromRedirectedBeadsDir(cfg, cityPath, dir)
+	if rig, ok, err := rigFromRedirectedBeadsDir(cfg, cityPath, dir); ok || err != nil {
+		return rig, ok, err
+	}
+	return rigFromGitWorktree(cfg, cityPath, dir)
 }
 
 func rigFromRedirectedBeadsDir(cfg *config.City, cityPath, dir string) (config.Rig, bool, error) {
@@ -74,4 +85,65 @@ func pathWithinScope(path, scopeRoot string) bool {
 		return true
 	}
 	return len(path) > len(scopeRoot) && strings.HasPrefix(path, scopeRoot) && path[len(scopeRoot)] == '/'
+}
+
+// gitCommonDirForDir is the seam used to ask git for the worktree's main
+// repository directory. Tests override this to avoid spawning a real git
+// subprocess while still exercising rigFromGitWorktree's matching logic.
+var gitCommonDirForDir = func(dir string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitCommonDirLookupTimeout)
+	defer cancel()
+	common, err := git.New(dir).CommonDirCtx(ctx)
+	if err != nil {
+		return "", false
+	}
+	return common, true
+}
+
+// rigFromGitWorktree resolves the rig by asking git for the main repository
+// directory of the worktree containing dir, then matching that against
+// configured rig.Path values. This is the safety net for callers (typically
+// polecat worktrees) whose .beads/redirect was never created or has been
+// removed: filesystem path heuristics alone cannot map an unrelated worktree
+// location back to its rig, but git itself always knows.
+//
+// Returns false when dir is not inside any git repository, when git is
+// unavailable, or when the resolved repository root does not match any
+// configured rig.Path. The city's own checkout (when cityPath happens to
+// be a git repo) is intentionally not treated as a rig — callers that want
+// the HQ scope already fall through to bdCityScopeTarget.
+func rigFromGitWorktree(cfg *config.City, cityPath, dir string) (config.Rig, bool, error) {
+	commonDir, ok := gitCommonDirForDir(dir)
+	if !ok {
+		return config.Rig{}, false, nil
+	}
+	commonDir = normalizePathForCompare(commonDir)
+	// git rev-parse --git-common-dir returns "<repo>/.git" for the standard
+	// layout. The repository root is the parent directory; fall back to
+	// commonDir itself for bare repos or unusual layouts where the basename
+	// is not ".git".
+	repoRoot := commonDir
+	if filepath.Base(commonDir) == ".git" {
+		repoRoot = filepath.Dir(commonDir)
+	}
+	repoRoot = normalizePathForCompare(repoRoot)
+
+	cityRoot := normalizePathForCompare(cityPath)
+	if repoRoot == cityRoot {
+		// Skip the city checkout itself so HQ-rooted callers still fall
+		// through to the city scope instead of being misidentified as a
+		// rig with the same path.
+		return config.Rig{}, false, nil
+	}
+
+	for _, rig := range cfg.Rigs {
+		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		rigPath := normalizePathForCompare(resolveStoreScopeRoot(cityPath, rig.Path))
+		if repoRoot == rigPath {
+			return rig, true, nil
+		}
+	}
+	return config.Rig{}, false, nil
 }

--- a/cmd/gc/rig_scope_resolution_test.go
+++ b/cmd/gc/rig_scope_resolution_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -50,5 +52,192 @@ func TestRigFromRedirectedBeadsDirIgnoresCwdOutsideCity(t *testing.T) {
 	}
 	if ok {
 		t.Fatalf("rigFromRedirectedBeadsDir() ok = true, want false; rig = %+v", rig)
+	}
+}
+
+// TestRigFromGitWorktreeResolvesPolecatWorktreeWithoutRedirect verifies that
+// rig auto-detection recovers from a missing .beads/redirect by asking git
+// for the worktree's main repository. This is the failure mode behind ga-cuk:
+// polecat worktrees occasionally land beads in the HQ rig because their
+// redirect file was lost or never created, and path-only resolution has no
+// other signal that maps the worktree back to its rig.
+func TestRigFromGitWorktreeResolvesPolecatWorktreeWithoutRedirect(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	cityDir := t.TempDir()
+	rigRoot := filepath.Join(t.TempDir(), "frontend-rig")
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, rigRoot, "init", "-q")
+	runGitForTest(t, rigRoot, "config", "user.email", "test@test.com")
+	runGitForTest(t, rigRoot, "config", "user.name", "Test")
+	runGitForTest(t, rigRoot, "commit", "--allow-empty", "-m", "init")
+
+	// Polecat-style worktree under cityPath, deliberately created without
+	// a .beads/redirect file — the case ga-cuk is fixing.
+	worktree := filepath.Join(cityDir, ".gc", "worktrees", "frontend", "polecats", "polecat-1")
+	if err := os.MkdirAll(filepath.Dir(worktree), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, rigRoot, "worktree", "add", "--detach", worktree)
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Rigs: []config.Rig{
+			{Name: "frontend", Path: rigRoot, Prefix: "fr"},
+		},
+	}
+
+	rig, ok, err := resolveRigForDir(cfg, cityDir, normalizePathForCompare(worktree))
+	if err != nil {
+		t.Fatalf("resolveRigForDir() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("resolveRigForDir() ok = false; want frontend rig resolved via git worktree fallback")
+	}
+	if rig.Name != "frontend" {
+		t.Fatalf("resolveRigForDir() rig.Name = %q, want %q", rig.Name, "frontend")
+	}
+}
+
+// TestRigFromGitWorktreeIgnoresNonRigRepo verifies that the git-based
+// fallback returns false when the worktree's main repo is not a configured
+// rig. Without this guard, an unrelated git checkout would route bd commands
+// to a rig it has nothing to do with.
+func TestRigFromGitWorktreeIgnoresNonRigRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	cityDir := t.TempDir()
+	unrelatedRepo := filepath.Join(t.TempDir(), "unrelated")
+	if err := os.MkdirAll(unrelatedRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, unrelatedRepo, "init", "-q")
+	runGitForTest(t, unrelatedRepo, "config", "user.email", "test@test.com")
+	runGitForTest(t, unrelatedRepo, "config", "user.name", "Test")
+	runGitForTest(t, unrelatedRepo, "commit", "--allow-empty", "-m", "init")
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Rigs: []config.Rig{
+			{Name: "frontend", Path: filepath.Join(t.TempDir(), "frontend-rig"), Prefix: "fr"},
+		},
+	}
+
+	_, ok, err := rigFromGitWorktree(cfg, cityDir, normalizePathForCompare(unrelatedRepo))
+	if err != nil {
+		t.Fatalf("rigFromGitWorktree() error = %v", err)
+	}
+	if ok {
+		t.Fatalf("rigFromGitWorktree() ok = true; want false for unrelated repo")
+	}
+}
+
+// TestRigFromGitWorktreeIgnoresCityCheckout verifies that when cityPath itself
+// is a git repo, rigFromGitWorktree does not treat it as a rig. The city
+// checkout maps to the HQ scope, not to any rig.
+func TestRigFromGitWorktreeIgnoresCityCheckout(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	cityDir := t.TempDir()
+	runGitForTest(t, cityDir, "init", "-q")
+	runGitForTest(t, cityDir, "config", "user.email", "test@test.com")
+	runGitForTest(t, cityDir, "config", "user.name", "Test")
+	runGitForTest(t, cityDir, "commit", "--allow-empty", "-m", "init")
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Rigs: []config.Rig{
+			{Name: "frontend", Path: filepath.Join(t.TempDir(), "frontend-rig"), Prefix: "fr"},
+		},
+	}
+	subdir := filepath.Join(cityDir, "nested")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := rigFromGitWorktree(cfg, cityDir, normalizePathForCompare(subdir)); err != nil || ok {
+		t.Fatalf("rigFromGitWorktree() in city checkout = (_, %v, %v); want (_, false, nil)", ok, err)
+	}
+}
+
+// TestRigFromGitWorktreeStub exercises the matching logic without invoking
+// git, so the test runs in environments where git is not installed.
+func TestRigFromGitWorktreeStub(t *testing.T) {
+	rigRoot := filepath.Join(t.TempDir(), "frontend-rig")
+	cityDir := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Rigs: []config.Rig{
+			{Name: "frontend", Path: rigRoot, Prefix: "fr"},
+		},
+	}
+	prev := gitCommonDirForDir
+	t.Cleanup(func() { gitCommonDirForDir = prev })
+
+	tests := []struct {
+		name    string
+		stub    func(string) (string, bool)
+		wantOK  bool
+		wantRig string
+	}{
+		{
+			name:    "matches configured rig",
+			stub:    func(string) (string, bool) { return filepath.Join(rigRoot, ".git"), true },
+			wantOK:  true,
+			wantRig: "frontend",
+		},
+		{
+			name:   "git unavailable",
+			stub:   func(string) (string, bool) { return "", false },
+			wantOK: false,
+		},
+		{
+			name:   "non-matching repo",
+			stub:   func(string) (string, bool) { return filepath.Join(t.TempDir(), "other", ".git"), true },
+			wantOK: false,
+		},
+		{
+			name:   "skips city checkout",
+			stub:   func(string) (string, bool) { return filepath.Join(cityDir, ".git"), true },
+			wantOK: false,
+		},
+		{
+			name:    "bare-style common dir without .git suffix",
+			stub:    func(string) (string, bool) { return rigRoot, true },
+			wantOK:  true,
+			wantRig: "frontend",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gitCommonDirForDir = tt.stub
+			rig, ok, err := rigFromGitWorktree(cfg, cityDir, normalizePathForCompare(t.TempDir()))
+			if err != nil {
+				t.Fatalf("rigFromGitWorktree() error = %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("rigFromGitWorktree() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if tt.wantOK && rig.Name != tt.wantRig {
+				t.Fatalf("rigFromGitWorktree() rig.Name = %q, want %q", rig.Name, tt.wantRig)
+			}
+		})
+	}
+}
+
+func runGitForTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	// Strip git env vars so tests do not inherit ambient repo state.
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
 	}
 }

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1637,6 +1637,15 @@ func closeFailedCreateBead(store beads.Store, id string, now time.Time, stderr i
 	patch["pending_create_claim"] = ""
 	patch["pending_create_started_at"] = ""
 	patch["sleep_intent"] = ""
+	// Match the release-on-close behavior in closeBead so failed-create
+	// retirement frees its pool-slot alias on the same write that closes
+	// the bead, not only via the failedCreateIdentityReleased state guard
+	// in ensureSessionAliasAvailable (ga-bgz).
+	if existing, err := store.Get(id); err == nil {
+		for k, v := range session.ReleaseClaimedIdentityPatch(existing.Metadata) {
+			patch[k] = v
+		}
+	}
 	if setMetaBatch(store, id, patch, stderr) != nil {
 		return false
 	}
@@ -1910,13 +1919,27 @@ func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Wr
 	// bead.updated event. Skipping the write when status is already
 	// closed is safe because all three callers are reconciler tick logic
 	// that should be no-op on terminal beads.
-	if existing, err := store.Get(id); err == nil && existing.Status == "closed" {
+	existing, getErr := store.Get(id)
+	if getErr == nil && existing.Status == "closed" {
 		return false
 	}
 	if reason == string(session.StateFailedCreate) {
 		return closeFailedCreateBead(store, id, now, stderr)
 	}
-	if setMetaBatch(store, id, session.ClosePatch(now, reason), stderr) != nil {
+	patch := session.ClosePatch(now, reason)
+	// Terminal close reasons (gc_swept, orphaned, stale-session, ...)
+	// produce beads that cannot be reopened. Release the bead's
+	// runtime-identity claim (alias, agent_name) so the next pool spawn
+	// can take the same slot. Without this, a stale cache view of the
+	// closed bead still surfaces as an open alias claim in
+	// ensureSessionAliasAvailable, blocking new sessions until a
+	// supervisor reload primes the cache from backing (ga-bgz).
+	if getErr == nil && session.ReleaseClaimedIdentityOnCloseState(reason) {
+		for k, v := range session.ReleaseClaimedIdentityPatch(existing.Metadata) {
+			patch[k] = v
+		}
+	}
+	if setMetaBatch(store, id, patch, stderr) != nil {
 		return false
 	}
 	if err := store.Close(id); err != nil {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -5584,6 +5584,128 @@ func TestCloseBeadIsNoopOnAlreadyClosedBead(t *testing.T) {
 	}
 }
 
+// TestCloseBeadReleasesAliasOnTerminalCloseState locks in ga-bgz: a pool
+// session bead closed with a terminal state (gc_swept, orphaned, ...) must
+// clear its alias and agent_name metadata, preserving the prior alias in
+// alias_history. Without this, a stale "open" cache view of the closed
+// bead still surfaces as an alias claim in ensureSessionAliasAvailable,
+// blocking new pool sessions from taking the same slot until a supervisor
+// reload re-primes the cache from the backing store.
+func TestCloseBeadReleasesAliasOnTerminalCloseState(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason string
+	}{
+		{"gc_swept", "gc_swept"},
+		{"orphaned", "orphaned"},
+		{"stale-session", "stale-session"},
+		{"duplicate", "duplicate"},
+		{"reconfigured", "reconfigured"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			sessionBead, err := store.Create(beads.Bead{
+				Title:  "gastown.furiosa",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel, "agent:zack/gastown.furiosa"},
+				Metadata: map[string]string{
+					"session_name": "gastown__polecat-pe-r7c1",
+					"agent_name":   "zack/gastown.furiosa",
+					"alias":        "zack/gastown.furiosa",
+					"template":     "zack/gastown.polecat",
+					"pool_managed": "true",
+					"state":        "active",
+				},
+			})
+			if err != nil {
+				t.Fatalf("create session bead: %v", err)
+			}
+
+			var stderr bytes.Buffer
+			now := time.Date(2026, 5, 19, 17, 15, 54, 0, time.UTC)
+			if !closeBead(store, sessionBead.ID, tc.reason, now, &stderr) {
+				t.Fatalf("closeBead returned false: stderr=%s", stderr.String())
+			}
+
+			got, err := store.Get(sessionBead.ID)
+			if err != nil {
+				t.Fatalf("get after close: %v", err)
+			}
+			if got.Status != "closed" {
+				t.Fatalf("status = %q, want closed", got.Status)
+			}
+			if alias := got.Metadata["alias"]; alias != "" {
+				t.Errorf("metadata.alias = %q, want \"\" — terminal close must release alias claim", alias)
+			}
+			if agentName := got.Metadata["agent_name"]; agentName != "" {
+				t.Errorf("metadata.agent_name = %q, want \"\" — terminal close must release agent_name", agentName)
+			}
+			if history := got.Metadata["alias_history"]; history != "zack/gastown.furiosa" {
+				t.Errorf("metadata.alias_history = %q, want %q", history, "zack/gastown.furiosa")
+			}
+			// session_name is the unique bead identifier, not a pool-slot
+			// alias, so it remains intact for historical lookups.
+			if sn := got.Metadata["session_name"]; sn != "gastown__polecat-pe-r7c1" {
+				t.Errorf("metadata.session_name = %q, want %q (unchanged)", sn, "gastown__polecat-pe-r7c1")
+			}
+
+			// The alias resolver must agree the slot is free for a fresh
+			// pool spawn under the same identity.
+			if err := session.EnsureAliasAvailableWithConfigForOwner(store, nil, "zack/gastown.furiosa", "", "zack/gastown.furiosa"); err != nil {
+				t.Errorf("EnsureAliasAvailableWithConfigForOwner after %s close = %v, want nil", tc.reason, err)
+			}
+		})
+	}
+}
+
+// TestCloseBeadPreservesAliasForReopenEligibleClose verifies the other
+// half of the contract: non-terminal close reasons that
+// closedNamedSessionReopenEligible accepts must keep the alias intact so
+// gc start can reopen the bead under the same identity.
+func TestCloseBeadPreservesAliasForReopenEligibleClose(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":              "mayor",
+			"alias":                     "mayor",
+			"agent_name":                "mayor",
+			"configured_named_session":  "true",
+			"configured_named_identity": "mayor",
+			"state":                     "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	now := time.Date(2026, 5, 19, 17, 15, 54, 0, time.UTC)
+	// "suspended" and the empty-state fallthrough in
+	// closedNamedSessionReopenEligible both pass the eligibility check;
+	// "suspended" is the canonical case where gc start should resume the
+	// same bead.
+	if !closeBead(store, sessionBead.ID, "suspended", now, &stderr) {
+		t.Fatalf("closeBead returned false: stderr=%s", stderr.String())
+	}
+	got, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("get after close: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed", got.Status)
+	}
+	if alias := got.Metadata["alias"]; alias != "mayor" {
+		t.Errorf("metadata.alias = %q, want %q — reopen-eligible close must preserve alias", alias, "mayor")
+	}
+	if agentName := got.Metadata["agent_name"]; agentName != "mayor" {
+		t.Errorf("metadata.agent_name = %q, want %q — reopen-eligible close must preserve agent_name", agentName, "mayor")
+	}
+}
+
 // setupSessionWithExtmsgMembership creates a session bead and registers a
 // participant in a group, which also writes the matching membership via
 // ensureMembershipLocked. Returns the session bead, fabric, and caller so

--- a/cmd/gc/session_model_phase0_runtime_env_spec_test.go
+++ b/cmd/gc/session_model_phase0_runtime_env_spec_test.go
@@ -48,6 +48,38 @@ func TestPhase0RuntimeEnv_TemplateResolutionSetsOriginAndPublicHandle(t *testing
 	}
 }
 
+// TestPhase0RuntimeEnv_TemplateResolutionSetsCityBeadsDir verifies that
+// agent sessions are spawned with GC_CITY_BEADS_DIR pointed at the HQ city
+// bd. EffectiveWorkQuery's federation tier reads this var to also probe
+// city-bd beads routed to rig-scoped agents (ga-xw6).
+func TestPhase0RuntimeEnv_TemplateResolutionSetsCityBeadsDir(t *testing.T) {
+	cityPath := t.TempDir()
+	params := &agentBuildParams{
+		cityName:   "phase0-city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test-agent"},
+		providers:  map[string]config.ProviderSpec{"test-agent": {DisplayName: "Test Agent", Command: "true"}},
+		lookPath:   func(string) (string, error) { return filepath.Join("/usr/bin", "true"), nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+	agentCfg := &config.Agent{
+		Name:     "worker",
+		Provider: "test-agent",
+	}
+
+	tp, err := resolveTemplate(params, agentCfg, agentCfg.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate(worker): %v", err)
+	}
+	want := filepath.Join(cityPath, ".beads")
+	if got := tp.Env["GC_CITY_BEADS_DIR"]; got != want {
+		t.Fatalf("GC_CITY_BEADS_DIR = %q, want %q", got, want)
+	}
+}
+
 func TestPhase0RuntimeEnv_TemplateResolutionDoesNotPublishLifecycleBeadsWrapper(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1788,6 +1788,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	advanceSessionDrainsWithSessionsTraced(dt, sp, store, sessionLookup, ordered, wakeEvals, cfg, poolDesired, nil, readyWaitSet, clk, trace)
 	clearMissingIdleProbes(dt, beadByID)
 
+	// Phase 3: Re-nudge alive ephemeral pool sessions that look idle
+	// while routed pool work waits. Catches the reload-survivor case:
+	// a polecat whose spawn-time nudge fired against an older prompt
+	// is sitting at "Session started. Ready..." instead of running
+	// gc hook. detectIdleReloadSurvivors is idempotent across ticks
+	// via the idleRenudgeLastAtKey cooldown.
+	if ctx == nil || ctx.Err() == nil {
+		idleTargets := detectIdleReloadSurvivors(ordered, cfg, assignedWorkBeads, workSet, clk)
+		renudgeIdleSessions(ctx, idleTargets, sp, store, clk, stderr)
+	}
+
 	return plannedWakes
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -315,7 +315,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		ProviderKey:         providerKey,
 		ProviderDisplayName: providerDisplayName,
 		Env:                 cfgAgent.Env,
-	}, p.sessionTemplate, p.stderr, p.packDirs, fragments, p.beadStore)
+	}, p.sessionTemplate, p.stderr, effectivePackDirs(p.packDirs, p.rigPackDirs, rigName), fragments, p.beadStore)
 	hasHooks := config.AgentHasHooks(cfgAgent, p.workspace, resolved.Name, p.providers)
 	beacon := runtime.FormatBeaconAt(p.cityName, qualifiedName, !hasHooks, p.beaconTime)
 	if prompt != "" {

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -241,6 +241,11 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		"BEADS_ACTOR":         sessName,
 		"GC_DIR":              workDir,
 		"GC_BEADS_SCOPE_ROOT": p.cityPath,
+		// GC_CITY_BEADS_DIR pins the HQ city bd path so rig-scoped agents can
+		// federate their work_query against it (ga-xw6). Set even for
+		// city-scoped agents so the variable is stable across the runtime;
+		// EffectiveWorkQuery emits the federation block only when a.Dir != "".
+		"GC_CITY_BEADS_DIR": filepath.Join(p.cityPath, ".beads"),
 		// Explicit empty values matter here. tmux session creation uses `env -u`
 		// only for keys present with empty strings, which prevents stale rig
 		// scope from leaking out of the tmux server's inherited environment.

--- a/cmd/gc/template_resolve_rig_pack_fragments_test.go
+++ b/cmd/gc/template_resolve_rig_pack_fragments_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// TestEffectivePackDirsMergesCityAndRig verifies the helper concatenates
+// city pack dirs first (lower priority) followed by rig-specific pack dirs
+// (higher priority), mirroring the contract of effectiveOverlayDirs.
+func TestEffectivePackDirsMergesCityAndRig(t *testing.T) {
+	got := effectivePackDirs(
+		[]string{"/city-a", "/city-b"},
+		map[string][]string{"r1": {"/rig-x"}, "r2": {"/rig-y"}},
+		"r1",
+	)
+	want := []string{"/city-a", "/city-b", "/rig-x"}
+	if len(got) != len(want) {
+		t.Fatalf("effectivePackDirs len = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("effectivePackDirs[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestEffectivePackDirsEmptyRigReturnsCityOnly verifies the helper returns
+// the city dirs slice unchanged when the rig has no extra pack imports.
+func TestEffectivePackDirsEmptyRigReturnsCityOnly(t *testing.T) {
+	city := []string{"/city-a"}
+	got := effectivePackDirs(city, map[string][]string{"r1": {"/rig-x"}}, "no-such-rig")
+	if len(got) != 1 || got[0] != "/city-a" {
+		t.Errorf("effectivePackDirs(no rig match) = %v, want [/city-a]", got)
+	}
+}
+
+// TestEffectivePackDirsEmptyCityReturnsRigOnly verifies the helper returns
+// the rig-specific slice when no city-level packs are configured.
+func TestEffectivePackDirsEmptyCityReturnsRigOnly(t *testing.T) {
+	got := effectivePackDirs(nil, map[string][]string{"r1": {"/rig-x", "/rig-y"}}, "r1")
+	want := []string{"/rig-x", "/rig-y"}
+	if len(got) != len(want) {
+		t.Fatalf("effectivePackDirs(no city) = %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("effectivePackDirs[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestResolveTemplateLoadsRigImportedTemplateFragments is the regression
+// test for ga-bbi: a city that imports a pack at the rig level (the dipcity
+// shape — see https://github.com/kolloch/gascity beads ga-bbi) must still
+// see template-fragments/ from that pack when rendering an agent prompt.
+//
+// Before the fix, the renderer only loaded fragments from cfg.PackDirs
+// (city-level imports). Rig-imported packs ended up in cfg.RigPackDirs and
+// were silently skipped, so the agent's prompt body would still contain
+// literal `{{ template "foo" . }}` and `{{ .BindingPrefix }}` directives —
+// either as raw leaked text (when template execution failed because the
+// referenced fragment was undefined) or as un-routed handoff targets.
+func TestResolveTemplateLoadsRigImportedTemplateFragments(t *testing.T) {
+	cityPath := t.TempDir()
+	write := func(rel, data string) {
+		path := filepath.Join(cityPath, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	rigRoot := filepath.Join(cityPath, "repos", "demo")
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rigRoot): %v", err)
+	}
+
+	write("city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "demo"
+path = "repos/demo"
+
+[rigs.imports.gastown]
+source = "packs/gastown"
+`)
+	write("packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[[agent]]
+name = "polecat"
+scope = "rig"
+provider = "claude"
+prompt_template = "agents/polecat/prompt.template.md"
+`)
+	// Pack-level template-fragments/. Referenced by the agent prompt below.
+	write("packs/gastown/template-fragments/handoff.template.md",
+		`{{ define "handoff" }}HANDOFF target={{ .RigName }}/{{ .BindingPrefix }}refinery{{ end }}`)
+	write("packs/gastown/agents/polecat/prompt.template.md",
+		`Polecat in {{ .RigName }} ({{ .BindingPrefix }}role)
+{{ template "handoff" . }}`)
+
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	// Sanity: the rig's import landed in RigPackDirs, not PackDirs.
+	if rigDirs := cfg.RigPackDirs["demo"]; len(rigDirs) == 0 {
+		t.Fatalf("cfg.RigPackDirs[\"demo\"] is empty; rig import did not populate (got %v)", cfg.RigPackDirs)
+	}
+	for _, d := range cfg.PackDirs {
+		if strings.HasSuffix(d, filepath.Join("packs", "gastown")) {
+			t.Fatalf("cfg.PackDirs unexpectedly contains the rig-imported gastown pack (%q) — this test only repros the bug when the pack is rig-scoped", d)
+		}
+	}
+
+	var agentCfg config.Agent
+	for _, a := range cfg.Agents {
+		if !a.Implicit && a.Name == "polecat" {
+			agentCfg = a
+			break
+		}
+	}
+	if agentCfg.Name == "" {
+		t.Fatalf("expected polecat agent from rig import; got agents %v", cfg.Agents)
+	}
+
+	var stderr bytes.Buffer
+	params := &agentBuildParams{
+		city:            cfg,
+		fs:              fsys.OSFS{},
+		cityName:        "test",
+		cityPath:        cityPath,
+		workspace:       &cfg.Workspace,
+		providers:       config.BuiltinProviders(),
+		lookPath:        func(string) (string, error) { return "/usr/bin/claude", nil },
+		rigs:            cfg.Rigs,
+		beaconTime:      testBeaconTime,
+		packDirs:        cfg.PackDirs,
+		rigPackDirs:     cfg.RigPackDirs,
+		globalFragments: cfg.Workspace.GlobalFragments,
+		appendFragments: mergeFragmentLists(cfg.AgentDefaults.AppendFragments, cfg.AgentsDefaults.AppendFragments),
+		beadNames:       make(map[string]string),
+		stderr:          &stderr,
+	}
+
+	tp, err := resolveTemplate(params, &agentCfg, agentCfg.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	for _, leak := range []string{
+		`{{ template "handoff"`,
+		`{{ .BindingPrefix }}`,
+		`{{ .RigName }}`,
+	} {
+		if strings.Contains(tp.Prompt, leak) {
+			t.Errorf("rendered prompt still contains literal %q — template-fragments were not loaded.\nstderr=%q\nprompt=%q",
+				leak, stderr.String(), tp.Prompt)
+		}
+	}
+
+	for _, want := range []string{
+		"Polecat in demo (gastown.role)",
+		"HANDOFF target=demo/gastown.refinery",
+	} {
+		if !strings.Contains(tp.Prompt, want) {
+			t.Errorf("rendered prompt missing %q.\nstderr=%q\nprompt=%q", want, stderr.String(), tp.Prompt)
+		}
+	}
+}
+
+// TestDoPrime_LoadsRigImportedTemplateFragments is the companion regression
+// test for ga-bbi covering the `gc prime` codepath. `gc prime` is invoked
+// by the SessionStart hook each time an agent session boots — a different
+// rendering call site from resolveTemplate, so both need explicit coverage.
+func TestDoPrime_LoadsRigImportedTemplateFragments(t *testing.T) {
+	cityDir := t.TempDir()
+	rigRoot := filepath.Join(cityDir, "repos", "demo")
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rigRoot): %v", err)
+	}
+	write := func(rel, data string) {
+		path := filepath.Join(cityDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	write("city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "demo"
+path = "repos/demo"
+
+[rigs.imports.gastown]
+source = "packs/gastown"
+`)
+	write("packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[[agent]]
+name = "polecat"
+scope = "rig"
+provider = "claude"
+prompt_template = "agents/polecat/prompt.template.md"
+`)
+	write("packs/gastown/template-fragments/handoff.template.md",
+		`{{ define "handoff" }}HANDOFF target={{ .RigName }}/{{ .BindingPrefix }}refinery{{ end }}`)
+	write("packs/gastown/agents/polecat/prompt.template.md",
+		`Polecat in {{ .RigName }} ({{ .BindingPrefix }}role)
+{{ template "handoff" . }}`)
+
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_RIG", "demo")
+	t.Setenv("GC_RIG_ROOT", rigRoot)
+	t.Setenv("GC_DIR", rigRoot)
+	t.Setenv("GC_ALIAS", "demo/gastown.polecat")
+	t.Setenv("GC_AGENT", "demo/gastown.polecat")
+	t.Setenv("GC_BRANCH", "")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrime([]string{"demo/gastown.polecat"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doPrime() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, leak := range []string{
+		`{{ template "handoff"`,
+		`{{ .BindingPrefix }}`,
+		`{{ .RigName }}`,
+	} {
+		if strings.Contains(out, leak) {
+			t.Errorf("rendered prompt still contains literal %q — rig-import template-fragments were not loaded.\nstderr=%q\nstdout=%q",
+				leak, stderr.String(), out)
+		}
+	}
+	for _, want := range []string{
+		"Polecat in demo (gastown.role)",
+		"HANDOFF target=demo/gastown.refinery",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered prompt missing %q.\nstderr=%q\nstdout=%q", want, stderr.String(), out)
+		}
+	}
+}
+

--- a/cmd/gc/work_query_probe.go
+++ b/cmd/gc/work_query_probe.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -46,6 +47,10 @@ func controllerQueryRuntimeEnv(cityPath string, cfg *config.City, agentCfg *conf
 	for key, value := range source {
 		env[key] = value
 	}
+	// GC_CITY_BEADS_DIR pins the HQ city bd for EffectiveWorkQuery /
+	// EffectiveScaleCheck federation (ga-xw6). The probe subprocess inherits
+	// this so a rig-scoped probe can also reach pe-* beads routed to the rig.
+	env["GC_CITY_BEADS_DIR"] = filepath.Join(cityPath, ".beads")
 	return env, nil
 }
 
@@ -59,6 +64,10 @@ func controllerWorkQueryEnv(cityPath string, cfg *config.City, agentCfg *config.
 	env["GC_BEADS_PREFIX"] = config.EffectiveHQPrefix(cfg)
 	env["GC_RIG"] = ""
 	env["GC_RIG_ROOT"] = ""
+	// GC_CITY_BEADS_DIR is the HQ city bd path used by EffectiveWorkQuery's
+	// federation tier (ga-xw6). Set unconditionally so rig-scoped probes can
+	// reach pe-* beads routed to the rig.
+	env["GC_CITY_BEADS_DIR"] = filepath.Join(cityPath, ".beads")
 	if rigName := configuredRigName(cityPath, agentCfg, cfg.Rigs); rigName != "" {
 		if rigRoot := rigRootForName(rigName, cfg.Rigs); rigRoot != "" {
 			env["GC_STORE_ROOT"] = rigRoot

--- a/cmd/gc/work_query_probe_test.go
+++ b/cmd/gc/work_query_probe_test.go
@@ -278,6 +278,66 @@ provider = "file"
 	}
 }
 
+// TestControllerWorkQueryEnvSetsCityBeadsDir verifies that the controller's
+// work_query probe env carries GC_CITY_BEADS_DIR for both city- and
+// rig-scoped agents. The federation tier in EffectiveWorkQuery reads this
+// var to also probe HQ beads routed to rig agents (ga-xw6).
+func TestControllerWorkQueryEnvSetsCityBeadsDir(t *testing.T) {
+	cityPath, rigDir, _ := newControllerProbeFixture(t)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{{
+			Name:   "demo",
+			Path:   rigDir,
+			Prefix: "de",
+		}},
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "demo"},
+			{Name: "mayor"},
+		},
+	}
+
+	wantCity := filepath.Join(cityPath, ".beads")
+	for i, agentCfg := range cfg.Agents {
+		env, err := controllerWorkQueryEnv(cityPath, cfg, &cfg.Agents[i])
+		if err != nil {
+			t.Fatalf("controllerWorkQueryEnv(%q) error = %v", agentCfg.Name, err)
+		}
+		if got := env["GC_CITY_BEADS_DIR"]; got != wantCity {
+			t.Fatalf("controllerWorkQueryEnv(%q): GC_CITY_BEADS_DIR = %q, want %q", agentCfg.Name, got, wantCity)
+		}
+	}
+}
+
+// TestControllerQueryRuntimeEnvSetsCityBeadsDir verifies that the
+// session-reconciler probe env (controllerQueryRuntimeEnv) also carries
+// GC_CITY_BEADS_DIR. The session reconciler uses this env for probes that
+// drive named-session lifecycle; without the var the federation block
+// would silently skip the city bd query.
+func TestControllerQueryRuntimeEnvSetsCityBeadsDir(t *testing.T) {
+	cityPath, rigDir, _ := newControllerProbeFixture(t)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{{
+			Name:   "demo",
+			Path:   rigDir,
+			Prefix: "de",
+		}},
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "demo"},
+		},
+	}
+
+	wantCity := filepath.Join(cityPath, ".beads")
+	env, err := controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[0])
+	if err != nil {
+		t.Fatalf("controllerQueryRuntimeEnv() error = %v", err)
+	}
+	if got := env["GC_CITY_BEADS_DIR"]; got != wantCity {
+		t.Fatalf("controllerQueryRuntimeEnv(): GC_CITY_BEADS_DIR = %q, want %q", got, wantCity)
+	}
+}
+
 func newControllerProbeFixture(t *testing.T) (string, string, *config.City) {
 	t.Helper()
 	t.Setenv("GC_BEADS", "bd")

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -17793,22 +17793,22 @@
             }
           },
           {
-            "description": "Filter by agent name.",
+            "description": "Filter by recipient (mailbox).",
             "explode": false,
             "in": "query",
             "name": "agent",
             "schema": {
-              "description": "Filter by agent name.",
+              "description": "Filter by recipient (mailbox).",
               "type": "string"
             }
           },
           {
-            "description": "Filter by status (unread, all).",
+            "description": "Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads.",
             "explode": false,
             "in": "query",
             "name": "status",
             "schema": {
-              "description": "Filter by status (unread, all).",
+              "description": "Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads.",
               "type": "string"
             }
           },
@@ -17820,6 +17820,46 @@
             "schema": {
               "description": "Filter by rig name.",
               "type": "string"
+            }
+          },
+          {
+            "description": "Filter by sender (metadata.from / Bead.From). Empty = no sender constraint.",
+            "explode": false,
+            "in": "query",
+            "name": "from",
+            "schema": {
+              "description": "Filter by sender (metadata.from / Bead.From). Empty = no sender constraint.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint.",
+            "explode": false,
+            "in": "query",
+            "name": "label",
+            "schema": {
+              "description": "Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Convenience filter for the per-viewer archive model: equivalent to label='archived:\u003cviewer\u003e' with read messages included. Conflicts with 'label'.",
+            "explode": false,
+            "in": "query",
+            "name": "archived_for",
+            "schema": {
+              "description": "Convenience filter for the per-viewer archive model: equivalent to label='archived:\u003cviewer\u003e' with read messages included. Conflicts with 'label'.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics.",
+            "explode": false,
+            "in": "query",
+            "name": "include_closed",
+            "schema": {
+              "description": "Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics.",
+              "type": "boolean"
             }
           }
         ],

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -17793,22 +17793,22 @@
             }
           },
           {
-            "description": "Filter by agent name.",
+            "description": "Filter by recipient (mailbox).",
             "explode": false,
             "in": "query",
             "name": "agent",
             "schema": {
-              "description": "Filter by agent name.",
+              "description": "Filter by recipient (mailbox).",
               "type": "string"
             }
           },
           {
-            "description": "Filter by status (unread, all).",
+            "description": "Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads.",
             "explode": false,
             "in": "query",
             "name": "status",
             "schema": {
-              "description": "Filter by status (unread, all).",
+              "description": "Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads.",
               "type": "string"
             }
           },
@@ -17820,6 +17820,46 @@
             "schema": {
               "description": "Filter by rig name.",
               "type": "string"
+            }
+          },
+          {
+            "description": "Filter by sender (metadata.from / Bead.From). Empty = no sender constraint.",
+            "explode": false,
+            "in": "query",
+            "name": "from",
+            "schema": {
+              "description": "Filter by sender (metadata.from / Bead.From). Empty = no sender constraint.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint.",
+            "explode": false,
+            "in": "query",
+            "name": "label",
+            "schema": {
+              "description": "Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Convenience filter for the per-viewer archive model: equivalent to label='archived:\u003cviewer\u003e' with read messages included. Conflicts with 'label'.",
+            "explode": false,
+            "in": "query",
+            "name": "archived_for",
+            "schema": {
+              "description": "Convenience filter for the per-viewer archive model: equivalent to label='archived:\u003cviewer\u003e' with read messages included. Conflicts with 'label'.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics.",
+            "explode": false,
+            "in": "query",
+            "name": "include_closed",
+            "schema": {
+              "description": "Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics.",
+              "type": "boolean"
             }
           }
         ],

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -560,3 +560,39 @@ three-step formula wisp to the `worker` pool. Neither requires anyone to type
 
 Orders are formulas and scripts on autopilot, gated by time, schedule,
 conditions, or events, evaluated by the controller on every tick.
+
+## Convention: surfacing stranded beads
+
+`gc sling` routes work the moment you call it; auto-route orders can wire
+that up automatically when a bead is created. But work-type beads created
+outside that path — by humans typing `bd create`, by older orders before
+auto-route existed, or in rigs (like an HQ rig) that have no auto-route
+order — can sit in the queue with no `gc.routed_to` and no assignee, and
+no agent will ever pick them up. They are *stranded*.
+
+The maintenance pack ships an order that handles this case as a generic
+convention:
+
+```
+examples/gastown/packs/maintenance/orders/stranded-bead-sweep.toml
+```
+
+On a cooldown (default hourly), the sweep walks every initialized rig,
+finds open work-type beads with no `gc.routed_to`, no assignee, no exempt
+label, and no recent activity (default ≥ 4 hours since last update), and
+adds a surface label (default `needs:human`). UIs and queries that filter
+on that label then expose the strand to the operator. A periodic digest
+(default weekly) mails the recipient (default `mayor`) the aggregate
+count and the oldest few entries.
+
+Composability: the surface label, exempt labels, age threshold, digest
+interval, and digest recipient are all environment-configurable
+(`GC_STRANDED_SURFACE_LABEL`, `GC_STRANDED_EXEMPT_LABELS`,
+`GC_STRANDED_AGE_HOURS`, `GC_STRANDED_DIGEST_DAYS`,
+`GC_STRANDED_DIGEST_TO`) so the convention slots into cities that
+already have their own labeling vocabulary. See the script docstring for
+the full env-var contract.
+
+This is the counterpart to `gc sling`: sling routes intentional work
+forward; the stranded-bead sweep ensures unintentional work doesn't fall
+out the back.

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2322,12 +2322,44 @@ op_probe() {
     exit 2
 }
 
+# recovery_should_skip_due_to_enospc returns 0 (true) when the recent
+# dolt server log shows disk-exhaustion (ENOSPC) signatures. Restarting
+# dolt under ENOSPC does not free disk space, and the recovery cycle
+# itself amplifies the failure: every restart triggers a fresh conjoin
+# that drops another partial nbs_table_* file in the backup remote,
+# accelerating the disk-full feedback loop. See gastownhall/gascity#2158.
+#
+# Returns 1 (false) when no ENOSPC signature is found in the recent log
+# tail, or when the log file cannot be read.
+recovery_should_skip_due_to_enospc() {
+    [ -n "$LOG_FILE" ] && [ -r "$LOG_FILE" ] || return 1
+    # Scan the recent log tail rather than the whole file; an old transient
+    # ENOSPC error from a since-resolved disk-pressure event should not
+    # block recovery indefinitely.
+    tail -n 1000 "$LOG_FILE" 2>/dev/null \
+        | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
+        || return 1
+    return 0
+}
+
 # op_recover stops the dolt server, restarts it, and verifies health.
 op_recover() {
     local read_only_status
 
     if is_remote; then
         die "recovery not supported for remote dolt servers"
+    fi
+
+    # Skip auto-recovery when dolt has been failing due to disk exhaustion.
+    # Restarting dolt does not free disk space, and the recovery cycle
+    # itself amplifies the failure: each restart triggers a conjoin/backup
+    # sync that writes another partial table file to the backup remote.
+    # Require manual intervention (free disk space) before recovery
+    # resumes. See gastownhall/gascity#2158.
+    if recovery_should_skip_due_to_enospc; then
+        echo "skipping dolt recovery: recent dolt log shows ENOSPC — manual intervention required" >&2
+        echo "  free disk space, then re-run health checks" >&2
+        die "dolt recovery skipped: ENOSPC detected"
     fi
 
     if load_recover_managed_from_gc; then

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -434,6 +434,56 @@ func TestPolecatPromptDoneSequenceSignalsRefinery(t *testing.T) {
 	}
 }
 
+// TestPolecatPromptOpensWithImperativeFirstAction guards against the
+// regression observed 2026-05-18 (ga-2ph): freshly-spawned or reload-
+// survivor polecat sessions sometimes sat idle at the Claude Code prompt
+// instead of auto-claiming routed pool work. A manual nudge with
+// "Run bd ready..." was enough to wake them, so the failure was that the
+// existing prompt buried its startup imperative far enough down the page
+// that the LLM's first turn produced "Session started. Ready..." text
+// instead of a `gc hook` tool call.
+//
+// The fix puts an unconditional "START IMMEDIATELY" section at the top of
+// the polecat prompt so the first substantive content the LLM sees is the
+// imperative to run `gc hook` as its very first tool call. This test
+// pins the section in place — it must precede the "FINAL REMINDER" done
+// sequence and must name both the hook call and the escalation path for
+// the empty-hook case (which is always a bug, never a wait state).
+func TestPolecatPromptOpensWithImperativeFirstAction(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "polecat", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat prompt: %v", err)
+	}
+	body := string(data)
+
+	assertContainsInOrder(t, body,
+		"## START IMMEDIATELY",
+		"`gc hook`",
+		`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`,
+		`gc bd update <id> --claim`,
+		`ESCALATION: polecat spawned with empty hook`,
+		"## FINAL REMINDER: RUN THE DONE SEQUENCE",
+	)
+
+	// The imperative must be the first H2 in the file so it precedes every
+	// other section (Idle Polecat Heresy, Never Close Beads, etc.). If a
+	// future edit inserts another H2 above it, the LLM's first scan will
+	// hit that section first and the fix is silently undone.
+	firstH2 := strings.Index(body, "\n## ")
+	if firstH2 == -1 {
+		t.Fatalf("polecat prompt has no H2 sections")
+	}
+	firstH2Line := body[firstH2+1:]
+	if nl := strings.IndexByte(firstH2Line, '\n'); nl != -1 {
+		firstH2Line = firstH2Line[:nl]
+	}
+	if !strings.HasPrefix(firstH2Line, "## START IMMEDIATELY") {
+		t.Fatalf("first H2 in polecat prompt must be START IMMEDIATELY, got %q", firstH2Line)
+	}
+}
+
 func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -297,6 +297,51 @@ func TestRefineryFormulaChainsMergeMetadataWithClose(t *testing.T) {
 	)
 }
 
+// TestRefineryFormulaDirectMergePushIsWorktreeSafe guards against the
+// regression observed in di-jlv: the formula's direct-merge path used to
+// run `git checkout $TARGET; git merge --ff-only temp; git push origin
+// $TARGET`. In gc worktrees the rig's $TARGET is checked out in the
+// primary worktree, so `git checkout $TARGET` fails from the refinery
+// worktree with "fatal: '$TARGET' is already used by worktree". The
+// shell wrapping did not check that exit, the agent stayed on `temp`,
+// `git merge --ff-only temp` reported "Already up to date", and
+// `git push origin $TARGET` shipped the unchanged local `$TARGET` ref
+// so the merge was silently dropped.
+//
+// The fix verifies temp is a fast-forward over origin/$TARGET, then
+// pushes `temp:$TARGET` directly so origin/$TARGET advances without
+// touching the local $TARGET ref. The verification step then compares
+// `git rev-parse temp` against `git rev-parse origin/$TARGET` instead
+// of the old apples-to-apples local-target-vs-origin-target compare,
+// which matched by accident when the push was a no-op.
+func TestRefineryFormulaDirectMergePushIsWorktreeSafe(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery formula: %v", err)
+	}
+	body := string(data)
+
+	// Positive: the worktree-safe shape must be present, in order, in the
+	// direct-merge path of the merge-push step.
+	assertContainsInOrder(t, body,
+		`**If MERGE_STRATEGY = "direct" (default):**`,
+		`git merge-base --is-ancestor "origin/$TARGET" temp`,
+		`git push origin "temp:$TARGET"`,
+		`LOCAL=$(git rev-parse temp)`,
+		`REMOTE=$(git rev-parse "origin/$TARGET")`,
+	)
+
+	// Positive: cleanup must detach off `temp` before deleting it. We
+	// stay on `temp` through the push (no local $TARGET checkout), so
+	// `git branch -d temp` without a prior detach would fail.
+	assertContainsInOrder(t, body,
+		`git checkout --detach`,
+		`git branch -D temp`,
+	)
+}
+
 // TestRefineryPromptRejectionFlowEnforcesClearOnMerge guards against
 // the regression observed in L5c (2026-05-10): the refinery agent
 // merged a previously-rejected work bead and closed it, but never ran

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -6898,20 +6898,200 @@ exit 1
 		t.Fatalf("wisp-compact should parse BSD Z timestamps as UTC at the heartbeat TTL boundary\nwant substring: %q\ngot output:\n%s", want, out)
 	}
 
-	dateData, err := os.ReadFile(dateLog)
-	if err != nil {
-		t.Fatalf("ReadFile(date log): %v", err)
-	}
-	if !strings.Contains(string(dateData), "-ju -f %Y-%m-%dT%H:%M:%SZ "+nearBoundary+" +%s") {
-		t.Fatalf("BSD Z fallback did not force UTC:\n%s", dateData)
-	}
-
 	bdData, err := os.ReadFile(bdLog)
 	if err != nil {
 		t.Fatalf("ReadFile(bd log): %v", err)
 	}
 	if !strings.Contains(string(bdData), "update ga-heartbeat --persistent") {
-		t.Fatalf("expected expired heartbeat to be promoted, got bd calls:\n%s", bdData)
+		t.Fatalf("expected expired heartbeat to be promoted under non-UTC TZ, got bd calls:\n%s", bdData)
+	}
+
+	// Per-bead timestamp parsing was hoisted into a single jq pass (ga-blt
+	// batching refactor). The remaining `date` call is the once-per-run
+	// `date +%s` for NOW — verify the stub was invoked for that and not for
+	// per-bead BSD/-ju fallbacks. The TZ correctness contract is now enforced
+	// by jq's fromdateiso8601 (always-UTC); this test pins that the script
+	// classifies the near-boundary heartbeat correctly under non-UTC TZ.
+	dateData, err := os.ReadFile(dateLog)
+	if err != nil {
+		t.Fatalf("ReadFile(date log): %v", err)
+	}
+	if !strings.Contains(string(dateData), "+%s") {
+		t.Fatalf("expected `date +%%s` for NOW; got date calls:\n%s", dateData)
+	}
+	for _, banned := range []string{"-ju -f", "-d ", "-j -f"} {
+		if strings.Contains(string(dateData), banned) {
+			t.Errorf("refactor should have hoisted per-bead %q date calls into jq; date log:\n%s", banned, dateData)
+		}
+	}
+}
+
+// TestWispCompactBatchesBdCalls pins the batching contract introduced for
+// ga-blt: bd write subcommands MUST be invoked at most once per category
+// (promote/delete/archive) per cooldown, even when many beads are eligible.
+// At ~4000 ephemerals/cooldown the per-bead loop spawned thousands of bd
+// subprocesses and saturated dolt's thread pool (pe-t07v). Regressing this
+// behavior would re-introduce the dolt server peg.
+func TestWispCompactBatchesBdCalls(t *testing.T) {
+	pastTTL := time.Now().Add(-48 * time.Hour).UTC().Format(wispTimestampLayout)
+	beadsJSON := fmt.Sprintf(`[
+  {"id":"ga-del-1","status":"closed","ephemeral":true,"updated_at":%q,"comment_count":0,"labels":[]},
+  {"id":"ga-del-2","status":"closed","ephemeral":true,"updated_at":%q,"comment_count":0,"labels":[]},
+  {"id":"ga-stuck-1","status":"open","ephemeral":true,"updated_at":%q,"comment_count":0,"labels":[]},
+  {"id":"ga-stuck-2","status":"open","ephemeral":true,"updated_at":%q,"comment_count":0,"labels":[]},
+  {"id":"ga-mail-1","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read"]},
+  {"id":"ga-mail-2","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read"]}
+]`, pastTTL, pastTTL, pastTTL, pastTTL, pastTTL, pastTTL)
+
+	bdLog, env := wispCompactEnv(t, beadsJSON)
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+	if err != nil {
+		t.Fatalf("wisp-compact.sh failed: %v\n%s", err, out)
+	}
+
+	logData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	log := string(logData)
+
+	var updateCalls, deleteCalls, closeCalls, commentCalls int
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "update "):
+			updateCalls++
+		case strings.HasPrefix(line, "delete "):
+			deleteCalls++
+		case strings.HasPrefix(line, "close "):
+			closeCalls++
+		case strings.HasPrefix(line, "comment "):
+			commentCalls++
+		}
+	}
+
+	if updateCalls != 1 {
+		t.Errorf("want exactly 1 bd update call (batched promotion); got %d\nlog:\n%s", updateCalls, log)
+	}
+	if deleteCalls != 1 {
+		t.Errorf("want exactly 1 bd delete call (batched deletion); got %d\nlog:\n%s", deleteCalls, log)
+	}
+	if closeCalls != 1 {
+		t.Errorf("want exactly 1 bd close call (batched mail archive); got %d\nlog:\n%s", closeCalls, log)
+	}
+	if commentCalls != 0 {
+		t.Errorf("want 0 bd comment calls (auditing must be batched via --append-notes); got %d\nlog:\n%s", commentCalls, log)
+	}
+
+	// The single multi-ID bd update line must carry both stuck IDs and the
+	// "stuck detection" reason text — equivalent of the old per-bead comment.
+	var promoteLine string
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		if strings.HasPrefix(line, "update ") {
+			promoteLine = line
+			break
+		}
+	}
+	for _, id := range []string{"ga-stuck-1", "ga-stuck-2"} {
+		if !strings.Contains(promoteLine, id) {
+			t.Errorf("batched promote line missing %q: %q", id, promoteLine)
+		}
+	}
+	if !strings.Contains(promoteLine, "stuck detection") {
+		t.Errorf("batched promote line missing audit reason 'stuck detection': %q", promoteLine)
+	}
+
+	var deleteLine string
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		if strings.HasPrefix(line, "delete ") {
+			deleteLine = line
+			break
+		}
+	}
+	for _, id := range []string{"ga-del-1", "ga-del-2"} {
+		if !strings.Contains(deleteLine, id) {
+			t.Errorf("batched delete line missing %q: %q", id, deleteLine)
+		}
+	}
+
+	var closeLine string
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		if strings.HasPrefix(line, "close ") {
+			closeLine = line
+			break
+		}
+	}
+	for _, id := range []string{"ga-mail-1", "ga-mail-2"} {
+		if !strings.Contains(closeLine, id) {
+			t.Errorf("batched close line missing %q: %q", id, closeLine)
+		}
+	}
+}
+
+// TestWispCompactBatchesPromotionsByReason verifies that beads with different
+// promotion reasons (proven value vs stuck detection) are still grouped into
+// at-most-two bd update calls — never per-bead. This is the boundary case for
+// the batching contract: mixed reasons must not collapse the audit text.
+func TestWispCompactBatchesPromotionsByReason(t *testing.T) {
+	pastTTL := time.Now().Add(-48 * time.Hour).UTC().Format(wispTimestampLayout)
+	beadsJSON := fmt.Sprintf(`[
+  {"id":"ga-proven-1","status":"closed","ephemeral":true,"updated_at":%q,"comment_count":3,"labels":[]},
+  {"id":"ga-proven-2","status":"closed","ephemeral":true,"updated_at":%q,"comment_count":5,"labels":[]},
+  {"id":"ga-stuck-1","status":"open","ephemeral":true,"updated_at":%q,"comment_count":0,"labels":[]},
+  {"id":"ga-stuck-2","status":"open","ephemeral":true,"updated_at":%q,"comment_count":0,"labels":[]}
+]`, pastTTL, pastTTL, pastTTL, pastTTL)
+
+	bdLog, env := wispCompactEnv(t, beadsJSON)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+
+	logData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	log := string(logData)
+
+	var updateLines []string
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		if strings.HasPrefix(line, "update ") {
+			updateLines = append(updateLines, line)
+		}
+	}
+	if len(updateLines) != 2 {
+		t.Fatalf("want exactly 2 bd update calls (one per reason group); got %d\nlog:\n%s", len(updateLines), log)
+	}
+
+	var provenLine, stuckLine string
+	for _, line := range updateLines {
+		switch {
+		case strings.Contains(line, "proven value"):
+			provenLine = line
+		case strings.Contains(line, "stuck detection"):
+			stuckLine = line
+		}
+	}
+	if provenLine == "" {
+		t.Fatalf("missing proven-value update line:\n%s", log)
+	}
+	if stuckLine == "" {
+		t.Fatalf("missing stuck-detection update line:\n%s", log)
+	}
+	for _, id := range []string{"ga-proven-1", "ga-proven-2"} {
+		if !strings.Contains(provenLine, id) {
+			t.Errorf("proven-value line missing %q: %q", id, provenLine)
+		}
+		if strings.Contains(stuckLine, id) {
+			t.Errorf("stuck-detection line accidentally contains proven id %q: %q", id, stuckLine)
+		}
+	}
+	for _, id := range []string{"ga-stuck-1", "ga-stuck-2"} {
+		if !strings.Contains(stuckLine, id) {
+			t.Errorf("stuck-detection line missing %q: %q", id, stuckLine)
+		}
+		if strings.Contains(provenLine, id) {
+			t.Errorf("proven-value line accidentally contains stuck id %q: %q", id, provenLine)
+		}
 	}
 }
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -5968,7 +5968,7 @@ EOF
         ;;
     esac
     ;;
-  update|comment|delete)
+  update|comment|delete|close)
     printf '%%s\n' "$*" >> "$BD_LOG"
     exit 0
     ;;
@@ -6026,7 +6026,7 @@ func TestWispCompactReportsSummaryForActions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("wisp-compact.sh failed: %v\n%s", err, out)
 	}
-	if got, want := strings.TrimSpace(string(out)), "wisp-compact: promoted=0 deleted=1 skipped=1"; got != want {
+	if got, want := strings.TrimSpace(string(out)), "wisp-compact: promoted=0 deleted=1 skipped=1 archived=0"; got != want {
 		t.Fatalf("summary = %q, want %q", got, want)
 	}
 }
@@ -6142,6 +6142,172 @@ func TestWispCompactSkipsNonEphemeralBeads(t *testing.T) {
 		if strings.Contains(s, banned) {
 			t.Fatalf("non-ephemeral bead must be ignored; saw %q in bd log:\n%s", banned, s)
 		}
+	}
+}
+
+// Pass 2 (mail archive) tests. These cover the read-mail TTL rule added for
+// ga-l17. Mail beads are non-ephemeral (issue_type=message), so they bypass
+// Pass 1; Pass 2 closes them with `bd close --reason "..."` once the
+// recipient has marked them read and the TTL has elapsed.
+
+func TestWispCompactArchivesAgedReadMessage(t *testing.T) {
+	pastTTL := time.Now().Add(-48 * time.Hour).UTC().Format(wispTimestampLayout)
+	beads := fmt.Sprintf(`[
+  {"id":"ga-mail-aged","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read","thread:abc"]}
+]`, pastTTL)
+
+	bdLog, env := wispCompactEnv(t, beads)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+
+	log, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	s := string(log)
+	if !strings.Contains(s, "close ga-mail-aged") {
+		t.Fatalf("expected `bd close ga-mail-aged`; bd log:\n%s", s)
+	}
+	if !strings.Contains(s, "wisp-compact:") {
+		t.Fatalf("expected close reason to start with `wisp-compact:`; bd log:\n%s", s)
+	}
+	for _, banned := range []string{"delete ga-mail-aged", "update ga-mail-aged", "comment ga-mail-aged"} {
+		if strings.Contains(s, banned) {
+			t.Fatalf("aged read mail must be archived via close, not %q; bd log:\n%s", banned, s)
+		}
+	}
+}
+
+func TestWispCompactSkipsReadMessageWithinTTL(t *testing.T) {
+	withinTTL := time.Now().Add(-1 * time.Hour).UTC().Format(wispTimestampLayout)
+	beads := fmt.Sprintf(`[
+  {"id":"ga-mail-fresh","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read"]}
+]`, withinTTL)
+
+	bdLog, env := wispCompactEnv(t, beads)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+
+	log, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	s := string(log)
+	if strings.Contains(s, "close ga-mail-fresh") {
+		t.Fatalf("within-TTL read mail must not be archived; bd log:\n%s", s)
+	}
+}
+
+func TestWispCompactSkipsUnreadMessage(t *testing.T) {
+	pastTTL := time.Now().Add(-48 * time.Hour).UTC().Format(wispTimestampLayout)
+	beads := fmt.Sprintf(`[
+  {"id":"ga-mail-unread","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["thread:abc"]}
+]`, pastTTL)
+
+	bdLog, env := wispCompactEnv(t, beads)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+
+	log, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	s := string(log)
+	if strings.Contains(s, "close ga-mail-unread") {
+		t.Fatalf("unread mail must never be archived even past TTL; bd log:\n%s", s)
+	}
+}
+
+func TestWispCompactSkipsReadMessageWithKeepLabel(t *testing.T) {
+	pastTTL := time.Now().Add(-48 * time.Hour).UTC().Format(wispTimestampLayout)
+	beads := fmt.Sprintf(`[
+  {"id":"ga-mail-keep","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read","keep"]}
+]`, pastTTL)
+
+	bdLog, env := wispCompactEnv(t, beads)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+
+	log, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	s := string(log)
+	if strings.Contains(s, "close ga-mail-keep") {
+		t.Fatalf("read mail with `keep` label must not be archived; bd log:\n%s", s)
+	}
+}
+
+func TestWispCompactSkipsReadMessageWithComments(t *testing.T) {
+	pastTTL := time.Now().Add(-48 * time.Hour).UTC().Format(wispTimestampLayout)
+	beads := fmt.Sprintf(`[
+  {"id":"ga-mail-discussed","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":2,"labels":["read"]}
+]`, pastTTL)
+
+	bdLog, env := wispCompactEnv(t, beads)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+
+	log, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	s := string(log)
+	if strings.Contains(s, "close ga-mail-discussed") {
+		t.Fatalf("read mail with comments (proven value) must not be archived; bd log:\n%s", s)
+	}
+}
+
+func TestWispCompactSkipsClosedMessage(t *testing.T) {
+	pastTTL := time.Now().Add(-48 * time.Hour).UTC().Format(wispTimestampLayout)
+	beads := fmt.Sprintf(`[
+  {"id":"ga-mail-closed","issue_type":"message","status":"closed","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read"]}
+]`, pastTTL)
+
+	bdLog, env := wispCompactEnv(t, beads)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+
+	log, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	s := string(log)
+	if strings.Contains(s, "close ga-mail-closed") {
+		t.Fatalf("already-closed message must not be re-closed; bd log:\n%s", s)
+	}
+}
+
+func TestWispCompactArchiveCountInSummary(t *testing.T) {
+	pastTTL := time.Now().Add(-48 * time.Hour).UTC().Format(wispTimestampLayout)
+	beads := fmt.Sprintf(`[
+  {"id":"ga-mail-a","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read"]},
+  {"id":"ga-mail-b","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read"]}
+]`, pastTTL, pastTTL)
+
+	_, env := wispCompactEnv(t, beads)
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+	if err != nil {
+		t.Fatalf("wisp-compact.sh failed: %v\n%s", err, out)
+	}
+	want := "archived=2"
+	if !strings.Contains(string(out), want) {
+		t.Fatalf("summary missing %q; got: %s", want, out)
+	}
+}
+
+func TestWispCompactMailArchiveAgeOverride(t *testing.T) {
+	// Override the default 24h TTL to 1h so a 2-hour-old read message archives.
+	twoHoursAgo := time.Now().Add(-2 * time.Hour).UTC().Format(wispTimestampLayout)
+	beads := fmt.Sprintf(`[
+  {"id":"ga-mail-overridden","issue_type":"message","status":"open","ephemeral":false,"updated_at":%q,"comment_count":0,"labels":["read"]}
+]`, twoHoursAgo)
+
+	bdLog, env := wispCompactEnv(t, beads)
+	env["GC_MAIL_ARCHIVE_AGE_HOURS"] = "1"
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh"), env)
+
+	log, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	s := string(log)
+	if !strings.Contains(s, "close ga-mail-overridden") {
+		t.Fatalf("GC_MAIL_ARCHIVE_AGE_HOURS=1 should archive a 2h-old read message; bd log:\n%s", s)
 	}
 }
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2822,6 +2822,316 @@ exit 0
 	}
 }
 
+// reaperAlertDoltStub returns a dolt-mock script body where the open-wisp count
+// query (no created_at filter) returns openWispCount. All other COUNT queries
+// return 0. Used by the alert-dedup tests below.
+func reaperAlertDoltStub(openWispCount int) string {
+	return fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*)
+    printf 'COUNT(*)\n%d\n'
+    ;;
+  *"DELETE FROM "*"wisps"*)
+    printf 'ROW_COUNT()\n0\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`, openWispCount)
+}
+
+// reaperAlertBaseEnv returns the common env vars used by the alert-dedup
+// tests. Threshold is hardcoded to 10 so the test stubs (which return modest
+// open-wisp counts) exercise the alert path without inflated counters.
+func reaperAlertBaseEnv(cityDir, binDir, doltLog, gcLog, stateDir string) map[string]string {
+	return map[string]string{
+		"DOLT_ARGS_LOG":             doltLog,
+		"GC_CALL_LOG":               gcLog,
+		"GC_CITY":                   cityDir,
+		"GC_CITY_PATH":              cityDir,
+		"GC_DOLT_HOST":              "127.0.0.1",
+		"GC_DOLT_PORT":              "3307",
+		"GC_DOLT_USER":              "root",
+		"GC_DOLT_PASSWORD":          "",
+		"GC_PACK_STATE_DIR":         stateDir,
+		"GC_REAPER_ALERT_THRESHOLD": "10",
+		"PATH":                      binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+}
+
+// TestReaperAlertEmitsOnFirstThresholdCross verifies that the threshold-crossed
+// anomaly is escalated when no prior alert state exists. Pin against ga-sh6
+// regression: without dedup state, the first crossing should always escalate.
+func TestReaperAlertEmitsOnFirstThresholdCross(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), reaperAlertDoltStub(50))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := reaperAlertBaseEnv(cityDir, binDir, doltLog, gcLog, stateDir)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION: Reaper anomalies detected [MEDIUM]") {
+		t.Fatalf("reaper did not escalate on first threshold cross:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "50 open wisps (threshold: 10)") {
+		t.Fatalf("reaper escalation body missing open-wisp count:\n%s", gcLogText)
+	}
+
+	statePath := filepath.Join(stateDir, "reaper-alert-state.txt")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("reaper did not persist alert state file %s: %v", statePath, err)
+	}
+	stateData, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(state): %v", err)
+	}
+	stateText := string(stateData)
+	if !strings.Contains(stateText, "count=50") {
+		t.Fatalf("state file missing recorded count:\n%s", stateText)
+	}
+}
+
+// TestReaperAlertDedupSkipsWithinWindowAndSmallDelta verifies that a second
+// reaper run within the dedup window with a small open-wisp delta does NOT
+// emit a duplicate mail. Pin against ga-sh6 feedback loop.
+func TestReaperAlertDedupSkipsWithinWindowAndSmallDelta(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), reaperAlertDoltStub(52))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(stateDir): %v", err)
+	}
+	// Prior alert: count=50, 30 seconds ago. Within 3600s window, delta=2 < 10.
+	priorEpoch := time.Now().Add(-30 * time.Second).Unix()
+	priorState := fmt.Sprintf("epoch=%d\ncount=50\n", priorEpoch)
+	statePath := filepath.Join(stateDir, "reaper-alert-state.txt")
+	if err := os.WriteFile(statePath, []byte(priorState), 0o644); err != nil {
+		t.Fatalf("WriteFile(state): %v", err)
+	}
+
+	env := reaperAlertBaseEnv(cityDir, binDir, doltLog, gcLog, stateDir)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION") {
+		t.Fatalf("reaper escalated duplicate alert within dedup window (small delta):\n%s", gcLogText)
+	}
+
+	// State should not be updated when dedup applies.
+	stateData, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(state): %v", err)
+	}
+	if !strings.Contains(string(stateData), "count=50") {
+		t.Fatalf("dedup-skip path overwrote prior state:\n%s", stateData)
+	}
+}
+
+// TestReaperAlertDedupEmitsOnLargeDelta verifies that a count delta >= 10
+// re-emits an alert even within the dedup window.
+func TestReaperAlertDedupEmitsOnLargeDelta(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), reaperAlertDoltStub(65))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(stateDir): %v", err)
+	}
+	// Prior alert: count=50, 30 seconds ago. Within window but delta=15 >= 10.
+	priorEpoch := time.Now().Add(-30 * time.Second).Unix()
+	priorState := fmt.Sprintf("epoch=%d\ncount=50\n", priorEpoch)
+	statePath := filepath.Join(stateDir, "reaper-alert-state.txt")
+	if err := os.WriteFile(statePath, []byte(priorState), 0o644); err != nil {
+		t.Fatalf("WriteFile(state): %v", err)
+	}
+
+	env := reaperAlertBaseEnv(cityDir, binDir, doltLog, gcLog, stateDir)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION") {
+		t.Fatalf("reaper did not escalate on large count delta:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "65 open wisps") {
+		t.Fatalf("reaper escalation body missing updated count:\n%s", gcLogText)
+	}
+
+	// State should be updated.
+	stateData, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(state): %v", err)
+	}
+	if !strings.Contains(string(stateData), "count=65") {
+		t.Fatalf("state file did not record updated count after re-emit:\n%s", stateData)
+	}
+}
+
+// TestReaperAlertDedupEmitsAfterWindow verifies that an alert older than the
+// dedup window is re-emitted even when count delta is small.
+func TestReaperAlertDedupEmitsAfterWindow(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), reaperAlertDoltStub(52))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(stateDir): %v", err)
+	}
+	// Prior alert: count=50, narrow window of 1s. Backdate 2 seconds to escape.
+	priorEpoch := time.Now().Add(-2 * time.Second).Unix()
+	priorState := fmt.Sprintf("epoch=%d\ncount=50\n", priorEpoch)
+	statePath := filepath.Join(stateDir, "reaper-alert-state.txt")
+	if err := os.WriteFile(statePath, []byte(priorState), 0o644); err != nil {
+		t.Fatalf("WriteFile(state): %v", err)
+	}
+
+	env := reaperAlertBaseEnv(cityDir, binDir, doltLog, gcLog, stateDir)
+	env["GC_REAPER_ALERT_DEDUP_WINDOW_SEC"] = "1"
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION") {
+		t.Fatalf("reaper did not escalate after dedup window expired:\n%s", gcLogText)
+	}
+}
+
+// TestReaperAlertNonThresholdAnomalyBypassesDedup verifies that anomalies other
+// than the wisp-count threshold (e.g. Dolt commit failures) are escalated
+// without dedup, even when the threshold alert state is fresh.
+func TestReaperAlertNonThresholdAnomalyBypassesDedup(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	// open-wisp count = 5 (below threshold of 10). Inject commit failure to
+	// force a non-threshold anomaly.
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"CALL DOLT_COMMIT"*)
+    printf 'commit failed\n' >&2
+    exit 42
+    ;;
+  *"DELETE FROM "*"wisps"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"status = 'closed'"*"closed_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(stateDir): %v", err)
+	}
+	// Fresh prior alert state — would normally trigger dedup, but a non-
+	// threshold anomaly must still escalate.
+	priorEpoch := time.Now().Unix()
+	priorState := fmt.Sprintf("epoch=%d\ncount=0\n", priorEpoch)
+	statePath := filepath.Join(stateDir, "reaper-alert-state.txt")
+	if err := os.WriteFile(statePath, []byte(priorState), 0o644); err != nil {
+		t.Fatalf("WriteFile(state): %v", err)
+	}
+
+	env := reaperAlertBaseEnv(cityDir, binDir, doltLog, gcLog, stateDir)
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION") {
+		t.Fatalf("reaper suppressed a non-threshold anomaly via threshold dedup:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "Dolt commit failed") {
+		t.Fatalf("reaper non-threshold escalation lost commit-failure context:\n%s", gcLogText)
+	}
+}
+
 func TestReaperFormulaMatchesScriptDefaults(t *testing.T) {
 	scriptPath := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh")
 	scriptData, err := os.ReadFile(scriptPath)

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -7180,3 +7180,320 @@ exit 0
 		t.Fatalf("cross-rig-deps summary missing or wrong (subshell counter regression?)\nwant substring: %q\ngot output:\n%s\nbd log:\n%s", want, out, logData)
 	}
 }
+
+// strandedBeadSweepGCStub is a `gc` stub that:
+//   - logs every invocation to $GC_CALL_LOG;
+//   - serves a one-rig topology (rig=project, prefix=ga);
+//   - serves bd list responses driven by env vars
+//     (GC_TEST_CANDIDATES_JSON, GC_TEST_DIGEST_JSON);
+//   - records mail sends to $GC_MAIL_LOG.
+//
+// Sweep candidate queries carry --unassigned; digest still-stranded
+// queries carry --label= without --unassigned. We dispatch on those.
+const strandedBeadSweepGCStub = `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+case "$1" in
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      cat <<'JSON'
+{"rigs":[{"name":"project","prefix":"ga","hq":false,"beads":"initialized","suspended":false}]}
+JSON
+      exit 0
+    fi
+    ;;
+  bd)
+    case "$2" in
+      --rig|-C) shift 2 ;;
+    esac
+    case "$2" in
+      list)
+        case "$*" in
+          *"--unassigned"*)
+            printf '%s\n' "${GC_TEST_CANDIDATES_JSON:-[]}"
+            ;;
+          *"--label="*)
+            printf '%s\n' "${GC_TEST_DIGEST_JSON:-[]}"
+            ;;
+          *)
+            printf '[]\n'
+            ;;
+        esac
+        exit 0
+        ;;
+      update)
+        exit 0
+        ;;
+    esac
+    ;;
+  mail)
+    if [ "$2" = "send" ]; then
+      printf '%s\n' "$*" >> "$GC_MAIL_LOG"
+      exit 0
+    fi
+    ;;
+esac
+exit 0
+`
+
+// runStrandedBeadSweep wires up the test environment and invokes the
+// stranded-bead-sweep.py script via python3 (bypassing the uv-run
+// shebang so tests don't require uv on PATH). Optional flags is the
+// "--dry-run" toggle.
+func runStrandedBeadSweep(
+	t *testing.T,
+	overrides map[string]string,
+	candidatesJSON, digestJSON string,
+	flags ...string,
+) (stdout []byte, gcCalls, mailLog string) {
+	t.Helper()
+
+	python3, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLogPath := filepath.Join(t.TempDir(), "mail.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), strandedBeadSweepGCStub)
+
+	env := map[string]string{
+		"GC_CALL_LOG":             gcLog,
+		"GC_MAIL_LOG":             mailLogPath,
+		"GC_PACK_STATE_DIR":       stateDir,
+		"GC_TEST_CANDIDATES_JSON": candidatesJSON,
+		"GC_TEST_DIGEST_JSON":     digestJSON,
+		"PATH":                    binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	for k, v := range overrides {
+		env[k] = v
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "stranded-bead-sweep.py")
+	args := append([]string{script}, flags...)
+	cmd := exec.Command(python3, args...)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("stranded-bead-sweep.py failed: %v\n%s", err, out)
+	}
+	gcData, _ := os.ReadFile(gcLog)
+	mailData, _ := os.ReadFile(mailLogPath)
+	return out, string(gcData), string(mailData)
+}
+
+func TestStrandedBeadSweepLabelsCandidates(t *testing.T) {
+	candidates := `[
+		{"id":"ga-stranded","issue_type":"task","status":"open","title":"unrouted","updated_at":"2026-05-01T00:00:00Z","priority":2,"metadata":{}},
+		{"id":"ga-routed","issue_type":"task","status":"open","title":"already routed","updated_at":"2026-05-01T00:00:00Z","metadata":{"gc.routed_to":"project/worker"}},
+		{"id":"ga-assigned","issue_type":"task","status":"open","title":"already assigned","updated_at":"2026-05-01T00:00:00Z","assignee":"alice","metadata":{}},
+		{"id":"ga-message","issue_type":"message","status":"open","title":"non-work-type","updated_at":"2026-05-01T00:00:00Z","metadata":{}},
+		{"id":"za-wrong-rig","issue_type":"task","status":"open","title":"wrong-rig","updated_at":"2026-05-01T00:00:00Z","metadata":{}}
+	]`
+
+	out, gcCalls, mailLog := runStrandedBeadSweep(t, nil, candidates, "[]")
+
+	if !strings.Contains(gcCalls, "bd --rig project update ga-stranded --add-label needs:human") {
+		t.Fatalf("expected ga-stranded to be labeled needs:human; gc calls:\n%s", gcCalls)
+	}
+	for _, skip := range []string{"ga-routed", "ga-assigned", "ga-message", "za-wrong-rig"} {
+		if strings.Contains(gcCalls, "bd --rig project update "+skip) {
+			t.Fatalf("expected %s to be skipped; gc calls:\n%s", skip, gcCalls)
+		}
+	}
+	if mailLog != "" {
+		t.Fatalf("did not expect digest mail (state file missing means first run advances quietly); mail log:\n%s", mailLog)
+	}
+	if !strings.Contains(string(out), "labeled 1") {
+		t.Fatalf("expected summary 'labeled 1'; got:\n%s", out)
+	}
+}
+
+func TestStrandedBeadSweepDryRunSkipsWrites(t *testing.T) {
+	candidates := `[
+		{"id":"ga-stranded","issue_type":"task","status":"open","title":"unrouted","updated_at":"2026-05-01T00:00:00Z","metadata":{}}
+	]`
+	digest := `[
+		{"id":"ga-stranded","issue_type":"task","status":"open","title":"unrouted","updated_at":"2026-05-01T00:00:00Z","priority":2,"metadata":{}}
+	]`
+
+	out, gcCalls, mailLog := runStrandedBeadSweep(t, nil, candidates, digest, "--dry-run")
+
+	if strings.Contains(gcCalls, " update ga-stranded ") {
+		t.Fatalf("dry-run should not call bd update; gc calls:\n%s", gcCalls)
+	}
+	if mailLog != "" {
+		t.Fatalf("dry-run should not send mail; mail log:\n%s", mailLog)
+	}
+	if !strings.Contains(string(out), "would label ga-stranded") {
+		t.Fatalf("expected dry-run preview line; got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "would send digest") {
+		t.Fatalf("expected dry-run digest preview; got:\n%s", out)
+	}
+}
+
+func TestStrandedBeadSweepCustomSurfaceLabel(t *testing.T) {
+	candidates := `[
+		{"id":"ga-stranded","issue_type":"task","status":"open","title":"unrouted","updated_at":"2026-05-01T00:00:00Z","metadata":{}}
+	]`
+
+	_, gcCalls, _ := runStrandedBeadSweep(t,
+		map[string]string{"GC_STRANDED_SURFACE_LABEL": "needs:operator"},
+		candidates, "[]")
+
+	if !strings.Contains(gcCalls, "update ga-stranded --add-label needs:operator") {
+		t.Fatalf("expected custom surface label needs:operator; gc calls:\n%s", gcCalls)
+	}
+	// The candidate-query exclude-label filter must include the configured
+	// surface label so already-labeled beads stay exempt across runs.
+	if !strings.Contains(gcCalls, "--exclude-label=needs:operator,skip:auto-route") {
+		t.Fatalf("expected exclude-label to lead with needs:operator; gc calls:\n%s", gcCalls)
+	}
+}
+
+func TestStrandedBeadSweepCustomExemptLabels(t *testing.T) {
+	candidates := `[
+		{"id":"ga-stranded","issue_type":"task","status":"open","title":"unrouted","updated_at":"2026-05-01T00:00:00Z","metadata":{}}
+	]`
+
+	_, gcCalls, _ := runStrandedBeadSweep(t,
+		map[string]string{"GC_STRANDED_EXEMPT_LABELS": "foo,bar"},
+		candidates, "[]")
+
+	if !strings.Contains(gcCalls, "--exclude-label=needs:human,foo,bar") {
+		t.Fatalf("expected configured exempt labels appended after surface; gc calls:\n%s", gcCalls)
+	}
+}
+
+func TestStrandedBeadSweepDigestSilentWithRecentState(t *testing.T) {
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	maintStateDir := filepath.Join(stateDir, "maintenance")
+	if err := os.MkdirAll(maintStateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(maintStateDir, "stranded-bead-digest-last")
+	recent := time.Now().UTC().Add(-1 * time.Hour).Format("2006-01-02T15:04:05Z")
+	if err := os.WriteFile(statePath, []byte(recent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "mail.log")
+	writeExecutable(t, filepath.Join(binDir, "gc"), strandedBeadSweepGCStub)
+
+	digest := `[
+		{"id":"ga-stranded","issue_type":"task","status":"open","title":"unrouted","updated_at":"2026-05-01T00:00:00Z","priority":2,"metadata":{}}
+	]`
+
+	python3, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+	env := map[string]string{
+		"GC_CALL_LOG":             gcLog,
+		"GC_MAIL_LOG":             mailLog,
+		"GC_PACK_STATE_DIR":       maintStateDir,
+		"GC_TEST_CANDIDATES_JSON": "[]",
+		"GC_TEST_DIGEST_JSON":     digest,
+		"PATH":                    binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "stranded-bead-sweep.py")
+	cmd := exec.Command(python3, script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("stranded-bead-sweep.py failed: %v\n%s", err, out)
+	}
+	mailData, _ := os.ReadFile(mailLog)
+	if len(mailData) != 0 {
+		t.Fatalf("digest mail sent within interval; mail log:\n%s", mailData)
+	}
+	// State file should be unchanged (not advanced) when interval hasn't elapsed.
+	stateBytes, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("ReadFile(state): %v", err)
+	}
+	if got := strings.TrimSpace(string(stateBytes)); got != recent {
+		t.Fatalf("state file should be unchanged within interval; got %q want %q", got, recent)
+	}
+}
+
+func TestStrandedBeadSweepDigestSendsWhenDue(t *testing.T) {
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "mail.log")
+	writeExecutable(t, filepath.Join(binDir, "gc"), strandedBeadSweepGCStub)
+
+	digest := `[
+		{"id":"ga-stranded","issue_type":"task","status":"open","title":"unrouted","updated_at":"2026-05-01T00:00:00Z","priority":2,"metadata":{}}
+	]`
+
+	python3, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+	env := map[string]string{
+		"GC_CALL_LOG":             gcLog,
+		"GC_MAIL_LOG":             mailLog,
+		"GC_PACK_STATE_DIR":       stateDir,
+		"GC_TEST_CANDIDATES_JSON": "[]",
+		"GC_TEST_DIGEST_JSON":     digest,
+		"PATH":                    binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "stranded-bead-sweep.py")
+	cmd := exec.Command(python3, script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("stranded-bead-sweep.py failed: %v\n%s", err, out)
+	}
+	mailData, _ := os.ReadFile(mailLog)
+	if !strings.Contains(string(mailData), "send mayor") {
+		t.Fatalf("digest mail should go to mayor; mail log:\n%s\nstdout:\n%s", mailData, out)
+	}
+	if !strings.Contains(string(mailData), "Weekly stranded-bead digest") {
+		t.Fatalf("digest mail subject missing; mail log:\n%s", mailData)
+	}
+	// State file should now exist.
+	statePath := filepath.Join(stateDir, "stranded-bead-digest-last")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state file not advanced after digest send: %v", err)
+	}
+}
+
+func TestStrandedBeadSweepDigestRecipientConfigurable(t *testing.T) {
+	digest := `[
+		{"id":"ga-stranded","issue_type":"task","status":"open","title":"unrouted","updated_at":"2026-05-01T00:00:00Z","priority":2,"metadata":{}}
+	]`
+
+	_, _, mailLog := runStrandedBeadSweep(t,
+		map[string]string{"GC_STRANDED_DIGEST_TO": "watcher"},
+		"[]", digest)
+
+	if !strings.Contains(mailLog, "send watcher") {
+		t.Fatalf("digest should target configured recipient; mail log:\n%s", mailLog)
+	}
+}
+
+func TestStrandedBeadSweepSilentAdvanceWhenNoStranded(t *testing.T) {
+	stateDir := t.TempDir()
+	_, gcCalls, mailLog := runStrandedBeadSweep(t,
+		map[string]string{"GC_PACK_STATE_DIR": stateDir},
+		"[]", "[]")
+
+	if mailLog != "" {
+		t.Fatalf("should not send mail when no stranded beads; mail log:\n%s", mailLog)
+	}
+	if strings.Contains(gcCalls, "mail send") {
+		t.Fatalf("should not call mail send when no stranded beads; gc calls:\n%s", gcCalls)
+	}
+	// State file is advanced silently so the next due window stays an
+	// interval away rather than firing on every tick.
+	statePath := filepath.Join(stateDir, "stranded-bead-digest-last")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state file should be advanced silently when nothing to send: %v", err)
+	}
+}

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -27,9 +27,10 @@ gc sling "$POLECAT_TARGET" <bead-id>                     # dispatch to polecat p
 ```
 
 **Pool dispatch leaves the assignee empty.** The polecat that picks the bead up sets the
-assignee on claim. If you set `--assignee` yourself, the supervisor's scale_check
-(`bd ready --metadata-field gc.routed_to=<canonical> --unassigned`) won't count the bead as
-pool demand and no session will spawn. Set `gc.routed_to` only.
+assignee on claim. Set `gc.routed_to` only — `gc sling` does this and nothing else.
+(If a caller does set `--assignee=<pool-template>` as a placeholder, the supervisor's
+Tier 3b rescue still surfaces the bead to pool members, but the canonical pattern is
+empty assignee.)
 
 **Why this is the default:**
 - Every polecat completion is a ledger entry — transparent, auditable work

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -1,5 +1,42 @@
 # Polecat Context
 
+## START IMMEDIATELY: run `gc hook` as your first tool call
+
+**Your first action this session is `gc hook`. Run it now, before reading any
+further. The rest of this prompt is reference material — it does not gate
+your first turn.**
+
+Polecat sessions are spawned because work is waiting for you. There is no
+human approving your start. There is no "Session started. Ready for your
+next instruction" pause. The instant Claude Code hands you the prompt, your
+first tool call MUST be `gc hook` — or, equivalently:
+
+```bash
+gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress
+# if empty, the pool query:
+gc bd ready --assignee="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat" --json
+```
+
+If a bead is returned, claim it with `gc bd update <id> --claim` and follow
+the formula steps. If both come up empty, that is a bug — never wait at the
+prompt. Escalate to the witness:
+
+```bash
+WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
+gc mail send "$WITNESS_TARGET" \
+  -s "ESCALATION: polecat spawned with empty hook [HIGH]" \
+  -m "Session $GC_SESSION_NAME found no assigned work and no routed pool work."
+gc runtime drain-ack
+exit
+```
+
+This rule applies on every entry into this session — first turn after spawn,
+first turn after `gc reload`, first turn after any nudge. **Always start
+with `gc hook`.** Reading the rest of this prompt before that call is the
+Idle Polecat Heresy in another costume.
+
+---
+
 > **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
 {{ template "approval-fallacy-polecat" . }}

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -241,8 +241,7 @@ alert the witness, not `gc mail send`.
 | Remove metadata field | `gc bd update $WORK --unset-metadata key` |
 | Fetch remote branches | `git fetch --prune origin` |
 | Rebase on target | `refinery-rebase.sh "$BRANCH" "$TARGET"` (see "Rebase Safety" above) |
-| Fast-forward merge | `git merge --ff-only temp` |
-| Push merged changes | `git push origin $TARGET` |
+| Push merged changes | `git push origin "temp:$TARGET"` (after verifying `git merge-base --is-ancestor "origin/$TARGET" temp`) |
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -91,6 +91,46 @@ RIGHT (sequential rebase):
 
 **After every merge, main moves. Next branch MUST rebase on new baseline.**
 
+## Rebase Safety — `refinery-rebase.sh`
+
+**Always run the canonical helper, never an ad-hoc inline rebase.** The
+shipped script (`refinery-rebase.sh` in the gastown pack's `assets/scripts/`)
+is the only sanctioned way to rebase a polecat branch onto the merge target.
+
+**Anti-pattern to refuse on sight:**
+
+```bash
+# WRONG — silent data loss bug ga-vnr / post-mortem pe-wisp-tj0bj5.
+git rebase origin/main 2>&1 | tail -15
+```
+
+Without `set -o pipefail`, the pipe-to-`tail` swallows rebase's non-zero
+exit. A failed rebase looks successful, the caller force-pushes the
+pre-rebase ancestor, and commits silently disappear from `main`. The same
+trap applies to `git push | tee`, `git fetch | grep`, `gh pr create | tail`
+or any pipe that demotes a failable command's exit code through an always-
+succeeding filter.
+
+**Why a separate script (not just inline bash):**
+
+- `set -euo pipefail` is baked in, so future drift cannot reintroduce the
+  masking-pipe shape by accident.
+- Rebase output is redirected to a tempfile and only emitted on failure,
+  so the LLM never sees verbose output it might be tempted to `tail`.
+- Conflict cleanup (`git rebase --abort`, drop `temp`, restore `$TARGET`)
+  runs deterministically before exit, so the worktree contract the
+  rejection flow depends on (clean status, on `$TARGET`, no `temp`) holds
+  every time.
+- Exit codes are explicit: `0` success, `2` usage error, `3` rebase
+  conflict, `4` pre-rebase failure (fetch/checkout). Callers branch on
+  the numeric code, never on text-grep over output.
+
+**If you must wrap it** (e.g. structured logging): the wrapper itself
+MUST start with `set -euo pipefail`, MUST NOT pipe the script's output
+through `tail`/`grep`/`tee`, and MUST propagate the exit code verbatim.
+A wrapper that swallows the non-zero exit is the bug ga-vnr exists to
+forbid.
+
 ## Work Bead Metadata Contract
 
 Polecats set these metadata fields before assigning a work bead to you:
@@ -200,7 +240,7 @@ alert the witness, not `gc mail send`.
 | Set metadata field | `gc bd update $WORK --set-metadata key=value` |
 | Remove metadata field | `gc bd update $WORK --unset-metadata key` |
 | Fetch remote branches | `git fetch --prune origin` |
-| Rebase on target | `git rebase origin/$TARGET` |
+| Rebase on target | `refinery-rebase.sh "$BRANCH" "$TARGET"` (see "Rebase Safety" above) |
 | Fast-forward merge | `git merge --ff-only temp` |
 | Push merged changes | `git push origin $TARGET` |
 

--- a/examples/gastown/packs/gastown/assets/scripts/refinery-rebase.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/refinery-rebase.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# refinery-rebase.sh — safely rebase a polecat branch onto a merge target.
+#
+# Usage:
+#   refinery-rebase.sh <branch> <target>
+#
+# Behavior:
+#   - Fetches origin, creates a `temp` working branch at origin/<branch>,
+#     and rebases it onto origin/<target>.
+#   - On success (exit 0): the working branch is `temp`, ready for the
+#     refinery's run-tests / merge-push steps.
+#   - On rebase conflict (exit 3): `git rebase --abort` runs first, the
+#     `temp` branch is deleted, and the worktree is left on <target>.
+#     A one-line summary naming the conflict files is printed on stderr
+#     and (if REFINERY_REBASE_REPORT is set) written to that file.
+#   - On pre-rebase failure (exit 4): fetch or checkout failed before the
+#     rebase began; no `temp` branch or rebase state to clean up.
+#   - On usage error (exit 2): missing arguments.
+#
+# Why this script exists
+# ----------------------
+# The earlier refinery wrapped `git rebase` in `git rebase ... 2>&1 | tail -15`.
+# Without `set -o pipefail`, the pipe swallowed rebase's non-zero exit:
+# the wrapper proceeded as if the rebase had succeeded and pushed the
+# pre-rebase ancestor to the target branch, silently dropping commits
+# (issue ga-vnr; post-mortem pe-wisp-tj0bj5). This script encodes the
+# safe pattern (set -euo pipefail, output redirected to a tempfile,
+# explicit exit codes) so the refinery cannot regress to the buggy
+# shape by accident.
+#
+# Exit codes:
+#   0  — rebase succeeded; `temp` branch holds the rebased history
+#   2  — usage error (missing branch/target argument)
+#   3  — rebase conflict (worktree cleaned up, conflict files reported)
+#   4  — fetch / branch-checkout failed before rebase began
+set -euo pipefail
+
+BRANCH="${1:-}"
+TARGET="${2:-}"
+
+if [ -z "$BRANCH" ] || [ -z "$TARGET" ]; then
+    echo "usage: refinery-rebase.sh <branch> <target>" >&2
+    exit 2
+fi
+
+LOG="$(mktemp -t refinery-rebase.XXXXXX.log)"
+trap 'rm -f "$LOG"' EXIT
+
+drop_temp_if_present() {
+    if git rev-parse --verify --quiet temp >/dev/null 2>&1; then
+        # Avoid `git branch -D` while checked out on temp.
+        if [ "$(git rev-parse --abbrev-ref HEAD)" = "temp" ]; then
+            git checkout "$TARGET" >>"$LOG" 2>&1 || true
+        fi
+        git branch -D temp >>"$LOG" 2>&1 || true
+    fi
+}
+
+if ! git fetch --prune origin >>"$LOG" 2>&1; then
+    cat "$LOG" >&2
+    exit 4
+fi
+
+drop_temp_if_present
+
+if ! git checkout -b temp "origin/$BRANCH" >>"$LOG" 2>&1; then
+    cat "$LOG" >&2
+    exit 4
+fi
+
+# Run the rebase with output redirected to a tempfile. Never pipe `git
+# rebase` through `tail`/`grep` — that masks rebase's non-zero exit
+# without `pipefail` and is fragile even with `pipefail`.
+if git rebase "origin/$TARGET" >>"$LOG" 2>&1; then
+    tail -n 5 "$LOG" || true
+    exit 0
+fi
+
+# Rebase failed. Capture conflicted paths BEFORE aborting — after `git
+# rebase --abort` the conflict markers and unmerged paths are gone.
+CONFLICT_FILES="$(git diff --name-only --diff-filter=U 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+
+git rebase --abort >>"$LOG" 2>&1 || true
+git checkout "$TARGET" >>"$LOG" 2>&1 || true
+drop_temp_if_present
+
+if [ -z "$CONFLICT_FILES" ]; then
+    CONFLICT_FILES="<unknown>"
+fi
+REPORT="Rebase conflict: $BRANCH onto $TARGET. Conflict files: $CONFLICT_FILES."
+echo "$REPORT" >&2
+if [ -n "${REFINERY_REBASE_REPORT:-}" ]; then
+    printf '%s\n' "$REPORT" >"$REFINERY_REBASE_REPORT"
+fi
+exit 3

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -448,18 +448,37 @@ fi
 
 **If MERGE_STRATEGY = "direct" (default):**
 
-**1. Merge and push target branch:**
+**1. Push the rebased branch into `$TARGET`:**
+
+Do NOT `git checkout $TARGET` here. In gc worktrees the rig's `$TARGET`
+branch is checked out in the primary worktree, and `git checkout $TARGET`
+from the refinery worktree fails with `fatal: '$TARGET' is already used
+by worktree`. The earlier shape — `git checkout $TARGET; git merge --ff-only
+temp; git push origin $TARGET` — silently continued on `temp` when that
+checkout failed, and `git push origin $TARGET` then shipped the unchanged
+local `$TARGET` ref so the merge was silently dropped (di-jlv).
+
+Push `temp` directly into `origin/$TARGET` after verifying it is a
+fast-forward over the current remote tip:
+
 ```bash
-git checkout $TARGET
-git merge --ff-only temp
-git push origin $TARGET
+git fetch origin
+if ! git merge-base --is-ancestor "origin/$TARGET" temp; then
+  echo "temp is not a descendant of origin/$TARGET — refusing to push"
+  exit 1
+fi
+git push origin "temp:$TARGET"
 ```
+
+This updates `origin/$TARGET` to point at `temp`'s tip without touching
+the local `$TARGET` ref. Works in standalone clones and gc worktrees
+alike.
 
 **2. Verify push:**
 ```bash
 git fetch origin
-LOCAL=$(git rev-parse $TARGET)
-REMOTE=$(git rev-parse origin/$TARGET)
+LOCAL=$(git rev-parse temp)
+REMOTE=$(git rev-parse "origin/$TARGET")
 [ "$LOCAL" = "$REMOTE" ] || echo "PUSH FAILED — do not proceed"
 ```
 If SHAs differ: STOP. Debug and retry. Do NOT continue.
@@ -487,7 +506,10 @@ gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"
 
 **4. Cleanup:**
 ```bash
-git branch -d temp
+# Detach HEAD off `temp` so we can delete it. We never checked out the
+# local `$TARGET` ref, so there is nothing to "leave" — just detach.
+git checkout --detach
+git branch -D temp
 ```
 If delete_merged_branches = "true": `git push origin --delete $BRANCH`
 

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -180,38 +180,77 @@ BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
 TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 ```
 
-Fetch and attempt mechanical rebase:
+**SAFETY: Use the canonical `refinery-rebase.sh` helper. Do NOT inline a
+fresh `git rebase` and especially do NOT wrap rebase output in `| tail`,
+`| grep`, or any other pipe.** The earlier refinery wrapped the rebase
+in `git rebase origin/main 2>&1 | tail -15`; without `set -o pipefail`
+the pipe swallowed rebase's non-zero exit and the wrapper pushed the
+pre-rebase ancestor to main, silently dropping commits (ga-vnr;
+post-mortem pe-wisp-tj0bj5). The shipped script has `set -euo pipefail`
+baked in, captures rebase output to a tempfile, and uses explicit exit
+codes (0 success, 3 conflict, 4 pre-rebase failure, 2 usage). If you
+need to write a wrapper for any reason, the wrapper itself MUST start
+with `set -euo pipefail`.
+
+Locate and invoke the helper from the refinery worktree. The pack is
+installed under the city runtime directory; the fallback walks the
+current working tree for the dev-checkout layout used by the gascity
+SDK.
 ```bash
-git fetch --prune origin
-git checkout -b temp origin/$BRANCH
-git rebase origin/$TARGET
+PACK_DIR="${GC_CITY_RUNTIME_DIR:-${GC_CITY:-${GC_CITY_PATH:-.}}/.gc/runtime}/packs/gastown"
+SCRIPT="$PACK_DIR/assets/scripts/refinery-rebase.sh"
+if [ ! -x "$SCRIPT" ]; then
+  SCRIPT="$(find . -path '*/packs/gastown/assets/scripts/refinery-rebase.sh' -type f -perm -u+x -print -quit 2>/dev/null)"
+fi
+if [ -z "$SCRIPT" ] || [ ! -x "$SCRIPT" ]; then
+  echo "refinery-rebase.sh not found; cannot safely rebase $BRANCH. STOP." >&2
+  gc runtime drain-ack
+  exit 1
+fi
+REPORT="$(mktemp -t refinery-rebase-report.XXXXXX)"
+REFINERY_REBASE_REPORT="$REPORT" "$SCRIPT" "$BRANCH" "$TARGET"
+REBASE_EXIT=$?
+CONFLICT_FILES=""
+if [ -s "$REPORT" ]; then
+  CONFLICT_FILES="$(cat "$REPORT")"
+fi
 ```
 
-If rebase SUCCEEDED (exit 0): close this step, proceed to run-tests.
+If rebase SUCCEEDED (`REBASE_EXIT` = 0): close this step, proceed to
+run-tests. The working branch is now `temp` with the rebased history.
 
-If rebase FAILED (conflicts):
+If rebase FAILED (conflicts): `REBASE_EXIT` = 3, and the script has
+already aborted the rebase, removed the temp branch, and switched the
+worktree back to $TARGET. The conflict summary is in `$CONFLICT_FILES`.
 
-1. Abort: `git rebase --abort`
-2. Clean up the existing workflow and reopen the source bead:
+1. Clean up the existing workflow and reopen the source bead:
 ```bash
 gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
 ```
-3. Put the work bead back in the pool with rejection metadata:
+2. Put the work bead back in the pool with rejection metadata naming the
+   conflict files (load-bearing — the next polecat reads
+   `rejection_reason` to know what to fix):
 ```bash
 gc bd update $WORK \
   --status=open \
   --assignee="" \
-  --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
+  --set-metadata rejection_reason="$CONFLICT_FILES (target $TARGET at $(git rev-parse origin/$TARGET))" \
   --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
 ```
-4. Do NOT delete the branch (new polecat needs it for conflict resolution).
-5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
-6. Pour next patrol iteration before burning:
+3. Do NOT delete the branch (new polecat needs it for conflict resolution).
+4. Pour next patrol iteration before burning:
 ```bash
 NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
-7. Burn this wisp: `gc bd mol burn <wisp-id> --force`
+5. Burn this wisp: `gc bd mol burn <wisp-id> --force`
+
+If `REBASE_EXIT` = 4 (pre-rebase failure — fetch or checkout failed):
+STOP. The repo state was not mutated. Investigate (network, branch
+deleted on origin, permission) and retry. Do NOT mutate the bead.
+
+If `REBASE_EXIT` = 2 (usage error): STOP. `metadata.branch` or
+`metadata.target` was missing or empty. Escalate to mayor.
 
 **A new polecat will pick up the bead, see the branch and rejection,
 rebase, and reassign to refinery.**"""

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -20,6 +20,14 @@ PURGE_AGE="${GC_REAPER_PURGE_AGE:-168h}"
 STALE_ISSUE_AGE="${GC_REAPER_STALE_ISSUE_AGE:-720h}"
 SESSION_PURGE_AGE="${GC_REAPER_SESSION_PURGE_AGE:-720h}"
 ALERT_THRESHOLD="${GC_REAPER_ALERT_THRESHOLD:-500}"
+# Alert dedup: skip threshold-only escalations when the previous emit is
+# fresher than ALERT_DEDUP_WINDOW_SEC and the open-wisp count has not moved
+# by at least ALERT_DEDUP_DELTA. Without this, every cycle past the
+# threshold spawns another mail wisp and feeds itself (ga-sh6).
+ALERT_DEDUP_WINDOW_SEC="${GC_REAPER_ALERT_DEDUP_WINDOW_SEC:-3600}"
+ALERT_DEDUP_DELTA="${GC_REAPER_ALERT_DEDUP_DELTA:-10}"
+PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/maintenance}"
+ALERT_STATE_FILE="$PACK_STATE_DIR/reaper-alert-state.txt"
 DRY_RUN="${GC_REAPER_DRY_RUN:-}"
 
 # Convert Go durations to SQL INTERVAL hours for Dolt.
@@ -120,6 +128,15 @@ TOTAL_SESSIONS_PRUNED=0
 SESSION_PRUNE_ATTEMPTED=0
 ANOMALIES=""
 
+# Track which kind(s) of anomaly fired this run so the report stage can
+# decide whether dedup applies (threshold-only) or must be bypassed
+# (non-threshold anomalies always escalate). MAX_OPEN_WISPS holds the
+# largest open-wisp count seen across databases this run; it feeds the
+# dedup delta comparison.
+THRESHOLD_ANOMALY_RECORDED=0
+NONTHRESHOLD_ANOMALY_RECORDED=0
+MAX_OPEN_WISPS=0
+
 sanitize_output() {
     printf '%s' "$1" | tr '\n' ' ' | cut -c1-500
 }
@@ -129,6 +146,58 @@ record_anomaly() {
     shift
     ANOMALIES="${ANOMALIES}$db: $*
 "
+    NONTHRESHOLD_ANOMALY_RECORDED=1
+}
+
+# reaper_alert_should_emit decides whether a threshold-only escalation is
+# allowed to leave the script. It is consulted only when no non-threshold
+# anomaly was recorded; non-threshold paths (commit failures, missing city
+# DB, etc.) bypass dedup unconditionally. Returns success (emit) when there
+# is no prior state, the state is unparseable, the dedup window has expired,
+# or the open-wisp count has moved by at least ALERT_DEDUP_DELTA. Returns
+# failure (skip) only when a fresh prior emit had a close-enough count.
+reaper_alert_should_emit() {
+    local current_max="$1"
+    [ -f "$ALERT_STATE_FILE" ] || return 0
+
+    local last_epoch=""
+    local last_count=""
+    local key value
+    while IFS='=' read -r key value; do
+        case "$key" in
+            epoch) last_epoch="$value" ;;
+            count) last_count="$value" ;;
+        esac
+    done < "$ALERT_STATE_FILE"
+
+    case "$last_epoch" in ''|*[!0-9]*) return 0 ;; esac
+    case "$last_count" in ''|*[!0-9]*) return 0 ;; esac
+
+    local now age diff
+    now=$(date +%s 2>/dev/null || echo 0)
+    case "$now" in ''|*[!0-9]*) return 0 ;; esac
+
+    age=$((now - last_epoch))
+    [ "$age" -lt 0 ] && age=0
+    diff=$((current_max - last_count))
+    [ "$diff" -lt 0 ] && diff=$((last_count - current_max))
+
+    if [ "$age" -lt "$ALERT_DEDUP_WINDOW_SEC" ] && [ "$diff" -lt "$ALERT_DEDUP_DELTA" ]; then
+        return 1
+    fi
+    return 0
+}
+
+# reaper_alert_save_state persists the most recent threshold-emit count and
+# timestamp so future runs can dedup. Best-effort: a write failure does not
+# fail the reaper run because the next cycle simply re-checks the threshold.
+reaper_alert_save_state() {
+    local current_max="$1"
+    mkdir -p "$PACK_STATE_DIR" 2>/dev/null || return 0
+    local now
+    now=$(date +%s 2>/dev/null || echo 0)
+    case "$now" in ''|*[!0-9]*) return 0 ;; esac
+    printf 'epoch=%d\ncount=%d\n' "$now" "$current_max" > "$ALERT_STATE_FILE" 2>/dev/null || true
 }
 
 CITY_DB_ANOMALY_RECORDED=0
@@ -474,6 +543,10 @@ while IFS= read -r DB; do
 
     if [ "$OPEN_WISPS" -gt "$ALERT_THRESHOLD" ]; then
         ANOMALIES="${ANOMALIES}$DB: $OPEN_WISPS open wisps (threshold: $ALERT_THRESHOLD)\n"
+        THRESHOLD_ANOMALY_RECORDED=1
+        if [ "$OPEN_WISPS" -gt "$MAX_OPEN_WISPS" ]; then
+            MAX_OPEN_WISPS=$OPEN_WISPS
+        fi
     fi
 
     # Commit Dolt changes. Must use CALL (not SELECT) and have an active
@@ -529,8 +602,22 @@ fi
 
 # Report.
 if [ -n "$ANOMALIES" ]; then
-    gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
-        -m "$ANOMALIES" 2>/dev/null || true
+    SHOULD_EMIT=1
+    # Threshold-only escalations dedup against the persisted state file.
+    # Any non-threshold anomaly always emits — operators need to see those
+    # promptly even if a recent threshold mail is still on file.
+    if [ "$NONTHRESHOLD_ANOMALY_RECORDED" -eq 0 ] && [ "$THRESHOLD_ANOMALY_RECORDED" -eq 1 ]; then
+        if ! reaper_alert_should_emit "$MAX_OPEN_WISPS"; then
+            SHOULD_EMIT=0
+        fi
+    fi
+    if [ "$SHOULD_EMIT" -eq 1 ]; then
+        gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
+            -m "$ANOMALIES" 2>/dev/null || true
+        if [ "$THRESHOLD_ANOMALY_RECORDED" -eq 1 ]; then
+            reaper_alert_save_state "$MAX_OPEN_WISPS"
+        fi
+    fi
 fi
 
 SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED"

--- a/examples/gastown/packs/maintenance/assets/scripts/stranded-bead-sweep.py
+++ b/examples/gastown/packs/maintenance/assets/scripts/stranded-bead-sweep.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Label stranded beads with a surface label and mail a periodic digest.
+
+A "stranded" bead is open, work-type, has no `gc.routed_to` metadata, no
+assignee, no exempt label, and has not been touched for at least
+GC_STRANDED_AGE_HOURS hours (default 4). Such beads will not be picked up
+by any auto-route order and have no agent working on them — they would
+sit invisible in the queue until a human noticed.
+
+Each cooldown run:
+  1. Walks every initialized rig and adds the surface label (default
+     `needs:human`) to stranded beads. UIs and queries that filter on
+     this label (e.g. the gas-ui TODO tab) surface the beads to the
+     operator.
+  2. Once per N days (gated by a state file), counts the still-stranded
+     labeled beads across all rigs and mails the digest recipient
+     (default `mayor`). Silent on every other run.
+
+Acts as a backstop for any city where the HQ rig has no auto-route order:
+`pe-*` (or equivalent) beads that nobody slung get visibility this way
+without requiring a per-city auto-route order.
+
+Configuration (all optional, sensible defaults):
+
+  GC_STRANDED_AGE_HOURS       Hours since last update before a bead is
+                              eligible for the surface label. Default 4.
+  GC_STRANDED_SURFACE_LABEL   Label to add to stranded beads. Default
+                              `needs:human`. Idempotency: any bead that
+                              already carries this label is exempt.
+  GC_STRANDED_EXEMPT_LABELS   Comma-separated additional labels that
+                              exempt a bead from being labeled. The
+                              surface label is always exempt; this adds
+                              extras. Default `skip:auto-route`.
+  GC_STRANDED_DIGEST_DAYS     Days between digest mails. Default 7.
+  GC_STRANDED_DIGEST_TO       Recipient (agent name or rig/agent) of
+                              the digest mail. Default `mayor`.
+
+Run with --dry-run to print what would happen without modifying beads
+or sending mail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+WORK_TYPES = {"task", "bug", "feature", "chore", "epic", "decision"}
+
+DEFAULT_SURFACE_LABEL = "needs:human"
+DEFAULT_EXTRA_EXEMPT_LABELS = ("skip:auto-route",)
+DEFAULT_AGE_HOURS = 4
+DEFAULT_DIGEST_DAYS = 7
+DEFAULT_DIGEST_TO = "mayor"
+
+STATE_FILENAME = "stranded-bead-digest-last"
+PACK_NAME = "maintenance"
+DIGEST_PREVIEW = 5
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Print what would happen; skip label writes, mail send, "
+            "and state-file update."
+        ),
+    )
+    return parser.parse_args()
+
+
+def positive_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        n = int(raw)
+    except ValueError:
+        return default
+    return n if n > 0 else default
+
+
+def surface_label() -> str:
+    return (os.environ.get("GC_STRANDED_SURFACE_LABEL") or "").strip() \
+        or DEFAULT_SURFACE_LABEL
+
+
+def exempt_labels(surface: str) -> tuple[str, ...]:
+    """Set of labels that disqualify a bead from being labeled.
+
+    Always includes the configured surface label (idempotency: beads
+    already labeled are skipped). Additional labels are configurable via
+    GC_STRANDED_EXEMPT_LABELS as a comma-separated list.
+    """
+    raw = os.environ.get("GC_STRANDED_EXEMPT_LABELS")
+    if raw is None:
+        extras = DEFAULT_EXTRA_EXEMPT_LABELS
+    else:
+        extras = tuple(s.strip() for s in raw.split(",") if s.strip())
+    out: list[str] = [surface]
+    for lbl in extras:
+        if lbl and lbl not in out:
+            out.append(lbl)
+    return tuple(out)
+
+
+def digest_interval() -> timedelta:
+    return timedelta(days=positive_int_env(
+        "GC_STRANDED_DIGEST_DAYS", DEFAULT_DIGEST_DAYS,
+    ))
+
+
+def digest_to() -> str:
+    return (os.environ.get("GC_STRANDED_DIGEST_TO") or "").strip() \
+        or DEFAULT_DIGEST_TO
+
+
+def age_hours() -> int:
+    return positive_int_env("GC_STRANDED_AGE_HOURS", DEFAULT_AGE_HOURS)
+
+
+def state_path() -> Path:
+    """Resolve the digest state file. Same lookup as closed-beads-digest."""
+    if pack_state := os.environ.get("GC_PACK_STATE_DIR"):
+        base = Path(pack_state)
+    else:
+        city = (
+            os.environ.get("GC_CITY")
+            or os.environ.get("GC_CITY_PATH")
+            or os.getcwd()
+        )
+        runtime = (
+            os.environ.get("GC_CITY_RUNTIME_DIR") or f"{city}/.gc/runtime"
+        )
+        base = Path(runtime) / "packs" / PACK_NAME
+    return base / STATE_FILENAME
+
+
+def fmt_iso(dt: datetime) -> str:
+    """Format a UTC datetime with the Z suffix bd expects."""
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def read_last_digest(path: Path) -> datetime | None:
+    """Return the last digest send time, or None if never sent."""
+    try:
+        text = path.read_text().strip()
+    except OSError:
+        return None
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def write_last_digest(path: Path, when: datetime) -> None:
+    """Atomically write the digest send timestamp (temp file + rename)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".stranded-bead-digest-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(fmt_iso(when))
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def run_json(cmd: list[str]) -> object | None:
+    """Run a JSON-emitting subprocess; return parsed value or None on error."""
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def list_rigs() -> list[dict]:
+    """Return rigs with initialized bead stores, skipping suspended ones."""
+    data = run_json(["gc", "rig", "list", "--json"])
+    if not isinstance(data, dict):
+        return []
+    rigs: list[dict] = []
+    for r in data.get("rigs", []):
+        if not r.get("name") or not r.get("prefix"):
+            continue
+        if r.get("beads") != "initialized":
+            continue
+        if r.get("suspended"):
+            continue
+        rigs.append(r)
+    return rigs
+
+
+def bd_cmd(rig: dict) -> list[str]:
+    """Return the `gc bd` prefix appropriate for this rig.
+
+    HQ rigs use `gc bd -C <path>` because `gc bd --rig <hq-name>` is not
+    supported.
+    """
+    if rig.get("hq"):
+        return ["gc", "bd", "-C", rig["path"]]
+    return ["gc", "bd", "--rig", rig["name"]]
+
+
+def query_stranded_candidates(
+    rig: dict, cutoff: datetime, exempt: tuple[str, ...],
+) -> list[dict]:
+    """Return open unassigned work beads in `rig` older than `cutoff`.
+
+    Server-side filters cut the scan; the `gc.routed_to` and issue-type
+    checks happen in Python because bd lacks "missing-metadata-key" and
+    its `--type` filter only takes a single type.
+    """
+    cmd = bd_cmd(rig) + [
+        "list",
+        "--status=open",
+        "--unassigned",
+        f"--updated-before={fmt_iso(cutoff)}",
+        f"--exclude-label={','.join(exempt)}",
+        "--limit=0",
+        "--json",
+    ]
+    data = run_json(cmd)
+    if not isinstance(data, list):
+        return []
+
+    prefix = f"{rig['prefix']}-"
+    keep: list[dict] = []
+    for b in data:
+        bid = b.get("id") or ""
+        if not bid.startswith(prefix):
+            continue
+        if b.get("issue_type") not in WORK_TYPES:
+            continue
+        if b.get("ephemeral"):
+            continue
+        meta = b.get("metadata") or {}
+        if meta.get("gc.routed_to"):
+            continue
+        if b.get("assignee"):
+            # Belt-and-suspenders: --unassigned should have filtered these.
+            continue
+        keep.append(b)
+    return keep
+
+
+def query_still_stranded(rig: dict, surface: str) -> list[dict]:
+    """Return labeled-stranded beads currently in `rig` for the digest.
+
+    These are the beads `surface`-labeled by this script (or by any
+    other path) that still have no `gc.routed_to` — i.e. they remain
+    operator-actionable.
+    """
+    cmd = bd_cmd(rig) + [
+        "list",
+        "--status=open",
+        f"--label={surface}",
+        "--limit=0",
+        "--json",
+    ]
+    data = run_json(cmd)
+    if not isinstance(data, list):
+        return []
+
+    prefix = f"{rig['prefix']}-"
+    keep: list[dict] = []
+    for b in data:
+        bid = b.get("id") or ""
+        if not bid.startswith(prefix):
+            continue
+        if b.get("issue_type") not in WORK_TYPES:
+            continue
+        if b.get("ephemeral"):
+            continue
+        meta = b.get("metadata") or {}
+        if meta.get("gc.routed_to"):
+            continue
+        keep.append(b)
+    return keep
+
+
+def add_surface_label(rig: dict, bead_id: str, surface: str) -> bool:
+    """Add the surface label to a bead. Returns True on success."""
+    cmd = bd_cmd(rig) + ["update", bead_id, "--add-label", surface]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print(
+            f"stranded-bead-sweep: label {bead_id} failed: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def updated_at_dt(b: dict) -> datetime:
+    raw = b.get("updated_at") or b.get("created_at") or ""
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+
+
+def format_digest_entry(b: dict) -> str:
+    bid = b.get("id", "?")
+    prio = b.get("priority")
+    prio_s = f"P{prio}" if isinstance(prio, int) else "P?"
+    title = (b.get("title") or "").strip()
+    age = datetime.now(UTC) - updated_at_dt(b)
+    days = age.days
+    age_s = f"{days}d" if days >= 1 else f"{age.seconds // 3600}h"
+    return f"- {bid}  {prio_s}  {title}  (idle {age_s})"
+
+
+def build_digest_body(stranded: list[dict], surface: str) -> tuple[str, str]:
+    total = len(stranded)
+    # Show oldest first — those are most likely to have been forgotten.
+    by_age = sorted(stranded, key=updated_at_dt)
+    preview = by_age[:DIGEST_PREVIEW]
+    remaining = total - len(preview)
+
+    subject = f"Weekly stranded-bead digest: {total} unrouted"
+    lines = [
+        f"{total} stranded beads still unrouted; first {len(preview)} listed; "
+        f"full list via filter `label={surface} AND no:routed_to`.",
+        "",
+    ]
+    lines.extend(format_digest_entry(b) for b in preview)
+    if remaining > 0:
+        lines.append(f"- ... +{remaining} more")
+    return subject, "\n".join(lines) + "\n"
+
+
+def send_digest_mail(to: str, subject: str, body: str) -> bool:
+    cmd = [
+        "gc", "mail", "send", to,
+        "--from", "stranded-bead-sweep",
+        "-s", subject, "-m", body, "--notify",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print(
+            f"stranded-bead-sweep: mail send failed: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def sweep(
+    rigs: list[dict],
+    cutoff: datetime,
+    surface: str,
+    exempt: tuple[str, ...],
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Find and (in dry-run, just count) label stranded beads.
+
+    Returns (scanned, labeled) totals.
+    """
+    scanned = 0
+    labeled = 0
+    for rig in rigs:
+        candidates = query_stranded_candidates(rig, cutoff, exempt)
+        scanned += len(candidates)
+        for b in candidates:
+            bid = b.get("id")
+            if not bid:
+                continue
+            if dry_run:
+                print(
+                    f"stranded-bead-sweep[{rig['name']}]: would label "
+                    f"{bid} {surface} (idle since {b.get('updated_at')})"
+                )
+                labeled += 1
+                continue
+            if add_surface_label(rig, bid, surface):
+                labeled += 1
+                print(
+                    f"stranded-bead-sweep[{rig['name']}]: labeled {bid} "
+                    f"{surface} (idle since {b.get('updated_at')})"
+                )
+    return scanned, labeled
+
+
+def maybe_send_digest(
+    rigs: list[dict],
+    surface: str,
+    to: str,
+    interval: timedelta,
+    path: Path,
+    now: datetime,
+    dry_run: bool,
+) -> None:
+    """Send the periodic digest if due; advance the state file regardless."""
+    last = read_last_digest(path)
+    if last is not None and now - last < interval:
+        return
+
+    stranded: list[dict] = []
+    for rig in rigs:
+        stranded.extend(query_still_stranded(rig, surface))
+
+    if not stranded:
+        if dry_run:
+            print(
+                "stranded-bead-sweep: dry-run — digest due but no stranded "
+                "beads; would advance state"
+            )
+            return
+        # Advance state so the next digest fires `interval` from now, not
+        # next tick.
+        write_last_digest(path, now)
+        return
+
+    subject, body = build_digest_body(stranded, surface)
+
+    if dry_run:
+        print(f"stranded-bead-sweep: dry-run — would send digest to {to}")
+        print(f"Subject: {subject}\n")
+        print(body)
+        return
+
+    if not send_digest_mail(to, subject, body):
+        # Don't advance state; retry next tick.
+        return
+    write_last_digest(path, now)
+    print(
+        f"stranded-bead-sweep: mailed digest to {to} "
+        f"({len(stranded)} bead(s) still unrouted)"
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(hours=age_hours())
+
+    surface = surface_label()
+    exempt = exempt_labels(surface)
+    interval = digest_interval()
+    to = digest_to()
+
+    rigs = list_rigs()
+    if not rigs:
+        print("stranded-bead-sweep: no initialized rigs; nothing to do")
+        return 0
+
+    scanned, labeled = sweep(rigs, cutoff, surface, exempt, args.dry_run)
+    maybe_send_digest(rigs, surface, to, interval, state_path(), now, args.dry_run)
+
+    if labeled:
+        print(
+            f"stranded-bead-sweep: scanned {scanned}, labeled {labeled} "
+            f"bead(s) (age threshold {age_hours()}h, label {surface})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
@@ -26,125 +26,118 @@
 # escape hatches. TTL defaults to 24h; GC_MAIL_ARCHIVE_AGE_HOURS overrides.
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
+#
+# Batched bd contract (ga-blt): a single jq pass classifies every bead;
+# eligible IDs are collected into bash arrays and applied with one bd call
+# per category (promote-proven, promote-stuck, delete, archive). This
+# replaces the per-bead loop that spawned 5,000–32,000 bd subprocesses per
+# cooldown and pegged dolt's thread pool (pe-t07v).
 set -euo pipefail
 
 CITY="${GC_CITY:-.}"
 
 # Get all beads.
 ALL=$(bd list --json --all -n 0 2>/dev/null) || exit 0
-EPHEMERALS=$(echo "$ALL" | jq '[.[] | select(.ephemeral == true)]' 2>/dev/null) || EPHEMERALS="[]"
 
 NOW=$(date +%s)
-PROMOTED=0
-DELETED=0
+MAIL_ARCHIVE_AGE_H="${GC_MAIL_ARCHIVE_AGE_HOURS:-24}"
+MAIL_ARCHIVE_AGE_S=$((MAIL_ARCHIVE_AGE_H * 3600))
+
+# Single jq pass over all beads. Emits tab-separated "<action>\t<id>" lines
+# for each actionable bead and "skip\t<id>" for ephemerals still within TTL
+# (used only to maintain the SKIPPED counter). Date math is done inside jq
+# via fromdateiso8601 (always-UTC), so we no longer call `date` per bead.
+#
+# Action values:
+#   promote_proven   — closed past TTL with comments or 'keep' label
+#   promote_stuck    — non-closed past TTL (stuck detection)
+#   delete_wisp      — closed past TTL, no comments, no 'keep'
+#   archive_mail     — Pass 2: read mail past mail-archive TTL
+#   skip             — ephemeral within TTL (skipped counter only)
+CLASSIFIED=$(echo "$ALL" | jq -r \
+    --argjson now "$NOW" \
+    --argjson mail_age "$MAIL_ARCHIVE_AGE_S" '
+  def wisp_ttl(labels):
+    if any(labels[]; . == "keep") then 0
+    elif any(labels[]; . == "wisp_type:heartbeat" or . == "wisp_type:ping") then 6 * 3600
+    elif any(labels[]; . == "wisp_type:patrol" or . == "wisp_type:gc_report") then 24 * 3600
+    elif any(labels[]; . == "wisp_type:recovery" or . == "wisp_type:error" or . == "wisp_type:escalation") then 7 * 24 * 3600
+    else 24 * 3600
+    end;
+
+  def parse_ts:
+    # Try both RFC3339-with-Z (jq native) and no-Z (append Z and retry).
+    (fromdateiso8601? // ((. + "Z") | fromdateiso8601?));
+
+  .[]
+  | (.labels // []) as $labels
+  | (.updated_at // .created_at // "") as $ts_str
+  | ($ts_str | parse_ts) as $ts
+  | select($ts != null)
+  | ($now - $ts) as $age
+  | (.comment_count // 0) as $cc
+  | (.status // "open") as $status
+
+  | if .ephemeral == true then
+      wisp_ttl($labels) as $ttl
+      | if $ttl > 0 and $age < $ttl then
+          "skip\t\(.id)"
+        elif $cc > 0 or any($labels[]; . == "keep") or $status != "closed" then
+          (if $status != "closed" then "promote_stuck\t\(.id)"
+           else "promote_proven\t\(.id)" end)
+        else
+          "delete_wisp\t\(.id)"
+        end
+    elif .issue_type == "message" and $status == "open" then
+      if any($labels[]; . == "read")
+         and (any($labels[]; . == "keep") | not)
+         and $cc == 0
+         and $age >= $mail_age then
+        "archive_mail\t\(.id)"
+      else empty end
+    else empty end
+' 2>/dev/null) || CLASSIFIED=""
+
+PROMOTE_PROVEN=()
+PROMOTE_STUCK=()
+DELETE_IDS=()
+ARCHIVE_IDS=()
 SKIPPED=0
 
-# Pass 1 (ephemerals): apply wisp_type TTL retention.
-#
-# Capturing jq output into BEADS first (instead of piping into the loop)
-# preserves the original pipefail fail-loud on jq error AND keeps
-# PROMOTED/DELETED/SKIPPED in the parent shell so they survive to the
-# summary echo below.
-if [ -n "$EPHEMERALS" ] && [ "$EPHEMERALS" != "[]" ]; then
-BEADS=$(echo "$EPHEMERALS" | jq -c '.[]' 2>/dev/null)
-while IFS= read -r bead; do
-    id=$(echo "$bead" | jq -r '.id')
-    status=$(echo "$bead" | jq -r '.status')
-    updated_at=$(echo "$bead" | jq -r '.updated_at // .created_at')
-    comment_count=$(echo "$bead" | jq -r '.comment_count // 0')
-    labels=$(echo "$bead" | jq -r '.labels // [] | .[]' 2>/dev/null)
+while IFS=$'\t' read -r action id; do
+    [ -z "$action" ] && continue
+    case "$action" in
+        skip) SKIPPED=$((SKIPPED + 1)) ;;
+        promote_proven) PROMOTE_PROVEN+=("$id") ;;
+        promote_stuck) PROMOTE_STUCK+=("$id") ;;
+        delete_wisp) DELETE_IDS+=("$id") ;;
+        archive_mail) ARCHIVE_IDS+=("$id") ;;
+    esac
+done <<< "$CLASSIFIED"
 
-    # Determine TTL from wisp_type label.
-    TTL_SECONDS=$((24 * 3600))  # default: 24h
-    for label in $labels; do
-        case "$label" in
-            wisp_type:heartbeat|wisp_type:ping) TTL_SECONDS=$((6 * 3600)) ;;
-            wisp_type:patrol|wisp_type:gc_report) TTL_SECONDS=$((24 * 3600)) ;;
-            wisp_type:recovery|wisp_type:error|wisp_type:escalation) TTL_SECONDS=$((7 * 24 * 3600)) ;;
-            keep) TTL_SECONDS=0 ;;  # force promote
-        esac
-    done
-
-    # Calculate age. bd emits RFC3339 timestamps with a trailing 'Z'; the
-    # second BSD `date -ju -f` fallback handles that explicitly and forces
-    # UTC semantics to match GNU `date -d`. The third layout supports older
-    # no-Z timestamps without interpreting them in the local timezone.
-    BEAD_TS=$(date -d "$updated_at" +%s 2>/dev/null || \
-              date -ju -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null || \
-              date -ju -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
-    AGE=$((NOW - BEAD_TS))
-
-    # Skip if within TTL (unless force-promote via keep label).
-    if [ "$TTL_SECONDS" -gt 0 ] && [ "$AGE" -lt "$TTL_SECONDS" ]; then
-        SKIPPED=$((SKIPPED + 1))
-        continue
-    fi
-
-    # Promote if has comments, keep label, or non-closed.
-    if [ "$comment_count" -gt 0 ] || echo "$labels" | grep -q '^keep$' || [ "$status" != "closed" ]; then
-        REASON="proven value"
-        [ "$status" != "closed" ] && REASON="open past TTL (stuck detection)"
-        bd update "$id" --persistent 2>/dev/null || true
-        bd comment "$id" "Promoted from wisp: $REASON" 2>/dev/null || true
-        PROMOTED=$((PROMOTED + 1))
-        continue
-    fi
-
-    # Closed + past TTL + no special attributes → delete.
-    bd delete "$id" --force 2>/dev/null || true
-    DELETED=$((DELETED + 1))
-done <<< "$BEADS"
-fi
-
-# Pass 2: archive aged read mail messages.
-#
-# Mail messages aren't ephemeral wisps, so they bypass Pass 1's
-# ephemeral-only filter. They need their own retention rule, keyed off the
-# 'read' label (set by beadmail.Read / MarkRead when a recipient consumes
-# the message). Unread mail is never archived here — only the recipient's
-# explicit acknowledgement triggers the TTL countdown.
-MAIL_ARCHIVE_AGE_H="${GC_MAIL_ARCHIVE_AGE_HOURS:-24}"
+PROMOTED=0
+DELETED=0
 ARCHIVED=0
 
-MESSAGES=$(echo "$ALL" | jq -c '.[] | select(.issue_type == "message" and .status == "open")' 2>/dev/null) || MESSAGES=""
-
-if [ -n "$MESSAGES" ]; then
-    while IFS= read -r msg; do
-        [ -z "$msg" ] && continue
-        id=$(echo "$msg" | jq -r '.id')
-        updated_at=$(echo "$msg" | jq -r '.updated_at // .created_at')
-        comment_count=$(echo "$msg" | jq -r '.comment_count // 0')
-        labels=$(echo "$msg" | jq -r '.labels // [] | .[]' 2>/dev/null)
-
-        # Skip messages the recipient hasn't consumed yet.
-        if ! echo "$labels" | grep -q '^read$'; then
-            continue
-        fi
-
-        # 'keep' overrides the auto-archive, same opt-out as Pass 1.
-        if echo "$labels" | grep -q '^keep$'; then
-            continue
-        fi
-
-        # Active discussion = proven value, leave it alone.
-        if [ "$comment_count" -gt 0 ]; then
-            continue
-        fi
-
-        # Same date fallback chain as Pass 1 (GNU → BSD with Z → BSD without Z).
-        MSG_TS=$(date -d "$updated_at" +%s 2>/dev/null || \
-                 date -ju -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null || \
-                 date -ju -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
-        AGE_H=$(( (NOW - MSG_TS) / 3600 ))
-
-        if [ "$AGE_H" -lt "$MAIL_ARCHIVE_AGE_H" ]; then
-            continue
-        fi
-
-        # bd validation.on-close=error requires a reason >= 20 chars.
-        bd close "$id" --reason "wisp-compact: archived aged read mail past TTL" 2>/dev/null || true
-        ARCHIVED=$((ARCHIVED + 1))
-    done <<< "$MESSAGES"
+# Promotion: one bd update call per audit-reason group. --append-notes
+# captures the reason on each promoted bead's notes field, replacing the
+# old per-bead `bd comment` audit trail.
+if [ ${#PROMOTE_PROVEN[@]} -gt 0 ]; then
+    bd update "${PROMOTE_PROVEN[@]}" --persistent --append-notes "Promoted from wisp: proven value" 2>/dev/null || true
+    PROMOTED=$((PROMOTED + ${#PROMOTE_PROVEN[@]}))
+fi
+if [ ${#PROMOTE_STUCK[@]} -gt 0 ]; then
+    bd update "${PROMOTE_STUCK[@]}" --persistent --append-notes "Promoted from wisp: open past TTL (stuck detection)" 2>/dev/null || true
+    PROMOTED=$((PROMOTED + ${#PROMOTE_STUCK[@]}))
+fi
+if [ ${#DELETE_IDS[@]} -gt 0 ]; then
+    bd delete "${DELETE_IDS[@]}" --force 2>/dev/null || true
+    DELETED=${#DELETE_IDS[@]}
+fi
+if [ ${#ARCHIVE_IDS[@]} -gt 0 ]; then
+    # bd validation.on-close=error requires a reason >= 20 chars.
+    bd close "${ARCHIVE_IDS[@]}" --reason "wisp-compact: archived aged read mail past TTL" 2>/dev/null || true
+    ARCHIVED=${#ARCHIVE_IDS[@]}
 fi
 
 TOTAL=$((PROMOTED + DELETED + ARCHIVED))

--- a/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# wisp-compact — TTL-based cleanup of expired ephemeral beads.
+# wisp-compact — TTL-based cleanup of expired ephemeral beads and aged read mail.
 #
 # Wisps are short-lived work items (heartbeats, pings, patrols) that
 # accumulate and bloat the database. This script applies retention policy:
@@ -13,30 +13,39 @@
 #   recovery, error, escalation: 7d
 #   default (untyped): 24h
 #
+# Pass 2 archives aged read mail messages (issue_type=message). Mail beads
+# are not ephemeral — they live in the issues tier and are git-synced — but
+# once the recipient has marked one "read" it has served its purpose, and
+# without active cleanup the read backlog drives the open-bead count past
+# the reaper alert threshold (see ga-l17).
+#
+# Rule (Pass 2): issue_type=message AND status=open AND label=read AND
+# updated_at past TTL AND no 'keep' label AND comment_count=0 → archive
+# (bd close with reason). The 'keep' label and any active discussion
+# (comment_count>0) opt the message out, mirroring Pass 1's "proven value"
+# escape hatches. TTL defaults to 24h; GC_MAIL_ARCHIVE_AGE_HOURS overrides.
+#
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
 CITY="${GC_CITY:-.}"
 
-# Get all ephemeral beads.
+# Get all beads.
 ALL=$(bd list --json --all -n 0 2>/dev/null) || exit 0
-EPHEMERALS=$(echo "$ALL" | jq '[.[] | select(.ephemeral == true)]' 2>/dev/null) || exit 0
-
-if [ -z "$EPHEMERALS" ] || [ "$EPHEMERALS" = "[]" ]; then
-    exit 0
-fi
+EPHEMERALS=$(echo "$ALL" | jq '[.[] | select(.ephemeral == true)]' 2>/dev/null) || EPHEMERALS="[]"
 
 NOW=$(date +%s)
 PROMOTED=0
 DELETED=0
 SKIPPED=0
 
-# Process each ephemeral bead. Capturing jq output into BEADS first
-# (instead of piping into the loop) preserves the original pipefail
-# fail-loud on jq error AND keeps PROMOTED/DELETED/SKIPPED in the parent
-# shell so they survive to the summary echo below. EPHEMERALS is
-# pre-validated as a non-empty array on lines 22-27, so BEADS is
-# guaranteed non-empty here.
+# Pass 1 (ephemerals): apply wisp_type TTL retention.
+#
+# Capturing jq output into BEADS first (instead of piping into the loop)
+# preserves the original pipefail fail-loud on jq error AND keeps
+# PROMOTED/DELETED/SKIPPED in the parent shell so they survive to the
+# summary echo below.
+if [ -n "$EPHEMERALS" ] && [ "$EPHEMERALS" != "[]" ]; then
 BEADS=$(echo "$EPHEMERALS" | jq -c '.[]' 2>/dev/null)
 while IFS= read -r bead; do
     id=$(echo "$bead" | jq -r '.id')
@@ -85,8 +94,60 @@ while IFS= read -r bead; do
     bd delete "$id" --force 2>/dev/null || true
     DELETED=$((DELETED + 1))
 done <<< "$BEADS"
+fi
 
-TOTAL=$((PROMOTED + DELETED))
+# Pass 2: archive aged read mail messages.
+#
+# Mail messages aren't ephemeral wisps, so they bypass Pass 1's
+# ephemeral-only filter. They need their own retention rule, keyed off the
+# 'read' label (set by beadmail.Read / MarkRead when a recipient consumes
+# the message). Unread mail is never archived here — only the recipient's
+# explicit acknowledgement triggers the TTL countdown.
+MAIL_ARCHIVE_AGE_H="${GC_MAIL_ARCHIVE_AGE_HOURS:-24}"
+ARCHIVED=0
+
+MESSAGES=$(echo "$ALL" | jq -c '.[] | select(.issue_type == "message" and .status == "open")' 2>/dev/null) || MESSAGES=""
+
+if [ -n "$MESSAGES" ]; then
+    while IFS= read -r msg; do
+        [ -z "$msg" ] && continue
+        id=$(echo "$msg" | jq -r '.id')
+        updated_at=$(echo "$msg" | jq -r '.updated_at // .created_at')
+        comment_count=$(echo "$msg" | jq -r '.comment_count // 0')
+        labels=$(echo "$msg" | jq -r '.labels // [] | .[]' 2>/dev/null)
+
+        # Skip messages the recipient hasn't consumed yet.
+        if ! echo "$labels" | grep -q '^read$'; then
+            continue
+        fi
+
+        # 'keep' overrides the auto-archive, same opt-out as Pass 1.
+        if echo "$labels" | grep -q '^keep$'; then
+            continue
+        fi
+
+        # Active discussion = proven value, leave it alone.
+        if [ "$comment_count" -gt 0 ]; then
+            continue
+        fi
+
+        # Same date fallback chain as Pass 1 (GNU → BSD with Z → BSD without Z).
+        MSG_TS=$(date -d "$updated_at" +%s 2>/dev/null || \
+                 date -ju -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null || \
+                 date -ju -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
+        AGE_H=$(( (NOW - MSG_TS) / 3600 ))
+
+        if [ "$AGE_H" -lt "$MAIL_ARCHIVE_AGE_H" ]; then
+            continue
+        fi
+
+        # bd validation.on-close=error requires a reason >= 20 chars.
+        bd close "$id" --reason "wisp-compact: archived aged read mail past TTL" 2>/dev/null || true
+        ARCHIVED=$((ARCHIVED + 1))
+    done <<< "$MESSAGES"
+fi
+
+TOTAL=$((PROMOTED + DELETED + ARCHIVED))
 if [ "$TOTAL" -gt 0 ]; then
-    echo "wisp-compact: promoted=$PROMOTED deleted=$DELETED skipped=$SKIPPED"
+    echo "wisp-compact: promoted=$PROMOTED deleted=$DELETED skipped=$SKIPPED archived=$ARCHIVED"
 fi

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -78,6 +78,15 @@ The Dog should watch for and flag:
 - Dolt commit failures except benign no-op races where another process already
   committed the counted change
 
+Threshold escalations are deduped against a persisted state file:
+`$GC_PACK_STATE_DIR/reaper-alert-state.txt` (or
+`$GC_CITY_RUNTIME_DIR/packs/maintenance/...` when unset). A threshold-only
+mail is suppressed when the previous emit was within
+`GC_REAPER_ALERT_DEDUP_WINDOW_SEC` (default 3600) and the open-wisp count
+has not moved by `GC_REAPER_ALERT_DEDUP_DELTA` (default 10). Non-threshold
+anomalies (commit failures, missing city DB, etc.) always escalate so the
+operator does not lose those signals.
+
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-reaper"
 version = 2

--- a/examples/gastown/packs/maintenance/orders/stranded-bead-sweep.toml
+++ b/examples/gastown/packs/maintenance/orders/stranded-bead-sweep.toml
@@ -1,0 +1,26 @@
+# Hourly sweep that surfaces stranded beads — open work-type beads with no
+# routing target, no assignee, and no recent activity — by labeling them
+# so UIs and queries that filter on the label (e.g. a TODO tab) surface
+# them to the operator.
+#
+# Acts as a backstop for any city that has no auto-route order for the
+# HQ rig (or any rig at all): unrouted beads would otherwise sit
+# invisible in the queue forever.
+#
+# A weekly digest mail (gated by a state file in $GC_PACK_STATE_DIR/maintenance)
+# surfaces the aggregate count to the digest recipient. The per-tick run
+# is silent; the human only sees a mail once per digest interval.
+#
+# Configuration (all env vars, optional):
+#   GC_STRANDED_AGE_HOURS       Hours since update before eligible (default 4)
+#   GC_STRANDED_SURFACE_LABEL   Label to add (default needs:human)
+#   GC_STRANDED_EXEMPT_LABELS   Extra exempt labels, comma-separated
+#                               (default skip:auto-route; surface label is
+#                               always exempt for idempotency)
+#   GC_STRANDED_DIGEST_DAYS     Days between digest mails (default 7)
+#   GC_STRANDED_DIGEST_TO       Digest recipient (default mayor)
+[order]
+description = "Label stranded unrouted+unassigned beads, mail recipient a periodic digest"
+trigger = "cooldown"
+interval = "1h"
+exec = "$PACK_DIR/assets/scripts/stranded-bead-sweep.py"

--- a/examples/gastown/refinery_rebase_script_test.go
+++ b/examples/gastown/refinery_rebase_script_test.go
@@ -1,0 +1,559 @@
+package gastown_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// refineryRebaseScript returns the absolute path to the shipped helper.
+func refineryRebaseScript(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(exampleDir(),
+		"packs", "gastown", "assets", "scripts", "refinery-rebase.sh")
+}
+
+// initRebaseTestRepo sets up a bare "origin" repository plus a local clone,
+// ready to host branches the refinery-rebase test cases will exercise. It
+// returns the path to the local clone (the worktree the script runs in).
+//
+// Layout:
+//
+//	originDir  — bare repo at <tmp>/origin.git
+//	cloneDir   — working clone at <tmp>/clone
+//
+// The clone has `main` initialized with a single seed commit and is
+// configured with a committer identity so the test does not depend on the
+// developer's global git config.
+func initRebaseTestRepo(t *testing.T) (cloneDir string) {
+	t.Helper()
+	tmp := t.TempDir()
+	originDir := filepath.Join(tmp, "origin.git")
+	cloneDir = filepath.Join(tmp, "clone")
+
+	mustGit := func(dir string, args ...string) {
+		t.Helper()
+		full := append([]string{"-C", dir}, args...)
+		cmd := exec.Command("git", full...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.invalid",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.invalid",
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	mustRun := func(dir, name string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.invalid",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.invalid",
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+		}
+	}
+
+	if err := os.MkdirAll(originDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", originDir, err)
+	}
+	mustRun(originDir, "git", "-c", "init.defaultBranch=main", "init", "--bare", "-q")
+
+	if err := os.MkdirAll(cloneDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", cloneDir, err)
+	}
+	mustRun(cloneDir, "git", "-c", "init.defaultBranch=main", "init", "-q")
+	mustGit(cloneDir, "remote", "add", "origin", originDir)
+	mustGit(cloneDir, "config", "user.email", "test@example.invalid")
+	mustGit(cloneDir, "config", "user.name", "test")
+
+	if err := os.WriteFile(filepath.Join(cloneDir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(cloneDir, "add", "seed.txt")
+	mustGit(cloneDir, "commit", "-q", "-m", "seed")
+	mustGit(cloneDir, "branch", "-M", "main")
+	mustGit(cloneDir, "push", "-q", "origin", "main")
+	return cloneDir
+}
+
+// gitInRepo runs git in the given working tree with a deterministic
+// committer identity and no inherited global config.
+func gitInRepo(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.invalid",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.invalid",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitInRepoAllowErr(dir string, args ...string) (string, error) {
+	full := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.invalid",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.invalid",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// runRefineryRebase invokes the helper and returns its stderr and exit
+// code. The script writes operational details to stderr (the success log
+// tail and the conflict summary line), which is the only stream callers
+// in these tests inspect.
+func runRefineryRebase(t *testing.T, repo, branch, target string) (stderr string, exitCode int) {
+	t.Helper()
+	cmd := exec.Command(refineryRebaseScript(t), branch, target)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.invalid",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.invalid",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	var errBuf strings.Builder
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			exitCode = ee.ExitCode()
+		} else {
+			t.Fatalf("run script: %v", err)
+		}
+	}
+	return errBuf.String(), exitCode
+}
+
+// TestRefineryRebaseScriptHasPipefail enforces the load-bearing line of
+// defense the script exists to encode (acceptance criterion 1 on ga-vnr).
+// Without `set -o pipefail`, future drift could reintroduce
+// `git rebase ... | tail` patterns that mask non-zero exits.
+func TestRefineryRebaseScriptHasPipefail(t *testing.T) {
+	body, err := os.ReadFile(refineryRebaseScript(t))
+	if err != nil {
+		t.Fatalf("reading refinery-rebase.sh: %v", err)
+	}
+	src := string(body)
+	if !strings.Contains(src, "set -euo pipefail") {
+		t.Fatalf("refinery-rebase.sh missing `set -euo pipefail`:\n%s", src)
+	}
+}
+
+// TestRefineryRebaseScriptExitsZeroOnCleanRebase covers the happy path:
+// a feature branch that touches a different file than the target rebases
+// cleanly and the working branch is left on `temp`.
+func TestRefineryRebaseScriptExitsZeroOnCleanRebase(t *testing.T) {
+	repo := initRebaseTestRepo(t)
+
+	// Feature branch touches feature.txt only — no conflict with main.
+	gitInRepo(t, repo, "checkout", "-q", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(repo, "feature.txt"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "add", "feature.txt")
+	gitInRepo(t, repo, "commit", "-q", "-m", "feature work")
+	gitInRepo(t, repo, "push", "-q", "origin", "feature")
+
+	// Main advances on a non-conflicting file.
+	gitInRepo(t, repo, "checkout", "-q", "main")
+	if err := os.WriteFile(filepath.Join(repo, "main.txt"), []byte("m\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "add", "main.txt")
+	gitInRepo(t, repo, "commit", "-q", "-m", "main forward")
+	gitInRepo(t, repo, "push", "-q", "origin", "main")
+
+	// Pre-rebase: feature.txt is not in main.
+	if _, err := gitInRepoAllowErr(repo, "cat-file", "-e", "origin/main:feature.txt"); err == nil {
+		t.Fatalf("precondition: feature.txt should not yet exist on origin/main")
+	}
+
+	stderr, code := runRefineryRebase(t, repo, "feature", "main")
+	if code != 0 {
+		t.Fatalf("clean rebase: exit=%d stderr=%q", code, stderr)
+	}
+
+	if got := gitInRepo(t, repo, "rev-parse", "--abbrev-ref", "HEAD"); got != "temp" {
+		t.Fatalf("after success, HEAD on %q, want %q", got, "temp")
+	}
+	// Rebased history must contain both the new main commit and the feature commit.
+	log := gitInRepo(t, repo, "log", "--format=%s", "-n", "3")
+	for _, want := range []string{"feature work", "main forward", "seed"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("rebased log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+// TestRefineryRebaseScriptExitsNonZeroOnConflict is the regression test
+// the bead calls out (acceptance criterion 2 on ga-vnr): fabricate a
+// rebase conflict and assert the script exits non-zero. The historic
+// bug was that the earlier `git rebase | tail` wrapper masked the
+// non-zero exit, so the caller proceeded as if the rebase had succeeded.
+func TestRefineryRebaseScriptExitsNonZeroOnConflict(t *testing.T) {
+	repo := initRebaseTestRepo(t)
+
+	// Feature branch edits seed.txt.
+	gitInRepo(t, repo, "checkout", "-q", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "commit", "-q", "-am", "feature edits seed")
+	gitInRepo(t, repo, "push", "-q", "origin", "feature")
+
+	// Main edits the same file on the same line — guaranteed conflict on rebase.
+	gitInRepo(t, repo, "checkout", "-q", "main")
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("main2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "commit", "-q", "-am", "main edits seed")
+	gitInRepo(t, repo, "push", "-q", "origin", "main")
+
+	stderr, code := runRefineryRebase(t, repo, "feature", "main")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit on rebase conflict; got 0\nstderr=%s", stderr)
+	}
+	if code != 3 {
+		t.Fatalf("expected exit code 3 (conflict), got %d\nstderr=%s", code, stderr)
+	}
+	if !strings.Contains(stderr, "Rebase conflict") {
+		t.Fatalf("expected stderr to identify the conflict; got %q", stderr)
+	}
+	if !strings.Contains(stderr, "seed.txt") {
+		t.Fatalf("expected stderr to name the conflicting file (seed.txt); got %q", stderr)
+	}
+}
+
+// TestRefineryRebaseScriptCleansUpAfterConflict verifies the
+// post-conflict invariants the refinery relies on before reassigning the
+// work bead back to the polecat pool:
+//   - no in-progress rebase state (.git/rebase-merge / .git/rebase-apply)
+//   - no leftover `temp` branch
+//   - working tree on the target branch with no unmerged paths
+func TestRefineryRebaseScriptCleansUpAfterConflict(t *testing.T) {
+	repo := initRebaseTestRepo(t)
+
+	gitInRepo(t, repo, "checkout", "-q", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "commit", "-q", "-am", "feature edits seed")
+	gitInRepo(t, repo, "push", "-q", "origin", "feature")
+
+	gitInRepo(t, repo, "checkout", "-q", "main")
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("main2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "commit", "-q", "-am", "main edits seed")
+	gitInRepo(t, repo, "push", "-q", "origin", "main")
+
+	_, code := runRefineryRebase(t, repo, "feature", "main")
+	if code != 3 {
+		t.Fatalf("expected conflict exit 3, got %d", code)
+	}
+
+	for _, stateDir := range []string{".git/rebase-merge", ".git/rebase-apply"} {
+		if _, err := os.Stat(filepath.Join(repo, stateDir)); err == nil {
+			t.Fatalf("expected %s to be cleaned up after rebase abort", stateDir)
+		}
+	}
+	branches := gitInRepo(t, repo, "branch", "--list", "temp")
+	if strings.TrimSpace(branches) != "" {
+		t.Fatalf("expected `temp` branch to be deleted; got %q", branches)
+	}
+	if got := gitInRepo(t, repo, "rev-parse", "--abbrev-ref", "HEAD"); got != "main" {
+		t.Fatalf("expected HEAD on main after conflict cleanup, got %q", got)
+	}
+	status := gitInRepo(t, repo, "status", "--porcelain")
+	if status != "" {
+		t.Fatalf("expected clean status after conflict cleanup; got %q", status)
+	}
+}
+
+// TestRefineryRebaseScriptWritesReportFile asserts the optional
+// REFINERY_REBASE_REPORT side-channel: when the caller sets that
+// environment variable to a path, a conflict run writes the same
+// one-line summary it printed on stderr. The refinery uses this to
+// thread conflict file names into the rejection_reason metadata on the
+// work bead so the next polecat sees what to fix.
+func TestRefineryRebaseScriptWritesReportFile(t *testing.T) {
+	repo := initRebaseTestRepo(t)
+
+	gitInRepo(t, repo, "checkout", "-q", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "commit", "-q", "-am", "feature edits seed")
+	gitInRepo(t, repo, "push", "-q", "origin", "feature")
+
+	gitInRepo(t, repo, "checkout", "-q", "main")
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("main2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "commit", "-q", "-am", "main edits seed")
+	gitInRepo(t, repo, "push", "-q", "origin", "main")
+
+	reportPath := filepath.Join(t.TempDir(), "report.txt")
+	cmd := exec.Command(refineryRebaseScript(t), "feature", "main")
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.invalid",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.invalid",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"REFINERY_REBASE_REPORT="+reportPath,
+	)
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("expected non-zero exit on conflict")
+	}
+
+	body, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("reading report: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "Rebase conflict") || !strings.Contains(got, "seed.txt") {
+		t.Fatalf("report did not capture conflict + file: %q", got)
+	}
+}
+
+// TestRefineryRebaseScriptRejectsMissingArgs guards the script's input
+// contract — passing fewer than two arguments exits 2 with a usage line.
+func TestRefineryRebaseScriptRejectsMissingArgs(t *testing.T) {
+	repo := initRebaseTestRepo(t)
+	stderr, code := runRefineryRebase(t, repo, "", "")
+	if code != 2 {
+		t.Fatalf("expected usage exit 2, got %d (stderr=%q)", code, stderr)
+	}
+	if !strings.Contains(stderr, "usage:") {
+		t.Fatalf("expected usage hint on stderr, got %q", stderr)
+	}
+}
+
+// TestRefineryRebaseScriptRecoversFromLeftoverTempBranch ensures the
+// script is re-entrant: a `temp` branch surviving from an aborted prior
+// run does not block a fresh rebase.
+func TestRefineryRebaseScriptRecoversFromLeftoverTempBranch(t *testing.T) {
+	repo := initRebaseTestRepo(t)
+
+	gitInRepo(t, repo, "checkout", "-q", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(repo, "feature.txt"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, repo, "add", "feature.txt")
+	gitInRepo(t, repo, "commit", "-q", "-m", "feature work")
+	gitInRepo(t, repo, "push", "-q", "origin", "feature")
+
+	gitInRepo(t, repo, "checkout", "-q", "main")
+	gitInRepo(t, repo, "branch", "temp", "main")
+
+	stderr, code := runRefineryRebase(t, repo, "feature", "main")
+	if code != 0 {
+		t.Fatalf("expected clean rebase even with leftover temp branch; exit=%d stderr=%q", code, stderr)
+	}
+}
+
+// TestRefineryFormulaTeachesSafeRebasePattern enforces that the rebase
+// step explicitly warns against the masking-pipe anti-pattern that
+// caused ga-vnr, and points the refinery agent at the canonical script.
+// Future edits that revert to ad-hoc inline rebases or remove the warning
+// will fail this test.
+func TestRefineryFormulaTeachesSafeRebasePattern(t *testing.T) {
+	path := filepath.Join(exampleDir(),
+		"packs", "gastown", "formulas", "mol-refinery-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery formula: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		"refinery-rebase.sh",
+		"set -euo pipefail",
+		// The anti-pattern warning is the durable bit — losing it would
+		// silently re-enable the buggy `git rebase ... | tail` shape.
+		"| tail",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("refinery formula missing safety guidance %q", want)
+		}
+	}
+}
+
+// TestRefineryPromptWarnsAgainstUnsafePipes mirrors the formula assertion
+// at the prompt-template layer: the LLM agent reads the prompt at startup
+// and needs the same anti-pattern warning so it does not regenerate the
+// buggy wrapper from training data.
+func TestRefineryPromptWarnsAgainstUnsafePipes(t *testing.T) {
+	path := filepath.Join(exampleDir(),
+		"packs", "gastown", "agents", "refinery", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery prompt: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		"refinery-rebase.sh",
+		"| tail",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("refinery prompt missing safety guidance %q", want)
+		}
+	}
+}
+
+// stripInlineCode replaces markdown inline-code spans (`...`) with
+// equally-sized whitespace so that index positions are preserved. The
+// audit then operates on the prose-only view, so an anti-pattern cited
+// inside `inline code` is exempt while bare bash on the same line is
+// not.
+func stripInlineCode(line string) string {
+	out := []byte(line)
+	inCode := false
+	for i, c := range out {
+		if c == '`' {
+			inCode = !inCode
+			out[i] = ' '
+			continue
+		}
+		if inCode {
+			out[i] = ' '
+		}
+	}
+	return string(out)
+}
+
+// nearbyMentionsAntiPattern returns true if any of the up-to-five
+// preceding non-blank lines flag the following code block as an
+// intentional citation of the anti-pattern (e.g. "WRONG", "anti-pattern",
+// "ga-vnr"). The audit uses this to exempt fenced code blocks that
+// document the bug instead of reintroducing it.
+func nearbyMentionsAntiPattern(lines []string, i int) bool {
+	seen := 0
+	for j := i - 1; j >= 0 && seen < 5; j-- {
+		stripped := strings.TrimSpace(lines[j])
+		if stripped == "" || strings.HasPrefix(stripped, "```") {
+			continue
+		}
+		seen++
+		lower := strings.ToLower(stripped)
+		for _, marker := range []string{"wrong", "anti-pattern", "ga-vnr", "do not", "never wrap", "never pipe"} {
+			if strings.Contains(lower, marker) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestGastownPackRefineryHasNoUnsafePipesOnFailableCommands grep-audits
+// the gastown pack for the historical anti-pattern: piping a command
+// that can fail (rebase, push, fetch) through `tail` or `grep`. Without
+// `set -o pipefail`, those pipes mask non-zero exits — the exact bug
+// ga-vnr exists to prevent. Documented citations of the anti-pattern
+// (inside `inline code` or fenced blocks preceded by "WRONG" /
+// "anti-pattern" markers) are exempt; bare bash that reintroduces the
+// pattern is not.
+func TestGastownPackRefineryHasNoUnsafePipesOnFailableCommands(t *testing.T) {
+	roots := []string{
+		filepath.Join(exampleDir(), "packs", "gastown", "formulas"),
+		filepath.Join(exampleDir(), "packs", "gastown", "agents", "refinery"),
+	}
+	unsafe := []string{
+		"git rebase ",
+		"git push ",
+		"git fetch ",
+		"gh pr create ",
+	}
+	for _, root := range roots {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			lines := strings.Split(string(data), "\n")
+			inFence := false
+			fenceIsCitation := false
+			for i, line := range lines {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "```") {
+					if inFence {
+						inFence = false
+						fenceIsCitation = false
+					} else {
+						inFence = true
+						fenceIsCitation = nearbyMentionsAntiPattern(lines, i)
+					}
+					continue
+				}
+				if inFence && fenceIsCitation {
+					continue
+				}
+				view := line
+				if !inFence {
+					// Outside fences, treat inline-code spans as citations.
+					view = stripInlineCode(line)
+				}
+				if strings.HasPrefix(strings.TrimSpace(view), "#") ||
+					strings.HasPrefix(strings.TrimSpace(view), ">") {
+					continue
+				}
+				for _, cmd := range unsafe {
+					idx := strings.Index(view, cmd)
+					if idx < 0 {
+						continue
+					}
+					tail := view[idx:]
+					if (strings.Contains(tail, "| tail") || strings.Contains(tail, "| grep")) &&
+						!strings.Contains(tail, "tee ") {
+						t.Errorf("%s:%d: unsafe pipe (`%s... | tail/grep`) on a failable command:\n  %s",
+							path, i+1, strings.TrimSpace(cmd), line)
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+}

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -4632,14 +4632,26 @@ type GetV0CityByCityNameMailParams struct {
 	// Limit Maximum number of results to return. 0 = server default.
 	Limit *int64 `form:"limit,omitempty" json:"limit,omitempty"`
 
-	// Agent Filter by agent name.
+	// Agent Filter by recipient (mailbox).
 	Agent *string `form:"agent,omitempty" json:"agent,omitempty"`
 
-	// Status Filter by status (unread, all).
+	// Status Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads.
 	Status *string `form:"status,omitempty" json:"status,omitempty"`
 
 	// Rig Filter by rig name.
 	Rig *string `form:"rig,omitempty" json:"rig,omitempty"`
+
+	// From Filter by sender (metadata.from / Bead.From). Empty = no sender constraint.
+	From *string `form:"from,omitempty" json:"from,omitempty"`
+
+	// Label Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint.
+	Label *string `form:"label,omitempty" json:"label,omitempty"`
+
+	// ArchivedFor Convenience filter for the per-viewer archive model: equivalent to label='archived:<viewer>' with read messages included. Conflicts with 'label'.
+	ArchivedFor *string `form:"archived_for,omitempty" json:"archived_for,omitempty"`
+
+	// IncludeClosed Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics.
+	IncludeClosed *bool `form:"include_closed,omitempty" json:"include_closed,omitempty"`
 }
 
 // SendMailParams defines parameters for SendMail.
@@ -16200,6 +16212,70 @@ func NewGetV0CityByCityNameMailRequest(server string, cityName string, params *G
 		if params.Rig != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "rig", *params.Rig, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.From != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "from", *params.From, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Label != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "label", *params.Label, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ArchivedFor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "archived_for", *params.ArchivedFor, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeClosed != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "include_closed", *params.IncludeClosed, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -313,14 +313,6 @@ func (s *Server) configuredMailRecipientAddress(store beads.Store, identifier st
 	return spec.Identity, true, nil
 }
 
-func mailInboxForRecipients(mp mail.Provider, recipients []string) ([]mail.Message, error) {
-	return mailMessagesForRecipients(mp.Inbox, recipients)
-}
-
-func mailAllForRecipients(mp mail.Provider, recipients []string) ([]mail.Message, error) {
-	return mailMessagesForRecipients(mp.All, recipients)
-}
-
 func mailMessagesForRecipients(fetch func(string) ([]mail.Message, error), recipients []string) ([]mail.Message, error) {
 	recipients = uniqueMailRecipients(recipients)
 	var all []mail.Message
@@ -341,6 +333,112 @@ func mailMessagesForRecipients(fetch func(string) ([]mail.Message, error), recip
 		}
 	}
 	return all, nil
+}
+
+// filterMessagesForRecipients serves the extended /mail filter API. When the
+// provider implements [mail.Filterer], the query is dispatched server-side
+// per recipient route, then deduplicated across routes. Providers without
+// Filter support fall back to All-by-recipient and post-filter every field
+// in [mail.FilterOptions] except IncludeClosed (which is unreachable through
+// the legacy All path — those providers will silently miss legacy archived
+// beads, which matches the pre-ga-rdz behavior).
+//
+// recipients may be empty or contain a single empty string when the caller
+// passed no `agent=` constraint; in that case the filter scans every
+// mailbox the provider serves.
+func filterMessagesForRecipients(mp mail.Provider, recipients []string, opts mail.FilterOptions) ([]mail.Message, error) {
+	recipients = uniqueMailRecipients(recipients)
+	if filterer, ok := mp.(mail.Filterer); ok {
+		return filterViaProvider(filterer, recipients, opts)
+	}
+	return filterViaFallback(mp, recipients, opts)
+}
+
+func filterViaProvider(filterer mail.Filterer, recipients []string, opts mail.FilterOptions) ([]mail.Message, error) {
+	seen := make(map[string]bool)
+	var all []mail.Message
+	for _, recipient := range recipients {
+		routeOpts := opts
+		routeOpts.Recipient = recipient
+		msgs, err := filterer.Filter(routeOpts)
+		if err != nil {
+			return nil, err
+		}
+		for _, msg := range msgs {
+			if msg.ID != "" {
+				if seen[msg.ID] {
+					continue
+				}
+				seen[msg.ID] = true
+			}
+			all = append(all, msg)
+		}
+	}
+	return all, nil
+}
+
+func filterViaFallback(mp mail.Provider, recipients []string, opts mail.FilterOptions) ([]mail.Message, error) {
+	fetch := mp.Inbox
+	if opts.IncludeRead {
+		fetch = mp.All
+	}
+	msgs, err := mailMessagesForRecipients(fetch, recipients)
+	if err != nil {
+		return nil, err
+	}
+	return applyMailPostFilter(msgs, opts), nil
+}
+
+// applyMailPostFilter enforces the FilterOptions fields the Inbox/All
+// providers cannot honor natively: sender, label, and (when IncludeRead is
+// false but a label-narrowed query still returned read-but-archived rows)
+// the read filter. IncludeClosed is intentionally not enforced here — the
+// All path already excludes closed beads at the provider level, so a
+// fallback consumer never sees them.
+func applyMailPostFilter(msgs []mail.Message, opts mail.FilterOptions) []mail.Message {
+	sender := strings.TrimSpace(opts.Sender)
+	label := strings.TrimSpace(opts.Label)
+	if sender == "" && label == "" {
+		return msgs
+	}
+	filtered := msgs[:0]
+	for _, m := range msgs {
+		if sender != "" && strings.TrimSpace(m.From) != sender {
+			continue
+		}
+		if label != "" && !messageHasLabel(m, label) {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
+}
+
+// messageHasLabel reports whether the mail.Message carries the named label.
+// Labels are reflected on the Message indirectly: ThreadID maps to a
+// thread:<id> label, ReplyTo to reply-to:<id>, the Read flag to "read", and
+// CC entries to cc:<addr> labels. The archived-for-viewer label is currently
+// not reflected on [mail.Message] — providers without server-side filtering
+// cannot detect it in this fallback path and will return an empty list for
+// archived-by-label queries, which is the documented degraded behavior.
+func messageHasLabel(m mail.Message, label string) bool {
+	switch {
+	case label == "read":
+		return m.Read
+	case strings.HasPrefix(label, "thread:"):
+		return label == "thread:"+m.ThreadID
+	case strings.HasPrefix(label, "reply-to:"):
+		return label == "reply-to:"+m.ReplyTo
+	case strings.HasPrefix(label, "cc:"):
+		want := strings.TrimPrefix(label, "cc:")
+		for _, cc := range m.CC {
+			if cc == want {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 func mailCountForRecipients(mp mail.Provider, recipients []string) (int, int, error) {

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -593,3 +593,232 @@ func TestMailReplyWithoutRigHintUsesResolvedRig(t *testing.T) {
 		t.Fatalf("reply event message rig = %q, want %q", payload.Message.Rig, "test-city")
 	}
 }
+
+// TestMailListFromFilterScopesBySender is the gu-2jr regression case: when a
+// previous incarnation of ?from= shipped, it silently returned every mail
+// bead regardless of value. After ga-rdz it must narrow to exactly the sender
+// (and only the sender) supplied.
+func TestMailListFromFilterScopesBySender(t *testing.T) {
+	state := newFakeState(t)
+	mp := state.cityMailProv
+	mp.Send("alice", "bob", "From alice", "to bob")     //nolint:errcheck
+	mp.Send("alice", "carol", "Also alice", "to carol") //nolint:errcheck
+	mp.Send("dave", "bob", "From dave", "to bob")       //nolint:errcheck
+
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?from=alice&status=all"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("from=alice status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+	if resp.Total != 2 {
+		t.Fatalf("from=alice Total = %d, want 2 (gu-2jr regression: filter must not return every bead)", resp.Total)
+	}
+	for _, m := range resp.Items {
+		if m.From != "alice" {
+			t.Errorf("from=alice returned message From=%q, want alice", m.From)
+		}
+	}
+
+	req = httptest.NewRequest("GET", cityURL(state, "/mail?from=nobody&status=all"), nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+	if resp.Total != 0 {
+		t.Errorf("from=nobody Total = %d, want 0 (unknown sender must yield empty list)", resp.Total)
+	}
+}
+
+// TestMailListArchivedForReturnsLabelMatchesIncludingRead is the gu-vx0
+// regression case: archived mail under the per-viewer label model
+// (status=open + archived:<viewer> label) is typically read, so the default
+// status=unread filter hid every archived row. archived_for must surface
+// those rows regardless of their read state.
+func TestMailListArchivedForReturnsLabelMatchesIncludingRead(t *testing.T) {
+	state := newFakeState(t)
+	store := state.stores["myrig"]
+	mp := state.cityMailProv
+
+	// Archived for bob: status=open with the archived:bob label, marked read.
+	archived, err := store.Create(beads.Bead{
+		Title:    "Old thread",
+		Type:     "message",
+		Assignee: "bob",
+		From:     "alice",
+		Labels:   []string{"archived:bob", "read"},
+		Metadata: map[string]string{"from": "alice", "mail.read": "true"},
+	})
+	if err != nil {
+		t.Fatalf("seed archived bead: %v", err)
+	}
+
+	// Unrelated open message also for bob — should not appear under archived_for.
+	if _, err := mp.Send("alice", "bob", "Live message", "still in inbox"); err != nil {
+		t.Fatalf("send live: %v", err)
+	}
+
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?archived_for=bob"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("archived_for status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+	if resp.Total != 1 {
+		t.Fatalf("archived_for=bob Total = %d, want 1 (gu-vx0 regression: read+archived rows must be visible)", resp.Total)
+	}
+	if resp.Items[0].ID != archived.ID {
+		t.Errorf("archived_for=bob returned %q, want archived bead %q", resp.Items[0].ID, archived.ID)
+	}
+	if !resp.Items[0].Read {
+		t.Errorf("archived_for=bob: returned message should still report Read=true (it is read)")
+	}
+}
+
+// TestMailListIncludeClosedSurfacesLegacyArchive covers the legacy archive
+// model that closed message beads (status=closed) rather than labeling them.
+// include_closed=true must surface those beads alongside open ones.
+func TestMailListIncludeClosedSurfacesLegacyArchive(t *testing.T) {
+	state := newFakeState(t)
+	mp := state.cityMailProv
+
+	open, _ := mp.Send("alice", "bob", "Open", "still here")
+	closedMsg, _ := mp.Send("alice", "bob", "Closed", "archived legacy-style")
+	if err := mp.Archive(closedMsg.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	h := newTestCityHandler(t, state)
+
+	// Default (no include_closed): only open messages.
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?agent=bob&status=all"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("default status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+	if resp.Total != 1 {
+		t.Fatalf("default Total = %d, want 1 (closed message should be hidden)", resp.Total)
+	}
+	if resp.Items[0].ID != open.ID {
+		t.Errorf("default returned %q, want open %q", resp.Items[0].ID, open.ID)
+	}
+
+	// include_closed=true: both open and closed visible.
+	req = httptest.NewRequest("GET", cityURL(state, "/mail?agent=bob&status=all&include_closed=true"), nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("include_closed status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+	if resp.Total != 2 {
+		t.Fatalf("include_closed Total = %d, want 2 (must include legacy-archived bead)", resp.Total)
+	}
+	gotIDs := map[string]bool{resp.Items[0].ID: true, resp.Items[1].ID: true}
+	if !gotIDs[open.ID] || !gotIDs[closedMsg.ID] {
+		t.Errorf("include_closed items = %v, want both %q and %q", []string{resp.Items[0].ID, resp.Items[1].ID}, open.ID, closedMsg.ID)
+	}
+}
+
+// TestMailListLabelFilter exercises the generic ?label= shape: callers can
+// pass any exact label match and the result narrows accordingly.
+func TestMailListLabelFilter(t *testing.T) {
+	state := newFakeState(t)
+	store := state.stores["myrig"]
+	if _, err := store.Create(beads.Bead{
+		Title: "Tagged", Type: "message", Assignee: "bob", From: "alice",
+		Labels:   []string{"priority:high"},
+		Metadata: map[string]string{"from": "alice"},
+	}); err != nil {
+		t.Fatalf("seed labeled bead: %v", err)
+	}
+	if _, err := state.cityMailProv.Send("alice", "bob", "Untagged", "no labels"); err != nil {
+		t.Fatalf("send untagged: %v", err)
+	}
+
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?label=priority:high&status=all"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("label= status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+	if resp.Total != 1 {
+		t.Fatalf("label= Total = %d, want 1", resp.Total)
+	}
+	if resp.Items[0].Subject != "Tagged" {
+		t.Errorf("label= returned %q, want Tagged", resp.Items[0].Subject)
+	}
+}
+
+// TestMailListArchivedForAndLabelConflict rejects callers that pass both
+// archived_for (sugar) and label (raw) — there is no sensible composition.
+func TestMailListArchivedForAndLabelConflict(t *testing.T) {
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?archived_for=bob&label=priority:high"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (archived_for + label must conflict)", rec.Code, http.StatusBadRequest)
+	}
+}
+
+// TestMailListFromAndAgentCompose verifies the conjunctive contract:
+// passing both ?from=X and ?agent=Y matches only messages sent BY X TO Y.
+func TestMailListFromAndAgentCompose(t *testing.T) {
+	state := newFakeState(t)
+	mp := state.cityMailProv
+
+	mp.Send("alice", "bob", "alice→bob", "match")     //nolint:errcheck
+	mp.Send("alice", "carol", "alice→carol", "miss1") //nolint:errcheck
+	mp.Send("dave", "bob", "dave→bob", "miss2")       //nolint:errcheck
+
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?from=alice&agent=bob&status=all"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	var resp struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
+	if resp.Total != 1 {
+		t.Fatalf("from=alice&agent=bob Total = %d, want 1", resp.Total)
+	}
+	if resp.Items[0].From != "alice" || resp.Items[0].To != "bob" {
+		t.Errorf("from=alice&agent=bob got From=%q To=%q, want alice→bob", resp.Items[0].From, resp.Items[0].To)
+	}
+}

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -13,6 +13,16 @@ import (
 )
 
 // humaHandleMailList is the Huma-typed handler for GET /v0/mail.
+//
+// Filter precedence and combinations: agent/status define the base "Inbox"
+// vs "All" shape (read-state filter). Adding `from`, `label`, or
+// `archived_for` narrows further. `include_closed=true` extends the result
+// to status=closed beads alongside open ones, primarily for the legacy
+// archive model that closed message beads (rather than the current
+// `archived:<viewer>` label model). See [filterOptionsForRequest] for the
+// exact mapping; see [filterMessagesForRecipients] for how providers serve
+// the query (server-side when they implement [mail.Filterer], otherwise a
+// post-filter fallback over Inbox/All).
 func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (*MailListOutput, error) {
 	bp := input.toBlockingParams()
 	if bp.isBlocking() {
@@ -31,162 +41,100 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 		pp.IsPaging = true
 	}
 
-	agents := s.resolveMailQueryRecipientsWithContext(ctx, input.Agent)
 	status := input.Status
-	rig := input.Rig
-	index := s.latestIndex()
-
 	switch status {
-	case "", "unread":
-		if rig != "" {
-			mp := s.state.MailProvider(rig)
-			if mp == nil {
-				return &MailListOutput{
-					Index: index,
-					Body:  MailListBody{Items: []mail.Message{}, Total: 0},
-				}, nil
-			}
-			msgs, err := mailInboxForRecipients(mp, agents)
-			if err != nil {
-				return nil, huma.Error500InternalServerError(err.Error())
-			}
-			if msgs == nil {
-				msgs = []mail.Message{}
-			}
-			msgs = tagRig(msgs, rig)
-			if !pp.IsPaging {
-				total := len(msgs)
-				if pp.Limit < len(msgs) {
-					msgs = msgs[:pp.Limit]
-				}
-				return &MailListOutput{
-					Index: index,
-					Body:  MailListBody{Items: msgs, Total: total},
-				}, nil
-			}
-			page, total, nextCursor := paginate(msgs, pp)
-			if page == nil {
-				page = []mail.Message{}
-			}
-			return &MailListOutput{
-				Index: index,
-				Body:  MailListBody{Items: page, Total: total, NextCursor: nextCursor},
-			}, nil
-		}
-
-		providers := s.state.MailProviders()
-		var allMsgs []mail.Message
-		var partialErrs []string
-		for _, name := range sortedProviderNames(providers) {
-			msgs, err := mailInboxForRecipients(providers[name], agents)
-			if err != nil {
-				partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
-				continue
-			}
-			allMsgs = append(allMsgs, tagRig(msgs, name)...)
-		}
-		if len(partialErrs) == len(providers) && len(providers) > 0 {
-			return nil, huma.Error503ServiceUnavailable("all mail providers failed: " + strings.Join(partialErrs, "; "))
-		}
-		if allMsgs == nil {
-			allMsgs = []mail.Message{}
-		}
-		partial := len(partialErrs) > 0
-		if !pp.IsPaging {
-			total := len(allMsgs)
-			if pp.Limit < len(allMsgs) {
-				allMsgs = allMsgs[:pp.Limit]
-			}
-			return &MailListOutput{
-				Index: index,
-				Body:  MailListBody{Items: allMsgs, Total: total, Partial: partial, PartialErrors: partialErrs},
-			}, nil
-		}
-		page, total, nextCursor := paginate(allMsgs, pp)
-		if page == nil {
-			page = []mail.Message{}
-		}
-		return &MailListOutput{
-			Index: index,
-			Body:  MailListBody{Items: page, Total: total, NextCursor: nextCursor, Partial: partial, PartialErrors: partialErrs},
-		}, nil
-
-	case "all":
-		if rig != "" {
-			mp := s.state.MailProvider(rig)
-			if mp == nil {
-				return &MailListOutput{
-					Index: index,
-					Body:  MailListBody{Items: []mail.Message{}, Total: 0},
-				}, nil
-			}
-			msgs, err := mailAllForRecipients(mp, agents)
-			if err != nil {
-				return nil, huma.Error500InternalServerError(err.Error())
-			}
-			if msgs == nil {
-				msgs = []mail.Message{}
-			}
-			msgs = tagRig(msgs, rig)
-			if !pp.IsPaging {
-				total := len(msgs)
-				if pp.Limit < len(msgs) {
-					msgs = msgs[:pp.Limit]
-				}
-				return &MailListOutput{
-					Index: index,
-					Body:  MailListBody{Items: msgs, Total: total},
-				}, nil
-			}
-			page, total, nextCursor := paginate(msgs, pp)
-			if page == nil {
-				page = []mail.Message{}
-			}
-			return &MailListOutput{
-				Index: index,
-				Body:  MailListBody{Items: page, Total: total, NextCursor: nextCursor},
-			}, nil
-		}
-
-		providers := s.state.MailProviders()
-		var allMsgs []mail.Message
-		var partialErrs []string
-		for _, name := range sortedProviderNames(providers) {
-			msgs, err := mailAllForRecipients(providers[name], agents)
-			if err != nil {
-				partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
-				continue
-			}
-			allMsgs = append(allMsgs, tagRig(msgs, name)...)
-		}
-		if len(partialErrs) == len(providers) && len(providers) > 0 {
-			return nil, huma.Error503ServiceUnavailable("all mail providers failed: " + strings.Join(partialErrs, "; "))
-		}
-		if allMsgs == nil {
-			allMsgs = []mail.Message{}
-		}
-		partial := len(partialErrs) > 0
-		if !pp.IsPaging {
-			total := len(allMsgs)
-			if pp.Limit < len(allMsgs) {
-				allMsgs = allMsgs[:pp.Limit]
-			}
-			return &MailListOutput{
-				Index: index,
-				Body:  MailListBody{Items: allMsgs, Total: total, Partial: partial, PartialErrors: partialErrs},
-			}, nil
-		}
-		page, total, nextCursor := paginate(allMsgs, pp)
-		if page == nil {
-			page = []mail.Message{}
-		}
-		return &MailListOutput{
-			Index: index,
-			Body:  MailListBody{Items: page, Total: total, NextCursor: nextCursor, Partial: partial, PartialErrors: partialErrs},
-		}, nil
-
+	case "", "unread", "all":
 	default:
 		return nil, huma.Error400BadRequest("unsupported status filter: " + status + "; supported: unread, all")
+	}
+
+	if input.Label != "" && input.ArchivedFor != "" {
+		return nil, huma.Error400BadRequest("label and archived_for are mutually exclusive")
+	}
+
+	agents := s.resolveMailQueryRecipientsWithContext(ctx, input.Agent)
+	rig := input.Rig
+	index := s.latestIndex()
+	opts := filterOptionsForRequest(input)
+
+	if rig != "" {
+		mp := s.state.MailProvider(rig)
+		if mp == nil {
+			return &MailListOutput{
+				Index: index,
+				Body:  MailListBody{Items: []mail.Message{}, Total: 0},
+			}, nil
+		}
+		msgs, err := filterMessagesForRecipients(mp, agents, opts)
+		if err != nil {
+			return nil, huma.Error500InternalServerError(err.Error())
+		}
+		if msgs == nil {
+			msgs = []mail.Message{}
+		}
+		msgs = tagRig(msgs, rig)
+		return paginatedMailListOutput(msgs, pp, index, false, nil), nil
+	}
+
+	providers := s.state.MailProviders()
+	var allMsgs []mail.Message
+	var partialErrs []string
+	for _, name := range sortedProviderNames(providers) {
+		msgs, err := filterMessagesForRecipients(providers[name], agents, opts)
+		if err != nil {
+			partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
+			continue
+		}
+		allMsgs = append(allMsgs, tagRig(msgs, name)...)
+	}
+	if len(partialErrs) == len(providers) && len(providers) > 0 {
+		return nil, huma.Error503ServiceUnavailable("all mail providers failed: " + strings.Join(partialErrs, "; "))
+	}
+	if allMsgs == nil {
+		allMsgs = []mail.Message{}
+	}
+	partial := len(partialErrs) > 0
+	return paginatedMailListOutput(allMsgs, pp, index, partial, partialErrs), nil
+}
+
+// filterOptionsForRequest maps the wire-level filter knobs onto a single
+// [mail.FilterOptions]. archived_for is sugar for label=archived:<viewer> with
+// IncludeRead=true — archived mail in the per-viewer model is typically read
+// and the user wouldn't sensibly want to hide it. status=all flips IncludeRead
+// regardless of archived_for so the explicit knob still works.
+func filterOptionsForRequest(input *MailListInput) mail.FilterOptions {
+	label := strings.TrimSpace(input.Label)
+	includeRead := input.Status == "all"
+	if archivedFor := strings.TrimSpace(input.ArchivedFor); archivedFor != "" {
+		label = "archived:" + archivedFor
+		includeRead = true
+	}
+	return mail.FilterOptions{
+		Sender:        strings.TrimSpace(input.From),
+		Label:         label,
+		IncludeRead:   includeRead,
+		IncludeClosed: input.IncludeClosed,
+	}
+}
+
+func paginatedMailListOutput(msgs []mail.Message, pp pageParams, index uint64, partial bool, partialErrs []string) *MailListOutput {
+	if !pp.IsPaging {
+		total := len(msgs)
+		if pp.Limit > 0 && pp.Limit < len(msgs) {
+			msgs = msgs[:pp.Limit]
+		}
+		return &MailListOutput{
+			Index: index,
+			Body:  MailListBody{Items: msgs, Total: total, Partial: partial, PartialErrors: partialErrs},
+		}
+	}
+	page, total, nextCursor := paginate(msgs, pp)
+	if page == nil {
+		page = []mail.Message{}
+	}
+	return &MailListOutput{
+		Index: index,
+		Body:  MailListBody{Items: page, Total: total, NextCursor: nextCursor, Partial: partial, PartialErrors: partialErrs},
 	}
 }
 

--- a/internal/api/huma_types_mail.go
+++ b/internal/api/huma_types_mail.go
@@ -35,13 +35,22 @@ type MailListOutput struct {
 // --- Mail types ---
 
 // MailListInput is the Huma input for GET /v0/city/{cityName}/mail.
+//
+// The filter shape extends the original (agent, status, rig) with sender,
+// label, archived-by-label, and closed-status filters so consumers like
+// gas-ui can render Sent/Archived tabs from a single typed API call
+// instead of falling back to `bd list` subprocess scans (ga-rdz).
 type MailListInput struct {
 	CityScope
 	BlockingParam
 	PaginationParam
-	Agent  string `query:"agent" required:"false" doc:"Filter by agent name."`
-	Status string `query:"status" required:"false" doc:"Filter by status (unread, all)."`
-	Rig    string `query:"rig" required:"false" doc:"Filter by rig name."`
+	Agent         string `query:"agent" required:"false" doc:"Filter by recipient (mailbox)."`
+	Status        string `query:"status" required:"false" doc:"Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads."`
+	Rig           string `query:"rig" required:"false" doc:"Filter by rig name."`
+	From          string `query:"from" required:"false" doc:"Filter by sender (metadata.from / Bead.From). Empty = no sender constraint."`
+	Label         string `query:"label" required:"false" doc:"Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint."`
+	ArchivedFor   string `query:"archived_for" required:"false" doc:"Convenience filter for the per-viewer archive model: equivalent to label='archived:<viewer>' with read messages included. Conflicts with 'label'."`
+	IncludeClosed bool   `query:"include_closed" required:"false" doc:"Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics."`
 }
 
 // MailGetInput is the Huma input for GET /v0/city/{cityName}/mail/{id}.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -17793,22 +17793,22 @@
             }
           },
           {
-            "description": "Filter by agent name.",
+            "description": "Filter by recipient (mailbox).",
             "explode": false,
             "in": "query",
             "name": "agent",
             "schema": {
-              "description": "Filter by agent name.",
+              "description": "Filter by recipient (mailbox).",
               "type": "string"
             }
           },
           {
-            "description": "Filter by status (unread, all).",
+            "description": "Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads.",
             "explode": false,
             "in": "query",
             "name": "status",
             "schema": {
-              "description": "Filter by status (unread, all).",
+              "description": "Read-state filter: 'unread' (default) or 'all'. This is independent of the bead status; pass include_closed=true to surface legacy archived (status=closed) beads.",
               "type": "string"
             }
           },
@@ -17820,6 +17820,46 @@
             "schema": {
               "description": "Filter by rig name.",
               "type": "string"
+            }
+          },
+          {
+            "description": "Filter by sender (metadata.from / Bead.From). Empty = no sender constraint.",
+            "explode": false,
+            "in": "query",
+            "name": "from",
+            "schema": {
+              "description": "Filter by sender (metadata.from / Bead.From). Empty = no sender constraint.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint.",
+            "explode": false,
+            "in": "query",
+            "name": "label",
+            "schema": {
+              "description": "Filter by exact label match (e.g. 'archived:viewer/me'). Empty = no label constraint.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Convenience filter for the per-viewer archive model: equivalent to label='archived:\u003cviewer\u003e' with read messages included. Conflicts with 'label'.",
+            "explode": false,
+            "in": "query",
+            "name": "archived_for",
+            "schema": {
+              "description": "Convenience filter for the per-viewer archive model: equivalent to label='archived:\u003cviewer\u003e' with read messages included. Conflicts with 'label'.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics.",
+            "explode": false,
+            "in": "query",
+            "name": "include_closed",
+            "schema": {
+              "description": "Include status=closed message beads (legacy archived). Default false matches Inbox/All semantics.",
+              "type": "boolean"
             }
           }
         ],

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2441,7 +2441,12 @@ func (a *Agent) AttachEnabled() bool {
 // was used when assigning.
 //
 // State priority: in_progress+assigned (crash recovery) >
-// ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool).
+// ready+assigned (pre-assigned) > ready+routed_to (pool). Pool work matches
+// in two sub-tiers: --unassigned (the canonical "leave assignee empty"
+// pattern), then --assignee=<template> (callers that park work on the pool
+// template name as a placeholder, e.g. `bd update --assignee=<pool>
+// --set-metadata gc.routed_to=<pool>`). Without the placeholder sub-tier
+// the bead is invisible to every pool member and never claimed (ga-2pz).
 // Formula roots that are themselves executable must be represented as ready()
 // work (for example type=wisp); molecule containers are not routable demand.
 //
@@ -2478,14 +2483,21 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`r=$(bd ready --assignee="$id" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`done; ` +
-			// Tier 3: ready unassigned routed to this config (shared routed queue).
+			// Tier 3: ready routed to this config (shared routed queue).
 			// Only ephemeral sessions and controller probes consume generic config demand.
 			`case "$GC_SESSION_ORIGIN" in ` +
 			`ephemeral|"") ;; ` +
 			`*) exit 0 ;; ` +
 			`esac; ` +
+			// Tier 3a: assignee unset (canonical "leave assignee empty" pattern).
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
 			` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			// Tier 3b: assignee parked on the pool template as a placeholder.
+			// Rescues beads routed with `bd update --assignee=<pool>` (ga-2pz)
+			// where --unassigned would otherwise hide them from every member.
+			`r=$(bd ready --metadata-field gc.routed_to=` + target +
+			` --assignee=` + target + ` --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`printf "[]"'`
 	}
@@ -2512,8 +2524,11 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; ` +
-		// Tier 3: ready unassigned routed to this config (shared routed queue),
-		// then the legacy workflow-control route for pre-rename graphs.
+		// Tier 3: ready routed to this config (shared routed queue), with the
+		// legacy workflow-control route as a pre-rename fallback. Each route
+		// checks two assignee shapes: unassigned (canonical) and parked on the
+		// route name itself (placeholder pattern that hides beads from
+		// --unassigned, ga-2pz).
 		// Only ephemeral sessions and controller probes consume generic config demand.
 		`case "$GC_SESSION_ORIGIN" in ` +
 		`ephemeral|"") ;; ` +
@@ -2522,8 +2537,14 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`r=$(bd ready --metadata-field gc.routed_to=` + target +
 		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`r=$(bd ready --metadata-field gc.routed_to=` + target +
+		` --assignee=` + target + ` --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`r=$(bd ready --metadata-field gc.routed_to=` + legacyTarget +
+		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`bd ready --metadata-field gc.routed_to=` + legacyTarget +
-		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null'`
+		` --assignee=` + legacyTarget + ` --exclude-type=epic --json --limit=1 2>/dev/null'`
 }
 
 func legacyWorkflowControlQualifiedName(target string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2460,6 +2460,14 @@ func (a *Agent) AttachEnabled() bool {
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only
 // the routed_to tier fires to detect new demand.
+//
+// City-bd federation (ga-xw6): rig-scoped agents (a.Dir != "") also probe
+// the city bd via $GC_CITY_BEADS_DIR after their rig-bd Tier 3 queries
+// return empty. Without this, beads filed in the HQ city bd with
+// gc.routed_to=<rig>/<role> are invisible to the rig's agents and become
+// dead-letter routing. The federation is a fallback — rig-bd work always
+// wins. Guarded by env so older runtimes that don't inject the env stay
+// on the rig-only path.
 func (a *Agent) EffectiveWorkQuery() string {
 	if a.WorkQuery != "" {
 		return a.WorkQuery
@@ -2499,6 +2507,7 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
 			` --assignee=` + target + ` --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			a.cityFederationTier3(target) +
 			`printf "[]"'`
 	}
 	return `sh -c '` +
@@ -2543,8 +2552,33 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`r=$(bd ready --metadata-field gc.routed_to=` + legacyTarget +
 		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
-		`bd ready --metadata-field gc.routed_to=` + legacyTarget +
-		` --assignee=` + legacyTarget + ` --exclude-type=epic --json --limit=1 2>/dev/null'`
+		`r=$(bd ready --metadata-field gc.routed_to=` + legacyTarget +
+		` --assignee=` + legacyTarget + ` --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		a.cityFederationTier3(target) +
+		a.cityFederationTier3(legacyTarget) +
+		`printf "[]"'`
+}
+
+// cityFederationTier3 returns the shell fragment that re-runs Tier 3a and
+// Tier 3b against the HQ city bd via $GC_CITY_BEADS_DIR. Returns "" for
+// city-scoped agents (a.Dir == "") — the city bd is already their primary
+// store. The emitted fragment guards at runtime so older runtimes that have
+// not been updated to inject GC_CITY_BEADS_DIR fall through to the existing
+// printf "[]" exit. Designed to be concatenated AFTER the rig-bd Tier 3
+// clauses and BEFORE the final printf "[]". See ga-xw6.
+func (a *Agent) cityFederationTier3(target string) string {
+	if a.Dir == "" {
+		return ""
+	}
+	return `if [ -n "$GC_CITY_BEADS_DIR" ] && [ "$GC_CITY_BEADS_DIR" != "$BEADS_DIR" ]; then ` +
+		`r=$(BEADS_DIR="$GC_CITY_BEADS_DIR" bd ready --metadata-field gc.routed_to=` + target +
+		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`r=$(BEADS_DIR="$GC_CITY_BEADS_DIR" bd ready --metadata-field gc.routed_to=` + target +
+		` --assignee=` + target + ` --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`fi; `
 }
 
 func legacyWorkflowControlQualifiedName(target string) string {
@@ -2610,13 +2644,33 @@ func (a *Agent) DrainTimeoutDuration() time.Duration {
 // counts new unassigned work routed to this agent's template via ready().
 // Assigned in-progress work is resumed from session beads, so it must not
 // create additional generic pool demand here.
+//
+// City-bd federation (ga-xw6): rig-scoped agents (a.Dir != "") also count
+// demand in the HQ city bd via $GC_CITY_BEADS_DIR, summing the rig and city
+// counts. Without this, beads filed in the city bd routed to a rig agent
+// are invisible to the supervisor's demand counter — no polecats spawn.
+// Both probe paths fail loudly (no error masking) so a broken bd surfaces
+// as supervisor error rather than silent zero demand.
 func (a *Agent) EffectiveScaleCheck() string {
 	if a.ScaleCheck != "" {
 		return a.ScaleCheck
 	}
 	template := a.QualifiedName()
-	return `ready_json=$(bd ready --metadata-field gc.routed_to=` + template +
-		` --unassigned --limit 0 --json) && printf '%s\n' "$ready_json" | jq 'length'`
+	if a.Dir == "" {
+		return `ready_json=$(bd ready --metadata-field gc.routed_to=` + template +
+			` --unassigned --limit 0 --json) && printf '%s\n' "$ready_json" | jq 'length'`
+	}
+	// Rig-scoped: count rig and (when GC_CITY_BEADS_DIR is set) city demand.
+	// The && chain ensures any bd or jq failure aborts before printf — empty
+	// output triggers parseScaleCheckCount's "empty output" error so a broken
+	// scope surfaces rather than masquerading as zero demand.
+	return `rig_json=$(bd ready --metadata-field gc.routed_to=` + template +
+		` --unassigned --limit 0 --json) && rig=$(printf '%s\n' "$rig_json" | jq 'length') && ` +
+		`{ if [ -n "$GC_CITY_BEADS_DIR" ] && [ "$GC_CITY_BEADS_DIR" != "$BEADS_DIR" ]; then ` +
+		`city_json=$(BEADS_DIR="$GC_CITY_BEADS_DIR" bd ready --metadata-field gc.routed_to=` + template +
+		` --unassigned --limit 0 --json) && city=$(printf '%s\n' "$city_json" | jq 'length') && ` +
+		`printf '%d\n' "$((rig + city))"; ` +
+		`else printf '%s\n' "$rig"; fi; }`
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1760,6 +1760,180 @@ esac
 	}
 }
 
+// TestEffectiveWorkQueryFederatesCityBeadsForRigAgent verifies the ga-xw6
+// behavior: a rig-scoped agent's work_query queries the rig bd first, and on
+// empty falls back to the HQ city bd via $GC_CITY_BEADS_DIR. Without this
+// federation, beads filed in the city bd with gc.routed_to=<rig>/<role> are
+// invisible to the rig's agents — a documented dead-letter routing bug.
+func TestEffectiveWorkQueryFederatesCityBeadsForRigAgent(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "rig-x"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"BEADS_DIR":         "/rig/.beads",
+		"GC_CITY_BEADS_DIR": "/city/.beads",
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$BEADS_DIR" in
+  /city/.beads)
+    case "$*" in
+      *"--metadata-field gc.routed_to=rig-x/polecat"*"--unassigned"*)
+        printf '[{"id":"pe-fed","issue_type":"task"}]'
+        ;;
+      *)
+        printf '[]'
+        ;;
+    esac
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if !strings.Contains(out, "pe-fed") {
+		t.Fatalf("EffectiveWorkQuery() did not federate city bd: %q", out)
+	}
+}
+
+// TestEffectiveWorkQueryCityFederationSkippedWhenEnvUnset verifies the
+// federation guard: with GC_CITY_BEADS_DIR unset, the federation block does
+// not query the city bd. This preserves backwards-compatibility for runtimes
+// that have not been updated to inject the city beads dir env.
+func TestEffectiveWorkQueryCityFederationSkippedWhenEnvUnset(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "rig-x"}
+	calls := t.TempDir() + "/calls"
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"BEADS_DIR":         "/rig/.beads",
+		"GC_SESSION_ORIGIN": "ephemeral",
+		"CALL_LOG":          calls,
+	}, `#!/bin/sh
+set -eu
+printf '%s|%s\n' "${BEADS_DIR:-}" "$*" >> "$CALL_LOG"
+printf '[]'
+`)
+	if strings.TrimSpace(out) != "[]" {
+		t.Fatalf("EffectiveWorkQuery() = %q, want [] (no federation)", out)
+	}
+	data, err := os.ReadFile(calls)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	if strings.Contains(string(data), "/city/.beads") {
+		t.Fatalf("federation block queried city bd without GC_CITY_BEADS_DIR set: %s", data)
+	}
+}
+
+// TestEffectiveWorkQueryCityFederationSkippedWhenSameDir verifies that if
+// GC_CITY_BEADS_DIR equals BEADS_DIR (degenerate setup), the script skips the
+// redundant second query.
+func TestEffectiveWorkQueryCityFederationSkippedWhenSameDir(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "rig-x"}
+	calls := t.TempDir() + "/calls"
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"BEADS_DIR":         "/same/.beads",
+		"GC_CITY_BEADS_DIR": "/same/.beads",
+		"GC_SESSION_ORIGIN": "ephemeral",
+		"CALL_LOG":          calls,
+	}, `#!/bin/sh
+set -eu
+printf '%s|%s\n' "${BEADS_DIR:-}" "$*" >> "$CALL_LOG"
+printf '[]'
+`)
+	if strings.TrimSpace(out) != "[]" {
+		t.Fatalf("EffectiveWorkQuery() = %q, want []", out)
+	}
+	// The script should query /same/.beads only once per tier-3 step, not
+	// twice (rig + city aliased to same path).
+	data, err := os.ReadFile(calls)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	// Count the routed_to tier 3a calls. There should be exactly one
+	// (not two, which would happen if federation re-queried the same dir).
+	tier3aCount := strings.Count(string(data), "ready --metadata-field gc.routed_to=rig-x/polecat --unassigned --exclude-type=epic")
+	if tier3aCount != 1 {
+		t.Fatalf("expected exactly one tier-3a call, got %d: %s", tier3aCount, data)
+	}
+}
+
+// TestEffectiveWorkQueryCityFederationNotEmittedForCityScopedAgent verifies
+// that agents without a rig (a.Dir == "") do not have the federation block in
+// their emitted script. City-scoped agents already query the city bd as their
+// primary store.
+func TestEffectiveWorkQueryCityFederationNotEmittedForCityScopedAgent(t *testing.T) {
+	a := Agent{Name: "mayor"}
+	got := a.EffectiveWorkQuery()
+	if strings.Contains(got, "GC_CITY_BEADS_DIR") {
+		t.Fatalf("EffectiveWorkQuery() for city-scoped agent should not reference GC_CITY_BEADS_DIR: %q", got)
+	}
+}
+
+// TestEffectiveWorkQueryRigBdWorkBeatsCityBdWork verifies tier ordering: a
+// rig-bd Tier 3a result is returned before any city-bd Tier 3a query fires.
+// Federation must be a fallback, not a parallel/merged search.
+func TestEffectiveWorkQueryRigBdWorkBeatsCityBdWork(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "rig-x"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"BEADS_DIR":         "/rig/.beads",
+		"GC_CITY_BEADS_DIR": "/city/.beads",
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$BEADS_DIR" in
+  /rig/.beads)
+    case "$*" in
+      *"--metadata-field gc.routed_to=rig-x/polecat"*"--unassigned"*)
+        printf '[{"id":"rig-work","issue_type":"task"}]'
+        ;;
+      *)
+        printf '[]'
+        ;;
+    esac
+    ;;
+  /city/.beads)
+    printf '[{"id":"city-work-should-not-win","issue_type":"task"}]'
+    ;;
+esac
+`)
+	if !strings.Contains(out, "rig-work") {
+		t.Fatalf("rig bd work should win: %q", out)
+	}
+	if strings.Contains(out, "city-work-should-not-win") {
+		t.Fatalf("city bd work should not have been queried when rig had work: %q", out)
+	}
+}
+
+// TestEffectiveWorkQueryFederationCoversPoolPlaceholderRescue verifies the
+// Tier 3b placeholder-assignee rescue also federates: a city-bd bead with
+// assignee parked on the pool template name is still claimable.
+func TestEffectiveWorkQueryFederationCoversPoolPlaceholderRescue(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "rig-x"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"BEADS_DIR":         "/rig/.beads",
+		"GC_CITY_BEADS_DIR": "/city/.beads",
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$BEADS_DIR" in
+  /city/.beads)
+    case "$*" in
+      *"--metadata-field gc.routed_to=rig-x/polecat --assignee=rig-x/polecat"*)
+        printf '[{"id":"pe-parked","issue_type":"task"}]'
+        ;;
+      *)
+        printf '[]'
+        ;;
+    esac
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if !strings.Contains(out, "pe-parked") {
+		t.Fatalf("EffectiveWorkQuery() did not federate Tier 3b placeholder rescue: %q", out)
+	}
+}
+
 // TestEffectiveWorkQueryControlDispatcherFindsPoolPlaceholderAssignee mirrors
 // TestEffectiveWorkQueryFindsPoolPlaceholderAssignee for the control-dispatcher
 // path, which carries a separate Tier 3 emission and must apply the same
@@ -1774,6 +1948,71 @@ func TestEffectiveWorkQueryControlDispatcherFindsPoolPlaceholderAssignee(t *test
 	wantLegacy := "bd ready --metadata-field gc.routed_to=gascity/workflow-control --assignee=gascity/workflow-control --exclude-type=epic --json --limit=1"
 	if !strings.Contains(got, wantLegacy) {
 		t.Errorf("EffectiveWorkQuery() missing legacy placeholder-assignee route: %q", got)
+	}
+}
+
+// TestEffectiveScaleCheckFederatesCityBeadsForRigAgent verifies the ga-xw6
+// scale_check federation: a rig-scoped agent's demand counter sums beads
+// routed to it in both the rig bd and the HQ city bd.
+func TestEffectiveScaleCheckFederatesCityBeadsForRigAgent(t *testing.T) {
+	a := Agent{
+		Name:              "polecat",
+		Dir:               "rig-x",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(3),
+	}
+	got := runEffectiveScaleCheck(t, a, map[string]string{
+		"BEADS_DIR":         "/rig/.beads",
+		"GC_CITY_BEADS_DIR": "/city/.beads",
+	}, `#!/bin/sh
+set -eu
+case "$BEADS_DIR" in
+  /rig/.beads)
+    printf '[{"id":"r-1"},{"id":"r-2"}]'
+    ;;
+  /city/.beads)
+    printf '[{"id":"c-1"}]'
+    ;;
+esac
+`)
+	if strings.TrimSpace(got) != "3" {
+		t.Fatalf("EffectiveScaleCheck() = %q, want 3 (2 rig + 1 city)", got)
+	}
+}
+
+// TestEffectiveScaleCheckCityFederationSkippedWhenEnvUnset verifies the
+// scale_check federation is guarded by $GC_CITY_BEADS_DIR. Without the env
+// var, the federation block does not contribute extra demand counts.
+func TestEffectiveScaleCheckCityFederationSkippedWhenEnvUnset(t *testing.T) {
+	a := Agent{
+		Name:              "polecat",
+		Dir:               "rig-x",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(3),
+	}
+	got := runEffectiveScaleCheck(t, a, map[string]string{
+		"BEADS_DIR": "/rig/.beads",
+	}, `#!/bin/sh
+set -eu
+case "$BEADS_DIR" in
+  /rig/.beads)
+    printf '[{"id":"r-1"}]'
+    ;;
+  *)
+    printf '[{"id":"should-not-count"}]'
+    ;;
+esac
+`)
+	if strings.TrimSpace(got) != "1" {
+		t.Fatalf("EffectiveScaleCheck() = %q, want 1 (rig only, no federation)", got)
+	}
+}
+
+// TestEffectiveScaleCheckNoFederationForCityScopedAgent verifies that
+// city-scoped agents emit the simpler non-federation form.
+func TestEffectiveScaleCheckNoFederationForCityScopedAgent(t *testing.T) {
+	a := Agent{Name: "mayor"}
+	got := a.EffectiveScaleCheck()
+	if strings.Contains(got, "GC_CITY_BEADS_DIR") {
+		t.Fatalf("EffectiveScaleCheck() for city-scoped agent should not reference GC_CITY_BEADS_DIR: %q", got)
 	}
 }
 
@@ -3829,6 +4068,31 @@ func runEffectiveWorkQuery(t *testing.T, a Agent, env map[string]string, bdScrip
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("run work query: %v", err)
+	}
+	return string(out)
+}
+
+// runEffectiveScaleCheck executes the agent's effective scale check command
+// against a stub bd that emits configured JSON for `bd ready ...` calls.
+// Returns the captured stdout. The bd stub script can switch on $BEADS_DIR
+// to differentiate rig vs city federation tiers (ga-xw6).
+func runEffectiveScaleCheck(t *testing.T, a Agent, env map[string]string, bdScript string) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	cmd := exec.Command("sh", "-c", a.EffectiveScaleCheck())
+	cmd.Env = []string{"PATH=" + tmp + ":" + os.Getenv("PATH")}
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run scale check: %v\n%s", err, out)
 	}
 	return string(out)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1718,6 +1718,65 @@ esac
 	}
 }
 
+// TestEffectiveWorkQueryFindsPoolPlaceholderAssignee verifies the Tier 3b
+// fallback: a bead routed to the pool with `assignee` parked on the pool
+// template name (the documented `bd update --assignee=<pool>` pattern) is
+// still claimable by pool members. The original work_query only matched
+// --unassigned and dropped these beads on the floor (ga-2pz: polecats
+// spawned, found no work, drained while routed beads piled up).
+func TestEffectiveWorkQueryFindsPoolPlaceholderAssignee(t *testing.T) {
+	a := Agent{
+		Name:              "polecat",
+		Dir:               "hello-world",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(3),
+	}
+	got := a.EffectiveWorkQuery()
+	want := "bd ready --metadata-field gc.routed_to=hello-world/polecat --assignee=hello-world/polecat --exclude-type=epic --json --limit=1"
+	if !strings.Contains(got, want) {
+		t.Errorf("EffectiveWorkQuery() missing tier 3b placeholder-assignee route: %q", got)
+	}
+
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"GC_SESSION_ORIGIN": "ephemeral",
+		"GC_SESSION_NAME":   "polecat-instance-1",
+		"GC_ALIAS":          "hello-world/polecat-instance-1",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--unassigned"*)
+    printf '[]'
+    ;;
+  *"--assignee=hello-world/polecat"*"--metadata-field gc.routed_to=hello-world/polecat"*|\
+  *"--metadata-field gc.routed_to=hello-world/polecat"*"--assignee=hello-world/polecat"*)
+    printf '[{"id":"parked-on-template","issue_type":"task"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if !strings.Contains(out, "parked-on-template") {
+		t.Fatalf("EffectiveWorkQuery() did not return the template-parked bead: %q", out)
+	}
+}
+
+// TestEffectiveWorkQueryControlDispatcherFindsPoolPlaceholderAssignee mirrors
+// TestEffectiveWorkQueryFindsPoolPlaceholderAssignee for the control-dispatcher
+// path, which carries a separate Tier 3 emission and must apply the same
+// placeholder-assignee rescue.
+func TestEffectiveWorkQueryControlDispatcherFindsPoolPlaceholderAssignee(t *testing.T) {
+	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
+	got := a.EffectiveWorkQuery()
+	wantCanonical := "bd ready --metadata-field gc.routed_to=gascity/control-dispatcher --assignee=gascity/control-dispatcher --exclude-type=epic --json --limit=1"
+	if !strings.Contains(got, wantCanonical) {
+		t.Errorf("EffectiveWorkQuery() missing canonical placeholder-assignee route: %q", got)
+	}
+	wantLegacy := "bd ready --metadata-field gc.routed_to=gascity/workflow-control --assignee=gascity/workflow-control --exclude-type=epic --json --limit=1"
+	if !strings.Contains(got, wantLegacy) {
+		t.Errorf("EffectiveWorkQuery() missing legacy placeholder-assignee route: %q", got)
+	}
+}
+
 func TestDefaultPoolCheckUsesPoolName(t *testing.T) {
 	a := Agent{
 		Name:              "dog-1",

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -38,6 +38,28 @@ func (g *Git) IsRepoCtx(ctx context.Context) bool {
 	return err == nil
 }
 
+// CommonDir returns the absolute path of the common git directory for
+// workDir. For a normal checkout this is "<repo>/.git"; for a linked
+// worktree it is the main clone's ".git", not the per-worktree directory.
+// Callers that want the repository root (the parent of ".git") should
+// take filepath.Dir of the result.
+func (g *Git) CommonDir() (string, error) {
+	return g.CommonDirCtx(context.Background())
+}
+
+// CommonDirCtx is like CommonDir but accepts a context for cancellation.
+func (g *Git) CommonDirCtx(ctx context.Context) (string, error) {
+	out, err := g.runCtx(ctx, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return "", fmt.Errorf("getting git common dir: %w", err)
+	}
+	common := strings.TrimSpace(out)
+	if common == "" {
+		return "", fmt.Errorf("git rev-parse --git-common-dir returned empty path")
+	}
+	return common, nil
+}
+
 // CurrentBranch returns the current branch name. Returns "HEAD" if detached.
 func (g *Git) CurrentBranch() (string, error) {
 	return g.CurrentBranchCtx(context.Background())

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -55,6 +55,57 @@ func TestIsRepo(t *testing.T) {
 	}
 }
 
+// TestCommonDir verifies that CommonDir returns the main repository's
+// .git directory both from the main checkout and from a linked worktree.
+// The linked-worktree case is the key one for polecat rig auto-detection:
+// gc bd uses CommonDir to identify the rig when a worktree's
+// .beads/redirect is missing.
+func TestCommonDir(t *testing.T) {
+	repo := initTestRepo(t)
+	wantMainGit, err := filepath.EvalSymlinks(filepath.Join(repo, ".git"))
+	if err != nil {
+		t.Fatalf("EvalSymlinks(repo/.git): %v", err)
+	}
+
+	g := New(repo)
+	got, err := g.CommonDir()
+	if err != nil {
+		t.Fatalf("CommonDir from main checkout: %v", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(got); err == nil {
+		got = resolved
+	}
+	if got != wantMainGit {
+		t.Fatalf("CommonDir from main checkout = %q, want %q", got, wantMainGit)
+	}
+
+	// Linked worktree: CommonDir must still point to the main repo's .git,
+	// not the per-worktree subdirectory under .git/worktrees/<name>.
+	worktree := filepath.Join(t.TempDir(), "linked-worktree")
+	runGit(t, repo, "worktree", "add", "--detach", worktree)
+
+	gw := New(worktree)
+	gotFromWorktree, err := gw.CommonDir()
+	if err != nil {
+		t.Fatalf("CommonDir from linked worktree: %v", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(gotFromWorktree); err == nil {
+		gotFromWorktree = resolved
+	}
+	if gotFromWorktree != wantMainGit {
+		t.Fatalf("CommonDir from linked worktree = %q, want %q (main repo .git)", gotFromWorktree, wantMainGit)
+	}
+}
+
+func TestCommonDir_NotARepo(t *testing.T) {
+	notRepo := t.TempDir()
+	t.Setenv("GIT_CEILING_DIRECTORIES", filepath.Dir(notRepo))
+	g := New(notRepo)
+	if _, err := g.CommonDir(); err == nil {
+		t.Error("CommonDir() in non-repo returned nil error, want error")
+	}
+}
+
 func TestCurrentBranch(t *testing.T) {
 	repo := initTestRepo(t)
 	g := New(repo)

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -103,6 +103,14 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 		}
 	}
 
+	// Mirror the top-level From into metadata["from"] so stores that don't
+	// auto-mirror (MemStore in tests, exec backends) can still serve the
+	// metadata-indexed sender query that humaHandleMailList issues for
+	// ?from=. BdStore performs the same mirror inside Create — see
+	// bdstore.go where metadata["from"] is filled from b.From — so the
+	// production behavior is unchanged.
+	metadata = ensureSenderMetadata(metadata, from)
+
 	b, err := p.store.Create(beads.Bead{
 		Title:       title,
 		Description: body,
@@ -116,6 +124,25 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 		return mail.Message{}, fmt.Errorf("beadmail send: %w", err)
 	}
 	return beadToMessage(b), nil
+}
+
+// ensureSenderMetadata returns metadata with metadata["from"] populated from
+// the resolved sender when it is non-empty and not already set. The branch
+// without an existing entry mirrors the bd CLI store: callers that pass an
+// explicit metadata.from win, and the SDK always carries the canonical sender
+// in metadata so the API filter can index it.
+func ensureSenderMetadata(metadata map[string]string, from string) map[string]string {
+	from = strings.TrimSpace(from)
+	if from == "" {
+		return metadata
+	}
+	if metadata == nil {
+		metadata = make(map[string]string, 1)
+	}
+	if strings.TrimSpace(metadata["from"]) == "" {
+		metadata["from"] = from
+	}
+	return metadata
 }
 
 func (p *Provider) resolveSenderRoute(from string) (string, map[string]string, error) {
@@ -345,6 +372,7 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail reply: %w", err)
 	}
+	metadata = ensureSenderMetadata(metadata, from)
 	if metadata == nil {
 		metadata = make(map[string]string)
 	}
@@ -501,6 +529,161 @@ func (p *Provider) filterMessages(recipient string, includeRead bool) ([]mail.Me
 		msgs = append(msgs, beadToMessage(b))
 	}
 	return msgs, nil
+}
+
+// Filter implements [mail.Filterer]. The candidate set is chosen by the most
+// selective populated filter (recipient routes > sender > label > global), and
+// every populated [mail.FilterOptions] field is then enforced post-query so the
+// result respects the conjunctive contract documented on FilterOptions.
+//
+// The candidate selector keeps recipient-based queries fast (alias history is
+// expanded through [Provider.recipientRoutes] just like Inbox/All); when no
+// recipient is given but a sender or label is supplied, a single indexed query
+// avoids the global type=message scan.
+func (p *Provider) Filter(opts mail.FilterOptions) ([]mail.Message, error) {
+	recipient := strings.TrimSpace(opts.Recipient)
+	sender := strings.TrimSpace(opts.Sender)
+	label := strings.TrimSpace(opts.Label)
+
+	var routes []string
+	if recipient != "" {
+		routes = p.recipientRoutes(recipient)
+	}
+
+	candidates, err := p.filterCandidates(routes, sender, label, opts.IncludeClosed)
+	if err != nil {
+		return nil, fmt.Errorf("beadmail filter: %w", err)
+	}
+
+	msgs := make([]mail.Message, 0, len(candidates))
+	for _, b := range candidates {
+		if !isMessage(b) {
+			continue
+		}
+		if !opts.IncludeClosed && b.Status != "open" {
+			continue
+		}
+		if opts.IncludeClosed && b.Status != "open" && b.Status != "closed" {
+			continue
+		}
+		if len(routes) > 0 && !matchesRecipientRoute(routes, b.Assignee) {
+			continue
+		}
+		if sender != "" && !messageMatchesSender(b, sender) {
+			continue
+		}
+		if label != "" && !hasLabel(b.Labels, label) {
+			continue
+		}
+		if !opts.IncludeRead && hasLabel(b.Labels, "read") {
+			continue
+		}
+		msgs = append(msgs, beadToMessage(b))
+	}
+	return msgs, nil
+}
+
+// filterCandidates collects message beads using the most selective populated
+// constraint as the indexed query, deduplicating across multiple recipient
+// routes. IncludeClosed flips on closed-status retrieval (issuing both
+// open and closed queries when no recipient route narrows the scan further).
+func (p *Provider) filterCandidates(routes []string, sender, label string, includeClosed bool) ([]beads.Bead, error) {
+	seen := make(map[string]beads.Bead)
+	order := make([]string, 0)
+	add := func(bs []beads.Bead) {
+		for _, b := range bs {
+			if !isMessage(b) {
+				continue
+			}
+			if _, ok := seen[b.ID]; !ok {
+				order = append(order, b.ID)
+			}
+			seen[b.ID] = b
+		}
+	}
+
+	statuses := []string{"open"}
+	if includeClosed {
+		statuses = []string{"open", "closed"}
+	}
+
+	switch {
+	case len(routes) > 0:
+		for _, route := range routes {
+			for _, status := range statuses {
+				items, err := p.store.List(beads.ListQuery{
+					Assignee: route,
+					Type:     "message",
+					Status:   status,
+					TierMode: beads.TierBoth,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("listing by assignee %q: %w", route, err)
+				}
+				add(items)
+			}
+		}
+	case sender != "":
+		for _, status := range statuses {
+			items, err := p.store.List(beads.ListQuery{
+				Metadata: map[string]string{"from": sender},
+				Type:     "message",
+				Status:   status,
+				TierMode: beads.TierBoth,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("listing by sender %q: %w", sender, err)
+			}
+			add(items)
+		}
+	case label != "":
+		for _, status := range statuses {
+			items, err := p.store.List(beads.ListQuery{
+				Label:    label,
+				Type:     "message",
+				Status:   status,
+				TierMode: beads.TierBoth,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("listing by label %q: %w", label, err)
+			}
+			add(items)
+		}
+	default:
+		query := beads.ListQuery{Type: "message", TierMode: beads.TierBoth}
+		if includeClosed {
+			query.IncludeClosed = true
+		}
+		items, err := p.store.List(query)
+		if err != nil {
+			return nil, fmt.Errorf("listing message beads: %w", err)
+		}
+		add(items)
+	}
+
+	result := make([]beads.Bead, 0, len(order))
+	for _, id := range order {
+		result = append(result, seen[id])
+	}
+	return result, nil
+}
+
+// messageMatchesSender returns true when the bead's sender, taken from the
+// top-level From field with fall-through to metadata.from, equals want. The
+// fall-through mirrors [bdIssue.toBead] in the bd-backed store, which is the
+// canonical sender-resolution rule for message beads.
+func messageMatchesSender(b beads.Bead, want string) bool {
+	want = strings.TrimSpace(want)
+	if want == "" {
+		return true
+	}
+	if strings.TrimSpace(b.From) == want {
+		return true
+	}
+	if strings.TrimSpace(b.Metadata["from"]) == want {
+		return true
+	}
+	return false
 }
 
 // messageCandidates returns message beads relevant to a recipient using

--- a/internal/mail/beadmail/beadmail_bench_test.go
+++ b/internal/mail/beadmail/beadmail_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail"
 )
 
 // BenchmarkArchiveMany measures the cost of an N-message batch close
@@ -71,5 +72,46 @@ func benchName(base string, n int) string {
 		return base + "_N200"
 	default:
 		return base
+	}
+}
+
+// BenchmarkFilter measures Filter dispatch cost at inbox sizes that match the
+// gas-ui ga-rdz acceptance shape (the /mail render budget is <250ms over a
+// 100+-message fixture inbox). Memstore is the lower bound on backing-store
+// cost; BdStore costs strictly more because of its bd-subprocess round-trips.
+//
+// Two shapes are exercised: a recipient-only filter (the inbox path) and a
+// sender-only filter (the Sent tab). Both use the metadata-indexed query path
+// from filterCandidates, not a broad type=message scan.
+func BenchmarkFilter(b *testing.B) {
+	for _, n := range []int{100, 500} {
+		b.Run(benchName("FilterByRecipient", n), func(b *testing.B) {
+			runFilterBench(b, n, mail.FilterOptions{Recipient: "bob", IncludeRead: true})
+		})
+		b.Run(benchName("FilterBySender", n), func(b *testing.B) {
+			runFilterBench(b, n, mail.FilterOptions{Sender: "alice", IncludeRead: true})
+		})
+	}
+}
+
+func runFilterBench(b *testing.B, n int, opts mail.FilterOptions) {
+	b.Helper()
+	b.ReportAllocs()
+	store := beads.NewMemStore()
+	p := New(store)
+	for i := 0; i < n; i++ {
+		if _, err := p.Send("alice", "bob", "", "bench"); err != nil {
+			b.Fatalf("Send: %v", err)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msgs, err := p.Filter(opts)
+		if err != nil {
+			b.Fatalf("Filter: %v", err)
+		}
+		if len(msgs) == 0 {
+			b.Fatalf("Filter returned 0 messages, want %d", n)
+		}
 	}
 }

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1856,6 +1856,171 @@ func TestProviderCached_BroadSessionListCachedAcrossInboxCalls(t *testing.T) {
 	}
 }
 
+// --- Filter (ga-rdz) ---
+
+// TestFilterBySenderUsesMetadataIndex confirms that ?from= is honored by
+// the beadmail provider via the metadata-indexed query path, not a broad
+// type=message scan. This is the regression mode for gu-2jr (where a prior
+// from-filter shipped broken because it post-filtered nothing).
+func TestFilterBySenderUsesMetadataIndex(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	if _, err := p.Send("alice", "bob", "From alice 1", "a"); err != nil {
+		t.Fatalf("Send alice→bob: %v", err)
+	}
+	if _, err := p.Send("alice", "carol", "From alice 2", "b"); err != nil {
+		t.Fatalf("Send alice→carol: %v", err)
+	}
+	if _, err := p.Send("dave", "bob", "From dave", "c"); err != nil {
+		t.Fatalf("Send dave→bob: %v", err)
+	}
+
+	msgs, err := p.Filter(mail.FilterOptions{Sender: "alice", IncludeRead: true})
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("Filter sender=alice returned %d messages, want 2", len(msgs))
+	}
+	for _, m := range msgs {
+		if m.From != "alice" {
+			t.Errorf("Filter sender=alice returned From=%q, want alice", m.From)
+		}
+	}
+}
+
+// TestFilterByLabelMatchesArchivedForViewer confirms the archived-by-label
+// shape returns rows even when they carry the "read" label, replacing the
+// pre-ga-rdz bd-subprocess scan in gas-ui.
+func TestFilterByLabelMatchesArchivedForViewer(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	if _, err := store.Create(beads.Bead{
+		Title: "Archived", Type: "message", Assignee: "bob", From: "alice",
+		Labels: []string{"archived:bob", "read"},
+	}); err != nil {
+		t.Fatalf("seed archived: %v", err)
+	}
+	if _, err := p.Send("alice", "bob", "Unrelated", "still open"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	msgs, err := p.Filter(mail.FilterOptions{
+		Recipient:   "bob",
+		Label:       "archived:bob",
+		IncludeRead: true,
+	})
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Filter label=archived:bob returned %d, want 1", len(msgs))
+	}
+	if msgs[0].Subject != "Archived" {
+		t.Errorf("Filter returned %q, want Archived", msgs[0].Subject)
+	}
+}
+
+// TestFilterIncludeClosedSurfacesArchivedBeads covers the legacy archive
+// model where Archive() closes the bead. Without IncludeClosed, the bead is
+// hidden; with it, the bead is returned.
+func TestFilterIncludeClosedSurfacesArchivedBeads(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	msg, err := p.Send("alice", "bob", "To archive", "body")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := p.Archive(msg.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	open, err := p.Filter(mail.FilterOptions{Recipient: "bob", IncludeRead: true})
+	if err != nil {
+		t.Fatalf("Filter open: %v", err)
+	}
+	if len(open) != 0 {
+		t.Fatalf("Filter without IncludeClosed returned %d, want 0", len(open))
+	}
+
+	all, err := p.Filter(mail.FilterOptions{Recipient: "bob", IncludeRead: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("Filter closed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("Filter with IncludeClosed returned %d, want 1", len(all))
+	}
+	if all[0].ID != msg.ID {
+		t.Errorf("Filter with IncludeClosed returned id=%q, want %q", all[0].ID, msg.ID)
+	}
+}
+
+// TestFilterConjunctiveAcrossSenderAndRecipient confirms FilterOptions
+// fields stack: sender + recipient narrows to the intersection.
+func TestFilterConjunctiveAcrossSenderAndRecipient(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	if _, err := p.Send("alice", "bob", "match", "x"); err != nil {
+		t.Fatalf("Send alice→bob: %v", err)
+	}
+	if _, err := p.Send("alice", "carol", "miss-recipient", "x"); err != nil {
+		t.Fatalf("Send alice→carol: %v", err)
+	}
+	if _, err := p.Send("dave", "bob", "miss-sender", "x"); err != nil {
+		t.Fatalf("Send dave→bob: %v", err)
+	}
+
+	msgs, err := p.Filter(mail.FilterOptions{Recipient: "bob", Sender: "alice", IncludeRead: true})
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Filter Recipient=bob Sender=alice returned %d, want 1", len(msgs))
+	}
+	if msgs[0].Subject != "match" {
+		t.Errorf("Filter returned subject=%q, want match", msgs[0].Subject)
+	}
+}
+
+// TestFilterUnreadOnlyHidesReadEvenWhenLabelMatches verifies that
+// IncludeRead=false (the default) still hides "read" messages, even when
+// the label-narrowed candidate set would otherwise include them.
+func TestFilterUnreadOnlyHidesReadEvenWhenLabelMatches(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	if _, err := store.Create(beads.Bead{
+		Title: "Read", Type: "message", Assignee: "bob", From: "alice",
+		Labels: []string{"priority:high", "read"},
+	}); err != nil {
+		t.Fatalf("seed read: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title: "Unread", Type: "message", Assignee: "bob", From: "alice",
+		Labels: []string{"priority:high"},
+	}); err != nil {
+		t.Fatalf("seed unread: %v", err)
+	}
+
+	msgs, err := p.Filter(mail.FilterOptions{Recipient: "bob", Label: "priority:high"})
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Filter unread-only returned %d, want 1", len(msgs))
+	}
+	if msgs[0].Subject != "Unread" {
+		t.Errorf("Filter unread-only returned %q, want Unread", msgs[0].Subject)
+	}
+}
+
 // --- Compile-time interface check ---
 
-var _ mail.Provider = (*Provider)(nil)
+var (
+	_ mail.Provider = (*Provider)(nil)
+	_ mail.Filterer = (*Provider)(nil)
+)

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -113,3 +113,40 @@ type Provider interface {
 	// Count returns (total, unread) message counts for a recipient.
 	Count(recipient string) (total int, unread int, err error)
 }
+
+// FilterOptions describes a fine-grained mail query that composes the
+// recipient-routing semantics of Inbox/All with explicit sender, label, and
+// status filters. Zero-value fields are unset (no constraint).
+//
+// The fields stack conjunctively: a message must match every non-empty
+// constraint to be returned. Note that Recipient still goes through the
+// provider's alias/session-history resolution, so the same routes that
+// surface a message in Inbox(recipient) surface it here.
+type FilterOptions struct {
+	// Recipient narrows by the message Assignee, including alias history.
+	// Empty means "no recipient constraint" — the result spans every
+	// mailbox the caller has access to.
+	Recipient string
+	// Sender narrows by the message From / metadata.from. Empty means
+	// "no sender constraint".
+	Sender string
+	// Label narrows by exact label match (e.g. "archived:viewer/me",
+	// "thread:foo"). Empty means "no label constraint".
+	Label string
+	// IncludeRead controls whether messages with the "read" label are
+	// returned. Default false matches Inbox semantics (unread only).
+	IncludeRead bool
+	// IncludeClosed controls whether status="closed" messages are
+	// returned alongside status="open". Default false matches the
+	// legacy Inbox/All semantics (open only). Set to true to surface
+	// legacy-archived (status=closed) beads.
+	IncludeClosed bool
+}
+
+// Filterer is the optional capability for providers that support
+// server-side filtering by sender, label, and status. Providers without
+// this capability can still serve filter requests through the generic
+// post-filter fallback in the API handler.
+type Filterer interface {
+	Filter(opts FilterOptions) ([]Message, error)
+}

--- a/internal/session/alias.go
+++ b/internal/session/alias.go
@@ -28,6 +28,47 @@ func UpdatedAliasMetadata(metadata map[string]string, nextAlias string) map[stri
 	}
 }
 
+// ReleaseClaimedIdentityOnCloseState reports whether closing with the given
+// short stateCode should release the bead's runtime-identity metadata
+// (alias, agent_name). True for terminal states a bead cannot be reopened
+// from — its claim on a pool slot or alias must not block fresh spawns.
+// Mirrors the not-eligible list in closedNamedSessionReopenEligible so any
+// close that won't be reopened also frees its identity.
+func ReleaseClaimedIdentityOnCloseState(stateCode string) bool {
+	switch strings.TrimSpace(stateCode) {
+	case "gc_swept", "orphaned", "stale-session", "duplicate", "duplicate-repair", "reconfigured", string(StateFailedCreate):
+		return true
+	}
+	return false
+}
+
+// ReleaseClaimedIdentityPatch returns metadata mutations that clear the
+// bead's runtime-identity claim (alias, agent_name) while preserving the
+// previous alias in alias_history so delivery continuity for mail and
+// orphan recovery still finds prior routes. Pass the bead's current
+// metadata so the helper can move the live alias into history.
+//
+// Apply alongside ClosePatch on terminal close states (see
+// ReleaseClaimedIdentityOnCloseState). Without this, a closed pool bead
+// keeps its alias metadata indefinitely; if a stale cache view of the
+// bead lingers as open, the alias-availability check still matches it
+// and rejects the next spawn under the same slot.
+func ReleaseClaimedIdentityPatch(metadata map[string]string) map[string]string {
+	patch := map[string]string{
+		"alias":      "",
+		"agent_name": "",
+	}
+	currentAlias := strings.TrimSpace(metadata["alias"])
+	if currentAlias == "" {
+		return patch
+	}
+	history := AliasHistory(metadata)
+	history = append([]string{currentAlias}, history...)
+	history = normalizeAliasList(history, "")
+	patch[aliasHistoryMetadataKey] = strings.Join(history, ",")
+	return patch
+}
+
 func normalizeAliasList(values []string, exclude string) []string {
 	exclude = strings.TrimSpace(exclude)
 	seen := map[string]bool{}

--- a/internal/session/alias_test.go
+++ b/internal/session/alias_test.go
@@ -1,0 +1,85 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReleaseClaimedIdentityOnCloseState(t *testing.T) {
+	cases := map[string]bool{
+		"gc_swept":         true,
+		"orphaned":         true,
+		"stale-session":    true,
+		"duplicate":        true,
+		"duplicate-repair": true,
+		"reconfigured":     true,
+		"failed-create":    true,
+		"drained":          false,
+		"suspended":        false,
+		"active":           false,
+		"":                 false,
+	}
+	for state, want := range cases {
+		if got := ReleaseClaimedIdentityOnCloseState(state); got != want {
+			t.Errorf("ReleaseClaimedIdentityOnCloseState(%q) = %v, want %v", state, got, want)
+		}
+	}
+}
+
+func TestReleaseClaimedIdentityPatch_MovesAliasIntoHistory(t *testing.T) {
+	meta := map[string]string{
+		"alias":        "zack/gastown.furiosa",
+		"agent_name":   "zack/gastown.furiosa",
+		"session_name": "gastown__polecat-pe-r7c1",
+	}
+	got := ReleaseClaimedIdentityPatch(meta)
+	want := map[string]string{
+		"alias":         "",
+		"agent_name":    "",
+		"alias_history": "zack/gastown.furiosa",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ReleaseClaimedIdentityPatch = %v, want %v", got, want)
+	}
+}
+
+func TestReleaseClaimedIdentityPatch_PrependsToExistingHistory(t *testing.T) {
+	meta := map[string]string{
+		"alias":         "rig-2/worker",
+		"agent_name":    "rig-2/worker",
+		"alias_history": "rig-1/worker,old-alias",
+	}
+	got := ReleaseClaimedIdentityPatch(meta)
+	want := map[string]string{
+		"alias":         "",
+		"agent_name":    "",
+		"alias_history": "rig-2/worker,rig-1/worker,old-alias",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ReleaseClaimedIdentityPatch = %v, want %v", got, want)
+	}
+}
+
+func TestReleaseClaimedIdentityPatch_AliasAlreadyInHistoryIsDeduped(t *testing.T) {
+	meta := map[string]string{
+		"alias":         "shared",
+		"alias_history": "shared,older",
+	}
+	got := ReleaseClaimedIdentityPatch(meta)
+	if got["alias_history"] != "shared,older" {
+		t.Fatalf("alias_history = %q, want %q", got["alias_history"], "shared,older")
+	}
+}
+
+func TestReleaseClaimedIdentityPatch_EmptyAliasOmitsHistoryWrite(t *testing.T) {
+	meta := map[string]string{
+		"agent_name": "stale",
+	}
+	got := ReleaseClaimedIdentityPatch(meta)
+	if _, ok := got["alias_history"]; ok {
+		t.Fatalf("alias_history written when current alias was empty: %v", got)
+	}
+	if got["alias"] != "" || got["agent_name"] != "" {
+		t.Fatalf("identity fields not cleared: %v", got)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -799,16 +799,54 @@ func (m *Manager) Suspend(id string) error {
 
 // RequestFreshRestart marks a session for a controller-owned fresh restart
 // without closing its bead or clearing resume metadata immediately.
+//
+// For providers that wake via --resume (resume_flag / resume_command /
+// resume_style and no session_id_flag), the patch also clears the persisted
+// session_key and started_config_hash. The reconciler normally performs this
+// clear when it processes restart_requested, but several gating checks
+// (alive/dead state, circuit breaker, stale live_hash, etc.) can skip that
+// branch, leaving session_key stamped with a value pointing at a provider
+// conversation file that no longer exists. Doing the clear here makes
+// `gc session reset` deterministic for resume-style providers (e.g. claude
+// with --resume) so a missing provider conversation file is healed on the
+// next wake without operator intervention.
+//
+// For session_id_flag providers we deliberately do not touch session_key:
+// the reconciler must rotate it to a freshly generated UUID and emit
+// `--session-id <new_key>` on the next start. Clearing here would race that
+// rotation.
 func (m *Manager) RequestFreshRestart(id string) error {
 	return withSessionMutationLock(id, func() error {
-		if _, _, err := m.sessionBead(id); err != nil {
+		b, _, err := m.sessionBead(id)
+		if err != nil {
 			return err
 		}
-		return m.store.SetMetadataBatch(id, map[string]string{
+		patch := map[string]string{
 			"restart_requested":          "true",
 			"continuation_reset_pending": "true",
-		})
+		}
+		if usesResumeWake(b.Metadata) {
+			patch["session_key"] = ""
+			patch["started_config_hash"] = ""
+		}
+		return m.store.SetMetadataBatch(id, patch)
 	})
+}
+
+// usesResumeWake reports whether the bead metadata identifies a session that
+// wakes via a --resume-style command rather than session-id injection. The
+// session_id_flag branch takes precedence because providers that support both
+// (current claude config) wake via --session-id, not --resume.
+func usesResumeWake(meta map[string]string) bool {
+	if meta == nil {
+		return false
+	}
+	if strings.TrimSpace(meta["session_id_flag"]) != "" {
+		return false
+	}
+	return strings.TrimSpace(meta["resume_flag"]) != "" ||
+		strings.TrimSpace(meta["resume_command"]) != "" ||
+		strings.TrimSpace(meta["resume_style"]) != ""
 }
 
 // Close ends a conversation permanently.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3730,3 +3730,124 @@ func TestEnsureRunning_StartupDeathClearMetadataFailurePropagates(t *testing.T) 
 		t.Fatal("session_key should remain set after failed metadata clear")
 	}
 }
+
+// TestRequestFreshRestartClearsSessionKeyForResumeWake covers the operator-
+// reported failure mode on mayor (2026-05-19): `gc session reset mayor` left
+// session_key stamped, so the next wake tried to --resume a Claude
+// conversation file that no longer existed.
+//
+// For resume-style providers (resume_flag set, no session_id_flag) the patch
+// must clear session_key and started_config_hash so the next wake starts
+// fresh. The reconciler does this when it processes restart_requested, but
+// only on paths that survive its gating checks; doing it here makes the
+// behavior deterministic for every caller of RequestFreshRestart.
+//
+// For session_id_flag providers we must NOT clear session_key here — the
+// reconciler rotates it to a fresh UUID and emits `--session-id <new_key>`
+// on the next start. Clearing here would race that rotation and leave the
+// next wake without a key.
+func TestRequestFreshRestartClearsSessionKeyForResumeWake(t *testing.T) {
+	t.Run("resume_flag session clears session_key", func(t *testing.T) {
+		store := beads.NewMemStore()
+		sp := runtime.NewFake()
+		mgr := NewManager(store, sp)
+
+		info, err := mgr.Create(
+			context.Background(),
+			"helper", "", "claude", t.TempDir(), "claude",
+			nil,
+			ProviderResume{ResumeFlag: "--resume", ResumeStyle: "flag"},
+			runtime.Config{},
+		)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+
+		// Simulate a session that has been running long enough to have
+		// accumulated identity state we expect to clear on reset.
+		if err := store.SetMetadataBatch(info.ID, map[string]string{
+			"session_key":         "stale-conversation-uuid",
+			"started_config_hash": "deadbeef",
+		}); err != nil {
+			t.Fatalf("seeding session metadata: %v", err)
+		}
+
+		if err := mgr.RequestFreshRestart(info.ID); err != nil {
+			t.Fatalf("RequestFreshRestart: %v", err)
+		}
+
+		b, err := store.Get(info.ID)
+		if err != nil {
+			t.Fatalf("store.Get: %v", err)
+		}
+		if got := b.Metadata["restart_requested"]; got != "true" {
+			t.Errorf("restart_requested = %q, want %q", got, "true")
+		}
+		if got := b.Metadata["continuation_reset_pending"]; got != "true" {
+			t.Errorf("continuation_reset_pending = %q, want %q", got, "true")
+		}
+		if got := b.Metadata["session_key"]; got != "" {
+			t.Errorf("session_key = %q, want empty for resume-style reset", got)
+		}
+		if got := b.Metadata["started_config_hash"]; got != "" {
+			t.Errorf("started_config_hash = %q, want empty for resume-style reset", got)
+		}
+		// resume_flag itself must survive — it describes the provider, not
+		// the conversation identity.
+		if got := b.Metadata["resume_flag"]; got != "--resume" {
+			t.Errorf("resume_flag = %q, want %q (provider capability must persist)", got, "--resume")
+		}
+	})
+
+	t.Run("session_id_flag session preserves session_key for reconciler rotation", func(t *testing.T) {
+		store := beads.NewMemStore()
+		sp := runtime.NewFake()
+		mgr := NewManager(store, sp)
+
+		info, err := mgr.Create(
+			context.Background(),
+			"helper", "", "claude", t.TempDir(), "claude",
+			nil,
+			ProviderResume{SessionIDFlag: "--session-id"},
+			runtime.Config{},
+		)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+
+		// Create stamps a generated session_key when SessionIDFlag is set.
+		// Capture it so we can assert it survives RequestFreshRestart and
+		// is left for the reconciler to rotate.
+		seedBead, err := store.Get(info.ID)
+		if err != nil {
+			t.Fatalf("store.Get seed: %v", err)
+		}
+		originalKey := seedBead.Metadata["session_key"]
+		if originalKey == "" {
+			t.Fatalf("expected Create to stamp session_key for SessionIDFlag provider")
+		}
+		// Mirror what worker_handle_test.go does: stamp session_id_flag onto
+		// the bead so RequestFreshRestart can detect this provider style.
+		if err := store.SetMetadata(info.ID, "session_id_flag", "--session-id"); err != nil {
+			t.Fatalf("seed session_id_flag: %v", err)
+		}
+
+		if err := mgr.RequestFreshRestart(info.ID); err != nil {
+			t.Fatalf("RequestFreshRestart: %v", err)
+		}
+
+		b, err := store.Get(info.ID)
+		if err != nil {
+			t.Fatalf("store.Get: %v", err)
+		}
+		if got := b.Metadata["restart_requested"]; got != "true" {
+			t.Errorf("restart_requested = %q, want %q", got, "true")
+		}
+		if got := b.Metadata["continuation_reset_pending"]; got != "true" {
+			t.Errorf("continuation_reset_pending = %q, want %q", got, "true")
+		}
+		if got := b.Metadata["session_key"]; got != originalKey {
+			t.Errorf("session_key = %q, want %q (reconciler must rotate, not RequestFreshRestart)", got, originalKey)
+		}
+	})
+}


### PR DESCRIPTION
Operator reported on 2026-05-19 that `gc session reset mayor` did not recover a session whose Claude conversation file was missing — manual `bd update pe-cvy --unset-metadata session_key` + `gc supervisor reload` was required.

**Root cause:** `RequestFreshRestart` only set `restart_requested` + `continuation_reset_pending`; the actual session_key clear lived in the reconciler's restart-requested branch, which is gated behind several liveness/circuit-breaker checks that can skip when `live_hash` is stale.

**Fix:** For resume-style providers (`resume_flag` / `resume_command` / `resume_style` with no `session_id_flag`), also clear `session_key` and `started_config_hash` in `RequestFreshRestart` itself so every caller benefits, not just the paths the reconciler happens to reach. `session_id_flag` providers are intentionally left untouched — the reconciler must rotate `session_key` to a freshly generated UUID for the next `--session-id` start.

Branch: `helper-agent/fix-session-reset` @ 4d1555dd