### PR TITLE
fix(api): keep session reads live during cache priming

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1537,7 +1537,7 @@ func TestOrderTrackingSweepWatchdogAllowsSweepOrderToCleanStaleTracking(t *testi
 		execRan = true
 		_, err := sweepStaleOrderTrackingAcrossStores(
 			[]beads.Store{store},
-			time.Now(),
+			freshMerge.CreatedAt.Add(25*time.Millisecond),
 			50*time.Millisecond,
 			nil,
 			orderTrackingSweepMetadataInitiator,

--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -22,9 +22,6 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	if store == nil {
 		return nil, huma.Error503ServiceUnavailable("no bead store configured")
 	}
-	if err := cacheLiveOr503(store); err != nil {
-		return nil, err
-	}
 	mgr := s.sessionManager(store)
 	cfg := s.state.Config()
 
@@ -108,9 +105,6 @@ func (s *Server) humaHandleSessionGet(_ context.Context, input *SessionGetInput)
 	store := s.state.CityBeadStore()
 	if store == nil {
 		return nil, huma.Error503ServiceUnavailable("no bead store configured")
-	}
-	if err := cacheLiveOr503(store); err != nil {
-		return nil, err
 	}
 	mgr := s.sessionManager(store)
 	cfg := s.state.Config()

--- a/release-gates/ga-n6aky-gate.md
+++ b/release-gates/ga-n6aky-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: ga-n6aky
+
+Bead: `ga-n6aky` - Review: PR #1149 session read-path liveness fix
+
+Source PR: https://github.com/gastownhall/gascity/pull/1149
+
+Source branch: `feat/adr-0001-status-routing`
+
+Source commit: `b87a7436c` (`fix(api): keep session reads live during cache priming`)
+
+Release branch: `release/ga-n6aky`
+
+Cherry-picked commit: `7c15a2f90`
+
+Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this worktree; evaluated against the deployer release gate criteria.
+
+## Gate Result
+
+FAIL
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-n6aky` includes `VERDICT: pass` and "No blockers" for builder commit `b87a7436c`. |
+| 2 | Acceptance criteria met | PASS | Final diff from `origin/main` changes only `internal/api/huma_handlers_sessions_query.go`, removing `cacheLiveOr503(store)` from session list/get handlers while retaining the `store == nil` guards and partial read-model behavior. `go test ./internal/api -count=1` passed, and `go test -tags integration ./test/integration -run TestGCLiveContract_BeadsAndEvents -count=1` passed. |
+| 3 | Tests pass | FAIL | `make test` failed. The failing package is `github.com/gastownhall/gascity/examples/gastown`; failing test is `TestPolecatFormulaHaltsOnAutoPushFalse` with `gastown_test.go:777: missing "**2. Push your branch:**" after byte offset 0`. Reproduced with `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1`. The same test/formula mismatch is present in `origin/main` (`origin/main` test expects `**2. Push your branch:**`; `origin/main` formula contains `**3. Push your branch:**`). |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-n6aky` report "No blockers"; only two informational pre-existing findings were noted and neither is introduced by this change. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed `## release/ga-n6aky...origin/main [ahead 1]` with no uncommitted changes. |
+| 6 | Branch diverges cleanly from main | PASS | Branch was created from `origin/main`; `git cherry-pick b87a7436c` applied cleanly; `git merge-base --is-ancestor origin/main HEAD` passed; `git diff --check origin/main...HEAD` produced no output. |
+
+## Commands Run
+
+- `git fetch origin main:refs/remotes/origin/main`
+- `git checkout -B release/ga-n6aky origin/main`
+- `git cherry-pick b87a7436c`
+- `go test ./internal/api -count=1` - PASS
+- `go test -tags integration ./test/integration -run TestGCLiveContract_BeadsAndEvents -count=1` - PASS
+- `make dashboard-check` - PASS
+- `go vet ./...` - PASS
+- `make test` - FAIL
+- `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1` - FAIL
+- `git merge-base --is-ancestor origin/main HEAD` - PASS
+- `git diff --check origin/main...HEAD` - PASS
+
+## Diagnosis
+
+The release change itself is surgical and the targeted regression checks passed. The release gate still fails because the rig's full test command does not pass on the assembled branch. The failure appears to be a pre-existing `origin/main` mismatch in the Gastown example test expectations, outside the session read-path change.

--- a/release-gates/ga-n6aky-gate.md
+++ b/release-gates/ga-n6aky-gate.md
@@ -12,11 +12,16 @@ Release branch: `release/ga-n6aky`
 
 Cherry-picked commit: `7c15a2f90`
 
+Additional release support commits:
+
+- `6775a3a39` (`test(gastown): renumber polecat submit Push step in halts-on-auto-push test`)
+- `90300aa81` (`test(gc): stabilize order tracking sweep freshness clock`)
+
 Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this worktree; evaluated against the deployer release gate criteria.
 
 ## Gate Result
 
-FAIL
+PASS
 
 ## Criteria
 
@@ -24,9 +29,9 @@ FAIL
 |---|-----------|--------|----------|
 | 1 | Review PASS present | PASS | `bd show ga-n6aky` includes `VERDICT: pass` and "No blockers" for builder commit `b87a7436c`. |
 | 2 | Acceptance criteria met | PASS | Final diff from `origin/main` changes only `internal/api/huma_handlers_sessions_query.go`, removing `cacheLiveOr503(store)` from session list/get handlers while retaining the `store == nil` guards and partial read-model behavior. `go test ./internal/api -count=1` passed, and `go test -tags integration ./test/integration -run TestGCLiveContract_BeadsAndEvents -count=1` passed. |
-| 3 | Tests pass | FAIL | `make test` failed. The failing package is `github.com/gastownhall/gascity/examples/gastown`; failing test is `TestPolecatFormulaHaltsOnAutoPushFalse` with `gastown_test.go:777: missing "**2. Push your branch:**" after byte offset 0`. Reproduced with `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1`. The same test/formula mismatch is present in `origin/main` (`origin/main` test expects `**2. Push your branch:**`; `origin/main` formula contains `**3. Push your branch:**`). |
+| 3 | Tests pass | PASS | The Gastown formula expectation mismatch was fixed by cherry-picking `55ae16332`; a wall-clock-sensitive `cmd/gc` watchdog test exposed by the broad suite was stabilized in `90300aa81`. Focused checks, `go vet ./...`, `make dashboard-check`, pre-commit `make test-fast-parallel`, and final `make test` passed. |
 | 4 | No high-severity review findings open | PASS | Review notes for `ga-n6aky` report "No blockers"; only two informational pre-existing findings were noted and neither is introduced by this change. |
-| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed `## release/ga-n6aky...origin/main [ahead 1]` with no uncommitted changes. |
+| 5 | Final branch is clean | PASS | Before writing this updated gate file, `git status --short --branch` showed `## release/ga-n6aky...origin/main [ahead 4]` with no uncommitted changes. |
 | 6 | Branch diverges cleanly from main | PASS | Branch was created from `origin/main`; `git cherry-pick b87a7436c` applied cleanly; `git merge-base --is-ancestor origin/main HEAD` passed; `git diff --check origin/main...HEAD` produced no output. |
 
 ## Commands Run
@@ -34,15 +39,20 @@ FAIL
 - `git fetch origin main:refs/remotes/origin/main`
 - `git checkout -B release/ga-n6aky origin/main`
 - `git cherry-pick b87a7436c`
+- `git cherry-pick -x 55ae16332`
 - `go test ./internal/api -count=1` - PASS
 - `go test -tags integration ./test/integration -run TestGCLiveContract_BeadsAndEvents -count=1` - PASS
 - `make dashboard-check` - PASS
 - `go vet ./...` - PASS
-- `make test` - FAIL
-- `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1` - FAIL
+- `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1` - PASS
+- `go test ./examples/gastown -count=1` - PASS
+- `go test ./cmd/gc -run TestOrderTrackingSweepWatchdogAllowsSweepOrderToCleanStaleTracking -count=20 -v` - PASS
+- `go test ./cmd/gc -count=1` - PASS
+- `make test` - PASS
+- `.githooks/pre-commit` - PASS (`make test-fast-parallel` passed during commit)
 - `git merge-base --is-ancestor origin/main HEAD` - PASS
 - `git diff --check origin/main...HEAD` - PASS
 
 ## Diagnosis
 
-The release change itself is surgical and the targeted regression checks passed. The release gate still fails because the rig's full test command does not pass on the assembled branch. The failure appears to be a pre-existing `origin/main` mismatch in the Gastown example test expectations, outside the session read-path change.
+The release change itself remains surgical. The initial release gate failed on a pre-existing Gastown example expectation mismatch, and the broad rerun then exposed a wall-clock-sensitive `cmd/gc` test. Both are fixed on `release/ga-n6aky`; the assembled branch now passes the required local gate commands.

--- a/release-gates/ga-n6aky-gate.md
+++ b/release-gates/ga-n6aky-gate.md
@@ -27,12 +27,12 @@ PASS
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
-| 1 | Review PASS present | PASS | `bd show ga-n6aky` includes `VERDICT: pass` and "No blockers" for builder commit `b87a7436c`. |
+| 1 | Review PASS present | PASS | `bd show ga-3blic` includes `VERDICT: PASS - ready to deploy` for release branch `fork/release/ga-n6aky`; `bd show ga-n6aky` includes the earlier source review `VERDICT: pass` and "No blockers" for builder commit `b87a7436c`. |
 | 2 | Acceptance criteria met | PASS | Final diff from `origin/main` changes only `internal/api/huma_handlers_sessions_query.go`, removing `cacheLiveOr503(store)` from session list/get handlers while retaining the `store == nil` guards and partial read-model behavior. `go test ./internal/api -count=1` passed, and `go test -tags integration ./test/integration -run TestGCLiveContract_BeadsAndEvents -count=1` passed. |
-| 3 | Tests pass | PASS | The Gastown formula expectation mismatch was fixed by cherry-picking `55ae16332`; a wall-clock-sensitive `cmd/gc` watchdog test exposed by the broad suite was stabilized in `90300aa81`. Focused checks, `go vet ./...`, `make dashboard-check`, pre-commit `make test-fast-parallel`, and final `make test` passed. |
-| 4 | No high-severity review findings open | PASS | Review notes for `ga-n6aky` report "No blockers"; only two informational pre-existing findings were noted and neither is introduced by this change. |
-| 5 | Final branch is clean | PASS | Before writing this updated gate file, `git status --short --branch` showed `## release/ga-n6aky...origin/main [ahead 4]` with no uncommitted changes. |
-| 6 | Branch diverges cleanly from main | PASS | Branch was created from `origin/main`; `git cherry-pick b87a7436c` applied cleanly; `git merge-base --is-ancestor origin/main HEAD` passed; `git diff --check origin/main...HEAD` produced no output. |
+| 3 | Tests pass | PASS | The Gastown formula expectation mismatch was fixed by cherry-picking `55ae16332`; a wall-clock-sensitive `cmd/gc` watchdog test exposed by the broad suite was stabilized in `90300aa81`. Deployer reran `make test`, `go vet ./...`, `make dashboard-check`, `go test ./internal/api -count=1`, and the focused live-contract integration test; all passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-3blic` report only two informational pre-existing findings and no blockers; neither finding is introduced by this change. |
+| 5 | Final branch is clean | PASS | Before writing this deployer verification update, `git status --short --branch` showed `## release/ga-n6aky...fork/release/ga-n6aky` with no uncommitted changes. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` passed; `git merge-tree --write-tree HEAD origin/main` produced tree `ddb34df053410552a1c2affe722c48c019d6815c`; `git diff --check origin/main...HEAD` produced no output. |
 
 ## Commands Run
 
@@ -51,6 +51,19 @@ PASS
 - `make test` - PASS
 - `.githooks/pre-commit` - PASS (`make test-fast-parallel` passed during commit)
 - `git merge-base --is-ancestor origin/main HEAD` - PASS
+- `git diff --check origin/main...HEAD` - PASS
+
+## Deployer Verification
+
+Run at `2026-05-26T04:35:51Z` on `release/ga-n6aky`:
+
+- `make test` - PASS
+- `go vet ./...` - PASS
+- `make dashboard-check` - PASS
+- `go test ./internal/api -count=1` - PASS
+- `go test -tags integration ./test/integration -run TestGCLiveContract_BeadsAndEvents -count=1` - PASS
+- `git merge-base --is-ancestor origin/main HEAD` - PASS
+- `git merge-tree --write-tree HEAD origin/main` - PASS (`ddb34df053410552a1c2affe722c48c019d6815c`)
 - `git diff --check origin/main...HEAD` - PASS
 
 ## Diagnosis


### PR DESCRIPTION
## What this changes

`gc` session list/get reads now continue to serve live runtime session state while the bead cache is still priming. The handlers no longer return a 503 solely because cache liveness is unavailable; they retain the nil-store guard and still use the existing partial read-model behavior for bead enrichment.

This PR also carries two test-only stabilizations needed to keep the release branch green against current `main`: the Gastown auto-push=false prompt expectation now matches the current step numbering, and the order tracking sweep watchdog test uses a deterministic freshness timestamp instead of wall-clock timing.

## Review notes

- API surface touched: `GET /v0/city/{cityName}/sessions` and `GET /v0/city/{cityName}/session/{id}` behavior under cache priming.
- No OpenAPI shape changes, generated type changes, auth changes, or new config.
- The session read model can still report partial bead-enrichment errors; this change only removes the incorrect cache-liveness hard gate from list/get.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] `make dashboard-check`
- [x] `go test ./internal/api -count=1`
- [x] `go test -tags integration ./test/integration -run TestGCLiveContract_BeadsAndEvents -count=1`
- [x] Release gate: [`release-gates/ga-n6aky-gate.md`](release-gates/ga-n6aky-gate.md)