### PR TITLE
fix: free city-stop pool slots

### DIFF
--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2296,8 +2296,8 @@ func TestReconcileSessionBeads_SuspendedCloseIgnoresUnreachableRigAssignedWork(t
 
 // TestReconcileSessionBeads_CloseGatePreservesSleepReason verifies that the
 // close gate carries the session's existing sleep_reason (idle,
-// idle-timeout, drained) into the closed bead's close reason. Losing this
-// distinction in closed records erases the forensic difference between an
+// idle-timeout, drained, city-stop) into the closed bead's close reason. Losing
+// this distinction in closed records erases the forensic difference between an
 // idle-timeout recycle and an explicit drain.
 func TestReconcileSessionBeads_CloseGatePreservesSleepReason(t *testing.T) {
 	cases := []struct {
@@ -2307,6 +2307,7 @@ func TestReconcileSessionBeads_CloseGatePreservesSleepReason(t *testing.T) {
 	}{
 		{"idle", "idle", "idle"},
 		{"idle-timeout", "idle-timeout", "idle-timeout"},
+		{"city-stop", sleepReasonCityStop, sleepReasonCityStop},
 		{"drained-reason", "drained", "drained"},
 		{"missing-reason", "", "drained"}, // fallback
 	}

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -43,7 +43,7 @@ func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	}
 	reason := strings.TrimSpace(session.Metadata["sleep_reason"])
 	switch reason {
-	case "idle", "idle-timeout", "failed-create", sleepReasonRuntimeMissing:
+	case "idle", "idle-timeout", sleepReasonCityStop, "failed-create", sleepReasonRuntimeMissing:
 		return true
 	}
 	return false

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -20,6 +20,7 @@ func TestIsPoolSessionSlotFreeable_Matrix(t *testing.T) {
 		{"asleep+drained-reason", map[string]string{"state": "asleep", "sleep_reason": "drained"}, true},
 		{"asleep+idle", map[string]string{"state": "asleep", "sleep_reason": "idle"}, true},
 		{"asleep+idle-timeout", map[string]string{"state": "asleep", "sleep_reason": "idle-timeout"}, true},
+		{"asleep+city-stop", map[string]string{"state": "asleep", "sleep_reason": sleepReasonCityStop}, true},
 		{"asleep+failed-create", map[string]string{"state": "asleep", "sleep_reason": "failed-create"}, true},
 		{"asleep+runtime-missing", map[string]string{"state": "asleep", "sleep_reason": sleepReasonRuntimeMissing}, true},
 		{"asleep+empty-reason", map[string]string{"state": "asleep", "sleep_reason": ""}, false},


### PR DESCRIPTION
## Summary

- Treat pool-managed sessions stopped by `gc stop` (`sleep_reason=city-stop`) as freeable once their runtime is gone and they have no real assigned work.
- Preserve the close reason as `city-stop` when the reconciler closes those stale pool session beads, so alias slots are released without losing forensic context.
- Add both helper-level and reconciler close-gate regression coverage.

## Testing

- [x] `go test ./cmd/gc -run 'TestIsPoolSessionSlotFreeable_Matrix|TestReconcileSessionBeads_CloseGatePreservesSleepReason|TestReconcileSessionBeads_DrainedPoolSessionStoreQueryPartialStaysOpen|TestGCSweep(SessionBeads_(ClosesWhenOnlyAssignedWorkIsReadMail|KeepsAssignedRealWorkWhenReadMailAlsoAssigned|KeepsAssignedUnreadMail)|StoppedSessionBeads_IgnoresReadMailButKeepsRealWork)$' -count=1`
- [x] Rescue-branch pre-commit hook for the same patch: `go vet ./...` and `./scripts/test-local-parallel fast`

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No issue was filed because this is a narrow operational cleanup bug found while unblocking maintainer-city pool aliases. No user-facing docs, breaking changes, or migrations are needed.
