### PR TITLE
docs: update PackV2 public guides

### DIFF
--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -96,7 +96,6 @@ directory has its own `pack.toml`, and the old "everything lives in
 - pack identity and compatibility metadata
 - imports
 - providers
-- pack-wide agent defaults
 - named sessions
 - pack-level patches
 - other pack-wide declarative policy
@@ -140,6 +139,7 @@ includes = ["packs/gastown"]
 # pack.toml
 [pack]
 name = "my-city"
+schema = 1
 
 [imports.gastown]
 source = "../shared/gastown"
@@ -173,11 +173,16 @@ source = "../shared/gastown"
 Use the city pack's `pack.toml` for city-wide imports. Use rig-scoped
 imports in `city.toml` when a pack should compose only into one rig.
 
-For remote imports, run `gc import install` after the import declarations
-are in place. That writes or repairs `packs.lock` and materializes the
-local cache. Use `gc import check` when you want a read-only validation
-pass: it reports missing or stale lock/cache state and points back to
-`gc import install` for repair.
+For remote imports, run the current import-install command after the import
+declarations are in place. Today that is `gc import install`: it writes or
+repairs `packs.lock` and materializes the local cache. Use `gc import check`
+when you want a read-only validation pass: it reports missing or stale
+lock/cache state and points back to `gc import install` for repair.
+
+> **Registry note:** #2351 adds `gc pack registry` discovery commands. Those
+> commands help you find registry records and durable sources; they do not make
+> registry handles such as `main:gastown` durable PackV2 import syntax. Keep
+> committed imports as `source` plus optional `version`.
 
 Those commands are about pack acquisition and cache state, not PackV1 to
 PackV2 migration. Use `gc doctor` for migration work.
@@ -232,7 +237,7 @@ defaults.
 - move each `[[agent]]` definition into `agents/<name>/`
 - move templated prompt content to `agents/<name>/prompt.template.md`
 - move agent-local overlay content to `agents/<name>/overlay/`
-- keep shared defaults in `[agent_defaults]` (in `pack.toml` for pack-wide, `city.toml` for city-level overrides)
+- keep city-owned defaults in `[agent_defaults]` in `city.toml`
 - keep pack-wide providers in `[providers.*]`
 
 If you are migrating a city, city-local agents are still just agents in
@@ -471,12 +476,12 @@ template inclusion.
 | `inject_fragments_append` on patches | Gone — same approach |
 | All `.md` files run through Go templates | Only `.template.md` files run through Go templates |
 
-For migration convenience, `[agent_defaults].append_fragments`
-auto-appends named fragments to `.template.md` prompts without editing
-each prompt file:
+For migration convenience, `[agent_defaults].append_fragments` in `city.toml`
+auto-appends named fragments to `.template.md` prompts without editing each
+prompt file:
 
 ```toml
-# pack.toml or city.toml
+# city.toml
 [agent_defaults]
 append_fragments = ["operational-awareness", "command-glossary"]
 ```
@@ -631,7 +636,7 @@ schema, plus the qualified rows that matter most during migration.
 | `workspace.name` | Workspace identity | Move to `.gc/site.toml` as `workspace_name`. Runtime identity resolves from registered alias (supervisor-managed flows), then site binding / legacy config, then directory basename. `pack.name` remains the portable definition identity and init-time default only. |
 | `workspace.prefix` | Workspace bead prefix | Move to `.gc/site.toml` as `workspace_prefix`. Runtime/API surfaces use the effective site-bound prefix when present and otherwise derive from the effective city name. |
 | `workspace.includes` | City-level pack composition | Move to `[imports.*]` in the root city `pack.toml`. |
-| `workspace.default_rig_includes` | Default pack composition for newly added rigs | Move each default include to `[defaults.rig.imports.<binding>]` entries in the root city `pack.toml`. |
+| `workspace.default_rig_includes` | Default pack composition for newly added rigs | Move each default include to `[defaults.rig.imports.<binding>]` entries in `city.toml`. |
 | `[providers.*]` | Named provider presets | Usually move to `[providers.*]` in the root city `pack.toml`, unless the setting is truly deployment-only. |
 | `[packs.*]` | Named remote pack sources used by includes | Collapse into `[imports.*]` entries. There should no longer be a separate `[packs.*]` registry in `city.toml`. |
 | `[[agent]]` | Inline agent definitions | Move to `agents/<name>/`, with optional `agent.toml`. |
