### PR TITLE
Add GitHub PR readiness monitor config

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -36,6 +36,7 @@ City is the top-level configuration for a Gas City instance.
 | `convergence` | ConvergenceConfig |  |  | Convergence configures convergence loop limits. |
 | `doctor` | DoctorConfig |  |  | Doctor configures gc doctor thresholds and policy toggles (worktree size warnings, nested-worktree auto-prune). |
 | `service` | []Service |  |  | Services declares workspace-owned HTTP services mounted on the controller edge under /svc/&#123;name&#125;. |
+| `github` | GitHubConfig |  |  | GitHub configures GitHub-facing repository monitors. |
 | `agent_defaults` | AgentDefaults |  |  | AgentDefaults provides city-level defaults for agents that don't override them (canonical TOML key: agent_defaults). The runtime currently applies default_sling_formula and append_fragments; the attachment-list fields remain tombstones, and the other fields are parsed/composed but not yet inherited automatically. |
 | `pricing` | []ModelPricing |  |  | Pricing holds per-model cost rate overrides keyed by (provider, model). City-level entries override pack-level entries which override the defaults shipped with the pricing package. See internal/pricing for the estimation seam introduced by issue #1255 (1d). |
 
@@ -342,6 +343,51 @@ FormulasConfig holds legacy formula directory settings.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 
+## GitHubConfig
+
+GitHubConfig groups GitHub-facing repository monitor declarations.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `pr_monitor` | []GitHubPRMonitor |  |  | PRMonitors declares GitHub pull-request readiness monitors. |
+
+## GitHubPRMonitor
+
+GitHubPRMonitor declares how one repository/base-branch set is monitored and where durable repair work should be routed when readiness fails.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | **yes** |  | Name is the stable monitor identity used by patches and diagnostics. |
+| `owner` | string | **yes** |  | Owner is the GitHub repository owner or organization. |
+| `repo` | string | **yes** |  | Repo is the GitHub repository name. |
+| `base_branches` | []string | **yes** |  | BaseBranches lists the base branches this monitor owns. |
+| `rig` | string | **yes** |  | Rig is the Gas City rig that owns repair work for this repository. |
+| `notify` | []string |  |  | Notify lists session or mail recipients for readiness notifications. |
+| `repair_route` | string | **yes** |  | RepairRoute is the operator-supplied route target for repair work. |
+| `webhook_secret_env` | string |  |  | WebhookSecretEnv is the environment variable containing the webhook HMAC secret. The secret value itself must not be stored in city.toml. |
+| `webhook_secret_key` | string |  |  | WebhookSecretKey is an optional stable key for identifying the webhook secret during rotation. When omitted, WebhookSecretEnv is the key. |
+| `poll_interval` | string |  |  | PollInterval optionally enables bounded polling/backfill cadence. |
+| `merge_queue` | string |  |  | MergeQueuePolicy controls merge-queue signal handling. Empty defaults to "observe"; valid values are "ignore", "observe", and "repair". Enum: `ignore`, `observe`, `repair` |
+
+## GitHubPRMonitorPatch
+
+GitHubPRMonitorPatch modifies an existing GitHub PR readiness monitor by name.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | **yes** |  | Name is the monitor identity to patch. |
+| `owner` | string |  |  | Owner overrides the GitHub repository owner or organization. |
+| `repo` | string |  |  | Repo overrides the GitHub repository name. |
+| `base_branches` | []string |  |  | BaseBranches replaces the monitored base branch list. An empty list clears the field and will fail validation unless another patch fills it. |
+| `rig` | string |  |  | Rig overrides the owning rig. |
+| `notify` | []string |  |  | Notify replaces notification recipients. An empty list clears recipients. |
+| `notify_append` | []string |  |  | NotifyAppend appends notification recipients after Notify replacement. |
+| `repair_route` | string |  |  | RepairRoute overrides the repair route target. |
+| `webhook_secret_env` | string |  |  | WebhookSecretEnv overrides the env var containing the webhook secret. |
+| `webhook_secret_key` | string |  |  | WebhookSecretKey overrides the stable webhook secret key. |
+| `poll_interval` | string |  |  | PollInterval overrides the optional polling cadence. |
+| `merge_queue` | string |  |  | MergeQueuePolicy overrides merge-queue signal handling. Enum: `ignore`, `observe`, `repair` |
+
 ## Import
 
 Import defines a named import of another pack.
@@ -474,6 +520,7 @@ Patches holds all patch blocks from composition.
 | `agent` | []AgentPatch |  |  | Agents targets agents by (dir, name). |
 | `rigs` | []RigPatch |  |  | Rigs targets rigs by name. |
 | `providers` | []ProviderPatch |  |  | Providers targets providers by name. |
+| `github_pr_monitor` | []GitHubPRMonitorPatch |  |  | GitHubPRMonitors targets GitHub PR readiness monitors by name. |
 
 ## PoolOverride
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1055,6 +1055,10 @@
           "type": "array",
           "description": "Services declares workspace-owned HTTP services mounted on the\ncontroller edge under /svc/{name}."
         },
