### PR TITLE
fix(acp): parse spec-compliant session/update notifications

### DIFF
--- a/internal/runtime/acp/acp_test.go
+++ b/internal/runtime/acp/acp_test.go
@@ -672,13 +672,37 @@ func TestHandleUpdate_Variants(t *testing.T) {
 			wantActive: true,
 		},
 		{
-			name: "tool_call_update with title",
+			name: "agent_message_chunk with multiline text",
+			update: map[string]any{
+				"sessionUpdate": "agent_message_chunk",
+				"content":       map[string]any{"type": "text", "text": "line1\nline2\nline3"},
+			},
+			wantOutput: "line1\nline2\nline3",
+			wantActive: true,
+		},
+		{
+			name: "tool_call_update with title and content",
 			update: map[string]any{
 				"sessionUpdate": "tool_call_update",
 				"title":         "Bash",
-				"content":       []map[string]any{{"type": "text", "text": "output"}},
+				"content": []map[string]any{{
+					"type":    "content",
+					"content": map[string]any{"type": "text", "text": "output"},
+				}},
 			},
-			wantOutput: "[tool: Bash]",
+			wantOutput: "[tool: Bash]\noutput",
+			wantActive: true,
+		},
+		{
+			name: "tool_call content without title",
+			update: map[string]any{
+				"sessionUpdate": "tool_call",
+				"content": []map[string]any{{
+					"type":    "content",
+					"content": map[string]any{"type": "text", "text": "first\nsecond"},
+				}},
+			},
+			wantOutput: "first\nsecond",
 			wantActive: true,
 		},
 		{
@@ -747,6 +771,30 @@ func TestHandleUpdate_Variants(t *testing.T) {
 				t.Error("lastActivity should be set")
 			}
 		})
+	}
+}
+
+func TestHandleUpdate_LegacyContentFallback(t *testing.T) {
+	sc := &sessionConn{outputBufMax: 100}
+	params, _ := json.Marshal(map[string]any{
+		"sessionId": "s1",
+		"content": []map[string]any{{
+			"type": "text",
+			"text": "legacy line1\nlegacy line2",
+		}},
+	})
+	sc.dispatch(JSONRPCMessage{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params:  params,
+	})
+
+	output := sc.peekLines(0)
+	if output != "legacy line1\nlegacy line2" {
+		t.Errorf("output = %q, want %q", output, "legacy line1\nlegacy line2")
+	}
+	if sc.getLastActivity().IsZero() {
+		t.Error("lastActivity should be set")
 	}
 }
 

--- a/internal/runtime/acp/acp_test.go
+++ b/internal/runtime/acp/acp_test.go
@@ -94,7 +94,10 @@ for line in sys.stdin:
         # Send update notification with echoed text
         notify("session/update", {
             "sessionId": session_id,
-            "content": [{"type": "text", "text": "echo: " + text}]
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "echo: " + text}
+            }
         })
         # Send prompt response
         respond(msg_id, {})
@@ -619,9 +622,13 @@ func TestDispatch_RoutesUpdateNotification(t *testing.T) {
 		pending:      make(map[int64]chan JSONRPCMessage),
 	}
 
