### PR TITLE
feat(doctor): bd-backup-size canary catches unbounded .beads/backup growth

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -236,7 +236,7 @@ func doDoctor(fix, verbose, jsonOut bool, stdout, stderr io.Writer) int {
 	// gascity, gastownhall/beads#2993) writes to .beads/backup/ on every bd
 	// invocation without retention. This check warns before the directory
 	// fills the disk and cascades into broken dolt writes.
-	d.Register(doctor.NewBdBackupSizeCheck(cityPath))
+	d.Register(doctor.NewBdBackupSizeCheckForConfig(cityPath, cfg, cfgErr))
 	// Worktree checks deliberately run even when cfgErr != nil — they
 	// only need the city path, and a broken city.toml is exactly when
 	// silent disk-fill is most likely. The zero-value DoctorConfig

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -232,6 +232,11 @@ func doDoctor(fix, verbose, jsonOut bool, stdout, stderr io.Writer) int {
 	d.Register(doctor.NewScopedDoltVersionCheckForConfig(cityPath, skipManagedDoltCheck, cfg, cfgErr))
 	d.Register(&doctor.EventsLogCheck{})
 	d.Register(doctor.NewEventLogSizeCheck())
+	// bd auto-backup growth canary. bd's auto-backup pipeline (upstream of
+	// gascity, gastownhall/beads#2993) writes to .beads/backup/ on every bd
+	// invocation without retention. This check warns before the directory
+	// fills the disk and cascades into broken dolt writes.
+	d.Register(doctor.NewBdBackupSizeCheck(cityPath))
 	// Worktree checks deliberately run even when cfgErr != nil — they
 	// only need the city path, and a broken city.toml is exactly when
 	// silent disk-fill is most likely. The zero-value DoctorConfig

--- a/docs/troubleshooting/bd-backup-cleanup.md
+++ b/docs/troubleshooting/bd-backup-cleanup.md
@@ -1,0 +1,171 @@
+---
+title: bd Auto-Backup Cleanup
+description: Reclaim space when bd's `.beads/backup/` directory grows large enough to threaten disk pressure.
+---
+
+## Overview
+
+`bd` (the beads CLI) maintains a Dolt-native backup of every workspace it
+touches. The backup writes to `<root>/.beads/backup/` on a hardcoded
+remote named `backup_export`, throttled to one sync per fifteen minutes
+per bd process (`gastownhall/beads`: `cmd/bd/backup_auto.go`).
+
+The backup remote is **append-only**. There is no retention, rotation,
+or garbage-collection logic in the bd auto-backup path today; the
+architectural redesign for snapshot collections is tracked at
+[gastownhall/beads#2993](https://github.com/gastownhall/beads/issues/2993).
+Over weeks of normal use the directory grows monotonically — and in busy
+multi-agent cities (where every controller, agent, and order touches
+bd), the growth is fast enough to fill the disk in days.
+
+`gc doctor` emits a `bd-backup-size` warning at 5 GB and an error at
+15 GB to catch this before the next cascade.
+
+## Why it matters — the disk-full cascade
+
+`bd auto-backup`'s unbounded growth was the proximate root cause of a
+multi-hour outage on 2026-05-20/21 (qlandia incident, `qlandia/gc-p831i`):
+
+1. `.beads/backup/` hit 34 GB and filled the disk.
+2. Dolt's mmap writes started returning `ENOSPC`.
+3. Dolt entered a 95% CPU retry loop that **did not** recover when disk
+   was freed.
+4. Gas City's supervisor reconciler wedged on Dolt writes; named agents
+   stuck `stopped`; recovery flags stuck.
+5. Recovery required SIGTERM-to-dolt, supervisor restart, plist
+   regeneration, and session-kill of every named-always agent — two days
+   of disruption.
+
+The gas-city-side amplifier (auto-recover-on-ENOSPC) was fixed in
+[gastownhall/gascity#2347](https://github.com/gastownhall/gascity/pull/2347).
+This doc covers the still-live bd-side root cause.
+
+## Inspect
+
+When `gc doctor` flags `bd-backup-size`, first inspect the directory:
+
+```bash
+du -sh ~/qlandia/.beads/backup       # total size
+ls -lh ~/qlandia/.beads/backup       # file mix (.darc vs nbs_table_*)
+cat ~/qlandia/.beads/backup/backup_state.json  # last sync watermark
+```
+
+You're looking for:
+
+- A current `last_dolt_commit` in `backup_state.json` (within minutes of
+  now). If the backup is current, you can rotate it safely.
+- A mix of `.darc` archive files (one per conjoined chunk) and
+  `nbs_table_*` files (raw uncompacted writes). Many `nbs_table_*` files
+  indicate that conjoin has been failing — see "Atomicity / sync
+  failure" below.
+
+## Cleanup options
+
+### Option A — disable bd auto-backup (least invasive)
+
+If the only consumer of `.beads/backup/` was the implicit auto-backup,
+turn it off and let `mol-dog-backup` (which writes to `.dolt-backup/`)
+handle backups instead:
+
+```bash
+bd config set backup.enabled false
+```
+
+After this, you can `rm -rf .beads/backup/`. Verify next `gc doctor` run
+that `bd-backup-size` reports `no bd backup directory present`.
+
+You retain coverage from `mol-dog-backup` writing to `.dolt-backup/`,
+which is run by the dolt pack on a 6h cooldown and is operator-managed
+through gas-city.
+
+### Option B — rotate the backup (preserve coverage)
+
+Use this when you want to keep auto-backup running but reclaim the
+accumulated bloat.
+
+> **Risk**: bd auto-backup is non-atomic
+> ([gastownhall/beads#4070](https://github.com/gastownhall/beads/issues/4070)).
+> Mid-sync interruption can leave a broken backup. Schedule rotation at
+> a quiet moment and verify the result.
+
+```bash
+# 1. Stop the supervisor so no agent is writing beads.
+gc stop
+
+# 2. Capture the existing backup as a safety net.
+mv ~/qlandia/.beads/backup ~/qlandia/.beads/backup.old-$(date +%Y%m%d)
+
+# 3. Re-sync — bd will register backup_export on next invocation and
+#    sync the current (post-GC) database state to the empty directory.
+gc start
+bd backup       # forces an immediate sync, dumps current size
+
+# 4. Verify the new backup is sane.
+du -sh ~/qlandia/.beads/backup        # should be ≲ source database size
+cat ~/qlandia/.beads/backup/backup_state.json  # current timestamp
+
+# 5. After confirming a clean run for ~1 day, delete the safety net.
+rm -rf ~/qlandia/.beads/backup.old-*
+```
+
+### Option C — operator wipe (when the database has shrunk hard)
+
+After running `dolt gc --full` on the source database (see
+[dolt-bloat-recovery.md](dolt-bloat-recovery.md)), the source's noms
+directory shrinks but the backup remote does not. The full backup
+chain — every chunk ever written — is still on disk in
+`.beads/backup/`.
+
+If you've just run a source GC and have a verified safety copy of the
+data, Option B's wipe-and-resync is the only mechanism that propagates
+the GC into the backup.
+
+## Atomicity / sync failure
+
+If you see every bd command print
+
+```
+Warning: auto-backup failed: sync to backup: sync backup backup_export:
+Error 1105: error opening table file: table file not found:
+/path/to/.beads/backup/<chunk-hash>
+```
+
+you've hit [gastownhall/beads#4070](https://github.com/gastownhall/beads/issues/4070):
+the backup manifest references chunks that were never delivered. Manual
+repair until upstream lands a fix:
+
+```bash
+# Identify missing chunks
+python3 -c "
+import os, sys
+manifest = open(os.path.expanduser('~/qlandia/.beads/backup/manifest')).read()
+parts = manifest.strip().split(':')
+chunks = [parts[i] for i in range(5, len(parts), 2)]
+existing = set(
+    f.replace('.darc', '') for f in os.listdir(os.path.expanduser('~/qlandia/.beads/backup/'))
+    if f.endswith('.darc')
+)
+missing = [c for c in chunks if c not in existing]
+for c in missing:
+    print(c)
+"
+# Then copy each missing chunk from the live noms store:
+#   cp ~/qlandia/.beads/dolt/<db>/.dolt/noms/<hash> ~/qlandia/.beads/backup/
+```
+
+## Prevention
+
+- **Track [gastownhall/beads#2993](https://github.com/gastownhall/beads/issues/2993).**
+  The architectural fix is snapshot-collection semantics with explicit
+  retention. Until it lands, every bd-driven city accumulates this
+  bloat.
+- **Run `gc doctor` regularly.** The `bd-backup-size` canary fires at
+  5 GB warn, 15 GB error — well before disk pressure breaks Dolt.
+- **Prefer `mol-dog-backup`'s `.dolt-backup/` path** for primary backup
+  coverage. It's operator-managed through gas-city, runs on a 6h
+  cooldown rather than per-command, and is the one targeted by
+  retention work in `gastownhall/gascity`.
+- **Watch `gc doctor` for `dolt-noms-size` alongside this check.** Both
+  surfaces grow together on busy cities; treating them as a single
+  disk-pressure signal works better than reasoning about each in
+  isolation.

--- a/docs/troubleshooting/bd-backup-cleanup.md
+++ b/docs/troubleshooting/bd-backup-cleanup.md
@@ -19,7 +19,9 @@ multi-agent cities (where every controller, agent, and order touches
 bd), the growth is fast enough to fill the disk in days.
 
 `gc doctor` emits a `bd-backup-size` warning at 5 GB and an error at
-15 GB to catch this before the next cascade.
+15 GB to catch this before the next cascade. The canary checks the city
+workspace and managed rig scope roots, reporting the largest individual
+`.beads/backup/` directory and the aggregate backup footprint.
 
 ## Why it matters — the disk-full cascade
 
@@ -95,16 +97,20 @@ gc stop
 # 2. Capture the existing backup as a safety net.
 mv ~/qlandia/.beads/backup ~/qlandia/.beads/backup.old-$(date +%Y%m%d)
 
-# 3. Re-sync — bd will register backup_export on next invocation and
-#    sync the current (post-GC) database state to the empty directory.
-gc start
-bd backup       # forces an immediate sync, dumps current size
+# 3. Trigger bd's auto-backup pipeline while the supervisor remains
+#    stopped. Do not use `bd backup sync` here; that syncs the separate
+#    explicit "default" backup remote, not the auto-backup `backup_export`
+#    remote documented above.
+bd -C ~/qlandia list --status open --limit 1 --json >/tmp/qlandia-bd-autobackup-smoke.json
 
 # 4. Verify the new backup is sane.
 du -sh ~/qlandia/.beads/backup        # should be ≲ source database size
 cat ~/qlandia/.beads/backup/backup_state.json  # current timestamp
 
-# 5. After confirming a clean run for ~1 day, delete the safety net.
+# 5. Restart the supervisor only after the first backup is known good.
+gc start
+
+# 6. After confirming a clean run for ~1 day, delete the safety net.
 rm -rf ~/qlandia/.beads/backup.old-*
 ```
 
@@ -141,14 +147,18 @@ import os, sys
 manifest = open(os.path.expanduser('~/qlandia/.beads/backup/manifest')).read()
 parts = manifest.strip().split(':')
 chunks = [parts[i] for i in range(5, len(parts), 2)]
-existing = set(
-    f.replace('.darc', '') for f in os.listdir(os.path.expanduser('~/qlandia/.beads/backup/'))
-    if f.endswith('.darc')
-)
+existing = set()
+for f in os.listdir(os.path.expanduser('~/qlandia/.beads/backup/')):
+    if f.endswith('.darc'):
+        existing.add(f[:-len('.darc')])
 missing = [c for c in chunks if c not in existing]
 for c in missing:
     print(c)
 "
+# If nbs_table_* files are present, treat the output as a candidate
+# list and cross-check with bd backup status or Dolt tooling before
+# copying. Raw table files can contain valid chunks that are not visible
+# as standalone .darc files.
 # Then copy each missing chunk from the live noms store:
 #   cp ~/qlandia/.beads/dolt/<db>/.dolt/noms/<hash> ~/qlandia/.beads/backup/
 ```

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -2207,7 +2207,7 @@ func duDirBytes(root string) (int64, bool, error) {
 	if ctx.Err() == context.DeadlineExceeded {
 		total, exists, fallbackErr := boundedSumDirBytes(root)
 		if fallbackErr != nil {
-			return 0, true, fmt.Errorf("measure dolt data dir: du -sk timed out after %s; fallback walk: %w", doltDirMeasureTimeout, fallbackErr)
+			return 0, true, fmt.Errorf("measure directory: du -sk timed out after %s; fallback walk: %w", doltDirMeasureTimeout, fallbackErr)
 		}
 		return total, exists, nil
 	}
@@ -2215,16 +2215,16 @@ func duDirBytes(root string) (int64, bool, error) {
 		if errors.Is(err, exec.ErrNotFound) {
 			return boundedSumDirBytes(root)
 		}
-		return 0, true, fmt.Errorf("measure dolt data dir with du -sk: %w", err)
+		return 0, true, fmt.Errorf("measure directory with du -sk: %w", err)
 	}
 
 	fields := strings.Fields(string(out))
 	if len(fields) == 0 {
-		return 0, true, fmt.Errorf("measure dolt data dir with du -sk: empty output")
+		return 0, true, fmt.Errorf("measure directory with du -sk: empty output")
 	}
 	kb, err := strconv.ParseInt(fields[0], 10, 64)
 	if err != nil {
-		return 0, true, fmt.Errorf("measure dolt data dir with du -sk: parse %q: %w", fields[0], err)
+		return 0, true, fmt.Errorf("measure directory with du -sk: parse %q: %w", fields[0], err)
 	}
 	return kb * 1024, true, nil
 }

--- a/internal/doctor/checks_bd_backup_size.go
+++ b/internal/doctor/checks_bd_backup_size.go
@@ -1,0 +1,111 @@
+package doctor
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// bd auto-backup growth thresholds. bd's PersistentPostRun-driven
+// auto-backup writes to a single hardcoded "backup_export" Dolt remote
+// at <root>/.beads/backup/ on every bd invocation (15-minute throttle).
+// There is no retention or rotation logic upstream
+// (gastownhall/beads#2993), so the directory grows unbounded.
+//
+// Real-world cascade reference: qlandia gc-p831i, 2026-05-20/21 — the
+// directory reached 34 GB and filled the disk, which broke dolt writes
+// and amplified into a multi-hour outage. Warn well below that.
+const (
+	bdBackupWarnBytes  = int64(5) * 1024 * 1024 * 1024  // 5 GB
+	bdBackupErrorBytes = int64(15) * 1024 * 1024 * 1024 // 15 GB
+)
+
+// BdBackupSizeCheck warns when bd's auto-backup directory has grown
+// large enough to risk a disk-full cascade.
+//
+// Upstream context: gastownhall/beads#2993 (snapshot-collection
+// redesign), #4070 (non-atomic sync), #3522/#3501/#3878 (auto-backup
+// race/config bugs). Until the upstream fix lands, operators rely on
+// this canary to catch the growth early.
+//
+// The check is intentionally narrow: it scans <city>/.beads/backup/,
+// the canonical city-level auto-backup destination. Rig-scoped bd
+// installations have their own .beads/backup/ subdirectories; extending
+// the scan to those is straightforward when an operator needs it.
+type BdBackupSizeCheck struct {
+	cityPath   string
+	measureDir func(string) (int64, bool, error)
+}
+
+// NewBdBackupSizeCheck creates a size check against
+// <cityPath>/.beads/backup/.
+func NewBdBackupSizeCheck(cityPath string) *BdBackupSizeCheck {
+	return &BdBackupSizeCheck{cityPath: cityPath, measureDir: duDirBytes}
+}
+
+// Name returns the check identifier.
+func (c *BdBackupSizeCheck) Name() string { return "bd-backup-size" }
+
+// Run measures the bd auto-backup directory and compares against
+// warning/error thresholds.
+func (c *BdBackupSizeCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+
+	backupDir := filepath.Join(c.cityPath, ".beads", "backup")
+	if info, err := os.Stat(backupDir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			r.Status = StatusOK
+			r.Message = "no bd backup directory present"
+			return r
+		}
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("stat bd backup dir: %v", err)
+		return r
+	} else if !info.IsDir() {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("%s is not a directory", backupDir)
+		return r
+	}
+
+	measure := c.measureDir
+	if measure == nil {
+		measure = duDirBytes
+	}
+	bytes, _, err := measure(backupDir)
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("measure bd backup dir: %v", err)
+		return r
+	}
+
+	size := formatGB(bytes)
+	switch {
+	case bytes >= bdBackupErrorBytes:
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("bd auto-backup directory is %s — excessive; cleanup recommended", size)
+		r.FixHint = bdBackupFixHint()
+	case bytes >= bdBackupWarnBytes:
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("bd auto-backup directory is %s — approaching threshold", size)
+		r.FixHint = bdBackupFixHint()
+	default:
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("bd auto-backup directory is %s", size)
+	}
+	return r
+}
+
+// CanFix returns false. Backup cleanup has nontrivial atomicity
+// concerns (gastownhall/beads#4070) and the right cleanup is operator
+// policy: rotate-and-recreate vs prune-stale-by-manifest vs disable
+// auto-backup. We surface the size; the operator picks the recipe.
+func (c *BdBackupSizeCheck) CanFix() bool { return false }
+
+// Fix is a no-op. See CanFix.
+func (c *BdBackupSizeCheck) Fix(_ *CheckContext) error { return nil }
+
+func bdBackupFixHint() string {
+	return "see docs/troubleshooting/bd-backup-cleanup.md"
+}

--- a/internal/doctor/checks_bd_backup_size.go
+++ b/internal/doctor/checks_bd_backup_size.go
@@ -6,6 +6,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // bd auto-backup growth thresholds. bd's PersistentPostRun-driven
@@ -30,71 +33,175 @@ const (
 // race/config bugs). Until the upstream fix lands, operators rely on
 // this canary to catch the growth early.
 //
-// The check is intentionally narrow: it scans <city>/.beads/backup/,
-// the canonical city-level auto-backup destination. Rig-scoped bd
-// installations have their own .beads/backup/ subdirectories; extending
-// the scan to those is straightforward when an operator needs it.
+// The check scans the city and all managed rig scope roots, because each bd
+// workspace root can maintain its own .beads/backup/ auto-backup directory.
 type BdBackupSizeCheck struct {
 	cityPath   string
 	measureDir func(string) (int64, bool, error)
+	scopeRoots []string
 }
 
-// NewBdBackupSizeCheck creates a size check against
-// <cityPath>/.beads/backup/.
+// NewBdBackupSizeCheck creates a size check against managed
+// <scope>/.beads/backup/ directories.
 func NewBdBackupSizeCheck(cityPath string) *BdBackupSizeCheck {
 	return &BdBackupSizeCheck{cityPath: cityPath, measureDir: duDirBytes}
+}
+
+// NewBdBackupSizeCheckForConfig creates a size check using preloaded city
+// config to avoid reparsing city.toml during doctor registration.
+func NewBdBackupSizeCheckForConfig(cityPath string, cfg *config.City, cfgErr error) *BdBackupSizeCheck {
+	return &BdBackupSizeCheck{
+		cityPath:   cityPath,
+		measureDir: duDirBytes,
+		scopeRoots: managedDoltScopeRootsForConfig(cityPath, cfg, cfgErr),
+	}
 }
 
 // Name returns the check identifier.
 func (c *BdBackupSizeCheck) Name() string { return "bd-backup-size" }
 
-// Run measures the bd auto-backup directory and compares against
+// Run measures the bd auto-backup directories and compares them against
 // warning/error thresholds.
 func (c *BdBackupSizeCheck) Run(_ *CheckContext) *CheckResult {
 	r := &CheckResult{Name: c.Name()}
-
-	backupDir := filepath.Join(c.cityPath, ".beads", "backup")
-	if info, err := os.Stat(backupDir); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			r.Status = StatusOK
-			r.Message = "no bd backup directory present"
-			return r
-		}
-		r.Status = StatusWarning
-		r.Message = fmt.Sprintf("stat bd backup dir: %v", err)
-		return r
-	} else if !info.IsDir() {
-		r.Status = StatusWarning
-		r.Message = fmt.Sprintf("%s is not a directory", backupDir)
-		return r
-	}
 
 	measure := c.measureDir
 	if measure == nil {
 		measure = duDirBytes
 	}
-	bytes, _, err := measure(backupDir)
-	if err != nil {
-		r.Status = StatusWarning
-		r.Message = fmt.Sprintf("measure bd backup dir: %v", err)
+
+	var (
+		worstTarget bdBackupScanTarget
+		worstBytes  int64
+		totalBytes  int64
+		existsCount int
+	)
+	targets := c.backupScanTargets()
+	for _, target := range targets {
+		if info, err := os.Stat(target.BackupDir); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			r.Status = StatusWarning
+			r.Message = fmt.Sprintf("stat bd backup dir for %s: %v", target.Label, err)
+			return r
+		} else if !info.IsDir() {
+			r.Status = StatusWarning
+			r.Message = fmt.Sprintf("%s for %s is not a directory", target.BackupDir, target.Label)
+			return r
+		}
+
+		bytes, exists, err := measure(target.BackupDir)
+		if err != nil {
+			r.Status = StatusWarning
+			r.Message = fmt.Sprintf("measure bd backup dir for %s: %v", target.Label, err)
+			return r
+		}
+		if !exists {
+			continue
+		}
+		existsCount++
+		totalBytes += bytes
+		if bytes > worstBytes {
+			worstBytes = bytes
+			worstTarget = target
+		}
+	}
+
+	if existsCount == 0 {
+		scopeNoun := "managed scopes"
+		if len(targets) == 1 {
+			scopeNoun = "managed scope"
+		}
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("no bd backup directory present across %d %s", len(targets), scopeNoun)
 		return r
 	}
 
-	size := formatGB(bytes)
+	size := formatGB(worstBytes)
+	scopeNote := ""
+	if existsCount > 1 {
+		scopeNote = fmt.Sprintf(" (largest of %d backup directories)", existsCount)
+	}
 	switch {
-	case bytes >= bdBackupErrorBytes:
+	case worstBytes >= bdBackupErrorBytes:
 		r.Status = StatusError
-		r.Message = fmt.Sprintf("bd auto-backup directory is %s — excessive; cleanup recommended", size)
+		r.Message = fmt.Sprintf("bd auto-backup directory for %s is %s%s — excessive; cleanup recommended", worstTarget.Label, size, scopeNote)
 		r.FixHint = bdBackupFixHint()
-	case bytes >= bdBackupWarnBytes:
+	case totalBytes >= bdBackupErrorBytes:
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("aggregate bd auto-backup footprint is %s across %d backup directories — excessive; cleanup recommended", formatGB(totalBytes), existsCount)
+		r.FixHint = bdBackupFixHint()
+	case worstBytes >= bdBackupWarnBytes:
 		r.Status = StatusWarning
-		r.Message = fmt.Sprintf("bd auto-backup directory is %s — approaching threshold", size)
+		r.Message = fmt.Sprintf("bd auto-backup directory for %s is %s%s — approaching threshold", worstTarget.Label, size, scopeNote)
+		r.FixHint = bdBackupFixHint()
+	case totalBytes >= bdBackupWarnBytes:
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("aggregate bd auto-backup footprint is %s across %d backup directories — approaching threshold", formatGB(totalBytes), existsCount)
 		r.FixHint = bdBackupFixHint()
 	default:
 		r.Status = StatusOK
-		r.Message = fmt.Sprintf("bd auto-backup directory is %s", size)
+		if existsCount > 1 {
+			r.Message = fmt.Sprintf("aggregate bd auto-backup footprint is %s across %d backup directories (largest %s: %s)", formatGB(totalBytes), existsCount, worstTarget.Label, size)
+		} else {
+			r.Message = fmt.Sprintf("bd auto-backup directory for %s is %s", worstTarget.Label, size)
+		}
 	}
 	return r
+}
+
+type bdBackupScanTarget struct {
+	Label     string
+	BackupDir string
+}
+
+func (c *BdBackupSizeCheck) backupScanTargets() []bdBackupScanTarget {
+	scopeRoots := c.scopeRoots
+	if len(scopeRoots) == 0 {
+		scopeRoots = managedDoltScopeRoots(c.cityPath)
+	}
+	if len(scopeRoots) == 0 {
+		scopeRoots = []string{c.cityPath}
+	}
+
+	seen := make(map[string]struct{}, len(scopeRoots))
+	targets := make([]bdBackupScanTarget, 0, len(scopeRoots))
+	for _, scopeRoot := range scopeRoots {
+		scopeRoot = strings.TrimSpace(scopeRoot)
+		if scopeRoot == "" {
+			continue
+		}
+		scopeRoot = filepath.Clean(scopeRoot)
+		if _, ok := seen[scopeRoot]; ok {
+			continue
+		}
+		seen[scopeRoot] = struct{}{}
+		targets = append(targets, bdBackupScanTarget{
+			Label:     bdBackupScopeLabel(c.cityPath, scopeRoot),
+			BackupDir: filepath.Join(scopeRoot, ".beads", "backup"),
+		})
+	}
+	if len(targets) == 0 {
+		cityPath := filepath.Clean(c.cityPath)
+		targets = append(targets, bdBackupScanTarget{
+			Label:     bdBackupScopeLabel(c.cityPath, cityPath),
+			BackupDir: filepath.Join(cityPath, ".beads", "backup"),
+		})
+	}
+	return targets
+}
+
+func bdBackupScopeLabel(cityPath, scopeRoot string) string {
+	cityPath = filepath.Clean(cityPath)
+	scopeRoot = filepath.Clean(scopeRoot)
+	if scopeRoot == cityPath {
+		return "city"
+	}
+	if rel, err := filepath.Rel(cityPath, scopeRoot); err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "scope " + rel
+	}
+	return "scope " + scopeRoot
 }
 
 // CanFix returns false. Backup cleanup has nontrivial atomicity

--- a/internal/doctor/checks_bd_backup_size_test.go
+++ b/internal/doctor/checks_bd_backup_size_test.go
@@ -1,0 +1,125 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestBdBackupSizeCheck(cityPath string) *BdBackupSizeCheck {
+	c := NewBdBackupSizeCheck(cityPath)
+	c.measureDir = sumDirBytes
+	return c
+}
+
+func TestBdBackupSizeCheck_NoBackupDir(t *testing.T) {
+	c := newTestBdBackupSizeCheck(t.TempDir())
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no bd backup directory present") {
+		t.Errorf("message = %q, want no-backup-dir message", r.Message)
+	}
+}
+
+func TestBdBackupSizeCheck_EmptyBackupDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads", "backup"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	c := newTestBdBackupSizeCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestBdBackupSizeCheck_OKUnderThreshold(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, ".beads", "backup")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Small file far below warn threshold.
+	if err := os.WriteFile(filepath.Join(backupDir, "manifest"), []byte("small content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c := newTestBdBackupSizeCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK under threshold; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "bd auto-backup directory") {
+		t.Errorf("message = %q, want size summary", r.Message)
+	}
+}
+
+func TestBdBackupSizeCheck_WarnAtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, ".beads", "backup")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	c := NewBdBackupSizeCheck(dir)
+	c.measureDir = func(string) (int64, bool, error) {
+		return bdBackupWarnBytes + 1, true, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.FixHint, "bd-backup-cleanup.md") {
+		t.Errorf("FixHint = %q, want cleanup doc pointer", r.FixHint)
+	}
+}
+
+func TestBdBackupSizeCheck_ErrorAtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, ".beads", "backup")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	c := NewBdBackupSizeCheck(dir)
+	c.measureDir = func(string) (int64, bool, error) {
+		return bdBackupErrorBytes + 1, true, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusError {
+		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.FixHint, "bd-backup-cleanup.md") {
+		t.Errorf("FixHint = %q, want cleanup doc pointer", r.FixHint)
+	}
+}
+
+func TestBdBackupSizeCheck_MeasureErrorWarns(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, ".beads", "backup")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	c := NewBdBackupSizeCheck(dir)
+	c.measureDir = func(string) (int64, bool, error) {
+		return 0, true, os.ErrPermission
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning on measure error; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestBdBackupSizeCheck_CanFixFalse(t *testing.T) {
+	c := newTestBdBackupSizeCheck(t.TempDir())
+	if c.CanFix() {
+		t.Error("CanFix() = true, want false")
+	}
+}
+
+func TestBdBackupSizeCheck_Name(t *testing.T) {
+	c := newTestBdBackupSizeCheck(t.TempDir())
+	if got, want := c.Name(), "bd-backup-size"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}

--- a/internal/doctor/checks_bd_backup_size_test.go
+++ b/internal/doctor/checks_bd_backup_size_test.go
@@ -36,6 +36,25 @@ func TestBdBackupSizeCheck_EmptyBackupDir(t *testing.T) {
 	}
 }
 
