### PR TITLE
fix: harden dispatch control failure handling

### DIFF
--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -89,7 +89,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 
 	items, err := resolveFanoutItems(source, bead.Metadata["gc.for_each"])
 	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: resolving items: %w", bead.ID, err)
+		return ControlResult{}, fmt.Errorf("%w: %s: resolving items: %w", ErrControlGraphMalformed, bead.ID, err)
 	}
 	if len(items) == 0 {
 		if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
@@ -111,7 +111,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 
 	bondVars, err := parseFanoutVars(bead.Metadata["gc.bond_vars"])
 	if err != nil {
-		return ControlResult{}, fmt.Errorf("%s: parsing gc.bond_vars: %w", bead.ID, err)
+		return ControlResult{}, fmt.Errorf("%w: %s: parsing gc.bond_vars: %w", ErrControlGraphMalformed, bead.ID, err)
 	}
 	mode := bead.Metadata["gc.fanout_mode"]
 	if mode == "" {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -1,6 +1,7 @@
 package dispatch
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -243,8 +244,14 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 		if strings.TrimSpace(subject.Metadata["gc.failure_class"]) != "" || strings.TrimSpace(subject.Metadata["gc.failure_reason"]) != "" {
 			return retryEvalResult{Outcome: "transient", Reason: "pass_with_failure_metadata"}
 		}
-		if strings.TrimSpace(subject.Metadata["gc.output_json_required"]) == "true" && strings.TrimSpace(subject.Metadata["gc.output_json"]) == "" {
-			return retryEvalResult{Outcome: "transient", Reason: "missing_required_output_json"}
+		if strings.TrimSpace(subject.Metadata["gc.output_json_required"]) == "true" {
+			rawOutput := strings.TrimSpace(subject.Metadata["gc.output_json"])
+			if rawOutput == "" {
+				return retryEvalResult{Outcome: "transient", Reason: "missing_required_output_json"}
+			}
+			if !json.Valid([]byte(rawOutput)) {
+				return retryEvalResult{Outcome: "transient", Reason: "invalid_required_output_json"}
+			}
 		}
 		return retryEvalResult{Outcome: "pass"}
 	case "fail":

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -182,6 +182,22 @@ func TestProcessRetryEvalRetriesPassMissingRequiredOutputJSON(t *testing.T) {
 	}
 }
 
+func TestClassifyRetryAttemptRetriesInvalidRequiredOutputJSON(t *testing.T) {
+	t.Parallel()
+
+	got := classifyRetryAttempt(beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":              "pass",
+			"gc.output_json_required": "true",
+			"gc.output_json":          "/tmp/gc.output_json.pretty.json",
+		},
+	})
+	want := retryEvalResult{Outcome: "transient", Reason: "invalid_required_output_json"}
+	if got != want {
+		t.Fatalf("classifyRetryAttempt() = %+v, want %+v", got, want)
+	}
+}
+
 func TestProcessRetryEvalTransientAppendErrorStaysOpenForRetry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -108,6 +108,9 @@ func ProcessControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (Co
 			bead.ID, bead.Metadata["gc.kind"], bead.Status)
 		return ControlResult{}, nil
 	}
+	if result, handled, err := closeOrphanedControl(store, bead, opts); handled || err != nil {
+		return result, err
+	}
 
 	switch bead.Metadata["gc.kind"] {
 	case "retry":
@@ -127,6 +130,34 @@ func ProcessControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (Co
 	default:
 		return ControlResult{}, fmt.Errorf("%s: unsupported control bead kind %q", bead.ID, bead.Metadata["gc.kind"])
 	}
+}
+
+func closeOrphanedControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, bool, error) {
+	rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
+	rootStoreRef := strings.TrimSpace(bead.Metadata["gc.root_store_ref"])
+	if rootID == "" || rootStoreRef == "" || rootID == bead.ID {
+		return ControlResult{}, false, nil
+	}
+	if _, err := store.Get(rootID); err == nil {
+		return ControlResult{}, false, nil
+	} else if !errors.Is(err, beads.ErrNotFound) {
+		return ControlResult{}, false, fmt.Errorf("%s: loading workflow root %s: %w", bead.ID, rootID, err)
+	}
+
+	opts.tracef("process-control bead=%s kind=%s close reason=missing_workflow_root root=%s store_ref=%s",
+		bead.ID, bead.Metadata["gc.kind"], rootID, rootStoreRef)
+	closeMetadata := map[string]string{
+		"gc.outcome":              "fail",
+		"gc.failure_class":        "hard",
+		"gc.failure_reason":       "missing_workflow_root",
+		"gc.final_disposition":    "orphaned_workflow",
+		"gc.missing_root_bead_id": rootID,
+	}
+	clearControllerSpawnErrorMetadata(closeMetadata)
+	if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
+		return ControlResult{}, true, fmt.Errorf("%s: closing orphaned control: %w", bead.ID, err)
+	}
+	return ControlResult{Processed: true, Action: "orphaned-workflow"}, true, nil
 }
 
 func (opts ProcessOptions) tracef(format string, args ...any) {

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -133,6 +133,9 @@ func ProcessControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (Co
 }
 
 func closeOrphanedControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, bool, error) {
+	if bead.Metadata["gc.kind"] == "workflow-finalize" {
+		return ControlResult{}, false, nil
+	}
 	rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
 	rootStoreRef := strings.TrimSpace(bead.Metadata["gc.root_store_ref"])
 	if rootID == "" || rootStoreRef == "" || rootID == bead.ID {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -836,6 +836,50 @@ func TestProcessFanoutReturnsMalformedForInvalidSourceOutputJSON(t *testing.T) {
 	}
 }
 
+func TestProcessFanoutReturnsMalformedForInvalidBondVars(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare review items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"personas":[{"name":"architect"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Fan out review items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.control_for":  "demo.prepare-review-items",
+			"gc.for_each":     "output.personas",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    "{not-json",
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	_, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{t.TempDir()}})
+	if !errors.Is(err, ErrControlGraphMalformed) {
+		t.Fatalf("ProcessControl(fanout invalid bond vars) err = %v, want %v", err, ErrControlGraphMalformed)
+	}
+}
+
 func TestReconcileTerminalScopedMemberReusesResolvedBodyForFailingScope(t *testing.T) {
 	t.Parallel()
 
@@ -1373,8 +1417,9 @@ func TestProcessWorkflowFinalizeOrphanedRootClosesFinalizerWithoutError(t *testi
 		Title: "Finalize workflow",
 		Type:  "task",
 		Metadata: map[string]string{
-			"gc.kind":         "workflow-finalize",
-			"gc.root_bead_id": "missing-root-id",
+			"gc.kind":           "workflow-finalize",
+			"gc.root_bead_id":   "missing-root-id",
+			"gc.root_store_ref": "rig:gascity",
 		},
 	})
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -793,6 +793,49 @@ func TestProcessFanoutReturnsMalformedWhenScopeBodyMissing(t *testing.T) {
 	}
 }
 
