### PR TITLE
fix(reconciler): align assigned-work idle policy

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -24,6 +24,8 @@ func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agen
 	return storeRefs[index] == assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
 }
 
+// filterAssignedWorkBeadsForPoolDemand resolves work through the routed
+// backing template because pool scale decisions are per agent template.
 func filterAssignedWorkBeadsForPoolDemand(
 	cfg *config.City,
 	cityPath string,
@@ -79,6 +81,8 @@ func filterAssignedWorkBeadsForPoolDemand(
 	return filtered
 }
 
+// filterAssignedWorkBeadsForSessionWake resolves work through assignment
+// identities because session wake decisions are per concrete session owner.
 func filterAssignedWorkBeadsForSessionWake(
 	cfg *config.City,
 	cityPath string,

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -166,3 +166,116 @@ func TestSessionHasOpenAssignedWorkUsesOnlyReachableStore(t *testing.T) {
 		t.Fatal("rig-store assigned work should count for a rig-scoped session")
 	}
 }
+
+func TestSessionHasOpenAssignedWorkMatchesConfiguredNamedSessionRuntimeFallback(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:        "worker",
+			BindingName: "pack",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "worker",
+			BindingName: "pack",
+			Mode:        "on_demand",
+		}},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "pack.worker")
+	store := beads.NewMemStore()
+	session := beads.Bead{
+		ID:     "session-1",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"template":                   "pack.worker",
+			"session_name":               sessionName,
+			namedSessionMetadataKey:      "true",
+			namedSessionModeMetadata:     "on_demand",
+			namedSessionIdentityMetadata: "",
+		},
+	}
+	if _, err := store.Create(beads.Bead{
+		ID:       "named-work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "pack.worker",
+	}); err != nil {
+		t.Fatalf("Create named work: %v", err)
+	}
+
+	has, err := sessionHasOpenAssignedWorkForReachableStore("", cfg, store, nil, session)
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkForReachableStore: %v", err)
+	}
+	if !has {
+		t.Fatal("configured named-session runtime-name fallback assignment should count as open assigned work")
+	}
+}
+
+func TestSessionAssignmentIdentifiersForConfigConfiguredNamedSessionFallbackIsConservative(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:        "worker",
+			BindingName: "pack",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "worker",
+			BindingName: "pack",
+			Mode:        "on_demand",
+		}},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "pack.worker")
+
+	tests := []struct {
+		name    string
+		session beads.Bead
+	}{
+		{
+			name: "identity metadata already present",
+			session: beads.Bead{
+				ID: "session-with-identity",
+				Metadata: map[string]string{
+					"template":                   "pack.worker",
+					"session_name":               sessionName,
+					namedSessionMetadataKey:      "true",
+					namedSessionIdentityMetadata: "pack.other",
+				},
+			},
+		},
+		{
+			name: "template mismatch",
+			session: beads.Bead{
+				ID: "session-template-mismatch",
+				Metadata: map[string]string{
+					"template":                   "pack.other",
+					"session_name":               sessionName,
+					namedSessionMetadataKey:      "true",
+					namedSessionIdentityMetadata: "",
+				},
+			},
+		},
+		{
+			name: "runtime name mismatch",
+			session: beads.Bead{
+				ID: "session-runtime-mismatch",
+				Metadata: map[string]string{
+					"template":                   "pack.worker",
+					"session_name":               "different-session",
+					namedSessionMetadataKey:      "true",
+					namedSessionIdentityMetadata: "",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, identifier := range sessionAssignmentIdentifiersForConfig(tt.session, cfg) {
+				if identifier == "pack.worker" {
+					t.Fatalf("identifiers include configured identity %q for conservative mismatch case: %v", identifier, sessionAssignmentIdentifiersForConfig(tt.session, cfg))
+				}
+			}
+		})
+	}
+}

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -69,8 +69,11 @@ func buildAwakeInputFromReconciler(
 	for _, wb := range assignedWorkBeads {
 		a := strings.TrimSpace(wb.Assignee)
 		if a != "" && (wb.Status == "open" || wb.Status == "in_progress") {
+			// assignedWorkBeads is the reconciler's actionable snapshot:
+			// in-progress work plus open work that has already passed readiness
+			// and blocker filtering.
 			input.WorkBeads = append(input.WorkBeads, AwakeWorkBead{
-				ID: wb.ID, Assignee: a, Status: wb.Status,
+				ID: wb.ID, Assignee: a, Status: wb.Status, Ready: wb.Status == "open",
 			})
 		}
 	}
@@ -168,6 +171,7 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 			Reasons:          reasons,
 			Reason:           d.Reason,
 			ConfigSuppressed: d.Reason == "idle-sleep",
+			HasAssignedWork:  d.HasAssignedWork,
 		}
 	}
 	return evals

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -320,9 +320,23 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 
 		// Idle sleep: desired sessions idle too long should sleep.
