### PR TITLE
fix(reconciler): respect held_until in max_session_age + idle_timeout

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1554,11 +1554,19 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if maxAgeTr != nil && alive {
 			creationCompleteAt, hasAnchor := parseRFC3339Metadata(session.Metadata["creation_complete_at"])
 			if hasAnchor && maxAgeTr.shouldRestart(name, creationCompleteAt, clk.Now()) {
-				if pendingInteractionKeepsAwake(*session, sp, name, clk) {
+				switch {
+				case metadataTimeInFuture(session.Metadata["held_until"], clk.Now()):
+					// Respect user-hold: a future held_until means an operator
+					// explicitly suspended the session. Bypass the max-age
+					// restart so SleepPatch does not clobber held_until.
+					if trace != nil {
+						trace.recordDecision("reconciler.session.max_session_age", tp.TemplateName, name, "user_hold", "deferred_user_hold", nil, nil, "")
+					}
+				case pendingInteractionKeepsAwake(*session, sp, name, clk):
 					if trace != nil {
 						trace.recordDecision("reconciler.session.max_session_age", tp.TemplateName, name, "pending", "deferred_pending", nil, nil, "")
 					}
-				} else {
+				default:
 					hasWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
 					if assignedErr != nil {
 						// Fail closed: treat error as "has work" so a transient
@@ -1603,6 +1611,18 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		// Idle timeout: restart sessions idle longer than configured threshold.
 		if it != nil && alive && it.checkIdle(name, sp, clk.Now()) {
+			if metadataTimeInFuture(session.Metadata["held_until"], clk.Now()) {
+				// Respect user-hold: skip the idle-timeout kill (and the
+				// drain-cancel side effect of the pending branch) so
+				// SleepPatch does not clear held_until. Matches the
+				// pending-interaction branch's `continue` semantics — a
+				// held session does not participate in this tick's wake
+				// decision.
+				if trace != nil {
+					trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "user_hold", "deferred_user_hold", nil, nil, "")
+				}
+				continue
+			}
 			if pendingInteractionKeepsAwake(*session, sp, name, clk) {
 				drainCancelled := false
 				if dt != nil {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -36,6 +36,17 @@ type wakeTarget struct {
 	alive   bool
 }
 
+func lifecycleTimerBlocker(metadata map[string]string, now time.Time) string {
+	switch {
+	case metadataTimeInFuture(metadata["held_until"], now):
+		return "user_hold"
+	case metadataTimeInFuture(metadata["quarantined_until"], now):
+		return "quarantine"
+	default:
+		return ""
+	}
+}
+
 // buildDepsMap extracts template dependency edges from config for topo ordering.
 // Maps template QualifiedName -> list of dependency template QualifiedNames.
 func buildDepsMap(cfg *config.City) map[string][]string {
@@ -1554,13 +1565,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if maxAgeTr != nil && alive {
 			creationCompleteAt, hasAnchor := parseRFC3339Metadata(session.Metadata["creation_complete_at"])
 			if hasAnchor && maxAgeTr.shouldRestart(name, creationCompleteAt, clk.Now()) {
+				blocker := lifecycleTimerBlocker(session.Metadata, clk.Now())
 				switch {
-				case metadataTimeInFuture(session.Metadata["held_until"], clk.Now()):
-					// Respect user-hold: a future held_until means an operator
-					// explicitly suspended the session. Bypass the max-age
-					// restart so SleepPatch does not clobber held_until.
+				case blocker != "":
+					// Respect lifecycle timer blockers already enforced by
+					// wake evaluation. Bypass the max-age restart so
+					// SleepPatch does not rewrite the intended sleep state.
 					if trace != nil {
-						trace.recordDecision("reconciler.session.max_session_age", tp.TemplateName, name, "user_hold", "deferred_user_hold", nil, nil, "")
+						trace.recordDecision("reconciler.session.max_session_age", tp.TemplateName, name, blocker, "deferred_"+blocker, nil, nil, "")
 					}
 				case pendingInteractionKeepsAwake(*session, sp, name, clk):
 					if trace != nil {
@@ -1611,19 +1623,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		// Idle timeout: restart sessions idle longer than configured threshold.
 		if it != nil && alive && it.checkIdle(name, sp, clk.Now()) {
-			if metadataTimeInFuture(session.Metadata["held_until"], clk.Now()) {
-				// Respect user-hold: skip the idle-timeout kill (and the
-				// drain-cancel side effect of the pending branch) so
-				// SleepPatch does not clear held_until. Matches the
-				// pending-interaction branch's `continue` semantics — a
-				// held session does not participate in this tick's wake
-				// decision.
+			blocker := lifecycleTimerBlocker(session.Metadata, clk.Now())
+			switch {
+			case blocker != "":
+				// Respect lifecycle timer blockers without skipping the
+				// post-loop wake/drain pass. A metadata-only suspend uses
+				// sleep_intent=user-hold and still needs that pass to drain
+				// the live runtime.
 				if trace != nil {
-					trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "user_hold", "deferred_user_hold", nil, nil, "")
+					trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, blocker, "deferred_"+blocker, nil, nil, "")
 				}
-				continue
-			}
-			if pendingInteractionKeepsAwake(*session, sp, name, clk) {
+			case pendingInteractionKeepsAwake(*session, sp, name, clk):
 				drainCancelled := false
 				if dt != nil {
 					drainCancelled = cancelSessionDrain(*session, sp, dt)
@@ -1634,33 +1644,34 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					}, nil, "")
 				}
 				continue
-			}
-			fmt.Fprintf(stderr, "session reconciler: idle timeout for %s\n", tp.DisplayName()) //nolint:errcheck // best-effort stderr
-			if trace != nil {
-				trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "idle_timeout", "stop", nil, nil, "")
-			}
-			if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
-				fmt.Fprintf(stderr, "session reconciler: stopping idle %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
-			} else {
-				_ = sp.ClearScrollback(name)
-				rec.Record(events.Event{
-					Type:    events.SessionIdleKilled,
-					Actor:   "gc",
-					Subject: tp.DisplayName(),
-				})
-				telemetry.RecordAgentIdleKill(context.Background(), tp.DisplayName())
-				// Mark for immediate re-wake on this same tick by clearing
-				// last_woke_at and setting state to asleep. The wake logic
-				// below will pick it up.
-				batch := sessionpkg.SleepPatch(clk.Now(), "idle-timeout")
-				_ = store.SetMetadataBatch(session.ID, batch)
-				if session.Metadata == nil {
-					session.Metadata = make(map[string]string, len(batch))
+			default:
+				fmt.Fprintf(stderr, "session reconciler: idle timeout for %s\n", tp.DisplayName()) //nolint:errcheck // best-effort stderr
+				if trace != nil {
+					trace.recordDecision("reconciler.session.idle_timeout", tp.TemplateName, name, "idle_timeout", "stop", nil, nil, "")
 				}
-				for key, value := range batch {
-					session.Metadata[key] = value
+				if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
+					fmt.Fprintf(stderr, "session reconciler: stopping idle %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+				} else {
+					_ = sp.ClearScrollback(name)
+					rec.Record(events.Event{
+						Type:    events.SessionIdleKilled,
+						Actor:   "gc",
+						Subject: tp.DisplayName(),
+					})
+					telemetry.RecordAgentIdleKill(context.Background(), tp.DisplayName())
+					// Mark for immediate re-wake on this same tick by clearing
+					// last_woke_at and setting state to asleep. The wake logic
+					// below will pick it up.
+					batch := sessionpkg.SleepPatch(clk.Now(), "idle-timeout")
+					_ = store.SetMetadataBatch(session.ID, batch)
+					if session.Metadata == nil {
+						session.Metadata = make(map[string]string, len(batch))
+					}
+					for key, value := range batch {
+						session.Metadata[key] = value
+					}
+					alive = false
 				}
-				alive = false
 			}
 			// Fall through to wakeReasons — it will re-wake immediately if config present
 		}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -5590,8 +5590,8 @@ func TestReconcileSessionBeads_IdleTimeoutStopsAndStaysAsleep(t *testing.T) {
 // TestReconcileSessionBeads_IdleTimeoutRespectsUserHold guards the
 // session_reconciler.go idle-timeout block: a session with a future
 // held_until (set by `gc session suspend`) must not be idle-killed.
-// Without the guard, SleepPatch overwrites bead metadata and clears
-// held_until, silently un-suspending the session.
+// Without the guard, the idle kill path stops the runtime and rewrites the
+// intended user-hold sleep state.
 func TestReconcileSessionBeads_IdleTimeoutRespectsUserHold(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
@@ -5635,6 +5635,94 @@ func TestReconcileSessionBeads_IdleTimeoutRespectsUserHold(t *testing.T) {
 	for _, e := range rec.Events {
 		if e.Type == events.SessionIdleKilled {
 			t.Error("SessionIdleKilled must not fire while held_until is in the future")
+		}
+	}
+}
+
+func TestReconcileSessionBeads_IdleTimeoutSuspendedUserHoldStartsDrain(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	heldUntil := env.clk.Now().Add(100 * time.Hour).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"held_until":   heldUntil,
+		"sleep_intent": "user-hold",
+		"state":        "suspended",
+	})
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	it := newFakeIdleTracker()
+	it.idle["worker"] = true
+
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, configuredSessionNames(env.cfg, "", env.store),
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		it, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	ds := env.dt.get(session.ID)
+	if ds == nil {
+		t.Fatal("expected suspended user-hold session to start draining")
+	}
+	if ds.reason != "user-hold" {
+		t.Fatalf("drain reason = %q, want user-hold", ds.reason)
+	}
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("held worker must drain before the runtime is stopped")
+	}
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := b.Metadata["held_until"]; got != heldUntil {
+		t.Fatalf("held_until = %q, want preserved %q", got, heldUntil)
+	}
+}
+
+func TestReconcileSessionBeads_IdleTimeoutRespectsQuarantineBlocker(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	qUntil := env.clk.Now().Add(15 * time.Minute).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"quarantined_until": qUntil,
+		"sleep_reason":      "quarantine",
+		"state":             "quarantined",
+	})
+
+	it := newFakeIdleTracker()
+	it.idle["worker"] = true
+	rec := events.NewFake()
+	env.rec = rec
+
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, configuredSessionNames(env.cfg, "", env.store),
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		it, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("quarantined worker must not be idle-killed while quarantined_until is in the future")
+	}
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Metadata["sleep_reason"] == "idle-timeout" {
+		t.Fatalf("sleep_reason = %q, must not be idle-timeout for quarantined session", b.Metadata["sleep_reason"])
+	}
+	if got := b.Metadata["quarantined_until"]; got != qUntil {
+		t.Fatalf("quarantined_until = %q, want preserved %q", got, qUntil)
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionIdleKilled {
+			t.Fatal("SessionIdleKilled must not fire while quarantined_until is in the future")
 		}
 	}
 }
@@ -5722,8 +5810,8 @@ func TestReconcileSessionBeads_MaxSessionAgeKillsAgedSession(t *testing.T) {
 // TestReconcileSessionBeads_MaxSessionAgeRespectsUserHold guards the
 // session_reconciler.go max-session-age block: a session with a future
 // held_until (set by `gc session suspend`) must not be max-age killed.
-// Without the guard, SleepPatch overwrites bead metadata and clears
-// held_until, silently un-suspending the session.
+// Without the guard, the max-age kill path stops the runtime and rewrites the
+// intended user-hold sleep state.
 func TestReconcileSessionBeads_MaxSessionAgeRespectsUserHold(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "witness", MaxSessionAge: "5h"}}}
@@ -5759,6 +5847,47 @@ func TestReconcileSessionBeads_MaxSessionAgeRespectsUserHold(t *testing.T) {
 	for _, e := range rec.Events {
 		if e.Type == events.SessionMaxAgeKilled {
 			t.Error("SessionMaxAgeKilled must not fire while held_until is in the future")
+		}
+	}
+}
+
+func TestReconcileSessionBeads_MaxSessionAgeRespectsQuarantineBlocker(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "witness", MaxSessionAge: "5h"}}}
+	env.addDesired("witness", "witness", true)
+	session := env.createSessionBead("witness", "witness")
+	env.markSessionActive(&session)
+	qUntil := env.clk.Now().Add(15 * time.Minute).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"creation_complete_at": env.clk.Now().Add(-6 * time.Hour).UTC().Format(time.RFC3339),
+		"quarantined_until":    qUntil,
+		"sleep_reason":         "quarantine",
+		"state":                "quarantined",
+	})
+
+	tr := newMaxSessionAgeTracker()
+	tr.setConfig("witness", 5*time.Hour, 0)
+	rec := events.NewFake()
+	env.rec = rec
+
+	env.maxAgeReconcile([]beads.Bead{session}, tr)
+
+	if !env.sp.IsRunning("witness") {
+		t.Fatal("quarantined witness must not be max-age killed while quarantined_until is in the future")
+	}
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Metadata["sleep_reason"] == "max-session-age" {
+		t.Fatalf("sleep_reason = %q, must not be max-session-age for quarantined session", b.Metadata["sleep_reason"])
+	}
+	if got := b.Metadata["quarantined_until"]; got != qUntil {
+		t.Fatalf("quarantined_until = %q, want preserved %q", got, qUntil)
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionMaxAgeKilled {
+			t.Fatal("SessionMaxAgeKilled must not fire while quarantined_until is in the future")
 		}
 	}
 }

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -5587,6 +5587,58 @@ func TestReconcileSessionBeads_IdleTimeoutStopsAndStaysAsleep(t *testing.T) {
 	}
 }
 
