### PR TITLE
fix(sling): render single-bead dry-run preview for leaf tasks

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -882,7 +882,14 @@ func doSlingBatchWithJSON(opts slingOpts, deps slingDeps, querier BeadChildQueri
 			return writeSlingJSONResult(result, jsonStdout, stderr)
 		}
 		// For batch dry-run, look up the container bead for display.
-		if querier != nil {
+		// DoSling sets ContainerType on the result only when it actually
+		// went down the batch path (i.e. the bead is a container type
+		// like convoy). For leaf tasks it returns the single-bead result
+		// with ContainerType unset — so the dry-run preview must use
+		// dryRunSingle, otherwise it renders the misleading "container
+		// with zero children" output even though the real run would
+		// route the bead itself.
+		if result.ContainerType != "" && querier != nil {
 			if b, getErr := querier.Get(opts.BeadOrFormula); getErr == nil {
 				children, _ := dryRunBatchChildren(querier, b.ID)
 				var open []beads.Bead

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -5593,6 +5593,77 @@ func TestDryRunConvoyUsesTracksMembers(t *testing.T) {
 	}
 }
 
+// TestDryRunLeafTaskViaBatchDispatchOnFormula is a regression test for
+// the dry-run mismatch where `gc sling --dry-run <pool> <leaf-task>
+// --on <formula>` rendered the batch ("container with zero children")
+// preview even though a real run would wrap-and-route the bead itself.
+//
+// The live CLI dispatches every sling invocation through
+// doSlingBatchWithJSON (cmd_sling.go calls it unconditionally from the
+// command handler). Inside, sling.DoSling decides single-vs-batch by
+// bead type. For non-container types (task, bug, feature, etc.) it
+// returns a single-bead result with ContainerType unset. The dry-run
+// rendering then has to honour that signal — otherwise it falls into
+// the batch preview and reports "Children (0 total, 0 open)" plus an
+// empty route list, which is the opposite of what the real run does.
+//
+// The fix in cmd_sling.go gates the dryRunBatch dispatch on
+// result.ContainerType being non-empty.
+func TestDryRunLeafTaskViaBatchDispatchOnFormula(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	a := config.Agent{
+		Name:              "polecat",
+		Dir:               "hw",
+		MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+	}
+	q := newFakeChildQuerier()
+	q.beadsByID["BL-42"] = beads.Bead{ID: "BL-42", Type: "task", Status: "open", Title: "Implement login page"}
+	q.childrenOf["BL-42"] = []beads.Bead{} // no molecule children
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = seededStore("BL-42")
+	opts := testOpts(a, "BL-42")
+	opts.OnFormula = "code-review"
+	opts.DryRun = true
+	// Mirror the live CLI: every sling invocation goes through
+	// doSlingBatchWithJSON; the function decides single-vs-batch
+	// internally from the bead type.
+	code := doSlingBatch(opts, deps, q, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("dry-run returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	// Must render the single-bead preview, NOT the batch container preview.
+	if strings.Contains(out, "Children (0 total, 0 open)") {
+		t.Errorf("stdout rendered misleading container preview for a leaf task; got: %s", out)
+	}
+	if strings.Contains(out, "is a container bead that groups related work") {
+		t.Errorf("stdout claimed leaf task is a container; got: %s", out)
+	}
+	if strings.Contains(out, "Attach formula (per open child):") {
+		t.Errorf("stdout rendered per-child attach section for a leaf task; got: %s", out)
+	}
+	// Should render the single-bead attach + route preview.
+	if !strings.Contains(out, "Attach formula:") {
+		t.Errorf("stdout missing single-bead attach section: %s", out)
+	}
+	if !strings.Contains(out, "Would run: bd mol cook --formula=code-review --on=BL-42") {
+		t.Errorf("stdout missing cook command: %s", out)
+	}
+	if !strings.Contains(out, "bd update 'BL-42' --set-metadata gc.routed_to=hw/polecat") {
+		t.Errorf("stdout missing route command: %s", out)
+	}
+	if !strings.Contains(out, "No side effects executed (--dry-run).") {
+		t.Errorf("stdout missing footer: %s", out)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("got %d runner calls, want 0 (dry-run): %v", len(runner.calls), runner.calls)
+	}
+}
+
 func TestDryRunBatchOnFormula(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -5603,7 +5603,7 @@ func TestDryRunConvoyUsesTracksMembers(t *testing.T) {
 // command handler). Inside, sling.DoSling decides single-vs-batch by
 // bead type. For non-container types (task, bug, feature, etc.) it
 // returns a single-bead result with ContainerType unset. The dry-run
-// rendering then has to honour that signal — otherwise it falls into
+// rendering then has to honor that signal — otherwise it falls into
 // the batch preview and reports "Children (0 total, 0 open)" plus an
 // empty route list, which is the opposite of what the real run does.
 //


### PR DESCRIPTION
## Summary

`gc sling --dry-run <target> <leaf-task> --on <formula>` rendered the batch ("container with zero children") preview even though a real run wraps and routes the leaf task itself. A user reading the dry-run output reasonably concludes that sling won't route the bead.

## Reproduction

```bash
bd create "anything" --type=task        # → wdsp-XXX

gc sling --dry-run <rig>/claude wdsp-XXX --on mol-do-work
# Output (truncated):
#   Type: task
#   A task is a container bead that groups related work. Sling
#   expands it and routes each open child individually.
#   Children (0 total, 0 open):
#   Attach formula (per open child):
#     Would run:
#   Route commands (not executed):
#   No side effects executed (--dry-run).

gc sling <rig>/claude wdsp-XXX --on mol-do-work
# → Auto-convoy <id>
# → Attached wisp <id> (formula "mol-do-work") to wdsp-XXX
# → Slung wdsp-XXX → <rig>/claude

bd show wdsp-XXX --json | jq '.[0].metadata'
# → {"molecule_id":"...","gc.routed_to":"<rig>/claude"}
```

I hit this in a real coordination flow ([context](https://github.com/gastownhall/gascity/issues) is a Mayor → polecat dispatch) and initially concluded sling wouldn't route the bead, switching to a `bd update --set-metadata` workaround that loses the wisp/molecule attachment sling otherwise provides.

## Root cause

`cmd/gc/cmd_sling.go` dispatches every CLI sling invocation through `doSlingBatchWithJSON`. Inside, `sling.DoSling` decides single-vs-batch by bead type: container types (e.g. `convoy`) take the batch path; everything else (task, bug, feature, …) takes the single path. `internal/sling/sling_core.go` sets `result.ContainerType` only on the batch path (line 1052, line 1064).

The dry-run rendering then has to honour that signal — but pre-fix it just checks whether the bead can be fetched:

```go
if querier != nil {
    if b, getErr := querier.Get(opts.BeadOrFormula); getErr == nil {
        // … always goes through dryRunBatch …
    }
}
return dryRunSingle(...)
```

For a leaf task, `querier.Get` succeeds, so the branch is taken — but the result was actually produced by the single-bead path. `dryRunBatch` then renders the misleading container preview with zero children.

## Fix

Gate the `dryRunBatch` dispatch on `result.ContainerType != ""`. The signal is already there in the result; the CLI just wasn't reading it.

```go
if result.ContainerType != "" && querier != nil {
    // … dryRunBatch …
}
return dryRunSingle(...)
```

One line of logic change plus an explanatory comment.

## Tests

Added `TestDryRunLeafTaskViaBatchDispatchOnFormula` in `cmd/gc/cmd_sling_test.go`. It mirrors the live CLI scenario — leaf task bead, multi-session pool config target, `--on` formula, real `BeadChildQuerier` — and asserts both negative cases (no `"Children (0 total, 0 open)"`, no `"is a container bead"`, no `"Attach formula (per open child)"`) and positive cases (single-bead `Attach formula:`, `bd mol cook ...`, and route command rendering).

Verified the test:
- **FAILS on HEAD without the fix** with the exact misleading output documented above.
- **PASSES with the fix**.

All 18 `TestDryRun*` tests pass with the fix. The full `cmd/gc` sling test set (`go test ./cmd/gc -run "Sling|sling"`) and `internal/sling/...` both pass clean. `go vet ./cmd/gc ./internal/sling` clean.

I did not run the pre-commit hook end-to-end (no `golangci-lint` installed locally) — but the change is two files, scoped to sling, and doesn't touch OpenAPI / dashboard / docs, so the hook's regeneration steps would produce no diff.

## Test plan
- [ ] CI passes
- [ ] Reviewer confirms the dry-run scenario above produces the correct single-bead preview on a local build of this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)