### PR TITLE
Suppress managed Dolt telemetry during bd provider startup

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1808,6 +1808,8 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 		env = removeEnvKey(env, key)
 	}
 	env = append(env, providerLifecycleDoltPathEnv(cityPath)...)
+	env = removeEnvKey(env, "DOLT_DISABLE_EVENT_FLUSH")
+	env = append(env, "DOLT_DISABLE_EVENT_FLUSH=1")
 	if gcBin := resolveProviderLifecycleGCBinary(); gcBin != "" {
 		env = removeEnvKey(env, "GC_BIN")
 		env = append(env, "GC_BIN="+gcBin)

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -668,6 +668,7 @@ func ensureBeadsProvider(cityPath string) error {
 			if err := standaloneBdDoltConflictIfPresent(cityPath); err != nil {
 				return err
 			}
+			ensureManagedDoltMetricsDisabled()
 		}
 		providerEnv, envErr := providerLifecycleProcessEnvWithError(cityPath, provider)
 		if envErr != nil {
@@ -692,6 +693,24 @@ func ensureBeadsProvider(cityPath string) error {
 		}
 	}
 	return nil
+}
+
+func ensureManagedDoltMetricsDisabled() {
+	ctx, cancel := providerLifecycleContext(context.Background(), providerOpTimeout("config"))
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "dolt", "config", "--global", "--add", "metrics.disabled", "true")
+	cmd.WaitDelay = 2 * time.Second
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return
+	}
+	msg := strings.TrimSpace(string(out))
+	if msg != "" {
+		log.Printf("gc: managed dolt metrics.disabled config failed: %v: %s", err, msg)
+		return
+	}
+	log.Printf("gc: managed dolt metrics.disabled config failed: %v", err)
 }
 
 // shutdownBeadsProvider stops the bead store's backing service.

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -10733,6 +10733,42 @@ func TestGcBeadsBdStartFallsBackToShellManagedConfigWriterWhenGCBinUnset(t *test
 	}
 }
 
+// TestProviderLifecycleProcessEnvIncludesDoltDisableEventFlushForManagedBDProvider
+// verifies that managed bd-provider processes suppress Dolt event flushes.
+func TestProviderLifecycleProcessEnvIncludesDoltDisableEventFlushForManagedBDProvider(t *testing.T) {
+	cityPath := t.TempDir()
+	env := mustProviderLifecycleProcessEnv(t, cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	for _, e := range env {
+		if e == "DOLT_DISABLE_EVENT_FLUSH=1" {
+			return
+		}
+	}
+	t.Error("DOLT_DISABLE_EVENT_FLUSH=1 not found in managed bd provider env")
+}
+
+// TestProviderLifecycleProcessEnvOmitsDoltDisableEventFlushForNonBDProviders
+// verifies the providerUsesBdStoreContract guard.
+func TestProviderLifecycleProcessEnvOmitsDoltDisableEventFlushForNonBDProviders(t *testing.T) {
+	cityPath := t.TempDir()
+	customScript := filepath.Join(t.TempDir(), "custom-beads.sh")
+	for _, tc := range []struct {
+		name     string
+		provider string
+	}{
+		{name: "file", provider: "file"},
+		{name: "external exec", provider: "exec:" + customScript},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := mustProviderLifecycleProcessEnv(t, cityPath, tc.provider)
+			for _, e := range env {
+				if e == "DOLT_DISABLE_EVENT_FLUSH=1" {
+					t.Errorf("DOLT_DISABLE_EVENT_FLUSH=1 should not be set for %s provider", tc.name)
+				}
+			}
+		})
+	}
+}
+
 func TestAcquireProviderSemaphore_SerializesConcurrentOps(t *testing.T) {
 	t.Parallel()
 	cityPath := t.TempDir()

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -10769,6 +10769,70 @@ func TestProviderLifecycleProcessEnvOmitsDoltDisableEventFlushForNonBDProviders(
 	}
 }
 
