### PR TITLE
feat: add city-local doctor checks

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/spf13/cobra"
 )
 
@@ -297,6 +298,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 				Warmup:    entry.Warmup,
 			})
 		}
+		registerLocalDoctorChecksTo(register, cityPath, cfg.Doctor.Checks)
 	}
 
 	return checks
@@ -363,6 +365,71 @@ func (expandedConfigLoadCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult
 			nil)
 	}
 	return okCheck("expanded-config-load", "expanded config loaded")
+}
+
+func registerLocalDoctorChecks(d *doctor.Doctor, cityPath string, checks []config.LocalDoctorCheck) {
+	registerLocalDoctorChecksTo(d.Register, cityPath, checks)
+}
+
+func registerLocalDoctorChecksTo(register func(doctor.Check), cityPath string, checks []config.LocalDoctorCheck) {
+	for _, check := range checks {
+		checkName := "local:" + check.Name
+		script, err := resolveLocalDoctorScript(cityPath, check.Script)
+		if err != nil {
+			register(doctor.ErrorCheck(checkName, err.Error()))
+			continue
+		}
+
+		packCheck := &doctor.PackScriptCheck{
+			CheckName: checkName,
+			Script:    script,
+			PackDir:   cityPath,
+		}
+		if check.Fix != "" {
+			fixScript, err := resolveLocalDoctorFixScript(cityPath, check.Fix)
+			if err != nil {
+				register(doctor.ErrorCheck(checkName, err.Error()))
+				continue
+			}
+			packCheck.FixScript = fixScript
+		}
+		register(packCheck)
+	}
+}
+
+func resolveLocalDoctorScript(cityPath, scriptPath string) (string, error) {
+	return resolveLocalDoctorPath("script", cityPath, scriptPath)
+}
+
+func resolveLocalDoctorFixScript(cityPath, fixPath string) (string, error) {
+	return resolveLocalDoctorPath("fix path", cityPath, fixPath)
+}
+
+func resolveLocalDoctorPath(kind, cityPath, relPath string) (string, error) {
+	if relPath == "" {
+		return "", fmt.Errorf("%s must not be empty", kind)
+	}
+	if filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("%s %q must be relative to the city root", kind, relPath)
+	}
+
+	candidate := filepath.Clean(filepath.Join(cityPath, relPath))
+	absCityPath, err := filepath.Abs(cityPath)
+	if err != nil {
+		return "", err
+	}
+	absCandidate, err := filepath.Abs(candidate)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(absCityPath, absCandidate)
+	if err != nil {
+		return "", err
+	}
+	if pathutil.IsOutsideDir(rel) {
+		return "", fmt.Errorf("%s %q escapes the city directory", kind, relPath)
+	}
+	return candidate, nil
 }
 
 // doctorJSONResult mirrors doctor.CheckResult for JSON output. Keeping the

