### PR TITLE
fix: add copilot to providersSkippingEscapeBeforeEnter

### DIFF
--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -36,7 +36,7 @@ import (
 
 const pollInterval = 100 * time.Millisecond
 
-var providersSkippingEscapeBeforeEnter = []string{"claude", "codex", "gemini", "kimi", "opencode", "pi"}
+var providersSkippingEscapeBeforeEnter = []string{"claude", "codex", "copilot", "gemini", "kimi", "opencode", "pi"}
 
 // Config holds configurable timeouts and intervals for the tmux provider.
 // All fields have sensible defaults matching the original hardcoded values.

--- a/internal/runtime/tmux/tmux_unit_test.go
+++ b/internal/runtime/tmux/tmux_unit_test.go
@@ -7,3 +7,9 @@ func TestProviderEnvSkipsEscapeForPiAlias(t *testing.T) {
 		t.Fatal("pi provider alias should skip pre-enter Escape")
 	}
 }
+
+func TestProviderEnvSkipsEscapeForCopilot(t *testing.T) {
+	if !providerEnvSkipsEscape("copilot") {
+		t.Fatal("copilot provider should skip pre-enter Escape")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `copilot` to the `providersSkippingEscapeBeforeEnter` list so nudge delivery doesn't send Escape before Enter to copilot sessions
- Copilot's TUI interprets Escape as cancel/clear, wiping the nudge text before Enter submits it

## Testing

- [x] `make check` (lint, vet, tests pass for affected package; full-repo lint timed out locally but is unrelated to this one-line change)
- [ ] `make check-docs` if docs, navigation, or links changed — N/A
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed — verified end-to-end manually on agent-vm

## Checklist

- [x] Linked an issue, or explained why one is not needed — No issue; discovered during live debugging of copilot nudge delivery failures. Fix is a one-line addition to an existing list.
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — N/A (internal runtime detail)
- [ ] Called out breaking changes or migration notes — N/A