+func TestBdBackupSizeCheck_PathIsNotADirectory(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "backup"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c := newTestBdBackupSizeCheck(dir)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "is not a directory") {
+		t.Errorf("message = %q, want not-a-directory warning", r.Message)
+	}
+}
+
 func TestBdBackupSizeCheck_OKUnderThreshold(t *testing.T) {
 	dir := t.TempDir()
 	backupDir := filepath.Join(dir, ".beads", "backup")
@@ -56,6 +75,54 @@ func TestBdBackupSizeCheck_OKUnderThreshold(t *testing.T) {
 	}
 }
 
+func TestBdBackupSizeCheck_RigScopedBackupWarns(t *testing.T) {
+	dir := t.TempDir()
+	rigDir := filepath.Join(dir, "rigs", "demo")
+	backupDir := filepath.Join(rigDir, ".beads", "backup")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	c := NewBdBackupSizeCheck(dir)
+	c.scopeRoots = []string{dir, rigDir}
+	c.measureDir = func(root string) (int64, bool, error) {
+		if root == backupDir {
+			return bdBackupWarnBytes, true, nil
+		}
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "scope rigs/demo") {
+		t.Errorf("message = %q, want rig scope label", r.Message)
+	}
+}
+
+func TestBdBackupSizeCheck_AggregateAcrossScopesWarns(t *testing.T) {
+	dir := t.TempDir()
+	rigDir := filepath.Join(dir, "rigs", "demo")
+	cityBackupDir := filepath.Join(dir, ".beads", "backup")
+	rigBackupDir := filepath.Join(rigDir, ".beads", "backup")
+	for _, backupDir := range []string{cityBackupDir, rigBackupDir} {
+		if err := os.MkdirAll(backupDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c := NewBdBackupSizeCheck(dir)
+	c.scopeRoots = []string{dir, rigDir}
+	c.measureDir = func(string) (int64, bool, error) {
+		return bdBackupWarnBytes / 2, true, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "aggregate bd auto-backup footprint") {
+		t.Errorf("message = %q, want aggregate warning", r.Message)
+	}
+}
+
 func TestBdBackupSizeCheck_WarnAtThreshold(t *testing.T) {
 	dir := t.TempDir()
 	backupDir := filepath.Join(dir, ".beads", "backup")
@@ -64,7 +131,7 @@ func TestBdBackupSizeCheck_WarnAtThreshold(t *testing.T) {
 	}
 	c := NewBdBackupSizeCheck(dir)
 	c.measureDir = func(string) (int64, bool, error) {
-		return bdBackupWarnBytes + 1, true, nil
+		return bdBackupWarnBytes, true, nil
 	}
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusWarning {
@@ -83,7 +150,7 @@ func TestBdBackupSizeCheck_ErrorAtThreshold(t *testing.T) {
 	}
 	c := NewBdBackupSizeCheck(dir)
 	c.measureDir = func(string) (int64, bool, error) {
-		return bdBackupErrorBytes + 1, true, nil
+		return bdBackupErrorBytes, true, nil
 	}
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusError {
@@ -107,6 +174,25 @@ func TestBdBackupSizeCheck_MeasureErrorWarns(t *testing.T) {
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusWarning {
 		t.Fatalf("status = %d, want Warning on measure error; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestBdBackupSizeCheck_MeasureMissingReportsNoBackupDir(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, ".beads", "backup")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	c := NewBdBackupSizeCheck(dir)
+	c.measureDir = func(string) (int64, bool, error) {
+		return 0, false, nil
+	}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "no bd backup directory present") {
+		t.Errorf("message = %q, want no-backup-dir message", r.Message)
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -46,6 +46,7 @@ func TestCheckWarmupEligibleDefaultsFalse(t *testing.T) {
 	checks := []Check{
 		&AgentSessionsCheck{},
 		&BDSplitStoreCheck{},
+		&BdBackupSizeCheck{},
 		&BeadsRoleCheck{},
 		&BeadsStoreCheck{},
 		&BinaryCheck{},

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -10,6 +10,10 @@ func (c *BDSplitStoreCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *BdBackupSizeCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *BeadsRoleCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the


### PR DESCRIPTION
Maintainer follow-up for https://github.com/gastownhall/gascity/pull/2478.

Original PR: https://github.com/gastownhall/gascity/pull/2478
Original title: feat(doctor): bd-backup-size canary catches unbounded .beads/backup growth
Original state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none; refreshed from 06cce4836d3c66737cf2a8aac853651eaccb546f to current main 8f10937c7a7de00d883254137e9d1928cd00e6e0 with patch-id preserved.

This carries forward the contributor's bd-backup-size doctor canary and adds the maintainer review fixes needed for merge readiness. The workflow first tried to update the contributor branch directly because maintainer edits were enabled, but GitHub rejected the fork push with a 403, so this follow-up is the safe maintainer-owned merge surface.

Maintainer changes:
- `fix: address bd backup rotation review`
- Short diff stat for the maintainer fixup: 5 files changed, 253 insertions(+), 50 deletions(-)

Validation:
- `go test ./internal/doctor`
- `make check-docs`
- Adopted review attempt 5 approved the final patch after validating the rig-scope backup scan and generic bd-backup measurement errors.

The original contributor commit is preserved in this branch, followed by the maintainer fixup commit.