### PR TITLE
fix(supervisor): widen provider-credential env prefix list

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -800,11 +800,61 @@ var supervisorServiceEnvKeys = map[string]bool{
 	"XDG_STATE_HOME":                           true,
 }
 
+// providerCredentialEnvPrefixes lists env-var name prefixes whose values are
+// treated as agent-provider credentials and forwarded into the supervisor's
+// persistent env (launchd plist / systemd unit) and into spawned agent
+// processes. The same predicate gates the global baseline in cmd_start.go:
+// the SDK cannot know which agent uses which provider (zero hardcoded
+// roles), so credentials for any known provider are passed through, and the
+// trust boundary is the managed session itself.
+//
+// The list is curated, not auto-discovered: the supervisor's persistent env
+// has a bounded size (launchd plists in particular), so we only forward
+// prefixes belonging to well-known LLM provider auth schemes. Users with
+// niche or in-house providers can opt in via GC_SUPERVISOR_ENV.
+//
+// Keep alphabetised. Documented providers (with the env vars they typically
+// use):
+//
+//	ANTHROPIC_   Anthropic / Claude (ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, ...)
+//	AWS_         AWS Bedrock auth (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+//	             AWS_REGION, AWS_PROFILE, AWS_SESSION_TOKEN,
+//	             AWS_BEARER_TOKEN_BEDROCK, ...)
+//	AZURE_       Azure OpenAI (AZURE_OPENAI_API_KEY, AZURE_OPENAI_BASE_URL,
+//	             AZURE_OPENAI_API_VERSION, AZURE_OPENAI_ENDPOINT, ...)
+//	CEREBRAS_    Cerebras (CEREBRAS_API_KEY)
+//	COHERE_      Cohere (COHERE_API_KEY)
+//	DEEPSEEK_    DeepSeek (DEEPSEEK_API_KEY)
+//	FIREWORKS_   Fireworks AI (FIREWORKS_API_KEY)
+//	GEMINI_      Google Gemini direct API (GEMINI_API_KEY)
+//	GOOGLE_      Google Cloud / Vertex (GOOGLE_API_KEY,
+//	             GOOGLE_APPLICATION_CREDENTIALS, GOOGLE_CLOUD_PROJECT, ...)
+//	GROQ_        Groq (GROQ_API_KEY)
+//	MISTRAL_     Mistral (MISTRAL_API_KEY)
+//	OLLAMA_      Ollama local (OLLAMA_API_KEY, OLLAMA_HOST, OLLAMA_BASE_URL)
+//	OPENAI_      OpenAI (OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_API_VERSION)
+//	OPENROUTER_  OpenRouter (OPENROUTER_API_KEY)
+//	TOGETHER_    Together AI (TOGETHER_API_KEY)
+//	VERTEX_      Vertex AI direct (VERTEX_PROJECT_ID, VERTEX_LOCATION, ...)
+//	XAI_         xAI / Grok (XAI_API_KEY)
 var providerCredentialEnvPrefixes = []string{
 	"ANTHROPIC_",
+	"AWS_",
+	"AZURE_",
+	"CEREBRAS_",
+	"COHERE_",
+	"DEEPSEEK_",
+	"FIREWORKS_",
 	"GEMINI_",
 	"GOOGLE_",
+	"GROQ_",
+	"MISTRAL_",
+	"OLLAMA_",
 	"OPENAI_",
+	"OPENROUTER_",
+	"TOGETHER_",
+	"VERTEX_",
+	"XAI_",
 }
 
 var supervisorServiceFixedEnvKeys = map[string]bool{

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -575,6 +575,58 @@ func supervisorServiceEnvMap(vars []supervisorServiceEnvVar) map[string]string {
 	return m
 }
 
+// TestBuildSupervisorServiceDataForwardsAllKnownProviderPrefixes asserts that
+// a canonical env var for every prefix in providerCredentialEnvPrefixes is
+// forwarded into the supervisor's persistent env. This is the regression
+// protection for the curated provider-prefix list: if a prefix is removed,
+// the corresponding probe key here fails and surfaces the omission.
+func TestBuildSupervisorServiceDataForwardsAllKnownProviderPrefixes(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+
+	// One canonical probe key per documented prefix.
+	probes := map[string]string{
+		"ANTHROPIC_API_KEY":    "sk-ant-probe",
+		"AWS_ACCESS_KEY_ID":    "AKIA-probe",
+		"AZURE_OPENAI_API_KEY": "azure-openai-probe",
+		"CEREBRAS_API_KEY":     "cb-probe",
+		"COHERE_API_KEY":       "cohere-probe",
+		"DEEPSEEK_API_KEY":     "ds-probe",
+		"FIREWORKS_API_KEY":    "fw-probe",
+		"GEMINI_API_KEY":       "gemini-probe",
+		"GOOGLE_CLOUD_PROJECT": "google-probe-project",
+		"GROQ_API_KEY":         "groq-probe",
+		"MISTRAL_API_KEY":      "mistral-probe",
+		"OLLAMA_HOST":          "http://localhost:11434",
+		"OPENAI_API_KEY":       "sk-openai-probe",
+		"OPENROUTER_API_KEY":   "or-probe",
+		"TOGETHER_API_KEY":     "together-probe",
+		"VERTEX_PROJECT_ID":    "vertex-probe-project",
+		"XAI_API_KEY":          "xai-probe",
+	}
+	if len(probes) != len(providerCredentialEnvPrefixes) {
+		t.Fatalf("probe set size %d does not match prefix list size %d; update the test when prefixes change",
+			len(probes), len(providerCredentialEnvPrefixes))
+	}
+	for k, v := range probes {
+		t.Setenv(k, v)
+	}
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for k, want := range probes {
+		if got[k] != want {
+			t.Errorf("ExtraEnv[%s] = %q, want %q — prefix may be missing from providerCredentialEnvPrefixes", k, got[k], want)
+		}
+	}
+}
+
 func TestBuildSupervisorServiceDataReadsAllowlistedDoltCredentialKeysFromLaunchctl(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)


### PR DESCRIPTION
## What

`providerCredentialEnvPrefixes` (`cmd/gc/cmd_supervisor_lifecycle.go`) is the list of env-var name prefixes that gate which credentials get forwarded into the supervisor's persistent env (launchd plist on macOS / systemd unit on Linux) and into spawned agent processes via the global baseline.

Previous list:

```go
ANTHROPIC_
GEMINI_
GOOGLE_
OPENAI_
```

This silently dropped mainstream LLM provider auth schemes — most visibly Azure OpenAI, which Gas Town's `omp`-provider agents use heavily, but also AWS Bedrock and several others.

Concrete repro that motivated this PR: a Mayor agent.toml configured for `omp` (azure/gpt-5.5) with `[env].AZURE_OPENAI_API_KEY = "$AZURE_OPENAI_API_KEY"`. The env-expansion path (`expandEnvMap` → `os.ExpandEnv` at `cmd/gc/template_resolve.go:376`) ran correctly, but the supervisor's launchd-spawned env had no `AZURE_*` keys to expand from — the shell `.zshrc` exports never reached the supervisor because the launchd plist's `EnvironmentVariables` block scopes its env, and the `AZURE_` prefix wasn't in the allowlist. So the value resolved to empty, and the agent failed to authenticate.

## What this PR changes

Widens the prefix list to cover mainstream LLM providers:

```
ANTHROPIC_   AWS_         AZURE_      CEREBRAS_   COHERE_     DEEPSEEK_
FIREWORKS_   GEMINI_      GOOGLE_     GROQ_       MISTRAL_    OLLAMA_
OPENAI_      OPENROUTER_  TOGETHER_   VERTEX_     XAI_
```

Adds a regression test (`TestBuildSupervisorServiceDataForwardsAllKnownProviderPrefixes`) that asserts every prefix has at least one canonical probe key surviving the predicate. The test's size assertion against `len(providerCredentialEnvPrefixes)` forces the test to be updated alongside any future prefix change — drop a prefix, the probe set fails to match the list size and the test names exactly which probe key didn't make it.

## Architectural principle

ZFC (Zero Framework Cognition), already cited at `cmd/gc/cmd_start.go:1226-1228` where the same predicate gates the global baseline:

> *"Agent credentials are included in the global baseline because the SDK cannot know which agent uses which provider (zero hardcoded roles); the trust boundary is the managed session itself."*

That principle is the direct argument for the wider list: the SDK shouldn't know Anthropic and OpenAI while not knowing Azure, AWS, Mistral, Cohere, Groq, etc. — the predicate's job is provider-agnostic credential passthrough.

The list stays curated rather than auto-discovered (e.g., `*_API_KEY` suffix matching) because:
1. The launchd plist has bounded size and we don't want arbitrary shell state persisted there.
2. A suffix-pattern would also catch unrelated keys (`GH_TOKEN`, project-local `FOO_API_KEY`s, etc.) that aren't provider creds.
3. Users with niche or in-house providers retain the explicit opt-in via `GC_SUPERVISOR_ENV`.

## Test

```bash
go test -run TestBuildSupervisorServiceData ./cmd/gc/ -count=1
```

The full `make test-fast-parallel` is currently red on macOS due to pre-existing Linux-only assumptions (e.g., `/proc/<pid>/exe` lookups in `TestRunStartDriftCheck_*`). Confirmed by running the same failing tests against bare `upstream/main` after stashing this diff — same failures. Not related to this change.

## Watch list

- [ ] Maintainer "Approve and run workflows" gate (fork-author PR)
- [ ] CI green after maintainer approval
- [ ] Review feedback addressed
- [ ] Merge upstream → drop local carry on next rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)