### PR TITLE
fix(dolt): defer compaction when a writer races the flatten, don't quarantine

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -697,13 +697,18 @@ preflight_counts() {
 # Row-count decreases fail. Row-count increases are recorded as concurrent
 # writer evidence only when the table value hash stays stable. Any table hash
 # drift is quarantined before full GC because row-count gain alone cannot prove
-# pre-flight rows remain reachable. Sets verify_counts_saw_gain,
-# verify_counts_failure_reason, and verify_counts_failure_guidance for callers.
+# pre-flight rows remain reachable. Sets category flags plus
+# verify_counts_failure_reason and verify_counts_failure_guidance for callers.
 verify_counts() {
   db="$1"
   preflight="$2"
   fail=0
   verify_counts_saw_gain=0
+  verify_counts_saw_gain_hash_drift=0
+  verify_counts_saw_row_decrease=0
+  verify_counts_saw_same_count_hash_drift=0
+  verify_counts_saw_table_list_change=0
+  verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
   verify_counts_failure_guidance=""
   preflight_tables=""
@@ -716,6 +721,7 @@ verify_counts() {
     expected_hash=${rest#* }
     if ! actual=$(row_count "$db" "$t"); then
       printf 'compact: db=%s post-flatten row count failed for table=%s\n' "$db" "$t" >&2
+      verify_counts_saw_probe_failure=1
       if [ "$fail" -eq 0 ]; then
         fail=2
         verify_counts_failure_reason="post-flatten row count probe failed"
@@ -726,6 +732,7 @@ verify_counts() {
     case "$actual" in
       ''|*[!0-9]*)
         printf 'compact: db=%s post-flatten row count failed for table=%s\n' "$db" "$t" >&2
+        verify_counts_saw_probe_failure=1
         if [ "$fail" -eq 0 ]; then
           fail=2
           verify_counts_failure_reason="post-flatten row count probe failed"
@@ -736,6 +743,7 @@ verify_counts() {
     esac
     if ! actual_hash=$(table_value_hash "$db" "$t"); then
       printf 'compact: db=%s post-flatten table value hash failed for table=%s\n' "$db" "$t" >&2
+      verify_counts_saw_probe_failure=1
       if [ "$fail" -eq 0 ]; then
         fail=2
         verify_counts_failure_reason="post-flatten table value hash probe failed"
@@ -745,6 +753,7 @@ verify_counts() {
     fi
     if [ -z "$actual_hash" ]; then
       printf 'compact: db=%s post-flatten table value hash returned empty value for table=%s\n' "$db" "$t" >&2
+      verify_counts_saw_probe_failure=1
       if [ "$fail" -eq 0 ]; then
         fail=2
         verify_counts_failure_reason="post-flatten table value hash probe failed"
@@ -757,6 +766,7 @@ verify_counts() {
       if [ "$actual" -lt "$expected" ]; then
         printf 'compact: db=%s row count decreased after flatten table=%s before=%s after=%s\n' \
           "$db" "$t" "$expected" "$actual" >&2
+        verify_counts_saw_row_decrease=1
         if [ "$fail" -ne 1 ]; then
           fail=1
           verify_counts_failure_reason="post-flatten row count decreased"
@@ -782,6 +792,7 @@ verify_counts() {
       else
         printf 'compact: db=%s table=%s value hash changed after flatten without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
+        verify_counts_saw_same_count_hash_drift=1
         if [ "$fail" -ne 1 ]; then
           fail=1
           verify_counts_failure_reason="post-flatten table value hash changed without row-count increase"
@@ -792,6 +803,7 @@ verify_counts() {
   done < "$preflight"
   post_tables_tmp=$(mktemp)
   if ! user_tables "$db" > "$post_tables_tmp"; then
+    verify_counts_saw_probe_failure=1
     if [ "$fail" -eq 0 ]; then
       fail=2
       verify_counts_failure_reason="post-flatten table list probe failed"
@@ -805,6 +817,7 @@ verify_counts() {
     if ! valid_table_name "$post_table"; then
       printf 'compact: db=%s invalid table name after flatten table=%s — quarantine and investigate before GC\n' \
         "$db" "$post_table" >&2
+      verify_counts_saw_table_list_change=1
       if [ "$fail" -ne 1 ]; then
         fail=1
         verify_counts_failure_reason="post-flatten table list changed"
@@ -817,6 +830,7 @@ verify_counts() {
       *)
         printf 'compact: db=%s table=%s appeared after pre-flight snapshot — quarantine and investigate before GC\n' \
           "$db" "$post_table" >&2
+        verify_counts_saw_table_list_change=1
         if [ "$fail" -ne 1 ]; then
           fail=1
           verify_counts_failure_reason="post-flatten table list changed"
@@ -1302,6 +1316,10 @@ flatten_database() {
   db="$1"
   verify_counts_saw_gain=0
   verify_counts_saw_gain_hash_drift=0
+  verify_counts_saw_row_decrease=0
+  verify_counts_saw_same_count_hash_drift=0
+  verify_counts_saw_table_list_change=0
+  verify_counts_saw_probe_failure=0
   verify_counts_failure_reason=""
   verify_counts_failure_guidance=""
   head_before_reset=""
@@ -1734,7 +1752,11 @@ flatten_database() {
     # gain+drift case with a stable HEAD still quarantine below unchanged.
     if [ "$writer_race_detected" = "1" ] && \
        [ "${verify_counts_saw_gain:-0}" = "1" ] && \
-       [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ]; then
+       [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] && \
+       [ "${verify_counts_saw_row_decrease:-0}" != "1" ] && \
+       [ "${verify_counts_saw_same_count_hash_drift:-0}" != "1" ] && \
+       [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \
+       [ "${verify_counts_saw_probe_failure:-0}" != "1" ]; then
       printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — table value hash drift with row-count increase is concurrent-writer data, not corruption; deferring, will retry next run\n' \
         "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
       if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
@@ -1745,6 +1767,11 @@ flatten_database() {
       fi
       rm -f "$preflight_tmp"
       return 0
+    fi
+    if [ "$writer_race_detected" = "1" ] && \
+       [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ]; then
+      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s), but additional integrity failure category prevents defer; quarantine unchanged\n' \
+        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
     fi
     printf 'compact: db=%s post-flatten INTEGRITY check failed — escalate (%s)\n' \
       "$db" "$integrity_guidance" >&2
@@ -1795,6 +1822,9 @@ flatten_database() {
   fi
   if [ "$postflight_hash" != "$preflight_hash" ]; then
     if [ "$db_hash_writer_race_detected" = "1" ]; then
+      # The DB hash probe runs after table-level verification has already
+      # passed. HEAD movement across this probe means an external writer may
+      # have changed any value without changing the checked table row counts.
       db_hash_drift_detail="database value hash drift"
       if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
         db_hash_drift_detail="database value hash drift with row-count increase"

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -24,6 +24,23 @@
 #      continue only when table and database value hashes stay stable. Any
 #      value-hash drift, table-list drift, or row-count decrease is
 #      quarantined before full GC.
+#   4a. Local-verify HEAD-stability gate. The pre-flight stability loop cannot
+#      close the residual window between its final HEAD check and the flatten,
+#      nor the window during post-flatten verify, so a normal MVCC writer (the
+#      beads/mail workload) can still commit inside the flatten window. That
+#      legitimately adds rows and shifts value hashes versus the snapshot, which
+#      otherwise looks identical to the ambiguous gain+drift corruption signal.
+#      Quarantining that false positive blocks all future GC of the db and
+#      starves DOLT_GC until host memory is exhausted. So, mirroring the remote-
+#      push path's HEAD-stability defer, the gain+drift case is downgraded from
+#      a blocking quarantine to a skip-and-retry-next-run ONLY when a concurrent
+#      writer is proven. A writer is proven (and distinguished from the flatten's
+#      OWN commit) when either HEAD captured immediately before the mutating
+#      reset differs from the stable pre-flight HEAD (a writer landed in the
+#      preflight->reset window, before the flatten committed), or HEAD captured
+#      after verify moved past the flatten's own commit (a writer landed during/
+#      after verify). All other failures — and gain+drift with a stable HEAD —
+#      still quarantine. Probe failure leaves the race unproven and quarantines.
 #   5. Run CALL DOLT_GC('--full') to reclaim chunks orphaned by the flatten.
 #
 # Remote push failures are recorded in compact-pending-push markers and do not
@@ -1230,6 +1247,9 @@ flatten_database() {
   verify_counts_saw_gain=0
   verify_counts_failure_reason=""
   verify_counts_failure_guidance=""
+  head_before_reset=""
+  post_verify_head=""
+  writer_race_detected=0
 
   if [ -n "$only_dbs" ]; then
     case ",$only_dbs," in
@@ -1574,6 +1594,16 @@ flatten_database() {
 
   start=$(date +%s)
 
+  # Capture HEAD one last time immediately before the mutating flatten. The
+  # preflight loop already proved HEAD == "$head" stayed stable across the
+  # snapshot gather, so this probe runs strictly BEFORE the flatten's own
+  # DOLT_RESET/DOLT_COMMIT — any difference from "$head" here can only be an
+  # external writer that committed inside the residual preflight->reset window,
+  # never the flatten's own commit (which has not happened yet). An empty/failed
+  # probe leaves head_before_reset empty, which the writer-race gate treats as
+  # "unproven" and therefore falls back to the safe quarantine behavior.
+  head_before_reset=$(head_commit "$db" || true)
+
   # Soft-reset to root + commit-everything is the flatten transaction.
   # Both run in a single dolt sql invocation so the session keeps the
   # USE selection across the two CALLs.
@@ -1609,9 +1639,51 @@ flatten_database() {
 
   verify_counts_rc=0
   verify_counts "$db" "$preflight_tmp" || verify_counts_rc=$?
+
+  # Writer-race gate (local-verify HEAD-stability). A normal MVCC writer (the
+  # beads/mail workload) can commit to this db inside the flatten window, which
+  # legitimately adds rows and changes value hashes versus the pre-flight
+  # snapshot. That is a benign, self-healing condition — the next scheduled run
+  # retries — and must NOT be quarantined (a quarantine marker blocks all future
+  # GC of the db and is the production memory-exhaustion bug).
+  #
+  # We distinguish a writer commit from the flatten's OWN commit using two
+  # independent signals, both anchored so the flatten's own commit never trips
+  # them:
+  #   * head_before_reset != head  — HEAD moved between the stable pre-flight
+  #     snapshot and the pre-reset probe. That probe runs before the flatten
+  #     mutates anything, so only an external writer can have moved HEAD.
+  #   * post_verify_head != flatten_head — HEAD moved past the flatten's own
+  #     commit during/after verify_counts. The script issues no commit between
+  #     the flatten and this probe, so only an external writer can have moved it.
+  # Either signal proves a concurrent writer. If a HEAD probe fails/returns
+  # empty we leave the corresponding value empty and the equality below cannot
+  # become true, so an unprovable race safely falls through to quarantine.
+  post_verify_head=$(head_commit "$db" || true)
+  writer_race_detected=0
+  if [ -n "$head" ] && [ -n "$head_before_reset" ] && [ "$head_before_reset" != "$head" ]; then
+    writer_race_detected=1
+  fi
+  if [ -n "$flatten_head" ] && [ -n "$post_verify_head" ] && [ "$post_verify_head" != "$flatten_head" ]; then
+    writer_race_detected=1
+  fi
+
   if [ "$verify_counts_rc" -ne 0 ]; then
     integrity_reason="${verify_counts_failure_reason:-post-flatten integrity check failed}"
     integrity_guidance="${verify_counts_failure_guidance:-post-flatten integrity check failed; investigate before re-running}"
+    # Downgrade quarantine -> defer ONLY for the ambiguous gain+drift case when
+    # a concurrent writer is proven. Every other integrity failure (row-count
+    # decrease, same-count hash drift, table-list drift, probe failure) and the
+    # gain+drift case with a stable HEAD still quarantine below unchanged.
+    if [ "$writer_race_detected" = "1" ] && \
+       [ "${verify_counts_saw_gain:-0}" = "1" ] && \
+       [ "$verify_counts_failure_reason" = "post-flatten table value hash changed with row-count increase" ]; then
+      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — table value hash drift with row-count increase is concurrent-writer data, not corruption; deferring, will retry next run\n' \
+        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
+      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      rm -f "$preflight_tmp"
+      return 0
+    fi
     printf 'compact: db=%s post-flatten INTEGRITY check failed — escalate (%s)\n' \
       "$db" "$integrity_guidance" >&2
     write_compact_marker "$quarantine_dir" "$db" "$integrity_reason" || {
@@ -1649,6 +1721,17 @@ flatten_database() {
   fi
   if [ "$postflight_hash" != "$preflight_hash" ]; then
     if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
+      # Same writer-race downgrade as the per-table gain+drift case above: a
+      # proven concurrent writer that added rows also shifts the whole-database
+      # value hash. Defer instead of quarantining. A stable-HEAD gain+drift here
+      # is still a genuine anomaly and quarantines unchanged.
+      if [ "$writer_race_detected" = "1" ]; then
+        printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — database value hash drift with row-count increase is concurrent-writer data, not corruption; deferring, will retry next run\n' \
+          "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
+        preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+        rm -f "$preflight_tmp"
+        return 0
+      fi
       printf 'compact: db=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
         "$db" "$preflight_hash" "$postflight_hash" >&2
       write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed with row-count increase" || {

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -771,6 +771,7 @@ verify_counts() {
     fi
     if [ "$actual_hash" != "$expected_hash" ]; then
       if [ "$table_gained_rows" = "1" ]; then
+        verify_counts_saw_gain_hash_drift=1
         printf 'compact: db=%s table=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
         if [ "$fail" -ne 1 ]; then
@@ -962,6 +963,25 @@ write_pending_push_marker() {
     "compacted_from_head=$compacted_from_head" \
     "local_branch=$local_branch" \
     "remote_branch=$remote_branch"
+}
+
+write_pending_gc_marker() {
+  _pg_db="$1"
+  _pg_reason="$2"
+  _pg_remote="${3:-}"
+  _pg_expected_remote_head="${4:-}"
+  _pg_expected_remote_head_verified="${5:-0}"
+  _pg_compacted_from_head="${6:-}"
+  _pg_local_branch="${7:-main}"
+  _pg_remote_branch="${8:-$_pg_local_branch}"
+
+  write_compact_marker "$pending_gc_dir" "$_pg_db" "$_pg_reason" \
+    "remote=$_pg_remote" \
+    "expected_remote_head=$_pg_expected_remote_head" \
+    "expected_remote_head_verified=$_pg_expected_remote_head_verified" \
+    "compacted_from_head=$_pg_compacted_from_head" \
+    "local_branch=$_pg_local_branch" \
+    "remote_branch=$_pg_remote_branch"
 }
 
 compact_marker_value() {
@@ -1242,9 +1262,46 @@ preserve_head_after_integrity_failure() {
   return 0
 }
 
+preserve_head_after_writer_race_defer() {
+  db="$1"
+  flatten_head="$2"
+  current_head=$(head_commit "$db" || true)
+  if [ -z "$current_head" ]; then
+    current_head="$flatten_head"
+  fi
+  printf 'compact: db=%s leaving post-flatten HEAD=%s in place after writer race; pending-GC marker will retry full GC next run\n' \
+    "$db" "${current_head:-<empty>}" >&2
+  return 0
+}
+
+defer_writer_race_after_flatten() {
+  db="$1"
+  flatten_head="$2"
+  defer_remote="$3"
+  defer_expected_remote_head="$4"
+  defer_expected_remote_head_verified="$5"
+  defer_compacted_from_head="$6"
+  defer_local_branch="$7"
+  defer_remote_branch="$8"
+  if ! write_pending_gc_marker "$db" "writer race during flatten deferred full GC" \
+    "$defer_remote" "$defer_expected_remote_head" "$defer_expected_remote_head_verified" \
+    "$defer_compacted_from_head" "$defer_local_branch" "$defer_remote_branch"; then
+    current_head=$(head_commit "$db" || true)
+    if [ -z "$current_head" ]; then
+      current_head="$flatten_head"
+    fi
+    printf 'compact: db=%s leaving post-flatten HEAD=%s in place after writer race; pending-GC marker write failed, manual repair required before compaction or GC\n' \
+      "$db" "${current_head:-<empty>}" >&2
+    return 1
+  fi
+  preserve_head_after_writer_race_defer "$db" "$flatten_head" || true
+  return 0
+}
+
 flatten_database() {
   db="$1"
   verify_counts_saw_gain=0
+  verify_counts_saw_gain_hash_drift=0
   verify_counts_failure_reason=""
   verify_counts_failure_guidance=""
   head_before_reset=""
@@ -1677,10 +1734,15 @@ flatten_database() {
     # gain+drift case with a stable HEAD still quarantine below unchanged.
     if [ "$writer_race_detected" = "1" ] && \
        [ "${verify_counts_saw_gain:-0}" = "1" ] && \
-       [ "$verify_counts_failure_reason" = "post-flatten table value hash changed with row-count increase" ]; then
+       [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ]; then
       printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — table value hash drift with row-count increase is concurrent-writer data, not corruption; deferring, will retry next run\n' \
         "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
-      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+        "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+        "$compacted_from_head" "$local_branch" "$remote_branch"; then
+        rm -f "$preflight_tmp"
+        return 1
+      fi
       rm -f "$preflight_tmp"
       return 0
     fi
@@ -1695,6 +1757,7 @@ flatten_database() {
     rm -f "$preflight_tmp"
     return 1
   fi
+  pre_db_hash_head=$(head_commit "$db" || true)
   if ! postflight_hash=$(db_value_hash "$db"); then
     printf 'compact: db=%s post-flatten value hash probe failed — quarantine and investigate before GC\n' \
       "$db" >&2
@@ -1719,7 +1782,34 @@ flatten_database() {
     rm -f "$preflight_tmp"
     return 1
   fi
+  post_db_hash_head=$(head_commit "$db" || true)
+  db_hash_writer_race_detected=0
+  if [ -n "$flatten_head" ] && [ -n "$pre_db_hash_head" ] && [ "$pre_db_hash_head" != "$flatten_head" ]; then
+    db_hash_writer_race_detected=1
+  fi
+  if [ -n "$pre_db_hash_head" ] && [ -n "$post_db_hash_head" ] && [ "$post_db_hash_head" != "$pre_db_hash_head" ]; then
+    db_hash_writer_race_detected=1
+  fi
+  if [ "$db_hash_writer_race_detected" = "1" ]; then
+    writer_race_detected=1
+  fi
   if [ "$postflight_hash" != "$preflight_hash" ]; then
+    if [ "$db_hash_writer_race_detected" = "1" ]; then
+      db_hash_drift_detail="database value hash drift"
+      if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
+        db_hash_drift_detail="database value hash drift with row-count increase"
+      fi
+      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s pre_db_hash_HEAD=%s post_db_hash_HEAD=%s) — %s is concurrent-writer data, not corruption; deferring, will retry next run\n' \
+        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" "${pre_db_hash_head:-<empty>}" "${post_db_hash_head:-<empty>}" "$db_hash_drift_detail" >&2
+      if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+        "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+        "$compacted_from_head" "$local_branch" "$remote_branch"; then
+        rm -f "$preflight_tmp"
+        return 1
+      fi
+      rm -f "$preflight_tmp"
+      return 0
+    fi
     if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
       # Same writer-race downgrade as the per-table gain+drift case above: a
       # proven concurrent writer that added rows also shifts the whole-database
@@ -1728,7 +1818,12 @@ flatten_database() {
       if [ "$writer_race_detected" = "1" ]; then
         printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — database value hash drift with row-count increase is concurrent-writer data, not corruption; deferring, will retry next run\n' \
           "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
-        preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+        if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+          "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+          "$compacted_from_head" "$local_branch" "$remote_branch"; then
+          rm -f "$preflight_tmp"
+          return 1
+        fi
         rm -f "$preflight_tmp"
         return 0
       fi

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -535,6 +535,46 @@ case "$query" in
         exit 49
       fi
     fi
+    # writer_race_before_flatten: a normal MVCC writer commits inside the
+    # residual window between the final stable pre-flight HEAD check and the
+    # flatten's DOLT_RESET. The pre-flight loop stabilizes at headcommit, so the
+    # pre-reset HEAD probe (the 3rd HEAD probe taken while still at headcommit)
+    # reports writercommit. State stays at headcommit so the flatten still
+    # advances HEAD to compactcommit and verify still observes the gain+drift.
+    # This advance lives in the HEAD-probe arm (not current_head) so the
+    # "$(current_head)" gate-checks in other arms keep seeing the real state.
+    if [ "$mode" = "writer_race_before_flatten" ] && [ "$(current_head)" = "headcommit" ]; then
+      calls_file="$state_file.prereset-head-calls"
+      calls=0
+      if [ -f "$calls_file" ]; then
+        calls="$(cat "$calls_file")"
+      fi
+      calls=$((calls + 1))
+      printf '%%s\n' "$calls" > "$calls_file"
+      if [ "$calls" -ge 3 ]; then
+        print_cell writercommit
+        exit 0
+      fi
+    fi
+    # writer_race_during_verify: a writer commits during/after the post-flatten
+    # verify. The flatten advances HEAD to compactcommit; the 1st HEAD probe at
+    # compactcommit is the flatten_head probe and the 2nd is the post-verify
+    # probe, which reports writercommit so HEAD has moved past the flatten's own
+    # commit. verify_counts still sees compactcommit (gain+drift) because it does
+    # not probe HEAD and the "$(current_head)" gates read the real state.
+    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+      calls_file="$state_file.postverify-head-calls"
+      calls=0
+      if [ -f "$calls_file" ]; then
+        calls="$(cat "$calls_file")"
+      fi
+      calls=$((calls + 1))
+      printf '%%s\n' "$calls" > "$calls_file"
+      if [ "$calls" -ge 2 ]; then
+        print_cell writercommit
+        exit 0
+      fi
+    fi
     print_cell "$(current_head)"
     exit 0
     ;;
@@ -574,7 +614,7 @@ case "$query" in
       print_cell ""
       exit 0
     fi
-    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-beads-after-writer
       exit 0
     fi
@@ -666,7 +706,7 @@ case "$query" in
       printf 'row count exploded after flatten\n' >&2
       exit 47
     fi
-    if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ]; } && [ "$calls" -gt 1 ]; then
+    if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ]; } && [ "$calls" -gt 1 ]; then
       print_cell 11
     elif [ "$mode" = "row_count_decreases" ] && [ "$calls" -gt 1 ]; then
       print_cell 9
@@ -698,7 +738,7 @@ case "$query" in
     if [ "$mode" = "same_row_count_writer" ]; then
       set_hash hash-after-writer
     fi
-    if [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "same_count_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ]; then
+    if [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "same_count_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "writer_race_db_hash_during_verify" ]; then
       set_hash hash-after-writer
     fi
     exit 0
@@ -1792,6 +1832,111 @@ func TestCompactScriptQuarantinesMixedRowGainAndSameCountHashDriftBeforeFullGC(t
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
 	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table value hash changed with row-count increase" {
 		t.Fatalf("quarantine reason should identify first table hash drift, got %q", reason)
+	}
+}
+
+// assertCompactWriterRaceDeferred encodes the shared expectations for a proven
+// writer-race defer: the gain+drift quarantine is downgraded to a skip, so the
+// run exits 0, logs the defer message, writes NO quarantine marker, and does not
+// run DOLT_GC (GC is left for the next run after the writer settles).
+func assertCompactWriterRaceDeferred(t *testing.T, fixture compactScriptFixture, out string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("writer-race defer must exit 0 (skip, not failure): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "writer race detected during flatten") ||
+		!strings.Contains(out, "deferring, will retry next run") {
+		t.Fatalf("output missing writer-race defer message:\n%s", out)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, statErr := os.Stat(quarantine); !os.IsNotExist(statErr) {
+		t.Fatalf("writer-race defer must NOT write a quarantine marker; stat=%v", statErr)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("writer-race defer must skip GC this run:\n%s", string(data))
+	}
+}
+
+// A normal MVCC writer that commits in the residual window between the final
+// stable pre-flight HEAD check and the flatten's reset produces a post-flatten
+// row-count gain + table value-hash drift that is indistinguishable, by value
+// alone, from corruption. Because HEAD captured immediately before the reset
+// differs from the stable pre-flight HEAD, the writer is proven and the run
+// defers instead of writing the blocking quarantine marker.
+func TestCompactScriptDefersWhenWriterCommitsBeforeFlatten(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_before_flatten", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if !strings.Contains(out, "table=beads gained rows during flatten") ||
+		!strings.Contains(out, "value hash changed with row-count increase") {
+		t.Fatalf("output missing the ambiguous gain+drift signal that the gate downgrades:\n%s", out)
+	}
+	if !strings.Contains(out, "pre_reset_HEAD=writercommit") {
+		t.Fatalf("defer message should report the pre-reset writer HEAD:\n%s", out)
+	}
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
+}
+
+// A writer that commits during/after the post-flatten verify moves HEAD past
+// the flatten's own commit. That difference proves a concurrent writer and the
+// gain+drift quarantine is downgraded to a defer.
+func TestCompactScriptDefersWhenWriterCommitsDuringVerify(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_during_verify", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if !strings.Contains(out, "table=beads gained rows during flatten") ||
+		!strings.Contains(out, "value hash changed with row-count increase") {
+		t.Fatalf("output missing the ambiguous gain+drift signal that the gate downgrades:\n%s", out)
+	}
+	if !strings.Contains(out, "post_verify_HEAD=writercommit") {
+		t.Fatalf("defer message should report HEAD moving past the flatten commit:\n%s", out)
+	}
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
+}
+
+// The whole-database value hash also drifts when a concurrent writer adds rows.
+// When per-table checks pass but the database hash drifts with a row gain and a
+// writer is proven (HEAD moved past the flatten commit), the database-hash
+// gain+drift quarantine is likewise downgraded to a defer.
+func TestCompactScriptDefersWhenWriterCommitsCausingDatabaseHashDrift(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_db_hash_during_verify", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if !strings.Contains(out, "database value hash drift with row-count increase") {
+		t.Fatalf("output missing the database-hash writer-race defer:\n%s", out)
+	}
+	if !strings.Contains(out, "post_verify_HEAD=writercommit") {
+		t.Fatalf("defer message should report HEAD moving past the flatten commit:\n%s", out)
+	}
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
+}
+
+// Control: the same gain+drift signal with a STABLE HEAD (no writer proven) is a
+// genuine anomaly and must still write the blocking quarantine marker and fail.
+// This guards against the writer-race gate weakening real-corruption detection.
+func TestCompactScriptStillQuarantinesGainAndHashDriftWithStableHead(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "same_table_replacement_with_row_gain", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("stable-HEAD gain+drift must remain a blocking failure:\n%s", out)
+	}
+	if strings.Contains(out, "writer race detected") {
+		t.Fatalf("stable HEAD must not be misclassified as a writer race:\n%s", out)
+	}
+	if !strings.Contains(out, "post-flatten INTEGRITY check failed") {
+		t.Fatalf("stable-HEAD gain+drift should escalate as an integrity failure:\n%s", out)
+	}
+	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table value hash changed with row-count increase" {
+		t.Fatalf("stable-HEAD gain+drift must quarantine with the gain+drift reason, got %q", reason)
+	}
+	data, readErr := os.ReadFile(fixture.doltLog)
+	if readErr != nil {
+		t.Fatalf("read dolt log: %v", readErr)
+	}
+	if strings.Contains(string(data), "DOLT_GC") {
+		t.Fatalf("stable-HEAD gain+drift must block full GC:\n%s", string(data))
 	}
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -562,7 +562,7 @@ case "$query" in
     # probe, which reports writercommit so HEAD has moved past the flatten's own
     # commit. verify_counts still sees compactcommit (gain+drift) because it does
     # not probe HEAD and the "$(current_head)" gates read the real state.
-    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       calls_file="$state_file.postverify-head-calls"
       calls=0
       if [ -f "$calls_file" ]; then
@@ -620,7 +620,7 @@ case "$query" in
       print_cell ""
       exit 0
     fi
-    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-beads-after-writer
       exit 0
     fi
@@ -632,7 +632,7 @@ case "$query" in
     exit 0
     ;;
   *"DOLT_HASHOF_TABLE('notes')"*)
-    if { [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "same_count_hash_drift_then_probe_failure" ] || [ "$mode" = "probe_failure_then_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
+    if { [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ] || [ "$mode" = "same_count_hash_drift_then_probe_failure" ] || [ "$mode" = "probe_failure_then_same_count_hash_drift" ]; } && [ "$(current_head)" = "compactcommit" ]; then
       print_cell hash-notes-after-writer
       exit 0
     fi
@@ -668,7 +668,7 @@ case "$query" in
       print_cell blocked_issues
       exit 0
     fi
-    if [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ]; then
+    if [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; then
       print_cells beads notes
       exit 0
     fi
@@ -712,7 +712,7 @@ case "$query" in
       printf 'row count exploded after flatten\n' >&2
       exit 47
     fi
-    if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ]; } && [ "$calls" -gt 1 ]; then
+    if { [ "$mode" = "row_count_gain_with_stable_hashes" ] || [ "$mode" = "row_count_gain_with_db_hash_drift" ] || [ "$mode" = "row_count_and_hash_diverges" ] || [ "$mode" = "same_table_replacement_with_row_gain" ] || [ "$mode" = "mixed_row_count_gain_and_same_count_hash_drift" ] || [ "$mode" = "writer_race_before_flatten" ] || [ "$mode" = "writer_race_during_verify" ] || [ "$mode" = "writer_race_db_hash_during_verify" ] || [ "$mode" = "writer_race_with_mixed_same_count_hash_drift" ]; } && [ "$calls" -gt 1 ]; then
       print_cell 11
     elif [ "$mode" = "row_count_decreases" ] && [ "$calls" -gt 1 ]; then
       print_cell 9
@@ -1839,6 +1839,37 @@ func TestCompactScriptQuarantinesMixedRowGainAndSameCountHashDriftBeforeFullGC(t
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
 	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table value hash changed with row-count increase" {
 		t.Fatalf("quarantine reason should identify first table hash drift, got %q", reason)
+	}
+}
+
+func TestCompactScriptQuarantinesMixedSignalsDespiteWriterRace(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_with_mixed_same_count_hash_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite proven writer plus same-count hash drift:\n%s", out)
+	}
+	if !strings.Contains(out, "writer race detected") {
+		t.Fatalf("output missing proven writer evidence:\n%s", out)
+	}
+	if !strings.Contains(out, "table=beads gained rows during flatten") ||
+		!strings.Contains(out, "table=notes value hash changed after flatten without row-count increase") {
+		t.Fatalf("output missing mixed integrity signals:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "DOLT_GC") {
+		t.Fatalf("mixed hard integrity signals must block full GC despite writer race:\n%s", log)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, err := os.Stat(quarantine); err != nil {
+		t.Fatalf("mixed hard integrity signals should write quarantine marker: %v", err)
+	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if _, err := os.Stat(pendingGC); !os.IsNotExist(err) {
+		t.Fatalf("mixed hard integrity signals must not write pending-GC marker; stat=%v", err)
 	}
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -599,6 +599,12 @@ case "$query" in
       print_cell ""
       exit 0
     fi
+    if [ "$mode" = "writer_race_after_postverify_before_db_hash" ] && [ "$(current_head)" = "compactcommit" ]; then
+      set_head writercommit
+      set_hash hash-after-writer
+      print_cell hash-after-writer
+      exit 0
+    fi
     # row_count_gain_with_stable_hashes models the narrow probe-ordering race
     # where the preflight row count is stale but the preflight value hashes
     # already match the post-flatten values.
@@ -761,6 +767,7 @@ case "$query" in
       printf 'gc exploded\n' >&2
       exit 45
     fi
+    rm -rf -- "${GC_DOLT_DATA_DIR:-}/$db/.dolt/noms/oldgen"
     exit 0
     ;;
   *"DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')"*)
@@ -1852,6 +1859,10 @@ func assertCompactWriterRaceDeferred(t *testing.T, fixture compactScriptFixture,
 	if _, statErr := os.Stat(quarantine); !os.IsNotExist(statErr) {
 		t.Fatalf("writer-race defer must NOT write a quarantine marker; stat=%v", statErr)
 	}
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if reason := compactMarkerValue(t, pendingGC, "reason"); reason != "writer race during flatten deferred full GC" {
+		t.Fatalf("writer-race defer should record pending-GC retry marker, got reason %q", reason)
+	}
 	data, readErr := os.ReadFile(fixture.doltLog)
 	if readErr != nil {
 		t.Fatalf("read dolt log: %v", readErr)
@@ -1910,6 +1921,76 @@ func TestCompactScriptDefersWhenWriterCommitsCausingDatabaseHashDrift(t *testing
 		t.Fatalf("defer message should report HEAD moving past the flatten commit:\n%s", out)
 	}
 	assertCompactWriterRaceDeferred(t, fixture, out, err)
+}
+
+func TestCompactScriptDefersWhenWriterCommitsDuringDatabaseHash(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "writer_race_after_postverify_before_db_hash", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if !strings.Contains(out, "database value hash drift") {
+		t.Fatalf("output missing database-hash drift evidence:\n%s", out)
+	}
+	if !strings.Contains(out, "post_db_hash_HEAD=writercommit") {
+		t.Fatalf("defer message should report HEAD moving across the database hash probe:\n%s", out)
+	}
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
+}
+
+func TestCompactScriptRetriesPendingGCAfterWriterRaceDefer(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	oldgenFile := filepath.Join(fixture.dataDir, "beads", ".dolt", "noms", "oldgen", "archive")
+	if err := os.MkdirAll(filepath.Dir(oldgenFile), 0o755); err != nil {
+		t.Fatalf("mkdir oldgen fixture: %v", err)
+	}
+	if err := os.WriteFile(oldgenFile, []byte("orphaned oldgen data"), 0o644); err != nil {
+		t.Fatalf("write oldgen fixture: %v", err)
+	}
+
+	firstOut, err := fixture.run(t, "writer_race_during_verify", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	assertCompactWriterRaceDeferred(t, fixture, firstOut, err)
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if compactedFrom := compactMarkerValue(t, pendingGC, "compacted_from_head"); compactedFrom != "headcommit" {
+		t.Fatalf("pending-GC marker should preserve compaction source HEAD, got %q", compactedFrom)
+	}
+
+	secondOut, err := fixture.run(t, "below_threshold")
+	if err != nil {
+		t.Fatalf("second compact should retry pending-GC path:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "pending_gc=present") {
+		t.Fatalf("second compact missing pending-GC retry explanation:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Count(log, "DOLT_GC") != 1 {
+		t.Fatalf("writer-race defer should skip GC once, then run full GC on retry:\n%s", log)
+	}
+	if strings.Count(log, "DOLT_RESET") != 1 {
+		t.Fatalf("pending-GC retry must not flatten again:\n%s", log)
+	}
+	if _, err := os.Stat(oldgenFile); !os.IsNotExist(err) {
+		t.Fatalf("successful pending-GC retry should reclaim oldgen fixture, stat err=%v", err)
+	}
+	if _, err := os.Stat(pendingGC); !os.IsNotExist(err) {
+		t.Fatalf("successful pending-GC retry should clear marker, stat err=%v", err)
+	}
+}
+
+func TestCompactScriptWriterRaceGateUsesFlagNotReasonText(t *testing.T) {
+	sourcePath := filepath.Join(repoRoot(t), "commands", "compact", "run.sh")
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read compact script: %v", err)
+	}
+	source := string(data)
+	if !strings.Contains(source, "verify_counts_saw_gain_hash_drift=1") {
+		t.Fatalf("writer-race gate needs a dedicated gain+hash-drift flag")
+	}
+	if strings.Contains(source, `verify_counts_failure_reason" = "post-flatten table value hash changed with row-count increase"`) {
+		t.Fatalf("writer-race gate must not depend on the human-readable failure reason")
+	}
 }
 
 // Control: the same gain+drift signal with a STABLE HEAD (no writer proven) is a


### PR DESCRIPTION
## Problem

`gc dolt compact` flattens commit history, then `verify_counts` compares post-flatten **live** tables against the **pre-flight snapshot**. A normal concurrent MVCC writer that commits during the flatten window produces a legitimate row-count increase **plus** table/db value-hash drift. `verify_counts` cannot tell that apart from corruption, so it writes a blocking integrity quarantine marker.

That marker makes **all** future compaction of the db early-return. With `auto_gc` disabled (the documented config), compaction is the **only** GC path — so blocking it lets Dolt's in-memory NBS chunk-journal range index (`go/store/nbs/journal_writer.go`, reset only by GC or restart) grow unbounded until the host runs out of memory.

This was hit repeatedly in a managed city whose beads/mail workload commits frequently. `dolt_log` forensics over the flatten windows showed only ordinary `beads`/`bd:` commits — **no corruption**; the quarantine was a false positive. The downstream effect is severe under WSL2 (RAM cap + `swap.vhdx` thrash, no OOM-kill → multi-minute freeze).

## Fix (approach chosen)

Extend the script's own stated principle — the algorithm comment already says it should *"require HEAD to remain stable across a bounded retry loop,"* and HEAD-stability/defer is already implemented for the **remote-push** path — to the **local flatten verify**:

- Capture HEAD immediately **before** the mutating `DOLT_RESET`/`DOLT_COMMIT`, and again **after** `verify_counts`.
- A writer is **proven** (and distinguished from the flatten's own commit) when the pre-reset HEAD differs from the stable pre-flight HEAD, **or** the post-verify HEAD has moved past the flatten's own commit. Comparing against the flatten's own commit (not the raw pre-flight HEAD) is what avoids mistaking the flatten itself for a writer.
- Only in that **proven-writer** case is the ambiguous gain+hash-drift result downgraded from a blocking quarantine to a clean skip ("deferring, will retry next run"). Next scheduled run retries.

**All other integrity signals still quarantine, unchanged:** row-count decrease; same-count value-hash drift (per-table and db); table-list change; any probe failure; and gain+hash-drift when HEAD was **stable** (a genuine anomaly). A failed HEAD probe leaves the race unproven and falls through to quarantine (safe default).

### Alternatives considered
- **(B) Snapshot isolation** — flatten a pinned commit and verify against it. Correct in principle but a larger redesign of the compaction concurrency model; deferred.
- **(C) City-level writer quiesce during compaction** — lives in the orchestrator, not this script; heavier operationally (downtime) and out of scope here.
- **(A) this PR** — chosen as the **minimal change**: it reuses the script's existing HEAD-stability/defer machinery and only *downgrades* quarantine→retry in the single ambiguous case where a concurrent writer is proven. Given this edits a **data-integrity safety check**, the smallest blast-radius change that still never weakens real-corruption detection seemed right.

**This touches a safety check, so it's worth maintainer discussion** — particularly the choice to defer-and-retry (vs. quarantine) on a proven writer race, and whether the db-level gain+drift branch should be downgraded alongside the per-table one (this PR downgrades both; reverting the db-level block is a one-line change).

## Relation to #2562
Companion to #2562 (opt-in `GOMEMLIMIT` for the managed dolt server). #2562 is the **safety net** (caps the host blast radius); **this PR removes the root cause** (the GC starvation that let the heap grow). They touch disjoint files and are independent.

## Test plan
- `bash -n examples/dolt/commands/compact/run.sh`
- `go test ./examples/dolt/ -run Compact` — 72 pass, incl. new tests: writer commits before flatten (Window A) → defer, no marker; writer commits during verify (Window B) → defer; db-level gain+drift with proven writer → defer; **control:** gain+drift with stable HEAD → still quarantines.