### PR TITLE
fix: replay startup prompt on resumed sessions

### DIFF
--- a/cmd/gc/phase2_reporting_test.go
+++ b/cmd/gc/phase2_reporting_test.go
@@ -183,19 +183,32 @@ func initialMessageResumeResult(tc phase2ProviderCase, prepared *preparedStart) 
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
 			fmt.Sprintf("PromptSuffix encoding invalid: %v", err)).WithEvidence(evidence)
 	}
+	if prepared == nil {
+		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
+			"prepared start = nil").WithEvidence(evidence)
+	}
 	switch {
-	case got != "":
+	case strings.TrimSpace(prepared.cfg.PromptSuffix) != "":
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
-			fmt.Sprintf("PromptSuffix payload = %q, want no startup user-turn on resume", got)).WithEvidence(evidence)
-	case strings.Contains(got, "Do the first task."):
+			fmt.Sprintf("PromptSuffix = %q, want resume restart prompt delivered via nudge", prepared.cfg.PromptSuffix)).WithEvidence(evidence)
+	case strings.TrimSpace(prepared.cfg.PromptFlag) != "":
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
-			fmt.Sprintf("PromptSuffix payload = %q, want no replayed initial message", got)).WithEvidence(evidence)
-	case prepared.cfg.Env[startupPromptDeliveredEnv] != "":
+			fmt.Sprintf("PromptFlag = %q, want no flag startup prompt replay on resume", prepared.cfg.PromptFlag)).WithEvidence(evidence)
+	case got != "Base worker prompt":
 		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
-			fmt.Sprintf("%s = %q, want unset on resume", startupPromptDeliveredEnv, prepared.cfg.Env[startupPromptDeliveredEnv])).WithEvidence(evidence)
+			fmt.Sprintf("restart prompt payload = %q, want base worker prompt on resume", got)).WithEvidence(evidence)
+	case strings.Contains(prepared.cfg.Nudge, "Do the first task."):
+		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
+			fmt.Sprintf("cfg.Nudge = %q, want no replayed initial message", prepared.cfg.Nudge)).WithEvidence(evidence)
+	case prepared.cfg.Env[startupPromptDeliveredEnv] != "1":
+		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
+			fmt.Sprintf("%s = %q, want 1 when restart prompt is delivered on resume", startupPromptDeliveredEnv, prepared.cfg.Env[startupPromptDeliveredEnv])).WithEvidence(evidence)
+	case !startupNudgeMatches(tc, prepared.cfg.Nudge):
+		return workertest.Fail(tc.profileID, workertest.RequirementInputInitialMessageResume,
+			fmt.Sprintf("cfg.Nudge = %q, want configured nudge preserved after restart prompt", prepared.cfg.Nudge)).WithEvidence(evidence)
 	default:
 		return workertest.Pass(tc.profileID, workertest.RequirementInputInitialMessageResume,
-			"resumed sessions do not replay startup prompt material as a new user turn").WithEvidence(evidence)
+			"resumed sessions receive the base restart prompt without replaying initial_message").WithEvidence(evidence)
 	}
 }
 
@@ -226,6 +239,50 @@ func inputOverrideDefaultsResult(tc phase2ProviderCase, prepared *preparedStart)
 	default:
 		return workertest.Pass(tc.profileID, workertest.RequirementInputOverrideDefaults,
 			"provider default launch flags survive schema overrides while first-input delivery stays exact-once").WithEvidence(evidence)
