### PR TITLE
fix(cmd/gc): keep explicit city ahead of inherited env

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1121,6 +1121,9 @@ func mirrorBeadsDoltEnv(env map[string]string) {
 	}
 }
 
+// cityForStoreDir resolves ambient store contexts. GC_CITY intentionally wins
+// over filesystem discovery here; callers with an authoritative city path or
+// hook-projected store root must pass that city directly.
 func cityForStoreDir(dir string) string {
 	if cityPath, ok := resolveExplicitCityPathEnv(); ok {
 		return cityPath

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1122,17 +1122,11 @@ func mirrorBeadsDoltEnv(env map[string]string) {
 }
 
 func cityForStoreDir(dir string) string {
-	// Walk up from the explicit dir first. When the caller knows the
-	// store path (e.g. an --city flag), a dir-discovered city is more
-	// authoritative than an inherited GC_CITY env. Env-first was
-	// silently swapping cityRoot/scopeRoot when an agent inherited
-	// GC_CITY from a different city, producing "managed_city endpoint
-	// origin is invalid for rig scope".
-	if p, err := findCity(dir); err == nil {
-		return p
-	}
 	if cityPath, ok := resolveExplicitCityPathEnv(); ok {
 		return cityPath
+	}
+	if p, err := findCity(dir); err == nil {
+		return p
 	}
 	return dir
 }

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1122,11 +1122,17 @@ func mirrorBeadsDoltEnv(env map[string]string) {
 }
 
 func cityForStoreDir(dir string) string {
-	if cityPath, ok := resolveExplicitCityPathEnv(); ok {
-		return cityPath
-	}
+	// Walk up from the explicit dir first. When the caller knows the
+	// store path (e.g. an --city flag), a dir-discovered city is more
+	// authoritative than an inherited GC_CITY env. Env-first was
+	// silently swapping cityRoot/scopeRoot when an agent inherited
+	// GC_CITY from a different city, producing "managed_city endpoint
+	// origin is invalid for rig scope".
 	if p, err := findCity(dir); err == nil {
 		return p
+	}
+	if cityPath, ok := resolveExplicitCityPathEnv(); ok {
+		return cityPath
 	}
 	return dir
 }

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2406,6 +2406,42 @@ func TestCityForStoreDirHonoursGCCity(t *testing.T) {
 	}
 }
 
+func TestCityForStoreDirPrefersDiscoveredCityOverGCCity(t *testing.T) {
+	// Regression: when an explicit dir resolves via findCity to a city
+	// AND GC_CITY env points to a different city, the dir-discovered
+	// city wins. Otherwise an explicit --city flag whose value differs
+	// from an inherited GC_CITY env gets silently swapped at the bd
+	// runtime env layer, producing
+	// "managed_city endpoint origin is invalid for rig scope" because
+	// downstream resolution pairs the dir's config with the env city's
+	// scope.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+	envCity := filepath.Join(homeDir, "envcity")
+	if err := os.MkdirAll(filepath.Join(envCity, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(envCity, "city.toml"), []byte("[workspace]\nname = \"env\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", envCity)
+
+	dirCity := filepath.Join(homeDir, "dircity")
+	if err := os.MkdirAll(filepath.Join(dirCity, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirCity, "city.toml"), []byte("[workspace]\nname = \"dir\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := cityForStoreDir(dirCity)
+	if canonicalTestPath(got) != canonicalTestPath(dirCity) {
+		t.Errorf("cityForStoreDir(%q) = %q, want %q (dir-discovered city must win over GC_CITY=%q)", dirCity, got, dirCity, envCity)
+	}
+}
+
 func TestCityForStoreDirFallsBackToFindCity(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2406,15 +2406,10 @@ func TestCityForStoreDirHonoursGCCity(t *testing.T) {
 	}
 }
 
-func TestCityForStoreDirPrefersDiscoveredCityOverGCCity(t *testing.T) {
-	// Regression: when an explicit dir resolves via findCity to a city
-	// AND GC_CITY env points to a different city, the dir-discovered
-	// city wins. Otherwise an explicit --city flag whose value differs
-	// from an inherited GC_CITY env gets silently swapped at the bd
-	// runtime env layer, producing
-	// "managed_city endpoint origin is invalid for rig scope" because
-	// downstream resolution pairs the dir's config with the env city's
-	// scope.
+func TestCityForStoreDirHonoursGCCityOverDiscoveredCity(t *testing.T) {
+	// Ambient store resolution honors an explicit city env before
+	// filesystem discovery. Callers that have already resolved --city must
+	// pass that city through directly instead of using this helper.
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
@@ -2437,8 +2432,44 @@ func TestCityForStoreDirPrefersDiscoveredCityOverGCCity(t *testing.T) {
 	}
 
 	got := cityForStoreDir(dirCity)
-	if canonicalTestPath(got) != canonicalTestPath(dirCity) {
-		t.Errorf("cityForStoreDir(%q) = %q, want %q (dir-discovered city must win over GC_CITY=%q)", dirCity, got, dirCity, envCity)
+	if canonicalTestPath(got) != canonicalTestPath(envCity) {
+		t.Errorf("cityForStoreDir(%q) = %q, want %q (GC_CITY should win over discovered city %q)", dirCity, got, envCity, dirCity)
+	}
+}
+
+func TestOpenCityStoreAtUsesExplicitCityOverGCCity(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("GC_BEADS", "bd")
+
+	envCity := filepath.Join(homeDir, "envcity")
+	if err := os.MkdirAll(filepath.Join(envCity, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(envCity, "city.toml"), []byte("[workspace]\nname = \"env\"\nprefix = \"env\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", envCity)
+
+	explicitCity := filepath.Join(homeDir, "explicit")
+	if err := os.MkdirAll(filepath.Join(explicitCity, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(explicitCity, "city.toml"), []byte("[workspace]\nname = \"explicit\"\nprefix = \"ex\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := openCityStoreAt(explicitCity)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(%q): %v", explicitCity, err)
+	}
+	bdStore, ok := store.(*beads.BdStore)
+	if !ok {
+		t.Fatalf("openCityStoreAt(%q) returned %T, want *beads.BdStore", explicitCity, store)
+	}
+	if got := bdStore.IDPrefix(); got != "ex" {
+		t.Fatalf("IDPrefix() = %q, want explicit city prefix %q", got, "ex")
 	}
 }
 

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -1478,7 +1478,7 @@ func doConvoyAutoclose(beadID string, stdout, stderr io.Writer) {
 		return
 	}
 	storeRoot := convoyAutocloseStoreRoot(cwd)
-	cityPath := cityForStoreDir(storeRoot)
+	cityPath := autocloseCityPathForStoreRoot(storeRoot)
 	store, err := openStoreAtForCity(storeRoot, cityPath)
 	if err != nil {
 		return
@@ -1501,6 +1501,17 @@ func convoyAutocloseStoreRoot(cwd string) string {
 		return filepath.Clean(filepath.Dir(beadsDir))
 	}
 	return cwd
+}
+
+// autocloseCityPathForStoreRoot resolves the runtime city for bd hook cleanup.
+// The hook-projected store root identifies the bead that just closed, so prefer
+// filesystem discovery from that root over an inherited GC_CITY from the
+// supervising process.
+func autocloseCityPathForStoreRoot(storeRoot string) string {
+	if cityPath, err := findCity(storeRoot); err == nil {
+		return cityPath
+	}
+	return cityForStoreDir(storeRoot)
 }
 
 // doConvoyAutocloseWith checks whether the closed bead's parent is a

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -933,7 +933,9 @@ func openCityStoreWithPath(stderr io.Writer, cmdName string) (beads.Store, strin
 
 // openCityStoreAt opens a bead store at the given city path.
 // Used by the controller (which already knows the city path) and by
-// openCityStore (which resolves the path first).
+// openCityStore (which resolves the path first). Keep the passed city path
+// authoritative; rerouting through cityForStoreDir would let inherited
+// GC_CITY override an explicit --city resolution.
 func openCityStoreAt(cityPath string) (beads.Store, error) {
 	return openStoreAtForCity(cityPath, cityPath)
 }

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -935,7 +935,7 @@ func openCityStoreWithPath(stderr io.Writer, cmdName string) (beads.Store, strin
 // Used by the controller (which already knows the city path) and by
 // openCityStore (which resolves the path first).
 func openCityStoreAt(cityPath string) (beads.Store, error) {
-	return openStoreAtForCity(cityPath, cityForStoreDir(cityPath))
+	return openStoreAtForCity(cityPath, cityPath)
 }
 
 const fileStoreLayoutScopedV1 = "scope-local-v1"

--- a/cmd/gc/provider_store_resolution_test.go
+++ b/cmd/gc/provider_store_resolution_test.go
@@ -332,6 +332,15 @@ func TestDoConvoyAutocloseUsesBeadsDirStoreRoot(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_BEADS", "file")
 
+	envCityDir := t.TempDir()
+	if err := ensureScopedFileStoreLayout(envCityDir); err != nil {
+		t.Fatal(err)
+	}
+	writeProviderAwareTestCity(t, envCityDir, `[workspace]
+name = "ambient"
+`)
+	t.Setenv("GC_CITY", envCityDir)
+
 	cityDir := t.TempDir()
 	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
 		t.Fatal(err)
@@ -390,9 +399,44 @@ name = "demo"
 	}
 }
 
+func TestAutocloseCityPathForStoreRootPrefersStoreRootCityOverInheritedGCCity(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+
+	envCityDir := t.TempDir()
+	if err := ensureScopedFileStoreLayout(envCityDir); err != nil {
+		t.Fatal(err)
+	}
+	writeProviderAwareTestCity(t, envCityDir, `[workspace]
+name = "ambient"
+`)
+	t.Setenv("GC_CITY", envCityDir)
+
+	storeCityDir := t.TempDir()
+	if err := ensureScopedFileStoreLayout(storeCityDir); err != nil {
+		t.Fatal(err)
+	}
+	writeProviderAwareTestCity(t, storeCityDir, `[workspace]
+name = "store"
+`)
+
+	got := autocloseCityPathForStoreRoot(storeCityDir)
+	if canonicalTestPath(got) != canonicalTestPath(storeCityDir) {
+		t.Fatalf("autocloseCityPathForStoreRoot(%q) = %q, want store-root city %q", storeCityDir, got, storeCityDir)
+	}
+}
+
 func TestDoWispAutocloseUsesBeadsDirStoreRoot(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_BEADS", "file")
+
+	envCityDir := t.TempDir()
+	if err := ensureScopedFileStoreLayout(envCityDir); err != nil {
+		t.Fatal(err)
+	}
+	writeProviderAwareTestCity(t, envCityDir, `[workspace]
+name = "ambient"
+`)
+	t.Setenv("GC_CITY", envCityDir)
 
 	cityDir := t.TempDir()
 	if err := ensureScopedFileStoreLayout(cityDir); err != nil {

--- a/cmd/gc/wisp_autoclose.go
+++ b/cmd/gc/wisp_autoclose.go
@@ -42,7 +42,7 @@ func doWispAutoclose(beadID string, stdout, _ io.Writer) {
 		return
 	}
 	storeRoot := convoyAutocloseStoreRoot(cwd)
-	cityPath := cityForStoreDir(storeRoot)
+	cityPath := autocloseCityPathForStoreRoot(storeRoot)
 	store, err := openStoreAtForCity(storeRoot, cityPath)
 	if err != nil {
 		return


### PR DESCRIPTION
## Summary

Replaces #2292 with the intended resolver priority while preserving the original fix as the first cherry-picked commit.

Commit layout:
- cherry-pick of #2292: demonstrates the stale inherited GC_CITY problem in cityForStoreDir
- maintainer commit: keeps ambient store resolution as GC_CITY > filesystem discovery, and changes openCityStoreAt so an already-resolved explicit city path is not re-resolved through GC_CITY

Final behavior:
- --city / resolved explicit city path wins over inherited GC_CITY
- GC_CITY / GC_CITY_PATH / GC_CITY_ROOT still win over cwd/filesystem discovery for ambient store resolution
- filesystem discovery is the fallback when no explicit city input is available

Bead: ga-cr6oe43

## Testing

- [x] GC_FAST_UNIT=1 go test ./cmd/gc -run 'TestCityForStoreDir|TestOpenCityStoreAtUsesExplicitCityOverGCCity|TestBdRuntimeEnv|TestOpenStoreAt|TestCanonicalScope|TestApplyResolvedRig'\n- [x] go vet ./...\n- [x] make test-fast-parallel\n- [x] pre-commit hook ran during maintainer commit\n