### PR TITLE
feat(refinery,polecat): rich PR bodies + detailed commit-message guidance

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -253,9 +253,16 @@ git status                  # Must be clean
 git log origin/{{base_branch}}..HEAD --oneline  # Must show your commits
 ```
 
-If uncommitted changes exist:
+If uncommitted changes exist, commit them with a body explaining what
+slipped through the `implement` step (typically a self-review touch-up,
+test addition, or formatter run):
 ```bash
-git add -A && git commit -m "<type>: <description> ({{issue}})"
+git add -A
+git commit -m "<type>: <imperative subject> ({{issue}})" -m "$(cat <<'BODY'
+<Explain what these residual changes are: a self-review fix,
+test-only addition, formatter run, etc. Be specific.>
+BODY
+)"
 ```
 
 NEVER discard implementation changes with `git checkout -- .`
@@ -276,7 +283,12 @@ git status --porcelain
 ```
 If ANY output (untracked files, uncommitted changes):
 ```bash
-git add -A && git commit -m "chore: capture remaining work ({{issue}})"
+git add -A
+git commit -m "chore: capture remaining work ({{issue}})" -m "$(cat <<'BODY'
+<Explain the remaining changes discovered by final clean-state
+verification and why they are safe to hand off.>
+BODY
+)"
 ```
 This is a belt-and-suspenders check — self-review should have caught this,
 but we never push with untracked work left behind.

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -706,7 +706,7 @@ PR_BODY_FILE=$(mktemp)
   echo
   echo "## Refinery handoff"
   echo
-  printf -- '- Issue: `%s` (%s%s)\n' "$WORK" "$ISSUE_TYPE" "${ISSUE_PRIORITY:+, $ISSUE_PRIORITY}"
+  printf -- '- Issue: `%s` (%s%s)\n' "$WORK" "$ISSUE_TYPE" "${ISSUE_PRIORITY:+, P$ISSUE_PRIORITY}"
   printf -- '- Source branch: `%s`\n' "$BRANCH"
   printf -- '- Target: `%s`\n' "$TARGET"
   printf -- '- Rebased on `%s` via Gastown Refinery.\n' "$TARGET"

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -672,20 +672,45 @@ fetch. STOP, fetch the latest branch, rebase your temp branch again, and
 retry with `--force-with-lease`. Do not use plain `--force`.
 
 **2. Reuse, create, or discover the pull request:**
