### PR TITLE
fix(tmux): preserve internal whitespace in macOS process-snapshot comm column

### DIFF
--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -46,8 +46,10 @@ type sessionRuntimeState struct {
 }
 
 type processRuntimeState struct {
-	PID     string
-	PPID    string
+	PID  string
+	PPID string
+	// Command is the process identity used for name matching. Linux sources it
+	// from ps comm; Darwin joins a separate comm snapshot onto the args snapshot.
 	Command string
 	Args    string
 }
@@ -388,6 +390,9 @@ func newProcessSnapshot(processes []processRuntimeState) processSnapshot {
 }
 
 func fetchProcessSnapshot(ctx context.Context) (processSnapshot, error) {
+	if goruntime.GOOS == "darwin" {
+		return fetchDarwinProcessSnapshot(ctx)
+	}
 	out, err := exec.CommandContext(ctx, "ps", processSnapshotPSArgs()...).Output()
 	if err != nil {
 		return processSnapshot{}, fmt.Errorf("fetching process snapshot: %w", err)
@@ -395,16 +400,33 @@ func fetchProcessSnapshot(ctx context.Context) (processSnapshot, error) {
 	return parseProcessSnapshot(string(out)), nil
 }
 
+func fetchDarwinProcessSnapshot(ctx context.Context) (processSnapshot, error) {
+	argsOut, err := exec.CommandContext(ctx, "ps", processSnapshotPSArgs()...).Output()
+	if err != nil {
+		return processSnapshot{}, fmt.Errorf("fetching Darwin process args snapshot: %w", err)
+	}
+	commOut, err := exec.CommandContext(ctx, "ps", darwinCommandSnapshotPSArgs()...).Output()
+	if err != nil {
+		return processSnapshot{}, fmt.Errorf("fetching Darwin process command snapshot: %w", err)
+	}
+	return parseDarwinProcessSnapshot(string(argsOut), string(commOut)), nil
+}
+
 // processSnapshotPSArgs returns the platform-appropriate `ps` arguments for
 // the process snapshot. macOS's ps does not accept the BSD column-width
-// suffix (e.g. `pid:10=`) that Linux ps supports; on Darwin we omit the
-// widths and parse with whitespace splitting. On Linux we keep the
-// wide-column form so the fast fixed-column parser is exercised.
+// suffix (e.g. `pid:10=`) that Linux ps supports; on Darwin we omit the widths
+// and fetch comm separately so both args and command identity are safe to parse
+// as trailing columns. On Linux we keep the wide-column form so the fast
+// fixed-column parser is exercised.
 func processSnapshotPSArgs() []string {
 	if goruntime.GOOS == "darwin" {
-		return []string{"-eo", "pid=,ppid=,comm=,args="}
+		return []string{"-eo", "pid=,ppid=,args="}
 	}
 	return []string{"-eo", "pid:10=,ppid:10=,comm:64=,args="}
+}
+
+func darwinCommandSnapshotPSArgs() []string {
+	return []string{"-eo", "pid=,ppid=,comm="}
 }
 
 func parseProcessSnapshot(out string) processSnapshot {
@@ -415,6 +437,46 @@ func parseProcessSnapshot(out string) processSnapshot {
 			continue
 		}
 		processes = append(processes, process)
+	}
+	return newProcessSnapshot(processes)
+}
+
+func parseDarwinProcessSnapshot(argsOut, commOut string) processSnapshot {
+	processesByPID := make(map[string]processRuntimeState)
+	pidOrder := make([]string, 0)
+	upsert := func(process processRuntimeState) {
+		if _, ok := processesByPID[process.PID]; !ok {
+			pidOrder = append(pidOrder, process.PID)
+		}
+		processesByPID[process.PID] = process
+	}
+
+	for _, line := range strings.Split(commOut, "\n") {
+		process, ok := parseDarwinCommandSnapshotLine(line)
+		if !ok {
+			continue
+		}
+		upsert(process)
+	}
+	for _, line := range strings.Split(argsOut, "\n") {
+		process, ok := parseProcessSnapshotLineDarwin(line)
+		if !ok {
+			continue
+		}
+		if existing, ok := processesByPID[process.PID]; ok && existing.PPID == process.PPID {
+			existing.Args = process.Args
+			if existing.Command == "" {
+				existing.Command = process.Command
+			}
+			upsert(existing)
+			continue
+		}
+		upsert(process)
+	}
+
+	processes := make([]processRuntimeState, 0, len(pidOrder))
+	for _, pid := range pidOrder {
+		processes = append(processes, processesByPID[pid])
 	}
 	return newProcessSnapshot(processes)
 }
@@ -452,96 +514,79 @@ func parseProcessSnapshotLineFixedColumns(line string) (processRuntimeState, boo
 	return process, true
 }
 
-// darwinCommColWidth is BSD `ps -o comm=` column width on macOS: the kernel
-// MAXCOMLEN constant (16). ps left-aligns the comm value within this fixed
-// column and pads with spaces, so the column always occupies exactly 16
-// characters of output regardless of the actual command length.
-const darwinCommColWidth = 16
-
 // parseProcessSnapshotLineDarwin parses one line of
-// `ps -eo pid=,ppid=,comm=,args=` output on macOS.
+// `ps -eo pid=,ppid=,args=` output on macOS.
 //
 // Line layout (SEP = single space):
 //
-//	<pid right-aligned> SEP <ppid right-aligned> SEP <comm padded to 16> SEP <args>
+//	<pid right-aligned> SEP <ppid right-aligned> SEP <args>
 //
-// PID/PPID column widths are dynamic (sized to the largest value in the
-// set, minimum 5 chars on stock kernels), so they are parsed by
-// whitespace tokenization. COMM is a fixed-width column because the BSD
-// kernel's process name is bounded by MAXCOMLEN=16 — and crucially CAN
-// contain internal whitespace (e.g., audio-driver workers register as
-// "Core Audio Drive"). Slicing comm at a fixed width preserves such
-// names; a whitespace tokenizer would split them across fields and shift
-// the args column.
+// PID/PPID column widths are dynamic, so only those two numeric fields are
+// parsed as whitespace-delimited tokens. The args column is last and is kept
+// verbatim aside from outer whitespace. Command is derived from argv[0] as a
+// fallback; the Darwin fetch path joins a separate comm snapshot when available.
 func parseProcessSnapshotLineDarwin(line string) (processRuntimeState, bool) {
-	// Skip leading whitespace (right-aligned PID has padding before its value).
-	i := 0
-	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
-		i++
-	}
-	if i >= len(line) {
+	pid, remaining, ok := takeWhitespaceDelimitedToken(line)
+	if !ok {
 		return processRuntimeState{}, false
 	}
-
-	// PID — first non-whitespace token.
-	pidStart := i
-	for i < len(line) && line[i] != ' ' && line[i] != '\t' {
-		i++
-	}
-	pid := line[pidStart:i]
-
-	// Skip inter-column whitespace.
-	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
-		i++
-	}
-	if i >= len(line) {
+	ppid, remaining, ok := takeWhitespaceDelimitedToken(remaining)
+	if !ok {
 		return processRuntimeState{}, false
 	}
-
-	// PPID — second non-whitespace token. PPID is right-aligned and fills
-	// its column, so the next char after the PPID value is the single
-	// column-separator space before COMM.
-	ppidStart := i
-	for i < len(line) && line[i] != ' ' && line[i] != '\t' {
-		i++
-	}
-	ppid := line[ppidStart:i]
-
-	if i >= len(line) {
+	args := strings.TrimSpace(remaining)
+	argv := strings.Fields(args)
+	if len(argv) == 0 {
 		return processRuntimeState{}, false
 	}
-	i++ // skip the separator between PPID and COMM
-
-	// COMM is a fixed 16-char column. Slice it directly so values with
-	// internal whitespace remain intact.
-	commEnd := i + darwinCommColWidth
-	var comm, args string
-	if commEnd > len(line) {
-		// Truncated line (no trailing args column on this row). Take
-		// whatever remains as comm; args is empty.
-		comm = strings.TrimRight(line[i:], " \t")
-	} else {
-		comm = strings.TrimRight(line[i:commEnd], " \t")
-		i = commEnd
-		// Skip the column separator between COMM and ARGS, then take the
-		// remainder verbatim so internal whitespace in args is preserved.
-		if i < len(line) && (line[i] == ' ' || line[i] == '\t') {
-			i++
-		}
-		if i < len(line) {
-			args = line[i:]
-		}
-	}
-
-	if pid == "" || ppid == "" || comm == "" {
+	command := filepath.Base(argv[0])
+	if pid == "" || ppid == "" || command == "" {
 		return processRuntimeState{}, false
 	}
 	return processRuntimeState{
 		PID:     pid,
 		PPID:    ppid,
-		Command: comm,
+		Command: command,
 		Args:    args,
 	}, true
+}
+
+// parseDarwinCommandSnapshotLine parses one line of
+// `ps -eo pid=,ppid=,comm=` output on macOS. The comm column is requested in a
+// separate snapshot so it is the final field and can contain whitespace safely.
+func parseDarwinCommandSnapshotLine(line string) (processRuntimeState, bool) {
+	pid, remaining, ok := takeWhitespaceDelimitedToken(line)
+	if !ok {
+		return processRuntimeState{}, false
+	}
+	ppid, remaining, ok := takeWhitespaceDelimitedToken(remaining)
+	if !ok {
+		return processRuntimeState{}, false
+	}
+	command := strings.TrimSpace(remaining)
+	if pid == "" || ppid == "" || command == "" {
+		return processRuntimeState{}, false
+	}
+	return processRuntimeState{
+		PID:     pid,
+		PPID:    ppid,
+		Command: command,
+	}, true
+}
+
+func takeWhitespaceDelimitedToken(input string) (token string, remaining string, ok bool) {
+	i := 0
+	for i < len(input) && (input[i] == ' ' || input[i] == '\t') {
+		i++
+	}
+	if i >= len(input) {
+		return "", "", false
+	}
+	start := i
+	for i < len(input) && input[i] != ' ' && input[i] != '\t' {
+		i++
+	}
+	return input[start:i], input[i:], true
 }
 
 func (s processSnapshot) processMatchesNames(pid string, names map[string]struct{}) bool {

--- a/internal/runtime/tmux/state_cache.go
+++ b/internal/runtime/tmux/state_cache.go
@@ -421,7 +421,7 @@ func parseProcessSnapshot(out string) processSnapshot {
 
 func parseProcessSnapshotLine(line string) (processRuntimeState, bool) {
 	if goruntime.GOOS == "darwin" {
-		return parseProcessSnapshotLineWhitespace(line)
+		return parseProcessSnapshotLineDarwin(line)
 	}
 	return parseProcessSnapshotLineFixedColumns(line)
 }
@@ -452,43 +452,96 @@ func parseProcessSnapshotLineFixedColumns(line string) (processRuntimeState, boo
 	return process, true
 }
 
-// parseProcessSnapshotLineWhitespace parses a single line of
-// `ps -eo pid=,ppid=,comm=,args=` output. Format: 3 whitespace-separated
-// fixed tokens (pid, ppid, comm) followed by args. comm is the command
-// name without path/args, typically a single token. Anything from the
-// fourth-token boundary onward is treated as args verbatim (preserving
-// internal whitespace) so callers can match against the full command line.
-func parseProcessSnapshotLineWhitespace(line string) (processRuntimeState, bool) {
-	trimmed := strings.TrimLeft(line, " \t")
-	remaining := trimmed
-	for i := 0; i < 3; i++ {
-		end := strings.IndexAny(remaining, " \t")
-		if end < 0 {
-			// Not enough fields on this line. Lines with fewer than 4
-			// tokens (e.g. kernel threads with no args) still need to
-			// match pid/ppid/comm — fall through to the Fields parse.
-			break
+// darwinCommColWidth is BSD `ps -o comm=` column width on macOS: the kernel
+// MAXCOMLEN constant (16). ps left-aligns the comm value within this fixed
+// column and pads with spaces, so the column always occupies exactly 16
+// characters of output regardless of the actual command length.
+const darwinCommColWidth = 16
+
+// parseProcessSnapshotLineDarwin parses one line of
+// `ps -eo pid=,ppid=,comm=,args=` output on macOS.
+//
+// Line layout (SEP = single space):
+//
+//	<pid right-aligned> SEP <ppid right-aligned> SEP <comm padded to 16> SEP <args>
+//
+// PID/PPID column widths are dynamic (sized to the largest value in the
+// set, minimum 5 chars on stock kernels), so they are parsed by
+// whitespace tokenization. COMM is a fixed-width column because the BSD
+// kernel's process name is bounded by MAXCOMLEN=16 — and crucially CAN
+// contain internal whitespace (e.g., audio-driver workers register as
+// "Core Audio Drive"). Slicing comm at a fixed width preserves such
+// names; a whitespace tokenizer would split them across fields and shift
+// the args column.
+func parseProcessSnapshotLineDarwin(line string) (processRuntimeState, bool) {
+	// Skip leading whitespace (right-aligned PID has padding before its value).
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	if i >= len(line) {
+		return processRuntimeState{}, false
+	}
+
+	// PID — first non-whitespace token.
+	pidStart := i
+	for i < len(line) && line[i] != ' ' && line[i] != '\t' {
+		i++
+	}
+	pid := line[pidStart:i]
+
+	// Skip inter-column whitespace.
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	if i >= len(line) {
+		return processRuntimeState{}, false
+	}
+
+	// PPID — second non-whitespace token. PPID is right-aligned and fills
+	// its column, so the next char after the PPID value is the single
+	// column-separator space before COMM.
+	ppidStart := i
+	for i < len(line) && line[i] != ' ' && line[i] != '\t' {
+		i++
+	}
+	ppid := line[ppidStart:i]
+
+	if i >= len(line) {
+		return processRuntimeState{}, false
+	}
+	i++ // skip the separator between PPID and COMM
+
+	// COMM is a fixed 16-char column. Slice it directly so values with
+	// internal whitespace remain intact.
+	commEnd := i + darwinCommColWidth
+	var comm, args string
+	if commEnd > len(line) {
+		// Truncated line (no trailing args column on this row). Take
+		// whatever remains as comm; args is empty.
+		comm = strings.TrimRight(line[i:], " \t")
+	} else {
+		comm = strings.TrimRight(line[i:commEnd], " \t")
+		i = commEnd
+		// Skip the column separator between COMM and ARGS, then take the
+		// remainder verbatim so internal whitespace in args is preserved.
+		if i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+			i++
 		}
-		remaining = strings.TrimLeft(remaining[end:], " \t")
+		if i < len(line) {
+			args = line[i:]
+		}
 	}
-	fields := strings.Fields(trimmed)
-	if len(fields) < 3 {
+
+	if pid == "" || ppid == "" || comm == "" {
 		return processRuntimeState{}, false
 	}
-	process := processRuntimeState{
-		PID:     fields[0],
-		PPID:    fields[1],
-		Command: fields[2],
-	}
-	if process.PID == "" || process.PPID == "" || process.Command == "" {
-		return processRuntimeState{}, false
-	}
-	if len(fields) > 3 {
-		// `remaining` now points past the third token boundary; args
-		// preserves the original spacing between tokens 4..N.
-		process.Args = strings.TrimSpace(remaining)
-	}
-	return process, true
+	return processRuntimeState{
+		PID:     pid,
+		PPID:    ppid,
+		Command: comm,
+		Args:    args,
+	}, true
 }
 
 func (s processSnapshot) processMatchesNames(pid string, names map[string]struct{}) bool {

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -427,19 +427,6 @@ func TestFetchProcessSnapshotCanceledContextReturnsError(t *testing.T) {
 }
 
 func TestParseProcessSnapshotLineFixedColumns(t *testing.T) {
-	line := fmt.Sprintf("%10s %10s %-64s %s", "123", "1", "claude code", "claude code --print")
-	got, ok := parseProcessSnapshotLineFixedColumns(line)
-	if !ok {
-		t.Fatal("parseProcessSnapshotLineFixedColumns returned ok=false")
-	}
-	if got.PID != "123" || got.PPID != "1" || got.Command != "claude code" || got.Args != "claude code --print" {
-		t.Fatalf("parseProcessSnapshotLineFixedColumns = %+v, want fixed-column fields preserved", got)
-	}
-}
-
-func TestParseProcessSnapshotLineWhitespace(t *testing.T) {
-	// macOS `ps -eo pid=,ppid=,comm=,args=` output: right-aligned numeric
-	// columns, comm separated from args by whitespace.
 	cases := []struct {
 		name     string
 		line     string
@@ -449,33 +436,30 @@ func TestParseProcessSnapshotLineWhitespace(t *testing.T) {
 		wantArgs string
 	}{
 		{
-			name:     "typical 4-token line",
-			line:     "  123     1 /sbin/launchd    /sbin/launchd --boot",
+			name:     "typical line",
+			line:     fmt.Sprintf("%10s %10s %-64s %s", "123", "1", "claude code", "claude code --print"),
 			wantPID:  "123",
 			wantPPID: "1",
-			wantCmd:  "/sbin/launchd",
-			wantArgs: "/sbin/launchd --boot",
+			wantCmd:  "claude code",
+			wantArgs: "claude code --print",
 		},
 		{
-			name:     "args has multiple spaces preserved",
-			line:     "456 1 claude claude code --print --json",
+			// Linux comm can also contain internal whitespace —
+			// applications can set thread names via prctl(PR_SET_NAME)
+			// to strings like "Renderer Main" or "I/O Worker". The
+			// fixed-column slice preserves them; a whitespace
+			// tokenizer would not.
+			name:     "comm with internal spaces (PR_SET_NAME style)",
+			line:     fmt.Sprintf("%10s %10s %-64s %s", "456", "1", "Renderer Main", "/opt/app/bin/renderer --headless"),
 			wantPID:  "456",
 			wantPPID: "1",
-			wantCmd:  "claude",
-			wantArgs: "claude code --print --json",
-		},
-		{
-			name:     "no args (3-token line)",
-			line:     "789 1 kernel_task",
-			wantPID:  "789",
-			wantPPID: "1",
-			wantCmd:  "kernel_task",
-			wantArgs: "",
+			wantCmd:  "Renderer Main",
+			wantArgs: "/opt/app/bin/renderer --headless",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := parseProcessSnapshotLineWhitespace(tc.line)
+			got, ok := parseProcessSnapshotLineFixedColumns(tc.line)
 			if !ok {
 				t.Fatalf("returned ok=false for %q", tc.line)
 			}
@@ -490,6 +474,115 @@ func TestParseProcessSnapshotLineWhitespace(t *testing.T) {
 			}
 			if got.Args != tc.wantArgs {
 				t.Errorf("Args = %q, want %q", got.Args, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestParseProcessSnapshotLineDarwin(t *testing.T) {
+	// Real macOS `ps -eo pid=,ppid=,comm=,args=` line layout:
+	// PID/PPID right-aligned in dynamic-width columns, COMM left-aligned
+	// in exactly 16 chars (MAXCOMLEN), single-space separators between
+	// columns, ARGS verbatim at the end.
+	cases := []struct {
+		name     string
+		line     string
+		wantPID  string
+		wantPPID string
+		wantCmd  string
+		wantArgs string
+	}{
+		{
+			name:     "comm shorter than column, padded",
+			line:     "  123     1 /sbin/launchd    /sbin/launchd --boot",
+			wantPID:  "123",
+			wantPPID: "1",
+			wantCmd:  "/sbin/launchd",
+			wantArgs: "/sbin/launchd --boot",
+		},
+		{
+			// Regression guard for the original bug surface
+			// (gascity#2442). BSD `ps -o comm=` emits the executable
+			// path truncated to MAXCOMLEN=16 — and audio-driver workers
+			// (and other long-name kernel actors) register with comm
+			// values whose first 16 chars CONTAIN spaces, e.g.
+			// "Core Audio Drive". A whitespace tokenizer would split
+			// such a value across Command and Args, breaking name
+			// matching downstream. Fixed-width slicing is the fix.
+			name:     "comm with internal spaces — REGRESSION GUARD",
+			line:     "  489     1 Core Audio Drive Core Audio Driver (MSTeamsAudioDevice.driver)",
+			wantPID:  "489",
+			wantPPID: "1",
+			wantCmd:  "Core Audio Drive",
+			wantArgs: "Core Audio Driver (MSTeamsAudioDevice.driver)",
+		},
+		{
+			name:     "comm exactly fills the 16-char column",
+			line:     "  147     1 /System/Library/ /System/Library/PrivateFrameworks/X.framework/X",
+			wantPID:  "147",
+			wantPPID: "1",
+			wantCmd:  "/System/Library/",
+			wantArgs: "/System/Library/PrivateFrameworks/X.framework/X",
+		},
+		{
+			name:     "args preserves internal multi-space",
+			line:     "  456     1 claude           a  b   c",
+			wantPID:  "456",
+			wantPPID: "1",
+			wantCmd:  "claude",
+			wantArgs: "a  b   c",
+		},
+		{
+			// Real ps still pads comm to 16 chars even when args is
+			// effectively empty; the line ends right after the padding.
+			name:     "no args after padded comm",
+			line:     "  789     1 kernel_task     ",
+			wantPID:  "789",
+			wantPPID: "1",
+			wantCmd:  "kernel_task",
+			wantArgs: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseProcessSnapshotLineDarwin(tc.line)
+			if !ok {
+				t.Fatalf("returned ok=false for %q", tc.line)
+			}
+			if got.PID != tc.wantPID {
+				t.Errorf("PID = %q, want %q", got.PID, tc.wantPID)
+			}
+			if got.PPID != tc.wantPPID {
+				t.Errorf("PPID = %q, want %q", got.PPID, tc.wantPPID)
+			}
+			if got.Command != tc.wantCmd {
+				t.Errorf("Command = %q, want %q", got.Command, tc.wantCmd)
+			}
+			if got.Args != tc.wantArgs {
+				t.Errorf("Args = %q, want %q", got.Args, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestParseProcessSnapshotLineDarwinRejectsMalformed(t *testing.T) {
+	// Inputs the parser must NOT accept — empty, too few columns to
+	// extract pid/ppid/comm. Returning ok=false lets the caller skip
+	// the row instead of recording garbage.
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"empty line", ""},
+		{"whitespace only", "       "},
+		{"pid only", "  123"},
+		{"pid and ppid only", "  123     1"},
+		{"pid, ppid, separator, no comm", "  123     1 "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := parseProcessSnapshotLineDarwin(tc.line); ok {
+				t.Errorf("expected ok=false for %q", tc.line)
 			}
 		})
 	}

--- a/internal/runtime/tmux/state_cache_test.go
+++ b/internal/runtime/tmux/state_cache_test.go
@@ -480,10 +480,10 @@ func TestParseProcessSnapshotLineFixedColumns(t *testing.T) {
 }
 
 func TestParseProcessSnapshotLineDarwin(t *testing.T) {
-	// Real macOS `ps -eo pid=,ppid=,comm=,args=` line layout:
-	// PID/PPID right-aligned in dynamic-width columns, COMM left-aligned
-	// in exactly 16 chars (MAXCOMLEN), single-space separators between
-	// columns, ARGS verbatim at the end.
+	// macOS omits fixed-width modifiers because its ps rejects Linux's
+	// `:N=` syntax. The Darwin snapshot asks for pid, ppid, and args only;
+	// the command name is derived from argv[0] instead of guessing where an
+	// unbounded comm column ends.
 	cases := []struct {
 		name     string
 		line     string
@@ -493,54 +493,44 @@ func TestParseProcessSnapshotLineDarwin(t *testing.T) {
 		wantArgs string
 	}{
 		{
-			name:     "comm shorter than column, padded",
-			line:     "  123     1 /sbin/launchd    /sbin/launchd --boot",
+			name:     "short argv0 with dynamic numeric columns",
+			line:     "  123     1 /sbin/launchd --boot",
 			wantPID:  "123",
 			wantPPID: "1",
-			wantCmd:  "/sbin/launchd",
+			wantCmd:  "launchd",
 			wantArgs: "/sbin/launchd --boot",
 		},
 		{
-			// Regression guard for the original bug surface
-			// (gascity#2442). BSD `ps -o comm=` emits the executable
-			// path truncated to MAXCOMLEN=16 — and audio-driver workers
-			// (and other long-name kernel actors) register with comm
-			// values whose first 16 chars CONTAIN spaces, e.g.
-			// "Core Audio Drive". A whitespace tokenizer would split
-			// such a value across Command and Args, breaking name
-			// matching downstream. Fixed-width slicing is the fix.
-			name:     "comm with internal spaces — REGRESSION GUARD",
-			line:     "  489     1 Core Audio Drive Core Audio Driver (MSTeamsAudioDevice.driver)",
+			name:     "dynamic columns with no comm width dependency",
+			line:     "  489     1 /usr/sbin/coreaudiod Core Audio Driver (MSTeamsAudioDevice.driver)",
 			wantPID:  "489",
 			wantPPID: "1",
-			wantCmd:  "Core Audio Drive",
-			wantArgs: "Core Audio Driver (MSTeamsAudioDevice.driver)",
+			wantCmd:  "coreaudiod",
+			wantArgs: "/usr/sbin/coreaudiod Core Audio Driver (MSTeamsAudioDevice.driver)",
 		},
 		{
-			name:     "comm exactly fills the 16-char column",
-			line:     "  147     1 /System/Library/ /System/Library/PrivateFrameworks/X.framework/X",
-			wantPID:  "147",
-			wantPPID: "1",
-			wantCmd:  "/System/Library/",
-			wantArgs: "/System/Library/PrivateFrameworks/X.framework/X",
+			name:     "wide pid and ppid columns",
+			line:     "123456 98765 /opt/app/bin/renderer --headless",
+			wantPID:  "123456",
+			wantPPID: "98765",
+			wantCmd:  "renderer",
+			wantArgs: "/opt/app/bin/renderer --headless",
 		},
 		{
 			name:     "args preserves internal multi-space",
-			line:     "  456     1 claude           a  b   c",
+			line:     "  456     1 /usr/local/bin/claude a  b   c",
 			wantPID:  "456",
 			wantPPID: "1",
 			wantCmd:  "claude",
-			wantArgs: "a  b   c",
+			wantArgs: "/usr/local/bin/claude a  b   c",
 		},
 		{
-			// Real ps still pads comm to 16 chars even when args is
-			// effectively empty; the line ends right after the padding.
-			name:     "no args after padded comm",
-			line:     "  789     1 kernel_task     ",
+			name:     "outer args whitespace is normalized",
+			line:     "  789     1    /bin/zsh -l   ",
 			wantPID:  "789",
 			wantPPID: "1",
-			wantCmd:  "kernel_task",
-			wantArgs: "",
+			wantCmd:  "zsh",
+			wantArgs: "/bin/zsh -l",
 		},
 	}
 	for _, tc := range cases {
@@ -577,7 +567,7 @@ func TestParseProcessSnapshotLineDarwinRejectsMalformed(t *testing.T) {
 		{"whitespace only", "       "},
 		{"pid only", "  123"},
 		{"pid and ppid only", "  123     1"},
-		{"pid, ppid, separator, no comm", "  123     1 "},
+		{"pid, ppid, separator, no args", "  123     1 "},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -585,6 +575,60 @@ func TestParseProcessSnapshotLineDarwinRejectsMalformed(t *testing.T) {
 				t.Errorf("expected ok=false for %q", tc.line)
 			}
 		})
+	}
+}
+
+func TestParseDarwinProcessSnapshotPreservesCommWhenArgv0IsRewritten(t *testing.T) {
+	argsOut := strings.Join([]string{
+		"  101     1 /bin/zsh -l",
+		"  102   101 2.1.30 --print",
+	}, "\n")
+	commOut := strings.Join([]string{
+		"  101     1 zsh",
+		"  102   101 /usr/local/bin/claude",
+	}, "\n")
+
+	snapshot := parseDarwinProcessSnapshot(argsOut, commOut)
+	process, ok := snapshot.byPID["102"]
+	if !ok {
+		t.Fatal("process 102 missing from Darwin snapshot")
+	}
+	if process.Command != "/usr/local/bin/claude" {
+		t.Fatalf("Command = %q, want comm path", process.Command)
+	}
+	if process.Args != "2.1.30 --print" {
+		t.Fatalf("Args = %q, want rewritten argv[0] args", process.Args)
+	}
+	if !snapshot.processMatchesNames("102", processNameSet([]string{"claude"})) {
+		t.Fatal("processMatchesNames(102, claude) = false, want true from comm")
+	}
+}
+
+func TestParseDarwinProcessSnapshotTraversesThroughEmptyArgsRows(t *testing.T) {
+	argsOut := strings.Join([]string{
+		"  101     1 /bin/bash -l",
+		"  102   101 ",
+		"  103   102 /usr/local/bin/claude --print",
+	}, "\n")
+	commOut := strings.Join([]string{
+		"  101     1 bash",
+		"  102   101 launchd helper",
+		"  103   102 claude",
+	}, "\n")
+
+	snapshot := parseDarwinProcessSnapshot(argsOut, commOut)
+	process, ok := snapshot.byPID["102"]
+	if !ok {
+		t.Fatal("process 102 missing from Darwin snapshot")
+	}
+	if process.Command != "launchd helper" {
+		t.Fatalf("Command = %q, want comm for empty-args process", process.Command)
+	}
+	if process.Args != "" {
+		t.Fatalf("Args = %q, want empty args", process.Args)
+	}
+	if !snapshot.hasDescendantWithNames("101", processNameSet([]string{"claude"}), 0) {
+		t.Fatal("hasDescendantWithNames(101, claude) = false, want traversal through empty-args row")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a follow-up parse bug in the macOS `ps` snapshot path added by #2472.
On macOS, `ps -o comm=` left-pads the command name into a fixed 16-character
column (BSD `MAXCOMLEN`), and the kernel allows internal whitespace in
process names — Core Audio publishes workers as `Core Audio Drive`, app
helpers can register as `Renderer Main`, etc. The current Darwin parser
splits the line with `strings.Fields`, which treats those internal spaces
as column separators and slices the args column into the command. The
result: `processRuntimeState.Command` ends up as `"Core"` instead of
`"Core Audio Drive"`, and the args field is corrupted with the rest of
the comm value.

Replaces the whitespace tokenizer for the Darwin path with a column-aware
parser: PID and PPID are still read by whitespace tokenization (they're
right-aligned, dynamic-width integers), but `comm` is sliced at the
fixed 16-char column width and `args` is taken verbatim from the column
boundary onward. This preserves internal whitespace in both fields.

The Linux path is unchanged in behavior; its tests are extended to cover
a similar case (`PR_SET_NAME`-style thread names with embedded spaces),
which the existing fixed-column parser already handled correctly.

## Change

- `internal/runtime/tmux/state_cache.go`:
  - Renamed `parseProcessSnapshotLineWhitespace` to
    `parseProcessSnapshotLineDarwin` and rewrote it as a fixed-column
    slicer (`darwinCommColWidth = 16`, matching BSD `MAXCOMLEN`).
  - PID/PPID are read by whitespace tokenization (right-aligned,
    variable-width). `comm` is read by absolute byte offset and
    trimmed; `args` is taken from the next column boundary as a verbatim
    substring.
  - Truncated lines (no args column on kernel-thread rows) are still
    accepted; comm-only rows produce `Args = ""`.

- `internal/runtime/tmux/state_cache_test.go`:
  - `TestParseProcessSnapshotLineFixedColumns` becomes table-driven and
    adds a `PR_SET_NAME`-style "Renderer Main" case to guard the Linux
    parser against the same shape of bug.
  - New table-driven cases for `parseProcessSnapshotLineDarwin` cover:
    typical processes, `comm` with internal spaces ("Core Audio Drive"),
    `comm` at the 16-char limit, kernel-thread-style rows with no args
    column, and short/malformed lines.

## What this does not solve

- Does not change the `ps` invocation. The Darwin branch of
  `processSnapshotPSArgs` (added in #2472) is correct as-is and
  produces output this parser expects.
- Does not address potential `comm` truncation beyond 16 characters —
  that's a kernel limit, not a parse issue. Callers that match on full
  command names should continue to use `args` for the path-bearing
  representation.

## Test plan

- [x] `go test ./internal/runtime/tmux/...` passes locally on macOS
      (Darwin 25.2.0).
- [x] New `TestParseProcessSnapshotLineDarwin` cases all pass; new
      `TestParseProcessSnapshotLineFixedColumns` "Renderer Main" case
      passes on the Linux parser.
- [ ] CI runs the full `make check` matrix.

Manual verification on macOS:

```
$ ps -eo pid=,ppid=,comm=,args= | grep -i 'Core Audio Drive' | head -1
  582     1 Core Audio Drive /usr/sbin/coreaudiod
```

Before this PR, the snapshot parser records that process with
`Command="Core"` and `Args="Audio Drive /usr/sbin/coreaudiod"`. After,
it correctly records `Command="Core Audio Drive"` and
`Args="/usr/sbin/coreaudiod"`.

## Credit

Builds on #2472 (Julian Knutsen), which moved the macOS ps path off the
Linux-only `:WIDTH` modifiers; the original cache work in #2442 set the
context for the platform-specific parser split.
