### PR TITLE
fix: bind managed local dolt to loopback

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -9108,6 +9108,9 @@ func TestGcBeadsBdStartUsesGCBinManagedConfigWriter(t *testing.T) {
 	if !strings.Contains(string(configData), "# rendered by fake gc") {
 		t.Fatalf("dolt-config.yaml was not rendered by GC_BIN:\n%s", string(configData))
 	}
+	if !strings.Contains(string(configData), "host: 127.0.0.1") {
+		t.Fatalf("dolt-config.yaml should bind managed local Dolt to loopback by default:\n%s", string(configData))
+	}
 	state, err := readDoltRuntimeStateFile(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt-from-gc", "dolt-provider-state.json"))
 	if err != nil {
 		t.Fatalf("readDoltRuntimeStateFile: %v", err)
@@ -9362,7 +9365,7 @@ func TestManagedDoltConfigGoWriterMatchesShellFallbackSemantics(t *testing.T) {
 		t.Fatal(err)
 	}
 	goConfigPath := filepath.Join(t.TempDir(), "go", "dolt-config.yaml")
-	if err := writeManagedDoltConfigFile(goConfigPath, "0.0.0.0", "3311", filepath.Join(cityPath, ".beads", "dolt"), "info", config.DoltConfig{}); err != nil {
+	if err := writeManagedDoltConfigFile(goConfigPath, "127.0.0.1", "3311", filepath.Join(cityPath, ".beads", "dolt"), "info", config.DoltConfig{}); err != nil {
 		t.Fatalf("writeManagedDoltConfigFile: %v", err)
 	}
 
@@ -11109,6 +11112,9 @@ func TestGcBeadsBdStartFallsBackToShellManagedConfigWriterWhenGCBinUnset(t *test
 	}
 	if strings.Contains(string(configData), "# rendered by fake gc") {
 		t.Fatalf("dolt-config.yaml should be rendered by shell fallback, not PATH gc:\n%s", string(configData))
+	}
+	if !strings.Contains(string(configData), "host: 127.0.0.1") {
+		t.Fatalf("dolt-config.yaml should bind managed local Dolt to loopback by default:\n%s", string(configData))
 	}
 	state, err := readDoltRuntimeStateFile(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt-provider-state.json"))
 	if err != nil {

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -13,7 +13,7 @@
 #   GC_PACK_STATE_DIR — canonical pack runtime root for dolt (optional)
 #   GC_DOLT       — set to "skip" to no-op all operations (exit 2)
 #   GC_BEADS_BACKEND — "dolt" (default) or "doltlite"
-#   GC_DOLT_HOST  — dolt server host (empty = local server)
+#   GC_DOLT_HOST  — dolt server host (empty = local loopback server)
 #   GC_DOLT_PORT  — dolt server port (default: ephemeral, hashed from city path)
 #   GC_DOLT_USER  — dolt user (default: root)
 #   GC_DOLT_PASSWORD — dolt password (default: empty)
@@ -24,7 +24,7 @@ set -e
 # --- Configuration ---
 
 # DOLT_PORT is set after derived paths are resolved (see allocate_port below).
-DOLT_HOST="${GC_DOLT_HOST:-0.0.0.0}"
+DOLT_HOST="${GC_DOLT_HOST:-127.0.0.1}"
 DOLT_USER="${GC_DOLT_USER:-root}"
 DOLT_PASSWORD="${GC_DOLT_PASSWORD:-}"
 DOLT_LOGLEVEL="${GC_DOLT_LOGLEVEL:-warning}"


### PR DESCRIPTION
## Summary
- default managed local Dolt listener host to `127.0.0.1` instead of `0.0.0.0`
- keep helper-backed and shell-fallback managed config generation aligned
- add regression coverage for the generated `dolt-config.yaml` host

## Why
A local managed Dolt server does not need to bind broadly. In constrained environments, the previous `0.0.0.0` default was brittle and caused `gc init` startup failures before repo-local packs could take over.

## Verification
- `env GOCACHE=/private/tmp/gocache-dolt-loopback GOTMPDIR=/private/tmp/gotmp-dolt-loopback go test ./cmd/gc -run "^(TestDoltConfigWriteManagedCmd|TestGcBeadsBdStartUsesGCBinManagedConfigWriter|TestGcBeadsBdStartFallsBackToShellManagedConfigWriterWhenGCBinUnset|TestManagedDoltConfigGoWriterMatchesShellFallbackSemantics)$" -count=1`

## Downstream proof
Using a binary built from this fix earlier in the investigation:
- the materialized managed Dolt config written during `gc init` contains `host: 127.0.0.1`
- `jurisdiction` test-city setup works again on the real `gc init` / `gc start` path when isolated from shared supervisor state
- `bash tests/acceptance/tier2-config.sh` passes
- `bash tests/acceptance/run-all.sh --tier 2` passes