### PR TITLE
test: relax polecat auto-push heading assertion

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -775,7 +775,7 @@ func TestPolecatFormulaHaltsOnAutoPushFalse(t *testing.T) {
 	submit := sectionBetween(t, body, `id = "submit-and-exit"`, "The refinery will pick this up")
 
 	assertContainsInOrder(t, submit,
-		"**2. Push your branch:**",
+		"Push your branch:",
 		`AUTO_PUSH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata | if has("auto_push") then (.auto_push | tostring) else "" end')`,
 		`if [ "$AUTO_PUSH" = "false" ]; then`,
 		`BRANCH=$(git branch --show-current)`,


### PR DESCRIPTION
## Summary
- Fix the `origin/main` failure in `examples/gastown.TestPolecatFormulaHaltsOnAutoPushFalse`.
- Keep the test asserting the auto-push guard sequence while avoiding a brittle numbered-heading dependency introduced when the branch-shape gate became step 1.

Fixes bead `ga-1fnkxm0`.

## Verification
- `go test ./examples/gastown -run TestPolecatFormulaHaltsOnAutoPushFalse -count=1 -v`
- `go test ./examples/gastown -count=1`
- `go vet ./...`
- `make test-fast-parallel`
- pre-commit hook (`core.hooksPath=.githooks`) passed on commit