+        "github": {
+          "$ref": "#/$defs/GitHubConfig",
+          "description": "GitHub configures GitHub-facing repository monitors."
+        },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
           "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies default_sling_formula and append_fragments; the\nattachment-list fields remain tombstones, and the other fields are\nparsed/composed but not yet inherited automatically."
@@ -1293,6 +1297,162 @@
       "additionalProperties": false,
       "type": "object",
       "description": "FormulasConfig holds legacy formula directory settings."
+    },
+    "GitHubConfig": {
+      "properties": {
+        "pr_monitor": {
+          "items": {
+            "$ref": "#/$defs/GitHubPRMonitor"
+          },
+          "type": "array",
+          "description": "PRMonitors declares GitHub pull-request readiness monitors."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "GitHubConfig groups GitHub-facing repository monitor declarations."
+    },
+    "GitHubPRMonitor": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the stable monitor identity used by patches and diagnostics."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner is the GitHub repository owner or organization."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repo is the GitHub repository name."
+        },
+        "base_branches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "BaseBranches lists the base branches this monitor owns."
+        },
+        "rig": {
+          "type": "string",
+          "description": "Rig is the Gas City rig that owns repair work for this repository."
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Notify lists session or mail recipients for readiness notifications."
+        },
+        "repair_route": {
+          "type": "string",
+          "description": "RepairRoute is the operator-supplied route target for repair work."
+        },
+        "webhook_secret_env": {
+          "type": "string",
+          "description": "WebhookSecretEnv is the environment variable containing the webhook\nHMAC secret. The secret value itself must not be stored in city.toml."
+        },
+        "webhook_secret_key": {
+          "type": "string",
+          "description": "WebhookSecretKey is an optional stable key for identifying the webhook\nsecret during rotation. When omitted, WebhookSecretEnv is the key."
+        },
+        "poll_interval": {
+          "type": "string",
+          "description": "PollInterval optionally enables bounded polling/backfill cadence."
+        },
+        "merge_queue": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "observe",
+            "repair"
+          ],
+          "description": "MergeQueuePolicy controls merge-queue signal handling. Empty defaults\nto \"observe\"; valid values are \"ignore\", \"observe\", and \"repair\"."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "repo",
+        "base_branches",
+        "rig",
+        "repair_route"
+      ],
+      "description": "GitHubPRMonitor declares how one repository/base-branch set is monitored and where durable repair work should be routed when readiness fails."
+    },
+    "GitHubPRMonitorPatch": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the monitor identity to patch."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner overrides the GitHub repository owner or organization."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repo overrides the GitHub repository name."
+        },
+        "base_branches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "BaseBranches replaces the monitored base branch list. An empty list\nclears the field and will fail validation unless another patch fills it."
+        },
+        "rig": {
+          "type": "string",
+          "description": "Rig overrides the owning rig."
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Notify replaces notification recipients. An empty list clears recipients."
+        },
+        "notify_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "NotifyAppend appends notification recipients after Notify replacement."
+        },
+        "repair_route": {
+          "type": "string",
+          "description": "RepairRoute overrides the repair route target."
+        },
+        "webhook_secret_env": {
+          "type": "string",
+          "description": "WebhookSecretEnv overrides the env var containing the webhook secret."
+        },
+        "webhook_secret_key": {
+          "type": "string",
+          "description": "WebhookSecretKey overrides the stable webhook secret key."
+        },
+        "poll_interval": {
+          "type": "string",
+          "description": "PollInterval overrides the optional polling cadence."
+        },
+        "merge_queue": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "observe",
+            "repair"
+          ],
+          "description": "MergeQueuePolicy overrides merge-queue signal handling."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "GitHubPRMonitorPatch modifies an existing GitHub PR readiness monitor by name."
     },
     "Import": {
       "properties": {
@@ -1632,6 +1792,13 @@
           },
           "type": "array",
           "description": "Providers targets providers by name."
+        },
+        "github_pr_monitor": {
+          "items": {
+            "$ref": "#/$defs/GitHubPRMonitorPatch"
+          },
+          "type": "array",
+          "description": "GitHubPRMonitors targets GitHub PR readiness monitors by name."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1055,6 +1055,10 @@
           "type": "array",
           "description": "Services declares workspace-owned HTTP services mounted on the\ncontroller edge under /svc/{name}."
         },
+        "github": {
+          "$ref": "#/$defs/GitHubConfig",
+          "description": "GitHub configures GitHub-facing repository monitors."
+        },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
           "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies default_sling_formula and append_fragments; the\nattachment-list fields remain tombstones, and the other fields are\nparsed/composed but not yet inherited automatically."
@@ -1293,6 +1297,162 @@
       "additionalProperties": false,
       "type": "object",
       "description": "FormulasConfig holds legacy formula directory settings."
