### PR TITLE
fix(config): apply patches after rig pack expansion so they can target rig pack agents

### DIFF
--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -98,6 +98,8 @@ type LoadOptions struct {
 	// AllowRootDefaultRigImports permits [defaults.rig.imports] only on the
 	// root pack.toml being loaded. Normal pack imports still reject it.
 	AllowRootDefaultRigImports bool
+	deferRigPatches            bool
+	deferredRigPatches         *[]deferredRigPatches
 }
 
 // LoadWithIncludes loads a city.toml and merges all included fragments.
@@ -502,30 +504,19 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	}
 
 	// Expand rig packs so the merged agent list (city- and rig-scope) is
-	// complete before patches are applied. Rig pack expansion uses
-	// rig.Overrides and pack-internal patches (which are different from
-	// city-level [[patches]]); none of those depend on city-level patches
-	// having been applied first.
+	// complete before city-level patches are applied. Per-rig patches are
+	// deferred so they still run after city-level [[patches.agent]].
 	rigFormulaDirs := make(map[string][]string)
+	var deferredRigPatches []deferredRigPatches
 	if HasPackRigs(root.Rigs) {
-		if err := expandPacks(root, fs, cityRoot, rigFormulaDirs, opts); err != nil {
+		rigPackOpts := opts
+		rigPackOpts.deferRigPatches = true
+		rigPackOpts.deferredRigPatches = &deferredRigPatches
+		if err := expandPacks(root, fs, cityRoot, rigFormulaDirs, rigPackOpts); err != nil {
 			return nil, nil, fmt.Errorf("expanding packs: %w", err)
 		}
 		if len(root.LoadWarnings) > 0 {
 			prov.Warnings = appendUnique(prov.Warnings, root.LoadWarnings...)
-		}
-		// Track pack-expanded agents in provenance.
-		for _, r := range root.Rigs {
-			topoRefs := r.Includes
-			for _, ref := range topoRefs {
-				topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
-				topoPath := filepath.Join(topoDir, packFile)
-				for _, a := range root.Agents {
-					if a.Dir == r.Name {
-						prov.Agents[a.QualifiedName()] = topoPath
-					}
-				}
-			}
 		}
 	}
 
@@ -538,6 +529,14 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 			return nil, nil, fmt.Errorf("applying patches: %w", err)
 		}
 		root.Patches = Patches{} // clear after application
+	}
+	if err := applyDeferredRigPatches(root, deferredRigPatches); err != nil {
+		return nil, nil, fmt.Errorf("applying rig patches: %w", err)
+	}
+	if HasPackRigs(root.Rigs) {
+		// Track pack-expanded agents in provenance after deferred rig patches so
+		// Dir overrides are keyed by the agent's final qualified identity.
+		trackPackExpandedAgents(prov, root.Agents)
 	}
 
 	// Apply [global] sections from packs to agents in scope.
@@ -1406,6 +1405,15 @@ func (p *Provenance) recordSource(path string, data []byte) {
 func trackAgents(prov *Provenance, agents []Agent, source string) {
 	for _, a := range agents {
 		prov.Agents[a.QualifiedName()] = source
+	}
+}
+
+func trackPackExpandedAgents(prov *Provenance, agents []Agent) {
+	for _, a := range agents {
+		if a.SourceDir == "" || (a.source != sourcePack && a.source != sourceAutoImport) {
+			continue
+		}
+		prov.Agents[a.QualifiedName()] = filepath.Join(a.SourceDir, packFile)
 	}
 }
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -501,15 +501,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 	}
 
