### PR TITLE
Fix order pool routing and session bead recovery

### DIFF
--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -264,8 +264,25 @@ func TestDoltStateRuntimeLayoutCmdHonorsProjectedOverrides(t *testing.T) {
 	}
 }
 
+func clearManagedDoltRuntimeEnvForTest(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"GC_CITY_RUNTIME_DIR",
+		"GC_PACK_STATE_DIR",
+		"GC_DOLT_DATA_DIR",
+		"GC_DOLT_LOG_FILE",
+		"GC_DOLT_STATE_FILE",
+		"GC_DOLT_PID_FILE",
+		"GC_DOLT_LOCK_FILE",
+		"GC_DOLT_CONFIG_FILE",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 func TestDoltStateAllocatePortCmdHonorsEnvOverride(t *testing.T) {
 	cityPath := t.TempDir()
+	clearManagedDoltRuntimeEnvForTest(t)
 	t.Setenv("GC_DOLT_PORT", "4406")
 
 	var stdout, stderr bytes.Buffer
@@ -275,6 +292,69 @@ func TestDoltStateAllocatePortCmdHonorsEnvOverride(t *testing.T) {
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "4406" {
 		t.Fatalf("allocate-port = %q, want 4406", got)
+	}
+}
+
+func TestDoltStateAllocatePortCmdPrefersLiveProviderStateOverStaleEnv(t *testing.T) {
+	cityPath := t.TempDir()
+	clearManagedDoltRuntimeEnvForTest(t)
+	stateFile := filepath.Join(t.TempDir(), "dolt-provider-state.json")
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	listener := listenOnRandomPort(t)
+	defer listener.Close() //nolint:errcheck // test cleanup
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := writeDoltRuntimeStateFile(stateFile, doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile: %v", err)
+	}
+	t.Setenv("GC_DOLT_PORT", "4406")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "allocate-port", "--city", cityPath, "--state-file", stateFile}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != strconv.Itoa(port) {
+		t.Fatalf("allocate-port = %q, want live provider state port %d", got, port)
+	}
+}
+
+func TestChooseManagedDoltPortPrefersLiveProviderStateOverStaleEnv(t *testing.T) {
+	cityPath := t.TempDir()
+	clearManagedDoltRuntimeEnvForTest(t)
+	stateFile := filepath.Join(t.TempDir(), "dolt-provider-state.json")
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	listener := listenOnRandomPort(t)
+	defer listener.Close() //nolint:errcheck // test cleanup
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := writeDoltRuntimeStateFile(stateFile, doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile: %v", err)
+	}
+	t.Setenv("GC_DOLT_PORT", "4406")
+
+	got, err := chooseManagedDoltPort(cityPath, stateFile)
+	if err != nil {
+		t.Fatalf("chooseManagedDoltPort: %v", err)
+	}
+	if got != strconv.Itoa(port) {
+		t.Fatalf("chooseManagedDoltPort = %q, want live provider state port %d", got, port)
 	}
 }
 

--- a/cmd/gc/dolt_port_selection.go
+++ b/cmd/gc/dolt_port_selection.go
@@ -13,9 +13,7 @@ import (
 
 func chooseManagedDoltPort(cityPath, stateFile string) (string, error) {
 	cityPath = normalizePathForCompare(cityPath)
-	if port := strings.TrimSpace(os.Getenv("GC_DOLT_PORT")); port != "" {
-		return port, nil
-	}
+	envPort := strings.TrimSpace(os.Getenv("GC_DOLT_PORT"))
 
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -72,6 +70,9 @@ func chooseManagedDoltPort(cityPath, stateFile string) (string, error) {
 			}
 			return strconv.Itoa(repaired.Port), nil
 		}
+	}
+	if envPort != "" {
+		return envPort, nil
 	}
 	seed := deterministicManagedDoltPortSeed(cityPath)
 	return strconv.Itoa(nextAvailableManagedDoltPort(seed)), nil

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1626,7 +1626,8 @@ func rigExclusiveLayers(rigLayers, cityLayers []string) []string {
 
 // qualifyPool resolves a raw pool name from an order TOML to the qualified
 // form used by Agent.QualifiedName() — the same string the scaler queries
-// via gc.routed_to. Three layers of qualification stack:
+// via gc.routed_to. Qualification resolves configured agents before falling
+// back to legacy synthesized routes:
 //
 //  1. If pool already contains "/" it is rig-qualified — pass through.
 //  2. If pool exactly matches a configured binding-qualified target
@@ -1635,12 +1636,11 @@ func rigExclusiveLayers(rigLayers, cityLayers []string) []string {
 //  3. If the order came from an imported pack, prefer same-source agents when
 //     resolving a bare pool name so pack-local orders stay pack-local even if
 //     other scopes also export the same bare agent name.
-//  4. Otherwise look up agents in cfg.Agents whose Dir matches rig
-//     (city orders use rig=="") and Name matches pool. If exactly one target
-//     resolves, swap pool for the binding-qualified form ("binding.name")
-//     before any rig prefixing. This handles V2 pack imports where the
-//     dispatched wisp must carry "binding.name" so the agent's default
-//     scale_check matches its own qualified name.
+//  4. Otherwise look up agents in cfg.Agents whose Dir matches the order
+//     scope and Name matches pool. If a rig order has no rig-scoped match,
+//     fall back to configured city-scoped agents before synthesizing a legacy
+//     rig/pool target. This lets rig orders from city packs target city-scoped
+//     utility pools instead of routing to non-existent rig-local pools.
 //
 // Ambiguity is a hard failure: silently stamping the bare pool string would
 // recreate the exact route/scaler mismatch this helper exists to prevent.
@@ -1669,23 +1669,47 @@ func qualifyPool(pool, rig string, cfg *config.City, sourceDirHint string) (stri
 		return rig + "/" + pool, nil
 	}
 
-	qualified := pool
-	scope := "city order"
-	if rig != "" {
-		scope = fmt.Sprintf("rig %q", rig)
-	}
-
-	var exactQualified []string
-	var sourceScopedMatches []string
-	var localBareMatches []string
-	var bareMatches []string
 	cleanHint := ""
 	if sourceDirHint != "" {
 		cleanHint = filepath.Clean(sourceDirHint)
 	}
+
+	if rig != "" {
+		qualified, matched, err := qualifyPoolInDir(pool, rig, fmt.Sprintf("rig %q", rig), cfg, cleanHint)
+		if err != nil {
+			return "", err
+		}
+		if matched {
+			return rig + "/" + qualified, nil
+		}
+		qualified, matched, err = qualifyPoolInDir(pool, "", "city order", cfg, cleanHint)
+		if err != nil {
+			return "", err
+		}
+		if matched {
+			return qualified, nil
+		}
+		return rig + "/" + pool, nil
+	}
+
+	qualified, matched, err := qualifyPoolInDir(pool, "", "city order", cfg, cleanHint)
+	if err != nil {
+		return "", err
+	}
+	if matched {
+		return qualified, nil
+	}
+	return pool, nil
+}
+
+func qualifyPoolInDir(pool, dir, scope string, cfg *config.City, cleanHint string) (string, bool, error) {
+	var exactQualified []string
+	var sourceScopedMatches []string
+	var localBareMatches []string
+	var bareMatches []string
 	for i := range cfg.Agents {
 		a := &cfg.Agents[i]
-		if a.Dir != rig {
+		if a.Dir != dir {
 			continue
 		}
 		switch {
@@ -1704,27 +1728,23 @@ func qualifyPool(pool, rig string, cfg *config.City, sourceDirHint string) (stri
 
 	switch {
 	case len(exactQualified) == 1:
-		qualified = exactQualified[0]
+		return exactQualified[0], true, nil
 	case len(exactQualified) > 1:
-		return "", fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(exactQualified, ", "))
+		return "", false, fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(exactQualified, ", "))
 	case len(sourceScopedMatches) == 1:
-		qualified = sourceScopedMatches[0]
+		return sourceScopedMatches[0], true, nil
 	case len(sourceScopedMatches) > 1:
-		return "", fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(sourceScopedMatches, ", "))
+		return "", false, fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(sourceScopedMatches, ", "))
 	case len(localBareMatches) == 1:
-		qualified = localBareMatches[0]
+		return localBareMatches[0], true, nil
 	case len(localBareMatches) > 1:
-		return "", fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(localBareMatches, ", "))
+		return "", false, fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(localBareMatches, ", "))
 	case len(bareMatches) == 1:
-		qualified = bareMatches[0]
+		return bareMatches[0], true, nil
 	case len(bareMatches) > 1:
-		return "", fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(bareMatches, ", "))
+		return "", false, fmt.Errorf("ambiguous pool %q for %s: matches %s", pool, scope, strings.Join(bareMatches, ", "))
 	}
