### PR TITLE
fix: async drain-ack session stops

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
-	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -97,6 +96,7 @@ type CityRuntime struct {
 	sessionDrains     *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
 	asyncStartLimiter *asyncStartLimiter
 	asyncStarts       asyncStartTracker
+	asyncStops        asyncStartTracker
 	demandSnapshot    *runtimeDemandSnapshot
 
 	fsPressureConsecutiveSkips int
@@ -882,12 +882,16 @@ func (cr *CityRuntime) tick(
 	// so stale names cannot block desired-state computation (#742).
 	phaseStart = time.Now()
 	cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
+	recordPhase(TraceSiteControllerTickPhase, "cleanup_dead_runtime_session_corpses", phaseStart, nil)
 	// Reap live runtimes still bound to a closed bead (e.g. a named-session
 	// identity re-minted as a pool slot) so the name's current owner can rebind
 	// it and attach lands on the right runtime.
+	phaseStart = time.Now()
 	reapRuntimesBoundToClosedBeads(cr.cityBeadStore(), sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
+	recordPhase(TraceSiteControllerTickPhase, "reap_runtimes_bound_to_closed_beads", phaseStart, nil)
+	phaseStart = time.Now()
 	reaped := reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr)
-	recordPhase(TraceSiteControllerTickPhase, "cleanup_dead_and_stale_sessions", phaseStart, map[string]any{"reaped": reaped})
+	recordPhase(TraceSiteControllerTickPhase, "reap_stale_session_beads", phaseStart, map[string]any{"reaped": reaped})
 	if reaped > 0 {
 		phaseStart = time.Now()
 		sessionBeads = cr.loadSessionBeadSnapshot()
@@ -908,6 +912,7 @@ func (cr *CityRuntime) tick(
 			sessionBeads.Open(),
 			cr.dops,
 			cr.sessionDrains,
+			&cr.asyncStops,
 			clock.Real{},
 			cr.rec,
 			cr.stderr,
@@ -1867,6 +1872,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		withAsyncStartFollowUp(cr.requestAsyncStartFollowUpTick),
 		withAsyncStartLimiter(cr.ensureAsyncStartLimiter()),
 		withAsyncStartTracker(&cr.asyncStarts),
+		withAsyncDrainAckStopTracker(&cr.asyncStops),
 		withMaxSessionAgeTracker(cr.mat),
 	)
 	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.reconcile_sessions", phaseStart, map[string]any{
@@ -2040,6 +2046,26 @@ func (cr *CityRuntime) waitForAsyncStarts() bool {
 	return true
 }
 
+func (cr *CityRuntime) waitForAsyncStops() bool {
+	if cr == nil {
+		return true
+	}
+	timeout := time.Duration(0)
+	if cr.cfg != nil {
+		timeout = cr.cfg.Daemon.ShutdownTimeoutDuration()
+	}
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	if !cr.asyncStops.waitUntil(timeout, cr.forceStopRequested) {
+		if cr.stderr != nil && !cr.forceStopRequested() {
+			fmt.Fprintf(cr.stderr, "%s: async drain-ack stops still running after %s; continuing shutdown\n", cr.logPrefix, timeout) //nolint:errcheck // best-effort stderr
+		}
+		return false
+	}
+	return true
+}
+
 func sweepUndesiredPoolSessionBeads(
 	store beads.Store,
 	rigStores map[string]beads.Store,
@@ -2150,13 +2176,16 @@ func sweepUndesiredPoolSessionBeads(
 
 func poolSessionBeadRuntimeRunning(bead beads.Bead, sp runtime.Provider) (bool, error) {
 	if sp == nil {
-		return false, sessionpkg.ErrSessionNotFound
+		return false, fmt.Errorf("pool session runtime check: %w", runtime.ErrSessionNotFound)
 	}
 	name := strings.TrimSpace(bead.Metadata["session_name"])
 	if name == "" {
-		return false, sessionpkg.ErrSessionNotFound
+		return false, fmt.Errorf("pool session runtime check missing session name: %w", runtime.ErrSessionNotFound)
 	}
-	return sp.IsRunning(name), nil
+	// The sweep only needs provider-runtime presence, not process aliveness or
+	// attachment/activity details. ObserveLiveness preserves provider-native
+	// running semantics without the heavier worker observation path.
+	return runtime.ObserveLiveness(sp, name, nil).Running, nil
 }
 
 // pendingCreateClaimStillLeasedForSweep keeps pending_create_claim protection
@@ -2656,6 +2685,7 @@ func (cr *CityRuntime) recordPreservedShutdownTrace() {
 func (cr *CityRuntime) shutdown() {
 	cr.shutdownOnce.Do(func() {
 		asyncStartsDrained := cr.waitForAsyncStarts()
+		cr.waitForAsyncStops()
 		preserveSessions := cr.preserveSessionsShutdown.Load()
 		if preserveSessions {
 			cr.recordPreservedShutdownTrace()

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -839,7 +840,15 @@ func (cr *CityRuntime) tick(
 		cr.resetFSPressureEpisode()
 	}
 
+	recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
+		if trace != nil {
+			trace.RecordControllerOperation(site, TraceReasonRetained, TraceOutcomeComplete, name, time.Since(start), fields)
+		}
+	}
+
+	phaseStart := time.Now()
 	cr.ensureManagedDoltPublishedForTick()
+	recordPhase(TraceSiteControllerTickPhase, "managed_dolt_preflight", phaseStart, nil)
 	if ctx.Err() != nil {
 		return
 	}
@@ -848,12 +857,16 @@ func (cr *CityRuntime) tick(
 	// phases so due formulas are not starved by slow startup/config drift work,
 	// but after the pressure gate and managed-Dolt preflight so skipped or
 	// endpoint-repair ticks do not add tracking writes first.
+	phaseStart = time.Now()
 	cr.dispatchOrders(ctx, cityRoot)
+	recordPhase(TraceSiteOrderDispatch, "dispatch_orders", phaseStart, nil)
 	if ctx.Err() != nil {
 		return
 	}
 
+	phaseStart = time.Now()
 	sessionBeads := cr.loadSessionBeadSnapshot()
+	recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.initial", phaseStart, traceSessionSnapshotFields(sessionBeads))
 	if trace != nil && sessionBeads != nil {
 		trace.RecordSessionBaseline("", "", traceRecordPayload{
 			"open_count": len(sessionBeads.Open()),
@@ -867,20 +880,61 @@ func (cr *CityRuntime) tick(
 	// the reconciler to read/write hashes during reconciliation.
 	// Reap open session beads whose tmux session is dead before loading demand
 	// so stale names cannot block desired-state computation (#742).
+	phaseStart = time.Now()
 	cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
 	// Reap live runtimes still bound to a closed bead (e.g. a named-session
 	// identity re-minted as a pool slot) so the name's current owner can rebind
 	// it and attach lands on the right runtime.
 	reapRuntimesBoundToClosedBeads(cr.cityBeadStore(), sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
-	if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
+	reaped := reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr)
+	recordPhase(TraceSiteControllerTickPhase, "cleanup_dead_and_stale_sessions", phaseStart, map[string]any{"reaped": reaped})
+	if reaped > 0 {
+		phaseStart = time.Now()
 		sessionBeads = cr.loadSessionBeadSnapshot()
+		recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_reap", phaseStart, traceSessionSnapshotFields(sessionBeads))
 	}
 	if ctx.Err() != nil {
 		return
 	}
+	phaseStart = time.Now()
+	finalizedDrainAckStops := 0
+	if sessionBeads != nil {
+		finalizedDrainAckStops = finalizeDrainAckStopPendingSessions(
+			cr.cityPath,
+			cr.cfg,
+			cr.sp,
+			cr.cityBeadStore(),
+			cr.rigBeadStores(),
+			sessionBeads.Open(),
+			cr.dops,
+			cr.sessionDrains,
+			clock.Real{},
+			cr.rec,
+			cr.stderr,
+		)
+	}
+	recordPhase(TraceSiteControllerTickPhase, "finalize_drain_ack_stop_pending", phaseStart, map[string]any{
+		"finalized": finalizedDrainAckStops,
+	})
+	if finalizedDrainAckStops > 0 {
+		phaseStart = time.Now()
+		sessionBeads = cr.loadSessionBeadSnapshot()
+		recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_drain_ack_stop_pending", phaseStart, traceSessionSnapshotFields(sessionBeads))
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	phaseStart = time.Now()
 	demand := cr.loadDemandSnapshot(sessionBeads, trace, trigger, configChanged)
+	recordPhase(TraceSiteDemandSnapshot, "load_demand_snapshot", phaseStart, map[string]any{
+		"config_changed": configChanged,
+		"trigger":        trigger,
+	})
 	result := demand.result
+	phaseStart = time.Now()
 	sessionBeads = cr.loadSessionBeadSnapshot()
+	recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_demand", phaseStart, traceSessionSnapshotFields(sessionBeads))
+	phaseStart = time.Now()
 	result = refreshDesiredStateWithSessionBeads(
 		result,
 		cr.cityName,
@@ -891,12 +945,18 @@ func (cr *CityRuntime) tick(
 		sessionBeads,
 		cr.stderr,
 	)
+	recordPhase(TraceSiteDesiredStateBuild, "refresh_desired_state.before_sync", phaseStart, traceDesiredStateFields(result))
+	phaseStart = time.Now()
 	_ = cr.syncBeadsAndUpdateIndex(result.State, sessionBeads)
+	recordPhase(TraceSiteSessionSync, "sync_beads_and_update_index", phaseStart, traceDesiredStateFields(result))
 	// Reload snapshot after sync so the reconciler sees metadata written
 	// by syncBeadsAndUpdateIndex (e.g., configured_named_session/mode
 	// stamped on adopted beads). The CachingStore has the updated data
 	// from SetMetadataBatch write-through.
+	phaseStart = time.Now()
 	sessionBeads = cr.loadSessionBeadSnapshot()
+	recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_sync", phaseStart, traceSessionSnapshotFields(sessionBeads))
+	phaseStart = time.Now()
 	result = refreshDesiredStateWithSessionBeads(
 		result,
 		cr.cityName,
@@ -907,21 +967,30 @@ func (cr *CityRuntime) tick(
 		sessionBeads,
 		cr.stderr,
 	)
+	recordPhase(TraceSiteDesiredStateBuild, "refresh_desired_state.after_sync", phaseStart, traceDesiredStateFields(result))
 
 	if manualReload != nil && manualReload.soft && manualReloadCompleted &&
 		(manualReply.Outcome == reloadOutcomeApplied || manualReply.Outcome == reloadOutcomeNoChange) {
+		phaseStart = time.Now()
 		cr.applySoftReloadAcceptance(&manualReply, result.State, sessionBeads)
+		recordPhase(TraceSiteConfigReload, "apply_soft_reload_acceptance", phaseStart, nil)
+		phaseStart = time.Now()
 		sessionBeads = cr.loadSessionBeadSnapshot()
+		recordPhase(TraceSiteSessionSnapshot, "load_session_snapshot.after_soft_reload", phaseStart, traceSessionSnapshotFields(sessionBeads))
 	}
 
 	// Bead-driven reconciliation (requires bead store / drain tracker).
 	if cr.sessionDrains != nil {
+		phaseStart = time.Now()
 		cr.beadReconcileTick(ctx, result, sessionBeads, trace)
+		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile_tick", phaseStart, traceDesiredStateFields(result))
 	}
 
 	// Wisp GC: purge expired closed molecules.
 	if store := cr.cityBeadStore(); cr.wg != nil && store != nil && cr.wg.shouldRun(time.Now()) {
+		phaseStart = time.Now()
 		purged, gcErr := cr.wg.runGC(store, time.Now())
+		recordPhase(TraceSiteControllerTickPhase, "wisp_gc", phaseStart, map[string]any{"purged": purged})
 		if gcErr != nil {
 			for _, line := range strings.Split(gcErr.Error(), "\n") {
 				if line == "" {
@@ -936,20 +1005,28 @@ func (cr *CityRuntime) tick(
 	}
 
 	if cr.svc != nil {
+		phaseStart = time.Now()
 		cr.svc.Tick(ctx, time.Now())
+		recordPhase(TraceSiteControllerTickPhase, "workspace_service_tick", phaseStart, nil)
 	}
 
 	// Chat session auto-suspend: suspend detached idle sessions.
 	if idleTimeout := cr.cfg.ChatSessions.IdleTimeoutDuration(); idleTimeout > 0 {
+		phaseStart = time.Now()
 		autoSuspendChatSessions(cr.cityBeadStore(), cr.sp, idleTimeout, clock.Real{}, cr.stdout, cr.stderr)
+		recordPhase(TraceSiteControllerTickPhase, "auto_suspend_chat_sessions", phaseStart, map[string]any{"idle_timeout_ms": idleTimeout.Milliseconds()})
 	}
 
 	// Drain queued convergence requests (CLI commands) BEFORE tick so
 	// user commands (e.g. stop) take precedence over automated progression.
+	phaseStart = time.Now()
 	cr.processConvergenceRequests(ctx)
+	recordPhase(TraceSiteControllerTickPhase, "process_convergence_requests", phaseStart, nil)
 
 	// Convergence tick: process active convergence loops.
+	phaseStart = time.Now()
 	cr.convergenceTick(ctx)
+	recordPhase(TraceSiteControllerTickPhase, "convergence_tick", phaseStart, nil)
 	completeManualReload()
 	completion = TraceCompletionCompleted
 	tickCompleted = true
@@ -1577,16 +1654,27 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	if store == nil {
 		return
 	}
+	recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
+		if trace != nil {
+			trace.RecordControllerOperation(site, TraceReasonRetained, TraceOutcomeComplete, name, time.Since(start), fields)
+		}
+	}
 
 	if sessionBeads == nil {
 		var sessionQueryPartial bool
+		phaseStart := time.Now()
 		sessionBeads, sessionQueryPartial = cr.loadSessionBeadSnapshotWithPartial()
+		recordPhase(TraceSiteSessionSnapshot, "bead_reconcile.load_session_snapshot", phaseStart, traceSessionSnapshotFields(sessionBeads))
 		result.SessionQueryPartial = result.SessionQueryPartial || sessionQueryPartial
 	}
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
 	assignedWorkStoreRefs := result.AssignedWorkStoreRefs
+	phaseStart := time.Now()
 	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, cr.cityPath, sessionBeads.Open(), result, rigStores)
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.release_orphaned_pool_assignments", phaseStart, map[string]any{
+		"released_count": len(released),
+	})
 	if len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
@@ -1599,6 +1687,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// work beads + new tier from scale_check + min fill.
 	poolDesired := result.PoolDesiredCounts
 	if poolDesired == nil {
+		phaseStart = time.Now()
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesired = retainScaleCheckPartialPoolDesired(
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
@@ -1606,6 +1695,10 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			sessionBeads,
 			result.PoolScaleCheckPartialTemplates,
 		)
+		recordPhase(TraceSitePoolDemandCompute, "bead_reconcile.compute_pool_desired", phaseStart, map[string]any{
+			"pool_work_bead_count": len(poolWorkBeads),
+			"pool_desired_count":   len(poolDesired),
+		})
 	}
 	// Merge named-session assignee demand so on-demand named sessions with
 	// direct work (Assignee match, no gc.routed_to) stay config-eligible.
@@ -1623,6 +1716,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			fmt.Fprintf(cr.stderr, "scaleCheck: %s = %d\n", tmpl, count) //nolint:errcheck
 		}
 	}
+	phaseStart = time.Now()
 	if sweepUndesiredPoolSessionBeads(
 		store,
 		rigStores,
@@ -1636,11 +1730,13 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		sessionBeads, sessionQueryPartial = cr.loadSessionBeadSnapshotWithPartial()
 		result.SessionQueryPartial = result.SessionQueryPartial || sessionQueryPartial
 	}
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.sweep_undesired_pool_sessions", phaseStart, traceSessionSnapshotFields(sessionBeads))
 	open := sessionBeads.Open()
 
 	// Use cr.cityName consistently — it's the authoritative runtime name.
 	cityName := cr.cityName
 
+	phaseStart = time.Now()
 	cfgNames := configuredSessionNamesWithSnapshot(cr.cfg, cityName, sessionBeads)
 
 	readyWaitSet, err := prepareWaitWakeStateForCityWithSnapshot(cr.cityPath, store, time.Now(), sessionBeads)
@@ -1648,6 +1744,10 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		fmt.Fprintf(cr.stderr, "%s: preparing waits: %v\n", cr.logPrefix, err) //nolint:errcheck
 		readyWaitSet = nil
 	}
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.prepare_wait_wake_state", phaseStart, map[string]any{
+		"configured_name_count": len(cfgNames),
+		"ready_wait_count":      len(readyWaitSet),
+	})
 
 	// Controller wake demand comes from assigned-work scans and scale_check.
 	// work_query remains the agent-side gc hook claim path; running every
@@ -1655,6 +1755,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	workSet := make(map[string]bool)
 	traceWorkRequested := traceWorkRequestedByTemplate(result.ScaleCheckCounts, result.NamedSessionDemand, workSet, cr.cfg)
 	if trace != nil {
+		phaseStart = time.Now()
 		templateNames := make(map[string]struct{})
 		openCounts := make(map[string]int)
 		desiredCounts := make(map[string]int)
@@ -1739,9 +1840,19 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 				"sling_query":         agent.SlingQuery,
 			})
 		}
+		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.record_trace_input_summary", phaseStart, map[string]any{
+			"template_count": len(templateNames),
+			"open_count":     len(open),
+		})
 	}
 
+	phaseStart = time.Now()
 	awakeAssignedWorkBeads := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, open, assignedWorkBeads, assignedWorkStoreRefs)
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.filter_assigned_work_for_wake", phaseStart, map[string]any{
+		"assigned_work_bead_count":       len(assignedWorkBeads),
+		"awake_assigned_work_bead_count": len(awakeAssignedWorkBeads),
+	})
+	phaseStart = time.Now()
 	reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, cr.cityPath, open, desiredState, cfgNames, cr.cfg, cr.sp, store,
 		cr.dops,
@@ -1758,8 +1869,14 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		withAsyncStartTracker(&cr.asyncStarts),
 		withMaxSessionAgeTracker(cr.mat),
 	)
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.reconcile_sessions", phaseStart, map[string]any{
+		"open_session_count":             len(open),
+		"desired_session_count":          len(desiredState),
+		"awake_assigned_work_bead_count": len(awakeAssignedWorkBeads),
+	})
 	cr.requestDeferredDrainFollowUpTick()
 	if trace != nil {
+		phaseStart = time.Now()
 		for _, bead := range open {
 			template := normalizedSessionTemplate(bead, cr.cfg)
 			if template == "" {
@@ -1770,17 +1887,24 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 				"sleep_reason": bead.Metadata["sleep_reason"],
 			})
 		}
+		recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.record_trace_session_results", phaseStart, map[string]any{
+			"open_count": len(open),
+		})
 	}
