### PR TITLE
fix(convergence): honor --rig so loops land in the rig bead store

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/convergence"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
@@ -102,14 +101,13 @@ type CityRuntime struct {
 	fsPressureConsecutiveSkips int
 	fsPressureEpisodeLogged    bool
 
-	convHandler         *convergence.Handler     // nil until bead store available
-	convStoreAdapter    *convergenceStoreAdapter // typed reference; avoids type assertions in tick/reconcile
-	convergenceReqCh    chan convergenceRequest  // receives CLI commands from controller.sock
-	reloadReqCh         chan reloadRequest       // receives structured reload requests from controller.sock
-	pokeCh              chan struct{}            // non-blocking signal to trigger immediate reconciler tick
-	controlDispatcherCh chan struct{}            // non-blocking signal for control-dispatcher-only reconcile
-	nudgeWakeCh         chan struct{}            // signal to dispatch queued nudges; fed by wake socket listener
-	reloadMu            sync.Mutex               // guards activeReload
+	convScopes          map[string]*convergenceScope // nil until bead store available; keyed by rig name ("" = city/HQ)
+	convergenceReqCh    chan convergenceRequest      // receives CLI commands from controller.sock
+	reloadReqCh         chan reloadRequest           // receives structured reload requests from controller.sock
+	pokeCh              chan struct{}                // non-blocking signal to trigger immediate reconciler tick
+	controlDispatcherCh chan struct{}                // non-blocking signal for control-dispatcher-only reconcile
+	nudgeWakeCh         chan struct{}                // signal to dispatch queued nudges; fed by wake socket listener
+	reloadMu            sync.Mutex                   // guards activeReload
 	activeReload        *reloadRequest
 	onStarted           func()
 	onStatus            func(string)
@@ -701,10 +699,16 @@ func (cr *CityRuntime) safeTick(fn func(), trigger string) (panicked bool) {
 }
 
 func convergenceStartupComplete(cr *CityRuntime) bool {
-	return cr.convHandler == nil ||
-		cr.convergenceReqCh == nil ||
-		cr.convStoreAdapter == nil ||
-		cr.convStoreAdapter.activeIndex != nil
+	if cr.convScopes == nil || cr.convergenceReqCh == nil {
+		return true
+	}
+	// Startup is complete once every scope's active index is populated.
+	for _, scope := range cr.convScopes {
+		if scope.adapter.activeIndex == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // tick performs one reconciliation tick: pool death detection, config

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -4648,7 +4648,7 @@ func TestCityRuntimeRun_RetriesConvergenceStartupUntilIndexPopulated(t *testing.
 
 	deadline := time.After(5 * time.Second)
 	for {
-		if cr.convStoreAdapter != nil && cr.convStoreAdapter.activeIndex != nil {
+		if scope := cr.convScopes[""]; scope != nil && scope.adapter.activeIndex != nil {
 			cancel()
 			break
 		}

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -130,7 +131,7 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			beadID := args[0]
-			store, _, code := openConvergeStore(stderr, "gc converge status")
+			store, _, _, code := openConvergeStore(stderr, "gc converge status")
 			if code != 0 {
 				return errExit
 			}
@@ -232,6 +233,7 @@ func newConvergeStopCmd(stdout, stderr io.Writer) *cobra.Command {
 func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 	var (
 		all         bool
+		allRigs     bool
 		stateFilter string
 		jsonOutput  bool
 	)
@@ -239,20 +241,6 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 		Use:   "list",
 		Short: "List convergence loops",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			store, _, code := openConvergeStore(stderr, "gc converge list")
-			if code != 0 {
-				return errExit
-			}
-			query := beads.ListQuery{Type: "convergence"}
-			if all {
-				query.IncludeClosed = true
-			}
-			beadList, err := store.List(query)
-			if err != nil {
-				fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
-				return errExit
-			}
-
 			type convEntry struct {
 				ID        string `json:"id"`
 				State     string `json:"state"`
@@ -264,37 +252,113 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 				Title     string `json:"title"`
 			}
 			var entries []convEntry
-			for _, b := range beadList {
-				meta := b.Metadata
-				if meta == nil {
-					meta = map[string]string{}
+			appendEntries := func(scopeRig string, store beads.Store) error {
+				query := beads.ListQuery{Type: "convergence"}
+				if all {
+					query.IncludeClosed = true
 				}
-				state := meta[convergence.FieldState]
-				if stateFilter != "" && state != stateFilter {
-					continue
+				beadList, err := store.List(query)
+				if err != nil {
+					return err
 				}
-				iter, _ := convergence.DecodeInt(meta[convergence.FieldIteration])
-				maxIter, _ := convergence.DecodeInt(meta[convergence.FieldMaxIterations])
-				entries = append(entries, convEntry{
-					ID:        b.ID,
-					State:     state,
-					Iteration: fmt.Sprintf("%d/%d", iter, maxIter),
-					Gate:      meta[convergence.FieldGateMode],
-					Formula:   meta[convergence.FieldFormula],
-					Target:    meta[convergence.FieldTarget],
-					Rig:       meta[convergence.FieldRig],
-					Title:     b.Title,
-				})
+				for _, b := range beadList {
+					meta := b.Metadata
+					if meta == nil {
+						meta = map[string]string{}
+					}
+					state := meta[convergence.FieldState]
+					if stateFilter != "" && state != stateFilter {
+						continue
+					}
+					iter, _ := convergence.DecodeInt(meta[convergence.FieldIteration])
+					maxIter, _ := convergence.DecodeInt(meta[convergence.FieldMaxIterations])
+					rig := meta[convergence.FieldRig]
+					if rig == "" {
+						rig = scopeRig
+					}
+					entries = append(entries, convEntry{
+						ID:        b.ID,
+						State:     state,
+						Iteration: fmt.Sprintf("%d/%d", iter, maxIter),
+						Gate:      meta[convergence.FieldGateMode],
+						Formula:   meta[convergence.FieldFormula],
+						Target:    meta[convergence.FieldTarget],
+						Rig:       rig,
+						Title:     b.Title,
+					})
+				}
+				return nil
+			}
+
+			hadScopeError := false
+			if allRigs {
+				rctx, err := resolveContext()
+				if err != nil {
+					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
+					return errExit
+				}
+				store, err := openStoreAtForCity(rctx.CityPath, rctx.CityPath)
+				if err != nil {
+					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
+					return errExit
+				}
+				if err := appendEntries("", store); err != nil {
+					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
+					return errExit
+				}
+				cfg, err := loadCityConfig(rctx.CityPath, io.Discard)
+				if err != nil {
+					fmt.Fprintf(stderr, "gc converge list: loading city config: %v\n", err) //nolint:errcheck
+					return errExit
+				}
+				rigs := make([]string, 0, len(cfg.Rigs))
+				rigPathByName := make(map[string]string, len(cfg.Rigs))
+				for i := range cfg.Rigs {
+					if strings.TrimSpace(cfg.Rigs[i].Path) == "" {
+						continue
+					}
+					rigs = append(rigs, cfg.Rigs[i].Name)
+					rigPathByName[cfg.Rigs[i].Name] = resolveStoreScopeRoot(rctx.CityPath, cfg.Rigs[i].Path)
+				}
+				sort.Strings(rigs)
+				for _, rig := range rigs {
+					store, err := openStoreAtForCity(rigPathByName[rig], rctx.CityPath)
+					if err != nil {
+						fmt.Fprintf(stderr, "gc converge list: rig %q: %v\n", rig, err) //nolint:errcheck
+						hadScopeError = true
+						continue
+					}
+					if err := appendEntries(rig, store); err != nil {
+						fmt.Fprintf(stderr, "gc converge list: rig %q: %v\n", rig, err) //nolint:errcheck
+						hadScopeError = true
+						continue
+					}
+				}
+			} else {
+				store, _, _, code := openConvergeStore(stderr, "gc converge list")
+				if code != 0 {
+					return errExit
+				}
+				if err := appendEntries("", store); err != nil {
+					fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
+					return errExit
+				}
 			}
 
 			if jsonOutput {
 				data, _ := json.MarshalIndent(entries, "", "  ")
 				fmt.Fprintln(stdout, string(data)) //nolint:errcheck
+				if hadScopeError {
+					return errExit
+				}
 				return nil
 			}
 
 			if len(entries) == 0 {
 				fmt.Fprintln(stdout, "No convergence loops found.") //nolint:errcheck
+				if hadScopeError {
+					return errExit
+				}
 				return nil
 			}
 
@@ -305,10 +369,14 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 				fmt.Fprintf(stdout, "%-14s %-10s %-10s %-10s %-26s %-16s %-16s %s\n", //nolint:errcheck
 					e.ID, e.State, e.Iteration, e.Gate, e.Formula, e.Target, e.Rig, e.Title)
 			}
+			if hadScopeError {
+				return errExit
+			}
 			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "Include closed/terminated loops")
+	cmd.Flags().BoolVar(&allRigs, "all-rigs", false, "List loops from city/HQ and every bound rig")
 	cmd.Flags().StringVar(&stateFilter, "state", "", "Filter by state (active, waiting_manual, terminated)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	return cmd
@@ -321,7 +389,7 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			beadID := args[0]
-			store, rctx, code := openConvergeStore(stderr, "gc converge test-gate")
+			store, rctx, storePath, code := openConvergeStore(stderr, "gc converge test-gate")
 			if code != 0 {
 				return errExit
 			}
@@ -363,6 +431,7 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 				MaxIterations: maxIter,
 				WispID:        meta[convergence.FieldActiveWisp],
 				CityPath:      cityPath,
+				StorePath:     storePath,
 				DocPath:       meta[convergence.VarPrefix+"doc_path"],
 			}
 
@@ -474,42 +543,43 @@ func convergeSocketCmd(beadID, command string, stdout, stderr io.Writer) error {
 // context it opens the city/HQ store; with a rig context it opens that
 // rig's store so rig-scoped convergence loops are visible. It also returns
 // the resolved context for callers that need the city path.
-func openConvergeStore(stderr io.Writer, cmdName string) (beads.Store, resolvedContext, int) {
+func openConvergeStore(stderr io.Writer, cmdName string) (beads.Store, resolvedContext, string, int) {
 	rctx, err := resolveContext()
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck
-		return nil, resolvedContext{}, 1
+		return nil, resolvedContext{}, "", 1
 	}
-	store, err := openContextStore(rctx)
+	storePath, err := convergeStorePathForContext(rctx)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck
-		return nil, resolvedContext{}, 1
+		return nil, resolvedContext{}, "", 1
 	}
-	return store, rctx, 0
+	store, err := openStoreAtForCity(storePath, rctx.CityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck
+		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck
+		return nil, resolvedContext{}, "", 1
+	}
+	return store, rctx, storePath, 0
 }
 
-// openContextStore opens the bead store for a resolved city+rig context:
-// the city/HQ store when RigName is empty, otherwise the named rig's
-// store. An unbound or unknown rig is an error so that --rig fails loudly
-// rather than silently falling back to city/HQ.
-func openContextStore(rctx resolvedContext) (beads.Store, error) {
+func convergeStorePathForContext(rctx resolvedContext) (string, error) {
 	if rctx.RigName == "" {
-		return openCityStoreAt(rctx.CityPath)
+		return rctx.CityPath, nil
 	}
 	cfg, err := loadCityConfig(rctx.CityPath, io.Discard)
 	if err != nil {
-		return nil, fmt.Errorf("loading city config: %w", err)
+		return "", fmt.Errorf("loading city config: %w", err)
 	}
 	for i := range cfg.Rigs {
 		if cfg.Rigs[i].Name != rctx.RigName {
 			continue
 		}
 		if strings.TrimSpace(cfg.Rigs[i].Path) == "" {
-			return nil, fmt.Errorf("rig %q is registered but has no rig path; "+
-				"convergence loops require a bound rig", rctx.RigName)
+			return "", unboundRigConvergenceError(rctx.RigName)
 		}
-		return openStoreAtForCity(cfg.Rigs[i].Path, rctx.CityPath)
+		return resolveStoreScopeRoot(rctx.CityPath, cfg.Rigs[i].Path), nil
 	}
-	return nil, fmt.Errorf("rig %q is not registered in this city", rctx.RigName)
+	return "", fmt.Errorf("rig %q is not registered in this city", rctx.RigName)
 }

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -52,13 +52,15 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Use:   "create",
 		Short: "Create a convergence loop",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cityPath, err := resolveCity()
+			rctx, err := resolveContext()
 			if err != nil {
 				fmt.Fprintf(stderr, "gc converge create: %v\n", err) //nolint:errcheck
 				return errExit
 			}
 
-			// Build params map.
+			// Build params map. "rig" carries the resolved --rig context
+			// so the controller creates the loop in the rig's bead store
+			// instead of silently writing it to city/HQ (issue #2357).
 			params := map[string]string{
 				"formula":             formula,
 				"target":              target,
@@ -69,6 +71,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 				"gate_timeout_action": gateTimeoutAction,
 				"title":               title,
 				"evaluate_prompt":     evaluatePrompt,
+				"rig":                 rctx.RigName,
 			}
 			for _, v := range vars {
 				parts := strings.SplitN(v, "=", 2)
@@ -84,7 +87,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 				User:    currentUsername(),
 				Params:  params,
 			}
-			reply, err := sendConvergenceRequest(cityPath, req)
+			reply, err := sendConvergenceRequest(rctx.CityPath, req)
 			if err != nil {
 				fmt.Fprintf(stderr, "gc converge create: %v\n", err) //nolint:errcheck
 				return errExit
@@ -127,7 +130,7 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			beadID := args[0]
-			store, code := openCityStore(stderr, "gc converge status")
+			store, _, code := openConvergeStore(stderr, "gc converge status")
 			if code != 0 {
 				return errExit
 			}
@@ -158,6 +161,7 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 			gateMode := meta[convergence.FieldGateMode]
 			formula := meta[convergence.FieldFormula]
 			target := meta[convergence.FieldTarget]
+			rig := meta[convergence.FieldRig]
 			gateOutcome := meta[convergence.FieldGateOutcome]
 			waitingReason := meta[convergence.FieldWaitingReason]
 			terminalReason := meta[convergence.FieldTerminalReason]
@@ -169,7 +173,10 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 			fmt.Fprintf(stdout, "Iteration:       %d/%d\n", iteration, maxIter) //nolint:errcheck
 			fmt.Fprintf(stdout, "Formula:         %s\n", formula)               //nolint:errcheck
 			fmt.Fprintf(stdout, "Target:          %s\n", target)                //nolint:errcheck
-			fmt.Fprintf(stdout, "Gate:            %s\n", gateMode)              //nolint:errcheck
+			if rig != "" {
+				fmt.Fprintf(stdout, "Rig:             %s\n", rig) //nolint:errcheck
+			}
+			fmt.Fprintf(stdout, "Gate:            %s\n", gateMode) //nolint:errcheck
 			if gateOutcome != "" {
 				fmt.Fprintf(stdout, "Gate Outcome:    %s\n", gateOutcome) //nolint:errcheck
 			}
@@ -195,7 +202,7 @@ func newConvergeApproveCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Approve and close a convergence loop (manual gate)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return convergeSocketCmd(args[0], "approve", nil, stdout, stderr)
+			return convergeSocketCmd(args[0], "approve", stdout, stderr)
 		},
 	}
 }
@@ -206,7 +213,7 @@ func newConvergeIterateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Force next iteration (manual gate)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return convergeSocketCmd(args[0], "iterate", nil, stdout, stderr)
+			return convergeSocketCmd(args[0], "iterate", stdout, stderr)
 		},
 	}
 }
@@ -217,7 +224,7 @@ func newConvergeStopCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Stop a convergence loop",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return convergeSocketCmd(args[0], "stop", nil, stdout, stderr)
+			return convergeSocketCmd(args[0], "stop", stdout, stderr)
 		},
 	}
 }
@@ -232,7 +239,7 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 		Use:   "list",
 		Short: "List convergence loops",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			store, code := openCityStore(stderr, "gc converge list")
+			store, _, code := openConvergeStore(stderr, "gc converge list")
 			if code != 0 {
 				return errExit
 			}
@@ -312,7 +319,7 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			beadID := args[0]
-			store, code := openCityStore(stderr, "gc converge test-gate")
+			store, rctx, code := openConvergeStore(stderr, "gc converge test-gate")
 			if code != 0 {
 				return errExit
 			}
@@ -345,7 +352,7 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 				return nil
 			}
 
