### PR TITLE
Keep beads runtime files ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ cmd/gc/.runtime/
 .runtime/
 *.test
 **/.beads/*
-!**/.beads/config.yaml
-!**/.beads/metadata.json
 !**/.beads/identity.toml
 .claude/
 !examples/gastown/packs/gastown/overlays/default/.claude/

--- a/cmd/gc/gitignore.go
+++ b/cmd/gc/gitignore.go
@@ -8,11 +8,11 @@ import (
 )
 
 // cityGitignoreEntries are the paths that gc init writes into .gitignore.
-var cityGitignoreEntries = []string{".gc/", ".beads/*", "!.beads/config.yaml", "!.beads/metadata.json", "!.beads/identity.toml", "hooks/", ".runtime/"}
+var cityGitignoreEntries = []string{".gc/", ".beads/*", "!.beads/identity.toml", "hooks/", ".runtime/"}
 
 // rigGitignoreEntries are the paths that gc rig add writes into
 // the rig-scoped .gitignore.
-var rigGitignoreEntries = []string{".beads/*", "!.beads/config.yaml", "!.beads/metadata.json", "!.beads/identity.toml"}
+var rigGitignoreEntries = []string{".beads/*", "!.beads/identity.toml"}
 
 func usesCanonicalBeadsEntries(entries []string) bool {
 	for _, entry := range entries {
@@ -26,6 +26,16 @@ func usesCanonicalBeadsEntries(entries []string) bool {
 func isLegacyWholeBeadsIgnore(line string) bool {
 	switch strings.TrimSpace(line) {
 	case ".beads", ".beads/", "/.beads", "/.beads/":
+		return true
+	default:
+		return false
+	}
+}
+
+func isObsoleteBeadsRuntimeUnignore(line string) bool {
+	switch strings.TrimSpace(line) {
+	case "!.beads/config.yaml", "!/.beads/config.yaml", "!**/.beads/config.yaml",
+		"!.beads/metadata.json", "!/.beads/metadata.json", "!**/.beads/metadata.json":
 		return true
 	default:
 		return false
@@ -53,7 +63,7 @@ func ensureGitignoreEntries(fs fsys.FS, dir string, entries []string) error {
 	removedLegacyBeadsIgnore := false
 	for _, line := range existingLines {
 		trimmed := strings.TrimSpace(line)
-		if upgradeCanonicalBeads && isLegacyWholeBeadsIgnore(trimmed) {
+		if upgradeCanonicalBeads && (isLegacyWholeBeadsIgnore(trimmed) || isObsoleteBeadsRuntimeUnignore(trimmed)) {
 			removedLegacyBeadsIgnore = true
 			continue
 		}

--- a/cmd/gc/gitignore_test.go
+++ b/cmd/gc/gitignore_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,14 +14,19 @@ import (
 func TestEnsureGitignoreEntries_CreatesNewFile(t *testing.T) {
 	f := fsys.NewFake()
 
-	if err := ensureGitignoreEntries(f, "/city", []string{".gc/", ".beads/*", "!.beads/config.yaml", "!.beads/metadata.json"}); err != nil {
+	if err := ensureGitignoreEntries(f, "/city", cityGitignoreEntries); err != nil {
 		t.Fatalf("ensureGitignoreEntries: %v", err)
 	}
 
 	got := string(f.Files[filepath.Join("/city", ".gitignore")])
-	for _, want := range []string{".gc/", ".beads/*", "!.beads/config.yaml", "!.beads/metadata.json"} {
+	for _, want := range cityGitignoreEntries {
 		if !strings.Contains(got, want) {
 			t.Errorf(".gitignore missing %q; got:\n%s", want, got)
+		}
+	}
+	for _, forbidden := range []string{"!.beads/config.yaml", "!.beads/metadata.json"} {
+		if strings.Contains(got, forbidden) {
+			t.Errorf(".gitignore should keep %q ignored; got:\n%s", forbidden, got)
 		}
 	}
 	if !strings.Contains(got, "# Gas City") {
@@ -27,7 +34,7 @@ func TestEnsureGitignoreEntries_CreatesNewFile(t *testing.T) {
 	}
 }
 
-func TestEnsureGitignoreEntries_RigEntriesTrackCanonicalBeadsFilesOnly(t *testing.T) {
+func TestEnsureGitignoreEntries_RigEntriesKeepBeadsRuntimeIgnored(t *testing.T) {
 	f := fsys.NewFake()
 
 	if err := ensureGitignoreEntries(f, "/rig", rigGitignoreEntries); err != nil {
@@ -40,18 +47,68 @@ func TestEnsureGitignoreEntries_RigEntriesTrackCanonicalBeadsFilesOnly(t *testin
 			t.Errorf("rig .gitignore missing %q; got:\n%s", want, got)
 		}
 	}
-	for _, forbidden := range []string{".gc/", "hooks/", ".runtime/"} {
+	for _, forbidden := range []string{".gc/", "hooks/", ".runtime/", "!.beads/config.yaml", "!.beads/metadata.json"} {
 		if strings.Contains(got, forbidden) {
 			t.Errorf("rig .gitignore should not contain %q; got:\n%s", forbidden, got)
 		}
 	}
 }
 
+func TestEnsureGitignoreEntries_BeadsRuntimeFilesSurviveGitClean(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+
+	if err := ensureGitignoreEntries(fsys.OSFS{}, repo, rigGitignoreEntries); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+	runGit(t, repo, "add", ".gitignore")
+
+	beadsDir := filepath.Join(repo, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir .beads/dolt: %v", err)
+	}
+	for _, rel := range []string{
+		filepath.Join(".beads", "config.yaml"),
+		filepath.Join(".beads", "metadata.json"),
+		filepath.Join(".beads", "dolt", "db"),
+	} {
+		if err := os.WriteFile(filepath.Join(repo, rel), []byte("local runtime state\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	out := runGit(t, repo, "clean", "-fdn")
+	for _, forbidden := range []string{
+		filepath.Join(".beads", "config.yaml"),
+		filepath.Join(".beads", "metadata.json"),
+		filepath.Join(".beads", "dolt"),
+	} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("git clean -fd would remove %s; dry-run output:\n%s", forbidden, out)
+		}
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
 func TestEnsureGitignoreEntries_SkipsExisting(t *testing.T) {
 	f := fsys.NewFake()
-	f.Files[filepath.Join("/city", ".gitignore")] = []byte(".gc/\n.beads/\n/.beads/\nnode_modules/\n")
+	f.Files[filepath.Join("/city", ".gitignore")] = []byte(".gc/\n.beads/\n/.beads/\n!.beads/config.yaml\n!.beads/metadata.json\nnode_modules/\n")
 
-	if err := ensureGitignoreEntries(f, "/city", []string{".gc/", ".beads/*", "!.beads/config.yaml", "!.beads/metadata.json"}); err != nil {
+	if err := ensureGitignoreEntries(f, "/city", cityGitignoreEntries); err != nil {
 		t.Fatalf("ensureGitignoreEntries: %v", err)
 	}
 
@@ -61,12 +118,12 @@ func TestEnsureGitignoreEntries_SkipsExisting(t *testing.T) {
 		t.Errorf(".gc/ appears %d times, want 1; got:\n%s", strings.Count(got, ".gc/"), got)
 	}
 	// Canonical .beads rules should be added.
-	for _, want := range []string{".beads/*", "!.beads/config.yaml", "!.beads/metadata.json"} {
+	for _, want := range []string{".beads/*", "!.beads/identity.toml"} {
 		if !strings.Contains(got, want) {
 			t.Errorf(".gitignore missing %q; got:\n%s", want, got)
 		}
 	}
-	for _, legacy := range []string{"\n.beads/\n", "\n/.beads/\n"} {
+	for _, legacy := range []string{"\n.beads/\n", "\n/.beads/\n", "\n!.beads/config.yaml\n", "\n!.beads/metadata.json\n"} {
 		if strings.Contains("\n"+got, legacy) {
 			t.Errorf("legacy .beads ignore %q should be removed; got:\n%s", strings.TrimSpace(legacy), got)
 		}
@@ -98,7 +155,7 @@ func TestEnsureGitignoreEntries_Idempotent(t *testing.T) {
 
 func TestEnsureGitignoreEntries_NoOpWhenAllPresent(t *testing.T) {
 	f := fsys.NewFake()
-	original := ".gc/\n.beads/*\n!.beads/config.yaml\n!.beads/metadata.json\n!.beads/identity.toml\nhooks/\n.runtime/\n"
+	original := ".gc/\n.beads/*\n!.beads/identity.toml\nhooks/\n.runtime/\n"
 	f.Files[filepath.Join("/city", ".gitignore")] = []byte(original)
 
 	if err := ensureGitignoreEntries(f, "/city", cityGitignoreEntries); err != nil {
@@ -157,8 +214,8 @@ func TestDoInit_GitignoreIdempotent(t *testing.T) {
 
 // TestEnsureGitignoreEntries_IdentityTomlNegationPresent locks designer §6:
 // both city- and rig-rendered .gitignore must contain
-// "!.beads/identity.toml" so the identity file is committed alongside
-// .beads/config.yaml and .beads/metadata.json.
+// "!.beads/identity.toml" so the identity file remains commit-eligible while
+// runtime bead state stays ignored.
 func TestEnsureGitignoreEntries_IdentityTomlNegationPresent(t *testing.T) {
 	for _, tc := range []struct {
 		name    string


### PR DESCRIPTION
## Summary
- keep `.beads/config.yaml` and `.beads/metadata.json` ignored in generated city/rig `.gitignore` entries
- migrate older config/metadata negation patterns out of refreshed `.gitignore` files
- add a git-clean dry-run regression test for `.beads/config.yaml`, `.beads/metadata.json`, and `.beads/dolt/`

## Verification
- go test ./cmd/gc -run 'TestEnsureGitignoreEntries|TestDoInit_Gitignore' -count=1\n- go test ./cmd/gc -run 'TestEnsureGitignoreEntries|TestDoInit_Gitignore|TestDoInit_WritesGitignoreEntries|TestDoInit' -count=1\n- go test ./internal/beads/contract -run 'TestNoExternalIdentityWriters|TestProjectIdentity' -count=1\n- git diff --check\n- go vet ./...\n\n## Broad Gate Notes\n- `go test ./cmd/gc -count=1` fails only on parent `/home/jaword/projects/gc-management` pack drift: `packs/maintainer-pr-review/pack.toml` still has deprecated `[formulas].dir`, affecting `TestRigAnywhere_ResolveRigToContext`.\n- pre-commit hook is active and ran. Its lint/generation/go vet portions passed.\n- `make test-fast-parallel` failed on unrelated local issues: nested `worktrees/ga-gjnt7` scanner failures in `internal/beads`, `internal/logutil`, `test/docsync`, plus the same parent-city pack drift in `cmd/gc`.\n- logs: `/tmp/gc-local-tests.Hkcj4I/unit-core.log` and `/tmp/gc-local-tests.Hkcj4I/unit-cmd-gc-6-of-6.log`.\n\nNote: `git clean -fdx` intentionally ignores `.gitignore`; review/test cleanup must still avoid `-x` at rig roots.