+// TestReconcileSessionBeads_IdleTimeoutRespectsUserHold guards the
+// session_reconciler.go idle-timeout block: a session with a future
+// held_until (set by `gc session suspend`) must not be idle-killed.
+// Without the guard, SleepPatch overwrites bead metadata and clears
+// held_until, silently un-suspending the session.
+func TestReconcileSessionBeads_IdleTimeoutRespectsUserHold(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	heldUntil := env.clk.Now().Add(100 * time.Hour).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"held_until": heldUntil,
+	})
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	it := newFakeIdleTracker()
+	it.idle["worker"] = true
+
+	rec := events.NewFake()
+	env.rec = rec
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{}, false, nil, "",
+		it, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	if !env.sp.IsRunning("worker") {
+		t.Error("held worker must not be idle-killed while held_until is in the future")
+	}
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Metadata["sleep_reason"] == "idle-timeout" {
+		t.Errorf("sleep_reason = %q, must not be idle-timeout for held session", b.Metadata["sleep_reason"])
+	}
+	if got := b.Metadata["held_until"]; got != heldUntil {
+		t.Errorf("held_until = %q, want preserved %q", got, heldUntil)
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionIdleKilled {
+			t.Error("SessionIdleKilled must not fire while held_until is in the future")
+		}
+	}
+}
+
 func TestReconcileSessionBeads_IdleTimeoutNilTrackerSkipped(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
@@ -5664,6 +5716,50 @@ func TestReconcileSessionBeads_MaxSessionAgeKillsAgedSession(t *testing.T) {
 	}
 	if !fired {
 		t.Error("expected SessionMaxAgeKilled event")
+	}
+}
+
+// TestReconcileSessionBeads_MaxSessionAgeRespectsUserHold guards the
+// session_reconciler.go max-session-age block: a session with a future
+// held_until (set by `gc session suspend`) must not be max-age killed.
+// Without the guard, SleepPatch overwrites bead metadata and clears
+// held_until, silently un-suspending the session.
+func TestReconcileSessionBeads_MaxSessionAgeRespectsUserHold(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "witness", MaxSessionAge: "5h"}}}
+	env.addDesired("witness", "witness", true)
+	session := env.createSessionBead("witness", "witness")
+	env.markSessionActive(&session)
+	heldUntil := env.clk.Now().Add(100 * time.Hour).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"creation_complete_at": env.clk.Now().Add(-6 * time.Hour).UTC().Format(time.RFC3339),
+		"held_until":           heldUntil,
+	})
+
+	tr := newMaxSessionAgeTracker()
+	tr.setConfig("witness", 5*time.Hour, 0)
+	rec := events.NewFake()
+	env.rec = rec
+
+	env.maxAgeReconcile([]beads.Bead{session}, tr)
+
+	if !env.sp.IsRunning("witness") {
+		t.Error("held witness must not be max-age killed while held_until is in the future")
+	}
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Metadata["sleep_reason"] == "max-session-age" {
+		t.Errorf("sleep_reason = %q, must not be max-session-age for held session", b.Metadata["sleep_reason"])
+	}
+	if got := b.Metadata["held_until"]; got != heldUntil {
+		t.Errorf("held_until = %q, want preserved %q", got, heldUntil)
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionMaxAgeKilled {
+			t.Error("SessionMaxAgeKilled must not fire while held_until is in the future")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Guard both reconciler kill paths in `cmd/gc/session_reconciler.go` with a `held_until` check so user-suspended sessions aren't silently un-suspended:

- **max_session_age**: bypass restart while `held_until` is in the future; trace decision as `deferred_user_hold`. The if/else chain becomes a `switch` (gocritic ifElseChain).
- **idle_timeout**: skip kill and `continue`, matching the pending-interaction branch's "do not participate in this tick" semantics.

Add two regression tests (`TestReconcileSessionBeads_IdleTimeoutRespectsUserHold`, `TestReconcileSessionBeads_MaxSessionAgeRespectsUserHold`) that fail without the guards and pass with them.

## Why

Root cause of HQ P1 `gc-s9z`: the reconciler killed user-held sessions when the `max_session_age` or `idle_timeout` windows elapsed. `gc session suspend` writes a 100-year `held_until`, but neither enforcement block consulted it; `SleepPatch` then overwrote bead metadata and the next ready/wake tick re-armed the session. Observed 4 instances against `ggp` refinery `gc-hi6` on 2026-05-20.

This is the minimal guard. The broader "dedicated suspend state column" redesign is out of scope (see gc-s9z).

## Related

- HQ `gc-s9z` (P1, root cause + evidence)
- HQ `gc-m3j` (P1, refinery claim filter — blocked on this)
- HQ `gc-t2c` (P1, pack-derived suspend gap — blocked on this)

## Test plan

- [x] `go test ./cmd/gc -run 'TestReconcileSessionBeads_(IdleTimeoutRespectsUserHold|MaxSessionAgeRespectsUserHold)'` passes
- [x] Both tests confirmed RED without the guards (stash + rerun)
- [x] Wider `TestReconcileSessionBeads_*` suite green
- [x] `go vet ./...` clean
- [x] `golangci-lint` fmt + lint-changed clean
- [x] `scripts/test-local-parallel fast` (8-job sweep) all green