### PR TITLE
perf: cache tmux process liveness

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -114,7 +114,9 @@ func buildAwakeInputFromReconciler(
 		input.SessionBeads = append(input.SessionBeads, bead)
 	}
 
-	// Runtime state from wakeTargets (already computed, no extra tmux calls)
+	// Runtime liveness comes from wakeTargets. Attachment is probed only when
+	// it can affect the awake decision; the common active desired-session path
+	// is already awake and has no idle reference to suppress.
 	for _, target := range wakeTargets {
 		name := strings.TrimSpace(target.session.Metadata["session_name"])
 		if name == "" {
@@ -123,8 +125,10 @@ func buildAwakeInputFromReconciler(
 		if target.alive {
 			input.RunningSessions[name] = true
 		}
-		if attached, err := workerSessionTargetAttachedWithConfig("", nil, sp, nil, name); err == nil && attached {
-			input.AttachedSessions[name] = true
+		if shouldProbeAttachmentForAwakeInput(target, cfg, poolDesired) {
+			if attached, err := workerSessionTargetAttachedWithConfig("", nil, sp, nil, name); err == nil && attached {
+				input.AttachedSessions[name] = true
+			}
 		}
 		if pendingInteractionReady(sp, name) {
 			input.PendingSessions[name] = true
@@ -132,6 +136,30 @@ func buildAwakeInputFromReconciler(
 	}
 
 	return input
+}
+
+func shouldProbeAttachmentForAwakeInput(target wakeTarget, cfg *config.City, poolDesired map[string]int) bool {
+	if target.session == nil {
+		return false
+	}
+	if !target.alive {
+		return false
+	}
+	state := target.session.Metadata["state"]
+	if state != string(session.StateActive) && state != string(session.StateAwake) {
+		return true
+	}
+	if target.session.Metadata["detached_at"] != "" {
+		return true
+	}
+	template := normalizedSessionTemplate(*target.session, cfg)
+	if template == "" {
+		template = target.session.Metadata["template"]
+	}
+	if template != "" && poolDesired[template] > 0 {
+		return false
+	}
+	return true
 }
 
 // awakeSetToWakeEvals converts ComputeAwakeSet output to wakeEvaluation map

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/telemetry"
-	"github.com/gastownhall/gascity/internal/worker"
 )
 
 const maxIdleSleepProbesPerTick = 3
@@ -957,12 +956,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		// Liveness includes zombie detection: tmux session exists AND
 		// the expected child process is alive (when ProcessNames configured).
-		obs, err := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, session.ID, tp.Hints.ProcessNames)
-		if err != nil {
-			obs = worker.LiveObservation{}
-		}
-		running := obs.Running
-		alive := obs.Alive
+		// The desired-session fast path only needs running/alive; attachment
+		// and activity are probed by the narrower branches that use them.
+		running, alive := observeRuntimeProviderLiveness(sp, name, tp.Hints.ProcessNames)
 		peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, tp.Hints.ProcessNames)
 
 		// Zombie capture: session exists but process dead — grab scrollback for forensics.

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -353,7 +353,7 @@ func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 func TestReconcileSessionBeads_DesiredFastPathSkipsAttachmentActivityObservation(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
-		Agents: []config.Agent{{Name: "worker"}},
+		Agents: []config.Agent{{Name: "worker", SleepAfterIdle: config.SessionSleepOff}},
 	}
 	env.desiredState["worker"] = TemplateParams{
 		Command:      "test-cmd",
@@ -366,6 +366,11 @@ func TestReconcileSessionBeads_DesiredFastPathSkipsAttachmentActivityObservation
 	}
 	session := env.createSessionBead("worker", "worker")
 	env.markSessionActive(&session)
+	agentCfg := sessionCoreConfigForHash(env.desiredState["worker"], session)
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": runtime.CoreFingerprint(agentCfg),
+		"started_live_hash":   runtime.LiveFingerprint(agentCfg),
+	})
 	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
 		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
 	}
@@ -374,11 +379,11 @@ func TestReconcileSessionBeads_DesiredFastPathSkipsAttachmentActivityObservation
 	if woken != 0 {
 		t.Fatalf("woken = %d, want 0", woken)
 	}
-	if got := env.sp.CountCalls("IsAttached", "worker"); got > 1 {
-		t.Fatalf("IsAttached calls = %d, want at most 1 downstream sleep/activity probe", got)
+	if got := env.sp.CountCalls("IsAttached", "worker"); got != 0 {
+		t.Fatalf("IsAttached calls = %d, want 0 on desired fast path", got)
 	}
-	if got := env.sp.CountCalls("GetLastActivity", "worker"); got > 1 {
-		t.Fatalf("GetLastActivity calls = %d, want at most 1 downstream sleep/activity probe", got)
+	if got := env.sp.CountCalls("GetLastActivity", "worker"); got != 0 {
+		t.Fatalf("GetLastActivity calls = %d, want 0 on desired fast path", got)
 	}
 }
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -287,7 +287,7 @@ func (e *reconcilerTestEnv) reconcileWithPoolDesiredAndDrainOps(sessions []beads
 func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
-		Agents: []config.Agent{{Name: "worker"}},
+		Agents: []config.Agent{{Name: "worker", SleepAfterIdle: config.SessionSleepOff}},
 	}
 	env.addDesired("worker", "worker", true)
 	session := env.createSessionBead("worker", "worker")
@@ -347,6 +347,38 @@ func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 	}
 	if got.Metadata["pending_create_claim"] != "" {
 		t.Fatalf("pending_create_claim = %q, want cleared after drain-ack", got.Metadata["pending_create_claim"])
+	}
+}
+
+func TestReconcileSessionBeads_DesiredFastPathSkipsAttachmentActivityObservation(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	env.desiredState["worker"] = TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  "worker",
+		TemplateName: "worker",
+		Hints:        agent.StartupHints{ProcessNames: []string{"worker"}},
+	}
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	woken := env.reconcile([]beads.Bead{session})
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	if got := env.sp.CountCalls("IsAttached", "worker"); got > 1 {
+		t.Fatalf("IsAttached calls = %d, want at most 1 downstream sleep/activity probe", got)
+	}
+	if got := env.sp.CountCalls("GetLastActivity", "worker"); got > 1 {
+		t.Fatalf("GetLastActivity calls = %d, want at most 1 downstream sleep/activity probe", got)
 	}
 }
 

