### PR TITLE
fix(doctor): guard local-only Dolt remotes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,10 +342,12 @@ bd close <id>         # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```
+   NOTE: gascity Dolt is LOCAL-ONLY (no remote). Do NOT run `bd dolt push`,
+   `bd dolt pull`, or `bd dolt remote add` here -- they fail and re-introduce
+   a doomed `origin` remote (ga-9wsri). Use `git push` only.
 5. **Clean up** - Clear stashes, prune remote branches
 6. **Verify** - All changes committed AND pushed
 7. **Hand off** - Provide context for next session

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	newDoctorDoltServerCheck    = doctor.NewDoltServerCheck
-	newDoctorRigDoltServerCheck = doctor.NewRigDoltServerCheck
-	newDoctorDoltBackupCheck    = doctor.NewDoltBackupCheck
+	newDoctorDoltServerCheck          = doctor.NewDoltServerCheck
+	newDoctorRigDoltServerCheck       = doctor.NewRigDoltServerCheck
+	newDoctorDoltBackupCheck          = doctor.NewDoltBackupCheck
+	newDoctorDoltLocalOnlyRemoteCheck = doctor.NewDoltLocalOnlyRemoteCheck
 )
 
 func newDoctorCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -278,6 +279,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 			// skip non-managed-bdstore rigs and GC_DOLT=skip environments.
 			if rigUsesManagedBdStoreContract(cityPath, rig) && !gcDoltSkip() {
 				register(newDoctorDoltBackupCheck(cityPath, rig, managedDoltDataDir))
+				register(newDoctorDoltLocalOnlyRemoteCheck(cityPath, rig, managedDoltDataDir))
 			}
 		}
 	}

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -298,7 +298,9 @@ suspended = true
 	oldCityCheck := newDoctorDoltServerCheck
 	oldRigCheck := newDoctorRigDoltServerCheck
 	oldBackupCheck := newDoctorDoltBackupCheck
-	registered := map[string]string{}
+	oldLocalOnlyCheck := newDoctorDoltLocalOnlyRemoteCheck
+	registeredBackup := map[string]string{}
+	registeredLocalOnly := map[string]string{}
 	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
 		return doctor.NewDoltServerCheck(cityPath, true)
 	}
@@ -306,29 +308,46 @@ suspended = true
 		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
 	}
 	newDoctorDoltBackupCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltBackupCheck {
-		registered[rig.Name] = dataDir
+		registeredBackup[rig.Name] = dataDir
 		return doctor.NewDoltBackupCheck(cityPath, rig, dataDir)
+	}
+	newDoctorDoltLocalOnlyRemoteCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltLocalOnlyRemoteCheck {
+		registeredLocalOnly[rig.Name] = dataDir
+		return doctor.NewDoltLocalOnlyRemoteCheck(cityPath, rig, dataDir)
 	}
 	t.Cleanup(func() {
 		newDoctorDoltServerCheck = oldCityCheck
 		newDoctorRigDoltServerCheck = oldRigCheck
 		newDoctorDoltBackupCheck = oldBackupCheck
+		newDoctorDoltLocalOnlyRemoteCheck = oldLocalOnlyCheck
 	})
 
 	var stdout, stderr bytes.Buffer
 	_ = doDoctor(false, false, false, &stdout, &stderr)
 
