### PR TITLE
fix(reconciler): keep pool session desired while it owns assigned work

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1302,6 +1302,15 @@ func discoverSessionBeadsWithRoots(
 			creating := b.Metadata["state"] == "creating"
 			pendingCreate := isPendingPoolCreate(b)
 			templateDesired := desiredHasTemplate(desired, template)
+			// A pool session that currently owns open/in-progress assigned
+			// work must stay in desired state even when templateDesired is
+			// false. A min_active_sessions=0 pool worker produces zero
+			// scale_check demand once it claims its bead, so templateDesired
+			// flips false while the session is actively working. Dropping it
+			// here routes a live worker to the orphan drain (GH#1029). An
+			// idle bead with no assigned work still drops below, so
+			// scale-to-zero is preserved.
+			hasAssignedWork := sessionBeadHasAssignedWork(bp.assignedWorkBeads, b)
 			// Pool-managed beads are controller-created capacity. A pending
 			// or creating bead that the pool pass did not select is stale
 			// capacity, not a reason to spawn a worker with an empty hook.
@@ -1316,10 +1325,10 @@ func discoverSessionBeadsWithRoots(
 				continue
 			}
 			if controllerManagedPool && !manualSession && !isNamedSessionBead(b) &&
-				!sessionAlreadyDesired && !templateDesired && !scaleCheckPartial {
+				!sessionAlreadyDesired && !templateDesired && !scaleCheckPartial && !hasAssignedWork {
 				continue
 			}
-			if !manualSession && (!creating || isStaleCreating(b)) && !templateDesired && !pendingCreate && !scaleCheckPartial {
+			if !manualSession && (!creating || isStaleCreating(b)) && !templateDesired && !pendingCreate && !scaleCheckPartial && !hasAssignedWork {
 				continue
 			}
 		}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2905,6 +2905,123 @@ func TestDiscoverSessionBeadsSkipsStaleMaxOneWhenDependencyFloorDesired(t *testi
 	}
 }
 
+// TestDiscoverSessionBeadsKeepsPoolSessionWithAssignedWorkWhenTemplateUndesired
+// reproduces GH#1029: a live pool worker with min_active_sessions=0 produces
+// zero scale_check demand once it claims its bead, so templateDesired flips
+// false even though the session is actively working its assigned bead. The
+// rediscovery overlay must keep that session bead in desired state so the
+// reconciler does not classify it as orphaned and drain it mid-work.
+func TestDiscoverSessionBeadsKeepsPoolSessionWithAssignedWorkWhenTemplateUndesired(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "gascity/worker-1",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/worker-1", "template:gascity/worker"},
+		Metadata: map[string]string{
+			"template":             "gascity/worker",
+			"agent_name":           "gascity/worker-1",
+			"alias":                "gascity/worker-1",
+			"session_name":         "s-worker-busy",
+			"state":                "awake",
+			poolManagedMetadataKey: boolMetadata(true),
+			"pool_slot":            "1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workBead, err := store.Create(beads.Bead{
+		Title:    "in-progress task",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: sessionBead.Metadata["session_name"],
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &sessionBeadSnapshot{}
+	snapshot.add(sessionBead)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "gascity",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		}},
+	}
+	// templateDesired is false: the pool pass produced zero requests for this
+	// template (no scale_check demand, min_active_sessions=0).
+	desired := map[string]TemplateParams{}
+	bp := &agentBuildParams{
+		cityPath:          t.TempDir(),
+		city:              cfg,
+		beadStore:         store,
+		sessionBeads:      snapshot,
+		agents:            cfg.Agents,
+		assignedWorkBeads: []beads.Bead{workBead},
+	}
+
+	discoverSessionBeadsWithRoots(bp, cfg, desired, nil, nil, nil, io.Discard)
+
+	if _, ok := desired[sessionBead.Metadata["session_name"]]; !ok {
+		t.Fatalf("desired state dropped a pool session that still owns assigned work; keys=%v", mapKeys(desired))
+	}
+}
+
+// TestDiscoverSessionBeadsDropsIdlePoolSessionWhenTemplateUndesired guards the
+// scale-to-zero invariant: an idle pool-managed session bead with no assigned
+// work and templateDesired false must still be dropped from desired state so
+// the pool can scale down. The GH#1029 fix only retains busy sessions.
+func TestDiscoverSessionBeadsDropsIdlePoolSessionWhenTemplateUndesired(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "gascity/worker-1",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/worker-1", "template:gascity/worker"},
+		Metadata: map[string]string{
+			"template":             "gascity/worker",
+			"agent_name":           "gascity/worker-1",
+			"alias":                "gascity/worker-1",
+			"session_name":         "s-worker-idle",
+			"state":                "awake",
+			poolManagedMetadataKey: boolMetadata(true),
+			"pool_slot":            "1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &sessionBeadSnapshot{}
+	snapshot.add(sessionBead)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "gascity",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		}},
+	}
+	desired := map[string]TemplateParams{}
+	bp := &agentBuildParams{
+		cityPath:          t.TempDir(),
+		city:              cfg,
+		beadStore:         store,
+		sessionBeads:      snapshot,
+		agents:            cfg.Agents,
+		assignedWorkBeads: nil,
+	}
+
+	discoverSessionBeadsWithRoots(bp, cfg, desired, nil, nil, nil, io.Discard)
+
+	if _, ok := desired[sessionBead.Metadata["session_name"]]; ok {
+		t.Fatalf("desired state revived an idle pool session with no work; keys=%v", mapKeys(desired))
+	}
+}
+
 func TestNonExpandingPoolIdentitySlotRecognizesOutOfRangeNumericSuffix(t *testing.T) {
 	cfgAgent := &config.Agent{
 		Name:              "refinery",


### PR DESCRIPTION
## The bug

A live, actively-working pool session gets classified `orphaned` and drained, and its in-progress work bead is reassigned to a duplicate session.

## Root cause

In `cmd/gc/build_desired_state.go`, function `discoverSessionBeadsWithRoots`, the rediscovery overlay has two `continue` guards that drop a session bead from the desired-state map. Both are keyed on `!templateDesired` — the pool desired-state pass produced zero requests for the template this tick:

- the first guard handles `controllerManagedPool` beads (`... && !templateDesired && !scaleCheckPartial`)
- the second is the fallthrough (`... && !templateDesired && !pendingCreate && !scaleCheckPartial`)

When a pool worker with `min_active_sessions=0` claims its bead, `scale_check` returns 0 and there is no min-fill request, so `templateDesired` goes false **even though the session is actively working**. The overlay then drops the live worker's bead, and `session_reconciler.go`'s `if !desired` branch drains it with the non-cancelable reason `orphaned`. Its in-progress bead is then reassigned to a duplicate session.

## The fix

Compute `hasAssignedWork := sessionBeadHasAssignedWork(bp.assignedWorkBeads, b)` near where `templateDesired` is computed — reusing the existing `sessionBeadHasAssignedWork` helper (already used by `reusablePoolSessionBead`) and the pool-filtered `bp.assignedWorkBeads` snapshot — and add `&& !hasAssignedWork` to **both** `!templateDesired` guards.

A pool session bead that currently owns open/in-progress assigned work is now kept in `desiredState` regardless of `templateDesired`, so it is never routed to the orphan drain.

## Why it is safe

- An idle bead (no assigned work) still drops, so **scale-to-zero is preserved**.
- This is the grace-window direction — it makes the drain *less* aggressive, not more — aligning with sjarmak's note in the issue thread that the proper fix should make drain less aggressive.
- No drain path is made more aggressive; the change only adds a retention condition.
- Scope is deliberately minimal: one logic change plus tests. The `session_wake.go` cancelable-drain idea is out of scope.

## Tests added

In `cmd/gc/build_desired_state_test.go`:

- `TestDiscoverSessionBeadsKeepsPoolSessionWithAssignedWorkWhenTemplateUndesired` — seeds an open, pool-managed session bead plus an in-progress work bead assigned to it, with `templateDesired` false (`min_active_sessions=0`, no scale_check demand). Asserts the session bead **is** retained in `desired`. Fails before the change, passes after.
- `TestDiscoverSessionBeadsDropsIdlePoolSessionWhenTemplateUndesired` — an idle pool-managed session bead with no assigned work and `templateDesired` false is still dropped. Guards the scale-to-zero invariant; passes before and after.

`go vet ./...` is clean. The `discoverSessionBeads` / `BuildDesiredState` / `PoolSession` test families pass.

Fixes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)