### PR TITLE
fix(cmd/gc): bypass async trace flush in tests so records are durable (ga-231oq)

### DIFF
--- a/cmd/gc/session_reconciler_trace_collector.go
+++ b/cmd/gc/session_reconciler_trace_collector.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -118,11 +119,20 @@ func newSessionReconcilerTracer(cityPath, cityName string, stderr io.Writer) *Se
 		store:     store,
 		armStore:  newSessionReconcilerTraceArmStore(cityPath),
 		lastArms:  make(map[string]TraceArm),
-		flushCh:   make(chan sessionReconcilerTraceFlushRequest, sessionReconcilerTraceFlushQueueSize),
-		flushDone: make(chan struct{}),
-		closeCh:   make(chan struct{}),
 	}
-	go tracer.runFlushLoop(tracer.flushCh)
+	// In production, an async worker goroutine drains the flush queue with a
+	// bounded wait budget so tick liveness wins over trace durability under
+	// slow storage. Under `go test`, the same bound makes assertions on trace
+	// records non-deterministic — back-to-back ticks in a single test can fill
+	// the queue or starve the result wait, and records silently drop. Bypass
+	// the queue in tests so AppendBatch is synchronous and trace assertions
+	// observe what the production gate actually decided. (ga-231oq)
+	if !testing.Testing() {
+		tracer.flushCh = make(chan sessionReconcilerTraceFlushRequest, sessionReconcilerTraceFlushQueueSize)
+		tracer.flushDone = make(chan struct{})
+		tracer.closeCh = make(chan struct{})
+		go tracer.runFlushLoop(tracer.flushCh)
+	}
 	return tracer
 }
 


### PR DESCRIPTION
## Summary

Fixes intermittent failure of `TestCityRuntimeTickForcesRunAfterMaxConsecutiveFSPressureSkips` in CI's `Preflight / unit cover` job (bead [ga-231oq](../..)).

## Root cause

The trace flusher uses a bounded queue (size 8) with a 25ms per-call wait budget so that production reconciliation ticks never block on slow storage. The FS pressure test runs 10 back-to-back ticks on the test goroutine; each one ends a trace cycle that enqueues a durable batch. Under CI load, the single flush worker can't drain fast enough, `appendBatch` returns `errTraceFlushQueueFull`, and `End()` silently drops the batch (logging `flush_queue_full` to stderr). The test then asserts on trace records that were never persisted and fails with:

```
fs_pressure_test.go:496: FS pressure trace decisions = N, want 7
```

The prior hypothesis in the bead — that a captured-slice race on the fake pressure reader was the culprit — is disproved: the read happens on the test goroutine and `-race` finds nothing.

## Reproduction

Shrinking `sessionReconcilerTraceDurableWait` from 25ms to 50ns deterministically reproduces the failure with the exact signature the bead describes (40/40 runs failed, every failure on the trace-records count assertion).

## Fix

Skip the async flush worker when `testing.Testing()` is true. The existing `appendBatch` fallback path already handles `flushCh == nil` by calling `store.AppendBatch` directly under `store.mu`, so it is synchronous and serialized. `Close()` already nil-checks the channels, so no other surgery is needed.

Production behavior is unchanged. Tests that intentionally exercise the async path (`TestTraceFlushCurrentBatchQueueFullDegrades`, `TestTraceFlushCurrentBatchWaitBudgetDegrades`) construct the tracer manually with their own `flushCh` and are unaffected.

## Test plan

- [x] `go test -count=500 -run TestCityRuntimeTickForcesRunAfterMaxConsecutiveFSPressureSkips ./cmd/gc/` — passes
- [x] `go test -count=20 -race -run TestCityRuntimeTickForcesRunAfterMaxConsecutiveFSPressureSkips ./cmd/gc/` — passes
- [x] `go test -count=1 -run 'TestFSPressure|TestShouldSkipTickForFSPressure|TestCityRuntime|TestTrace|TestSessionReconciler|TestSupervisor' ./cmd/gc/` — passes
- [x] `make test-fast-parallel` (via pre-commit hook) — all 8 jobs passed
- [ ] CI `Preflight / unit cover` passes on this branch