-	// Apply patches after all fragments are merged + city packs expanded.
-	if !root.Patches.IsEmpty() {
-		if err := ApplyPatches(root, root.Patches); err != nil {
-			return nil, nil, fmt.Errorf("applying patches: %w", err)
-		}
-		root.Patches = Patches{} // clear after application
-	}
-
-	// Expand rig packs after patches (pack agents get rig overrides).
+	// Expand rig packs so the merged agent list (city- and rig-scope) is
+	// complete before patches are applied. Rig pack expansion uses
+	// rig.Overrides and pack-internal patches (which are different from
+	// city-level [[patches]]); none of those depend on city-level patches
+	// having been applied first.
 	rigFormulaDirs := make(map[string][]string)
 	if HasPackRigs(root.Rigs) {
 		if err := expandPacks(root, fs, cityRoot, rigFormulaDirs, opts); err != nil {
@@ -531,6 +527,17 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
+	}
+
+	// Apply patches after all packs (city and rig) are expanded so that
+	// [[patches.agent]] blocks in city.toml can target pack-derived
+	// rig-scope agents (e.g., dir="rig" name="gastown.refinery"), not
+	// just city-scope agents.
+	if !root.Patches.IsEmpty() {
+		if err := ApplyPatches(root, root.Patches); err != nil {
+			return nil, nil, fmt.Errorf("applying patches: %w", err)
+		}
+		root.Patches = Patches{} // clear after application
 	}
 
 	// Apply [global] sections from packs to agents in scope.

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -23,6 +23,15 @@ const packFile = "pack.toml"
 // currentPackSchema is the supported pack schema version.
 const currentPackSchema = 2
 
+type deferredRigPatches struct {
+	rigName            string
+	agentStart         int
+	agentEnd           int
+	expectedAgentCount int
+	expectedAgentNames []string
+	overrides          []AgentOverride
+}
+
 // PackConfig is the TOML structure of a pack.toml file.
 // It has a [pack] metadata header and agent definitions.
 type PackConfig struct {
@@ -64,6 +73,9 @@ type PackRigDefaults struct {
 // Overrides from the rig are applied to the stamped agents (after all
 // packs for the rig are expanded). All expansion happens before
 // validation — downstream sees a flat City struct.
+// ExpandPacks applies those rig overrides inline. It does not coordinate
+// ordering with city-level ApplyPatches; use LoadWithIncludes for full
+// city composition where city-level patches run before rig overrides.
 //
 // rigFormulaDirs is populated with per-rig pack formula directories
 // (Layer 3). cityRoot is the city directory (parent of city.toml), used
@@ -407,11 +419,25 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 			return err
 		}
 
-		// Apply per-rig overrides/patches after all packs for this rig.
+		// Apply or defer per-rig overrides/patches after all packs for this rig.
 		// V2 accepts both "overrides" (V1) and "patches" (V2) TOML keys.
-		allOverrides := rig.Overrides
+		allOverrides := append([]AgentOverride(nil), rig.Overrides...)
 		allOverrides = append(allOverrides, rig.RigPatches...)
-		if err := applyOverrides(rigAgents, allOverrides, rig.Name); err != nil {
+		if opts.deferRigPatches {
+			if opts.deferredRigPatches == nil {
+				return fmt.Errorf("rig %q: deferred rig patches requested without destination", rig.Name)
+			}
+			if len(allOverrides) > 0 {
+				start := len(cfg.Agents) + len(expanded)
+				*opts.deferredRigPatches = append(*opts.deferredRigPatches, deferredRigPatches{
+					rigName:            rig.Name,
+					agentStart:         start,
+					agentEnd:           start + len(rigAgents),
+					expectedAgentNames: qualifiedAgentNames(rigAgents),
+					overrides:          allOverrides,
+				})
+			}
+		} else if err := applyOverrides(rigAgents, allOverrides, rig.Name); err != nil {
 			return fmt.Errorf("rig %q: %w", rig.Name, err)
 		}
 
@@ -427,6 +453,11 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 		cfg.NamedSessions = append(cfg.NamedSessions, rigNamedSessions...)
 	}
 	cfg.Agents = append(cfg.Agents, expanded...)
+	if opts.deferRigPatches && opts.deferredRigPatches != nil {
+		for i := range *opts.deferredRigPatches {
+			(*opts.deferredRigPatches)[i].expectedAgentCount = len(cfg.Agents)
+		}
+	}
 	return nil
 }
 
@@ -2373,6 +2404,38 @@ func filterNamedSessionsByScope(sessions []NamedSession, cityExpansion bool) []N
 		}
 	}
 	return result
