### PR TITLE
Expand beads trace logging

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -576,6 +576,12 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		// Record the tick reason for any bd subprocess spawned during
+		// this tick — TraceBDCall reads it to attribute calls to
+		// patrol vs poke. Single-tenant best-effort: restore the
+		// previous value on exit so nested ticks don't lose context.
+		prev := beads.SetReconcilerTickTrigger(trigger)
+		defer beads.RestoreReconcilerTickTrigger(prev)
 		cr.safeTick(func() {
 			cr.tick(ctx, dirty, &lastProviderName, cityRoot, &prevPoolRunning, trigger)
 		}, trigger)

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -8,7 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -193,12 +195,22 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	}
 	cmd.Env = workQueryEnvForDir(env, cmd.Dir)
 
+	traceStart := time.Now()
 	runErr := cmd.Run()
-
+	traceExit := 0
 	if runErr != nil {
 		var exitErr *exec.ExitError
 		if errors.As(runErr, &exitErr) {
-			return exitErr.ExitCode()
+			traceExit = exitErr.ExitCode()
+		} else {
+			traceExit = -1
+		}
+	}
+	beads.TraceBDCall("go:gc-bd-passthrough", target.ScopeRoot, bdArgs, traceStart, traceExit, runErr)
+
+	if runErr != nil {
+		if traceExit > 0 {
+			return traceExit
 		}
 		fmt.Fprintf(stderr, "gc bd: %v\n", runErr) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/hooks.go
+++ b/cmd/gc/hooks.go
@@ -53,6 +53,9 @@ HOOK_LOG="${BEADS_DIR:-.beads}/hooks.log"
 DATA=$(cat)
 PAYLOAD=$(printf '{"bead":%%s}' "$DATA")
 title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Tag subprocess bd calls so the bd-trace can attribute them to the
+# hook cascade (best-effort; ignored when GC_BD_TRACE is unset).
+export GC_BD_TRACE_SCOPE="hook:%[2]s"
 (
   "$GC_BIN" event emit %[2]s --subject "$1" --message "$title" --payload "$PAYLOAD" 2>>"$HOOK_LOG" \
     || echo "[$(date -u +%%FT%%TZ)] %[3]s $1: gc event emit %[2]s failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
@@ -94,6 +97,9 @@ HOOK_LOG="${BEADS_DIR:-.beads}/hooks.log"
 DATA=$(cat)
 PAYLOAD=$(printf '{"bead":%%s}' "$DATA")
 title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Tag subprocess bd calls so the bd-trace can attribute them to the
+# hook cascade (best-effort; ignored when GC_BD_TRACE is unset).
+export GC_BD_TRACE_SCOPE="hook:bead.closed"
 (
   "$GC_BIN" event emit bead.closed --subject "$1" --message "$title" --payload "$PAYLOAD" 2>>"$HOOK_LOG" \
     || echo "[$(date -u +%%FT%%TZ)] on_close $1: gc event emit bead.closed failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \

--- a/examples/gastown/packs/gastown/assets/scripts/status-line.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/status-line.sh
@@ -7,6 +7,23 @@
 agent="$1"
 [ -z "$agent" ] && exit 0
 
+# Trace gc hook / gc mail check invocations to $GC_BD_TRACE when set.
+# The helper lives in the maintenance pack scripts dir; if it's not
+# reachable, status-line continues without tracing.
+__bd_trace_helper=""
+for __cand in \
+    "${GC_CITY_PATH:-}/.gc/system/packs/maintenance/assets/scripts/_bd_trace.sh" \
+    "${GC_CITY:-}/.gc/system/packs/maintenance/assets/scripts/_bd_trace.sh"; do
+    if [ -n "$__cand" ] && [ -f "$__cand" ]; then
+        __bd_trace_helper="$__cand"
+        break
+    fi
+done
+if [ -n "$__bd_trace_helper" ]; then
+    # shellcheck disable=SC1090
+    . "$__bd_trace_helper" "status-line:$agent"
+fi
+
 # Count pending work items (non-empty lines from gc hook).
 w=$(gc hook "$agent" 2>/dev/null | grep -c . || true)
 

--- a/examples/gastown/packs/maintenance/assets/scripts/_bd_trace.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/_bd_trace.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# _bd_trace.sh — shell-side bd call trace helper.
+#
+# Sourced by gas city application scripts (maintenance pack scripts, tmux
+# status-line). Overrides `bd` and `gc bd` in the calling shell so each
+# invocation appends a JSONL record to $GC_BD_TRACE_JSON. When $GC_BD_TRACE_JSON is
+# unset, calls pass through with no logging overhead.
+#
+# Source with a source tag identifying the calling script:
+#
+#   . "$(dirname "$0")/_bd_trace.sh" "gate-sweep"
+#
+# Then call `bd ...` and `gc ...` normally — calls are traced.
+
+__bd_trace_source="${1:-unknown}"
+
+__bd_trace_emit() {
+    # $1 = command name (bd or gc), $2 = exit code, $3 = start_ns, $4..N = args
+    if [ -z "${GC_BD_TRACE_JSON:-}" ]; then
+        return 0
+    fi
+    __bd_trace_cmd="$1"
+    __bd_trace_exit="$2"
+    __bd_trace_start="$3"
+    shift 3
+    __bd_trace_end="$(date +%s%N 2>/dev/null || printf '%s000000000' "$(date +%s)")"
+    __bd_trace_dur_ms=$(( (__bd_trace_end - __bd_trace_start) / 1000000 ))
+    __bd_trace_ts="$(date -u +%Y-%m-%dT%H:%M:%S)Z"
+    # Build JSON args array. Each arg is JSON-escaped with python; fall back
+    # to a single string if python isn't available.
+    if command -v python3 >/dev/null 2>&1; then
+        __bd_trace_args=$(printf '%s\n' "$@" | python3 -c 'import sys,json; print(json.dumps([l.rstrip("\n") for l in sys.stdin]))')
+    else
+        __bd_trace_args="[\"$(printf '%s' "$*" | sed 's/\\/\\\\/g; s/"/\\"/g')\"]"
+    fi
+    printf '{"ts":"%s","source":"sh:%s/%s","args":%s,"dir":"%s","dur_ms":%d,"exit_code":%d,"pid":%d,"ppid":%d}\n' \
+        "$__bd_trace_ts" \
+        "$__bd_trace_source" \
+        "$__bd_trace_cmd" \
+        "$__bd_trace_args" \
+        "$(pwd)" \
+        "$__bd_trace_dur_ms" \
+        "$__bd_trace_exit" \
+        "$$" \
+        "${PPID:-0}" \
+        >> "$GC_BD_TRACE_JSON" 2>/dev/null || true
+}
+
+bd() {
+    __bd_start="$(date +%s%N 2>/dev/null || printf '%s000000000' "$(date +%s)")"
+    command bd "$@"
+    __bd_exit=$?
+    __bd_trace_emit bd "$__bd_exit" "$__bd_start" "$@"
+    return "$__bd_exit"
+}
+
+gc() {
+    __bd_start="$(date +%s%N 2>/dev/null || printf '%s000000000' "$(date +%s)")"
+    command gc "$@"
+    __bd_exit=$?
+    # Only emit a trace entry for gc subcommands that internally fire bd
+    # (bd passthrough, hook, mail). Others (gc session/runtime/etc) emit
+    # their own bd-trace lines via the Go-side TraceBDCall.
+    case "$1" in
+        bd|hook|mail)
+            __bd_trace_emit "gc-$1" "$__bd_exit" "$__bd_start" "$@"
+            ;;
+    esac
+    return "$__bd_exit"
+}

--- a/examples/gastown/packs/maintenance/assets/scripts/cross-rig-deps.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/cross-rig-deps.sh
@@ -15,6 +15,11 @@
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
+# Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "cross-rig-deps"
+
 CITY="${GC_CITY:-.}"
 LOOKBACK="${CROSS_RIG_LOOKBACK:-15m}"
 

--- a/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
@@ -20,5 +20,10 @@
 # Restore `bd gate check --type=bead --escalate` when beads adds it back.
 set -euo pipefail
 
+# Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "gate-sweep"
+
 bd gate check --type=timer --escalate
 bd gate check --type=gh --escalate || true

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -11,6 +11,11 @@
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
+# Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "orphan-sweep"
+
 CITY="${GC_CITY:-.}"
 
 # Step 1: Collect in-progress beads from HQ and every rig whose session

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -8,6 +8,11 @@
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
+# Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "reaper"
+
 CITY="${GC_CITY_PATH:-${GC_CITY:-.}}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/dolt-target.sh"

--- a/examples/gastown/packs/maintenance/assets/scripts/spawn-storm-detect.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/spawn-storm-detect.sh
@@ -11,6 +11,11 @@
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
+# Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "spawn-storm-detect"
+
 CITY="${GC_CITY:-.}"
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/maintenance}"
 LEDGER="$PACK_STATE_DIR/spawn-storm-counts.json"

--- a/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
@@ -16,6 +16,11 @@
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
+# Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
+__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$__SCRIPT_DIR/_bd_trace.sh" "wisp-compact"
+
 CITY="${GC_CITY:-.}"
 
 # Get all ephemeral beads.

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -56,6 +56,14 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 	return func(dir, name string, args ...string) ([]byte, error) {
 		start := time.Now()
 		trace := func(status string, err error) {
+			// GC_BD_TRACE_JSON wins: when the structured JSONL trace
+			// (via TraceBDCall in bdtrace.go) is enabled, suppress the
+			// legacy line-format trace so the two don't interleave
+			// incompatible records in the same file when an operator
+			// points both env vars at the same path.
+			if strings.TrimSpace(os.Getenv("GC_BD_TRACE_JSON")) != "" {
+				return
+			}
 			path := strings.TrimSpace(os.Getenv("GC_BD_TRACE"))
 			if path == "" {
 				return
@@ -99,6 +107,18 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 		cmd.Stderr = &stderr
 		out, err := cmd.Output()
 		if name == "bd" {
+			// Structured JSONL trace — independent of the legacy line-format
+			// trace above (gated by GC_BD_TRACE_JSON, not GC_BD_TRACE).
+			traceExit := 0
+			if err != nil {
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					traceExit = exitErr.ExitCode()
+				} else {
+					traceExit = -1
+				}
+			}
+			TraceBDCall("go:bdstore.runner", dir, args, start, traceExit, err)
 			telemetry.RecordBDCall(context.Background(),
 				args, float64(time.Since(start).Milliseconds()),
 				err, out, stderr.String())
@@ -293,6 +313,7 @@ func (s *BdStore) Purge(beadsDir string, dryRun bool) (PurgeResult, error) {
 
 // execPurge runs bd purge via exec.CommandContext with a 60-second timeout.
 func execPurge(dir string, env, args []string) ([]byte, error) {
+	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -305,6 +326,16 @@ func execPurge(dir string, env, args []string) ([]byte, error) {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
+	traceExit := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			traceExit = exitErr.ExitCode()
+		} else {
+			traceExit = -1
+		}
+	}
+	TraceBDCall("go:bdstore.execPurge", dir, args, start, traceExit, err)
 	if ctx.Err() == context.DeadlineExceeded {
 		return nil, fmt.Errorf("timed out after 60s")
 	}

--- a/internal/beads/bdtrace.go
+++ b/internal/beads/bdtrace.go
@@ -1,0 +1,329 @@
+package beads
+
+import (
+	"encoding/json"
+	"os"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// reconcilerTickTrigger is the most recent reason the reconciler loop
+// woke and ran cr.tick() — one of "patrol", "poke", or other trigger
+// strings recognized by city_runtime.runTick. Updated atomically by
+// SetReconcilerTickTrigger / ClearReconcilerTickTrigger and read by
+// TraceBDCall to attribute bd calls to the tick reason that drove them.
+//
+// Best-effort. In a supervisor managing multiple concurrent cities,
+// ticks from different cities can race and the value reflects the most
+// recent setter. For diagnosis of one-city workloads it is accurate;
+// for multi-city deployments treat the field as advisory and rely on
+// the Callers field for definitive attribution.
+var reconcilerTickTrigger atomic.Pointer[string]
+
+// SetReconcilerTickTrigger records the current tick reason; returns the
+// previous value so the caller can restore it on exit (supporting
+// nested tick frames if they ever exist).
+func SetReconcilerTickTrigger(trigger string) *string {
+	return reconcilerTickTrigger.Swap(&trigger)
+}
+
+// RestoreReconcilerTickTrigger restores the previous tick-trigger
+// pointer captured by SetReconcilerTickTrigger.
+func RestoreReconcilerTickTrigger(prev *string) {
+	reconcilerTickTrigger.Store(prev)
+}
+
+// classifyTraceScope inspects the Go call stack captured for a bd
+// invocation and returns a high-level scope label so consumers can
+// filter or aggregate without parsing function names themselves. The
+// classifier walks the stack outermost-frame-first and returns the
+// first scope whose marker is present; scopes are ordered from most
+// specific (cobra-driven CLI commands, hook cascades) to most generic
+// (reconciler tick).
+//
+// When no scope matches, returns "unknown" so analysis queries always
+// have a non-empty field to group on.
+func classifyTraceScope(callers []string) string {
+	// Walk from innermost to outermost and return the first matching
+	// scope. Innermost-first picks the MOST SPECIFIC scope when
+	// multiple frames on the stack match (e.g. a call from
+	// dispatchOrders inside tick() should classify as order-dispatch,
+	// not tick-body). The catch-alls (tick-body, cli-command) sit at
+	// the bottom of the switch so they only match when no specific
+	// inner scope did.
+	for _, fn := range callers {
+		switch {
+		// Hook cascade — bd write fired the on_<event> shell script,
+		// which forked one of these gc subcommands. The cobra frame
+		// is also present but the autoclose helper is more specific.
+		case strings.Contains(fn, "main.doConvoyAutoclose"):
+			return "hook:convoy-autoclose"
+		case strings.Contains(fn, "main.doWispAutoclose"):
+			return "hook:wisp-autoclose"
+
+		// Event-bus driven work.
+		case strings.Contains(fn, "applyBeadEventToStores"),
+			strings.Contains(fn, "startBeadEventWatcher"):
+			return "bead-event-watcher"
+
+		// CachingStore self-maintenance.
+		case strings.Contains(fn, "CachingStore).reconcileLoop"),
+			strings.Contains(fn, "runReconciliation"),
+			strings.Contains(fn, "PrimeActive"),
+			strings.Contains(fn, "(*CachingStore).Prime"):
+			return "cache-reconcile"
+
+		// Startup / one-time init paths.
+		case strings.Contains(fn, "initBeadsForDir"),
+			strings.Contains(fn, "initAndHookDir"),
+			strings.Contains(fn, "finalizeCanonicalBdScopeInit"),
+			strings.Contains(fn, "verifyCanonicalBdScopeStoreReady"),
+			strings.Contains(fn, "buildStores"),
+			strings.Contains(fn, "(*controllerState).build"),
+			strings.Contains(fn, "main.init.func"):
+			return "init"
+
+		// Order dispatch — includes the gating helpers that decide
+		// whether to fire (hasOpenWork, LastRunFuncForStore, cursor
+		// lookup, etc.). Without these the order-dispatch scope
+		// shows up as "unknown" because the dispatch frame is
+		// already deeper than the chokepoint sees.
+		case strings.Contains(fn, "memoryOrderDispatcher).dispatch"),
+			strings.Contains(fn, "memoryOrderDispatcher).hasOpenWork"),
+			strings.Contains(fn, "memoryOrderDispatcher).cachedLastRun"),
+			strings.Contains(fn, "dispatchOrders"),
+			strings.Contains(fn, "orders.LastRunFuncForStore"),
+			strings.Contains(fn, "orders.LastRunAcrossStores"),
+			strings.Contains(fn, "orders.CursorAcrossStores"),
+			strings.Contains(fn, "bdCursorAcrossStores"),
+			strings.Contains(fn, "doOrderCheck"):
+			return "order-dispatch"
+
+		// Session observation hot path.
+		case strings.Contains(fn, "workerObserveSessionTarget"),
+			strings.Contains(fn, "loadProviderSessionSnapshot"):
+			return "session-observe"
+
+		// Per-session bead reconciliation work.
+		case strings.Contains(fn, "reconcileSessionBeads"),
+			strings.Contains(fn, "beadReconcileTick"):
+			return "reconcile-session-beads"
+
+		// Demand probing — work_query subprocesses + ready() per agent.
+		case strings.Contains(fn, "loadDemandSnapshot"),
+			strings.Contains(fn, "computeWorkSet"),
+			strings.Contains(fn, "readyForControllerDemand"),
+			strings.Contains(fn, "defaultScaleCheckCounts"),
+			strings.Contains(fn, "defaultNamedSessionDemand"),
+			strings.Contains(fn, "collectAssignedWorkBeadsWith"):
+			return "demand-probe"
+
+		// Session-bead bookkeeping (writes that mirror state into beads).
+		case strings.Contains(fn, "syncSessionBeadsWith"),
+			strings.Contains(fn, "syncBeadsAndUpdateIndex"),
+			strings.Contains(fn, "(*Manager).confirmLiveSessionState"):
+			return "sync-session-beads"
+
+		// Session listing.
+		case strings.Contains(fn, "loadSessionBeadSnapshot"),
+			strings.Contains(fn, "listConfiguredNamedSessionBeadsByMetadata"),
+			strings.Contains(fn, "listSessionBeadsByMetadata"),
+			strings.Contains(fn, "ListAllSessionBeads"):
+			return "session-list"
+
+		// Session identity resolution — invoked by many entry points
+		// (CLI commands, workerHandle, sling). Classify as resolve
+		// only when no more-specific outer frame matched.
+		case strings.Contains(fn, "ResolveSessionBeadByExactID"),
+			strings.Contains(fn, "ResolveSessionIDByExactID"),
+			strings.Contains(fn, "session.ResolveSessionID"),
+			strings.Contains(fn, "session.(*Manager).loadSessionBead"),
+			strings.Contains(fn, "resolveSessionIDWithOptions"),
+			strings.Contains(fn, "resolveSessionIDMaterializingNamed"):
+			return "session-resolve"
+
+		// Mail subsystem — recipient route lookup is the hot one;
+		// Read/Send are explicit ops.
+		case strings.Contains(fn, "beadmail.(*Provider).filterMessages"),
+			strings.Contains(fn, "beadmail.(*Provider).messageCandidatesForRoutes"),
+			strings.Contains(fn, "beadmail.(*Provider).recipientRoutes"),
+			strings.Contains(fn, "beadmail.(*Provider).recipientSessionMatches"),
+			strings.Contains(fn, "resolveMailTargetsCached"):
+			return "mail-routing"
+		case strings.Contains(fn, "beadmail.(*Provider).Read"),
+			strings.Contains(fn, "beadmail.(*Provider).Send"):
+			return "mail-op"
+
+		// Reaper / corpse cleanup paths.
+		case strings.Contains(fn, "reapStaleSessionBeads"),
+			strings.Contains(fn, "cleanupDeadRuntimeSessionCorpses"),
+			strings.Contains(fn, "reapRuntimesBoundToClosedBeads"),
+			strings.Contains(fn, "releaseOrphanedPoolAssignments"):
+			return "session-reaper"
+
+		// Session lifecycle: spawning, stopping, drain commits.
+		case strings.Contains(fn, "prepareStartCandidateForCity"),
+			strings.Contains(fn, "commitAsyncStartResultWithContext"),
+			strings.Contains(fn, "executePlannedStarts"),
+			strings.Contains(fn, "createPoolSessionBead"),
+			strings.Contains(fn, "syncDesiredPoolSlots"):
+			return "session-start"
+		case strings.Contains(fn, "stopTargetThroughWorkerBoundary"),
+			strings.Contains(fn, "workerStopSessionTarget"),
+			strings.Contains(fn, "workerKillSessionTarget"):
+			return "session-stop"
+		case strings.Contains(fn, "withCitySessionIdentifierLock"):
+			return "session-lock"
+		case strings.Contains(fn, "(*CityRuntime).shutdown"):
+			return "city-shutdown"
+
+		// Order-tracking sweep (the periodic order body that closes
+		// stale order-tracking beads, NOT the dispatcher itself).
+		case strings.Contains(fn, "sweepStaleOrderTracking"),
+			strings.Contains(fn, "sweepOrphanedOrderTracking"):
+			return "order-tracking-sweep"
+
+		// Explicit mail ops via CLI/Go that the broader classifier missed.
+		case strings.Contains(fn, "doMailArchive"),
+			strings.Contains(fn, "doMailRead"),
+			strings.Contains(fn, "newMailSendCmd"),
+			strings.Contains(fn, "newMailReplyCmd"),
+			strings.Contains(fn, "newMailCheckCmd"),
+			strings.Contains(fn, "cmdMail"):
+			return "mail-op"
+
+		// Sling — work routing.
+		case strings.Contains(fn, "sling.CollectAttachedBeads"),
+			strings.Contains(fn, "sling.dispatch"),
+			strings.Contains(fn, "(*Sling)"):
+			return "sling"
+
+		// Generic tick-body catch-all for reconciler-driven calls
+		// that didn't match a more specific scope above.
+		case strings.Contains(fn, "(*CityRuntime).tick"):
+			return "tick-body"
+
+		// CLI-driven (gc bd, gc convoy, gc wisp, gc mail, etc.) —
+		// catch-all for direct user invocations and hook subprocesses
+		// not already classified above.
+		case strings.Contains(fn, "cobra.(*Command).execute"):
+			return "cli-command"
+		}
+	}
+	return "unknown"
+}
+
+// bdTraceCallerSkip is how many frames to skip past TraceBDCall and
+// the immediate site that invokes it (the BdStore runner closure or a
+// bypass site like execPurge) to find the actual user-facing caller.
+// Tuned per call site: the chokepoint runner is two frames deep
+// (runner closure → method that called runner), so frame 3 is the
+// originating BdStore method; frame 4 is the caller of that method.
+// We capture both frames so analysis can roll up either way.
+func captureBDTraceCallers() []string {
+	// 24 frames is enough to reach the outermost runTick or cobra
+	// entry point from the deepest BdStore call chains observed in
+	// practice (~15 frames). Going much higher costs runtime walk
+	// time on every traced call; lower truncates the outer scope
+	// information classifyTraceScope relies on.
+	var pcs [24]uintptr
+	n := runtime.Callers(2, pcs[:])
+	if n == 0 {
+		return nil
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	out := make([]string, 0, n)
+	for {
+		frame, more := frames.Next()
+		if frame.Function != "" {
+			out = append(out, frame.Function)
+		}
+		if !more || len(out) >= 16 {
+			break
+		}
+	}
+	return out
+}
+
+// TraceBDCall appends a JSONL record describing one bd subprocess
+// invocation to the file pointed to by the GC_BD_TRACE_JSON env var. When
+// GC_BD_TRACE_JSON is unset the call is a no-op.
+//
+// Designed to capture every bd subprocess spawned by gas city
+// application code (BdStore chokepoint, doctor checks, gc bd
+// passthrough, maintenance pack scripts, status-line scripts). Tag the
+// source so consumers can filter by call site when analyzing.
+//
+// Best-effort: trace failures are silently ignored so a broken trace
+// path can never break a real bd call.
+//
+// The trace is gated on the GC_BD_TRACE_JSON env var (NOT GC_BD_TRACE,
+// which the existing line-format trace in bdstore.go uses). The two
+// formats are incompatible, so separating the env vars lets operators
+// enable one, the other, or both independently. When GC_BD_TRACE_JSON
+// is unset, TraceBDCall returns immediately and is effectively a no-op.
+func TraceBDCall(source, dir string, args []string, start time.Time, exitCode int, err error) {
+	path := strings.TrimSpace(os.Getenv("GC_BD_TRACE_JSON"))
+	if path == "" {
+		return
+	}
+	f, openErr := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if openErr != nil {
+		return
+	}
+	defer f.Close() //nolint:errcheck // best-effort trace log
+
+	errMsg := ""
+	if err != nil {
+		errMsg = err.Error()
+	}
+	callers := captureBDTraceCallers()
+	scope := classifyTraceScope(callers)
+	tickTrigger := ""
+	if p := reconcilerTickTrigger.Load(); p != nil {
+		tickTrigger = *p
+	}
+	// Environment-provided scope hint: subprocesses spawned by gas
+	// city (notably the bd-hook cascade and order exec bodies) inherit
+	// GC_BD_TRACE_SCOPE so their bd calls record where they came from
+	// even though they're a fresh process with no in-memory context.
+	envScope := strings.TrimSpace(os.Getenv("GC_BD_TRACE_SCOPE"))
+
+	rec := struct {
+		TS          string   `json:"ts"`
+		Source      string   `json:"source"`
+		Scope       string   `json:"scope"`
+		EnvScope    string   `json:"env_scope,omitempty"`
+		TickTrigger string   `json:"tick_trigger,omitempty"`
+		Args        []string `json:"args"`
+		Dir         string   `json:"dir,omitempty"`
+		DurMs       int64    `json:"dur_ms"`
+		ExitCode    int      `json:"exit_code"`
+		Err         string   `json:"err,omitempty"`
+		PID         int      `json:"pid"`
+		PPID        int      `json:"ppid"`
+		Callers     []string `json:"callers,omitempty"`
+	}{
+		TS:          time.Now().UTC().Format(time.RFC3339Nano),
+		Source:      source,
+		Scope:       scope,
+		EnvScope:    envScope,
+		TickTrigger: tickTrigger,
+		Args:        args,
+		Dir:         dir,
+		DurMs:       time.Since(start).Milliseconds(),
+		ExitCode:    exitCode,
+		Err:         errMsg,
+		PID:         os.Getpid(),
+		PPID:        os.Getppid(),
+		Callers:     callers,
+	}
+	data, marshalErr := json.Marshal(rec)
+	if marshalErr != nil {
+		return
+	}
+	data = append(data, '\n')
+	_, _ = f.Write(data) //nolint:errcheck // best-effort trace log
+}

--- a/internal/beads/bdtrace_smoke_test.go
+++ b/internal/beads/bdtrace_smoke_test.go
@@ -1,0 +1,86 @@
+package beads
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTraceBDCall_WritesJSONL(t *testing.T) {
+	tmp := t.TempDir()
+	tracePath := tmp + "/trace.jsonl"
+	t.Setenv("GC_BD_TRACE_JSON", tracePath)
+
+	start := time.Now().Add(-12 * time.Millisecond)
+	TraceBDCall("go:test.success", "/work", []string{"list", "--json"}, start, 0, nil)
+	TraceBDCall("go:test.failure", "/other", []string{"show", "sc-xyz", "--json"}, start, 1, errors.New("boom"))
+
+	data, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2: %s", len(lines), string(data))
+	}
+	for _, line := range lines {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("invalid JSON: %v\nline: %s", err, line)
+		}
+		for _, k := range []string{"ts", "source", "scope", "args", "dur_ms", "exit_code", "pid", "ppid"} {
+			if _, ok := rec[k]; !ok {
+				t.Errorf("missing key %q in record: %s", k, line)
+			}
+		}
+	}
+
+	// Verify env-scope is captured when set.
+	t.Setenv("GC_BD_TRACE_SCOPE", "hook:bead.closed")
+	tracePath2 := tmp + "/trace2.jsonl"
+	t.Setenv("GC_BD_TRACE_JSON", tracePath2)
+	TraceBDCall("go:test.envscope", "/work", []string{"list"}, start, 0, nil)
+	envData, err := os.ReadFile(tracePath2)
+	if err != nil {
+		t.Fatalf("read env trace: %v", err)
+	}
+	var envRec map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(envData))), &envRec); err != nil {
+		t.Fatalf("env trace JSON parse: %v", err)
+	}
+	if envRec["env_scope"] != "hook:bead.closed" {
+		t.Errorf("env_scope = %v, want hook:bead.closed", envRec["env_scope"])
+	}
+
+	// Verify tick-trigger plumbing.
+	t.Setenv("GC_BD_TRACE_SCOPE", "")
+	tracePath3 := tmp + "/trace3.jsonl"
+	t.Setenv("GC_BD_TRACE_JSON", tracePath3)
+	prev := SetReconcilerTickTrigger("patrol")
+	TraceBDCall("go:test.tick", "/work", []string{"list"}, start, 0, nil)
+	RestoreReconcilerTickTrigger(prev)
+	tickData, err := os.ReadFile(tracePath3)
+	if err != nil {
+		t.Fatalf("read tick trace: %v", err)
+	}
+	var tickRec map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(tickData))), &tickRec); err != nil {
+		t.Fatalf("tick trace JSON parse: %v", err)
+	}
+	if tickRec["tick_trigger"] != "patrol" {
+		t.Errorf("tick_trigger = %v, want patrol", tickRec["tick_trigger"])
+	}
+
+	// Verify GC_BD_TRACE_JSON=unset is a no-op
+	t.Setenv("GC_BD_TRACE_JSON", "")
+	if err := os.Remove(tracePath); err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	TraceBDCall("go:test.noop", "/work", []string{"list"}, start, 0, nil)
+	if _, err := os.Stat(tracePath); !os.IsNotExist(err) {
+		t.Errorf("expected no file when GC_BD_TRACE_JSON unset, got: %v", err)
+	}
+}

