### PR TITLE
fix(pool): idle timeout now reaches ephemeral pool sessions

### DIFF
--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -183,17 +183,21 @@ var startVerboseMode bool
 // timeouts for agents that have idle_timeout set. Returns nil if no
 // agents use idle timeout (disabled).
 //
-// Two registration paths:
-//   - Named sessions (and singletons whose name is the qualified template)
-//     register a per-session-name timeout — their runtime name is stable
-//     and known at startup.
-//   - Pool agents register a per-template timeout. Their runtime session
-//     names carry per-instance bead IDs that are minted later when work
-//     is slung; static slot enumeration (worker-1, worker-2, ...) does
-//     not match those names, so per-name registration silently misses
-//     every pool session. The reconciler's checkIdle call site supplies
-//     the template name and the tracker falls back to it.
-func buildIdleTracker(cfg *config.City, cityName, _ string, _ runtime.Provider) idleTracker {
+// Two registration paths, complementary rather than exclusive:
+//   - Per-session-name registration via discoverPoolInstances covers stable
+//     identities known at startup: configured named sessions, canonical
+//     singleton pool members, namepool members ("furiosa"), and any
+//     currently-running stale "{name}-N" suffixes a previous pool layout
+//     left behind. Tests assert these exact keys, and the reconciler still
+//     hits them via the per-name lookup.
+//   - Per-template registration covers ephemeral pool agents whose runtime
+//     session names are minted from bead IDs at sling time
+//     (e.g. "local-core__builder-fm-abc123") and never match anything a
+//     static enumeration could produce. checkIdle falls back to the
+//     template lookup when the per-name lookup misses, so canonical and
+//     namepool members keep their per-name hit while bead-derived names
+//     pick up the template's timeout.
+func buildIdleTracker(cfg *config.City, cityName, _ string, sp runtime.Provider) idleTracker {
 	var hasAny bool
 	st := cfg.Workspace.SessionTemplate
 	for _, a := range cfg.Agents {
@@ -213,27 +217,47 @@ func buildIdleTracker(cfg *config.City, cityName, _ string, _ runtime.Provider) 
 			continue
 		}
 		named := config.FindNamedSession(cfg, a.QualifiedName())
+		namedAlways := named != nil && named.ModeOrDefault() == "always"
 		if named != nil {
 			// Configured named sessions own the canonical runtime session for
 			// direct configured identities. mode="always" must never be subject
 			// to idle timeout.
-			if named.ModeOrDefault() != "always" {
+			if !namedAlways {
 				it.setTimeout(config.NamedSessionRuntimeName(cityName, cfg.Workspace, a.QualifiedName()), timeout)
 				registeredAny = true
 			}
-			// Named agents whose template also serves as a pool are an
-			// uncommon hybrid; skip pool-side template registration so the
-			// always-running named identity is not re-imposed with a
-			// timeout via the template fallback path.
-			continue
+			if !a.SupportsInstanceExpansion() {
+				continue
+			}
+			// Hybrid named-and-pool: fall through to the pool registrations
+			// below so any non-named members of the pool still pick up a
+			// timeout. The named identity's registration above takes
+			// precedence in checkIdle's per-name lookup.
 		}
-		if a.SupportsGenericEphemeralSessions() && a.SupportsInstanceExpansion() {
-			// Pool agents: runtime session names are bead-derived and minted
-			// at sling time. Register the timeout per-template so any
-			// bead-derived pool session belonging to this agent picks it up
-			// via the template fallback in checkIdle.
-			it.setTimeoutForTemplate(a.QualifiedName(), timeout)
-			registeredAny = true
+		if a.SupportsInstanceExpansion() {
+			// Per-name registration for stable instance identities.
+			// discoverPoolInstances returns canonical / namepool / live-stale
+			// names. For bounded non-namepool pools it also returns static
+			// "{name}-N" slot names — those won't match runtime bead-derived
+			// names, but registering them is harmless and keeps the existing
+			// canonical-singleton and namepool tests asserting the right keys.
+			sp0 := scaleParamsFor(&a)
+			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, st, sp) {
+				sn := startupSessionName(cityName, qualifiedInstance, st)
+				it.setTimeout(sn, timeout)
+				registeredAny = true
+			}
+			// Per-template fallback so bead-derived runtime names for pool
+			// agents (e.g. "local-core__builder-fm-abc123") still pick up
+			// this timeout via checkIdle's template lookup. Skip when an
+			// always-mode named overlay claims the agent — that overlay
+			// exempts the canonical identity from idle timeout entirely, and
+			// without it we'd silently re-impose a timeout via the template
+			// fallback for any session belonging to the agent.
+			if a.SupportsGenericEphemeralSessions() && !namedAlways {
+				it.setTimeoutForTemplate(a.QualifiedName(), timeout)
+				registeredAny = true
+			}
 			continue
 		}
 		sn := startupSessionName(cityName, a.QualifiedName(), st)

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -222,9 +222,12 @@ func buildIdleTracker(cfg *config.City, cityName, _ string, sp runtime.Provider)
 			// Configured named sessions own the canonical runtime session for
 			// direct configured identities. mode="always" must never be subject
 			// to idle timeout.
+			namedSessionName := config.NamedSessionRuntimeName(cityName, cfg.Workspace, named.QualifiedName())
 			if !namedAlways {
-				it.setTimeout(config.NamedSessionRuntimeName(cityName, cfg.Workspace, a.QualifiedName()), timeout)
+				it.setTimeout(namedSessionName, timeout)
 				registeredAny = true
+			} else {
+				it.exemptTemplateFallbackForSession(namedSessionName)
 			}
 			if !a.SupportsInstanceExpansion() {
 				continue
@@ -248,14 +251,14 @@ func buildIdleTracker(cfg *config.City, cityName, _ string, sp runtime.Provider)
 				registeredAny = true
 			}
 			// Per-template fallback so bead-derived runtime names for pool
-			// agents (e.g. "local-core__builder-fm-abc123") still pick up
-			// this timeout via checkIdle's template lookup. Skip when an
-			// always-mode named overlay claims the agent — that overlay
-			// exempts the canonical identity from idle timeout entirely, and
-			// without it we'd silently re-impose a timeout via the template
-			// fallback for any session belonging to the agent.
-			if a.SupportsGenericEphemeralSessions() && !namedAlways {
-				it.setTimeoutForTemplate(a.QualifiedName(), timeout)
+			// agents still pick up this timeout via checkIdle's template
+			// lookup. Always-mode named sessions sharing this template are
+			// exempted per runtime name below; they must not suppress idle
+			// timeout for unnamed pool siblings.
+			if a.SupportsGenericEphemeralSessions() {
+				template := lifecycleTemplateFallbackKey(a)
+				it.setTimeoutForTemplate(template, timeout)
+				exemptAlwaysNamedTemplateFallbacks(cfg, cityName, template, it.exemptTemplateFallbackForSession)
 				registeredAny = true
 			}
 			continue
@@ -296,20 +299,30 @@ func buildMaxSessionAgeTracker(cfg *config.City, cityName string, sp runtime.Pro
 		}
 		jitter := a.MaxSessionAgeJitterDuration()
 		named := config.FindNamedSession(cfg, a.QualifiedName())
+		namedAlways := named != nil && named.ModeOrDefault() == "always"
 		if named != nil {
-			if named.ModeOrDefault() != "always" {
-				tr.setConfig(config.NamedSessionRuntimeName(cityName, cfg.Workspace, a.QualifiedName()), maxAge, jitter)
+			namedSessionName := config.NamedSessionRuntimeName(cityName, cfg.Workspace, named.QualifiedName())
+			if !namedAlways {
+				tr.setConfig(namedSessionName, maxAge, jitter)
 				registeredAny = true
+			} else {
+				tr.exemptTemplateFallbackForSession(namedSessionName)
 			}
 			if !a.SupportsInstanceExpansion() {
 				continue
 			}
 		}
-		sp0 := scaleParamsFor(&a)
 		if a.SupportsInstanceExpansion() {
+			sp0 := scaleParamsFor(&a)
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, st, sp) {
 				sn := startupSessionName(cityName, qualifiedInstance, st)
 				tr.setConfig(sn, maxAge, jitter)
+				registeredAny = true
+			}
+			if a.SupportsGenericEphemeralSessions() {
+				template := lifecycleTemplateFallbackKey(a)
+				tr.setConfigForTemplate(template, maxAge, jitter)
+				exemptAlwaysNamedTemplateFallbacks(cfg, cityName, template, tr.exemptTemplateFallbackForSession)
 				registeredAny = true
 			}
 			continue
@@ -322,6 +335,23 @@ func buildMaxSessionAgeTracker(cfg *config.City, cityName string, sp runtime.Pro
 		return nil
 	}
 	return tr
+}
+
+func lifecycleTemplateFallbackKey(a config.Agent) string {
+	return a.QualifiedName()
+}
+
+func exemptAlwaysNamedTemplateFallbacks(cfg *config.City, cityName, template string, exempt func(string)) {
+	if cfg == nil || template == "" || exempt == nil {
+		return
+	}
+	for i := range cfg.NamedSessions {
+		named := &cfg.NamedSessions[i]
+		if named.ModeOrDefault() != "always" || named.TemplateQualifiedName() != template {
+			continue
+		}
+		exempt(config.NamedSessionRuntimeName(cityName, cfg.Workspace, named.QualifiedName()))
+	}
 }
 
 func newStartCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -182,7 +182,18 @@ var startVerboseMode bool
 // buildIdleTracker creates an idleTracker from the config, populating
 // timeouts for agents that have idle_timeout set. Returns nil if no
 // agents use idle timeout (disabled).
-func buildIdleTracker(cfg *config.City, cityName, _ string, sp runtime.Provider) idleTracker {
+//
+// Two registration paths:
+//   - Named sessions (and singletons whose name is the qualified template)
+//     register a per-session-name timeout — their runtime name is stable
+//     and known at startup.
+//   - Pool agents register a per-template timeout. Their runtime session
+//     names carry per-instance bead IDs that are minted later when work
+//     is slung; static slot enumeration (worker-1, worker-2, ...) does
+//     not match those names, so per-name registration silently misses
+//     every pool session. The reconciler's checkIdle call site supplies
+//     the template name and the tracker falls back to it.
+func buildIdleTracker(cfg *config.City, cityName, _ string, _ runtime.Provider) idleTracker {
 	var hasAny bool
 	st := cfg.Workspace.SessionTemplate
 	for _, a := range cfg.Agents {
@@ -210,18 +221,19 @@ func buildIdleTracker(cfg *config.City, cityName, _ string, sp runtime.Provider)
 				it.setTimeout(config.NamedSessionRuntimeName(cityName, cfg.Workspace, a.QualifiedName()), timeout)
 				registeredAny = true
 			}
-			if !a.SupportsInstanceExpansion() {
-				continue
-			}
+			// Named agents whose template also serves as a pool are an
+			// uncommon hybrid; skip pool-side template registration so the
+			// always-running named identity is not re-imposed with a
+			// timeout via the template fallback path.
+			continue
 		}
-		sp0 := scaleParamsFor(&a)
-		if a.SupportsInstanceExpansion() {
-			// Register each pool instance (worker-1, worker-2, ...).
-			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, st, sp) {
-				sn := startupSessionName(cityName, qualifiedInstance, st)
-				it.setTimeout(sn, timeout)
-				registeredAny = true
-			}
+		if a.SupportsGenericEphemeralSessions() && a.SupportsInstanceExpansion() {
+			// Pool agents: runtime session names are bead-derived and minted
+			// at sling time. Register the timeout per-template so any
+			// bead-derived pool session belonging to this agent picks it up
+			// via the template fallback in checkIdle.
+			it.setTimeoutForTemplate(a.QualifiedName(), timeout)
+			registeredAny = true
 			continue
 		}
 		sn := startupSessionName(cityName, a.QualifiedName(), st)

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -244,6 +244,337 @@ func TestBuildLifecycleTrackers_CanonicalSingletonNamedSessionOverlayOneKey(t *t
 	}
 }
 
+func TestBuildIdleTracker_PoolAgentTemplateFallbackMatchesReconcilerTemplate(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		Agents: []config.Agent{
+			{
+				Name:              "builder",
+				Dir:               "local-core",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(5),
+				IdleTimeout:       "1h",
+			},
+		},
+	}
+	template := cfg.Agents[0].QualifiedName()
+	sessionName := sessionNameFromBeadID("fm-r56l0x")
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	sp := runtime.NewFake()
+	startFakeSession(t, sp, sessionName)
+	sp.SetActivity(sessionName, now.Add(-90*time.Minute))
+
+	idle, ok := buildIdleTracker(cfg, "city", "", sp).(*memoryIdleTracker)
+	if !ok {
+		t.Fatalf("buildIdleTracker returned %T, want *memoryIdleTracker", idle)
+	}
+	if _, ok := idle.templateTimeouts[template]; !ok {
+		t.Fatalf("idle tracker missing template %q in %v", template, idle.templateTimeouts)
+	}
+	if !idle.checkIdle(sessionName, template, sp, now) {
+		t.Fatalf("pool session %q did not idle out via template %q", sessionName, template)
+	}
+}
+
+func TestBuildIdleTracker_NamedOnDemandPoolRegistersNameAndTemplate(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		Agents: []config.Agent{
+			{
+				Name:              "builder",
+				Dir:               "local-core",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(5),
+				IdleTimeout:       "1h",
+			},
+		},
+		NamedSessions: []config.NamedSession{{
+			Template: "builder",
+			Dir:      "local-core",
+		}},
+	}
+	template := cfg.Agents[0].QualifiedName()
+	namedSession := config.NamedSessionRuntimeName("city", cfg.Workspace, template)
+	poolSession := sessionNameFromBeadID("fm-r56l0x")
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	sp := runtime.NewFake()
+	startFakeSession(t, sp, namedSession)
+	startFakeSession(t, sp, poolSession)
+	sp.SetActivity(namedSession, now.Add(-90*time.Minute))
+	sp.SetActivity(poolSession, now.Add(-90*time.Minute))
+
+	idle, ok := buildIdleTracker(cfg, "city", "", sp).(*memoryIdleTracker)
+	if !ok {
+		t.Fatalf("buildIdleTracker returned %T, want *memoryIdleTracker", idle)
+	}
+	if _, ok := idle.timeouts[namedSession]; !ok {
+		t.Fatalf("idle tracker missing named session %q in %v", namedSession, idle.timeouts)
+	}
+	if _, ok := idle.templateTimeouts[template]; !ok {
+		t.Fatalf("idle tracker missing named pool template %q in %v", template, idle.templateTimeouts)
+	}
+	if !idle.checkIdle(namedSession, template, sp, now) {
+		t.Fatalf("named session %q did not idle out via per-name timeout", namedSession)
+	}
+	if !idle.checkIdle(poolSession, template, sp, now) {
+		t.Fatalf("pool session %q did not inherit template idle timeout", poolSession)
+	}
+}
+
+func TestBuildIdleTracker_NamedAlwaysPoolExemptsNamedOnly(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		Agents: []config.Agent{
+			{
+				Name:              "builder",
+				Dir:               "local-core",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(5),
+				IdleTimeout:       "1h",
+			},
+		},
+		NamedSessions: []config.NamedSession{{
+			Template: "builder",
+			Dir:      "local-core",
+			Mode:     "always",
+		}},
+	}
+	template := cfg.Agents[0].QualifiedName()
+	namedSession := config.NamedSessionRuntimeName("city", cfg.Workspace, template)
+	poolSession := sessionNameFromBeadID("fm-r56l0x")
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	sp := runtime.NewFake()
+	startFakeSession(t, sp, namedSession)
+	startFakeSession(t, sp, poolSession)
+	sp.SetActivity(namedSession, now.Add(-90*time.Minute))
+	sp.SetActivity(poolSession, now.Add(-90*time.Minute))
+
+	idle, ok := buildIdleTracker(cfg, "city", "", sp).(*memoryIdleTracker)
+	if !ok {
+		t.Fatalf("buildIdleTracker returned %T, want *memoryIdleTracker", idle)
+	}
+	if _, ok := idle.templateTimeouts[template]; !ok {
+		t.Fatalf("idle tracker missing named pool template %q in %v", template, idle.templateTimeouts)
+	}
+	if idle.checkIdle(namedSession, template, sp, now) {
+		t.Fatalf("always named session %q must not inherit template idle timeout", namedSession)
+	}
+	if !idle.checkIdle(poolSession, template, sp, now) {
+		t.Fatalf("pool session %q did not inherit template idle timeout", poolSession)
+	}
+}
+
+func TestBuildIdleTracker_AliasAlwaysNamedPoolExemptsAliasOnly(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		Agents: []config.Agent{
+			{
+				Name:              "builder",
+				Dir:               "local-core",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(5),
+				IdleTimeout:       "1h",
+			},
+		},
+		NamedSessions: []config.NamedSession{{
+			Name:     "primary",
+			Template: "builder",
+			Dir:      "local-core",
+			Mode:     "always",
+		}},
+	}
+	template := cfg.Agents[0].QualifiedName()
+	namedSession := config.NamedSessionRuntimeName("city", cfg.Workspace, cfg.NamedSessions[0].QualifiedName())
+	poolSession := sessionNameFromBeadID("fm-r56l0x")
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	sp := runtime.NewFake()
+	startFakeSession(t, sp, namedSession)
+	startFakeSession(t, sp, poolSession)
+	sp.SetActivity(namedSession, now.Add(-90*time.Minute))
+	sp.SetActivity(poolSession, now.Add(-90*time.Minute))
+
+	idle, ok := buildIdleTracker(cfg, "city", "", sp).(*memoryIdleTracker)
+	if !ok {
+		t.Fatalf("buildIdleTracker returned %T, want *memoryIdleTracker", idle)
+	}
+	if idle.checkIdle(namedSession, template, sp, now) {
+		t.Fatalf("alias always-named session %q must not inherit template idle timeout", namedSession)
+	}
+	if !idle.checkIdle(poolSession, template, sp, now) {
+		t.Fatalf("pool session %q did not inherit template idle timeout", poolSession)
+	}
+}
+
+func TestBuildIdleTracker_NamedAlwaysNoExplicitPoolRegistersTemplateFallback(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		Agents: []config.Agent{
+			{
+				Name:        "builder",
+				Dir:         "local-core",
+				IdleTimeout: "1h",
+			},
+		},
+		NamedSessions: []config.NamedSession{{
+			Template: "builder",
+			Dir:      "local-core",
+			Mode:     "always",
+		}},
+	}
+	template := cfg.Agents[0].QualifiedName()
+	namedSession := config.NamedSessionRuntimeName("city", cfg.Workspace, template)
+	poolSession := sessionNameFromBeadID("fm-r56l0x")
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	sp := runtime.NewFake()
+	startFakeSession(t, sp, namedSession)
+	startFakeSession(t, sp, poolSession)
+	sp.SetActivity(namedSession, now.Add(-90*time.Minute))
+	sp.SetActivity(poolSession, now.Add(-90*time.Minute))
+
+	idle, ok := buildIdleTracker(cfg, "city", "", sp).(*memoryIdleTracker)
+	if !ok {
+		t.Fatalf("buildIdleTracker returned %T, want *memoryIdleTracker", idle)
+	}
+	if _, ok := idle.templateTimeouts[template]; !ok {
+		t.Fatalf("idle tracker missing template %q in %v", template, idle.templateTimeouts)
+	}
+	if idle.checkIdle(namedSession, template, sp, now) {
+		t.Fatalf("always named session %q must not inherit template idle timeout", namedSession)
+	}
+	if !idle.checkIdle(poolSession, template, sp, now) {
+		t.Fatalf("pool session %q did not inherit template idle timeout", poolSession)
+	}
+}
+
+func TestBuildMaxSessionAgeTracker_PoolAgentTemplateFallback(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		Agents: []config.Agent{
+			{
+				Name:              "builder",
+				Dir:               "local-core",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(5),
+				MaxSessionAge:     "1h",
+			},
+		},
+	}
+	template := cfg.Agents[0].QualifiedName()
+	sessionName := sessionNameFromBeadID("fm-r56l0x")
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	maxAge, ok := buildMaxSessionAgeTracker(cfg, "city", runtime.NewFake()).(*memoryMaxSessionAgeTracker)
+	if !ok {
+		t.Fatalf("buildMaxSessionAgeTracker returned %T, want *memoryMaxSessionAgeTracker", maxAge)
+	}
+	if _, ok := maxAge.templateConfigs[template]; !ok {
+		t.Fatalf("max-age tracker missing template %q in %v", template, maxAge.templateConfigs)
+	}
+	if !maxAge.shouldRestart(sessionName, template, now.Add(-2*time.Hour), now) {
+		t.Fatalf("pool session %q did not max-age restart via template %q", sessionName, template)
+	}
+}
+
+func TestBuildMaxSessionAgeTracker_NamedAlwaysNoExplicitPoolRegistersTemplateFallback(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		Agents: []config.Agent{
+			{
+				Name:          "builder",
+				Dir:           "local-core",
+				MaxSessionAge: "1h",
+			},
+		},
+		NamedSessions: []config.NamedSession{{
+			Template: "builder",
+			Dir:      "local-core",
+			Mode:     "always",
+		}},
+	}
+	template := cfg.Agents[0].QualifiedName()
+	namedSession := config.NamedSessionRuntimeName("city", cfg.Workspace, template)
+	poolSession := sessionNameFromBeadID("fm-r56l0x")
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	maxAge, ok := buildMaxSessionAgeTracker(cfg, "city", runtime.NewFake()).(*memoryMaxSessionAgeTracker)
+	if !ok {
+		t.Fatalf("buildMaxSessionAgeTracker returned %T, want *memoryMaxSessionAgeTracker", maxAge)
+	}
+	if _, ok := maxAge.templateConfigs[template]; !ok {
+		t.Fatalf("max-age tracker missing template %q in %v", template, maxAge.templateConfigs)
+	}
+	if maxAge.shouldRestart(namedSession, template, now.Add(-2*time.Hour), now) {
+		t.Fatalf("always named session %q must not inherit template max age", namedSession)
+	}
+	if !maxAge.shouldRestart(poolSession, template, now.Add(-2*time.Hour), now) {
+		t.Fatalf("pool session %q did not max-age restart via template %q", poolSession, template)
+	}
+}
+
+func TestLifecycleTemplateFallbackKeyMatchesTemplateParamsTemplateName(t *testing.T) {
+	agent := config.Agent{
+		Name:              "builder",
+		Dir:               "local-core",
+		MaxActiveSessions: intPtr(5),
+	}
+	template := lifecycleTemplateFallbackKey(agent)
+	if want := agent.QualifiedName(); template != want {
+		t.Fatalf("lifecycleTemplateFallbackKey = %q, want %q", template, want)
+	}
+
+	poolAgent, qualifiedInstance, _ := poolDesiredRequestIdentity(&agent, 1)
+	if got := templateNameFor(poolAgent, qualifiedInstance); got != template {
+		t.Fatalf("pool TemplateName = %q, want lifecycle fallback key %q", got, template)
+	}
+	namedIdentity := "local-core/primary"
+	if got := templateNameFor(&agent, namedIdentity); got != template {
+		t.Fatalf("named TemplateName = %q, want lifecycle fallback key %q", got, template)
+	}
+	if got := templateNameFor(&agent, agent.QualifiedName()); got != template {
+		t.Fatalf("base TemplateName = %q, want lifecycle fallback key %q", got, template)
+	}
+}
+
+func TestExemptAlwaysNamedTemplateFallbacksUsesBindingQualifiedRuntimeName(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{},
+		NamedSessions: []config.NamedSession{
+			{
+				Name:     "primary",
+				Template: "builder",
+				Dir:      "local-core",
+				Mode:     "always",
+			},
+			{
+				Name:     "secondary",
+				Template: "builder",
+				Dir:      "local-core",
+				Mode:     "on_demand",
+			},
+			{
+				Name:     "other",
+				Template: "reviewer",
+				Dir:      "local-core",
+				Mode:     "always",
+			},
+		},
+	}
+	template := "local-core/builder"
+	want := config.NamedSessionRuntimeName("city", cfg.Workspace, "local-core/primary")
+	var got []string
+
+	exemptAlwaysNamedTemplateFallbacks(cfg, "city", template, func(sessionName string) {
+		got = append(got, sessionName)
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("exempt callback called %d times, want 1: %v", len(got), got)
+	}
+	if got[0] != want {
+		t.Fatalf("exempted session = %q, want %q", got[0], want)
+	}
+}
+
 func TestStandaloneBuildAgentsFnWithSessionBeads_UsesRigStoresForAssignedWork(t *testing.T) {
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -610,10 +610,22 @@ func TestBuildIdleTracker_SkipsAlwaysNamedSessionIdleTimeout(t *testing.T) {
 	}
 
 	sp := runtime.NewFake()
-	sp.SetActivity("mayor", time.Now().Add(-10*time.Minute))
+	startFakeSession(t, sp, "mayor")
+	now := time.Now()
+	sp.SetActivity("mayor", now.Add(-10*time.Minute))
 
-	if tracker := buildIdleTracker(cfg, "test", dir, sp); tracker != nil {
-		t.Fatalf("buildIdleTracker(cfg) = %#v, want nil for always-named singleton", tracker)
+	tracker, ok := buildIdleTracker(cfg, "test", dir, sp).(*memoryIdleTracker)
+	if !ok {
+		t.Fatalf("buildIdleTracker(cfg) = %T, want *memoryIdleTracker with named fallback exemption", tracker)
+	}
+	if _, ok := tracker.templateTimeouts["mayor"]; !ok {
+		t.Fatalf("templateTimeouts = %v, want mayor fallback registered", tracker.templateTimeouts)
+	}
+	if !tracker.templateFallbackExemptions["mayor"] {
+		t.Fatalf("templateFallbackExemptions = %v, want mayor exempt", tracker.templateFallbackExemptions)
+	}
+	if tracker.checkIdle("mayor", "mayor", sp, now) {
+		t.Fatalf("always-named session inherited template idle timeout")
 	}
 }
 

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -1249,7 +1249,7 @@ func TestControllerReloadsNamedSessionModeAndAppliesIdleTimeout(t *testing.T) {
 	if !ok || tracker == nil {
 		t.Fatal("buildIdleTracker(parsedCfg) = nil, want tracker")
 	}
-	if !tracker.checkIdle("mayor", sp, time.Now()) {
+	if !tracker.checkIdle("mayor", "", sp, time.Now()) {
 		t.Fatalf("fresh idle tracker did not consider mayor idle; activity=%v timeouts=%v", sp.Activity["mayor"], tracker.timeouts)
 	}
 

--- a/cmd/gc/idle_tracker.go
+++ b/cmd/gc/idle_tracker.go
@@ -41,21 +41,28 @@ type idleTracker interface {
 	// runtime session names carry per-instance bead IDs and cannot be
 	// enumerated up front. Duration of 0 clears the entry.
 	setTimeoutForTemplate(template string, timeout time.Duration)
+
+	// exemptTemplateFallbackForSession prevents one stable session from
+	// inheriting the template timeout. Used for mode="always" named sessions
+	// that share a template with pool siblings.
+	exemptTemplateFallbackForSession(sessionName string)
 }
 
 // memoryIdleTracker is the production implementation of idleTracker.
 type memoryIdleTracker struct {
-	mu               sync.Mutex
-	timeouts         map[string]time.Duration // session name → idle timeout
-	templateTimeouts map[string]time.Duration // agent template → idle timeout
+	mu                         sync.Mutex
+	timeouts                   map[string]time.Duration // session name → idle timeout
+	templateTimeouts           map[string]time.Duration // agent template → idle timeout
+	templateFallbackExemptions map[string]bool          // session name → skip template fallback
 }
 
 // newIdleTracker creates an idle tracker. Returns nil if disabled.
 // Callers check for nil before using.
 func newIdleTracker() *memoryIdleTracker {
 	return &memoryIdleTracker{
-		timeouts:         make(map[string]time.Duration),
-		templateTimeouts: make(map[string]time.Duration),
+		timeouts:                   make(map[string]time.Duration),
+		templateTimeouts:           make(map[string]time.Duration),
+		templateFallbackExemptions: make(map[string]bool),
 	}
 }
 
@@ -70,6 +77,9 @@ func (m *memoryIdleTracker) setTimeout(sessionName string, timeout time.Duration
 }
 
 func (m *memoryIdleTracker) setTimeoutForTemplate(template string, timeout time.Duration) {
+	if template == "" {
+		return
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if timeout <= 0 {
@@ -79,10 +89,20 @@ func (m *memoryIdleTracker) setTimeoutForTemplate(template string, timeout time.
 	m.templateTimeouts[template] = timeout
 }
 
+func (m *memoryIdleTracker) exemptTemplateFallbackForSession(sessionName string) {
+	if sessionName == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.templateFallbackExemptions[sessionName] = true
+}
+
 func (m *memoryIdleTracker) checkIdle(sessionName, template string, sp runtime.Provider, now time.Time) bool {
 	m.mu.Lock()
 	timeout, ok := m.timeouts[sessionName]
-	if !ok && template != "" {
+	exempt := m.templateFallbackExemptions[sessionName]
+	if !ok && !exempt && template != "" {
 		timeout, ok = m.templateTimeouts[template]
 	}
 	m.mu.Unlock()

--- a/cmd/gc/idle_tracker.go
+++ b/cmd/gc/idle_tracker.go
@@ -10,27 +10,52 @@ import (
 // idleTracker checks for agents that have been idle longer than their
 // configured timeout. Nil means idle checking is disabled (backward
 // compatible). Follows the same nil-guard pattern as crashTracker.
+//
+// Timeouts may be registered two ways:
+//   - Per session name (setTimeout) for sessions whose runtime names are
+//     stable and knowable at controller startup — mainly configured named
+//     sessions like mayor.
+//   - Per agent template (setTimeoutForTemplate) for ephemeral pool agents
+//     whose runtime session names are bead-derived and minted as work is
+//     slung. Static slot enumeration (worker-1, worker-2, ...) does not
+//     match those names, so a per-name registration silently misses every
+//     pool session.
+//
+// checkIdle resolves a timeout by checking the session name first and
+// falling back to the template — preserving named-session behavior while
+// also covering bead-derived pool session names.
 type idleTracker interface {
 	// checkIdle returns true if the agent has been idle longer than its
-	// configured timeout. Queries sp.GetLastActivity().
-	checkIdle(sessionName string, sp runtime.Provider, now time.Time) bool
+	// configured timeout. Queries sp.GetLastActivity(). template is the
+	// agent's qualified template name and is used as a fallback lookup
+	// when the session name is not registered directly (pool sessions).
+	checkIdle(sessionName, template string, sp runtime.Provider, now time.Time) bool
 
-	// setTimeout configures the idle timeout for a session name.
-	// Called during agent list construction. Duration of 0 disables.
+	// setTimeout configures the idle timeout for a single session name.
+	// Used for sessions whose runtime names are deterministic at startup
+	// (configured named sessions). Duration of 0 clears the entry.
 	setTimeout(sessionName string, timeout time.Duration)
+
+	// setTimeoutForTemplate configures the idle timeout for every session
+	// belonging to an agent template. Used for ephemeral pool agents whose
+	// runtime session names carry per-instance bead IDs and cannot be
+	// enumerated up front. Duration of 0 clears the entry.
+	setTimeoutForTemplate(template string, timeout time.Duration)
 }
 
 // memoryIdleTracker is the production implementation of idleTracker.
 type memoryIdleTracker struct {
-	mu       sync.Mutex
-	timeouts map[string]time.Duration // session → idle timeout
+	mu               sync.Mutex
+	timeouts         map[string]time.Duration // session name → idle timeout
+	templateTimeouts map[string]time.Duration // agent template → idle timeout
 }
 
 // newIdleTracker creates an idle tracker. Returns nil if disabled.
 // Callers check for nil before using.
 func newIdleTracker() *memoryIdleTracker {
 	return &memoryIdleTracker{
-		timeouts: make(map[string]time.Duration),
+		timeouts:         make(map[string]time.Duration),
+		templateTimeouts: make(map[string]time.Duration),
 	}
 }
 
@@ -44,9 +69,22 @@ func (m *memoryIdleTracker) setTimeout(sessionName string, timeout time.Duration
 	m.timeouts[sessionName] = timeout
 }
 
-func (m *memoryIdleTracker) checkIdle(sessionName string, sp runtime.Provider, now time.Time) bool {
+func (m *memoryIdleTracker) setTimeoutForTemplate(template string, timeout time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if timeout <= 0 {
+		delete(m.templateTimeouts, template)
+		return
+	}
+	m.templateTimeouts[template] = timeout
+}
+
+func (m *memoryIdleTracker) checkIdle(sessionName, template string, sp runtime.Provider, now time.Time) bool {
 	m.mu.Lock()
 	timeout, ok := m.timeouts[sessionName]
+	if !ok && template != "" {
+		timeout, ok = m.templateTimeouts[template]
+	}
 	m.mu.Unlock()
 	if !ok || timeout <= 0 {
 		return false

--- a/cmd/gc/idle_tracker_test.go
+++ b/cmd/gc/idle_tracker_test.go
@@ -52,16 +52,16 @@ func TestIdleTracker_TemplateFallbackResolvesPoolSession(t *testing.T) {
 	t.Parallel()
 
 	it := newIdleTracker()
-	it.setTimeoutForTemplate("local-core.builder", 1*time.Hour)
+	template := "local-core/builder"
+	it.setTimeoutForTemplate(template, 1*time.Hour)
 
 	sp := runtime.NewFake()
-	// Bead-derived runtime name — not the static "local-core__builder-1" form.
-	sessionName := "local-core__builder-fm-miv1io"
+	sessionName := sessionNameFromBeadID("fm-miv1io")
 	startFakeSession(t, sp, sessionName)
 	now := time.Now()
 	sp.SetActivity(sessionName, now.Add(-90*time.Minute))
 
-	if !it.checkIdle(sessionName, "local-core.builder", sp, now) {
+	if !it.checkIdle(sessionName, template, sp, now) {
 		t.Fatalf("checkIdle did not fire for pool session via template fallback (90m idle vs 1h timeout)")
 	}
 }
@@ -75,10 +75,10 @@ func TestIdleTracker_TemplateFallbackDoesNotApplyWithoutTemplate(t *testing.T) {
 	t.Parallel()
 
 	it := newIdleTracker()
-	it.setTimeoutForTemplate("local-core.builder", 1*time.Hour)
+	it.setTimeoutForTemplate("local-core/builder", 1*time.Hour)
 
 	sp := runtime.NewFake()
-	sessionName := "local-core__builder-fm-anonymous"
+	sessionName := sessionNameFromBeadID("fm-anonymous")
 	startFakeSession(t, sp, sessionName)
 	now := time.Now()
 	sp.SetActivity(sessionName, now.Add(-90*time.Minute))
@@ -118,16 +118,28 @@ func TestIdleTracker_SetTimeoutForTemplateZeroClears(t *testing.T) {
 	t.Parallel()
 
 	it := newIdleTracker()
-	it.setTimeoutForTemplate("local-core.builder", 1*time.Hour)
-	it.setTimeoutForTemplate("local-core.builder", 0)
+	template := "local-core/builder"
+	it.setTimeoutForTemplate(template, 1*time.Hour)
+	it.setTimeoutForTemplate(template, 0)
 
 	sp := runtime.NewFake()
-	sessionName := "local-core__builder-fm-x"
+	sessionName := sessionNameFromBeadID("fm-x")
 	startFakeSession(t, sp, sessionName)
 	now := time.Now()
 	sp.SetActivity(sessionName, now.Add(-2*time.Hour))
 
-	if it.checkIdle(sessionName, "local-core.builder", sp, now) {
+	if it.checkIdle(sessionName, template, sp, now) {
 		t.Fatalf("checkIdle fired after template timeout was cleared")
+	}
+}
+
+func TestIdleTracker_SetTimeoutForTemplateIgnoresEmptyTemplate(t *testing.T) {
+	t.Parallel()
+
+	it := newIdleTracker()
+	it.setTimeoutForTemplate("", 1*time.Hour)
+
+	if len(it.templateTimeouts) != 0 {
+		t.Fatalf("templateTimeouts = %v, want empty after empty-template config", it.templateTimeouts)
 	}
 }

--- a/cmd/gc/idle_tracker_test.go
+++ b/cmd/gc/idle_tracker_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// startFakeSession marks `name` as running on the fake provider so the
+// observe path in workerSessionTargetLastActivityWithConfig will read the
+// activity timestamp set via SetActivity. Without a started session,
+// obs.Running stays false and the activity lookup is skipped.
+func startFakeSession(t *testing.T, sp *runtime.Fake, name string) {
+	t.Helper()
+	if err := sp.Start(context.Background(), name, runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("sp.Start(%q): %v", name, err)
+	}
+}
+
+// TestIdleTracker_PerNameTimeoutTriggersOnLastActivity sanity-checks the
+// original per-session-name registration: when a session has a registered
+// timeout, checkIdle returns true once its last activity exceeds the
+// threshold.
+func TestIdleTracker_PerNameTimeoutTriggersOnLastActivity(t *testing.T) {
+	t.Parallel()
+
+	it := newIdleTracker()
+	it.setTimeout("mayor", 5*time.Minute)
+
+	sp := runtime.NewFake()
+	startFakeSession(t, sp, "mayor")
+	now := time.Now()
+	sp.SetActivity("mayor", now.Add(-10*time.Minute))
+
+	if !it.checkIdle("mayor", "", sp, now) {
+		t.Fatalf("checkIdle(mayor, \"\", sp, now) = false, want true (last activity 10m old, timeout 5m)")
+	}
+
+	sp.SetActivity("mayor", now.Add(-1*time.Minute))
+	if it.checkIdle("mayor", "", sp, now) {
+		t.Fatalf("checkIdle returned true for not-yet-idle session")
+	}
+}
+
+// TestIdleTracker_TemplateFallbackResolvesPoolSession exercises the bug fix.
+// A pool session has a bead-derived runtime name that is unknown at registration
+// time. The tracker registers a per-template timeout and the call site supplies
+// the template so the timeout still applies.
+func TestIdleTracker_TemplateFallbackResolvesPoolSession(t *testing.T) {
+	t.Parallel()
+
+	it := newIdleTracker()
+	it.setTimeoutForTemplate("local-core.builder", 1*time.Hour)
+
+	sp := runtime.NewFake()
+	// Bead-derived runtime name — not the static "local-core__builder-1" form.
+	sessionName := "local-core__builder-fm-miv1io"
+	startFakeSession(t, sp, sessionName)
+	now := time.Now()
+	sp.SetActivity(sessionName, now.Add(-90*time.Minute))
+
+	if !it.checkIdle(sessionName, "local-core.builder", sp, now) {
+		t.Fatalf("checkIdle did not fire for pool session via template fallback (90m idle vs 1h timeout)")
+	}
+}
+
+// TestIdleTracker_TemplateFallbackDoesNotApplyWithoutTemplate verifies that
+// passing an empty template skips the per-template fallback. The call site
+// has the template available, but extra defensive: if a future call site
+// forgets to supply it, the old behavior (no fallback) is preserved rather
+// than silently picking up a timeout from an unrelated template.
+func TestIdleTracker_TemplateFallbackDoesNotApplyWithoutTemplate(t *testing.T) {
+	t.Parallel()
+
+	it := newIdleTracker()
+	it.setTimeoutForTemplate("local-core.builder", 1*time.Hour)
+
+	sp := runtime.NewFake()
+	sessionName := "local-core__builder-fm-anonymous"
+	startFakeSession(t, sp, sessionName)
+	now := time.Now()
+	sp.SetActivity(sessionName, now.Add(-90*time.Minute))
+
+	if it.checkIdle(sessionName, "", sp, now) {
+		t.Fatalf("checkIdle should not have fired without a template argument")
+	}
+}
+
+// TestIdleTracker_PerNameTakesPrecedenceOverTemplate ensures that a direct
+// per-session registration overrides the per-template fallback, so named
+// sessions retain their explicit timeouts even when their template also has
+// one registered (the hybrid named+pool case, should it arise).
+func TestIdleTracker_PerNameTakesPrecedenceOverTemplate(t *testing.T) {
+	t.Parallel()
+
+	it := newIdleTracker()
+	it.setTimeout("mayor", 5*time.Minute)
+	it.setTimeoutForTemplate("mayor", 24*time.Hour)
+
+	sp := runtime.NewFake()
+	startFakeSession(t, sp, "mayor")
+	now := time.Now()
+	sp.SetActivity("mayor", now.Add(-10*time.Minute))
+
+	// 10m idle should trip the per-name 5m timeout regardless of the larger
+	// template fallback.
+	if !it.checkIdle("mayor", "mayor", sp, now) {
+		t.Fatalf("checkIdle did not honor per-name 5m timeout (template fallback masked it?)")
+	}
+}
+
+// TestIdleTracker_SetTimeoutForTemplateZeroClears verifies that calling
+// setTimeoutForTemplate with a non-positive duration removes the entry —
+// matching setTimeout's behavior for consistency.
+func TestIdleTracker_SetTimeoutForTemplateZeroClears(t *testing.T) {
+	t.Parallel()
+
+	it := newIdleTracker()
+	it.setTimeoutForTemplate("local-core.builder", 1*time.Hour)
+	it.setTimeoutForTemplate("local-core.builder", 0)
+
+	sp := runtime.NewFake()
+	sessionName := "local-core__builder-fm-x"
+	startFakeSession(t, sp, sessionName)
+	now := time.Now()
+	sp.SetActivity(sessionName, now.Add(-2*time.Hour))
+
+	if it.checkIdle(sessionName, "local-core.builder", sp, now) {
+		t.Fatalf("checkIdle fired after template timeout was cleared")
+	}
+}

--- a/cmd/gc/max_session_age_tracker.go
+++ b/cmd/gc/max_session_age_tracker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"hash/fnv"
 	"math/rand"
 	"sync"
 	"time"
@@ -13,32 +14,45 @@ import (
 //
 // The tracker layers a per-session randomized jitter on top of the base
 // duration so fleets of identically-configured agents don't synchronize
-// restarts after a controller start. Jitter is recomputed per (sessionName,
-// creationCompleteAt) pair so a freshly-restarted session gets a new
-// target — without that, every restart would inherit the same offset and
-// the cycle would re-synchronize over time.
+// restarts after a controller start. Template fallback jitter is derived from
+// (template, sessionName, creationCompleteAt), so freshly-restarted pool
+// sessions get a new target without keeping per-lifecycle cache state.
 type maxSessionAgeTracker interface {
 	// shouldRestart reports whether the session identified by sessionName
 	// should be preemptively restarted given its current runtime-start
 	// anchor (creationCompleteAt, typically session.Metadata["creation_complete_at"])
 	// and the current wall clock. Returns false whenever the session is
 	// not registered, the anchor is zero, or the elapsed age has not yet
-	// reached the configured threshold.
-	shouldRestart(sessionName string, creationCompleteAt, now time.Time) bool
+	// reached the configured threshold. template is the agent's qualified
+	// template name and is used as a fallback lookup when the session name
+	// is not registered directly.
+	shouldRestart(sessionName, template string, creationCompleteAt, now time.Time) bool
 
 	// setConfig configures a session's preemptive-restart bounds. A zero
 	// maxAge removes the session from the tracker. jitter ≤ 0 disables
 	// jitter (deterministic threshold). Safe to call repeatedly — the
 	// tracker will re-roll the jitter window if the configuration changes.
 	setConfig(sessionName string, maxAge, jitter time.Duration)
+
+	// setConfigForTemplate configures preemptive-restart bounds for every
+	// session belonging to an agent template whose concrete runtime names
+	// are minted after controller startup.
+	setConfigForTemplate(template string, maxAge, jitter time.Duration)
+
+	// exemptTemplateFallbackForSession prevents one stable session from
+	// inheriting the template config. Used for mode="always" named sessions
+	// that share a template with pool siblings.
+	exemptTemplateFallbackForSession(sessionName string)
 }
 
 // memoryMaxSessionAgeTracker is the production implementation. The jitter
 // source is injected so tests can make the per-session offset deterministic.
 type memoryMaxSessionAgeTracker struct {
-	mu      sync.Mutex
-	configs map[string]maxSessionAgeConfig
-	offsets map[string]time.Duration // sessionName -> current per-session offset
+	mu                         sync.Mutex
+	configs                    map[string]maxSessionAgeConfig
+	templateConfigs            map[string]maxSessionAgeConfig
+	offsets                    map[string]time.Duration // sessionName -> current per-session offset
+	templateFallbackExemptions map[string]bool          // session name -> skip template fallback
 	// rng backs setConfig's random offset roll. Wrapped in a mutex so
 	// concurrent setConfig calls remain safe on the shared generator.
 	rngMu sync.Mutex
@@ -55,8 +69,10 @@ type maxSessionAgeConfig struct {
 // is disabled for the entire config.
 func newMaxSessionAgeTracker() *memoryMaxSessionAgeTracker {
 	return &memoryMaxSessionAgeTracker{
-		configs: make(map[string]maxSessionAgeConfig),
-		offsets: make(map[string]time.Duration),
+		configs:                    make(map[string]maxSessionAgeConfig),
+		templateConfigs:            make(map[string]maxSessionAgeConfig),
+		offsets:                    make(map[string]time.Duration),
+		templateFallbackExemptions: make(map[string]bool),
 		//nolint:gosec // jitter only needs uniform distribution, not crypto randomness
 		rng: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
@@ -86,17 +102,69 @@ func (m *memoryMaxSessionAgeTracker) setConfig(sessionName string, maxAge, jitte
 	m.mu.Unlock()
 }
 
-func (m *memoryMaxSessionAgeTracker) shouldRestart(sessionName string, creationCompleteAt, now time.Time) bool {
+func (m *memoryMaxSessionAgeTracker) setConfigForTemplate(template string, maxAge, jitter time.Duration) {
+	if template == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if maxAge <= 0 {
+		delete(m.templateConfigs, template)
+		return
+	}
+	m.templateConfigs[template] = maxSessionAgeConfig{maxAge: maxAge, jitter: jitter}
+}
+
+func (m *memoryMaxSessionAgeTracker) exemptTemplateFallbackForSession(sessionName string) {
+	if sessionName == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.templateFallbackExemptions[sessionName] = true
+}
+
+func (m *memoryMaxSessionAgeTracker) shouldRestart(sessionName, template string, creationCompleteAt, now time.Time) bool {
 	if sessionName == "" || creationCompleteAt.IsZero() || now.IsZero() {
 		return false
 	}
-	m.mu.Lock()
-	cfg, ok := m.configs[sessionName]
-	offset := m.offsets[sessionName]
-	m.mu.Unlock()
+	cfg, offset, ok := m.configFor(sessionName, template, creationCompleteAt)
 	if !ok || cfg.maxAge <= 0 {
 		return false
 	}
 	threshold := cfg.maxAge + offset
 	return now.Sub(creationCompleteAt) >= threshold
+}
+
+func (m *memoryMaxSessionAgeTracker) configFor(sessionName, template string, creationCompleteAt time.Time) (maxSessionAgeConfig, time.Duration, bool) {
+	m.mu.Lock()
+	cfg, ok := m.configs[sessionName]
+	if ok {
+		offset := m.offsets[sessionName]
+		m.mu.Unlock()
+		return cfg, offset, true
+	}
+	if m.templateFallbackExemptions[sessionName] || template == "" {
+		m.mu.Unlock()
+		return maxSessionAgeConfig{}, 0, false
+	}
+	cfg, ok = m.templateConfigs[template]
+	m.mu.Unlock()
+	if !ok {
+		return maxSessionAgeConfig{}, 0, false
+	}
+	return cfg, deterministicMaxSessionAgeOffset(template, sessionName, creationCompleteAt, cfg.jitter), true
+}
+
+func deterministicMaxSessionAgeOffset(template, sessionName string, creationCompleteAt time.Time, jitter time.Duration) time.Duration {
+	if jitter <= 0 {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(template))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(sessionName))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(creationCompleteAt.UTC().Format(time.RFC3339Nano)))
+	return time.Duration(h.Sum64() % uint64(jitter))
 }

--- a/cmd/gc/max_session_age_tracker_test.go
+++ b/cmd/gc/max_session_age_tracker_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestMaxSessionAgeTracker_UnregisteredSessionIsFalse(t *testing.T) {
 	tr := newMaxSessionAgeTracker()
 	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
-	if tr.shouldRestart("witness", now.Add(-10*time.Hour), now) {
+	if tr.shouldRestart("witness", "", now.Add(-10*time.Hour), now) {
 		t.Error("shouldRestart must be false for sessions with no config")
 	}
 }
@@ -16,7 +18,7 @@ func TestMaxSessionAgeTracker_UnregisteredSessionIsFalse(t *testing.T) {
 func TestMaxSessionAgeTracker_ZeroAnchorIsFalse(t *testing.T) {
 	tr := newMaxSessionAgeTracker()
 	tr.setConfig("witness", 5*time.Hour, 0)
-	if tr.shouldRestart("witness", time.Time{}, time.Now()) {
+	if tr.shouldRestart("witness", "", time.Time{}, time.Now()) {
 		t.Error("shouldRestart must be false when creation_complete_at is zero")
 	}
 }
@@ -25,7 +27,7 @@ func TestMaxSessionAgeTracker_YoungSessionIsFalse(t *testing.T) {
 	tr := newMaxSessionAgeTracker()
 	tr.setConfig("witness", 5*time.Hour, 0)
 	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
-	if tr.shouldRestart("witness", now.Add(-1*time.Hour), now) {
+	if tr.shouldRestart("witness", "", now.Add(-1*time.Hour), now) {
 		t.Error("shouldRestart must be false when session age < max age")
 	}
 }
@@ -34,7 +36,7 @@ func TestMaxSessionAgeTracker_OldSessionIsTrue(t *testing.T) {
 	tr := newMaxSessionAgeTracker()
 	tr.setConfig("witness", 5*time.Hour, 0)
 	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
-	if !tr.shouldRestart("witness", now.Add(-6*time.Hour), now) {
+	if !tr.shouldRestart("witness", "", now.Add(-6*time.Hour), now) {
 		t.Error("shouldRestart must be true when session age > max age")
 	}
 }
@@ -48,7 +50,7 @@ func TestMaxSessionAgeTracker_JitterExtendsThreshold(t *testing.T) {
 	tr.setConfig("a", 5*time.Hour, 0)
 	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
 	anchor := now.Add(-5 * time.Hour)
-	if !tr.shouldRestart("a", anchor, now) {
+	if !tr.shouldRestart("a", "", anchor, now) {
 		t.Error("zero-jitter: age == maxAge must trigger restart")
 	}
 
@@ -57,10 +59,10 @@ func TestMaxSessionAgeTracker_JitterExtendsThreshold(t *testing.T) {
 	// exactly at maxAge with any offset > 0 must NOT yet restart, and a
 	// session at maxAge + jitter must always restart.
 	tr.setConfig("b", 5*time.Hour, 30*time.Minute)
-	if tr.shouldRestart("b", now.Add(-4*time.Hour-59*time.Minute), now) {
+	if tr.shouldRestart("b", "", now.Add(-4*time.Hour-59*time.Minute), now) {
 		t.Error("jitter: session 1m below base threshold must not restart")
 	}
-	if !tr.shouldRestart("b", now.Add(-6*time.Hour), now) {
+	if !tr.shouldRestart("b", "", now.Add(-6*time.Hour), now) {
 		t.Error("jitter: session well past (maxAge + jitter) must restart")
 	}
 }
@@ -70,7 +72,7 @@ func TestMaxSessionAgeTracker_ClearingConfigDisablesRestart(t *testing.T) {
 	tr.setConfig("witness", 5*time.Hour, 0)
 	tr.setConfig("witness", 0, 0) // clear
 	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
-	if tr.shouldRestart("witness", now.Add(-10*time.Hour), now) {
+	if tr.shouldRestart("witness", "", now.Add(-10*time.Hour), now) {
 		t.Error("shouldRestart must be false after the config is cleared")
 	}
 }
@@ -87,5 +89,115 @@ func TestMaxSessionAgeTracker_ReconfigRerollsJitterForDifferentSessions(t *testi
 	tr.mu.Unlock()
 	if offsetA < 0 || offsetA >= time.Hour {
 		t.Errorf("offset for witness-a = %v, want in [0, 1h)", offsetA)
+	}
+}
+
+func TestMaxSessionAgeTracker_TemplateFallbackResolvesPoolSession(t *testing.T) {
+	tr := newMaxSessionAgeTracker()
+	template := "local-core/builder"
+	tr.setConfigForTemplate(template, time.Hour, 0)
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	sessionName := sessionNameFromBeadID("fm-miv1io")
+	if !tr.shouldRestart(sessionName, template, now.Add(-2*time.Hour), now) {
+		t.Fatalf("shouldRestart did not fire for pool session via template fallback")
+	}
+}
+
+func TestMaxSessionAgeTracker_TemplateFallbackJitterUsesDeterministicOffset(t *testing.T) {
+	tr := newMaxSessionAgeTracker()
+	template := "local-core/builder"
+	sessionName := sessionNameFromBeadID("fm-miv1io")
+	maxAge := 5 * time.Hour
+	jitter := 30 * time.Minute
+	tr.setConfigForTemplate(template, maxAge, jitter)
+
+	anchor := time.Date(2026, 5, 20, 6, 30, 0, 0, time.UTC)
+	offset := deterministicMaxSessionAgeOffset(template, sessionName, anchor, jitter)
+	if offset < 0 || offset >= jitter {
+		t.Fatalf("offset = %v, want in [0, %v)", offset, jitter)
+	}
+	if got := deterministicMaxSessionAgeOffset(template, sessionName, anchor, jitter); got != offset {
+		t.Fatalf("offset was not stable: got %v then %v", offset, got)
+	}
+	var nextOffset time.Duration
+	for i := 1; i <= 128; i++ {
+		nextOffset = deterministicMaxSessionAgeOffset(template, sessionName, anchor.Add(time.Duration(i)*time.Second), jitter)
+		if nextOffset != offset {
+			break
+		}
+	}
+	if nextOffset == offset {
+		t.Fatalf("offset did not change when creationCompleteAt changed: %v", offset)
+	}
+
+	if tr.shouldRestart(sessionName, template, anchor, anchor.Add(maxAge+offset-time.Nanosecond)) {
+		t.Fatalf("shouldRestart fired before maxAge+deterministic template jitter threshold")
+	}
+	if !tr.shouldRestart(sessionName, template, anchor, anchor.Add(maxAge+offset)) {
+		t.Fatalf("shouldRestart did not fire at maxAge+deterministic template jitter threshold")
+	}
+}
+
+func TestMaxSessionAgeTracker_TemplateFallbackDoesNotApplyWithoutTemplate(t *testing.T) {
+	tr := newMaxSessionAgeTracker()
+	tr.setConfigForTemplate("local-core/builder", time.Hour, 0)
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	sessionName := sessionNameFromBeadID("fm-anonymous")
+	if tr.shouldRestart(sessionName, "", now.Add(-2*time.Hour), now) {
+		t.Fatalf("shouldRestart fired without a template argument")
+	}
+}
+
+func TestMaxSessionAgeTracker_PerNameTakesPrecedenceOverTemplate(t *testing.T) {
+	tr := newMaxSessionAgeTracker()
+	sessionName := "session-a"
+	template := "local-core/builder"
+	tr.setConfig(sessionName, 5*time.Minute, 0)
+	tr.setConfigForTemplate(template, 24*time.Hour, 0)
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	if !tr.shouldRestart(sessionName, template, now.Add(-10*time.Minute), now) {
+		t.Fatalf("shouldRestart did not honor per-name max age before template fallback")
+	}
+}
+
+func TestMaxSessionAgeTracker_TemplateFallbackExemptionSkipsTemplate(t *testing.T) {
+	tr := newMaxSessionAgeTracker()
+	template := "local-core/builder"
+	sessionName := config.NamedSessionRuntimeName("city", config.Workspace{}, "local-core/primary")
+	tr.setConfigForTemplate(template, time.Hour, 0)
+	tr.exemptTemplateFallbackForSession(sessionName)
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	if tr.shouldRestart(sessionName, template, now.Add(-2*time.Hour), now) {
+		t.Fatalf("shouldRestart fired for template-exempt named session")
+	}
+}
+
+func TestMaxSessionAgeTracker_SetConfigForTemplateZeroClears(t *testing.T) {
+	tr := newMaxSessionAgeTracker()
+	template := "local-core/builder"
+	tr.setConfigForTemplate(template, time.Hour, 0)
+	tr.setConfigForTemplate(template, 0, 0)
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	sessionName := sessionNameFromBeadID("fm-x")
+	if tr.shouldRestart(sessionName, template, now.Add(-2*time.Hour), now) {
+		t.Fatalf("shouldRestart fired after template max age was cleared")
+	}
+}
+
+func TestMaxSessionAgeTracker_SetConfigForTemplateIgnoresEmptyTemplate(t *testing.T) {
+	tr := newMaxSessionAgeTracker()
+	tr.setConfigForTemplate("", time.Hour, 0)
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	if tr.shouldRestart("session", "", now.Add(-2*time.Hour), now) {
+		t.Fatalf("shouldRestart fired after empty-template config")
+	}
+	if len(tr.templateConfigs) != 0 {
+		t.Fatalf("templateConfigs = %v, want empty after empty-template config", tr.templateConfigs)
 	}
 }

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1636,7 +1636,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		}
 
 		// Idle timeout: restart sessions idle longer than configured threshold.
-		if it != nil && alive && it.checkIdle(name, sp, clk.Now()) {
+		// Pass the agent template so the tracker can fall back to a per-template
+		// timeout for pool sessions whose bead-derived runtime names are not
+		// registered directly.
+		if it != nil && alive && it.checkIdle(name, tp.TemplateName, sp, clk.Now()) {
 			blocker := lifecycleTimerBlocker(session.Metadata, clk.Now())
 			switch {
 			case blocker != "":

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1578,7 +1578,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// so no work is lost mid-flight. The next tick retries.
 		if maxAgeTr != nil && alive {
 			creationCompleteAt, hasAnchor := parseRFC3339Metadata(session.Metadata["creation_complete_at"])
-			if hasAnchor && maxAgeTr.shouldRestart(name, creationCompleteAt, clk.Now()) {
+			if hasAnchor && maxAgeTr.shouldRestart(name, tp.TemplateName, creationCompleteAt, clk.Now()) {
 				blocker := lifecycleTimerBlocker(session.Metadata, clk.Now())
 				switch {
 				case blocker != "":

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -30,11 +30,12 @@ func newFakeIdleTracker() *fakeIdleTracker {
 	return &fakeIdleTracker{idle: make(map[string]bool)}
 }
 
-func (f *fakeIdleTracker) checkIdle(sessionName string, _ runtime.Provider, _ time.Time) bool {
+func (f *fakeIdleTracker) checkIdle(sessionName, _ string, _ runtime.Provider, _ time.Time) bool {
 	return f.idle[sessionName]
 }
 
-func (f *fakeIdleTracker) setTimeout(_ string, _ time.Duration) {}
+func (f *fakeIdleTracker) setTimeout(_ string, _ time.Duration)            {}
+func (f *fakeIdleTracker) setTimeoutForTemplate(_ string, _ time.Duration) {}
 
 type lineLimitedPeekProvider struct {
 	*runtime.Fake

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -23,19 +23,44 @@ import (
 
 // fakeIdleTracker is a test double for idleTracker.
 type fakeIdleTracker struct {
-	idle map[string]bool
+	idle       map[string]bool
+	templates  map[string]bool
+	exemptions map[string]bool
 }
 
 func newFakeIdleTracker() *fakeIdleTracker {
-	return &fakeIdleTracker{idle: make(map[string]bool)}
+	return &fakeIdleTracker{
+		idle:       make(map[string]bool),
+		templates:  make(map[string]bool),
+		exemptions: make(map[string]bool),
+	}
 }
 
-func (f *fakeIdleTracker) checkIdle(sessionName, _ string, _ runtime.Provider, _ time.Time) bool {
-	return f.idle[sessionName]
+func (f *fakeIdleTracker) checkIdle(sessionName, template string, _ runtime.Provider, _ time.Time) bool {
+	if f.idle[sessionName] {
+		return true
+	}
+	if template == "" || f.exemptions[sessionName] {
+		return false
+	}
+	return f.templates[template]
 }
 
-func (f *fakeIdleTracker) setTimeout(_ string, _ time.Duration)            {}
-func (f *fakeIdleTracker) setTimeoutForTemplate(_ string, _ time.Duration) {}
+func (f *fakeIdleTracker) setTimeout(sessionName string, _ time.Duration) {
+	f.idle[sessionName] = true
+}
+
+func (f *fakeIdleTracker) setTimeoutForTemplate(template string, _ time.Duration) {
+	if template != "" {
+		f.templates[template] = true
+	}
+}
+
+func (f *fakeIdleTracker) exemptTemplateFallbackForSession(sessionName string) {
+	if sessionName != "" {
+		f.exemptions[sessionName] = true
+	}
+}
 
 type lineLimitedPeekProvider struct {
 	*runtime.Fake
@@ -5622,6 +5647,69 @@ func TestReconcileSessionBeads_IdleTimeoutStopsAndStaysAsleep(t *testing.T) {
 	}
 	if b.Metadata["slept_at"] != env.clk.Now().UTC().Format(time.RFC3339) {
 		t.Errorf("slept_at = %q, want idle stop timestamp", b.Metadata["slept_at"])
+	}
+}
+
+func TestReconcileSessionBeads_IdleTimeoutUsesTemplateFallbackForPoolSession(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{
+			Name: "builder",
+			Dir:  "local-core",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "primary",
+			Template: "builder",
+			Dir:      "local-core",
+			Mode:     "always",
+		}},
+	}
+	template := env.cfg.Agents[0].QualifiedName()
+	poolSessionName := sessionNameFromBeadID("fm-r56l0x")
+	namedSessionName := config.NamedSessionRuntimeName("", env.cfg.Workspace, "local-core/primary")
+
+	env.addDesired(poolSessionName, template, true)
+	env.addDesired(namedSessionName, template, true)
+	poolSession := env.createSessionBead(poolSessionName, template)
+	namedSession := env.createSessionBead(namedSessionName, template)
+	env.markSessionActive(&poolSession)
+	env.markSessionActive(&namedSession)
+	if err := env.sp.SetMeta(poolSessionName, "GC_SESSION_ID", poolSession.ID); err != nil {
+		t.Fatalf("SetMeta(%s, GC_SESSION_ID): %v", poolSessionName, err)
+	}
+	if err := env.sp.SetMeta(namedSessionName, "GC_SESSION_ID", namedSession.ID); err != nil {
+		t.Fatalf("SetMeta(%s, GC_SESSION_ID): %v", namedSessionName, err)
+	}
+
+	it := newFakeIdleTracker()
+	it.setTimeoutForTemplate(template, time.Hour)
+	exemptAlwaysNamedTemplateFallbacks(env.cfg, "", template, it.exemptTemplateFallbackForSession)
+
+	reconcileSessionBeads(
+		context.Background(), []beads.Bead{poolSession, namedSession}, env.desiredState, configuredSessionNames(env.cfg, "", env.store),
+		env.cfg, env.sp, env.store, nil, nil, nil, env.dt, map[string]int{template: 2}, false, nil, "",
+		it, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	if env.sp.IsRunning(poolSessionName) {
+		t.Fatalf("pool session %q should idle via template fallback %q", poolSessionName, template)
+	}
+	if !env.sp.IsRunning(namedSessionName) {
+		t.Fatalf("always named session %q must be exempt from template fallback %q", namedSessionName, template)
+	}
+	poolBead, err := env.store.Get(poolSession.ID)
+	if err != nil {
+		t.Fatalf("Get pool session: %v", err)
+	}
+	if poolBead.Metadata["sleep_reason"] != "idle-timeout" {
+		t.Fatalf("pool sleep_reason = %q, want idle-timeout", poolBead.Metadata["sleep_reason"])
+	}
+	namedBead, err := env.store.Get(namedSession.ID)
+	if err != nil {
+		t.Fatalf("Get named session: %v", err)
+	}
+	if namedBead.Metadata["sleep_reason"] == "idle-timeout" {
+		t.Fatalf("always named sleep_reason = %q, must not be idle-timeout", namedBead.Metadata["sleep_reason"])
 	}
 }
 


### PR DESCRIPTION
Carries forward https://github.com/gastownhall/gascity/pull/2395 through the maintainer adoption workflow.

Original PR: https://github.com/gastownhall/gascity/pull/2395
Original title: fix(pool): idle timeout now reaches ephemeral pool sessions
Original state at handoff: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

Why this follow-up exists:
The reviewed final head needed maintainer-side fixups and a latest-main replay, but the workflow could not safely update the contributor fork branch directly. GitHub rejected the fork push with a 403 for the current token, so this maintainer branch is the safe merge surface.

What is preserved:
The contributor commits from Austin Born are preserved with their original authorship, followed by the maintainer fixup commit. The branch was replayed onto the latest upstream main with the same stable patch-id as the reviewed adopted diff.

Review and validation summary:
The adoption review confirmed the idle-timeout fix now covers bead-derived ephemeral pool sessions by registering a template fallback and passing the template key through the reconciler. The maintainer fixes also restored per-name lifecycle registrations, handled always-mode named-session exemptions for shared pool templates, aligned max-session-age behavior with idle timeout, and added focused tracker/reconciler coverage.

Local validation run after the final replay:

```bash
go test ./cmd/gc -run 'Test(BuildLifecycleTrackers|BuildIdleTracker|ComputePoolSessions|StartupSessionComputationsDoNotQueryBeadStore|IdleTracker|ControllerReloadsNamedSessionModeAndAppliesIdleTimeout|BuildMaxSessionAgeTracker|MaxSessionAgeTracker|SessionReconciler)' -count=1
```

Result: pass.
