### PR TITLE
Maintainer follow-up for #2396: detect bd-standalone dolt before gc start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,20 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Managed bd provider startup now detects a bd-standalone dolt server running
+  against the same `.beads/dolt` database before invoking the managed-bd
+  lifecycle script, and refuses with a message naming `bd dolt stop` as the
+  unblock. This covers `gc start`, `gc init`, and `gc rig add` provider
+  convergence paths. Previously, running `bd dolt start` while a city was
+  registered at the same path would leave the standalone dolt holding the
+  exclusive write lock; the city-managed dolt could not acquire it and startup
+  failed with a generic "dolt server could not start via gc helper" error that
+  did not point at the lock holder. Stale `.beads/dolt-server.pid` files and
+  live PIDs that do not look like `dolt sql-server` are ignored so leftover
+  files and PID reuse do not block startup.
 - Default bead-backed pool-demand counts now use the same routed target
   resolution as worker claim queries and exclude epic-routed beads, matching
   the default worker `work_query` behavior. Custom `scale_check` overrides are
   unchanged.
-- `gc start` now detects a bd-standalone dolt server running against the
-  same `.beads/dolt` database before invoking the managed-bd lifecycle
-  script, and refuses with a message naming `bd dolt stop` as the unblock.
-  Previously, running `bd dolt start` while a city was registered at the
-  same path would leave the standalone dolt holding the exclusive write
-  lock; the city-managed dolt could not acquire it and `gc start` failed
-  with a generic "dolt server could not start via gc helper" error that
-  did not point at the lock holder. Stale `.beads/dolt-server.pid` files
-  (PID no longer alive) are ignored so leftover files from previous
-  bd-standalone sessions do not block startup.
 - Empty JSON result collections for `gc mail thread`, `gc trace status`, and
   `gc trace show` now encode as `[]` instead of `null`; `gc trace show` also
   reports a concise no-records message in the default text mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolution as worker claim queries and exclude epic-routed beads, matching
   the default worker `work_query` behavior. Custom `scale_check` overrides are
   unchanged.
