### PR TITLE
fix: count label-routed pool work in default pool demand

### DIFF
--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -144,6 +144,49 @@ func TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork(t *testing.T) {
 	}
 }
 
+func TestEvaluatePoolDefaultScaleCheckCountsPoolLabelReadyWork(t *testing.T) {
+	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")
+	if err != nil {
+		t.Skip("bd not installed")
+	}
+	jqPath, err := exec.LookPath("jq")
+	if err != nil {
+		t.Skip("jq not installed")
+	}
+	t.Setenv("PATH", filepath.Dir(bdPath)+":"+filepath.Dir(jqPath)+":"+os.Getenv("PATH"))
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	runExternal(t, dir, bdPath, "init", "-p", "ct", "--skip-hooks", "-q")
+
+	agent := &config.Agent{
+		Name:              "worker",
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: intPtr(3),
+	}
+
+	got, err := evaluatePool("worker", scaleParamsFor(agent), dir, nil, shellScaleCheck)
+	if err != nil {
+		t.Fatalf("evaluatePool without pooled label work: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("evaluatePool without pooled label work = %d, want 0", got)
+	}
+
+	runExternal(t, dir, bdPath, "create", "--json", "queued pooled worker job", "-t", "task",
+		"--labels", "pool:worker")
+
+	got, err = evaluatePool("worker", scaleParamsFor(agent), dir, nil, shellScaleCheck)
+	if err != nil {
+		t.Fatalf("evaluatePool with pooled label work: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("evaluatePool with pooled label work = %d, want 1", got)
+	}
+}
+
 func TestEvaluatePoolDefaultScaleCheckIgnoresRoutedActiveUnassignedWork(t *testing.T) {
 	skipSlowCmdGCTest(t, "uses real bd and jq for default scale_check coverage; run make test-cmd-gc-process for full coverage")
 	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2553,18 +2553,29 @@ func (a *Agent) AttachEnabled() bool {
 	return a.Attach == nil || *a.Attach
 }
 
-// bdReadyPoolDemandShell returns the bd ready predicate for unassigned,
-// non-epic pool demand routed to target. This is the one-source-of-truth for the
-// "is there work on this routed queue?" question that both the worker (via
-// EffectiveWorkQuery Tier 3) and the reconciler (via EffectivePoolDemandQuery,
-// count-form) ask. Diverging the two re-introduces the protocol-mismatch class;
-// see the "scale_check ↔ work_query correspondence" note in
+// bdReadyPoolDemandShell returns the shared bd ready predicate for
+// unassigned, non-epic pool demand routed to target. It checks the
+// metadata route first and falls back to pool:<target> labels for work
+// dispatched via label-only pool routing.
+//
+// This is the one-source-of-truth for the "is there work on this routed
+// queue?" question that both the worker (via EffectiveWorkQuery Tier 3)
+// and the reconciler (via EffectivePoolDemandQuery, count-form) ask.
+// Diverging the two re-introduces the protocol-mismatch class; see the
+// "scale_check ↔ work_query correspondence" note in
 // engdocs/architecture/dispatch.md.
 //
 // Callers append their own bd flags (--limit=1 for first-row work_query;
-// piped to jq 'length' for the count-form) and shell handling.
+// --limit 0 for the count-form) and shell handling.
 func bdReadyPoolDemandShell(target string) string {
-	return `bd ready --metadata-field gc.routed_to=` + target + ` --unassigned --exclude-type=epic --json`
+	return `sh -c 'r=$(bd ready --metadata-field gc.routed_to=` + target +
+		` --unassigned --exclude-type=epic --json "$@"); ` +
+		`if [ -n "$r" ] && [ "$r" != "[]" ]; then ` +
+		`printf "%s" "$r"; ` +
+		`else ` +
+		`bd ready --label pool:` + target +
+		` --unassigned --exclude-type=epic --json "$@"; ` +
+		`fi' --`
 }
 
 func (a *Agent) poolDemandTarget() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2088,6 +2088,9 @@ func TestEffectiveScaleCheckDefaults(t *testing.T) {
 	if !strings.Contains(check, "--unassigned") {
 		t.Errorf("EffectiveScaleCheck = %q, want --unassigned for new unassigned demand", check)
 	}
+	if !strings.Contains(check, "--label pool:refinery") {
+		t.Errorf("EffectiveScaleCheck = %q, want pool label fallback for refinery", check)
+	}
 	if !strings.Contains(check, "--exclude-type=epic") {
 		t.Errorf("EffectiveScaleCheck = %q, want --exclude-type=epic for executable demand only", check)
 	}


### PR DESCRIPTION
## Summary
- teach the shared default pool-demand helper to fall back from `gc.routed_to=<target>` to `pool:<target>` labels
- add regression coverage that `evaluatePool` counts label-routed ready work
- keep the newer ready-only demand contract intact on `main`

## Why
`EffectiveWorkQuery` and the reconciler pool-demand path are supposed to stay symmetric via the shared `bdReadyPoolDemandShell()` helper. On `main`, default pool demand only looked at `gc.routed_to=<target>`, so work dispatched via `pool:<target>` labels could be claimable once a worker was awake but would not create new controller demand.

This change keeps the current `main` contract of counting only new ready demand, but extends that shared predicate to treat label-routed pool work as equivalent demand.

## Verification
- `env GOCACHE=/private/tmp/gocache-pool-label GOTMPDIR=/private/tmp/gotmp-pool-label go test ./cmd/gc -run "^(TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork|TestEvaluatePoolDefaultScaleCheckCountsPoolLabelReadyWork|TestEvaluatePoolDefaultScaleCheckIgnoresRoutedActiveUnassignedWork)$" -count=1`
- `env GOCACHE=/private/tmp/gocache-pool-label GOTMPDIR=/private/tmp/gotmp-pool-label go test ./internal/config -run "^(TestEffectiveScaleCheckDefaults|TestEffectiveScaleCheckDefaultsQualified|TestEffectiveScaleCheckUsesReadyOnly|TestPoolDemandPredicateSharedWithWorkQuery|TestEffectiveWorkQueryExcludesEpics|TestEffectiveWorkQueryExcludesEpicsControlDispatcher)$" -count=1`