### PR TITLE
fix: harden malformed beads config repair

### DIFF
--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -620,10 +620,9 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		}
 		want, manage := replacements[key]
 		if !manage {
-			// Per YAML semantics, last-write-wins for duplicate top-level
-			// keys. Drop earlier occurrences so the canonical writer
-			// converges on a single entry per key.
-			if i != lastTopLevelIndex[key] {
+			// When fallback rewrites malformed input, keep YAML's
+			// last-write-wins semantics for duplicate top-level keys.
+			if key != "" && i != lastTopLevelIndex[key] {
 				changed = true
 				continue
 			}
@@ -956,7 +955,8 @@ func repairMalformedConfigLines(lines []string) ([]string, bool) {
 // key. Returns the original line as a one-element slice when no split is
 // possible.
 func splitGluedConfigLine(line string) []string {
-	if strings.TrimLeft(line, " \t") != line {
+	trimmedLeft := strings.TrimLeft(line, " \t")
+	if trimmedLeft != line || strings.HasPrefix(trimmedLeft, "#") {
 		return []string{line}
 	}
 	colon := strings.Index(line, ":")
@@ -973,7 +973,7 @@ func splitGluedConfigLine(line string) []string {
 		return []string{line}
 	}
 	afterQuote := quoteStart + 1 + quoteEnd + 1
-	tail := rest[afterQuote:]
+	tail := strings.TrimLeft(rest[afterQuote:], " \t")
 	if !looksLikeTopLevelKeyStart(tail) {
 		return []string{line}
 	}
@@ -1001,6 +1001,8 @@ func looksLikeTopLevelKeyStart(s string) bool {
 }
 
 func isYamlKeyRune(r rune) bool {
+	// This is intentionally a narrow .beads/config.yaml repair heuristic,
+	// not a general YAML key parser.
 	switch {
 	case r >= 'a' && r <= 'z':
 		return true
@@ -1022,6 +1024,9 @@ func lastTopLevelKeyIndex(lines []string) map[string]int {
 	last := make(map[string]int, len(lines))
 	for i, line := range lines {
 		if key, _, ok := topLevelConfigLine(line); ok {
+			if key == "" {
+				continue
+			}
 			last[key] = i
 		}
 	}

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -391,7 +391,7 @@ func TestEnsureCanonicalConfigRepairsGluedSyncRemoteLine(t *testing.T) {
 		"gc.endpoint_origin: inherited_city",
 		"gc.endpoint_status: verified",
 		"",
-		`sync.remote: "git+ssh://git@example.com/foo/service-inventory.git"types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step`,
+		`sync.remote: "git+ssh://git@example.com/foo/service-inventory.git"  types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step`,
 		"types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step",
 		"",
 	}, "\n")
@@ -435,12 +435,24 @@ func TestEnsureCanonicalConfigRepairsGluedSyncRemoteLine(t *testing.T) {
 	if got := countLineOccurrences(text, "types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step"); got != 1 {
 		t.Fatalf("types.custom should appear exactly once, found %d:\n%s", got, text)
 	}
+
+	changed, err = EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "si",
+		EndpointOrigin: EndpointOriginInheritedCity,
+		EndpointStatus: EndpointStatusVerified,
+	})
+	if err != nil {
+		t.Fatalf("second EnsureCanonicalConfig() error = %v", err)
+	}
+	if changed {
+		t.Fatalf("second EnsureCanonicalConfig() should be idempotent:\n%s", text)
+	}
 }
 
 // TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair ensures
-// that when fallback repairs are needed, duplicate top-level keys are
+// that when fallback rewrites malformed input, duplicate top-level keys are
 // collapsed even when they aren't in the managed set. YAML semantics say
-// last-write-wins; the canonical writer should match.
+// last-write-wins, and this fallback rewrite should match.
 func TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()
@@ -475,6 +487,103 @@ func TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair(t *testing.T)
 	}
 	if count := countLineOccurrences(text, "types.custom: second-value"); count != 1 {
 		t.Fatalf("expected exactly one types.custom line, found %d:\n%s", count, text)
+	}
+}
+
+func TestEnsureCanonicalConfigFallbackPreservesEmptyKeyMalformedLines(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue_prefix: gc",
+		": first malformed line",
+		": second malformed line",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, needle := range []string{": first malformed line", ": second malformed line"} {
+		if got := countLineOccurrences(text, needle); got != 1 {
+			t.Fatalf("expected malformed line %q to be preserved once, found %d:\n%s", needle, got, text)
+		}
+	}
+}
+
+func TestSplitGluedConfigLine(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "adjacent key",
+			line: `sync.remote: "git+ssh://git@example.com/foo.git"types.custom: molecule`,
+			want: []string{
+				`sync.remote: "git+ssh://git@example.com/foo.git"`,
+				"types.custom: molecule",
+			},
+		},
+		{
+			name: "horizontal whitespace before glued key",
+			line: `sync.remote: "git+ssh://git@example.com/foo.git"  types.custom: molecule`,
+			want: []string{
+				`sync.remote: "git+ssh://git@example.com/foo.git"`,
+				"types.custom: molecule",
+			},
+		},
+		{
+			name: "recursive chain",
+			line: `sync.remote: "git+ssh://git@example.com/foo.git"types.custom: "molecule"gc.endpoint_origin: managed_city`,
+			want: []string{
+				`sync.remote: "git+ssh://git@example.com/foo.git"`,
+				`types.custom: "molecule"`,
+				"gc.endpoint_origin: managed_city",
+			},
+		},
+		{
+			name: "comment line",
+			line: `# sync.remote: "git+ssh://git@example.com/foo.git"types.custom: molecule`,
+			want: []string{`# sync.remote: "git+ssh://git@example.com/foo.git"types.custom: molecule`},
+		},
+		{
+			name: "indented line",
+			line: `  sync.remote: "git+ssh://git@example.com/foo.git"types.custom: molecule`,
+			want: []string{`  sync.remote: "git+ssh://git@example.com/foo.git"types.custom: molecule`},
+		},
+		{
+			name: "unbalanced quote",
+			line: `sync.remote: "git+ssh://git@example.com/foo.gittypes.custom: molecule`,
+			want: []string{`sync.remote: "git+ssh://git@example.com/foo.gittypes.custom: molecule`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitGluedConfigLine(tc.line)
+			if len(got) != len(tc.want) {
+				t.Fatalf("splitGluedConfigLine() = %#v, want %#v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("splitGluedConfigLine()[%d] = %q, want %q; all got %#v", i, got[i], tc.want[i], got)
+				}
+			}
+		})
 	}
 }
 
@@ -981,7 +1090,7 @@ func TestReadDoltDatabase(t *testing.T) {
 func countLineOccurrences(text, needle string) int {
 	count := 0
 	for _, line := range strings.Split(text, "\n") {
-		if strings.TrimSpace(line) == needle {
+		if line == needle {
 			count++
 		}
 	}


### PR DESCRIPTION
Post-merge remediation for #2115.\n\nAddresses the required review findings by:\n- preserving comment lines during glued config repair\n- repairing quoted glued keys with horizontal whitespace before the next key\n- preserving malformed empty-key lines instead of collapsing them as duplicates\n- adding direct splitter coverage and post-repair idempotency coverage\n\nValidation:\n- go test ./internal/beads/contract\n- make test-fast-parallel\n- go vet ./...\n- git diff --check\n- .githooks/pre-commit