+    },
+    "GitHubConfig": {
+      "properties": {
+        "pr_monitor": {
+          "items": {
+            "$ref": "#/$defs/GitHubPRMonitor"
+          },
+          "type": "array",
+          "description": "PRMonitors declares GitHub pull-request readiness monitors."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "GitHubConfig groups GitHub-facing repository monitor declarations."
+    },
+    "GitHubPRMonitor": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the stable monitor identity used by patches and diagnostics."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner is the GitHub repository owner or organization."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repo is the GitHub repository name."
+        },
+        "base_branches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "BaseBranches lists the base branches this monitor owns."
+        },
+        "rig": {
+          "type": "string",
+          "description": "Rig is the Gas City rig that owns repair work for this repository."
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Notify lists session or mail recipients for readiness notifications."
+        },
+        "repair_route": {
+          "type": "string",
+          "description": "RepairRoute is the operator-supplied route target for repair work."
+        },
+        "webhook_secret_env": {
+          "type": "string",
+          "description": "WebhookSecretEnv is the environment variable containing the webhook\nHMAC secret. The secret value itself must not be stored in city.toml."
+        },
+        "webhook_secret_key": {
+          "type": "string",
+          "description": "WebhookSecretKey is an optional stable key for identifying the webhook\nsecret during rotation. When omitted, WebhookSecretEnv is the key."
+        },
+        "poll_interval": {
+          "type": "string",
+          "description": "PollInterval optionally enables bounded polling/backfill cadence."
+        },
+        "merge_queue": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "observe",
+            "repair"
+          ],
+          "description": "MergeQueuePolicy controls merge-queue signal handling. Empty defaults\nto \"observe\"; valid values are \"ignore\", \"observe\", and \"repair\"."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "repo",
+        "base_branches",
+        "rig",
+        "repair_route"
+      ],
+      "description": "GitHubPRMonitor declares how one repository/base-branch set is monitored and where durable repair work should be routed when readiness fails."
+    },
+    "GitHubPRMonitorPatch": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the monitor identity to patch."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner overrides the GitHub repository owner or organization."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repo overrides the GitHub repository name."
+        },
+        "base_branches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "BaseBranches replaces the monitored base branch list. An empty list\nclears the field and will fail validation unless another patch fills it."
+        },
+        "rig": {
+          "type": "string",
+          "description": "Rig overrides the owning rig."
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Notify replaces notification recipients. An empty list clears recipients."
+        },
+        "notify_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "NotifyAppend appends notification recipients after Notify replacement."
+        },
+        "repair_route": {
+          "type": "string",
+          "description": "RepairRoute overrides the repair route target."
+        },
+        "webhook_secret_env": {
+          "type": "string",
+          "description": "WebhookSecretEnv overrides the env var containing the webhook secret."
+        },
+        "webhook_secret_key": {
+          "type": "string",
+          "description": "WebhookSecretKey overrides the stable webhook secret key."
+        },
+        "poll_interval": {
+          "type": "string",
+          "description": "PollInterval overrides the optional polling cadence."
+        },
+        "merge_queue": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "observe",
+            "repair"
+          ],
+          "description": "MergeQueuePolicy overrides merge-queue signal handling."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "GitHubPRMonitorPatch modifies an existing GitHub PR readiness monitor by name."
     },
     "Import": {
       "properties": {
@@ -1632,6 +1792,13 @@
           },
           "type": "array",
           "description": "Providers targets providers by name."
+        },
+        "github_pr_monitor": {
+          "items": {
+            "$ref": "#/$defs/GitHubPRMonitorPatch"
+          },
+          "type": "array",
+          "description": "GitHubPRMonitors targets GitHub PR readiness monitors by name."
         }
       },
       "additionalProperties": false,

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -615,6 +615,10 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		return nil, nil, err
 	}
 
+	if err := ValidateGitHubPRMonitors(root); err != nil {
+		return nil, nil, err
+	}
+
 	// Validate all duration strings in the fully-merged config.
 	prov.Warnings = append(prov.Warnings, ValidateDurations(root, path)...)
 	prov.Warnings = append(prov.Warnings, ValidateEventsRotation(root)...)