+	phaseStart = time.Now()
 	dispatchSessionBeads, err := loadSessionBeadSnapshot(store)
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
 	} else if err := dispatchReadyWaitNudgesWithSnapshot(cr.cityPath, cr.cfg, store, time.Now(), dispatchSessionBeads); err != nil {
 		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
 	}
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.dispatch_wait_nudges", phaseStart, traceSessionSnapshotFields(dispatchSessionBeads))
 	// Patrol-tick fallback for the supervisor nudge dispatcher: ensures
 	// queued items get delivered even if the wake socket missed the
 	// enqueue (process race during supervisor restart, listener crash).
+	phaseStart = time.Now()
 	cr.nudgeDispatchTick(ctx)
+	recordPhase(TraceSiteControllerTickPhase, "bead_reconcile.nudge_dispatch_tick", phaseStart, nil)
 
 	// Idle recovery: detect pool sessions stuck at the prompt after
 }
@@ -1940,9 +2064,6 @@ func sweepUndesiredPoolSessionBeads(
 		if isManualSessionBead(bead) || isNamedSessionBead(bead) {
 			continue
 		}
-		if running, err := workerSessionTargetRunningWithConfig("", store, sp, cfg, bead.ID); err == nil && running {
-			continue
-		}
 		// Don't sweep beads that the reconciler still considers "start
 		// requested" — their work assignment window hasn't opened. The
 		// pending_create_claim lease mirrors the reconciler's recovery model:
@@ -2019,9 +2140,23 @@ func sweepUndesiredPoolSessionBeads(
 		if agentCfg == nil || !isEphemeralSessionBead(bead) {
 			continue
 		}
+		if running, err := poolSessionBeadRuntimeRunning(bead, sp); err == nil && running {
+			continue
+		}
 		candidates = append(candidates, bead)
 	}
 	return len(GCSweepSessionBeads(store, rigStores, candidates))
+}
+
+func poolSessionBeadRuntimeRunning(bead beads.Bead, sp runtime.Provider) (bool, error) {
+	if sp == nil {
+		return false, sessionpkg.ErrSessionNotFound
+	}
+	name := strings.TrimSpace(bead.Metadata["session_name"])
+	if name == "" {
+		return false, sessionpkg.ErrSessionNotFound
+	}
+	return sp.IsRunning(name), nil
 }
 
 // pendingCreateClaimStillLeasedForSweep keeps pending_create_claim protection
@@ -2223,6 +2358,25 @@ func (cr *CityRuntime) syncBeadsAndUpdateIndex(desiredState map[string]TemplateP
 		cr.cityPath, store, cr.rigBeadStores(), desiredState, cr.sp, cfgNames, cr.cfg, clock.Real{}, cr.stderr, cr.sessionDrains != nil, sessionBeads,
 	)
 	return updated
+}
+
+func traceSessionSnapshotFields(sessionBeads *sessionBeadSnapshot) map[string]any {
+	if sessionBeads == nil {
+		return nil
+	}
+	return map[string]any{
+		"open_session_count": len(sessionBeads.Open()),
+	}
+}
+
+func traceDesiredStateFields(result DesiredStateResult) map[string]any {
+	return map[string]any{
+		"desired_session_count":     len(result.State),
+		"assigned_work_bead_count":  len(result.AssignedWorkBeads),
+		"assigned_work_store_count": len(result.AssignedWorkStoreRefs),
+		"store_query_partial":       result.StoreQueryPartial,
+		"session_query_partial":     result.SessionQueryPartial,
+	}
 }
 
 // cityBeadStore returns the bead store for this city, preferring the

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -71,6 +71,95 @@ func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	}
 }
 
+func TestSweepUndesiredPoolSessionBeads_RunningProbeAvoidsFullObservation(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-running",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker-bd-running", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sp.SetAttached("worker-bd-running", true)
+	sp.SetActivity("worker-bd-running", time.Now())
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		nil,
+		sessionBeads,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		sp,
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+	if got := sp.CountCalls("IsAttached", "worker-bd-running"); got != 0 {
+		t.Fatalf("IsAttached calls = %d, want 0; sweep only needs running state", got)
+	}
+	if got := sp.CountCalls("GetLastActivity", "worker-bd-running"); got != 0 {
+		t.Fatalf("GetLastActivity calls = %d, want 0; sweep only needs running state", got)
+	}
+}
+
+func TestSweepUndesiredPoolSessionBeads_SkipsProtectedCreateBeforeRuntimeProbe(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":              "worker-bd-fresh-create",
+			"template":                  "worker",
+			"agent_name":                "worker",
+			"pool_slot":                 "1",
+			poolManagedMetadataKey:      boolMetadata(true),
+			"state":                     "creating",
+			"pending_create_started_at": pendingCreateStartedAtNow(time.Now().UTC()),
+			"continuation_epoch":        "1",
+			"generation":                "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+	sp := runtime.NewFake()
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		nil,
+		sessionBeads,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		sp,
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+	if got := sp.CountCalls("IsRunning", "worker-bd-fresh-create"); got != 0 {
+		t.Fatalf("IsRunning calls = %d, want 0; fresh pending create is protected by metadata", got)
+	}
+}
+
 // stubManagedDoltStoreOpeners replaces the two package-level store openers
 // used during newCityRuntime + newControllerState startup with in-memory
 // stubs. This prevents tests from spawning real managed dolt servers (~12s

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -24,6 +24,19 @@ import (
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
 )
 
+type sweepLivenessProvider struct {
+	*runtime.Fake
+	running map[string]bool
+}
+
+func (p *sweepLivenessProvider) IsRunning(string) bool {
+	return false
+}
+
+func (p *sweepLivenessProvider) ObserveLiveness(name string, _ []string) runtime.Liveness {
+	return runtime.Liveness{Running: p.running[name]}
+}
+
 func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
@@ -116,6 +129,57 @@ func TestSweepUndesiredPoolSessionBeads_RunningProbeAvoidsFullObservation(t *tes
 	}
 	if got := sp.CountCalls("GetLastActivity", "worker-bd-running"); got != 0 {
 		t.Fatalf("GetLastActivity calls = %d, want 0; sweep only needs running state", got)
+	}
+}
+
+func TestSweepUndesiredPoolSessionBeads_UsesRuntimeLivenessObservation(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-observed",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		nil,
+		newSessionBeadSnapshot([]beads.Bead{bead}),
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		&sweepLivenessProvider{Fake: runtime.NewFake(), running: map[string]bool{"worker-bd-observed": true}},
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 when runtime liveness reports the pool session as running", closed)
+	}
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("liveness-observed running pool bead was closed: %+v", got)
+	}
+}
+
+func TestPoolSessionBeadRuntimeRunningUsesRuntimeNotFoundSentinel(t *testing.T) {
+	if _, err := poolSessionBeadRuntimeRunning(beads.Bead{}, nil); !errors.Is(err, runtime.ErrSessionNotFound) {
+		t.Fatalf("nil provider error = %v, want runtime.ErrSessionNotFound", err)
+	}
+	if _, err := poolSessionBeadRuntimeRunning(beads.Bead{Metadata: map[string]string{}}, runtime.NewFake()); !errors.Is(err, runtime.ErrSessionNotFound) {
+		t.Fatalf("missing session name error = %v, want runtime.ErrSessionNotFound", err)
 	}
 }
 
