### PR TITLE
Harden detached session diagnostics and local-only Dolt checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,10 +342,12 @@ bd close <id>         # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```
+   NOTE: gascity Dolt is LOCAL-ONLY (no remote). Do NOT run `bd dolt push`,
+   `bd dolt pull`, or `bd dolt remote add` here -- they fail and re-introduce
+   a doomed `origin` remote (ga-9wsri). Use `git push` only.
 5. **Clean up** - Clear stashes, prune remote branches
 6. **Verify** - All changes committed AND pushed
 7. **Hand off** - Provide context for next session

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -298,7 +298,9 @@ suspended = true
 	oldCityCheck := newDoctorDoltServerCheck
 	oldRigCheck := newDoctorRigDoltServerCheck
 	oldBackupCheck := newDoctorDoltBackupCheck
-	registered := map[string]string{}
+	oldLocalOnlyCheck := newDoctorDoltLocalOnlyCheck
+	registeredBackup := map[string]string{}
+	registeredLocalOnly := map[string]string{}
 	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
 		return doctor.NewDoltServerCheck(cityPath, true)
 	}
@@ -306,29 +308,46 @@ suspended = true
 		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
 	}
 	newDoctorDoltBackupCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltBackupCheck {
-		registered[rig.Name] = dataDir
+		registeredBackup[rig.Name] = dataDir
 		return doctor.NewDoltBackupCheck(cityPath, rig, dataDir)
+	}
+	newDoctorDoltLocalOnlyCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltLocalOnlyRemoteCheck {
+		registeredLocalOnly[rig.Name] = dataDir
+		return doctor.NewDoltLocalOnlyRemoteCheck(cityPath, rig, dataDir)
 	}
 	t.Cleanup(func() {
 		newDoctorDoltServerCheck = oldCityCheck
 		newDoctorRigDoltServerCheck = oldRigCheck
 		newDoctorDoltBackupCheck = oldBackupCheck
+		newDoctorDoltLocalOnlyCheck = oldLocalOnlyCheck
 	})
 
 	var stdout, stderr bytes.Buffer
 	_ = doDoctor(false, false, false, false, &stdout, &stderr)
 