@@ -910,6 +914,10 @@ func mergeFragment(base, fragment *City, fragMeta toml.MetaData, fragPath string
 	// Services: concatenate.
 	base.Services = append(base.Services, fragment.Services...)
 
+	// GitHub PR monitors: concatenate. Validation rejects duplicate repo/base
+	// ownership after patches have had a chance to adjust declarations.
+	base.GitHub.PRMonitors = append(base.GitHub.PRMonitors, fragment.GitHub.PRMonitors...)
+
 	// Providers: deep-merge per-field.
 	mergeProviders(base, fragment, fragMeta, fragPath, prov)
 
@@ -929,6 +937,7 @@ func mergeFragment(base, fragment *City, fragMeta toml.MetaData, fragPath string
 	base.Patches.Agents = append(base.Patches.Agents, fragment.Patches.Agents...)
 	base.Patches.Rigs = append(base.Patches.Rigs, fragment.Patches.Rigs...)
 	base.Patches.Providers = append(base.Patches.Providers, fragment.Patches.Providers...)
+	base.Patches.GitHubPRMonitors = append(base.Patches.GitHubPRMonitors, fragment.Patches.GitHubPRMonitors...)
 
 	// Simple sections: last-writer-wins if fragment defines them.
 	if fragMeta.IsDefined("beads") {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,6 +218,8 @@ type City struct {
 	// Services declares workspace-owned HTTP services mounted on the
 	// controller edge under /svc/{name}.
 	Services []Service `toml:"service,omitempty"`
+	// GitHub configures GitHub-facing repository monitors.
+	GitHub GitHubConfig `toml:"github,omitempty"`
 	// AgentDefaults provides city-level defaults for agents that don't
 	// override them (canonical TOML key: agent_defaults). The runtime
 	// currently applies default_sling_formula and append_fragments; the
@@ -3642,6 +3644,9 @@ func Load(fs fsys.FS, path string) (*City, error) {
 	// direct named-session declarations without requiring pack-provided
 	// backing templates to be present yet.
 	if err := validateNamedSessions(cfg, false); err != nil {
+		return nil, err
+	}
+	if err := ValidateGitHubPRMonitors(cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil

--- a/internal/config/github_pr_monitor.go
+++ b/internal/config/github_pr_monitor.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var validGitHubWebhookSecretEnv = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+const defaultGitHubMergeQueuePolicy = "observe"
+
+// GitHubConfig groups GitHub-facing repository monitor declarations.
+type GitHubConfig struct {
+	// PRMonitors declares GitHub pull-request readiness monitors.
+	PRMonitors []GitHubPRMonitor `toml:"pr_monitor,omitempty"`
+}
+
+// GitHubPRMonitor declares how one repository/base-branch set is monitored
+// and where durable repair work should be routed when readiness fails.
+type GitHubPRMonitor struct {
+	// Name is the stable monitor identity used by patches and diagnostics.
+	Name string `toml:"name" jsonschema:"required"`
+	// Owner is the GitHub repository owner or organization.
+	Owner string `toml:"owner" jsonschema:"required"`
+	// Repo is the GitHub repository name.
+	Repo string `toml:"repo" jsonschema:"required"`
+	// BaseBranches lists the base branches this monitor owns.
+	BaseBranches []string `toml:"base_branches" jsonschema:"required"`
+	// Rig is the Gas City rig that owns repair work for this repository.
+	Rig string `toml:"rig" jsonschema:"required"`
+	// Notify lists session or mail recipients for readiness notifications.
+	Notify []string `toml:"notify,omitempty"`
+	// RepairRoute is the operator-supplied route target for repair work.
+	RepairRoute string `toml:"repair_route" jsonschema:"required"`
+	// WebhookSecretEnv is the environment variable containing the webhook
+	// HMAC secret. The secret value itself must not be stored in city.toml.
+	WebhookSecretEnv string `toml:"webhook_secret_env,omitempty"`
+	// WebhookSecretKey is an optional stable key for identifying the webhook
+	// secret during rotation. When omitted, WebhookSecretEnv is the key.
+	WebhookSecretKey string `toml:"webhook_secret_key,omitempty"`
+	// PollInterval optionally enables bounded polling/backfill cadence.
+	PollInterval string `toml:"poll_interval,omitempty"`
+	// MergeQueuePolicy controls merge-queue signal handling. Empty defaults
+	// to "observe"; valid values are "ignore", "observe", and "repair".
+	MergeQueuePolicy string `toml:"merge_queue,omitempty" jsonschema:"enum=ignore,enum=observe,enum=repair"`
+}
+
+// MergeQueuePolicyOrDefault returns the normalized merge-queue policy.
+func (m GitHubPRMonitor) MergeQueuePolicyOrDefault() string {
+	policy := strings.TrimSpace(strings.ToLower(m.MergeQueuePolicy))
+	if policy == "" {
+		return defaultGitHubMergeQueuePolicy
+	}
+	return policy
+}
+
+// WebhookSecretKeyOrDefault returns the configured secret key or the env var
+// name when no explicit key is configured.
+func (m GitHubPRMonitor) WebhookSecretKeyOrDefault() string {
+	if key := strings.TrimSpace(m.WebhookSecretKey); key != "" {
+		return key
+	}
+	return strings.TrimSpace(m.WebhookSecretEnv)
+}
+
+// ValidateGitHubPRMonitors checks GitHub PR readiness monitor declarations.
+func ValidateGitHubPRMonitors(cfg *City) error {
+	if cfg == nil || len(cfg.GitHub.PRMonitors) == 0 {
+		return nil
+	}
+
+	rigs := make(map[string]bool, len(cfg.Rigs))
+	for _, rig := range cfg.Rigs {
+		rigs[rig.Name] = true
+	}
+
+	seenNames := make(map[string]int, len(cfg.GitHub.PRMonitors))
+	seenRepoBase := make(map[string]string, len(cfg.GitHub.PRMonitors))
+	for i, monitor := range cfg.GitHub.PRMonitors {
+		ctx := fmt.Sprintf("github.pr_monitor[%d]", i)
+		name := strings.TrimSpace(monitor.Name)
+		if name == "" {
+			return fmt.Errorf("%s: name is required", ctx)
+		}
+		if prev, ok := seenNames[name]; ok {
+			return fmt.Errorf("%s %q: duplicate name also used by github.pr_monitor[%d]", ctx, name, prev)
+		}
+		seenNames[name] = i
+
+		owner := strings.TrimSpace(monitor.Owner)
+		if owner == "" {
+			return fmt.Errorf("%s %q: owner is required", ctx, name)
+		}
+		repo := strings.TrimSpace(monitor.Repo)
+		if repo == "" {
+			return fmt.Errorf("%s %q: repo is required", ctx, name)
+		}
+		rig := strings.TrimSpace(monitor.Rig)
+		if rig == "" {
+			return fmt.Errorf("%s %q: rig is required", ctx, name)
+		}
+		if !rigs[rig] {
+			return fmt.Errorf("%s %q: rig %q is not declared", ctx, name, rig)
+		}
+		if strings.TrimSpace(monitor.RepairRoute) == "" {
+			return fmt.Errorf("%s %q: repair_route is required", ctx, name)
+		}
+		if len(monitor.BaseBranches) == 0 {
+			return fmt.Errorf("%s %q: base_branches is required", ctx, name)
+		}
+
+		branchSeen := make(map[string]bool, len(monitor.BaseBranches))
+		for _, base := range monitor.BaseBranches {
+			base = strings.TrimSpace(base)
+			if base == "" {
+				return fmt.Errorf("%s %q: base_branches contains an empty branch", ctx, name)
+			}
+			baseKey := strings.ToLower(base)
+			if branchSeen[baseKey] {
+				return fmt.Errorf("%s %q: duplicate base branch %q", ctx, name, base)
+			}
+			branchSeen[baseKey] = true
+
+			repoBaseKey := strings.ToLower(owner) + "/" + strings.ToLower(repo) + "@" + baseKey
+			if prev, ok := seenRepoBase[repoBaseKey]; ok {
+				return fmt.Errorf("%s %q: duplicate repo/base %s/%s@%s also monitored by %q",
+					ctx, name, strings.ToLower(owner), strings.ToLower(repo), baseKey, prev)
+			}
+			seenRepoBase[repoBaseKey] = name
+		}
+
+		for _, recipient := range monitor.Notify {
+			if strings.TrimSpace(recipient) == "" {
+				return fmt.Errorf("%s %q: notify contains an empty recipient", ctx, name)
+			}
+		}
+		if envName := strings.TrimSpace(monitor.WebhookSecretEnv); envName != "" && !validGitHubWebhookSecretEnv.MatchString(envName) {
+			return fmt.Errorf("%s %q: webhook_secret_env must be an environment variable name, got %q", ctx, name, monitor.WebhookSecretEnv)
+		}
+		if monitor.WebhookSecretKey != "" && strings.TrimSpace(monitor.WebhookSecretKey) == "" {
+			return fmt.Errorf("%s %q: webhook_secret_key must not be blank", ctx, name)
+		}
+		if err := validateGitHubPRMonitorPollInterval(ctx, name, monitor.PollInterval); err != nil {
+			return err
+		}
+		switch monitor.MergeQueuePolicyOrDefault() {
+		case "ignore", "observe", "repair":
+		default:
+			return fmt.Errorf("%s %q: merge_queue must be \"ignore\", \"observe\", or \"repair\", got %q",
+				ctx, name, monitor.MergeQueuePolicy)
+		}
+	}
+	return nil
+}
+
+func validateGitHubPRMonitorPollInterval(ctx, name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	dur, err := time.ParseDuration(value)
+	if err != nil {
+		return fmt.Errorf("%s %q: poll_interval is not a valid duration: %w", ctx, name, err)
+	}
+	if dur <= 0 {
+		return fmt.Errorf("%s %q: poll_interval must be positive: got %q", ctx, name, value)
+	}
+	return nil
+}

--- a/internal/config/github_pr_monitor_test.go
+++ b/internal/config/github_pr_monitor_test.go
@@ -1,0 +1,254 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestParseGitHubPRMonitors(t *testing.T) {
+	cfg, err := Parse([]byte(`
+[workspace]
+name = "test"
+
+[[github.pr_monitor]]
+name = "sample-main"
+owner = "sample-org"
+repo = "sample-repo"
+base_branches = ["main", "release"]
+rig = "sample"
+notify = ["addr-a", "addr-b"]
+repair_route = "route-a"
+webhook_secret_env = "SAMPLE_GITHUB_WEBHOOK_SECRET"
+webhook_secret_key = "sample-main"
+poll_interval = "2m"
+merge_queue = "repair"
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(cfg.GitHub.PRMonitors) != 1 {
+		t.Fatalf("len(GitHub.PRMonitors) = %d, want 1", len(cfg.GitHub.PRMonitors))
+	}
+	got := cfg.GitHub.PRMonitors[0]
+	if got.Name != "sample-main" {
+		t.Errorf("Name = %q, want sample-main", got.Name)
+	}
+	if got.Owner != "sample-org" || got.Repo != "sample-repo" {
+		t.Errorf("repo = %s/%s, want sample-org/sample-repo", got.Owner, got.Repo)
+	}
+	if len(got.BaseBranches) != 2 || got.BaseBranches[0] != "main" || got.BaseBranches[1] != "release" {
+		t.Errorf("BaseBranches = %v, want [main release]", got.BaseBranches)
+	}
+	if got.Rig != "sample" {
+		t.Errorf("Rig = %q, want sample", got.Rig)
+	}
+	if len(got.Notify) != 2 || got.Notify[0] != "addr-a" || got.Notify[1] != "addr-b" {
+		t.Errorf("Notify = %v, want [addr-a addr-b]", got.Notify)
+	}
+	if got.RepairRoute != "route-a" {
+		t.Errorf("RepairRoute = %q, want route-a", got.RepairRoute)
+	}
+	if got.WebhookSecretEnv != "SAMPLE_GITHUB_WEBHOOK_SECRET" {
+		t.Errorf("WebhookSecretEnv = %q, want SAMPLE_GITHUB_WEBHOOK_SECRET", got.WebhookSecretEnv)
+	}
+	if got.WebhookSecretKey != "sample-main" {
+		t.Errorf("WebhookSecretKey = %q, want sample-main", got.WebhookSecretKey)
+	}
+	if got.PollInterval != "2m" {
+		t.Errorf("PollInterval = %q, want 2m", got.PollInterval)
+	}
+	if got.MergeQueuePolicy != "repair" {
+		t.Errorf("MergeQueuePolicy = %q, want repair", got.MergeQueuePolicy)
+	}
+}
+
+func TestValidateGitHubPRMonitorsRejectsMissingRepoAndRoute(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		monitor GitHubPRMonitor
+		want    string
+	}{
+		{
+			name: "missing owner",
+			monitor: GitHubPRMonitor{
+				Name:         "bad",
+				Repo:         "sample-repo",
+				BaseBranches: []string{"main"},
+				Rig:          "sample",
+				RepairRoute:  "route-a",
+			},
+			want: "owner is required",
+		},
+		{
+			name: "missing repo",
+			monitor: GitHubPRMonitor{
+				Name:         "bad",
+				Owner:        "sample-org",
+				BaseBranches: []string{"main"},
+				Rig:          "sample",
+				RepairRoute:  "route-a",
+			},
+			want: "repo is required",
+		},
+		{
+			name: "missing route",
+			monitor: GitHubPRMonitor{
+				Name:         "bad",
+				Owner:        "sample-org",
+				Repo:         "sample-repo",
+				BaseBranches: []string{"main"},
+				Rig:          "sample",
+			},
+			want: "repair_route is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &City{
+				Rigs: []Rig{{Name: "sample"}},
+				GitHub: GitHubConfig{
+					PRMonitors: []GitHubPRMonitor{tc.monitor},
+				},
+			}
+			err := ValidateGitHubPRMonitors(cfg)
+			if err == nil {
+				t.Fatal("ValidateGitHubPRMonitors() = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ValidateGitHubPRMonitors() = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateGitHubPRMonitorsRejectsDuplicateRepoBase(t *testing.T) {
+	cfg := &City{
+		Rigs: []Rig{{Name: "sample"}},
+		GitHub: GitHubConfig{
+			PRMonitors: []GitHubPRMonitor{
+				{
+					Name:         "main",
+					Owner:        "sample-org",
+					Repo:         "sample-repo",
+					BaseBranches: []string{"main", "release"},
+					Rig:          "sample",
+					RepairRoute:  "route-a",
+				},
+				{
+					Name:         "main-again",
+					Owner:        "SAMPLE-ORG",
+					Repo:         "Sample-Repo",
+					BaseBranches: []string{"main"},
+					Rig:          "sample",
+					RepairRoute:  "route-a",
+				},
+			},
+		},
+	}
+	err := ValidateGitHubPRMonitors(cfg)
+	if err == nil {
+		t.Fatal("ValidateGitHubPRMonitors() = nil, want duplicate error")
+	}
+	if !strings.Contains(err.Error(), "duplicate repo/base") || !strings.Contains(err.Error(), "sample-org/sample-repo") {
+		t.Fatalf("ValidateGitHubPRMonitors() = %v, want duplicate repo/base for sample-org/sample-repo", err)
+	}
+}
+
+func TestValidateGitHubPRMonitorsAcceptsEnvBackedWebhookSecret(t *testing.T) {
+	cfg := &City{
+		Rigs: []Rig{{Name: "sample"}},
+		GitHub: GitHubConfig{
+			PRMonitors: []GitHubPRMonitor{
+				{
+					Name:             "main",
+					Owner:            "sample-org",
+					Repo:             "sample-repo",
+					BaseBranches:     []string{"main"},
+					Rig:              "sample",
+					RepairRoute:      "route-a",
+					WebhookSecretEnv: "SAMPLE_GITHUB_WEBHOOK_SECRET",
+				},
+			},
+		},
+	}
+	if err := ValidateGitHubPRMonitors(cfg); err != nil {
+		t.Fatalf("ValidateGitHubPRMonitors: %v", err)
+	}
+
+	cfg.GitHub.PRMonitors[0].WebhookSecretEnv = "bad-name"
+	err := ValidateGitHubPRMonitors(cfg)
+	if err == nil {
+		t.Fatal("ValidateGitHubPRMonitors() = nil, want invalid env error")
+	}
+	if !strings.Contains(err.Error(), "webhook_secret_env") {
+		t.Fatalf("ValidateGitHubPRMonitors() = %v, want webhook_secret_env error", err)
+	}
+}
+
+func TestLoadWithIncludesMergesAndPatchesGitHubPRMonitors(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+include = ["github.toml"]
+
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "sample"
+path = "/sample"
+
+[[github.pr_monitor]]
+name = "release"
+owner = "sample-org"
+repo = "sample-repo"
+base_branches = ["release"]
+rig = "sample"
+repair_route = "route-a"
+merge_queue = "observe"
+
+[[patches.github_pr_monitor]]
+name = "main"
+poll_interval = "5m"
+notify = ["ops"]
+merge_queue = "repair"
+`)
+	fs.Files["/city/github.toml"] = []byte(`
+[[github.pr_monitor]]
+name = "main"
+owner = "sample-org"
+repo = "sample-repo"
+base_branches = ["main"]
+rig = "sample"
+repair_route = "route-a"
+poll_interval = "1m"
+merge_queue = "observe"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.GitHub.PRMonitors) != 2 {
+		t.Fatalf("len(GitHub.PRMonitors) = %d, want 2", len(cfg.GitHub.PRMonitors))
+	}
+	var mainMonitor *GitHubPRMonitor
+	for i := range cfg.GitHub.PRMonitors {
+		if cfg.GitHub.PRMonitors[i].Name == "main" {
+			mainMonitor = &cfg.GitHub.PRMonitors[i]
+			break
+		}
+	}
+	if mainMonitor == nil {
+		t.Fatalf("main monitor missing: %#v", cfg.GitHub.PRMonitors)
+	}
+	if mainMonitor.PollInterval != "5m" {
+		t.Errorf("patched PollInterval = %q, want 5m", mainMonitor.PollInterval)
+	}
+	if mainMonitor.MergeQueuePolicy != "repair" {
+		t.Errorf("patched MergeQueuePolicy = %q, want repair", mainMonitor.MergeQueuePolicy)
+	}
+	if len(mainMonitor.Notify) != 1 || mainMonitor.Notify[0] != "ops" {
+		t.Errorf("patched Notify = %v, want [ops]", mainMonitor.Notify)
+	}
+}

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -12,6 +12,8 @@ type Patches struct {
 	Rigs []RigPatch `toml:"rigs,omitempty"`
 	// Providers targets providers by name.
 	Providers []ProviderPatch `toml:"providers,omitempty"`
+	// GitHubPRMonitors targets GitHub PR readiness monitors by name.
+	GitHubPRMonitors []GitHubPRMonitorPatch `toml:"github_pr_monitor,omitempty"`
 }
 
 // AgentPatch modifies an existing agent identified by (Dir, Name).
@@ -226,9 +228,39 @@ type ProviderPatch struct {
 	Replace bool `toml:"_replace,omitempty"`
 }
 
+// GitHubPRMonitorPatch modifies an existing GitHub PR readiness monitor by
+// name. Pointer fields distinguish "not set" from "set to zero value."
+type GitHubPRMonitorPatch struct {
+	// Name is the monitor identity to patch.
+	Name string `toml:"name" jsonschema:"required"`
+	// Owner overrides the GitHub repository owner or organization.
+	Owner *string `toml:"owner,omitempty"`
+	// Repo overrides the GitHub repository name.
+	Repo *string `toml:"repo,omitempty"`
+	// BaseBranches replaces the monitored base branch list. An empty list
+	// clears the field and will fail validation unless another patch fills it.
+	BaseBranches *[]string `toml:"base_branches,omitempty"`
+	// Rig overrides the owning rig.
+	Rig *string `toml:"rig,omitempty"`
+	// Notify replaces notification recipients. An empty list clears recipients.
+	Notify *[]string `toml:"notify,omitempty"`
+	// NotifyAppend appends notification recipients after Notify replacement.
+	NotifyAppend []string `toml:"notify_append,omitempty"`
+	// RepairRoute overrides the repair route target.
+	RepairRoute *string `toml:"repair_route,omitempty"`
+	// WebhookSecretEnv overrides the env var containing the webhook secret.
+	WebhookSecretEnv *string `toml:"webhook_secret_env,omitempty"`
+	// WebhookSecretKey overrides the stable webhook secret key.
+	WebhookSecretKey *string `toml:"webhook_secret_key,omitempty"`
+	// PollInterval overrides the optional polling cadence.
+	PollInterval *string `toml:"poll_interval,omitempty"`
+	// MergeQueuePolicy overrides merge-queue signal handling.
+	MergeQueuePolicy *string `toml:"merge_queue,omitempty" jsonschema:"enum=ignore,enum=observe,enum=repair"`
+}
+
 // IsEmpty reports whether p has no patch operations.
 func (p *Patches) IsEmpty() bool {
-	return len(p.Agents) == 0 && len(p.Rigs) == 0 && len(p.Providers) == 0
+	return len(p.Agents) == 0 && len(p.Rigs) == 0 && len(p.Providers) == 0 && len(p.GitHubPRMonitors) == 0
 }
 
 // Fragments returns a pointer to the given inject_fragments list for use
@@ -274,6 +306,11 @@ func ApplyPatches(cfg *City, patches Patches) error {
 	for i, p := range patches.Providers {
 		if err := applyProviderPatch(cfg, &p); err != nil {
 			return fmt.Errorf("patches.providers[%d]: %w", i, err)
+		}
+	}
+	for i, p := range patches.GitHubPRMonitors {
+		if err := applyGitHubPRMonitorPatch(cfg, &p); err != nil {
+			return fmt.Errorf("patches.github_pr_monitor[%d]: %w", i, err)
 		}
 	}
 	return nil
@@ -514,6 +551,55 @@ func applyRigPatch(cfg *City, patch *RigPatch) error {
 		}
 	}
 	return fmt.Errorf("rig %q not found in merged config", patch.Name)
+}
+
+// applyGitHubPRMonitorPatch finds a GitHub PR monitor by name and applies
+// the patch.
+func applyGitHubPRMonitorPatch(cfg *City, patch *GitHubPRMonitorPatch) error {
+	if patch.Name == "" {
+		return fmt.Errorf("github pr monitor patch: name is required")
+	}
+	for i := range cfg.GitHub.PRMonitors {
+		monitor := &cfg.GitHub.PRMonitors[i]
+		if monitor.Name != patch.Name {
+			continue
+		}
+		if patch.Owner != nil {
+			monitor.Owner = *patch.Owner
+		}
+		if patch.Repo != nil {
+			monitor.Repo = *patch.Repo
+		}
+		if patch.BaseBranches != nil {
+			monitor.BaseBranches = append([]string(nil), (*patch.BaseBranches)...)
+		}
+		if patch.Rig != nil {
+			monitor.Rig = *patch.Rig
+		}
+		if patch.Notify != nil {
+			monitor.Notify = append([]string(nil), (*patch.Notify)...)
+		}
+		if len(patch.NotifyAppend) > 0 {
+			monitor.Notify = append(monitor.Notify, patch.NotifyAppend...)
+		}
+		if patch.RepairRoute != nil {
+			monitor.RepairRoute = *patch.RepairRoute
+		}
+		if patch.WebhookSecretEnv != nil {
+			monitor.WebhookSecretEnv = *patch.WebhookSecretEnv
+		}
+		if patch.WebhookSecretKey != nil {
+			monitor.WebhookSecretKey = *patch.WebhookSecretKey
+		}
+		if patch.PollInterval != nil {
+			monitor.PollInterval = *patch.PollInterval
+		}
+		if patch.MergeQueuePolicy != nil {
+			monitor.MergeQueuePolicy = *patch.MergeQueuePolicy
+		}
+		return nil
+	}
+	return fmt.Errorf("github pr monitor %q not found in merged config", patch.Name)
 }
 
 // applyProviderPatch modifies a provider. If Replace is true, replaces the

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -71,6 +71,11 @@ func ValidateDurations(cfg *City, source string) []string {
 		checkSleep(ctx, "noninteractive", r.SessionSleep.NonInteractive)
 	}
 
+	for _, monitor := range cfg.GitHub.PRMonitors {
+		ctx := fmt.Sprintf("github.pr_monitor %q", monitor.Name)
+		check(ctx, "poll_interval", monitor.PollInterval)
+	}
+
 	// Per-agent durations.
 	for _, a := range cfg.Agents {
 		ctx := fmt.Sprintf("agent %q", a.QualifiedName())


### PR DESCRIPTION
Adds config model support for GitHub PR readiness monitors.

This is the first piece of the PartCL PR readiness bridge: config parsing, patch/override wiring, validation, schema/docs, and focused tests. Follow-on beads add webhook/poller ingestion and repair-bead creation.

Local Gastown should consume this from the fork/local checkout while upstream review happens; do not require direct push access to gastownhall/gascity.