### PR TITLE
fix: repair legacy gc-beads-bd script path

### DIFF
--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -65,6 +65,9 @@ func MaterializeBuiltinPacks(cityPath string) error {
 			return fmt.Errorf("pruning legacy %s order paths: %w", bp.Name, err)
 		}
 	}
+	if err := repairLegacyGcBeadsBdScript(cityPath); err != nil {
+		return fmt.Errorf("repairing legacy gc-beads-bd script: %w", err)
+	}
 	return nil
 }
 
@@ -350,6 +353,44 @@ func materializeFS(embedded fs.FS, root, dstDir string) (map[string]struct{}, er
 		return nil, err
 	}
 	return desired, nil
+}
+
+func repairLegacyGcBeadsBdScript(cityPath string) error {
+	path := legacyGcBeadsBdScriptPath(cityPath)
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !looksLikeGeneratedGcBeadsBdScript(data) {
+		return nil
+	}
+	return fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, path, legacyGcBeadsBdShim(), 0o755)
+}
+
+func looksLikeGeneratedGcBeadsBdScript(data []byte) bool {
+	text := string(data)
+	return strings.Contains(text, "gc-beads-bd") && strings.Contains(text, "exec: beads provider")
+}
+
+func legacyGcBeadsBdShim() []byte {
+	return []byte(`#!/bin/sh
+set -eu
+
+script_dir=$(dirname "$0")
+city_root=$(cd "$script_dir/../.." && pwd)
+
+exec "$city_root/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh" "$@"
+`)
 }
 
 // pruneLegacyEmbeddedOrders removes deprecated order directory layouts when the

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -667,6 +667,45 @@ func TestMaterializeBuiltinPacks_PrunesLegacyOrderDirs(t *testing.T) {
 	}
 }
 
+func TestMaterializeBuiltinPacks_RepairsLegacyGcBeadsBdScript(t *testing.T) {
+	dir := t.TempDir()
+	legacyScript := filepath.Join(dir, ".gc", "scripts", "gc-beads-bd.sh")
+	if err := os.MkdirAll(filepath.Dir(legacyScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := `#!/bin/sh
+# gc-beads-bd - exec: beads provider for Dolt-backed beads (bd).
+run_bd_pinned "$dir" config set issue_prefix "$prefix" 2>/dev/null || true
+run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
+`
+	if err := os.WriteFile(legacyScript, []byte(stale), 0o755); err != nil {
+		t.Fatalf("write legacy script: %v", err)
+	}
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	data, err := os.ReadFile(legacyScript)
+	if err != nil {
+		t.Fatalf("read repaired legacy script: %v", err)
+	}
+	body := string(data)
+	if strings.Contains(body, "config set") {
+		t.Fatalf("legacy script still contains config mutation:\n%s", body)
+	}
+	if !strings.Contains(body, ".gc/system/packs/bd/assets/scripts/gc-beads-bd.sh") {
+		t.Fatalf("legacy script was not repaired to system-pack shim:\n%s", body)
+	}
+	info, err := os.Stat(legacyScript)
+	if err != nil {
+		t.Fatalf("stat repaired legacy script: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("repaired legacy script is not executable: mode %v", info.Mode())
+	}
+}
+
 func TestMaterializeBuiltinPacks_PrunesStaleGeneratedPackFiles(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -483,7 +483,7 @@ func normalizeRawBeadsProvider(cityPath, provider string) string {
 		return provider
 	}
 	script := strings.TrimSpace(strings.TrimPrefix(provider, "exec:"))
-	if samePath(script, gcBeadsBdScriptPath(cityPath)) {
+	if samePath(script, gcBeadsBdScriptPath(cityPath)) || samePath(script, legacyGcBeadsBdScriptPath(cityPath)) {
 		return "bd"
 	}
 	return provider
@@ -632,6 +632,10 @@ func beadsProvider(cityPath string) string {
 // inside the materialized bd pack (.gc/system/packs/bd/assets/scripts/).
 func gcBeadsBdScriptPath(cityPath string) string {
 	return filepath.Join(cityPath, citylayout.SystemPacksRoot, "bd", "assets", "scripts", "gc-beads-bd.sh")
+}
+
+func legacyGcBeadsBdScriptPath(cityPath string) string {
+	return filepath.Join(cityPath, ".gc", "scripts", "gc-beads-bd.sh")
 }
 
 // mailProviderName returns the mail provider name.

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -76,6 +76,15 @@ func TestRawBeadsProviderNormalizesManagedExecEnv(t *testing.T) {
 	}
 }
 
+func TestRawBeadsProviderNormalizesLegacyManagedExecEnv(t *testing.T) {
+	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS", "exec:"+filepath.Join(cityPath, ".gc", "scripts", "gc-beads-bd.sh"))
+
+	if got := rawBeadsProvider(cityPath); got != "bd" {
+		t.Fatalf("rawBeadsProvider() = %q, want bd", got)
+	}
+}
+
 func TestRawBeadsProviderPreservesCustomExecOverride(t *testing.T) {
 	t.Setenv("GC_BEADS", "exec:/tmp/custom-beads")
 


### PR DESCRIPTION
## Summary

- Repair stale generated `.gc/scripts/gc-beads-bd.sh` files during builtin-pack materialization by replacing recognized legacy copies with a shim to the canonical system-pack script.
- Treat legacy managed `GC_BEADS=exec:<city>/.gc/scripts/gc-beads-bd.sh` values as the logical `bd` provider, matching the current `.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh` path.
- Prevent old generated scripts from re-running the historical `bd config set` path that can rewrite Beads config into the wrong shape.

## Testing

- [x] `go test ./cmd/gc -run 'TestRawBeadsProvider|TestMaterializeBuiltinPacks' -count=1`
- [x] Pre-commit hook: lint-changed, generated reference/schema checks, `go vet ./...`, fast parallel tests
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed: no issue yet; this was found during maintainer-city production rescue after a stale generated provider script kept overwriting Beads config.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes: not user-facing
- [x] Called out breaking changes or migration notes: no breaking changes; existing legacy script paths are repaired/normalized
