### PR TITLE
test(gastown): correct step number in TestPolecatFormulaHaltsOnAutoPushFalse

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -775,7 +775,7 @@ func TestPolecatFormulaHaltsOnAutoPushFalse(t *testing.T) {
 	submit := sectionBetween(t, body, `id = "submit-and-exit"`, "The refinery will pick this up")
 
 	assertContainsInOrder(t, submit,
-		"**2. Push your branch:**",
+		"**3. Push your branch:**",
 		`AUTO_PUSH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')`,
 		`if [ "$AUTO_PUSH" = "false" ]; then`,
 		`BRANCH=$(git branch --show-current)`,


### PR DESCRIPTION
## Summary

`TestPolecatFormulaHaltsOnAutoPushFalse` in `examples/gastown/gastown_test.go` fails on `origin/main`:

```
gastown_test.go:777: missing "**2. Push your branch:**" after byte offset 0
```

#2559 (branch-validation gate at submit handoff) inserted `**1. Branch-shape gate**` as a new step 1 in the polecat submit-and-exit section, shifting the subsequent step numbers by one. The companion assertion in `TestPolecatFormulaSubmitHasBranchShapeGate` was updated to expect `**3. Push your branch:**`, but the sibling assertion in `TestPolecatFormulaHaltsOnAutoPushFalse` was missed — so the auto-push opt-out gate test now fails on `main`.

Push is now step 3 (after the branch-shape gate at step 1 and the final-clean-state safeguard at step 2), matching the sibling test.

## Change

- `examples/gastown/gastown_test.go:777` — assertion updated from `**2. Push your branch:**` to `**3. Push your branch:**`.

## Testing

- [x] `go test ./examples/gastown/... -count=1 -run TestPolecatFormulaHaltsOnAutoPushFalse` — passes after the fix; fails on `main` without it.
- [x] `go test ./examples/gastown/... -count=1 -run TestPolecatFormulaSubmitHasBranchShapeGate` — sibling test continues to pass.
- [x] `go vet ./examples/gastown/...` — clean.
- [x] `gofmt -l examples/gastown/gastown_test.go` — clean.
- [ ] `make check` — deferring to reviewers; the change is a single assertion string in one test file.

## Checklist

- [x] No issue linked — this is a one-string follow-up to #2559 (the PR that introduced the step renumbering).
- [x] No new test added — the existing assertion just needed to track the formula's current step numbering.
- [x] No docs / runtime / workflow behavior changed.
- [x] No breaking changes.