### PR TITLE
fix(config): dedupe pack globals across scopes

### DIFF
--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2195,11 +2195,25 @@ func legacyPackDoctors(fs fsys.FS, entries []PackDoctorEntry, packDir, packName 
 // to matching agents. City-level globals affect ALL agents. Rig-level
 // globals affect only agents in that rig.
 func applyPackGlobals(cfg *City) {
+	applied := make([]map[string]bool, len(cfg.Agents))
+	apply := func(agentIndex int, g ResolvedPackGlobal) {
+		if g.PackName != "" {
+			if applied[agentIndex] == nil {
+				applied[agentIndex] = make(map[string]bool)
+			}
+			if applied[agentIndex][g.PackName] {
+				return
+			}
+			applied[agentIndex][g.PackName] = true
+		}
+		cfg.Agents[agentIndex].SessionLive = append(
+			cfg.Agents[agentIndex].SessionLive, g.SessionLive...)
+	}
+
 	// City-level globals → all agents.
 	for _, g := range cfg.PackGlobals {
 		for i := range cfg.Agents {
-			cfg.Agents[i].SessionLive = append(
-				cfg.Agents[i].SessionLive, g.SessionLive...)
+			apply(i, g)
 		}
 	}
 	// Rig-level globals → only that rig's agents.
@@ -2207,8 +2221,7 @@ func applyPackGlobals(cfg *City) {
 		for _, g := range globals {
 			for i := range cfg.Agents {
 				if cfg.Agents[i].Dir == rigName {
-					cfg.Agents[i].SessionLive = append(
-						cfg.Agents[i].SessionLive, g.SessionLive...)
+					apply(i, g)
 				}
 			}
 		}

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -4345,6 +4345,32 @@ session_live = ["echo global"]
 	}
 }
 
+func TestPackGlobal_DedupesPackAcrossCityAndRigScopes(t *testing.T) {
+	cfg := &City{
+		PackGlobals: []ResolvedPackGlobal{
+			{PackName: "gastown", SessionLive: []string{"theme.sh", "keys.sh"}},
+		},
+		RigPackGlobals: map[string][]ResolvedPackGlobal{
+			"my-rig": {{PackName: "gastown", SessionLive: []string{"theme.sh", "keys.sh"}}},
+		},
+		Agents: []Agent{
+			{Name: "city-agent"},
+			{Name: "rig-agent", Dir: "my-rig"},
+		},
+	}
+
+	applyPackGlobals(cfg)
+
+	for _, a := range cfg.Agents {
+		if len(a.SessionLive) != 2 {
+			t.Fatalf("agent %q SessionLive = %v, want one gastown global application", a.Name, a.SessionLive)
+		}
+		if a.SessionLive[0] != "theme.sh" || a.SessionLive[1] != "keys.sh" {
+			t.Fatalf("agent %q SessionLive = %v, want [theme.sh keys.sh]", a.Name, a.SessionLive)
+		}
+	}
+}
+
 func TestPackDefinesAgent_Found(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gastown/pack.toml", `


### PR DESCRIPTION
Supersedes #2116.

This ports only the still-relevant part of #2116 after the pack v2 changes: `applyPackGlobals` now dedupes resolved pack globals per agent by `PackName`, so a pack applied at both city and rig scope contributes `session_live` once.

Scope intentionally excluded:
- the `gc rig add` / default rig import rewrite from #2116
- the unrelated `.beads/config.yaml` repair from #2115 / #2116

The commit is authored to the original contributor and adapted down to the minimal config-resolution fix.

Tests:
- `go test ./internal/config -run TestPackGlobal_DedupesPackAcrossCityAndRigScopes -count=1` (failed before fix, passed after)
- `go test ./internal/config -run 'TestPackGlobal_(DedupesPackAcrossCityAndRigScopes|CityLevel|RigLevel|MultipleGlobalPacks|OrderingAfterPatches)' -count=1`\n- `go test ./internal/config -count=1`\n- `git diff --check`\n- `make test`\n- `go vet ./...`\n- pre-commit hook (`.githooks`) ran successfully during commit