### PR TITLE
fix(maintenance): verify dolt counts before jsonl drop halt

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4773,6 +4773,33 @@ func writeIssuesPayloadDoltStub(t *testing.T, binDir, issuesPayload string) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), body)
 }
 
+func writeIssuesPayloadWithSourceCountDoltStub(t *testing.T, binDir, issuesPayload string, sourceCount int) {
+	t.Helper()
+	body := "#!/bin/sh\n" +
+		"if [ -n \"${DOLT_ARGS_LOG:-}\" ]; then\n" +
+		"  printf '%s\\n' \"$*\" >> \"$DOLT_ARGS_LOG\"\n" +
+		"fi\n" +
+		"case \"$*\" in\n" +
+		"  *\"SHOW TABLES FROM\"*\"LIKE 'wisps'\"*)\n" +
+		"    printf 'Tables_in_db\\nwisps\\n'\n" +
+		"    ;;\n" +
+		"  *\"SHOW DATABASES\"*)\n" +
+		"    printf 'Database\\nbeads\\n'\n" +
+		"    ;;\n" +
+		"  *\"COUNT(\"*\"FROM \\`beads\\`.issues\"*)\n" +
+		"    printf 'row_count\\n" + strconv.Itoa(sourceCount) + "\\n'\n" +
+		"    ;;\n" +
+		"  *\"FROM \\`beads\\`.issues\"*)\n" +
+		"    printf '%s\\n' '" + issuesPayload + "'\n" +
+		"    ;;\n" +
+		"  *\"SELECT *\"*)\n" +
+		"    printf '{\"rows\":[]}\\n'\n" +
+		"    ;;\n" +
+		"esac\n" +
+		"exit 0\n"
+	writeExecutable(t, filepath.Join(binDir, "dolt"), body)
+}
+
 func writeIssueRowsDoltStub(t *testing.T, binDir string, rows []string) {
 	t.Helper()
 	writeIssuesPayloadDoltStub(t, binDir, `{"rows":[`+strings.Join(rows, ",")+`]}`)
@@ -5136,6 +5163,75 @@ func TestJsonlExportSkipsSpikeCheckBelowMinPrev(t *testing.T) {
 	}
 	if strings.Contains(string(mailData), "ESCALATION: JSONL spike") {
 		t.Fatalf("spike escalation fired despite prev<MIN_PREV; mail log:\n%s", mailData)
+	}
+}
+
+func TestJsonlExportSuppressesDropSpikeWhenDoltSourceCountHealthy(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+
+	initSeedArchive(t, archiveRepo, 100)
+	writeIssuesPayloadWithSourceCountDoltStub(t, binDir, `{"rows":[]}`, 120)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+
+	mailData, err := os.ReadFile(mailLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(mail log): %v", err)
+	}
+	if strings.Contains(string(mailData), "ESCALATION: JSONL spike") {
+		t.Fatalf("spike escalation fired despite healthy Dolt source-of-truth count; mail log:\n%s", mailData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if strings.Contains(string(gcData), "HALTED on spike detection") {
+		t.Fatalf("healthy Dolt source-of-truth count should suppress HALT; gc log:\n%s", gcData)
+	}
+	if !strings.Contains(string(gcData), "DOG_DONE: jsonl — exported") {
+		t.Fatalf("expected normal export summary after source-of-truth suppression; gc log:\n%s", gcData)
+	}
+}
+
+func TestJsonlExportPreservesDropSpikeWhenDoltSourceCountAlsoShrank(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+
+	initSeedArchive(t, archiveRepo, 100)
+	writeIssuesPayloadWithSourceCountDoltStub(t, binDir, `{"rows":[]}`, 10)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+
+	mailData, err := os.ReadFile(mailLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(mail log): %v", err)
+	}
+	if !strings.Contains(string(mailData), "ESCALATION: JSONL spike") {
+		t.Fatalf("expected spike escalation when Dolt source-of-truth count also shrank; mail log:\n%s", mailData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "HALTED on spike detection") {
+		t.Fatalf("expected HALT when source-of-truth also confirms the drop; gc log:\n%s", gcData)
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -773,6 +773,56 @@ valid_database_identifier() {
     return 0
 }
 
+read_source_issue_count() {
+    local db="$1"
+    local output
+    local count
+
+    if ! output=$(dolt_sql -r csv -q "SELECT COUNT(*) AS row_count FROM \`$db\`.issues $SCRUB_FILTER" 2>/dev/null); then
+        return 1
+    fi
+    count=$(printf '%s\n' "$output" | tail -n 1 | tr -d '\r')
+    case "$count" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+    esac
+    printf '%s\n' "$count"
+}
+
+should_halt_for_jsonl_spike() {
+    local db="$1"
+    local prev_count="$2"
+    local current_count="$3"
+    local threshold="$4"
+    local source_count
+    local source_drop
+
+    # Growth spikes are still suspicious. Only drop spikes can be suppressed by
+    # checking the Dolt source-of-truth behind the passive JSONL export.
+    if [ "$current_count" -ge "$prev_count" ]; then
+        return 0
+    fi
+
+    if ! source_count=$(read_source_issue_count "$db"); then
+        echo "jsonl-export: source-of-truth count unavailable for $db; preserving JSONL spike halt" >&2
+        return 0
+    fi
+
+    if [ "$source_count" -ge "$prev_count" ]; then
+        echo "jsonl-export: suppressing JSONL drop spike for $db; source count $source_count >= previous $prev_count" >&2
+        return 1
+    fi
+
+    source_drop=$(( (prev_count - source_count) * 100 / prev_count ))
+    if [ "$source_drop" -le "$threshold" ]; then
+        echo "jsonl-export: suppressing JSONL drop spike for $db; source drop ${source_drop}% <= ${threshold}%" >&2
+        return 1
+    fi
+
+    return 0
+}
+
 while IFS= read -r DB; do
     [ -z "$DB" ] && continue
     TOTAL_DBS=$((TOTAL_DBS + 1))
@@ -893,7 +943,7 @@ while IFS= read -r DB; do
         if [ "$DELTA" -lt 0 ]; then
             DELTA=$(( -DELTA ))
         fi
-        if [ "$DELTA" -gt "$SPIKE_THRESHOLD" ]; then
+        if [ "$DELTA" -gt "$SPIKE_THRESHOLD" ] && should_halt_for_jsonl_spike "$DB" "$PREV_COUNT" "$FILTERED_COUNT" "$SPIKE_THRESHOLD"; then
             HALTED=1
             HALT_DB="$DB"
             HALT_PREV_COUNT="$PREV_COUNT"


### PR DESCRIPTION
## Summary
- consult Dolt source-of-truth row counts before halting on JSONL drop spikes
- suppress passive-export drop alerts when source rows are healthy or within threshold
- add regressions for healthy-source suppression and confirmed-source shrink escalation

## Tests
- bash -n examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
- git diff --check
- go test ./examples/gastown -run TestJsonlExport -count=1
- go test ./examples/gastown -count=1
- go vet ./...
- make test-fast-parallel (fails on unrelated local issues: worktrees/ga-gjnt7 scanner false positives and parent city pack drift in /home/jaword/projects/gc-management/packs/maintainer-pr-review/pack.toml)