--- a/cmd/gc/cmd_doctor_local_test.go
+++ b/cmd/gc/cmd_doctor_local_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func writeLocalDoctorScript(t *testing.T, cityPath, relPath, body string) {
+	t.Helper()
+	path := filepath.Join(cityPath, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+}
+
+func requireSingleDoctorResult(t *testing.T, report *doctor.Report) *doctor.CheckResult {
+	t.Helper()
+	if len(report.Results) != 1 {
+		t.Fatalf("len(report.Results) = %d, want 1", len(report.Results))
+	}
+	return report.Results[0]
+}
+
+func TestRegisterLocalDoctorChecksRunsCityRelativeScript(t *testing.T) {
+	cityPath := t.TempDir()
+	t.Setenv("GC_PACK_STATE_DIR", "")
+	writeLocalDoctorScript(t, cityPath, filepath.Join("scripts", "check-env.sh"), `#!/bin/sh
+if [ "$GC_PACK_DIR" != "$GC_CITY_PATH" ]; then
+	echo "GC_PACK_DIR mismatch"
+	exit 2
+fi
+if [ -n "${GC_PACK_STATE_DIR:-}" ]; then
+	echo "unexpected GC_PACK_STATE_DIR"
+	exit 2
+fi
+echo "local ok"
+`)
+
+	d := &doctor.Doctor{}
+	registerLocalDoctorChecks(d, cityPath, []config.LocalDoctorCheck{{
+		Name:   "env",
+		Script: filepath.Join("scripts", "check-env.sh"),
+	}})
+
+	result := requireSingleDoctorResult(t, d.RunCollect(&doctor.CheckContext{CityPath: cityPath}, false))
+	if result.Name != "local:env" {
+		t.Fatalf("result.Name = %q, want %q", result.Name, "local:env")
+	}
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("result.Status = %v, want OK; message=%q", result.Status, result.Message)
+	}
+	if result.Message != "local ok" {
+		t.Fatalf("result.Message = %q, want %q", result.Message, "local ok")
+	}
+}
+
+func TestResolveLocalDoctorScriptRejectsUnsafePaths(t *testing.T) {
+	cityPath := t.TempDir()
+	tests := []struct {
+		name    string
+		path    string
+		wantErr string
+	}{
+		{
+			name:    "absolute",
+			path:    filepath.Join(cityPath, "scripts", "check.sh"),
+			wantErr: "must be relative",
+		},
+		{
+			name:    "parent",
+			path:    "../escape.sh",
+			wantErr: "escapes the city directory",
+		},
+		{
+			name:    "nested parent",
+			path:    filepath.Join("scripts", "..", "..", "escape.sh"),
+			wantErr: "escapes the city directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := resolveLocalDoctorScript(cityPath, tt.path); err == nil {
+				t.Fatal("resolveLocalDoctorScript() error = nil, want error")
+			} else if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("resolveLocalDoctorScript() error = %q, want containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRegisterLocalDoctorChecksInvalidScriptPathReportsErrorCheck(t *testing.T) {
+	cityPath := t.TempDir()
+	d := &doctor.Doctor{}
+	registerLocalDoctorChecks(d, cityPath, []config.LocalDoctorCheck{{
+		Name:   "bad",
+		Script: "../escape.sh",
+	}})
+
+	result := requireSingleDoctorResult(t, d.RunCollect(&doctor.CheckContext{CityPath: cityPath}, false))
+	if result.Name != "local:bad" {
+		t.Fatalf("result.Name = %q, want %q", result.Name, "local:bad")
+	}
+	if result.Status != doctor.StatusError {
+		t.Fatalf("result.Status = %v, want error", result.Status)
+	}
+	if !strings.Contains(result.Message, "escapes the city directory") {
+		t.Fatalf("result.Message = %q, want escape error", result.Message)
+	}
+}
+
+func TestRegisterLocalDoctorChecksInvalidFixPathReportsErrorCheck(t *testing.T) {
+	cityPath := t.TempDir()
+	writeLocalDoctorScript(t, cityPath, filepath.Join("scripts", "check.sh"), "#!/bin/sh\necho ok\n")
+
+	d := &doctor.Doctor{}
+	registerLocalDoctorChecks(d, cityPath, []config.LocalDoctorCheck{{
+		Name:   "bad-fix",
+		Script: filepath.Join("scripts", "check.sh"),
+		Fix:    "../fix.sh",
+	}})
+
+	result := requireSingleDoctorResult(t, d.RunCollect(&doctor.CheckContext{CityPath: cityPath}, false))
+	if result.Name != "local:bad-fix" {
+		t.Fatalf("result.Name = %q, want %q", result.Name, "local:bad-fix")
+	}
+	if result.Status != doctor.StatusError {
+		t.Fatalf("result.Status = %v, want error", result.Status)
+	}
+	if !strings.Contains(result.Message, "fix path") || !strings.Contains(result.Message, "escapes the city directory") {
+		t.Fatalf("result.Message = %q, want fix escape error", result.Message)
+	}
+}

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -20,6 +20,37 @@ gc doctor --verbose   # extra detail
 gc doctor --fix       # attempt automatic repairs
 ```
 
+## Add City-Local Doctor Checks
+
+Use `[[doctor.check]]` in `city.toml` for a workspace-specific health check
+that does not need to be packaged as a reusable pack doctor. Provide the bare
+check name; `gc doctor` adds the `local:` prefix in output.
+
+```toml
+[doctor]
+
+[[doctor.check]]
+name = "gopath-symlink"
+description = "Verify the GOPATH symlink used by local build scripts"
+script = "scripts/check-gopath.sh"
+fix = "scripts/fix-gopath.sh"
+```
+
+The `script` and optional `fix` paths are relative to the city root. Absolute
+paths and paths that escape the city directory are rejected and reported as
+named `StatusError` check results.
+
+Local checks reuse the same script protocol as pack doctor checks:
+
+| Exit code | Result |
+|-----------|--------|
+| 0 | OK |
+| 1 | Warning |
+| 2 or higher | Error |
+
+The first stdout line becomes the check message. Additional stdout lines are
+shown by `gc doctor --verbose`.
+
 ## "command not found" After Install
 
 If `gc` is installed but your shell cannot find it, the binary is not on your

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -303,6 +303,7 @@ DoctorConfig holds settings for the gc doctor surface.
 | `worktree_rig_warn_size` | string |  | `10GB` | WorktreeRigWarnSize is the per-rig warning threshold for the total disk footprint under .gc/worktrees/&lt;rig&gt;/. Reported by the worktree-disk-size check. Go-style human size string ("10GB", "500MB"). Empty or unparseable falls back to the default (10 GB). |
 | `worktree_rig_error_size` | string |  | `50GB` | WorktreeRigErrorSize is the per-rig error threshold. When any rig exceeds this, the worktree-disk-size check reports an error rather than a warning. Empty or unparseable falls back to the default (50 GB). |
 | `nested_worktree_prune` | boolean |  | `false` | NestedWorktreePrune escalates the nested-worktree-prune check from warning to error severity when safely-prunable nested worktrees are present, so CI / scripted doctor runs fail until the operator runs `gc doctor --fix`. Actual removal still requires --fix; this flag does not auto-prune. Safety is enforced by mechanical checks (no uncommitted changes, no unpushed commits, no stashes) — never by role identity. |
+| `check` | []LocalDoctorCheck |  |  | Checks holds city-local inline doctor checks declared via [[doctor.check]] in city.toml. |
 
 ## DoltConfig
 
@@ -368,6 +369,17 @@ K8sConfig holds native K8s session provider settings.
 | `cpu_limit` | string |  | `2` | CPULimit is the pod CPU limit. Default: "2". |
 | `mem_limit` | string |  | `4Gi` | MemLimit is the pod memory limit. Default: "4Gi". |
 | `prebaked` | boolean |  |  | Prebaked skips init container staging and EmptyDir volumes when true. Use with images built by `gc build-image` that have city content baked in. |
+
+## LocalDoctorCheck
+
+LocalDoctorCheck is a city-local doctor check declared inline in city.toml via [[doctor.check]].
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | **yes** |  | Name is the bare check name. The SDK injects the "local:" prefix; do not include it here. |
+| `script` | string | **yes** |  | Script is the path to the check script, relative to the city root. Execution registration enforces containment within the city directory. |
+| `description` | string |  |  | Description is optional human-readable text shown in verbose output. |
+| `fix` | string |  |  | Fix is the optional path to a remediation script, relative to the city root. |
 
 ## MailConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1214,6 +1214,13 @@
           "type": "boolean",
           "description": "NestedWorktreePrune escalates the nested-worktree-prune check\nfrom warning to error severity when safely-prunable nested\nworktrees are present, so CI / scripted doctor runs fail until\nthe operator runs `gc doctor --fix`. Actual removal still\nrequires --fix; this flag does not auto-prune. Safety is\nenforced by mechanical checks (no uncommitted changes, no\nunpushed commits, no stashes) — never by role identity.",
           "default": false
+        },
+        "check": {
+          "items": {
+            "$ref": "#/$defs/LocalDoctorCheck"
+          },
+          "type": "array",
+          "description": "Checks holds city-local inline doctor checks declared via\n[[doctor.check]] in city.toml."
         }
       },
       "additionalProperties": false,
@@ -1371,6 +1378,33 @@
       "additionalProperties": false,
       "type": "object",
       "description": "K8sConfig holds native K8s session provider settings."
+    },
+    "LocalDoctorCheck": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the bare check name. The SDK injects the \"local:\" prefix;\ndo not include it here."
+        },
+        "script": {
+          "type": "string",
+          "description": "Script is the path to the check script, relative to the city root.\nExecution registration enforces containment within the city directory."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is optional human-readable text shown in verbose output."
+        },
+        "fix": {
+          "type": "string",
+          "description": "Fix is the optional path to a remediation script, relative to the\ncity root."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "script"
+      ],
+      "description": "LocalDoctorCheck is a city-local doctor check declared inline in city.toml via [[doctor.check]]."
     },
     "MailConfig": {
       "properties": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1214,6 +1214,13 @@
           "type": "boolean",
           "description": "NestedWorktreePrune escalates the nested-worktree-prune check\nfrom warning to error severity when safely-prunable nested\nworktrees are present, so CI / scripted doctor runs fail until\nthe operator runs `gc doctor --fix`. Actual removal still\nrequires --fix; this flag does not auto-prune. Safety is\nenforced by mechanical checks (no uncommitted changes, no\nunpushed commits, no stashes) — never by role identity.",
           "default": false
+        },
+        "check": {
+          "items": {
+            "$ref": "#/$defs/LocalDoctorCheck"
+          },
+          "type": "array",
+          "description": "Checks holds city-local inline doctor checks declared via\n[[doctor.check]] in city.toml."
         }
       },
       "additionalProperties": false,
@@ -1371,6 +1378,33 @@
       "additionalProperties": false,
       "type": "object",
       "description": "K8sConfig holds native K8s session provider settings."
+    },
+    "LocalDoctorCheck": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the bare check name. The SDK injects the \"local:\" prefix;\ndo not include it here."
+        },
+        "script": {
+          "type": "string",
+          "description": "Script is the path to the check script, relative to the city root.\nExecution registration enforces containment within the city directory."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description is optional human-readable text shown in verbose output."
+        },
+        "fix": {
+          "type": "string",
+          "description": "Fix is the optional path to a remediation script, relative to the\ncity root."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "script"
+      ],
+      "description": "LocalDoctorCheck is a city-local doctor check declared inline in city.toml via [[doctor.check]]."
     },
     "MailConfig": {
       "properties": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1577,6 +1577,26 @@ func (c ChatSessionsConfig) IdleTimeoutDuration() time.Duration {
 	return d
 }
 
+// LocalDoctorCheck is a city-local doctor check declared inline in city.toml
+// via [[doctor.check]]. Scripts use the same exit-code protocol as pack
+// doctor scripts: 0=OK, 1=Warning, 2+=Error.
+type LocalDoctorCheck struct {
+	// Name is the bare check name. The SDK injects the "local:" prefix;
+	// do not include it here.
+	Name string `toml:"name"`
+
+	// Script is the path to the check script, relative to the city root.
+	// Execution registration enforces containment within the city directory.
+	Script string `toml:"script"`
+
+	// Description is optional human-readable text shown in verbose output.
+	Description string `toml:"description,omitempty"`
+
+	// Fix is the optional path to a remediation script, relative to the
+	// city root.
+	Fix string `toml:"fix,omitempty"`
+}
+
 // DoctorConfig holds settings for the gc doctor surface. Operator-tunable
 // thresholds and policy toggles live here; mechanical structural checks
 // (broken-worktree pointers, missing files) remain hardcoded since they
@@ -1602,6 +1622,10 @@ type DoctorConfig struct {
 	// enforced by mechanical checks (no uncommitted changes, no
 	// unpushed commits, no stashes) — never by role identity.
 	NestedWorktreePrune bool `toml:"nested_worktree_prune,omitempty" jsonschema:"default=false"`
+
+	// Checks holds city-local inline doctor checks declared via
+	// [[doctor.check]] in city.toml.
+	Checks []LocalDoctorCheck `toml:"check,omitempty"`
 }
 
 const (

--- a/internal/config/doctor_config_test.go
+++ b/internal/config/doctor_config_test.go
@@ -33,6 +33,61 @@ name = "mayor"
 	}
 }
 
+func TestParseDoctorLocalChecks(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[doctor]
+worktree_rig_warn_size = "5GB"
+
+[[doctor.check]]
+name = "gopath-symlink"
+script = "./scripts/check-gopath.sh"
+description = "Verify GOPATH symlink"
+
+[[doctor.check]]
+name = "custom-env"
+script = "./scripts/check-env.sh"
+fix = "./scripts/fix-env.sh"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := len(cfg.Doctor.Checks); got != 2 {
+		t.Fatalf("len(Doctor.Checks) = %d, want 2", got)
+	}
+
+	first := cfg.Doctor.Checks[0]
+	if first.Name != "gopath-symlink" {
+		t.Errorf("Checks[0].Name = %q, want %q", first.Name, "gopath-symlink")
+	}
+	if first.Script != "./scripts/check-gopath.sh" {
+		t.Errorf("Checks[0].Script = %q, want %q", first.Script, "./scripts/check-gopath.sh")
+	}
+	if first.Description != "Verify GOPATH symlink" {
+		t.Errorf("Checks[0].Description = %q, want %q", first.Description, "Verify GOPATH symlink")
+	}
+	if first.Fix != "" {
+		t.Errorf("Checks[0].Fix = %q, want empty", first.Fix)
+	}
+
+	second := cfg.Doctor.Checks[1]
+	if second.Name != "custom-env" {
+		t.Errorf("Checks[1].Name = %q, want %q", second.Name, "custom-env")
+	}
+	if second.Script != "./scripts/check-env.sh" {
+		t.Errorf("Checks[1].Script = %q, want %q", second.Script, "./scripts/check-env.sh")
+	}
+	if second.Description != "" {
+		t.Errorf("Checks[1].Description = %q, want empty", second.Description)
+	}
+	if second.Fix != "./scripts/fix-env.sh" {
+		t.Errorf("Checks[1].Fix = %q, want %q", second.Fix, "./scripts/fix-env.sh")
+	}
+}
+
 func TestParseNoDoctorSection(t *testing.T) {
 	data := []byte(`
 [workspace]

--- a/internal/doctor/error_check.go
+++ b/internal/doctor/error_check.go
@@ -1,0 +1,28 @@
+package doctor
+
+// ErrorCheck returns a check that always reports StatusError with the
+// supplied name and message.
+func ErrorCheck(name, message string) Check {
+	return &errorCheck{name: name, message: message}
+}
+
+type errorCheck struct {
+	name    string
+	message string
+}
+
+func (c *errorCheck) Name() string { return c.name }
+
+func (c *errorCheck) Run(_ *CheckContext) *CheckResult {
+	return &CheckResult{
+		Name:    c.name,
+		Status:  StatusError,
+		Message: c.message,
+	}
+}
+
+func (c *errorCheck) CanFix() bool { return false }
+
+func (c *errorCheck) Fix(_ *CheckContext) error { return nil }
+
+func (c *errorCheck) WarmupEligible() bool { return false }

--- a/release-gates/ga-5frpc-local-doctor-checks-gate.md
+++ b/release-gates/ga-5frpc-local-doctor-checks-gate.md
@@ -1,0 +1,40 @@
+# Release gate - local doctor checks (ga-5frpc)
+
+**Verdict:** PASS
+
+- Source beads: `ga-5frpc.2`, `ga-5frpc.3`, `ga-5frpc.4`
+- Deploy beads on hook: `ga-1498l` (registration), `ga-km115` (docs)
+- Branch: `builder/ga-5frpc-3`
+- Reviewed HEAD: `e5021bb91`
+- Base: `origin/main` at `7e175b8f8`
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS verdict in bead notes | PASS | `ga-hsmtq` PASS for the config model; `ga-1498l` PASS for registration at commits `719f0209b`, `9f30b55d6`; `ga-km115` PASS for docs at `e5021bb91`. |
+| 2 | Acceptance criteria met | PASS | Config model adds `LocalDoctorCheck`, `DoctorConfig.Checks`, schema/reference docs, and parser coverage. Registration adds city-root-relative resolution, containment rejection, `local:` check names, `ErrorCheck` reporting, and reuses `PackScriptCheck`. Docs add a `[[doctor.check]]` example, naming rules, path rules, exit-code protocol, and local-check behavior. |
+| 3 | Tests pass on final branch | PASS | Focused Go tests pass; `make check-docs` passes; `TMPDIR=/home/jaword/tmp/gc-deploy-ga-5frpc make test-fast-parallel` passes; `TMPDIR=/home/jaword/tmp/gc-deploy-ga-5frpc go vet ./...` passes. Initial default-`/tmp` fast run failed only with host `no space left on device`; rerun used home-backed temp space. |
+| 4 | No high-severity review findings open | PASS | Reviewer findings: config model had 2 INFO findings; registration had 1 LOW finding matching existing pack-doctor containment behavior; docs had none. 0 HIGH. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` clean before gate-file commit on `builder/ga-5frpc-3...fork/builder/ga-5frpc-3`. |
+| 6 | Branch diverges cleanly from main | PASS | `origin/main` is an ancestor of HEAD; `git rev-list --left-right --count origin/main...HEAD` reported `0 3`; `git diff --check origin/main...HEAD` clean. |
+
+## Review Beads
+
+| Source bead | Review bead | Reviewed commit(s) | Verdict | Notes |
+|---|---|---|---|---|
+| `ga-5frpc.2` | `ga-hsmtq` | `523849098` and patch-equivalent branch commit `719f0209b` | PASS | Config model only; current branch includes the rebased config commit and was also covered by `ga-1498l` branch review. |
+| `ga-5frpc.3` | `ga-1498l` | `719f0209b`, `9f30b55d6` | PASS | Registration and execution wiring for local doctor checks. |
+| `ga-5frpc.4` | `ga-km115` | `e5021bb91` | PASS | Operator-facing docs for local doctor checks. |
+
+## Validation
+
+- `go test ./internal/config ./internal/doctor ./cmd/gc -run 'Test(ParseDoctorLocalChecks|RegisterLocalDoctorChecksRunsCityRelativeScript|ResolveLocalDoctorScriptRejectsUnsafePaths|RegisterLocalDoctorChecksInvalidScriptPathReportsErrorCheck|RegisterLocalDoctorChecksInvalidFixPathReportsErrorCheck)$' -count=1` - PASS
+- `make check-docs` - PASS
+- `TMPDIR=/home/jaword/tmp/gc-deploy-ga-5frpc make test-fast-parallel` - PASS
+- `TMPDIR=/home/jaword/tmp/gc-deploy-ga-5frpc go vet ./...` - PASS
+- `git diff --check origin/main...HEAD` - PASS
+
+## Push Target
+
+`git push --dry-run origin HEAD` succeeded, so the release branch can be pushed to `origin` per deployer policy.


### PR DESCRIPTION
## What this changes

Operators can now declare city-local doctor checks directly in `city.toml` with `[[doctor.check]]`. Each check has a bare `name`, `description`, `script`, and optional `fix`; `gc doctor` exposes them as `local:<name>` checks without requiring a pack.

Local check scripts are resolved relative to the city root. Absolute paths or paths that escape the city are rejected as named doctor check results instead of being ignored or panicking. Valid local checks reuse the existing doctor script exit-code protocol and `PackScriptCheck` runner.

The operator docs and generated city config schema/reference are updated with the new `[[doctor.check]]` shape and behavior.

## Why one PR

The config model, doctor registration, and docs are dependent: the config shape is only useful once `gc doctor` registers it, and the docs need to describe the shipped runtime behavior rather than a partial intermediate state.

## Review notes

- New config surface: `[[doctor.check]]` under `[doctor]` in `city.toml`.
- Runtime check names are `local:<name>`; operators configure only the bare name.
- Local scripts run through the existing script-check engine with `PackDir` set to the city root and no pack-state injection.
- Invalid local script or fix paths become named doctor check failures.
- No OpenAPI, dashboard, or agent-role behavior changes.

## Test plan

- [x] Focused config/doctor tests for parsing, registration, containment rejection, and invalid-path error checks.
- [x] `make check-docs`.
- [x] `make test-fast-parallel` with a home-backed `TMPDIR` because host `/tmp` was full.
- [x] `go vet ./...`.
- [x] Release gate: [`release-gates/ga-5frpc-local-doctor-checks-gate.md`](release-gates/ga-5frpc-local-doctor-checks-gate.md)