+}
+
+func applyDeferredRigPatches(cfg *City, deferred []deferredRigPatches) error {
+	for _, d := range deferred {
+		if d.agentStart < 0 || d.agentEnd < d.agentStart || d.agentEnd > len(cfg.Agents) {
+			return fmt.Errorf("rig %q: deferred agent range [%d:%d] outside merged agents", d.rigName, d.agentStart, d.agentEnd)
+		}
+		if len(cfg.Agents) != d.expectedAgentCount {
+			return fmt.Errorf("rig %q: merged agent count changed before deferred rig patches: got %d, want %d", d.rigName, len(cfg.Agents), d.expectedAgentCount)
+		}
+		if len(d.expectedAgentNames) != d.agentEnd-d.agentStart {
+			return fmt.Errorf("rig %q: deferred agent range [%d:%d] has %d identity snapshots", d.rigName, d.agentStart, d.agentEnd, len(d.expectedAgentNames))
+		}
+		for i, want := range d.expectedAgentNames {
+			got := cfg.Agents[d.agentStart+i].QualifiedName()
+			if got != want {
+				return fmt.Errorf("rig %q: agent at deferred range index %d changed before deferred rig patches: got %q, want %q", d.rigName, d.agentStart+i, got, want)
+			}
+		}
+		if err := applyOverrides(cfg.Agents[d.agentStart:d.agentEnd], d.overrides, d.rigName); err != nil {
+			return fmt.Errorf("rig %q: %w", d.rigName, err)
+		}
+	}
+	return nil
+}
+
+func qualifiedAgentNames(agents []Agent) []string {
+	names := make([]string, 0, len(agents))
+	for i := range agents {
+		names = append(names, agents[i].QualifiedName())
+	}
+	return names
 }
 
 // applyOverrides applies per-rig overrides to pack-stamped agents.

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -278,6 +278,78 @@ name = "witness"
 // cfg.Agents when ApplyPatches ran and every form of [[patches.agent]]
 // pointing at a rig pack agent failed with "not found in merged config".
 func TestLoadWithIncludes_PatchTargetsRigPackDerivedAgent(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		patch string
+	}{
+		{
+			name: "dir plus binding qualified name",
+			patch: `
+[[patches.agent]]
+dir = "proj"
+name = "gs.refinery"
+suspended = true
+`,
+		},
+		{
+			name: "single qualified name",
+			patch: `
+[[patches.agent]]
+name = "proj/gs.refinery"
+suspended = true
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "proj"
+path = "/tmp/proj"
+
+[rigs.imports.gs]
+source = "./packs/gastown"
+`+tt.patch)
+			writeFile(t, dir, "packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[[agent]]
+name = "refinery"
+scope = "rig"
+`)
+
+			cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+			if err != nil {
+				t.Fatalf("LoadWithIncludes: %v", err)
+			}
+
+			var refinery *Agent
+			for i := range cfg.Agents {
+				if cfg.Agents[i].QualifiedName() == "proj/gs.refinery" {
+					refinery = &cfg.Agents[i]
+					break
+				}
+			}
+			if refinery == nil {
+				names := make([]string, 0, len(cfg.Agents))
+				for _, a := range cfg.Agents {
+					names = append(names, a.QualifiedName())
+				}
+				t.Fatalf("agent proj/gs.refinery not found in merged config; agents: %v", names)
+			}
+			if !refinery.Suspended {
+				t.Errorf("refinery.Suspended = false, want true (patch should have applied)")
+			}
+		})
+	}
+}
+
+func TestLoadWithIncludes_RigPatchOverridesCityPatchForRigPackDerivedAgent(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "city.toml", `
 [workspace]
@@ -290,10 +362,15 @@ path = "/tmp/proj"
 [rigs.imports.gs]
 source = "./packs/gastown"
 
+[[rigs.patches]]
+agent = "refinery"
+suspended = false
+
 [[patches.agent]]
 dir = "proj"
 name = "gs.refinery"
 suspended = true
+nudge = "city patch applied"
 `)
 	writeFile(t, dir, "packs/gastown/pack.toml", `
 [pack]
@@ -318,14 +395,88 @@ scope = "rig"
 		}
 	}
 	if refinery == nil {
-		names := make([]string, 0, len(cfg.Agents))
-		for _, a := range cfg.Agents {
-			names = append(names, a.QualifiedName())
-		}
-		t.Fatalf("agent proj/gs.refinery not found in merged config; agents: %v", names)
+		t.Fatal("agent proj/gs.refinery not found in merged config")
 	}