+- `gc start` now detects a bd-standalone dolt server running against the
+  same `.beads/dolt` database before invoking the managed-bd lifecycle
+  script, and refuses with a message naming `bd dolt stop` as the unblock.
+  Previously, running `bd dolt start` while a city was registered at the
+  same path would leave the standalone dolt holding the exclusive write
+  lock; the city-managed dolt could not acquire it and `gc start` failed
+  with a generic "dolt server could not start via gc helper" error that
+  did not point at the lock holder. Stale `.beads/dolt-server.pid` files
+  (PID no longer alive) are ignored so leftover files from previous
+  bd-standalone sessions do not block startup.
 - Empty JSON result collections for `gc mail thread`, `gc trace status`, and
   `gc trace show` now encode as `[]` instead of `null`; `gc trace show` also
   reports a concise no-records message in the default text mode.

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -157,6 +157,16 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, stderr io.Writer)
 		skipLocalDolt = !owned
 	}
 	if !skipLocalDolt {
+		// Detect a bd-standalone dolt server running against the same
+		// .beads/dolt database before ensureBeadsProvider would hit a
+		// generic "dolt server could not start via gc helper" lock
+		// failure. The check names `bd dolt stop` as the unblock so the
+		// operator does not have to inspect dolt.log to find the cause.
+		if pid, alive, err := detectStandaloneBdDolt(cityPath); err != nil {
+			return fmt.Errorf("checking for standalone bd dolt: %w", err)
+		} else if alive {
+			return standaloneBdDoltConflictError(cityPath, pid)
+		}
 		if err := ensureBeadsProvider(cityPath); err != nil {
 			return fmt.Errorf("bead store: %w", err)
 		}

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -157,16 +157,6 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, stderr io.Writer)
 		skipLocalDolt = !owned
 	}
 	if !skipLocalDolt {
-		// Detect a bd-standalone dolt server running against the same
-		// .beads/dolt database before ensureBeadsProvider would hit a
-		// generic "dolt server could not start via gc helper" lock
-		// failure. The check names `bd dolt stop` as the unblock so the
-		// operator does not have to inspect dolt.log to find the cause.
-		if pid, alive, err := detectStandaloneBdDolt(cityPath); err != nil {
-			return fmt.Errorf("checking for standalone bd dolt: %w", err)
-		} else if alive {
-			return standaloneBdDoltConflictError(cityPath, pid)
-		}
 		if err := ensureBeadsProvider(cityPath); err != nil {
 			return fmt.Errorf("bead store: %w", err)
 		}
@@ -674,6 +664,11 @@ func ensureBeadsProvider(cityPath string) error {
 
 		script := strings.TrimPrefix(provider, "exec:")
 		managedBDProvider := samePath(script, gcBeadsBdScriptPath(cityPath))
+		if managedBDProvider {
+			if err := standaloneBdDoltConflictIfPresent(cityPath); err != nil {
+				return err
+			}
+		}
 		providerEnv, envErr := providerLifecycleProcessEnvWithError(cityPath, provider)
 		if envErr != nil {
 			return envErr

--- a/cmd/gc/dolt_cleanup_discovery.go
+++ b/cmd/gc/dolt_cleanup_discovery.go
@@ -329,18 +329,39 @@ func consumeLeadingFields(s string, n int) ([]string, string) {
 }
 
 func parseDoltPSCommandLine(command string) []string {
-	fields := strings.Fields(command)
-	if len(fields) == 0 {
+	command = strings.TrimSpace(command)
+	if command == "" {
 		return nil
 	}
-	if len(fields) < 2 || filepath.Base(fields[0]) != "dolt" || fields[1] != "sql-server" {
+	tail, ok := doltSQLServerPSTail(command)
+	if !ok {
+		return strings.Fields(command)
+	}
+	fields := strings.Fields(tail)
+	if len(fields) < 2 {
 		return fields
 	}
 	argv := []string{fields[0], fields[1]}
-	if cfg, ok := configPathFromPSCommandLine(command); ok {
+	if cfg, ok := configPathFromPSCommandLine(tail); ok {
 		argv = append(argv, "--config", cfg)
 	}
 	return argv
+}
+
+func doltSQLServerPSTail(command string) (string, bool) {
+	const marker = "dolt sql-server"
+	for start := 0; start < len(command); {
+		i := strings.Index(command[start:], marker)
+		if i < 0 {
+			return "", false
+		}
+		i += start
+		if i == 0 || command[i-1] == filepath.Separator || command[i-1] == '/' || command[i-1] == '\\' {
+			return command[i:], true
+		}
+		start = i + len("dolt")
+	}
+	return "", false
 }
 
 func configPathFromPSCommandLine(command string) (string, bool) {

--- a/cmd/gc/dolt_standalone_conflict.go
+++ b/cmd/gc/dolt_standalone_conflict.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/pidutil"
+)
+
+// standaloneBdDoltPIDPath is the path bd-standalone writes when it manages
+// its own dolt server. The city-managed dolt lifecycle (gc-beads-bd.sh)
+// instead writes its PID under the per-pack runtime state directory, so
+// the presence of this file with a live PID is a reliable indicator that
+// the operator started Dolt out-of-band via `bd dolt start` while a city
+// was registered at cityPath. Both sides want exclusive write access to
+// the same .beads/dolt database, so the second to start loses with a
+// generic "dolt server could not start via gc helper" error.
+func standaloneBdDoltPIDPath(cityPath string) string {
+	return filepath.Join(cityPath, ".beads", "dolt-server.pid")
+}
+
+// detectStandaloneBdDolt reports whether a bd-standalone dolt server is
+// currently holding the .beads/dolt-server lock at cityPath. The PID is
+// returned when the pid file exists and contains a parseable integer,
+// regardless of liveness, so callers can include it in error messages
+// or stale-file warnings.
+//
+// Returns (0, false, nil) when no pid file is present or it is empty.
+// Returns (pid, false, nil) when the file is present but the PID is dead
+// (stale leftover from a previous bd-standalone session that did not
+// clean up). Returns a non-nil error only on unexpected I/O failure or
+// malformed pid contents.
+//
+// pidAliveFn is injected for tests so liveness can be stubbed without
+// spawning real processes. Production callers use detectStandaloneBdDolt.
+func detectStandaloneBdDoltWithAlive(cityPath string, pidAliveFn func(int) bool) (pid int, alive bool, err error) {
+	raw, readErr := os.ReadFile(standaloneBdDoltPIDPath(cityPath))
+	if readErr != nil {
+		if errors.Is(readErr, os.ErrNotExist) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("read %s: %w", standaloneBdDoltPIDPath(cityPath), readErr)
+	}
+	s := strings.TrimSpace(string(raw))
+	if s == "" {
+		return 0, false, nil
+	}
+	pid, err = strconv.Atoi(s)
+	if err != nil {
+		return 0, false, fmt.Errorf("parse pid in %s: %w", standaloneBdDoltPIDPath(cityPath), err)
+	}
+	if pid <= 0 {
+		return pid, false, nil
+	}
+	return pid, pidAliveFn(pid), nil
+}
+
+func detectStandaloneBdDolt(cityPath string) (pid int, alive bool, err error) {
+	return detectStandaloneBdDoltWithAlive(cityPath, pidutil.Alive)
+}
+
+// standaloneBdDoltConflictError formats the actionable error returned
+// from startBeadsLifecycle when a bd-standalone dolt is detected. The
+// message names the unblock command (`bd dolt stop`) explicitly so the
+// operator does not have to guess from a generic "dolt server could not
+// start" failure.
+func standaloneBdDoltConflictError(cityPath string, pid int) error {
+	return fmt.Errorf(
+		"bd-managed dolt server is already running at %s (pid %d, lock file %s); "+
+			"it holds an exclusive write lock on the .beads/dolt database that the city-managed dolt "+
+			"cannot acquire. Run \"bd dolt stop\" to release the lock, then retry \"gc start\"",
+		cityPath, pid, standaloneBdDoltPIDPath(cityPath),
+	)
+}

--- a/cmd/gc/dolt_standalone_conflict.go
+++ b/cmd/gc/dolt_standalone_conflict.go
@@ -11,14 +11,15 @@ import (
 	"github.com/gastownhall/gascity/internal/pidutil"
 )
 
+type standaloneBdDoltProcessMatcher func(pid int, dataDir string) bool
+
 // standaloneBdDoltPIDPath is the path bd-standalone writes when it manages
 // its own dolt server. The city-managed dolt lifecycle (gc-beads-bd.sh)
-// instead writes its PID under the per-pack runtime state directory, so
-// the presence of this file with a live PID is a reliable indicator that
-// the operator started Dolt out-of-band via `bd dolt start` while a city
-// was registered at cityPath. Both sides want exclusive write access to
-// the same .beads/dolt database, so the second to start loses with a
-// generic "dolt server could not start via gc helper" error.
+// instead writes its PID under the per-pack runtime state directory. When
+// this file names a live `dolt sql-server` process, the operator likely
+// started Dolt out-of-band via `bd dolt start` while a city was registered
+// at cityPath. Both sides want exclusive write access to the same .beads/dolt
+// database, so the second to start loses with a generic managed-bd error.
 func standaloneBdDoltPIDPath(cityPath string) string {
 	return filepath.Join(cityPath, ".beads", "dolt-server.pid")
 }
@@ -30,14 +31,17 @@ func standaloneBdDoltPIDPath(cityPath string) string {
 // or stale-file warnings.
 //
 // Returns (0, false, nil) when no pid file is present or it is empty.
-// Returns (pid, false, nil) when the file is present but the PID is dead
-// (stale leftover from a previous bd-standalone session that did not
-// clean up). Returns a non-nil error only on unexpected I/O failure or
-// malformed pid contents.
+// Returns (pid, false, nil) when the file is present but the PID is dead or
+// belongs to another process. Returns a non-nil error only on unexpected I/O
+// failure or malformed pid contents.
 //
 // pidAliveFn is injected for tests so liveness can be stubbed without
 // spawning real processes. Production callers use detectStandaloneBdDolt.
 func detectStandaloneBdDoltWithAlive(cityPath string, pidAliveFn func(int) bool) (pid int, alive bool, err error) {
+	return detectStandaloneBdDoltWith(cityPath, pidAliveFn, processLooksLikeDoltSQLServer)
+}
+
+func detectStandaloneBdDoltWith(cityPath string, pidAliveFn func(int) bool, processMatches standaloneBdDoltProcessMatcher) (pid int, alive bool, err error) {
 	raw, readErr := os.ReadFile(standaloneBdDoltPIDPath(cityPath))
 	if readErr != nil {
 		if errors.Is(readErr, os.ErrNotExist) {
@@ -56,15 +60,82 @@ func detectStandaloneBdDoltWithAlive(cityPath string, pidAliveFn func(int) bool)
 	if pid <= 0 {
 		return pid, false, nil
 	}
-	return pid, pidAliveFn(pid), nil
+	if !pidAliveFn(pid) {
+		return pid, false, nil
+	}
+	if !processMatches(pid, filepath.Join(cityPath, ".beads", "dolt")) {
+		return pid, false, nil
+	}
+	return pid, true, nil
 }
 
 func detectStandaloneBdDolt(cityPath string) (pid int, alive bool, err error) {
 	return detectStandaloneBdDoltWithAlive(cityPath, pidutil.Alive)
 }
 
+func processLooksLikeDoltSQLServer(pid int, dataDir string) bool {
+	if argv, ok := readDoltSQLServerArgv(pid); ok {
+		return doltSQLServerProcessOwnsDataDir(pid, argv, "", dataDir)
+	}
+
+	args, err := processArgsFromPS(pid, processArgsPSTimeout)
+	if err != nil {
+		return false
+	}
+	argv := parseDoltPSCommandLine(args)
+	if !looksLikeDoltSQLServer(argv) {
+		return false
+	}
+	return doltSQLServerProcessOwnsDataDir(pid, argv, args, dataDir)
+}
+
+func doltSQLServerProcessOwnsDataDir(pid int, argv []string, args, dataDir string) bool {
+	if matched, found := argvDataDirMatches(argv, dataDir); found {
+		return matched
+	}
+	if strings.Contains(args, "--data-dir") {
+		return processDataDirMatches(args, dataDir)
+	}
+	return processCWDMatches(pid, dataDir)
+}
+
+func argvDataDirMatches(argv []string, dataDir string) (bool, bool) {
+	value, ok := argvFlagValue(argv, "--data-dir")
+	if !ok {
+		return false, false
+	}
+	return samePath(value, dataDir), true
+}
+
+func argvFlagValue(argv []string, flag string) (string, bool) {
+	for i, arg := range argv {
+		if arg == flag {
+			if i+1 >= len(argv) {
+				return "", true
+			}
+			return strings.TrimSpace(argv[i+1]), true
+		}
+		prefix := flag + "="
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(arg, prefix)), true
+		}
+	}
+	return "", false
+}
+
+func standaloneBdDoltConflictIfPresent(cityPath string) error {
+	pid, alive, err := detectStandaloneBdDolt(cityPath)
+	if err != nil {
+		return fmt.Errorf("checking for standalone bd dolt: %w", err)
+	}
+	if alive {
+		return standaloneBdDoltConflictError(cityPath, pid)
+	}
+	return nil
+}
+
 // standaloneBdDoltConflictError formats the actionable error returned
-// from startBeadsLifecycle when a bd-standalone dolt is detected. The
+// when a bd-standalone dolt is detected. The
 // message names the unblock command (`bd dolt stop`) explicitly so the
 // operator does not have to guess from a generic "dolt server could not
 // start" failure.
@@ -72,7 +143,7 @@ func standaloneBdDoltConflictError(cityPath string, pid int) error {
 	return fmt.Errorf(
 		"bd-managed dolt server is already running at %s (pid %d, lock file %s); "+
 			"it holds an exclusive write lock on the .beads/dolt database that the city-managed dolt "+
-			"cannot acquire. Run \"bd dolt stop\" to release the lock, then retry \"gc start\"",
+			"cannot acquire. Run \"bd dolt stop\" to release the lock, then retry the gc command",
 		cityPath, pid, standaloneBdDoltPIDPath(cityPath),
 	)
 }

--- a/cmd/gc/dolt_standalone_conflict_test.go
+++ b/cmd/gc/dolt_standalone_conflict_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func writeStandaloneBdPID(t *testing.T, cityPath string, contents string) {
+	t.Helper()
+	beadsDir := filepath.Join(cityPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(.beads): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.pid"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile(dolt-server.pid): %v", err)
+	}
+}
+
+func TestDetectStandaloneBdDoltNoPIDFile(t *testing.T) {
+	cityPath := t.TempDir()
+	pid, alive, err := detectStandaloneBdDoltWithAlive(cityPath, func(int) bool {
+		t.Fatal("alive should not be called when pid file is missing")
+		return false
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if pid != 0 || alive {
+		t.Fatalf("pid=%d alive=%v, want 0/false", pid, alive)
+	}
+}
+
+func TestDetectStandaloneBdDoltEmptyPIDFile(t *testing.T) {
+	cityPath := t.TempDir()
+	writeStandaloneBdPID(t, cityPath, "   \n")
+	pid, alive, err := detectStandaloneBdDoltWithAlive(cityPath, func(int) bool {
+		t.Fatal("alive should not be called when pid file is empty")
+		return false
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if pid != 0 || alive {
+		t.Fatalf("pid=%d alive=%v, want 0/false", pid, alive)
+	}
+}
+
+func TestDetectStandaloneBdDoltAlivePID(t *testing.T) {
+	cityPath := t.TempDir()
+	writeStandaloneBdPID(t, cityPath, "12345\n")
+	calls := 0
+	pid, alive, err := detectStandaloneBdDoltWithAlive(cityPath, func(p int) bool {
+		calls++
+		if p != 12345 {
+			t.Fatalf("alive called with pid=%d, want 12345", p)
+		}
+		return true
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if pid != 12345 || !alive {
+		t.Fatalf("pid=%d alive=%v, want 12345/true", pid, alive)
+	}
+	if calls != 1 {
+		t.Fatalf("alive called %d times, want 1", calls)
+	}
+}
+
+func TestDetectStandaloneBdDoltStalePID(t *testing.T) {
+	cityPath := t.TempDir()
+	writeStandaloneBdPID(t, cityPath, "67890")
+	pid, alive, err := detectStandaloneBdDoltWithAlive(cityPath, func(p int) bool {
+		if p != 67890 {
+			t.Fatalf("alive called with pid=%d, want 67890", p)
+		}
+		return false
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if pid != 67890 {
+		t.Fatalf("pid=%d, want 67890", pid)
+	}
+	if alive {
+		t.Fatal("alive=true, want false")
+	}
+}
+
+func TestDetectStandaloneBdDoltMalformedPID(t *testing.T) {
+	cityPath := t.TempDir()
+	writeStandaloneBdPID(t, cityPath, "not-a-number\n")
+	_, _, err := detectStandaloneBdDoltWithAlive(cityPath, func(int) bool {
+		t.Fatal("alive should not be called when pid file is malformed")
+		return false
+	})
+	if err == nil {
+		t.Fatal("err = nil, want non-nil for malformed pid")
+	}
+	if !strings.Contains(err.Error(), "parse pid") {
+		t.Fatalf("err = %v, want it to mention 'parse pid'", err)
+	}
+}
+
+func TestDetectStandaloneBdDoltNegativePID(t *testing.T) {
+	// Non-positive PID is suspicious; we report the file's contents but
+	// never treat it as a live process (Alive guards against pid <= 0
+	// anyway, but skipping the call avoids a meaningless syscall).
+	cityPath := t.TempDir()
+	writeStandaloneBdPID(t, cityPath, "-1\n")
+	pid, alive, err := detectStandaloneBdDoltWithAlive(cityPath, func(int) bool {
+		t.Fatal("alive should not be called for non-positive pid")
+		return false
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if pid != -1 || alive {
+		t.Fatalf("pid=%d alive=%v, want -1/false", pid, alive)
+	}
+}
+
+func TestStandaloneBdDoltConflictErrorContainsActionableHint(t *testing.T) {
+	err := standaloneBdDoltConflictError("/tmp/city", 4242)
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"bd dolt stop", "gc start", "/tmp/city", "4242"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt drives startBeadsLifecycle
+// with a city set up to use the bd-store contract and a .beads/dolt-server.pid
+// pointing at the current test process (guaranteed alive). The conflict
+// detection must surface as the standalone-bd error and ensureBeadsProvider
+// must not run.
+func TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt(t *testing.T) {
+	cityPath := t.TempDir()
+	// Minimal canonical setup for cityUsesBdStoreContract: write
+	// .beads/metadata.json and .beads/config.yaml so the function
+	// proceeds past the canonical compat/drift validation. This is the
+	// same shape other tests in beads_provider_lifecycle_test.go use.
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"),
+		[]byte("issue_prefix: gc\ngc.endpoint_origin: managed_city\ngc.endpoint_status: verified\ndolt.auto-start: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Live PID = ours.
+	writeStandaloneBdPID(t, cityPath, strconv.Itoa(os.Getpid()))
+
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+	}
+	err := startBeadsLifecycle(cityPath, "test-city", cfg, io.Discard)
+	if err == nil {
+		t.Fatal("startBeadsLifecycle returned nil, want standalone-bd conflict error")
+	}
+	for _, want := range []string{"bd dolt stop", "gc start"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("startBeadsLifecycle err = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+// TestStartBeadsLifecycleIgnoresStaleStandaloneBdPID drives startBeadsLifecycle
+// with a stale .beads/dolt-server.pid (PID 1 is init/launchd on every host,
+// so the alive stub returns false instead). The conflict detection must
+// not short-circuit on a stale file — startBeadsLifecycle proceeds to its
+// next step. We do not assert success of the rest of the lifecycle here
+// because that path exec's gc-beads-bd which depends on dolt being
+// installed; we only care that the error, if any, is NOT the standalone-bd
+// conflict error.
+func TestStartBeadsLifecycleIgnoresStaleStandaloneBdPID(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"),
+		[]byte("issue_prefix: gc\ngc.endpoint_origin: managed_city\ngc.endpoint_status: verified\ndolt.auto-start: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Almost-certainly-dead PID — 2147483646 (INT_MAX-1) is the largest
+	// non-special pid on a 32-bit pid_t, far outside the typical pid
+	// space on any real host.
+	writeStandaloneBdPID(t, cityPath, "2147483646")
+
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+	}
+	err := startBeadsLifecycle(cityPath, "test-city", cfg, io.Discard)
+	if err != nil && strings.Contains(err.Error(), "bd-managed dolt server is already running") {
+		t.Fatalf("startBeadsLifecycle incorrectly tripped conflict detection on stale pid: %v", err)
+	}
+}

--- a/cmd/gc/dolt_standalone_conflict_test.go
+++ b/cmd/gc/dolt_standalone_conflict_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -20,6 +23,62 @@ func writeStandaloneBdPID(t *testing.T, cityPath string, contents string) {
 	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.pid"), []byte(contents), 0o600); err != nil {
 		t.Fatalf("WriteFile(dolt-server.pid): %v", err)
 	}
+}
+
+func writeManagedBdCityFixture(t *testing.T, cityPath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"),
+		[]byte("issue_prefix: gc\ngc.endpoint_origin: managed_city\ngc.endpoint_status: verified\ndolt.auto-start: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func startStandaloneBdDoltLikeProcess(t *testing.T, dataDir string) *exec.Cmd {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("requires bash for exec -a")
+	}
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(dataDir): %v", err)
+	}
+	fifo := filepath.Join(dataDir, "sql-server")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("Mkfifo(sql-server): %v", err)
+	}
+	cmd := exec.Command("bash", "-c", "exec -a dolt cat sql-server")
+	cmd.Dir = dataDir
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start fake dolt sql-server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if cmd.Process.Signal(syscall.Signal(0)) == nil && processLooksLikeDoltSQLServer(cmd.Process.Pid, dataDir) {
+			return cmd
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	args, _ := processArgs(cmd.Process.Pid)
+	t.Fatalf("fake dolt sql-server did not become inspectable; pid=%d args=%q", cmd.Process.Pid, args)
+	return cmd
 }
 
 func TestDetectStandaloneBdDoltNoPIDFile(t *testing.T) {
@@ -55,10 +114,18 @@ func TestDetectStandaloneBdDoltAlivePID(t *testing.T) {
 	cityPath := t.TempDir()
 	writeStandaloneBdPID(t, cityPath, "12345\n")
 	calls := 0
-	pid, alive, err := detectStandaloneBdDoltWithAlive(cityPath, func(p int) bool {
+	pid, alive, err := detectStandaloneBdDoltWith(cityPath, func(p int) bool {
 		calls++
 		if p != 12345 {
 			t.Fatalf("alive called with pid=%d, want 12345", p)
+		}
+		return true
+	}, func(p int, dataDir string) bool {
+		if p != 12345 {
+			t.Fatalf("process match called with pid=%d, want 12345", p)
+		}
+		if dataDir != filepath.Join(cityPath, ".beads", "dolt") {
+			t.Fatalf("process match called with dataDir=%q, want city dolt dir", dataDir)
 		}
 		return true
 	})
@@ -70,6 +137,66 @@ func TestDetectStandaloneBdDoltAlivePID(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("alive called %d times, want 1", calls)
+	}
+}
+
+func TestDetectStandaloneBdDoltLiveUnrelatedPID(t *testing.T) {
+	cityPath := t.TempDir()
+	writeStandaloneBdPID(t, cityPath, "12345\n")
+	pid, alive, err := detectStandaloneBdDoltWith(cityPath, func(p int) bool {
+		if p != 12345 {
+			t.Fatalf("alive called with pid=%d, want 12345", p)
+		}
+		return true
+	}, func(p int, dataDir string) bool {
+		if p != 12345 {
+			t.Fatalf("process match called with pid=%d, want 12345", p)
+		}
+		if dataDir != filepath.Join(cityPath, ".beads", "dolt") {
+			t.Fatalf("process match called with dataDir=%q, want city dolt dir", dataDir)
+		}
+		return false
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if pid != 12345 {
+		t.Fatalf("pid=%d, want 12345", pid)
+	}
+	if alive {
+		t.Fatal("alive=true for live non-dolt pid, want false")
+	}
+}
+
+func TestDetectStandaloneBdDoltLiveDoltForDifferentDataDirDoesNotConflict(t *testing.T) {
+	cityPath := t.TempDir()
+	otherCityPath := t.TempDir()
+	proc := startStandaloneBdDoltLikeProcess(t, filepath.Join(otherCityPath, ".beads", "dolt"))
+	writeStandaloneBdPID(t, cityPath, strconv.Itoa(proc.Process.Pid))
+	pid, alive, err := detectStandaloneBdDolt(cityPath)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if pid != proc.Process.Pid {
+		t.Fatalf("pid=%d, want %d", pid, proc.Process.Pid)
+	}
+	if alive {
+		t.Fatal("alive=true for dolt sql-server with different data dir, want false")
+	}
+}
+
+func TestDetectStandaloneBdDoltCurrentProcessPIDDoesNotConflict(t *testing.T) {
+	cityPath := t.TempDir()
+	writeStandaloneBdPID(t, cityPath, strconv.Itoa(os.Getpid()))
+	pid, alive, err := detectStandaloneBdDolt(cityPath)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("pid=%d, want current process pid %d", pid, os.Getpid())
+	}
+	if alive {
+		t.Fatal("alive=true for current test process, want false because it is not dolt sql-server")
 	}
 }
 
@@ -132,10 +259,23 @@ func TestStandaloneBdDoltConflictErrorContainsActionableHint(t *testing.T) {
 		t.Fatal("err = nil, want non-nil")
 	}
 	msg := err.Error()
-	for _, want := range []string{"bd dolt stop", "gc start", "/tmp/city", "4242"} {
+	for _, want := range []string{"bd dolt stop", "/tmp/city", "4242"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("error message missing %q:\n%s", want, msg)
 		}
+	}
+	if strings.Contains(msg, "gc start") {
+		t.Fatalf("error message should not hardcode command-specific retry guidance:\n%s", msg)
+	}
+}
+
+func TestParseDoltPSCommandLineHandlesSpacedExecutablePath(t *testing.T) {
+	argv := parseDoltPSCommandLine("/Applications/Dolt Tools/bin/dolt sql-server --config /tmp/city/.gc/runtime/packs/dolt/dolt-config.yaml")
+	if !looksLikeDoltSQLServer(argv) {
+		t.Fatalf("parseDoltPSCommandLine did not preserve dolt sql-server shape: %#v", argv)
+	}
+	if len(argv) != 4 || argv[2] != "--config" || argv[3] != "/tmp/city/.gc/runtime/packs/dolt/dolt-config.yaml" {
+		t.Fatalf("parseDoltPSCommandLine argv = %#v, want config preserved", argv)
 	}
 }
 
@@ -146,24 +286,9 @@ func TestStandaloneBdDoltConflictErrorContainsActionableHint(t *testing.T) {
 // must not run.
 func TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt(t *testing.T) {
 	cityPath := t.TempDir()
-	// Minimal canonical setup for cityUsesBdStoreContract: write
-	// .beads/metadata.json and .beads/config.yaml so the function
-	// proceeds past the canonical compat/drift validation. This is the
-	// same shape other tests in beads_provider_lifecycle_test.go use.
-	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
-		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"),
-		[]byte("issue_prefix: gc\ngc.endpoint_origin: managed_city\ngc.endpoint_status: verified\ndolt.auto-start: false\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Live PID = ours.
-	writeStandaloneBdPID(t, cityPath, strconv.Itoa(os.Getpid()))
+	writeManagedBdCityFixture(t, cityPath)
+	proc := startStandaloneBdDoltLikeProcess(t, filepath.Join(cityPath, ".beads", "dolt"))
+	writeStandaloneBdPID(t, cityPath, strconv.Itoa(proc.Process.Pid))
 
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
@@ -174,10 +299,13 @@ func TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt(t *testing.T) {
 	if err == nil {
 		t.Fatal("startBeadsLifecycle returned nil, want standalone-bd conflict error")
 	}
-	for _, want := range []string{"bd dolt stop", "gc start"} {
+	for _, want := range []string{"bd dolt stop"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("startBeadsLifecycle err = %v, want it to mention %q", err, want)
 		}
+	}
+	if strings.Contains(err.Error(), "gc start") {
+		t.Fatalf("startBeadsLifecycle err should not hardcode retry command: %v", err)
 	}
 }
 
@@ -191,17 +319,7 @@ func TestStartBeadsLifecycleRefusesLiveStandaloneBdDolt(t *testing.T) {
 // conflict error.
 func TestStartBeadsLifecycleIgnoresStaleStandaloneBdPID(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
-		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gc"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"),
-		[]byte("issue_prefix: gc\ngc.endpoint_origin: managed_city\ngc.endpoint_status: verified\ndolt.auto-start: false\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeManagedBdCityFixture(t, cityPath)
 	// Almost-certainly-dead PID — 2147483646 (INT_MAX-1) is the largest
 	// non-special pid on a 32-bit pid_t, far outside the typical pid
 	// space on any real host.
@@ -215,5 +333,45 @@ func TestStartBeadsLifecycleIgnoresStaleStandaloneBdPID(t *testing.T) {
 	err := startBeadsLifecycle(cityPath, "test-city", cfg, io.Discard)
 	if err != nil && strings.Contains(err.Error(), "bd-managed dolt server is already running") {
 		t.Fatalf("startBeadsLifecycle incorrectly tripped conflict detection on stale pid: %v", err)
+	}
+}
+
+func TestInitDirIfReadyDetectsStandaloneBdDoltAtProviderConvergence(t *testing.T) {
+	cityPath := t.TempDir()
+	writeManagedBdCityFixture(t, cityPath)
+	MaterializeBuiltinPacks(cityPath) //nolint:errcheck
+
+	callLog := filepath.Join(cityPath, "provider-start.log")
+	script := gcBeadsBdScriptPath(cityPath)
+	content := "#!/bin/sh\n" +
+		"echo \"$1\" >> \"" + callLog + "\"\n" +
+		"echo 'provider should not start' >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := startStandaloneBdDoltLikeProcess(t, filepath.Join(cityPath, ".beads", "dolt"))
+	writeStandaloneBdPID(t, cityPath, strconv.Itoa(proc.Process.Pid))
+
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+	deferred, err := initDirIfReady(cityPath, cityPath, "gc")
+	if err == nil {
+		t.Fatal("initDirIfReady returned nil, want standalone-bd conflict error")
+	}
+	if deferred {
+		t.Fatal("initDirIfReady deferred = true, want false")
+	}
+	for _, want := range []string{"bd dolt stop"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("initDirIfReady err = %v, want it to mention %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "gc start") {
+		t.Fatalf("initDirIfReady err should not hardcode retry command: %v", err)
+	}
+	if _, statErr := os.Stat(callLog); !os.IsNotExist(statErr) {
+		t.Fatalf("provider script should not have started, stat err = %v", statErr)
 	}
 }


### PR DESCRIPTION
Maintainer follow-up for #2396.

Original PR: https://github.com/gastownhall/gascity/pull/2396
Original title: fix(beads-lifecycle): detect bd-standalone dolt before gc start
Original state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

This carries forward Austin Born's contribution after the adoption workflow review and maintainer fix loop. The original fork branch could not be updated by the current maintainer token, so this upstream branch preserves the contributor commit and adds the reviewed maintainer hardening commit on top of the latest `main`.

The change detects a standalone `bd dolt start` server that owns the same `.beads/dolt` data directory before the managed bd lifecycle starts, so `gc start`, `gc init`, and `gc rig add` can fail with an actionable `bd dolt stop` diagnostic instead of the generic managed-dolt startup failure.

Local validation:
- `go test ./cmd/gc` passed after the latest-base rebase repair.
- `go test ./cmd/gc -run 'Test(DetectStandaloneBdDolt|StartBeadsLifecycle.*StandaloneBd|InitDirIfReadyDetectsStandaloneBdDolt|ParseDoltPSCommandLine)'` passed.
- `go test ./test/docsync` passed from the local commit hook during amend.

Adopted via `/adopt-pr` workflow. Original contributor commit authorship is preserved.