### PR TITLE
docs: clean up JSON manifest follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `gc --json-schema` manifest output no longer includes the removed
+  `transport` field. Consumers should use each role schema's `x-gc-jsonl`
+  extension, when present, to determine JSONL record-count behavior.
 - `gc session attach` now re-applies `session_live` hooks (status-bar theme,
   keybindings) when it recreates a session whose tmux runtime had exited.
   Previously the resume path in `resolvedWorkerRuntimeWithConfigAndMetadata`

--- a/docs/guides/using-json-from-gc.md
+++ b/docs/guides/using-json-from-gc.md
@@ -227,7 +227,7 @@ For streaming commands, validate each JSONL record against the result schema:
 
 ```sh
 gc events --json-schema=result > /tmp/gc-events.schema.json
-gc events --follow | while IFS= read -r line; do
+gc events --json --follow | while IFS= read -r line; do
   printf '%s\n' "$line" | jq .
 done
 ```

--- a/engdocs/design/json-cli-support.md
+++ b/engdocs/design/json-cli-support.md
@@ -270,7 +270,6 @@ is either command-specific or the shared default:
 {
   "schema_version": "1",
   "command": ["status"],
-  "transport": "jsonl",
   "json_supported": true,
   "schemas": {
     "result": {
@@ -292,7 +291,6 @@ return a manifest with no embedded schemas rather than failing:
 {
   "schema_version": "1",
   "command": ["some", "command"],
-  "transport": "jsonl",
   "json_supported": false,
   "schemas": {}
 }


### PR DESCRIPTION
Follow-up to #2438. This closes the small review nits left after removing the optional `transport` field from `gc --json-schema` manifests.

Changes:
- add `--json` to the streaming `gc events --follow` guide example before piping records through `jq`
- remove stale `"transport": "jsonl"` fields from internal JSON manifest examples
- add a changelog note for the manifest `transport` removal

Verification:
- `git diff --check`
- `go test ./test/docsync -count=1 -timeout=5m`
- `rg -n '"transport": "jsonl"|gc events --follow \\|' docs/guides/using-json-from-gc.md engdocs/design/json-cli-support.md CHANGELOG.md` returns no matches