@@ -2111,6 +2175,59 @@ func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 	}
 	if got.Status != "closed" {
 		t.Fatalf("stopped pool bead status = %q, want closed", got.Status)
+	}
+}
+
+func TestSweepUndesiredPoolSessionBeads_ClosesMissingOrStaleSessionName(t *testing.T) {
+	tests := []struct {
+		name        string
+		sessionName string
+		liveName    string
+	}{
+		{name: "missing", sessionName: "", liveName: ""},
+		{name: "stale", sessionName: "worker-bd-stale", liveName: "worker-bd-current"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			bead, err := store.Create(beads.Bead{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel, "agent:worker"},
+				Metadata: map[string]string{
+					"session_name":         tt.sessionName,
+					"template":             "worker",
+					"agent_name":           "worker",
+					"pool_slot":            "1",
+					poolManagedMetadataKey: boolMetadata(true),
+					"state":                "drained",
+					"continuation_epoch":   "1",
+					"generation":           "1",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			sp := runtime.NewFake()
+			if tt.liveName != "" {
+				if err := sp.Start(context.Background(), tt.liveName, runtime.Config{}); err != nil {
+					t.Fatalf("Start(%s): %v", tt.liveName, err)
+				}
+			}
+
+			closed := sweepUndesiredPoolSessionBeads(
+				store,
+				nil,
+				newSessionBeadSnapshot([]beads.Bead{bead}),
+				nil,
+				&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+				sp,
+				false,
+			)
+			if closed != 1 {
+				t.Fatalf("closed = %d, want 1 for unrecoverable pool session name", closed)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/session_lifecycle_chaos_test.go
+++ b/cmd/gc/session_lifecycle_chaos_test.go
@@ -455,8 +455,10 @@ func TestSessionLifecycleChaosPendingInteractionDoesNotCancelAgentDrainAck(t *te
 	h.record("pending interaction after agent drain ack")
 	h.reconcileTickWithDrainOps()
 
+	h.assertDrainAckStopPending()
+	h.finalizeAsyncDrainAckStop()
 	if h.env.sp.IsRunning(h.sessionName) {
-		h.failf("pending interaction canceled agent-authored drain ack for %q", h.sessionName)
+		h.failf("agent-authored drain ack left runtime %q running after async stop", h.sessionName)
 	}
 }
 
@@ -491,8 +493,10 @@ func TestSessionLifecycleChaosAgentDrainAckClearsRecoveredReconcilerProvenance(t
 	h.record("pending interaction after agent drain ack overwrote provenance")
 	h.reconcileTickWithDrainOps()
 
+	h.assertDrainAckStopPending()
+	h.finalizeAsyncDrainAckStop()
 	if h.env.sp.IsRunning(h.sessionName) {
-		h.failf("pending interaction canceled agent-authored drain ack after provenance overwrite for %q", h.sessionName)
+		h.failf("agent-authored drain ack after provenance overwrite left runtime %q running after async stop", h.sessionName)
 	}
 }
 
@@ -519,9 +523,11 @@ func TestSessionLifecycleChaosAgentDrainAckClearsLiveControllerDrain(t *testing.
 	h.record("agent drain ack while controller drain remains in memory")
 	h.reconcileTickWithDrainOps()
 
-	if h.env.sp.IsRunning(h.sessionName) {
-		h.failf("agent-authored drain ack left runtime %q running", h.sessionName)
+	h.assertDrainAckStopPending()
+	if ds := h.env.dt.get(h.sessionID); ds != nil {
+		h.failf("agent-authored drain ack left controller drain active while stop pending: %+v", *ds)
 	}
+	h.finalizeAsyncDrainAckStop()
 	if ds := h.env.dt.get(h.sessionID); ds != nil {
 		h.failf("agent-authored drain ack left controller drain active: %+v", *ds)
 	}
@@ -552,8 +558,10 @@ func TestSessionLifecycleChaosAgentDrainAckStopFailurePreservesRetry(t *testing.
 	}
 	h.env.sp.StopErrors[h.sessionName] = errors.New("chaos stop failure")
 
+	stopsBefore := h.countRuntimeCalls("Stop")
 	h.record("agent drain ack with transient stop failure")
 	h.reconcileTickWithDrainOps()
+	h.waitForRuntimeCallCount("Stop", stopsBefore+1)
 
 	if !h.env.sp.IsRunning(h.sessionName) {
 		h.failf("stop failure removed runtime %q", h.sessionName)
@@ -564,10 +572,14 @@ func TestSessionLifecycleChaosAgentDrainAckStopFailurePreservesRetry(t *testing.
 	if ds := h.env.dt.get(h.sessionID); ds != nil {
 		h.failf("stop failure left cancelable controller drain active after agent ack: %+v", *ds)
 	}
+	h.assertDrainAckStopPending()
 
 	delete(h.env.sp.StopErrors, h.sessionName)
+	stopsBefore = h.countRuntimeCalls("Stop")
 	h.record("agent drain ack retry after stop recovers")
 	h.reconcileTickWithDrainOps()
+	h.waitForRuntimeCallCount("Stop", stopsBefore+1)
+	h.finalizeAsyncDrainAckStop()
 
 	if h.env.sp.IsRunning(h.sessionName) {
 		h.failf("retried agent drain ack left runtime %q running", h.sessionName)
@@ -1616,13 +1628,36 @@ func (h *sessionChaosHarness) record(format string, args ...any) {
 }
 
 func (h *sessionChaosHarness) countRuntimeCalls(method string) int {
-	count := 0
-	for _, call := range h.env.sp.Calls {
-		if call.Method == method && call.Name == h.sessionName {
-			count++
+	return h.env.sp.CountCalls(method, h.sessionName)
+}
+
+func (h *sessionChaosHarness) waitForRuntimeCallCount(method string, want int) {
+	h.t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := h.countRuntimeCalls(method); got >= want {
+			return
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	return count
+	h.failf("%s calls for %q = %d, want at least %d", method, h.sessionName, h.countRuntimeCalls(method), want)
+}
+
+func (h *sessionChaosHarness) assertDrainAckStopPending() {
+	h.t.Helper()
+	b := h.mustBead()
+	if got := b.Metadata["state"]; got != string(sessionpkg.StateDraining) {
+		h.failf("state = %q, want %q while drain ack stop is pending", got, sessionpkg.StateDraining)
+	}
+	if got := b.Metadata["state_reason"]; got != sessionpkg.DrainAckStopPendingReason {
+		h.failf("state_reason = %q, want %q", got, sessionpkg.DrainAckStopPendingReason)
+	}
+}
+
+func (h *sessionChaosHarness) finalizeAsyncDrainAckStop() {
+	h.t.Helper()
+	waitForProviderStopped(h.t, h.env.sp, h.sessionName)
+	h.reconcileTickWithDrainOps()
 }
 
 func (h *sessionChaosHarness) failf(format string, args ...any) {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -221,12 +221,13 @@ func (p startPhaseTimings) formatLog() string {
 }
 
 type startExecutionOptions struct {
-	async           bool
-	asyncFollowUp   func()
-	asyncLimiter    *asyncStartLimiter
-	asyncTracker    *asyncStartTracker
-	maxSessionAgeTr maxSessionAgeTracker
-	workDirResolver taskWorkDirResolver
+	async            bool
+	asyncFollowUp    func()
+	asyncLimiter     *asyncStartLimiter
+	asyncTracker     *asyncStartTracker
+	asyncStopTracker *asyncStartTracker
+	maxSessionAgeTr  maxSessionAgeTracker
+	workDirResolver  taskWorkDirResolver
 }
 
 type startExecutionOption func(*startExecutionOptions)
@@ -254,6 +255,12 @@ func withAsyncStartLimiter(limiter *asyncStartLimiter) startExecutionOption {
 func withAsyncStartTracker(tracker *asyncStartTracker) startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.asyncTracker = tracker
+	}
+}
+
+func withAsyncDrainAckStopTracker(tracker *asyncStartTracker) startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.asyncStopTracker = tracker
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -13,8 +13,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/api"
@@ -28,6 +30,8 @@ import (
 )
 
 const maxIdleSleepProbesPerTick = 3
+
+var drainAckAsyncStops sync.Map
 
 type wakeTarget struct {
 	session *beads.Bead
@@ -44,6 +48,241 @@ func lifecycleTimerBlocker(metadata map[string]string, now time.Time) string {
 	default:
 		return ""
 	}
+}
+
+func isDrainAckStopPending(session beads.Bead) bool {
+	return strings.TrimSpace(session.Metadata["state"]) == string(sessionpkg.StateDraining) &&
+		strings.TrimSpace(session.Metadata["state_reason"]) == sessionpkg.DrainAckStopPendingReason
+}
+
+func markDrainAckStopPending(session *beads.Bead, store beads.Store, clk clock.Clock) bool {
+	if session == nil || store == nil || session.ID == "" {
+		return false
+	}
+	batch := sessionpkg.DrainAckStopPendingPatch(clk.Now().UTC())
+	if err := store.SetMetadataBatch(session.ID, batch); err != nil {
+		return false
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, len(batch))
+	}
+	for key, value := range batch {
+		session.Metadata[key] = value
+	}
+	return true
+}
+
+func clearDrainTrackerForStopPending(session *beads.Bead, dt *drainTracker) {
+	if session == nil || dt == nil {
+		return
+	}
+	dt.clearIdleProbe(session.ID)
+	dt.remove(session.ID)
+}
+
+func drainAckAsyncStopKey(sp runtime.Provider, cityPath, sessionID, name string) string {
+	if id := strings.TrimSpace(sessionID); id != "" {
+		return fmt.Sprintf("provider:%p\x00city:%s\x00id:%s", sp, strings.TrimSpace(cityPath), id)
+	}
+	return fmt.Sprintf("provider:%p\x00city:%s\x00name:%s", sp, strings.TrimSpace(cityPath), strings.TrimSpace(name))
+}
+
+func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, sessionID, name string) {
+	name = strings.TrimSpace(name)
+	if name == "" || sp == nil {
+		return
+	}
+	key := drainAckAsyncStopKey(sp, cityPath, sessionID, name)
+	if _, loaded := drainAckAsyncStops.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+	go func() {
+		defer drainAckAsyncStops.Delete(key)
+		if err := workerKillSessionTargetWithConfig(cityPath, store, sp, cfg, name); err != nil && !runtime.IsSessionGone(err) {
+			log.Printf("session reconciler: async drain-ack stop %s: %v", name, err)
+		}
+	}()
+}
+
+func recordDrainAckAssignedWorkEvent(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	session beads.Bead,
+	subject string,
+	template string,
+	name string,
+	rec events.Recorder,
+	stderr io.Writer,
+) {
+	if rec == nil {
+		return
+	}
+	strandedBead, found, beadLookupErr := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, session)
+	if beadLookupErr != nil {
+		fmt.Fprintf(stderr, "session reconciler: locating stranded bead for drain-acked %s: %v\n", name, beadLookupErr) //nolint:errcheck
+	}
+	if !found {
+		return
+	}
+	rec.Record(events.Event{
+		Type:    events.SessionDrainAckedWithAssignedWork,
+		Actor:   "gc",
+		Subject: subject,
+		Message: "session drain-acked while still assigned to work bead",
+		Payload: api.SessionDrainAckedWithAssignedWorkPayloadJSON(
+			session.ID,
+			strandedBead.ID,
+			template,
+			strandedBead.Status,
+			"drain_acked_with_assigned_work",
+		),
+	})
+}
+
+func finalizeDrainAckStoppedSession(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	session *beads.Bead,
+	template string,
+	closeIfUnassigned bool,
+	dops drainOps,
+	dt *drainTracker,
+	clk clock.Clock,
+	rec events.Recorder,
+	stderr io.Writer,
+) {
+	if session == nil || store == nil || session.ID == "" {
+		return
+	}
+	name := strings.TrimSpace(session.Metadata["session_name"])
+	if template == "" {
+		template = normalizedSessionTemplate(*session, cfg)
+	}
+	if template == "" {
+		template = session.Metadata["template"]
+	}
+	if dops != nil {
+		_ = dops.clearDrain(name)
+	}
+	if dt != nil {
+		dt.clearIdleProbe(session.ID)
+		dt.remove(session.ID)
+	}
+	if rec != nil {
+		rec.Record(events.Event{
+			Type:    events.SessionStopped,
+			Actor:   "gc",
+			Subject: template,
+			Message: "drain acknowledged by agent",
+			Payload: api.SessionLifecyclePayloadJSON(session.ID, template, "drain acknowledged"),
+		})
+	}
+	hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
+	if assignedErr != nil {
+		fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
+		hasAssignedWork = true
+	}
+	if hasAssignedWork {
+		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, template, template, name, rec, stderr)
+	}
+	if closeIfUnassigned && !hasAssignedWork {
+		if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, "drained", clk.Now().UTC(), stderr) {
+			session.Status = "closed"
+			if session.Metadata == nil {
+				session.Metadata = make(map[string]string)
+			}
+			for key, value := range sessionpkg.ClosePatch(clk.Now().UTC(), "drained") {
+				session.Metadata[key] = value
+			}
+		}
+		return
+	}
+	batch := sessionpkg.AcknowledgeDrainPatch(session.Metadata["wake_mode"] == "fresh")
+	if hasAssignedWork {
+		batch = sessionpkg.CompleteDrainPatch(clk.Now().UTC(), "idle", session.Metadata["wake_mode"] == "fresh")
+	}
+	_ = store.SetMetadataBatch(session.ID, batch)
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string, len(batch))
+	}
+	for key, value := range batch {
+		session.Metadata[key] = value
+	}
+}
+
+func reconcileDrainAckStopPending(
+	cityPath string,
+	cfg *config.City,
+	sp runtime.Provider,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	session *beads.Bead,
+	tp TemplateParams,
+	desired bool,
+	dops drainOps,
+	dt *drainTracker,
+	clk clock.Clock,
+	rec events.Recorder,
+	stderr io.Writer,
+) bool {
+	if session == nil || !isDrainAckStopPending(*session) {
+		return false
+	}
+	name := strings.TrimSpace(session.Metadata["session_name"])
+	obs, err := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, session.ID, tp.Hints.ProcessNames)
+	if err != nil || obs.Running || obs.Alive {
+		queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name)
+		return true
+	}
+	finalizeDrainAckStoppedSession(
+		cityPath, cfg, store, rigStores, session, tp.TemplateName,
+		!desired || isPoolManagedSessionBead(*session),
+		dops, dt, clk, rec, stderr,
+	)
+	return true
+}
+
+func finalizeDrainAckStopPendingSessions(
+	cityPath string,
+	cfg *config.City,
+	sp runtime.Provider,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	sessions []beads.Bead,
+	dops drainOps,
+	dt *drainTracker,
+	clk clock.Clock,
+	rec events.Recorder,
+	stderr io.Writer,
+) int {
+	if store == nil || sp == nil || len(sessions) == 0 {
+		return 0
+	}
+	finalized := 0
+	for i := range sessions {
+		session := &sessions[i]
+		if !isDrainAckStopPending(*session) {
+			continue
+		}
+		name := strings.TrimSpace(session.Metadata["session_name"])
+		obs, err := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, session.ID, nil)
+		if err != nil || obs.Running || obs.Alive {
+			queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name)
+			continue
+		}
+		finalizeDrainAckStoppedSession(
+			cityPath, cfg, store, rigStores, session,
+			normalizedSessionTemplate(*session, cfg),
+			isPoolManagedSessionBead(*session),
+			dops, dt, clk, rec, stderr,
+		)
+		finalized++
+	}
+	return finalized
 }
 
 // buildDepsMap extracts template dependency edges from config for topo ordering.
@@ -499,12 +738,22 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		startupTimeout = cfg.Session.StartupTimeoutDuration()
 	}
 	maxAgeTr := reconcileOpts.maxSessionAgeTr
+	recordPhase := func(name string, start time.Time, fields map[string]any) {
+		if trace != nil {
+			trace.RecordControllerOperation(TraceSiteControllerTickPhase, TraceReasonRetained, TraceOutcomeComplete, name, time.Since(start), fields)
+		}
+	}
+	phaseStart := time.Now()
 	deps := buildDepsMap(cfg)
 	if cityName == "" {
 		cityName = config.EffectiveCityName(cfg, "")
 	}
+	recordPhase("session_reconcile.build_deps", phaseStart, map[string]any{
+		"dependency_template_count": len(deps),
+	})
 
 	// Phase 0: Heal expired timers on all sessions.
+	phaseStart = time.Now()
 	for i := range sessions {
 		healExpiredTimers(&sessions[i], store, clk)
 	}
@@ -524,10 +773,18 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			store, rigStores, sp, cfg, cityName, sessions, bySessionName, indexBySessionName, clk.Now().UTC(), stderr,
 		)
 	}
+	recordPhase("session_reconcile.heal_and_retire_duplicates", phaseStart, map[string]any{
+		"session_count": len(sessions),
+	})
 
 	// Topo-order sessions by template dependencies.
+	phaseStart = time.Now()
 	ordered := topoOrder(sessions, deps)
+	recordPhase("session_reconcile.topo_order", phaseStart, map[string]any{
+		"ordered_session_count": len(ordered),
+	})
 
+	phaseStart = time.Now()
 	cbNow := clk.Now().UTC()
 	cbCfg, cbEnabled := sessionCircuitBreakerConfigFromCity(cfg)
 	var cb *sessionCircuitBreaker
@@ -575,6 +832,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 		cb.pruneIdle(cbNow)
 	}
+	recordPhase("session_reconcile.circuit_breaker_restore", phaseStart, map[string]any{
+		"enabled":       cbEnabled,
+		"session_count": len(ordered),
+	})
 
 	// Build session ID -> *beads.Bead lookup for advanceSessionDrains.
 	// These pointers intentionally alias into the ordered slice so that
@@ -619,11 +880,18 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 		rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
 	}
+	phaseStart = time.Now()
 	for i := range ordered {
 		if ctx != nil && ctx.Err() != nil {
 			return 0
 		}
 		session := &ordered[i]
+		name := strings.TrimSpace(session.Metadata["session_name"])
+		tp, desired := desiredState[name]
+
+		if reconcileDrainAckStopPending(cityPath, cfg, sp, store, rigStores, session, tp, desired, dops, dt, clk, rec, stderr) {
+			continue
+		}
 
 		// Skip beads with unrecognized states. This enables forward-compatible
 		// rollback: if a newer version writes "draining" or "archived", the
@@ -638,9 +906,6 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 			continue
 		}
-
-		name := strings.TrimSpace(session.Metadata["session_name"])
-		tp, desired := desiredState[name]
 
 		// Orphan/suspended: bead exists but not in desired state.
 		// Handle BEFORE heal/stability to avoid false crash detection —
@@ -812,78 +1077,31 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								continue
 							}
 						}
