### PR TITLE
fix(sling): nudge bead-named pool sessions

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1465,8 +1465,9 @@ func doSlingNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
 	if a.SupportsInstanceExpansion() {
 		// Find a running multi-session instance to nudge.
 		sp0 := scaleParamsFor(a)
-		for _, qn := range discoverPoolInstances(a.Name, a.Dir, sp0, a, cityName, st, sp) {
-			sn := lookupSessionNameOrLegacy(store, cityName, qn, st)
+		for _, ref := range resolvePoolSessionRefs(store, cfg, a.Name, a.Dir, sp0, a, cityName, st, sp, stderr) {
+			qn := ref.qualifiedInstance
+			sn := ref.sessionName
 			running, err := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, sn)
 			if err == nil && running {
 				member, ok := resolveAgentIdentity(cfg, qn, currentRigContext(cfg))

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -934,6 +934,74 @@ func TestDoSlingNudgePoolMember(t *testing.T) {
 	}
 }
 
+func TestDoSlingNudgePoolMemberUsesBeadDerivedSessionName(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	const sessionName = "gm-glz06f"
+	if err := sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
+		t.Fatalf("Start(%q): %v", sessionName, err)
+	}
+	sp.WaitForIdleErrors[sessionName] = nil
+	sp.Calls = nil
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name: "polecat",
+			Dir:  "hw",
+		}},
+	}
+	a := cfg.Agents[0]
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.CityPath = t.TempDir()
+	store := newSlingTestStore()
+	deps.Store = store
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "pool session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":      "hw/polecat",
+			"agent_name":    "hw/polecat",
+			"provider_kind": "claude",
+			"session_name":  sessionName,
+			"pool_slot":     "7",
+			"state":         "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session bead): %v", err)
+	}
+
+	opts := testOpts(a, "BL-1")
+	opts.Nudge = true
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	for _, c := range sp.Calls {
+		if (c.Method == "Nudge" || c.Method == "NudgeNow") && c.Name == sessionName {
+			if !strings.Contains(stdout.String(), "Nudged hw/polecat") {
+				t.Fatalf("stdout = %q, want delivered nudge confirmation", stdout.String())
+			}
+			if strings.Contains(stdout.String(), "No running sessions") || strings.Contains(stderr.String(), "poke failed") {
+				t.Fatalf("stdout=%q stderr=%q, want no controller wake fallback", stdout.String(), stderr.String())
+			}
+			updated, err := store.Get(sessionBead.ID)
+			if err != nil {
+				t.Fatalf("Get(session bead): %v", err)
+			}
+			if got := updated.Metadata["last_nudge_delivered_at"]; got == "" {
+				t.Fatalf("last_nudge_delivered_at = %q, want delivered nudge stamp", got)
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime calls = %+v, want Nudge/NudgeNow on bead-derived session %q", sp.Calls, sessionName)
+}
+
 func TestDoSlingNudgePoolNoMembers(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/release-gates/ga-hv2pw-sling-nudge-gate.md
+++ b/release-gates/ga-hv2pw-sling-nudge-gate.md
@@ -1,0 +1,62 @@
+# Release Gate: gc sling nudge finds bead-named pool sessions
+
+Gate date: 2026-05-23
+
+Needs-deploy bead: ga-hv2pw
+Source bead: ga-r2skw.1
+Final branch: deploy/ga-hv2pw-sling-nudge
+Reviewed commit: 7483229bd
+Deploy commit: 754242820
+
+Note: docs/PROJECT_MANIFEST.md is not present in this worktree, so this gate
+uses the deployer Release Gate Criteria supplied in the agent prompt.
+
+## Summary
+
+This change fixes `gc sling <agent> --nudge` for expandable agent pools when a
+running pool member uses a bead-derived session name. The nudge path now uses
+bead-backed pool session refs and sends the runtime nudge to the stored
+`session_name`, while preserving the legacy discovery fallback.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-hv2pw` notes contain `verdict: pass`; reviewer reported `findings: none`. |
+| 2 | Acceptance criteria met | PASS | `TestDoSlingNudgePoolMemberUsesBeadDerivedSessionName` starts a fake runtime session named `gm-glz06f`, creates a matching session bead, runs the `--nudge` path, asserts a nudge is delivered to that bead-derived name, rejects the controller-wake fallback, and verifies `last_nudge_delivered_at` is stamped. `TestDoSlingNudgePoolMember` keeps legacy path coverage. The live factory nudge smoke was not run to avoid injecting work into active builder sessions; the isolated fake-runtime test covers the same delivery and stamp behavior without side effects. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestDoSlingNudgePool(Member|NoMembers)' -count=1` passed. `go test ./cmd/gc/... -count=1` passed. `go vet ./...` passed. `make test-fast-parallel` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-hv2pw` report `findings: none`; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed only `deploy/ga-hv2pw-sling-nudge...origin/main [ahead 1]` with no worktree changes. Gate file is committed in the release-gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | Branch was created with `git checkout -B deploy/ga-hv2pw-sling-nudge origin/main`; reviewed commit cherry-picked cleanly. `git merge-base --is-ancestor origin/main HEAD` passed and `git diff --check origin/main...HEAD` produced no output. |
+
+## Acceptance Checklist
+
+- [x] Expandable-agent `--nudge` delivers to a running bead-derived session
+      name instead of falling through to controller wake.
+- [x] Delivery updates the session bead's `last_nudge_delivered_at` metadata.
+- [x] Legacy pool-member nudge coverage remains in place.
+- [x] `go test ./cmd/gc/... -count=1` green.
+- [x] `go vet ./...` clean.
+
+## Test Log
+
+```text
+ok  	github.com/gastownhall/gascity/cmd/gc	0.439s
+
+ok  	github.com/gastownhall/gascity/cmd/gc	392.346s
+ok  	github.com/gastownhall/gascity/cmd/gc/dashboard	0.006s
+
+go vet ./...
+PASS
+
+make test-fast-parallel
+[fsys-darwin-compile] ok
+[unit-cmd-gc-1-of-6] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-cmd-gc-6-of-6] ok
+[unit-core] ok
+All fast jobs passed
+```


### PR DESCRIPTION
## What this changes

`gc sling <agent> --nudge` now finds running expandable pool sessions through bead-backed pool session refs and sends the runtime nudge to the stored `session_name`. Before this, the pool path reconstructed legacy names and prefix matches, so bead-derived sessions could look absent and fall through to controller wake instead of receiving the nudge.

The legacy discovery fallback remains in place for sessions without bead records.

## Review notes

- The main behavior change is in `cmd/gc/cmd_sling.go`: the expandable pool nudge loop now consumes `resolvePoolSessionRefs` results and uses `ref.sessionName` for the running check and nudge target.
- The regression in `cmd/gc/cmd_sling_test.go` starts a fake runtime session named `gm-glz06f`, records a matching session bead, and verifies direct nudge delivery plus `last_nudge_delivered_at` stamping.
- There are no config, schema, endpoint, or dashboard changes.

Internal tracking: ga-hv2pw / ga-r2skw.1.

## Test plan

- [x] `go test ./cmd/gc -run 'TestDoSlingNudgePool(Member|NoMembers)' -count=1`
- [x] `go test ./cmd/gc/... -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-hv2pw-sling-nudge-gate.md`](release-gates/ga-hv2pw-sling-nudge-gate.md)