-	if len(registered) != 1 {
-		t.Fatalf("registered dolt-backup checks = %#v, want only active managed rig", registered)
+	if len(registeredBackup) != 1 {
+		t.Fatalf("registered dolt-backup checks = %#v, want only active managed rig", registeredBackup)
 	}
-	if got := registered["managed"]; got != doltDataDir {
+	if got := registeredBackup["managed"]; got != doltDataDir {
 		t.Fatalf("managed rig data dir = %q, want runtime layout data dir %q", got, doltDataDir)
 	}
-	if _, ok := registered["filebacked"]; ok {
-		t.Fatalf("file-backed rig should not register dolt-backup check: %#v", registered)
+	if _, ok := registeredBackup["filebacked"]; ok {
+		t.Fatalf("file-backed rig should not register dolt-backup check: %#v", registeredBackup)
 	}
-	if _, ok := registered["sleeping"]; ok {
-		t.Fatalf("suspended rig should not register dolt-backup check: %#v", registered)
+	if _, ok := registeredBackup["sleeping"]; ok {
+		t.Fatalf("suspended rig should not register dolt-backup check: %#v", registeredBackup)
+	}
+	if len(registeredLocalOnly) != 1 {
+		t.Fatalf("registered dolt-local-only checks = %#v, want only active managed rig", registeredLocalOnly)
+	}
+	if got := registeredLocalOnly["managed"]; got != doltDataDir {
+		t.Fatalf("managed rig local-only data dir = %q, want runtime layout data dir %q", got, doltDataDir)
+	}
+	if _, ok := registeredLocalOnly["filebacked"]; ok {
+		t.Fatalf("file-backed rig should not register dolt-local-only check: %#v", registeredLocalOnly)
+	}
+	if _, ok := registeredLocalOnly["sleeping"]; ok {
+		t.Fatalf("suspended rig should not register dolt-local-only check: %#v", registeredLocalOnly)
 	}
 }
 
@@ -376,7 +395,9 @@ prefix = "ma"
 	oldCityCheck := newDoctorDoltServerCheck
 	oldRigCheck := newDoctorRigDoltServerCheck
 	oldBackupCheck := newDoctorDoltBackupCheck
-	registered := 0
+	oldLocalOnlyCheck := newDoctorDoltLocalOnlyCheck
+	registeredBackup := 0
+	registeredLocalOnly := 0
 	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
 		return doctor.NewDoltServerCheck(cityPath, true)
 	}
@@ -384,20 +405,28 @@ prefix = "ma"
 		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
 	}
 	newDoctorDoltBackupCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltBackupCheck {
-		registered++
+		registeredBackup++
 		return doctor.NewDoltBackupCheck(cityPath, rig, dataDir)
+	}
+	newDoctorDoltLocalOnlyCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltLocalOnlyRemoteCheck {
+		registeredLocalOnly++
+		return doctor.NewDoltLocalOnlyRemoteCheck(cityPath, rig, dataDir)
 	}
 	t.Cleanup(func() {
 		newDoctorDoltServerCheck = oldCityCheck
 		newDoctorRigDoltServerCheck = oldRigCheck
 		newDoctorDoltBackupCheck = oldBackupCheck
+		newDoctorDoltLocalOnlyCheck = oldLocalOnlyCheck
 	})
 
 	var stdout, stderr bytes.Buffer
 	_ = doDoctor(false, false, false, false, &stdout, &stderr)
 
-	if registered != 0 {
-		t.Fatalf("registered %d dolt-backup checks, want 0 when GC_DOLT=skip", registered)
+	if registeredBackup != 0 {
+		t.Fatalf("registered %d dolt-backup checks, want 0 when GC_DOLT=skip", registeredBackup)
+	}
+	if registeredLocalOnly != 0 {
+		t.Fatalf("registered %d dolt-local-only checks, want 0 when GC_DOLT=skip", registeredLocalOnly)
 	}
 }
 

--- a/cmd/gc/detached_probe.go
+++ b/cmd/gc/detached_probe.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
 const (
 	detachedProbeMetadataKey    = "gc.detached"
 	detachedProbeDefaultTimeout = time.Second
+	detachedProbeErrorThreshold = 3
 )
 
 type detachedProbeStatus string
@@ -33,6 +35,13 @@ type detachedProbeResult struct {
 	Status detachedProbeStatus
 	Spec   detachedProbeSpec
 	Err    error
+}
+
+var detachedProbeErrorCounts = struct {
+	sync.Mutex
+	byBead map[string]int
+}{
+	byBead: make(map[string]int),
 }
 
 func parseDetachedProbeSpec(spec string) (detachedProbeSpec, error) {
@@ -83,4 +92,26 @@ func probeDetachedWorkWithTimeout(ctx context.Context, spec string, timeout time
 		return detachedProbeResult{Status: detachedProbeError, Spec: parsed, Err: err}
 	}
 	return detachedProbeResult{Status: detachedProbeAlive, Spec: parsed}
+}
+
+func incrementDetachedProbeErrorCount(id string) int {
+	detachedProbeErrorCounts.Lock()
+	defer detachedProbeErrorCounts.Unlock()
+	if detachedProbeErrorCounts.byBead == nil {
+		detachedProbeErrorCounts.byBead = make(map[string]int)
+	}
+	detachedProbeErrorCounts.byBead[id]++
+	return detachedProbeErrorCounts.byBead[id]
+}
+
+func clearDetachedProbeErrorCount(id string) {
+	detachedProbeErrorCounts.Lock()
+	defer detachedProbeErrorCounts.Unlock()
+	delete(detachedProbeErrorCounts.byBead, id)
+}
+
+func resetDetachedProbeErrorCountsForTest() {
+	detachedProbeErrorCounts.Lock()
+	defer detachedProbeErrorCounts.Unlock()
+	detachedProbeErrorCounts.byBead = make(map[string]int)
 }

--- a/cmd/gc/detached_probe.go
+++ b/cmd/gc/detached_probe.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	detachedProbeMetadataKey    = "gc.detached"
+	detachedProbeDefaultTimeout = time.Second
+)
+
+type detachedProbeStatus string
+
+const (
+	detachedProbeAlive   detachedProbeStatus = "alive"
+	detachedProbeDead    detachedProbeStatus = "dead"
+	detachedProbeError   detachedProbeStatus = "error"
+	detachedProbeTimeout detachedProbeStatus = "timeout"
+)
+
+type detachedProbeSpec struct {
+	Kind    string
+	Socket  string
+	Session string
+}
+
+type detachedProbeResult struct {
+	Status detachedProbeStatus
+	Spec   detachedProbeSpec
+	Err    error
+}
+
+func parseDetachedProbeSpec(spec string) (detachedProbeSpec, error) {
+	parts := strings.SplitN(strings.TrimSpace(spec), ":", 3)
+	if len(parts) != 3 {
+		return detachedProbeSpec{}, fmt.Errorf("parsing detached probe spec %q: want tmux:<socket>:<session>", spec)
+	}
+	kind := strings.TrimSpace(parts[0])
+	socket := strings.TrimSpace(parts[1])
+	session := strings.TrimSpace(parts[2])
+	if kind != "tmux" {
+		return detachedProbeSpec{}, fmt.Errorf("parsing detached probe spec %q: unsupported kind %q", spec, kind)
+	}
+	if socket == "" || session == "" {
+		return detachedProbeSpec{}, fmt.Errorf("parsing detached probe spec %q: socket and session are required", spec)
+	}
+	return detachedProbeSpec{
+		Kind:    kind,
+		Socket:  socket,
+		Session: session,
+	}, nil
+}
+
+func probeDetachedWork(ctx context.Context, spec string) detachedProbeResult {
+	return probeDetachedWorkWithTimeout(ctx, spec, detachedProbeDefaultTimeout)
+}
+
+func probeDetachedWorkWithTimeout(ctx context.Context, spec string, timeout time.Duration) detachedProbeResult {
+	parsed, err := parseDetachedProbeSpec(spec)
+	if err != nil {
+		return detachedProbeResult{Status: detachedProbeError, Err: err}
+	}
+	if timeout <= 0 {
+		timeout = detachedProbeDefaultTimeout
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(probeCtx, "tmux", "-L", parsed.Socket, "has-session", "-t", parsed.Session)
+	if err := cmd.Run(); err != nil {
+		if errors.Is(probeCtx.Err(), context.DeadlineExceeded) {
+			return detachedProbeResult{Status: detachedProbeTimeout, Spec: parsed, Err: probeCtx.Err()}
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return detachedProbeResult{Status: detachedProbeDead, Spec: parsed}
+		}
+		return detachedProbeResult{Status: detachedProbeError, Spec: parsed, Err: err}
+	}
+	return detachedProbeResult{Status: detachedProbeAlive, Spec: parsed}
+}

--- a/cmd/gc/detached_probe_test.go
+++ b/cmd/gc/detached_probe_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseDetachedProbeSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    detachedProbeSpec
+		wantErr bool
+	}{
+		{
+			name: "tmux spec",
+			spec: "tmux:gascity:soak-loop",
+			want: detachedProbeSpec{
+				Kind:    "tmux",
+				Socket:  "gascity",
+				Session: "soak-loop",
+			},
+		},
+		{
+			name: "session keeps extra colons",
+			spec: "tmux:gascity:scope:soak-loop",
+			want: detachedProbeSpec{
+				Kind:    "tmux",
+				Socket:  "gascity",
+				Session: "scope:soak-loop",
+			},
+		},
+		{
+			name:    "unsupported kind",
+			spec:    "k8s:pod:agent",
+			wantErr: true,
+		},
+		{
+			name:    "missing session",
+			spec:    "tmux:gascity",
+			wantErr: true,
+		},
+		{
+			name:    "empty socket",
+			spec:    "tmux::soak-loop",
+			wantErr: true,
+		},
+		{
+			name:    "empty session",
+			spec:    "tmux:gascity:",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDetachedProbeSpec(tt.spec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseDetachedProbeSpec(%q) error = nil, want error", tt.spec)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDetachedProbeSpec(%q) error = %v", tt.spec, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseDetachedProbeSpec(%q) = %+v, want %+v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProbeDetachedWork_TmuxExitStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		exitCode   string
+		wantStatus detachedProbeStatus
+	}{
+		{name: "alive on exit zero", exitCode: "0", wantStatus: detachedProbeAlive},
+		{name: "dead on exit one", exitCode: "1", wantStatus: detachedProbeDead},
+		{name: "error on other exit", exitCode: "2", wantStatus: detachedProbeError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argsFile := filepath.Join(t.TempDir(), "args")
+			installFakeTmux(t, `printf '%s\n' "$@" > "$FAKE_TMUX_ARGS"; exit `+tt.exitCode)
+			t.Setenv("FAKE_TMUX_ARGS", argsFile)
+
+			got := probeDetachedWork(context.Background(), "tmux:gascity:soak-loop")
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %q, want %q (err=%v)", got.Status, tt.wantStatus, got.Err)
+			}
+			args, err := os.ReadFile(argsFile)
+			if err != nil {
+				t.Fatalf("read fake tmux args: %v", err)
+			}
+			wantArgs := "-L\ngascity\nhas-session\n-t\nsoak-loop\n"
+			if string(args) != wantArgs {
+				t.Fatalf("tmux args = %q, want %q", string(args), wantArgs)
+			}
+		})
+	}
+}
+
+func TestProbeDetachedWork_MalformedSpecIsError(t *testing.T) {
+	got := probeDetachedWorkWithTimeout(context.Background(), "tmux:gascity", time.Second)
+	if got.Status != detachedProbeError {
+		t.Fatalf("Status = %q, want %q", got.Status, detachedProbeError)
+	}
+	if got.Err == nil {
+		t.Fatal("Err = nil, want parse error")
+	}
+}
+
+func TestProbeDetachedWork_Timeout(t *testing.T) {
+	installFakeTmux(t, "sleep 1")
+
+	got := probeDetachedWorkWithTimeout(context.Background(), "tmux:gascity:soak-loop", 10*time.Millisecond)
+	if got.Status != detachedProbeTimeout {
+		t.Fatalf("Status = %q, want %q (err=%v)", got.Status, detachedProbeTimeout, got.Err)
+	}
+	if got.Err == nil {
+		t.Fatal("Err = nil, want timeout error")
+	}
+}
+
+func installFakeTmux(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tmux")
+	script := "#!/bin/sh\n" + body + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	pathEnv := dir
+	if existing := os.Getenv("PATH"); strings.TrimSpace(existing) != "" {
+		pathEnv += string(os.PathListSeparator) + existing
+	}
+	t.Setenv("PATH", pathEnv)
+}

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"path"
 	"strings"
