### PR TITLE
fix(sling): normalize slot-suffixed pool route targets at write (closes #2592)

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
@@ -624,7 +625,11 @@ func (r cliBeadRouter) Route(_ context.Context, req sling.RouteRequest) error {
 	if r.deps.Store == nil {
 		return fmt.Errorf("built-in sling routing requires a store")
 	}
-	if err := r.deps.Store.SetMetadata(req.BeadID, "gc.routed_to", req.Target); err != nil {
+	routedTo := req.Target
+	if r.deps.Cfg != nil {
+		routedTo = agentutil.NormalizePoolRouteTarget(r.deps.Cfg, req.Target)
+	}
+	if err := r.deps.Store.SetMetadata(req.BeadID, "gc.routed_to", routedTo); err != nil {
 		return fmt.Errorf("setting gc.routed_to on %s: %w", req.BeadID, err)
 	}
 	return nil

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1095,6 +1095,53 @@ func TestDoSlingNudgePoolNoMembers(t *testing.T) {
 	}
 }
 
+// TestBuiltInSlingSlotSuffixedTargetNormalizesRoutedTo is the write-side guard
+// for #2592: resolving and slinging a slot-suffixed pool target ("saitoc/polecat-2")
+// must record the base pool qualified name in gc.routed_to, so the pool's
+// exact-match work_query (keyed on the base template) can see the bead.
+func TestBuiltInSlingSlotSuffixedTargetNormalizesRoutedTo(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	maxPolecats := 5
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "saitoc", Path: "/tmp/saitoc", Prefix: "gc"}},
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "saitoc", MaxActiveSessions: &maxPolecats},
+		},
+	}
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	store := newSlingTestStore()
+	deps.Store = store
+
+	created, err := store.Create(beads.Bead{Title: "slot-routed work", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Resolve the slot-suffixed target the way the CLI does, then sling it.
+	target, ok := resolveAgentIdentity(cfg, "saitoc/polecat-2", "")
+	if !ok {
+		t.Fatal("resolveAgentIdentity(saitoc/polecat-2) failed")
+	}
+	if target.QualifiedName() != "saitoc/polecat-2" {
+		t.Fatalf("resolved target QualifiedName = %q, want saitoc/polecat-2", target.QualifiedName())
+	}
+
+	opts := testOpts(target, created.ID)
+	code := doSling(opts, deps, &fakeQuerier{bead: created}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("doSling returned %d; stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	routed, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get routed bead: %v", err)
+	}
+	if got := routed.Metadata["gc.routed_to"]; got != "saitoc/polecat" {
+		t.Fatalf("gc.routed_to = %q, want saitoc/polecat (slot suffix should be normalized away)", got)
+	}
+}
+
 func TestBuiltInSlingPoolRouteContractUsesMetadataOnly(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/internal/agentutil/resolve.go
+++ b/internal/agentutil/resolve.go
@@ -143,6 +143,50 @@ func resolvePoolInstanceQualified(cfg *config.City, input string) (config.Agent,
 	return config.Agent{}, false
 }
 
+// NormalizePoolRouteTarget collapses a slot-suffixed pool target qualified
+// name (e.g. "myrig/polecat-2") back to its base pool qualified name
+// ("myrig/polecat"). Slinging to a slot-suffixed target expresses a
+// load-balancing hint, not a hard pin: every slot in a pool shares the base
+// template, and pool work_query / nudgers key on that base via exact match.
+// Recording the slot-suffixed value in gc.routed_to therefore leaves the bead
+// structurally invisible to the pool. Normalizing at the routing write site
+// keeps slot-suffixed slings reachable by any slot.
+//
+// A target is collapsed only when it is exactly base.QualifiedName()+"-N" for
+// a configured multi-session pool agent and N is a valid slot (>=1, and within
+// the agent's max when bounded) — the inverse of resolvePoolInstanceQualified.
+// Any other target (base names, non-pool agents, out-of-range or non-numeric
+// suffixes, unknown agents) is returned unchanged.
+func NormalizePoolRouteTarget(cfg *config.City, target string) string {
+	if cfg == nil || target == "" {
+		return target
+	}
+	for i := range cfg.Agents {
+		a := cfg.Agents[i]
+		if !IsMultiSessionAgent(&a) {
+			continue
+		}
+		base := a.QualifiedName()
+		prefix := base + "-"
+		if !strings.HasPrefix(target, prefix) {
+			continue
+		}
+		suffix := target[len(prefix):]
+		n, err := strconv.Atoi(suffix)
+		if err != nil || n < 1 {
+			continue
+		}
+		if !a.HasUnlimitedSessionCapacity() {
+			maxSess := a.EffectiveMaxActiveSessions()
+			if maxSess == nil || n > *maxSess {
+				continue
+			}
+		}
+		return base
+	}
+	return target
+}
+
 // matchPoolInstanceBare checks if a bare input matches a multi-session
 // agent's instance pattern (e.g., "polecat-2" matches "polecat").
 func matchPoolInstanceBare(a config.Agent, input string) (config.Agent, bool) {

--- a/internal/agentutil/resolve_test.go
+++ b/internal/agentutil/resolve_test.go
@@ -183,3 +183,44 @@ func TestResolveAgentNotFound(t *testing.T) {
 		t.Error("expected not found")
 	}
 }
+
+func TestNormalizePoolRouteTarget(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "myrig", MaxActiveSessions: intPtr(3)},
+			{Name: "solo", Dir: "myrig", MaxActiveSessions: intPtr(1)},
+			{Name: "witness", BindingName: "gastown", MaxActiveSessions: intPtr(-1)},
+			{Name: "mayor"},
+		},
+	}
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{"qualified slot instance collapses to base", "myrig/polecat-2", "myrig/polecat"},
+		{"highest in-range slot collapses", "myrig/polecat-3", "myrig/polecat"},
+		{"binding slot instance collapses to base", "gastown.witness-7", "gastown.witness"},
+		{"base qualified name is left unchanged", "myrig/polecat", "myrig/polecat"},
+		{"out-of-range slot is left unchanged", "myrig/polecat-9", "myrig/polecat-9"},
+		{"zero slot is left unchanged", "myrig/polecat-0", "myrig/polecat-0"},
+		{"non-numeric suffix is left unchanged", "myrig/polecat-foo", "myrig/polecat-foo"},
+		{"singleton pool is left unchanged", "myrig/solo-1", "myrig/solo-1"},
+		{"non-pool agent is left unchanged", "mayor", "mayor"},
+		{"unknown target is left unchanged", "myrig/ghost-2", "myrig/ghost-2"},
+		{"empty target is left unchanged", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizePoolRouteTarget(cfg, tt.target); got != tt.want {
+				t.Errorf("NormalizePoolRouteTarget(%q) = %q, want %q", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizePoolRouteTargetNilConfig(t *testing.T) {
+	if got := NormalizePoolRouteTarget(nil, "myrig/polecat-2"); got != "myrig/polecat-2" {
+		t.Errorf("NormalizePoolRouteTarget(nil) = %q, want unchanged", got)
+	}
+}

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/execenv"
@@ -432,7 +433,11 @@ func (r apiBeadRouter) Route(_ context.Context, req sling.RouteRequest) error {
 	if r.store == nil {
 		return fmt.Errorf("built-in sling routing requires a store")
 	}
-	if err := r.store.SetMetadata(req.BeadID, "gc.routed_to", req.Target); err != nil {
+	routedTo := req.Target
+	if cfg != nil {
+		routedTo = agentutil.NormalizePoolRouteTarget(cfg, req.Target)
+	}
+	if err := r.store.SetMetadata(req.BeadID, "gc.routed_to", routedTo); err != nil {
 		if req.Force && errors.Is(err, beads.ErrNotFound) {
 			return nil
 		}

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -559,6 +559,41 @@ func TestSlingPoolTarget(t *testing.T) {
 	}
 }
 
+// TestSlingSlotSuffixedPoolTargetNormalizesRoutedTo is the write-side guard for
+// #2592: slinging to a slot-suffixed pool target must record the base pool
+// qualified name in gc.routed_to so the pool's exact-match work_query (which
+// keys on the base template) can see the bead.
+func TestSlingSlotSuffixedPoolTargetNormalizesRoutedTo(t *testing.T) {
+	h, state := newSlingTestServer(t)
+	state.cfg.Agents = []config.Agent{
+		{
+			Name:              "polecat",
+			Dir:               "myrig",
+			MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+		},
+	}
+	store := state.stores["myrig"]
+	b, err := store.Create(beads.Bead{Title: "test task", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"target":"myrig/polecat-2","bead":"` + b.ID + `"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/sling"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	updated, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", b.ID, err)
+	}
+	if got := updated.Metadata["gc.routed_to"]; got != "myrig/polecat" {
+		t.Fatalf("gc.routed_to = %q, want myrig/polecat (slot suffix should be normalized away)", got)
+	}
+}
+
 func TestSlingConflictReturns409ForExistingLiveWorkflow(t *testing.T) {
 	// The Huma migration moved sling to /v0/city/{cityName}/sling and
 	// replaced the old plain-JSON `{code, message, source_bead_id, ...}`


### PR DESCRIPTION
## Summary

Normalize slot-suffixed pool sling targets (e.g. `myrig/polecat-2`) to their base pool template name (`myrig/polecat`) at the `gc.routed_to` *write* sites, so the recorded routing matches the exact-equality work_query the pool template uses to claim work.

## Root cause

Per #2592: slinging to a slot-suffixed pool target resolves through `resolvePoolInstanceQualified` to a synthesized agent whose `Name` carries the slot suffix. That suffix then flows verbatim into `gc.routed_to`. The pool template's `work_query` matches by exact equality against the base pool name, so any slot-suffixed routing is structurally invisible to every slot in the pool. The bead sits routed-but-unclaimed indefinitely.

The routed-bead nudgers have the same shape (exact base-name match), so they don't notice either.

## Fix

Add `agentutil.NormalizePoolRouteTarget` — the inverse of `resolvePoolInstanceQualified`:

- If the target matches `<base.QualifiedName()>-<N>` AND `<base>` is a configured multi-session pool agent AND `N` is a valid slot of that pool, collapse to `<base.QualifiedName()>`.
- Otherwise, return the target unchanged.

Applied at both `gc.routed_to` write sites:

- `cliBeadRouter.Route` in `cmd/gc/cmd_sling.go`
- `apiBeadRouter.Route` in `internal/api/handler_sling.go`

The resolver itself is intentionally untouched. Its slot-suffixed identity is still needed by session naming, nudge, and prime — only the *recorded routing* needs to collapse to the base name.

## Trade-off

The recorded `gc.routed_to` loses its slot suffix. Per the #2592 issue body, the slot suffix was a load-balance hint, not a hard pin — any slot in the pool should be able to claim the work. This is consistent with that contract. If a caller did want hard slot pinning, that would need a different mechanism (separate field), not a slot suffix on `gc.routed_to`.

## Gates

- `make build` — clean
- `make check` — fmt, lint, vet, routed-test-rows, full test suite all pass; exit 0

## Tests added

- `TestNormalizePoolRouteTarget` + nil-guard variant in `internal/agentutil/resolve_test.go`
- `TestSlingSlotSuffixedPoolTargetNormalizesRoutedTo` in `internal/api/handler_sling_test.go`
- `TestBuiltInSlingSlotSuffixedTargetNormalizesRoutedTo` in `cmd/gc/cmd_sling_test.go`

## Files changed

- `internal/agentutil/resolve.go` (+44)
- `internal/agentutil/resolve_test.go` (+41)
- `cmd/gc/cmd_sling.go` (+7)
- `cmd/gc/cmd_sling_test.go` (+47)
- `internal/api/handler_sling.go` (+7)
- `internal/api/handler_sling_test.go` (+35)

Closes #2592
