### PR TITLE
Adopt PR #2439: widen provider-credential env prefix list

### DIFF
--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -458,6 +458,10 @@ func TestPassthroughEnvIncludesProviderCredentialEnv(t *testing.T) {
 	t.Setenv("GOOGLE_API_KEY", "google-123")
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/google-credentials.json")
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "gc-project")
+	t.Setenv("DEEPSEEK_API_KEY", "ds-123")
+	t.Setenv("OLLAMA_HOST", "http://localhost:11434")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIA123")
+	t.Setenv("AWS_PAGER", "less")
 
 	got := passthroughEnv()
 
@@ -469,10 +473,16 @@ func TestPassthroughEnvIncludesProviderCredentialEnv(t *testing.T) {
 		"GOOGLE_API_KEY":                 "google-123",
 		"GOOGLE_APPLICATION_CREDENTIALS": "/tmp/google-credentials.json",
 		"GOOGLE_CLOUD_PROJECT":           "gc-project",
+		"DEEPSEEK_API_KEY":               "ds-123",
+		"OLLAMA_HOST":                    "http://localhost:11434",
+		"AWS_ACCESS_KEY_ID":              "AKIA123",
 	} {
 		if got[key] != want {
 			t.Errorf("passthroughEnv()[%s] = %q, want %q", key, got[key], want)
 		}
+	}
+	if _, ok := got["AWS_PAGER"]; ok {
+		t.Errorf("passthroughEnv() should not include broad AWS runtime state")
 	}
 }
 

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -201,9 +201,11 @@ const (
 const supervisorPreserveSessionsOnSignalEnv = "GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL"
 
 // supervisorOmitProviderCredsEnv, when set to "1" at the time the supervisor
-// service file is generated, causes provider-credential env vars
-// (ANTHROPIC_*, GEMINI_*, GOOGLE_*, OPENAI_*) to be excluded from the
-// generated launchd plist or systemd unit. Default behavior is unchanged.
+// service file is generated, causes env vars matched by the shared
+// provider-credential predicate to be excluded from the generated launchd
+// plist or systemd unit. The source of truth is providerCredentialEnvPrefixes
+// and providerCredentialEnvKeys in cmd_supervisor_lifecycle.go. Default
+// behavior is unchanged.
 // When opted out, the user is responsible for delivering provider creds to
 // the supervisor's environment via some other mechanism (e.g. a wrapper
 // around `gc supervisor run` that sources a credentials file).

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -800,11 +800,61 @@ var supervisorServiceEnvKeys = map[string]bool{
 	"XDG_STATE_HOME":                           true,
 }
 
+// providerCredentialEnvPrefixes lists env-var name prefixes whose values are
+// treated as agent-provider credentials and forwarded into the supervisor's
+// persistent env (launchd plist / systemd unit) and into spawned agent
+// processes. The same predicate gates the global baseline in cmd_start.go:
+// the SDK cannot know which agent uses which provider (zero hardcoded
+// roles), so credentials for any known provider are passed through, and the
+// trust boundary is the managed session itself.
+//
+// The list is curated, not auto-discovered: the supervisor's persistent env
+// has a bounded size (launchd plists in particular), so we only forward
+// prefixes belonging to well-known LLM provider auth schemes. Users with
+// niche or in-house providers can opt in via GC_SUPERVISOR_ENV.
+//
+// Keep alphabetised. Documented providers (with the env vars they typically
+// use):
+//
+//	ANTHROPIC_   Anthropic / Claude (ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, ...)
+//	AWS_         AWS Bedrock auth (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+//	             AWS_REGION, AWS_PROFILE, AWS_SESSION_TOKEN,
+//	             AWS_BEARER_TOKEN_BEDROCK, ...)
+//	AZURE_       Azure OpenAI (AZURE_OPENAI_API_KEY, AZURE_OPENAI_BASE_URL,
+//	             AZURE_OPENAI_API_VERSION, AZURE_OPENAI_ENDPOINT, ...)
+//	CEREBRAS_    Cerebras (CEREBRAS_API_KEY)
+//	COHERE_      Cohere (COHERE_API_KEY)
+//	DEEPSEEK_    DeepSeek (DEEPSEEK_API_KEY)
+//	FIREWORKS_   Fireworks AI (FIREWORKS_API_KEY)
+//	GEMINI_      Google Gemini direct API (GEMINI_API_KEY)
+//	GOOGLE_      Google Cloud / Vertex (GOOGLE_API_KEY,
+//	             GOOGLE_APPLICATION_CREDENTIALS, GOOGLE_CLOUD_PROJECT, ...)
+//	GROQ_        Groq (GROQ_API_KEY)
+//	MISTRAL_     Mistral (MISTRAL_API_KEY)
+//	OLLAMA_      Ollama local (OLLAMA_API_KEY, OLLAMA_HOST, OLLAMA_BASE_URL)
+//	OPENAI_      OpenAI (OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_API_VERSION)
+//	OPENROUTER_  OpenRouter (OPENROUTER_API_KEY)
+//	TOGETHER_    Together AI (TOGETHER_API_KEY)
+//	VERTEX_      Vertex AI direct (VERTEX_PROJECT_ID, VERTEX_LOCATION, ...)
+//	XAI_         xAI / Grok (XAI_API_KEY)
 var providerCredentialEnvPrefixes = []string{
 	"ANTHROPIC_",
+	"AWS_",
+	"AZURE_",
+	"CEREBRAS_",
+	"COHERE_",
+	"DEEPSEEK_",
+	"FIREWORKS_",
 	"GEMINI_",
 	"GOOGLE_",
+	"GROQ_",
+	"MISTRAL_",
+	"OLLAMA_",
 	"OPENAI_",
+	"OPENROUTER_",
+	"TOGETHER_",
+	"VERTEX_",
+	"XAI_",
 }
 
 var supervisorServiceFixedEnvKeys = map[string]bool{

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -800,26 +800,25 @@ var supervisorServiceEnvKeys = map[string]bool{
 	"XDG_STATE_HOME":                           true,
 }
 
-// providerCredentialEnvPrefixes lists env-var name prefixes whose values are
-// treated as agent-provider credentials and forwarded into the supervisor's
-// persistent env (launchd plist / systemd unit) and into spawned agent
-// processes. The same predicate gates the global baseline in cmd_start.go:
-// the SDK cannot know which agent uses which provider (zero hardcoded
-// roles), so credentials for any known provider are passed through, and the
-// trust boundary is the managed session itself.
+// providerCredentialEnvPrefixes lists provider-specific env-var name prefixes
+// whose values are treated as agent-provider credentials and forwarded into
+// the supervisor's persistent env (launchd plist / systemd unit) and into
+// spawned agent processes. The same predicate gates the global baseline in
+// cmd_start.go: the SDK cannot know which agent uses which provider (zero
+// hardcoded roles), so credentials for any known provider are passed through,
+// and the trust boundary is the managed session itself.
 //
-// The list is curated, not auto-discovered: the supervisor's persistent env
-// has a bounded size (launchd plists in particular), so we only forward
-// prefixes belonging to well-known LLM provider auth schemes. Users with
-// niche or in-house providers can opt in via GC_SUPERVISOR_ENV.
+// The list is curated, not auto-discovered: the supervisor's persistent env has
+// a bounded size (launchd plists in particular), so we only forward prefixes
+// belonging to provider-owned namespaces. Broad ecosystems such as AWS use
+// exact names in providerCredentialEnvKeys to avoid persisting unrelated
+// tooling/runtime state. Users with niche or in-house providers can opt in via
+// GC_SUPERVISOR_ENV.
 //
 // Keep alphabetised. Documented providers (with the env vars they typically
 // use):
 //
 //	ANTHROPIC_   Anthropic / Claude (ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, ...)
-//	AWS_         AWS Bedrock auth (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
-//	             AWS_REGION, AWS_PROFILE, AWS_SESSION_TOKEN,
-//	             AWS_BEARER_TOKEN_BEDROCK, ...)
 //	AZURE_       Azure OpenAI (AZURE_OPENAI_API_KEY, AZURE_OPENAI_BASE_URL,
 //	             AZURE_OPENAI_API_VERSION, AZURE_OPENAI_ENDPOINT, ...)
 //	CEREBRAS_    Cerebras (CEREBRAS_API_KEY)
@@ -839,7 +838,6 @@ var supervisorServiceEnvKeys = map[string]bool{
 //	XAI_         xAI / Grok (XAI_API_KEY)
 var providerCredentialEnvPrefixes = []string{
 	"ANTHROPIC_",
-	"AWS_",
 	"AZURE_",
 	"CEREBRAS_",
 	"COHERE_",
@@ -855,6 +853,38 @@ var providerCredentialEnvPrefixes = []string{
 	"TOGETHER_",
 	"VERTEX_",
 	"XAI_",
+}
+
+// providerCredentialEnvKeys lists exact provider credential/config env vars for
+// providers whose common env namespace is broader than provider auth.
+//
+// AWS Bedrock uses standard AWS SDK credential and configuration env vars, but
+// the AWS_ prefix also covers unrelated CLI, CI, pager, runtime, and container
+// metadata state. Keep this exact list bounded to the keys agents need for
+// Bedrock auth/config; users can opt in additional keys through
+// GC_SUPERVISOR_ENV.
+var providerCredentialEnvKeys = map[string]bool{
+	"AWS_ACCESS_KEY_ID":                      true,
+	"AWS_BEARER_TOKEN_BEDROCK":               true,
+	"AWS_CA_BUNDLE":                          true,
+	"AWS_CONFIG_FILE":                        true,
+	"AWS_CONTAINER_AUTHORIZATION_TOKEN":      true,
+	"AWS_CONTAINER_CREDENTIALS_FULL_URI":     true,
+	"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": true,
+	"AWS_DEFAULT_REGION":                     true,
+	"AWS_EC2_METADATA_DISABLED":              true,
+	"AWS_ENDPOINT_URL":                       true,
+	"AWS_ENDPOINT_URL_BEDROCK":               true,
+	"AWS_PROFILE":                            true,
+	"AWS_REGION":                             true,
+	"AWS_ROLE_ARN":                           true,
+	"AWS_SDK_LOAD_CONFIG":                    true,
+	"AWS_SECRET_ACCESS_KEY":                  true,
+	"AWS_SESSION_TOKEN":                      true,
+	"AWS_SHARED_CREDENTIALS_FILE":            true,
+	"AWS_USE_DUALSTACK_ENDPOINT":             true,
+	"AWS_USE_FIPS_ENDPOINT":                  true,
+	"AWS_WEB_IDENTITY_TOKEN_FILE":            true,
 }
 
 var supervisorServiceFixedEnvKeys = map[string]bool{
@@ -934,6 +964,9 @@ func shouldPersistSupervisorEnv(key string) bool {
 }
 
 func isProviderCredentialEnv(key string) bool {
+	if providerCredentialEnvKeys[key] {
+		return true
+	}
 	for _, prefix := range providerCredentialEnvPrefixes {
 		if strings.HasPrefix(key, prefix) {
 			return true

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -575,6 +575,58 @@ func supervisorServiceEnvMap(vars []supervisorServiceEnvVar) map[string]string {
 	return m
 }
 
+// TestBuildSupervisorServiceDataForwardsAllKnownProviderPrefixes asserts that
+// a canonical env var for every prefix in providerCredentialEnvPrefixes is
+// forwarded into the supervisor's persistent env. This is the regression
+// protection for the curated provider-prefix list: if a prefix is removed,
+// the corresponding probe key here fails and surfaces the omission.
+func TestBuildSupervisorServiceDataForwardsAllKnownProviderPrefixes(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+
+	// One canonical probe key per documented prefix.
+	probes := map[string]string{
+		"ANTHROPIC_API_KEY":    "sk-ant-probe",
+		"AWS_ACCESS_KEY_ID":    "AKIA-probe",
+		"AZURE_OPENAI_API_KEY": "azure-openai-probe",
+		"CEREBRAS_API_KEY":     "cb-probe",
+		"COHERE_API_KEY":       "cohere-probe",
+		"DEEPSEEK_API_KEY":     "ds-probe",
+		"FIREWORKS_API_KEY":    "fw-probe",
+		"GEMINI_API_KEY":       "gemini-probe",
+		"GOOGLE_CLOUD_PROJECT": "google-probe-project",
+		"GROQ_API_KEY":         "groq-probe",
+		"MISTRAL_API_KEY":      "mistral-probe",
+		"OLLAMA_HOST":          "http://localhost:11434",
+		"OPENAI_API_KEY":       "sk-openai-probe",
+		"OPENROUTER_API_KEY":   "or-probe",
+		"TOGETHER_API_KEY":     "together-probe",
+		"VERTEX_PROJECT_ID":    "vertex-probe-project",
+		"XAI_API_KEY":          "xai-probe",
+	}
+	if len(probes) != len(providerCredentialEnvPrefixes) {
+		t.Fatalf("probe set size %d does not match prefix list size %d; update the test when prefixes change",
+			len(probes), len(providerCredentialEnvPrefixes))
+	}
+	for k, v := range probes {
+		t.Setenv(k, v)
+	}
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for k, want := range probes {
+		if got[k] != want {
+			t.Errorf("ExtraEnv[%s] = %q, want %q — prefix may be missing from providerCredentialEnvPrefixes", k, got[k], want)
+		}
+	}
+}
+
 func TestBuildSupervisorServiceDataReadsAllowlistedDoltCredentialKeysFromLaunchctl(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -491,6 +491,10 @@ func TestBuildSupervisorServiceDataIncludesProviderEnv(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-openai-123")
 	t.Setenv("GEMINI_API_KEY", "gemini-123")
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "gc-project")
+	t.Setenv("DEEPSEEK_API_KEY", "ds-123")
+	t.Setenv("OLLAMA_HOST", "http://localhost:11434")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIA123")
+	t.Setenv("AWS_PAGER", "less")
 	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(homeDir, ".claude"))
 	t.Setenv("GC_SUPERVISOR_ENV", "CUSTOM_PROVIDER_TOKEN,IGNORED_EMPTY")
 	t.Setenv("CUSTOM_PROVIDER_TOKEN", "custom-token")
@@ -509,6 +513,9 @@ func TestBuildSupervisorServiceDataIncludesProviderEnv(t *testing.T) {
 		"OPENAI_API_KEY":        "sk-openai-123",
 		"GEMINI_API_KEY":        "gemini-123",
 		"GOOGLE_CLOUD_PROJECT":  "gc-project",
+		"DEEPSEEK_API_KEY":      "ds-123",
+		"OLLAMA_HOST":           "http://localhost:11434",
+		"AWS_ACCESS_KEY_ID":     "AKIA123",
 		"CLAUDE_CONFIG_DIR":     filepath.Join(homeDir, ".claude"),
 		"CUSTOM_PROVIDER_TOKEN": "custom-token",
 	} {
@@ -516,7 +523,7 @@ func TestBuildSupervisorServiceDataIncludesProviderEnv(t *testing.T) {
 			t.Fatalf("ExtraEnv[%s] = %q, want %q (all env: %#v)", key, got[key], want, got)
 		}
 	}
-	for _, key := range []string{"GC_HOME", "PATH", "XDG_RUNTIME_DIR", "IGNORED_EMPTY", "UNRELATED_SECRET"} {
+	for _, key := range []string{"GC_HOME", "PATH", "XDG_RUNTIME_DIR", "IGNORED_EMPTY", "UNRELATED_SECRET", "AWS_PAGER"} {
 		if _, ok := got[key]; ok {
 			t.Fatalf("ExtraEnv should not include %s: %#v", key, got)
 		}
@@ -534,6 +541,9 @@ func TestBuildSupervisorServiceDataOmitsProviderEnvWhenOptedOut(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-openai-123")
 	t.Setenv("GEMINI_API_KEY", "gemini-123")
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "gc-project")
+	t.Setenv("DEEPSEEK_API_KEY", "ds-123")
+	t.Setenv("OLLAMA_HOST", "http://localhost:11434")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIA123")
 	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(homeDir, ".claude"))
 	t.Setenv("GC_SUPERVISOR_ENV", "CUSTOM_PROVIDER_TOKEN")
 	t.Setenv("CUSTOM_PROVIDER_TOKEN", "custom-token")
@@ -551,6 +561,9 @@ func TestBuildSupervisorServiceDataOmitsProviderEnvWhenOptedOut(t *testing.T) {
 		"OPENAI_API_KEY",
 		"GEMINI_API_KEY",
 		"GOOGLE_CLOUD_PROJECT",
+		"DEEPSEEK_API_KEY",
+		"OLLAMA_HOST",
+		"AWS_ACCESS_KEY_ID",
 	} {
 		if _, ok := got[key]; ok {
 			t.Fatalf("ExtraEnv should not include provider key %s when %s=1: %#v",
@@ -590,7 +603,6 @@ func TestBuildSupervisorServiceDataForwardsAllKnownProviderPrefixes(t *testing.T
 	// One canonical probe key per documented prefix.
 	probes := map[string]string{
 		"ANTHROPIC_API_KEY":    "sk-ant-probe",
-		"AWS_ACCESS_KEY_ID":    "AKIA-probe",
 		"AZURE_OPENAI_API_KEY": "azure-openai-probe",
 		"CEREBRAS_API_KEY":     "cb-probe",
 		"COHERE_API_KEY":       "cohere-probe",
@@ -623,6 +635,64 @@ func TestBuildSupervisorServiceDataForwardsAllKnownProviderPrefixes(t *testing.T
 	for k, want := range probes {
 		if got[k] != want {
 			t.Errorf("ExtraEnv[%s] = %q, want %q — prefix may be missing from providerCredentialEnvPrefixes", k, got[k], want)
+		}
+	}
+}
+
+func TestBuildSupervisorServiceDataForwardsCuratedProviderCredentialEnvKeys(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+
+	probes := map[string]string{
+		"AWS_ACCESS_KEY_ID":                      "AKIA-probe",
+		"AWS_BEARER_TOKEN_BEDROCK":               "bedrock-bearer-probe",
+		"AWS_CA_BUNDLE":                          "/tmp/aws-ca-bundle.pem",
+		"AWS_CONFIG_FILE":                        "/tmp/aws-config",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN":      "container-auth-probe",
+		"AWS_CONTAINER_CREDENTIALS_FULL_URI":     "http://127.0.0.1/credentials",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/probe",
+		"AWS_DEFAULT_REGION":                     "us-west-2",
+		"AWS_EC2_METADATA_DISABLED":              "true",
+		"AWS_ENDPOINT_URL":                       "https://aws.example.test",
+		"AWS_ENDPOINT_URL_BEDROCK":               "https://bedrock.example.test",
+		"AWS_PROFILE":                            "gascity",
+		"AWS_REGION":                             "us-east-1",
+		"AWS_ROLE_ARN":                           "arn:aws:iam::123456789012:role/gascity",
+		"AWS_SDK_LOAD_CONFIG":                    "1",
+		"AWS_SECRET_ACCESS_KEY":                  "aws-secret-probe",
+		"AWS_SESSION_TOKEN":                      "aws-session-probe",
+		"AWS_SHARED_CREDENTIALS_FILE":            "/tmp/aws-credentials",
+		"AWS_USE_DUALSTACK_ENDPOINT":             "true",
+		"AWS_USE_FIPS_ENDPOINT":                  "true",
+		"AWS_WEB_IDENTITY_TOKEN_FILE":            "/tmp/aws-web-identity-token",
+	}
+	if len(probes) != len(providerCredentialEnvKeys) {
+		t.Fatalf("probe set size %d does not match exact provider key set size %d; update the test when exact keys change",
+			len(probes), len(providerCredentialEnvKeys))
+	}
+	for k, v := range probes {
+		t.Setenv(k, v)
+	}
+	for _, key := range []string{"AWS_EXECUTION_ENV", "AWS_PAGER", "AWS_VAULT"} {
+		t.Setenv(key, "not-provider-auth")
+	}
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for k, want := range probes {
+		if got[k] != want {
+			t.Errorf("ExtraEnv[%s] = %q, want %q - exact provider key may be missing", k, got[k], want)
+		}
+	}
+	for _, key := range []string{"AWS_EXECUTION_ENV", "AWS_PAGER", "AWS_VAULT"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("ExtraEnv should not include broad AWS runtime state %s", key)
 		}
 	}
 }


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/2439.

Original PR: #2439
Original title: fix(supervisor): widen provider-credential env prefix list
Original state at adoption: OPEN
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

This follow-up preserves the contributor's change that widens the supervisor provider-credential allowlist so managed sessions receive credentials for providers beyond the original Anthropic/Gemini/Google/OpenAI set. The adopted branch was refreshed onto the latest main at f4cd04fa0de634a0942d724b040109baaf981e94 with the same patch-id.

A maintainer follow-up PR is needed because the workflow could not safely push maintainer fixes back to the fork branch with the available token. The contributor commit is preserved, and the maintainer fix narrows AWS handling from a blanket AWS_ prefix to exact Bedrock/AWS credential/configuration keys while adding regression coverage.

Review status: approved after one fix iteration. The review found and resolved broad AWS forwarding, stale GC_SUPERVISOR_OMIT_PROVIDER_CREDS documentation, and missing passthrough coverage for the expanded provider surface. Remaining notes around broad AZURE_/GOOGLE_ namespaces and future redaction cross-checks are non-gating follow-ups.

Local validation run before opening this PR:
- go test -run 'TestPassthroughEnvIncludesProviderCredentialEnv|TestBuildSupervisorServiceDataIncludesProviderEnv|TestBuildSupervisorServiceDataOmitsProviderEnvWhenOptedOut|TestBuildSupervisorServiceDataForwardsAllKnownProviderPrefixes|TestBuildSupervisorServiceDataForwardsCuratedProviderCredentialEnvKeys' ./cmd/gc/
- go vet ./cmd/gc/...
- git diff --check refs/adopt-pr/ga-u1aiex4/upstream-base..HEAD