### PR TITLE
fix(doctor): add advisory severity so benign failures don't gate (ga-c4ygy9)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -374,7 +374,7 @@ func doDoctor(fix, verbose, jsonOut, explainPostgresAuth bool, stdout, stderr io
 		doctor.PrintSummary(stdout, report)
 	}
 
-	if report.Failed > 0 {
+	if report.BlockingFailed > 0 {
 		return 1
 	}
 	return 0
@@ -406,6 +406,7 @@ func (expandedConfigLoadCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult
 type doctorJSONResult struct {
 	Name         string   `json:"name"`
 	Status       string   `json:"status"`
+	Severity     string   `json:"severity"`
 	Message      string   `json:"message"`
 	FixHint      string   `json:"fix_hint,omitempty"`
 	Details      []string `json:"details,omitempty"`
@@ -415,12 +416,13 @@ type doctorJSONResult struct {
 }
 
 type doctorJSONReport struct {
-	Passed  int                `json:"passed"`
-	Warned  int                `json:"warned"`
-	Failed  int                `json:"failed"`
-	Fixed   int                `json:"fixed"`
-	Results []doctorJSONResult `json:"results"`
-	Error   string             `json:"error,omitempty"`
+	Passed         int                `json:"passed"`
+	Warned         int                `json:"warned"`
+	Failed         int                `json:"failed"`
+	BlockingFailed int                `json:"blocking_failed"`
+	Fixed          int                `json:"fixed"`
+	Results        []doctorJSONResult `json:"results"`
+	Error          string             `json:"error,omitempty"`
 }
 
 func doctorStatusString(s doctor.CheckStatus) string {
@@ -435,18 +437,30 @@ func doctorStatusString(s doctor.CheckStatus) string {
 	return "unknown"
 }
 
+func doctorSeverityString(s doctor.CheckSeverity) string {
+	switch s {
+	case doctor.SeverityAdvisory:
+		return "advisory"
+	case doctor.SeverityBlocking:
+		return "blocking"
+	}
+	return "blocking"
+}
+
 func writeDoctorJSON(w io.Writer, report *doctor.Report) error {
 	out := doctorJSONReport{
-		Passed:  report.Passed,
-		Warned:  report.Warned,
-		Failed:  report.Failed,
-		Fixed:   report.Fixed,
-		Results: make([]doctorJSONResult, 0, len(report.Results)),
+		Passed:         report.Passed,
+		Warned:         report.Warned,
+		Failed:         report.Failed,
+		BlockingFailed: report.BlockingFailed,
+		Fixed:          report.Fixed,
+		Results:        make([]doctorJSONResult, 0, len(report.Results)),
 	}
 	for _, r := range report.Results {
 		out.Results = append(out.Results, doctorJSONResult{
 			Name:         r.Name,
 			Status:       doctorStatusString(r.Status),
+			Severity:     doctorSeverityString(r.Severity),
 			Message:      r.Message,
 			FixHint:      r.FixHint,
 			Details:      r.Details,

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -92,11 +92,9 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 	worst := StatusOK
 	monitored := 0
 	var firstNonOK string
-	// Track severity contributions across the monitored orders. The aggregate
-	// result Severity is Blocking unless every non-OK entry was Advisory —
-	// a single Blocking error must keep the whole check blocking so cooldown
-	// stale failures still gate dispatch consumers.
-	var blockingNonOK, advisoryNonOK int
+	// Track severity contributions across error-level entries. Warnings should
+	// stay visible without converting an advisory error into a blocking gate.
+	var blockingErrors, advisoryErrors int
 
 	for _, order := range allOrders {
 		if order.Trigger != "cron" && order.Trigger != "cooldown" {
@@ -110,7 +108,7 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 			if firstNonOK == "" {
 				firstNonOK = orderHistoryHintTarget(order)
 			}
-			blockingNonOK++
+			blockingErrors++
 			continue
 		}
 		status, severity, detail := classifyOrderFiring(order, now, expected, latestOrderFiredAt(firedEvents, order.ScopedName()), startedAt)
@@ -120,10 +118,12 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 			if firstNonOK == "" {
 				firstNonOK = orderHistoryHintTarget(order)
 			}
-			if severity == SeverityBlocking {
-				blockingNonOK++
-			} else {
-				advisoryNonOK++
+			if status == StatusError {
+				if severity == SeverityBlocking {
+					blockingErrors++
+				} else {
+					advisoryErrors++
+				}
 			}
 		}
 	}
@@ -143,7 +143,7 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 	case StatusError:
 		result.Message = "scheduled orders are stale"
 	}
-	if blockingNonOK == 0 && advisoryNonOK > 0 {
+	if blockingErrors == 0 && advisoryErrors > 0 {
 		result.Severity = SeverityAdvisory
 	}
 	if firstNonOK != "" {
@@ -394,12 +394,14 @@ func classifyOrderFiring(order orders.Order, now time.Time, expected time.Durati
 		}
 		uptime := nonNegativeDuration(now.Sub(controllerStarted))
 		if uptime >= expected+expected/2 {
-			// Advisory: a scheduled order that has never fired since the
-			// controller started may simply be the cron-scheduler bug
-			// (ga-97qngx), not a real outage. Dispatch gates should not
-			// wedge on it. Cooldown overdue/stale paths below remain
-			// blocking because they indicate a true execution gap.
-			return StatusError, SeverityAdvisory, fmt.Sprintf("%s: never fired since controller start %s ago", name, formatOrderFiringDuration(uptime))
+			// Advisory only for cron: a cron order that has never fired since
+			// controller start may be the cron-scheduler bug (ga-97qngx), not
+			// a real outage. Cooldown never-fired/stale paths remain blocking
+			// because they indicate an execution gap.
+			if order.Trigger == "cron" {
+				return StatusError, SeverityAdvisory, fmt.Sprintf("%s: never fired since controller start %s ago", name, formatOrderFiringDuration(uptime))
+			}
+			return StatusError, SeverityBlocking, fmt.Sprintf("%s: never fired since controller start %s ago", name, formatOrderFiringDuration(uptime))
 		}
 		return StatusOK, SeverityBlocking, fmt.Sprintf("%s: never fired (controller running %s, within first cycle)", name, formatOrderFiringDuration(uptime))
 	}

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -92,6 +92,11 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 	worst := StatusOK
 	monitored := 0
 	var firstNonOK string
+	// Track severity contributions across the monitored orders. The aggregate
+	// result Severity is Blocking unless every non-OK entry was Advisory —
+	// a single Blocking error must keep the whole check blocking so cooldown
+	// stale failures still gate dispatch consumers.
+	var blockingNonOK, advisoryNonOK int
 
 	for _, order := range allOrders {
 		if order.Trigger != "cron" && order.Trigger != "cooldown" {
@@ -105,13 +110,21 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 			if firstNonOK == "" {
 				firstNonOK = orderHistoryHintTarget(order)
 			}
+			blockingNonOK++
 			continue
 		}
-		status, detail := classifyOrderFiring(order, now, expected, latestOrderFiredAt(firedEvents, order.ScopedName()), startedAt)
+		status, severity, detail := classifyOrderFiring(order, now, expected, latestOrderFiredAt(firedEvents, order.ScopedName()), startedAt)
 		worst = worseStatus(worst, status)
 		result.Details = append(result.Details, detail)
-		if status != StatusOK && firstNonOK == "" {
-			firstNonOK = orderHistoryHintTarget(order)
+		if status != StatusOK {
+			if firstNonOK == "" {
+				firstNonOK = orderHistoryHintTarget(order)
+			}
+			if severity == SeverityBlocking {
+				blockingNonOK++
+			} else {
+				advisoryNonOK++
+			}
 		}
 	}
 
@@ -129,6 +142,9 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 		result.Message = "scheduled orders are overdue"
 	case StatusError:
 		result.Message = "scheduled orders are stale"
+	}
+	if blockingNonOK == 0 && advisoryNonOK > 0 {
+		result.Severity = SeverityAdvisory
 	}
 	if firstNonOK != "" {
 		result.FixHint = fmt.Sprintf(orderFiringInspectHintFmt, firstNonOK)
@@ -370,27 +386,32 @@ func latestOrderFiredAt(evts []events.Event, subject string) time.Time {
 	return latest
 }
 
-func classifyOrderFiring(order orders.Order, now time.Time, expected time.Duration, lastFired, controllerStarted time.Time) (CheckStatus, string) {
+func classifyOrderFiring(order orders.Order, now time.Time, expected time.Duration, lastFired, controllerStarted time.Time) (CheckStatus, CheckSeverity, string) {
 	name := orderDisplayName(order)
 	if lastFired.IsZero() {
 		if controllerStarted.IsZero() {
-			return StatusOK, fmt.Sprintf("%s: never fired (controller start unknown)", name)
+			return StatusOK, SeverityBlocking, fmt.Sprintf("%s: never fired (controller start unknown)", name)
 		}
 		uptime := nonNegativeDuration(now.Sub(controllerStarted))
 		if uptime >= expected+expected/2 {
-			return StatusError, fmt.Sprintf("%s: never fired since controller start %s ago", name, formatOrderFiringDuration(uptime))
+			// Advisory: a scheduled order that has never fired since the
+			// controller started may simply be the cron-scheduler bug
+			// (ga-97qngx), not a real outage. Dispatch gates should not
+			// wedge on it. Cooldown overdue/stale paths below remain
+			// blocking because they indicate a true execution gap.
+			return StatusError, SeverityAdvisory, fmt.Sprintf("%s: never fired since controller start %s ago", name, formatOrderFiringDuration(uptime))
 		}
-		return StatusOK, fmt.Sprintf("%s: never fired (controller running %s, within first cycle)", name, formatOrderFiringDuration(uptime))
+		return StatusOK, SeverityBlocking, fmt.Sprintf("%s: never fired (controller running %s, within first cycle)", name, formatOrderFiringDuration(uptime))
 	}
 
 	age := nonNegativeDuration(now.Sub(lastFired))
 	switch {
 	case age >= expected*3:
-		return StatusError, fmt.Sprintf("%s: last fired %s ago, expected every %s (CRITICAL: stale)", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
+		return StatusError, SeverityBlocking, fmt.Sprintf("%s: last fired %s ago, expected every %s (CRITICAL: stale)", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
 	case age >= expected+expected/2:
-		return StatusWarning, fmt.Sprintf("%s: last fired %s ago, expected every %s (overdue)", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
+		return StatusWarning, SeverityBlocking, fmt.Sprintf("%s: last fired %s ago, expected every %s (overdue)", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
 	default:
-		return StatusOK, fmt.Sprintf("%s: last fired %s ago, expected every %s", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
+		return StatusOK, SeverityBlocking, fmt.Sprintf("%s: last fired %s ago, expected every %s", name, formatOrderFiringDuration(age), formatOrderFiringDuration(expected))
 	}
 }
 

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -82,6 +82,47 @@ func TestOrderFiringCurrent_MixedAdvisoryAndBlocking_AggregatesBlocking(t *testi
 	}
 }
 
+func TestOrderFiringCurrent_MixedAdvisoryAndWarning_AggregatesAdvisory(t *testing.T) {
+	// A warning-level overdue order should stay visible in details without
+	// converting an advisory error into a blocking gate failure.
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-stale-db", "cron", "0 */4 * * *")
+	writeOrderFiringTestOrder(t, cityPath, "cleanup-cooldown", "cooldown", "1h")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "cleanup-cooldown", Ts: now.Add(-2 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusError {
+		t.Fatalf("status = %v, want error; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if result.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want SeverityAdvisory when only error entries are advisory", result.Severity)
+	}
+}
+
+func TestOrderFiringCurrent_NeverFiredCooldown_StaysBlocking(t *testing.T) {
+	// Never-fired cooldown orders represent the same execution gap as stale
+	// cooldown orders and should continue to gate dispatch consumers.
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "cleanup-cooldown", "cooldown", "1h")
+	writeOrderFiringTestEvents(t, cityPath, events.Event{
+		Type: events.ControllerStarted,
+		Ts:   now.Add(-2 * time.Hour),
+	})
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusError {
+		t.Fatalf("status = %v, want error; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if result.Severity != SeverityBlocking {
+		t.Fatalf("Severity = %v, want SeverityBlocking for never-fired cooldown", result.Severity)
+	}
+}
+
 func TestOrderFiringCurrent_NeverFired_WithinFirstCycle(t *testing.T) {
 	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
 	cityPath, cfg := orderFiringTestCity(t)

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -25,11 +25,60 @@ func TestOrderFiringCurrent_NeverFired_BeyondUptime(t *testing.T) {
 	if result.Status != StatusError {
 		t.Fatalf("status = %v, want error; msg = %s; details = %v", result.Status, result.Message, result.Details)
 	}
+	// The "never fired beyond uptime" path is advisory — it most often
+	// reflects the cron-scheduler bug (ga-97qngx) rather than a real
+	// outage, so it must not wedge dispatch gates that read BlockingFailed.
+	if result.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want SeverityAdvisory for never-fired-beyond-uptime path", result.Severity)
+	}
 	if !strings.Contains(strings.Join(result.Details, "\n"), "never fired since controller start") {
 		t.Fatalf("details = %v, want never-fired controller-start message", result.Details)
 	}
 	if result.FixHint != "Inspect with: gc order check && gc order history mol-dog-stale-db" {
 		t.Fatalf("FixHint = %q, want inspect hint for order", result.FixHint)
+	}
+}
+
+func TestOrderFiringCurrent_Stale_StaysBlocking(t *testing.T) {
+	// Cooldown stale (CRITICAL) must remain blocking even though the
+	// sibling "never fired" path was demoted to advisory; the stale
+	// signal reflects a real execution gap consumers should gate on.
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "cleanup-cooldown", "cooldown", "1h")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "cleanup-cooldown", Ts: now.Add(-6 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusError {
+		t.Fatalf("status = %v, want error; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if result.Severity != SeverityBlocking {
+		t.Fatalf("Severity = %v, want SeverityBlocking for cooldown stale", result.Severity)
+	}
+}
+
+func TestOrderFiringCurrent_MixedAdvisoryAndBlocking_AggregatesBlocking(t *testing.T) {
+	// One advisory (never-fired cron) + one blocking (cooldown stale) →
+	// aggregate severity must be Blocking so the presence of any real
+	// outage keeps gates closed even if other entries are merely advisory.
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-stale-db", "cron", "0 */4 * * *")
+	writeOrderFiringTestOrder(t, cityPath, "cleanup-cooldown", "cooldown", "1h")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "cleanup-cooldown", Ts: now.Add(-6 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusError {
+		t.Fatalf("status = %v, want error; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if result.Severity != SeverityBlocking {
+		t.Fatalf("Severity = %v, want SeverityBlocking when any non-OK entry is blocking", result.Severity)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -11,8 +11,12 @@ type Report struct {
 	Passed int
 	// Warned is the number of checks with StatusWarning.
 	Warned int
-	// Failed is the number of checks with StatusError.
+	// Failed is the number of checks with StatusError (any severity).
 	Failed int
+	// BlockingFailed is the number of failed checks whose Severity is
+	// SeverityBlocking — the subset of Failed that should gate dispatch,
+	// CLI exit codes, and other automation.
+	BlockingFailed int
 	// Fixed is the number of checks remediated by --fix.
 	Fixed int
 	// Results holds the per-check results in the order they ran. Populated
@@ -99,6 +103,9 @@ func (d *Doctor) run(ctx *CheckContext, w io.Writer, fix, stream bool) *Report {
 			r.Warned++
 		case result.Status == StatusError:
 			r.Failed++
+			if result.Severity == SeverityBlocking {
+				r.BlockingFailed++
+			}
 		}
 	}
 	return r
@@ -149,6 +156,9 @@ func PrintSummary(w io.Writer, r *Report) {
 	}
 	if r.Failed > 0 {
 		parts = append(parts, fmt.Sprintf("%d failed", r.Failed))
+	}
+	if advisory := r.Failed - r.BlockingFailed; advisory > 0 {
+		parts = append(parts, fmt.Sprintf("%d advisory", advisory))
 	}
 	if r.Fixed > 0 {
 		parts = append(parts, fmt.Sprintf("%d fixed", r.Fixed))

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -9,12 +9,13 @@ import (
 
 // mockCheck is a configurable Check for testing the runner.
 type mockCheck struct {
-	name   string
-	status CheckStatus
-	msg    string
-	canFix bool
-	fixErr error
-	fixed  bool // set by Fix
+	name     string
+	status   CheckStatus
+	severity CheckSeverity
+	msg      string
+	canFix   bool
+	fixErr   error
+	fixed    bool // set by Fix
 }
 
 func (m *mockCheck) Name() string { return m.name }
@@ -24,9 +25,10 @@ func (m *mockCheck) Run(_ *CheckContext) *CheckResult {
 		st = StatusOK
 	}
 	return &CheckResult{
-		Name:    m.name,
-		Status:  st,
-		Message: m.msg,
+		Name:     m.name,
+		Status:   st,
+		Severity: m.severity,
+		Message:  m.msg,
 	}
 }
 func (m *mockCheck) CanFix() bool { return m.canFix }
@@ -390,3 +392,101 @@ func (c *unchangedFixCheck) Fix(_ *CheckContext) error { return nil }
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
 func (c *unchangedFixCheck) WarmupEligible() bool { return false }
+
+// TestDoctor_BlockingFailedSeverityAccounting exercises the per-severity
+// counters added so dispatch gates can ignore advisory failures.
+func TestDoctor_BlockingFailedSeverityAccounting(t *testing.T) {
+	tests := []struct {
+		name              string
+		checks            []Check
+		wantPassed        int
+		wantFailed        int
+		wantBlockingFails int
+	}{
+		{
+			name:              "pure-ok",
+			checks:            []Check{&mockCheck{name: "a", status: StatusOK, msg: "ok"}},
+			wantPassed:        1,
+			wantFailed:        0,
+			wantBlockingFails: 0,
+		},
+		{
+			name:              "blocking-error",
+			checks:            []Check{&mockCheck{name: "blocker", status: StatusError, severity: SeverityBlocking, msg: "blocked"}},
+			wantPassed:        0,
+			wantFailed:        1,
+			wantBlockingFails: 1,
+		},
+		{
+			name:              "advisory-error",
+			checks:            []Check{&mockCheck{name: "advisor", status: StatusError, severity: SeverityAdvisory, msg: "info"}},
+			wantPassed:        0,
+			wantFailed:        1,
+			wantBlockingFails: 0,
+		},
+		{
+			name: "mixed-blocking-advisory",
+			checks: []Check{
+				&mockCheck{name: "ok", status: StatusOK, msg: "fine"},
+				&mockCheck{name: "blocker", status: StatusError, severity: SeverityBlocking, msg: "blocked"},
+				&mockCheck{name: "advisor", status: StatusError, severity: SeverityAdvisory, msg: "info"},
+			},
+			wantPassed:        1,
+			wantFailed:        2,
+			wantBlockingFails: 1,
+		},
+		{
+			name: "default-severity-is-blocking",
+			checks: []Check{
+				// Severity field omitted; zero value must count as Blocking
+				// so existing checks remain gate-relevant.
+				&mockCheck{name: "legacy", status: StatusError, msg: "bad"},
+			},
+			wantPassed:        0,
+			wantFailed:        1,
+			wantBlockingFails: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Doctor{}
+			for _, c := range tt.checks {
+				d.Register(c)
+			}
+			var buf bytes.Buffer
+			r := d.Run(&CheckContext{CityPath: "/tmp"}, &buf, false)
+
+			if r.Passed != tt.wantPassed {
+				t.Errorf("Passed = %d, want %d", r.Passed, tt.wantPassed)
+			}
+			if r.Failed != tt.wantFailed {
+				t.Errorf("Failed = %d, want %d", r.Failed, tt.wantFailed)
+			}
+			if r.BlockingFailed != tt.wantBlockingFails {
+				t.Errorf("BlockingFailed = %d, want %d", r.BlockingFailed, tt.wantBlockingFails)
+			}
+		})
+	}
+}
+
+// TestPrintSummary_AdvisoryRenderedSeparately confirms advisory failures get
+// their own component in the summary line so operators can tell at a glance
+// that a doctor pass had non-blocking findings.
+func TestPrintSummary_AdvisoryRenderedSeparately(t *testing.T) {
+	var buf bytes.Buffer
+	PrintSummary(&buf, &Report{Passed: 1, Failed: 2, BlockingFailed: 1})
+	out := buf.String()
+	if !strings.Contains(out, "2 failed") {
+		t.Errorf("summary = %q, want '2 failed'", out)
+	}
+	if !strings.Contains(out, "1 advisory") {
+		t.Errorf("summary = %q, want '1 advisory'", out)
+	}
+
+	buf.Reset()
+	PrintSummary(&buf, &Report{Passed: 3, Failed: 1, BlockingFailed: 1})
+	if got := buf.String(); strings.Contains(got, "advisory") {
+		t.Errorf("summary = %q, must not include 'advisory' when all failures are blocking", got)
+	}
+}

--- a/internal/doctor/types.go
+++ b/internal/doctor/types.go
@@ -17,6 +17,20 @@ const (
 	StatusError
 )
 
+// CheckSeverity tells consumers (e.g. dispatch gates) whether a failing check
+// should be treated as blocking or merely informational. The zero value is
+// SeverityBlocking so existing checks remain blocking without modification.
+type CheckSeverity int
+
+const (
+	// SeverityBlocking means a failing result should gate consumers
+	// (dispatch, automation, exit codes). This is the default.
+	SeverityBlocking CheckSeverity = iota
+	// SeverityAdvisory means a failing result is informational only;
+	// consumers may proceed past it without remediation.
+	SeverityAdvisory
+)
+
 // Check is a single diagnostic check. Implementations are registered with
 // a Doctor and executed sequentially during Run.
 type Check interface {
@@ -69,6 +83,11 @@ type CheckResult struct {
 	Name string
 	// Status is the outcome: OK, Warning, or Error.
 	Status CheckStatus
+	// Severity classifies a failing Status for gate consumers. Zero
+	// value (SeverityBlocking) preserves the legacy "every error gates"
+	// behavior; checks that opt in to SeverityAdvisory let callers
+	// proceed past their failures.
+	Severity CheckSeverity
 	// Message is a human-readable summary of the result.
 	Message string
 	// Details holds extra lines shown only in verbose mode.


### PR DESCRIPTION
## Summary
Adds a `severity` field to doctor checks so benign known-issue ✗ results no longer hard-block dispatch gates. Introduces an Advisory severity tier; gate consumers can now distinguish blocking failures from advisory ones (closes ga-c4ygy9).

## Changes
- `internal/doctor/types.go` — new severity enum
- `internal/doctor/checks_order_firing.go` — `order-firing-current` marked advisory while ga-97qngx (cron fix) is outstanding
- `internal/doctor/doctor.go` + tests — severity-aware result aggregation
- `cmd/gc/cmd_doctor.go` — exit-code logic respects severity

## Test plan
- [x] `go vet ./internal/doctor/... ./cmd/gc/...` clean
- [x] `go test ./internal/doctor/...` passes (6.2s)
- [x] `go build ./...` clean
- [ ] CI status checks green
- [ ] CodeQL scan complete

Refinery-merged from `gc-gastown.polecat-adhoc-397a63aa7f-8ae4f719a969`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)