### PR TITLE
fix(ralph): inject GC_MOLECULE_DIR and GC_ARTIFACT_DIR into check subprocess env (closes #2522)

### DIFF
--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -63,7 +63,7 @@ type ConditionEnv struct {
 	WispID               string
 	DocPath              string // from var.doc_path, may be empty
 	MoleculeDir          string // molecule.Dir(CityPath, rootID); may be empty for non-molecule beads
-	ArtifactDir          string
+	ArtifactDir          string // per-step artifact dir; GC_ARTIFACT_DIR is omitted when empty (matches the sling-time contract)
 	IterationDurationMs  int64
 	CumulativeDurationMs int64
 	MaxIterations        int
@@ -95,7 +95,6 @@ func (ce ConditionEnv) Environ() []string {
 		"GC_BEAD_ID=" + ce.BeadID,
 		"GC_ITERATION=" + strconv.Itoa(ce.Iteration),
 		"GC_WISP_ID=" + ce.WispID,
-		"GC_ARTIFACT_DIR=" + ce.ArtifactDir,
 		"GC_ITERATION_DURATION_MS=" + strconv.FormatInt(ce.IterationDurationMs, 10),
 		"GC_CUMULATIVE_DURATION_MS=" + strconv.FormatInt(ce.CumulativeDurationMs, 10),
 		"GC_MAX_ITERATIONS=" + strconv.Itoa(ce.MaxIterations),
@@ -120,6 +119,9 @@ func (ce ConditionEnv) Environ() []string {
 	}
 	if ce.StorePath != "" {
 		env = append(env, "GC_STORE_PATH="+ce.StorePath)
+	}
+	if ce.ArtifactDir != "" {
+		env = append(env, "GC_ARTIFACT_DIR="+ce.ArtifactDir)
 	}
 	if ce.MoleculeDir != "" {
 		env = append(env, "GC_MOLECULE_DIR="+ce.MoleculeDir)

--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -62,6 +62,7 @@ type ConditionEnv struct {
 	WorkDir              string
 	WispID               string
 	DocPath              string // from var.doc_path, may be empty
+	MoleculeDir          string // molecule.Dir(CityPath, rootID); may be empty for non-molecule beads
 	ArtifactDir          string
 	IterationDurationMs  int64
 	CumulativeDurationMs int64
@@ -119,6 +120,9 @@ func (ce ConditionEnv) Environ() []string {
 	}
 	if ce.StorePath != "" {
 		env = append(env, "GC_STORE_PATH="+ce.StorePath)
+	}
+	if ce.MoleculeDir != "" {
+		env = append(env, "GC_MOLECULE_DIR="+ce.MoleculeDir)
 	}
 	if realBD := os.Getenv("GC_INTEGRATION_REAL_BD"); realBD != "" {
 		env = append(env, "GC_INTEGRATION_REAL_BD="+realBD)

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -81,12 +81,11 @@ func TestConditionEnvEnviron(t *testing.T) {
 
 func TestConditionEnvEnvironOptionalEmpty(t *testing.T) {
 	env := ConditionEnv{
-		BeadID:      "bead-789",
-		Iteration:   1,
-		CityPath:    "/city",
-		WispID:      "wisp-abc",
-		ArtifactDir: "/tmp/art",
-		// DocPath, AgentVerdict, AgentProvider, AgentModel all empty.
+		BeadID:    "bead-789",
+		Iteration: 1,
+		CityPath:  "/city",
+		WispID:    "wisp-abc",
+		// ArtifactDir, DocPath, AgentVerdict, AgentProvider, AgentModel all empty.
 	}
 
 	vars := env.Environ()
@@ -98,8 +97,10 @@ func TestConditionEnvEnvironOptionalEmpty(t *testing.T) {
 		}
 	}
 
-	// Optional vars should be absent when empty.
-	for _, key := range []string{"GC_DOC_PATH", "GC_AGENT_VERDICT", "GC_AGENT_PROVIDER", "GC_AGENT_MODEL", "GC_MOLECULE_DIR"} {
+	// Optional vars should be absent when empty. GC_ARTIFACT_DIR is omitted
+	// when ArtifactDir is empty, matching GC_MOLECULE_DIR and the sling-time
+	// contract (a non-molecule bead gets neither var).
+	for _, key := range []string{"GC_DOC_PATH", "GC_AGENT_VERDICT", "GC_AGENT_PROVIDER", "GC_AGENT_MODEL", "GC_MOLECULE_DIR", "GC_ARTIFACT_DIR"} {
 		if _, ok := lookup[key]; ok {
 			t.Errorf("expected %s to be absent for empty value, but it was present", key)
 		}

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -19,6 +19,7 @@ func TestConditionEnvEnviron(t *testing.T) {
 		CityPath:             "/home/test/city",
 		WispID:               "wisp-456",
 		DocPath:              "/docs/review.md",
+		MoleculeDir:          "/home/test/city/.gc/molecules/root-xyz",
 		ArtifactDir:          "/tmp/artifacts",
 		IterationDurationMs:  1500,
 		CumulativeDurationMs: 4500,
@@ -48,6 +49,7 @@ func TestConditionEnvEnviron(t *testing.T) {
 		"GC_CITY_RUNTIME_DIR":       "/home/test/city/.gc/runtime",
 		"GC_WISP_ID":                "wisp-456",
 		"GC_DOC_PATH":               "/docs/review.md",
+		"GC_MOLECULE_DIR":           "/home/test/city/.gc/molecules/root-xyz",
 		"GC_ARTIFACT_DIR":           "/tmp/artifacts",
 		"GC_ITERATION_DURATION_MS":  "1500",
 		"GC_CUMULATIVE_DURATION_MS": "4500",
@@ -97,7 +99,7 @@ func TestConditionEnvEnvironOptionalEmpty(t *testing.T) {
 	}
 
 	// Optional vars should be absent when empty.
-	for _, key := range []string{"GC_DOC_PATH", "GC_AGENT_VERDICT", "GC_AGENT_PROVIDER", "GC_AGENT_MODEL"} {
+	for _, key := range []string{"GC_DOC_PATH", "GC_AGENT_VERDICT", "GC_AGENT_PROVIDER", "GC_AGENT_MODEL", "GC_MOLECULE_DIR"} {
 		if _, ok := lookup[key]; ok {
 			t.Errorf("expected %s to be absent for empty value, but it was present", key)
 		}

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -230,17 +230,22 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	}
 
 	conditionBeadID := subject.ID
+	pathBead := subject
 	if conditionBeadID == "" {
 		conditionBeadID = bead.ID
+		pathBead = bead
 	}
 	// gastownhall/gascity#2522: ralph.check scripts read $GC_MOLECULE_DIR and
 	// $GC_ARTIFACT_DIR to access the molecule-scoped working storage where
-	// the per-attempt agent wrote its verdict. Resolve both from the bead's
-	// gc.root_bead_id metadata that molecule.Instantiate stamps onto every
-	// member. Best-effort: when the bead is not a molecule member (no root
-	// stamped) both stay empty and the env vars are omitted, matching the
-	// sling-time GC_ARTIFACT_DIR contract that pack scripts already handle.
-	moleculeDir, artifactDir := resolveRalphCheckMoleculePaths(bead, cityPath)
+	// the per-attempt agent wrote its verdict. Resolve both from the same
+	// bead we expose as GC_BEAD_ID (the subject/attempt, falling back to the
+	// control bead) so the per-step artifact dir matches where that agent
+	// wrote — using the bead's gc.root_bead_id metadata that
+	// molecule.Instantiate stamps onto every member. Best-effort: when the
+	// bead is not a molecule member (no root stamped) both stay empty and
+	// the env vars are omitted, matching the sling-time GC_ARTIFACT_DIR
+	// contract that pack scripts already handle.
+	moleculeDir, artifactDir := resolveRalphCheckMoleculePaths(pathBead, cityPath)
 	result := convergence.RunCondition(context.Background(), scriptPath, convergence.ConditionEnv{
 		BeadID:      conditionBeadID,
 		Iteration:   attempt,
@@ -254,12 +259,12 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 }
 
 // resolveRalphCheckMoleculePaths derives the molecule root directory and the
-// per-step artifact directory for a ralph parent bead. Both paths are
-// derived from the bead's gc.root_bead_id metadata (stamped by
-// molecule.Instantiate on every formula-scaffolded member). Returns empty
-// strings when the bead is not a molecule member or when the artifact dir
-// cannot be created; the caller treats empty as "omit the env var", which
-// matches the sling-time GC_ARTIFACT_DIR contract.
+// per-step artifact directory for a ralph bead. Both paths are derived from
+// the bead's gc.root_bead_id metadata (stamped by molecule.Instantiate on
+// every formula-scaffolded member). Returns empty strings when the bead is
+// not a molecule member, when gc.root_bead_id is path-unsafe, or when the
+// artifact dir cannot be created; the caller treats empty as "omit the env
+// var", which matches the sling-time GC_ARTIFACT_DIR contract.
 func resolveRalphCheckMoleculePaths(bead beads.Bead, cityPath string) (string, string) {
 	if strings.TrimSpace(cityPath) == "" {
 		return "", ""
@@ -268,12 +273,20 @@ func resolveRalphCheckMoleculePaths(bead beads.Bead, cityPath string) (string, s
 	if rootID == "" {
 		return "", ""
 	}
+	// Reject a path-traversing/unsafe gc.root_bead_id before joining it so
+	// an unsafe root cannot surface a path-escaping GC_MOLECULE_DIR. This
+	// mirrors the rejection molecule.EnsureArtifactDir applies to rootID and
+	// keeps the omit-on-unsafe contract used by the sling env path.
+	if molecule.ValidateMemberID(rootID) != nil {
+		return "", ""
+	}
 	moleculeDir := molecule.Dir(cityPath, rootID)
 	artifactDir, err := molecule.EnsureArtifactDir(fsys.OSFS{}, cityPath, rootID, bead.ID)
 	if err != nil {
-		// Surface the molecule root even if EnsureArtifactDir failed —
-		// check scripts that only need GC_MOLECULE_DIR (not the per-step
-		// dir) still work, and the artifact-dir omission mirrors the
+		// rootID is already validated, so EnsureArtifactDir failed either
+		// on the per-step bead ID or on mkdir (e.g. permissions). Surface
+		// the (safe) molecule root so check scripts that only need
+		// GC_MOLECULE_DIR still work; the artifact-dir omission mirrors the
 		// sling-time best-effort contract.
 		return moleculeDir, ""
 	}

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/pathutil"
 )
@@ -232,14 +233,51 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	if conditionBeadID == "" {
 		conditionBeadID = bead.ID
 	}
+	// gastownhall/gascity#2522: ralph.check scripts read $GC_MOLECULE_DIR and
+	// $GC_ARTIFACT_DIR to access the molecule-scoped working storage where
+	// the per-attempt agent wrote its verdict. Resolve both from the bead's
+	// gc.root_bead_id metadata that molecule.Instantiate stamps onto every
+	// member. Best-effort: when the bead is not a molecule member (no root
+	// stamped) both stay empty and the env vars are omitted, matching the
+	// sling-time GC_ARTIFACT_DIR contract that pack scripts already handle.
+	moleculeDir, artifactDir := resolveRalphCheckMoleculePaths(bead, cityPath)
 	result := convergence.RunCondition(context.Background(), scriptPath, convergence.ConditionEnv{
-		BeadID:    conditionBeadID,
-		Iteration: attempt,
-		CityPath:  cityPath,
-		StorePath: storePath,
-		WorkDir:   resolvedWorkDir,
+		BeadID:      conditionBeadID,
+		Iteration:   attempt,
+		CityPath:    cityPath,
+		StorePath:   storePath,
+		WorkDir:     resolvedWorkDir,
+		MoleculeDir: moleculeDir,
+		ArtifactDir: artifactDir,
 	}, timeout, 0)
 	return result, nil
+}
+
+// resolveRalphCheckMoleculePaths derives the molecule root directory and the
+// per-step artifact directory for a ralph parent bead. Both paths are
+// derived from the bead's gc.root_bead_id metadata (stamped by
+// molecule.Instantiate on every formula-scaffolded member). Returns empty
+// strings when the bead is not a molecule member or when the artifact dir
+// cannot be created; the caller treats empty as "omit the env var", which
+// matches the sling-time GC_ARTIFACT_DIR contract.
+func resolveRalphCheckMoleculePaths(bead beads.Bead, cityPath string) (string, string) {
+	if strings.TrimSpace(cityPath) == "" {
+		return "", ""
+	}
+	rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
+	if rootID == "" {
+		return "", ""
+	}
+	moleculeDir := molecule.Dir(cityPath, rootID)
+	artifactDir, err := molecule.EnsureArtifactDir(fsys.OSFS{}, cityPath, rootID, bead.ID)
+	if err != nil {
+		// Surface the molecule root even if EnsureArtifactDir failed —
+		// check scripts that only need GC_MOLECULE_DIR (not the per-step
+		// dir) still work, and the artifact-dir omission mirrors the
+		// sling-time best-effort contract.
+		return moleculeDir, ""
+	}
+	return moleculeDir, artifactDir
 }
 
 func parsePositiveRalphTimeout(beadID, key, raw string) (time.Duration, error) {

--- a/internal/dispatch/ralph_test.go
+++ b/internal/dispatch/ralph_test.go
@@ -1,11 +1,13 @@
 package dispatch
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/convergence"
 )
 
 func TestFormatGateExitCode(t *testing.T) {
@@ -125,5 +127,78 @@ func TestResolveRalphCheckMoleculePaths_EmptyCityPath(t *testing.T) {
 	// could produce).
 	if strings.Contains(moleculeDir, ".gc") || strings.Contains(artifactDir, ".gc") {
 		t.Fatalf("empty cityPath should not surface .gc-rooted relative path; got moleculeDir=%q artifactDir=%q", moleculeDir, artifactDir)
+	}
+}
+
+// TestResolveRalphCheckMoleculePaths_UnsafeRootID pins the fail-closed guard
+// against a path-traversing gc.root_bead_id: when the root ID is unsafe,
+// EnsureArtifactDir rejects it, and the resolver must NOT surface a
+// path-escaping GC_MOLECULE_DIR — both paths come back empty so the caller
+// omits the env vars entirely.
+func TestResolveRalphCheckMoleculePaths_UnsafeRootID(t *testing.T) {
+	cityPath := t.TempDir()
+	for _, rootID := range []string{"../escape", "/abs/root", "..", `a\b`} {
+		bead := beads.Bead{
+			ID:       "gc-ralph-parent",
+			Metadata: map[string]string{"gc.root_bead_id": rootID},
+		}
+		moleculeDir, artifactDir := resolveRalphCheckMoleculePaths(bead, cityPath)
+		if moleculeDir != "" || artifactDir != "" {
+			t.Fatalf("unsafe rootID %q got moleculeDir=%q artifactDir=%q; want both empty", rootID, moleculeDir, artifactDir)
+		}
+	}
+}
+
+// TestRunRalphCheckEnvTracksSubject pins gastownhall/gascity#2558 review
+// feedback: GC_BEAD_ID and the molecule/artifact dirs must describe the SAME
+// bead. The per-attempt agent runs on the subject (attempt) bead and writes
+// its verdict under that bead's artifact dir, so the check script's
+// GC_ARTIFACT_DIR must key off the subject — not the control bead.
+func TestRunRalphCheckEnvTracksSubject(t *testing.T) {
+	cityPath := t.TempDir()
+	script := filepath.Join(cityPath, "check.sh")
+	// Echo the env the check subprocess actually receives so the test can
+	// assert which bead the molecule/artifact dirs were derived from.
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho \"GC_BEAD_ID=$GC_BEAD_ID\"\necho \"GC_ARTIFACT_DIR=$GC_ARTIFACT_DIR\"\necho \"GC_MOLECULE_DIR=$GC_MOLECULE_DIR\"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewMemStore()
+	root := mustCreate(t, store, beads.Bead{Title: "workflow", Metadata: map[string]string{"gc.kind": "workflow"}})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.check_path":   "check.sh",
+			"gc.max_attempts": "3",
+		},
+	})
+	subject := mustCreate(t, store, beads.Bead{
+		Title:    "review loop iteration 1",
+		Metadata: map[string]string{"gc.kind": "scope", "gc.root_bead_id": root.ID},
+	})
+	if subject.ID == control.ID {
+		t.Fatalf("test setup: subject and control share ID %q", subject.ID)
+	}
+
+	result, err := runRalphCheck(store, control, subject, 1, ProcessOptions{CityPath: cityPath})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("Outcome = %q (stderr=%q), want pass", result.Outcome, result.Stderr)
+	}
+
+	wantBeadID := "GC_BEAD_ID=" + subject.ID
+	if !strings.Contains(result.Stdout, wantBeadID) {
+		t.Errorf("stdout missing %q; got %q", wantBeadID, result.Stdout)
+	}
+	wantArtifact := "GC_ARTIFACT_DIR=" + filepath.Join(cityPath, ".gc", "molecules", root.ID, "artifacts", subject.ID)
+	if !strings.Contains(result.Stdout, wantArtifact) {
+		t.Errorf("artifact dir not keyed by subject; want line %q; got %q", wantArtifact, result.Stdout)
+	}
+	if strings.Contains(result.Stdout, "artifacts/"+control.ID) {
+		t.Errorf("artifact dir wrongly keyed by control bead %q; got %q", control.ID, result.Stdout)
 	}
 }

--- a/internal/dispatch/ralph_test.go
+++ b/internal/dispatch/ralph_test.go
@@ -1,6 +1,12 @@
 package dispatch
 
-import "testing"
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
 
 func TestFormatGateExitCode(t *testing.T) {
 	t.Parallel()
@@ -50,5 +56,74 @@ func TestTraceClipString(t *testing.T) {
 				t.Fatalf("traceClipString(%q, %d) = %q, want %q", tt.input, tt.limit, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestResolveRalphCheckMoleculePaths_MoleculeMember pins the
+// gastownhall/gascity#2522 fix: a ralph parent bead carrying
+// gc.root_bead_id metadata (stamped by molecule.Instantiate) must
+// resolve both the molecule root directory and a per-bead artifact
+// directory, so the ralph engine can inject GC_MOLECULE_DIR and
+// GC_ARTIFACT_DIR into the check script's environment. Before the fix
+// both env vars were absent and `set -eu` check scripts referencing
+// them crashed with "unbound variable" on every attempt.
+func TestResolveRalphCheckMoleculePaths_MoleculeMember(t *testing.T) {
+	cityPath := t.TempDir()
+	const rootID = "gc-mol-root"
+	const beadID = "gc-ralph-parent"
+
+	bead := beads.Bead{
+		ID: beadID,
+		Metadata: map[string]string{
+			"gc.root_bead_id": rootID,
+		},
+	}
+
+	moleculeDir, artifactDir := resolveRalphCheckMoleculePaths(bead, cityPath)
+
+	wantMolDir := filepath.Join(cityPath, ".gc", "molecules", rootID)
+	if moleculeDir != wantMolDir {
+		t.Fatalf("moleculeDir = %q, want %q", moleculeDir, wantMolDir)
+	}
+	wantArtDir := filepath.Join(wantMolDir, "artifacts", beadID)
+	if artifactDir != wantArtDir {
+		t.Fatalf("artifactDir = %q, want %q", artifactDir, wantArtDir)
+	}
+}
+
+// TestResolveRalphCheckMoleculePaths_NonMolecule pins the no-side-effect
+// guard: a bead without gc.root_bead_id (not a molecule member) returns
+// empty strings for both paths, and the caller treats empty as "omit the
+// env var" so non-molecule ralph checks keep their pre-#2522 behavior.
+func TestResolveRalphCheckMoleculePaths_NonMolecule(t *testing.T) {
+	cityPath := t.TempDir()
+	bead := beads.Bead{ID: "gc-loose-bead"}
+
+	moleculeDir, artifactDir := resolveRalphCheckMoleculePaths(bead, cityPath)
+
+	if moleculeDir != "" || artifactDir != "" {
+		t.Fatalf("non-molecule bead got moleculeDir=%q artifactDir=%q; want both empty", moleculeDir, artifactDir)
+	}
+}
+
+// TestResolveRalphCheckMoleculePaths_EmptyCityPath guards against
+// resolving paths against the caller's cwd when the city path is
+// missing (mirrors the empty-cityPath rejection in molecule.RemoveDir).
+func TestResolveRalphCheckMoleculePaths_EmptyCityPath(t *testing.T) {
+	bead := beads.Bead{
+		ID:       "gc-ralph-parent",
+		Metadata: map[string]string{"gc.root_bead_id": "gc-mol-root"},
+	}
+
+	moleculeDir, artifactDir := resolveRalphCheckMoleculePaths(bead, "")
+
+	if moleculeDir != "" || artifactDir != "" {
+		t.Fatalf("empty cityPath got moleculeDir=%q artifactDir=%q; want both empty", moleculeDir, artifactDir)
+	}
+	// Tiny sanity check that we did not accidentally return relative
+	// strings either (which a future regression to filepath.Join("",..)
+	// could produce).
+	if strings.Contains(moleculeDir, ".gc") || strings.Contains(artifactDir, ".gc") {
+		t.Fatalf("empty cityPath should not surface .gc-rooted relative path; got moleculeDir=%q artifactDir=%q", moleculeDir, artifactDir)
 	}
 }

--- a/internal/molecule/artifact.go
+++ b/internal/molecule/artifact.go
@@ -92,6 +92,15 @@ func RemoveDir(cityPath, rootID string) error {
 	return nil
 }
 
+// ValidateMemberID rejects empty or path-unsafe molecule member IDs (root
+// bead IDs, step bead IDs) using the same rules EnsureArtifactDir applies.
+// Callers that compute molecule paths from untrusted metadata should
+// validate before joining so a malformed ID cannot escape the molecules
+// root or surface a path-traversing directory.
+func ValidateMemberID(id string) error {
+	return validateIDSegment("molecule member ID", id)
+}
+
 // validateIDSegment rejects empty or path-unsafe ID segments. A valid ID
 // must be non-empty, not contain path separators, not be an absolute
 // path, and not be the literal ".." (parent directory reference).


### PR DESCRIPTION
Thanks to @rileywhite for the precise root-cause analysis in #2522 — the fix landed exactly where the issue body predicted ("the ralph engine's check-invocation path, where it builds the subprocess environment before exec'ing the check script").

## Summary

The ralph engine's check-invocation path (`internal/dispatch/ralph.go:runRalphCheck`) built the `ConditionEnv` with only `BeadID`, `Iteration`, `CityPath`, `StorePath`, and `WorkDir` set. The existing `GC_ARTIFACT_DIR` support in `convergence.ConditionEnv` was unused because `ArtifactDir` stayed empty here, and `GC_MOLECULE_DIR` did not exist at all.

A `ralph.check` script using `set -eu` and referencing `$GC_MOLECULE_DIR` died on first reference with "unbound variable", burning every attempt up to `max_attempts` on the same crash — and the formula then advanced as if the gate passed, silently masking the fact that the check never ran.

## Two-part fix

- **`internal/convergence/condition.go`** — gains a `MoleculeDir` field on `ConditionEnv`. `Environ()` emits `GC_MOLECULE_DIR` when it is set (omitted when empty, matching the existing optional-field pattern alongside `GC_DOC_PATH`, `GC_WORK_DIR`, etc.).
- **`internal/dispatch/ralph.go`** — new `resolveRalphCheckMoleculePaths` helper derives both molecule root dir and per-bead artifact dir from the bead's `gc.root_bead_id` metadata (stamped by `molecule.Instantiate` on every formula-scaffolded member). `runRalphCheck` threads `MoleculeDir` + `ArtifactDir` into the `ConditionEnv`. Best-effort: a non-molecule bead yields both empty → both env vars omitted, preserving pre-#2522 behavior. `EnsureArtifactDir` failure surfaces the molecule root only (check scripts that need just `GC_MOLECULE_DIR` still work).

Consistent with the `sling.ResolveSlingEnvForBead` env contract referenced in the issue body.

## Tests

- `TestConditionEnvEnviron` extended to exercise the `MoleculeDir` → `GC_MOLECULE_DIR` path.
- `TestConditionEnvEnvironOptionalEmpty` asserts `GC_MOLECULE_DIR` is absent when `MoleculeDir` is empty.
- **New** `TestResolveRalphCheckMoleculePaths_MoleculeMember` / `_NonMolecule` / `_EmptyCityPath` pin the three branches of the new helper.

## Acceptance criteria from the issue body

- [x] Runtime injects `GC_MOLECULE_DIR` equivalent to `molecule.Dir(cityPath, rootID)`
- [x] Runtime injects `GC_ARTIFACT_DIR` (per-step artifact path)
- [x] Check script's subprocess env carries both
- [x] Consistent with `sling.ResolveSlingEnvForBead` env contract
- [ ] End-to-end live-formula run not exercised in unit tests (would belong under `test/` with build tags as a follow-up)

## Context

Adjacent issues #2248 (re-resolve sling env at claim time) and #2249 (inject `GC_MOLECULE_DIR` at sling time) cover other rungs of the env-injection chain but neither addressed the `ralph.check` path, which is invoked by the engine separately from the claim / sling flow.

## Files

`internal/convergence/condition.go`, `internal/convergence/condition_test.go`, `internal/dispatch/ralph.go`, `internal/dispatch/ralph_test.go` (+126 / -7)

Closes #2522
