### PR TITLE
fix(workdir): resolve rig from qualified-name prefix for rig-scoped agents (#2070)

### DIFF
--- a/internal/workdir/workdir.go
+++ b/internal/workdir/workdir.go
@@ -71,9 +71,36 @@ func RigRootForName(rigName string, rigs []config.Rig) string {
 	return ""
 }
 
+// rigNameForQualifiedAgent resolves the rig an agent belongs to. It prefers
+// the dir-based association used by ConfiguredRigName, then falls back to the
+// qualified-name prefix for explicitly rig-scoped agents whose Dir is not
+// stamped or points outside any configured rig path. This keeps
+// GC_RIG/GC_RIG_ROOT populated for rig-scoped agents whose work_dir lands
+// outside the rig filesystem (e.g. a city-level worktree), where the
+// dir heuristic alone returns "" and the rig keys would otherwise leak
+// through as empty values — gascity#2070.
+func rigNameForQualifiedAgent(cityPath, qualifiedName string, a config.Agent, rigs []config.Rig) string {
+	if name := ConfiguredRigName(cityPath, a, rigs); name != "" {
+		return name
+	}
+	if a.Scope != "rig" {
+		return ""
+	}
+	dir, _ := config.ParseQualifiedName(qualifiedName)
+	if dir == "" {
+		return ""
+	}
+	for _, rig := range rigs {
+		if dir == rig.Name {
+			return rig.Name
+		}
+	}
+	return ""
+}
+
 // PathContextForQualifiedName builds template context for work_dir expansion.
 func PathContextForQualifiedName(cityPath, cityName, qualifiedName string, a config.Agent, rigs []config.Rig) PathContext {
-	rigName := ConfiguredRigName(cityPath, a, rigs)
+	rigName := rigNameForQualifiedAgent(cityPath, qualifiedName, a, rigs)
 	_, agentBase := config.ParseQualifiedName(qualifiedName)
 	return PathContext{
 		Agent:     qualifiedName,

--- a/internal/workdir/workdir_test.go
+++ b/internal/workdir/workdir_test.go
@@ -461,3 +461,56 @@ func TestResolveTmuxAlias_ReturnsErrorOnBadTemplate(t *testing.T) {
 		t.Fatal("ResolveTmuxAlias: want error on unknown template field, got nil")
 	}
 }
+
+// TestPathContextRigScopedAgentResolvesRigFromQualifiedNamePrefix covers
+// gascity#2070: a scope="rig" agent whose Dir is not stamped (or points
+// outside any configured rig path) must still resolve its rig — and thus
+// GC_RIG/GC_RIG_ROOT — from the qualified-name prefix. Without this, the
+// rig keys leak through as empty values.
+func TestPathContextRigScopedAgentResolvesRigFromQualifiedNamePrefix(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "thriva")
+	rigs := []config.Rig{{Name: "thriva", Path: rigPath}}
+	// No Dir stamp; the rig association lives only in the qualified name.
+	a := config.Agent{Name: "my_impl", Scope: "rig", WorkDir: ".gc/worktrees/my_impl"}
+
+	ctx := PathContextForQualifiedName(cityPath, "city", "thriva/my_impl", a, rigs)
+	if ctx.Rig != "thriva" {
+		t.Fatalf("ctx.Rig = %q, want %q", ctx.Rig, "thriva")
+	}
+	if ctx.RigRoot != rigPath {
+		t.Fatalf("ctx.RigRoot = %q, want %q", ctx.RigRoot, rigPath)
+	}
+}
+
+// TestPathContextNonRigScopedAgentDoesNotInferRig guards against false
+// positives: a non-rig-scoped agent must not be assigned a rig from a
+// coincidental qualified-name prefix.
+func TestPathContextNonRigScopedAgentDoesNotInferRig(t *testing.T) {
+	cityPath := t.TempDir()
+	rigs := []config.Rig{{Name: "thriva", Path: filepath.Join(cityPath, "rigs", "thriva")}}
+	a := config.Agent{Name: "my_impl", Scope: "city"}
+
+	ctx := PathContextForQualifiedName(cityPath, "city", "thriva/my_impl", a, rigs)
+	if ctx.Rig != "" {
+		t.Fatalf("ctx.Rig = %q, want empty for city-scoped agent", ctx.Rig)
+	}
+}
+
+// TestPathContextRigScopedAgentPrefersStampedDir confirms the existing
+// dir-based association still wins when Dir is stamped (no regression of
+// the working path).
+func TestPathContextRigScopedAgentPrefersStampedDir(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "thriva")
+	rigs := []config.Rig{{Name: "thriva", Path: rigPath}}
+	a := config.Agent{Name: "my_impl", Dir: "thriva", Scope: "rig"}
+
+	ctx := PathContextForQualifiedName(cityPath, "city", "thriva/my_impl", a, rigs)
+	if ctx.Rig != "thriva" {
+		t.Fatalf("ctx.Rig = %q, want %q", ctx.Rig, "thriva")
+	}
+	if ctx.RigRoot != rigPath {
+		t.Fatalf("ctx.RigRoot = %q, want %q", ctx.RigRoot, rigPath)
+	}
+}


