### PR TITLE
fix(doctor): widen cron-interval scan window for weekly+ schedules (#2499)

### DIFF
--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -183,14 +183,20 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 	// coarser than daily (#2499). The 24h fast-path stays cheap for the
 	// common case; coarser schedules pay the larger scan once per unique
 	// schedule (results are cached at the caller).
-	base := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	//
+	// Base is the start of a leap year so the 366d window can include a
+	// Feb 29 occurrence — `0 0 29 2 *` (leap-day schedules) would otherwise
+	// produce a permanent doctor-red on cities whose check started outside
+	// a leap-year window (Copilot review on #2525).
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	windowsMinutes := []int{
 		1440,       // 24h — covers sub-daily and daily schedules
 		7 * 1440,   // 7d  — covers weekly and weekday-set schedules
 		31 * 1440,  // 31d — covers monthly schedules (longest month)
-		366 * 1440, // 366d — covers yearly and leap-year schedules
+		366 * 1440, // 366d — covers yearly + leap-year (Feb 29) schedules
 	}
-	for _, windowMinutes := range windowsMinutes {
+	lastWindowIndex := len(windowsMinutes) - 1
+	for windowIndex, windowMinutes := range windowsMinutes {
 		matches := make([]time.Time, 0, 16)
 		for i := 0; i < windowMinutes; i++ {
 			ts := base.Add(time.Duration(i) * time.Minute)
@@ -207,6 +213,17 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 		}
 		window := time.Duration(windowMinutes) * time.Minute
 		if len(matches) == 1 {
+			// Don't fix the interval on the first window that happens to
+			// catch one match: a yearly schedule whose firing minute
+			// coincidentally falls inside the 24h or 7d window (e.g.
+			// `0 0 12 5 *` from a base near May 5) would otherwise be
+			// mis-classified as sub-daily. Keep widening until either a
+			// second match lands (use the real minGap) or we exhaust the
+			// horizon — only then is the window length a defensible
+			// conservative interval (Copilot review on #2525).
+			if windowIndex < lastWindowIndex {
+				continue
+			}
 			return window, nil
 		}
 		minGap := window
@@ -216,10 +233,12 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 				minGap = gap
 			}
 		}
-		wrapGap := matches[0].Add(window).Sub(matches[len(matches)-1])
-		if wrapGap < minGap {
-			minGap = wrapGap
-		}
+		// Do not include a wrap-around gap (matches[0]+window - matches[last]).
+		// It is only meaningful when the schedule's natural period divides the
+		// window evenly, and produces wrong results for schedules whose period
+		// does not — e.g. a weekly schedule in the 31d window would report a
+		// bogus 3d "wrap" from Mon to Mon-of-next-month-mod-31d, drowning out
+		// the real 7d gap from the loop above.
 		return minGap, nil
 	}
 	return 0, fmt.Errorf("cron schedule %q has no firing minutes in a 366-day window", schedule)

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -185,10 +185,10 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 	// schedule (results are cached at the caller).
 	base := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
 	windowsMinutes := []int{
-		1440,           // 24h — covers sub-daily and daily schedules
-		7 * 1440,       // 7d  — covers weekly and weekday-set schedules
-		31 * 1440,      // 31d — covers monthly schedules (longest month)
-		366 * 1440,     // 366d — covers yearly and leap-year schedules
+		1440,       // 24h — covers sub-daily and daily schedules
+		7 * 1440,   // 7d  — covers weekly and weekday-set schedules
+		31 * 1440,  // 31d — covers monthly schedules (longest month)
+		366 * 1440, // 366d — covers yearly and leap-year schedules
 	}
 	for _, windowMinutes := range windowsMinutes {
 		matches := make([]time.Time, 0, 16)

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -176,38 +176,53 @@ func computeExpectedIntervalForCronSchedule(schedule string) (time.Duration, err
 		return 0, fmt.Errorf("invalid cron schedule: want 5 fields, got %d", len(fields))
 	}
 
-	const day = 24 * time.Hour
+	// Scan minute-by-minute from a fixed base so the result is deterministic
+	// and independent of when the check runs. Widen the scan progressively so
+	// weekly, monthly, and yearly schedules are computed honestly instead of
+	// erroring out: the typical 24h window has zero matches for any schedule
+	// coarser than daily (#2499). The 24h fast-path stays cheap for the
+	// common case; coarser schedules pay the larger scan once per unique
+	// schedule (results are cached at the caller).
 	base := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
-	matches := make([]time.Time, 0, 1440)
-	for i := 0; i < 1440; i++ {
-		ts := base.Add(time.Duration(i) * time.Minute)
-		matched, err := cronScheduleMatchesAt(fields, ts)
-		if err != nil {
-			return 0, err
+	windowsMinutes := []int{
+		1440,           // 24h — covers sub-daily and daily schedules
+		7 * 1440,       // 7d  — covers weekly and weekday-set schedules
+		31 * 1440,      // 31d — covers monthly schedules (longest month)
+		366 * 1440,     // 366d — covers yearly and leap-year schedules
+	}
+	for _, windowMinutes := range windowsMinutes {
+		matches := make([]time.Time, 0, 16)
+		for i := 0; i < windowMinutes; i++ {
+			ts := base.Add(time.Duration(i) * time.Minute)
+			matched, err := cronScheduleMatchesAt(fields, ts)
+			if err != nil {
+				return 0, err
+			}
+			if matched {
+				matches = append(matches, ts)
+			}
 		}
-		if matched {
-			matches = append(matches, ts)
+		if len(matches) == 0 {
+			continue
 		}
-	}
-	switch len(matches) {
-	case 0:
-		return 0, fmt.Errorf("cron schedule %q has no firing minutes in a 24h window", schedule)
-	case 1:
-		return day, nil
-	}
-
-	minGap := day
-	for i := 1; i < len(matches); i++ {
-		gap := matches[i].Sub(matches[i-1])
-		if gap < minGap {
-			minGap = gap
+		window := time.Duration(windowMinutes) * time.Minute
+		if len(matches) == 1 {
+			return window, nil
 		}
+		minGap := window
+		for i := 1; i < len(matches); i++ {
+			gap := matches[i].Sub(matches[i-1])
+			if gap < minGap {
+				minGap = gap
+			}
+		}
+		wrapGap := matches[0].Add(window).Sub(matches[len(matches)-1])
+		if wrapGap < minGap {
+			minGap = wrapGap
+		}
+		return minGap, nil
 	}
-	wrapGap := matches[0].Add(day).Sub(matches[len(matches)-1])
-	if wrapGap < minGap {
-		minGap = wrapGap
-	}
-	return minGap, nil
+	return 0, fmt.Errorf("cron schedule %q has no firing minutes in a 366-day window", schedule)
 }
 
 func cronScheduleMatchesAt(fields []string, ts time.Time) (bool, error) {

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -129,22 +129,48 @@ func TestOrderFiringCurrent_IgnoresManualAndEventTriggers(t *testing.T) {
 
 func TestComputeExpectedIntervalForCronSchedules(t *testing.T) {
 	tests := []struct {
+		name     string
 		schedule string
 		want     time.Duration
 	}{
-		{"0 */4 * * *", 4 * time.Hour},
-		{"*/15 * * * *", 15 * time.Minute},
-		{"0 3 * * *", 24 * time.Hour},
-		{"0 9-17 * * *", time.Hour},
+		{"every-4h", "0 */4 * * *", 4 * time.Hour},
+		{"every-15min", "*/15 * * * *", 15 * time.Minute},
+		{"daily-0300", "0 3 * * *", 24 * time.Hour},
+		{"hourly-business", "0 9-17 * * *", time.Hour},
+		// #2499: schedules coarser than daily must compute an honest interval
+		// instead of erroring on an empty 24h scan window. Weekly, biweekly,
+		// monthly, and yearly are the common shapes; the progressive-widen
+		// algorithm walks 24h → 7d → 31d → 366d until it finds at least one
+		// match.
+		{"weekly-monday-0830", "30 8 * * 1", 7 * 24 * time.Hour},
+		{"weekly-sunday", "0 0 * * 0", 7 * 24 * time.Hour},
+		{"mon-wed-fri-0830", "30 8 * * 1,3,5", 2 * 24 * time.Hour},   // min(Mon→Wed, Wed→Fri, Fri-wrap→Mon)
+		{"monthly-first-midnight", "0 0 1 * *", 31 * 24 * time.Hour}, // 31d window from May 12 sees only June 1 → returns window length (longest-month upper bound; suits staleness checks)
+		{"yearly-new-year", "0 0 1 1 *", 366 * 24 * time.Hour},       // single match in 366d window → returns window length
 	}
 	for _, tt := range tests {
-		got, err := computeExpectedIntervalForCronSchedule(tt.schedule)
-		if err != nil {
-			t.Fatalf("computeExpectedIntervalForCronSchedule(%q): %v", tt.schedule, err)
-		}
-		if got != tt.want {
-			t.Fatalf("computeExpectedIntervalForCronSchedule(%q) = %s, want %s", tt.schedule, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := computeExpectedIntervalForCronSchedule(tt.schedule)
+			if err != nil {
+				t.Fatalf("computeExpectedIntervalForCronSchedule(%q): %v", tt.schedule, err)
+			}
+			if got != tt.want {
+				t.Fatalf("computeExpectedIntervalForCronSchedule(%q) = %s, want %s", tt.schedule, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestComputeExpectedIntervalForCronSchedule_NoMatchInAYear pins the only
+// remaining error path now that coarse schedules widen the scan up to 366
+// days: a schedule that cannot match any minute in a year (here, an
+// impossible day-of-month) still returns an explicit error so doctor
+// surfaces it rather than silently mis-classifying the order.
+func TestComputeExpectedIntervalForCronSchedule_NoMatchInAYear(t *testing.T) {
+	const impossible = "0 0 31 2 *" // Feb 31 — never matches
+	_, err := computeExpectedIntervalForCronSchedule(impossible)
+	if err == nil {
+		t.Fatalf("computeExpectedIntervalForCronSchedule(%q) returned no error; want diagnostic for unmatched schedule", impossible)
 	}
 }
 

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -140,13 +140,17 @@ func TestComputeExpectedIntervalForCronSchedules(t *testing.T) {
 		// #2499: schedules coarser than daily must compute an honest interval
 		// instead of erroring on an empty 24h scan window. Weekly, biweekly,
 		// monthly, and yearly are the common shapes; the progressive-widen
-		// algorithm walks 24h → 7d → 31d → 366d until it finds at least one
-		// match.
-		{"weekly-monday-0830", "30 8 * * 1", 7 * 24 * time.Hour},
+		// algorithm walks 24h → 7d → 31d → 366d. Per the Copilot review on
+		// #2525, a single match in a smaller window no longer fixes the
+		// interval — the algorithm keeps widening until either a second match
+		// lands or the largest window is exhausted, at which point the window
+		// length is used as a conservative interval.
+		{"weekly-monday-0830", "30 8 * * 1", 7 * 24 * time.Hour}, // 31d window: 5 Mondays → minGap 7d
 		{"weekly-sunday", "0 0 * * 0", 7 * 24 * time.Hour},
-		{"mon-wed-fri-0830", "30 8 * * 1,3,5", 2 * 24 * time.Hour},   // min(Mon→Wed, Wed→Fri, Fri-wrap→Mon)
-		{"monthly-first-midnight", "0 0 1 * *", 31 * 24 * time.Hour}, // 31d window from May 12 sees only June 1 → returns window length (longest-month upper bound; suits staleness checks)
-		{"yearly-new-year", "0 0 1 1 *", 366 * 24 * time.Hour},       // single match in 366d window → returns window length
+		{"biweekly-1st-and-15th", "0 0 1,15 * *", 14 * 24 * time.Hour}, // 31d window: Jan 1, 15, Feb 1, 15, ... → minGap 14d
+		{"mon-wed-fri-0830", "30 8 * * 1,3,5", 2 * 24 * time.Hour},     // 7d window has 3 matches → minGap min(Mon→Wed, Wed→Fri) = 2d
+		{"monthly-first-midnight", "0 0 1 * *", 29 * 24 * time.Hour},   // 31d window: only Jan 1 → continue. 366d window: 12 matches → minGap = Feb→Mar in leap-year base 2024 = 29d
+		{"yearly-new-year", "0 0 1 1 *", 366 * 24 * time.Hour},         // 366d window: Jan 1 base + (next Jan 1 at boundary excluded) → single match → window length
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -158,6 +162,46 @@ func TestComputeExpectedIntervalForCronSchedules(t *testing.T) {
 				t.Fatalf("computeExpectedIntervalForCronSchedule(%q) = %s, want %s", tt.schedule, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestComputeExpectedIntervalForCronSchedule_YearlyWithFirstWindowMatch
+// pins the Copilot review finding on PR #2525 thread @ line 211: a yearly
+// schedule whose firing minute coincidentally falls inside the 24h or 7d
+// window must not be classified as a 24h/7d interval. The progressive-widen
+// loop continues past single-match windows until either a second match
+// lands or the largest (366d) window is exhausted; the chosen base of
+// 2024-01-01 plus the leap-year window covers `0 H 1 1 *` schedules
+// honestly (1 match in 366d → 366d, not 24h).
+func TestComputeExpectedIntervalForCronSchedule_YearlyWithFirstWindowMatch(t *testing.T) {
+	// `0 0 1 1 *` matches at base (Jan 1 2024 00:00 — i=0) and the next
+	// occurrence is Jan 1 2025, which lies at exactly base+366d and is
+	// excluded by the `i < windowMinutes` loop boundary. Before the
+	// Copilot fix, the 24h-window early-return would have returned 24h.
+	// After the fix, the loop continues past every window-with-one-match
+	// and returns the 366d window length only at the last step.
+	got, err := computeExpectedIntervalForCronSchedule("0 0 1 1 *")
+	if err != nil {
+		t.Fatalf("computeExpectedIntervalForCronSchedule(yearly): %v", err)
+	}
+	if got < 30*24*time.Hour {
+		t.Fatalf("yearly schedule classified as %s (< 30d) — early-return-on-first-window bug regressed", got)
+	}
+}
+
+// TestComputeExpectedIntervalForCronSchedule_LeapDay pins the Copilot
+// finding on PR #2525 thread @ line 192: `0 0 29 2 *` (Feb 29) must not
+// produce a permanent doctor-red on cities whose check window starts
+// outside a leap-year window. The leap-year base (2024-01-01) means the
+// 366d window includes 2024-02-29, so Feb 29 schedules match once and
+// are classified as 366d (single-match-in-largest-window).
+func TestComputeExpectedIntervalForCronSchedule_LeapDay(t *testing.T) {
+	got, err := computeExpectedIntervalForCronSchedule("0 0 29 2 *")
+	if err != nil {
+		t.Fatalf("computeExpectedIntervalForCronSchedule(Feb 29): %v — leap-day schedule should not error", err)
+	}
+	if got != 366*24*time.Hour {
+		t.Fatalf("Feb 29 schedule = %s, want 366d (single match in leap-year 366d window)", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #2499.

## Root cause

`computeExpectedIntervalForCronSchedule` in `internal/doctor/checks_order_firing.go` scanned a fixed 1440-minute (24h) window from a hardcoded Tuesday base (`2026-05-12`). Any cron schedule that fires less often than daily (weekly, biweekly, monthly, yearly) matched zero minutes in that window → returned `cron schedule "<x>" has no firing minutes in a 24h window` → caller escalated to `StatusError` → whole `order-firing-current` check permanently red.

Trigger in the affected city: `mayor-pattern-miner` order with schedule `30 8 * * 1` (Mondays 08:30).

Consequence: the check could no longer signal real order stalls — staleness detection masked.

## Fix (Option A: progressive widening)

Scan the smallest window that captures at least 2 firings of the schedule, walking 24h → 7d → 31d → 366d. Return the min inter-fire gap, or fall back to the window length when only one firing is found. Only error out if even a 366-day window finds zero firings (genuinely never-fires schedule).

This preserves the precision of the original 24h scan for sub-daily schedules (most orders) while honestly representing the cadence of weekly/monthly/yearly schedules.

## Tests

5 new cron-schedule subtests covering weekly, biweekly, monthly, yearly + one no-match-in-year error-path test. 9 cron subtests + 1 error-path + 6 order-firing neighbors all pass.

`go build ./internal/doctor/...` + `go vet ./internal/doctor/...` clean.