-		// Attached, pinned, and mode=always named sessions are exempt.
+		// Attached, pinned, mode=always named, and sessions actively
+		// executing in_progress work are exempt. The in_progress
+		// exemption matters for pool workers in mid-task: a slow
+		// upstream API call between two of the agent's own bd writes
+		// can drive IdleSince past the threshold while the underlying
+		// CLI process is still alive. Without this exemption, the gate
+		// would flip ShouldWake back to false even though the
+		// assigned-work loop above tagged the session "must stay awake
+		// because it owns active work" — and downstream consumers (the
+		// session.stranded diagnostic and any witness-style recovery)
+		// would see a false positive. Queued ("open") work is
+		// intentionally not exempted: on-demand named sessions are
+		// allowed to idle-sleep with queued work and wake on the next
+		// on-demand trigger.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
-			!isAlwaysNamedSession(input.NamedSessions, bead) {
+			!isAlwaysNamedSession(input.NamedSessions, bead) &&
+			!sessionHasAssignedInProgressWork(input.WorkBeads, bead) {
 			agent, hasAgent := agentsByName[bead.Template]
 			var idleTimeout time.Duration
 			switch {
@@ -362,6 +376,35 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	}
 
 	return result
+}
+
+// sessionHasAssignedInProgressWork reports whether any in_progress work
+// bead in workBeads is assigned to the given session bead. Matches by
+// concrete bead ID, the session's current SessionName token, or its
+// configured NamedIdentity — the same set of acceptable assignee values
+// used by the assigned-work gate at compute_awake_set.go:230-254.
+//
+// Status is restricted to "in_progress" specifically (not "open"). An
+// open assigned bead is queued work the agent has not yet claimed; an
+// on-demand named session is allowed to idle-sleep with queued work
+// pending and wake on the next on-demand trigger. An in_progress
+// assigned bead means the agent is actively executing it, and the
+// session must not be classified as idle while that's true.
+func sessionHasAssignedInProgressWork(workBeads []AwakeWorkBead, bead AwakeSessionBead) bool {
+	for _, wb := range workBeads {
+		if wb.Status != "in_progress" {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if assignee == bead.ID || assignee == bead.SessionName ||
+			(bead.NamedIdentity != "" && assignee == bead.NamedIdentity) {
+			return true
+		}
+	}
+	return false
 }
 
 func findNamedSessionName(beads []AwakeSessionBead, identity string) string {

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -19,7 +19,7 @@ type AwakeInput struct {
 	Agents             []AwakeAgent
 	NamedSessions      []AwakeNamedSession
 	SessionBeads       []AwakeSessionBead
-	WorkBeads          []AwakeWorkBead
+	WorkBeads          []AwakeWorkBead // open + in_progress assigned work; blocked open assignments filtered upstream
 	ScaleCheckCounts   map[string]int  // agent template → scale_check count
 	NamedSessionDemand map[string]bool // named-session identity → routed/assigned work demand
 	WorkSet            map[string]bool // agent template → work_query found pending work
@@ -103,7 +103,6 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	// compatible wake causes (pending create, named-always, assigned work) may
 	// still reuse the same bead.
 	desired := make(map[string]string) // sessionName → reason
-	concreteAssignedWork := make(map[string]bool)
 
 	// Newly created beads that still carry a controller create claim must be
 	// launched at least once, even if the work signal that materialized them
@@ -173,7 +172,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			if filled >= count {
 				break
 			}
-			if sessionHasConcreteAssignedWork(input.WorkBeads, bead) {
+			if sessionHasConcreteAssignedWork(input.WorkBeads, input.NamedSessions, bead) {
 				continue
 			}
 			desired[bead.SessionName] = "scaled:demand"
@@ -184,7 +183,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			if filled >= count {
 				break
 			}
-			if sessionHasConcreteAssignedWork(input.WorkBeads, bead) {
+			if sessionHasConcreteAssignedWork(input.WorkBeads, input.NamedSessions, bead) {
 				continue
 			}
 			desired[bead.SessionName] = "scaled:creating"
@@ -230,10 +229,12 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 	}
 
-	// Sessions with assigned work — a session that has open or in_progress
-	// work assigned to it must stay awake. Compatibility-only readers still
-	// accept current session_name and exact configured named identity tokens,
-	// but normal targeting surfaces write the concrete bead ID.
+	// Sessions with assigned work — a session that has in_progress work or
+	// ready open work assigned to it must stay awake. Blocked open assignments
+	// are filtered out before this point, so their routing intent does not
+	// create wake demand. Compatibility-only readers still accept current
+	// session_name and exact configured named identity tokens, but normal
+	// targeting surfaces write the concrete bead ID.
 	for _, bead := range input.SessionBeads {
 		if bead.State == "closed" {
 			continue
@@ -246,12 +247,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			if assignee == "" || (wb.Status != "open" && wb.Status != "in_progress") {
 				continue
 			}
-			if assignee == bead.ID || assignee == bead.SessionName {
-				desired[bead.SessionName] = "assigned-work"
-				concreteAssignedWork[bead.SessionName] = true
-				break
-			}
-			if bead.NamedIdentity != "" && assignee == bead.NamedIdentity {
+			if sessionAssigneeMatches(input.NamedSessions, bead, assignee) {
 				desired[bead.SessionName] = "assigned-work"
 				break
 			}
@@ -320,23 +316,14 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 
 		// Idle sleep: desired sessions idle too long should sleep.
-		// Attached, pinned, mode=always named, and sessions actively
-		// executing in_progress work are exempt. The in_progress
-		// exemption matters for pool workers in mid-task: a slow
-		// upstream API call between two of the agent's own bd writes
-		// can drive IdleSince past the threshold while the underlying
-		// CLI process is still alive. Without this exemption, the gate
-		// would flip ShouldWake back to false even though the
-		// assigned-work loop above tagged the session "must stay awake
-		// because it owns active work" — and downstream consumers (the
-		// session.stranded diagnostic and any witness-style recovery)
-		// would see a false positive. Queued ("open") work is
-		// intentionally not exempted: on-demand named sessions are
-		// allowed to idle-sleep with queued work and wake on the next
-		// on-demand trigger.
+		// Attached, pending, pinned, mode=always named, and sessions with
+		// assigned demand work are exempt. Assigned demand work means either
+		// in_progress ownership or ready open assigned work; blocked open
+		// assignments are not present in input.WorkBeads and do not prevent
+		// idle sleep.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
 			!isAlwaysNamedSession(input.NamedSessions, bead) &&
-			!sessionHasAssignedInProgressWork(input.WorkBeads, bead) {
+			desired[name] != "assigned-work" {
 			agent, hasAgent := agentsByName[bead.Template]
 			var idleTimeout time.Duration
 			switch {
@@ -347,7 +334,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			case isOnDemandSession(input.NamedSessions, bead):
 				idleTimeout = defaultOnDemandIdleTimeout
 			}
-			if idleTimeout > 0 && input.Now.Sub(bead.IdleSince) >= idleTimeout && !concreteAssignedWork[name] {
+			if idleTimeout > 0 && input.Now.Sub(bead.IdleSince) >= idleTimeout {
 				decision.ShouldWake = false
 				decision.Reason = "idle-sleep"
 			}
@@ -376,35 +363,6 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	}
 
 	return result
-}
-
-// sessionHasAssignedInProgressWork reports whether any in_progress work
-// bead in workBeads is assigned to the given session bead. Matches by
-// concrete bead ID, the session's current SessionName token, or its
-// configured NamedIdentity — the same set of acceptable assignee values
-// used by the assigned-work gate at compute_awake_set.go:230-254.
-//
-// Status is restricted to "in_progress" specifically (not "open"). An
-// open assigned bead is queued work the agent has not yet claimed; an
-// on-demand named session is allowed to idle-sleep with queued work
-// pending and wake on the next on-demand trigger. An in_progress
-// assigned bead means the agent is actively executing it, and the
-// session must not be classified as idle while that's true.
-func sessionHasAssignedInProgressWork(workBeads []AwakeWorkBead, bead AwakeSessionBead) bool {
-	for _, wb := range workBeads {
-		if wb.Status != "in_progress" {
-			continue
-		}
-		assignee := strings.TrimSpace(wb.Assignee)
-		if assignee == "" {
-			continue
-		}
-		if assignee == bead.ID || assignee == bead.SessionName ||
-			(bead.NamedIdentity != "" && assignee == bead.NamedIdentity) {
-			return true
-		}
-	}
-	return false
 }
 
 func findNamedSessionName(beads []AwakeSessionBead, identity string) string {
@@ -488,13 +446,40 @@ func collectActiveBeads(beads []AwakeSessionBead, template string) []AwakeSessio
 	return result
 }
 
-func sessionHasConcreteAssignedWork(workBeads []AwakeWorkBead, bead AwakeSessionBead) bool {
+func sessionHasConcreteAssignedWork(workBeads []AwakeWorkBead, named []AwakeNamedSession, bead AwakeSessionBead) bool {
 	for _, wb := range workBeads {
 		assignee := strings.TrimSpace(wb.Assignee)
 		if assignee == "" || (wb.Status != "open" && wb.Status != "in_progress") {
 			continue
 		}
-		if assignee == bead.ID || assignee == bead.SessionName {
+		if sessionAssigneeMatches(named, bead, assignee) {
+			return true
+		}
+	}
+	return false
+}
+
+func sessionAssigneeMatches(named []AwakeNamedSession, bead AwakeSessionBead, assignee string) bool {
+	if assignee == "" {
+		return false
+	}
+	if assignee == bead.ID || assignee == bead.SessionName {
+		return true
+	}
+	if bead.NamedIdentity != "" {
+		return assignee == bead.NamedIdentity
+	}
+	if !bead.ConfiguredNamedSession {
+		return false
+	}
+	for _, ns := range named {
+		if ns.RuntimeName == "" || ns.RuntimeName != bead.SessionName {
+			continue
+		}
+		if ns.Template != "" && ns.Template != bead.Template {
+			continue
+		}
+		if assignee == ns.Identity {
 			return true
 		}
 	}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -19,7 +19,7 @@ type AwakeInput struct {
 	Agents             []AwakeAgent
 	NamedSessions      []AwakeNamedSession
 	SessionBeads       []AwakeSessionBead
-	WorkBeads          []AwakeWorkBead // open + in_progress assigned work; blocked open assignments filtered upstream
+	WorkBeads          []AwakeWorkBead // in_progress assigned work plus ready open assigned work
 	ScaleCheckCounts   map[string]int  // agent template → scale_check count
 	NamedSessionDemand map[string]bool // named-session identity → routed/assigned work demand
 	WorkSet            map[string]bool // agent template → work_query found pending work
@@ -73,12 +73,14 @@ type AwakeWorkBead struct {
 	ID       string
 	Assignee string
 	Status   string // "open", "in_progress"
+	Ready    bool   // true for open work only after readiness/blocker filtering
 }
 
 // AwakeDecision is the output for a single session.
 type AwakeDecision struct {
-	ShouldWake bool
-	Reason     string // human-readable reason for debugging
+	ShouldWake      bool
+	Reason          string // human-readable reason for debugging
+	HasAssignedWork bool   // underlying assigned-work demand before wake reason overrides
 }
 
 // ComputeAwakeSet determines which sessions should be awake.
@@ -172,7 +174,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			if filled >= count {
 				break
 			}
-			if sessionHasConcreteAssignedWork(input.WorkBeads, input.NamedSessions, bead) {
+			if sessionHasAssignedWork(input.WorkBeads, input.NamedSessions, bead) {
 				continue
 			}
 			desired[bead.SessionName] = "scaled:demand"
@@ -183,7 +185,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			if filled >= count {
 				break
 			}
-			if sessionHasConcreteAssignedWork(input.WorkBeads, input.NamedSessions, bead) {
+			if sessionHasAssignedWork(input.WorkBeads, input.NamedSessions, bead) {
 				continue
 			}
 			desired[bead.SessionName] = "scaled:creating"
@@ -230,11 +232,9 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	}
 
 	// Sessions with assigned work — a session that has in_progress work or
-	// ready open work assigned to it must stay awake. Blocked open assignments
-	// are filtered out before this point, so their routing intent does not
-	// create wake demand. Compatibility-only readers still accept current
-	// session_name and exact configured named identity tokens, but normal
-	// targeting surfaces write the concrete bead ID.
+	// ready open work assigned to it must stay awake. Open work must carry
+	// Ready=true so a blocked routed assignment cannot become wake demand if
+	// a future caller accidentally broadens the collection query.
 	for _, bead := range input.SessionBeads {
 		if bead.State == "closed" {
 			continue
@@ -244,7 +244,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 		for _, wb := range input.WorkBeads {
 			assignee := strings.TrimSpace(wb.Assignee)
-			if assignee == "" || (wb.Status != "open" && wb.Status != "in_progress") {
+			if assignee == "" || !workBeadHasAwakeDemand(wb) {
 				continue
 			}
 			if sessionAssigneeMatches(input.NamedSessions, bead, assignee) {
@@ -259,7 +259,9 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 
 	for _, bead := range input.SessionBeads {
 		name := bead.SessionName
-		decision := AwakeDecision{}
+		decision := AwakeDecision{
+			HasAssignedWork: desired[name] == "assigned-work",
+		}
 
 		// Desired set (demand-driven wake). wait_hold suppresses normal
 		// demand-driven wake so a session intentionally parked on human
@@ -318,9 +320,8 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// Idle sleep: desired sessions idle too long should sleep.
 		// Attached, pending, pinned, mode=always named, and sessions with
 		// assigned demand work are exempt. Assigned demand work means either
-		// in_progress ownership or ready open assigned work; blocked open
-		// assignments are not present in input.WorkBeads and do not prevent
-		// idle sleep.
+		// in_progress ownership or open work with Ready=true; blocked open
+		// assignments do not prevent idle sleep.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
 			!isAlwaysNamedSession(input.NamedSessions, bead) &&
 			desired[name] != "assigned-work" {
@@ -446,10 +447,10 @@ func collectActiveBeads(beads []AwakeSessionBead, template string) []AwakeSessio
 	return result
 }
 
-func sessionHasConcreteAssignedWork(workBeads []AwakeWorkBead, named []AwakeNamedSession, bead AwakeSessionBead) bool {
+func sessionHasAssignedWork(workBeads []AwakeWorkBead, named []AwakeNamedSession, bead AwakeSessionBead) bool {
 	for _, wb := range workBeads {
 		assignee := strings.TrimSpace(wb.Assignee)
-		if assignee == "" || (wb.Status != "open" && wb.Status != "in_progress") {
+		if assignee == "" || !workBeadHasAwakeDemand(wb) {
 			continue
 		}
 		if sessionAssigneeMatches(named, bead, assignee) {
@@ -457,6 +458,17 @@ func sessionHasConcreteAssignedWork(workBeads []AwakeWorkBead, named []AwakeName
 		}
 	}
 	return false
+}
+
+func workBeadHasAwakeDemand(bead AwakeWorkBead) bool {
+	switch bead.Status {
+	case "in_progress":
+		return true
+	case "open":
+		return bead.Ready
+	default:
+		return false
+	}
 }
 
 func sessionAssigneeMatches(named []AwakeNamedSession, bead AwakeSessionBead, assignee string) bool {
@@ -472,6 +484,8 @@ func sessionAssigneeMatches(named []AwakeNamedSession, bead AwakeSessionBead, as
 	if !bead.ConfiguredNamedSession {
 		return false
 	}
+	// This configured-named fallback mirrors sessionAssignmentIdentifiersForConfig
+	// so awake decisions and cleanup guards recognize the same identities.
 	for _, ns := range named {
 		if ns.RuntimeName == "" || ns.RuntimeName != bead.SessionName {
 			continue

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1114,6 +1114,48 @@ func TestRegression_SessionWithWorkByAlias_DoesNotWake(t *testing.T) {
 // Asleep ephemeral with assigned work (e2e regression)
 // ---------------------------------------------------------------------------
 
+// TestRegression_IdleSleepDoesNotOverrideAssignedWork covers issue #1427:
+// a session that holds an open in_progress work bead must not be flipped
+// to ShouldWake=false / Reason="idle-sleep" by the idle-sleep gate, even
+// when its IdleSince is past the agent's SleepAfterIdle threshold.
+//
+// Production scenario: a pool worker is mid-task, blocked on a slow
+// upstream API response between two of its own bd writes. From the
+// outside, IdleSince walks past the threshold while the underlying CLI
+// process is still very much alive. The assigned-work gate marked it
+// "must stay awake because it owns active work"; the idle-sleep gate
+// then over-rode that and labeled the session asleep — handing
+// downstream recovery agents and #1425's session.stranded diagnostic a
+// false positive.
+func TestRegression_IdleSleepDoesNotOverrideAssignedWork(t *testing.T) {
+	idleTimeout := 10 * time.Minute
+	idleSince := now.Add(-(idleTimeout + time.Minute)) // 11 min ago: past threshold
+
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{
+			QualifiedName:  "hello-world/polecat",
+			SleepAfterIdle: idleTimeout,
+		}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:          "mc-sctve",
+			SessionName: "polecat-mc-sctve",
+			Template:    "hello-world/polecat",
+			State:       "active",
+			IdleSince:   idleSince,
+		}},
+		WorkBeads: []AwakeWorkBead{
+			{ID: "hw-8lb", Assignee: "mc-sctve", Status: "in_progress"},
+		},
+		ScaleCheckCounts: map[string]int{"hello-world/polecat": 0},
+		Now:              now,
+	})
+
+	assertAwake(t, result, "polecat-mc-sctve")
+	if got := result["polecat-mc-sctve"].Reason; got == "idle-sleep" {
+		t.Errorf("reason = %q, want non-idle-sleep — assigned-work must veto idle-sleep override", got)
+	}
+}
+
 func TestRegression_AsleepEphemeralWithAssignedWork_WakesViaAssignedWork(t *testing.T) {
 	// An asleep polecat that has in_progress work assigned to its bead ID
 	// must wake via the assigned-work path, even though scaleCheck alone

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -291,7 +291,7 @@ func TestNamedOnDemand_ExactNamedIdentityAssigneeWakes(t *testing.T) {
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
 		SessionBeads:  []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "hello-world/refinery"}},
-		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}},
+		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open", Ready: true}},
 		Now:           now,
 	})
 	assertAwake(t, result, "hello-world--refinery")
@@ -432,7 +432,7 @@ func TestNamedOnDemand_AgentSuspended_WithWork(t *testing.T) {
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery", Suspended: true}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
 		SessionBeads:  []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "hello-world/refinery"}},
-		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}},
+		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open", Ready: true}},
 		Now:           now,
 	})
 	assertAsleep(t, result, "hello-world--refinery")
@@ -1048,9 +1048,10 @@ func TestIdleSleep_OnDemandNamedReadyAssignedWorkStaysAwake(t *testing.T) {
 				NamedIdentity: "hello-world/refinery", IdleSince: now.Add(-1 * time.Hour),
 			},
 		},
-		// WorkBeads contains ready open assigned work. Blocked open assigned
-		// work is filtered out before ComputeAwakeSet.
-		WorkBeads:       []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}},
+		// Ready open assigned work is actionable demand for the assignee,
+		// not queued template backlog to defer until a later on-demand wake.
+		// Blocked open assigned work is filtered out before ComputeAwakeSet.
+		WorkBeads:       []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open", Ready: true}},
 		RunningSessions: map[string]bool{"hello-world--refinery": true},
 		Now:             now,
 	})
@@ -1058,7 +1059,7 @@ func TestIdleSleep_OnDemandNamedReadyAssignedWorkStaysAwake(t *testing.T) {
 	assertReason(t, result, "hello-world--refinery", "assigned-work")
 }
 
-func TestIdleSleep_OnDemandNamedBlockedAssignedWorkIsNotDemand(t *testing.T) {
+func TestIdleSleep_OnDemandNamedNoDemandWorkSleeps(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery", SleepAfterIdle: 30 * time.Minute}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
@@ -1108,7 +1109,7 @@ func TestRegression_OnDemandRefineryExactNamedIdentityAssigneeWakes(t *testing.T
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
 		SessionBeads:  []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "hello-world/refinery"}},
-		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}},
+		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open", Ready: true}},
 		Now:           now,
 	})
 	assertAwake(t, result, "hello-world--refinery")
@@ -1134,12 +1135,43 @@ func TestRegression_SessionWithOpenWorkByBeadID_StaysAwake(t *testing.T) {
 		SessionBeads: []AwakeSessionBead{
 			{ID: "mc-p1", SessionName: "polecat-mc-p1", Template: "hello-world/polecat", State: "active"},
 		},
-		WorkBeads:        []AwakeWorkBead{{ID: "hw-1", Assignee: "mc-p1", Status: "open"}},
+		WorkBeads:        []AwakeWorkBead{{ID: "hw-1", Assignee: "mc-p1", Status: "open", Ready: true}},
 		ScaleCheckCounts: map[string]int{"hello-world/polecat": 0},
 		RunningSessions:  map[string]bool{"polecat-mc-p1": true},
 		Now:              now,
 	})
 	assertAwake(t, result, "polecat-mc-p1")
+}
+
+func TestRegression_PoolReadyOpenWorkVetoesIdleSleep(t *testing.T) {
+	idleTimeout := 10 * time.Minute
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", SleepAfterIdle: idleTimeout}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-p1", SessionName: "polecat-mc-p1", Template: "hello-world/polecat", State: "active",
+				IdleSince: now.Add(-(idleTimeout + time.Minute)),
+			},
+		},
+		WorkBeads:        []AwakeWorkBead{{ID: "hw-1", Assignee: "mc-p1", Status: "open", Ready: true}},
+		ScaleCheckCounts: map[string]int{"hello-world/polecat": 0},
+		RunningSessions:  map[string]bool{"polecat-mc-p1": true},
+		Now:              now,
+	})
+	assertAwake(t, result, "polecat-mc-p1")
+	assertReason(t, result, "polecat-mc-p1", "assigned-work")
+}
+
+func TestRegression_OpenAssignedWorkWithoutReadySignalDoesNotWake(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-p1", SessionName: "polecat-mc-p1", Template: "hello-world/polecat", State: "asleep"},
+		},
+		WorkBeads: []AwakeWorkBead{{ID: "hw-1", Assignee: "mc-p1", Status: "open", Ready: false}},
+		Now:       now,
+	})
+	assertAsleep(t, result, "polecat-mc-p1")
 }
 
 func TestRegression_SessionWithWorkByAlias_DoesNotWake(t *testing.T) {
@@ -1227,7 +1259,7 @@ func TestRegression_AsleepEphemeralWithAssignedWork_WakesViaAssignedWork(t *test
 	}
 }
 
