### PR TITLE
feat(dolt): add gc dolt restart pack command

### DIFF
--- a/examples/bd/assets/scripts/dolt-enospc.sh
+++ b/examples/bd/assets/scripts/dolt-enospc.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# recovery_should_skip_due_to_enospc returns 0 (true) when the recent Dolt
+# server log shows disk-exhaustion (ENOSPC) signatures.
+#
+# Restarting Dolt under ENOSPC does not free disk space, and the recovery cycle
+# itself amplifies the failure: every restart triggers a fresh conjoin that can
+# drop another partial nbs_table_* file in the backup remote, accelerating the
+# disk-full feedback loop. See gastownhall/gascity#2158.
+#
+# Returns 1 (false) when no ENOSPC signature is found in the recent log tail, or
+# when LOG_FILE is unset or unreadable.
+recovery_should_skip_due_to_enospc() {
+    [ -n "${LOG_FILE:-}" ] && [ -r "$LOG_FILE" ] || return 1
+    # Scan the recent log tail rather than the whole file; an old transient
+    # ENOSPC error from a since-resolved disk-pressure event should not block
+    # recovery indefinitely.
+    tail -n 1000 "$LOG_FILE" 2>/dev/null \
+        | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
+        || return 1
+    return 0
+}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2363,25 +2363,21 @@ op_probe() {
     exit 2
 }
 
-# recovery_should_skip_due_to_enospc returns 0 (true) when the recent
-# dolt server log shows disk-exhaustion (ENOSPC) signatures. Restarting
-# dolt under ENOSPC does not free disk space, and the recovery cycle
-# itself amplifies the failure: every restart triggers a fresh conjoin
-# that drops another partial nbs_table_* file in the backup remote,
-# accelerating the disk-full feedback loop. See gastownhall/gascity#2158.
-#
-# Returns 1 (false) when no ENOSPC signature is found in the recent log
-# tail, or when the log file cannot be read.
-recovery_should_skip_due_to_enospc() {
-    [ -n "$LOG_FILE" ] && [ -r "$LOG_FILE" ] || return 1
-    # Scan the recent log tail rather than the whole file; an old transient
-    # ENOSPC error from a since-resolved disk-pressure event should not
-    # block recovery indefinitely.
-    tail -n 1000 "$LOG_FILE" 2>/dev/null \
-        | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
-        || return 1
-    return 0
-}
+enospc_helper="$(CDPATH= cd -- "$(dirname "$0")" && pwd)/dolt-enospc.sh"
+if [ -r "$enospc_helper" ]; then
+    . "$enospc_helper"
+else
+    # Some focused shell harnesses execute gc-beads-bd's prelude as a single
+    # temporary file without sibling assets. Keep the production helper as the
+    # canonical copy, but preserve the same detector behavior for those harnesses.
+    recovery_should_skip_due_to_enospc() {
+        [ -n "${LOG_FILE:-}" ] && [ -r "$LOG_FILE" ] || return 1
+        tail -n 1000 "$LOG_FILE" 2>/dev/null \
+            | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
+            || return 1
+        return 0
+    }
+fi
 
 # op_recover stops the dolt server, restarts it, and verifies health.
 op_recover() {

--- a/examples/dolt/commands/restart/command.toml
+++ b/examples/dolt/commands/restart/command.toml
@@ -1,0 +1,1 @@
+description = "Stop and start the Dolt server (force restart when start would no-op)"

--- a/examples/dolt/commands/restart/run.sh
+++ b/examples/dolt/commands/restart/run.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# gc dolt restart — Stop and start the managed Dolt server.
+#
+# `gc dolt start` is idempotent and no-ops when a managed dolt server is
+# already running. restart is the operator escape hatch when the server
+# is alive but unable to make progress — for example, a wedged process
+# that keeps returning ENOSPC on writes even after disk pressure has
+# cleared (see gastownhall/gascity#2158, dolthub/dolt#11068). The
+# `gc dolt recover` command only handles the read-only failure mode;
+# this command is the deliberate forced-restart counterpart.
+#
+# Environment: GC_CITY_PATH
+set -e
+
+: "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
+PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
+. "$PACK_DIR/assets/scripts/runtime.sh"
+
+if [ ! -x "$GC_BEADS_BD_SCRIPT" ]; then
+  echo "gc dolt restart: gc-beads-bd not found" >&2
+  exit 1
+fi
+
+# Stop. Exit 2 from gc-beads-bd stop means "nothing was running" — a
+# recoverable state for restart. Any other non-zero exit is a real
+# failure (e.g., couldn't kill the managed PID); abort without calling
+# start so the operator can investigate.
+set +e
+GC_CITY_PATH="$GC_CITY_PATH" "$GC_BEADS_BD_SCRIPT" stop
+stop_rc=$?
+set -e
+case "$stop_rc" in
+  0|2) ;;
+  *) echo "gc dolt restart: stop failed (exit $stop_rc)" >&2; exit "$stop_rc" ;;
+esac
+
+GC_CITY_PATH="$GC_CITY_PATH" "$GC_BEADS_BD_SCRIPT" start

