### PR TITLE
fix(cmd/gc): wait for cmdStop body goroutine before global cleanup

### DIFF
--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -113,9 +113,14 @@ func cmdStopJSON(args []string, stdout, stderr io.Writer, wallClockTimeout time.
 
 	type stopOutcome struct{ code int }
 	doneCh := make(chan stopOutcome, 1)
+	bodyDone := make(chan struct{})
 	go func() {
+		defer close(bodyDone)
 		doneCh <- stopOutcome{code: cmdStopBody(cityPath, cfg, force, stopStdout, stderr)}
 	}()
+	if h := stopBodyLifecycleHook; h != nil {
+		h(bodyDone)
+	}
 
 	select {
 	case out := <-doneCh:
@@ -128,6 +133,13 @@ func cmdStopJSON(args []string, stdout, stderr io.Writer, wallClockTimeout time.
 		return 1
 	}
 }
+
+// stopBodyLifecycleHook receives the cmdStopBody goroutine's done channel
+// when cmdStopJSON spawns it. Tests with providers that block past the
+// wall-clock cap register this hook so they can wait for the body to
+// finish, preventing the leaked goroutine from racing on package-level
+// stop hooks against a later test.
+var stopBodyLifecycleHook func(<-chan struct{})
 
 func writeCityStopSuccess(stdout, stderr io.Writer, cityPath string, force bool) int {
 	return writeLifecycleActionJSONOrExit(stdout, stderr, "gc stop", lifecycleActionJSON{

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -175,17 +175,36 @@ func TestCmdStopWallClockTimeoutBoundsDirectStop(t *testing.T) {
 	}
 
 	sp := newHangingProvider()
-	t.Cleanup(sp.release)
 	sessionName := lookupSessionNameOrLegacy(nil, loadedCityName(cfg, cityDir), cfg.Agents[0].QualifiedName(), cfg.Workspace.SessionTemplate)
 	if err := sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
 		t.Fatal(err)
 	}
 
+	// cmdStop's wall-clock cap returns 1 while cmdStopBody is still blocked
+	// in hangingProvider.Stop. The body goroutine eventually calls back into
+	// shutdownBeadsProviderForStop; if it does so after another test has
+	// installed its own override, the global state races. Capture the body's
+	// done channel via stopBodyLifecycleHook and wait for it to close in
+	// teardown so the leaked goroutine cannot outlive this test.
 	oldFactory := sessionProviderForStopCity
-	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	oldHook := stopBodyLifecycleHook
+	var bodyDone <-chan struct{}
+	stopBodyLifecycleHook = func(done <-chan struct{}) { bodyDone = done }
 	sessionProviderForStopCity = func(*config.City, string) runtime.Provider {
 		return sp
 	}
+	t.Cleanup(func() {
+		sp.release()
+		if bodyDone != nil {
+			select {
+			case <-bodyDone:
+			case <-time.After(10 * time.Second):
+				t.Errorf("cmdStopBody goroutine did not exit after hangingProvider release")
+			}
+		}
+		sessionProviderForStopCity = oldFactory
+		stopBodyLifecycleHook = oldHook
+	})
 
 	var stdout, stderr lockedBuffer
 	started := time.Now()


### PR DESCRIPTION
## Summary

Closes #2450.

`TestCmdStopWallClockTimeoutBoundsDirectStop` installed a `hangingProvider` via the package-level `sessionProviderForStopCity` global and relied on `cmdStop`'s 100ms wall-clock cap to return early. The cap caused `cmdStop` to leave the body goroutine running while the test returned and `t.Cleanup` restored globals. After `sp.release` unblocked the body, it continued through `stopOrphans` and `shutdownBeadsProviderForStop` using whichever overrides happened to be installed at that instant — typically belonging to a later parallel test.

`TestCmdStopSupervisorManagedInvalidCityTomlFailsWhenShutdownFails` then saw an `assertSameTestPath` callback fire with the leaking test's `cityDir`, producing the flake on `make test-fast-parallel`.

## Fix

`cmdStopJSON` now exposes the body goroutine's done channel via a test-only `stopBodyLifecycleHook`, mirroring the existing `waitForSupervisorControllerStopHook` pattern. The hanging-provider test captures the channel and waits up to 10s for the body to finish after `sp.release`, ordering cleanup so the leaked goroutine cannot outlive the test or race against another test's stop-hook override.

## Test plan

- [x] `go test ./cmd/gc -run "TestCmdStop" -count=20 -parallel=8` — passes cleanly (was 2/4 flake on the prior branch)
- [ ] `make test-fast-parallel` green on PR CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)