### PR TITLE
fix(opencode): carry forward current PR 1292 support

### DIFF
--- a/cmd/gc/template_resolve_phase2_test.go
+++ b/cmd/gc/template_resolve_phase2_test.go
@@ -102,13 +102,15 @@ func selectedPhase2ProviderCases(t *testing.T) []phase2ProviderCase {
 			wantModelOverrideArgs: []string{"--model", "kimi-k2.6"},
 		},
 		{
-			profileID:        "opencode/tmux-cli",
-			family:           "opencode",
-			wantCommand:      "opencode",
-			wantPromptMode:   "flag",
-			wantPromptFlag:   "--prompt",
-			wantReadyDelayMs: 8000,
-			wantProcessNames: []string{"opencode", "node", "bun"},
+			profileID:             "opencode/tmux-cli",
+			family:                "opencode",
+			wantCommand:           "opencode",
+			wantPromptMode:        "flag",
+			wantPromptFlag:        "--prompt",
+			wantReadyDelayMs:      8000,
+			wantProcessNames:      []string{"opencode", "node", "bun"},
+			wantModelOverride:     "opencode/deepseek-v4-flash-free",
+			wantModelOverrideArgs: []string{"--model", "opencode/deepseek-v4-flash-free"},
 		},
 	}
 

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -20,11 +20,14 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const GC_OPENCODE_HOOK_VERSION = 2;
 const GC_BIN = process.env.GC_BIN || "gc";
+// GC_BIN is the explicit override. The fallback order matches Pi hooks so
+// sibling providers resolve the same installed gc before developer-local bins.
 const PATH_PREFIX =
