### PR TITLE
fix(maintenance): split reaper mail-wisp anomaly count

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -1348,6 +1348,254 @@ func TestMaintenanceDoltScriptsRejectInvalidManagedPort(t *testing.T) {
 	}
 }
 
+func TestReaperMessageWispsAboveAlertThresholdDoNotTriggerReapFailureAnomaly(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"issue_type NOT IN"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"issue_type = 'message'"*)
+    printf 'COUNT(*)\n600\n'
+    ;;
+  *"created_at < DATE_SUB"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"status IN ('open', 'hooked', 'in_progress')"*)
+    printf 'COUNT(*)\n600\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":             doltLog,
+		"GC_CALL_LOG":               gcLog,
+		"GC_CITY":                   cityDir,
+		"GC_CITY_PATH":              cityDir,
+		"GC_DOLT_HOST":              "127.0.0.1",
+		"GC_DOLT_PORT":              "3307",
+		"GC_DOLT_USER":              "root",
+		"GC_DOLT_PASSWORD":          "",
+		"GC_REAPER_ALERT_THRESHOLD": "500",
+		"PATH":                      binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if strings.Contains(gcLogText, "ESCALATION") {
+		t.Fatalf("reaper fired false-positive escalation for message-type wisps above alert threshold:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "mail_wisps:600") {
+		t.Fatalf("reaper summary missing mail_wisps:600 for message-type wisp backlog:\n%s", gcLogText)
+	}
+}
+
+func TestReaperNonMessageWispsAboveAlertThresholdStillTriggerReapFailureAnomaly(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"issue_type NOT IN"*)
+    printf 'COUNT(*)\n600\n'
+    ;;
+  *"issue_type = 'message'"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"created_at < DATE_SUB"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"status IN ('open', 'hooked', 'in_progress')"*)
+    printf 'COUNT(*)\n600\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":             doltLog,
+		"GC_CALL_LOG":               gcLog,
+		"GC_CITY":                   cityDir,
+		"GC_CITY_PATH":              cityDir,
+		"GC_DOLT_HOST":              "127.0.0.1",
+		"GC_DOLT_PORT":              "3307",
+		"GC_DOLT_USER":              "root",
+		"GC_DOLT_PASSWORD":          "",
+		"GC_REAPER_ALERT_THRESHOLD": "500",
+		"PATH":                      binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "ESCALATION: Reaper anomalies detected [MEDIUM]") {
+		t.Fatalf("reaper did not fire reap-failure anomaly for non-message wisps above threshold:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "open wisps (threshold: 500)") {
+		t.Fatalf("reaper anomaly body missing open wisp count format:\n%s", gcLogText)
+	}
+}
+
+func TestReaperMailAlertThresholdPositiveBranchEmitsMailBacklogAnomaly(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"issue_type NOT IN"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"issue_type = 'message'"*)
+    printf 'COUNT(*)\n300\n'
+    ;;
+  *"created_at < DATE_SUB"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"status IN ('open', 'hooked', 'in_progress')"*)
+    printf 'COUNT(*)\n300\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":                  doltLog,
+		"GC_CALL_LOG":                    gcLog,
+		"GC_CITY":                        cityDir,
+		"GC_CITY_PATH":                   cityDir,
+		"GC_DOLT_HOST":                   "127.0.0.1",
+		"GC_DOLT_PORT":                   "3307",
+		"GC_DOLT_USER":                   "root",
+		"GC_DOLT_PASSWORD":               "",
+		"GC_REAPER_ALERT_THRESHOLD":      "500",
+		"GC_REAPER_MAIL_ALERT_THRESHOLD": "200",
+		"PATH":                           binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "ESCALATION: Reaper anomalies detected [MEDIUM]") {
+		t.Fatalf("reaper did not fire mail backlog anomaly above mail threshold:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "open mail-wisps (mail threshold: 200)") {
+		t.Fatalf("reaper anomaly body missing mail backlog threshold format:\n%s", gcLogText)
+	}
+	if strings.Contains(gcLogText, "open wisps (threshold: 500)") {
+		t.Fatalf("reaper fired reapable-wisp anomaly for message-only backlog:\n%s", gcLogText)
+	}
+}
+
+func TestReaperMailWispsSummaryFieldAlwaysPresent(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"DOLT_DBS":         "beads",
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "mail_wisps:0") {
+		t.Fatalf("reaper summary missing mail_wisps field when wisp counts are zero:\n%s", gcLogText)
+	}
+}
+
 func TestMaintenanceDoltScriptsSkipTestPatternDatabases(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -20,6 +20,7 @@ PURGE_AGE="${GC_REAPER_PURGE_AGE:-168h}"
 STALE_ISSUE_AGE="${GC_REAPER_STALE_ISSUE_AGE:-720h}"
 SESSION_PURGE_AGE="${GC_REAPER_SESSION_PURGE_AGE:-720h}"
 ALERT_THRESHOLD="${GC_REAPER_ALERT_THRESHOLD:-500}"
+MAIL_ALERT_THRESHOLD="${GC_REAPER_MAIL_ALERT_THRESHOLD:-0}"  # 0 = disabled
 DRY_RUN="${GC_REAPER_DRY_RUN:-}"
 
 # Convert Go durations to SQL INTERVAL hours for Dolt.
@@ -114,6 +115,7 @@ fi
 TOTAL_STALE_WISPS=0
 TOTAL_CLOSED_WISPS=0
 TOTAL_PURGED=0
+TOTAL_MAIL_WISPS=0
 TOTAL_ISSUES_CLOSED=0
 TOTAL_STALE_ISSUES_SKIPPED=0
 TOTAL_SESSIONS_PRUNED=0
@@ -490,15 +492,29 @@ while IFS= read -r DB; do
         fi
     fi
 
-    # Step 5: Anomaly check — open wisp count.
-    get_sql_count "$DB" "open wisp" "
+    # Step 5a: Anomaly check — reapable open wisp count.
+    get_sql_count "$DB" "reapable open wisp" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status IN ('open', 'hooked', 'in_progress')
+        AND issue_type NOT IN ('message')
     "
-    OPEN_WISPS=$SQL_COUNT_RESULT
+    REAPABLE_WISPS=$SQL_COUNT_RESULT
 
-    if [ "$OPEN_WISPS" -gt "$ALERT_THRESHOLD" ]; then
-        ANOMALIES="${ANOMALIES}$DB: $OPEN_WISPS open wisps (threshold: $ALERT_THRESHOLD)\n"
+    if [ "$REAPABLE_WISPS" -gt "$ALERT_THRESHOLD" ]; then
+        ANOMALIES="${ANOMALIES}$DB: $REAPABLE_WISPS open wisps (threshold: $ALERT_THRESHOLD)\n"
+    fi
+
+    # Step 5b: Mail-wisp backlog count, observed separately from reapable wisps.
+    get_sql_count "$DB" "open mail wisp" "
+        SELECT COUNT(*) FROM \`$DB\`.wisps
+        WHERE status IN ('open', 'hooked', 'in_progress')
+        AND issue_type = 'message'
+    "
+    MAIL_WISPS=$SQL_COUNT_RESULT
+    TOTAL_MAIL_WISPS=$((TOTAL_MAIL_WISPS + MAIL_WISPS))
+
+    if [ "$MAIL_ALERT_THRESHOLD" -gt 0 ] && [ "$MAIL_WISPS" -gt "$MAIL_ALERT_THRESHOLD" ]; then
+        ANOMALIES="${ANOMALIES}$DB: $MAIL_WISPS open mail-wisps (mail threshold: $MAIL_ALERT_THRESHOLD)\n"
     fi
 
     # Commit Dolt changes. Must use CALL (not SELECT) and have an active
@@ -558,7 +574,7 @@ if [ -n "$ANOMALIES" ]; then
         -m "$ANOMALIES" 2>/dev/null || true
 fi
 
-SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED"
+SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
 if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY (dry run)"
 fi

--- a/release-gates/ga-q4t23-gate.md
+++ b/release-gates/ga-q4t23-gate.md
@@ -1,0 +1,46 @@
+# Release Gate: ga-q4t23
+
+Status: PASS
+
+## Context
+
+- Release bead: `ga-q4t23` - Review: reaper mail-wisp anomaly split recheck
+- Source bead: `ga-fkdeq.2` - As an operator, the canonical reaper stops mail-wisp false escalations
+- Source review bead: `ga-nmop3` - prior request-changes, closed after builder fix
+- Reviewed branch: `builder/ga-fkdeq-2`
+- Reviewed commit: `be8cd0a4980a99193e286b4a8b8bef376e121a66`
+- PR branch: `release/ga-q4t23`
+- Base: `origin/main` at `ed237aa31b6b0838e745c8759ff5c3fdb509ae2b`
+- Project release manifest: `docs/PROJECT_MANIFEST.md` was not present in this checkout; this gate applies the active deployer role criteria.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-q4t23` notes contain `Reviewer verdict: pass` for commit `be8cd0a49`; reviewer reports findings none. |
+| 2 | Acceptance criteria met | PASS | Checked source bead `ga-fkdeq.2` acceptance against `examples/gastown/packs/maintenance/assets/scripts/reaper.sh` and `examples/gastown/maintenance_scripts_test.go`; details below. |
+| 3 | Tests pass | PASS | `bash -n examples/gastown/packs/maintenance/assets/scripts/reaper.sh`; `git diff --check origin/main...HEAD`; focused reaper `go test`; `go test ./examples/gastown -count=1`; `go vet ./...`; `make test` all passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-q4t23` list `Findings: none`; prior `ga-nmop3` MEDIUM coverage finding was fixed by adding `TestReaperMailAlertThresholdPositiveBranchEmitsMailBacklogAnomaly`. |
+| 5 | Final branch is clean | PASS | Working tree was clean before writing this checklist; final cleanliness is rechecked after committing the gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `origin/main` is an ancestor of `be8cd0a49`; `git merge-tree $(git merge-base builder/ga-fkdeq-2 origin/main) builder/ga-fkdeq-2 origin/main` produced no conflicts. |
+
+## Acceptance Evidence
+
+| Acceptance criterion | Evidence |
+|---------------------|----------|
+| `reaper.sh` defines `MAIL_ALERT_THRESHOLD` from `GC_REAPER_MAIL_ALERT_THRESHOLD` with default `0` and disabled note. | `reaper.sh:23` defines `MAIL_ALERT_THRESHOLD="${GC_REAPER_MAIL_ALERT_THRESHOLD:-0}"  # 0 = disabled`. |
+| Script initializes `TOTAL_MAIL_WISPS` alongside other counters. | `reaper.sh:118` initializes `TOTAL_MAIL_WISPS=0`. |
+| Step 5 splits reapable count using `issue_type NOT IN ('message')` and mail count using `issue_type = 'message'`. | `reaper.sh:499` filters non-message wisps; `reaper.sh:511` filters message wisps. |
+| Reapable anomalies keep existing wording: `open wisps (threshold: N)`. | `reaper.sh:504` keeps `open wisps (threshold: $ALERT_THRESHOLD)`. |
+| Mail backlog anomalies emit only when mail alert threshold is enabled and exceeded, using `open mail-wisps (mail threshold: N)`. | `reaper.sh:516-517` gates on threshold > 0 and emits the mail-specific wording. |
+| Summary appends `mail_wisps:N` after `skipped_non_city_issues`. | `reaper.sh:577` appends `mail_wisps:$TOTAL_MAIL_WISPS` after `skipped_non_city_issues`. |
+| Guardrail: Steps 1-4 not filtered by `issue_type`; no schema migration; escalation subject unchanged. | Diff is limited to `reaper.sh` Step 5/summary and `maintenance_scripts_test.go`; no migration files or escalation subject changes. |
+
+## Test Evidence
+
+- `git diff --check origin/main...HEAD`: PASS
+- `bash -n examples/gastown/packs/maintenance/assets/scripts/reaper.sh`: PASS
+- `go test ./examples/gastown -run 'TestReaper(MessageWispsAboveAlertThresholdDoNotTriggerReapFailureAnomaly|NonMessageWispsAboveAlertThresholdStillTriggerReapFailureAnomaly|MailAlertThresholdPositiveBranchEmitsMailBacklogAnomaly|MailWispsSummaryFieldAlwaysPresent)' -count=1`: PASS
+- `go test ./examples/gastown -count=1`: PASS (`ok github.com/gastownhall/gascity/examples/gastown 25.392s`)
+- `go vet ./...`: PASS
+- `make test`: PASS (`observable go test: PASS`)


### PR DESCRIPTION
## What this changes

The canonical maintenance reaper now counts message-type wisps separately from reapable wisps. Message wisps no longer trigger the existing reap-failure escalation, while non-message wisps keep the current `open wisps (threshold: N)` behavior.

The change adds `GC_REAPER_MAIL_ALERT_THRESHOLD` as a default-off opt-in for separate mail-backlog escalation and always includes `mail_wisps:N` in the reaper summary. Keeping the mail threshold disabled by default preserves existing operator behavior unless they explicitly choose to alert on mail backlog size.

## Review notes

- `GC_REAPER_MAIL_ALERT_THRESHOLD` is a new environment knob; default `0` disables mail-backlog escalation.
- Steps 1-4 in `reaper.sh` are intentionally unchanged and not filtered by `issue_type`.
- The existing escalation subject and non-message wisp body wording are unchanged.
- There are no schema migrations or config-file shape changes.
- Release bead: `ga-q4t23`.

## Test plan

- [x] `bash -n examples/gastown/packs/maintenance/assets/scripts/reaper.sh`
- [x] `git diff --check origin/main...HEAD`
- [x] Focused reaper tests for mail-wisp suppression, non-message preservation, mail-threshold alerting, and summary output
- [x] `go test ./examples/gastown -count=1`
- [x] `go vet ./...`
- [x] `make test`
- [x] Release gate: [`release-gates/ga-q4t23-gate.md`](release-gates/ga-q4t23-gate.md)