### PR TITLE
fix: correct work-query failure session events

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -156,20 +156,36 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		overrides["GC_TEMPLATE"] = os.Getenv("GC_TEMPLATE")
 	}
 	queryEnv := mergeRuntimeEnv(os.Environ(), overrides)
+	failureTemplate, emitFailureEvent := hookWorkQueryFailureTemplate(len(args) > 0, sessionTemplateContext, a.QualifiedName())
 	runner := func(command, dir string) (string, error) {
 		out, err := shellWorkQueryWithEnv(command, dir, queryEnv)
-		if err != nil {
+		if err != nil && emitFailureEvent {
 			// A killed/timed-out work query strands the session with no
 			// output and no cause on the event bus; emit one so the
 			// reconciler can escalate instead of skipping it forever
 			// (issues #1496/#1497). Ordinary command errors are ignored
 			// by emitWorkQueryFailure and stay on the stderr path below.
-			emitWorkQueryFailure(openCityRecorderAt(cityPath, stderr),
-				os.Getenv("GC_SESSION_ID"), a.QualifiedName(), command, err)
+			emitCityWorkQueryFailure(cityPath, stderr,
+				os.Getenv("GC_SESSION_ID"), failureTemplate, command, err)
 		}
 		return out, err
 	}
 	return doHook(workQuery, workDir, inject, runner, stdout, stderr)
+}
+
+func hookWorkQueryFailureTemplate(explicitTarget, sessionTemplateContext bool, resolvedAgentName string) (string, bool) {
+	currentTemplate := strings.TrimSpace(os.Getenv("GC_TEMPLATE"))
+	resolvedAgentName = strings.TrimSpace(resolvedAgentName)
+	if explicitTarget {
+		if currentTemplate == "" || currentTemplate != resolvedAgentName {
+			return "", false
+		}
+		return currentTemplate, true
+	}
+	if currentTemplate != "" && (sessionTemplateContext || strings.TrimSpace(os.Getenv("GC_SESSION_ID")) != "") {
+		return currentTemplate, true
+	}
+	return resolvedAgentName, true
 }
 
 // hookQueryEnv returns the full work-query environment for a hook subprocess.

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -9,7 +9,109 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/events"
 )
