### PR TITLE
fix(build): prefer stable local macOS signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,11 @@ permission grants, such as App Management and Apple Events, across rebuilds.
 The build auto-detects the first valid certificate in your keychain, in this
 order: `Apple Development:`, `Developer ID Application:`, then `GasCity Dev`.
 Override the selection with `GC_SIGN_IDENTITY=<certificate name>`.
+The signing identifier defaults to `com.gascity.gc`; override it with
+`GC_SIGN_IDENTIFIER=<identifier>` only when you intentionally want a separate
+local TCC identity. After a successful stable or opt-in ad-hoc signing pass,
+the script removes the `com.apple.provenance` extended attribute when present
+so macOS does not retain stale local-build provenance metadata.
 
 If no stable identity is available, the build leaves Go's linker-produced
 macOS signature unchanged. It does not automatically ad-hoc re-sign the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,35 @@ Run `make help` for the full list. The most useful targets are:
 | `make dashboard-check` | Typecheck + build + test the dashboard |
 | `make cover` | Coverage run |
 
+## macOS Local Development
+
+On macOS, `make build` signs `gc` with a stable local codesigning identity
+when one is available. Stable signing helps macOS TCC remember local
+permission grants, such as App Management and Apple Events, across rebuilds.
+
+The build auto-detects the first valid certificate in your keychain, in this
+order: `Apple Development:`, `Developer ID Application:`, then `GasCity Dev`.
+Override the selection with `GC_SIGN_IDENTITY=<certificate name>`.
+
+If no stable identity is available, the build leaves Go's linker-produced
+macOS signature unchanged. It does not automatically ad-hoc re-sign the
+binary, because ad-hoc signing creates a fresh identity and can cause repeated
+TCC prompts. If you need the old behavior for a local experiment, opt in with
+`GC_ADHOC_SIGN=1`.
+
+Getting a free local certificate does not require paid Apple Developer Program
+membership:
+
+- **Apple Development**: Xcode -> Settings -> Accounts -> sign in with an
+  Apple ID -> Manage Certificates -> `+` -> Apple Development.
+- **Self-signed**: Keychain Access -> Certificate Assistant -> Create a
+  Certificate. Use Identity Type **Self Signed Root** and Certificate Type
+  **Code Signing**. Name it `GasCity Dev` for auto-detection, or set
+  `GC_SIGN_IDENTITY` to its name.
+
+For official distribution, local development signing is not enough; release
+artifacts need a Developer ID certificate and notarization.
+
 ## macOS Release Verification
 
 Before tagging a release, run the macOS smoke test on a Mac:

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,13 @@ endif
 ## install: build and install gc to GOPATH/bin (same location as go install)
 install: build
 	@mkdir -p $(INSTALL_DIR)
-	@tmp="$(INSTALL_DIR)/.$(BINARY).tmp.$$$$"; \
+	@set -e; \
+		tmp="$(INSTALL_DIR)/.$(BINARY).tmp.$$$$"; \
+		trap 'rm -f "$$tmp"' EXIT INT TERM HUP; \
 		cp -f "$(BUILD_DIR)/$(BINARY)" "$$tmp"; \
 		chmod 0755 "$$tmp"; \