-						stopped := !providerAlive
 						if providerAlive {
-							if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
-								fmt.Fprintf(stderr, "session reconciler: stopping drain-acked %s: %v\n", name, err) //nolint:errcheck
-							} else {
-								stopped = true
-								fmt.Fprintf(stdout, "Stopped drain-acked session '%s'\n", name) //nolint:errcheck
-							}
-						}
-						if stopped {
 							template := normalizedSessionTemplate(*session, cfg)
 							if template == "" {
 								template = session.Metadata["template"]
 							}
-							rec.Record(events.Event{
-								Type:    events.SessionStopped,
-								Actor:   "gc",
-								Subject: template,
-								Message: "drain acknowledged by agent",
-								Payload: api.SessionLifecyclePayloadJSON(session.ID, template, "drain acknowledged"),
-							})
 							if hasAssignedWork {
-								// gastownhall/gascity#2293: the session drain-acked but the
-								// bead it owned is still assigned to it. Emit a typed event
-								// so pack-side subscribers can decide recovery policy (commit-
-								// and-push, clear-assignee-and-respawn, escalate). The SDK
-								// reconciler intentionally stops at signal emission — it must
-								// not bake pack-specific recovery into core (ZFC + zero
-								// hardcoded roles per AGENTS.md).
-								strandedBead, found, beadLookupErr := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, *session)
-								if beadLookupErr != nil {
-									fmt.Fprintf(stderr, "session reconciler: locating stranded bead for drain-acked %s: %v\n", name, beadLookupErr) //nolint:errcheck
-								}
-								if found {
-									rec.Record(events.Event{
-										Type:    events.SessionDrainAckedWithAssignedWork,
-										Actor:   "gc",
-										Subject: template,
-										Message: "session drain-acked while still assigned to work bead",
-										Payload: api.SessionDrainAckedWithAssignedWorkPayloadJSON(
-											session.ID,
-											strandedBead.ID,
-											template,
-											strandedBead.Status,
-											"drain_acked_with_assigned_work",
-										),
-									})
-								}
-								batch := sessionpkg.CompleteDrainPatch(clk.Now().UTC(), "idle", session.Metadata["wake_mode"] == "fresh")
-								_ = store.SetMetadataBatch(session.ID, batch)
-								if session.Metadata == nil {
-									session.Metadata = make(map[string]string, len(batch))
-								}
-								for key, value := range batch {
-									session.Metadata[key] = value
-								}
-								_ = dops.clearDrain(name)
-								if dt != nil {
-									dt.clearIdleProbe(session.ID)
-									dt.remove(session.ID)
-								}
-								continue
+								recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, template, template, name, rec, stderr)
 							}
-							_ = dops.clearDrain(name)
-							if dt != nil {
-								dt.clearIdleProbe(session.ID)
-								dt.remove(session.ID)
+							if markDrainAckStopPending(session, store, clk) {
+								clearDrainTrackerForStopPending(session, dt)
+								queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name)
+								if trace != nil {
+									trace.recordDecision("reconciler.session.drain_ack", template, name, "orphaned", "stop_pending", nil, nil, "")
+								}
 							}
-							if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, "drained", clk.Now().UTC(), stderr) {
-								session.Status = "closed"
-							}
+							continue
 						}
+						template := normalizedSessionTemplate(*session, cfg)
+						if template == "" {
+							template = session.Metadata["template"]
+						}
+						finalizeDrainAckStoppedSession(
+							cityPath, cfg, store, rigStores, session, template,
+							true, dops, dt, clk, rec, stderr,
+						)
 						continue
 					}
 				}
@@ -1066,28 +1284,25 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						}
 						continue
 					}
-					stopped := !alive // already dead = effectively stopped
 					if alive {
-						if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
-							fmt.Fprintf(stderr, "session reconciler: stopping drain-acked %s: %v\n", name, err) //nolint:errcheck
-							if !reconcilerOwnedAck && dt != nil {
-								dt.clearIdleProbe(session.ID)
-								dt.remove(session.ID)
-							}
-						} else {
-							stopped = true
-							fmt.Fprintf(stdout, "Stopped drain-acked session '%s'\n", name) //nolint:errcheck
+						hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
+						if assignedErr != nil {
+							fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
+							hasAssignedWork = true
 						}
+						if hasAssignedWork {
+							recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, tp.DisplayName(), tp.TemplateName, name, rec, stderr)
+						}
+						if markDrainAckStopPending(session, store, clk) {
+							clearDrainTrackerForStopPending(session, dt)
+							queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name)
+							if trace != nil {
+								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "acknowledged", "stop_pending", nil, nil, "")
+							}
+						}
+						continue
 					}
-					if stopped && store != nil && session.ID != "" {
-						_ = dops.clearDrain(name)
-						rec.Record(events.Event{
-							Type:    events.SessionStopped,
-							Actor:   "gc",
-							Subject: tp.DisplayName(),
-							Message: "drain acknowledged by agent",
-							Payload: api.SessionLifecyclePayloadJSON(session.ID, tp.TemplateName, "drain acknowledged"),
-						})
+					if store != nil && session.ID != "" {
 						// Drain-ack lands here right after the agent ran
 						// `bd close` on its last unit of work. The cached
 						// `ownershipWorkBeads` snapshot taken earlier in
@@ -1100,7 +1315,6 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						// queue work on a ghost slot. Re-query the store
 						// so the decision reflects reality.
 						hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
-						sleepReason := "idle"
 						if assignedErr != nil {
 							fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
 							hasAssignedWork = true
@@ -1112,42 +1326,19 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							// subscribers can apply recovery policy. SDK stays
 							// out of the commit/push/respawn decision (ZFC +
 							// zero hardcoded roles per AGENTS.md).
-							strandedBead, found, beadLookupErr := firstOpenAssignedWorkBeadForReachableStore(cityPath, cfg, store, rigStores, *session)
-							if beadLookupErr != nil {
-								fmt.Fprintf(stderr, "session reconciler: locating stranded bead for drain-acked %s: %v\n", name, beadLookupErr) //nolint:errcheck
-							}
-							if found {
-								rec.Record(events.Event{
-									Type:    events.SessionDrainAckedWithAssignedWork,
-									Actor:   "gc",
-									Subject: tp.DisplayName(),
-									Message: "session drain-acked while still assigned to work bead",
-									Payload: api.SessionDrainAckedWithAssignedWorkPayloadJSON(
-										session.ID,
-										strandedBead.ID,
-										tp.TemplateName,
-										strandedBead.Status,
-										"drain_acked_with_assigned_work",
-									),
-								})
-							}
-						}
-						batch := sessionpkg.AcknowledgeDrainPatch(session.Metadata["wake_mode"] == "fresh")
-						if hasAssignedWork {
-							batch = sessionpkg.CompleteDrainPatch(clk.Now().UTC(), sleepReason, session.Metadata["wake_mode"] == "fresh")
-						}
-						_ = store.SetMetadataBatch(session.ID, batch)
-						if session.Metadata == nil {
-							session.Metadata = make(map[string]string, len(batch))
-						}
-						for key, value := range batch {
-							session.Metadata[key] = value
-						}
-						if !reconcilerOwnedAck && dt != nil {
-							dt.clearIdleProbe(session.ID)
-							dt.remove(session.ID)
+							recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, tp.DisplayName(), tp.TemplateName, name, rec, stderr)
 						}
 					}
+					finalizeDT := dt
+					if reconcilerOwnedAck {
+						finalizeDT = nil
+					}
+					finalizeDrainAckStoppedSession(
+						cityPath, cfg, store, rigStores, session, tp.TemplateName,
+						isPoolManagedSessionBead(*session),
+						dops, finalizeDT,
+						clk, rec, stderr,
+					)
 					continue
 				}
 			}
@@ -1699,12 +1890,21 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		wakeTargets = append(wakeTargets, wakeTarget{session: session, tp: tp, alive: alive})
 	}
+	recordPhase("session_reconcile.forward_pass", phaseStart, map[string]any{
+		"ordered_session_count":  len(ordered),
+		"wake_target_count":      len(wakeTargets),
+		"rollback_count":         rollbacksThisTick,
+		"rollback_budget":        maxRollbacksPerTick,
+		"start_candidate_count":  len(startCandidates),
+		"assigned_work_bead_cnt": len(assignedWorkBeads),
+	})
 
 	if ctx != nil && ctx.Err() != nil {
 		return 0
 	}
 
 	// Use ComputeAwakeSet for the wake/sleep decision.
