### PR TITLE
fix(tmux): use macOS-compatible ps syntax in process snapshot

### DIFF
--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -387,11 +388,23 @@ func newProcessSnapshot(processes []processRuntimeState) processSnapshot {
 }
 
 func fetchProcessSnapshot(ctx context.Context) (processSnapshot, error) {
-	out, err := exec.CommandContext(ctx, "ps", "-eo", "pid:10=,ppid:10=,comm:64=,args=").Output()
+	out, err := exec.CommandContext(ctx, "ps", processSnapshotPSArgs()...).Output()
 	if err != nil {
 		return processSnapshot{}, fmt.Errorf("fetching process snapshot: %w", err)
 	}
 	return parseProcessSnapshot(string(out)), nil
+}
+
+// processSnapshotPSArgs returns the platform-appropriate `ps` arguments for
+// the process snapshot. macOS's ps does not accept the BSD column-width
+// suffix (e.g. `pid:10=`) that Linux ps supports; on Darwin we omit the
+// widths and parse with whitespace splitting. On Linux we keep the
+// wide-column form so the fast fixed-column parser is exercised.
+func processSnapshotPSArgs() []string {
+	if goruntime.GOOS == "darwin" {
+		return []string{"-eo", "pid=,ppid=,comm=,args="}
+	}
+	return []string{"-eo", "pid:10=,ppid:10=,comm:64=,args="}
 }
 
 func parseProcessSnapshot(out string) processSnapshot {
@@ -407,6 +420,13 @@ func parseProcessSnapshot(out string) processSnapshot {
 }
 
 func parseProcessSnapshotLine(line string) (processRuntimeState, bool) {
+	if goruntime.GOOS == "darwin" {
+		return parseProcessSnapshotLineWhitespace(line)
+	}
+	return parseProcessSnapshotLineFixedColumns(line)
+}
+
+func parseProcessSnapshotLineFixedColumns(line string) (processRuntimeState, bool) {
 	const (
 		pidWidth     = 10
 		ppidStart    = pidWidth + 1
@@ -428,6 +448,45 @@ func parseProcessSnapshotLine(line string) (processRuntimeState, bool) {
 	}
 	if process.PID == "" || process.PPID == "" || process.Command == "" {
 		return processRuntimeState{}, false
+	}
+	return process, true
+}
+
+// parseProcessSnapshotLineWhitespace parses a single line of
+// `ps -eo pid=,ppid=,comm=,args=` output. Format: 3 whitespace-separated
+// fixed tokens (pid, ppid, comm) followed by args. comm is the command
+// name without path/args, typically a single token. Anything from the
+// fourth-token boundary onward is treated as args verbatim (preserving
+// internal whitespace) so callers can match against the full command line.
+func parseProcessSnapshotLineWhitespace(line string) (processRuntimeState, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	remaining := trimmed
+	for i := 0; i < 3; i++ {
+		end := strings.IndexAny(remaining, " \t")
+		if end < 0 {
+			// Not enough fields on this line. Lines with fewer than 4
+			// tokens (e.g. kernel threads with no args) still need to
+			// match pid/ppid/comm — fall through to the Fields parse.
+			break
+		}
+		remaining = strings.TrimLeft(remaining[end:], " \t")
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) < 3 {
+		return processRuntimeState{}, false
+	}
+	process := processRuntimeState{
+		PID:     fields[0],
+		PPID:    fields[1],
+		Command: fields[2],
+	}
+	if process.PID == "" || process.PPID == "" || process.Command == "" {
+		return processRuntimeState{}, false
+	}
+	if len(fields) > 3 {
+		// `remaining` now points past the third token boundary; args
+		// preserves the original spacing between tokens 4..N.
+		process.Args = strings.TrimSpace(remaining)
 	}
 	return process, true
 }

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -427,12 +428,85 @@ func TestFetchProcessSnapshotCanceledContextReturnsError(t *testing.T) {
 
 func TestParseProcessSnapshotLineFixedColumns(t *testing.T) {
 	line := fmt.Sprintf("%10s %10s %-64s %s", "123", "1", "claude code", "claude code --print")
-	got, ok := parseProcessSnapshotLine(line)
+	got, ok := parseProcessSnapshotLineFixedColumns(line)
 	if !ok {
-		t.Fatal("parseProcessSnapshotLine returned ok=false")
+		t.Fatal("parseProcessSnapshotLineFixedColumns returned ok=false")
 	}
 	if got.PID != "123" || got.PPID != "1" || got.Command != "claude code" || got.Args != "claude code --print" {
-		t.Fatalf("parseProcessSnapshotLine = %+v, want fixed-column fields preserved", got)
+		t.Fatalf("parseProcessSnapshotLineFixedColumns = %+v, want fixed-column fields preserved", got)
+	}
+}
+
+func TestParseProcessSnapshotLineWhitespace(t *testing.T) {
+	// macOS `ps -eo pid=,ppid=,comm=,args=` output: right-aligned numeric
+	// columns, comm separated from args by whitespace.
+	cases := []struct {
+		name     string
+		line     string
+		wantPID  string
+		wantPPID string
+		wantCmd  string
+		wantArgs string
+	}{
+		{
+			name:     "typical 4-token line",
+			line:     "  123     1 /sbin/launchd    /sbin/launchd --boot",
+			wantPID:  "123",
+			wantPPID: "1",
+			wantCmd:  "/sbin/launchd",
+			wantArgs: "/sbin/launchd --boot",
+		},
+		{
+			name:     "args has multiple spaces preserved",
+			line:     "456 1 claude claude code --print --json",
+			wantPID:  "456",
+			wantPPID: "1",
+			wantCmd:  "claude",
+			wantArgs: "claude code --print --json",
+		},
+		{
+			name:     "no args (3-token line)",
+			line:     "789 1 kernel_task",
+			wantPID:  "789",
+			wantPPID: "1",
+			wantCmd:  "kernel_task",
+			wantArgs: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseProcessSnapshotLineWhitespace(tc.line)
+			if !ok {
+				t.Fatalf("returned ok=false for %q", tc.line)
+			}
+			if got.PID != tc.wantPID {
+				t.Errorf("PID = %q, want %q", got.PID, tc.wantPID)
+			}
+			if got.PPID != tc.wantPPID {
+				t.Errorf("PPID = %q, want %q", got.PPID, tc.wantPPID)
+			}
+			if got.Command != tc.wantCmd {
+				t.Errorf("Command = %q, want %q", got.Command, tc.wantCmd)
+			}
+			if got.Args != tc.wantArgs {
+				t.Errorf("Args = %q, want %q", got.Args, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestProcessSnapshotPSArgsRejectsLinuxSyntaxOnDarwin(t *testing.T) {
+	// Regression: macOS ps rejects the BSD `:N=` column-width form. Confirm
+	// we don't emit it on Darwin. Skip elsewhere — Linux ps accepts both
+	// forms so verifying the wide form there is just a tautology.
+	if runtime.GOOS != "darwin" {
+		t.Skip("Darwin-specific syntax guard")
+	}
+	args := processSnapshotPSArgs()
+	for _, a := range args {
+		if strings.Contains(a, ":") {
+			t.Fatalf("processSnapshotPSArgs returned %v on darwin; contains Linux-only `:N=` width specifier", args)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up for #2466.

Original PR URL: https://github.com/gastownhall/gascity/pull/2466
Original title: fix(tmux): use macOS-compatible ps syntax in process snapshot
Original state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

This follow-up exists because the adoption workflow reviewed and base-refreshed the contributor change, but the guarded maintainer push back to `quickserve-ai/gascity:fix/tmux-state-cache-ps-macos` was rejected by GitHub with a 403. The workflow therefore needs a maintainer-owned merge surface instead of retrying an unsafe fork update.

The change set preserves @A3Ackerman's contribution and authorship. It carries the tmux state-cache macOS `ps` fix onto current `main` (`1fc187565e9b972c5df3516636850d24a709597e`) with final head `37cc1acfd6a1ce1c0e27db72cfcfd6d3ed8a443b`.

Review and validation:
- Adoption review attempt 1 approved the change with no required changes.
- Base refresh preserved the patch-id.
- Local focused validation passed: `go test ./internal/runtime/tmux/... -count=1`.

Diff stat:
- `internal/runtime/tmux/state_cache.go`
- `internal/runtime/tmux/state_cache_test.go`
- 2 files changed, 137 insertions(+), 4 deletions(-)
