### PR TITLE
fix(config): align legacy workspace warning provenance

### DIFF
--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -263,7 +263,7 @@ func TestEmitLoadCityConfigWarningsFiltersNonMigrationWarnings(t *testing.T) {
 			`workspace.name redefined by "/city/defaults.toml"`,
 			`/city/pack.toml: [agents] is a deprecated compatibility alias for [agent_defaults]; rewrite the table name to [agent_defaults]`,
 			`/city/pack.toml: both [agent_defaults] and [agents] are present; [agent_defaults] wins on overlapping keys and [agents] only fills gaps`,
-			`/city/pack.toml: "agent_defaults.provider" is not supported in [agent_defaults]; keep using workspace.provider or set provider per agent in agents/<name>/agent.toml`,
+			`/city/pack.toml: "agent_defaults.provider" is not supported in this release wave; keep setting provider per agent in agents/<name>/agent.toml`,
 			`/city/city.toml: workspace.provider is deprecated: Set provider per agent in agents/<name>/agent.toml.`,
 			`gc: warning: attachment-list fields (` + "`skills`, `mcp`, `skills_append`, `mcp_append`, `shared_skills`" + `) are deprecated as of v0.15.1 and ignored.`,
 		},
@@ -471,7 +471,7 @@ func TestStrictFatalLoadConfigWarningsKeepsMixedTableWarningsFatal(t *testing.T)
 	warnings := []string{
 		`/city/pack.toml: [agents] is a deprecated compatibility alias for [agent_defaults]; rewrite the table name to [agent_defaults]`,
 		`/city/pack.toml: both [agent_defaults] and [agents] are present; [agent_defaults] wins on overlapping keys and [agents] only fills gaps`,
-		`/city/pack.toml: "agent_defaults.provider" is not supported in [agent_defaults]; keep using workspace.provider or set provider per agent in agents/<name>/agent.toml`,
+		`/city/pack.toml: "agent_defaults.provider" is not supported in this release wave; keep setting provider per agent in agents/<name>/agent.toml`,
 		`/city/city.toml: workspace.provider is deprecated: Set provider per agent in agents/<name>/agent.toml.`,
 		`workspace.name redefined by "/city/defaults.toml"`,
 	}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1157,6 +1157,14 @@ func mergeWorkspace(base, fragment *City, fragMeta toml.MetaData, fragPath strin
 			prov.Workspace[f.key] = fragPath
 		}
 	}
