### PR TITLE
Avoid managed Dolt restart on transient health probe failures

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -921,8 +921,8 @@ func initFileStoreForDir(cityPath, dir string) error {
 
 // healthBeadsProvider checks the bead store's backing service health.
 // For exec providers, fires the "health" operation. For bd (dolt), runs
-// a three-layer health check and attempts recovery on failure. For file
-// provider, always healthy (no-op).
+// a three-layer health check and attempts recovery only for failures that
+// indicate a restart can help. For file provider, always healthy (no-op).
 //
 // Acquires a per-city semaphore to prevent concurrent health/recovery
 // operations from causing a thundering herd when dolt bounces.
@@ -952,6 +952,9 @@ func healthBeadsProvider(cityPath string) error {
 				if !owned {
 					return err
 				}
+				if !managedDoltHealthFailureShouldRecover(err) {
+					return fmt.Errorf("unhealthy (%w); not restarting managed dolt for non-recoverable health failure", err)
+				}
 			}
 			if recErr := runProviderOpWithEnv(script, providerEnv, "recover"); recErr != nil {
 				return fmt.Errorf("unhealthy (%w) and recovery failed: %w", err, recErr)
@@ -980,6 +983,30 @@ func healthBeadsProvider(cityPath string) error {
 		return nil
 	}
 	return nil // file: always healthy
+}
+
+func managedDoltHealthFailureShouldRecover(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "dolt server is in read-only mode") {
+		return true
+	}
+	if strings.Contains(msg, "dolt server not reachable") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no route to host") {
+		return true
+	}
+	if strings.Contains(msg, "dolt query probe failed") ||
+		strings.Contains(msg, "context canceled") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection was closed") ||
+		strings.Contains(msg, "socket state is broken") {
+		return false
+	}
+	return false
 }
 
 func waitForAllBeadsScopesReadyAfterRecovery(cityPath string, timeout time.Duration) error {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -4555,7 +4555,7 @@ set -eu
 printf '%%s\n' "$1" >> %q
 case "$1" in
   health)
-    echo unhealthy >&2
+    echo "dolt server is in read-only mode" >&2
     exit 1
     ;;
   recover)
@@ -4625,6 +4625,60 @@ exit 2
 	opLines := strings.Fields(strings.TrimSpace(string(ops)))
 	if len(opLines) < 2 || opLines[0] != "health" || opLines[1] != "recover" {
 		t.Fatalf("provider ops = %q, want first health then recover", string(ops))
+	}
+}
+
+func TestHealthBeadsProviderDoesNotRecoverManagedDoltQueryProbeFailure(t *testing.T) {
+	cityPath := t.TempDir()
+	writeMinimalCityToml(t, cityPath)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "issue_prefix: gc\ngc.endpoint_origin: managed_city\ngc.endpoint_status: verified\ndolt.auto-start: false\n"
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opsFile := filepath.Join(t.TempDir(), "provider-ops.log")
+	script := gcBeadsBdScriptPath(cityPath)
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptBody := fmt.Sprintf(`#!/bin/sh
+set -eu
+printf '%%s\n' "$1" >> %q
+case "$1" in
+  health)
+    echo "dolt query probe failed (SELECT active_branch())" >&2
+    exit 1
+    ;;
+  recover)
+    echo "recover should not run" >&2
+    exit 0
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`, opsFile)
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+
+	err := healthBeadsProvider(cityPath)
+	if err == nil || !strings.Contains(err.Error(), "not restarting managed dolt") {
+		t.Fatalf("healthBeadsProvider() error = %v, want non-recoverable query probe failure", err)
+	}
+
+	ops, err := os.ReadFile(opsFile)
+	if err != nil {
+		t.Fatalf("read provider ops: %v", err)
+	}
+	opLines := strings.Fields(strings.TrimSpace(string(ops)))
+	if len(opLines) != 1 || opLines[0] != "health" {
+		t.Fatalf("provider ops = %q, want only health", string(ops))
 	}
 }
 


### PR DESCRIPTION
## Summary
- gate managed bd recovery to actionable health failures
- keep automatic recovery for unreachable/read-only Dolt, but do not restart on query-probe/context/socket failures
- add regression coverage that a managed query-probe failure reports unhealthy without running recover

## Tests
- /home/charlie/.local/go/bin/go test ./cmd/gc -run 'TestHealthBeadsProvider'