### PR TITLE
fix(gc): reap guard and federation Dolt test DBs

### DIFF
--- a/cmd/gc/dolt_cleanup_drop_planner.go
+++ b/cmd/gc/dolt_cleanup_drop_planner.go
@@ -9,13 +9,15 @@ import "strings"
 //
 // Convention:
 //   - testdb_*: BEADS_TEST_MODE=1 FNV hash of temp paths
+//   - test_guard_*: guard/registry isolation tests
+//   - test_federation_*: federation isolation tests
 //   - doctest_*: doctor test helpers
 //   - doctortest_*: doctor test helpers
 //   - beads_pt*: orchestrator patrol_helpers_test.go random prefixes
 //   - beads_vr*: orchestrator mail/router_test.go random prefixes
 //   - beads_t[0-9a-f]*: protocol test random prefixes (t + 8 hex chars)
 var defaultStaleDatabasePrefixes = []string{
-	"testdb_", "doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t",
+	"testdb_", "test_guard_", "test_federation_", "doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t",
 }
 
 // systemDatabaseNames are the Dolt/MySQL system databases that SHOW

--- a/cmd/gc/dolt_cleanup_drop_planner_test.go
+++ b/cmd/gc/dolt_cleanup_drop_planner_test.go
@@ -92,6 +92,31 @@ func TestPlanDoltDrops_BeadsTRequiresHexSuffix(t *testing.T) {
 	}
 }
 