@@ -661,7 +666,7 @@ schema, plus the qualified rows that matter most during migration.
 | `[session_sleep]` | Sleep policy defaults | Keep in `city.toml`. |
 | `[convergence]` | Convergence limits | Keep in `city.toml`. |
 | `[[service]]` | Workspace-owned service declarations | Keep in `city.toml` if they are deployment-owned services. |
-| `[agent_defaults]` | Defaults applied to agents in this city | Lives in both `pack.toml` (pack-wide portable defaults) and `city.toml` (city-level deployment overrides). City layers on top of pack. As of release v0.15.0, the actively-applied defaults are still narrow: `default_sling_formula` plus `[agent_defaults].append_fragments`. |
+| `[agent_defaults]` | Defaults applied to agents in this city | Keep in `city.toml`. The actively-applied defaults are still narrow: `default_sling_formula` plus `[agent_defaults].append_fragments`. |
 
 > **Schema contract note:** This rollout also changes the generated schema
 > contract: checked-in `city.toml` files and downstream validators must no
@@ -678,7 +683,7 @@ transitional pack fields that people are likely to have.
 | `[pack]` | Pack metadata | Keep in `pack.toml`. |
 | `pack.name` | Pack identity | Keep in `[pack]`. |
 | `pack.version` | Pack version | Keep in `[pack]`. |
-| `pack.schema` | Pack schema version | Keep in `[pack]`, updated to the new schema as needed. |
+| `pack.schema` | Pack schema version | Keep in `[pack]`; PackV2 currently uses `schema = 1`. |
 | `pack.requires_gc` | Minimum supported gc version | Keep in `[pack]`. |
 | `pack.city_agents` | City-vs-rig stamping hint in the old pack system | Revisit during migration. The new model prefers agent-local definition and scope rules instead of this field. |
 | `pack.includes` | Pack-to-pack composition | Replace with `[imports.*]` in `pack.toml`. |

--- a/docs/guides/shareable-packs.md
+++ b/docs/guides/shareable-packs.md
@@ -5,18 +5,19 @@ description: Create, import, and customize PackV2 Gas City packs.
 
 A pack is a portable definition of behavior: agents, prompt templates,
 providers, formulas, orders, commands, doctor checks, overlays, skills, and
-other reusable assets. A city is the root pack plus a `city.toml` deployment
-file and machine-local `.gc/` bindings.
+other reusable assets. A city is a root pack plus `city.toml` deployment
+configuration and machine-local `.gc/` bindings.
 
-PackV2 separates three concerns:
+PackV2 keeps those concerns separate:
 
-- `pack.toml` and pack directories define what the system is.
-- `city.toml` defines how this deployment runs.
+- `pack.toml` names the pack and declares its pack dependencies.
+- Pack directories such as `agents/`, `formulas/`, and `commands/` hold
+  reusable definitions and support files.
+- `city.toml` says how this city runs those definitions.
 - `.gc/` stores local site bindings and runtime state managed by `gc`.
 
-Legacy `includes`, `[packs.*]`, and `[[agent]]` examples may still load for
-migration compatibility, but new docs and new packs should use PackV2 imports
-and `agents/<name>/` directories.
+Use this guide when you want to create a reusable pack, import one into a city,
+or customize an imported pack without editing the pack's files.
 
 ## Pack Layout
 
@@ -43,207 +44,209 @@ code-review-pack/
 │       └── run.sh
 ├── overlay/
 ├── skills/
-├── mcp/
-├── template-fragments/
 └── assets/
     └── scripts/
         └── setup-reviewer.sh
 ```
 
-## Minimal `pack.toml`
-
-Pack metadata and imports live in `pack.toml`. Agent definitions live in
-`agents/<name>/`, not in `[[agent]]` tables.
+The smallest useful `pack.toml` names the pack and records the schema:
 
 ```toml
 [pack]
 name = "code-review"
-schema = 2
+schema = 1
 version = "1.0.0"
-
-[agent_defaults]
-provider = "claude"
-scope = "rig"
 ```
 
-`schema = 2` is the current PackV2 format. `[agent_defaults]` applies to
-agents discovered from `agents/` unless an agent's own `agent.toml` overrides a
-field.
-
-## Agent Directories
-
-A minimal agent is just a directory with a prompt:
-
-```text
-agents/reviewer/
-└── prompt.template.md
-```
-
-Use `agent.toml` for fields that differ from pack defaults:
+Agent definitions live in `agents/<name>/agent.toml`. The directory name is
+the agent's local name:
 
 ```toml
 # agents/reviewer/agent.toml
 scope = "rig"
