### PR TITLE
fix(dolt-health): #2482 — collapse per-PID ps fork in zombie scan into one pass

### DIFF
--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -260,14 +260,27 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
     [ -n "$rig_pid" ] && rig_dolt_pids="$rig_dolt_pids $rig_pid "
   done < "$_meta_cache"
 
-  for p in $(pgrep -x dolt 2>/dev/null || true); do
-    [ "$p" = "$server_pid" ] && continue
-    case "$rig_dolt_pids" in *" $p "*) continue ;; esac
-    cmd=$(ps -p "$p" -o args= 2>/dev/null || true)
-    case "$cmd" in
-      *sql-server*) ;;
-      *) continue ;;
-    esac
+  # Enumerate the process table ONCE, not one `ps -p <pid> -o args=` fork per
+  # `pgrep -x dolt` match. pgrep matches every dolt-named process including
+  # Z-state zombies, so under a non-reaping PID 1 the old per-PID fork became
+  # an O(zombies) `ps` storm re-paid on every 30s health tick (#2482). Collect
+  # the candidate PIDs from pgrep, then classify them in a single `ps`+`awk`
+  # pass: keep candidates that are dolt sql-server processes, skip Z-state
+  # zombies (a defunct dolt never carries sql-server args anyway), and exclude
+  # the managed city server and rig-local dolts.
+  candidate_pids=" $(pgrep -x dolt 2>/dev/null | tr '\n' ' ' || true)"
+  matched_pids=$(ps -eo pid=,stat=,args= 2>/dev/null | awk \
+    -v server="$server_pid" -v rigs="$rig_dolt_pids" -v cands="$candidate_pids" '
+    {
+      pid = $1
+      if (index(cands, " " pid " ") == 0) next   # not a pgrep -x dolt match
+      if (pid == server) next                     # the managed city server
+      if (index(rigs, " " pid " ") != 0) next     # a configured rig-local dolt
+      if ($2 ~ /Z/) next                          # Z-state zombie: never a server
+      if (index($0, "sql-server") == 0) next      # not a dolt sql-server
+      print pid
+    }' || true)
+  for p in $matched_pids; do
     zombie_count=$((zombie_count + 1))
     zombie_pids="$zombie_pids $p"
   done

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -271,9 +271,18 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
   candidate_pids=" $(pgrep -x dolt 2>/dev/null | tr '\n' ' ' || true)"
   matched_pids=$(ps -eo pid=,stat=,args= 2>/dev/null | awk \
     -v server="$server_pid" -v rigs="$rig_dolt_pids" -v cands="$candidate_pids" '
+    BEGIN {
+      # Build an O(1) lookup set from the pgrep candidates once. The
+      # per-row membership test below was an index() substring scan
+      # re-paid for every process-table row, i.e. O(rows x candidate
+      # string length); the reported incident had ~41k candidate PIDs
+      # (#2618). Splitting into an associative set makes each lookup O(1).
+      n = split(cands, a, " ")
+      for (i = 1; i <= n; i++) if (a[i] != "") cand[a[i]] = 1
+    }
     {
       pid = $1
-      if (index(cands, " " pid " ") == 0) next   # not a pgrep -x dolt match
+      if (!(pid in cand)) next                   # not a pgrep -x dolt match
       if (pid == server) next                     # the managed city server
       if (index(rigs, " " pid " ") != 0) next     # a configured rig-local dolt
       if ($2 ~ /Z/) next                          # Z-state zombie: never a server

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -802,16 +802,23 @@ done
 exit 1
 `, mainPort, mainPID, rigPort, rigPID))
 
-	// Fake ps: handles pid_is_running (-o pid=) and zombie scan (-o args=).
-	writeExecutable(t, filepath.Join(fakeBin, "ps"), `#!/bin/sh
-if [ "$1" = "-p" ] && [ "$3" = "-o" ]; then
-  case "$4" in
-    pid=) printf ' %s\n' "$2"; exit 0 ;;
-    args=) echo "dolt sql-server"; exit 0 ;;
-  esac
+	// Fake ps: handles pid_is_running (`-p <pid> -o pid=`) and the zombie
+	// scan's single process-table pass (`ps -eo pid=,stat=,args=`, #2482).
+	// All three dolt PIDs appear as live sql-servers; the script excludes the
+	// city server (server_pid) and the rig-local dolt, leaving the orphan.
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "-eo" ]; then
+  echo "%s Sl dolt sql-server"
+  echo "%s Sl dolt sql-server"
+  echo "%s Sl dolt sql-server"
+  exit 0
+fi
+if [ "$1" = "-p" ] && [ "$3" = "-o" ] && [ "$4" = "pid=" ]; then
+  printf ' %%s\n' "$2"
+  exit 0
 fi
 exit 1
-`)
+`, mainPID, rigPID, zombiePID))
 
 	// Fake nc: unreachable (no real server).
 	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
@@ -875,6 +882,118 @@ func TestHealthScriptZombieScanExcludesRigLocalServers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			runHealthScriptZombieScanExcludesRigLocalServers(t, tc.rigConfig)
 		})
