### PR TITLE
fix: retry control fallback on transient bead scans

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -1226,15 +1226,30 @@ func findLatestAttempt(store beads.Store, control beads.Bead) (beads.Bead, error
 	}
 
 	all, err := listByWorkflowRoot(store, rootID)
-	if err != nil {
-		return beads.Bead{}, err
+	if err == nil {
+		latest := latestAttemptFromCandidates(control, all)
+		if latest.ID != "" {
+			return latest, nil
+		}
 	}
 
-	latest := latestAttemptFromCandidates(control, all)
+	latest, depErr := latestAttemptFromDependencies(store, control)
+	if depErr != nil {
+		if err != nil {
+			return beads.Bead{}, fmt.Errorf("%w; dependency fallback: %w", err, depErr)
+		}
+		return beads.Bead{}, depErr
+	}
 	if latest.ID != "" {
 		return latest, nil
 	}
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	return beads.Bead{}, nil
+}
 
+func latestAttemptFromDependencies(store beads.Store, control beads.Bead) (beads.Bead, error) {
 	deps, err := store.DepList(control.ID, "down")
 	if err != nil {
 		return beads.Bead{}, err

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -1376,6 +1376,49 @@ func TestFindLatestAttemptMultipleAttempts(t *testing.T) {
 	}
 }
 
+func TestFindLatestAttemptFallsBackToDependenciesWhenRootScanFails(t *testing.T) {
+	t.Parallel()
+	base := beads.NewMemStore()
+
+	root := mustCreate(t, base, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+
+	control := mustCreate(t, base, beads.Bead{
+		Title: "rebase retry",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-feature.rebase-check",
+			"gc.step_id":      "rebase-check",
+		},
+	})
+
+	attempt := mustCreate(t, base, beads.Bead{
+		Title: "rebase attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-feature.rebase-check.attempt.1",
+			"gc.attempt":      "1",
+		},
+	})
+	mustClose(t, base, attempt.ID)
+	mustDep(t, base, control.ID, attempt.ID, "blocks")
+
+	store := &listFailStore{
+		Store: base,
+		err:   errors.New("search wisps: context canceled"),
+	}
+	found, err := findLatestAttempt(store, mustGet(t, store, control.ID))
+	if err != nil {
+		t.Fatalf("findLatestAttempt: %v", err)
+	}
+	if found.ID != attempt.ID {
+		t.Fatalf("findLatestAttempt returned %q, want dependency attempt %q", found.ID, attempt.ID)
+	}
+}
+
 func TestFindLatestAttemptSkipsMoleculeFailedPartialRoot(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
@@ -2120,6 +2163,15 @@ func mustDep(t *testing.T, store beads.Store, from, to, depType string) { //noli
 	if err := store.DepAdd(from, to, depType); err != nil {
 		t.Fatalf("dep %s -> %s: %v", from, to, err)
 	}
+}
+
+type listFailStore struct {
+	beads.Store
+	err error
+}
+
+func (s *listFailStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return nil, s.err
 }
 
 type controlCloseTrackingStore struct {


### PR DESCRIPTION
## Summary
- retry control fallback scanning when transient bead-store scans fail
- add regression coverage for transient scan retry behavior

## Verification
- go test ./internal/dispatch -count=1

Cherry-picked from rescue commit cb1de2530afb0b36f7acd7e1f1d3b3d9e6880a21 and rebased onto current main.