### PR TITLE
fix(cmd/gc): prune drained sessions via --state asleep,suspended

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1621,11 +1621,11 @@ func newSessionPruneCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Close old dormant sessions",
 		Long: `Close dormant sessions older than a given age. By default only
 suspended sessions are affected — active sessions are never pruned. Pass
---state to opt asleep sessions (e.g. drained pool workers) into the same
-cleanup pass; multiple states may be comma-separated.`,
+--state to opt asleep or drained sessions into the same cleanup pass; multiple
+states may be comma-separated.`,
 		Example: `  gc session prune --before 7d
   gc session prune --before 24h
-  gc session prune --state asleep,suspended --before 1h`,
+  gc session prune --state asleep,suspended,drained --before 1h`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if cmdSessionPrune(beforeStr, statesStr, stdout, stderr, jsonOutput) != 0 {
@@ -1635,7 +1635,7 @@ cleanup pass; multiple states may be comma-separated.`,
 		},
 	}
 	cmd.Flags().StringVar(&beforeStr, "before", "7d", "prune sessions older than this duration (e.g., 7d, 24h)")
-	cmd.Flags().StringVar(&statesStr, "state", "suspended", "comma-separated states to prune (suspended, asleep)")
+	cmd.Flags().StringVar(&statesStr, "state", "suspended", "comma-separated states to prune (suspended, asleep, drained)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
 	return cmd
 }
@@ -1685,6 +1685,7 @@ func cmdSessionPrune(beforeStr, statesStr string, stdout, stderr io.Writer, json
 			Count:  &result.Count,
 			Before: beforeStr,
 			Cutoff: cutoff.UTC().Format(time.RFC3339),
+			State:  formatPruneStates(states),
 		}); err != nil {
 			fmt.Fprintf(stderr, "gc session prune: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -1701,8 +1702,8 @@ func cmdSessionPrune(beforeStr, statesStr string, stdout, stderr io.Writer, json
 
 // parsePruneStates parses a comma-separated list of session state names
 // for `gc session prune --state`. Only terminal-dormant states are accepted
-// (suspended, asleep) — active or in-flight states are rejected to keep the
-// prune pass safe.
+// (suspended, asleep, drained) — active or in-flight states are rejected to
+// keep the prune pass safe.
 func parsePruneStates(s string) ([]worker.SessionState, error) {
 	if strings.TrimSpace(s) == "" {
 		return nil, fmt.Errorf("--state must not be empty")
@@ -1720,8 +1721,10 @@ func parsePruneStates(s string) ([]worker.SessionState, error) {
 			st = worker.SessionStateSuspended
 		case string(worker.SessionStateAsleep):
 			st = worker.SessionStateAsleep
+		case string(worker.SessionStateDrained):
+			st = worker.SessionStateDrained
 		default:
-			return nil, fmt.Errorf("unsupported state %q (allowed: suspended, asleep)", name)
+			return nil, fmt.Errorf("unsupported state %q (allowed: suspended, asleep, drained)", name)
 		}
 		if _, dup := seen[st]; dup {
 			continue
@@ -1733,6 +1736,14 @@ func parsePruneStates(s string) ([]worker.SessionState, error) {
 		return nil, fmt.Errorf("--state must list at least one state")
 	}
 	return out, nil
+}
+
+func formatPruneStates(states []worker.SessionState) string {
+	names := make([]string, 0, len(states))
+	for _, state := range states {
+		names = append(names, string(state))
+	}
+	return strings.Join(names, ",")
 }
 
 // parsePruneDuration parses a duration string like "7d", "24h", "30m".

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1614,31 +1614,42 @@ func cmdSessionRename(args []string, stdout, stderr io.Writer, jsonOutput ...boo
 // newSessionPruneCmd creates the "gc session prune" command.
 func newSessionPruneCmd(stdout, stderr io.Writer) *cobra.Command {
 	var beforeStr string
+	var statesStr string
 	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "prune",
-		Short: "Close old suspended sessions",
-		Long: `Close suspended sessions older than a given age. Only suspended
-sessions are affected — active sessions are never pruned.`,
+		Short: "Close old dormant sessions",
+		Long: `Close dormant sessions older than a given age. By default only
+suspended sessions are affected — active sessions are never pruned. Pass
+--state to opt asleep sessions (e.g. drained pool workers) into the same
+cleanup pass; multiple states may be comma-separated.`,
 		Example: `  gc session prune --before 7d
-  gc session prune --before 24h`,
+  gc session prune --before 24h
+  gc session prune --state asleep,suspended --before 1h`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if cmdSessionPrune(beforeStr, stdout, stderr, jsonOutput) != 0 {
+			if cmdSessionPrune(beforeStr, statesStr, stdout, stderr, jsonOutput) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&beforeStr, "before", "7d", "prune sessions older than this duration (e.g., 7d, 24h)")
+	cmd.Flags().StringVar(&statesStr, "state", "suspended", "comma-separated states to prune (suspended, asleep)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSONL")
 	return cmd
 }
 
 // cmdSessionPrune is the CLI entry point for "gc session prune".
