### PR TITLE
fix(reconciler): rebaseline config-drift hash on pool alias change

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1411,6 +1411,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 						for key, value := range session.UpdatedAliasMetadata(b.Metadata, managedAlias) {
 							queueMeta(key, value)
 						}
+						queueAliasChangeDriftRebaseline(b, tp, queueMeta, stderr)
 					}
 					mergeAliasGuardedBatch()
 				}
@@ -1501,6 +1502,26 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 	}
 
 	return openIndex, newSessionBeadSnapshot(openBeads)
+}
+
+// queueAliasChangeDriftRebaseline moves a started pool session's config-drift
+// baseline onto its post-rename config. A pool alias change re-renders the
+// alias-derived pre_start, which would otherwise trip the reconciler's
+// CoreFingerprint drift check and drain the session. Unstarted sessions (no
+// started_config_hash) are skipped — the start path baselines them.
+// See gastownhall/gascity#2234.
+func queueAliasChangeDriftRebaseline(b beads.Bead, tp TemplateParams, queueMeta func(key, value string), stderr io.Writer) {
+	if strings.TrimSpace(b.Metadata["started_config_hash"]) == "" {
+		return
+	}
+	rebaseline, err := sessionHashRebaselineMetadata(sessionCoreConfigForHash(tp, b))
+	if err != nil {
+		fmt.Fprintf(stderr, "session beads: rebaselining drift baseline after alias change for %s: %v\n", b.ID, err) //nolint:errcheck
+		return
+	}
+	for key, value := range rebaseline {
+		queueMeta(key, value)
+	}
 }
 
 func syncDesiredPoolSlots(

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -3481,6 +3481,150 @@ func TestSyncSessionBeads_ClearsStaleWrongPoolAliasWhenRepairFails(t *testing.T)
 	}
 }
 
