### PR TITLE
test(gastown): renumber polecat submit Push step in halts-on-auto-push test

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -775,7 +775,7 @@ func TestPolecatFormulaHaltsOnAutoPushFalse(t *testing.T) {
 	submit := sectionBetween(t, body, `id = "submit-and-exit"`, "The refinery will pick this up")
 
 	assertContainsInOrder(t, submit,
-		"**2. Push your branch:**",
+		"**3. Push your branch:**",
 		`AUTO_PUSH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')`,
 		`if [ "$AUTO_PUSH" = "false" ]; then`,
 		`BRANCH=$(git branch --show-current)`,


### PR DESCRIPTION
## Summary

PR #2559 added `**1. Branch-shape gate**` as a new first step to the `submit-and-exit` section of `examples/gastown/packs/gastown/formulas/mol-polecat-work.toml`, renumbering the subsequent steps so that "Push your branch" became step **3** (was **2**). The new `TestPolecatFormulaIncludesBranchShapeGate` was updated to match the new numbering, but the older `TestPolecatFormulaHaltsOnAutoPushFalse` was missed — it still asserted `"**2. Push your branch:**"` and started failing on `main` as soon as #2559 merged.

The result is that `Integration / packages-core-1-of-4` and the `CI / required` umbrella are red on every PR (e.g. #2612), even when the PR itself is unrelated to gastown.

This change is **one character** in the assertion text: `"**2. Push your branch:**"` → `"**3. Push your branch:**"`. No formula or production code is touched.

## Root cause trace

- `examples/gastown/packs/gastown/formulas/mol-polecat-work.toml` (on `main`, lines 280-412) — the `submit-and-exit` step description now numbers its sub-steps **1. Branch-shape gate**, **2. Final clean-state verification**, **3. Push your branch:**, …
- `examples/gastown/gastown_test.go:778` (on `main`) — still says `"**2. Push your branch:**"`.
- Introduced by commit `51a48b267` ("fix(polecat): enforce branch-validation gate at submit handoff (closes #2082) (#2559)") on 2026-05-25.

The companion test added in the same commit at line 591 already uses `"**3. Push your branch:**"`, so the new numbering is the intended truth; only the older test was missed.

## Test plan

- [x] `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1 -v` (fails on `origin/main`, passes with this change)
- [x] `go test ./examples/gastown -count=1` (full package — passes, 50s)
- [x] `go vet ./examples/gastown`
- [x] `.githooks/pre-commit` (8 fast jobs — all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)