### PR TITLE
fix(session): prevent self-close wedge in gc session close

### DIFF
--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -217,7 +218,12 @@ func (p *Provider) RunLive(name string, cfg runtime.Config) error {
 // IsRunning calls see the updated state immediately.
 func (p *Provider) Stop(name string) error {
 	p.tm.CloseHiddenAttachClient(name)
-	err := p.tm.KillSessionWithProcesses(name)
+	// Exclude the calling process from the kill set. When `gc session close`
+	// runs from inside the pane it is tearing down (the self-close path), the
+	// caller is a descendant of the pane leader; without exclusion it would be
+	// SIGTERMed mid-cleanup, leaving the agent alive and the bead un-closed.
+	// Excluding a caller that lives outside the pane is a harmless no-op.
+	err := p.tm.KillSessionWithProcessesExcluding(name, []string{strconv.Itoa(os.Getpid())})
 	if err != nil && (errors.Is(err, ErrSessionNotFound) || errors.Is(err, ErrNoServer)) {
 		return nil // idempotent
 	}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -619,9 +619,6 @@ func (t *Tmux) KillSessionWithProcessesExcluding(name string, excludePIDs []stri
 		// Get the process group ID
 		pgid := getProcessGroupID(pid)
 
-		// Collect all PIDs to kill (from multiple sources)
-		toKill := make(map[string]bool)
-
 		// 1. Get all descendant PIDs recursively (catches processes that called setsid())
 		descendants := getAllDescendants(pid)
 
@@ -629,9 +626,6 @@ func (t *Tmux) KillSessionWithProcessesExcluding(name string, excludePIDs []stri
 		knownPIDs := make(map[string]bool, len(descendants)+1)
 		knownPIDs[pid] = true
 		for _, dpid := range descendants {
-			if !exclude[dpid] {
-				toKill[dpid] = true
-			}
 			knownPIDs[dpid] = true
 		}
 
@@ -639,19 +633,16 @@ func (t *Tmux) KillSessionWithProcessesExcluding(name string, excludePIDs []stri
 		// Instead of adding ALL group members — which could include unrelated
 		// processes sharing the same PGID — we only add those that were reparented
 		// to init (PPID == 1), indicating they were likely children in our tree.
+		var reparented []string
 		if pgid != "" && pgid != "0" && pgid != "1" {
-			for _, member := range collectReparentedGroupMembers(pgid, knownPIDs) {
-				if !exclude[member] {
-					toKill[member] = true
-				}
-			}
+			reparented = collectReparentedGroupMembers(pgid, knownPIDs)
 		}
 
-		// Convert to slice for iteration
-		var killList []string
-		for p := range toKill {
-			killList = append(killList, p)
-		}
+		// Partition the discovered process set into the descendant/group PIDs to
+		// terminate and whether the pane leader should be killed, honoring the
+		// exclusion set. This decision is pure so it can be unit-tested without
+		// real processes (see computeExcludingKillSet).
+		killList, killPaneLeader := computeExcludingKillSet(pid, descendants, reparented, exclude)
 
 		// Send SIGTERM to all non-excluded processes
 		for _, dpid := range killList {
@@ -668,7 +659,7 @@ func (t *Tmux) KillSessionWithProcessesExcluding(name string, excludePIDs []stri
 
 		// Kill the pane process itself (may have called setsid() and detached)
 		// Only if not excluded
-		if !exclude[pid] {
+		if killPaneLeader {
 			_ = exec.Command("kill", "-TERM", pid).Run()
 			time.Sleep(processKillGracePeriod)
 			_ = exec.Command("kill", "-KILL", pid).Run()
@@ -683,6 +674,38 @@ func (t *Tmux) KillSessionWithProcessesExcluding(name string, excludePIDs []stri
 		return nil
 	}
 	return err
+}
+
+// computeExcludingKillSet partitions a discovered process set into the
+// descendant/group PIDs that should be terminated and whether the pane leader
+// itself should be terminated, honoring an exclusion set. It performs no I/O,
+// so the self-kill exclusion decision can be unit-tested without real
+// processes.
+//
+// exclude protects the calling process from being signaled before it finishes
+// its own cleanup. This is essential for the self-close path where
+// `gc session close` runs inside the very pane it is tearing down: the caller
+// is a descendant of the pane leader and, without exclusion, would receive
+// SIGTERM mid-cleanup — leaving the agent alive and the session bead un-closed.
+// Excluding a caller that lives outside the pane is a harmless no-op because it
+// is not present in the descendant or reparented sets.
+func computeExcludingKillSet(panePID string, descendants, reparented []string, exclude map[string]bool) (killList []string, killPaneLeader bool) {
+	toKill := make(map[string]bool, len(descendants)+len(reparented))
+	for _, dpid := range descendants {
+		if !exclude[dpid] {
+			toKill[dpid] = true
+		}
+	}
+	for _, member := range reparented {
+		if !exclude[member] {
+			toKill[member] = true
+		}
+	}
+	killList = make([]string, 0, len(toKill))
+	for p := range toKill {
+		killList = append(killList, p)
+	}
+	return killList, !exclude[panePID]
 }
 
 // collectReparentedGroupMembers returns process group members that have been

--- a/internal/runtime/tmux/tmux_unit_test.go
+++ b/internal/runtime/tmux/tmux_unit_test.go
@@ -1,6 +1,9 @@
 package tmux
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestProviderEnvSkipsEscapeForPiAlias(t *testing.T) {
 	if !providerEnvSkipsEscape("my-pi/tmux") {
@@ -11,5 +14,73 @@ func TestProviderEnvSkipsEscapeForPiAlias(t *testing.T) {
 func TestProviderEnvSkipsEscapeForCopilot(t *testing.T) {
 	if !providerEnvSkipsEscape("copilot") {
 		t.Fatal("copilot provider should skip pre-enter Escape")
+	}
+}
+
+// TestComputeExcludingKillSet_SelfCloseExcludesCallerKeepsAgent locks in the
+// fix for the self-close wedge: when `gc session close` runs from inside the
+// pane it is tearing down, the caller is a descendant of the pane leader (the
+// agent). The caller must be excluded from the TERM list so it survives long
+// enough to finish cleanup, while the pane leader (agent) is still reached.
+func TestComputeExcludingKillSet_SelfCloseExcludesCallerKeepsAgent(t *testing.T) {
+	const (
+		agentPID  = "100" // pane leader (e.g. the coding agent) — must be killed
+		shellPID  = "101" // intermediate shell spawned by the agent
+		callerPID = "102" // gc session close — the excluded caller
+	)
+	exclude := map[string]bool{callerPID: true}
+
+	killList, killPaneLeader := computeExcludingKillSet(
+		agentPID,
+		[]string{shellPID, callerPID},
+		nil,
+		exclude,
+	)
+
+	if !killPaneLeader {
+		t.Error("pane leader (agent) must be killed, but it was reported excluded")
+	}
+	if slices.Contains(killList, callerPID) {
+		t.Errorf("caller %s must be excluded from TERM list, got %v", callerPID, killList)
+	}
+	if !slices.Contains(killList, shellPID) {
+		t.Errorf("non-excluded descendant %s must be in TERM list, got %v", shellPID, killList)
+	}
+}
+
+// TestComputeExcludingKillSet_ExternalCallerKillsEverything verifies that when
+// the caller lives outside the pane (e.g. the supervisor running the close),
+// excluding its PID is a harmless no-op: every process in the pane's tree is
+// still terminated.
+func TestComputeExcludingKillSet_ExternalCallerKillsEverything(t *testing.T) {
+	const agentPID = "200"
+	exclude := map[string]bool{"999": true} // external caller, not in the pane tree
+
+	killList, killPaneLeader := computeExcludingKillSet(
+		agentPID,
+		[]string{"201"},
+		[]string{"202"},
+		exclude,
+	)
+
+	if !killPaneLeader {
+		t.Error("pane leader must be killed for an external caller")
+	}
+	if !slices.Contains(killList, "201") || !slices.Contains(killList, "202") {
+		t.Errorf("all pane descendants must be killed, got %v", killList)
+	}
+}
+
+// TestComputeExcludingKillSet_ExcludedPaneLeaderSurvives guards the degenerate
+// case where the pane leader itself is in the exclusion set: it must not be
+// signaled directly (the final tmux kill-session reaps it instead).
+func TestComputeExcludingKillSet_ExcludedPaneLeaderSurvives(t *testing.T) {
+	const agentPID = "300"
+	exclude := map[string]bool{agentPID: true}
+
+	_, killPaneLeader := computeExcludingKillSet(agentPID, nil, nil, exclude)
+
+	if killPaneLeader {
+		t.Error("an excluded pane leader must not be killed directly")
 	}
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -886,9 +886,15 @@ func (m *Manager) CloseDetailed(id string) (CloseResult, error) {
 			return err
 		}
 
-		// Best-effort stop cleans up any live runtime and allows auto.Provider
-		// to discard stale ACP route entries for suspended sessions as well.
-		_ = m.sp.Stop(sessName)
+		// Stop the live runtime before marking the bead closed. Stop is
+		// idempotent for an already-gone session (returns nil), which also lets
+		// auto.Provider discard stale ACP route entries for suspended sessions.
+		// A genuine terminate failure must propagate and leave the bead open
+		// rather than report a "closed but still running" session — swallowing
+		// it here previously masked exactly that wedge.
+		if err := m.sp.Stop(sessName); err != nil {
+			return fmt.Errorf("stopping runtime for session %s: %w", id, err)
+		}
 		nudgeIDs, capped, err := CancelWaitsAndCollectNudgeIDs(m.store, id, time.Now().UTC())
 		if err != nil {
 			log.Printf("session %s: closing after wait cancellation lookup failed: %v", id, err)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -4199,3 +4199,59 @@ func TestEnsureRunning_StartupDeathClearMetadataFailurePropagates(t *testing.T) 
 		t.Fatal("session_key should remain set after failed metadata clear")
 	}
 }
+
+// TestCloseDetailed_StopErrorLeavesBeadOpen verifies the secondary fix for the
+// self-close wedge: when the runtime terminate genuinely fails, CloseDetailed
+// must propagate the error and leave the bead open rather than reporting a
+// "closed but still running" session. The previous code discarded the Stop
+// error and closed the bead unconditionally.
+func TestCloseDetailed_StopErrorLeavesBeadOpen(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Arm a non-idempotent terminate failure (not "session gone").
+	sp.StopErrors[info.SessionName] = errors.New("kill failed")
+
+	if _, err := mgr.CloseDetailed(info.ID); err == nil {
+		t.Fatal("CloseDetailed: expected error when runtime Stop fails, got nil")
+	}
+
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if b.Status == "closed" {
+		t.Error("bead was closed despite the runtime Stop failing")
+	}
+}
+
+// TestCloseDetailed_StopSuccessClosesBead is the happy-path companion: when the
+// runtime terminate succeeds, the bead closes normally.
+func TestCloseDetailed_StopSuccessClosesBead(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := mgr.CloseDetailed(info.ID); err != nil {
+		t.Fatalf("CloseDetailed: %v", err)
+	}
+
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if b.Status != "closed" {
+		t.Errorf("bead Status = %q, want closed", b.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Fix the `gc session close` self-close wedge: when a polecat closes its own session from inside the pane (mandated by the polecat prompt running `gc session close $GC_SESSION_ID`), the in-process kill TERMs all pane descendants — INCLUDING the caller `gc` itself — before reaching the agent process or `store.Close`. Result: agent survives, bead stays active, command returns ~0. Only recovery is an external `gc session reset polecat-N` from outside the pane.

## Root cause

- `gc session close` runs in-process (`cmd/gc/cmd_session.go:1677`), not via supervisor API.
- `Provider.Stop` calls `KillSessionWithProcesses` (`internal/runtime/tmux/adapter.go:220`), which SIGTERMs all pane descendants first (`internal/runtime/tmux/tmux.go:568-570`) and the pane leader last (`internal/runtime/tmux/tmux.go:581`).
- When the caller `gc` is itself a pane descendant (self-close case), it gets TERM'd before the loop reaches the agent kill and before `manager.go:880` runs `store.Close`.

Live-reproed on production polecats; 5+ instances observed in the 24h before the fix.

The fix primitive already existed at `tmux.go:600` (`KillSessionWithProcessesExcluding`) — its own doc comment describes exactly this self-kill scenario. The close path just didn't use it.

Secondary defect addressed: `manager.go:864` `_ = m.sp.Stop()` swallowed the terminate error and closed the bead regardless. Now propagates.

## What changed

- **`internal/runtime/tmux/adapter.go`** — `Provider.Stop` now calls `KillSessionWithProcessesExcluding(name, [os.Getpid()])` instead of the non-excluding variant. The self-closing caller is excluded from the descendant-TERM sweep, so it survives to reach the pane-leader/agent kill and let `Manager.CloseDetailed` run `store.Close`. Excluding an out-of-pane caller is a no-op, so reconciler/supervisor closes are unaffected.
- **`internal/runtime/tmux/tmux.go`** — extracted pure helper `computeExcludingKillSet` (no I/O) so the exclusion decision is unit-testable.
- **`internal/session/manager.go`** — `CloseDetailed` no longer discards `m.sp.Stop()` error. Genuine terminate failures propagate and the bead stays OPEN instead of closed-but-running. `auto.Provider.Stop` already propagates non-session-gone errors, so this is effective end-to-end.

## Tests

TDD: RED confirmed first.

- `TestComputeExcludingKillSet_SelfCloseExcludesCallerKeepsAgent`
- `TestComputeExcludingKillSet_ExternalCallerKillsEverything`
- `TestComputeExcludingKillSet_ExcludedPaneLeaderSurvives`
- `TestCloseDetailed_StopErrorLeavesBeadOpen`
- `TestCloseDetailed_StopSuccessClosesBead`

## Scope

Minimal — self-close path only. Other `KillSessionWithProcesses` callers (reconciler reaper, startup `killSession`, tmux cleanup) left untouched — they're external-caller paths and `Excluding(<empty>)` would be a no-op anyway.

## Gates

On changed packages:
- `go build ./...` OK
- `go vet -tags integration ./...` OK
- `make lint-changed` 0 issues
- `go test ./internal/runtime/tmux ./internal/session` OK
- `gofmt` clean
