### PR TITLE
docs(gc-dispatch): use `gc bd create --rig` for rig-scoped bead creation

### DIFF
--- a/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
@@ -35,12 +35,13 @@ so the rig's `.beads` database is found without manual intervention.
 
 **Beads must be in the agent's rig database.** Sling operates on the
 target agent's rig database — formula cooking, labeling, and convoy
-creation all happen there. Create beads with `--rig` so they land in
-the right database:
+creation all happen there. Create the bead in a specific rig's database
+with `gc bd create --rig <rig>`, which resolves the rig from city config
+and uses its database and prefix:
 
 ```
-bd create "fix the bug" --rig frontend   # Creates fe-xxx in frontend's db
-gc sling frontend/polecat fe-xxx         # Works — bead is in the right db
+gc bd create "fix the bug" --rig frontend   # Creates fe-xxx in frontend's db
+gc sling frontend/polecat fe-xxx            # Works — bead is in the right db
 ```
 
 If the bead is in the wrong database (e.g. `gc-xxx` in HQ but targeting


### PR DESCRIPTION
## Summary

The `gc-dispatch` skill documents `bd create "<title>" --rig <rig>` for creating a bead in a specific rig's database, but `bd create` has no `--rig` flag — that flag lives on the `gc bd` wrapper, which resolves the rig from city config before delegating to `bd`. Following the documented example fails with an unknown-flag error. This corrects the example to `gc bd create --rig <rig>` and tightens the surrounding wording.

## Change

- `internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md`: replace the `bd create ... --rig` example with `gc bd create ... --rig`, and reword the lead-in to state the rig is resolved from city config (using its database and prefix). The companion `gc sling` line is unchanged.

## What this does not solve

Documentation-only — no change to `bd`, `gc`, or any command behavior; it aligns the example with the flag that actually exists. The `gc-work` skill already uses the correct form, so it needs no change.

## Test plan

- [x] `gc bd create --rig <rig> --help` resolves the flag, whereas `bd create --rig` errors with an unknown flag.
- [x] `go vet ./internal/bootstrap/...` and `go test ./internal/bootstrap/...` pass.
- [ ] Maintainer confirms the reworded prose reads correctly.