--- a/internal/runtime/fake.go
+++ b/internal/runtime/fake.go
@@ -62,6 +62,19 @@ type Call struct {
 	Action    string         // only set for Respond calls
 }
 
+// CountCalls returns the number of recorded calls matching method and name.
+func (f *Fake) CountCalls(method, name string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	count := 0
+	for _, call := range f.Calls {
+		if call.Method == method && call.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
 // NewFake returns a ready-to-use [Fake].
 func NewFake() *Fake {
 	return &Fake{

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -308,7 +308,7 @@ func (p *Provider) ObserveLiveness(name string, processNames []string) runtime.L
 	if len(processNames) == 0 {
 		return runtime.Liveness{Running: running, Alive: running}
 	}
-	alive := p.tm.IsRuntimeRunning(name, processNames)
+	alive := p.cache.ProcessAlive(name, processNames)
 	if alive && !running {
 		running = true
 	}

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -290,7 +290,7 @@ func (p *Provider) ProcessAlive(name string, processNames []string) bool {
 	if len(processNames) == 0 {
 		return true
 	}
-	return p.tm.IsRuntimeRunning(name, processNames)
+	return p.cache.ProcessAlive(name, processNames)
 }
 
 // ObserveLiveness reports both pane presence and agent-process presence for a

--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,23 +23,49 @@ const defaultCacheTTL = 2 * time.Second
 // sessions and logs a degraded warning.
 const defaultStaleTTL = 30 * time.Second
 
-// fetchTimeout is the hard timeout for a single FetchRunning call.
+// fetchTimeout is the hard timeout for a single runtime-state fetch.
 const fetchTimeout = 3 * time.Second
 
 // StateFetcher abstracts tmux subprocess calls for testability.
 type StateFetcher interface {
-	// FetchRunning returns the set of session names with live (non-dead) panes.
+	// FetchState returns a runtime-state snapshot for live sessions.
 	// Sessions with remain-on-exit corpses (pane_dead=1) are excluded.
-	FetchRunning(ctx context.Context) (map[string]bool, error)
+	FetchState(ctx context.Context) (runtimeStateSnapshot, error)
 }
 
-// StateCache caches the set of running tmux sessions to avoid
-// spawning N subprocess calls per status check. Concurrent callers
-// are coalesced via singleflight so at most one tmux list-sessions
-// subprocess runs at a time.
+type paneRuntimeState struct {
+	Command string
+	PID     string
+}
+
+type sessionRuntimeState struct {
+	Running bool
+	Panes   []paneRuntimeState
+}
+
+type processRuntimeState struct {
+	PID     string
+	PPID    string
+	Command string
+	Args    string
+}
+
+type processSnapshot struct {
+	byPID    map[string]processRuntimeState
+	children map[string][]string
+}
+
+type runtimeStateSnapshot struct {
+	Sessions  map[string]sessionRuntimeState
+	Processes processSnapshot
+}
+
+// StateCache caches tmux runtime state to avoid spawning N subprocess calls per
+// status check or reconciler pass. Concurrent callers are coalesced via
+// singleflight so at most one tmux/process snapshot refresh runs at a time.
 type StateCache struct {
 	mu        sync.RWMutex
-	sessions  map[string]bool
+	state     runtimeStateSnapshot
 	fetchedAt time.Time
 	lastError error
 	dirty     bool // set by Invalidate(); cleared on successful refresh
@@ -61,15 +89,31 @@ func NewStateCache(fetcher StateFetcher, ttl time.Duration) *StateCache {
 // If the cache is stale, a refresh is triggered (coalesced via singleflight).
 // On refresh failure, the last-known-good cache is preserved up to staleTTL.
 func (c *StateCache) IsRunning(name string) bool {
+	state := c.currentState()
+	session, ok := state.Sessions[name]
+	return ok && session.Running
+}
+
+// ProcessAlive reports whether the named session has a process matching one of
+// processNames according to the cached runtime snapshot. An empty processNames
+// slice preserves Provider.ProcessAlive's "no check possible" behavior.
+func (c *StateCache) ProcessAlive(name string, processNames []string) bool {
+	if len(processNames) == 0 {
+		return true
+	}
+	return c.currentState().processAlive(name, processNames)
+}
+
+func (c *StateCache) currentState() runtimeStateSnapshot {
 	c.mu.RLock()
-	sessions := c.sessions
+	state := c.state
 	fetchedAt := c.fetchedAt
 	dirty := c.dirty
 	c.mu.RUnlock()
 
 	// Cache hit: fresh data, not invalidated.
-	if sessions != nil && !fetchedAt.IsZero() && !dirty && time.Since(fetchedAt) < c.ttl {
-		return sessions[name]
+	if state.Sessions != nil && !fetchedAt.IsZero() && !dirty && time.Since(fetchedAt) < c.ttl {
+		return state
 	}
 
 	// Stale, empty, or dirty — trigger refresh.
@@ -82,17 +126,17 @@ func (c *StateCache) IsRunning(name string) bool {
 
 	// Read the (potentially updated) cache.
 	c.mu.RLock()
-	sessions = c.sessions
+	state = c.state
 	fetchedAt = c.fetchedAt
 	c.mu.RUnlock()
 
 	// If the cache is older than staleTTL, report all sessions as not running.
 	// Note: fetchedAt is preserved on failure (never zeroed), so this only
 	// triggers after staleTTL of real wall-clock time since last success.
-	if sessions == nil || fetchedAt.IsZero() || time.Since(fetchedAt) > c.staleTTL {
-		return false
+	if state.Sessions == nil || fetchedAt.IsZero() || time.Since(fetchedAt) > c.staleTTL {
+		return runtimeStateSnapshot{}
 	}
-	return sessions[name]
+	return state
 }
 
 // Invalidate marks the cache as dirty, forcing the next IsRunning call
@@ -109,7 +153,7 @@ func (c *StateCache) Invalidate() {
 // the next refresh cycle (which may race with singleflight coalescing).
 func (c *StateCache) EvictSession(name string) {
 	c.mu.Lock()
-	delete(c.sessions, name)
+	delete(c.state.Sessions, name)
 	c.dirty = true
 	c.mu.Unlock()
 }
@@ -122,7 +166,7 @@ func (c *StateCache) refresh() {
 		defer cancel()
 
 		start := time.Now()
-		sessions, err := c.fetcher.FetchRunning(ctx)
+		state, err := c.fetcher.FetchState(ctx)
 		elapsed := time.Since(start)
 
 		if err != nil {
@@ -137,11 +181,11 @@ func (c *StateCache) refresh() {
 		// Successful refresh is noisy on the session loop; opt-in via env var
 		// keeps it available for diagnostics without polluting normal CLI use.
 		if os.Getenv("GC_LOG_TMUX_CACHE") == "true" {
-			log.Printf("tmux state cache: refreshed %d sessions in %v", len(sessions), elapsed)
+			log.Printf("tmux state cache: refreshed %d sessions in %v", len(state.Sessions), elapsed)
 		}
 
 		c.mu.Lock()
-		c.sessions = sessions
+		c.state = state
 		c.fetchedAt = time.Now()
 		c.lastError = nil
 		c.dirty = false
@@ -155,45 +199,215 @@ type tmuxFetcher struct {
 	tm *Tmux
 }
 
-// FetchRunning runs `tmux list-panes -a -F '#{session_name}\t#{pane_dead}'`
-// and returns a map of session names that have at least one live pane.
+// FetchState runs one tmux pane snapshot and one process-table snapshot.
 // Sessions where remain-on-exit has kept a dead pane (pane_dead=1) are
 // excluded — they represent exited processes, not running ones.
-func (f *tmuxFetcher) FetchRunning(ctx context.Context) (map[string]bool, error) {
-	out, err := f.tm.runCtx(ctx, "list-panes", "-a", "-F", "#{session_name}\t#{pane_dead}")
+func (f *tmuxFetcher) FetchState(ctx context.Context) (runtimeStateSnapshot, error) {
+	out, err := f.tm.runCtx(ctx, "list-panes", "-a", "-F", "#{session_name}\t#{pane_dead}\t#{pane_current_command}\t#{pane_pid}")
 	if err != nil {
 		if isNoServerError(err) {
-			return map[string]bool{}, nil // No server = no sessions
+			return runtimeStateSnapshot{Sessions: map[string]sessionRuntimeState{}}, nil // No server = no sessions
 		}
-		return nil, err
+		return runtimeStateSnapshot{}, err
+	}
+	state := runtimeStateSnapshot{
+		Sessions: make(map[string]sessionRuntimeState),
 	}
 	if out == "" {
-		return map[string]bool{}, nil
+		return state, nil
 	}
 
-	// Track which sessions have dead panes vs live panes.
-	// A session is "running" if it has at least one live pane.
-	dead := make(map[string]bool)
-	alive := make(map[string]bool)
 	for _, line := range strings.Split(out, "\n") {
-		parts := strings.SplitN(line, "\t", 2)
-		if len(parts) != 2 || parts[0] == "" {
+		parts := strings.SplitN(line, "\t", 4)
+		if len(parts) < 2 || parts[0] == "" {
 			continue
 		}
 		name := parts[0]
 		if parts[1] == "1" {
-			dead[name] = true
-		} else {
-			alive[name] = true
+			continue
+		}
+		var pane paneRuntimeState
+		if len(parts) > 2 {
+			pane.Command = strings.TrimSpace(parts[2])
+		}
+		if len(parts) > 3 {
+			pane.PID = strings.TrimSpace(parts[3])
+		}
+		session := state.Sessions[name]
+		session.Running = true
+		if pane.Command != "" || pane.PID != "" {
+			session.Panes = append(session.Panes, pane)
+		}
+		state.Sessions[name] = session
+	}
+	state.Processes = fetchProcessSnapshot(ctx)
+	return state, nil
+}
+
+func (s runtimeStateSnapshot) processAlive(sessionName string, processNames []string) bool {
+	session, ok := s.Sessions[sessionName]
+	if !ok || !session.Running {
+		return false
+	}
+	names := processNameSet(processNames)
+	if len(names) == 0 {
+		return false
+	}
+	for _, pane := range session.Panes {
+		if pane.processAlive(names, s.Processes) {
+			return true
 		}
 	}
+	return false
+}
 
-	// alive wins over dead — if any pane is alive, session is running.
-	sessions := make(map[string]bool, len(alive))
-	for name := range alive {
-		sessions[name] = true
+func (p paneRuntimeState) processAlive(names map[string]struct{}, processes processSnapshot) bool {
+	if _, ok := names[p.Command]; ok && p.Command != "" {
+		return true
 	}
-	return sessions, nil
+	if p.PID == "" {
+		return false
+	}
+	if isSupportedShell(p.Command) {
+		return processes.hasDescendantWithNames(p.PID, names, 0)
+	}
+	if processes.processMatchesNames(p.PID, names) {
+		return true
+	}
+	return processes.hasDescendantWithNames(p.PID, names, 0)
+}
+
+func processNameSet(names []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name = strings.TrimSpace(name); name != "" {
+			set[name] = struct{}{}
+		}
+	}
+	return set
+}
+
+func isSupportedShell(command string) bool {
+	for _, shell := range supportedShells {
+		if command == shell {
+			return true
+		}
+	}
+	return false
+}
+
+func newProcessSnapshot(processes []processRuntimeState) processSnapshot {
+	snapshot := processSnapshot{
+		byPID:    make(map[string]processRuntimeState, len(processes)),
+		children: make(map[string][]string),
+	}
+	for _, process := range processes {
+		process.PID = strings.TrimSpace(process.PID)
+		process.PPID = strings.TrimSpace(process.PPID)
+		process.Command = strings.TrimSpace(process.Command)
+		process.Args = strings.TrimSpace(process.Args)
+		if process.PID == "" {
+			continue
+		}
+		snapshot.byPID[process.PID] = process
+		if process.PPID != "" {
+			snapshot.children[process.PPID] = append(snapshot.children[process.PPID], process.PID)
+		}
+	}
+	return snapshot
+}
+
+func fetchProcessSnapshot(ctx context.Context) processSnapshot {
+	out, err := exec.CommandContext(ctx, "ps", "-eo", "pid=,ppid=,comm=,args=").Output()
+	if err != nil {
+		return processSnapshot{}
+	}
+	return parseProcessSnapshot(string(out))
+}
+
+func parseProcessSnapshot(out string) processSnapshot {
+	processes := make([]processRuntimeState, 0)
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		process := processRuntimeState{
+			PID:     fields[0],
+			PPID:    fields[1],
+			Command: fields[2],
+		}
+		if len(fields) > 3 {
+			process.Args = strings.Join(fields[3:], " ")
+		}
+		processes = append(processes, process)
+	}
+	return newProcessSnapshot(processes)
+}
+
+func (s processSnapshot) processMatchesNames(pid string, names map[string]struct{}) bool {
+	if len(names) == 0 {
+		return false
+	}
+	process, ok := s.byPID[pid]
+	if !ok {
+		return false
+	}
+	if _, ok := names[filepath.Base(process.Command)]; ok {
+		return true
+	}
+	args := strings.Fields(process.Args)
+	if len(args) == 0 {
+		return false
+	}
+	argv0 := filepath.Base(args[0])
+	if _, ok := names[argv0]; ok {
+		return true
+	}
+	knownInterpreters := map[string]struct{}{
+		"node": {}, "bun": {}, "npx": {}, "deno": {},
+	}
+	runnerSubcommands := map[string]struct{}{
+		"run": {}, "exec": {}, "x": {},
+	}
+	if _, isInterpreter := knownInterpreters[argv0]; !isInterpreter {
+		return false
+	}
+	for _, token := range args[1:] {
+		token = strings.TrimSpace(token)
+		if token == "" || strings.HasPrefix(token, "-") {
+			continue
+		}
+		if _, isRunner := runnerSubcommands[token]; isRunner {
+			continue
+		}
+		base := filepath.Base(token)
+		if _, ok := names[base]; ok {
+			return true
+		}
+		baseNoExt := strings.TrimSuffix(base, filepath.Ext(base))
+		if _, ok := names[baseNoExt]; ok {
+			return true
+		}
+		break
+	}
+	return false
+}
+
+func (s processSnapshot) hasDescendantWithNames(pid string, names map[string]struct{}, depth int) bool {
+	const maxDepth = 10
+	if len(names) == 0 || depth > maxDepth {
+		return false
+	}
+	for _, childPID := range s.children[pid] {
+		if s.processMatchesNames(childPID, names) {
+			return true
+		}
+		if s.hasDescendantWithNames(childPID, names, depth+1) {
+			return true
+		}
+	}
+	return false
 }
 
 // isNoServerError checks if the error is a "no server running" error.

--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -64,15 +65,16 @@ type runtimeStateSnapshot struct {
 // status check or reconciler pass. Concurrent callers are coalesced via
 // singleflight so at most one tmux/process snapshot refresh runs at a time.
 type StateCache struct {
-	mu        sync.RWMutex
-	state     runtimeStateSnapshot
-	fetchedAt time.Time
-	lastError error
-	dirty     bool // set by Invalidate(); cleared on successful refresh
-	ttl       time.Duration
-	staleTTL  time.Duration
-	sf        singleflight.Group
-	fetcher   StateFetcher
+	mu         sync.RWMutex
+	state      runtimeStateSnapshot
+	fetchedAt  time.Time
+	lastError  error
+	dirty      bool   // set by Invalidate(); cleared on successful refresh
+	generation uint64 // advanced by invalidation/eviction to reject stale refreshes
+	ttl        time.Duration
+	staleTTL   time.Duration
+	sf         singleflight.Group
+	fetcher    StateFetcher
 }
 
 // NewStateCache creates a new cache with the given fetcher and TTL.
@@ -145,6 +147,7 @@ func (c *StateCache) currentState() runtimeStateSnapshot {
 func (c *StateCache) Invalidate() {
 	c.mu.Lock()
 	c.dirty = true
+	c.generation++
 	c.mu.Unlock()
 }
 
@@ -155,6 +158,7 @@ func (c *StateCache) EvictSession(name string) {
 	c.mu.Lock()
 	delete(c.state.Sessions, name)
 	c.dirty = true
+	c.generation++
 	c.mu.Unlock()
 }
 
@@ -164,6 +168,10 @@ func (c *StateCache) refresh() {
 	_, _, _ = c.sf.Do("refresh", func() (interface{}, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
 		defer cancel()
+
+		c.mu.RLock()
+		startGeneration := c.generation
+		c.mu.RUnlock()
 
 		start := time.Now()
 		state, err := c.fetcher.FetchState(ctx)
@@ -178,13 +186,20 @@ func (c *StateCache) refresh() {
 			return nil, err
 		}
 
+		c.mu.Lock()
+		if c.generation != startGeneration {
+			c.mu.Unlock()
+			if os.Getenv("GC_LOG_TMUX_CACHE") == "true" {
+				log.Printf("tmux state cache: discarded refresh from generation %d after %v", startGeneration, elapsed)
+			}
+			return nil, nil
+		}
 		// Successful refresh is noisy on the session loop; opt-in via env var
 		// keeps it available for diagnostics without polluting normal CLI use.
 		if os.Getenv("GC_LOG_TMUX_CACHE") == "true" {
 			log.Printf("tmux state cache: refreshed %d sessions in %v", len(state.Sessions), elapsed)
 		}
 
-		c.mu.Lock()
 		c.state = state
 		c.fetchedAt = time.Now()
 		c.lastError = nil
@@ -240,7 +255,11 @@ func (f *tmuxFetcher) FetchState(ctx context.Context) (runtimeStateSnapshot, err
 		}
 		state.Sessions[name] = session
 	}
-	state.Processes = fetchProcessSnapshot(ctx)
+	processes, err := fetchProcessSnapshot(ctx)
+	if err != nil {
+		return runtimeStateSnapshot{}, err
+	}
+	state.Processes = processes
 	return state, nil
 }
 
@@ -287,6 +306,56 @@ func processNameSet(names []string) map[string]struct{} {
 	return set
 }
 
+func processMatchesNameSet(command, args string, names map[string]struct{}) bool {
+	if len(names) == 0 {
+		return false
+	}
+	command = filepath.Base(strings.TrimSpace(command))
+	if _, ok := names[command]; ok && command != "" {
+		return true
+	}
+	argv := strings.Fields(strings.TrimSpace(args))
+	if len(argv) == 0 {
+		return false
+	}
+	argv0 := filepath.Base(argv[0])
+	if _, ok := names[argv0]; ok {
+		return true
+	}
+	if _, isInterpreter := knownInterpreters[argv0]; !isInterpreter {
+		return false
+	}
+	for _, token := range argv[1:] {
+		token = strings.TrimSpace(token)
+		if token == "" || strings.HasPrefix(token, "-") {
+			continue
+		}
+		if _, isRunner := runnerSubcommands[token]; isRunner {
+			continue
+		}
+		base := filepath.Base(token)
+		if _, ok := names[base]; ok {
+			return true
+		}
+		baseNoExt := strings.TrimSuffix(base, filepath.Ext(base))
+		if _, ok := names[baseNoExt]; ok {
+			return true
+		}
+		break
+	}
+	return false
+}
+
+var knownInterpreters = map[string]struct{}{
+	"node": {}, "bun": {}, "npx": {}, "deno": {},
+}
+
+var runnerSubcommands = map[string]struct{}{
+	"run": {}, "exec": {}, "x": {},
+}
+
+const maxProcessDescendantDepth = 10
+
 func isSupportedShell(command string) bool {
 	for _, shell := range supportedShells {
 		if command == shell {
@@ -317,86 +386,62 @@ func newProcessSnapshot(processes []processRuntimeState) processSnapshot {
 	return snapshot
 }
 
-func fetchProcessSnapshot(ctx context.Context) processSnapshot {
-	out, err := exec.CommandContext(ctx, "ps", "-eo", "pid=,ppid=,comm=,args=").Output()
+func fetchProcessSnapshot(ctx context.Context) (processSnapshot, error) {
+	out, err := exec.CommandContext(ctx, "ps", "-eo", "pid:10=,ppid:10=,comm:64=,args=").Output()
 	if err != nil {
-		return processSnapshot{}
+		return processSnapshot{}, fmt.Errorf("fetching process snapshot: %w", err)
 	}
-	return parseProcessSnapshot(string(out))
+	return parseProcessSnapshot(string(out)), nil
 }
 
 func parseProcessSnapshot(out string) processSnapshot {
 	processes := make([]processRuntimeState, 0)
 	for _, line := range strings.Split(out, "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 3 {
+		process, ok := parseProcessSnapshotLine(line)
+		if !ok {
 			continue
-		}
-		process := processRuntimeState{
-			PID:     fields[0],
-			PPID:    fields[1],
-			Command: fields[2],
-		}
-		if len(fields) > 3 {
-			process.Args = strings.Join(fields[3:], " ")
 		}
 		processes = append(processes, process)
 	}
 	return newProcessSnapshot(processes)
 }
 
-func (s processSnapshot) processMatchesNames(pid string, names map[string]struct{}) bool {
-	if len(names) == 0 {
-		return false
+func parseProcessSnapshotLine(line string) (processRuntimeState, bool) {
+	const (
+		pidWidth     = 10
+		ppidStart    = pidWidth + 1
+		ppidWidth    = 10
+		commandStart = ppidStart + ppidWidth + 1
+		commandWidth = 64
+		argsStart    = commandStart + commandWidth + 1
+	)
+	if len(line) < commandStart+commandWidth {
+		return processRuntimeState{}, false
 	}
+	process := processRuntimeState{
+		PID:     strings.TrimSpace(line[:pidWidth]),
+		PPID:    strings.TrimSpace(line[ppidStart : ppidStart+ppidWidth]),
+		Command: strings.TrimSpace(line[commandStart : commandStart+commandWidth]),
+	}
+	if len(line) > argsStart {
+		process.Args = strings.TrimSpace(line[argsStart:])
+	}
+	if process.PID == "" || process.PPID == "" || process.Command == "" {
+		return processRuntimeState{}, false
+	}
+	return process, true
+}
+
+func (s processSnapshot) processMatchesNames(pid string, names map[string]struct{}) bool {
 	process, ok := s.byPID[pid]
 	if !ok {
 		return false
 	}
-	if _, ok := names[filepath.Base(process.Command)]; ok {
-		return true
-	}
-	args := strings.Fields(process.Args)
-	if len(args) == 0 {
-		return false
-	}
-	argv0 := filepath.Base(args[0])
-	if _, ok := names[argv0]; ok {
-		return true
-	}
-	knownInterpreters := map[string]struct{}{
-		"node": {}, "bun": {}, "npx": {}, "deno": {},
-	}
-	runnerSubcommands := map[string]struct{}{
-		"run": {}, "exec": {}, "x": {},
-	}
-	if _, isInterpreter := knownInterpreters[argv0]; !isInterpreter {
-		return false
-	}
-	for _, token := range args[1:] {
-		token = strings.TrimSpace(token)
-		if token == "" || strings.HasPrefix(token, "-") {
-			continue
-		}
-		if _, isRunner := runnerSubcommands[token]; isRunner {
-			continue
-		}
-		base := filepath.Base(token)
-		if _, ok := names[base]; ok {
-			return true
-		}
-		baseNoExt := strings.TrimSuffix(base, filepath.Ext(base))
-		if _, ok := names[baseNoExt]; ok {
-			return true
-		}
-		break
-	}
-	return false
+	return processMatchesNameSet(process.Command, process.Args, names)
 }
 
 func (s processSnapshot) hasDescendantWithNames(pid string, names map[string]struct{}, depth int) bool {
-	const maxDepth = 10
-	if len(names) == 0 || depth > maxDepth {
+	if len(names) == 0 || depth > maxProcessDescendantDepth {
 		return false
 	}
 	for _, childPID := range s.children[pid] {

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -17,6 +17,7 @@ type mockFetcher struct {
 	mu       sync.Mutex
 	calls    int
 	sessions map[string]bool
+	state    runtimeStateSnapshot
 	err      error
 	delay    time.Duration
 }
@@ -39,6 +40,31 @@ func (m *mockFetcher) FetchRunning(ctx context.Context) (map[string]bool, error)
 	return sessions, err
 }
 
+func (m *mockFetcher) FetchState(ctx context.Context) (runtimeStateSnapshot, error) {
+	m.mu.Lock()
+	m.calls++
+	state := m.state
+	sessions := m.sessions
+	err := m.err
+	delay := m.delay
+	m.mu.Unlock()
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return runtimeStateSnapshot{}, ctx.Err()
+		}
+	}
+	if state.Sessions == nil && sessions != nil {
+		state.Sessions = make(map[string]sessionRuntimeState, len(sessions))
+		for name, running := range sessions {
+			state.Sessions[name] = sessionRuntimeState{Running: running}
+		}
+	}
+	return state, err
+}
+
 func (m *mockFetcher) getCalls() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -49,6 +75,7 @@ func (m *mockFetcher) setResult(sessions map[string]bool, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.sessions = sessions
+	m.state = runtimeStateSnapshot{}
 	m.err = err
 }
 
@@ -131,6 +158,70 @@ func TestStateCache_ConcurrentCallersCoalesceIntoOneFetch(t *testing.T) {
 	// singleflight should have coalesced all callers into exactly 1 fetch.
 	if got := f.getCalls(); got != 1 {
 		t.Errorf("expected 1 fetch call (singleflight), got %d", got)
+	}
+}
+
+func TestStateCache_ProcessAliveUsesFreshSnapshot(t *testing.T) {
+	f := &mockFetcher{
+		state: runtimeStateSnapshot{
+			Sessions: map[string]sessionRuntimeState{
+				"agent-1": {
+					Running: true,
+					Panes: []paneRuntimeState{{
+						Command: "claude",
+						PID:     "101",
+					}},
+				},
+			},
+			Processes: newProcessSnapshot([]processRuntimeState{{
+				PID:     "101",
+				PPID:    "1",
+				Command: "claude",
+				Args:    "claude --dangerously-skip-permissions",
+			}}),
+		},
+	}
+	cache := NewStateCache(f, 2*time.Second)
+
+	if !cache.ProcessAlive("agent-1", []string{"claude"}) {
+		t.Fatal("ProcessAlive(agent-1, claude) = false, want true")
+	}
+	if !cache.IsRunning("agent-1") {
+		t.Fatal("IsRunning(agent-1) = false, want true from same snapshot")
+	}
+	if cache.ProcessAlive("agent-1", []string{"codex"}) {
+		t.Fatal("ProcessAlive(agent-1, codex) = true, want false")
+	}
+	if got := f.getCalls(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1 across ProcessAlive and IsRunning", got)
+	}
+}
+
+func TestStateCache_ProcessAliveMatchesShellDescendantFromSnapshot(t *testing.T) {
+	f := &mockFetcher{
+		state: runtimeStateSnapshot{
+			Sessions: map[string]sessionRuntimeState{
+				"agent-1": {
+					Running: true,
+					Panes: []paneRuntimeState{{
+						Command: "bash",
+						PID:     "101",
+					}},
+				},
+			},
+			Processes: newProcessSnapshot([]processRuntimeState{
+				{PID: "101", PPID: "1", Command: "bash", Args: "bash -lc codex"},
+				{PID: "102", PPID: "101", Command: "node", Args: "node /usr/local/bin/codex"},
+			}),
+		},
+	}
+	cache := NewStateCache(f, 2*time.Second)
+
+	if !cache.ProcessAlive("agent-1", []string{"codex"}) {
+		t.Fatal("ProcessAlive(agent-1, codex) = false, want true from cached descendant snapshot")
+	}
+	if got := f.getCalls(); got != 1 {
+		t.Fatalf("fetch calls = %d, want 1", got)
 	}
 }
 

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 	"sync"
@@ -20,24 +21,6 @@ type mockFetcher struct {
 	state    runtimeStateSnapshot
 	err      error
 	delay    time.Duration
-}
-
-func (m *mockFetcher) FetchRunning(ctx context.Context) (map[string]bool, error) {
-	m.mu.Lock()
-	m.calls++
-	sessions := m.sessions
-	err := m.err
-	delay := m.delay
-	m.mu.Unlock()
-
-	if delay > 0 {
-		select {
-		case <-time.After(delay):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
-	return sessions, err
 }
 
 func (m *mockFetcher) FetchState(ctx context.Context) (runtimeStateSnapshot, error) {
@@ -77,6 +60,39 @@ func (m *mockFetcher) setResult(sessions map[string]bool, err error) {
 	m.sessions = sessions
 	m.state = runtimeStateSnapshot{}
 	m.err = err
+}
+
+type controlledRefreshFetcher struct {
+	mu        sync.Mutex
+	calls     int
+	state     runtimeStateSnapshot
+	blockCall int
+	entered   chan struct{}
+	release   chan struct{}
+}
+
+func (f *controlledRefreshFetcher) FetchState(ctx context.Context) (runtimeStateSnapshot, error) {
+	f.mu.Lock()
+	f.calls++
+	call := f.calls
+	state := f.state
+	f.mu.Unlock()
+
+	if call == f.blockCall {
+		close(f.entered)
+		select {
+		case <-f.release:
+		case <-ctx.Done():
+			return runtimeStateSnapshot{}, ctx.Err()
+		}
+	}
+	return state, nil
+}
+
+func (f *controlledRefreshFetcher) getCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
 }
 
 func TestStateCache_FreshCacheReturnsCorrectState(t *testing.T) {
@@ -225,6 +241,39 @@ func TestStateCache_ProcessAliveMatchesShellDescendantFromSnapshot(t *testing.T)
 	}
 }
 
+func TestProviderObserveLivenessUsesCacheProcessSnapshot(t *testing.T) {
+	f := &mockFetcher{
+		state: runtimeStateSnapshot{
+			Sessions: map[string]sessionRuntimeState{
+				"agent-1": {
+					Running: true,
+					Panes: []paneRuntimeState{{
+						Command: "bash",
+						PID:     "101",
+					}},
+				},
+			},
+			Processes: newProcessSnapshot([]processRuntimeState{
+				{PID: "101", PPID: "1", Command: "bash", Args: "bash -lc codex"},
+				{PID: "102", PPID: "101", Command: "node", Args: "node /usr/local/bin/codex"},
+			}),
+		},
+	}
+	provider := &Provider{cache: NewStateCache(f, time.Hour)}
+
+	got := provider.ObserveLiveness("agent-1", []string{"codex"})
+	if !got.Running || !got.Alive {
+		t.Fatalf("ObserveLiveness = %+v, want running and alive from cache", got)
+	}
+	got = provider.ObserveLiveness("agent-1", []string{"codex"})
+	if !got.Running || !got.Alive {
+		t.Fatalf("second ObserveLiveness = %+v, want running and alive from cache", got)
+	}
+	if calls := f.getCalls(); calls != 1 {
+		t.Fatalf("fetch calls = %d, want 1 across repeated ObserveLiveness calls", calls)
+	}
+}
+
 func TestStateCache_RefreshFailurePreservesLastKnownGood(t *testing.T) {
 	f := &mockFetcher{
 		sessions: map[string]bool{"agent-1": true},
@@ -252,6 +301,51 @@ func TestStateCache_RefreshFailurePreservesLastKnownGood(t *testing.T) {
 	cache.mu.RUnlock()
 	if lastErr == nil {
 		t.Error("expected lastError to be set after refresh failure")
+	}
+}
+
+func TestStateCache_DiscardRefreshAfterEvictSession(t *testing.T) {
+	state := runtimeStateSnapshot{
+		Sessions: map[string]sessionRuntimeState{
+			"agent-1": {Running: true},
+		},
+	}
+	f := &controlledRefreshFetcher{
+		state:     state,
+		blockCall: 2,
+		entered:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	cache := NewStateCache(f, time.Nanosecond)
+
+	if !cache.IsRunning("agent-1") {
+		t.Fatal("expected agent-1 running after prime")
+	}
+	time.Sleep(time.Millisecond)
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- cache.IsRunning("agent-1")
+	}()
+
+	select {
+	case <-f.entered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for refresh to start")
+	}
+	cache.EvictSession("agent-1")
+	close(f.release)
+
+	select {
+	case got := <-result:
+		if got {
+			t.Fatal("IsRunning(agent-1) = true after concurrent eviction, want false")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for IsRunning result")
+	}
+	if calls := f.getCalls(); calls != 2 {
+		t.Fatalf("fetch calls = %d, want 2", calls)
 	}
 }
 
@@ -318,6 +412,27 @@ func TestStateCache_EmptySessionsMap(t *testing.T) {
 
 	if cache.IsRunning("anything") {
 		t.Error("expected false for any session when tmux has no sessions")
+	}
+}
+
+func TestFetchProcessSnapshotCanceledContextReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := fetchProcessSnapshot(ctx)
+	if err == nil {
+		t.Fatal("fetchProcessSnapshot canceled context returned nil error")
+	}
+}
+
+func TestParseProcessSnapshotLineFixedColumns(t *testing.T) {
+	line := fmt.Sprintf("%10s %10s %-64s %s", "123", "1", "claude code", "claude code --print")
+	got, ok := parseProcessSnapshotLine(line)
+	if !ok {
+		t.Fatal("parseProcessSnapshotLine returned ok=false")
+	}
+	if got.PID != "123" || got.PPID != "1" || got.Command != "claude code" || got.Args != "claude code --print" {
+		t.Fatalf("parseProcessSnapshotLine = %+v, want fixed-column fields preserved", got)
 	}
 }
 

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -2013,12 +2013,9 @@ func (t *Tmux) CheckSessionHealth(session string, maxInactivity time.Duration) Z
 // Uses ps to get the actual command name from the process's executable path.
 // This handles cases where argv[0] is modified (e.g., Claude showing version "2.1.30").
 func processMatchesNames(pid string, names []string) bool {
-	if len(names) == 0 {
+	nameSet := processNameSet(names)
+	if len(nameSet) == 0 {
 		return false
-	}
-	nameSet := make(map[string]struct{}, len(names))
-	for _, name := range names {
-		nameSet[name] = struct{}{}
 	}
 
 	// Use ps to get the command name (COMM column gives the executable name)
@@ -2027,12 +2024,7 @@ func processMatchesNames(pid string, names []string) bool {
 	if err != nil {
 		return false
 	}
-	// Get just the base name (in case it's a full path like /Users/.../claude)
 	commPath := strings.TrimSpace(string(out))
-	comm := filepath.Base(commPath)
-	if _, ok := nameSet[comm]; ok {
-		return true
-	}
 
 	// Fall back to argv[0] from the full command line. This catches wrapper
 	// scripts launched as "/path/to/codex" where COMM may report "bash" or
@@ -2042,57 +2034,14 @@ func processMatchesNames(pid string, names []string) bool {
 	if err != nil {
 		return false
 	}
-	args := strings.Fields(strings.TrimSpace(string(out)))
-	if len(args) == 0 {
-		return false
-	}
-	argv0 := filepath.Base(args[0])
-	if _, ok := nameSet[argv0]; ok {
-		return true
-	}
-
-	// Wrapper runtimes often execute providers through interpreters such as bun,
-	// node, or npx, leaving the actual provider name only in the first positional
-	// argument. Only check the first non-flag argument after a known interpreter
-	// to avoid false positives (e.g., "vim claude.txt" or "tail -f gemini.log").
-	knownInterpreters := map[string]struct{}{
-		"node": {}, "bun": {}, "npx": {}, "deno": {},
-	}
-	// Runner subcommands (e.g., "bun run gemini") that should be skipped
-	// when scanning for the provider name in positional args.
-	runnerSubcommands := map[string]struct{}{
-		"run": {}, "exec": {}, "x": {},
-	}
-	if _, isInterpreter := knownInterpreters[argv0]; isInterpreter {
-		for _, token := range args[1:] {
-			token = strings.TrimSpace(token)
-			if token == "" || strings.HasPrefix(token, "-") {
-				continue
-			}
-			// Skip known runner subcommands like "run" in "bun run gemini".
-			if _, isRunner := runnerSubcommands[token]; isRunner {
-				continue
-			}
-			base := filepath.Base(token)
-			if _, ok := nameSet[base]; ok {
-				return true
-			}
-			baseNoExt := strings.TrimSuffix(base, filepath.Ext(base))
-			if _, ok := nameSet[baseNoExt]; ok {
-				return true
-			}
-			break // only check the first positional argument
-		}
-	}
-	return false
+	return processMatchesNameSet(commPath, string(out), nameSet)
 }
 
 // hasDescendantWithNames checks if a process has any descendant (child, grandchild, etc.)
 // matching any of the given names. Recursively traverses the process tree up to maxDepth.
 // Used when the pane command is a shell (bash, zsh) that launched an agent.
 func hasDescendantWithNames(pid string, names []string, depth int) bool {
-	const maxDepth = 10 // Prevent infinite loops in case of circular references
-	if len(names) == 0 || depth > maxDepth {
+	if len(names) == 0 || depth > maxProcessDescendantDepth {
 		return false
 	}
 	// Use pgrep to find child processes.


### PR DESCRIPTION
## Summary
- use the tmux state cache for process liveness checks
- avoid extra attachment/activity probes in the desired-session fast path
- add fake-runtime call counting used by the regression test

## Verification
- pre-commit hook passed: lint-changed, docs generation, go vet ./..., fast sharded tests
- go test ./cmd/gc ./internal/runtime ./internal/runtime/tmux -run 'TestReconcileSessionBeads_DesiredFastPathSkipsAttachmentActivityObservation|TestReconcileSessionBeads_DrainAckKeepsBeadOpen|TestStateCache|TestProvider' -count=1\n\nCherry-picked from rescue commit caf0dab435bdbe73288f81ce8060601603e8afba and rebased onto current main.