-nudge = "Check your hook, review the assigned change, and leave findings."
+provider = "codex"
+prompt_template = "prompt.template.md"
+nudge = "Review the assigned change and leave findings."
 idle_timeout = "30m"
-min_active_sessions = 0
-max_active_sessions = 3
 pre_start = ["{{.ConfigDir}}/assets/scripts/setup-reviewer.sh {{.RigRoot}}"]
 ```
 
-Prompt file discovery prefers `prompt.template.md`. `prompt.md` and
-`prompt.md.tmpl` are accepted for compatibility.
+Use `scope = "city"` for agents that should load at the city level. Use
+`scope = "rig"` for agents that should be stamped into rigs that import the
+pack. If `scope` is omitted, the agent is eligible in both contexts.
 
-## Imports
+## Import A Pack
 
-Packs compose other packs with named imports. Imports preserve provenance, so
-consumers can distinguish `gastown.polecat` from `review.polecat`.
+An import is a named dependency. Durable imports use `source` plus an optional
+`version` constraint.
 
 ```toml
-[imports.maintenance]
-source = "../maintenance"
-export = true
+[imports.review]
+source = "../packs/code-review"
 ```
 
-Local imports use a path relative to the importing pack. Remote imports use a
-source plus a version constraint:
+For a versioned source:
 
 ```toml
 [imports.gastown]
-source = "github.com/gastownhall/gastown"
-version = "^1.2"
+source = "https://github.com/gastownhall/gascity-packs.git//gastown"
+version = "^1"
 ```
 
-Imports are transitive by default. Set `transitive = false` only when the
-import is internal to the pack and should not be visible to consumers.
+The table name, such as `review` or `gastown`, is the local import binding. It
+helps Gas City load dependencies deterministically, but it does not become part
+of runtime agent names.
 
-## City Usage
+## Find Packs With A Registry
 
-A city imports packs at the root pack level and declares deployment details in
-`city.toml`.
+> **Review note:** The registry discovery commands in this section depend on
+> #2351. Confirm the final command wording with Donna or Mabel before merging
+> this guide.
+
+A pack registry is a catalog. It tells `gc` which packs exist, what versions
+are available, and where their durable sources live.
+
+Configure a registry on the local machine:
+
+```text
+$ gc pack registry add main https://packages.example/registry.toml
+$ gc pack registry refresh main
+```
+
+Search the cached registry records:
+
+```text
+$ gc pack registry search "code review"
+```
+
+Inspect one result:
+
+```text
+$ gc pack registry show main:gascity
+```
+
+Registry handles such as `main:gascity` are command-time lookup handles. Do
+not persist them in `pack.toml`. Use the durable `source` and optional
+`version` from the registry record when you write the import.
+
+## Import Into A City
+
+A city can import a pack at the root pack level:
 
 ```toml
 # pack.toml
 [pack]
 name = "bright-lights"
-schema = 2
-
-[imports.gastown]
-source = "./assets/gastown"
+schema = 1
 
 [imports.review]
-source = "./assets/code-review"
+source = "../packs/code-review"
 ```
+
+City-level imports make city-scoped agents and definitions available to the
+city. If the imported pack defines a city-scoped `reviewer` agent, the runtime
+agent name is `reviewer`.
+
+Use rig-level imports when only one rig should receive a pack's rig-scoped
+agents or formulas:
 
 ```toml
 # city.toml
-[beads]
-provider = "bd"
-
 [[rigs]]
 name = "backend"
-max_active_sessions = 4
-default_sling_target = "backend/gastown.polecat"
-```
-
-Machine-local rig paths are site bindings managed by `gc`:
-
-```bash
-gc rig add ~/src/backend --name backend
-```
-
-## Rig-Level Imports
-
-Use rig-level imports when only one rig should receive a pack's agents or
-formulas.
-
-```toml
-[[rigs]]
-name = "backend"
-
-[rigs.imports.gastown]
-source = "./assets/gastown"
 
 [rigs.imports.review]