+func TestSyncSessionBeads_RebaselinesDriftHashOnPoolAliasChange(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+
+	startedTP := TemplateParams{
+		TemplateName: template,
+		InstanceName: "pack/worker-2",
+		Alias:        "pack/worker-2",
+		Command:      "claude",
+		PoolSlot:     2,
+		Hints: agent.StartupHints{
+			PreStart: []string{"worktree-setup.sh /rig /wt/pack.worker-2 pack.worker-2 --sync"},
+		},
+	}
+	startedCore := runtime.CoreFingerprint(sessionCoreConfigForHash(startedTP, beads.Bead{}))
+
+	live, err := store.Create(beads.Bead{
+		Title:  "pool worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-live",
+			"agent_name":           "pack/worker-2",
+			"command":              "claude",
+			"alias":                "pack/worker-2",
+			"pool_slot":            "2",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			"started_config_hash":  startedCore,
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repairedTP := TemplateParams{
+		TemplateName: template,
+		InstanceName: "pack/worker-2",
+		Alias:        "pack/worker-1",
+		Command:      "claude",
+		PoolSlot:     2,
+		Hints: agent.StartupHints{
+			PreStart: []string{"worktree-setup.sh /rig /wt/pack.worker-1 pack.worker-1 --sync"},
+		},
+	}
+	wantCore := runtime.CoreFingerprint(sessionCoreConfigForHash(repairedTP, beads.Bead{}))
+	if wantCore == startedCore {
+		t.Fatal("test setup: alias-driven pre_start change must alter CoreFingerprint")
+	}
+
+	desired := map[string]TemplateParams{"pack-worker-live": repairedTP}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["alias"] != "pack/worker-1" {
+		t.Fatalf("alias = %q, want pack/worker-1", got.Metadata["alias"])
+	}
+	if got.Metadata["started_config_hash"] == startedCore {
+		t.Fatalf("started_config_hash still at stale pre-rename baseline %q; reconciler would drain as config-drift", startedCore)
+	}
+	if got.Metadata["started_config_hash"] != wantCore {
+		t.Fatalf("started_config_hash = %q, want %q (rebaselined to post-rename config)", got.Metadata["started_config_hash"], wantCore)
+	}
+	if got.Metadata["core_hash_breakdown"] == "" {
+		t.Fatal("core_hash_breakdown not refreshed alongside the rebaselined hash")
+	}
+}
+
+func TestSyncSessionBeads_SkipsDriftRebaselineForUnstartedPoolSession(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 21, 12, 5, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+
+	live, err := store.Create(beads.Bead{
+		Title:  "pool worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-live",
+			"agent_name":           "pack/worker-2",
+			"command":              "claude",
+			"alias":                "pack/worker-2",
+			"pool_slot":            "2",
+			"state":                "creating",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repairedTP := TemplateParams{
+		TemplateName: template,
+		InstanceName: "pack/worker-2",
+		Alias:        "pack/worker-1",
+		Command:      "claude",
+		PoolSlot:     2,
+		Hints: agent.StartupHints{
+			PreStart: []string{"worktree-setup.sh /rig /wt/pack.worker-1 pack.worker-1 --sync"},
+		},
+	}
+	desired := map[string]TemplateParams{"pack-worker-live": repairedTP}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["alias"] != "pack/worker-1" {
+		t.Fatalf("alias = %q, want pack/worker-1", got.Metadata["alias"])
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q, want empty for a session that never started", got.Metadata["started_config_hash"])
+	}
+}
+
 func TestSyncSessionBeads_ManagedPoolAliasValidationKeepsCleanAlias(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 14, 0, 0, time.UTC)}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2750,6 +2750,24 @@ func rebaselineLegacyHashOutcome(stored string) TraceOutcomeCode {
 	return TraceOutcomeRebaselinedUnversioned
 }
 
+// sessionHashRebaselineMetadata builds the four fingerprint metadata fields
+// — started_config_hash, started_live_hash, live_hash, core_hash_breakdown —
+// from a resolved agent config. Callers merge the result into a session
+// bead's metadata batch to move its config-drift baseline to agentCfg.
+func sessionHashRebaselineMetadata(agentCfg runtime.Config) (map[string]string, error) {
+	breakdownJSON, err := json.Marshal(runtime.CoreFingerprintBreakdown(agentCfg))
+	if err != nil {
+		return nil, fmt.Errorf("marshaling core_hash_breakdown: %w", err)
+	}
+	liveHash := runtime.LiveFingerprint(agentCfg)
+	return map[string]string{
+		"started_config_hash": runtime.CoreFingerprint(agentCfg),
+		"started_live_hash":   liveHash,
+		"live_hash":           liveHash,
+		"core_hash_breakdown": string(breakdownJSON),
+	}, nil
+}
+
 // silentRebaselineSessionHashes overwrites the four fingerprint metadata
 // fields (started_config_hash, started_live_hash, live_hash,
 // core_hash_breakdown) with values produced by the current binary. Used
@@ -2761,18 +2779,9 @@ func silentRebaselineSessionHashes(session *beads.Bead, store beads.Store, agent
 	if session == nil || store == nil {
 		return nil
 	}
-	coreHash := runtime.CoreFingerprint(agentCfg)
-	liveHash := runtime.LiveFingerprint(agentCfg)
-	breakdown := runtime.CoreFingerprintBreakdown(agentCfg)
-	breakdownJSON, err := json.Marshal(breakdown)
+	patch, err := sessionHashRebaselineMetadata(agentCfg)
 	if err != nil {
-		return fmt.Errorf("marshaling core_hash_breakdown: %w", err)
-	}
-	patch := map[string]string{
-		"started_config_hash": coreHash,
-		"started_live_hash":   liveHash,
-		"live_hash":           liveHash,
-		"core_hash_breakdown": string(breakdownJSON),
+		return err
 	}
 	if err := store.SetMetadataBatch(session.ID, patch); err != nil {
 		return fmt.Errorf("rebaselining hashes: %w", err)


### PR DESCRIPTION
## Summary

Fixes #2234 — pool polecat sessions self-drain mid-task with `sleep_reason=config-drift` and orphan their in-flight work beads.

**Root cause.** Pool agent templates render `pre_start` (and `work_dir`) from `{{.AgentBase}}`, which resolves from the session alias. When the controller repairs a *started* pool session's alias — e.g. PR #2076's alias-repair renaming an adhoc polecat into a vacated named slot — `pre_start` re-renders to a different string. The reconciler's `CoreFingerprint` drift check then sees `storedHash != currentHash` and drains the session as config-drifted, even though nothing meaningful changed.

**Fix (Option A from #2234).** When `syncSessionBeads` writes an alias change for a started pool session, it now also recomputes the four fingerprint metadata fields (`started_config_hash`, `started_live_hash`, `live_hash`, `core_hash_breakdown`) in the *same write batch* as the alias change. The post-rename config becomes the new drift baseline, so the spurious drain no longer fires — while PR #2076's alias-repair intent is preserved.

- Unstarted sessions (no `started_config_hash`) are skipped: the start path baselines them, and the drift check is already gated on a non-empty stored hash.
- Extracts `sessionHashRebaselineMetadata` so the new alias-change path and the existing `silentRebaselineSessionHashes` share the fingerprint-field construction.

## Testing

- [x] `make check`
- [ ] `make check-docs`
- [ ] `make test-integration`

New unit tests in `cmd/gc/session_beads_test.go`:
- `TestSyncSessionBeads_RebaselinesDriftHashOnPoolAliasChange` — a started pool session whose alias is repaired gets `started_config_hash` moved to the post-rename config (not left stale) and `core_hash_breakdown` refreshed.
- `TestSyncSessionBeads_SkipsDriftRebaselineForUnstartedPoolSession` — an unstarted session gets no fingerprint metadata written early.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes