### PR TITLE
fix(gc): prevent integration dolt process leaks

### DIFF
--- a/cmd/gc/dolt_cleanup_reaper.go
+++ b/cmd/gc/dolt_cleanup_reaper.go
@@ -107,6 +107,8 @@ func testConfigPathPrefixes() []string {
 		"gc-supervisor-city-",
 		"gc-reload-invalid-",
 		"gc-rename-",
+		"gcit-",
+		"gc-int-env-",
 	}
 }
 

--- a/cmd/gc/dolt_cleanup_reaper_test.go
+++ b/cmd/gc/dolt_cleanup_reaper_test.go
@@ -71,6 +71,18 @@ func TestIsTestConfigPath_KnownGCTestPrefix(t *testing.T) {
 	}
 }
 
+func TestIsTestConfigPath_IntegrationTempPrefixes(t *testing.T) {
+	cases := []string{
+		"/tmp/gcit-123/cities/x/.gc/runtime/packs/dolt/dolt-config.yaml",
+		"/tmp/gc-int-env-123/.gc/runtime/packs/dolt/dolt-config.yaml",
+	}
+	for _, p := range cases {
+		if !isTestConfigPath(p, "/home/u", "") {
+			t.Errorf("isTestConfigPath(%q) = false, want true", p)
+		}
+	}
+}
+
 func TestIsTestConfigPath_NotTest(t *testing.T) {
 	cases := []string{
 		"/tmp/be-s9d-bench-dolt/config.yaml", // benchmark
@@ -119,6 +131,27 @@ func TestClassifyDoltProcess_OrphanByTestPath(t *testing.T) {
 	}
 }
 
+func TestClassifyDoltProcess_ReapsIntegrationTempRoots(t *testing.T) {
+	cases := []string{
+		"/tmp/gcit-123/cities/x/.gc/runtime/packs/dolt/dolt-config.yaml",
+		"/tmp/gc-int-env-123/.gc/runtime/packs/dolt/dolt-config.yaml",
+	}
+	for _, cfg := range cases {
+		p := DoltProcInfo{
+			PID:   2224,
+			Argv:  []string{"dolt", "sql-server", "--config", cfg},
+			Ports: []int{},
+		}
+		got := classifyDoltProcess(p, nil, "/home/u", "", nil)
+		if got.Action != "reap" {
+			t.Errorf("classifyDoltProcess(%q).Action = %q, want reap", cfg, got.Action)
+		}
+		if got.ConfigPath != cfg {
+			t.Errorf("classifyDoltProcess(%q).ConfigPath = %q, want %q", cfg, got.ConfigPath, cfg)
+		}
+	}
+}
+
 func TestClassifyDoltProcess_ProtectsActiveTestRoot(t *testing.T) {
 	p := DoltProcInfo{
 		PID:   2223,
@@ -153,6 +186,22 @@ func TestClassifyDoltProcess_ProtectedByPathNotOnAllowlist(t *testing.T) {
 	// Reason should echo the actual config path so operators can see it.
 	if !strings.Contains(got.Reason, "/tmp/be-s9d-bench-dolt") {
 		t.Errorf("Reason = %q, want config path echoed (architect Open Q 0)", got.Reason)
+	}
+}
+
+func TestClassifyDoltProcess_ProtectsRealManagedConfig(t *testing.T) {
+	cfg := "/home/u/projects/foo/.gc/runtime/packs/dolt/dolt-config.yaml"
+	p := DoltProcInfo{
+		PID:   3334,
+		Argv:  []string{"dolt", "sql-server", "--config", cfg},
+		Ports: []int{},
+	}
+	got := classifyDoltProcess(p, nil, "/home/u", "", nil)
+	if got.Action != "protect" {
+		t.Errorf("Action = %q, want protect", got.Action)
+	}
+	if !strings.Contains(got.Reason, "allowlist") || !strings.Contains(got.Reason, cfg) {
+		t.Errorf("Reason = %q, want allowlist reason containing config path", got.Reason)
 	}
 }
 

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -53,6 +53,7 @@ func TestGCLiveContract_BeadsAndEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	cmd := exec.CommandContext(ctx, bin, "supervisor", "run")
+	configureIntegrationSupervisorCommand(cmd)
 	cmd.Env = env
 	stderr, err := cmd.StderrPipe()
 	if err != nil {

--- a/test/integration/huma_binary_test.go
+++ b/test/integration/huma_binary_test.go
@@ -58,6 +58,7 @@ func TestHumaBinary_SupervisorBootsAndServesSpec(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	cmd := exec.CommandContext(ctx, bin, "supervisor", "run")
+	configureIntegrationSupervisorCommand(cmd)
 	cmd.Env = env
 	// Capture supervisor stderr for triage on failure.
 	stderr, err := cmd.StderrPipe()
@@ -260,6 +261,7 @@ func shortTempDir(t *testing.T) string {
 		t.Fatalf("short tmp dir: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	registerIntegrationDoltSQLServerCleanup(t, dir)
 	return dir
 }
 
@@ -327,6 +329,7 @@ func TestHumaBinary_CityCreateAsync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	cmd := exec.CommandContext(ctx, bin, "supervisor", "run")
+	configureIntegrationSupervisorCommand(cmd)
 	cmd.Env = env
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -517,6 +520,7 @@ func TestHumaBinary_CityUnregisterAsync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	cmd := exec.CommandContext(ctx, bin, "supervisor", "run")
+	configureIntegrationSupervisorCommand(cmd)
 	cmd.Env = env
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -777,6 +781,7 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	cmd := exec.CommandContext(ctx, bin, "supervisor", "run")
+	configureIntegrationSupervisorCommand(cmd)
 	cmd.Env = env
 	stderr, err := cmd.StderrPipe()
 	if err != nil {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -66,6 +66,7 @@ const (
 	integrationGCDoltCommandTimeout  = 120 * time.Second
 	integrationBDCommandTimeout      = 15 * time.Second
 	integrationSupervisorStopTimeout = 10 * time.Second
+	integrationSupervisorWaitDelay   = 10 * time.Second
 )
 
 const (
@@ -351,6 +352,98 @@ func sweepSubprocessTestProcesses() {
 		return
 	}
 
+	for pid := range killSet {
+		_ = syscall.Kill(pid, syscall.SIGTERM)
+	}
+	time.Sleep(150 * time.Millisecond)
+	for pid := range killSet {
+		if err := syscall.Kill(pid, syscall.Signal(0)); err == nil {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	}
+}
+
+func configureIntegrationSupervisorCommand(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	cmd.WaitDelay = integrationSupervisorWaitDelay
+}
+
+func registerIntegrationDoltSQLServerCleanup(t *testing.T, root string) {
+	t.Helper()
+	t.Cleanup(func() {
+		cleanupIntegrationDoltSQLServersUnderRoot(root)
+	})
+}
+
+func cleanupIntegrationDoltSQLServersUnderRoot(root string) {
+	procs := readProcessSnapshot()
+	if len(procs) == 0 {
+		return
+	}
+	terminateIntegrationPIDs(integrationDoltSQLServerKillSet(procs, root))
+}
+
+func integrationDoltSQLServerKillSet(procs map[int]procSnapshot, root string) map[int]bool {
+	killSet := make(map[int]bool)
+	for pid, info := range procs {
+		configPath := integrationDoltSQLServerConfigPath(info.cmd)
+		if configPath == "" || !pathWithinIntegrationRoot(root, configPath) {
+			continue
+		}
+		killSet[pid] = true
+	}
+	return killSet
+}
+
+func integrationDoltSQLServerConfigPath(cmd string) string {
+	fields := strings.Fields(cmd)
+	if !integrationLooksLikeDoltSQLServer(fields) {
+		return ""
+	}
+	for i, field := range fields {
+		if field == "--config" {
+			if i+1 < len(fields) {
+				return fields[i+1]
+			}
+			return ""
+		}
+		if strings.HasPrefix(field, "--config=") {
+			return strings.TrimPrefix(field, "--config=")
+		}
+	}
+	return ""
+}
+
+func integrationLooksLikeDoltSQLServer(fields []string) bool {
+	for i := 0; i+1 < len(fields); i++ {
+		if filepath.Base(fields[i]) == "dolt" && fields[i+1] == "sql-server" {
+			return true
+		}
+	}
+	return false
+}
+
+func pathWithinIntegrationRoot(root, path string) bool {
+	if root == "" || path == "" {
+		return false
+	}
+	cleanRoot := filepath.Clean(root)
+	if cleanRoot == "." || cleanRoot == string(os.PathSeparator) {
+		return false
+	}
+	cleanPath := filepath.Clean(path)
+	return cleanPath == cleanRoot || strings.HasPrefix(cleanPath, cleanRoot+string(os.PathSeparator))
+}
+
+func terminateIntegrationPIDs(killSet map[int]bool) {
+	if len(killSet) == 0 {
+		return
+	}
 	for pid := range killSet {
 		_ = syscall.Kill(pid, syscall.SIGTERM)
 	}
@@ -948,6 +1041,7 @@ func newIsolatedEnvRoot(t *testing.T, useDolt bool) (string, string, []string) {
 	t.Cleanup(func() {
 		_ = os.RemoveAll(root)
 	})
+	registerIntegrationDoltSQLServerCleanup(t, root)
 	gcHome := filepath.Join(root, "gc-home")
 	runtimeDir := filepath.Join(root, "runtime")
 	if err := os.MkdirAll(gcHome, 0o755); err != nil {
@@ -1202,7 +1296,9 @@ func startIsolatedSupervisor(t *testing.T, env []string, gcHome string) {
 		t.Fatalf("creating isolated supervisor log: %v", err)
 	}
 
-	cmd := exec.Command(gcBinary, "supervisor", "run")
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, gcBinary, "supervisor", "run")
+	configureIntegrationSupervisorCommand(cmd)
 	cmd.Dir = gcHome
 	cmd.Env = env
 	cmd.Stdout = logFile
@@ -1225,14 +1321,8 @@ func startIsolatedSupervisor(t *testing.T, env []string, gcHome string) {
 				// --wait so runCommand blocks until the supervisor fully
 				// shut down, aligning with the cmd.Wait() synchronization below.
 				_, _ = runCommand("", env, 15*time.Second, gcBinary, "supervisor", "stop", "--wait")
-				select {
-				case <-done:
-				case <-time.After(10 * time.Second):
-					if cmd.Process != nil {
-						_ = cmd.Process.Kill()
-					}
-					<-done
-				}
+				cancel()
+				waitForIntegrationSupervisorDone(cmd, done, integrationSupervisorWaitDelay)
 				_ = logFile.Close()
 			})
 			return
@@ -1250,9 +1340,22 @@ func startIsolatedSupervisor(t *testing.T, env []string, gcHome string) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
+	cancel()
+	waitForIntegrationSupervisorDone(cmd, done, integrationSupervisorWaitDelay)
 	_ = logFile.Close()
 	logData, _ := os.ReadFile(logPath)
 	t.Fatalf("isolated supervisor did not become ready:\n%s", string(logData))
+}
+
+func waitForIntegrationSupervisorDone(cmd *exec.Cmd, done <-chan error, timeout time.Duration) {
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		<-done
+	}
 }
 
 func restartIsolatedSupervisor(t *testing.T, env []string) {
@@ -1749,6 +1852,41 @@ func TestSubprocessTestKillSetIncludesRootsDescendantsAndLeaves(t *testing.T) {
 	}
 	if got[40] {
 		t.Fatalf("kill set unexpectedly included unrelated pid 40: %#v", got)
+	}
+}
+
+func TestConfigureIntegrationSupervisorCommandUsesGracefulCancel(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "gc", "supervisor", "run")
+	configureIntegrationSupervisorCommand(cmd)
+
+	if cmd.Cancel == nil {
+		t.Fatal("supervisor command Cancel is nil, want SIGTERM cancel")
+	}
+	if cmd.WaitDelay != 10*time.Second {
+		t.Fatalf("supervisor command WaitDelay = %s, want 10s", cmd.WaitDelay)
+	}
+}
+
+func TestIntegrationDoltSQLServerKillSetMatchesOnlyRootedConfigs(t *testing.T) {
+	root := "/tmp/gcit-123"
+	procs := map[int]procSnapshot{
+		10: {pid: 10, ppid: 1, cmd: "dolt sql-server --config /tmp/gcit-123/cities/x/.gc/runtime/packs/dolt/dolt-config.yaml"},
+		11: {pid: 11, ppid: 1, cmd: "dolt sql-server --config=/tmp/gcit-123/cities/y/.gc/runtime/packs/dolt/dolt-config.yaml"},
+		12: {pid: 12, ppid: 1, cmd: "dolt sql-server --config /tmp/gcit-1234/cities/z/.gc/runtime/packs/dolt/dolt-config.yaml"},
+		13: {pid: 13, ppid: 1, cmd: "dolt sql-server --config /home/u/projects/foo/.gc/runtime/packs/dolt/dolt-config.yaml"},
+		14: {pid: 14, ppid: 1, cmd: "dolt sql --config /tmp/gcit-123/cities/x/.gc/runtime/packs/dolt/dolt-config.yaml"},
+	}
+
+	got := integrationDoltSQLServerKillSet(procs, root)
+	for _, pid := range []int{10, 11} {
+		if !got[pid] {
+			t.Fatalf("kill set missing pid %d: %#v", pid, got)
+		}
+	}
+	for _, pid := range []int{12, 13, 14} {
+		if got[pid] {
+			t.Fatalf("kill set unexpectedly included pid %d: %#v", pid, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- extend the dolt cleanup allowlist to cover integration temp roots (`gcit-`, `gc-int-env-`) while preserving protection for real managed configs
- make integration supervisor CommandContext cancellation send SIGTERM with a bounded WaitDelay
- add root-scoped cleanup for leaked `dolt sql-server --config <test-root>/...` processes before integration temp roots are removed

## Verification
- go test ./cmd/gc -run 'TestIsTestConfigPath|TestClassifyDoltProcess|TestPlanReap|TestRunDoltCleanup' -count=1\n- go test -tags integration ./test/integration/ -run 'TestConfigureIntegrationSupervisorCommandUsesGracefulCancel|TestIntegrationDoltSQLServerKillSetMatchesOnlyRootedConfigs' -count=1\n- go test -tags integration ./test/integration/ -run 'TestHumaBinary_SupervisorBootsAndServesSpec|TestGastown_MultiRig_ConfigLoads' -count=1\n- go vet ./...\n- make test-fast-parallel\n- .githooks/pre-commit\n\nFixes ga-22q7p.