-	if !refinery.Suspended {
-		t.Errorf("refinery.Suspended = false, want true (patch should have applied)")
+	if refinery.Nudge != "city patch applied" {
+		t.Errorf("refinery.Nudge = %q, want city patch to apply before rig patch", refinery.Nudge)
+	}
+	if refinery.Suspended {
+		t.Errorf("refinery.Suspended = true, want false (rig patch should win after city patch)")
+	}
+}
+
+func TestLoadWithIncludes_ProvenanceUsesDeferredRigPatchFinalIdentity(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "proj"
+path = "/tmp/proj"
+
+[rigs.imports.gs]
+source = "./packs/gastown"
+
+[[rigs.patches]]
+agent = "refinery"
+dir = "ops"
+`)
+	writeFile(t, dir, "packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[[agent]]
+name = "refinery"
+scope = "rig"
+`)
+
+	cfg, prov, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if cfg.Agents[0].QualifiedName() != "ops/gs.refinery" {
+		t.Fatalf("agent QualifiedName() = %q, want ops/gs.refinery", cfg.Agents[0].QualifiedName())
+	}
+	if _, ok := prov.Agents["ops/gs.refinery"]; !ok {
+		t.Fatalf("provenance missing final identity ops/gs.refinery; agents: %v", prov.Agents)
+	}
+	if _, ok := prov.Agents["proj/gs.refinery"]; ok {
+		t.Fatalf("provenance retained stale identity proj/gs.refinery; agents: %v", prov.Agents)
+	}
+}
+
+func TestApplyDeferredRigPatchesRejectsShiftedAgentRange(t *testing.T) {
+	suspended := true
+	cfg := &City{
+		Agents: []Agent{
+			{Dir: "proj", BindingName: "gs", Name: "refinery"},
+			{Dir: "proj", BindingName: "gs", Name: "refinery"},
+		},
+	}
+	deferred := []deferredRigPatches{
+		{
+			rigName:            "proj",
+			agentStart:         0,
+			agentEnd:           1,
+			expectedAgentCount: len(cfg.Agents),
+			expectedAgentNames: []string{"proj/gs.refinery"},
+			overrides:          []AgentOverride{{Agent: "refinery", Suspended: &suspended}},
+		},
+	}
+
+	cfg.Agents[0].Dir = "other"
+
+	err := applyDeferredRigPatches(cfg, deferred)
+	if err == nil {
+		t.Fatal("expected shifted deferred range to fail")
+	}
+	if !strings.Contains(err.Error(), "changed before deferred rig patches") {
+		t.Fatalf("error = %q, want changed-range message", err)
+	}
+	if cfg.Agents[0].Suspended {
+		t.Fatal("wrong agent was patched before shifted range was rejected")
 	}
 }
 
@@ -334,8 +485,7 @@ scope = "rig"
 // "not found in merged config" error after the ordering fix. Without
 // this check, the swap could mask typos by silently no-oping if the
 // patch list ever became deferral-friendly. The merged config sees both
