### PR TITLE
fix(config): hoist city-scoped agents from rig includes instead of silently dropping them

### DIFF
--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -1224,9 +1224,14 @@ scope = "city"
 	if !found["proj/gs.polecat"] {
 		t.Errorf("missing proj/gs.polecat; got: %v", found)
 	}
-	// City-scoped agent should NOT appear from rig import.
-	if found["gs.mayor"] || found["proj/gs.mayor"] {
-		t.Error("city-scoped mayor should not appear from rig-level import")
+	// City-scoped agent reached through a rig-level import is hoisted to city
+	// scope (rig dir cleared) rather than dropped, so it registers as the
+	// binding-qualified "gs.mayor" — not under the rig prefix "proj/gs.mayor".
+	if !found["gs.mayor"] {
+		t.Errorf("city-scoped mayor should be hoisted from rig import as gs.mayor; got: %v", found)
+	}
+	if found["proj/gs.mayor"] {
+		t.Errorf("hoisted mayor should not retain rig prefix proj/gs.mayor; got: %v", found)
 	}
 }
 

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -98,6 +98,13 @@ func ExpandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 
 func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[string][]string, opts LoadOptions) error {
 	var expanded []Agent
+	// City-scoped agents and named sessions encountered through a rig-scope
+	// include/import are hoisted to city scope (deduped) rather than dropped,
+	// so a city-scoped agent that lives in a rig-included pack (e.g. a routing
+	// coordinator in a pack only ever rig-included) still registers. Collected
+	// here across all rigs and merged into cfg once below.
+	var hoistedAgents []Agent
+	var hoistedNamedSessions []NamedSession
 	for i := range cfg.Rigs {
 		rig := &cfg.Rigs[i]
 		cache := &packLoadCache{results: make(map[string]*packLoadResult)}
@@ -175,7 +182,10 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 			rigTopoDirs = appendUnique(rigTopoDirs, topoDirs...)
 			rigPackGraphOnlyDirs = appendUniqueLastWins(rigPackGraphOnlyDirs, topoDirs...)
 
-			// Keep only rig-scoped and unscoped agents for rig expansion.
+			// Keep only rig-scoped and unscoped agents for rig expansion;
+			// hoist city-scoped ones to city scope instead of dropping them.
+			hoistedAgents = append(hoistedAgents, hoistCityScopedAgents(agents)...)
+			hoistedNamedSessions = append(hoistedNamedSessions, hoistCityScopedNamedSessions(namedSessions)...)
 			agents = filterAgentsByScope(agents, false)
 			namedSessions = filterNamedSessionsByScope(namedSessions, false)
 
@@ -359,6 +369,10 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 				rigTopoDirs = appendUnique(rigTopoDirs, topoDirs...)
 				rigImportPackDirs = prependUniqueBlock(rigImportPackDirs, mcpTopoDirs...)
 
+				// Hoist city-scoped agents/sessions to city scope instead of
+				// dropping them at the rig-import boundary.
+				hoistedAgents = append(hoistedAgents, hoistCityScopedAgents(agents)...)
+				hoistedNamedSessions = append(hoistedNamedSessions, hoistCityScopedNamedSessions(namedSessions)...)
 				agents = filterAgentsByScope(agents, false)
 				namedSessions = filterNamedSessionsByScope(namedSessions, false)
 
@@ -465,6 +479,14 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 		cfg.NamedSessions = append(cfg.NamedSessions, rigNamedSessions...)
 	}
 	cfg.Agents = append(cfg.Agents, expanded...)
+	// Merge hoisted city-scoped agents/sessions (from rig includes/imports)
+	// into the city set, deduped by qualified name. The same pack is commonly
+	// included by several rigs; without dedup the same city-scoped agent would
+	// be registered once per rig and collide (see duplicate_agent_error.go).
+	// Any name already present at city scope (city-scope expansion, a city-root
+	// agents/<name>/, or an earlier hoist) wins; the hoisted copy is skipped.
+	cfg.Agents = mergeHoistedCityAgents(cfg.Agents, hoistedAgents)
+	cfg.NamedSessions = mergeHoistedCityNamedSessions(cfg.NamedSessions, hoistedNamedSessions)
 	if opts.deferRigPatches && opts.deferredRigPatches != nil {
 		for i := range *opts.deferredRigPatches {
 			(*opts.deferredRigPatches)[i].expectedAgentCount = len(cfg.Agents)
@@ -2417,6 +2439,84 @@ func filterNamedSessionsByScope(sessions []NamedSession, cityExpansion bool) []N
 		}
 	}
 	return result
+}
+
+// hoistCityScopedAgents returns copies of the city-scoped agents in the
+// given slice, restamped for city scope (Dir cleared — it was stamped to the
+// rig name during pack load). Used at rig include/import boundaries so a
+// city-scoped agent that lives in a rig-included pack is hoisted to city
+// scope instead of being silently dropped. BindingName is preserved so a
+// city-scoped agent imported under a binding keeps its qualified identity.
+func hoistCityScopedAgents(agents []Agent) []Agent {
+	var hoisted []Agent
+	for _, a := range agents {
+		if a.Scope != "city" {
+			continue
+		}
+		a.Dir = ""
+		hoisted = append(hoisted, a)
+	}
+	return hoisted
+}
+
+// hoistCityScopedNamedSessions mirrors hoistCityScopedAgents for named
+// sessions.
+func hoistCityScopedNamedSessions(sessions []NamedSession) []NamedSession {
+	var hoisted []NamedSession
+	for _, s := range sessions {
+		if s.Scope != "city" {
+			continue
+		}
+		s.Dir = ""
+		hoisted = append(hoisted, s)
+	}
+	return hoisted
+}
+
+// mergeHoistedCityAgents appends hoisted city-scoped agents to the city
+// agent set, skipping any whose qualified name is already present (from
+// city-scope expansion, a city-root agent, or an earlier hoist of the same
+// agent via another rig). First occurrence wins, so an existing city-scope
+// or city-root definition is preferred over a hoisted one. Identical
+// definitions reached through multiple rigs register exactly once.
+func mergeHoistedCityAgents(agents, hoisted []Agent) []Agent {
+	if len(hoisted) == 0 {
+		return agents
+	}
+	seen := make(map[string]bool, len(agents))
+	for i := range agents {
+		seen[agents[i].QualifiedName()] = true
+	}
+	for _, a := range hoisted {
+		qn := a.QualifiedName()
+		if seen[qn] {
+			continue
+		}
+		seen[qn] = true
+		agents = append(agents, a)
+	}
+	return agents
+}
+
+// mergeHoistedCityNamedSessions mirrors mergeHoistedCityAgents for named
+// sessions.
+func mergeHoistedCityNamedSessions(sessions, hoisted []NamedSession) []NamedSession {
+	if len(hoisted) == 0 {
+		return sessions
+	}
+	seen := make(map[string]bool, len(sessions))
+	for i := range sessions {
+		seen[sessions[i].QualifiedName()] = true
+	}
+	for _, s := range hoisted {
+		qn := s.QualifiedName()
+		if seen[qn] {
+			continue
+		}
+		seen[qn] = true
+		sessions = append(sessions, s)
+	}
+	return sessions
 }
 
 func applyDeferredRigPatches(cfg *City, deferred []deferredRigPatches) error {

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -2013,22 +2013,35 @@ scope = "rig"
 		t.Fatalf("ExpandPacks: %v", err)
 	}
 
