### PR TITLE
Align gastown polecat auto-push assertion

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -775,7 +775,7 @@ func TestPolecatFormulaHaltsOnAutoPushFalse(t *testing.T) {
 	submit := sectionBetween(t, body, `id = "submit-and-exit"`, "The refinery will pick this up")
 
 	assertContainsInOrder(t, submit,
-		"**2. Push your branch:**",
+		"**3. Push your branch:**",
 		`AUTO_PUSH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')`,
 		`if [ "$AUTO_PUSH" = "false" ]; then`,
 		`BRANCH=$(git branch --show-current)`,

--- a/release-gates/ga-3up9d-gate.md
+++ b/release-gates/ga-3up9d-gate.md
@@ -1,0 +1,27 @@
+# Release Gate: ga-3up9d
+
+Bead: ga-3up9d - Review: polecat auto-push false assertion
+
+Source bead: ga-q0aoo - TestPolecatFormulaHaltsOnAutoPushFalse stale after #2559 renumbered submit step (2->3) - main latently red
+
+Feature branch: `builder/ga-q0aoo`
+
+Source commit: `cc9db78e23e13f10c3e062b06532b3bc2bc14548`
+
+Release criteria source: deployer gate criteria; `docs/PROJECT_MANIFEST.md` is not present in this worktree.
+
+## Checklist
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-3up9d` notes contain `REVIEW PASS (reviewer)` for commit `cc9db78e2`. |
+| 2 | Acceptance criteria met | PASS | `examples/gastown/gastown_test.go` now expects `**3. Push your branch:**`, matching the current formula step numbering while preserving the auto-push-false ordering assertion before `git push origin HEAD`. Focused check: `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1` passed. |
+| 3 | Tests pass | PASS | `make test` passed on `builder/ga-q0aoo`; `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes report no spec, style, or security issues; no unresolved HIGH findings found in the review bead notes. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before gate file creation; final clean status is verified after committing this gate. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` produced no conflict markers or conflict diagnostics. |
+
+## Additional Checks
+
+- `git diff --check origin/main...HEAD` passed.
+- `.githooks` is configured as `core.hooksPath`.


### PR DESCRIPTION
## What this changes

The gastown example regression test for the polecat `auto_push=false` path now expects the submit-and-exit formula's `Push your branch` heading to be step 3 instead of step 2. That matches the current formula after the branch-shape gate was inserted ahead of the push step, restoring the fast test baseline without changing runtime behavior.

## Review notes

- This is a test-only change under `examples/gastown/gastown_test.go`.
- The assertion still verifies that the `auto_push=false` halt path runs before `git push origin HEAD`.
- No config, API, CLI, or formula behavior changes in this PR.

## Test plan

- [x] `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1`
- [x] `make test`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-3up9d-gate.md`](release-gates/ga-3up9d-gate.md)
