### PR TITLE
Cache HQStore opens

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -121,6 +121,14 @@ var cityFlag string
 // Empty means "discover from cwd or omit."
 var rigFlag string
 
+var hqStoreCache sync.Map // map[string]*hqStoreCacheEntry
+
+type hqStoreCacheEntry struct {
+	ready chan struct{}
+	store *beads.HQStore
+	err   error
+}
+
 // run executes the gc CLI with the given args, writing output to stdout and
 // errors to stderr. Returns the exit code.
 func run(args []string, stdout, stderr io.Writer) int {
@@ -1152,11 +1160,62 @@ func openCompatibleFileStore(scopeRoot, cityPath string) (*beads.FileStore, erro
 }
 
 func openHQStoreAt(scopeRoot, cityPath string) (*beads.HQStore, error) {
+	storeDir, err := canonicalHQStoreDir(scopeRoot)
+	if err != nil {
+		return nil, err
+	}
+	cityPath, err = canonicalHQCityPath(cityPath)
+	if err != nil {
+		return nil, err
+	}
+	scopeRoot = hqStoreScopeRoot(storeDir)
+
+	entry := &hqStoreCacheEntry{ready: make(chan struct{})}
+	actual, loaded := hqStoreCache.LoadOrStore(storeDir, entry)
+	if loaded {
+		cached := actual.(*hqStoreCacheEntry)
+		<-cached.ready
+		return cached.store, cached.err
+	}
+
+	entry.store, entry.err = openHQStoreUncached(scopeRoot, cityPath, storeDir)
+	close(entry.ready)
+	if entry.err != nil {
+		hqStoreCache.Delete(storeDir)
+		return nil, entry.err
+	}
+	return entry.store, nil
+}
+
+func canonicalHQStoreDir(scopeRoot string) (string, error) {
+	storeDir := filepath.Join(scopeRoot, ".gc", "hqstore")
+	abs, err := filepath.Abs(filepath.Clean(storeDir))
+	if err != nil {
+		return "", fmt.Errorf("resolving hqstore dir %q: %w", storeDir, err)
+	}
+	return abs, nil
+}
+
+func canonicalHQCityPath(cityPath string) (string, error) {
+	if strings.TrimSpace(cityPath) == "" {
+		return "", nil
+	}
+	abs, err := filepath.Abs(filepath.Clean(cityPath))
+	if err != nil {
+		return "", fmt.Errorf("resolving hqstore city path %q: %w", cityPath, err)
+	}
+	return abs, nil
+}
+
+func hqStoreScopeRoot(storeDir string) string {
+	return filepath.Dir(filepath.Dir(storeDir))
+}
+
+func openHQStoreUncached(scopeRoot, cityPath, storeDir string) (*beads.HQStore, error) {
 	cfg, err := loadCityConfig(cityPath, io.Discard)
 	if err != nil {
 		cfg = nil
 	}
-	storeDir := filepath.Join(scopeRoot, ".gc", "hqstore")
 	return beads.OpenHQStore(
 		storeDir,
 		beads.WithHQStoreIDPrefix(issuePrefixForScope(scopeRoot, cityPath, cfg)),

--- a/cmd/gc/main_hqstore_cache_test.go
+++ b/cmd/gc/main_hqstore_cache_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestOpenHQStoreAtCachesByStoreDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("opens real HQStore and starts its TTL goroutine")
+	}
+
+	dir := t.TempDir()
+	s0, err := openHQStoreAt(dir, dir)
+	if err != nil {
+		t.Fatalf("openHQStoreAt initial: %v", err)
+	}
+	baseline := runtime.NumGoroutine()
+
+	for i := 0; i < 50; i++ {
+		scopeRoot := dir
+		if i%2 == 1 {
+			scopeRoot = filepath.Join(dir, ".")
+		}
+		s, err := openHQStoreAt(scopeRoot, dir)
+		if err != nil {
+			t.Fatalf("openHQStoreAt call %d: %v", i, err)
+		}
+		if s != s0 {
+			t.Fatalf("call %d returned a different *HQStore (cache miss)", i)
+		}
+	}
+
+	if got := runtime.NumGoroutine(); got > baseline+1 {
+		t.Fatalf("NumGoroutine grew: baseline=%d after-50-calls=%d (want <= baseline+1)", baseline, got)
+	}
+}


### PR DESCRIPTION
## Summary
- cache `openHQStoreAt` results by absolute cleaned `.gc/hqstore` directory
- use an in-flight cache entry so concurrent callers share the first opener instead of creating duplicate TTL sweepers
- add regression coverage for pointer identity and bounded goroutine growth

## Verification
- `go test ./cmd/gc -run TestOpenHQStoreAtCachesByStoreDir -count=1`
- `go test ./cmd/gc -run 'TestOpenHQStoreAtCachesByStoreDir|TestOpenCityStoreAtSupportsHQStoreProvider|TestCollectStoreHealthUsesHQStorePath' -count=1`\n- `go test ./internal/beads -run 'TestHQStore' -count=1`\n- `go vet ./cmd/gc/...`\n- `go vet ./...`\n\n## Known Baseline\n- `make test-fast-parallel` fails in unrelated nested `worktrees/ga-gjnt7` scanner checks: `TestNoBdExecOutsideBeads`, `TestWalkthroughURLStringsStayInContractFile`, `TestDocDirCoverage`. Final log: `/tmp/gc-local-tests.WKpT4H`.\n- `.githooks/pre-commit` was run; changed-file lint and vet passed before the same fast-target baseline failure. Hook log: `/tmp/gc-local-tests.BrihxU`.\n\nBead: ga-r5e32