### PR TITLE
fix(orders): #2168 — widen order-tracking sweep watchdog to all orders

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1195,15 +1195,22 @@ func (cr *CityRuntime) runOrderTrackingSweepWatchdog(now time.Time) {
 	}
 	cr.orderSweepWatchdogLast = now
 
-	stores, targets, storeErr := cr.orderTrackingSweepStores()
+	stores, _, storeErr := cr.orderTrackingSweepStores()
 	if len(stores) == 0 {
 		if storeErr != nil && cr.stderr != nil {
 			fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog: %v\n", cr.logPrefix, storeErr) //nolint:errcheck // best-effort stderr
 		}
 		return
 	}
-	onlyOrders := orderTrackingSweepOrderFilterForTargets(targets)
-	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, now, orderTrackingSweepWatchdogStaleAfter, onlyOrders, orderTrackingWatchdogMetadataInitiator, false)
+	// Sweep stale tracking beads for ALL orders (nil filter), not just
+	// order-tracking-sweep's own. The old narrow scope only swept the sweep
+	// order's tracking so that order could bootstrap and clean the rest — a
+	// single-point-of-failure: when slow reconciler cycles keep order-tracking-
+	// sweep from firing, every order's tracking jams and no order fires (#2168).
+	// The staleAfter cutoff still protects in-flight dispatches regardless of
+	// which order they belong to, so a direct all-orders sweep is safe and
+	// recovers the jam without depending on any single order being scheduled.
+	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, now, orderTrackingSweepWatchdogStaleAfter, nil, orderTrackingWatchdogMetadataInitiator, false)
 	if err := errors.Join(storeErr, sweepErr); err != nil {
 		if cr.stderr != nil {
 			fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
@@ -1232,20 +1239,6 @@ func (cr *CityRuntime) orderTrackingSweepStores() ([]beads.Store, []orderTrackin
 		return store, nil
 	})
 	return stores, targets, err
-}
-
-func orderTrackingSweepOrderFilterForTargets(targets []orderTrackingSweepTarget) map[string]struct{} {
-	onlyOrders := map[string]struct{}{
-		orderTrackingSweepOrder: {},
-	}
-	for _, sweepTarget := range targets {
-		if sweepTarget.target.ScopeKind != "rig" || strings.TrimSpace(sweepTarget.target.RigName) == "" {
-			continue
-		}
-		scoped := (&orders.Order{Name: orderTrackingSweepOrder, Rig: sweepTarget.target.RigName}).ScopedName()
-		onlyOrders[scoped] = struct{}{}
-	}
-	return onlyOrders
 }
 
 func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1444,7 +1444,13 @@ func TestCityRuntimeRunStartupOrderDispatchPanicIsRecovered(t *testing.T) {
 	}
 }
 
-func TestOrderTrackingSweepWatchdogOnlyClosesSweepOrderTracking(t *testing.T) {
+func TestOrderTrackingSweepWatchdogClosesAllStaleTracking(t *testing.T) {
+	// #2168: the watchdog must clear stale tracking beads for EVERY order, not
+	// just order-tracking-sweep's own. The old narrow scope only swept the
+	// sweep order's tracking to bootstrap it, relying on order-tracking-sweep
+	// to then clean the rest — a single-point-of-failure that jammed every
+	// order when slow reconciler cycles kept that one order from firing. The
+	// staleAfter cutoff still protects in-flight dispatches regardless of order.
 	store := beads.NewMemStore()
 	sweepTracking, err := store.Create(beads.Bead{
 		Title:  "order:" + orderTrackingSweepOrder,
@@ -1482,8 +1488,8 @@ func TestOrderTrackingSweepWatchdogOnlyClosesSweepOrderTracking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get(merge): %v", err)
 	}
-	if gotMerge.Status != "open" {
-		t.Fatalf("merge tracking status = %s, want open", gotMerge.Status)
+	if gotMerge.Status != "closed" {
+		t.Fatalf("merge tracking status = %s, want closed (watchdog now sweeps all orders, not just order-tracking-sweep)", gotMerge.Status)
 	}
 }
 


### PR DESCRIPTION
Closes #2168.

`runOrderTrackingSweepWatchdog` now sweeps stale tracking beads for
ALL orders (nil filter), not just `order-tracking-sweep`'s own. The
old narrow scope made `order-tracking-sweep` a single point of
failure — it had to fire to clean every other order, so when slow
reconciler cycles (`beads#3948` race) kept it from firing, all orders
jammed behind `hasOpenWorkStrict` and the pipeline silently halted
after a supervisor crash/restart.

The 2m `staleAfter` cutoff still protects in-flight dispatches
regardless of order, so the broader sweep is safe. Removed
now-unused `orderTrackingSweepOrderFilterForTargets`.

Tests:

- Rewrote `TestOrderTrackingSweepWatchdogOnlyClosesSweepOrderTracking`
  (encoded the old narrow spec) →
  `TestOrderTrackingSweepWatchdogClosesAllStaleTracking` (asserts a
  non-sweep order's stale tracking is now closed). Sibling watchdog
  and rig-store tests still pass.

Scope: the issue also suggested (2) controller-cold-start
unconditional sweep and (3) logging the `hasOpenWork` skip. Deferred
as separable enhancements — recommend follow-ups.