-  `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:`;
+  `/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
 
-async function run(directory, ...args) {
+async function runCommand(directory, args, warnOnFailure) {
   try {
     const { stdout } = await execFileAsync(GC_BIN, args, {
       cwd: directory,
@@ -33,8 +36,36 @@ async function run(directory, ...args) {
       env: { ...process.env, PATH: PATH_PREFIX + (process.env.PATH || "") },
     });
     return stdout.trim();
-  } catch {
+  } catch (err) {
+    if (warnOnFailure) {
+      logRunFailure(args, directory, err);
+    }
     return "";
+  }
+}
+
+async function run(directory, ...args) {
+  return runCommand(directory, args, false);
+}
+
+async function runWithWarning(directory, ...args) {
+  return runCommand(directory, args, true);
+}
+
+function logRunFailure(args, directory, err) {
+  try {
+    const detail =
+      (err && (err.code || err.signal || err.message)) || "unknown error";
+    console.warn(
+      "gascity opencode plugin:",
+      `${GC_BIN} ${args.join(" ")}`,
+      "cwd",
+      directory,
+      "failed:",
+      detail,
+    );
+  } catch {
+    return;
   }
 }
 
@@ -142,9 +173,20 @@ export default async function gascityPlugin({ directory, client }) {
     },
 
     "experimental.session.compacting": async (_input, output) => {
-      const handoff = await run(directory, "handoff", "--auto", "context cycle");
-      if (handoff && Array.isArray(output?.context)) {
+      const handoff = await runWithWarning(directory, "handoff", "--auto", "context cycle");
+      if (!handoff) {
+        return;
+      }
+      if (Array.isArray(output?.context)) {
         output.context.push(handoff);
+        return;
+      }
+      try {
+        console.warn(
+          "gascity opencode plugin: compacting output.context is not an array; skipped handoff injection",
+        );
+      } catch {
+        return;
       }
     },
   };

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -4,10 +4,13 @@
 // OpenCode's plugin API is ESM and hook-oriented:
 //   - event() is side-effect-only (no prompt injection)
 //   - experimental.chat.system.transform mutates output.system
+//   - experimental.session.compacting → inject context before compaction
 //
 // Gas City uses:
 //   - session.created / session.compacted → gc prime --hook (side effects such
 //     as session-id persistence and poller bootstrap)
+//   - experimental.session.compacting → gc handoff --auto "context cycle"
+//     and inject the handoff confirmation into the compaction context
 //   - experimental.chat.system.transform → inject gc prime --hook, queued
 //     nudges, and unread mail into the system prompt for each turn
 
@@ -17,12 +20,13 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const GC_BIN = process.env.GC_BIN || "gc";
 const PATH_PREFIX =
-  `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
+  `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:`;
 
 async function run(directory, ...args) {
   try {
-    const { stdout } = await execFileAsync("gc", args, {
+    const { stdout } = await execFileAsync(GC_BIN, args, {
       cwd: directory,
       encoding: "utf-8",
       timeout: 30000,
@@ -134,6 +138,13 @@ export default async function gascityPlugin({ directory, client }) {
         } else {
           output.system.unshift(prefix);
         }
+      }
+    },
+
+    "experimental.session.compacting": async (_input, output) => {
+      const handoff = await run(directory, "handoff", "--auto", "context cycle");
+      if (handoff && Array.isArray(output?.context)) {
+        output.context.push(handoff);
       }
     },
   };

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -1142,6 +1142,37 @@ func TestBuiltinProviders_GeminiHasNilArgsAndOptionDefaults(t *testing.T) {
 	}
 }
 
+func TestBuiltinProviders_OpenCodeHasModelOptions(t *testing.T) {
+	builtins := BuiltinProviders()
+	opencode := builtins["opencode"]
+
+	if !schemaHasChoice(opencode.OptionsSchema, "model", "opencode/deepseek-v4-flash-free") {
+		t.Fatal("opencode OptionsSchema missing hosted model choice")
+	}
+	args, metadata, err := ResolveOptions(opencode.OptionsSchema, map[string]string{
+		"model": "opencode/deepseek-v4-flash-free",
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResolveOptions(opencode model): %v", err)
+	}
+	if !reflect.DeepEqual(args, []string{"--model", "opencode/deepseek-v4-flash-free"}) {
+		t.Fatalf("model args = %v, want --model opencode/deepseek-v4-flash-free", args)
+	}
+	if metadata["opt_model"] != "opencode/deepseek-v4-flash-free" {
+		t.Fatalf("metadata[opt_model] = %q, want opencode/deepseek-v4-flash-free", metadata["opt_model"])
+	}
+
+	legacy := normalizeProviderLayerArgsForSchema(ProviderSpec{
+		Args: []string{"-m", "opencode/deepseek-v4-flash-free"},
+	}, opencode.OptionsSchema)
+	if len(legacy.Args) != 0 {
+		t.Fatalf("normalized legacy args = %v, want empty", legacy.Args)
+	}
+	if legacy.OptionDefaults["model"] != "opencode/deepseek-v4-flash-free" {
+		t.Fatalf("inferred model = %q, want opencode/deepseek-v4-flash-free", legacy.OptionDefaults["model"])
+	}
+}
+
 func TestValidateOptionDefaults_Valid(t *testing.T) {
 	schema := []ProviderOption{
 		{Key: "permission_mode", Choices: []OptionChoice{

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -1146,30 +1146,48 @@ func TestBuiltinProviders_OpenCodeHasModelOptions(t *testing.T) {
 	builtins := BuiltinProviders()
 	opencode := builtins["opencode"]
 
-	if !schemaHasChoice(opencode.OptionsSchema, "model", "opencode/deepseek-v4-flash-free") {
-		t.Fatal("opencode OptionsSchema missing hosted model choice")
-	}
-	args, metadata, err := ResolveOptions(opencode.OptionsSchema, map[string]string{
-		"model": "opencode/deepseek-v4-flash-free",
-	}, nil)
-	if err != nil {
-		t.Fatalf("ResolveOptions(opencode model): %v", err)
-	}
-	if !reflect.DeepEqual(args, []string{"--model", "opencode/deepseek-v4-flash-free"}) {
-		t.Fatalf("model args = %v, want --model opencode/deepseek-v4-flash-free", args)
-	}
-	if metadata["opt_model"] != "opencode/deepseek-v4-flash-free" {
-		t.Fatalf("metadata[opt_model] = %q, want opencode/deepseek-v4-flash-free", metadata["opt_model"])
+	tests := []struct {
+		name  string
+		model string
+		args  []string
+	}{
+		{name: "Default"},
+		{name: "DeepSeek V4 Flash Free", model: "opencode/deepseek-v4-flash-free", args: []string{"--model", "opencode/deepseek-v4-flash-free"}},
+		{name: "Nemotron 3 Super Free", model: "opencode/nemotron-3-super-free", args: []string{"--model", "opencode/nemotron-3-super-free"}},
+		{name: "Big Pickle", model: "opencode/big-pickle", args: []string{"--model", "opencode/big-pickle"}},
 	}
 
-	legacy := normalizeProviderLayerArgsForSchema(ProviderSpec{
-		Args: []string{"-m", "opencode/deepseek-v4-flash-free"},
-	}, opencode.OptionsSchema)
-	if len(legacy.Args) != 0 {
-		t.Fatalf("normalized legacy args = %v, want empty", legacy.Args)
-	}
-	if legacy.OptionDefaults["model"] != "opencode/deepseek-v4-flash-free" {
-		t.Fatalf("inferred model = %q, want opencode/deepseek-v4-flash-free", legacy.OptionDefaults["model"])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !schemaHasChoice(opencode.OptionsSchema, "model", tt.model) {
+				t.Fatalf("opencode OptionsSchema missing model choice %q", tt.model)
+			}
+			args, metadata, err := ResolveOptions(opencode.OptionsSchema, map[string]string{
+				"model": tt.model,
+			}, nil)
+			if err != nil {
+				t.Fatalf("ResolveOptions(opencode model %q): %v", tt.model, err)
+			}
+			if !reflect.DeepEqual(args, tt.args) {
+				t.Fatalf("model args = %v, want %v", args, tt.args)
+			}
+			if metadata["opt_model"] != tt.model {
+				t.Fatalf("metadata[opt_model] = %q, want %q", metadata["opt_model"], tt.model)
+			}
+
+			if tt.model == "" {
+				return
+			}
+			legacy := normalizeProviderLayerArgsForSchema(ProviderSpec{
+				Args: []string{"-m", tt.model},
+			}, opencode.OptionsSchema)
+			if len(legacy.Args) != 0 {
+				t.Fatalf("normalized legacy args = %v, want empty", legacy.Args)
+			}
+			if legacy.OptionDefaults["model"] != tt.model {
+				t.Fatalf("inferred model = %q, want %q", legacy.OptionDefaults["model"], tt.model)
+			}
+		})
 	}
 }
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -31,9 +31,15 @@ var configFS embed.FS
 // Gas Town's installer.
 var supported = []string{"claude", "codex", "gemini", "kiro", "opencode", "copilot", "cursor", "pi", "omp"}
 
-const managedPiHookVersion = 4
+const (
+	managedPiHookVersion       = 4
+	managedOpenCodeHookVersion = 2
+)
 
-var piHookVersionPattern = regexp.MustCompile(`\bGC_PI_HOOK_VERSION\s*=\s*([0-9]+)\b`)
+var (
+	piHookVersionPattern       = regexp.MustCompile(`\bGC_PI_HOOK_VERSION\s*=\s*([0-9]+)\b`)
+	opencodeHookVersionPattern = regexp.MustCompile(`\bGC_OPENCODE_HOOK_VERSION\s*=\s*([0-9]+)\b`)
+)
 
 // unwiredHookProviders lists provider names whose own CLIs do expose a
 // hook mechanism (per upstream documentation) but for which Gas Town
@@ -195,6 +201,9 @@ func overlayManagedNeedsUpgrade(provider, rel string) func([]byte) bool {
 	if provider == "pi" && rel == path.Join(".pi", "extensions", "gc-hooks.js") {
 		return piHookNeedsUpgrade
 	}
+	if provider == "opencode" && rel == path.Join(".opencode", "plugins", "gascity.js") {
+		return opencodeHookNeedsUpgrade
+	}
 	return nil
 }
 
@@ -226,6 +235,44 @@ func piHookNeedsUpgrade(existing []byte) bool {
 
 func piHookVersion(content string) int {
 	match := piHookVersionPattern.FindStringSubmatch(content)
+	if len(match) != 2 {
+		return 0
+	}
+	version, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0
+	}
+	return version
+}
+
+func opencodeHookNeedsUpgrade(existing []byte) bool {
+	content := string(existing)
+	if !strings.Contains(content, "Gas City hooks for OpenCode.") {
+		return false
+	}
+	if opencodeHookVersion(content) < managedOpenCodeHookVersion ||
+		!strings.Contains(content, `process.env.GC_BIN || "gc"`) ||
+		!strings.Contains(content, `/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`) ||
+		!strings.Contains(content, `"experimental.session.compacting"`) ||
+		!strings.Contains(content, `runWithWarning(directory, "handoff", "--auto", "context cycle")`) ||
+		!strings.Contains(content, "output.context.push(handoff)") ||
+		!strings.Contains(content, "logRunFailure") {
+		return true
+	}
+	for _, marker := range []string{
+		`run(directory, "handoff", "context cycle")`,
+		`"session", "reset"`,
+		`"session.deleted"`,
+	} {
+		if strings.Contains(content, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func opencodeHookVersion(content string) int {
+	match := opencodeHookVersionPattern.FindStringSubmatch(content)
 	if len(match) != 2 {
 		return 0
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1478,6 +1478,28 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	if !strings.Contains(copilotHooks, `gc handoff --auto \"context cycle\"`) {
 		t.Error("copilot preCompact should use auto handoff")
 	}
+	opencodeHooks := string(fs.Files["/work/.opencode/plugins/gascity.js"])
+	for _, want := range []string{
+		`process.env.GC_BIN || "gc"`,
+		`/opt/homebrew/bin:/usr/local/bin`,
+		`"experimental.session.compacting"`,
+		`run(directory, "handoff", "--auto", "context cycle")`,
+		"output.context.push(handoff)",
+		"mirrorTranscript(directory, client",
+	} {
+		if !strings.Contains(opencodeHooks, want) {
+			t.Errorf("OpenCode plugin missing marker %q:\n%s", want, opencodeHooks)
+		}
+	}
+	for _, unwanted := range []string{
+		`run(directory, "handoff", "context cycle")`,
+		`"session", "reset"`,
+		`"session.deleted"`,
+	} {
+		if strings.Contains(opencodeHooks, unwanted) {
+			t.Errorf("OpenCode plugin contains obsolete marker %q:\n%s", unwanted, opencodeHooks)
+		}
+	}
 	for _, rel := range []string{
 		"/work/.codex/hooks.json",
 		"/work/.gemini/settings.json",

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1480,11 +1480,13 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	}
 	opencodeHooks := string(fs.Files["/work/.opencode/plugins/gascity.js"])
 	for _, want := range []string{
+		"const GC_OPENCODE_HOOK_VERSION = 2",
 		`process.env.GC_BIN || "gc"`,
-		`/opt/homebrew/bin:/usr/local/bin`,
+		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
 		`"experimental.session.compacting"`,
-		`run(directory, "handoff", "--auto", "context cycle")`,
+		`runWithWarning(directory, "handoff", "--auto", "context cycle")`,
 		"output.context.push(handoff)",
+		"logRunFailure",
 		"mirrorTranscript(directory, client",
 	} {
 		if !strings.Contains(opencodeHooks, want) {
@@ -1647,6 +1649,92 @@ let mirrorTempCounter = 0;
 	}
 	if piHookNeedsUpgrade(future) {
 		t.Fatal("newer Pi hook version requested downgrade")
+	}
+}
+
+func TestInstallOpenCodeHookUpgradesStaleManagedPlugin(t *testing.T) {
+	fs := fsys.NewFake()
+	legacy := []byte(`// Gas City hooks for OpenCode.
+import { execFile } from "node:child_process";
+async function run(directory, ...args) {
+  const { stdout } = await execFileAsync("gc", args, { cwd: directory });
+  return stdout.trim();
+}
+export default async function gascityPlugin() {
+  return {
+    "experimental.chat.system.transform": async () => {},
+  };
+}
+`)
+	fs.Files["/work/.opencode/plugins/gascity.js"] = legacy
+
+	if err := Install(fs, "/city", "/work", []string{"opencode"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data := string(fs.Files["/work/.opencode/plugins/gascity.js"])
+	if data == string(legacy) {
+		t.Fatal("stale OpenCode managed plugin was preserved; expected managed upgrade")
+	}
+	for _, want := range []string{
+		"const GC_OPENCODE_HOOK_VERSION = 2",
+		`process.env.GC_BIN || "gc"`,
+		`/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`,
+		`"experimental.session.compacting"`,
+		`runWithWarning(directory, "handoff", "--auto", "context cycle")`,
+		"logRunFailure",
+	} {
+		if !strings.Contains(data, want) {
+			t.Errorf("upgraded OpenCode plugin missing marker %q:\n%s", want, data)
+		}
+	}
+	backup := string(fs.Files["/work/.opencode/plugins/gascity.js.bak"])
+	if backup != string(legacy) {
+		t.Fatalf("legacy OpenCode plugin backup = %q, want original legacy content", backup)
+	}
+}
+
+func TestOpenCodeHookNeedsUpgradeComparesParsedVersion(t *testing.T) {
+	current := []byte(`// Gas City hooks for OpenCode.
+const GC_OPENCODE_HOOK_VERSION = 2;
+const GC_BIN = process.env.GC_BIN || "gc";
+const PATH_PREFIX =
+  "/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:";
+function logRunFailure(args, directory, err) {}
+async function runWithWarning(directory, ...args) {}
+"experimental.session.compacting";
+runWithWarning(directory, "handoff", "--auto", "context cycle");
+output.context.push(handoff);
+`)
+	stale := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 2"), []byte("GC_OPENCODE_HOOK_VERSION = 1"), 1)
+	future := bytes.Replace(current, []byte("GC_OPENCODE_HOOK_VERSION = 2"), []byte("GC_OPENCODE_HOOK_VERSION = 3"), 1)
+
+	if !opencodeHookNeedsUpgrade(stale) {
+		t.Fatal("stale OpenCode hook version did not request upgrade")
+	}
+	if opencodeHookNeedsUpgrade(current) {
+		t.Fatal("current OpenCode hook version requested upgrade")
+	}
+	if opencodeHookNeedsUpgrade(future) {
+		t.Fatal("newer OpenCode hook version requested downgrade")
+	}
+}
+
+func TestInstallOpenCodeHookPreservesUserAuthoredPlugin(t *testing.T) {
+	fs := fsys.NewFake()
+	custom := []byte(`export default async function customPlugin() {
+  return {
+    "experimental.chat.system.transform": async () => {},
+  };
+}
+`)
+	fs.Files["/work/.opencode/plugins/gascity.js"] = custom
+
+	if err := Install(fs, "/city", "/work", []string{"opencode"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if got := string(fs.Files["/work/.opencode/plugins/gascity.js"]); got != string(custom) {
+		t.Fatalf("user-authored OpenCode plugin was overwritten:\n%s", got)
 	}
 }
 

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -388,6 +388,19 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		ResumeFlag:       "--session",
 		ResumeStyle:      "flag",
 		ACPArgs:          []string{"acp"},
+		OptionsSchema: []BuiltinProviderOption{
+			{
+				Key:   "model",
+				Label: "Model",
+				Type:  "select",
+				Choices: []BuiltinOptionChoice{
+					{Value: "", Label: "Default"},
+					{Value: "opencode/deepseek-v4-flash-free", Label: "DeepSeek V4 Flash Free", FlagArgs: []string{"--model", "opencode/deepseek-v4-flash-free"}, FlagAliases: [][]string{{"-m", "opencode/deepseek-v4-flash-free"}}},
+					{Value: "opencode/nemotron-3-super-free", Label: "Nemotron 3 Super Free", FlagArgs: []string{"--model", "opencode/nemotron-3-super-free"}, FlagAliases: [][]string{{"-m", "opencode/nemotron-3-super-free"}}},
+					{Value: "opencode/big-pickle", Label: "Big Pickle", FlagArgs: []string{"--model", "opencode/big-pickle"}, FlagAliases: [][]string{{"-m", "opencode/big-pickle"}}},
+				},
+			},
+		},
 	},
 	"auggie": {
 		// Hook mechanism: Auggie CLI exposes SessionStart, SessionEnd,


### PR DESCRIPTION
## Summary

Supersedes #1292 with only the OpenCode changes that still apply on current `main`.

- Adds OpenCode model options for currently available hosted OpenCode models while preserving the existing `--prompt` startup delivery, resume metadata, ACP support, and transcript mirroring.
- Updates the OpenCode plugin to prefer `GC_BIN` and retain Homebrew/local PATH fallback for hook commands.
- Adds `experimental.session.compacting` support using `gc handoff --auto "context cycle"` and injects the handoff confirmation into OpenCode's compaction context.

## PR #1292 Handling

Adapted from these PR #1292 commits:

- `fe7a767d54fb8013bc1391c91ee646c8718c9abc`
- `13321872270f6920763e2e125808eaa1460e369b`
- `b1d864b0d7994e8a883b0ef3d993f68e8ded4d5c`

Skipped as obsolete on current `main`:

- `0b262645b85d599f1efa3b94f0b85d4248a22801` - old session-reset compaction behavior conflicts with current `gc handoff --auto` semantics.
- `23c25e9c00732a1c59375794328c059457863b59` - current handoff already uses bounded, signal-aware controller restart waiting instead of the old blocking path.

## Testing

- `go test ./internal/config ./internal/hooks ./cmd/gc -run 'TestBuiltinProviders_OpenCodeHasModelOptions|TestInstallOverlayManagedProviders|TestPhase2InitialInputDelivery|TestPhase2StartupMaterialization'`
- pre-commit hook ran with `.githooks` active, including `go vet ./...` and `./scripts/test-local-parallel fast`