-			cityPath, _ := resolveCity()
+			cityPath := rctx.CityPath
 			iter, _ := convergence.DecodeInt(meta[convergence.FieldIteration])
 			maxIter, _ := convergence.DecodeInt(meta[convergence.FieldMaxIterations])
 			env := convergence.ConditionEnv{
@@ -384,13 +391,15 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Retry a terminated convergence loop",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			cityPath, err := resolveCity()
+			rctx, err := resolveContext()
 			if err != nil {
 				fmt.Fprintf(stderr, "gc converge retry: %v\n", err) //nolint:errcheck
 				return errExit
 			}
 
-			params := map[string]string{}
+			// "rig" routes the retry to the same bead store as the source
+			// loop; the retry loop is created in that store.
+			params := map[string]string{"rig": rctx.RigName}
 			if maxIterations > 0 {
 				params["max_iterations"] = convergence.EncodeInt(maxIterations)
 			}
@@ -401,7 +410,7 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 				BeadID:  args[0],
 				Params:  params,
 			}
-			reply, err := sendConvergenceRequest(cityPath, req)
+			reply, err := sendConvergenceRequest(rctx.CityPath, req)
 			if err != nil {
 				fmt.Fprintf(stderr, "gc converge retry: %v\n", err) //nolint:errcheck
 				return errExit
@@ -425,9 +434,11 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 // convergeSocketCmd sends a simple convergence command (approve, iterate, stop)
-// through the controller socket and prints the result.
-func convergeSocketCmd(beadID, command string, params map[string]string, stdout, stderr io.Writer) error {
-	cityPath, err := resolveCity()
+// through the controller socket and prints the result. The resolved --rig
+// context is forwarded as the "rig" parameter so the command targets the
+// rig's bead store rather than always city/HQ.
+func convergeSocketCmd(beadID, command string, stdout, stderr io.Writer) error {
+	rctx, err := resolveContext()
 	if err != nil {
 		fmt.Fprintf(stderr, "gc converge %s: %v\n", command, err) //nolint:errcheck
 		return errExit
@@ -437,9 +448,9 @@ func convergeSocketCmd(beadID, command string, params map[string]string, stdout,
 		Command: command,
 		User:    currentUsername(),
 		BeadID:  beadID,
-		Params:  params,
+		Params:  map[string]string{"rig": rctx.RigName},
 	}
-	reply, err := sendConvergenceRequest(cityPath, req)
+	reply, err := sendConvergenceRequest(rctx.CityPath, req)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc converge %s: %v\n", command, err) //nolint:errcheck
 		return errExit
@@ -454,4 +465,49 @@ func convergeSocketCmd(beadID, command string, params map[string]string, stdout,
 		fmt.Fprintf(stdout, "%s: %s\n", beadID, result.Action) //nolint:errcheck
 	}
 	return nil
+}
+
+// openConvergeStore opens the bead store for a read-side converge
+// subcommand (status, list, test-gate), honoring --rig. With no rig
+// context it opens the city/HQ store; with a rig context it opens that
+// rig's store so rig-scoped convergence loops are visible. It also returns
+// the resolved context for callers that need the city path.
+func openConvergeStore(stderr io.Writer, cmdName string) (beads.Store, resolvedContext, int) {
+	rctx, err := resolveContext()
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck
+		return nil, resolvedContext{}, 1
+	}
+	store, err := openContextStore(rctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck
+		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck
+		return nil, resolvedContext{}, 1
+	}
+	return store, rctx, 0
+}
+
+// openContextStore opens the bead store for a resolved city+rig context:
+// the city/HQ store when RigName is empty, otherwise the named rig's
+// store. An unbound or unknown rig is an error so that --rig fails loudly
+// rather than silently falling back to city/HQ.
+func openContextStore(rctx resolvedContext) (beads.Store, error) {
+	if rctx.RigName == "" {
+		return openCityStoreAt(rctx.CityPath)
+	}
+	cfg, err := loadCityConfig(rctx.CityPath, io.Discard)
+	if err != nil {
+		return nil, fmt.Errorf("loading city config: %w", err)
+	}
+	for i := range cfg.Rigs {
+		if cfg.Rigs[i].Name != rctx.RigName {
+			continue
+		}
+		if strings.TrimSpace(cfg.Rigs[i].Path) == "" {
+			return nil, fmt.Errorf("rig %q is registered but unbound (no rig path); "+
+				"convergence loops require a bound rig", rctx.RigName)
+		}
+		return openStoreAtForCity(cfg.Rigs[i].Path, rctx.CityPath)
+	}
+	return nil, fmt.Errorf("rig %q not found in city configuration", rctx.RigName)
 }

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -260,6 +260,7 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 				Gate      string `json:"gate"`
 				Formula   string `json:"formula"`
 				Target    string `json:"target"`
+				Rig       string `json:"rig"`
 				Title     string `json:"title"`
 			}
 			var entries []convEntry
@@ -281,6 +282,7 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 					Gate:      meta[convergence.FieldGateMode],
 					Formula:   meta[convergence.FieldFormula],
 					Target:    meta[convergence.FieldTarget],
+					Rig:       meta[convergence.FieldRig],
 					Title:     b.Title,
 				})
 			}
@@ -296,12 +298,12 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 				return nil
 			}
 
-			// Table output.
-			fmt.Fprintf(stdout, "%-14s %-10s %-10s %-10s %-26s %-16s %s\n", //nolint:errcheck
-				"ID", "STATE", "ITERATION", "GATE", "FORMULA", "TARGET", "TITLE")
+			// Table output. The RIG column is empty for city/HQ-scoped loops.
+			fmt.Fprintf(stdout, "%-14s %-10s %-10s %-10s %-26s %-16s %-16s %s\n", //nolint:errcheck
+				"ID", "STATE", "ITERATION", "GATE", "FORMULA", "TARGET", "RIG", "TITLE")
 			for _, e := range entries {
-				fmt.Fprintf(stdout, "%-14s %-10s %-10s %-10s %-26s %-16s %s\n", //nolint:errcheck
-					e.ID, e.State, e.Iteration, e.Gate, e.Formula, e.Target, e.Title)
+				fmt.Fprintf(stdout, "%-14s %-10s %-10s %-10s %-26s %-16s %-16s %s\n", //nolint:errcheck
+					e.ID, e.State, e.Iteration, e.Gate, e.Formula, e.Target, e.Rig, e.Title)
 			}
 			return nil
 		},
@@ -504,10 +506,10 @@ func openContextStore(rctx resolvedContext) (beads.Store, error) {
 			continue
 		}
 		if strings.TrimSpace(cfg.Rigs[i].Path) == "" {
-			return nil, fmt.Errorf("rig %q is registered but unbound (no rig path); "+
+			return nil, fmt.Errorf("rig %q is registered but has no rig path; "+
 				"convergence loops require a bound rig", rctx.RigName)
 		}
 		return openStoreAtForCity(cfg.Rigs[i].Path, rctx.CityPath)
 	}
-	return nil, fmt.Errorf("rig %q not found in city configuration", rctx.RigName)
+	return nil, fmt.Errorf("rig %q is not registered in this city", rctx.RigName)
 }

--- a/cmd/gc/cmd_converge_test.go
+++ b/cmd/gc/cmd_converge_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/convergence"
@@ -21,4 +24,35 @@ func TestConvergeCreateGateTimeoutDefaultMatchesSharedDefault(t *testing.T) {
 	if got := flag.Value.String(); got != want {
 		t.Fatalf("gate-timeout bound value = %q, want %q", got, want)
 	}
+}
+
+func TestOpenContextStore_RigErrors(t *testing.T) {
+	cityDir := t.TempDir()
+	cityToml := "[workspace]\nname = \"convtest\"\n\n" +
+		"[beads]\nprovider = \"file\"\n\n" +
+		"[session]\nprovider = \"fake\"\n\n" +
+		"[[rigs]]\nname = \"unbound-rig\"\n"
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	t.Run("unknown rig", func(t *testing.T) {
+		_, err := openContextStore(resolvedContext{CityPath: cityDir, RigName: "ghost-rig"})
+		if err == nil {
+			t.Fatal("expected error for an unregistered rig")
+		}
+		if !strings.Contains(err.Error(), "ghost-rig") || !strings.Contains(err.Error(), "not registered") {
+			t.Errorf("error = %q, want it to name the rig and say it is not registered", err)
+		}
+	})
+
+	t.Run("unbound rig", func(t *testing.T) {
+		_, err := openContextStore(resolvedContext{CityPath: cityDir, RigName: "unbound-rig"})
+		if err == nil {
+			t.Fatal("expected error for a registered but unbound rig")
+		}
+		if !strings.Contains(err.Error(), "unbound-rig") || !strings.Contains(err.Error(), "no rig path") {
+			t.Errorf("error = %q, want it to name the rig and mention the missing path", err)
+		}
+	})
 }

--- a/cmd/gc/cmd_converge_test.go
+++ b/cmd/gc/cmd_converge_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/convergence"
 )
 
@@ -26,7 +30,249 @@ func TestConvergeCreateGateTimeoutDefaultMatchesSharedDefault(t *testing.T) {
 	}
 }
 