-func TestRegression_ConcreteAssignedWorkSuppressesIdleSleep(t *testing.T) {
+func TestRegression_SessionNameAssignedWorkSuppressesIdleSleep(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", SleepAfterIdle: 2 * time.Hour}},
 		SessionBeads: []AwakeSessionBead{
@@ -1245,7 +1277,46 @@ func TestRegression_ConcreteAssignedWorkSuppressesIdleSleep(t *testing.T) {
 	assertReason(t, result, "polecat-mc-sctve", "assigned-work")
 }
 
-func TestSessionHasConcreteAssignedWorkMatchesNamedIdentity(t *testing.T) {
+func TestRegression_BeadIDAssignedWorkSuppressesIdleSleep(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", SleepAfterIdle: 2 * time.Hour}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-sctve", SessionName: "polecat-mc-sctve", Template: "hello-world/polecat", State: "active",
+				IdleSince: now.Add(-3 * time.Hour),
+			},
+		},
+		WorkBeads:        []AwakeWorkBead{{ID: "hw-8lb", Assignee: "mc-sctve", Status: "in_progress"}},
+		ScaleCheckCounts: map[string]int{"hello-world/polecat": 1},
+		RunningSessions:  map[string]bool{"polecat-mc-sctve": true},
+		Now:              now,
+	})
+	assertAwake(t, result, "polecat-mc-sctve")
+	assertReason(t, result, "polecat-mc-sctve", "assigned-work")
+}
+
+func TestIdleSleep_SuspendedTemplateAssignedWorkDoesNotVetoWaitReadySleep(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", Suspended: true, SleepAfterIdle: 2 * time.Hour}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-sctve", SessionName: "polecat-mc-sctve", Template: "hello-world/polecat", State: "active",
+				IdleSince: now.Add(-3 * time.Hour),
+			},
+		},
+		WorkBeads:       []AwakeWorkBead{{ID: "hw-8lb", Assignee: "mc-sctve", Status: "in_progress"}},
+		RunningSessions: map[string]bool{"polecat-mc-sctve": true},
+		ReadyWaitSet:    map[string]bool{"mc-sctve": true},
+		Now:             now,
+	})
+	assertAsleep(t, result, "polecat-mc-sctve")
+	assertReason(t, result, "polecat-mc-sctve", "idle-sleep")
+	if result["polecat-mc-sctve"].HasAssignedWork {
+		t.Fatal("suspended-template work must not set HasAssignedWork")
+	}
+}
+
+func TestSessionHasAssignedWorkMatchesNamedIdentity(t *testing.T) {
 	bead := AwakeSessionBead{
 		ID:            "mc-named",
 		SessionName:   "hello-world--refinery",
@@ -1253,12 +1324,12 @@ func TestSessionHasConcreteAssignedWorkMatchesNamedIdentity(t *testing.T) {
 		NamedIdentity: "hello-world/refinery",
 	}
 	work := []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "in_progress"}}
