### PR TITLE
Fix managed Dolt test leak guard follow-up

### DIFF
--- a/cmd/gc/dolt_cleanup_reaper.go
+++ b/cmd/gc/dolt_cleanup_reaper.go
@@ -101,6 +101,8 @@ func isTestConfigPath(p, homeDir, tempDir string) bool {
 func testConfigPathPrefixes() []string {
 	return []string{
 		"Test",
+		// Legacy pre-owner-PID cmd/gc test roots. Current cmd/gc roots use
+		// the gct<PID>-* prefix and are handled by stale-root owner PID logic.
 		"gctest-",
 		"gc-state-runtime-builtin-",
 		"gc-state-mutation-builtin-",

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -546,6 +546,7 @@ func TestDoltLeakGuardedTestingMFinalSnapshotRunsBeforeRegistryReap(t *testing.T
 	}
 	var scan int
 	registeredReaped := false
+	var reapedLeaks []DoltProcInfo
 	enumerate := func() ([]DoltProcInfo, error) {
 		scan++
 		if scan == 1 {
@@ -563,10 +564,14 @@ func TestDoltLeakGuardedTestingMFinalSnapshotRunsBeforeRegistryReap(t *testing.T
 		enumerate,
 		func(string) bool { return false },
 		func() { registeredReaped = true },
+		func(leaked []DoltProcInfo) { reapedLeaks = append(reapedLeaks, leaked...) },
 	)
 
 	if code != 1 {
 		t.Fatalf("guard returned code %d, want 1 for leaked registered process", code)
+	}
+	if len(reapedLeaks) != 1 || reapedLeaks[0].PID != leaked.PID {
+		t.Fatalf("reaped leaks = %#v, want only PID %d through injected reaper", reapedLeaks, leaked.PID)
 	}
 	if !registeredReaped {
 		t.Fatal("registered process reaper was not called after leak detection")

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -416,6 +416,41 @@ func TestIsStaleCmdGCTestConfigPathSkipsLivePeerOwnerPIDRoot(t *testing.T) {
 	}
 }
 
+func TestIsStaleCmdGCTestConfigPathUsesCurrentGCTOwnerPID(t *testing.T) {
+	ownerPID := 12345
+	root := filepath.Join("/tmp", fmt.Sprintf("%s%d-current", testCmdGCTempRootPrefix, ownerPID))
+	configPath := filepath.Join(root, "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+
+	if isStaleCmdGCTestConfigPathWithPIDCheck(configPath, nil, "/tmp", func(pid int) bool {
+		if pid != ownerPID {
+			t.Fatalf("pidAlive called with pid %d, want %d", pid, ownerPID)
+		}
+		return true
+	}) {
+		t.Fatalf("live current gct owner config path %q classified as stale", configPath)
+	}
+	if !isStaleCmdGCTestConfigPathWithPIDCheck(configPath, nil, "/tmp", func(pid int) bool {
+		if pid != ownerPID {
+			t.Fatalf("pidAlive called with pid %d, want %d", pid, ownerPID)
+		}
+		return false
+	}) {
+		t.Fatalf("dead current gct owner config path %q not classified as stale", configPath)
+	}
+}
+
+func TestIsTestConfigPathRetainsLegacyGCTestAllowlistOnly(t *testing.T) {
+	legacyConfig := filepath.Join("/tmp", "gctest-legacy", "TestCase", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	currentConfig := filepath.Join("/tmp", fmt.Sprintf("%s%d-current", testCmdGCTempRootPrefix, os.Getpid()), "TestCase", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+
+	if !isTestConfigPath(legacyConfig, "/home/u", "/tmp") {
+		t.Fatalf("legacy gctest config path %q should stay in the test allowlist", legacyConfig)
+	}
+	if isTestConfigPath(currentConfig, "/home/u", "/tmp") {
+		t.Fatalf("current gct config path %q must use owner-PID stale-root logic, not the legacy allowlist", currentConfig)
+	}
+}
+
 func TestIsStaleCmdGCTestConfigPathSkipsLegacyUnownedRoot(t *testing.T) {
 	legacyConfig := filepath.Join("/tmp", "gctest-legacy", "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
 
@@ -495,5 +530,45 @@ func TestDiffDoltProcessSnapshotsReportsOnlyNewPIDsSorted(t *testing.T) {
 	}
 	if got[0].PID != 1001 || got[1].PID != 1003 {
 		t.Fatalf("diff PIDs = [%d %d], want [1001 1003]", got[0].PID, got[1].PID)
+	}
+}
+
+func TestDoltLeakGuardedTestingMFinalSnapshotRunsBeforeRegistryReap(t *testing.T) {
+	tempRoot := filepath.Join(t.TempDir(), "gct12345-current")
+	leaked := DoltProcInfo{
+		PID: 1001,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join(tempRoot, "TestCase", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+	var scan int
+	registeredReaped := false
+	enumerate := func() ([]DoltProcInfo, error) {
+		scan++
+		if scan == 1 {
+			return nil, nil
+		}
+		if registeredReaped {
+			return nil, nil
+		}
+		return []DoltProcInfo{leaked}, nil
+	}
+	g := newDoltLeakGuardedTestingM(nil, tempRoot)
+
+	code := g.runWith(
+		func() int { return 0 },
+		enumerate,
+		func(string) bool { return false },
+		func() { registeredReaped = true },
+	)
+
+	if code != 1 {
+		t.Fatalf("guard returned code %d, want 1 for leaked registered process", code)
+	}
+	if !registeredReaped {
+		t.Fatal("registered process reaper was not called after leak detection")
 	}
 }

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -48,6 +48,7 @@ const (
 	managedDoltTestModeEnv      = "GC_MANAGED_DOLT_TEST_MODE"
 	managedDoltTestParentPIDEnv = "GC_MANAGED_DOLT_TEST_PARENT_PID"
 	managedDoltTestWatchdogArg  = "__gc-managed-dolt-test-watchdog"
+	// The first ExtraFiles entry is exposed to the child as fd 3.
 	managedDoltTestParentPipeFD = 3
 )
 
@@ -251,41 +252,63 @@ func startManagedDoltSQLServerWithTestWatchdog(cityPath, configFile, logFilePath
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, err
 	}
-	parentPipeRead, parentPipeWrite, err := os.Pipe()
-	if err != nil {
-		_ = os.Remove(disarmFile)
-		return managedDoltStartedProcess{}, fmt.Errorf("create dolt test watchdog parent pipe: %w", err)
+	args := []string{managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile}
+	var parentPipeRead *os.File
+	var parentPipeWrite *os.File
+	if !managedDoltTestHasExternalParent() {
+		parentPipeRead, parentPipeWrite, err = os.Pipe()
+		if err != nil {
+			_ = os.Remove(disarmFile)
+			return managedDoltStartedProcess{}, fmt.Errorf("create dolt test watchdog parent pipe: %w", err)
+		}
+		args = append(args, strconv.Itoa(managedDoltTestParentPipeFD))
 	}
-	cmd := exec.Command(watchdogExecutable, managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile, strconv.Itoa(managedDoltTestParentPipeFD))
+	cmd := exec.Command(watchdogExecutable, args...)
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
 	cmd.Env = doltServerEnv(os.Environ())
-	cmd.ExtraFiles = []*os.File{parentPipeRead}
+	if parentPipeRead != nil {
+		cmd.ExtraFiles = []*os.File{parentPipeRead}
+	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		_ = parentPipeRead.Close()
-		_ = parentPipeWrite.Close()
+		if parentPipeRead != nil {
+			_ = parentPipeRead.Close()
+		}
+		if parentPipeWrite != nil {
+			_ = parentPipeWrite.Close()
+		}
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, fmt.Errorf("prepare dolt test watchdog: %w", err)
 	}
 	if err := cmd.Start(); err != nil {
-		_ = parentPipeRead.Close()
-		_ = parentPipeWrite.Close()
+		if parentPipeRead != nil {
+			_ = parentPipeRead.Close()
+		}
+		if parentPipeWrite != nil {
+			_ = parentPipeWrite.Close()
+		}
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, fmt.Errorf("start dolt test watchdog: %w", err)
 	}
-	_ = parentPipeRead.Close()
+	if parentPipeRead != nil {
+		_ = parentPipeRead.Close()
+	}
 	pid, err := readManagedDoltTestWatchdogPID(stdout, cmd.Process.Pid)
 	if err != nil {
 		_ = terminateManagedDoltPID(cityPath, cmd.Process.Pid)
 		_ = cmd.Wait()
-		_ = parentPipeWrite.Close()
+		if parentPipeWrite != nil {
+			_ = parentPipeWrite.Close()
+		}
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, err
 	}
 	go func() {
 		_ = cmd.Wait()
-		_ = parentPipeWrite.Close()
+		if parentPipeWrite != nil {
+			_ = parentPipeWrite.Close()
+		}
 	}()
 	started := managedDoltStartedProcess{
 		CityPath:    cityPath,
@@ -691,6 +714,10 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 			<-done
 			return 0
 		case <-parentDone:
+			if _, err := os.Stat(disarmFile); err == nil {
+				_ = os.Remove(disarmFile)
+				return 0
+			}
 			_ = terminateManagedDoltPID("", cmd.Process.Pid)
 			<-done
 			return 0

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -48,6 +48,7 @@ const (
 	managedDoltTestModeEnv      = "GC_MANAGED_DOLT_TEST_MODE"
 	managedDoltTestParentPIDEnv = "GC_MANAGED_DOLT_TEST_PARENT_PID"
 	managedDoltTestWatchdogArg  = "__gc-managed-dolt-test-watchdog"
+	managedDoltTestParentPipeFD = 3
 )
 
 var (
@@ -250,27 +251,42 @@ func startManagedDoltSQLServerWithTestWatchdog(cityPath, configFile, logFilePath
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, err
 	}
-	cmd := exec.Command(watchdogExecutable, managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile)
+	parentPipeRead, parentPipeWrite, err := os.Pipe()
+	if err != nil {
+		_ = os.Remove(disarmFile)
+		return managedDoltStartedProcess{}, fmt.Errorf("create dolt test watchdog parent pipe: %w", err)
+	}
+	cmd := exec.Command(watchdogExecutable, managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile, strconv.Itoa(managedDoltTestParentPipeFD))
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
 	cmd.Env = doltServerEnv(os.Environ())
+	cmd.ExtraFiles = []*os.File{parentPipeRead}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		_ = parentPipeRead.Close()
+		_ = parentPipeWrite.Close()
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, fmt.Errorf("prepare dolt test watchdog: %w", err)
 	}
 	if err := cmd.Start(); err != nil {
+		_ = parentPipeRead.Close()
+		_ = parentPipeWrite.Close()
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, fmt.Errorf("start dolt test watchdog: %w", err)
 	}
+	_ = parentPipeRead.Close()
 	pid, err := readManagedDoltTestWatchdogPID(stdout, cmd.Process.Pid)
 	if err != nil {
 		_ = terminateManagedDoltPID(cityPath, cmd.Process.Pid)
 		_ = cmd.Wait()
+		_ = parentPipeWrite.Close()
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, err
 	}
-	go func() { _ = cmd.Wait() }()
+	go func() {
+		_ = cmd.Wait()
+		_ = parentPipeWrite.Close()
+	}()
 	started := managedDoltStartedProcess{
 		CityPath:    cityPath,
 		PID:         pid,
@@ -613,8 +629,8 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 		fmt.Fprintln(stderr, "managed dolt test watchdog is only available in managed Dolt test mode") //nolint:errcheck
 		return 2
 	}
-	if len(args) != 4 {
-		fmt.Fprintf(stderr, "usage: %s <parent-pid> <config-file> <log-file> <disarm-file>\n", managedDoltTestWatchdogArg) //nolint:errcheck
+	if len(args) != 4 && len(args) != 5 {
+		fmt.Fprintf(stderr, "usage: %s <parent-pid> <config-file> <log-file> <disarm-file> [parent-pipe-fd]\n", managedDoltTestWatchdogArg) //nolint:errcheck
 		return 2
 	}
 	parentPID, err := strconv.Atoi(args[0])
@@ -625,6 +641,16 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 	configFile := args[1]
 	logFilePath := args[2]
 	disarmFile := args[3]
+	var parentDone <-chan struct{}
+	if len(args) == 5 {
+		done, closeParentDone, err := managedDoltTestParentDone(args[4])
+		if err != nil {
+			fmt.Fprintf(stderr, "watch parent pipe: %v\n", err) //nolint:errcheck
+			return 2
+		}
+		parentDone = done
+		defer closeParentDone()
+	}
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		fmt.Fprintf(stderr, "open dolt log: %v\n", err) //nolint:errcheck
@@ -664,6 +690,10 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 			_ = terminateManagedDoltPID("", cmd.Process.Pid)
 			<-done
 			return 0
+		case <-parentDone:
+			_ = terminateManagedDoltPID("", cmd.Process.Pid)
+			<-done
+			return 0
 		case <-ticker.C:
 			if _, err := os.Stat(disarmFile); err == nil {
 				_ = os.Remove(disarmFile)
@@ -681,6 +711,25 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 			return 0
 		}
 	}
+}
+
+func managedDoltTestParentDone(rawFD string) (<-chan struct{}, func(), error) {
+	fd, err := strconv.Atoi(strings.TrimSpace(rawFD))
+	if err != nil || fd <= 2 {
+		return nil, nil, fmt.Errorf("invalid parent pipe fd %q", rawFD)
+	}
+	parentPipe := os.NewFile(uintptr(fd), "gc-managed-dolt-test-parent")
+	if parentPipe == nil {
+		return nil, nil, fmt.Errorf("open parent pipe fd %d", fd)
+	}
+	syscall.CloseOnExec(fd)
+	done := make(chan struct{})
+	go func() {
+		var buf [1]byte
+		_, _ = parentPipe.Read(buf[:])
+		close(done)
+	}()
+	return done, func() { _ = parentPipe.Close() }, nil
 }
 
 // doltServerEnv returns the environment applied to every managed dolt

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -385,6 +386,27 @@ func TestManagedDoltTestDisarmOnReadyForEnvOnlyHelperWithoutParent(t *testing.T)
 	}
 }
 
+func TestManagedDoltTestParentDoneClosesOnPipeEOF(t *testing.T) {
+	parentPipeRead, parentPipeWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	done, closeDone, err := managedDoltTestParentDone(strconv.Itoa(int(parentPipeRead.Fd())))
+	if err != nil {
+		t.Fatalf("managedDoltTestParentDone: %v", err)
+	}
+	defer closeDone()
+
+	if err := parentPipeWrite.Close(); err != nil {
+		t.Fatalf("close parent pipe writer: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("parent pipe EOF did not close done channel")
+	}
+}
+
 func TestDisarmManagedDoltStartedProcessUnregistersReadyProcess(t *testing.T) {
 	withManagedDoltTestMode(t, true)
 	clearManagedDoltTestProcessRegistry(t)
@@ -485,12 +507,29 @@ func TestReapManagedDoltTestProcessesTerminatesRegisteredChildren(t *testing.T) 
 	}
 	t.Cleanup(func() { managedDoltTestTerminateProcess = oldTerminate })
 
-	pid := os.Getpid()
-	registerManagedDoltTestProcess(managedDoltStartedProcess{PID: pid, WatchdogPID: pid})
+	startChild := func(name string) *exec.Cmd {
+		t.Helper()
+		cmd := exec.Command("sleep", "60")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start %s child: %v", name, err)
+		}
+		t.Cleanup(func() {
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			_ = cmd.Wait()
+		})
+		return cmd
+	}
+	dolt := startChild("dolt")
+	watchdog := startChild("watchdog")
+	started := managedDoltStartedProcess{PID: dolt.Process.Pid, WatchdogPID: watchdog.Process.Pid}
+	registerManagedDoltTestProcess(started)
 	reapManagedDoltTestProcesses()
 
-	if len(terminated) != 2 || terminated[0] != pid || terminated[1] != pid {
-		t.Fatalf("terminated = %v, want child and watchdog pid %d", terminated, pid)
+	want := []int{started.PID, started.WatchdogPID}
+	if fmt.Sprint(terminated) != fmt.Sprint(want) {
+		t.Fatalf("terminated = %v, want %v", terminated, want)
 	}
 	var remaining int
 	managedDoltTestProcessRegistry.Range(func(_, _ any) bool {

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -228,6 +228,54 @@ func clearManagedDoltTestProcessRegistry(t *testing.T) {
 	})
 }
 
+func writeFakeDoltSQLServer(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake requires POSIX sh")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "dolt")
+	content := "#!/bin/sh\n" +
+		"if [ \"$1\" != \"sql-server\" ]; then\n" +
+		"  echo \"unexpected dolt args: $*\" >&2\n" +
+		"  exit 2\n" +
+		"fi\n" +
+		"exec sleep 60\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return dir
+}
+
+func readManagedDoltTestState(t *testing.T, path string) (int, int) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read helper state: %v", err)
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) != 2 {
+		t.Fatalf("helper state %q has %d fields, want 2", string(data), len(fields))
+	}
+	doltPID, err := strconv.Atoi(fields[0])
+	if err != nil || doltPID <= 0 {
+		t.Fatalf("helper dolt pid %q invalid", fields[0])
+	}
+	watchdogPID, err := strconv.Atoi(fields[1])
+	if err != nil || watchdogPID <= 0 {
+		t.Fatalf("helper watchdog pid %q invalid", fields[1])
+	}
+	return doltPID, watchdogPID
+}
+
+func cleanupManagedDoltTestPID(t *testing.T, pid int) {
+	t.Helper()
+	if pid <= 0 {
+		return
+	}
+	_ = terminateManagedDoltTestPID(pid)
+}
+
 func TestManagedDoltSQLServerSysProcAttrProductionDetaches(t *testing.T) {
 	withManagedDoltTestMode(t, false)
 	t.Setenv(managedDoltTestModeEnv, "")
@@ -391,8 +439,14 @@ func TestManagedDoltTestParentDoneClosesOnPipeEOF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
-	done, closeDone, err := managedDoltTestParentDone(strconv.Itoa(int(parentPipeRead.Fd())))
+	defer parentPipeRead.Close() //nolint:errcheck
+	parentPipeFD, err := syscall.Dup(int(parentPipeRead.Fd()))
 	if err != nil {
+		t.Fatalf("dup parent pipe fd: %v", err)
+	}
+	done, closeDone, err := managedDoltTestParentDone(strconv.Itoa(parentPipeFD))
+	if err != nil {
+		_ = syscall.Close(parentPipeFD)
 		t.Fatalf("managedDoltTestParentDone: %v", err)
 	}
 	defer closeDone()
@@ -404,6 +458,161 @@ func TestManagedDoltTestParentDoneClosesOnPipeEOF(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("parent pipe EOF did not close done channel")
+	}
+}
+
+func TestManagedDoltWatchdogExternalParentSurvivesSpawnerExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX process semantics required")
+	}
+	dir := t.TempDir()
+	fakeDoltDir := writeFakeDoltSQLServer(t)
+	statePath := filepath.Join(dir, "state")
+	configPath := filepath.Join(dir, "dolt-config.yaml")
+	logPath := filepath.Join(dir, "dolt.log")
+	if err := os.WriteFile(configPath, []byte("log_level: debug\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestManagedDoltWatchdogExternalParentHelper", "-test.v")
+	cmd.Env = sanitizedBaseEnv(
+		"GC_TEST_MANAGED_DOLT_HELPER=external-parent",
+		"GC_TEST_MANAGED_DOLT_HELPER_PARENT_PID="+strconv.Itoa(os.Getpid()),
+		"GC_TEST_MANAGED_DOLT_HELPER_STATE="+statePath,
+		"GC_TEST_MANAGED_DOLT_HELPER_CONFIG="+configPath,
+		"GC_TEST_MANAGED_DOLT_HELPER_LOG="+logPath,
+		"GC_TEST_MANAGED_DOLT_HELPER_FAKE_DOLT_DIR="+fakeDoltDir,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper failed: %v\n%s", err, output)
+	}
+	doltPID, watchdogPID := readManagedDoltTestState(t, statePath)
+	t.Cleanup(func() {
+		cleanupManagedDoltTestPID(t, doltPID)
+		cleanupManagedDoltTestPID(t, watchdogPID)
+	})
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if !pidAlive(doltPID) {
+			logData, _ := os.ReadFile(logPath)
+			t.Fatalf("fake dolt pid %d exited after short-lived spawner exit; helper output:\n%s\nwatchdog log:\n%s", doltPID, output, logData)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestManagedDoltWatchdogExternalParentHelper(t *testing.T) {
+	if os.Getenv("GC_TEST_MANAGED_DOLT_HELPER") != "external-parent" {
+		t.Skip("helper process only")
+	}
+	parentPID := strings.TrimSpace(os.Getenv("GC_TEST_MANAGED_DOLT_HELPER_PARENT_PID"))
+	if parentPID == "" {
+		t.Fatal("missing helper parent pid")
+	}
+	t.Setenv(managedDoltTestModeEnv, "1")
+	t.Setenv(managedDoltTestParentPIDEnv, parentPID)
+	fakeDoltDir := strings.TrimSpace(os.Getenv("GC_TEST_MANAGED_DOLT_HELPER_FAKE_DOLT_DIR"))
+	if fakeDoltDir == "" {
+		t.Fatal("missing fake dolt dir")
+	}
+	t.Setenv("PATH", fakeDoltDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	statePath := strings.TrimSpace(os.Getenv("GC_TEST_MANAGED_DOLT_HELPER_STATE"))
+	configPath := strings.TrimSpace(os.Getenv("GC_TEST_MANAGED_DOLT_HELPER_CONFIG"))
+	logPath := strings.TrimSpace(os.Getenv("GC_TEST_MANAGED_DOLT_HELPER_LOG"))
+	if statePath == "" || configPath == "" || logPath == "" {
+		t.Fatal("missing helper paths")
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open log file: %v", err)
+	}
+	defer logFile.Close() //nolint:errcheck
+
+	started, err := startManagedDoltSQLServerWithTestWatchdog("", configPath, logPath, logFile)
+	if err != nil {
+		t.Fatalf("start managed dolt with watchdog: %v", err)
+	}
+	state := fmt.Sprintf("%d %d\n", started.PID, started.WatchdogPID)
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatalf("write helper state: %v", err)
+	}
+	unregisterManagedDoltStartedProcess(started)
+}
+
+func TestManagedDoltWatchdogParentPipeEOFHonorsDisarm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX process semantics required")
+	}
+	withManagedDoltTestMode(t, false)
+	t.Setenv(managedDoltTestModeEnv, "1")
+	fakeDoltDir := writeFakeDoltSQLServer(t)
+	t.Setenv("PATH", fakeDoltDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "dolt-config.yaml")
+	logPath := filepath.Join(dir, "dolt.log")
+	disarmFile := filepath.Join(dir, "watchdog.disarm")
+	if err := os.WriteFile(configPath, []byte("log_level: debug\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(disarmFile, []byte("ready\n"), 0o644); err != nil {
+		t.Fatalf("write disarm file: %v", err)
+	}
+	parentPipeRead, parentPipeWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create parent pipe: %v", err)
+	}
+	defer parentPipeRead.Close()  //nolint:errcheck
+	defer parentPipeWrite.Close() //nolint:errcheck
+	watchdogParentPipeFD, err := syscall.Dup(int(parentPipeRead.Fd()))
+	if err != nil {
+		t.Fatalf("dup parent pipe fd for watchdog: %v", err)
+	}
+	stdoutRead, stdoutWrite, err := os.Pipe()
+	if err != nil {
+		_ = syscall.Close(watchdogParentPipeFD)
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	defer stdoutRead.Close()  //nolint:errcheck
+	defer stdoutWrite.Close() //nolint:errcheck
+	stderrPath := filepath.Join(dir, "watchdog.stderr")
+	stderrFile, err := os.OpenFile(stderrPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		_ = syscall.Close(watchdogParentPipeFD)
+		t.Fatalf("open stderr file: %v", err)
+	}
+	defer stderrFile.Close() //nolint:errcheck
+
+	result := make(chan int, 1)
+	args := []string{strconv.Itoa(os.Getpid()), configPath, logPath, disarmFile, strconv.Itoa(watchdogParentPipeFD)}
+	go func() {
+		result <- runManagedDoltTestWatchdog(args, stdoutWrite, stderrFile)
+	}()
+
+	doltPID, err := readManagedDoltTestWatchdogPID(stdoutRead, os.Getpid())
+	if err != nil {
+		t.Fatalf("read fake dolt pid: %v", err)
+	}
+	t.Cleanup(func() { cleanupManagedDoltTestPID(t, doltPID) })
+	if err := parentPipeWrite.Close(); err != nil {
+		t.Fatalf("close parent pipe writer: %v", err)
+	}
+	select {
+	case code := <-result:
+		if code != 0 {
+			stderrData, _ := os.ReadFile(stderrPath)
+			t.Fatalf("watchdog exit code = %d, want 0; stderr:\n%s", code, stderrData)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not exit after disarm file and parent pipe EOF")
+	}
+	if !pidAlive(doltPID) {
+		t.Fatalf("fake dolt pid %d exited; disarm file should win over parent pipe EOF", doltPID)
+	}
+	if _, err := os.Stat(disarmFile); !os.IsNotExist(err) {
+		t.Fatalf("disarm file still exists after watchdog exit: %v", err)
 	}
 }
 

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -87,23 +87,29 @@ func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...s
 }
 
 func (g *doltLeakGuardedTestingM) Run() int {
-	_ = g.sweepStaleCmdGCTestDoltProcesses("startup")
+	return g.runWith(g.m.Run, discoverDoltProcesses, g.sweepStaleCmdGCTestDoltProcesses, reapManagedDoltTestProcesses)
+}
+
+func (g *doltLeakGuardedTestingM) runWith(
+	runTests func() int,
+	enumerate func() ([]DoltProcInfo, error),
+	sweepStale func(string) bool,
+	reapRegistered func(),
+) int {
+	_ = sweepStale("startup")
 	stopSignalHandler := g.installSignalHandler()
 	defer stopSignalHandler()
 
-	initial, initialErr := snapshotDoltProcessesForConfigRoot(discoverDoltProcesses, g.tempRoot)
+	initial, initialErr := snapshotDoltProcessesForConfigRoot(enumerate, g.tempRoot)
 	if initialErr != nil {
 		fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: initial scan failed: %v\n", initialErr) //nolint:errcheck
 	}
 
-	code := g.m.Run()
-
-	g.cleanupTemporaryPaths()
-	reapManagedDoltTestProcesses()
+	code := runTests()
 
 	guardFailed := initialErr != nil
 	if initialErr == nil {
-		final, finalErr := snapshotDoltProcessesForConfigRoot(discoverDoltProcesses, g.tempRoot)
+		final, finalErr := snapshotDoltProcessesForConfigRoot(enumerate, g.tempRoot)
 		if finalErr != nil {
 			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: final scan failed: %v\n", finalErr) //nolint:errcheck
 			guardFailed = true
@@ -114,6 +120,9 @@ func (g *doltLeakGuardedTestingM) Run() int {
 			guardFailed = true
 		}
 	}
+
+	g.cleanupTemporaryPaths()
+	reapRegistered()
 
 	if guardFailed && code == 0 {
 		return 1

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -87,7 +87,7 @@ func newDoltLeakGuardedTestingM(m *testing.M, tempRoot string, cleanupPaths ...s
 }
 
 func (g *doltLeakGuardedTestingM) Run() int {
-	return g.runWith(g.m.Run, discoverDoltProcesses, g.sweepStaleCmdGCTestDoltProcesses, reapManagedDoltTestProcesses)
+	return g.runWith(g.m.Run, discoverDoltProcesses, g.sweepStaleCmdGCTestDoltProcesses, reapManagedDoltTestProcesses, reapDoltLeakProcesses)
 }
 
 func (g *doltLeakGuardedTestingM) runWith(
@@ -95,6 +95,7 @@ func (g *doltLeakGuardedTestingM) runWith(
 	enumerate func() ([]DoltProcInfo, error),
 	sweepStale func(string) bool,
 	reapRegistered func(),
+	reapLeaks func([]DoltProcInfo),
 ) int {
 	_ = sweepStale("startup")
 	stopSignalHandler := g.installSignalHandler()
@@ -116,7 +117,7 @@ func (g *doltLeakGuardedTestingM) runWith(
 		} else if leaked := diffDoltProcessSnapshots(initial, final); len(leaked) > 0 {
 			fmt.Fprintf(os.Stderr, "cmd/gc test dolt leak guard: leaked %d dolt sql-server process(es) under %s\n", len(leaked), g.tempRoot) //nolint:errcheck
 			writeDoltLeakReport(os.Stderr, leaked)
-			reapDoltLeakProcesses(leaked)
+			reapLeaks(leaked)
 			guardFailed = true
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up for post-merge review of #2313.

- Make the package-level cmd/gc Dolt leak guard snapshot before registry reaping, so registered managed Dolt children cannot be silently killed and hidden from the final leak report.
- Add a parent-owned pipe signal for the managed Dolt test watchdog, keeping PID polling as a fallback but avoiding the parent PID reuse blind spot.
- Strengthen regression coverage for distinct Dolt/watchdog PIDs and current `gct<PID>-*` roots versus legacy `gctest-` allowlist behavior.

## Test evidence

- `go test ./cmd/gc -run 'TestManagedDoltTestParentDoneClosesOnPipeEOF|TestDoltLeakGuardedTestingMFinalSnapshotRunsBeforeRegistryReap|TestIsStaleCmdGCTestConfigPathUsesCurrentGCTOwnerPID|TestIsTestConfigPathRetainsLegacyGCTestAllowlistOnly|TestReapManagedDoltTestProcessesTerminatesRegisteredChildren|TestTerminateManagedDoltStartedProcessUnregistersFailedStartup|TestDisarmManagedDoltStartedProcessUnregistersReadyProcess'`
- `go test ./cmd/gc -run 'Dolt|StaleCmdGC|TestConfigPath|SweepOrphan'`
- `go test ./cmd/gc`
- `go vet ./...`
- `make test-fast-parallel`
- pre-commit hook (`lint-changed`, generated reference checks, `go vet ./...`, `make test-fast-parallel`)