--- a/examples/dolt/commands/restart/run.sh
+++ b/examples/dolt/commands/restart/run.sh
@@ -13,12 +13,49 @@
 set -e
 
 : "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
-PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
-. "$PACK_DIR/assets/scripts/runtime.sh"
+GC_BEADS_BD_SCRIPT="${GC_BEADS_BD_SCRIPT:-$GC_CITY_PATH/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh}"
 
 if [ ! -x "$GC_BEADS_BD_SCRIPT" ]; then
   echo "gc dolt restart: gc-beads-bd not found" >&2
   exit 1
+fi
+
+case "${1:-}" in
+  "")
+    force_restart=false
+    ;;
+  --force)
+    force_restart=true
+    shift
+    ;;
+  *)
+    echo "usage: gc dolt restart [--force]" >&2
+    exit 64
+    ;;
+esac
+if [ "$#" -ne 0 ]; then
+  echo "usage: gc dolt restart [--force]" >&2
+  exit 64
+fi
+
+if [ -n "${GC_DOLT_HOST:-}" ] && [ "$GC_DOLT_HOST" != "0.0.0.0" ]; then
+  echo "gc dolt restart: not supported for remote dolt servers (set GC_DOLT_HOST=0.0.0.0 or unset to manage a local server)" >&2
+  exit 1
+fi
+
+CITY_RUNTIME_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}"
+PACK_STATE_DIR="${GC_PACK_STATE_DIR:-$CITY_RUNTIME_DIR/packs/dolt}"
+LOG_FILE="${GC_DOLT_LOG_FILE:-$PACK_STATE_DIR/dolt.log}"
+BD_SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$GC_BEADS_BD_SCRIPT")" && pwd)"
+. "$BD_SCRIPT_DIR/dolt-enospc.sh"
+
+if recovery_should_skip_due_to_enospc; then
+  if [ "$force_restart" != "true" ]; then
+    echo "gc dolt restart: recent Dolt log shows ENOSPC; refusing restart because it can amplify recovery writes" >&2
+    echo "  free disk space, then run gc dolt restart --force only if a restart is still required" >&2
+    exit 1
+  fi
+  echo "gc dolt restart: --force set; restarting despite recent ENOSPC evidence" >&2
 fi
 
 # Stop. Exit 2 from gc-beads-bd stop means "nothing was running" — a
@@ -34,4 +71,11 @@ case "$stop_rc" in
   *) echo "gc dolt restart: stop failed (exit $stop_rc)" >&2; exit "$stop_rc" ;;
 esac
 
+set +e
 GC_CITY_PATH="$GC_CITY_PATH" "$GC_BEADS_BD_SCRIPT" start
+start_rc=$?
+set -e
+if [ "$start_rc" -ne 0 ]; then
+  echo "gc dolt restart: start failed (exit $start_rc)" >&2
+  exit "$start_rc"
+fi

--- a/examples/dolt/pack.toml
+++ b/examples/dolt/pack.toml
@@ -1,7 +1,7 @@
 # Dolt — reusable Dolt database management pack.
 #
-# Provides lifecycle commands (status, start, logs, sql, list, recover, sync,
-# rollback, cleanup, health) for the Dolt SQL server backing bead storage.
+# Provides lifecycle commands (status, start, restart, logs, sql, list, recover,
+# sync, rollback, cleanup, health) for the Dolt SQL server backing bead storage.
 #
 # Dog-backed formulas and orders rely on the city's maintenance pack.
 #

