### PR TITLE
docs(coordination-store): S1 entity inventory + S2 volume/churn census (ga-aec8q.{1,2})

### DIFF
--- a/docs/coordination-store/findings/S1-entities.md
+++ b/docs/coordination-store/findings/S1-entities.md
@@ -1,0 +1,935 @@
+# S1 — Entity & lifecycle inventory of HQ coordination state
+
+> Spike **ga-aec8q.1** (parent epic **ga-aec8q**). Finding doc, not a
+> proposal. **Tech-agnostic by intent**: this catalog describes WHAT the
+> coordination data is and HOW it is used, not "which Dolt table it
+> happens to live in today". Per-entity storage-location lines exist only
+> as forward-references for S2/S5 to anchor measurements against.
+>
+> Sources: `gc` source tree (`internal/`), `bd` schema and live data from
+> the HQ store (database `hq`, port from `.beads/dolt-server.port`),
+> filesystem state under `.gc/` and `.beads/`.
+>
+> Observation rig: gascity rig, 2026-05-22.
+
+## Reading guide
+
+Each entity is given as:
+
+- **Purpose** — what this entity represents in the coordination model.
+- **Producers** — who creates instances.
+- **Updaters** — who mutates them after creation.
+- **Consumers** — who reads / depends on them.
+- **Reaper** — who is supposed to delete or close them (and "none" if
+  no reaper exists today — that's an unbounded-growth flag for S2/S7).
+- **Lifecycle** — birth → states → death.
+- **Intent: ephemeral or durable?** — design-time question, ignoring how
+  it happens to be stored today.
+- **Persisted today in** — single line; for S2/S5 anchoring only.
+
+The intent column is the one to read first: it identifies entities whose
+current storage technology (full-history versioned database) is wildly
+mismatched with their design-time durability requirement.
+
+---
+
+## Section index
+
+| § | Section | What lives here |
+|---|---------|-----------------|
+| I | Work primitives | Task, Chore, Bug, Feature, Epic, Step |
+| II | Runtime identity | Session, Agent, Role, Rig |
+| III | Workflow execution | Molecule, Convoy, Spec |
+| IV | Communication | Mail message, Order-tracking wisp, Field-change event row, System event |
+| V | Coordination & async dispatch | Gate, Merge-request, Dependency edge, Label, Nudge queue item, Session-name lock, Convergence |
+| VI | Routing & sync | Rig route, Federation peer |
+| VII | Memory & config | bd memory (kv.memory.*), Custom status, Custom type, Counter, Project metadata, Schema migration |
+| VIII | Snapshots & retention | Compaction snapshot, Issue snapshot, Comment, Repo mtime |
+| IX | Process-level filesystem state | Controller lock, Dolt server lock/port/log, Pack runtime state, Maintainer-PR-review run, Beads cache, Interactions log, Hooks state, Backup |
+| X | Defined-but-unused surfaces | extmsg labels, polymorphic dead columns, JSONL-mirrored tables, federation_peers |
+| XI | Derived views | ready_issues, blocked_issues |
+
+Headline ratios (live, 2026-05-22, HQ database):
+
+- **Issues**: 23,373 rows; 91% of those are CLOSED tasks (21,286 / 23,373).
+  Dead-weight on the most-read collection in the store.
+- **Wisps**: 6,364 rows; 2,365 are OPEN message wisps still accumulating
+  (oldest open = 15 days). No reaper for unread/old message wisps today.
+- **Events (audit log of bead mutations)**: 75,933 issue events +
+  47,075 wisp events = **123,008 audit rows**. Largest single growth
+  driver in the store.
+- **Wisp labels**: 22,979 rows — dominated by `order-tracking` (7,163)
+  and `exec` (6,981) plus per-order-name `order-run:<name>` labels.
+  Wisp labels alone are ≈50× the corresponding issue-label count (447).
+- **Dependencies**: 13 rows. The HQ dependency graph is essentially
+  flat; the rich DAG lives in rig-scoped databases, not HQ.
+
+---
+
+## I. Work primitives
+
+These are the canonical "unit of work" entities. They all share the same
+schema row and differ only by `issue_type`. They are what most users
+think of as "beads".
+
+### I.1 Task
+
+- **Purpose**: a unit of work assignable to an agent or human.
+- **Producers**: humans (`bd create`), agents (autonomous filing of
+  follow-up work), the dispatch/sling pipeline (creates ready-to-build,
+  ready-to-deploy, etc. tasks).
+- **Updaters**: assignee on claim/status changes; the field-change event
+  log on every mutation; reconcilers that close orphan tasks.
+- **Consumers**: agents looking for work (`bd ready`), humans reviewing
+  state, dashboards, the ready/blocked materialized views.
+- **Reaper**: no explicit reaper for closed tasks today. Closure is the
+  end of the active lifecycle but rows stay forever.
+- **Lifecycle**: open → (optional `in_progress`, `blocked`, `deferred`,
+  or `hooked` custom status) → closed | `resolved` custom status.
+- **Intent**: **durable while active; archivable once closed.** History
+  is occasionally referenced for retrospectives but the row itself
+  carries no per-row audit value once closed; the event log carries
+  the audit.
+- **Persisted today in**: `issues` row (`issue_type='task'`).
+
+### I.2 Chore / Bug / Feature / Epic / Step
+
+- **Purpose**: workflow taxonomy variants of Task, used to drive
+  view filtering and prompt context. Semantically they share Task's
+  lifecycle.
+- **Producers / Updaters / Consumers**: same as Task.
+- **Reaper**: none. Same as Task.
+- **Lifecycle**: same as Task. `epic` is a container type (closed when
+  its children are closed); `step` is a non-actionable child of a
+  molecule (excluded from ready queries).
+- **Intent**: **durable while active; archivable once closed.** Epics
+  are slightly more durable because they index history; steps are
+  ephemeral once their parent molecule closes.
+- **Persisted today in**: `issues` row with the variant `issue_type`.
+
+---
+
+## II. Runtime identity & state
+
+Beads that represent live system actors rather than work.
+
+### II.1 Session
+
+- **Purpose**: the persistent identity bead for a running (or recently
+  running) agent session. Carries continuation epoch, generation,
+  instance token, alias, template, runtime state, hook-bead pointer,
+  agent_state, last_activity. Roughly: "who am I across crashes and
+  resumes". Discovery via session-name lookup, not assignee/owner.
+- **Producers**: the session manager and runtime providers when a new
+  session is started (`gc session start`, controller spawn, pool fill).
+- **Updaters**: the lifecycle projection (`internal/session/lifecycle_projection.go`)
+  on every state transition (creating → active → asleep → draining →
+  drained → archived → orphaned → closed, plus the off-path
+  failed-create, suspended, quarantined, stopped states). The
+  controller's reconciler tick. Health-patrol restarts. Drain-ack and
+  drain-detection from the agent.
+- **Consumers**: the controller (deciding which sessions to wake/keep),
+  the API (`/v0/sessions`), `gc agents` CLI, dispatch ("which session
+  for this work"), nudge delivery.
+- **Reaper**: a stop / close path exists (drained → closed), but
+  crashed-and-never-rejoined sessions accumulate as
+  `state='stopped'` until manual cleanup. HQ shows 164 session beads
+  total; 47 open today, with 2 active 11 days old.
+- **Lifecycle**: 13+ named base states (see
+  `internal/session/lifecycle.go:BaseState*` consts), 4 desired
+  states, 5 runtime projections. The richest single-entity lifecycle
+  in the system.
+- **Intent**: **active state is ephemeral** (the runtime can be
+  rebuilt from runtime providers + city config). The bead exists
+  primarily to serialize this ephemeral state across the controller's
+  reconciliation ticks and to make it observable. History past
+  drain/close has no operational value; **archival or reap should be
+  the default** once the session is terminal.
+- **Persisted today in**: `issues` row (`issue_type='session'`).
+  Many denormalized columns are session-specific:
+  `hook_bead`, `role_bead`, `agent_state`, `last_activity`,
+  `role_type`, `rig`, `started_at`. Of these, **`agent_state` and
+  `role_type` are completely empty in the live HQ today** —
+  schema weight without payload (anti-requirement flag for S6).
+
+### II.2 Agent (custom type)
+
+- **Purpose**: identity bead for a configured agent role at the city
+  level (separate from the per-session bead above). Custom type
+  registered in `custom_types`. Used as a long-lived target for
+  routing.
+- **Producers**: city init / agent config registration.
+- **Updaters**: config-edit operations and the controller's
+  agent-state syncer.
+- **Consumers**: dispatch (`gc.routed_to=<agent>`), `gc agents`
+  CLI, the API.
+- **Reaper**: deregistration on config removal. In practice these
+  beads are very long-lived.
+- **Lifecycle**: open (registered) → closed (deregistered).
+- **Intent**: **durable.** This is the closest thing in the system to
+  a static "registry" entity; lifetime matches the agent's
+  configured lifetime.
+- **Persisted today in**: `issues` row with `issue_type='agent'`
+  (defined in `custom_types`, infrequently materialized in
+  practice — see X).
+
+### II.3 Role (custom type)
+
+- **Purpose**: pure metadata describing an agent role (prompts,
+  capability hints). Indexed by `role_bead` pointers from Session.
+- **Producers**: pack/role config materialization.
+- **Updaters**: re-materialization on config change.
+- **Consumers**: session-start hydration (template + prompt lookup).
+- **Reaper**: deregistration on config removal.
+- **Intent**: **durable** — this is configuration as data.
+- **Persisted today in**: `issues` row with `issue_type='role'`.
+  (Custom type registered, but in this rig the actual prompts and
+  templates also live in pack files under `.gc/system/packs/...`,
+  so the bead form is duplicative.)
+
+### II.4 Rig
+
+- **Purpose**: identity bead for a registered rig (workspace).
+- **Producers**: `gc rig add`.
+- **Updaters**: rig suspend/resume.
+- **Consumers**: routing, dispatch, the rigs CLI.
+- **Reaper**: rig removal.
+- **Intent**: **durable** — registration scope.
+- **Persisted today in**: `issues` row with `issue_type='rig'`.
+  Note: rig prefix → filesystem-path routing is **also** kept in
+  `.beads/routes.jsonl` (see VI.1), and the `routes` table in Dolt
+  is empty — same data, two surfaces.
+
+---
+
+## III. Workflow execution
+
+Composite work structures built atop tasks.
+
+### III.1 Molecule (root + steps)
+
+- **Purpose**: an instantiation of a compiled formula recipe — a
+  root bead plus child step beads that form a DAG of executable
+  work. Each step is itself a bead (often `issue_type='task'`)
+  carrying dependency edges to its parent and to its predecessors.
+- **Producers**: `internal/molecule/Cook` and `Instantiate`; the
+  formula compilation layer; the orders system on trigger fire.
+- **Updaters**: agents executing steps (each step's status), the
+  dispatch system, the formula graph apply (`ApplyGraphPlan`)
+  which mutates the bead graph atomically.
+- **Consumers**: workers picking up step beads, dashboards showing
+  molecule progress, the reaper that closes finished molecules.
+- **Reaper**: molecule cleanup logic in
+  `internal/molecule/cleanup.go`. Cleanup conditions are formula
+  recipes; not all molecule shapes get reaped. 11 open molecules in
+  HQ today, oldest 3 days.
+- **Lifecycle**: root created with idempotency key → children
+  attached → steps execute (own task lifecycle) → root closes when
+  terminal step completes (or cleanup logic runs).
+- **Intent**: **medium-durable.** Active state is operationally
+  critical (the DAG is the execution plan). Closed molecules have
+  some retrospective value for "did we get this through". The
+  ratio of active to historical molecules should be low; in HQ
+  today only 11 are open. The DAG edges (dependencies) are
+  themselves first-class entities; see V.3.
+- **Persisted today in**: `issues` rows with `issue_type` in
+  `{molecule, step}`, plus `mol_type` column (currently empty in
+  HQ — anti-requirement flag).
+
+### III.2 Convoy
+
+- **Purpose**: a "multi-bead" grouping for dispatch — typically a
+  cross-rig batch tracked together (e.g., a single review request
+  spanning multiple rigs). A convoy bead has child items linked
+  via `tracks`-type dependencies.
+- **Producers**: `internal/convoy/ConvoyCreate`, the dispatch
+  pipeline (sling).
+- **Updaters**: child-status reconciliation; convoy completion
+  events (`ConvoyCreated`, `ConvoyClosed`).
+- **Consumers**: the dispatcher, dashboards, the order-tracking
+  layer.
+- **Reaper**: ConvoyClose when all members terminal.
+- **Lifecycle**: created (open) → members tracked → progress
+  computed → closed when complete. 28 total convoys, 22 open.
+- **Intent**: **medium-durable** — same logic as Molecule.
+- **Persisted today in**: `issues` row with `issue_type='convoy'`,
+  plus structured fields in the metadata JSON column (parsed by
+  `internal/convoy/convoy_fields.go`).
+
+### III.3 Spec (custom type)
+
+- **Purpose**: a frozen specification doc-as-bead, referenced by
+  `spec_id` from work beads. Lets work point to a stable spec
+  whose body doesn't change as the work evolves.
+- **Producers**: spec materialization (`gc spec ...`, pack-driven).
+- **Updaters**: rare — specs are intentionally append-only in
+  spirit.
+- **Consumers**: workers and reviewers looking up the binding
+  contract.
+- **Reaper**: spec retirement; rarely happens.
+- **Lifecycle**: created → referenced → optionally closed (retired).
+- **Intent**: **durable** — historical referenceability is the
+  point.
+- **Persisted today in**: `issues` row with `issue_type='spec'`,
+  plus the `spec_id` column on referencing beads.
+
+---
+
+## IV. Communication
+
+The data that flows between actors (humans, agents, the system itself).
+
+### IV.1 Mail message
+
+- **Purpose**: addressed agent-to-agent or human-to-agent
+  communication, with subject + body + sender + recipient. The
+  built-in `beadmail` backend implements `mail.Provider` (see
+  `internal/mail/mail.go`) on top of the wisp table.
+- **Producers**: `gc mail send`, automation flows, system reminders
+  emitted on session events.
+- **Updaters**: Read / MarkRead / MarkUnread / Archive operations
+  (each emits an event of the same name into `.gc/events.jsonl`).
+  Recipients reading the message flip `read` label state.
+- **Consumers**: the recipient agent (inbox check on every turn),
+  dashboards showing mail traffic, the mail CLI.
+- **Reaper**: Archive / Delete (alias for Archive — closes the
+  bead). **No automatic archive policy today.** Result: 2,365 OPEN
+  message wisps in HQ, oldest 15 days, accumulating without
+  intervention. This is the single clearest unbounded-growth
+  pattern in the live data.
+- **Lifecycle**: created (open, unread) → read (label flip) →
+  archived (closed). Optional thread linkage via `ThreadID`,
+  reply linkage via `ReplyTo`.
+- **Intent**: **mostly ephemeral.** The notification value of a
+  message decays quickly; the audit value rarely justifies
+  retaining 2k+ open rows. Some threads carry slow
+  multi-turn context — those want medium-durable retention. A
+  retention policy ("archive read messages older than N days,
+  unread messages older than M days") is the obvious missing
+  policy.
+- **Persisted today in**: `wisps` row with `issue_type='message'`,
+  metadata keys
+  `mail.from_session_id`, `mail.from_display`,
+  `mail.to_session_id`, `mail.to_display` (sender/recipient by
+  session-bead-ID + display name).
+
+### IV.2 Order-tracking wisp
+
+- **Purpose**: a per-order-run audit/observability wisp emitted
+  every time the orders system fires an order. Labels capture
+  which order ran, which formula, success/failure. Body captures
+  the trigger context.
+- **Producers**: the orders system on every order run (driven by
+  cooldown / cron / condition / event triggers).
+- **Updaters**: labels added on completion (`exec`, `wisp-failed`,
+  etc.), closed on terminal state.
+- **Consumers**: the orders feed in the API
+  (`internal/api/handler_orders*.go`), dashboards, debug
+  retrospectives.
+- **Reaper**: a `wisp-compact` order is registered (see
+  `.gc/scripts/wisp-compact.sh`) but examining HQ shows
+  `wisp_labels` for order-tracking already at 7,163 entries —
+  retention policy is too generous or not running often enough.
+  ~1,100 entries per high-frequency order (gate-sweep,
+  beads-health, dolt-health) is observed.
+- **Lifecycle**: created on trigger fire → labels added → closed
+  on completion. Most are short-lived (seconds-to-minutes).
+- **Intent**: **highly ephemeral.** This is a debug/audit trail —
+  the only consumers are dashboards and post-hoc inspection. A
+  3-day window would cover all known operational queries.
+- **Persisted today in**: `wisps` row, labelled `order-tracking`
+  + per-order `order-run:<name>` + `exec` / `exec-failed`.
+
+### IV.3 Field-change event row
+
+- **Purpose**: an append-only audit row capturing every mutation
+  to a bead — `created`, `updated`, `closed`, `claimed`,
+  `status_changed`, `label_added`, `label_removed`, `reopened`.
+  Carries `actor`, `old_value`, `new_value`, `comment`.
+- **Producers**: the bead store emits one of these on every
+  mutating operation, automatically.
+- **Updaters**: append-only; never updated.
+- **Consumers**: `bd history`, "who closed this", time-travel
+  retrospectives, dashboards.
+- **Reaper**: none today. Cascades when the parent bead is
+  hard-deleted (`ON DELETE CASCADE`), but beads are almost never
+  hard-deleted.
+- **Lifecycle**: created at mutation time → lives forever.
+- **Intent**: **medium-durable for active beads, archivable for
+  closed beads.** This is the largest single growth driver in
+  HQ: 123,008 rows (75,933 issue events + 47,075 wisp events).
+  Per-bead amplification: every bead's lifecycle generates ~5
+  rows on average (created + several updated + closed for a
+  task; a session generates many more).
+- **Persisted today in**: `events` table (for issues),
+  `wisp_events` table (for wisps).
+  Notable: `event_kind`, `actor`, `target`, `payload` columns
+  also exist denormalized on the *issues* table — those
+  columns appear to be a legacy attempt to model events
+  in-band, currently unused (0 rows).
+
+### IV.4 System event (the Event Bus)
+
+- **Purpose**: a separate, cross-package observability stream
+  recording infrastructure activity: city lifecycle (resumed,
+  suspended), bead lifecycle (created, closed), session lifecycle
+  (woke, stopped, crashed, drain_acked_with_assigned_work, …),
+  mail operations, order fired/completed/failed, controller
+  start/stop, request results, supervisor signals, extmsg events.
+- **Producers**: every domain package emits via
+  `events.Recorder.Record` — see the long list of constants in
+  `internal/events/events.go`.
+- **Updaters**: append-only; consumed via reader/scanner.
+- **Consumers**: the orders system (event-triggered orders consume
+  by `event_type` + cursor), the API's `/v0/events/stream` SSE
+  projection, gate evaluators (`gates.go`), dashboards, traces.
+- **Reaper**: log rotation (`rotation.go`, `rotation_archive.go`).
+- **Lifecycle**: emitted at the moment of action → rotated to
+  archive → eventually deleted.
+- **Intent**: **ephemeral with bounded retention.** The cursor
+  model means we only need to retain enough events to outlast
+  the slowest consumer; everything else can roll off.
+- **Persisted today in**: `.gc/events.jsonl` (live tail),
+  `.gc/events.jsonl.seq` (next-seq pointer), rotated archives.
+  This is a **distinct system** from the per-bead `events`
+  table in IV.3.
+
+---
+
+## V. Coordination & async dispatch
+
+State that exists to coordinate or sequence actors.
+
+### V.1 Gate (custom type / mechanism)
+
+- **Purpose**: an async wait condition — a bead that opens when
+  some external state is true. Used to gate dispatch ("wait for
+  the build to be green before slinging the deploy"). Custom type
+  `gate` is registered.
+- **Producers**: order definitions of `trigger='condition'` or
+  `gate='cooldown'`, etc. (see `internal/orders/gates.go`).
+- **Updaters**: the gate evaluator on each tick.
+- **Consumers**: the dispatcher; molecules waiting on a step.
+- **Reaper**: closed when the condition is satisfied.
+- **Lifecycle**: open (waiting) → satisfied (closed).
+- **Intent**: **ephemeral** — the gate has no value after it
+  fires; only the event it produces matters.
+- **Persisted today in**: order-config (TOML on disk under
+  `<pack>/orders/`) plus per-evaluator state in the orders
+  cursor/last-run tracking. The schema has `await_type`,
+  `await_id`, `timeout_ns`, `waiters` columns ostensibly for
+  bead-modeled gates, **all currently empty** in HQ — another
+  defined-but-unused surface.
+
+### V.2 Merge-request (custom type)
+
+- **Purpose**: bead representing an in-flight code-review /
+  merge request, processed by automation (e.g., the
+  maintainer-pr-review pack). Bead carries the GitHub PR
+  number, decision state, and labels indicating review
+  progress.
+- **Producers**: PR-ingest automation; user filing.
+- **Updaters**: review automation, label sweepers.
+- **Consumers**: review automation, dashboards.
+- **Reaper**: closed when the PR merges or closes.
+- **Lifecycle**: open (PR live) → closed (merged or rejected).
+- **Intent**: **ephemeral while in-flight; closed entries
+  archivable.** Recent counts: 40 `needs-human-review` and
+  26 `mpr-rebase-routed` labels in HQ, with corresponding
+  on-disk state under `.gc/maintainer-pr-review/...` (IX.4).
+- **Persisted today in**: `issues` row with
+  `issue_type='merge-request'`, plus the rich filesystem run
+  state.
+
+### V.3 Dependency edge
+
+- **Purpose**: directed edges in the bead DAG —
+  `blocks`, `parent-child`, `waits-for`, `tracks`,
+  `relates-to`. Drives the readiness query (a bead is ready
+  iff no `blocks` predecessor is still open) and the molecule
+  step graph.
+- **Producers**: bead-create-with-deps, formula
+  instantiation (`ApplyGraphPlan` writes entire dependency
+  sets atomically), molecule-attach, dispatch-time wiring.
+- **Updaters**: dependencies are mostly immutable once
+  written; closure happens via the parent bead's lifecycle.
+- **Consumers**: the readiness materialized view, blocked-
+  issues view, dispatchers, dashboards, cleanup logic.
+- **Reaper**: cascade on parent-bead delete (uncommon).
+- **Lifecycle**: created at structure-build time → lives as
+  long as its endpoints exist.
+- **Intent**: **durable for the lifetime of the endpoints.**
+  Note: HQ has only 13 dependency rows because HQ is
+  primarily a coordination database, not a workflow database.
+  The rig database (`gascity`) has 5,520 dependency rows —
+  the rich DAG lives there.
+- **Persisted today in**: `dependencies` table; can point to
+  `issues.id`, `wisps.id`, or an external ref (cross-rig).
+
+### V.4 Label
+
+- **Purpose**: many-to-many tags on beads/wisps. Used for
+  routing (`gc.routed_to=<x>`), workflow state (`needs-investigation`,
+  `needs-human-review`, `ready-to-build`), agent/template
+  identification (`agent:<x>`, `template:<x>`), order
+  tracking (`order-tracking`, `order-run:<name>`), source
+  attribution (`source:mail`, `source:session`),
+  read/unread state for mail.
+- **Producers**: bead-create-with-labels, label-add operations,
+  automation.
+- **Updaters**: add/remove operations, automation flows.
+- **Consumers**: every query that filters or routes by tag.
+- **Reaper**: cascade on parent-bead delete.
+- **Lifecycle**: added → removed (or persists to bead close).
+- **Intent**: **lifetime of parent bead.** Labels are a
+  flat tag space; multiplicity is up to the producer. The
+  current asymmetry (447 issue labels vs 22,979 wisp labels)
+  is driven entirely by per-order-run wisp-labelling
+  (`order-tracking` + per-run name), not by an intentional
+  modelling choice.
+- **Persisted today in**: `labels` table, `wisp_labels` table.
+
+### V.5 Nudge queue item
+
+- **Purpose**: a persisted deferred-nudge waiting to be
+  delivered to an agent — `(bead_id, agent, session_id,
+  message, deliver_after, expires_at)` with claim/lease
+  bookkeeping for at-most-once delivery.
+- **Producers**: dispatch (sling) when slinging across a
+  cool-down or to an asleep session; mail handoff
+  ("send a system-reminder when this agent wakes").
+- **Updaters**: claim/lease, deliver, fail, dead-letter.
+- **Consumers**: the supervisor's nudge dispatcher (when
+  configured via `daemon.nudge_dispatcher`).
+- **Reaper**: delivered items go through Pending → InFlight →
+  (delivered: removed) | (expired/failed: Dead bucket).
+  Dead-letter entries are not auto-pruned today.
+- **Lifecycle**: Pending → InFlight → done | Dead.
+- **Intent**: **ephemeral**, with the caveat that items must
+  survive a controller restart (durable storage required).
+- **Persisted today in**: `.gc/runtime/nudges/state.json`
+  with `.gc/runtime/nudges/state.lock`; the wake socket is at
+  `.gc/runtime/nudges/wake.sock`. This entity is
+  filesystem-only — there is no Dolt mirror today.
+
+### V.6 Session-name lock
+
+- **Purpose**: advisory cross-process lock guarding
+  session-name assignment so two simultaneous create operations
+  cannot grab the same name.
+- **Producers**: any code path that creates a new aliased
+  session (see `internal/session/names_test.go`
+  `WithCitySessionNameLock`).
+- **Updaters**: acquired and released within a single
+  operation.
+- **Consumers**: the lock holder for the duration of the
+  protected critical section.
+- **Reaper**: released on operation completion. Stale lock
+  files are tolerated via flock-based detection of dead
+  holders.
+- **Lifecycle**: acquired → held → released (file remains
+  on disk as flock target).
+- **Intent**: **ephemeral process-coordination state**, not
+  application data. Pure synchronization primitive.
+- **Persisted today in**: `.gc/session-name-locks/<hashed-name>`
+  files. The directory may not exist when no locks have
+  ever been taken.
+
+### V.7 Convergence (custom type)
+
+- **Purpose**: bead representing a "convergence point" — work
+  expected to land into a single state, used by the
+  convergence loop for crash-retry idempotency on molecule
+  instantiation. The `IdempotencyKey` option in
+  `molecule.Options` is the producer-side input.
+- **Producers**: molecule instantiation through the
+  convergence loop.
+- **Updaters**: the convergence reconciler on retry.
+- **Consumers**: the convergence reconciler.
+- **Reaper**: convergence cleanup when the target state is
+  reached.
+- **Lifecycle**: claimed (open) → converged (closed).
+- **Intent**: **ephemeral** — the only point is to make
+  crash-retry safe.
+- **Persisted today in**: `issues` row with
+  `issue_type='convergence'`. Custom type registered;
+  rare in this rig.
+
+---
+
+## VI. Routing & sync
+
+State controlling how requests and data flow between rigs and remotes.
+
+### VI.1 Rig route (prefix → path)
+
+- **Purpose**: maps bead-ID prefix (`gm`, `ga`, `mc`, `be`,
+  `projectwrenunity`) to a filesystem path of the rig that
+  owns that prefix. Drives cross-rig bead lookup ("which DB
+  holds `ga-abc.1`?") and `gc mail send` cross-rig delivery.
+- **Producers**: `gc rig add` writes this; `bd init` of a new
+  prefix.
+- **Updaters**: very rare — when a rig is moved on disk.
+- **Consumers**: every cross-rig bead query.
+- **Reaper**: route removal when a rig is deregistered.
+- **Lifecycle**: created → updated rarely → deleted.
+- **Intent**: **durable, low-churn configuration.**
+- **Persisted today in**: `.beads/routes.jsonl` (live source
+  of truth, 5 rows). The `routes` Dolt table exists in the
+  schema and is **empty** — a defined-but-unused surface.
+
+### VI.2 Federation peer
+
+- **Purpose**: pairing record for sync against another bead
+  store (`remote_url`, credentials, sovereignty mode,
+  last_sync).
+- **Producers**: `bd remote add` / federation pairing.
+- **Updaters**: sync runs update `last_sync`.
+- **Consumers**: bd's federation-sync code path.
+- **Reaper**: unpair operation.
+- **Lifecycle**: paired → synced repeatedly → unpaired.
+- **Intent**: **durable, low-churn configuration.**
+- **Persisted today in**: `federation_peers` table
+  (**empty in HQ today** — federation not in use here).
+
+---
+
+## VII. Memory & config
+
+Long-lived configuration that lives in the store, not on disk.
+
+### VII.1 bd memory (kv.memory.*)
+
+- **Purpose**: a key-value store for `bd remember`'d notes —
+  persistent agent memories that survive sessions. Each is
+  one row keyed by `kv.memory.<slug>` with the content as the
+  value.
+- **Producers**: `bd remember` invocations by agents and
+  humans.
+- **Updaters**: `bd remember --key <key> "new content"`.
+- **Consumers**: `bd memories <keyword>`, `bd prime`
+  context injection.
+- **Reaper**: `bd forget <key>`.
+- **Lifecycle**: created → updated → deleted.
+- **Intent**: **durable**, intentionally so — the point is
+  cross-session continuity.
+- **Persisted today in**: `config` table; 24 entries live
+  today (out of 49 total config rows).
+
+### VII.2 Custom status / Custom type
+
+- **Purpose**: extends the default status enum and bead-type
+  taxonomy. Status carries a `category` (`open` / `done` /
+  `frozen` etc.) that views (ready_issues, blocked_issues)
+  use to decide whether an entry should be reachable.
+- **Producers**: `bd add-status` / `bd add-type` (or schema
+  migration).
+- **Updaters**: rare.
+- **Consumers**: the readiness views, type-aware queries.
+- **Reaper**: deregistration is rare.
+- **Lifecycle**: created at schema-extension time → lives
+  with the store.
+- **Intent**: **durable, very low churn.**
+- **Persisted today in**: `custom_statuses` (3 rows:
+  `deferred`/open, `hooked`/open, `resolved`/closed),
+  `custom_types` (12 rows: `agent`, `convergence`,
+  `convoy`, `event`, `gate`, `merge-request`, `message`,
+  `molecule`, `rig`, `role`, `session`, `spec`).
+
+### VII.3 Counter
+
+- **Purpose**: allocator state for next ID. `issue_counter`
+  for top-level IDs (`ga-aec8q`); `child_counters` /
+  `wisp_child_counters` for sub-IDs (`ga-aec8q.1`).
+- **Producers**: bead create on every bead.
+- **Updaters**: monotonic increment on bead create.
+- **Consumers**: bead create.
+- **Reaper**: none — values are append-only.
+- **Lifecycle**: increment-only.
+- **Intent**: **durable** — must persist across restarts.
+- **Persisted today in**: `issue_counter`, `child_counters`,
+  `wisp_child_counters` (HQ: 11 child_counter rows).
+
+### VII.4 Project metadata
+
+- **Purpose**: project-identity facts (`_project_id`) and
+  per-machine state (`bd_version`, `bd_version_max`,
+  `tip_claude_setup_last_shown`).
+- **Producers**: `bd init`, version upgrades.
+- **Updaters**: version upgrades.
+- **Consumers**: bd's version-compat checks.
+- **Reaper**: none.
+- **Intent**: **durable, low-churn.**
+- **Persisted today in**: `metadata` table (project-wide),
+  `local_metadata` table (per-machine, not synced).
+
+### VII.5 Schema migration
+
+- **Purpose**: applied-migrations ledger. Two tables:
+  `schema_migrations` (versions applied) and
+  `ignored_schema_migrations` (intentionally skipped).
+- **Producers**: bd schema-init/upgrade.
+- **Updaters**: monotonic on each migration apply.
+- **Consumers**: bd's on-startup migration check.
+- **Reaper**: none — append-only ledger.
+- **Intent**: **durable, append-only.**
+- **Persisted today in**: tables of the same names.
+
+---
+
+## VIII. Snapshots & retention
+
+### VIII.1 Compaction snapshot
+
+- **Purpose**: compacted summary of older closed beads — when
+  compaction runs, a full closed bead's body is replaced
+  with a snapshot row pointing to a hash; `compaction_level`,
+  `compacted_at`, `compacted_at_commit`, `original_size`
+  columns on the live bead track the operation.
+- **Producers**: the compaction job
+  (config: `auto_compact_enabled`, `compact_batch_size`,
+  `compact_parallel_workers`, `compact_tier1_days`,
+  `compact_tier2_days`, `compact_tier1_dep_levels`,
+  `compact_tier2_dep_levels`, `compact_tier2_commits`,
+  `compaction_enabled`).
+- **Updaters**: only the compaction job itself.
+- **Consumers**: the bead reader, falling back to the
+  snapshot when the live row is compacted.
+- **Reaper**: tier-2 graduation deletes tier-1; deletion of
+  the parent bead cascades.
+- **Lifecycle**: appears at compaction time → may be
+  upgraded (tier-1 → tier-2) → deleted with parent.
+- **Intent**: **medium-durable** — compaction is the
+  store's main retention mechanism today.
+- **Persisted today in**: `compaction_snapshots` table
+  (**0 rows in HQ today** — compaction either not yet run
+  or not configured to compact this rig's data).
+
+### VIII.2 Issue snapshot
+
+- **Purpose**: complete point-in-time snapshot of a bead.
+  Schema column present.
+- **Producers**: ad-hoc snapshot creation, certain workflow
+  paths.
+- **Lifecycle**: created → optionally restored from →
+  deleted.
+- **Intent**: **rarely used.** 0 rows in HQ today.
+- **Persisted today in**: `issue_snapshots` table.
+
+### VIII.3 Comment
+
+- **Purpose**: a threaded note on a bead, separate from the
+  bead's free-text `notes` field.
+- **Producers**: `bd comment`.
+- **Updaters**: append-only typically.
+- **Consumers**: bead viewers.
+- **Reaper**: cascade on parent delete.
+- **Intent**: **lifetime of parent bead.** 6 issue
+  comments + 0 wisp comments in HQ — barely used in practice;
+  `notes` field is preferred.
+- **Persisted today in**: `comments`, `wisp_comments`.
+
+### VIII.4 Repo mtime
+
+- **Purpose**: cached mtimes for files in the project repo —
+  used by some bd workflows to detect change without
+  re-stat-ing the filesystem.
+- **Producers**: bd's mtime tracker.
+- **Lifecycle**: written on observation → overwritten on
+  next observation.
+- **Intent**: **ephemeral cache.**
+- **Persisted today in**: `repo_mtimes` table (**0 rows in
+  HQ** — feature unused).
+
+---
+
+## IX. Process-level filesystem state
+
+State that the coordination model treats as primary but cannot live in
+Dolt because it represents process facts (PIDs, sockets, ports) or
+because it pre-dates the store.
+
+### IX.1 Controller lock
+
+- `.gc/controller.lock` — flock target ensuring only one
+  controller runs per city. Releases on process exit.
+- **Intent**: **ephemeral process synchronization.**
+
+### IX.2 Dolt server lock / port / log
+
+- `.beads/dolt-server.lock` — flock on the Dolt server PID.
+- `.beads/dolt-server.port` — live port the Dolt server
+  bound to (rewritten on each restart; see the bd port-drift
+  memory in this project).
+- `.beads/dolt-server.log` — server stdout/stderr.
+- **Intent**: **ephemeral process state.**
+
+### IX.3 Pack runtime state
+
+- `.gc/runtime/packs/<pack>/...` — per-pack runtime state
+  (e.g., `dolt.pid`, `dolt.lock`, `dolt-state.json`,
+  `dolt-provider-state.json`, `dolt-config.yaml`,
+  `dolt.log`).
+- `.gc/system/packs/<pack>/...` — installed pack manifests
+  (read-mostly).
+- **Intent**: **ephemeral process state** (runtime/),
+  **durable configuration** (system/).
+
+### IX.4 Maintainer-PR-review run state
+
+- `.gc/maintainer-pr-review/<owner>-<repo>/pr-<n>/runs/<ts>/*.json`
+  — per-run JSON artefacts from the maintainer-pr-review
+  pack: `repo-policy.json`, `label-status.json`,
+  `metadata.json`, `files.json`, `reviews.json`,
+  `comments.json`, `repo-info.json`, `codeql-alerts.json`,
+  `runner-status.json`, `ensemble-status.json`,
+  `fix-executor.json`, `review-decision.json`,
+  `human-hold.json` (optional), `publish-result.json`.
+- **Intent**: **medium-durable run artefacts**, retention
+  TBD by pack.
+
+### IX.5 Beads cache (.gc/beads.json)
+
+- `.gc/beads.json` (~14 KB) — a SNAPSHOT of beads at some
+  seq (`seq: 21`). Format: a list of `{id, title, status,
+  issue_type, created_at}`. Body lacks descriptions.
+  **Purpose unclear** — looks like a passive export
+  cache. Stale (last touched May 1, current date is
+  May 22). Possibly orphaned from an earlier version of
+  the bd export pipeline.
+- **Intent**: presumably **ephemeral cache**, but it's
+  stale enough to suggest it's no longer maintained.
+  Flagging for S6 (anti-requirements audit).
+
+### IX.6 Interactions log (.beads/interactions.jsonl)
+
+- 5,597 entries. Each entry is `{id, kind, created_at,
+  actor, issue_id, extra}` recording a `field_change`
+  caused by an agent (session ID) closing or updating an
+  issue. The Dolt `interactions` table is **empty** —
+  this entire surface is JSONL-only.
+- **Producers**: bd hooks that intercept agent operations.
+- **Intent**: **medium-durable audit log**, with
+  retention TBD. Duplicates information already captured
+  in the `events` audit table (IV.3) plus session
+  attribution — possible redundancy flag for S6.
+
+### IX.7 Hooks state + log
+
+- `.beads/hooks/` — hook scripts and state.
+- `.beads/hooks.log` — hook execution log.
+- **Intent**: **scripts are durable config; log is
+  ephemeral.**
+
+### IX.8 Formulas
+
+- `.beads/formulas/` — formula store (TOML files).
+- **Intent**: **durable configuration.**
+
+### IX.9 Backup
+
+- `.beads/backup/` — periodic backups of the Dolt store.
+  PR #2478 (the `bd-backup-size` doctor canary) is open
+  *specifically* because this directory has shown
+  unbounded growth.
+- **Intent**: **bounded-retention durable backups.**
+  Current retention policy is the subject of an in-flight
+  PR — anti-requirement flag.
+
+### IX.10 Other supporting files
+
+- `.beads/identity.toml` — bd identity (machine/user).
+- `.beads/config.yaml` — bd config (issue_prefix,
+  sync.remote, dolt.auto-push, etc.).
+- `.beads/metadata.json` — bd metadata snapshot.
+- `.beads/export-state.json` — export cursor state.
+- `.beads/push-state.json` — push cursor state.
+- `.beads/last-touched` — mtime stamp.
+- `.beads/embeddeddolt/` — embedded Dolt assets.
+- All **durable configuration** or **small bookkeeping**
+  files; none implicated as growth drivers.
+
+---
+
+## X. Defined-but-unused entity surfaces
+
+These exist in the schema or codebase but carry no data in the live HQ
+today. They are **anti-requirement flags** for S6: every one of them is
+schema or code surface that pays cost without earning benefit.
+
+| Surface | Defined as | Live rows | Notes |
+|---------|------------|-----------|-------|
+| `issues.wisp_type` column | `varchar(32)` | 0 | Schema weight. |
+| `issues.mol_type` column | `varchar(32)` | 0 | Schema weight. |
+| `issues.event_kind` column | `varchar(32)` | 0 | Attempt at in-band event modelling; abandoned. |
+| `issues.actor` / `target` / `payload` cols | text | 0 | Same as above. |
+| `issues.await_type` / `await_id` / `timeout_ns` / `waiters` | varied | 0 | Bead-modeled gates; gates live in TOML today. |
+| `issues.role_type` column | `varchar(32)` | 0 | Schema weight. |
+| `issues.agent_state` column | `varchar(32)` | 0 | Schema weight. |
+| `routes` table | full table | 0 | Authoritative copy lives in `.beads/routes.jsonl`. |
+| `interactions` table | full table | 0 | Authoritative copy lives in `.beads/interactions.jsonl`. |
+| `federation_peers` table | full table | 0 | Federation is not used in this rig. |
+| `compaction_snapshots` table | full table | 0 | Compaction not actively producing tier rows here. |
+| `issue_snapshots` table | full table | 0 | Snapshot feature unused. |
+| `repo_mtimes` table | full table | 0 | Feature unused. |
+| extmsg labels (`gc:extmsg-*`) | label-based bead pattern | 0 | extmsg not active in this rig. |
+| `interactions` table column `extra json` | json | 0 | (table empty, but column itself shows the wire-shape ambiguity discussed in S6). |
+| `.gc/beads.json` | JSON cache | stale 21-day-old snapshot | Either ratchet it or remove it. |
+
+---
+
+## XI. Derived views
+
+These are **not entities** in the storage sense — they are computed
+projections — but they must be enumerated because the readiness model
+is what makes coordination work.
+
+### XI.1 `ready_issues`
+
+A computed view: an issue is ready when (a) it is open OR in an "active"
+custom status, (b) it is not ephemeral, (c) all `blocks` predecessors are
+closed or pinned, (d) no transitively-parent has an unexpired `defer_until`,
+and (e) `defer_until` itself is in the past (or null). Implemented as a
+recursive CTE.
+
+### XI.2 `blocked_issues`
+
+An open issue with at least one open `blocks` predecessor. Returns the
+issue plus a `blocked_by_count` column.
+
+**Recompute cost**: both views walk the dependencies graph. Even the
+sparse HQ dep set is cheap to traverse, but a heavy rig DB with 5k+
+edges and recursive descent puts these views on the hot read path.
+
+---
+
+## Cross-references for S2 and S5
+
+The volume/churn census (S2) should anchor on:
+- **Highest-volume entities**: field-change event rows
+  (123k), issues (23k), wisps (6k), labels (23k wisp + 0.4k issue).
+- **Highest-churn entities**: order-tracking wisps, system events,
+  session beads (lifecycle transitions amplify into many event rows),
+  message wisps (create-only with no reaper).
+- **Highest dead-weight ratios**: closed tasks (91% of issues), closed
+  message wisps relative to value (notification-only).
+- **Unbounded entities (no reaper today)**: closed tasks,
+  archived message wisps, field-change events, dead-letter nudges,
+  order-tracking wisps (compaction policy too loose),
+  `.beads/backup/` (in-flight fix).
+
+The durability/restart-resilience matrix (S5) should split entities by:
+- **Must-survive-restart, no rebuild possible**: bead identity rows
+  (Task/Bug/Feature/Epic/Step/Spec), dependencies, labels, counters,
+  config, custom types, schema_migrations, federation_peers, routes.
+- **Must-survive-restart, but value decays fast**: open mail message,
+  open order-tracking wisp, open convoy/molecule (decays only after
+  closure).
+- **Must-survive-restart, ephemeral state with reconstructible body**:
+  session bead (live runtime is the authoritative source, bead is the
+  serialization), gate (re-evaluable), convergence claims, nudge-queue
+  items.
+- **Best-effort-only**: field-change events past N days, system events
+  past M cursors, comments, interactions.jsonl.
+- **Pure process state, freely rebuildable**: controller lock, Dolt
+  server lock/port/log, pack runtime state, session-name locks.

--- a/docs/coordination-store/findings/S2-volume-churn.md
+++ b/docs/coordination-store/findings/S2-volume-churn.md
@@ -390,15 +390,15 @@ its observed effectiveness.
 | Issue field-change event (IV.3) | 75,933 | ~9,000 | n/a (FK cascade only) | implicit cascade on bead delete | tied to bead deletion (never happens) |
 | Wisp field-change event (IV.3) | 47,334 (21,445 orphan) | ~17,000 | n/a | **none** (no FK) | **broken — 45 % orphans** |
 | System event (IV.4) | 184 in jsonl | variable | n/a | log rotation | OK |
-| Dependency (V.3, HQ) | 13 | <1 | n/a | implicit cascade | OK (HQ is shallow) |
+| Dependency (V.3, HQ) | 13 | &lt;1 | n/a | implicit cascade | OK (HQ is shallow) |
 | Issue label (V.4) | 447 | ~50 | n/a | implicit cascade | OK |
 | Wisp label (V.4) | 23,106 (10,706 orphan) | ~10,500 | n/a | **none** (no FK) | **broken — 46 % orphans** |
 | Nudge queue item (V.5) | 0 today | bursts | per-delivery | dispatcher cleanup | OK |
 | Session-name lock (V.6) | 0 today | per-create | per-release | release on op | OK |
-| Rig route (VI.1) | 5 (jsonl) | <1 | rare | manual | OK |
-| Federation peer (VI.2) | 0 | <1 | rare | manual | OK |
-| bd memory `kv.memory.*` (VII.1) | 24 | <1 | manual `bd forget` | OK |
-| Custom status / type (VII.2) | 3 + 12 | <<1 | rare | manual | OK |
+| Rig route (VI.1) | 5 (jsonl) | &lt;1 | rare | manual | OK |
+| Federation peer (VI.2) | 0 | &lt;1 | rare | manual | OK |
+| bd memory `kv.memory.*` (VII.1) | 24 | &lt;1 | manual `bd forget` | OK |
+| Custom status / type (VII.2) | 3 + 12 | &lt;&lt;1 | rare | manual | OK |
 | Counters (VII.3) | 11 | per-create | n/a | n/a (monotonic) | OK |
 | Compaction snapshot (VIII.1) | 0 | (not running on this rig) | n/a | tier-2 graduation | not active |
 | Issue snapshot (VIII.2) | 0 | feature unused | — | — | n/a |

--- a/docs/coordination-store/findings/S2-volume-churn.md
+++ b/docs/coordination-store/findings/S2-volume-churn.md
@@ -1,0 +1,488 @@
+# S2 — Volume & churn census of HQ coordination state
+
+> Spike **ga-aec8q.2** (parent epic **ga-aec8q**). Quantifies the
+> entities catalogued in [[S1-entities]]. Tech-agnostic: rows-per-day
+> rather than "Dolt scans". Anchors S5 (durability matrix) and
+> S7 (targets & retention).
+>
+> Observation rig: gascity, 2026-05-22 23:30 local. Live HQ store on
+> the embedded Dolt server. Numbers below are point-in-time except
+> where labelled as "per day" or "last 24h".
+
+## Headline
+
+| Finding | Number |
+|---|---|
+| Most-populated table | `issues`, **23,373 rows**, of which **91 % (21,286) are closed tasks**. |
+| Single largest growth driver | **`wisp_events`** (audit log of wisp mutations) — **45 % of rows are orphans** from already-deleted parent wisps because `wisp_events` has no FK to `wisps`. |
+| Same problem, different table | **`wisp_labels`** — **46 % of rows are orphans** for the same reason. |
+| Highest sustained create rate | Order-tracking wisps — **24 per minute** (last hour), **~3,500 per day** sustained. |
+| Most clearly unbounded user-facing entity | Open mail messages — **+200 per day net** (created ≫ archived), oldest open is 15 days, no reaper today. |
+| Schema-defined-but-empty surfaces | 6 entire tables empty + 9 unused columns on `issues` — pure dead schema weight. |
+
+The store is **bounded today** only by the recency of its installation
+(events table spans 4-5 days). Two of the largest tables already show
+the unbounded pattern within that window. **Projection: at sustained
+~10 k orphan `wisp_events`/day, the table reaches 3.65 M rows in one
+year of continuous operation.**
+
+---
+
+## Method
+
+Counts come from direct SQL against the live HQ store (database `hq`
+on the per-rig Dolt server, port read from `.beads/dolt-server.port`).
+Filesystem-only entities are measured with `wc -l` / `du -h` on the
+canonical paths inventoried in S1 §IX.
+
+Per-day rates use `GROUP BY DATE(created_at)` / `GROUP BY DATE(closed_at)`.
+"Last 24h" uses `created_at > NOW() - INTERVAL 1 DAY`. Orphan
+detection uses `LEFT JOIN ... WHERE parent.id IS NULL`. Schema
+column-emptiness uses `WHERE col != '' GROUP BY col`.
+
+The events table only carries the last **4-5 days** of history at the
+moment, so all per-event-row rates are computed against that window.
+Per-bead rates use the bead row's `created_at`, which goes back ~17
+days.
+
+---
+
+## I. Volume snapshot (point-in-time)
+
+### I.1 Bead tables
+
+| Table | Rows | Open | Closed | Dead-weight ratio | Notes |
+|-------|------|------|--------|--------------------|-------|
+| `issues` | 23,373 | 224 | 23,148+ | **91 %** are closed tasks (21,286) | Includes 47 open sessions and 22 open convoys. The closed-task mass is from a May 14-18 burst — see §III. |
+| `wisps` | 6,364 | 2,407 | 3,955 | — | Two distinct populations: order-tracking (3,623, all `issue_type='task'`, 24 h TTL) and mail messages (2,776 mostly `issue_type='message'`, no reaper). |
+
+### I.2 Bead breakdown by issue_type / status (issues)
+
+| issue_type / status | Count |
+|---|---|
+| task / closed | 21,286 |
+| message / closed | 1,677 |
+| task / open | 130 |
+| session / closed | 117 |
+| session / open | 47 |
+| chore / closed | 28 |
+| convoy / open | 22 |
+| chore / open | 16 |
+| bug / open | 13 |
+| molecule / open | 11 |
+| bug / closed | 8 |
+| feature / open | 6 |
+| convoy / closed | 6 |
+| feature / closed | 2 |
+| task / deferred | 1 |
+| chore / deferred | 1 |
+| epic / closed | 1 |
+| step / open | 1 |
+
+### I.3 Bead breakdown by issue_type / status (wisps)
+
+| issue_type / status | Count |
+|---|---|
+| task / closed | 3,585 |
+| message / open | 2,359 |
+| message / closed | 417 |
+| task / open | 3 |
+
+Confirmed via JOIN to wisp_labels: **100 % of the 3,623 task wisps
+carry the `order-tracking` label** — task wisps in this store are
+exclusively order-tracking artefacts (see S1 §IV.2).
+
+### I.4 Audit-log / supporting tables
+
+| Table | Rows | FK to parent? | Orphan rate |
+|-------|------|--------------|-------------|
+| `events` (issue audit log) | 75,933 | yes, `ON DELETE CASCADE` | **0 %** (FK works). |
+| `wisp_events` (wisp audit log) | 47,334 | **NO FK** | **45 %** (21,445 orphans). |
+| `labels` | 447 | yes, `ON DELETE CASCADE` | 0 %. |
+| `wisp_labels` | 23,106 | **NO FK** | **46 %** (10,706 orphans). |
+| `dependencies` (issue side) | 13 | yes, cascade on parent | 0 %. |
+| `wisp_dependencies` | 0 | no FK | — |
+| `comments` | 6 | yes | 0 %. |
+| `wisp_comments` | 0 | no FK | — |
+| `interactions` table | 0 | — | (live data is in `.beads/interactions.jsonl`, 5,606 lines) |
+| `routes` table | 0 | — | (live data is in `.beads/routes.jsonl`, 5 lines) |
+| `federation_peers` | 0 | — | federation unused here |
+| `compaction_snapshots` | 0 | — | compaction not producing rows |
+| `issue_snapshots` | 0 | — | feature unused |
+| `repo_mtimes` | 0 | — | feature unused |
+| `child_counters` | 11 | — | low churn |
+| `wisp_child_counters` | 0 | — | low churn |
+| `config` | 49 | — | includes 24 `kv.memory.*` rows |
+| `metadata` | 1 | — | `_project_id` only |
+| `local_metadata` | 3 | — | bd version + tip-shown timestamp |
+| `custom_statuses` | 3 | — | deferred, hooked, resolved |
+| `custom_types` | 12 | — | agent, convergence, convoy, event, gate, merge-request, message, molecule, rig, role, session, spec |
+| `schema_migrations` | (small, append-only) | — | — |
+| `ignored_schema_migrations` | (small, append-only) | — | — |
+
+### I.5 Filesystem-only entities (sizes)
+
+| Path | Size / lines | Notes |
+|------|--------------|-------|
+| `.gc/events.jsonl` | 184 lines, 104 KB | Event Bus log. Bounded by rotation. |
+| `.beads/interactions.jsonl` | 5,606 lines | Mirrors the empty `interactions` table. No reaper today. |
+| `.beads/routes.jsonl` | 5 lines | Mirrors the empty `routes` table. Config-shaped, low churn. |
+| `.gc/beads.json` | 14 KB, seq=21 | **Stale 21-day-old snapshot.** Last update May 1, current date May 22. Likely orphaned from an older export pipeline (S1 §IX.5). |
+| `.gc/runtime/nudges/state.json` | does not exist | Empty queue right now. |
+| `.gc/session-name-locks/` | does not exist | No active locks right now. |
+| `.gc/maintainer-pr-review/` | per-PR-run directories with ~14 JSON artefacts each | Bounded per PR; growth scales with PR-review activity. |
+| `.beads/dolt/` | (database itself — out of scope for row-count census) | — |
+| `.beads/backup/` | (subject of in-flight PR #2478 — known growth bug) | — |
+
+### I.6 Live HQ dependency graph
+
+The `dependencies` table has **13 rows**. The dense workflow DAG
+(5,520 dependency rows) lives in the rig database (`gascity`), not
+in HQ. **HQ is primarily a coordination/messaging store, not a
+workflow database**, and right-sizing HQ should treat the rig DB as
+a separate problem with potentially different retention requirements.
+
+---
+
+## II. Churn rates
+
+### II.1 Per-day bead create rate (issues, by type, last 7 days)
+
+| Date | task | session | convoy | molecule | bug | chore | feature |
+|------|------|---------|--------|----------|-----|-------|---------|
+| 2026-05-16 | 7,023 | 5 | 5 | — | 4 | 4 | — |
+| 2026-05-17 | 7,339 | 2 | 12 | — | 1 | 4 | 3 |
+| 2026-05-18 | 2,031 | 6 | — | 2 | — | — | — |
+| 2026-05-19 | 12 | 20 | 4 | 3 | 2 | 4 | — |
+| 2026-05-20 | 17 | 41 | 3 | 1 | 2 | — | — |
+| 2026-05-21 | 31 | 21 | 1 | 2 | 2 | 3 | — |
+| 2026-05-22 | 16 | 16 | 3 | 3 | 3 | 15 | 1 |
+
+The May 14-18 task burst (~21k tasks over 4 days) is a one-off
+**migration / dispatch backfill**, not a steady-state rate. Steady
+state since May 19 is **~20 tasks/day** + **~20 sessions/day** with
+balanced close.
+
+### II.2 Per-day bead close rate (issues, last 7 days)
+
+| Date | task | session | convoy | molecule |
+|------|------|---------|--------|----------|
+| 2026-05-16 | 6,993 | 1 | 2 | — |
+| 2026-05-17 | 7,317 | — | — | — |
+| 2026-05-18 | 2,027 | 3 | — | — |
+| 2026-05-19 | 2 | 45 | 1 | — |
+| 2026-05-20 | 1 | 24 | 1 | — |
+| 2026-05-21 | 2 | 20 | 1 | — |
+| 2026-05-22 | — | 14 | 1 | — |
+
+Closes match creates within a day for the May 14-18 burst — strong
+evidence those 21k tasks were create-and-immediately-close
+automation output, not real work. Their ROWS will remain forever
+under the current retention policy (i.e., no retention).
+
+### II.3 Per-day wisp create rate (last 7 days)
+
+| Date | message | task (order-tracking) | Notes |
+|------|---------|----------------------|-------|
+| 2026-05-15 | 148 | — | |
+| 2026-05-16 | 353 | — | |
+| 2026-05-17 | 510 | — | |
+| 2026-05-18 | 56 | — | |
+| 2026-05-19 | 4 | — | |
+| 2026-05-20 | 92 | — | |
+| 2026-05-21 | 191 | 179 | order-tracking activity starts |
+| 2026-05-22 | 408 | **3,443** | sustained order-tracking rate |
+
+The order-tracking pipeline started producing wisps on May 21 (or
+earlier with a retention window narrow enough that we can't see the
+prior days from the wisp rows themselves). At **~3,500/day** it is
+the largest single producer of rows in the entire store.
+
+### II.4 Per-day wisp close rate (last 7 days)
+
+| Date | message | task |
+|------|---------|------|
+| 2026-05-15 | 18 | — |
+| 2026-05-16 | 111 | — |
+| 2026-05-17 | 3 | — |
+| 2026-05-19 | 254 | — |
+| 2026-05-20 | 29 | — |
+| 2026-05-21 | — | 179 |
+| 2026-05-22 | 2 | **3,438** |
+
+Order-tracking wisps close within hours of creation (24h TTL,
+roughly — see §III.2). Message wisps essentially **do not close**:
+408 created today, 2 closed today. The 2-vs-408 ratio is the
+unbounded-growth fingerprint.
+
+### II.5 Per-day audit-event rate (last 4-5 days, current retention window)
+
+| Date | issue events | wisp events |
+|------|-------------:|------------:|
+| 2026-05-18 | 24,307 | 8,936 |
+| 2026-05-19 | 22,014 | 1,343 |
+| 2026-05-20 | 17,230 | 6,911 |
+| 2026-05-21 | 5,610 | 12,163 |
+| 2026-05-22 | 6,846 | **17,936** |
+
+The May 18-20 issue-event surge is the tail of the May 14-18 task
+burst (created/updated/closed events for those tasks). The May 21-22
+wisp-event surge is the order-tracking pipeline starting up.
+
+### II.6 Top order producers (last 24 h)
+
+| Order | Wisps in last 24h | Notes |
+|-------|-------------------:|-------|
+| gate-sweep | 678 | runs every ~2 min |
+| beads-health | 669 | runs every ~2 min |
+| dolt-health | 638 | runs every ~2 min |
+| order-tracking-sweep | 509 | runs every ~3 min |
+| cross-rig-deps | 216 | runs every ~7 min |
+| orphan-sweep | 208 | runs every ~7 min |
+| spawn-storm-detect | 207 | runs every ~7 min |
+| mol-dog-jsonl | 88 | runs every ~16 min |
+| dolt-remotes-patrol | 84 | runs every ~17 min |
+| main-ci-watcher | 70 | runs every ~20 min |
+| maintainer-pr-review-queue | 49 | every ~30 min |
+| triager-poll | 47 | every ~30 min |
+| mol-dog-reaper | 47 | every ~30 min |
+| wisp-compact | 24 | every ~60 min |
+| pr-audit | 24 | every ~60 min |
+| mol-dog-phantom-db | 23 | every ~60 min |
+| daily-mpr-sweep | 23 | every ~60 min |
+| mol-dog-{stale-db, backup} | 4 each | every ~6 h |
+| prune-branches | 4 | every ~6 h |
+| daily-standup-* (×4 rigs) | 1 each | daily |
+| mol-dog-compactor, verify-standups | 1 each | daily |
+
+24.4 order-tracking wisps per **minute** (= 1,464/hour) when measured
+across the entire last hour.
+
+### II.7 Filesystem append rates
+
+- `.gc/events.jsonl`: 184 lines total. Growth quiet during this
+  observation window (most of those entries are city-resumed/suspended
+  + bead.created/closed from earlier sessions). Bounded by log
+  rotation.
+- `.beads/interactions.jsonl`: 5,606 lines. No reaper. Append rate
+  appears tied to bead-mutation rate via the hook layer; on a
+  high-mutation day, this file grows comparably to `events`.
+
+---
+
+## III. Unbounded-growth findings, ranked by severity
+
+### III.1 wisp_events orphans (severity: **highest**)
+
+- **47,334 rows, 21,445 (45 %) orphaned.**
+- Root cause: `wisp_events` has **no foreign-key constraint** to
+  `wisps`. When `wisp-compact` deletes a closed wisp, the wisp row
+  disappears but its ~5 audit rows in `wisp_events` remain.
+- Each wisp produces ~5 audit-event rows on its lifecycle (created,
+  label_added ×3, closed), so the orphan count grows in lockstep
+  with the deleted-wisp count.
+- At current rate (~3,500 wisps deleted/day × 5 events/wisp =
+  17.5 k orphan events/day):
+  - 30 days → 525 k orphan rows
+  - 90 days → 1.58 M
+  - 365 days → 6.4 M
+- The audit value of a wisp_event row from a deleted wisp is **zero**
+  by definition — the wisp it audits is gone. These rows are pure
+  dead-weight on the hottest write surface.
+
+### III.2 wisp_labels orphans (severity: **highest**, same root cause)
+
+- **23,106 rows, 10,706 (46 %) orphaned.**
+- Same root cause: `wisp_labels` has no FK to `wisps`.
+- ~3 labels per order-tracking wisp × ~3,500 deleted/day =
+  **10.5 k orphan labels/day** at the current sustained rate.
+- Indexed by `(issue_id, label)` and by `label` — the index also
+  carries the dead weight.
+
+### III.3 Closed-task pile on `issues` (severity: high, slower growth)
+
+- **21,286 closed tasks (91 % of issues table).**
+- Root cause: no retention policy on closed beads. Compaction
+  exists (`compact_tier1_days`, `compact_tier2_days` configured)
+  but `compaction_snapshots` has 0 rows — compaction is either
+  not running, not yet hitting tier thresholds, or not compacting
+  these.
+- Sustained creation rate (since the May 14-18 burst tapered off)
+  is ~20 tasks/day, so steady-state amortized growth is slow. But
+  episodic bursts (~7 k/day during dispatch backfills) can land
+  thousands in a single day with no plan to ever remove them.
+- Every closed task row also contributes 1 `created` + 1+ `updated`
+  + 1 `closed` event row to the `events` table. With the FK
+  cascade in place, deleting the task row WOULD clean those — but
+  nothing deletes them today.
+
+### III.4 Open mail messages on `wisps` (severity: high)
+
+- **2,365 open message wisps, oldest 15 days old.**
+- Create vs close: 408 / 2 on May 22 alone — **2 % archive rate**
+  on the day's incoming mail.
+- Root cause: no retention or auto-archive policy on mail. Each
+  agent's `gc mail inbox` does not auto-mark-read older items.
+- Projected growth at +200/day net: 30 d → +6 k, 90 d → +18 k,
+  365 d → +73 k. Worse if traffic increases.
+- Unlike order-tracking wisps, message wisps have semantic value
+  (notification of recent communication) for at least a few days.
+  Naive deletion is wrong; a tiered retention policy ("archive
+  read after 7 days, unread after 30") is the obvious shape.
+
+### III.5 `events` (issue audit log) (severity: medium)
+
+- **75,933 rows over 4-5 days = ~17 k events/day** sustained.
+- `events` HAS the FK cascade, so it would clean if closed issues
+  were ever deleted. They are not deleted, so the table grows
+  monotonically with issue creation.
+- Of the 75 k rows, ~52 k are `updated` events from the May 14-18
+  burst (bulk-updating 21 k tasks ~2.5 times each). Steady-state
+  growth is ~9 k events/day (= 1 created + ~1 updated + ~1 closed
+  per ~20 tasks/day, plus ~50 sessions/day × ~5 events each, plus
+  per-bead label-add events).
+- Projected at 9 k/day: 30 d → 270 k, 90 d → 810 k, 365 d → 3.3 M.
+
+### III.6 `.beads/interactions.jsonl` (severity: medium)
+
+- **5,606 lines, no reaper.**
+- File grows on every agent-mutation hook fire. Largely duplicates
+  the same field-change information already captured in the
+  `events` Dolt table, but indexed by *session-actor* (the gc agent
+  name) rather than the bead.
+- At observed rates the file gains roughly as many rows per day as
+  the issue `events` table (the hook is the same trigger). No
+  rotation today.
+
+### III.7 `.beads/backup/` (severity: medium, fix in flight)
+
+- Subject of open PR #2478 (`bd-backup-size` doctor canary). The
+  existence of the PR is sufficient documentation that the growth
+  pattern is recognized. Volume not measured here because the size
+  is sensitive to the backup retention policy currently being
+  changed.
+
+### III.8 Stale `.gc/beads.json` (severity: low, but a smell)
+
+- 14 KB file, last touched 2026-05-01, current date 2026-05-22 —
+  **21 days stale**. Seq is 21 (vs the Event Bus log's seq=184).
+- The file appears to be an orphan from an earlier export pipeline.
+  Either ratchet it (resume updates) or remove it. Not a growth
+  driver in itself, but a confusing artefact.
+
+---
+
+## IV. Entity-by-entity volume + churn matrix
+
+Compact reference for S5/S7. Rate units are "rows per day" measured
+on the current sustained steady state (not the May 14-18 burst).
+"Reaper" is the existing automatic cleanup mechanism; "Eff." is
+its observed effectiveness.
+
+| Entity (S1 §) | Population today | Create / day | Close / day | Reaper today | Eff. |
+|---|---:|---:|---:|---|---|
+| Task bead (I.1) | 21,417 (130 open) | ~20 | ~20 | none (closure ≠ deletion) | n/a |
+| Session bead (II.1) | 164 (47 open) | ~20 | ~20 | none on closed sessions | balanced create/close, accumulating closed |
+| Convoy (III.2) | 28 (22 open) | ~3 | ~1 | manual close on completion | OK |
+| Molecule (III.1) | 11 open | ~2 | (closes via cleanup logic) | molecule cleanup | OK |
+| Mail message wisp (IV.1) | 2,776 (2,365 open) | 200-500 | 0-50 | **none** | broken |
+| Order-tracking wisp (IV.2) | 3,623 (all closed) | **3,500** | ~3,500 | `wisp-compact` order | wisp row OK; labels/events leak |
+| Issue field-change event (IV.3) | 75,933 | ~9,000 | n/a (FK cascade only) | implicit cascade on bead delete | tied to bead deletion (never happens) |
+| Wisp field-change event (IV.3) | 47,334 (21,445 orphan) | ~17,000 | n/a | **none** (no FK) | **broken — 45 % orphans** |
+| System event (IV.4) | 184 in jsonl | variable | n/a | log rotation | OK |
+| Dependency (V.3, HQ) | 13 | <1 | n/a | implicit cascade | OK (HQ is shallow) |
+| Issue label (V.4) | 447 | ~50 | n/a | implicit cascade | OK |
+| Wisp label (V.4) | 23,106 (10,706 orphan) | ~10,500 | n/a | **none** (no FK) | **broken — 46 % orphans** |
+| Nudge queue item (V.5) | 0 today | bursts | per-delivery | dispatcher cleanup | OK |
+| Session-name lock (V.6) | 0 today | per-create | per-release | release on op | OK |
+| Rig route (VI.1) | 5 (jsonl) | <1 | rare | manual | OK |
+| Federation peer (VI.2) | 0 | <1 | rare | manual | OK |
+| bd memory `kv.memory.*` (VII.1) | 24 | <1 | manual `bd forget` | OK |
+| Custom status / type (VII.2) | 3 + 12 | <<1 | rare | manual | OK |
+| Counters (VII.3) | 11 | per-create | n/a | n/a (monotonic) | OK |
+| Compaction snapshot (VIII.1) | 0 | (not running on this rig) | n/a | tier-2 graduation | not active |
+| Issue snapshot (VIII.2) | 0 | feature unused | — | — | n/a |
+| Comment (VIII.3) | 6 issue + 0 wisp | ~0 | implicit cascade (issue side) | OK |
+| Repo mtime (VIII.4) | 0 | feature unused | — | — | n/a |
+| Maintainer-PR-review run state (IX.4) | per PR | per PR run | retention TBD by pack | TBD |
+| `.beads/interactions.jsonl` (IX.6) | 5,606 | ~9 k (matches `events`) | **none** | broken |
+| `.gc/beads.json` (IX.5) | 14 KB stale snapshot | n/a (orphaned) | n/a | unmaintained |
+| `.beads/backup/` (IX.9) | (PR #2478 in flight) | per-backup | retention TBD | in-fix |
+
+---
+
+## V. 30 / 90 / 365-day projection at sustained rates
+
+Assumes the May 21+ steady state (no more 21k-task bursts), no
+retention-policy changes, current order-tracking rate of ~3,500
+wisps/day.
+
+| Surface | Today | +30 d | +90 d | +365 d |
+|---|---:|---:|---:|---:|
+| `issues` (mostly closed tasks) | 23.4 k | +0.6 k → 24.0 k | +1.8 k → 25.2 k | +7.3 k → 30.7 k |
+| `wisps` (order-tracking; bounded by TTL) | 6.4 k | ≈ 4 k steady | ≈ 4 k | ≈ 4 k |
+| `wisps` (open message wisps, no reaper) | 2.4 k | +6 k → 8.4 k | +18 k → 20 k | +73 k → 75 k |
+| `events` (issue audit, FK cascade) | 75.9 k | +270 k → 346 k | +810 k → 886 k | +3.28 M → 3.36 M |
+| `wisp_events` (orphans + live) | 47.3 k | +525 k → 572 k | +1.58 M → 1.62 M | +6.4 M → 6.4 M |
+| `wisp_labels` (orphans + live) | 23.1 k | +315 k → 338 k | +945 k → 968 k | +3.83 M → 3.85 M |
+| `.beads/interactions.jsonl` | 5.6 k lines | +270 k → 276 k | +810 k | +3.28 M |
+
+These projections are **extrapolated from rates measured during a
+single 24-hour observation window** and so should be read as
+order-of-magnitude rather than exact. The qualitative shape (the
+wisp_events / wisp_labels / open-mail surfaces grow at orders of
+magnitude faster than the others) is robust.
+
+---
+
+## VI. Where to act, in priority order
+
+1. **Add foreign keys (or an explicit reaper) for `wisp_events` and
+   `wisp_labels`.** This is the single most-impactful change.
+   Removing the existing 32 k orphan rows would cut combined wisp-
+   audit storage by ~45 % overnight; preventing future orphans
+   removes the largest growth vector. Architecturally aligned with
+   the `events` / `labels` tables on the issue side, which already
+   work this way.
+2. **Add a retention policy for open mail messages**, separately for
+   read and unread. The current "no reaper" pattern produces
+   visible UX harm (overloaded inboxes) on top of the storage cost.
+3. **Verify compaction is actually running** (`compaction_snapshots`
+   has 0 rows despite config being present), or delete the
+   compaction columns + tables if the feature is dead.
+4. **Decide the fate of `.gc/beads.json`.** Either resume updating
+   it on every bead-mutation hook (matching the Event Bus seq), or
+   remove it.
+5. **Rotate / cap `.beads/interactions.jsonl`.** Largely duplicates
+   the `events` Dolt table; either delete it (and route hooks to
+   write the table) or apply log rotation.
+6. **Take action on PR #2478** (backup-size canary) so backup
+   growth has a documented bound.
+7. **Drop dead schema** identified in S1 §X: 9 unused columns on
+   `issues`, 6 entire empty tables. Zero data loss; cleaner schema
+   for whatever S7 lands on.
+
+---
+
+## VII. Anchors for S5 (durability matrix) and S7 (targets & retention)
+
+For each entity in S1, S2 has provided:
+
+- **A population** — so S5 can answer "how much must survive a
+  restart?" with a real number.
+- **A churn rate** — so S5 can compute a recovery-time budget for
+  losing N seconds of data.
+- **A reaper status** — so S7 can target retention policies at the
+  surfaces that need them.
+
+The matrix in §IV ranks reaper effectiveness as:
+- **OK** — close + delete or implicit cascade work, population
+  stable.
+- **Broken** — no reaper or no cascade, population unbounded.
+- **n/a** — entity is by-design append-only or single-row config.
+
+S5 should anchor durability requirements on **populations**, and
+crash-recovery requirements on **churn rates**. S7 must address
+the **broken** rows: wisp_events orphans, wisp_labels orphans,
+open mail messages, closed-task pile, and the
+`.beads/interactions.jsonl` log.


### PR DESCRIPTION
## Summary

Two-spike deliverable for parent epic **ga-aec8q** (HQ
coordination-state store discovery):

- **S1 (ga-aec8q.1) — Entity & lifecycle inventory**: tech-agnostic
  catalog of every kind of coordination state HQ persists. 935 lines.
- **S2 (ga-aec8q.2) — Volume & churn census**: per-entity row counts,
  rates, and dead-weight ratios. 488 lines.

S2 builds on S1's catalog and references it via `[[S1-entities]]`
links. Both files live under `docs/coordination-store/findings/`.

## S1 coverage

- **Work primitives** — task, chore, bug, feature, epic, step.
- **Runtime identity** — session (13+ states), agent, role, rig.
- **Workflow execution** — molecule, convoy, spec.
- **Communication** — mail message, order-tracking wisp, field-change
  event row (audit log), system event (Event Bus / `.gc/events.jsonl`).
- **Coordination & async dispatch** — gate, merge-request, dependency
  edge, label, nudge queue item, session-name lock, convergence.
- **Routing & sync** — rig route (prefix→path), federation peer.
- **Memory & config** — `kv.memory.*`, custom status/type, counter,
  project metadata, schema migration.
- **Snapshots & retention** — compaction snapshot, issue snapshot,
  comment, repo mtime.
- **Process-level filesystem state** — controller lock, Dolt
  server lock/port/log, pack runtime state, maintainer-PR-review run,
  `.gc/beads.json` cache, interactions log, hooks, backup.
- **Defined-but-unused surfaces** — 9 dead columns on `issues` +
  6 empty tables.
- **Derived views** — `ready_issues`, `blocked_issues`.

Each entity is given as Purpose / Producers / Updaters / Consumers /
Reaper / Lifecycle / **Intent (ephemeral vs durable)** / where-persisted-today.

## S2 headline findings

| Finding | Number |
|---|---|
| Most-populated table | `issues`, **23,373 rows**, of which **91 %** are closed tasks. |
| Single largest growth driver | `wisp_events` — **45 % of rows are orphans** because there's no FK to `wisps`. wisp-compact deletes the wisp but its audit rows linger. |
| Same problem, same root cause | `wisp_labels` — **46 % orphans**. |
| Highest sustained create rate | Order-tracking wisps — **24 per minute** (1,464/hr), ~3,500/day. |
| Most clearly unbounded user-facing entity | Open mail messages — **+200/day net** (2,365 open, oldest 15 days, no reaper). |

S2 includes per-day create/close rates per entity (last 7 days),
top-order-producer breakdown, 30/90/365-day projections at
sustained rate, and a prioritized action list for S7 (targets &
retention).

## Top recommendations (S2 §VI)

1. **Add FKs (or an explicit reaper) for `wisp_events` and
   `wisp_labels`.** Single highest-impact change — would clear
   32 k orphan rows overnight and remove the largest growth vector.
2. **Add a retention policy for open mail messages**, tiered by
   read/unread.
3. **Verify compaction is actually running** (`compaction_snapshots`
   has 0 rows despite config) or drop the columns/tables.
4. **Decide the fate of `.gc/beads.json`** (21-day-old stale cache).
5. **Rotate / cap `.beads/interactions.jsonl`** — largely duplicates
   the `events` Dolt table.
6. **Land PR #2478** (`bd-backup-size` canary) for `.beads/backup/`.
7. **Drop dead schema** identified in S1 §X.

## Test plan

- [ ] Architect (gascity/architect) skim for accuracy on architecture
      invariants.
- [ ] S3 / S4 / S5 / S6 author confirms cross-references at the
      bottom of each doc map cleanly onto their own findings.
- [ ] S7 author confirms the action priority list gives the right
      starting set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)