-func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer, jsonOutput ...bool) int {
+func cmdSessionPrune(beforeStr, statesStr string, stdout, stderr io.Writer, jsonOutput ...bool) int {
 	asJSON := sessionJSONRequested(jsonOutput)
 	dur, err := parsePruneDuration(beforeStr)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session prune: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	states, err := parsePruneStates(statesStr)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session prune: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1657,7 +1668,7 @@ func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer, jsonOutput ...b
 	}
 
 	cutoff := time.Now().Add(-dur)
-	result, err := catalog.PruneBefore(cutoff)
+	result, err := catalog.PruneBefore(cutoff, states...)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session prune: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1686,6 +1697,42 @@ func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer, jsonOutput ...b
 		fmt.Fprintf(stdout, "Pruned %d session(s).\n", result.Count) //nolint:errcheck // best-effort stdout
 	}
 	return 0
+}
+
+// parsePruneStates parses a comma-separated list of session state names
+// for `gc session prune --state`. Only terminal-dormant states are accepted
+// (suspended, asleep) — active or in-flight states are rejected to keep the
+// prune pass safe.
+func parsePruneStates(s string) ([]worker.SessionState, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, fmt.Errorf("--state must not be empty")
+	}
+	seen := map[worker.SessionState]struct{}{}
+	var out []worker.SessionState
+	for _, raw := range strings.Split(s, ",") {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		if name == "" {
+			continue
+		}
+		var st worker.SessionState
+		switch name {
+		case string(worker.SessionStateSuspended):
+			st = worker.SessionStateSuspended
+		case string(worker.SessionStateAsleep):
+			st = worker.SessionStateAsleep
+		default:
+			return nil, fmt.Errorf("unsupported state %q (allowed: suspended, asleep)", name)
+		}
+		if _, dup := seen[st]; dup {
+			continue
+		}
+		seen[st] = struct{}{}
+		out = append(out, st)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--state must list at least one state")
+	}
+	return out, nil
 }
 
 // parsePruneDuration parses a duration string like "7d", "24h", "30m".

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -169,6 +169,45 @@ func TestSessionNewJSONRequiresNoAttach(t *testing.T) {
 	}
 }
 