-	if len(registered) != 1 {
-		t.Fatalf("registered dolt-backup checks = %#v, want only active managed rig", registered)
+	if len(registeredBackup) != 1 {
+		t.Fatalf("registered dolt-backup checks = %#v, want only active managed rig", registeredBackup)
 	}
-	if got := registered["managed"]; got != doltDataDir {
+	if got := registeredBackup["managed"]; got != doltDataDir {
 		t.Fatalf("managed rig data dir = %q, want runtime layout data dir %q", got, doltDataDir)
 	}
-	if _, ok := registered["filebacked"]; ok {
-		t.Fatalf("file-backed rig should not register dolt-backup check: %#v", registered)
+	if _, ok := registeredBackup["filebacked"]; ok {
+		t.Fatalf("file-backed rig should not register dolt-backup check: %#v", registeredBackup)
 	}
-	if _, ok := registered["sleeping"]; ok {
-		t.Fatalf("suspended rig should not register dolt-backup check: %#v", registered)
+	if _, ok := registeredBackup["sleeping"]; ok {
+		t.Fatalf("suspended rig should not register dolt-backup check: %#v", registeredBackup)
+	}
+	if len(registeredLocalOnly) != 1 {
+		t.Fatalf("registered dolt-local-only checks = %#v, want only active managed rig", registeredLocalOnly)
+	}
+	if got := registeredLocalOnly["managed"]; got != doltDataDir {
+		t.Fatalf("managed rig local-only data dir = %q, want runtime layout data dir %q", got, doltDataDir)
+	}
+	if _, ok := registeredLocalOnly["filebacked"]; ok {
+		t.Fatalf("file-backed rig should not register dolt-local-only check: %#v", registeredLocalOnly)
+	}
+	if _, ok := registeredLocalOnly["sleeping"]; ok {
+		t.Fatalf("suspended rig should not register dolt-local-only check: %#v", registeredLocalOnly)
 	}
 }
 
@@ -376,7 +395,9 @@ prefix = "ma"
 	oldCityCheck := newDoctorDoltServerCheck
 	oldRigCheck := newDoctorRigDoltServerCheck
 	oldBackupCheck := newDoctorDoltBackupCheck
-	registered := 0
+	oldLocalOnlyCheck := newDoctorDoltLocalOnlyRemoteCheck
+	registeredBackup := 0
+	registeredLocalOnly := 0
 	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
 		return doctor.NewDoltServerCheck(cityPath, true)
 	}
@@ -384,20 +405,28 @@ prefix = "ma"
 		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
 	}
 	newDoctorDoltBackupCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltBackupCheck {
-		registered++
+		registeredBackup++
 		return doctor.NewDoltBackupCheck(cityPath, rig, dataDir)
+	}
+	newDoctorDoltLocalOnlyRemoteCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltLocalOnlyRemoteCheck {
+		registeredLocalOnly++
+		return doctor.NewDoltLocalOnlyRemoteCheck(cityPath, rig, dataDir)
 	}
 	t.Cleanup(func() {
 		newDoctorDoltServerCheck = oldCityCheck
 		newDoctorRigDoltServerCheck = oldRigCheck
 		newDoctorDoltBackupCheck = oldBackupCheck
+		newDoctorDoltLocalOnlyRemoteCheck = oldLocalOnlyCheck
 	})
 
 	var stdout, stderr bytes.Buffer
 	_ = doDoctor(false, false, false, &stdout, &stderr)
 
-	if registered != 0 {
-		t.Fatalf("registered %d dolt-backup checks, want 0 when GC_DOLT=skip", registered)
+	if registeredBackup != 0 {
+		t.Fatalf("registered %d dolt-backup checks, want 0 when GC_DOLT=skip", registeredBackup)
+	}
+	if registeredLocalOnly != 0 {
+		t.Fatalf("registered %d dolt-local-only checks, want 0 when GC_DOLT=skip", registeredLocalOnly)
 	}
 }
 

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -172,6 +172,24 @@ func ReadAutoStartDisabled(fs fsys.FS, path string) (bool, error) {
 	return false, nil
 }
 
+// ReadDoltLocalOnly reports whether dolt.local-only is explicitly enabled.
+func ReadDoltLocalOnly(fs fsys.FS, path string) (bool, error) {
+	doc, err := readConfigDoc(fs, path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		if value, ok := scanConfigLineValue(fs, path, "dolt.local-only:"); ok {
+			return value == "true", nil
+		}
+		return false, err
+	}
+	if value, ok := configStringValue(mappingRoot(doc), "dolt.local-only"); ok {
+		return value == "true", nil
+	}
+	return false, nil
+}
+
 // ReadExportAuto returns the configured value of export.auto along with a
 // presence indicator. ok=false means the key is absent from the config OR
 // the value is not a recognized boolean (the upstream bd default is true).

--- a/internal/doctor/checks_dolt_local_only.go
+++ b/internal/doctor/checks_dolt_local_only.go
@@ -1,0 +1,237 @@
+package doctor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// DoltLocalOnlyRemoteCheck detects off-box Dolt remotes in rigs that
+// explicitly declare dolt.local-only:true.
+type DoltLocalOnlyRemoteCheck struct {
+	cityPath     string
+	rig          config.Rig
+	doltDataDir  string
+	removeRemote func(rigPath, name string) error
+}
+
+type doltRemote struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// NewDoltLocalOnlyRemoteCheck creates a per-rig local-only Dolt remote check.
+func NewDoltLocalOnlyRemoteCheck(cityPath string, rig config.Rig, doltDataDir string) *DoltLocalOnlyRemoteCheck {
+	if strings.TrimSpace(doltDataDir) == "" {
+		doltDataDir = filepath.Join(cityPath, ".beads", "dolt")
+	}
+	return &DoltLocalOnlyRemoteCheck{
+		cityPath:     cityPath,
+		rig:          rig,
+		doltDataDir:  doltDataDir,
+		removeRemote: removeDoltRemote,
+	}
+}
+
+// Name returns the check identifier ("rig:<name>:dolt-local-only-remote").
+func (c *DoltLocalOnlyRemoteCheck) Name() string {
+	return "rig:" + c.rig.Name + ":dolt-local-only-remote"
+}
+
+// Run executes the check.
+func (c *DoltLocalOnlyRemoteCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	rigPath := c.normalizedRigPath()
+
+	localOnly, err := c.localOnlyEnabled(rigPath)
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("rig %q: cannot read dolt.local-only config: %v", c.rig.Name, err)
+		return r
+	}
+	if !localOnly {
+		r.Status = StatusOK
+		r.Message = "dolt.local-only not enabled"
+		return r
+	}
+
+	dbName, details := c.resolveDBName(rigPath)
+	r.Details = append(r.Details, details...)
+	remotes, err := localOnlyOffBoxRemotes(c.doltDataDir, dbName)
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("rig %q: cannot inspect dolt remotes: %v", c.rig.Name, err)
+		return r
+	}
+	if len(remotes) == 0 {
+		r.Status = StatusOK
+		r.Message = "dolt.local-only enabled; no off-box remotes registered"
+		return r
+	}
+
+	names := remoteNames(remotes)
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("rig %q: dolt.local-only forbids off-box remote(s): %s", c.rig.Name, strings.Join(names, ", "))
+	r.FixHint = localOnlyRemoteFixHint(names)
+	return r
+}
+
+// CanFix returns true. Fix is scoped by the explicit dolt.local-only flag.
+func (c *DoltLocalOnlyRemoteCheck) CanFix() bool { return true }
+
+// Fix removes off-box Dolt remotes only when dolt.local-only is explicitly true.
+func (c *DoltLocalOnlyRemoteCheck) Fix(_ *CheckContext) error {
+	rigPath := c.normalizedRigPath()
+	localOnly, err := c.localOnlyEnabled(rigPath)
+	if err != nil {
+		return fmt.Errorf("read dolt.local-only config: %w", err)
+	}
+	if !localOnly {
+		return nil
+	}
+	dbName, _ := c.resolveDBName(rigPath)
+	remotes, err := localOnlyOffBoxRemotes(c.doltDataDir, dbName)
+	if err != nil {
+		return err
+	}
+	for _, remote := range remotes {
+		if err := c.removeRemote(rigPath, remote.Name); err != nil {
+			return fmt.Errorf("remove dolt remote %q: %w", remote.Name, err)
+		}
+	}
+	return nil
+}
+
+func (c *DoltLocalOnlyRemoteCheck) normalizedRigPath() string {
+	rigPath := c.rig.Path
+	if !filepath.IsAbs(rigPath) {
+		rigPath = filepath.Join(c.cityPath, rigPath)
+	}
+	return rigPath
+}
+
+func (c *DoltLocalOnlyRemoteCheck) localOnlyEnabled(rigPath string) (bool, error) {
+	return contract.ReadDoltLocalOnly(fsys.OSFS{}, filepath.Join(rigPath, ".beads", "config.yaml"))
+}
+
+func (c *DoltLocalOnlyRemoteCheck) resolveDBName(rigPath string) (string, []string) {
+	metadataPath := filepath.Join(rigPath, ".beads", "metadata.json")
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return c.rig.Name, nil
+		}
+		return c.rig.Name, []string{fmt.Sprintf("read metadata.json: %v; using rig name %q", err, c.rig.Name)}
+	}
+	var meta struct {
+		DoltDatabase string `json:"dolt_database"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return c.rig.Name, []string{fmt.Sprintf("parse metadata.json: %v; using rig name %q", err, c.rig.Name)}
+	}
+	if s := strings.TrimSpace(meta.DoltDatabase); s != "" {
+		return s, nil
+	}
+	return c.rig.Name, nil
+}
+
+func localOnlyOffBoxRemotes(doltDataDir, dbName string) ([]doltRemote, error) {
+	for _, statePath := range localOnlyRepoStatePaths(doltDataDir, dbName) {
+		data, err := os.ReadFile(statePath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		return parseLocalOnlyOffBoxRemotes(statePath, data)
+	}
+	return nil, nil
+}
+
+func localOnlyRepoStatePaths(doltDataDir, dbName string) []string {
+	paths := []string{filepath.Join(doltDataDir, dbName, ".dolt", "repo_state.json")}
+	direct := filepath.Join(doltDataDir, ".dolt", "repo_state.json")
+	if direct != paths[0] {
+		paths = append(paths, direct)
+	}
+	return paths
+}
+
+func parseLocalOnlyOffBoxRemotes(statePath string, data []byte) ([]doltRemote, error) {
+	var state struct {
+		Remotes map[string]doltRemote `json:"remotes"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", statePath, err)
+	}
+	remotes := make([]doltRemote, 0, len(state.Remotes))
+	for key, remote := range state.Remotes {
+		if strings.TrimSpace(remote.Name) == "" {
+			remote.Name = key
+		}
+		if localOnlyRemoteIsOffBox(remote) {
+			remotes = append(remotes, remote)
+		}
+	}
+	sort.Slice(remotes, func(i, j int) bool {
+		return remotes[i].Name < remotes[j].Name
+	})
+	return remotes, nil
+}
+
+func localOnlyRemoteIsOffBox(remote doltRemote) bool {
+	name := strings.TrimSpace(remote.Name)
+	if name == "origin" {
+		return true
+	}
+	url := strings.ToLower(strings.TrimSpace(remote.URL))
+	if url == "" {
+		return false
+	}
+	for _, prefix := range []string{"http://", "https://", "git://", "git+http://", "git+https://", "ssh://"} {
+		if strings.HasPrefix(url, prefix) {
+			return true
+		}
+	}
+	return strings.Contains(url, "@") && strings.Contains(url, ":")
+}
+
+func remoteNames(remotes []doltRemote) []string {
+	names := make([]string, 0, len(remotes))
+	for _, remote := range remotes {
+		names = append(names, remote.Name)
+	}
+	return names
+}
+
+func localOnlyRemoteFixHint(names []string) string {
+	commands := make([]string, 0, len(names))
+	for _, name := range names {
+		commands = append(commands, "bd dolt remote remove "+name)
+	}
+	return "gascity Dolt is local-only; run `gc doctor --fix` or remove manually: " + strings.Join(commands, "; ")
+}
+
+func removeDoltRemote(rigPath, name string) error {
+	cmd := exec.Command("bd", "dolt", "remote", "remove", name)
+	cmd.Dir = rigPath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/doctor/checks_dolt_local_only_test.go
+++ b/internal/doctor/checks_dolt_local_only_test.go
@@ -1,0 +1,238 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func writeRigBeadsConfig(t *testing.T, rigPath, body string) {
+	t.Helper()
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("create .beads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+}
+
+func writeRepoStateWithRemotes(t *testing.T, doltDataDir string, remotes map[string]string) {
+	t.Helper()
+	writeRepoStateWithRemotesAt(t, filepath.Join(doltDataDir, "testdb"), remotes)
+}
+
+func writeRepoStateWithRemotesAt(t *testing.T, repoDir string, remotes map[string]string) {
+	t.Helper()
+	doltDir := filepath.Join(repoDir, ".dolt")
+	if err := os.MkdirAll(doltDir, 0o700); err != nil {
+		t.Fatalf("create .dolt dir: %v", err)
+	}
+	stateRemotes := make(map[string]any, len(remotes))
+	for name, url := range remotes {
+		stateRemotes[name] = map[string]string{
+			"name": name,
+			"url":  url,
+		}
+	}
+	state := map[string]any{
+		"head":     "refs/heads/main",
+		"remotes":  stateRemotes,
+		"backups":  map[string]any{},
+		"branches": map[string]any{},
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal repo_state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, "repo_state.json"), data, 0o600); err != nil {
+		t.Fatalf("write repo_state: %v", err)
+	}
+}
+
+func TestDoltLocalOnlyRemoteCheck_LocalOnlyOriginRemoteWarns(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigBeadsConfig(t, rigPath, "dolt.local-only: true\n")
+	writeRepoStateWithRemotes(t, doltDataDir, map[string]string{
+		"origin": "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, config.Rig{Name: "testrig", Path: rigPath}, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning; message=%s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "origin") {
+		t.Fatalf("Message should name offending remote: %s", r.Message)
+	}
+	if !strings.Contains(r.FixHint, "bd dolt remote remove origin") {
+		t.Fatalf("FixHint should tell operator how to remove origin: %s", r.FixHint)
+	}
+	if !c.CanFix() {
+		t.Fatal("CanFix should be true when dolt.local-only scopes the remote removal")
+	}
+
+	var removedName, removedPath string
+	c.removeRemote = func(gotRigPath, gotName string) error {
+		removedPath = gotRigPath
+		removedName = gotName
+		return nil
+	}
+	if err := c.Fix(&CheckContext{CityPath: cityPath}); err != nil {
+		t.Fatalf("Fix() error = %v", err)
+	}
+	if removedName != "origin" {
+		t.Fatalf("Fix removed remote %q, want origin", removedName)
+	}
+	if removedPath != rigPath {
+		t.Fatalf("Fix used rig path %q, want %q", removedPath, rigPath)
+	}
+}
+
+func TestDoltLocalOnlyRemoteCheck_LocalOnlyDirectDataDirOriginRemoteWarns(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigBeadsConfig(t, rigPath, "dolt.local-only: true\n")
+	writeRepoStateWithRemotesAt(t, doltDataDir, map[string]string{
+		"origin": "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, config.Rig{Name: "testrig", Path: rigPath}, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning; message=%s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "origin") {
+		t.Fatalf("Message should name offending remote in direct data dir layout: %s", r.Message)
+	}
+}
+
+func TestDoltLocalOnlyRemoteCheck_LocalOnlyWithoutOffBoxRemoteOK(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigBeadsConfig(t, rigPath, "dolt.local-only: true\n")
+
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, config.Rig{Name: "testrig", Path: rigPath}, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want StatusOK without repo_state remotes; message=%s", r.Status, r.Message)
+	}
+}
+
+func TestDoltLocalOnlyRemoteCheck_LocalBackupRemoteOK(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigBeadsConfig(t, rigPath, "dolt.local-only: true\n")
+	writeRepoStateWithRemotes(t, doltDataDir, map[string]string{
+		"testdb-backup": "file://" + filepath.Join(cityPath, ".dolt-backup", "testdb"),
+	})
+
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, config.Rig{Name: "testrig", Path: rigPath}, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want StatusOK for local backup remote; message=%s", r.Status, r.Message)
+	}
+}
+
+func TestDoltLocalOnlyRemoteCheck_FlagAbsentOrFalseAllowsRemote(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config string
+	}{
+		{name: "absent", config: "dolt.auto-push: false\n"},
+		{name: "false", config: "dolt.local-only: false\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+			rigPath := filepath.Join(cityPath, "rig")
+			if err := os.MkdirAll(rigPath, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			writeRigMetadata(t, rigPath, "testdb")
+			writeRigBeadsConfig(t, rigPath, tc.config)
+			writeRepoStateWithRemotes(t, doltDataDir, map[string]string{
+				"origin": "https://github.com/gastownhall/gascity.git",
+			})
+
+			c := NewDoltLocalOnlyRemoteCheck(cityPath, config.Rig{Name: "testrig", Path: rigPath}, doltDataDir)
+			r := c.Run(&CheckContext{CityPath: cityPath})
+			if r.Status != StatusOK {
+				t.Fatalf("status = %d, want StatusOK without dolt.local-only:true; message=%s", r.Status, r.Message)
+			}
+
+			called := false
+			c.removeRemote = func(_ string, _ string) error {
+				called = true
+				return nil
+			}
+			if err := c.Fix(&CheckContext{CityPath: cityPath}); err != nil {
+				t.Fatalf("Fix() error = %v", err)
+			}
+			if called {
+				t.Fatal("Fix removed a remote without dolt.local-only:true")
+			}
+		})
+	}
+}
+
+func TestDoltLocalOnlyRemoteCheck_OffBoxRemoteNameWarns(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigBeadsConfig(t, rigPath, "dolt.local-only: true\n")
+	writeRepoStateWithRemotes(t, doltDataDir, map[string]string{
+		"mirror": "ssh://git@github.com/gastownhall/gascity.git",
+	})
+
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, config.Rig{Name: "testrig", Path: rigPath}, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning; message=%s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "mirror") || !strings.Contains(r.FixHint, "bd dolt remote remove mirror") {
+		t.Fatalf("expected warning and fix hint to name mirror; message=%s hint=%s", r.Message, r.FixHint)
+	}
+}
+
+func TestDoltLocalOnlyRemoteCheck_Name(t *testing.T) {
+	c := NewDoltLocalOnlyRemoteCheck(t.TempDir(), config.Rig{Name: "myrig", Path: t.TempDir()}, "")
+	want := "rig:myrig:dolt-local-only-remote"
+	if got := c.Name(); got != want {
+		t.Fatalf("Name() = %q, want %q", got, want)
+	}
+}

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -78,6 +78,10 @@ func (c *DoltBackupCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *DoltLocalOnlyRemoteCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *DoltVersionCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the

--- a/release-gates/ga-9usr9-dolt-local-only-remote-guard-gate.md
+++ b/release-gates/ga-9usr9-dolt-local-only-remote-guard-gate.md
@@ -1,0 +1,32 @@
+# Release Gate: Dolt Local-Only Remote Guard
+
+Bead: ga-9usr9
+Source bead: ga-d457b
+Branch: deploy/ga-d457b
+Reviewed branch: origin/builder/ga-d457b
+Base: origin/main 8fe54229572b
+Merge-base: 1b89b21bbfa8
+Reviewed commit: d7b4341379c4
+Gate result: PASS
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-9usr9` notes contain `Reviewer verdict: PASS`; reviewer mail `gm-wisp-d19n3u` confirms PASS for source bead `ga-d457b`, branch `origin/builder/ga-d457b`, commit `d7b434137`. |
+| 2 | Acceptance criteria met | PASS | The reviewed diff is scoped to 7 files. It adds `DoltLocalOnlyRemoteCheck`, keys detection on literal `dolt.local-only: true`, exposes `ReadDoltLocalOnly`, registers the check beside `DoltBackupCheck`, removes `bd dolt push/pull/remote add` session-close guidance from `AGENTS.md`, and covers warning, OK, direct data-dir, local-backup, absent/false flag, name, and fix injection cases. Live config has `/home/jaword/projects/gascity/.beads/config.yaml` line `dolt.local-only: true`; branch `gc doctor --json` reports `rig:gascity:dolt-local-only-remote` OK with `dolt.local-only enabled; no off-box remotes registered`. |
+| 3 | Tests pass | PASS | `make test` passed via `scripts/go-test-observable`: `observable go test: PASS log=/tmp/gascity-test.jsonl.IfZgvu`. `go vet ./...` passed with no output. `git diff --check origin/main...HEAD` passed with no output. |
+| 4 | No high-severity review findings open | PASS | Review notes list three informational, non-blocking observations and no HIGH or blocker findings. |
+| 5 | Final branch is clean | PASS | Before writing this release gate, `git status --short --branch` printed only `## deploy/ga-d457b...origin/builder/ga-d457b`; there were no uncommitted files. |
+| 6 | Branch diverges cleanly from main | PASS | After refreshing `origin/main`, `git merge-tree --write-tree HEAD origin/main` succeeded. Branch shape is 1 commit ahead and 3 commits behind `origin/main`; there are no merge conflicts. |
+
+## Validation Notes
+
+- `git diff --stat origin/main...HEAD` shows the expected 7-file doctor,
+  contract, and AGENTS.md change set.
+- The full `gc doctor --json` smoke against the city context exits nonzero due
+  to existing unrelated city diagnostics, but the new local-only remote check
+  reports OK for the gascity rig.
+- Dashboard/API checks are not required; this change does not touch
+  `internal/api/`, OpenAPI schema files, dashboard code, or generated
+  dashboard types.


### PR DESCRIPTION
## What this changes

`gc doctor` now detects off-box Dolt remotes on rigs that explicitly declare `dolt.local-only: true` in their `.beads/config.yaml`. When that flag is present, the new `rig:<name>:dolt-local-only-remote` check warns on remotes such as `origin` or network URLs, allows local backup remotes, and can remove the offending remote through `gc doctor --fix` by calling `bd dolt remote remove <name>`.

The change also updates the gascity agent instructions so session close no longer tells agents to run `bd dolt push`, `bd dolt pull`, or `bd dolt remote add` in this local-only setup.

## Review notes

- The check is deliberately gated by the literal `dolt.local-only` key; absent or false means no warning and no fix.
- Registration follows the existing managed-bdstore rig path next to `DoltBackupCheck`, and skips file-backed, suspended, or `GC_DOLT=skip` cases.
- `internal/beads/contract.ReadDoltLocalOnly` is the new shared reader for the raw config key.
- No HTTP API, dashboard, OpenAPI, or generated dashboard type changes are included.
- Tracking bead: `ga-9usr9`; full gate evidence is in the release gate file.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] `gc doctor --json` smoke: `rig:gascity:dolt-local-only-remote` reports OK for the live gascity rig
- [x] Release gate: [`release-gates/ga-9usr9-dolt-local-only-remote-guard-gate.md`](release-gates/ga-9usr9-dolt-local-only-remote-guard-gate.md)