### PR TITLE
fix: address post-merge JSON CLI review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,13 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `gc converge status --json` and `gc converge list --json` now emit
-  schema-versioned envelope objects. `gc converge status --json` previously
-  returned the raw convergence metadata map; it now returns an object with
-  `schema_version`, `ok`, `bead_id`, `state`, `iteration`,
-  `max_iterations`, `gate_mode`, `formula`, and `target`. `gc converge list
-  --json` previously returned a raw array; it now returns an object with
-  `schema_version`, `ok`, and `entries`.
+- `gc converge status --json` returns the convergence metadata object with
+  `ok: true` injected. `gc converge list --json` returns an object with
+  `ok: true` and `entries`. These converge JSON outputs do not include a
+  `schema_version` field.
+- `gc runtime drain-check --json` now emits a JSON result when the target
+  session is not draining, with `ok: true`, `draining: false`, and the
+  existing shell-condition exit code of 1.
 - `gc sling --json` now emits one JSONL result record, matching its checked-in
   result schema; earlier JSON support emitted an indented multi-line object.
 - `gc trace status` and `gc trace show` now default to human-readable output;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `gc converge status --json` and `gc converge list --json` now emit
+  schema-versioned envelope objects. `gc converge status --json` previously
+  returned the raw convergence metadata map; it now returns an object with
+  `schema_version`, `ok`, `bead_id`, `state`, `iteration`,
+  `max_iterations`, `gate_mode`, `formula`, and `target`. `gc converge list
+  --json` previously returned a raw array; it now returns an object with
+  `schema_version`, `ok`, and `entries`.
 - `gc sling --json` now emits one JSONL result record, matching its checked-in
   result schema; earlier JSON support emitted an indented multi-line object.
 - `gc trace status` and `gc trace show` now default to human-readable output;