-		mv -f "$$tmp" "$(INSTALL_DIR)/$(BINARY)"
+		mv -f "$$tmp" "$(INSTALL_DIR)/$(BINARY)"; \
+		trap - EXIT INT TERM HUP
 	@# Migrate from old install location: replace stale binary with symlink
 	@if [ "$(INSTALL_DIR)" != "$(HOME)/.local/bin" ]; then \
 		if [ -f "$(HOME)/.local/bin/$(BINARY)" ] || [ -L "$(HOME)/.local/bin/$(BINARY)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,16 @@ LDFLAGS := -X main.version=$(VERSION) \
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/gc
 ifeq ($(shell uname),Darwin)
-	@codesign -s - -f $(BUILD_DIR)/$(BINARY) 2>/dev/null || true
-	@echo "Signed $(BINARY) for macOS"
+	@scripts/sign-darwin-local.sh $(BUILD_DIR)/$(BINARY)
 endif
 
 ## install: build and install gc to GOPATH/bin (same location as go install)
 install: build
 	@mkdir -p $(INSTALL_DIR)
-	@rm -f $(INSTALL_DIR)/$(BINARY)
-	@cp $(BUILD_DIR)/$(BINARY) $(INSTALL_DIR)/$(BINARY)
+	@tmp="$(INSTALL_DIR)/.$(BINARY).tmp.$$$$"; \
+		cp -f "$(BUILD_DIR)/$(BINARY)" "$$tmp"; \
+		chmod 0755 "$$tmp"; \
+		mv -f "$$tmp" "$(INSTALL_DIR)/$(BINARY)"
 	@# Migrate from old install location: replace stale binary with symlink
 	@if [ "$(INSTALL_DIR)" != "$(HOME)/.local/bin" ]; then \
 		if [ -f "$(HOME)/.local/bin/$(BINARY)" ] || [ -L "$(HOME)/.local/bin/$(BINARY)" ]; then \

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -196,8 +196,10 @@ On macOS, `make build` signs the binary with a stable local codesigning
 identity when one is available, which helps macOS remember local permission
 grants across rebuilds. Without a stable identity, the build leaves Go's
 linker-produced signature unchanged. Set `GC_SIGN_IDENTITY=<certificate name>`
-to choose a specific certificate, or `GC_ADHOC_SIGN=1` to opt into ad-hoc
-signing for a local experiment.
+to choose a specific certificate, `GC_SIGN_IDENTIFIER=<identifier>` to use a
+separate local TCC identity, or `GC_ADHOC_SIGN=1` to opt into ad-hoc signing
+for a local experiment. Successful local signing also removes stale
+`com.apple.provenance` metadata when present.
 
 ### Contributor setup
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -192,7 +192,12 @@ make build          # outputs bin/gc in the repo root
 ./bin/gc version
 ```
 
-On macOS, `make build` automatically ad-hoc code-signs the binary (`codesign -s -`).
+On macOS, `make build` signs the binary with a stable local codesigning
+identity when one is available, which helps macOS remember local permission
+grants across rebuilds. Without a stable identity, the build leaves Go's
+linker-produced signature unchanged. Set `GC_SIGN_IDENTITY=<certificate name>`
+to choose a specific certificate, or `GC_ADHOC_SIGN=1` to opt into ad-hoc
+signing for a local experiment.
 
 ### Contributor setup
 

--- a/scripts/makefile_install_test.go
+++ b/scripts/makefile_install_test.go
@@ -1,0 +1,84 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMakeInstallFailsClosedWhenCopyFails(t *testing.T) {
+	repoRoot := repoRoot(t)
+	tmp := t.TempDir()
+	buildDir := filepath.Join(tmp, "build")
+	installDir := filepath.Join(tmp, "install")
+	binDir := filepath.Join(tmp, "bin")
+	for _, dir := range []string{buildDir, installDir, binDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	sourceBinary := filepath.Join(buildDir, "gc")
+	if err := os.WriteFile(sourceBinary, []byte("new binary"), 0o755); err != nil {
+		t.Fatalf("write source binary: %v", err)
+	}
+	installedBinary := filepath.Join(installDir, "gc")
+	if err := os.WriteFile(installedBinary, []byte("old binary"), 0o755); err != nil {
+		t.Fatalf("write installed binary: %v", err)
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "cp"), `#!/usr/bin/env sh
+for last do :; done
+printf 'partial binary' > "$last"
+exit 1
+`)
+
+	makefile, err := os.ReadFile(filepath.Join(repoRoot, "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	testMakefile := filepath.Join(tmp, "Makefile")
+	makefileText := string(makefile)
+	if !strings.Contains(makefileText, "\ninstall: build\n") {
+		t.Fatal("Makefile install target no longer depends on build as expected")
+	}
+	makefileContent := strings.Replace(makefileText, "\ninstall: build\n", "\ninstall:\n", 1)
+	if err := os.WriteFile(testMakefile, []byte(makefileContent), 0o644); err != nil {
+		t.Fatalf("write test Makefile: %v", err)
+	}
+
+	cmd := exec.Command("make", "--no-print-directory", "-f", testMakefile, "install",
+		"BUILD_DIR="+buildDir,
+		"INSTALL_DIR="+installDir,
+		"BINARY=gc",
+	)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+filepath.Join(tmp, "home"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("make install succeeded after cp failure:\n%s", out)
+	}
+
+	content, readErr := os.ReadFile(installedBinary)
+	if readErr != nil {
+		t.Fatalf("read installed binary: %v\nmake output:\n%s", readErr, out)
+	}
+	if string(content) != "old binary" {
+		t.Fatalf("installed binary = %q, want old binary after cp failure\nmake output:\n%s", content, out)
+	}
+
+	entries, readDirErr := os.ReadDir(installDir)
+	if readDirErr != nil {
+		t.Fatalf("read install dir: %v", readDirErr)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".gc.tmp.") {
+			t.Fatalf("temporary install file was not cleaned up: %s\nmake output:\n%s", entry.Name(), out)
+		}
+	}
+}

--- a/scripts/sign-darwin-local.sh
+++ b/scripts/sign-darwin-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -u
+set -euo pipefail
 
 if [ "$#" -ne 1 ]; then
 	echo "usage: scripts/sign-darwin-local.sh <binary>" >&2
@@ -49,6 +49,21 @@ sign_with_stable_identity() {
 	return 0
 }
 
+find_stable_identity() {
+	local candidates=$1
+	local pattern
+	local candidate
+
+	for pattern in 'Apple Development:' 'Developer ID Application:' 'GasCity Dev'; do
+		candidate=$(printf '%s\n' "$candidates" | awk -F '"' -v pattern="$pattern" 'index($0, pattern) {print $2; exit}')
+		if [ -n "$candidate" ]; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 0
+}
+
 if [ -n "${GC_SIGN_IDENTITY:-}" ]; then
 	sign_with_stable_identity "$GC_SIGN_IDENTITY" "explicit"
 	exit $?
@@ -56,10 +71,8 @@ fi
 
 identity=""
 if command -v security >/dev/null 2>&1; then
-	identity=$(
-		security find-identity -p codesigning -v 2>/dev/null |
-			awk -F '"' '/Apple Development:|Developer ID Application:|GasCity Dev/{print $2; exit}'
-	)
+	candidates=$(security find-identity -p codesigning -v 2>/dev/null || true)
+	identity=$(find_stable_identity "$candidates")
 fi
 
 if [ -n "$identity" ]; then

--- a/scripts/sign-darwin-local.sh
+++ b/scripts/sign-darwin-local.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -u
+
+if [ "$#" -ne 1 ]; then
+	echo "usage: scripts/sign-darwin-local.sh <binary>" >&2
+	exit 2
+fi
+
+binary=$1
+binary_name=$(basename "$binary")
+identifier=${GC_SIGN_IDENTIFIER:-com.gascity.gc}
+
+if [ "$(uname -s)" != "Darwin" ]; then
+	exit 0
+fi
+
+if [ ! -f "$binary" ]; then
+	echo "cannot sign missing binary: $binary" >&2
+	exit 1
+fi
+
+if ! command -v codesign >/dev/null 2>&1; then
+	echo "codesign not found; leaving Go linker signature unchanged for $binary_name"
+	exit 0
+fi
+
+strip_provenance() {
+	if command -v xattr >/dev/null 2>&1; then
+		xattr -d com.apple.provenance "$binary" 2>/dev/null || true
+	fi
+}
+
+sign_with_stable_identity() {
+	local identity=$1
+	local source=$2
+
+	if codesign --force --sign "$identity" --identifier "$identifier" "$binary" 2>/dev/null; then
+		strip_provenance
+		echo "Signed $binary_name with stable macOS identity: $identity"
+		return 0
+	fi
+
+	if [ "$source" = "explicit" ]; then
+		echo "failed to sign $binary_name with GC_SIGN_IDENTITY=$identity" >&2
+		return 1
+	fi
+
+	echo "Could not sign $binary_name with auto-detected identity; leaving Go linker signature unchanged." >&2
+	return 0
+}
+
+if [ -n "${GC_SIGN_IDENTITY:-}" ]; then
+	sign_with_stable_identity "$GC_SIGN_IDENTITY" "explicit"
+	exit $?
+fi
+
+identity=""
+if command -v security >/dev/null 2>&1; then
+	identity=$(
+		security find-identity -p codesigning -v 2>/dev/null |
+			awk -F '"' '/Apple Development:|Developer ID Application:|GasCity Dev/{print $2; exit}'
+	)
+fi
+
+if [ -n "$identity" ]; then
+	sign_with_stable_identity "$identity" "auto"
+	exit $?
+fi
+
+if [ "${GC_ADHOC_SIGN:-0}" = "1" ]; then
+	if codesign --force --sign - "$binary" 2>/dev/null; then
+		strip_provenance
+		echo "Ad-hoc signed $binary_name by explicit opt-in"
+	else
+		echo "Could not ad-hoc sign $binary_name; leaving Go linker signature unchanged." >&2
+	fi
+	exit 0
+fi
+
+echo "No stable macOS signing identity found; leaving Go linker signature unchanged for $binary_name."
+echo "Set GC_SIGN_IDENTITY='<certificate name>' for persistent local TCC grants."

--- a/scripts/sign_darwin_local_test.go
+++ b/scripts/sign_darwin_local_test.go
@@ -40,6 +40,26 @@ func TestSignDarwinLocalAutoDetectsStableIdentity(t *testing.T) {
 	}
 }
 
+func TestSignDarwinLocalAutoDetectsStableIdentityByDocumentedPriority(t *testing.T) {
+	env := newSignTestEnv(t, "Darwin")
+	env.securityOutput = strings.Join([]string{
+		"  1) 1234567890ABCDEF \"GasCity Dev\"",
+		"  2) 1234567890ABCDEF \"Developer ID Application: Gas City (TEAMID)\"",
+		"  3) 1234567890ABCDEF \"Apple Development: Example (TEAMID)\"",
+		"",
+	}, "\n")
+
+	result := env.run(t)
+	if result.err != nil {
+		t.Fatalf("sign-darwin-local.sh failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+
+	log := env.readLog(t)
+	if !strings.Contains(log, "codesign\t--force\t--sign\tApple Development: Example (TEAMID)\t--identifier\tcom.gascity.gc\t"+env.binary) {
+		t.Fatalf("expected Apple Development to win documented priority, got log:\n%s", log)
+	}
+}
+
 func TestSignDarwinLocalLeavesGoSignatureWhenNoIdentity(t *testing.T) {
 	env := newSignTestEnv(t, "Darwin")
 
@@ -74,6 +94,23 @@ func TestSignDarwinLocalDoesNotFallbackToAdhocWhenAutoSignFails(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "leaving Go linker signature unchanged") {
 		t.Fatalf("expected fallback guidance, got stderr:\n%s", result.stderr)
+	}
+}
+
+func TestSignDarwinLocalExplicitIdentityFailureExitsNonZero(t *testing.T) {
+	env := newSignTestEnv(t, "Darwin")
+
+	result := env.run(t, "GC_SIGN_IDENTITY=Apple Development: Missing (TEAMID)", "CODESIGN_EXIT=1")
+	if result.err == nil {
+		t.Fatalf("expected explicit signing failure to exit non-zero\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+
+	log := env.readLog(t)
+	if strings.Count(log, "codesign") != 1 {
+		t.Fatalf("expected exactly one stable codesign attempt, got log:\n%s", log)
+	}
+	if !strings.Contains(result.stderr, "failed to sign") {
+		t.Fatalf("expected explicit signing failure message, got stderr:\n%s", result.stderr)
 	}
 }
 

--- a/scripts/sign_darwin_local_test.go
+++ b/scripts/sign_darwin_local_test.go
@@ -1,0 +1,198 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSignDarwinLocalUsesExplicitStableIdentity(t *testing.T) {
+	env := newSignTestEnv(t, "Darwin")
+
+	result := env.run(t, "GC_SIGN_IDENTITY=Apple Development: Example (TEAMID)")
+	if result.err != nil {
+		t.Fatalf("sign-darwin-local.sh failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+
+	log := env.readLog(t)
+	if !strings.Contains(log, "codesign\t--force\t--sign\tApple Development: Example (TEAMID)\t--identifier\tcom.gascity.gc\t"+env.binary) {
+		t.Fatalf("expected stable codesign invocation, got log:\n%s", log)
+	}
+	if !strings.Contains(log, "xattr\t-d\tcom.apple.provenance\t"+env.binary) {
+		t.Fatalf("expected provenance xattr cleanup, got log:\n%s", log)
+	}
+}
+
+func TestSignDarwinLocalAutoDetectsStableIdentity(t *testing.T) {
+	env := newSignTestEnv(t, "Darwin")
+	env.securityOutput = "  1) 1234567890ABCDEF \"Developer ID Application: Gas City (TEAMID)\"\n"
+
+	result := env.run(t)
+	if result.err != nil {
+		t.Fatalf("sign-darwin-local.sh failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+
+	log := env.readLog(t)
+	if !strings.Contains(log, "codesign\t--force\t--sign\tDeveloper ID Application: Gas City (TEAMID)\t--identifier\tcom.gascity.gc\t"+env.binary) {
+		t.Fatalf("expected auto-detected stable codesign invocation, got log:\n%s", log)
+	}
+}
+
+func TestSignDarwinLocalLeavesGoSignatureWhenNoIdentity(t *testing.T) {
+	env := newSignTestEnv(t, "Darwin")
+
+	result := env.run(t)
+	if result.err != nil {
+		t.Fatalf("sign-darwin-local.sh failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+
+	if log := env.readLog(t); strings.Contains(log, "codesign") {
+		t.Fatalf("expected no codesign invocation, got log:\n%s", log)
+	}
+	if !strings.Contains(result.stdout, "leaving Go linker signature unchanged") {
+		t.Fatalf("expected no-identity guidance, got stdout:\n%s", result.stdout)
+	}
+}
+
+func TestSignDarwinLocalDoesNotFallbackToAdhocWhenAutoSignFails(t *testing.T) {
+	env := newSignTestEnv(t, "Darwin")
+	env.securityOutput = "  1) 1234567890ABCDEF \"Apple Development: Example (TEAMID)\"\n"
+
+	result := env.run(t, "CODESIGN_EXIT=1")
+	if result.err != nil {
+		t.Fatalf("sign-darwin-local.sh failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+
+	log := env.readLog(t)
+	if strings.Count(log, "codesign") != 1 {
+		t.Fatalf("expected exactly one stable codesign attempt, got log:\n%s", log)
+	}
+	if strings.Contains(log, "codesign\t--force\t--sign\t-\t") {
+		t.Fatalf("expected no ad-hoc fallback, got log:\n%s", log)
+	}
+	if !strings.Contains(result.stderr, "leaving Go linker signature unchanged") {
+		t.Fatalf("expected fallback guidance, got stderr:\n%s", result.stderr)
+	}
+}
+
+func TestSignDarwinLocalAdhocSignsOnlyWhenOptedIn(t *testing.T) {
+	env := newSignTestEnv(t, "Darwin")
+
+	result := env.run(t, "GC_ADHOC_SIGN=1")
+	if result.err != nil {
+		t.Fatalf("sign-darwin-local.sh failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+
+	log := env.readLog(t)
+	if !strings.Contains(log, "codesign\t--force\t--sign\t-\t"+env.binary) {
+		t.Fatalf("expected opt-in ad-hoc codesign invocation, got log:\n%s", log)
+	}
+}
+
+func TestSignDarwinLocalSkipsNonDarwin(t *testing.T) {
+	env := newSignTestEnv(t, "Linux")
+
+	result := env.run(t)
+	if result.err != nil {
+		t.Fatalf("sign-darwin-local.sh failed: %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	if log := env.readLog(t); log != "" {
+		t.Fatalf("expected no signing commands on non-Darwin, got log:\n%s", log)
+	}
+}
+
+type signTestEnv struct {
+	t              *testing.T
+	binDir         string
+	binary         string
+	logFile        string
+	repoRoot       string
+	securityOutput string
+}
+
+type signResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func newSignTestEnv(t *testing.T, unameOutput string) *signTestEnv {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := filepath.Dir(wd)
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	env := &signTestEnv{
+		t:        t,
+		binDir:   binDir,
+		binary:   filepath.Join(tmp, "gc"),
+		logFile:  filepath.Join(tmp, "commands.log"),
+		repoRoot: repoRoot,
+	}
+	if err := os.WriteFile(env.binary, []byte("fake binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	env.writeStub(t, "uname", "printf '%s\\n' "+shellQuote(unameOutput)+"\n")
+	env.writeStub(t, "security", "printf '%s' \"${SECURITY_OUTPUT:-}\"\n")
+	env.writeStub(t, "codesign", "printf 'codesign' >> \"$SIGN_LOG\"\nfor arg in \"$@\"; do printf '\\t%s' \"$arg\" >> \"$SIGN_LOG\"; done\nprintf '\\n' >> \"$SIGN_LOG\"\nexit \"${CODESIGN_EXIT:-0}\"\n")
+	env.writeStub(t, "xattr", "printf 'xattr' >> \"$SIGN_LOG\"\nfor arg in \"$@\"; do printf '\\t%s' \"$arg\" >> \"$SIGN_LOG\"; done\nprintf '\\n' >> \"$SIGN_LOG\"\nexit 0\n")
+
+	return env
+}
+
+func (e *signTestEnv) run(t *testing.T, extraEnv ...string) signResult {
+	t.Helper()
+
+	script := filepath.Join(e.repoRoot, "scripts", "sign-darwin-local.sh")
+	cmd := exec.Command(script, e.binary)
+	cmd.Dir = e.repoRoot
+	cmd.Env = append([]string{
+		"PATH=" + e.binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"SIGN_LOG=" + e.logFile,
+		"SECURITY_OUTPUT=" + e.securityOutput,
+	}, extraEnv...)
+
+	stdout, stderr := strings.Builder{}, strings.Builder{}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return signResult{stdout: stdout.String(), stderr: stderr.String(), err: err}
+}
+
+func (e *signTestEnv) readLog(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile(e.logFile)
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func (e *signTestEnv) writeStub(t *testing.T, name, body string) {
+	t.Helper()
+
+	path := filepath.Join(e.binDir, name)
+	content := "#!/usr/bin/env sh\n" + body
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}


### PR DESCRIPTION
## Summary

Supersedes #1475 with the same local TCC stability goal, but avoids automatic ad-hoc re-signing when no stable identity exists.

- add `scripts/sign-darwin-local.sh` for Darwin local build signing
- prefer `GC_SIGN_IDENTITY`, then auto-detect `Apple Development:`, `Developer ID Application:`, or `GasCity Dev`
- leave Go's linker-produced signature unchanged when no stable identity exists
- make ad-hoc signing explicit via `GC_ADHOC_SIGN=1`
- install via temp-copy plus `mv -f` so local installs replace the binary atomically
- document the local-dev signing path and distinguish it from official distribution signing

## Why

Ad-hoc signing produces an unstable local identity, which can make macOS TCC re-prompt after rebuilds. A stable local certificate fixes that for developers who have one, while preserving normal builds for developers and CI without Apple signing material.

This intentionally does not add Developer ID release signing or notarization. That should be handled as a separate distribution-hardening change.

## Test plan

- `go test ./scripts`
- `make build`
- pre-commit hook in a clean worktree:
  - `make lint-changed LINT_CHANGED_SCOPE=staged LINT_FLAGS="--new-from-rev=HEAD --whole-files --fix"`
  - generated schema/doc checks from the hook
  - `make vet`
  - `make test-fast-parallel`
  - `make check-docs`

