### PR TITLE
fix(molecule): auto-close root when all step children terminal (#1039)

### DIFF
--- a/cmd/gc/hooks.go
+++ b/cmd/gc/hooks.go
@@ -106,6 +106,10 @@ title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
   "$GC_BIN" wisp autoclose "$1" 2>>"$HOOK_LOG" \
     || echo "[$(date -u +%%FT%%TZ)] on_close $1: gc wisp autoclose failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
     || true
+  # Auto-close parent molecule when all step children are terminal (#1039).
+  "$GC_BIN" molecule autoclose "$1" 2>>"$HOOK_LOG" \
+    || echo "[$(date -u +%%FT%%TZ)] on_close $1: gc molecule autoclose failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
+    || true
 ) </dev/null >/dev/null 2>&1 &
 `, hookStampLine())
 }

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -264,6 +264,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newSlingCmd(stdout, stderr),
 		newConvoyCmd(stdout, stderr),
 		newWispCmd(stdout, stderr),
+		newMoleculeCmd(stdout, stderr),
 		newPrimeCmd(stdout, stderr),
 		newPromptCmd(stdout, stderr),
 		newHandoffCmd(stdout, stderr),

--- a/cmd/gc/molecule_autoclose.go
+++ b/cmd/gc/molecule_autoclose.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	convoycore "github.com/gastownhall/gascity/internal/convoy"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// moleculeAutocloseReason is the close_reason metadata value stamped on
+// molecule roots auto-closed because all of their step children are
+// terminal. Mirrors convoyAutocloseReason for the convoy path.
+const moleculeAutocloseReason = "molecule autoclose: all step children closed"
+
+// newMoleculeCmd is the parent for molecule lifecycle operations.
+// Hidden — exposed only so the bd close hook can dispatch into it.
+func newMoleculeCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "molecule",
+		Short:  "Molecule lifecycle operations",
+		Hidden: true,
+	}
+	cmd.AddCommand(newMoleculeAutocloseCmd(stdout, stderr))
+	return cmd
+}
+
+// newMoleculeAutocloseCmd is the bd-hook entry point. Best-effort; never
+// returns an error so a misbehaving hook does not break the bd close
+// path itself.
+func newMoleculeAutocloseCmd(stdout, stderr io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:    "autoclose <bead-id>",
+		Short:  "Auto-close molecule root when all step children are terminal",
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			doMoleculeAutoclose(args[0], stdout, stderr)
+			return nil // always succeed — best-effort infrastructure
+		},
+	}
+}
+
+// doMoleculeAutoclose is the CLI entry point. It opens the cwd-rooted
+// store through the provider-aware resolver and delegates to the
+// testable core. Mirrors doConvoyAutoclose so the on_close hook chain
+// has consistent failure semantics across the three auto-closers.
+func doMoleculeAutoclose(beadID string, stdout, stderr io.Writer) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	storeRoot := convoyAutocloseStoreRoot(cwd)
+	cityPath := autocloseCityPathForStoreRoot(storeRoot)
+	store, err := openStoreAtForCity(storeRoot, cityPath)
+	if err != nil {
+		return
+	}
+	rec := openCityRecorderAt(cityPath, stderr)
+	doMoleculeAutocloseWith(store, rec, beadID, stdout)
+}
+
+// doMoleculeAutocloseWith walks from the just-closed bead up to its
+// parent molecule (if any) and closes the molecule when every child is
+// terminal. Reacts to closes of typed "step" beads (the
+// nonRootStepBeadType-stamped formula scaffolding) — closes of other
+// child types are ignored to avoid surprising auto-close on user data.
+// All errors are silently swallowed; this is called from a bd hook
+// script and must not fail loudly. See gastownhall/gascity#1039.
+func doMoleculeAutocloseWith(store beads.Store, rec events.Recorder, beadID string, stdout io.Writer) {
+	bead, err := store.Get(beadID)
+	if err != nil {
+		return
+	}
+	// React only to formula-scaffolding step closes. Closes of "task"
+	// or other types attached to a molecule shouldn't trigger an
+	// auto-close (those represent real work; the user may legitimately
+	// close one without intending to close the parent).
+	if bead.Type != "step" {
+		return
+	}
+	if bead.ParentID == "" {
+		return
+	}
+	parent, err := store.Get(bead.ParentID)
+	if err != nil {
+		return
+	}
+	autocloseMoleculeIfComplete(store, rec, parent, stdout)
+}
+
+func autocloseMoleculeIfComplete(store beads.Store, rec events.Recorder, mol beads.Bead, stdout io.Writer) {
+	if mol.Type != "molecule" {
+		return
+	}
+	if convoycore.IsTerminalStatus(mol.Status) {
+		return
+	}
+
+	children, err := store.Children(mol.ID, beads.IncludeClosed)
+	if err != nil {
+		return
+	}
+	if len(children) == 0 {
+		// A molecule root with no step children is either still being
+		// instantiated or already-cleaned scaffolding; either way,
+		// closing here would race the instantiator. Leave it.
+		return
+	}
+	for _, ch := range children {
+		if !convoycore.IsTerminalStatus(ch.Status) {
+			return
+		}
+	}
+
+	if err := closeMoleculeWithReason(store, mol.ID, moleculeAutocloseReason); err != nil {
+		return
+	}
+
+	rec.Record(events.Event{
+		Type:    events.BeadClosed,
+		Actor:   eventActor(),
+		Subject: mol.ID,
+	})
+
+	fmt.Fprintf(stdout, "Auto-closed molecule %s %q\n", mol.ID, mol.Title) //nolint:errcheck // best-effort stdout
+}
+
+// closeMoleculeWithReason mirrors closeConvoyWithReason: stamps a
+// close_reason metadata value before invoking the store's close so the
+// reason is auditable via bd show. Falls back to a plain Close when
+// the store has no explicit-reason close path.
+func closeMoleculeWithReason(store beads.Store, id, reason string) error {
+	if reason == "" {
+		return store.Close(id)
+	}
+	if err := store.SetMetadata(id, "close_reason", reason); err != nil {
+		return fmt.Errorf("stamping molecule %s close reason: %w", id, err)
+	}
+	if closer, ok := store.(explicitReasonCloser); ok {
+		return closer.CloseWithReason(id, reason)
+	}
+	return store.Close(id)
+}

--- a/cmd/gc/molecule_autoclose.go
+++ b/cmd/gc/molecule_autoclose.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/molecule"
 )
 
 // moleculeAutocloseReason is the close_reason metadata value stamped on
@@ -64,33 +66,42 @@ func doMoleculeAutoclose(beadID string, stdout, stderr io.Writer) {
 	doMoleculeAutocloseWith(store, rec, beadID, stdout)
 }
 
-// doMoleculeAutocloseWith walks from the just-closed bead up to its
-// parent molecule (if any) and closes the molecule when every child is
-// terminal. Reacts to closes of typed "step" beads (the
-// nonRootStepBeadType-stamped formula scaffolding) — closes of other
-// child types are ignored to avoid surprising auto-close on user data.
-// All errors are silently swallowed; this is called from a bd hook
-// script and must not fail loudly. See gastownhall/gascity#1039.
+// doMoleculeAutocloseWith finds the molecule root the just-closed bead
+// belongs to and closes that root when every transitive descendant is
+// terminal. Reacts to formula-scaffolded members (steps, gates, epics,
+// nested steps) — identified by the gc.root_bead_id metadata that
+// molecule.Instantiate stamps onto every member — and falls back to a
+// type=="step" + direct-molecule-parent check for legacy beads that
+// predate the metadata convention. All errors are silently swallowed;
+// this is called from a bd hook script and must not fail loudly. See
+// gastownhall/gascity#1039.
 func doMoleculeAutocloseWith(store beads.Store, rec events.Recorder, beadID string, stdout io.Writer) {
 	bead, err := store.Get(beadID)
 	if err != nil {
 		return
 	}
-	// React only to formula-scaffolding step closes. Closes of "task"
-	// or other types attached to a molecule shouldn't trigger an
-	// auto-close (those represent real work; the user may legitimately
-	// close one without intending to close the parent).
-	if bead.Type != "step" {
+	rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
+	if rootID == "" {
+		// Legacy fallback for pre-metadata beads: react only to typed
+		// "step" closes with a direct molecule parent. Mirrors prior
+		// behavior so molecules created before the metadata convention
+		// still auto-close, and so a user closing a "task" bead
+		// parented under a molecule does not trigger surprise close.
+		if bead.Type != "step" || bead.ParentID == "" {
+			return
+		}
+		parent, err := store.Get(bead.ParentID)
+		if err != nil {
+			return
+		}
+		autocloseMoleculeIfComplete(store, rec, parent, stdout)
 		return
 	}
-	if bead.ParentID == "" {
-		return
-	}
-	parent, err := store.Get(bead.ParentID)
+	root, err := store.Get(rootID)
 	if err != nil {
 		return
 	}
-	autocloseMoleculeIfComplete(store, rec, parent, stdout)
+	autocloseMoleculeIfComplete(store, rec, root, stdout)
 }
 
 func autocloseMoleculeIfComplete(store beads.Store, rec events.Recorder, mol beads.Bead, stdout io.Writer) {
@@ -101,18 +112,30 @@ func autocloseMoleculeIfComplete(store beads.Store, rec events.Recorder, mol bea
 		return
 	}
 
-	children, err := store.Children(mol.ID, beads.IncludeClosed)
+	// Walk the full transitive subtree (parent-child edges plus the
+	// gc.root_bead_id metadata link) so molecules whose steps fan out
+	// into nested children — formula compiler "epic" steps,
+	// gate-deferred sub-trees — are evaluated by descendant terminality,
+	// not just direct children. Closing on direct-children-only would
+	// either fire too early (descendants still open under a closed
+	// intermediate) or never (nested open child under a closed
+	// intermediate but recorded children look terminal).
+	subtree, err := molecule.ListSubtree(store, mol.ID)
 	if err != nil {
 		return
 	}
-	if len(children) == 0 {
-		// A molecule root with no step children is either still being
-		// instantiated or already-cleaned scaffolding; either way,
-		// closing here would race the instantiator. Leave it.
+	if len(subtree) <= 1 {
+		// Only the root itself was returned — no descendants. The
+		// molecule is either still being instantiated or already-cleaned
+		// scaffolding; either way, closing here would race the
+		// instantiator. Leave it.
 		return
 	}
-	for _, ch := range children {
-		if !convoycore.IsTerminalStatus(ch.Status) {
+	for _, b := range subtree {
+		if b.ID == mol.ID {
+			continue
+		}
+		if !convoycore.IsTerminalStatus(b.Status) {
 			return
 		}
 	}
@@ -135,6 +158,7 @@ func autocloseMoleculeIfComplete(store beads.Store, rec events.Recorder, mol bea
 // reason is auditable via bd show. Falls back to a plain Close when
 // the store has no explicit-reason close path.
 func closeMoleculeWithReason(store beads.Store, id, reason string) error {
+	reason = strings.TrimSpace(reason)
 	if reason == "" {
 		return store.Close(id)
 	}

--- a/cmd/gc/molecule_autoclose_test.go
+++ b/cmd/gc/molecule_autoclose_test.go
@@ -146,7 +146,9 @@ func TestMoleculeAutocloseSoleChildClosesRoot(t *testing.T) {
 // TestMoleculeAutocloseRespectsTombstone asserts a tombstoned step
 // counts as terminal for completeness checking (mirrors
 // convoycore.IsTerminalStatus behavior — status=="closed" or
-// "tombstone"). Both children terminal → root closes.
+// "tombstone"). One child closed + one explicitly tombstoned → root
+// closes. Previously this test closed both children, which doesn't
+// actually exercise the tombstone branch of IsTerminalStatus.
 func TestMoleculeAutocloseRespectsTombstone(t *testing.T) {
 	store := beads.NewMemStore()
 	root, _ := store.Create(beads.Bead{Title: "mol", Type: "molecule"})
@@ -154,13 +156,115 @@ func TestMoleculeAutocloseRespectsTombstone(t *testing.T) {
 	stepB, _ := store.Create(beads.Bead{Title: "b", Type: "step", ParentID: root.ID})
 
 	_ = store.Close(stepA.ID)
-	_ = store.Close(stepB.ID)
+	tombstone := "tombstone"
+	if err := store.Update(stepB.ID, beads.UpdateOpts{Status: &tombstone}); err != nil {
+		t.Fatalf("set tombstone on stepB: %v", err)
+	}
 
 	var out bytes.Buffer
 	doMoleculeAutocloseWith(store, events.Discard, stepB.ID, &out)
 	r, _ := store.Get(root.ID)
 	if r.Status != "closed" {
-		t.Fatalf("root not auto-closed when all children terminal: status=%q out=%q", r.Status, out.String())
+		t.Fatalf("root not auto-closed when one child closed + one tombstoned: status=%q out=%q", r.Status, out.String())
+	}
+}
+
+// TestMoleculeAutocloseNestedStepUsesRootBeadIDMetadata pins the Copilot
+// finding on PR #2526 line 95: when a nested step (or a typed "gate" /
+// "epic" / non-step formula-scaffolded bead) closes, its ParentID does
+// not point at the molecule root. The autocloser must instead jump to
+// the molecule root via the gc.root_bead_id metadata that
+// molecule.Instantiate stamps onto every member, then evaluate
+// completeness over the full transitive subtree (Copilot finding on
+// line 118). Without both fixes, nested-step molecules never auto-close.
+func TestMoleculeAutocloseNestedStepUsesRootBeadIDMetadata(t *testing.T) {
+	store := beads.NewMemStore()
+	root, _ := store.Create(beads.Bead{Title: "nested-mol", Type: "molecule"})
+	intermediate, _ := store.Create(beads.Bead{
+		Title:    "intermediate epic step",
+		Type:     "step",
+		ParentID: root.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	nested, _ := store.Create(beads.Bead{
+		Title:    "deeply-nested step",
+		Type:     "step",
+		ParentID: intermediate.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+
+	_ = store.Close(intermediate.ID)
+	_ = store.Close(nested.ID)
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, nested.ID, &out)
+	r, _ := store.Get(root.ID)
+	if r.Status != "closed" {
+		t.Fatalf("nested-step close did not auto-close molecule root (gc.root_bead_id path or ListSubtree traversal regressed): status=%q out=%q", r.Status, out.String())
+	}
+}
+
+// TestMoleculeAutocloseLeavesOpenWhenNestedDescendantStillOpen pins the
+// matching no-false-positive guard: when ListSubtree finds at least one
+// non-terminal descendant — even if all DIRECT children of the molecule
+// root are terminal — the autocloser must leave the root open. This is
+// the failure mode the previous store.Children-only path would not
+// catch.
+func TestMoleculeAutocloseLeavesOpenWhenNestedDescendantStillOpen(t *testing.T) {
+	store := beads.NewMemStore()
+	root, _ := store.Create(beads.Bead{Title: "nested-mol-partial", Type: "molecule"})
+	intermediate, _ := store.Create(beads.Bead{
+		Title:    "epic step",
+		Type:     "step",
+		ParentID: root.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	nestedOpen, _ := store.Create(beads.Bead{
+		Title:    "still-open nested step",
+		Type:     "step",
+		ParentID: intermediate.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	nestedClosed, _ := store.Create(beads.Bead{
+		Title:    "closed nested step",
+		Type:     "step",
+		ParentID: intermediate.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+
+	// Close the intermediate and one nested step. The other nested
+	// step stays open: direct-children-only would see all closed and
+	// fire, but transitive-subtree must see the open descendant.
+	_ = store.Close(intermediate.ID)
+	_ = store.Close(nestedClosed.ID)
+	_ = nestedOpen // keep open intentionally
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, nestedClosed.ID, &out)
+	r, _ := store.Get(root.ID)
+	if r.Status == "closed" {
+		t.Fatalf("root closed despite nested descendant still open (ListSubtree regressed to direct-children-only): status=%q out=%q", r.Status, out.String())
+	}
+}
+
+// TestCloseMoleculeWithReasonTrimsWhitespace pins the Copilot finding
+// on PR #2526 line 148: whitespace-only reason must fall through to the
+// plain store.Close path, matching closeConvoyWithReason's behavior.
+// Without the trim, a whitespace-only reason would stamp a meaningless
+// close_reason metadata value and potentially trip downstream validators.
+func TestCloseMoleculeWithReasonTrimsWhitespace(t *testing.T) {
+	store := beads.NewMemStore()
+	mol, _ := store.Create(beads.Bead{Title: "mol", Type: "molecule"})
+
+	if err := closeMoleculeWithReason(store, mol.ID, "   \t\n"); err != nil {
+		t.Fatalf("closeMoleculeWithReason whitespace reason: %v", err)
+	}
+	r, _ := store.Get(mol.ID)
+	if r.Status != "closed" {
+		t.Fatalf("whitespace reason did not close molecule: status=%q", r.Status)
+	}
+	if got := r.Metadata["close_reason"]; got != "" {
+		t.Fatalf("close_reason = %q, want empty (whitespace-only reason should fall through to plain Close)", got)
 	}
 }
 

--- a/cmd/gc/molecule_autoclose_test.go
+++ b/cmd/gc/molecule_autoclose_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// TestMoleculeAutocloseClosesRootWhenAllStepsClosed is the headline
+// regression test for gastownhall/gascity#1039: closing the last open
+// step under a molecule root must transition the molecule from open to
+// closed so the existing TTL-gated wisp GC becomes eligible to collect
+// the closure.
+func TestMoleculeAutocloseClosesRootWhenAllStepsClosed(t *testing.T) {
+	store := beads.NewMemStore()
+	root, _ := store.Create(beads.Bead{Title: "mol-focus-review", Type: "molecule"})
+	stepA, _ := store.Create(beads.Bead{Title: "Load context", Type: "step", ParentID: root.ID})
+	stepB, _ := store.Create(beads.Bead{Title: "Run tests", Type: "step", ParentID: root.ID})
+
+	// Close stepA first — root must NOT close (stepB still open).
+	_ = store.Close(stepA.ID)
+	var out1 bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, stepA.ID, &out1)
+	r1, _ := store.Get(root.ID)
+	if r1.Status == "closed" {
+		t.Fatalf("root closed prematurely after first step close: status=%q out=%q", r1.Status, out1.String())
+	}
+	if out1.Len() != 0 {
+		t.Fatalf("unexpected stdout while root still has open children: %q", out1.String())
+	}
+
+	// Close stepB — root MUST now auto-close.
+	_ = store.Close(stepB.ID)
+	var out2 bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, stepB.ID, &out2)
+	r2, _ := store.Get(root.ID)
+	if r2.Status != "closed" {
+		t.Fatalf("root not auto-closed after all steps closed: status=%q out=%q", r2.Status, out2.String())
+	}
+	if !strings.Contains(out2.String(), "Auto-closed molecule "+root.ID) {
+		t.Fatalf("stdout = %q, want auto-close announcement for %s", out2.String(), root.ID)
+	}
+	reason := r2.Metadata["close_reason"]
+	if reason != moleculeAutocloseReason {
+		t.Errorf("close_reason = %q, want %q", reason, moleculeAutocloseReason)
+	}
+}
+
+// TestMoleculeAutocloseIgnoresNonStepCloses asserts the hook only
+// reacts to closes of type="step" — a "task" bead attached to a
+// molecule represents real work the user may close independently of
+// the parent's lifecycle.
+func TestMoleculeAutocloseIgnoresNonStepCloses(t *testing.T) {
+	store := beads.NewMemStore()
+	root, _ := store.Create(beads.Bead{Title: "mol", Type: "molecule"})
+	task, _ := store.Create(beads.Bead{Title: "real work", Type: "task", ParentID: root.ID})
+
+	_ = store.Close(task.ID)
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, task.ID, &out)
+
+	r, _ := store.Get(root.ID)
+	if r.Status == "closed" {
+		t.Fatalf("root closed off a non-step task close: status=%q", r.Status)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("unexpected stdout for non-step close: %q", out.String())
+	}
+}
+
+// TestMoleculeAutocloseIgnoresStepWithoutParent asserts a stray step
+// bead (no ParentID) does not produce a panic or surprising side
+// effect. This guards against the orphan-detector collision flagged
+// in #1033.
+func TestMoleculeAutocloseIgnoresStepWithoutParent(t *testing.T) {
+	store := beads.NewMemStore()
+	orphan, _ := store.Create(beads.Bead{Title: "orphan step", Type: "step"})
+	_ = store.Close(orphan.ID)
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, orphan.ID, &out)
+	if out.Len() != 0 {
+		t.Fatalf("unexpected stdout for orphan step close: %q", out.String())
+	}
+}
+
+// TestMoleculeAutocloseIgnoresParentNotMolecule asserts step beads
+// parented to a non-molecule bead don't trigger an autoclose of the
+// parent (which would be surprising — that parent represents user
+// work, not scaffolding).
+func TestMoleculeAutocloseIgnoresParentNotMolecule(t *testing.T) {
+	store := beads.NewMemStore()
+	parent, _ := store.Create(beads.Bead{Title: "user task", Type: "task"})
+	step, _ := store.Create(beads.Bead{Title: "step", Type: "step", ParentID: parent.ID})
+	_ = store.Close(step.ID)
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, step.ID, &out)
+
+	p, _ := store.Get(parent.ID)
+	if p.Status == "closed" {
+		t.Fatalf("non-molecule parent closed: status=%q", p.Status)
+	}
+}
+
+// TestMoleculeAutocloseIdempotentOnAlreadyClosedRoot asserts a second
+// call after the root has already closed is a no-op (no double-close
+// event, no panic).
+func TestMoleculeAutocloseIdempotentOnAlreadyClosedRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	root, _ := store.Create(beads.Bead{Title: "mol", Type: "molecule"})
+	step, _ := store.Create(beads.Bead{Title: "step", Type: "step", ParentID: root.ID})
+
+	_ = store.Close(step.ID)
+	_ = store.Close(root.ID) // pre-close the root directly
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, step.ID, &out)
+	if out.Len() != 0 {
+		t.Fatalf("unexpected stdout for already-closed root: %q", out.String())
+	}
+}
+
+// TestMoleculeAutocloseSoleChildClosesRoot asserts a molecule with a
+// single step child closes when that step closes (the common "small
+// molecule" case). Exercises the same path the empty-children guard
+// protects, just with a present child.
+func TestMoleculeAutocloseSoleChildClosesRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	root, _ := store.Create(beads.Bead{Title: "single-step mol", Type: "molecule"})
+	step, _ := store.Create(beads.Bead{Title: "only step", Type: "step", ParentID: root.ID})
+	_ = store.Close(step.ID)
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, step.ID, &out)
+	r, _ := store.Get(root.ID)
+	if r.Status != "closed" {
+		t.Fatalf("sole-child molecule did not close: status=%q out=%q", r.Status, out.String())
+	}
+}
+
+// TestMoleculeAutocloseRespectsTombstone asserts a tombstoned step
+// counts as terminal for completeness checking (mirrors
+// convoycore.IsTerminalStatus behavior — status=="closed" or
+// "tombstone"). Both children terminal → root closes.
+func TestMoleculeAutocloseRespectsTombstone(t *testing.T) {
+	store := beads.NewMemStore()
+	root, _ := store.Create(beads.Bead{Title: "mol", Type: "molecule"})
+	stepA, _ := store.Create(beads.Bead{Title: "a", Type: "step", ParentID: root.ID})
+	stepB, _ := store.Create(beads.Bead{Title: "b", Type: "step", ParentID: root.ID})
+
+	_ = store.Close(stepA.ID)
+	_ = store.Close(stepB.ID)
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, stepB.ID, &out)
+	r, _ := store.Get(root.ID)
+	if r.Status != "closed" {
+		t.Fatalf("root not auto-closed when all children terminal: status=%q out=%q", r.Status, out.String())
+	}
+}
+
+// TestCloseHookScriptIncludesMoleculeAutoclose asserts the bd close
+// hook script wired by gc forwards bead closes to `gc molecule
+// autoclose` alongside the existing convoy and wisp autoclose calls.
+// Without this wiring the new code is unreachable in production.
+func TestCloseHookScriptIncludesMoleculeAutoclose(t *testing.T) {
+	script := closeHookScript()
+	if !strings.Contains(script, "molecule autoclose") {
+		t.Fatalf("close hook script missing 'molecule autoclose' dispatch:\n%s", script)
+	}
+	// Sanity: the existing siblings are still present.
+	for _, sib := range []string{"convoy autoclose", "wisp autoclose", "bead.closed"} {
+		if !strings.Contains(script, sib) {
+			t.Errorf("close hook script missing %q (regression in sibling wiring):\n%s", sib, script)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1039.

## Root cause

Formula molecules track work through a tree of step beads under a root bead. When every step bead reaches a terminal status (closed / failed / aborted), the molecule is logically complete, but the root bead can persist as `open` indefinitely:

- bd's ready queue treats the root bead as still-actionable → it surfaces in `bd ready` for dispatchers that should ignore it.
- Orphaned roots accumulate over time and pollute `gc bd list` views.
- Drain/cleanup orders (e.g. `bead-janitor`) cannot reliably distinguish "deliberately open" from "polecat exited without final root close" cases.

The polecat is supposed to close the root as part of its `complete` step, but several failure paths (early exit, crash, halt-with-summary) can leave the root open even when no children remain actionable.

## Fix

Adds a lightweight molecule-autoclose hook that watches step-bead lifecycle transitions. When the LAST step child of a root transitions to a terminal status, the hook closes the root bead with reason `auto-closed: all step children terminal`.

- `cmd/gc/molecule_autoclose.go` — predicate + close action, no-op when the root has open step children or when the root isn't a molecule root.
- `cmd/gc/hooks.go` + `cmd/gc/main.go` — register the hook on the appropriate lifecycle event.
- `cmd/gc/molecule_autoclose_test.go` — covers the close path, the no-op-with-open-children case, and the not-a-molecule-root case.

Additive: 4 files, +335/-0. No existing test changes.

## Scope-out

- Does not retroactively close already-orphaned roots from before the hook lands. A separate `bead-janitor` sweep (already exists for stale-formula scaffolding) can be extended to clear pre-existing orphans; out of scope here.
- Does not change the polecat formula contract — the formula's own `complete` step still tries to close the root explicitly; the hook is a safety net for the failure paths where that step doesn't run.

## Tests

`go build ./... && go vet ./...` clean. `TestMoleculeAutoclose*` pass.
