### PR TITLE
Preserve session REASON priority ordering

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1226,7 +1226,10 @@ func buildAttachmentCache(sessions []session.Info, observe ...func(session.Info)
 	return cache
 }
 
-const resetPendingReason = "reset-pending"
+const (
+	resetPendingReason = "reset-pending"
+	circuitOpenReason  = "circuit-open"
+)
 
 // sessionReason computes the REASON column for a session in gc session list.
 // For awake sessions, shows wake reasons (e.g., "config", "attached").
@@ -1253,6 +1256,9 @@ func sessionReason(s session.Info, beadIndex map[string]beads.Bead, cfg *config.
 	}
 	if resetPendingReasonVisible(s, b, sp, now) {
 		return resetPendingReason
+	}
+	if circuitOpenReasonVisible(b) {
+		return circuitOpenReason
 	}
 
 	// If config is available, compute full wake reasons (including WakeConfig).
@@ -1286,6 +1292,10 @@ func resetPendingReasonVisible(s session.Info, b beads.Bead, sp runtime.Provider
 		isRunning = sp.IsRunning
 	}
 	return session.LifecycleResetPendingReasonVisible(b.Status, b.Metadata, now, s.SessionName, isRunning)
+}
+
+func circuitOpenReasonVisible(b beads.Bead) bool {
+	return strings.TrimSpace(b.Metadata[sessionCircuitStateMetadata]) == circuitOpen.String()
 }
 
 func pinAwakeWakeReasonVisible(b beads.Bead, cfg *config.City, now time.Time) bool {

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1261,8 +1261,12 @@ func sessionReason(s session.Info, beadIndex map[string]beads.Bead, cfg *config.
 		return circuitOpenReason
 	}
 
-	// If config is available, compute full wake reasons (including WakeConfig).
-	// Otherwise, only bead metadata (sleep/hold/quarantine) is shown.
+	if reason := session.LifecycleDisplayReason(b.Status, b.Metadata, now); reason != "" {
+		return reason
+	}
+
+	// If config is available and no lifecycle reason blocks display, compute
+	// full wake reasons (including WakeConfig).
 	if cfg != nil {
 		reasons := wakeReasons(b, cfg, sp, poolDesired, nil, readyWaitSet, clock.Real{})
 		if pinAwakeWakeReasonVisible(b, cfg, time.Now().UTC()) && !containsWakeReason(reasons, WakePin) {
@@ -1277,10 +1281,6 @@ func sessionReason(s session.Info, beadIndex map[string]beads.Bead, cfg *config.
 		}
 	}
 
-	// No wake reasons (or no config) — show why it's asleep from lifecycle metadata.
-	if reason := session.LifecycleDisplayReason(b.Status, b.Metadata, now); reason != "" {
-		return reason
-	}
 	return "-"
 }
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1461,6 +1461,75 @@ func TestSessionReason_ResetPendingNotLiveFallsBack(t *testing.T) {
 	assertStringMapEqual(t, bead.Metadata, before)
 }
 
+func TestSessionReason_CircuitOpenMetadataVisible(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "gc-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"template":                     "worker",
+			"session_name":                 "worker-circuit",
+			"state":                        "asleep",
+			"sleep_reason":                 "user-hold",
+			sessionCircuitStateMetadata:    circuitOpen.String(),
+			sessionCircuitRestartsMetadata: `["2026-04-10T12:00:00Z"]`,
+		},
+	}
+	before := cloneSessionReasonMetadata(bead.Metadata)
+	info := session.Info{
+		ID:          bead.ID,
+		Template:    "worker",
+		State:       session.StateAsleep,
+		SessionName: "worker-circuit",
+	}
+
+	reason := sessionReason(
+		info,
+		map[string]beads.Bead{bead.ID: bead},
+		nil,
+		runtime.NewFake(),
+		nil,
+		nil,
+	)
+	if reason != "circuit-open" {
+		t.Fatalf("sessionReason = %q, want circuit-open", reason)
+	}
+	assertStringMapEqual(t, bead.Metadata, before)
+}
+
+func TestSessionReason_CircuitOpenNonMatchingMetadataFallsBack(t *testing.T) {
+	bead := beads.Bead{
+		ID:     "gc-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"template":                  "worker",
+			"session_name":              "worker-circuit",
+			"state":                     "asleep",
+			"sleep_reason":              "user-hold",
+			sessionCircuitStateMetadata: "open",
+		},
+	}
+	before := cloneSessionReasonMetadata(bead.Metadata)
+	info := session.Info{
+		ID:          bead.ID,
+		Template:    "worker",
+		State:       session.StateAsleep,
+		SessionName: "worker-circuit",
+	}
+
+	reason := sessionReason(
+		info,
+		map[string]beads.Bead{bead.ID: bead},
+		nil,
+		runtime.NewFake(),
+		nil,
+		nil,
+	)
+	if reason != "user-hold" {
+		t.Fatalf("sessionReason = %q, want user-hold for non-matching circuit metadata", reason)
+	}
+	assertStringMapEqual(t, bead.Metadata, before)
+}
+
 func cloneSessionReasonMetadata(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 	for k, v := range in {

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1573,6 +1573,129 @@ func TestSessionReason_CircuitOpenNonMatchingMetadataFallsBack(t *testing.T) {
 	assertStringMapEqual(t, bead.Metadata, before)
 }
 
+func TestSessionReason_PriorityMatrix(t *testing.T) {
+	const agentName = "worker"
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              agentName,
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+	poolDesired := map[string]int{agentName: 1}
+
+	newBead := func(metadata map[string]string) beads.Bead {
+		base := map[string]string{
+			"template":     agentName,
+			"session_name": "worker-session",
+			"state":        "asleep",
+		}
+		for k, v := range metadata {
+			base[k] = v
+		}
+		return beads.Bead{
+			ID:       "gc-1",
+			Status:   "open",
+			Metadata: base,
+		}
+	}
+	newInfo := func(sessionName string) session.Info {
+		return session.Info{
+			ID:          "gc-1",
+			Template:    agentName,
+			State:       session.StateAsleep,
+			SessionName: sessionName,
+		}
+	}
+
+	tests := []struct {
+		name        string
+		metadata    map[string]string
+		cfg         *config.City
+		poolDesired map[string]int
+		live        bool
+		want        string
+	}{
+		{
+			name: "reset-pending beats circuit open and sleep",
+			metadata: map[string]string{
+				"restart_requested":         "true",
+				sessionCircuitStateMetadata: circuitOpen.String(),
+				"sleep_reason":              "idle-timeout",
+				"pool_slot":                 "1",
+			},
+			cfg:         cfg,
+			poolDesired: poolDesired,
+			live:        true,
+			want:        resetPendingReason,
+		},
+		{
+			name: "circuit-open beats sleep reason",
+			metadata: map[string]string{
+				sessionCircuitStateMetadata: circuitOpen.String(),
+				"sleep_reason":              "idle-timeout",
+				"pool_slot":                 "1",
+			},
+			cfg:         cfg,
+			poolDesired: poolDesired,
+			want:        circuitOpenReason,
+		},
+		{
+			name: "sleep reason beats wake config",
+			metadata: map[string]string{
+				"sleep_reason": "idle-timeout",
+				"pool_slot":    "1",
+			},
+			cfg:         cfg,
+			poolDesired: poolDesired,
+			want:        "idle-timeout",
+		},
+		{
+			name: "wake config falls through after blocking states",
+			metadata: map[string]string{
+				"pool_slot": "1",
+			},
+			cfg:         cfg,
+			poolDesired: poolDesired,
+			want:        string(WakeConfig),
+		},
+		{
+			name: "no config fallback remains empty reason",
+			metadata: map[string]string{
+				"pool_slot": "1",
+			},
+			want: "-",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := runtime.NewFake()
+			sessionName := "worker-session"
+			if tt.live {
+				if err := provider.Start(context.Background(), sessionName, runtime.Config{Command: "echo"}); err != nil {
+					t.Fatalf("Start: %v", err)
+				}
+			}
+			bead := newBead(tt.metadata)
+			before := cloneSessionReasonMetadata(bead.Metadata)
+
+			reason := sessionReason(
+				newInfo(sessionName),
+				map[string]beads.Bead{bead.ID: bead},
+				tt.cfg,
+				provider,
+				tt.poolDesired,
+				nil,
+			)
+			if reason != tt.want {
+				t.Fatalf("sessionReason = %q, want %q", reason, tt.want)
+			}
+			assertStringMapEqual(t, bead.Metadata, before)
+		})
+	}
+}
+
 func cloneSessionReasonMetadata(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 	for k, v := range in {

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1351,7 +1351,6 @@ func TestSessionReason_FallsThroughToProviderForSleepingAttachment(t *testing.T)
 			"template":     "worker",
 			"session_name": "sleeping-worker",
 			"state":        "asleep",
-			"sleep_reason": "idle-timeout",
 		},
 	}
 	info := session.Info{
@@ -1381,6 +1380,49 @@ func TestSessionReason_FallsThroughToProviderForSleepingAttachment(t *testing.T)
 	}
 }
 
