### PR TITLE
fix(extmsg): port unmerged gc-kvt session_id propagation into origin/main

### DIFF
--- a/internal/extmsg/outbound.go
+++ b/internal/extmsg/outbound.go
@@ -120,7 +120,7 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 	// surface and PublishRequest is the gc-to-adapter wire contract; any
 	// future divergence (e.g. an internal-only OutboundRequest field)
 	// must not silently leak onto the wire.
-	receipt, err := adapter.Publish(ctx, PublishRequest{ //nolint:staticcheck // documents the wire boundary; see comment above
+	receipt, err := adapter.Publish(ctx, PublishRequest{ //nolint:staticcheck // S1016: field-by-field copy is intentional, not a struct conversion — see comment above
 		SessionID:        req.SessionID,
 		Conversation:     req.Conversation,
 		Text:             req.Text,

--- a/internal/extmsg/outbound.go
+++ b/internal/extmsg/outbound.go
@@ -9,6 +9,18 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 )
 
+// MetadataKeySourceSessionID is the reserved metadata key used to propagate
+// the originating gc session id across the publish wire to adapters.
+//
+// PublishRequest itself does not carry a SessionID field (intentional —
+// keeps the request shape provider-neutral). Adapters that need the
+// session id (e.g. for per-session identity overrides like Slack
+// chat:write.customize) read it from PublishRequest.Metadata using this
+// key. The key is unprefixed because user-supplied metadata is namespaced
+// under "meta." (see metadataPrefix); system-controlled keys live in the
+// bare namespace.
+const MetadataKeySourceSessionID = "source_session_id"
+
 // OutboundRequest specifies what to publish to an external conversation.
 type OutboundRequest struct {
 	SessionID        string
@@ -102,12 +114,25 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 	}
 
 	// Step 4: Publish.
+	//
+	// Inject the originating session id into wire metadata so adapters
+	// can route per-session behavior (e.g. Slack identity overrides)
+	// without PublishRequest needing a SessionID field. Done by copying
+	// the caller's metadata onto a new map so we don't mutate it.
+	wireMetadata := req.Metadata
+	if req.SessionID != "" {
+		wireMetadata = make(map[string]string, len(req.Metadata)+1)
+		for k, v := range req.Metadata {
+			wireMetadata[k] = v
+		}
+		wireMetadata[MetadataKeySourceSessionID] = req.SessionID
+	}
 	receipt, err := adapter.Publish(ctx, PublishRequest{
 		Conversation:     req.Conversation,
 		Text:             req.Text,
 		ReplyToMessageID: req.ReplyToMessageID,
 		IdempotencyKey:   req.IdempotencyKey,
-		Metadata:         req.Metadata,
+		Metadata:         wireMetadata,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("adapter publish: %w", err)

--- a/internal/extmsg/outbound.go
+++ b/internal/extmsg/outbound.go
@@ -9,16 +9,13 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 )
 
-// MetadataKeySourceSessionID is the reserved metadata key used to propagate
-// the originating gc session id across the publish wire to adapters.
-//
-// PublishRequest itself does not carry a SessionID field (intentional —
-// keeps the request shape provider-neutral). Adapters that need the
-// session id (e.g. for per-session identity overrides like Slack
-// chat:write.customize) read it from PublishRequest.Metadata using this
-// key. The key is unprefixed because user-supplied metadata is namespaced
-// under "meta." (see metadataPrefix); system-controlled keys live in the
-// bare namespace.
+// MetadataKeySourceSessionID was the reserved metadata key used to
+// propagate the originating gc session id across the publish wire before
+// PublishRequest gained a native SessionID field (gc-kvt). It is no
+// longer written by gc; it is retained here only because some adapter
+// binaries still fall back to it when PublishRequest.SessionID is empty
+// (e.g. an old gc binary publishing through a newer adapter). New code
+// must populate PublishRequest.SessionID directly.
 const MetadataKeySourceSessionID = "source_session_id"
 
 // OutboundRequest specifies what to publish to an external conversation.
@@ -113,26 +110,23 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 		return nil, fmt.Errorf("no adapter for %s/%s", req.Conversation.Provider, req.Conversation.AccountID)
 	}
 
-	// Step 4: Publish.
+	// Step 4: Publish. SessionID is propagated to the adapter as a
+	// first-class field on PublishRequest (gc-kvt); adapters that need
+	// per-session behavior (e.g. Slack identity overrides) read it
+	// directly. The caller-supplied metadata flows through unchanged.
 	//
-	// Inject the originating session id into wire metadata so adapters
-	// can route per-session behavior (e.g. Slack identity overrides)
-	// without PublishRequest needing a SessionID field. Done by copying
-	// the caller's metadata onto a new map so we don't mutate it.
-	wireMetadata := req.Metadata
-	if req.SessionID != "" {
-		wireMetadata = make(map[string]string, len(req.Metadata)+1)
-		for k, v := range req.Metadata {
-			wireMetadata[k] = v
-		}
-		wireMetadata[MetadataKeySourceSessionID] = req.SessionID
-	}
-	receipt, err := adapter.Publish(ctx, PublishRequest{
+	// Field-by-field assignment is intentional even though the structs
+	// currently share a shape — OutboundRequest is the API caller's input
+	// surface and PublishRequest is the gc-to-adapter wire contract; any
+	// future divergence (e.g. an internal-only OutboundRequest field)
+	// must not silently leak onto the wire.
+	receipt, err := adapter.Publish(ctx, PublishRequest{ //nolint:staticcheck // documents the wire boundary; see comment above
+		SessionID:        req.SessionID,
 		Conversation:     req.Conversation,
 		Text:             req.Text,
 		ReplyToMessageID: req.ReplyToMessageID,
 		IdempotencyKey:   req.IdempotencyKey,
-		Metadata:         wireMetadata,
+		Metadata:         req.Metadata,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("adapter publish: %w", err)

--- a/internal/extmsg/outbound_test.go
+++ b/internal/extmsg/outbound_test.go
@@ -107,6 +107,9 @@ func TestHandleOutbound_BindingPathUnchanged(t *testing.T) {
 	if len(adapter.publishs) != 1 {
 		t.Fatalf("adapter publishes = %d, want 1", len(adapter.publishs))
 	}
+	if adapter.publishs[0].SessionID != "sess-bound" {
+		t.Fatalf("adapter publish SessionID = %q, want sess-bound", adapter.publishs[0].SessionID)
+	}
 	if result.DeliveryContext == nil {
 		t.Fatalf("DeliveryContext = nil, want recorded")
 	}

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -153,7 +153,15 @@ type AdapterCapabilities struct {
 // and case-insensitive matching on the receiver does not bridge the
 // underscore difference (so `ReplyToMessageID` would not match the
 // adapter's `reply_to_message_id` tag and the field would silently zero).
+//
+// SessionID is the originating gc session id. Adapters that need it for
+// per-session behavior (e.g. Slack `chat:write.customize` identity
+// overrides) read this field directly. Until gc-kvt landed, gc forwarded
+// the session id under `Metadata["source_session_id"]` instead;
+// adapters may still honor that key as a legacy fallback for old gc
+// binaries, but new code should rely on SessionID.
 type PublishRequest struct {
+	SessionID        string            `json:"session_id,omitempty"`
 	Conversation     ConversationRef   `json:"conversation"`
 	Text             string            `json:"text"`
 	ReplyToMessageID string            `json:"reply_to_message_id,omitempty"`

--- a/internal/extmsg/types_wire_test.go
+++ b/internal/extmsg/types_wire_test.go
@@ -14,6 +14,7 @@ import (
 // This test fails loudly if the tags are removed or renamed.
 func TestPublishRequestSnakeCaseWire(t *testing.T) {
 	req := PublishRequest{
+		SessionID: "gc-1",
 		Conversation: ConversationRef{
 			Provider:       "slack",
 			ConversationID: "C123",
@@ -31,6 +32,7 @@ func TestPublishRequestSnakeCaseWire(t *testing.T) {
 	}
 
 	mustContain := []string{
+		`"session_id":"gc-1"`,
 		`"conversation":`,
 		`"text":"hello"`,
 		`"reply_to_message_id":"1700000000.000100"`,
@@ -44,6 +46,7 @@ func TestPublishRequestSnakeCaseWire(t *testing.T) {
 	}
 
 	mustNotContain := []string{
+		`"SessionID"`,
 		`"ReplyToMessageID"`,
 		`"IdempotencyKey"`,
 		`"Metadata"`,
@@ -54,6 +57,44 @@ func TestPublishRequestSnakeCaseWire(t *testing.T) {
 		if bytes.Contains(body, []byte(banned)) {
 			t.Errorf("PublishRequest JSON contains PascalCase key %q (tags missing or wrong)\nfull body: %s", banned, body)
 		}
+	}
+}
+
+// TestPublishRequestSessionIDOmitemptyWhenBlank asserts the gc-kvt native
+// SessionID field is omitted from the wire when empty, so direct
+// adapter-publish callers (smoke tests, raw curl, pack helpers) that
+// don't supply a session id produce the same wire shape they did before
+// the field was added.
+func TestPublishRequestSessionIDOmitemptyWhenBlank(t *testing.T) {
+	req := PublishRequest{
+		Conversation: ConversationRef{Provider: "slack", AccountID: "T0", ConversationID: "C0"},
+		Text:         "hi",
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(body, []byte(`"session_id"`)) {
+		t.Errorf("PublishRequest with empty SessionID should omit session_id key, got: %s", body)
+	}
+}
+
+// TestPublishRequestSessionIDRoundTrip asserts the gc-kvt SessionID
+// field decodes into the Go struct from a snake_case wire body — the
+// native path the slack adapter prefers over the legacy
+// metadata["source_session_id"] fallback.
+func TestPublishRequestSessionIDRoundTrip(t *testing.T) {
+	wire := []byte(`{
+		"session_id":"gc-pl-7",
+		"conversation":{"provider":"slack","account_id":"T0","conversation_id":"C0","kind":"room"},
+		"text":"hi"
+	}`)
+	var req PublishRequest
+	if err := json.Unmarshal(wire, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.SessionID != "gc-pl-7" {
+		t.Errorf("SessionID = %q, want %q", req.SessionID, "gc-pl-7")
 	}
 }
 


### PR DESCRIPTION
Brings origin/main into alignment with the deployed gas-city binary by porting two unmerged commits from the `gc-kvt` feature branch:

- `cd3726271` feat(extmsg): propagate source session id via wire metadata (gc-kvt prep)
- `bfd64511a` fix(extmsg): add native SessionID to PublishRequest, drop metadata workaround (gc-kvt)

## Motivation

`HandleOutbound → adapter.Publish` currently *does not propagate the publishing session* on origin/main — `PublishRequest` has no `session_id` field, and `req.SessionID` is used only for delivery/transcript records. Any consumer building gas-city from main therefore produces identity-less Slack posts at channel root with `as=""`, because the slack adapter falls back to the bot's default identity when `/publish` receives no session attribution.

The deployed binary running on ds-research already has these two commits (good posts carry `session=gc-XXXXX`, `as="<PL name>"`), but origin/main is behind. New deployments from main regress.

Headline mechanism: `adapter/main.go:1163-1175` falls back to `as=""` only when `req.SessionID == "" && req.Metadata.SourceSessionID == ""` — the bad posts bypass HandleOutbound and have no `extmsg.outbound` event.

A defense-in-depth guard for the slack adapter (fail closed on session-less `/publish`) is in flight as a separate PR on gastownhall/gascity-packs.

## What changed

3 files, +68/-25:

- `internal/extmsg/types.go` — `PublishRequest` gains `SessionID string \`json:"session_id,omitempty"\``; `MetadataKeySourceSessionID` kept as legacy-fallback const with updated doc comment.
- `internal/extmsg/outbound.go` — `HandleOutbound` populates the new field directly.
- `internal/extmsg/types_wire_test.go` — 3 wire-shape tests added:
  - `TestPublishRequestSnakeCaseWire` (extended with present/absent `session_id` assertions)
  - `TestPublishRequestSessionIDOmitemptyWhenBlank`
  - `TestPublishRequestSessionIDRoundTrip`

The 3rd commit on the source branch touched `examples/oversight-rig/adapter/main.go` with a doc-comment-only change; that directory was already deleted from origin/main, so the hunk was safely dropped.

## Gates

`make build` PASS; `make check` exit 0 against current origin/main base (`73ee09df`).

## Authorship

Cherry-picks preserve original `gc-kvt` authorship and commit messages on the production hunks. Test re-homing is a fresh commit on this branch.