-	// Should only have rig agents (witness, polecat), not city agents.
-	if len(cfg.Agents) != 2 {
-		t.Fatalf("got %d agents, want 2", len(cfg.Agents))
-	}
-	names := make(map[string]bool)
+	// Rig agents (witness, polecat) are stamped with the rig dir; city-scoped
+	// agents (mayor, deacon) are hoisted to city scope (dir cleared) rather
+	// than dropped.
+	byName := make(map[string]Agent)
 	for _, a := range cfg.Agents {
-		names[a.Name] = true
+		byName[a.Name] = a
+	}
+	if len(cfg.Agents) != 4 {
+		t.Fatalf("got %d agents, want 4 (2 rig + 2 hoisted city): %v", len(cfg.Agents), agentNamesOf(cfg.Agents))
+	}
+	for _, n := range []string{"witness", "polecat"} {
+		a, ok := byName[n]
+		if !ok {
+			t.Errorf("missing rig agent %q", n)
+			continue
+		}
 		if a.Dir != "hw" {
-			t.Errorf("rig agent %q: dir = %q, want %q", a.Name, a.Dir, "hw")
+			t.Errorf("rig agent %q: dir = %q, want %q", n, a.Dir, "hw")
 		}
 	}
-	if !names["witness"] || !names["polecat"] {
-		t.Errorf("agents = %v, want witness and polecat", names)
-	}
-	if names["mayor"] || names["deacon"] {
-		t.Error("city agents should be filtered out of rig pack expansion")
+	for _, n := range []string{"mayor", "deacon"} {
+		a, ok := byName[n]
+		if !ok {
+			t.Errorf("city-scoped agent %q was dropped, want hoisted to city scope", n)
+			continue
+		}
+		if a.Dir != "" {
+			t.Errorf("hoisted city agent %q: dir = %q, want empty (city scope)", n, a.Dir)
+		}
 	}
 }
 
