### PR TITLE
fix(provider): persist OMP session keys (adopted)

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -557,7 +557,10 @@ func persistPrimeHookSessionID(sessionID string) {
 
 func persistPrimeHookProviderSessionKey() {
 	gcSessionID := strings.TrimSpace(os.Getenv("GC_SESSION_ID"))
-	providerSessionID := strings.TrimSpace(os.Getenv("GEMINI_SESSION_ID"))
+	providerSessionID := strings.TrimSpace(os.Getenv("GC_PROVIDER_SESSION_ID"))
+	if providerSessionID == "" {
+		providerSessionID = strings.TrimSpace(os.Getenv("GEMINI_SESSION_ID"))
+	}
 	if gcSessionID == "" || providerSessionID == "" || gcSessionID == providerSessionID {
 		return
 	}

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -501,11 +501,14 @@ func TestMaterializeBuiltinPacksOmpHookPublishesProviderSessionID(t *testing.T) 
 	data := readMaterializedOmpHook(t, dir)
 	for _, want := range []string{
 		`import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent"`,
+		`const GC_OMP_HOOK_VERSION = 1`,
 		`export default function gascityOmpExtension(pi: ExtensionAPI)`,
 		`pi.on("session_start"`,
 		`pi.on("session_compact"`,
+		`pi.on("before_agent_start"`,
 		`GC_PROVIDER_SESSION_ID`,
 		`getSessionId`,
+		`logRunFailure`,
 	} {
 		if !strings.Contains(data, want) {
 			t.Errorf("materialized OMP hook missing provider-session marker %q:\n%s", want, data)

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -491,8 +491,54 @@ module.exports = {
 	}
 }
 
+func TestMaterializeBuiltinPacksOmpHookPublishesProviderSessionID(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	data := readMaterializedOmpHook(t, dir)
+	for _, want := range []string{
+		`import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent"`,
+		`export default function gascityOmpExtension(pi: ExtensionAPI)`,
+		`pi.on("session_start"`,
+		`pi.on("session_compact"`,
+		`GC_PROVIDER_SESSION_ID`,
+		`getSessionId`,
+	} {
+		if !strings.Contains(data, want) {
+			t.Errorf("materialized OMP hook missing provider-session marker %q:\n%s", want, data)
+		}
+	}
+	for _, legacy := range []string{
+		"export default {",
+		`"session.created"`,
+		`"session.compacted"`,
+		`"experimental.chat.system.transform"`,
+	} {
+		if strings.Contains(data, legacy) {
+			t.Errorf("materialized OMP hook still contains legacy API marker %q:\n%s", legacy, data)
+		}
+	}
+}
+
 func materializedPiHookPath(dir string) string {
 	return filepath.Join(dir, citylayout.SystemPacksRoot, "core", "overlay", "per-provider", "pi", ".pi", "extensions", "gc-hooks.js")
+}
+
+func materializedOmpHookPath(dir string) string {
+	return filepath.Join(dir, citylayout.SystemPacksRoot, "core", "overlay", "per-provider", "omp", ".omp", "hooks", "gc-hook.ts")
+}
+
+func readMaterializedOmpHook(t *testing.T, dir string) string {
+	t.Helper()
+	path := materializedOmpHookPath(dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(data)
 }
 
 func readMaterializedPiHook(t *testing.T, dir string) string {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -6782,6 +6782,81 @@ prompt_template = "prompts/probe.md"
 	}
 }
 
+func TestDoPrimeHookPersistsGenericProviderSessionKey(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	promptsDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptsDir, "probe.md"), []byte("probe prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := `[workspace]
+name = "test-city"
+provider = "omp"
+
+[[agent]]
+name = "probe"
+prompt_template = "prompts/probe.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openCityStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionBead, err := store.Create(beads.Bead{
+		Title: "probe",
+		Type:  "task",
+		Labels: []string{
+			"gc:session",
+			"template:probe",
+		},
+		Metadata: map[string]string{
+			"template":     "probe",
+			"provider":     "omp",
+			"session_name": "probe",
+			"state":        "active",
+			"work_dir":     dir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_AGENT", "probe")
+	t.Setenv("GC_SESSION_ID", sessionBead.ID)
+	t.Setenv("GC_PROVIDER_SESSION_ID", "omp-provider-session")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode(nil, &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithMode = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	updatedStore, err := openCityStoreAt(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := updatedStore.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["session_key"]); got != "omp-provider-session" {
+		t.Fatalf("session_key = %q, want generic provider session id", got)
+	}
+}
+
 func TestDoPrimeHookFallsBackToGCTemplateForManualSessionAlias(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()

--- a/internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts
+++ b/internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts
@@ -11,6 +11,7 @@
 import { execFileSync } from "node:child_process";
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 
+const GC_OMP_HOOK_VERSION = 1;
 const PATH_PREFIX =
   `/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
 
@@ -26,8 +27,26 @@ function run(args: string[], cwd?: string, extraEnv: Record<string, string> = {}
         PATH: PATH_PREFIX + (process.env.PATH || ""),
       },
     }).trim();
-  } catch {
+  } catch (err) {
+    logRunFailure(args, cwd, err);
     return "";
+  }
+}
+
+function logRunFailure(args: string[], cwd: string | undefined, err: unknown): void {
+  try {
+    const maybeError = err as { code?: string; signal?: string; message?: string } | undefined;
+    const detail = maybeError?.code || maybeError?.signal || maybeError?.message || "unknown error";
+    console.error(
+      "gc-hooks run:",
+      `gc ${args.join(" ")}`,
+      "cwd",
+      cwd || process.cwd(),
+      "failed:",
+      detail,
+    );
+  } catch {
+    // Keep OMP hooks non-fatal even if stderr is unavailable.
   }
 }
 

--- a/internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts
+++ b/internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts
@@ -1,45 +1,67 @@
 // Gas City hooks for Oh My Pi (OMP).
 // Installed by gc into {workDir}/.omp/hooks/gc-hook.ts
+// Managed by `gc hooks install`; put custom OMP hooks in separate extension
+// files so upgrades can replace this file safely.
 //
 // Events:
-//   session.created    → gc prime (load context)
-//   session.compacted  → gc prime (reload after compaction)
-//   chat.system.transform → gc nudge drain --inject + gc mail check --inject
+//   session_start       → gc prime --hook (load context side effects and capture OMP session id)
+//   session_compact     → gc prime --hook (reload after compaction)
+//   before_agent_start  → inject queued nudges + unread mail
 
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 
 const PATH_PREFIX =
-  `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
+  `/opt/homebrew/bin:/usr/local/bin:${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
 
-function run(cmd: string): string {
+function run(args: string[], cwd?: string, extraEnv: Record<string, string> = {}): string {
   try {
-    return execSync(cmd, {
+    return execFileSync("gc", args, {
+      cwd: cwd || process.cwd(),
       encoding: "utf-8",
       timeout: 30000,
-      env: { ...process.env, PATH: PATH_PREFIX + (process.env.PATH || "") },
+      env: {
+        ...process.env,
+        ...extraEnv,
+        PATH: PATH_PREFIX + (process.env.PATH || ""),
+      },
     }).trim();
   } catch {
     return "";
   }
 }
 
-export default {
-  name: "gascity",
+function providerSessionEnv(ctx: { sessionManager?: { getSessionId?: () => string } }): Record<string, string> {
+  const sessionID = ctx.sessionManager?.getSessionId?.() || "";
+  if (!sessionID) {
+    return {};
+  }
+  return { GC_PROVIDER_SESSION_ID: sessionID };
+}
 
-  events: {
-    "session.created": () => run("gc prime --hook"),
-    "session.compacted": () => run("gc prime --hook"),
-  },
+function appendSystemPrompt(systemPrompt: string[], additions: string[]): string[] {
+  const extras = additions.filter(Boolean);
+  if (extras.length === 0) {
+    return systemPrompt;
+  }
+  return [...systemPrompt, extras.join("\n\n")];
+}
 
-  hooks: {
-    "experimental.chat.system.transform": (system: string): string => {
-      const nudges = run("gc nudge drain --inject");
-      const mail = run("gc mail check --inject");
-      const extras = [nudges, mail].filter(Boolean);
-      if (extras.length > 0) {
-        return system + "\n\n" + extras.join("\n\n");
-      }
-      return system;
-    },
-  },
-};
+export default function gascityOmpExtension(pi: ExtensionAPI) {
+  pi.on("session_start", (_event, ctx) => {
+    run(["prime", "--hook"], ctx.cwd, providerSessionEnv(ctx));
+  });
+
+  pi.on("session_compact", (_event, ctx) => {
+    run(["prime", "--hook"], ctx.cwd, providerSessionEnv(ctx));
+  });
+
+  pi.on("before_agent_start", (event, ctx) => {
+    const nudges = run(["nudge", "drain", "--inject"], ctx.cwd);
+    const mail = run(["mail", "check", "--inject"], ctx.cwd);
+    const systemPrompt = appendSystemPrompt(event.systemPrompt, [nudges, mail]);
+    if (systemPrompt !== event.systemPrompt) {
+      return { systemPrompt };
+    }
+  });
+}

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -345,6 +345,7 @@ func TestBuiltinProvidersResumeFlags(t *testing.T) {
 		{"amp", "threads continue", "subcommand"},
 		{"opencode", "--session", "flag"},
 		{"auggie", "--resume", "flag"},
+		{"omp", "--resume", "flag"},
 	}
 	providers := BuiltinProviders()
 	for _, tt := range tests {

--- a/internal/hooks/config/README.md
+++ b/internal/hooks/config/README.md
@@ -29,10 +29,10 @@ the event, or it does but Gas City has not opted in yet).
 
 | Canonical event | claude | codex | cursor | copilot | gemini | opencode | omp | pi |
 |---|---|---|---|---|---|---|---|---|
-| session start    | `SessionStart` ✓ | `SessionStart` ✓ | `sessionStart` ✓ | `sessionStart` ✓ | `SessionStart` ✓ | `session.created` ✓ | `session.created` ✓ | `session_start` ✓ |
-| pre-compaction   | `PreCompact` ✓   | `PreCompact` ✓   | `preCompact` ✓   | — (gap, #672)    | `PreCompress` ✓  | `session.compacted` ✓ | `session.compacted` ✓ | `session_compact` ✓ |
-| user prompt submit | `UserPromptSubmit` ✓ | `UserPromptSubmit` ✓ | `beforeSubmitPrompt` ✓ | `userPromptSubmitted` ✓ | — | — | `experimental.chat.system.transform` ✓ | — |
-| before agent run | —                | —                | —                | —                | `BeforeAgent` ✓  | —                | (via prompt transform) | `before_agent_start` ✓ |
+| session start    | `SessionStart` ✓ | `SessionStart` ✓ | `sessionStart` ✓ | `sessionStart` ✓ | `SessionStart` ✓ | `session.created` ✓ | `session_start` ✓ | `session_start` ✓ |
+| pre-compaction   | `PreCompact` ✓   | `PreCompact` ✓   | `preCompact` ✓   | — (gap, #672)    | `PreCompress` ✓  | `session.compacted` ✓ | `session_compact` ✓ | `session_compact` ✓ |
+| user prompt submit | `UserPromptSubmit` ✓ | `UserPromptSubmit` ✓ | `beforeSubmitPrompt` ✓ | `userPromptSubmitted` ✓ | — | — | — | — |
+| before agent run | —                | —                | —                | —                | `BeforeAgent` ✓  | —                | `before_agent_start` ✓ | `before_agent_start` ✓ |
 
 ### Gas City command bindings
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -34,11 +34,13 @@ var supported = []string{"claude", "codex", "gemini", "kiro", "opencode", "copil
 const (
 	managedPiHookVersion       = 4
 	managedOpenCodeHookVersion = 2
+	managedOmpHookVersion      = 1
 )
 
 var (
 	piHookVersionPattern       = regexp.MustCompile(`\bGC_PI_HOOK_VERSION\s*=\s*([0-9]+)\b`)
 	opencodeHookVersionPattern = regexp.MustCompile(`\bGC_OPENCODE_HOOK_VERSION\s*=\s*([0-9]+)\b`)
+	ompHookVersionPattern      = regexp.MustCompile(`\bGC_OMP_HOOK_VERSION\s*=\s*([0-9]+)\b`)
 )
 
 // unwiredHookProviders lists provider names whose own CLIs do expose a
@@ -204,6 +206,9 @@ func overlayManagedNeedsUpgrade(provider, rel string) func([]byte) bool {
 	if provider == "opencode" && rel == path.Join(".opencode", "plugins", "gascity.js") {
 		return opencodeHookNeedsUpgrade
 	}
+	if provider == "omp" && rel == path.Join(".omp", "hooks", "gc-hook.ts") {
+		return ompHookNeedsUpgrade
+	}
 	return nil
 }
 
@@ -273,6 +278,45 @@ func opencodeHookNeedsUpgrade(existing []byte) bool {
 
 func opencodeHookVersion(content string) int {
 	match := opencodeHookVersionPattern.FindStringSubmatch(content)
+	if len(match) != 2 {
+		return 0
+	}
+	version, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0
+	}
+	return version
+}
+
+func ompHookNeedsUpgrade(existing []byte) bool {
+	content := string(existing)
+	if !strings.Contains(content, "Gas City hooks for Oh My Pi (OMP).") {
+		return false
+	}
+	if ompHookVersion(content) < managedOmpHookVersion ||
+		!strings.Contains(content, "gascityOmpExtension") ||
+		!strings.Contains(content, "GC_PROVIDER_SESSION_ID") ||
+		!strings.Contains(content, `pi.on("session_start"`) ||
+		!strings.Contains(content, `pi.on("session_compact"`) ||
+		!strings.Contains(content, `pi.on("before_agent_start"`) ||
+		!strings.Contains(content, "logRunFailure") {
+		return true
+	}
+	for _, marker := range []string{
+		"export default {",
+		`"session.created"`,
+		`"session.compacted"`,
+		`"experimental.chat.system.transform"`,
+	} {
+		if strings.Contains(content, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func ompHookVersion(content string) int {
+	match := ompHookVersionPattern.FindStringSubmatch(content)
 	if len(match) != 2 {
 		return 0
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1652,6 +1652,91 @@ let mirrorTempCounter = 0;
 	}
 }
 
+func TestInstallOMPHookUpgradesLegacyObjectExport(t *testing.T) {
+	fs := fsys.NewFake()
+	legacy := []byte(`// Gas City hooks for Oh My Pi (OMP).
+export default {
+  name: "gascity",
+  events: {
+    "session.created": () => "",
+    "session.compacted": () => "",
+  },
+  hooks: {
+    "experimental.chat.system.transform": (system: string): string => system,
+  },
+};
+`)
+	fs.Files["/work/.omp/hooks/gc-hook.ts"] = legacy
+
+	if err := Install(fs, "/city", "/work", []string{"omp"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data := string(fs.Files["/work/.omp/hooks/gc-hook.ts"])
+	if data == string(legacy) {
+		t.Fatal("legacy OMP object-export hook was preserved; expected managed upgrade")
+	}
+	for _, want := range []string{
+		"const GC_OMP_HOOK_VERSION = 1",
+		`export default function gascityOmpExtension(pi: ExtensionAPI)`,
+		`pi.on("session_start"`,
+		`pi.on("session_compact"`,
+		`pi.on("before_agent_start"`,
+		"GC_PROVIDER_SESSION_ID",
+		"logRunFailure",
+	} {
+		if !strings.Contains(data, want) {
+			t.Errorf("upgraded OMP hook missing marker %q:\n%s", want, data)
+		}
+	}
+	backup := string(fs.Files["/work/.omp/hooks/gc-hook.ts.bak"])
+	if backup != string(legacy) {
+		t.Fatalf("legacy OMP hook backup = %q, want original legacy content", backup)
+	}
+}
+
+func TestOMPHookNeedsUpgradeComparesParsedVersion(t *testing.T) {
+	current := []byte(`// Gas City hooks for Oh My Pi (OMP).
+const GC_OMP_HOOK_VERSION = 1;
+function logRunFailure(args: string[], cwd: string | undefined, err: unknown) {}
+function providerSessionEnv(ctx: { sessionManager?: { getSessionId?: () => string } }): Record<string, string> {}
+export default function gascityOmpExtension(pi: ExtensionAPI) {
+  pi.on("session_start", () => {});
+  pi.on("session_compact", () => {});
+  pi.on("before_agent_start", () => {});
+}
+GC_PROVIDER_SESSION_ID;
+`)
+	stale := bytes.Replace(current, []byte("GC_OMP_HOOK_VERSION = 1"), []byte("GC_OMP_HOOK_VERSION = 0"), 1)
+	future := bytes.Replace(current, []byte("GC_OMP_HOOK_VERSION = 1"), []byte("GC_OMP_HOOK_VERSION = 2"), 1)
+
+	if !ompHookNeedsUpgrade(stale) {
+		t.Fatal("stale OMP hook version did not request upgrade")
+	}
+	if ompHookNeedsUpgrade(current) {
+		t.Fatal("current OMP hook version requested upgrade")
+	}
+	if ompHookNeedsUpgrade(future) {
+		t.Fatal("newer OMP hook version requested downgrade")
+	}
+}
+
+func TestInstallOMPHookPreservesUserAuthoredFile(t *testing.T) {
+	fs := fsys.NewFake()
+	custom := []byte(`export default function customOmpExtension(pi: ExtensionAPI) {
+  pi.on("session_start", () => {});
+}
+`)
+	fs.Files["/work/.omp/hooks/gc-hook.ts"] = custom
+
+	if err := Install(fs, "/city", "/work", []string{"omp"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if got := string(fs.Files["/work/.omp/hooks/gc-hook.ts"]); got != string(custom) {
+		t.Fatalf("user-authored OMP hook was overwritten:\n%s", got)
+	}
+}
+
 func TestInstallOpenCodeHookUpgradesStaleManagedPlugin(t *testing.T) {
 	fs := fsys.NewFake()
 	legacy := []byte(`// Gas City hooks for OpenCode.

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -453,6 +453,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		ProcessNames:     []string{"omp", "node", "bun"},
 		SupportsHooks:    true,
 		InstructionsFile: "AGENTS.md",
+		ResumeFlag:       "--resume",
+		ResumeStyle:      "flag",
 	},
 }
 


### PR DESCRIPTION
## Summary

This maintainer follow-up carries forward #2393 because the adopted review branch needed maintainer-side fixups, but GitHub rejected updating the fork branch with `403` for the maintainer token.

- Preserves the contributor change that persists OMP provider session keys so OMP sessions can resume with the recorded provider key.
- Adds the maintainer fixup for managed OMP hook upgrades, stale-hook replacement coverage, and observable non-fatal `gc prime --hook` failure logging.
- Keeps the final reviewed diff on the configured `main` base.

## Original PR

- Original PR: https://github.com/gastownhall/gascity/pull/2393
- Original title: `fix(provider): persist OMP session keys`
- Original state at follow-up creation: OPEN
- Contributor: @A3Ackerman
- Original head: `quickserve-ai/gascity:fix/omp-provider-session-keys` at `29ee033e3a93cf3f337439e1d93eb6b3a0bcaa88`
- Configured base: `main`
- Original GitHub base: `main`
- Base mismatch: none
- Reviewed final head: `adb53cb82e547f5b73fe3c51f906fc4f5be198f9`

## Review And Validation

The adoption review reached approval on the second pass after the maintainer fixup. Review validated the generic provider-session persistence path, the OMP hook's `getSessionId()` forwarding, managed OMP hook upgrades, OMP resume metadata, and the current OMP `string[]` prompt-injection contract.

Targeted validation recorded by the review workflow:

- `go test ./internal/hooks -run 'TestInstallOMPHook|TestOMPHook'`
- `go test ./internal/config -run TestBuiltinProvidersResumeFlags`
- `go test ./cmd/gc -run 'TestDoPrimeHookPersistsGenericProviderSessionKey|TestDoPrimeGeminiHookPersistsProviderSessionKey|TestMaterializeBuiltinPacksOmpHookPublishesProviderSessionID'`

CI for this follow-up branch is expected to run on the final adopted head before it is handed to the merge queue.
