### PR TITLE
fix: split queued session starts from creating

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1200,7 +1200,7 @@ func (cs *controllerState) WaitForSessionCommandable(ctx context.Context, sessio
 		switch info.State {
 		case session.StateActive, session.StateAwake, session.StateAsleep, session.StateSuspended, session.StateQuarantined:
 			return info, nil
-		case session.StateCreating, "":
+		case session.StateStartPending, session.StateCreating, "":
 		default:
 			return session.Info{}, fmt.Errorf("session %s reached non-commandable state %q", sessionID, info.State)
 		}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1184,7 +1184,7 @@ func retainScaleCheckPartialPoolDesired(counts map[string]int, sessionBeads *ses
 // failures, but do not count them as awake demand.
 func scaleCheckPartialSessionPreservable(b beads.Bead) bool {
 	switch strings.TrimSpace(b.Metadata["state"]) {
-	case "", "active", "awake", "creating", "asleep", "stopped", "suspended", "quarantined", "draining", "drained", "archived":
+	case "", "active", "awake", "start-pending", "creating", "asleep", "stopped", "suspended", "quarantined", "draining", "drained", "archived":
 		return true
 	default:
 		return isPendingPoolCreate(b)
@@ -1193,7 +1193,7 @@ func scaleCheckPartialSessionPreservable(b beads.Bead) bool {
 
 func scaleCheckPartialSessionRetainable(b beads.Bead) bool {
 	switch strings.TrimSpace(b.Metadata["state"]) {
-	case "active", "awake", "creating":
+	case "active", "awake", "start-pending", "creating":
 		return true
 	default:
 		return isPendingPoolCreate(b)
@@ -1438,7 +1438,7 @@ func discoverSessionBeadsWithRoots(
 		// no work.
 		if isEphemeralSessionBeadForAgent(b, cfgAgent) {
 			manualSession := isManualSessionBeadForAgent(b, cfgAgent)
-			creating := b.Metadata["state"] == "creating"
+			creating := b.Metadata["state"] == "creating" || b.Metadata["state"] == string(session.StateStartPending)
 			pendingCreate := isPendingPoolCreate(b)
 			templateDesired := desiredHasTemplate(desired, template)
 			// Pool-managed beads are controller-created capacity. A pending
@@ -1924,7 +1924,8 @@ func poolRuntimeAliasIsDeferred(sessionBead beads.Bead) bool {
 	if strings.TrimSpace(sessionBead.Metadata["pending_create_claim"]) == boolMetadata(true) {
 		return true
 	}
-	return strings.TrimSpace(sessionBead.Metadata["state"]) == "creating"
+	state := strings.TrimSpace(sessionBead.Metadata["state"])
+	return state == "creating" || state == string(session.StateStartPending)
 }
 
 func normalizeNonExpandingPoolSessionBead(

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -2236,7 +2236,7 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer, jsonOutput ...bool)
 
 func sessionKillRuntimeAlreadyInactive(bead beads.Bead, sp runtime.Provider) bool {
 	switch session.State(strings.TrimSpace(bead.Metadata["state"])) {
-	case session.StateActive, session.StateCreating, session.StateDraining, session.StateAwake:
+	case session.StateActive, session.StateStartPending, session.StateCreating, session.StateDraining, session.StateAwake:
 		return false
 	}
 	sessionName := strings.TrimSpace(bead.Metadata["session_name"])

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -293,7 +293,7 @@ func sessionLogFallbackCandidateLive(b beads.Bead) bool {
 		return false
 	}
 	switch sessionpkg.State(strings.TrimSpace(b.Metadata["state"])) {
-	case sessionpkg.StateActive, sessionpkg.StateAwake, sessionpkg.StateCreating, sessionpkg.StateDraining:
+	case sessionpkg.StateActive, sessionpkg.StateAwake, sessionpkg.StateStartPending, sessionpkg.StateCreating, sessionpkg.StateDraining:
 		return true
 	default:
 		return false

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1980,8 +1980,8 @@ func TestCmdSessionNew_AllowsReservedNamedAliasWithController(t *testing.T) {
 	if got := b.Metadata["alias"]; got != "mayor" {
 		t.Fatalf("alias = %q, want mayor", got)
 	}
-	if got := b.Metadata["state"]; got != "creating" {
-		t.Fatalf("state = %q, want creating", got)
+	if got := b.Metadata["state"]; got != string(session.StateStartPending) {
+		t.Fatalf("state = %q, want start-pending", got)
 	}
 }
 

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"time"
+
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 // defaultOnDemandIdleTimeout is the fallback idle timeout for on-demand
@@ -536,11 +538,20 @@ func collectCreatingBeads(beads []AwakeSessionBead, template string) []AwakeSess
 	for _, b := range beads {
 		// See collectActiveBeads above for why ConfiguredNamedSession beads
 		// must be excluded even when NamedIdentity is empty.
-		if b.Template == template && b.State == "creating" &&
+		if b.Template == template && isCreatingCandidateState(b.State) &&
 			b.NamedIdentity == "" && !b.ConfiguredNamedSession &&
 			!b.ManualSession && !b.Drained && !b.DependencyOnly {
 			result = append(result, b)
 		}
 	}
 	return result
+}
+
+func isCreatingCandidateState(state string) bool {
+	switch sessionpkg.State(state) {
+	case sessionpkg.StateStartPending, sessionpkg.StateCreating:
+		return true
+	default:
+		return false
+	}
 }

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 var now = time.Date(2026, 3, 31, 12, 0, 0, 0, time.UTC)
@@ -519,6 +520,19 @@ func TestScaled_NewDemandDoesNotUseActiveAssignedSessions(t *testing.T) {
 		assertAwake(t, result, "polecat-new-"+suffix)
 		assertReason(t, result, "polecat-new-"+suffix, "scaled:creating")
 	}
+}
+
+func TestScaled_DemandCountsStartPendingAsCreating(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-pending-1", SessionName: "polecat-pending-1", Template: "hello-world/polecat", State: string(sessionpkg.StateStartPending)},
+		},
+		ScaleCheckCounts: map[string]int{"hello-world/polecat": 1},
+		Now:              now,
+	})
+	assertAwake(t, result, "polecat-pending-1")
+	assertReason(t, result, "polecat-pending-1", "scaled:creating")
 }
 
 func TestScaled_Demand1_TwoActive(t *testing.T) {
@@ -1540,6 +1554,19 @@ func TestWorkSet_FallsBackToCreating(t *testing.T) {
 		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
 		SessionBeads: []AwakeSessionBead{
 			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "creating"},
+		},
+		WorkSet: map[string]bool{"hello-world/polecat": true},
+		Now:     now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "work-query")
+}
+
+func TestWorkSet_FallsBackToStartPending(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: string(sessionpkg.StateStartPending)},
 		},
 		WorkSet: map[string]bool{"hello-world/polecat": true},
 		Now:     now,

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 // SessionRequest represents a single session the reconciler should start.
@@ -275,7 +276,8 @@ func poolSessionConsumesNewDemand(session beads.Bead) bool {
 	// This pure desired-state pass has no reconciler clock. Creating sessions
 	// still represent already-spent new demand; lifecycle code owns stale
 	// creating recovery with its clock-aware predicate.
-	return strings.TrimSpace(session.Metadata["state"]) == "creating"
+	state := strings.TrimSpace(session.Metadata["state"])
+	return state == "creating" || state == string(sessionpkg.StateStartPending)
 }
 
 // applyNestedCaps enforces workspace, rig, and agent max_active_sessions caps.

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -63,6 +63,8 @@ func syncSessionCachedState(sessionName string, existing beads.Bead, exists bool
 		switch session.State(strings.TrimSpace(existing.Metadata["state"])) {
 		case "", session.StateActive, session.StateAwake:
 			return string(session.StateActive)
+		case session.StateStartPending:
+			return string(session.StateStartPending)
 		case session.StateCreating:
 			return string(session.StateCreating)
 		case session.StateAsleep, session.StateSuspended, session.StateDraining, session.StateArchived, session.StateQuarantined:
@@ -984,7 +986,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			// Create a new session bead.
 			createState := state
 			if createState != "active" {
-				createState = "creating"
+				createState = string(session.StateStartPending)
 			}
 			instanceToken := session.NewInstanceToken()
 			meta := map[string]string{

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -282,8 +282,8 @@ func TestSyncSessionBeads_CreatesNonActiveBeadWithPendingCreateStartedAt(t *test
 		t.Fatalf("expected 1 bead, got %d", len(all))
 	}
 	b := all[0]
-	if got := b.Metadata["state"]; got != "creating" {
-		t.Fatalf("state = %q, want creating", got)
+	if got := b.Metadata["state"]; got != string(session.StateStartPending) {
+		t.Fatalf("state = %q, want start-pending", got)
 	}
 	if got := b.Metadata["pending_create_claim"]; got != "true" {
 		t.Fatalf("pending_create_claim = %q, want true", got)
@@ -3890,8 +3890,8 @@ func TestSyncSessionBeads_StoppedAgent(t *testing.T) {
 	if len(all) != 1 {
 		t.Fatalf("expected 1 bead, got %d", len(all))
 	}
-	if all[0].Metadata["state"] != "creating" {
-		t.Errorf("state = %q, want %q", all[0].Metadata["state"], "creating")
+	if all[0].Metadata["state"] != string(session.StateStartPending) {
+		t.Errorf("state = %q, want %q", all[0].Metadata["state"], session.StateStartPending)
 	}
 	if all[0].Metadata["pending_create_claim"] != "true" {
 		t.Errorf("pending_create_claim = %q, want true", all[0].Metadata["pending_create_claim"])
@@ -4033,8 +4033,8 @@ func TestSyncSessionBeads_ResumedAfterSuspension(t *testing.T) {
 			closedCount++
 		case "open":
 			openCount++
-			if b.Metadata["state"] != "creating" {
-				t.Errorf("resumed bead state = %q, want %q", b.Metadata["state"], "creating")
+			if b.Metadata["state"] != string(session.StateStartPending) {
+				t.Errorf("resumed bead state = %q, want %q", b.Metadata["state"], session.StateStartPending)
 			}
 			if b.Metadata["pending_create_claim"] != "true" {
 				t.Errorf("resumed bead pending_create_claim = %q, want true", b.Metadata["pending_create_claim"])

--- a/cmd/gc/session_index.go
+++ b/cmd/gc/session_index.go
@@ -112,7 +112,7 @@ func (idx *sessionIndex) occupancy(template string) int {
 			continue
 		}
 		switch e.state {
-		case "creating", "active", "awake", "asleep", "suspended", "quarantined":
+		case "start-pending", "creating", "active", "awake", "asleep", "suspended", "quarantined":
 			count++
 		}
 	}

--- a/cmd/gc/session_lifecycle_chaos_test.go
+++ b/cmd/gc/session_lifecycle_chaos_test.go
@@ -1154,8 +1154,8 @@ func (h *sessionChaosHarness) reconcileTickWithReadyWait(readyWaitSet map[string
 
 func (h *sessionChaosHarness) assertCreatingIntent() {
 	b := h.mustBead()
-	if got := b.Metadata["state"]; got != string(sessionpkg.StateCreating) {
-		h.failf("new intent state = %q, want creating", got)
+	if got := b.Metadata["state"]; got != string(sessionpkg.StateStartPending) {
+		h.failf("new intent state = %q, want start-pending", got)
 	}
 	if got := b.Metadata["pending_create_claim"]; got != "true" {
 		h.failf("new intent pending_create_claim = %q, want true", got)

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1512,14 +1512,14 @@ func commitStartResult(
 
 // confirmPendingStart reports whether a session in the given metadata
 // state should be transitioned to "active" after a successful runtime
-// spawn. Empty, "creating", "asleep", and "drained" all indicate the
+// spawn. Empty, "start-pending", "creating", "asleep", and "drained" all indicate the
 // session was pending a spawn; "awake" is treated by the reconciler as
 // equivalent to "active" and is intentionally NOT restamped (a no-op
 // metadata write on every spawn). Any other state ("draining",
 // "archived", "quarantined", ...) is left alone.
 func confirmPendingStart(currentState string) bool {
 	switch sessionpkg.State(strings.TrimSpace(currentState)) {
-	case "", sessionpkg.StateCreating, sessionpkg.StateAsleep, sessionpkg.State("drained"):
+	case "", sessionpkg.StateStartPending, sessionpkg.StateCreating, sessionpkg.StateAsleep, sessionpkg.State("drained"):
 		return true
 	}
 	return false

--- a/cmd/gc/session_lifecycle_start_boundary_test.go
+++ b/cmd/gc/session_lifecycle_start_boundary_test.go
@@ -50,8 +50,8 @@ func TestExecutePreparedStartWaveUsesWorkerBoundaryForKnownSession(t *testing.T)
 	if err != nil {
 		t.Fatalf("Get session: %v", err)
 	}
-	if got.State != sessionpkg.StateCreating {
-		t.Fatalf("state = %q, want %q before commit", got.State, sessionpkg.StateCreating)
+	if got.State != sessionpkg.StateStartPending {
+		t.Fatalf("state = %q, want %q before lifecycle commit", got.State, sessionpkg.StateStartPending)
 	}
 	updatedBead, err := store.Get(info.ID)
 	if err != nil {

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -180,7 +180,7 @@ func createPoolSessionBeadWithAlias(
 	meta := map[string]string{
 		"template":                  template,
 		"agent_name":                agentName,
-		"state":                     "creating",
+		"state":                     string(sessionpkg.StateStartPending),
 		"pending_create_claim":      "true",
 		"pending_create_started_at": pendingCreateStartedAtNow(now),
 		"session_origin":            "ephemeral",
@@ -485,7 +485,7 @@ func poolLookupCandidateStateRank(b beads.Bead) int {
 	switch sessionMetadataState(b) {
 	case "active":
 		return 2
-	case "creating":
+	case "creating", string(sessionpkg.StateStartPending):
 		return 1
 	default:
 		return 0

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -169,6 +169,9 @@ func sessionWithinDesiredConfig(session beads.Bead, cfg *config.City, poolDesire
 }
 
 func sessionStartRequested(session beads.Bead, clk clock.Clock) bool {
+	if strings.TrimSpace(session.Metadata["state"]) == string(sessionpkg.StateStartPending) {
+		return true
+	}
 	if strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" {
 		return true
 	}
@@ -190,6 +193,8 @@ func sessionMetadataState(session beads.Bead) string {
 	switch state := strings.TrimSpace(session.Metadata["state"]); state {
 	case "awake":
 		return "active"
+	case string(sessionpkg.StateStartPending):
+		return "creating"
 	case "drained":
 		return "asleep"
 	default:
@@ -262,7 +267,7 @@ func capWakeConfigByDemand(sessions []beads.Bead, cfg *config.City, evals map[st
 
 		state := sessionMetadataState(session)
 		switch state {
-		case "active", "creating":
+		case "active", "start-pending", "creating":
 			// Already running or starting — counts against desired.
 			b.active++
 		default:
@@ -967,7 +972,7 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 		if alive {
 			target = string(sessionpkg.StateAwake)
 		} else if sessionStartRequested(session, clk) {
-			target = string(sessionpkg.StateCreating)
+			target = string(sessionpkg.StateStartPending)
 		}
 	}
 	// failed-create is a terminal rollback marker written by
@@ -1002,8 +1007,11 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 	// rollbackAvailable=false means the caller deferred the formal rollback
 	// (e.g. storeQueryPartial); preserve the claim so the next complete tick
 	// can drive attemptRollbackPendingCreate properly.
-	if rollbackAvailable && !alive && view.RuntimeProjection == sessionpkg.RuntimeProjectionStaleCreating {
+	stalePendingCreateRollback := false
+	if rollbackAvailable && !alive && strings.TrimSpace(meta["state"]) == "creating" {
 		if pendingCreateLeaseExpiredForRollback(session, clk, startupTimeout) {
+			target = string(sessionpkg.StateAsleep)
+			stalePendingCreateRollback = true
 			clearPendingCreateLease(meta, batch)
 		}
 	}
@@ -1012,7 +1020,7 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 	}
 	if meta["state"] != target {
 		batch["state"] = target
-		if target == string(sessionpkg.StateAsleep) && view.ResetContinuation && strings.TrimSpace(meta["sleep_reason"]) == "" {
+		if target == string(sessionpkg.StateAsleep) && (view.ResetContinuation || stalePendingCreateRollback) && strings.TrimSpace(meta["sleep_reason"]) == "" {
 			batch["sleep_reason"] = sleepReasonRuntimeMissing
 		}
 	}
@@ -1020,7 +1028,7 @@ func healStatePatchWithRollback(session beads.Bead, alive bool, clk clock.Clock,
 		if strings.TrimSpace(meta["sleep_reason"]) == "" && strings.TrimSpace(meta["state"]) == "failed-create" {
 			batch["sleep_reason"] = "failed-create"
 		}
-		if view.ResetContinuation {
+		if view.ResetContinuation || stalePendingCreateRollback {
 			if !isNamedSessionBead(session) || namedSessionMode(session) != "always" {
 				batch["session_key"] = ""
 				batch["started_config_hash"] = ""
@@ -1198,6 +1206,7 @@ var knownSessionStates = map[string]bool{
 	"orphaned":                           true,
 	"closed":                             true,
 	"quarantined":                        true,
+	string(sessionpkg.StateStartPending): true,
 	"creating":                           true,
 	"drained":                            true,
 	string(sessionpkg.StateFailedCreate): true, // processed so skip/orphan-close can release the slot

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1592,11 +1592,8 @@ func TestHealState_PreservesCreatingWhileStartRequested(t *testing.T) {
 	session := makeBead("b1", map[string]string{
 		"state":                "creating",
 		"pending_create_claim": "true",
+		"last_woke_at":         clk.Now().Add(-30 * time.Second).Format(time.RFC3339),
 	})
-	// #1460: pending_create_claim only short-circuits while the create
-	// lease is fresh. Pin CreatedAt to "now" so the bead is within the
-	// lease window — without this the zero CreatedAt is treated as stale
-	// and the bead correctly heals to asleep (covered by the test below).
 	session.CreatedAt = clk.Now().Add(-30 * time.Second)
 
 	healState(&session, false, store, clk)
@@ -1605,8 +1602,8 @@ func TestHealState_PreservesCreatingWhileStartRequested(t *testing.T) {
 	}
 }
 
-// #1460: stale-creating + pending_create_claim must heal to asleep so a
-// crashed creator does not strand the pool slot indefinitely.
+// #1460: stale provider-start creating + pending_create_claim must heal to
+// asleep so a crashed creator does not strand the pool slot indefinitely.
 func TestHealState_StaleCreatingWithPendingClaimHealsToAsleep(t *testing.T) {
 	store := newTestStore()
 	clk := &clock.Fake{Time: time.Date(2026, 3, 29, 4, 0, 0, 0, time.UTC)}
@@ -1614,12 +1611,34 @@ func TestHealState_StaleCreatingWithPendingClaimHealsToAsleep(t *testing.T) {
 	session := makeBead("b1", map[string]string{
 		"state":                "creating",
 		"pending_create_claim": "true",
+		"last_woke_at":         clk.Now().Add(-2 * time.Minute).Format(time.RFC3339),
 	})
 	session.CreatedAt = clk.Now().Add(-2 * time.Minute)
 
 	healState(&session, false, store, clk)
 	if session.Metadata["state"] != "asleep" {
 		t.Fatalf("state = %q, want asleep", session.Metadata["state"])
+	}
+}
+
+func TestHealState_NeverStartedPendingCreateMigratesToStartPendingUntilRollbackLeaseExpires(t *testing.T) {
+	store := newTestStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 18, 20, 0, 0, 0, time.UTC)}
+
+	startedAt := clk.Now().Add(-2 * time.Minute)
+	session := makeBead("b1", map[string]string{
+		"state":                     "creating",
+		"pending_create_claim":      "true",
+		"pending_create_started_at": pendingCreateStartedAtNow(startedAt),
+	})
+	session.CreatedAt = startedAt
+
+	healState(&session, false, store, clk)
+	if session.Metadata["state"] != string(sessionpkg.StateStartPending) {
+		t.Fatalf("state = %q, want start-pending while pending-create lease is active", session.Metadata["state"])
+	}
+	if got := len(store.metadata["b1"]); got != 1 {
+		t.Fatalf("healState wrote %d metadata entries for active pending-create lease; want state migration only", got)
 	}
 }
 
@@ -1805,13 +1824,13 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 			want: map[string]string{"state": "asleep"},
 		},
 		{
-			name:  "dead blank legacy state with create claim heals to creating",
+			name:  "dead blank legacy state with create claim heals to start-pending",
 			alive: false,
 			session: makeBead("b1", map[string]string{
 				"state":                "",
 				"pending_create_claim": "true",
 			}),
-			want: map[string]string{"state": "creating"},
+			want: map[string]string{"state": string(sessionpkg.StateStartPending)},
 		},
 		{
 			name:  "stale creating heals to asleep and resets stale resume identity",

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -476,7 +476,8 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 }
 
 func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
-	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" &&
+		sessionpkg.State(strings.TrimSpace(session.Metadata["state"])) != sessionpkg.StateCreating {
 		return false
 	}
 	lastWoke := strings.TrimSpace(session.Metadata["last_woke_at"])
@@ -528,7 +529,7 @@ func pendingCreateNeverStartedExpired(session beads.Bead, clk clock.Clock) bool 
 	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
 		return false
 	}
-	if strings.TrimSpace(session.Metadata["state"]) != "creating" {
+	if !pendingCreateRollbackState(session.Metadata["state"]) {
 		return false
 	}
 	return pendingCreateNeverStartedLeaseExpired(session, clk)
@@ -559,8 +560,15 @@ func pendingCreateLeaseExpiredForRollback(session beads.Bead, clk clock.Clock, s
 	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
 		return false
 	}
-	if strings.TrimSpace(session.Metadata["state"]) != "creating" {
+	state := sessionpkg.State(strings.TrimSpace(session.Metadata["state"]))
+	if !pendingCreateRollbackState(string(state)) {
 		return false
+	}
+	if state == sessionpkg.StateAsleep {
+		if strings.TrimSpace(session.Metadata["last_woke_at"]) == "" {
+			return pendingCreateNeverStartedExpired(session, clk)
+		}
+		return pendingCreateAttemptStale(session, clk)
 	}
 	if pendingCreateStartInFlight(session, clk, startupTimeout) {
 		return false
@@ -568,11 +576,29 @@ func pendingCreateLeaseExpiredForRollback(session beads.Bead, clk clock.Clock, s
 	if strings.TrimSpace(session.Metadata["last_woke_at"]) == "" {
 		return pendingCreateNeverStartedExpired(session, clk)
 	}
-	return staleCreatingState(session, clk)
+	return pendingCreateAttemptStale(session, clk)
+}
+
+func pendingCreateQueuedOrCreatingState(state string) bool {
+	switch sessionpkg.State(strings.TrimSpace(state)) {
+	case sessionpkg.StateStartPending, sessionpkg.StateCreating:
+		return true
+	default:
+		return false
+	}
+}
+
+func pendingCreateRollbackState(state string) bool {
+	if pendingCreateQueuedOrCreatingState(state) {
+		return true
+	}
+	return sessionpkg.State(strings.TrimSpace(state)) == sessionpkg.StateAsleep
 }
 
 func pendingResumePreservingNamedRestart(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
-	if strings.TrimSpace(session.Metadata["state"]) != string(sessionpkg.StateCreating) {
+	switch sessionpkg.State(strings.TrimSpace(session.Metadata["state"])) {
+	case sessionpkg.StateStartPending, sessionpkg.StateCreating:
+	default:
 		return false
 	}
 	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
@@ -1481,11 +1507,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			clearChurn(session, store)
 		}
 		if alive && shouldRollbackPendingCreate(session) {
-			if stateBeforeHeal == sessionpkg.StateCreating && pendingCreateStartInFlight(*session, clk, startupTimeout) {
-				if trace != nil {
-					trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_recovery_in_flight", "deferred", nil, nil, "")
+			switch stateBeforeHeal {
+			case sessionpkg.StateStartPending, sessionpkg.StateCreating:
+				if pendingCreateStartInFlight(*session, clk, startupTimeout) {
+					if trace != nil {
+						trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_recovery_in_flight", "deferred", nil, nil, "")
+					}
+					continue
 				}
-				continue
 			}
 			if !recoverRunningPendingCreate(session, tp, cfg, store, clk, trace) {
 				fmt.Fprintf(stderr, "session reconciler: recovering pending create %s: metadata repair incomplete\n", name) //nolint:errcheck
@@ -1592,7 +1621,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								}
 								continue
 							}
-							resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, "creating", clk.Now().UTC(), stderr)
+							resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, string(sessionpkg.StateStartPending), clk.Now().UTC(), stderr)
 							if trace != nil {
 								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "restart_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
 							}
@@ -2816,7 +2845,7 @@ func traceHealClearedPendingCreateLease(
 	providerAlive bool,
 	batch map[string]string,
 ) {
-	if trace == nil || strings.TrimSpace(stateBeforeHeal) != string(sessionpkg.StateCreating) {
+	if trace == nil || !pendingCreateQueuedOrCreatingState(stateBeforeHeal) {
 		return
 	}
 	if cleared, ok := batch["pending_create_claim"]; !ok || cleared != "" {
@@ -2940,7 +2969,7 @@ func resetConfiguredNamedSessionForConfigDrift(
 	nextSessionState := sessionpkg.State(nextState)
 	priorSessionKey := strings.TrimSpace(session.Metadata["session_key"])
 	priorStartedConfigHash := strings.TrimSpace(session.Metadata["started_config_hash"])
-	preserveResume := nextSessionState == sessionpkg.StateCreating &&
+	preserveResume := (nextSessionState == sessionpkg.StateStartPending || nextSessionState == sessionpkg.StateCreating) &&
 		priorSessionKey != "" && priorStartedConfigHash != ""
 
 	rotatedSessionKey := ""

--- a/cmd/gc/session_reconciler_drift_resume_test.go
+++ b/cmd/gc/session_reconciler_drift_resume_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 // TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyOnContinuationReset
@@ -186,8 +187,8 @@ func TestReconcileSessionBeads_PreservesSessionKeyWhenNamedRestartDeferred(t *te
 	if env.sp.IsRunning(sessionName) {
 		t.Fatalf("%s should have been stopped for in-place config-drift restart", sessionName)
 	}
-	if got := deferred.Metadata["state"]; got != "creating" {
-		t.Fatalf("state after deferred restart = %q, want creating", got)
+	if got := deferred.Metadata["state"]; got != string(sessionpkg.StateStartPending) {
+		t.Fatalf("state after deferred restart = %q, want start-pending", got)
 	}
 	if got := deferred.Metadata["pending_create_claim"]; got != "true" {
 		t.Fatalf("pending_create_claim after deferred restart = %q, want true", got)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -8473,8 +8473,8 @@ func TestReconcileSessionBeads_SyncReplacesFailedCreateNamedSession(t *testing.T
 	if fresh.ID == "" {
 		t.Fatalf("sync did not create a fresh named-session bead; open sessions=%#v stderr:\n%s", sessions, stderr.String())
 	}
-	if fresh.Metadata["state"] != string(sessionpkg.StateCreating) {
-		t.Fatalf("fresh named-session state = %q, want creating", fresh.Metadata["state"])
+	if fresh.Metadata["state"] != string(sessionpkg.StateStartPending) {
+		t.Fatalf("fresh named-session state = %q, want start-pending", fresh.Metadata["state"])
 	}
 
 	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessions, dsResult.ScaleCheckCounts))

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -56,7 +56,7 @@ func preWakeCommit(
 		sleepReason = "idle-timeout"
 	}
 
-	freshWake := session.Metadata["wake_mode"] == "fresh"
+	freshWake := session.Metadata["wake_mode"] == "fresh" || pendingContinuationResetNeedsFreshStart(session.Metadata)
 	batch := sessions.PreWakePatch(sessions.PreWakePatchInput{
 		Generation:        newGen,
 		InstanceToken:     token,
@@ -108,6 +108,18 @@ func shouldBumpContinuationEpoch(meta map[string]string) bool {
 		return true
 	}
 	return meta["wake_mode"] == "fresh" && meta["last_woke_at"] != ""
+}
+
+func pendingContinuationResetNeedsFreshStart(meta map[string]string) bool {
+	if meta == nil {
+		return false
+	}
+	switch sessions.State(strings.TrimSpace(meta["state"])) {
+	case sessions.StateStartPending, sessions.StateCreating:
+		return false
+	}
+	return strings.TrimSpace(meta["continuation_reset_pending"]) != "" &&
+		strings.TrimSpace(meta["started_config_hash"]) != ""
 }
 
 // validateWorkDir ensures the path is safe to use as a working directory.

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -436,7 +436,7 @@ func (m *Manager) confirmLiveSessionState(id string, b *beads.Bead) error {
 	}
 	batch := make(map[string]string)
 	switch State(b.Metadata["state"]) {
-	case "", StateCreating, StateAsleep, StateSuspended:
+	case "", StateStartPending, StateCreating, StateAsleep, StateSuspended:
 		batch["state"] = string(StateActive)
 		batch["state_reason"] = "creation_complete"
 	}

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -15,6 +15,9 @@ const (
 	BaseStateNone BaseState = ""
 	// BaseStateCreating means the session is being started.
 	BaseStateCreating BaseState = "creating"
+	// BaseStateStartPending means a start is desired but no provider Start
+	// call has been committed yet.
+	BaseStateStartPending BaseState = "start-pending"
 	// BaseStateActive means the session is running and available.
 	BaseStateActive BaseState = "active"
 	// BaseStateAsleep means the session is intentionally stopped but resumable.
@@ -411,6 +414,8 @@ func projectBaseState(status, storedState, sleepReason string) BaseState {
 	switch strings.TrimSpace(storedState) {
 	case "":
 		return BaseStateNone
+	case string(StateStartPending):
+		return BaseStateStartPending
 	case string(StateCreating):
 		return BaseStateCreating
 	case string(StateActive), string(StateAwake):
@@ -447,6 +452,8 @@ func projectBaseState(status, storedState, sleepReason string) BaseState {
 
 func compatStateForBase(base BaseState) State {
 	switch base {
+	case BaseStateStartPending:
+		return StateStartPending
 	case BaseStateCreating:
 		return StateCreating
 	case BaseStateActive:
@@ -550,12 +557,18 @@ func projectRuntimeProjection(input LifecycleInput, base BaseState, compat State
 	if base == BaseStateNone || base == BaseStateClosed || base == BaseStateClosing {
 		return RuntimeProjectionMissing, compat, false
 	}
-	// #1460: When base is BaseStateCreating, evaluate staleness first.
-	// pending_create_claim represents an in-flight create attempt and is
-	// honored only while the lease (StaleCreatingAfter) is fresh. Once the
-	// lease expires with no live runtime, the claim no longer protects the
-	// bead — otherwise a crashed creator strands the slot indefinitely.
+	if base == BaseStateStartPending {
+		return RuntimeProjectionStartRequested, StateStartPending, false
+	}
+	// #1460: A creating bead with last_woke_at represents an in-flight provider
+	// Start attempt and must age out through the stale-creating path. Legacy
+	// rows that never reached the start boundary have no last_woke_at; project
+	// those back to start-pending so the controller can safely start them.
 	if base == BaseStateCreating {
+		if strings.TrimSpace(input.Metadata["pending_create_claim"]) == "true" &&
+			strings.TrimSpace(input.Metadata["last_woke_at"]) == "" {
+			return RuntimeProjectionStartRequested, StateStartPending, false
+		}
 		if !creatingStateIsStale(input) {
 			if hasWakeCause(wakeCauses, WakeCausePendingCreate) {
 				return RuntimeProjectionStartRequested, StateCreating, false
@@ -568,7 +581,7 @@ func projectRuntimeProjection(input LifecycleInput, base BaseState, compat State
 		return RuntimeProjectionMissing, StateFailedCreate, false
 	}
 	if hasWakeCause(wakeCauses, WakeCausePendingCreate) {
-		return RuntimeProjectionStartRequested, StateCreating, false
+		return RuntimeProjectionStartRequested, StateStartPending, false
 	}
 	return RuntimeProjectionMissing, StateAsleep, shouldResetContinuation(base, input.Metadata, sleepReason)
 }
@@ -650,7 +663,7 @@ func projectDesiredState(input LifecycleInput, terminal bool, blockers []Lifecyc
 
 func countsAgainstCapacity(base BaseState) bool {
 	switch base {
-	case BaseStateCreating, BaseStateActive, BaseStateDraining, BaseStateQuarantined:
+	case BaseStateStartPending, BaseStateCreating, BaseStateActive, BaseStateDraining, BaseStateQuarantined:
 		return true
 	default:
 		return false

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -472,6 +472,7 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 					"session_name":         "s-worker",
 					"session_key":          "old-provider-conversation",
 					"pending_create_claim": "true",
+					"last_woke_at":         now.Add(-2 * time.Minute).UTC().Format(time.RFC3339),
 				},
 				Runtime:            RuntimeFacts{Observed: true, Alive: false},
 				CreatedAt:          now.Add(-2 * time.Minute),
@@ -481,6 +482,23 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 			wantRuntime:         RuntimeProjectionStaleCreating,
 			wantReconciledState: StateAsleep,
 			wantReset:           true,
+		},
+		{
+			name: "start-pending with pending_create_claim stays start-pending",
+			input: LifecycleInput{
+				Status: "open",
+				Metadata: map[string]string{
+					"state":                string(StateStartPending),
+					"session_name":         "s-worker",
+					"pending_create_claim": "true",
+				},
+				Runtime:            RuntimeFacts{Observed: true, Alive: false},
+				CreatedAt:          now.Add(-2 * time.Minute),
+				StaleCreatingAfter: time.Minute,
+				Now:                now,
+			},
+			wantRuntime:         RuntimeProjectionStartRequested,
+			wantReconciledState: StateStartPending,
 		},
 		{
 			// Counterpart: while the lease is still fresh, pending_create_claim
@@ -493,6 +511,7 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 					"state":                "creating",
 					"session_name":         "s-worker",
 					"pending_create_claim": "true",
+					"last_woke_at":         now.Add(-30 * time.Second).UTC().Format(time.RFC3339),
 				},
 				Runtime:            RuntimeFacts{Observed: true, Alive: false},
 				CreatedAt:          now.Add(-30 * time.Second),
@@ -532,7 +551,7 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 				Now:     now,
 			},
 			wantRuntime:         RuntimeProjectionStartRequested,
-			wantReconciledState: StateCreating,
+			wantReconciledState: StateStartPending,
 		},
 	}
 

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -99,7 +99,9 @@ type PreWakePatchInput struct {
 }
 
 // PreWakePatch records the metadata transition for a concrete runtime wake
-// attempt.
+// attempt. It intentionally owns the StateStartPending to StateCreating
+// provider-start boundary outside Transition because this patch is the atomic
+// reconciler commit made immediately before runtime start.
 func PreWakePatch(input PreWakePatchInput) MetadataPatch {
 	patch := MetadataPatch{
 		"instance_token":             input.InstanceToken,

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -71,7 +71,7 @@ func RequestExplicitWakePatch(reason string, now time.Time) MetadataPatch {
 // RequestWakePatch records a controller-owned one-shot create claim.
 func RequestWakePatch(reason string, now time.Time) MetadataPatch {
 	return MetadataPatch{
-		"state":                     string(StateCreating),
+		"state":                     string(StateStartPending),
 		"state_reason":              reason,
 		"pending_create_claim":      "true",
 		"pending_create_started_at": pendingCreateStartedAt(now),
@@ -106,6 +106,8 @@ func PreWakePatch(input PreWakePatchInput) MetadataPatch {
 		"continuation_epoch":         fmt.Sprintf("%d", input.ContinuationEpoch),
 		"continuation_reset_pending": "",
 		"detached_at":                "",
+		"state":                      string(StateCreating),
+		"pending_create_started_at":  pendingCreateStartedAt(input.Now),
 		"last_woke_at":               input.Now.UTC().Format(time.RFC3339),
 		"sleep_reason":               input.SleepReason,
 		"sleep_intent":               "",
@@ -117,6 +119,17 @@ func PreWakePatch(input PreWakePatchInput) MetadataPatch {
 		patch["session_key"] = ""
 		applyFreshWakeConversationReset(patch)
 	}
+	return patch
+}
+
+// ContinuationResetWakePatch records a controller-owned fresh wake for a
+// session whose pending continuation reset was observed while a stale runtime
+// was still alive.
+func ContinuationResetWakePatch(now time.Time) MetadataPatch {
+	patch := RequestWakePatch("continuation-reset", now)
+	patch["session_key"] = ""
+	applyFreshWakeConversationReset(patch)
+	patch["continuation_reset_pending"] = "true"
 	return patch
 }
 
@@ -208,9 +221,10 @@ type CommitStartedPatchInput struct {
 // configuration hashes that future drift checks use.
 func CommitStartedPatch(input CommitStartedPatchInput) MetadataPatch {
 	patch := MetadataPatch{
-		"started_config_hash": input.CoreHash,
-		"live_hash":           input.LiveHash,
-		"started_live_hash":   input.LiveHash,
+		"started_config_hash":        input.CoreHash,
+		"live_hash":                  input.LiveHash,
+		"started_live_hash":          input.LiveHash,
+		"continuation_reset_pending": "",
 	}
 	if input.CoreBreakdown != "" {
 		patch["core_hash_breakdown"] = input.CoreBreakdown
@@ -218,6 +232,7 @@ func CommitStartedPatch(input CommitStartedPatchInput) MetadataPatch {
 	if input.ConfirmState {
 		patch["state"] = string(StateActive)
 		patch["state_reason"] = "creation_complete"
+		patch["pending_create_started_at"] = ""
 	}
 	// creation_complete_at tracks when the runtime was last confirmed started.
 	// Stamp it whenever Now is non-zero — the ConfirmState path marks the
@@ -340,7 +355,7 @@ func ConfigDriftResetPatch(nextState State, sessionKey string, now time.Time) Me
 		"pending_create_started_at":  "",
 	}
 	applyFreshWakeConversationReset(patch)
-	if nextState == StateCreating {
+	if nextState == StateCreating || nextState == StateStartPending {
 		patch["pending_create_claim"] = "true"
 		patch["pending_create_started_at"] = pendingCreateStartedAt(now)
 	}

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -28,7 +28,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			name:  "request wake",
 			patch: RequestWakePatch("explicit", now),
 			want: MetadataPatch{
-				"state":                     string(StateCreating),
+				"state":                     string(StateStartPending),
 				"state_reason":              "explicit",
 				"pending_create_claim":      "true",
 				"pending_create_started_at": now.UTC().Format(time.RFC3339),
@@ -56,6 +56,8 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"continuation_epoch":         "2",
 				"continuation_reset_pending": "",
 				"detached_at":                "",
+				"state":                      string(StateCreating),
+				"pending_create_started_at":  now.UTC().Format(time.RFC3339),
 				"last_woke_at":               now.UTC().Format(time.RFC3339),
 				"sleep_reason":               "idle-timeout",
 				"sleep_intent":               "",
@@ -78,6 +80,8 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"continuation_epoch":         "5",
 				"continuation_reset_pending": "",
 				"detached_at":                "",
+				"state":                      string(StateCreating),
+				"pending_create_started_at":  now.UTC().Format(time.RFC3339),
 				"last_woke_at":               now.UTC().Format(time.RFC3339),
 				"sleep_reason":               "",
 				"sleep_intent":               "",
@@ -89,6 +93,29 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"started_live_hash":          "",
 				"live_hash":                  "",
 				"startup_dialog_verified":    "",
+			},
+		},
+		{
+			name:  "continuation reset wake",
+			patch: ContinuationResetWakePatch(now),
+			want: MetadataPatch{
+				"state":                      string(StateStartPending),
+				"state_reason":               "continuation-reset",
+				"pending_create_claim":       "true",
+				"pending_create_started_at":  now.UTC().Format(time.RFC3339),
+				"held_until":                 "",
+				"quarantined_until":          "",
+				"sleep_reason":               "",
+				"wait_hold":                  "",
+				"sleep_intent":               "",
+				"wake_attempts":              "0",
+				"churn_count":                "0",
+				"session_key":                "",
+				"started_config_hash":        "",
+				"started_live_hash":          "",
+				"live_hash":                  "",
+				"startup_dialog_verified":    "",
+				"continuation_reset_pending": "true",
 			},
 		},
 		{
@@ -416,8 +443,8 @@ func TestMetadataPatchApplyReturnsMergedCopy(t *testing.T) {
 	patch := RequestWakePatch("pin", time.Date(2026, 4, 15, 13, 0, 0, 0, time.UTC))
 
 	merged := patch.Apply(original)
-	if merged["state"] != string(StateCreating) {
-		t.Fatalf("merged state = %q, want creating", merged["state"])
+	if merged["state"] != string(StateStartPending) {
+		t.Fatalf("merged state = %q, want start-pending", merged["state"])
 	}
 	if merged["session_name"] != "s-worker" {
 		t.Fatalf("merged session_name = %q, want preserved", merged["session_name"])
@@ -440,16 +467,17 @@ func TestCommitStartedPatchBuildsAtomicStartMetadata(t *testing.T) {
 	})
 
 	want := MetadataPatch{
-		"started_config_hash":       "core-hash",
-		"live_hash":                 "live-hash",
-		"started_live_hash":         "live-hash",
-		"core_hash_breakdown":       `{"command":"core-hash"}`,
-		"state":                     string(StateActive),
-		"state_reason":              "creation_complete",
-		"creation_complete_at":      now.Format(time.RFC3339),
-		"sleep_reason":              "",
-		"pending_create_claim":      "",
-		"pending_create_started_at": "",
+		"started_config_hash":        "core-hash",
+		"live_hash":                  "live-hash",
+		"started_live_hash":          "live-hash",
+		"continuation_reset_pending": "",
+		"core_hash_breakdown":        `{"command":"core-hash"}`,
+		"state":                      string(StateActive),
+		"state_reason":               "creation_complete",
+		"creation_complete_at":       now.Format(time.RFC3339),
+		"sleep_reason":               "",
+		"pending_create_claim":       "",
+		"pending_create_started_at":  "",
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)
@@ -483,6 +511,22 @@ func TestCommitStartedPatchClearsPendingCreateClaimAtomicallyWithStateTransition
 	}
 }
 
+func TestCommitStartedPatchClearsCreateStartedAtWhenConfirmingNoClaimStart(t *testing.T) {
+	now := time.Date(2026, 5, 19, 15, 0, 0, 0, time.UTC)
+	patch := CommitStartedPatch(CommitStartedPatchInput{
+		CoreHash:     "c",
+		LiveHash:     "l",
+		ConfirmState: true,
+		Now:          now,
+	})
+	if got := patch["pending_create_started_at"]; got != "" {
+		t.Fatalf("pending_create_started_at = %q, want cleared", got)
+	}
+	if _, ok := patch["pending_create_claim"]; ok {
+		t.Fatalf("pending_create_claim should not be touched for a no-claim start: %#v", patch)
+	}
+}
+
 func TestCommitStartedPatchCanPersistHashesWithoutRestampingState(t *testing.T) {
 	patch := CommitStartedPatch(CommitStartedPatchInput{
 		CoreHash:         "core-hash",
@@ -491,10 +535,11 @@ func TestCommitStartedPatchCanPersistHashesWithoutRestampingState(t *testing.T) 
 	})
 
 	want := MetadataPatch{
-		"started_config_hash": "core-hash",
-		"live_hash":           "live-hash",
-		"started_live_hash":   "live-hash",
-		"sleep_reason":        "",
+		"started_config_hash":        "core-hash",
+		"live_hash":                  "live-hash",
+		"started_live_hash":          "live-hash",
+		"continuation_reset_pending": "",
+		"sleep_reason":               "",
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -31,7 +31,10 @@ const (
 	StateAsleep State = "asleep"
 	// StateSuspended means the conversation is paused with no runtime resources.
 	StateSuspended State = "suspended"
-	// StateCreating means the session bead has been written but the runtime
+	// StateStartPending means the controller has reserved a session identity
+	// and should start it, but no provider Start call is currently in flight.
+	StateStartPending State = "start-pending"
+	// StateCreating means the provider Start call is in flight and the runtime
 	// process has not yet been confirmed alive. Counts against pool occupancy.
 	StateCreating State = "creating"
 	// StateFailedCreate means create rollback wrote terminal metadata but the
@@ -594,8 +597,9 @@ func runtimeSessionMatchesBead(sp runtime.Provider, sessionName, beadID, instanc
 }
 
 // CreateBeadOnly creates a session bead without starting the runtime process.
-// The bead is created with state "creating" — the controller's reconciler
-// will detect it in buildDesiredState and start the process on its next tick.
+// The bead is created with state "start-pending" — the controller's
+// reconciler will detect it in buildDesiredState and start the process on its
+// next tick.
 //
 // This is the Phase 2 path: CLI creates intent (bead), reconciler executes.
 func (m *Manager) CreateBeadOnly(template, title, command, workDir, provider, transport string, env map[string]string, resume ProviderResume) (Info, error) {
@@ -651,7 +655,7 @@ func (m *Manager) createAliasedBeadOnlyNamed(alias, explicitName, template, titl
 
 		meta := map[string]string{
 			"template":           template,
-			"state":              "creating",
+			"state":              string(StateStartPending),
 			"provider":           provider,
 			"work_dir":           workDir,
 			"command":            command,
@@ -924,7 +928,7 @@ func (m *Manager) Kill(id string) error {
 	// state can lag behind reality, so also check provider liveness.
 	state := State(b.Metadata["state"])
 	switch state {
-	case StateActive, StateCreating, StateDraining, StateAwake:
+	case StateActive, StateStartPending, StateCreating, StateDraining, StateAwake:
 		// Known live states — proceed.
 	default:
 		if !m.sp.IsRunning(sessName) {
@@ -1178,7 +1182,7 @@ func (m *Manager) UpdateTemplateOverrides(id string, updates map[string]string) 
 // for template override changes that only apply on the next launch.
 func IsTemplateOverrideRuntimeActive(state State) bool {
 	switch state {
-	case StateActive, StateAwake, StateCreating, StateDraining, StateQuarantined:
+	case StateActive, StateAwake, StateStartPending, StateCreating, StateDraining, StateQuarantined:
 		return true
 	default:
 		return false

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -632,9 +632,9 @@ func TestCreateBeadOnly(t *testing.T) {
 		t.Error("runtime session should not be started in bead-only mode")
 	}
 
-	// Verify bead was created with state "creating" (not "active").
-	if b.Metadata["state"] != "creating" {
-		t.Errorf("bead state = %q, want %q", b.Metadata["state"], "creating")
+	// Verify bead was created with state "start-pending" (not "active").
+	if b.Metadata["state"] != string(StateStartPending) {
+		t.Errorf("bead state = %q, want %q", b.Metadata["state"], StateStartPending)
 	}
 	if b.Metadata["session_name"] == "" {
 		t.Error("bead missing session_name metadata")

--- a/internal/session/state_machine.go
+++ b/internal/session/state_machine.go
@@ -43,7 +43,7 @@ type TransitionCommand string
 
 const (
 	// CmdCreate writes a new session bead.
-	// Transitions: (nil) → StateCreating → StateActive.
+	// Transitions: (nil) → StateStartPending.
 	CmdCreate TransitionCommand = "create"
 
 	// CmdReady confirms the runtime process is alive.
@@ -91,7 +91,7 @@ const StateClosed State = "closed"
 
 // StateNone is the virtual state before a session is created. Used as the
 // source state for CmdCreate — transitions from StateNone can only go to
-// StateCreating (via CmdCreate) and nothing else.
+// StateStartPending (via CmdCreate) and nothing else.
 const StateNone State = ""
 
 // anyState is a sentinel used in the transitions table to mean "any non-none
@@ -101,7 +101,7 @@ const anyState State = "*"
 // transitions is the allowed (command, from-state) → to-state table.
 var transitions = map[TransitionCommand]map[State]State{
 	CmdCreate: {
-		StateNone: StateCreating,
+		StateNone: StateStartPending,
 	},
 	CmdReady: {
 		StateCreating: StateActive,

--- a/internal/session/state_machine.go
+++ b/internal/session/state_machine.go
@@ -47,6 +47,10 @@ const (
 	CmdCreate TransitionCommand = "create"
 
 	// CmdReady confirms the runtime process is alive.
+	// The provider-start boundary from StateStartPending to StateCreating is
+	// intentionally owned by PreWakePatch, not this advisory command table,
+	// because it is an internal reconciler metadata commit immediately before
+	// runtime start rather than an operator/API command.
 	// Transitions: StateCreating → StateActive.
 	CmdReady TransitionCommand = "ready"
 

--- a/internal/session/state_machine_test.go
+++ b/internal/session/state_machine_test.go
@@ -16,7 +16,7 @@ func TestTransitionLegalMoves(t *testing.T) {
 		cmd  TransitionCommand
 		to   State
 	}{
-		{StateNone, CmdCreate, StateCreating},
+		{StateNone, CmdCreate, StateStartPending},
 		{StateCreating, CmdReady, StateActive},
 
 		{StateActive, CmdSuspend, StateSuspended},
@@ -45,6 +45,7 @@ func TestTransitionLegalMoves(t *testing.T) {
 		{StateAsleep, CmdClose, StateClosed},
 		{StateSuspended, CmdClose, StateClosed},
 		{StateDraining, CmdClose, StateClosed},
+		{StateStartPending, CmdClose, StateClosed},
 		{StateCreating, CmdClose, StateClosed},
 		{StateArchived, CmdClose, StateClosed},
 		{StateQuarantined, CmdClose, StateClosed},

--- a/internal/session/submit.go
+++ b/internal/session/submit.go
@@ -111,7 +111,7 @@ func (m *Manager) submit(ctx context.Context, id, message, resumeCommand string,
 			return m.interruptAndSubmitLocked(ctx, id, b, sessName, message, resumeCommand, hints)
 		default:
 			running := m.sp.IsRunning(sessName)
-			if State(b.Metadata["state"]) == StateCreating && !running {
+			if (State(b.Metadata["state"]) == StateStartPending || State(b.Metadata["state"]) == StateCreating) && !running {
 				if err := m.enqueueDeferredSubmitLocked(b, sessName, message); err != nil {
 					return err
 				}

--- a/internal/worker/handle_lifecycle.go
+++ b/internal/worker/handle_lifecycle.go
@@ -198,7 +198,7 @@ func (h *SessionHandle) State(ctx context.Context) (State, error) {
 	}
 
 	switch info.State {
-	case sessionpkg.StateCreating:
+	case sessionpkg.StateStartPending, sessionpkg.StateCreating:
 		state.Phase = PhaseStarting
 		return state, nil
 	case sessionpkg.StateDraining:
@@ -425,11 +425,13 @@ func (h *SessionHandle) currentSessionID() string {
 }
 
 func (h *SessionHandle) startCommand(id string) (string, error) {
-	info, err := h.manager.Get(id)
+	info, b, err := h.manager.GetWithBead(id)
 	if err != nil {
 		return "", err
 	}
-	if info.State == sessionpkg.StateCreating && h.session.Resume.SessionIDFlag != "" && strings.TrimSpace(info.SessionKey) != "" {
+	if firstProviderSessionStart(info.State, b.Metadata) &&
+		h.session.Resume.SessionIDFlag != "" &&
+		strings.TrimSpace(info.SessionKey) != "" {
 		command := strings.TrimSpace(info.Command)
 		if command == "" {
 			command = strings.TrimSpace(h.session.Command)
@@ -462,6 +464,18 @@ func (h *SessionHandle) startCommand(id string) (string, error) {
 		resumeInfo.ResumeCommand = resumeCommand
 	}
 	return sessionpkg.BuildResumeCommand(resumeInfo), nil
+}
+
+func firstProviderSessionStart(state sessionpkg.State, metadata map[string]string) bool {
+	switch state {
+	case sessionpkg.StateStartPending, sessionpkg.StateCreating:
+	default:
+		return false
+	}
+	if strings.TrimSpace(metadata["creation_complete_at"]) != "" {
+		return false
+	}
+	return strings.TrimSpace(metadata["started_config_hash"]) == ""
 }
 
 func (h *SessionHandle) providerLabel() string {

--- a/internal/worker/handle_test.go
+++ b/internal/worker/handle_test.go
@@ -242,8 +242,8 @@ func TestSessionHandleCreateDeferred(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store.Get(%q): %v", info.ID, err)
 	}
-	if bead.Metadata["state"] != string(sessionpkg.StateCreating) {
-		t.Fatalf("bead state = %q, want %q", bead.Metadata["state"], sessionpkg.StateCreating)
+	if bead.Metadata["state"] != string(sessionpkg.StateStartPending) {
+		t.Fatalf("bead state = %q, want %q", bead.Metadata["state"], sessionpkg.StateStartPending)
 	}
 	if bead.Metadata["pending_create_claim"] != "true" {
 		t.Fatalf("pending_create_claim = %q, want true", bead.Metadata["pending_create_claim"])


### PR DESCRIPTION
Summary:
- Introduce `start-pending` for queued session starts before provider Start is in flight.
- Move provider wake metadata to the pre-wake boundary and keep capacity/lifecycle projections aware of both queued and creating states.
- Updates session, worker, reconciler, and CLI expectations for the split.

Tests:
- go test ./internal/session ./internal/worker
- go test ./cmd/gc -run 'Test(CmdSessionNew_AllowsReservedNamedAliasWithController|SessionLifecycleChaos|ExecutePreparedStartWaveUsesWorkerBoundaryForKnownSession|HealState_|HealStatePatchProjectsRuntimeLiveness|ReconcileSessionBeads_PreservesSessionKeyWhenNamedRestartDeferred|ReconcileSessionBeads_SyncReplacesFailedCreateNamedSession)$'\n- go test ./cmd/gc -run 'TestSyncSessionBeads_(CreatesNonActiveBeadWithPendingCreateStartedAt|StoppedAgent|ResumedAfterSuspension)$'\n- pre-commit fast suite passed\n\nNote:\n- Full `go test ./cmd/gc` was used during iteration to find lifecycle expectation drift; final verification is the targeted coverage above plus the repo fast shard hook.