### PR TITLE
docs: use served JSON schema downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,9 +602,9 @@ dashboard-ci: dashboard-check
 	fi
 
 ## spec-ci: regenerate the OpenAPI spec + generated Go client, fail on drift.
-## Used by CI to enforce that internal/api/openapi.json, docs/schema/openapi.{json,txt},
-## docs/schema/events.{json,txt}, and internal/api/genclient/client_gen.go are
-## all in lock-step with Huma.
+## Used by CI to enforce that internal/api/openapi.json, docs/schema JSON
+## artifacts, compatibility .txt mirrors, and internal/api/genclient/client_gen.go
+## are all in lock-step with Huma.
 spec-ci: install-oapi-codegen
 	go run ./cmd/genspec
 	go generate ./internal/api/genclient

--- a/cmd/genspec/main.go
+++ b/cmd/genspec/main.go
@@ -11,9 +11,9 @@
 //
 //	internal/api/openapi.json   — drift-check source of truth
 //	docs/schema/openapi.json    — committed docs copy
-//	docs/schema/openapi.txt     — Mint-served download mirror
+//	docs/schema/openapi.txt     — compatibility mirror kept in sync
 //	docs/schema/events.json     — gc events JSONL line schema
-//	docs/schema/events.txt      — Mint-served download mirror
+//	docs/schema/events.txt      — compatibility mirror kept in sync
 //
 // Pass -out <path> to write a single file instead, or -stdout to
 // emit to stdout (useful for ad-hoc inspection or legacy tooling).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -9,11 +9,11 @@ third-party client can do too — there is no hidden surface.
 
 ## Download the spec
 
-- **<a href="/schema/openapi.txt" download="openapi.json">Download openapi.json</a>** —
+- **<a href="/schema/openapi.json" download="openapi.json">Download openapi.json</a>** —
   the authoritative contract. Drop it into Stoplight, Postman,
   Swagger UI, or any OpenAPI-aware tool to browse operations
   interactively.
-- **<a href="/schema/events.txt" download="events.json">Download events.json</a>** —
+- **<a href="/schema/events.json" download="events.json">Download events.json</a>** —
   the `gc events` JSONL line schema. It references DTO components in
   `openapi.json`, so the API remains the source of truth.
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -156,7 +156,7 @@ payload objects. For example, use
 
 ## Machine-Readable Schema
 
-The downloadable <a href="/schema/events.txt" download="events.json">events.json</a>
+The downloadable <a href="/schema/events.json" download="events.json">events.json</a>
 schema validates one JSON object line from list, watch, or follow mode. It
 contains only framing metadata and `$ref`s into `openapi.json`:
 

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -4,8 +4,8 @@ description: Machine-readable schema artifacts published with the Gas City docs.
 ---
 
 This section publishes generated schema artifacts for tooling. The canonical
-JSON files stay in `docs/schema/`, and the download links below use Mint-served
-text mirrors so local preview and production both offer a working file
+JSON files stay in `docs/schema/`, and the download links below point at the
+served JSON artifacts so local preview and production both offer a working file
 download.
 
 ## OpenAPI 3.1
@@ -13,7 +13,7 @@ download.
 The supervisor HTTP and SSE control plane is published as a raw OpenAPI
 document:
 
-- <a href="/schema/openapi.txt" download="openapi.json">Download <code>openapi.json</code></a>
+- <a href="/schema/openapi.json" download="openapi.json">Download <code>openapi.json</code></a>
 
 Use this file with Swagger UI, Stoplight, Postman, or client generators. To
 regenerate it from the live supervisor schema:
@@ -30,7 +30,7 @@ the [Supervisor REST API](/reference/api) page.
 `gc events` list/watch/follow output is published as a small JSON Schema that
 references the OpenAPI DTO components instead of duplicating their fields:
 
-- <a href="/schema/events.txt" download="events.json">Download <code>events.json</code></a>
+- <a href="/schema/events.json" download="events.json">Download <code>events.json</code></a>
 
 Use this file to validate one JSON object line emitted by `gc events`,
 `gc events --watch`, or `gc events --follow`. Cursor mode is intentionally
@@ -46,7 +46,7 @@ behavior, heartbeat suppression, and cursor formats, see
 The `city.toml` configuration schema is also published as a raw JSON Schema
 document:
 