+
+Read the bead's description and notes once and stage them into a PR body
+file (using `--body-file` avoids quoting/encoding hazards with multi-line
+markdown). The body always carries the bead's full description (the
+"why"), and includes the polecat's implementation notes (the "what")
+when present.
+
 ```bash
-EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
-ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.[0].title')
-PR_BODY=$(cat <<EOF
-## Summary
+WORK_JSON=$(gc bd show $WORK --json)
+EXISTING_PR=$(printf '%s' "$WORK_JSON" | jq -r '.[0].metadata.existing_pr // empty')
+ISSUE_TITLE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].title')
+ISSUE_DESC=$(printf '%s' "$WORK_JSON" | jq -r '.[0].description // empty')
+ISSUE_NOTES=$(printf '%s' "$WORK_JSON" | jq -r '.[0].notes // empty')
+ISSUE_TYPE=$(printf '%s' "$WORK_JSON" | jq -r '.[0].issue_type // "task"')
+ISSUE_PRIORITY=$(printf '%s' "$WORK_JSON" | jq -r '.[0].priority // empty')
 
-Automated pull request published by Gastown Refinery.
-
-- Issue: $WORK
-- Branch: $BRANCH
-- Target: $TARGET
-
-EOF
-)
+PR_BODY_FILE=$(mktemp)
+{
+  echo "## Summary"
+  echo
+  if [ -n "$ISSUE_DESC" ]; then
+    printf '%s\n' "$ISSUE_DESC"
+  else
+    printf 'Refinery handoff for `%s` (no bead description recorded).\n' "$WORK"
+  fi
+  if [ -n "$ISSUE_NOTES" ]; then
+    echo
+    echo "## Implementation notes"
+    echo
+    printf '%s\n' "$ISSUE_NOTES"
+  fi
+  echo
+  echo "## Refinery handoff"
+  echo
+  printf -- '- Issue: `%s` (%s%s)\n' "$WORK" "$ISSUE_TYPE" "${ISSUE_PRIORITY:+, $ISSUE_PRIORITY}"
+  printf -- '- Source branch: `%s`\n' "$BRANCH"
+  printf -- '- Target: `%s`\n' "$TARGET"
+  printf -- '- Rebased on `%s` via Gastown Refinery.\n' "$TARGET"
+} > "$PR_BODY_FILE"
 
 if [ -n "$EXISTING_PR" ]; then
   PR_REF="$EXISTING_PR"
@@ -695,7 +720,7 @@ else
       --base "$TARGET" \
       --head "$BRANCH" \
       --title "$ISSUE_TITLE ($WORK)" \
-      --body "$PR_BODY" 2>/dev/null || true)
+      --body-file "$PR_BODY_FILE" 2>/dev/null || true)
 
     if [ -z "$PR_URL" ]; then
       PR_URL=$(gh pr view "$BRANCH" --json url -q '.url')
@@ -728,7 +753,7 @@ else
         --arg title "$ISSUE_TITLE ($WORK)" \
         --arg head "$BRANCH" \
         --arg base "$TARGET" \
-        --arg body "$PR_BODY" \
+        --rawfile body "$PR_BODY_FILE" \
         '{title:$title, head:$head, base:$base, body:$body}')
       CREATED=$(curl_gh_api "$PR_ERR" \
         -X POST "$API/pulls" \
@@ -764,6 +789,8 @@ else
   fi
   PR_REF="$BRANCH"
 fi
+
+rm -f "$PR_BODY_FILE"
 ```
 
 **3. Verify the pull request exists:**

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
@@ -195,15 +195,15 @@ BODY
 Commit types: feat, fix, refactor, perf, test, docs, chore
 
 **Examples of strong subjects + bodies:**
-- `fix(boson): handle null pin_set in resolve_sdc_target_patterns (pa-xxxx)`
-  body: explains the iter-104 hang traceback, the input shape that
-  triggered the loop, the polars `is_in` fix, and the >1024-pin threshold
-- `perf(nucleus): vectorize _section_key fingerprint (pa-xxxx)`
-  body: cites the cProfile cumtime delta, names the call site that
-  drove the regression, notes why a Python dict still wins on small N
+- `fix(session): preserve lifecycle metadata during crash adoption (ga-xxxx)`
+  body: explains the stale session projection, the resume path that
+  lost metadata, the projection update, and the focused adoption test
+- `perf(events): batch typed payload registration lookups (ga-xxxx)`
+  body: cites the event fan-out profile, names the registry call site
+  that drove the regression, and notes why the cache stays read-only
 
 **Weak commits to avoid** (refinery/reviewer can't tell what's going on):
-- `fix: stuff (pa-xxxx)`
+- `fix: stuff (ga-xxxx)`
 - `perf: speed up the slow loop`
 - `refactor` with no body
 

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
@@ -170,13 +170,42 @@ Do the actual implementation work.
 from load-context. Focus on fixing the specific issue that caused
 rejection — don't redo everything.
 
-**Commit frequently:**
+**Commit frequently with detailed messages.** Every commit gets a
+subject AND a body. The body is what makes the repo navigable a year
+from now — the reviewer (and future-you) needs to understand *why* the
+change exists, not just *what* the diff did. The diff already shows
+the what.
+
 ```bash
 git add <files>
-git commit -m "<type>: <description> ({{issue}})"
+git commit -m "<type>: <imperative subject> ({{issue}})" -m "$(cat <<'BODY'
+<1-3 paragraph explanation:>
+- The motivation: which bug, regression, design decision, or upstream
+  request drove this commit
+- What the change actually does at a higher level than the diff
+- Anything non-obvious about the approach: trade-offs taken, paths not
+  chosen, hidden constraints honored
+- Validation: which tests/benchmarks/manual checks confirmed correctness
+
+Note any follow-ups, deferred edge cases, or downstream impacts here.
+BODY
+)"
 ```
 
