### PR TITLE
Clear session circuit breakers after explicit kill/reset

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2165,9 +2165,22 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 		return 1
 	}
 
+	bead, err := store.Get(sessionID)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session kill: loading session %s: %v\n", sessionID, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	identity := namedSessionIdentity(bead)
+
 	if err := handle.Kill(context.Background()); err != nil {
 		fmt.Fprintf(stderr, "gc session kill: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if identity != "" {
+		if err := resetSessionCircuitBreakerAfterExplicitKill(cityPath, store, sessionID, identity); err != nil {
+			fmt.Fprintf(stderr, "gc session kill: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	// Use the resolved session ID as the canonical Subject for event

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2176,13 +2176,6 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 		fmt.Fprintf(stderr, "gc session kill: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if identity != "" {
-		if err := resetSessionCircuitBreakerAfterExplicitKill(cityPath, store, sessionID, identity); err != nil {
-			fmt.Fprintf(stderr, "gc session kill: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-	}
-
 	// Use the resolved session ID as the canonical Subject for event
 	// consumers. This ensures a stable key regardless of how the user
 	// specified the target (session ID or alias).
@@ -2194,6 +2187,11 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 		Message: "killed",
 		Payload: api.SessionLifecyclePayloadJSON(sessionID, "", "killed"),
 	})
+	if identity != "" {
+		if err := resetSessionCircuitBreakerAfterExplicitKill(cityPath, store, sessionID, identity); err != nil {
+			fmt.Fprintf(stderr, "gc session kill: warning: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
+		}
+	}
 
 	if asJSON {
 		if err := writeSessionActionJSON(stdout, sessionActionResult{

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/spf13/cobra"
 )
 
@@ -109,4 +111,19 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer, jsonOutput ...bool
 	}
 	fmt.Fprintf(stdout, "Session %s reset requested. Controller will restart it fresh.\n", sessionID) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+func resetSessionCircuitBreakerAfterExplicitKill(cityPath string, store beads.Store, sessionID, identity string) error {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return nil
+	}
+	if strings.TrimSpace(cityPath) != "" && cityUsesManagedReconciler(cityPath) {
+		if err := resetSessionCircuitBreakerOnController(cityPath, sessionID, identity); err != nil {
+			return err
+		}
+		_ = pokeController(cityPath)
+		return nil
+	}
+	return resetSessionCircuitBreakerState(store, sessionID, identity, defaultSessionCircuitBreaker())
 }

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -106,6 +108,9 @@ func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
 	}
 	if got := updated.Metadata[sessionCircuitRestartsMetadata]; got != "" {
 		t.Fatalf("persisted restart history = %q, want cleared", got)
+	}
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got == "" {
+		t.Fatal("persisted reset generation is empty, want explicit reset generation")
 	}
 }
 
@@ -212,6 +217,126 @@ func TestCmdSessionKill_ClearsCircuitBreaker(t *testing.T) {
 	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got == "" {
 		t.Fatal("persisted reset generation is empty, want explicit reset generation")
 	}
+}
+
+func TestCmdSessionKill_RecordsStoppedWhenCircuitBreakerResetFails(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-session-kill-cb-reset-fails-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	fakeProvider := runtime.NewFake()
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	const identity = "session-a"
+	const sessionName = "s-gc-kill-cb-reset-fails-test"
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                        identity,
+			"template":                     "worker",
+			"session_name":                 sessionName,
+			"state":                        "awake",
+			namedSessionMetadataKey:        "true",
+			namedSessionIdentityMetadata:   identity,
+			sessionCircuitStateMetadata:    circuitOpen.String(),
+			sessionCircuitRestartsMetadata: `["2026-04-10T12:00:00Z"]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+	if err := fakeProvider.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("fakeProvider.Start: %v", err)
+	}
+	if err := fakeProvider.SetMeta(sessionName, "GC_SESSION_ID", bead.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	lis := startFailingCircuitResetController(t, cityDir)
+	defer lis.Close()                              //nolint:errcheck
+	defer os.Remove(controllerSocketPath(cityDir)) //nolint:errcheck
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionKill([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionKill = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if fakeProvider.IsRunning(sessionName) {
+		t.Fatalf("session %q still running after kill", sessionName)
+	}
+	if got := stderr.String(); !strings.Contains(got, "warning: clearing session circuit breaker") {
+		t.Fatalf("stderr = %q, want circuit-breaker warning", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Session "+bead.ID+" killed.") {
+		t.Fatalf("stdout = %q, want killed message", got)
+	}
+
+	rec, err := events.NewFileRecorder(filepath.Join(cityDir, ".gc", "events.jsonl"), &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("NewFileRecorder(events): %v", err)
+	}
+	defer rec.Close() //nolint:errcheck
+	recorded, err := rec.List(events.Filter{Type: events.SessionStopped, Subject: bead.ID})
+	if err != nil {
+		t.Fatalf("List(SessionStopped): %v", err)
+	}
+	if len(recorded) != 1 {
+		t.Fatalf("SessionStopped events for %s = %d, want 1", bead.ID, len(recorded))
+	}
+}
+
+func startFailingCircuitResetController(t *testing.T, cityDir string) net.Listener {
+	t.Helper()
+	sockPath := controllerSocketPath(cityDir)
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll(controller socket dir): %v", err)
+	}
+	os.Remove(sockPath) //nolint:errcheck
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", sockPath, err)
+	}
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close() //nolint:errcheck
+				scanner := bufio.NewScanner(conn)
+				if !scanner.Scan() {
+					return
+				}
+				line := scanner.Text()
+				switch {
+				case line == "ping":
+					fmt.Fprintf(conn, "%d\n", os.Getpid()) //nolint:errcheck
+				case strings.HasPrefix(line, sessionCircuitResetCommandPrefix):
+					conn.Write([]byte(`{"outcome":"failed","error":"forced reset failure"}` + "\n")) //nolint:errcheck
+				default:
+					conn.Write([]byte("ok\n")) //nolint:errcheck
+				}
+			}(conn)
+		}
+	}()
+	return lis
 }
 
 func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"net"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
@@ -103,6 +106,111 @@ func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
 	}
 	if got := updated.Metadata[sessionCircuitRestartsMetadata]; got != "" {
 		t.Fatalf("persisted restart history = %q, want cleared", got)
+	}
+}
+
+func TestCmdSessionKill_ClearsCircuitBreaker(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := shortSocketTempDir(t, "gc-session-kill-cb-")
+	t.Setenv("GC_CITY", cityDir)
+	writeGenericNamedSessionCityTOML(t, cityDir)
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+
+	fakeProvider := runtime.NewFake()
+	oldBuild := buildSessionProviderByName
+	buildSessionProviderByName = func(string, config.SessionConfig, string, string) (runtime.Provider, error) {
+		return fakeProvider, nil
+	}
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	const identity = "session-a"
+	const sessionName = "s-gc-kill-cb-test"
+	bead, err := store.Create(beads.Bead{
+		Title:  "named session",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "template:worker"},
+		Metadata: map[string]string{
+			"alias":                        identity,
+			"template":                     "worker",
+			"session_name":                 sessionName,
+			"state":                        "awake",
+			namedSessionMetadataKey:        "true",
+			namedSessionIdentityMetadata:   identity,
+			sessionCircuitStateMetadata:    circuitOpen.String(),
+			sessionCircuitRestartsMetadata: `["2026-04-10T12:00:00Z"]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create(session bead): %v", err)
+	}
+	if err := fakeProvider.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("fakeProvider.Start: %v", err)
+	}
+	if err := fakeProvider.SetMeta(sessionName, "GC_SESSION_ID", bead.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	cb := newSessionCircuitBreaker(sessionCircuitBreakerConfig{
+		Window:      30 * time.Minute,
+		MaxRestarts: 3,
+	})
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		cb.RecordRestart(identity, now.Add(time.Duration(i)*time.Second))
+	}
+	if !cb.IsOpen(identity, now.Add(time.Minute)) {
+		t.Fatalf("precondition: expected breaker OPEN for %q after 4 restarts", identity)
+	}
+
+	lis, err := startControllerSocket(
+		cityDir,
+		func() {},
+		nil,
+		nil,
+		make(chan reloadRequest),
+		make(chan convergenceRequest, 1),
+		make(chan struct{}, 1),
+		make(chan struct{}, 1),
+	)
+	if err != nil {
+		t.Fatalf("startControllerSocket: %v", err)
+	}
+	defer lis.Close()                              //nolint:errcheck
+	defer os.Remove(controllerSocketPath(cityDir)) //nolint:errcheck
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionKill([]string{identity}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionKill = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	if fakeProvider.IsRunning(sessionName) {
+		t.Fatalf("session %q still running after kill", sessionName)
+	}
+	if cb.IsOpen(identity, now.Add(time.Minute)) {
+		t.Fatalf("breaker still OPEN for %q after `gc session kill %s`", identity, identity)
+	}
+	updated, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(session bead): %v", err)
+	}
+	if got := updated.Metadata[sessionCircuitStateMetadata]; got != "" {
+		t.Fatalf("persisted circuit state = %q, want cleared", got)
+	}
+	if got := updated.Metadata[sessionCircuitRestartsMetadata]; got != "" {
+		t.Fatalf("persisted restart history = %q, want cleared", got)
+	}
+	if got := updated.Metadata[sessionCircuitResetGenerationMetadata]; got == "" {
+		t.Fatal("persisted reset generation is empty, want explicit reset generation")
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1362,6 +1362,67 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 		}
 
+		// Restart-requested: agent asked for a fresh session
+		// (gc runtime request-restart / gc handoff). This runs after
+		// drain-ack handling, but before autonomous rate-limit,
+		// stability, and churn gates so an explicit operator/model reset
+		// is not swallowed by crash heuristics. Use provider-session
+		// liveness (running), not process liveness (alive), so a zombie
+		// tmux/container session is still stopped before the next wake.
+		{
+			runtimeRunning := running || alive
+			tmuxRequested := false
+			if runtimeRunning && dops != nil {
+				tmuxRequested, _ = dops.isRestartRequested(name)
+			}
+			beadRequested := session.Metadata["restart_requested"] == "true"
+			if tmuxRequested || beadRequested {
+				if runtimeRunning {
+					if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
+						fmt.Fprintf(stderr, "session reconciler: stopping restart-requested %s: %v\n", name, err) //nolint:errcheck
+						continue
+					}
+				}
+				// Providers that can inject a fresh session ID get a
+				// rotated key here so the next wake starts a brand-new
+				// conversation. Providers without SessionIDFlag must
+				// clear any stored key and wake fresh without resume.
+				// Clearing started_config_hash forces firstStart=true in
+				// resolveSessionCommand. Clearing last_woke_at masks the
+				// intentional death from crash and churn trackers (both
+				// check last_woke_at first).
+				newSessionKey, hasCapability := freshRestartSessionKey(tp, session.Metadata)
+				batch := sessionpkg.RestartRequestPatch(newSessionKey)
+				if hasCapability && newSessionKey == "" {
+					batch["session_key"] = ""
+				}
+				if err := store.SetMetadataBatch(session.ID, batch); err != nil {
+					fmt.Fprintf(stderr, "session reconciler: recording restart handoff for %s: %v\n", name, err) //nolint:errcheck
+					continue
+				}
+				if session.Metadata == nil {
+					session.Metadata = make(map[string]string, len(batch))
+				}
+				for key, value := range batch {
+					session.Metadata[key] = value
+				}
+				if runtimeRunning {
+					if tmuxRequested && dops != nil {
+						_ = dops.clearRestartRequested(name)
+					}
+					fmt.Fprintf(stdout, "Stopped restart-requested session '%s'\n", name) //nolint:errcheck
+					// Yield this tick so the kill and the next wake run
+					// on separate reconciler passes; the new start should
+					// not race the tmux alias release.
+					continue
+				}
+				// Runtime was already dead — no kill happened, no alias
+				// release to wait on. Fall through so the wake decision
+				// can pick up the freshly cleared metadata and emit a
+				// start_candidate on this same tick. See #2345.
+			}
+		}
+
 		policy := resolveSessionSleepPolicy(*session, cfg, sp)
 
 		rateLimitHit, rateLimitErr := checkRateLimitStability(session, cfg, alive, dt, store, clk, peek)
@@ -1422,81 +1483,6 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 			if !recoverRunningPendingCreate(session, tp, cfg, store, clk, trace) {
 				fmt.Fprintf(stderr, "session reconciler: recovering pending create %s: metadata repair incomplete\n", name) //nolint:errcheck
-			}
-		}
-
-		// Restart-requested: agent asked for a fresh session
-		// (gc runtime request-restart / gc handoff). Rotate session_key
-		// to a fresh value and clear started_config_hash so the next wake
-		// builds a first-start command (--session-id <new_key>). Also set
-		// continuation_reset_pending so the next wake bumps the continuation
-		// epoch instead of silently reusing the prior continuation lineage.
-		//
-		// When the runtime is alive, stop it and yield this tick so the
-		// kill and the next wake run on separate reconciler passes; that
-		// keeps the start from racing the tmux alias release. When the
-		// runtime is already dead — for example, a named-always session
-		// whose tmux was killed by `gc handoff --target` before the bead's
-		// restart_requested flag was processed — there is no live runtime
-		// to stop. Apply the patch and fall through to the wake decision
-		// on this same tick instead of waiting for the next reconciler
-		// interval. The yield-a-tick rule existed to protect a live kill;
-		// extending it to the already-dead case is what caused the
-		// patrol_interval-sized post-handoff wake delay in #2345.
-		//
-		// Check both tmux metadata (dops) and bead metadata. The bead
-		// metadata flag survives tmux session death, so this works even
-		// when the session is already dead.
-		{
-			tmuxRequested := false
-			if alive && dops != nil {
-				tmuxRequested, _ = dops.isRestartRequested(name)
-			}
-			beadRequested := session.Metadata["restart_requested"] == "true"
-			if tmuxRequested || beadRequested {
-				if alive {
-					if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
-						fmt.Fprintf(stderr, "session reconciler: stopping restart-requested %s: %v\n", name, err) //nolint:errcheck
-						continue
-					}
-				}
-				// Providers that can inject a fresh session ID get a
-				// rotated key here so the next wake starts a brand-new
-				// conversation. Providers without SessionIDFlag must
-				// clear any stored key and wake fresh without resume.
-				// Clearing started_config_hash forces firstStart=true in
-				// resolveSessionCommand. Clearing last_woke_at masks the
-				// intentional death from crash and churn trackers (both
-				// check last_woke_at first).
-				newSessionKey, hasCapability := freshRestartSessionKey(tp, session.Metadata)
-				batch := sessionpkg.RestartRequestPatch(newSessionKey)
-				if hasCapability && newSessionKey == "" {
-					batch["session_key"] = ""
-				}
-				if err := store.SetMetadataBatch(session.ID, batch); err != nil {
-					fmt.Fprintf(stderr, "session reconciler: recording restart handoff for %s: %v\n", name, err) //nolint:errcheck
-					continue
-				}
-				if session.Metadata == nil {
-					session.Metadata = make(map[string]string, len(batch))
-				}
-				for key, value := range batch {
-					session.Metadata[key] = value
-				}
-				if alive {
-					if tmuxRequested && dops != nil {
-						_ = dops.clearRestartRequested(name)
-					}
-					fmt.Fprintf(stdout, "Stopped restart-requested session '%s'\n", name) //nolint:errcheck
-					// Yield this tick so the kill and the next wake run
-					// on separate reconciler passes; the new start should
-					// not race the tmux alias release.
-					continue
-				}
-				// Runtime was already dead — no kill happened, no alias
-				// release to wait on. Fall through so the wake decision
-				// can pick up the freshly cleared metadata and emit a
-				// start_candidate on this same tick. See #2345.
 			}
 		}
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1383,6 +1383,12 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						continue
 					}
 				}
