### PR TITLE
feat: provider-aware quality-gate fallback to repo instruction file

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -307,6 +307,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		if a.PromptTemplate != "" || hookMode || sessionTemplateContext {
 			ctx = buildPrimeContext(cityPath, cityName, &a, cfg.Rigs, stderr)
 			ctx.ProviderKey, ctx.ProviderDisplayName = providerInfoForAgent(&a, &cfg.Workspace, cfg.Providers)
+			ctx.InstructionsFile = instructionsFileForAgent(&a, &cfg.Workspace, cfg.Providers)
 		}
 		if a.PromptTemplate != "" {
 			fragments := effectivePromptFragments(

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -47,7 +47,14 @@ type PromptContext struct {
 	// builtins, then the builtin family of a custom provider; falls back to
 	// ProviderKey when nothing else matches.
 	ProviderDisplayName string
-	Env                 map[string]string // from Agent.Env — custom vars
+	// InstructionsFile is the filename the resolved provider reads for project
+	// instructions (e.g. "CLAUDE.md" for claude, "AGENTS.md" for codex/kiro).
+	// Resolved from city providers, then builtins, then the builtin family of a
+	// custom provider; defaults to "AGENTS.md" when no provider is configured.
+	// Templates use {{ .InstructionsFile }} as a provider-aware fallback when
+	// pack-specific guidance (e.g. quality-gate commands) is missing or empty.
+	InstructionsFile string
+	Env              map[string]string // from Agent.Env — custom vars
 }
 
 // PromptRenderResult holds the rendered text plus the version and rendered
@@ -301,6 +308,7 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	m["SlingQuery"] = ctx.SlingQuery
 	m["ProviderKey"] = ctx.ProviderKey
 	m["ProviderDisplayName"] = ctx.ProviderDisplayName
+	m["InstructionsFile"] = ctx.InstructionsFile
 	return m
 }
 
@@ -412,6 +420,39 @@ func providerInfoForAgent(a *config.Agent, ws *config.Workspace, cityProviders m
 		return "", ""
 	}
 	return name, providerDisplayNameFor(name, cityProviders)
+}
+
+// instructionsFileForAgent returns the project-instructions filename the
+// resolved provider expects (e.g. "CLAUDE.md", "AGENTS.md"). It mirrors the
+// resolution chain used by providerInfoForAgent (agent.Provider >
+// workspace.Provider) and looks the filename up via the same precedence as
+// config.ResolveProvider (city providers > builtin spec > builtin family).
+// Returns "AGENTS.md" — the same default config.resolveProvider uses — when no
+// provider is configured or the resolved spec leaves InstructionsFile empty.
+func instructionsFileForAgent(a *config.Agent, ws *config.Workspace, cityProviders map[string]config.ProviderSpec) string {
+	const defaultInstructionsFile = "AGENTS.md"
+	if a == nil {
+		return defaultInstructionsFile
+	}
+	name := a.Provider
+	if name == "" && ws != nil {
+		name = ws.Provider
+	}
+	if name == "" {
+		return defaultInstructionsFile
+	}
+	if spec, ok := cityProviders[name]; ok && spec.InstructionsFile != "" {
+		return spec.InstructionsFile
+	}
+	if spec, ok := config.BuiltinProviders()[name]; ok && spec.InstructionsFile != "" {
+		return spec.InstructionsFile
+	}
+	if family := config.BuiltinFamily(name, cityProviders); family != "" && family != name {
+		if spec, ok := config.BuiltinProviders()[family]; ok && spec.InstructionsFile != "" {
+			return spec.InstructionsFile
+		}
+	}
+	return defaultInstructionsFile
 }
 
 // providerDisplayNameFor returns the human-readable name for a provider.

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -1008,6 +1008,120 @@ func TestEmbeddedMayorPromptRendersProviderSpecificSlashNote(t *testing.T) {
 	}
 }
 