-source = "./assets/code-review"
+source = "../packs/code-review"
 ```
 
-Rig-level imports create rig-scoped identities such as
-`backend/gastown.polecat` and `backend/review.reviewer`.
+If the imported pack defines a rig-scoped `reviewer` agent, the runtime name is
+`backend/reviewer`. The `backend` part comes from the rig `name`, not from the
+import binding and not from the rig filesystem path.
 
-## Named Sessions
+Validate after changing imports:
 
-Packs can declare sessions that should exist independent of current work.
-
-```toml
-[[named_session]]
-template = "mayor"
-scope = "city"
-mode = "always"
-
-[[named_session]]
-template = "polecat"
-scope = "rig"
-mode = "on_demand"
+```text
+$ gc config show --validate
 ```
 
-The `template` is an agent name from the same pack or an imported qualified
-name when needed.
+## Customize An Imported Pack
 
-## Customizing Imported Agents
+A reusable pack should work without editing its files. Customize from the city
+that imports it.
 
-Use patches to modify imported agents without redefining them.
+Use city defaults for broad local policy. Defaults fill blank fields only:
 
 ```toml
+# city.toml
+[agent_defaults]
+default_sling_formula = "review-change"
+```
+
+Use a patch when you need to change one city-level agent:
+
+```toml
+# city.toml
 [[patches.agent]]
-name = "gastown.mayor"
+name = "reviewer"
 provider = "codex"
-idle_timeout = "2h"
-
-[patches.agent.env]
-GC_MODE = "coordination"
+session_setup_append = ["tmux set status-left '[review]'"]
 ```
 
-For rig-specific customization, patch under the rig:
+For a rig-scoped agent, target the rig identity prefix with `dir`:
+
+```toml
+# city.toml
+[[patches.agent]]
+dir = "backend"
+name = "reviewer"
+provider = "gemini"
+```
+
+The `dir` value is the rig name. It is not the rig path.
+
+Rig overrides are another rig-local customization point:
 
 ```toml
 [[rigs]]
 name = "backend"
 
-[[rigs.patches]]
-agent = "gastown.polecat"
+[[rigs.overrides]]
+agent = "reviewer"
 provider = "gemini"
-
-[rigs.patches.pool]
-max = 8
 ```
 
-## Formula and Order Files
+Prefer patches and rig overrides over forking. Fork only when you want to own a
+new pack with a different public surface.
 
-Formula files go in `formulas/` and order files go in `orders/`. No
-`[formulas].dir` declaration is needed for PackV2 packs.
+## Name Public Surface Carefully
+
+Names are part of a pack's public API. A downstream city can route work to an
+agent name, invoke a formula name, or call a command name.
+
+Choose stable names for:
+
+- agents under `agents/<name>/`
+- formulas under `formulas/<name>.toml`
+- orders under `orders/<name>.toml`
+- commands under `commands/<name>/`
+
+If two imported packs define the same city-level agent name, config load fails.
+The same applies inside one rig. Rename one public definition or avoid
+importing both packs onto the same surface.
+
+## Update Or Remove A Pack
+
+The checked-in import records the compatibility range. The lock and cache
+record the exact resolved copy used locally.
+
+After editing imports, run:
 
 ```text
-formulas/
-└── review-change.toml
-
-orders/
-└── nightly-review.toml
+$ gc config show --validate
 ```
 
-When multiple packs provide the same formula name, the importing pack wins over
-its imports. Rig-level imports can override city-level formulas for that rig.
+If the pack came from a remote source, keep the lock and cache in sync with the
+current import-management commands for your release. Registry discovery in
+#2351 does not make registry handles durable pack coordinates; the committed
+import remains `source` plus optional `version`.
 
-## Compatibility Notes
-
-The loader still exposes some V1 fields for migration and old city support:
-
-- `workspace.includes`
-- `[[rigs]].includes`
-- `[packs.*]`
-- `[[agent]]`
-- `[formulas].dir`
-
-Treat those as migration surfaces. New shareable packs should use PackV2:
-`schema = 2`, `[imports.*]`, `agents/<name>/`, conventional `formulas/`, and
-patches for customization.


### PR DESCRIPTION
## Summary
- rewrite `shareable-packs.md` around the current PackV2 directory/import/customization model
- update `migrating-to-pack-vnext.md` for `schema = 1`, city-owned defaults, rig default imports in `city.toml`, and source-first imports
- keep registry handles as command-time lookup handles only; committed PackV2 imports stay `source` plus optional `version`

## Validation
- `make check-docs`

## Review notes
- #2351 registry command names are still draft; Donna/Mabel should review the registry wording before this leaves draft
- `migrating-to-pack-vnext.md` intentionally still shows PackV1/deprecated shapes as old-input migration examples
- No implementation code changed