+				if identity := namedSessionIdentity(*session); identity != "" {
+					if err := resetSessionCircuitBreakerState(store, session.ID, identity, cb); err != nil {
+						fmt.Fprintf(stderr, "session reconciler: clearing session circuit breaker for restart-requested %s: %v\n", name, err) //nolint:errcheck
+						continue
+					}
+				}
 				// Providers that can inject a fresh session ID get a
 				// rotated key here so the next wake starts a brand-new
 				// conversation. Providers without SessionIDFlag must

--- a/cmd/gc/session_reconciler_restart_request_test.go
+++ b/cmd/gc/session_reconciler_restart_request_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
@@ -301,6 +302,116 @@ func TestReconcileSessionBeads_RestartRequestPreservesIntentWhenKillFails(t *tes
 	}
 	if got := env.stderr.String(); !strings.Contains(got, "stopping restart-requested") || !strings.Contains(got, "kill denied") {
 		t.Fatalf("stderr = %q, want kill failure diagnostic", got)
+	}
+}
+
+func TestReconcileSessionBeads_RestartRequestPreemptsRateLimitGate(t *testing.T) {
+	env, session, sessionName := newRestartRequestedZombieSession(t)
+	env.sp.SetPeekOutput(sessionName, "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	env.setSessionMetadata(&session, map[string]string{
+		"last_woke_at": env.clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	assertRestartRequestStoppedBeforeAutonomousGate(t, env, session.ID, sessionName)
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata["sleep_reason"] == "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want explicit reset to preempt rate-limit gate", got.Metadata["sleep_reason"])
+	}
+}
+
+func TestReconcileSessionBeads_RestartRequestPreemptsStabilityGate(t *testing.T) {
+	env, session, sessionName := newRestartRequestedZombieSession(t)
+	env.setSessionMetadata(&session, map[string]string{
+		"last_woke_at": env.clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	assertRestartRequestStoppedBeforeAutonomousGate(t, env, session.ID, sessionName)
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want restart patch to clear crash-tracker lease", got.Metadata["last_woke_at"])
+	}
+	if got.Metadata["sleep_reason"] == "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want explicit reset to preempt stability gate", got.Metadata["sleep_reason"])
+	}
+}
+
+func TestReconcileSessionBeads_RestartRequestPreemptsChurnGate(t *testing.T) {
+	env, session, sessionName := newRestartRequestedZombieSession(t)
+	env.setSessionMetadata(&session, map[string]string{
+		"last_woke_at": env.clk.Now().Add(-90 * time.Second).UTC().Format(time.RFC3339),
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	assertRestartRequestStoppedBeforeAutonomousGate(t, env, session.ID, sessionName)
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata["churn_count"] != "" {
+		t.Fatalf("churn_count = %q, want explicit reset to preempt churn gate", got.Metadata["churn_count"])
+	}
+}
+
+func newRestartRequestedZombieSession(t *testing.T) (*restartRequestTestEnv, beads.Bead, string) {
+	t.Helper()
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "worker",
+		Hints:        agent.StartupHints{ProcessNames: []string{"agent-cli"}},
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"state":                      "active",
+		"restart_requested":          "true",
+		"session_key":                "original-key",
+		"started_config_hash":        "hash-before-restart",
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true", ProcessNames: []string{"agent-cli"}}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+	env.sp.Zombies[sessionName] = true
+	return env, session, sessionName
+}
+
+func assertRestartRequestStoppedBeforeAutonomousGate(t *testing.T, env *restartRequestTestEnv, sessionID, sessionName string) {
+	t.Helper()
+	if env.sp.IsRunning(sessionName) {
+		t.Fatalf("session %q still running; explicit reset should stop it before autonomous gates", sessionName)
+	}
+	got, _ := env.store.Get(sessionID)
+	if got.Metadata["restart_requested"] != "" {
+		t.Fatalf("restart_requested = %q, want cleared after explicit reset patch", got.Metadata["restart_requested"])
+	}
+	if got.Metadata["session_key"] == "" || got.Metadata["session_key"] == "original-key" {
+		t.Fatalf("session_key = %q, want rotated key", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q, want cleared", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "true" {
+		t.Fatalf("continuation_reset_pending = %q, want true", got.Metadata["continuation_reset_pending"])
+	}
+	if got := env.stdout.String(); !strings.Contains(got, "Stopped restart-requested session") {
+		t.Fatalf("stdout = %q, want stop diagnostic", got)
 	}
 }
 

--- a/cmd/gc/session_reconciler_restart_request_test.go
+++ b/cmd/gc/session_reconciler_restart_request_test.go
@@ -305,6 +305,94 @@ func TestReconcileSessionBeads_RestartRequestPreservesIntentWhenKillFails(t *tes
 	}
 }
 
+func TestReconcileSessionBeads_RestartRequestClearsCircuitBreakerForNextWake(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Daemon: config.DaemonConfig{
+			SessionCircuitBreaker:            true,
+			SessionCircuitBreakerMaxRestarts: restartRequestTestIntPtr(3),
+			SessionCircuitBreakerWindow:      "30m",
+		},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "worker",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	const identity = "worker"
+	cb := breakerAt(30*time.Minute, 3)
+	base := env.clk.Now().UTC()
+	for i := 0; i < 4; i++ {
+		cb.RecordRestart(identity, base.Add(time.Duration(i)*time.Second))
+	}
+	if !cb.IsOpen(identity, base.Add(time.Minute)) {
+		t.Fatalf("precondition: breaker should be OPEN for %q", identity)
+	}
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: identity,
+		namedSessionModeMetadata:     "always",
+		"state":                      "active",
+		"restart_requested":          "true",
+		"session_key":                "original-key",
+		"started_config_hash":        "hash-before-restart",
+	})
+	if err := persistSessionCircuitBreakerMetadata(env.store, &session, cb, identity, base); err != nil {
+		t.Fatalf("persist circuit metadata: %v", err)
+	}
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	if env.sp.IsRunning(sessionName) {
+		t.Fatalf("session %q still running after restart-requested kill", sessionName)
+	}
+	if cb.IsOpen(identity, base.Add(time.Minute)) {
+		t.Fatalf("breaker still OPEN for %q after restart-requested kill", identity)
+	}
+	stopped, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", session.ID, err)
+	}
+	if got := stopped.Metadata[sessionCircuitStateMetadata]; got != "" {
+		t.Fatalf("persisted circuit state = %q, want cleared", got)
+	}
+	if got := stopped.Metadata[sessionCircuitRestartsMetadata]; got != "" {
+		t.Fatalf("persisted restart history = %q, want cleared", got)
+	}
+	if got := stopped.Metadata[sessionCircuitResetGenerationMetadata]; got == "" {
+		t.Fatal("persisted reset generation is empty, want explicit reset generation")
+	}
+
+	env.stdout.Reset()
+	env.stderr.Reset()
+	env.reconcile([]beads.Bead{stopped})
+
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatalf("session %q did not wake after explicit reset cleared the circuit breaker", sessionName)
+	}
+	if got := env.stderr.String(); strings.Contains(got, "CIRCUIT_OPEN") {
+		t.Fatalf("stderr = %q, want no circuit-open block after explicit reset", got)
+	}
+}
+
 func TestReconcileSessionBeads_RestartRequestPreemptsRateLimitGate(t *testing.T) {
 	env, session, sessionName := newRestartRequestedZombieSession(t)
 	env.sp.SetPeekOutput(sessionName, "You've hit your limit, Pro plan\n\n/rate-limit-options")

--- a/release-gates/ga-mpi3a-clear-session-circuit-breaker-gate.md
+++ b/release-gates/ga-mpi3a-clear-session-circuit-breaker-gate.md
@@ -1,0 +1,87 @@
+# Release Gate: ga-mpi3a
+
+Bead: ga-mpi3a - Review: clear session circuit breaker on explicit kill
+Source bead: ga-k0n20.1.2 - Builder: clear circuit breaker after explicit reset or kill
+Feature branch: builder/ga-k0n20-1-2
+Evaluated by: gascity/deployer
+Date: 2026-05-24
+
+## Gate Result
+
+PASS
+
+## Scope Note
+
+`builder/ga-k0n20-1-2` is stacked on the reviewed prerequisite
+`ga-k0n20.1.1` commit `c849db89e`, then adds the `ga-k0n20.1.2`
+circuit-breaker clear commit `5381615e`. The branch is evaluated as the PR
+surface because `ga-k0n20.1.2` depends on the restart-request kill block being
+ordered before the autonomous reconciler gates.
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree; this gate uses the
+release criteria supplied by the deployer role prompt.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-mpi3a` notes contain `REVIEWER VERDICT: PASS` for `5381615e`. The carried prerequisite review bead `ga-brf9n` contains `REVIEW VERDICT: PASS` for `c849db89e`. |
+| 2 | Acceptance criteria met | PASS | The prerequisite commit moves the `restart_requested` kill block after drain-ack handling and before rate-limit, stability, and churn gates. The source commit clears named-session circuit breaker state after explicit `gc session kill` and restart-requested reconciler kills, reusing the reset circuit-breaker path. Tests cover the preemption gates and circuit-open-to-wakeable recovery paths. |
+| 3 | Tests pass | PASS | Focused `cmd/gc` regression tests passed. `LOCAL_TEST_JOBS=8 make test-fast-parallel` passed all fast shards. `go vet ./...` passed. `git diff --check origin/main...HEAD` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes list no HIGH findings. The only noted item for `ga-mpi3a` is MINOR / no action required around loading the session bead before kill. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before this gate file was added. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` completed without conflicts (`5768f9f812527fc0c025902ea41f95bd7782e09d`). |
+
+## Commits Evaluated
+
+| Bead | Review | Commit |
+|------|--------|--------|
+| ga-k0n20.1.1 | PASS via ga-brf9n | `c849db89e` - `fix(gc): preempt autonomous gates for reset requests` |
+| ga-k0n20.1.2 | PASS via ga-mpi3a | `5381615e` - `fix(gc): clear session circuit breaker on explicit kill` |
+
+## Acceptance Evidence
+
+### ga-k0n20.1.1
+
+- `cmd/gc/session_reconciler.go` now handles restart-requested sessions after
+  drain-ack handling and before rate-limit, stability, and churn gates.
+- Runtime liveness uses `running || alive`, so provider-visible zombie sessions
+  still get stopped before the next wake.
+- Existing drain-ack behavior remains ahead of the restart-request block.
+- Tests present for restart requests preempting rate-limit, stability, and
+  churn gates.
+
+### ga-k0n20.1.2
+
+- `gc session kill` loads the session bead, resolves named-session identity,
+  kills through the worker boundary, then clears circuit-breaker state for that
+  identity.
+- The shared explicit-kill helper uses the managed controller circuit-breaker
+  path when available and falls back to the local default breaker otherwise.
+- The reconciler clears circuit-breaker state after a successful
+  restart-requested kill and before recording the restart handoff metadata.
+- Tests present for `gc session kill` clearing circuit-breaker state and for a
+  restart-requested kill making an open-circuit named session wakeable on the
+  next reconciler pass.
+
+## Test Evidence
+
+Commands run:
+
+```text
+go test ./cmd/gc -run 'Test(CmdSession(Kill|Reset)_ClearsCircuitBreaker|ReconcileSessionBeads_RestartRequest|Reconciler_Circuit(OpenBlocksSpawn|ClosedAllowsSpawn))' -count=1
+git diff --check origin/main...HEAD
+LOCAL_TEST_JOBS=8 make test-fast-parallel
+go vet ./...
+git merge-tree --write-tree origin/main HEAD
+```
+
+Results:
+
+```text
+focused go test: PASS
+git diff --check: PASS
+make test-fast-parallel: PASS
+go vet ./...: PASS
+merge-tree with origin/main: PASS
+```


### PR DESCRIPTION
## What this changes

Explicit session recovery now clears the path for the next wake instead of leaving a named session stuck behind stale safety state. When a live reset is requested, the reconciler stops the runtime before the autonomous rate-limit, stability, and churn gates can defer it, then clears the named-session circuit breaker after the kill succeeds.

`gc session kill` now uses the same recoverability contract for named sessions: after a successful kill, it clears the circuit-breaker state for that session identity so an operator can wake it again immediately.

## Review notes

- The restart-request kill path still runs after drain-ack handling, preserving acknowledged drain behavior.
- The branch includes the prerequisite restart-request ordering change because the circuit-breaker clear depends on that ordering.
- `gc session kill` now loads the session bead before killing so it can resolve the named-session identity; if that load fails, the command fails before killing.
- No config, API, schema, or dashboard surface changes.

## Test plan

- [x] `go test ./cmd/gc -run 'Test(CmdSession(Kill|Reset)_ClearsCircuitBreaker|ReconcileSessionBeads_RestartRequest|Reconciler_Circuit(OpenBlocksSpawn|ClosedAllowsSpawn))' -count=1`
- [x] `LOCAL_TEST_JOBS=8 make test-fast-parallel`
- [x] `go vet ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] Release gate: [`release-gates/ga-mpi3a-clear-session-circuit-breaker-gate.md`](release-gates/ga-mpi3a-clear-session-circuit-breaker-gate.md)