+func TestInstructionsFileForAgentClaudeReturnsCLAUDEMD(t *testing.T) {
+	ws := &config.Workspace{Provider: "claude"}
+	got := instructionsFileForAgent(&config.Agent{}, ws, nil)
+	if got != "CLAUDE.md" {
+		t.Errorf("InstructionsFile = %q, want %q", got, "CLAUDE.md")
+	}
+}
+
+func TestInstructionsFileForAgentCodexReturnsAGENTSMD(t *testing.T) {
+	ws := &config.Workspace{Provider: "codex"}
+	got := instructionsFileForAgent(&config.Agent{}, ws, nil)
+	if got != "AGENTS.md" {
+		t.Errorf("InstructionsFile = %q, want %q", got, "AGENTS.md")
+	}
+}
+
+func TestInstructionsFileForAgentDefaultsToAGENTSMDWhenUnset(t *testing.T) {
+	got := instructionsFileForAgent(&config.Agent{}, &config.Workspace{}, nil)
+	if got != "AGENTS.md" {
+		t.Errorf("InstructionsFile = %q, want %q (default)", got, "AGENTS.md")
+	}
+}
+
+func TestInstructionsFileForAgentResolvesAgentOverWorkspace(t *testing.T) {
+	ws := &config.Workspace{Provider: "codex"}
+	a := &config.Agent{Provider: "claude"}
+	got := instructionsFileForAgent(a, ws, nil)
+	if got != "CLAUDE.md" {
+		t.Errorf("InstructionsFile = %q, want %q (agent.Provider beats workspace.Provider)", got, "CLAUDE.md")
+	}
+}
+
+func TestInstructionsFileForAgentUsesCityOverride(t *testing.T) {
+	// A custom provider declared in city.toml with InstructionsFile set
+	// takes precedence over its builtin family default.
+	cityProviders := map[string]config.ProviderSpec{
+		"custom-claude": {
+			Command:          "claude-fork",
+			InstructionsFile: "INSTRUCTIONS.md",
+		},
+	}
+	ws := &config.Workspace{Provider: "custom-claude"}
+	got := instructionsFileForAgent(&config.Agent{}, ws, cityProviders)
+	if got != "INSTRUCTIONS.md" {
+		t.Errorf("InstructionsFile = %q, want %q (city override)", got, "INSTRUCTIONS.md")
+	}
+}
+
+func TestInstructionsFileForAgentFallsBackToBuiltinFamily(t *testing.T) {
+	// A custom provider with empty InstructionsFile but a builtin family
+	// inherits the family's filename. `kiro` (a claude-family fork) is the
+	// canonical case from internal/config/chain_test.go; here we mimic that
+	// pattern with a synthetic provider whose Base points at "claude".
+	base := "claude"
+	cityProviders := map[string]config.ProviderSpec{
+		"my-fork": {
+			Base:    &base,
+			Command: "my-fork",
+		},
+	}
+	ws := &config.Workspace{Provider: "my-fork"}
+	got := instructionsFileForAgent(&config.Agent{}, ws, cityProviders)
+	if got != "CLAUDE.md" {
+		t.Errorf("InstructionsFile = %q, want %q (inherited from claude family)", got, "CLAUDE.md")
+	}
+}
+
+func TestRenderedCrewPromptShowsProviderSpecificInstructionsFile(t *testing.T) {
+	// Regression test for Wasteland w-d4dba7b056: the Gastown pack's crew
+	// prompt should reference the provider-specific instruction filename as
+	// the fallback for missing/empty quality-gate guidance.
+	//
+	// Two assertions: (a) the shipped crew.template.md references the
+	// {{ .InstructionsFile }} placeholder in the expected backtick pattern,
+	// and (b) renderPrompt substitutes that placeholder to the right value
+	// for each provider via buildTemplateData. Asserting (a)+(b)
+	// independently keeps the test stable when crew.template.md gains new
+	// fragment includes that would otherwise break a full-render assertion.
+	crewPath := filepath.Join("..", "..", "examples", "gastown", "packs", "gastown", "assets", "prompts", "crew.template.md")
+	source, err := os.ReadFile(crewPath)
+	if err != nil {
+		t.Skipf("crew.template.md not readable at %s: %v", crewPath, err)
+	}
+	if !strings.Contains(string(source), "`{{ .InstructionsFile }}`") {
+		t.Fatalf("crew.template.md missing fallback marker `{{ .InstructionsFile }}` (w-d4dba7b056 regression)")
+	}
+
+	cases := []struct {
+		providerKey string
+		wantFile    string
+	}{
+		{"claude", "CLAUDE.md"},
+		{"codex", "AGENTS.md"},
+		{"", "AGENTS.md"},
+	}
+
+	const tmplBody = "fallback: (`{{ .InstructionsFile }}`)"
+	for _, tc := range cases {
+		f := fsys.NewFake()
+		f.Files["/city/prompts/p.template.md"] = []byte(tmplBody)
+		ws := &config.Workspace{Provider: tc.providerKey}
+		got := renderPrompt(f, "/city", "test-city", "prompts/p.template.md",
+			PromptContext{
+				ProviderKey:      tc.providerKey,
+				InstructionsFile: instructionsFileForAgent(&config.Agent{}, ws, nil),
+			},
+			"", io.Discard, nil, nil, nil)
+		want := "fallback: (`" + tc.wantFile + "`)"
+		if got != want {
+			t.Errorf("ProviderKey=%q: rendered = %q, want %q", tc.providerKey, got, want)
+		}
+	}
+}
+
 func TestProviderDisplayNameFallsBackToKeyForUnknownProvider(t *testing.T) {
 	ws := &config.Workspace{Provider: "totally-unknown"}
 	a := &config.Agent{}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -314,6 +314,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		SlingQuery:          expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "sling_query", cfgAgent.EffectiveSlingQuery(), p.stderr),
 		ProviderKey:         providerKey,
 		ProviderDisplayName: providerDisplayName,