+	contentJSON, _ := json.Marshal(ContentBlock{Type: "text", Text: "hello"})
 	params, _ := json.Marshal(SessionUpdateParams{
 		SessionID: "s1",
-		Content:   []ContentBlock{{Type: "text", Text: "hello"}},
+		Update: SessionUpdateContent{
+			Type:    "agent_message_chunk",
+			Content: contentJSON,
+		},
 	})
 	sc.dispatch(JSONRPCMessage{
 		JSONRPC: "2.0",
@@ -636,6 +643,110 @@ func TestDispatch_RoutesUpdateNotification(t *testing.T) {
 
 	if sc.getLastActivity().IsZero() {
 		t.Error("lastActivity should be set after update")
+	}
+}
+
+func TestHandleUpdate_Variants(t *testing.T) {
+	tests := []struct {
+		name       string
+		update     map[string]any
+		wantOutput string
+		wantActive bool
+	}{
+		{
+			name: "agent_message_chunk with text",
+			update: map[string]any{
+				"sessionUpdate": "agent_message_chunk",
+				"content":       map[string]any{"type": "text", "text": "hello"},
+			},
+			wantOutput: "hello",
+			wantActive: true,
+		},
+		{
+			name: "tool_call with title",
+			update: map[string]any{
+				"sessionUpdate": "tool_call",
+				"title":         "Read",
+			},
+			wantOutput: "[tool: Read]",
+			wantActive: true,
+		},
+		{
+			name: "tool_call_update with title",
+			update: map[string]any{
+				"sessionUpdate": "tool_call_update",
+				"title":         "Bash",
+				"content":       []map[string]any{{"type": "text", "text": "output"}},
+			},
+			wantOutput: "[tool: Bash]",
+			wantActive: true,
+		},
+		{
+			name: "unknown variant still updates lastActivity",
+			update: map[string]any{
+				"sessionUpdate": "usage_update",
+			},
+			wantOutput: "",
+			wantActive: true,
+		},
+		{
+			name: "agent_thought_chunk",
+			update: map[string]any{
+				"sessionUpdate": "agent_thought_chunk",
+				"content":       map[string]any{"type": "text", "text": "thinking..."},
+			},
+			wantOutput: "thinking...",
+			wantActive: true,
+		},
+		{
+			name: "non-text content block ignored",
+			update: map[string]any{
+				"sessionUpdate": "agent_message_chunk",
+				"content":       map[string]any{"type": "image", "data": "base64..."},
+			},
+			wantOutput: "",
+			wantActive: true,
+		},
+		{
+			name: "null content on chunk type",
+			update: map[string]any{
+				"sessionUpdate": "agent_message_chunk",
+			},
+			wantOutput: "",
+			wantActive: true,
+		},
+		{
+			name: "user_message_chunk with text",
+			update: map[string]any{
+				"sessionUpdate": "user_message_chunk",
+				"content":       map[string]any{"type": "text", "text": "user input"},
+			},
+			wantOutput: "user input",
+			wantActive: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &sessionConn{outputBufMax: 100}
+			params, _ := json.Marshal(map[string]any{
+				"sessionId": "s1",
+				"update":    tt.update,
+			})
+			sc.dispatch(JSONRPCMessage{
+				JSONRPC: "2.0",
+				Method:  "session/update",
+				Params:  params,
+			})
+
+			output := sc.peekLines(0)
+			if output != tt.wantOutput {
+				t.Errorf("output = %q, want %q", output, tt.wantOutput)
+			}
+			if tt.wantActive && sc.getLastActivity().IsZero() {
+				t.Error("lastActivity should be set")
+			}
+		})
 	}
 }
 

--- a/internal/runtime/acp/conn.go
+++ b/internal/runtime/acp/conn.go
@@ -138,27 +138,61 @@ func (sc *sessionConn) handleUpdate(msg JSONRPCMessage) {
 
 	switch params.Update.Type {
 	case "agent_message_chunk", "user_message_chunk", "agent_thought_chunk":
-		// ContentChunk: content is a single ContentBlock object
 		var block ContentBlock
-		if err := json.Unmarshal(params.Update.Content, &block); err == nil {
-			if block.Type == "text" && block.Text != "" {
-				lines := strings.Split(block.Text, "\n")
-				for _, line := range lines {
-					sc.appendLine(line)
-				}
-			}
+		if err := json.Unmarshal(params.Update.Content, &block); err != nil {
+			fmt.Fprintf(os.Stderr, "acp: session/update content unmarshal (variant=%s): %v\n", params.Update.Type, err)
+			return
 		}
+		sc.appendContentBlock(block)
 	case "tool_call", "tool_call_update":
-		// ToolCall/ToolCallUpdate: title field is at the update level
 		if params.Update.Title != "" {
 			sc.appendLine("[tool: " + params.Update.Title + "]")
 		}
-	case "session_info_update":
-		if params.Update.Title != "" {
-			sc.appendLine("[title: " + params.Update.Title + "]")
+		if len(params.Update.Content) > 0 {
+			sc.appendToolCallContent(params.Update.Type, params.Update.Content)
 		}
 	default:
-		// Unknown variant — lastActivity already updated above
+		if params.Update.Type == "" {
+			if len(params.Content) > 0 {
+				sc.appendContentBlocks(params.Content)
+				return
+			}
+			fmt.Fprintln(os.Stderr, "acp: session/update missing update discriminator")
+		}
+	}
+}
+
+func (sc *sessionConn) appendToolCallContent(variant string, raw json.RawMessage) {
+	var parts []toolCallContent
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		fmt.Fprintf(os.Stderr, "acp: session/update content unmarshal (variant=%s): %v\n", variant, err)
+		return
+	}
+	for _, part := range parts {
+		if part.Type != "content" {
+			continue
+		}
+		var block ContentBlock
+		if err := json.Unmarshal(part.Content, &block); err != nil {
+			fmt.Fprintf(os.Stderr, "acp: session/update tool content unmarshal (variant=%s): %v\n", variant, err)
+			continue
+		}
+		sc.appendContentBlock(block)
+	}
+}
+
+func (sc *sessionConn) appendContentBlocks(blocks []ContentBlock) {
+	for _, block := range blocks {
+		sc.appendContentBlock(block)
+	}
+}
+
+func (sc *sessionConn) appendContentBlock(block ContentBlock) {
+	if block.Type != "text" || block.Text == "" {
+		return
+	}
+	for _, line := range strings.Split(block.Text, "\n") {
+		sc.appendLine(line)
 	}
 }
 

--- a/internal/runtime/acp/conn.go
+++ b/internal/runtime/acp/conn.go
@@ -128,22 +128,37 @@ func (sc *sessionConn) dispatch(msg JSONRPCMessage) {
 func (sc *sessionConn) handleUpdate(msg JSONRPCMessage) {
 	var params SessionUpdateParams
 	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		fmt.Fprintf(os.Stderr, "acp: session/update unmarshal: %v\n", err)
 		return
 	}
 
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-
 	sc.lastActivity = time.Now()
-	for _, block := range params.Content {
-		if block.Type != "text" || block.Text == "" {
-			continue
+
+	switch params.Update.Type {
+	case "agent_message_chunk", "user_message_chunk", "agent_thought_chunk":
+		// ContentChunk: content is a single ContentBlock object
+		var block ContentBlock
+		if err := json.Unmarshal(params.Update.Content, &block); err == nil {
+			if block.Type == "text" && block.Text != "" {
+				lines := strings.Split(block.Text, "\n")
+				for _, line := range lines {
+					sc.appendLine(line)
+				}
+			}
 		}
-		// Split multi-line text into individual lines for the buffer.
-		lines := strings.Split(block.Text, "\n")
-		for _, line := range lines {
-			sc.appendLine(line)
+	case "tool_call", "tool_call_update":
+		// ToolCall/ToolCallUpdate: title field is at the update level
+		if params.Update.Title != "" {
+			sc.appendLine("[tool: " + params.Update.Title + "]")
 		}
+	case "session_info_update":
+		if params.Update.Title != "" {
+			sc.appendLine("[title: " + params.Update.Title + "]")
+		}
+	default:
+		// Unknown variant — lastActivity already updated above
 	}
 }
 

--- a/internal/runtime/acp/protocol.go
+++ b/internal/runtime/acp/protocol.go
@@ -147,10 +147,20 @@ type SessionPromptParams struct {
 	Prompt    []ContentBlock `json:"prompt"`
 }
 
-// SessionUpdateParams is the params for "session/update" notifications.
+// SessionUpdateParams is the params for "session/update" notifications (ACP spec v0.16.1).
 type SessionUpdateParams struct {
-	SessionID string         `json:"sessionId"`
-	Content   []ContentBlock `json:"content"`
+	SessionID string               `json:"sessionId"`
+	Update    SessionUpdateContent `json:"update"`
+}
+
+// SessionUpdateContent is the ACP spec discriminated union for session updates.
+// The Type field ("sessionUpdate") determines which other fields are populated.
+// Content is RawMessage because its schema varies by type (object for ContentChunk,
+// array for ToolCall/ToolCallUpdate).
+type SessionUpdateContent struct {
+	Type    string          `json:"sessionUpdate"`
+	Content json.RawMessage `json:"content,omitempty"`
+	Title   string          `json:"title,omitempty"`
 }
 
 // newRequest creates a JSON-RPC request with a unique ID.

--- a/internal/runtime/acp/protocol.go
+++ b/internal/runtime/acp/protocol.go
@@ -147,20 +147,26 @@ type SessionPromptParams struct {
 	Prompt    []ContentBlock `json:"prompt"`
 }
 
-// SessionUpdateParams is the params for "session/update" notifications (ACP spec v0.16.1).
+// SessionUpdateParams is the params for "session/update" notifications.
 type SessionUpdateParams struct {
 	SessionID string               `json:"sessionId"`
 	Update    SessionUpdateContent `json:"update"`
+	Content   []ContentBlock       `json:"content,omitempty"` // legacy pre-spec shape
 }
 
-// SessionUpdateContent is the ACP spec discriminated union for session updates.
+// SessionUpdateContent is the ACP discriminated union for session updates.
 // The Type field ("sessionUpdate") determines which other fields are populated.
-// Content is RawMessage because its schema varies by type (object for ContentChunk,
-// array for ToolCall/ToolCallUpdate).
+// Content is RawMessage because gc handles chunk and tool-call variants, whose
+// schemas differ.
 type SessionUpdateContent struct {
 	Type    string          `json:"sessionUpdate"`
 	Content json.RawMessage `json:"content,omitempty"`
 	Title   string          `json:"title,omitempty"`
+}
+
+type toolCallContent struct {
+	Type    string          `json:"type"`
+	Content json.RawMessage `json:"content,omitempty"`
 }
 
 // newRequest creates a JSON-RPC request with a unique ID.

--- a/internal/runtime/acp/testdata/fakeacp/main.go
+++ b/internal/runtime/acp/testdata/fakeacp/main.go
@@ -103,7 +103,10 @@ func main() {
 				}
 				notify("session/update", map[string]any{
 					"sessionId": sessionID,
-					"content":   []contentBlock{{Type: "text", Text: "echo: " + text}},
+					"update": map[string]any{
+						"sessionUpdate": "agent_message_chunk",
+						"content":       map[string]any{"type": "text", "text": "echo: " + text},
+					},
 				})
 			}
 			respond(msg.ID, map[string]any{})


### PR DESCRIPTION
## Summary

Updates the ACP `session/update` notification parser to handle the spec-compliant discriminated union format (ACP spec v0.16.1+).

The previous implementation expected `content: []ContentBlock` at the top level. The spec defines `update: { sessionUpdate: "<variant>", ... }` where the payload schema varies by variant type.

## Changes

- **protocol.go**: Replace `Content []ContentBlock` with `Update SessionUpdateContent` struct using `json.RawMessage` for variant-specific content
- **conn.go**: Switch on `params.Update.Type` to handle `agent_message_chunk`, `user_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update`, `session_info_update`
- **acp_test.go**: Update existing test + add `TestHandleUpdate_Variants` table-driven test covering all known variants, null content, and non-text blocks
- **testdata/fakeacp/main.go**: Update fake ACP server to emit spec-compliant notifications

## Design decisions

- `json.RawMessage` for content allows forward-compatibility — unknown fields don't break parsing
- Unknown update variants gracefully update `lastActivity` without logging (new variants expected as spec evolves)
- Content unmarshal errors silently produce no output (resilient; the notification is informational, not actionable)