### PR TITLE
config: allow legacy root pack.toml [defaults.rig.imports] with deprecation warning

### DIFF
--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -174,7 +174,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		if decErr != nil {
 			return nil, nil, fmt.Errorf("parsing city pack.toml: %w", decErr)
 		}
-		if err := validatePackAuthoringSurface(md, packPath); err != nil {
+		if err := validatePackAuthoringSurfaceWithOptions(md, packPath, true); err != nil {
 			return nil, nil, fmt.Errorf("parsing city pack.toml: %w", err)
 		}
 		if fatalWarnings := fatalUndecodedWarnings(md, packPath); len(fatalWarnings) > 0 {
@@ -183,6 +183,28 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		prov.Warnings = append(prov.Warnings, packWarnings...)
 		if err := validatePackMeta(&pc.Pack); err != nil {
 			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
+		}
+		packDefaultRigImports, err := defaultRigImportsFromPackDefaults(pc.Defaults, md)
+		if err != nil {
+			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
+		}
+		if len(packDefaultRigImports) > 0 {
+			prov.Warnings = append(prov.Warnings,
+				fmt.Sprintf("%s: [defaults.rig.imports] in root pack.toml is deprecated; move these entries to city.toml", packPath))
+			if root.DefaultRigImports == nil {
+				root.DefaultRigImports = make(map[string]Import, len(packDefaultRigImports))
+			}
+			if defaultBindings == nil {
+				defaultBindings = make(map[string]bool, len(packDefaultRigImports))
+			}
+			for _, bound := range packDefaultRigImports {
+				if _, exists := root.DefaultRigImports[bound.Binding]; exists {
+					continue
+				}
+				root.DefaultRigImports[bound.Binding] = bound.Import
+				root.DefaultRigImportOrder = append(root.DefaultRigImportOrder, bound.Binding)
+				defaultBindings[bound.Binding] = true
+			}
 		}
 		legacyV1SurfaceWarningsEnabled = pc.Pack.Schema >= 2
 		if legacyV1SurfaceWarningsEnabled {

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -316,14 +316,6 @@ append_fragments = ["footer"]
 			want: "[agents] is a city.toml compatibility alias for [agent_defaults], not a pack.toml field",
 		},
 		{
-			name: "default_rig_imports",
-			packBody: `
-[defaults.rig.imports.ops]
-source = "../ops"
-`,
-			want: "[defaults.rig.imports] belongs in city.toml, not pack.toml",
-		},
-		{
 			name: "formulas_dir",
 			packBody: `
 [formulas]
@@ -373,6 +365,82 @@ schema = 2
 			}
 		})
 	}
+}
+
+func TestLoadWithIncludesRejectsNestedPackDefaultRigImports(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "test"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "test"
+schema = 2
+
+[imports.ops]
+source = "packs/ops"
+`)
+	fs.Files["/city/packs/ops/pack.toml"] = []byte(`
+[pack]
+name = "ops"
+schema = 2
+
+[defaults.rig.imports.worker]
+source = "../worker"
+`)
+
+	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err == nil {
+		t.Fatal("expected LoadWithIncludes to reject nested pack default rig imports")
+	}
+	if !strings.Contains(err.Error(), "[defaults.rig.imports] belongs in city.toml, not pack.toml") {
+		t.Fatalf("error = %v, want nested default rig import rejection", err)
+	}
+}
+
+func TestLoadWithIncludesAllowsLegacyRootPackDefaultRigImports(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "test"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "test"
+schema = 2
+
+[defaults.rig.imports.ops]
+source = "packs/ops"
+`)
+	fs.Files["/city/packs/ops/pack.toml"] = []byte(`
+[pack]
+name = "ops"
+schema = 2
+`)
+
+	cfg, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if got := cfg.DefaultRigImports["ops"].Source; got != "packs/ops" {
+		t.Fatalf("DefaultRigImports[ops].Source = %q, want packs/ops", got)
+	}
+	if len(cfg.DefaultRigImportOrder) != 1 || cfg.DefaultRigImportOrder[0] != "ops" {
+		t.Fatalf("DefaultRigImportOrder = %#v, want [ops]", cfg.DefaultRigImportOrder)
+	}
+	if !configWarningsContain(prov.Warnings, "root pack.toml is deprecated") {
+		t.Fatalf("warnings = %#v, want root pack default-rig deprecation warning", prov.Warnings)
+	}
+}
+
+func configWarningsContain(warnings []string, substr string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestLoadWithIncludes_ConcatRigs(t *testing.T) {

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -71,13 +71,20 @@ func validateCityAuthoringSurface(md toml.MetaData) error {
 }
 
 func validatePackAuthoringSurface(md toml.MetaData, source string) error {
+	return validatePackAuthoringSurfaceWithOptions(md, source, false)
+}
+
+// validatePackAuthoringSurfaceWithOptions keeps nested/imported packs on the
+// strict PackV2 surface while allowing the root city pack loader to tolerate
+// legacy default rig imports long enough to emit a migration warning.
+func validatePackAuthoringSurfaceWithOptions(md toml.MetaData, source string, allowDefaultRigImports bool) error {
 	if md.IsDefined("agent_defaults") {
 		return fmt.Errorf("%s: [agent_defaults] is a city.toml table, not a pack.toml field", source)
 	}
 	if md.IsDefined("agents") {
 		return fmt.Errorf("%s: [agents] is a city.toml compatibility alias for [agent_defaults], not a pack.toml field", source)
 	}
-	if md.IsDefined("defaults", "rig", "imports") {
+	if md.IsDefined("defaults", "rig", "imports") && !allowDefaultRigImports {
 		return fmt.Errorf("%s: [defaults.rig.imports] belongs in city.toml, not pack.toml", source)
 	}
 	if md.IsDefined("formulas", "dir") {


### PR DESCRIPTION
## Summary

Currently `origin/main` rejects `[defaults.rig.imports]` in root `pack.toml`, but existing migrated cities can still have that layout. The reject lands during city load and breaks any subsequent operation (including unrelated fixes that need to install on those cities).

This PR softens the reject to a deprecation warning at the city root level, while keeping the hard-stop for imported/nested packs (the pack-authoring validator is unchanged on that surface).

## Why split

Split out from #2594 (bd subprocess hardening) per [sjarmak review request](https://github.com/gastownhall/gascity/pull/2594#pullrequestreview-PRR_kwDORVx34c8AAAABBJ2PWg) — bd-hardening and this shim are orthogonal and read cleaner as their own focused changes.

## Behavior

- Loading the city root `pack.toml` accepts `[defaults.rig.imports.<name>]` entries with a deprecation warning, merging them into the canonical default-rig import path.
- Imported/nested packs still reject the same surface (no behavior change for the existing pack-authoring validator).

## Test plan

- [x] `go test ./internal/config/ -run 'TestLoadWithIncludes'` (covers the new accept-with-warning path + the still-rejecting nested case)

## Open follow-up (not in this PR)

The schema=2 hard-stop intent was deliberate; this is a soft-stop that should eventually re-tighten. Worth tracking the migration deadline (which version reinstates the hard error) as a follow-up issue once existing migrated cities have moved their entries to `city.toml`.