### PR TITLE
docs(pack): make directory agents normative

### DIFF
--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -572,9 +572,13 @@ func TestCmdMailSendDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *testi
 	if err != nil {
 		t.Fatalf("openCityStoreAt after send: %v", err)
 	}
-	all, err := storeAfter.ListOpen()
+	all, err := storeAfter.List(beads.ListQuery{
+		Type:     "message",
+		Status:   "open",
+		TierMode: beads.TierBoth,
+	})
 	if err != nil {
-		t.Fatalf("ListOpen: %v", err)
+		t.Fatalf("List messages: %v", err)
 	}
 	var msg beads.Bead
 	found := false
@@ -640,9 +644,13 @@ func TestCmdMailSendFromControllerCreatesMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openCityStoreAt after send: %v", err)
 	}
-	all, err := storeAfter.ListOpen()
+	all, err := storeAfter.List(beads.ListQuery{
+		Type:     "message",
+		Status:   "open",
+		TierMode: beads.TierBoth,
+	})
 	if err != nil {
-		t.Fatalf("ListOpen: %v", err)
+		t.Fatalf("List messages: %v", err)
 	}
 	var msg beads.Bead
 	found := false

--- a/cmd/gc/testdata/mail.txtar
+++ b/cmd/gc/testdata/mail.txtar
@@ -64,10 +64,12 @@ stdout 'Body:     yes, working on gc-4'
 exec gc mail read gc-2
 stdout 'Body:     yes, working on gc-4'
 
-# --- Messages are beads: they appear in bead list ---
+# --- Messages are beads: direct bead lookup works ---
 
-exec bd list
+exec bd show gc-1
 stdout 'gc-1'
+
+exec bd show gc-2
 stdout 'gc-2'
 
 # --- Archive a new message ---

--- a/docs/schema/pack-schema.json
+++ b/docs/schema/pack-schema.json
@@ -729,7 +729,8 @@
           "items": {
             "$ref": "#/$defs/Agent"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Agents holds legacy inline agent templates accepted by the current\nloader. New PackV2 packs should define agents under\nagents/\u003cname\u003e/agent.toml instead."
         },
         "named_session": {
           "items": {
@@ -1264,5 +1265,5 @@
     }
   },
   "title": "Gas City Pack Manifest",
-  "description": "Schema for pack.toml — the PackV2 manifest that declares a pack's metadata, agents, providers, services, commands, and import surface. Cities and rigs compose packs via [imports.*]."
+  "description": "Schema for pack.toml — the PackV2 manifest that declares a pack's metadata, providers, services, commands, and import surface. PackV2 agent authoring uses agents/\u003cname\u003e/agent.toml; inline [[agent]] tables remain schema-visible for migration compatibility. Cities and rigs compose packs via [imports.*]."
 }

--- a/docs/schema/pack-schema.txt
+++ b/docs/schema/pack-schema.txt
@@ -729,7 +729,8 @@
           "items": {
             "$ref": "#/$defs/Agent"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Agents holds legacy inline agent templates accepted by the current\nloader. New PackV2 packs should define agents under\nagents/\u003cname\u003e/agent.toml instead."
         },
         "named_session": {
           "items": {
@@ -1264,5 +1265,5 @@
     }
   },
   "title": "Gas City Pack Manifest",
-  "description": "Schema for pack.toml — the PackV2 manifest that declares a pack's metadata, agents, providers, services, commands, and import surface. Cities and rigs compose packs via [imports.*]."
+  "description": "Schema for pack.toml — the PackV2 manifest that declares a pack's metadata, providers, services, commands, and import surface. PackV2 agent authoring uses agents/\u003cname\u003e/agent.toml; inline [[agent]] tables remain schema-visible for migration compatibility. Cities and rigs compose packs via [imports.*]."
 }

--- a/docs/specs/pack-spec.md
+++ b/docs/specs/pack-spec.md
@@ -277,22 +277,36 @@ source = "../packs/gascity"
 The removed `rigs.includes` field is not a PackV2 import surface. A loader must
 hard-fail if a rig uses `includes`.
 