+func TestProcessFanoutReturnsMalformedForInvalidSourceOutputJSON(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare review items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  "/tmp/gc.output_json.pretty.json",
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Fan out review items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.control_for":  "demo.prepare-review-items",
+			"gc.for_each":     "output.personas",
+			"gc.bond":         "expansion-review",
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	_, err := ProcessControl(store, fanout, ProcessOptions{})
+	if !errors.Is(err, ErrControlGraphMalformed) {
+		t.Fatalf("ProcessControl(fanout invalid output JSON) err = %v, want %v", err, ErrControlGraphMalformed)
+	}
+}
+
 func TestReconcileTerminalScopedMemberReusesResolvedBodyForFailingScope(t *testing.T) {
 	t.Parallel()
 
@@ -7845,6 +7888,62 @@ func TestProcessControlEmitsSkipReasonWhenNotOpen(t *testing.T) {
 	}
 	if !strings.Contains(traced, "status=in_progress") {
 		t.Fatalf("trace missing the actual status; got:\n%s", traced)
+	}
+}
+
+func TestProcessControlClosesControlWhenWorkflowRootMissing(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	control, err := store.Create(beads.Bead{
+		Title:  "orphaned retry control",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":           "retry",
+			"gc.max_attempts":   "3",
+			"gc.root_bead_id":   "missing-root",
+			"gc.root_store_ref": "rig:gascity",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+
+	var traceBuf bytes.Buffer
+	opts := ProcessOptions{
+		Tracef: func(format string, args ...any) {
+			fmt.Fprintf(&traceBuf, format, args...)
+			traceBuf.WriteByte('\n')
+		},
+	}
+
+	result, err := ProcessControl(store, control, opts)
+	if err != nil {
+		t.Fatalf("ProcessControl: %v", err)
+	}
+	if !result.Processed || result.Action != "orphaned-workflow" {
+		t.Fatalf("result = %+v, want processed orphaned-workflow", result)
+	}
+	after := mustGetBead(t, store, control.ID)
+	if after.Status != "closed" {
+		t.Fatalf("status = %q, want closed", after.Status)
+	}
+	if after.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("gc.outcome = %q, want fail", after.Metadata["gc.outcome"])
+	}
+	if after.Metadata["gc.failure_reason"] != "missing_workflow_root" {
+		t.Fatalf("gc.failure_reason = %q, want missing_workflow_root", after.Metadata["gc.failure_reason"])
+	}
+	if after.Metadata["gc.final_disposition"] != "orphaned_workflow" {
+		t.Fatalf("gc.final_disposition = %q, want orphaned_workflow", after.Metadata["gc.final_disposition"])
+	}
+	if after.Metadata["gc.missing_root_bead_id"] != "missing-root" {
+		t.Fatalf("gc.missing_root_bead_id = %q, want missing-root", after.Metadata["gc.missing_root_bead_id"])
+	}
+	traced := traceBuf.String()
+	if !strings.Contains(traced, "close reason=missing_workflow_root") {
+		t.Fatalf("trace missing missing-root close reason; got:\n%s", traced)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Mark malformed fanout inputs as control graph errors.
- Treat invalid required output JSON as retryable.
- Close orphaned control beads when their workflow root is missing.

Tests:
- go test ./internal/dispatch -run 'Test(ClassifyRetryAttemptRetriesInvalidRequiredOutputJSON|ProcessFanoutReturnsMalformedForInvalidSourceOutputJSON|ProcessControlClosesControlWhenWorkflowRootMissing)$'\n- pre-commit fast suite passed