+	phaseStart = time.Now()
 	awakeInput := buildAwakeInputFromReconciler(
 		cfg, ordered, poolDesired, namedSessionDemand, workSet, readyWaitSet,
 		assignedWorkBeads, wakeTargets, sp, clk.Now(),
@@ -1746,7 +1946,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 	idleProbeTargets := selectIdleProbeTargets(wakeTargets, wakeEvals, dt)
 	launchIdleProbes(ctx, idleProbeTargets, wakeTargets, dt, sp, clk)
+	recordPhase("session_reconcile.compute_awake_set_and_idle_probes", phaseStart, map[string]any{
+		"wake_target_count":      len(wakeTargets),
+		"idle_probe_target_cnt":  len(idleProbeTargets),
+		"awake_decision_count":   len(awakeDecisions),
+		"awake_eval_count":       len(wakeEvals),
+		"assigned_work_bead_cnt": len(assignedWorkBeads),
+	})
 
+	phaseStart = time.Now()
 	for _, target := range wakeTargets {
 		if ctx != nil && ctx.Err() != nil {
 			return 0
@@ -1906,28 +2114,42 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			closeBead(store, target.session.ID, closeReason, clk.Now().UTC(), stderr)
 		}
 	}
+	recordPhase("session_reconcile.apply_wake_sleep_decisions", phaseStart, map[string]any{
+		"wake_target_count":     len(wakeTargets),
+		"start_candidate_count": len(startCandidates),
+	})
 
 	if ctx != nil && ctx.Err() != nil {
 		return 0
 	}
 
+	phaseStart = time.Now()
 	plannedWakes := executePlannedStartsTraced(
 		ctx, startCandidates, cfg, desiredState, sp, store, cityName,
 		cityPath,
 		clk, rec, startupTimeout, stdout, stderr, trace,
 		effectiveStartOptions...,
 	)
+	recordPhase("session_reconcile.execute_planned_starts", phaseStart, map[string]any{
+		"start_candidate_count": len(startCandidates),
+		"planned_wake_count":    plannedWakes,
+	})
 
 	if ctx != nil && ctx.Err() != nil {
 		return plannedWakes
 	}
 
 	// Phase 2: Advance all in-flight drains.
+	phaseStart = time.Now()
 	sessionLookup := func(id string) *beads.Bead {
 		return beadByID[id]
 	}
 	advanceSessionDrainsWithSessionsTraced(dt, sp, store, sessionLookup, ordered, wakeEvals, cfg, poolDesired, nil, readyWaitSet, clk, trace)
 	clearMissingIdleProbes(dt, beadByID)
+	recordPhase("session_reconcile.advance_drains", phaseStart, map[string]any{
+		"ordered_session_count": len(ordered),
+		"wake_eval_count":       len(wakeEvals),
+	})
 
 	return plannedWakes
 }

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -31,6 +30,9 @@ import (
 
 const maxIdleSleepProbesPerTick = 3
 
+// drainAckAsyncStops deduplicates process-local async stop goroutines. A
+// controller restart can briefly double-stop through a fresh process map; stop
+// providers are idempotent and SessionGone errors are suppressed below.
 var drainAckAsyncStops sync.Map
 
 type wakeTarget struct {
@@ -55,12 +57,20 @@ func isDrainAckStopPending(session beads.Bead) bool {
 		strings.TrimSpace(session.Metadata["state_reason"]) == sessionpkg.DrainAckStopPendingReason
 }
 
-func markDrainAckStopPending(session *beads.Bead, store beads.Store, clk clock.Clock) bool {
+func markDrainAckStopPending(session *beads.Bead, store beads.Store, clk clock.Clock, stderr io.Writer) bool {
 	if session == nil || store == nil || session.ID == "" {
 		return false
 	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
 	batch := sessionpkg.DrainAckStopPendingPatch(clk.Now().UTC())
 	if err := store.SetMetadataBatch(session.ID, batch); err != nil {
+		name := strings.TrimSpace(session.Metadata["session_name"])
+		if name == "" {
+			name = session.ID
+		}
+		fmt.Fprintf(stderr, "session reconciler: marking drain-ack stop-pending %s: %v\n", name, err) //nolint:errcheck
 		return false
 	}
 	if session.Metadata == nil {
@@ -80,26 +90,49 @@ func clearDrainTrackerForStopPending(session *beads.Bead, dt *drainTracker) {
 	dt.remove(session.ID)
 }
 
-func drainAckAsyncStopKey(sp runtime.Provider, cityPath, sessionID, name string) string {
-	if id := strings.TrimSpace(sessionID); id != "" {
-		return fmt.Sprintf("provider:%p\x00city:%s\x00id:%s", sp, strings.TrimSpace(cityPath), id)
+func drainAckAsyncStopKey(store beads.Store, cityPath, sessionID, name string) string {
+	scope := strings.TrimSpace(cityPath)
+	if scope == "" {
+		scope = fmt.Sprintf("store:%p", store)
 	}
-	return fmt.Sprintf("provider:%p\x00city:%s\x00name:%s", sp, strings.TrimSpace(cityPath), strings.TrimSpace(name))
+	if id := strings.TrimSpace(sessionID); id != "" {
+		return fmt.Sprintf("city:%s\x00id:%s", scope, id)
+	}
+	return fmt.Sprintf("city:%s\x00name:%s", scope, strings.TrimSpace(name))
 }
 
-func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, sessionID, name string) {
+func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, sessionID, name string, tracker *asyncStartTracker, stderr io.Writer) {
 	name = strings.TrimSpace(name)
 	if name == "" || sp == nil {
 		return
 	}
-	key := drainAckAsyncStopKey(sp, cityPath, sessionID, name)
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	key := drainAckAsyncStopKey(store, cityPath, sessionID, name)
 	if _, loaded := drainAckAsyncStops.LoadOrStore(key, struct{}{}); loaded {
 		return
 	}
+	done := func() {}
+	if tracker != nil {
+		var tracking bool
+		done, tracking = tracker.start()
+		if !tracking {
+			drainAckAsyncStops.Delete(key)
+			return
+		}
+	}
 	go func() {
-		defer drainAckAsyncStops.Delete(key)
+		defer func() {
+			drainAckAsyncStops.Delete(key)
+			done()
+			if r := recover(); r != nil {
+				fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s panicked: %v\n", name, r) //nolint:errcheck
+				panic(r)
+			}
+		}()
 		if err := workerKillSessionTargetWithConfig(cityPath, store, sp, cfg, name); err != nil && !runtime.IsSessionGone(err) {
-			log.Printf("session reconciler: async drain-ack stop %s: %v", name, err)
+			fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s: %v\n", name, err) //nolint:errcheck
 		}
 	}()
 }
@@ -165,14 +198,10 @@ func finalizeDrainAckStoppedSession(
 	if template == "" {
 		template = session.Metadata["template"]
 	}
-	if dops != nil {
-		_ = dops.clearDrain(name)
-	}
-	if dt != nil {
-		dt.clearIdleProbe(session.ID)
-		dt.remove(session.ID)
-	}
-	if rec != nil {
+	recordStopped := func() {
+		if rec == nil {
+			return
+		}
 		rec.Record(events.Event{
 			Type:    events.SessionStopped,
 			Actor:   "gc",
@@ -186,9 +215,6 @@ func finalizeDrainAckStoppedSession(
 		fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
 		hasAssignedWork = true
 	}
-	if hasAssignedWork {
-		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, template, template, name, rec, stderr)
-	}
 	if closeIfUnassigned && !hasAssignedWork {
 		if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, "drained", clk.Now().UTC(), stderr) {
 			session.Status = "closed"
@@ -198,19 +224,62 @@ func finalizeDrainAckStoppedSession(
 			for key, value := range sessionpkg.ClosePatch(clk.Now().UTC(), "drained") {
 				session.Metadata[key] = value
 			}
+			if dops != nil {
+				_ = dops.clearDrain(name)
+			}
+			if dt != nil {
+				dt.clearIdleProbe(session.ID)
+				dt.remove(session.ID)
+			}
+			recordStopped()
+			return
 		}
-		return
+		if latest, err := store.Get(session.ID); err == nil && latest.Status == "closed" {
+			session.Status = latest.Status
+			session.Metadata = latest.Metadata
+			if dops != nil {
+				_ = dops.clearDrain(name)
+			}
+			if dt != nil {
+				dt.clearIdleProbe(session.ID)
+				dt.remove(session.ID)
+			}
+			recordStopped()
+			return
+		}
+		assignedAfterCloseGate, closeGateAssignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
+		if closeGateAssignedErr != nil {
+			fmt.Fprintf(stderr, "session reconciler: checking assigned work after failed drain-ack close gate for %s: %v\n", name, closeGateAssignedErr) //nolint:errcheck
+			assignedAfterCloseGate = true
+		}
+		if assignedAfterCloseGate {
+			hasAssignedWork = true
+		}
 	}
 	batch := sessionpkg.AcknowledgeDrainPatch(session.Metadata["wake_mode"] == "fresh")
 	if hasAssignedWork {
 		batch = sessionpkg.CompleteDrainPatch(clk.Now().UTC(), "idle", session.Metadata["wake_mode"] == "fresh")
 	}
-	_ = store.SetMetadataBatch(session.ID, batch)
+	if err := store.SetMetadataBatch(session.ID, batch); err != nil {
+		fmt.Fprintf(stderr, "session reconciler: finalizing drain-ack stopped %s: %v\n", name, err) //nolint:errcheck
+		return
+	}
 	if session.Metadata == nil {
 		session.Metadata = make(map[string]string, len(batch))
 	}
 	for key, value := range batch {
 		session.Metadata[key] = value
+	}
+	if dops != nil {
+		_ = dops.clearDrain(name)
+	}
+	if dt != nil {
+		dt.clearIdleProbe(session.ID)
+		dt.remove(session.ID)
+	}
+	recordStopped()
+	if hasAssignedWork {
+		recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, template, template, name, rec, stderr)
 	}
 }
 
@@ -225,6 +294,7 @@ func reconcileDrainAckStopPending(
 	desired bool,
 	dops drainOps,
 	dt *drainTracker,
+	asyncStopTracker *asyncStartTracker,
 	clk clock.Clock,
 	rec events.Recorder,
 	stderr io.Writer,
@@ -235,7 +305,7 @@ func reconcileDrainAckStopPending(
 	name := strings.TrimSpace(session.Metadata["session_name"])
 	obs, err := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, session.ID, tp.Hints.ProcessNames)
 	if err != nil || obs.Running || obs.Alive {
-		queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name)
+		queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
 		return true
 	}
 	finalizeDrainAckStoppedSession(
@@ -255,6 +325,7 @@ func finalizeDrainAckStopPendingSessions(
 	sessions []beads.Bead,
 	dops drainOps,
 	dt *drainTracker,
+	asyncStopTracker *asyncStartTracker,
 	clk clock.Clock,
 	rec events.Recorder,
 	stderr io.Writer,
@@ -271,9 +342,12 @@ func finalizeDrainAckStopPendingSessions(
 		name := strings.TrimSpace(session.Metadata["session_name"])
 		obs, err := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, session.ID, nil)
 		if err != nil || obs.Running || obs.Alive {
-			queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name)
+			queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
 			continue
 		}
+		// Pool-managed stop-pending beads close here instead of staying open as
+		// state=drained: open pool session beads occupy slots in the next demand
+		// calculation, while closed beads remain only as lifecycle history.
 		finalizeDrainAckStoppedSession(
 			cityPath, cfg, store, rigStores, session,
 			normalizedSessionTemplate(*session, cfg),
@@ -738,9 +812,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		startupTimeout = cfg.Session.StartupTimeoutDuration()
 	}
 	maxAgeTr := reconcileOpts.maxSessionAgeTr
-	recordPhase := func(name string, start time.Time, fields map[string]any) {
+	asyncStopTracker := reconcileOpts.asyncStopTracker
+	recordPhase := func(site TraceSiteCode, name string, start time.Time, fields map[string]any) {
 		if trace != nil {
-			trace.RecordControllerOperation(TraceSiteControllerTickPhase, TraceReasonRetained, TraceOutcomeComplete, name, time.Since(start), fields)
+			trace.RecordControllerOperation(site, TraceReasonRetained, TraceOutcomeComplete, name, time.Since(start), fields)
 		}
 	}
 	phaseStart := time.Now()
@@ -748,7 +823,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	if cityName == "" {
 		cityName = config.EffectiveCityName(cfg, "")
 	}
-	recordPhase("session_reconcile.build_deps", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileBuildDeps, "session_reconcile.build_deps", phaseStart, map[string]any{
 		"dependency_template_count": len(deps),
 	})
 
@@ -773,14 +848,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			store, rigStores, sp, cfg, cityName, sessions, bySessionName, indexBySessionName, clk.Now().UTC(), stderr,
 		)
 	}
-	recordPhase("session_reconcile.heal_and_retire_duplicates", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileHealRetire, "session_reconcile.heal_and_retire_duplicates", phaseStart, map[string]any{
 		"session_count": len(sessions),
 	})
 
 	// Topo-order sessions by template dependencies.
 	phaseStart = time.Now()
 	ordered := topoOrder(sessions, deps)
-	recordPhase("session_reconcile.topo_order", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileTopoOrder, "session_reconcile.topo_order", phaseStart, map[string]any{
 		"ordered_session_count": len(ordered),
 	})
 
@@ -832,7 +907,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 		cb.pruneIdle(cbNow)
 	}
-	recordPhase("session_reconcile.circuit_breaker_restore", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileCircuitBreaker, "session_reconcile.circuit_breaker_restore", phaseStart, map[string]any{
 		"enabled":       cbEnabled,
 		"session_count": len(ordered),
 	})
@@ -889,7 +964,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		name := strings.TrimSpace(session.Metadata["session_name"])
 		tp, desired := desiredState[name]
 
-		if reconcileDrainAckStopPending(cityPath, cfg, sp, store, rigStores, session, tp, desired, dops, dt, clk, rec, stderr) {
+		if reconcileDrainAckStopPending(cityPath, cfg, sp, store, rigStores, session, tp, desired, dops, dt, asyncStopTracker, clk, rec, stderr) {
 			continue
 		}
 
@@ -1082,12 +1157,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							if template == "" {
 								template = session.Metadata["template"]
 							}
-							if hasAssignedWork {
-								recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, template, template, name, rec, stderr)
-							}
-							if markDrainAckStopPending(session, store, clk) {
+							if markDrainAckStopPending(session, store, clk, stderr) {
 								clearDrainTrackerForStopPending(session, dt)
-								queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name)
+								queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
 								if trace != nil {
 									trace.recordDecision("reconciler.session.drain_ack", template, name, "orphaned", "stop_pending", nil, nil, "")
 								}
@@ -1285,49 +1357,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						continue
 					}
 					if alive {
-						hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
-						if assignedErr != nil {
-							fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
-							hasAssignedWork = true
-						}
-						if hasAssignedWork {
-							recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, tp.DisplayName(), tp.TemplateName, name, rec, stderr)
-						}
-						if markDrainAckStopPending(session, store, clk) {
+						if markDrainAckStopPending(session, store, clk, stderr) {
 							clearDrainTrackerForStopPending(session, dt)
-							queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name)
+							queueDrainAckAsyncStop(cityPath, store, sp, cfg, session.ID, name, asyncStopTracker, stderr)
 							if trace != nil {
 								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "acknowledged", "stop_pending", nil, nil, "")
 							}
 						}
 						continue
-					}
-					if store != nil && session.ID != "" {
-						// Drain-ack lands here right after the agent ran
-						// `bd close` on its last unit of work. The cached
-						// `ownershipWorkBeads` snapshot taken earlier in
-						// this tick predates that close, so it still shows
-						// the bead as open+assigned and falsely flipped
-						// pool workers into CompleteDrainPatch
-						// (state=asleep + sleep_reason=idle) instead of
-						// AcknowledgeDrainPatch (state=drained). That hid
-						// the bead from the close gate and stranded new
-						// queue work on a ghost slot. Re-query the store
-						// so the decision reflects reality.
-						hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
-						if assignedErr != nil {
-							fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
-							hasAssignedWork = true
-						}
-						if hasAssignedWork {
-							// gastownhall/gascity#2293: cap-hit-shape drain-ack —
-							// the worker exited mid-task without nulling the
-							// bead's assignee. Emit a typed event so pack-side
-							// subscribers can apply recovery policy. SDK stays
-							// out of the commit/push/respawn decision (ZFC +
-							// zero hardcoded roles per AGENTS.md).
-							recordDrainAckAssignedWorkEvent(cityPath, cfg, store, rigStores, *session, tp.DisplayName(), tp.TemplateName, name, rec, stderr)
-						}
 					}
 					finalizeDT := dt
 					if reconcilerOwnedAck {
@@ -1890,7 +1927,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		wakeTargets = append(wakeTargets, wakeTarget{session: session, tp: tp, alive: alive})
 	}
-	recordPhase("session_reconcile.forward_pass", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileForwardPass, "session_reconcile.forward_pass", phaseStart, map[string]any{
 		"ordered_session_count":  len(ordered),
 		"wake_target_count":      len(wakeTargets),
 		"rollback_count":         rollbacksThisTick,
@@ -1946,7 +1983,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 	idleProbeTargets := selectIdleProbeTargets(wakeTargets, wakeEvals, dt)
 	launchIdleProbes(ctx, idleProbeTargets, wakeTargets, dt, sp, clk)
-	recordPhase("session_reconcile.compute_awake_set_and_idle_probes", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileAwakeSet, "session_reconcile.compute_awake_set_and_idle_probes", phaseStart, map[string]any{
 		"wake_target_count":      len(wakeTargets),
 		"idle_probe_target_cnt":  len(idleProbeTargets),
 		"awake_decision_count":   len(awakeDecisions),
@@ -2114,7 +2151,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			closeBead(store, target.session.ID, closeReason, clk.Now().UTC(), stderr)
 		}
 	}
-	recordPhase("session_reconcile.apply_wake_sleep_decisions", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileWakeSleep, "session_reconcile.apply_wake_sleep_decisions", phaseStart, map[string]any{
 		"wake_target_count":     len(wakeTargets),
 		"start_candidate_count": len(startCandidates),
 	})
@@ -2130,7 +2167,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		clk, rec, startupTimeout, stdout, stderr, trace,
 		effectiveStartOptions...,
 	)
-	recordPhase("session_reconcile.execute_planned_starts", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileStartExecution, "session_reconcile.execute_planned_starts", phaseStart, map[string]any{
 		"start_candidate_count": len(startCandidates),
 		"planned_wake_count":    plannedWakes,
 	})
@@ -2146,7 +2183,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	}
 	advanceSessionDrainsWithSessionsTraced(dt, sp, store, sessionLookup, ordered, wakeEvals, cfg, poolDesired, nil, readyWaitSet, clk, trace)
 	clearMissingIdleProbes(dt, beadByID)
-	recordPhase("session_reconcile.advance_drains", phaseStart, map[string]any{
+	recordPhase(TraceSiteSessionReconcileDrainAdvance, "session_reconcile.advance_drains", phaseStart, map[string]any{
 		"ordered_session_count": len(ordered),
 		"wake_eval_count":       len(wakeEvals),
 	})

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -93,6 +93,29 @@ func (p *transientPeekErrorProvider) Peek(name string, lines int) (string, error
 	return p.Fake.Peek(name, lines)
 }
 
+type blockingStopProvider struct {
+	*runtime.Fake
+	stopStarted chan string
+	releaseStop chan struct{}
+}
+
+func newBlockingStopProvider() *blockingStopProvider {
+	return &blockingStopProvider{
+		Fake:        runtime.NewFake(),
+		stopStarted: make(chan string, 8),
+		releaseStop: make(chan struct{}),
+	}
+}
+
+func (p *blockingStopProvider) Stop(name string) error {
+	select {
+	case p.stopStarted <- name:
+	default:
+	}
+	<-p.releaseStop
+	return p.Fake.Stop(name)
+}
+
 type delayedSessionExistsProvider struct {
 	*runtime.Fake
 	pendingConflict map[string]bool
@@ -510,6 +533,41 @@ func reconcileSessionBeadsWithTaskWorkDirSnapshot(
 	)
 }
 
+func waitForProviderStopped(t *testing.T, sp runtime.Provider, name string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !sp.IsRunning(name) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("session %q still running after async stop", name)
+}
+
+func (e *reconcilerTestEnv) reconcileStopPendingToTerminal(t *testing.T, sp runtime.Provider, session beads.Bead, dops drainOps, cfgNames map[string]bool) beads.Bead {
+	t.Helper()
+	name := strings.TrimSpace(session.Metadata["session_name"])
+	waitForProviderStopped(t, sp, name)
+	got, err := e.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s) before stop-pending finalize: %v", session.ID, err)
+	}
+	woken := reconcileSessionBeads(
+		context.Background(), []beads.Bead{got}, e.desiredState, cfgNames, e.cfg, sp,
+		e.store, dops, nil, nil, e.dt, nil, false, nil, "",
+		nil, e.clk, e.rec, 0, 0, &e.stdout, &e.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken during stop-pending finalize = %d, want 0", woken)
+	}
+	final, err := e.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s) after stop-pending finalize: %v", session.ID, err)
+	}
+	return final
+}
+
 func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -557,14 +615,7 @@ func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
 	}
-	if env.sp.IsRunning("worker") {
-		t.Fatal("worker should be stopped after drain-ack")
-	}
-
-	got, err := env.store.Get(session.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", session.ID, err)
-	}
+	got := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
 	if got.Status == "closed" {
 		t.Fatalf("session bead closed unexpectedly: metadata=%v", got.Metadata)
 	}
@@ -610,6 +661,140 @@ func TestReconcileSessionBeads_DesiredFastPathSkipsAttachmentActivityObservation
 	}
 	if got := env.sp.CountCalls("GetLastActivity", "worker"); got != 0 {
 		t.Fatalf("GetLastActivity calls = %d, want 0 on desired fast path", got)
+	}
+}
+
+func TestReconcileSessionBeads_DrainAckMarksStopPendingAndStopsAsync(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.addDesired("worker", "worker", false)
+	sp := newBlockingStopProvider()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	releaseStop := func() {
+		select {
+		case <-sp.releaseStop:
+		default:
+			close(sp.releaseStop)
+		}
+	}
+	t.Cleanup(releaseStop)
+
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		"pending_create_claim": "true",
+	})
+	if err := sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	done := make(chan int, 1)
+	go func() {
+		done <- reconcileSessionBeads(
+			context.Background(),
+			[]beads.Bead{session},
+			env.desiredState,
+			map[string]bool{"worker": true},
+			env.cfg,
+			sp,
+			env.store,
+			dops,
+			nil,
+			nil,
+			env.dt,
+			nil,
+			false,
+			nil,
+			"",
+			nil,
+			env.clk,
+			env.rec,
+			0,
+			0,
+			&env.stdout,
+			&env.stderr,
+		)
+	}()
+
+	select {
+	case woken := <-done:
+		if woken != 0 {
+			t.Fatalf("woken = %d, want 0", woken)
+		}
+	case <-time.After(200 * time.Millisecond):
+		releaseStop()
+		t.Fatal("reconcile blocked on provider Stop; drain-ack stop must be async")
+	}
+
+	select {
+	case name := <-sp.stopStarted:
+		if name != "worker" {
+			t.Fatalf("Stop called for %q, want worker", name)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("async Stop was not started")
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state"] != string(sessionpkg.StateDraining) {
+		t.Fatalf("state = %q, want draining", got.Metadata["state"])
+	}
+	if got.Metadata["state_reason"] != sessionpkg.DrainAckStopPendingReason {
+		t.Fatalf("state_reason = %q, want %q", got.Metadata["state_reason"], sessionpkg.DrainAckStopPendingReason)
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared before async stop", got.Metadata["pending_create_claim"])
+	}
+	if len(dops.clearDrainCalls) != 0 {
+		t.Fatalf("clearDrain calls = %v, want none until terminal patch", dops.clearDrainCalls)
+	}
+	if !sp.IsRunning("worker") {
+		t.Fatal("worker stopped before release; test no longer proves async stop-pending behavior")
+	}
+}
+
+func TestFinalizeDrainAckStopPendingSessionsClosesStoppedPoolBeforeAllocation(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	session := env.createSessionBead("worker", "worker")
+	patch := sessionpkg.DrainAckStopPendingPatch(env.clk.Now().UTC())
+	patch[poolManagedMetadataKey] = boolMetadata(true)
+	if err := env.store.SetMetadataBatch(session.ID, patch); err != nil {
+		t.Fatalf("SetMetadataBatch(stop-pending): %v", err)
+	}
+	session.Metadata = patch.Apply(session.Metadata)
+
+	finalized := finalizeDrainAckStopPendingSessions(
+		"", env.cfg, env.sp, env.store, nil, []beads.Bead{session},
+		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
+	)
+	if finalized != 1 {
+		t.Fatalf("finalized = %d, want 1", finalized)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed so the pool slot is free before allocation", got.Status)
+	}
+	if got.Metadata["state"] != "drained" {
+		t.Fatalf("state = %q, want drained", got.Metadata["state"])
 	}
 }
 