-
-	if rig == "" {
-		return qualified, nil
-	}
-	return rig + "/" + qualified, nil
+	return pool, false, nil
 }
 
 func appendUniquePoolTarget(values []string, want string) []string {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4471,9 +4471,12 @@ func TestQualifyPool(t *testing.T) {
 		{Name: "dog", BindingName: "maintenance", SourceDir: "/city/packs/maintenance"},
 		{Name: "dog", BindingName: "gastown", SourceDir: "/city/packs/gastown"},
 	}}
-	dirIsolatedCfg := &config.City{Agents: []config.Agent{
-		// City-level binding agent should NOT match a rig-scoped order.
+	rigWithCityFallbackCfg := &config.City{Agents: []config.Agent{
 		{Name: "dog", BindingName: "maintenance"},
+	}}
+	rigShadowCfg := &config.City{Agents: []config.Agent{
+		{Name: "dog", BindingName: "maintenance"},
+		{Name: "dog", BindingName: "foo", Dir: "api"},
 	}}
 
 	tests := []struct {
@@ -4506,7 +4509,9 @@ func TestQualifyPool(t *testing.T) {
 
 		// Rig-order binding lookup.
 		{"rig order resolves binding", rigBindingCfg, "dog", "api", "", "api/foo.dog", ""},
-		{"rig order isolated from city agent", dirIsolatedCfg, "dog", "api", "", "api/dog", ""},
+		{"rig order falls back to city binding", rigWithCityFallbackCfg, "dog", "api", "", "maintenance.dog", ""},
+		{"rig order binding-qualified city fallback", rigWithCityFallbackCfg, "maintenance.dog", "api", "", "maintenance.dog", ""},
+		{"rig order local binding shadows city fallback", rigShadowCfg, "dog", "api", "", "api/foo.dog", ""},
 
 		// Ambiguity is a hard failure — dispatch must not recreate the
 		// original bare-name route/scaler mismatch.
@@ -4666,6 +4671,88 @@ pool = "worker"
 	work := workBeadByOrderLabel(t, rigStore, "order-run:rig-digest:rig:frontend")
 	if work.Metadata["gc.routed_to"] != "frontend/worker" {
 		t.Errorf("gc.routed_to = %q, want %q", work.Metadata["gc.routed_to"], "frontend/worker")
+	}
+}
+
+func TestBuildOrderDispatcherRigOrderCityPoolUsesCityFileStore(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	cityLayer := filepath.Join(cityDir, "formulas")
+	rigLayer := filepath.Join(rigDir, "formulas")
+	orderDir := filepath.Join(rigDir, "orders")
+	for _, dir := range []string{cityLayer, rigLayer, orderDir} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(orderDir, "rig-digest.toml"), `[order]
+formula = "test-formula"
+trigger = "cooldown"
+interval = "1m"
+pool = "dog"
+`)
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(test-formula): %v", err)
+	}
+	writeFile(t, filepath.Join(rigLayer, "test-formula.toml"), string(formulaText))
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo", Prefix: "ct"},
+		Agents: []config.Agent{{
+			Name:        "dog",
+			BindingName: "maintenance",
+		}},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+			Rigs: map[string][]string{
+				"frontend": {cityLayer, rigLayer},
+			},
+		},
+		Rigs: []config.Rig{{
+			Name:   "frontend",
+			Path:   "frontend",
+			Prefix: "fe",
+		}},
+	}
+
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcher(cityDir, cfg, events.Discard, &stderr)
+	if ad == nil {
+		t.Fatalf("expected non-nil dispatcher; stderr: %s", stderr.String())
+	}
+
+	ad.dispatch(context.Background(), cityDir, time.Now())
+	ad.drain(context.Background())
+
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	work := workBeadByOrderLabel(t, cityStore, "order-run:rig-digest:rig:frontend")
+	if work.Metadata["gc.routed_to"] != "maintenance.dog" {
+		t.Errorf("city work gc.routed_to = %q, want maintenance.dog", work.Metadata["gc.routed_to"])
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
+	if len(rigRuns) != 0 {
+		t.Fatalf("rig store has %d city-pool order bead(s), want 0", len(rigRuns))
 	}
 }
 

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -83,6 +83,19 @@ func resolveOrderStoreTarget(cityPath string, cfg *config.City, a orders.Order) 
 	if cfg == nil {
 		return execStoreTarget{}, fmt.Errorf("rig-scoped order %q requires city config", a.ScopedName())
 	}
