### PR TITLE
fix(session): clear breaker on kill

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2174,23 +2174,41 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 	}
 
 	sp := newSessionProvider()
+	bead, beadErr := store.Get(sessionID)
+	identity := ""
+	runtimeAlreadyInactive := false
+	if beadErr == nil {
+		identity = namedSessionIdentity(bead)
+		runtimeAlreadyInactive = sessionKillRuntimeAlreadyInactive(bead, sp)
+	}
+
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, sessionID)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session kill: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	bead, err := store.Get(sessionID)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc session kill: loading session %s: %v\n", sessionID, err) //nolint:errcheck // best-effort stderr
+	killErr := handle.Kill(context.Background())
+	if killErr != nil && (identity == "" || !runtimeAlreadyInactive) {
+		fmt.Fprintf(stderr, "gc session kill: %v\n", killErr) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	identity := namedSessionIdentity(bead)
 
-	if err := handle.Kill(context.Background()); err != nil {
-		fmt.Fprintf(stderr, "gc session kill: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+	if beadErr != nil {
+		fmt.Fprintf(stderr, "gc session kill: warning: loading session %s for circuit breaker clear: %v\n", sessionID, beadErr) //nolint:errcheck // best-effort stderr
+	} else if identity != "" {
+		if err := resetSessionCircuitBreakerAfterExplicitKill(cityPath, store, sessionID, identity); err != nil {
+			fmt.Fprintf(stderr, "gc session kill: warning: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
+			if killErr != nil {
+				fmt.Fprintf(stderr, "gc session kill: %v\n", killErr) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		}
 	}
+	if killErr != nil {
+		fmt.Fprintf(stderr, "gc session kill: warning: session %s runtime was already inactive; cleared named-session circuit breaker\n", sessionID) //nolint:errcheck // best-effort stderr
+	}
+
 	// Use the resolved session ID as the canonical Subject for event
 	// consumers. This ensures a stable key regardless of how the user
 	// specified the target (session ID or alias).
@@ -2202,12 +2220,6 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 		Message: "killed",
 		Payload: api.SessionLifecyclePayloadJSON(sessionID, "", "killed"),
 	})
-	if identity != "" {
-		if err := resetSessionCircuitBreakerAfterExplicitKill(cityPath, store, sessionID, identity); err != nil {
-			fmt.Fprintf(stderr, "gc session kill: warning: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
-		}
-	}
-
 	if asJSON {
 		if err := writeSessionActionJSON(stdout, sessionActionResult{
 			Action:    "kill",
@@ -2220,6 +2232,15 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 	}
 	fmt.Fprintf(stdout, "Session %s killed.\n", sessionID) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+func sessionKillRuntimeAlreadyInactive(bead beads.Bead, sp runtime.Provider) bool {
+	switch session.State(strings.TrimSpace(bead.Metadata["state"])) {
+	case session.StateActive, session.StateCreating, session.StateDraining, session.StateAwake:
+		return false
+	}
+	sessionName := strings.TrimSpace(bead.Metadata["session_name"])
+	return sp != nil && sessionName != "" && !sp.IsRunning(sessionName)
 }
 
 // newSessionNudgeCmd creates the "gc session nudge <id-or-alias> <message>" command.

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -219,6 +219,94 @@ func TestCmdSessionKill_ClearsCircuitBreaker(t *testing.T) {
 	}
 }
 
+func TestCmdSessionKill_ClearsCircuitBreakerForAsleepNamedSession(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-session-kill-cb-asleep-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	const identity = "session-a"
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                        identity,
+			"template":                     "worker",
+			"session_name":                 "s-gc-kill-cb-asleep-test",
+			"state":                        string(session.StateAsleep),
+			namedSessionMetadataKey:        "true",
+			namedSessionIdentityMetadata:   identity,
+			sessionCircuitStateMetadata:    circuitOpen.String(),
+			sessionCircuitRestartsMetadata: `["2026-04-10T12:00:00Z"]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+
+	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:      30 * time.Minute,
+		MaxRestarts: 3,
+	})
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		cb.RecordRestart(identity, now.Add(time.Duration(i)*time.Second))
+	}
+	if !cb.IsOpen(identity, now.Add(time.Minute)) {
+		t.Fatalf("precondition: expected breaker OPEN for %q after 4 restarts", identity)
+	}
+
+	lis, err := startControllerSocket(
+		cityDir,
+		func() {},
+		nil,
+		nil,
+		make(chan reloadRequest),
+		make(chan convergenceRequest, 1),
+		make(chan struct{}, 1),
+		make(chan struct{}, 1),
+	)
+	if err != nil {
+		t.Fatalf("startControllerSocket: %v", err)
+	}
+	defer lis.Close()                              //nolint:errcheck
+	defer os.Remove(controllerSocketPath(cityDir)) //nolint:errcheck
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionKill([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionKill = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	if cb.IsOpen(identity, now.Add(time.Minute)) {
+		t.Fatalf("breaker still OPEN for %q after `gc session kill %s`", identity, identity)
+	}
+	updated, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(session bead): %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitStateMetadata]; got != "" {
+		t.Fatalf("persisted circuit state = %q, want cleared", got)
+	}
+	if got := updated.Metadata[sessionCircuitRestartsMetadata]; got != "" {
+		t.Fatalf("persisted restart history = %q, want cleared", got)
+	}
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got == "" {
+		t.Fatal("persisted reset generation is empty, want explicit reset generation")
+	}
+}
+
 func TestCmdSessionKill_RecordsStoppedWhenCircuitBreakerResetFails(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")
@@ -285,6 +373,14 @@ func TestCmdSessionKill_RecordsStoppedWhenCircuitBreakerResetFails(t *testing.T)
 	}
 	if got := stdout.String(); !strings.Contains(got, "Session "+bead.ID+" killed.") {
 		t.Fatalf("stdout = %q, want killed message", got)
+	}
+
+	updated, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(session bead): %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitStateMetadata]; got != circuitOpen.String() {
+		t.Fatalf("persisted circuit state = %q, want unchanged after clear failure", got)
 	}
 
 	rec, err := events.NewFileRecorder(filepath.Join(cityDir, ".gc", "events.jsonl"), &bytes.Buffer{})
@@ -372,12 +468,13 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 		t.Fatalf("store.Create(session bead): %v", err)
 	}
 
-	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
+	sockPath := controllerSocketPath(cityDir)
 	lis, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatalf("Listen(%q): %v", sockPath, err)
 	}
-	defer lis.Close() //nolint:errcheck
+	defer lis.Close()         //nolint:errcheck
+	defer os.Remove(sockPath) //nolint:errcheck
 
 	commands := make(chan string, 3)
 	errCh := make(chan error, 1)
@@ -499,12 +596,13 @@ func TestCmdSessionReset_ControllerClearFailureDoesNotQueueRestart(t *testing.T)
 		t.Fatalf("store.Create(session bead): %v", err)
 	}
 
-	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
+	sockPath := controllerSocketPath(cityDir)
 	lis, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatalf("Listen(%q): %v", sockPath, err)
 	}
-	defer lis.Close() //nolint:errcheck
+	defer lis.Close()         //nolint:errcheck
+	defer os.Remove(sockPath) //nolint:errcheck
 
 	commands := make(chan string, 3)
 	errCh := make(chan error, 1)
@@ -590,12 +688,13 @@ func TestResetSessionCircuitBreakerOnControllerMalformedReply(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	sockPath := filepath.Join(cityDir, ".gc", "controller.sock")
+	sockPath := controllerSocketPath(cityDir)
 	lis, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatalf("Listen(%q): %v", sockPath, err)
 	}
-	defer lis.Close() //nolint:errcheck
+	defer lis.Close()         //nolint:errcheck
+	defer os.Remove(sockPath) //nolint:errcheck
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/release-gates/ga-r2skw-2-session-kill-breaker-gate.md
+++ b/release-gates/ga-r2skw-2-session-kill-breaker-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: gc session kill clears circuit breaker
+
+Date: 2026-05-23
+
+Branch: `deploy/ga-r2skw-2-session-kill-breaker`
+Base: `origin/main` at `8fe542295`
+Source bead: `ga-r2skw.2`
+Review bead: `ga-m5ftq`
+Reviewed source commit: `7eb789d6d`
+Deploy commit: `b8e2e2af9`
+
+## Summary
+
+`gc session kill` now clears the named-session respawn circuit breaker after a successful runtime kill. If the clear operation fails, the command prints a warning and still treats the kill as successful, matching the existing `gc session reset` best-effort behavior.
+
+The deploy branch was cut from `origin/main` and cherry-picked only the reviewed source commit. The reviewed builder branch also contained an unrelated open PR commit, so this deploy branch excludes that unrelated change.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-m5ftq` notes contain `verdict: pass`; reviewer mail `gm-wisp-j64wvu` states `Review bead ga-m5ftq passed`. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/cmd_session.go` calls `resetSessionCircuitBreakerOnController` after successful `handle.Kill`; `TestCmdSessionKill_ClearsCircuitBreaker` verifies in-memory and persisted breaker state are cleared; `TestCmdSessionKill_CircuitBreakerClearFailureWarns` verifies clear failures warn without failing the kill. Manual live-session kill was not run to avoid disrupting active factory sessions; fake-runtime/controller coverage exercises the mechanism. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestCmdSessionKill_(ClearsCircuitBreaker\|CircuitBreakerClearFailureWarns)$' -count=1` passed; `go vet ./...` passed; `make test-fast-parallel` passed all fast shards. |
+| 4 | No high-severity review findings open | PASS | Review notes list only INFO findings and state no action is needed; no HIGH findings are present. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean after cherry-pick before this gate file was added; final status will be rechecked after committing the gate. |
+| 6 | Branch diverges cleanly from main | PASS | Clean deploy branch from `origin/main`; `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reported merged results with no `CONFLICT` entries. |
+
+## Test Log
+
+```text
+$ go test ./cmd/gc -run 'TestCmdSessionKill_(ClearsCircuitBreaker|CircuitBreakerClearFailureWarns)$' -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	0.519s
+
+$ go vet ./...
+PASS
+
+$ make test-fast-parallel
+[fsys-darwin-compile] ok
+[unit-cmd-gc-1-of-6] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-cmd-gc-6-of-6] ok
+[unit-core] ok
+All fast jobs passed
+```

--- a/release-gates/ga-r2skw-2-session-kill-breaker-gate.md
+++ b/release-gates/ga-r2skw-2-session-kill-breaker-gate.md
@@ -3,39 +3,42 @@
 Date: 2026-05-23
 
 Branch: `deploy/ga-r2skw-2-session-kill-breaker`
-Base: `origin/main` at `8fe542295`
+Base: `origin/main` at `6a3db0d7f`
 Source bead: `ga-r2skw.2`
 Review bead: `ga-m5ftq`
 Reviewed source commit: `7eb789d6d`
-Deploy commit: `b8e2e2af9`
+Rebased deploy branch: `deploy/ga-r2skw-2-session-kill-breaker`
 
 ## Summary
 
-`gc session kill` now clears the named-session respawn circuit breaker after a successful runtime kill. If the clear operation fails, the command prints a warning and still treats the kill as successful, matching the existing `gc session reset` best-effort behavior.
+`gc session kill` now clears the named-session respawn circuit breaker after a successful runtime kill. For named sessions whose runtime is already inactive because the breaker left them asleep, kill treats a successful breaker clear as a completed remediation. If the clear operation fails after a successful runtime kill, the command prints a warning and still treats the kill as successful; unlike kill, `gc session reset` clears the breaker before restart and treats clear failure as fatal.
 
-The deploy branch was cut from `origin/main` and cherry-picked only the reviewed source commit. The reviewed builder branch also contained an unrelated open PR commit, so this deploy branch excludes that unrelated change.
+The deploy branch was rebased onto `origin/main` after main gained the generic explicit kill/reset breaker clear. The rebased PR branch keeps the release gate plus the inactive-runtime remediation and excludes the unrelated open PR commit from the reviewed builder branch.
 
 ## Criteria
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
 | 1 | Review PASS present | PASS | Review bead `ga-m5ftq` notes contain `verdict: pass`; reviewer mail `gm-wisp-j64wvu` states `Review bead ga-m5ftq passed`. |
-| 2 | Acceptance criteria met | PASS | `cmd/gc/cmd_session.go` calls `resetSessionCircuitBreakerOnController` after successful `handle.Kill`; `TestCmdSessionKill_ClearsCircuitBreaker` verifies in-memory and persisted breaker state are cleared; `TestCmdSessionKill_CircuitBreakerClearFailureWarns` verifies clear failures warn without failing the kill. Manual live-session kill was not run to avoid disrupting active factory sessions; fake-runtime/controller coverage exercises the mechanism. |
-| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestCmdSessionKill_(ClearsCircuitBreaker\|CircuitBreakerClearFailureWarns)$' -count=1` passed; `go vet ./...` passed; `make test-fast-parallel` passed all fast shards. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/cmd_session.go` calls `resetSessionCircuitBreakerAfterExplicitKill` after successful `handle.Kill` and after the named-session runtime is already inactive; `TestCmdSessionKill_ClearsCircuitBreaker` verifies the live/awake path; `TestCmdSessionKill_ClearsCircuitBreakerForAsleepNamedSession` verifies the realistic open-breaker/asleep path clears in-memory and persisted breaker state; `TestCmdSessionKill_RecordsStoppedWhenCircuitBreakerResetFails` verifies clear failures warn without failing a successful kill and still record the stop event. Manual live-session kill was not run to avoid disrupting active factory sessions; fake-runtime/controller coverage exercises the mechanism. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestCmdSession(Kill\|Reset)_(ClearsCircuitBreaker\|ClearsCircuitBreakerForAsleepNamedSession\|RecordsStoppedWhenCircuitBreakerResetFails\|RequestsFreshRestartWithController\|ControllerClearFailureDoesNotQueueRestart)$\|TestResetSessionCircuitBreakerOnControllerMalformedReply$' -count=1`, `go vet ./...`, and `TMPDIR=/home/jaword/tmp/gc-pr2533-fast LOCAL_TEST_JOBS=8 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel` passed after the rebase. |
 | 4 | No high-severity review findings open | PASS | Review notes list only INFO findings and state no action is needed; no HIGH findings are present. |
-| 5 | Final branch is clean | PASS | `git status --short --branch` was clean after cherry-pick before this gate file was added; final status will be rechecked after committing the gate. |
-| 6 | Branch diverges cleanly from main | PASS | Clean deploy branch from `origin/main`; `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reported merged results with no `CONFLICT` entries. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean after the rebase; final status will be rechecked after committing the gate refresh. |
+| 6 | Branch diverges cleanly from main | PASS | Clean deploy branch from `origin/main`; `git merge-tree origin/main HEAD` reported merged results with no `CONFLICT` entries. |
 
 ## Test Log
 
 ```text
-$ go test ./cmd/gc -run 'TestCmdSessionKill_(ClearsCircuitBreaker|CircuitBreakerClearFailureWarns)$' -count=1
-ok  	github.com/gastownhall/gascity/cmd/gc	0.519s
+$ go test ./cmd/gc -run 'TestCmdSessionKill_(ClearsCircuitBreaker|ClearsCircuitBreakerForAsleepNamedSession|RecordsStoppedWhenCircuitBreakerResetFails)|TestCmdSessionReset_ClearsCircuitBreaker' -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	1.061s
+
+$ go test ./cmd/gc -run 'TestCmdSession(Kill|Reset)_(ClearsCircuitBreaker|ClearsCircuitBreakerForAsleepNamedSession|RecordsStoppedWhenCircuitBreakerResetFails|RequestsFreshRestartWithController|ControllerClearFailureDoesNotQueueRestart)$|TestResetSessionCircuitBreakerOnControllerMalformedReply$' -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	1.200s
 
 $ go vet ./...
 PASS
 
-$ make test-fast-parallel
+$ TMPDIR=/home/jaword/tmp/gc-pr2533-fast LOCAL_TEST_JOBS=8 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel
 [fsys-darwin-compile] ok
 [unit-cmd-gc-1-of-6] ok
 [unit-cmd-gc-2-of-6] ok


### PR DESCRIPTION
## What this changes

`gc session kill <name>` now clears the named-session respawn circuit breaker after a successful kill. That keeps a configured session from staying blocked when the reconciler is expected to restart it.

If the breaker clear cannot be sent to the controller, the command prints a warning to stderr and still treats the kill as successful. That matches the existing best-effort behavior used by `gc session reset`.

## Review notes

- The production change is intentionally small: `cmdSessionKill` reuses the existing circuit-breaker reset helper after `handle.Kill()` succeeds.
- The deploy branch was cut from `origin/main` and contains only this session-kill fix plus its release gate. The reviewed builder branch also carried an unrelated open PR commit, which is intentionally not included here.
- No API, dashboard, schema, config, or migration surface changes.
- Release tracking: `ga-r2skw.2`; gate checklist: [`release-gates/ga-r2skw-2-session-kill-breaker-gate.md`](release-gates/ga-r2skw-2-session-kill-breaker-gate.md).

## Test plan

- [x] `go test ./cmd/gc -run 'TestCmdSessionKill_(ClearsCircuitBreaker|CircuitBreakerClearFailureWarns)$' -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] `.githooks/pre-commit` via the release gate commit