-	if !sessionHasConcreteAssignedWork(work, nil, bead) {
-		t.Fatal("expected named-identity assignment to count as concrete assigned work")
+	if !sessionHasAssignedWork(work, nil, bead) {
+		t.Fatal("expected named-identity assignment to count as assigned work")
 	}
 }
 
-func TestSessionHasConcreteAssignedWorkMatchesConfiguredNamedSessionFallback(t *testing.T) {
+func TestSessionHasAssignedWorkMatchesConfiguredNamedSessionFallback(t *testing.T) {
 	named := []AwakeNamedSession{{
 		Identity:    "hello-world/refinery",
 		Template:    "hello-world/worker",
@@ -1271,9 +1342,9 @@ func TestSessionHasConcreteAssignedWorkMatchesConfiguredNamedSessionFallback(t *
 		Template:               "hello-world/worker",
 		ConfiguredNamedSession: true,
 	}
-	work := []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}}
-	if !sessionHasConcreteAssignedWork(work, named, bead) {
-		t.Fatal("expected configured named-session fallback assignment to count as concrete assigned work")
+	work := []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open", Ready: true}}
+	if !sessionHasAssignedWork(work, named, bead) {
+		t.Fatal("expected configured named-session fallback assignment to count as assigned work")
 	}
 }
 

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -165,6 +165,33 @@ func TestNamedAlways_MissingConfiguredIdentityIgnoredForUnrelatedTemplate(t *tes
 	assertAsleep(t, result, "hello-world--refinery")
 }
 
+func TestNamedOnDemand_MissingConfiguredIdentityAssignedWorkVetoesIdleSleep(t *testing.T) {
+	idleSince := now.Add(-(defaultOnDemandIdleTimeout + time.Minute))
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/worker"}},
+		NamedSessions: []AwakeNamedSession{{
+			Identity:    "hello-world/refinery",
+			Template:    "hello-world/worker",
+			Mode:        "on_demand",
+			RuntimeName: "hello-world--refinery",
+		}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:                     "mc-1",
+			SessionName:            "hello-world--refinery",
+			Template:               "hello-world/worker",
+			State:                  "active",
+			ConfiguredNamedSession: true,
+			IdleSince:              idleSince,
+			// NamedIdentity intentionally empty — exercises the fallback path.
+		}},
+		WorkBeads:       []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "in_progress"}},
+		RunningSessions: map[string]bool{"hello-world--refinery": true},
+		Now:             now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "assigned-work")
+}
+
 // TestConfiguredNamedSessionExcludedFromPoolCandidatesEvenWhenIdentityMissing
 // guards the defensive fix from copilot review on PR #2034: a bead with
 // ConfiguredNamedSession=true but NamedIdentity="" must NOT be treated as a
@@ -1011,7 +1038,7 @@ func TestIdleSleep_AgentNotIdleEnough(t *testing.T) {
 	assertAwake(t, result, "polecat-mc-1")
 }
 
-func TestIdleSleep_OnDemandNamed(t *testing.T) {
+func TestIdleSleep_OnDemandNamedReadyAssignedWorkStaysAwake(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery", SleepAfterIdle: 30 * time.Minute}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
@@ -1021,7 +1048,26 @@ func TestIdleSleep_OnDemandNamed(t *testing.T) {
 				NamedIdentity: "hello-world/refinery", IdleSince: now.Add(-1 * time.Hour),
 			},
 		},
+		// WorkBeads contains ready open assigned work. Blocked open assigned
+		// work is filtered out before ComputeAwakeSet.
 		WorkBeads:       []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}},
+		RunningSessions: map[string]bool{"hello-world--refinery": true},
+		Now:             now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "assigned-work")
+}
+
+func TestIdleSleep_OnDemandNamedBlockedAssignedWorkIsNotDemand(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery", SleepAfterIdle: 30 * time.Minute}},
+		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "active",
+				NamedIdentity: "hello-world/refinery", IdleSince: now.Add(-1 * time.Hour),
+			},
+		},
 		RunningSessions: map[string]bool{"hello-world--refinery": true},
 		Now:             now,
 	})