@@ -2398,11 +2411,20 @@ scope = "rig"
 		t.Fatalf("ExpandPacks: %v", err)
 	}
 
-	if len(cfg.NamedSessions) != 1 {
-		t.Fatalf("NamedSessions = %d, want 1", len(cfg.NamedSessions))
+	// The rig-scoped witness session stays rig-qualified; the city-scoped
+	// mayor session is hoisted to city scope rather than dropped.
+	got := make(map[string]bool)
+	for i := range cfg.NamedSessions {
+		got[cfg.NamedSessions[i].QualifiedName()] = true
 	}
-	if got := cfg.NamedSessions[0].QualifiedName(); got != "frontend/witness" {
-		t.Fatalf("NamedSessions[0] = %q, want frontend/witness", got)
+	if len(cfg.NamedSessions) != 2 {
+		t.Fatalf("NamedSessions = %d, want 2 (rig witness + hoisted city mayor): %v", len(cfg.NamedSessions), got)
+	}
+	if !got["frontend/witness"] {
+		t.Errorf("expected rig-scoped named session frontend/witness, got %v", got)
+	}
+	if !got["mayor"] {
+		t.Errorf("expected city-scoped named session mayor to be hoisted, got %v", got)
 	}
 }
 
@@ -2778,13 +2800,240 @@ scope = "rig"
 		t.Fatalf("ExpandPacks: %v", err)
 	}
 