+	}
+}
+
+func inProgressResumeRestartResult(tc phase2ProviderCase, prepared *preparedStart) workertest.Result {
+	return resumeRestartPromptResult(tc, prepared, workertest.RequirementInputInProgressResumeRestart, "in-progress assigned work")
+}
+
+func preClaimResumeRestartResult(tc phase2ProviderCase, prepared *preparedStart) workertest.Result {
+	return resumeRestartPromptResult(tc, prepared, workertest.RequirementInputPreClaimResumeRestart, "pre-claim work demand")
+}
+
+func resumeRestartPromptResult(tc phase2ProviderCase, prepared *preparedStart, requirement workertest.RequirementCode, label string) workertest.Result {
+	got, evidence, err := phase2PromptPayload(tc, prepared)
+	if err != nil {
+		return workertest.Fail(tc.profileID, requirement,
+			fmt.Sprintf("PromptSuffix encoding invalid: %v", err)).WithEvidence(evidence)
+	}
+	if prepared != nil {
+		evidence["cfg_prompt_suffix"] = prepared.cfg.PromptSuffix
+		evidence["cfg_prompt_flag"] = prepared.cfg.PromptFlag
+		evidence["cfg_nudge"] = prepared.cfg.Nudge
+		evidence["startup_prompt_delivered"] = prepared.cfg.Env[startupPromptDeliveredEnv]
+	}
+	switch {
+	case prepared == nil:
+		return workertest.Fail(tc.profileID, requirement, "prepared start = nil").WithEvidence(evidence)
+	case strings.TrimSpace(prepared.cfg.PromptSuffix) != "":
+		return workertest.Fail(tc.profileID, requirement,
+			fmt.Sprintf("PromptSuffix = %q, want restart prompt delivered via nudge", prepared.cfg.PromptSuffix)).WithEvidence(evidence)
+	case strings.TrimSpace(prepared.cfg.PromptFlag) != "":
+		return workertest.Fail(tc.profileID, requirement,
+			fmt.Sprintf("PromptFlag = %q, want no flag startup prompt replay on resume", prepared.cfg.PromptFlag)).WithEvidence(evidence)
+	case got != "Base worker prompt":
+		return workertest.Fail(tc.profileID, requirement,
+			fmt.Sprintf("restart prompt payload = %q, want base worker prompt", got)).WithEvidence(evidence)
+	case strings.Contains(prepared.cfg.Nudge, "Do the first task."):
+		return workertest.Fail(tc.profileID, requirement,
+			fmt.Sprintf("cfg.Nudge = %q, want no replayed initial_message on resume", prepared.cfg.Nudge)).WithEvidence(evidence)
+	case prepared.cfg.Env[startupPromptDeliveredEnv] != "1":
+		return workertest.Fail(tc.profileID, requirement,
+			fmt.Sprintf("%s = %q, want 1 when restart prompt is delivered", startupPromptDeliveredEnv, prepared.cfg.Env[startupPromptDeliveredEnv])).WithEvidence(evidence)
+	default:
+		return workertest.Pass(tc.profileID, requirement,
+			fmt.Sprintf("%s receives a restart prompt on resume without replaying initial_message", label)).WithEvidence(evidence)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -831,9 +831,15 @@ func buildPreparedStartWithWorkDirResolver(
 	if !firstStart && !forceFresh && hasResumeKey {
 		agentCfg.PromptSuffix = ""
 		agentCfg.PromptFlag = ""
-		agentCfg.Nudge = tp.Hints.Nudge
+		agentCfg.Nudge = restartPromptNudge(tp.Prompt, tp.Hints.Nudge)
 		if agentCfg.Env != nil {
 			delete(agentCfg.Env, startupPromptDeliveredEnv)
+		}
+		if strings.TrimSpace(tp.Prompt) != "" {
+			if agentCfg.Env == nil {
+				agentCfg.Env = map[string]string{}
+			}
+			agentCfg.Env[startupPromptDeliveredEnv] = "1"
 		}
 	}
 	// Initial message: append to prompt on first start only.
@@ -1124,6 +1130,13 @@ func appendInitialMessageToStartupNudge(nudge, msg string) string {
 		return nudge + startupPromptNudgeSeparator + userMessage
 	}
 	return userMessage
+}
+
+func restartPromptNudge(prompt, nudge string) string {
+	if strings.TrimSpace(prompt) == "" {
+		return nudge
+	}
+	return prependStartupPromptToNudge(prompt, nudge)
 }
 
 func startupRateLimitScreenDetected(

--- a/cmd/gc/session_lifecycle_parallel_phase2_test.go
+++ b/cmd/gc/session_lifecycle_parallel_phase2_test.go
@@ -42,6 +42,22 @@ func TestPhase2InitialInputDelivery(t *testing.T) {
 
 				reporter.Require(t, inputOverrideDefaultsResult(tc, prepared))
 			})
+
+			t.Run(string(workertest.RequirementInputInProgressResumeRestart), func(t *testing.T) {
+				prepared := preparePhase2ResumeRestartStart(t, tc, map[string]string{
+					"initial_message": "Do the first task.",
+				}, true)
+
+				reporter.Require(t, inProgressResumeRestartResult(tc, prepared))
+			})
+
+			t.Run(string(workertest.RequirementInputPreClaimResumeRestart), func(t *testing.T) {
+				prepared := preparePhase2ResumeRestartStart(t, tc, map[string]string{
+					"initial_message": "Do the first task.",
+				}, false)
+
+				reporter.Require(t, preClaimResumeRestartResult(tc, prepared))
+			})
 		})
 	}
 }