+// TestEnsureBeadsProviderCallsDoltConfigMetricsDisabledBeforeStart verifies
+// that managed bd startup disables Dolt metrics collection before start.
+func TestEnsureBeadsProviderCallsDoltConfigMetricsDisabledBeforeStart(t *testing.T) {
+	dir := t.TempDir()
+	script := gcBeadsBdScriptPath(dir)
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nset -eu\nexit 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	doltCallFile := filepath.Join(dir, "dolt-calls.log")
+	fakeBinDir := t.TempDir()
+	fakeDolt := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nexit 0\n", doltCallFile)
+	if err := os.WriteFile(filepath.Join(fakeBinDir, "dolt"), []byte(fakeDolt), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeReachableProviderManagedDoltState(t, dir)
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := ensureBeadsProvider(dir); err != nil {
+		t.Fatalf("ensureBeadsProvider: %v", err)
+	}
+
+	data, err := os.ReadFile(doltCallFile)
+	if err != nil {
+		t.Fatalf("dolt was not invoked (want dolt config metrics.disabled call): %v", err)
+	}
+	if !strings.Contains(string(data), "config --global --add metrics.disabled true") {
+		t.Errorf("dolt config --global --add metrics.disabled true was not called; got:\n%s", data)
+	}
+}
+
+// TestEnsureBeadsProviderDoltConfigFailureIsNonFatal verifies that a failing
+// dolt config call does not prevent managed bd startup.
+func TestEnsureBeadsProviderDoltConfigFailureIsNonFatal(t *testing.T) {
+	dir := t.TempDir()
+	script := gcBeadsBdScriptPath(dir)
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nset -eu\nexit 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBinDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fakeBinDir, "dolt"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeReachableProviderManagedDoltState(t, dir)
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := ensureBeadsProvider(dir); err != nil {
+		t.Fatalf("ensureBeadsProvider = %v, want nil (dolt config failure must be non-fatal)", err)
+	}
+}
+
 func TestAcquireProviderSemaphore_SerializesConcurrentOps(t *testing.T) {
 	t.Parallel()
 	cityPath := t.TempDir()

--- a/release-gates/ga-fxde8-managed-dolt-telemetry-gate.md
+++ b/release-gates/ga-fxde8-managed-dolt-telemetry-gate.md
@@ -1,0 +1,36 @@
+# Release Gate: Managed Dolt Telemetry Suppression
+
+Date: 2026-05-23
+Deployer: gascity/deployer
+Deploy bead: ga-fxde8
+Source bead: ga-um72h.3
+Branch: builder/ga-um72h-3
+Head: 125d1c2f7 (`fix(provider): persist managed dolt metrics opt-out`)
+
+## Scope
+
+This branch ships the managed Dolt telemetry suppression stack:
+
+| Bead | Review bead | Commit | Status | Review evidence |
+| --- | --- | --- | --- | --- |
+| ga-um72h.2 | ga-n7qr3 | 493c3c233 | closed | `VERDICT: pass`; no blocking findings |
+| ga-um72h.3 | ga-fxde8 | 125d1c2f7 | closed source, open deploy bead | `Review verdict: PASS`; no blockers |
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate applies the release criteria supplied by the deployer role prompt and the repository `AGENTS.md`.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | PASS | Current deploy bead `ga-fxde8` notes include `Review verdict: PASS` from `gascity/reviewer`. Stack parent review bead `ga-n7qr3` is closed and notes `VERDICT: pass`. |
+| 2 | Acceptance criteria met | PASS | `ensureBeadsProvider` calls `ensureManagedDoltMetricsDisabled()` only inside the managed bd provider block before provider startup. `ensureManagedDoltMetricsDisabled` runs `dolt config --global --add metrics.disabled true` with a lifecycle timeout and logs failures without returning an error. `providerLifecycleProcessEnvFromBase` strips inherited `DOLT_DISABLE_EVENT_FLUSH` and appends `DOLT_DISABLE_EVENT_FLUSH=1` inside the existing `providerUsesBdStoreContract` guard. File/external providers remain outside that guard. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestProviderLifecycleProcessEnv.*DoltDisableEventFlush\|TestEnsureBeadsProvider.*DoltConfig\|TestGcBeadsBdStartFallsBack' -count=1` passed. `make test-fast-parallel` passed all 8 fast jobs. `go vet ./...` completed cleanly. `git diff --check origin/main..HEAD` completed cleanly. |
+| 4 | No high-severity review findings open | PASS | `ga-fxde8` review notes: "No blockers. Clean implementation." Parent review `ga-n7qr3`: "No blocking issues found." No unresolved HIGH findings are recorded in either review. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` was clean on `builder/ga-um72h-3` tracking `fork/builder/ga-um72h-3`. This checklist is the only deployer-added file and is committed as the release-gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` reported `no_conflict`. `origin/main..builder/ga-um72h-3` contains the two reviewed stack commits listed above. |
+
+## Reviewer Notes
+
+- Behavior is limited to managed bd provider processes; external/file providers are intentionally unchanged.
+- The metrics opt-out is best-effort. Failure to run `dolt config` is logged with the existing `gc:` log prefix and does not block startup.
+- The PR includes both stacked commits because the parent telemetry-flush suppression commit is not yet on `origin/main`.


### PR DESCRIPTION
## What this changes

Managed bd provider startup now suppresses Dolt telemetry in both places operators care about. Provider lifecycle commands for the managed `gc-beads-bd` path receive `DOLT_DISABLE_EVENT_FLUSH=1`, and managed startup also attempts `dolt config --global --add metrics.disabled true` before starting the provider.

The Dolt config write is best-effort: failures are logged with the existing `gc:` prefix and startup continues. File-backed and external provider configurations are unchanged.

## Why one PR

The metrics opt-out is stacked on the event-flush suppression change, and both updates touch the same managed Dolt lifecycle helper and tests. Reviewing them together shows the complete telemetry-suppression behavior for managed bd provider startup.

## Review notes

- Scope is limited to providers covered by `providerUsesBdStoreContract`; custom exec and file providers do not receive the new env var or config write.
- The global Dolt config command uses hardcoded arguments and the process `HOME`, matching the managed provider environment.
- No API, dashboard, schema, or config-file shape changes are included.

## Test plan

- [x] `go test ./cmd/gc -run 'TestProviderLifecycleProcessEnv.*DoltDisableEventFlush|TestEnsureBeadsProvider.*DoltConfig|TestGcBeadsBdStartFallsBack' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `.githooks/pre-commit` on the release-gate commit (`go test ./test/docsync`)
- [x] Release gate: [`release-gates/ga-fxde8-managed-dolt-telemetry-gate.md`](release-gates/ga-fxde8-managed-dolt-telemetry-gate.md)
