### PR TITLE
fix(tmux): paste large startup nudges

### DIFF
--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -842,7 +842,9 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 		return err
 	}
 	if cfg.Nudge != "" {
-		_ = ops.sendKeys(name, cfg.Nudge) // best-effort
+		if err := ops.sendKeys(name, cfg.Nudge); err != nil {
+			return fmt.Errorf("sending startup nudge: %w", err)
+		}
 	}
 
 	// Step 6.5: Run session_live commands (idempotent, re-applicable).

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -61,6 +61,7 @@ type fakeStartOps struct {
 	hasSessionErr            error
 	setRemainOnExitErr       error
 	runSetupCommandErr       error
+	sendKeysErr              error
 }
 
 type errReader struct{}
@@ -156,7 +157,7 @@ func (f *fakeStartOps) sendKeys(name, text string) error {
 	if f.sendKeysHook != nil {
 		f.sendKeysHook()
 	}
-	return nil
+	return f.sendKeysErr
 }
 
 func (f *fakeStartOps) setRemainOnExit(name string) error {
@@ -596,6 +597,36 @@ func TestDoStartSession_KimiSkipsStartupDialogAcceptance(t *testing.T) {
 		"waitForCommand",
 		"waitForReady",
 		"hasSession",
+	})
+}
+
+func TestDoStartSessionReturnsNudgeDeliveryError(t *testing.T) {
+	ops := &fakeStartOps{
+		hasSessionResult: true,
+		sendKeysErr:      errors.New("command too long"),
+	}
+
+	cfg := runtime.Config{
+		Command: "kimi",
+		Nudge:   strings.Repeat("startup prompt\n", 100),
+	}
+
+	err := doStartSession(context.Background(), ops, "test", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected startup nudge delivery error, got nil")
+	}
+	if !strings.Contains(err.Error(), "sending startup nudge") {
+		t.Fatalf("error = %v, want startup nudge context", err)
+	}
+	if !strings.Contains(err.Error(), "command too long") {
+		t.Fatalf("error = %v, want original nudge error", err)
+	}
+
+	assertCallSequence(t, ops, []string{
+		"createSession",
+		"setRemainOnExit",
+		"hasSession",
+		"sendKeys",
 	})
 }
 

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -1458,6 +1458,8 @@ func (t *Tmux) pasteLiteralText(target, text string) error {
 		}
 	}()
 
+	// Force bracketed paste so multiline nudges arrive as one paste operation
+	// instead of being interpreted as individual keypresses by provider TUIs.
 	if _, err := t.run("paste-buffer", "-p", "-d", "-b", bufferName, "-t", target); err != nil {
 		return fmt.Errorf("pasting tmux buffer: %w", err)
 	}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -113,6 +114,8 @@ type RuntimeTmuxConfig struct {
 // timed lock acquisition — preventing permanent lockout if a nudge hangs.
 var sessionNudgeLocks sync.Map // map[string]chan struct{}
 
+var pasteBufferSeq uint64
+
 // validSessionNameRe validates session names to prevent shell injection
 var validSessionNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
@@ -137,6 +140,7 @@ const (
 	hiddenAttachReadyTimeout = 2 * time.Second
 	hiddenAttachMaxLifetime  = 20 * time.Second
 	hiddenAttachPollInterval = 50 * time.Millisecond
+	maxSendKeysLiteralLen    = 4096
 )
 
 // tmuxSubprocessTimeout caps the wall-clock time any single tmux subprocess
@@ -1403,6 +1407,64 @@ func isTransientSendKeysError(err error) bool {
 	return strings.Contains(msg, "not in a mode")
 }
 
+func isCommandTooLongError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "command too long")
+}
+
+func nextPasteBufferName() string {
+	seq := atomic.AddUint64(&pasteBufferSeq, 1)
+	return fmt.Sprintf("gc-nudge-%d-%d", os.Getpid(), seq)
+}
+
+func (t *Tmux) sendLiteralText(target, text string) error {
+	if len(text) > maxSendKeysLiteralLen {
+		return t.pasteLiteralText(target, text)
+	}
+	_, err := t.run("send-keys", "-t", target, "-l", text)
+	if isCommandTooLongError(err) {
+		return t.pasteLiteralText(target, text)
+	}
+	return err
+}
+
+func (t *Tmux) pasteLiteralText(target, text string) error {
+	tmp, err := os.CreateTemp("", "gc-tmux-paste-*")
+	if err != nil {
+		return fmt.Errorf("creating tmux paste buffer file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.WriteString(text); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing tmux paste buffer file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing tmux paste buffer file: %w", err)
+	}
+
+	bufferName := nextPasteBufferName()
+	loaded := false
+	if _, err := t.run("load-buffer", "-b", bufferName, tmpName); err != nil {
+		return fmt.Errorf("loading tmux paste buffer: %w", err)
+	}
+	loaded = true
+	defer func() {
+		if loaded {
+			_, _ = t.run("delete-buffer", "-b", bufferName)
+		}
+	}()
+
+	if _, err := t.run("paste-buffer", "-p", "-d", "-b", bufferName, "-t", target); err != nil {
+		return fmt.Errorf("pasting tmux buffer: %w", err)
+	}
+	loaded = false
+	return nil
+}
+
 // sendKeysLiteralWithRetry sends literal text to a tmux target, retrying on
 // transient errors (e.g., "not in a mode" during agent TUI startup).
 // This is the core retry loop used by both NudgeSession and NudgePane.
