### PR TITLE
fix: refine control dispatcher startup suppression

### DIFF
--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -346,7 +346,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	// subprocess with WorkDir ≠ scope root — because subprocess
 	// doesn't execute PreStart) get no appendix; we'd be lying to
 	// them. Discovered via the pass-1 Codex review.
-	if prompt != "" && effectiveInjectAssignedSkills(cfgAgent) {
+	if !suppressStartupPrompt && effectiveInjectAssignedSkills(cfgAgent) {
 		wsProvider := ""
 		if p.workspace != nil {
 			wsProvider = p.workspace.Provider
@@ -522,9 +522,10 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	nudge := cfgAgent.Nudge
 	acceptStartupDialogs := resolved.AcceptStartupDialogs
 	if suppressStartupPrompt {
-		// The control dispatcher is a deterministic gc subprocess, not an
-		// interactive model provider. Keep ProcessNames for liveness without
-		// routing startup through prompt, nudge, or trust-dialog handling.
+		// Implicit start-command infrastructure agents are deterministic
+		// subprocesses, not interactive model providers. Keep ProcessNames for
+		// liveness without routing startup through prompt, nudge, or
+		// trust-dialog handling.
 		nudge = ""
 		accept := false
 		acceptStartupDialogs = &accept
@@ -572,8 +573,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 
 func suppressStartupPromptForAgent(cfgAgent *config.Agent) bool {
 	return cfgAgent != nil &&
-		cfgAgent.Name == config.ControlDispatcherAgentName &&
-		strings.TrimSpace(cfgAgent.StartCommand) != ""
+		cfgAgent.Implicit &&
+		strings.TrimSpace(cfgAgent.StartCommand) != "" &&
+		strings.TrimSpace(cfgAgent.Provider) == ""
 }
 
 func sessionBackendEnvWithError(cityPath, rigRoot string, rigs []config.Rig) (map[string]string, error) {

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -225,6 +225,7 @@ func TestResolveTemplateControlDispatcherSuppressesStartupPrompt(t *testing.T) {
 		StartCommand:   config.ControlDispatcherStartCommandFor("gascity/" + config.ControlDispatcherAgentName),
 		Nudge:          "configured startup nudge",
 		ProcessNames:   []string{"gc"},
+		Implicit:       true,
 	}
 
 	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
@@ -246,6 +247,59 @@ func TestResolveTemplateControlDispatcherSuppressesStartupPrompt(t *testing.T) {
 	}
 	if !reflect.DeepEqual(cfg.ProcessNames, []string{"gc"}) {
 		t.Fatalf("ProcessNames = %v, want [gc]", cfg.ProcessNames)
+	}
+}
+
+func TestResolveTemplateExplicitControlDispatcherKeepsStartupPrompt(t *testing.T) {
+	cityPath := t.TempDir()
+	fakeFS := fsys.NewFake()
+	promptPath := filepath.Join(cityPath, "prompts", "control-dispatcher.template.md")
+	if err := fakeFS.WriteFile(promptPath, []byte("startup prompt for {{.AgentName}}"), 0o644); err != nil {
+		t.Fatalf("write prompt template: %v", err)
+	}
+	params := &agentBuildParams{
+		fs:              fakeFS,
+		cityName:        "maintainer-city",
+		cityPath:        cityPath,
+		workspace:       &config.Workspace{Name: "maintainer-city"},
+		providers:       map[string]config.ProviderSpec{},
+		lookPath:        func(string) (string, error) { return "", fmt.Errorf("not found") },
+		beaconTime:      testBeaconTime,
+		sessionTemplate: "",
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+	}
+	agent := &config.Agent{
+		Name:           config.ControlDispatcherAgentName,
+		Dir:            "gascity",
+		PromptTemplate: "prompts/control-dispatcher.template.md",
+		StartCommand:   "custom-control-dispatcher --serve",
+		Nudge:          "configured startup nudge",
+		ProcessNames:   []string{"custom-control-dispatcher"},
+	}
+
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if !strings.Contains(tp.Prompt, "startup prompt for "+agent.QualifiedName()) {
+		t.Fatalf("Prompt = %q, want rendered startup prompt for explicit agent", tp.Prompt)
+	}
+	cfg := templateParamsToConfig(tp)
+	if cfg.PromptSuffix != "" {
+		t.Fatalf("PromptSuffix = %q, want prompt delivered by nudge for start_command prompt_mode=none", cfg.PromptSuffix)
+	}
+	if !strings.Contains(cfg.Nudge, "startup prompt for "+agent.QualifiedName()) {
+		t.Fatalf("Nudge = %q, want startup prompt for explicit agent", cfg.Nudge)
+	}
+	if !strings.Contains(cfg.Nudge, "configured startup nudge") {
+		t.Fatalf("Nudge = %q, want configured nudge preserved", cfg.Nudge)
+	}
+	if cfg.AcceptStartupDialogs != nil {
+		t.Fatalf("AcceptStartupDialogs = %v, want no deterministic suppression override", cfg.AcceptStartupDialogs)
+	}
+	if !reflect.DeepEqual(cfg.ProcessNames, []string{"custom-control-dispatcher"}) {
+		t.Fatalf("ProcessNames = %v, want [custom-control-dispatcher]", cfg.ProcessNames)
 	}
 }
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -6659,9 +6659,7 @@ func TestRunRalphCheckResolvesRelativeWorkDirAgainstCityPath(t *testing.T) {
 	}
 
 	checkPath := filepath.Join(checkDir, "pass.sh")
-	if err := os.WriteFile(checkPath, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write check script: %v", err)
-	}
+	writeExecutableScript(t, checkPath, "#!/usr/bin/env bash\nexit 0\n")
 
 	store := beads.NewMemStore()
 	check := beads.Bead{
@@ -6794,9 +6792,7 @@ func TestRunRalphCheckUsesStorePathForRelativeCheckAndSubjectEnv(t *testing.T) {
 		"printf 'CITY=%s\\n' \"$GC_CITY\"\n" +
 		"printf 'STORE=%s\\n' \"$GC_STORE_PATH\"\n" +
 		"printf 'BEADS=%s\\n' \"$BEADS_DIR\"\n"
-	if err := os.WriteFile(checkPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write check script: %v", err)
-	}
+	writeExecutableScript(t, checkPath, script)
 
 	store := beads.NewMemStore()
 	check := beads.Bead{
@@ -6855,9 +6851,7 @@ func TestRunRalphCheckRigScopedRelativeCheckPathResolvesAgainstStore(t *testing.
 		t.Fatalf("mkdir: %v", err)
 	}
 	scriptPath := filepath.Join(scriptDir, "check.sh")
-	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write script: %v", err)
-	}
+	writeExecutableScript(t, scriptPath, "#!/bin/sh\nexit 0\n")
 
 	store := beads.NewMemStore()
 	check := beads.Bead{
@@ -6899,9 +6893,7 @@ func TestRunRalphCheckRejectsPathTraversalAboveCityPath(t *testing.T) {
 		t.Fatalf("mkdir outside: %v", err)
 	}
 	outsideScript := filepath.Join(outsideDir, "check.sh")
-	if err := os.WriteFile(outsideScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write script: %v", err)
-	}
+	writeExecutableScript(t, outsideScript, "#!/bin/sh\nexit 0\n")
 
 	store := beads.NewMemStore()
 	check := beads.Bead{
@@ -6933,9 +6925,19 @@ func writeCheckScript(t *testing.T, cityPath, name, contents string) string {
 		t.Fatalf("mkdir script dir: %v", err)
 	}
 	scriptPath := filepath.Join(scriptDir, name)
-	tmp, err := os.CreateTemp(scriptDir, "."+name+".tmp-*")
+	writeExecutableScript(t, scriptPath, contents)
+	return filepath.ToSlash(filepath.Join(".gc", "scripts", name))
+}
+
+func writeExecutableScript(t *testing.T, scriptPath, contents string) {
+	t.Helper()
+	scriptDir := filepath.Dir(scriptPath)
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	tmp, err := os.CreateTemp(scriptDir, "."+filepath.Base(scriptPath)+".tmp-*")
 	if err != nil {
-		t.Fatalf("create temp script %s: %v", name, err)
+		t.Fatalf("create temp script %s: %v", scriptPath, err)
 	}
 	tmpPath := tmp.Name()
 	keepTemp := true
@@ -6946,19 +6948,18 @@ func writeCheckScript(t *testing.T, cityPath, name, contents string) string {
 	}()
 	if _, err := tmp.WriteString(contents); err != nil {
 		_ = tmp.Close()
-		t.Fatalf("write %s: %v", name, err)
+		t.Fatalf("write %s: %v", scriptPath, err)
 	}
 	if err := tmp.Close(); err != nil {
-		t.Fatalf("close %s: %v", name, err)
+		t.Fatalf("close %s: %v", scriptPath, err)
 	}
 	if err := os.Chmod(tmpPath, 0o755); err != nil {
-		t.Fatalf("chmod %s: %v", name, err)
+		t.Fatalf("chmod %s: %v", scriptPath, err)
 	}
 	if err := os.Rename(tmpPath, scriptPath); err != nil {
-		t.Fatalf("install %s: %v", name, err)
+		t.Fatalf("install %s: %v", scriptPath, err)
 	}
 	keepTemp = false
-	return filepath.ToSlash(filepath.Join(".gc", "scripts", name))
 }
 
 func newSimpleRalphLoopInStore(t *testing.T, store beads.Store, stepID, checkPath string, maxAttempts int) (beads.Bead, beads.Bead, beads.Bead) {


### PR DESCRIPTION
Post-merge remediation for #2419.

This follow-up:
- replaces name-keyed startup prompt suppression with a structural implicit start-command infrastructure predicate
- keeps explicit/user-configured `control-dispatcher` agents on the normal startup prompt/nudge path, with a negative test
- makes assigned-skills appendix gating use the suppression invariant directly
- applies the atomic executable script helper consistently across the adjacent ralph-check tests

Validation:
- `go test -count=1 ./cmd/gc -run 'TestResolveTemplateControlDispatcherSuppressesStartupPrompt|TestResolveTemplateExplicitControlDispatcherKeepsStartupPrompt|TestTemplateParamsToConfigNoneModeUsesNudge'`
- `go test -count=1 ./internal/config -run 'TestResolveProviderAgentStartCommand|TestInjectImplicitAgents_NoProviders'`
- `go test -count=1 ./internal/dispatch -run 'TestRunRalphCheckResolvesRelativeWorkDirAgainstCityPath|TestRunRalphCheckUsesStorePathForRelativeCheckAndSubjectEnv|TestRunRalphCheckRigScopedRelativeCheckPathResolvesAgainstStore|TestRunRalphCheckRejectsPathTraversalAboveCityPath'`
- `go vet ./cmd/gc ./internal/config ./internal/dispatch`
- `.githooks/pre-commit`
