### PR TITLE
fix: harden async drain-ack stop handling

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime/debug"
 	"sort"
@@ -2166,7 +2167,8 @@ func sweepUndesiredPoolSessionBeads(
 		if agentCfg == nil || !isEphemeralSessionBead(bead) {
 			continue
 		}
-		if running, err := poolSessionBeadRuntimeRunning(bead, sp); err == nil && running {
+		processNames := config.AgentProcessNames(cfg, *agentCfg, exec.LookPath)
+		if running, err := poolSessionBeadRuntimeRunning(bead, sp, processNames); err == nil && running {
 			continue
 		}
 		candidates = append(candidates, bead)
@@ -2174,7 +2176,7 @@ func sweepUndesiredPoolSessionBeads(
 	return len(GCSweepSessionBeads(store, rigStores, candidates))
 }
 
-func poolSessionBeadRuntimeRunning(bead beads.Bead, sp runtime.Provider) (bool, error) {
+func poolSessionBeadRuntimeRunning(bead beads.Bead, sp runtime.Provider, processNames []string) (bool, error) {
 	if sp == nil {
 		return false, fmt.Errorf("pool session runtime check: %w", runtime.ErrSessionNotFound)
 	}
@@ -2182,10 +2184,10 @@ func poolSessionBeadRuntimeRunning(bead beads.Bead, sp runtime.Provider) (bool, 
 	if name == "" {
 		return false, fmt.Errorf("pool session runtime check missing session name: %w", runtime.ErrSessionNotFound)
 	}
-	// The sweep only needs provider-runtime presence, not process aliveness or
-	// attachment/activity details. ObserveLiveness preserves provider-native
-	// running semantics without the heavier worker observation path.
-	return runtime.ObserveLiveness(sp, name, nil).Running, nil
+	// The sweep only needs provider-runtime/process presence, not attachment or
+	// activity details. Process-name hints preserve the same false-negative
+	// recovery used by worker observation without the heavier handle path.
+	return runtime.ObserveLiveness(sp, name, processNames).Running, nil
 }
 
 // pendingCreateClaimStillLeasedForSweep keeps pending_create_claim protection

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -37,6 +37,15 @@ func (p *sweepLivenessProvider) ObserveLiveness(name string, _ []string) runtime
 	return runtime.Liveness{Running: p.running[name]}
 }
 
+type sweepIsRunningFalseNegativeProvider struct {
+	*runtime.Fake
+}
+
+func (p *sweepIsRunningFalseNegativeProvider) IsRunning(name string) bool {
+	_ = p.Fake.IsRunning(name)
+	return false
+}
+
 func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
@@ -81,6 +90,61 @@ func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	}
 	if got.Status == "closed" {
 		t.Fatalf("running pool bead was closed: %+v", got)
+	}
+}
+
+func TestSweepUndesiredPoolSessionBeads_UsesProcessNameFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-process-alive",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+			"continuation_epoch":   "1",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+	sp := &sweepIsRunningFalseNegativeProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "worker-bd-process-alive", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		nil,
+		sessionBeads,
+		nil,
+		&config.City{Agents: []config.Agent{{
+			Name:              "worker",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(2),
+			ProcessNames:      []string{"agent-cli"},
+		}}},
+		sp,
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 when process-name liveness recovers IsRunning false negative", closed)
+	}
+	if got := sp.CountCalls("ProcessAlive", "worker-bd-process-alive"); got == 0 {
+		t.Fatal("ProcessAlive was not checked with configured process-name hints")
+	}
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("process-alive pool bead was closed: %+v", got)
 	}
 }
 