@@ -1422,7 +1484,7 @@ func (t *Tmux) sendKeysLiteralWithRetry(target, text string, timeout time.Durati
 	var lastErr error
 
 	for time.Now().Before(deadline) {
-		_, err := t.run("send-keys", "-t", target, "-l", text)
+		err := t.sendLiteralText(target, text)
 		if err == nil {
 			return nil
 		}

--- a/internal/runtime/tmux/tmux_test.go
+++ b/internal/runtime/tmux/tmux_test.go
@@ -2006,6 +2006,60 @@ func TestSendKeysLiteralWithRetry_NonTransientFailsFast(t *testing.T) {
 	}
 }
 
+func TestSendKeysLiteralWithRetryFallsBackToPasteBufferOnCommandTooLong(t *testing.T) {
+	fe := &fakeExecutor{
+		errs: []error{errors.New("command too long")},
+	}
+	tm := NewTmuxWithConfig(DefaultConfig())
+	tm.exec = fe
+
+	err := tm.sendKeysLiteralWithRetry("%1", "large startup prompt", time.Second)
+	if err != nil {
+		t.Fatalf("sendKeysLiteralWithRetry() = %v, want nil", err)
+	}
+
+	if len(fe.calls) != 3 {
+		t.Fatalf("tmux calls = %d, want 3: %#v", len(fe.calls), fe.calls)
+	}
+	first := strings.Join(fe.calls[0], " ")
+	if !strings.Contains(first, "send-keys") || !strings.Contains(first, "-l") {
+		t.Fatalf("first call = %v, want literal send-keys", fe.calls[0])
+	}
+	if got := fe.calls[1][2]; got != "load-buffer" {
+		t.Fatalf("second call = %v, want load-buffer", fe.calls[1])
+	}
+	if got := fe.calls[2][2]; got != "paste-buffer" {
+		t.Fatalf("third call = %v, want paste-buffer", fe.calls[2])
+	}
+	third := strings.Join(fe.calls[2], "\x00")
+	for _, want := range []string{"\x00-p\x00", "\x00-d\x00", "\x00-t\x00%1"} {
+		if !strings.Contains(third, want) {
+			t.Fatalf("paste-buffer call = %v, missing %q", fe.calls[2], want)
+		}
+	}
+}
+
+func TestSendKeysLiteralWithRetryUsesPasteBufferForLargeText(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := NewTmuxWithConfig(DefaultConfig())
+	tm.exec = fe
+
+	err := tm.sendKeysLiteralWithRetry("%1", strings.Repeat("x", maxSendKeysLiteralLen+1), time.Second)
+	if err != nil {
+		t.Fatalf("sendKeysLiteralWithRetry() = %v, want nil", err)
+	}
+
+	if len(fe.calls) != 2 {
+		t.Fatalf("tmux calls = %d, want 2: %#v", len(fe.calls), fe.calls)
+	}
+	if got := fe.calls[0][2]; got != "load-buffer" {
+		t.Fatalf("first call = %v, want load-buffer", fe.calls[0])
+	}
+	if got := fe.calls[1][2]; got != "paste-buffer" {
+		t.Fatalf("second call = %v, want paste-buffer", fe.calls[1])
+	}
+}
+
 func TestNudgeSession_WithRetry(t *testing.T) {
 	if !hasTmux() {
 		t.Skip("tmux not installed")

--- a/internal/runtime/tmux/tmux_test.go
+++ b/internal/runtime/tmux/tmux_test.go
@@ -2025,12 +2025,8 @@ func TestSendKeysLiteralWithRetryFallsBackToPasteBufferOnCommandTooLong(t *testi
 	if !strings.Contains(first, "send-keys") || !strings.Contains(first, "-l") {
 		t.Fatalf("first call = %v, want literal send-keys", fe.calls[0])
 	}
-	if got := fe.calls[1][2]; got != "load-buffer" {
-		t.Fatalf("second call = %v, want load-buffer", fe.calls[1])
-	}
-	if got := fe.calls[2][2]; got != "paste-buffer" {
-		t.Fatalf("third call = %v, want paste-buffer", fe.calls[2])
-	}
+	assertTmuxCommand(t, fe.calls[1], "load-buffer")
+	assertTmuxCommand(t, fe.calls[2], "paste-buffer")
 	third := strings.Join(fe.calls[2], "\x00")
 	for _, want := range []string{"\x00-p\x00", "\x00-d\x00", "\x00-t\x00%1"} {
 		if !strings.Contains(third, want) {
@@ -2052,11 +2048,16 @@ func TestSendKeysLiteralWithRetryUsesPasteBufferForLargeText(t *testing.T) {
 	if len(fe.calls) != 2 {
 		t.Fatalf("tmux calls = %d, want 2: %#v", len(fe.calls), fe.calls)
 	}
-	if got := fe.calls[0][2]; got != "load-buffer" {
-		t.Fatalf("first call = %v, want load-buffer", fe.calls[0])
-	}
-	if got := fe.calls[1][2]; got != "paste-buffer" {
-		t.Fatalf("second call = %v, want paste-buffer", fe.calls[1])
+	assertTmuxCommand(t, fe.calls[0], "load-buffer")
+	assertTmuxCommand(t, fe.calls[1], "paste-buffer")
+}
+
+func assertTmuxCommand(t *testing.T, args []string, want string) {
+	t.Helper()
+
+	joined := "\x00" + strings.Join(args, "\x00") + "\x00"
+	if !strings.Contains(joined, "\x00"+want+"\x00") {
+		t.Fatalf("tmux call = %v, want command %q", args, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- paste large startup nudges into tmux panes instead of sending them as oversized key sequences
- add regression coverage for the large-startup-nudge path

## Verification
- go test ./internal/runtime/tmux -count=1

Cherry-picked from rescue commit e0dbdde08b92a79e3d8f73ba24a58b3c458d6f6f and rebased onto current main.