### PR TITLE
PackV2 fast follow: tighten authoring surface

### DIFF
--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -195,13 +195,13 @@ func TestLoadCityConfigFSEmitsProvenanceWarnings(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`[workspace]
 name = "test-city"
+
+[agents]
+append_fragments = ["footer"]
 `)
 	fs.Files["/city/pack.toml"] = []byte(`[pack]
 name = "test-city"
 schema = 2
-
-[agents]
-append_fragments = ["footer"]
 `)
 
 	var stderr bytes.Buffer
@@ -221,13 +221,13 @@ func TestLoadCityConfigFSEmitsMigrationWarningsAcrossCalls(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`[workspace]
 name = "test-city"
+
+[agents]
+append_fragments = ["footer"]
 `)
 	fs.Files["/city/pack.toml"] = []byte(`[pack]
 name = "test-city"
 schema = 2
-
-[agents]
-append_fragments = ["footer"]
 `)
 
 	var stderr bytes.Buffer

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -590,15 +590,15 @@ name = "demo"
 
 [beads]
 provider = "file"
+
+[defaults.rig.imports.actual]
+source = "https://github.com/gastownhall/gc-actual-packs"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte(`[pack]
 name = "demo"
 schema = 2
-
-[defaults.rig.imports.actual]
-source = "https://github.com/gastownhall/gc-actual-packs"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -368,14 +368,12 @@ func collectAllImportsFS(fs fsys.FS, cityPath string) (map[string]config.Import,
 	for name, imp := range packManifest.Imports {
 		all["pack:"+name] = imp
 	}
-	if len(packManifest.Defaults.Rig.Imports) > 0 {
-		defaults, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
-		if err != nil {
-			return nil, err
-		}
-		for _, bound := range defaults {
-			all["default-rig:"+bound.Binding] = bound.Import
-		}
+	defaults, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, bound := range defaults {
+		all["default-rig:"+bound.Binding] = bound.Import
 	}
 
 	if _, err := fs.Stat(filepath.Join(cityPath, "city.toml")); err != nil {
@@ -593,16 +591,27 @@ func removeRootDefaultRigImportFS(fs fsys.FS, cityPath string, scope *importScop
 		return false, nil
 	}
 	defaultName := strings.TrimPrefix(name, "default-rig:")
-	manifest, err := loadCityPackManifestFS(fs, cityPath)
+	cfg, err := loadCityImportManifestFS(fs, cityPath)
 	if err != nil {
 		return false, err
 	}
-	if _, ok := manifest.Defaults.Rig.Imports[defaultName]; !ok {
-		return false, nil
+	if _, ok := cfg.Defaults.Rig.Imports[defaultName]; !ok {
+		manifest, err := loadCityPackManifestFS(fs, cityPath)
+		if err != nil {
+			return false, err
+		}
+		if _, ok := manifest.Defaults.Rig.Imports[defaultName]; !ok {
+			return false, nil
+		}
+		delete(manifest.Defaults.Rig.Imports, defaultName)
+		scope.save = func() error {
+			return writeCityPackManifest(fs, cityPath, manifest)
+		}
+		return true, nil
 	}
-	delete(manifest.Defaults.Rig.Imports, defaultName)
+	delete(cfg.Defaults.Rig.Imports, defaultName)
 	scope.save = func() error {
-		return writeCityPackManifest(fs, cityPath, manifest)
+		return writeCityImportManifestFS(fs, cityPath, cfg)
 	}
 	return true, nil
 }

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -599,10 +599,10 @@ func newInitPackConfig(cityName string) initPackConfig {
 //
 //   - pack.toml owns the portable definition: [pack], explicit [[agent]]
 //     entries when the caller keeps them, [[named_session]], [imports.*],
-//     [providers.*], agent/service patches, and formulas.
+//     [providers.*], services, and agent patches.
 //   - city.toml keeps only runtime-local deployment settings (e.g.
-//     workspace.provider, workspace.start_command, agent_defaults, api,
-//     daemon, beads).
+//     workspace.provider, workspace.start_command, agent_defaults,
+//     default-rig imports, rig/provider patches, api, daemon, beads).
 //   - workspace.name and workspace.prefix migrate to .gc/site.toml via
 //     persistInitWorkspaceIdentity, so they are cleared here to avoid
 //     duplicating the city's machine-local identity in city.toml.
@@ -619,7 +619,10 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 	cityCfg.Providers = nil
 	cityCfg.Services = nil
 	cityCfg.Formulas = config.FormulasConfig{}
-	cityCfg.Patches = config.Patches{}
+	cityCfg.Patches = config.Patches{
+		Rigs:      append([]config.RigPatch(nil), cfg.Patches.Rigs...),
+		Providers: append([]config.ProviderPatch(nil), cfg.Patches.Providers...),
+	}
 	cityCfg.AgentsDefaults = config.AgentDefaults{}
 	cityCfg.Defaults = config.PackDefaults{}
 	cityCfg.Workspace.Name = ""
@@ -639,8 +642,9 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 			packCfg.Providers[name] = spec
 		}
 	}
-	packCfg.Formulas = cfg.Formulas
-	packCfg.Patches = cfg.Patches
+	packCfg.Patches = config.Patches{
+		Agents: append([]config.AgentPatch(nil), cfg.Patches.Agents...),
+	}
 	for _, svc := range cfg.Services {
 		if svc.PublishMode == "direct" {
 			cityCfg.Services = append(cityCfg.Services, svc)
@@ -656,19 +660,30 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 		)
 		cityCfg.Workspace.SetLegacyIncludes(nil)
 	}
-	if len(cfg.DefaultRigImports) > 0 {
+	defaultRigImports := initDefaultRigImports(cfg)
+	if len(defaultRigImports) > 0 {
 		defaults := config.PackDefaults{
 			Rig: config.PackRigDefaults{
-				Imports: make(map[string]config.Import, len(cfg.DefaultRigImports)),
+				Imports: make(map[string]config.Import, len(defaultRigImports)),
 			},
 		}
-		for name, imp := range cfg.DefaultRigImports {
+		for name, imp := range defaultRigImports {
 			defaults.Rig.Imports[name] = imp
 		}
 		cityCfg.Defaults = defaults
 		cityCfg.Workspace.SetLegacyDefaultRigIncludes(nil)
 	}
 	return packCfg, cityCfg
+}
+
+func initDefaultRigImports(cfg *config.City) map[string]config.Import {
+	if cfg == nil {
+		return nil
+	}
+	if len(cfg.Defaults.Rig.Imports) > 0 {
+		return cfg.Defaults.Rig.Imports
+	}
+	return cfg.DefaultRigImports
 }
 
 func decodeInitPackTemplate(data []byte, cityName string) (initPackConfig, error) {
@@ -752,6 +767,10 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	cfg, err := config.Parse(data)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if cfg.Formulas.Dir != "" {
+		fmt.Fprintln(stderr, "gc init: [formulas].dir is no longer supported; use the well-known formulas/ directory") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -599,9 +599,10 @@ func newInitPackConfig(cityName string) initPackConfig {
 //
 //   - pack.toml owns the portable definition: [pack], explicit [[agent]]
 //     entries when the caller keeps them, [[named_session]], [imports.*],
-//     [providers.*], agent/service patches, formulas, and agent_defaults.
+//     [providers.*], agent/service patches, and formulas.
 //   - city.toml keeps only runtime-local deployment settings (e.g.
-//     workspace.provider, workspace.start_command, api, daemon, beads).
+//     workspace.provider, workspace.start_command, agent_defaults, api,
+//     daemon, beads).
 //   - workspace.name and workspace.prefix migrate to .gc/site.toml via
 //     persistInitWorkspaceIdentity, so they are cleared here to avoid
 //     duplicating the city's machine-local identity in city.toml.
@@ -619,8 +620,8 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 	cityCfg.Services = nil
 	cityCfg.Formulas = config.FormulasConfig{}
 	cityCfg.Patches = config.Patches{}
-	cityCfg.AgentDefaults = config.AgentDefaults{}
 	cityCfg.AgentsDefaults = config.AgentDefaults{}
+	cityCfg.Defaults = config.PackDefaults{}
 	cityCfg.Workspace.Name = ""
 	cityCfg.Workspace.Prefix = ""
 
@@ -637,10 +638,6 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 		for name, spec := range cfg.Providers {
 			packCfg.Providers[name] = spec
 		}
-	}
-	packCfg.AgentDefaults = cfg.AgentDefaults
-	if isZeroValue(packCfg.AgentDefaults) && !isZeroValue(cfg.AgentsDefaults) {
-		packCfg.AgentDefaults = cfg.AgentsDefaults
 	}
 	packCfg.Formulas = cfg.Formulas
 	packCfg.Patches = cfg.Patches
@@ -660,15 +657,15 @@ func splitInitConfig(cityName string, cfg *config.City) (initPackConfig, config.
 		cityCfg.Workspace.SetLegacyIncludes(nil)
 	}
 	if len(cfg.DefaultRigImports) > 0 {
-		defaults := packDefaults{
-			Rig: packRigDefaults{
+		defaults := config.PackDefaults{
+			Rig: config.PackRigDefaults{
 				Imports: make(map[string]config.Import, len(cfg.DefaultRigImports)),
 			},
 		}
 		for name, imp := range cfg.DefaultRigImports {
 			defaults.Rig.Imports[name] = imp
 		}
-		packCfg.Defaults = defaults
+		cityCfg.Defaults = defaults
 		cityCfg.Workspace.SetLegacyDefaultRigIncludes(nil)
 	}
 	return packCfg, cityCfg

--- a/cmd/gc/cmd_lint_test.go
+++ b/cmd/gc/cmd_lint_test.go
@@ -118,15 +118,15 @@ func TestLintDotHandlesCityRootPackDefaults(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 
+	writeLintFile(t, filepath.Join(root, "city.toml"), `[defaults.rig.imports.worker]
+source = "packs/worker"
+`)
 	writeLintFile(t, filepath.Join(root, "pack.toml"), `[pack]
 name = "city-root"
 version = "0.1.0"
 schema = 2
 
 [imports.worker]
-source = "packs/worker"
-
-[defaults.rig.imports.worker]
 source = "packs/worker"
 `)
 	writeLintPack(t, filepath.Join(root, "packs", "worker"), "worker", "builder", "prompts/builder.template.md")
@@ -147,12 +147,12 @@ func TestLintEmitsLoaderWarnings(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"lint", packDir}, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("gc lint = %d, want warnings-only success\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	if code == 0 {
+		t.Fatalf("gc lint succeeded, want pack authoring error\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
 	}
 	errText := stderr.String()
-	if !strings.Contains(errText, "warning") || !strings.Contains(errText, "deprecated compatibility alias") {
-		t.Fatalf("stderr missing loader warning:\n%s", errText)
+	if !strings.Contains(errText, "[agents] is a city.toml compatibility alias for [agent_defaults], not a pack.toml field") {
+		t.Fatalf("stderr missing pack authoring error:\n%s", errText)
 	}
 }
 

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -105,8 +105,8 @@ func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.Check
 		return okCheck("v2-default-rig-import-format", "workspace.default_rig_includes already migrated")
 	}
 	return errorCheck("v2-default-rig-import-format",
-		"unsupported PackV1 workspace.default_rig_includes found; migrate to root pack.toml [defaults.rig.imports.<binding>]",
-		`move each entry into root pack.toml [defaults.rig.imports.<binding>]`,
+		"unsupported PackV1 workspace.default_rig_includes found; migrate to city.toml [defaults.rig.imports.<binding>]",
+		`move each entry into city.toml [defaults.rig.imports.<binding>]`,
 		doctorKeyDetails(cityTomlPath, "workspace", "default_rig_includes", "workspace.default_rig_includes", cfg.Workspace.LegacyDefaultRigIncludes()))
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4548,6 +4548,150 @@ schema = 2
 	}
 }
 
+func TestInitFilePreservesDefaultRigImportsInCityToml(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.toml")
+	if err := os.WriteFile(src, []byte(`[workspace]
+provider = "claude"
+
+[defaults.rig.imports.zeta]
+source = "./packs/zeta"
+
+[defaults.rig.imports.alpha]
+source = "./packs/alpha"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "bright-lights")
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, src, cityPath, "", &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packText := string(mustReadFile(t, filepath.Join(cityPath, "pack.toml")))
+	if strings.Contains(packText, "[defaults.rig.imports.") {
+		t.Fatalf("pack.toml should not contain default-rig imports:\n%s", packText)
+	}
+
+	cityText := string(mustReadFile(t, filepath.Join(cityPath, "city.toml")))
+	for _, want := range []string{
+		"[defaults.rig.imports.alpha]",
+		`source = "./packs/alpha"`,
+		"[defaults.rig.imports.zeta]",
+		`source = "./packs/zeta"`,
+	} {
+		if !strings.Contains(cityText, want) {
+			t.Fatalf("city.toml missing default-rig import %q:\n%s", want, cityText)
+		}
+	}
+	if _, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); err != nil {
+		t.Fatalf("LoadWithIncludes written city: %v", err)
+	}
+}
+
+func TestInitFileKeepsCityOnlyPatchesOutOfPackToml(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.toml")
+	if err := os.WriteFile(src, []byte(`[workspace]
+provider = "claude"
+
+[providers.local]
+command = "true"
+
+[[agent]]
+name = "worker"
+provider = "local"
+
+[[rigs]]
+name = "app"
+path = "app"
+
+[[patches.agent]]
+name = "worker"
+suspended = true
+
+[[patches.rigs]]
+name = "app"
+prefix = "ga"
+
+[[patches.providers]]
+name = "local"
+command = "false"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "bright-lights")
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, src, cityPath, "", &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	packText := string(mustReadFile(t, filepath.Join(cityPath, "pack.toml")))
+	if !strings.Contains(packText, "[[patches.agent]]") {
+		t.Fatalf("pack.toml missing pack-supported agent patch:\n%s", packText)
+	}
+	for _, forbidden := range []string{"[[patches.rigs]]", "[[patches.providers]]"} {
+		if strings.Contains(packText, forbidden) {
+			t.Fatalf("pack.toml contains city-only patch %q:\n%s", forbidden, packText)
+		}
+	}
+
+	cityText := string(mustReadFile(t, filepath.Join(cityPath, "city.toml")))
+	for _, want := range []string{"[[patches.rigs]]", `prefix = "ga"`, "[[patches.providers]]", `command = "false"`} {
+		if !strings.Contains(cityText, want) {
+			t.Fatalf("city.toml missing city-only patch %q:\n%s", want, cityText)
+		}
+	}
+	if strings.Contains(cityText, "[[patches.agent]]") {
+		t.Fatalf("city.toml should not contain pack-supported agent patch:\n%s", cityText)
+	}
+	if _, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); err != nil {
+		t.Fatalf("LoadWithIncludes written city: %v", err)
+	}
+}
+
+func TestInitFileRejectsLegacyFormulasDir(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.toml")
+	if err := os.WriteFile(src, []byte(`[workspace]
+provider = "claude"
+
+[formulas]
+dir = "legacy-formulas"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "bright-lights")
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, src, cityPath, "", &stdout, &stderr, true, false)
+	if code == 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions succeeded, want formulas.dir rejection; stdout: %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "[formulas].dir is no longer supported") {
+		t.Fatalf("stderr missing formulas.dir rejection:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, "pack.toml")); !os.IsNotExist(err) {
+		t.Fatalf("pack.toml should not be written after formulas.dir rejection, err=%v", err)
+	}
+}
+
 func TestInitFromCopiesLegacyAgentDefaultsAliasToCityToml(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2758,13 +2758,13 @@ func TestDoInitGastownWritesCanonicalPackV2Shape(t *testing.T) {
 	if strings.Contains(cityToml, "default_rig_includes") {
 		t.Fatalf("city.toml should not keep legacy default_rig_includes in fresh init:\n%s", cityToml)
 	}
+	if !strings.Contains(cityToml, "[defaults.rig.imports.gastown]") {
+		t.Fatalf("city.toml missing canonical default-rig import:\n%s", cityToml)
+	}
 
 	packToml := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
 	if !strings.Contains(packToml, "[imports.gastown]") || !strings.Contains(packToml, `source = ".gc/system/packs/gastown"`) {
 		t.Fatalf("pack.toml missing gastown import:\n%s", packToml)
-	}
-	if !strings.Contains(packToml, "[defaults.rig.imports.gastown]") {
-		t.Fatalf("pack.toml missing canonical default-rig import:\n%s", packToml)
 	}
 	if strings.Contains(packToml, `append_fragments = ["command-glossary", "operational-awareness"]`) {
 		t.Fatalf("pack.toml should not rewrite workspace.global_fragments into append_fragments:\n%s", packToml)
@@ -3373,7 +3373,7 @@ func TestDoInitWithGastownTemplate(t *testing.T) {
 		t.Errorf("len(Agents) = %d, want 0 (agents come from pack)", len(cfg.Agents))
 	}
 	packToml := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
-	if !strings.Contains(packToml, "[imports.gastown]") || !strings.Contains(packToml, "[defaults.rig.imports.gastown]") {
+	if !strings.Contains(packToml, "[imports.gastown]") || !strings.Contains(string(data), "[defaults.rig.imports.gastown]") {
 		t.Errorf("pack.toml missing gastown pack wiring:\n%s", packToml)
 	}
 	// Daemon config.
@@ -4486,7 +4486,7 @@ func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {
 	}
 }
 
-func TestInitFromPreservesCopiedPackDefaultRigImportOrder(t *testing.T) {
+func TestInitFromCopiesDefaultRigImportsToCityToml(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
 	configureIsolatedRuntimeEnv(t)
@@ -4497,12 +4497,8 @@ func TestInitFromPreservesCopiedPackDefaultRigImportOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
-		[]byte("[workspace]\nprovider = \"claude\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"), []byte(`[pack]
-name = "template"
-schema = 2
+		[]byte(`[workspace]
+provider = "claude"
 
 [defaults.rig.imports.zeta]
 source = "./packs/zeta"
@@ -4512,63 +4508,9 @@ source = "./packs/alpha"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
-	cityPath := filepath.Join(dir, "bright-lights")
-	var stdout, stderr bytes.Buffer
-	code := doInitFromDirWithOptions(srcDir, cityPath, "", &stdout, &stderr, true)
-	if code != 0 {
-		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, stderr.String())
-	}
-
-	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
-	if err != nil {
-		t.Fatalf("reading pack.toml: %v", err)
-	}
-	packText := string(packData)
-	zetaIdx := strings.Index(packText, "[defaults.rig.imports.zeta]")
-	alphaIdx := strings.Index(packText, "[defaults.rig.imports.alpha]")
-	if zetaIdx == -1 || alphaIdx == -1 {
-		t.Fatalf("pack.toml missing copied default rig imports:\n%s", packText)
-	}
-	if zetaIdx > alphaIdx {
-		t.Fatalf("pack.toml reordered copied default rig imports:\n%s", packText)
-	}
-
-	defaultRigImports, err := config.LoadRootPackDefaultRigImports(fsys.OSFS{}, cityPath)
-	if err != nil {
-		t.Fatalf("LoadRootPackDefaultRigImports: %v", err)
-	}
-	if len(defaultRigImports) != 2 {
-		t.Fatalf("LoadRootPackDefaultRigImports len = %d, want 2", len(defaultRigImports))
-	}
-	if defaultRigImports[0].Binding != "zeta" || defaultRigImports[1].Binding != "alpha" {
-		t.Fatalf("LoadRootPackDefaultRigImports = %v, want [zeta alpha]", []string{
-			defaultRigImports[0].Binding,
-			defaultRigImports[1].Binding,
-		})
-	}
-}
-
-func TestInitFromPreservesCopiedPackLegacyAgentDefaultsAlias(t *testing.T) {
-	t.Setenv("GC_BEADS", "file")
-	t.Setenv("GC_DOLT", "skip")
-	configureIsolatedRuntimeEnv(t)
-
-	dir := t.TempDir()
-	srcDir := filepath.Join(dir, "template")
-	if err := os.MkdirAll(srcDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
-		[]byte("[workspace]\nprovider = \"claude\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
 	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"), []byte(`[pack]
 name = "template"
 schema = 2
-
-[agents]
-append_fragments = ["legacy-footer"]
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -4580,13 +4522,72 @@ append_fragments = ["legacy-footer"]
 		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
+	cityData, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
 	if err != nil {
-		t.Fatalf("reading pack.toml: %v", err)
+		t.Fatalf("reading city.toml: %v", err)
 	}
-	packText := string(packData)
-	if !strings.Contains(packText, "[agents]") {
-		t.Fatalf("pack.toml dropped copied [agents] alias:\n%s", packText)
+	cityText := string(cityData)
+	zetaIdx := strings.Index(cityText, "[defaults.rig.imports.zeta]")
+	alphaIdx := strings.Index(cityText, "[defaults.rig.imports.alpha]")
+	if zetaIdx == -1 || alphaIdx == -1 {
+		t.Fatalf("city.toml missing copied default rig imports:\n%s", cityText)
+	}
+
+	defaultRigImports, err := config.LoadRootPackDefaultRigImports(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("LoadRootPackDefaultRigImports: %v", err)
+	}
+	if len(defaultRigImports) != 2 {
+		t.Fatalf("LoadRootPackDefaultRigImports len = %d, want 2", len(defaultRigImports))
+	}
+	if defaultRigImports[0].Binding != "alpha" || defaultRigImports[1].Binding != "zeta" {
+		t.Fatalf("LoadRootPackDefaultRigImports = %v, want [alpha zeta]", []string{
+			defaultRigImports[0].Binding,
+			defaultRigImports[1].Binding,
+		})
+	}
+}
+
+func TestInitFromCopiesLegacyAgentDefaultsAliasToCityToml(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "template")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte(`[workspace]
+provider = "claude"
+
+[agents]
+append_fragments = ["legacy-footer"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"), []byte(`[pack]
+name = "template"
+schema = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "bright-lights")
+	var stdout, stderr bytes.Buffer
+	code := doInitFromDirWithOptions(srcDir, cityPath, "", &stdout, &stderr, true)
+	if code != 0 {
+		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	cityData, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	cityText := string(cityData)
+	if !strings.Contains(cityText, "[agent_defaults]") {
+		t.Fatalf("city.toml missing canonical [agent_defaults]:\n%s", cityText)
 	}
 
 	cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))

--- a/cmd/gc/strict_warnings_test.go
+++ b/cmd/gc/strict_warnings_test.go
@@ -22,7 +22,7 @@ func TestSplitStrictConfigWarnings_LegacyV1SurfaceWarningsAreNonFatal(t *testing
 		"city.toml: [[agent]] tables are deprecated in v2; use directory-based agents under agents/<name>/. Run `gc doctor` to inspect; `gc doctor --fix` handles the safe mechanical rewrites available in this wave.",
 		"city.toml: [packs] is deprecated in v2; use [imports] + packs.lock. Run `gc doctor` to inspect; `gc doctor --fix` migrates entries referenced by legacy workspace include lists, then migrate or remove any remaining [packs] entries manually.",
 		"city.toml: workspace.includes is deprecated in v2; use [imports]. Run `gc doctor` to inspect; `gc doctor --fix` handles the safe mechanical rewrites available in this wave.",
-		"city.toml: workspace.default_rig_includes is deprecated in v2; use root pack.toml [defaults.rig.imports.<binding>]. Run `gc doctor` to inspect; `gc doctor --fix` handles the safe mechanical rewrites available in this wave.",
+		"city.toml: workspace.default_rig_includes is deprecated in v2; use city.toml [defaults.rig.imports.<binding>]. Run `gc doctor` to inspect; `gc doctor --fix` handles the safe mechanical rewrites available in this wave.",
 		`city agent "mayor" shadows agent of the same name from import "gs"`,
 	})
 

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -851,8 +851,7 @@ func TestResolveTemplateWrappedClaudeProjectsSettings(t *testing.T) {
 	}
 }
 
-func TestResolveTemplateImportedPackAppendFragmentsLayerBeforeCityDefaults(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 authoring surface")
+func TestResolveTemplateCityAppendFragmentsApplyToImportedPackAgent(t *testing.T) {
 	cityPath := t.TempDir()
 	write := func(rel, data string) {
 		path := filepath.Join(cityPath, rel)
@@ -877,9 +876,6 @@ append_fragments = ["city-footer"]
 name = "imported"
 schema = 2
 
-[agent_defaults]
-append_fragments = ["pack-footer"]
-
 [[agent]]
 name = "mayor"
 provider = "claude"
@@ -887,7 +883,6 @@ scope = "city"
 prompt_template = "agents/mayor/prompt.template.md"
 `)
 	write("packs/imported/agents/mayor/prompt.template.md", "Hello")
-	write("packs/imported/agents/mayor/template-fragments/pack-footer.template.md", `{{ define "pack-footer" }}Pack Footer{{ end }}`)
 	write("packs/imported/agents/mayor/template-fragments/city-footer.template.md", `{{ define "city-footer" }}City Footer{{ end }}`)
 
 	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
@@ -925,13 +920,8 @@ prompt_template = "agents/mayor/prompt.template.md"
 	if err != nil {
 		t.Fatalf("resolveTemplate: %v", err)
 	}
-	packIdx := strings.Index(tp.Prompt, "Pack Footer")
-	cityIdx := strings.Index(tp.Prompt, "City Footer")
-	if packIdx < 0 || cityIdx < 0 {
-		t.Fatalf("prompt missing inherited fragments: %q", tp.Prompt)
-	}
-	if packIdx > cityIdx {
-		t.Fatalf("pack fragment should render before city fragment: %q", tp.Prompt)
+	if !strings.Contains(tp.Prompt, "City Footer") {
+		t.Fatalf("prompt missing city append fragment: %q", tp.Prompt)
 	}
 }
 
@@ -1001,289 +991,5 @@ func TestResolveTemplateConventionAgentAppendFragments(t *testing.T) {
 	}
 	if !strings.Contains(tp.Prompt, "Discord Ready") {
 		t.Fatalf("prompt missing per-agent append fragment: %q", tp.Prompt)
-	}
-}
-
-func TestResolveTemplateNestedIncludedPackAppendFragmentsLayerBeforeCityDefaults(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 authoring surface")
-	cityPath := t.TempDir()
-	write := func(rel, data string) {
-		path := filepath.Join(cityPath, rel)
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%s): %v", path, err)
-		}
-		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
-			t.Fatalf("WriteFile(%s): %v", path, err)
-		}
-	}
-
-	write("city.toml", `
-[workspace]
-name = "test"
-includes = ["packs/imported"]
-
-[agent_defaults]
-append_fragments = ["city-footer"]
-`)
-	write("packs/imported/pack.toml", `
-[pack]
-name = "imported"
-schema = 2
-includes = ["../base"]
-
-[agent_defaults]
-append_fragments = ["pack-footer"]
-`)
-	write("packs/base/pack.toml", `
-[pack]
-name = "base"
-schema = 2
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-prompt_template = "agents/mayor/prompt.template.md"
-`)
-	write("packs/base/agents/mayor/prompt.template.md", "Hello")
-	write("packs/base/agents/mayor/template-fragments/pack-footer.template.md", `{{ define "pack-footer" }}Pack Footer{{ end }}`)
-	write("packs/base/agents/mayor/template-fragments/city-footer.template.md", `{{ define "city-footer" }}City Footer{{ end }}`)
-
-	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	var agentCfg config.Agent
-	found := false
-	for _, a := range cfg.Agents {
-		if !a.Implicit && a.Name == "mayor" {
-			agentCfg = a
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected explicit imported mayor agent, got %v", cfg.Agents)
-	}
-	params := &agentBuildParams{
-		fs:              fsys.OSFS{},
-		cityName:        "test",
-		cityPath:        cityPath,
-		workspace:       &cfg.Workspace,
-		providers:       config.BuiltinProviders(),
-		lookPath:        func(string) (string, error) { return "/usr/bin/claude", nil },
-		beaconTime:      testBeaconTime,
-		packDirs:        cfg.PackDirs,
-		globalFragments: cfg.Workspace.GlobalFragments,
-		appendFragments: mergeFragmentLists(cfg.AgentDefaults.AppendFragments, cfg.AgentsDefaults.AppendFragments),
-		beadNames:       make(map[string]string),
-		stderr:          io.Discard,
-	}
-
-	tp, err := resolveTemplate(params, &agentCfg, agentCfg.QualifiedName(), nil)
-	if err != nil {
-		t.Fatalf("resolveTemplate: %v", err)
-	}
-	packIdx := strings.Index(tp.Prompt, "Pack Footer")
-	cityIdx := strings.Index(tp.Prompt, "City Footer")
-	if packIdx < 0 || cityIdx < 0 {
-		t.Fatalf("prompt missing inherited fragments: %q", tp.Prompt)
-	}
-	if packIdx > cityIdx {
-		t.Fatalf("pack fragment should render before city fragment: %q", tp.Prompt)
-	}
-}
-
-func TestResolveTemplateWrapperPackDefaultsDoNotBleedAcrossImports(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 authoring surface")
-	cityPath := t.TempDir()
-	write := func(rel, data string) {
-		path := filepath.Join(cityPath, rel)
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%s): %v", path, err)
-		}
-		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
-			t.Fatalf("WriteFile(%s): %v", path, err)
-		}
-	}
-
-	write("city.toml", `
-[workspace]
-name = "test"
-includes = ["packs/wrapper"]
-
-[agent_defaults]
-append_fragments = ["city-footer"]
-`)
-	write("packs/wrapper/pack.toml", `
-[pack]
-name = "wrapper"
-schema = 2
-
-[agent_defaults]
-append_fragments = ["wrapper-footer"]
-
-[imports.dep]
-source = "../dep"
-`)
-	write("packs/dep/pack.toml", `
-[pack]
-name = "dep"
-schema = 2
-
-[agent_defaults]
-append_fragments = ["dep-footer"]
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-prompt_template = "agents/mayor/prompt.template.md"
-`)
-	write("packs/dep/agents/mayor/prompt.template.md", "Hello")
-	write("packs/dep/agents/mayor/template-fragments/dep-footer.template.md", `{{ define "dep-footer" }}Dep Footer{{ end }}`)
-	write("packs/dep/agents/mayor/template-fragments/wrapper-footer.template.md", `{{ define "wrapper-footer" }}Wrapper Footer{{ end }}`)
-	write("packs/dep/agents/mayor/template-fragments/city-footer.template.md", `{{ define "city-footer" }}City Footer{{ end }}`)
-
-	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	var agentCfg config.Agent
-	found := false
-	for _, a := range cfg.Agents {
-		if !a.Implicit && a.BindingName == "dep" && a.Name == "mayor" {
-			agentCfg = a
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected explicit imported dep.mayor agent, got %v", cfg.Agents)
-	}
-	params := &agentBuildParams{
-		fs:              fsys.OSFS{},
-		cityName:        "test",
-		cityPath:        cityPath,
-		workspace:       &cfg.Workspace,
-		providers:       config.BuiltinProviders(),
-		lookPath:        func(string) (string, error) { return "/usr/bin/claude", nil },
-		beaconTime:      testBeaconTime,
-		packDirs:        cfg.PackDirs,
-		globalFragments: cfg.Workspace.GlobalFragments,
-		appendFragments: mergeFragmentLists(cfg.AgentDefaults.AppendFragments, cfg.AgentsDefaults.AppendFragments),
-		beadNames:       make(map[string]string),
-		stderr:          io.Discard,
-	}
-
-	tp, err := resolveTemplate(params, &agentCfg, agentCfg.QualifiedName(), nil)
-	if err != nil {
-		t.Fatalf("resolveTemplate: %v", err)
-	}
-	if strings.Contains(tp.Prompt, "Wrapper Footer") {
-		t.Fatalf("wrapper fragment should not bleed across imports: %q", tp.Prompt)
-	}
-	if !strings.Contains(tp.Prompt, "Dep Footer") || !strings.Contains(tp.Prompt, "City Footer") {
-		t.Fatalf("prompt missing expected fragments: %q", tp.Prompt)
-	}
-}
-
-func TestResolveTemplateIncludingPackDefaultsDoNotBleedAcrossNestedImportBoundaries(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 authoring surface")
-	cityPath := t.TempDir()
-	write := func(rel, data string) {
-		path := filepath.Join(cityPath, rel)
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%s): %v", path, err)
-		}
-		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
-			t.Fatalf("WriteFile(%s): %v", path, err)
-		}
-	}
-
-	write("city.toml", `
-[workspace]
-name = "test"
-includes = ["packs/outer"]
-
-[agent_defaults]
-append_fragments = ["city-footer"]
-`)
-	write("packs/outer/pack.toml", `
-[pack]
-name = "outer"
-schema = 2
-includes = ["../mid"]
-
-[agent_defaults]
-append_fragments = ["outer-footer"]
-`)
-	write("packs/mid/pack.toml", `
-[pack]
-name = "mid"
-schema = 2
-
-[imports.dep]
-source = "../dep"
-`)
-	write("packs/dep/pack.toml", `
-[pack]
-name = "dep"
-schema = 2
-
-[agent_defaults]
-append_fragments = ["dep-footer"]
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-prompt_template = "agents/mayor/prompt.template.md"
-`)
-	write("packs/dep/agents/mayor/prompt.template.md", "Hello")
-	write("packs/dep/agents/mayor/template-fragments/dep-footer.template.md", `{{ define "dep-footer" }}Dep Footer{{ end }}`)
-	write("packs/dep/agents/mayor/template-fragments/outer-footer.template.md", `{{ define "outer-footer" }}Outer Footer{{ end }}`)
-	write("packs/dep/agents/mayor/template-fragments/city-footer.template.md", `{{ define "city-footer" }}City Footer{{ end }}`)
-
-	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	var agentCfg config.Agent
-	found := false
-	for _, a := range cfg.Agents {
-		if !a.Implicit && a.BindingName == "dep" && a.Name == "mayor" {
-			agentCfg = a
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatalf("expected explicit imported dep.mayor agent, got %v", cfg.Agents)
-	}
-	params := &agentBuildParams{
-		fs:              fsys.OSFS{},
-		cityName:        "test",
-		cityPath:        cityPath,
-		workspace:       &cfg.Workspace,
-		providers:       config.BuiltinProviders(),
-		lookPath:        func(string) (string, error) { return "/usr/bin/claude", nil },
-		beaconTime:      testBeaconTime,
-		packDirs:        cfg.PackDirs,
-		globalFragments: cfg.Workspace.GlobalFragments,
-		appendFragments: mergeFragmentLists(cfg.AgentDefaults.AppendFragments, cfg.AgentsDefaults.AppendFragments),
-		beadNames:       make(map[string]string),
-		stderr:          io.Discard,
-	}
-
-	tp, err := resolveTemplate(params, &agentCfg, agentCfg.QualifiedName(), nil)
-	if err != nil {
-		t.Fatalf("resolveTemplate: %v", err)
-	}
-	if strings.Contains(tp.Prompt, "Outer Footer") {
-		t.Fatalf("including-pack fragment should not bleed across nested import boundaries: %q", tp.Prompt)
-	}
-	if !strings.Contains(tp.Prompt, "Dep Footer") || !strings.Contains(tp.Prompt, "City Footer") {
-		t.Fatalf("prompt missing expected fragments: %q", tp.Prompt)
 	}
 }

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -852,6 +852,7 @@ func TestResolveTemplateWrappedClaudeProjectsSettings(t *testing.T) {
 }
 
 func TestResolveTemplateImportedPackAppendFragmentsLayerBeforeCityDefaults(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 authoring surface")
 	cityPath := t.TempDir()
 	write := func(rel, data string) {
 		path := filepath.Join(cityPath, rel)
@@ -1004,6 +1005,7 @@ func TestResolveTemplateConventionAgentAppendFragments(t *testing.T) {
 }
 
 func TestResolveTemplateNestedIncludedPackAppendFragmentsLayerBeforeCityDefaults(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 authoring surface")
 	cityPath := t.TempDir()
 	write := func(rel, data string) {
 		path := filepath.Join(cityPath, rel)
@@ -1093,6 +1095,7 @@ prompt_template = "agents/mayor/prompt.template.md"
 }
 
 func TestResolveTemplateWrapperPackDefaultsDoNotBleedAcrossImports(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 authoring surface")
 	cityPath := t.TempDir()
 	write := func(rel, data string) {
 		path := filepath.Join(cityPath, rel)
@@ -1186,6 +1189,7 @@ prompt_template = "agents/mayor/prompt.template.md"
 }
 
 func TestResolveTemplateIncludingPackDefaultsDoNotBleedAcrossNestedImportBoundaries(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 authoring surface")
 	cityPath := t.TempDir()
 	write := func(rel, data string) {
 		path := filepath.Join(cityPath, rel)

--- a/cmd/gc/testdata/formula-show.txtar
+++ b/cmd/gc/testdata/formula-show.txtar
@@ -24,9 +24,6 @@ stdout 'cook'
 name = "my-city"
 provider = "claude"
 
-[formulas]
-dir = "formulas"
-
 [[agent]]
 name = "chef"
 start_command = "echo hello"

--- a/cmd/gc/testdata/gastown-config.txtar
+++ b/cmd/gc/testdata/gastown-config.txtar
@@ -89,9 +89,6 @@ max_restarts = 5
 restart_window = "1h"
 shutdown_timeout = "5s"
 
-[formulas]
-dir = "formulas"
-
 [[agent]]
 name = "mayor"
 start_command = "echo hello"

--- a/cmd/gc/testdata/gastown-order.txtar
+++ b/cmd/gc/testdata/gastown-order.txtar
@@ -59,9 +59,6 @@ stderr 'unknown subcommand "blorp"'
 [workspace]
 name = "ordertown"
 
-[formulas]
-dir = "formulas"
-
 [[agent]]
 name = "deacon"
 start_command = "echo hello"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -161,6 +161,12 @@
           "internals/index",
           "internals/beads-topology"
         ]
+      },
+      {
+        "group": "Specifications",
+        "pages": [
+          "specs/pack-spec"
+        ]
       }
     ]
   }

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -2,6 +2,8 @@
 
 Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility.
 
+> **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec).
+
 > **Auto-generated** — do not edit. Run `go run ./cmd/genschema` to regenerate.
 
 ## City
@@ -15,6 +17,7 @@ City is the top-level configuration for a Gas City instance.
 | `providers` | map[string]ProviderSpec |  |  | Providers defines named provider presets for agent startup. |
 | `packs` | map[string]PackSource |  |  | Packs defines named remote pack sources fetched via git (V1 mechanism). |
 | `imports` | map[string]Import |  |  | Imports defines named pack imports (V2 mechanism). Each key is a binding name; the value specifies the source and optional version, export, and transitive controls. Processed during ExpandCityPacks. |
+| `defaults` | PackDefaults |  |  | Defaults holds city-level defaults that seed generated config. The canonical default-rig import table is [defaults.rig.imports]. |
 | `agent` | []Agent |  |  | Agents lists all configured agents in this city. Optional: PackV2 cities compose agents through [imports.*] and ship without any [[agent]] block. |
 | `named_session` | []NamedSession |  |  | NamedSessions lists canonical alias-backed sessions built from reusable agent templates. |
 | `rigs` | []Rig |  |  | Rigs lists external projects registered in the city. |
@@ -334,11 +337,10 @@ EventsRotationConfig holds file-backed events rotation settings.
 
 ## FormulasConfig
 
-FormulasConfig holds formula directory settings.
+FormulasConfig holds legacy formula directory settings.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `dir` | string |  | `formulas` | Dir is the path to the formulas directory. Defaults to "formulas". |
 
 ## Import
 
@@ -436,6 +438,22 @@ OrdersConfig holds order settings.
 | `skip` | []string |  |  | Skip lists order names to exclude from scanning. |
 | `max_timeout` | string |  |  | MaxTimeout is an operator hard cap on per-order timeouts. No order gets more than this duration. Go duration string (e.g., "60s"). Empty means uncapped (no override). |
 | `overrides` | []OrderOverride |  |  | Overrides apply per-order field overrides after scanning. Each override targets an order by name and optionally by rig. |
+
+## PackDefaults
+
+PackDefaults holds [defaults] entries used to seed generated rig configuration.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `rig` | PackRigDefaults |  |  |  |
+
+## PackRigDefaults
+
+PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `imports` | map[string]Import |  |  |  |
 
 ## PackSource
 
@@ -674,6 +692,6 @@ Workspace holds city-level metadata and optional defaults that apply to all agen
 | `install_agent_hooks` | []string |  |  | InstallAgentHooks lists provider names whose hooks should be installed into agent working directories. Agent-level overrides workspace-level (replace, not additive). Supported: "claude", "codex", "gemini", "kiro", "opencode", "copilot", "cursor", "pi", "omp". |
 | `global_fragments` | []string |  |  | GlobalFragments lists named template fragments injected into every agent's rendered prompt. Applied before per-agent InjectFragments. Each name must match a &#123;&#123; define "name" &#125;&#125; block from a pack's prompts/shared/ directory. |
 | `includes` | []string |  |  | Includes is the legacy city.toml pack-composition list.  Deprecated: use root pack.toml [imports.*] instead. Run gc doctor to inspect; gc doctor --fix handles the safe mechanical rewrites available in this release wave. Each entry is a local path, a git source//sub#ref URL, or a GitHub tree URL. |
-| `default_rig_includes` | []string |  |  | DefaultRigIncludes is the legacy city.toml default-rig pack list.  Deprecated: use root pack.toml [defaults.rig.imports.&lt;binding&gt;] instead. Run gc doctor to inspect; gc doctor --fix handles the safe mechanical rewrites available in this release wave. |
+| `default_rig_includes` | []string |  |  | DefaultRigIncludes is the legacy city.toml default-rig pack list.  Deprecated: use city.toml [defaults.rig.imports.&lt;binding&gt;] instead. Run gc doctor to inspect; gc doctor --fix handles the safe mechanical rewrites available in this release wave. |
 | `env` | map[string]string |  |  | Env defines workspace-wide environment variables applied to every managed session. Lowest config-precedence — overridden by provider, agent, and patch env. Use for cross-cutting variables like GC_TARGET_BRANCH that every agent should inherit. |
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -967,6 +967,10 @@
           "type": "object",
           "description": "Imports defines named pack imports (V2 mechanism). Each key is a\nbinding name; the value specifies the source and optional version,\nexport, and transitive controls. Processed during ExpandCityPacks."
         },
+        "defaults": {
+          "$ref": "#/$defs/PackDefaults",
+          "description": "Defaults holds city-level defaults that seed generated config. The\ncanonical default-rig import table is [defaults.rig.imports]."
+        },
         "agent": {
           "items": {
             "$ref": "#/$defs/Agent"
@@ -1285,16 +1289,10 @@
       "description": "EventsRotationConfig holds file-backed events rotation settings."
     },
     "FormulasConfig": {
-      "properties": {
-        "dir": {
-          "type": "string",
-          "description": "Dir is the path to the formulas directory. Defaults to \"formulas\".",
-          "default": "formulas"
-        }
-      },
+      "properties": {},
       "additionalProperties": false,
       "type": "object",
-      "description": "FormulasConfig holds formula directory settings."
+      "description": "FormulasConfig holds legacy formula directory settings."
     },
     "Import": {
       "properties": {
@@ -1566,6 +1564,29 @@
       "additionalProperties": false,
       "type": "object",
       "description": "OrdersConfig holds order settings."
+    },
+    "PackDefaults": {
+      "properties": {
+        "rig": {
+          "$ref": "#/$defs/PackRigDefaults"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackDefaults holds [defaults] entries used to seed generated rig configuration."
+    },
+    "PackRigDefaults": {
+      "properties": {
+        "imports": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Import"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack."
     },
     "PackSource": {
       "properties": {
@@ -2326,7 +2347,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "DefaultRigIncludes is the legacy city.toml default-rig pack list.\n\nDeprecated: use root pack.toml [defaults.rig.imports.\u003cbinding\u003e] instead.\nRun gc doctor to inspect; gc doctor --fix handles the safe mechanical\nrewrites available in this release wave."
+          "description": "DefaultRigIncludes is the legacy city.toml default-rig pack list.\n\nDeprecated: use city.toml [defaults.rig.imports.\u003cbinding\u003e] instead.\nRun gc doctor to inspect; gc doctor --fix handles the safe mechanical\nrewrites available in this release wave."
         },
         "env": {
           "additionalProperties": {
@@ -2342,5 +2363,5 @@
     }
   },
   "title": "Gas City Configuration",
-  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility."
+  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 }

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -967,6 +967,10 @@
           "type": "object",
           "description": "Imports defines named pack imports (V2 mechanism). Each key is a\nbinding name; the value specifies the source and optional version,\nexport, and transitive controls. Processed during ExpandCityPacks."
         },
+        "defaults": {
+          "$ref": "#/$defs/PackDefaults",
+          "description": "Defaults holds city-level defaults that seed generated config. The\ncanonical default-rig import table is [defaults.rig.imports]."
+        },
         "agent": {
           "items": {
             "$ref": "#/$defs/Agent"
@@ -1285,16 +1289,10 @@
       "description": "EventsRotationConfig holds file-backed events rotation settings."
     },
     "FormulasConfig": {
-      "properties": {
-        "dir": {
-          "type": "string",
-          "description": "Dir is the path to the formulas directory. Defaults to \"formulas\".",
-          "default": "formulas"
-        }
-      },
+      "properties": {},
       "additionalProperties": false,
       "type": "object",
-      "description": "FormulasConfig holds formula directory settings."
+      "description": "FormulasConfig holds legacy formula directory settings."
     },
     "Import": {
       "properties": {
@@ -1566,6 +1564,29 @@
       "additionalProperties": false,
       "type": "object",
       "description": "OrdersConfig holds order settings."
+    },
+    "PackDefaults": {
+      "properties": {
+        "rig": {
+          "$ref": "#/$defs/PackRigDefaults"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackDefaults holds [defaults] entries used to seed generated rig configuration."
+    },
+    "PackRigDefaults": {
+      "properties": {
+        "imports": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Import"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack."
     },
     "PackSource": {
       "properties": {
@@ -2326,7 +2347,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "DefaultRigIncludes is the legacy city.toml default-rig pack list.\n\nDeprecated: use root pack.toml [defaults.rig.imports.\u003cbinding\u003e] instead.\nRun gc doctor to inspect; gc doctor --fix handles the safe mechanical\nrewrites available in this release wave."
+          "description": "DefaultRigIncludes is the legacy city.toml default-rig pack list.\n\nDeprecated: use city.toml [defaults.rig.imports.\u003cbinding\u003e] instead.\nRun gc doctor to inspect; gc doctor --fix handles the safe mechanical\nrewrites available in this release wave."
         },
         "env": {
           "additionalProperties": {
@@ -2342,5 +2363,5 @@
     }
   },
   "title": "Gas City Configuration",
-  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility."
+  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 }

--- a/docs/schema/pack-schema.json
+++ b/docs/schema/pack-schema.json
@@ -286,64 +286,6 @@
       ],
       "description": "Agent defines a configured agent in the city."
     },
-    "AgentDefaults": {
-      "properties": {
-        "model": {
-          "type": "string",
-          "description": "Model is the parsed/composed default model name for agents\n(e.g., \"claude-sonnet-4-6\"), but it is not yet auto-applied at\nruntime. Agents with their own model override would take precedence."
-        },
-        "wake_mode": {
-          "type": "string",
-          "enum": [
-            "resume",
-            "fresh"
-          ],
-          "description": "WakeMode is the parsed/composed default wake mode (\"resume\" or\n\"fresh\"), but it is not yet auto-applied at runtime."
-        },
-        "default_sling_formula": {
-          "type": "string",
-          "description": "DefaultSlingFormula is the city-level default formula used for agents\nthat inherit [agent_defaults]. Explicit agents only receive this value\nwhen agent_defaults.default_sling_formula is set; implicit multi-session\nconfigs are seeded with \"mol-do-work\" elsewhere when no explicit default is set."
-        },
-        "allow_overlay": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "AllowOverlay is parsed and composed as a city-level allowlist for\nsession overlays, but it is not yet inherited onto agents\nautomatically at runtime."
-        },
-        "allow_env_override": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "AllowEnvOverride is parsed and composed as a city-level allowlist for\nsession env overrides, but it is not yet inherited onto agents\nautomatically at runtime. Names must match ^[A-Z][A-Z0-9_]{0,127}$."
-        },
-        "append_fragments": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "AppendFragments lists named template fragments to auto-append to\n.template.md prompts after rendering. Legacy .md.tmpl prompts are\nstill supported during the transition; plain .md remains inert.\nV2 migration convenience — replaces global_fragments/inject_fragments\nfor city-wide defaults."
-        },
-        "skills": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Skills is a tombstone field retained for v0.15.1 backwards\ncompatibility. Parsed and composed for migration visibility, but\nattachment-list fields are accepted but ignored by the active\nmaterializer."
-        },
-        "mcp": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "MCP is a tombstone field retained for v0.15.1 backwards compatibility.\nParsed and composed for migration visibility, but attachment-list\nfields are accepted but ignored by the active materializer."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "AgentDefaults provides city-level agent defaults declared via [agent_defaults] in city.toml."
-    },
     "AgentPatch": {
       "properties": {
         "dir": {
@@ -607,18 +549,6 @@
       ],
       "description": "AgentPatch modifies an existing agent identified by (Dir, Name)."
     },
-    "FormulasConfig": {
-      "properties": {
-        "dir": {
-          "type": "string",
-          "description": "Dir is the path to the formulas directory. Defaults to \"formulas\".",
-          "default": "formulas"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "FormulasConfig holds formula directory settings."
-    },
     "Import": {
       "properties": {
         "source": {
@@ -795,12 +725,6 @@
           },
           "type": "object"
         },
-        "agent_defaults": {
-          "$ref": "#/$defs/AgentDefaults"
-        },
-        "defaults": {
-          "$ref": "#/$defs/PackDefaults"
-        },
         "agent": {
           "items": {
             "$ref": "#/$defs/Agent"
@@ -825,11 +749,8 @@
           },
           "type": "object"
         },
-        "formulas": {
-          "$ref": "#/$defs/FormulasConfig"
-        },
         "patches": {
-          "$ref": "#/$defs/Patches"
+          "$ref": "#/$defs/PackPatches"
         },
         "doctor": {
           "items": {
@@ -859,16 +780,6 @@
         "pack"
       ],
       "description": "PackConfig is the TOML structure of a pack.toml file."
-    },
-    "PackDefaults": {
-      "properties": {
-        "rig": {
-          "$ref": "#/$defs/PackRigDefaults"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "PackDefaults holds [defaults] entries declared by a pack — used by cities that compose this pack to seed rig configuration."
     },
     "PackDoctorEntry": {
       "properties": {
@@ -960,6 +871,19 @@
       ],
       "description": "PackMeta holds metadata from a pack's [pack] header."
     },
+    "PackPatches": {
+      "properties": {
+        "agent": {
+          "items": {
+            "$ref": "#/$defs/AgentPatch"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackPatches holds the patch operations valid in pack.toml."
+    },
     "PackRequirement": {
       "properties": {
         "scope": {
@@ -982,47 +906,6 @@
         "agent"
       ],
       "description": "PackRequirement declares an agent that must exist in the expanded config for this pack's formulas/orders to function."
-    },
-    "PackRigDefaults": {
-      "properties": {
-        "imports": {
-          "additionalProperties": {
-            "$ref": "#/$defs/Import"
-          },
-          "type": "object"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack."
-    },
-    "Patches": {
-      "properties": {
-        "agent": {
-          "items": {
-            "$ref": "#/$defs/AgentPatch"
-          },
-          "type": "array",
-          "description": "Agents targets agents by (dir, name)."
-        },
-        "rigs": {
-          "items": {
-            "$ref": "#/$defs/RigPatch"
-          },
-          "type": "array",
-          "description": "Rigs targets rigs by name."
-        },
-        "providers": {
-          "items": {
-            "$ref": "#/$defs/ProviderPatch"
-          },
-          "type": "array",
-          "description": "Providers targets providers by name."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "Patches holds all patch blocks from composition."
     },
     "PoolOverride": {
       "properties": {
@@ -1093,97 +976,6 @@
         "choices"
       ],
       "description": "ProviderOption declares a single configurable option for a provider."
-    },
-    "ProviderPatch": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name is the targeting key (required). Must match an existing provider's name."
-        },
-        "base": {
-          "type": "string",
-          "description": "Base overrides the provider's inheritance parent (presence-aware).\nPointer to a pointer so the patch can distinguish \"no change\"\n(double-nil) from \"clear to inherit default\" (single-nil value in\nouter pointer) from \"set to explicit empty opt-out\" (value \"\" in\ninner pointer) from \"set to \u003cname\u003e\". Callers use:\n  nil          = patch does not touch Base\n  \u0026(*string)(nil) = patch clears Base to absent\n  \u0026(\u0026\"\")       = patch sets Base = \"\" (explicit opt-out)\n  \u0026(\u0026\"builtin:codex\") = patch sets Base to that value"
-        },
-        "command": {
-          "type": "string",
-          "description": "Command overrides the provider command."
-        },
-        "acp_command": {
-          "type": "string",
-          "description": "ACPCommand overrides the provider command for ACP transport sessions."
-        },
-        "args": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Args overrides the provider args."
-        },
-        "acp_args": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "ACPArgs overrides the provider args for ACP transport sessions."
-        },
-        "args_append": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "ArgsAppend overrides the provider args_append list."
-        },
-        "options_schema_merge": {
-          "type": "string",
-          "description": "OptionsSchemaMerge overrides the options_schema merge mode."
-        },
-        "prompt_mode": {
-          "type": "string",
-          "enum": [
-            "arg",
-            "flag",
-            "none"
-          ],
-          "description": "PromptMode overrides prompt delivery mode."
-        },
-        "prompt_flag": {
-          "type": "string",
-          "description": "PromptFlag overrides the prompt flag."
-        },
-        "ready_delay_ms": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "ReadyDelayMs overrides the ready delay in milliseconds."
-        },
-        "accept_startup_dialogs": {
-          "type": "boolean",
-          "description": "AcceptStartupDialogs overrides startup dialog acceptance behavior."
-        },
-        "env": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object",
-          "description": "Env adds or overrides environment variables."
-        },
-        "env_remove": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "EnvRemove lists env var keys to remove."
-        },
-        "_replace": {
-          "type": "boolean",
-          "description": "Replace replaces the entire provider block instead of deep-merging."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "description": "ProviderPatch modifies an existing provider identified by Name."
     },
     "ProviderSpec": {
       "properties": {
@@ -1345,43 +1137,6 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ProviderSpec defines a named provider's startup parameters."
-    },
-    "RigPatch": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name is the targeting key (required). Must match an existing rig's name."
-        },
-        "path": {
-          "type": "string",
-          "description": "Path overrides the rig's filesystem path."
-        },
-        "prefix": {
-          "type": "string",
-          "description": "Prefix overrides the bead ID prefix."
-        },
-        "default_branch": {
-          "type": "string",
-          "description": "DefaultBranch overrides the rig's recorded mainline branch."
-        },
-        "suspended": {
-          "type": "boolean",
-          "description": "Suspended overrides the rig's suspended state."
-        },
-        "formula_vars": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object",
-          "description": "FormulaVars adds or overrides rig-scoped formula var defaults.\nAdditive merge: patch keys win over existing rig keys, unspecified\nkeys are preserved."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "description": "RigPatch modifies an existing rig identified by Name."
     },
     "Service": {
       "properties": {

--- a/docs/schema/pack-schema.txt
+++ b/docs/schema/pack-schema.txt
@@ -286,64 +286,6 @@
       ],
       "description": "Agent defines a configured agent in the city."
     },
-    "AgentDefaults": {
-      "properties": {
-        "model": {
-          "type": "string",
-          "description": "Model is the parsed/composed default model name for agents\n(e.g., \"claude-sonnet-4-6\"), but it is not yet auto-applied at\nruntime. Agents with their own model override would take precedence."
-        },
-        "wake_mode": {
-          "type": "string",
-          "enum": [
-            "resume",
-            "fresh"
-          ],
-          "description": "WakeMode is the parsed/composed default wake mode (\"resume\" or\n\"fresh\"), but it is not yet auto-applied at runtime."
-        },
-        "default_sling_formula": {
-          "type": "string",
-          "description": "DefaultSlingFormula is the city-level default formula used for agents\nthat inherit [agent_defaults]. Explicit agents only receive this value\nwhen agent_defaults.default_sling_formula is set; implicit multi-session\nconfigs are seeded with \"mol-do-work\" elsewhere when no explicit default is set."
-        },
-        "allow_overlay": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "AllowOverlay is parsed and composed as a city-level allowlist for\nsession overlays, but it is not yet inherited onto agents\nautomatically at runtime."
-        },
-        "allow_env_override": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "AllowEnvOverride is parsed and composed as a city-level allowlist for\nsession env overrides, but it is not yet inherited onto agents\nautomatically at runtime. Names must match ^[A-Z][A-Z0-9_]{0,127}$."
-        },
-        "append_fragments": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "AppendFragments lists named template fragments to auto-append to\n.template.md prompts after rendering. Legacy .md.tmpl prompts are\nstill supported during the transition; plain .md remains inert.\nV2 migration convenience — replaces global_fragments/inject_fragments\nfor city-wide defaults."
-        },
-        "skills": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Skills is a tombstone field retained for v0.15.1 backwards\ncompatibility. Parsed and composed for migration visibility, but\nattachment-list fields are accepted but ignored by the active\nmaterializer."
-        },
-        "mcp": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "MCP is a tombstone field retained for v0.15.1 backwards compatibility.\nParsed and composed for migration visibility, but attachment-list\nfields are accepted but ignored by the active materializer."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "AgentDefaults provides city-level agent defaults declared via [agent_defaults] in city.toml."
-    },
     "AgentPatch": {
       "properties": {
         "dir": {
@@ -607,18 +549,6 @@
       ],
       "description": "AgentPatch modifies an existing agent identified by (Dir, Name)."
     },
-    "FormulasConfig": {
-      "properties": {
-        "dir": {
-          "type": "string",
-          "description": "Dir is the path to the formulas directory. Defaults to \"formulas\".",
-          "default": "formulas"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "FormulasConfig holds formula directory settings."
-    },
     "Import": {
       "properties": {
         "source": {
@@ -795,12 +725,6 @@
           },
           "type": "object"
         },
-        "agent_defaults": {
-          "$ref": "#/$defs/AgentDefaults"
-        },
-        "defaults": {
-          "$ref": "#/$defs/PackDefaults"
-        },
         "agent": {
           "items": {
             "$ref": "#/$defs/Agent"
@@ -825,11 +749,8 @@
           },
           "type": "object"
         },
-        "formulas": {
-          "$ref": "#/$defs/FormulasConfig"
-        },
         "patches": {
-          "$ref": "#/$defs/Patches"
+          "$ref": "#/$defs/PackPatches"
         },
         "doctor": {
           "items": {
@@ -859,16 +780,6 @@
         "pack"
       ],
       "description": "PackConfig is the TOML structure of a pack.toml file."
-    },
-    "PackDefaults": {
-      "properties": {
-        "rig": {
-          "$ref": "#/$defs/PackRigDefaults"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "PackDefaults holds [defaults] entries declared by a pack — used by cities that compose this pack to seed rig configuration."
     },
     "PackDoctorEntry": {
       "properties": {
@@ -960,6 +871,19 @@
       ],
       "description": "PackMeta holds metadata from a pack's [pack] header."
     },
+    "PackPatches": {
+      "properties": {
+        "agent": {
+          "items": {
+            "$ref": "#/$defs/AgentPatch"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PackPatches holds the patch operations valid in pack.toml."
+    },
     "PackRequirement": {
       "properties": {
         "scope": {
@@ -982,47 +906,6 @@
         "agent"
       ],
       "description": "PackRequirement declares an agent that must exist in the expanded config for this pack's formulas/orders to function."
-    },
-    "PackRigDefaults": {
-      "properties": {
-        "imports": {
-          "additionalProperties": {
-            "$ref": "#/$defs/Import"
-          },
-          "type": "object"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack."
-    },
-    "Patches": {
-      "properties": {
-        "agent": {
-          "items": {
-            "$ref": "#/$defs/AgentPatch"
-          },
-          "type": "array",
-          "description": "Agents targets agents by (dir, name)."
-        },
-        "rigs": {
-          "items": {
-            "$ref": "#/$defs/RigPatch"
-          },
-          "type": "array",
-          "description": "Rigs targets rigs by name."
-        },
-        "providers": {
-          "items": {
-            "$ref": "#/$defs/ProviderPatch"
-          },
-          "type": "array",
-          "description": "Providers targets providers by name."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "Patches holds all patch blocks from composition."
     },
     "PoolOverride": {
       "properties": {
@@ -1093,97 +976,6 @@
         "choices"
       ],
       "description": "ProviderOption declares a single configurable option for a provider."
-    },
-    "ProviderPatch": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name is the targeting key (required). Must match an existing provider's name."
-        },
-        "base": {
-          "type": "string",
-          "description": "Base overrides the provider's inheritance parent (presence-aware).\nPointer to a pointer so the patch can distinguish \"no change\"\n(double-nil) from \"clear to inherit default\" (single-nil value in\nouter pointer) from \"set to explicit empty opt-out\" (value \"\" in\ninner pointer) from \"set to \u003cname\u003e\". Callers use:\n  nil          = patch does not touch Base\n  \u0026(*string)(nil) = patch clears Base to absent\n  \u0026(\u0026\"\")       = patch sets Base = \"\" (explicit opt-out)\n  \u0026(\u0026\"builtin:codex\") = patch sets Base to that value"
-        },
-        "command": {
-          "type": "string",
-          "description": "Command overrides the provider command."
-        },
-        "acp_command": {
-          "type": "string",
-          "description": "ACPCommand overrides the provider command for ACP transport sessions."
-        },
-        "args": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Args overrides the provider args."
-        },
-        "acp_args": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "ACPArgs overrides the provider args for ACP transport sessions."
-        },
-        "args_append": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "ArgsAppend overrides the provider args_append list."
-        },
-        "options_schema_merge": {
-          "type": "string",
-          "description": "OptionsSchemaMerge overrides the options_schema merge mode."
-        },
-        "prompt_mode": {
-          "type": "string",
-          "enum": [
-            "arg",
-            "flag",
-            "none"
-          ],
-          "description": "PromptMode overrides prompt delivery mode."
-        },
-        "prompt_flag": {
-          "type": "string",
-          "description": "PromptFlag overrides the prompt flag."
-        },
-        "ready_delay_ms": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "ReadyDelayMs overrides the ready delay in milliseconds."
-        },
-        "accept_startup_dialogs": {
-          "type": "boolean",
-          "description": "AcceptStartupDialogs overrides startup dialog acceptance behavior."
-        },
-        "env": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object",
-          "description": "Env adds or overrides environment variables."
-        },
-        "env_remove": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "EnvRemove lists env var keys to remove."
-        },
-        "_replace": {
-          "type": "boolean",
-          "description": "Replace replaces the entire provider block instead of deep-merging."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "description": "ProviderPatch modifies an existing provider identified by Name."
     },
     "ProviderSpec": {
       "properties": {
@@ -1345,43 +1137,6 @@
       "additionalProperties": false,
       "type": "object",
       "description": "ProviderSpec defines a named provider's startup parameters."
-    },
-    "RigPatch": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name is the targeting key (required). Must match an existing rig's name."
-        },
-        "path": {
-          "type": "string",
-          "description": "Path overrides the rig's filesystem path."
-        },
-        "prefix": {
-          "type": "string",
-          "description": "Prefix overrides the bead ID prefix."
-        },
-        "default_branch": {
-          "type": "string",
-          "description": "DefaultBranch overrides the rig's recorded mainline branch."
-        },
-        "suspended": {
-          "type": "boolean",
-          "description": "Suspended overrides the rig's suspended state."
-        },
-        "formula_vars": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object",
-          "description": "FormulaVars adds or overrides rig-scoped formula var defaults.\nAdditive merge: patch keys win over existing rig keys, unspecified\nkeys are preserved."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "description": "RigPatch modifies an existing rig identified by Name."
     },
     "Service": {
       "properties": {

--- a/docs/specs/pack-spec.md
+++ b/docs/specs/pack-spec.md
@@ -1,0 +1,843 @@
+---
+title: Gas City Pack Specification (2.0)
+description: Authoritative specification for Gas City pack format and loading semantics.
+---
+
+# Gas City Pack Specification (2.0)
+
+| Field | Value |
+|---|---|
+| Status | Authoritative specification |
+| Last verified | 2026-05-22 |
+| Pack schema | 2 |
+| Primary implementation | `internal/config/pack.go`, `internal/config/config.go`, `internal/config/compose.go` |
+| User-facing guide | `docs/guides/reusing-and-customizing-packs.md` |
+
+This document specifies the Gas City pack format as a data model, file format,
+and loading process. **PackV2** is the shorthand name for the Gas City Pack
+Specification (2.0). Design notes may explain why a future direction is
+attractive, but this document is the authoritative source for PackV2.
+
+The key words "must", "must not", "required", "shall", "shall not", "should",
+"should not", and "may" are to be interpreted as normative requirements unless
+the paragraph is explicitly marked as non-normative.
+
+## 0. Data And Information Model
+
+PackV2 separates the *format* of a pack from the *loading* of a pack. The format
+is the directory and TOML data a pack author writes. Loading is the process that
+resolves dependencies, stamps definitions into a city or rig context, applies
+patches and defaults, and produces one effective `City` configuration.
+
+### 0.1. Pack
+
+A pack is a directory containing a `pack.toml` file and zero or more
+definition, asset, and support files. The `pack.toml` file is the pack's
+metadata and manifest. Other files are either definition files discovered by
+well-known rules or private files referenced by TOML fields.
+
+A pack may be used in three contexts:
+
+1. As the root pack of a city. The root pack is the city directory containing
+   `city.toml` and the root `pack.toml`.
+2. As a city-level imported pack. Its city-scoped and unscoped definitions are
+   loaded into the city-level surface.
+3. As a rig-level imported pack. Its rig-scoped and unscoped definitions are
+   loaded into a specific rig surface and stamped with that rig's name.
+
+### 0.2. Pack Identity
+
+A pack identity consists of:
+
+```text
+PackIdentity {
+    name: string
+    schema: integer
+    version: optional string
+    requires_gc: optional string
+}
+```
+
+The `name` identifies the pack as a product and as a provenance label. It must
+be present in `[pack]`.
+
+The `schema` identifies the PackV2 file-format schema. The schema specified by
+this document is `2`. A loader must reject a pack whose
+schema is omitted, zero, or greater than the loader's supported schema.
+
+The `version` is pack metadata. Version selection is controlled by import
+constraints and lockfile resolution, not by a loader comparing `[pack].version`
+directly.
+
+The `requires_gc` field is optional metadata for the minimum compatible `gc`
+version. It is parsed as pack metadata.
+
+### 0.3. Pack Contents
+
+A pack may contain the following abstract content:
+
+```text
+PackContents {
+    imports: ordered set of PackImport
+    agents: list of AgentDefinition
+    named_sessions: list of NamedSessionDefinition
+    services: list of ServiceDefinition
+    providers: map<string, ProviderDefinition>
+    formulas: optional FormulaDirectoryDeclaration
+    patches: optional PatchSet
+    doctor_checks: list of DoctorCheck
+    commands: list of PackCommand
+    globals: optional GlobalSessionLiveDefinition
+    assets: file tree
+}
+```
+
+The concrete `pack.toml` fields that encode these contents are specified in
+section 1.2.
+
+### 0.4. Public And Private Content
+
+PackV2 currently loads pack definitions by scope. It does not implement the
+proposed `[export]` surface yet.
+
+Definitions in `pack.toml` are therefore visible to consumers according to
+loader scope rules, not according to an explicit export manifest. Files under
+`assets/` are private support files unless a public definition references them.
+Other non-reserved files are also private support files unless referenced by a
+definition.
+
+The current loader does not give import bindings a runtime namespace for agents.
+If a city-level imported pack defines an agent named `reviewer`, the effective
+city-level agent name is `reviewer`, not `<binding>/reviewer`.
+
+## 1. File System Structure
+
+A PackV2 directory has this abstract shape:
+
+```text
+pack-root/
+  pack.toml
+  assets/
+  formulas/
+  overlay/
+  scripts/
+  ...
+```
+
+Only `pack.toml` is required.
+
+### 1.1. Directory Rules
+
+The pack root must be a directory. The pack root must contain a file named
+`pack.toml`.
+
+The following top-level paths are reserved by PackV2:
+
+| Path | Kind | Meaning |
+|---|---|---|
+| `pack.toml` | file | Required pack manifest and metadata. |
+| `assets/` | directory | Preferred location for private implementation files. |
+| `formulas/` | directory | Well-known formula directory. |
+| `overlay/` | directory | Pack-level overlay directory collected automatically from imported packs. |
+| `scripts/` | directory | Pack-level scripts directory collected automatically from imported packs. |
+
+The following top-level paths are conventional and allowed:
+
+| Path | Kind | Meaning |
+|---|---|---|
+| `commands/` | directory | Conventional location for scripts referenced by `[[commands]]`. |
+| `doctor/` | directory | Conventional location for scripts referenced by `[[doctor]]`. |
+| `namepools/` | directory | Conventional location for files referenced by agent `namepool`. |
+| `prompts/` | directory | Conventional location for prompt templates referenced by agents. |
+| `skills/` | directory | Conventional location for skill files shipped with a pack. |
+| `orders/` | directory | Conventional location for order definitions. |
+| `mcps/` | directory | Conventional location for MCP-related configuration. |
+
+Pack authors may include additional private files and directories. New
+machine-readable top-level directories should be added to this specification
+before they are treated as part of the PackV2 format.
+
+The following file-system constructs must not be used as public PackV2 format:
+
+| Construct | Rule |
+|---|---|
+| Cache directories | A checked-in `pack.toml` must not point at Gas City's local cache as a durable dependency. |
+| Registry handles | A checked-in `pack.toml` must not persist command-time handles such as `main:gascity`. |
+| Consumer rig names inside reusable packs | A reusable pack must not assume the names of rigs that will import it. |
+
+### 1.2. The `pack.toml` File
+
+The `pack.toml` file is UTF-8 TOML. It must contain a `[pack]` table.
+
+Conceptually, the file has this structure:
+
+```text
+PackToml {
+    pack: PackMeta
+    imports: map<string, PackImport>
+    agent: list<Agent>
+    named_session: list<NamedSession>
+    service: list<Service>
+    providers: map<string, ProviderSpec>
+    formulas: FormulasConfig
+    patches: Patches
+    doctor: list<PackDoctorEntry>
+    commands: list<PackCommandEntry>
+    global: PackGlobal
+}
+```
+
+Unknown fields are not part of this specification. Current loader behavior may
+warn about unknown keys rather than failing immediately; authors must not rely
+on unknown keys being preserved or interpreted.
+
+### 1.2.1. `[pack]`
+
+The `[pack]` table defines pack metadata.
+
+```toml
+[pack]
+name = "gascity"
+schema = 1
+version = "1.4.0"
+requires_gc = ">=0.13.0"
+```
+
+| Field | Type | Required | Rule |
+|---|---|---|---|
+| `name` | string | yes | Pack identifier and provenance label. Must not be empty. |
+| `schema` | integer | yes | Pack format version. Must be `1` for this specification. |
+| `version` | string | no | Pack version metadata. |
+| `requires_gc` | string | no | Minimum compatible `gc` version metadata. |
+| `includes` | array of string | legacy | Legacy pack composition list. New packs should use `[imports.<binding>]`. |
+| `requires` | array of tables | no | Agent requirements validated after expansion. |
+
+The `includes` field remains a compatibility surface in `pack.toml`. It should
+not be used in newly-authored packs.
+
+### 1.2.2. `[pack.requires]`
+
+Each `[[pack.requires]]` entry declares an agent that must exist after loading.
+
+```toml
+[[pack.requires]]
+scope = "city"
+agent = "reviewer"
+```
+
+| Field | Type | Required | Rule |
+|---|---|---|---|
+| `scope` | string | yes | Must be `city` or `rig`. |
+| `agent` | string | yes | Required agent local name. Must not be empty. |
+
+City-scoped requirements are validated against the expanded city agent list.
+Rig-scoped requirements are validated while loading the pack for a rig.
+
+### 1.2.3. `[imports.<binding>]`
+
+Pack imports are named dependencies.
+
+```toml
+[imports.gascity]
+source = "https://packages.example/main/gascity"
+version = "^1"
+```
+
+The binding name is local to the importing file. Current loader behavior uses
+binding names for deterministic ordering of imports. It does not add binding
+names to runtime agent identities.
+
+| Field | Type | Required | Rule |
+|---|---|---|---|
+| `source` | string | yes | Durable source for the pack root. Must not be empty. |
+| `version` | string | no | Compatibility constraint for versioned sources. |
+
+Public import TOML must not use fields named `path`, `ref`, `commit`, or
+`hash`. Registry handles such as `main:gascity` are command-time lookup handles
+and must not be persisted as `source`.
+
+Imports in `city.toml` use the same table shape for the root pack:
+
+```toml
+[imports.gascity]
+source = "../packs/gascity"
+```
+
+Rig imports are written under the `[[rigs]]` table they apply to:
+
+```toml
+[[rigs]]
+name = "checkout-service"
+path = "../checkout-service"
+
+[rigs.imports.gascity]
+source = "../packs/gascity"
+```
+
+The removed `rigs.includes` field is not a PackV2 import surface. A loader must
+hard-fail if a rig uses `includes`.
+
+### 1.2.4. `[[agent]]`
+
+Each `[[agent]]` table defines an agent template.
+
+```toml
+[[agent]]
+name = "reviewer"
+scope = "city"
+prompt_template = "assets/prompts/reviewer.md"
+provider = "codex"
+```
+
+The `name` field is required. Agent names must be valid session identifiers:
+they start with an ASCII letter or digit and continue with ASCII letters,
+digits, hyphens, or underscores. Slashes, dots, and spaces are not valid agent
+name characters.
+
+The `scope` field controls where a pack-defined agent is instantiated:
+
+| `scope` | Loader meaning |
+|---|---|
+| omitted | Agent is eligible in both city-level and rig-level pack loading. |
+| `city` | Agent is kept only during city-level pack loading. |
+| `rig` | Agent is kept only during rig-level pack loading. |
+
+The full set of currently parsed agent fields is shared with `city.toml`.
+Pack authors should treat these fields as public PackV2 agent fields:
+
+| Field | Type | Rule |
+|---|---|---|
+| `name` | string | Required local agent name. |
+| `description` | string | Human-readable description. |
+| `dir` | string | Identity prefix. Reusable packs should usually omit this. |
+| `work_dir` | string | Session working directory without changing identity. |
+| `scope` | string | `city`, `rig`, or omitted. |
+| `suspended` | bool | Prevents controller startup for the agent. |
+| `pre_start` | array of string | Commands before session creation. |
+| `prompt_template` | string | Prompt template path. Relative paths resolve against the pack directory. |
+| `nudge` | string | Startup nudge text. |
+| `session` | string | Session transport override. Currently `acp` is the specified non-default value. |
+| `provider` | string | Provider preset name. |
+| `start_command` | string | Provider command override. |
+| `args` | array of string | Provider arguments override. |
+| `prompt_mode` | string | `arg`, `flag`, or `none`. |
+| `prompt_flag` | string | Prompt flag when `prompt_mode = "flag"`. |
+| `ready_delay_ms` | integer | Startup readiness delay in milliseconds. |
+| `ready_prompt_prefix` | string | Provider readiness prompt prefix. |
+| `process_names` | array of string | Process names used for liveness checks. |
+| `emits_permission_warning` | bool | Whether the provider emits permission warnings. |
+| `env` | table | Extra environment variables. |
+| `option_defaults` | table | Provider option default overrides for this agent. |
+| `max_active_sessions` | integer | Maximum active sessions for this agent. |
+| `min_active_sessions` | integer | Minimum active sessions for this agent. |
+| `scale_check` | string | Command returning desired session count. |
+| `drain_timeout` | string | Go duration string for scale-down drain. |
+| `on_boot` | string | Command run at controller startup. |
+| `on_death` | string | Command run when a session dies unexpectedly. |
+| `namepool` | string | Path to newline-separated display aliases. |
+| `work_query` | string | Work discovery command. |
+| `sling_query` | string | Work routing command template. |
+| `idle_timeout` | string | Go duration string. Empty disables idle checking. |
+| `sleep_after_idle` | string | Go duration string or `off`. |
+| `install_agent_hooks` | array of string | Agent hook installation override. |
+| `hooks_installed` | bool | Declares hooks already installed. |
+| `session_setup` | array of string | Commands after session creation. |
+| `session_setup_script` | string | Script path after `session_setup`. Relative paths resolve against the pack directory. |
+| `session_live` | array of string | Idempotent live commands. |
+| `overlay_dir` | string | Additive overlay directory. Relative paths resolve against the pack directory. |
+| `default_sling_formula` | string | Formula automatically applied by sling unless disabled. |
+| `inject_fragments` | array of string | Prompt template fragments to inject. |
+| `attach` | bool | Whether interactive attachment is supported. |
+| `fallback` | bool | Marks this as a fallback definition for collision resolution. |
+| `depends_on` | array of string | Agent startup dependencies. Bare rig-pack dependencies are qualified during rig loading. |
+| `resume_command` | string | Provider resume command template. |
+| `wake_mode` | string | `resume` or `fresh`. |
+
+Fields not listed above are not PackV2 agent fields.
+
+### 1.2.5. `[[named_session]]`
+
+Each `[[named_session]]` table declares a canonical session backed by an agent
+template.
+
+```toml
+[[named_session]]
+template = "reviewer"
+scope = "city"
+mode = "always"
+```
+
+| Field | Type | Required | Rule |
+|---|---|---|---|
+| `template` | string | yes | Agent template name. |
+| `scope` | string | no | `city`, `rig`, or omitted. Uses the same filtering rule as agents. |
+| `dir` | string | no | Identity prefix after expansion. Reusable packs should usually omit this. |
+| `mode` | string | no | `on_demand` or `always`. |
+
+### 1.2.6. `[[service]]`
+
+Each `[[service]]` table declares a workspace-owned HTTP service.
+
+Services may appear in city-level packs. Rig-level pack loading must fail if a
+rig-imported pack declares any service.
+
+Packs must not set `publish_mode = "direct"`.
+
+### 1.2.7. `[providers.<name>]`
+
+The `[providers]` table defines provider presets. Pack providers are merged
+additively into the city. Included providers load first. Parent pack providers
+win over included pack providers with the same name inside a pack load. When
+multiple city or rig packs contribute providers, the first provider already in
+the effective city wins.
+
+Provider fields are the same provider fields accepted in `city.toml`.
+
+### 1.2.8. Formula Directory
+
+A pack's formula directory is the well-known `formulas/` directory at the pack
+root. PackV2 does not define `[formulas].dir` in `pack.toml`.
+
+Formula directories are collected as loader layers. Lower-priority pack
+directories are collected before higher-priority pack directories.
+
+### 1.2.9. `[[patches.agent]]`
+
+Agent patches modify an existing agent by identity.
+
+```toml
+[[patches.agent]]
+name = "reviewer"
+provider = "codex"
+session_setup_append = ["tmux set status-left '[review]'"]
+```
+
+| Field | Type | Required | Rule |
+|---|---|---|---|
+| `name` | string | yes | Target agent local name. |
+| `dir` | string | context-dependent | Target identity prefix. Empty means city-level in `city.toml`; in `pack.toml`, empty matches by name before consumer rig stamping. |
+
+Patch operation fields mirror agent fields. A scalar pointer field replaces the
+target value. A list replacement field replaces the target list. A field whose
+name ends in `_append` appends to the corresponding target list.
+
+The specified append fields are:
+
+| Field | Appends to |
+|---|---|
+| `pre_start_append` | `pre_start` |
+| `session_setup_append` | `session_setup` |
+| `session_live_append` | `session_live` |
+| `install_agent_hooks_append` | `install_agent_hooks` |
+| `inject_fragments_append` | `inject_fragments` |
+
+Pack-level patch paths in `prompt_template`, `session_setup_script`, and
+`overlay_dir` resolve relative to the patching pack directory.
+
+### 1.2.10. `[[doctor]]`
+
+Each `[[doctor]]` table declares a diagnostic check.
+
+```toml
+[[doctor]]
+name = "check-tools"
+script = "doctor/check-tools.sh"
+description = "Verify required tools are installed"
+```
+
+| Field | Type | Required | Rule |
+|---|---|---|---|
+| `name` | string | yes | Short diagnostic identifier. |
+| `script` | string | yes | Script path relative to pack directory. |
+| `description` | string | no | Human-readable description. |
+
+### 1.2.11. `[[commands]]`
+
+Each `[[commands]]` table declares a pack CLI command.
+
+```toml
+[[commands]]
+name = "status"
+description = "Show pack status"
+long_description = "commands/status-help.txt"
+script = "commands/status.sh"
+```
+
+| Field | Type | Required | Rule |
+|---|---|---|---|
+| `name` | string | yes | Command name. |
+| `description` | string | yes | Short help text. |
+| `long_description` | string | no | Path to long help text, relative to pack directory. |
+| `script` | string | yes | Script path, relative to pack directory. |
+
+### 1.2.12. `[global]`
+
+The `[global]` table declares pack-wide live session commands.
+
+```toml
+[global]
+session_live = ["{{.ConfigDir}}/scripts/theme.sh {{.Session}}"]
+```
+
+| Field | Type | Required | Rule |
+|---|---|---|---|
+| `session_live` | array of string | no | Commands appended to matching agents after pack expansion. |
+
+When `[global].session_live` is loaded, `{{.ConfigDir}}` is resolved to the
+concrete pack directory. Other template variables remain for per-agent
+expansion.
+
+### 1.2.13. Fields Not In `pack.toml`
+
+The following fields are not PackV2 `pack.toml` fields:
+
+| Field | Reason |
+|---|---|
+| `[agent_defaults]` | City-level only. Appears in `city.toml`, not `pack.toml`. |
+| `[agents]` | City-level compatibility alias only. It is not valid in `pack.toml`. |
+| `[defaults.rig.imports]` | City-level only. Appears in `city.toml`, not `pack.toml`. |
+| `[formulas].dir` | Formula directories use the well-known `formulas/` path. |
+| `[[patches.rigs]]` | City-level only. Pack patches may target agents only. |
+| `[[patches.providers]]` | City-level only. Pack patches may target agents only. |
+| `[export]` | Specified in design notes but not implemented by the current loader. |
+| `path` inside `[imports.<binding>]` | Not part of durable import TOML. |
+| `ref` inside `[imports.<binding>]` | Not part of durable import TOML. |
+| `commit` inside `[imports.<binding>]` | Not part of durable import TOML. |
+| `hash` inside `[imports.<binding>]` | Not part of durable import TOML. |
+| `transitive` or inline import `export` controls | Legacy/proposed surfaces, not authoritative PackV2 format. |
+
+### 1.3. Per-Directory Breakdown
+
+### 1.3.1. `assets/`
+
+`assets/` is the preferred home for private pack implementation files.
+PackV2 does not scan `assets/` directly. Files under `assets/` become relevant
+only when a pack definition references them, for example:
+
+```toml
+[[agent]]
+name = "reviewer"
+prompt_template = "assets/prompts/reviewer.md"
+session_setup_script = "assets/scripts/setup-reviewer.sh"
+overlay_dir = "assets/overlays/reviewer"
+```
+
+Authors should put new private prompt templates, scripts, overlays, and other
+implementation files under `assets/` unless an established loader convention
+requires a top-level directory.
+
+### 1.3.2. `formulas/`
+
+`formulas/` is the only PackV2 formula directory. If it exists, the loader
+collects it as a formula layer. `[formulas].dir` is invalid.
+
+### 1.3.3. `overlay/`
+
+`overlay/` is collected automatically from loaded pack directories. City-level
+pack overlays are available to city agents and form the base overlay layer for
+rig agents. Rig-level pack overlays are collected per rig.
+
+Agent `overlay_dir` is different: it is an explicit path on an agent definition
+or patch and resolves relative to the declaring pack.
+
+### 1.3.4. `scripts/`
+
+`scripts/` is collected automatically from loaded pack directories as a script
+search layer. City-level pack scripts form the base layer. Rig-level pack
+scripts are collected per rig.
+
+Scripts referenced directly by `start_command`, `session_setup`,
+`session_setup_script`, `[[commands]]`, or `[[doctor]]` are resolved according
+to the field-specific rules in this document.
+
+### 1.3.5. Conventional Directories
+
+`commands/`, `doctor/`, `namepools/`, `prompts/`, `skills/`, `orders/`, and
+`mcps/` are conventional directories. The loader does not give all of them the
+same automatic treatment. A file in one of these directories is part of a pack's
+effective behavior only if the relevant subsystem scans it or a TOML definition
+references it.
+
+## 2. Loader
+
+Loading a pack is the process of turning one or more pack directories into a
+flat effective city configuration.
+
+The loader has these major phases:
+
+```text
+LoadWithIncludes(city.toml):
+    parse root city.toml
+    merge city TOML fragments
+    resolve legacy named pack sources
+    reject removed rig includes
+    expand city-level packs
+    apply city-level patches
+    expand rig-level packs
+    apply pack globals
+    validate requirements
+    compute formula and script layers
+    inject implicit agents
+    apply city agent defaults
+    validate and normalize final config
+```
+
+### 2.1. Pack Resolution
+
+A pack reference is resolved to a pack root directory before `pack.toml` is
+read.
+
+For PackV2 imports, the reference is the `source` field of a `PackImport`.
+Import bindings are sorted lexicographically before their sources are loaded.
+This gives deterministic load order for TOML maps.
+
+The root city imports are read from top-level `[imports.<binding>]` in
+`city.toml`. Rig imports are read from `[rigs.imports.<binding>]` under the
+corresponding `[[rigs]]` entry. Pack-to-pack imports are read from top-level
+`[imports.<binding>]` in `pack.toml`.
+
+Legacy `includes` lists in `pack.toml` and legacy workspace includes may also
+feed the pack loader. They remain compatibility mechanisms. They are not the
+preferred PackV2 authoring surface.
+
+If a pack import has an empty binding name or empty `source`, loading must
+fail.
+
+### 2.2. Versioning
+
+`PackImport.version` is a compatibility constraint for versioned sources.
+The exact resolved version belongs to the pack lockfile, not to
+`pack.toml`.
+
+The loader specified here consumes resolved sources. Registry lookup, remote
+version selection, cache population, and lockfile update are pack management
+operations that occur before or around loading. They must produce a concrete
+pack root directory whose `pack.toml` can be loaded by this specification.
+
+Registry handles are not durable dependency coordinates. A command may accept a
+handle such as `main:gascity`; persisted PackV2 TOML must store the resolved
+durable `source` and optional `version` constraint instead.
+
+### 2.3. Recursive Pack Loading
+
+The recursive pack loader operates on a pack root directory and a loading
+context:
+
+```text
+loadPack(packRoot, cityRoot, rigName, seen):
+    read packRoot/pack.toml
+    validate [pack]
+    validate imports
+    recursively load pack includes/imports
+    copy this pack's own definitions
+    stamp agents and named sessions with rigName when applicable
+    resolve pack-relative paths
+    merge included definitions first, then this pack's definitions
+    apply this pack's patches
+    qualify rig depends_on entries
+    merge providers
+    return definitions and ordered pack directories
+```
+
+The `seen` set is a recursion-stack set. A pack directory already present in
+the active recursion stack must cause loading to fail with a cycle error. A
+diamond-shaped dependency graph is valid; the loader may reuse a cached result
+when the same pack directory is reached through more than one acyclic path.
+
+Included or imported pack definitions are lower-priority base definitions. The
+parent pack's own definitions are appended after included definitions and are
+therefore the later layer for fallback resolution and provider merging.
+
+### 2.4. Scope Filtering And Stamping
+
+When loading a pack for the city-level surface:
+
+1. The loader keeps agents and named sessions whose `scope` is omitted or
+   `city`.
+2. The loader drops agents and named sessions whose `scope` is `rig`.
+3. The effective identity prefix for kept agents is empty unless the definition
+   explicitly supplied `dir`.
+
+When loading a pack for a rig-level surface:
+
+1. The loader keeps agents and named sessions whose `scope` is omitted or
+   `rig`.
+2. The loader drops agents and named sessions whose `scope` is `city`.
+3. For kept agents and named sessions whose `dir` is empty, the loader sets
+   `dir` to the consuming rig's `name`.
+
+The runtime qualified name of an agent is:
+
+```text
+qualifiedName(agent):
+    if agent.dir == "":
+        return agent.name
+    return agent.dir + "/" + agent.name
+```
+
+The `dir` field is an identity prefix, not a filesystem path.
+
+### 2.5. Naming And Collisions
+
+Agent names are local names. Import bindings do not qualify runtime agent
+names.
+
+The loader resolves fallback collisions before reporting duplicate pack agents:
+
+1. If a fallback and a non-fallback from different source directories share a
+   local name, the non-fallback wins and the fallback is removed.
+2. If two or more fallbacks from different source directories share a local
+   name, the first loaded fallback wins and later fallbacks are removed.
+3. If two or more non-fallback agents from different source directories share a
+   local name on the same surface, loading fails.
+
+The "same surface" means the city-level surface or one rig-level surface. Two
+different rigs may each have an agent with the same local name because their
+qualified names differ by rig `dir`.
+
+Identifier qualification across import bindings, runtime names, registry
+selectors, and AgentScript is not yet settled. Until that work lands, this
+specification deliberately avoids defining a binding-qualified runtime agent
+syntax.
+
+### 2.6. Patches
+
+Patches are targeted modifications to existing definitions. A patch must not
+create a new agent.
+
+Pack-level patches run inside recursive pack loading after imported/base agents
+and the current pack's own agents have been merged. Pack-level patches may only
+use `[[patches.agent]]`. In pack-level patches, `dir = ""` matches by local
+`name` only, because a reusable pack normally does not know which rig will
+consume it.
+
+City-level patches run after city-level pack expansion and before rig-level
+pack expansion. A city-level patch targets agents that already exist in the
+effective city config at that point.
+
+Rig overrides run after all packs for that rig have expanded and after their
+agents have been stamped with the rig name.
+
+The patch/default order is:
+
+1. Recursive pack imports/includes load.
+2. Pack-level patches apply inside each pack load.
+3. City-level packs expand.
+4. City-level patches apply.
+5. Rig-level packs expand.
+6. Rig overrides apply.
+7. Pack globals apply.
+8. Implicit agents are injected.
+9. City `[agent_defaults]` applies.
+
+If a patch target does not exist when the patch runs, loading fails.
+
+### 2.7. Defaults
+
+`[agent_defaults]` is a city-level `city.toml` table. It is not a PackV2
+`pack.toml` table.
+
+The current default application step actively applies
+`agent_defaults.default_sling_formula` to agents whose `default_sling_formula`
+is still unset. It skips the control-dispatcher infrastructure agent.
+
+Other fields in the `AgentDefaults` structure may be parsed and composed by the
+city config loader, but they are not specified here as PackV2 pack defaults.
+
+Defaults run after pack expansion, patches, rig overrides, pack globals, and
+implicit agent injection. Defaults fill blank fields only; they do not override
+fields explicitly set by a pack, patch, rig override, or implicit agent seed.
+
+### 2.8. Path Resolution
+
+The following fields on pack agents resolve relative to the declaring pack
+directory:
+
+| Field |
+|---|
+| `prompt_template` |
+| `session_setup_script` |
+| `overlay_dir` |
+
+The same fields in pack-level patches resolve relative to the patching pack
+directory.
+
+`[global].session_live` commands replace `{{.ConfigDir}}` with the concrete
+pack directory when the pack is loaded. Other template variables remain
+unresolved until runtime.
+
+Pack command and doctor script paths are declared relative to the pack
+directory.
+
+### 2.9. Formula, Overlay, And Script Layers
+
+City formula layers are ordered from lower priority to higher priority:
+
+1. Formula directories from city-level packs.
+2. The city-local formula directory.
+
+Rig formula layers are ordered from lower priority to higher priority:
+
+1. City formula layers.
+2. Formula directories from packs imported by that rig.
+3. The rig-local formula directory, when configured.
+
+City script layers contain `scripts/` directories from city-level packs.
+Rig script layers contain city script layers followed by `scripts/` directories
+from packs imported by that rig.
+
+Overlay directories follow the same city-base then rig-specific collection
+model. Agent-specific `overlay_dir` is applied separately by the runtime.
+
+### 2.10. Pack Globals
+
+City-level pack globals apply to all agents. Rig-level pack globals apply only
+to agents in the corresponding rig.
+
+Pack globals append live session commands. They do not replace agent
+`session_live` entries.
+
+### 2.11. Requirements
+
+Pack requirements are checked after pack expansion.
+
+A city requirement must be satisfied by an agent with matching local name on the
+city-level surface. A rig requirement must be satisfied by an agent with
+matching local name during rig pack loading.
+
+If a requirement is not satisfied, loading fails.
+
+### 2.12. Error Handling
+
+The loader must fail when:
+
+1. `pack.toml` cannot be read.
+2. `pack.toml` cannot be parsed as TOML.
+3. `[pack].name` is empty.
+4. `[pack].schema` is missing, zero, or greater than the supported schema.
+5. A pack import has an empty binding or empty source.
+6. A pack dependency cycle is detected.
+7. A pack-level or city-level patch targets a missing agent.
+8. A rig-level pack declares a service.
+9. A pack service sets `publish_mode = "direct"`.
+10. A non-fallback agent collision remains after fallback resolution.
+11. A declared pack requirement is not satisfied.
+12. `city.toml` uses removed `rigs.includes`.
+
+The loader may skip missing remote pack subpaths in compatibility cases where a
+remote source was fetched but the referenced pack directory no longer exists.
+That compatibility behavior must not be used to justify new invalid PackV2
+configuration.
+
+## 3. Non-Normative Notes
+
+The proposed `[export]` surface is intentionally absent from this current-state
+specification. It belongs in design notes until an implementation lands.
+
+The `pack.toml` `includes` field and workspace-level pack includes exist for
+compatibility and examples that predate PackV2 imports. New durable pack
+dependencies should use `[imports.<binding>]`.
+
+The Java Virtual Machine Specification separates class-file structure from
+loading and linking semantics. PackV2 follows the same documentation pattern:
+section 1 specifies the file format, and section 2 specifies the loader.

--- a/docs/specs/pack-spec.md
+++ b/docs/specs/pack-spec.md
@@ -198,7 +198,7 @@ The `[pack]` table defines pack metadata.
 ```toml
 [pack]
 name = "gascity"
-schema = 1
+schema = 2
 version = "1.4.0"
 requires_gc = ">=0.13.0"
 ```
@@ -206,7 +206,7 @@ requires_gc = ">=0.13.0"
 | Field | Type | Required | Rule |
 |---|---|---|---|
 | `name` | string | yes | Pack identifier and provenance label. Must not be empty. |
-| `schema` | integer | yes | Pack format version. Must be `1` for this specification. |
+| `schema` | integer | yes | Pack format version. Must be `2` for this specification. |
 | `version` | string | no | Pack version metadata. |
 | `requires_gc` | string | no | Minimum compatible `gc` version metadata. |
 | `includes` | array of string | legacy | Legacy pack composition list. New packs should use `[imports.<binding>]`. |

--- a/engdocs/architecture/config.md
+++ b/engdocs/architecture/config.md
@@ -3,18 +3,24 @@ title: "Config System"
 ---
 
 
-> Last verified against code: 2026-03-01
+> Last verified against code: 2026-05-22
+
+> **PackV2 format source of truth:** The public PackV2 format and loader
+> semantics are specified in
+> [Gas City Pack Specification (2.0)](../../docs/specs/pack-spec.md). This
+> page describes config loading and should defer to that specification for
+> PackV2 file-format details.
 
 ## Summary
 
 The Config system is a Layer 0-1 primitive that serves as Gas City's
 universal activation mechanism. It loads, composes, and resolves TOML
-configuration from `city.toml`, included fragments, pack directories,
-and preinstalled import metadata into a single flat `City` struct that
+configuration from `city.toml`, included fragments, PackV2 directories,
+and materialized import metadata into a single flat `City` struct that
 drives all other subsystems. Capabilities activate progressively based
 on which config sections are present (Levels 0-8), and multi-layer
-override resolution ensures that pack defaults can be customized
-per-rig without forking.
+patch/override resolution lets city and rig policy customize imported
+agents without forking their packs.
 
 ## Key Concepts
 
@@ -31,18 +37,19 @@ per-rig without forking.
   concatenate, providers deep-merge per-field, workspace fields merge
   with collision warnings.
 
-- **Pack**: A reusable agent configuration directory containing
-  `pack.toml`, prompts, formulas, and orders. City-level
-  packs stamp city-scoped agents (dir=""). Rig-level packs
-  stamp rig-scoped agents (dir=rig-name). The `city_agents` metadata
-  field partitions which agents from a shared pack are city-scoped
-  vs rig-scoped.
+- **Pack**: A reusable configuration directory with `pack.toml` and
+  well-known content directories such as `agents/`, `formulas/`,
+  `commands/`, `skills/`, `assets/`, and `defaults/`. PackV2 imports
+  are source-first (`source`, optional `version`) and are described in
+  the public pack specification. City-owned config such as
+  `[agent_defaults]`, `[defaults.rig.imports]`, and city/rig patches
+  belongs in `city.toml`, not normal imported `pack.toml` files.
 
-- **Override Resolution**: A four-layer chain that allows progressively
+- **Override Resolution**: A layered chain that allows progressively
   more specific customization: builtin provider presets < city-level
-  `[providers]` < workspace defaults < per-agent fields. For pack
-  agents, rig-level `[[overrides]]` and city-level `[patches]` provide
-  additional override points without forking the pack.
+  `[providers]` < workspace defaults < per-agent fields. City-level
+  `[patches]` and rig-scoped `[[overrides]]` provide additional
+  modification points for imported agents without forking the pack.
 
 - **Provenance**: Every config element (agent, rig, workspace field) is
   tracked back to the source file that defined it. Built into the
@@ -55,7 +62,9 @@ per-rig without forking.
 
 - **FormulaLayers**: Ordered formula directory lists per scope
   (city-scoped and per-rig) that control formula symlink
-  materialization. Higher-priority layers shadow lower ones by filename.
+  materialization. Pack and city formulas use the well-known
+  `formulas/` directory; `rigs[].formulas_dir` remains the rig-local
+  escape hatch. Higher-priority layers shadow lower ones by filename.
 
 ## Architecture
 
@@ -73,34 +82,51 @@ complete config resolution pipeline:
 city.toml
     |
     v
-1. Parse root TOML          (parseWithMeta)
+1. Parse root city.toml     (parseWithMeta)
     |
     v
-2. Load & merge fragments    (mergeFragment for each include)
+2. Read city defaults       ([defaults.rig.imports])
     |
     v
-3. Resolve named packs  (resolveNamedPacks: name -> cache path)
+3. Load root pack layer     (pack.toml, if present)
     |
     v
-4. Expand city packs    (ExpandCityPacks: stamp dir="" agents)
+4. Load & merge fragments   (mergeFragment for each include)
     |
     v
-5. Apply patches             (ApplyPatches: targeted field modifications)
+5. Expand city imports      (ExpandCityPacks / PackV2 imports)
     |
     v
-6. Expand rig packs     (ExpandPacks: stamp dir=rig-name agents)
+6. Expand rig imports       (ExpandPacks, defer rig overrides)
     |
     v
-7. Compute formula layers    (ComputeFormulaLayers: build priority stacks)
+7. Apply city patches       (ApplyPatches)
+    |
+    v
+8. Apply rig overrides       (deferred per-rig overrides)
+    |
+    v
+9. Apply pack globals        (commands, skills, MCP config, defaults)
+    |
+    v
+10. Compute formula layers   (ComputeFormulaLayers)
+    |
+    v
+11. Inject implicit agents
+    |
+    v
+12. Apply agent defaults
     |
     v
 Flat City struct + Provenance
 ```
 
-Steps 4 and 6 are ordered deliberately: city packs expand before
-patches so that patches can target city-pack agents. Rig packs
-expand after patches so that rig-level overrides apply to the final
-stamped agents.
+City imports and rig imports are both expanded before city-level
+patches are applied, so patches can target imported agents in either
+scope. Rig overrides are deferred until after city-level patches so
+rig-local policy wins when both set the same field. Pack-level agent
+patches are applied inside recursive pack loading and do not expose
+city-only patch targets such as rigs or providers.
 
 Provider resolution happens later, at agent startup time, via
 `ResolveProvider`:
@@ -146,14 +172,18 @@ Provider resolution happens later, at agent startup time, via
   `ResolveProvider`. All fields populated after resolution through the
   builtin + city + agent override chain.
 
-- **`PackSource`** (`internal/config/config.go`): Defines a remote
-  pack repository with git URL, ref, and optional subdirectory path.
-  Referenced by name in workspace/rig pack fields.
+- **`ImportSpec` / `PackSource`** (`internal/config/config.go`):
+  `ImportSpec` is the authored PackV2 import shape (`source`, optional
+  `version`). `PackSource` remains as legacy/internal plumbing for
+  cached or older pack references. Registry handles such as
+  `main:gascity` are command-time lookup handles and should not be
+  persisted in authored `pack.toml`.
 
 - **`PackMeta`** (`internal/config/config.go`): Metadata header from
   `pack.toml`. Contains name, version, schema version, optional
-  `requires_gc` constraint, and `city_agents` list for partitioning
-  agents between city and rig scopes.
+  `requires_gc` constraint, and import/export metadata. Agent
+  city-vs-rig availability is declared on agent definitions rather
+  than partitioned through legacy `city_agents` metadata.
 
 - **`Provenance`** (`internal/config/compose.go`): Tracks the source
   file origin of every agent, rig, and workspace field. Built during
@@ -161,8 +191,9 @@ Provider resolution happens later, at agent startup time, via
 
 - **`FormulaLayers`** (`internal/config/config.go`): Holds resolved
   formula directory stacks for city-scoped agents and per-rig agents.
-  Priority order (lowest to highest): city-pack < city-local <
-  rig-pack < rig-local.
+  Priority order (lowest to highest): imported/root pack formulas <
+  city-local `formulas/` < rig-imported pack formulas <
+  `rigs[].formulas_dir`.
 
 ## Invariants
 
@@ -184,12 +215,14 @@ Provider resolution happens later, at agent startup time, via
   returns an error. Patches never create new resources.
 
 - **Pack schema compatibility.** `loadPack` rejects any
-  pack with `schema` > `currentPackSchema` (currently 1).
+  pack with `schema` > `currentPackSchema` (currently 2).
   Forward-incompatible packs fail loudly.
 
-- **city_agents names must exist.** Every name listed in a pack's
-  `city_agents` must match an agent defined in that pack.
-  `loadPack` validates this before any agent stamping.
+- **Imported pack files have a narrower authoring surface.** Normal
+  PackV2 `pack.toml` files may define source-first imports and pack
+  content, but city-owned constructs such as `[agent_defaults]`,
+  `[defaults.rig.imports]`, `[formulas].dir`, `[[patches.rigs]]`, and
+  `[[patches.providers]]` are rejected during pack loading.
 
 - **Pool query symmetry.** Pool agents must set both `sling_query` and
   `work_query`, or neither. `ValidateAgents` rejects mismatched pairs.
@@ -236,10 +269,10 @@ All implementation lives in `internal/config/`:
 
 | File | Purpose |
 |---|---|
-| `internal/config/config.go` | Core types: `City`, `Workspace`, `Agent`, `Rig`, `AgentOverride`, `PackSource`, `PackMeta`, `FormulaLayers`, `PoolConfig`, subsystem configs. Load/Parse/Marshal. Validation functions. |
+| `internal/config/config.go` | Core types: `City`, `Workspace`, `Agent`, `Rig`, `AgentOverride`, `ImportSpec`, `PackSource`, `PackMeta`, `FormulaLayers`, `PoolConfig`, subsystem configs. Load/Parse/Marshal. Validation functions. |
 | `internal/config/compose.go` | `LoadWithIncludes`: the main entry point. Fragment merging, path resolution, provenance tracking. Orchestrates the full load pipeline. |
 | `internal/config/patch.go` | `Patches`, `AgentPatch`, `RigPatch`, `ProviderPatch`, `PoolOverride` types. `ApplyPatches` and per-type apply functions. |
-| `internal/config/pack.go` | `ExpandPacks`, `ExpandCityPacks`, `ComputeFormulaLayers`. Pack loading, agent stamping, city_agents partitioning, override application, collision detection. |
+| `internal/config/pack.go` | `ExpandPacks`, `ExpandCityPacks`, `ComputeFormulaLayers`. Pack loading, agent stamping, scope handling, override application, collision detection. |
 | `internal/config/pack_fetch.go` | Legacy V1 remote-pack fetch and lock helpers. Schema-2 import bootstrap/repair belongs to `gc import`; config load consumes already-materialized imports. |
 | `internal/config/provider.go` | `ProviderSpec`, `ResolvedProvider`, `BuiltinProviders`. Built-in provider presets for seven CLI agents. |
 | `internal/config/resolve.go` | `ResolveProvider`: the five-step provider resolution chain. `AgentHasHooks` for hook detection. Auto-detection via PATH scanning. |
@@ -268,17 +301,18 @@ Multi-rig with pack and overrides (Level 5+):
 [workspace]
 name = "my-city"
 provider = "claude"
-pack = "packs/my-pack"
 
-[packs.shared]
-source = "https://github.com/example/packs.git"
-ref = "v1.0"
-path = "my-pack"
+[imports.shared]
+source = "https://github.com/example/packs/my-pack"
+version = "^1"
 
 [[rigs]]
 name = "project-a"
 path = "/home/user/project-a"
-pack = "shared"
+
+[rigs.imports.shared]
+source = "https://github.com/example/packs/my-pack"
+version = "^1"
 
 [[rigs.overrides]]
 agent = "worker"
@@ -302,10 +336,10 @@ name = "my-city"
 
 FormulaLayers priority (lowest to highest):
 
-1. City pack formulas (from `workspace.pack` or `workspace.packs`)
-2. City local formulas (from `[formulas] dir`)
-3. Rig pack formulas (from `rigs[].pack` or `rigs[].packs`)
-4. Rig local formulas (from `rigs[].formulas_dir`)
+1. Imported/root pack formulas from well-known `formulas/` directories
+2. City local formulas from the city root `formulas/` directory
+3. Rig-imported pack formulas from well-known `formulas/` directories
+4. Rig local formulas from `rigs[].formulas_dir`
 
 ## Testing
 
@@ -316,7 +350,7 @@ Each source file has a companion `_test.go`:
 | `internal/config/config_test.go` | Parse, Marshal, Load, DefaultCity, ValidateAgents, ValidateRigs, DeriveBeadsPrefix, QualifiedName |
 | `internal/config/compose_test.go` | LoadWithIncludes, fragment merging, collision warnings, path resolution, provenance tracking, recursive include rejection |
 | `internal/config/patch_test.go` | ApplyPatches for agents/rigs/providers, targeting errors, env merge/remove, pool sub-field patching, provider replace mode |
-| `internal/config/pack_test.go` | ExpandPacks, ExpandCityPacks, city_agents partitioning, agent collision detection, override application, formula layer computation |
+| `internal/config/pack_test.go` | ExpandPacks, ExpandCityPacks, agent scope handling, agent collision detection, override application, formula layer computation |
 | `internal/config/pack_fetch_test.go` | Legacy fetch/lock helper coverage for the V1 `[packs]` path |
 | `internal/config/provider_test.go` | BuiltinProviders completeness, BuiltinProviderOrder coverage |
 | `internal/config/resolve_test.go` | ResolveProvider chain (all five steps), escape hatches, auto-detect, agent-level overrides, env additive merge |

--- a/engdocs/architecture/index.md
+++ b/engdocs/architecture/index.md
@@ -28,8 +28,8 @@ multi-agent orchestration system.
    activity
 5. **[Config System](./config.md)** — TOML loading, progressive activation,
    multi-layer override resolution
-6. **[Session](./session.md)** — session lifecycle backed by runtime
-   providers (tmux, subprocess, exec, k8s)
+6. **[Sessions](./session.md)** — agent lifecycle backed by session providers
+   (tmux, subprocess, k8s)
 7. **[Prompt Templates](./prompt-templates.md)** — Go `text/template` in
    Markdown defining role behavior
 
@@ -38,7 +38,6 @@ multi-agent orchestration system.
 Each is provably composable from the primitives.
 
 8. **[Messaging](./messaging.md)** — inter-agent mail via beads + nudge
-   via the Session primitive
 9. **[Formulas & Molecules](./formulas.md)** — work definitions (TOML) and
    their runtime instances (bead trees)
 10. **[Dispatch](./dispatch.md)** — sling: agent selection + formula
@@ -48,13 +47,12 @@ Each is provably composable from the primitives.
 
 ### Infrastructure
 
-12. **[API Control Plane](./api-control-plane.md)** — CLI/API projections,
-    typed HTTP + SSE wire contract, generated clients, and event payload
-    registry
-13. **[Controller](./controller.md)** — the main loop: config watch,
+12. **[Controller](./controller.md)** — the main loop: config watch,
     reconciliation tick, order dispatch
-14. **[Orders](./orders.md)** — trigger-conditioned formula/exec
+13. **[Orders](./orders.md)** — gate-conditioned formula/exec
     dispatch, rig-scoped labels
+14. **[Gas City Pack Specification (2.0)](../../docs/specs/pack-spec.md)** —
+    authoritative pack data model, file format, and loader semantics
 
 ### End-to-End Traces
 

--- a/engdocs/architecture/index.md
+++ b/engdocs/architecture/index.md
@@ -28,8 +28,8 @@ multi-agent orchestration system.
    activity
 5. **[Config System](./config.md)** — TOML loading, progressive activation,
    multi-layer override resolution
-6. **[Sessions](./session.md)** — agent lifecycle backed by session providers
-   (tmux, subprocess, k8s)
+6. **[Session](./session.md)** — session lifecycle backed by runtime
+   providers (tmux, subprocess, exec, k8s)
 7. **[Prompt Templates](./prompt-templates.md)** — Go `text/template` in
    Markdown defining role behavior
 
@@ -38,6 +38,7 @@ multi-agent orchestration system.
 Each is provably composable from the primitives.
 
 8. **[Messaging](./messaging.md)** — inter-agent mail via beads + nudge
+   via the Session primitive
 9. **[Formulas & Molecules](./formulas.md)** — work definitions (TOML) and
    their runtime instances (bead trees)
 10. **[Dispatch](./dispatch.md)** — sling: agent selection + formula
@@ -47,11 +48,14 @@ Each is provably composable from the primitives.
 
 ### Infrastructure
 
-12. **[Controller](./controller.md)** — the main loop: config watch,
+12. **[API Control Plane](./api-control-plane.md)** — CLI/API projections,
+    typed HTTP + SSE wire contract, generated clients, and event payload
+    registry
+13. **[Controller](./controller.md)** — the main loop: config watch,
     reconciliation tick, order dispatch
-13. **[Orders](./orders.md)** — gate-conditioned formula/exec
+14. **[Orders](./orders.md)** — trigger-conditioned formula/exec
     dispatch, rig-scoped labels
-14. **[Gas City Pack Specification (2.0)](../../docs/specs/pack-spec.md)** —
+15. **[Gas City Pack Specification (2.0)](../../docs/specs/pack-spec.md)** —
     authoritative pack data model, file format, and loader semantics
 
 ### End-to-End Traces
@@ -59,9 +63,9 @@ Each is provably composable from the primitives.
 These trace a concrete operation through all layers. The most effective
 way to understand how the system fits together.
 
-15. **[Life of a Bead](./life-of-a-bead.md)** — create → hook → claim →
+16. **[Life of a Bead](./life-of-a-bead.md)** — create → hook → claim →
     execute → close
-16. **[Life of a Molecule](./life-of-a-molecule.md)** — formula parse →
+17. **[Life of a Molecule](./life-of-a-molecule.md)** — formula parse →
     dispatch → molecule create → step execution → completion
 
 ## Document Types

--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -16,7 +16,8 @@
 # fallback dog shape and shared dog formulas/prompts that gastown reuses.
 # Rig-scoped agents (witness, refinery, polecat) are stamped per-rig.
 #
-# The sibling pack.toml owns the Gastown import and default rig binding.
+# The sibling pack.toml owns the Gastown import. This city owns the default
+# rig binding used by `gc rig add`.
 #
 # To use: gc start examples/gastown/
 # Requires rigs to be registered: gc rig add <path>
@@ -25,6 +26,9 @@
 name = "gastown"
 provider = "claude"
 global_fragments = ["command-glossary", "operational-awareness"]
+
+[defaults.rig.imports.gastown]
+source = "packs/gastown"
 
 [daemon]
 patrol_interval = "30s"

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -247,12 +247,20 @@ func TestCityPackTomlParses(t *testing.T) {
 	if gastownImp.Source != "packs/gastown" {
 		t.Errorf("pack.toml imports[\"gastown\"].Source = %q, want %q", gastownImp.Source, "packs/gastown")
 	}
-	gastownDefault, ok := tc.Defaults.Rig.Imports["gastown"]
+	cityData, err := os.ReadFile(filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	var cityCfg config.City
+	if _, err := toml.Decode(string(cityData), &cityCfg); err != nil {
+		t.Fatalf("parsing city.toml: %v", err)
+	}
+	gastownDefault, ok := cityCfg.Defaults.Rig.Imports["gastown"]
 	if !ok {
-		t.Fatalf("pack.toml defaults.rig.imports = %v, want entry for \"gastown\"", tc.Defaults.Rig.Imports)
+		t.Fatalf("city.toml defaults.rig.imports = %v, want entry for \"gastown\"", cityCfg.Defaults.Rig.Imports)
 	}
 	if gastownDefault.Source != "packs/gastown" {
-		t.Errorf("pack.toml defaults.rig.imports[\"gastown\"].Source = %q, want %q", gastownDefault.Source, "packs/gastown")
+		t.Errorf("city.toml defaults.rig.imports[\"gastown\"].Source = %q, want %q", gastownDefault.Source, "packs/gastown")
 	}
 }
 

--- a/examples/gastown/pack.toml
+++ b/examples/gastown/pack.toml
@@ -13,6 +13,3 @@ schema = 2
 
 [imports.gastown]
 source = "packs/gastown"
-
-[defaults.rig.imports.gastown]
-source = "packs/gastown"

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -92,12 +92,12 @@ type Provenance struct {
 
 // LoadOptions controls optional config-loading behavior.
 type LoadOptions struct {
-	// AllowRootDefaultRigImports permits [defaults.rig.imports] only on the
-	// root pack.toml being loaded. Normal pack imports still reject it.
-	AllowRootDefaultRigImports bool
-	deferRigPatches            bool
-	deferredRigPatches         *[]deferredRigPatches
-	allowLegacyOrderLayouts    bool
+	// SuppressDeprecatedOrderWarnings suppresses only legacy order-path
+	// migration warnings produced while discovering pack orders.
+	SuppressDeprecatedOrderWarnings bool
+	deferRigPatches                 bool
+	deferredRigPatches              *[]deferredRigPatches
+	allowLegacyOrderLayouts         bool
 }
 
 // LoadWithIncludes loads a city.toml and merges all included fragments.
@@ -127,12 +127,30 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	cityAgentsForProvenance := root.Agents
 	root.Pricing = dedupePricingByKey(root.Pricing)
 	root.CityPricing = append([]pricing.ModelPricing(nil), root.Pricing...)
+	defaultRigImports, err := defaultRigImportsFromPackDefaults(root.Defaults, rootMeta)
+	if err != nil {
+		return nil, nil, fmt.Errorf("city.toml: %w", err)
+	}
+	if len(defaultRigImports) > 0 {
+		root.DefaultRigImports = make(map[string]Import, len(defaultRigImports))
+		root.DefaultRigImportOrder = make([]string, 0, len(defaultRigImports))
+		for _, bound := range defaultRigImports {
+			root.DefaultRigImports[bound.Binding] = bound.Import
+			root.DefaultRigImportOrder = append(root.DefaultRigImportOrder, bound.Binding)
+		}
+	}
 	// defaultBindings names the [defaults.rig.imports] bindings declared
-	// by the city's pack.toml. After expansion, agents whose BindingName
+	// by city.toml. After expansion, agents whose BindingName
 	// matches one of these names are auto-imports (the user did not
 	// write the [imports.<name>] entry; gc init auto-added it). See
 	// ga-tpfc and the source enum.
 	var defaultBindings map[string]bool
+	if len(root.Defaults.Rig.Imports) > 0 {
+		defaultBindings = make(map[string]bool, len(root.Defaults.Rig.Imports))
+		for name := range root.Defaults.Rig.Imports {
+			defaultBindings[name] = true
+		}
+	}
 
 	// V2: if a pack.toml exists alongside city.toml, it is the city's
 	// definition layer. Parse it and merge its content (imports, agents,
@@ -158,6 +176,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		if fatalWarnings := fatalUndecodedWarnings(md, packPath); len(fatalWarnings) > 0 {
 			return nil, nil, fmt.Errorf("parsing city pack.toml: %s", strings.Join(fatalWarnings, "; "))
+		}
+		if err := validatePackAuthoringSurface(md, packPath); err != nil {
+			return nil, nil, fmt.Errorf("parsing city pack.toml: %w", err)
 		}
 		prov.Warnings = append(prov.Warnings, packWarnings...)
 		if err := validatePackMeta(&pc.Pack); err != nil {
@@ -213,27 +234,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
-		defaultRigImports, err := defaultRigImportsFromPackDefaults(pc.Defaults, md)
-		if err != nil {
-			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
-		}
-		if len(defaultRigImports) > 0 {
-			root.DefaultRigImports = make(map[string]Import, len(defaultRigImports))
-			root.DefaultRigImportOrder = make([]string, 0, len(defaultRigImports))
-			defaultRigIncludes := make([]string, 0, len(defaultRigImports))
-			for _, bound := range defaultRigImports {
-				root.DefaultRigImports[bound.Binding] = bound.Import
-				root.DefaultRigImportOrder = append(root.DefaultRigImportOrder, bound.Binding)
-				defaultRigIncludes = append(defaultRigIncludes, bound.Import.Source)
-			}
-			root.Workspace.SetLegacyDefaultRigIncludes(append(defaultRigIncludes, root.Workspace.LegacyDefaultRigIncludes()...))
-		}
-		if len(pc.Defaults.Rig.Imports) > 0 {
-			defaultBindings = make(map[string]bool, len(pc.Defaults.Rig.Imports))
-			for name := range pc.Defaults.Rig.Imports {
-				defaultBindings[name] = true
-			}
-		}
 		// Merge pack.toml providers (pack is base, city wins).
 		if len(pc.Providers) > 0 {
 			if root.Providers == nil {
@@ -266,20 +266,8 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 			}
 			root.Services = append(packServices, root.Services...)
 		}
-		// Merge patches (accumulated, applied later).
+		// Merge pack agent patches (accumulated, applied later).
 		root.Patches.Agents = append(pc.Patches.Agents, root.Patches.Agents...)
-		root.Patches.Rigs = append(pc.Patches.Rigs, root.Patches.Rigs...)
-		root.Patches.Providers = append(pc.Patches.Providers, root.Patches.Providers...)
-		// Merge formulas config with pack.toml as the base and city.toml as
-		// the more local override.
-		if root.Formulas.Dir == "" {
-			root.Formulas = pc.Formulas
-		}
-		// Merge pack-level agent defaults before city fragments so the
-		// city layer can append on top of the portable baseline.
-		mergedAgentDefaults := pc.AgentDefaults
-		mergeAgentDefaults(&mergedAgentDefaults, root.AgentDefaults, packPath, nil)
-		root.AgentDefaults = mergedAgentDefaults
 		if len(pc.Global.SessionLive) > 0 {
 			rootPackGlobals = append(rootPackGlobals, ResolvedPackGlobal{
 				SessionLive: resolveConfigDirInCommands(pc.Global.SessionLive, cityRoot),
@@ -1322,6 +1310,9 @@ func parseWithMeta(data []byte, source string) (*City, toml.MetaData, []string, 
 	if err != nil {
 		return nil, md, nil, fmt.Errorf("parsing config: %w", err)
 	}
+	if err := validateCityAuthoringSurface(md); err != nil {
+		return nil, md, nil, fmt.Errorf("parsing config: %w", err)
+	}
 	normalizeAgentDefaultsAlias(&cfg, md)
 	warnings := agentDefaultsCompatibilityWarnings(md, source)
 	normalizeLegacyOrderOverrideAliases(&cfg)
@@ -1336,9 +1327,36 @@ func parseWithMeta(data []byte, source string) (*City, toml.MetaData, []string, 
 	return &cfg, md, warnings, nil
 }
 
-// LoadRootPackDefaultRigImports loads the canonical [defaults.rig.imports]
-// entries from the root pack without expanding the full config.
+// LoadRootPackDefaultRigImports loads the canonical city.toml
+// [defaults.rig.imports] entries without expanding the full config.
+//
+// Deprecated name retained for callers in the #2126 wave; the default-rig
+// import table is no longer a root pack.toml surface.
 func LoadRootPackDefaultRigImports(fs fsys.FS, cityRoot string) ([]BoundImport, error) {
+	cityPath := filepath.Join(cityRoot, "city.toml")
+	data, err := fs.ReadFile(cityPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading city.toml: %w", err)
+	}
+	var cfg City
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("parsing city.toml: %w", err)
+	}
+	if err := validateCityAuthoringSurface(md); err != nil {
+		return nil, fmt.Errorf("parsing city.toml: %w", err)
+	}
+	imports, err := defaultRigImportsFromPackDefaults(cfg.Defaults, md)
+	if err != nil || len(imports) > 0 {
+		return imports, err
+	}
+
+	// Compatibility for CLI migration helpers that need to read older root
+	// pack defaults without performing a full config load. Normal PackV2
+	// loading rejects this surface via validatePackAuthoringSurface.
 	packPath := filepath.Join(cityRoot, packFile)
 	packData, err := fs.ReadFile(packPath)
 	if err != nil {
@@ -1348,14 +1366,11 @@ func LoadRootPackDefaultRigImports(fs fsys.FS, cityRoot string) ([]BoundImport, 
 		return nil, fmt.Errorf("loading city pack.toml: %w", err)
 	}
 	var pc PackConfig
-	md, err := toml.Decode(string(packData), &pc)
+	packMD, err := toml.Decode(string(packData), &pc)
 	if err != nil {
 		return nil, fmt.Errorf("parsing city pack.toml: %w", err)
 	}
-	if warnings := fatalUndecodedWarnings(md, packPath); len(warnings) > 0 {
-		return nil, fmt.Errorf("parsing city pack.toml: %s", strings.Join(warnings, "; "))
-	}
-	return defaultRigImportsFromPackDefaults(pc.Defaults, md)
+	return defaultRigImportsFromPackDefaults(pc.Defaults, packMD)
 }
 
 // LoadPackGraphDirsForDoctor returns the pack directories the canonical city

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -174,11 +174,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		if decErr != nil {
 			return nil, nil, fmt.Errorf("parsing city pack.toml: %w", decErr)
 		}
-		if fatalWarnings := fatalUndecodedWarnings(md, packPath); len(fatalWarnings) > 0 {
-			return nil, nil, fmt.Errorf("parsing city pack.toml: %s", strings.Join(fatalWarnings, "; "))
-		}
 		if err := validatePackAuthoringSurface(md, packPath); err != nil {
 			return nil, nil, fmt.Errorf("parsing city pack.toml: %w", err)
+		}
+		if fatalWarnings := fatalUndecodedWarnings(md, packPath); len(fatalWarnings) > 0 {
+			return nil, nil, fmt.Errorf("parsing city pack.toml: %s", strings.Join(fatalWarnings, "; "))
 		}
 		prov.Warnings = append(prov.Warnings, packWarnings...)
 		if err := validatePackMeta(&pc.Pack); err != nil {

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -68,31 +68,27 @@ command = "bad"
 func TestLoadWithIncludes_RootPackDefaultRigImportsPreserveOrder(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
-[workspace]
-name = "test"
-`)
-	fs.Files["/city/pack.toml"] = []byte(`
-[pack]
-name = "test"
-schema = 2
-
 [defaults.rig.imports.z-pack]
 source = "packs/z-pack"
 
 [defaults.rig.imports.a-pack]
 source = "packs/a-pack"
+
+[defaults.rig.imports.city-local]
+source = "packs/city-local"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "test"
+schema = 2
 `)
 
 	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
 	if err != nil {
 		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-	want := []string{"packs/z-pack", "packs/a-pack"}
-	if got := cfg.Workspace.LegacyDefaultRigIncludes(); !reflect.DeepEqual(got, want) {
-		t.Fatalf("DefaultRigIncludes = %v, want %v", got, want)
-	}
-	if got := cfg.DefaultRigImportOrder; !reflect.DeepEqual(got, []string{"z-pack", "a-pack"}) {
-		t.Fatalf("DefaultRigImportOrder = %v, want [z-pack a-pack]", got)
+	if got := cfg.DefaultRigImportOrder; !reflect.DeepEqual(got, []string{"z-pack", "a-pack", "city-local"}) {
+		t.Fatalf("DefaultRigImportOrder = %v, want [z-pack a-pack city-local]", got)
 	}
 	if got := cfg.DefaultRigImports["z-pack"].Source; got != "packs/z-pack" {
 		t.Fatalf("DefaultRigImports[z-pack].Source = %q, want packs/z-pack", got)
@@ -298,6 +294,7 @@ mcp = ["shared-mcp", "common-mcp"]
 }
 
 func TestLoadWithIncludes_WarnsOnPackAgentDefaultsCompatibilityAndMigrationKeys(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]
@@ -349,6 +346,7 @@ scope = "rig"
 }
 
 func TestLoadWithIncludes_ImportedPackAgentDefaultsLayerIntoEffectiveFormula(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
 	tests := []struct {
 		name        string
 		cityDefault string
@@ -425,6 +423,7 @@ scope = "city"
 }
 
 func TestLoadWithIncludes_PackAgentDefaultsMergesNonOverlappingAgentsAliasFields(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]
@@ -465,6 +464,7 @@ scope = "city"
 }
 
 func TestLoadWithIncludes_ImportedPackWarningsSurfaceInProvenanceWithoutRigPacks(t *testing.T) {
+	t.Skip("pack-level agents alias is now rejected in pack.toml")
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]
@@ -491,6 +491,7 @@ append_fragments = ["footer"]
 }
 
 func TestLoadWithIncludes_WrapperPackDefaultsDoNotBleedAcrossImports(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]
@@ -539,6 +540,7 @@ scope = "city"
 }
 
 func TestLoadWithIncludes_IncludingPackDefaultsKeepInnermostScalarDefault(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]
@@ -581,6 +583,7 @@ scope = "city"
 }
 
 func TestLoadWithIncludes_IncludingPackDefaultsDoNotBleedAcrossNestedImportBoundaries(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -293,348 +293,86 @@ mcp = ["shared-mcp", "common-mcp"]
 	}
 }
 
-func TestLoadWithIncludes_WarnsOnPackAgentDefaultsCompatibilityAndMigrationKeys(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
-	fs := fsys.NewFake()
-	fs.Files["/city/city.toml"] = []byte(`
-[workspace]
-name = "test"
-
-[[rigs]]
-name = "hw"
-includes = ["packs/rigpack"]
-`)
-	fs.Files["/city/.gc/site.toml"] = []byte(`
-[[rig]]
-name = "hw"
-path = "/tmp/hw"
-`)
-	fs.Files["/city/pack.toml"] = []byte(`
-[pack]
-name = "test"
-schema = 2
-
-[agents]
-append_fragments = ["root-footer"]
-`)
-	fs.Files["/city/packs/rigpack/pack.toml"] = []byte(`
-[pack]
-name = "rigpack"
-schema = 2
-
-[agent_defaults]
-provider = "claude"
-`)
-	fs.Files["/city/packs/rigpack/agents/worker/agent.toml"] = []byte(`
-scope = "rig"
-`)
-
-	cfg, prov, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	if got := cfg.AgentDefaults.AppendFragments; len(got) != 1 || got[0] != "root-footer" {
-		t.Fatalf("AgentDefaults.AppendFragments = %v, want [root-footer]", got)
-	}
-	warnings := strings.Join(prov.Warnings, "\n")
-	if !strings.Contains(warnings, "/city/pack.toml: "+agentsAliasWarning) {
-		t.Fatalf("expected root pack alias warning, got: %v", prov.Warnings)
-	}
-	if !strings.Contains(warnings, `/city/packs/rigpack/pack.toml: "agent_defaults.provider" is not supported`) {
-		t.Fatalf("expected rig pack migration warning, got: %v", prov.Warnings)
-	}
-}
-
-func TestLoadWithIncludes_ImportedPackAgentDefaultsLayerIntoEffectiveFormula(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
+func TestLoadWithIncludesRejectsPackAuthoringSurfaces(t *testing.T) {
 	tests := []struct {
-		name        string
-		cityDefault string
-		nested      bool
-		want        string
+		name     string
+		packBody string
+		want     string
 	}{
-		{name: "pack default only", want: "mol-pack"},
-		{name: "city override wins", cityDefault: "mol-city", want: "mol-city"},
-		{name: "nested pack include inherits default", nested: true, want: "mol-pack"},
-		{name: "city override wins for nested pack include", cityDefault: "mol-city", nested: true, want: "mol-city"},
+		{
+			name: "agent_defaults",
+			packBody: `
+[agent_defaults]
+default_sling_formula = "mol-pack"
+`,
+			want: "[agent_defaults] is a city.toml table, not a pack.toml field",
+		},
+		{
+			name: "agents_alias",
+			packBody: `
+[agents]
+append_fragments = ["footer"]
+`,
+			want: "[agents] is a city.toml compatibility alias for [agent_defaults], not a pack.toml field",
+		},
+		{
+			name: "default_rig_imports",
+			packBody: `
+[defaults.rig.imports.ops]
+source = "../ops"
+`,
+			want: "[defaults.rig.imports] belongs in city.toml, not pack.toml",
+		},
+		{
+			name: "formulas_dir",
+			packBody: `
+[formulas]
+dir = "legacy-formulas"
+`,
+			want: "[formulas].dir is no longer supported; use the well-known formulas/ directory",
+		},
+		{
+			name: "rig_patches",
+			packBody: `
+[[patches.rigs]]
+name = "app"
+prefix = "ga"
+`,
+			want: "[[patches.rigs]] is only valid in city.toml; pack.toml supports [[patches.agent]] only",
+		},
+		{
+			name: "provider_patches",
+			packBody: `
+[[patches.providers]]
+name = "local"
+command = "false"
+`,
+			want: "[[patches.providers]] is only valid in city.toml; pack.toml supports [[patches.agent]] only",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := fsys.NewFake()
-			cityDefaults := ""
-			if tt.cityDefault != "" {
-				cityDefaults = "\n[agent_defaults]\ndefault_sling_formula = \"" + tt.cityDefault + "\"\n"
-			}
 			fs.Files["/city/city.toml"] = []byte(`
 [workspace]
 name = "test"
-includes = ["packs/imported"]
-` + cityDefaults)
-			if tt.nested {
-				fs.Files["/city/packs/imported/pack.toml"] = []byte(`
-[pack]
-name = "imported"
-schema = 2
-includes = ["../base"]
-
-[agent_defaults]
-default_sling_formula = "mol-pack"
 `)
-				fs.Files["/city/packs/base/pack.toml"] = []byte(`
+			fs.Files["/city/pack.toml"] = []byte(`
 [pack]
-name = "base"
+name = "test"
 schema = 2
+` + tt.packBody)
 
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-`)
-			} else {
-				fs.Files["/city/packs/imported/pack.toml"] = []byte(`
-[pack]
-name = "imported"
-schema = 2
-
-[agent_defaults]
-default_sling_formula = "mol-pack"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-`)
+			_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+			if err == nil {
+				t.Fatal("expected LoadWithIncludes to reject pack authoring surface")
 			}
-
-			cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
-			if err != nil {
-				t.Fatalf("LoadWithIncludes: %v", err)
-			}
-			if len(explicitAgents(cfg.Agents)) != 1 {
-				t.Fatalf("len(explicit agents) = %d, want 1", len(explicitAgents(cfg.Agents)))
-			}
-			got := explicitAgents(cfg.Agents)[0].EffectiveDefaultSlingFormula()
-			if got != tt.want {
-				t.Fatalf("EffectiveDefaultSlingFormula = %q, want %q", got, tt.want)
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
 		})
 	}
-}
-
-func TestLoadWithIncludes_PackAgentDefaultsMergesNonOverlappingAgentsAliasFields(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
-	fs := fsys.NewFake()
-	fs.Files["/city/city.toml"] = []byte(`
-[workspace]
-name = "test"
-includes = ["packs/imported"]
-`)
-	fs.Files["/city/packs/imported/pack.toml"] = []byte(`
-[pack]
-name = "imported"
-schema = 2
-
-[agent_defaults]
-append_fragments = ["canonical-footer"]
-
-[agents]
-default_sling_formula = "mol-legacy"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-`)
-
-	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	if len(explicitAgents(cfg.Agents)) != 1 {
-		t.Fatalf("len(explicit agents) = %d, want 1", len(explicitAgents(cfg.Agents)))
-	}
-	agent := explicitAgents(cfg.Agents)[0]
-	if got := agent.EffectiveDefaultSlingFormula(); got != "mol-legacy" {
-		t.Fatalf("EffectiveDefaultSlingFormula = %q, want %q", got, "mol-legacy")
-	}
-	if !reflect.DeepEqual(agent.InheritedAppendFragments, []string{"canonical-footer"}) {
-		t.Fatalf("InheritedAppendFragments = %v, want %v", agent.InheritedAppendFragments, []string{"canonical-footer"})
-	}
-}
-
-func TestLoadWithIncludes_ImportedPackWarningsSurfaceInProvenanceWithoutRigPacks(t *testing.T) {
-	t.Skip("pack-level agents alias is now rejected in pack.toml")
-	fs := fsys.NewFake()
-	fs.Files["/city/city.toml"] = []byte(`
-[workspace]
-name = "test"
-includes = ["packs/imported"]
-`)
-	fs.Files["/city/packs/imported/pack.toml"] = []byte(`
-[pack]
-name = "imported"
-schema = 2
-
-[agents]
-append_fragments = ["footer"]
-`)
-
-	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	warnings := strings.Join(prov.Warnings, "\n")
-	if !strings.Contains(warnings, "/city/packs/imported/pack.toml: "+agentsAliasWarning) {
-		t.Fatalf("expected imported-pack alias warning in provenance, got: %v", prov.Warnings)
-	}
-}
-
-func TestLoadWithIncludes_WrapperPackDefaultsDoNotBleedAcrossImports(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
-	fs := fsys.NewFake()
-	fs.Files["/city/city.toml"] = []byte(`
-[workspace]
-name = "test"
-includes = ["packs/wrapper"]
-`)
-	fs.Files["/city/packs/wrapper/pack.toml"] = []byte(`
-[pack]
-name = "wrapper"
-schema = 2
-
-[agent_defaults]
-default_sling_formula = "mol-wrapper"
-
-[imports.dep]
-source = "../dep"
-`)
-	fs.Files["/city/packs/dep/pack.toml"] = []byte(`
-[pack]
-name = "dep"
-schema = 2
-
-[agent_defaults]
-default_sling_formula = "mol-dep"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-`)
-
-	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	for _, a := range explicitAgents(cfg.Agents) {
-		if a.BindingName != "dep" || a.Name != "mayor" {
-			continue
-		}
-		if got := a.EffectiveDefaultSlingFormula(); got != "mol-dep" {
-			t.Fatalf("dep.mayor EffectiveDefaultSlingFormula = %q, want %q", got, "mol-dep")
-		}
-		return
-	}
-	t.Fatalf("expected dep.mayor agent, got %v", explicitAgents(cfg.Agents))
-}
-
-func TestLoadWithIncludes_IncludingPackDefaultsKeepInnermostScalarDefault(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
-	fs := fsys.NewFake()
-	fs.Files["/city/city.toml"] = []byte(`
-[workspace]
-name = "test"
-includes = ["packs/outer"]
-`)
-	fs.Files["/city/packs/outer/pack.toml"] = []byte(`
-[pack]
-name = "outer"
-schema = 2
-includes = ["../base"]
-
-[agent_defaults]
-default_sling_formula = "mol-outer"
-`)
-	fs.Files["/city/packs/base/pack.toml"] = []byte(`
-[pack]
-name = "base"
-schema = 2
-
-[agent_defaults]
-default_sling_formula = "mol-base"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-`)
-
-	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	if len(explicitAgents(cfg.Agents)) != 1 {
-		t.Fatalf("len(explicit agents) = %d, want 1", len(explicitAgents(cfg.Agents)))
-	}
-	if got := explicitAgents(cfg.Agents)[0].EffectiveDefaultSlingFormula(); got != "mol-base" {
-		t.Fatalf("EffectiveDefaultSlingFormula = %q, want %q", got, "mol-base")
-	}
-}
-
-func TestLoadWithIncludes_IncludingPackDefaultsDoNotBleedAcrossNestedImportBoundaries(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
-	fs := fsys.NewFake()
-	fs.Files["/city/city.toml"] = []byte(`
-[workspace]
-name = "test"
-includes = ["packs/outer"]
-`)
-	fs.Files["/city/packs/outer/pack.toml"] = []byte(`
-[pack]
-name = "outer"
-schema = 2
-includes = ["../mid"]
-
-[agent_defaults]
-default_sling_formula = "mol-outer"
-`)
-	fs.Files["/city/packs/mid/pack.toml"] = []byte(`
-[pack]
-name = "mid"
-schema = 2
-
-[imports.dep]
-source = "../dep"
-`)
-	fs.Files["/city/packs/dep/pack.toml"] = []byte(`
-[pack]
-name = "dep"
-schema = 2
-
-[agent_defaults]
-default_sling_formula = "mol-dep"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-scope = "city"
-`)
-
-	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-	for _, a := range explicitAgents(cfg.Agents) {
-		if a.BindingName != "dep" || a.Name != "mayor" {
-			continue
-		}
-		if got := a.EffectiveDefaultSlingFormula(); got != "mol-dep" {
-			t.Fatalf("dep.mayor EffectiveDefaultSlingFormula = %q, want %q", got, "mol-dep")
-		}
-		return
-	}
-	t.Fatalf("expected dep.mayor agent, got %v", explicitAgents(cfg.Agents))
 }
 
 func TestLoadWithIncludes_ConcatRigs(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,6 +174,9 @@ type City struct {
 	// binding name; the value specifies the source and optional version,
 	// export, and transitive controls. Processed during ExpandCityPacks.
 	Imports map[string]Import `toml:"imports,omitempty"`
+	// Defaults holds city-level defaults that seed generated config. The
+	// canonical default-rig import table is [defaults.rig.imports].
+	Defaults PackDefaults `toml:"defaults,omitempty"`
 	// Agents lists all configured agents in this city. Optional: PackV2
 	// cities compose agents through [imports.*] and ship without any
 	// [[agent]] block.
@@ -1098,7 +1101,7 @@ type Workspace struct {
 	Includes []string `toml:"includes,omitempty"`
 	// DefaultRigIncludes is the legacy city.toml default-rig pack list.
 	//
-	// Deprecated: use root pack.toml [defaults.rig.imports.<binding>] instead.
+	// Deprecated: use city.toml [defaults.rig.imports.<binding>] instead.
 	// Run gc doctor to inspect; gc doctor --fix handles the safe mechanical
 	// rewrites available in this release wave.
 	DefaultRigIncludes []string `toml:"default_rig_includes,omitempty"`
@@ -1441,10 +1444,12 @@ type DoltConfig struct {
 	ArchiveLevel *int `toml:"archive_level,omitempty" jsonschema:"default=0"`
 }
 
-// FormulasConfig holds formula directory settings.
+// FormulasConfig holds legacy formula directory settings.
 type FormulasConfig struct {
-	// Dir is the path to the formulas directory. Defaults to "formulas".
-	Dir string `toml:"dir,omitempty" jsonschema:"default=formulas"`
+	// Dir is the legacy path to the formulas directory. PackV2 cities and
+	// packs use the well-known formulas/ directory; authored [formulas].dir
+	// is rejected for schema 2 configs.
+	Dir string `toml:"dir,omitempty" jsonschema:"-"`
 }
 
 // OrdersConfig holds order settings.

--- a/internal/config/import_negative_test.go
+++ b/internal/config/import_negative_test.go
@@ -44,6 +44,7 @@ includes = ["../mypk"]
 }
 
 func TestImport_TransitiveFalseSuppressesNestedPackWarnings(t *testing.T) {
+	t.Skip("pack-level warning surfaces used by this test are now rejected")
 	dir := t.TempDir()
 	cityDir := filepath.Join(dir, "city")
 	for _, name := range []string{"city", "b", "c"} {
@@ -63,8 +64,6 @@ transitive = false
 name = "b"
 schema = 1
 
-[agents]
-append_fragments = ["direct"]
 
 [imports.c]
 source = "../c"
@@ -78,8 +77,6 @@ scope = "city"
 name = "c"
 schema = 1
 
-[agent_defaults]
-provider = "claude"
 
 [[agent]]
 name = "transitive"

--- a/internal/config/import_negative_test.go
+++ b/internal/config/import_negative_test.go
@@ -44,7 +44,6 @@ includes = ["../mypk"]
 }
 
 func TestImport_TransitiveFalseSuppressesNestedPackWarnings(t *testing.T) {
-	t.Skip("pack-level warning surfaces used by this test are now rejected")
 	dir := t.TempDir()
 	cityDir := filepath.Join(dir, "city")
 	for _, name := range []string{"city", "b", "c"} {
@@ -77,7 +76,6 @@ scope = "city"
 name = "c"
 schema = 1
 
-
 [[agent]]
 name = "transitive"
 scope = "city"
@@ -85,13 +83,10 @@ scope = "city"
 
 	_, prov, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
 	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
+		t.Fatalf("LoadWithIncludes should not inspect transitive=false nested pack: %v", err)
 	}
 
 	warnings := strings.Join(prov.Warnings, "\n")
-	if !strings.Contains(warnings, filepath.Join(dir, "b", "pack.toml")) {
-		t.Fatalf("expected direct import warning from b pack.toml; got %q", warnings)
-	}
 	if strings.Contains(warnings, filepath.Join(dir, "c", "pack.toml")) {
 		t.Fatalf("nested pack warnings should be suppressed by transitive=false; got %q", warnings)
 	}

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -117,6 +117,7 @@ scope = "city"
 }
 
 func TestImport_AgentDefaultsDefaultSlingFormulaInherited(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
 	dir := t.TempDir()
 	cityDir := filepath.Join(dir, "city")
 	importDir := filepath.Join(dir, "tools")
@@ -176,6 +177,7 @@ scope = "city"
 }
 
 func TestImport_AgentDefaultsDefaultSlingFormulaInheritedBeatsCityDefault(t *testing.T) {
+	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
 	dir := t.TempDir()
 	cityDir := filepath.Join(dir, "city")
 	importDir := filepath.Join(dir, "tools")

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -116,8 +116,7 @@ scope = "city"
 	}
 }
 
-func TestImport_AgentDefaultsDefaultSlingFormulaInherited(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
+func TestImport_RejectsPackAgentDefaultsDefaultSlingFormula(t *testing.T) {
 	dir := t.TempDir()
 	cityDir := filepath.Join(dir, "city")
 	importDir := filepath.Join(dir, "tools")
@@ -149,35 +148,19 @@ name = "worker"
 scope = "city"
 `)
 
-	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected LoadWithIncludes to reject imported pack [agent_defaults]")
 	}
-
-	for _, a := range explicitAgents(cfg.Agents) {
-		if a.QualifiedName() != "tools.worker" {
-			continue
-		}
-		if a.DefaultSlingFormula != nil {
-			t.Fatalf("tools.worker DefaultSlingFormula = %v, want nil explicit override", *a.DefaultSlingFormula)
-		}
-		if a.InheritedDefaultSlingFormula == nil || *a.InheritedDefaultSlingFormula != "mol-pack-default" {
-			got := "<nil>"
-			if a.InheritedDefaultSlingFormula != nil {
-				got = *a.InheritedDefaultSlingFormula
-			}
-			t.Fatalf("tools.worker InheritedDefaultSlingFormula = %s, want %q", got, "mol-pack-default")
-		}
-		if got := a.EffectiveDefaultSlingFormula(); got != "mol-pack-default" {
-			t.Fatalf("tools.worker EffectiveDefaultSlingFormula() = %q, want %q", got, "mol-pack-default")
-		}
-		return
+	if !strings.Contains(err.Error(), "[agent_defaults] is a city.toml table, not a pack.toml field") {
+		t.Fatalf("error = %v, want pack authoring surface rejection", err)
 	}
-	t.Fatalf("imported agent tools.worker not found: %+v", explicitAgents(cfg.Agents))
+	if !strings.Contains(err.Error(), filepath.Join(importDir, "pack.toml")) {
+		t.Fatalf("error = %v, want offending imported pack path", err)
+	}
 }
 
-func TestImport_AgentDefaultsDefaultSlingFormulaInheritedBeatsCityDefault(t *testing.T) {
-	t.Skip("pack-level agent defaults are no longer a PackV2 surface")
+func TestImport_CityAgentDefaultsDefaultSlingFormulaAppliesToImportedAgent(t *testing.T) {
 	dir := t.TempDir()
 	cityDir := filepath.Join(dir, "city")
 	importDir := filepath.Join(dir, "tools")
@@ -187,11 +170,6 @@ func TestImport_AgentDefaultsDefaultSlingFormulaInheritedBeatsCityDefault(t *tes
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
-`)
-	writeTestFile(t, cityDir, "pack.toml", `
-[pack]
-name = "test"
-schema = 1
 
 [agent_defaults]
 default_sling_formula = "mol-city-default"
@@ -204,9 +182,6 @@ source = "../tools"
 name = "tools"
 schema = 1
 
-[agent_defaults]
-default_sling_formula = "mol-pack-default"
-
 [[agent]]
 name = "worker"
 scope = "city"
@@ -221,11 +196,8 @@ scope = "city"
 		if a.QualifiedName() != "tools.worker" {
 			continue
 		}
-		if got := a.EffectiveDefaultSlingFormula(); got != "mol-pack-default" {
-			t.Fatalf("tools.worker EffectiveDefaultSlingFormula() = %q, want %q", got, "mol-pack-default")
-		}
-		if a.DefaultSlingFormula != nil {
-			t.Fatalf("tools.worker DefaultSlingFormula = %q, want nil when city default should not override imported pack default", *a.DefaultSlingFormula)
+		if got := a.EffectiveDefaultSlingFormula(); got != "mol-city-default" {
+			t.Fatalf("tools.worker EffectiveDefaultSlingFormula() = %q, want %q", got, "mol-city-default")
 		}
 		return
 	}

--- a/internal/config/legacy_v1_surfaces.go
+++ b/internal/config/legacy_v1_surfaces.go
@@ -75,7 +75,7 @@ func DetectLegacyV1Surfaces(cfg *City, source string) []string {
 	if len(cfg.Workspace.DefaultRigIncludes) > 0 {
 		warnings = append(warnings, fmt.Sprintf(
 			"%s: workspace.default_rig_includes is deprecated in v2; use "+
-				"root pack.toml [defaults.rig.imports.<binding>]. Run "+
+				"city.toml [defaults.rig.imports.<binding>]. Run "+
 				"`gc doctor` to inspect; `gc doctor --fix` handles the safe mechanical rewrites available in this wave.",
 			source))
 	}
@@ -111,7 +111,7 @@ func LegacyV1SurfaceErrors(cfg *City, source string, data ...[]byte) []string {
 	}
 	if len(cfg.Workspace.DefaultRigIncludes) > 0 {
 		errors = append(errors, fmt.Sprintf(
-			"%s: unsupported PackV1 workspace.default_rig_includes; move defaults into root pack.toml [defaults.rig.imports.<binding>]",
+			"%s: unsupported PackV1 workspace.default_rig_includes; move defaults into city.toml [defaults.rig.imports.<binding>]",
 			sourceWithDiagnosticLine(source, locator.lineForKey("workspace", "default_rig_includes"))))
 	}
 	return errors

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -37,23 +37,35 @@ type deferredRigPatches struct {
 type PackConfig struct {
 	Pack           PackMeta                `toml:"pack" jsonschema:"required"`
 	Imports        map[string]Import       `toml:"imports,omitempty"`
-	AgentDefaults  AgentDefaults           `toml:"agent_defaults,omitempty"`
+	AgentDefaults  AgentDefaults           `toml:"agent_defaults,omitempty" jsonschema:"-"`
 	AgentsDefaults AgentDefaults           `toml:"agents,omitempty" jsonschema:"-"`
-	Defaults       PackDefaults            `toml:"defaults,omitempty"`
+	Defaults       PackDefaults            `toml:"defaults,omitempty" jsonschema:"-"`
 	Agents         []Agent                 `toml:"agent,omitempty"`
 	NamedSessions  []NamedSession          `toml:"named_session,omitempty"`
 	Services       []Service               `toml:"service,omitempty"`
 	Providers      map[string]ProviderSpec `toml:"providers,omitempty"`
-	Formulas       FormulasConfig          `toml:"formulas,omitempty"`
-	Patches        Patches                 `toml:"patches,omitempty"`
+	Formulas       FormulasConfig          `toml:"formulas,omitempty" jsonschema:"-"`
+	Patches        PackPatches             `toml:"patches,omitempty"`
 	Doctor         []PackDoctorEntry       `toml:"doctor,omitempty"`
 	Commands       []PackCommandEntry      `toml:"commands,omitempty"`
 	Global         PackGlobal              `toml:"global,omitempty"`
 	Pricing        []pricing.ModelPricing  `toml:"pricing,omitempty"`
 }
 
-// PackDefaults holds [defaults] entries declared by a pack — used by
-// cities that compose this pack to seed rig configuration.
+// PackPatches holds the patch operations valid in pack.toml. City
+// configuration may patch agents, rigs, and providers; packs may only patch
+// agents visible within that pack load.
+type PackPatches struct {
+	Agents []AgentPatch `toml:"agent,omitempty"`
+}
+
+// IsEmpty reports whether the pack declares no supported patch entries.
+func (p *PackPatches) IsEmpty() bool {
+	return p == nil || len(p.Agents) == 0
+}
+
+// PackDefaults holds [defaults] entries used to seed generated rig
+// configuration.
 type PackDefaults struct {
 	Rig PackRigDefaults `toml:"rig,omitempty"`
 }
@@ -1094,7 +1106,7 @@ func LoadPackForLint(fs fsys.FS, packDir string) (*LintPackLoad, error) {
 	topoPath := filepath.Join(absDir, packFile)
 	cache := &packLoadCache{results: make(map[string]*packLoadResult)}
 	agents, namedSessions, providers, _, topoDirs, _, _, err := loadPackWithCacheOptions(
-		fs, topoPath, absDir, absDir, "", nil, cache, LoadOptions{AllowRootDefaultRigImports: true})
+		fs, topoPath, absDir, absDir, "", nil, cache, LoadOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -1132,21 +1144,6 @@ func loadPackWithCacheOptions(fs fsys.FS, topoPath, topoDir, cityRoot, rigName s
 		return loadErr
 	})
 	return agents, namedSessions, providers, services, topoDirs, requirements, globals, err
-}
-
-func allowRootDefaultRigImports(opts LoadOptions, topoDir, cityRoot string) bool {
-	if !opts.AllowRootDefaultRigImports {
-		return false
-	}
-	absTopoDir, err := filepath.Abs(topoDir)
-	if err != nil {
-		absTopoDir = topoDir
-	}
-	absCityRoot, err := filepath.Abs(cityRoot)
-	if err != nil {
-		absCityRoot = cityRoot
-	}
-	return absTopoDir == absCityRoot
 }
 
 func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rigName string, seen map[string]bool, cache *packLoadCache, opts LoadOptions) ([]Agent, []NamedSession, map[string]ProviderSpec, []Service, []string, []PackRequirement, []ResolvedPackGlobal, error) {
@@ -1196,8 +1193,8 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	if fatalWarnings := fatalUndecodedWarnings(md, topoPath); len(fatalWarnings) > 0 {
 		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %s", packFile, strings.Join(fatalWarnings, "; "))
 	}
-	if len(tc.Defaults.Rig.Imports) > 0 && !allowRootDefaultRigImports(opts, topoDir, cityRoot) {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: [defaults.rig.imports] is only supported in a city root pack.toml", packFile)
+	if err := validatePackAuthoringSurface(md, packFile); err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
 	}
 
 	if err := validatePackMeta(&tc.Pack); err != nil {
@@ -2247,7 +2244,7 @@ func resolveConfigDirInCommands(cmds []string, configDir string) []string {
 // absolute path because patches do not retain independent source provenance
 // after application; prompt_template and overlay_dir keep the existing
 // city-root-relative representation used elsewhere in composition.
-func adjustPackPatchPaths(patches *Patches, topoDir, cityRoot string) {
+func adjustPackPatchPaths(patches *PackPatches, topoDir, cityRoot string) {
 	for i := range patches.Agents {
 		p := &patches.Agents[i]
 		if p.SessionSetupScript != nil && *p.SessionSetupScript != "" {

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1190,11 +1190,11 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
 	}
+	if err := validatePackAuthoringSurface(md, topoPath); err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
+	}
 	if fatalWarnings := fatalUndecodedWarnings(md, topoPath); len(fatalWarnings) > 0 {
 		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %s", packFile, strings.Join(fatalWarnings, "; "))
-	}
-	if err := validatePackAuthoringSurface(md, packFile); err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("parsing %s: %w", packFile, err)
 	}
 
 	if err := validatePackMeta(&tc.Pack); err != nil {

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -1219,8 +1219,6 @@ func TestExpandCityPacks_FormulaDirsStacked(t *testing.T) {
 name = "alpha"
 schema = 1
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "agent-a"
@@ -1231,8 +1229,6 @@ name = "agent-a"
 name = "beta"
 schema = 1
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "agent-b"
@@ -1421,8 +1417,6 @@ func TestExpandPacks_RigFormulaDirsMultiple(t *testing.T) {
 name = "alpha"
 schema = 1
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "worker-a"
@@ -1433,8 +1427,6 @@ name = "worker-a"
 name = "beta"
 schema = 1
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "worker-b"
@@ -1621,8 +1613,6 @@ name = "gastown"
 version = "1.0.0"
 schema = 1
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "mayor"
@@ -1796,8 +1786,6 @@ name = "gastown"
 version = "1.0.0"
 schema = 1
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "witness"
@@ -2427,8 +2415,6 @@ func TestPackIncludesFormulas(t *testing.T) {
 name = "maintenance"
 schema = 1
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "dog"
@@ -2442,8 +2428,6 @@ name = "gastown"
 schema = 1
 includes = ["../maintenance"]
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "mayor"
@@ -2586,8 +2570,6 @@ func TestExpandCityPacksWithIncludes(t *testing.T) {
 name = "maintenance"
 schema = 1
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "dog"
@@ -2602,8 +2584,6 @@ name = "gastown"
 schema = 1
 includes = ["../maintenance"]
 
-[formulas]
-dir = "formulas"
 
 [[agent]]
 name = "mayor"

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -63,6 +63,36 @@ func fatalUndecodedWarnings(md toml.MetaData, source string) []string {
 	return warnings
 }
 
+func validateCityAuthoringSurface(md toml.MetaData) error {
+	if md.IsDefined("formulas", "dir") {
+		return fmt.Errorf("[formulas].dir is no longer supported; use the well-known formulas/ directory")
+	}
+	return nil
+}
+
+func validatePackAuthoringSurface(md toml.MetaData, source string) error {
+	if md.IsDefined("agent_defaults") {
+		return fmt.Errorf("[agent_defaults] is a city.toml table, not a pack.toml field")
+	}
+	if md.IsDefined("agents") {
+		return fmt.Errorf("[agents] is a city.toml compatibility alias for [agent_defaults], not a pack.toml field")
+	}
+	if md.IsDefined("defaults", "rig", "imports") {
+		return fmt.Errorf("[defaults.rig.imports] belongs in city.toml, not pack.toml")
+	}
+	if md.IsDefined("formulas", "dir") {
+		return fmt.Errorf("[formulas].dir is no longer supported; use the well-known formulas/ directory")
+	}
+	if md.IsDefined("patches", "rigs") {
+		return fmt.Errorf("[[patches.rigs]] is only valid in city.toml; pack.toml supports [[patches.agent]] only")
+	}
+	if md.IsDefined("patches", "providers") {
+		return fmt.Errorf("[[patches.providers]] is only valid in city.toml; pack.toml supports [[patches.agent]] only")
+	}
+	_ = source
+	return nil
+}
+
 func unknownFieldWarning(source, key string, known []string) string {
 	suggestion := suggestKey(key, known)
 	w := fmt.Sprintf("%s: unknown field %q", source, key)

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -72,24 +72,23 @@ func validateCityAuthoringSurface(md toml.MetaData) error {
 
 func validatePackAuthoringSurface(md toml.MetaData, source string) error {
 	if md.IsDefined("agent_defaults") {
-		return fmt.Errorf("[agent_defaults] is a city.toml table, not a pack.toml field")
+		return fmt.Errorf("%s: [agent_defaults] is a city.toml table, not a pack.toml field", source)
 	}
 	if md.IsDefined("agents") {
-		return fmt.Errorf("[agents] is a city.toml compatibility alias for [agent_defaults], not a pack.toml field")
+		return fmt.Errorf("%s: [agents] is a city.toml compatibility alias for [agent_defaults], not a pack.toml field", source)
 	}
 	if md.IsDefined("defaults", "rig", "imports") {
-		return fmt.Errorf("[defaults.rig.imports] belongs in city.toml, not pack.toml")
+		return fmt.Errorf("%s: [defaults.rig.imports] belongs in city.toml, not pack.toml", source)
 	}
 	if md.IsDefined("formulas", "dir") {
-		return fmt.Errorf("[formulas].dir is no longer supported; use the well-known formulas/ directory")
+		return fmt.Errorf("%s: [formulas].dir is no longer supported; use the well-known formulas/ directory", source)
 	}
 	if md.IsDefined("patches", "rigs") {
-		return fmt.Errorf("[[patches.rigs]] is only valid in city.toml; pack.toml supports [[patches.agent]] only")
+		return fmt.Errorf("%s: [[patches.rigs]] is only valid in city.toml; pack.toml supports [[patches.agent]] only", source)
 	}
 	if md.IsDefined("patches", "providers") {
-		return fmt.Errorf("[[patches.providers]] is only valid in city.toml; pack.toml supports [[patches.agent]] only")
+		return fmt.Errorf("%s: [[patches.providers]] is only valid in city.toml; pack.toml supports [[patches.agent]] only", source)
 	}
-	_ = source
 	return nil
 }
 

--- a/internal/docgen/schema.go
+++ b/internal/docgen/schema.go
@@ -73,7 +73,8 @@ func GenerateCitySchema() (*jsonschema.Schema, error) {
 	s.Title = "Gas City Configuration"
 	s.Description = "Schema for city.toml — the PackV2 deployment file for a Gas City instance. " +
 		"Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. " +
-		"Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility."
+		"Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility.\n\n" +
+		"> **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 	return s, nil
 }
 

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -43,6 +43,7 @@ type packFile struct {
 	Agents         []config.Agent                 `toml:"agent"`
 
 	defaultRigImportOrder []string
+	metadata              toml.MetaData
 }
 
 type packDefaults struct {
@@ -211,6 +212,10 @@ func Apply(cityPath string, opts Options) (*Report, error) {
 		cityCfg.Workspace.SetLegacyDefaultRigIncludes(nil)
 	}
 
+	if migratePackAuthoringSurfaces(&packCfg, cityCfg, report) {
+		packChanged = true
+	}
+
 	removeMigratedPackSources(cityCfg, migratedPacks)
 
 	cityContent, err := cityCfg.Marshal()
@@ -305,10 +310,136 @@ func loadPackFile(path string) (packFile, bool, error) {
 		return packFile{}, true, fmt.Errorf("migrate %q: %w", path, err)
 	}
 	if warnings := config.CheckUndecodedKeys(md, path); len(warnings) > 0 {
-		return packFile{}, true, fmt.Errorf("migrate %q: %s", path, strings.Join(warnings, "; "))
+		if filtered := migrationFatalPackWarnings(warnings); len(filtered) > 0 {
+			return packFile{}, true, fmt.Errorf("migrate %q: %s", path, strings.Join(filtered, "; "))
+		}
 	}
 	cfg.defaultRigImportOrder = packDefaultRigImportOrder(md)
+	cfg.metadata = md
 	return cfg, true, nil
+}
+
+func migrationFatalPackWarnings(warnings []string) []string {
+	var fatal []string
+	for _, warning := range warnings {
+		if strings.Contains(warning, "[agents] is a deprecated compatibility alias for [agent_defaults]") {
+			continue
+		}
+		if strings.Contains(warning, "both [agent_defaults] and [agents] are present") {
+			continue
+		}
+		fatal = append(fatal, warning)
+	}
+	return fatal
+}
+
+func migratePackAuthoringSurfaces(packCfg *packFile, cityCfg *config.City, report *Report) bool {
+	if packCfg == nil || cityCfg == nil {
+		return false
+	}
+
+	packChanged := false
+	defaults := normalizedPackAgentDefaults(*packCfg)
+	if !isZeroAgentDefaults(defaults) {
+		mergeMigratedAgentDefaults(&cityCfg.AgentDefaults, defaults)
+		packCfg.AgentDefaults = config.AgentDefaults{}
+		packCfg.AgentsDefaults = config.AgentDefaults{}
+		packChanged = true
+	}
+
+	if len(packCfg.Patches.Rigs) > 0 {
+		cityCfg.Patches.Rigs = append(cityCfg.Patches.Rigs, packCfg.Patches.Rigs...)
+		packCfg.Patches.Rigs = nil
+		packChanged = true
+	}
+	if len(packCfg.Patches.Providers) > 0 {
+		cityCfg.Patches.Providers = append(cityCfg.Patches.Providers, packCfg.Patches.Providers...)
+		packCfg.Patches.Providers = nil
+		packChanged = true
+	}
+
+	if packCfg.Formulas.Dir != "" {
+		report.Warnings = append(report.Warnings,
+			fmt.Sprintf("dropped pack.toml formulas.dir ([formulas].dir) %q; use the well-known formulas/ directory", packCfg.Formulas.Dir))
+		packCfg.Formulas.Dir = ""
+		packChanged = true
+	}
+	if cityCfg.Formulas.Dir != "" {
+		report.Warnings = append(report.Warnings,
+			fmt.Sprintf("dropped city.toml formulas.dir ([formulas].dir) %q; use the well-known formulas/ directory", cityCfg.Formulas.Dir))
+		cityCfg.Formulas.Dir = ""
+	}
+
+	return packChanged
+}
+
+func normalizedPackAgentDefaults(packCfg packFile) config.AgentDefaults {
+	defaults := packCfg.AgentDefaults
+	if packCfg.metadata.IsDefined("agent_defaults") {
+		if packCfg.metadata.IsDefined("agents") {
+			mergeAgentDefaultsAliasForMigration(&defaults, packCfg.AgentsDefaults, packCfg.metadata)
+		}
+		return defaults
+	}
+	if packCfg.metadata.IsDefined("agents") {
+		return packCfg.AgentsDefaults
+	}
+	return config.AgentDefaults{}
+}
+
+func mergeAgentDefaultsAliasForMigration(dst *config.AgentDefaults, src config.AgentDefaults, meta toml.MetaData) {
+	if !meta.IsDefined("agent_defaults", "model") {
+		dst.Model = src.Model
+	}
+	if !meta.IsDefined("agent_defaults", "wake_mode") {
+		dst.WakeMode = src.WakeMode
+	}
+	if !meta.IsDefined("agent_defaults", "default_sling_formula") {
+		dst.DefaultSlingFormula = src.DefaultSlingFormula
+	}
+	if !meta.IsDefined("agent_defaults", "allow_overlay") {
+		dst.AllowOverlay = append([]string(nil), src.AllowOverlay...)
+	}
+	if !meta.IsDefined("agent_defaults", "allow_env_override") {
+		dst.AllowEnvOverride = append([]string(nil), src.AllowEnvOverride...)
+	}
+	if !meta.IsDefined("agent_defaults", "append_fragments") {
+		dst.AppendFragments = append([]string(nil), src.AppendFragments...)
+	}
+	if !meta.IsDefined("agent_defaults", "skills") {
+		dst.Skills = append([]string(nil), src.Skills...)
+	}
+	if !meta.IsDefined("agent_defaults", "mcp") {
+		dst.MCP = append([]string(nil), src.MCP...)
+	}
+}
+
+func mergeMigratedAgentDefaults(dst *config.AgentDefaults, src config.AgentDefaults) {
+	if dst.Model == "" {
+		dst.Model = src.Model
+	}
+	if dst.WakeMode == "" {
+		dst.WakeMode = src.WakeMode
+	}
+	if dst.DefaultSlingFormula == "" {
+		dst.DefaultSlingFormula = src.DefaultSlingFormula
+	}
+	dst.AllowOverlay = dedupeStrings(append(dst.AllowOverlay, src.AllowOverlay...))
+	dst.AllowEnvOverride = dedupeStrings(append(dst.AllowEnvOverride, src.AllowEnvOverride...))
+	dst.AppendFragments = dedupeStrings(append(dst.AppendFragments, src.AppendFragments...))
+	dst.Skills = dedupeStrings(append(dst.Skills, src.Skills...))
+	dst.MCP = dedupeStrings(append(dst.MCP, src.MCP...))
+}
+
+func isZeroAgentDefaults(defaults config.AgentDefaults) bool {
+	return defaults.Model == "" &&
+		defaults.WakeMode == "" &&
+		defaults.DefaultSlingFormula == "" &&
+		len(defaults.AllowOverlay) == 0 &&
+		len(defaults.AllowEnvOverride) == 0 &&
+		len(defaults.AppendFragments) == 0 &&
+		len(defaults.Skills) == 0 &&
+		len(defaults.MCP) == 0
 }
 
 func packDefaultRigImportOrder(md toml.MetaData) []string {

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -182,20 +182,32 @@ func Apply(cityPath string, opts Options) (*Report, error) {
 		cityCfg.Workspace.SetLegacyIncludes(nil)
 	}
 
-	if len(cityCfg.Workspace.LegacyDefaultRigIncludes()) > 0 {
-		if packCfg.Defaults.Rig.Imports == nil {
-			packCfg.Defaults.Rig.Imports = make(map[string]config.Import)
+	if len(packCfg.Defaults.Rig.Imports) > 0 {
+		if cityCfg.Defaults.Rig.Imports == nil {
+			cityCfg.Defaults.Rig.Imports = make(map[string]config.Import, len(packCfg.Defaults.Rig.Imports))
 		}
-		var changed bool
-		packCfg.defaultRigImportOrder, changed = addOrderedImports(
-			packCfg.Defaults.Rig.Imports,
-			packCfg.defaultRigImportOrder,
+		for _, name := range orderedPackDefaultRigImportNames(packCfg.Defaults.Rig.Imports, packCfg.defaultRigImportOrder) {
+			if _, exists := cityCfg.Defaults.Rig.Imports[name]; exists {
+				continue
+			}
+			cityCfg.Defaults.Rig.Imports[name] = packCfg.Defaults.Rig.Imports[name]
+		}
+		packCfg.Defaults.Rig.Imports = nil
+		packCfg.defaultRigImportOrder = nil
+		packChanged = true
+	}
+
+	if len(cityCfg.Workspace.LegacyDefaultRigIncludes()) > 0 {
+		if cityCfg.Defaults.Rig.Imports == nil {
+			cityCfg.Defaults.Rig.Imports = make(map[string]config.Import)
+		}
+		_, changed := addOrderedImports(
+			cityCfg.Defaults.Rig.Imports,
+			nil,
 			cityCfg.Workspace.LegacyDefaultRigIncludes(),
 			cityCfg.Packs,
 		)
-		if changed {
-			packChanged = true
-		}
+		_ = changed
 		cityCfg.Workspace.SetLegacyDefaultRigIncludes(nil)
 	}
 

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -354,6 +354,99 @@ source = "../packs/a-pack"
 	}
 }
 
+func TestMigrateMovesPackV2RejectedSurfacesThenLoads(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+
+[[rigs]]
+name = "app"
+
+[formulas]
+dir = "city-formulas"
+
+[providers.local]
+command = "true"
+`)
+	writeFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+
+[agent_defaults]
+default_sling_formula = "mol-canonical"
+
+[agents]
+append_fragments = ["legacy-footer"]
+
+[formulas]
+dir = "legacy-formulas"
+
+[defaults.rig.imports.ops]
+source = "../packs/ops"
+
+[[patches.rigs]]
+name = "app"
+prefix = "ga"
+
+[[patches.providers]]
+name = "local"
+command = "false"
+
+[[agent]]
+name = "worker"
+provider = "local"
+`)
+
+	report, err := Apply(cityDir, Options{})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	packToml := readFile(t, filepath.Join(cityDir, "pack.toml"))
+	for _, forbidden := range []string{
+		"[agent_defaults]",
+		"[agents]",
+		"[formulas]",
+		"[defaults.rig.imports.",
+		"[[patches.rigs]]",
+		"[[patches.providers]]",
+	} {
+		if strings.Contains(packToml, forbidden) {
+			t.Fatalf("pack.toml still contains rejected surface %q:\n%s", forbidden, packToml)
+		}
+	}
+
+	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
+	for _, want := range []string{
+		"[agent_defaults]",
+		`default_sling_formula = "mol-canonical"`,
+		`append_fragments = ["legacy-footer"]`,
+		"[defaults.rig.imports.ops]",
+		"[[patches.rigs]]",
+		`prefix = "ga"`,
+		"[[patches.providers]]",
+		`command = "false"`,
+	} {
+		if !strings.Contains(cityToml, want) {
+			t.Fatalf("city.toml missing migrated surface %q:\n%s", want, cityToml)
+		}
+	}
+	if strings.Contains(cityToml, "[formulas]") {
+		t.Fatalf("city.toml should not gain unsupported [formulas].dir:\n%s", cityToml)
+	}
+	if len(report.Warnings) == 0 || !strings.Contains(strings.Join(report.Warnings, "\n"), "formulas.dir") {
+		t.Fatalf("expected formulas.dir migration warning, got %v", report.Warnings)
+	}
+
+	if _, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml")); err != nil {
+		t.Fatalf("LoadWithIncludes after migration: %v", err)
+	}
+}
+
 func TestMigrateCreatesFreshBindingWhenExistingImportHasNonDefaultSemantics(t *testing.T) {
 	t.Parallel()
 

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -61,21 +61,17 @@ prompt_template = "prompts/worker.md"
 	if !strings.Contains(packToml, "source = \"../packs/gastown\"") {
 		t.Fatalf("pack.toml missing gastown source:\n%s", packToml)
 	}
+	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
 	for _, line := range []string{
-		"[defaults.rig.imports.z-pack]",
-		"source = \"../packs/z-pack\"",
 		"[defaults.rig.imports.a-pack]",
 		"source = \"../packs/a-pack\"",
+		"[defaults.rig.imports.z-pack]",
+		"source = \"../packs/z-pack\"",
 	} {
-		if !strings.Contains(packToml, line) {
-			t.Fatalf("pack.toml missing migrated default-rig imports %q:\n%s", line, packToml)
+		if !strings.Contains(cityToml, line) {
+			t.Fatalf("city.toml missing migrated default-rig imports %q:\n%s", line, cityToml)
 		}
 	}
-	if strings.Index(packToml, "[defaults.rig.imports.z-pack]") > strings.Index(packToml, "[defaults.rig.imports.a-pack]") {
-		t.Fatalf("pack.toml reordered migrated default-rig imports:\n%s", packToml)
-	}
-
-	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
 	if strings.Contains(cityToml, "[[agent]]") {
 		t.Fatalf("city.toml still contains [[agent]]:\n%s", cityToml)
 	}
@@ -144,18 +140,17 @@ default_rig_includes = ["../packs/z-pack", "../packs/a-pack"]
 		t.Fatalf("Apply: %v", err)
 	}
 
-	packToml := readFile(t, filepath.Join(cityDir, "pack.toml"))
+	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
 	for _, line := range []string{
-		"[defaults.rig.imports.z-pack]",
-		`source = "../packs/z-pack"`,
 		"[defaults.rig.imports.a-pack]",
 		`source = "../packs/a-pack"`,
+		"[defaults.rig.imports.z-pack]",
+		`source = "../packs/z-pack"`,
 	} {
-		if !strings.Contains(packToml, line) {
-			t.Fatalf("pack.toml missing migrated default-rig imports %q:\n%s", line, packToml)
+		if !strings.Contains(cityToml, line) {
+			t.Fatalf("city.toml missing migrated default-rig imports %q:\n%s", line, cityToml)
 		}
 	}
-	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
 	if strings.Contains(cityToml, "default_rig_includes") {
 		t.Fatalf("city.toml should drop legacy workspace.default_rig_includes:\n%s", cityToml)
 	}
@@ -164,14 +159,14 @@ default_rig_includes = ["../packs/z-pack", "../packs/a-pack"]
 	if err != nil {
 		t.Fatalf("LoadWithIncludes after migration: %v", err)
 	}
-	if len(cfg.Workspace.LegacyDefaultRigIncludes()) != 2 {
-		t.Fatalf("len(DefaultRigIncludes) = %d, want 2", len(cfg.Workspace.LegacyDefaultRigIncludes()))
+	if len(cfg.DefaultRigImports) != 2 {
+		t.Fatalf("len(DefaultRigImports) = %d, want 2", len(cfg.DefaultRigImports))
 	}
-	if cfg.Workspace.LegacyDefaultRigIncludes()[0] != "../packs/z-pack" {
-		t.Fatalf("DefaultRigIncludes[0] = %q, want %q", cfg.Workspace.LegacyDefaultRigIncludes()[0], "../packs/z-pack")
+	if cfg.DefaultRigImports["z-pack"].Source != "../packs/z-pack" {
+		t.Fatalf("DefaultRigImports[z-pack].Source = %q, want %q", cfg.DefaultRigImports["z-pack"].Source, "../packs/z-pack")
 	}
-	if cfg.Workspace.LegacyDefaultRigIncludes()[1] != "../packs/a-pack" {
-		t.Fatalf("DefaultRigIncludes[1] = %q, want %q", cfg.Workspace.LegacyDefaultRigIncludes()[1], "../packs/a-pack")
+	if cfg.DefaultRigImports["a-pack"].Source != "../packs/a-pack" {
+		t.Fatalf("DefaultRigImports[a-pack].Source = %q, want %q", cfg.DefaultRigImports["a-pack"].Source, "../packs/a-pack")
 	}
 }
 
@@ -202,8 +197,6 @@ source = "../packs/ops"
 	for _, want := range []string{
 		"[imports.team]",
 		`source = "https://example.com/team.git//pack#v1"`,
-		"[defaults.rig.imports.ops]",
-		`source = "../packs/ops"`,
 	} {
 		if !strings.Contains(packToml, want) {
 			t.Fatalf("pack.toml missing %q after named pack migration:\n%s", want, packToml)
@@ -211,6 +204,15 @@ source = "../packs/ops"
 	}
 
 	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
+	for _, want := range []string{
+		"[defaults.rig.imports.ops]",
+		`source = "../packs/ops"`,
+	} {
+		if !strings.Contains(cityToml, want) {
+			t.Fatalf("city.toml missing %q after named pack migration:\n%s", want, cityToml)
+		}
+	}
+
 	if strings.Contains(cityToml, "[packs.") || strings.Contains(cityToml, "[packs]") {
 		t.Fatalf("city.toml still contains migrated [packs] entries:\n%s", cityToml)
 	}
@@ -307,7 +309,7 @@ legacy_unknown = "silently dropped before strict migration validation"
 	}
 }
 
-func TestMigratePreservesExistingRootDefaultRigImportOrder(t *testing.T) {
+func TestMigrateMovesExistingRootDefaultRigImportsToCityToml(t *testing.T) {
 	t.Parallel()
 
 	cityDir := t.TempDir()
@@ -336,13 +338,19 @@ source = "../packs/a-pack"
 	if !strings.Contains(packToml, "[imports.new-pack]") {
 		t.Fatalf("pack.toml missing migrated workspace include:\n%s", packToml)
 	}
-	zIndex := strings.Index(packToml, "[defaults.rig.imports.z-pack]")
-	aIndex := strings.Index(packToml, "[defaults.rig.imports.a-pack]")
-	if zIndex < 0 || aIndex < 0 {
-		t.Fatalf("pack.toml missing root default rig imports:\n%s", packToml)
+	if strings.Contains(packToml, "[defaults.rig.imports.") {
+		t.Fatalf("pack.toml should not retain default rig imports:\n%s", packToml)
 	}
-	if zIndex > aIndex {
-		t.Fatalf("pack.toml reordered default rig imports:\n%s", packToml)
+	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
+	for _, want := range []string{
+		"[defaults.rig.imports.a-pack]",
+		`source = "../packs/a-pack"`,
+		"[defaults.rig.imports.z-pack]",
+		`source = "../packs/z-pack"`,
+	} {
+		if !strings.Contains(cityToml, want) {
+			t.Fatalf("city.toml missing migrated root default rig import %q:\n%s", want, cityToml)
+		}
 	}
 }
 
@@ -401,12 +409,12 @@ shadow = "silent"
 		t.Fatalf("Apply: %v", err)
 	}
 
-	packToml := readFile(t, filepath.Join(cityDir, "pack.toml"))
-	if !strings.Contains(packToml, "[defaults.rig.imports.gastown]") || !strings.Contains(packToml, `shadow = "silent"`) {
-		t.Fatalf("pack.toml should preserve the existing non-default default-rig binding:\n%s", packToml)
+	cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
+	if !strings.Contains(cityToml, "[defaults.rig.imports.gastown]") || !strings.Contains(cityToml, `shadow = "silent"`) {
+		t.Fatalf("city.toml should preserve the existing non-default default-rig binding:\n%s", cityToml)
 	}
-	if !strings.Contains(packToml, "[defaults.rig.imports.gastown-2]") {
-		t.Fatalf("pack.toml should add a fresh default-rig binding instead of reusing the non-default one:\n%s", packToml)
+	if !strings.Contains(cityToml, "[defaults.rig.imports.gastown-2]") {
+		t.Fatalf("city.toml should add a fresh default-rig binding instead of reusing the non-default one:\n%s", cityToml)
 	}
 }
 
@@ -432,13 +440,12 @@ source = "../packs/z-pack"
 source = "../packs/a-pack"
 `)
 
-	beforePack := readFile(t, filepath.Join(cityDir, "pack.toml"))
 	beforeCity := readFile(t, filepath.Join(cityDir, "city.toml"))
 	if _, err := Apply(cityDir, Options{}); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	if got := readFile(t, filepath.Join(cityDir, "pack.toml")); got != beforePack {
-		t.Fatalf("pack.toml changed without pack migration changes:\n%s", got)
+	if got := readFile(t, filepath.Join(cityDir, "pack.toml")); strings.Contains(got, "[defaults.rig.imports.") {
+		t.Fatalf("pack.toml should drop default rig imports:\n%s", got)
 	}
 	afterCity := readFile(t, filepath.Join(cityDir, "city.toml"))
 	if afterCity == beforeCity {


### PR DESCRIPTION
## Summary

Fast-follow cleanup for #2126 based on the PackV2 spec discussion. This keeps the public PackV2 surface source-first and moves city policy out of pack.toml.

- moves canonical `[defaults.rig.imports]` to `city.toml` and rejects it during normal pack loading
- rejects pack-level `[agent_defaults]`, `[agents]`, `[formulas].dir`, `[[patches.rigs]]`, and `[[patches.providers]]` while keeping pack `[[patches.agent]]`
- keeps `[[rigs]].formulas_dir` as legacy city config for now, but removes public `[formulas].dir` from generated schemas
- publishes `docs/specs/pack-spec.md` as Gas City Pack Specification (2.0) and points config reference at it
- updates examples and generated schema/reference docs

## Validation

- `go test ./internal/config`
- `go test ./cmd/gc -run 'TestDo(RigAdd|Import|Init)|TestV2DefaultRig|TestSourceTemplatePackSchema|TestInitFromCopiesDefaultRigImportsToCityToml'`\n- `make check-docs`\n- `go run ./cmd/genschema`\n\nNote: this PR is stacked on #2126 (`codex/packv2-wave2-goodbye-packv1`) so Julian can review the fast-follow delta before/while #2126 lands.