### PR TITLE
fix(reaper): split-target gate skips legacy-schema DBs silently

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -1768,12 +1768,14 @@ exit 0
 		t.Fatalf("reaper ran dependency-aware queries against legacy dependency schema:\n%s", log)
 	}
 
+	// A silently-skipped DB may make no gc calls at all, so a missing
+	// gc log is a valid no-escalation outcome.
 	gcData, err := os.ReadFile(gcLog)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
-	if !strings.Contains(string(gcData), "dependencies table lacks split target columns") {
-		t.Fatalf("reaper did not surface legacy dependency schema anomaly:\n%s", gcData)
+	if strings.Contains(string(gcData), "dependencies table lacks split target columns") {
+		t.Errorf("reaper escalated the legacy dependency schema as an anomaly; the split-target gate must skip silently:\n%s", gcData)
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -330,7 +330,9 @@ while IFS= read -r DB; do
         continue
     fi
     if ! has_split_dependency_target_columns "$DB"; then
-        record_anomaly "$DB" "dependencies table lacks split target columns; dependency-aware reaper queries skipped"
+        # Legacy dependency schema (pre-#2399). Skip silently like the
+        # has_wisps_table gate above; the only fix is the schema migration,
+        # which the reaper cannot perform. See gastownhall/gascity#2456.
         continue
     fi
 


### PR DESCRIPTION
## Summary

Fixes #2456.

- `reaper.sh`'s `has_split_dependency_target_columns` gate called `record_anomaly`
  for every city DB whose `dependencies` table predates migration #2399 (lacking
  the `depends_on_issue_id` / `depends_on_wisp_id` split-target columns). That
  escalates a `[MEDIUM]` "Reaper anomalies detected" mail to the mayor on every
  reaper run — ~48 body-identical mails/day per un-migrated DB, indefinitely.
- The only resolution is the schema migration, which the reaper itself cannot
  perform — so the escalation has no resolution path and is pure mail noise.
- This drops the `record_anomaly` call and skips silently, mirroring the
  `has_wisps_table` gate immediately above it (added in #1819 for #1816), which
  already handles the same operator condition that way. The `continue` is kept,
  so dependency-aware queries are still correctly skipped on a legacy schema.

## Testing

- [ ] `make check` — see note below.
- [ ] `make check-docs`
- [ ] `make test-integration`

`go test ./examples/gastown/ -run TestReaper` passes (the package this change
lives in).

`make check` was **not** completed on the contributor host: it fails only on 3
unrelated `cmd/gc/dolt_standalone_conflict_test.go` tests whose fake-dolt-server
fixtures are incompatible with a host already running a live Gas City. Those
tests are in a different package from this change, fail on unmodified `cmd/gc`,
and pass in this repo's CI — a local-environment artifact, not a regression
from this change.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes