### PR TITLE
Add GitHub PR repair backfill command

### DIFF
--- a/cmd/gc/cmd_github.go
+++ b/cmd/gc/cmd_github.go
@@ -1,0 +1,400 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/githubmonitor"
+	"github.com/spf13/cobra"
+)
+
+type githubPRLister interface {
+	ListOpenPullRequests(context.Context, string, string) ([]githubmonitor.PullRequest, error)
+}
+
+var (
+	newGitHubPRBackfillClient = func(token string) githubPRLister {
+		return githubmonitor.NewGraphQLClient(token)
+	}
+	resolveGitHubTokenForBackfill = resolveGitHubToken
+	openGitHubPRRepairStore       = func(cityPath, scopeRoot string) (beads.Store, error) {
+		return openStoreAtForCity(scopeRoot, cityPath)
+	}
+)
+
+type githubPRBackfillOptions struct {
+	monitorName    string
+	jsonOutput     bool
+	includeClean   bool
+	timeout        time.Duration
+	actionableOnly bool
+	createRepairs  bool
+}
+
+type githubPRBackfillResult struct {
+	SchemaVersion   string                 `json:"schema_version"`
+	CityPath        string                 `json:"city_path"`
+	MonitorCount    int                    `json:"monitor_count"`
+	ResultCount     int                    `json:"result_count"`
+	ActionableCount int                    `json:"actionable_count"`
+	Results         []githubmonitor.Result `json:"results"`
+	RepairBeads     []githubPRRepairBead   `json:"repair_beads,omitempty"`
+	ExistingRepairs int                    `json:"existing_repairs,omitempty"`
+	CreatedRepairs  int                    `json:"created_repairs,omitempty"`
+}
+
+type githubPRRepairBead struct {
+	ID      string `json:"id"`
+	PR      int    `json:"pr"`
+	URL     string `json:"url,omitempty"`
+	Created bool   `json:"created"`
+	Route   string `json:"route,omitempty"`
+}
+
+func newGitHubCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "github",
+		Short: "GitHub integration commands",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newGitHubPRCmd(stdout, stderr))
+	return cmd
+}
+
+func newGitHubPRCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pr",
+		Short: "GitHub pull-request monitor commands",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newGitHubPRBackfillCmd(stdout, stderr))
+	return cmd
+}
+
+func newGitHubPRBackfillCmd(stdout, stderr io.Writer) *cobra.Command {
+	opts := githubPRBackfillOptions{
+		timeout:        45 * time.Second,
+		actionableOnly: true,
+	}
+	cmd := &cobra.Command{
+		Use:   "backfill [monitor-name]",
+		Short: "Query configured GitHub PR readiness monitors",
+		Long: `Query configured GitHub PR readiness monitors.
+
+The command reads [[github.pr_monitor]] entries from the resolved city
+configuration, queries open pull requests from GitHub, and reports PRs that
+need repair: failed checks, merge conflicts, blocked mergeability, or branches
+behind their base. By default clean and pending-only PRs are omitted; pass
+--all to include every observed PR.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.monitorName = args[0]
+			}
+			if opts.includeClean {
+				opts.actionableOnly = false
+			}
+			if doGitHubPRBackfill(opts, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit JSON")
+	cmd.Flags().BoolVar(&opts.includeClean, "all", false, "include clean and pending-only PRs")
+	cmd.Flags().BoolVar(&opts.createRepairs, "create-repair-beads", false, "create deduped repair beads for actionable PRs")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "GitHub query timeout")
+	return cmd
+}
+
+func doGitHubPRBackfill(opts githubPRBackfillOptions, stdout, stderr io.Writer) int {
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc github pr backfill: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	cfg, prov, err := loadConfigCommandCityConfig(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc github pr backfill: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !opts.jsonOutput {
+		for _, warning := range prov.Warnings {
+			fmt.Fprintf(stderr, "gc github pr backfill: warning: %s\n", warning) //nolint:errcheck // best-effort stderr
+		}
+	}
+
+	monitors, err := selectGitHubPRMonitors(cfg, opts.monitorName)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc github pr backfill: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
+	defer cancel()
+
+	token, err := resolveGitHubTokenForBackfill(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc github pr backfill: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	client := newGitHubPRBackfillClient(token)
+
+	result := githubPRBackfillResult{
+		SchemaVersion: "1",
+		CityPath:      cityPath,
+		MonitorCount:  len(monitors),
+	}
+	for _, monitor := range monitors {
+		prs, err := client.ListOpenPullRequests(ctx, strings.TrimSpace(monitor.Owner), strings.TrimSpace(monitor.Repo))
+		if err != nil {
+			fmt.Fprintf(stderr, "gc github pr backfill: monitor %q: %v\n", monitor.Name, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		evaluated := githubmonitor.EvaluatePullRequests(monitor, prs)
+		for _, prResult := range evaluated {
+			if prResult.Actionable {
+				result.ActionableCount++
+				if opts.createRepairs {
+					repair, created, err := ensureGitHubPRRepairBead(cityPath, cfg, monitor, prResult)
+					if err != nil {
+						fmt.Fprintf(stderr, "gc github pr backfill: repair bead for %s/%s#%d: %v\n", prResult.Owner, prResult.Repo, prResult.Number, err) //nolint:errcheck // best-effort stderr
+						return 1
+					}
+					result.RepairBeads = append(result.RepairBeads, githubPRRepairBead{
+						ID:      repair.ID,
+						PR:      prResult.Number,
+						URL:     prResult.URL,
+						Created: created,
+						Route:   prResult.RepairRoute,
+					})
+					if created {
+						result.CreatedRepairs++
+					} else {
+						result.ExistingRepairs++
+					}
+				}
+			}
+			if opts.actionableOnly && !prResult.Actionable {
+				continue
+			}
+			result.Results = append(result.Results, prResult)
+		}
+	}
+	result.ResultCount = len(result.Results)
+	sortGitHubPRBackfillResults(result.Results)
+
+	if opts.jsonOutput {
+		if writeCLIJSONLineOrExit(stdout, stderr, "gc github pr backfill", result) != 0 {
+			return 1
+		}
+		return 0
+	}
+	writeGitHubPRBackfillText(stdout, result)
+	return 0
+}
+
+func ensureGitHubPRRepairBead(cityPath string, cfg *config.City, monitor config.GitHubPRMonitor, result githubmonitor.Result) (beads.Bead, bool, error) {
+	if !result.Actionable {
+		return beads.Bead{}, false, errors.New("result is not actionable")
+	}
+	rig, ok := rigByName(cfg, strings.TrimSpace(monitor.Rig))
+	if !ok {
+		return beads.Bead{}, false, fmt.Errorf("rig %q not found", monitor.Rig)
+	}
+	scopeRoot := resolveStoreScopeRoot(cityPath, rig.Path)
+	store, err := openGitHubPRRepairStore(cityPath, scopeRoot)
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+
+	filters := githubPRRepairDedupeMetadata(result)
+	existing, err := store.ListByMetadata(filters, 1)
+	if err != nil {
+		return beads.Bead{}, false, fmt.Errorf("checking existing repair beads: %w", err)
+	}
+	if len(existing) > 0 {
+		return existing[0], false, nil
+	}
+
+	priority := 1
+	created, err := store.Create(beads.Bead{
+		Title:       githubPRRepairTitle(result),
+		Type:        "task",
+		Priority:    &priority,
+		Description: githubPRRepairDescription(result),
+		Labels:      []string{"github", "ci", "repair", "pr-monitor"},
+		Metadata:    githubPRRepairMetadata(result),
+	})
+	if err != nil {
+		return beads.Bead{}, false, fmt.Errorf("creating repair bead: %w", err)
+	}
+	return created, true, nil
+}
+
+func githubPRRepairDedupeMetadata(result githubmonitor.Result) map[string]string {
+	return map[string]string{
+		"source":              "github-pr-monitor",
+		"github.owner":        result.Owner,
+		"github.repo":         result.Repo,
+		"github.pr":           strconv.Itoa(result.Number),
+		"github.head_sha":     result.HeadSHA,
+		"github.failure_kind": result.FailureKind,
+	}
+}
+
+func githubPRRepairMetadata(result githubmonitor.Result) map[string]string {
+	metadata := githubPRRepairDedupeMetadata(result)
+	metadata["github.monitor"] = result.Monitor
+	metadata["github.url"] = result.URL
+	metadata["github.base"] = result.BaseRefName
+	metadata["github.head"] = result.HeadRefName
+	metadata["github.merge_state_status"] = result.MergeStateStatus
+	metadata["github.state"] = result.State
+	metadata["github.failed_checks"] = strings.Join(result.FailedChecks, "\n")
+	metadata["github.pending_checks"] = strings.Join(result.PendingChecks, "\n")
+	metadata["gc.routed_to"] = result.RepairRoute
+	return metadata
+}
+
+func githubPRRepairTitle(result githubmonitor.Result) string {
+	title := strings.TrimSpace(result.Title)
+	if title == "" {
+		title = result.URL
+	}
+	if title == "" {
+		title = result.FailureKind
+	}
+	return fmt.Sprintf("Repair GitHub PR %s/%s#%d readiness: %s", result.Owner, result.Repo, result.Number, title)
+}
+
+func githubPRRepairDescription(result githubmonitor.Result) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "GitHub PR readiness monitor %q found actionable work.\n\n", result.Monitor)
+	fmt.Fprintf(&b, "Repository: %s/%s\n", result.Owner, result.Repo)
+	fmt.Fprintf(&b, "PR: #%d", result.Number)
+	if result.URL != "" {
+		fmt.Fprintf(&b, " %s", result.URL)
+	}
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "Base: %s\n", result.BaseRefName)
+	if result.HeadRefName != "" {
+		fmt.Fprintf(&b, "Head: %s\n", result.HeadRefName)
+	}
+	if result.HeadSHA != "" {
+		fmt.Fprintf(&b, "Head SHA: %s\n", result.HeadSHA)
+	}
+	fmt.Fprintf(&b, "State: %s\n", result.State)
+	if result.FailureKind != "" {
+		fmt.Fprintf(&b, "Failure kind: %s\n", result.FailureKind)
+	}
+	if result.MergeStateStatus != "" {
+		fmt.Fprintf(&b, "GitHub merge state: %s\n", result.MergeStateStatus)
+	}
+	if len(result.FailedChecks) > 0 {
+		b.WriteString("\nFailed checks:\n")
+		for _, check := range result.FailedChecks {
+			fmt.Fprintf(&b, "- %s\n", check)
+		}
+	}
+	if len(result.PendingChecks) > 0 {
+		b.WriteString("\nPending checks:\n")
+		for _, check := range result.PendingChecks {
+			fmt.Fprintf(&b, "- %s\n", check)
+		}
+	}
+	if result.RepairRoute != "" {
+		fmt.Fprintf(&b, "\nRoute: %s\n", result.RepairRoute)
+	}
+	return b.String()
+}
+
+func selectGitHubPRMonitors(cfg *config.City, name string) ([]config.GitHubPRMonitor, error) {
+	if cfg == nil || len(cfg.GitHub.PRMonitors) == 0 {
+		return nil, errors.New("no github.pr_monitor entries are configured")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return append([]config.GitHubPRMonitor(nil), cfg.GitHub.PRMonitors...), nil
+	}
+	for _, monitor := range cfg.GitHub.PRMonitors {
+		if strings.TrimSpace(monitor.Name) == name {
+			return []config.GitHubPRMonitor{monitor}, nil
+		}
+	}
+	return nil, fmt.Errorf("github.pr_monitor %q not found", name)
+}
+
+func sortGitHubPRBackfillResults(results []githubmonitor.Result) {
+	slices.SortFunc(results, func(a, b githubmonitor.Result) int {
+		if c := strings.Compare(a.Monitor, b.Monitor); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Repo, b.Repo); c != 0 {
+			return c
+		}
+		return a.Number - b.Number
+	})
+}
+
+func writeGitHubPRBackfillText(stdout io.Writer, result githubPRBackfillResult) {
+	if len(result.Results) == 0 {
+		fmt.Fprintf(stdout, "No actionable GitHub PR readiness problems found across %d monitor(s).\n", result.MonitorCount) //nolint:errcheck
+		return
+	}
+	for _, pr := range result.Results {
+		fmt.Fprintf(stdout, "%s %s/%s#%d %s", pr.Monitor, pr.Owner, pr.Repo, pr.Number, pr.State) //nolint:errcheck
+		if pr.FailureKind != "" {
+			fmt.Fprintf(stdout, " %s", pr.FailureKind) //nolint:errcheck
+		}
+		if pr.MergeStateStatus != "" {
+			fmt.Fprintf(stdout, " merge=%s", pr.MergeStateStatus) //nolint:errcheck
+		}
+		if len(pr.FailedChecks) > 0 {
+			fmt.Fprintf(stdout, " failed=%s", strings.Join(pr.FailedChecks, ",")) //nolint:errcheck
+		}
+		if len(pr.PendingChecks) > 0 {
+			fmt.Fprintf(stdout, " pending=%s", strings.Join(pr.PendingChecks, ",")) //nolint:errcheck
+		}
+		if pr.RepairRoute != "" {
+			fmt.Fprintf(stdout, " route=%s", pr.RepairRoute) //nolint:errcheck
+		}
+		if pr.URL != "" {
+			fmt.Fprintf(stdout, " url=%s", pr.URL) //nolint:errcheck
+		}
+		fmt.Fprintln(stdout) //nolint:errcheck
+	}
+}
+
+func resolveGitHubToken(ctx context.Context) (string, error) {
+	for _, key := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if token := strings.TrimSpace(os.Getenv(key)); token != "" {
+			return token, nil
+		}
+	}
+	cmd := exec.CommandContext(ctx, "gh", "auth", "token")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("GitHub token not found in GITHUB_TOKEN/GH_TOKEN and `gh auth token` failed: %w", err)
+	}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", errors.New("GitHub token not found: `gh auth token` returned empty output")
+	}
+	return token, nil
+}

--- a/cmd/gc/cmd_github_test.go
+++ b/cmd/gc/cmd_github_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/githubmonitor"
+)
+
+type fakeGitHubPRLister struct {
+	prs []githubmonitor.PullRequest
+	err error
+}
+
+func (f fakeGitHubPRLister) ListOpenPullRequests(context.Context, string, string) ([]githubmonitor.PullRequest, error) {
+	return f.prs, f.err
+}
+
+func TestGitHubPRBackfillCommandReportsActionableResults(t *testing.T) {
+	cityPath := writeGitHubMonitorTestCity(t)
+	oldToken := resolveGitHubTokenForBackfill
+	oldClient := newGitHubPRBackfillClient
+	resolveGitHubTokenForBackfill = func(context.Context) (string, error) { return "token", nil }
+	newGitHubPRBackfillClient = func(token string) githubPRLister {
+		if token != "token" {
+			t.Fatalf("token = %q, want test token", token)
+		}
+		return fakeGitHubPRLister{prs: []githubmonitor.PullRequest{
+			{
+				Number:           2560,
+				Title:            "Deploy",
+				URL:              "https://github.com/partcleda/partcl/pull/2560",
+				BaseRefName:      "main",
+				HeadRefName:      "fix",
+				HeadSHA:          "abc123",
+				MergeStateStatus: "BLOCKED",
+				Checks:           []githubmonitor.Check{{Name: "deploy", Status: "COMPLETED", Conclusion: "FAILURE"}},
+			},
+		}}
+	}
+	t.Cleanup(func() {
+		resolveGitHubTokenForBackfill = oldToken
+		newGitHubPRBackfillClient = oldClient
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityPath, "github", "pr", "backfill", "partcl-main", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
+	}
+	var payload struct {
+		MonitorCount    int `json:"monitor_count"`
+		ResultCount     int `json:"result_count"`
+		ActionableCount int `json:"actionable_count"`
+		Results         []githubmonitor.Result
+		OK              bool `json:"ok"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode stdout %q: %v", stdout.String(), err)
+	}
+	if !payload.OK {
+		t.Fatal("ok = false, want true")
+	}
+	if payload.MonitorCount != 1 || payload.ResultCount != 1 || payload.ActionableCount != 1 {
+		t.Fatalf("counts = monitors %d results %d actionable %d, want 1/1/1", payload.MonitorCount, payload.ResultCount, payload.ActionableCount)
+	}
+	if got := payload.Results[0]; got.Number != 2560 || got.State != githubmonitor.StateFailed || got.RepairRoute != "partcl/polecat" {
+		t.Fatalf("result = %#v, want failing PR routed to partcl/polecat", got)
+	}
+}
+
+func TestGitHubPRBackfillCommandCreatesDedupedRepairBeads(t *testing.T) {
+	cityPath := writeGitHubMonitorTestCity(t)
+	store := beads.NewMemStore()
+	oldToken := resolveGitHubTokenForBackfill
+	oldClient := newGitHubPRBackfillClient
+	oldStore := openGitHubPRRepairStore
+	resolveGitHubTokenForBackfill = func(context.Context) (string, error) { return "token", nil }
+	newGitHubPRBackfillClient = func(string) githubPRLister {
+		return fakeGitHubPRLister{prs: []githubmonitor.PullRequest{
+			{
+				Number:           2560,
+				Title:            "Deploy",
+				URL:              "https://github.com/partcleda/partcl/pull/2560",
+				BaseRefName:      "main",
+				HeadRefName:      "fix",
+				HeadSHA:          "abc123",
+				MergeStateStatus: "BLOCKED",
+				Checks:           []githubmonitor.Check{{Name: "deploy", Status: "COMPLETED", Conclusion: "FAILURE"}},
+			},
+		}}
+	}
+	openGitHubPRRepairStore = func(string, string) (beads.Store, error) {
+		return store, nil
+	}
+	t.Cleanup(func() {
+		resolveGitHubTokenForBackfill = oldToken
+		newGitHubPRBackfillClient = oldClient
+		openGitHubPRRepairStore = oldStore
+	})
+
+	for i := 0; i < 2; i++ {
+		var stdout, stderr bytes.Buffer
+		code := run([]string{"--city", cityPath, "github", "pr", "backfill", "partcl-main", "--create-repair-beads", "--json"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run %d code = %d, stdout = %q, stderr = %q", i, code, stdout.String(), stderr.String())
+		}
+	}
+
+	created, err := store.ListByMetadata(map[string]string{
+		"source":          "github-pr-monitor",
+		"github.owner":    "partcleda",
+		"github.repo":     "partcl",
+		"github.pr":       "2560",
+		"github.head_sha": "abc123",
+	}, 0)
+	if err != nil {
+		t.Fatalf("ListByMetadata: %v", err)
+	}
+	if len(created) != 1 {
+		t.Fatalf("created repair beads = %#v, want one deduped bead", created)
+	}
+	if got := created[0].Metadata["gc.routed_to"]; got != "partcl/polecat" {
+		t.Fatalf("gc.routed_to = %q, want partcl/polecat", got)
+	}
+	if !strings.Contains(created[0].Description, "deploy") {
+		t.Fatalf("description = %q, want failed check detail", created[0].Description)
+	}
+}
+
+func TestGitHubPRBackfillCommandFiltersCleanResultsByDefault(t *testing.T) {
+	cityPath := writeGitHubMonitorTestCity(t)
+	oldToken := resolveGitHubTokenForBackfill
+	oldClient := newGitHubPRBackfillClient
+	resolveGitHubTokenForBackfill = func(context.Context) (string, error) { return "token", nil }
+	newGitHubPRBackfillClient = func(string) githubPRLister {
+		return fakeGitHubPRLister{prs: []githubmonitor.PullRequest{
+			{Number: 1, BaseRefName: "main", MergeStateStatus: "CLEAN"},
+		}}
+	}
+	t.Cleanup(func() {
+		resolveGitHubTokenForBackfill = oldToken
+		newGitHubPRBackfillClient = oldClient
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityPath, "github", "pr", "backfill", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), `"number":1`) {
+		t.Fatalf("stdout = %s, clean PR should be filtered by default", stdout.String())
+	}
+}
+
+func writeGitHubMonitorTestCity(t *testing.T) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir .gc: %v", err)
+	}
+	body := `[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "partcl"
+path = "partcl"
+prefix = "pa"
+
+[[github.pr_monitor]]
+name = "partcl-main"
+owner = "partcleda"
+repo = "partcl"
+base_branches = ["main"]
+rig = "partcl"
+repair_route = "partcl/polecat"
+notify = ["gastown.mayor"]
+poll_interval = "2m"
+merge_queue = "repair"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, "partcl"), 0o755); err != nil {
+		t.Fatalf("mkdir partcl: %v", err)
+	}
+	return cityPath
+}
+
+func TestGitHubPRBackfillCommandPropagatesRepairStoreError(t *testing.T) {
+	cityPath := writeGitHubMonitorTestCity(t)
+	oldToken := resolveGitHubTokenForBackfill
+	oldClient := newGitHubPRBackfillClient
+	oldStore := openGitHubPRRepairStore
+	resolveGitHubTokenForBackfill = func(context.Context) (string, error) { return "token", nil }
+	newGitHubPRBackfillClient = func(string) githubPRLister {
+		return fakeGitHubPRLister{prs: []githubmonitor.PullRequest{{Number: 1, BaseRefName: "main", HeadSHA: "abc", MergeStateStatus: "DIRTY"}}}
+	}
+	openGitHubPRRepairStore = func(string, string) (beads.Store, error) {
+		return nil, fmt.Errorf("store unavailable")
+	}
+	t.Cleanup(func() {
+		resolveGitHubTokenForBackfill = oldToken
+		newGitHubPRBackfillClient = oldClient
+		openGitHubPRRepairStore = oldStore
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityPath, "github", "pr", "backfill", "--create-repair-beads"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run code = 0, want failure")
+	}
+	if !strings.Contains(stderr.String(), "store unavailable") {
+		t.Fatalf("stderr = %q, want store error", stderr.String())
+	}
+}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -251,6 +251,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 		newWaitCmd(stdout, stderr),
 		newAgentCmd(stdout, stderr),
 		newAgentScriptCmd(stdout, stderr),
+		newGitHubCmd(stdout, stderr),
 		newEventCmd(stdout, stderr),
 		newEventsCmd(stdout, stderr),
 		newTraceCmd(stdout, stderr),

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,6 +37,7 @@ gc [flags]
 | [gc event](#gc-event) | Event operations |
 | [gc events](#gc-events) | Show events from the GC API |
 | [gc formula](#gc-formula) | Manage and inspect formulas |
+| [gc github](#gc-github) | GitHub integration commands |
 | [gc graph](#gc-graph) | Show dependency graph for beads |
 | [gc handoff](#gc-handoff) | Send handoff mail and restart controller-managed sessions |
 | [gc help](#gc-help) | Help about any command |
@@ -1361,6 +1362,51 @@ gc formula show <formula-name> [flags]
 |------|------|---------|-------------|
 | `--json` | bool |  | emit JSON |
 | `--var` | stringArray |  | variable substitution for preview (key=value) |
+
+## gc github
+
+GitHub integration commands
+
+```
+gc github
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc github pr](#gc-github-pr) | GitHub pull-request monitor commands |
+
+## gc github pr
+
+GitHub pull-request monitor commands
+
+```
+gc github pr
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc github pr backfill](#gc-github-pr-backfill) | Query configured GitHub PR readiness monitors |
+
+## gc github pr backfill
+
+Query configured GitHub PR readiness monitors.
+
+The command reads [[github.pr_monitor]] entries from the resolved city
+configuration, queries open pull requests from GitHub, and reports PRs that
+need repair: failed checks, merge conflicts, blocked mergeability, or branches
+behind their base. By default clean and pending-only PRs are omitted; pass
+--all to include every observed PR.
+
+```
+gc github pr backfill [monitor-name] [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--all` | bool |  | include clean and pending-only PRs |
+| `--create-repair-beads` | bool |  | create deduped repair beads for actionable PRs |
+| `--json` | bool |  | emit JSON |
+| `--timeout` | duration | `45s` | GitHub query timeout |
 
 ## gc graph
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -36,6 +36,7 @@ City is the top-level configuration for a Gas City instance.
 | `convergence` | ConvergenceConfig |  |  | Convergence configures convergence loop limits. |
 | `doctor` | DoctorConfig |  |  | Doctor configures gc doctor thresholds and policy toggles (worktree size warnings, nested-worktree auto-prune). |
 | `service` | []Service |  |  | Services declares workspace-owned HTTP services mounted on the controller edge under /svc/&#123;name&#125;. |
+| `github` | GitHubConfig |  |  | GitHub configures GitHub-facing repository monitors. |
 | `agent_defaults` | AgentDefaults |  |  | AgentDefaults provides city-level defaults for agents that don't override them (canonical TOML key: agent_defaults). The runtime currently applies default_sling_formula and append_fragments; the attachment-list fields remain tombstones, and the other fields are parsed/composed but not yet inherited automatically. |
 | `pricing` | []ModelPricing |  |  | Pricing holds per-model cost rate overrides keyed by (provider, model). City-level entries override pack-level entries which override the defaults shipped with the pricing package. See internal/pricing for the estimation seam introduced by issue #1255 (1d). |
 
@@ -342,6 +343,51 @@ FormulasConfig holds legacy formula directory settings.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 
+## GitHubConfig
+
+GitHubConfig groups GitHub-facing repository monitor declarations.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `pr_monitor` | []GitHubPRMonitor |  |  | PRMonitors declares GitHub pull-request readiness monitors. |
+
+## GitHubPRMonitor
+
+GitHubPRMonitor declares how one repository/base-branch set is monitored and where durable repair work should be routed when readiness fails.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | **yes** |  | Name is the stable monitor identity used by patches and diagnostics. |
+| `owner` | string | **yes** |  | Owner is the GitHub repository owner or organization. |
+| `repo` | string | **yes** |  | Repo is the GitHub repository name. |
+| `base_branches` | []string | **yes** |  | BaseBranches lists the base branches this monitor owns. |
+| `rig` | string | **yes** |  | Rig is the Gas City rig that owns repair work for this repository. |
+| `notify` | []string |  |  | Notify lists session or mail recipients for readiness notifications. |
+| `repair_route` | string | **yes** |  | RepairRoute is the operator-supplied route target for repair work. |
+| `webhook_secret_env` | string |  |  | WebhookSecretEnv is the environment variable containing the webhook HMAC secret. The secret value itself must not be stored in city.toml. |
+| `webhook_secret_key` | string |  |  | WebhookSecretKey is an optional stable key for identifying the webhook secret during rotation. When omitted, WebhookSecretEnv is the key. |
+| `poll_interval` | string |  |  | PollInterval optionally enables bounded polling/backfill cadence. |
+| `merge_queue` | string |  |  | MergeQueuePolicy controls merge-queue signal handling. Empty defaults to "observe"; valid values are "ignore", "observe", and "repair". Enum: `ignore`, `observe`, `repair` |
+
+## GitHubPRMonitorPatch
+
+GitHubPRMonitorPatch modifies an existing GitHub PR readiness monitor by name.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | **yes** |  | Name is the monitor identity to patch. |
+| `owner` | string |  |  | Owner overrides the GitHub repository owner or organization. |
+| `repo` | string |  |  | Repo overrides the GitHub repository name. |
+| `base_branches` | []string |  |  | BaseBranches replaces the monitored base branch list. An empty list clears the field and will fail validation unless another patch fills it. |
+| `rig` | string |  |  | Rig overrides the owning rig. |
+| `notify` | []string |  |  | Notify replaces notification recipients. An empty list clears recipients. |
+| `notify_append` | []string |  |  | NotifyAppend appends notification recipients after Notify replacement. |
+| `repair_route` | string |  |  | RepairRoute overrides the repair route target. |
+| `webhook_secret_env` | string |  |  | WebhookSecretEnv overrides the env var containing the webhook secret. |
+| `webhook_secret_key` | string |  |  | WebhookSecretKey overrides the stable webhook secret key. |
+| `poll_interval` | string |  |  | PollInterval overrides the optional polling cadence. |
+| `merge_queue` | string |  |  | MergeQueuePolicy overrides merge-queue signal handling. Enum: `ignore`, `observe`, `repair` |
+
 ## Import
 
 Import defines a named import of another pack.
@@ -474,6 +520,7 @@ Patches holds all patch blocks from composition.
 | `agent` | []AgentPatch |  |  | Agents targets agents by (dir, name). |
 | `rigs` | []RigPatch |  |  | Rigs targets rigs by name. |
 | `providers` | []ProviderPatch |  |  | Providers targets providers by name. |
+| `github_pr_monitor` | []GitHubPRMonitorPatch |  |  | GitHubPRMonitors targets GitHub PR readiness monitors by name. |
 
 ## PoolOverride
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1055,6 +1055,10 @@
           "type": "array",
           "description": "Services declares workspace-owned HTTP services mounted on the\ncontroller edge under /svc/{name}."
         },
+        "github": {
+          "$ref": "#/$defs/GitHubConfig",
+          "description": "GitHub configures GitHub-facing repository monitors."
+        },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
           "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies default_sling_formula and append_fragments; the\nattachment-list fields remain tombstones, and the other fields are\nparsed/composed but not yet inherited automatically."
@@ -1293,6 +1297,162 @@
       "additionalProperties": false,
       "type": "object",
       "description": "FormulasConfig holds legacy formula directory settings."
+    },
+    "GitHubConfig": {
+      "properties": {
+        "pr_monitor": {
+          "items": {
+            "$ref": "#/$defs/GitHubPRMonitor"
+          },
+          "type": "array",
+          "description": "PRMonitors declares GitHub pull-request readiness monitors."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "GitHubConfig groups GitHub-facing repository monitor declarations."
+    },
+    "GitHubPRMonitor": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the stable monitor identity used by patches and diagnostics."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner is the GitHub repository owner or organization."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repo is the GitHub repository name."
+        },
+        "base_branches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "BaseBranches lists the base branches this monitor owns."
+        },
+        "rig": {
+          "type": "string",
+          "description": "Rig is the Gas City rig that owns repair work for this repository."
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Notify lists session or mail recipients for readiness notifications."
+        },
+        "repair_route": {
+          "type": "string",
+          "description": "RepairRoute is the operator-supplied route target for repair work."
+        },
+        "webhook_secret_env": {
+          "type": "string",
+          "description": "WebhookSecretEnv is the environment variable containing the webhook\nHMAC secret. The secret value itself must not be stored in city.toml."
+        },
+        "webhook_secret_key": {
+          "type": "string",
+          "description": "WebhookSecretKey is an optional stable key for identifying the webhook\nsecret during rotation. When omitted, WebhookSecretEnv is the key."
+        },
+        "poll_interval": {
+          "type": "string",
+          "description": "PollInterval optionally enables bounded polling/backfill cadence."
+        },
+        "merge_queue": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "observe",
+            "repair"
+          ],
+          "description": "MergeQueuePolicy controls merge-queue signal handling. Empty defaults\nto \"observe\"; valid values are \"ignore\", \"observe\", and \"repair\"."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "repo",
+        "base_branches",
+        "rig",
+        "repair_route"
+      ],
+      "description": "GitHubPRMonitor declares how one repository/base-branch set is monitored and where durable repair work should be routed when readiness fails."
+    },
+    "GitHubPRMonitorPatch": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the monitor identity to patch."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner overrides the GitHub repository owner or organization."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repo overrides the GitHub repository name."
+        },
+        "base_branches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "BaseBranches replaces the monitored base branch list. An empty list\nclears the field and will fail validation unless another patch fills it."
+        },
+        "rig": {
+          "type": "string",
+          "description": "Rig overrides the owning rig."
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Notify replaces notification recipients. An empty list clears recipients."
+        },
+        "notify_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "NotifyAppend appends notification recipients after Notify replacement."
+        },
+        "repair_route": {
+          "type": "string",
+          "description": "RepairRoute overrides the repair route target."
+        },
+        "webhook_secret_env": {
+          "type": "string",
+          "description": "WebhookSecretEnv overrides the env var containing the webhook secret."
+        },
+        "webhook_secret_key": {
+          "type": "string",
+          "description": "WebhookSecretKey overrides the stable webhook secret key."
+        },
+        "poll_interval": {
+          "type": "string",
+          "description": "PollInterval overrides the optional polling cadence."
+        },
+        "merge_queue": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "observe",
+            "repair"
+          ],
+          "description": "MergeQueuePolicy overrides merge-queue signal handling."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "GitHubPRMonitorPatch modifies an existing GitHub PR readiness monitor by name."
     },
     "Import": {
       "properties": {
@@ -1632,6 +1792,13 @@
           },
           "type": "array",
           "description": "Providers targets providers by name."
+        },
+        "github_pr_monitor": {
+          "items": {
+            "$ref": "#/$defs/GitHubPRMonitorPatch"
+          },
+          "type": "array",
+          "description": "GitHubPRMonitors targets GitHub PR readiness monitors by name."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1055,6 +1055,10 @@
           "type": "array",
           "description": "Services declares workspace-owned HTTP services mounted on the\ncontroller edge under /svc/{name}."
         },
+        "github": {
+          "$ref": "#/$defs/GitHubConfig",
+          "description": "GitHub configures GitHub-facing repository monitors."
+        },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
           "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies default_sling_formula and append_fragments; the\nattachment-list fields remain tombstones, and the other fields are\nparsed/composed but not yet inherited automatically."
@@ -1293,6 +1297,162 @@
       "additionalProperties": false,
       "type": "object",
       "description": "FormulasConfig holds legacy formula directory settings."
+    },
+    "GitHubConfig": {
+      "properties": {
+        "pr_monitor": {
+          "items": {
+            "$ref": "#/$defs/GitHubPRMonitor"
+          },
+          "type": "array",
+          "description": "PRMonitors declares GitHub pull-request readiness monitors."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "GitHubConfig groups GitHub-facing repository monitor declarations."
+    },
+    "GitHubPRMonitor": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the stable monitor identity used by patches and diagnostics."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner is the GitHub repository owner or organization."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repo is the GitHub repository name."
+        },
+        "base_branches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "BaseBranches lists the base branches this monitor owns."
+        },
+        "rig": {
+          "type": "string",
+          "description": "Rig is the Gas City rig that owns repair work for this repository."
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Notify lists session or mail recipients for readiness notifications."
+        },
+        "repair_route": {
+          "type": "string",
+          "description": "RepairRoute is the operator-supplied route target for repair work."
+        },
+        "webhook_secret_env": {
+          "type": "string",
+          "description": "WebhookSecretEnv is the environment variable containing the webhook\nHMAC secret. The secret value itself must not be stored in city.toml."
+        },
+        "webhook_secret_key": {
+          "type": "string",
+          "description": "WebhookSecretKey is an optional stable key for identifying the webhook\nsecret during rotation. When omitted, WebhookSecretEnv is the key."
+        },
+        "poll_interval": {
+          "type": "string",
+          "description": "PollInterval optionally enables bounded polling/backfill cadence."
+        },
+        "merge_queue": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "observe",
+            "repair"
+          ],
+          "description": "MergeQueuePolicy controls merge-queue signal handling. Empty defaults\nto \"observe\"; valid values are \"ignore\", \"observe\", and \"repair\"."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "repo",
+        "base_branches",
+        "rig",
+        "repair_route"
+      ],
+      "description": "GitHubPRMonitor declares how one repository/base-branch set is monitored and where durable repair work should be routed when readiness fails."
+    },
+    "GitHubPRMonitorPatch": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the monitor identity to patch."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner overrides the GitHub repository owner or organization."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repo overrides the GitHub repository name."
+        },
+        "base_branches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "BaseBranches replaces the monitored base branch list. An empty list\nclears the field and will fail validation unless another patch fills it."
+        },
+        "rig": {
+          "type": "string",
+          "description": "Rig overrides the owning rig."
+        },
+        "notify": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Notify replaces notification recipients. An empty list clears recipients."
+        },
+        "notify_append": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "NotifyAppend appends notification recipients after Notify replacement."
+        },
+        "repair_route": {
+          "type": "string",
+          "description": "RepairRoute overrides the repair route target."
+        },
+        "webhook_secret_env": {
+          "type": "string",
+          "description": "WebhookSecretEnv overrides the env var containing the webhook secret."
+        },
+        "webhook_secret_key": {
+          "type": "string",
+          "description": "WebhookSecretKey overrides the stable webhook secret key."
+        },
+        "poll_interval": {
+          "type": "string",
+          "description": "PollInterval overrides the optional polling cadence."
+        },
+        "merge_queue": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "observe",
+            "repair"
+          ],
+          "description": "MergeQueuePolicy overrides merge-queue signal handling."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "GitHubPRMonitorPatch modifies an existing GitHub PR readiness monitor by name."
     },
     "Import": {
       "properties": {
@@ -1632,6 +1792,13 @@
           },
           "type": "array",
           "description": "Providers targets providers by name."
+        },
+        "github_pr_monitor": {
+          "items": {
+            "$ref": "#/$defs/GitHubPRMonitorPatch"
+          },
+          "type": "array",
+          "description": "GitHubPRMonitors targets GitHub PR readiness monitors by name."
         }
       },
       "additionalProperties": false,

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -615,6 +615,10 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		return nil, nil, err
 	}
 
+	if err := ValidateGitHubPRMonitors(root); err != nil {
+		return nil, nil, err
+	}
+
 	// Validate all duration strings in the fully-merged config.
 	prov.Warnings = append(prov.Warnings, ValidateDurations(root, path)...)
 	prov.Warnings = append(prov.Warnings, ValidateEventsRotation(root)...)
@@ -910,6 +914,10 @@ func mergeFragment(base, fragment *City, fragMeta toml.MetaData, fragPath string
 	// Services: concatenate.
 	base.Services = append(base.Services, fragment.Services...)
 
+	// GitHub PR monitors: concatenate. Validation rejects duplicate repo/base
+	// ownership after patches have had a chance to adjust declarations.
+	base.GitHub.PRMonitors = append(base.GitHub.PRMonitors, fragment.GitHub.PRMonitors...)
+
 	// Providers: deep-merge per-field.
 	mergeProviders(base, fragment, fragMeta, fragPath, prov)
 
@@ -929,6 +937,7 @@ func mergeFragment(base, fragment *City, fragMeta toml.MetaData, fragPath string
 	base.Patches.Agents = append(base.Patches.Agents, fragment.Patches.Agents...)
 	base.Patches.Rigs = append(base.Patches.Rigs, fragment.Patches.Rigs...)
 	base.Patches.Providers = append(base.Patches.Providers, fragment.Patches.Providers...)
+	base.Patches.GitHubPRMonitors = append(base.Patches.GitHubPRMonitors, fragment.Patches.GitHubPRMonitors...)
 
 	// Simple sections: last-writer-wins if fragment defines them.
 	if fragMeta.IsDefined("beads") {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,6 +218,8 @@ type City struct {
 	// Services declares workspace-owned HTTP services mounted on the
 	// controller edge under /svc/{name}.
 	Services []Service `toml:"service,omitempty"`
+	// GitHub configures GitHub-facing repository monitors.
+	GitHub GitHubConfig `toml:"github,omitempty"`
 	// AgentDefaults provides city-level defaults for agents that don't
 	// override them (canonical TOML key: agent_defaults). The runtime
 	// currently applies default_sling_formula and append_fragments; the
@@ -3642,6 +3644,9 @@ func Load(fs fsys.FS, path string) (*City, error) {
 	// direct named-session declarations without requiring pack-provided
 	// backing templates to be present yet.
 	if err := validateNamedSessions(cfg, false); err != nil {
+		return nil, err
+	}
+	if err := ValidateGitHubPRMonitors(cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil

--- a/internal/config/github_pr_monitor.go
+++ b/internal/config/github_pr_monitor.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var validGitHubWebhookSecretEnv = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+const defaultGitHubMergeQueuePolicy = "observe"
+
+// GitHubConfig groups GitHub-facing repository monitor declarations.
+type GitHubConfig struct {
+	// PRMonitors declares GitHub pull-request readiness monitors.
+	PRMonitors []GitHubPRMonitor `toml:"pr_monitor,omitempty"`
+}
+
+// GitHubPRMonitor declares how one repository/base-branch set is monitored
+// and where durable repair work should be routed when readiness fails.
+type GitHubPRMonitor struct {
+	// Name is the stable monitor identity used by patches and diagnostics.
+	Name string `toml:"name" jsonschema:"required"`
+	// Owner is the GitHub repository owner or organization.
+	Owner string `toml:"owner" jsonschema:"required"`
+	// Repo is the GitHub repository name.
+	Repo string `toml:"repo" jsonschema:"required"`
+	// BaseBranches lists the base branches this monitor owns.
+	BaseBranches []string `toml:"base_branches" jsonschema:"required"`
+	// Rig is the Gas City rig that owns repair work for this repository.
+	Rig string `toml:"rig" jsonschema:"required"`
+	// Notify lists session or mail recipients for readiness notifications.
+	Notify []string `toml:"notify,omitempty"`
+	// RepairRoute is the operator-supplied route target for repair work.
+	RepairRoute string `toml:"repair_route" jsonschema:"required"`
+	// WebhookSecretEnv is the environment variable containing the webhook
+	// HMAC secret. The secret value itself must not be stored in city.toml.
+	WebhookSecretEnv string `toml:"webhook_secret_env,omitempty"`
+	// WebhookSecretKey is an optional stable key for identifying the webhook
+	// secret during rotation. When omitted, WebhookSecretEnv is the key.
+	WebhookSecretKey string `toml:"webhook_secret_key,omitempty"`
+	// PollInterval optionally enables bounded polling/backfill cadence.
+	PollInterval string `toml:"poll_interval,omitempty"`
+	// MergeQueuePolicy controls merge-queue signal handling. Empty defaults
+	// to "observe"; valid values are "ignore", "observe", and "repair".
+	MergeQueuePolicy string `toml:"merge_queue,omitempty" jsonschema:"enum=ignore,enum=observe,enum=repair"`
+}
+
+// MergeQueuePolicyOrDefault returns the normalized merge-queue policy.
+func (m GitHubPRMonitor) MergeQueuePolicyOrDefault() string {
+	policy := strings.TrimSpace(strings.ToLower(m.MergeQueuePolicy))
+	if policy == "" {
+		return defaultGitHubMergeQueuePolicy
+	}
+	return policy
+}
+
+// WebhookSecretKeyOrDefault returns the configured secret key or the env var
+// name when no explicit key is configured.
+func (m GitHubPRMonitor) WebhookSecretKeyOrDefault() string {
+	if key := strings.TrimSpace(m.WebhookSecretKey); key != "" {
+		return key
+	}
+	return strings.TrimSpace(m.WebhookSecretEnv)
+}
+
+// ValidateGitHubPRMonitors checks GitHub PR readiness monitor declarations.
+func ValidateGitHubPRMonitors(cfg *City) error {
+	if cfg == nil || len(cfg.GitHub.PRMonitors) == 0 {
+		return nil
+	}
+
+	rigs := make(map[string]bool, len(cfg.Rigs))
+	for _, rig := range cfg.Rigs {
+		rigs[rig.Name] = true
+	}
+
+	seenNames := make(map[string]int, len(cfg.GitHub.PRMonitors))
+	seenRepoBase := make(map[string]string, len(cfg.GitHub.PRMonitors))
+	for i, monitor := range cfg.GitHub.PRMonitors {
+		ctx := fmt.Sprintf("github.pr_monitor[%d]", i)
+		name := strings.TrimSpace(monitor.Name)
+		if name == "" {
+			return fmt.Errorf("%s: name is required", ctx)
+		}
+		if prev, ok := seenNames[name]; ok {
+			return fmt.Errorf("%s %q: duplicate name also used by github.pr_monitor[%d]", ctx, name, prev)
+		}
+		seenNames[name] = i
+
+		owner := strings.TrimSpace(monitor.Owner)
+		if owner == "" {
+			return fmt.Errorf("%s %q: owner is required", ctx, name)
+		}
+		repo := strings.TrimSpace(monitor.Repo)
+		if repo == "" {
+			return fmt.Errorf("%s %q: repo is required", ctx, name)
+		}
+		rig := strings.TrimSpace(monitor.Rig)
+		if rig == "" {
+			return fmt.Errorf("%s %q: rig is required", ctx, name)
+		}
+		if !rigs[rig] {
+			return fmt.Errorf("%s %q: rig %q is not declared", ctx, name, rig)
+		}
+		if strings.TrimSpace(monitor.RepairRoute) == "" {
+			return fmt.Errorf("%s %q: repair_route is required", ctx, name)
+		}
+		if len(monitor.BaseBranches) == 0 {
+			return fmt.Errorf("%s %q: base_branches is required", ctx, name)
+		}
+
+		branchSeen := make(map[string]bool, len(monitor.BaseBranches))
+		for _, base := range monitor.BaseBranches {
+			base = strings.TrimSpace(base)
+			if base == "" {
+				return fmt.Errorf("%s %q: base_branches contains an empty branch", ctx, name)
+			}
+			baseKey := strings.ToLower(base)
+			if branchSeen[baseKey] {
+				return fmt.Errorf("%s %q: duplicate base branch %q", ctx, name, base)
+			}
+			branchSeen[baseKey] = true
+
+			repoBaseKey := strings.ToLower(owner) + "/" + strings.ToLower(repo) + "@" + baseKey
+			if prev, ok := seenRepoBase[repoBaseKey]; ok {
+				return fmt.Errorf("%s %q: duplicate repo/base %s/%s@%s also monitored by %q",
+					ctx, name, strings.ToLower(owner), strings.ToLower(repo), baseKey, prev)
+			}
+			seenRepoBase[repoBaseKey] = name
+		}
+
+		for _, recipient := range monitor.Notify {
+			if strings.TrimSpace(recipient) == "" {
+				return fmt.Errorf("%s %q: notify contains an empty recipient", ctx, name)
+			}
+		}
+		if envName := strings.TrimSpace(monitor.WebhookSecretEnv); envName != "" && !validGitHubWebhookSecretEnv.MatchString(envName) {
+			return fmt.Errorf("%s %q: webhook_secret_env must be an environment variable name, got %q", ctx, name, monitor.WebhookSecretEnv)
+		}
+		if monitor.WebhookSecretKey != "" && strings.TrimSpace(monitor.WebhookSecretKey) == "" {
+			return fmt.Errorf("%s %q: webhook_secret_key must not be blank", ctx, name)
+		}
+		if err := validateGitHubPRMonitorPollInterval(ctx, name, monitor.PollInterval); err != nil {
+			return err
+		}
+		switch monitor.MergeQueuePolicyOrDefault() {
+		case "ignore", "observe", "repair":
+		default:
+			return fmt.Errorf("%s %q: merge_queue must be \"ignore\", \"observe\", or \"repair\", got %q",
+				ctx, name, monitor.MergeQueuePolicy)
+		}
+	}
+	return nil
+}
+
+func validateGitHubPRMonitorPollInterval(ctx, name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	dur, err := time.ParseDuration(value)
+	if err != nil {
+		return fmt.Errorf("%s %q: poll_interval is not a valid duration: %w", ctx, name, err)
+	}
+	if dur <= 0 {
+		return fmt.Errorf("%s %q: poll_interval must be positive: got %q", ctx, name, value)
+	}
+	return nil
+}

--- a/internal/config/github_pr_monitor_test.go
+++ b/internal/config/github_pr_monitor_test.go
@@ -1,0 +1,254 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestParseGitHubPRMonitors(t *testing.T) {
+	cfg, err := Parse([]byte(`
+[workspace]
+name = "test"
+
+[[github.pr_monitor]]
+name = "sample-main"
+owner = "sample-org"
+repo = "sample-repo"
+base_branches = ["main", "release"]
+rig = "sample"
+notify = ["addr-a", "addr-b"]
+repair_route = "route-a"
+webhook_secret_env = "SAMPLE_GITHUB_WEBHOOK_SECRET"
+webhook_secret_key = "sample-main"
+poll_interval = "2m"
+merge_queue = "repair"
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(cfg.GitHub.PRMonitors) != 1 {
+		t.Fatalf("len(GitHub.PRMonitors) = %d, want 1", len(cfg.GitHub.PRMonitors))
+	}
+	got := cfg.GitHub.PRMonitors[0]
+	if got.Name != "sample-main" {
+		t.Errorf("Name = %q, want sample-main", got.Name)
+	}
+	if got.Owner != "sample-org" || got.Repo != "sample-repo" {
+		t.Errorf("repo = %s/%s, want sample-org/sample-repo", got.Owner, got.Repo)
+	}
+	if len(got.BaseBranches) != 2 || got.BaseBranches[0] != "main" || got.BaseBranches[1] != "release" {
+		t.Errorf("BaseBranches = %v, want [main release]", got.BaseBranches)
+	}
+	if got.Rig != "sample" {
+		t.Errorf("Rig = %q, want sample", got.Rig)
+	}
+	if len(got.Notify) != 2 || got.Notify[0] != "addr-a" || got.Notify[1] != "addr-b" {
+		t.Errorf("Notify = %v, want [addr-a addr-b]", got.Notify)
+	}
+	if got.RepairRoute != "route-a" {
+		t.Errorf("RepairRoute = %q, want route-a", got.RepairRoute)
+	}
+	if got.WebhookSecretEnv != "SAMPLE_GITHUB_WEBHOOK_SECRET" {
+		t.Errorf("WebhookSecretEnv = %q, want SAMPLE_GITHUB_WEBHOOK_SECRET", got.WebhookSecretEnv)
+	}
+	if got.WebhookSecretKey != "sample-main" {
+		t.Errorf("WebhookSecretKey = %q, want sample-main", got.WebhookSecretKey)
+	}
+	if got.PollInterval != "2m" {
+		t.Errorf("PollInterval = %q, want 2m", got.PollInterval)
+	}
+	if got.MergeQueuePolicy != "repair" {
+		t.Errorf("MergeQueuePolicy = %q, want repair", got.MergeQueuePolicy)
+	}
+}
+
+func TestValidateGitHubPRMonitorsRejectsMissingRepoAndRoute(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		monitor GitHubPRMonitor
+		want    string
+	}{
+		{
+			name: "missing owner",
+			monitor: GitHubPRMonitor{
+				Name:         "bad",
+				Repo:         "sample-repo",
+				BaseBranches: []string{"main"},
+				Rig:          "sample",
+				RepairRoute:  "route-a",
+			},
+			want: "owner is required",
+		},
+		{
+			name: "missing repo",
+			monitor: GitHubPRMonitor{
+				Name:         "bad",
+				Owner:        "sample-org",
+				BaseBranches: []string{"main"},
+				Rig:          "sample",
+				RepairRoute:  "route-a",
+			},
+			want: "repo is required",
+		},
+		{
+			name: "missing route",
+			monitor: GitHubPRMonitor{
+				Name:         "bad",
+				Owner:        "sample-org",
+				Repo:         "sample-repo",
+				BaseBranches: []string{"main"},
+				Rig:          "sample",
+			},
+			want: "repair_route is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &City{
+				Rigs: []Rig{{Name: "sample"}},
+				GitHub: GitHubConfig{
+					PRMonitors: []GitHubPRMonitor{tc.monitor},
+				},
+			}
+			err := ValidateGitHubPRMonitors(cfg)
+			if err == nil {
+				t.Fatal("ValidateGitHubPRMonitors() = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ValidateGitHubPRMonitors() = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateGitHubPRMonitorsRejectsDuplicateRepoBase(t *testing.T) {
+	cfg := &City{
+		Rigs: []Rig{{Name: "sample"}},
+		GitHub: GitHubConfig{
+			PRMonitors: []GitHubPRMonitor{
+				{
+					Name:         "main",
+					Owner:        "sample-org",
+					Repo:         "sample-repo",
+					BaseBranches: []string{"main", "release"},
+					Rig:          "sample",
+					RepairRoute:  "route-a",
+				},
+				{
+					Name:         "main-again",
+					Owner:        "SAMPLE-ORG",
+					Repo:         "Sample-Repo",
+					BaseBranches: []string{"main"},
+					Rig:          "sample",
+					RepairRoute:  "route-a",
+				},
+			},
+		},
+	}
+	err := ValidateGitHubPRMonitors(cfg)
+	if err == nil {
+		t.Fatal("ValidateGitHubPRMonitors() = nil, want duplicate error")
+	}
+	if !strings.Contains(err.Error(), "duplicate repo/base") || !strings.Contains(err.Error(), "sample-org/sample-repo") {
+		t.Fatalf("ValidateGitHubPRMonitors() = %v, want duplicate repo/base for sample-org/sample-repo", err)
+	}
+}
+
+func TestValidateGitHubPRMonitorsAcceptsEnvBackedWebhookSecret(t *testing.T) {
+	cfg := &City{
+		Rigs: []Rig{{Name: "sample"}},
+		GitHub: GitHubConfig{
+			PRMonitors: []GitHubPRMonitor{
+				{
+					Name:             "main",
+					Owner:            "sample-org",
+					Repo:             "sample-repo",
+					BaseBranches:     []string{"main"},
+					Rig:              "sample",
+					RepairRoute:      "route-a",
+					WebhookSecretEnv: "SAMPLE_GITHUB_WEBHOOK_SECRET",
+				},
+			},
+		},
+	}
+	if err := ValidateGitHubPRMonitors(cfg); err != nil {
+		t.Fatalf("ValidateGitHubPRMonitors: %v", err)
+	}
+
+	cfg.GitHub.PRMonitors[0].WebhookSecretEnv = "bad-name"
+	err := ValidateGitHubPRMonitors(cfg)
+	if err == nil {
+		t.Fatal("ValidateGitHubPRMonitors() = nil, want invalid env error")
+	}
+	if !strings.Contains(err.Error(), "webhook_secret_env") {
+		t.Fatalf("ValidateGitHubPRMonitors() = %v, want webhook_secret_env error", err)
+	}
+}
+
+func TestLoadWithIncludesMergesAndPatchesGitHubPRMonitors(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+include = ["github.toml"]
+
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "sample"
+path = "/sample"
+
+[[github.pr_monitor]]
+name = "release"
+owner = "sample-org"
+repo = "sample-repo"
+base_branches = ["release"]
+rig = "sample"
+repair_route = "route-a"
+merge_queue = "observe"
+
+[[patches.github_pr_monitor]]
+name = "main"
+poll_interval = "5m"
+notify = ["ops"]
+merge_queue = "repair"
+`)
+	fs.Files["/city/github.toml"] = []byte(`
+[[github.pr_monitor]]
+name = "main"
+owner = "sample-org"
+repo = "sample-repo"
+base_branches = ["main"]
+rig = "sample"
+repair_route = "route-a"
+poll_interval = "1m"
+merge_queue = "observe"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.GitHub.PRMonitors) != 2 {
+		t.Fatalf("len(GitHub.PRMonitors) = %d, want 2", len(cfg.GitHub.PRMonitors))
+	}
+	var mainMonitor *GitHubPRMonitor
+	for i := range cfg.GitHub.PRMonitors {
+		if cfg.GitHub.PRMonitors[i].Name == "main" {
+			mainMonitor = &cfg.GitHub.PRMonitors[i]
+			break
+		}
+	}
+	if mainMonitor == nil {
+		t.Fatalf("main monitor missing: %#v", cfg.GitHub.PRMonitors)
+	}
+	if mainMonitor.PollInterval != "5m" {
+		t.Errorf("patched PollInterval = %q, want 5m", mainMonitor.PollInterval)
+	}
+	if mainMonitor.MergeQueuePolicy != "repair" {
+		t.Errorf("patched MergeQueuePolicy = %q, want repair", mainMonitor.MergeQueuePolicy)
+	}
+	if len(mainMonitor.Notify) != 1 || mainMonitor.Notify[0] != "ops" {
+		t.Errorf("patched Notify = %v, want [ops]", mainMonitor.Notify)
+	}
+}

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -12,6 +12,8 @@ type Patches struct {
 	Rigs []RigPatch `toml:"rigs,omitempty"`
 	// Providers targets providers by name.
 	Providers []ProviderPatch `toml:"providers,omitempty"`
+	// GitHubPRMonitors targets GitHub PR readiness monitors by name.
+	GitHubPRMonitors []GitHubPRMonitorPatch `toml:"github_pr_monitor,omitempty"`
 }
 
 // AgentPatch modifies an existing agent identified by (Dir, Name).
@@ -226,9 +228,39 @@ type ProviderPatch struct {
 	Replace bool `toml:"_replace,omitempty"`
 }
 
+// GitHubPRMonitorPatch modifies an existing GitHub PR readiness monitor by
+// name. Pointer fields distinguish "not set" from "set to zero value."
+type GitHubPRMonitorPatch struct {
+	// Name is the monitor identity to patch.
+	Name string `toml:"name" jsonschema:"required"`
+	// Owner overrides the GitHub repository owner or organization.
+	Owner *string `toml:"owner,omitempty"`
+	// Repo overrides the GitHub repository name.
+	Repo *string `toml:"repo,omitempty"`
+	// BaseBranches replaces the monitored base branch list. An empty list
+	// clears the field and will fail validation unless another patch fills it.
+	BaseBranches *[]string `toml:"base_branches,omitempty"`
+	// Rig overrides the owning rig.
+	Rig *string `toml:"rig,omitempty"`
+	// Notify replaces notification recipients. An empty list clears recipients.
+	Notify *[]string `toml:"notify,omitempty"`
+	// NotifyAppend appends notification recipients after Notify replacement.
+	NotifyAppend []string `toml:"notify_append,omitempty"`
+	// RepairRoute overrides the repair route target.
+	RepairRoute *string `toml:"repair_route,omitempty"`
+	// WebhookSecretEnv overrides the env var containing the webhook secret.
+	WebhookSecretEnv *string `toml:"webhook_secret_env,omitempty"`
+	// WebhookSecretKey overrides the stable webhook secret key.
+	WebhookSecretKey *string `toml:"webhook_secret_key,omitempty"`
+	// PollInterval overrides the optional polling cadence.
+	PollInterval *string `toml:"poll_interval,omitempty"`
+	// MergeQueuePolicy overrides merge-queue signal handling.
+	MergeQueuePolicy *string `toml:"merge_queue,omitempty" jsonschema:"enum=ignore,enum=observe,enum=repair"`
+}
+
 // IsEmpty reports whether p has no patch operations.
 func (p *Patches) IsEmpty() bool {
-	return len(p.Agents) == 0 && len(p.Rigs) == 0 && len(p.Providers) == 0
+	return len(p.Agents) == 0 && len(p.Rigs) == 0 && len(p.Providers) == 0 && len(p.GitHubPRMonitors) == 0
 }
 
 // Fragments returns a pointer to the given inject_fragments list for use
@@ -274,6 +306,11 @@ func ApplyPatches(cfg *City, patches Patches) error {
 	for i, p := range patches.Providers {
 		if err := applyProviderPatch(cfg, &p); err != nil {
 			return fmt.Errorf("patches.providers[%d]: %w", i, err)
+		}
+	}
+	for i, p := range patches.GitHubPRMonitors {
+		if err := applyGitHubPRMonitorPatch(cfg, &p); err != nil {
+			return fmt.Errorf("patches.github_pr_monitor[%d]: %w", i, err)
 		}
 	}
 	return nil
@@ -514,6 +551,55 @@ func applyRigPatch(cfg *City, patch *RigPatch) error {
 		}
 	}
 	return fmt.Errorf("rig %q not found in merged config", patch.Name)
+}
+
+// applyGitHubPRMonitorPatch finds a GitHub PR monitor by name and applies
+// the patch.
+func applyGitHubPRMonitorPatch(cfg *City, patch *GitHubPRMonitorPatch) error {
+	if patch.Name == "" {
+		return fmt.Errorf("github pr monitor patch: name is required")
+	}
+	for i := range cfg.GitHub.PRMonitors {
+		monitor := &cfg.GitHub.PRMonitors[i]
+		if monitor.Name != patch.Name {
+			continue
+		}
+		if patch.Owner != nil {
+			monitor.Owner = *patch.Owner
+		}
+		if patch.Repo != nil {
+			monitor.Repo = *patch.Repo
+		}
+		if patch.BaseBranches != nil {
+			monitor.BaseBranches = append([]string(nil), (*patch.BaseBranches)...)
+		}
+		if patch.Rig != nil {
+			monitor.Rig = *patch.Rig
+		}
+		if patch.Notify != nil {
+			monitor.Notify = append([]string(nil), (*patch.Notify)...)
+		}
+		if len(patch.NotifyAppend) > 0 {
+			monitor.Notify = append(monitor.Notify, patch.NotifyAppend...)
+		}
+		if patch.RepairRoute != nil {
+			monitor.RepairRoute = *patch.RepairRoute
+		}
+		if patch.WebhookSecretEnv != nil {
+			monitor.WebhookSecretEnv = *patch.WebhookSecretEnv
+		}
+		if patch.WebhookSecretKey != nil {
+			monitor.WebhookSecretKey = *patch.WebhookSecretKey
+		}
+		if patch.PollInterval != nil {
+			monitor.PollInterval = *patch.PollInterval
+		}
+		if patch.MergeQueuePolicy != nil {
+			monitor.MergeQueuePolicy = *patch.MergeQueuePolicy
+		}
+		return nil
+	}
+	return fmt.Errorf("github pr monitor %q not found in merged config", patch.Name)
 }
 
 // applyProviderPatch modifies a provider. If Replace is true, replaces the

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -71,6 +71,11 @@ func ValidateDurations(cfg *City, source string) []string {
 		checkSleep(ctx, "noninteractive", r.SessionSleep.NonInteractive)
 	}
 
+	for _, monitor := range cfg.GitHub.PRMonitors {
+		ctx := fmt.Sprintf("github.pr_monitor %q", monitor.Name)
+		check(ctx, "poll_interval", monitor.PollInterval)
+	}
+
 	// Per-agent durations.
 	for _, a := range cfg.Agents {
 		ctx := fmt.Sprintf("agent %q", a.QualifiedName())

--- a/internal/githubmonitor/client.go
+++ b/internal/githubmonitor/client.go
@@ -1,0 +1,188 @@
+package githubmonitor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultGraphQLEndpoint = "https://api.github.com/graphql"
+
+// GraphQLClient queries GitHub's GraphQL API for pull-request readiness state.
+type GraphQLClient struct {
+	endpoint   string
+	token      string
+	httpClient *http.Client
+}
+
+// ClientOption configures a GraphQLClient.
+type ClientOption func(*GraphQLClient)
+
+// WithEndpoint overrides the GitHub GraphQL endpoint.
+func WithEndpoint(endpoint string) ClientOption {
+	return func(c *GraphQLClient) {
+		if strings.TrimSpace(endpoint) != "" {
+			c.endpoint = strings.TrimSpace(endpoint)
+		}
+	}
+}
+
+// WithHTTPClient overrides the HTTP client used for GitHub requests.
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(c *GraphQLClient) {
+		if client != nil {
+			c.httpClient = client
+		}
+	}
+}
+
+// NewGraphQLClient constructs a GitHub GraphQL API client.
+func NewGraphQLClient(token string, opts ...ClientOption) *GraphQLClient {
+	c := &GraphQLClient{
+		endpoint: defaultGraphQLEndpoint,
+		token:    strings.TrimSpace(token),
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
+	return c
+}
+
+// ListOpenPullRequests returns all currently open pull requests for a repo.
+func (c *GraphQLClient) ListOpenPullRequests(ctx context.Context, owner, repo string) ([]PullRequest, error) {
+	if c == nil {
+		return nil, fmt.Errorf("GitHub client is nil")
+	}
+	if c.token == "" {
+		return nil, fmt.Errorf("GitHub token is required")
+	}
+	owner = strings.TrimSpace(owner)
+	repo = strings.TrimSpace(repo)
+	if owner == "" || repo == "" {
+		return nil, fmt.Errorf("GitHub owner and repo are required")
+	}
+
+	var out []PullRequest
+	cursor := ""
+	for {
+		page, next, err := c.listOpenPullRequestsPage(ctx, owner, repo, cursor)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, page...)
+		if next == "" {
+			return out, nil
+		}
+		cursor = next
+	}
+}
+
+func (c *GraphQLClient) listOpenPullRequestsPage(ctx context.Context, owner, repo, cursor string) ([]PullRequest, string, error) {
+	payload := graphQLRequest{
+		Query: pullRequestsQuery,
+		Variables: pullRequestsQueryVariables{
+			Owner:  owner,
+			Repo:   repo,
+			Cursor: nullableString(cursor),
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("encoding GitHub GraphQL request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, "", fmt.Errorf("creating GitHub GraphQL request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("calling GitHub GraphQL: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // response body close is best-effort
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, "", fmt.Errorf("GitHub GraphQL HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+	return DecodePullRequestsPage(resp.Body)
+}
+
+type graphQLRequest struct {
+	Query     string                     `json:"query"`
+	Variables pullRequestsQueryVariables `json:"variables"`
+}
+
+type pullRequestsQueryVariables struct {
+	Owner  string  `json:"owner"`
+	Repo   string  `json:"repo"`
+	Cursor *string `json:"cursor"`
+}
+
+func nullableString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+const pullRequestsQuery = `
+query GasCityPRReadiness($owner: String!, $repo: String!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(first: 50, after: $cursor, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        number
+        title
+        url
+        isDraft
+        mergeStateStatus
+        baseRefName
+        headRefName
+        headRefOid
+        commits(last: 1) {
+          nodes {
+            commit {
+              oid
+              statusCheckRollup {
+                contexts(first: 100) {
+                  nodes {
+                    __typename
+                    ... on CheckRun {
+                      checkName: name
+                      status
+                      conclusion
+                      detailsUrl
+                    }
+                    ... on StatusContext {
+                      checkName: context
+                      state
+                      targetUrl
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`

--- a/internal/githubmonitor/client_test.go
+++ b/internal/githubmonitor/client_test.go
@@ -1,0 +1,74 @@
+package githubmonitor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGraphQLClientListOpenPullRequestsPaginates(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want bearer token", got)
+		}
+		calls++
+		switch calls {
+		case 1:
+			if _, err := fmt.Fprint(w, `{
+				"data": {"repository": {"pullRequests": {
+					"pageInfo": {"hasNextPage": true, "endCursor": "cursor-1"},
+					"nodes": [{"number": 1, "baseRefName": "main", "headRefOid": "abc", "mergeStateStatus": "CLEAN"}]
+				}}}
+			}`); err != nil {
+				t.Fatalf("writing response: %v", err)
+			}
+		case 2:
+			if _, err := fmt.Fprint(w, `{
+				"data": {"repository": {"pullRequests": {
+					"pageInfo": {"hasNextPage": false, "endCursor": null},
+					"nodes": [{"number": 2, "baseRefName": "main", "headRefOid": "def", "mergeStateStatus": "DIRTY"}]
+				}}}
+			}`); err != nil {
+				t.Fatalf("writing response: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected call %d", calls)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGraphQLClient("test-token", WithEndpoint(server.URL))
+	prs, err := client.ListOpenPullRequests(context.Background(), "partcleda", "partcl")
+	if err != nil {
+		t.Fatalf("ListOpenPullRequests: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if len(prs) != 2 || prs[0].Number != 1 || prs[1].Number != 2 {
+		t.Fatalf("prs = %#v, want two decoded pages", prs)
+	}
+}
+
+func TestGraphQLClientReportsHTTPFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad token", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewGraphQLClient("test-token", WithEndpoint(server.URL))
+	_, err := client.ListOpenPullRequests(context.Background(), "partcleda", "partcl")
+	if err == nil {
+		t.Fatal("ListOpenPullRequests error = nil, want HTTP failure")
+	}
+	if !strings.Contains(err.Error(), "HTTP 401") {
+		t.Fatalf("error = %v, want HTTP 401", err)
+	}
+}

--- a/internal/githubmonitor/monitor.go
+++ b/internal/githubmonitor/monitor.go
@@ -1,0 +1,367 @@
+// Package githubmonitor evaluates configured GitHub pull-request readiness
+// monitors against live or fixture-supplied pull-request state.
+package githubmonitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+const (
+	// StateClean means the PR has no currently observed readiness problem.
+	StateClean = "clean"
+	// StatePending means the PR has checks still running or queued.
+	StatePending = "pending"
+	// StateFailed means one or more checks or status contexts failed.
+	StateFailed = "failed"
+	// StateConflicted means GitHub reports the PR as dirty/conflicted.
+	StateConflicted = "conflicted"
+	// StateBehind means the PR branch is behind its base branch.
+	StateBehind = "behind"
+	// StateBlocked means GitHub reports a branch-protection/mergeability block.
+	StateBlocked = "blocked"
+	// StateDraft means the PR is draft and should not be repaired.
+	StateDraft = "draft"
+	// StateUnknown means GitHub did not provide a recognized readiness state.
+	StateUnknown = "unknown"
+
+	// FailureKindChecksFailed identifies failed required or reported checks.
+	FailureKindChecksFailed = "checks_failed"
+	// FailureKindMergeConflict identifies a dirty/conflicted PR branch.
+	FailureKindMergeConflict = "merge_conflict"
+	// FailureKindBehindBase identifies a PR branch that needs updating.
+	FailureKindBehindBase = "behind_base"
+	// FailureKindBlocked identifies a GitHub mergeability block without a more
+	// specific failed-check or conflict cause.
+	FailureKindBlocked = "blocked"
+)
+
+// Check is a normalized GitHub check run or commit status context.
+type Check struct {
+	Name       string `json:"name"`
+	Status     string `json:"status,omitempty"`
+	Conclusion string `json:"conclusion,omitempty"`
+	URL        string `json:"url,omitempty"`
+}
+
+// PullRequest is the normalized GitHub pull-request state used by monitors.
+type PullRequest struct {
+	Number           int     `json:"number"`
+	Title            string  `json:"title"`
+	URL              string  `json:"url"`
+	BaseRefName      string  `json:"base_ref_name"`
+	HeadRefName      string  `json:"head_ref_name"`
+	HeadSHA          string  `json:"head_sha"`
+	MergeStateStatus string  `json:"merge_state_status"`
+	IsDraft          bool    `json:"is_draft"`
+	Checks           []Check `json:"checks,omitempty"`
+}
+
+// Result is one monitor evaluation for one pull request.
+type Result struct {
+	Monitor          string   `json:"monitor"`
+	Owner            string   `json:"owner"`
+	Repo             string   `json:"repo"`
+	Number           int      `json:"number"`
+	Title            string   `json:"title,omitempty"`
+	URL              string   `json:"url,omitempty"`
+	BaseRefName      string   `json:"base_ref_name"`
+	HeadRefName      string   `json:"head_ref_name,omitempty"`
+	HeadSHA          string   `json:"head_sha,omitempty"`
+	MergeStateStatus string   `json:"merge_state_status,omitempty"`
+	State            string   `json:"state"`
+	FailureKind      string   `json:"failure_kind,omitempty"`
+	Actionable       bool     `json:"actionable"`
+	FailedChecks     []string `json:"failed_checks,omitempty"`
+	PendingChecks    []string `json:"pending_checks,omitempty"`
+	Rig              string   `json:"rig"`
+	RepairRoute      string   `json:"repair_route"`
+	Notify           []string `json:"notify,omitempty"`
+}
+
+// EvaluatePullRequests evaluates PR readiness for one configured monitor.
+func EvaluatePullRequests(monitor config.GitHubPRMonitor, prs []PullRequest) []Result {
+	baseBranches := normalizedBranchSet(monitor.BaseBranches)
+	results := make([]Result, 0, len(prs))
+	for _, pr := range prs {
+		if len(baseBranches) > 0 && !baseBranches[strings.ToLower(strings.TrimSpace(pr.BaseRefName))] {
+			continue
+		}
+		failed, pending := classifyChecks(pr.Checks)
+		state, failureKind, actionable := classifyPullRequest(pr, failed, pending)
+		results = append(results, Result{
+			Monitor:          strings.TrimSpace(monitor.Name),
+			Owner:            strings.TrimSpace(monitor.Owner),
+			Repo:             strings.TrimSpace(monitor.Repo),
+			Number:           pr.Number,
+			Title:            pr.Title,
+			URL:              pr.URL,
+			BaseRefName:      pr.BaseRefName,
+			HeadRefName:      pr.HeadRefName,
+			HeadSHA:          pr.HeadSHA,
+			MergeStateStatus: strings.TrimSpace(strings.ToUpper(pr.MergeStateStatus)),
+			State:            state,
+			FailureKind:      failureKind,
+			Actionable:       actionable,
+			FailedChecks:     failed,
+			PendingChecks:    pending,
+			Rig:              strings.TrimSpace(monitor.Rig),
+			RepairRoute:      strings.TrimSpace(monitor.RepairRoute),
+			Notify:           cleanStrings(monitor.Notify),
+		})
+	}
+	return results
+}
+
+func normalizedBranchSet(branches []string) map[string]bool {
+	out := make(map[string]bool, len(branches))
+	for _, branch := range branches {
+		branch = strings.ToLower(strings.TrimSpace(branch))
+		if branch != "" {
+			out[branch] = true
+		}
+	}
+	return out
+}
+
+func cleanStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func classifyChecks(checks []Check) (failed, pending []string) {
+	for _, check := range checks {
+		name := strings.TrimSpace(check.Name)
+		if name == "" {
+			continue
+		}
+		status := strings.ToUpper(strings.TrimSpace(check.Status))
+		conclusion := strings.ToUpper(strings.TrimSpace(check.Conclusion))
+		switch {
+		case checkFailed(status, conclusion):
+			failed = append(failed, name)
+		case checkPending(status, conclusion):
+			pending = append(pending, name)
+		}
+	}
+	slices.Sort(failed)
+	slices.Sort(pending)
+	return failed, pending
+}
+
+func checkFailed(status, conclusion string) bool {
+	switch conclusion {
+	case "FAILURE", "ERROR", "CANCELED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE":
+		return true
+	}
+	switch status {
+	case "FAILURE", "ERROR":
+		return true
+	}
+	return false
+}
+
+func checkPending(status, conclusion string) bool {
+	if conclusion != "" {
+		switch conclusion {
+		case "SUCCESS", "NEUTRAL", "SKIPPED":
+			return false
+		}
+		return !checkFailed(status, conclusion)
+	}
+	switch status {
+	case "PENDING", "EXPECTED", "QUEUED", "REQUESTED", "WAITING", "IN_PROGRESS":
+		return true
+	case "COMPLETED", "SUCCESS":
+		return false
+	}
+	return false
+}
+
+func classifyPullRequest(pr PullRequest, failed, pending []string) (state, failureKind string, actionable bool) {
+	if pr.IsDraft {
+		return StateDraft, "", false
+	}
+	if len(failed) > 0 {
+		return StateFailed, FailureKindChecksFailed, true
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
+	case "DIRTY":
+		return StateConflicted, FailureKindMergeConflict, true
+	case "BEHIND":
+		return StateBehind, FailureKindBehindBase, true
+	case "UNSTABLE":
+		return StateFailed, FailureKindChecksFailed, true
+	case "BLOCKED":
+		return StateBlocked, FailureKindBlocked, true
+	}
+
+	if len(pending) > 0 {
+		return StatePending, "", false
+	}
+	switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
+	case "", "UNKNOWN":
+		return StateUnknown, "", false
+	default:
+		return StateClean, "", false
+	}
+}
+
+type graphQLPullRequestsResponse struct {
+	Data   graphQLData    `json:"data"`
+	Errors []graphQLError `json:"errors,omitempty"`
+}
+
+type graphQLError struct {
+	Message string `json:"message"`
+}
+
+type graphQLData struct {
+	Repository graphQLRepository `json:"repository"`
+}
+
+type graphQLRepository struct {
+	PullRequests graphQLPullRequestConnection `json:"pullRequests"`
+}
+
+type graphQLPullRequestConnection struct {
+	PageInfo graphQLPageInfo      `json:"pageInfo"`
+	Nodes    []graphQLPullRequest `json:"nodes"`
+}
+
+type graphQLPageInfo struct {
+	HasNextPage bool    `json:"hasNextPage"`
+	EndCursor   *string `json:"endCursor"`
+}
+
+type graphQLPullRequest struct {
+	Number           int                `json:"number"`
+	Title            string             `json:"title"`
+	URL              string             `json:"url"`
+	IsDraft          bool               `json:"isDraft"`
+	MergeStateStatus string             `json:"mergeStateStatus"`
+	BaseRefName      string             `json:"baseRefName"`
+	HeadRefName      string             `json:"headRefName"`
+	HeadRefOID       string             `json:"headRefOid"`
+	Commits          graphQLCommitNodes `json:"commits"`
+}
+
+type graphQLCommitNodes struct {
+	Nodes []graphQLCommitNode `json:"nodes"`
+}
+
+type graphQLCommitNode struct {
+	Commit graphQLCommit `json:"commit"`
+}
+
+type graphQLCommit struct {
+	OID               string              `json:"oid"`
+	StatusCheckRollup *graphQLCheckRollup `json:"statusCheckRollup"`
+}
+
+type graphQLCheckRollup struct {
+	Contexts graphQLCheckContextConnection `json:"contexts"`
+}
+
+type graphQLCheckContextConnection struct {
+	Nodes []graphQLCheckContext `json:"nodes"`
+}
+
+type graphQLCheckContext struct {
+	Type       string `json:"__typename"`
+	CheckName  string `json:"checkName"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	State      string `json:"state"`
+	DetailsURL string `json:"detailsUrl"`
+	TargetURL  string `json:"targetUrl"`
+}
+
+// DecodePullRequestsPage decodes one GraphQL pull-request page.
+func DecodePullRequestsPage(r io.Reader) ([]PullRequest, string, error) {
+	var resp graphQLPullRequestsResponse
+	if err := json.NewDecoder(r).Decode(&resp); err != nil {
+		return nil, "", fmt.Errorf("decoding GitHub GraphQL response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		messages := make([]string, 0, len(resp.Errors))
+		for _, graphErr := range resp.Errors {
+			if msg := strings.TrimSpace(graphErr.Message); msg != "" {
+				messages = append(messages, msg)
+			}
+		}
+		if len(messages) == 0 {
+			messages = append(messages, "unknown GraphQL error")
+		}
+		return nil, "", fmt.Errorf("GitHub GraphQL error: %s", strings.Join(messages, "; "))
+	}
+
+	conn := resp.Data.Repository.PullRequests
+	prs := make([]PullRequest, 0, len(conn.Nodes))
+	for _, node := range conn.Nodes {
+		pr := PullRequest{
+			Number:           node.Number,
+			Title:            node.Title,
+			URL:              node.URL,
+			IsDraft:          node.IsDraft,
+			MergeStateStatus: node.MergeStateStatus,
+			BaseRefName:      node.BaseRefName,
+			HeadRefName:      node.HeadRefName,
+			HeadSHA:          node.HeadRefOID,
+		}
+		if len(node.Commits.Nodes) > 0 {
+			commit := node.Commits.Nodes[len(node.Commits.Nodes)-1].Commit
+			if pr.HeadSHA == "" {
+				pr.HeadSHA = commit.OID
+			}
+			if commit.StatusCheckRollup != nil {
+				pr.Checks = normalizeGraphQLChecks(commit.StatusCheckRollup.Contexts.Nodes)
+			}
+		}
+		prs = append(prs, pr)
+	}
+
+	next := ""
+	if conn.PageInfo.HasNextPage && conn.PageInfo.EndCursor != nil {
+		next = *conn.PageInfo.EndCursor
+	}
+	return prs, next, nil
+}
+
+func normalizeGraphQLChecks(nodes []graphQLCheckContext) []Check {
+	checks := make([]Check, 0, len(nodes))
+	for _, node := range nodes {
+		name := strings.TrimSpace(node.CheckName)
+		if name == "" {
+			continue
+		}
+		check := Check{
+			Name:   name,
+			Status: strings.TrimSpace(node.Status),
+			URL:    strings.TrimSpace(node.DetailsURL),
+		}
+		if node.State != "" {
+			check.Status = strings.TrimSpace(node.State)
+			check.Conclusion = strings.TrimSpace(node.State)
+			if check.URL == "" {
+				check.URL = strings.TrimSpace(node.TargetURL)
+			}
+		} else {
+			check.Conclusion = strings.TrimSpace(node.Conclusion)
+		}
+		checks = append(checks, check)
+	}
+	return checks
+}

--- a/internal/githubmonitor/monitor_test.go
+++ b/internal/githubmonitor/monitor_test.go
@@ -1,0 +1,193 @@
+package githubmonitor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestEvaluatePullRequestsMarksFailedChecksActionable(t *testing.T) {
+	monitor := config.GitHubPRMonitor{
+		Name:         "partcl-main",
+		Owner:        "partcleda",
+		Repo:         "partcl",
+		BaseBranches: []string{"main"},
+		Rig:          "partcl",
+		RepairRoute:  "partcl/polecat",
+		Notify:       []string{"ops"},
+	}
+	prs := []PullRequest{
+		{
+			Number:           2560,
+			Title:            "Fix deployment",
+			URL:              "https://github.com/partcleda/partcl/pull/2560",
+			BaseRefName:      "main",
+			HeadRefName:      "feature/deploy",
+			HeadSHA:          "abc123",
+			MergeStateStatus: "UNSTABLE",
+			Checks: []Check{
+				{Name: "version-check / check-versions", Status: "COMPLETED", Conclusion: "FAILURE"},
+				{Name: "lint", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "integration", Status: "IN_PROGRESS"},
+			},
+		},
+	}
+
+	results := EvaluatePullRequests(monitor, prs)
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	got := results[0]
+	if got.State != StateFailed {
+		t.Fatalf("State = %q, want %q", got.State, StateFailed)
+	}
+	if !got.Actionable {
+		t.Fatal("Actionable = false, want true")
+	}
+	if got.FailureKind != FailureKindChecksFailed {
+		t.Fatalf("FailureKind = %q, want %q", got.FailureKind, FailureKindChecksFailed)
+	}
+	if len(got.FailedChecks) != 1 || got.FailedChecks[0] != "version-check / check-versions" {
+		t.Fatalf("FailedChecks = %v, want failed version check", got.FailedChecks)
+	}
+	if len(got.PendingChecks) != 1 || got.PendingChecks[0] != "integration" {
+		t.Fatalf("PendingChecks = %v, want integration", got.PendingChecks)
+	}
+	if got.RepairRoute != "partcl/polecat" || got.Rig != "partcl" {
+		t.Fatalf("route metadata = %q/%q, want partcl/polecat and partcl", got.RepairRoute, got.Rig)
+	}
+}
+
+func TestEvaluatePullRequestsMarksMergeProblemsActionable(t *testing.T) {
+	monitor := config.GitHubPRMonitor{
+		Name:         "main",
+		Owner:        "org",
+		Repo:         "repo",
+		BaseBranches: []string{"main"},
+		Rig:          "repo",
+		RepairRoute:  "repo/polecat",
+	}
+
+	results := EvaluatePullRequests(monitor, []PullRequest{
+		{Number: 10, BaseRefName: "main", MergeStateStatus: "DIRTY"},
+		{Number: 11, BaseRefName: "main", MergeStateStatus: "BEHIND"},
+	})
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].State != StateConflicted || results[0].FailureKind != FailureKindMergeConflict {
+		t.Fatalf("dirty result = %#v, want conflict", results[0])
+	}
+	if results[1].State != StateBehind || results[1].FailureKind != FailureKindBehindBase {
+		t.Fatalf("behind result = %#v, want behind base", results[1])
+	}
+}
+
+func TestEvaluatePullRequestsFiltersUnconfiguredBaseBranches(t *testing.T) {
+	monitor := config.GitHubPRMonitor{
+		Name:         "main",
+		Owner:        "org",
+		Repo:         "repo",
+		BaseBranches: []string{"main"},
+		Rig:          "repo",
+		RepairRoute:  "repo/polecat",
+	}
+
+	results := EvaluatePullRequests(monitor, []PullRequest{
+		{Number: 10, BaseRefName: "release", MergeStateStatus: "DIRTY"},
+	})
+
+	if len(results) != 0 {
+		t.Fatalf("results = %#v, want no release PRs", results)
+	}
+}
+
+func TestEvaluatePullRequestsCleanWithPendingChecksIsNotRepairActionable(t *testing.T) {
+	monitor := config.GitHubPRMonitor{
+		Name:         "main",
+		Owner:        "org",
+		Repo:         "repo",
+		BaseBranches: []string{"main"},
+		Rig:          "repo",
+		RepairRoute:  "repo/polecat",
+	}
+
+	results := EvaluatePullRequests(monitor, []PullRequest{
+		{
+			Number:           12,
+			BaseRefName:      "main",
+			MergeStateStatus: "CLEAN",
+			Checks:           []Check{{Name: "ci", Status: "QUEUED"}},
+		},
+	})
+
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Actionable {
+		t.Fatalf("Actionable = true for pending-only result: %#v", results[0])
+	}
+	if results[0].State != StatePending {
+		t.Fatalf("State = %q, want %q", results[0].State, StatePending)
+	}
+}
+
+func TestGraphQLDecodePullRequests(t *testing.T) {
+	body := strings.NewReader(`{
+		"data": {
+			"repository": {
+				"pullRequests": {
+					"pageInfo": {"hasNextPage": false, "endCursor": null},
+					"nodes": [{
+						"number": 2560,
+						"title": "Deploy",
+						"url": "https://github.com/partcleda/partcl/pull/2560",
+						"isDraft": false,
+						"mergeStateStatus": "BLOCKED",
+						"baseRefName": "main",
+						"headRefName": "fix",
+						"headRefOid": "abc123",
+						"commits": {
+							"nodes": [{
+								"commit": {
+									"oid": "abc123",
+									"statusCheckRollup": {
+										"contexts": {
+											"nodes": [
+												{"__typename":"CheckRun","checkName":"unit","status":"COMPLETED","conclusion":"SUCCESS","detailsUrl":"https://example.test/unit"},
+												{"__typename":"StatusContext","checkName":"deploy","state":"FAILURE","targetUrl":"https://example.test/deploy"}
+											]
+										}
+									}
+								}
+							}]
+						}
+					}]
+				}
+			}
+		}
+	}`)
+
+	prs, next, err := DecodePullRequestsPage(body)
+	if err != nil {
+		t.Fatalf("DecodePullRequestsPage: %v", err)
+	}
+	if next != "" {
+		t.Fatalf("next = %q, want empty", next)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("len(prs) = %d, want 1", len(prs))
+	}
+	got := prs[0]
+	if got.HeadSHA != "abc123" || got.MergeStateStatus != "BLOCKED" {
+		t.Fatalf("decoded PR = %#v", got)
+	}
+	if len(got.Checks) != 2 {
+		t.Fatalf("checks = %#v, want 2", got.Checks)
+	}
+	if got.Checks[1].Name != "deploy" || got.Checks[1].Conclusion != "FAILURE" {
+		t.Fatalf("status context = %#v, want normalized failing deploy check", got.Checks[1])
+	}
+}

--- a/internal/githubmonitor/testenv_import_test.go
+++ b/internal/githubmonitor/testenv_import_test.go
@@ -1,0 +1,3 @@
+package githubmonitor
+
+import _ "github.com/gastownhall/gascity/internal/testenv"

--- a/schemas/github/pr/backfill/result.schema.json
+++ b/schemas/github/pr/backfill/result.schema.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "ok",
+    "city_path",
+    "monitor_count",
+    "result_count",
+    "actionable_count",
+    "results"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1"
+    },
+    "ok": {
+      "const": true
+    },
+    "city_path": {
+      "type": "string"
+    },
+    "monitor_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "result_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "actionable_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "monitor",
+          "owner",
+          "repo",
+          "number",
+          "base_ref_name",
+          "state",
+          "actionable",
+          "rig",
+          "repair_route"
+        ],
+        "properties": {
+          "monitor": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "number": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "base_ref_name": {
+            "type": "string"
+          },
+          "head_ref_name": {
+            "type": "string"
+          },
+          "head_sha": {
+            "type": "string"
+          },
+          "merge_state_status": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "failure_kind": {
+            "type": "string"
+          },
+          "actionable": {
+            "type": "boolean"
+          },
+          "failed_checks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pending_checks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rig": {
+            "type": "string"
+          },
+          "repair_route": {
+            "type": "string"
+          },
+          "notify": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "repair_beads": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "pr", "created"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "pr": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          },
+          "created": {
+            "type": "boolean"
+          },
+          "route": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "existing_repairs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "created_repairs": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
Adds a typed GitHub PR monitor client/evaluator plus `gc github pr backfill` for configured `[[github.pr_monitor]]` entries. The command can report actionable PRs and create deduped repair beads routed to the configured repair target.\n\nLocal verification:\n- `GOTOOLCHAIN=auto go test ./internal/githubmonitor ./cmd/gc -run 'Test(GraphQLClient|EvaluatePullRequests|GitHubPRBackfillCommand|JSONSchemaManifestForSupportedCommand|JSONResultSchemasRequireSuccessDiscriminator)'`\n- `GOTOOLCHAIN=auto go vet ./internal/githubmonitor ./cmd/gc`\n- Live PartCL backfill: 24 actionable PRs, 24 deduped repair beads, repeat run created 0 duplicates\n\nNote: the repo-wide pre-commit hook was run and failed in this live checkout because the local Gas Town runtime has unstaged PartCL city config changes and untracked `examples/gastown/.gc/worktrees` Go worktrees, which cause unrelated example/boundary tests to fail. The staged monitor packages passed focused tests and vet.