### PR TITLE
fix: harden mail and trace JSON contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `gc mail inbox`, `gc mail read`, `gc mail peek`, `gc mail thread`,
   and `gc mail count` now accept `--json` and emit schema-versioned result
-  envelopes for script and dashboard consumers.
+  envelopes for script and dashboard consumers. `gc mail inbox --json` and
+  `gc mail count --json` always include the resolved `recipients` array,
+  including single-recipient targets.
 
 ### Fixed
 
@@ -81,6 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `records` instead of a bare record array. See
   `schemas/trace/status/result.schema.json` and
   `schemas/trace/show/result.schema.json` for the exact contracts.
+  During rolling upgrades, trace controller socket status replies include the
+  legacy `arms` alias and upgraded CLIs still accept `arms` from older
+  controllers.
 - Pack import cache validation now requires commit abbreviations in
   `packs.lock` to be at least seven characters long. Shorter abbreviations
   should be refreshed with `gc import install`.

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -2112,7 +2112,7 @@ func doMailCountTargetWithJSON(mp mail.Provider, target resolvedMailTarget, json
 }
 
 func jsonRecipients(target resolvedMailTarget) []string {
-	if len(target.recipients) <= 1 {
+	if len(target.recipients) == 0 {
 		return nil
 	}
 	return append([]string(nil), target.recipients...)

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -38,7 +38,7 @@ const (
 type mailInboxJSONResult struct {
 	SchemaVersion string         `json:"schema_version"`
 	Recipient     string         `json:"recipient"`
-	Recipients    []string       `json:"recipients,omitempty"`
+	Recipients    []string       `json:"recipients"`
 	Messages      []mail.Message `json:"messages"`
 }
 
@@ -56,7 +56,7 @@ type mailMessageJSONResult struct {
 type mailCountJSONResult struct {
 	SchemaVersion string   `json:"schema_version"`
 	Recipient     string   `json:"recipient"`
-	Recipients    []string `json:"recipients,omitempty"`
+	Recipients    []string `json:"recipients"`
 	Total         int      `json:"total"`
 	Unread        int      `json:"unread"`
 }
@@ -2113,7 +2113,7 @@ func doMailCountTargetWithJSON(mp mail.Provider, target resolvedMailTarget, json
 
 func jsonRecipients(target resolvedMailTarget) []string {
 	if len(target.recipients) == 0 {
-		return nil
+		return []string{}
 	}
 	return append([]string(nil), target.recipients...)
 }

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -1281,6 +1281,29 @@ func TestMailInboxJSON(t *testing.T) {
 	validateJSONResultSchema(t, []string{"mail", "inbox"}, stdout.Bytes())
 }
 
+func TestMailInboxJSONIncludesEmptyRecipientsArray(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+
+	var stdout, stderr bytes.Buffer
+	code := doMailInboxTargetWithJSON(mp, resolvedMailTarget{display: "nobody"}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailInboxTargetWithJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &got); err != nil {
+		t.Fatalf("unmarshal stdout: %v; output=%s", err, stdout.String())
+	}
+	recipients, ok := got["recipients"].([]any)
+	if !ok {
+		t.Fatalf("recipients = %#v, want empty array", got["recipients"])
+	}
+	if len(recipients) != 0 {
+		t.Fatalf("recipients = %#v, want empty array", recipients)
+	}
+	validateJSONResultSchema(t, []string{"mail", "inbox"}, stdout.Bytes())
+}
+
 func TestMailInboxFiltersCorrectly(t *testing.T) {
 	store := beads.NewMemStore()
 	mp := beadmail.New(store)
@@ -2178,6 +2201,26 @@ func TestMailCountJSON(t *testing.T) {
 	}
 	if len(got.Recipients) != 1 || got.Recipients[0] != "bob" {
 		t.Fatalf("recipients = %#v, want [bob]", got.Recipients)
+	}
+	validateJSONResultSchema(t, []string{"mail", "count"}, stdout.Bytes())
+}
+
+func TestMailCountJSONIncludesEmptyRecipientsArray(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := doMailCountTargetWithJSON(countOnlyMailProvider{}, resolvedMailTarget{display: "nobody"}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailCountTargetWithJSON = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &got); err != nil {
+		t.Fatalf("unmarshal stdout: %v; output=%s", err, stdout.String())
+	}
+	recipients, ok := got["recipients"].([]any)
+	if !ok {
+		t.Fatalf("recipients = %#v, want empty array", got["recipients"])
+	}
+	if len(recipients) != 0 {
+		t.Fatalf("recipients = %#v, want empty array", recipients)
 	}
 	validateJSONResultSchema(t, []string{"mail", "count"}, stdout.Bytes())
 }

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -1275,6 +1275,9 @@ func TestMailInboxJSON(t *testing.T) {
 	if got.SchemaVersion != "1" || got.Recipient != "mayor" || len(got.Messages) != 1 || got.Messages[0].Body != "json body" {
 		t.Fatalf("unexpected JSON result: %+v", got)
 	}
+	if len(got.Recipients) != 1 || got.Recipients[0] != "mayor" {
+		t.Fatalf("recipients = %#v, want [mayor]", got.Recipients)
+	}
 	validateJSONResultSchema(t, []string{"mail", "inbox"}, stdout.Bytes())
 }
 
@@ -2172,6 +2175,9 @@ func TestMailCountJSON(t *testing.T) {
 	}
 	if got.SchemaVersion != "1" || got.Recipient != "bob" || got.Total != 2 || got.Unread != 1 {
 		t.Fatalf("unexpected JSON result: %+v", got)
+	}
+	if len(got.Recipients) != 1 || got.Recipients[0] != "bob" {
+		t.Fatalf("recipients = %#v, want [bob]", got.Recipients)
 	}
 	validateJSONResultSchema(t, []string{"mail", "count"}, stdout.Bytes())
 }

--- a/cmd/gc/cmd_trace_test.go
+++ b/cmd/gc/cmd_trace_test.go
@@ -99,6 +99,49 @@ func TestTraceStatusJSONEmptyArmsConformsToSchema(t *testing.T) {
 	validateJSONResultSchema(t, []string{"trace", "status"}, stdout.Bytes())
 }
 
+func TestTraceStatusHeadSeqPrefersStatusSnapshot(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityTOML(t, cityDir, "trace-town", "mayor")
+
+	store, err := newSessionReconcilerTraceStore(cityDir, io.Discard)
+	if err != nil {
+		t.Fatalf("newSessionReconcilerTraceStore: %v", err)
+	}
+	rec := newTraceRecord(TraceRecordDecision)
+	rec.TraceID = "cycle-1"
+	rec.TickID = "tick-1"
+	rec.RecordID = "record-1"
+	rec.Ts = time.Now().UTC()
+	if err := store.AppendBatch([]SessionReconcilerTraceRecord{rec}, TraceDurabilityMetadata); err != nil {
+		t.Fatalf("AppendBatch: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close trace store: %v", err)
+	}
+	storedHead, err := traceHeadSeq(traceCityRuntimeDir(cityDir))
+	if err != nil {
+		t.Fatalf("traceHeadSeq: %v", err)
+	}
+	if storedHead == 42 {
+		t.Fatal("stored head unexpectedly matches socket snapshot fixture")
+	}
+
+	head, err := traceStatusHeadSeq(traceStatusJSON{HeadSeq: 42}, cityDir)
+	if err != nil {
+		t.Fatalf("traceStatusHeadSeq with snapshot head: %v", err)
+	}
+	if head != 42 {
+		t.Fatalf("head seq = %d, want socket snapshot 42", head)
+	}
+	head, err = traceStatusHeadSeq(traceStatusJSON{}, cityDir)
+	if err != nil {
+		t.Fatalf("traceStatusHeadSeq fallback: %v", err)
+	}
+	if head != storedHead {
+		t.Fatalf("fallback head seq = %d, want stored head %d", head, storedHead)
+	}
+}
+
 func TestTraceControllerSocketCommands(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime"), 0o755); err != nil {
@@ -167,6 +210,13 @@ func TestTraceControllerSocketCommands(t *testing.T) {
 	if stopReply.Status == nil || len(stopReply.Status.ActiveArms) != 0 {
 		t.Fatalf("stop reply status = %#v", stopReply.Status)
 	}
+	stopPayload, err := json.Marshal(stopReply.Status)
+	if err != nil {
+		t.Fatalf("marshal stop status reply: %v", err)
+	}
+	if !bytes.Contains(stopPayload, []byte(`"arms":[]`)) {
+		t.Fatalf("stop status reply JSON = %s, want empty legacy arms alias", stopPayload)
+	}
 	select {
 	case <-pokeCh3:
 	default:
@@ -182,7 +232,6 @@ func TestTraceStatusJSONAcceptsLegacySocketArms(t *testing.T) {
 			"as_of": "2026-05-21T00:00:00Z",
 			"controller_running": true,
 			"controller_pid": 123,
-			"head_seq": 42,
 			"arms": [{
 				"scope_type": "template",
 				"scope_value": "repo/polecat",
@@ -203,8 +252,8 @@ func TestTraceStatusJSONAcceptsLegacySocketArms(t *testing.T) {
 	if reply.Status == nil {
 		t.Fatal("status is nil")
 	}
-	if reply.Status.HeadSeq != 42 {
-		t.Fatalf("head_seq = %d, want 42", reply.Status.HeadSeq)
+	if reply.Status.HeadSeq != 0 {
+		t.Fatalf("head_seq = %d, want old-controller default 0", reply.Status.HeadSeq)
 	}
 	if len(reply.Status.ActiveArms) != 1 {
 		t.Fatalf("active arms = %#v, want one legacy arm", reply.Status.ActiveArms)
@@ -296,6 +345,9 @@ func TestTraceShowAndReasonsWithoutTemplateFilter(t *testing.T) {
 	if showJSON.SchemaVersion != "1" || showJSON.Count != len(showJSON.Records) || !foundTemplate {
 		t.Fatalf("trace show JSON = %+v, want repo/polecat", showJSON)
 	}
+	validateJSONResultSchema(t, []string{"trace", "show"}, stdout.Bytes())
+	assertTraceShowSchemaRecordProperty(t, "template")
+	assertTraceShowSchemaRecordProperty(t, "session_name")
 
 	stdout.Reset()
 	stderr.Reset()
@@ -446,4 +498,27 @@ func readTraceSocketReply(t *testing.T, conn net.Conn) traceControlReply {
 		t.Fatalf("decode reply: %v", err)
 	}
 	return reply
+}
+
+func assertTraceShowSchemaRecordProperty(t *testing.T, name string) {
+	t.Helper()
+	rawSchema, err := readBuiltinSchema([]string{"trace", "show"}, jsonSchemaResultRole)
+	if err != nil {
+		t.Fatalf("read trace show result schema: %v", err)
+	}
+	var schema struct {
+		Properties struct {
+			Records struct {
+				Items struct {
+					Properties map[string]json.RawMessage `json:"properties"`
+				} `json:"items"`
+			} `json:"records"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(rawSchema, &schema); err != nil {
+		t.Fatalf("unmarshal trace show result schema: %v", err)
+	}
+	if _, ok := schema.Properties.Records.Items.Properties[name]; !ok {
+		t.Fatalf("trace show result schema missing record property %q", name)
+	}
 }

--- a/cmd/gc/cmd_trace_test.go
+++ b/cmd/gc/cmd_trace_test.go
@@ -137,6 +137,13 @@ func TestTraceControllerSocketCommands(t *testing.T) {
 	if statusReply.Status == nil || len(statusReply.Status.ActiveArms) != 1 {
 		t.Fatalf("status reply = %#v", statusReply.Status)
 	}
+	statusPayload, err := json.Marshal(statusReply.Status)
+	if err != nil {
+		t.Fatalf("marshal status reply: %v", err)
+	}
+	if !bytes.Contains(statusPayload, []byte(`"arms"`)) {
+		t.Fatalf("status reply JSON = %s, want legacy arms alias", statusPayload)
+	}
 	select {
 	case <-pokeCh2:
 		t.Fatal("did not expect pokeCh to be signaled on status")
@@ -164,6 +171,46 @@ func TestTraceControllerSocketCommands(t *testing.T) {
 	case <-pokeCh3:
 	default:
 		t.Fatal("expected pokeCh to be signaled on stop")
+	}
+}
+
+func TestTraceStatusJSONAcceptsLegacySocketArms(t *testing.T) {
+	payload := []byte(`{
+		"ok": true,
+		"status": {
+			"city_path": "/tmp/trace-town",
+			"as_of": "2026-05-21T00:00:00Z",
+			"controller_running": true,
+			"controller_pid": 123,
+			"head_seq": 42,
+			"arms": [{
+				"scope_type": "template",
+				"scope_value": "repo/polecat",
+				"source": "manual",
+				"level": "detail",
+				"armed_at": "2026-05-21T00:00:00Z",
+				"expires_at": "2026-05-21T00:15:00Z",
+				"last_extended_at": "2026-05-21T00:00:00Z",
+				"updated_at": "2026-05-21T00:00:00Z"
+			}]
+		}
+	}`)
+
+	var reply traceControlReply
+	if err := json.Unmarshal(payload, &reply); err != nil {
+		t.Fatalf("unmarshal legacy trace status reply: %v", err)
+	}
+	if reply.Status == nil {
+		t.Fatal("status is nil")
+	}
+	if reply.Status.HeadSeq != 42 {
+		t.Fatalf("head_seq = %d, want 42", reply.Status.HeadSeq)
+	}
+	if len(reply.Status.ActiveArms) != 1 {
+		t.Fatalf("active arms = %#v, want one legacy arm", reply.Status.ActiveArms)
+	}
+	if reply.Status.ActiveArms[0].ScopeValue != "repo/polecat" {
+		t.Fatalf("scope_value = %q, want repo/polecat", reply.Status.ActiveArms[0].ScopeValue)
 	}
 }
 
@@ -257,6 +304,46 @@ func TestTraceShowAndReasonsWithoutTemplateFilter(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, string(TraceReasonIdle)) {
 		t.Fatalf("trace reasons output = %q, want idle reason", got)
+	}
+}
+
+func TestTraceShowTextIncludesPopulatedRecordSummary(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityTOML(t, cityDir, "trace-town", "mayor")
+	t.Setenv("GC_CITY", cityDir)
+
+	store, err := newSessionReconcilerTraceStore(cityDir, io.Discard)
+	if err != nil {
+		t.Fatalf("newSessionReconcilerTraceStore: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	rec := newTraceRecord(TraceRecordDecision)
+	rec.TraceID = "cycle-1"
+	rec.TickID = "tick-1"
+	rec.RecordID = "record-1"
+	rec.Template = "repo/polecat"
+	rec.SessionName = "polecat-1"
+	rec.SiteCode = TraceSiteReconcilerWakeDecision
+	rec.ReasonCode = TraceReasonIdle
+	rec.OutcomeCode = TraceOutcomeApplied
+	rec.Ts = time.Now().UTC()
+	if err := store.AppendBatch([]SessionReconcilerTraceRecord{rec}, TraceDurabilityMetadata); err != nil {
+		t.Fatalf("AppendBatch: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdTraceShow("", "", "", "", "", "", false, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdTraceShow = %d; stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() > 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"template=repo/polecat", "session=polecat-1", string(TraceReasonIdle)} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
 	}
 }
 

--- a/cmd/gc/session_reconciler_trace_cmd.go
+++ b/cmd/gc/session_reconciler_trace_cmd.go
@@ -46,7 +46,7 @@ type traceStatusJSON struct {
 	ControllerPID     int        `json:"controller_pid,omitempty"`
 	HeadSeq           uint64     `json:"head_seq"`
 	ActiveArms        []TraceArm `json:"active_arms"`
-	LegacyArms        []TraceArm `json:"arms,omitempty"`
+	LegacyArms        []TraceArm `json:"arms"`
 }
 
 func (s *traceStatusJSON) UnmarshalJSON(data []byte) error {
@@ -57,10 +57,10 @@ func (s *traceStatusJSON) UnmarshalJSON(data []byte) error {
 	}
 	*s = traceStatusJSON(decoded)
 	if s.ActiveArms == nil && s.LegacyArms != nil {
-		s.ActiveArms = append([]TraceArm(nil), s.LegacyArms...)
+		s.ActiveArms = traceArmsJSONSlice(s.LegacyArms)
 	}
 	if s.LegacyArms == nil && s.ActiveArms != nil {
-		s.LegacyArms = append([]TraceArm(nil), s.ActiveArms...)
+		s.LegacyArms = traceArmsJSONSlice(s.ActiveArms)
 	}
 	return nil
 }
@@ -356,7 +356,7 @@ func cmdTraceStatusWithJSON(jsonOut bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc trace status: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	head, err := traceHeadSeq(traceCityRuntimeDir(cityPath))
+	head, err := traceStatusHeadSeq(status, cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc trace status: %v\n", err) //nolint:errcheck
 		return 1
@@ -394,6 +394,13 @@ func cmdTraceStatusWithJSON(jsonOut bool, stdout, stderr io.Writer) int {
 			arm.Source, arm.ScopeValue, arm.Level, arm.ExpiresAt.Format(time.RFC3339))
 	}
 	return 0
+}
+
+func traceStatusHeadSeq(status traceStatusJSON, cityPath string) (uint64, error) {
+	if status.HeadSeq != 0 {
+		return status.HeadSeq, nil
+	}
+	return traceHeadSeq(traceCityRuntimeDir(cityPath))
 }
 
 func cmdTraceShow(template, since, traceID, tickID, recordType, reason string, jsonOut bool, stdout, stderr io.Writer) int {
@@ -729,8 +736,15 @@ func traceStatusFromState(cityPath string, state TraceArmState, now time.Time) t
 		ControllerPID:     pid,
 		HeadSeq:           head,
 		ActiveArms:        arms,
-		LegacyArms:        append([]TraceArm(nil), arms...),
+		LegacyArms:        traceArmsJSONSlice(arms),
 	}
+}
+
+func traceArmsJSONSlice(arms []TraceArm) []TraceArm {
+	if len(arms) == 0 {
+		return []TraceArm{}
+	}
+	return append([]TraceArm(nil), arms...)
 }
 
 func traceSocketControl(cityPath, command string, req traceControlRequest) (*traceStatusJSON, string, error) {

--- a/cmd/gc/session_reconciler_trace_cmd.go
+++ b/cmd/gc/session_reconciler_trace_cmd.go
@@ -44,7 +44,25 @@ type traceStatusJSON struct {
 	AsOf              time.Time  `json:"as_of"`
 	ControllerRunning bool       `json:"controller_running"`
 	ControllerPID     int        `json:"controller_pid,omitempty"`
+	HeadSeq           uint64     `json:"head_seq"`
 	ActiveArms        []TraceArm `json:"active_arms"`
+	LegacyArms        []TraceArm `json:"arms,omitempty"`
+}
+
+func (s *traceStatusJSON) UnmarshalJSON(data []byte) error {
+	type traceStatusJSONAlias traceStatusJSON
+	var decoded traceStatusJSONAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*s = traceStatusJSON(decoded)
+	if s.ActiveArms == nil && s.LegacyArms != nil {
+		s.ActiveArms = append([]TraceArm(nil), s.LegacyArms...)
+	}
+	if s.LegacyArms == nil && s.ActiveArms != nil {
+		s.LegacyArms = append([]TraceArm(nil), s.ActiveArms...)
+	}
+	return nil
 }
 
 type traceStatusResultJSON struct {
@@ -703,12 +721,15 @@ func traceStatusLocal(cityPath string) (*traceStatusJSON, string, error) {
 func traceStatusFromState(cityPath string, state TraceArmState, now time.Time) traceStatusJSON {
 	arms := traceArmStatus(state, now)
 	pid := controllerAlive(cityPath)
+	head, _ := traceHeadSeq(traceCityRuntimeDir(cityPath))
 	return traceStatusJSON{
 		CityPath:          cityPath,
 		AsOf:              now,
 		ControllerRunning: pid != 0,
 		ControllerPID:     pid,
+		HeadSeq:           head,
 		ActiveArms:        arms,
+		LegacyArms:        append([]TraceArm(nil), arms...),
 	}
 }
 

--- a/schemas/mail/count/result.schema.json
+++ b/schemas/mail/count/result.schema.json
@@ -5,6 +5,7 @@
     "schema_version",
     "ok",
     "recipient",
+    "recipients",
     "total",
     "unread"
   ],

--- a/schemas/mail/inbox/result.schema.json
+++ b/schemas/mail/inbox/result.schema.json
@@ -4,6 +4,7 @@
   "required": [
     "schema_version",
     "ok",
+    "recipients",
     "messages"
   ],
   "properties": {

--- a/schemas/trace/show/result.schema.json
+++ b/schemas/trace/show/result.schema.json
@@ -46,6 +46,12 @@
           "record_type": {
             "type": "string"
           },
+          "template": {
+            "type": "string"
+          },
+          "session_name": {
+            "type": "string"
+          },
           "reason_code": {
             "type": "string"
           },


### PR DESCRIPTION
Remediates post-merge review findings from #2259.

Changes:
- Add trace controller socket compatibility for legacy `arms`/`head_seq` status replies and test the rolling-upgrade path.
- Add populated text-mode `gc trace show` coverage for template, session, and reason output.
- Always include resolved `recipients` for `gc mail inbox --json` and `gc mail count --json`, including single-recipient targets, and tighten the checked-in schemas.
- Document the trace rolling-upgrade compatibility and mail recipients JSON contract.

Validation:
- `go test ./cmd/gc -run 'TestTraceControllerSocketCommands|TestTraceStatusJSONAcceptsLegacySocketArms|TestTraceShowTextIncludesPopulatedRecordSummary|TestMailInboxJSON|TestMailCountJSON'`\n- `make test-fast-parallel`\n- `go vet ./...`\n- `.githooks/pre-commit`