### PR TITLE
fix(reconciler): keep named handoffs out of scale demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -819,6 +819,9 @@ func defaultScaleCheckTargetForAgent(
 	return target
 }
 
+// defaultScaleCheckCounts reports ready, unassigned, routed work as fresh
+// generic pool demand. Assigned beads are handled by assigned-work collection
+// and named-session demand so they are intentionally excluded here.
 func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int, map[string]bool, []error) {
 	counts := make(map[string]int, len(targets))
 	if len(targets) == 0 {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -871,22 +871,13 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			}
 		}
 		for _, b := range ready {
+			if strings.TrimSpace(b.Assignee) != "" {
+				continue
+			}
 			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
-			if _, ok := group.templates[template]; !ok {
-				continue
+			if _, ok := group.templates[template]; ok {
+				counts[template]++
 			}
-			// Beads with assignee=="" (newly-slung routed work) or
-			// assignee==template (pool→pool handoff pattern, where the
-			// pool template name is written into Assignee but no session
-			// by that name exists) are genuine pool demand for this
-			// template. Beads with a session-identity assignee are
-			// already counted by collectAssignedWorkBeadsWithStores
-			// (Path 1) and must be skipped here to avoid double-counting.
-			assignee := strings.TrimSpace(b.Assignee)
-			if assignee != "" && assignee != template {
-				continue
-			}
-			counts[template]++
 		}
 	}
 	return counts, partialTemplates, errs

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4091,72 +4091,95 @@ func TestBuildDesiredState_OnDemandNamedSession_DirectAssigneeMaterializes(t *te
 }
 
 func TestBuildDesiredState_RigOnDemandNamedSessionAssigneeWithRouteMaterializesNamedOnly(t *testing.T) {
-	cityPath := t.TempDir()
-	rigPath := filepath.Join(cityPath, "riga")
-	if err := os.MkdirAll(rigPath, 0o755); err != nil {
-		t.Fatalf("create rig dir: %v", err)
-	}
-	cityStore := beads.NewMemStore()
-	rigStore := beads.NewMemStore()
-	if _, err := rigStore.Create(beads.Bead{
-		Title:    "refinery handoff",
-		Type:     "task",
-		Status:   "open",
-		Assignee: "riga/refinery",
-		Metadata: map[string]string{
-			"gc.routed_to": "riga/refinery",
+	tests := []struct {
+		name     string
+		metadata map[string]string
+	}{
+		{
+			name: "retained route metadata",
+			metadata: map[string]string{
+				"gc.routed_to": "riga/refinery",
+			},
 		},
-	}); err != nil {
-		t.Fatalf("create rig work: %v", err)
-	}
-	cfg := &config.City{
-		Workspace: config.Workspace{Name: "test-city"},
-		Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
-		Agents: []config.Agent{{
-			Name:              "refinery",
-			Dir:               "riga",
-			StartCommand:      "true",
-			MaxActiveSessions: intPtr(1),
-			WorkQuery:         "printf ''",
-		}},
-		NamedSessions: []config.NamedSession{{
-			Template: "refinery",
-			Dir:      "riga",
-			Mode:     "on_demand",
-		}},
+		{
+			name: "cleared route metadata",
+			metadata: map[string]string{
+				"gc.routed_to": "",
+			},
+		},
+		{
+			name: "absent route metadata",
+		},
 	}
 
-	dsResult := buildDesiredStateWithSessionBeads(
-		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
-		cityStore, map[string]beads.Store{"riga": rigStore}, nil, nil, io.Discard,
-	)
-	if !dsResult.NamedSessionDemand["riga/refinery"] {
-		t.Fatal("NamedSessionDemand[riga/refinery] = false for direct named-session assignee")
-	}
-	if got := dsResult.ScaleCheckCounts["riga/refinery"]; got != 0 {
-		t.Fatalf("ScaleCheckCounts[riga/refinery] = %d, want 0 for assigned named-session handoff", got)
-	}
-	var refineryEntries []TemplateParams
-	for _, tp := range dsResult.State {
-		if tp.ConfiguredNamedIdentity == "riga/refinery" || tp.TemplateName == "riga/refinery" {
-			refineryEntries = append(refineryEntries, tp)
-		}
-	}
-	if len(refineryEntries) != 1 {
-		t.Fatalf("refinery desired entries = %d, want exactly one named session: %+v", len(refineryEntries), refineryEntries)
-	}
-	refinery := refineryEntries[0]
-	if refinery.ConfiguredNamedIdentity != "riga/refinery" {
-		t.Fatalf("ConfiguredNamedIdentity = %q, want riga/refinery", refinery.ConfiguredNamedIdentity)
-	}
-	if refinery.PoolSlot != 0 {
-		t.Fatalf("PoolSlot = %d, want 0 for named session", refinery.PoolSlot)
-	}
-	if got := refinery.Env["GC_ALIAS"]; got != "riga/refinery" {
-		t.Fatalf("GC_ALIAS = %q, want riga/refinery", got)
-	}
-	if got := refinery.Env["GC_TEMPLATE"]; got != "riga/refinery" {
-		t.Fatalf("GC_TEMPLATE = %q, want riga/refinery", got)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			rigPath := filepath.Join(cityPath, "riga")
+			if err := os.MkdirAll(rigPath, 0o755); err != nil {
+				t.Fatalf("create rig dir: %v", err)
+			}
+			cityStore := beads.NewMemStore()
+			rigStore := beads.NewMemStore()
+			if _, err := rigStore.Create(beads.Bead{
+				Title:    "refinery handoff",
+				Type:     "task",
+				Status:   "open",
+				Assignee: "riga/refinery",
+				Metadata: tc.metadata,
+			}); err != nil {
+				t.Fatalf("create rig work: %v", err)
+			}
+			cfg := &config.City{
+				Workspace: config.Workspace{Name: "test-city"},
+				Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
+				Agents: []config.Agent{{
+					Name:              "refinery",
+					Dir:               "riga",
+					StartCommand:      "true",
+					MaxActiveSessions: intPtr(1),
+					WorkQuery:         "printf ''",
+				}},
+				NamedSessions: []config.NamedSession{{
+					Template: "refinery",
+					Dir:      "riga",
+					Mode:     "on_demand",
+				}},
+			}
+
+			dsResult := buildDesiredStateWithSessionBeads(
+				"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+				cityStore, map[string]beads.Store{"riga": rigStore}, nil, nil, io.Discard,
+			)
+			if !dsResult.NamedSessionDemand["riga/refinery"] {
+				t.Fatal("NamedSessionDemand[riga/refinery] = false for direct named-session assignee")
+			}
+			if got := dsResult.ScaleCheckCounts["riga/refinery"]; got != 0 {
+				t.Fatalf("ScaleCheckCounts[riga/refinery] = %d, want 0 for assigned named-session handoff", got)
+			}
+			var refineryEntries []TemplateParams
+			for _, tp := range dsResult.State {
+				if tp.ConfiguredNamedIdentity == "riga/refinery" || tp.TemplateName == "riga/refinery" {
+					refineryEntries = append(refineryEntries, tp)
+				}
+			}
+			if len(refineryEntries) != 1 {
+				t.Fatalf("refinery desired entries = %d, want exactly one named session: %+v", len(refineryEntries), refineryEntries)
+			}
+			refinery := refineryEntries[0]
+			if refinery.ConfiguredNamedIdentity != "riga/refinery" {
+				t.Fatalf("ConfiguredNamedIdentity = %q, want riga/refinery", refinery.ConfiguredNamedIdentity)
+			}
+			if refinery.PoolSlot != 0 {
+				t.Fatalf("PoolSlot = %d, want 0 for named session", refinery.PoolSlot)
+			}
+			if got := refinery.Env["GC_ALIAS"]; got != "riga/refinery" {
+				t.Fatalf("GC_ALIAS = %q, want riga/refinery", got)
+			}
+			if got := refinery.Env["GC_TEMPLATE"]; got != "riga/refinery" {
+				t.Fatalf("GC_TEMPLATE = %q, want riga/refinery", got)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -387,25 +387,13 @@ func TestDefaultScaleCheckCountsUsesCachedReadyReadModel(t *testing.T) {
 	}
 }
 
-// TestDefaultScaleCheckCountsCountsBeadsAssignedToPoolTemplate pins the
-// regression fix for gastownhall/gascity#1991: a bead with status=open and
-// assignee==<pool-template> + gc.routed_to==<pool-template> (the pool→pool
-// handoff write pattern used by gas-town pack formulas, e.g.
-// mol-polecat-work.toml's submit-and-exit) must produce non-zero demand for
-// the matching template. Before the fix, the Assignee!="" filter in
-// defaultScaleCheckCounts dropped this bead, leaving "assignedWorkBeads: 0"
-// indefinitely and stranding the next pool in the handoff chain. After the
-// fix, assignee==template is treated as pool demand because no session by
-// that name exists; only session-identity assignees (which Path 1 counts)
-// are excluded here.
-func TestDefaultScaleCheckCountsCountsBeadsAssignedToPoolTemplate(t *testing.T) {
+func TestDefaultScaleCheckCountsCountsUnassignedRoutedPoolWork(t *testing.T) {
 	const template = "gascity/reviewer"
 	backing := beads.NewMemStore()
 	if _, err := backing.Create(beads.Bead{
-		Title:    "pool→pool handoff routed work",
-		Type:     "task",
-		Status:   "open",
-		Assignee: template,
+		Title:  "routed pool work",
+		Type:   "task",
+		Status: "open",
 		Metadata: map[string]string{
 			"gc.routed_to": template,
 		},
@@ -426,16 +414,46 @@ func TestDefaultScaleCheckCountsCountsBeadsAssignedToPoolTemplate(t *testing.T) 
 		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
 	}
 	if got := counts[template]; got != 1 {
-		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1 (#1991 regression: pool→pool handoff bead must count as demand)", template, got)
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1", template, got)
+	}
+}
+
+func TestDefaultScaleCheckCountsDoesNotTreatTemplateAssigneeAsDemand(t *testing.T) {
+	const template = "gascity/reviewer"
+	backing := beads.NewMemStore()
+	if _, err := backing.Create(beads.Bead{
+		Title:    "assigned routed work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: template,
+		Metadata: map[string]string{
+			"gc.routed_to": template,
+		},
+	}); err != nil {
+		t.Fatalf("create assigned bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts[template]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0 (assignee must be a concrete session identity, never pool demand)", template, got)
 	}
 }
 
 // TestDefaultScaleCheckCountsExcludesBeadsAssignedToSession pins the
 // invariant that beads with assignee==<session-id> (Path 1 territory) are
 // NOT counted by defaultScaleCheckCounts, to avoid double-counting when
-// collectAssignedWorkBeadsWithStores has already counted them. Companion to
-// TestDefaultScaleCheckCountsCountsBeadsAssignedToPoolTemplate: together
-// they cover the asymmetry table from issue #1991.
+// collectAssignedWorkBeadsWithStores has already counted them.
 func TestDefaultScaleCheckCountsExcludesBeadsAssignedToSession(t *testing.T) {
 	const template = "gascity/reviewer"
 	backing := beads.NewMemStore()
@@ -4069,6 +4087,76 @@ func TestBuildDesiredState_OnDemandNamedSession_DirectAssigneeMaterializes(t *te
 	}
 	if !found {
 		t.Fatal("direct assignee should materialize on-demand named session")
+	}
+}
+
+func TestBuildDesiredState_RigOnDemandNamedSessionAssigneeWithRouteMaterializesNamedOnly(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("create rig dir: %v", err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	if _, err := rigStore.Create(beads.Bead{
+		Title:    "refinery handoff",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "riga/refinery",
+		Metadata: map[string]string{
+			"gc.routed_to": "riga/refinery",
+		},
+	}); err != nil {
+		t.Fatalf("create rig work: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			Dir:               "riga",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+			Dir:      "riga",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"riga": rigStore}, nil, nil, io.Discard,
+	)
+	if !dsResult.NamedSessionDemand["riga/refinery"] {
+		t.Fatal("NamedSessionDemand[riga/refinery] = false for direct named-session assignee")
+	}
+	if got := dsResult.ScaleCheckCounts["riga/refinery"]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[riga/refinery] = %d, want 0 for assigned named-session handoff", got)
+	}
+	var refineryEntries []TemplateParams
+	for _, tp := range dsResult.State {
+		if tp.ConfiguredNamedIdentity == "riga/refinery" || tp.TemplateName == "riga/refinery" {
+			refineryEntries = append(refineryEntries, tp)
+		}
+	}
+	if len(refineryEntries) != 1 {
+		t.Fatalf("refinery desired entries = %d, want exactly one named session: %+v", len(refineryEntries), refineryEntries)
+	}
+	refinery := refineryEntries[0]
+	if refinery.ConfiguredNamedIdentity != "riga/refinery" {
+		t.Fatalf("ConfiguredNamedIdentity = %q, want riga/refinery", refinery.ConfiguredNamedIdentity)
+	}
+	if refinery.PoolSlot != 0 {
+		t.Fatalf("PoolSlot = %d, want 0 for named session", refinery.PoolSlot)
+	}
+	if got := refinery.Env["GC_ALIAS"]; got != "riga/refinery" {
+		t.Fatalf("GC_ALIAS = %q, want riga/refinery", got)
+	}
+	if got := refinery.Env["GC_TEMPLATE"]; got != "riga/refinery" {
+		t.Fatalf("GC_TEMPLATE = %q, want riga/refinery", got)
 	}
 }
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1063,13 +1063,11 @@ func TestBuiltInSlingPoolRouteContractUsesMetadataOnly(t *testing.T) {
 	if got := counts["saitoc/polecat"]; got != 0 {
 		t.Fatalf("polecat scale count after refinery handoff with stale pool label = %d, want 0", got)
 	}
-	// #1991: a bead with assignee==<pool-template> + gc.routed_to==<pool-template>
-	// is the documented pool→pool handoff pattern (no session by the pool template
-	// name exists), so it MUST register as demand for that template. The earlier
-	// "want 0" pinned the broken pre-#1991 behavior where defaultScaleCheckCounts
-	// filtered out any non-empty Assignee and stranded the next pool.
-	if got := counts["saitoc/refinery"]; got != 1 {
-		t.Fatalf("refinery generic scale count for pool→pool handoff = %d, want 1 (#1991)", got)
+	// A pool-template assignee is not concrete ownership. Generic scale demand
+	// stays strictly unassigned+routed; callers that want pool demand must clear
+	// Assignee and set gc.routed_to.
+	if got := counts["saitoc/refinery"]; got != 0 {
+		t.Fatalf("refinery generic scale count for assigned handoff = %d, want 0", got)
 	}
 }
 

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -163,6 +163,13 @@ the work-query form appends
 `Agent.PoolName` when set and `Agent.QualifiedName()` otherwise, so
 pool instances and pool templates land on the same routed queue.
 
+Supported handoff forms are intentionally distinct. Generic pool demand is
+ready work with `assignee=""` and `gc.routed_to=<target>`; assigning the
+pool template itself is not pool demand. Direct named-session delivery is
+ready work with `assignee=<named-session-identity>` and no generic route
+metadata, so the reconciler does not also treat the handoff as generic pool
+demand.
+
 The shared predicate is the agreement substrate. Failure envelopes
 intentionally differ: the worker path suppresses `bd ready` stderr and
 returns `[]` so a session exits cleanly, while the count form propagates

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -470,7 +470,7 @@ func TestPolecatFormulaSignalsRefineryAfterReassign(t *testing.T) {
 	assertContainsInOrder(t, body,
 		"**5. Reassign to refinery:**",
 		refineryTarget,
-		`gc bd update {{issue}} --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"`,
+		`gc bd update {{issue}} --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""`,
 		"**6. Signal refinery to check for work immediately",
 		refineryTarget,
 		`gc session wake "$REFINERY_TARGET" || true`,
@@ -486,6 +486,9 @@ func TestPolecatFormulaSignalsRefineryAfterReassign(t *testing.T) {
 		if strings.Contains(body, bad) {
 			t.Fatalf("polecat formula must preserve refinery handoff diagnostics and pass a nudge message; found %q", bad)
 		}
+	}
+	if strings.Contains(body, `--assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"`) {
+		t.Fatal("polecat formula must clear gc.routed_to instead of routing to the refinery named session")
 	}
 }
 
@@ -554,11 +557,14 @@ func TestPolecatPromptDoneSequenceSignalsRefinery(t *testing.T) {
 	assertContainsInOrder(t, body,
 		"## FINAL REMINDER: RUN THE DONE SEQUENCE",
 		`REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"`,
-		`gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"`,
+		`gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""`,
 		`gc session wake "$REFINERY_TARGET" || true`,
 		`gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true`,
 		`gc runtime drain-ack`,
 	)
+	if strings.Contains(body, `--assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"`) {
+		t.Fatal("polecat prompt must clear gc.routed_to instead of routing to the refinery named session")
+	}
 	if !strings.Contains(body, "Done sequence (push, set metadata, reassign, wake refinery, nudge refinery, `gc runtime drain-ack`, exit)") {
 		t.Fatalf("polecat quick reference must include the refinery wake+nudge handoff")
 	}
@@ -1766,9 +1772,7 @@ func TestGastownPromptRoutedToHandoffIsFullyQualifiedUnderBinding(t *testing.T) 
 			rel:          "packs/gastown/agents/polecat/prompt.template.md",
 			agentName:    rigName + "/" + bindingPrefix + "furiosa",
 			templateName: "polecat",
-			wantRoutes: map[string]string{
-				`"${GC_RIG:+$GC_RIG/}gastown.refinery"`: rigName + "/" + bindingPrefix + "refinery",
-			},
+			wantRoutes:   map[string]string{},
 		},
 		{
 			rel:          "packs/gastown/agents/witness/prompt.template.md",

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -216,7 +216,7 @@ gc bd update <work-bead> \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"
-gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"
+gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
 gc session wake "$REFINERY_TARGET" || true
 gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
 gc runtime drain-ack

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -318,8 +318,9 @@ the workspace is the rig. Writing a rendered empty rig prefix produces
 `/{{binding_prefix}}refinery` and strands beads outside the refinery pool.
 
 Set `assignee` to the configured refinery named-session identity and clear
-`gc.routed_to` so a stale route left by an earlier refinery rejection cannot
-turn this direct named-session delivery back into generic pool routing.
+`gc.routed_to` because the direct assignment is the handoff. Generic pool
+demand is represented by unassigned work with `gc.routed_to=<target>`, so
+named-session work should not retain pool-demand metadata.
 
 The refinery will pick this up, rebase onto {{base_branch}}, run tests,
 merge, and close the bead. If there's a conflict, the refinery puts the

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -308,7 +308,7 @@ the PR is open and matches the branch, base, and origin repository.
 **5. Reassign to refinery:**
 ```bash
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
-gc bd update {{issue}} --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"
+gc bd update {{issue}} --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
 ```
 
 `${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery` resolves to
@@ -317,10 +317,9 @@ or `{{binding_prefix}}refinery` when running in an HQ-only city where
 the workspace is the rig. Writing a rendered empty rig prefix produces
 `/{{binding_prefix}}refinery` and strands beads outside the refinery pool.
 
-Update both `assignee` AND `gc.routed_to` so the reconciler stops
-counting this bead for the polecat pool and starts counting it for
-the refinery pool. Without updating `gc.routed_to`, the reconciler
-spawns phantom polecats that can't claim the bead.
+Set `assignee` to the configured refinery named-session identity and clear
+`gc.routed_to` so a stale route left by an earlier refinery rejection cannot
+turn this direct named-session delivery back into generic pool routing.
 
 The refinery will pick this up, rebase onto {{base_branch}}, run tests,
 merge, and close the bead. If there's a conflict, the refinery puts the

--- a/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
@@ -42,7 +42,7 @@ gc bd update <work-bead> \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"
-gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"
+gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
 gc runtime drain-ack
 exit
 ```


### PR DESCRIPTION
## Summary
- restore default scale-check demand to count only unassigned beads routed by `gc.routed_to`
- add regressions proving assigned named-session refinery handoffs wake the named session without adding generic pool demand
- update the Gastown polecat done sequence to assign the refinery named session and explicitly clear stale `gc.routed_to`

## Tests
- `go test ./cmd/gc ./examples/gastown -run 'TestDefaultScaleCheckCounts(CountsUnassignedRoutedPoolWork|DoesNotTreatTemplateAssigneeAsDemand|ExcludesBeadsAssignedToSession)|TestBuiltInSlingPoolRouteContractUsesMetadataOnly|TestBuildDesiredState_RigOnDemandNamedSessionAssigneeWithRouteMaterializesNamedOnly|TestPolecatFormulaSignalsRefineryAfterReassign|TestPolecatPromptDoneSequenceSignalsRefinery|TestGastownRoutedToTargetsUseBindingPrefix|TestGastownPromptRoutedToHandoffIsFullyQualifiedUnderBinding'`
- `go test ./cmd/gc ./examples/gastown`
- `make test-fast-parallel`
- `go vet ./...`
- pre-commit hook (`.githooks`) ran during commit
