### PR TITLE
fix(cmd/gc): silence unused lint on non-Linux fsPressureReadFile

### DIFF
--- a/cmd/gc/fs_pressure_other.go
+++ b/cmd/gc/fs_pressure_other.go
@@ -6,8 +6,12 @@ package main
 // reference it in tests without build-tag juggling.
 var fsPressurePath = ""
 
-// fsPressureReadFile is unused on non-Linux but declared so tests on
-// non-Linux platforms can still reference the symbol.
+// fsPressureReadFile mirrors the Linux declaration so the shared test helper
+// configureFSPressureForTests (main_test.go) compiles on all platforms. The
+// non-Linux readFSPressureAvg60 stub never reads it, so it is write-only here;
+// silence the unused check rather than build-tag-splitting the test helper.
+//
+//nolint:unused // assigned cross-platform by tests; only read on Linux
 var fsPressureReadFile = func(string) ([]byte, error) { return nil, nil }
 
 // readFSPressureAvg60 always returns 0 on non-Linux so the backpressure gate


### PR DESCRIPTION
## What

`Mac / quality (lint, fmt, vet, docs)` has been red on `main` because golangci-lint's `unused` analyzer flags a write-only var on the non-Linux build:

```
cmd/gc/fs_pressure_other.go:11:5: var fsPressureReadFile is unused (unused)
```

## Why it only fails on macOS

`fsPressureReadFile` is **assigned** by the shared test helper `configureFSPressureForTests` (`cmd/gc/main_test.go`, not build-tagged, so it compiles on every platform) but **read** only by `readFSPressureAvg60` in `cmd/gc/fs_pressure_linux.go` (`//go:build linux`). On non-Linux the `readFSPressureAvg60` stub is a no-op, so the var is write-only — and staticcheck's `unused` reports write-only package vars. Linux builds read it, so they stay green. (Its sibling `fsPressurePath` is fine because the shared `fs_pressure.go` reads it on all platforms.)

## Fix

Keep the declaration — `main_test.go` references it unconditionally, so removing it breaks the darwin **test** build (`undefined: fsPressureReadFile`) — and annotate it `//nolint:unused` with the rationale. Build-tag-splitting the shared test helper would be more churn for no benefit.

## Verification

- `GOOS=darwin golangci-lint run --default=none --enable=unused ./cmd/gc/` → **0 issues** (was 1).
- `GOOS=darwin` and Linux `go build` + `go vet ./cmd/gc/` clean.
- Linux `fs_pressure` tests pass.
- pre-commit hook (incl. its `fsys-darwin-compile` check) green.

## Context

Triaged from the `main-ci-watcher` anchor **ga-40dtz** (P1, `Mac / quality`). Part of the macOS-CI-red cleanup; the sibling `Mac / make test` failures are specced in ready-to-build **ga-ulwil** (EvalSymlinks path comparisons + `/proc/<pid>/exe` drift tests). This PR addresses only the `quality` job's `unused` finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)