### PR TITLE
Document gc 1.0.0 issue-prefix workaround

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -39,6 +39,15 @@ gc rig add ~/hello-world
 A rig is an external project directory registered with the city. It gets its
 own beads database, hook installation, and routing context.
 
+<Note>
+Published `gc` 1.0.0 can leave a clean rig without the beads `issue_prefix`,
+which makes later `bd` or `gc sling` calls fail. If you installed 1.0.0 and
+see that error after this clean `gc init` / `gc rig add` path, run
+`gc doctor --fix` from the city directory, then retry. This is a temporary
+workaround for [GitHub issue #1670](https://github.com/gastownhall/gascity/issues/1670);
+newer builds include the code fix.
+</Note>
+
 ## 3. Sling Work
 
 ```bash

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -215,6 +215,15 @@ Rig added.
 Gas City derived the rig name from the directory basename (`my-project`) and set
 up work tracking in it. The shared rig declaration lives in `city.toml`:
 
+<Note>
+Published `gc` 1.0.0 can leave a clean rig without the beads `issue_prefix`,
+which makes later `bd` or `gc sling` calls fail. If you installed 1.0.0 and
+see that error after this clean `gc init` / `gc rig add` path, run
+`gc doctor --fix` from the city directory, then retry. This is a temporary
+workaround for [GitHub issue #1670](https://github.com/gastownhall/gascity/issues/1670);
+newer builds include the code fix.
+</Note>
+
 ```shell
 
 ~/my-city

--- a/release-gates/ga-moh9o-tutorial-01-workaround-docs-gate.md
+++ b/release-gates/ga-moh9o-tutorial-01-workaround-docs-gate.md
@@ -1,0 +1,36 @@
+# Release Gate: Tutorial 01 gc 1.0.0 Workaround Docs
+
+Bead: ga-moh9o
+Source bead: ga-6a84.1
+Branch: builder/ga-6a84-1-docs-workaround
+Base: origin/main 93e927a401249d27f127de587180980dbf4e0b6d
+Reviewed commit: 9feeb81e7e9c13fdf63723cb49d217f0f26e0cef
+Gate result: PASS
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-moh9o` notes contain `VERDICT: pass` and list all four acceptance criteria as met. |
+| 2 | Acceptance criteria met | PASS | `git diff --stat --name-status origin/main...HEAD` shows only `docs/getting-started/quickstart.md` and `docs/tutorials/01-cities-and-rigs.md`. Both files include the clean `gc init` / `gc rig add` workaround, `gc doctor --fix`, `temporary workaround`, a link to `https://github.com/gastownhall/gascity/issues/1670`, and `newer builds include the code fix`. |
+| 3 | Tests pass | PASS | `make check-docs` passed: `ok github.com/gastownhall/gascity/test/docsync 1.549s`. `git diff --check origin/main...HEAD` passed with no output. |
+| 4 | No high-severity review findings open | PASS | Review notes contain no blocker or HIGH finding; the only note is a PASS verdict with docs-only scope and no security impact. |
+| 5 | Final branch is clean | PASS | After the checklist commit, `git status --short --branch` printed only the branch header with `[ahead 1]`; there are no uncommitted files. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` succeeded with no conflict diagnostics, indicating no merge conflicts with `origin/main`. |
+
+## Non-Blocking Observation
+
+`make test-tutorial-goldens` was started because this patch touches tutorial
+text. The target is a live acceptance suite with a 90-minute timeout, and it
+entered unrelated existing drift before this patch's changed flow:
+
+- `TestTutorialCommandInventoryMatchesPinnedDocs/docs/tutorials/07-orders.md`
+  failed on the known `review-check` versus `pancakes-check` command inventory
+  drift.
+- `TestTutorial01Cities/PrimaryWizardFlow/cat_pack.toml` reported existing
+  generated `pack.toml` shape drift: `[[named_session]]` instead of the pinned
+  `[[agent]]` expectation.
+
+The changed `docs/tutorials/01-cities-and-rigs.md` command inventory subtest
+passed before the optional run was terminated to keep the release gate scoped to
+the docs-only patch.


### PR DESCRIPTION
## What this changes

Adds a temporary docs note to the quickstart and Tutorial 01 for published `gc` 1.0.0 users who hit the missing beads `issue_prefix` failure after the clean `gc init` / `gc rig add` path. The note tells affected users to run `gc doctor --fix` from the city directory, retry, and follow GitHub issue #1670 for context.

This is docs-only guidance for users on the published build; newer builds already include the code fix.

## Review notes

- Touches only `docs/getting-started/quickstart.md` and `docs/tutorials/01-cities-and-rigs.md`.
- No CLI, config, generated schema, or runtime behavior changes.
- The broad live tutorial golden suite has pre-existing drift outside these files; the release gate records the non-blocking observation.

## Test plan

- [x] `make check-docs`
- [x] `git diff --check origin/main...HEAD`
- [x] `git merge-tree --write-tree HEAD origin/main`
- [x] Release gate: [`release-gates/ga-moh9o-tutorial-01-workaround-docs-gate.md`](release-gates/ga-moh9o-tutorial-01-workaround-docs-gate.md)
