### PR TITLE
fix(extmsg): suppress target discriminator for routed recipient

### DIFF
--- a/internal/api/handler_extmsg.go
+++ b/internal/api/handler_extmsg.go
@@ -105,6 +105,7 @@ func (s *Server) extmsgNotifyMembers(
 		return
 	}
 	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "extmsg-notify"}
+	explicitTargetSessionID := extmsgNotifyExplicitTargetSessionID(ctx, svc, conv, explicitTarget)
 	members, err := svc.Transcript.ListMemberships(ctx, caller, conv)
 	if err != nil {
 		log.Printf("extmsg: ListMemberships failed for %s/%s: %v", conv.Provider, conv.ConversationID, err)
@@ -125,13 +126,16 @@ func (s *Server) extmsgNotifyMembers(
 	notifyResolved := func(sessionSelector, resolvedID string) {
 		handle := s.extmsgSessionHandleForResolvedID(resolvedID, sessionSelector)
 		nudge := formatExtmsgNotifyReminder(extmsgNotifyReminder{
-			Provider:       conv.Provider,
-			ConversationID: conv.ConversationID,
-			ActorDisplay:   actorDisplayName,
-			ActorKind:      actorKind,
-			Text:           text,
-			Handle:         handle,
-			ExplicitTarget: explicitTarget,
+			Provider:                conv.Provider,
+			ConversationID:          conv.ConversationID,
+			ActorDisplay:            actorDisplayName,
+			ActorKind:               actorKind,
+			Text:                    text,
+			RecipientSelector:       sessionSelector,
+			RecipientSessionID:      resolvedID,
+			Handle:                  handle,
+			ExplicitTarget:          explicitTarget,
+			ExplicitTargetSessionID: explicitTargetSessionID,
 		})
 		if err := s.sendBackgroundMessageToSession(ctx, store, resolvedID, nudge); err != nil {
 			log.Printf("extmsg: notify %s failed: %v", sessionSelector, err)
@@ -171,6 +175,24 @@ func (s *Server) extmsgNotifyMembers(
 	wg.Wait()
 }
 
+func extmsgNotifyExplicitTargetSessionID(ctx context.Context, svc *extmsg.Services, conv extmsg.ConversationRef, explicitTarget string) string {
+	if strings.TrimSpace(explicitTarget) == "" || svc == nil || svc.Groups == nil {
+		return ""
+	}
+	route, err := svc.Groups.ResolveInbound(ctx, extmsg.ExternalInboundMessage{
+		Conversation:   conv,
+		ExplicitTarget: explicitTarget,
+	})
+	if err != nil {
+		log.Printf("extmsg: resolve explicit target %q for %s/%s failed: %v", explicitTarget, conv.Provider, conv.ConversationID, err)
+		return ""
+	}
+	if route == nil || route.Match != extmsg.GroupRouteExplicitTarget {
+		return ""
+	}
+	return strings.TrimSpace(route.TargetSessionID)
+}
+
 func (s *Server) extmsgNotifyInboundMembers(ctx context.Context, msg extmsg.ExternalInboundMessage) {
 	actorKind := "agent"
 	if !msg.Actor.IsBot {
@@ -202,18 +224,21 @@ func titleCaseProvider(name string) string {
 //
 // ExplicitTarget carries the provider-resolved address-by-handle target (set
 // when an inbound was addressed to a specific agent via @handle: prefix or a
-// subteam mention). When non-empty and not equal to the receiving member's
-// own Handle, formatExtmsgNotifyReminder emits a "do not reply" discriminator
-// line so peer sessions can self-silence on off-target messages. See
+// subteam mention). When non-empty and not routed to the receiving session,
+// formatExtmsgNotifyReminder emits a "do not reply" discriminator line so
+// peer sessions can self-silence on off-target messages. See
 // gastownhall/gascity#2484.
 type extmsgNotifyReminder struct {
-	Provider       string
-	ConversationID string
-	ActorDisplay   string
-	ActorKind      string
-	Text           string
-	Handle         string
-	ExplicitTarget string
+	Provider                string
+	ConversationID          string
+	ActorDisplay            string
+	ActorKind               string
+	Text                    string
+	RecipientSelector       string
+	RecipientSessionID      string
+	Handle                  string
+	ExplicitTarget          string
+	ExplicitTargetSessionID string
 }
 
 // formatExtmsgNotifyReminder builds the inbound-message reminder body.
@@ -224,7 +249,7 @@ type extmsgNotifyReminder struct {
 // injecting attacker-controlled instructions into the receiving agent's
 // prompt. See gastownhall/gascity#2195.
 //
-// When ExplicitTarget is non-empty and does not match the receiving Handle,
+// When ExplicitTarget is non-empty and does not target the receiving session,
 // a discriminator line is appended so peer sessions can self-silence on
 // messages addressed to a different agent. See gastownhall/gascity#2484.
 func formatExtmsgNotifyReminder(r extmsgNotifyReminder) string {
@@ -240,7 +265,7 @@ func formatExtmsgNotifyReminder(r extmsgNotifyReminder) string {
 		r.Provider, r.ConversationID,
 		safeActor, r.ActorKind, safeText,
 	)
-	if target := strings.TrimSpace(r.ExplicitTarget); target != "" && !strings.EqualFold(target, strings.TrimSpace(r.Handle)) {
+	if target := strings.TrimSpace(r.ExplicitTarget); target != "" && !extmsgNotifyReminderTargetsRecipient(r, target) {
 		safeTarget := extmsg.SanitizeForSystemReminder(target)
 		fmt.Fprintf(&b,
 			"Addressed to: @%s — if that is not you, do not reply.\n\n",
@@ -257,4 +282,12 @@ func formatExtmsgNotifyReminder(r extmsgNotifyReminder) string {
 		r.Handle,
 	)
 	return b.String()
+}
+
+func extmsgNotifyReminderTargetsRecipient(r extmsgNotifyReminder, target string) bool {
+	if targetSessionID := strings.TrimSpace(r.ExplicitTargetSessionID); targetSessionID != "" {
+		return strings.TrimSpace(r.RecipientSessionID) == targetSessionID ||
+			apiNormalizeSessionTarget(r.RecipientSelector) == apiNormalizeSessionTarget(targetSessionID)
+	}
+	return strings.EqualFold(target, strings.TrimSpace(r.Handle))
 }

--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -202,6 +203,81 @@ func TestExtmsgNotifyMembersDoesNotMaterializeExcludedNamedSender(t *testing.T) 
 		if call.Method == "Nudge" {
 			t.Fatalf("excluded sender should not receive nudge; calls=%#v", fs.sp.Calls)
 		}
+	}
+}
+
+func TestExtmsgNotifyMembersSuppressesDiscriminatorForRoutedParticipant(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+
+	services := extmsg.NewServices(fs.cityBeadStore)
+	fs.extmsgSvc = &services
+
+	ref := extmsg.ConversationRef{
+		ScopeID:        "guild-1",
+		Provider:       "discord",
+		AccountID:      "acct-1",
+		ConversationID: "thread-1",
+		Kind:           extmsg.ConversationThread,
+	}
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	group, err := services.Groups.EnsureGroup(context.Background(), caller, extmsg.EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             extmsg.GroupModeLauncher,
+		DefaultHandle:    "project-lead",
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+
+	mayor := createTestSession(t, fs.cityBeadStore, fs.sp, "Mayor")
+	if err := fs.cityBeadStore.Update(mayor.ID, beads.UpdateOpts{
+		Metadata: map[string]string{"alias": "myrig/mayor-worker"},
+	}); err != nil {
+		t.Fatalf("Update(mayor alias): %v", err)
+	}
+	peer := createTestSession(t, fs.cityBeadStore, fs.sp, "Project Lead")
+	if err := fs.cityBeadStore.Update(peer.ID, beads.UpdateOpts{
+		Metadata: map[string]string{"alias": "myrig/project-lead"},
+	}); err != nil {
+		t.Fatalf("Update(peer alias): %v", err)
+	}
+
+	if _, err := services.Groups.UpsertParticipant(context.Background(), caller, extmsg.UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "mayor",
+		SessionID: mayor.ID,
+		Public:    true,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant(mayor): %v", err)
+	}
+	if _, err := services.Groups.UpsertParticipant(context.Background(), caller, extmsg.UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "project-lead",
+		SessionID: peer.ID,
+		Public:    true,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant(project-lead): %v", err)
+	}
+
+	srv.extmsgNotifyMembers(context.Background(), ref, "Alice", "human", "@mayor: status?", "", "mayor")
+
+	nudgesBySessionName := map[string]string{}
+	for _, call := range fs.sp.Calls {
+		if call.Method == "Nudge" {
+			nudgesBySessionName[call.Name] = call.Message
+		}
+	}
+	mayorNudge := nudgesBySessionName[mayor.SessionName]
+	if mayorNudge == "" {
+		t.Fatalf("missing mayor nudge; calls=%#v", fs.sp.Calls)
+	}
+	if strings.Contains(mayorNudge, "Addressed to:") {
+		t.Fatalf("addressed participant saw discriminator:\n%s", mayorNudge)
+	}
+	peerNudge := nudgesBySessionName[peer.SessionName]
+	if !strings.Contains(peerNudge, "Addressed to: @mayor") {
+		t.Fatalf("peer nudge missing discriminator; peer=%q calls=%#v", peerNudge, fs.sp.Calls)
 	}
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/gastownhall/gascity/pull/2489.

Original PR title: fix(extmsg): thread ExplicitTarget through member-broadcast reminder so bound sessions can self-silence
Original PR state: MERGED
Configured base: main
Original GitHub base: main
Base mismatch: none

The original contribution has already landed on main. This follow-up carries the maintainer-side review fix from the adoption workflow: the explicit-target discriminator is suppressed for the routed recipient by session identity, while off-target peer reminders still include the self-silencing line.

Maintainer validation:
- Base refresh replayed the maintainer-only patch onto current main.
- `go test ./internal/api -run 'TestExtmsgNotifyMembersSuppressesDiscriminatorForRoutedParticipant|TestHandleExtMsgInbound|TestHandleExtMsgOutbound|TestFormatExtmsgNotifyReminder'`
- Adoption review attempt 2 approved the final behavior.

Adopted via `/adopt-pr` workflow for #2489. Original contributor commits are preserved in the already-merged PR; this PR contains only the maintainer follow-up fix.