### PR TITLE
feat(runtime/cloudflare): implement CopyTo via Worker file upload

### DIFF
--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionacp "github.com/gastownhall/gascity/internal/runtime/acp"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
+	sessioncloudflare "github.com/gastownhall/gascity/internal/runtime/cloudflare"
 	sessionexec "github.com/gastownhall/gascity/internal/runtime/exec"
 	sessionhybrid "github.com/gastownhall/gascity/internal/runtime/hybrid"
 	sessionk8s "github.com/gastownhall/gascity/internal/runtime/k8s"
@@ -141,6 +142,8 @@ func newSessionProviderByName(name string, sc config.SessionConfig, cityName, ci
 			return sessionacp.NewProviderWithDir(providerStateDir("acp", cityPath), cfg), nil
 		}
 		return sessionacp.NewProvider(cfg), nil
+	case "cloudflare":
+		return sessioncloudflare.NewProvider()
 	case "k8s":
 		return sessionk8s.NewProvider()
 	case "hybrid":

--- a/internal/runtime/cloudflare/cloudflare.go
+++ b/internal/runtime/cloudflare/cloudflare.go
@@ -116,9 +116,11 @@ func (p *Provider) Stop(name string) error {
 	return err
 }
 
-// Interrupt sends a best-effort SIGINT to the named remote session via exec.
+// Interrupt sends a best-effort SIGINT to user-owned processes in the remote
+// session. Targets the current user only to avoid signalling system daemons in
+// the shared container environment.
 func (p *Provider) Interrupt(name string) error {
-	err := p.exec(context.Background(), name, "pkill -INT -f . 2>/dev/null; true", nil)
+	err := p.exec(context.Background(), name, `pkill -INT -u "$(id -u)" 2>/dev/null; true`, nil)
 	if runtime.IsSessionGone(err) {
 		return nil
 	}
@@ -146,28 +148,28 @@ func (p *Provider) Attach(_ string) error {
 }
 
 // ProcessAlive reports whether any of the named processes are alive in the
-// remote session via a pgrep exec.
+// remote session via a pgrep exec. Uses -E (extended regex) so the | alternation
+// is interpreted correctly, and -- to guard against process names starting with -.
 func (p *Provider) ProcessAlive(name string, processNames []string) bool {
 	if len(processNames) == 0 {
 		return true
 	}
 	pattern := shellQuoteSingle(strings.Join(processNames, "|"))
 	var out execResponse
-	if err := p.exec(context.Background(), name, "pgrep -f "+pattern, &out); err != nil {
+	if err := p.exec(context.Background(), name, "pgrep -Ef -- "+pattern, &out); err != nil {
 		return false
 	}
 	return out.ExitCode == 0
 }
 
-// Nudge sends text content blocks to the named remote session.
+// Nudge sends content blocks to the named remote session. Uses FlattenText so
+// file_path blocks emit a visible placeholder rather than being silently dropped.
 func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
-	var sb strings.Builder
-	for _, block := range content {
-		if block.Type == "text" {
-			sb.WriteString(block.Text)
-		}
+	text := runtime.FlattenText(content)
+	if text == "" {
+		return nil
 	}
-	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"session", name, "nudge"}, nudgeRequest{Text: sb.String()}, nil)
+	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"session", name, "nudge"}, nudgeRequest{Text: text}, nil)
 }
 
 // SetMeta stores session metadata in the remote runtime.
@@ -254,9 +256,11 @@ func (p *Provider) SendKeys(name string, keys ...string) error {
 	return err
 }
 
-// RunLive is not supported: the Cloudflare Worker has no session-live replay endpoint.
+// RunLive is a best-effort no-op: the Cloudflare Worker has no session-live
+// replay endpoint. Returns nil so the reconciler can persist the live-hash and
+// stop re-triggering on every tick.
 func (p *Provider) RunLive(_ string, _ runtime.Config) error {
-	return fmt.Errorf("cloudflare provider does not support RunLive")
+	return nil
 }
 
 // Capabilities reports Cloudflare runtime observation support.