-	// Only scope="rig" agents should be kept (scope="city" excluded).
-	if len(cfg.Agents) != 1 {
-		t.Fatalf("got %d agents, want 1", len(cfg.Agents))
+	// The rig-scoped polecat is stamped with the rig dir; the city-scoped
+	// mayor is hoisted to city scope (dir cleared) rather than dropped.
+	byName := make(map[string]Agent)
+	for _, a := range cfg.Agents {
+		byName[a.Name] = a
 	}
-	if cfg.Agents[0].Name != "polecat" {
-		t.Errorf("agent name = %q, want polecat", cfg.Agents[0].Name)
+	if len(cfg.Agents) != 2 {
+		t.Fatalf("got %d agents, want 2 (rig polecat + hoisted city mayor)", len(cfg.Agents))
 	}
+	polecat, ok := byName["polecat"]
+	if !ok {
+		t.Fatal("expected rig-scoped polecat agent")
+	}
+	if polecat.Dir != "myrig" {
+		t.Errorf("polecat dir = %q, want myrig", polecat.Dir)
+	}
+	mayor, ok := byName["mayor"]
+	if !ok {
+		t.Fatal("expected city-scoped mayor to be hoisted from rig include")
+	}
+	if mayor.Dir != "" {
+		t.Errorf("hoisted mayor dir = %q, want \"\" (city scope)", mayor.Dir)
+	}
+}
+
+// TestExpandPacks_HoistCityScopedFromSingleRig verifies a city-scoped agent
+// (and named session) that lives in a pack reached only through a single
+// rig include is hoisted to city scope and registers, rather than being
+// silently dropped. This is the root-cause fix for ga-hy0co: a city-scoped
+// routing coordinator (e.g. "deacon") that ships in a rig-included pack must
+// still register, or autonomous routing never starts.
+func TestExpandPacks_HoistCityScopedFromSingleRig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "packs/supervisor/pack.toml", `
+[pack]
+name = "supervisor"
+schema = 1
+
+[[agent]]
+name = "deacon"
+scope = "city"
+
+[[named_session]]
+template = "deacon"
+scope = "city"
+
+[[agent]]
+name = "polecat"
+scope = "rig"
+`)
+
+	cfg := &City{
+		Rigs: []Rig{
+			{Name: "gascity", Path: "/tmp/gascity", Includes: []string{"packs/supervisor"}},
+		},
+	}
+
+	if err := ExpandPacks(cfg, fsys.OSFS{}, dir, nil); err != nil {
+		t.Fatalf("ExpandPacks: %v", err)
+	}
+
+	var deacon *Agent
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "deacon" {
+			deacon = &cfg.Agents[i]
+		}
+	}
+	if deacon == nil {
+		t.Fatalf("city-scoped deacon was dropped, not hoisted; agents: %v", agentNamesOf(cfg.Agents))
+	}
+	if deacon.Dir != "" {
+		t.Errorf("hoisted deacon dir = %q, want \"\" (city scope)", deacon.Dir)
+	}
+	if deacon.Scope != "city" {
+		t.Errorf("hoisted deacon scope = %q, want city", deacon.Scope)
+	}
+
+	// The city-scoped named session is hoisted too.
+	var sawDeaconSession bool
+	for i := range cfg.NamedSessions {
+		if cfg.NamedSessions[i].QualifiedName() == "deacon" {
+			sawDeaconSession = true
+		}
+	}
+	if !sawDeaconSession {
+		t.Errorf("city-scoped deacon named session was dropped, not hoisted; sessions: %v", cfg.NamedSessions)
+	}
+}
+
+// TestExpandPacks_HoistCityScopedDedupAcrossRigs verifies the same pack
+// included by MULTIPLE rigs registers its city-scoped agent exactly ONCE
+// (dedup), instead of registering one copy per rig and colliding via
+// checkPackAgentCollisions / duplicate_agent_error.go. In this city
+// packs/actual/all is rig-included by four rigs; a naive hoist would
+// register "deacon" four times.
+func TestExpandPacks_HoistCityScopedDedupAcrossRigs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "packs/supervisor/pack.toml", `
+[pack]
+name = "supervisor"
+schema = 1
+
+[[agent]]
+name = "deacon"
+scope = "city"
+
+[[named_session]]
+template = "deacon"
+scope = "city"
+
+[[agent]]
+name = "polecat"
+scope = "rig"
+`)
+
+	cfg := &City{
+		Rigs: []Rig{
+			{Name: "gascity", Path: "/tmp/gascity", Includes: []string{"packs/supervisor"}},
+			{Name: "mcdclient", Path: "/tmp/mcdclient", Includes: []string{"packs/supervisor"}},
+			{Name: "beads", Path: "/tmp/beads", Includes: []string{"packs/supervisor"}},
+			{Name: "wren", Path: "/tmp/wren", Includes: []string{"packs/supervisor"}},
+		},
+	}
+
+	// Must not error on the multi-rig collision; dedup makes it register once.
+	if err := ExpandPacks(cfg, fsys.OSFS{}, dir, nil); err != nil {
+		t.Fatalf("ExpandPacks (multi-rig dedup): %v", err)
+	}
+
+	var deaconCount int
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "deacon" {
+			deaconCount++
+		}
+	}
+	if deaconCount != 1 {
+		t.Fatalf("deacon registered %d times across 4 rigs, want exactly 1 (dedup); agents: %v", deaconCount, agentNamesOf(cfg.Agents))
+	}
+
+	var deaconSessions int
+	for i := range cfg.NamedSessions {
+		if cfg.NamedSessions[i].QualifiedName() == "deacon" {
+			deaconSessions++
+		}
+	}
+	if deaconSessions != 1 {
+		t.Fatalf("deacon named session registered %d times, want exactly 1 (dedup)", deaconSessions)
+	}
+
+	// Each rig still gets its own rig-scoped polecat.
+	var polecatCount int
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "polecat" {
+			polecatCount++
+		}
+	}
+	if polecatCount != 4 {
+		t.Errorf("polecat (rig-scoped) registered %d times, want 4 (one per rig)", polecatCount)
+	}
+}
+
+// TestExpandPacks_HoistDoesNotDuplicateCityScopeAgent verifies that when a
+// city-scoped agent already exists at city scope (here via city includes),
+// hoisting the same-named agent from a rig include does NOT add a duplicate:
+// the existing city-scope/city-root definition wins.
+func TestExpandPacks_HoistDoesNotDuplicateCityScopeAgent(t *testing.T) {
+	dir := t.TempDir()
+
+	// City pack defines deacon at city scope (the canonical definition).
+	writeFile(t, dir, "packs/citysup/pack.toml", `
+[pack]
+name = "citysup"
+schema = 1
+
+[[agent]]
+name = "deacon"
+scope = "city"
+prompt_template = "prompts/deacon.md"
+`)
+	writeFile(t, dir, "packs/citysup/prompts/deacon.md", "city-scope deacon")
+
+	// Rig pack ALSO defines a city-scoped deacon; reached via a rig include.
+	writeFile(t, dir, "packs/rigsup/pack.toml", `
+[pack]
+name = "rigsup"
+schema = 1
+
+[[agent]]
+name = "deacon"
+scope = "city"
+`)
+
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+includes = ["packs/citysup"]
+
+[[rigs]]
+name = "gascity"
+path = "/tmp/gascity"
+includes = ["packs/rigsup"]
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	var deacons []Agent
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "deacon" {
+			deacons = append(deacons, cfg.Agents[i])
+		}
+	}
+	if len(deacons) != 1 {
+		t.Fatalf("deacon registered %d times, want exactly 1 (city-scope wins over hoist); agents: %v", len(deacons), agentNamesOf(cfg.Agents))
+	}
+	// The surviving deacon is the city-scope definition (has the prompt
+	// template), not the bare rig-pack one.
+	if !strings.Contains(deacons[0].PromptTemplate, "prompts/deacon.md") {
+		t.Errorf("surviving deacon prompt_template = %q, want the city-scope definition (prompts/deacon.md)", deacons[0].PromptTemplate)
+	}
+	if deacons[0].Dir != "" {
+		t.Errorf("surviving deacon dir = %q, want \"\" (city scope)", deacons[0].Dir)
+	}
+}
+
+// agentNamesOf is a small test helper for readable failure messages.
+func agentNamesOf(agents []Agent) []string {
+	names := make([]string, 0, len(agents))
+	for i := range agents {
+		names = append(names, agents[i].QualifiedName())
+	}
+	return names
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`filterAgentsByScope(agents, false)` at the two **rig** include/import sites in `expandPacks` (`internal/config/pack.go`) **silently DISCARDED** any agent with `scope = "city"` whose pack was reached through a rig-scope include. City/workspace expansion (`expandCityPacks`) calls the same filter with `true` and keeps city-scoped agents, but the rig sites dropped them on the floor.

**Symptom:** a `scope = "city"` agent that only lives in a pack that is *only ever rig-included* — e.g. the `actual` "supervisor" pack's **`deacon`** routing coordinator — was never registered. So the autonomous routing loop silently never started. This surfaced as a **production routing outage** (tracking bead `ga-hy0co`).

## The fix: hoist, with dedup

At both the rig `includes` site and the rig `[imports.X]` site, instead of discarding the city-scoped agents (and `named_sessions`), we **collect** them, clear their rig stamping (`Dir`, which `loadPack` had set to the rig name), and **hoist** them up to **city scope** so they register. They are merged into `cfg.Agents` / `cfg.NamedSessions` once at the end of `expandPacks`.

The merge is **deduped by qualified name**, which is required: the same pack is commonly included by several rigs (in our city `packs/actual/all` is rig-included by **four** rigs — gascity, MCDClient, beads, wren). A naive hoist would register `deacon` once per rig and **collide** via `checkPackAgentCollisions` / `duplicate_agent_error.go`. The merge skips any qualified name already present, so:

- an existing **city-scope** or **city-root** definition of the same name **wins** over a hoisted copy, and
- **identical** definitions reached through multiple rigs register **exactly once** (first occurrence wins; no error on the identical-pack case).

### Why this approach

- **Chosen over warn-only:** a warning leaves autonomous routing broken until someone manually adds city config — the outage would persist. Hoisting fixes the root cause with zero manual config.
- **Chosen over a naive hoist:** that collides across the multiple rigs that include the same pack.

## Changes

- `internal/config/pack.go`
  - `expandPacks`: capture+hoist city-scoped agents/sessions at the rig `includes` and rig `[imports.X]` filter sites; merge into the city set (deduped) before recording the deferred-rig-patch agent count (so the deferred-patch index invariant is preserved).
  - New helpers: `hoistCityScopedAgents`, `hoistCityScopedNamedSessions`, `mergeHoistedCityAgents`, `mergeHoistedCityNamedSessions`.
- `internal/config/pack_test.go`, `internal/config/import_test.go`
  - New tests: hoist from a single rig; dedup across four rigs (no collision / duplicate error); city-scope/city-root definition wins over the hoisted copy.
  - Updated existing tests that asserted the old silent-drop behavior (`TestExpandPacks_ScopeExcludesCity`, `TestExpandPacks_IncludesRigScopedNamedSessions`, `TestExpandPacksFilters`, `TestImport_RigLevelImports`).

## Testing

`go test ./internal/config` — all green (full package). `go vet ./internal/config` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)