### PR TITLE
fix: use assigned work snapshot for restart workdir

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -226,9 +226,12 @@ type startExecutionOptions struct {
 	asyncLimiter    *asyncStartLimiter
 	asyncTracker    *asyncStartTracker
 	maxSessionAgeTr maxSessionAgeTracker
+	workDirResolver taskWorkDirResolver
 }
 
 type startExecutionOption func(*startExecutionOptions)
+
+type taskWorkDirResolver func(startCandidate, *config.City) string
 
 func withAsyncStartExecution() startExecutionOption {
 	return func(opts *startExecutionOptions) {
@@ -259,6 +262,12 @@ func withAsyncStartTracker(tracker *asyncStartTracker) startExecutionOption {
 func withMaxSessionAgeTracker(tr maxSessionAgeTracker) startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.maxSessionAgeTr = tr
+	}
+}
+
+func withTaskWorkDirResolver(resolver taskWorkDirResolver) startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.workDirResolver = resolver
 	}
 }
 
@@ -643,6 +652,7 @@ func prepareStartCandidateForCity(
 	store beads.Store,
 	clk clock.Clock,
 	stderr io.Writer,
+	workDirResolvers ...taskWorkDirResolver,
 ) (*preparedStart, error) {
 	session := candidate.session
 	if session != nil && strings.TrimSpace(session.ID) != "" && store != nil {
@@ -661,7 +671,11 @@ func prepareStartCandidateForCity(
 		return nil, err
 	}
 	candidate = refreshConfiguredNamedStartCandidate(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
-	return buildPreparedStart(candidate, cfg, store)
+	var workDirResolver taskWorkDirResolver
+	if len(workDirResolvers) > 0 {
+		workDirResolver = workDirResolvers[0]
+	}
+	return buildPreparedStartWithWorkDirResolver(candidate, cfg, store, workDirResolver)
 }
 
 func refreshConfiguredNamedStartCandidate(
@@ -702,6 +716,15 @@ func buildPreparedStart(
 	candidate startCandidate,
 	cfg *config.City,
 	store beads.Store,
+) (*preparedStart, error) {
+	return buildPreparedStartWithWorkDirResolver(candidate, cfg, store, nil)
+}
+
+func buildPreparedStartWithWorkDirResolver(
+	candidate startCandidate,
+	cfg *config.City,
+	store beads.Store,
+	workDirResolver taskWorkDirResolver,
 ) (*preparedStart, error) {
 	session := candidate.session
 	tp := candidate.tp
@@ -751,7 +774,7 @@ func buildPreparedStart(
 	coreHash := runtime.CoreFingerprint(agentCfg)
 	coreBreakdown := runtime.CoreFingerprintBreakdown(agentCfg)
 	liveHash := runtime.LiveFingerprint(agentCfg)
-	if wd := resolveTaskWorkDir(store, session.ID, candidate.name(), strings.TrimSpace(session.Metadata["alias"]), candidate.logicalTemplate(cfg)); wd != "" {
+	if wd := resolvePreparedTaskWorkDir(candidate, cfg, store, workDirResolver); wd != "" {
 		agentCfg.WorkDir = wd
 	} else if wd := session.Metadata["work_dir"]; wd != "" {
 		agentCfg.WorkDir = wd
@@ -855,6 +878,31 @@ func buildPreparedStart(
 		coreBreakdown: coreBreakdown,
 		liveHash:      liveHash,
 	}, nil
+}
+
+func resolvePreparedTaskWorkDir(
+	candidate startCandidate,
+	cfg *config.City,
+	store beads.Store,
+	workDirResolver taskWorkDirResolver,
+) string {
+	if workDirResolver != nil {
+		return workDirResolver(candidate, cfg)
+	}
+	return resolveTaskWorkDir(store, taskWorkDirAssignees(candidate, cfg)...)
+}
+
+func taskWorkDirAssignees(candidate startCandidate, cfg *config.City) []string {
+	if candidate.session == nil {
+		return nil
+	}
+	session := candidate.session
+	return []string{
+		session.ID,
+		candidate.name(),
+		strings.TrimSpace(session.Metadata["alias"]),
+		candidate.logicalTemplate(cfg),
+	}
 }
 
 func executePreparedStartWave(
@@ -1928,7 +1976,7 @@ func executePlannedStartsTraced(
 						}
 					}
 				}
-				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
+				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr, startOpts.workDirResolver)
 				if err != nil {
 					clearPendingStartInFlightLease(candidate.session, store, stderr)
 					if release != nil {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -640,7 +640,7 @@ func prepareStartCandidate(
 	store beads.Store,
 	clk clock.Clock,
 ) (*preparedStart, error) {
-	return prepareStartCandidateForCity(candidate, "", "", cfg, nil, store, clk, io.Discard)
+	return prepareStartCandidateForCity(candidate, "", "", cfg, nil, store, clk, io.Discard, nil)
 }
 
 func prepareStartCandidateForCity(
@@ -652,7 +652,7 @@ func prepareStartCandidateForCity(
 	store beads.Store,
 	clk clock.Clock,
 	stderr io.Writer,
-	workDirResolvers ...taskWorkDirResolver,
+	workDirResolver taskWorkDirResolver,
 ) (*preparedStart, error) {
 	session := candidate.session
 	if session != nil && strings.TrimSpace(session.ID) != "" && store != nil {
@@ -671,10 +671,6 @@ func prepareStartCandidateForCity(
 		return nil, err
 	}
 	candidate = refreshConfiguredNamedStartCandidate(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
-	var workDirResolver taskWorkDirResolver
-	if len(workDirResolvers) > 0 {
-		workDirResolver = workDirResolvers[0]
-	}
 	return buildPreparedStartWithWorkDirResolver(candidate, cfg, store, workDirResolver)
 }
 
@@ -887,7 +883,9 @@ func resolvePreparedTaskWorkDir(
 	workDirResolver taskWorkDirResolver,
 ) string {
 	if workDirResolver != nil {
-		return workDirResolver(candidate, cfg)
+		if workDir := workDirResolver(candidate, cfg); workDir != "" {
+			return workDir
+		}
 	}
 	return resolveTaskWorkDir(store, taskWorkDirAssignees(candidate, cfg)...)
 }

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -64,6 +64,18 @@ func (s *failSetMetadataStore) SetMetadata(id, key, value string) error {
 	return s.MemStore.SetMetadata(id, key, value)
 }
 
+type taskWorkDirLiveListCountingStore struct {
+	beads.Store
+	liveInProgressAssigneeLists int
+}
+
+func (s *taskWorkDirLiveListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Live && query.Status == "in_progress" && query.Assignee != "" {
+		s.liveInProgressAssigneeLists++
+	}
+	return s.Store.List(query)
+}
+
 type panicMetadataBatchStore struct {
 	*beads.MemStore
 }
@@ -732,6 +744,65 @@ func TestPrepareStartCandidate_UsesSessionIDForTaskWorkDir(t *testing.T) {
 	}
 	if prepared.cfg.WorkDir != workDir {
 		t.Fatalf("prepared.cfg.WorkDir = %q, want %q", prepared.cfg.WorkDir, workDir)
+	}
+}
+
+func TestPrepareStartCandidate_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &taskWorkDirLiveListCountingStore{Store: base}
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:frontend/worker-1"},
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "custom-worker-1",
+			"pool_slot":    "1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workDir := t.TempDir()
+	task, err := store.Create(beads.Bead{
+		Title: "task",
+		Metadata: map[string]string{
+			"work_dir": workDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := "in_progress"
+	assignee := session.ID
+	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatal(err)
+	}
+	task, err = store.Get(task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := prepareStartCandidateForCity(startCandidate{
+		session: &session,
+		tp: TemplateParams{
+			TemplateName: "frontend/worker",
+			SessionName:  "custom-worker-1",
+		},
+		order: 0,
+	}, "", "", &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2)},
+		},
+	}, nil, store, &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}, nil, newAssignedTaskWorkDirResolver([]beads.Bead{task}))
+	if err != nil {
+		t.Fatalf("prepareStartCandidateForCity: %v", err)
+	}
+	if prepared.cfg.WorkDir != workDir {
+		t.Fatalf("prepared.cfg.WorkDir = %q, want %q", prepared.cfg.WorkDir, workDir)
+	}
+	if store.liveInProgressAssigneeLists != 0 {
+		t.Fatalf("live in-progress assignee List calls = %d, want 0 with snapshot resolver", store.liveInProgressAssigneeLists)
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -491,6 +491,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			apply(&reconcileOpts)
 		}
 	}
+	effectiveStartOptions := startOptions
+	if !storeQueryPartial && reconcileOpts.workDirResolver == nil {
+		effectiveStartOptions = append(append([]startExecutionOption(nil), startOptions...), withTaskWorkDirResolver(newAssignedTaskWorkDirResolver(assignedWorkBeads)))
+	}
 	if startupTimeout <= 0 && cfg != nil {
 		startupTimeout = cfg.Session.StartupTimeoutDuration()
 	}
@@ -1911,7 +1915,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, startCandidates, cfg, desiredState, sp, store, cityName,
 		cityPath,
 		clk, rec, startupTimeout, stdout, stderr, trace,
-		startOptions...,
+		effectiveStartOptions...,
 	)
 
 	if ctx != nil && ctx.Err() != nil {
@@ -2743,6 +2747,45 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 		}
 	}
 	return ""
+}
+
+type assignedTaskWorkDir struct {
+	path      string
+	createdAt time.Time
+}
+
+func newAssignedTaskWorkDirResolver(assignedWorkBeads []beads.Bead) taskWorkDirResolver {
+	index := make(map[string]assignedTaskWorkDir)
+	for _, bead := range assignedWorkBeads {
+		if bead.Status != "in_progress" {
+			continue
+		}
+		assignee := strings.TrimSpace(bead.Assignee)
+		if assignee == "" {
+			continue
+		}
+		workDir := strings.TrimSpace(bead.Metadata["work_dir"])
+		if workDir == "" {
+			continue
+		}
+		info, err := os.Stat(workDir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		current, ok := index[assignee]
+		if ok && !bead.CreatedAt.After(current.createdAt) {
+			continue
+		}
+		index[assignee] = assignedTaskWorkDir{path: workDir, createdAt: bead.CreatedAt}
+	}
+	return func(candidate startCandidate, cfg *config.City) string {
+		for _, assignee := range taskWorkDirAssignees(candidate, cfg) {
+			if workDir := index[strings.TrimSpace(assignee)].path; workDir != "" {
+				return workDir
+			}
+		}
+		return ""
+	}
 }
 
 // truncateHashForLog returns a short representation of a fingerprint hash

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -492,7 +492,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 	}
 	effectiveStartOptions := startOptions
-	if !storeQueryPartial && reconcileOpts.workDirResolver == nil {
+	if !storeQueryPartial && reconcileOpts.workDirResolver == nil && len(assignedWorkBeads) > 0 {
 		effectiveStartOptions = append(append([]startExecutionOption(nil), startOptions...), withTaskWorkDirResolver(newAssignedTaskWorkDirResolver(assignedWorkBeads)))
 	}
 	if startupTimeout <= 0 && cfg != nil {
@@ -2721,6 +2721,9 @@ func clearMissingIdleProbes(dt *drainTracker, beadByID map[string]*beads.Bead) {
 // in the worktree that the previous session (or this session's prior run)
 // created, without any prompt-side logic.
 func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
+	if store == nil {
+		return ""
+	}
 	seen := make(map[string]bool, len(assignees))
 	for _, assignee := range assignees {
 		assignee = strings.TrimSpace(assignee)
@@ -2738,7 +2741,7 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 			continue
 		}
 		for _, b := range assigned {
-			wd := b.Metadata["work_dir"]
+			wd := strings.TrimSpace(b.Metadata["work_dir"])
 			if wd != "" {
 				if info, err := os.Stat(wd); err == nil && info.IsDir() {
 					return wd
@@ -2754,6 +2757,8 @@ type assignedTaskWorkDir struct {
 	createdAt time.Time
 }
 
+// newAssignedTaskWorkDirResolver resolves work_dir values from the
+// reconciler's snapshot; misses intentionally fall back to the live lookup.
 func newAssignedTaskWorkDirResolver(assignedWorkBeads []beads.Bead) taskWorkDirResolver {
 	index := make(map[string]assignedTaskWorkDir)
 	for _, bead := range assignedWorkBeads {

--- a/cmd/gc/session_reconciler_drift_resume_test.go
+++ b/cmd/gc/session_reconciler_drift_resume_test.go
@@ -76,7 +76,7 @@ func TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyOnContinua
 
 	prepared, err := prepareStartCandidateForCity(
 		startCandidate{session: &got, tp: tp, order: 0},
-		"", "", cfg, env.sp, env.store, clk, io.Discard,
+		"", "", cfg, env.sp, env.store, clk, io.Discard, nil,
 	)
 	if err != nil {
 		t.Fatalf("prepareStartCandidateForCity: %v", err)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -310,6 +310,77 @@ func (e *reconcilerTestEnv) reconcileWithPoolDesiredAndDrainOps(sessions []beads
 	)
 }
 
+func TestReconcileSessionBeads_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing.T) {
+	env := newReconcilerTestEnv()
+	base := beads.NewMemStore()
+	store := &taskWorkDirLiveListCountingStore{Store: base}
+	env.store = store
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionCreating(&session)
+
+	workDir := t.TempDir()
+	task, err := env.store.Create(beads.Bead{
+		Title: "assigned task",
+		Type:  "task",
+		Metadata: map[string]string{
+			"work_dir": workDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(task): %v", err)
+	}
+	status := "in_progress"
+	assignee := session.ID
+	if err := env.store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(task): %v", err)
+	}
+	task, err = env.store.Get(task.ID)
+	if err != nil {
+		t.Fatalf("Get(task): %v", err)
+	}
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		cfgNames,
+		env.cfg,
+		env.sp,
+		env.store,
+		nil,
+		[]beads.Bead{task},
+		nil,
+		env.dt,
+		map[string]int{"worker": 1},
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
+	}
+	startCfg := env.sp.LastStartConfig("worker")
+	if startCfg == nil {
+		t.Fatal("worker was not started")
+	}
+	if startCfg.WorkDir != workDir {
+		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
+	}
+	if store.liveInProgressAssigneeLists != 0 {
+		t.Fatalf("live in-progress assignee List calls = %d, want 0 with complete assigned-work snapshot", store.liveInProgressAssigneeLists)
+	}
+}
+
 func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -381,6 +381,135 @@ func TestReconcileSessionBeads_UsesAssignedWorkSnapshotForTaskWorkDir(t *testing
 	}
 }
 
+func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWithoutAssignedWorkSnapshot(t *testing.T) {
+	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
+	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, nil, false)
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
+	}
+	startCfg := env.sp.LastStartConfig("worker")
+	if startCfg == nil {
+		t.Fatal("worker was not started")
+	}
+	if startCfg.WorkDir != workDir {
+		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
+	}
+	if store.liveInProgressAssigneeLists == 0 {
+		t.Fatal("live in-progress assignee List calls = 0, want live fallback without assigned-work snapshot")
+	}
+}
+
+func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWhenAssignedWorkSnapshotPartial(t *testing.T) {
+	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
+	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, nil, true)
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
+	}
+	startCfg := env.sp.LastStartConfig("worker")
+	if startCfg == nil {
+		t.Fatal("worker was not started")
+	}
+	if startCfg.WorkDir != workDir {
+		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
+	}
+	if store.liveInProgressAssigneeLists == 0 {
+		t.Fatal("live in-progress assignee List calls = 0, want live fallback when assigned-work snapshot is partial")
+	}
+}
+
+func TestReconcileSessionBeads_FallsBackToLiveTaskWorkDirWhenAssignedWorkSnapshotMisses(t *testing.T) {
+	env, store, session, workDir := newReconcilerTaskWorkDirTest(t)
+	unrelatedWorkDir := t.TempDir()
+	unrelatedTask := createInProgressTaskWithWorkDir(t, env.store, "other-worker", unrelatedWorkDir)
+	woken := reconcileSessionBeadsWithTaskWorkDirSnapshot(t, env, session, []beads.Bead{unrelatedTask}, false)
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
+	}
+	startCfg := env.sp.LastStartConfig("worker")
+	if startCfg == nil {
+		t.Fatal("worker was not started")
+	}
+	if startCfg.WorkDir != workDir {
+		t.Fatalf("started WorkDir = %q, want %q", startCfg.WorkDir, workDir)
+	}
+	if store.liveInProgressAssigneeLists == 0 {
+		t.Fatal("live in-progress assignee List calls = 0, want live fallback when assigned-work snapshot misses")
+	}
+}
+
+func newReconcilerTaskWorkDirTest(t *testing.T) (*reconcilerTestEnv, *taskWorkDirLiveListCountingStore, beads.Bead, string) {
+	t.Helper()
+	env := newReconcilerTestEnv()
+	base := beads.NewMemStore()
+	store := &taskWorkDirLiveListCountingStore{Store: base}
+	env.store = store
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionCreating(&session)
+	workDir := t.TempDir()
+	createInProgressTaskWithWorkDir(t, env.store, session.ID, workDir)
+	return env, store, session, workDir
+}
+
+func createInProgressTaskWithWorkDir(t *testing.T, store beads.Store, assignee, workDir string) beads.Bead {
+	t.Helper()
+	task, err := store.Create(beads.Bead{
+		Title: "assigned task",
+		Type:  "task",
+		Metadata: map[string]string{
+			"work_dir": workDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(task): %v", err)
+	}
+	status := "in_progress"
+	if err := store.Update(task.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(task): %v", err)
+	}
+	task, err = store.Get(task.ID)
+	if err != nil {
+		t.Fatalf("Get(task): %v", err)
+	}
+	return task
+}
+
+func reconcileSessionBeadsWithTaskWorkDirSnapshot(
+	t *testing.T,
+	env *reconcilerTestEnv,
+	session beads.Bead,
+	assignedWorkBeads []beads.Bead,
+	storeQueryPartial bool,
+) int {
+	t.Helper()
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	return reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		cfgNames,
+		env.cfg,
+		env.sp,
+		env.store,
+		nil,
+		assignedWorkBeads,
+		nil,
+		env.dt,
+		map[string]int{"worker": 1},
+		storeQueryPartial,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+}
+
 func TestReconcileSessionBeads_DrainAckKeepsBeadOpen(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{


### PR DESCRIPTION
## Summary
- reuse the reconciler assigned-work snapshot when preparing session restarts
- preserve the existing live lookup fallback for callers without a complete snapshot
- add regression coverage that restarted sessions use the assigned task work_dir without a second live assigned-work query

## Tests
- go test ./cmd/gc -run 'TestPrepareStartCandidate_UsesAssignedWorkSnapshotForTaskWorkDir|TestReconcileSessionBeads_UsesAssignedWorkSnapshotForTaskWorkDir' -count=1\n- git commit hook: lint-changed, go vet ./..., scripts/test-local-parallel fast\n\nNote: an earlier manual full `go test ./cmd/gc` was stopped after it ran silently for several minutes; the commit hook subsequently completed the sharded fast suite successfully.