@@ -155,6 +171,58 @@ func preparePhase2Start(t *testing.T, tc phase2ProviderCase, startedConfigHash s
 	prepared, err := prepareStartCandidate(startCandidate{
 		session: &session,
 		tp:      phase2TemplateParams(t, tc, "Base worker prompt"),
+	}, &config.City{}, store, &clock.Fake{Time: time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("prepareStartCandidate(%s): %v", tc.profileID, err)
+	}
+	return prepared
+}
+
+func preparePhase2ResumeRestartStart(t *testing.T, tc phase2ProviderCase, overrides map[string]string, assignedWork bool) *preparedStart {
+	t.Helper()
+
+	rawOverrides, err := json.Marshal(overrides)
+	if err != nil {
+		t.Fatalf("json.Marshal(overrides): %v", err)
+	}
+
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "phase2-" + tc.family,
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "phase2-" + tc.family,
+			"template":            "worker",
+			"template_overrides":  string(rawOverrides),
+			"started_config_hash": "already-started",
+			"session_key":         "phase2-resume-key",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+
+	if assignedWork {
+		work, err := store.Create(beads.Bead{
+			Title: "phase2 in-progress work",
+			Type:  "task",
+		})
+		if err != nil {
+			t.Fatalf("Create work bead: %v", err)
+		}
+		status := "in_progress"
+		assignee := session.ID
+		if err := store.Update(work.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+			t.Fatalf("assign work bead: %v", err)
+		}
+	}
+
+	tp := phase2TemplateParams(t, tc, "Base worker prompt")
+	tp.Hints.Nudge = ""
+	prepared, err := prepareStartCandidate(startCandidate{
+		session: &session,
+		tp:      tp,
 	}, &config.City{}, store, &clock.Fake{Time: time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)})
 	if err != nil {
 		t.Fatalf("prepareStartCandidate(%s): %v", tc.profileID, err)

--- a/internal/worker/workertest/catalog.go
+++ b/internal/worker/workertest/catalog.go
@@ -28,6 +28,8 @@ const ( //nolint:revive // exported requirement IDs are documented by the catalo
 	RequirementInputInitialMessageFirstStart       RequirementCode = "WC-INPUT-001"
 	RequirementInputInitialMessageResume           RequirementCode = "WC-INPUT-002"
 	RequirementInputOverrideDefaults               RequirementCode = "WC-INPUT-003"
+	RequirementInputInProgressResumeRestart        RequirementCode = "WC-INPUT-004"
+	RequirementInputPreClaimResumeRestart          RequirementCode = "WC-INPUT-005"
 	RequirementInferenceFreshSpawn                 RequirementCode = "WI-START-001"
 	RequirementInferenceTemplateStartup            RequirementCode = "WI-START-002"
 	RequirementInferenceFreshTask                  RequirementCode = "WI-TASK-001"

--- a/internal/worker/workertest/catalog_phase2_data_test.go
+++ b/internal/worker/workertest/catalog_phase2_data_test.go
@@ -13,6 +13,8 @@ func TestPhase2CatalogDataIsAuthoritative(t *testing.T) {
 		{Code: RequirementInputInitialMessageFirstStart, Group: "input_delivery", Description: "A configured initial_message is injected into the first start exactly once."},
 		{Code: RequirementInputInitialMessageResume, Group: "input_delivery", Description: "A resumed session does not replay the initial_message after the first start has been recorded."},
 		{Code: RequirementInputOverrideDefaults, Group: "input_delivery", Description: "Schema overrides and initial_message handling preserve provider default launch flags while separating first-input delivery from option overrides."},
+		{Code: RequirementInputInProgressResumeRestart, Group: "input_delivery", Description: "A resumed session with in-progress assigned work receives a restart turn instead of landing idle when no explicit nudge is configured."},
+		{Code: RequirementInputPreClaimResumeRestart, Group: "input_delivery", Description: "A resumed session with pre-claim work demand receives a restart turn instead of landing idle when no explicit nudge is configured."},
 		{Code: RequirementTranscriptDiagnostics, Group: "transcript", Description: "Malformed or torn transcript data is reported as degraded history or a fail-closed load error instead of clean normalized history."},
 		{Code: RequirementInteractionSignal, Group: "interaction", Description: "The standalone fake worker surfaces a blocked structured interaction signal and state."},
 		{Code: RequirementInteractionPending, Group: "interaction", Description: "Required structured interactions surface through the runtime interaction seam."},

--- a/internal/worker/workertest/phase2_conformance_test.go
+++ b/internal/worker/workertest/phase2_conformance_test.go
@@ -18,6 +18,8 @@ func TestPhase2Catalog(t *testing.T) {
 		RequirementInputInitialMessageFirstStart,
 		RequirementInputInitialMessageResume,
 		RequirementInputOverrideDefaults,
+		RequirementInputInProgressResumeRestart,
+		RequirementInputPreClaimResumeRestart,
 		RequirementTranscriptDiagnostics,
 		RequirementInteractionSignal,
 		RequirementInteractionPending,

--- a/internal/worker/workertest/testdata/phase2/catalog.json
+++ b/internal/worker/workertest/testdata/phase2/catalog.json
@@ -38,6 +38,18 @@
       "scenario_id": "input-override-defaults"
     },
     {
+      "code": "WC-INPUT-004",
+      "group": "input_delivery",
+      "description": "A resumed session with in-progress assigned work receives a restart turn instead of landing idle when no explicit nudge is configured.",
+      "scenario_id": "input-in-progress-resume-restart"
+    },
+    {
+      "code": "WC-INPUT-005",
+      "group": "input_delivery",
+      "description": "A resumed session with pre-claim work demand receives a restart turn instead of landing idle when no explicit nudge is configured.",
+      "scenario_id": "input-pre-claim-resume-restart"
+    },
+    {
       "code": "WC-TX-003",
       "group": "transcript",
       "description": "Malformed or torn transcript data is reported as degraded history or a fail-closed load error instead of clean normalized history.",

--- a/internal/worker/workertest/testdata/phase2/scenarios.yaml
+++ b/internal/worker/workertest/testdata/phase2/scenarios.yaml
@@ -48,6 +48,22 @@ scenarios:
     executable: true
     profiles: [claude/tmux-cli, codex/tmux-cli, gemini/tmux-cli, kimi/tmux-cli, opencode/tmux-cli, pi/tmux-cli]
     requirement_codes: [WC-INPUT-003]
+  - id: input-in-progress-resume-restart
+    runner: fake-worker
+    phase: phase2
+    kind: input_delivery
+    description: In-progress assigned work receives a restart turn on resume even without an explicit nudge.
+    executable: true
+    profiles: [claude/tmux-cli, codex/tmux-cli, gemini/tmux-cli, kimi/tmux-cli, opencode/tmux-cli, pi/tmux-cli]
+    requirement_codes: [WC-INPUT-004]
+  - id: input-pre-claim-resume-restart
+    runner: fake-worker
+    phase: phase2
+    kind: input_delivery
+    description: Pre-claim work demand receives a restart turn on resume even without an explicit nudge.
+    executable: true
+    profiles: [claude/tmux-cli, codex/tmux-cli, gemini/tmux-cli, kimi/tmux-cli, opencode/tmux-cli, pi/tmux-cli]
+    requirement_codes: [WC-INPUT-005]
   - id: transcript-diagnostics
     runner: fake-worker
     phase: phase2


### PR DESCRIPTION
## Summary
- deliver the rendered startup prompt through the resume nudge path so restarted sessions do not land idle
- keep provider resume flags clean and avoid replaying template initial_message on resume
- add Phase 2 worker conformance coverage for in-progress and pre-claim resume restarts

## Tests
- go test ./cmd/gc -run TestPhase2InitialInputDelivery -count=1
- go test ./internal/worker/workertest -run 'TestPhase2Catalog|TestPhase2CatalogData' -count=1
- go test ./cmd/gc -run 'TestPhase2|TestPrepareStartCandidate|TestExecutePlannedStarts' -count=1
- go test ./internal/worker/workertest -count=1
- go test ./cmd/gc -count=1
- pre-commit hook: lint-changed, generated docs/schema check, go vet ./..., fast sharded tests