### PR TITLE
fix(template): materialize-skills uses template name for named_session

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -223,10 +223,17 @@ func effectiveOverlayDirs(cityDirs []string, rigDirs map[string][]string, rigNam
 
 // templateNameFor returns the configuration template name for an agent.
 // For pool instances, this is the original template name (PoolName).
-// For regular agents, it's the qualified name.
+// For named_session expansions, the template name is cfgAgent's own
+// qualified name (e.g. "pringle/crew") — qualifiedName is the session
+// identity (e.g. "pringle/utz") and resolveAgentIdentity can't map it
+// back to the template, so `gc internal materialize-skills` exits 1.
+// For regular agents, qualifiedName already equals the template name.
 func templateNameFor(cfgAgent *config.Agent, qualifiedName string) string {
 	if cfgAgent.PoolName != "" {
 		return cfgAgent.PoolName
+	}
+	if t := cfgAgent.QualifiedName(); t != "" && t != qualifiedName {
+		return t
 	}
 	return qualifiedName
 }

--- a/cmd/gc/template_resolve_skills_test.go
+++ b/cmd/gc/template_resolve_skills_test.go
@@ -684,3 +684,83 @@ func TestResolveTemplatePoolInstanceMaterializeUsesTemplateName(t *testing.T) {
 		t.Errorf("singleton materialize-skills should carry own qualified name mayor; got: %q", singletonCmd)
 	}
 }
+
+// TestResolveTemplateNamedSessionMaterializeUsesTemplateName mirrors the
+// pool-instance regression for [[named_session]] entries. A named_session
+// expands a template agent under a session-specific qualifiedName
+// (e.g. template "rig/crew" → session "rig/utz"). materialize-skills
+// resolves the template via resolveAgentIdentity, which has no mapping
+// from "rig/utz" back to "rig/crew" — so pre_start[1] fails on every
+// named-session start (utz/frito/dorito in city_hy). Skills are
+// per-template; all sessions sharing a template share the catalog.
+func TestResolveTemplateNamedSessionMaterializeUsesTemplateName(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"),
+		[]byte("[pack]\nname = \"s\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skillDir := filepath.Join(cityPath, "skills", "plan")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: plan\ndescription: test\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sharedCat, err := materialize.LoadCityCatalog(filepath.Join(cityPath, "skills"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Template agent — Name="crew", Dir="rig". The named_session shares
+	// this config under qualifiedName "rig/utz". WorkDir != scope root
+	// so the stage-2 PreStart entry fires.
+	template := &config.Agent{
+		Name:     "crew",
+		Dir:      "rig",
+		Scope:    "rig",
+		Provider: "claude",
+		WorkDir:  ".gc/worktrees/rig/utz",
+	}
+
+	params := &agentBuildParams{
+		cityName:  "city",
+		cityPath:  cityPath,
+		workspace: &config.Workspace{Provider: "claude"},
+		providers: map[string]config.ProviderSpec{
+			"claude": {Command: "echo", PromptMode: "none"},
+		},
+		lookPath:        func(string) (string, error) { return "/bin/echo", nil },
+		fs:              fsys.OSFS{},
+		rigs:            []config.Rig{{Name: "rig", Path: filepath.Join(cityPath, "rig")}},
+		beaconTime:      time.Unix(0, 0),
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+		skillCatalog:    &sharedCat,
+		sessionProvider: "tmux",
+	}
+
+	tp, err := resolveTemplate(params, template, "rig/utz", nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	var materializeCmd string
+	for _, entry := range tp.Hints.PreStart {
+		if strings.Contains(entry, "internal materialize-skills") {
+			materializeCmd = entry
+			break
+		}
+	}
+	if materializeCmd == "" {
+		t.Fatalf("expected stage-2 materialize-skills PreStart entry; PreStart=%v", tp.Hints.PreStart)
+	}
+
+	if !strings.Contains(materializeCmd, "--agent rig/crew") {
+		t.Errorf("materialize-skills --agent flag should carry template name rig/crew; got: %q", materializeCmd)
+	}
+	if strings.Contains(materializeCmd, "--agent rig/utz") {
+		t.Errorf("materialize-skills --agent flag must NOT carry named_session identity rig/utz; got: %q", materializeCmd)
+	}
+}


### PR DESCRIPTION
## Summary

Mirror of [cb770047](https://github.com/gastownhall/gascity/commit/cb770047) ("materialize-skills uses template name for pool instances") for `[[named_session]]` entries.

Pool instances are detected via `cfgAgent.PoolName`; named_session expansions don't set `PoolName`, so `templateNameFor` fell through to `qualifiedName` (the session identity, e.g. `pringle/utz`) and the stage-2 PreStart `gc internal materialize-skills --agent <session>` hit `unknown agent` — exit 1 — on every wake-from-suspend.

`resolveAgentIdentity` resolves `[[agent]]` templates only; named_session expansions are template+session pairs (e.g. template `crew` rendered as session `utz` under rig `pringle`). Detect the named_session shape via `cfgAgent.QualifiedName() != qualifiedName` and route materialize-skills to the template's own qualified name. Skills are per-template, so every session sharing a template shares the catalog (same invariant the pool fix relied on).

**Reproducing the pre-fix bug:**

```
$ gc internal materialize-skills --agent pringle/utz --workdir <wd>
gc internal materialize-skills: unknown agent "pringle/utz"
```

After the fix the supervisor emits `--agent pringle/crew` and the command succeeds. Verified live: named_session crew wakes from suspend without manual close/submit gymnastics.

Adds `TestResolveTemplateNamedSessionMaterializeUsesTemplateName` as a focused regression next to the pool-instance test.

## Testing

- [x] `make check`
- [ ] `make check-docs` — no docs/navigation/links touched
- [ ] `make test-integration` — change is a one-line predicate extension covered by the unit test next to the existing pool-instance regression; runtime path itself is untouched

## Checklist

- [x] Linked an issue, or explained why one is not needed — no existing issue; this is the direct follow-up to cb770047 for the named_session leg
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — no user-facing surface changed
- [ ] Called out breaking changes or migration notes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>