### PR TITLE
Use public gastown pack import for init and doctor

### DIFF
--- a/cmd/gc/import_state_doctor_check.go
+++ b/cmd/gc/import_state_doctor_check.go
@@ -214,6 +214,10 @@ func legacyPublicPackNames(imports map[string]config.Import, cityPath string) []
 }
 
 func legacyPublicPackForSource(cityPath, source string) (string, bool) {
+	source = strings.TrimSpace(source)
+	if isRemoteImportSource(source) {
+		return "", false
+	}
 	source = strings.TrimSpace(filepath.Clean(source))
 	if source == "." || source == "" {
 		return "", false

--- a/cmd/gc/import_state_doctor_check.go
+++ b/cmd/gc/import_state_doctor_check.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/packman"
@@ -11,6 +15,23 @@ import (
 
 type importStateDoctorCheck struct {
 	cityPath string
+}
+
+const importStateSyncFixHint = `run "gc doctor --fix" or "gc import install"`
+
+var (
+	resolveWave1PublicPackImports = defaultWave1PublicPackImports
+)
+
+type wave1PublicPackImportTarget struct {
+	Binding string
+	Import  config.Import
+	Remove  bool
+}
+
+type legacyPublicPackRewrite struct {
+	From string
+	To   string
 }
 
 func newImportStateDoctorCheck(cityPath string) *importStateDoctorCheck {
@@ -28,11 +49,25 @@ func (c *importStateDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult
 		r.Message = fmt.Sprintf("reading declared imports: %v", err)
 		return r
 	}
+	if details := durableRegistryImportDetails(imports); len(details) > 0 {
+		r.Status = doctor.StatusError
+		r.Message = fmt.Sprintf("%d durable import(s) use command-time registry selectors", len(details))
+		r.FixHint = "replace registry: sources with concrete pack sources"
+		r.Details = details
+		return r
+	}
+	if details := legacyPublicPackImportDetails(c.cityPath, imports); len(details) > 0 {
+		r.Status = doctor.StatusError
+		r.Message = fmt.Sprintf("%d legacy public built-in pack import(s)", len(details))
+		r.FixHint = `run "gc doctor --fix" to rewrite legacy gastown imports and remove legacy maintenance imports`
+		r.Details = details
+		return r
+	}
 	report, err := checkInstalledImports(c.cityPath, imports)
 	if err != nil {
 		r.Status = doctor.StatusError
 		r.Message = fmt.Sprintf("checking import state: %v", err)
-		r.FixHint = `run "gc import install"`
+		r.FixHint = importStateSyncFixHint
 		return r
 	}
 	if !report.HasIssues() {
@@ -43,16 +78,90 @@ func (c *importStateDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult
 
 	r.Status = doctor.StatusError
 	r.Message = fmt.Sprintf("%d import state issue(s)", len(report.Issues))
-	r.FixHint = `run "gc import install"`
+	r.FixHint = importStateSyncFixHint
 	for _, issue := range report.Issues {
 		r.Details = append(r.Details, formatImportStateDoctorDetail(issue))
 	}
 	return r
 }
 
-func (c *importStateDoctorCheck) CanFix() bool { return false }
+func durableRegistryImportDetails(imports map[string]config.Import) []string {
+	var names []string
+	for name, imp := range imports {
+		if strings.HasPrefix(strings.TrimSpace(imp.Source), "registry:") {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	details := make([]string, 0, len(names))
+	for _, name := range names {
+		details = append(details, fmt.Sprintf("registry-selector-source | %s | %s | registry selectors are command-time inputs only; pack.toml must store the concrete pack source", name, imports[name].Source))
+	}
+	return details
+}
 
-func (c *importStateDoctorCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (c *importStateDoctorCheck) CanFix() bool { return true }
+
+func (c *importStateDoctorCheck) Fix(_ *doctor.CheckContext) error {
+	imports, err := collectAllImportsFS(fsys.OSFS{}, c.cityPath)
+	if err != nil {
+		return fmt.Errorf("reading declared imports: %w", err)
+	}
+	if details := durableRegistryImportDetails(imports); len(details) > 0 {
+		return fmt.Errorf("durable registry selectors require manual replacement with concrete pack sources")
+	}
+	var lock *packman.Lockfile
+	if details := legacyPublicPackImportDetails(c.cityPath, imports); len(details) > 0 {
+		targets, err := resolveWave1PublicPackImports(legacyPublicPackNames(imports, c.cityPath))
+		if err != nil {
+			return err
+		}
+		if _, err := rewriteLegacyPublicPackImportsFS(fsys.OSFS{}, c.cityPath, targets); err != nil {
+			return err
+		}
+		imports, err = collectAllImportsFS(fsys.OSFS{}, c.cityPath)
+		if err != nil {
+			return fmt.Errorf("reading migrated imports: %w", err)
+		}
+		lock, err = syncImports(c.cityPath, imports, packman.InstallResolveIfNeeded)
+	} else {
+		lock, err = syncImports(c.cityPath, imports, packman.InstallResolveIfNeeded)
+	}
+	if err != nil {
+		return err
+	}
+	if err := writeImportLockfile(fsys.OSFS{}, c.cityPath, lock); err != nil {
+		return err
+	}
+	if _, err := installLockedImports(c.cityPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func defaultWave1PublicPackImports(packNames []string) (map[string]wave1PublicPackImportTarget, error) {
+	targets := make(map[string]wave1PublicPackImportTarget, len(packNames))
+	for _, packName := range packNames {
+		switch packName {
+		case "gastown":
+			targets[packName] = wave1PublicPackImportTarget{
+				Binding: "gastown",
+				Import: config.Import{
+					Source:  config.PublicGastownPackSource,
+					Version: config.PublicGastownPackVersion,
+				},
+			}
+		case "maintenance":
+			targets[packName] = wave1PublicPackImportTarget{
+				Binding: "maintenance",
+				Remove:  true,
+			}
+		default:
+			return nil, fmt.Errorf("unsupported wave 1 public pack migration target %q", packName)
+		}
+	}
+	return targets, nil
+}
 
 func formatImportStateDoctorDetail(issue packman.CheckIssue) string {
 	parts := []string{issue.Code}
@@ -72,4 +181,218 @@ func formatImportStateDoctorDetail(issue packman.CheckIssue) string {
 		parts = append(parts, issue.Message)
 	}
 	return strings.Join(parts, " | ")
+}
+
+func legacyPublicPackImportDetails(cityPath string, imports map[string]config.Import) []string {
+	var names []string
+	for name, imp := range imports {
+		if _, ok := legacyPublicPackForSource(cityPath, imp.Source); ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	details := make([]string, 0, len(names))
+	for _, name := range names {
+		pack, _ := legacyPublicPackForSource(cityPath, imports[name].Source)
+		action := "should use the public gascity-packs source"
+		if pack == "maintenance" {
+			action = "should be removed; maintenance/core is supplied implicitly"
+		}
+		details = append(details, fmt.Sprintf("legacy-public-pack-source | %s | %s | legacy %s import %s", name, imports[name].Source, pack, action))
+	}
+	return details
+}
+
+func legacyPublicPackNames(imports map[string]config.Import, cityPath string) []string {
+	seen := make(map[string]bool)
+	for _, imp := range imports {
+		if pack, ok := legacyPublicPackForSource(cityPath, imp.Source); ok {
+			seen[pack] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func legacyPublicPackForSource(cityPath, source string) (string, bool) {
+	source = strings.TrimSpace(filepath.Clean(source))
+	if source == "." || source == "" {
+		return "", false
+	}
+	source = filepath.ToSlash(source)
+	for _, pack := range []string{"gastown", "maintenance"} {
+		if source == ".gc/system/packs/"+pack || source == "examples/gastown/packs/"+pack {
+			return pack, true
+		}
+	}
+	path := source
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(cityPath, filepath.FromSlash(source))
+	}
+	path = filepath.ToSlash(filepath.Clean(path))
+	for _, pack := range []string{"gastown", "maintenance"} {
+		for _, suffix := range []string{"/.gc/system/packs/" + pack, "/examples/gastown/packs/" + pack} {
+			if strings.HasSuffix(path, suffix) {
+				return pack, true
+			}
+		}
+	}
+	return "", false
+}
+
+func rewriteLegacyPublicPackImportsFS(fs fsys.FS, cityPath string, targets map[string]wave1PublicPackImportTarget) (bool, error) {
+	for packName, target := range targets {
+		if strings.TrimSpace(packName) == "" || strings.TrimSpace(target.Binding) == "" {
+			return false, fmt.Errorf("wave 1 public pack migration target for %q is incomplete", packName)
+		}
+		if !target.Remove && strings.TrimSpace(target.Import.Source) == "" {
+			return false, fmt.Errorf("wave 1 public pack migration target for %q is missing source", packName)
+		}
+	}
+	changed := false
+
+	manifest, err := loadCityPackManifestFS(fs, cityPath)
+	if err != nil {
+		return false, err
+	}
+	packChanged, _, err := rewriteLegacyPublicPackImportMap(cityPath, manifest.Imports, targets)
+	if err != nil {
+		return false, fmt.Errorf("pack.toml imports: %w", err)
+	}
+	defaultRigChanged, defaultRigRewrites, err := rewriteLegacyPublicPackImportMap(cityPath, manifest.Defaults.Rig.Imports, targets)
+	if err != nil {
+		return false, fmt.Errorf("pack.toml default rig imports: %w", err)
+	}
+
+	var cfg *config.City
+	cityChanged := false
+	if _, err := fs.Stat(filepath.Join(cityPath, "city.toml")); err != nil {
+		if os.IsNotExist(err) {
+			if packChanged || defaultRigChanged {
+				if defaultRigChanged {
+					manifest.DefaultRigImportOrder = replaceImportOrderWithTargets(manifest.DefaultRigImportOrder, defaultRigRewrites)
+				}
+				if err := writeCityPackManifest(fs, cityPath, manifest); err != nil {
+					return false, err
+				}
+				changed = true
+			}
+			return changed, nil
+		}
+		return false, err
+	}
+	cfg, err = loadCityImportManifestFS(fs, cityPath)
+	if err != nil {
+		return false, err
+	}
+	for i := range cfg.Rigs {
+		rigChanged, _, err := rewriteLegacyPublicPackImportMap(cityPath, cfg.Rigs[i].Imports, targets)
+		if err != nil {
+			return false, fmt.Errorf("city.toml rig %q imports: %w", cfg.Rigs[i].Name, err)
+		}
+		cityChanged = cityChanged || rigChanged
+	}
+	if packChanged || defaultRigChanged {
+		if defaultRigChanged {
+			manifest.DefaultRigImportOrder = replaceImportOrderWithTargets(manifest.DefaultRigImportOrder, defaultRigRewrites)
+		}
+		if err := writeCityPackManifest(fs, cityPath, manifest); err != nil {
+			return false, err
+		}
+		changed = true
+	}
+	if cityChanged {
+		if err := writeCityImportManifestFS(fs, cityPath, cfg); err != nil {
+			return false, err
+		}
+		changed = true
+	}
+
+	return changed, nil
+}
+
+func rewriteLegacyPublicPackImportMap(cityPath string, imports map[string]config.Import, targets map[string]wave1PublicPackImportTarget) (bool, []legacyPublicPackRewrite, error) {
+	if len(imports) == 0 {
+		return false, nil, nil
+	}
+	legacy := make(map[string]string)
+	for name, imp := range imports {
+		if packName, ok := legacyPublicPackForSource(cityPath, imp.Source); ok {
+			legacy[name] = packName
+		}
+	}
+	if len(legacy) == 0 {
+		return false, nil, nil
+	}
+	var legacyNames []string
+	for name := range legacy {
+		legacyNames = append(legacyNames, name)
+	}
+	sort.Strings(legacyNames)
+
+	var rewrites []legacyPublicPackRewrite
+	targetBindings := make(map[string]wave1PublicPackImportTarget)
+	for _, name := range legacyNames {
+		packName := legacy[name]
+		target, ok := targets[packName]
+		if !ok {
+			return false, nil, fmt.Errorf("missing migration target for legacy %q import %q", packName, name)
+		}
+		to := ""
+		if !target.Remove {
+			targetBindings[target.Binding] = target
+			to = target.Binding
+		}
+		rewrites = append(rewrites, legacyPublicPackRewrite{From: name, To: to})
+	}
+	for binding, target := range targetBindings {
+		if existing, ok := imports[binding]; ok && !sameImport(existing, target.Import) {
+			if _, legacyTarget := legacyPublicPackForSource(cityPath, existing.Source); !legacyTarget {
+				return false, nil, fmt.Errorf("refusing to overwrite existing %q import with source %q", binding, existing.Source)
+			}
+		}
+	}
+	for _, name := range legacyNames {
+		delete(imports, name)
+	}
+	for binding, target := range targetBindings {
+		imports[binding] = target.Import
+	}
+	return true, rewrites, nil
+}
+
+func sameImport(a, b config.Import) bool {
+	return strings.TrimSpace(a.Source) == strings.TrimSpace(b.Source) &&
+		strings.TrimSpace(a.Version) == strings.TrimSpace(b.Version)
+}
+
+func replaceImportOrderWithTargets(order []string, rewrites []legacyPublicPackRewrite) []string {
+	targetByLegacy := make(map[string]string, len(rewrites))
+	for _, rewrite := range rewrites {
+		targetByLegacy[rewrite.From] = rewrite.To
+	}
+	out := make([]string, 0, len(order)+1)
+	seenTarget := make(map[string]bool)
+	for _, name := range order {
+		if target, ok := targetByLegacy[name]; ok {
+			if target != "" && !seenTarget[target] {
+				out = append(out, target)
+				seenTarget[target] = true
+			}
+			continue
+		}
+		seenTarget[name] = true
+		out = append(out, name)
+	}
+	for _, rewrite := range rewrites {
+		if rewrite.To != "" && !seenTarget[rewrite.To] {
+			out = append(out, rewrite.To)
+			seenTarget[rewrite.To] = true
+		}
+	}
+	return out
 }

--- a/cmd/gc/import_state_doctor_check.go
+++ b/cmd/gc/import_state_doctor_check.go
@@ -19,9 +19,7 @@ type importStateDoctorCheck struct {
 
 const importStateSyncFixHint = `run "gc doctor --fix" or "gc import install"`
 
-var (
-	resolveWave1PublicPackImports = defaultWave1PublicPackImports
-)
+var resolveWave1PublicPackImports = defaultWave1PublicPackImports
 
 type wave1PublicPackImportTarget struct {
 	Binding string
@@ -110,7 +108,6 @@ func (c *importStateDoctorCheck) Fix(_ *doctor.CheckContext) error {
 	if details := durableRegistryImportDetails(imports); len(details) > 0 {
 		return fmt.Errorf("durable registry selectors require manual replacement with concrete pack sources")
 	}
-	var lock *packman.Lockfile
 	if details := legacyPublicPackImportDetails(c.cityPath, imports); len(details) > 0 {
 		targets, err := resolveWave1PublicPackImports(legacyPublicPackNames(imports, c.cityPath))
 		if err != nil {
@@ -123,10 +120,8 @@ func (c *importStateDoctorCheck) Fix(_ *doctor.CheckContext) error {
 		if err != nil {
 			return fmt.Errorf("reading migrated imports: %w", err)
 		}
-		lock, err = syncImports(c.cityPath, imports, packman.InstallResolveIfNeeded)
-	} else {
-		lock, err = syncImports(c.cityPath, imports, packman.InstallResolveIfNeeded)
 	}
+	lock, err := syncImports(c.cityPath, imports, packman.InstallResolveIfNeeded)
 	if err != nil {
 		return err
 	}
@@ -296,6 +291,11 @@ func rewriteLegacyPublicPackImportsFS(fs fsys.FS, cityPath string, targets map[s
 		}
 		cityChanged = cityChanged || rigChanged
 	}
+	cityDefaultRigChanged, _, err := rewriteLegacyPublicPackImportMap(cityPath, cfg.Defaults.Rig.Imports, targets)
+	if err != nil {
+		return false, fmt.Errorf("city.toml default rig imports: %w", err)
+	}
+	cityChanged = cityChanged || cityDefaultRigChanged
 	if packChanged || defaultRigChanged {
 		if defaultRigChanged {
 			manifest.DefaultRigImportOrder = replaceImportOrderWithTargets(manifest.DefaultRigImportOrder, defaultRigRewrites)

--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -287,6 +287,24 @@ func TestLegacyPublicPackForSourceDetectsAbsolutePaths(t *testing.T) {
 	}
 }
 
+func TestLegacyPublicPackForSourceIgnoresRemoteSubdirectorySources(t *testing.T) {
+	cityDir := filepath.Join(string(filepath.Separator), "city")
+	cases := []string{
+		"https://example.com/repo.git//examples/gastown/packs/gastown",
+		"ssh://example.com/repo.git//.gc/system/packs/gastown",
+		"git@example.com:org/repo.git//examples/gastown/packs/maintenance",
+		"github.com/org/repo//examples/gastown/packs/maintenance",
+		"file:///repo/examples/gastown/packs/gastown",
+	}
+	for _, source := range cases {
+		t.Run(source, func(t *testing.T) {
+			if got, ok := legacyPublicPackForSource(cityDir, source); ok {
+				t.Fatalf("legacyPublicPackForSource(%q) = %q, true; want false", source, got)
+			}
+		})
+	}
+}
+
 func TestImportStateDoctorCheckFixRewritesLegacyPublicPackImports(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()

--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -79,11 +79,344 @@ version = "^1.0"
 	if result.Status != doctor.StatusError {
 		t.Fatalf("status = %v, want Error; result=%#v", result.Status, result)
 	}
-	if check.CanFix() || result.FixHint != `run "gc import install"` {
-		t.Fatalf("result = %#v, want non-fixable install hint", result)
+	if !check.CanFix() || !strings.Contains(result.FixHint, `gc doctor --fix`) || !strings.Contains(result.FixHint, `gc import install`) {
+		t.Fatalf("result = %#v, want fixable doctor/import-install hint", result)
 	}
 	if len(result.Details) != 1 || !strings.Contains(result.Details[0], "missing-cache") {
 		t.Fatalf("details = %#v", result.Details)
+	}
+}
+
+func TestImportStateDoctorCheckFixRunsImportInstallPath(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.0"
+`)
+
+	prevSync := syncImports
+	prevInstall := installLockedImports
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() {
+		syncImports = prevSync
+		installLockedImports = prevInstall
+		checkInstalledImports = prevCheck
+	})
+	synced := false
+	installed := false
+	lock := &packman.Lockfile{
+		Schema: packman.LockfileSchema,
+		Packs: map[string]packman.LockedPack{
+			"https://example.com/tools.git": {Version: "1.1.0", Commit: "new"},
+		},
+	}
+	syncImports = func(cityRoot string, imports map[string]config.Import, mode packman.InstallMode) (*packman.Lockfile, error) {
+		if cityRoot != cityDir {
+			t.Fatalf("sync cityRoot = %q, want %q", cityRoot, cityDir)
+		}
+		if _, ok := imports["pack:tools"]; !ok {
+			t.Fatalf("sync imports = %#v, want pack:tools", imports)
+		}
+		if mode != packman.InstallResolveIfNeeded {
+			t.Fatalf("sync mode = %v, want InstallResolveIfNeeded", mode)
+		}
+		synced = true
+		return lock, nil
+	}
+	installLockedImports = func(cityRoot string) (*packman.Lockfile, error) {
+		if cityRoot != cityDir {
+			t.Fatalf("install cityRoot = %q, want %q", cityRoot, cityDir)
+		}
+		installed = true
+		return lock, nil
+	}
+	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
+		if !installed {
+			return &packman.CheckReport{Issues: []packman.CheckIssue{{
+				Severity: packman.CheckSeverityError,
+				Code:     "missing-lockfile",
+			}}}, nil
+		}
+		return &packman.CheckReport{CheckedSources: 1}, nil
+	}
+
+	check := newImportStateDoctorCheck(cityDir)
+	before := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if before.Status != doctor.StatusError {
+		t.Fatalf("before status = %v, want error", before.Status)
+	}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if !synced || !installed {
+		t.Fatalf("sync/install called = %v/%v, want both", synced, installed)
+	}
+	after := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if after.Status != doctor.StatusOK {
+		t.Fatalf("after status = %v, want OK; result=%#v", after.Status, after)
+	}
+}
+
+func TestImportStateDoctorCheckReportsDurableRegistrySelectors(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.lighthouse]
+source = "registry:main:lighthouse"
+version = "^1.0"
+`)
+
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() { checkInstalledImports = prevCheck })
+	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
+		t.Fatal("checkInstalledImports should not run when durable registry selectors are present")
+		return nil, nil
+	}
+
+	result := newImportStateDoctorCheck(cityDir).Run(&doctor.CheckContext{CityPath: cityDir})
+	if result.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want Error; result=%#v", result.Status, result)
+	}
+	if !strings.Contains(result.Message, "command-time registry selectors") {
+		t.Fatalf("message = %q", result.Message)
+	}
+	if !strings.Contains(result.FixHint, "concrete pack sources") {
+		t.Fatalf("fix hint = %q", result.FixHint)
+	}
+	if len(result.Details) != 1 || !strings.Contains(result.Details[0], "registry-selector-source") || !strings.Contains(result.Details[0], "registry:main:lighthouse") {
+		t.Fatalf("details = %#v", result.Details)
+	}
+	if err := newImportStateDoctorCheck(cityDir).Fix(&doctor.CheckContext{CityPath: cityDir}); err == nil {
+		t.Fatal("Fix succeeded for durable registry selector, want manual error")
+	}
+}
+
+func TestImportStateDoctorCheckReportsLegacyPublicPackImports(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.gastown]
+source = ".gc/system/packs/gastown"
+
+[defaults.rig.imports.maintenance]
+source = "examples/gastown/packs/maintenance"
+`)
+
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() { checkInstalledImports = prevCheck })
+	checkInstalledImports = func(_ string, _ map[string]config.Import) (*packman.CheckReport, error) {
+		t.Fatal("checkInstalledImports should not run when legacy public pack imports are present")
+		return nil, nil
+	}
+
+	result := newImportStateDoctorCheck(cityDir).Run(&doctor.CheckContext{CityPath: cityDir})
+	if result.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want Error; result=%#v", result.Status, result)
+	}
+	if !strings.Contains(result.Message, "legacy public built-in pack import") {
+		t.Fatalf("message = %q", result.Message)
+	}
+	if !strings.Contains(result.FixHint, `gc doctor --fix`) || !strings.Contains(result.FixHint, "legacy maintenance imports") {
+		t.Fatalf("fix hint = %q", result.FixHint)
+	}
+	if len(result.Details) != 2 {
+		t.Fatalf("details = %#v, want two legacy public pack details", result.Details)
+	}
+	for _, want := range []string{"pack:gastown", "default-rig:maintenance"} {
+		found := false
+		for _, detail := range result.Details {
+			found = found || strings.Contains(detail, want)
+		}
+		if !found {
+			t.Fatalf("details = %#v, missing %s", result.Details, want)
+		}
+	}
+}
+
+func TestImportStateDoctorCheckFixRewritesLegacyPublicPackImports(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "main"
+path = "rigs/main"
+
+[rigs.imports.gastown]
+source = "examples/gastown/packs/gastown"
+`)
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.gastown]
+source = ".gc/system/packs/gastown"
+
+[imports.tools]
+source = "https://example.com/tools.git"
+version = "^1.0"
+
+[defaults.rig.imports.maintenance]
+source = ".gc/system/packs/maintenance"
+`)
+
+	prevResolve := resolveWave1PublicPackImports
+	prevSync := syncImports
+	prevInstall := installLockedImports
+	prevCheck := checkInstalledImports
+	t.Cleanup(func() {
+		resolveWave1PublicPackImports = prevResolve
+		syncImports = prevSync
+		installLockedImports = prevInstall
+		checkInstalledImports = prevCheck
+	})
+
+	targets := map[string]wave1PublicPackImportTarget{
+		"gastown": {
+			Binding: "gastown",
+			Import:  config.Import{Source: "https://packages.example/gastown.git", Version: "^1.2"},
+		},
+		"maintenance": {
+			Binding: "maintenance",
+			Remove:  true,
+		},
+	}
+	resolveWave1PublicPackImports = func(packNames []string) (map[string]wave1PublicPackImportTarget, error) {
+		if got, want := strings.Join(packNames, ","), "gastown,maintenance"; got != want {
+			t.Fatalf("resolve pack names = %q, want %q", got, want)
+		}
+		return targets, nil
+	}
+	lock := &packman.Lockfile{
+		Schema: packman.LockfileSchema,
+		Packs: map[string]packman.LockedPack{
+			targets["gastown"].Import.Source: {Version: "1.2.3", Commit: "abc"},
+		},
+	}
+	syncImports = func(cityRoot string, imports map[string]config.Import, mode packman.InstallMode) (*packman.Lockfile, error) {
+		if cityRoot != cityDir {
+			t.Fatalf("sync cityRoot = %q, want %q", cityRoot, cityDir)
+		}
+		if mode != packman.InstallResolveIfNeeded {
+			t.Fatalf("sync mode = %v, want InstallResolveIfNeeded", mode)
+		}
+		for key, target := range map[string]wave1PublicPackImportTarget{
+			"pack:gastown":     targets["gastown"],
+			"rig:main:gastown": targets["gastown"],
+		} {
+			if got := imports[key]; got.Source != target.Import.Source || got.Version != target.Import.Version {
+				t.Fatalf("imports[%s] = %+v, want %s target", key, got, target.Binding)
+			}
+		}
+		if _, ok := imports["default-rig:maintenance"]; ok {
+			t.Fatalf("imports still contains maintenance, want implicit maintenance only: %#v", imports)
+		}
+		for key, imp := range imports {
+			if strings.HasPrefix(imp.Source, ".gc/system/packs/") || strings.HasPrefix(imp.Source, "examples/gastown/packs/") {
+				t.Fatalf("imports still contains legacy source at %s: %#v", key, imports)
+			}
+		}
+		return lock, nil
+	}
+	installLockedImports = func(cityRoot string) (*packman.Lockfile, error) {
+		if cityRoot != cityDir {
+			t.Fatalf("install cityRoot = %q, want %q", cityRoot, cityDir)
+		}
+		return lock, nil
+	}
+	checkInstalledImports = func(_ string, imports map[string]config.Import) (*packman.CheckReport, error) {
+		for key, imp := range imports {
+			if strings.HasPrefix(imp.Source, ".gc/system/packs/") || strings.HasPrefix(imp.Source, "examples/gastown/packs/") {
+				return &packman.CheckReport{Issues: []packman.CheckIssue{{Code: "legacy-leftover", ImportName: key, Source: imp.Source}}}, nil
+			}
+		}
+		return &packman.CheckReport{CheckedSources: 2}, nil
+	}
+
+	check := newImportStateDoctorCheck(cityDir)
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	after := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if after.Status != doctor.StatusOK {
+		t.Fatalf("after status = %v, want OK; result=%#v", after.Status, after)
+	}
+
+	packData, err := os.ReadFile(filepath.Join(cityDir, "pack.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	packText := string(packData)
+	if !strings.Contains(packText, "[imports.gastown]") {
+		t.Fatalf("pack.toml missing migrated gastown import:\n%s", packText)
+	}
+	if strings.Contains(packText, "maintenance") {
+		t.Fatalf("pack.toml should remove legacy maintenance import because maintenance/core is implicit:\n%s", packText)
+	}
+	if strings.Contains(packText, ".gc/system/packs") || strings.Contains(packText, "examples/gastown/packs") {
+		t.Fatalf("pack.toml still contains legacy public pack references:\n%s", packText)
+	}
+	cityData, err := os.ReadFile(filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cityText := string(cityData)
+	if !strings.Contains(cityText, "[[rigs]]") || !strings.Contains(cityText, "[rigs.imports.gastown]") {
+		t.Fatalf("city.toml missing rig gastown import:\n%s", cityText)
+	}
+	if strings.Contains(cityText, ".gc/system/packs") || strings.Contains(cityText, "examples/gastown/packs") {
+		t.Fatalf("city.toml still contains legacy public pack references:\n%s", cityText)
+	}
+}
+
+func TestImportStateDoctorCheckFixRefusesToOverwriteExistingTargetImport(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.gastown]
+source = "https://example.com/custom-gastown.git"
+version = "^9.0"
+
+[imports.legacy_gastown]
+source = ".gc/system/packs/gastown"
+`)
+
+	prevResolve := resolveWave1PublicPackImports
+	t.Cleanup(func() { resolveWave1PublicPackImports = prevResolve })
+	resolveWave1PublicPackImports = func(_ []string) (map[string]wave1PublicPackImportTarget, error) {
+		return map[string]wave1PublicPackImportTarget{
+			"gastown": {
+				Binding: "gastown",
+				Import:  config.Import{Source: "https://packages.example/gastown.git", Version: "^1.2"},
+			},
+		}, nil
+	}
+
+	err := newImportStateDoctorCheck(cityDir).Fix(&doctor.CheckContext{CityPath: cityDir})
+	if err == nil {
+		t.Fatal("Fix succeeded despite conflicting existing target import")
+	}
+	if !strings.Contains(err.Error(), "refusing to overwrite existing") {
+		t.Fatalf("Fix error = %v, want overwrite refusal", err)
 	}
 }
 
@@ -133,7 +466,7 @@ version = "^1.0"
 	var stdout, stderr bytes.Buffer
 	_ = doDoctor(false, true, false, false, &stdout, &stderr)
 	out := stdout.String() + stderr.String()
-	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, `run "gc import install"`) {
+	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, `gc import install`) {
 		t.Fatalf("doctor output missing import state check:\n%s", out)
 	}
 }
@@ -176,7 +509,7 @@ version = "^1.0"
 	if !strings.Contains(out, "packv2-import-state") || !strings.Contains(out, "missing-lockfile") {
 		t.Fatalf("doctor output missing import-state failure for broken install state:\n%s", out)
 	}
-	if !strings.Contains(out, `run "gc import install"`) {
+	if !strings.Contains(out, `gc import install`) {
 		t.Fatalf("doctor output missing install hint:\n%s", out)
 	}
 }

--- a/cmd/gc/import_state_doctor_check_test.go
+++ b/cmd/gc/import_state_doctor_check_test.go
@@ -204,16 +204,18 @@ version = "^1.0"
 func TestImportStateDoctorCheckReportsLegacyPublicPackImports(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
-	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writeCityToml(t, cityDir, `[workspace]
+name = "demo"
+
+[defaults.rig.imports.maintenance]
+source = "examples/gastown/packs/maintenance"
+`)
 	writePackToml(t, cityDir, `[pack]
 name = "demo"
 schema = 1
 
 [imports.gastown]
 source = ".gc/system/packs/gastown"
-
-[defaults.rig.imports.maintenance]
-source = "examples/gastown/packs/maintenance"
 `)
 
 	prevCheck := checkInstalledImports
@@ -247,6 +249,44 @@ source = "examples/gastown/packs/maintenance"
 	}
 }
 
+func TestLegacyPublicPackForSourceDetectsAbsolutePaths(t *testing.T) {
+	cityDir := filepath.Join(string(filepath.Separator), "city")
+	cases := []struct {
+		name   string
+		source string
+		pack   string
+	}{
+		{
+			name:   "absolute materialized gastown",
+			source: filepath.Join(string(filepath.Separator), "other", ".gc", "system", "packs", "gastown"),
+			pack:   "gastown",
+		},
+		{
+			name:   "absolute example maintenance",
+			source: filepath.Join(string(filepath.Separator), "repo", "examples", "gastown", "packs", "maintenance"),
+			pack:   "maintenance",
+		},
+		{
+			name:   "absolute unrelated pack",
+			source: filepath.Join(string(filepath.Separator), "repo", "packs", "custom"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := legacyPublicPackForSource(cityDir, tc.source)
+			if tc.pack == "" {
+				if ok {
+					t.Fatalf("legacyPublicPackForSource(%q) = %q, true; want false", tc.source, got)
+				}
+				return
+			}
+			if !ok || got != tc.pack {
+				t.Fatalf("legacyPublicPackForSource(%q) = %q, %v; want %q, true", tc.source, got, ok, tc.pack)
+			}
+		})
+	}
+}
+
 func TestImportStateDoctorCheckFixRewritesLegacyPublicPackImports(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
@@ -259,6 +299,9 @@ path = "rigs/main"
 
 [rigs.imports.gastown]
 source = "examples/gastown/packs/gastown"
+
+[defaults.rig.imports.maintenance]
+source = ".gc/system/packs/maintenance"
 `)
 	writePackToml(t, cityDir, `[pack]
 name = "demo"
@@ -270,9 +313,6 @@ source = ".gc/system/packs/gastown"
 [imports.tools]
 source = "https://example.com/tools.git"
 version = "^1.0"
-
-[defaults.rig.imports.maintenance]
-source = ".gc/system/packs/maintenance"
 `)
 
 	prevResolve := resolveWave1PublicPackImports
@@ -381,6 +421,9 @@ source = ".gc/system/packs/maintenance"
 	}
 	if strings.Contains(cityText, ".gc/system/packs") || strings.Contains(cityText, "examples/gastown/packs") {
 		t.Fatalf("city.toml still contains legacy public pack references:\n%s", cityText)
+	}
+	if strings.Contains(cityText, "maintenance") {
+		t.Fatalf("city.toml should remove legacy maintenance default-rig import because maintenance/core is implicit:\n%s", cityText)
 	}
 }
 

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -61,6 +61,10 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 		printDoltAuthorIdentityBlock(stderr, opts.commandName, status)
 		return 1
 	}
+	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {
+		fmt.Fprintf(stderr, "%s: fetching packs: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	if opts.showProgress {
 		if opts.skipProviderReadiness {
@@ -76,12 +80,13 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 	} else if !opts.showProgress && stdout != nil {
 		fmt.Fprintln(stdout, "Skipping provider readiness checks.") //nolint:errcheck // best-effort stdout
 	}
-	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {
-		fmt.Fprintf(stderr, "%s: fetching packs: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
 	if err := ensureInitRemoteImportsInstalled(cityPath); err != nil {
 		fmt.Fprintf(stderr, "%s: installing imports: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	hasRemoteImports, err := initHasRemoteImports(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: reading imports for provider readiness: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -92,6 +97,11 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: loading config for prefix resolution: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if !opts.skipProviderReadiness && hasRemoteImports {
+		if err := runInitProviderPreflightForConfig(cityPath, cfg, stdout, stderr, opts.commandName); err != nil {
+			return 1
+		}
 	}
 	prefix := config.EffectiveHQPrefix(cfg)
 	if _, err := initDirIfReady(cityPath, cityPath, prefix); err != nil {
@@ -153,6 +163,10 @@ func runInitProviderPreflight(cityPath string, stdout, stderr io.Writer, command
 		fmt.Fprintf(stderr, "%s: fix the config issue, then run 'gc start'\n", commandName)                     //nolint:errcheck // best-effort stderr
 		return errInitProviderPreflight
 	}
+	return runInitProviderPreflightForConfig(cityPath, cfg, stdout, stderr, commandName)
+}
+
+func runInitProviderPreflightForConfig(cityPath string, cfg *config.City, stdout, stderr io.Writer, commandName string) error {
 	ensureInitArtifacts(cityPath, stderr, commandName)
 	if err := seedDeferredManagedBeadsBeforeProviderReadiness(cityPath, cfg); err != nil {
 		fmt.Fprintf(stderr, "%s: city created, but startup is blocked by bead store initialization\n", commandName) //nolint:errcheck // best-effort stderr
@@ -209,6 +223,14 @@ func runInitProviderPreflight(cityPath string, stdout, stderr io.Writer, command
 	fmt.Fprintf(stderr, "Next: cd %s && gc start\n", shellQuotePath(cityPath))                        //nolint:errcheck // best-effort stderr
 	fmt.Fprintf(stderr, "Override: gc init --skip-provider-readiness %s\n", shellQuotePath(cityPath)) //nolint:errcheck // best-effort stderr
 	return errInitProviderPreflight
+}
+
+func initHasRemoteImports(cityPath string) (bool, error) {
+	allImports, err := collectAllImportsFS(fsys.OSFS{}, cityPath)
+	if err != nil {
+		return false, err
+	}
+	return hasRemoteImport(allImports), nil
 }
 
 func loadInitProviderPreflightConfig(cityPath string) (*config.City, error) {

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -69,16 +69,20 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 			logInitProgress(stdout, 6, "Checking provider readiness")
 		}
 	}
-	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {
-		fmt.Fprintf(stderr, "%s: fetching packs: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
 	if !opts.skipProviderReadiness {
 		if err := runInitProviderPreflight(cityPath, stdout, stderr, opts.commandName); err != nil {
 			return 1
 		}
 	} else if !opts.showProgress && stdout != nil {
 		fmt.Fprintln(stdout, "Skipping provider readiness checks.") //nolint:errcheck // best-effort stdout
+	}
+	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {
+		fmt.Fprintf(stderr, "%s: fetching packs: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := ensureInitRemoteImportsInstalled(cityPath); err != nil {
+		fmt.Fprintf(stderr, "%s: installing imports: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
+		return 1
 	}
 
 	// Load config to resolve explicit HQ prefix (workspace.prefix field).
@@ -142,7 +146,7 @@ func wizardProviderGuidanceMessage(item api.ReadinessItem) string {
 }
 
 func runInitProviderPreflight(cityPath string, stdout, stderr io.Writer, commandName string) error {
-	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	cfg, err := loadInitProviderPreflightConfig(cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: city created, but startup is blocked by configuration loading\n", commandName) //nolint:errcheck // best-effort stderr
 		fmt.Fprintf(stderr, "%s: loading config for provider readiness: %v\n", commandName, err)                //nolint:errcheck // best-effort stderr
@@ -205,6 +209,26 @@ func runInitProviderPreflight(cityPath string, stdout, stderr io.Writer, command
 	fmt.Fprintf(stderr, "Next: cd %s && gc start\n", shellQuotePath(cityPath))                        //nolint:errcheck // best-effort stderr
 	fmt.Fprintf(stderr, "Override: gc init --skip-provider-readiness %s\n", shellQuotePath(cityPath)) //nolint:errcheck // best-effort stderr
 	return errInitProviderPreflight
+}
+
+func loadInitProviderPreflightConfig(cityPath string) (*config.City, error) {
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err == nil {
+		return cfg, nil
+	}
+	// Fresh init can check provider readiness before PackV2 remote imports
+	// have been installed. In that bootstrap-only case, fall back to raw
+	// city.toml so workspace.provider still gets checked before any network
+	// fetch. Other include/load errors remain startup-blocking.
+	if !strings.Contains(err.Error(), "remote import") || !strings.Contains(err.Error(), "gc import install") {
+		return nil, err
+	}
+	rawCfg, rawErr := config.Load(fsys.OSFS{}, tomlPath)
+	if rawErr != nil {
+		return nil, err
+	}
+	return rawCfg, nil
 }
 
 func collectInitProviderTargets(cfg *config.City) ([]initProviderTarget, []string, error) {

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -273,8 +273,10 @@ func TestFinalizeInitFetchesRemotePacksBeforeProviderReadiness(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	probeCalls := 0
 	oldProbe := initProbeProvidersReadiness
 	initProbeProvidersReadiness = func(_ context.Context, providers []string, fresh bool) (map[string]api.ReadinessItem, error) {
+		probeCalls++
 		if !fresh {
 			t.Fatal("finalizeInit should force a fresh readiness probe")
 		}
@@ -305,10 +307,98 @@ func TestFinalizeInitFetchesRemotePacksBeforeProviderReadiness(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("finalizeInit = %d, want 0: %s", code, stderr.String())
 	}
+	if probeCalls != 1 {
+		t.Fatalf("readiness probe calls = %d, want 1", probeCalls)
+	}
 
 	cacheDir := config.PackCachePath(cityPath, "remote-pack", config.PackSource{Source: remote})
 	if _, err := os.Stat(filepath.Join(cacheDir, "pack.toml")); err != nil {
 		t.Fatalf("expected fetched pack cache at %s: %v", cacheDir, err)
+	}
+}
+
+func TestFinalizeInitChecksRemoteImportProvidersAfterInstall(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("HOME", t.TempDir())
+	configureIsolatedRuntimeEnv(t)
+	disableBootstrapForTests(t)
+	stubInitDependencyChecks(t)
+
+	remote := initImportBarePackRepo(t, "remote-pack", "", strings.Join([]string{
+		"[pack]",
+		`name = "remote-pack"`,
+		`version = "1.0.0"`,
+		"schema = 1",
+		"",
+		"[[agent]]",
+		`name = "worker"`,
+		`provider = "claude"`,
+		"",
+	}, "\n"))
+	commit := gitOutputImport(t, remote, "rev-parse", "HEAD")
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureCityScaffold(cityPath); err != nil {
+		t.Fatal(err)
+	}
+	writeCityToml(t, cityPath, `[workspace]
+name = "bright-lights"
+`)
+	writePackToml(t, cityPath, strings.Join([]string{
+		"[pack]",
+		`name = "bright-lights"`,
+		"schema = 1",
+		"",
+		"[imports.remote]",
+		`source = "file://` + filepath.ToSlash(remote) + `"`,
+		`version = "sha:` + commit + `"`,
+		"",
+	}, "\n"))
+
+	probeCalls := 0
+	oldProbe := initProbeProvidersReadiness
+	initProbeProvidersReadiness = func(_ context.Context, providers []string, fresh bool) (map[string]api.ReadinessItem, error) {
+		probeCalls++
+		if !fresh {
+			t.Fatal("finalizeInit should force a fresh readiness probe")
+		}
+		if len(providers) != 1 || providers[0] != "claude" {
+			t.Fatalf("providers = %v, want [claude]", providers)
+		}
+		return map[string]api.ReadinessItem{
+			"claude": {
+				Name:        "claude",
+				Kind:        api.ProbeKindProvider,
+				DisplayName: "Claude Code",
+				Status:      api.ProbeStatusNeedsAuth,
+			},
+		}, nil
+	}
+	t.Cleanup(func() { initProbeProvidersReadiness = oldProbe })
+
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = func(_ string, _ string, _ io.Writer, _ io.Writer) (bool, int) {
+		t.Fatal("registerCityWithSupervisor should not run when imported provider readiness blocks init")
+		return true, 0
+	}
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	var stdout, stderr bytes.Buffer
+	code := finalizeInit(cityPath, &stdout, &stderr, initFinalizeOptions{
+		commandName: "gc init",
+	})
+	if code != 1 {
+		t.Fatalf("finalizeInit = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if probeCalls != 1 {
+		t.Fatalf("readiness probe calls = %d, want 1", probeCalls)
+	}
+	if !strings.Contains(stderr.String(), "startup is blocked by provider readiness") {
+		t.Fatalf("stderr = %q, want provider readiness block", stderr.String())
 	}
 }
 

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/bootstrap"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
 )
 
 func disableBootstrapForTests(t *testing.T) {
@@ -348,6 +349,129 @@ func TestFinalizeInitDoesNotWriteImplicitImportState(t *testing.T) {
 	}
 }
 
+func TestInstallInitRemoteImportsSyncsRemoteImports(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.gastown]
+source = "https://github.com/gastownhall/gascity-packs.git//gastown"
+version = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
+`)
+
+	prevSync := syncImports
+	prevInstall := installLockedImports
+	t.Cleanup(func() {
+		syncImports = prevSync
+		installLockedImports = prevInstall
+	})
+
+	lock := &packman.Lockfile{
+		Schema: packman.LockfileSchema,
+		Packs: map[string]packman.LockedPack{
+			config.PublicGastownPackSource: {
+				Version: config.PublicGastownPackVersion,
+				Commit:  strings.TrimPrefix(config.PublicGastownPackVersion, "sha:"),
+			},
+		},
+	}
+	syncImports = func(cityRoot string, imports map[string]config.Import, mode packman.InstallMode) (*packman.Lockfile, error) {
+		if cityRoot != cityDir {
+			t.Fatalf("sync cityRoot = %q, want %q", cityRoot, cityDir)
+		}
+		if mode != packman.InstallResolveIfNeeded {
+			t.Fatalf("sync mode = %v, want InstallResolveIfNeeded", mode)
+		}
+		if got := imports["pack:gastown"]; got.Source != config.PublicGastownPackSource {
+			t.Fatalf("pack:gastown import = %+v, want public gastown source", got)
+		}
+		return lock, nil
+	}
+	installLockedImports = func(cityRoot string) (*packman.Lockfile, error) {
+		if cityRoot != cityDir {
+			t.Fatalf("install cityRoot = %q, want %q", cityRoot, cityDir)
+		}
+		return lock, nil
+	}
+
+	if err := installInitRemoteImports(cityDir); err != nil {
+		t.Fatalf("installInitRemoteImports: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, packman.LockfileName)); err != nil {
+		t.Fatalf("expected %s to be written: %v", packman.LockfileName, err)
+	}
+}
+
+func TestInstallInitRemoteImportsSkipsLocalOnlyImports(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, "[workspace]\nname = \"demo\"\n")
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 1
+
+[imports.local]
+source = "./packs/local"
+`)
+
+	prevSync := syncImports
+	t.Cleanup(func() { syncImports = prevSync })
+	syncImports = func(string, map[string]config.Import, packman.InstallMode) (*packman.Lockfile, error) {
+		t.Fatal("syncImports should not run for local-only imports")
+		return nil, nil
+	}
+
+	if err := installInitRemoteImports(cityDir); err != nil {
+		t.Fatalf("installInitRemoteImports: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, packman.LockfileName)); !os.IsNotExist(err) {
+		t.Fatalf("%s should not be written for local-only imports, stat err = %v", packman.LockfileName, err)
+	}
+}
+
+func TestFinalizeInitReportsRemoteImportInstallFailure(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+	disableBootstrapForTests(t)
+	stubInitDependencyChecks(t)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	var initStdout, initStderr bytes.Buffer
+	code := doInit(fsys.OSFS{}, cityPath, defaultWizardConfig(), "", &initStdout, &initStderr, false)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
+	}
+
+	prevInstall := ensureInitRemoteImportsInstalled
+	t.Cleanup(func() { ensureInitRemoteImportsInstalled = prevInstall })
+	ensureInitRemoteImportsInstalled = func(string) error {
+		return errors.New("sync failed")
+	}
+
+	oldRegister := registerCityWithSupervisorTestHook
+	registerCityWithSupervisorTestHook = func(_ string, _ string, _ io.Writer, _ io.Writer) (bool, int) {
+		t.Fatal("registerCityWithSupervisor should not run when import install fails")
+		return true, 0
+	}
+	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
+
+	var stdout, stderr bytes.Buffer
+	code = finalizeInit(cityPath, &stdout, &stderr, initFinalizeOptions{
+		commandName:           "gc init",
+		skipProviderReadiness: true,
+	})
+	if code != 1 {
+		t.Fatalf("finalizeInit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "installing imports: sync failed") {
+		t.Fatalf("stderr = %q, want import install failure", stderr.String())
+	}
+}
+
 func TestFinalizeInitReportsConfigLoadErrorDuringProviderPreflight(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")
@@ -499,6 +623,31 @@ func TestCmdInitResumesFinalizeForExistingCity(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "Referenced providers not ready:") {
 		t.Fatalf("stderr = %q, want provider readiness guidance", stderr.String())
+	}
+}
+
+func TestLoadInitProviderPreflightConfigFallsBackForUninstalledRemoteImports(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+	disableBootstrapForTests(t)
+
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	var initStdout, initStderr bytes.Buffer
+	code := doInit(fsys.OSFS{}, cityPath, wizardConfig{
+		configName: "gastown",
+		provider:   "claude",
+	}, "", &initStdout, &initStderr, false)
+	if code != 0 {
+		t.Fatalf("doInit = %d, want 0: %s", code, initStderr.String())
+	}
+
+	cfg, err := loadInitProviderPreflightConfig(cityPath)
+	if err != nil {
+		t.Fatalf("loadInitProviderPreflightConfig: %v", err)
+	}
+	if got := cfg.Workspace.Provider; got != "claude" {
+		t.Fatalf("Workspace.Provider = %q, want claude", got)
 	}
 }
 

--- a/cmd/gc/legacy_pack_preflight.go
+++ b/cmd/gc/legacy_pack_preflight.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
 )
 
 // ensureLegacyNamedPacksCached preserves legacy [packs] compatibility.
@@ -18,4 +19,36 @@ func ensureLegacyNamedPacksCached(cityPath string) error {
 		}
 	}
 	return nil
+}
+
+var ensureInitRemoteImportsInstalled = installInitRemoteImports
+
+func installInitRemoteImports(cityPath string) error {
+	allImports, err := collectAllImportsFS(fsys.OSFS{}, cityPath)
+	if err != nil {
+		return err
+	}
+	if !hasRemoteImport(allImports) {
+		return nil
+	}
+	lock, err := syncImports(cityPath, allImports, packman.InstallResolveIfNeeded)
+	if err != nil {
+		return err
+	}
+	if err := writeImportLockfile(fsys.OSFS{}, cityPath, lock); err != nil {
+		return err
+	}
+	if _, err := installLockedImports(cityPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func hasRemoteImport(imports map[string]config.Import) bool {
+	for _, imp := range imports {
+		if isRemoteImportSource(imp.Source) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2763,8 +2763,14 @@ func TestDoInitGastownWritesCanonicalPackV2Shape(t *testing.T) {
 	}
 
 	packToml := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
-	if !strings.Contains(packToml, "[imports.gastown]") || !strings.Contains(packToml, `source = ".gc/system/packs/gastown"`) {
+	if !strings.Contains(packToml, "[imports.gastown]") || !strings.Contains(packToml, `source = "`+config.PublicGastownPackSource+`"`) {
 		t.Fatalf("pack.toml missing gastown import:\n%s", packToml)
+	}
+	if !strings.Contains(packToml, `version = "`+config.PublicGastownPackVersion+`"`) {
+		t.Fatalf("pack.toml missing gastown version pin:\n%s", packToml)
+	}
+	if strings.Contains(packToml, ".gc/system/packs/gastown") {
+		t.Fatalf("pack.toml should not import legacy materialized gastown:\n%s", packToml)
 	}
 	if strings.Contains(packToml, `append_fragments = ["command-glossary", "operational-awareness"]`) {
 		t.Fatalf("pack.toml should not rewrite workspace.global_fragments into append_fragments:\n%s", packToml)

--- a/internal/builtinpacks/registry.go
+++ b/internal/builtinpacks/registry.go
@@ -27,6 +27,11 @@ const (
 	// Repository is the canonical clone URL for bundled pack imports.
 	Repository = "https://github.com/gastownhall/gascity.git"
 
+	// PublicRepository is the wave-one public pack repository. The gc binary
+	// can serve its bundled public-pack aliases from the embedded pack set
+	// when the network is unavailable during init or doctor repair.
+	PublicRepository = "https://github.com/gastownhall/gascity-packs.git"
+
 	// SyntheticCacheNamespace separates bundled synthetic repo caches from
 	// ordinary git checkouts that point at the same repository and commit.
 	SyntheticCacheNamespace = "bundled-synthetic-v1"
@@ -84,15 +89,47 @@ func ByName(name string) (Pack, bool) {
 // NameForSource reports the bundled pack addressed by source.
 func NameForSource(source string) (string, bool) {
 	normalizedRepo, subpath := splitSource(source)
-	if normalizedRepo != Repository {
-		return "", false
-	}
-	for _, pack := range All() {
-		if subpath == pack.Subpath {
-			return pack.Name, true
+	for _, layout := range syntheticPackLayouts() {
+		if normalizedRepo == layout.Repository && subpath == layout.Subpath {
+			return layout.Pack.Name, true
 		}
 	}
 	return "", false
+}
+
+type syntheticPackLayout struct {
+	Repository string
+	Subpath    string
+	Pack       Pack
+}
+
+func syntheticPackLayouts() []syntheticPackLayout {
+	packs := All()
+	layouts := make([]syntheticPackLayout, 0, len(packs)+2)
+	for _, pack := range packs {
+		layouts = append(layouts, syntheticPackLayout{
+			Repository: Repository,
+			Subpath:    pack.Subpath,
+			Pack:       pack,
+		})
+		if publicSubpath, ok := publicSubpathForPack(pack.Name); ok {
+			layouts = append(layouts, syntheticPackLayout{
+				Repository: PublicRepository,
+				Subpath:    publicSubpath,
+				Pack:       pack,
+			})
+		}
+	}
+	return layouts
+}
+
+func publicSubpathForPack(name string) (string, bool) {
+	switch name {
+	case "gastown", "maintenance":
+		return name, true
+	default:
+		return "", false
+	}
 }
 
 // IsSource reports whether source addresses one of gc's bundled packs.
@@ -118,10 +155,10 @@ func MaterializeSyntheticRepo(dst, commit string) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return fmt.Errorf("removing stale bundled pack cache %q: %w", dst, err)
 	}
-	for _, pack := range All() {
-		target := filepath.Join(dst, filepath.FromSlash(pack.Subpath))
-		if err := materializeFS(pack.FS, target); err != nil {
-			return fmt.Errorf("materializing bundled pack %q: %w", pack.Name, err)
+	for _, layout := range syntheticPackLayouts() {
+		target := filepath.Join(dst, filepath.FromSlash(layout.Subpath))
+		if err := materializeFS(layout.Pack.FS, target); err != nil {
+			return fmt.Errorf("materializing bundled pack %q at %s: %w", layout.Pack.Name, layout.Subpath, err)
 		}
 	}
 	hash, err := SyntheticContentHash()
@@ -191,8 +228,8 @@ func ValidateSyntheticRepo(dir, commit string) error {
 	if err := validateSyntheticRepoFileSet(dir); err != nil {
 		return err
 	}
-	for _, pack := range All() {
-		if err := validatePackFiles(pack, filepath.Join(dir, filepath.FromSlash(pack.Subpath))); err != nil {
+	for _, layout := range syntheticPackLayouts() {
+		if err := validatePackFiles(layout.Pack, filepath.Join(dir, filepath.FromSlash(layout.Subpath))); err != nil {
 			return err
 		}
 	}
@@ -214,7 +251,8 @@ func MaterializedFileMode(path string) os.FileMode {
 // and modes.
 func SyntheticContentHash() (string, error) {
 	var entries []string
-	for _, pack := range All() {
+	for _, layout := range syntheticPackLayouts() {
+		pack := layout.Pack
 		manifest, err := manifestForFS(pack.FS)
 		if err != nil {
 			return "", fmt.Errorf("hashing bundled pack %q: %w", pack.Name, err)
@@ -227,7 +265,7 @@ func SyntheticContentHash() (string, error) {
 		for _, rel := range paths {
 			file := manifest[rel]
 			sum := sha256.Sum256(file.data)
-			entries = append(entries, fmt.Sprintf("%s/%s %04o %x", pack.Subpath, rel, file.perm.Perm(), sum[:]))
+			entries = append(entries, fmt.Sprintf("%s/%s %04o %x", layout.Subpath, rel, file.perm.Perm(), sum[:]))
 		}
 	}
 	sort.Strings(entries)
@@ -354,11 +392,11 @@ func validateSyntheticRepoFileSet(dir string) error {
 func syntheticRepoAllowedPaths() (map[string]struct{}, map[string]struct{}, error) {
 	files := map[string]struct{}{syntheticMarkerFile: {}}
 	dirs := make(map[string]struct{})
-	for _, pack := range All() {
-		subpath := filepath.ToSlash(pack.Subpath)
-		manifest, err := manifestForFS(pack.FS)
+	for _, layout := range syntheticPackLayouts() {
+		subpath := filepath.ToSlash(layout.Subpath)
+		manifest, err := manifestForFS(layout.Pack.FS)
 		if err != nil {
-			return nil, nil, fmt.Errorf("reading bundled pack %q manifest: %w", pack.Name, err)
+			return nil, nil, fmt.Errorf("reading bundled pack %q manifest: %w", layout.Pack.Name, err)
 		}
 		for rel := range manifest {
 			full := path.Join(subpath, rel)
@@ -413,6 +451,9 @@ func normalizeRepository(repo string) string {
 	}
 	if repo == "https://github.com/gastownhall/gascity" {
 		return Repository
+	}
+	if repo == "https://github.com/gastownhall/gascity-packs" {
+		return PublicRepository
 	}
 	return repo
 }

--- a/internal/config/bundled_import_test.go
+++ b/internal/config/bundled_import_test.go
@@ -95,6 +95,26 @@ func TestResolveInstalledRemoteImportAcceptsBundledSyntheticCache(t *testing.T) 
 	}
 }
 
+func TestResolveImportPackRefAcceptsPublicGastownSyntheticCache(t *testing.T) {
+	home, cityDir := setupBundledImportTest(t)
+	source := PublicGastownPackSource
+	commit := strings.TrimPrefix(PublicGastownPackVersion, "sha:")
+	writeBundledImportLock(t, cityDir, source, commit)
+	cacheDir := bundledRepoCacheDir(home, source, commit)
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+		t.Fatalf("materialize synthetic repo: %v", err)
+	}
+
+	got, err := resolveImportPackRef(source, cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("resolveImportPackRef: %v", err)
+	}
+	want := filepath.Join(cacheDir, "gastown")
+	if got != want {
+		t.Fatalf("import path = %q, want %q", got, want)
+	}
+}
+
 func TestResolveLockedRemoteImportSurfacesInvalidBundledMarker(t *testing.T) {
 	home, cityDir := setupBundledImportTest(t)
 	source := bundledPackSource()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3645,8 +3645,8 @@ func WizardCity(name, provider, startCommand string) City {
 }
 
 // GastownCity returns a City configured for the gastown orchestration pack.
-// Agents come from the pack (.gc/system/packs/gastown); no inline agents are
-// defined. The root city pack imports gastown and sets canonical
+// Agents come from the public gastown pack; no inline agents are defined. The
+// root city pack imports gastown explicitly and sets canonical
 // DefaultRigImports so newly added rigs inherit the same pack by default. It
 // also sets global fragments and daemon config. If startCommand is set, it
 // takes precedence over provider.
@@ -3665,10 +3665,16 @@ func GastownCity(name, provider, startCommand string) City {
 	return City{
 		Workspace: ws,
 		Imports: map[string]Import{
-			"gastown": {Source: ".gc/system/packs/gastown"},
+			"gastown": {
+				Source:  PublicGastownPackSource,
+				Version: PublicGastownPackVersion,
+			},
 		},
 		DefaultRigImports: map[string]Import{
-			"gastown": {Source: ".gc/system/packs/gastown"},
+			"gastown": {
+				Source:  PublicGastownPackSource,
+				Version: PublicGastownPackVersion,
+			},
 		},
 		DefaultRigImportOrder: []string{"gastown"},
 		Daemon: DaemonConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -862,11 +862,11 @@ func TestGastownCity(t *testing.T) {
 	if c.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", c.Workspace.Provider, "claude")
 	}
-	if len(c.Imports) != 1 || c.Imports["gastown"].Source != ".gc/system/packs/gastown" {
-		t.Errorf("Imports = %v, want gastown=.gc/system/packs/gastown", c.Imports)
+	if len(c.Imports) != 1 || c.Imports["gastown"].Source != PublicGastownPackSource || c.Imports["gastown"].Version != PublicGastownPackVersion {
+		t.Errorf("Imports = %v, want gastown=%s %s", c.Imports, PublicGastownPackSource, PublicGastownPackVersion)
 	}
-	if len(c.DefaultRigImports) != 1 || c.DefaultRigImports["gastown"].Source != ".gc/system/packs/gastown" {
-		t.Errorf("DefaultRigImports = %v, want gastown=.gc/system/packs/gastown", c.DefaultRigImports)
+	if len(c.DefaultRigImports) != 1 || c.DefaultRigImports["gastown"].Source != PublicGastownPackSource || c.DefaultRigImports["gastown"].Version != PublicGastownPackVersion {
+		t.Errorf("DefaultRigImports = %v, want gastown=%s %s", c.DefaultRigImports, PublicGastownPackSource, PublicGastownPackVersion)
 	}
 	if len(c.Workspace.GlobalFragments) != 2 {
 		t.Errorf("Workspace.GlobalFragments = %v, want 2 entries", c.Workspace.GlobalFragments)
@@ -914,8 +914,8 @@ func TestGastownCityRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse(Marshal output): %v", err)
 	}
-	if len(got.Imports) != 1 || got.Imports["gastown"].Source != ".gc/system/packs/gastown" {
-		t.Errorf("round-trip Imports = %v, want gastown=.gc/system/packs/gastown", got.Imports)
+	if len(got.Imports) != 1 || got.Imports["gastown"].Source != PublicGastownPackSource || got.Imports["gastown"].Version != PublicGastownPackVersion {
+		t.Errorf("round-trip Imports = %v, want gastown=%s %s", got.Imports, PublicGastownPackSource, PublicGastownPackVersion)
 	}
 	if got.Workspace.Provider != "claude" {
 		t.Errorf("round-trip Provider = %q, want %q", got.Workspace.Provider, "claude")

--- a/internal/config/public_packs.go
+++ b/internal/config/public_packs.go
@@ -1,0 +1,12 @@
+package config
+
+const (
+	// PublicGastownPackSource is the concrete durable source for the wave-one
+	// public gastown pack. Registry selectors resolve to this same concrete
+	// source before being written to pack.toml.
+	PublicGastownPackSource = "https://github.com/gastownhall/gascity-packs.git//gastown"
+
+	// PublicGastownPackVersion pins fresh init output to the validation commit
+	// from the public built-in pack migration branch.
+	PublicGastownPackVersion = "sha:0090440b8e8efa4c40c2cef6bf585805ac87fa37"
+)

--- a/internal/config/public_packs.go
+++ b/internal/config/public_packs.go
@@ -6,7 +6,7 @@ const (
 	// source before being written to pack.toml.
 	PublicGastownPackSource = "https://github.com/gastownhall/gascity-packs.git//gastown"
 
-	// PublicGastownPackVersion pins fresh init output to the validation commit
-	// from the public built-in pack migration branch.
-	PublicGastownPackVersion = "sha:0090440b8e8efa4c40c2cef6bf585805ac87fa37"
+	// PublicGastownPackVersion pins fresh init output to the registry release
+	// content commit from gastownhall/gascity-packs main.
+	PublicGastownPackVersion = "sha:d3617d1319a1206ac85f69ba024ec395c49c6f4b"
 )

--- a/internal/packman/check_test.go
+++ b/internal/packman/check_test.go
@@ -46,6 +46,60 @@ func TestCheckInstalledReportsMissingLockfile(t *testing.T) {
 	assertSingleIssue(t, report, "missing-lockfile")
 }
 
+func TestSyncLockUsesBundledFallbackForPublicGastownWhenRemoteUnavailable(t *testing.T) {
+	home := t.TempDir()
+	city := t.TempDir()
+	t.Setenv("HOME", home)
+
+	oldRunGit := runGit
+	t.Cleanup(func() { runGit = oldRunGit })
+	runGit = func(_ string, args ...string) (string, error) {
+		return "", fmt.Errorf("network unavailable for git %s", strings.Join(args, " "))
+	}
+
+	imports := map[string]config.Import{
+		"gastown": {
+			Source:  config.PublicGastownPackSource,
+			Version: config.PublicGastownPackVersion,
+		},
+	}
+	lock, err := SyncLock(city, imports, InstallResolveIfNeeded)
+	if err != nil {
+		t.Fatalf("SyncLock: %v", err)
+	}
+	pack, ok := lock.Packs[config.PublicGastownPackSource]
+	if !ok {
+		t.Fatalf("lock packs = %#v, want public gastown source", lock.Packs)
+	}
+	if pack.Commit != strings.TrimPrefix(config.PublicGastownPackVersion, "sha:") {
+		t.Fatalf("lock commit = %q, want pinned public gastown commit", pack.Commit)
+	}
+	if err := WriteLockfile(fsys.OSFS{}, city, lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+	if _, err := InstallLocked(city); err != nil {
+		t.Fatalf("InstallLocked: %v", err)
+	}
+	report, err := CheckInstalled(city, imports)
+	if err != nil {
+		t.Fatalf("CheckInstalled: %v", err)
+	}
+	if report.HasIssues() {
+		t.Fatalf("issues = %#v, want none", report.Issues)
+	}
+
+	cacheDir, err := RepoCachePath(config.PublicGastownPackSource, pack.Commit)
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "gastown", "pack.toml")); err != nil {
+		t.Fatalf("public gastown synthetic cache missing pack.toml: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "maintenance", "pack.toml")); err != nil {
+		t.Fatalf("public maintenance synthetic cache missing pack.toml: %v", err)
+	}
+}
+
 func TestCheckInstalledReportsMissingCache(t *testing.T) {
 	home := t.TempDir()
 	city := t.TempDir()

--- a/test/acceptance/init_lifecycle_test.go
+++ b/test/acceptance/init_lifecycle_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/config"
 	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
 )
 
@@ -146,6 +147,56 @@ source = ".gc/system/packs/gastown"
 	// Positive assertion: packs must have been materialized.
 	if !c.HasFile(".gc/system/packs/gastown/pack.toml") {
 		t.Fatal(".gc/system/packs/gastown/pack.toml not materialized after resume — Bug 4 regression")
+	}
+}
+
+func TestInitPublicGastownPackStartsFromCanonicalImport(t *testing.T) {
+	c := helpers.NewCity(t, testEnv)
+	templatePath := filepath.Join(helpers.TempDir(t), "public-gastown.toml")
+	cfg := config.GastownCity(filepath.Base(c.Dir), "claude", "")
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatalf("marshaling public gastown template: %v", err)
+	}
+	if err := os.WriteFile(templatePath, data, 0o644); err != nil {
+		t.Fatalf("writing public gastown template: %v", err)
+	}
+
+	out, err := helpers.RunGC(testEnv, "", "init", "--file", templatePath, "--skip-provider-readiness", c.Dir)
+	if err != nil {
+		t.Fatalf("gc init --file public gastown failed: %v\n%s", err, out)
+	}
+	t.Cleanup(c.CleanupRuntime)
+
+	packToml := c.ReadFile("pack.toml")
+	if !strings.Contains(packToml, `source = "`+config.PublicGastownPackSource+`"`) {
+		t.Fatalf("pack.toml missing canonical public gastown source:\n%s", packToml)
+	}
+	if !strings.Contains(packToml, `version = "`+config.PublicGastownPackVersion+`"`) {
+		t.Fatalf("pack.toml missing canonical public gastown version:\n%s", packToml)
+	}
+	if strings.Contains(packToml, ".gc/system/packs/gastown") {
+		t.Fatalf("pack.toml should not reference legacy materialized gastown paths:\n%s", packToml)
+	}
+
+	packsLock := c.ReadFile("packs.lock")
+	if !strings.Contains(packsLock, `[packs."`+config.PublicGastownPackSource+`"]`) {
+		t.Fatalf("packs.lock missing canonical public gastown source:\n%s", packsLock)
+	}
+
+	if out, err := c.GC("config", "show", "--validate"); err != nil {
+		t.Fatalf("config validation after public gastown init failed: %v\n%s", err, out)
+	}
+	if out, err := c.GC("stop", c.Dir); err != nil {
+		t.Fatalf("gc stop after public gastown init failed: %v\n%s", err, out)
+	}
+	if out, err := c.GC("unregister", c.Dir); err != nil {
+		t.Fatalf("gc unregister after public gastown init failed: %v\n%s", err, out)
+	}
+
+	c.StartWithSupervisor()
+	if out, err := c.GC("status", "--city", c.Dir); err != nil {
+		t.Fatalf("gc status after public gastown start failed: %v\n%s", err, out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `gc init` write an explicit public `gastown` import from `gastownhall/gascity-packs`
- pin fresh init output to the `gascity-packs` registry release content commit `d3617d1319a1206ac85f69ba024ec395c49c6f4b`
- teach `gc doctor` to detect/fix legacy public built-in imports: rewrite `gastown`, remove explicit legacy `maintenance` because maintenance/core remains implicit, and reject durable `registry:` selectors
- install declared remote imports during init finalization after provider readiness passes, while preserving provider-readiness behavior for fresh public gastown init before the pack is installed

## Context
Builds on landed `gascity-packs` PR #27 and registry release content commit `d3617d1319a1206ac85f69ba024ec395c49c6f4b`. `maintenance` / core remains in `gascity` and implicit for this wave; `bd` and `dolt` stay SDK-integrated.

## Validation
- PASS: `go test ./cmd/gc -run 'TestLoadInitProviderPreflightConfigFallsBackForUninstalledRemoteImports|TestInstallInitRemoteImports|TestFinalizeInitReportsRemoteImportInstallFailure|TestCmdInitResumesFinalizeForExistingCity|TestImportStateDoctorCheck|TestLegacyPublicPackForSourceDetectsAbsolutePaths|TestDoInitGastownWritesCanonicalPackV2Shape' -count=1`
- PASS: `go test ./internal/config -run 'TestGastownCity|TestGastownCityRoundTrip' -count=1`
- PASS: `git diff --check`
- REVIEW: Claude review found no critical bugs; actionable findings on the provider-readiness fallback and init import-install test coverage were addressed.
- BROAD: `go test ./cmd/gc ./internal/config -count=1 -timeout=15m` still fails in unrelated existing macOS/local-env tests: `TestRunStartDriftCheck_RestartReturnsContinue`, `TestDoStartJSONAlreadyRunningSupervisorKeepsStdoutJSONOnly/drift_restart`, and `TestRigAnywhere_ResolveRigToContext` `/private/tmp` vs `/tmp` cases. `internal/config` passed.
