### PR TITLE
fix: add bounded filtered mail archive

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/mail/beadmail"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/spf13/cobra"
@@ -74,6 +75,7 @@ type mailActionResult struct {
 	Count         *int                 `json:"count,omitempty"`
 	AlreadyDone   bool                 `json:"already_done,omitempty"`
 	Notified      bool                 `json:"notified,omitempty"`
+	DryRun        bool                 `json:"dry_run,omitempty"`
 }
 
 type mailMessageSummary struct {
@@ -83,6 +85,17 @@ type mailMessageSummary struct {
 	Subject  string `json:"subject,omitempty"`
 	ThreadID string `json:"thread_id,omitempty"`
 	ReplyTo  string `json:"reply_to,omitempty"`
+}
+
+type mailArchiveSelectOptions struct {
+	Recipient       string
+	From            string
+	SubjectPrefix   string
+	SubjectContains string
+	Limit           int
+	IncludeRead     bool
+	DryRun          bool
+	CaseInsensitive bool
 }
 
 func summarizeMailMessage(m mail.Message) mailMessageSummary {
@@ -144,6 +157,7 @@ hooks to deliver mail notifications into agent prompts.`,
 
 func newMailArchiveCmd(stdout, stderr io.Writer) *cobra.Command {
 	var jsonOut bool
+	opts := mailArchiveSelectOptions{Limit: 100, CaseInsensitive: true}
 	cmd := &cobra.Command{
 		Use:   "archive <id>...",
 		Short: "Archive one or more messages without reading them",
@@ -151,13 +165,23 @@ func newMailArchiveCmd(stdout, stderr io.Writer) *cobra.Command {
 
 Use this to dismiss messages without reading them. Each message is marked
 as closed and will no longer appear in mail check or inbox results. When
-multiple IDs are passed, they are archived in a single batch round-trip.`,
+multiple IDs are passed, they are archived in a single batch round-trip.
+
+For large advisory backlogs, use --to with --subject-prefix, --subject-contains,
+or --from to archive a bounded matching slice without enumerating IDs by hand.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			code := 0
-			if jsonOut {
+			switch {
+			case opts.hasSelector():
+				if jsonOut {
+					code = cmdMailArchiveSelectedJSON(args, opts, true, stdout, stderr)
+				} else {
+					code = cmdMailArchiveSelectedJSON(args, opts, false, stdout, stderr)
+				}
+			case jsonOut:
 				code = cmdMailArchiveJSON(args, true, stdout, stderr)
-			} else {
+			default:
 				code = cmdMailArchive(args, stdout, stderr)
 			}
 			if code != 0 {
@@ -167,6 +191,13 @@ multiple IDs are passed, they are archived in a single batch round-trip.`,
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	cmd.Flags().StringVar(&opts.Recipient, "to", "", "archive matching unread messages addressed to this recipient")
+	cmd.Flags().StringVar(&opts.From, "from", "", "archive matching unread messages from this exact sender")
+	cmd.Flags().StringVar(&opts.SubjectPrefix, "subject-prefix", "", "archive matching unread messages whose subject starts with this text")
+	cmd.Flags().StringVar(&opts.SubjectContains, "subject-contains", "", "archive matching unread messages whose subject contains this text")
+	cmd.Flags().IntVar(&opts.Limit, "limit", opts.Limit, "maximum matching messages to archive in this run")
+	cmd.Flags().BoolVar(&opts.IncludeRead, "include-read", false, "include read-but-open messages when selecting by filter")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "list matching messages without archiving them")
 	return cmd
 }
 
@@ -184,12 +215,121 @@ func cmdMailArchiveJSON(args []string, jsonOut bool, stdout, stderr io.Writer) i
 	return doMailArchiveJSON(mp, rec, args, jsonOut, stdout, stderr)
 }
 
+func (o mailArchiveSelectOptions) hasSelector() bool {
+	return strings.TrimSpace(o.Recipient) != "" ||
+		strings.TrimSpace(o.From) != "" ||
+		strings.TrimSpace(o.SubjectPrefix) != "" ||
+		strings.TrimSpace(o.SubjectContains) != "" ||
+		o.IncludeRead ||
+		o.DryRun
+}
+
+func (o mailArchiveSelectOptions) hasContentFilter() bool {
+	return strings.TrimSpace(o.From) != "" ||
+		strings.TrimSpace(o.SubjectPrefix) != "" ||
+		strings.TrimSpace(o.SubjectContains) != ""
+}
+
+func cmdMailArchiveSelectedJSON(args []string, opts mailArchiveSelectOptions, jsonOut bool, stdout, stderr io.Writer) int {
+	mp, code := openCityMailProvider(stderr, "gc mail archive")
+	if mp == nil {
+		return code
+	}
+	rec := openCityRecorder(stderr)
+	return doMailArchiveSelectedJSON(mp, rec, args, opts, jsonOut, stdout, stderr)
+}
+
 // doMailArchive closes one or more message beads. For a single ID the
 // behavior matches the pre-batch CLI byte-for-byte; for two or more IDs it
 // delegates to mp.ArchiveMany for a single-round-trip close and prints one
 // result line per id.
 func doMailArchive(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
 	return doMailArchiveJSON(mp, rec, args, false, stdout, stderr)
+}
+
+func doMailArchiveSelected(mp mail.Provider, rec events.Recorder, opts mailArchiveSelectOptions, stdout, stderr io.Writer) int {
+	return doMailArchiveSelectedJSON(mp, rec, nil, opts, false, stdout, stderr)
+}
+
+type archiveMatchingProvider interface {
+	ArchiveCandidates(beadmail.ArchiveFilter) ([]mail.Message, error)
+	ArchiveMatching(beadmail.ArchiveFilter) ([]mail.Message, []mail.ArchiveResult, error)
+}
+
+func doMailArchiveSelectedJSON(mp mail.Provider, rec events.Recorder, args []string, opts mailArchiveSelectOptions, jsonOut bool, stdout, stderr io.Writer) int {
+	if len(args) > 0 {
+		fmt.Fprintln(stderr, "gc mail archive: message IDs cannot be combined with --to/--from/--subject filters") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	opts.Recipient = strings.TrimSpace(opts.Recipient)
+	if opts.Recipient == "" {
+		fmt.Fprintln(stderr, "gc mail archive: --to is required when using archive filters") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !opts.hasContentFilter() {
+		fmt.Fprintln(stderr, "gc mail archive: use --from, --subject-prefix, or --subject-contains to avoid archiving unrelated mail") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if opts.Limit <= 0 {
+		fmt.Fprintln(stderr, "gc mail archive: --limit must be greater than zero") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	archiver, ok := mp.(archiveMatchingProvider)
+	if !ok {
+		fmt.Fprintln(stderr, "gc mail archive: filtered archive requires the beadmail provider") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	filter := beadmail.ArchiveFilter{
+		Recipients:      []string{opts.Recipient},
+		From:            opts.From,
+		SubjectPrefix:   opts.SubjectPrefix,
+		SubjectContains: opts.SubjectContains,
+		IncludeRead:     opts.IncludeRead,
+		CaseInsensitive: opts.CaseInsensitive,
+		Limit:           opts.Limit,
+	}
+	if opts.DryRun {
+		matches, err := archiver.ArchiveCandidates(filter)
+		if err != nil {
+			telemetry.RecordMailOp(context.Background(), "archive", err)
+			fmt.Fprintf(stderr, "gc mail archive: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		return renderMailArchiveSelection(matches, nil, opts, jsonOut, stdout, stderr)
+	}
+	matches, results, err := archiver.ArchiveMatching(filter)
+	if err != nil {
+		telemetry.RecordMailOp(context.Background(), "archive", err)
+		fmt.Fprintf(stderr, "gc mail archive: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	exit := 0
+	for _, r := range results {
+		switch {
+		case r.Err == nil:
+			telemetry.RecordMailOp(context.Background(), "archive", nil)
+			rec.Record(events.Event{
+				Type:    events.MailArchived,
+				Actor:   eventActor(),
+				Subject: r.ID,
+				Payload: mailEventPayload(nil),
+			})
+		case errors.Is(r.Err, mail.ErrAlreadyArchived):
+			// Candidate selection returns open messages, but preserve the
+			// idempotent batch contract if a concurrent archive wins the race.
+		default:
+			telemetry.RecordMailOp(context.Background(), "archive", r.Err)
+			fmt.Fprintf(stderr, "gc mail archive %s: %v\n", r.ID, r.Err) //nolint:errcheck // best-effort stderr
+			exit = 1
+		}
+	}
+	if jsonOut && exit != 0 {
+		return exit
+	}
+	if renderExit := renderMailArchiveSelection(matches, results, opts, jsonOut, stdout, stderr); renderExit != 0 && exit == 0 {
+		exit = renderExit
+	}
+	return exit
 }
 
 func doMailArchiveJSON(mp mail.Provider, rec events.Recorder, args []string, jsonOut bool, stdout, stderr io.Writer) int {
@@ -283,6 +423,51 @@ func doMailArchiveManyJSON(mp mail.Provider, rec events.Recorder, ids []string, 
 		return writeCLIJSONLineOrExit(stdout, stderr, "gc mail archive", mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.archive", Action: "archive", IDs: ids, Count: intRef(archived), AlreadyDone: already == len(ids)})
 	}
 	return exit
+}
+
+func renderMailArchiveSelection(matches []mail.Message, results []mail.ArchiveResult, opts mailArchiveSelectOptions, jsonOut bool, stdout, stderr io.Writer) int {
+	ids := make([]string, 0, len(matches))
+	summaries := make([]mailMessageSummary, 0, len(matches))
+	for _, msg := range matches {
+		ids = append(ids, msg.ID)
+		summaries = append(summaries, summarizeMailMessage(msg))
+	}
+	if opts.DryRun {
+		if jsonOut {
+			return writeCLIJSONLineOrExit(stdout, stderr, "gc mail archive", mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.archive", Action: "archive", IDs: ids, Messages: summaries, Count: intRef(len(matches)), DryRun: true})
+		}
+		if len(matches) == 0 {
+			fmt.Fprintln(stdout, "No matching messages") //nolint:errcheck // best-effort stdout
+			return 0
+		}
+		for _, msg := range matches {
+			fmt.Fprintf(stdout, "Would archive message %s\t%s\n", msg.ID, msg.Subject) //nolint:errcheck // best-effort stdout
+		}
+		return 0
+	}
+	archived := 0
+	already := 0
+	for _, r := range results {
+		switch {
+		case r.Err == nil:
+			archived++
+			if !jsonOut {
+				fmt.Fprintf(stdout, "Archived message %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			}
+		case errors.Is(r.Err, mail.ErrAlreadyArchived):
+			already++
+			if !jsonOut {
+				fmt.Fprintf(stdout, "Already archived %s\n", r.ID) //nolint:errcheck // best-effort stdout
+			}
+		}
+	}
+	if len(matches) == 0 && !jsonOut {
+		fmt.Fprintln(stdout, "No matching messages") //nolint:errcheck // best-effort stdout
+	}
+	if jsonOut {
+		return writeCLIJSONLineOrExit(stdout, stderr, "gc mail archive", mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.archive", Action: "archive", IDs: ids, Messages: summaries, Count: intRef(archived), AlreadyDone: already == len(results) && len(results) > 0})
+	}
+	return 0
 }
 
 func newMailCheckCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2547,6 +2547,68 @@ func TestMailArchiveMultiPartialFailure(t *testing.T) {
 	}
 }
 
+func TestMailArchiveSelectedIsFilteredAndBounded(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	first, err := mp.Send("human", "operator", "Dolt health advisory one", "archive me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := mp.Send("human", "operator", "Dolt health advisory two", "archive later")
+	if err != nil {
+		t.Fatal(err)
+	}
+	readMatch, err := mp.Send("human", "operator", "Dolt health advisory read", "leave read")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mp.MarkRead(readMatch.ID); err != nil {
+		t.Fatal(err)
+	}
+	nonMatch, err := mp.Send("human", "operator", "Human handoff", "preserve")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherRecipient, err := mp.Send("human", "other", "Dolt health advisory other", "preserve")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailArchiveSelected(mp, events.Discard, mailArchiveSelectOptions{
+		Recipient:       "operator",
+		SubjectPrefix:   "Dolt health",
+		Limit:           1,
+		CaseInsensitive: true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailArchiveSelected = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Archived message "+first.ID) {
+		t.Fatalf("stdout = %q, want archive confirmation for %s", stdout.String(), first.ID)
+	}
+	if strings.Contains(stdout.String(), second.ID) {
+		t.Fatalf("stdout = %q, did not expect second match past limit", stdout.String())
+	}
+
+	status := func(id string) string {
+		t.Helper()
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		return b.Status
+	}
+	if got := status(first.ID); got != "closed" {
+		t.Fatalf("first status = %q, want closed", got)
+	}
+	for _, id := range []string{second.ID, readMatch.ID, nonMatch.ID, otherRecipient.ID} {
+		if got := status(id); got != "open" {
+			t.Fatalf("message %s status = %q, want open", id, got)
+		}
+	}
+}
+
 // --- gc mail send --notify ---
 
 func TestMailSendNotifySuccess(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1645,13 +1645,23 @@ Use this to dismiss messages without reading them. Each message is marked
 as closed and will no longer appear in mail check or inbox results. When
 multiple IDs are passed, they are archived in a single batch round-trip.
 
+For large advisory backlogs, use --to with --subject-prefix, --subject-contains,
+or --from to archive a bounded matching slice without enumerating IDs by hand.
+
 ```
 gc mail archive <id>... [flags]
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--dry-run` | bool |  | list matching messages without archiving them |
+| `--from` | string |  | archive matching unread messages from this exact sender |
+| `--include-read` | bool |  | include read-but-open messages when selecting by filter |
 | `--json` | bool |  | emit JSONL result |
+| `--limit` | int | `100` | maximum matching messages to archive in this run |
+| `--subject-contains` | string |  | archive matching unread messages whose subject contains this text |
+| `--subject-prefix` | string |  | archive matching unread messages whose subject starts with this text |
+| `--to` | string |  | archive matching unread messages addressed to this recipient |
 
 ## gc mail check
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1248,6 +1248,32 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 	return len(ids), nil
 }
 
+// CloseAllWithReason closes multiple beads with one reasoned bd close command
+// without pre-writing metadata on each bead.
+func (s *BdStore) CloseAllWithReason(ids []string, reason string) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	reason = strings.TrimSpace(reason)
+	_, err := s.runner(s.dir, "bd", bdCloseArgs(reason, ids...)...)
+	if err != nil {
+		closed := 0
+		var fallbackErr error
+		for _, id := range ids {
+			if closeErr := s.close(id, reason); closeErr == nil {
+				closed++
+			} else {
+				fallbackErr = errors.Join(fallbackErr, closeErr)
+			}
+		}
+		if fallbackErr != nil {
+			return closed, errors.Join(fmt.Errorf("bd close batch: %w", err), fallbackErr)
+		}
+		return closed, nil
+	}
+	return len(ids), nil
+}
+
 // Close sets a bead's status to closed via bd close. If the bead already has
 // metadata.close_reason, the trimmed value is forwarded as bd close --reason.
 // Idempotent: closing an already-closed bead returns nil.

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1163,6 +1163,37 @@ func TestBdStoreCloseAllForwardsCloseReason(t *testing.T) {
 	}
 }
 
+func TestBdStoreCloseAllWithReasonSkipsMetadataWrites(t *testing.T) {
+	const reason = "mail archive: bounded advisory cleanup"
+	commands := make([]string, 0, 1)
+	runner := func(_ string, name string, args ...string) ([]byte, error) {
+		cmd := name + " " + strings.Join(args, " ")
+		commands = append(commands, cmd)
+		if strings.HasPrefix(cmd, "bd update ") {
+			t.Fatalf("CloseAllWithReason must not pre-write metadata: %s", cmd)
+		}
+		if cmd != "bd close --force --json --reason "+reason+" bd-1 bd-2" {
+			return nil, fmt.Errorf("unexpected command: %s", cmd)
+		}
+		return []byte(`[
+			{"id":"bd-1","title":"one","status":"closed","issue_type":"message","created_at":"2025-01-15T10:30:00Z"},
+			{"id":"bd-2","title":"two","status":"closed","issue_type":"message","created_at":"2025-01-15T10:30:00Z"}
+		]`), nil
+	}
+
+	s := beads.NewBdStore("/city", runner)
+	closed, err := s.CloseAllWithReason([]string{"bd-1", "bd-2"}, reason)
+	if err != nil {
+		t.Fatalf("CloseAllWithReason: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("closed = %d, want 2", closed)
+	}
+	if len(commands) != 1 {
+		t.Fatalf("commands = %v, want exactly one close command", commands)
+	}
+}
+
 // TestBdStoreCloseAllOmitsReasonWhenAbsent verifies that when no
 // close_reason is present in the metadata map, CloseAll does not pass
 // --reason and lets bd assign its default. Preserves backward

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -226,6 +226,17 @@ func (p *Provider) MarkUnread(id string) error {
 // message stays open, and the archive operation silently fails.
 const MailArchivedCloseReason = "beadmail: message archived without read"
 
+// ArchiveFilter selects open message beads for bounded archive cleanup.
+type ArchiveFilter struct {
+	Recipients      []string
+	From            string
+	SubjectPrefix   string
+	SubjectContains string
+	IncludeRead     bool
+	CaseInsensitive bool
+	Limit           int
+}
+
 // Archive closes a message bead without reading it.
 func (p *Provider) Archive(id string) error {
 	b, err := p.store.Get(id)
@@ -247,6 +258,123 @@ func (p *Provider) Archive(id string) error {
 		return fmt.Errorf("beadmail archive: %w", err)
 	}
 	return nil
+}
+
+// ArchiveCandidates returns open messages that match filter without closing
+// them.
+func (p *Provider) ArchiveCandidates(filter ArchiveFilter) ([]mail.Message, error) {
+	routes := p.recipientRoutesForAll(filter.Recipients)
+	candidates, err := p.messageCandidatesForRoutes(routes)
+	if err != nil {
+		return nil, fmt.Errorf("beadmail archive matching: %w", err)
+	}
+	matches := make([]mail.Message, 0, len(candidates))
+	for _, b := range candidates {
+		if b.Status != "open" {
+			continue
+		}
+		if len(routes) > 0 && !matchesRecipientRoute(routes, b.Assignee) {
+			continue
+		}
+		msg := beadToMessage(b)
+		if !filter.IncludeRead && msg.Read {
+			continue
+		}
+		if !archiveExactMatches(msg.From, filter.From, filter.CaseInsensitive) {
+			continue
+		}
+		if !archivePrefixMatches(msg.Subject, filter.SubjectPrefix, filter.CaseInsensitive) {
+			continue
+		}
+		if !archiveContainsMatches(msg.Subject, filter.SubjectContains, filter.CaseInsensitive) {
+			continue
+		}
+		matches = append(matches, msg)
+		if filter.Limit > 0 && len(matches) >= filter.Limit {
+			break
+		}
+	}
+	return matches, nil
+}
+
+// ArchiveMatching closes open messages selected by filter without per-message
+// lookups after the candidate list has already verified them.
+func (p *Provider) ArchiveMatching(filter ArchiveFilter) ([]mail.Message, []mail.ArchiveResult, error) {
+	candidates, err := p.ArchiveCandidates(filter)
+	if err != nil {
+		return nil, nil, err
+	}
+	results := make([]mail.ArchiveResult, len(candidates))
+	ids := make([]string, len(candidates))
+	for i, msg := range candidates {
+		ids[i] = msg.ID
+		results[i] = mail.ArchiveResult{ID: msg.ID}
+	}
+	if len(ids) == 0 {
+		return candidates, results, nil
+	}
+	if err := p.closeKnownOpenMessages(ids); err != nil {
+		retryResults, retryErr := p.ArchiveMany(ids)
+		if retryErr != nil {
+			return candidates, retryResults, errors.Join(err, retryErr)
+		}
+		return candidates, retryResults, nil
+	}
+	return candidates, results, nil
+}
+
+type reasonedBatchCloser interface {
+	CloseAllWithReason([]string, string) (int, error)
+}
+
+func (p *Provider) closeKnownOpenMessages(ids []string) error {
+	if p.store == nil {
+		return fmt.Errorf("beadmail archive matching: nil store")
+	}
+	if closer, ok := p.store.(reasonedBatchCloser); ok {
+		_, err := closer.CloseAllWithReason(ids, MailArchivedCloseReason)
+		return err
+	}
+	_, err := p.store.CloseAll(ids, map[string]string{
+		"close_reason": MailArchivedCloseReason,
+	})
+	return err
+}
+
+func archiveExactMatches(value, exact string, insensitive bool) bool {
+	exact = strings.TrimSpace(exact)
+	if exact == "" {
+		return true
+	}
+	if insensitive {
+		value = strings.ToLower(value)
+		exact = strings.ToLower(exact)
+	}
+	return value == exact
+}
+
+func archivePrefixMatches(value, prefix string, insensitive bool) bool {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return true
+	}
+	if insensitive {
+		value = strings.ToLower(value)
+		prefix = strings.ToLower(prefix)
+	}
+	return strings.HasPrefix(value, prefix)
+}
+
+func archiveContainsMatches(value, partial string, insensitive bool) bool {
+	partial = strings.TrimSpace(partial)
+	if partial == "" {
+		return true
+	}
+	if insensitive {
+		value = strings.ToLower(value)
+		partial = strings.ToLower(partial)
+	}
+	return strings.Contains(value, partial)
 }
 
 // Delete is an alias for Archive (closes the bead).

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -855,6 +855,70 @@ func TestArchiveManyStampsCloseReason(t *testing.T) {
 	}
 }
 
+func TestArchiveMatchingSkipsPerMessageGet(t *testing.T) {
+	base := beads.NewMemStore()
+	store := noMessageGetStore{MemStore: base}
+	p := New(store)
+
+	matchingA, err := p.Send("human", "human", "Dolt health advisory one", "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchingB, err := p.Send("human", "human", "Dolt health advisory two", "second")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := p.Send("human", "human", "Operator handoff", "leave open")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matches, results, err := p.ArchiveMatching(ArchiveFilter{
+		Recipients:      []string{"human"},
+		SubjectPrefix:   "Dolt health",
+		Limit:           10,
+		CaseInsensitive: true,
+	})
+	if err != nil {
+		t.Fatalf("ArchiveMatching: %v", err)
+	}
+	if len(matches) != 2 || len(results) != 2 {
+		t.Fatalf("ArchiveMatching returned %d matches/%d results, want 2/2", len(matches), len(results))
+	}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Fatalf("results[%d].Err = %v", i, r.Err)
+		}
+	}
+	for _, id := range []string{matchingA.ID, matchingB.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("message %s status = %q, want closed", id, got.Status)
+		}
+	}
+	got, err := base.Get(other.ID)
+	if err != nil {
+		t.Fatalf("Get(other): %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("nonmatching message status = %q, want open", got.Status)
+	}
+}
+
+type noMessageGetStore struct {
+	*beads.MemStore
+}
+
+func (s noMessageGetStore) Get(id string) (beads.Bead, error) {
+	if strings.HasPrefix(id, "gc-") {
+		return beads.Bead{}, errors.New("per-message Get must not be used")
+	}
+	return s.MemStore.Get(id)
+}
+
 // --- Delete ---
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Implements bounded filtered `gc mail archive` cleanup for large health/reaper-style backlogs.

Changes:
- add `gc mail archive` filters for recipient, sender, subject prefix/contains, limit, include-read, dry-run, and JSON output
- add beadmail batch archive selection that avoids per-message reads on large backlogs
- add bdstore batch close with reason support
- update CLI docs and regression coverage

Validation:
- `env GOTOOLCHAIN=auto go test ./cmd/gc -run 'TestMailArchive'`
- `env GOTOOLCHAIN=auto go test ./internal/mail/beadmail -run 'TestArchive'`
- `env GOTOOLCHAIN=auto go test ./internal/beads -run 'TestBdStoreCloseAll'`
- `env GOTOOLCHAIN=auto go vet ./...`

Note: direct push to `gastownhall/gascity` failed because the authenticated account only has read permission on the upstream repository, so this PR is from the authenticated fork.