### PR TITLE
fix(dolt): cover compact post-flatten drift

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -113,6 +113,8 @@ should treat these strings as the current vocabulary:
 
 | Reason | Meaning |
 |--------|---------|
+| `post-flatten HEAD probe failed` | The compactor could not read the database HEAD after flatten. |
+| `post-flatten integrity check failed` | A post-flatten integrity check failed before recording a more specific reason. |
 | `post-flatten row count decreased` | A table lost rows after flatten. |
 | `post-flatten row count probe failed` | The post-flatten row-count query failed or returned a non-number. |
 | `post-flatten table value hash probe failed` | A post-flatten table hash query failed or returned empty. |

--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -104,6 +104,27 @@ If GC finishes but the size barely moves, the chunks are nearly all live
 - **Avoid long-lived `dolt sql` sessions from outside Gas City.** External
   clients hold open transactions that can block GC.
 
+## Compact Quarantine Reasons
+
+`gc dolt compact` writes exact reason strings into
+`.gc/runtime/packs/dolt/compact-quarantine/<database>` when it detects
+possible writer interference before full GC. Operator dashboards and runbooks
+should treat these strings as the current vocabulary:
+
+| Reason | Meaning |
+|--------|---------|
+| `post-flatten row count decreased` | A table lost rows after flatten. |
+| `post-flatten row count probe failed` | The post-flatten row-count query failed or returned a non-number. |
+| `post-flatten table value hash probe failed` | A post-flatten table hash query failed or returned empty. |
+| `post-flatten table value hash changed with row-count increase` | A table gained rows and its value hash changed. |
+| `post-flatten table value hash changed without row-count increase` | A table's value hash changed without a row-count gain. |
+| `post-flatten table list changed` | A table appeared or an invalid table name was observed after preflight. |
+| `post-flatten table list probe failed` | The post-flatten `information_schema.tables` query failed. |
+| `post-flatten value hash probe failed` | The database hash query failed after flatten. |
+| `post-flatten value hash probe returned empty value` | The database hash query returned an empty value after flatten. |
+| `post-flatten value hash changed with row-count increase` | The database hash changed after at least one stable-table row-count gain. |
+| `post-flatten value hash changed without row-count increase` | The database hash changed without a row-count gain. |
+
 ## When to Escalate
 
 If a recovery GC reduces the store by less than ~10% and `gc doctor` still

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -642,7 +642,7 @@ preflight_counts() {
   preflight_failed=0
   while IFS= read -r t; do
     [ -n "$t" ] || continue
-    if ! valid_database_name "$t"; then
+    if ! valid_table_name "$t"; then
       printf 'compact: db=%s invalid table name from information_schema table=%s — fail\n' \
         "$db" "$t" >&2
       preflight_failed=1

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -283,6 +283,10 @@ valid_database_name() {
   esac
 }
 
+valid_table_name() {
+  valid_database_name "$1"
+}
+
 valid_remote_name() {
   remote_candidate="$1"
   case "$remote_candidate" in
@@ -780,7 +784,7 @@ verify_counts() {
   fi
   while IFS= read -r post_table; do
     [ -n "$post_table" ] || continue
-    if ! valid_database_name "$post_table"; then
+    if ! valid_table_name "$post_table"; then
       printf 'compact: db=%s invalid table name after flatten table=%s — quarantine and investigate before GC\n' \
         "$db" "$post_table" >&2
       if [ "$fail" -ne 1 ]; then
@@ -1224,6 +1228,8 @@ preserve_head_after_integrity_failure() {
 flatten_database() {
   db="$1"
   verify_counts_saw_gain=0
+  verify_counts_failure_reason=""
+  verify_counts_failure_guidance=""
 
   if [ -n "$only_dbs" ]; then
     case ",$only_dbs," in
@@ -1642,16 +1648,29 @@ flatten_database() {
     return 1
   fi
   if [ "$postflight_hash" != "$preflight_hash" ]; then
-    printf 'compact: db=%s value hash changed after flatten before=%s after=%s — quarantine and investigate before GC\n' \
-      "$db" "$preflight_hash" "$postflight_hash" >&2
-    write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed" || {
+    if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
+      printf 'compact: db=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
+        "$db" "$preflight_hash" "$postflight_hash" >&2
+      write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed with row-count increase" || {
+        preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+        rm -f "$preflight_tmp"
+        return 1
+      }
       preserve_head_after_integrity_failure "$db" "$flatten_head" || true
       rm -f "$preflight_tmp"
       return 1
-    }
-    preserve_head_after_integrity_failure "$db" "$flatten_head" || true
-    rm -f "$preflight_tmp"
-    return 1
+    else
+      printf 'compact: db=%s value hash changed without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
+        "$db" "$preflight_hash" "$postflight_hash" >&2
+      write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed without row-count increase" || {
+        preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+        rm -f "$preflight_tmp"
+        return 1
+      }
+      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      rm -f "$preflight_tmp"
+      return 1
+    fi
   fi
   if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
     printf 'compact: db=%s row-count increase passed value-hash verification — full GC allowed\n' \

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -614,6 +614,10 @@ case "$query" in
       print_cells beads notes
       exit 0
     fi
+    if [ "$mode" = "post_flatten_invalid_table_name" ] && [ "$(current_head)" = "compactcommit" ]; then
+      print_cells beads 'bad/name'
+      exit 0
+    fi
     if [ "$mode" = "table_name_clobber" ]; then
       print_cell blocked_issues
       exit 0
@@ -1877,6 +1881,29 @@ func TestCompactScriptReportsPostFlattenTableListProbeFailureSeparately(t *testi
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
 	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table list probe failed" {
 		t.Fatalf("quarantine reason should identify table-list probe failure, got %q", reason)
+	}
+}
+
+func TestCompactScriptQuarantinesPostFlattenInvalidTableNameBeforeFullGC(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "post_flatten_invalid_table_name", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite an invalid table name after preflight:\n%s", out)
+	}
+	if !strings.Contains(out, "invalid table name after flatten table=bad/name") ||
+		!strings.Contains(out, "post-flatten table list changed") {
+		t.Fatalf("output missing post-flatten invalid-table-name quarantine:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("post-flatten invalid table name must block full GC:\n%s", logData)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table list changed" {
+		t.Fatalf("quarantine reason should identify table-list drift, got %q", reason)
 	}
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -602,8 +602,16 @@ case "$query" in
       printf 'information_schema unavailable\n' >&2
       exit 43
     fi
+    if [ "$mode" = "post_flatten_table_list_failure" ] && [ "$(current_head)" = "compactcommit" ]; then
+      printf 'information_schema unavailable after flatten\n' >&2
+      exit 43
+    fi
     if [ "$mode" = "invalid_table_name" ]; then
       print_cell 'bad/name'
+      exit 0
+    fi
+    if [ "$mode" = "post_flatten_table_appears" ] && [ "$(current_head)" = "compactcommit" ]; then
+      print_cells beads notes
       exit 0
     fi
     if [ "$mode" = "table_name_clobber" ]; then
@@ -654,7 +662,7 @@ case "$query" in
       printf 'row count exploded after flatten\n' >&2
       exit 47
     fi
-    if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ]; } && [ "$calls" -gt 1 ]; then
+    if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ]; } && [ "$calls" -gt 1 ]; then
       print_cell 11
     elif [ "$mode" = "row_count_decreases" ] && [ "$calls" -gt 1 ]; then
       print_cell 9