--- a/cmd/gc/cmd_build_image.go
+++ b/cmd/gc/cmd_build_image.go
@@ -64,6 +64,7 @@ volume mounts at runtime.`,
 			if jsonOut {
 				return writeCLIJSONLineOrErr(stdout, stderr, "gc build-image", buildImageJSONResult{
 					SchemaVersion: "1",
+					OK:            true,
 					CityPath:      result.CityPath,
 					Tag:           tag,
 					BaseImage:     baseImage,
@@ -89,6 +90,7 @@ volume mounts at runtime.`,
 
 type buildImageJSONResult struct {
 	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
 	CityPath      string `json:"city_path,omitempty"`
 	Tag           string `json:"tag,omitempty"`
 	BaseImage     string `json:"base_image"`

--- a/cmd/gc/cmd_event_emit.go
+++ b/cmd/gc/cmd_event_emit.go
@@ -29,6 +29,7 @@ func newEventCmd(stdout, stderr io.Writer) *cobra.Command {
 
 type eventEmitJSONResult struct {
 	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
 	EventType     string `json:"event_type"`
 	Actor         string `json:"actor"`
 	Subject       string `json:"subject,omitempty"`
@@ -61,6 +62,7 @@ durable persistence.`,
 				submitted = cmdEventEmitSubmitted(args[0], subject, message, effectiveActor, payload, stderr)
 				return writeCLIJSONLineOrErr(stdout, stderr, "gc event emit", eventEmitJSONResult{
 					SchemaVersion: "1",
+					OK:            true,
 					EventType:     args[0],
 					Actor:         effectiveActor,
 					Subject:       subject,

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -41,6 +41,7 @@ configured via packs and formulas_dir settings.`,
 			if jsonOutput {
 				return writeCLIJSONLine(stdout, formulaListJSON{
 					SchemaVersion: "1",
+					OK:            true,
 					CityPath:      cityPath,
 					SearchPaths:   paths,
 					Formulas:      rows,
@@ -257,6 +258,7 @@ Examples:
 
 type formulaListJSON struct {
 	SchemaVersion string                 `json:"schema_version"`
+	OK            bool                   `json:"ok"`
 	CityPath      string                 `json:"city_path,omitempty"`
 	SearchPaths   []string               `json:"search_paths"`
 	Formulas      []formulaListRowJSON   `json:"formulas"`
@@ -275,6 +277,7 @@ type formulaListSummaryJSON struct {
 
 type formulaShowJSON struct {
 	SchemaVersion string                `json:"schema_version"`
+	OK            bool                  `json:"ok"`
 	CityPath      string                `json:"city_path,omitempty"`
 	Name          string                `json:"name"`
 	Description   string                `json:"description,omitempty"`
@@ -394,6 +397,7 @@ func formulaSearchPathsForList(cfg *config.City) []string {
 func formulaShowJSONFromRecipe(recipe *formula.Recipe, cityPath string, scope formulaScope, rigVars, providedVars, displayVars map[string]string) formulaShowJSON {
 	out := formulaShowJSON{
 		SchemaVersion: "1",
+		OK:            true,
 		CityPath:      cityPath,
 		Name:          recipe.Name,
 		Description:   recipe.Description,

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -79,6 +79,7 @@ or ID. Subject is required unless --auto is set.`,
 			if jsonOut {
 				return writeCLIJSONLineOrErr(stdout, stderr, "gc handoff", handoffJSONResult{
 					SchemaVersion: "1",
+					OK:            true,
 					Mode:          handoffJSONMode(target, auto),
 					Target:        target,
 					Auto:          auto,
@@ -97,6 +98,7 @@ or ID. Subject is required unless --auto is set.`,
 
 type handoffJSONResult struct {
 	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
 	Mode          string `json:"mode"`
 	Target        string `json:"target,omitempty"`
 	Auto          bool   `json:"auto"`

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -304,6 +304,7 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 
 type initJSONResult struct {
 	SchemaVersion    string `json:"schema_version"`
+	OK               bool   `json:"ok"`
 	CityPath         string `json:"city_path"`
 	CityName         string `json:"city_name"`
 	Mode             string `json:"mode"`
@@ -324,6 +325,7 @@ func writeInitJSONOrExit(code int, jsonOut bool, args []string, nameOverride, pr
 	}
 	return writeCLIJSONLine(stdout, initJSONResult{
 		SchemaVersion:    "1",
+		OK:               true,
 		CityPath:         cityPath,
 		CityName:         resolveCityName(nameOverride, "", cityPath),
 		Mode:             mode,

--- a/cmd/gc/cmd_mcp.go
+++ b/cmd/gc/cmd_mcp.go
@@ -118,6 +118,7 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 
 type projectedMCPJSON struct {
 	SchemaVersion string                   `json:"schema_version"`
+	OK            bool                     `json:"ok"`
 	CityPath      string                   `json:"city_path"`
 	Query         projectedMCPQueryJSON    `json:"query"`
 	Projection    projectedMCPTargetJSON   `json:"projection"`
@@ -193,6 +194,7 @@ func projectedMCPJSONFromView(cityPath string, view resolvedMCPProjection, agent
 	}
 	return projectedMCPJSON{
 		SchemaVersion: "1",
+		OK:            true,
 		CityPath:      cityPath,
 		Query: projectedMCPQueryJSON{
 			Agent:   agentName,

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -75,11 +76,16 @@ func doRegisterWithOptionsJSON(args []string, nameOverride string, jsonOut bool,
 		return 1
 	}
 	registerStdout := stdout
+	var registerProgress bytes.Buffer
 	if jsonOut {
-		registerStdout = io.Discard
+		registerStdout = &registerProgress
 	}
 	code := registerCityWithSupervisorNamed(cityPath, registerName, registerStdout, stderr, "gc register", true)
-	if code != 0 || !jsonOut {
+	if code != 0 {
+		replayJSONModeProgress(stderr, &registerProgress)
+		return code
+	}
+	if !jsonOut {
 		return code
 	}
 	return writeLifecycleActionJSONOrExit(stdout, stderr, "gc register", lifecycleActionJSON{
@@ -148,11 +154,16 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 	}
 	entry, registered, _ := registeredCityEntry(cityPath)
 	unregisterStdout := stdout
+	var unregisterProgress bytes.Buffer
 	if jsonOut {
-		unregisterStdout = io.Discard
+		unregisterStdout = &unregisterProgress
 	}
 	_, code := unregisterCityFromSupervisor(cityPath, unregisterStdout, stderr)
-	if code != 0 || !jsonOut {
+	if code != 0 {
+		replayJSONModeProgress(stderr, &unregisterProgress)
+		return code
+	}
+	if !jsonOut {
 		return code
 	}
 	cityName := ""
@@ -166,6 +177,13 @@ func doUnregisterJSON(args []string, jsonOut bool, stdout, stderr io.Writer) int
 		CityName: cityName,
 		CityPath: cityPath,
 	})
+}
+
+func replayJSONModeProgress(stderr io.Writer, progress *bytes.Buffer) {
+	if progress == nil || progress.Len() == 0 {
+		return
+	}
+	_, _ = io.Copy(stderr, progress)
 }
 
 func newCitiesCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/supervisor"
 )
@@ -49,6 +52,80 @@ func TestDoRegister(t *testing.T) {
 	resolvedCityPath := canonicalTestPath(cityPath)
 	if len(entries) != 1 || entries[0].Path != resolvedCityPath {
 		t.Errorf("expected 1 entry at %s, got %v", resolvedCityPath, entries)
+	}
+}
+
+func TestDoRegisterJSONFailureReplaysHelperProgressToStderr(t *testing.T) {
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = func(_ string, _ string, stdout, _ io.Writer) (bool, int) {
+		_, _ = fmt.Fprintln(stdout, "helper progress before failure")
+		return true, 1
+	}
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"my-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_HOME", dir)
+
+	var stdout, stderr bytes.Buffer
+	code := doRegisterWithOptionsJSON([]string{cityPath}, "", true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty JSON stdout on failure", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "helper progress before failure") {
+		t.Fatalf("stderr = %q, want helper progress replayed", stderr.String())
+	}
+}
+
+func TestDoUnregisterJSONFailureReplaysHelperProgressToStderr(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GC_HOME", dir)
+
+	cityPath := filepath.Join(dir, "my-city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"my-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "my-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(stdout, stderr io.Writer) int {
+			_, _ = fmt.Fprintln(stdout, "reload progress before failure")
+			_, _ = fmt.Fprintln(stderr, "reload failed")
+			return 1
+		},
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", false },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+
+	var stdout, stderr bytes.Buffer
+	code := doUnregisterJSON([]string{cityPath}, true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty JSON stdout on failure", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "reload progress before failure") {
+		t.Fatalf("stderr = %q, want helper progress replayed", stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -39,6 +39,7 @@ type providerDrainOps struct {
 
 type runtimeDrainCheckJSON struct {
 	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
 	Command       string `json:"command"`
 	Session       string `json:"session"`
 	Target        string `json:"target,omitempty"`
@@ -47,6 +48,7 @@ type runtimeDrainCheckJSON struct {
 
 type runtimeActionJSON struct {
 	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
 	Command       string `json:"command"`
 	Action        string `json:"action"`
 	Session       string `json:"session"`
@@ -220,6 +222,7 @@ func doRuntimeDrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 	if jsonOutput {
 		if err := writeCLIJSONLine(stdout, runtimeActionJSON{
 			SchemaVersion: "1",
+			OK:            true,
 			Command:       "runtime drain",
 			Action:        "drain",
 			Session:       sn,
@@ -301,6 +304,7 @@ func doRuntimeUndrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 	if jsonOutput {
 		if err := writeCLIJSONLine(stdout, runtimeActionJSON{
 			SchemaVersion: "1",
+			OK:            true,
 			Command:       "runtime undrain",
 			Action:        "undrain",
 			Session:       sn,
@@ -367,12 +371,29 @@ func cmdRuntimeDrainCheck(args []string, jsonOutput bool, stdout, stderr io.Writ
 // Silent on stdout — designed for `if gc runtime drain-check; then ...`.
 func doRuntimeDrainCheck(dops drainOps, targetName, sn string, jsonOutput bool, stdout, stderr io.Writer) int {
 	draining, err := dops.isDraining(sn)
-	if err != nil || !draining {
+	if err != nil {
+		return 1
+	}
+	if !draining {
+		if jsonOutput {
+			if err := writeCLIJSONLine(stdout, runtimeDrainCheckJSON{
+				SchemaVersion: "1",
+				OK:            true,
+				Command:       "runtime drain-check",
+				Session:       sn,
+				Target:        targetName,
+				Draining:      false,
+			}); err != nil {
+				fmt.Fprintf(stderr, "gc runtime drain-check: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		}
 		return 1
 	}
 	if jsonOutput {
 		if err := writeCLIJSONLine(stdout, runtimeDrainCheckJSON{
 			SchemaVersion: "1",
+			OK:            true,
 			Command:       "runtime drain-check",
 			Session:       sn,
 			Target:        targetName,
@@ -612,6 +633,7 @@ func doRuntimeDrainAck(dops drainOps, targetName, sn string, jsonOutput bool, st
 	if jsonOutput {
 		if err := writeCLIJSONLine(stdout, runtimeActionJSON{
 			SchemaVersion: "1",
+			OK:            true,
 			Command:       "runtime drain-ack",
 			Action:        "drain-ack",
 			Session:       sn,

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -408,6 +408,27 @@ func TestDoRuntimeDrainCheckJSON(t *testing.T) {
 	}
 }
 
+func TestDoRuntimeDrainCheckJSONNotDrainingWritesFalseResult(t *testing.T) {
+	dops := newFakeDrainOps()
+
+	var stdout, stderr bytes.Buffer
+	code := doRuntimeDrainCheck(dops, "worker", "worker", true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 for shell-condition false; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var result runtimeDrainCheckJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
+	}
+	if result.SchemaVersion != "1" || result.Command != "runtime drain-check" || result.Draining || result.Session != "worker" {
+		t.Fatalf("unexpected JSON result: %+v", result)
+	}
+	validateJSONAgainstResultSchema(t, []string{"runtime", "drain-check"}, stdout.Bytes())
+}
+
 // ---------------------------------------------------------------------------
 // doRuntimeDrainAck tests
 // ---------------------------------------------------------------------------

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -403,9 +403,14 @@ func TestDoRuntimeDrainCheckJSON(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
 	}
-	if result.SchemaVersion != "1" || result.Command != "runtime drain-check" || !result.Draining || result.Session != "worker" {
+	if result.SchemaVersion != "1" ||
+		!result.OK ||
+		result.Command != "runtime drain-check" ||
+		!result.Draining ||
+		result.Session != "worker" {
 		t.Fatalf("unexpected JSON result: %+v", result)
 	}
+	validateJSONAgainstResultSchema(t, []string{"runtime", "drain-check"}, stdout.Bytes())
 }
 
 func TestDoRuntimeDrainCheckJSONNotDrainingWritesFalseResult(t *testing.T) {
@@ -423,7 +428,11 @@ func TestDoRuntimeDrainCheckJSONNotDrainingWritesFalseResult(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("stdout is not JSON: %v\nraw: %s", err, stdout.String())
 	}
-	if result.SchemaVersion != "1" || result.Command != "runtime drain-check" || result.Draining || result.Session != "worker" {
+	if result.SchemaVersion != "1" ||
+		!result.OK ||
+		result.Command != "runtime drain-check" ||
+		result.Draining ||
+		result.Session != "worker" {
 		t.Fatalf("unexpected JSON result: %+v", result)
 	}
 	validateJSONAgainstResultSchema(t, []string{"runtime", "drain-check"}, stdout.Bytes())

--- a/cmd/gc/json_runtime_schema_test.go
+++ b/cmd/gc/json_runtime_schema_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -116,6 +117,69 @@ func TestDirectJSONWriterPayloadsValidateDeclaredSchemas(t *testing.T) {
 			}
 			assertTopLevelOKTrue(t, stdout.Bytes())
 			validateJSONAgainstResultSchema(t, tc.command, stdout.Bytes())
+		})
+	}
+}
+
+func TestJSONResultStructsExposeExplicitOKField(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "runtime drain-check", value: runtimeDrainCheckJSON{}},
+		{name: "runtime action", value: runtimeActionJSON{}},
+		{name: "handoff", value: handoffJSONResult{}},
+		{name: "build-image", value: buildImageJSONResult{}},
+		{name: "mcp list", value: projectedMCPJSON{}},
+		{name: "formula list", value: formulaListJSON{}},
+		{name: "formula show", value: formulaShowJSON{}},
+		{name: "event emit", value: eventEmitJSONResult{}},
+		{name: "init", value: initJSONResult{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			field, ok := reflect.TypeOf(tc.value).FieldByName("OK")
+			if !ok {
+				t.Fatalf("%s JSON result does not expose explicit OK field", tc.name)
+			}
+			if field.Type.Kind() != reflect.Bool {
+				t.Fatalf("%s OK field kind = %s, want bool", tc.name, field.Type.Kind())
+			}
+			if got := field.Tag.Get("json"); got != "ok" {
+				t.Fatalf("%s OK json tag = %q, want ok", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestFixedResultSchemasPinSchemaVersion(t *testing.T) {
+	for _, command := range [][]string{
+		{"handoff"},
+		{"build-image"},
+		{"formula", "list"},
+		{"formula", "show"},
+		{"event", "emit"},
+		{"init"},
+	} {
+		t.Run(strings.Join(command, " "), func(t *testing.T) {
+			rawSchema, err := readBuiltinSchema(command, jsonSchemaResultRole)
+			if err != nil {
+				t.Fatalf("read schema for %v: %v", command, err)
+			}
+			var schema struct {
+				Properties map[string]map[string]any `json:"properties"`
+			}
+			if err := json.Unmarshal(rawSchema, &schema); err != nil {
+				t.Fatalf("parse schema for %v: %v", command, err)
+			}
+			version, ok := schema.Properties["schema_version"]
+			if !ok {
+				t.Fatalf("schema for %v lacks schema_version property", command)
+			}
+			if got := version["const"]; got != "1" {
+				t.Fatalf("schema_version const = %#v, want %q", got, "1")
+			}
 		})
 	}
 }

--- a/schemas/build-image/result.schema.json
+++ b/schemas/build-image/result.schema.json
@@ -11,7 +11,7 @@
   ],
   "properties": {
     "schema_version": {
-      "type": "string"
+      "const": "1"
     },
     "ok": {
       "const": true

--- a/schemas/event/emit/result.schema.json
+++ b/schemas/event/emit/result.schema.json
@@ -11,7 +11,7 @@
   ],
   "properties": {
     "schema_version": {
-      "type": "string"
+      "const": "1"
     },
     "ok": {
       "const": true

--- a/schemas/formula/list/result.schema.json
+++ b/schemas/formula/list/result.schema.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "schema_version": {
-      "type": "string"
+      "const": "1"
     },
     "ok": {
       "const": true

--- a/schemas/formula/show/result.schema.json
+++ b/schemas/formula/show/result.schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "schema_version": {
-      "type": "string"
+      "const": "1"
     },
     "ok": {
       "const": true

--- a/schemas/handoff/result.schema.json
+++ b/schemas/handoff/result.schema.json
@@ -9,7 +9,7 @@
   ],
   "properties": {
     "schema_version": {
-      "type": "string"
+      "const": "1"
     },
     "ok": {
       "const": true

--- a/schemas/init/result.schema.json
+++ b/schemas/init/result.schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "schema_version": {
-      "type": "string"
+      "const": "1"
     },
     "ok": {
       "const": true

--- a/schemas/runtime/drain-check/result.schema.json
+++ b/schemas/runtime/drain-check/result.schema.json
@@ -25,7 +25,7 @@
       "type": "string"
     },
     "draining": {
-      "const": true
+      "type": "boolean"
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
## Summary
- document converge status/list JSON envelope shape changes in the changelog
- emit structured JSON for the normal runtime drain-check false state
- make selected JSON result ok fields explicit and pin fixed result schema versions
- replay register/unregister helper progress to stderr on JSON-mode failures

## Verification
- go test ./cmd/gc -run 'TestDoRuntimeDrainCheckJSONNotDrainingWritesFalseResult|TestJSONResultStructsExposeExplicitOKField|TestFixedResultSchemasPinSchemaVersion|TestDoRegisterJSONFailureReplaysHelperProgressToStderr|TestDoUnregisterJSONFailureReplaysHelperProgressToStderr'
- go test ./cmd/gc -run 'JSON|Json'
- go test ./cmd/gc -run 'Register|Unregister|RuntimeDrain|DrainCheck'
- git diff --check
- make test-fast-parallel
- go vet ./...
- make check-docs

Post-merge follow-up for #2349.