--- a/internal/runtime/cloudflare/cloudflare.go
+++ b/internal/runtime/cloudflare/cloudflare.go
@@ -1,0 +1,521 @@
+package cloudflare
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+const (
+	defaultTimeout      = 30 * time.Second
+	defaultStartTimeout = 120 * time.Second
+	maxResponseBytes    = 1 << 20
+)
+
+// Config holds Cloudflare runtime provider settings.
+type Config struct {
+	// Endpoint is the base URL for the Cloudflare Worker runtime API.
+	Endpoint string
+	// Token is an optional bearer token sent to the Worker runtime API.
+	Token string
+	// Timeout bounds non-start runtime operations.
+	Timeout time.Duration
+	// StartTimeout bounds session start operations.
+	StartTimeout time.Duration
+	// Client is the HTTP client used to call the Worker runtime API.
+	Client *http.Client
+	// ReportActivity enables CanReportActivity in provider capabilities.
+	ReportActivity bool
+}
+
+// Provider manages sessions through a Cloudflare Worker runtime API.
+type Provider struct {
+	endpoint       *url.URL
+	token          string
+	timeout        time.Duration
+	startTimeout   time.Duration
+	client         *http.Client
+	reportActivity bool
+}
+
+var _ runtime.Provider = (*Provider)(nil)
+
+// NewProvider creates a Cloudflare runtime provider from environment variables.
+//
+// Required:
+//   - GC_CLOUDFLARE_RUNTIME_URL
+//
+// Optional:
+//   - GC_CLOUDFLARE_RUNTIME_TOKEN
+func NewProvider() (*Provider, error) {
+	return NewProviderWithConfig(Config{
+		Endpoint: os.Getenv("GC_CLOUDFLARE_RUNTIME_URL"),
+		Token:    os.Getenv("GC_CLOUDFLARE_RUNTIME_TOKEN"),
+	})
+}
+
+// NewProviderWithConfig creates a Cloudflare runtime provider.
+func NewProviderWithConfig(cfg Config) (*Provider, error) {
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	if endpoint == "" {
+		return nil, fmt.Errorf("cloudflare runtime endpoint is required")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parsing cloudflare runtime endpoint: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("cloudflare runtime endpoint must be an absolute URL")
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	startTimeout := cfg.StartTimeout
+	if startTimeout <= 0 {
+		startTimeout = defaultStartTimeout
+	}
+	client := cfg.Client
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+
+	return &Provider{
+		endpoint:       parsed,
+		token:          cfg.Token,
+		timeout:        timeout,
+		startTimeout:   startTimeout,
+		client:         client,
+		reportActivity: cfg.ReportActivity,
+	}, nil
+}
+
+// Start creates a new remote session.
+func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	body := startConfigFromRuntime(cfg)
+	if err := p.do(ctx, p.startTimeout, http.MethodPost, []string{"sessions", name, "start"}, body, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Stop destroys the named remote session. Missing sessions are treated as
+// already stopped.
+func (p *Provider) Stop(name string) error {
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "stop"}, nil, nil)
+	if runtime.IsSessionGone(err) {
+		return nil
+	}
+	return err
+}
+
+// Interrupt sends a best-effort interrupt to the named remote session.
+func (p *Provider) Interrupt(name string) error {
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "interrupt"}, nil, nil)
+	if runtime.IsSessionGone(err) {
+		return nil
+	}
+	return err
+}
+
+// IsRunning reports whether the named remote session is running.
+func (p *Provider) IsRunning(name string) bool {
+	var out statusResponse
+	if err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"sessions", name, "running"}, nil, &out); err != nil {
+		return false
+	}
+	return out.Running
+}
+
+// IsAttached reports whether an operator is attached to the named remote session.
+func (p *Provider) IsAttached(name string) bool {
+	var out statusResponse
+	if err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"sessions", name, "attached"}, nil, &out); err != nil {
+		return false
+	}
+	return out.Attached
+}
+
+// Attach is not supported because the Cloudflare runtime API has no local TTY.
+func (p *Provider) Attach(_ string) error {
+	return fmt.Errorf("cloudflare provider does not support attach")
+}
+
+// ProcessAlive reports whether the expected process is alive in the remote
+// session.
+func (p *Provider) ProcessAlive(name string, processNames []string) bool {
+	if len(processNames) == 0 {
+		return true
+	}
+	var out statusResponse
+	body := processAliveRequest{ProcessNames: processNames}
+	if err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "process-alive"}, body, &out); err != nil {
+		return false
+	}
+	return out.Alive
+}
+
+// Nudge sends structured content to the named remote session.
+func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
+	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "nudge"}, nudgeRequest{Content: content}, nil)
+}
+
+// SetMeta stores session metadata in the remote runtime.
+func (p *Provider) SetMeta(name, key, value string) error {
+	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "meta", key}, metaRequest{Value: value}, nil)
+}
+
+// GetMeta retrieves session metadata from the remote runtime.
+func (p *Provider) GetMeta(name, key string) (string, error) {
+	var out metaResponse
+	err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"sessions", name, "meta", key}, nil, &out)
+	if runtime.IsSessionGone(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return out.Value, nil
+}
+
+// RemoveMeta removes session metadata from the remote runtime.
+func (p *Provider) RemoveMeta(name, key string) error {
+	err := p.do(context.Background(), p.timeout, http.MethodDelete, []string{"sessions", name, "meta", key}, nil, nil)
+	if runtime.IsSessionGone(err) {
+		return nil
+	}
+	return err
+}
+
+// Peek captures recent output from the named remote session.
+func (p *Provider) Peek(name string, lines int) (string, error) {
+	var out peekResponse
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "peek"}, peekRequest{Lines: lines}, &out)
+	if err != nil {
+		return "", err
+	}
+	return out.Output, nil
+}
+
+// ListRunning returns remote session names with the given prefix.
+func (p *Provider) ListRunning(prefix string) ([]string, error) {
+	var out listResponse
+	err := p.doList(context.Background(), prefix, &out)
+	if err != nil {
+		return nil, err
+	}
+	return out.Names, nil
+}
+
+// GetLastActivity returns the last remote activity timestamp.
+func (p *Provider) GetLastActivity(name string) (time.Time, error) {
+	var out activityResponse
+	err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"sessions", name, "last-activity"}, nil, &out)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if strings.TrimSpace(out.LastActivity) == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, out.LastActivity)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parsing cloudflare last activity for %q: %w", name, err)
+	}
+	return t, nil
+}
+
+// ClearScrollback clears the remote output buffer.
+func (p *Provider) ClearScrollback(name string) error {
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "clear-scrollback"}, nil, nil)
+	if runtime.IsSessionGone(err) {
+		return nil
+	}
+	return err
+}
+
+// CopyTo asks the remote runtime to copy a host-visible path into the session.
+func (p *Provider) CopyTo(name, src, relDst string) error {
+	if _, err := os.Stat(src); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat copy source %q: %w", src, err)
+	}
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "copy-to"}, copyRequest{Src: src, RelDst: relDst}, nil)
+	if runtime.IsSessionGone(err) {
+		return nil
+	}
+	return err
+}
+
+// SendKeys sends raw key tokens to the remote session.
+func (p *Provider) SendKeys(name string, keys ...string) error {
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "send-keys"}, sendKeysRequest{Keys: keys}, nil)
+	if runtime.IsSessionGone(err) {
+		return nil
+	}
+	return err
+}
+
+// RunLive reapplies live session commands to the remote session.
+func (p *Provider) RunLive(name string, cfg runtime.Config) error {
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "run-live"}, runLiveRequest{Config: startConfigFromRuntime(cfg)}, nil)
+	if runtime.IsSessionGone(err) {
+		return nil
+	}
+	return err
+}
+
+// Capabilities reports Cloudflare runtime observation support.
+func (p *Provider) Capabilities() runtime.ProviderCapabilities {
+	return runtime.ProviderCapabilities{
+		CanReportActivity: p.reportActivity,
+	}
+}
+
+func (p *Provider) doList(ctx context.Context, prefix string, out any) error {
+	u := p.urlFor("sessions")
+	q := u.Query()
+	if prefix != "" {
+		q.Set("prefix", prefix)
+	}
+	u.RawQuery = q.Encode()
+	return p.doURL(ctx, p.timeout, http.MethodGet, u.String(), nil, out)
+}
+
+func (p *Provider) do(ctx context.Context, timeout time.Duration, method string, parts []string, body any, out any) error {
+	return p.doURL(ctx, timeout, method, p.urlFor(parts...).String(), body, out)
+}
+
+func (p *Provider) doURL(parent context.Context, timeout time.Duration, method, target string, body any, out any) error {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if timeout <= 0 {
+		timeout = p.timeout
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshaling cloudflare runtime request: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, target, reader)
+	if err != nil {
+		return fmt.Errorf("building cloudflare runtime request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	if p.token != "" {
+		req.Header.Set("Authorization", "Bearer "+p.token)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("cloudflare runtime request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return fmt.Errorf("reading cloudflare runtime response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return cloudflareStatusError(resp.StatusCode, target, data)
+	}
+	if out == nil || len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decoding cloudflare runtime response: %w", err)
+	}
+	return nil
+}
+
+func (p *Provider) urlFor(parts ...string) *url.URL {
+	u := *p.endpoint
+	base := strings.TrimRight(u.Path, "/")
+	escaped := make([]string, 0, len(parts))
+	for _, part := range parts {
+		escaped = append(escaped, url.PathEscape(part))
+	}
+	if len(escaped) > 0 {
+		u.Path = base + "/" + strings.Join(escaped, "/")
+	} else {
+		u.Path = base
+	}
+	return &u
+}
+
+func cloudflareStatusError(status int, target string, data []byte) error {
+	msg := statusText(status, data)
+	switch status {
+	case http.StatusNotFound:
+		return fmt.Errorf("%w: cloudflare runtime %s: %s", runtime.ErrSessionNotFound, target, msg)
+	case http.StatusConflict:
+		return fmt.Errorf("%w: cloudflare runtime %s: %s", runtime.ErrSessionExists, target, msg)
+	default:
+		return fmt.Errorf("cloudflare runtime %s: status %d: %s", target, status, msg)
+	}
+}
+
+func statusText(status int, data []byte) string {
+	var payload errorResponse
+	if err := json.Unmarshal(data, &payload); err == nil {
+		switch {
+		case payload.Error != "":
+			return payload.Error
+		case payload.Message != "":
+			return payload.Message
+		}
+	}
+	text := strings.TrimSpace(string(data))
+	if text != "" {
+		return text
+	}
+	return http.StatusText(status)
+}
+
+type errorResponse struct {
+	Error   string `json:"error,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type copyEntry struct {
+	Src    string `json:"src"`
+	RelDst string `json:"rel_dst,omitempty"`
+}
+
+type startConfig struct {
+	WorkDir                string                    `json:"work_dir,omitempty"`
+	Command                string                    `json:"command,omitempty"`
+	Env                    map[string]string         `json:"env,omitempty"`
+	MCPServers             []runtime.MCPServerConfig `json:"mcp_servers,omitempty"`
+	ReadyPromptPrefix      string                    `json:"ready_prompt_prefix,omitempty"`
+	ReadyDelayMs           int                       `json:"ready_delay_ms,omitempty"`
+	ProcessNames           []string                  `json:"process_names,omitempty"`
+	EmitsPermissionWarning bool                      `json:"emits_permission_warning,omitempty"`
+	Nudge                  string                    `json:"nudge,omitempty"`
+	PreStart               []string                  `json:"pre_start,omitempty"`
+	SessionSetup           []string                  `json:"session_setup,omitempty"`
+	SessionSetupScript     string                    `json:"session_setup_script,omitempty"`
+	SessionLive            []string                  `json:"session_live,omitempty"`
+	ProviderName           string                    `json:"provider_name,omitempty"`
+	ProviderOverlayName    string                    `json:"provider_overlay_name,omitempty"`
+	InstallAgentHooks      []string                  `json:"install_agent_hooks,omitempty"`
+	PackOverlayDirs        []string                  `json:"pack_overlay_dirs,omitempty"`
+	OverlayDir             string                    `json:"overlay_dir,omitempty"`
+	CopyFiles              []copyEntry               `json:"copy_files,omitempty"`
+	FingerprintExtra       map[string]string         `json:"fingerprint_extra,omitempty"`
+	PromptSuffix           string                    `json:"prompt_suffix,omitempty"`
+	PromptFlag             string                    `json:"prompt_flag,omitempty"`
+}
+
+func startConfigFromRuntime(cfg runtime.Config) startConfig {
+	copyFiles := make([]copyEntry, 0, len(cfg.CopyFiles))
+	for _, entry := range cfg.CopyFiles {
+		copyFiles = append(copyFiles, copyEntry{
+			Src:    entry.Src,
+			RelDst: entry.RelDst,
+		})
+	}
+	return startConfig{
+		WorkDir:                cfg.WorkDir,
+		Command:                cfg.Command,
+		Env:                    cfg.Env,
+		MCPServers:             cfg.MCPServers,
+		ReadyPromptPrefix:      cfg.ReadyPromptPrefix,
+		ReadyDelayMs:           cfg.ReadyDelayMs,
+		ProcessNames:           cfg.ProcessNames,
+		EmitsPermissionWarning: cfg.EmitsPermissionWarning,
+		Nudge:                  cfg.Nudge,
+		PreStart:               cfg.PreStart,
+		SessionSetup:           cfg.SessionSetup,
+		SessionSetupScript:     cfg.SessionSetupScript,
+		SessionLive:            cfg.SessionLive,
+		ProviderName:           cfg.ProviderName,
+		ProviderOverlayName:    cfg.ProviderOverlayName,
+		InstallAgentHooks:      cfg.InstallAgentHooks,
+		PackOverlayDirs:        cfg.PackOverlayDirs,
+		OverlayDir:             cfg.OverlayDir,
+		CopyFiles:              copyFiles,
+		FingerprintExtra:       cfg.FingerprintExtra,
+		PromptSuffix:           cfg.PromptSuffix,
+		PromptFlag:             cfg.PromptFlag,
+	}
+}
+
+type statusResponse struct {
+	Running  bool `json:"running,omitempty"`
+	Attached bool `json:"attached,omitempty"`
+	Alive    bool `json:"alive,omitempty"`
+}
+
+type processAliveRequest struct {
+	ProcessNames []string `json:"process_names,omitempty"`
+}
+
+type nudgeRequest struct {
+	Content []runtime.ContentBlock `json:"content,omitempty"`
+}
+
+type metaRequest struct {
+	Value string `json:"value"`
+}
+
+type metaResponse struct {
+	Value string `json:"value"`
+}
+
+type peekRequest struct {
+	Lines int `json:"lines,omitempty"`
+}
+
+type peekResponse struct {
+	Output string `json:"output"`
+}
+
+type listResponse struct {
+	Names []string `json:"names"`
+}
+
+type activityResponse struct {
+	LastActivity string `json:"last_activity,omitempty"`
+}
+
+type copyRequest struct {
+	Src    string `json:"src"`
+	RelDst string `json:"rel_dst,omitempty"`
+}
+
+type sendKeysRequest struct {
+	Keys []string `json:"keys,omitempty"`
+}
+
+type runLiveRequest struct {
+	Config startConfig `json:"config"`
+}
+
+func isSessionGone(err error) bool {
+	return err != nil && (runtime.IsSessionGone(err) || errors.Is(err, runtime.ErrSessionNotFound))
+}

--- a/internal/runtime/cloudflare/cloudflare.go
+++ b/internal/runtime/cloudflare/cloudflare.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -101,28 +100,25 @@ func NewProviderWithConfig(cfg Config) (*Provider, error) {
 	}, nil
 }
 
-// Start creates a new remote session.
+// Start creates a new remote session. Maps to POST /session.
 func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) error {
-	body := startConfigFromRuntime(cfg)
-	if err := p.do(ctx, p.startTimeout, http.MethodPost, []string{"sessions", name, "start"}, body, nil); err != nil {
-		return err
-	}
-	return nil
+	body := startRequest{SessionID: name, Config: startConfigFromRuntime(cfg)}
+	return p.do(ctx, p.startTimeout, http.MethodPost, []string{"session"}, body, nil)
 }
 
 // Stop destroys the named remote session. Missing sessions are treated as
 // already stopped.
 func (p *Provider) Stop(name string) error {
-	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "stop"}, nil, nil)
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"session", name, "stop"}, nil, nil)
 	if runtime.IsSessionGone(err) {
 		return nil
 	}
 	return err
 }
 
-// Interrupt sends a best-effort interrupt to the named remote session.
+// Interrupt sends a best-effort SIGINT to the named remote session via exec.
 func (p *Provider) Interrupt(name string) error {
-	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "interrupt"}, nil, nil)
+	err := p.exec(context.Background(), name, "pkill -INT -f . 2>/dev/null; true", nil)
 	if runtime.IsSessionGone(err) {
 		return nil
 	}
@@ -131,20 +127,17 @@ func (p *Provider) Interrupt(name string) error {
 
 // IsRunning reports whether the named remote session is running.
 func (p *Provider) IsRunning(name string) bool {
-	var out statusResponse
-	if err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"sessions", name, "running"}, nil, &out); err != nil {
+	var out sessionStatusResponse
+	if err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"session", name, "status"}, nil, &out); err != nil {
 		return false
 	}
-	return out.Running
+	return out.Alive
 }
 
-// IsAttached reports whether an operator is attached to the named remote session.
-func (p *Provider) IsAttached(name string) bool {
-	var out statusResponse
-	if err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"sessions", name, "attached"}, nil, &out); err != nil {
-		return false
-	}
-	return out.Attached
+// IsAttached always returns false: the Cloudflare runtime has no local TTY and
+// CanReportAttachment is false in Capabilities.
+func (p *Provider) IsAttached(_ string) bool {
+	return false
 }
 
 // Attach is not supported because the Cloudflare runtime API has no local TTY.
@@ -152,34 +145,40 @@ func (p *Provider) Attach(_ string) error {
 	return fmt.Errorf("cloudflare provider does not support attach")
 }
 
-// ProcessAlive reports whether the expected process is alive in the remote
-// session.
+// ProcessAlive reports whether any of the named processes are alive in the
+// remote session via a pgrep exec.
 func (p *Provider) ProcessAlive(name string, processNames []string) bool {
 	if len(processNames) == 0 {
 		return true
 	}
-	var out statusResponse
-	body := processAliveRequest{ProcessNames: processNames}
-	if err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "process-alive"}, body, &out); err != nil {
+	pattern := shellQuoteSingle(strings.Join(processNames, "|"))
+	var out execResponse
+	if err := p.exec(context.Background(), name, "pgrep -f "+pattern, &out); err != nil {
 		return false
 	}
-	return out.Alive
+	return out.ExitCode == 0
 }
 
-// Nudge sends structured content to the named remote session.
+// Nudge sends text content blocks to the named remote session.
 func (p *Provider) Nudge(name string, content []runtime.ContentBlock) error {
-	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "nudge"}, nudgeRequest{Content: content}, nil)
+	var sb strings.Builder
+	for _, block := range content {
+		if block.Type == "text" {
+			sb.WriteString(block.Text)
+		}
+	}
+	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"session", name, "nudge"}, nudgeRequest{Text: sb.String()}, nil)
 }
 
 // SetMeta stores session metadata in the remote runtime.
 func (p *Provider) SetMeta(name, key, value string) error {
-	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "meta", key}, metaRequest{Value: value}, nil)
+	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"session", name, "meta", key}, metaRequest{Value: value}, nil)
 }
 
 // GetMeta retrieves session metadata from the remote runtime.
 func (p *Provider) GetMeta(name, key string) (string, error) {
 	var out metaResponse
-	err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"sessions", name, "meta", key}, nil, &out)
+	err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"session", name, "meta", key}, nil, &out)
 	if runtime.IsSessionGone(err) {
 		return "", nil
 	}
@@ -191,7 +190,7 @@ func (p *Provider) GetMeta(name, key string) (string, error) {
 
 // RemoveMeta removes session metadata from the remote runtime.
 func (p *Provider) RemoveMeta(name, key string) error {
-	err := p.do(context.Background(), p.timeout, http.MethodDelete, []string{"sessions", name, "meta", key}, nil, nil)
+	err := p.do(context.Background(), p.timeout, http.MethodDelete, []string{"session", name, "meta", key}, nil, nil)
 	if runtime.IsSessionGone(err) {
 		return nil
 	}
@@ -201,80 +200,63 @@ func (p *Provider) RemoveMeta(name, key string) error {
 // Peek captures recent output from the named remote session.
 func (p *Provider) Peek(name string, lines int) (string, error) {
 	var out peekResponse
-	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "peek"}, peekRequest{Lines: lines}, &out)
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"session", name, "peek"}, peekRequest{Lines: lines}, &out)
 	if err != nil {
 		return "", err
 	}
 	return out.Output, nil
 }
 
-// ListRunning returns remote session names with the given prefix.
-func (p *Provider) ListRunning(prefix string) ([]string, error) {
-	var out listResponse
-	err := p.doList(context.Background(), prefix, &out)
-	if err != nil {
-		return nil, err
-	}
-	return out.Names, nil
+// ListRunning is not supported: the Cloudflare Worker has no session index endpoint.
+func (p *Provider) ListRunning(_ string) ([]string, error) {
+	return nil, fmt.Errorf("cloudflare provider does not support ListRunning")
 }
 
-// GetLastActivity returns the last remote activity timestamp.
+// GetLastActivity returns the session creation time from the status record.
+// The Cloudflare Worker embeds this in GET /session/:name/status as record.createdAt.
 func (p *Provider) GetLastActivity(name string) (time.Time, error) {
-	var out activityResponse
-	err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"sessions", name, "last-activity"}, nil, &out)
-	if err != nil {
+	var out sessionStatusResponse
+	if err := p.do(context.Background(), p.timeout, http.MethodGet, []string{"session", name, "status"}, nil, &out); err != nil {
 		return time.Time{}, err
 	}
-	if strings.TrimSpace(out.LastActivity) == "" {
+	ts := strings.TrimSpace(out.Record.CreatedAt)
+	if ts == "" {
 		return time.Time{}, nil
 	}
-	t, err := time.Parse(time.RFC3339Nano, out.LastActivity)
+	t, err := time.Parse(time.RFC3339Nano, ts)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parsing cloudflare last activity for %q: %w", name, err)
 	}
 	return t, nil
 }
 
-// ClearScrollback clears the remote output buffer.
+// ClearScrollback clears the remote output buffer via exec.
 func (p *Provider) ClearScrollback(name string) error {
-	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "clear-scrollback"}, nil, nil)
+	err := p.exec(context.Background(), name, "truncate -s0 /workspace/.gc-scrollback 2>/dev/null || true", nil)
 	if runtime.IsSessionGone(err) {
 		return nil
 	}
 	return err
 }
 
-// CopyTo asks the remote runtime to copy a host-visible path into the session.
-func (p *Provider) CopyTo(name, src, relDst string) error {
-	if _, err := os.Stat(src); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("stat copy source %q: %w", src, err)
-	}
-	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "copy-to"}, copyRequest{Src: src, RelDst: relDst}, nil)
-	if runtime.IsSessionGone(err) {
-		return nil
-	}
-	return err
+// CopyTo is not supported: the Cloudflare runtime has no host-to-sandbox file
+// transfer endpoint in this version of the Worker API.
+func (p *Provider) CopyTo(_, _, _ string) error {
+	return fmt.Errorf("cloudflare provider does not support CopyTo")
 }
 
 // SendKeys sends raw key tokens to the remote session.
 func (p *Provider) SendKeys(name string, keys ...string) error {
-	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "send-keys"}, sendKeysRequest{Keys: keys}, nil)
+	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"session", name, "keys"}, sendKeysRequest{Keys: keys}, nil)
 	if runtime.IsSessionGone(err) {
 		return nil
 	}
 	return err
 }
 
-// RunLive reapplies live session commands to the remote session.
-func (p *Provider) RunLive(name string, cfg runtime.Config) error {
-	err := p.do(context.Background(), p.timeout, http.MethodPost, []string{"sessions", name, "run-live"}, runLiveRequest{Config: startConfigFromRuntime(cfg)}, nil)
-	if runtime.IsSessionGone(err) {
-		return nil
-	}
-	return err
+// RunLive is not supported: the Cloudflare Worker has no session-live replay endpoint.
+func (p *Provider) RunLive(_ string, _ runtime.Config) error {
+	return fmt.Errorf("cloudflare provider does not support RunLive")
 }
 
 // Capabilities reports Cloudflare runtime observation support.
@@ -284,14 +266,9 @@ func (p *Provider) Capabilities() runtime.ProviderCapabilities {
 	}
 }
 
-func (p *Provider) doList(ctx context.Context, prefix string, out any) error {
-	u := p.urlFor("sessions")
-	q := u.Query()
-	if prefix != "" {
-		q.Set("prefix", prefix)
-	}
-	u.RawQuery = q.Encode()
-	return p.doURL(ctx, p.timeout, http.MethodGet, u.String(), nil, out)
+// exec posts a shell command to POST /session/:name/exec and decodes the result into out (may be nil).
+func (p *Provider) exec(ctx context.Context, name, cmd string, out any) error {
+	return p.do(ctx, p.timeout, http.MethodPost, []string{"session", name, "exec"}, execRequest{Cmd: cmd}, out)
 }
 
 func (p *Provider) do(ctx context.Context, timeout time.Duration, method string, parts []string, body any, out any) error {
@@ -396,6 +373,11 @@ func statusText(status int, data []byte) string {
 	return http.StatusText(status)
 }
 
+// shellQuoteSingle wraps s in single quotes, escaping any embedded single quotes.
+func shellQuoteSingle(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
 type errorResponse struct {
 	Error   string `json:"error,omitempty"`
 	Message string `json:"message,omitempty"`
@@ -429,6 +411,12 @@ type startConfig struct {
 	FingerprintExtra       map[string]string         `json:"fingerprint_extra,omitempty"`
 	PromptSuffix           string                    `json:"prompt_suffix,omitempty"`
 	PromptFlag             string                    `json:"prompt_flag,omitempty"`
+}
+
+// startRequest is the body for POST /session.
+type startRequest struct {
+	SessionID string      `json:"sessionId"`
+	Config    startConfig `json:"config,omitempty"`
 }
 
 func startConfigFromRuntime(cfg runtime.Config) startConfig {
@@ -465,18 +453,25 @@ func startConfigFromRuntime(cfg runtime.Config) startConfig {
 	}
 }
 
-type statusResponse struct {
-	Running  bool `json:"running,omitempty"`
-	Attached bool `json:"attached,omitempty"`
-	Alive    bool `json:"alive,omitempty"`
+type execRequest struct {
+	Cmd string `json:"cmd"`
 }
 
-type processAliveRequest struct {
-	ProcessNames []string `json:"process_names,omitempty"`
+type execResponse struct {
+	ExitCode int  `json:"exitCode"`
+	Success  bool `json:"success"`
+}
+
+// sessionStatusResponse is the shape of GET /session/:name/status.
+type sessionStatusResponse struct {
+	Alive  bool `json:"alive"`
+	Record struct {
+		CreatedAt string `json:"createdAt"`
+	} `json:"record"`
 }
 
 type nudgeRequest struct {
-	Content []runtime.ContentBlock `json:"content,omitempty"`
+	Text string `json:"text"`
 }
 
 type metaRequest struct {
@@ -495,27 +490,6 @@ type peekResponse struct {
 	Output string `json:"output"`
 }
 
-type listResponse struct {
-	Names []string `json:"names"`
-}
-
-type activityResponse struct {
-	LastActivity string `json:"last_activity,omitempty"`
-}
-
-type copyRequest struct {
-	Src    string `json:"src"`
-	RelDst string `json:"rel_dst,omitempty"`
-}
-
 type sendKeysRequest struct {
 	Keys []string `json:"keys,omitempty"`
-}
-
-type runLiveRequest struct {
-	Config startConfig `json:"config"`
-}
-
-func isSessionGone(err error) bool {
-	return err != nil && (runtime.IsSessionGone(err) || errors.Is(err, runtime.ErrSessionNotFound))
 }

--- a/internal/runtime/cloudflare/cloudflare.go
+++ b/internal/runtime/cloudflare/cloudflare.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -241,10 +242,16 @@ func (p *Provider) ClearScrollback(name string) error {
 	return err
 }
 
-// CopyTo is not supported: the Cloudflare runtime has no host-to-sandbox file
-// transfer endpoint in this version of the Worker API.
-func (p *Provider) CopyTo(_, _, _ string) error {
-	return fmt.Errorf("cloudflare provider does not support CopyTo")
+// CopyTo copies a local file into the named remote session by base64-encoding
+// its content and posting it to POST /session/:name/copy. The Worker enforces a
+// ~1 MiB decoded size limit and rejects path traversal in relDst.
+func (p *Provider) CopyTo(name, src, relDst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("cloudflare CopyTo: reading %s: %w", src, err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+	return p.do(context.Background(), p.timeout, http.MethodPost, []string{"session", name, "copy"}, copyRequest{RelDst: relDst, Content: encoded}, nil)
 }
 
 // SendKeys sends raw key tokens to the remote session.
@@ -496,4 +503,9 @@ type peekResponse struct {
 
 type sendKeysRequest struct {
 	Keys []string `json:"keys,omitempty"`
+}
+
+type copyRequest struct {
+	RelDst  string `json:"relDst"`
+	Content string `json:"content"`
 }

--- a/internal/runtime/cloudflare/cloudflare_test.go
+++ b/internal/runtime/cloudflare/cloudflare_test.go
@@ -2,10 +2,12 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -485,6 +487,120 @@ func TestNudgeDropsEmptyContent(t *testing.T) {
 	}
 	if called {
 		t.Fatal("Nudge made HTTP call for empty content, want no-op")
+	}
+}
+
+func TestCopyToPostsBase64Content(t *testing.T) {
+	var gotPath string
+	var gotBody copyRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "copyto-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	content := []byte("hello cloudflare")
+	if _, err := f.Write(content); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	f.Close()
+
+	if err := p.CopyTo("sess-one", f.Name(), "sub/hello.txt"); err != nil {
+		t.Fatalf("CopyTo: %v", err)
+	}
+	if gotPath != "/session/sess-one/copy" {
+		t.Fatalf("path = %q, want /session/sess-one/copy", gotPath)
+	}
+	if gotBody.RelDst != "sub/hello.txt" {
+		t.Fatalf("relDst = %q, want sub/hello.txt", gotBody.RelDst)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(gotBody.Content)
+	if err != nil {
+		t.Fatalf("decode content: %v", err)
+	}
+	if string(decoded) != string(content) {
+		t.Fatalf("content = %q, want %q", decoded, content)
+	}
+}
+
+func TestCopyToBinaryContent(t *testing.T) {
+	var gotBody copyRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "copyto-bin-*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	binary := []byte{0x00, 0xFF, 0xFE, 0x80, 0x01, 0x02, 0x03}
+	if _, err := f.Write(binary); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	f.Close()
+
+	if err := p.CopyTo("sess-one", f.Name(), "bin.dat"); err != nil {
+		t.Fatalf("CopyTo: %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(gotBody.Content)
+	if err != nil {
+		t.Fatalf("decode content: %v", err)
+	}
+	if string(decoded) != string(binary) {
+		t.Fatalf("binary round-trip mismatch: got %x, want %x", decoded, binary)
+	}
+}
+
+func TestCopyToSurfacesWorkerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = w.Write([]byte(`{"error":"content exceeds 1 MiB limit"}`))
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "copyto-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	f.Close()
+
+	if err := p.CopyTo("sess-one", f.Name(), "file.txt"); err == nil {
+		t.Fatal("CopyTo: want error on 413, got nil")
+	}
+}
+
+func TestCopyToMissingFileReturnsError(t *testing.T) {
+	p, err := NewProviderWithConfig(Config{Endpoint: "http://unused.example"})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+	if err := p.CopyTo("sess-one", "/nonexistent/file.txt", "file.txt"); err == nil {
+		t.Fatal("CopyTo succeeded for missing file, want error")
 	}
 }
 

--- a/internal/runtime/cloudflare/cloudflare_test.go
+++ b/internal/runtime/cloudflare/cloudflare_test.go
@@ -21,10 +21,10 @@ func TestNewProviderRequiresAbsoluteEndpoint(t *testing.T) {
 	}
 }
 
-func TestStartPostsTypedConfig(t *testing.T) {
+func TestStartPostsToSessionCollection(t *testing.T) {
 	var gotPath string
 	var gotAuth string
-	var got startConfig
+	var got startRequest
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.EscapedPath()
@@ -70,23 +70,26 @@ func TestStartPostsTypedConfig(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	if gotPath != "/runtime/sessions/sess-one/start" {
-		t.Fatalf("path = %q, want /runtime/sessions/sess-one/start", gotPath)
+	if gotPath != "/runtime/session" {
+		t.Fatalf("path = %q, want /runtime/session", gotPath)
 	}
 	if gotAuth != "Bearer secret" {
 		t.Fatalf("authorization = %q, want bearer token", gotAuth)
 	}
-	if got.WorkDir != "/work" || got.Command != "codex exec" {
-		t.Fatalf("start config = %+v, missing workdir/command", got)
+	if got.SessionID != "sess-one" {
+		t.Fatalf("sessionId = %q, want sess-one", got.SessionID)
 	}
-	if got.Env["GC_CITY"] != "/city" {
-		t.Fatalf("env = %#v, missing GC_CITY", got.Env)
+	if got.Config.WorkDir != "/work" || got.Config.Command != "codex exec" {
+		t.Fatalf("config = %+v, missing workdir/command", got.Config)
 	}
-	if len(got.ProcessNames) != 1 || got.ProcessNames[0] != "codex" {
-		t.Fatalf("process_names = %#v, want codex", got.ProcessNames)
+	if got.Config.Env["GC_CITY"] != "/city" {
+		t.Fatalf("env = %#v, missing GC_CITY", got.Config.Env)
 	}
-	if len(got.CopyFiles) != 1 || got.CopyFiles[0].Src != "/host/file" || got.CopyFiles[0].RelDst != "file" {
-		t.Fatalf("copy_files = %#v, want stable copy entry", got.CopyFiles)
+	if len(got.Config.ProcessNames) != 1 || got.Config.ProcessNames[0] != "codex" {
+		t.Fatalf("process_names = %#v, want codex", got.Config.ProcessNames)
+	}
+	if len(got.Config.CopyFiles) != 1 || got.Config.CopyFiles[0].Src != "/host/file" || got.Config.CopyFiles[0].RelDst != "file" {
+		t.Fatalf("copy_files = %#v, want stable copy entry", got.Config.CopyFiles)
 	}
 }
 
@@ -124,15 +127,15 @@ func TestStopTreatsNotFoundAsIdempotent(t *testing.T) {
 	}
 }
 
-func TestIsRunningDecodesRemoteState(t *testing.T) {
+func TestIsRunningDecodesStatusEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Fatalf("method = %s, want GET", r.Method)
 		}
-		if r.URL.EscapedPath() != "/sessions/sess-one/running" {
-			t.Fatalf("path = %q, want running endpoint", r.URL.EscapedPath())
+		if r.URL.EscapedPath() != "/session/sess-one/status" {
+			t.Fatalf("path = %q, want /session/sess-one/status", r.URL.EscapedPath())
 		}
-		_, _ = w.Write([]byte(`{"running":true}`))
+		_, _ = w.Write([]byte(`{"alive":true}`))
 	}))
 	defer server.Close()
 
@@ -146,38 +149,34 @@ func TestIsRunningDecodesRemoteState(t *testing.T) {
 	}
 }
 
-func TestListRunningUsesPrefixQuery(t *testing.T) {
-	var gotPrefix string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPrefix = r.URL.Query().Get("prefix")
-		if r.URL.EscapedPath() != "/sessions" {
-			t.Fatalf("path = %q, want /sessions", r.URL.EscapedPath())
-		}
-		_, _ = w.Write([]byte(`{"names":["alpha-1","alpha-2"]}`))
-	}))
-	defer server.Close()
-
-	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+func TestIsAttachedAlwaysReturnsFalse(t *testing.T) {
+	p, err := NewProviderWithConfig(Config{Endpoint: "http://unused.example"})
 	if err != nil {
 		t.Fatalf("NewProviderWithConfig: %v", err)
 	}
-
-	names, err := p.ListRunning("alpha")
-	if err != nil {
-		t.Fatalf("ListRunning: %v", err)
-	}
-	if gotPrefix != "alpha" {
-		t.Fatalf("prefix = %q, want alpha", gotPrefix)
-	}
-	if len(names) != 2 || names[0] != "alpha-1" || names[1] != "alpha-2" {
-		t.Fatalf("names = %#v, want alpha sessions", names)
+	if p.IsAttached("any") {
+		t.Fatal("IsAttached = true, want false (unsupported)")
 	}
 }
 
-func TestGetLastActivityParsesRFC3339Nano(t *testing.T) {
-	want := time.Date(2026, 5, 24, 2, 14, 25, 123, time.UTC)
+func TestListRunningNotSupported(t *testing.T) {
+	p, err := NewProviderWithConfig(Config{Endpoint: "http://unused.example"})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+	names, err := p.ListRunning("any")
+	if err == nil {
+		t.Fatalf("ListRunning succeeded, want error")
+	}
+	if names != nil {
+		t.Fatalf("ListRunning names = %v, want nil", names)
+	}
+}
+
+func TestGetLastActivityParsesCreatedAt(t *testing.T) {
+	want := time.Date(2026, 5, 24, 2, 14, 25, 0, time.UTC)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(activityResponse{LastActivity: want.Format(time.RFC3339Nano)})
+		_, _ = w.Write([]byte(`{"alive":true,"record":{"createdAt":"` + want.Format(time.RFC3339Nano) + `"}}`))
 	}))
 	defer server.Close()
 
@@ -195,11 +194,11 @@ func TestGetLastActivityParsesRFC3339Nano(t *testing.T) {
 	}
 }
 
-func TestNudgePostsContentBlocks(t *testing.T) {
+func TestNudgePostsText(t *testing.T) {
 	var got nudgeRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.EscapedPath() != "/sessions/sess-one/nudge" {
-			t.Fatalf("path = %q, want nudge endpoint", r.URL.EscapedPath())
+		if r.URL.EscapedPath() != "/session/sess-one/nudge" {
+			t.Fatalf("path = %q, want /session/sess-one/nudge", r.URL.EscapedPath())
 		}
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
 			t.Fatalf("decode body: %v", err)
@@ -217,8 +216,8 @@ func TestNudgePostsContentBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Nudge: %v", err)
 	}
-	if len(got.Content) != 1 || got.Content[0].Text != "hello" {
-		t.Fatalf("content = %#v, want text block", got.Content)
+	if got.Text != "hello" {
+		t.Fatalf("text = %q, want hello", got.Text)
 	}
 }
 

--- a/internal/runtime/cloudflare/cloudflare_test.go
+++ b/internal/runtime/cloudflare/cloudflare_test.go
@@ -1,0 +1,243 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestNewProviderRequiresAbsoluteEndpoint(t *testing.T) {
+	if _, err := NewProviderWithConfig(Config{}); err == nil {
+		t.Fatal("NewProviderWithConfig succeeded without endpoint")
+	}
+	if _, err := NewProviderWithConfig(Config{Endpoint: "/relative"}); err == nil {
+		t.Fatal("NewProviderWithConfig succeeded with relative endpoint")
+	}
+}
+
+func TestStartPostsTypedConfig(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	var got startConfig
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotAuth = r.Header.Get("Authorization")
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{
+		Endpoint: server.URL + "/runtime",
+		Token:    "secret",
+	})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	err = p.Start(context.Background(), "sess-one", runtime.Config{
+		WorkDir:           "/work",
+		Command:           "codex exec",
+		Env:               map[string]string{"GC_CITY": "/city"},
+		ProcessNames:      []string{"codex"},
+		Nudge:             "hello",
+		SessionLive:       []string{"echo live"},
+		ProviderName:      "codex",
+		PromptFlag:        "--prompt",
+		PromptSuffix:      "do work",
+		FingerprintExtra:  map[string]string{"pool": "workers"},
+		PackOverlayDirs:   []string{"/pack/overlay"},
+		InstallAgentHooks: []string{"gemini"},
+		CopyFiles: []runtime.CopyEntry{{
+			Src:    "/host/file",
+			RelDst: "file",
+			Probed: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if gotPath != "/runtime/sessions/sess-one/start" {
+		t.Fatalf("path = %q, want /runtime/sessions/sess-one/start", gotPath)
+	}
+	if gotAuth != "Bearer secret" {
+		t.Fatalf("authorization = %q, want bearer token", gotAuth)
+	}
+	if got.WorkDir != "/work" || got.Command != "codex exec" {
+		t.Fatalf("start config = %+v, missing workdir/command", got)
+	}
+	if got.Env["GC_CITY"] != "/city" {
+		t.Fatalf("env = %#v, missing GC_CITY", got.Env)
+	}
+	if len(got.ProcessNames) != 1 || got.ProcessNames[0] != "codex" {
+		t.Fatalf("process_names = %#v, want codex", got.ProcessNames)
+	}
+	if len(got.CopyFiles) != 1 || got.CopyFiles[0].Src != "/host/file" || got.CopyFiles[0].RelDst != "file" {
+		t.Fatalf("copy_files = %#v, want stable copy entry", got.CopyFiles)
+	}
+}
+
+func TestStartConflictWrapsSessionExists(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"already exists"}`))
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	err = p.Start(context.Background(), "sess-one", runtime.Config{})
+	if !errors.Is(err, runtime.ErrSessionExists) {
+		t.Fatalf("Start error = %v, want ErrSessionExists", err)
+	}
+}
+
+func TestStopTreatsNotFoundAsIdempotent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if err := p.Stop("missing"); err != nil {
+		t.Fatalf("Stop missing: %v", err)
+	}
+}
+
+func TestIsRunningDecodesRemoteState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.EscapedPath() != "/sessions/sess-one/running" {
+			t.Fatalf("path = %q, want running endpoint", r.URL.EscapedPath())
+		}
+		_, _ = w.Write([]byte(`{"running":true}`))
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if !p.IsRunning("sess-one") {
+		t.Fatal("IsRunning = false, want true")
+	}
+}
+
+func TestListRunningUsesPrefixQuery(t *testing.T) {
+	var gotPrefix string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPrefix = r.URL.Query().Get("prefix")
+		if r.URL.EscapedPath() != "/sessions" {
+			t.Fatalf("path = %q, want /sessions", r.URL.EscapedPath())
+		}
+		_, _ = w.Write([]byte(`{"names":["alpha-1","alpha-2"]}`))
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	names, err := p.ListRunning("alpha")
+	if err != nil {
+		t.Fatalf("ListRunning: %v", err)
+	}
+	if gotPrefix != "alpha" {
+		t.Fatalf("prefix = %q, want alpha", gotPrefix)
+	}
+	if len(names) != 2 || names[0] != "alpha-1" || names[1] != "alpha-2" {
+		t.Fatalf("names = %#v, want alpha sessions", names)
+	}
+}
+
+func TestGetLastActivityParsesRFC3339Nano(t *testing.T) {
+	want := time.Date(2026, 5, 24, 2, 14, 25, 123, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(activityResponse{LastActivity: want.Format(time.RFC3339Nano)})
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	got, err := p.GetLastActivity("sess-one")
+	if err != nil {
+		t.Fatalf("GetLastActivity: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("last activity = %s, want %s", got, want)
+	}
+}
+
+func TestNudgePostsContentBlocks(t *testing.T) {
+	var got nudgeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/sessions/sess-one/nudge" {
+			t.Fatalf("path = %q, want nudge endpoint", r.URL.EscapedPath())
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	err = p.Nudge("sess-one", runtime.TextContent("hello"))
+	if err != nil {
+		t.Fatalf("Nudge: %v", err)
+	}
+	if len(got.Content) != 1 || got.Content[0].Text != "hello" {
+		t.Fatalf("content = %#v, want text block", got.Content)
+	}
+}
+
+func TestGetMetaNotFoundReturnsEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	got, err := p.GetMeta("sess-one", "missing")
+	if err != nil {
+		t.Fatalf("GetMeta: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("GetMeta = %q, want empty", got)
+	}
+}

--- a/internal/runtime/cloudflare/cloudflare_test.go
+++ b/internal/runtime/cloudflare/cloudflare_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -238,5 +239,275 @@ func TestGetMetaNotFoundReturnsEmpty(t *testing.T) {
 	}
 	if got != "" {
 		t.Fatalf("GetMeta = %q, want empty", got)
+	}
+}
+
+func TestGetMetaReturnsValue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/session/sess-one/meta/mykey" {
+			t.Fatalf("path = %q, want /session/sess-one/meta/mykey", r.URL.EscapedPath())
+		}
+		_, _ = w.Write([]byte(`{"value":"myval"}`))
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	got, err := p.GetMeta("sess-one", "mykey")
+	if err != nil {
+		t.Fatalf("GetMeta: %v", err)
+	}
+	if got != "myval" {
+		t.Fatalf("GetMeta = %q, want myval", got)
+	}
+}
+
+func TestSetMetaPostsKeyAndValue(t *testing.T) {
+	var gotPath, gotValue string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		var body metaRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotValue = body.Value
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if err := p.SetMeta("sess-one", "mykey", "myval"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	if gotPath != "/session/sess-one/meta/mykey" {
+		t.Fatalf("path = %q, want /session/sess-one/meta/mykey", gotPath)
+	}
+	if gotValue != "myval" {
+		t.Fatalf("value = %q, want myval", gotValue)
+	}
+}
+
+func TestRemoveMetaTreatsNotFoundAsIdempotent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if err := p.RemoveMeta("sess-one", "gone"); err != nil {
+		t.Fatalf("RemoveMeta not-found: %v", err)
+	}
+}
+
+func TestPeekDecodesOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/session/sess-one/peek" {
+			t.Fatalf("path = %q, want /session/sess-one/peek", r.URL.EscapedPath())
+		}
+		var body peekRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Lines != 20 {
+			t.Fatalf("lines = %d, want 20", body.Lines)
+		}
+		_, _ = w.Write([]byte(`{"output":"hello\nworld"}`))
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	got, err := p.Peek("sess-one", 20)
+	if err != nil {
+		t.Fatalf("Peek: %v", err)
+	}
+	if got != "hello\nworld" {
+		t.Fatalf("output = %q, want hello\\nworld", got)
+	}
+}
+
+func TestProcessAliveUsesExtendedRegex(t *testing.T) {
+	var gotBody execRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/session/sess-one/exec" {
+			t.Fatalf("path = %q, want /session/sess-one/exec", r.URL.EscapedPath())
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"exitCode":0,"success":true}`))
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if !p.ProcessAlive("sess-one", []string{"codex", "claude"}) {
+		t.Fatal("ProcessAlive = false, want true")
+	}
+	if !strings.Contains(gotBody.Cmd, "pgrep -Ef --") {
+		t.Fatalf("cmd = %q, want pgrep -Ef -- flag", gotBody.Cmd)
+	}
+	if !strings.Contains(gotBody.Cmd, "codex|claude") {
+		t.Fatalf("cmd = %q, want pattern with alternation", gotBody.Cmd)
+	}
+}
+
+func TestProcessAliveNonZeroExitMeansDead(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"exitCode":1,"success":false}`))
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if p.ProcessAlive("sess-one", []string{"codex"}) {
+		t.Fatal("ProcessAlive = true, want false for non-zero exit")
+	}
+}
+
+func TestInterruptPostsToExec(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if err := p.Interrupt("sess-one"); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	if gotPath != "/session/sess-one/exec" {
+		t.Fatalf("path = %q, want /session/sess-one/exec", gotPath)
+	}
+}
+
+func TestInterruptTreatsNotFoundAsIdempotent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if err := p.Interrupt("gone"); err != nil {
+		t.Fatalf("Interrupt missing session: %v", err)
+	}
+}
+
+func TestClearScrollbackPostsToExec(t *testing.T) {
+	var gotBody execRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/session/sess-one/exec" {
+			t.Fatalf("path = %q, want /session/sess-one/exec", r.URL.EscapedPath())
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if err := p.ClearScrollback("sess-one"); err != nil {
+		t.Fatalf("ClearScrollback: %v", err)
+	}
+	if !strings.Contains(gotBody.Cmd, ".gc-scrollback") {
+		t.Fatalf("cmd = %q, want scrollback truncate command", gotBody.Cmd)
+	}
+}
+
+func TestSendKeysPostsToKeysEndpoint(t *testing.T) {
+	var gotBody sendKeysRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/session/sess-one/keys" {
+			t.Fatalf("path = %q, want /session/sess-one/keys", r.URL.EscapedPath())
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if err := p.SendKeys("sess-one", "Up", "Enter"); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+	if len(gotBody.Keys) != 2 || gotBody.Keys[0] != "Up" || gotBody.Keys[1] != "Enter" {
+		t.Fatalf("keys = %v, want [Up Enter]", gotBody.Keys)
+	}
+}
+
+func TestNudgeDropsEmptyContent(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	p, err := NewProviderWithConfig(Config{Endpoint: server.URL})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+
+	if err := p.Nudge("sess-one", nil); err != nil {
+		t.Fatalf("Nudge nil: %v", err)
+	}
+	if called {
+		t.Fatal("Nudge made HTTP call for empty content, want no-op")
+	}
+}
+
+func TestRunLiveReturnsNil(t *testing.T) {
+	p, err := NewProviderWithConfig(Config{Endpoint: "http://unused.example"})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+	if err := p.RunLive("sess-one", runtime.Config{}); err != nil {
+		t.Fatalf("RunLive = %v, want nil", err)
+	}
+}
+
+func TestCapabilitiesReflectsConfig(t *testing.T) {
+	p, err := NewProviderWithConfig(Config{Endpoint: "http://unused.example", ReportActivity: true})
+	if err != nil {
+		t.Fatalf("NewProviderWithConfig: %v", err)
+	}
+	caps := p.Capabilities()
+	if !caps.CanReportActivity {
+		t.Fatal("CanReportActivity = false, want true when configured")
+	}
+	if caps.CanReportAttachment {
+		t.Fatal("CanReportAttachment = true, want always false")
 	}
 }