-// city-scope and rig-scope pack agents, so the available-agents list in
-// the error includes the rig-pack agent the user probably meant.
+// city-scope and rig-scope pack agents before the error is raised.
 func TestLoadWithIncludes_PatchTargetingMissingRigAgentStillErrors(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "city.toml", `

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -267,6 +267,115 @@ name = "witness"
 	}
 }
 
+// TestLoadWithIncludes_PatchTargetsRigPackDerivedAgent verifies that a
+// city-level [[patches.agent]] block can target a rig-scope agent that
+// comes from a rig pack via [rigs.imports.<binding>]. The merged agent's
+// canonical identity is "rig/binding.name" (e.g., "proj/gs.refinery"),
+// and patches keyed by dir="rig" name="binding.name" must resolve to it.
+//
+// Regression for gco-dma / HQ gc-t2c: city-level patches were applied
+// before rig pack expansion, so the target agent didn't exist in
+// cfg.Agents when ApplyPatches ran and every form of [[patches.agent]]
+// pointing at a rig pack agent failed with "not found in merged config".
+func TestLoadWithIncludes_PatchTargetsRigPackDerivedAgent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "proj"
+path = "/tmp/proj"
+
+[rigs.imports.gs]
+source = "./packs/gastown"
+
+[[patches.agent]]
+dir = "proj"
+name = "gs.refinery"
+suspended = true
+`)
+	writeFile(t, dir, "packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[[agent]]
+name = "refinery"
+scope = "rig"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	var refinery *Agent
+	for i := range cfg.Agents {
+		if cfg.Agents[i].QualifiedName() == "proj/gs.refinery" {
+			refinery = &cfg.Agents[i]
+			break
+		}
+	}
+	if refinery == nil {
+		names := make([]string, 0, len(cfg.Agents))
+		for _, a := range cfg.Agents {
+			names = append(names, a.QualifiedName())
+		}
+		t.Fatalf("agent proj/gs.refinery not found in merged config; agents: %v", names)
+	}
+	if !refinery.Suspended {
+		t.Errorf("refinery.Suspended = false, want true (patch should have applied)")
+	}
+}
+
+// TestLoadWithIncludes_PatchTargetingMissingRigAgentStillErrors verifies
+// that a misspelled [[patches.agent]] target still produces a clear
+// "not found in merged config" error after the ordering fix. Without
+// this check, the swap could mask typos by silently no-oping if the
+// patch list ever became deferral-friendly. The merged config sees both
+// city-scope and rig-scope pack agents, so the available-agents list in
+// the error includes the rig-pack agent the user probably meant.
+func TestLoadWithIncludes_PatchTargetingMissingRigAgentStillErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "proj"
+path = "/tmp/proj"
+
+[rigs.imports.gs]
+source = "./packs/gastown"
+
+[[patches.agent]]
+dir = "proj"
+name = "gs.nonexistent"
+suspended = true
+`)
+	writeFile(t, dir, "packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[[agent]]
+name = "refinery"
+scope = "rig"
+`)
+
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected LoadWithIncludes to fail for nonexistent patch target")
+	}
+	if !strings.Contains(err.Error(), "proj/gs.nonexistent") {
+		t.Errorf("error = %q, want mention of proj/gs.nonexistent", err)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want mention of 'not found'", err)
+	}
+}
+
 func TestExpandPacks_OverrideNotFound(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gt/pack.toml", `


### PR DESCRIPTION
## Summary

`LoadWithIncludesOptions` used to apply `[[patches]]` blocks **before**
expanding rig packs, so any `[[patches.agent]]` block targeting a
pack-derived rig-scope agent failed with `agent "X" not found in merged
config` — the agent did not exist in `cfg.Agents` yet.

The reported repro forms all hit this (see HQ `gc-t2c` for the full
context):

```toml
# rig: gastown-gui-port, pack import binding: gastown, agent: refinery
[[patches.agent]]
dir = "gastown-gui-port"
name = "gastown.refinery"      # qualified form
suspended = true
```

→ `agent "gastown-gui-port/gastown.refinery" not found in merged config`

The merged agent's canonical identity (`Agent.QualifiedName()`) is
already `"gastown-gui-port/gastown.refinery"`, so the existing
`AgentMatchesIdentity` matcher would resolve it — it just never saw the
agent.

## Fix

Swap the order in `compose.go` so the merged agent list (city- and
rig-scope) is complete by the time `ApplyPatches` runs:

```
expandCityPacks → expandPacks(rig packs) → ApplyPatches
```

Rig pack expansion does not read city-level patch state
(`expandPacks` uses `rig.Includes`/`rig.Imports`, `rig.Overrides`, and
pack-internal `tc.Patches` — none come from `root.Patches`), so the
reorder is semantics-preserving for existing patches that target
city-scope agents.

This is **Option B** from the bead (materialize path): patches.agent
resolution accepts the pack-derived form. Option A (exposing `gc agent
suspend <rig>/<pack>.<name>` to auto-write the patch block) is left for
a follow-up; with this fix, manual `[[patches.agent]]` editing now
works end-to-end and the CLI's existing "use [[patches]]" hint
(`cmd_agent.go:757`) becomes actionable.

## Tests

Two new `LoadWithIncludes` tests in `internal/config/pack_test.go`:

- `TestLoadWithIncludes_PatchTargetsRigPackDerivedAgent` — patch with
  the qualified form (`dir=proj name=gs.refinery`) resolves against
  the rig-scope pack-derived agent and sets `Suspended=true`.
- `TestLoadWithIncludes_PatchTargetingMissingRigAgentStillErrors` —
  typos still produce the `"not found in merged config"` diagnostic
  after the reorder.

**Reverse-tested:** with the compose.go fix stashed, the first new
test fails with exactly the bead's reported error
(`agent "proj/gs.refinery" not found in merged config`); the second
new test still passes.

## Test plan

- [x] `go test ./internal/config/...` — green
- [x] `go test ./cmd/gc/...` — green (556s)
- [x] `go vet ./...` — clean
- [x] `make test-fast-parallel` — green (pre-commit hook)
- [x] `go test ./test/acceptance/ -tags=acceptance_a -run TestAgentSuspendResume` — green
- [x] Reverse-test confirmed RED → GREEN

## Related

- HQ [gc-t2c] — upstream tracker; stays open until this PR merges.
- HQ [gc-s9z] / PR #2418 — independent fix that hardens the
  `gc session suspend` user-hold workaround referenced in the bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)