@@ -662,14 +847,7 @@ func TestReconcileSessionBeads_DrainAckWithAssignedOpenWorkSleepsInsteadOfDraini
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
 	}
-	if env.sp.IsRunning("worker") {
-		t.Fatal("worker should be stopped after drain-ack")
-	}
-
-	got, err := env.store.Get(session.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", session.ID, err)
-	}
+	got := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
 	if got.Status == "closed" {
 		t.Fatalf("session bead closed unexpectedly: metadata=%v", got.Metadata)
 	}
@@ -879,14 +1057,7 @@ func TestReconcileSessionBeads_UndesiredDrainAckStopsAndCloses(t *testing.T) {
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
 	}
-	if env.sp.IsRunning("worker") {
-		t.Fatal("worker should be stopped after drain-ack even after leaving desired state")
-	}
-
-	got, err := env.store.Get(session.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", session.ID, err)
-	}
+	got := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, nil)
 	if got.Status != "closed" {
 		t.Fatalf("status = %q, want closed; metadata=%v", got.Status, got.Metadata)
 	}
@@ -946,14 +1117,7 @@ func TestReconcileSessionBeads_UndesiredDrainAckWithAssignedOpenWorkSleepsInstea
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
 	}
-	if env.sp.IsRunning("worker") {
-		t.Fatal("worker should be stopped after drain-ack even after leaving desired state")
-	}
-
-	got, err := env.store.Get(session.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", session.ID, err)
-	}
+	got := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, nil)
 	if got.Status == "closed" {
 		t.Fatalf("session bead closed unexpectedly: metadata=%v", got.Metadata)
 	}
@@ -1023,10 +1187,7 @@ func TestReconcileSessionBeads_DrainAckUsesLiveStoreQuery(t *testing.T) {
 		&env.stderr,
 	)
 
-	got, err := env.store.Get(session.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", session.ID, err)
-	}
+	got := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
 	if got.Metadata["state"] != "drained" {
 		t.Fatalf("state = %q, want drained — drain-ack must query the live store and land a session with no assigned work in drained state", got.Metadata["state"])
 	}
@@ -1161,9 +1322,40 @@ func TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed(t *testing.T) {
 		&env.stderr,
 	)
 