### PR DESCRIPTION
## Summary

Implements \`CopyTo\` in the Cloudflare transport, which previously returned
an error. Closes #2570.

Depends on #2543.

## What this does

Adds \`POST /session/:id/copy\` to the control-plane Worker and wires it to
\`CopyTo(name, src, relDst string)\` in the Go provider.

**Worker side** (\`stage/worker/src/index.ts\`):
- Accepts \`{ relDst, content }\` where \`content\` is standard base64 (RFC 4648)
- Validates base64 format; returns 400 for malformed input rather than leaking a 500
- Enforces a ~1 MiB decoded size cap; returns 413
- Guards against path traversal: rejects \`..\` and leading \`/\`, then normalizes
  and re-verifies the resolved path stays inside \`/workspace/\`
- Calls \`sandbox.writeFile(path, content, { encoding: "base64" })\` so binary
  files are handled without manual decoding

**Go side** (\`internal/runtime/cloudflare/cloudflare.go\`):
- Reads the local file with \`os.ReadFile\`
- Encodes with \`base64.StdEncoding\` (matches the Worker's \`encoding:"base64"\`)
- POSTs to \`POST /session/:name/copy\`

## Test plan

- [x] \`go build ./...\` exits 0
- [x] \`go vet ./...\` exits 0
- [x] gofmt-clean
- [x] \`TestCopyToPostsBase64Content\` — correct path and base64 round-trip
- [x] \`TestCopyToBinaryContent\` — binary (non-UTF8) bytes survive encode/decode intact
- [x] \`TestCopyToSurfacesWorkerError\` — Worker 413 surfaces as a Go error
- [x] \`TestCopyToMissingFileReturnsError\` — missing source file errors before any HTTP call

## Notes

- Files larger than ~1 MiB must be split; this establishes the base64-over-HTTP
  pattern for the common case
- Path traversal guard is defense-in-depth: early string checks +
  post-normalization re-verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)