### PR TITLE
fix(runtime): trust Codex hook review startup dialog

### DIFF
--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -33,8 +33,9 @@ func StartupDialogTimeout() time.Duration {
 //  1. Claude resume selector — requires Down+Enter to resume the full session
 //  2. Codex update dialog ("Update available") — requires Down+Enter to skip
 //  3. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?")
-//  4. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
-//  5. Claude custom API key confirmation — requires Up+Enter to select "Yes"
+//  4. Codex hook review dialog — requires Down+Enter to trust hooks
+//  5. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
+//  6. Claude custom API key confirmation — requires Up+Enter to select "Yes"
 //
 // The peek function should return the last N lines of the session's terminal output.
 // The sendKeys function should send bare tmux-style keystrokes (e.g., "Enter", "Down").
@@ -102,6 +103,17 @@ func AcceptStartupDialogsFromStreamWithStatus(
 	phaseObserved, err = acceptWorkspaceTrustDialogFromStream(ctx, timeout, stream, trackingSendKeys)
 	if err != nil {
 		return observed, fmt.Errorf("workspace trust dialog: %w", err)
+	}
+	observed = observed || phaseObserved
+	if !phaseObserved && !observed {
+		return false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return observed, err
+	}
+	phaseObserved, err = acceptCodexHookReviewDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	if err != nil {
+		return observed, fmt.Errorf("codex hook review dialog: %w", err)
 	}
 	observed = observed || phaseObserved
 	if !phaseObserved && !observed {
@@ -178,6 +190,12 @@ func AcceptStartupDialogsWithTimeout(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if err := acceptCodexHookReviewDialog(ctx, timeout, peek, sendKeys); err != nil {
+		return fmt.Errorf("codex hook review dialog: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := acceptBypassPermissionsWarning(ctx, timeout, peek, sendKeys); err != nil {
 		return fmt.Errorf("bypass permissions warning: %w", err)
 	}
@@ -228,6 +246,7 @@ func acceptClaudeResumeDialog(
 		if containsPromptIndicator(content) ||
 			containsCodexUpdateDialog(content) ||
 			containsWorkspaceTrustDialog(content) ||
+			containsCodexHookReviewDialog(content) ||
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
 			ContainsRateLimitDialog(content) {
@@ -263,6 +282,7 @@ func acceptClaudeResumeDialogFromStream(
 func containsPostClaudeResumeStartupDialog(content string) bool {
 	return containsCodexUpdateDialog(content) ||
 		containsWorkspaceTrustDialog(content) ||
+		containsCodexHookReviewDialog(content) ||
 		strings.Contains(content, "Bypass Permissions mode") ||
 		containsCustomAPIKeyDialog(content) ||
 		ContainsRateLimitDialog(content)
@@ -297,6 +317,7 @@ func acceptCodexUpdateDialog(
 
 		if containsPromptIndicator(content) ||
 			containsWorkspaceTrustDialog(content) ||
+			containsCodexHookReviewDialog(content) ||
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
 			ContainsRateLimitDialog(content) {
@@ -331,6 +352,7 @@ func acceptCodexUpdateDialogFromStream(
 
 func containsPostUpdateStartupDialog(content string) bool {
 	return containsWorkspaceTrustDialog(content) ||
+		containsCodexHookReviewDialog(content) ||
 		strings.Contains(content, "Bypass Permissions mode") ||
 		containsCustomAPIKeyDialog(content) ||
 		ContainsRateLimitDialog(content)
@@ -369,8 +391,10 @@ func acceptWorkspaceTrustDialog(
 			return nil
 		}
 
-		// Check if a bypass dialog appeared instead — let the next phase handle it.
-		if strings.Contains(content, "Bypass Permissions mode") {
+		if containsCodexHookReviewDialog(content) ||
+			strings.Contains(content, "Bypass Permissions mode") ||
+			containsCustomAPIKeyDialog(content) ||
+			ContainsRateLimitDialog(content) {
 			return nil
 		}
 
@@ -402,6 +426,74 @@ func containsWorkspaceTrustDialog(content string) bool {
 }
 
 func containsPostTrustStartupDialog(content string) bool {
+	return containsCodexHookReviewDialog(content) ||
+		strings.Contains(content, "Bypass Permissions mode") ||
+		containsCustomAPIKeyDialog(content) ||
+		ContainsRateLimitDialog(content)
+}
+
+// acceptCodexHookReviewDialog dismisses Codex's startup hook trust review.
+// The first option reviews hook details; automated managed sessions want the
+// second option, "Trust all and continue", so press Down then Enter.
+func acceptCodexHookReviewDialog(
+	ctx context.Context,
+	timeout time.Duration,
+	peek func(lines int) (string, error),
+	sendKeys func(keys ...string) error,
+) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		content, err := peek(startupDialogPeekLines)
+		if err != nil {
+			return err
+		}
+
+		if containsCodexHookReviewDialog(content) {
+			if err := sendKeys("Down"); err != nil {
+				return err
+			}
+			sleep(ctx, bypassDialogConfirmDelay)
+			return sendKeys("Enter")
+		}
+
+		if containsPromptIndicator(content) ||
+			strings.Contains(content, "Bypass Permissions mode") ||
+			containsCustomAPIKeyDialog(content) ||
+			ContainsRateLimitDialog(content) {
+			return nil
+		}
+
+		sleep(ctx, dialogPollInterval)
+	}
+	return nil
+}
+
+func acceptCodexHookReviewDialogFromStream(
+	ctx context.Context,
+	timeout time.Duration,
+	snapshots *replayableSnapshotCursor,
+	sendKeys func(keys ...string) error,
+) (bool, error) {
+	return acceptDialogFromStream(ctx, timeout, snapshots, sendKeys, streamDialogSpec{
+		match:       containsCodexHookReviewDialog,
+		matchKeys:   []string{"Down", "Enter"},
+		matchDelay:  bypassDialogConfirmDelay,
+		ready:       containsPromptIndicator,
+		readyOrNext: containsPostCodexHookReviewStartupDialog,
+	})
+}
+
+func containsCodexHookReviewDialog(content string) bool {
+	return strings.Contains(content, "Hooks need review") &&
+		strings.Contains(content, "Trust all and continue") &&
+		strings.Contains(content, "Continue without trusting")
+}
+
+func containsPostCodexHookReviewStartupDialog(content string) bool {
 	return strings.Contains(content, "Bypass Permissions mode") ||
 		containsCustomAPIKeyDialog(content) ||
 		ContainsRateLimitDialog(content)

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -287,10 +287,90 @@ func TestAcceptStartupDialogsSkipsUpdateThenHandlesTrustDialog(t *testing.T) {
 	}
 }
 
+func TestAcceptStartupDialogsTrustsCodexHookReviewDialog(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) {
+			if len(sent) == 0 {
+				return codexHookReviewDialogFixture(), nil
+			}
+			return "› Implement {feature}", nil
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Down,Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
+func TestAcceptStartupDialogsHandlesTrustThenCodexHookReview(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) {
+			switch len(sent) {
+			case 0:
+				return "Do you trust the contents of this directory?", nil
+			case 1:
+				return codexHookReviewDialogFixture(), nil
+			default:
+				return "› Implement {feature}", nil
+			}
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Enter,Down,Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
 func TestAcceptStartupDialogsFromStreamSkipsCodexUpdateDialog(t *testing.T) {
 	var sent []string
 	snapshots := make(chan string, 2)
 	snapshots <- codexUpdateDialogFixture()
+	snapshots <- "› Implement {feature}"
+	close(snapshots)
+
+	err := AcceptStartupDialogsFromStream(
+		context.Background(),
+		time.Second,
+		snapshots,
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsFromStream() error = %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Down,Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
+func TestAcceptStartupDialogsFromStreamTrustsCodexHookReviewDialog(t *testing.T) {
+	var sent []string
+	snapshots := make(chan string, 2)
+	snapshots <- codexHookReviewDialogFixture()
 	snapshots <- "› Implement {feature}"
 	close(snapshots)
 
@@ -667,6 +747,16 @@ func codexUpdateDialogFixture() string {
 		"  2. Skip\n" +
 		"  3. Skip until next version\n" +
 		"Press enter to continue"
+}
+
+func codexHookReviewDialogFixture() string {
+	return "Hooks need review\n" +
+		"  4 hooks are new or changed.\n" +
+		"  Hooks can run outside the sandbox after you trust them.\n\n" +
+		"› 1. Review hooks\n" +
+		"  2. Trust all and continue\n" +
+		"  3. Continue without trusting (hooks won't run)\n\n" +
+		"  Press enter to confirm or esc to go back"
 }
 
 func TestExitsEarlyOnPrompt(t *testing.T) {


### PR DESCRIPTION
## Summary
- recognize Codex startup hook-review prompts
- choose the trust-all option for managed startup dialog handling
- cover both direct peek/send and stream-based startup dialog paths

## Verification
- pre-commit hook passed: lint-changed, docs generation, go vet ./..., fast sharded tests
- go test ./internal/runtime -run 'TestAcceptStartupDialogs.*CodexHook|TestAcceptStartupDialogsHandlesTrustThenCodexHookReview|TestAcceptStartupDialogsTrustsCodexHookReviewDialog' -count=1\n\nExtracted from the uncommitted rescue branch dialog handling diff and rebased onto current main.