+	waitForProviderStopped(t, env.sp, "worker")
+	stopPending, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s) before fail-closed finalize: %v", session.ID, err)
+	}
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{stopPending},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		erroring,
+		dops,
+		nil,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
 	got, err := env.store.Get(session.ID)
 	if err != nil {
-		t.Fatalf("Get(%s): %v", session.ID, err)
+		t.Fatalf("Get(%s) after fail-closed finalize: %v", session.ID, err)
 	}
 	if got.Metadata["state"] != "asleep" || got.Metadata["sleep_reason"] != "idle" {
 		t.Fatalf("state=%q sleep_reason=%q, want asleep/idle — live-query error must fail closed (hasAssignedWork=true) so the session does not enter drained state",
@@ -1536,10 +1728,7 @@ func TestReconcileSessionBeads_DrainAckResumeModePreservesSessionIdentity(t *tes
 		t.Fatalf("woken = %d, want 0", woken)
 	}
 
-	got, err := env.store.Get(session.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", session.ID, err)
-	}
+	got := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
 	if got.Metadata["state"] != "drained" {
 		t.Fatalf("state = %q, want drained", got.Metadata["state"])
 	}
@@ -1601,10 +1790,7 @@ func TestReconcileSessionBeads_DrainAckFreshModeClearsSessionIdentity(t *testing
 		t.Fatalf("woken = %d, want 0", woken)
 	}
 
-	got, err := env.store.Get(session.ID)
-	if err != nil {
-		t.Fatalf("Get(%s): %v", session.ID, err)
-	}
+	got := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
 	if got.Metadata["state"] != "drained" {
 		t.Fatalf("state = %q, want drained", got.Metadata["state"])
 	}
@@ -1744,15 +1930,17 @@ func TestReconcileSessionBeads_DrainAckStopFailurePreservesMetadata(t *testing.T
 	if err != nil {
 		t.Fatalf("Get(%s): %v", session.ID, err)
 	}
-	// When Stop fails, metadata should NOT be updated — the session is still alive.
-	if got.Metadata["state"] == "drained" {
-		t.Fatalf("state should not be drained when stop failed")
+	if got.Metadata["state"] != string(sessionpkg.StateDraining) {
+		t.Fatalf("state = %q, want draining while async stop retry is pending", got.Metadata["state"])
+	}
+	if got.Metadata["state_reason"] != sessionpkg.DrainAckStopPendingReason {
+		t.Fatalf("state_reason = %q, want %q", got.Metadata["state_reason"], sessionpkg.DrainAckStopPendingReason)
 	}
 	if got.Metadata["last_woke_at"] == "" {
-		t.Fatalf("last_woke_at should be preserved when stop failed")
+		t.Fatalf("last_woke_at should be preserved while stop is still pending")
 	}
 	if got.Metadata["session_key"] == "" {
-		t.Fatalf("session_key should be preserved when stop failed")
+		t.Fatalf("session_key should be preserved while stop is still pending")
 	}
 }
 
@@ -1803,10 +1991,7 @@ func TestReconcileSessionBeads_DrainAckResumeModeNotClassifiedAsCrashNextTick(t 
 		t.Fatalf("woken = %d, want 0", woken)
 	}
 
-	got, err := env.store.Get(session.ID)
-	if err != nil {
-		t.Fatalf("Get(%s) after drain-ack: %v", session.ID, err)
-	}
+	got := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
 	if got.Metadata["last_woke_at"] != "" {
 		t.Fatalf("last_woke_at = %q, want cleared after drain-ack", got.Metadata["last_woke_at"])
 	}
@@ -1839,7 +2024,7 @@ func TestReconcileSessionBeads_DrainAckResumeModeNotClassifiedAsCrashNextTick(t 
 		t.Fatalf("second tick woken = %d, want 0", woken)
 	}
 
-	got, err = env.store.Get(session.ID)
+	got, err := env.store.Get(session.ID)
 	if err != nil {
 		t.Fatalf("Get(%s) after second tick: %v", session.ID, err)
 	}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -114,6 +115,41 @@ func (p *blockingStopProvider) Stop(name string) error {
 	}
 	<-p.releaseStop
 	return p.Fake.Stop(name)
+}
+
+type shutdownWaitStopProvider struct {
+	*blockingStopProvider
+	listCalled chan struct{}
+	listOnce   sync.Once
+}
+
+func newShutdownWaitStopProvider() *shutdownWaitStopProvider {
+	return &shutdownWaitStopProvider{
+		blockingStopProvider: newBlockingStopProvider(),
+		listCalled:           make(chan struct{}),
+	}
+}
+
+func (p *shutdownWaitStopProvider) ListRunning(prefix string) ([]string, error) {
+	p.listOnce.Do(func() { close(p.listCalled) })
+	return p.Fake.ListRunning(prefix)
+}
+
+type synchronizedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 type delayedSessionExistsProvider struct {
@@ -765,6 +801,72 @@ func TestReconcileSessionBeads_DrainAckMarksStopPendingAndStopsAsync(t *testing.
 	}
 }
 
+func TestQueueDrainAckAsyncStopTracksShutdownWait(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := newBlockingStopProvider()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	var stderr synchronizedBuffer
+	tracker := &asyncStartTracker{}
+	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", tracker, &stderr)
+
+	select {
+	case <-sp.stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("async drain-ack stop did not start")
+	}
+
+	if tracker.wait(10 * time.Millisecond) {
+		t.Fatal("async drain-ack stop tracker reported drained while Stop is blocked")
+	}
+	close(sp.releaseStop)
+	if !tracker.wait(time.Second) {
+		t.Fatal("async drain-ack stop tracker did not drain after Stop returned")
+	}
+}
+
+func TestCityRuntimeShutdownWaitsForTrackedAsyncDrainAckStopsBeforeStopSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := newShutdownWaitStopProvider()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	cr := &CityRuntime{
+		cfg:                 &config.City{Daemon: config.DaemonConfig{ShutdownTimeout: "500ms"}},
+		sp:                  sp,
+		rec:                 events.Discard,
+		standaloneCityStore: store,
+		logPrefix:           "gc test",
+		stdout:              ioDiscard{},
+		stderr:              ioDiscard{},
+	}
+	queueDrainAckAsyncStop("", store, sp, cr.cfg, "gc-worker", "worker", &cr.asyncStops, &synchronizedBuffer{})
+
+	select {
+	case <-sp.stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("async drain-ack stop did not start")
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		cr.shutdown()
+		close(shutdownDone)
+	}()
+	select {
+	case <-sp.listCalled:
+		t.Fatal("shutdown took stop snapshot before async drain-ack stop finished")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(sp.releaseStop)
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not finish after async drain-ack stop returned")
+	}
+}
+
 func TestFinalizeDrainAckStopPendingSessionsClosesStoppedPoolBeforeAllocation(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -780,7 +882,7 @@ func TestFinalizeDrainAckStopPendingSessionsClosesStoppedPoolBeforeAllocation(t 
 
 	finalized := finalizeDrainAckStopPendingSessions(
 		"", env.cfg, env.sp, env.store, nil, []beads.Bead{session},
-		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
+		newFakeDrainOps(), env.dt, nil, env.clk, env.rec, &env.stderr,
 	)
 	if finalized != 1 {
 		t.Fatalf("finalized = %d, want 1", finalized)
@@ -867,8 +969,9 @@ func TestReconcileSessionBeads_DrainAckWithAssignedOpenWorkSleepsInsteadOfDraini
 // while still holding the assignee on an in-progress work bead (the cap-hit
 // shape — worker exited mid-task without nulling assignee), the reconciler
 // MUST emit events.SessionDrainAckedWithAssignedWork carrying the session
-// and bead IDs so pack-side subscribers can apply recovery policy. The SDK
-// reconciler stops at the event; it does not commit, push, or clear assignee.
+// and bead IDs exactly once after the provider stop has completed so pack-side
+// subscribers can apply recovery policy. The SDK reconciler stops at the event;
+// it does not commit, push, or clear assignee.
 func TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
@@ -921,16 +1024,28 @@ func TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent(t *testing
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
 	}
+	gotSession := env.reconcileStopPendingToTerminal(t, env.sp, session, dops, map[string]bool{"worker": true})
+	if gotSession.Status == "closed" {
+		t.Fatalf("session bead closed unexpectedly: metadata=%v", gotSession.Metadata)
+	}
+	if gotSession.Metadata["state"] != "asleep" || gotSession.Metadata["sleep_reason"] != "idle" {
+		t.Fatalf("session state=%q sleep_reason=%q, want asleep/idle after assigned-work drain-ack",
+			gotSession.Metadata["state"], gotSession.Metadata["sleep_reason"])
+	}
 
 	var matched *events.Event
+	matches := 0
 	for i := range fake.Events {
 		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			matches++
 			matched = &fake.Events[i]
-			break
 		}
 	}
 	if matched == nil {
 		t.Fatalf("expected %s event, got %d events of other types", events.SessionDrainAckedWithAssignedWork, len(fake.Events))
+	}
+	if matches != 1 {
+		t.Fatalf("%s events = %d, want exactly 1 across stop-pending lifecycle", events.SessionDrainAckedWithAssignedWork, matches)
 	}
 	if !strings.Contains(string(matched.Payload), session.ID) {
 		t.Errorf("event payload does not reference session ID %q: %s", session.ID, matched.Payload)
@@ -950,6 +1065,93 @@ func TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent(t *testing
 	}
 	if got.Status == "closed" {
 		t.Errorf("stranded bead status = %q, SDK must not close the bead", got.Status)
+	}
+}
+
+func TestReconcileSessionBeads_DeadDesiredDrainAckWithAssignedWorkEmitsOneEvent(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+	fake := events.NewFake()
+	env.rec = fake
+
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	stranded, err := env.store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(stranded bead): %v", err)
+	}
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	gotSession, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if gotSession.Status == "closed" {
+		t.Fatalf("session bead closed unexpectedly: metadata=%v", gotSession.Metadata)
+	}
+	if gotSession.Metadata["state"] != "asleep" || gotSession.Metadata["sleep_reason"] != "idle" {
+		t.Fatalf("session state=%q sleep_reason=%q, want asleep/idle after assigned-work drain-ack",
+			gotSession.Metadata["state"], gotSession.Metadata["sleep_reason"])
+	}
+
+	matches := 0
+	var matched *events.Event
+	for i := range fake.Events {
+		if fake.Events[i].Type == events.SessionDrainAckedWithAssignedWork {
+			matches++
+			matched = &fake.Events[i]
+		}
+	}
+	if matched == nil {
+		t.Fatalf("expected %s event, got %d events of other types", events.SessionDrainAckedWithAssignedWork, len(fake.Events))
+	}
+	if matches != 1 {
+		t.Fatalf("%s events = %d, want exactly 1 for already-stopped desired drain-ack", events.SessionDrainAckedWithAssignedWork, matches)
+	}
+	if !strings.Contains(string(matched.Payload), session.ID) {
+		t.Errorf("event payload does not reference session ID %q: %s", session.ID, matched.Payload)
+	}
+	if !strings.Contains(string(matched.Payload), stranded.ID) {
+		t.Errorf("event payload does not reference stranded bead ID %q: %s", stranded.ID, matched.Payload)
 	}
 }
 
@@ -1270,6 +1472,110 @@ func (s *listErrStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 		return nil, s.err
 	}
 	return s.Store.List(q)
+}
+
+type assignOnListStore struct {
+	beads.Store
+	sessionID string
+	calls     int
+	assigned  bool
+}
+
+func (s *assignOnListStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.calls++
+	if !s.assigned && s.calls == 3 {
+		if _, err := s.Create(beads.Bead{
+			Title:    "raced assigned work",
+			Type:     "task",
+			Status:   "open",
+			Assignee: s.sessionID,
+		}); err != nil {
+			return nil, err
+		}
+		s.assigned = true
+	}
+	return s.Store.List(q)
+}
+
+type failSetMetadataBatchStore struct {
+	beads.Store
+	err error
+}
+
+func (s *failSetMetadataBatchStore) SetMetadataBatch(string, map[string]string) error {
+	if s.err != nil {
+		return s.err
+	}
+	return nil
+}
+
+func TestFinalizeDrainAckStoppedSessionDoesNotEmitEventsWhenFinalMetadataFails(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	fake := events.NewFake()
+	env.rec = fake
+
+	session := env.createSessionBead("worker", "worker")
+	patch := sessionpkg.DrainAckStopPendingPatch(env.clk.Now().UTC())
+	if err := env.store.SetMetadataBatch(session.ID, patch); err != nil {
+		t.Fatalf("SetMetadataBatch(stop-pending): %v", err)
+	}
+	session.Metadata = patch.Apply(session.Metadata)
+
+	failingStore := &failSetMetadataBatchStore{Store: env.store, err: errors.New("metadata write failed")}
+	finalizeDrainAckStoppedSession(
+		"", env.cfg, failingStore, nil, &session, "worker", false,
+		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
+	)
+
+	if len(fake.Events) != 0 {
+		t.Fatalf("events emitted before final metadata persisted: %v", fake.Events)
+	}
+	if !strings.Contains(env.stderr.String(), "finalizing drain-ack stopped worker") {
+		t.Fatalf("stderr = %q, want final metadata failure diagnostic", env.stderr.String())
+	}
+}
+
+func TestFinalizeDrainAckStoppedSessionFallsThroughWhenCloseGateRacesWithAssignment(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	fake := events.NewFake()
+	env.rec = fake
+
+	session := env.createSessionBead("worker", "worker")
+	patch := sessionpkg.DrainAckStopPendingPatch(env.clk.Now().UTC())
+	if err := env.store.SetMetadataBatch(session.ID, patch); err != nil {
+		t.Fatalf("SetMetadataBatch(stop-pending): %v", err)
+	}
+	session.Metadata = patch.Apply(session.Metadata)
+
+	racingStore := &assignOnListStore{Store: env.store, sessionID: session.ID}
+	finalizeDrainAckStoppedSession(
+		"", env.cfg, racingStore, nil, &session, "worker", true,
+		newFakeDrainOps(), env.dt, env.clk, env.rec, &env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("session bead closed after close-gate assignment race: metadata=%v", got.Metadata)
+	}
+	if got.Metadata["state"] != "asleep" || got.Metadata["sleep_reason"] != "idle" {
+		t.Fatalf("state=%q sleep_reason=%q, want asleep/idle after close-gate assignment race",
+			got.Metadata["state"], got.Metadata["sleep_reason"])
+	}
+
+	matches := 0
+	for _, ev := range fake.Events {
+		if ev.Type == events.SessionDrainAckedWithAssignedWork {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("%s events = %d, want 1 after assignment race", events.SessionDrainAckedWithAssignedWork, matches)
+	}
 }
 
 // TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed guards the
@@ -1869,9 +2175,16 @@ func TestReconcileSessionBeads_DrainedPoolSessionStoreQueryPartialStaysOpen(t *t
 // The session remains running (IsRunning returns true).
 type stopFailProvider struct {
 	*runtime.Fake
+	stopCalled chan struct{}
 }
 
 func (p *stopFailProvider) Stop(_ string) error {
+	if p.stopCalled != nil {
+		select {
+		case p.stopCalled <- struct{}{}:
+		default:
+		}
+	}
 	return fmt.Errorf("stop failed: session unavailable")
 }
 
@@ -1896,7 +2209,9 @@ func TestReconcileSessionBeads_DrainAckStopFailurePreservesMetadata(t *testing.T
 	}
 
 	// Wrap the real provider so Stop fails but IsRunning still returns true.
-	failSp := &stopFailProvider{Fake: env.sp}
+	stopCalled := make(chan struct{}, 1)
+	failSp := &stopFailProvider{Fake: env.sp, stopCalled: stopCalled}
+	var stderr synchronizedBuffer
 
 	woken := reconcileSessionBeads(
 		context.Background(),
@@ -1920,10 +2235,22 @@ func TestReconcileSessionBeads_DrainAckStopFailurePreservesMetadata(t *testing.T
 		0,
 		0,
 		&env.stdout,
-		&env.stderr,
+		&stderr,
 	)
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
+	}
+	select {
+	case <-stopCalled:
+	case <-time.After(time.Second):
+		t.Fatal("async Stop was not called")
+	}
+	deadline := time.Now().Add(time.Second)
+	for !strings.Contains(stderr.String(), "session reconciler: async drain-ack stop worker: stop failed: session unavailable") && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := stderr.String(); !strings.Contains(got, "session reconciler: async drain-ack stop worker: stop failed: session unavailable") {
+		t.Fatalf("stderr = %q, want async stop error", got)
 	}
 
 	got, err := env.store.Get(session.ID)
@@ -1941,6 +2268,61 @@ func TestReconcileSessionBeads_DrainAckStopFailurePreservesMetadata(t *testing.T
 	}
 	if got.Metadata["session_key"] == "" {
 		t.Fatalf("session_key should be preserved while stop is still pending")
+	}
+}
+
+type failStopPendingStore struct {
+	beads.Store
+}
+
+func (s *failStopPendingStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if kvs["state_reason"] == sessionpkg.DrainAckStopPendingReason {
+		return errors.New("stop-pending metadata failed")
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+func TestReconcileSessionBeads_DrainAckStopPendingMetadataFailureLogsDiagnostic(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		&failStopPendingStore{Store: env.store},
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	if got := env.stderr.String(); !strings.Contains(got, "session reconciler: marking drain-ack stop-pending worker: stop-pending metadata failed") {
+		t.Fatalf("stderr = %q, want stop-pending metadata diagnostic", got)
 	}
 }
 

--- a/cmd/gc/session_reconciler_trace_cycle.go
+++ b/cmd/gc/session_reconciler_trace_cycle.go
@@ -95,6 +95,27 @@ func (c *SessionReconcilerTraceCycle) RecordControllerDecision(site TraceSiteCod
 	c.addRecord(rec)
 }
 
+// RecordControllerOperation records an always-on controller phase duration.
+func (c *SessionReconcilerTraceCycle) RecordControllerOperation(site TraceSiteCode, reason TraceReasonCode, outcome TraceOutcomeCode, opName string, duration time.Duration, fields map[string]any) {
+	if c == nil {
+		return
+	}
+	rec := newTraceRecord(TraceRecordOperation).withCycle(c, time.Now().UTC())
+	rec.SiteCode = site
+	rec.ReasonCode = reason
+	rec.OutcomeCode = outcome
+	rec.OperationID = newTraceID(opName)
+	rec.TraceMode = TraceModeBaseline
+	rec.TraceSource = TraceSourceAlwaysOn
+	rec.DurationMS = duration.Milliseconds()
+	rec.ensureFields()
+	rec.Fields["operation_name"] = opName
+	for k, v := range fields {
+		rec.Fields[k] = v
+	}
+	c.addRecord(rec)
+}
+
 func (c *SessionReconcilerTraceCycle) recordOperation(siteCode, template, sessionName, _ string, reason, outcome string, data traceRecordPayload, _ string) {
 	if c == nil {
 		return

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -497,6 +497,62 @@ func TestTraceCycleResultRollupIncludesFlushedRecords(t *testing.T) {
 	}
 }
 
+func TestRecordControllerOperationIsAlwaysOnBaseline(t *testing.T) {
+	cityDir := t.TempDir()
+	tracer := newSessionReconcilerTracer(cityDir, "trace-town", io.Discard)
+	if !tracer.Enabled() {
+		t.Fatal("tracer should be enabled")
+	}
+	cycle := tracer.BeginCycle(TraceTickTriggerPatrol, "", time.Now().UTC(), &config.City{})
+	if cycle == nil {
+		t.Fatal("BeginCycle returned nil")
+	}
+	cycle.RecordControllerOperation(
+		TraceSiteDesiredStateBuild,
+		TraceReasonRetained,
+		TraceOutcomeApplied,
+		"load_demand_snapshot",
+		42*time.Millisecond,
+		map[string]any{"phase": "demand"},
+	)
+	if err := cycle.End(TraceCompletionCompleted, map[string]any{}); err != nil {
+		t.Fatalf("End: %v", err)
+	}
+	if err := tracer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	records, err := ReadTraceRecords(traceCityRuntimeDir(cityDir), TraceFilter{})
+	if err != nil {
+		t.Fatalf("ReadTraceRecords: %v", err)
+	}
+	var op *SessionReconcilerTraceRecord
+	for i := range records {
+		if records[i].RecordType == TraceRecordOperation && records[i].SiteCode == TraceSiteDesiredStateBuild {
+			op = &records[i]
+			break
+		}
+	}
+	if op == nil {
+		t.Fatal("controller operation missing")
+	}
+	if op.TraceMode != TraceModeBaseline {
+		t.Fatalf("trace_mode = %q, want baseline", op.TraceMode)
+	}
+	if op.TraceSource != TraceSourceAlwaysOn {
+		t.Fatalf("trace_source = %q, want always_on", op.TraceSource)
+	}
+	if op.OperationID == "" {
+		t.Fatal("operation_id should be populated")
+	}
+	if op.DurationMS != 42 {
+		t.Fatalf("duration_ms = %d, want 42", op.DurationMS)
+	}
+	if op.Fields["phase"] != "demand" {
+		t.Fatalf("phase field = %#v, want demand", op.Fields["phase"])
+	}
+}
+
 func TestTraceFlushAfterEndOnlyPersistsPostEndRecords(t *testing.T) {
 	cityDir := t.TempDir()
 	tracer := newSessionReconcilerTracer(cityDir, "trace-town", io.Discard)

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,7 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 )
 
 func TestTraceDetailScopesIncludesDependencies(t *testing.T) {
@@ -550,6 +553,71 @@ func TestRecordControllerOperationIsAlwaysOnBaseline(t *testing.T) {
 	}
 	if op.Fields["phase"] != "demand" {
 		t.Fatalf("phase field = %#v, want demand", op.Fields["phase"])
+	}
+}
+
+func TestSessionReconcilePhaseTraceUsesDistinctSites(t *testing.T) {
+	cityDir := t.TempDir()
+	tracer := newSessionReconcilerTracer(cityDir, "trace-town", io.Discard)
+	defer tracer.Close() //nolint:errcheck
+	cycle := tracer.BeginCycle(TraceTickTriggerPatrol, "", time.Now().UTC(), &config.City{})
+	if cycle == nil {
+		t.Fatal("BeginCycle returned nil")
+	}
+
+	reconcileSessionBeadsTracedWithNamedDemand(
+		context.Background(),
+		cityDir,
+		nil,
+		nil,
+		nil,
+		&config.City{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		newDrainTracker(),
+		nil,
+		nil,
+		false,
+		nil,
+		"trace-town",
+		nil,
+		clock.Real{},
+		events.Discard,
+		0,
+		0,
+		io.Discard,
+		io.Discard,
+		cycle,
+	)
+
+	got := make(map[string]TraceSiteCode)
+	for _, rec := range cycle.records {
+		if rec.RecordType != TraceRecordOperation {
+			continue
+		}
+		name, _ := rec.Fields["operation_name"].(string)
+		if strings.HasPrefix(name, "session_reconcile.") {
+			got[name] = rec.SiteCode
+		}
+	}
+	want := map[string]TraceSiteCode{
+		"session_reconcile.build_deps":                        TraceSiteSessionReconcileBuildDeps,
+		"session_reconcile.heal_and_retire_duplicates":        TraceSiteSessionReconcileHealRetire,
+		"session_reconcile.topo_order":                        TraceSiteSessionReconcileTopoOrder,
+		"session_reconcile.forward_pass":                      TraceSiteSessionReconcileForwardPass,
+		"session_reconcile.compute_awake_set_and_idle_probes": TraceSiteSessionReconcileAwakeSet,
+		"session_reconcile.apply_wake_sleep_decisions":        TraceSiteSessionReconcileWakeSleep,
+		"session_reconcile.execute_planned_starts":            TraceSiteSessionReconcileStartExecution,
+		"session_reconcile.advance_drains":                    TraceSiteSessionReconcileDrainAdvance,
+	}
+	for name, site := range want {
+		if got[name] != site {
+			t.Fatalf("%s site = %q, want %q; all sites: %#v", name, got[name], site, got)
+		}
 	}
 }
 

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -62,8 +62,13 @@ const (
 	TraceSiteCycleStart              TraceSiteCode = "cycle.start"
 	TraceSiteCycleFinish             TraceSiteCode = "cycle.finish"
 	TraceSiteConfigReload            TraceSiteCode = "config.reload"
+	TraceSiteControllerTickPhase     TraceSiteCode = "controller.tick.phase"
 	TraceSiteDesiredStateBuild       TraceSiteCode = "desired_state.build"
+	TraceSiteDemandSnapshot          TraceSiteCode = "demand_snapshot.load"
+	TraceSiteOrderDispatch           TraceSiteCode = "orders.dispatch"
 	TraceSitePoolDemandCompute       TraceSiteCode = "pool_desired.compute"
+	TraceSiteSessionSnapshot         TraceSiteCode = "session_snapshot.load"
+	TraceSiteSessionSync             TraceSiteCode = "session_sync.update_index"
 	TraceSitePoolAgentCap            TraceSiteCode = "reconciler.pool.agent_cap"
 	TraceSitePoolRigCap              TraceSiteCode = "reconciler.pool.rig_cap"
 	TraceSitePoolWorkspaceCap        TraceSiteCode = "reconciler.pool.workspace_cap"
@@ -539,8 +544,13 @@ func normalizeTraceSiteCode(raw string) (TraceSiteCode, string) {
 		TraceSiteCycleStart,
 		TraceSiteCycleFinish,
 		TraceSiteConfigReload,
+		TraceSiteControllerTickPhase,
 		TraceSiteDesiredStateBuild,
+		TraceSiteDemandSnapshot,
+		TraceSiteOrderDispatch,
 		TraceSitePoolDemandCompute,
+		TraceSiteSessionSnapshot,
+		TraceSiteSessionSync,
 		TraceSitePoolAgentCap,
 		TraceSitePoolRigCap,
 		TraceSitePoolWorkspaceCap,

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -57,49 +57,58 @@ const (
 type TraceSiteCode string
 
 const (
-	TraceSiteUnknown                 TraceSiteCode = "unknown"
-	TraceSiteScaleCheckExec          TraceSiteCode = "trace.scale_check_exec"
-	TraceSiteCycleStart              TraceSiteCode = "cycle.start"
-	TraceSiteCycleFinish             TraceSiteCode = "cycle.finish"
-	TraceSiteConfigReload            TraceSiteCode = "config.reload"
-	TraceSiteControllerTickPhase     TraceSiteCode = "controller.tick.phase"
-	TraceSiteDesiredStateBuild       TraceSiteCode = "desired_state.build"
-	TraceSiteDemandSnapshot          TraceSiteCode = "demand_snapshot.load"
-	TraceSiteOrderDispatch           TraceSiteCode = "orders.dispatch"
-	TraceSitePoolDemandCompute       TraceSiteCode = "pool_desired.compute"
-	TraceSiteSessionSnapshot         TraceSiteCode = "session_snapshot.load"
-	TraceSiteSessionSync             TraceSiteCode = "session_sync.update_index"
-	TraceSitePoolAgentCap            TraceSiteCode = "reconciler.pool.agent_cap"
-	TraceSitePoolRigCap              TraceSiteCode = "reconciler.pool.rig_cap"
-	TraceSitePoolWorkspaceCap        TraceSiteCode = "reconciler.pool.workspace_cap"
-	TraceSitePoolAccept              TraceSiteCode = "reconciler.pool.accept"
-	TraceSitePoolMinFill             TraceSiteCode = "reconciler.pool.min_fill"
-	TraceSitePoolInFlightReuse       TraceSiteCode = "reconciler.pool.inflight_reuse"
-	TraceSiteReconcilerUnknownState  TraceSiteCode = "reconciler.session.skip_unknown_state"
-	TraceSiteReconcilerOrphaned      TraceSiteCode = "reconciler.session.orphan_or_suspended"
-	TraceSiteReconcilerCloseOrphan   TraceSiteCode = "reconciler.session.close_orphan"
-	TraceSiteReconcilerPendingCreate TraceSiteCode = "reconciler.session.rollback_pending_create"
-	TraceSiteReconcilerConfigDrift   TraceSiteCode = "reconciler.session.config_drift"
-	TraceSiteReconcilerIdleDrain     TraceSiteCode = "reconciler.session.idle_drain"
-	TraceSiteReconcilerIdleTimeout   TraceSiteCode = "reconciler.session.idle_timeout"
-	TraceSiteReconcilerWakeDecision  TraceSiteCode = "reconciler.session.wake_decision"
-	TraceSiteReconcilerDrainDecision TraceSiteCode = "reconciler.session.drain"
-	TraceSiteDrainStale              TraceSiteCode = "reconciler.drain.stale"
-	TraceSiteDrainComplete           TraceSiteCode = "reconciler.drain.complete"
-	TraceSiteDrainCancel             TraceSiteCode = "reconciler.drain.cancel"
-	TraceSiteDrainTimeout            TraceSiteCode = "reconciler.drain.timeout"
-	TraceSiteMutationBeadMetadata    TraceSiteCode = "bead_metadata"
-	TraceSiteMutationRuntimeMeta     TraceSiteCode = "runtime_meta"
-	TraceSiteLifecycleStartRollback  TraceSiteCode = "reconciler.start.rollback_pending"
-	TraceSiteLifecycleStartFailed    TraceSiteCode = "reconciler.start.failed"
-	TraceSiteLifecycleStartRun       TraceSiteCode = "reconciler.start.execute"
-	TraceSiteLifecycleStartPrepare   TraceSiteCode = "lifecycle.start.prepare"
-	TraceSiteLifecycleStartExecute   TraceSiteCode = "lifecycle.start.execute"
-	TraceSiteLifecycleStartCommit    TraceSiteCode = "lifecycle.start.commit"
-	TraceSiteLifecycleDrainBegin     TraceSiteCode = "lifecycle.drain.begin"
-	TraceSiteLifecycleDrainAdvance   TraceSiteCode = "lifecycle.drain.advance"
-	TraceSiteSupervisorFSPressure    TraceSiteCode = "supervisor.fs_pressure"
-	TraceSiteTraceControl            TraceSiteCode = "trace.control"
+	TraceSiteUnknown                        TraceSiteCode = "unknown"
+	TraceSiteScaleCheckExec                 TraceSiteCode = "trace.scale_check_exec"
+	TraceSiteCycleStart                     TraceSiteCode = "cycle.start"
+	TraceSiteCycleFinish                    TraceSiteCode = "cycle.finish"
+	TraceSiteConfigReload                   TraceSiteCode = "config.reload"
+	TraceSiteControllerTickPhase            TraceSiteCode = "controller.tick.phase"
+	TraceSiteDesiredStateBuild              TraceSiteCode = "desired_state.build"
+	TraceSiteDemandSnapshot                 TraceSiteCode = "demand_snapshot.load"
+	TraceSiteOrderDispatch                  TraceSiteCode = "orders.dispatch"
+	TraceSitePoolDemandCompute              TraceSiteCode = "pool_desired.compute"
+	TraceSiteSessionSnapshot                TraceSiteCode = "session_snapshot.load"
+	TraceSiteSessionSync                    TraceSiteCode = "session_sync.update_index"
+	TraceSiteSessionReconcileBuildDeps      TraceSiteCode = "session_reconcile.build_deps"
+	TraceSiteSessionReconcileHealRetire     TraceSiteCode = "session_reconcile.heal_retire"
+	TraceSiteSessionReconcileTopoOrder      TraceSiteCode = "session_reconcile.topo_order"
+	TraceSiteSessionReconcileCircuitBreaker TraceSiteCode = "session_reconcile.circuit_breaker"
+	TraceSiteSessionReconcileForwardPass    TraceSiteCode = "session_reconcile.forward_pass"
+	TraceSiteSessionReconcileAwakeSet       TraceSiteCode = "session_reconcile.awake_set"
+	TraceSiteSessionReconcileWakeSleep      TraceSiteCode = "session_reconcile.wake_sleep"
+	TraceSiteSessionReconcileStartExecution TraceSiteCode = "session_reconcile.start_execution"
+	TraceSiteSessionReconcileDrainAdvance   TraceSiteCode = "session_reconcile.drain_advance"
+	TraceSitePoolAgentCap                   TraceSiteCode = "reconciler.pool.agent_cap"
+	TraceSitePoolRigCap                     TraceSiteCode = "reconciler.pool.rig_cap"
+	TraceSitePoolWorkspaceCap               TraceSiteCode = "reconciler.pool.workspace_cap"
+	TraceSitePoolAccept                     TraceSiteCode = "reconciler.pool.accept"
+	TraceSitePoolMinFill                    TraceSiteCode = "reconciler.pool.min_fill"
+	TraceSitePoolInFlightReuse              TraceSiteCode = "reconciler.pool.inflight_reuse"
+	TraceSiteReconcilerUnknownState         TraceSiteCode = "reconciler.session.skip_unknown_state"
+	TraceSiteReconcilerOrphaned             TraceSiteCode = "reconciler.session.orphan_or_suspended"
+	TraceSiteReconcilerCloseOrphan          TraceSiteCode = "reconciler.session.close_orphan"
+	TraceSiteReconcilerPendingCreate        TraceSiteCode = "reconciler.session.rollback_pending_create"
+	TraceSiteReconcilerConfigDrift          TraceSiteCode = "reconciler.session.config_drift"
+	TraceSiteReconcilerIdleDrain            TraceSiteCode = "reconciler.session.idle_drain"
+	TraceSiteReconcilerIdleTimeout          TraceSiteCode = "reconciler.session.idle_timeout"
+	TraceSiteReconcilerWakeDecision         TraceSiteCode = "reconciler.session.wake_decision"
+	TraceSiteReconcilerDrainDecision        TraceSiteCode = "reconciler.session.drain"
+	TraceSiteDrainStale                     TraceSiteCode = "reconciler.drain.stale"
+	TraceSiteDrainComplete                  TraceSiteCode = "reconciler.drain.complete"
+	TraceSiteDrainCancel                    TraceSiteCode = "reconciler.drain.cancel"
+	TraceSiteDrainTimeout                   TraceSiteCode = "reconciler.drain.timeout"
+	TraceSiteMutationBeadMetadata           TraceSiteCode = "bead_metadata"
+	TraceSiteMutationRuntimeMeta            TraceSiteCode = "runtime_meta"
+	TraceSiteLifecycleStartRollback         TraceSiteCode = "reconciler.start.rollback_pending"
+	TraceSiteLifecycleStartFailed           TraceSiteCode = "reconciler.start.failed"
+	TraceSiteLifecycleStartRun              TraceSiteCode = "reconciler.start.execute"
+	TraceSiteLifecycleStartPrepare          TraceSiteCode = "lifecycle.start.prepare"
+	TraceSiteLifecycleStartExecute          TraceSiteCode = "lifecycle.start.execute"
+	TraceSiteLifecycleStartCommit           TraceSiteCode = "lifecycle.start.commit"
+	TraceSiteLifecycleDrainBegin            TraceSiteCode = "lifecycle.drain.begin"
+	TraceSiteLifecycleDrainAdvance          TraceSiteCode = "lifecycle.drain.advance"
+	TraceSiteSupervisorFSPressure           TraceSiteCode = "supervisor.fs_pressure"
+	TraceSiteTraceControl                   TraceSiteCode = "trace.control"
 )
 
 type TraceReasonCode string
@@ -551,6 +560,15 @@ func normalizeTraceSiteCode(raw string) (TraceSiteCode, string) {
 		TraceSitePoolDemandCompute,
 		TraceSiteSessionSnapshot,
 		TraceSiteSessionSync,
+		TraceSiteSessionReconcileBuildDeps,
+		TraceSiteSessionReconcileHealRetire,
+		TraceSiteSessionReconcileTopoOrder,
+		TraceSiteSessionReconcileCircuitBreaker,
+		TraceSiteSessionReconcileForwardPass,
+		TraceSiteSessionReconcileAwakeSet,
+		TraceSiteSessionReconcileWakeSleep,
+		TraceSiteSessionReconcileStartExecution,
+		TraceSiteSessionReconcileDrainAdvance,
 		TraceSitePoolAgentCap,
 		TraceSitePoolRigCap,
 		TraceSitePoolWorkspaceCap,

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -247,6 +247,21 @@ func BeginDrainPatch(now time.Time, reason string) MetadataPatch {
 	}
 }
 
+// DrainAckStopPendingReason marks a drain-acked runtime whose provider stop is
+// running asynchronously and waiting for controller finalization.
+const DrainAckStopPendingReason = "drain-ack-stop-pending"
+
+// DrainAckStopPendingPatch records that a drain-acked session has moved into
+// durable stop-pending state. The provider stop itself is asynchronous; the
+// controller finalizes the bead with the normal drain completion patches after
+// observing the runtime stopped.
+func DrainAckStopPendingPatch(now time.Time) MetadataPatch {
+	patch := BeginDrainPatch(now, DrainAckStopPendingReason)
+	patch["pending_create_claim"] = ""
+	patch["pending_create_started_at"] = ""
+	return patch
+}
+
 // SleepPatch records a non-terminal sleep/drain result.
 func SleepPatch(now time.Time, reason string) MetadataPatch {
 	return MetadataPatch{

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -281,6 +281,7 @@ func SleepPatch(now time.Time, reason string) MetadataPatch {
 func AcknowledgeDrainPatch(freshWake bool) MetadataPatch {
 	patch := MetadataPatch{
 		"state":                     string(StateDrained),
+		"state_reason":              "",
 		"last_woke_at":              "",
 		"pending_create_claim":      "",
 		"pending_create_started_at": "",
@@ -296,6 +297,7 @@ func AcknowledgeDrainPatch(freshWake bool) MetadataPatch {
 // CompleteDrainPatch records a completed controller drain as ordinary asleep.
 func CompleteDrainPatch(now time.Time, reason string, freshWake bool) MetadataPatch {
 	patch := SleepPatch(now, reason)
+	patch["state_reason"] = ""
 	if freshWake {
 		patch["session_key"] = ""
 		applyFreshWakeConversationReset(patch)

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -498,6 +498,22 @@ func TestCommitStartedPatchCanPersistHashesWithoutRestampingState(t *testing.T) 
 	}
 }
 
+func TestDrainAckStopPendingPatchOwnsDurableStopPendingMetadata(t *testing.T) {
+	now := time.Date(2026, 5, 18, 4, 15, 0, 0, time.UTC)
+	patch := DrainAckStopPendingPatch(now)
+
+	want := MetadataPatch{
+		"state":                     string(StateDraining),
+		"state_reason":              DrainAckStopPendingReason,
+		"drain_at":                  now.Format(time.RFC3339),
+		"pending_create_claim":      "",
+		"pending_create_started_at": "",
+	}
+	if !reflect.DeepEqual(patch, want) {
+		t.Fatalf("patch = %#v, want %#v", patch, want)
+	}
+}
+
 func TestClearWakeBlockersPatchClearsOnlyWakeBlockerMetadata(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -130,6 +130,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			patch: AcknowledgeDrainPatch(false),
 			want: MetadataPatch{
 				"state":                     "drained",
+				"state_reason":              "",
 				"last_woke_at":              "",
 				"pending_create_claim":      "",
 				"pending_create_started_at": "",
@@ -140,6 +141,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			patch: AcknowledgeDrainPatch(true),
 			want: MetadataPatch{
 				"state":                      "drained",
+				"state_reason":               "",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
 				"pending_create_started_at":  "",
@@ -156,6 +158,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			patch: CompleteDrainPatch(now, "idle", true),
 			want: MetadataPatch{
 				"state":                      string(StateAsleep),
+				"state_reason":               "",
 				"sleep_reason":               "idle",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
@@ -511,6 +514,24 @@ func TestDrainAckStopPendingPatchOwnsDurableStopPendingMetadata(t *testing.T) {
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)
+	}
+}
+
+func TestDrainCompletionPatchesClearStopPendingReason(t *testing.T) {
+	now := time.Date(2026, 5, 18, 4, 15, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		patch MetadataPatch
+	}{
+		{name: "acknowledge", patch: AcknowledgeDrainPatch(false)},
+		{name: "complete", patch: CompleteDrainPatch(now, "idle", false)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, ok := tt.patch["state_reason"]; !ok || got != "" {
+				t.Fatalf("state_reason = %q, present=%v; want explicit clear", got, ok)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- convert drain-ack provider stops to stop-pending metadata plus async provider stop
- finalize stop-pending sessions once the runtime is gone so pool slots can reopen
- preserve main assigned-work drain-ack event behavior while rebasing the rescue fix

## Verification
- pre-commit hook passed: lint-changed, docs generation, go vet ./..., fast sharded tests
- go test ./cmd/gc ./internal/session ./internal/runtime -run 'TestReconcileSessionBeads_DrainAckMidPhaseEmitsAssignedWorkEvent|TestReconcileSessionBeads_DrainAckCleanHandoffSuppressesAssignedWorkEvent|TestReconcileSessionBeads_DrainAckLiveStoreErrorFailsClosed|TestReconcileSessionBeads_DrainAckMarksStopPendingAndStopsAsync|TestFinalizeDrainAckStopPendingSessionsClosesStoppedPoolBeforeAllocation|TestDrainAckStopPendingPatchOwnsDurableStopPendingMetadata' -count=1\n\nCherry-picked from rescue commit d0526ac725ab6035754c2c486aefe522cd76bfc1 and rebased onto current main.