-- <a href="/schema/city-schema.txt" download="city-schema.json">Download <code>city-schema.json</code></a>
+- <a href="/schema/city-schema.json" download="city-schema.json">Download <code>city-schema.json</code></a>
 
 Use this file for validation, editor integration, and external tooling. To
 regenerate it:

--- a/internal/api/openapi_sync_test.go
+++ b/internal/api/openapi_sync_test.go
@@ -44,9 +44,8 @@ func TestOpenAPISpecInSync(t *testing.T) {
 
 	// Every tracked copy of the spec must match the live server. The internal
 	// copy (internal/api/openapi.json) feeds the Go client generator. The
-	// docs copies (docs/schema/openapi.{json,txt}) are what Mintlify publishes
-	// for external consumers. All three must agree or external readers see a
-	// different contract than the code enforces.
+	// docs/schema/openapi.json is the published docs artifact. The .txt copy is
+	// a compatibility mirror kept in sync with the served JSON contract.
 	tracked := []string{
 		"openapi.json",
 		filepath.Join("..", "..", "docs", "schema", "openapi.json"),

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -24,7 +24,10 @@ func repoRoot() string {
 	return filepath.Join(filepath.Dir(filename), "..", "..")
 }
 
-var markdownLinkRE = regexp.MustCompile(`\[[^][]+\]\(([^)]+)\)`)
+var (
+	markdownLinkRE = regexp.MustCompile(`\[[^][]+\]\(([^)]+)\)`)
+	schemaHrefRE   = regexp.MustCompile(`href="/schema/([^"#?]+)"`)
+)
 
 // docTreeDirs lists the top-level directories that are documentation trees
 // and should be link-checked. Update this list when adding or removing doc
@@ -44,6 +47,37 @@ var docTreeIgnored = []string{"cmd", "examples", "internal", "plans", "scripts",
 var knownBrokenLinks = map[string]bool{
 	"contrib/events-scripts/README.md -> ../../docs/k8s-guide.md":  true,
 	"contrib/session-scripts/README.md -> ../../docs/k8s-guide.md": true,
+}
+
+func TestSchemaDownloadLinksUsePublishedJSONArtifacts(t *testing.T) {
+	root := repoRoot()
+	docs := []string{
+		"docs/reference/api.md",
+		"docs/reference/events.md",
+		"docs/schema/index.md",
+	}
+
+	for _, rel := range docs {
+		path := filepath.Join(root, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		for _, match := range schemaHrefRE.FindAllStringSubmatch(string(data), -1) {
+			target := match[1]
+			if filepath.Ext(target) == ".txt" {
+				t.Errorf("%s links /schema/%s; public schema downloads must use served JSON artifacts", rel, target)
+				continue
+			}
+			if filepath.Ext(target) != ".json" {
+				continue
+			}
+			artifact := filepath.Join(root, "docs", "schema", filepath.FromSlash(target))
+			if _, err := os.Stat(artifact); err != nil {
+				t.Errorf("%s links /schema/%s but %s is not committed: %v", rel, target, artifact, err)
+			}
+		}
+	}
 }
 
 func allDocsMarkdownFiles(root string) ([]string, error) {


### PR DESCRIPTION
## Summary
- Point API and schema docs download links at the served `/schema/*.json` artifacts instead of the production-404ing `.txt` mirrors.
- Update schema publishing comments to describe `.txt` files as compatibility mirrors, not public download targets.
- Add a docsync regression test that rejects public `/schema/*.txt` download links and checks linked JSON artifacts exist.

Closes #2596

## Verification
- `go test ./test/docsync -run TestSchemaDownloadLinksUsePublishedJSONArtifacts -count=1`
- `go test ./test/docsync -count=1`
- `go test ./internal/api -run 'TestOpenAPISpecInSync|TestEventsSchemaPublished' -count=1`
- `go vet ./...`
- `make spec-ci`
- `make dashboard-check`
- `make dashboard-smoke`

## Known Baseline Failure
- `make test-fast-parallel` fails on `examples/gastown.TestPolecatFormulaHaltsOnAutoPushFalse` with missing `"**2. Push your branch:**"`. Reproduced unchanged on detached `origin/main` at `6acc1692e`; tracked separately as bead `ga-1fnkxm0`.