@@ -185,12 +186,64 @@ func releaseOrphanedPoolAssignments(
 		if !liveWorkAssignmentStillReleasable(ownerStore, wb.ID, assignee) {
 			continue
 		}
+		if !detachedProbeAllowsOrphanRelease(ownerStore, wb) {
+			continue
+		}
 		if !releaseOrphanedPoolAssignment(ownerStore, wb.ID) {
 			continue
 		}
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
 	}
 	return released
+}
+
+func detachedProbeAllowsOrphanRelease(store beads.Store, wb beads.Bead) bool {
+	spec := strings.TrimSpace(wb.Metadata[detachedProbeMetadataKey])
+	if spec == "" {
+		clearDetachedProbeErrorCount(wb.ID)
+		return true
+	}
+
+	result := probeDetachedWork(context.Background(), spec)
+	switch result.Status {
+	case detachedProbeAlive:
+		clearDetachedProbeErrorCount(wb.ID)
+		log.Printf("releaseOrphanedPoolAssignments: skipping release: detached probe alive for %s: %s", wb.ID, spec)
+		return false
+	case detachedProbeDead:
+		clearDetachedProbeErrorCount(wb.ID)
+		log.Printf("releaseOrphanedPoolAssignments: releasing %s: detached probe dead: %s", wb.ID, spec)
+		clearDetachedProbeMetadata(store, wb.ID)
+		return true
+	case detachedProbeError, detachedProbeTimeout:
+		count := incrementDetachedProbeErrorCount(wb.ID)
+		if count < detachedProbeErrorThreshold {
+			log.Printf("releaseOrphanedPoolAssignments: detached probe %s for %s: %v (error %d/%d)", result.Status, wb.ID, result.Err, count, detachedProbeErrorThreshold)
+			return false
+		}
+		clearDetachedProbeErrorCount(wb.ID)
+		log.Printf("releaseOrphanedPoolAssignments: releasing %s: detached probe %s after %d errors: %v", wb.ID, result.Status, count, result.Err)
+		clearDetachedProbeMetadata(store, wb.ID)
+		return true
+	default:
+		count := incrementDetachedProbeErrorCount(wb.ID)
+		if count < detachedProbeErrorThreshold {
+			log.Printf("releaseOrphanedPoolAssignments: detached probe unknown result for %s: %q (error %d/%d)", wb.ID, result.Status, count, detachedProbeErrorThreshold)
+			return false
+		}
+		clearDetachedProbeErrorCount(wb.ID)
+		clearDetachedProbeMetadata(store, wb.ID)
+		return true
+	}
+}
+
+func clearDetachedProbeMetadata(store beads.Store, id string) {
+	if store == nil || id == "" {
+		return
+	}
+	if err := store.SetMetadata(id, detachedProbeMetadataKey, ""); err != nil {
+		log.Printf("releaseOrphanedPoolAssignments: clearing detached probe metadata for %s: %v", id, err)
+	}
 }
 
 const unresolvedOpenSessionStoreRef = "\x00unresolved"

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -277,6 +280,178 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 	}
 	if got.Assignee != "" {
 		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_DetachedProbeAliveSkipsRelease(t *testing.T) {
+	resetDetachedProbeErrorCountsForTest()
+	store := beads.NewMemStore()
+	work := createDetachedOrphanedPoolWork(t, store, "tmux:gascity:soak-loop")
+	installFakeTmux(t, "exit 0")
+	var logs bytes.Buffer
+	restore := captureLogOutput(&logs)
+	defer restore()
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		nil,
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none while detached probe is alive", released)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Assignee != "worker-dead" {
+		t.Fatalf("assignee = %q, want worker-dead", got.Assignee)
+	}
+	if got.Metadata[detachedProbeMetadataKey] != "tmux:gascity:soak-loop" {
+		t.Fatalf("gc.detached = %q, want preserved", got.Metadata[detachedProbeMetadataKey])
+	}
+	if !strings.Contains(logs.String(), "detached probe alive") {
+		t.Fatalf("logs = %q, want detached probe alive diagnostic", logs.String())
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_DetachedProbeDeadReleasesAndClears(t *testing.T) {
+	resetDetachedProbeErrorCountsForTest()
+	store := beads.NewMemStore()
+	work := createDetachedOrphanedPoolWork(t, store, "tmux:gascity:soak-loop")
+	installFakeTmux(t, "exit 1")
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		nil,
+		nil,
+		nil,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+	if got.Metadata[detachedProbeMetadataKey] != "" {
+		t.Fatalf("gc.detached = %q, want cleared", got.Metadata[detachedProbeMetadataKey])
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_DetachedProbeErrorsReleaseOnThirdTick(t *testing.T) {
+	resetDetachedProbeErrorCountsForTest()
+	store := beads.NewMemStore()
+	work := createDetachedOrphanedPoolWork(t, store, "tmux:gascity:soak-loop")
+	installFakeTmux(t, "exit 2")
+
+	for tick := 1; tick <= 2; tick++ {
+		released := releaseOrphanedPoolAssignments(
+			store,
+			testPoolReleaseConfig(),
+			"",
+			nil,
+			[]beads.Bead{work},
+			nil,
+			nil,
+			nil,
+		)
+		if len(released) != 0 {
+			t.Fatalf("tick %d released = %v, want none before third error", tick, released)
+		}
+		got, err := store.Get(work.ID)
+		if err != nil {
+			t.Fatalf("tick %d Get work bead: %v", tick, err)
+		}
+		if got.Status != "in_progress" {
+			t.Fatalf("tick %d status = %q, want in_progress", tick, got.Status)
+		}
+		if _, ok := got.Metadata["error_count"]; ok {
+			t.Fatalf("tick %d persisted error_count metadata: %+v", tick, got.Metadata)
+		}
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		testPoolReleaseConfig(),
+		"",
+		nil,
+		[]beads.Bead{work},
+		nil,
+		nil,
+		nil,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("third tick released = %v, want [%s]", released, work.ID)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Metadata[detachedProbeMetadataKey] != "" {
+		t.Fatalf("gc.detached = %q, want cleared", got.Metadata[detachedProbeMetadataKey])
+	}
+	if _, ok := got.Metadata["error_count"]; ok {
+		t.Fatalf("persisted error_count metadata after release: %+v", got.Metadata)
+	}
+}
+
+func createDetachedOrphanedPoolWork(t *testing.T, store beads.Store, detachedSpec string) beads.Bead {
+	t.Helper()
+	work, err := store.Create(beads.Bead{
+		Title:    "orphaned pool work",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{
+			"gc.routed_to":           "worker",
+			detachedProbeMetadataKey: detachedSpec,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+	return work
+}
+
+func testPoolReleaseConfig() *config.City {
+	return &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
+}
+
+func captureLogOutput(buf *bytes.Buffer) func() {
+	previousOutput := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(buf)
+	log.SetFlags(0)
+	return func() {
+		log.SetOutput(previousOutput)
+		log.SetFlags(previousFlags)
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -2453,10 +2454,15 @@ func emitSessionStrandedDiagnostic(
 	if strings.TrimSpace(session.Metadata[strandedEventEmittedKey]) != "" {
 		return
 	}
-	ids, err := collectSessionAssignedWorkIDs(cityPath, cfg, store, rigStores, *session)
+	assignedWork, err := collectSessionAssignedWork(cityPath, cfg, store, rigStores, *session)
 	if err != nil {
 		fmt.Fprintf(stderr, "session reconciler: collecting stranded work ids for %s: %v\n", session.Metadata["session_name"], err) //nolint:errcheck
 	}
+	diagnosticWork := filterDetachedStrandedDiagnosticWork(assignedWork)
+	if err == nil && len(assignedWork) > 0 && len(diagnosticWork) == 0 {
+		return
+	}
+	ids := strandedAssignedWorkIDs(diagnosticWork)
 	now := clk.Now().UTC()
 	rec.Record(events.Event{
 		Type:    events.SessionStranded,
@@ -2472,6 +2478,39 @@ func emitSessionStrandedDiagnostic(
 	if err := store.SetMetadata(session.ID, strandedEventEmittedKey, now.Format(time.RFC3339)); err != nil {
 		fmt.Fprintf(stderr, "session reconciler: stamping stranded throttle marker on %s: %v\n", session.ID, err) //nolint:errcheck
 	}
+}
+
+type strandedAssignedWork struct {
+	bead  beads.Bead
+	store beads.Store
+}
+
+func filterDetachedStrandedDiagnosticWork(work []strandedAssignedWork) []strandedAssignedWork {
+	if len(work) == 0 {
+		return work
+	}
+	out := make([]strandedAssignedWork, 0, len(work))
+	for _, item := range work {
+		spec := strings.TrimSpace(item.bead.Metadata[detachedProbeMetadataKey])
+		if spec == "" {
+			out = append(out, item)
+			continue
+		}
+		result := probeDetachedWork(context.Background(), spec)
+		switch result.Status {
+		case detachedProbeAlive:
+			log.Printf("session reconciler: suppressing session.stranded for %s: detached probe alive: %s", item.bead.ID, spec)
+			continue
+		case detachedProbeDead:
+			log.Printf("session reconciler: clearing dead detached probe for %s before session.stranded: %s", item.bead.ID, spec)
+			clearDetachedProbeMetadata(item.store, item.bead.ID)
+			out = append(out, item)
+		default:
+			log.Printf("session reconciler: preserving session.stranded for %s after detached probe %s: %v", item.bead.ID, result.Status, result.Err)
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 // formatStrandedMessage builds the diagnostic message body for a
@@ -2495,21 +2534,22 @@ func formatStrandedMessage(template, sessionName string, ids []string) string {
 		prefix, len(ids), strings.Join(shown, ","), suffix)
 }
 
-// collectSessionAssignedWorkIDs returns the IDs of open/in_progress
-// work beads assigned to the session, excluding session beads
-// themselves. Mirrors the identifier resolution and store routing of
-// sessionHasOpenAssignedWorkForReachableStore so the diagnostic message
-// lists exactly the beads the gate considered when deciding to emit.
+// collectSessionAssignedWork returns the open/in_progress work beads
+// assigned to the session, excluding session beads themselves, along
+// with the store that owns each work bead. Mirrors the identifier
+// resolution and store routing of sessionHasOpenAssignedWorkForReachableStore
+// so the diagnostic path lists and mutates exactly the beads the gate
+// considered when deciding to emit.
 //
 // Without this alignment the gate could see assigned work (via the
 // config-derived named-session identity, or via a rig-store-routed
 // query) while the collector queried only the bare bead identifiers
 // against every store — producing a "0 stranded beads" message in the
 // exact failure mode the diagnostic exists to surface.
-func collectSessionAssignedWorkIDs(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, session beads.Bead) ([]string, error) {
+func collectSessionAssignedWork(cityPath string, cfg *config.City, store beads.Store, rigStores map[string]beads.Store, session beads.Bead) ([]strandedAssignedWork, error) {
 	identifiers := sessionAssignmentIdentifiersForConfig(session, cfg)
 	seen := make(map[string]struct{})
-	out := make([]string, 0, 4)
+	out := make([]strandedAssignedWork, 0, 4)
 	collect := func(s beads.Store) error {
 		if s == nil {
 			return nil
@@ -2531,7 +2571,7 @@ func collectSessionAssignedWorkIDs(cityPath string, cfg *config.City, store bead
 						continue
 					}
 					seen[item.ID] = struct{}{}
-					out = append(out, item.ID)
+					out = append(out, strandedAssignedWork{bead: item, store: s})
 				}
 			}
 		}
@@ -2567,6 +2607,14 @@ func collectSessionAssignedWorkIDs(cityPath string, cfg *config.City, store bead
 		}
 	}
 	return out, nil
+}
+
+func strandedAssignedWorkIDs(work []strandedAssignedWork) []string {
+	ids := make([]string, 0, len(work))
+	for _, item := range work {
+		ids = append(ids, item.bead.ID)
+	}
+	return ids
 }
 
 func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (bool, error) {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1570,6 +1570,127 @@ func (c *capturingRecorder) strandedEvents() []events.Event {
 	return out
 }
 
+func TestEmitSessionStrandedDiagnostic_DetachedProbeAliveSuppressesEvent(t *testing.T) {
+	store := beads.NewMemStore()
+	session, work := createDetachedStrandedWork(t, store, "tmux:gctest-stranded:soak-loop")
+	installFakeTmux(t, "exit 0")
+	rec := emitStrandedDiagnosticForTest(t, store, &session)
+
+	if stranded := rec.strandedEvents(); len(stranded) != 0 {
+		t.Fatalf("session.stranded events = %d, want 0 while detached probe is alive; events: %+v", len(stranded), rec.events)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Metadata[detachedProbeMetadataKey] != "tmux:gctest-stranded:soak-loop" {
+		t.Fatalf("gc.detached = %q, want preserved", got.Metadata[detachedProbeMetadataKey])
+	}
+	if session.Metadata[strandedEventEmittedKey] != "" {
+		t.Fatalf("session in-memory throttle marker = %q, want unset when event suppressed", session.Metadata[strandedEventEmittedKey])
+	}
+}
+
+func TestEmitSessionStrandedDiagnostic_DetachedProbeDeadClearsAndEmits(t *testing.T) {
+	store := beads.NewMemStore()
+	session, work := createDetachedStrandedWork(t, store, "tmux:gctest-stranded:soak-loop")
+	installFakeTmux(t, "exit 1")
+	rec := emitStrandedDiagnosticForTest(t, store, &session)
+
+	stranded := rec.strandedEvents()
+	if len(stranded) != 1 {
+		t.Fatalf("session.stranded events = %d, want 1 for dead detached probe; events: %+v", len(stranded), rec.events)
+	}
+	if !strings.Contains(stranded[0].Message, work.ID) {
+		t.Fatalf("session.stranded message = %q, want work bead %q", stranded[0].Message, work.ID)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Metadata[detachedProbeMetadataKey] != "" {
+		t.Fatalf("gc.detached = %q, want cleared before diagnostic emit", got.Metadata[detachedProbeMetadataKey])
+	}
+}
+
+func TestEmitSessionStrandedDiagnostic_DetachedProbeErrorEmitsNormally(t *testing.T) {
+	store := beads.NewMemStore()
+	session, work := createDetachedStrandedWork(t, store, "tmux:gctest-stranded:soak-loop")
+	installFakeTmux(t, "exit 2")
+	rec := emitStrandedDiagnosticForTest(t, store, &session)
+
+	stranded := rec.strandedEvents()
+	if len(stranded) != 1 {
+		t.Fatalf("session.stranded events = %d, want 1 when detached probe errors; events: %+v", len(stranded), rec.events)
+	}
+	if !strings.Contains(stranded[0].Message, work.ID) {
+		t.Fatalf("session.stranded message = %q, want work bead %q", stranded[0].Message, work.ID)
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Metadata[detachedProbeMetadataKey] != "tmux:gctest-stranded:soak-loop" {
+		t.Fatalf("gc.detached = %q, want preserved after probe error", got.Metadata[detachedProbeMetadataKey])
+	}
+}
+
+func createDetachedStrandedWork(t *testing.T, store beads.Store, detachedSpec string) (beads.Bead, beads.Bead) {
+	t.Helper()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-mc-dead",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "stranded work",
+		Type:     "task",
+		Assignee: session.ID,
+		Metadata: map[string]string{
+			detachedProbeMetadataKey: detachedSpec,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	status := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update work bead status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+	return session, work
+}
+
+func emitStrandedDiagnosticForTest(t *testing.T, store beads.Store, session *beads.Bead) *capturingRecorder {
+	t.Helper()
+	rec := &capturingRecorder{}
+	var stderr bytes.Buffer
+	emitSessionStrandedDiagnostic(
+		"",
+		nil,
+		store,
+		nil,
+		session,
+		"worker",
+		rec,
+		&clock.Fake{Time: time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)},
+		&stderr,
+	)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	return rec
+}
+
 // TestReconcileSessionBeads_PoolSlotWithStrandedWorkEmitsDiagnostic
 // covers issue #1424: when a pool-managed session is observed
 // asleep + not-alive AND still has open in-progress work assigned, the

--- a/release-gates/ga-fbai2-detached-work-stranded-diagnostic-suppression-gate.md
+++ b/release-gates/ga-fbai2-detached-work-stranded-diagnostic-suppression-gate.md
@@ -1,0 +1,58 @@
+# Release Gate: detached work stranded diagnostic suppression
+
+Bead: ga-fbai2
+Branch: builder/ga-d457b
+Reviewed head: 2b324e31a9c05c07b995da635aaee56be7791848
+Base: origin/main @ 8fe54229572b539ad7e5e2d3fe236ab621b565b6
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate
+uses the release criteria from the deployer instructions.
+
+## Commit Stack
+
+| Commit | Subject |
+|--------|---------|
+| d7b434137 | fix(doctor): guard local-only dolt remotes |
+| 7eb789d6d | fix(session): clear breaker on kill |
+| 7483229bd | fix(sling): nudge bead-named pool sessions |
+| 5c14613c1 | feat(gc): add detached tmux probe primitive |
+| f31b167b6 | fix(gc): protect orphan release for detached work |
+| 2b324e31a | fix(gc): suppress stranded diagnostics for live detached work |
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-fbai2` contains reviewer verdict `PASS` for reviewed head `2b324e31a`; minor findings are explicitly non-blocking. |
+| 2 | Acceptance criteria met | PASS | Branch implements the reviewed behavior: detached tmux probe primitive, detached orphan-release protection, stranded diagnostic suppression for live detached work, circuit-breaker clear on session kill, sling nudge resolution through bead session names, and local-only Dolt remote doctor guard/fix. Tests cover these surfaces in `cmd/gc` and `internal/doctor`. |
+| 3 | Tests pass | PASS | `TMPDIR=/tmp make test-fast-parallel`; `TMPDIR=/tmp go vet ./...`. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list three minor non-blocking findings and no HIGH findings. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty before writing this gate file; deployer rechecks after the gate commit before opening the PR. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded before and after the gate commit; no content conflicts with `origin/main`. |
+
+## Changed Surface
+
+- `cmd/gc`: detached session probing, stranded diagnostic filtering, session
+  reset/circuit behavior, and sling nudge session-name resolution.
+- `internal/doctor`: local-only Dolt remote check and explicit-fix guard.
+- `internal/beads/contract`: file helper support used by the doctor check.
+- `examples/gastown`: prompt/template cleanup for detached-work guidance.
+
+## Test Output Summary
+
+```text
+TMPDIR=/tmp make test-fast-parallel
+All fast jobs passed
+
+TMPDIR=/tmp go vet ./...
+PASS (no output)
+```
+
+## Diagnostic Notes
+
+An initial monolithic `go test ./cmd/gc ./internal/doctor ./internal/beads/contract -count=1`
+run was discarded as gate evidence because it hit local environment issues:
+`/home/jaword/.local/bin/bd` was unavailable for a slow provider path, the
+shared `/tmp` root was under pressure, and an unrelated controller socket test
+timed out. The official sharded fast baseline was rerun with `/tmp` after
+space recovered and passed.

--- a/release-gates/ga-fbai2-detached-work-stranded-diagnostic-suppression-gate.md
+++ b/release-gates/ga-fbai2-detached-work-stranded-diagnostic-suppression-gate.md
@@ -1,9 +1,11 @@
 # Release Gate: detached work stranded diagnostic suppression
 
 Bead: ga-fbai2
+Post-rebase review bead: ga-eqhao
+PR: https://github.com/gastownhall/gascity/pull/2539
 Branch: builder/ga-d457b
-Reviewed head: 2b324e31a9c05c07b995da635aaee56be7791848
-Base: origin/main @ 8fe54229572b539ad7e5e2d3fe236ab621b565b6
+Reviewed rebased head: f9455e7e738e5c35ab299994f4ac9d1877bb6a7d
+Base: origin/main @ 3268ee094b2d7b5f7f753029a929ac5f88691c1e
 
 Note: `docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate
 uses the release criteria from the deployer instructions.
@@ -12,47 +14,50 @@ uses the release criteria from the deployer instructions.
 
 | Commit | Subject |
 |--------|---------|
-| d7b434137 | fix(doctor): guard local-only dolt remotes |
-| 7eb789d6d | fix(session): clear breaker on kill |
-| 7483229bd | fix(sling): nudge bead-named pool sessions |
-| 5c14613c1 | feat(gc): add detached tmux probe primitive |
-| f31b167b6 | fix(gc): protect orphan release for detached work |
-| 2b324e31a | fix(gc): suppress stranded diagnostics for live detached work |
+| 95ea97d6b | fix(doctor): guard local-only dolt remotes |
+| 5e0acc1d3 | feat(gc): add detached tmux probe primitive |
+| 23f8e8051 | fix(gc): protect orphan release for detached work |
+| 40f63157e | fix(gc): suppress stranded diagnostics for live detached work |
+| f9455e7e7 | chore: release gate PASS for ga-fbai2 |
+
+The rebase intentionally dropped duplicate upstream session-breaker and sling
+nudge patches that were present in the earlier reviewed stack.
 
 ## Gate Checklist
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
-| 1 | Review PASS present | PASS | `bd show ga-fbai2` contains reviewer verdict `PASS` for reviewed head `2b324e31a`; minor findings are explicitly non-blocking. |
-| 2 | Acceptance criteria met | PASS | Branch implements the reviewed behavior: detached tmux probe primitive, detached orphan-release protection, stranded diagnostic suppression for live detached work, circuit-breaker clear on session kill, sling nudge resolution through bead session names, and local-only Dolt remote doctor guard/fix. Tests cover these surfaces in `cmd/gc` and `internal/doctor`. |
-| 3 | Tests pass | PASS | `TMPDIR=/tmp make test-fast-parallel`; `TMPDIR=/tmp go vet ./...`. |
-| 4 | No high-severity review findings open | PASS | Reviewer notes list three minor non-blocking findings and no HIGH findings. |
-| 5 | Final branch is clean | PASS | `git status --short` was empty before writing this gate file; deployer rechecks after the gate commit before opening the PR. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded before and after the gate commit; no content conflicts with `origin/main`. |
+| 1 | Review PASS present | PASS | `bd show ga-fbai2` contains reviewer verdict `PASS` for the original feature stack. `bd show ga-eqhao` contains `REVIEWER VERDICT: PASS` for the rebased PR head `f9455e7e7`; low/info findings are explicitly non-blocking. |
+| 2 | Acceptance criteria met | PASS | The rebased branch preserves the reviewed behavior: detached tmux probe primitive, detached orphan-release protection, stranded diagnostic suppression for live detached work, and local-only Dolt remote doctor guard/fix. Duplicate session-breaker and sling-nudge commits were dropped because those changes are already in `origin/main`. Focused tests remain in `cmd/gc` and `internal/doctor`. |
+| 3 | Tests pass | PASS | From isolated worktree `/home/jaword/.gotmp/gascity-pr2539-gate.uDdSKk`: `TMPDIR=/home/jaword/.gotmp/gc-pr2539-gate LOCAL_TEST_JOBS=2 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel` passed; `TMPDIR=/home/jaword/.gotmp/gc-pr2539-gate go vet ./...` passed. GitHub PR checks for PR #2539 are also green. |
+| 4 | No high-severity review findings open | PASS | Rebase review notes list two LOW findings and one INFO note; no HIGH or BLOCKING findings. Original feature review listed only minor non-blocking findings. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty before writing this refreshed gate file; deployer rechecks after the gate commit before pushing. |
+| 6 | Branch diverges cleanly from main | PASS | `gh pr view 2539` reports merge state `CLEAN`; `git merge-tree origin/main f9455e7e738e5c35ab299994f4ac9d1877bb6a7d` succeeded with tree `770490ce176ad0c9815da1406dfd11e7c40f5c1c`. |
 
 ## Changed Surface
 
-- `cmd/gc`: detached session probing, stranded diagnostic filtering, session
-  reset/circuit behavior, and sling nudge session-name resolution.
+- `cmd/gc`: detached session probing, stranded diagnostic filtering, and
+  detached orphan-release protection.
 - `internal/doctor`: local-only Dolt remote check and explicit-fix guard.
 - `internal/beads/contract`: file helper support used by the doctor check.
-- `examples/gastown`: prompt/template cleanup for detached-work guidance.
+- `AGENTS.md`: tmux safety guidance aligned with the detached-work behavior.
 
 ## Test Output Summary
 
 ```text
-TMPDIR=/tmp make test-fast-parallel
+TMPDIR=/home/jaword/.gotmp/gc-pr2539-gate LOCAL_TEST_JOBS=2 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel
 All fast jobs passed
 
-TMPDIR=/tmp go vet ./...
+TMPDIR=/home/jaword/.gotmp/gc-pr2539-gate go vet ./...
 PASS (no output)
 ```
 
 ## Diagnostic Notes
 
-An initial monolithic `go test ./cmd/gc ./internal/doctor ./internal/beads/contract -count=1`
-run was discarded as gate evidence because it hit local environment issues:
-`/home/jaword/.local/bin/bd` was unavailable for a slow provider path, the
-shared `/tmp` root was under pressure, and an unrelated controller socket test
-timed out. The official sharded fast baseline was rerun with `/tmp` after
-space recovered and passed.
+An initial `make test-fast-parallel` from the deployer worktree failed in
+`TestRigAnywhere_ResolveRigToContext` because the test discovered the parent
+`/home/jaword/projects/gc-management` city and parsed its local
+`packs/maintainer-pr-review/pack.toml`, which still uses the deprecated
+`[formulas].dir` field. The same branch passed from the isolated worktree above,
+so the parent-city failure is treated as environmental contamination rather than
+release-gate evidence for PR #2539.


### PR DESCRIPTION
## What this changes

Gas City now checks detached tmux-backed sessions before treating their assigned work as stranded. If tmux still reports the session exists, the reconciler suppresses the stranded-work diagnostic and leaves the assignment intact; once the session is gone, the existing orphan-release path can proceed.

`gc doctor` also gains a local-only Dolt remote guard. In local-only mode it reports off-box remotes and only removes them under the explicit fix path, keeping remote cleanup opt-in.

## Review notes

- The detached probe shells out to `tmux -L <socket> has-session -t <session>` with separate argv entries; there is no shell interpolation.
- The stranded diagnostic suppression is intentionally re-evaluated on each tick instead of adding a sticky throttle marker while the detached session is still live.
- Duplicate session-breaker and `gc sling --nudge` fixes were dropped during rebase because they already exist on `origin/main`; this PR now carries the detached diagnostics and local-only Dolt remote work.
- No HTTP API, OpenAPI schema, or generated dashboard types change.
- Bead: `ga-fbai2`

## Test plan

- [x] `TMPDIR=/home/jaword/.gotmp/gc-pr2539-gate LOCAL_TEST_JOBS=2 CMD_GC_PROCESS_TOTAL=6 make test-fast-parallel` from isolated worktree
- [x] `TMPDIR=/home/jaword/.gotmp/gc-pr2539-gate go vet ./...` from isolated worktree
- [x] Release gate: [`release-gates/ga-fbai2-detached-work-stranded-diagnostic-suppression-gate.md`](release-gates/ga-fbai2-detached-work-stranded-diagnostic-suppression-gate.md)