### PR DESCRIPTION
## Summary

Rig-scoped agents (`scope = "rig"`) whose `work_dir` resolves outside the rig filesystem (e.g. a city-level worktree) leaked `GC_RIG` / `GC_RIG_ROOT` through to the agent process as empty strings, breaking `gc bd` routing from inside the agent.

Root cause: `internal/workdir/workdir.go:75 ConfiguredRigName` returns `""` when the agent's `Dir` does not match a configured rig name or path. The agent env block only overrides the rig keys when `rigName != ""`, so the explicit empty placeholders (kept for the tmux `env -u` strip) propagate to the agent process.

Fix: add a scope-aware fallback in `PathContextForQualifiedName`. When the dir-based lookup comes up empty AND the agent is explicitly rig-scoped, recover the rig from the qualified-name prefix (e.g. qualified name `thriva/my_impl` + configured rig `thriva` → rig `thriva`). The dir-based association still wins when present, so the already-working stamped-`Dir` path is unchanged; non-rig-scoped agents are never assigned a rig from a coincidental prefix.

## Evidence

- `internal/workdir/workdir.go:74-100` — new `rigNameForQualifiedAgent` helper with explicit fallback ordering: configured-dir match first, then qualified-name prefix only for `scope == "rig"`.
- `internal/workdir/workdir.go:103` — `PathContextForQualifiedName` now calls `rigNameForQualifiedAgent` instead of `ConfiguredRigName` directly.

## Tests

`internal/workdir/workdir_test.go` adds three table-driven cases:

- **positive**: rig-scoped agent with empty `Dir` and qualified-name prefix matching a configured rig → resolves rig + RigRoot.
- **guard**: non-rig-scoped agent with the same qualified-name prefix → rig stays empty (no coincidental-prefix capture).
- **regression**: existing stamped-`Dir` path still wins over the prefix fallback when both could match.

## Gates

- `go build ./...` — clean
- `go vet ./internal/workdir/... ./cmd/gc/...` — clean
- `go test ./internal/workdir/...` — pass
- Rebased onto current `origin/main` (`da5af1e4a`); no conflicts (`internal/workdir/` untouched on main since branch base).

## Scope notes

This fixes the `PathContextForQualifiedName` side of the rig-binding plumbing, which is the source of truth for `work_dir` expansion and the agent env block. It does NOT touch `cmd/gc/template_resolve.go`'s `SessionSetupContext`, which is the separate pipeline used for `pre_start` template substitution. That separate pipeline is the surface tracked in #1940 — the workdir fix here is necessary groundwork for #1940's fix candidate A (unify the two contexts) but is not sufficient on its own. Follow-up needed.

Closes #2070
