### PR TITLE
fix(session): re-apply session_live theming on gc session attach resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `gc session attach` now re-applies `session_live` hooks (status-bar theme,
+  keybindings) when it recreates a session whose tmux runtime had exited.
+  Previously the resume path in `resolvedWorkerRuntimeWithConfigAndMetadata`
+  built the runtime `Hints` without `SessionLive`, so `runSessionLive`
+  early-returned on the empty list and attach-recreated sessions came up
+  unthemed while reconciler-started sessions did not. The setup context is
+  built via the reconciler's own `sessionSetupContextForAgent` so
+  `session_live` templates referencing `{{.Rig}}`/`{{.RigRoot}}`/`{{.AgentBase}}`
+  expand correctly on the resume path.
 - Managed bd provider startup now detects a bd-standalone dolt server running
   against the same `.beads/dolt` database before invoking the managed-bd
   lifecycle script, and refuses with a message naming `bd dolt stop` as the

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -521,6 +521,25 @@ func resolvedWorkerRuntimeWithConfigAndMetadata(cityPath string, cfg *config.Cit
 	// overwritten with the city-uniform default here. template_resolve.go
 	// owns the qualified override for the CLI create path.
 	sessionEnv := mergeEnv(resolved.Env, cityIdentityAnchorsForCity(cityPath))
+	// Resolve session_live so resumed sessions get re-themed (status bar,
+	// keybindings) the same way reconciler-started sessions do. Without this,
+	// `gc session attach` recreates the tmux runtime with an empty
+	// Hints.SessionLive, doStartSession's runSessionLive early-returns, and
+	// the session_live theme/keybinding hooks never run. The setup context is
+	// built via the reconciler's own sessionSetupContextForAgent() so
+	// {{.Rig}}/{{.RigRoot}}/{{.AgentBase}} expand correctly. See ga-vtkhi.
+	qualifiedName := firstNonEmptyGCString(info.AgentName, info.Template)
+	var sessionLive []string
+	if agentCfg := findAgentByTemplate(cfg, info.Template); agentCfg != nil && len(agentCfg.SessionLive) > 0 {
+		setupCtx := sessionSetupContextForAgent(cityPath, cfg.EffectiveCityName(), qualifiedName, agentCfg, cfg.Rigs)
+		setupCtx.Session = info.SessionName
+		setupCtx.WorkDir = workDir
+		setupCtx.ConfigDir = cityPath
+		if agentCfg.SourceDir != "" {
+			setupCtx.ConfigDir = agentCfg.SourceDir
+		}
+		sessionLive = expandSessionSetup(agentCfg.SessionLive, setupCtx)
+	}
 	return &worker.ResolvedRuntime{
 		Command:    command,
 		WorkDir:    workDir,
@@ -535,6 +554,7 @@ func resolvedWorkerRuntimeWithConfigAndMetadata(cityPath string, cfg *config.Cit
 			EmitsPermissionWarning: resolved.EmitsPermissionWarning,
 			AcceptStartupDialogs:   resolved.AcceptStartupDialogs,
 			MCPServers:             mcpServers,
+			SessionLive:            sessionLive,
 		},
 		Resume: session.ProviderResume{
 			ResumeFlag:    firstNonEmptyGCString(resolved.ResumeFlag, info.ResumeFlag),

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -1504,42 +1504,103 @@ ready_delay_ms = 250
 // same way reconciler-started sessions do.
 func TestResolvedWorkerRuntimeWithConfigPopulatesSessionLiveOnResume(t *testing.T) {
 	cityDir := t.TempDir()
-	writePhase0InterfaceCity(t, cityDir, `[workspace]
+	rigDir := t.TempDir()
+	writePhase0InterfaceCity(t, cityDir, fmt.Sprintf(`[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
+
+[[rigs]]
+name = "myrig"
+path = %q
 
 [[agent]]
 name = "worker"
 provider = "stub"
 session_live = ["theme apply {{.Session}}"]
 
+[[agent]]
+name = "rig-worker"
+dir = "myrig"
+provider = "stub"
+session_live = ["theme rig={{.Rig}} root={{.RigRoot}} base={{.AgentBase}} city={{.CityName}} work={{.WorkDir}} config={{.ConfigDir}}"]
+
+[[agent]]
+name = "polecat"
+dir = "myrig"
+provider = "stub"
+session_live = ["theme agent={{.Agent}} base={{.AgentBase}} rig={{.Rig}} root={{.RigRoot}}"]
+
+[[agent]]
+name = "plain"
+provider = "stub"
+
 [providers.stub]
 command = "/bin/echo"
-`)
+`, rigDir))
 
 	cfg, err := loadCityConfig(cityDir)
 	if err != nil {
 		t.Fatalf("loadCityConfig: %v", err)
 	}
 
-	runtimeCfg, err := resolvedWorkerRuntimeWithConfig(cityDir, cfg, session.Info{
-		Template:    "worker",
-		AgentName:   "worker",
-		SessionName: "test-city__worker",
-	}, "")
-	if err != nil {
-		t.Fatalf("resolvedWorkerRuntimeWithConfig: %v", err)
+	tests := []struct {
+		name string
+		info session.Info
+		want []string
+	}{
+		{
+			name: "session name template",
+			info: session.Info{
+				Template:    "worker",
+				AgentName:   "worker",
+				SessionName: "test-city__worker",
+			},
+			want: []string{"theme apply test-city__worker"},
+		},
+		{
+			name: "rig template context",
+			info: session.Info{
+				Template:    "myrig/rig-worker",
+				AgentName:   "myrig/rig-worker",
+				SessionName: "test-city__myrig__rig-worker",
+				WorkDir:     filepath.Join(rigDir, "agents", "rig-worker"),
+			},
+			want: []string{"theme rig=myrig root=" + rigDir + " base=rig-worker city=test-city work=" + filepath.Join(rigDir, "agents", "rig-worker") + " config=" + cityDir},
+		},
+		{
+			name: "pool instance uses concrete agent name",
+			info: session.Info{
+				Template:    "myrig/polecat",
+				AgentName:   "myrig/polecat__furiosa-1",
+				SessionName: "test-city__myrig__polecat__furiosa-1",
+			},
+			want: []string{"theme agent=myrig/polecat__furiosa-1 base=polecat__furiosa-1 rig=myrig root=" + rigDir},
+		},
+		{
+			name: "missing session live stays empty",
+			info: session.Info{
+				Template:    "plain",
+				AgentName:   "plain",
+				SessionName: "test-city__plain",
+			},
+			want: nil,
+		},
 	}
-	if runtimeCfg == nil {
-		t.Fatal("resolvedWorkerRuntimeWithConfig() = nil")
-	}
-	if len(runtimeCfg.Hints.SessionLive) != 1 {
-		t.Fatalf("Hints.SessionLive = %v, want 1 command", runtimeCfg.Hints.SessionLive)
-	}
-	if got, want := runtimeCfg.Hints.SessionLive[0], "theme apply test-city__worker"; got != want {
-		t.Fatalf("Hints.SessionLive[0] = %q, want %q (template must expand on resume)", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtimeCfg, err := resolvedWorkerRuntimeWithConfig(cityDir, cfg, tt.info, "")
+			if err != nil {
+				t.Fatalf("resolvedWorkerRuntimeWithConfig: %v", err)
+			}
+			if runtimeCfg == nil {
+				t.Fatal("resolvedWorkerRuntimeWithConfig() = nil")
+			}
+			if got, want := runtimeCfg.Hints.SessionLive, tt.want; !slicesEqual(got, want) {
+				t.Fatalf("Hints.SessionLive = %v, want %v", got, want)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -1497,6 +1497,52 @@ ready_delay_ms = 250
 	}
 }
 
+// TestResolvedWorkerRuntimeWithConfigPopulatesSessionLiveOnResume guards the
+// ga-vtkhi fix: the `gc session attach` resume path must carry the agent's
+// session_live commands (with templates expanded) into Hints.SessionLive so
+// the recreated tmux runtime re-applies the status-bar/keybinding theme the
+// same way reconciler-started sessions do.
+func TestResolvedWorkerRuntimeWithConfigPopulatesSessionLiveOnResume(t *testing.T) {
+	cityDir := t.TempDir()
+	writePhase0InterfaceCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "worker"
+provider = "stub"
+session_live = ["theme apply {{.Session}}"]
+
+[providers.stub]
+command = "/bin/echo"
+`)
+
+	cfg, err := loadCityConfig(cityDir)
+	if err != nil {
+		t.Fatalf("loadCityConfig: %v", err)
+	}
+
+	runtimeCfg, err := resolvedWorkerRuntimeWithConfig(cityDir, cfg, session.Info{
+		Template:    "worker",
+		AgentName:   "worker",
+		SessionName: "test-city__worker",
+	}, "")
+	if err != nil {
+		t.Fatalf("resolvedWorkerRuntimeWithConfig: %v", err)
+	}
+	if runtimeCfg == nil {
+		t.Fatal("resolvedWorkerRuntimeWithConfig() = nil")
+	}
+	if len(runtimeCfg.Hints.SessionLive) != 1 {
+		t.Fatalf("Hints.SessionLive = %v, want 1 command", runtimeCfg.Hints.SessionLive)
+	}
+	if got, want := runtimeCfg.Hints.SessionLive[0], "theme apply test-city__worker"; got != want {
+		t.Fatalf("Hints.SessionLive[0] = %q, want %q (template must expand on resume)", got, want)
+	}
+}
+
 func TestResolvedWorkerRuntimeWithConfigIgnoresMCPResolutionErrorForACPResume(t *testing.T) {
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]


### PR DESCRIPTION
## Summary

`gc session attach` recreates a session whose tmux runtime has exited. The resume path `resolvedWorkerRuntimeWithConfigAndMetadata` (`cmd/gc/worker_handle.go`) built the runtime `Hints` without populating `SessionLive`, so `doStartSession`'s `runSessionLive` early-returned on the empty list. Attach-recreated sessions therefore came up on tmux's default status bar — raw session name, no city icon or keybindings — while reconciler-started sessions, which populate `SessionLive`, were themed correctly.

This resolves the agent's `session_live` commands on the resume path and passes them through `Hints.SessionLive`. The setup context is built via the reconciler's own `sessionSetupContextForAgent`, so `session_live` templates referencing `{{.Rig}}` / `{{.RigRoot}}` / `{{.AgentBase}}` expand correctly on resume.

Tracked internally as bead `ga-vtkhi`; no separate GitHub issue.

## Testing

- [x] `make check` — Go gates clean for this change: `gofmt`, `go vet ./cmd/gc/`, and `golangci-lint run ./cmd/gc/...` (`GOOS=linux`, CI's platform) all pass; the `TestResolvedWorkerRuntime*` suite including the new test passes. The only `cmd/gc` suite failures are pre-existing macOS-only environment issues (`/proc` absence; `/tmp`→`/private/tmp` symlink), unrelated to this change — they pass on Linux/CI.
- [ ] `make check-docs` — n/a, no docs/navigation/links changed
- [ ] `make test-integration` — covered by CI integration shards; change is on the session-resume runtime path

## Checklist

- [x] Linked an issue, or explained why one is not needed — tracked as internal bead `ga-vtkhi`; no GitHub issue
- [x] Added or updated tests for behavior changes — `TestResolvedWorkerRuntimeWithConfigPopulatesSessionLiveOnResume`
- [x] Updated docs for user-facing changes — n/a; `CHANGELOG.md` updated under `### Fixed`
- [x] Called out breaking changes or migration notes — none; purely additive on the resume path