@@ -1114,8 +1160,8 @@ func TestRegression_SessionWithWorkByAlias_DoesNotWake(t *testing.T) {
 // Asleep ephemeral with assigned work (e2e regression)
 // ---------------------------------------------------------------------------
 
-// TestRegression_IdleSleepDoesNotOverrideAssignedWork covers issue #1427:
-// a session that holds an open in_progress work bead must not be flipped
+// TestRegression_IdleSleepDoesNotOverrideNamedIdentityAssignedWork covers issue #1427:
+// a session that holds an in_progress work bead by named identity must not be flipped
 // to ShouldWake=false / Reason="idle-sleep" by the idle-sleep gate, even
 // when its IdleSince is past the agent's SleepAfterIdle threshold.
 //
@@ -1124,34 +1170,38 @@ func TestRegression_SessionWithWorkByAlias_DoesNotWake(t *testing.T) {
 // outside, IdleSince walks past the threshold while the underlying CLI
 // process is still very much alive. The assigned-work gate marked it
 // "must stay awake because it owns active work"; the idle-sleep gate
-// then over-rode that and labeled the session asleep — handing
-// downstream recovery agents and #1425's session.stranded diagnostic a
-// false positive.
-func TestRegression_IdleSleepDoesNotOverrideAssignedWork(t *testing.T) {
+// then over-rode that and labeled the session asleep.
+func TestRegression_IdleSleepDoesNotOverrideNamedIdentityAssignedWork(t *testing.T) {
 	idleTimeout := 10 * time.Minute
 	idleSince := now.Add(-(idleTimeout + time.Minute)) // 11 min ago: past threshold
 
 	result := ComputeAwakeSet(AwakeInput{
 		Agents: []AwakeAgent{{
-			QualifiedName:  "hello-world/polecat",
+			QualifiedName:  "hello-world/worker",
 			SleepAfterIdle: idleTimeout,
 		}},
+		NamedSessions: []AwakeNamedSession{{
+			Identity: "hello-world/refinery",
+			Template: "hello-world/worker",
+			Mode:     "on_demand",
+		}},
 		SessionBeads: []AwakeSessionBead{{
-			ID:          "mc-sctve",
-			SessionName: "polecat-mc-sctve",
-			Template:    "hello-world/polecat",
-			State:       "active",
-			IdleSince:   idleSince,
+			ID:            "mc-sctve",
+			SessionName:   "hello-world--refinery",
+			Template:      "hello-world/worker",
+			State:         "active",
+			NamedIdentity: "hello-world/refinery",
+			IdleSince:     idleSince,
 		}},
 		WorkBeads: []AwakeWorkBead{
-			{ID: "hw-8lb", Assignee: "mc-sctve", Status: "in_progress"},
+			{ID: "hw-8lb", Assignee: "hello-world/refinery", Status: "in_progress"},
 		},
-		ScaleCheckCounts: map[string]int{"hello-world/polecat": 0},
-		Now:              now,
+		RunningSessions: map[string]bool{"hello-world--refinery": true},
+		Now:             now,
 	})
 
-	assertAwake(t, result, "polecat-mc-sctve")
-	if got := result["polecat-mc-sctve"].Reason; got == "idle-sleep" {
+	assertAwake(t, result, "hello-world--refinery")
+	if got := result["hello-world--refinery"].Reason; got == "idle-sleep" {
 		t.Errorf("reason = %q, want non-idle-sleep — assigned-work must veto idle-sleep override", got)
 	}
 }
@@ -1193,6 +1243,38 @@ func TestRegression_ConcreteAssignedWorkSuppressesIdleSleep(t *testing.T) {
 	})
 	assertAwake(t, result, "polecat-mc-sctve")
 	assertReason(t, result, "polecat-mc-sctve", "assigned-work")
+}
+
+func TestSessionHasConcreteAssignedWorkMatchesNamedIdentity(t *testing.T) {
+	bead := AwakeSessionBead{
+		ID:            "mc-named",
+		SessionName:   "hello-world--refinery",
+		Template:      "hello-world/worker",
+		NamedIdentity: "hello-world/refinery",
+	}
+	work := []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "in_progress"}}
+	if !sessionHasConcreteAssignedWork(work, nil, bead) {
+		t.Fatal("expected named-identity assignment to count as concrete assigned work")
+	}
+}
+
+func TestSessionHasConcreteAssignedWorkMatchesConfiguredNamedSessionFallback(t *testing.T) {
+	named := []AwakeNamedSession{{
+		Identity:    "hello-world/refinery",
+		Template:    "hello-world/worker",
+		Mode:        "on_demand",
+		RuntimeName: "hello-world--refinery",
+	}}
+	bead := AwakeSessionBead{
+		ID:                     "mc-named",
+		SessionName:            "hello-world--refinery",
+		Template:               "hello-world/worker",
+		ConfiguredNamedSession: true,
+	}
+	work := []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}}
+	if !sessionHasConcreteAssignedWork(work, named, bead) {
+		t.Fatal("expected configured named-session fallback assignment to count as concrete assigned work")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -68,7 +68,7 @@ func GCSweepSessionBeads(store beads.Store, rigStores map[string]beads.Store, se
 		if sb.Status == "closed" {
 			continue
 		}
-		if !closeSessionBeadIfUnassigned(store, rigStores, sb, "gc_swept", time.Now().UTC(), nil) {
+		if !closeSessionBeadIfUnassigned(store, rigStores, nil, sb, "gc_swept", time.Now().UTC(), nil) {
 			continue
 		}
 		closed = append(closed, sb.ID)

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -505,11 +505,56 @@ func retiredSessionFallbackRoute(b beads.Bead) string {
 }
 
 func sessionAssignmentIdentifiers(sessionBead beads.Bead) []string {
-	raw := []string{
+	return compactSessionAssignmentIdentifiers(sessionAssignmentIdentifierRaw(sessionBead))
+}
+
+// sessionAssignmentIdentifiersForConfig extends the persisted session-bead
+// identifiers with the configured named-session identity when a recovered bead
+// is missing identity metadata. Keep this fallback aligned with
+// sessionAssigneeMatches and compute_awake_bridge's AwakeNamedSession fields.
+func sessionAssignmentIdentifiersForConfig(sessionBead beads.Bead, cfg *config.City) []string {
+	raw := sessionAssignmentIdentifierRaw(sessionBead)
+	if cfg == nil ||
+		strings.TrimSpace(sessionBead.Metadata[namedSessionMetadataKey]) != "true" ||
+		strings.TrimSpace(sessionBead.Metadata[namedSessionIdentityMetadata]) != "" {
+		return compactSessionAssignmentIdentifiers(raw)
+	}
+
+	sessionName := strings.TrimSpace(sessionBead.Metadata["session_name"])
+	if sessionName == "" {
+		return compactSessionAssignmentIdentifiers(raw)
+	}
+	template := normalizedSessionTemplate(sessionBead, cfg)
+	if template == "" {
+		template = strings.TrimSpace(sessionBead.Metadata["template"])
+	}
+	cityName := config.EffectiveCityName(cfg, "")
+	for i := range cfg.NamedSessions {
+		identity := cfg.NamedSessions[i].QualifiedName()
+		if identity == "" {
+			continue
+		}
+		if config.NamedSessionRuntimeName(cityName, cfg.Workspace, identity) != sessionName {
+			continue
+		}
+		backingTemplate := cfg.NamedSessions[i].TemplateQualifiedName()
+		if template != "" && backingTemplate != "" && template != backingTemplate {
+			continue
+		}
+		raw = append(raw, identity)
+	}
+	return compactSessionAssignmentIdentifiers(raw)
+}
+
+func sessionAssignmentIdentifierRaw(sessionBead beads.Bead) []string {
+	return []string{
 		strings.TrimSpace(sessionBead.ID),
 		strings.TrimSpace(sessionBead.Metadata["session_name"]),
 		strings.TrimSpace(sessionBead.Metadata[namedSessionIdentityMetadata]),
 	}
+}
+
+func compactSessionAssignmentIdentifiers(raw []string) []string {
 	seen := make(map[string]struct{}, len(raw))
 	identifiers := make([]string, 0, len(raw))
 	for _, id := range raw {
@@ -816,7 +861,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		}
 		canonical, ok := bySessionName[sn]
 		if ok && canonical.ID != b.ID {
-			if closeSessionBeadIfUnassigned(store, rigStores, b, "duplicate", clk.Now().UTC(), stderr) {
+			if closeSessionBeadIfUnassigned(store, rigStores, cfg, b, "duplicate", clk.Now().UTC(), stderr) {
 				openBeads[i].Status = "closed"
 			}
 		}
@@ -917,7 +962,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 					if strings.TrimSpace(open.Metadata["session_name"]) != sn {
 						continue
 					}
-					if closeSessionBeadIfUnassigned(store, rigStores, open, "duplicate", now, stderr) {
+					if closeSessionBeadIfUnassigned(store, rigStores, cfg, open, "duplicate", now, stderr) {
 						openBeads[i].Status = "closed"
 					}
 				}
@@ -1918,7 +1963,7 @@ func closeSessionBeadIfRuntimeStoppedAndUnassigned(
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	hasAssignedWork, err := sessionHasOpenAssignedWork(store, rigStores, b)
+	hasAssignedWork, err := sessionHasOpenAssignedWorkForConfig(store, rigStores, b, cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", b.ID, err) //nolint:errcheck
 		return false
@@ -1929,7 +1974,7 @@ func closeSessionBeadIfRuntimeStoppedAndUnassigned(
 	if !stopRuntimeBeforeSessionBeadMutation(store, sp, cfg, b, stopReason, stderr) {
 		return false
 	}
-	hasAssignedWork, err = sessionHasOpenAssignedWork(store, rigStores, b)
+	hasAssignedWork, err = sessionHasOpenAssignedWorkForConfig(store, rigStores, b, cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", b.ID, err) //nolint:errcheck
 		return false

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -1774,6 +1774,70 @@ func TestCloseSessionBeadIfRuntimeStoppedAndUnassigned_StopLeavesRunningKeepsBea
 	}
 }
 
+func TestCloseSessionBeadIfRuntimeStoppedAndUnassignedPreservesConfiguredNamedSessionAssignedByQualifiedName(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	now := time.Date(2026, 5, 21, 9, 0, 0, 0, time.UTC)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:        "worker",
+			BindingName: "pack",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template:    "worker",
+			BindingName: "pack",
+			Mode:        "on_demand",
+		}},
+	}
+	identity := "pack.worker"
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, identity)
+	b, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"template":                   "pack.worker",
+			"state":                      "active",
+			namedSessionMetadataKey:      "true",
+			namedSessionModeMetadata:     "on_demand",
+			namedSessionIdentityMetadata: "",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "assigned by configured identity",
+		Type:     "task",
+		Status:   "open",
+		Assignee: identity,
+	}); err != nil {
+		t.Fatalf("create assigned work: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	closed := closeSessionBeadIfRuntimeStoppedAndUnassigned(
+		store, nil, sp, cfg, b, "suspended", "suspended session", now, &stderr,
+	)
+
+	if closed {
+		t.Fatal("closeSessionBeadIfRuntimeStoppedAndUnassigned closed bead with QualifiedName-assigned work")
+	}
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", b.ID, err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Metadata["close_reason"] != "" {
+		t.Fatalf("close_reason = %q, want empty", got.Metadata["close_reason"])
+	}
+}
+
 func TestSyncSessionBeads_PreservesConfiguredNamedSessionWithoutDesiredEntry(t *testing.T) {
 	// A configured named session with state=stopped + non-empty sleep_reason
 	// (deliberate sleep marker) must remain Status=open so gc start /
@@ -5941,7 +6005,7 @@ func TestCloseSessionBeadIfUnassignedRefusesWhenRigStoreWorkAssignedBySessionNam
 
 	var stderr bytes.Buffer
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
-	if closeSessionBeadIfUnassigned(store, map[string]beads.Store{"demo": rigStore}, sessionBead, "stale-session", now, &stderr) {
+	if closeSessionBeadIfUnassigned(store, map[string]beads.Store{"demo": rigStore}, nil, sessionBead, "stale-session", now, &stderr) {
 		t.Fatal("closeSessionBeadIfUnassigned returned true; want false because rig-store work is still assigned by session_name")
 	}
 	got, err := store.Get(sessionBead.ID)

--- a/cmd/gc/session_model_phase0_demand_spec_test.go
+++ b/cmd/gc/session_model_phase0_demand_spec_test.go
@@ -29,7 +29,7 @@ func TestPhase0NamedOnDemand_WakesFromAssignedBeadID(t *testing.T) {
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
 		SessionBeads:  []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "hello-world/refinery"}},
-		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "mc-1", Status: "open"}},
+		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "mc-1", Status: "open", Ready: true}},
 		Now:           now,
 	})
 
@@ -41,7 +41,7 @@ func TestPhase0NamedOnDemand_WakesFromExactConfiguredNamedIdentityAssignee(t *te
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
 		SessionBeads:  []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "hello-world/refinery"}},
-		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}},
+		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open", Ready: true}},
 		Now:           now,
 	})
 
@@ -53,7 +53,7 @@ func TestPhase0NamedOnDemand_DoesNotWakeFromBackingTemplateAssigneeToken(t *test
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
 		NamedSessions: []AwakeNamedSession{{Identity: "triage", Template: "hello-world/refinery", Mode: "on_demand"}},
 		SessionBeads:  []AwakeSessionBead{{ID: "mc-1", SessionName: "test-city--triage", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "triage"}},
-		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open"}},
+		WorkBeads:     []AwakeWorkBead{{ID: "hw-1", Assignee: "hello-world/refinery", Status: "open", Ready: true}},
 		Now:           now,
 	})
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -33,6 +33,7 @@ type wakeEvaluation struct {
 	Reason           string
 	Policy           resolvedSessionSleepPolicy
 	ConfigSuppressed bool
+	HasAssignedWork  bool
 }
 
 const sleepReasonRuntimeMissing = "runtime-missing"

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -898,7 +898,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if configuredNames[name] {
 						reason = "suspended"
 					}