+
+func TestCmdHookQueryKillEmitsCurrentSessionTemplate(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+work_query = "kill -9 $$"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_TEMPLATE", "worker")
+	t.Setenv("GC_SESSION_ID", "sess-hook-123")
+	t.Setenv("GC_SESSION_NAME", "worker-1")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHookWithFormat(nil, false, "", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdHookWithFormat() = %d, want 1 for killed work query; stderr=%s", code, stderr.String())
+	}
+	evts, err := events.ReadFiltered(filepath.Join(cityDir, ".gc", "events.jsonl"), events.Filter{Type: events.SessionWorkQueryFailed})
+	if err != nil {
+		t.Fatalf("read work-query failure events: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("work-query failure events = %d, want 1: %+v", len(evts), evts)
+	}
+	if evts[0].Subject != "worker" {
+		t.Fatalf("event subject = %q, want current session template", evts[0].Subject)
+	}
+	if strings.Contains(evts[0].Message, "kill -9") {
+		t.Fatalf("event message leaked raw work query command: %q", evts[0].Message)
+	}
+	payload := decodeSessionLifecyclePayload(t, evts[0])
+	if payload.SessionID != "sess-hook-123" {
+		t.Fatalf("payload SessionID = %q, want sess-hook-123", payload.SessionID)
+	}
+	if payload.Template != "worker" {
+		t.Fatalf("payload Template = %q, want current session template", payload.Template)
+	}
+	if payload.Reason != "work query killed (signal: killed)" {
+		t.Fatalf("payload Reason = %q, want work query killed (signal: killed)", payload.Reason)
+	}
+}
+
+func TestCmdHookExplicitDifferentTargetSuppressesSessionFailureEvent(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+work_query = "printf '[]'"
+
+[[agent]]
+name = "other"
+work_query = "kill -9 $$"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_TEMPLATE", "worker")
+	t.Setenv("GC_SESSION_ID", "sess-hook-456")
+	t.Setenv("GC_SESSION_NAME", "worker-1")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHookWithFormat([]string{"other"}, false, "", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdHookWithFormat(explicit other) = %d, want 1 for killed work query; stderr=%s", code, stderr.String())
+	}
+	evts, err := events.ReadFiltered(filepath.Join(cityDir, ".gc", "events.jsonl"), events.Filter{Type: events.SessionWorkQueryFailed})
+	if err != nil {
+		t.Fatalf("read work-query failure events: %v", err)
+	}
+	if len(evts) != 0 {
+		t.Fatalf("work-query failure events = %d, want 0 for explicit different target: %+v", len(evts), evts)
+	}
+}
 
 func TestHookNoWork(t *testing.T) {
 	runner := func(string, string) (string, error) { return "", nil }

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -441,7 +441,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 			// Surface a killed/timed-out control work query on the event
 			// bus so the reconciler has a named cause to escalate on
 			// rather than the session dying silently (issues #1496/#1497).
-			emitWorkQueryFailure(openCityRecorderAt(cityPath, stderr),
+			emitCityWorkQueryFailure(cityPath, stderr,
 				os.Getenv("GC_SESSION_ID"), os.Getenv("GC_TEMPLATE"), serveQuery, err)
 			return result, fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
 		}

--- a/cmd/gc/work_query_failure.go
+++ b/cmd/gc/work_query_failure.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"strconv"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/api"
@@ -34,8 +36,42 @@ func classifyWorkQueryKill(err error) (reason string, killed bool) {
 	case strings.Contains(msg, "timed out after"):
 		return "work query timed out", true
 	default:
+		if reason, ok := classifySignalExitStatus(msg); ok {
+			return reason, true
+		}
 		return "", false
 	}
+}
+
+func classifySignalExitStatus(msg string) (string, bool) {
+	const marker = "exit status "
+	idx := strings.LastIndex(msg, marker)
+	if idx < 0 {
+		return "", false
+	}
+	fields := strings.Fields(msg[idx+len(marker):])
+	if len(fields) == 0 {
+		return "", false
+	}
+	codeText := strings.Trim(fields[0], ".,:;)")
+	code, err := strconv.Atoi(codeText)
+	if err != nil {
+		return "", false
+	}
+	if code < 129 || code > 159 {
+		return "", false
+	}
+	return fmt.Sprintf("work query terminated by signal (exit status %d)", code), true
+}
+
+// emitCityWorkQueryFailure records a work-query failure against the city event
+// log and closes file-backed recorders after the best-effort write.
+func emitCityWorkQueryFailure(cityPath string, stderr io.Writer, sessionID, template, command string, err error) {
+	rec := openCityRecorderAt(cityPath, stderr)
+	if closer, ok := rec.(interface{ Close() error }); ok {
+		defer closer.Close() //nolint:errcheck // best-effort event recorder cleanup
+	}
+	emitWorkQueryFailure(rec, sessionID, template, command, err)
 }
 
 // emitWorkQueryFailure records a SessionWorkQueryFailed event when a
@@ -44,7 +80,7 @@ func classifyWorkQueryKill(err error) (reason string, killed bool) {
 // into unknown state (issue #1496, companion #1497). Best-effort: a nil
 // recorder is treated as a discard. Returns true when the failure was recorded,
 // false for ordinary errors or when no current session ID is available.
-func emitWorkQueryFailure(rec events.Recorder, sessionID, template, command string, err error) bool {
+func emitWorkQueryFailure(rec events.Recorder, sessionID, template, _ string, err error) bool {
 	reason, killed := classifyWorkQueryKill(err)
 	if !killed {
 		return false
@@ -65,7 +101,7 @@ func emitWorkQueryFailure(rec events.Recorder, sessionID, template, command stri
 		Type:    events.SessionWorkQueryFailed,
 		Actor:   eventActor(),
 		Subject: subject,
-		Message: fmt.Sprintf("%s while running %q: %v", reason, command, err),
+		Message: reason,
 		Payload: api.SessionLifecyclePayloadJSON(sessionID, template, reason),
 	})
 	return true

--- a/cmd/gc/work_query_failure_test.go
+++ b/cmd/gc/work_query_failure_test.go
@@ -18,8 +18,10 @@ func TestClassifyWorkQueryKill(t *testing.T) {
 		{"signal terminated", errors.New("signal: terminated"), true},
 		{"exit 137 sigkill", errors.New("exit status 137"), true},
 		{"exit 143 sigterm", errors.New("exit status 143"), true},
+		{"exit 130 sigint", errors.New("exit status 130"), true},
 		{"runner timeout", errors.New(`running work query "x": timed out after 30s`), true},
 		{"ordinary command error", errors.New("exit status 1"), false},
+		{"non signal high exit", errors.New("exit status 200"), false},
 		{"config error", errors.New("agent not found"), false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Post-merge remediation for #2206.

## Summary
- Use the current `GC_TEMPLATE` for managed-session hook-side `session.work_query_failed` events.
- Suppress lifecycle failure events for explicit hook targets that are not proven to be the current session template.
- Redact raw `work_query` commands from event messages, close city event recorders after best-effort emission, and classify POSIX signal-style exit statuses.
- Add `cmdHookWithFormat` regression coverage for hook-side event payload fields and explicit-target suppression.

## Tests
- `go test ./cmd/gc -run 'Test(ClassifyWorkQueryKill|EmitWorkQueryFailure.*|RunWorkflowServeQueryKillEmitsCurrentSessionPayload|CmdHookQueryKillEmitsCurrentSessionTemplate|CmdHookExplicitDifferentTargetSuppressesSessionFailureEvent)$'`
- `go vet ./...`
- `make test-fast-parallel`
- `.githooks/pre-commit`