@@ -175,10 +239,10 @@ func TestSweepUndesiredPoolSessionBeads_UsesRuntimeLivenessObservation(t *testin
 }
 
 func TestPoolSessionBeadRuntimeRunningUsesRuntimeNotFoundSentinel(t *testing.T) {
-	if _, err := poolSessionBeadRuntimeRunning(beads.Bead{}, nil); !errors.Is(err, runtime.ErrSessionNotFound) {
+	if _, err := poolSessionBeadRuntimeRunning(beads.Bead{}, nil, nil); !errors.Is(err, runtime.ErrSessionNotFound) {
 		t.Fatalf("nil provider error = %v, want runtime.ErrSessionNotFound", err)
 	}
-	if _, err := poolSessionBeadRuntimeRunning(beads.Bead{Metadata: map[string]string{}}, runtime.NewFake()); !errors.Is(err, runtime.ErrSessionNotFound) {
+	if _, err := poolSessionBeadRuntimeRunning(beads.Bead{Metadata: map[string]string{}}, runtime.NewFake(), nil); !errors.Is(err, runtime.ErrSessionNotFound) {
 		t.Fatalf("missing session name error = %v, want runtime.ErrSessionNotFound", err)
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -279,9 +279,10 @@ func withTaskWorkDirResolver(resolver taskWorkDirResolver) startExecutionOption 
 }
 
 type asyncStartTracker struct {
-	mu       sync.Mutex
-	wg       sync.WaitGroup
-	stopping bool
+	mu               sync.Mutex
+	wg               sync.WaitGroup
+	stopping         bool
+	drainAckStopKeys sync.Map
 }
 
 func (t *asyncStartTracker) start() (func(), bool) {
@@ -295,6 +296,28 @@ func (t *asyncStartTracker) start() (func(), bool) {
 	}
 	t.wg.Add(1)
 	return t.wg.Done, true
+}
+
+func (t *asyncStartTracker) startDrainAckStop(key string) (func(), bool) {
+	if t == nil {
+		return func() {}, true
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return t.start()
+	}
+	if _, loaded := t.drainAckStopKeys.LoadOrStore(key, struct{}{}); loaded {
+		return nil, false
+	}
+	done, ok := t.start()
+	if !ok {
+		t.drainAckStopKeys.Delete(key)
+		return nil, false
+	}
+	return func() {
+		t.drainAckStopKeys.Delete(key)
+		done()
+	}, true
 }
 
 func (t *asyncStartTracker) wait(timeout time.Duration) bool {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/api"
@@ -29,11 +29,6 @@ import (
 )
 
 const maxIdleSleepProbesPerTick = 3
-
-// drainAckAsyncStops deduplicates process-local async stop goroutines. A
-// controller restart can briefly double-stop through a fresh process map; stop
-// providers are idempotent and SessionGone errors are suppressed below.
-var drainAckAsyncStops sync.Map
 
 type wakeTarget struct {
 	session *beads.Bead
@@ -90,15 +85,11 @@ func clearDrainTrackerForStopPending(session *beads.Bead, dt *drainTracker) {
 	dt.remove(session.ID)
 }
 
-func drainAckAsyncStopKey(store beads.Store, cityPath, sessionID, name string) string {
-	scope := strings.TrimSpace(cityPath)
-	if scope == "" {
-		scope = fmt.Sprintf("store:%p", store)
-	}
+func drainAckAsyncStopKey(sessionID, name string) string {
 	if id := strings.TrimSpace(sessionID); id != "" {
-		return fmt.Sprintf("city:%s\x00id:%s", scope, id)
+		return "id:" + id
 	}
-	return fmt.Sprintf("city:%s\x00name:%s", scope, strings.TrimSpace(name))
+	return "name:" + strings.TrimSpace(name)
 }
 
 func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, sessionID, name string, tracker *asyncStartTracker, stderr io.Writer) {
@@ -109,27 +100,17 @@ func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provi
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	key := drainAckAsyncStopKey(store, cityPath, sessionID, name)
-	if _, loaded := drainAckAsyncStops.LoadOrStore(key, struct{}{}); loaded {
+	key := drainAckAsyncStopKey(sessionID, name)
+	done, tracking := tracker.startDrainAckStop(key)
+	if !tracking {
 		return
-	}
-	done := func() {}
-	if tracker != nil {
-		var tracking bool
-		done, tracking = tracker.start()
-		if !tracking {
-			drainAckAsyncStops.Delete(key)
-			return
-		}
 	}
 	go func() {
 		defer func() {
-			drainAckAsyncStops.Delete(key)
-			done()
 			if r := recover(); r != nil {
-				fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s panicked: %v\n", name, r) //nolint:errcheck
-				panic(r)
+				fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s panicked: %v\n%s", name, r, debug.Stack()) //nolint:errcheck
 			}
+			done()
 		}()
 		if err := workerKillSessionTargetWithConfig(cityPath, store, sp, cfg, name); err != nil && !runtime.IsSessionGone(err) {
 			fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s: %v\n", name, err) //nolint:errcheck

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -117,6 +117,23 @@ func (p *blockingStopProvider) Stop(name string) error {
 	return p.Fake.Stop(name)
 }
 
+type panicStopProvider struct {
+	*runtime.Fake
+	stopStarted chan string
+}
+
+func newPanicStopProvider() *panicStopProvider {
+	return &panicStopProvider{
+		Fake:        runtime.NewFake(),
+		stopStarted: make(chan string, 1),
+	}
+}
+
+func (p *panicStopProvider) Stop(name string) error {
+	p.stopStarted <- name
+	panic("stop exploded")
+}
+
 type shutdownWaitStopProvider struct {
 	*blockingStopProvider
 	listCalled chan struct{}
@@ -823,6 +840,82 @@ func TestQueueDrainAckAsyncStopTracksShutdownWait(t *testing.T) {
 	close(sp.releaseStop)
 	if !tracker.wait(time.Second) {
 		t.Fatal("async drain-ack stop tracker did not drain after Stop returned")
+	}
+}
+
+func TestQueueDrainAckAsyncStopDedupScopedToTracker(t *testing.T) {
+	store := beads.NewMemStore()
+	first := newBlockingStopProvider()
+	if err := first.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(first worker): %v", err)
+	}
+	second := newBlockingStopProvider()
+	if err := second.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(second worker): %v", err)
+	}
+	firstReleased := false
+	secondReleased := false
+	defer func() {
+		if !firstReleased {
+			close(first.releaseStop)
+		}
+		if !secondReleased {
+			close(second.releaseStop)
+		}
+	}()
+
+	var stderr synchronizedBuffer
+	firstTracker := &asyncStartTracker{}
+	secondTracker := &asyncStartTracker{}
+	queueDrainAckAsyncStop("", store, first, &config.City{}, "gc-worker", "worker", firstTracker, &stderr)
+	select {
+	case <-first.stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first async drain-ack stop did not start")
+	}
+
+	queueDrainAckAsyncStop("", store, second, &config.City{}, "gc-worker", "worker", secondTracker, &stderr)
+	select {
+	case <-second.stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second async drain-ack stop was suppressed by another tracker scope")
+	}
+	close(first.releaseStop)
+	firstReleased = true
+	close(second.releaseStop)
+	secondReleased = true
+	if !firstTracker.wait(time.Second) {
+		t.Fatal("first async drain-ack stop tracker did not drain after release")
+	}
+	if !secondTracker.wait(time.Second) {
+		t.Fatal("second async drain-ack stop tracker did not drain after release")
+	}
+}
+
+func TestQueueDrainAckAsyncStopRecoversStopPanic(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := newPanicStopProvider()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	var stderr synchronizedBuffer
+	tracker := &asyncStartTracker{}
+	queueDrainAckAsyncStop(t.TempDir(), store, sp, &config.City{}, "gc-worker", "worker", tracker, &stderr)
+
+	select {
+	case <-sp.stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("async drain-ack stop did not start")
+	}
+	if !tracker.wait(time.Second) {
+		t.Fatal("async drain-ack stop tracker did not drain after Stop panic")
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "session reconciler: async drain-ack stop worker panicked: stop exploded") {
+		t.Fatalf("stderr = %q, want panic diagnostic", got)
+	}
+	if !strings.Contains(got, "goroutine ") {
+		t.Fatalf("stderr = %q, want stack trace", got)
 	}
 }
 

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -608,11 +608,15 @@ func TestSessionReconcilePhaseTraceUsesDistinctSites(t *testing.T) {
 		"session_reconcile.build_deps":                        TraceSiteSessionReconcileBuildDeps,
 		"session_reconcile.heal_and_retire_duplicates":        TraceSiteSessionReconcileHealRetire,
 		"session_reconcile.topo_order":                        TraceSiteSessionReconcileTopoOrder,
+		"session_reconcile.circuit_breaker_restore":           TraceSiteSessionReconcileCircuitBreaker,
 		"session_reconcile.forward_pass":                      TraceSiteSessionReconcileForwardPass,
 		"session_reconcile.compute_awake_set_and_idle_probes": TraceSiteSessionReconcileAwakeSet,
 		"session_reconcile.apply_wake_sleep_decisions":        TraceSiteSessionReconcileWakeSleep,
 		"session_reconcile.execute_planned_starts":            TraceSiteSessionReconcileStartExecution,
 		"session_reconcile.advance_drains":                    TraceSiteSessionReconcileDrainAdvance,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("session_reconcile operation count = %d, want %d; got %#v, want %#v", len(got), len(want), got, want)
 	}
 	for name, site := range want {
 		if got[name] != site {

--- a/engdocs/contributors/reconciler-debugging.md
+++ b/engdocs/contributors/reconciler-debugging.md
@@ -74,6 +74,12 @@ Point the next agent at these artifacts:
 
 If a real session existed and the bug crossed into runtime behavior, also include the relevant session or provider logs.
 
+Drain-ack stop completion is event-first: newer controllers record
+`SessionStopped` with message `drain acknowledged by agent` instead of relying
+on the old `Stopped drain-acked session` stdout line. Use `.gc/events.jsonl`
+and the trace `operation` records as the durable signal, with stdout/stderr as
+supporting diagnostics only.
+
 ## Rig-Scoped Convergence Rollback
 
 Before rolling back a release that has created rig-scoped convergence loops,


### PR DESCRIPTION
Post-merge remediation for #2440.

Fixes the actionable review findings from the landed async drain-ack change:

- recover async drain-ack Stop panics with stack diagnostics instead of re-panicking the controller
- scope async drain-ack Stop deduplication to the runtime tracker instead of process-global store-pointer keys
- preserve process-name liveness fallback in the pool sweep path so `IsRunning` false negatives do not close live sessions
- pin the circuit-breaker restore trace phase in the phase-site coverage test
- document the event-first drain-ack Stop completion signal in the reconciler debugging guide

Validation:

- `go test ./cmd/gc ./internal/session -run 'DrainAck|SweepUndesired|TraceCycle|RecordControllerOperation|SessionReconcilePhaseTrace|LifecycleTransition'`
- `go vet ./cmd/gc ./internal/session`
- pre-commit hook: `go vet ./...`, `./scripts/test-local-parallel fast`, and `go test ./test/docsync`