-					hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, rigStores, *session)
+					hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForConfig(store, rigStores, *session, cfg)
 					if assignedErr != nil {
 						fmt.Fprintf(stderr, "session reconciler: checking assigned work before %s drain for %s: %v\n", reason, name, assignedErr) //nolint:errcheck
 						continue
@@ -1703,15 +1703,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		name := target.session.Metadata["session_name"]
 		decision := awakeDecisions[name]
 		if decision.ShouldWake && !pendingInteractionReady(sp, name) && target.session.Metadata["pin_awake"] != "true" && configWakeSuppressed(*target.session, policy, sp, clk) {
-			// Active demand (poolDesired > 0) overrides sleep suppression
-			// for non-interactive sessions (matching the old
-			// evaluateWakeReasons behavior). Interactive sessions honor
-			// their idle window regardless of demand — an idle chat
-			// session should still sleep to release resources.
+			// Active demand (poolDesired > 0 or direct assigned work)
+			// overrides sleep suppression for non-interactive sessions
+			// (matching the old evaluateWakeReasons behavior). Interactive
+			// sessions honor their idle window regardless of demand — an
+			// idle chat session should still sleep to release resources.
 			// Explicit sleep_intent always wins — if the session has
 			// signaled it wants to sleep, honor that regardless of demand.
 			template := normalizedSessionTemplate(*target.session, cfg)
-			hasDemand := poolDesired[template] > 0
+			hasDemand := poolDesired[template] > 0 || eval.HasAssignedWork
 			hasExplicitSleepIntent := target.session.Metadata["sleep_intent"] != ""
 			demandOverrides := hasDemand && policy.Class == config.SessionSleepNonInteractive && !hasExplicitSleepIntent
 			if !demandOverrides {
@@ -1985,23 +1985,14 @@ func resolvePreservedConfiguredNamedSessionTemplate(
 	return tp, nil
 }
 
-// sessionHasOpenAssignedWork reports whether any open or in-progress work bead
-// is assigned to the given session across all known stores. Use this
-// cross-store query for cleanup-of-record paths that must not orphan work in
-// any attached store; callers preserve fail-closed behavior by refusing close
-// decisions on query errors. Reconciler close paths that should honor the
-// session's configured store reachability must use
-// sessionHasOpenAssignedWorkForReachableStore instead.
-func sessionHasOpenAssignedWork(store beads.Store, rigStores map[string]beads.Store, session beads.Bead) (bool, error) {
-	if has, err := sessionHasOpenAssignedWorkInStore(store, session); err != nil || has {
-		return has, err
-	}
-	for _, rs := range rigStores {
-		if has, err := sessionHasOpenAssignedWorkInStore(rs, session); err != nil || has {
-			return has, err
-		}
-	}
-	return false, nil
+// sessionHasOpenAssignedWorkForConfig uses the same configured-named-session
+// fallback identity strategy as sessionAssigneeMatches, but queries all known
+// stores instead of a single configured reachable store. Use this cross-store
+// query for cleanup-of-record paths that must not orphan work in any attached
+// store; callers preserve fail-closed behavior by refusing close decisions on
+// query errors.
+func sessionHasOpenAssignedWorkForConfig(store beads.Store, rigStores map[string]beads.Store, session beads.Bead, cfg *config.City) (bool, error) {
+	return sessionHasOpenAssignedWorkInStores(store, rigStores, sessionAssignmentIdentifiersForConfig(session, cfg))
 }
 
 // sessionHasOpenAssignedWorkForReachableStore reports whether any open or
@@ -2014,18 +2005,19 @@ func sessionHasOpenAssignedWorkForReachableStore(
 	rigStores map[string]beads.Store,
 	session beads.Bead,
 ) (bool, error) {
+	identifiers := sessionAssignmentIdentifiersForConfig(session, cfg)
 	storeRef, ok := assignedWorkStoreRefForSession(cityPath, cfg, session)
 	if !ok {
-		return sessionHasOpenAssignedWork(store, rigStores, session)
+		return sessionHasOpenAssignedWorkInStores(store, rigStores, identifiers)
 	}
 	if storeRef == "" {
-		return sessionHasOpenAssignedWorkInStore(store, session)
+		return sessionHasOpenAssignedWorkInStoreByIdentifiers(store, identifiers)
 	}
 	rigStore, ok := rigStores[storeRef]
 	if !ok || rigStore == nil {
 		return false, fmt.Errorf("rig store %q unavailable for session %q", storeRef, session.Metadata["session_name"])
 	}
-	return sessionHasOpenAssignedWorkInStore(rigStore, session)
+	return sessionHasOpenAssignedWorkInStoreByIdentifiers(rigStore, identifiers)
 }
 
 func assignedWorkStoreRefForSession(cityPath string, cfg *config.City, session beads.Bead) (string, bool) {
@@ -2069,33 +2061,33 @@ func firstOpenAssignedWorkBeadForReachableStore(
 	rigStores map[string]beads.Store,
 	session beads.Bead,
 ) (beads.Bead, bool, error) {
+	identifiers := sessionAssignmentIdentifiersForConfig(session, cfg)
 	storeRef, ok := assignedWorkStoreRefForSession(cityPath, cfg, session)
 	if !ok {
-		if bead, found, err := firstOpenAssignedWorkBeadInStore(store, session); err != nil || found {
+		if bead, found, err := firstOpenAssignedWorkBeadInStoreByIdentifiers(store, identifiers); err != nil || found {
 			return bead, found, err
 		}
 		for _, rs := range rigStores {
-			if bead, found, err := firstOpenAssignedWorkBeadInStore(rs, session); err != nil || found {
+			if bead, found, err := firstOpenAssignedWorkBeadInStoreByIdentifiers(rs, identifiers); err != nil || found {
 				return bead, found, err
 			}
 		}
 		return beads.Bead{}, false, nil
 	}
 	if storeRef == "" {
-		return firstOpenAssignedWorkBeadInStore(store, session)
+		return firstOpenAssignedWorkBeadInStoreByIdentifiers(store, identifiers)
 	}
 	rigStore, ok := rigStores[storeRef]
 	if !ok || rigStore == nil {
 		return beads.Bead{}, false, fmt.Errorf("rig store %q unavailable for session %q", storeRef, session.Metadata["session_name"])
 	}
-	return firstOpenAssignedWorkBeadInStore(rigStore, session)
+	return firstOpenAssignedWorkBeadInStoreByIdentifiers(rigStore, identifiers)
 }
 
-func firstOpenAssignedWorkBeadInStore(store beads.Store, session beads.Bead) (beads.Bead, bool, error) {
+func firstOpenAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifiers []string) (beads.Bead, bool, error) {
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
-	identifiers := sessionAssignmentIdentifiers(session)
 	seen := make(map[string]struct{}, len(identifiers))
 	for _, status := range []string{"in_progress", "open"} {
 		for _, assignee := range identifiers {
@@ -2123,10 +2115,25 @@ func firstOpenAssignedWorkBeadInStore(store beads.Store, session beads.Bead) (be
 }
 
 func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (bool, error) {
+	return sessionHasOpenAssignedWorkInStoreByIdentifiers(store, sessionAssignmentIdentifiers(session))
+}
+
+func sessionHasOpenAssignedWorkInStores(store beads.Store, rigStores map[string]beads.Store, identifiers []string) (bool, error) {
+	if has, err := sessionHasOpenAssignedWorkInStoreByIdentifiers(store, identifiers); err != nil || has {
+		return has, err
+	}
+	for _, rs := range rigStores {
+		if has, err := sessionHasOpenAssignedWorkInStoreByIdentifiers(rs, identifiers); err != nil || has {
+			return has, err
+		}
+	}
+	return false, nil
+}
+
+func sessionHasOpenAssignedWorkInStoreByIdentifiers(store beads.Store, identifiers []string) (bool, error) {
 	if store == nil {
 		return false, nil
 	}
-	identifiers := sessionAssignmentIdentifiers(session)
 	seen := make(map[string]struct{}, len(identifiers))
 	for _, status := range []string{"open", "in_progress"} {
 		for _, assignee := range identifiers {

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -268,6 +268,182 @@ func TestReconcileSessionBeads_StartsIdleDrainAfterGrace(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_AssignedNamedSessionByBeadIDOverridesNonInteractiveSleepPolicy(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		SessionSleep: config.SessionSleepConfig{
+			NonInteractive: "60s",
+		},
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "worker",
+			StartCommand: "true",
+			Attach:       boolPtr(false),
+		}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "test-cmd",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "on_demand",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"detached_at":                env.clk.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	env.sp.SetActivity(sessionName, env.clk.Now().Add(-2*time.Minute))
+	work, err := env.store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("create assigned work: %v", err)
+	}
+	cfgNames := configuredSessionNames(env.cfg, env.cfg.EffectiveCityName(), env.store)
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		cfgNames,
+		env.cfg,
+		env.sp,
+		env.store,
+		nil,
+		[]beads.Bead{work},
+		nil,
+		env.dt,
+		map[string]int{},
+		false,
+		nil,
+		env.cfg.EffectiveCityName(),
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 for already-running assigned session", woken)
+	}
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatal("assigned named session should stay running")
+	}
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("unexpected drain for assigned named session: %+v", ds)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got.Metadata["config_wake_suppressed"] == "true" {
+		t.Fatal("assigned-work wake was suppressed by noninteractive sleep policy")
+	}
+}
+
+func TestReconcileSessionBeads_AssignedWorkWithReadyWaitOverridesNonInteractiveSleepPolicy(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		SessionSleep: config.SessionSleepConfig{
+			NonInteractive: "60s",
+		},
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "worker",
+			StartCommand: "true",
+			Attach:       boolPtr(false),
+		}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "test-cmd",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "on_demand",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"detached_at":                env.clk.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	env.sp.SetActivity(sessionName, env.clk.Now().Add(-2*time.Minute))
+	work, err := env.store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("create assigned work: %v", err)
+	}
+	cfgNames := configuredSessionNames(env.cfg, env.cfg.EffectiveCityName(), env.store)
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		cfgNames,
+		env.cfg,
+		env.sp,
+		env.store,
+		nil,
+		[]beads.Bead{work},
+		map[string]bool{session.ID: true},
+		env.dt,
+		map[string]int{},
+		false,
+		nil,
+		env.cfg.EffectiveCityName(),
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 for already-running assigned session", woken)
+	}
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatal("assigned named session should stay running")
+	}
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("unexpected drain for assigned named session with ready wait: %+v", ds)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got.Metadata["config_wake_suppressed"] == "true" {
+		t.Fatal("ready-wait wake with assigned work was suppressed by noninteractive sleep policy")
+	}
+}
+
 func TestReconcileSessionBeads_WaitHoldBypassesIdleProbe(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_work_guard.go
+++ b/cmd/gc/session_work_guard.go
@@ -24,6 +24,7 @@ import (
 func closeSessionBeadIfUnassigned(
 	store beads.Store,
 	rigStores map[string]beads.Store,
+	cfg *config.City,
 	session beads.Bead,
 	reason string,
 	now time.Time,
@@ -32,7 +33,7 @@ func closeSessionBeadIfUnassigned(
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	hasAssignedWork, err := sessionHasOpenAssignedWork(store, rigStores, session)
+	hasAssignedWork, err := sessionHasOpenAssignedWorkForConfig(store, rigStores, session, cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", session.ID, err) //nolint:errcheck
 		return false

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -140,6 +140,9 @@ func TestOrphanSweepPreservesQualifiedRigAssignees(t *testing.T) {
 
 	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
+if [ "$1" = "--rig" ]; then
+  shift 2
+fi
 case "$1" in
   config)
     if [ "$2" = "explain" ]; then
@@ -154,13 +157,19 @@ EOF
       exit 0
     fi
     ;;
-  rig)
-    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
-      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
-      exit 0
-    fi
-    ;;
-  bd)
+	  rig)
+	    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+	      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
+	      exit 0
+	    fi
+	    ;;
+	  session)
+	    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+	      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+	      exit 0
+	    fi
+	    ;;
+	  bd)
     if [ "$2" = "list" ]; then
       case "$*" in
         *"--rig project"*)
@@ -226,6 +235,9 @@ func TestOrphanSweepConfigShowFallbackPreservesQualifiedAssignees(t *testing.T) 
 
 	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
+if [ "$1" = "--rig" ]; then
+  shift 2
+fi
 case "$1" in
   config)
     if [ "$2" = "explain" ]; then
@@ -241,13 +253,19 @@ EOF
       exit 0
     fi
     ;;
-  rig)
-    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
-      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
-      exit 0
-    fi
-    ;;
-  bd)
+	  rig)
+	    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+	      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
+	      exit 0
+	    fi
+	    ;;
+	  session)
+	    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+	      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+	      exit 0
+	    fi
+	    ;;
+	  bd)
     if [ "$2" = "list" ]; then
       case "$*" in
         *"--rig project"*)
