### PR TITLE
fix: repair tracks-based convoy followups

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -1264,6 +1264,9 @@ func doConvoyStrandedAcrossStoresJSON(stores []convoyStoreView, jsonOut bool, st
 			return 1
 		}
 		for _, ch := range children {
+			if convoycore.IsUnresolvedTrackedItem(ch) {
+				continue
+			}
 			if !convoycore.IsTerminalStatus(ch.Status) && ch.Assignee == "" {
 				items = append(items, strandedItem{convoyID: item.bead.ID, issue: ch})
 			}

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -445,8 +445,9 @@ type convoyWithStore struct {
 }
 
 type convoyProgressJSON struct {
-	Closed int `json:"closed"`
-	Total  int `json:"total"`
+	Closed         int `json:"closed"`
+	Total          int `json:"total"`
+	DanglingTracks int `json:"dangling_tracks,omitempty"`
 }
 
 type convoyFieldsJSON struct {
@@ -477,11 +478,12 @@ type convoyListResultJSON struct {
 }
 
 type convoyChildJSON struct {
-	ID       string `json:"id"`
-	Title    string `json:"title"`
-	Status   string `json:"status"`
-	Type     string `json:"type"`
-	Assignee string `json:"assignee,omitempty"`
+	ID            string `json:"id"`
+	Title         string `json:"title"`
+	Status        string `json:"status"`
+	Type          string `json:"type"`
+	Assignee      string `json:"assignee,omitempty"`
+	DanglingTrack bool   `json:"dangling_track,omitempty"`
 }
 
 type convoyDetailJSON struct {
@@ -518,6 +520,31 @@ func collectOpenConvoys(stores []convoyStoreView) ([]convoyWithStore, error) {
 		return convoys[i].bead.ID < convoys[j].bead.ID
 	})
 	return convoys, nil
+}
+
+func convoyProgressFromChildren(children []beads.Bead) convoyProgressJSON {
+	progress := convoyProgressJSON{Total: len(children)}
+	for _, ch := range children {
+		if convoycore.IsTerminalStatus(ch.Status) {
+			progress.Closed++
+		}
+		if convoycore.IsUnresolvedTrackedItem(ch) {
+			progress.DanglingTracks++
+		}
+	}
+	return progress
+}
+
+func formatConvoyProgress(progress convoyProgressJSON) string {
+	text := fmt.Sprintf("%d/%d closed", progress.Closed, progress.Total)
+	if progress.DanglingTracks > 0 {
+		suffix := "tracks"
+		if progress.DanglingTracks == 1 {
+			suffix = "track"
+		}
+		text += fmt.Sprintf(" (%d dangling %s)", progress.DanglingTracks, suffix)
+	}
+	return text
 }
 
 func openConvoyStoreByID(convoyID string, stderr io.Writer, cmdName string) (beads.Store, int) {
@@ -576,13 +603,8 @@ func doConvoyListAcrossStores(stores []convoyStoreView, jsonOut bool, stdout, st
 			fmt.Fprintf(stderr, "gc convoy list: children of %s: %v\n", c.bead.ID, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		closed := 0
-		for _, ch := range children {
-			if convoycore.IsTerminalStatus(ch.Status) {
-				closed++
-			}
-		}
-		fmt.Fprintf(tw, "%s\t%s\t%d/%d closed\n", c.bead.ID, c.bead.Title, closed, len(children)) //nolint:errcheck // best-effort stdout
+		progress := convoyProgressFromChildren(children)
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", c.bead.ID, c.bead.Title, formatConvoyProgress(progress)) //nolint:errcheck // best-effort stdout
 	}
 	tw.Flush() //nolint:errcheck // best-effort stdout
 	return 0
@@ -612,18 +634,14 @@ func writeConvoyListJSON(convoys []convoyWithStore, stdout, stderr io.Writer) in
 
 func convoySummaryFromBead(convoy beads.Bead, children []beads.Bead) convoySummaryJSON {
 	childIDs := make([]string, 0, len(children))
-	closed := 0
 	for _, ch := range children {
 		childIDs = append(childIDs, ch.ID)
-		if convoycore.IsTerminalStatus(ch.Status) {
-			closed++
-		}
 	}
 	return convoySummaryJSON{
 		ID:       convoy.ID,
 		Title:    convoy.Title,
 		Status:   convoy.Status,
-		Progress: convoyProgressJSON{Closed: closed, Total: len(children)},
+		Progress: convoyProgressFromChildren(children),
 		Owned:    hasLabel(convoy.Labels, "owned"),
 		Fields:   convoyFieldsFromBead(convoy),
 		ChildIDs: childIDs,
@@ -705,22 +723,17 @@ func doConvoyStatusWithJSON(store beads.Store, args []string, jsonOut bool, stdo
 		return 1
 	}
 
-	closed := 0
-	for _, ch := range children {
-		if convoycore.IsTerminalStatus(ch.Status) {
-			closed++
-		}
-	}
+	progress := convoyProgressFromChildren(children)
 
 	if jsonOut {
-		return writeConvoyStatusJSON(convoy, children, closed, stdout, stderr)
+		return writeConvoyStatusJSON(convoy, children, progress, stdout, stderr)
 	}
 
 	w := func(s string) { fmt.Fprintln(stdout, s) } //nolint:errcheck // best-effort stdout
 	w(fmt.Sprintf("Convoy:   %s", convoy.ID))
 	w(fmt.Sprintf("Title:    %s", convoy.Title))
 	w(fmt.Sprintf("Status:   %s", convoy.Status))
-	w(fmt.Sprintf("Progress: %d/%d closed", closed, len(children)))
+	w(fmt.Sprintf("Progress: %s", formatConvoyProgress(progress)))
 	fields := getConvoyFields(convoy)
 	if hasLabel(convoy.Labels, "owned") {
 		w("Lifecycle: owned")
@@ -754,15 +767,16 @@ func doConvoyStatusWithJSON(store beads.Store, args []string, jsonOut bool, stdo
 	return 0
 }
 
-func writeConvoyStatusJSON(convoy beads.Bead, children []beads.Bead, closed int, stdout, stderr io.Writer) int {
+func writeConvoyStatusJSON(convoy beads.Bead, children []beads.Bead, progress convoyProgressJSON, stdout, stderr io.Writer) int {
 	childItems := make([]convoyChildJSON, 0, len(children))
 	for _, ch := range children {
 		childItems = append(childItems, convoyChildJSON{
-			ID:       ch.ID,
-			Title:    ch.Title,
-			Status:   ch.Status,
-			Type:     ch.Type,
-			Assignee: ch.Assignee,
+			ID:            ch.ID,
+			Title:         ch.Title,
+			Status:        ch.Status,
+			Type:          ch.Type,
+			Assignee:      ch.Assignee,
+			DanglingTrack: convoycore.IsUnresolvedTrackedItem(ch),
 		})
 	}
 	if err := writeCLIJSONLine(stdout, convoyStatusResultJSON{
@@ -775,7 +789,7 @@ func writeConvoyStatusJSON(convoy beads.Bead, children []beads.Bead, closed int,
 			Fields: convoyFieldsFromBead(convoy),
 			Labels: convoy.Labels,
 		},
-		Progress: convoyProgressJSON{Closed: closed, Total: len(children)},
+		Progress: progress,
 		Children: childItems,
 	}); err != nil {
 		fmt.Fprintf(stderr, "gc convoy status: writing JSON: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -465,6 +465,28 @@ func TestConvoyStatusTracksDeps(t *testing.T) {
 	}
 }
 
+func TestConvoyStatusReportsDanglingTracks(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "deploy", Type: "convoy"}) // gc-1
+	_, _ = store.Create(beads.Bead{Title: "task A"})                 // gc-2
+	requireNoError(t, store.DepAdd("gc-1", "gc-2", "tracks"))
+	requireNoError(t, store.DepAdd("gc-1", "gc-missing", "tracks"))
+	_ = store.Close("gc-2")
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyStatus(store, []string{"gc-1"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyStatus = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"Progress: 1/2 closed (1 dangling track)", "gc-missing", "unknown"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestConvoyStatusJSON(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{
@@ -508,6 +530,29 @@ func TestConvoyStatusJSON(t *testing.T) {
 	}
 	if len(result.Children) != 2 || result.Children[1].Assignee != "worker" {
 		t.Fatalf("children = %+v, want two children with second assigned", result.Children)
+	}
+}
+
+func TestConvoyStatusJSONReportsDanglingTracks(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "deploy", Type: "convoy"}) // gc-1
+	_, _ = store.Create(beads.Bead{Title: "task A"})                 // gc-2
+	requireNoError(t, store.DepAdd("gc-1", "gc-2", "tracks"))
+	requireNoError(t, store.DepAdd("gc-1", "gc-missing", "tracks"))
+	_ = store.Close("gc-2")
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyStatusWithJSON(store, []string{"gc-1"}, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyStatus --json = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var result convoyStatusResultJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if result.Progress.Closed != 1 || result.Progress.Total != 2 || result.Progress.DanglingTracks != 1 {
+		t.Fatalf("progress = %+v, want 1/2 with 1 dangling track", result.Progress)
 	}
 }
 
@@ -1155,6 +1200,25 @@ func TestConvoyStrandedClosedExcluded(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "No stranded work") {
 		t.Errorf("stdout = %q, want no stranded (closed issues excluded)", stdout.String())
+	}
+}
+
+func TestConvoyListReportsDanglingTracks(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"}) // gc-1
+	_, _ = store.Create(beads.Bead{Title: "task A"})                // gc-2
+	requireNoError(t, store.DepAdd("gc-1", "gc-2", "tracks"))
+	requireNoError(t, store.DepAdd("gc-1", "gc-missing", "tracks"))
+	_ = store.Close("gc-2")
+
+	var stdout, stderr bytes.Buffer
+	code := doConvoyList(store, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doConvoyList = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "1/2 closed (1 dangling track)") {
+		t.Errorf("stdout = %q, want dangling track progress", stdout.String())
 	}
 }
 

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -1158,6 +1158,21 @@ func TestConvoyStrandedClosedExcluded(t *testing.T) {
 	}
 }
 
+func TestConvoyStrandedIgnoresDanglingTracks(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "batch", Type: "convoy"}) // gc-1
+	requireNoError(t, store.DepAdd("gc-1", "gc-missing", "tracks"))
+
+	var stdout bytes.Buffer
+	code := doConvoyStranded(store, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatalf("doConvoyStranded = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "No stranded work") {
+		t.Errorf("stdout = %q, want no stranded message for dangling tracks", stdout.String())
+	}
+}
+
 func TestConvoyStrandedAcrossStores(t *testing.T) {
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()

--- a/cmd/gc/cmd_graph.go
+++ b/cmd/gc/cmd_graph.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/spf13/cobra"
 )
 
@@ -272,10 +273,7 @@ func resolveGraphInput(store beads.Store, args []string, stderr io.Writer) ([]be
 			fmt.Fprintf(stderr, "gc graph: epic %s is treated as an ordinary bead; convoy expansion is first-class\n", b.ID) //nolint:errcheck // best-effort stderr
 		}
 		if beads.IsContainerType(b.Type) {
-			children, err := store.List(beads.ListQuery{
-				ParentID: b.ID,
-				Sort:     beads.SortCreatedAsc,
-			})
+			children, err := convoycore.Members(store, b.ID, false)
 			if err != nil {
 				return nil, fmt.Errorf("expanding %s %s: %w", b.Type, b.ID, err)
 			}

--- a/cmd/gc/cmd_graph_test.go
+++ b/cmd/gc/cmd_graph_test.go
@@ -129,6 +129,33 @@ func TestGraphConvoyExpansion(t *testing.T) {
 	}
 }
 
+func TestGraphConvoyExpansionUsesTracksDependencies(t *testing.T) {
+	store := beads.NewMemStore()
+	_, _ = store.Create(beads.Bead{Title: "my convoy", Type: "convoy"}) // gc-1
+	_, _ = store.Create(beads.Bead{Title: "child A"})                   // gc-2
+	_, _ = store.Create(beads.Bead{Title: "child B"})                   // gc-3
+	if err := store.DepAdd("gc-1", "gc-2", "tracks"); err != nil {
+		t.Fatalf("DepAdd child A: %v", err)
+	}
+	if err := store.DepAdd("gc-1", "gc-3", "tracks"); err != nil {
+		t.Fatalf("DepAdd child B: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doGraph(store, []string{"gc-1"}, graphOpts{}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doGraph convoy = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+
+	if strings.Contains(out, "my convoy") {
+		t.Errorf("convoy bead should be expanded, not shown:\n%s", out)
+	}
+	if !strings.Contains(out, "child A") || !strings.Contains(out, "child B") {
+		t.Errorf("should show tracks-based convoy children:\n%s", out)
+	}
+}
+
 func TestGraphEpicIsTreatedAsOrdinaryBead(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{Title: "my epic", Type: "epic"})     // gc-1

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -6080,7 +6080,7 @@ func TestDoSlingNoConvoyRepeatIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestDoSlingKeepsLiveNonConvoyParentIdempotent(t *testing.T) {
+func TestDoSlingKeepsWorkflowParentIdempotent(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
@@ -6096,7 +6096,7 @@ func TestDoSlingKeepsLiveNonConvoyParentIdempotent(t *testing.T) {
 
 	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
 	deps.Store = beads.NewMemStoreFrom(0, []beads.Bead{
-		{ID: "WF-1", Title: "workflow", Type: "workflow", Status: "in_progress", Metadata: map[string]string{}},
+		{ID: "WF-1", Title: "workflow", Type: "workflow", Status: "in_progress", Metadata: map[string]string{"gc.kind": "workflow"}},
 		{
 			ID:       "BL-42",
 			Title:    "workflow step",
@@ -6117,10 +6117,10 @@ func TestDoSlingKeepsLiveNonConvoyParentIdempotent(t *testing.T) {
 		t.Fatalf("store.Get(BL-42): %v", err)
 	}
 	if bead.ParentID != "WF-1" {
-		t.Fatalf("ParentID = %q, want original non-convoy parent WF-1", bead.ParentID)
+		t.Fatalf("ParentID = %q, want original workflow parent WF-1", bead.ParentID)
 	}
 	if pokeCount != 0 {
-		t.Fatalf("idempotent live non-convoy parent sling poked controller; count = %d, want 0", pokeCount)
+		t.Fatalf("idempotent workflow parent sling poked controller; count = %d, want 0", pokeCount)
 	}
 	if !strings.Contains(stdout.String(), "skipping (idempotent)") {
 		t.Fatalf("stdout = %q, want idempotent skip", stdout.String())

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sling"
 )
@@ -327,6 +328,16 @@ func collectBeadGraph(store beads.Store, root beads.Bead) ([]beads.Bead, []workf
 	}
 	for _, child := range metadataChildren {
 		upsert(child)
+	}
+
+	if root.Type == "convoy" {
+		members, err := convoycore.Members(store, root.ID, true)
+		if err != nil {
+			return nil, nil, fmt.Errorf("listing convoy members for bead %q: %w", root.ID, err)
+		}
+		for _, member := range members {
+			upsert(member)
+		}
 	}
 
 	parentEdges := make([]workflowDepResponse, 0)

--- a/internal/api/handler_beads_graph_test.go
+++ b/internal/api/handler_beads_graph_test.go
@@ -138,6 +138,46 @@ func TestBeadGraphIncludesParentChildChildrenAndEdges(t *testing.T) {
 	}
 }
 
+func TestBeadGraphIncludesTracksConvoyMembersAndEdges(t *testing.T) {
+	state := newFakeState(t)
+	store := state.stores["myrig"]
+	h := newTestCityHandler(t, state)
+
+	convoy, err := store.Create(beads.Bead{Title: "Convoy", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("Create(convoy): %v", err)
+	}
+	child, err := store.Create(beads.Bead{Title: "Child", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	if err := store.DepAdd(convoy.ID, child.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+
+	rec, resp := getGraph(t, h, state, convoy.ID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	beadIDs := map[string]bool{}
+	for _, b := range resp.Beads {
+		beadIDs[b.ID] = true
+	}
+	for _, id := range []string{convoy.ID, child.ID} {
+		if !beadIDs[id] {
+			t.Fatalf("graph beads missing %s; got %#v", id, resp.Beads)
+		}
+	}
+
+	for _, dep := range resp.Deps {
+		if dep.From == child.ID && dep.To == convoy.ID && dep.Kind == "tracks" {
+			return
+		}
+	}
+	t.Fatalf("missing tracks edge %s -> %s; deps=%#v", child.ID, convoy.ID, resp.Deps)
+}
+
 func TestBeadGraphReturnsErrorWhenGraphListFails(t *testing.T) {
 	state := newFakeState(t)
 	base := state.stores["myrig"]

--- a/internal/convoy/convoy_test.go
+++ b/internal/convoy/convoy_test.go
@@ -237,6 +237,23 @@ func TestConvoyAddItemsOps(t *testing.T) {
 	requireTracksDep(t, store, convoy.ID, b1.ID)
 }
 
+func TestUntrackItemFailsOnAmbiguousMixedDependencyTypes(t *testing.T) {
+	store := beads.NewMemStore()
+	convoy, _ := store.Create(beads.Bead{Title: "test", Type: "convoy"})
+	item, _ := store.Create(beads.Bead{Title: "task"})
+	if err := store.DepAdd(convoy.ID, item.ID, "parent-child"); err != nil {
+		t.Fatalf("DepAdd(parent-child): %v", err)
+	}
+	if err := store.DepAdd(convoy.ID, item.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+
+	if err := UntrackItem(store, convoy.ID, item.ID); err == nil {
+		t.Fatal("UntrackItem succeeded for mixed dependency types, want error")
+	}
+	requireTracksDep(t, store, convoy.ID, item.ID)
+}
+
 func TestConvoyCloseOps(t *testing.T) {
 	store := beads.NewMemStore()
 	deps := testConvoyDeps(store)

--- a/internal/convoy/membership.go
+++ b/internal/convoy/membership.go
@@ -33,6 +33,28 @@ func TrackItem(store beads.Store, convoyID, itemID string) error {
 
 // UntrackItem removes a convoy membership edge from convoyID to itemID.
 func UntrackItem(store beads.Store, convoyID, itemID string) error {
+	deps, err := store.DepList(convoyID, "down")
+	if err != nil {
+		return fmt.Errorf("listing convoy %s dependencies: %w", convoyID, err)
+	}
+	hasTrack := false
+	var mixedTypes []string
+	for _, dep := range deps {
+		if dep.IssueID != convoyID || dep.DependsOnID != itemID {
+			continue
+		}
+		if dep.Type == TrackingDepType {
+			hasTrack = true
+			continue
+		}
+		mixedTypes = append(mixedTypes, dep.Type)
+	}
+	if !hasTrack {
+		return nil
+	}
+	if len(mixedTypes) > 0 {
+		return fmt.Errorf("not removing ambiguous %s dependency %s -> %s with other dependency types: %v", TrackingDepType, convoyID, itemID, mixedTypes)
+	}
 	if err := store.DepRemove(convoyID, itemID); err != nil {
 		return fmt.Errorf("removing %s dependency %s -> %s: %w", TrackingDepType, convoyID, itemID, err)
 	}
@@ -99,6 +121,12 @@ func unresolvedTrackedItem(id string) beads.Bead {
 		Type:   "task",
 		Status: trackedStatusUnknown,
 	}
+}
+
+// IsUnresolvedTrackedItem reports whether b is a synthetic placeholder for a
+// dangling tracks dependency whose target bead is unavailable.
+func IsUnresolvedTrackedItem(b beads.Bead) bool {
+	return b.Status == trackedStatusUnknown && b.Type == "task" && b.Title == b.ID
 }
 
 // HasTrack reports whether convoyID has a tracks dependency to itemID.

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -346,6 +346,11 @@ func needsConvoyRecovery(q BeadQuerier, b beads.Bead, deps SlingDeps, opts BeadC
 	if sourceworkflow.IsWorkflowRoot(parent) {
 		return false
 	}
+	// Ordinary parent beads do not own the routing lifecycle. A routed child
+	// without a live tracking convoy needs finalize to run again so the missing
+	// auto-convoy can be recreated; finalize is idempotent for an already-routed
+	// bead because CheckBeadState preserves the routed metadata and only repairs
+	// the missing tracking attachment.
 	return true
 }
 

--- a/internal/sling/sling_attachment.go
+++ b/internal/sling/sling_attachment.go
@@ -340,7 +340,13 @@ func needsConvoyRecovery(q BeadQuerier, b beads.Bead, deps SlingDeps, opts BeadC
 	if err != nil {
 		return true
 	}
-	return parent.Type == "convoy" && parent.Status == "closed"
+	if parent.Type == "convoy" {
+		return convoycore.IsTerminalStatus(parent.Status)
+	}
+	if sourceworkflow.IsWorkflowRoot(parent) {
+		return false
+	}
+	return true
 }
 
 func hasLiveTrackingConvoy(store beads.Store, itemID string) bool {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -534,9 +534,16 @@ func TestCheckBeadStateRoutedWithClosedConvoyIsNotIdempotent(t *testing.T) {
 	}
 }
 
-func TestCheckBeadStateRoutedWithLiveNonConvoyParentIsIdempotent(t *testing.T) {
+func TestCheckBeadStateRoutedWithWorkflowParentIsIdempotent(t *testing.T) {
 	store := beads.NewMemStore()
-	parent, err := store.Create(beads.Bead{Title: "workflow", Type: "workflow", Status: "in_progress"})
+	parent, err := store.Create(beads.Bead{
+		Title:  "workflow",
+		Type:   "workflow",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
 	if err != nil {
 		t.Fatalf("store.Create(parent): %v", err)
 	}
@@ -554,7 +561,31 @@ func TestCheckBeadStateRoutedWithLiveNonConvoyParentIsIdempotent(t *testing.T) {
 	result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
 
 	if !result.Idempotent {
-		t.Fatalf("expected Idempotent=true for routed bead under live non-convoy parent, got %+v", result)
+		t.Fatalf("expected Idempotent=true for routed bead under workflow parent, got %+v", result)
+	}
+}
+
+func TestCheckBeadStateRoutedWithNormalParentWithoutTrackingConvoyRecovers(t *testing.T) {
+	store := beads.NewMemStore()
+	parent, err := store.Create(beads.Bead{Title: "epic", Type: "epic", Status: "open"})
+	if err != nil {
+		t.Fatalf("store.Create(parent): %v", err)
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    "epic child",
+		Type:     "task",
+		Status:   "open",
+		ParentID: parent.ID,
+		Metadata: map[string]string{"gc.routed_to": "mayor"},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(bead): %v", err)
+	}
+
+	result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+	if result.Idempotent {
+		t.Fatalf("expected Idempotent=false for routed bead under normal parent with no tracking convoy, got %+v", result)
 	}
 }
 

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -535,33 +535,60 @@ func TestCheckBeadStateRoutedWithClosedConvoyIsNotIdempotent(t *testing.T) {
 }
 
 func TestCheckBeadStateRoutedWithWorkflowParentIsIdempotent(t *testing.T) {
-	store := beads.NewMemStore()
-	parent, err := store.Create(beads.Bead{
-		Title:  "workflow",
-		Type:   "workflow",
-		Status: "in_progress",
-		Metadata: map[string]string{
-			"gc.kind": "workflow",
+	tests := []struct {
+		name     string
+		metadata map[string]string
+	}{
+		{
+			name: "workflow kind",
+			metadata: map[string]string{
+				"gc.kind": "workflow",
+			},
 		},
-	})
-	if err != nil {
-		t.Fatalf("store.Create(parent): %v", err)
-	}
-	bead, err := store.Create(beads.Bead{
-		Title:    "workflow step",
-		Type:     "task",
-		Status:   "open",
-		ParentID: parent.ID,
-		Metadata: map[string]string{"gc.routed_to": "mayor"},
-	})
-	if err != nil {
-		t.Fatalf("store.Create(bead): %v", err)
+		{
+			name: "graph v2 contract",
+			metadata: map[string]string{
+				"gc.formula_contract": "graph.v2",
+			},
+		},
+		{
+			name: "workflow kind and graph v2 contract",
+			metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+			},
+		},
 	}
 
-	result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			parent, err := store.Create(beads.Bead{
+				Title:    "workflow",
+				Type:     "workflow",
+				Status:   "in_progress",
+				Metadata: tt.metadata,
+			})
+			if err != nil {
+				t.Fatalf("store.Create(parent): %v", err)
+			}
+			bead, err := store.Create(beads.Bead{
+				Title:    "workflow step",
+				Type:     "task",
+				Status:   "open",
+				ParentID: parent.ID,
+				Metadata: map[string]string{"gc.routed_to": "mayor"},
+			})
+			if err != nil {
+				t.Fatalf("store.Create(bead): %v", err)
+			}
 
-	if !result.Idempotent {
-		t.Fatalf("expected Idempotent=true for routed bead under workflow parent, got %+v", result)
+			result := CheckBeadState(store, bead.ID, config.Agent{Name: "mayor"}, SlingDeps{Store: store})
+
+			if !result.Idempotent {
+				t.Fatalf("expected Idempotent=true for routed bead under workflow parent, got %+v", result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up for post-merge review of #1105.

This repairs the tracks-based convoy gaps found after the original merge:

- recover already-routed normal hierarchy children when auto-convoy tracking is missing, while preserving workflow-parent idempotency
- expand tracks-based convoy members in `gc graph` and the bead graph API
- avoid reporting dangling tracks placeholders as ordinary stranded work
- make convoy untracking fail on ambiguous mixed dependency types instead of risking removal of the wrong edge

## Verification

- `go test ./internal/convoy`
- `go test ./internal/sling`
- `go test ./internal/api`
- `go test ./cmd/gc -run 'TestDoSlingKeepsWorkflowParentIdempotent|TestGraphConvoyExpansionUsesTracksDependencies|TestConvoyStrandedIgnoresDanglingTracks'`
- `make dashboard-check`
- `make test-fast-parallel`
- `go vet ./...`
- pre-commit hook ran during commit
