### PR TITLE
fix(api): restore read parity after PR 1149

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -381,7 +381,7 @@ func renderMailCheckFromAPI(cr api.CachedRead[[]mail.Message], recipient string,
 	messages := cr.Body
 	if inject {
 		if len(messages) > 0 {
-			_ = writeProviderHookContext(stdout, hookFormat, formatInjectOutput(messages))
+			_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatInjectOutput(messages))
 		}
 		return 0
 	}

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3581,6 +3581,34 @@ func TestRouteMailCheck_StaleBannerOver30s(t *testing.T) {
 	}
 }
 
+func TestRenderMailCheckFromAPIInjectCodexUsesUserPromptSubmit(t *testing.T) {
+	cr := api.CachedRead[[]mail.Message]{
+		Body: []mail.Message{{
+			ID:        "msg-1",
+			From:      "human",
+			To:        "mayor",
+			Body:      "review this",
+			CreatedAt: time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+		}},
+	}
+
+	var stdout bytes.Buffer
+	if code := renderMailCheckFromAPI(cr, "mayor", true, hookOutputFormatCodex, &stdout); code != 0 {
+		t.Fatalf("renderMailCheckFromAPI = %d, want 0", code)
+	}
+	var out struct {
+		HookSpecificOutput struct {
+			HookEventName string `json:"hookEventName"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode codex hook JSON: %v\n%s", err, stdout.String())
+	}
+	if out.HookSpecificOutput.HookEventName != "UserPromptSubmit" {
+		t.Fatalf("hookEventName = %q, want UserPromptSubmit; output=%s", out.HookSpecificOutput.HookEventName, stdout.String())
+	}
+}
+
 func TestRouteMailPeek_StaleBannerOver30s(t *testing.T) {
 	t.Setenv("GC_DEBUG", "0")
 	cityPath := writeMailTestCity(t)

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -899,11 +898,19 @@ func renderRigListFromAPI(fs fsys.FS, cityPath string, cr api.CachedRead[[]api.R
 	}
 	hqPrefix := config.EffectiveHQPrefix(cfg)
 	cityName := cfg.EffectiveCityName()
+	resolveRigPaths(cityPath, cfg.Rigs)
+	rigsByName := make(map[string]config.Rig, len(cfg.Rigs))
+	for i := range cfg.Rigs {
+		rigsByName[cfg.Rigs[i].Name] = cfg.Rigs[i]
+	}
 
 	if jsonOutput {
-		result := rigListJSONWithCache{
-			CityPath: cityPath,
-			CityName: cityName,
+		cacheAgeS := cr.AgeSeconds
+		result := RigListJSON{
+			SchemaVersion: "1",
+			CityPath:      cityPath,
+			CityName:      cityName,
+			CacheAgeS:     &cacheAgeS,
 			Rigs: []RigListItem{{
 				Name:   cityName,
 				Path:   cityPath,
@@ -911,20 +918,39 @@ func renderRigListFromAPI(fs fsys.FS, cityPath string, cr api.CachedRead[[]api.R
 				HQ:     true,
 				Beads:  rigBeadsStatus(fs, cityPath),
 			}},
-			CacheAgeS: cr.AgeSeconds,
 		}
 		for _, rig := range cr.Body {
+			path := rig.Path
+			prefix := rig.Prefix
+			defaultBranch := rig.DefaultBranch
+			defaultSlingTarget := ""
+			if cfgRig, ok := rigsByName[rig.Name]; ok {
+				path = cfgRig.Path
+				prefix = cfgRig.EffectivePrefix()
+				defaultBranch = cfgRig.EffectiveDefaultBranch()
+				defaultSlingTarget = cfgRig.DefaultSlingTarget
+			}
 			result.Rigs = append(result.Rigs, RigListItem{
-				Name:      rig.Name,
-				Path:      rig.Path,
-				Prefix:    rig.Prefix,
-				Suspended: rig.Suspended,
-				Beads:     rigBeadsStatus(fs, rig.Path),
+				Name:               rig.Name,
+				Path:               path,
+				Prefix:             prefix,
+				DefaultBranch:      defaultBranch,
+				Suspended:          rig.Suspended,
+				Running:            rig.RunningCount > 0,
+				DefaultSlingTarget: defaultSlingTarget,
+				Beads:              rigBeadsStatus(fs, path),
 			})
 		}
-		enc := json.NewEncoder(stdout)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(result); err != nil {
+		result.Summary.Total = len(result.Rigs)
+		for _, rig := range result.Rigs {
+			if rig.Suspended {
+				result.Summary.Suspended++
+			}
+			if rig.Running {
+				result.Summary.Running++
+			}
+		}
+		if err := writeCLIJSONLine(stdout, result); err != nil {
 			fmt.Fprintf(stderr, "gc rig list: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
@@ -962,16 +988,6 @@ func renderRigListFromAPI(fs fsys.FS, cityPath string, cr api.CachedRead[[]api.R
 	return 0
 }
 
-// rigListJSONWithCache is the --json output for `gc rig list` on the API
-// path. Structurally identical to RigListJSON but adds the _cache_age_s
-// envelope field documented in docs/rules/gc-read-path-routes-through-api.md.
-type rigListJSONWithCache struct {
-	CityPath  string        `json:"city_path"`
-	CityName  string        `json:"city_name"`
-	Rigs      []RigListItem `json:"rigs"`
-	CacheAgeS float64       `json:"_cache_age_s"`
-}
-
 // cacheAgeBannerThresholdSeconds is the cache-age cutoff above which human
 // output appends the "reconciler may be lagging" banner. Matches the
 // enabler contract D5 documented in the ga-h6w plan.
@@ -984,6 +1000,7 @@ type RigListJSON struct {
 	CityName      string         `json:"city_name"`
 	Rigs          []RigListItem  `json:"rigs"`
 	Summary       RigListSummary `json:"summary"`
+	CacheAgeS     *float64       `json:"_cache_age_s,omitempty"`
 }
 
 // RigListItem is one rig entry in the JSON output.

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -912,11 +912,12 @@ func renderRigListFromAPI(fs fsys.FS, cityPath string, cr api.CachedRead[[]api.R
 			CityName:      cityName,
 			CacheAgeS:     &cacheAgeS,
 			Rigs: []RigListItem{{
-				Name:   cityName,
-				Path:   cityPath,
-				Prefix: hqPrefix,
-				HQ:     true,
-				Beads:  rigBeadsStatus(fs, cityPath),
+				Name:    cityName,
+				Path:    cityPath,
+				Prefix:  hqPrefix,
+				HQ:      true,
+				Running: true,
+				Beads:   rigBeadsStatus(fs, cityPath),
 			}},
 		}
 		for _, rig := range cr.Body {

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -970,15 +970,26 @@ func renderRigListFromAPI(fs fsys.FS, cityPath string, cr api.CachedRead[[]api.R
 	w(fmt.Sprintf("    Beads:  %s", hqBeads))
 
 	for _, rig := range cr.Body {
-		beads := rigBeadsStatus(fs, rig.Path)
+		path := rig.Path
+		prefix := rig.Prefix
+		defaultBranch := rig.DefaultBranch
+		if cfgRig, ok := rigsByName[rig.Name]; ok {
+			path = cfgRig.Path
+			prefix = cfgRig.EffectivePrefix()
+			defaultBranch = cfgRig.EffectiveDefaultBranch()
+		}
+		beads := rigBeadsStatus(fs, path)
 		header := rig.Name
 		if rig.Suspended {
 			header += " (suspended)"
 		}
 		w("")
 		w(fmt.Sprintf("  %s:", header))
-		w(fmt.Sprintf("    Path:   %s", rig.Path))
-		w(fmt.Sprintf("    Prefix: %s", rig.Prefix))
+		w(fmt.Sprintf("    Path:   %s", path))
+		w(fmt.Sprintf("    Prefix: %s", prefix))
+		if defaultBranch != "" {
+			w(fmt.Sprintf("    Default branch: %s", defaultBranch))
+		}
 		w(fmt.Sprintf("    Beads:  %s", beads))
 	}
 

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -3012,6 +3012,78 @@ func TestRouteRigList_APIJSONIncludesCacheAge(t *testing.T) {
 	}
 }
 
+func TestRouteRigList_APIJSONPreservesFallbackContract(t *testing.T) {
+	t.Setenv("GC_DEBUG", "0")
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+
+[[rigs]]
+name = "frontend"
+path = "/abs/frontend"
+prefix = "fe"
+default_branch = "trunk"
+default_sling_target = "frontend/worker"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		prefix := "fe"
+		w.Header().Set("X-GC-Cache-Age-S", "3")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"name": "frontend", "path": "/abs/frontend", "prefix": prefix, "suspended": false, "agent_count": 1, "running_count": 1},
+			},
+			"total": 1,
+		})
+	}))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	if code := routeRigList(cityPath, c, "", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal stdout: %v\n%s", err, stdout.String())
+	}
+	if got := out["schema_version"]; got != "1" {
+		t.Fatalf("schema_version = %#v, want 1; output=%s", got, stdout.String())
+	}
+	if _, ok := out["summary"].(map[string]any); !ok {
+		t.Fatalf("summary missing or wrong type: %#v; output=%s", out["summary"], stdout.String())
+	}
+	rigs, ok := out["rigs"].([]any)
+	if !ok || len(rigs) != 2 {
+		t.Fatalf("rigs = %#v, want HQ + frontend", out["rigs"])
+	}
+	frontend, ok := rigs[1].(map[string]any)
+	if !ok {
+		t.Fatalf("frontend row = %#v", rigs[1])
+	}
+	if got := frontend["default_branch"]; got != "trunk" {
+		t.Fatalf("default_branch = %#v, want trunk; row=%#v", got, frontend)
+	}
+	if got := frontend["default_sling_target"]; got != "frontend/worker" {
+		t.Fatalf("default_sling_target = %#v, want frontend/worker; row=%#v", got, frontend)
+	}
+	if got := frontend["running"]; got != true {
+		t.Fatalf("running = %#v, want true; row=%#v", got, frontend)
+	}
+	if _, ok := out["_cache_age_s"]; !ok {
+		t.Fatalf("_cache_age_s missing; output=%s", stdout.String())
+	}
+}
+
 func TestRouteRigList_StaleBannerOver30s(t *testing.T) {
 	// Human output must append a staleness banner when the server reports
 	// a cache age > 30 s.

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -3066,6 +3066,13 @@ default_sling_target = "frontend/worker"
 	if !ok || len(rigs) != 2 {
 		t.Fatalf("rigs = %#v, want HQ + frontend", out["rigs"])
 	}
+	hq, ok := rigs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("HQ row = %#v", rigs[0])
+	}
+	if got := hq["running"]; got != true {
+		t.Fatalf("HQ running = %#v, want true; row=%#v", got, hq)
+	}
 	frontend, ok := rigs[1].(map[string]any)
 	if !ok {
 		t.Fatalf("frontend row = %#v", rigs[1])

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -3089,6 +3089,7 @@ default_sling_target = "frontend/worker"
 	if _, ok := out["_cache_age_s"]; !ok {
 		t.Fatalf("_cache_age_s missing; output=%s", stdout.String())
 	}
+	validateJSONResultSchema(t, []string{"rig", "list"}, stdout.Bytes())
 }
 
 func TestRouteRigList_StaleBannerOver30s(t *testing.T) {

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -2964,7 +2964,7 @@ func writeRigListTestCity(t *testing.T) string {
 name = "test-city"
 
 [[agent]]
-name = "mayor"
+name = "coordinator"
 
 [[rigs]]
 name = "frontend"
@@ -3022,7 +3022,7 @@ func TestRouteRigList_APIJSONPreservesFallbackContract(t *testing.T) {
 name = "test-city"
 
 [[agent]]
-name = "mayor"
+name = "coordinator"
 
 [[rigs]]
 name = "frontend"
@@ -3090,6 +3090,82 @@ default_sling_target = "frontend/worker"
 		t.Fatalf("_cache_age_s missing; output=%s", stdout.String())
 	}
 	validateJSONResultSchema(t, []string{"rig", "list"}, stdout.Bytes())
+}
+
+func TestRouteRigList_APIHumanPreservesFallbackContract(t *testing.T) {
+	t.Setenv("GC_DEBUG", "0")
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configRigPath := filepath.Join(t.TempDir(), "frontend-from-config")
+	if err := os.MkdirAll(filepath.Join(configRigPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configRigPath, ".beads", "metadata.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleAPIPath := filepath.Join(t.TempDir(), "frontend-from-api")
+	cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[agent]]
+name = "coordinator"
+
+[[rigs]]
+name = "frontend"
+path = %q
+prefix = "cfg"
+default_branch = "trunk"
+`, configRigPath)
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-GC-Cache-Age-S", "3")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{
+					"name":           "frontend",
+					"path":           staleAPIPath,
+					"prefix":         "api",
+					"default_branch": "api-main",
+					"suspended":      false,
+					"agent_count":    1,
+					"running_count":  1,
+				},
+			},
+			"total": 1,
+		})
+	}))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	if code := routeRigList(cityPath, c, "", false, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"Path:   " + configRigPath,
+		"Prefix: cfg",
+		"Default branch: trunk",
+		"Beads:  initialized",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("human API output missing %q:\n%s", want, output)
+		}
+	}
+	for _, unwanted := range []string{
+		staleAPIPath,
+		"Prefix: api",
+		"Default branch: api-main",
+	} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("human API output used stale API row value %q:\n%s", unwanted, output)
+		}
+	}
 }
 
 func TestRouteRigList_StaleBannerOver30s(t *testing.T) {

--- a/cmd/gc/store_health.go
+++ b/cmd/gc/store_health.go
@@ -50,7 +50,7 @@ func liveRowCount(store beads.Store) int {
 	if store == nil {
 		return 0
 	}
-	list, err := store.List(beads.ListQuery{AllowScan: true})
+	list, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
 	if err != nil {
 		return 0
 	}

--- a/cmd/gc/store_health_test.go
+++ b/cmd/gc/store_health_test.go
@@ -126,6 +126,25 @@ func TestLiveRowCountCountsBeads(t *testing.T) {
 	}
 }
 
+func TestLiveRowCountIncludesClosedBeads(t *testing.T) {
+	store := beads.NewMemStore()
+	open, err := store.Create(beads.Bead{Title: "open"})
+	if err != nil {
+		t.Fatalf("Create open: %v", err)
+	}
+	closed, err := store.Create(beads.Bead{Title: "closed"})
+	if err != nil {
+		t.Fatalf("Create closed: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := liveRowCount(store); got != 2 {
+		t.Fatalf("liveRowCount = %d, want 2 including closed bead %s and open bead %s", got, closed.ID, open.ID)
+	}
+}
+
 func TestCollectStoreHealthReadsEvents(t *testing.T) {
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{Title: "x"}); err != nil {

--- a/internal/api/decode_rigs.go
+++ b/internal/api/decode_rigs.go
@@ -3,25 +3,31 @@ package api
 import "github.com/gastownhall/gascity/internal/api/genclient"
 
 // RigView is the CLI-facing shape for `gc rig list` rows. It mirrors the
-// subset of fields the CLI formatter reads (name, path, prefix, suspended)
-// so cmd/gc/ never imports genclient directly.
+// subset of fields the CLI formatter reads so cmd/gc/ never imports genclient
+// directly.
 type RigView struct {
-	Name      string
-	Path      string
-	Prefix    string
-	Suspended bool
+	Name          string
+	Path          string
+	Prefix        string
+	DefaultBranch string
+	Suspended     bool
+	RunningCount  int
 }
 
 // rigViewFromGen translates one genclient.RigResponse into a RigView.
-// Optional pointer fields (Prefix) are dereferenced safely.
+// Optional pointer fields are dereferenced safely.
 func rigViewFromGen(g genclient.RigResponse) RigView {
 	out := RigView{
-		Name:      g.Name,
-		Path:      g.Path,
-		Suspended: g.Suspended,
+		Name:         g.Name,
+		Path:         g.Path,
+		Suspended:    g.Suspended,
+		RunningCount: int(g.RunningCount),
 	}
 	if g.Prefix != nil {
 		out.Prefix = *g.Prefix
+	}
+	if g.DefaultBranch != nil {
+		out.DefaultBranch = *g.DefaultBranch
 	}
 	return out
 }

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -130,8 +130,11 @@ func (s *Server) resolveMailQueryRecipientsWithContext(ctx context.Context, reci
 		return []string{recipient}
 	}
 	if spec, ok, err := s.findNamedSessionSpecForTarget(store, recipient); err == nil && ok {
-		if recipients, listErr := s.mailRecipientsForNamedSession(store, spec); listErr == nil && len(recipients) > 0 {
-			return append(recipients, recipient)
+		if recipients, listErr := s.mailRecipientsForNamedSession(store, spec); listErr == nil {
+			recipients = uniqueNonEmptyMailRecipients(append(recipients, recipient))
+			if len(recipients) > 0 {
+				return recipients
+			}
 		}
 	}
 	resolved, err := s.resolveSessionTargetIDWithContext(ctx, store, recipient, apiSessionResolveOptions{})
@@ -174,7 +177,10 @@ func (s *Server) mailRecipientsForNamedSession(store beads.Store, spec apiNamedS
 		seen[b.ID] = true
 		recipients = append(recipients, apiSessionMailboxAddresses(b)...)
 	}
-	recipients = uniqueMailRecipients(recipients)
+	if len(recipients) == 0 {
+		recipients = append(recipients, identity)
+	}
+	recipients = uniqueNonEmptyMailRecipients(recipients)
 	sort.Strings(recipients)
 	return recipients, nil
 }
@@ -383,6 +389,20 @@ func uniqueMailRecipients(recipients []string) []string {
 	}
 	if len(unique) == 0 {
 		return []string{""}
+	}
+	return unique
+}
+
+func uniqueNonEmptyMailRecipients(recipients []string) []string {
+	seen := make(map[string]bool, len(recipients))
+	unique := recipients[:0]
+	for _, recipient := range recipients {
+		recipient = strings.TrimSpace(recipient)
+		if recipient == "" || seen[recipient] {
+			continue
+		}
+		seen[recipient] = true
+		unique = append(unique, recipient)
 	}
 	return unique
 }

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -138,6 +138,11 @@ func (s *Server) resolveMailQueryRecipientsWithContext(ctx context.Context, reci
 	if err != nil {
 		return []string{recipient}
 	}
+	if bead, getErr := store.Get(resolved); getErr == nil {
+		if recipients := apiSessionMailboxAddresses(bead); len(recipients) > 0 {
+			return recipients
+		}
+	}
 	return []string{resolved}
 }
 
@@ -167,8 +172,9 @@ func (s *Server) mailRecipientsForNamedSession(store beads.Store, spec apiNamedS
 			continue
 		}
 		seen[b.ID] = true
-		recipients = append(recipients, b.ID)
+		recipients = append(recipients, apiSessionMailboxAddresses(b)...)
 	}
+	recipients = uniqueMailRecipients(recipients)
 	sort.Strings(recipients)
 	return recipients, nil
 }

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -163,7 +163,9 @@ func (s *Server) mailRecipientsForNamedSession(store beads.Store, spec apiNamedS
 	if err != nil {
 		return nil, fmt.Errorf("listing named session mail recipients: %w", err)
 	}
-	recipients := make([]string, 0)
+	// The configured identity is a durable mailbox address even after a
+	// materialized session bead adds aliases, IDs, or runtime session names.
+	recipients := []string{identity}
 	seen := make(map[string]bool)
 	for _, b := range candidates {
 		if !session.IsSessionBeadOrRepairable(b) ||
@@ -176,9 +178,6 @@ func (s *Server) mailRecipientsForNamedSession(store beads.Store, spec apiNamedS
 		}
 		seen[b.ID] = true
 		recipients = append(recipients, apiSessionMailboxAddresses(b)...)
-	}
-	if len(recipients) == 0 {
-		recipients = append(recipients, identity)
 	}
 	recipients = uniqueNonEmptyMailRecipients(recipients)
 	sort.Strings(recipients)

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -242,9 +242,7 @@ func apiSessionMailboxAddresses(b beads.Bead) []string {
 	for _, alias := range session.AliasHistory(b.Metadata) {
 		add(alias)
 	}
-	if len(addresses) == 0 {
-		add(strings.TrimSpace(b.Metadata["session_name"]))
-	}
+	add(b.Metadata["session_name"])
 	return addresses
 }
 

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +14,77 @@ import (
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/session"
 )
+
+type exactRecipientMailProvider struct {
+	messages map[string][]mail.Message
+}
+
+func (p *exactRecipientMailProvider) Send(from, to, subject, body string) (mail.Message, error) {
+	return mail.Message{}, fmt.Errorf("unexpected Send(%q, %q, %q, %q)", from, to, subject, body)
+}
+
+func (p *exactRecipientMailProvider) Inbox(recipient string) ([]mail.Message, error) {
+	return p.unread(recipient), nil
+}
+
+func (p *exactRecipientMailProvider) Get(string) (mail.Message, error) {
+	return mail.Message{}, mail.ErrNotFound
+}
+
+func (p *exactRecipientMailProvider) Read(string) (mail.Message, error) {
+	return mail.Message{}, mail.ErrNotFound
+}
+
+func (p *exactRecipientMailProvider) MarkRead(string) error { return nil }
+
+func (p *exactRecipientMailProvider) MarkUnread(string) error { return nil }
+
+func (p *exactRecipientMailProvider) Archive(string) error { return nil }
+
+func (p *exactRecipientMailProvider) ArchiveMany(ids []string) ([]mail.ArchiveResult, error) {
+	return make([]mail.ArchiveResult, len(ids)), nil
+}
+
+func (p *exactRecipientMailProvider) Delete(string) error { return nil }
+
+func (p *exactRecipientMailProvider) DeleteMany(ids []string) ([]mail.ArchiveResult, error) {
+	return make([]mail.ArchiveResult, len(ids)), nil
+}
+
+func (p *exactRecipientMailProvider) Check(recipient string) ([]mail.Message, error) {
+	return p.unread(recipient), nil
+}
+
+func (p *exactRecipientMailProvider) Reply(string, string, string, string) (mail.Message, error) {
+	return mail.Message{}, mail.ErrNotFound
+}
+
+func (p *exactRecipientMailProvider) Thread(string) ([]mail.Message, error) { return nil, nil }
+
+func (p *exactRecipientMailProvider) All(recipient string) ([]mail.Message, error) {
+	return append([]mail.Message(nil), p.messages[recipient]...), nil
+}
+
+func (p *exactRecipientMailProvider) Count(recipient string) (int, int, error) {
+	msgs := p.messages[recipient]
+	var unread int
+	for _, msg := range msgs {
+		if !msg.Read {
+			unread++
+		}
+	}
+	return len(msgs), unread, nil
+}
+
+func (p *exactRecipientMailProvider) unread(recipient string) []mail.Message {
+	var out []mail.Message
+	for _, msg := range p.messages[recipient] {
+		if !msg.Read {
+			out = append(out, msg)
+		}
+	}
+	return out
+}
 
 func TestMailLifecycle(t *testing.T) {
 	state := newFakeState(t)
@@ -201,6 +273,122 @@ func TestMailCount(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
 	if resp["unread"] != 2 {
 		t.Errorf("unread = %d, want 2", resp["unread"])
+	}
+}
+
+func TestMailInboxAndCountResolveSessionMailboxAddresses(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = state.stores["myrig"]
+	sessionBead, err := state.cityBeadStore.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "sky",
+			"alias_history": "mayor,witness",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	for _, msg := range []struct {
+		to   string
+		body string
+	}{
+		{to: "sky", body: "current alias"},
+		{to: sessionBead.ID, body: "session id"},
+		{to: "mayor", body: "historical alias"},
+	} {
+		if _, err := state.cityMailProv.Send("human", msg.to, "", msg.body); err != nil {
+			t.Fatalf("Send(%q): %v", msg.to, err)
+		}
+	}
+	h := newTestCityHandler(t, state)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/mail?agent=sky"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("inbox status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var inbox struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&inbox); err != nil {
+		t.Fatalf("decode inbox: %v", err)
+	}
+	if inbox.Total != 3 {
+		t.Fatalf("inbox Total = %d, want 3; items=%#v", inbox.Total, inbox.Items)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/mail/count?agent=sky"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("count status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var count struct {
+		Total  int `json:"total"`
+		Unread int `json:"unread"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&count); err != nil {
+		t.Fatalf("decode count: %v", err)
+	}
+	if count.Total != 3 || count.Unread != 3 {
+		t.Fatalf("count = (%d total, %d unread), want (3 total, 3 unread)", count.Total, count.Unread)
+	}
+}
+
+func TestMailAPIQueriesAllResolvedSessionMailboxAddresses(t *testing.T) {
+	state := newFakeState(t)
+	state.cityBeadStore = state.stores["myrig"]
+	sessionBead, err := state.cityBeadStore.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "sky",
+			"alias_history": "mayor,witness",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	state.cityMailProv = &exactRecipientMailProvider{messages: map[string][]mail.Message{
+		"sky":            {{ID: "msg-current", From: "human", To: "sky", Body: "current alias"}},
+		sessionBead.ID:   {{ID: "msg-id", From: "human", To: sessionBead.ID, Body: "session id"}},
+		"mayor":          {{ID: "msg-history", From: "human", To: "mayor", Body: "historical alias"}},
+		"unrelated-user": {{ID: "msg-other", From: "human", To: "unrelated-user", Body: "other"}},
+	}}
+	h := newTestCityHandler(t, state)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/mail?agent=sky"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("inbox status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var inbox struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&inbox); err != nil {
+		t.Fatalf("decode inbox: %v", err)
+	}
+	if inbox.Total != 3 {
+		t.Fatalf("inbox Total = %d, want 3 resolved mailbox addresses; items=%#v", inbox.Total, inbox.Items)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/mail/count?agent=sky"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("count status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var count struct {
+		Total  int `json:"total"`
+		Unread int `json:"unread"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&count); err != nil {
+		t.Fatalf("decode count: %v", err)
+	}
+	if count.Total != 3 || count.Unread != 3 {
+		t.Fatalf("count = (%d total, %d unread), want (3 total, 3 unread)", count.Total, count.Unread)
 	}
 }
 

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -346,6 +346,7 @@ func TestMailAPIQueriesAllResolvedSessionMailboxAddresses(t *testing.T) {
 		Metadata: map[string]string{
 			"alias":         "sky",
 			"alias_history": "mayor,witness",
+			"session_name":  "runtime-sky",
 		},
 	})
 	if err != nil {
@@ -355,6 +356,7 @@ func TestMailAPIQueriesAllResolvedSessionMailboxAddresses(t *testing.T) {
 		"sky":            {{ID: "msg-current", From: "human", To: "sky", Body: "current alias"}},
 		sessionBead.ID:   {{ID: "msg-id", From: "human", To: sessionBead.ID, Body: "session id"}},
 		"mayor":          {{ID: "msg-history", From: "human", To: "mayor", Body: "historical alias"}},
+		"runtime-sky":    {{ID: "msg-runtime", From: "human", To: "runtime-sky", Body: "runtime session name"}},
 		"unrelated-user": {{ID: "msg-other", From: "human", To: "unrelated-user", Body: "other"}},
 	}}
 	h := newTestCityHandler(t, state)
@@ -371,8 +373,8 @@ func TestMailAPIQueriesAllResolvedSessionMailboxAddresses(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&inbox); err != nil {
 		t.Fatalf("decode inbox: %v", err)
 	}
-	if inbox.Total != 3 {
-		t.Fatalf("inbox Total = %d, want 3 resolved mailbox addresses; items=%#v", inbox.Total, inbox.Items)
+	if inbox.Total != 4 {
+		t.Fatalf("inbox Total = %d, want 4 resolved mailbox addresses; items=%#v", inbox.Total, inbox.Items)
 	}
 
 	rec = httptest.NewRecorder()
@@ -387,8 +389,8 @@ func TestMailAPIQueriesAllResolvedSessionMailboxAddresses(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&count); err != nil {
 		t.Fatalf("decode count: %v", err)
 	}
-	if count.Total != 3 || count.Unread != 3 {
-		t.Fatalf("count = (%d total, %d unread), want (3 total, 3 unread)", count.Total, count.Unread)
+	if count.Total != 4 || count.Unread != 4 {
+		t.Fatalf("count = (%d total, %d unread), want (4 total, 4 unread)", count.Total, count.Unread)
 	}
 }
 

--- a/internal/api/session_model_phase0_interface_spec_test.go
+++ b/internal/api/session_model_phase0_interface_spec_test.go
@@ -337,9 +337,90 @@ func TestPhase0APIMailQuery_BareNamedSessionUsesTargetedRecipientLookup(t *testi
 	srv := New(fs)
 
 	recipients := srv.resolveMailQueryRecipientsWithContext(t.Context(), "worker")
-	want := []string{live.ID, closed.ID, "live-worker", "s-gc-test-city-worker", "s-gc-test-city-worker-old", "worker"}
+	want := []string{live.ID, closed.ID, "live-worker", "myrig/worker", "s-gc-test-city-worker", "s-gc-test-city-worker-old", "worker"}
 	if strings.Join(recipients, ",") != strings.Join(want, ",") {
 		t.Fatalf("recipients = %#v, want %#v", recipients, want)
+	}
+}
+
+func TestPhase0APIMailQuery_MaterializedNamedSessionKeepsConfiguredMailbox(t *testing.T) {
+	fs := newPhase0APINamedWorkerState(t)
+	baseStore := fs.cityBeadStore
+	for _, msg := range []struct {
+		to   string
+		body string
+	}{
+		{to: "myrig/worker", body: "configured mailbox before materialization"},
+		{to: "worker", body: "raw compatibility mailbox"},
+		{to: "unrelated", body: "must not leak"},
+	} {
+		if _, err := fs.cityMailProv.Send("human", msg.to, "test", msg.body); err != nil {
+			t.Fatalf("Send(%q): %v", msg.to, err)
+		}
+	}
+	if _, err := baseStore.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			apiNamedSessionMetadataKey: "true",
+			apiNamedSessionIdentityKey: "myrig/worker",
+			apiNamedSessionModeKey:     "always",
+			"alias":                    "live-worker",
+			"session_name":             "s-gc-test-city-worker",
+			"state":                    "asleep",
+		},
+	}); err != nil {
+		t.Fatalf("create live named session: %v", err)
+	}
+	fs.cityBeadStore = noBroadAPISessionListStore{Store: baseStore, t: t}
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(fs, "/mail?agent=worker"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("inbox status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var inbox struct {
+		Items []struct {
+			To   string `json:"to"`
+			Body string `json:"body"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&inbox); err != nil {
+		t.Fatalf("decode inbox: %v", err)
+	}
+	if inbox.Total != 2 {
+		t.Fatalf("inbox Total = %d, want 2; items=%#v", inbox.Total, inbox.Items)
+	}
+	seen := map[string]bool{}
+	for _, item := range inbox.Items {
+		if item.To == "unrelated" || item.Body == "must not leak" {
+			t.Fatalf("inbox leaked unrelated recipient message: %#v", inbox.Items)
+		}
+		seen[item.To] = true
+	}
+	for _, to := range []string{"myrig/worker", "worker"} {
+		if !seen[to] {
+			t.Fatalf("inbox missing message for %q: %#v", to, inbox.Items)
+		}
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(fs, "/mail/count?agent=worker"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("count status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var count struct {
+		Total  int `json:"total"`
+		Unread int `json:"unread"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&count); err != nil {
+		t.Fatalf("decode count: %v", err)
+	}
+	if count.Total != inbox.Total || count.Unread != inbox.Total {
+		t.Fatalf("count = (%d total, %d unread), want (%d total, %d unread)", count.Total, count.Unread, inbox.Total, inbox.Total)
 	}
 }
 

--- a/internal/api/session_model_phase0_interface_spec_test.go
+++ b/internal/api/session_model_phase0_interface_spec_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -339,6 +340,65 @@ func TestPhase0APIMailQuery_BareNamedSessionUsesTargetedRecipientLookup(t *testi
 	want := []string{live.ID, closed.ID, "live-worker", "worker"}
 	if strings.Join(recipients, ",") != strings.Join(want, ",") {
 		t.Fatalf("recipients = %#v, want %#v", recipients, want)
+	}
+}
+
+func TestPhase0APIMailQuery_UnmaterializedNamedSessionUsesConfiguredMailboxOnly(t *testing.T) {
+	fs := newPhase0APINamedWorkerState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	for _, msg := range []struct {
+		to   string
+		body string
+	}{
+		{to: "myrig/worker", body: "configured mailbox"},
+		{to: "worker", body: "raw compatibility mailbox"},
+		{to: "unrelated", body: "must not leak"},
+	} {
+		if _, err := fs.cityMailProv.Send("human", msg.to, "test", msg.body); err != nil {
+			t.Fatalf("Send(%q): %v", msg.to, err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(fs, "/mail?agent=worker"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("inbox status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var inbox struct {
+		Items []struct {
+			To   string `json:"to"`
+			Body string `json:"body"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&inbox); err != nil {
+		t.Fatalf("decode inbox: %v", err)
+	}
+	if inbox.Total != 2 {
+		t.Fatalf("inbox Total = %d, want 2; items=%#v", inbox.Total, inbox.Items)
+	}
+	for _, item := range inbox.Items {
+		if item.To == "unrelated" || item.Body == "must not leak" {
+			t.Fatalf("inbox leaked unrelated recipient message: %#v", inbox.Items)
+		}
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(fs, "/mail/count?agent=worker"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("count status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var count struct {
+		Total  int `json:"total"`
+		Unread int `json:"unread"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&count); err != nil {
+		t.Fatalf("decode count: %v", err)
+	}
+	if count.Total != inbox.Total || count.Unread != inbox.Total {
+		t.Fatalf("count = (%d total, %d unread), want (%d total, %d unread)", count.Total, count.Unread, inbox.Total, inbox.Total)
 	}
 }
 

--- a/internal/api/session_model_phase0_interface_spec_test.go
+++ b/internal/api/session_model_phase0_interface_spec_test.go
@@ -336,7 +336,7 @@ func TestPhase0APIMailQuery_BareNamedSessionUsesTargetedRecipientLookup(t *testi
 	srv := New(fs)
 
 	recipients := srv.resolveMailQueryRecipientsWithContext(t.Context(), "worker")
-	want := []string{live.ID, closed.ID, "worker"}
+	want := []string{live.ID, closed.ID, "live-worker", "worker"}
 	if strings.Join(recipients, ",") != strings.Join(want, ",") {
 		t.Fatalf("recipients = %#v, want %#v", recipients, want)
 	}

--- a/internal/api/session_model_phase0_interface_spec_test.go
+++ b/internal/api/session_model_phase0_interface_spec_test.go
@@ -337,7 +337,7 @@ func TestPhase0APIMailQuery_BareNamedSessionUsesTargetedRecipientLookup(t *testi
 	srv := New(fs)
 
 	recipients := srv.resolveMailQueryRecipientsWithContext(t.Context(), "worker")
-	want := []string{live.ID, closed.ID, "live-worker", "worker"}
+	want := []string{live.ID, closed.ID, "live-worker", "s-gc-test-city-worker", "s-gc-test-city-worker-old", "worker"}
 	if strings.Join(recipients, ",") != strings.Join(want, ",") {
 		t.Fatalf("recipients = %#v, want %#v", recipients, want)
 	}

--- a/internal/api/store_health.go
+++ b/internal/api/store_health.go
@@ -17,15 +17,24 @@ const storeHealthCacheTTL = 30 * time.Second
 // when the TTL has elapsed. Safe for concurrent callers.
 func (s *Server) cachedStoreHealth(now time.Time) *StatusStoreHealth {
 	s.storeHealthMu.Lock()
-	defer s.storeHealthMu.Unlock()
 	if s.storeHealthEntry != nil && now.Before(s.storeHealthExpires) {
-		return s.storeHealthEntry
+		entry := s.storeHealthEntry
+		s.storeHealthMu.Unlock()
+		return entry
 	}
 	compute := s.storeHealthComputer
 	if compute == nil {
 		compute = s.computeStoreHealth
 	}
+	s.storeHealthMu.Unlock()
+
 	h := compute()
+
+	s.storeHealthMu.Lock()
+	defer s.storeHealthMu.Unlock()
+	if s.storeHealthEntry != nil && now.Before(s.storeHealthExpires) {
+		return s.storeHealthEntry
+	}
 	s.storeHealthEntry = h
 	s.storeHealthExpires = now.Add(storeHealthCacheTTL)
 	return h
@@ -70,7 +79,7 @@ func countBeadStoreRows(store beads.Store) int {
 	if store == nil {
 		return 0
 	}
-	list, err := store.List(beads.ListQuery{AllowScan: true})
+	list, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
 	if err != nil {
 		return 0
 	}

--- a/internal/api/store_health_test.go
+++ b/internal/api/store_health_test.go
@@ -59,6 +59,31 @@ func TestCachedStoreHealthRefreshesAfterTTL(t *testing.T) {
 	}
 }
 
+func TestCachedStoreHealthDoesNotHoldMutexDuringRefreshCompute(t *testing.T) {
+	s := &Server{}
+	canLockDuringCompute := make(chan bool, 1)
+	s.storeHealthComputer = func() *StatusStoreHealth {
+		locked := make(chan struct{})
+		go func() {
+			s.storeHealthMu.Lock()
+			defer s.storeHealthMu.Unlock()
+			close(locked)
+		}()
+		select {
+		case <-locked:
+			canLockDuringCompute <- true
+		case <-time.After(100 * time.Millisecond):
+			canLockDuringCompute <- false
+		}
+		return &StatusStoreHealth{SizeBytes: 1}
+	}
+
+	_ = s.cachedStoreHealth(time.Unix(1_000_000, 0))
+	if !<-canLockDuringCompute {
+		t.Fatal("cachedStoreHealth held storeHealthMu while running the refresh computer")
+	}
+}
+
 func TestStatusStoreHealthFromDomainOmitsEmptyLastGC(t *testing.T) {
 	h := storehealth.Health{Path: "/c/.beads/dolt"}
 	out := statusStoreHealthFromDomain(h)
@@ -135,6 +160,24 @@ func TestComputeStoreHealthEmptyCityPath(t *testing.T) {
 func TestCountBeadStoreRowsNil(t *testing.T) {
 	if got := countBeadStoreRows(nil); got != 0 {
 		t.Fatalf("countBeadStoreRows(nil) = %d, want 0", got)
+	}
+}
+
+func TestCountBeadStoreRowsIncludesClosedBeads(t *testing.T) {
+	store := beads.NewMemStore()
+	open, err := store.Create(beads.Bead{Title: "open"})
+	if err != nil {
+		t.Fatalf("Create open: %v", err)
+	}
+	closed, err := store.Create(beads.Bead{Title: "closed"})
+	if err != nil {
+		t.Fatalf("Create closed: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := countBeadStoreRows(store); got != 2 {
+		t.Fatalf("countBeadStoreRows = %d, want 2 including closed bead %s and open bead %s", got, closed.ID, open.ID)
 	}
 }
 

--- a/schemas/rig/list/result.schema.json
+++ b/schemas/rig/list/result.schema.json
@@ -28,6 +28,10 @@
       "type": "string",
       "description": "Configured or inferred city name."
     },
+    "_cache_age_s": {
+      "type": "number",
+      "description": "Age in seconds of the supervisor read-model cache for API-routed output."
+    },
     "rigs": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Follow-up to #1149 from the routed post-merge review workflow.

Fixes the required review findings:
- restores API mail recipient lookup across session id, current alias, and alias history
- emits Codex mail injection as UserPromptSubmit on the API read path
- preserves the gc rig list --json fallback envelope and item fields while adding _cache_age_s
- counts closed beads in store-health row counters
- releases the store-health cache mutex while recomputing health

Verification:
- go test ./internal/api
- go test ./cmd/gc -run 'TestRenderMailCheckFromAPIInjectCodexUsesUserPromptSubmit|TestRouteRigList_APIJSONPreservesFallbackContract|TestLiveRowCountIncludesClosedBeads'
- make dashboard-check
- go vet ./...
- pre-commit hook fast shard suite