+	}
+}
+
+// TestHealthScriptZombieScanIsBoundedFork is the regression guard for #2482:
+// the zombie scan must enumerate the process table a bounded number of times,
+// independent of how many dolt processes (especially Z-state zombies) exist.
+// The old loop forked one `ps -p <pid> -o args=` per `pgrep -x dolt` match, so
+// under a non-reaping PID 1 it became an O(zombies) `ps` storm re-paid every
+// 30s. We drive the real run.sh with a pgrep that reports many dolt PIDs and a
+// ps shim that logs every invocation, then assert zero per-PID `-o args=`
+// forks while the orphaned sql-servers are still classified.
+func TestHealthScriptZombieScanIsBoundedFork(t *testing.T) {
+	const candidateCount = 50
+	const firstPID = 500000
+
+	cityPath := t.TempDir()
+	fakeBin := t.TempDir()
+	psLog := filepath.Join(t.TempDir(), "ps_calls")
+
+	mainPort := "19901"
+	serverPID := strconv.Itoa(firstPID) // first candidate is the managed city server
+
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"dolt_database":"city"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// pgrep reports candidateCount dolt PIDs — the candidate set the old loop
+	// forked `ps -p <pid> -o args=` over, one per PID.
+	var pgrepBody strings.Builder
+	pgrepBody.WriteString("#!/bin/sh\n")
+	for i := 0; i < candidateCount; i++ {
+		fmt.Fprintf(&pgrepBody, "echo %d\n", firstPID+i)
+	}
+	writeExecutable(t, filepath.Join(fakeBin, "pgrep"), pgrepBody.String())
+
+	// gc fails -> metadata_files falls back to find (no rigs here).
+	writeExecutable(t, filepath.Join(fakeBin, "gc"), "#!/bin/sh\nexit 1\n")
+	// lsof maps the city port to the server PID so server_pid resolves.
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"),
+		fmt.Sprintf("#!/bin/sh\nfor a in \"$@\"; do case \"$a\" in -iTCP:%s) echo %s; exit 0 ;; esac; done\nexit 1\n", mainPort, serverPID))
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	// ps shim: log every invocation, answer the port->pid confirmation
+	// (`-p <pid> -o pid=`) and the single process-table pass (`-eo ...`).
+	psShim := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %q
+if [ "$1" = "-eo" ]; then
+  i=0
+  while [ "$i" -lt %d ]; do
+    echo "$((%d + i)) Sl dolt sql-server"
+    i=$((i + 1))
+  done
+  exit 0
+fi
+if [ "$1" = "-p" ] && [ "$3" = "-o" ] && [ "$4" = "pid=" ]; then
+  printf ' %%s\n' "$2"
+  exit 0
+fi
+exit 1
+`, psLog, candidateCount, firstPID)
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), psShim)
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(
+		filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT",
+			"GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+mainPort,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
+	}
+
+	callsRaw, readErr := os.ReadFile(psLog)
+	if readErr != nil {
+		t.Fatalf("read ps log: %v", readErr)
+	}
+	calls := strings.Split(strings.TrimSpace(string(callsRaw)), "\n")
+	perPIDForks := 0
+	tableForks := 0
+	for _, line := range calls {
+		switch {
+		case strings.Contains(line, "args=") && strings.Contains(line, "-p "):
+			perPIDForks++
+		case strings.HasPrefix(line, "-eo"):
+			tableForks++
+		}
+	}
+	if perPIDForks != 0 {
+		t.Errorf("zombie scan made %d per-PID `ps -p <pid> -o args=` forks across %d candidates; want 0 (must use a single bounded pass)\nps calls:\n%s",
+			perPIDForks, candidateCount, callsRaw)
+	}
+	if tableForks > 1 {
+		t.Errorf("zombie scan ran %d full `ps -eo` passes; want at most 1\nps calls:\n%s", tableForks, callsRaw)
+	}
+	// All candidates are orphaned sql-servers except the managed city server,
+	// which is excluded by the server_pid check.
+	wantCount := fmt.Sprintf(`"zombie_count": %d`, candidateCount-1)
+	if !strings.Contains(string(out), wantCount) {
+		t.Errorf("expected %s (candidates minus the city server); got:\n%s", wantCount, out)
 	}
 }
 


### PR DESCRIPTION
Closes #2482.

The dolt-health zombie scan forked one `ps -p <pid> -o args=` per
`pgrep` match. Under a non-reaping PID 1, dead `dolt` children become
permanent Z-state zombies that `pgrep` matches, so cost was
O(zombies) re-paid every 30s (reported: ~54k zombies, `pgrep`
matching 41,689 PIDs, 1425% CPU).

Now: collect candidate PIDs from `pgrep`, classify in ONE
`ps -eo pid=,stat=,args=` + `awk` pass (O(1) enumerations). Z-state
zombies dropped; city server + rig-local dolts excluded — identical
classification, bounded cost.

Tests:

- `TestHealthScriptZombieScanIsBoundedFork` (new — drives the real
  `run.sh`, asserts 0 per-PID `args=` forks across 50 candidates
  while orphans are still classified).
- Existing rig-exclusion test updated to the single-pass contract.

Scope note: the issue also suggested (2) promoting
`GC_HEALTH_SKIP_ZOMBIE_SCAN` to a documented operator knob and
(3) operator init guidance. Deferred — the fork-cost fix is
self-contained; the knob touches builtin-pack re-materialization,
better as its own change.