### PR TITLE
fix: create pool session beads with explicit IDs

### DIFF
--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -502,7 +502,7 @@ var initRunVersion = func(binary string) (string, error) {
 // Minimum versions for beads-provider binaries.
 const (
 	doltMinVersion = doltversion.ManagedMin // sql-server features used by gc-beads-bd
-	bdMinVersion   = "1.0.0"                // BdStore shell-out interface
+	bdMinVersion   = "1.0.4"                // BdStore shell-out interface, including bd create --id
 )
 
 // checkHardDependencies verifies that all required binaries are available

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -745,6 +745,41 @@ func TestCheckHardDependenciesAcceptsPythonFallbackForBdContract(t *testing.T) {
 	}
 }
 
+func TestCheckHardDependenciesRejectsBdBelowExplicitIDSupport(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	oldLookPath := initLookPath
+	initLookPath = func(name string) (string, error) {
+		return "/usr/bin/" + name, nil
+	}
+	t.Cleanup(func() { initLookPath = oldLookPath })
+
+	oldRunVersion := initRunVersion
+	initRunVersion = func(binary string) (string, error) {
+		switch binary {
+		case "bd":
+			return "bd version 1.0.3", nil
+		case "dolt":
+			return "dolt version " + doltMinVersion, nil
+		case "flock", "tmux", "jq", "git", "pgrep", "lsof":
+			return binary + " version", nil
+		default:
+			return binary + " version " + doltMinVersion, nil
+		}
+	}
+	t.Cleanup(func() { initRunVersion = oldRunVersion })
+
+	missing := checkHardDependencies(t.TempDir())
+	if len(missing) != 1 {
+		t.Fatalf("missing deps = %#v, want only bd version rejection", missing)
+	}
+	for _, want := range []string{"bd", "1.0.3", "1.0.4"} {
+		if !strings.Contains(missing[0].name, want) {
+			t.Fatalf("missing dep = %#v, want %q", missing[0], want)
+		}
+	}
+}
+
 func TestCheckHardDependenciesRejectsDoltPreReleaseAtFloor(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -22,6 +22,10 @@ type poolSessionCreateIdentity struct {
 	Slot      int
 }
 
+type explicitBeadIDStore interface {
+	IDPrefix() string
+}
+
 func isPoolManagedSessionBead(bead beads.Bead) bool {
 	if isEphemeralSessionBead(bead) {
 		return true
@@ -177,6 +181,11 @@ func createPoolSessionBeadWithAlias(
 	} else {
 		title = agentName
 	}
+	explicitID := poolSessionExplicitBeadID(store, instanceToken)
+	sessionName := pendingPoolSessionName(template, instanceToken)
+	if explicitID != "" {
+		sessionName = PoolSessionName(template, explicitID)
+	}
 	meta := map[string]string{
 		"template":                  template,
 		"agent_name":                agentName,
@@ -187,7 +196,7 @@ func createPoolSessionBeadWithAlias(
 		"generation":                "1",
 		"continuation_epoch":        "1",
 		"instance_token":            instanceToken,
-		"session_name":              pendingPoolSessionName(template, instanceToken),
+		"session_name":              sessionName,
 		poolManagedMetadataKey:      boolMetadata(true),
 	}
 	if alias := strings.TrimSpace(identity.Alias); alias != "" {
@@ -197,6 +206,7 @@ func createPoolSessionBeadWithAlias(
 		meta["pool_slot"] = strconv.Itoa(identity.Slot)
 	}
 	bead, err := store.Create(beads.Bead{
+		ID:       explicitID,
 		Title:    title,
 		Type:     sessionBeadType,
 		Labels:   []string{sessionBeadLabel, "agent:" + agentName},
@@ -205,20 +215,41 @@ func createPoolSessionBeadWithAlias(
 	if err != nil {
 		return beads.Bead{}, err
 	}
-	sessionName, err := derivePoolSessionName(store, cfg, template, bead.ID, resolvedTmuxAlias, sessionBeads)
+	sessionName, err = derivePoolSessionName(store, cfg, template, bead.ID, resolvedTmuxAlias, sessionBeads)
 	if err != nil {
 		_ = store.Close(bead.ID)
 		return beads.Bead{}, err
 	}
-	if err := store.SetMetadata(bead.ID, "session_name", sessionName); err != nil {
-		_ = store.Close(bead.ID)
-		return beads.Bead{}, err
+	if bead.Metadata == nil {
+		bead.Metadata = map[string]string{}
 	}
-	bead.Metadata["session_name"] = sessionName
+	if bead.Metadata["session_name"] != sessionName {
+		if err := store.SetMetadata(bead.ID, "session_name", sessionName); err != nil {
+			_ = store.Close(bead.ID)
+			return beads.Bead{}, err
+		}
+		bead.Metadata["session_name"] = sessionName
+	}
 	if sessionBeads != nil {
 		sessionBeads.add(bead)
 	}
 	return bead, nil
+}
+
+func poolSessionExplicitBeadID(store beads.Store, instanceToken string) string {
+	prefixStore, ok := store.(explicitBeadIDStore)
+	if !ok {
+		return ""
+	}
+	prefix := strings.TrimSpace(prefixStore.IDPrefix())
+	if prefix == "" {
+		return ""
+	}
+	instanceToken = strings.TrimSpace(instanceToken)
+	if instanceToken == "" {
+		return ""
+	}
+	return prefix + "-session-" + instanceToken
 }
 
 // derivePoolSessionName picks the session_name for a fresh pool bead. When

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +37,100 @@ func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
 	if got, want := stored.Metadata["pending_create_started_at"], pendingCreateStartedAtNow(now); got != want {
 		t.Fatalf("stored pending_create_started_at = %q, want %q", got, want)
 	}
+}
+
+func TestCreatePoolSessionBead_UsesExplicitIDThroughCachingStore(t *testing.T) {
+	var created beads.Bead
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			return nil, fmt.Errorf("unexpected command %q", name)
+		}
+		switch args[0] {
+		case "create":
+			id := testFlagValue(args, "--id")
+			if id == "" {
+				return nil, fmt.Errorf("bd create missing explicit --id: %v", args)
+			}
+			var metadata map[string]string
+			if raw := testFlagValue(args, "--metadata"); raw != "" {
+				if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+					return nil, err
+				}
+			}
+			created = beads.Bead{
+				ID:        id,
+				Title:     args[2],
+				Status:    "open",
+				Type:      "task",
+				CreatedAt: nowForBDJSONTest(),
+				Metadata:  metadata,
+			}
+			return mustMarshalBDIssueJSON(t, created, false), nil
+		case "show":
+			return mustMarshalBDIssueJSON(t, created, true), nil
+		case "update":
+			return nil, fmt.Errorf("unexpected bd update after explicit create: %v", args)
+		default:
+			return nil, fmt.Errorf("unexpected bd args: %v", args)
+		}
+	}
+	backing := beads.NewBdStoreWithPrefix(t.TempDir(), runner, "mc")
+	store := beads.NewCachingStore(backing, nil)
+	now := time.Date(2026, 5, 1, 9, 15, 0, 0, time.UTC)
+
+	bead, err := createPoolSessionBead(store, "gascity/claude", now, poolSessionCreateIdentity{})
+	if err != nil {
+		t.Fatalf("createPoolSessionBead: %v", err)
+	}
+	if !strings.HasPrefix(bead.ID, "mc-session-") {
+		t.Fatalf("bead.ID = %q, want explicit mc-session-* ID", bead.ID)
+	}
+	wantSessionName := PoolSessionName("gascity/claude", bead.ID)
+	if got := bead.Metadata["session_name"]; got != wantSessionName {
+		t.Fatalf("session_name = %q, want %q", got, wantSessionName)
+	}
+
+	stored, err := backing.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("backing.Get(%s): %v", bead.ID, err)
+	}
+	if got := stored.Metadata["session_name"]; got != wantSessionName {
+		t.Fatalf("stored session_name = %q, want %q", got, wantSessionName)
+	}
+}
+
+func testFlagValue(args []string, flag string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func nowForBDJSONTest() time.Time {
+	return time.Date(2026, 5, 1, 9, 15, 0, 0, time.UTC)
+}
+
+func mustMarshalBDIssueJSON(t *testing.T, bead beads.Bead, list bool) []byte {
+	t.Helper()
+	item := map[string]any{
+		"id":         bead.ID,
+		"title":      bead.Title,
+		"status":     bead.Status,
+		"issue_type": bead.Type,
+		"created_at": bead.CreatedAt.Format(time.RFC3339),
+		"metadata":   bead.Metadata,
+	}
+	var v any = item
+	if list {
+		v = []any{item}
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
 }
 
 func TestResolvedTemplateForIdentity_ResolvesUniqueInBoundsLegacyLocalPoolIdentity(t *testing.T) {

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -99,6 +99,83 @@ func TestCreatePoolSessionBead_UsesExplicitIDThroughCachingStore(t *testing.T) {
 	}
 }
 
+func TestCreatePoolSessionBeadWithAlias_UpdatesExplicitIDBeadToResolvedAlias(t *testing.T) {
+	var created beads.Bead
+	var updatedMetadata string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			return nil, fmt.Errorf("unexpected command %q", name)
+		}
+		switch args[0] {
+		case "create":
+			id := testFlagValue(args, "--id")
+			if id == "" {
+				return nil, fmt.Errorf("bd create missing explicit --id: %v", args)
+			}
+			var metadata map[string]string
+			if raw := testFlagValue(args, "--metadata"); raw != "" {
+				if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+					return nil, err
+				}
+			}
+			created = beads.Bead{
+				ID:        id,
+				Title:     args[2],
+				Status:    "open",
+				Type:      "task",
+				CreatedAt: nowForBDJSONTest(),
+				Metadata:  metadata,
+			}
+			return mustMarshalBDIssueJSON(t, created, false), nil
+		case "show":
+			return mustMarshalBDIssueJSON(t, created, true), nil
+		case "list":
+			return []byte(`[]`), nil
+		case "update":
+			if got := args[2]; got != created.ID {
+				return nil, fmt.Errorf("bd update id = %q, want %q", got, created.ID)
+			}
+			updatedMetadata = testFlagValue(args, "--set-metadata")
+			if updatedMetadata == "" {
+				return nil, fmt.Errorf("bd update missing --set-metadata: %v", args)
+			}
+			key, value, ok := strings.Cut(updatedMetadata, "=")
+			if !ok || key != "session_name" {
+				return nil, fmt.Errorf("bd update metadata = %q, want session_name=<alias>", updatedMetadata)
+			}
+			created.Metadata[key] = value
+			return []byte(`{"id":"` + created.ID + `"}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected bd args: %v", args)
+		}
+	}
+	backing := beads.NewBdStoreWithPrefix(t.TempDir(), runner, "mc")
+	store := beads.NewCachingStore(backing, nil)
+	now := time.Date(2026, 5, 1, 9, 15, 0, 0, time.UTC)
+
+	bead, err := createPoolSessionBeadWithAlias(store, "crew-gastown", nil, nil, now, poolSessionCreateIdentity{}, "crew--gastown")
+	if err != nil {
+		t.Fatalf("createPoolSessionBeadWithAlias: %v", err)
+	}
+	if !strings.HasPrefix(bead.ID, "mc-session-") {
+		t.Fatalf("bead.ID = %q, want explicit mc-session-* ID", bead.ID)
+	}
+	if updatedMetadata != "session_name=crew--gastown" {
+		t.Fatalf("updated metadata = %q, want session_name=crew--gastown", updatedMetadata)
+	}
+	if got := bead.Metadata["session_name"]; got != "crew--gastown" {
+		t.Fatalf("session_name = %q, want resolved alias", got)
+	}
+
+	stored, err := backing.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("backing.Get(%s): %v", bead.ID, err)
+	}
+	if got := stored.Metadata["session_name"]; got != "crew--gastown" {
+		t.Fatalf("stored session_name = %q, want resolved alias", got)
+	}
+}
+
 func testFlagValue(args []string, flag string) string {
 	for i := 0; i+1 < len(args); i++ {
 		if args[i] == flag {

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -617,6 +617,9 @@ func (s *BdStore) Create(b Bead) (Bead, error) {
 		typ = "task"
 	}
 	args := []string{"create", "--json", b.Title, "-t", typ}
+	if id := strings.TrimSpace(b.ID); id != "" {
+		args = append(args, "--id", id)
+	}
 	if b.Priority != nil {
 		args = append(args, "--priority", strconv.Itoa(*b.Priority))
 	}

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -106,6 +106,27 @@ func TestBdStoreCreatePreservesExplicitType(t *testing.T) {
 	}
 }
 
+func TestBdStoreCreatePassesExplicitID(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`{"id":"mc-session-abc123","title":"test","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+
+	created, err := s.Create(beads.Bead{ID: "mc-session-abc123", Title: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--id mc-session-abc123") {
+		t.Fatalf("args = %q, want explicit --id", args)
+	}
+	if created.ID != "mc-session-abc123" {
+		t.Fatalf("created.ID = %q, want mc-session-abc123", created.ID)
+	}
+}
+
 func TestBdStoreCreatePassesDeps(t *testing.T) {
 	var gotArgs []string
 	runner := func(_, _ string, args ...string) ([]byte, error) {

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -230,6 +230,14 @@ func NewCachingStoreForTestWithPrefix(backing Store, idPrefix string, onChange f
 	return newCachingStore(backing, idPrefix, onChange)
 }
 
+// IDPrefix returns the bead ID prefix owned by this cache, without trailing "-".
+func (c *CachingStore) IDPrefix() string {
+	if c == nil {
+		return ""
+	}
+	return c.idPrefix
+}
+
 func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
 		backing:     backing,


### PR DESCRIPTION
Summary:
- Forward explicit bead IDs through `BdStore.Create` via the beads 1.0.4 `bd create --id` API.
- Expose caching-store ID ownership and precompute pool session bead IDs so the final pool session_name can be written during create.
- Avoids the post-create session_name rename when the explicit ID path is available.

Tests:
- go test ./internal/beads -run TestBdStoreCreatePassesExplicitID
- go test ./cmd/gc -run TestCreatePoolSessionBead_UsesExplicitIDThroughCachingStore
- pre-commit fast suite passed

Beads support:
- Uses existing `bd create --id` from beads 1.0.4; no storage-tier or wisp-tier API is required.