+		InstructionsFile:    instructionsFileForAgent(cfgAgent, p.workspace, p.providers),
 		Env:                 cfgAgent.Env,
 	}, p.sessionTemplate, p.stderr, p.packDirs, fragments, p.beadStore)
 	hasHooks := config.AgentHasHooks(cfgAgent, p.workspace, resolved.Name, p.providers)

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -44,6 +44,18 @@ the bead. No separate MR beads.
 
 Your formula: `mol-refinery-patrol`
 
+## Quality-Gate Fallback
+
+The `run-tests` step reads `setup_command`, `typecheck_command`,
+`lint_command`, `build_command`, and `test_command` from the wisp's
+vars. When the pack ships no commands for this rig (all of those vars
+are empty), do not silently skip the gates. Read this repo's
+project-instructions file, **`{{ .InstructionsFile }}`**, and run
+the quality gates documented there instead. Treat their failures the
+same as failures from configured commands (reject or file pre-existing
+bug, per the formula's `handle-failures` step). The fallback preserves
+the quality-gate intent even when pack-specific guidance is missing.
+
 ---
 
 ## Startup

--- a/examples/gastown/packs/gastown/assets/prompts/crew.template.md
+++ b/examples/gastown/packs/gastown/assets/prompts/crew.template.md
@@ -335,6 +335,11 @@ you are!" - that is a FAILURE. YOU must push, not the user.
    go test ./...             # or: make test
    golangci-lint run ./...   # or: make lint
    ```
+   If these don't apply to this repo (non-Go project) or no commands are
+   configured for your wisp, fall back to the repo's instruction file
+   (`{{ .InstructionsFile }}`) for the project-specific quality gates and
+   run those instead. Do not skip the gates — the fallback preserves the
+   intent even when pack-specific guidance is missing or empty.
    File P0 beads if quality gates are broken.
 
 3. **Update beads** - close finished work, update status:

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -242,6 +242,15 @@ If run_tests = "true":
 
 If run_tests = "false": skip tests entirely.
 
+**Fallback when this wisp has no quality-gate commands configured** (all of
+setup_command, typecheck_command, lint_command, build_command, test_command
+empty): do not silently skip. Read the repo's project-instructions file
+(CLAUDE.md or AGENTS.md — whichever the configured provider expects; your
+agent prompt lists the exact filename) and run the quality gates it
+documents. Treat their failures the same way you would treat failures
+from configured commands. The fallback preserves the quality-gate intent
+when pack-specific guidance is missing.
+
 Track results: which checks ran, pass/fail, specific failures.
 Close this step when all checks complete (pass or fail)."""
 


### PR DESCRIPTION
## Summary

When the Gastown pack ships no quality-gate guidance for a rig — or a wisp's `setup_command` / `typecheck_command` / `lint_command` / `build_command` / `test_command` vars are all empty — agents currently effectively skip gates. This wires a provider-aware fallback so the rendered crew prompt and refinery patrol formula direct agents at the repo's own instruction file (`CLAUDE.md` for claude, `AGENTS.md` for codex/kiro/others) and run the gates documented there instead.

Closes wasteland item `w-d4dba7b056`.

## How

- Add `InstructionsFile` to `PromptContext` and to the `buildTemplateData` map so templates can reference `{{ .InstructionsFile }}`.
- New `instructionsFileForAgent()` helper resolves the right filename via the same chain as `providerInfoForAgent`: `agent.Provider` → `workspace.Provider` → city providers → builtin spec → builtin family. Defaults to `AGENTS.md`, matching `config.resolveProvider`.
- Wire it into `resolveTemplate()` (session / agent rendering) and `doPrimeWithHookFormat()` (the `gc prime` path).
- Crew prompt: add a 4-line fallback note after the `go test` / `golangci-lint` block.
- Refinery prompt: add a `Quality-Gate Fallback` section.
- `mol-refinery-patrol.toml`: extend the `run-tests` step so the refinery doesn't silently green-light wisps with no configured commands.

Complementary to #2008 (`w-c243404137`), which added a `bd doctor` check for missing `InstructionsFile`. That PR caught the misconfiguration; this PR makes the runtime prompt actually use the resolved file as a fallback.

## Test plan

- [x] `go build ./cmd/gc/...`
- [x] `go vet ./cmd/gc/...`
- [x] `go test -run 'Prompt|Template|Instructions' ./cmd/gc/` — passes (`12.8s`)
  - Includes new `TestInstructionsFileForAgent*` (resolution chain) and `TestRenderedCrewPromptShowsProviderSpecificInstructionsFile` (pins the placeholder in the shipped crew template + asserts substitution).
- [ ] Full suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)