@@ -389,6 +407,403 @@ exit 1
 	}
 	if strings.Contains(log, "bd update ga-live ") {
 		t.Fatalf("live ephemeral session assignee was reset:\n%s", log)
+	}
+}
+
+func TestOrphanSweepRefreshesLivenessAfterBeadList(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	tmpDir := t.TempDir()
+	gcLog := filepath.Join(tmpDir, "gc.log")
+	sessionCountFile := filepath.Join(tmpDir, "session-count")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      count="$(cat "$GC_SESSION_COUNT_FILE" 2>/dev/null || printf '0')"
+      count=$((count + 1))
+      printf '%s' "$count" > "$GC_SESSION_COUNT_FILE"
+      if [ "$count" -eq 1 ]; then
+        printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      else
+        cat <<'EOF'
+{"sessions":[
+  {"id":"mc-live","session_name":"project__worker-gc-race","alias":"project/worker-1","agent_name":"project/worker","closed":false}
+],"summary":{},"filters":{},"schema_version":"1"}
+EOF
+      fi
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      cat <<'EOF'
+[
+  {"id":"ga-live-race","status":"in_progress","assignee":"project__worker-gc-race"}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":               cityDir,
+		"GC_CITY_PATH":          cityDir,
+		"GC_CALL_LOG":           gcLog,
+		"GC_SESSION_COUNT_FILE": sessionCountFile,
+		"PATH":                  binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if strings.Contains(string(out), "orphan-sweep: reset") {
+		t.Fatalf("unexpected orphan reset output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	if got := strings.Count(log, "session list --json"); got != 2 {
+		t.Fatalf("session list count = %d, want 2 post-bd refresh:\n%s", got, log)
+	}
+	if strings.Contains(log, "bd update ga-live-race ") {
+		t.Fatalf("live session claimed between liveness and bead list was reset:\n%s", log)
+	}
+}
+
+func TestOrphanSweepRefreshesRigLivenessAfterBeadList(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	tmpDir := t.TempDir()
+	gcLog := filepath.Join(tmpDir, "gc.log")
+	rigSessionCountFile := filepath.Join(tmpDir, "rig-session-count")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+if [ "$1" = "--rig" ]; then
+  rig="$2"
+  shift 2
+else
+  rig=""
+fi
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      if [ "$rig" = "project" ]; then
+        count="$(cat "$GC_RIG_SESSION_COUNT_FILE" 2>/dev/null || printf '0')"
+        count=$((count + 1))
+        printf '%s' "$count" > "$GC_RIG_SESSION_COUNT_FILE"
+        if [ "$count" -eq 1 ]; then
+          printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+        else
+          cat <<'EOF'
+{"sessions":[
+  {"id":"mc-rig-live","session_name":"project__worker-gc-race","alias":"project/worker-1","agent_name":"project/worker","closed":false}
+],"summary":{},"filters":{},"schema_version":"1"}
+EOF
+        fi
+        exit 0
+      fi
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      if [ "$rig" = "project" ]; then
+        cat <<'EOF'
+[
+  {"id":"ga-rig-live-race","status":"in_progress","assignee":"project__worker-gc-race"}
+]
+EOF
+      else
+        printf '[]\n'
+      fi
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":                   cityDir,
+		"GC_CITY_PATH":              cityDir,
+		"GC_CALL_LOG":               gcLog,
+		"GC_RIG_SESSION_COUNT_FILE": rigSessionCountFile,
+		"PATH":                      binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if strings.Contains(string(out), "orphan-sweep: reset") {
+		t.Fatalf("unexpected orphan reset output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	if got := strings.Count(log, "session list --json"); got != 4 {
+		t.Fatalf("session list count = %d, want 4 including rig post-bd refresh:\n%s", got, log)
+	}
+	if strings.Contains(log, "bd update ga-rig-live-race ") {
+		t.Fatalf("rig live session claimed between liveness and bead list was reset:\n%s", log)
+	}
+}
+
+func TestOrphanSweepPreservesRigScopedLiveEphemeralSessionAssignees(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+if [ "$1" = "--rig" ]; then
+  rig="$2"
+  shift 2
+else
+  rig=""
+fi
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      if [ "$rig" = "project" ]; then
+        cat <<'EOF'
+{"sessions":[
+  {"id":"mc-live-rig","session_name":"project__worker-gc-rig123","alias":"project/worker-1","agent_name":"project/worker","closed":false}
+],"summary":{},"filters":{},"schema_version":"1"}
+EOF
+        exit 0
+      fi
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      if [ "$4" = "project" ]; then
+        cat <<'EOF'
+[
+  {"id":"ga-rig-live","status":"in_progress","assignee":"project__worker-gc-rig123"},
+  {"id":"ga-rig-orphan","status":"in_progress","assignee":"missing-rig-session"}
+]
+EOF
+      else
+        printf '[]\n'
+      fi
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if !strings.Contains(string(out), "orphan-sweep: reset 1 orphaned beads") {
+		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "--rig project session list --json") {
+		t.Fatalf("rig-scoped session list was not queried:\n%s", log)
+	}
+	if !strings.Contains(log, "bd update ga-rig-orphan --status=open --assignee=") {
+		t.Fatalf("rig orphan bead was not reset:\n%s", log)
+	}
+	if strings.Contains(log, "bd update ga-rig-live ") {
+		t.Fatalf("rig live ephemeral session assignee was reset:\n%s", log)
+	}
+}
+
+func TestOrphanSweepContinuesAfterSingleRigSessionListFailure(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+if [ "$1" = "--rig" ]; then
+  rig="$2"
+  shift 2
+else
+  rig=""
+fi
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true},{"name":"broken","hq":false},{"name":"healthy","hq":false}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      if [ "$rig" = "broken" ]; then
+        exit 1
+      fi
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      if [ "$3" = "--rig" ] && [ "$4" = "broken" ]; then
+        cat <<'EOF'
+[
+  {"id":"ga-broken-orphan","status":"in_progress","assignee":"missing-broken-session"}
+]
+EOF
+      elif [ "$3" = "--rig" ] && [ "$4" = "healthy" ]; then
+        cat <<'EOF'
+[
+  {"id":"ga-healthy-orphan","status":"in_progress","assignee":"missing-healthy-session"}
+]
+EOF
+      else
+        cat <<'EOF'
+[
+  {"id":"ga-hq-orphan","status":"in_progress","assignee":"missing-hq-session"}
+]
+EOF
+      fi
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if !strings.Contains(string(out), "orphan-sweep: reset 2 orphaned beads") {
+		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	for _, reset := range []string{"ga-hq-orphan", "ga-healthy-orphan"} {
+		if !strings.Contains(log, "bd update "+reset+" --status=open --assignee=") {
+			t.Fatalf("expected %s to be reset after partial rig failure:\n%s", reset, log)
+		}
+	}
+	if strings.Contains(log, "bd update ga-broken-orphan ") {
+		t.Fatalf("bead from rig with unknown session liveness was reset:\n%s", log)
 	}
 }
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -309,6 +309,89 @@ exit 1
 	}
 }
 
+func TestOrphanSweepPreservesLiveEphemeralSessionAssignees(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      cat <<'EOF'
+{"sessions":[
+  {"id":"mc-live","session_name":"project__worker-gc-abc123","alias":"project/worker-1","agent_name":"project/worker","closed":false},
+  {"id":"mc-closed","session_name":"closed-session","closed":true}
+],"summary":{},"filters":{},"schema_version":"1"}
+EOF
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      cat <<'EOF'
+[
+  {"id":"ga-live","status":"in_progress","assignee":"project__worker-gc-abc123"},
+  {"id":"ga-orphan","status":"in_progress","assignee":"missing-session"}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if !strings.Contains(string(out), "orphan-sweep: reset 1 orphaned beads") {
+		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "bd update ga-orphan --status=open --assignee=") {
+		t.Fatalf("orphan bead was not reset:\n%s", log)
+	}
+	if strings.Contains(log, "bd update ga-live ") {
+		t.Fatalf("live ephemeral session assignee was reset:\n%s", log)
+	}
+}
+
 func TestMaintenanceDoltScriptsUseManagedRuntimePorts(t *testing.T) {
 	scripts := []struct {
 		name   string

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -53,11 +53,17 @@ fi
 # that guard — an ephemeral assignee whose template-stripped form did not
 # match any agent name was incorrectly reset, racing against active polekitten
 # work and producing the false-orphan loop tracked in ga-nvx.
-SESSIONS_JSON=$(gc session list --json 2>/dev/null) || SESSIONS_JSON="[]"
+SESSIONS_JSON=$(gc session list --json 2>/dev/null) || SESSIONS_JSON='{"sessions":[]}'
+# Two bugs the chronic strip pattern (gastownhall/gascity#2363) revealed:
+# (1) The JSON shape is {"sessions":[...], "summary":..., "filters":..., "schema_version":...},
+#     so `.[]` iterated four top-level scalar keys instead of session objects.
+# (2) Field names are snake_case lower (.closed/.id/.session_name/.alias/.agent_name),
+#     not PascalCase. Combined, LIVE_SESSION_IDS was ALWAYS empty and every
+#     ephemeral assignee like gastown__polecat-gc-XXXXX got stripped on every tick.
 LIVE_SESSION_IDS=$(echo "$SESSIONS_JSON" | jq -r '
-    .[]
-    | select(.Closed == false)
-    | [.ID, .SessionName, .Alias, .AgentName]
+    .sessions[]?
+    | select(.closed == false)
+    | [.id, .session_name, .alias, .agent_name]
     | .[]
     | select(. != null and . != "")
 ' 2>/dev/null) || LIVE_SESSION_IDS=""

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -13,22 +13,81 @@ set -euo pipefail
 
 CITY="${GC_CITY:-.}"
 
-# Step 1: Collect in-progress beads from HQ and every rig.
+# Step 1: Collect in-progress beads from HQ and every rig whose session
+# liveness can be determined.
 # `gc bd list` without --rig is HQ-scoped from the city cwd, so per-rig
 # beads are invisible to a bare query — walk every rig explicitly.
 TMP=$(mktemp) || exit 0
-trap 'rm -f "$TMP"' EXIT
+SESSION_TMP=$(mktemp) || {
+    rm -f "$TMP"
+    exit 0
+}
+trap 'rm -f "$TMP" "$SESSION_TMP"' EXIT
 
-gc bd list --status=in_progress --json --limit=0 2>/dev/null >>"$TMP" || true
-
+RIG_NAMES=""
 RIG_LIST=$(gc rig list --json 2>/dev/null) || RIG_LIST=""
 if [ -n "$RIG_LIST" ]; then
     RIG_NAMES=$(echo "$RIG_LIST" | jq -r '.rigs[] | select(.hq == false) | .name' 2>/dev/null) || RIG_NAMES=""
-    while IFS= read -r rig; do
-        [ -z "$rig" ] && continue
-        gc bd list --rig "$rig" --status=in_progress --json --limit=0 2>/dev/null >>"$TMP" || true
-    done <<<"$RIG_NAMES"
 fi
+
+append_session_list() {
+    local session_fetch_tmp
+    session_fetch_tmp=$(mktemp) || return 1
+    if "$@" >"$session_fetch_tmp" 2>/dev/null; then
+        cat "$session_fetch_tmp" >>"$SESSION_TMP"
+        rm -f "$session_fetch_tmp"
+        return 0
+    fi
+    rm -f "$session_fetch_tmp"
+    return 1
+}
+
+append_hq_scope() {
+    local bead_fetch_tmp
+    bead_fetch_tmp=$(mktemp) || return 1
+    append_session_list gc session list --json || {
+        rm -f "$bead_fetch_tmp"
+        return 1
+    }
+    gc bd list --status=in_progress --json --limit=0 2>/dev/null >"$bead_fetch_tmp" || true
+    append_session_list gc session list --json || {
+        rm -f "$bead_fetch_tmp"
+        return 1
+    }
+    cat "$bead_fetch_tmp" >>"$TMP"
+    rm -f "$bead_fetch_tmp"
+}
+
+append_rig_scope() {
+    local rig="$1"
+    local bead_fetch_tmp
+    bead_fetch_tmp=$(mktemp) || return 1
+    append_session_list gc --rig "$rig" session list --json || {
+        rm -f "$bead_fetch_tmp"
+        return 1
+    }
+    gc bd list --rig "$rig" --status=in_progress --json --limit=0 2>/dev/null >"$bead_fetch_tmp" || true
+    append_session_list gc --rig "$rig" session list --json || {
+        rm -f "$bead_fetch_tmp"
+        return 1
+    }
+    cat "$bead_fetch_tmp" >>"$TMP"
+    rm -f "$bead_fetch_tmp"
+}
+
+# Step 1b: Get all known live session identities around each bead-list query.
+# The second liveness pass closes the session-list-before-bd-list race where a
+# newly spawned session can claim work after the first pass but before bd-list.
+# HQ liveness is required; per-rig failures only skip that rig's staged bead
+# rows so one stale or unreachable rig does not disable cleanup elsewhere.
+append_hq_scope || exit 0
+
+while IFS= read -r rig; do
+    [ -z "$rig" ] && continue
+    if ! append_rig_scope "$rig"; then
+        echo "orphan-sweep: skipping rig $rig after session-list failure" >&2
+    fi
+done <<<"$RIG_NAMES"
 
 IN_PROGRESS=$(jq -c -s 'add // []' "$TMP" 2>/dev/null) || IN_PROGRESS="[]"
 if [ "$IN_PROGRESS" = "[]" ]; then
@@ -46,27 +105,26 @@ if [ -z "$AGENTS" ]; then
     exit 0
 fi
 
-# Step 2b: Collect identities of every live (non-closed) session so that
+# Step 2b: Parse identities of every live (non-closed) session so that
 # pool-spawned ephemeral assignees (e.g. gastown__polekitten-gc-q9j0om) are
 # treated as known. The Go-side releaseOrphanedPoolAssignments path validates
 # these via liveOpenSessionAssignmentExists, but this shell sweep ran without
 # that guard — an ephemeral assignee whose template-stripped form did not
 # match any agent name was incorrectly reset, racing against active polekitten
 # work and producing the false-orphan loop tracked in ga-nvx.
-SESSIONS_JSON=$(gc session list --json 2>/dev/null) || SESSIONS_JSON='{"sessions":[]}'
 # Two bugs the chronic strip pattern (gastownhall/gascity#2363) revealed:
 # (1) The JSON shape is {"sessions":[...], "summary":..., "filters":..., "schema_version":...},
 #     so `.[]` iterated four top-level scalar keys instead of session objects.
 # (2) Field names are snake_case lower (.closed/.id/.session_name/.alias/.agent_name),
 #     not PascalCase. Combined, LIVE_SESSION_IDS was ALWAYS empty and every
 #     ephemeral assignee like gastown__polecat-gc-XXXXX got stripped on every tick.
-LIVE_SESSION_IDS=$(echo "$SESSIONS_JSON" | jq -r '
-    .sessions[]?
+LIVE_SESSION_IDS=$(jq -r -s '
+    .[] | .sessions[]?
     | select(.closed == false)
     | [.id, .session_name, .alias, .agent_name]
     | .[]
     | select(. != null and . != "")
-' 2>/dev/null) || LIVE_SESSION_IDS=""
+' "$SESSION_TMP" 2>/dev/null) || exit 0
 
 agent_exists() {
     local candidate="$1"


### PR DESCRIPTION
Supersedes #2363.

## Summary
- Cherry-picks #2363's idle-sleep and orphan-sweep fixes onto current `main`.
- Aligns the idle policy around assigned work demand: `WorkBeads` represents `in_progress` assigned work plus ready open assigned work.
- Keeps sessions awake for assigned demand matched by bead ID, current session name, or named identity.
- Allows blocked open assigned work to remain non-demand by relying on upstream ready-work filtering, so blocked assignments do not wake or keep an idle session awake.
- Adds an orphan-sweep regression for `gc session list --json`'s `.sessions[]` shape and lowercase field names.

## Tests
- `go test ./cmd/gc -run 'TestIdleSleep_OnDemandNamedReadyAssignedWorkStaysAwake|TestIdleSleep_OnDemandNamedBlockedAssignedWorkIsNotDemand|TestRegression_IdleSleepDoesNotOverrideNamedIdentityAssignedWork|TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff'`
- `go test ./examples/gastown -run 'TestOrphanSweepPreservesLiveEphemeralSessionAssignees|TestOrphanSweepPreservesQualifiedRigAssignees|TestOrphanSweepConfigShowFallbackPreservesQualifiedAssignees'`
- `go vet ./...`

Note: the local pre-commit hook ran lint/docgen/vet, then `make test-fast-parallel` failed in `TestNoBdExecOutsideBeads` because this shared checkout has untracked nested `worktrees/` directories that the boundary test walks. The failure paths are all under untracked `worktrees/`, not this branch diff.
