### PR TITLE
fix(order,supervisor): surface cron pool demand via gc.pool_demand metadata

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -334,7 +334,15 @@ func buildDesiredStateWithSessionBeads(
 		if len(defaultScaleTargets) > 0 {
 			defaultCounts, partialTemplates, errs := defaultScaleCheckCounts(defaultScaleTargets)
 			for _, err := range errs {
-				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", err) //nolint:errcheck
+				// defaultScaleCheckCounts can fail on either of two
+				// demand sources (Ready iteration or pool-demand list);
+				// the wrapped error message names which one ("Ready()"
+				// vs "List(gc.pool_demand)") so this generic outer log
+				// stays honest about the partial nature without
+				// claiming the demand is necessarily zero. A failing
+				// pool-demand list does not zero the Ready-source
+				// contributions to scaleCheckCounts[template].
+				fmt.Fprintf(stderr, "buildDesiredState: %v (counts above may be a partial of one demand source)\n", err) //nolint:errcheck
 			}
 			poolScaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(poolScaleCheckPartialTemplates, partialTemplates)
 			for template, count := range defaultCounts {
@@ -865,12 +873,23 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 	}
 
 	for key, group := range groups {
-		ready, err := readyForControllerDemand(group.store)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: Ready(): %w", key, strings.Join(sortedStringSet(group.templates), ","), err))
+		// counted dedups across the two demand sources below so a bead
+		// surfaced by both Ready() and the gc.pool_demand list (rare —
+		// only if a task-shaped routed bead also happens to carry the
+		// flag) is counted exactly once per template.
+		counted := make(map[string]struct{})
+
+		// Source 1: Ready()/CachedReady() iteration. Surfaces the
+		// actionable-type set (task, etc.) matched against gc.routed_to.
+		// Legacy formula step beads are NOT here because PR #1154 added
+		// "step" to readyExcludeTypes; molecule wisps are NOT here
+		// because workflow containers were already excluded.
+		ready, readyErr := readyForControllerDemand(group.store)
+		if readyErr != nil {
+			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: Ready(): %w", key, strings.Join(sortedStringSet(group.templates), ","), readyErr))
 			partialTemplates = markScaleCheckPartialSet(partialTemplates, group.templates)
-			if !beads.IsPartialResult(err) || len(ready) == 0 {
-				continue
+			if !beads.IsPartialResult(readyErr) {
+				ready = nil
 			}
 		}
 		for _, b := range ready {
@@ -878,9 +897,62 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 				continue
 			}
 			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
-			if _, ok := group.templates[template]; ok {
-				counts[template]++
+			if _, ok := group.templates[template]; !ok {
+				continue
 			}
+			if _, dup := counted[b.ID]; dup {
+				continue
+			}
+			counted[b.ID] = struct{}{}
+			counts[template]++
+		}
+
+		// Source 2: explicit pool-demand path. Two writers stamp the wisp
+		// when a.Pool != "" — doOrderRunWithJSON (cmd_order.go, the
+		// gc order run CLI path) and memoryOrderDispatcher.dispatchOne
+		// (order_dispatch.go, the supervisor's in-process cron path).
+		// Both write poolDemandMetadataPair() alongside the routing key,
+		// so cron-fired pool orders surface scale_check demand even when
+		// the wisp lands as a molecule that readyExcludeTypes filters out
+		// (per PR #1154 / issue #1039 — formula steps are not actionable
+		// work, the molecule is the container). The list filter is
+		// metadata-only (open + gc.pool_demand=<sentinel>); the
+		// unassigned + matching-routed_to checks apply below as for the
+		// Ready source.
+		//
+		// Live: true skips the CachingStore in-memory snapshot and reads
+		// the backing store directly. The cache populates from PrimeActive
+		// at supervisor startup and is maintained by the event stream, but
+		// gc order run is a sibling subprocess so the cache lag would
+		// otherwise stretch demand observation by an unbounded number of
+		// reconcile ticks. Mirrors openSessionBeadExists in
+		// adoption_barrier.go, which uses Live: true for the same
+		// cross-process freshness reason.
+		demand, demandErr := group.store.List(beads.ListQuery{
+			Status:   "open",
+			Metadata: poolDemandMetadataPair(),
+			Live:     true,
+		})
+		if demandErr != nil {
+			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: List(%s): %w", key, strings.Join(sortedStringSet(group.templates), ","), poolDemandMetadataKey, demandErr))
+			partialTemplates = markScaleCheckPartialSet(partialTemplates, group.templates)
+			if !beads.IsPartialResult(demandErr) {
+				demand = nil
+			}
+		}
+		for _, b := range demand {
+			if strings.TrimSpace(b.Assignee) != "" {
+				continue
+			}
+			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
+			if _, ok := group.templates[template]; !ok {
+				continue
+			}
+			if _, dup := counted[b.ID]; dup {
+				continue
+			}
+			counted[b.ID] = struct{}{}
+			counts[template]++
 		}
 	}
 	return counts, partialTemplates, errs
@@ -943,6 +1015,18 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 		identitiesByTemplate[template] = append(identitiesByTemplate[template], spec.Identity)
 	}
 
+	// NOTE: this loop intentionally only consults Ready(), not the
+	// gc.pool_demand list path that defaultScaleCheckCounts uses for
+	// pool agents. All current pack-shipped cron orders route to pool
+	// agents (none target named on_demand sessions), so this function
+	// is never the load-bearing demand source for cron-fired wisps in
+	// practice. If a future named on_demand cron order surfaces — i.e.
+	// a wisp lands with gc.routed_to=<named-identity> AND the molecule
+	// type filters it out of Ready() — mirror the Source-2 List path
+	// from defaultScaleCheckCounts here (query open + poolDemandMetadataPair()
+	// from the same group.store, apply the unassigned + routed-to
+	// match, dedup against the Ready source) and add a parallel test
+	// next to TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag.
 	for key, group := range groups {
 		ready, err := readyForControllerDemand(group.store)
 		if err != nil {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -120,6 +120,7 @@ type demandListCountingStore struct {
 	beads.Store
 	liveInProgressLists int
 	liveOpenMolecules   int
+	livePoolDemand      int
 }
 
 func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
@@ -128,6 +129,9 @@ func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, err
 	}
 	if query.Live && query.Status == "open" && query.Type == "molecule" {
 		s.liveOpenMolecules++
+	}
+	if query.Live && query.Status == "open" && query.Metadata[poolDemandMetadataKey] == poolDemandMetadataValue {
+		s.livePoolDemand++
 	}
 	return s.Store.List(query)
 }
@@ -516,6 +520,266 @@ func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
 	}
 	if backing.liveOpenMolecules != 0 {
 		t.Fatalf("live open molecule list calls = %d, want no molecule demand query", backing.liveOpenMolecules)
+	}
+}
+
+// TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag asserts the
+// gc.pool_demand path end-to-end: cmd/gc/cmd_order.go and
+// cmd/gc/order_dispatch.go both write the pair from
+// poolDemandMetadataPair() onto the wisp when a.Pool != "", and
+// defaultScaleCheckCounts must count such beads regardless of type. The
+// molecule type itself is still excluded from Ready()/CachedReady() per
+// PR #1154 + the TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers
+// invariant above, so without the explicit metadata-list path cron pool
+// orders generate zero scale_check demand and the pool never spawns.
+// Regression for https://github.com/gastownhall/gascity/pull/2531
+// → https://github.com/gastownhall/gascity/pull/2556.
+//
+// Also asserts the Live: true cache-bypass behavior is load-bearing:
+// the demandListCountingStore's livePoolDemand counter must increment,
+// proving defaultScaleCheckCounts goes through to the backing store
+// rather than the CachingStore snapshot (which can lag for wisps
+// created by sibling subprocesses like gc order run).
+func TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:    "mol-dog-stale-db",
+		Type:     "molecule",
+		Status:   "open",
+		Metadata: poolWispMetadata("dog"),
+	}); err != nil {
+		t.Fatalf("create pool-order wisp: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "dog",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["dog"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1 (gc.pool_demand wisp must count as cron pool demand)", "dog", got)
+	}
+	if backing.livePoolDemand == 0 {
+		t.Fatalf("livePoolDemand list calls = 0, want >0 (defaultScaleCheckCounts must use Live: true to bypass the CachingStore snapshot, since cron pool orders fire from sibling subprocesses and the cache lags)")
+	}
+}
+
+// poolWispMetadata builds the metadata map a pool-order wisp carries —
+// gc.routed_to + the poolDemandMetadataPair pair — for fixture use.
+// Mirrors the production composition in cmd/gc/cmd_order.go and
+// cmd/gc/order_dispatch.go so tests drift with the production
+// contract instead of duplicating string literals.
+func poolWispMetadata(pool string) map[string]string {
+	m := map[string]string{"gc.routed_to": pool}
+	for k, v := range poolDemandMetadataPair() {
+		m[k] = v
+	}
+	return m
+}
+
+// TestDefaultScaleCheckCountsIgnoresMoleculeWithoutPoolDemand asserts that a
+// molecule carrying gc.routed_to but NO gc.pool_demand flag stays excluded
+// from the count — the workflow-container invariant from PR #1154 / the
+// existing TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers test
+// holds even after the metadata-list path is added.
+func TestDefaultScaleCheckCountsIgnoresMoleculeWithoutPoolDemand(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "graph workflow root",
+		Type:   "molecule",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-min",
+		},
+	}); err != nil {
+		t.Fatalf("create molecule: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-min",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-min"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want 0 (molecule without gc.pool_demand is a workflow container, not pool demand)", got)
+	}
+}
+
+// TestDefaultScaleCheckCountsIgnoresAssignedCronPoolDemand asserts that even
+// with gc.pool_demand="order", a bead that has already been claimed (Assignee
+// non-empty) is not double-counted alongside the worker session itself.
+// Mirrors the existing TestDefaultScaleCheckCountsExcludesBeadsAssignedToSession
+// invariant for the new metadata path.
+func TestDefaultScaleCheckCountsIgnoresAssignedCronPoolDemand(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	wisp := poolWispMetadata("dog")
+	if _, err := backing.Create(beads.Bead{
+		Title:    "mol-dog-stale-db",
+		Type:     "molecule",
+		Status:   "open",
+		Assignee: "dog-1",
+		Metadata: wisp,
+	}); err != nil {
+		t.Fatalf("create assigned pool wisp: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "dog",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["dog"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0 (assigned bead is a worker's territory, not pool demand)", "dog", got)
+	}
+}
+
+// TestDefaultScaleCheckCountsIgnoresGraphV2StepRoutedToPool pins the
+// "graph.v2 step → not counted" invariant @sjarmak enumerated in the
+// Option B design discussion on PR #2531. The trifecta defense:
+//   - readyExcludeTypes filters Type:"step" out of Ready() per PR #1154.
+//   - The metadata-list source only matches beads carrying
+//     poolDemandMetadataPair(), which only cmd_order.go and
+//     order_dispatch.go write (and only on the wisp ROOT, never on
+//     step children stamped by stampLegacyRecipeRouting).
+//   - graph.v2 steps carry gc.kind=workflow plus gc.routed_to to the
+//     pool but no gc.pool_demand, so neither source counts them.
+//
+// Guards against future regressions where (a) step gets removed from
+// readyExcludeTypes, or (b) stampLegacyRecipeRouting or its graph.v2
+// equivalent starts propagating gc.pool_demand to step children.
+func TestDefaultScaleCheckCountsIgnoresGraphV2StepRoutedToPool(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "graph.v2 step routed to dog",
+		Type:   "step",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "dog",
+			"gc.kind":      "workflow",
+		},
+	}); err != nil {
+		t.Fatalf("create graph.v2 step: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "dog",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["dog"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0 (graph.v2 step routed to a pool is not pool demand — it's workflow scaffolding handled by the parent agent)", "dog", got)
+	}
+}
+
+// TestDefaultScaleCheckCountsIgnoresNumericPoolDemand pins the value
+// choice in poolDemandMetadataValue against future drift to a
+// numeric-looking string. bd's --set-metadata write path infers JSON
+// type from string content, so a bead created with "1" (or any digit
+// string) lands in storage as a JSON integer, and the cache's
+// matchesMetadata does strict string equality — so a "1" writer paired
+// with a "1" reader silently misses every bead. Pins:
+//
+//   - Whatever sentinel we ship, a bead with the numeric "1" must NOT
+//     match the count predicate. If this test starts failing because
+//     someone changed poolDemandMetadataValue to "1", they are
+//     reintroducing the trap.
+//   - If they fixed the bd cast bug upstream and want to use "1",
+//     they should also delete this test and add a parallel one
+//     asserting "1" DOES match.
+func TestDefaultScaleCheckCountsIgnoresNumericPoolDemand(t *testing.T) {
+	if poolDemandMetadataValue == "1" {
+		t.Skip("poolDemandMetadataValue is now \"1\"; this regression guard no longer applies — see test comment")
+	}
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "wisp with numeric pool_demand",
+		Type:   "molecule",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to":        "dog",
+			poolDemandMetadataKey: "1",
+		},
+	}); err != nil {
+		t.Fatalf("create numeric-flagged wisp: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "dog",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["dog"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0 (a numeric-string pool_demand must not match the non-numeric sentinel — see cmd/gc/pool_demand.go for the rationale)", "dog", got)
+	}
+}
+
+// TestDefaultScaleCheckCountsDedupsBeadInBothSources pins the dedup
+// map at defaultScaleCheckCounts: a task-shaped routed bead that also
+// happens to carry gc.pool_demand would be visible to BOTH the Ready
+// iteration (task is not in readyExcludeTypes) and the metadata-list
+// source. Without the counted-by-ID dedup it would be counted twice.
+// Documents the defensive shape so future refactors don't drop the
+// dedup when "the two sources can't overlap" looks self-evident.
+func TestDefaultScaleCheckCountsDedupsBeadInBothSources(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:    "task with both signals",
+		Type:     "task",
+		Status:   "open",
+		Metadata: poolWispMetadata("dog"),
+	}); err != nil {
+		t.Fatalf("create dual-source bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "dog",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["dog"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1 (bead visible to BOTH Ready and gc.pool_demand list must count exactly once)", "dog", got)
 	}
 }
 

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -686,7 +686,20 @@ func doOrderRunWithJSON(aa []orders.Order, name, rig, cityPath string, store bea
 		)
 	}
 	if a.Pool != "" {
+		// poolDemandMetadataPair() returns the explicit, type-independent
+		// signal that this wisp counts as scale_check demand for the
+		// routed pool — see cmd/gc/pool_demand.go for the value-choice
+		// rationale (bd's --set-metadata write path infers JSON type
+		// from the string, so a numeric-looking value would round-trip
+		// as an integer and silently miss the supervisor's metadata
+		// equality match). Same pair is written by
+		// memoryOrderDispatcher.dispatchOne in order_dispatch.go so
+		// both the CLI (gc order run) and supervisor cron paths land
+		// matching beads.
 		update.Metadata = map[string]string{"gc.routed_to": pool}
+		for k, v := range poolDemandMetadataPair() {
+			update.Metadata[k] = v
+		}
 	}
 	if err := store.Update(rootID, update); err != nil {
 		fmt.Fprintf(stderr, "gc order run: labeling wisp: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1242,8 +1242,41 @@ func TestOrderRunResolvesPackBindingForPool(t *testing.T) {
 	if got := results[0].Metadata["gc.routed_to"]; got != "maintenance.dog" {
 		t.Fatalf("gc.routed_to = %q, want maintenance.dog", got)
 	}
+	if got := results[0].Metadata[poolDemandMetadataKey]; got != poolDemandMetadataValue {
+		t.Fatalf("%s = %q, want %q (cron pool orders need this flag so defaultScaleCheckCounts can count the molecule wisp despite readyExcludeTypes filtering molecules out of Ready() — see cmd/gc/pool_demand.go for the non-numeric-value rationale)", poolDemandMetadataKey, got, poolDemandMetadataValue)
+	}
 	if !strings.Contains(stdout.String(), "gc.routed_to=maintenance.dog") {
 		t.Fatalf("stdout = %q, want binding-qualified route", stdout.String())
+	}
+}
+
+// TestOrderRunNonPoolDoesNotSetPoolDemand asserts the symmetric: orders
+// without a pool field do NOT get gc.pool_demand stamped. The flag is
+// strictly a cron-pool-order signal.
+func TestOrderRunNonPoolDoesNotSetPoolDemand(t *testing.T) {
+	aa := []orders.Order{
+		{Name: "cleanup", Formula: "mol-cleanup", Trigger: "cron", Schedule: "0 3 * * *", FormulaLayer: sharedTestFormulaDir},
+	}
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "cleanup", "", "/city", store, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRun = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	results, err := store.ListByLabel("order-run:cleanup", 0)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
+	}
+	if got := results[0].Metadata[poolDemandMetadataKey]; got != "" {
+		t.Fatalf("%s = %q, want empty (only pool orders should carry the flag)", poolDemandMetadataKey, got)
+	}
+	if got := results[0].Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("gc.routed_to = %q, want empty for unrouted order", got)
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1016,7 +1016,18 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		)
 	}
 	if a.Pool != "" {
+		// Same metadata-pair the CLI path (cmd_order.go:doOrderRunWithJSON)
+		// writes — gc.routed_to so the worker's Tier-3 work_query and bd
+		// CLI tooling see the routing, plus poolDemandMetadataPair() so
+		// the supervisor's defaultScaleCheckCounts can count the wisp as
+		// scale_check demand. Without the second pair, supervisor-cron
+		// dispatched orders silently never spawn a pool worker because
+		// the molecule wisp is filtered out of Ready() by
+		// readyExcludeTypes (per PR #1154). See cmd/gc/pool_demand.go.
 		update.Metadata = map[string]string{"gc.routed_to": pool}
+		for k, v := range poolDemandMetadataPair() {
+			update.Metadata[k] = v
+		}
 	}
 	if err := store.Update(rootID, update); err != nil {
 		// Label failure is critical for duplicate-dispatch prevention.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -379,6 +379,9 @@ func TestOrderDispatchResolvesPackBindingForPool(t *testing.T) {
 	if got := work.Metadata["gc.routed_to"]; got != "maintenance.dog" {
 		t.Errorf("gc.routed_to = %q, want %q (pack binding must qualify pool target)", got, "maintenance.dog")
 	}
+	if got := work.Metadata[poolDemandMetadataKey]; got != poolDemandMetadataValue {
+		t.Errorf("%s = %q, want %q (supervisor-cron-dispatched pool orders must carry the demand sentinel so defaultScaleCheckCounts can count the wisp despite readyExcludeTypes filtering molecules out of Ready() — see cmd/gc/pool_demand.go)", poolDemandMetadataKey, got, poolDemandMetadataValue)
+	}
 }
 
 func TestOrderDispatchPrefersCityShadowForPool(t *testing.T) {

--- a/cmd/gc/pool_demand.go
+++ b/cmd/gc/pool_demand.go
@@ -1,0 +1,52 @@
+// Copyright (c) Gas City contributors. SPDX-License-Identifier: Apache-2.0
+
+package main
+
+// poolDemandMetadataKey is the bead-metadata flag set on a pooled order
+// wisp at creation time and read by the supervisor's default scale_check
+// path. It exists because PR #1154 added "molecule" and "step" to
+// readyExcludeTypes for queue hygiene (workflow containers and formula
+// scaffolding stay out of bd ready), leaving the supervisor's
+// defaultScaleCheckCounts with no Ready surface for cron-fired pool
+// orders. Rather than relax the type filter, the order-side writer
+// stamps this key on the wisp and the supervisor takes a second
+// metadata-filtered list as a separate demand source.
+//
+// Writers: doOrderRunWithJSON (cmd_order.go) and
+// memoryOrderDispatcher.dispatchOne (order_dispatch.go).
+// Reader: defaultScaleCheckCounts (build_desired_state.go).
+const poolDemandMetadataKey = "gc.pool_demand"
+
+// poolDemandMetadataValue is the literal value the writers stamp and the
+// reader's ListQuery.Metadata equality match looks up.
+//
+// The value is a stable non-numeric sentinel, not "1", because bd's
+// --set-metadata write path infers JSON type from the string — a
+// numeric-looking value like "1" lands in the SQL metadata column as
+// the JSON integer 1, and the cache's matchesMetadata (caching_store_reads.go)
+// does strict string equality, so a "1" writer paired with a "1" reader
+// silently misses every bead. Verified empirically when the first
+// iteration of this fix shipped with "1": post-build dolt rows showed
+// gc.pool_demand stored as INTEGER and scale_check_counts stayed at 0.
+//
+// Any future change to this value must (a) stay non-numeric to keep the
+// bd round-trip lossless and (b) update poolDemandMetadataPair()'s
+// returned map so writers and the equality-match reader stay in sync.
+const poolDemandMetadataValue = "order"
+
+// poolDemandMetadataPair returns the metadata map a pool-order writer
+// must merge into its UpdateOpts.Metadata alongside the existing
+// gc.routed_to write. Writers compose with the routing key:
+//
+//	if a.Pool != "" {
+//	    update.Metadata = map[string]string{"gc.routed_to": pool}
+//	    for k, v := range poolDemandMetadataPair() {
+//	        update.Metadata[k] = v
+//	    }
+//	}
+//
+// The helper exists so adding a second flag in the future (e.g., a
+// per-trigger discriminator) does not require auditing every writer.
+func poolDemandMetadataPair() map[string]string {
+	return map[string]string{poolDemandMetadataKey: poolDemandMetadataValue}
+}

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -59,6 +59,16 @@ passed since the last run, it instantiates the `pancakes` formula as a wisp and
 routes it to the `worker` pool. The order name comes from the file basename
 (`pancakes-check.toml` → `pancakes-check`), not from anything in the TOML.
 
+When the dispatcher stamps the wisp for a pool target it writes two metadata
+keys: `gc.routed_to=<pool>` so the worker's `bd ready` query finds it via the
+shared routed queue, and `gc.pool_demand=order` so the supervisor's default
+`scale_check` counts the wisp as pool demand even though the wisp itself is a
+`molecule` (which `bd ready` filters out as a workflow container). Both keys
+come from the same dispatcher write and you don't need to set them by hand;
+wisps that pre-date this dispatcher version won't carry the second key and
+won't generate demand from the in-process default `scale_check` until they
+close or are re-created.
+
 Orders are discovered when the city starts and whenever the controller reloads
 config. You don't need to restart anything if the city is already watching the
 orders directory.


### PR DESCRIPTION
## Summary

Resubmission of #2531 implementing the **Option B** design @sjarmak picked in https://github.com/gastownhall/gascity/pull/2531#issuecomment-4526797234 — explicit `gc.pool_demand` metadata signal rather than relaxing the type filter. Closes #2531 (architecturally) with the agreed shape.

Cron-fired pool orders (`gc order run` with `pool = "<name>"`) create a `molecule` wisp via `molecule.Instantiate`. #1154 intentionally added `molecule` and `step` to `readyExcludeTypes` (and coerced legacy formula steps to `type=step`) so workflow containers and scaffolding stay out of `bd ready` / `Store.Ready` output — that's the right semantics for graph.v2 and legacy formula step beads alike. But it leaves cron pool orders with no surface for `scale_check` demand: the wisp is a molecule that's filtered out by `readyExcludeTypes`, and the steps are also filtered. `defaultScaleCheckCounts` iterates `Ready()`, so it sees zero pool demand and the pool never spawns even when work is queued.

The shell `scale_check` path (when an agent has explicit `scale_check`) already worked because it shells out to `bd ready` via the bd binary, which doesn't apply gascity's `IsReadyExcludedType`. Only the in-process default path was affected.

## Approach (Option B)

Add an explicit, type-independent demand signal rather than relax the type filter. From the PR #2531 thread:

> **@sjarmak**: Let's go with Option B: explicit `gc.pool_demand` metadata signal from `cmd_order.go` when `a.Pool != ""`, and teach `defaultScaleCheckCounts` to count beads carrying that flag regardless of `readyExcludeTypes`. The reasoning is exactly your "smallest reviewer surface" framing — it leaves `Ready()` / `CachedReady()` semantics untouched, preserves #1154's intent (legacy formula steps stay out of `bd ready`), and avoids any risk of accidentally re-surfacing graph.v2 step beads or sling-routed-to-named-agent formula steps.

The PR matches the shape requested:

- `cmd/gc/cmd_order.go` writes `gc.pool_demand="order"` alongside `gc.routed_to="<pool>"` on the wisp when `a.Pool != ""`
- `cmd/gc/build_desired_state.go::defaultScaleCheckCounts` gains a second demand source: a metadata-filtered `List(Status=open, Metadata={gc.pool_demand: order}, Live=true)` that applies the same unassigned + matching-`routed_to` + dedup checks as the existing `Ready`-iteration source
- No change to `Ready()` / `CachedReady()` / `IsReadyExcludedType`
- Beads carried by both sources (rare — only a task-shaped routed bead that also happens to carry the flag) are deduped on bead ID

`Live: true` is set on the demand `List` because pool orders fire from sibling subprocesses (`gc order run`), and the CachingStore's in-memory snapshot can lag external writes by an unbounded number of reconcile ticks. Same gating shape the existing `collectAssignedWorkBeadsWithStores` path uses for assigned-work freshness.

## One subtle detail worth a heads-up

The flag value is the literal string `"order"`, not `"1"`. Verified empirically: storing `"1"` via `bd update --set-metadata gc.pool_demand=1` lands as JSON `INTEGER` 1 in the SQL metadata column (smart-cast somewhere in the bd write path), and the supervisor's `matchesMetadata` does plain string equality so the integer-vs-string mismatch silently breaks the count. Non-numeric value sidesteps the cast. Comment in `cmd_order.go` calls this out so future tweaks don't reintroduce the trap.

## Test plan

`cmd/gc/build_desired_state_test.go`:
- `TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag` — molecule with `gc.pool_demand="order"` + `gc.routed_to=dog` counts as `1`
- `TestDefaultScaleCheckCountsIgnoresMoleculeWithoutPoolDemand` — molecule with `gc.routed_to` but no `gc.pool_demand` stays at `0` (preserves the existing `TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers` invariant)
- `TestDefaultScaleCheckCountsIgnoresAssignedCronPoolDemand` — claimed pool wisp does not double-count alongside the worker session (mirrors the existing `TestDefaultScaleCheckCountsExcludesBeadsAssignedToSession` invariant for the new metadata path)

`cmd/gc/cmd_order_test.go`:
- `TestOrderRunResolvesPackBindingForPool` extended to assert `gc.pool_demand="order"` on the wisp
- `TestOrderRunNonPoolDoesNotSetPoolDemand` — orders without a pool field do NOT carry the flag

Full `./cmd/gc/...` + `./internal/beads/...` + `./internal/sling/...` + `./internal/molecule/...` + `./internal/graphroute/...` suites green. All existing `TestDefaultScaleCheck*` tests still pass — including `TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers` (the workflow-container invariant) and `TestDefaultScaleCheckCountsExcludesBeadsAssignedToSession` (the assigned-bead invariant).

## Verified live on a city with the stock dog pool agent

`.gc/system/packs/maintenance/agents/dog/agent.toml` — no explicit `scale_check`, `fallback=true`, `min=0 max=3`:

```
$ gc order run mol-dog-stale-db
Order "mol-dog-stale-db" executed: wisp pc-vnvhcme → gc.routed_to=dog

# pre-fix:  scale_check_counts["dog"] = 0 forever; pool stays at 0
# post-fix:
#   poll 1 (2026-05-24T10:30:48): dog=1   ← within 8 seconds of trigger
#   supervisor materialized dog-1 ephemeral session
#   dog claimed the step via Tier-3 work_query
#   ran the cleanup shell script
#   closed the step + parent molecule via the children-done cascade
#   ("Close reason: all steps complete")
#   dog drained and recycled the pool slot
# All without operator intervention. Verified across multiple consecutive
# triggers — pc-begypfa, pc-ama3095, pc-ym73tua, pc-bv1qtae each ran the
# full lifecycle cleanly.
```

## History

- #2529 (closed) — first attempt set `Assignee=<pool>` at order creation time. @julianknutsen flagged: "orders to ephemeral pools (routed_to) and instantiated sessions (assignee) are different", confirmed correct: setting `Assignee` at order time breaks `scale_check` (`--unassigned` filter) and the worker's Tier-3 claim.
- #2531 (replaced by this PR) — second attempt carved out routed-step beads from `readyExcludeTypes`. @julianknutsen flagged the conflict with #1154 and pinged @sjarmak (author of #1154) for design input. @sjarmak picked Option B from the design-tension comment as the smallest-reviewer-surface option that preserves #1154's intent. This PR is that option, implemented.