### PR TITLE
fix: resolve pool adoption from session snapshot

### DIFF
--- a/cmd/gc/adoption_barrier.go
+++ b/cmd/gc/adoption_barrier.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -115,6 +116,7 @@ func runAdoptionBarrier(
 	}
 	agentBySession := make(map[string]*config.Agent, len(cfg.Agents))
 	agentByQN := make(map[string]*config.Agent, len(cfg.Agents))
+	agentBaseSessionName := make(map[string]string, len(cfg.Agents))
 	for i := range cfg.Agents {
 		a := &cfg.Agents[i]
 		sn := snapshot.FindSessionNameByTemplate(a.QualifiedName())
@@ -123,6 +125,7 @@ func runAdoptionBarrier(
 		}
 		agentBySession[sn] = a
 		agentByQN[a.QualifiedName()] = a
+		agentBaseSessionName[a.QualifiedName()] = sn
 	}
 
 	// Step 3: For each running session, adopt if no open bead exists.
@@ -135,11 +138,11 @@ func runAdoptionBarrier(
 		isPoolInstance := false
 		staleSingletonSuffix := false
 		if !isConfigAgent {
-			if base := resolveCanonicalSingletonSuffixBase(sessionName, store, cityName, st, agentByQN); base != nil {
+			if base := resolveCanonicalSingletonSuffixBase(sessionName, agentBaseSessionName, agentByQN); base != nil {
 				cfgAgent = base
 				isConfigAgent = true
 				staleSingletonSuffix = true
-			} else if base := resolvePoolBase(sessionName, store, cityName, st, agentByQN); base != nil {
+			} else if base := resolvePoolBase(sessionName, agentBaseSessionName, agentByQN); base != nil {
 				cfgAgent = base
 				isConfigAgent = true
 				isPoolInstance = true
@@ -291,7 +294,7 @@ func openSessionBeadExists(store beads.Store, sessionName string) (bool, error) 
 // base template agent. It strips the numeric suffix (e.g., "worker-3" -> "worker")
 // and checks whether the resulting base name corresponds to a configured agent.
 // Returns nil if no match is found.
-func resolvePoolBase(sessionName string, store beads.Store, cityName, sessionTemplate string, agentByQN map[string]*config.Agent) *config.Agent {
+func resolvePoolBase(sessionName string, agentBaseSessionName map[string]string, agentByQN map[string]*config.Agent) *config.Agent {
 	slot := parsePoolSlot(sessionName)
 	if slot == 0 {
 		return nil
@@ -304,7 +307,7 @@ func resolvePoolBase(sessionName string, store beads.Store, cityName, sessionTem
 		if !a.SupportsInstanceExpansion() {
 			continue
 		}
-		sn := lookupSessionNameOrLegacy(store, cityName, a.QualifiedName(), sessionTemplate)
+		sn := strings.TrimSpace(agentBaseSessionName[a.QualifiedName()])
 		if sn == baseSessName {
 			return a
 		}
@@ -312,7 +315,7 @@ func resolvePoolBase(sessionName string, store beads.Store, cityName, sessionTem
 	return nil
 }
 
-func resolveCanonicalSingletonSuffixBase(sessionName string, store beads.Store, cityName, sessionTemplate string, agentByQN map[string]*config.Agent) *config.Agent {
+func resolveCanonicalSingletonSuffixBase(sessionName string, agentBaseSessionName map[string]string, agentByQN map[string]*config.Agent) *config.Agent {
 	slot := parsePoolSlot(sessionName)
 	if slot == 0 {
 		return nil
@@ -323,7 +326,7 @@ func resolveCanonicalSingletonSuffixBase(sessionName string, store beads.Store, 
 		if !a.UsesCanonicalSingletonPoolIdentity() {
 			continue
 		}
-		sn := lookupSessionNameOrLegacy(store, cityName, a.QualifiedName(), sessionTemplate)
+		sn := strings.TrimSpace(agentBaseSessionName[a.QualifiedName()])
 		if sn == baseSessName {
 			return a
 		}

--- a/cmd/gc/adoption_barrier_test.go
+++ b/cmd/gc/adoption_barrier_test.go
@@ -57,6 +57,10 @@ type adoptionClockAdvanceStore struct {
 	advanced bool
 }
 
+type adoptionSessionNameLookupFailStore struct {
+	beads.Store
+}
+
 func (s *adoptionLockProbeStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	result, err := s.Store.List(query)
 	if query.Label == sessionBeadLabel {
@@ -82,6 +86,13 @@ func (s *adoptionClockAdvanceStore) List(query beads.ListQuery) ([]beads.Bead, e
 		s.advance()
 	}
 	return result, err
+}
+
+func (s *adoptionSessionNameLookupFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.TrimSpace(query.Label) == "agent:worker" || strings.TrimSpace(query.Metadata["agent_name"]) == "worker" || strings.TrimSpace(query.Metadata["template"]) == "worker" || strings.TrimSpace(query.Metadata["common_name"]) == "worker" {
+		return nil, errors.New("unexpected per-agent session name lookup")
+	}
+	return s.Store.List(query)
 }
 
 func (s *adoptionLockProbeStore) Create(b beads.Bead) (beads.Bead, error) {
@@ -658,6 +669,44 @@ func TestAdoptionBarrier_PoolSlotDetection(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected detail with PoolSlot=3, AgentName=worker-3 for worker-3, got %+v", result.Details)
+	}
+}
+
+func TestAdoptionBarrier_PoolSlotResolutionUsesLoadedSnapshot(t *testing.T) {
+	backing := beads.NewMemStore()
+	if _, err := backing.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"agent_name":   "worker",
+			"session_name": "custom-worker",
+			"state":        "awake",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store := &adoptionSessionNameLookupFailStore{Store: backing}
+	sp := &fakeAdoptionProvider{running: []string{"custom-worker-3"}}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(5)},
+		},
+	}
+	var stderr bytes.Buffer
+
+	result, _ := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, true)
+
+	found := false
+	for _, d := range result.Details {
+		if d.SessionName == "custom-worker-3" && d.PoolSlot == 3 && d.AgentName == "worker-3" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected snapshot-backed pool detail for custom-worker-3, got %+v; stderr=%q", result.Details, stderr.String())
 	}
 }
 


### PR DESCRIPTION
Summary:
- Resolve pool-slot and canonical singleton suffix matches from the loaded session snapshot instead of per-agent store lookups.
- Adds coverage proving adoption does not re-query per-agent session names for pool slot detection.

Tests:
- go test ./cmd/gc -run TestAdoptionBarrier_PoolSlotResolutionUsesLoadedSnapshot
- pre-commit fast suite passed