--- a/internal/doctor/checks_custom_types.go
+++ b/internal/doctor/checks_custom_types.go
@@ -2,11 +2,15 @@ package doctor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 // RequiredCustomTypes lists the bead types that Gas City requires
@@ -155,9 +159,21 @@ func mergeCustomTypes(current, required []string) []string {
 // the human-readable "types.custom (not set)" sentinel (which would
 // otherwise be persisted as a fake custom type when Fix() merges).
 func getCustomTypes(dir string) ([]string, error) {
-	cmd := exec.Command("bd", "config", "get", "--json", "types.custom")
+	start := time.Now()
+	args := []string{"config", "get", "--json", "types.custom"}
+	cmd := exec.Command("bd", args...)
 	cmd.Dir = dir
 	out, err := cmd.Output()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+	beads.TraceBDCall("go:doctor.getCustomTypes", dir, args, start, exitCode, err)
 	if err != nil {
 		return nil, err
 	}
@@ -182,9 +198,22 @@ func parseCustomTypesJSON(out []byte) ([]string, error) {
 
 // setCustomTypes writes the types.custom config to a bd store.
 func setCustomTypes(dir, types string) error {
-	cmd := exec.Command("bd", "config", "set", "types.custom", types)
+	start := time.Now()
+	args := []string{"config", "set", "types.custom", types}
+	cmd := exec.Command("bd", args...)
 	cmd.Dir = dir
-	return cmd.Run()
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+	beads.TraceBDCall("go:doctor.setCustomTypes", dir, args, start, exitCode, err)
+	return err
 }
 
 // dirExists checks if a directory exists.


### PR DESCRIPTION
## Summary

Adds a structured JSONL trace of every `bd` subprocess invocation so we can quantify `bd` traffic and attribute it to specific call sites (order-dispatch, mail-routing, session-resolve, hook cascades, etc.). Gated behind a new `GC_BD_TRACE_JSON` env var — fully no-op when unset. No production behavior changes.

```bash
export GC_BD_TRACE_JSON=$HOME/.gc/bd-calls.jsonl
gc supervisor start
gc start
```
Then examine the file at $GC_BD_TRACE_JSON for analysis. The structure looks like this:
```jsonl
    {"ts":"...", "source":"go:bdstore.runner", "scope":"order-dispatch",
     "env_scope":"", "tick_trigger":"patrol", "args":["list","--json",...],
     "dir":"/path", "dur_ms":42, "exit_code":0, "pid":123, "ppid":456,
     "callers":[...]}
```
Useful for investigating https://github.com/gastownhall/gascity/issues/2463.
