### PR TITLE
docs(gastown): replace deprecated inline [[agent]] crew example with directory-agent + named_session

### DIFF
--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -40,21 +40,30 @@ formula_v2 = true
 # name = "myproject"
 # path = "/path/to/your/project"
 
-# Crew members are individually named, so they can't be pack-stamped:
-# [[agent]]
-# name = "wolf"
+# Crew members are persistent, individually named workers, so they can't be
+# pack-stamped. Each one is a directory agent under agents/<name>/ plus a
+# named session that keeps it alive. To add a crew member "wolf" bound to a
+# registered rig "myproject":
+#
+#   1. Create agents/wolf/agent.toml (relative paths resolve against this
+#      city directory):
+#
+#        scope = "rig"
+#        dir = "myproject"
+#        nudge = "Check your hook and mail, then act accordingly."
+#        work_dir = ".gc/worktrees/myproject/crew/wolf"
+#        idle_timeout = "4h"
+#        prompt_template = "packs/gastown/assets/prompts/crew.template.md"
+#        pre_start = ["packs/gastown/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
+#
+#      tmux theming comes from the gastown pack's [global] session_live hooks,
+#      so crew members need no session_setup wiring of their own.
+#
+#   2. Keep the crew session alive by declaring a named session here. The
+#      dir must match the agent's so the session resolves to "myproject/wolf":
+#
+# [[named_session]]
+# template = "wolf"
 # dir = "myproject"
-# pre_start = ["packs/gastown/assets/scripts/worktree-setup.sh /path/to/myproject /path/to/city/.gc/worktrees/myproject/wolf wolf --sync"]
-# prompt_template = "packs/gastown/assets/prompts/crew.template.md"
-# nudge = "Check your hook and mail, then act accordingly."
-# overlay_dir = "packs/gastown/agents/wolf/overlay"
-# idle_timeout = "4h"
-# session_setup_script = "packs/gastown/assets/scripts/tmux-theme.sh"
-# session_setup = [
-#     "tmux ${GC_TMUX_SOCKET:+-L $GC_TMUX_SOCKET} set-option -t {{.Session}} status-right-length 80",
-#     "tmux ${GC_TMUX_SOCKET:+-L $GC_TMUX_SOCKET} set-option -t {{.Session}} status-interval 5",
-#     "tmux ${GC_TMUX_SOCKET:+-L $GC_TMUX_SOCKET} set-option -t {{.Session}} status-right '#({{.ConfigDir}}/assets/scripts/status-line.sh {{.Agent}}) %H:%M'",
-#     "{{.ConfigDir}}/assets/scripts/bind-key.sh n \"run-shell '{{.ConfigDir}}/assets/scripts/cycle.sh next #{session_name} #{client_tty}'\"",
-#     "{{.ConfigDir}}/assets/scripts/bind-key.sh p \"run-shell '{{.ConfigDir}}/assets/scripts/cycle.sh prev #{session_name} #{client_tty}'\"",
-#     "{{.ConfigDir}}/assets/scripts/bind-key.sh g \"run-shell '{{.ConfigDir}}/assets/scripts/agent-menu.sh #{client_tty}'\"",
-# ]
+# scope = "rig"
+# mode = "always"

--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -54,7 +54,7 @@ formula_v2 = true
 #        work_dir = ".gc/worktrees/myproject/crew/wolf"
 #        idle_timeout = "4h"
 #        prompt_template = "packs/gastown/assets/prompts/crew.template.md"
-#        pre_start = ["packs/gastown/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
+#        pre_start = ["{{.CityRoot}}/packs/gastown/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.WorkDir}} {{.AgentBase}} --sync"]
 #
 #      tmux theming comes from the gastown pack's [global] session_live hooks,
 #      so crew members need no session_setup wiring of their own.

--- a/examples/gastown/packs/gastown/pack.toml
+++ b/examples/gastown/packs/gastown/pack.toml
@@ -9,7 +9,8 @@
 #   workspace.pack → expands city-scoped agents only (mayor, deacon, boot)
 #   rigs[].pack    → expands rig agents only (witness, refinery, polecat)
 #
-# Crew members are individually named and declared inline in city.toml.
+# Crew members are individually named directory agents (agents/<name>/) plus a
+# named session; see the worked example in examples/gastown/city.toml.
 
 [pack]
 name = "gastown"


### PR DESCRIPTION
## Summary

The commented crew example in `examples/gastown/city.toml` taught a **v2-deprecated** inline `[[agent]]` pattern — `gc start` warns `[[agent]] tables are deprecated in v2; use directory-based agents under agents/<name>/` and no longer registers/starts a session from such a declaration. The block was also doubly stale: it used legacy `session_setup` / `session_setup_script` fields (superseded by the gastown pack's `[global]` → `session_live` hooks) and literal `/path/to/...` placeholders, and it contradicted the project's own docs (`docs/tutorials/03-sessions.md`, `docs/getting-started/coming-from-gastown.md`).

This replaces it with the canonical directory-agent + `[[named_session]]` crew pattern those docs teach:

- a directory agent under `agents/<name>/` (`scope = "rig"`, `dir`, `work_dir`, `prompt_template`, `pre_start`) using template vars (`{{.RigRoot}}`, `{{.WorkDir}}`, `{{.AgentBase}}`) instead of `/path/to/...`;
- tmux theming via the pack's `[global]` → `session_live` hooks, so `session_setup` wiring is dropped;
- a `[[named_session]]` with a matching `dir` so the crew session resolves to a stable `myproject/wolf`.

The `packs/gastown/pack.toml` comment ("declared inline in city.toml") is updated to match. Docs-only — no behavior change.

## Testing

- [x] `make check-docs` — `ok github.com/gastownhall/gascity/test/docsync`
- [x] `go test ./examples/gastown/` — passes; `go vet ./examples/gastown/` clean
- [x] Verified the documented pattern in a throwaway gastown city: materialized `agents/wolf/agent.toml` + the `[[named_session]]` exactly as documented, then `gc start --dry-run` (gc 1.1.1):

```
Dry-run: 4 agent(s) would start in city "gastown"
  gastown.boot     session=gastown__boot
  gastown.deacon   session=gastown__deacon
  gastown.mayor    session=gastown__mayor
  myproject/wolf   session=myproject--wolf
```

## Checklist

- [x] Linked an issue — Fixes #2468
- [x] Docs-only change (no code/tests changed); existing `examples/gastown` tests and docsync still pass
- [x] No breaking changes — corrects a stale commented example to match current PackV2 behavior and the docs