### PR TITLE
docs: restore schema txt download links

### DIFF
--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -148,7 +148,7 @@ dir = "formulas"
 	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
 
 	var stdout, stderr bytes.Buffer
-	code := doDoctor(true, false, false, &stdout, &stderr)
+	code := doDoctor(true, false, false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("gc doctor --fix = %d, want 0; stdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
 	}
@@ -195,7 +195,7 @@ dir = "custom-formulas"
 	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
 
 	var stdout, stderr bytes.Buffer
-	code := doDoctor(true, false, false, &stdout, &stderr)
+	code := doDoctor(true, false, false, false, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("gc doctor --fix unexpectedly passed with custom formulas dir; stdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
 	}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,6 +70,26 @@
       "destination": "/guides/migrating-to-pack-vnext"
     },
     {
+      "source": "/schema/openapi.txt",
+      "destination": "/schema/openapi.json",
+      "permanent": false
+    },
+    {
+      "source": "/schema/events.txt",
+      "destination": "/schema/events.json",
+      "permanent": false
+    },
+    {
+      "source": "/schema/city-schema.txt",
+      "destination": "/schema/city-schema.json",
+      "permanent": false
+    },
+    {
+      "source": "/schema/pack-schema.txt",
+      "destination": "/schema/pack-schema.json",
+      "permanent": false
+    },
+    {
       "source": "/tutorials/01-cities-and-rigs.md",
       "destination": "/tutorials/01-cities-and-rigs"
     },

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -9,11 +9,11 @@ third-party client can do too — there is no hidden surface.
 
 ## Download the spec
 
-- **<a href="/schema/openapi.json" download="openapi.json">Download openapi.json</a>** —
+- **<a href="/schema/openapi.txt" download="openapi.json">Download openapi.json</a>** —
   the authoritative contract. Drop it into Stoplight, Postman,
   Swagger UI, or any OpenAPI-aware tool to browse operations
   interactively.
-- **<a href="/schema/events.json" download="events.json">Download events.json</a>** —
+- **<a href="/schema/events.txt" download="events.json">Download events.json</a>** —
   the `gc events` JSONL line schema. It references DTO components in
   `openapi.json`, so the API remains the source of truth.
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -156,7 +156,7 @@ payload objects. For example, use
 
 ## Machine-Readable Schema
 
-The downloadable <a href="/schema/events.json" download="events.json">events.json</a>
+The downloadable <a href="/schema/events.txt" download="events.json">events.json</a>
 schema validates one JSON object line from list, watch, or follow mode. It
 contains only framing metadata and `$ref`s into `openapi.json`:
 

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -4,8 +4,8 @@ description: Machine-readable schema artifacts published with the Gas City docs.
 ---
 
 This section publishes generated schema artifacts for tooling. The canonical
-JSON files stay in `docs/schema/`, and the download links below point at the
-served JSON artifacts so local preview and production both offer a working file
+JSON files stay in `docs/schema/`, and the download links below use text mirrors
+with hosted redirects so local preview and production both offer a working file
 download.
 
 ## OpenAPI 3.1
@@ -13,7 +13,7 @@ download.
 The supervisor HTTP and SSE control plane is published as a raw OpenAPI
 document:
 
-- <a href="/schema/openapi.json" download="openapi.json">Download <code>openapi.json</code></a>
+- <a href="/schema/openapi.txt" download="openapi.json">Download <code>openapi.json</code></a>
 
 Use this file with Swagger UI, Stoplight, Postman, or client generators. To
 regenerate it from the live supervisor schema:
@@ -30,7 +30,7 @@ the [Supervisor REST API](/reference/api) page.
 `gc events` list/watch/follow output is published as a small JSON Schema that
 references the OpenAPI DTO components instead of duplicating their fields:
 
-- <a href="/schema/events.json" download="events.json">Download <code>events.json</code></a>
+- <a href="/schema/events.txt" download="events.json">Download <code>events.json</code></a>
 
 Use this file to validate one JSON object line emitted by `gc events`,
 `gc events --watch`, or `gc events --follow`. Cursor mode is intentionally
@@ -46,7 +46,7 @@ behavior, heartbeat suppression, and cursor formats, see
 The `city.toml` configuration schema is also published as a raw JSON Schema
 document:
 
-- <a href="/schema/city-schema.json" download="city-schema.json">Download <code>city-schema.json</code></a>
+- <a href="/schema/city-schema.txt" download="city-schema.json">Download <code>city-schema.json</code></a>
 
 Use this file for validation, editor integration, and external tooling. To
 regenerate it:

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -49,8 +49,9 @@ var knownBrokenLinks = map[string]bool{
 	"contrib/session-scripts/README.md -> ../../docs/k8s-guide.md": true,
 }
 
-func TestSchemaDownloadLinksUsePublishedJSONArtifacts(t *testing.T) {
+func TestSchemaDownloadLinksUseTxtMirrorsWithHostedRedirects(t *testing.T) {
 	root := repoRoot()
+	redirects := schemaRedirects(t, root)
 	docs := []string{
 		"docs/reference/api.md",
 		"docs/reference/events.md",
@@ -65,19 +66,77 @@ func TestSchemaDownloadLinksUsePublishedJSONArtifacts(t *testing.T) {
 		}
 		for _, match := range schemaHrefRE.FindAllStringSubmatch(string(data), -1) {
 			target := match[1]
-			if filepath.Ext(target) == ".txt" {
-				t.Errorf("%s links /schema/%s; public schema downloads must use served JSON artifacts", rel, target)
+			if filepath.Ext(target) != ".txt" {
+				t.Errorf("%s links /schema/%s; local Mintlify preview serves schema downloads through .txt mirrors", rel, target)
 				continue
 			}
-			if filepath.Ext(target) != ".json" {
-				continue
+			txtArtifact := filepath.Join(root, "docs", "schema", filepath.FromSlash(target))
+			if _, err := os.Stat(txtArtifact); err != nil {
+				t.Errorf("%s links /schema/%s but %s is not committed: %v", rel, target, txtArtifact, err)
 			}
-			artifact := filepath.Join(root, "docs", "schema", filepath.FromSlash(target))
-			if _, err := os.Stat(artifact); err != nil {
-				t.Errorf("%s links /schema/%s but %s is not committed: %v", rel, target, artifact, err)
+
+			jsonTarget := strings.TrimSuffix(target, ".txt") + ".json"
+			jsonArtifact := filepath.Join(root, "docs", "schema", filepath.FromSlash(jsonTarget))
+			if _, err := os.Stat(jsonArtifact); err != nil {
+				t.Errorf("%s links /schema/%s but hosted redirect target %s is not committed: %v", rel, target, jsonArtifact, err)
+			}
+
+			source := "/schema/" + target
+			destination := "/schema/" + jsonTarget
+			if redirects[source] != destination {
+				t.Errorf("docs.json redirects[%q] = %q, want %q", source, redirects[source], destination)
 			}
 		}
 	}
+}
+
+func TestSchemaTxtMirrorsRedirectToHostedJSONArtifacts(t *testing.T) {
+	root := repoRoot()
+	redirects := schemaRedirects(t, root)
+	entries, err := os.ReadDir(filepath.Join(root, "docs", "schema"))
+	if err != nil {
+		t.Fatalf("read docs/schema: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".txt" {
+			continue
+		}
+		jsonName := strings.TrimSuffix(name, ".txt") + ".json"
+		jsonPath := filepath.Join(root, "docs", "schema", jsonName)
+		if _, err := os.Stat(jsonPath); err != nil {
+			t.Errorf("docs/schema/%s has no JSON artifact for hosted redirect: %v", name, err)
+			continue
+		}
+
+		source := "/schema/" + name
+		destination := "/schema/" + jsonName
+		if redirects[source] != destination {
+			t.Errorf("docs.json redirects[%q] = %q, want %q", source, redirects[source], destination)
+		}
+	}
+}
+
+func schemaRedirects(t *testing.T, root string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "docs", "docs.json"))
+	if err != nil {
+		t.Fatalf("read docs/docs.json: %v", err)
+	}
+	var docs struct {
+		Redirects []struct {
+			Source      string `json:"source"`
+			Destination string `json:"destination"`
+		} `json:"redirects"`
+	}
+	if err := json.Unmarshal(data, &docs); err != nil {
+		t.Fatalf("parse docs/docs.json: %v", err)
+	}
+	redirects := make(map[string]string, len(docs.Redirects))
+	for _, redirect := range docs.Redirects {
+		redirects[redirect.Source] = redirect.Destination
+	}
+	return redirects
 }
 
 func allDocsMarkdownFiles(root string) ([]string, error) {


### PR DESCRIPTION
## Summary
- restore docs download hrefs to the `.txt` schema mirrors so Mintlify local preview can serve them
- add hosted Mintlify redirects from `/schema/*.txt` to the supported `/schema/*.json` artifacts
- guard the local/hosted schema-link contract in docsync tests
- repair two stale `doDoctor` test calls from current `origin/main` so `cmd/gc` builds

## Verification
- `go test ./test/docsync`
- `npx -y -p node@22 -p mint@4.2.577 mint validate`
- local `mint dev` + `curl -I` for `/schema/openapi.txt`, `/schema/events.txt`, `/schema/city-schema.txt`, `/schema/pack-schema.txt`
- `make test-fast-parallel`
- `go vet ./...`
- `make check-docs`
- `make fmt-check`
- `make lint`
- `PROFILE=codex/tmux-cli make test-worker-core-phase2`
- `PROFILE=codex/tmux-cli make test-worker-core-phase2-real-transport`
- `make test-cmd-gc-process-parallel`