### PR TITLE
fix(cmd/gc): reap live runtimes bound to closed session beads

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -482,6 +482,10 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		}()
 
 		cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
+		// Reap live runtimes still bound to a closed bead (e.g. a named-session
+		// identity re-minted as a pool slot) so the name's current owner can
+		// rebind it and attach lands on the right runtime.
+		reapRuntimesBoundToClosedBeads(cr.cityBeadStore(), sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
 		// Reap stale session beads from a previous run before building desired
 		// state, so desired state does not reference already-closed beads (#742).
 		if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
@@ -855,6 +859,10 @@ func (cr *CityRuntime) tick(
 	// Reap open session beads whose tmux session is dead before loading demand
 	// so stale names cannot block desired-state computation (#742).
 	cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
+	// Reap live runtimes still bound to a closed bead (e.g. a named-session
+	// identity re-minted as a pool slot) so the name's current owner can rebind
+	// it and attach lands on the right runtime.
+	reapRuntimesBoundToClosedBeads(cr.cityBeadStore(), sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
 	if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
 		sessionBeads = cr.loadSessionBeadSnapshot()
 	}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1801,6 +1801,109 @@ func cleanupDeadRuntimeSessionCorpses(
 	return cleaned
 }
 
+// reapRuntimesBoundToClosedBeads stops live runtime sessions whose
+// GC_SESSION_ID identifies a session bead that has already been closed.
+//
+// This heals the case where a session_name (or its public alias) is reassigned
+// from one bead to another — e.g. a named session is retired and the same
+// identity is re-minted as a pool slot, or the two race over the alias and the
+// loser is archived. The losing bead is closed, but its tmux runtime can keep
+// running, still stamped with the closed bead's GC_SESSION_ID. The session_name
+// is now owned by a different, live bead, so:
+//   - `gc session attach <alias>` resolves to the live bead but lands on the
+//     stale runtime (matched by name), which exits on the next interaction
+//     because its own bead is gone; and
+//   - the live bead cannot (re)bind the name because the corpse still holds it.
+//
+// cleanupDeadRuntimeSessionCorpses does not catch this: it walks *open* beads
+// and only stops runtimes whose pane is already dead. Here the bead is *closed*
+// and the runtime is very much alive, so we walk the other direction — over
+// live runtimes — and reap any whose owning bead is confirmed closed.
+//
+// Safety: a runtime is only reaped when its GC_SESSION_ID names a bead the store
+// confirms is closed. A runtime without a readable GC_SESSION_ID, or one whose
+// bead is still open or cannot be fetched (e.g. another rig, or a transient
+// store error), is left untouched. Active drains are left to the drainTracker.
+func reapRuntimesBoundToClosedBeads(
+	store beads.Store,
+	sessionBeads *sessionBeadSnapshot,
+	dt *drainTracker,
+	sp runtime.Provider,
+	stderr io.Writer,
+) int {
+	if store == nil || sp == nil {
+		return 0
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	visible, err := sp.ListRunning("")
+	partialList := runtime.IsPartialListError(err)
+	if err != nil && !partialList {
+		fmt.Fprintf(stderr, "session reconciler: listing runtime sessions for closed-bead reap: %v\n", err) //nolint:errcheck
+		return 0
+	}
+	if partialList {
+		fmt.Fprintf(stderr, "session reconciler: listing runtime sessions partially failed for closed-bead reap; checking %d visible session(s): %v\n", len(visible), err) //nolint:errcheck
+	}
+	if len(visible) == 0 {
+		return 0
+	}
+
+	reaped := 0
+	seen := make(map[string]bool, len(visible))
+	for _, name := range visible {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+
+		// Attribute the runtime to a bead via GC_SESSION_ID. Without it we
+		// cannot tell which bead owns the runtime, so we leave it alone.
+		liveID, err := sp.GetMeta(name, "GC_SESSION_ID")
+		if err != nil {
+			continue
+		}
+		liveID = strings.TrimSpace(liveID)
+		if liveID == "" {
+			continue
+		}
+
+		// A runtime whose bead is still open is healthy (or is mid-wake and
+		// will be); the snapshot holds only open beads, so a hit means leave it.
+		if _, ok := sessionBeads.FindByID(liveID); ok {
+			continue
+		}
+
+		// The bead is not open. Confirm it is actually closed before reaping —
+		// a missing or unreadable record must not trigger a stop.
+		bead, err := store.Get(liveID)
+		if err != nil {
+			continue
+		}
+		if bead.Status != "closed" {
+			continue
+		}
+
+		// Teardown ordering for draining beads belongs to the drainTracker.
+		if dt != nil && dt.get(liveID) != nil {
+			continue
+		}
+
+		if err := sp.Stop(name); err != nil {
+			if runtime.IsSessionGone(err) {
+				continue
+			}
+			fmt.Fprintf(stderr, "session reconciler: reaping runtime %q bound to closed bead %s: %v\n", name, liveID, err) //nolint:errcheck
+			continue
+		}
+		fmt.Fprintf(stderr, "session reconciler: reaped runtime %q bound to closed session bead %s\n", name, liveID) //nolint:errcheck
+		reaped++
+	}
+	return reaped
+}
+
 func closeSessionBeadIfRuntimeStoppedAndUnassigned(
 	store beads.Store,
 	rigStores map[string]beads.Store,

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -5414,6 +5414,129 @@ func TestCleanupDeadRuntimeSessionCorpsesReportsStopErrors(t *testing.T) {
 	}
 }
 
+// TestReapRuntimesBoundToClosedBeadsStopsLiveRuntime reproduces the alias
+// hand-off corpse: a live runtime is still stamped with a closed bead's
+// GC_SESSION_ID while its session_name now belongs to a different, open bead.
+// The corpse must be reaped so the live owner can rebind the name.
+func TestReapRuntimesBoundToClosedBeadsStopsLiveRuntime(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["mayor"] = true
+	if err := sp.SetMeta("mayor", "GC_SESSION_ID", "gm-closed"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+
+	store := beads.NewMemStoreFrom(0, []beads.Bead{{ID: "gm-closed", Status: "closed"}}, nil)
+	// The session_name "mayor" is now owned by a different, open bead.
+	snapshot := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "gm-open",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "mayor",
+		},
+	}})
+
+	var stderr bytes.Buffer
+	got := reapRuntimesBoundToClosedBeads(store, snapshot, nil, sp, &stderr)
+	if got != 1 {
+		t.Fatalf("reapRuntimesBoundToClosedBeads() = %d, want 1; stderr=%q", got, stderr.String())
+	}
+	if len(sp.stopped) != 1 || sp.stopped[0] != "mayor" {
+		t.Fatalf("stopped = %v, want [mayor]", sp.stopped)
+	}
+	if !strings.Contains(stderr.String(), "reaped runtime \"mayor\" bound to closed session bead gm-closed") {
+		t.Fatalf("stderr = %q, want reap message", stderr.String())
+	}
+}
+
+// TestReapRuntimesBoundToClosedBeadsSkipsOpenBeadRuntime: a healthy runtime
+// whose bead is still open must never be reaped.
+func TestReapRuntimesBoundToClosedBeadsSkipsOpenBeadRuntime(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["worker"] = true
+	if err := sp.SetMeta("worker", "GC_SESSION_ID", "gm-open"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	snapshot := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "gm-open",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker",
+		},
+	}})
+
+	var stderr bytes.Buffer
+	got := reapRuntimesBoundToClosedBeads(store, snapshot, nil, sp, &stderr)
+	if got != 0 || sp.stopCalls["worker"] != 0 {
+		t.Fatalf("reaped open-bead runtime: got=%d stopCalls=%d stderr=%q", got, sp.stopCalls["worker"], stderr.String())
+	}
+}
+
+// TestReapRuntimesBoundToClosedBeadsSkipsRuntimeWithoutSessionID: a runtime we
+// cannot attribute to a bead (no GC_SESSION_ID) is left untouched.
+func TestReapRuntimesBoundToClosedBeadsSkipsRuntimeWithoutSessionID(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["mystery"] = true
+
+	store := beads.NewMemStore()
+	snapshot := newSessionBeadSnapshot(nil)
+
+	var stderr bytes.Buffer
+	got := reapRuntimesBoundToClosedBeads(store, snapshot, nil, sp, &stderr)
+	if got != 0 || sp.stopCalls["mystery"] != 0 {
+		t.Fatalf("reaped unattributable runtime: got=%d stopCalls=%d", got, sp.stopCalls["mystery"])
+	}
+}
+
+// TestReapRuntimesBoundToClosedBeadsSkipsUnknownAndNonClosedBeads: a runtime
+// whose bead the store cannot return (e.g. another rig) or returns as not-closed
+// must not be reaped — only a confirmed-closed bead triggers a stop.
+func TestReapRuntimesBoundToClosedBeadsSkipsUnknownAndNonClosedBeads(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["foreign"] = true
+	sp.visible["still-open"] = true
+	if err := sp.SetMeta("foreign", "GC_SESSION_ID", "gm-elsewhere"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	if err := sp.SetMeta("still-open", "GC_SESSION_ID", "gm-open-not-in-snapshot"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+
+	// gm-elsewhere is absent from the store; gm-open-not-in-snapshot is present
+	// but open (a degraded snapshot that simply didn't list it).
+	store := beads.NewMemStoreFrom(0, []beads.Bead{{ID: "gm-open-not-in-snapshot", Status: "open"}}, nil)
+	snapshot := newSessionBeadSnapshot(nil)
+
+	var stderr bytes.Buffer
+	got := reapRuntimesBoundToClosedBeads(store, snapshot, nil, sp, &stderr)
+	if got != 0 || sp.stopCalls["foreign"] != 0 || sp.stopCalls["still-open"] != 0 {
+		t.Fatalf("reaped a runtime that was not confirmed-closed: got=%d stderr=%q", got, stderr.String())
+	}
+}
+
+// TestReapRuntimesBoundToClosedBeadsSkipsActiveDrain: teardown ordering for a
+// draining bead belongs to the drainTracker, so the reaper must defer to it.
+func TestReapRuntimesBoundToClosedBeadsSkipsActiveDrain(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["mayor"] = true
+	if err := sp.SetMeta("mayor", "GC_SESSION_ID", "gm-closed"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+
+	store := beads.NewMemStoreFrom(0, []beads.Bead{{ID: "gm-closed", Status: "closed"}}, nil)
+	snapshot := newSessionBeadSnapshot(nil)
+
+	dt := newDrainTracker()
+	dt.set("gm-closed", &drainState{reason: "user"})
+
+	var stderr bytes.Buffer
+	got := reapRuntimesBoundToClosedBeads(store, snapshot, dt, sp, &stderr)
+	if got != 0 || sp.stopCalls["mayor"] != 0 {
+		t.Fatalf("reaped a draining runtime: got=%d stopCalls=%d", got, sp.stopCalls["mayor"])
+	}
+}
+
 // TestUnclaimResetsInProgressStatus verifies the Bug 2 fix: unclaiming a
 // retired session's in_progress work must reset status to "open" so a fresh
 // worker can re-claim via the routed queue (Tier 3: gc.routed_to +


### PR DESCRIPTION
## Problem

When a session's `session_name`/alias is reassigned from one bead to another — e.g. a **named-session** identity is retired and re-minted as a **pool slot**, or the two race over the alias and the loser is archived — the losing bead is **closed**, but its tmux runtime can keep running, still stamped with the closed bead's `GC_SESSION_ID`. The `session_name` is now owned by a different, live bead, so:

- `gc session attach <alias>` resolves to the live bead but lands on the **stale runtime** (matched by name), which exits on the next interaction because its own bead is gone; and
- the live owner **cannot rebind the name** because the corpse still holds it.

`cleanupDeadRuntimeSessionCorpses` does **not** catch this: it walks *open* beads and only stops runtimes whose pane is already *dead*. Here the bead is **closed** and the runtime is **alive**.

### Observed in the wild

A `mayor` agent was migrated named-session → pool slot. Both beads existed for a while and fought over the `mayor` alias **423 times** (`pool_alias_conflict_count: 423`). The named bead lost, was archived, then closed — but its live tmux runtime (`GC_SESSION_ID=<closed-bead>`, `session_name=mayor`) was never torn down. `attach mayor` kept landing on the corpse and dying on first keystroke; the open pool bead that now owned `mayor` could not rebind the name.

## Fix

Add `reapRuntimesBoundToClosedBeads`, which walks **live runtimes** and stops any whose `GC_SESSION_ID` names a bead the store **confirms is closed**. Wired into both reconcile entry points (startup + per-tick), right after `cleanupDeadRuntimeSessionCorpses`.

### Safety

Only reaps when `GC_SESSION_ID` resolves to a **store-confirmed closed** bead. Left untouched:
- runtimes with no readable `GC_SESSION_ID` (unattributable),
- runtimes whose bead is still **open** (healthy / mid-wake),
- runtimes whose bead the store **cannot return** (e.g. another rig, transient error),
- runtimes with an **active drain** (teardown belongs to the drainTracker).

## Tests

`TestReapRuntimesBoundToClosedBeads*` — reap-the-corpse path plus four safety-skip paths (open bead, no session id, unknown/non-closed bead, active drain). `go vet` + `gofmt` clean; full pre-push suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)