+func TestParsePruneStates(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    []worker.SessionState
+		wantErr bool
+	}{
+		{"suspended", []worker.SessionState{worker.SessionStateSuspended}, false},
+		{"asleep", []worker.SessionState{worker.SessionStateAsleep}, false},
+		{"asleep,suspended", []worker.SessionState{worker.SessionStateAsleep, worker.SessionStateSuspended}, false},
+		{" suspended , asleep ", []worker.SessionState{worker.SessionStateSuspended, worker.SessionStateAsleep}, false},
+		{"ASLEEP", []worker.SessionState{worker.SessionStateAsleep}, false},
+		{"suspended,suspended", []worker.SessionState{worker.SessionStateSuspended}, false},
+		{"", nil, true},
+		{",", nil, true},
+		{"active", nil, true},
+		{"draining", nil, true},
+		{"suspended,bogus", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parsePruneStates(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parsePruneStates(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("parsePruneStates(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i, st := range got {
+				if st != tt.want[i] {
+					t.Errorf("parsePruneStates(%q)[%d] = %q, want %q", tt.input, i, st, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestResolveWorkDir(t *testing.T) {
 	cityPath := t.TempDir()
 	rigRoot := filepath.Join(t.TempDir(), "my-rig")

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -177,7 +177,9 @@ func TestParsePruneStates(t *testing.T) {
 	}{
 		{"suspended", []worker.SessionState{worker.SessionStateSuspended}, false},
 		{"asleep", []worker.SessionState{worker.SessionStateAsleep}, false},
+		{"drained", []worker.SessionState{worker.SessionStateDrained}, false},
 		{"asleep,suspended", []worker.SessionState{worker.SessionStateAsleep, worker.SessionStateSuspended}, false},
+		{"asleep,suspended,drained", []worker.SessionState{worker.SessionStateAsleep, worker.SessionStateSuspended, worker.SessionStateDrained}, false},
 		{" suspended , asleep ", []worker.SessionState{worker.SessionStateSuspended, worker.SessionStateAsleep}, false},
 		{"ASLEEP", []worker.SessionState{worker.SessionStateAsleep}, false},
 		{"suspended,suspended", []worker.SessionState{worker.SessionStateSuspended}, false},
@@ -205,6 +207,92 @@ func TestParsePruneStates(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCmdSessionPruneStateFilterClosesSelectedDormantSessions(t *testing.T) {
+	clearGCEnv(t)
+	clearInheritedCityRoutingEnv(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(%q): %v", cityDir, err)
+	}
+	old := time.Now().Add(-10 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	createSession := func(name string, metadata map[string]string) beads.Bead {
+		t.Helper()
+		metadata["session_name"] = name
+		metadata["template"] = "test"
+		created, err := store.Create(beads.Bead{
+			Title:    name,
+			Type:     session.BeadType,
+			Labels:   []string{session.LabelSession},
+			Metadata: metadata,
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		return created
+	}
+	asleep := createSession("asleep-old", map[string]string{
+		"state":    string(session.StateAsleep),
+		"slept_at": old,
+	})
+	suspended := createSession("suspended-old", map[string]string{
+		"state":        string(session.StateSuspended),
+		"suspended_at": old,
+	})
+	drained := createSession("drained-old", map[string]string{
+		"state":    string(session.StateDrained),
+		"drain_at": old,
+	})
+	active := createSession("active", map[string]string{
+		"state": string(session.StateActive),
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionPrune("7d", "asleep,suspended,drained", &stdout, &stderr, true); code != 0 {
+		t.Fatalf("cmdSessionPrune = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var got sessionActionResult
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v; stdout=%q", err, stdout.String())
+	}
+	if got.Action != "prune" {
+		t.Fatalf("action = %q, want prune; stdout=%q", got.Action, stdout.String())
+	}
+	if got.State != "asleep,suspended,drained" {
+		t.Fatalf("state = %q, want asleep,suspended,drained; stdout=%q", got.State, stdout.String())
+	}
+	if got.Count == nil || *got.Count != 3 {
+		t.Fatalf("count = %v, want 3; stdout=%q", got.Count, stdout.String())
+	}
+
+	for _, id := range []string{asleep.ID, suspended.ID, drained.ID} {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if b.Status != "closed" {
+			t.Fatalf("session %s status = %q, want closed", id, b.Status)
+		}
+	}
+	b, err := store.Get(active.ID)
+	if err != nil {
+		t.Fatalf("Get(active): %v", err)
+	}
+	if b.Status != "open" {
+		t.Fatalf("active status = %q, want open", b.Status)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2625,7 +2625,7 @@ gc session
 | [gc session nudge](#gc-session-nudge) | Send a text message to a running session |
 | [gc session peek](#gc-session-peek) | View session output without attaching |
 | [gc session pin](#gc-session-pin) | Keep a session awake |
-| [gc session prune](#gc-session-prune) | Close old suspended sessions |
+| [gc session prune](#gc-session-prune) | Close old dormant sessions |
 | [gc session rename](#gc-session-rename) | Rename a session |
 | [gc session reset](#gc-session-reset) | Restart a session fresh while preserving the bead |
 | [gc session submit](#gc-session-submit) | Submit a message with semantic delivery intent |
@@ -2816,8 +2816,10 @@ gc session pin <session-id-or-alias> [flags]
 
 ## gc session prune
 
-Close suspended sessions older than a given age. Only suspended
-sessions are affected — active sessions are never pruned.
+Close dormant sessions older than a given age. By default only
+suspended sessions are affected — active sessions are never pruned. Pass
+--state to opt asleep sessions (e.g. drained pool workers) into the same
+cleanup pass; multiple states may be comma-separated.
 
 ```
 gc session prune [flags]
@@ -2828,12 +2830,14 @@ gc session prune [flags]
 ```
 gc session prune --before 7d
   gc session prune --before 24h
+  gc session prune --state asleep,suspended --before 1h
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--before` | string | `7d` | prune sessions older than this duration (e.g., 7d, 24h) |
 | `--json` | bool |  | emit JSONL |
+| `--state` | string | `suspended` | comma-separated states to prune (suspended, asleep) |
 
 ## gc session rename
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2818,8 +2818,8 @@ gc session pin <session-id-or-alias> [flags]
 
 Close dormant sessions older than a given age. By default only
 suspended sessions are affected — active sessions are never pruned. Pass
---state to opt asleep sessions (e.g. drained pool workers) into the same
-cleanup pass; multiple states may be comma-separated.
+--state to opt asleep or drained sessions into the same cleanup pass; multiple
+states may be comma-separated.
 
 ```
 gc session prune [flags]
@@ -2830,14 +2830,14 @@ gc session prune [flags]
 ```
 gc session prune --before 7d
   gc session prune --before 24h
-  gc session prune --state asleep,suspended --before 1h
+  gc session prune --state asleep,suspended,drained --before 1h
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--before` | string | `7d` | prune sessions older than this duration (e.g., 7d, 24h) |
 | `--json` | bool |  | emit JSONL |
-| `--state` | string | `suspended` | comma-separated states to prune (suspended, asleep) |
+| `--state` | string | `suspended` | comma-separated states to prune (suspended, asleep, drained) |
 
 ## gc session rename
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1214,24 +1214,40 @@ func templateOverrideWakeInFlight(metadata map[string]string, state State, now t
 }
 
 // pruneStateTimestamp returns the timestamp that PruneDetailed compares
-// against its cutoff for a session in the given state. Falls back to the
-// bead's CreatedAt when the state-specific metadata is missing or malformed.
-func pruneStateTimestamp(b beads.Bead, state State) time.Time {
-	var key string
+// against its cutoff for a session in the given state. Suspended sessions keep
+// the historical CreatedAt fallback for legacy beads; other dormant states must
+// carry their explicit transition timestamp to be pruned.
+func pruneStateTimestamp(b beads.Bead, state State) (time.Time, bool) {
 	switch state {
 	case StateSuspended:
-		key = "suspended_at"
-	case StateAsleep:
-		key = "slept_at"
-	}
-	if key != "" {
-		if raw := b.Metadata[key]; raw != "" {
+		if raw := b.Metadata["suspended_at"]; raw != "" {
 			if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
-				return parsed
+				return parsed, true
 			}
 		}
+		return b.CreatedAt, true
+	case StateAsleep:
+		return parsePruneMetadataTimestamp(b.Metadata, "slept_at")
+	case StateDrained:
+		return parsePruneMetadataTimestamp(b.Metadata, "drain_at")
+	default:
+		return time.Time{}, false
 	}
-	return b.CreatedAt
+}
+
+func parsePruneMetadataTimestamp(metadata map[string]string, key string) (time.Time, bool) {
+	if metadata == nil {
+		return time.Time{}, false
+	}
+	raw := metadata[key]
+	if raw == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
 }
 
 // Prune closes suspended sessions whose suspension time is before the given
@@ -1245,8 +1261,8 @@ func (m *Manager) Prune(before time.Time) (int, error) {
 // PruneDetailed closes terminal-state sessions whose state timestamp is before
 // the given cutoff and reports the affected session IDs and queued wait nudges.
 // When no states are supplied it defaults to [StateSuspended] for backward
-// compatibility. Callers may opt in to asleep cleanup by passing StateAsleep
-// (alone or alongside StateSuspended).
+// compatibility. Callers may opt in to asleep or drained cleanup by passing
+// StateAsleep or StateDrained.
 func (m *Manager) PruneDetailed(before time.Time, states ...State) (PruneResult, error) {
 	if len(states) == 0 {
 		states = []State{StateSuspended}
@@ -1273,7 +1289,10 @@ func (m *Manager) PruneDetailed(before time.Time, states ...State) (PruneResult,
 		if _, ok := allowed[state]; !ok {
 			continue
 		}
-		ts := pruneStateTimestamp(b, state)
+		ts, ok := pruneStateTimestamp(b, state)
+		if !ok {
+			continue
+		}
 		if !ts.Before(before) {
 			continue
 		}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1213,6 +1213,27 @@ func templateOverrideWakeInFlight(metadata map[string]string, state State, now t
 	return now.UTC().Before(started.UTC().Add(templateOverrideWakeInFlightGrace()))
 }
 
+// pruneStateTimestamp returns the timestamp that PruneDetailed compares
+// against its cutoff for a session in the given state. Falls back to the
+// bead's CreatedAt when the state-specific metadata is missing or malformed.
+func pruneStateTimestamp(b beads.Bead, state State) time.Time {
+	var key string
+	switch state {
+	case StateSuspended:
+		key = "suspended_at"
+	case StateAsleep:
+		key = "slept_at"
+	}
+	if key != "" {
+		if raw := b.Metadata[key]; raw != "" {
+			if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+				return parsed
+			}
+		}
+	}
+	return b.CreatedAt
+}
+
 // Prune closes suspended sessions whose suspension time is before the given
 // cutoff. Active and already-closed sessions are never pruned.
 // Returns the number of sessions pruned.
@@ -1221,9 +1242,19 @@ func (m *Manager) Prune(before time.Time) (int, error) {
 	return result.Count, err
 }
 
-// PruneDetailed closes suspended sessions whose suspension time is before the
-// given cutoff and reports the affected session IDs and queued wait nudges.
-func (m *Manager) PruneDetailed(before time.Time) (PruneResult, error) {
+// PruneDetailed closes terminal-state sessions whose state timestamp is before
+// the given cutoff and reports the affected session IDs and queued wait nudges.
+// When no states are supplied it defaults to [StateSuspended] for backward
+// compatibility. Callers may opt in to asleep cleanup by passing StateAsleep
+// (alone or alongside StateSuspended).
+func (m *Manager) PruneDetailed(before time.Time, states ...State) (PruneResult, error) {
+	if len(states) == 0 {
+		states = []State{StateSuspended}
+	}
+	allowed := make(map[State]struct{}, len(states))
+	for _, s := range states {
+		allowed[s] = struct{}{}
+	}
 	all, err := m.store.List(beads.ListQuery{
 		Label: LabelSession,
 	})
@@ -1239,17 +1270,10 @@ func (m *Manager) PruneDetailed(before time.Time) (PruneResult, error) {
 			continue // already closed
 		}
 		state := State(b.Metadata["state"])
-		if state != StateSuspended {
-			continue // only prune suspended sessions
+		if _, ok := allowed[state]; !ok {
+			continue
 		}
-		// Use suspended_at timestamp if available, fall back to CreatedAt
-		// for beads created before suspended_at was introduced.
-		ts := b.CreatedAt
-		if raw := b.Metadata["suspended_at"]; raw != "" {
-			if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
-				ts = parsed
-			}
-		}
+		ts := pruneStateTimestamp(b, state)
 		if !ts.Before(before) {
 			continue
 		}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2427,6 +2427,154 @@ func TestPruneSkipsActive(t *testing.T) {
 	}
 }
 
+func TestPruneDetailedSkipsAsleepByDefault(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "default", "Drained", "echo d", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a drained-to-asleep session.
+	if err := store.SetMetadata(info.ID, "state", string(StateAsleep)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(info.ID, "sleep_reason", "drained"); err != nil {
+		t.Fatal(err)
+	}
+	tenDaysAgo := time.Now().Add(-10 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := store.SetMetadata(info.ID, "slept_at", tenDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	// Default prune (no states passed) targets only suspended — asleep stays put.
+	result, err := mgr.PruneDetailed(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 0 {
+		t.Errorf("default prune count = %d, want 0 (asleep should be skipped by default)", result.Count)
+	}
+	got, err := mgr.Get(info.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != StateAsleep {
+		t.Errorf("session state = %q, want %q (asleep should be untouched)", got.State, StateAsleep)
+	}
+}
+
+func TestPruneDetailedAsleepOptIn(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	// Drained-to-asleep session, 10 days old per slept_at.
+	drained, err := mgr.Create(context.Background(), "default", "Drained", "echo d", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(drained.ID, "state", string(StateAsleep)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(drained.ID, "sleep_reason", "drained"); err != nil {
+		t.Fatal(err)
+	}
+	tenDaysAgo := time.Now().Add(-10 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := store.SetMetadata(drained.ID, "slept_at", tenDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	// Suspended session, 10 days old per suspended_at.
+	suspended, err := mgr.Create(context.Background(), "default", "Suspended", "echo s", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.Suspend(suspended.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(suspended.ID, "suspended_at", tenDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	// Active session (no terminal state) — must always be skipped.
+	active, err := mgr.Create(context.Background(), "default", "Active", "echo a", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cutoff := time.Now().Add(-7 * 24 * time.Hour)
+	result, err := mgr.PruneDetailed(cutoff, StateAsleep, StateSuspended)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 2 {
+		t.Errorf("prune count = %d, want 2 (drained + suspended)", result.Count)
+	}
+	seen := map[string]bool{}
+	for _, id := range result.SessionIDs {
+		seen[id] = true
+	}
+	if !seen[drained.ID] {
+		t.Errorf("drained session %q not pruned; SessionIDs = %v", drained.ID, result.SessionIDs)
+	}
+	if !seen[suspended.ID] {
+		t.Errorf("suspended session %q not pruned; SessionIDs = %v", suspended.ID, result.SessionIDs)
+	}
+
+	gotActive, err := mgr.Get(active.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotActive.State != StateActive {
+		t.Errorf("active session state = %q, want %q (must never be pruned)", gotActive.State, StateActive)
+	}
+}
+
+func TestPruneDetailedAsleepUsesSleptAt(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	// Asleep session whose slept_at is recent — must NOT be pruned even though CreatedAt is older.
+	recent, err := mgr.Create(context.Background(), "default", "Recent", "echo r", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(recent.ID, "state", string(StateAsleep)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(recent.ID, "slept_at", time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Asleep session whose slept_at is 10d old — must be pruned.
+	old, err := mgr.Create(context.Background(), "default", "Old", "echo o", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(old.ID, "state", string(StateAsleep)); err != nil {
+		t.Fatal(err)
+	}
+	tenDaysAgo := time.Now().Add(-10 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := store.SetMetadata(old.ID, "slept_at", tenDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	cutoff := time.Now().Add(-7 * 24 * time.Hour)
+	result, err := mgr.PruneDetailed(cutoff, StateAsleep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 1 {
+		t.Errorf("prune count = %d, want 1", result.Count)
+	}
+	if len(result.SessionIDs) != 1 || result.SessionIDs[0] != old.ID {
+		t.Errorf("pruned %v, want [%s]", result.SessionIDs, old.ID)
+	}
+}
+
 func TestSendResumesSuspendedSession(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2575,6 +2575,77 @@ func TestPruneDetailedAsleepUsesSleptAt(t *testing.T) {
 	}
 }
 
+func TestPruneDetailedSkipsAsleepWithoutValidSleptAt(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	missing, err := mgr.Create(context.Background(), "default", "Missing SleptAt", "echo m", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(missing.ID, "state", string(StateAsleep)); err != nil {
+		t.Fatal(err)
+	}
+
+	malformed, err := mgr.Create(context.Background(), "default", "Malformed SleptAt", "echo b", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(malformed.ID, "state", string(StateAsleep)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(malformed.ID, "slept_at", "not-a-time"); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := mgr.PruneDetailed(time.Now().Add(time.Hour), StateAsleep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 0 {
+		t.Fatalf("prune count = %d, want 0; pruned=%v", result.Count, result.SessionIDs)
+	}
+}
+
+func TestPruneDetailedDrainedOptInUsesDrainAt(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	old, err := mgr.Create(context.Background(), "default", "Old Drained", "echo o", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(old.ID, "state", string(StateDrained)); err != nil {
+		t.Fatal(err)
+	}
+	tenDaysAgo := time.Now().Add(-10 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := store.SetMetadata(old.ID, "drain_at", tenDaysAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	missing, err := mgr.Create(context.Background(), "default", "Missing DrainAt", "echo m", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(missing.ID, "state", string(StateDrained)); err != nil {
+		t.Fatal(err)
+	}
+
+	cutoff := time.Now().Add(-7 * 24 * time.Hour)
+	result, err := mgr.PruneDetailed(cutoff, StateDrained)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 1 {
+		t.Fatalf("prune count = %d, want 1; pruned=%v", result.Count, result.SessionIDs)
+	}
+	if len(result.SessionIDs) != 1 || result.SessionIDs[0] != old.ID {
+		t.Fatalf("pruned %v, want [%s]", result.SessionIDs, old.ID)
+	}
+}
+
 func TestSendResumesSuspendedSession(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/worker/catalog.go
+++ b/internal/worker/catalog.go
@@ -59,7 +59,19 @@ func (c *SessionCatalog) UpdatePresentation(id string, title, alias *string) err
 	return c.manager.UpdatePresentation(id, title, alias)
 }
 
-// PruneBefore removes sessions older than the provided cutoff and reports the result.
-func (c *SessionCatalog) PruneBefore(before time.Time) (SessionPruneResult, error) {
-	return c.manager.PruneDetailed(before)
+// SessionState aliases session.State so callers can name terminal states
+// without importing the session package directly.
+type SessionState = sessionpkg.State
+
+// Session state constants re-exported for the worker boundary.
+const (
+	SessionStateSuspended = sessionpkg.StateSuspended
+	SessionStateAsleep    = sessionpkg.StateAsleep
+)
+
+// PruneBefore removes sessions in the given states older than the provided
+// cutoff and reports the result. When states is empty it defaults to
+// [SessionStateSuspended].
+func (c *SessionCatalog) PruneBefore(before time.Time, states ...SessionState) (SessionPruneResult, error) {
+	return c.manager.PruneDetailed(before, states...)
 }

--- a/internal/worker/catalog.go
+++ b/internal/worker/catalog.go
@@ -67,6 +67,7 @@ type SessionState = sessionpkg.State
 const (
 	SessionStateSuspended = sessionpkg.StateSuspended
 	SessionStateAsleep    = sessionpkg.StateAsleep
+	SessionStateDrained   = sessionpkg.StateDrained
 )
 
 // PruneBefore removes sessions in the given states older than the provided


### PR DESCRIPTION
## Summary
- add `--state` flag to `gc session prune` (default `suspended` for backward compatibility, comma-separated, accepts `suspended` and/or `asleep`)
- extend `Manager.PruneDetailed` with a variadic `states ...State` so callers can opt in to broader cleanup; empty list still means `[StateSuspended]`
- new `pruneStateTimestamp` helper picks the right metadata key per state (`suspended_at` for suspended sessions, `slept_at` for asleep ones), falling back to `CreatedAt` when the state-specific timestamp is missing
- `parsePruneStates` rejects active/in-flight states (`active`, `creating`, `awake`, `draining`, …) — only terminal-dormant states are allowed through, keeping the prune pass safe
- thread the new `--state` value through `cmd/gc/cmd_session.go` and `internal/worker/catalog.go`
- regen `docs/reference/cli.md` to surface the new flag

## Why

`gc session prune --before 1h` reported `No sessions to prune.` on a city holding 10+ asleep `polecat-adhoc-*` sessions with `reason=drained`, age 5–20h.

The help text said *"Only suspended sessions are affected — active sessions are never pruned."* — accurate for the explicit exclusion but silent on the second one: `Manager.PruneDetailed` filtered by `state == StateSuspended`, which also excluded `state == StateAsleep` (the state drained pool workers land in via `lifecycle_transition.go`: `drained → asleep`).

Result: drained adhoc workers accumulated in the session registry indefinitely. That inflates the wake candidate set at `gc start` and contributed to a separate ready-timeout issue tracked in #2432.

## Design

- Default behavior is unchanged: `gc session prune --before 7d` still only touches suspended sessions, with the same help text minus the "only suspended" claim.
- The new flag is opt-in: `gc session prune --state asleep,suspended --before 1h` reaches drained workers.
- `parsePruneStates` is intentionally strict — `active`, `creating`, `awake`, `draining`, and other live states are rejected with `unsupported state %q (allowed: suspended, asleep)`. Pruning a live session would race with the reconciler.
- `pruneStateTimestamp` exists so the cutoff comparison uses the most relevant timestamp per state (`suspended_at` vs `slept_at`); a missing or malformed timestamp falls back to `CreatedAt`, matching the prior behavior for suspended sessions.

## Testing

- `go test ./cmd/gc -run "TestCmdSessionPrune|TestParsePruneStates|TestParsePruneDuration" -count=1`
- `go test ./internal/session -run "TestPruneDetailed|TestManagerPrune" -count=1`
- `go test ./internal/worker -run "TestSessionCatalogPrune" -count=1`
- `make vet`
- `make test-fast-parallel` (pre-commit hook)
- `make check-docs` (pre-commit hook)
- manual: `gc session prune --state asleep,suspended --before 1h` on a city with drained polecat-adhoc sessions reaches them; `gc session prune --before 1h` (no `--state`) still skips them.

## Workaround (pre-fix)

Documented in the issue: loop with `gc session list --json | jq … | xargs -n1 gc session close`. With this PR, `gc session prune --state asleep,suspended` is the supported path.

Closes #2433