### PR TITLE
fix: preserve reaper Dolt error tails

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3249,6 +3249,73 @@ exit 0
 	}
 }
 
+func TestReaperFailureAnomalyPreservesDoltErrorTail(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"DELETE FROM "*"wisps"*)
+    printf 'stdout-query-preview:'
+    i=0
+    while [ "$i" -lt 700 ]; do
+      printf 'Q'
+      i=$((i + 1))
+    done
+    printf '\n'
+    printf 'Error 1105 (HY000): dependencies.depends_on_wisp_id missing from schema\n' >&2
+    exit 42
+    ;;
+  *"status = 'closed'"*"closed_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "purging closed wisps failed for beads") {
+		t.Fatalf("reaper did not escalate failed purge:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "Error 1105 (HY000): dependencies.depends_on_wisp_id missing from schema") {
+		t.Fatalf("reaper escalation lost Dolt stderr error tail:\n%s", gcLogText)
+	}
+}
+
 func TestReaperCommitReportsOnlySuccessfulPurgeRows(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -128,7 +128,7 @@ SESSION_PRUNE_ATTEMPTED=0
 ANOMALIES=""
 
 sanitize_output() {
-    printf '%s' "$1" | tr '\n' ' ' | cut -c1-500
+    printf '%s' "$1" | tr '\n' ' ' | cut -c1-4000
 }
 
 record_anomaly() {
@@ -215,7 +215,7 @@ get_sql_count() {
     if ! output=$(dolt_sql -r csv -q "$query" 2>"$stderr_file"); then
         stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
         rm -f "$stderr_file"
-        record_anomaly "$db" "$label count failed for $db: $(sanitize_output "$output $stderr_output")"
+        record_anomaly "$db" "$label count failed for $db: $(sanitize_output "$stderr_output $output")"
         return 0
     fi
     rm -f "$stderr_file"
@@ -246,7 +246,7 @@ get_sql_rows() {
     if ! output=$(dolt_sql -r csv -q "$query" 2>"$stderr_file"); then
         stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
         rm -f "$stderr_file"
-        record_anomaly "$db" "$label query failed for $db: $(sanitize_output "$output $stderr_output")"
+        record_anomaly "$db" "$label query failed for $db: $(sanitize_output "$stderr_output $output")"
         return 0
     fi
     rm -f "$stderr_file"
@@ -308,7 +308,7 @@ SELECT ROW_COUNT();
     " 2>"$stderr_file"); then
         stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
         rm -f "$stderr_file"
-        record_anomaly "$db" "$label failed for $db: $(sanitize_output "$output $stderr_output")"
+        record_anomaly "$db" "$label failed for $db: $(sanitize_output "$stderr_output $output")"
         return 1
     fi
     stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
@@ -316,7 +316,7 @@ SELECT ROW_COUNT();
 
     rows=$(printf '%s\n' "$output" | tail -1 | tr -d '\r')
     if [ -z "$rows" ] || ! [[ "$rows" =~ ^[0-9]+$ ]]; then
-        record_anomaly "$db" "$label returned non-numeric row count for $db: $(sanitize_output "$output $stderr_output")"
+        record_anomaly "$db" "$label returned non-numeric row count for $db: $(sanitize_output "$stderr_output $output")"
         return 1
     fi
 


### PR DESCRIPTION
Fixes #2667

## Summary
- Increase reaper anomaly sanitization from 500 to 4000 characters so Dolt error tails survive long SQL previews.
- Put stderr before stdout when constructing mixed Dolt failure anomalies, preserving the actual database error before verbose query output.
- Add a regression test covering long stdout plus a Dolt stderr schema error during closed-wisp purge.

## Scope and second-order impact
- Diagnostic-only change: no purge SQL, commit flow, retention window, or session pruning behavior changes.
- Output remains bounded at 4000 characters.
- Stderr-first ordering is limited to existing failure-anomaly paths that already combine stdout and stderr; single-stream diagnostics are unchanged.

## Validation
- PASS: `bash -n examples/gastown/packs/maintenance/assets/scripts/reaper.sh`
- PASS: `git diff --check`
- PASS: `go test ./examples/gastown -run 'TestReaperFailureAnomalyPreservesDoltErrorTail|TestReaperDoesNotCountFailedPurgeAsSuccess|TestReaperEscalatesDoltCommitFailure' -count=1`\n- PASS: `go test ./examples/gastown -run 'Reaper' -count=1`\n- PASS: `go test ./cmd/gc -run 'TestEmbedBuiltinPacks|TestMaterializeBuiltinPacks|TestBuiltinPack' -count=1`\n- ATTEMPTED: `make check` failed in unrelated existing/local-environment areas: repository `worktrees/` scanned by documentation/no-bd-exec checks, macOS `/private/tmp` and `/var` path canonicalization mismatches, darwin `/proc/<pid>/exe` supervisor drift tests, condition/readiness timing tests, and a slow `bd.slow` assertion. Focused reaper and pack-materialization coverage passed.\n\n## Local runtime validation\n- Installed the patched `gc` locally, materialized the maintenance pack in `vehicle-graph-city`, and confirmed `.gc/system/packs/maintenance/assets/scripts/reaper.sh` now uses `cut -c1-4000`.\n- `gc status --json` now reports `ok: true`, `running: true`, and usable health after supervisor restart/reconciliation.\n