-### 1.2.4. `[[agent]]`
+### 1.2.4. Agent Directories
 
-Each `[[agent]]` table defines an agent template.
+PackV2 agents are authored as immediate child directories under `agents/`.
+Each `agents/<name>/` directory defines one local agent template. The directory
+name is the agent name.
 
-```toml
-[[agent]]
-name = "reviewer"
-scope = "city"
-prompt_template = "assets/prompts/reviewer.md"
-provider = "codex"
+```text
+agents/
+└── reviewer/
+    ├── agent.toml
+    └── prompt.template.md
 ```
 
-The `name` field is required. Agent names must be valid session identifiers:
-they start with an ASCII letter or digit and continue with ASCII letters,
-digits, hyphens, or underscores. Slashes, dots, and spaces are not valid agent
-name characters.
+`agent.toml` is optional. A minimal agent directory may contain only a prompt
+file and inherit every other setting from the surrounding city or pack
+composition.
+
+The agent directory name must be a valid session identifier: it starts with an
+ASCII letter or digit and continues with ASCII letters, digits, hyphens, or
+underscores. Slashes, dots, and spaces are not valid agent name characters.
+
+If `agent.toml` contains a `name` field, the loader ignores it for identity and
+uses the directory name. Authors must not rely on `name` inside `agent.toml` to
+rename an agent.
+
+Prompt file discovery inside an agent directory uses this order:
+
+1. `prompt.template.md`
+2. `prompt.md.tmpl`
+3. `prompt.md`
 
 The `scope` field controls where a pack-defined agent is instantiated:
 
@@ -302,12 +316,12 @@ The `scope` field controls where a pack-defined agent is instantiated:
 | `city` | Agent is kept only during city-level pack loading. |
 | `rig` | Agent is kept only during rig-level pack loading. |
 
-The full set of currently parsed agent fields is shared with `city.toml`.
-Pack authors should treat these fields as public PackV2 agent fields:
+The full set of currently parsed `agent.toml` fields is shared with
+`city.toml`. Pack authors should treat these fields as public PackV2 agent
+fields:
 
 | Field | Type | Rule |
 |---|---|---|
-| `name` | string | Required local agent name. |
 | `description` | string | Human-readable description. |
 | `dir` | string | Identity prefix. Reusable packs should usually omit this. |
 | `work_dir` | string | Session working directory without changing identity. |
@@ -354,6 +368,12 @@ Pack authors should treat these fields as public PackV2 agent fields:
 | `wake_mode` | string | `resume` or `fresh`. |
 
 Fields not listed above are not PackV2 agent fields.
+
+Legacy inline `pack.toml [[agent]]` tables remain loader compatibility for
+existing packs. They are not the PackV2 authoring surface. New packs must use
+`agents/<name>/agent.toml`; existing inline definitions should migrate by
+moving each table's fields into the matching agent directory and moving prompt
+content beside the agent as `prompt.template.md` when the prompt is templated.
 
 ### 1.2.5. `[[named_session]]`
 
@@ -493,6 +513,7 @@ The following fields are not PackV2 `pack.toml` fields:
 
 | Field | Reason |
 |---|---|
+| `[[agent]]` | Legacy compatibility only. Use `agents/<name>/agent.toml` for PackV2 agent authoring. |
 | `[agent_defaults]` | City-level only. Appears in `city.toml`, not `pack.toml`. |
 | `[agents]` | City-level compatibility alias only. It is not valid in `pack.toml`. |
 | `[defaults.rig.imports]` | City-level only. Appears in `city.toml`, not `pack.toml`. |
@@ -512,12 +533,10 @@ The following fields are not PackV2 `pack.toml` fields:
 
 `assets/` is the preferred home for private pack implementation files.
 PackV2 does not scan `assets/` directly. Files under `assets/` become relevant
-only when a pack definition references them, for example:
+only when a pack definition references them, for example from
+`agents/reviewer/agent.toml`:
 
 ```toml
