### PR TITLE
fix(beads): include pool-routed steps in Ready() and CachedReady()

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1612,7 +1612,7 @@ func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	result := make([]Bead, 0, len(issues))
 	for i := range issues {
 		bead := issues[i].toBead()
-		if IsReadyExcludedType(bead.Type) {
+		if !readyTypeIncluded(bead) {
 			continue
 		}
 		if bead.Ephemeral {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -5,6 +5,7 @@ package beads
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -123,6 +124,36 @@ var readyExcludeTypes = map[string]bool{
 // Ready() results by default.
 func IsReadyExcludedType(t string) bool {
 	return readyExcludeTypes[t]
+}
+
+// readyTypeIncluded reports whether a bead's type allows it into Ready()
+// results. Excluded types (molecule, step, ...) normally stay out because
+// they're workflow-container bookkeeping rather than actionable work.
+//
+// The single carve-out: STEPS that carry gc.routed_to ARE actionable
+// units for a pool agent. Cron-fired pool orders (gc order run with
+// pool = "<name>") create a molecule wisp container plus step children
+// that inherit the routing via stampLegacyRecipeRouting. The molecule
+// stays excluded (matches TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers
+// in cmd/gc/build_desired_state_test.go — workflow containers are not
+// pool demand). The steps need to be surfaced so the supervisor's
+// defaultScaleCheckCounts can see them; without that, pool demand
+// stays at 0 for cron-fired orders and dog/polecat pools never spawn.
+//
+// All four Ready paths use this helper — CachingStore.Ready,
+// CachingStore.CachedReady, MemStore.Ready, BdStore.Ready — so the
+// behavior is uniform across store implementations.
+func readyTypeIncluded(b Bead) bool {
+	if !IsReadyExcludedType(b.Type) {
+		return true
+	}
+	if b.Type != "step" {
+		return false
+	}
+	if b.Metadata == nil {
+		return false
+	}
+	return strings.TrimSpace(b.Metadata["gc.routed_to"]) != ""
 }
 
 // Dep represents a dependency relationship between two beads. The IssueID

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1908,6 +1908,135 @@ func TestCachingStoreBdPrimeActiveUsesListDependenciesForCachedReady(t *testing.
 	}
 }
 
+// TestCachingStoreCachedReadyIncludesPoolRoutedSteps guards the
+// pool-demand path in cmd/gc/build_desired_state.go::defaultScaleCheckCounts,
+// which queries CachedReady() to count routed pool work. Cron-fired pool
+// orders (e.g. mol-dog-stale-db with pool = "dog") create a molecule
+// wisp plus step children carrying gc.routed_to=<pool>; without this
+// carve-out CachedReady would filter the steps out via IsReadyExcludedType
+// (since "step" is in readyExcludeTypes) and the supervisor would report
+// 0 pool demand even when the queue has matching work. The carve-out is
+// deliberately narrow:
+//
+//   - Steps with gc.routed_to ARE included — they're the actionable
+//     units a pool worker claims and runs (the parent molecule is just
+//     the formula's container; cmd/gc/cmd_order.go writes routing onto
+//     the steps via stampLegacyRecipeRouting in graphroute.go).
+//   - Steps without gc.routed_to remain excluded — those are graph
+//     workflow step bookkeeping, processed via named-session demand
+//     against the parent agent, not pool scale_check.
+//   - Molecules stay excluded regardless of routing — that's the
+//     existing contract guarded by
+//     TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers in
+//     cmd/gc/build_desired_state_test.go (workflow containers are not
+//     pool demand).
+//   - Other excluded types (gate, message, session, agent, role, rig,
+//     merge-request) stay excluded regardless of routing.
+//
+// The same parity check on Ready() asserts the live path agrees with
+// the cached path so callers can swap between them without behavior
+// change.
+func TestCachingStoreCachedReadyIncludesPoolRoutedSteps(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// Plain task — actionable, no exclusion, no carve-out needed.
+	task, err := cache.Create(Bead{Title: "task", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create task: %v", err)
+	}
+	// Pool-routed step (cron-fired order's child) — must be visible to
+	// CachedReady so defaultScaleCheckCounts can count it.
+	routedStep, err := cache.Create(Bead{
+		Title:    "scan-step",
+		Type:     "step",
+		Metadata: map[string]string{"gc.routed_to": "dog"},
+	})
+	if err != nil {
+		t.Fatalf("Create routed step: %v", err)
+	}
+	// Pool-routed molecule (cron-fired order's wisp) — stays excluded
+	// as a workflow container; the steps below it carry the demand.
+	routedMol, err := cache.Create(Bead{
+		Title:    "mol-dog-stale-db",
+		Type:     "molecule",
+		Metadata: map[string]string{"gc.routed_to": "dog"},
+	})
+	if err != nil {
+		t.Fatalf("Create routed molecule: %v", err)
+	}
+	// Non-pool step (graph workflow step, no routing) — stays excluded
+	// because graph workflows drive named-session demand via Assignee,
+	// not pool scale_check via gc.routed_to.
+	plainStep, err := cache.Create(Bead{
+		Title: "graph-step",
+		Type:  "step",
+	})
+	if err != nil {
+		t.Fatalf("Create plain step: %v", err)
+	}
+	// Non-pool molecule — stays excluded as workflow container.
+	plainMol, err := cache.Create(Bead{
+		Title: "workflow-container",
+		Type:  "molecule",
+	})
+	if err != nil {
+		t.Fatalf("Create plain molecule: %v", err)
+	}
+
+	assertIncludes := func(label string, beads []Bead, ids ...string) {
+		t.Helper()
+		got := make(map[string]bool, len(beads))
+		for _, b := range beads {
+			got[b.ID] = true
+		}
+		for _, id := range ids {
+			if !got[id] {
+				t.Errorf("%s missing %s; got=%v", label, id, poolDemandBeadIDs(beads))
+			}
+		}
+	}
+	assertExcludes := func(label string, beads []Bead, ids ...string) {
+		t.Helper()
+		got := make(map[string]bool, len(beads))
+		for _, b := range beads {
+			got[b.ID] = true
+		}
+		for _, id := range ids {
+			if got[id] {
+				t.Errorf("%s should not contain %s; got=%v", label, id, poolDemandBeadIDs(beads))
+			}
+		}
+	}
+
+	cached, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	assertIncludes("CachedReady", cached, task.ID, routedStep.ID)
+	assertExcludes("CachedReady", cached, routedMol.ID, plainStep.ID, plainMol.ID)
+
+	live, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	assertIncludes("Ready", live, task.ID, routedStep.ID)
+	assertExcludes("Ready", live, routedMol.ID, plainStep.ID, plainMol.ID)
+}
+
+func poolDemandBeadIDs(beads []Bead) []string {
+	out := make([]string, 0, len(beads))
+	for _, b := range beads {
+		out = append(out, b.ID)
+	}
+	return out
+}
+
 func TestCachingStoreReadySkipsEphemeralOpenTasks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -351,7 +351,7 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		openBeads := make([]Bead, 0, len(c.beads))
 		for _, b := range c.beads {
 			statusByID[b.ID] = b.Status
-			if b.Status == "open" && !b.Ephemeral && !IsReadyExcludedType(b.Type) {
+			if b.Status == "open" && !b.Ephemeral && readyTypeIncluded(b) {
 				openBeads = append(openBeads, cloneBead(b))
 			}
 		}
@@ -403,7 +403,7 @@ func (c *CachingStore) CachedReady() ([]Bead, bool) {
 	openBeads := make([]Bead, 0, len(c.beads))
 	for _, b := range c.beads {
 		statusByID[b.ID] = b.Status
-		if b.Status == "open" && !b.Ephemeral && !IsReadyExcludedType(b.Type) {
+		if b.Status == "open" && !b.Ephemeral && readyTypeIncluded(b) {
 			openBeads = append(openBeads, cloneBead(b))
 		}
 	}

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -263,7 +263,7 @@ func (m *MemStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		if b.Ephemeral {
 			continue
 		}
-		if IsReadyExcludedType(b.Type) {
+		if !readyTypeIncluded(b) {
 			continue
 		}
 		if q.Assignee != "" && b.Assignee != q.Assignee {


### PR DESCRIPTION
## Summary

Pursuing what @julianknutsen flagged in #2529 — "I think there is a there there we just need to figure out what else is hidden." This is the actual bug.

Cron-fired pool orders (`gc order run` with `pool = "<name>"`) create a `molecule` wisp via `molecule.Instantiate` plus `step` children that pick up `gc.routed_to=<pool>` from `stampLegacyRecipeRouting` in `internal/graphroute/graphroute.go`. The supervisor's `defaultScaleCheckCounts` in `cmd/gc/build_desired_state.go` counts pool demand by iterating `CachedReady()` and matching `gc.routed_to` against each pool template — but all four `Ready` paths (`CachingStore.Ready`, `CachingStore.CachedReady`, `MemStore.Ready`, `BdStore.Ready`) strip `step` beads out via `IsReadyExcludedType`. Net: cron-fired pool orders never generate scale_check demand, the pool stays at `min`, the queue grows forever.

Manual repro on a city with the stock `dog` pool agent from `.gc/system/packs/maintenance/agents/dog/agent.toml` (no explicit `scale_check`, `fallback=true`, `min=0 max=3`):

```
$ gc order run mol-dog-stale-db
Order "mol-dog-stale-db" executed: wisp pc-X → gc.routed_to=dog

$ gc bd sql "SELECT COUNT(*) FROM ready_issues WHERE \
     metadata->>'\$.\"gc.routed_to\"'='dog' AND \
     (assignee='' OR assignee IS NULL)"
3

# supervisor reconciler trace, every tick:
"scale_check_counts": {"dog": 0, ...}
"pool_desired": {}
"scale_check_partial_templates": []   # not partial — really zero

# dog pool stays at min=0, queue accumulates indefinitely
```

## Approach

Single shared helper `readyTypeIncluded` in `internal/beads/beads.go` that all four `Ready` paths consult. The carve-out is deliberately narrow:

- **Steps with `gc.routed_to` are included** — pool workers discover and claim them via the Tier-3 `work_query` in `EffectiveWorkQuery` (already keyed on `bd ready --metadata-field gc.routed_to=$target --unassigned`).
- **Steps without `gc.routed_to` remain excluded** — graph workflow steps where the parent agent claims via named-session `Assignee` demand.
- **Molecules stay excluded regardless of routing** — the existing contract guarded by `TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers` (workflow containers are not pool demand; the steps below them are). This PR keeps that test passing.
- **Other excluded types** (`gate`, `message`, `session`, `agent`, `role`, `rig`, `merge-request`) stay excluded — they're not work for anyone.

Verified by `TestCachingStoreCachedReadyIncludesPoolRoutedSteps` (new) — checks both `Ready()` and `CachedReady()` for each of the four cases above.

## Why this is the right layer

The shell `scale_check` path (used when an agent has an explicit `scale_check` command) already worked because it shells out to `bd ready` via the bd binary, which doesn't apply the gascity-side `IsReadyExcludedType` filter. Only the in-process default `scale_check` path (taken when `agent.ScaleCheck == ""`, which is the case for the stock `dog` template) was affected. Fixing it at the cache layer brings the in-process path into agreement with the shell path without changing either of them.

Architecturally adjacent to @julianknutsen's review of #2529: he correctly flagged that setting `Assignee` at order time would break pool routing because pool workers claim via `--unassigned` query. The actual missing piece was on the supervisor **read** side, not the order **write** side.

## Test plan

- New test `TestCachingStoreCachedReadyIncludesPoolRoutedSteps` asserts both `Ready()` and `CachedReady()` correctly include routed steps and correctly exclude routed molecules / unrouted steps / unrouted molecules.
- Existing `TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers` still passes — molecules stay excluded.
- Full `./cmd/gc/...` suite green (`go test ./cmd/gc/... -count=1`).
- Full `./internal/beads/...` `./internal/sling/...` `./internal/molecule/...` `./internal/graphroute/...` suites green.
- Verified live on a city with `mol-dog-stale-db` cron: `gc order run mol-dog-stale-db` post-fix moved `scale_check_counts["dog"]` from `0` to `1`, supervisor materialized a `dog-1` ephemeral session, the dog claimed the step, ran the cleanup script, closed the step + parent molecule, drained, and recycled the pool slot — all without operator intervention. Pre-fix repro of the same flow showed `scale_check_counts["dog"]` stuck at `0` across every tick.

## Out of scope

- The cmd_order Assignee change attempted in #2529 — confirmed wrong (breaks pool routing semantics) and reverted.
- The cron formula's step shell script itself — works fine once the dog spawns.
- Other excluded types (`gate`, `message`, etc.) — no known use case for pool-routing them. If one emerges, the same carve-out could extend.