### PR TITLE
fix(polecat): enforce branch-validation gate at submit handoff (closes #2082)

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -468,14 +468,14 @@ func TestPolecatFormulaSignalsRefineryAfterReassign(t *testing.T) {
 	nudge := `gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true`
 
 	assertContainsInOrder(t, body,
-		"**5. Reassign to refinery:**",
+		"**6. Reassign to refinery:**",
 		refineryTarget,
 		`gc bd update {{issue}} --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""`,
-		"**6. Signal refinery to check for work immediately",
+		"**7. Signal refinery to check for work immediately",
 		refineryTarget,
 		`gc session wake "$REFINERY_TARGET" || true`,
 		nudge,
-		"**7. Signal reconciler and exit.**",
+		"**8. Signal reconciler and exit.**",
 	)
 
 	for _, bad := range []string{
@@ -490,6 +490,69 @@ func TestPolecatFormulaSignalsRefineryAfterReassign(t *testing.T) {
 	if strings.Contains(body, `--assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"`) {
 		t.Fatal("polecat formula must clear gc.routed_to instead of routing to the refinery named session")
 	}
+}
+
+// TestPolecatFormulaSubmitHasBranchShapeGate is the regression test
+// for gastownhall/gascity#2082: the submit-and-exit step must include
+// a fail-closed gate that refuses to reassign to refinery when the
+// current branch isn't `polecat/<bead-id>`. Without this gate, a
+// provider that skipped workspace-setup (observed with codex)
+// silently strands work on its agent home branch — the refinery's
+// `polecat/*` scan never finds the commit.
+func TestPolecatFormulaSubmitHasBranchShapeGate(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat formula: %v", err)
+	}
+	body := string(data)
+
+	// The gate body must appear before the push (so a divergent
+	// branch never reaches origin) and before the refinery reassign
+	// (so a divergent branch never advances the bead state).
+	assertContainsInOrder(t, body,
+		"**1. Branch-shape gate (fails closed",
+		`CURRENT_BRANCH=$(git branch --show-current)`,
+		`EXPECTED_BRANCH="polecat/{{issue}}"`,
+		`if [ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]; then`,
+		`BRANCH SHAPE GATE FAILED`,
+		`gc runtime drain-ack`,
+		`exit 1`,
+		"**2. Final clean-state verification (safeguard):**",
+		"**3. Push your branch:**",
+		"**6. Reassign to refinery:**",
+	)
+
+	// The metadata.branch reconciliation must also be present so a
+	// workspace-setup step that ran but failed to record the branch
+	// is repaired before refinery handoff.
+	assertContainsInOrder(t, body,
+		`METADATA_BRANCH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.branch // empty')`,
+		`gc bd update {{issue}} --set-metadata branch="$EXPECTED_BRANCH"`,
+	)
+}
+
+// TestPolecatPromptInlinesBranchConvention asserts the polecat agent
+// prompt embeds the polecat/<bead-id> convention verbatim in a
+// CRITICAL section, so a provider that skips reading the formula
+// (observed with codex on #2082) still sees the rule inline.
+func TestPolecatPromptInlinesBranchConvention(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "polecat", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat prompt: %v", err)
+	}
+	body := string(data)
+
+	assertContainsInOrder(t, body,
+		"## CRITICAL: Branch Convention",
+		"`polecat/<bead-id>`",
+		"refinery's standard scan only",
+		"`polecat/*`",
+		"gastownhall/gascity#2082",
+	)
 }
 
 func TestPolecatFormulaSelfReviewRendersAffectedTestModes(t *testing.T) {

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -497,8 +497,9 @@ func TestPolecatFormulaSignalsRefineryAfterReassign(t *testing.T) {
 // a fail-closed gate that refuses to reassign to refinery when the
 // current branch isn't `polecat/<bead-id>`. Without this gate, a
 // provider that skipped workspace-setup (observed with codex)
-// silently strands work on its agent home branch — the refinery's
-// `polecat/*` scan never finds the commit.
+// silently strands work on its agent home branch — metadata.branch
+// never points at a valid polecat/<bead-id> merge target, so the
+// refinery's bead-driven handoff finds nothing to merge.
 func TestPolecatFormulaSubmitHasBranchShapeGate(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")
@@ -549,8 +550,8 @@ func TestPolecatPromptInlinesBranchConvention(t *testing.T) {
 	assertContainsInOrder(t, body,
 		"## CRITICAL: Branch Convention",
 		"`polecat/<bead-id>`",
-		"refinery's standard scan only",
-		"`polecat/*`",
+		"`metadata.branch`",
+		"handoff contract is broken",
 		"gastownhall/gascity#2082",
 	)
 }

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -29,17 +29,19 @@ metadata that points back to `metadata.work_dir`.
 
 Stay in your worktree. Install deps there if needed (`npm install`). Commit and push from there.
 
-## CRITICAL: Branch Convention (REQUIRED — refinery scans for this)
+## CRITICAL: Branch Convention (REQUIRED — the refinery handoff contract)
 
 Every commit must land on a per-bead branch named `polecat/<bead-id>`,
-created from `origin/<base_branch>`. The refinery's standard scan only
-discovers `polecat/*` branches; anything else (your agent home branch,
-a stray local checkout) is invisible to the merge queue and the work
-is silently stranded.
+created from `origin/<base_branch>`. The refinery finds work by bead
+assignment (`gc bd list --assignee=...`) and merges the branch recorded
+in the bead's `metadata.branch`, which must follow the `polecat/<bead-id>`
+convention. Commit on anything else (your agent home branch, a stray
+local checkout) and the handoff contract is broken — `metadata.branch`
+has no valid merge target and the work is silently stranded.
 
 **Required shape for a bead with ID `vg-1jp`:**
 
-| | Value |
+| Field | Value |
 |---|---|
 | Branch name | `polecat/vg-1jp` |
 | Base | freshly-fetched `origin/<base_branch>` |
@@ -50,7 +52,7 @@ is silently stranded.
 The `workspace-setup` formula step creates this for you. **Do not skip
 that step.** The `submit-and-exit` step's first action is a fail-closed
 gate that refuses to reassign to refinery if the current branch isn't
-`polecat/<bead-id>`. Skipping branch-setup will halt the workflow at
+`polecat/<bead-id>`. Skipping `workspace-setup` will halt the workflow at
 submit time and require manual recovery
 (see gastownhall/gascity#2082).
 

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -29,6 +29,31 @@ metadata that points back to `metadata.work_dir`.
 
 Stay in your worktree. Install deps there if needed (`npm install`). Commit and push from there.
 
+## CRITICAL: Branch Convention (REQUIRED — refinery scans for this)
+
+Every commit must land on a per-bead branch named `polecat/<bead-id>`,
+created from `origin/<base_branch>`. The refinery's standard scan only
+discovers `polecat/*` branches; anything else (your agent home branch,
+a stray local checkout) is invisible to the merge queue and the work
+is silently stranded.
+
+**Required shape for a bead with ID `vg-1jp`:**
+
+| | Value |
+|---|---|
+| Branch name | `polecat/vg-1jp` |
+| Base | freshly-fetched `origin/<base_branch>` |
+| Worktree path | `<home>/worktrees/vg-1jp` |
+| Push target | `origin/polecat/vg-1jp` |
+| `metadata.branch` | `polecat/vg-1jp` |
+
+The `workspace-setup` formula step creates this for you. **Do not skip
+that step.** The `submit-and-exit` step's first action is a fail-closed
+gate that refuses to reassign to refinery if the current branch isn't
+`polecat/<bead-id>`. Skipping branch-setup will halt the workflow at
+submit time and require manual recovery
+(see gastownhall/gascity#2082).
+
 ---
 
 {{ template "propulsion-polecat" . }}

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -270,7 +270,49 @@ needs = ["self-review"]
 description = """
 Hand off your work and self-clean. You cease to exist after this step.
 
-**1. Final clean-state verification (safeguard):**
+**1. Branch-shape gate (fails closed — non-negotiable).**
+
+Before anything else, verify you are on a per-bead branch. The refinery
+scans for `polecat/<bead-id>` branches; if you push from a different
+branch (your agent home branch, a stray local checkout, etc.), the
+refinery silently never finds your work and the bead is permanently
+stranded as "assigned to refinery, no merge target". See
+gastownhall/gascity#2082.
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+EXPECTED_BRANCH="polecat/{{issue}}"
+if [ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]; then
+    echo "BRANCH SHAPE GATE FAILED"
+    echo "  current branch:  $CURRENT_BRANCH"
+    echo "  expected branch: $EXPECTED_BRANCH"
+    echo ""
+    echo "Refinery's standard scan only finds 'polecat/*' branches."
+    echo "Pushing this commit and reassigning to refinery would strand the work."
+    echo ""
+    echo "Recover by re-running the workspace-setup step:"
+    echo "  - Create the per-bead worktree at \\$(pwd)/worktrees/{{issue}}"
+    echo "  - Create branch '$EXPECTED_BRANCH' from origin/{{base_branch}}"
+    echo "  - Cherry-pick your commits from $CURRENT_BRANCH onto the new branch"
+    echo "  - Re-run submit-and-exit"
+    echo ""
+    echo "Do NOT proceed past this gate."
+    gc runtime drain-ack
+    exit 1
+fi
+```
+
+Also confirm `metadata.branch` reflects this branch (workspace-setup
+recorded it, but a divergent local state would be invisible to the
+refinery without this re-check):
+```bash
+METADATA_BRANCH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.branch // empty')
+if [ "$METADATA_BRANCH" != "$EXPECTED_BRANCH" ]; then
+    gc bd update {{issue}} --set-metadata branch="$EXPECTED_BRANCH"
+fi
+```
+
+**2. Final clean-state verification (safeguard):**
 ```bash
 git status --porcelain
 ```
@@ -281,19 +323,19 @@ git add -A && git commit -m "chore: capture remaining work ({{issue}})"
 This is a belt-and-suspenders check — self-review should have caught this,
 but we never push with untracked work left behind.
 
-**2. Push your branch:**
+**3. Push your branch:**
 ```bash
 git push origin HEAD
 ```
 
-**3. Clean up local branch (prevent stale branch accumulation):**
+**4. Clean up local branch (prevent stale branch accumulation):**
 ```bash
 BRANCH=$(git branch --show-current)
 git checkout --detach                 # Detach so we can delete the branch
 git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 ```
 
-**4. Update metadata on the work bead:**
+**5. Update metadata on the work bead:**
 ```bash
 gc bd update {{issue}} \
   --set-metadata target={{base_branch}} \
@@ -305,7 +347,7 @@ provided by the caller, `metadata.existing_pr` is preserved for refinery
 validation. The refinery records canonical `pr_url` only after verifying
 the PR is open and matches the branch, base, and origin repository.
 
-**5. Reassign to refinery:**
+**6. Reassign to refinery:**
 ```bash
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
 gc bd update {{issue}} --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to=""
@@ -327,20 +369,20 @@ merge, and close the bead. If there's a conflict, the refinery puts the
 bead back in the pool with `rejection_reason` metadata — a new polecat
 picks it up and resumes from the existing branch.
 
-**6. Signal refinery to check for work immediately (belt-and-suspenders):**
+**7. Signal refinery to check for work immediately (belt-and-suspenders):**
 ```bash
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
 gc session wake "$REFINERY_TARGET" || true
 gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
 ```
 
-The `gc bd update` in step 5 generates a `bead.updated` event the refinery's
+The `gc bd update` in step 6 generates a `bead.updated` event the refinery's
 event-watch will see, but that can take up to `event_timeout` seconds. Wake
 starts a stopped on_demand session; nudge leaves a visible prompt for a running
 one as soon as it is ready for input. Failure is non-fatal: the refinery finds
 the work on its next poll.
 
-**7. Signal reconciler and exit.**
+**8. Signal reconciler and exit.**
 ```bash
 gc runtime drain-ack
 exit

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -273,11 +273,11 @@ Hand off your work and self-clean. You cease to exist after this step.
 **1. Branch-shape gate (fails closed — non-negotiable).**
 
 Before anything else, verify you are on a per-bead branch. The refinery
-scans for `polecat/<bead-id>` branches; if you push from a different
+merges the branch recorded in your bead's `metadata.branch`, which must
+follow the `polecat/<bead-id>` convention; if you push from a different
 branch (your agent home branch, a stray local checkout, etc.), the
-refinery silently never finds your work and the bead is permanently
-stranded as "assigned to refinery, no merge target". See
-gastownhall/gascity#2082.
+handoff contract is broken and the bead is permanently stranded as
+"assigned to refinery, no merge target". See gastownhall/gascity#2082.
 
 ```bash
 CURRENT_BRANCH=$(git branch --show-current)
@@ -287,7 +287,7 @@ if [ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]; then
     echo "  current branch:  $CURRENT_BRANCH"
     echo "  expected branch: $EXPECTED_BRANCH"
     echo ""
-    echo "Refinery's standard scan only finds 'polecat/*' branches."
+    echo "Refinery handoff merges metadata.branch, which must be 'polecat/<bead-id>'."
     echo "Pushing this commit and reassigning to refinery would strand the work."
     echo ""
     echo "Recover by re-running the workspace-setup step:"


### PR DESCRIPTION
Thanks to @mike-matchpoint for the clear repro and the structured options menu in #2082 — this PR implements the smallest set of fail-closed mitigations (options #2 + #3 from the issue body) that stop the silent strand at the polecat boundary.

## Summary

The polecat formula's `workspace-setup` step creates a per-bead branch `polecat/<bead-id>` and the refinery's standard scan only discovers those. Providers that skip `workspace-setup` (the reported codex case) commit on whatever branch happens to be checked out in the agent's home worktree, and the refinery silently never finds the work — beads end up "assigned to refinery, no merge target", requiring manual recovery.

Two mitigations, both fail-closed:

### 1. Branch-shape gate in `mol-polecat-work.toml` (`submit-and-exit`)

A new **step 1** runs before the push and before the refinery reassign:

- Reads `git branch --show-current`.
- Refuses to proceed if the current branch is not `polecat/{{issue}}` — prints recovery instructions, signals `gc runtime drain-ack`, and exits 1.
- Also reconciles `metadata.branch` so the refinery's metadata view matches what is about to be pushed (in case `workspace-setup` recorded a divergent value).

This stops the strand at the polecat boundary instead of after the bead has already advanced to "assigned to refinery". Existing step numbers shift by one (3→4 cleanup, 4→5 metadata, 5→6 reassign, 6→7 signal, 7→8 reconciler+exit); the existing `TestPolecatFormulaSignalsRefineryAfterReassign` assertions are updated to match.

### 2. `CRITICAL: Branch Convention` section in `prompt.template.md`

The original prompt deferred all branch detail to the formula description. A provider that skips reading the formula now still sees the `polecat/<bead-id>` rule **inline** in the prompt, with a worked example table.

## Tests

- **New** `TestPolecatFormulaSubmitHasBranchShapeGate` — asserts the gate body appears in order before the push and before the refinery reassign, AND that the `metadata.branch` reconciliation is present.
- **New** `TestPolecatPromptInlinesBranchConvention` — asserts the CRITICAL section names the convention and references #2082.
- **Updated** `TestPolecatFormulaSignalsRefineryAfterReassign` — step renumber.

## Out of scope (deferred from the issue body)

- **Option #1** (move per-bead worktree+branch creation into a pre-claim hook) — the more robust structural fix, but touches the supervisor/dispatch layer and warrants a maintainer design call. Belongs in a separate PR.
- **Option #4** (codex-specific memory instructions) — provider-side and out of the formula+prompt surface this PR addresses.

This change covers the prompt + formula layer where polecats already operate; the supervisor-side hook is its own PR.

## Files

`examples/gastown/packs/gastown/formulas/mol-polecat-work.toml`, `examples/gastown/packs/gastown/agents/polecat/prompt.template.md`, `examples/gastown/gastown_test.go` (+141 / -11)

Closes #2082