--- a/examples/dolt/restart_test.go
+++ b/examples/dolt/restart_test.go
@@ -1,0 +1,129 @@
+package dolt_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const restartScript = "commands/restart/run.sh"
+
+// writeFakeBeadsBDForRestart writes a stub gc-beads-bd that records each
+// invocation's first argument and exits with the code specified for that
+// op. ops that aren't in opExitCodes exit 0.
+func writeFakeBeadsBDForRestart(t *testing.T, cityPath string, opExitCodes map[string]int) string {
+	t.Helper()
+	scriptDir := filepath.Join(cityPath, ".gc", "system", "packs", "bd", "assets", "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bd dir: %v", err)
+	}
+	logPath := filepath.Join(cityPath, "bd.log")
+	var cases strings.Builder
+	for op, code := range opExitCodes {
+		fmt.Fprintf(&cases, "  %s) exit %d ;;\n", op, code)
+	}
+	body := `#!/bin/sh
+printf '%s\n' "$1" >> "` + logPath + `"
+case "$1" in
+` + cases.String() + `  *) exit 0 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(scriptDir, "gc-beads-bd.sh"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake bd script: %v", err)
+	}
+	return logPath
+}
+
+func runRestart(t *testing.T, cityPath, root string, port int) ([]byte, error) {
+	t.Helper()
+	script := filepath.Join(root, restartScript)
+	cmd := exec.Command("sh", script)
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	return cmd.CombinedOutput()
+}
+
+func TestRestartCallsStopThenStart_HappyPath(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 0})
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err != nil {
+		t.Fatalf("gc dolt restart failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	got := strings.Join(strings.Fields(string(data)), " ")
+	if got != "stop start" {
+		t.Fatalf("expected ops in order 'stop start', got %q\noutput:\n%s", got, out)
+	}
+}
+
+func TestRestartCallsStartWhenStopReportsNothingRunning(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	// op_stop exits 2 when no managed dolt PID is found. restart must
+	// treat that as success and still invoke start.
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 2, "start": 0})
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err != nil {
+		t.Fatalf("gc dolt restart failed when stop reported nothing-running: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	got := strings.Join(strings.Fields(string(data)), " ")
+	if got != "stop start" {
+		t.Fatalf("expected ops in order 'stop start' (exit 2 on stop is recoverable), got %q\noutput:\n%s", got, out)
+	}
+}
+
+func TestRestartAbortsAndDoesNotStartWhenStopFails(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	// op_stop exit code 1 is the genuine-failure path (e.g., couldn't kill
+	// the managed PID). restart must abort without calling start so the
+	// operator can investigate.
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 1, "start": 0})
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err == nil {
+		t.Fatalf("gc dolt restart unexpectedly succeeded when stop failed:\n%s", out)
+	}
+
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	if strings.Contains(string(data), "start") {
+		t.Fatalf("restart called start after stop failed; ops log:\n%s\noutput:\n%s", data, out)
+	}
+}

--- a/examples/dolt/restart_test.go
+++ b/examples/dolt/restart_test.go
@@ -34,24 +34,43 @@ esac
 	if err := os.WriteFile(filepath.Join(scriptDir, "gc-beads-bd.sh"), []byte(body), 0o755); err != nil {
 		t.Fatalf("write fake bd script: %v", err)
 	}
+	enospcHelper := `#!/bin/sh
+recovery_should_skip_due_to_enospc() {
+  [ -n "${LOG_FILE:-}" ] && [ -r "$LOG_FILE" ] || return 1
+  tail -n 1000 "$LOG_FILE" 2>/dev/null \
+    | grep -qE 'no space left on device|copy_file_range:.*no space|ENOSPC' \
+    || return 1
+  return 0
+}
+`
+	if err := os.WriteFile(filepath.Join(scriptDir, "dolt-enospc.sh"), []byte(enospcHelper), 0o644); err != nil {
+		t.Fatalf("write fake enospc helper: %v", err)
+	}
 	return logPath
 }
 
 func runRestart(t *testing.T, cityPath, root string, port int) ([]byte, error) {
 	t.Helper()
+	return runRestartWithEnv(t, cityPath, root, []string{fmt.Sprintf("GC_DOLT_PORT=%d", port)})
+}
+
+func runRestartWithEnv(t *testing.T, cityPath, root string, extraEnv []string, args ...string) ([]byte, error) {
+	t.Helper()
 	script := filepath.Join(root, restartScript)
-	cmd := exec.Command("sh", script)
+	cmd := exec.Command("sh", append([]string{script}, args...)...)
 	cmd.Env = append(filteredEnv(
 		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
 		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_CITY_RUNTIME_DIR", "GC_PACK_STATE_DIR", "GC_DOLT_LOG_FILE",
+		"GC_BEADS_BD_SCRIPT",
 	),
 		"PATH="+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
-		fmt.Sprintf("GC_DOLT_PORT=%d", port),
 		"GC_DOLT_USER=root",
 		"GC_DOLT_PASSWORD=",
 	)
+	cmd.Env = append(cmd.Env, extraEnv...)
 	return cmd.CombinedOutput()
 }
 
@@ -103,6 +122,26 @@ func TestRestartCallsStartWhenStopReportsNothingRunning(t *testing.T) {
 	}
 }
 
+func TestRestartDoesNotRequirePortWhenStopReportsNothingRunning(t *testing.T) {
+	root := repoRoot(t)
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 2, "start": 0})
+
+	out, err := runRestartWithEnv(t, cityPath, root, nil)
+	if err != nil {
+		t.Fatalf("gc dolt restart failed without a resolved runtime port: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	got := strings.Join(strings.Fields(string(data)), " ")
+	if got != "stop start" {
+		t.Fatalf("expected ops in order 'stop start' without a runtime port, got %q\noutput:\n%s", got, out)
+	}
+}
+
 func TestRestartAbortsAndDoesNotStartWhenStopFails(t *testing.T) {
 	root := repoRoot(t)
 	port, cleanup := startReachableTCPListener(t)
@@ -125,5 +164,94 @@ func TestRestartAbortsAndDoesNotStartWhenStopFails(t *testing.T) {
 	}
 	if strings.Contains(string(data), "start") {
 		t.Fatalf("restart called start after stop failed; ops log:\n%s\noutput:\n%s", data, out)
+	}
+}
+
+func TestRestartPropagatesStartFailureWithDiagnostic(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 1})
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err == nil {
+		t.Fatalf("gc dolt restart unexpectedly succeeded when start failed:\n%s", out)
+	}
+	if !strings.Contains(string(out), "gc dolt restart: start failed (exit 1)") {
+		t.Fatalf("restart did not report start failure; output:\n%s", out)
+	}
+
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	got := strings.Join(strings.Fields(string(data)), " ")
+	if got != "stop start" {
+		t.Fatalf("expected restart to attempt stop and start before reporting start failure, got %q\noutput:\n%s", got, out)
+	}
+}
+
+func TestRestartRefusesRecentENOSPCUnlessForced(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 0})
+	logPath := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir dolt log dir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("fatal: no space left on device\n"), 0o644); err != nil {
+		t.Fatalf("write dolt log: %v", err)
+	}
+
+	out, err := runRestart(t, cityPath, root, port)
+	if err == nil {
+		t.Fatalf("gc dolt restart unexpectedly ignored recent ENOSPC:\n%s", out)
+	}
+	if !strings.Contains(string(out), "recent Dolt log shows ENOSPC") {
+		t.Fatalf("restart did not explain ENOSPC refusal; output:\n%s", out)
+	}
+	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("restart invoked gc-beads-bd despite ENOSPC refusal; ops log:\n%s\noutput:\n%s", data, out)
+	}
+
+	out, err = runRestartWithEnv(t, cityPath, root, []string{fmt.Sprintf("GC_DOLT_PORT=%d", port)}, "--force")
+	if err != nil {
+		t.Fatalf("gc dolt restart --force failed despite fake stop/start success: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	got := strings.Join(strings.Fields(string(data)), " ")
+	if got != "stop start" {
+		t.Fatalf("expected forced restart to call stop then start, got %q\noutput:\n%s", got, out)
+	}
+}
+
+func TestRestartRejectsRemoteHostWithDiagnostic(t *testing.T) {
+	root := repoRoot(t)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	bdLog := writeFakeBeadsBDForRestart(t, cityPath, map[string]int{"stop": 0, "start": 0})
+
+	out, err := runRestartWithEnv(t, cityPath, root, []string{
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_HOST=example.internal",
+	})
+	if err == nil {
+		t.Fatalf("gc dolt restart unexpectedly succeeded for a remote host:\n%s", out)
+	}
+	if !strings.Contains(string(out), "gc dolt restart: not supported for remote dolt servers") {
+		t.Fatalf("restart did not explain remote-host refusal; output:\n%s", out)
+	}
+	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("restart invoked gc-beads-bd despite remote-host refusal; ops log:\n%s\noutput:\n%s", data, out)
 	}
 }


### PR DESCRIPTION
Adopted follow-up for https://github.com/gastownhall/gascity/pull/2476.

Original PR title: feat(dolt): add gc dolt restart pack command
Original PR state: open
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

This follow-up preserves the contributor change set from PR #2476 and carries it forward on the current upstream base after the adoption review. The workflow could not safely update the original fork branch because GitHub rejected the maintainer push to `quickserve-ai/gascity:feat/dolt-restart-command` with a 403, so this PR is the maintained merge surface.

Maintainer adoption review summary:
- Contributor commit preserved: `feat(dolt): add gc dolt restart pack command`
- Maintainer fixup included: `fix(dolt): harden restart recovery guard`
- Focused validation: `go test ./examples/dolt -run 'Test.*Restart|TestRestart'`
- Review root: `ga-lvot9v4`, latest approved attempt: 2