@@ -686,7 +694,7 @@ case "$query" in
     if [ "$mode" = "same_row_count_writer" ]; then
       set_hash hash-after-writer
     fi
-    if [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ]; then
+    if [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "same_count_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ]; then
       set_hash hash-after-writer
     fi
     exit 0
@@ -1823,6 +1831,97 @@ func TestCompactScriptReportsPostFlattenRowCountProbeFailureSeparately(t *testin
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
 	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten row count probe failed" {
 		t.Fatalf("quarantine reason should identify probe failure, got %q", reason)
+	}
+}
+
+func TestCompactScriptQuarantinesPostFlattenTableListDriftBeforeFullGC(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "post_flatten_table_appears", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite a new table appearing after preflight:\n%s", out)
+	}
+	if !strings.Contains(out, "table=notes appeared after pre-flight snapshot") ||
+		!strings.Contains(out, "post-flatten table list changed") {
+		t.Fatalf("output missing post-flatten table-list drift quarantine:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("post-flatten table-list drift must block full GC:\n%s", logData)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table list changed" {
+		t.Fatalf("quarantine reason should identify table-list drift, got %q", reason)
+	}
+}
+
+func TestCompactScriptReportsPostFlattenTableListProbeFailureSeparately(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "post_flatten_table_list_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite post-flatten table-list probe failure:\n%s", out)
+	}
+	if !strings.Contains(out, "post-flatten table list probe failed") ||
+		!strings.Contains(out, "information_schema unavailable after flatten") {
+		t.Fatalf("output missing post-flatten table-list probe failure:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("post-flatten table-list probe failure must block full GC:\n%s", logData)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table list probe failed" {
+		t.Fatalf("quarantine reason should identify table-list probe failure, got %q", reason)
+	}
+}
+
+func TestCompactScriptPreservesRowGainReasonForDatabaseHashDrift(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "row_count_gain_with_db_hash_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite database value-hash drift after row-count gain:\n%s", out)
+	}
+	if !strings.Contains(out, "gained rows during flatten") ||
+		!strings.Contains(out, "value hash changed with row-count increase") {
+		t.Fatalf("output missing row-count-gain database hash drift reason:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("database hash drift after row-count gain must block full GC:\n%s", logData)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten value hash changed with row-count increase" {
+		t.Fatalf("quarantine reason should identify DB hash drift after row-count gain, got %q", reason)
+	}
+}
+
+func TestCompactScriptPreservesNoGainReasonForDatabaseHashDrift(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "same_count_db_hash_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite database value-hash drift without row-count gain:\n%s", out)
+	}
+	if !strings.Contains(out, "value hash changed without row-count increase") {
+		t.Fatalf("output missing no-gain database hash drift reason:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("database hash drift without row-count gain must block full GC:\n%s", logData)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten value hash changed without row-count increase" {
+		t.Fatalf("quarantine reason should identify DB hash drift without row-count gain, got %q", reason)
 	}
 }
 


### PR DESCRIPTION
Post-merge remediation for #2350.

Fixes the required compact follow-ups from the landed audit:
- add fake-Dolt coverage for a table appearing after preflight and for post-flatten table-list probe failure
- restore row-count-aware database hash quarantine reasons and reset all verify_counts output globals at the flatten caller boundary
- document the compact quarantine marker reason vocabulary for operators

Tests:
- `go test ./examples/dolt -run 'TestCompactScript(QuarantinesPostFlattenTableListDriftBeforeFullGC|ReportsPostFlattenTableListProbeFailureSeparately|PreservesRowGainReasonForDatabaseHashDrift|PreservesNoGainReasonForDatabaseHashDrift)'`
- `go test ./examples/dolt -run 'TestCompactScript'`
- `go test ./examples/dolt`
- `go vet ./examples/dolt`
- pre-commit: `go vet ./...`, `./scripts/test-local-parallel fast`, `go test ./test/docsync`