-Commit types: feat, fix, refactor, test, docs, chore
+Commit types: feat, fix, refactor, perf, test, docs, chore
+
+**Examples of strong subjects + bodies:**
+- `fix(boson): handle null pin_set in resolve_sdc_target_patterns (pa-xxxx)`
+  body: explains the iter-104 hang traceback, the input shape that
+  triggered the loop, the polars `is_in` fix, and the >1024-pin threshold
+- `perf(nucleus): vectorize _section_key fingerprint (pa-xxxx)`
+  body: cites the cProfile cumtime delta, names the call site that
+  drove the regression, notes why a Python dict still wins on small N
+
+**Weak commits to avoid** (refinery/reviewer can't tell what's going on):
+- `fix: stuff (pa-xxxx)`
+- `perf: speed up the slow loop`
+- `refactor` with no body
 
 **Discovered work (outside scope):**
 ```bash
@@ -241,9 +270,16 @@ git status                  # Must be clean
 git log origin/{{base_branch}}..HEAD --oneline  # Must show your commits
 ```
 
-If uncommitted changes exist:
+If uncommitted changes exist, commit them with a body explaining what
+slipped through the `implement` step (typically a self-review touch-up,
+test addition, or formatter run):
 ```bash
-git add -A && git commit -m "<type>: <description> ({{issue}})"
+git add -A
+git commit -m "<type>: <imperative subject> ({{issue}})" -m "$(cat <<'BODY'
+<Explain what these residual changes are: a self-review fix,
+test-only addition, formatter run, etc. Be specific.>
+BODY
+)"
 ```
 
 NEVER discard implementation changes with `git checkout -- .`


### PR DESCRIPTION
## Summary

Two prompt-template improvements aimed at the same gap: **the bead's full context isn't carried into the artifacts the team reviews afterward.**

### Refinery: richer PR bodies

The refinery's PR-creation step in `mol-refinery-patrol.toml` previously hardcoded a 6-line shell heredoc:

```
## Summary
Automated pull request published by Gastown Refinery.
- Issue: pa-xxxxxx
- Branch: polecat/pa-xxxxxx
- Target: main
```

The bead itself often contains a full reproducer, root-cause analysis, or validation log (especially refinery replacement PRs for stuck work). None of it made it into the PR — reviewers had to bounce back to beads to figure out what each change was even for.

New template reads the bead's description and notes via `gc bd show $WORK --json` and stages a multi-section PR body to a temp file (`--body-file` avoids heredoc quoting hazards for markdown content containing backticks/dollar signs/etc.):

```
## Summary           — bead description (or fallback if empty)
## Implementation    — polecat's notes (skipped if empty)
## Refinery handoff  — issue ID, branch, target, type/priority
```

### Polecat: detailed commits required, not optional

The existing `implement` step in `mol-polecat-base.toml` said only:

\`\`\`
**Commit frequently:**
git commit -m "<type>: <description> ({{issue}})"
\`\`\`

A one-line subject with no body guidance. Polecats were following the template verbatim and shipping diffs whose history reads as a string of \"fix: stuff\" subjects.

New template requires every commit to carry a body and explains what it should contain (motivation, what the change does at a higher level than the diff, non-obvious approach choices, validation). Includes positive examples and explicitly calls out the weak patterns to avoid. Same treatment applied to the self-review residual-commit path.

## Why now

In one recent session we landed 11 PRs through the refinery and the bodies were all the 6-line auto-template. Several were debugging Modal infra cascades where the reasoning lived entirely in the bead and was never lifted into the PR. The reviewer experience was bad.

## Test plan

- [ ] Build a gc binary with these formula changes
- [ ] Pour a refinery patrol against a real polecat-completed bead
- [ ] Verify the published PR body includes bead description + polecat notes
- [ ] Verify polecats following the new \`implement\` step produce commits with bodies

## Scope

These are pack-template edits only. The `gc` binary embeds these formulas via `go:embed` at build time, so taking effect requires a rebuild + install of `gc`. Until then, refinery PRs and polecat commits use the materialized old templates.

Not touched: `mol-polecat-work`'s `submit-and-exit` step. Its `Implemented: <brief summary>` notes contract is fine as-is and is what the new refinery template reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)