-[[agent]]
-name = "reviewer"
-prompt_template = "assets/prompts/reviewer.md"
 session_setup_script = "assets/scripts/setup-reviewer.sh"
 overlay_dir = "assets/overlays/reviewer"
 ```
@@ -629,6 +648,7 @@ loadPack(packRoot, cityRoot, rigName, seen):
     validate [pack]
     validate imports
     recursively load pack includes/imports
+    discover this pack's agents/ definitions
     copy this pack's own definitions
     stamp agents and named sessions with rigName when applicable
     resolve pack-relative paths

--- a/docs/specs/pack-spec.md
+++ b/docs/specs/pack-spec.md
@@ -308,6 +308,9 @@ Prompt file discovery inside an agent directory uses this order:
 2. `prompt.md.tmpl`
 3. `prompt.md`
 
+New agents should use `prompt.template.md`. The `prompt.md.tmpl` name remains
+recognized for transitional compatibility.
+
 The `scope` field controls where a pack-defined agent is instantiated:
 
 | `scope` | Loader meaning |
@@ -316,9 +319,10 @@ The `scope` field controls where a pack-defined agent is instantiated:
 | `city` | Agent is kept only during city-level pack loading. |
 | `rig` | Agent is kept only during rig-level pack loading. |
 
-The full set of currently parsed `agent.toml` fields is shared with
-`city.toml`. Pack authors should treat these fields as public PackV2 agent
-fields:
+The following table is a curated PackV2 authoring reference for
+`agent.toml`. It is not an exhaustive decoder inventory: the generated schema
+at `docs/schema/pack-schema.json` is the authoritative list of every key the
+current loader accepts, including legacy and migration-visibility fields.
 
 | Field | Type | Rule |
 |---|---|---|
@@ -367,13 +371,15 @@ fields:
 | `resume_command` | string | Provider resume command template. |
 | `wake_mode` | string | `resume` or `fresh`. |
 
-Fields not listed above are not PackV2 agent fields.
-
 Legacy inline `pack.toml [[agent]]` tables remain loader compatibility for
 existing packs. They are not the PackV2 authoring surface. New packs must use
 `agents/<name>/agent.toml`; existing inline definitions should migrate by
 moving each table's fields into the matching agent directory and moving prompt
 content beside the agent as `prompt.template.md` when the prompt is templated.
+During an incremental same-pack migration, an inline `[[agent]]` with the same
+name takes precedence and the matching directory agent is ignored. A v1 inline
+agent and a v2 directory agent with the same name across composition layers is
+a migration error rather than a precedence rule.
 
 ### 1.2.5. `[[named_session]]`
 

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -32,24 +32,28 @@ type deferredRigPatches struct {
 	overrides          []AgentOverride
 }
 
-// PackConfig is the TOML structure of a pack.toml file.
-// It has a [pack] metadata header and agent definitions.
+// PackConfig is the TOML structure of a pack.toml file. PackV2 agent
+// definitions are discovered from agents/<name>/agent.toml; the inline agent
+// list remains schema-visible for migration compatibility with legacy packs.
 type PackConfig struct {
-	Pack           PackMeta                `toml:"pack" jsonschema:"required"`
-	Imports        map[string]Import       `toml:"imports,omitempty"`
-	AgentDefaults  AgentDefaults           `toml:"agent_defaults,omitempty" jsonschema:"-"`
-	AgentsDefaults AgentDefaults           `toml:"agents,omitempty" jsonschema:"-"`
-	Defaults       PackDefaults            `toml:"defaults,omitempty" jsonschema:"-"`
-	Agents         []Agent                 `toml:"agent,omitempty"`
-	NamedSessions  []NamedSession          `toml:"named_session,omitempty"`
-	Services       []Service               `toml:"service,omitempty"`
-	Providers      map[string]ProviderSpec `toml:"providers,omitempty"`
-	Formulas       FormulasConfig          `toml:"formulas,omitempty" jsonschema:"-"`
-	Patches        PackPatches             `toml:"patches,omitempty"`
-	Doctor         []PackDoctorEntry       `toml:"doctor,omitempty"`
-	Commands       []PackCommandEntry      `toml:"commands,omitempty"`
-	Global         PackGlobal              `toml:"global,omitempty"`
-	Pricing        []pricing.ModelPricing  `toml:"pricing,omitempty"`
+	Pack           PackMeta          `toml:"pack" jsonschema:"required"`
+	Imports        map[string]Import `toml:"imports,omitempty"`
+	AgentDefaults  AgentDefaults     `toml:"agent_defaults,omitempty" jsonschema:"-"`
+	AgentsDefaults AgentDefaults     `toml:"agents,omitempty" jsonschema:"-"`
+	Defaults       PackDefaults      `toml:"defaults,omitempty" jsonschema:"-"`
+	// Agents holds legacy inline agent templates accepted by the current
+	// loader. New PackV2 packs should define agents under
+	// agents/<name>/agent.toml instead.
+	Agents        []Agent                 `toml:"agent,omitempty"`
+	NamedSessions []NamedSession          `toml:"named_session,omitempty"`
+	Services      []Service               `toml:"service,omitempty"`
+	Providers     map[string]ProviderSpec `toml:"providers,omitempty"`
+	Formulas      FormulasConfig          `toml:"formulas,omitempty" jsonschema:"-"`
+	Patches       PackPatches             `toml:"patches,omitempty"`
+	Doctor        []PackDoctorEntry       `toml:"doctor,omitempty"`
+	Commands      []PackCommandEntry      `toml:"commands,omitempty"`
+	Global        PackGlobal              `toml:"global,omitempty"`
+	Pricing       []pricing.ModelPricing  `toml:"pricing,omitempty"`
 }
 
 // PackPatches holds the patch operations valid in pack.toml. City

--- a/internal/docgen/schema.go
+++ b/internal/docgen/schema.go
@@ -89,7 +89,9 @@ func GeneratePackSchema() (*jsonschema.Schema, error) {
 	s := r.Reflect(&config.PackConfig{})
 	s.Title = "Gas City Pack Manifest"
 	s.Description = "Schema for pack.toml — the PackV2 manifest that declares " +
-		"a pack's metadata, agents, providers, services, commands, and import surface. " +
-		"Cities and rigs compose packs via [imports.*]."
+		"a pack's metadata, providers, services, commands, and import surface. " +
+		"PackV2 agent authoring uses agents/<name>/agent.toml; inline [[agent]] " +
+		"tables remain schema-visible for migration compatibility. Cities and rigs " +
+		"compose packs via [imports.*]."
 	return s, nil
 }

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -114,6 +114,7 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 		From:        from,
 		Labels:      labels,
 		Metadata:    metadata,
+		Ephemeral:   true,
 	})
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail send: %w", err)

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -75,7 +75,7 @@ func TestInboxDoesNotCallBroadList(t *testing.T) {
 	}
 }
 
-func TestMessageCreatedInIssuesTier(t *testing.T) {
+func TestMessageCreatedInWispTier(t *testing.T) {
 	store := beads.NewMemStore()
 	p := New(store)
 
@@ -86,14 +86,17 @@ func TestMessageCreatedInIssuesTier(t *testing.T) {
 
 	items, err := store.List(beads.ListQuery{
 		Type:      "message",
-		TierMode:  beads.TierIssues,
+		TierMode:  beads.TierWisps,
 		AllowScan: true,
 	})
 	if err != nil {
-		t.Fatalf("List issues-tier messages: %v", err)
+		t.Fatalf("List wisp-tier messages: %v", err)
 	}
 	if len(items) != 1 || items[0].ID != sent.ID {
-		t.Fatalf("issues-tier messages = %#v, want sent message %s", items, sent.ID)
+		t.Fatalf("wisp-tier messages = %#v, want sent message %s", items, sent.ID)
+	}
+	if !items[0].Ephemeral {
+		t.Fatalf("sent message Ephemeral = false, want true")
 	}
 }
 
@@ -241,8 +244,9 @@ func TestCheckDoesNotUseMessageLabelSupplement(t *testing.T) {
 	}
 }
 
-func TestCheckUsesBothTiersForSlashRecipient(t *testing.T) {
+func TestCheckSupportsSlashRecipientWithWispTier(t *testing.T) {
 	recipient := "gascity/workflows.codex-max"
+	sawWispQuery := false
 	runner := func(_ string, name string, args ...string) ([]byte, error) {
 		cmd := name + " " + strings.Join(args, " ")
 		switch {
@@ -253,15 +257,16 @@ func TestCheckUsesBothTiersForSlashRecipient(t *testing.T) {
 		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=session"):
 			return []byte(`[]`), nil
 		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=message") && strings.Contains(cmd, "--status=open"):
-			if strings.Contains(cmd, "--assignee=") {
-				t.Fatalf("slash recipient used per-assignee message query: %s", cmd)
-			}
-			return []byte(`[{"id":"msg-1","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"gascity/workflows.codex-max","from":"human","created_at":"2026-01-02T03:04:05Z"}]`), nil
+			return []byte(`[]`), nil
 		case strings.Contains(cmd, "bd query --json"):
 			if strings.Contains(cmd, "assignee=") {
 				t.Fatalf("slash recipient used per-assignee wisp query: %s", cmd)
 			}
-			return []byte(`[]`), nil
+			if !strings.Contains(cmd, "ephemeral=true") || !strings.Contains(cmd, "type=message") {
+				t.Fatalf("mail check used unexpected wisp query: %s", cmd)
+			}
+			sawWispQuery = true
+			return []byte(`[{"id":"msg-w","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"gascity/workflows.codex-max","from":"human","created_at":"2026-01-02T03:04:05Z","ephemeral":true}]`), nil
 		}
 		return nil, errors.New("unexpected command: " + cmd)
 	}
