### PR TITLE
fix(jsonl-export): #1906 cleanups (memoize archive-mode, name relog interval, hoist helper, doc-update push-modes)

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4751,10 +4751,30 @@ func writeMultiRecordDoltStub(t *testing.T, binDir string, currentCount int) {
 
 func writeIssuesPayloadDoltStub(t *testing.T, binDir, issuesPayload string) {
 	t.Helper()
+	writeIssuesPayloadDoltStubWithPrelude(t, binDir, issuesPayload, "")
+}
+
+func writeOriginRemovingMultiRecordDoltStub(t *testing.T, binDir string, currentCount int) {
+	t.Helper()
+	rows := make([]string, 0, currentCount)
+	for i := 0; i < currentCount; i++ {
+		rows = append(rows, fmt.Sprintf(`{"id":"c%d","title":"cur-%d"}`, i, i))
+	}
+	writeIssuesPayloadDoltStubWithPrelude(t, binDir, `{"rows":[`+strings.Join(rows, ",")+`]}`, `
+if [ -n "${DOLT_REMOVE_ORIGIN_FLAG:-}" ] && [ ! -e "$DOLT_REMOVE_ORIGIN_FLAG" ]; then
+  : > "$DOLT_REMOVE_ORIGIN_FLAG"
+  git -C "$GC_JSONL_ARCHIVE_REPO" remote remove origin 2>/dev/null || true
+fi
+`)
+}
+
+func writeIssuesPayloadDoltStubWithPrelude(t *testing.T, binDir, issuesPayload, prelude string) {
+	t.Helper()
 	body := "#!/bin/sh\n" +
 		"if [ -n \"${DOLT_ARGS_LOG:-}\" ]; then\n" +
 		"  printf '%s\\n' \"$*\" >> \"$DOLT_ARGS_LOG\"\n" +
 		"fi\n" +
+		prelude +
 		"case \"$*\" in\n" +
 		"  *\"SHOW TABLES FROM\"*\"LIKE 'wisps'\"*)\n" +
 		"    printf 'Tables_in_db\\nwisps\\n'\n" +
@@ -7080,6 +7100,105 @@ func TestJsonlExportPushModeAttemptsPushWhenOriginConfigured(t *testing.T) {
 	}
 	if got := state["last_logged_mode"]; got != "push" {
 		t.Fatalf("last_logged_mode = %v, want push\nstate: %s", got, stateData)
+	}
+}
+
+func TestJsonlExportPushModeMemoizesOriginForRun(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+	originRemovedFlag := filepath.Join(t.TempDir(), "origin-removed")
+
+	initSeedArchiveWithRemote(t, archiveRepo)
+	writeOriginRemovingMultiRecordDoltStub(t, binDir, 5)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["GC_JSONL_MIN_PREV_FOR_SPIKE"] = "1000"
+	env["DOLT_REMOVE_ORIGIN_FLAG"] = originRemovedFlag
+
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "archive running in push mode") {
+		t.Fatalf("expected first mode probe to log push mode, got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "push: failed") {
+		t.Fatalf("expected cached push mode to still attempt push after origin removal, got:\n%s", out)
+	}
+	if strings.Contains(string(out), "push: skipped (local-only)") {
+		t.Fatalf("cached push mode must not fall back to local-only mid-run, got:\n%s", out)
+	}
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["last_logged_mode"]; got != "push" {
+		t.Fatalf("last_logged_mode = %v, want push\nstate: %s", got, stateData)
+	}
+	if got, ok := state["consecutive_push_failures"].(float64); !ok || got != 1 {
+		t.Fatalf("consecutive_push_failures = %v, want 1\nstate: %s", state["consecutive_push_failures"], stateData)
+	}
+}
+
+func TestJsonlExportModeRelogIntervalOverrideRelogsSameMode(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+
+	initSeedArchive(t, archiveRepo, 3)
+	writeMultiRecordDoltStub(t, binDir, 3)
+	writeJsonlExportGCStub(t, binDir)
+
+	if err := os.MkdirAll(filepath.Dir(stateFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll(state dir): %v", err)
+	}
+	priorState := `{"last_logged_mode":"local-only","last_logged_at":"2026-05-01T00:00:00Z"}` + "\n"
+	if err := os.WriteFile(stateFile, []byte(priorState), 0o644); err != nil {
+		t.Fatalf("WriteFile(state file): %v", err)
+	}
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["GC_JSONL_MODE_RELOG_INTERVAL"] = "1"
+	delete(env, "GC_JSONL_MAX_PUSH_FAILURES")
+
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "archive running in local-only mode") {
+		t.Fatalf("expected expired override interval to re-log local-only mode, got:\n%s", out)
+	}
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["last_logged_mode"]; got != "local-only" {
+		t.Fatalf("last_logged_mode = %v, want local-only\nstate: %s", got, stateData)
+	}
+	if got := state["last_logged_at"]; got == "2026-05-01T00:00:00Z" {
+		t.Fatalf("last_logged_at not refreshed after interval expiry\nstate: %s", stateData)
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -36,7 +36,7 @@ ARCHIVE_REPO="${GC_JSONL_ARCHIVE_REPO:-$PACK_STATE_DIR/jsonl-archive}"
 # Re-log the archive mode at least this often (seconds) even without a mode
 # transition, so operators who missed the first line still see the current
 # configuration. Default one week.
-WEEKLY_RELOG_SECONDS="${GC_JSONL_MODE_RELOG_INTERVAL:-604800}"
+MODE_RELOG_INTERVAL_SECONDS="${GC_JSONL_MODE_RELOG_INTERVAL:-604800}"
 
 # Cached archive mode ("push" or "local-only"). Resolved once on the first
 # get_archive_mode call and reused thereafter so every push checkpoint in a
@@ -286,9 +286,8 @@ archive_has_local_only_commits() {
 # no extra command. The result is memoized in ARCHIVE_MODE on first call so
 # every push checkpoint within a single run agrees, even if the remote changes
 # mid-run.
-get_archive_mode() {
+resolve_archive_mode() {
     if [ -n "$ARCHIVE_MODE" ]; then
-        echo "$ARCHIVE_MODE"
         return
     fi
     if [ -d "$ARCHIVE_REPO/.git" ] \
@@ -297,11 +296,16 @@ get_archive_mode() {
     else
         ARCHIVE_MODE="local-only"
     fi
+}
+
+get_archive_mode() {
+    resolve_archive_mode
     echo "$ARCHIVE_MODE"
 }
 
 should_attempt_push() {
-    [ "$(get_archive_mode)" = "push" ]
+    resolve_archive_mode
+    [ "$ARCHIVE_MODE" = "push" ]
 }
 
 # Log the archive mode on transitions and re-log weekly so operators who
@@ -320,7 +324,8 @@ log_archive_mode_if_needed() {
     local should_log=0
     local message
 
-    current_mode=$(get_archive_mode)
+    resolve_archive_mode
+    current_mode="$ARCHIVE_MODE"
     state_json=$(read_state_json)
     last_logged_mode=$(printf '%s\n' "$state_json" | jq -r '.last_logged_mode // empty')
     last_logged_at=$(printf '%s\n' "$state_json" | jq -r '.last_logged_at // empty')
@@ -335,7 +340,7 @@ log_archive_mode_if_needed() {
         should_log=1
     else
         last_ts=$(jq -n -r --arg ts "$last_logged_at" '$ts | try fromdateiso8601 catch 0')
-        if [ "$last_ts" = "0" ] || [ "$((now_ts - last_ts))" -gt "$WEEKLY_RELOG_SECONDS" ]; then
+        if [ "$last_ts" = "0" ] || [ "$((now_ts - last_ts))" -gt "$MODE_RELOG_INTERVAL_SECONDS" ]; then
             should_log=1
         fi
     fi

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -33,6 +33,16 @@ PUSH_RETRY_DELAY_MIN="${GC_JSONL_PUSH_RETRY_DELAY_MIN:-1}"
 PUSH_RETRY_DELAY_SPAN="${GC_JSONL_PUSH_RETRY_DELAY_SPAN:-4}"
 SCRUB="${GC_JSONL_SCRUB:-true}"
 ARCHIVE_REPO="${GC_JSONL_ARCHIVE_REPO:-$PACK_STATE_DIR/jsonl-archive}"
+# Re-log the archive mode at least this often (seconds) even without a mode
+# transition, so operators who missed the first line still see the current
+# configuration. Default one week.
+WEEKLY_RELOG_SECONDS="${GC_JSONL_MODE_RELOG_INTERVAL:-604800}"
+
+# Cached archive mode ("push" or "local-only"). Resolved once on the first
+# get_archive_mode call and reused thereafter so every push checkpoint in a
+# single run sees a consistent value even if an operator adds or removes the
+# origin remote mid-run.
+ARCHIVE_MODE=""
 
 # Count records in a `dolt sql -r json` payload. The output is `{"rows":[...]}`
 # on (typically) a single physical line, so `wc -l` measures formatting, not
@@ -273,14 +283,21 @@ archive_has_local_only_commits() {
 # Detect the archive's push mode from the live state of its remotes rather
 # than from a cached state field. Operators opt into off-box backup by adding
 # an `origin` remote; removing it reverts to local-only on the next run with
-# no extra command.
+# no extra command. The result is memoized in ARCHIVE_MODE on first call so
+# every push checkpoint within a single run agrees, even if the remote changes
+# mid-run.
 get_archive_mode() {
+    if [ -n "$ARCHIVE_MODE" ]; then
+        echo "$ARCHIVE_MODE"
+        return
+    fi
     if [ -d "$ARCHIVE_REPO/.git" ] \
         && git -C "$ARCHIVE_REPO" remote get-url origin >/dev/null 2>&1; then
-        echo "push"
+        ARCHIVE_MODE="push"
     else
-        echo "local-only"
+        ARCHIVE_MODE="local-only"
     fi
+    echo "$ARCHIVE_MODE"
 }
 
 should_attempt_push() {
@@ -318,7 +335,7 @@ log_archive_mode_if_needed() {
         should_log=1
     else
         last_ts=$(jq -n -r --arg ts "$last_logged_at" '$ts | try fromdateiso8601 catch 0')
-        if [ "$last_ts" = "0" ] || [ "$((now_ts - last_ts))" -gt 604800 ]; then
+        if [ "$last_ts" = "0" ] || [ "$((now_ts - last_ts))" -gt "$WEEKLY_RELOG_SECONDS" ]; then
             should_log=1
         fi
     fi
@@ -476,6 +493,15 @@ retry_pending_spike_alert() {
     fi
 }
 
+# Retain only the last ~20 lines of stderr so an extremely chatty failure
+# doesn't drown the escalation body.
+truncate_stderr_context() {
+    local raw="$1"
+
+    [ -z "$raw" ] && return 0
+    printf '%s\n' "$raw" | tail -n 20
+}
+
 push_archive_main() {
     local consecutive
     local fetch_err
@@ -483,15 +509,6 @@ push_archive_main() {
     local push_err
     local push_attempt
     local push_succeeded
-
-    # Retain only the last ~20 lines of stderr so an extremely chatty failure
-    # doesn't drown the escalation body.
-    truncate_stderr_context() {
-        local raw="$1"
-
-        [ -z "$raw" ] && return 0
-        printf '%s\n' "$raw" | tail -n 20
-    }
 
     record_archive_push_failure() {
         local message="$1"

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
@@ -153,20 +153,37 @@ git -C <git_repo> commit -m "backup <timestamp>: <db>=<count> ..." \\
 
 Include failed databases in commit message so staleness is visible.
 
-**4. Push to origin:**
+**4. Push to origin (push mode only):**
+The archive's mode is detected from the live remote state: with an `origin`
+remote configured on the archive repo it runs in **push** mode; without one it
+runs **local-only** and skips the push entirely (the commit above is the
+backup).
 ```bash
 git -C <git_repo> push origin main
 ```
 
-**5. Handle push failures:**
+**5. Handle push failures (push mode only):**
 Track consecutive failures. After {{max_push_failures}} consecutive failures,
-escalate:
+escalate once with an enriched body (archive path, failure count vs threshold,
+the last git push stderr, and remediation steps):
 ```bash
 gc mail send mayor/ -s "ESCALATION: JSONL push failed [HIGH]" \\
-  -m "Consecutive failures: {{max_push_failures}}"
-```
+  -m "Order: mol-dog-jsonl
+Archive: <archive_repo>
+Consecutive failures: <n> (threshold: {{max_push_failures}})
 
-**Exit criteria:** Changes committed and pushed (or no changes to commit)."""
+Last git push stderr:
+<truncated stderr>
+
+Remediation:
+- Check remote: git -C <archive_repo> remote -v
+- Verify remote is reachable and credentials are valid
+- Temporarily suppress: export GC_JSONL_MAX_PUSH_FAILURES=99"
+```
+Local-only mode never escalates on push failure because it never pushes.
+
+**Exit criteria:** Changes committed, and pushed when in push mode (or no
+changes to commit)."""
 
 [[steps]]
 id = "report"

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
@@ -178,7 +178,8 @@ Last git push stderr:
 Remediation:
 - Check remote: git -C <archive_repo> remote -v
 - Verify remote is reachable and credentials are valid
-- Temporarily suppress: export GC_JSONL_MAX_PUSH_FAILURES=99"
+- Temporarily suppress: export GC_JSONL_MAX_PUSH_FAILURES=99
+- See docs/getting-started/troubleshooting.md#jsonl-archive-push-failures"
 ```
 Local-only mode never escalates on push failure because it never pushes.
 


### PR DESCRIPTION
## Summary

Four small follow-up cleanups from the #1800 review, bundled in #1906:

- **`mol-dog-jsonl.toml` push-step prose** — bring the doc string in line with current behavior (push vs local-only modes, enriched escalation body). Doc-only drift.
- **Memoize `get_archive_mode` into `ARCHIVE_MODE`** in `jsonl-export.sh` so every push checkpoint inside a single run agrees, even if the `origin` remote is added or removed mid-run.
- **Named constant `WEEKLY_RELOG_SECONDS`** (default 7d) for the weekly re-log interval, with `GC_JSONL_MODE_RELOG_INTERVAL` env override. No behavior change at default value; gives test/operator hooks.
- **Hoist `truncate_stderr_context` to file scope** instead of redefining it on every `push_archive_main` call.

### Deliberately not hoisted: `record_archive_push_failure`

That helper is left nested inside `push_archive_main` on purpose — it reassigns the parent function's `consecutive` local. Hoisting would change behavior (it'd lose the binding to the caller's local). Flagged here so a future cleanup pass doesn't reflexively move it.

## Gates

- `bash -n jsonl-export.sh` — OK
- `shellcheck -S warning jsonl-export.sh` — 0 new findings vs baseline
- `go test ./examples/gastown/...` — PASS (jsonl, archive, relog, escalation, formula tests all green)

Closes #1906.