-func TestOpenContextStore_RigErrors(t *testing.T) {
+func TestConvergeListAllRigsAggregatesCityAndRigStores(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("creating rig dir: %v", err)
+	}
+	cityToml := "[workspace]\nname = \"convtest\"\n\n" +
+		"[beads]\nprovider = \"file\"\n\n" +
+		"[session]\nprovider = \"fake\"\n\n" +
+		"[[rigs]]\nname = \"frontend\"\npath = " + strconv.Quote(rigDir) + "\n"
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensuring scoped file store layout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensuring city file store: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensuring rig file store: %v", err)
+	}
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open city store: %v", err)
+	}
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("open rig store: %v", err)
+	}
+	createConvergeListTestBead(t, cityStore, "city loop", "")
+	createConvergeListTestBead(t, rigStore, "rig loop", "frontend")
+
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
+	})
+	t.Setenv("GC_CITY", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newConvergeListCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"--all-rigs", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	var entries []struct {
+		ID    string `json:"id"`
+		Rig   string `json:"rig"`
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout.String(), err)
+	}
+	got := map[string]string{}
+	for _, entry := range entries {
+		got[entry.Title] = entry.Rig
+	}
+	if got["city loop"] != "" {
+		t.Fatalf("city bead rig = %q, want empty", got["city loop"])
+	}
+	if got["rig loop"] != "frontend" {
+		t.Fatalf("rig bead rig = %q, want frontend", got["rig loop"])
+	}
+}
+
+func TestConvergeListAllRigsContinuesAfterRigStoreError(t *testing.T) {
+	cityDir := t.TempDir()
+	brokenRigPath := filepath.Join(cityDir, "rigs", "broken")
+	frontendRigPath := filepath.Join(cityDir, "rigs", "frontend")
+	if err := os.MkdirAll(filepath.Dir(brokenRigPath), 0o755); err != nil {
+		t.Fatalf("creating rigs dir: %v", err)
+	}
+	if err := os.WriteFile(brokenRigPath, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("creating broken rig path: %v", err)
+	}
+	if err := os.MkdirAll(frontendRigPath, 0o755); err != nil {
+		t.Fatalf("creating frontend rig dir: %v", err)
+	}
+	cityToml := "[workspace]\nname = \"convtest\"\n\n" +
+		"[beads]\nprovider = \"file\"\n\n" +
+		"[session]\nprovider = \"fake\"\n\n" +
+		"[[rigs]]\nname = \"broken\"\npath = " + strconv.Quote(brokenRigPath) + "\n\n" +
+		"[[rigs]]\nname = \"frontend\"\npath = " + strconv.Quote(frontendRigPath) + "\n"
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensuring scoped file store layout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensuring city file store: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(frontendRigPath); err != nil {
+		t.Fatalf("ensuring frontend rig file store: %v", err)
+	}
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open city store: %v", err)
+	}
+	frontendStore, err := openStoreAtForCity(frontendRigPath, cityDir)
+	if err != nil {
+		t.Fatalf("open frontend store: %v", err)
+	}
+	createConvergeListTestBead(t, cityStore, "city loop", "")
+	createConvergeListTestBead(t, frontendStore, "frontend loop", "frontend")
+
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
+	})
+	t.Setenv("GC_CITY", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newConvergeListCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"--all-rigs", "--json"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute returned nil, want non-zero error for broken rig")
+	}
+	if !strings.Contains(stderr.String(), `rig "broken"`) {
+		t.Fatalf("stderr = %q, want per-rig error", stderr.String())
+	}
+	var entries []struct {
+		Rig   string `json:"rig"`
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout.String(), err)
+	}
+	got := map[string]string{}
+	for _, entry := range entries {
+		got[entry.Title] = entry.Rig
+	}
+	if _, ok := got["city loop"]; !ok {
+		t.Fatalf("city loop missing from output after broken rig: %#v", got)
+	}
+	if got["frontend loop"] != "frontend" {
+		t.Fatalf("frontend loop rig = %q, want frontend", got["frontend loop"])
+	}
+}
+
+func TestConvergeListAllRigsAppliesStateFilterAcrossScopes(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("creating rig dir: %v", err)
+	}
+	cityToml := "[workspace]\nname = \"convtest\"\n\n" +
+		"[beads]\nprovider = \"file\"\n\n" +
+		"[session]\nprovider = \"fake\"\n\n" +
+		"[[rigs]]\nname = \"frontend\"\npath = " + strconv.Quote(rigDir) + "\n"
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensuring scoped file store layout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensuring city file store: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensuring rig file store: %v", err)
+	}
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open city store: %v", err)
+	}
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("open rig store: %v", err)
+	}
+	createConvergeListTestBeadWithState(t, cityStore, "city active", "", convergence.StateActive)
+	createConvergeListTestBeadWithState(t, rigStore, "rig active", "frontend", convergence.StateActive)
+	createConvergeListTestBeadWithState(t, cityStore, "city waiting", "", convergence.StateWaitingManual)
+	createConvergeListTestBeadWithState(t, rigStore, "rig terminated", "frontend", convergence.StateTerminated)
+
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
+	})
+	t.Setenv("GC_CITY", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newConvergeListCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"--all-rigs", "--state", convergence.StateActive, "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	var entries []struct {
+		Title string `json:"title"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout.String(), err)
+	}
+	got := map[string]string{}
+	for _, entry := range entries {
+		got[entry.Title] = entry.State
+	}
+	if len(got) != 2 {
+		t.Fatalf("got entries %#v, want only two active loops", got)
+	}
+	for _, title := range []string{"city active", "rig active"} {
+		if got[title] != convergence.StateActive {
+			t.Fatalf("%s state = %q, want active; all entries %#v", title, got[title], got)
+		}
+	}
+}
+
+func createConvergeListTestBead(t *testing.T, store beads.Store, title, rig string) {
+	t.Helper()
+	createConvergeListTestBeadWithState(t, store, title, rig, convergence.StateActive)
+}
+
+func createConvergeListTestBeadWithState(t *testing.T, store beads.Store, title, rig, state string) {
+	t.Helper()
+	bead, err := store.Create(beads.Bead{Title: title, Type: "convergence", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("creating convergence bead: %v", err)
+	}
+	for key, value := range map[string]string{
+		convergence.FieldState:         state,
+		convergence.FieldIteration:     "1",
+		convergence.FieldMaxIterations: "2",
+		convergence.FieldGateMode:      convergence.GateModeManual,
+		convergence.FieldFormula:       "test-formula",
+		convergence.FieldTarget:        "test-agent",
+		convergence.FieldRig:           rig,
+	} {
+		if err := store.SetMetadata(bead.ID, key, value); err != nil {
+			t.Fatalf("setting %s: %v", key, err)
+		}
+	}
+}
+
+func TestConvergeStorePathForContext_RigErrors(t *testing.T) {
 	cityDir := t.TempDir()
 	cityToml := "[workspace]\nname = \"convtest\"\n\n" +
 		"[beads]\nprovider = \"file\"\n\n" +
@@ -37,7 +283,7 @@ func TestOpenContextStore_RigErrors(t *testing.T) {
 	}
 
 	t.Run("unknown rig", func(t *testing.T) {
-		_, err := openContextStore(resolvedContext{CityPath: cityDir, RigName: "ghost-rig"})
+		_, err := convergeStorePathForContext(resolvedContext{CityPath: cityDir, RigName: "ghost-rig"})
 		if err == nil {
 			t.Fatal("expected error for an unregistered rig")
 		}
@@ -47,12 +293,87 @@ func TestOpenContextStore_RigErrors(t *testing.T) {
 	})
 
 	t.Run("unbound rig", func(t *testing.T) {
-		_, err := openContextStore(resolvedContext{CityPath: cityDir, RigName: "unbound-rig"})
+		_, err := convergeStorePathForContext(resolvedContext{CityPath: cityDir, RigName: "unbound-rig"})
 		if err == nil {
 			t.Fatal("expected error for a registered but unbound rig")
 		}
-		if !strings.Contains(err.Error(), "unbound-rig") || !strings.Contains(err.Error(), "no rig path") {
-			t.Errorf("error = %q, want it to name the rig and mention the missing path", err)
+		if !strings.Contains(err.Error(), "unbound-rig") || !strings.Contains(err.Error(), "no bead store") {
+			t.Errorf("error = %q, want it to name the rig and mention the missing bead store", err)
 		}
 	})
+}
+
+func TestConvergeTestGateUsesRigStorePath(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("creating rig dir: %v", err)
+	}
+	cityToml := "[workspace]\nname = \"convtest\"\n\n" +
+		"[beads]\nprovider = \"file\"\n\n" +
+		"[session]\nprovider = \"fake\"\n\n" +
+		"[[rigs]]\nname = \"frontend\"\npath = " + strconv.Quote(rigDir) + "\n"
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensuring scoped file store layout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensuring rig file store: %v", err)
+	}
+	store, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	bead, err := store.Create(beads.Bead{Title: "gate", Type: "convergence", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("creating convergence bead: %v", err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "beads-dir.txt")
+	scriptPath := filepath.Join(t.TempDir(), "gate.sh")
+	script := "#!/bin/sh\nprintf '%s' \"$BEADS_DIR\" > " + strconv.Quote(outputPath) + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing gate script: %v", err)
+	}
+	for key, value := range map[string]string{
+		convergence.FieldState:             convergence.StateActive,
+		convergence.FieldGateMode:          convergence.GateModeCondition,
+		convergence.FieldGateCondition:     scriptPath,
+		convergence.FieldGateTimeout:       convergence.DefaultGateTimeout.String(),
+		convergence.FieldGateTimeoutAction: convergence.TimeoutActionIterate,
+		convergence.FieldIteration:         "1",
+		convergence.FieldMaxIterations:     "2",
+		convergence.FieldActiveWisp:        "wisp-1",
+		convergence.FieldCityPath:          cityDir,
+		convergence.FieldRig:               "frontend",
+	} {
+		if err := store.SetMetadata(bead.ID, key, value); err != nil {
+			t.Fatalf("setting %s: %v", key, err)
+		}
+	}
+
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
+	cityFlag, rigFlag = "", ""
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
+	})
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_RIG", "frontend")
+
+	var stdout, stderr bytes.Buffer
+	cmd := newConvergeTestGateCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{bead.ID})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v\nstderr:\n%s", err, stderr.String())
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("reading gate output: %v", err)
+	}
+	if got, want := string(data), filepath.Join(rigDir, ".beads"); got != want {
+		t.Fatalf("BEADS_DIR = %q, want %q\nstdout:\n%s", got, want, stdout.String())
+	}
 }

--- a/cmd/gc/convergence_integration_test.go
+++ b/cmd/gc/convergence_integration_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -50,7 +52,7 @@ func setupConvergenceRuntime(t *testing.T) (*CityRuntime, *beads.MemStore) {
 
 	// Initialize the city/HQ convergence scope (mimics initConvergenceHandler).
 	cr.convScopes = map[string]*convergenceScope{
-		"": cr.newConvergenceScope("", store, []string{sharedTestFormulaDir}),
+		"": cr.newConvergenceScope("", store, cr.cityPath, []string{sharedTestFormulaDir}),
 	}
 
 	return cr, store
@@ -70,9 +72,42 @@ func hqScope(t *testing.T, cr *CityRuntime) *convergenceScope {
 // addConvergenceRigScope attaches a rig-scoped convergence scope backed by
 // the given store, mimicking initConvergenceHandler's per-rig wiring.
 func addConvergenceRigScope(cr *CityRuntime, rig string, store beads.Store) *convergenceScope {
-	scope := cr.newConvergenceScope(rig, store, []string{sharedTestFormulaDir})
+	return addConvergenceRigScopeAt(cr, rig, store, filepath.Join(cr.cityPath, "rigs", rig))
+}
+
+func addConvergenceRigScopeAt(cr *CityRuntime, rig string, store beads.Store, storePath string) *convergenceScope {
+	scope := cr.newConvergenceScope(rig, store, storePath, []string{sharedTestFormulaDir})
 	cr.convScopes[rig] = scope
+	if cr.cfg != nil {
+		found := false
+		for i := range cr.cfg.Rigs {
+			if cr.cfg.Rigs[i].Name == rig {
+				found = true
+				break
+			}
+		}
+		if !found {
+			cr.cfg.Rigs = append(cr.cfg.Rigs, config.Rig{Name: rig, Path: storePath})
+		}
+	}
 	return scope
+}
+
+type convergenceListErrorStore struct {
+	beads.Store
+	err error
+}
+
+func (s convergenceListErrorStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return nil, s.err
+}
+
+type getPanicStore struct {
+	beads.Store
+}
+
+func (s getPanicStore) Get(string) (beads.Bead, error) {
+	panic("injected convergence store get panic")
 }
 
 // sendAndReceive sends a convergence request via handleConvergenceRequest
@@ -447,6 +482,400 @@ func TestConvergence_StartupReconcileCoversRigScopes(t *testing.T) {
 	}
 	if hqScope(t, cr).adapter.activeIndex == nil {
 		t.Error("city scope active index should be populated after startup reconcile")
+	}
+}
+
+func TestConvergence_GateConditionUsesRigStorePath(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	rigStore := beads.NewMemStore()
+	rigPath := filepath.Join(cr.cityPath, "rigs", "gascity-prod")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("creating rig path: %v", err)
+	}
+	rigScope := addConvergenceRigScopeAt(cr, "gascity-prod", rigStore, rigPath)
+
+	outputPath := filepath.Join(t.TempDir(), "beads-dir.txt")
+	scriptPath := filepath.Join(t.TempDir(), "gate.sh")
+	script := "#!/bin/sh\nprintf '%s' \"$BEADS_DIR\" > " + strconv.Quote(outputPath) + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing gate script: %v", err)
+	}
+
+	createReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula":        "test-formula",
+			"target":         "test-agent",
+			"max_iterations": "2",
+			"gate_mode":      convergence.GateModeCondition,
+			"gate_condition": scriptPath,
+			"rig":            "gascity-prod",
+		},
+	})
+	if createReply.Error != "" {
+		t.Fatalf("create error: %s", createReply.Error)
+	}
+	var created convergence.CreateResult
+	if err := json.Unmarshal(createReply.Result, &created); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+	if err := rigScope.adapter.populateIndex(); err != nil {
+		t.Fatalf("populateIndex: %v", err)
+	}
+	if err := rigStore.Close(created.FirstWispID); err != nil {
+		t.Fatalf("closing wisp: %v", err)
+	}
+
+	cr.convergenceTick(context.Background())
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("reading gate output: %v", err)
+	}
+	if got, want := string(data), filepath.Join(rigPath, ".beads"); got != want {
+		t.Fatalf("BEADS_DIR = %q, want %q", got, want)
+	}
+}
+
+func TestConvergence_TickIsolatesPanickingScope(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	cr.convScopes[""] = cr.newConvergenceScope("", getPanicStore{Store: beads.NewMemStore()}, cr.cityPath, []string{sharedTestFormulaDir})
+	hqScope(t, cr).adapter.activeIndex = map[string]string{"panic-root": "test-agent"}
+
+	rigStore := beads.NewMemStore()
+	rigScope := addConvergenceRigScope(cr, "healthy-rig", rigStore)
+	createReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula":        "test-formula",
+			"target":         "test-agent",
+			"max_iterations": "5",
+			"rig":            "healthy-rig",
+		},
+	})
+	if createReply.Error != "" {
+		t.Fatalf("create error: %s", createReply.Error)
+	}
+	var created convergence.CreateResult
+	if err := json.Unmarshal(createReply.Result, &created); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+	if err := rigScope.adapter.populateIndex(); err != nil {
+		t.Fatalf("populateIndex: %v", err)
+	}
+	if err := rigStore.Close(created.FirstWispID); err != nil {
+		t.Fatalf("closing wisp: %v", err)
+	}
+
+	cr.convergenceTick(context.Background())
+
+	bead, err := rigStore.Get(created.BeadID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if state := bead.Metadata[convergence.FieldState]; state != convergence.StateWaitingManual {
+		t.Fatalf("healthy rig state = %q, want %q", state, convergence.StateWaitingManual)
+	}
+}
+
+func TestConvergence_StartupReconcileMarksFailedScopeComplete(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	cr.convScopes[""] = cr.newConvergenceScope("", convergenceListErrorStore{
+		Store: beads.NewMemStore(),
+		err:   errors.New("injected list failure"),
+	}, cr.cityPath, []string{sharedTestFormulaDir})
+
+	rigStore := beads.NewMemStore()
+	rigScope := addConvergenceRigScope(cr, "healthy-rig", rigStore)
+	b, err := rigStore.Create(beads.Bead{Title: "interrupted", Type: "convergence", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("creating bead: %v", err)
+	}
+	if err := rigStore.SetMetadata(b.ID, convergence.FieldState, convergence.StateCreating); err != nil {
+		t.Fatalf("setting state: %v", err)
+	}
+
+	cr.convergenceStartupReconcile(context.Background())
+
+	if !convergenceStartupComplete(cr) {
+		t.Fatal("startup should be complete after isolating the failed scope")
+	}
+	if rigScope.adapter.activeIndex == nil {
+		t.Fatal("healthy rig active index should be populated")
+	}
+	updated, err := rigStore.Get(b.ID)
+	if err != nil {
+		t.Fatalf("getting bead: %v", err)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("healthy rig interrupted bead status = %q, want closed", updated.Status)
+	}
+}
+
+func TestConvergence_StartupReconcileRetriesFailedScopeOnTick(t *testing.T) {
+	cr, store := setupConvergenceRuntime(t)
+	hqScope(t, cr).store = convergenceListErrorStore{
+		Store: store,
+		err:   errors.New("injected list failure"),
+	}
+
+	b, err := store.Create(beads.Bead{Title: "active", Type: "convergence", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("creating bead: %v", err)
+	}
+	for key, value := range map[string]string{
+		convergence.FieldState:  convergence.StateActive,
+		convergence.FieldTarget: "test-agent",
+	} {
+		if err := store.SetMetadata(b.ID, key, value); err != nil {
+			t.Fatalf("setting %s: %v", key, err)
+		}
+	}
+
+	cr.convergenceStartupReconcile(context.Background())
+
+	if !convergenceStartupComplete(cr) {
+		t.Fatal("startup should complete after isolating the failed scope")
+	}
+	scope := hqScope(t, cr)
+	if !scope.needsStartupReconcile {
+		t.Fatal("failed scope should remain eligible for later startup reconcile retry")
+	}
+	if _, ok := scope.adapter.activeIndex[b.ID]; ok {
+		t.Fatal("failed startup reconcile should not make active bead visible until retry succeeds")
+	}
+
+	scope.store = store
+	cr.convergenceTick(context.Background())
+
+	if scope.needsStartupReconcile {
+		t.Fatal("successful tick retry should clear startup reconcile retry marker")
+	}
+	if got := scope.adapter.activeIndex[b.ID]; got != "test-agent" {
+		t.Fatalf("active index[%s] = %q, want test-agent", b.ID, got)
+	}
+}
+
+func TestConvergenceScopeForRigRejectsStaleCachedScope(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, cr *CityRuntime)
+		wantError string
+	}{
+		{
+			name: "cached rig path changed",
+			setup: func(t *testing.T, cr *CityRuntime) {
+				t.Helper()
+				oldPath := filepath.Join(cr.cityPath, "rigs", "prod-old")
+				newPath := filepath.Join(cr.cityPath, "rigs", "prod-new")
+				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
+				addConvergenceRigScopeAt(cr, "prod", beads.NewMemStore(), oldPath)
+				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: newPath}}
+			},
+			wantError: "changed after config reload",
+		},
+		{
+			name: "cached rig became unbound",
+			setup: func(t *testing.T, cr *CityRuntime) {
+				t.Helper()
+				oldPath := filepath.Join(cr.cityPath, "rigs", "prod")
+				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
+				addConvergenceRigScopeAt(cr, "prod", beads.NewMemStore(), oldPath)
+				cr.cfg.Rigs = []config.Rig{{Name: "prod"}}
+			},
+			wantError: "became unbound after config reload",
+		},
+		{
+			name: "cached rig removed",
+			setup: func(t *testing.T, cr *CityRuntime) {
+				t.Helper()
+				oldPath := filepath.Join(cr.cityPath, "rigs", "prod")
+				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
+				addConvergenceRigScopeAt(cr, "prod", beads.NewMemStore(), oldPath)
+				cr.cfg.Rigs = nil
+			},
+			wantError: "was removed from city config",
+		},
+		{
+			name: "bound rig lacks cached scope",
+			setup: func(t *testing.T, cr *CityRuntime) {
+				t.Helper()
+				path := filepath.Join(cr.cityPath, "rigs", "prod")
+				cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: path}}
+			},
+			wantError: "is bound but convergence scopes were not rebuilt",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cr, _ := setupConvergenceRuntime(t)
+			tc.setup(t, cr)
+
+			scope, err := cr.convergenceScopeForRig("prod")
+			if err == nil {
+				t.Fatal("expected stale cached scope error")
+			}
+			if scope != nil {
+				t.Fatalf("scope = %#v, want nil", scope)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("error = %q, want diagnostic containing %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestConvergenceTickSkipsStaleCachedRigScope(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	rigStore := beads.NewMemStore()
+	oldPath := filepath.Join(cr.cityPath, "rigs", "prod-old")
+	newPath := filepath.Join(cr.cityPath, "rigs", "prod-new")
+	cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
+	rigScope := addConvergenceRigScopeAt(cr, "prod", rigStore, oldPath)
+
+	createReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula":        "test-formula",
+			"target":         "test-agent",
+			"max_iterations": "5",
+			"rig":            "prod",
+		},
+	})
+	if createReply.Error != "" {
+		t.Fatalf("create error: %s", createReply.Error)
+	}
+	var created convergence.CreateResult
+	if err := json.Unmarshal(createReply.Result, &created); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+	if err := rigScope.adapter.populateIndex(); err != nil {
+		t.Fatalf("populateIndex: %v", err)
+	}
+	if err := rigStore.Close(created.FirstWispID); err != nil {
+		t.Fatalf("closing wisp: %v", err)
+	}
+	cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: newPath}}
+
+	cr.convergenceTick(context.Background())
+
+	meta, err := rigScope.handler.Store.GetMetadata(created.BeadID)
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	if got := meta[convergence.FieldState]; got != convergence.StateActive {
+		t.Fatalf("state after stale-scope tick = %q, want %q", got, convergence.StateActive)
+	}
+	if !strings.Contains(cr.stderr.(*bytes.Buffer).String(), "changed after config reload") {
+		t.Fatalf("stderr = %q, want stale-scope diagnostic", cr.stderr.(*bytes.Buffer).String())
+	}
+}
+
+func TestConvergenceStartupReconcileSkipsRemovedRigScope(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	rigStore := beads.NewMemStore()
+	oldPath := filepath.Join(cr.cityPath, "rigs", "prod")
+	cr.cfg.Rigs = []config.Rig{{Name: "prod", Path: oldPath}}
+	addConvergenceRigScopeAt(cr, "prod", rigStore, oldPath)
+
+	b, err := rigStore.Create(beads.Bead{Title: "terminated", Type: "convergence", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("creating bead: %v", err)
+	}
+	for key, value := range map[string]string{
+		convergence.FieldState:          convergence.StateTerminated,
+		convergence.FieldTerminalReason: convergence.TerminalApproved,
+		convergence.FieldTerminalActor:  "controller",
+	} {
+		if err := rigStore.SetMetadata(b.ID, key, value); err != nil {
+			t.Fatalf("setting %s: %v", key, err)
+		}
+	}
+	cr.cfg.Rigs = nil
+
+	cr.convergenceStartupReconcile(context.Background())
+
+	got, err := rigStore.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status after stale-scope startup reconcile = %q, want unclosed", got.Status)
+	}
+	if !strings.Contains(cr.stderr.(*bytes.Buffer).String(), "was removed from city config") {
+		t.Fatalf("stderr = %q, want removed-rig diagnostic", cr.stderr.(*bytes.Buffer).String())
+	}
+}
+
+func TestConvergence_LifecycleCommandsRouteToRigScope(t *testing.T) {
+	commands := []struct {
+		name      string
+		wantState string
+	}{
+		{name: "stop", wantState: convergence.StateTerminated},
+		{name: "approve", wantState: convergence.StateTerminated},
+		{name: "iterate", wantState: convergence.StateActive},
+	}
+
+	for _, tc := range commands {
+		t.Run(tc.name, func(t *testing.T) {
+			cr, _ := setupConvergenceRuntime(t)
+			rigStore := beads.NewMemStore()
+			rigScope := addConvergenceRigScope(cr, "gascity-prod", rigStore)
+
+			createReply := sendAndReceive(t, cr, convergenceRequest{
+				Command: "create",
+				Params: map[string]string{
+					"formula":        "test-formula",
+					"target":         "test-agent",
+					"max_iterations": "5",
+					"rig":            "gascity-prod",
+				},
+			})
+			if createReply.Error != "" {
+				t.Fatalf("create error: %s", createReply.Error)
+			}
+			var created convergence.CreateResult
+			if err := json.Unmarshal(createReply.Result, &created); err != nil {
+				t.Fatalf("unmarshaling: %v", err)
+			}
+			if tc.name == "approve" || tc.name == "iterate" {
+				if err := rigScope.adapter.populateIndex(); err != nil {
+					t.Fatalf("populateIndex: %v", err)
+				}
+				if err := rigStore.Close(created.FirstWispID); err != nil {
+					t.Fatalf("closing wisp: %v", err)
+				}
+				cr.convergenceTick(context.Background())
+			}
+
+			noRigReply := sendAndReceive(t, cr, convergenceRequest{
+				Command: tc.name,
+				BeadID:  created.BeadID,
+				User:    "test-operator",
+			})
+			if noRigReply.Error == "" {
+				t.Fatalf("%s without --rig should not find the rig-scoped loop", tc.name)
+			}
+
+			reply := sendAndReceive(t, cr, convergenceRequest{
+				Command: tc.name,
+				BeadID:  created.BeadID,
+				User:    "test-operator",
+				Params:  map[string]string{"rig": "gascity-prod"},
+			})
+			if reply.Error != "" {
+				t.Fatalf("%s error: %s", tc.name, reply.Error)
+			}
+			bead, err := rigStore.Get(created.BeadID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if state := bead.Metadata[convergence.FieldState]; state != tc.wantState {
+				t.Fatalf("state after %s = %q, want %q", tc.name, state, tc.wantState)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/convergence_integration_test.go
+++ b/cmd/gc/convergence_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,16 +48,31 @@ func setupConvergenceRuntime(t *testing.T) (*CityRuntime, *beads.MemStore) {
 		stderr:              &bytes.Buffer{},
 	}
 
-	// Initialize convergence handler (mimics initConvergenceHandler).
-	adapter := newConvergenceStoreAdapter(store, []string{sharedTestFormulaDir})
-	emitter := &convergenceEventEmitter{rec: cr.rec}
-	cr.convStoreAdapter = adapter
-	cr.convHandler = &convergence.Handler{
-		Store:   adapter,
-		Emitter: emitter,
+	// Initialize the city/HQ convergence scope (mimics initConvergenceHandler).
+	cr.convScopes = map[string]*convergenceScope{
+		"": cr.newConvergenceScope("", store, []string{sharedTestFormulaDir}),
 	}
 
 	return cr, store
+}
+
+// hqScope returns the city/HQ convergence scope from a test runtime,
+// failing the test if convergence was not initialized.
+func hqScope(t *testing.T, cr *CityRuntime) *convergenceScope {
+	t.Helper()
+	scope := cr.convScopes[""]
+	if scope == nil {
+		t.Fatal("city/HQ convergence scope not initialized")
+	}
+	return scope
+}
+
+// addConvergenceRigScope attaches a rig-scoped convergence scope backed by
+// the given store, mimicking initConvergenceHandler's per-rig wiring.
+func addConvergenceRigScope(cr *CityRuntime, rig string, store beads.Store) *convergenceScope {
+	scope := cr.newConvergenceScope(rig, store, []string{sharedTestFormulaDir})
+	cr.convScopes[rig] = scope
+	return scope
 }
 
 // sendAndReceive sends a convergence request via handleConvergenceRequest
@@ -126,7 +142,7 @@ func TestConvergence_StopCommand(t *testing.T) {
 	}
 
 	// Verify state is terminated.
-	meta, err := cr.convHandler.Store.GetMetadata(created.BeadID)
+	meta, err := hqScope(t, cr).handler.Store.GetMetadata(created.BeadID)
 	if err != nil {
 		t.Fatalf("GetMetadata: %v", err)
 	}
@@ -149,10 +165,10 @@ func TestConvergence_UnknownCommand(t *testing.T) {
 func TestConvergence_PanicRecovery(t *testing.T) {
 	cr, _ := setupConvergenceRuntime(t)
 
-	// Temporarily replace convHandler with nil to cause a panic
-	// when handleConvergenceRequest tries to access it for "approve".
-	savedHandler := cr.convHandler
-	cr.convHandler = nil
+	// Clear convScopes so handleConvergenceRequest hits the
+	// "convergence not available" guard for "approve".
+	savedScopes := cr.convScopes
+	cr.convScopes = nil
 
 	reply := cr.safeHandleConvergenceRequest(context.Background(), convergenceRequest{
 		Command: "approve",
@@ -160,10 +176,10 @@ func TestConvergence_PanicRecovery(t *testing.T) {
 	})
 	// safeHandleConvergenceRequest should return error, not panic.
 	if reply.Error == "" {
-		t.Error("expected error reply from nil handler")
+		t.Error("expected error reply when convergence is unavailable")
 	}
 
-	cr.convHandler = savedHandler
+	cr.convScopes = savedScopes
 }
 
 func TestConvergence_TickProcessesClosedWisp(t *testing.T) {
@@ -187,7 +203,7 @@ func TestConvergence_TickProcessesClosedWisp(t *testing.T) {
 	}
 
 	// Populate the active index so convergenceTick works.
-	adapter := cr.convHandler.Store.(*convergenceStoreAdapter)
+	adapter := hqScope(t, cr).adapter
 	if err := adapter.populateIndex(); err != nil {
 		t.Fatalf("populateIndex: %v", err)
 	}
@@ -202,7 +218,7 @@ func TestConvergence_TickProcessesClosedWisp(t *testing.T) {
 
 	// After processing, active_wisp should have changed (iterated to next wisp
 	// or terminated, depending on gate mode — manual mode transitions to waiting_manual).
-	meta, _ := cr.convHandler.Store.GetMetadata(created.BeadID)
+	meta, _ := hqScope(t, cr).handler.Store.GetMetadata(created.BeadID)
 	state := meta[convergence.FieldState]
 	// With manual gate mode, closing a wisp transitions to waiting_manual.
 	if state != convergence.StateWaitingManual {
@@ -229,7 +245,7 @@ func TestConvergence_TickRecoversMissingActiveWisp(t *testing.T) {
 		t.Fatalf("unmarshaling: %v", err)
 	}
 
-	adapter := cr.convHandler.Store.(*convergenceStoreAdapter)
+	adapter := hqScope(t, cr).adapter
 	if err := adapter.populateIndex(); err != nil {
 		t.Fatalf("populateIndex: %v", err)
 	}
@@ -240,7 +256,7 @@ func TestConvergence_TickRecoversMissingActiveWisp(t *testing.T) {
 
 	cr.convergenceTick(context.Background())
 
-	meta, err := cr.convHandler.Store.GetMetadata(created.BeadID)
+	meta, err := hqScope(t, cr).handler.Store.GetMetadata(created.BeadID)
 	if err != nil {
 		t.Fatalf("GetMetadata: %v", err)
 	}
@@ -287,9 +303,202 @@ func TestConvergence_StartupReconcile(t *testing.T) {
 	}
 
 	// The active index should be populated after startup reconcile.
-	adapter := cr.convHandler.Store.(*convergenceStoreAdapter)
+	adapter := hqScope(t, cr).adapter
 	if adapter.activeIndex == nil {
 		t.Error("active index should be populated after startup reconcile")
+	}
+}
+
+// --- Rig-scoped convergence tests (issue #2357) ---
+
+func TestConvergence_CreateRoutesToRigStore(t *testing.T) {
+	cr, cityStore := setupConvergenceRuntime(t)
+	rigStore := beads.NewMemStore()
+	addConvergenceRigScope(cr, "gascity-prod", rigStore)
+
+	reply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula":        "test-formula",
+			"target":         "test-agent",
+			"max_iterations": "3",
+			"rig":            "gascity-prod",
+		},
+	})
+	if reply.Error != "" {
+		t.Fatalf("unexpected error: %s", reply.Error)
+	}
+	var result convergence.CreateResult
+	if err := json.Unmarshal(reply.Result, &result); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+
+	// The convergence bead must land in the rig store, not city/HQ.
+	if _, err := rigStore.Get(result.BeadID); err != nil {
+		t.Errorf("convergence bead %q not found in rig store: %v", result.BeadID, err)
+	}
+	if _, err := cityStore.Get(result.BeadID); err == nil {
+		t.Errorf("convergence bead %q leaked into the city/HQ store", result.BeadID)
+	}
+
+	// The bead records its owning rig for status/list and audit.
+	bead, err := rigStore.Get(result.BeadID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bead.Metadata[convergence.FieldRig] != "gascity-prod" {
+		t.Errorf("rig metadata = %q, want %q", bead.Metadata[convergence.FieldRig], "gascity-prod")
+	}
+}
+
+func TestConvergence_CreateUnknownRigErrors(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+
+	reply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula":        "test-formula",
+			"target":         "test-agent",
+			"max_iterations": "3",
+			"rig":            "no-such-rig",
+		},
+	})
+	// An unknown --rig must fail loudly, not silently write to HQ.
+	if reply.Error == "" {
+		t.Fatal("expected error for unknown rig, got success")
+	}
+	if !strings.Contains(reply.Error, "no-such-rig") {
+		t.Errorf("error = %q, want it to name the unknown rig", reply.Error)
+	}
+}
+
+func TestConvergence_TickDrivesRigScopedLoop(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	rigStore := beads.NewMemStore()
+	rigScope := addConvergenceRigScope(cr, "gascity-prod", rigStore)
+
+	createReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula":        "test-formula",
+			"target":         "test-agent",
+			"max_iterations": "5",
+			"rig":            "gascity-prod",
+		},
+	})
+	if createReply.Error != "" {
+		t.Fatalf("create error: %s", createReply.Error)
+	}
+	var created convergence.CreateResult
+	if err := json.Unmarshal(createReply.Result, &created); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+
+	// Populate the rig scope's active index so convergenceTick processes it.
+	if err := rigScope.adapter.populateIndex(); err != nil {
+		t.Fatalf("populateIndex: %v", err)
+	}
+
+	// Close the active wisp to simulate it finishing.
+	if err := rigStore.Close(created.FirstWispID); err != nil {
+		t.Fatalf("closing wisp: %v", err)
+	}
+
+	// convergenceTick must iterate the rig scope, not just city/HQ — without
+	// this the rig-scoped loop would be created but never driven.
+	cr.convergenceTick(context.Background())
+
+	bead, err := rigStore.Get(created.BeadID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if state := bead.Metadata[convergence.FieldState]; state != convergence.StateWaitingManual {
+		t.Errorf("rig-scoped loop state after tick = %q, want %q", state, convergence.StateWaitingManual)
+	}
+}
+
+func TestConvergence_StartupReconcileCoversRigScopes(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	rigStore := beads.NewMemStore()
+	rigScope := addConvergenceRigScope(cr, "data-rig", rigStore)
+
+	// A convergence bead interrupted mid-creation in the rig store.
+	b, err := rigStore.Create(beads.Bead{Title: "interrupted", Type: "convergence", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("creating bead: %v", err)
+	}
+	if err := rigStore.SetMetadata(b.ID, convergence.FieldState, convergence.StateCreating); err != nil {
+		t.Fatalf("setting state: %v", err)
+	}
+
+	cr.convergenceStartupReconcile(context.Background())
+
+	// The interrupted rig bead should be terminated and closed.
+	updated, err := rigStore.Get(b.ID)
+	if err != nil {
+		t.Fatalf("getting bead: %v", err)
+	}
+	if updated.Status != "closed" {
+		t.Errorf("rig bead status = %q, want closed", updated.Status)
+	}
+	// Both scopes' active indexes must be populated.
+	if rigScope.adapter.activeIndex == nil {
+		t.Error("rig scope active index should be populated after startup reconcile")
+	}
+	if hqScope(t, cr).adapter.activeIndex == nil {
+		t.Error("city scope active index should be populated after startup reconcile")
+	}
+}
+
+func TestConvergence_StopRoutesToRigScope(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	rigStore := beads.NewMemStore()
+	addConvergenceRigScope(cr, "gascity-prod", rigStore)
+
+	createReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula":        "test-formula",
+			"target":         "test-agent",
+			"max_iterations": "5",
+			"rig":            "gascity-prod",
+		},
+	})
+	if createReply.Error != "" {
+		t.Fatalf("create error: %s", createReply.Error)
+	}
+	var created convergence.CreateResult
+	if err := json.Unmarshal(createReply.Result, &created); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+
+	// Stopping without the rig param looks in city/HQ and cannot find the
+	// rig-scoped bead — it must fail rather than affecting the wrong store.
+	noRigReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "stop",
+		BeadID:  created.BeadID,
+		User:    "test-operator",
+	})
+	if noRigReply.Error == "" {
+		t.Error("stop without --rig should not find the rig-scoped loop")
+	}
+
+	// With the rig param, stop routes to the rig scope and terminates it.
+	stopReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "stop",
+		BeadID:  created.BeadID,
+		User:    "test-operator",
+		Params:  map[string]string{"rig": "gascity-prod"},
+	})
+	if stopReply.Error != "" {
+		t.Fatalf("stop error: %s", stopReply.Error)
+	}
+	bead, err := rigStore.Get(created.BeadID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if bead.Metadata[convergence.FieldState] != convergence.StateTerminated {
+		t.Errorf("state = %q, want %q", bead.Metadata[convergence.FieldState], convergence.StateTerminated)
 	}
 }
 

--- a/cmd/gc/convergence_integration_test.go
+++ b/cmd/gc/convergence_integration_test.go
@@ -502,6 +502,63 @@ func TestConvergence_StopRoutesToRigScope(t *testing.T) {
 	}
 }
 
+func TestConvergence_RetryRoutesToRigScope(t *testing.T) {
+	cr, _ := setupConvergenceRuntime(t)
+	rigStore := beads.NewMemStore()
+	addConvergenceRigScope(cr, "gascity-prod", rigStore)
+
+	// Create a rig-scoped loop and stop it so it is terminated and retryable.
+	createReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "create",
+		Params: map[string]string{
+			"formula": "test-formula", "target": "test-agent",
+			"max_iterations": "5", "rig": "gascity-prod",
+		},
+	})
+	if createReply.Error != "" {
+		t.Fatalf("create error: %s", createReply.Error)
+	}
+	var created convergence.CreateResult
+	if err := json.Unmarshal(createReply.Result, &created); err != nil {
+		t.Fatalf("unmarshaling: %v", err)
+	}
+	stopReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "stop", BeadID: created.BeadID, User: "test-operator",
+		Params: map[string]string{"rig": "gascity-prod"},
+	})
+	if stopReply.Error != "" {
+		t.Fatalf("stop error: %s", stopReply.Error)
+	}
+
+	// Retry without --rig looks in city/HQ and cannot find the rig loop.
+	noRigReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "retry", BeadID: created.BeadID,
+	})
+	if noRigReply.Error == "" {
+		t.Error("retry without --rig should not find the rig-scoped loop")
+	}
+
+	// Retry with --rig routes to the rig scope; the new loop lands there.
+	retryReply := sendAndReceive(t, cr, convergenceRequest{
+		Command: "retry", BeadID: created.BeadID,
+		Params: map[string]string{"rig": "gascity-prod"},
+	})
+	if retryReply.Error != "" {
+		t.Fatalf("retry error: %s", retryReply.Error)
+	}
+	var retried convergence.RetryResult
+	if err := json.Unmarshal(retryReply.Result, &retried); err != nil {
+		t.Fatalf("unmarshaling retry result: %v", err)
+	}
+	bead, err := rigStore.Get(retried.NewBeadID)
+	if err != nil {
+		t.Fatalf("retry bead %q not found in rig store: %v", retried.NewBeadID, err)
+	}
+	if bead.Metadata[convergence.FieldRig] != "gascity-prod" {
+		t.Errorf("retry bead rig = %q, want %q", bead.Metadata[convergence.FieldRig], "gascity-prod")
+	}
+}
+
 func TestConvergence_EnqueueTimeout(t *testing.T) {
 	cr, _ := setupConvergenceRuntime(t)
 

--- a/cmd/gc/convergence_tick.go
+++ b/cmd/gc/convergence_tick.go
@@ -52,9 +52,10 @@ func (s *convergenceScope) logSuffix() string {
 
 // initConvergenceHandler builds one convergence scope per available bead
 // store: the city/HQ store plus every bound rig store. Called once during
-// CityRuntime.run() initialization. Rigs added by a later config reload
-// are not picked up until the controller restarts — this matches how the
-// city-level handler has always been built once at startup.
+// CityRuntime.run() initialization.
+//
+// TODO(#2403): rigs added by a later config reload are not picked up until
+// the controller restarts — convScopes is not rebuilt on reload.
 func (cr *CityRuntime) initConvergenceHandler() {
 	cityStore := cr.cityBeadStore()
 	if cityStore == nil {
@@ -90,18 +91,24 @@ func (cr *CityRuntime) newConvergenceScope(rig string, store beads.Store, formul
 }
 
 // convergenceScopeForRig returns the convergence scope for a rig name. An
-// empty rig selects the city/HQ scope. An unknown rig is an error so a
-// mistyped or unbound --rig fails loudly instead of silently writing the
-// bead to HQ (the defect tracked in issue #2357).
+// empty rig selects the city/HQ scope. An unknown or unbound rig is an
+// error so a mistyped or unbound --rig fails loudly instead of silently
+// writing the bead to HQ (the defect tracked in issue #2357). The error
+// distinguishes a misspelled rig from a registered-but-unusable one.
 func (cr *CityRuntime) convergenceScopeForRig(rig string) (*convergenceScope, error) {
 	if cr.convScopes == nil {
 		return nil, fmt.Errorf("convergence not available (no bead store)")
 	}
-	scope, ok := cr.convScopes[rig]
-	if !ok {
-		return nil, fmt.Errorf("rig %q has no bead store; convergence loops require a registered, bound rig", rig)
+	if scope, ok := cr.convScopes[rig]; ok {
+		return scope, nil
 	}
-	return scope, nil
+	for i := range cr.cfg.Rigs {
+		if cr.cfg.Rigs[i].Name == rig {
+			return nil, fmt.Errorf("rig %q is registered but has no bead store; "+
+				"convergence loops require a bound rig", rig)
+		}
+	}
+	return nil, fmt.Errorf("rig %q is not registered in this city", rig)
 }
 
 // convergenceTick processes active convergence loops in every scope — the

--- a/cmd/gc/convergence_tick.go
+++ b/cmd/gc/convergence_tick.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"os/user"
+	"sort"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
 )
 
@@ -33,10 +36,15 @@ type convergenceReply struct {
 // in whichever store the operator's --rig context selected. The empty rig
 // name ("") denotes the city/HQ scope.
 type convergenceScope struct {
-	rig     string // "" for the city/HQ store
-	store   beads.Store
-	adapter *convergenceStoreAdapter
-	handler *convergence.Handler
+	rig       string // "" for the city/HQ store
+	storePath string // city root for HQ, rig root for rig scopes
+	store     beads.Store
+	adapter   *convergenceStoreAdapter
+	handler   *convergence.Handler
+	// needsStartupReconcile keeps a scope eligible for retry when startup
+	// reconciliation failed but the controller kept running with an empty
+	// active index.
+	needsStartupReconcile bool
 }
 
 // logSuffix returns a human-readable scope qualifier for log lines: empty
@@ -48,6 +56,13 @@ func (s *convergenceScope) logSuffix() string {
 		return ""
 	}
 	return " (rig " + s.rig + ")"
+}
+
+func (s *convergenceScope) triggerName(prefix string) string {
+	if s.rig == "" {
+		return prefix
+	}
+	return prefix + "-rig-" + s.rig
 }
 
 // initConvergenceHandler builds one convergence scope per available bead
@@ -62,14 +77,15 @@ func (cr *CityRuntime) initConvergenceHandler() {
 		return
 	}
 	scopes := map[string]*convergenceScope{
-		"": cr.newConvergenceScope("", cityStore, cr.cfg.FormulaLayers.City),
+		"": cr.newConvergenceScope("", cityStore, cr.cityPath, cr.cfg.FormulaLayers.City),
 	}
+	rigStorePaths := cr.convergenceRigStorePaths()
 	for rigName, store := range cr.rigBeadStores() {
 		if store == nil {
 			continue
 		}
 		scopes[rigName] = cr.newConvergenceScope(
-			rigName, store, cr.cfg.FormulaLayers.SearchPaths(rigName))
+			rigName, store, rigStorePaths[rigName], cr.cfg.FormulaLayers.SearchPaths(rigName))
 	}
 	cr.convScopes = scopes
 }
@@ -77,17 +93,75 @@ func (cr *CityRuntime) initConvergenceHandler() {
 // newConvergenceScope wires a store adapter and convergence handler for a
 // single bead store. Each rig scope resolves formulas through that rig's
 // formula search paths so rig-local formulas are honored.
-func (cr *CityRuntime) newConvergenceScope(rig string, store beads.Store, formulaSearchPaths []string) *convergenceScope {
+func (cr *CityRuntime) newConvergenceScope(rig string, store beads.Store, storePath string, formulaSearchPaths []string) *convergenceScope {
 	adapter := newConvergenceStoreAdapter(store, formulaSearchPaths)
 	return &convergenceScope{
-		rig:     rig,
-		store:   store,
-		adapter: adapter,
+		rig:       rig,
+		storePath: storePath,
+		store:     store,
+		adapter:   adapter,
 		handler: &convergence.Handler{
-			Store:   adapter,
-			Emitter: &convergenceEventEmitter{rec: cr.rec},
+			Store:     adapter,
+			StorePath: storePath,
+			Emitter:   &convergenceEventEmitter{rec: cr.rec},
 		},
 	}
+}
+
+func (cr *CityRuntime) convergenceRigStorePaths() map[string]string {
+	rigs := cr.convergenceRigSnapshot()
+	if len(rigs) == 0 {
+		return nil
+	}
+	paths := make(map[string]string, len(rigs))
+	for _, rig := range rigs {
+		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		paths[rig.Name] = resolveStoreScopeRoot(cr.cityPath, rig.Path)
+	}
+	return paths
+}
+
+func (cr *CityRuntime) convergenceRigSnapshot() []config.Rig {
+	cr.serviceStateMu.RLock()
+	defer cr.serviceStateMu.RUnlock()
+	if cr.cfg == nil || len(cr.cfg.Rigs) == 0 {
+		return nil
+	}
+	return append([]config.Rig(nil), cr.cfg.Rigs...)
+}
+
+func (cr *CityRuntime) convergenceMaxPerAgent() int {
+	cr.serviceStateMu.RLock()
+	defer cr.serviceStateMu.RUnlock()
+	if cr.cfg == nil {
+		return (config.ConvergenceConfig{}).MaxPerAgentOrDefault()
+	}
+	return cr.cfg.Convergence.MaxPerAgentOrDefault()
+}
+
+func (cr *CityRuntime) convergenceScopes() []*convergenceScope {
+	if len(cr.convScopes) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(cr.convScopes))
+	for key := range cr.convScopes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	scopes := make([]*convergenceScope, 0, len(keys))
+	for _, key := range keys {
+		if scope := cr.convScopes[key]; scope != nil {
+			scopes = append(scopes, scope)
+		}
+	}
+	return scopes
+}
+
+func unboundRigConvergenceError(rig string) error {
+	return fmt.Errorf("rig %q is registered but has no bead store; "+
+		"convergence loops require a bound rig", rig)
 }
 
 // convergenceScopeForRig returns the convergence scope for a rig name. An
@@ -100,15 +174,50 @@ func (cr *CityRuntime) convergenceScopeForRig(rig string) (*convergenceScope, er
 		return nil, fmt.Errorf("convergence not available (no bead store)")
 	}
 	if scope, ok := cr.convScopes[rig]; ok {
-		return scope, nil
+		if rig == "" {
+			return scope, nil
+		}
+		for _, candidate := range cr.convergenceRigSnapshot() {
+			if candidate.Name != rig {
+				continue
+			}
+			if strings.TrimSpace(candidate.Path) == "" {
+				return nil, fmt.Errorf("rig %q became unbound after config reload but convergence scopes were not rebuilt; restart the controller (#2403)", rig)
+			}
+			currentPath := resolveStoreScopeRoot(cr.cityPath, candidate.Path)
+			if currentPath != scope.storePath {
+				return nil, fmt.Errorf("rig %q bead store changed after config reload from %q to %q; restart the controller (#2403)", rig, scope.storePath, currentPath)
+			}
+			return scope, nil
+		}
+		return nil, fmt.Errorf("rig %q was removed from city config but convergence scopes were not rebuilt; restart the controller (#2403)", rig)
 	}
-	for i := range cr.cfg.Rigs {
-		if cr.cfg.Rigs[i].Name == rig {
-			return nil, fmt.Errorf("rig %q is registered but has no bead store; "+
-				"convergence loops require a bound rig", rig)
+	for _, candidate := range cr.convergenceRigSnapshot() {
+		if candidate.Name == rig {
+			if strings.TrimSpace(candidate.Path) == "" {
+				return nil, unboundRigConvergenceError(rig)
+			}
+			return nil, fmt.Errorf("rig %q is bound but convergence scopes were not rebuilt after config reload; restart the controller (#2403)", rig)
 		}
 	}
 	return nil, fmt.Errorf("rig %q is not registered in this city", rig)
+}
+
+func (cr *CityRuntime) validateConvergenceScopeCurrent(scope *convergenceScope) error {
+	if scope == nil {
+		return fmt.Errorf("convergence scope is nil")
+	}
+	current, err := cr.convergenceScopeForRig(scope.rig)
+	if err != nil {
+		return err
+	}
+	if current != scope {
+		if scope.rig == "" {
+			return fmt.Errorf("city/HQ convergence scope was rebuilt; skipping stale cached scope")
+		}
+		return fmt.Errorf("rig %q convergence scope was rebuilt; skipping stale cached scope", scope.rig)
+	}
+	return nil
 }
 
 // convergenceTick processes active convergence loops in every scope — the
@@ -117,8 +226,11 @@ func (cr *CityRuntime) convergenceTick(ctx context.Context) {
 	if cr.convScopes == nil || cr.convergenceReqCh == nil {
 		return
 	}
-	for _, scope := range cr.convScopes {
-		cr.convergenceTickScope(ctx, scope)
+	for _, scope := range cr.convergenceScopes() {
+		scope := scope
+		cr.safeTick(func() {
+			cr.convergenceTickScope(ctx, scope)
+		}, scope.triggerName("convergence-tick"))
 	}
 }
 
@@ -127,7 +239,21 @@ func (cr *CityRuntime) convergenceTick(ctx context.Context) {
 // HandleWispClosed. Uses the scope's in-memory active index (O(active)
 // instead of O(all beads)).
 func (cr *CityRuntime) convergenceTickScope(ctx context.Context, scope *convergenceScope) {
-	if scope.adapter == nil || scope.adapter.activeIndex == nil {
+	if scope == nil || scope.adapter == nil {
+		return
+	}
+	if err := cr.validateConvergenceScopeCurrent(scope); err != nil {
+		fmt.Fprintf(cr.stderr, "%s: convergence%s: skipping stale scope: %v\n", //nolint:errcheck
+			cr.logPrefix, scope.logSuffix(), err)
+		return
+	}
+	if scope.needsStartupReconcile {
+		cr.convergenceStartupReconcileScope(ctx, scope)
+		if scope.needsStartupReconcile {
+			return
+		}
+	}
+	if scope.adapter.activeIndex == nil {
 		return
 	}
 
@@ -154,13 +280,13 @@ func (cr *CityRuntime) convergenceTickScope(ctx context.Context, scope *converge
 			reconciler := &convergence.Reconciler{Handler: scope.handler}
 			report, rErr := reconciler.ReconcileBeads(ctx, []string{beadID})
 			if rErr != nil {
-				fmt.Fprintf(cr.stderr, "%s: convergence: reconcile(%s): %v\n", //nolint:errcheck
-					cr.logPrefix, beadID, rErr)
+				fmt.Fprintf(cr.stderr, "%s: convergence%s: reconcile(%s): %v\n", //nolint:errcheck
+					cr.logPrefix, scope.logSuffix(), beadID, rErr)
 				continue
 			}
 			if len(report.Details) > 0 && report.Details[0].Error != nil {
-				fmt.Fprintf(cr.stderr, "%s: convergence: reconcile(%s): %v\n", //nolint:errcheck
-					cr.logPrefix, beadID, report.Details[0].Error)
+				fmt.Fprintf(cr.stderr, "%s: convergence%s: reconcile(%s): %v\n", //nolint:errcheck
+					cr.logPrefix, scope.logSuffix(), beadID, report.Details[0].Error)
 			}
 			continue
 		}
@@ -170,8 +296,8 @@ func (cr *CityRuntime) convergenceTickScope(ctx context.Context, scope *converge
 		// Process the closed wisp.
 		result, hErr := scope.handler.HandleWispClosed(ctx, beadID, activeWisp)
 		if hErr != nil {
-			fmt.Fprintf(cr.stderr, "%s: convergence: HandleWispClosed(%s, %s): %v\n", //nolint:errcheck
-				cr.logPrefix, beadID, activeWisp, hErr)
+			fmt.Fprintf(cr.stderr, "%s: convergence%s: HandleWispClosed(%s, %s): %v\n", //nolint:errcheck
+				cr.logPrefix, scope.logSuffix(), beadID, activeWisp, hErr)
 			continue
 		}
 		if result.Action != convergence.ActionSkipped {
@@ -295,7 +421,7 @@ func (cr *CityRuntime) handleConvergenceCreate(ctx context.Context, req converge
 
 	// Concurrency checks are scoped to this store: each bead store accounts
 	// for its own active convergence loops independently.
-	maxPerAgent := cr.cfg.Convergence.MaxPerAgentOrDefault()
+	maxPerAgent := cr.convergenceMaxPerAgent()
 	if err := convergence.CheckConcurrencyLimits(scope.handler.Store, target, maxPerAgent); err != nil {
 		return convergenceReply{Error: err.Error()}
 	}
@@ -367,7 +493,7 @@ func (cr *CityRuntime) handleConvergenceRetry(ctx context.Context, req convergen
 	target := meta[convergence.FieldTarget]
 
 	// Concurrency checks.
-	maxPerAgent := cr.cfg.Convergence.MaxPerAgentOrDefault()
+	maxPerAgent := cr.convergenceMaxPerAgent()
 	if err := convergence.CheckConcurrencyLimits(scope.handler.Store, target, maxPerAgent); err != nil {
 		return convergenceReply{Error: err.Error()}
 	}
@@ -394,20 +520,41 @@ func (cr *CityRuntime) convergenceStartupReconcile(ctx context.Context) {
 	if cr.convScopes == nil || cr.convergenceReqCh == nil {
 		return
 	}
-	for _, scope := range cr.convScopes {
-		cr.convergenceStartupReconcileScope(ctx, scope)
+	for _, scope := range cr.convergenceScopes() {
+		scope := scope
+		run := func() {
+			cr.convergenceStartupReconcileScope(ctx, scope)
+		}
+		trigger := scope.triggerName("convergence-startup-reconcile")
+		if cr.safeTick(run, trigger) && scope.adapter.activeIndex == nil {
+			cr.safeTick(run, trigger+"-retry")
+		}
+		if scope.adapter.activeIndex == nil {
+			scope.needsStartupReconcile = true
+			scope.adapter.activeIndex = map[string]string{}
+		}
 	}
 }
 
 // convergenceStartupReconcileScope reconciles interrupted convergence
 // beads in one scope's store and then populates that scope's active index.
 func (cr *CityRuntime) convergenceStartupReconcileScope(ctx context.Context, scope *convergenceScope) {
+	if scope == nil {
+		return
+	}
+	if err := cr.validateConvergenceScopeCurrent(scope); err != nil {
+		fmt.Fprintf(cr.stderr, "%s: convergence reconcile%s: skipping stale scope: %v\n", //nolint:errcheck
+			cr.logPrefix, scope.logSuffix(), err)
+		return
+	}
 	// List() waits for CachingStore prime if not yet live, then serves
 	// from memory. No subprocess stampede.
 	all, err := scope.store.List(beads.ListQuery{Type: "convergence"})
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: convergence reconcile%s: listing beads: %v\n", //nolint:errcheck
 			cr.logPrefix, scope.logSuffix(), err)
+		scope.needsStartupReconcile = true
+		scope.adapter.activeIndex = map[string]string{}
 		return
 	}
 
@@ -422,6 +569,8 @@ func (cr *CityRuntime) convergenceStartupReconcileScope(ctx context.Context, sco
 		if err != nil {
 			fmt.Fprintf(cr.stderr, "%s: convergence reconciliation%s: %v\n", //nolint:errcheck
 				cr.logPrefix, scope.logSuffix(), err)
+			scope.needsStartupReconcile = true
+			scope.adapter.activeIndex = map[string]string{}
 			return
 		}
 		if report.Recovered > 0 || report.Errors > 0 {
@@ -435,7 +584,11 @@ func (cr *CityRuntime) convergenceStartupReconcileScope(ctx context.Context, sco
 	if err := scope.adapter.populateIndex(); err != nil {
 		fmt.Fprintf(cr.stderr, "%s: convergence: populating active index%s: %v\n", //nolint:errcheck
 			cr.logPrefix, scope.logSuffix(), err)
+		scope.needsStartupReconcile = true
+		scope.adapter.activeIndex = map[string]string{}
+		return
 	}
+	scope.needsStartupReconcile = false
 }
 
 // sendConvergenceRequest sends a request through the controller socket and

--- a/cmd/gc/convergence_tick.go
+++ b/cmd/gc/convergence_tick.go
@@ -27,35 +27,105 @@ type convergenceReply struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-// initConvergenceHandler creates the convergence handler if a bead store is
-// available. Called once during CityRuntime.run() initialization.
+// convergenceScope binds a convergence handler to one bead store — the
+// city/HQ store or a single rig's store. The controller maintains one
+// scope per store so a convergence loop is created, ticked, and reconciled
+// in whichever store the operator's --rig context selected. The empty rig
+// name ("") denotes the city/HQ scope.
+type convergenceScope struct {
+	rig     string // "" for the city/HQ store
+	store   beads.Store
+	adapter *convergenceStoreAdapter
+	handler *convergence.Handler
+}
+
+// logSuffix returns a human-readable scope qualifier for log lines: empty
+// for the city/HQ scope, " (rig <name>)" for a rig scope. Keeping the
+// city-scope suffix empty leaves city-scope log lines byte-identical to
+// the pre-rig-scoping output.
+func (s *convergenceScope) logSuffix() string {
+	if s.rig == "" {
+		return ""
+	}
+	return " (rig " + s.rig + ")"
+}
+
+// initConvergenceHandler builds one convergence scope per available bead
+// store: the city/HQ store plus every bound rig store. Called once during
+// CityRuntime.run() initialization. Rigs added by a later config reload
+// are not picked up until the controller restarts — this matches how the
+// city-level handler has always been built once at startup.
 func (cr *CityRuntime) initConvergenceHandler() {
-	store := cr.cityBeadStore()
-	if store == nil {
+	cityStore := cr.cityBeadStore()
+	if cityStore == nil {
 		return
 	}
-	adapter := newConvergenceStoreAdapter(store, cr.cfg.FormulaLayers.City)
-	emitter := &convergenceEventEmitter{rec: cr.rec}
-	cr.convStoreAdapter = adapter
-	cr.convHandler = &convergence.Handler{
-		Store:   adapter,
-		Emitter: emitter,
+	scopes := map[string]*convergenceScope{
+		"": cr.newConvergenceScope("", cityStore, cr.cfg.FormulaLayers.City),
+	}
+	for rigName, store := range cr.rigBeadStores() {
+		if store == nil {
+			continue
+		}
+		scopes[rigName] = cr.newConvergenceScope(
+			rigName, store, cr.cfg.FormulaLayers.SearchPaths(rigName))
+	}
+	cr.convScopes = scopes
+}
+
+// newConvergenceScope wires a store adapter and convergence handler for a
+// single bead store. Each rig scope resolves formulas through that rig's
+// formula search paths so rig-local formulas are honored.
+func (cr *CityRuntime) newConvergenceScope(rig string, store beads.Store, formulaSearchPaths []string) *convergenceScope {
+	adapter := newConvergenceStoreAdapter(store, formulaSearchPaths)
+	return &convergenceScope{
+		rig:     rig,
+		store:   store,
+		adapter: adapter,
+		handler: &convergence.Handler{
+			Store:   adapter,
+			Emitter: &convergenceEventEmitter{rec: cr.rec},
+		},
 	}
 }
 
-// convergenceTick processes active convergence loops by checking indexed
-// beads for closed wisps and calling HandleWispClosed. Called from tick().
-// Uses the in-memory active index (O(active) instead of O(all beads)).
+// convergenceScopeForRig returns the convergence scope for a rig name. An
+// empty rig selects the city/HQ scope. An unknown rig is an error so a
+// mistyped or unbound --rig fails loudly instead of silently writing the
+// bead to HQ (the defect tracked in issue #2357).
+func (cr *CityRuntime) convergenceScopeForRig(rig string) (*convergenceScope, error) {
+	if cr.convScopes == nil {
+		return nil, fmt.Errorf("convergence not available (no bead store)")
+	}
+	scope, ok := cr.convScopes[rig]
+	if !ok {
+		return nil, fmt.Errorf("rig %q has no bead store; convergence loops require a registered, bound rig", rig)
+	}
+	return scope, nil
+}
+
+// convergenceTick processes active convergence loops in every scope — the
+// city/HQ store and each bound rig store. Called from tick().
 func (cr *CityRuntime) convergenceTick(ctx context.Context) {
-	if cr.convHandler == nil || cr.convergenceReqCh == nil {
+	if cr.convScopes == nil || cr.convergenceReqCh == nil {
 		return
 	}
-	if cr.convStoreAdapter == nil || cr.convStoreAdapter.activeIndex == nil {
+	for _, scope := range cr.convScopes {
+		cr.convergenceTickScope(ctx, scope)
+	}
+}
+
+// convergenceTickScope processes active convergence loops in a single
+// scope by checking indexed beads for closed wisps and calling
+// HandleWispClosed. Uses the scope's in-memory active index (O(active)
+// instead of O(all beads)).
+func (cr *CityRuntime) convergenceTickScope(ctx context.Context, scope *convergenceScope) {
+	if scope.adapter == nil || scope.adapter.activeIndex == nil {
 		return
 	}
 
-	for _, beadID := range cr.convStoreAdapter.activeBeadIDs() {
-		meta, err := cr.convStoreAdapter.GetMetadata(beadID)
+	for _, beadID := range scope.adapter.activeBeadIDs() {
+		meta, err := scope.adapter.GetMetadata(beadID)
 		if err != nil {
 			continue
 		}
@@ -69,12 +139,12 @@ func (cr *CityRuntime) convergenceTick(ctx context.Context) {
 			continue
 		}
 		// Check if the active wisp is closed.
-		wispInfo, wErr := cr.convStoreAdapter.GetBead(activeWisp)
+		wispInfo, wErr := scope.adapter.GetBead(activeWisp)
 		if wErr != nil {
 			if !errors.Is(wErr, beads.ErrNotFound) {
 				continue
 			}
-			reconciler := &convergence.Reconciler{Handler: cr.convHandler}
+			reconciler := &convergence.Reconciler{Handler: scope.handler}
 			report, rErr := reconciler.ReconcileBeads(ctx, []string{beadID})
 			if rErr != nil {
 				fmt.Fprintf(cr.stderr, "%s: convergence: reconcile(%s): %v\n", //nolint:errcheck
@@ -91,7 +161,7 @@ func (cr *CityRuntime) convergenceTick(ctx context.Context) {
 			continue
 		}
 		// Process the closed wisp.
-		result, hErr := cr.convHandler.HandleWispClosed(ctx, beadID, activeWisp)
+		result, hErr := scope.handler.HandleWispClosed(ctx, beadID, activeWisp)
 		if hErr != nil {
 			fmt.Fprintf(cr.stderr, "%s: convergence: HandleWispClosed(%s, %s): %v\n", //nolint:errcheck
 				cr.logPrefix, beadID, activeWisp, hErr)
@@ -108,7 +178,7 @@ func (cr *CityRuntime) convergenceTick(ctx context.Context) {
 // processes each command serially. Called from the event loop to serialize
 // CLI commands with tick-based processing.
 func (cr *CityRuntime) processConvergenceRequests(ctx context.Context) {
-	if cr.convHandler == nil || cr.convergenceReqCh == nil {
+	if cr.convScopes == nil || cr.convergenceReqCh == nil {
 		return
 	}
 	for {
@@ -141,9 +211,10 @@ func (cr *CityRuntime) safeHandleConvergenceRequest(ctx context.Context, req con
 	return reply
 }
 
-// handleConvergenceRequest dispatches a single convergence command.
+// handleConvergenceRequest dispatches a single convergence command to the
+// scope selected by the request's "rig" parameter.
 func (cr *CityRuntime) handleConvergenceRequest(ctx context.Context, req convergenceRequest) convergenceReply {
-	if cr.convHandler == nil {
+	if cr.convScopes == nil {
 		return convergenceReply{Error: "convergence not available (no bead store)"}
 	}
 
@@ -157,24 +228,12 @@ func (cr *CityRuntime) handleConvergenceRequest(ctx context.Context, req converg
 	switch req.Command {
 	case "create":
 		return cr.handleConvergenceCreate(ctx, req)
-	case "approve":
-		result, err := cr.convHandler.ApproveHandler(ctx, req.BeadID, username, "")
+	case "approve", "iterate", "stop":
+		scope, err := cr.convergenceScopeForRig(req.Params["rig"])
 		if err != nil {
 			return convergenceReply{Error: err.Error()}
 		}
-		return marshalReply(result)
-	case "iterate":
-		result, err := cr.convHandler.IterateHandler(ctx, req.BeadID, username, "")
-		if err != nil {
-			return convergenceReply{Error: err.Error()}
-		}
-		return marshalReply(result)
-	case "stop":
-		result, err := cr.convHandler.StopHandler(ctx, req.BeadID, username, "")
-		if err != nil {
-			return convergenceReply{Error: err.Error()}
-		}
-		return marshalReply(result)
+		return cr.handleConvergenceLifecycle(ctx, scope, req.Command, req.BeadID, username)
 	case "retry":
 		return cr.handleConvergenceRetry(ctx, req)
 	default:
@@ -182,8 +241,39 @@ func (cr *CityRuntime) handleConvergenceRequest(ctx context.Context, req converg
 	}
 }
 
-// handleConvergenceCreate processes a create command.
+// handleConvergenceLifecycle dispatches approve/iterate/stop to the
+// convergence handler bound to the resolved scope's bead store.
+func (cr *CityRuntime) handleConvergenceLifecycle(ctx context.Context, scope *convergenceScope, command, beadID, username string) convergenceReply {
+	var (
+		result convergence.HandlerResult
+		err    error
+	)
+	switch command {
+	case "approve":
+		result, err = scope.handler.ApproveHandler(ctx, beadID, username, "")
+	case "iterate":
+		result, err = scope.handler.IterateHandler(ctx, beadID, username, "")
+	case "stop":
+		result, err = scope.handler.StopHandler(ctx, beadID, username, "")
+	default:
+		return convergenceReply{Error: fmt.Sprintf("unknown convergence command: %q", command)}
+	}
+	if err != nil {
+		return convergenceReply{Error: err.Error()}
+	}
+	return marshalReply(result)
+}
+
+// handleConvergenceCreate processes a create command. The "rig" parameter
+// selects the bead store: empty creates the loop in the city/HQ store, a
+// rig name creates it in that rig's store.
 func (cr *CityRuntime) handleConvergenceCreate(ctx context.Context, req convergenceRequest) convergenceReply {
+	rig := req.Params["rig"]
+	scope, err := cr.convergenceScopeForRig(rig)
+	if err != nil {
+		return convergenceReply{Error: err.Error()}
+	}
+
 	formula := req.Params["formula"]
 	target := req.Params["target"]
 	maxIter := 5
@@ -196,12 +286,13 @@ func (cr *CityRuntime) handleConvergenceCreate(ctx context.Context, req converge
 		gateMode = convergence.GateModeManual
 	}
 
-	// Concurrency checks.
+	// Concurrency checks are scoped to this store: each bead store accounts
+	// for its own active convergence loops independently.
 	maxPerAgent := cr.cfg.Convergence.MaxPerAgentOrDefault()
-	if err := convergence.CheckConcurrencyLimits(cr.convHandler.Store, target, maxPerAgent); err != nil {
+	if err := convergence.CheckConcurrencyLimits(scope.handler.Store, target, maxPerAgent); err != nil {
 		return convergenceReply{Error: err.Error()}
 	}
-	if err := convergence.CheckNestedConvergence(cr.convHandler.Store, "", target); err != nil {
+	if err := convergence.CheckNestedConvergence(scope.handler.Store, "", target); err != nil {
 		return convergenceReply{Error: err.Error()}
 	}
 
@@ -225,17 +316,25 @@ func (cr *CityRuntime) handleConvergenceCreate(ctx context.Context, req converge
 		Vars:              vars,
 		CityPath:          cr.cityPath,
 		EvaluatePrompt:    req.Params["evaluate_prompt"],
+		Rig:               rig,
 	}
 
-	result, err := cr.convHandler.CreateHandler(ctx, params)
+	result, err := scope.handler.CreateHandler(ctx, params)
 	if err != nil {
 		return convergenceReply{Error: err.Error()}
 	}
 	return marshalReply(result)
 }
 
-// handleConvergenceRetry processes a retry command.
+// handleConvergenceRetry processes a retry command. The retry loop is
+// created in the same scope as the source loop, selected by the request's
+// "rig" parameter.
 func (cr *CityRuntime) handleConvergenceRetry(ctx context.Context, req convergenceRequest) convergenceReply {
+	scope, err := cr.convergenceScopeForRig(req.Params["rig"])
+	if err != nil {
+		return convergenceReply{Error: err.Error()}
+	}
+
 	sourceBeadID := req.BeadID
 	maxIter := 0
 	if v, ok := convergence.DecodeInt(req.Params["max_iterations"]); ok && v > 0 {
@@ -243,7 +342,7 @@ func (cr *CityRuntime) handleConvergenceRetry(ctx context.Context, req convergen
 	}
 
 	// Read source bead metadata once for both max_iterations and target.
-	meta, err := cr.convHandler.Store.GetMetadata(sourceBeadID)
+	meta, err := scope.handler.Store.GetMetadata(sourceBeadID)
 	if err != nil {
 		return convergenceReply{Error: fmt.Sprintf("reading source bead: %v", err)}
 	}
@@ -262,10 +361,10 @@ func (cr *CityRuntime) handleConvergenceRetry(ctx context.Context, req convergen
 
 	// Concurrency checks.
 	maxPerAgent := cr.cfg.Convergence.MaxPerAgentOrDefault()
-	if err := convergence.CheckConcurrencyLimits(cr.convHandler.Store, target, maxPerAgent); err != nil {
+	if err := convergence.CheckConcurrencyLimits(scope.handler.Store, target, maxPerAgent); err != nil {
 		return convergenceReply{Error: err.Error()}
 	}
-	if err := convergence.CheckNestedConvergence(cr.convHandler.Store, "", target); err != nil {
+	if err := convergence.CheckNestedConvergence(scope.handler.Store, "", target); err != nil {
 		return convergenceReply{Error: err.Error()}
 	}
 
@@ -274,29 +373,34 @@ func (cr *CityRuntime) handleConvergenceRetry(ctx context.Context, req convergen
 		username = currentUsername()
 	}
 
-	result, err := cr.convHandler.RetryHandler(ctx, sourceBeadID, username, maxIter)
+	result, err := scope.handler.RetryHandler(ctx, sourceBeadID, username, maxIter)
 	if err != nil {
 		return convergenceReply{Error: err.Error()}
 	}
 	return marshalReply(result)
 }
 
-// convergenceStartupReconcile runs convergence bead reconciliation on startup
-// and then populates the in-memory active index.
+// convergenceStartupReconcile runs convergence bead reconciliation on
+// startup for every scope and then populates each scope's in-memory
+// active index.
 func (cr *CityRuntime) convergenceStartupReconcile(ctx context.Context) {
-	if cr.convHandler == nil || cr.convergenceReqCh == nil {
+	if cr.convScopes == nil || cr.convergenceReqCh == nil {
 		return
 	}
-	store := cr.cityBeadStore()
-	if store == nil {
-		return
+	for _, scope := range cr.convScopes {
+		cr.convergenceStartupReconcileScope(ctx, scope)
 	}
+}
 
+// convergenceStartupReconcileScope reconciles interrupted convergence
+// beads in one scope's store and then populates that scope's active index.
+func (cr *CityRuntime) convergenceStartupReconcileScope(ctx context.Context, scope *convergenceScope) {
 	// List() waits for CachingStore prime if not yet live, then serves
 	// from memory. No subprocess stampede.
-	all, err := store.List(beads.ListQuery{Type: "convergence"})
+	all, err := scope.store.List(beads.ListQuery{Type: "convergence"})
 	if err != nil {
-		fmt.Fprintf(cr.stderr, "%s: convergence reconcile: listing beads: %v\n", cr.logPrefix, err) //nolint:errcheck
+		fmt.Fprintf(cr.stderr, "%s: convergence reconcile%s: listing beads: %v\n", //nolint:errcheck
+			cr.logPrefix, scope.logSuffix(), err)
 		return
 	}
 
@@ -306,24 +410,24 @@ func (cr *CityRuntime) convergenceStartupReconcile(ctx context.Context) {
 	}
 
 	if len(beadIDs) > 0 {
-		reconciler := &convergence.Reconciler{Handler: cr.convHandler}
+		reconciler := &convergence.Reconciler{Handler: scope.handler}
 		report, err := reconciler.ReconcileBeads(ctx, beadIDs)
 		if err != nil {
-			fmt.Fprintf(cr.stderr, "%s: convergence reconciliation: %v\n", cr.logPrefix, err) //nolint:errcheck
+			fmt.Fprintf(cr.stderr, "%s: convergence reconciliation%s: %v\n", //nolint:errcheck
+				cr.logPrefix, scope.logSuffix(), err)
 			return
 		}
 		if report.Recovered > 0 || report.Errors > 0 {
-			fmt.Fprintf(cr.stdout, "Convergence recovery: %d scanned, %d recovered, %d errors\n", //nolint:errcheck
-				report.Scanned, report.Recovered, report.Errors)
+			fmt.Fprintf(cr.stdout, "Convergence recovery%s: %d scanned, %d recovered, %d errors\n", //nolint:errcheck
+				scope.logSuffix(), report.Scanned, report.Recovered, report.Errors)
 		}
 	}
 
 	// Populate the active index after reconciliation so it reflects
 	// post-recovery state.
-	if cr.convStoreAdapter != nil {
-		if err := cr.convStoreAdapter.populateIndex(); err != nil {
-			fmt.Fprintf(cr.stderr, "%s: convergence: populating active index: %v\n", cr.logPrefix, err) //nolint:errcheck
-		}
+	if err := scope.adapter.populateIndex(); err != nil {
+		fmt.Fprintf(cr.stderr, "%s: convergence: populating active index%s: %v\n", //nolint:errcheck
+			cr.logPrefix, scope.logSuffix(), err)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -639,6 +639,7 @@ gc converge list [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--all` | bool |  | Include closed/terminated loops |
+| `--all-rigs` | bool |  | List loops from city/HQ and every bound rig |
 | `--json` | bool |  | Output as JSON |
 | `--state` | string |  | Filter by state (active, waiting_manual, terminated) |
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -255,7 +255,7 @@ ConvergenceConfig holds convergence loop limits.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `max_per_agent` | integer |  | `2` | MaxPerAgent is the maximum number of active convergence loops per agent. 0 means use default (2). |
+| `max_per_agent` | integer |  | `2` | MaxPerAgent is the maximum number of active convergence loops per agent in each bead store scope. City/HQ and each bound rig enforce the limit independently. 0 means use default (2). |
 | `max_total` | integer |  | `10` | MaxTotal is the maximum total number of active convergence loops. 0 means use default (10). |
 
 ## DaemonConfig

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1042,7 +1042,7 @@
       "properties": {
         "max_per_agent": {
           "type": "integer",
-          "description": "MaxPerAgent is the maximum number of active convergence loops per agent.\n0 means use default (2).",
+          "description": "MaxPerAgent is the maximum number of active convergence loops per agent\nin each bead store scope. City/HQ and each bound rig enforce the limit\nindependently. 0 means use default (2).",
           "default": 2
         },
         "max_total": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1042,7 +1042,7 @@
       "properties": {
         "max_per_agent": {
           "type": "integer",
-          "description": "MaxPerAgent is the maximum number of active convergence loops per agent.\n0 means use default (2).",
+          "description": "MaxPerAgent is the maximum number of active convergence loops per agent\nin each bead store scope. City/HQ and each bound rig enforce the limit\nindependently. 0 means use default (2).",
           "default": 2
         },
         "max_total": {

--- a/engdocs/contributors/reconciler-debugging.md
+++ b/engdocs/contributors/reconciler-debugging.md
@@ -74,6 +74,20 @@ Point the next agent at these artifacts:
 
 If a real session existed and the bug crossed into runtime behavior, also include the relevant session or provider logs.
 
+## Rig-Scoped Convergence Rollback
+
+Before rolling back a release that has created rig-scoped convergence loops,
+stop active loops in each affected rig:
+
+```bash
+gc --rig <rig-name> converge list
+gc --rig <rig-name> converge stop <bead-id>
+```
+
+Older controllers only watch the city/HQ convergence store. If rollback happens
+with active rig-scoped convergence beads still present, those loops become
+crash-orphans until a controller with rig-scoped convergence support runs again.
+
 ## How To Read The Trace
 
 These record types are usually the fastest path to the bug:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1649,8 +1649,9 @@ func parseHumanSize(s string) (int64, bool) {
 
 // ConvergenceConfig holds convergence loop limits.
 type ConvergenceConfig struct {
-	// MaxPerAgent is the maximum number of active convergence loops per agent.
-	// 0 means use default (2).
+	// MaxPerAgent is the maximum number of active convergence loops per agent
+	// in each bead store scope. City/HQ and each bound rig enforce the limit
+	// independently. 0 means use default (2).
 	MaxPerAgent int `toml:"max_per_agent,omitempty" jsonschema:"default=2"`
 	// MaxTotal is the maximum total number of active convergence loops.
 	// 0 means use default (10).

--- a/internal/convergence/create.go
+++ b/internal/convergence/create.go
@@ -18,6 +18,11 @@ type CreateParams struct {
 	Vars              map[string]string
 	CityPath          string
 	EvaluatePrompt    string
+	// Rig names the rig whose bead store owns this convergence loop.
+	// Empty means the city/HQ store. The loop physically lives in
+	// whichever store the handler is bound to; Rig is persisted as
+	// metadata so status/list and audit can report the owning scope.
+	Rig string
 }
 
 // CreateResult holds the outcome of creating a convergence loop.
@@ -89,6 +94,7 @@ func (h *Handler) CreateHandler(_ context.Context, params CreateParams) (CreateR
 		{FieldGateTimeout, params.GateTimeout},
 		{FieldGateTimeoutAction, params.GateTimeoutAction},
 		{FieldCityPath, params.CityPath},
+		{FieldRig, params.Rig},
 		{FieldEvaluatePrompt, params.EvaluatePrompt},
 		{FieldState, StateActive},
 	}

--- a/internal/convergence/create_test.go
+++ b/internal/convergence/create_test.go
@@ -284,9 +284,10 @@ func TestCreateHandler_DefaultGateMode(t *testing.T) {
 
 func TestCreateHandler_PersistsRig(t *testing.T) {
 	store := newFakeStore()
+	emitter := &fakeEmitter{}
 	handler := &Handler{
 		Store:   store,
-		Emitter: &fakeEmitter{},
+		Emitter: emitter,
 		Clock:   time.Now,
 	}
 
@@ -306,6 +307,16 @@ func TestCreateHandler_PersistsRig(t *testing.T) {
 	}
 	if meta[FieldRig] != "gascity-prod" {
 		t.Errorf("rig = %q, want %q", meta[FieldRig], "gascity-prod")
+	}
+	if len(emitter.events) != 1 {
+		t.Fatalf("emitted events = %d, want 1", len(emitter.events))
+	}
+	var payload CreatedPayload
+	if err := json.Unmarshal(emitter.events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshaling event payload: %v", err)
+	}
+	if payload.Rig != "gascity-prod" {
+		t.Errorf("payload.Rig = %q, want %q", payload.Rig, "gascity-prod")
 	}
 }
 

--- a/internal/convergence/create_test.go
+++ b/internal/convergence/create_test.go
@@ -281,3 +281,54 @@ func TestCreateHandler_DefaultGateMode(t *testing.T) {
 		t.Errorf("gate_mode = %q, want %q", meta[FieldGateMode], GateModeManual)
 	}
 }
+
+func TestCreateHandler_PersistsRig(t *testing.T) {
+	store := newFakeStore()
+	handler := &Handler{
+		Store:   store,
+		Emitter: &fakeEmitter{},
+		Clock:   time.Now,
+	}
+
+	result, err := handler.CreateHandler(context.Background(), CreateParams{
+		Formula:       "test-formula",
+		Target:        "test-agent",
+		MaxIterations: 3,
+		GateMode:      GateModeManual,
+		Rig:           "gascity-prod",
+	})
+	if err != nil {
+		t.Fatalf("CreateHandler returned error: %v", err)
+	}
+	meta, err := store.GetMetadata(result.BeadID)
+	if err != nil {
+		t.Fatalf("GetMetadata(%q): %v", result.BeadID, err)
+	}
+	if meta[FieldRig] != "gascity-prod" {
+		t.Errorf("rig = %q, want %q", meta[FieldRig], "gascity-prod")
+	}
+}
+
+func TestCreateHandler_EmptyRigForCityScope(t *testing.T) {
+	store := newFakeStore()
+	handler := &Handler{
+		Store:   store,
+		Emitter: &fakeEmitter{},
+		Clock:   time.Now,
+	}
+
+	result, err := handler.CreateHandler(context.Background(), CreateParams{
+		Formula:       "test-formula",
+		Target:        "test-agent",
+		MaxIterations: 3,
+		GateMode:      GateModeManual,
+		// Rig left empty — city/HQ scope.
+	})
+	if err != nil {
+		t.Fatalf("CreateHandler returned error: %v", err)
+	}
+	meta, _ := store.GetMetadata(result.BeadID)
+	if meta[FieldRig] != "" {
+		t.Errorf("rig = %q, want empty for city scope", meta[FieldRig])
+	}
+}

--- a/internal/convergence/events.go
+++ b/internal/convergence/events.go
@@ -74,6 +74,7 @@ func EventIDManualStop(beadID string) string {
 type CreatedPayload struct {
 	Formula       string  `json:"formula"`
 	Target        string  `json:"target"`
+	Rig           string  `json:"rig,omitempty"`
 	GateMode      string  `json:"gate_mode"`
 	MaxIterations int     `json:"max_iterations"`
 	Title         string  `json:"title"`
@@ -92,6 +93,7 @@ type GateResultPayload struct {
 
 // IterationPayload is the structured payload for ConvergenceIteration events.
 type IterationPayload struct {
+	Rig                  string             `json:"rig,omitempty"`
 	Iteration            int                `json:"iteration"`
 	WispID               string             `json:"wisp_id"`
 	AgentVerdict         string             `json:"agent_verdict"`
@@ -110,6 +112,7 @@ type IterationPayload struct {
 
 // TerminatedPayload is the structured payload for ConvergenceTerminated events.
 type TerminatedPayload struct {
+	Rig                  string `json:"rig,omitempty"`
 	TerminalReason       string `json:"terminal_reason"` // approved|no_convergence|stopped
 	TotalIterations      int    `json:"total_iterations"`
 	FinalStatus          string `json:"final_status"` // always "closed"
@@ -119,6 +122,7 @@ type TerminatedPayload struct {
 
 // WaitingManualPayload is the structured payload for ConvergenceWaitingManual events.
 type WaitingManualPayload struct {
+	Rig                  string             `json:"rig,omitempty"`
 	Iteration            int                `json:"iteration"`
 	WispID               string             `json:"wisp_id"`
 	AgentVerdict         string             `json:"agent_verdict"`
@@ -133,6 +137,7 @@ type WaitingManualPayload struct {
 // ManualActionPayload is the structured payload for ConvergenceManualApprove,
 // ConvergenceManualIterate, and ConvergenceManualStop events.
 type ManualActionPayload struct {
+	Rig        string  `json:"rig,omitempty"`
 	Actor      string  `json:"actor"` // operator:<username>
 	PriorState string  `json:"prior_state"`
 	NewState   string  `json:"new_state"`

--- a/internal/convergence/handler.go
+++ b/internal/convergence/handler.go
@@ -143,9 +143,10 @@ type HandlerResult struct {
 // root bead at a time. The controller event loop provides this guarantee.
 // Violating this assumption can cause stale-read races on metadata snapshots.
 type Handler struct {
-	Store   Store
-	Emitter EventEmitter
-	Clock   func() time.Time // injectable for testing; defaults to time.Now
+	Store     Store
+	StorePath string
+	Emitter   EventEmitter
+	Clock     func() time.Time // injectable for testing; defaults to time.Now
 }
 
 // HandleWispClosed processes a wisp_closed event for a convergence root bead.
@@ -668,6 +669,7 @@ func (h *Handler) evaluateGate(
 		BeadID:      rootBeadID,
 		Iteration:   iteration,
 		CityPath:    cityPath,
+		StorePath:   h.StorePath,
 		WispID:      wispID,
 		DocPath:     meta[VarPrefix+"doc_path"],
 		ArtifactDir: ArtifactDirFor(cityPath, rootBeadID, iteration),
@@ -776,7 +778,44 @@ func (h *Handler) emitEvent(eventType, eventID, beadID string, payload any) {
 	if h.Emitter == nil {
 		return
 	}
-	h.Emitter.Emit(eventType, eventID, beadID, MarshalPayload(payload), false)
+	h.Emitter.Emit(eventType, eventID, beadID, MarshalPayload(h.withEventRig(beadID, payload)), false)
+}
+
+func (h *Handler) withEventRig(beadID string, payload any) any {
+	rig := h.eventRig(beadID)
+	if rig == "" {
+		return payload
+	}
+	switch p := payload.(type) {
+	case CreatedPayload:
+		p.Rig = rig
+		return p
+	case IterationPayload:
+		p.Rig = rig
+		return p
+	case TerminatedPayload:
+		p.Rig = rig
+		return p
+	case WaitingManualPayload:
+		p.Rig = rig
+		return p
+	case ManualActionPayload:
+		p.Rig = rig
+		return p
+	default:
+		return payload
+	}
+}
+
+func (h *Handler) eventRig(beadID string) string {
+	if h.Store == nil || beadID == "" {
+		return ""
+	}
+	meta, err := h.Store.GetMetadata(beadID)
+	if err != nil {
+		return ""
+	}
+	return meta[FieldRig]
 }
 
 // clock returns the current time, using the injected Clock or time.Now.

--- a/internal/convergence/handler_test.go
+++ b/internal/convergence/handler_test.go
@@ -304,6 +304,42 @@ func (e *fakeEmitter) findEvent(eventType string) (emittedEvent, bool) {
 	return emittedEvent{}, false
 }
 
+func TestWithEventRigPopulatesEveryRigPayload(t *testing.T) {
+	store := newFakeStore()
+	store.addBead("root-1", "in_progress", "", "", map[string]string{
+		FieldRig: "prod",
+	})
+	handler := &Handler{Store: store}
+
+	tests := []struct {
+		name    string
+		payload any
+	}{
+		{name: "created", payload: CreatedPayload{}},
+		{name: "iteration", payload: IterationPayload{}},
+		{name: "terminated", payload: TerminatedPayload{}},
+		{name: "waiting manual", payload: WaitingManualPayload{}},
+		{name: "manual action", payload: ManualActionPayload{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := handler.withEventRig("root-1", tc.payload)
+			data, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshaling payload: %v", err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshaling payload: %v", err)
+			}
+			if decoded["rig"] != "prod" {
+				t.Fatalf("rig = %v, want prod", decoded["rig"])
+			}
+		})
+	}
+}
+
 // --- Test Helpers ---
 
 // setupBasicHandler creates a handler with a fake store and emitter,

--- a/internal/convergence/metadata.go
+++ b/internal/convergence/metadata.go
@@ -32,6 +32,7 @@ const (
 	FieldWaitingReason     = "convergence.waiting_reason"
 	FieldRetrySource       = "convergence.retry_source"
 	FieldCityPath          = "convergence.city_path"
+	FieldRig               = "convergence.rig"
 	FieldEvaluatePrompt    = "convergence.evaluate_prompt"
 	FieldGateStdout        = "convergence.gate_stdout"
 	FieldGateStderr        = "convergence.gate_stderr"

--- a/internal/convergence/reconcile.go
+++ b/internal/convergence/reconcile.go
@@ -667,5 +667,5 @@ func (r *Reconciler) emitRecoveryEvent(eventType, eventID, beadID string, payloa
 	if r.Handler.Emitter == nil {
 		return
 	}
-	r.Handler.Emitter.Emit(eventType, eventID, beadID, MarshalPayload(payload), true)
+	r.Handler.Emitter.Emit(eventType, eventID, beadID, MarshalPayload(r.Handler.withEventRig(beadID, payload)), true)
 }

--- a/internal/convergence/reconcile_test.go
+++ b/internal/convergence/reconcile_test.go
@@ -161,6 +161,7 @@ func TestReconcile_TerminatedNotClosed_CompletesClosure(t *testing.T) {
 		FieldTerminalActor:  "controller",
 		FieldFormula:        "test-formula",
 		FieldMaxIterations:  "5",
+		FieldRig:            "prod",
 	})
 
 	// Add a closed wisp child.
@@ -192,6 +193,13 @@ func TestReconcile_TerminatedNotClosed_CompletesClosure(t *testing.T) {
 	}
 	if ev.BeadID != "root-1" {
 		t.Errorf("event bead_id = %q, want %q", ev.BeadID, "root-1")
+	}
+	var payload TerminatedPayload
+	if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+		t.Fatalf("unmarshaling payload: %v", err)
+	}
+	if payload.Rig != "prod" {
+		t.Errorf("payload.Rig = %q, want prod", payload.Rig)
 	}
 }
 
@@ -296,6 +304,7 @@ func TestReconcile_WaitingManual_GenuineHold_NoStateChange(t *testing.T) {
 		FieldFormula:           "test-formula",
 		FieldGateMode:          GateModeManual,
 		FieldIteration:         "1",
+		FieldRig:               "prod",
 	})
 
 	store.addBead("wisp-1", "closed", "root-1", IdempotencyKey("root-1", 1), nil)
@@ -323,6 +332,13 @@ func TestReconcile_WaitingManual_GenuineHold_NoStateChange(t *testing.T) {
 	}
 	if !ev.Recovery {
 		t.Error("expected recovery flag to be true")
+	}
+	var payload WaitingManualPayload
+	if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+		t.Fatalf("unmarshaling payload: %v", err)
+	}
+	if payload.Rig != "prod" {
+		t.Errorf("payload.Rig = %q, want prod", payload.Rig)
 	}
 }
 

--- a/internal/convergence/retry.go
+++ b/internal/convergence/retry.go
@@ -49,6 +49,7 @@ func (h *Handler) RetryHandler(_ context.Context, sourceBeadID, _ string, maxIte
 	gateTimeout := meta[FieldGateTimeout]
 	gateTimeoutAction := meta[FieldGateTimeoutAction]
 	cityPath := meta[FieldCityPath]
+	rig := meta[FieldRig]
 	evaluatePrompt := meta[FieldEvaluatePrompt]
 	vars := ExtractVars(meta)
 
@@ -93,6 +94,7 @@ func (h *Handler) RetryHandler(_ context.Context, sourceBeadID, _ string, maxIte
 		{FieldGateTimeoutAction, gateTimeoutAction},
 		{FieldMaxIterations, EncodeInt(maxIterations)},
 		{FieldCityPath, cityPath},
+		{FieldRig, rig},
 		{FieldEvaluatePrompt, evaluatePrompt},
 		{FieldRetrySource, sourceBeadID},
 		{FieldState, StateActive},

--- a/internal/convergence/retry_test.go
+++ b/internal/convergence/retry_test.go
@@ -52,6 +52,20 @@ func setupTerminatedHandler(t *testing.T, terminalReason string, extraMeta map[s
 	return handler, store, emitter
 }
 
+func TestRetryHandler_CarriesRigForward(t *testing.T) {
+	handler, store, _ := setupTerminatedHandler(t, TerminalStopped,
+		map[string]string{FieldRig: "gascity-prod"})
+
+	result, err := handler.RetryHandler(context.Background(), "source-1", "alice", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	meta, _ := store.GetMetadata(result.NewBeadID)
+	if meta[FieldRig] != "gascity-prod" {
+		t.Errorf("retry bead rig = %q, want %q (rig must carry forward)", meta[FieldRig], "gascity-prod")
+	}
+}
+
 func TestRetryHandler_Success(t *testing.T) {
 	handler, store, _ := setupTerminatedHandler(t, TerminalStopped, nil)
 


### PR DESCRIPTION
## Summary

- `gc --rig <name> converge create` silently ignored `--rig` and always
  wrote the convergence root bead to the city/HQ store — the flag was
  parsed at the root command but dropped by the `converge` subcommand and
  the controller handler. Fixes #2357.
- Convergence is now multi-store: the controller keeps one
  `convergenceScope` per bead store (city/HQ plus each bound rig); the
  tick loop, startup reconcile, create, retry, approve, iterate and stop
  all route by the resolved `--rig`.
- `internal/convergence`: `CreateParams` gains a `Rig` field, persisted
  as the `convergence.rig` metadata key; `RetryHandler` carries it
  forward.
- CLI: `create`/`retry`/`approve`/`iterate`/`stop` forward the resolved
  `--rig`; `status`/`list`/`test-gate` open the rig's bead store;
  `status` and `list` surface the owning rig.
- An unknown or unbound `--rig` fails loudly (distinguishing the two)
  instead of silently falling back to HQ.
- `--max-per-agent` concurrency is accounted per bead store.
- New unit + controller integration tests cover rig-store create
  routing, unknown/unbound-rig errors, multi-store tick and startup
  reconcile, and rig-scoped stop/retry routing.
- Known limitation: scopes are built once at controller start; rigs
  added by a later config reload need a restart — tracked in #2403.

## Validation

- `go build ./...`
- `go vet ./...`
- `golangci-lint run` — clean for changed packages
- `go test ./internal/convergence/...`
- `go test ./cmd/gc/ -run Convergence`

Three pre-existing macOS-only `cmd/gc` failures
(`TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates`,
`TestRunStartDriftCheck_RestartReturnsContinue`,
`TestFileOpenedByAnyProcessUsesUnixSocketTableForStaleSocket`) are
unrelated to convergence and reproduce on a clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
