### PR TITLE
fix(reconciler): count pool→pool handoff beads in default scale-check demand (#1991)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -871,13 +871,22 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			}
 		}
 		for _, b := range ready {
-			if strings.TrimSpace(b.Assignee) != "" {
+			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
+			if _, ok := group.templates[template]; !ok {
 				continue
 			}
-			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
-			if _, ok := group.templates[template]; ok {
-				counts[template]++
+			// Beads with assignee=="" (newly-slung routed work) or
+			// assignee==template (pool→pool handoff pattern, where the
+			// pool template name is written into Assignee but no session
+			// by that name exists) are genuine pool demand for this
+			// template. Beads with a session-identity assignee are
+			// already counted by collectAssignedWorkBeadsWithStores
+			// (Path 1) and must be skipped here to avoid double-counting.
+			assignee := strings.TrimSpace(b.Assignee)
+			if assignee != "" && assignee != template {
+				continue
 			}
+			counts[template]++
 		}
 	}
 	return counts, partialTemplates, errs

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -387,6 +387,87 @@ func TestDefaultScaleCheckCountsUsesCachedReadyReadModel(t *testing.T) {
 	}
 }
 
+// TestDefaultScaleCheckCountsCountsBeadsAssignedToPoolTemplate pins the
+// regression fix for gastownhall/gascity#1991: a bead with status=open and
+// assignee==<pool-template> + gc.routed_to==<pool-template> (the pool→pool
+// handoff write pattern used by gas-town pack formulas, e.g.
+// mol-polecat-work.toml's submit-and-exit) must produce non-zero demand for
+// the matching template. Before the fix, the Assignee!="" filter in
+// defaultScaleCheckCounts dropped this bead, leaving "assignedWorkBeads: 0"
+// indefinitely and stranding the next pool in the handoff chain. After the
+// fix, assignee==template is treated as pool demand because no session by
+// that name exists; only session-identity assignees (which Path 1 counts)
+// are excluded here.
+func TestDefaultScaleCheckCountsCountsBeadsAssignedToPoolTemplate(t *testing.T) {
+	const template = "gascity/reviewer"
+	backing := beads.NewMemStore()
+	if _, err := backing.Create(beads.Bead{
+		Title:    "pool→pool handoff routed work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: template,
+		Metadata: map[string]string{
+			"gc.routed_to": template,
+		},
+	}); err != nil {
+		t.Fatalf("create handoff bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1 (#1991 regression: pool→pool handoff bead must count as demand)", template, got)
+	}
+}
+
+// TestDefaultScaleCheckCountsExcludesBeadsAssignedToSession pins the
+// invariant that beads with assignee==<session-id> (Path 1 territory) are
+// NOT counted by defaultScaleCheckCounts, to avoid double-counting when
+// collectAssignedWorkBeadsWithStores has already counted them. Companion to
+// TestDefaultScaleCheckCountsCountsBeadsAssignedToPoolTemplate: together
+// they cover the asymmetry table from issue #1991.
+func TestDefaultScaleCheckCountsExcludesBeadsAssignedToSession(t *testing.T) {
+	const template = "gascity/reviewer"
+	backing := beads.NewMemStore()
+	if _, err := backing.Create(beads.Bead{
+		Title:    "in-flight session work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "reviewer-gc-12345",
+		Metadata: map[string]string{
+			"gc.routed_to": template,
+		},
+	}); err != nil {
+		t.Fatalf("create in-flight bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts[template]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0 (session-identity assignee is Path 1's territory; counting here would double-count)", template, got)
+	}
+}
+
 func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
 	backing := &demandListCountingStore{Store: beads.NewMemStore()}
 	if _, err := backing.Create(beads.Bead{

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1063,8 +1063,13 @@ func TestBuiltInSlingPoolRouteContractUsesMetadataOnly(t *testing.T) {
 	if got := counts["saitoc/polecat"]; got != 0 {
 		t.Fatalf("polecat scale count after refinery handoff with stale pool label = %d, want 0", got)
 	}
-	if got := counts["saitoc/refinery"]; got != 0 {
-		t.Fatalf("refinery generic scale count for assigned handoff = %d, want 0", got)
+	// #1991: a bead with assignee==<pool-template> + gc.routed_to==<pool-template>
+	// is the documented pool→pool handoff pattern (no session by the pool template
+	// name exists), so it MUST register as demand for that template. The earlier
+	// "want 0" pinned the broken pre-#1991 behavior where defaultScaleCheckCounts
+	// filtered out any non-empty Assignee and stranded the next pool.
+	if got := counts["saitoc/refinery"]; got != 1 {
+		t.Fatalf("refinery generic scale count for pool→pool handoff = %d, want 1 (#1991)", got)
 	}
 }
 


### PR DESCRIPTION
Closes #1991.

## Root cause

`defaultScaleCheckCounts` in `cmd/gc/build_desired_state.go` previously
filtered out any ready bead with a non-empty `Assignee`, on the
assumption that an assigned bead is already in flight via a session. But
pool→pool handoffs (e.g. `mol-polecat-work.toml`'s submit-and-exit in
the gas-town pack family) deliberately write
`assignee=<pool-template>` + `gc.routed_to=<pool-template>` to wake the
next pool — and no session by that pool-template name exists. The
blanket filter left such beads stranded: Path 1
(`collectAssignedWorkBeadsWithStores`) misses them because pool template
names are not session identities, and Path 2 was filtering them out.
The supervisor reported `assignedWorkBeads: 0` indefinitely and the next
pool stayed stopped until a human ran `gc sling --nudge --force`.

This relaxes the Path 2 filter: a bead is counted as demand for template
T when it carries `gc.routed_to=T` AND its Assignee is either empty OR
equal to T. Session-identity assignees (Path 1's territory) remain
excluded, so the fix does not introduce double-counting.

## Decision: Option C, not Option A

The issue body proposed two fix candidates: Option A (per-binding probe
queries the canonical template form) and Option C (relax the Path 2
assignee filter). Option A as originally proposed depended on PR #1736,
which has since been closed. Option C lands the same observable
behavior without the per-binding probe surface area and is the path
this PR takes.

## Tests

Two regression tests in `cmd/gc/build_desired_state_test.go`:

- `TestDefaultScaleCheckCountsCountsBeadsAssignedToPoolTemplate` — pins
  the bug fix: a ready bead with `assignee=<pool-template>` +
  `gc.routed_to=<pool-template>` IS counted as demand for that template.
- `TestDefaultScaleCheckCountsExcludesBeadsAssignedToSession` — pins
  the companion invariant: session-identity assignees stay in Path 1's
  territory and are not double-counted by Path 2.

Full `TestDefaultScaleCheckCounts*` and `TestCollectAssignedWorkBeads*`
families pass.

## Scope-out

The companion long-term fix #1398 (proper pool-template→session
qualification at sling time) and the prefix-naming bug #1486 are not
touched here. This PR is the narrow Path-2 relaxation; structural
changes to the templating layer remain in their own queue.
