### PR TITLE
fix(mcp): skip MCP projection for implicit infrastructure agents (#2203)

### DIFF
--- a/cmd/gc/mcp_integration.go
+++ b/cmd/gc/mcp_integration.go
@@ -73,6 +73,15 @@ func resolveAgentMCPProjection(
 	qualifiedName, workDir string,
 	providerKind string,
 ) (materialize.MCPCatalog, materialize.MCPProjection, error) {
+	// Implicit infrastructure agents (control-dispatcher, provider-coverage
+	// stubs from config.InjectImplicitAgents) never invoke MCP — same
+	// reasoning as the peer-conflict loop in proposeAgentMCPTargets below.
+	// Skipping here avoids the provider-family check tripping on synthesized
+	// agents that have no Provider field set yet inherit the city pack's
+	// MCP catalog (gascity#2203).
+	if agent != nil && agent.Implicit {
+		return materialize.MCPCatalog{}, materialize.MCPProjection{}, nil
+	}
 	catalog, err := loadEffectiveMCPForAgent(cityPath, cfg, agent, qualifiedName, workDir)
 	if err != nil {
 		return materialize.MCPCatalog{}, materialize.MCPProjection{}, err

--- a/cmd/gc/mcp_integration.go
+++ b/cmd/gc/mcp_integration.go
@@ -73,20 +73,14 @@ func resolveAgentMCPProjection(
 	qualifiedName, workDir string,
 	providerKind string,
 ) (materialize.MCPCatalog, materialize.MCPProjection, error) {
-	// Implicit infrastructure agents (control-dispatcher, provider-coverage
-	// stubs from config.InjectImplicitAgents) never invoke MCP — same
-	// reasoning as the peer-conflict loop in proposeAgentMCPTargets below.
-	// Skipping here avoids the provider-family check tripping on synthesized
-	// agents that have no Provider field set yet inherit the city pack's
-	// MCP catalog (gascity#2203).
-	if agent != nil && agent.Implicit {
-		return materialize.MCPCatalog{}, materialize.MCPProjection{}, nil
-	}
 	catalog, err := loadEffectiveMCPForAgent(cityPath, cfg, agent, qualifiedName, workDir)
 	if err != nil {
 		return materialize.MCPCatalog{}, materialize.MCPProjection{}, err
 	}
 	if !supportsMCPProviderKind(providerKind) {
+		if shouldSkipImplicitStartCommandMCP(agent, providerKind) {
+			return materialize.MCPCatalog{}, materialize.MCPProjection{}, nil
+		}
 		if len(catalog.Servers) > 0 {
 			return materialize.MCPCatalog{}, materialize.MCPProjection{}, fmt.Errorf(
 				"effective MCP requires a supported provider family, got %q", providerKind)
@@ -98,6 +92,19 @@ func resolveAgentMCPProjection(
 		return materialize.MCPCatalog{}, materialize.MCPProjection{}, err
 	}
 	return catalog, projection, nil
+}
+
+// shouldSkipImplicitStartCommandMCP matches implicit infrastructure agents that
+// run from StartCommand without a provider family. Provider-backed implicit
+// agents injected for coverage set Provider and must still project inherited
+// MCP; validateStage2TargetClaimants can skip implicit peers more broadly
+// because it is only checking conflicts from other agents.
+func shouldSkipImplicitStartCommandMCP(agent *config.Agent, providerKind string) bool {
+	return agent != nil &&
+		agent.Implicit &&
+		strings.TrimSpace(agent.StartCommand) != "" &&
+		strings.TrimSpace(agent.Provider) == "" &&
+		strings.TrimSpace(providerKind) == ""
 }
 
 func mergeMCPFingerprintEntry(fpExtra map[string]string, projection materialize.MCPProjection) map[string]string {

--- a/cmd/gc/mcp_supervisor_test.go
+++ b/cmd/gc/mcp_supervisor_test.go
@@ -363,15 +363,14 @@ url = "https://example.com/deputy"
 	}
 }
 
-func TestResolveAgentMCPProjectionSkipsImplicitAgents(t *testing.T) {
-	// Implicit infrastructure agents (control-dispatcher,
-	// provider-coverage stubs from config.InjectImplicitAgents) are
-	// synthesized without a Provider field but inherit the city pack's
-	// MCP catalog. They never invoke `gc internal project-mcp` (see the
-	// peer-conflict skip in proposeAgentMCPTargets), so MCP resolution
-	// should short-circuit for them rather than trip the provider-family
-	// validation. Regression for gascity#2203 — formula_v2 cities that
-	// register MCP servers used to fail city start with:
+func TestResolveAgentMCPProjectionSkipsImplicitStartCommandAgents(t *testing.T) {
+	// Implicit start-command infrastructure agents can inherit the city pack's
+	// MCP catalog while having no provider family. They never invoke
+	// `gc internal project-mcp`, matching the implicit-peer skip in
+	// validateStage2TargetClaimants, so MCP resolution should short-circuit for
+	// them rather than trip provider-family validation. Regression for
+	// gascity#2203 - formula_v2 cities that register MCP servers used to fail
+	// city start with:
 	//   init: project MCP: agent "control-dispatcher": effective MCP
 	//   requires a supported provider family, got ""
 	cityPath := t.TempDir()
@@ -392,9 +391,10 @@ url = "http://localhost:3100/mcp/kb"
 	// emitted by config.injectControlDispatcherAgents: Implicit=true,
 	// empty Provider.
 	implicit := &config.Agent{
-		Name:     "control-dispatcher",
-		Scope:    "city",
-		Implicit: true,
+		Name:         config.ControlDispatcherAgentName,
+		Scope:        "city",
+		StartCommand: config.ControlDispatcherStartCommandFor(config.ControlDispatcherAgentName),
+		Implicit:     true,
 	}
 
 	catalog, projection, err := resolveAgentMCPProjection(
@@ -411,5 +411,83 @@ url = "http://localhost:3100/mcp/kb"
 	}
 	if projection.Provider != "" || len(projection.Servers) != 0 {
 		t.Fatalf("implicit agent should return zero MCPProjection, got %+v", projection)
+	}
+}
+
+func TestResolveAgentMCPProjectionKeepsImplicitStartCommandWithProviderKind(t *testing.T) {
+	cityPath := t.TempDir()
+	mcpFile := filepath.Join(cityPath, "mcp", "kb.toml")
+	writeMCPSource(t, mcpFile, `
+name = "kb"
+transport = "http"
+url = "http://localhost:3100/mcp/kb"
+`)
+
+	cfg := &config.City{
+		Workspace:  config.Workspace{Provider: "claude"},
+		Providers:  map[string]config.ProviderSpec{"claude": {Command: "echo", PromptMode: "none"}},
+		PackMCPDir: filepath.Join(cityPath, "mcp"),
+	}
+	implicit := &config.Agent{
+		Name:         config.ControlDispatcherAgentName,
+		Scope:        "city",
+		StartCommand: config.ControlDispatcherStartCommandFor(config.ControlDispatcherAgentName),
+		Implicit:     true,
+	}
+
+	catalog, projection, err := resolveAgentMCPProjection(
+		cityPath, cfg, implicit,
+		config.ControlDispatcherAgentName,
+		filepath.Join(cityPath, ".gc", "control-dispatcher"),
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("resolveAgentMCPProjection(implicit with providerKind): %v", err)
+	}
+	if len(catalog.Servers) != 1 {
+		t.Fatalf("catalog servers len = %d, want 1", len(catalog.Servers))
+	}
+	if projection.Provider != "claude" {
+		t.Fatalf("projection provider = %q, want claude", projection.Provider)
+	}
+	if len(projection.Servers) != 1 {
+		t.Fatalf("projection servers len = %d, want 1", len(projection.Servers))
+	}
+}
+
+func TestBuildStage1MCPTargetsIncludesImplicitProviderAgents(t *testing.T) {
+	cityPath := t.TempDir()
+	mcpFile := filepath.Join(cityPath, "mcp", "kb.toml")
+	writeMCPSource(t, mcpFile, `
+name = "kb"
+transport = "http"
+url = "http://localhost:3100/mcp/kb"
+`)
+
+	cfg := &config.City{
+		Workspace:  config.Workspace{Provider: "claude"},
+		Providers:  map[string]config.ProviderSpec{"claude": {Command: "echo", PromptMode: "none"}},
+		Session:    config.SessionConfig{Provider: "tmux"},
+		PackMCPDir: filepath.Join(cityPath, "mcp"),
+		Agents: []config.Agent{
+			{Name: "claude", Provider: "claude", Implicit: true},
+		},
+	}
+
+	targets, err := buildStage1MCPTargets(cityPath, cfg, stubLookPath)
+	if err != nil {
+		t.Fatalf("buildStage1MCPTargets: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("stage1 targets len = %d, want 1: %+v", len(targets), targets)
+	}
+	if targets[0].Projection.Provider != "claude" {
+		t.Fatalf("projection provider = %q, want claude", targets[0].Projection.Provider)
+	}
+	if len(targets[0].Projection.Servers) != 1 {
+		t.Fatalf("projection servers len = %d, want 1", len(targets[0].Projection.Servers))
+	}
+	if got := targets[0].Agents; len(got) != 1 || got[0] != "claude" {
+		t.Fatalf("target agents = %+v, want [claude]", got)
 	}
 }

--- a/cmd/gc/mcp_supervisor_test.go
+++ b/cmd/gc/mcp_supervisor_test.go
@@ -362,3 +362,54 @@ url = "https://example.com/deputy"
 		t.Fatalf("stage2-only agents should not contribute stage1 targets, got %+v", targets)
 	}
 }
+
+func TestResolveAgentMCPProjectionSkipsImplicitAgents(t *testing.T) {
+	// Implicit infrastructure agents (control-dispatcher,
+	// provider-coverage stubs from config.InjectImplicitAgents) are
+	// synthesized without a Provider field but inherit the city pack's
+	// MCP catalog. They never invoke `gc internal project-mcp` (see the
+	// peer-conflict skip in proposeAgentMCPTargets), so MCP resolution
+	// should short-circuit for them rather than trip the provider-family
+	// validation. Regression for gascity#2203 — formula_v2 cities that
+	// register MCP servers used to fail city start with:
+	//   init: project MCP: agent "control-dispatcher": effective MCP
+	//   requires a supported provider family, got ""
+	cityPath := t.TempDir()
+	mcpFile := filepath.Join(cityPath, "mcp", "kb.toml")
+	writeMCPSource(t, mcpFile, `
+name = "kb"
+transport = "http"
+url = "http://localhost:3100/mcp/kb"
+`)
+
+	cfg := &config.City{
+		Workspace:  config.Workspace{Provider: "claude"},
+		Providers:  map[string]config.ProviderSpec{"claude": {Command: "echo", PromptMode: "none"}},
+		PackMCPDir: filepath.Join(cityPath, "mcp"),
+	}
+
+	// Reproduce the shape of the implicit control-dispatcher agent
+	// emitted by config.injectControlDispatcherAgents: Implicit=true,
+	// empty Provider.
+	implicit := &config.Agent{
+		Name:     "control-dispatcher",
+		Scope:    "city",
+		Implicit: true,
+	}
+
+	catalog, projection, err := resolveAgentMCPProjection(
+		cityPath, cfg, implicit,
+		"control-dispatcher",
+		filepath.Join(cityPath, ".gc", "control-dispatcher"),
+		"", // empty providerKind matches the bug scenario
+	)
+	if err != nil {
+		t.Fatalf("resolveAgentMCPProjection(implicit) returned error: %v", err)
+	}
+	if len(catalog.Servers) != 0 {
+		t.Fatalf("implicit agent should return empty MCP catalog, got %d servers", len(catalog.Servers))
+	}
+	if projection.Provider != "" || len(projection.Servers) != 0 {
+		t.Fatalf("implicit agent should return zero MCPProjection, got %+v", projection)
+	}
+}

--- a/cmd/gc/template_resolve_mcp_test.go
+++ b/cmd/gc/template_resolve_mcp_test.go
@@ -143,6 +143,50 @@ args = ["notes-mcp"]
 		}
 	})
 
+	t.Run("implicit control dispatcher skips inherited pack mcp", func(t *testing.T) {
+		cfg := &config.City{
+			Workspace:  config.Workspace{Provider: "claude"},
+			Providers:  map[string]config.ProviderSpec{"claude": {Command: "echo", PromptMode: "none"}},
+			Daemon:     config.DaemonConfig{FormulaV2: true},
+			PackMCPDir: filepath.Join(cityPath, "mcp"),
+		}
+		config.InjectImplicitAgents(cfg)
+		var control *config.Agent
+		for i := range cfg.Agents {
+			if cfg.Agents[i].Name == config.ControlDispatcherAgentName {
+				control = &cfg.Agents[i]
+				break
+			}
+		}
+		if control == nil {
+			t.Fatal("InjectImplicitAgents did not create control-dispatcher")
+		}
+		params := &agentBuildParams{
+			city:            cfg,
+			cityName:        "city",
+			cityPath:        cityPath,
+			workspace:       &cfg.Workspace,
+			providers:       cfg.Providers,
+			lookPath:        stubLookPath,
+			fs:              fsys.OSFS{},
+			beaconTime:      time.Unix(0, 0),
+			beadNames:       make(map[string]string),
+			stderr:          io.Discard,
+			sessionProvider: "tmux",
+		}
+
+		tp, err := resolveTemplate(params, control, control.QualifiedName(), nil)
+		if err != nil {
+			t.Fatalf("resolveTemplate(control-dispatcher): %v", err)
+		}
+		if len(tp.MCPServers) != 0 {
+			t.Fatalf("control-dispatcher MCPServers len = %d, want 0", len(tp.MCPServers))
+		}
+		if got := tp.FPExtra["mcp:claude"]; got != "" {
+			t.Fatalf("control-dispatcher unexpectedly contributed MCP fingerprint %q", got)
+		}
+	})
+
 	t.Run("wrapped opencode provider accepts mcp", func(t *testing.T) {
 		cityCfg.Providers["wrapped-opencode"] = config.ProviderSpec{
 			Base:       stringPtr("builtin:opencode"),


### PR DESCRIPTION
## Summary

Implements **option 2** from #2203: skip MCP catalog resolution for `Implicit=true` agents in `resolveAgentMCPProjection`, mirroring the existing skip in the peer-conflict loop at `cmd/gc/mcp_integration.go:461`.

## Problem

`InjectImplicitAgents` synthesizes infrastructure agents (`control-dispatcher`, provider-coverage stubs) with `Implicit=true` and **no** `Provider` field. They never invoke `gc internal project-mcp` — they exist only as sling-target stubs and graph.v2 control beads handlers.

However, `resolveAgentMCPProjection` (the main resolution path called for each agent) loads the city pack's MCP catalog for *every* agent, then validates the provider family. For an implicit agent with empty `Provider` and a non-empty `cfg.PackMCPDir` (any pack registering MCP servers), `supportsMCPProviderKind("")` returns false → the `len(catalog.Servers) > 0` branch fires → city init fails:

```
init: project MCP: agent "control-dispatcher": effective MCP requires a supported provider family, got ""
```

This blocks `formula_v2 = true` for any city that registers MCP tools. We hit this in [pedalix/agentic-factory](https://github.com/pedalix/agentic-factory) — our factory daemon serves an HTTP MCP via `mcp/kb.toml`, and turning on `formula_v2` for graph.v2 dispatch breaks the city.

## Fix

Early-return for `Implicit` agents at the top of `resolveAgentMCPProjection`:

```go
if agent != nil && agent.Implicit {
    return materialize.MCPCatalog{}, materialize.MCPProjection{}, nil
}
```

This is semantically correct (infrastructure agents don't have user-tool MCPs) and aligns with the existing precedent at `proposeAgentMCPTargets:461` where `other.Implicit` peers are already skipped from MCP target-claim conflicts:

```go
// Implicit agents are synthetic provider-coverage entries
// (config.InjectImplicitAgents) used for sling target
// materialization, not real MCP writers. They never invoke
// `gc internal project-mcp`, so they cannot race with the
// caller for this target.
if other.Implicit {
    continue
}
```

The caller-side skip wasn't there — this PR closes that gap.

## Test

Added `TestResolveAgentMCPProjectionSkipsImplicitAgents` in `cmd/gc/mcp_supervisor_test.go`:

- Builds a `City` with `Workspace.Provider = "claude"`, a populated `PackMCPDir` (one MCP server registered)
- Creates an `Agent{Name: "control-dispatcher", Implicit: true}` with empty `Provider`
- Calls `resolveAgentMCPProjection(...)` with `providerKind=""`
- Asserts: no error, empty `MCPCatalog`, empty `MCPProjection`

Pre-patch this test would fail with `effective MCP requires a supported provider family, got ""`. Post-patch it passes.

Verified locally: `go test ./cmd/gc/ -run TestResolveAgentMCPProjection -v` passes.

The other adjacent tests in `mcp_supervisor_test.go` (`TestValidateStage2*`, `TestBuildStage1MCPTargets*`, `TestResolveAgent*`) continue to pass — no regression.

## Notes

This addresses option 2 from #2203, which the issue author noted is "safer as it doesn't require infrastructure agents to opt into a provider." Option 1 (propagating `cfg.Workspace.Provider` into `newControlDispatcherAgent`) would also work but couples the implicit agent's MCP eligibility to workspace provider configuration, where as option 2 expresses the actual semantics: implicit agents don't have MCP catalogs.

Closes #2203.