### PR TITLE
Disable Beads Dolt push paths for local-only gascity state

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -2,6 +2,10 @@ issue_prefix: ga
 issue-prefix: ga
 dolt.auto-start: false
 dolt.auto-push: false
+no-push: true
 export.auto: false
 gc.endpoint_origin: inherited_city
 gc.endpoint_status: verified
+types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step
+
+sync.remote: "git+https://github.com/gastownhall/gascity.git"

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,7 @@
+issue_prefix: ga
+issue-prefix: ga
+dolt.auto-start: false
+dolt.auto-push: false
+export.auto: false
+gc.endpoint_origin: inherited_city
+gc.endpoint_status: verified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,7 +342,6 @@ bd close <id>         # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```

--- a/release-gates/ga-3k2ax-dolt-local-only-closeout-gate.md
+++ b/release-gates/ga-3k2ax-dolt-local-only-closeout-gate.md
@@ -1,0 +1,36 @@
+# Release gate - local-only Beads closeout config (ga-3k2ax)
+
+**Verdict:** PASS
+
+- Deploy bead: `ga-3k2ax`
+- Branch: `builder/ga-oy52f-remove-dolt-push`
+- Final reviewed HEAD before gate commit: `a8fbc0fc0`
+- Included reviewed changes:
+  - `c36b1b666` - remove `bd dolt push` from `AGENTS.md`
+  - `ed08c431b` + `a8fbc0fc0` - add Beads config with `dolt.auto-push: false` and restore required defaults after review
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Reviewer PASS verdict in bead notes | PASS | `ga-whl55` records reviewer PASS for `c36b1b666`. `ga-3k2ax` records reviewer PASS for final config repair commit `a8fbc0fc0`. |
+| 2 | Acceptance criteria met | PASS | `AGENTS.md` session close block contains `git pull --rebase`, `git push`, and `git status`, with `bd dolt push` removed. `.beads/config.yaml` contains `dolt.auto-push: false` while preserving `no-push: true`, `types.custom`, and `sync.remote`. |
+| 3 | Tests pass on final branch | PASS | `make test` PASS; `go vet ./...` clean; `go test ./test/docsync` PASS; `git diff --check origin/main...HEAD` clean. |
+| 4 | No high-severity review findings open | PASS | `ga-whl55` reviewer found no blockers. `ga-3k2ax` reviewer listed only an INFO trailing-newline note. Earlier MEDIUM findings in `ga-f43h1` were fixed by `a8fbc0fc0` and re-reviewed PASS. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before adding this gate file; gate commit will be the only deployer-added change. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree `d8ee58d085d2820c0774e3593339fe8cb057f2d1`. |
+
+## Validation
+
+- `git diff --check origin/main...HEAD` - PASS
+- `git merge-tree --write-tree origin/main HEAD` - PASS
+- `make test` - PASS
+- `go vet ./...` - PASS
+- `go test ./test/docsync` - PASS
+
+## Review surface
+
+Reviewers should focus on the two local-only Beads surfaces:
+
+- `AGENTS.md` no longer tells gascity agents to run `bd dolt push` during session close.
+- `.beads/config.yaml` makes Beads background auto-push explicitly disabled while preserving the tracked default config entries.


### PR DESCRIPTION
## What this changes

Gascity agents no longer get told to run `bd dolt push` during session close. That keeps routine closeout focused on the Git branch push and avoids repeatedly trying to sync the local-only Beads Dolt store to the stale GitHub remote.

The repo also now carries `.beads/config.yaml` with `dolt.auto-push: false` while preserving the existing Beads defaults for `no-push`, custom bead types, and `sync.remote`. This disables Beads background auto-push even if the stale Dolt remote is re-registered during normal Beads writes.

## Review notes

- `.beads/config.yaml` is intentionally tracked here because it is the local-only Beads guardrail for this repo.
- This does not remove or repair the stale Dolt remote; it stops the session-close and background push paths that were producing expected failures.
- No runtime Go code paths change.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] `go test ./test/docsync`
- [x] `git diff --check origin/main...HEAD`
- [x] `git merge-tree --write-tree origin/main HEAD`
- [x] Release gate: [`release-gates/ga-3k2ax-dolt-local-only-closeout-gate.md`](release-gates/ga-3k2ax-dolt-local-only-closeout-gate.md)
