### PR TITLE
fix(runtime): consolidate zombie-shell liveness checks

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1406,18 +1406,8 @@ func observeRuntimeProviderLiveness(sp runtime.Provider, name string, processNam
 	if sp == nil || strings.TrimSpace(name) == "" {
 		return false, false
 	}
-	return runtimeProviderLivenessFromRunning(sp, name, processNames, sp.IsRunning(name))
-}
-
-func runtimeProviderLivenessFromRunning(sp runtime.Provider, name string, processNames []string, running bool) (bool, bool) {
-	if len(processNames) == 0 {
-		return running, running
-	}
-	alive := sp.ProcessAlive(name, processNames)
-	if alive && !running {
-		running = true
-	}
-	return running, alive
+	obs := runtime.ObserveLiveness(sp, name, processNames)
+	return obs.Running, obs.Alive
 }
 
 func commitStartResult(

--- a/internal/api/runtime_observation.go
+++ b/internal/api/runtime_observation.go
@@ -16,20 +16,14 @@ func observeProviderSession(sp runtime.Provider, sessionName string, processName
 	if sp == nil || sessionName == "" {
 		return obs
 	}
-	obs.Running = sp.IsRunning(sessionName)
+	liveness := runtime.ObserveLiveness(sp, sessionName, processNames)
+	obs.Running = liveness.Running
+	obs.Alive = liveness.Alive
 	if suspended, err := sp.GetMeta(sessionName, "suspended"); err == nil && strings.TrimSpace(suspended) == "true" {
 		obs.Suspended = true
 	}
 	if sessionID, err := sp.GetMeta(sessionName, "GC_SESSION_ID"); err == nil {
 		obs.RuntimeSessionID = strings.TrimSpace(sessionID)
-	}
-	if len(processNames) > 0 {
-		obs.Alive = sp.ProcessAlive(sessionName, processNames)
-		if obs.Alive && !obs.Running {
-			obs.Running = true
-		}
-	} else {
-		obs.Alive = obs.Running
 	}
 	if !obs.Running {
 		return obs

--- a/internal/runtime/liveness.go
+++ b/internal/runtime/liveness.go
@@ -1,0 +1,53 @@
+package runtime
+
+import "strings"
+
+// Liveness reports both provider-runtime presence and configured agent-process
+// presence for a session target.
+type Liveness struct {
+	Running bool
+	Alive   bool
+}
+
+// LivenessObserver is implemented by providers that can observe runtime and
+// agent-process liveness in one provider-native pass.
+type LivenessObserver interface {
+	ObserveLiveness(name string, processNames []string) Liveness
+}
+
+// ObserveLiveness returns the consolidated liveness view for a provider
+// session. Providers with native support may use additional persisted runtime
+// hints; other providers fall back to IsRunning plus ProcessAlive.
+func ObserveLiveness(sp Provider, name string, processNames []string) Liveness {
+	if sp == nil || strings.TrimSpace(name) == "" {
+		return Liveness{}
+	}
+	if observer, ok := sp.(LivenessObserver); ok {
+		return normalizeLiveness(observer.ObserveLiveness(name, processNames))
+	}
+	running := sp.IsRunning(name)
+	if !hasProcessNameHints(processNames) {
+		return Liveness{Running: running, Alive: running}
+	}
+	alive := sp.ProcessAlive(name, processNames)
+	if alive && !running {
+		running = true
+	}
+	return normalizeLiveness(Liveness{Running: running, Alive: alive})
+}
+
+func hasProcessNameHints(processNames []string) bool {
+	for _, name := range processNames {
+		if strings.TrimSpace(name) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeLiveness(obs Liveness) Liveness {
+	if obs.Alive && !obs.Running {
+		obs.Running = true
+	}
+	return obs
+}

--- a/internal/runtime/liveness_test.go
+++ b/internal/runtime/liveness_test.go
@@ -1,0 +1,57 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+func TestObserveLivenessTracksZombieProcess(t *testing.T) {
+	sp := NewFake()
+	if err := sp.Start(context.Background(), "worker", Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sp.Zombies["worker"] = true
+
+	got := ObserveLiveness(sp, "worker", []string{"agent-cli"})
+	if !got.Running {
+		t.Fatalf("ObserveLiveness.Running = false, want true for present runtime")
+	}
+	if got.Alive {
+		t.Fatalf("ObserveLiveness.Alive = true, want false for zombie process")
+	}
+}
+
+func TestObserveLivenessWithoutProcessNamesTreatsRunningAsAlive(t *testing.T) {
+	sp := NewFake()
+	if err := sp.Start(context.Background(), "worker", Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sp.Zombies["worker"] = true
+
+	got := ObserveLiveness(sp, "worker", nil)
+	if !got.Running || !got.Alive {
+		t.Fatalf("ObserveLiveness() = %#v, want running+alive when no process names are configured", got)
+	}
+}
+
+func TestObserveLivenessPromotesRunningWhenProcessCheckFindsFalseNegative(t *testing.T) {
+	base := NewFake()
+	if err := base.Start(context.Background(), "worker", Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sp := falseNegativeLivenessProvider{Fake: base}
+
+	got := ObserveLiveness(sp, "worker", []string{"agent-cli"})
+	if !got.Running || !got.Alive {
+		t.Fatalf("ObserveLiveness() = %#v, want process liveness to recover IsRunning false negative", got)
+	}
+}
+
+type falseNegativeLivenessProvider struct {
+	*Fake
+}
+
+func (p falseNegativeLivenessProvider) IsRunning(name string) bool {
+	_ = p.Fake.IsRunning(name)
+	return false
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -119,8 +119,9 @@ type Provider interface {
 	// exist. Used for graceful shutdown before Stop.
 	Interrupt(name string) error
 
-	// IsRunning reports whether the named session exists and has a
-	// live process.
+	// IsRunning reports whether the named provider runtime exists. It does not
+	// prove that the configured agent process is alive; callers that need that
+	// distinction should use ObserveLiveness or ProcessAlive.
 	IsRunning(name string) bool
 
 	// IsAttached reports whether a user terminal is currently connected

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -154,11 +154,10 @@ func injectSessionRuntimeHintsEnv(env map[string]string, cfg runtime.Config) map
 	} else {
 		delete(cloned, sessionReadyPromptEnvKey)
 	}
-	// Publish ProcessNames into the session env so subsequent liveness
-	// checks (Provider.IsRunning) can verify the agent process is alive
-	// in the pane's process tree, not just that the pane shell hasn't
-	// exited. Sessions without ProcessNames get pane-only liveness —
-	// preserves behavior for conformance tests and ad-hoc invocations.
+	// Publish ProcessNames into the session env so later liveness observation
+	// can distinguish a live pane shell from a live agent process. Sessions
+	// without ProcessNames keep pane-only liveness for conformance tests and
+	// ad-hoc invocations.
 	if names := joinNonEmpty(cfg.ProcessNames, ","); names != "" && strings.TrimSpace(cloned[gtProcessNamesEnvKey]) == "" {
 		cloned[gtProcessNamesEnvKey] = names
 	}
@@ -251,41 +250,14 @@ func (p *Provider) Interrupt(name string) error {
 	return err
 }
 
-// IsRunning reports whether the named session has a live (non-dead) pane
-// AND, if the session was started with GT_PROCESS_NAMES, that the named
-// agent process is alive in the pane's process tree.
-//
-// The pane_dead=0 check alone is not sufficient: when an agent (e.g.,
-// claude) exits cleanly inside an interactive shell, the shell returns
-// to its prompt rather than exiting. The pane stays alive (pane_dead=0)
-// but no agent process is running. Without the process-tree check,
-// these zombie shells satisfy `pool_desired` in the supervisor's
-// scale_check and replacements are never spawned.
-//
-// Sessions without GT_PROCESS_NAMES (legacy or ad-hoc invocations)
-// fall back to the original pane_dead-only behavior.
-//
+// IsRunning reports whether the named session has a live (non-dead) pane.
 // Uses a short-lived cache (default 2s TTL) backed by a single
-// `tmux list-panes -a` call for the pane_dead check. The process-tree
-// check (when applicable) is a per-call `ps` lookup — bounded by the
-// existing IsRuntimeRunning implementation.
+// `tmux list-panes -a` call instead of per-session HasSession + IsPaneDead
+// subprocess calls. Sessions with remain-on-exit corpses (pane_dead=1)
+// are correctly excluded. A live pane can still be a zombie shell; use
+// ObserveLiveness or ProcessAlive when agent-process liveness matters.
 func (p *Provider) IsRunning(name string) bool {
-	if !p.cache.IsRunning(name) {
-		return false
-	}
-	// Strict GT_PROCESS_NAMES lookup (NOT resolveSessionProcessNames —
-	// that one falls back to a hardcoded ["node","claude"] default which
-	// would cause this check to fail spuriously for any session not
-	// running claude, breaking conformance tests + ad-hoc usage).
-	//
-	// GT_PROCESS_NAMES is set on managed sessions by
-	// injectSessionRuntimeHintsEnv from cfg.ProcessNames; sessions
-	// without it fall back to pane_dead-only behavior.
-	namesRaw, err := p.tm.GetEnvironment(name, gtProcessNamesEnvKey)
-	if err != nil || strings.TrimSpace(namesRaw) == "" {
-		return true
-	}
-	return p.tm.IsRuntimeRunning(name, strings.Split(namesRaw, ","))
+	return p.cache.IsRunning(name)
 }
 
 // IsDeadRuntimeSession reports whether a visible tmux session is a
@@ -314,10 +286,54 @@ func (p *Provider) IsAttached(name string) bool {
 // process matching one of the given names in its process tree.
 // Returns true if processNames is empty (no check possible).
 func (p *Provider) ProcessAlive(name string, processNames []string) bool {
+	processNames = nonEmptyProcessNames(processNames)
 	if len(processNames) == 0 {
 		return true
 	}
 	return p.tm.IsRuntimeRunning(name, processNames)
+}
+
+// ObserveLiveness reports both pane presence and agent-process presence for a
+// tmux session. If processNames is empty, it strictly consults GT_PROCESS_NAMES
+// from the session environment; it never falls back to Claude defaults.
+func (p *Provider) ObserveLiveness(name string, processNames []string) runtime.Liveness {
+	if strings.TrimSpace(name) == "" {
+		return runtime.Liveness{}
+	}
+	running := p.cache.IsRunning(name)
+	processNames = nonEmptyProcessNames(processNames)
+	if len(processNames) == 0 {
+		processNames = p.sessionProcessNames(name)
+	}
+	if len(processNames) == 0 {
+		return runtime.Liveness{Running: running, Alive: running}
+	}
+	alive := p.tm.IsRuntimeRunning(name, processNames)
+	if alive && !running {
+		running = true
+	}
+	return runtime.Liveness{
+		Running: running,
+		Alive:   alive,
+	}
+}
+
+func (p *Provider) sessionProcessNames(name string) []string {
+	namesRaw, err := p.tm.GetEnvironment(name, gtProcessNamesEnvKey)
+	if err != nil {
+		return nil
+	}
+	return nonEmptyProcessNames(strings.Split(namesRaw, ","))
+}
+
+func nonEmptyProcessNames(processNames []string) []string {
+	out := make([]string, 0, len(processNames))
+	for _, name := range processNames {
+		if name = strings.TrimSpace(name); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 // Capabilities reports tmux provider capabilities.

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -154,8 +154,29 @@ func injectSessionRuntimeHintsEnv(env map[string]string, cfg runtime.Config) map
 	} else {
 		delete(cloned, sessionReadyPromptEnvKey)
 	}
+	// Publish ProcessNames into the session env so subsequent liveness
+	// checks (Provider.IsRunning) can verify the agent process is alive
+	// in the pane's process tree, not just that the pane shell hasn't
+	// exited. Sessions without ProcessNames get pane-only liveness —
+	// preserves behavior for conformance tests and ad-hoc invocations.
+	if names := joinNonEmpty(cfg.ProcessNames, ","); names != "" && strings.TrimSpace(cloned[gtProcessNamesEnvKey]) == "" {
+		cloned[gtProcessNamesEnvKey] = names
+	}
 	return cloned
 }
+
+// joinNonEmpty joins trimmed non-empty entries with sep; returns "" if none.
+func joinNonEmpty(parts []string, sep string) string {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, sep)
+}
+
+const gtProcessNamesEnvKey = "GT_PROCESS_NAMES"
 
 func newInstanceToken() (string, error) {
 	b := make([]byte, 16)
@@ -230,13 +251,41 @@ func (p *Provider) Interrupt(name string) error {
 	return err
 }
 
-// IsRunning reports whether the named session has a live (non-dead) pane.
+// IsRunning reports whether the named session has a live (non-dead) pane
+// AND, if the session was started with GT_PROCESS_NAMES, that the named
+// agent process is alive in the pane's process tree.
+//
+// The pane_dead=0 check alone is not sufficient: when an agent (e.g.,
+// claude) exits cleanly inside an interactive shell, the shell returns
+// to its prompt rather than exiting. The pane stays alive (pane_dead=0)
+// but no agent process is running. Without the process-tree check,
+// these zombie shells satisfy `pool_desired` in the supervisor's
+// scale_check and replacements are never spawned.
+//
+// Sessions without GT_PROCESS_NAMES (legacy or ad-hoc invocations)
+// fall back to the original pane_dead-only behavior.
+//
 // Uses a short-lived cache (default 2s TTL) backed by a single
-// `tmux list-panes -a` call instead of per-session HasSession + IsPaneDead
-// subprocess calls. Sessions with remain-on-exit corpses (pane_dead=1)
-// are correctly excluded — only sessions with live panes are "running".
+// `tmux list-panes -a` call for the pane_dead check. The process-tree
+// check (when applicable) is a per-call `ps` lookup — bounded by the
+// existing IsRuntimeRunning implementation.
 func (p *Provider) IsRunning(name string) bool {
-	return p.cache.IsRunning(name)
+	if !p.cache.IsRunning(name) {
+		return false
+	}
+	// Strict GT_PROCESS_NAMES lookup (NOT resolveSessionProcessNames —
+	// that one falls back to a hardcoded ["node","claude"] default which
+	// would cause this check to fail spuriously for any session not
+	// running claude, breaking conformance tests + ad-hoc usage).
+	//
+	// GT_PROCESS_NAMES is set on managed sessions by
+	// injectSessionRuntimeHintsEnv from cfg.ProcessNames; sessions
+	// without it fall back to pane_dead-only behavior.
+	namesRaw, err := p.tm.GetEnvironment(name, gtProcessNamesEnvKey)
+	if err != nil || strings.TrimSpace(namesRaw) == "" {
+		return true
+	}
+	return p.tm.IsRuntimeRunning(name, strings.Split(namesRaw, ","))
 }
 
 // IsDeadRuntimeSession reports whether a visible tmux session is a

--- a/internal/runtime/tmux/adapter_test.go
+++ b/internal/runtime/tmux/adapter_test.go
@@ -159,6 +159,42 @@ func TestProvider_RecyclesDeadPaneWithoutProcessNames(t *testing.T) {
 	}
 }
 
+func TestProviderObserveLivenessKeepsZombieShellVisible(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	cfg := DefaultConfig()
+	cfg.SocketName = testSocketName
+	p := NewProviderWithConfig(cfg)
+	name := "gc-test-zombie-shell-liveness"
+	_ = p.Stop(name)
+	defer func() { _ = p.Stop(name) }()
+
+	if err := p.Start(context.Background(), name, runtime.Config{
+		Command:      "sh -c 'sleep 2; exec sh -i'",
+		WorkDir:      t.TempDir(),
+		ProcessNames: []string{"sleep"},
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		obs := runtime.ObserveLiveness(p, name, nil)
+		if obs.Running && !obs.Alive {
+			if !p.IsRunning(name) {
+				t.Fatalf("IsRunning = false, want true while zombie shell pane is still present")
+			}
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	obs := runtime.ObserveLiveness(p, name, nil)
+	t.Fatalf("ObserveLiveness() = %#v, want running zombie shell with dead process", obs)
+}
+
 func TestProvider_StartCanceledCleansUpSession(t *testing.T) {
 	if !hasTmux() {
 		t.Skip("tmux not installed")

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1301,15 +1301,9 @@ func (m *Manager) ObserveRuntimeForInfo(info Info, processNames []string) Runtim
 	if strings.TrimSpace(info.SessionName) == "" || m.sp == nil {
 		return obs
 	}
-	obs.Running = m.sp.IsRunning(info.SessionName)
-	if len(processNames) > 0 {
-		obs.Alive = m.sp.ProcessAlive(info.SessionName, processNames)
-		if obs.Alive && !obs.Running {
-			obs.Running = true
-		}
-	} else {
-		obs.Alive = obs.Running
-	}
+	liveness := runtime.ObserveLiveness(m.sp, info.SessionName, processNames)
+	obs.Running = liveness.Running
+	obs.Alive = liveness.Alive
 	if obs.Running {
 		obs.Attached = m.sp.IsAttached(info.SessionName)
 		if lastActive, err := m.sp.GetLastActivity(info.SessionName); err == nil {

--- a/internal/worker/runtime_handle.go
+++ b/internal/worker/runtime_handle.go
@@ -340,9 +340,10 @@ func (h *RuntimeHandle) PendingStatus(ctx context.Context) (*PendingInteraction,
 // LiveObservation reports runtime presence metadata for a legacy runtime-only
 // worker target.
 func (h *RuntimeHandle) LiveObservation(_ context.Context) (LiveObservation, error) {
+	liveness := runtime.ObserveLiveness(h.provider, h.sessionName, h.processNames)
 	obs := LiveObservation{
-		Running:     h.provider.IsRunning(h.sessionName),
-		Alive:       false,
+		Running:     liveness.Running,
+		Alive:       liveness.Alive,
 		SessionName: h.sessionName,
 	}
 	if suspended, err := h.provider.GetMeta(h.sessionName, "suspended"); err == nil && strings.TrimSpace(suspended) == "true" {
@@ -350,14 +351,6 @@ func (h *RuntimeHandle) LiveObservation(_ context.Context) (LiveObservation, err
 	}
 	if sessionID, err := h.provider.GetMeta(h.sessionName, "GC_SESSION_ID"); err == nil {
 		obs.RuntimeSessionID = strings.TrimSpace(sessionID)
-	}
-	if len(h.processNames) > 0 {
-		obs.Alive = h.provider.ProcessAlive(h.sessionName, h.processNames)
-		if obs.Alive && !obs.Running {
-			obs.Running = true
-		}
-	} else {
-		obs.Alive = obs.Running
 	}
 	if obs.Running {
 		obs.Attached = h.provider.IsAttached(h.sessionName)


### PR DESCRIPTION
Supersedes #2387.

## Summary
- Cherry-picks the original PR #2387 commit first so contributor authorship is preserved.
- Adds a consolidated `runtime.ObserveLiveness` path that keeps provider runtime presence separate from configured agent process liveness.
- Keeps tmux `IsRunning` pane-only while tmux `ObserveLiveness` uses `GT_PROCESS_NAMES` for zombie-shell detection.
- Routes session/API/worker/CLI liveness observation through the shared helper.

## Validation
- `.githooks/pre-commit` during cherry-pick: lint-changed, generated docs check, `go vet ./...`, fast shard suite.
- `go test ./internal/runtime ./internal/runtime/tmux -run TestObserveLiveness`
- `go test -tags integration ./internal/runtime/tmux -run TestProviderObserveLivenessKeepsZombieShellVisible -count=1`