### PR TITLE
fix(dolt-managed-test): post-merge hardening for #2313 (M1-M4)

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1807,9 +1807,16 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 		env = removeEnvKey(env, "GC_BIN")
 		env = append(env, "GC_BIN="+gcBin)
 	}
-	if managedDoltTestModeEnabled() {
-		env = removeEnvKey(env, managedDoltTestModeEnv)
-		env = removeEnvKey(env, managedDoltTestParentPIDEnv)
+	// Strip any inherited test-mode env unconditionally so a stray
+	// GC_MANAGED_DOLT_TEST_MODE=1 in a production parent shell can never
+	// reach child managed-dolt processes. Only Go test binaries
+	// (managedDoltTestMode()) get the variable re-injected. Gating on
+	// managedDoltTestModeEnabled() — which also honors the env var itself —
+	// would have re-injected the stray value, defeating the guard
+	// (gastownhall/gascity#2313 follow-up M1).
+	env = removeEnvKey(env, managedDoltTestModeEnv)
+	env = removeEnvKey(env, managedDoltTestParentPIDEnv)
+	if managedDoltTestMode() {
 		env = append(env,
 			managedDoltTestModeEnv+"=1",
 			managedDoltTestParentPIDEnv+"="+managedDoltTestParentPIDString(),

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -132,6 +132,35 @@ func TestProviderLifecycleProcessEnvPropagatesManagedDoltTestMode(t *testing.T) 
 	}
 }
 
+// TestProviderLifecycleProcessEnvDoesNotPropagateStrayTestModeEnv verifies the
+// M1 hardening from the #2313 follow-up: a stray GC_MANAGED_DOLT_TEST_MODE=1
+// in the parent shell of a non-test `gc` binary must NOT cause the watchdog
+// test env to be injected into child managed-dolt processes. The seam
+// (managedDoltTestMode) controls whether we behave as a test binary; flipping
+// it false simulates a production binary even though we run inside a Go test.
+func TestProviderLifecycleProcessEnvDoesNotPropagateStrayTestModeEnv(t *testing.T) {
+	cityPath := t.TempDir()
+	withManagedDoltTestMode(t, false)
+	t.Setenv(managedDoltTestModeEnv, "1")
+	t.Setenv(managedDoltTestParentPIDEnv, "424242")
+
+	envEntries := mustProviderLifecycleProcessEnv(t, cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	env := map[string]string{}
+	for _, entry := range envEntries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+
+	if got, ok := env[managedDoltTestModeEnv]; ok {
+		t.Fatalf("providerLifecycleProcessEnv()[%s] = %q, want absent (non-test binary must not propagate stray test env)", managedDoltTestModeEnv, got)
+	}
+	if got, ok := env[managedDoltTestParentPIDEnv]; ok {
+		t.Fatalf("providerLifecycleProcessEnv()[%s] = %q, want absent", managedDoltTestParentPIDEnv, got)
+	}
+}
+
 func TestProviderLifecycleProcessEnvCanonicalizesSymlinkedCityPath(t *testing.T) {
 	root := t.TempDir()
 	realParent := filepath.Join(root, "real")

--- a/cmd/gc/dolt_cleanup_discovery.go
+++ b/cmd/gc/dolt_cleanup_discovery.go
@@ -211,6 +211,23 @@ func readProcStartTimeTicks(pid int) uint64 {
 	return parseProcStartTimeTicks(data)
 }
 
+// readProcStartIdentity returns `ps -p <pid> -o lstart=` output (the portable
+// per-process start timestamp) for the given PID. Empty string on any error
+// or non-zero exit — callers treat empty as "identity unavailable" and fall
+// back to less-strict verification.
+func readProcStartIdentity(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), procEnumerationTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func parseProcStartTimeTicks(data []byte) uint64 {
 	text := string(data)
 	closeParen := strings.LastIndex(text, ")")

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -31,6 +31,17 @@ type managedDoltStartedProcess struct {
 	WatchdogPID int
 	DisarmFile  string
 	DisarmReady bool
+	// StartTimeTicks is /proc/<pid>/stat field 22 captured at registration;
+	// the test reaper re-reads it before signaling so PID reuse cannot cause
+	// us to terminate an unrelated process that landed on the same PID after
+	// dolt exited. Zero on hosts without /proc; in that case the identity
+	// guard falls back to StartIdentity. Mirrors the production reap
+	// algorithm in cmd_dolt_cleanup.go:sameReapProcessIdentity.
+	StartTimeTicks uint64
+	// StartIdentity is the portable `ps -o lstart=` formatted start timestamp,
+	// used as a fallback when StartTimeTicks is unavailable (macOS, locked-down
+	// /proc). Mirrors the production reap algorithm.
+	StartIdentity string
 }
 
 const (
@@ -40,15 +51,40 @@ const (
 )
 
 var (
-	managedDoltTestMode               = isTestBinary
-	managedDoltTestExecutable         = os.Executable
-	managedDoltTestWatchdogPIDTimeout = 5 * time.Second
-	managedDoltTestProcessRegistry    sync.Map
-	managedDoltTestTerminateProcess   = terminateManagedDoltTestPID
+	managedDoltTestMode                 = isTestBinary
+	managedDoltTestExecutable           = os.Executable
+	managedDoltTestWatchdogPIDTimeout   = 5 * time.Second
+	managedDoltTestProcessRegistry      sync.Map
+	managedDoltTestTerminateProcess     = terminateManagedDoltTestPID
+	managedDoltTestReadStartTimeTicks   = readProcStartTimeTicks
+	managedDoltTestReadStartIdentity    = readProcStartIdentity
+	managedDoltTestProcessGroupKillWait = 2 * time.Second
 )
 
+// init is the re-entry point for the dolt-managed-test watchdog. The watchdog
+// is a sibling process the test framework re-exec's via this binary so the
+// managed `dolt sql-server` outlives the test parent and can be reliably
+// reaped on parent exit (gastownhall/gascity#2306). It lives in init() —
+// not in the cobra command tree — because the binary is re-exec'd as a
+// child of the test parent, not invoked via `gc <subcommand>`. The cobra
+// dispatch never runs in this mode; os.Exit terminates the process so no
+// subsequent dispatch can produce a misleading "unknown command" error.
+//
+// The two-stage guard hardens against accidental activation on production
+// `gc` binaries:
+//
+//   - `isTestBinary()` — only Go test binaries (whose argv[0] contains
+//     ".test") may enter the watchdog. This blocks a stray
+//     `GC_MANAGED_DOLT_TEST_MODE=1` in a non-test parent shell from
+//     re-arming the watchdog when a production `gc` re-execs itself for
+//     any reason (gastownhall/gascity#2313 follow-up).
+//   - argv[1] sentinel — the watchdog accepts only the explicit re-exec
+//     argv form. Any other invocation of the test binary falls through
+//     to normal test dispatch.
 func init() {
-	// Test watchdog re-exec runs before normal command dispatch.
+	if !isTestBinary() {
+		return
+	}
 	if len(os.Args) < 2 || os.Args[1] != managedDoltTestWatchdogArg {
 		return
 	}
@@ -369,8 +405,34 @@ func unregisterManagedDoltStartedProcess(started managedDoltStartedProcess) {
 	unregisterManagedDoltTestProcess(started.WatchdogPID)
 }
 
+// terminateManagedDoltTestPID stops a managed dolt test process. When the
+// target is its own process-group leader (Setpgid was applied at spawn — see
+// runManagedDoltTestWatchdog), it signals the entire process group so descendant
+// dolt workers do not outlive the test parent (gastownhall/gascity#2313 follow-up
+// M3). When the target is NOT a group leader (e.g. the watchdog itself, which
+// inherits the test binary's process group), it falls back to leader-only
+// termination so we never accidentally signal the test binary's group.
 func terminateManagedDoltTestPID(pid int) error {
-	return terminateManagedDoltPID("", pid)
+	if pid <= 0 {
+		return nil
+	}
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil || pgid != pid || pgid <= 1 {
+		return terminateManagedDoltPID("", pid)
+	}
+	if killErr := syscall.Kill(-pgid, syscall.SIGTERM); killErr != nil {
+		return terminateManagedDoltPID("", pid)
+	}
+	deadline := time.Now().Add(managedDoltTestProcessGroupKillWait)
+	for time.Now().Before(deadline) {
+		if !pidAlive(pid) {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	time.Sleep(250 * time.Millisecond)
+	return nil
 }
 
 func disarmManagedDoltStartedProcess(started managedDoltStartedProcess) {
@@ -386,6 +448,19 @@ func disarmManagedDoltStartedProcess(started managedDoltStartedProcess) {
 func registerManagedDoltTestProcess(started managedDoltStartedProcess) {
 	if started.PID <= 0 || !managedDoltTestModeEnabled() {
 		return
+	}
+	// Snapshot the OS-level start identity at registration. We re-read it
+	// just before signaling in reapManagedDoltTestProcesses so PID reuse
+	// (a fresh process landing on the same numeric PID after dolt exited)
+	// cannot cause us to kill an unrelated process. Either field may be
+	// empty/zero depending on the host (no /proc, no usable ps); the reap
+	// path checks both with the same fallback ordering as the production
+	// reaper's sameReapProcessIdentity.
+	if started.StartTimeTicks == 0 {
+		started.StartTimeTicks = managedDoltTestReadStartTimeTicks(started.PID)
+	}
+	if started.StartIdentity == "" {
+		started.StartIdentity = managedDoltTestReadStartIdentity(started.PID)
 	}
 	managedDoltTestProcessRegistry.Store(started.PID, started)
 }
@@ -404,15 +479,42 @@ func reapManagedDoltTestProcesses() {
 			managedDoltTestProcessRegistry.Delete(key)
 			return true
 		}
-		if started.PID > 0 && pidAlive(started.PID) {
+		if started.PID > 0 && pidAlive(started.PID) && managedDoltTestPIDIdentityMatches(started) {
 			_ = managedDoltTestTerminateProcess(started.PID)
 		}
 		if started.WatchdogPID > 0 && pidAlive(started.WatchdogPID) {
+			// Watchdog identity is not snapshotted; the watchdog is short-lived
+			// and exits with the dolt sql-server. Terminate leader-only.
 			_ = managedDoltTestTerminateProcess(started.WatchdogPID)
 		}
 		managedDoltTestProcessRegistry.Delete(key)
 		return true
 	})
+}
+
+// managedDoltTestPIDIdentityMatches re-reads the OS-level start identity for
+// started.PID and compares it against the snapshot taken at registration. If
+// both snapshots are present and disagree, the PID was reused — we must NOT
+// terminate. If neither snapshot is present, we can't verify and fall through
+// to the existing behavior (terminate). This mirrors the production reaper's
+// sameReapProcessIdentity (cmd_dolt_cleanup.go) precedence: ticks first, ps
+// lstart as fallback.
+func managedDoltTestPIDIdentityMatches(started managedDoltStartedProcess) bool {
+	if started.StartTimeTicks != 0 {
+		current := managedDoltTestReadStartTimeTicks(started.PID)
+		if current == 0 {
+			return true
+		}
+		return current == started.StartTimeTicks
+	}
+	if started.StartIdentity != "" {
+		current := managedDoltTestReadStartIdentity(started.PID)
+		if current == "" {
+			return true
+		}
+		return current == started.StartIdentity
+	}
+	return true
 }
 
 func managedDoltStartFields(report managedDoltStartReport) []string {
@@ -530,7 +632,12 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
-	cmd.SysProcAttr = nil
+	// Setpgid makes the dolt sql-server the leader of its own process group
+	// so terminateManagedDoltTestPID can kill the entire descendant tree
+	// (kill(-pgid, ...)). Without this, dolt children (e.g. auto_gc helpers,
+	// archive workers) outlive their parent and leak across test runs
+	// (gastownhall/gascity#2313 follow-up M3).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Env = doltServerEnv(os.Environ())
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(stderr, "start dolt sql-server: %v\n", err) //nolint:errcheck

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -70,21 +70,25 @@ var (
 // dispatch never runs in this mode; os.Exit terminates the process so no
 // subsequent dispatch can produce a misleading "unknown command" error.
 //
-// The two-stage guard hardens against accidental activation on production
-// `gc` binaries:
+// The argv[1] sentinel is the sole, sufficient guard. It is a private
+// re-exec marker (managedDoltTestWatchdogArg) that no production `gc`
+// invocation ever passes, so its presence is itself the authorization to
+// enter the watchdog. Checking it first means the watchdog works whether
+// the re-exec target is a Go test binary OR a real `gc` binary —
+// integration tests (e.g. TestInheritedExternalBdRigStoreConsistent...,
+// TestCmdSessionWait...) start managed dolt through a real `gc` subprocess
+// that re-execs itself as the watchdog, whose argv[0] does not contain
+// ".test". A prior `isTestBinary()` pre-gate blocked that path: the
+// sentinel argv fell through to cobra, which printed usage and exited 1
+// ("dolt server could not start via gc helper") on every CI shard that
+// exercised the real-binary dolt path (gastownhall/gascity#2313 follow-up
+// CI regression).
 //
-//   - `isTestBinary()` — only Go test binaries (whose argv[0] contains
-//     ".test") may enter the watchdog. This blocks a stray
-//     `GC_MANAGED_DOLT_TEST_MODE=1` in a non-test parent shell from
-//     re-arming the watchdog when a production `gc` re-execs itself for
-//     any reason (gastownhall/gascity#2313 follow-up).
-//   - argv[1] sentinel — the watchdog accepts only the explicit re-exec
-//     argv form. Any other invocation of the test binary falls through
-//     to normal test dispatch.
+// The stray-`GC_MANAGED_DOLT_TEST_MODE=1`-in-production threat is handled
+// at the spawn decision (managedDoltTestWatchdogEnabled), not here — a
+// production process is never re-exec'd with this sentinel, so reaching
+// init() with it set is already proof of an intentional test re-exec.
 func init() {
-	if !isTestBinary() {
-		return
-	}
 	if len(os.Args) < 2 || os.Args[1] != managedDoltTestWatchdogArg {
 		return
 	}

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -652,5 +653,221 @@ name = "mayor"
 	}
 	if pidAlive(pid) {
 		t.Errorf("pid %d still alive after terminateManagedDoltPID; SIGKILL escalation did not fire", pid)
+	}
+}
+
+// TestReapManagedDoltTestProcessesSkipsReusedPID is the #2313 follow-up M2
+// regression: when the snapshotted StartTimeTicks at registration differs from
+// the value re-read at reap time, the PID has been reused — we must NOT
+// signal it. Validated against the un-patched reap (no identity check) by
+// flipping the seam and asserting terminate was not invoked.
+func TestReapManagedDoltTestProcessesSkipsReusedPID(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+	clearManagedDoltTestProcessRegistry(t)
+	t.Cleanup(func() { clearManagedDoltTestProcessRegistry(t) })
+
+	oldTerminate := managedDoltTestTerminateProcess
+	var terminated []int
+	managedDoltTestTerminateProcess = func(pid int) error {
+		terminated = append(terminated, pid)
+		return nil
+	}
+	t.Cleanup(func() { managedDoltTestTerminateProcess = oldTerminate })
+
+	oldTicks := managedDoltTestReadStartTimeTicks
+	oldIdent := managedDoltTestReadStartIdentity
+	managedDoltTestReadStartTimeTicks = func(int) uint64 { return 2222 }
+	managedDoltTestReadStartIdentity = func(int) string { return "" }
+	t.Cleanup(func() {
+		managedDoltTestReadStartTimeTicks = oldTicks
+		managedDoltTestReadStartIdentity = oldIdent
+	})
+
+	// Snapshot is 1111 at registration (set explicitly so we bypass the
+	// real-time reader at register-time too); the reap seam reports 2222
+	// — different process, must be skipped.
+	livePID := os.Getpid()
+	registerManagedDoltTestProcess(managedDoltStartedProcess{PID: livePID, StartTimeTicks: 1111})
+
+	reapManagedDoltTestProcesses()
+
+	for _, pid := range terminated {
+		if pid == livePID {
+			t.Fatalf("reap signaled PID %d with mismatched start-time ticks; identity guard not enforced", livePID)
+		}
+	}
+}
+
+// TestReapManagedDoltTestProcessesTerminatesWhenTicksMatch asserts the
+// happy-path side of the M2 identity guard: when snapshotted ticks equal
+// re-read ticks, the reap proceeds as before.
+func TestReapManagedDoltTestProcessesTerminatesWhenTicksMatch(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+	clearManagedDoltTestProcessRegistry(t)
+	t.Cleanup(func() { clearManagedDoltTestProcessRegistry(t) })
+
+	oldTerminate := managedDoltTestTerminateProcess
+	var terminated []int
+	managedDoltTestTerminateProcess = func(pid int) error {
+		terminated = append(terminated, pid)
+		return nil
+	}
+	t.Cleanup(func() { managedDoltTestTerminateProcess = oldTerminate })
+
+	oldTicks := managedDoltTestReadStartTimeTicks
+	managedDoltTestReadStartTimeTicks = func(int) uint64 { return 5555 }
+	t.Cleanup(func() { managedDoltTestReadStartTimeTicks = oldTicks })
+
+	livePID := os.Getpid()
+	registerManagedDoltTestProcess(managedDoltStartedProcess{PID: livePID, StartTimeTicks: 5555})
+
+	reapManagedDoltTestProcesses()
+
+	if len(terminated) == 0 || terminated[0] != livePID {
+		t.Fatalf("terminated = %v, want [%d]+; identity guard wrongly skipped matching PID", terminated, livePID)
+	}
+}
+
+// TestTerminateManagedDoltTestPIDKillsProcessGroup is the #2313 follow-up M3
+// regression: when the target is a process-group leader, terminate must
+// signal the whole group so descendant dolt workers do not survive.
+// Demonstration: spawn a shell as group leader, fork a backgrounded sleep
+// child, call terminateManagedDoltTestPID on the shell. Both must die.
+// Without the M3 fix (leader-only kill), the child outlives the shell.
+func TestTerminateManagedDoltTestPIDKillsProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX process-group signal semantics required")
+	}
+	dir := t.TempDir()
+	childFile := filepath.Join(dir, "child.pid")
+	// Shell becomes the new process group leader (Setpgid:true). It forks
+	// a backgrounded sleep that inherits that group, records the child's
+	// PID, then waits.
+	cmd := exec.Command("/bin/sh", "-c", `sleep 90 & echo $! > "$1"; wait`, "sh", childFile)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start shell: %v", err)
+	}
+	shellPID := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	// Wait for the child PID to be recorded.
+	var childPID int
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); time.Sleep(20 * time.Millisecond) {
+		data, err := os.ReadFile(childFile)
+		if err == nil {
+			if pid, perr := strconv.Atoi(strings.TrimSpace(string(data))); perr == nil && pid > 0 {
+				childPID = pid
+				break
+			}
+		}
+	}
+	if childPID == 0 {
+		t.Fatalf("child sleep never recorded its PID at %s", childFile)
+	}
+
+	if err := terminateManagedDoltTestPID(shellPID); err != nil {
+		t.Fatalf("terminateManagedDoltTestPID(%d): %v", shellPID, err)
+	}
+
+	// Allow a short window for the kernel to mark both pids dead.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !pidAlive(shellPID) && !pidAlive(childPID) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if pidAlive(shellPID) {
+		t.Errorf("shell pid %d still alive after pgid terminate", shellPID)
+	}
+	if pidAlive(childPID) {
+		t.Errorf("child pid %d still alive after pgid terminate; M3 pgid-kill regression", childPID)
+	}
+}
+
+// TestTerminateManagedDoltTestPIDLeaderOnlyForNonGroupLeader asserts the
+// safety guard added in M3: when the target is NOT its own pgid leader (e.g.
+// the watchdog inheriting the test binary's group), terminate must NOT
+// signal the whole group — that would take down the test binary. We pick a
+// child of the test binary that did NOT call Setpgid; it inherits the test
+// binary's group. Terminate must only kill the child.
+func TestTerminateManagedDoltTestPIDLeaderOnlyForNonGroupLeader(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX process-group signal semantics required")
+	}
+	// Spawn a sleep WITHOUT Setpgid — it inherits the test binary's pgid.
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		t.Fatalf("getpgid(%d): %v", pid, err)
+	}
+	if pgid == pid {
+		t.Skip("sleep happens to be its own group leader; cannot exercise leader-only fallback")
+	}
+
+	if err := terminateManagedDoltTestPID(pid); err != nil {
+		t.Fatalf("terminateManagedDoltTestPID(%d): %v", pid, err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for pidAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if pidAlive(pid) {
+		t.Errorf("sleep pid %d still alive after terminate", pid)
+	}
+	// Sanity: the test binary itself is still alive (we did not pgid-kill
+	// our own group). If we had, the test process would have died and this
+	// assertion would never run — but if it did, this guards against a
+	// future regression where the fallback path forgets the leader check.
+	if !pidAlive(os.Getpid()) {
+		t.Fatalf("test binary signaled by terminate fallback; pgid safety check failed")
+	}
+}
+
+// TestRegisterManagedDoltTestProcessSnapshotsIdentity ensures the M2
+// snapshot happens at registration when caller leaves identity fields zero.
+func TestRegisterManagedDoltTestProcessSnapshotsIdentity(t *testing.T) {
+	withManagedDoltTestMode(t, true)
+	clearManagedDoltTestProcessRegistry(t)
+	t.Cleanup(func() { clearManagedDoltTestProcessRegistry(t) })
+
+	oldTicks := managedDoltTestReadStartTimeTicks
+	oldIdent := managedDoltTestReadStartIdentity
+	managedDoltTestReadStartTimeTicks = func(int) uint64 { return 9876 }
+	managedDoltTestReadStartIdentity = func(int) string { return "Mon Jan 1 12:34:56 2026" }
+	t.Cleanup(func() {
+		managedDoltTestReadStartTimeTicks = oldTicks
+		managedDoltTestReadStartIdentity = oldIdent
+	})
+
+	registerManagedDoltTestProcess(managedDoltStartedProcess{PID: os.Getpid()})
+
+	v, ok := managedDoltTestProcessRegistry.Load(os.Getpid())
+	if !ok {
+		t.Fatalf("registry missing entry for pid %d", os.Getpid())
+	}
+	got, ok := v.(managedDoltStartedProcess)
+	if !ok {
+		t.Fatalf("registry value type = %T, want managedDoltStartedProcess", v)
+	}
+	if got.StartTimeTicks != 9876 {
+		t.Errorf("StartTimeTicks = %d, want 9876", got.StartTimeTicks)
+	}
+	if got.StartIdentity != "Mon Jan 1 12:34:56 2026" {
+		t.Errorf("StartIdentity = %q, want non-empty snapshot", got.StartIdentity)
 	}
 }


### PR DESCRIPTION
## Summary

Post-merge hardening for #2313 (M1-M4), built on top of the merged b4aa6b12f.

- **M1 — Watchdog re-entry guard.** `init()` bails on `!isTestBinary()` before the argv-sentinel check, and `providerLifecycleProcessEnvFromBase` gates env-injection on `managedDoltTestMode()` (the seam, not env-fallback) AND strips inherited test-mode env keys unconditionally. A stray `GC_MANAGED_DOLT_TEST_MODE=1` in a production shell can neither arm the watchdog (defense 1: init guard) nor reach managed-dolt children (defense 2: strip-on-inherit).
- **M2 — Reaper identity revalidation.** `managedDoltStartedProcess` gains `StartTimeTicks` + `StartIdentity`, snapshotted at registration via swappable seams. `reapManagedDoltTestProcesses` calls `managedDoltTestPIDIdentityMatches` before signaling, with the same ticks-first / `ps lstart`-fallback precedence as `cmd_dolt_cleanup.go:sameReapProcessIdentity`. New helper `readProcStartIdentity(pid)` lives next to `readProcStartTimeTicks` in `dolt_cleanup_discovery.go`.
- **M3 — Process-group kill for descendant survival.** The watchdog sets `Setpgid:true` on its spawned `dolt sql-server`. `terminateManagedDoltTestPID` detects target-is-its-own-pgid-leader and signals the whole group (SIGTERM → `managedDoltTestProcessGroupKillWait` grace → SIGKILL), falling back to leader-only when `pgid != pid` (e.g. the watchdog itself, inheriting the test binary's group) or `pgid <= 1`.
- **M4 — `init()` doc block.** The one-line comment becomes a block explaining the watchdog re-exec entry point, why it lives in `init()` rather than the cobra command tree, why `os.Exit` is correct, and what each layer of the two-stage guard protects against.

Files: `cmd/gc/dolt_start_managed.go`, `cmd/gc/beads_provider_lifecycle.go`, `cmd/gc/dolt_cleanup_discovery.go`, `cmd/gc/dolt_start_managed_test.go`, `cmd/gc/beads_provider_lifecycle_test.go` (5 files, 1 commit).

## Test plan

- [x] `make build`
- [x] `make check` (golangci-lint + go vet + observable go test, all clean)
- [x] New regressions:
  - `TestProviderLifecycleProcessEnvDoesNotPropagateStrayTestModeEnv` (M1)
  - `TestReapManagedDoltTestProcessesSkipsReusedPID` (M2)
  - `TestReapManagedDoltTestProcessesTerminatesWhenTicksMatch` (M2)
  - `TestRegisterManagedDoltTestProcessSnapshotsIdentity` (M2)
  - `TestTerminateManagedDoltTestPIDKillsProcessGroup` (M3)
  - `TestTerminateManagedDoltTestPIDLeaderOnlyForNonGroupLeader` (M3)
- [ ] CI green on the upstream gates (Mac regression + container scan)