+func TestSessionReason_SleepReasonOverridesWakeReason(t *testing.T) {
+	provider := runtime.NewFake()
+	if err := provider.Start(context.Background(), "sleeping-worker", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	cfg := &config.City{}
+	bead := beads.Bead{
+		ID:     "gc-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "sleeping-worker",
+			"state":        "asleep",
+			"sleep_reason": "idle-timeout",
+		},
+	}
+	info := session.Info{
+		ID:          "gc-1",
+		Template:    "worker",
+		State:       session.StateAsleep,
+		SessionName: "sleeping-worker",
+		Attached:    false,
+	}
+	wrapped := &attachmentCachingProvider{
+		Provider: provider,
+		cache: buildAttachmentCache([]session.Info{info}, func(info session.Info) (bool, error) {
+			return info.SessionName == "sleeping-worker", nil
+		}),
+	}
+
+	reason := sessionReason(
+		info,
+		map[string]beads.Bead{bead.ID: bead},
+		cfg,
+		wrapped,
+		nil,
+		nil,
+	)
+	if reason != "idle-timeout" {
+		t.Fatalf("sessionReason = %q, want idle-timeout before wake reasons", reason)
+	}
+}
+
 func TestSessionReason_ResetPendingLiveRuntimeOverridesOtherReasons(t *testing.T) {
 	provider := runtime.NewFake()
 	if err := provider.Start(context.Background(), "worker-live", runtime.Config{Command: "echo"}); err != nil {
@@ -1396,12 +1438,13 @@ func TestSessionReason_ResetPendingLiveRuntimeOverridesOtherReasons(t *testing.T
 		ID:     "gc-1",
 		Status: "open",
 		Metadata: map[string]string{
-			"template":          "worker",
-			"session_name":      "worker-live",
-			"state":             "asleep",
-			"sleep_reason":      "user-hold",
-			"pin_awake":         "true",
-			"restart_requested": "true",
+			"template":                  "worker",
+			"session_name":              "worker-live",
+			"state":                     "asleep",
+			"sleep_reason":              "user-hold",
+			"pin_awake":                 "true",
+			"restart_requested":         "true",
+			sessionCircuitStateMetadata: circuitOpen.String(),
 		},
 	}
 	before := cloneSessionReasonMetadata(bead.Metadata)

--- a/release-gates/ga-wzx5d-reason-priority-coverage-gate.md
+++ b/release-gates/ga-wzx5d-reason-priority-coverage-gate.md
@@ -1,0 +1,47 @@
+# Release Gate: REASON priority coverage
+
+- Deploy bead: `ga-wzx5d`
+- Source bead: `ga-4arrr.1.3`
+- Branch: `builder/ga-4arrr-1-2`
+- Remote branch: `origin/builder/ga-4arrr-1-2`
+- Reviewed commit: `ed0660200 test(gc): cover session reason priority matrix`
+- Base checked: `origin/main`
+- Stack note: this branch builds on open PR #2538 (`builder/ga-k0n20-1-3`) for the reset-pending REASON display. PR #2538 is clean with CI green at gate time.
+- Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses the deployer role criteria plus the source bead acceptance checklist.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-wzx5d` notes include `Review verdict: PASS` from `gascity/reviewer` at `ed0660200`. |
+| 2 | Acceptance criteria met | PASS | The source bead requested coverage for reset-pending, circuit-open, `sleep_reason`, wake/config fallback, and reset-pending-over-circuit-open conflict. `cmd/gc/cmd_session_test.go` now has `TestSessionReason_PriorityMatrix` plus focused tests for reset-pending, circuit-open, and sleep-reason priority. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestSessionReason' -count=1` passed; `go vet ./...` passed; `make test-fast-parallel` completed with `All fast jobs passed`. |
+| 4 | No high-severity review findings open | PASS | Reviewer findings list is empty. The only note is a non-blocking observation about a defensive impossible-state test value. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before gate creation; deployer will recheck after committing this gate file before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` exited 0; `git merge-tree` reported `merged`; `git diff --check origin/main...HEAD` exited 0. |
+
+## Acceptance Evidence
+
+| Source criterion | Result | Evidence |
+|---|---|---|
+| Cover reset-pending priority. | PASS | `TestSessionReason_ResetPendingLiveRuntimeOverridesOtherReasons` and `TestSessionReason_PriorityMatrix/reset-pending beats circuit-open and sleep_reason` assert `restart_requested=true` on a live runtime displays `reset-pending` ahead of lower-priority reasons. |
+| Cover circuit-open priority. | PASS | `TestSessionReason_CircuitOpenMetadataVisible` and `TestSessionReason_PriorityMatrix/circuit-open beats sleep_reason` assert `session_circuit_state=CIRCUIT_OPEN` displays `circuit-open`. |
+| Cover `sleep_reason` fallback before wake/config reasons. | PASS | `TestSessionReason_SleepReasonOverridesWakeReason` and `TestSessionReason_PriorityMatrix/sleep_reason beats wake config` assert lifecycle display reasons win before wake reasons. |
+| Cover wake/config fallback and no-config fallback. | PASS | `TestSessionReason_PriorityMatrix/wake config remains fallback` and `TestSessionReason_PriorityMatrix/no config and no blocking reason falls back to dash` cover both tail cases. |
+| Avoid hardcoded production roles. | PASS | The production code adds reason helpers only. Tests use `config.Agent{Name: "worker"}` as local fixture data, not production role-conditioned logic. |
+| Affected package tests pass. | PASS | `go test ./cmd/gc -run 'TestSessionReason' -count=1` passed in `0.404s`. |
+
+## Validation
+
+| Command | Result |
+|---|---|
+| `go test ./cmd/gc -run 'TestSessionReason' -count=1` | PASS |
+| `go vet ./...` | PASS |
+| `make test-fast-parallel` | PASS (`fsys-darwin-compile`, `unit-core`, and `unit-cmd-gc` shards 1-6 passed; `All fast jobs passed`) |
+| `git diff --check origin/main...HEAD` | PASS |
+
+## Changed Files
+
+- `cmd/gc/cmd_session.go`
+- `cmd/gc/cmd_session_test.go`
+- `release-gates/ga-oeqam-reset-pending-session-reason-display-gate.md` (stack prerequisite from PR #2538)


### PR DESCRIPTION
## What this changes

`gc session list` now keeps operator-facing REASON values in blocking-priority order. A live reset request still reports `reset-pending`, an open session circuit breaker reports `circuit-open`, explicit lifecycle sleep reasons stay visible before wake/config reasons, and `config` remains the fallback only when no blocking reason is present.

The branch also adds a priority matrix around `sessionReason()` so future changes cannot accidentally hide an actionable blocker behind the generic wake reason.

## Review notes

- This PR is stacked on #2538. Review and merge after #2538; until then GitHub will show the reset-pending prerequisite commit in this diff.
- Runtime behavior is limited to the `gc session list` REASON column and its tests. There are no config, schema, API, or dashboard changes.
- Display values remain plain text and script-friendly: `reset-pending`, `circuit-open`, lifecycle reasons such as `idle-timeout`, then wake reasons such as `config`.
- Internal tracking: `ga-wzx5d`.

## Test plan

- [x] `go test ./cmd/gc -run 'TestSessionReason' -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-wzx5d-reason-priority-coverage-gate.md`](release-gates/ga-wzx5d-reason-priority-coverage-gate.md)
