### PR TITLE
fix(refinery): replace checkout+merge+push with refspec push + PRE/POST origin verification

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -408,23 +408,52 @@ fi
 
 **If MERGE_STRATEGY = "direct" (default):**
 
-**1. Merge and push target branch:**
-```bash
-git checkout $TARGET
-git merge --ff-only temp
-git push origin $TARGET
-```
+**1. Push via refspec and verify origin moved:**
 
-**2. Verify push:**
+No local checkout of `$TARGET` — avoids "already used by worktree" failure
+when the target branch is held by another worktree in the repo.
+
 ```bash
+git fetch --prune origin
+PRE_MERGE_SHA=$(git rev-parse origin/$TARGET)
+BRANCH_TIP=$(git rev-parse temp)
+if [ -z "$PRE_MERGE_SHA" ] || [ -z "$BRANCH_TIP" ]; then
+  echo "Could not resolve SHAs for origin/$TARGET or temp."
+  gc runtime drain-ack; exit 1
+fi
+if git merge-base --is-ancestor "$BRANCH_TIP" "$PRE_MERGE_SHA"; then
+  echo "Branch already ancestor of $TARGET — no-op merge, rejecting."
+  gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
+  gc bd update $WORK \
+    --status=open \
+    --assignee="" \
+    --set-metadata rejection_reason="no-op merge: branch already merged into $TARGET" \
+    --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat"
+  git branch -D temp 2>/dev/null || true
+  NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
+  gc bd update "$NEXT" --assignee=$GC_AGENT
+  gc bd mol burn <wisp-id> --force
+  gc runtime drain-ack; exit 0
+fi
+git push origin temp:$TARGET || {
+  echo "FATAL: Refspec push to origin/$TARGET failed."
+  gc runtime drain-ack; exit 1
+}
 git fetch origin
-LOCAL=$(git rev-parse $TARGET)
-REMOTE=$(git rev-parse origin/$TARGET)
-[ "$LOCAL" = "$REMOTE" ] || echo "PUSH FAILED — do not proceed"
+POST_MERGE_SHA=$(git rev-parse origin/$TARGET)
+if [ "$POST_MERGE_SHA" = "$PRE_MERGE_SHA" ]; then
+  echo "FATAL: origin/$TARGET did not advance after push."
+  gc runtime drain-ack; exit 1
+fi
+if [ "$POST_MERGE_SHA" != "$BRANCH_TIP" ]; then
+  echo "FATAL: origin/$TARGET ($POST_MERGE_SHA) != branch tip ($BRANCH_TIP) after push."
+  gc runtime drain-ack; exit 1
+fi
+MERGED_SHA=$POST_MERGE_SHA
+MERGED_SHORT=$(git rev-parse --short $POST_MERGE_SHA)
 ```
-If SHAs differ: STOP. Debug and retry. Do NOT continue.
 
-**3. Record merge metadata and close work bead:**
+**2. Record merge metadata and close work bead:**
 
 Run as a single chained command so the metadata write cannot be skipped
 when the close-reason already names the SHA. Both the `--set-metadata`
@@ -435,8 +464,6 @@ clears any stale rejection field from an earlier rejected/reworked
 attempt before the successful close.
 
 ```bash
-MERGED_SHA=$(git rev-parse HEAD) && \
-MERGED_SHORT=$(git rev-parse --short HEAD) && \
 gc bd update $WORK \
   --set-metadata merge_result=merged \
   --set-metadata merged_sha=$MERGED_SHA \
@@ -445,7 +472,7 @@ gc bd update $WORK \
 gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"
 ```
 
-**4. Cleanup:**
+**3. Cleanup:**
 ```bash
 git branch -d temp
 ```


### PR DESCRIPTION
## Summary

- Replaces `git checkout $TARGET; git merge --ff-only temp; git push origin $TARGET` with `git push origin temp:$TARGET` (refspec push)
- Adds PRE/POST `origin/$TARGET` SHA capture and verification to ensure the push actually moved the remote ref
- Adds upfront ancestor check to reject no-op merges (branch already merged into target)
- Records `MERGED_SHA` from `POST_MERGE_SHA` (verified origin tip) instead of `git rev-parse HEAD`

## Root cause (gp-t5w)

When the refinery worktree is on its own branch and the target branch is held by another worktree (e.g., `/home/b/GIT/gc-packs` holds `master`), `git checkout $TARGET` fails with "already used by worktree". The formula had no error handling — the LLM would continue, the push was a no-op, and `MERGED_SHA=$(git rev-parse HEAD)` would record the stale local commit (the pre-existing target tip). The refinery would then delete the source branch believing the merge had landed, and the bead would be closed with a fabricated SHA.

## Test plan

- [ ] Review the diff: only `examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml` changed
- [ ] Verify `git checkout $TARGET` is gone from the direct-merge block
- [ ] Verify `git push origin temp:$TARGET` is the new push mechanism
- [ ] Verify `MERGED_SHA` is set from `POST_MERGE_SHA` (post-fetch origin ref), not `git rev-parse HEAD`
- [ ] Verify PRE/POST verification fails loudly if origin did not advance
- [ ] Verify no-op merge (branch already ancestor) is caught upfront and rejected

Fixes: ga-jzb0i
Upstream investigation: gp-t5w (gc-packs rig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)