+func TestPlanDoltDrops_DefaultPrefixesIncludeGuardAndFederationTests(t *testing.T) {
+	all := []string{
+		"hq",
+		"gascity",
+		"test_guard_abc123",
+		"test_federation_xyz",
+		"testdb_old",
+	}
+	protected := []string{"hq", "gascity"}
+
+	plan := planDoltDrops(all, defaultStaleDatabasePrefixes, protected)
+
+	wantDrop := []string{"test_guard_abc123", "test_federation_xyz", "testdb_old"}
+	if !equalStringSlice(plan.ToDrop, wantDrop) {
+		t.Errorf("ToDrop = %v, want %v", plan.ToDrop, wantDrop)
+	}
+	wantProtected := []string{"hq", "gascity"}
+	if !equalStringSlice(plan.Protected, wantProtected) {
+		t.Errorf("Protected = %v, want %v", plan.Protected, wantProtected)
+	}
+	if len(plan.Skipped) != 0 {
+		t.Errorf("Skipped = %v, want empty", plan.Skipped)
+	}
+}
+
 func TestPlanDoltDrops_SkipsInvalidDropIdentifiers(t *testing.T) {
 	all := []string{
 		"testdb_valid_1",
@@ -163,7 +188,10 @@ func TestPlanDoltDrops_EmptyInputsProduceEmptyPlan(t *testing.T) {
 func TestDefaultStaleDatabasePrefixes_MirrorsBeadsCleanDatabases(t *testing.T) {
 	// be-hjj-3 is the beads-side bead that converges these prefixes; until
 	// then we mirror beads/cmd/bd/dolt.go:staleDatabasePrefixes.
-	want := []string{"testdb_", "doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t"}
+	want := []string{
+		"testdb_", "test_guard_", "test_federation_",
+		"doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t",
+	}
 	if !equalStringSlice(defaultStaleDatabasePrefixes, want) {
 		t.Errorf("defaultStaleDatabasePrefixes = %v, want %v", defaultStaleDatabasePrefixes, want)
 	}

--- a/release-gates/ga-m3gz4-dolt-cleanup-test-db-prefixes-gate.md
+++ b/release-gates/ga-m3gz4-dolt-cleanup-test-db-prefixes-gate.md
@@ -1,0 +1,47 @@
+# Release Gate - ga-m3gz4 Dolt cleanup test DB prefixes
+
+Date: 2026-05-25
+
+- Source bead: `ga-m3gz4`
+- Review bead: `ga-r96vg`
+- Branch: `builder/ga-m3gz4`
+- Reviewed commit: `b33f17f16a74`
+- Base: `origin/main` at `d48bcb4c5432`
+- Diff: `cmd/gc/dolt_cleanup_drop_planner.go`, `cmd/gc/dolt_cleanup_drop_planner_test.go`
+- Project manifest: `docs/PROJECT_MANIFEST.md` is absent in this checkout; gate uses the deployer prompt criteria plus `TESTING.md`.
+
+## Gate Checklist
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-r96vg` contains `Reviewer verdict: PASS` for commit `b33f17f16` on `origin/builder/ga-m3gz4`; findings are `None`. |
+| 2 | Acceptance criteria met | PASS | `defaultStaleDatabasePrefixes` now includes `test_guard_` and `test_federation_`; `TestPlanDoltDrops_DefaultPrefixesIncludeGuardAndFederationTests` asserts those names are dropped while live rig DB names `hq` and `gascity` are protected; `TestDefaultStaleDatabasePrefixes_MirrorsBeadsCleanDatabases` includes the beads-side convergence note for `be-hjj-3`. |
+| 3 | Tests pass | PASS, no branch regression | Focused release checks passed: `go test ./cmd/gc/ -run 'DoltCleanup|Planner' -count=1` (`ok github.com/gastownhall/gascity/cmd/gc 2.141s`), `go vet ./cmd/gc/`, `go vet ./...`, and `git diff --check origin/main..HEAD`. `make test-fast-parallel` failed only in `examples/gastown` on `TestPolecatFormulaHaltsOnAutoPushFalse`; the same focused test reproduces on `origin/main` at `d48bcb4c5432`, this branch has no diff under `examples/gastown`, and the failure is tracked by closed bead `ga-q0aoo`. |
+| 4 | No high-severity review findings open | PASS | Review notes report `Findings: None`; unresolved HIGH finding count is 0. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed only `## builder/ga-m3gz4...origin/builder/ga-m3gz4`. |
+| 6 | Branch diverges cleanly from main | PASS | `git rev-list --left-right --count origin/main...HEAD` returned `0 1`; `git merge-tree --write-tree origin/main HEAD` exited 0 with tree `bdcbc1f9e99bf25aa0a62bf9aa5a9cc5f15edb0e`. |
+
+## Acceptance Trace
+
+| Done-when | Result |
+|-----------|--------|
+| `defaultStaleDatabasePrefixes` includes `test_guard_` and `test_federation_`. | PASS - both prefixes are present in `cmd/gc/dolt_cleanup_drop_planner.go`. |
+| Planner unit test asserts those names are planned for drop and live rig DB names are preserved. | PASS - `TestPlanDoltDrops_DefaultPrefixesIncludeGuardAndFederationTests` covers `test_guard_abc123`, `test_federation_xyz`, `testdb_old`, `hq`, and `gascity`. |
+| `go test ./cmd/gc/ -run 'DoltCleanup|Planner' -count=1` passes. | PASS. |
+| `go vet ./cmd/gc/` clean. | PASS. |
+| PR description references the needed beads-side convergence (`be-hjj-3`). | PASS - this is called out in the release gate and must remain in the PR review notes. |
+
+## Validation Commands
+
+| Command | Result |
+|---------|--------|
+| `go test ./cmd/gc/ -run 'DoltCleanup|Planner' -count=1` | PASS |
+| `go vet ./cmd/gc/` | PASS |
+| `go vet ./...` | PASS |
+| `git diff --check origin/main..HEAD` | PASS |
+| `make test-fast-parallel` | Existing main-red failure in `examples/gastown`: `TestPolecatFormulaHaltsOnAutoPushFalse` expects `**2. Push your branch:**`; the same failure reproduces on `origin/main` and this branch does not touch that package. |
+| `git merge-tree --write-tree origin/main HEAD` | PASS |
+
+## Verdict
+
+PASS. Open a PR from `builder/ga-m3gz4` to `main`, with the PR body noting that the Gas City stale-prefix list now mirrors the beads-side cleanup prefixes tracked by `be-hjj-3`.


### PR DESCRIPTION
## What this changes

`gc dolt cleanup --force` now recognizes stale Dolt databases left by interrupted guard and federation test runs. Cadence cleanup that already catches `testdb_*` databases will also plan `test_guard_*` and `test_federation_*` databases for removal, while preserving registered rig databases such as `hq` and `gascity`.

The cleanup still goes through the existing planner safety layers: system databases are ignored, registered rig databases win over stale-prefix matches, destructive names must pass identifier validation, and live-session checks can still hold a database back from dropping.

## Review notes

- The runtime behavior change is limited to the stale database prefix list used by `gc dolt cleanup`; there is no new command, config, or default-on background process.
- The planner unit test now covers the two new prefixes and confirms live rig database names stay protected.
- The Gas City prefix list intentionally mirrors the beads-side cleanup list; the matching beads-side convergence remains tracked by `be-hjj-3`.
- The broad fast suite is currently blocked by an existing `examples/gastown` assertion failure on `origin/main`; the release gate documents the non-regression check.

## Test plan

- [x] `go test ./cmd/gc/ -run 'DoltCleanup|Planner' -count=1`
- [x] `go vet ./cmd/gc/`
- [x] `go vet ./...`
- [x] `git diff --check origin/main..HEAD`
- [x] `make test-fast-parallel` non-regression checked; current branch and `origin/main` both hit the existing `examples/gastown` `TestPolecatFormulaHaltsOnAutoPushFalse` failure, and this branch does not touch that package.
- [x] Release gate: [`release-gates/ga-m3gz4-dolt-cleanup-test-db-prefixes-gate.md`](release-gates/ga-m3gz4-dolt-cleanup-test-db-prefixes-gate.md)
