### PR TITLE
fix(session): #2597 — gc stop tears down failed-create sessions

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -766,6 +766,23 @@ func (m *Manager) Suspend(id string) error {
 		if current == StateSuspended {
 			return nil // idempotent: already suspended
 		}
+		// failed-create is a create-rollback terminal state: the create never
+		// reached creation_complete, so there is no live turn to suspend — only
+		// a possibly-leaked runtime process to tear down. `gc stop` issues
+		// suspend on every session bead (no state pre-filter), and under a
+		// backing-store outage the reconciler cannot reap failed-create beads
+		// (its close path requires a reachable store), so suspend is the only
+		// thing that can clear the leaked process. Tear the runtime down
+		// best-effort and report success rather than rejecting with an
+		// illegal-transition error that blocks `gc stop` city-wide (#2597). The
+		// bead is left in failed-create for the reconciler to reap once the
+		// store is reachable again.
+		if current == StateFailedCreate {
+			if strings.TrimSpace(sessName) != "" {
+				_ = m.sp.Stop(sessName) // best-effort: tear down any leaked runtime
+			}
+			return nil
+		}
 		// Legacy bead normalization: pre-metadata cities may have empty
 		// state fields. Treat empty as StateActive so the state-machine
 		// transition works during upgrade. Matches what Close and

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -777,6 +777,16 @@ func (m *Manager) Suspend(id string) error {
 		// illegal-transition error that blocks `gc stop` city-wide (#2597). The
 		// bead is left in failed-create for the reconciler to reap once the
 		// store is reachable again.
+		//
+		// Limitation: explicit-named beads whose rollback already cleared
+		// session_name (rollbackPendingCreate in
+		// cmd/gc/session_lifecycle_parallel.go) fall back to the synthetic
+		// sessionNameFor(id) here, so this Stop targets the synthetic name
+		// rather than the original explicit name and the leak under the
+		// original name persists. That is a strict improvement over the pre-fix
+		// state (suspend rejected outright, runtime leaked, `gc stop` blocked
+		// city-wide); preserving the original name across rollback for cleanup
+		// is tracked as follow-up.
 		if current == StateFailedCreate {
 			if strings.TrimSpace(sessName) != "" {
 				_ = m.sp.Stop(sessName) // best-effort: tear down any leaked runtime

--- a/internal/session/manager_states_test.go
+++ b/internal/session/manager_states_test.go
@@ -258,12 +258,12 @@ func TestConformance_SuspendFailedCreateTearsDownRuntime(t *testing.T) {
 		t.Fatalf("set failed-create state: %v", err)
 	}
 
-	suspendErr := m.Suspend(id)
-	if suspendErr != nil {
-		t.Fatalf("Suspend(failed-create) = %v, want nil (must not block gc stop)", suspendErr)
-	}
-	if errors.Is(suspendErr, ErrIllegalTransition) {
-		t.Fatalf("Suspend(failed-create) returned illegal-transition; want success")
+	// Suspend(failed-create) must succeed so `gc stop` is not blocked
+	// city-wide. The pre-fix regression returned a wrapped ErrIllegalTransition;
+	// either symptom (any non-nil) trips this assertion and pinpoints the
+	// regression by quoting the returned error.
+	if err := m.Suspend(id); err != nil {
+		t.Fatalf("Suspend(failed-create) = %v, want nil (must not block gc stop)", err)
 	}
 	if sp.CountCalls("Stop", sessName) == 0 {
 		t.Errorf("Suspend(failed-create) did not tear down the leaked runtime session %q", sessName)

--- a/internal/session/manager_states_test.go
+++ b/internal/session/manager_states_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -226,6 +227,48 @@ func TestConformance_IllegalTransitionDraining(t *testing.T) {
 	}
 	if ite.Command != CmdSuspend {
 		t.Errorf("ite.Command = %q, want %q", ite.Command, CmdSuspend)
+	}
+}
+
+func TestConformance_SuspendFailedCreateTearsDownRuntime(t *testing.T) {
+	// #2597: `gc stop` issues suspend on every session bead, including
+	// failed-create ones (it does not pre-filter by state). failed-create is a
+	// create-rollback terminal state with no live turn to suspend, but it may
+	// have leaked a runtime process. Under a backing-store outage the reconciler
+	// cannot reap these (its close path requires a reachable store), so suspend
+	// is the only thing that can tear the leaked process down. Suspend must
+	// therefore succeed and stop the runtime rather than reject the command
+	// with an illegal-transition error that blocks `gc stop` city-wide.
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	m := NewManager(store, sp)
+
+	id := createTestSession(t, m, "dog")
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	sessName := b.Metadata["session_name"]
+
+	// Seed a leaked runtime process and the failed-create landing state.
+	if err := sp.Start(context.Background(), sessName, runtime.Config{}); err != nil {
+		t.Fatalf("seeding runtime: %v", err)
+	}
+	if err := store.SetMetadata(id, "state", string(StateFailedCreate)); err != nil {
+		t.Fatalf("set failed-create state: %v", err)
+	}
+
+	if err := m.Suspend(id); err != nil {
+		t.Fatalf("Suspend(failed-create) = %v, want nil (must not block gc stop)", err)
+	}
+	if errors.Is(err, ErrIllegalTransition) {
+		t.Fatalf("Suspend(failed-create) returned illegal-transition; want success")
+	}
+	if sp.CountCalls("Stop", sessName) == 0 {
+		t.Errorf("Suspend(failed-create) did not tear down the leaked runtime session %q", sessName)
+	}
+	if sp.IsRunning(sessName) {
+		t.Errorf("runtime session %q still running after Suspend(failed-create)", sessName)
 	}
 }
 

--- a/internal/session/manager_states_test.go
+++ b/internal/session/manager_states_test.go
@@ -258,10 +258,11 @@ func TestConformance_SuspendFailedCreateTearsDownRuntime(t *testing.T) {
 		t.Fatalf("set failed-create state: %v", err)
 	}
 
-	if err := m.Suspend(id); err != nil {
-		t.Fatalf("Suspend(failed-create) = %v, want nil (must not block gc stop)", err)
+	suspendErr := m.Suspend(id)
+	if suspendErr != nil {
+		t.Fatalf("Suspend(failed-create) = %v, want nil (must not block gc stop)", suspendErr)
 	}
-	if errors.Is(err, ErrIllegalTransition) {
+	if errors.Is(suspendErr, ErrIllegalTransition) {
 		t.Fatalf("Suspend(failed-create) returned illegal-transition; want success")
 	}
 	if sp.CountCalls("Stop", sessName) == 0 {


### PR DESCRIPTION
Closes #2597.

`Manager.Suspend` now handles `failed-create`: tears down any leaked
runtime process best-effort and returns success, instead of returning
`illegal transition: state "failed-create" does not accept command
"suspend"`. That error made `gc stop` fail per-session and left the
city unstoppable (~18 leaked `dog-ga-*.pid.lock` files in the original
report).

The bead is left in `failed-create` for the reconciler to reap once
the store is reachable — distinct from the reap-side fix already on
main (#1912 / #1941 / `close_failed_create`).

Scope notes — #2597 lists three bullets:
1. **reap** — already fixed on main, no change here.
2. **suspend** — fixed here (the "unstoppable city" impact).
3. **Dolt-outage surfacing / admission backoff** — deferred as a separate
   change; `session_circuit_breaker.go` already handles admission backoff.

Test: `TestConformance_SuspendFailedCreateTearsDownRuntime` reproduces
the exact error and asserts runtime teardown.

2 files changed.