### PR TITLE
test(cmd/gc): stabilize parallel-pool-create test under scheduler jitter

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3226,7 +3226,10 @@ func (s *delayingPoolCreateStore) Create(bead beads.Bead) (beads.Bead, error) {
 func TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates(t *testing.T) {
 	const (
 		requestCount = 8
-		createDelay  = 50 * time.Millisecond
+		// createDelay must be large enough that scheduler jitter on loaded
+		// hosts stays small relative to the per-create cost; otherwise the
+		// parallel-vs-serial wall-clock comparison below loses signal.
+		createDelay = 200 * time.Millisecond
 	)
 	store := &delayingPoolCreateStore{MemStore: beads.NewMemStore(), delay: createDelay}
 	cityPath := t.TempDir()


### PR DESCRIPTION
## Summary
- bump `createDelay` from 50ms to 200ms in `TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates`
- preserve the existing parallel-vs-serial assertion shape (`parallelCeiling = serialFloor / 2`) — the ceiling moves from 200ms to 800ms with the larger delay
- a regression that re-serializes the loop still produces ~1.6s and fails the check

## Why

`TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates`
(`cmd/gc/build_desired_state_test.go:3264`) fails on hosts under load:

```
realizePoolDesiredSessions ran in 257.822ms for 8 creates × 50ms delay;
serial floor = 400ms, parallel ceiling = 200ms — the refactor did not parallelize
```

With `createDelay = 50ms`, the ideal parallel runtime is ~50ms and the parallel
ceiling (`serialFloor / 2 = 200ms`) is only 150ms above ideal. On busy hosts
(e.g. load avg comparable to or above `runtime.NumCPU()`), Go scheduler stalls
of ~200ms flip the test even though the work is being parallelized — elapsed
lands in the 250–560ms band, well below the 400ms serial floor.

Raising `createDelay` to 200ms makes the per-create cost large relative to
scheduling jitter:
- ideal parallel runtime: ~200ms
- new parallel ceiling: 800ms
- new serial floor: 1600ms

A genuine re-serialization regression still produces ~1.6s and trips the
assertion; benign scheduler jitter no longer flips it. The signal shape
(parallel vs serial) is preserved.

## Testing

- `go test ./cmd/gc -count=20 -race -run TestRealizePoolDesiredSessions_ParallelizesDistinctAliasCreates`
- `go vet ./...`

## History

Test was introduced in #2336 (closes #2319) alongside the parallel realizer.
The 50ms × 8 creates × 200ms ceiling was correct at low load on the original
author's machine; it did not survive scheduler jitter at higher load.

Closes #2445