+	if fragMeta.IsDefined("workspace", "suspended") {
+		if base.Workspace.Suspended {
+			prov.Warnings = append(prov.Warnings,
+				fmt.Sprintf("workspace.suspended redefined by %q", fragPath))
+		}
+		base.Workspace.Suspended = fragment.Workspace.Suspended
+		prov.Workspace["suspended"] = fragPath
+	}
 	// install_agent_hooks is a []string — handle outside the wsField loop.
 	if fragMeta.IsDefined("workspace", "install_agent_hooks") {
 		if len(base.Workspace.InstallAgentHooks) > 0 {

--- a/internal/config/legacy_workspace_warnings.go
+++ b/internal/config/legacy_workspace_warnings.go
@@ -5,23 +5,55 @@ import (
 	"strings"
 )
 
-// legacyWorkspaceFieldMarkers are stable substrings that uniquely identify
-// each warning produced by DetectLegacyWorkspaceFields. Callers that enforce
-// strict warning policies use them to keep these soft-deprecation warnings
-// non-fatal.
-var legacyWorkspaceFieldMarkers = []string{
-	"workspace.provider is deprecated",
-	"workspace.start_command is deprecated",
-	"workspace.suspended is deprecated",
-	"workspace.install_agent_hooks is deprecated",
-	"workspace.global_fragments is deprecated",
+type legacyWorkspaceFieldRule struct {
+	field      string
+	suggestion string
+	defined    func(Workspace, map[string]string) bool
+}
+
+var legacyWorkspaceFieldRules = []legacyWorkspaceFieldRule{
+	{
+		field:      "provider",
+		suggestion: "Set provider per agent in agents/<name>/agent.toml.",
+		defined: func(ws Workspace, _ map[string]string) bool {
+			return ws.Provider != ""
+		},
+	},
+	{
+		field:      "start_command",
+		suggestion: "Use per-agent `start_command` in `agent.toml` instead.",
+		defined: func(ws Workspace, _ map[string]string) bool {
+			return ws.StartCommand != ""
+		},
+	},
+	{
+		field:      "suspended",
+		suggestion: "This will move to `.gc/site.toml` in a future release. No action is required now.",
+		defined: func(ws Workspace, workspaceSources map[string]string) bool {
+			return ws.Suspended || workspaceFieldDefined(workspaceSources, "suspended")
+		},
+	},
+	{
+		field:      "install_agent_hooks",
+		suggestion: "Set install_agent_hooks per agent in agents/<name>/agent.toml.",
+		defined: func(ws Workspace, _ map[string]string) bool {
+			return len(ws.InstallAgentHooks) > 0
+		},
+	},
+	{
+		field:      "global_fragments",
+		suggestion: "Use `[agent_defaults] append_fragments` or explicit `{{ template }}` instead.",
+		defined: func(ws Workspace, _ map[string]string) bool {
+			return len(ws.GlobalFragments) > 0
+		},
+	},
 }
 
 // IsLegacyWorkspaceFieldWarning reports whether warning is one of the
 // soft-deprecation warnings emitted by DetectLegacyWorkspaceFields.
 func IsLegacyWorkspaceFieldWarning(warning string) bool {
-	for _, marker := range legacyWorkspaceFieldMarkers {
-		if strings.Contains(warning, marker) {
+	for _, rule := range legacyWorkspaceFieldRules {
+		if strings.Contains(warning, legacyWorkspaceFieldMarker(rule.field)) {
 			return true
 		}
 	}
@@ -42,8 +74,8 @@ func IsLegacyWorkspaceFieldWarning(warning string) bool {
 // Detection rules per field:
 //   - workspace.provider: warn when non-empty.
 //   - workspace.start_command: warn when non-empty.
-//   - workspace.suspended: warn when true (the false zero-value is
-//     indistinguishable from unset).
+//   - workspace.suspended: warn when true, or when load provenance shows the
+//     field was explicitly defined.
 //   - workspace.install_agent_hooks: warn when non-empty.
 //   - workspace.global_fragments: warn when non-empty.
 func DetectLegacyWorkspaceFields(cfg *City, source string) []string {
@@ -70,20 +102,21 @@ func detectLegacyWorkspaceFields(cfg *City, defaultSource string, workspaceSourc
 		))
 	}
 
-	if ws.Provider != "" {
-		emit("provider", "Set provider per agent in agents/<name>/agent.toml.")
-	}
-	if ws.StartCommand != "" {
-		emit("start_command", "Use per-agent `start_command` in `agent.toml` instead.")
-	}
-	if ws.Suspended {
-		emit("suspended", "This will move to `.gc/site.toml` in a future release. No action is required now.")
-	}
-	if len(ws.InstallAgentHooks) > 0 {
-		emit("install_agent_hooks", "Set install_agent_hooks per agent in agents/<name>/agent.toml.")
-	}
-	if len(ws.GlobalFragments) > 0 {
-		emit("global_fragments", "Use `[agent_defaults] append_fragments` or explicit `{{ template }}` instead.")
+	for _, rule := range legacyWorkspaceFieldRules {
+		if rule.defined(ws, workspaceSources) {
+			emit(rule.field, rule.suggestion)
+		}
 	}
 	return warnings
+}
+
+func legacyWorkspaceFieldMarker(field string) string {
+	return "workspace." + field + " is deprecated"
+}
+
+func workspaceFieldDefined(workspaceSources map[string]string, field string) bool {
+	if workspaceSources == nil {
+		return false
+	}
+	return workspaceSources[field] != ""
 }

--- a/internal/config/legacy_workspace_warnings_test.go
+++ b/internal/config/legacy_workspace_warnings_test.go
@@ -184,6 +184,9 @@ name = "legacy-workspace"
 	fs.Files["/city/fragment.toml"] = []byte(`
 [workspace]
 provider = "claude"
+start_command = "claude --resume"
+suspended = true
+install_agent_hooks = ["claude"]
 global_fragments = ["shared"]
 `)
 
@@ -192,7 +195,7 @@ global_fragments = ["shared"]
 		t.Fatalf("LoadWithIncludes: %v", err)
 	}
 
-	for _, field := range []string{"provider", "global_fragments"} {
+	for _, field := range []string{"provider", "start_command", "suspended", "install_agent_hooks", "global_fragments"} {
 		want := "/city/fragment.toml: workspace." + field + " is deprecated:"
 		if !containsWarningPrefix(prov.Warnings, want) {
 			t.Fatalf("missing fragment-sourced %s warning with prefix %q in %v", field, want, prov.Warnings)
@@ -201,6 +204,26 @@ global_fragments = ["shared"]
 		if containsWarningPrefix(prov.Warnings, wrong) {
 			t.Fatalf("warning for fragment-authored %s was attributed to root: %v", field, prov.Warnings)
 		}
+	}
+}
+
+func TestLoadWithIncludesLegacyWorkspaceWarningsDetectExplicitSuspendedFalse(t *testing.T) {
+	t.Parallel()
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "legacy-workspace"
+suspended = false
+`)
+
+	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	want := "/city/city.toml: workspace.suspended is deprecated:"
+	if !containsWarningPrefix(prov.Warnings, want) {
+		t.Fatalf("missing explicit suspended=false warning with prefix %q in %v", want, prov.Warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary
- merge fragment-authored workspace.suspended into composed config provenance
- derive legacy workspace warning classification from the emitted rule table
- expand include-path coverage for all legacy workspace warning fields and explicit suspended=false
- refresh stale agent_defaults.provider warning fixtures

## Verification
- go test ./internal/config -run 'Test(DetectLegacyWorkspaceFields|IsLegacyWorkspaceFieldWarning|LoadWithIncludesLegacyWorkspaceWarnings|LoadWithIncludesEmitsNonFatalLegacyWorkspaceWarning)' -count=1
- go test ./cmd/gc -run 'Test(EmitLoadCityConfigWarningsFiltersNonMigrationWarnings|StrictFatalLoadConfigWarningsKeepsMixedTableWarningsFatal)' -count=1
- go test ./internal/config -count=1
- go test ./cmd/gc -run 'Test(EmitLoadCityConfigWarningsFiltersNonMigrationWarnings|StrictFatalLoadConfigWarningsKeepsMixedTableWarningsFatal|NonTestLoadCityConfigCallersPassWarningWriter)' -count=1
- pre-commit hook: lint-changed, docs/schema generation check, go vet ./..., fast unit baseline