### PR TITLE
fix(convoy): keep check auto-close on live reads

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -1340,103 +1340,20 @@ func cmdConvoyCheckJSON(jsonOut bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc convoy check: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	c, reason := convoyCheckAPIClient(cityPath)
-	return routeConvoyCheck(cityPath, c, reason, jsonOut, stdout, stderr)
+	return routeConvoyCheck(cityPath, nil, "requires-live-read", jsonOut, stdout, stderr)
 }
 
-// convoyCheckAPIClient returns (client, "") when the API path is available,
-// or (nil, reason) when the caller should fall back.
-var convoyCheckAPIClient = func(cityPath string) (*api.Client, string) {
-	if c := apiClient(cityPath); c != nil {
-		return c, ""
-	}
-	return nil, apiClientFallbackReason(cityPath)
-}
-
-// routeConvoyCheck dispatches `convoy check` to the supervisor API when a
-// controller is up; otherwise falls back to the all-local iterator. Emits
-// exactly one route=... log line per exit path (gated on GC_DEBUG).
-//
-// The API path queries /convoys then /convoy/{id}/check for each non-owned
-// convoy. Completed convoys are closed via local bd — mutation routing is
-// intentionally outside this read-path migration. A fallbackable error on
-// any check call aborts the whole operation back to the local iterator so
-// the user sees consistent output.
-func routeConvoyCheck(cityPath string, c *api.Client, nilReason string, jsonOut bool, stdout, stderr io.Writer) int {
+// routeConvoyCheck always uses the local live store path because the command
+// may auto-close convoys. The supervisor API is cache-backed, and cached data
+// must not drive state mutations.
+func routeConvoyCheck(cityPath string, _ *api.Client, nilReason string, jsonOut bool, stdout, stderr io.Writer) int {
 	const cmdName = "convoy check"
-	if c != nil {
-		cr, err := c.ListConvoys()
-		switch {
-		case err == nil:
-			progress, progErr := fetchConvoyProgress(c, cr.Body)
-			if progErr == nil {
-				logRoute(stderr, cmdName, "api", "")
-				return autoCloseConvoysFromAPI(cityPath, cr, progress, jsonOut, stdout, stderr)
-			}
-			if !api.ShouldFallbackForRead(progErr) {
-				logRoute(stderr, cmdName, "api", "error")
-				fmt.Fprintf(stderr, "gc convoy check: %v\n", progErr) //nolint:errcheck // best-effort stderr
-				return 1
-			}
-			logRoute(stderr, cmdName, "fallback", api.FallbackReason(progErr))
-		case !api.ShouldFallbackForRead(err):
-			logRoute(stderr, cmdName, "api", "error")
-			fmt.Fprintf(stderr, "gc convoy check: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		default:
-			logRoute(stderr, cmdName, "fallback", api.FallbackReason(err))
-		}
-	} else {
-		logRoute(stderr, cmdName, "fallback", nilReason)
+	reason := nilReason
+	if reason == "" {
+		reason = "requires-live-read"
 	}
+	logRoute(stderr, cmdName, "fallback", reason)
 	return doConvoyCheckFallback(cityPath, jsonOut, stdout, stderr)
-}
-
-// autoCloseConvoysFromAPI closes non-owned convoys whose API-reported
-// progress is complete. Closure uses local bd stores (resolved per-convoy
-// via openConvoyStoreByID) so mutation routing stays out of scope for the
-// read-path migration. Prints the stale banner when cache age > 30s.
-func autoCloseConvoysFromAPI(cityPath string, cr api.CachedRead[[]beads.Bead], progress []api.ConvoyCheckView, jsonOut bool, stdout, stderr io.Writer) int {
-	rec := openCityRecorderAt(cityPath, stderr)
-	closed := 0
-	for i, convoy := range cr.Body {
-		if hasLabel(convoy.Labels, "owned") {
-			continue
-		}
-		p := progress[i]
-		if !p.Complete {
-			continue
-		}
-		store, code := openConvoyStoreByIDAt(convoy.ID, cityPath, stderr, "gc convoy check")
-		if store == nil {
-			return code
-		}
-		if err := closeConvoyWithReason(store, convoy.ID, convoyAutocloseReason); err != nil {
-			fmt.Fprintf(stderr, "gc convoy check: closing %s: %v\n", convoy.ID, err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		rec.Record(events.Event{
-			Type:    events.ConvoyClosed,
-			Actor:   eventActor(),
-			Subject: convoy.ID,
-		})
-		if !jsonOut {
-			fmt.Fprintf(stdout, "Auto-closed convoy %s %q\n", convoy.ID, convoy.Title) //nolint:errcheck // best-effort stdout
-		}
-		closed++
-	}
-	if jsonOut {
-		if err := writeCLIJSONLine(stdout, convoyActionResult{SchemaVersion: "1", OK: true, Command: "convoy.check", Action: "check", Closed: intRef(closed)}); err != nil {
-			fmt.Fprintf(stderr, "gc convoy check: writing JSON result: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-	} else {
-		fmt.Fprintf(stdout, "%d convoy(s) auto-closed\n", closed) //nolint:errcheck // best-effort stdout
-	}
-	if cr.AgeSeconds > cacheAgeBannerThresholdSeconds {
-		fmt.Fprintf(stdout, "(cache age: %.0fs — reconciler may be lagging)\n", cr.AgeSeconds) //nolint:errcheck
-	}
-	return 0
 }
 
 // doConvoyCheckFallback is the direct-bd path for "gc convoy check".

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -1895,8 +1895,10 @@ func requireNoError(t *testing.T, err error) {
 }
 
 // ---------------------------------------------------------------------------
-// Six-row read-path routing matrix for `gc convoy list/status/check`
-// (ADR 0001, ga-h6w). Each command gets the six mandatory rows:
+// Six-row read-path routing matrix for `gc convoy list/status` (ADR 0001,
+// ga-h6w). `gc convoy check` keeps the same route-log coverage below, but it
+// is deliberately excluded from API routing because it may mutate state.
+// Each API-routed command gets the six mandatory rows:
 //
 //   api-happy-path       API returns 200 with items         route=api, exit 0
 //   api-cache-not-live   API returns 503 cache_not_live     fallback, exit 0
@@ -2192,7 +2194,7 @@ func TestRouteConvoyStatus_SixRowMatrix(t *testing.T) {
 	}
 }
 
-func TestRouteConvoyCheck_SixRowMatrix(t *testing.T) {
+func TestRouteConvoyCheckAlwaysFallsBackForLiveMutation(t *testing.T) {
 	tests := []struct {
 		name         string
 		handler      convoyMatrixHandler
@@ -2205,31 +2207,33 @@ func TestRouteConvoyCheck_SixRowMatrix(t *testing.T) {
 		wantStdout   string
 	}{
 		{
-			name:       "api-happy-path",
+			name:       "api-happy-path-ignored-for-live-mutation",
 			handler:    okConvoyCheckHandler,
 			wantExit:   0,
-			wantRoute:  "api",
+			wantRoute:  "fallback",
+			wantReason: "requires-live-read",
 			wantStdout: "0 convoy(s) auto-closed",
 		},
 		{
-			name:       "api-cache-not-live",
+			name:       "api-cache-not-live-ignored-for-live-mutation",
 			handler:    convoyProblemHandler(http.StatusServiceUnavailable, "cache_not_live: supervisor cache is priming"),
 			wantExit:   0,
 			wantRoute:  "fallback",
-			wantReason: "cache-not-live",
+			wantReason: "requires-live-read",
 		},
 		{
-			name:       "api-500-fallback",
+			name:       "api-500-ignored-for-live-mutation",
 			handler:    convoyProblemHandler(http.StatusInternalServerError, "internal: something exploded"),
 			wantExit:   0,
 			wantRoute:  "fallback",
-			wantReason: "conn-refused",
+			wantReason: "requires-live-read",
 		},
 		{
-			name:       "api-404-error",
+			name:       "api-404-ignored-for-live-mutation",
 			handler:    convoyProblemHandler(http.StatusNotFound, "not_found: city not configured"),
-			wantExit:   1,
-			wantStderr: "not_found",
+			wantExit:   0,
+			wantRoute:  "fallback",
+			wantReason: "requires-live-read",
 		},
 		{
 			name:         "controller-down",
@@ -2281,6 +2285,69 @@ func TestRouteConvoyCheck_SixRowMatrix(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRouteConvoyCheckUsesLiveStoreForAutoCloseDecision(t *testing.T) {
+	cityPath := writeConvoyTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt(): %v", err)
+	}
+	convoy, err := store.Create(beads.Bead{Title: "batch", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("create convoy: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{Title: "still open", ParentID: convoy.ID}); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-GC-Cache-Age-S", "25")
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/convoys"):
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"items": []map[string]any{
+					{"id": convoy.ID, "title": convoy.Title, "issue_type": "convoy", "status": "open", "created_at": "2026-04-23T10:00:00Z"},
+				},
+				"total": 1,
+			})
+		case strings.HasSuffix(r.URL.Path, "/check"):
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"convoy_id": convoy.ID,
+				"total":     1,
+				"closed":    1,
+				"complete":  true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeConvoyCheck(cityPath, c, "", false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("routeConvoyCheck = %d, want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	assertRouteLog(t, stderr.String(), "fallback", "requires-live-read")
+	if strings.Contains(stdout.String(), "Auto-closed") {
+		t.Fatalf("stdout should not auto-close from API progress:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "0 convoy(s) auto-closed") {
+		t.Fatalf("stdout = %q, want zero auto-close summary", stdout.String())
+	}
+
+	got, err := store.Get(convoy.ID)
+	if err != nil {
+		t.Fatalf("get convoy: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("convoy status = %q, want open; stdout=%q stderr=%q", got.Status, stdout.String(), stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- route `gc convoy check` through the direct live store path instead of the supervisor API
- remove the API-driven auto-close path so cached progress cannot drive state mutation
- add a regression test where stale API progress says complete while live child work is still open

## Tests
- `go test ./cmd/gc -run TestRouteConvoyCheckUsesLiveStoreForAutoCloseDecision -count=1` (fails before the fix, passes after)
- `go test ./cmd/gc -run 'TestRouteConvoy(List|Status|Check)|TestConvoyCheck' -count=1`
- `scripts/check-routed-test-rows.sh`
- `make test-fast-parallel`
- `go vet ./...`