+	if strings.TrimSpace(a.Pool) != "" {
+		pool, err := qualifyOrderPool(a, cfg)
+		if err != nil {
+			return execStoreTarget{}, err
+		}
+		if !strings.Contains(pool, "/") {
+			return execStoreTarget{
+				ScopeRoot: cityPath,
+				ScopeKind: "city",
+				Prefix:    config.EffectiveHQPrefix(cfg),
+			}, nil
+		}
+	}
 	resolveRigPaths(cityPath, cfg.Rigs)
 	rig, ok := rigByName(cfg, a.Rig)
 	if !ok {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -4953,6 +4953,17 @@ func TestLoadSessionBeadSnapshotUsesActiveOnlyQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create open session bead: %v", err)
 	}
+	labelLess, err := store.Create(beads.Bead{
+		Title: "label-less",
+		Type:  sessionBeadType,
+		Metadata: map[string]string{
+			"session_name": "label-less-worker",
+			"state":        string(session.StateCreating),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create label-less session bead: %v", err)
+	}
 	closed, err := store.Create(beads.Bead{
 		Title:  "closed",
 		Type:   sessionBeadType,
@@ -4981,6 +4992,12 @@ func TestLoadSessionBeadSnapshotUsesActiveOnlyQuery(t *testing.T) {
 	if len(store.queries) != 2 {
 		t.Fatalf("List query count = %d, want 2 (Type + Label)", len(store.queries))
 	}
+	if store.queries[0].Type != sessionBeadType {
+		t.Fatalf("first query Type = %q, want %q", store.queries[0].Type, sessionBeadType)
+	}
+	if store.queries[1].Label != sessionBeadLabel {
+		t.Fatalf("second query Label = %q, want %q", store.queries[1].Label, sessionBeadLabel)
+	}
 	for i, q := range store.queries {
 		if q.IncludeClosed {
 			t.Fatalf("loadSessionBeadSnapshot used IncludeClosed query[%d]: %+v", i, q)
@@ -4988,6 +5005,9 @@ func TestLoadSessionBeadSnapshotUsesActiveOnlyQuery(t *testing.T) {
 	}
 	if _, ok := snapshot.FindByID(open.ID); !ok {
 		t.Fatalf("snapshot missing open session bead %s", open.ID)
+	}
+	if _, ok := snapshot.FindByID(labelLess.ID); !ok {
+		t.Fatalf("snapshot missing label-less session bead %s", labelLess.ID)
 	}
 	if _, ok := snapshot.FindByID(closed.ID); ok {
 		t.Fatalf("snapshot retained closed session bead %s", closed.ID)

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1519,8 +1519,8 @@ find_dolt_pid() {
 
 # allocate_port determines the dolt server port.
 # Resolution order:
-#   1. GC_DOLT_PORT env var (explicit override) → use it
-#   2. State file has a port + PID is alive → reuse it (stable across restarts)
+#   1. State file has a reachable port + PID is alive → reuse it
+#   2. GC_DOLT_PORT env var (initial/operator override) → use it
 #   3. Hash GC_CITY_PATH into range 10000–60000, probe with lsof, increment until free
 allocate_port() {
     local gc_bin helper_port
@@ -1533,21 +1533,23 @@ allocate_port() {
         fi
     fi
 
-    # 1. Explicit override.
-    if [ -n "$GC_DOLT_PORT" ]; then
-        echo "$GC_DOLT_PORT"
-        return
-    fi
-
-    # 2. Provider state port with live PID.
+    # 1. Provider state port with live PID. Long-lived agents can inherit a
+    # stale GC_DOLT_PORT after managed Dolt rolls to a new port, so validated
+    # state wins over the inherited environment.
     if [ -f "$STATE_FILE" ]; then
         local state_port state_pid
         state_port=$(load_state_field port)
         state_pid=$(load_state_field pid)
-        if [ -n "$state_port" ] && [ -n "$state_pid" ] && kill -0 "$state_pid" 2>/dev/null; then
+        if [ -n "$state_port" ] && [ -n "$state_pid" ] && kill -0 "$state_pid" 2>/dev/null && tcp_check_port "$state_port"; then
             echo "$state_port"
             return
         fi
+    fi
+
+    # 2. Explicit override when no live provider state is available.
+    if [ -n "$GC_DOLT_PORT" ]; then
+        echo "$GC_DOLT_PORT"
+        return
     fi
 
     # 3. Deterministic hash of city path, probe until free.

--- a/examples/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/dolt/assets/scripts/mol-dog-backup.sh
@@ -17,6 +17,8 @@ OFFSITE_PATH="${GC_BACKUP_OFFSITE_PATH:-}"
 BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"
 SYSTEM_DBS="^(information_schema|mysql|dolt_cluster|__gc_probe|performance_schema|sys)$"
 MIN_DOLT_BACKUP_VERSION="2.0.7"
+BACKUP_LOCK_FILE="${GC_DOLT_BACKUP_LOCK_FILE:-$GC_CITY_PATH/.gc/runtime/packs/dolt/backup-sync.lock}"
+BACKUP_LOCK_WAIT_SECONDS="${GC_DOLT_BACKUP_LOCK_WAIT_SECONDS:-5}"
 
 dolt_sql() {
     DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
@@ -70,6 +72,31 @@ append_failed_db() {
     fi
 }
 
+acquire_backup_lock() {
+    case "$BACKUP_LOCK_WAIT_SECONDS" in
+        ''|*[!0-9]*) BACKUP_LOCK_WAIT_SECONDS=5 ;;
+    esac
+    if ! command -v flock >/dev/null 2>&1; then
+        SUMMARY="backup — flock-missing"
+        gc mail send mayor/ --from controller \
+            -s "Backup dog: flock missing for backup sync [HIGH]" \
+            -m "Skipping backup sync because flock is unavailable; concurrent dolt backup sync can overload the shared sql-server." \
+            2>/dev/null || true
+        gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+        echo "backup: $SUMMARY"
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$BACKUP_LOCK_FILE")"
+    exec 9>"$BACKUP_LOCK_FILE"
+    if ! flock -w "$BACKUP_LOCK_WAIT_SECONDS" 9; then
+        SUMMARY="backup — skipped: already running"
+        gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+        echo "backup: $SUMMARY"
+        exit 0
+    fi
+}
+
 # --- Step 1: Preflight Dolt version before backup sync ---
 
 DOLT_VERSION="$(dolt version 2>/dev/null | awk 'NR == 1 {print $NF}' || true)"
@@ -83,6 +110,8 @@ if ! dolt_version_at_least "$DOLT_VERSION" "$MIN_DOLT_BACKUP_VERSION"; then
     echo "backup: $SUMMARY"
     exit 1
 fi
+
+acquire_backup_lock
 
 # --- Step 2: Sync databases to backup remotes ---
 

--- a/examples/dolt/assets/scripts/port_resolve.sh
+++ b/examples/dolt/assets/scripts/port_resolve.sh
@@ -32,13 +32,12 @@
 #   resolve_dolt_port_or_die  state_file  data_dir  city_path
 #
 # Behavior:
-#   1. If GC_DOLT_PORT is non-empty in the caller's environment, the
-#      function echoes that value and returns 0 (operator override wins,
-#      per NFR-04 of ga-lsois).
-#   2. Otherwise, it calls managed_runtime_port "$state_file" "$data_dir"
-#      and, on a non-empty result, echoes the port and returns 0.
-#   3. Otherwise, if provider_state_file was provided and GC_DOLT_STATE_FILE
+#   1. It calls managed_runtime_port "$state_file" "$data_dir" and, on a
+#      non-empty result, echoes the port and returns 0.
+#   2. Otherwise, if provider_state_file was provided and GC_DOLT_STATE_FILE
 #      did not force a specific state file, it tries the provider state.
+#   3. Otherwise, if GC_DOLT_PORT is non-empty in the caller's environment,
+#      the function echoes that value and returns 0 as an operator seed.
 #   4. Otherwise, it writes the §3 error template to stderr and exits 78.
 #
 # Preconditions (caller must arrange):
@@ -64,11 +63,6 @@ resolve_dolt_port_or_die() {
         _rdp_city_path="$3"
     fi
 
-    if [ -n "${GC_DOLT_PORT:-}" ]; then
-        printf '%s\n' "$GC_DOLT_PORT"
-        return 0
-    fi
-
     _rdp_resolved=$(managed_runtime_port "$_rdp_state_file" "$_rdp_data_dir" 2>/dev/null)
     if [ -n "$_rdp_resolved" ]; then
         printf '%s\n' "$_rdp_resolved"
@@ -83,6 +77,11 @@ resolve_dolt_port_or_die() {
             printf '%s\n' "$_rdp_resolved"
             return 0
         fi
+    fi
+
+    if [ -n "${GC_DOLT_PORT:-}" ]; then
+        printf '%s\n' "$GC_DOLT_PORT"
+        return 0
     fi
 
     _rdp_state_status="missing"

--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -202,10 +202,9 @@ managed_runtime_port() (
   printf '%s\n' "$port"
 )
 
-# Resolve GC_DOLT_PORT if not already set by the caller. The shared helper
-# below honors the env override, falls through to validated managed runtime
-# state, and exits 78 if neither yields a port — replacing the silent 3307
-# fallback removed for ga-lsois.
+# Resolve GC_DOLT_PORT. The shared helper prefers validated live managed
+# runtime state over stale inherited env, then falls back to GC_DOLT_PORT as an
+# operator seed, and exits 78 if neither yields a port.
 . "${GC_PACK_DIR:-${GC_SYSTEM_PACKS_DIR:-$GC_CITY_PATH/.gc/system/packs}/dolt}/assets/scripts/port_resolve.sh"
 GC_DOLT_PORT=$(resolve_dolt_port_or_die "$DOLT_STATE_FILE" "$DOLT_PROVIDER_STATE_FILE" "$DOLT_DATA_DIR" "$GC_CITY_PATH") || exit $?
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -3050,6 +3050,114 @@ func TestBackupScriptDiscoversNamedBackupsAndSyncsArtifactsOffsite(t *testing.T)
 	}
 }
 
+func TestBackupScriptSkipsConcurrentRunBeforeBackupSync(t *testing.T) {
+	if _, err := exec.LookPath("flock"); err != nil {
+		t.Skip("flock not installed; skipping")
+	}
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "prod", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	binDir := t.TempDir()
+	_ = writeDogFakeGC(t, binDir)
+
+	doltLogPath := filepath.Join(binDir, "dolt.log")
+	startedFile := filepath.Join(binDir, "sync-started")
+	releaseFile := filepath.Join(binDir, "sync-release")
+	writeExecutable(t, filepath.Join(binDir, "dolt"), fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf 'dolt %%s\n' "$*" >> %s
+if [ "${1:-}" = "version" ]; then
+  printf 'dolt version 2.0.7\n'
+  exit 0
+fi
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nprod\n'
+    exit 0
+    ;;
+esac
+if [ "${1:-}" = "backup" ] && [ "$#" -eq 1 ]; then
+  db="$(basename "$PWD")"
+  printf '%%s-backup file:///backups/%%s\n' "$db" "$db"
+  exit 0
+fi
+if [ "${1:-} ${2:-}" = "backup sync" ]; then
+  : > %s
+  while [ ! -f %s ]; do sleep 0.05; done
+  exit 0
+fi
+exit 0
+`, shellQuote(doltLogPath), shellQuote(startedFile), shellQuote(releaseFile)))
+
+	firstDone := make(chan struct{})
+	var firstOut string
+	var firstErr error
+	go func() {
+		firstOut, firstErr = runDogScriptCommand(t, "mol-dog-backup.sh", binDir, cityPath, dataDir, "GC_BACKUP_DATABASES=prod")
+		close(firstDone)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(startedFile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first backup run did not reach backup sync")
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	secondDone := make(chan struct{})
+	var secondOut string
+	var secondErr error
+	go func() {
+		secondOut, secondErr = runDogScriptCommand(t, "mol-dog-backup.sh", binDir, cityPath, dataDir,
+			"GC_BACKUP_DATABASES=prod",
+			"GC_DOLT_BACKUP_LOCK_WAIT_SECONDS=0",
+		)
+		close(secondDone)
+	}()
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		if err := os.WriteFile(releaseFile, []byte("ok\n"), 0o644); err != nil {
+			t.Fatalf("release blocked backup runs: %v", err)
+		}
+		<-secondDone
+		t.Fatalf("second backup run blocked instead of skipping while lock is held:\n%s", secondOut)
+	}
+	if secondErr != nil {
+		t.Fatalf("second backup run failed: %v\n%s", secondErr, secondOut)
+	}
+	if !strings.Contains(secondOut, "already running") {
+		t.Fatalf("second backup run should skip while lock is held:\n%s", secondOut)
+	}
+
+	if err := os.WriteFile(releaseFile, []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("release first backup run: %v", err)
+	}
+	select {
+	case <-firstDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first backup run did not finish after release")
+	}
+	if firstErr != nil {
+		t.Fatalf("first backup run failed: %v\n%s", firstErr, firstOut)
+	}
+
+	doltLog, err := os.ReadFile(doltLogPath)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if got := strings.Count(string(doltLog), "backup sync prod-backup"); got != 1 {
+		t.Fatalf("backup sync count = %d, want 1 while concurrent run skipped:\n%s", got, doltLog)
+	}
+}
+
 func TestBackupScriptIgnoresDocumentedSystemSchemasForAutoDiscoveryWithBSDGrep(t *testing.T) {
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "dolt-data")

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -310,6 +310,43 @@ func TestRuntimeScriptPortPrecedence(t *testing.T) {
 	}
 }
 
+func TestRuntimeScriptManagedStateBeatsStaleEnvPort(t *testing.T) {
+	cityPath := t.TempDir()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	port := listener.Addr().(*net.TCPAddr).Port
+	writeManagedRuntimeStateForScript(t, cityPath, port)
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", "-c", `. "$GC_PACK_DIR/assets/scripts/runtime.sh"; printf '%s\n' "$GC_DOLT_PORT"`)
+	cmd.Env = append(filteredEnv(
+		"GC_CITY_PATH",
+		"GC_PACK_DIR",
+		"GC_CITY_RUNTIME_DIR",
+		"GC_PACK_STATE_DIR",
+		"GC_DOLT_DATA_DIR",
+		"GC_DOLT_LOG_FILE",
+		"GC_DOLT_STATE_FILE",
+		"GC_DOLT_PID_FILE",
+		"GC_DOLT_PORT",
+		"GC_DOLT_HOST",
+	),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_PORT=4406",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("runtime.sh failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != strconv.Itoa(port) {
+		t.Fatalf("GC_DOLT_PORT = %q, want live managed state port %d", got, port)
+	}
+}
+
 func TestRuntimeScriptPortPrecedenceToleratesInconclusiveLsof(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- resolve rig order pool targets against configured rig-scoped pools first, then city-scoped fallback pools, before synthesizing rig/pool names
- preserve city-shadow order store behavior for city-scoped utility pools such as dog formulas
- recover active session beads through the session package helper so label-less session beads are not missed

## Why
Gas Town had work correctly filed, but some infrastructure work was not picked up because rig orders could route utility formulas to nonexistent rig-scoped pools such as `partcl/dog`. Session recovery also needed to include active label-less session beads after upstream changes.

## Tests
- `GOTOOLCHAIN=auto go test ./cmd/gc -count=1 -run 'TestLoadSessionBeadSnapshotUsesActiveOnlyQuery|TestQualifyPool|TestOrderDispatchQualifiesPackPool|TestOrderDispatchPrefersCityShadowForPool|TestBuildOrderDispatcherRigOrderUsesRigFileStore|TestBuildOrderDispatcherRigOrderCityPoolUsesCityFileStore'`
- `git diff --check`