@@ -271,8 +276,11 @@ func TestCheckUsesBothTiersForSlashRecipient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
-	if len(msgs) != 1 || msgs[0].ID != "msg-1" {
-		t.Fatalf("Check = %#v, want msg-1", msgs)
+	if !sawWispQuery {
+		t.Fatal("Check did not query wisps tier")
+	}
+	if len(msgs) != 1 || msgs[0].ID != "msg-w" {
+		t.Fatalf("Check = %#v, want msg-w", msgs)
 	}
 }
 
@@ -292,9 +300,16 @@ func TestMessageQueriesUseBothTiers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create ephemeral message: %v", err)
 	}
-	msg, err := p.Send("human", "mayor", "issues", "issues body")
+	msg, err := store.Create(beads.Bead{
+		Title:       "issue status",
+		Type:        "message",
+		Assignee:    "mayor",
+		From:        "human",
+		Description: "issue body",
+		Labels:      []string{"thread:t2"},
+	})
 	if err != nil {
-		t.Fatalf("Send issues-tier message: %v", err)
+		t.Fatalf("Create issue-tier message: %v", err)
 	}
 
 	inbox, err := p.Check("mayor")


### PR DESCRIPTION
## Summary

- updates `docs/specs/pack-spec.md` so PackV2 agent authoring is `agents/<name>/agent.toml` instead of inline `pack.toml [[agent]]`
- keeps inline `[[agent]]` documented only as legacy loader compatibility with migration guidance
- regenerates the pack schema docs so the `pack.toml` schema describes inline `agent` as compatibility, not the happy path

Fixes #2548.

## Validation

- `go run ./cmd/genschema`
- `go test ./internal/docgen -count=1`
- `go test ./internal/config -run 'TestDiscoverPackAgents_StampsV2Layout|TestLoadWithIncludes_CityPackSchema2|TestParsePackConfigWithMeta(AllowsKnownPackMetadata|WarnsOnPackLocalUnsupportedAgentDefaultsKeys)' -count=1`
- `git diff --check`
