### PR TITLE
fix: quarantine fanouts with invalid expansion vars

### DIFF
--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -145,6 +145,9 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		}
 		fragment, err := formula.CompileExpansionFragment(context.Background(), bead.Metadata["gc.bond"], opts.FormulaSearchPaths, target, itemVars)
 		if err != nil {
+			if errors.Is(err, formula.ErrVarValidation) {
+				return ControlResult{}, fmt.Errorf("%w: %s: compiling fragment %d: %w", ErrControlGraphMalformed, bead.ID, index+1, err)
+			}
 			return ControlResult{}, fmt.Errorf("%s: compiling fragment %d: %w", bead.ID, index+1, err)
 		}
 		if opts.PrepareFragment != nil {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -880,6 +880,75 @@ func TestProcessFanoutReturnsMalformedForInvalidBondVars(t *testing.T) {
 	}
 }
 
+func TestProcessFanoutReturnsMalformedForMissingRequiredBondVar(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[vars.reviewer]
+required = true
+
+[vars.source_convoy_id]
+required = true
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+description = "Source {source_convoy_id}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare review items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"personas":[{"name":"architect"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Fan out review items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.control_for":  "demo.prepare-review-items",
+			"gc.for_each":     "output.personas",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	_, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if !errors.Is(err, ErrControlGraphMalformed) {
+		t.Fatalf("ProcessControl(fanout missing required bond var) err = %v, want %v", err, ErrControlGraphMalformed)
+	}
+	if !strings.Contains(err.Error(), `variable "source_convoy_id" is required`) {
+		t.Fatalf("ProcessControl error = %v, want missing source_convoy_id", err)
+	}
+}
+
 func TestReconcileTerminalScopedMemberReusesResolvedBodyForFailingScope(t *testing.T) {
 	t.Parallel()
 

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -2,6 +2,7 @@ package formula
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,6 +21,9 @@ const (
 	FormulaExtJSON       = ".formula.json"
 	FormulaExt           = FormulaExtJSON // Legacy alias for backwards compatibility
 )
+
+// ErrVarValidation reports invalid formula variable input.
+var ErrVarValidation = errors.New("variable validation failed")
 
 // Parser handles loading and resolving formulas.
 //
@@ -610,7 +614,7 @@ func formatVarValidationErrors(errs []string) error {
 	if len(errs) == 0 {
 		return nil
 	}
-	return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	return fmt.Errorf("%w:\n  - %s", ErrVarValidation, strings.Join(errs, "\n  - "))
 }
 
 // ApplyDefaults returns a new map with default values filled in.

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -1,6 +1,7 @@
 package formula
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -685,6 +686,9 @@ func TestValidateVars(t *testing.T) {
 			err := ValidateVars(formula, tt.values)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateVars() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !errors.Is(err, ErrVarValidation) {
+				t.Errorf("ValidateVars() error = %v, want ErrVarValidation", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Add a formula variable-validation sentinel so callers can classify missing required expansion vars.
- Treat fanout expansion variable validation failures as malformed control graphs so the control dispatcher quarantines them instead of retrying forever.
- Add regression coverage for parser classification and fanout quarantine behavior.

## Tests
- go test ./internal/formula -run "TestValidateVars|TestCompileExpansionFragmentValidatesRequiredVars"
- go test ./internal/dispatch -run "TestProcessFanoutReturnsMalformedFor(InvalidSourceOutputJSON|InvalidBondVars|MissingRequiredBondVar)|TestProcessFanoutSpawnsFragmentsAndClosesOnSecondPass"
- go test ./cmd/gc -run "TestRunControlDispatcherQuarantinesMalformed"
- pre-commit hook: lint-changed, go vet ./..., ./scripts/test-local-parallel fast