### PR TITLE
fix(controller): bound patrol-wisp named-session wake probes

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/beads/doltread"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doltauth"
@@ -57,7 +58,8 @@ func bdStoreForCity(dir, cityPath string) *beads.BdStore {
 		cfg = nil
 	}
 	reapStaleBdExportJSONL(dir)
-	return beads.NewBdStoreWithPrefix(dir, bdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
+	store := beads.NewBdStoreWithPrefix(dir, bdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
+	return attachIndexedDoltReader(store, cityPath, dir)
 }
 
 // bdStoreForRig opens a bead store at rigDir using rig-level Dolt config
@@ -74,7 +76,8 @@ func bdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...str
 		}
 	}
 	reapStaleBdExportJSONL(rigDir)
-	return beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+	store := beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+	return attachIndexedDoltReader(store, cityPath, rigDir)
 }
 
 // reapStaleBdExportJSONL removes .beads/issues.jsonl best-effort when the
@@ -159,7 +162,8 @@ func scopeIsGCManaged(scopeRoot string) bool {
 
 func controlBdStoreForCity(dir, cityPath string, cfg *config.City) *beads.BdStore {
 	reapStaleBdExportJSONL(dir)
-	return beads.NewBdStoreWithPrefix(dir, controlBdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
+	store := beads.NewBdStoreWithPrefix(dir, controlBdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
+	return attachIndexedDoltReader(store, cityPath, dir)
 }
 
 func controlBdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...string) *beads.BdStore {
@@ -173,7 +177,38 @@ func controlBdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix
 		}
 	}
 	reapStaleBdExportJSONL(rigDir)
-	return beads.NewBdStoreWithPrefix(rigDir, controlBdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+	store := beads.NewBdStoreWithPrefix(rigDir, controlBdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+	return attachIndexedDoltReader(store, cityPath, rigDir)
+}
+
+func attachIndexedDoltReader(store *beads.BdStore, cityPath, scopeRoot string) *beads.BdStore {
+	if store == nil {
+		return store
+	}
+	target, err := contract.ResolveDoltConnectionTarget(fsys.OSFS{}, cityPath, scopeRoot)
+	if err != nil {
+		return store
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(target.Port))
+	if err != nil {
+		return store
+	}
+	host := strings.TrimSpace(target.Host)
+	if host == "" {
+		return store
+	}
+	auth := doltauth.Resolve(doltauth.AuthScopeRoot(cityPath, scopeRoot, target), strings.TrimSpace(target.User), host, port)
+	reader, err := doltread.Open(doltread.Config{
+		Host:     host,
+		Port:     port,
+		Database: target.Database,
+		User:     auth.User,
+		Password: auth.Password,
+	})
+	if err != nil {
+		return store
+	}
+	return store.WithIndexedReader(reader)
 }
 
 func controlBdCommandRunnerForCity(cityPath string) beads.CommandRunner {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -53,6 +53,11 @@ type DesiredStateResult struct {
 	// direct assignee demand (Assignee == identity). The reconciler merges this
 	// into poolDesired so that on-demand named sessions remain config-eligible.
 	NamedSessionDemand map[string]bool
+	// NamedSessionWispDemand records the patrol wisp that produced
+	// NamedSessionDemand for an on-demand named session. The reconciler uses
+	// this only to re-fire an already-live idle named session; generic assigned
+	// work, pool demand, and order dispatch must not consume it.
+	NamedSessionWispDemand map[string]NamedSessionWispDemandSource
 	// StoreQueryPartial is true when one or more bead store work queries
 	// failed. When set, the reconciler must NOT drain sessions based on the
 	// incomplete desired state — a transient failure would cause running
@@ -64,6 +69,26 @@ type DesiredStateResult struct {
 	// orphaned.
 	SessionQueryPartial bool
 	BeaconTime          time.Time
+}
+
+type NamedSessionWispDemandSource struct {
+	WispID    string
+	StoreRef  string
+	Status    string
+	CreatedAt time.Time
+}
+
+func (s NamedSessionWispDemandSource) ReferenceID() string {
+	if strings.TrimSpace(s.WispID) == "" {
+		return ""
+	}
+	storeRef := strings.TrimSpace(s.StoreRef)
+	if storeRef == "" {
+		storeRef = "city"
+	} else {
+		storeRef = "rig:" + storeRef
+	}
+	return storeRef + ":" + strings.TrimSpace(s.WispID)
 }
 
 func (r DesiredStateResult) snapshotQueryPartial() bool {
@@ -587,6 +612,7 @@ func buildDesiredStateWithSessionBeads(
 			break
 		}
 	}
+	var namedWispDemand map[string]NamedSessionWispDemandSource
 	if store != nil && len(namedSpecs) > 0 {
 		wispDemand, wispPartial := namedSessionPatrolWispWakeDemand(cityPath, cfg, store, rigStores, namedSpecs, namedWorkReady, stderr)
 		if wispPartial {
@@ -595,6 +621,7 @@ func buildDesiredStateWithSessionBeads(
 		for identity := range wispDemand {
 			namedWorkReady[identity] = true
 		}
+		namedWispDemand = wispDemand
 	}
 	if len(assignedWorkBeads) > 0 {
 		fmt.Fprintf(stderr, "namedWorkReady: %d assigned beads, %d named specs, ready=%v\n", len(assignedWorkBeads), len(namedSpecs), namedWorkReady) //nolint:errcheck
@@ -660,6 +687,7 @@ func buildDesiredStateWithSessionBeads(
 		AssignedWorkStores:              assignedWorkStores,
 		AssignedWorkStoreRefs:           assignedWorkStoreRefs,
 		NamedSessionDemand:              namedWorkReady,
+		NamedSessionWispDemand:          namedWispDemand,
 		StoreQueryPartial:               storePartial,
 		BeaconTime:                      beaconTime,
 	}
@@ -874,7 +902,7 @@ func namedSessionPatrolWispWakeDemand(
 	namedSpecs map[string]namedSessionSpec,
 	alreadyReady map[string]bool,
 	stderr io.Writer,
-) (map[string]bool, bool) {
+) (map[string]NamedSessionWispDemandSource, bool) {
 	if cfg == nil || cityStore == nil || len(namedSpecs) == 0 {
 		return nil, false
 	}
@@ -885,7 +913,7 @@ func namedSessionPatrolWispWakeDemand(
 	sort.Strings(identities)
 
 	var partial bool
-	demand := make(map[string]bool)
+	demand := make(map[string]NamedSessionWispDemandSource)
 	probeCtx, cancel := context.WithTimeout(context.Background(), namedSessionWispWakeTotalBudget)
 	defer cancel()
 	readPolicy := beads.RuntimeReadPolicy(beads.ReadClassHotDegradedOK, "controller.named-session.wisp-wake")
@@ -929,10 +957,15 @@ func namedSessionPatrolWispWakeDemand(
 					continue
 				}
 				fmt.Fprintf(stderr, "namedWispWake: %s matched by wisp %s (store=%s status=%s)\n", identity, row.ID, storeRef, row.Status) //nolint:errcheck
-				demand[identity] = true
+				demand[identity] = NamedSessionWispDemandSource{
+					WispID:    row.ID,
+					StoreRef:  storeRef,
+					Status:    row.Status,
+					CreatedAt: row.CreatedAt,
+				}
 				break
 			}
-			if demand[identity] {
+			if _, ok := demand[identity]; ok {
 				break
 			}
 		}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -934,6 +934,8 @@ func namedSessionPatrolWispWakeDemand(
 			fmt.Fprintf(stderr, "namedWispWake: %s reachable store %q unavailable\n", identity, storeRef) //nolint:errcheck
 			continue
 		}
+		var selected NamedSessionWispDemandSource
+		var selectedOK bool
 		for _, status := range []string{"in_progress", "open"} {
 			if err := probeCtx.Err(); err != nil {
 				partial = true
@@ -956,24 +958,40 @@ func namedSessionPatrolWispWakeDemand(
 				if !isPatrolWispWakeCandidate(row) {
 					continue
 				}
-				fmt.Fprintf(stderr, "namedWispWake: %s matched by wisp %s (store=%s status=%s)\n", identity, row.ID, storeRef, row.Status) //nolint:errcheck
-				demand[identity] = NamedSessionWispDemandSource{
+				candidate := NamedSessionWispDemandSource{
 					WispID:    row.ID,
 					StoreRef:  storeRef,
 					Status:    row.Status,
 					CreatedAt: row.CreatedAt,
 				}
-				break
+				if namedSessionWispDemandSourceNewer(candidate, selected, selectedOK) {
+					selected = candidate
+					selectedOK = true
+				}
 			}
-			if _, ok := demand[identity]; ok {
-				break
-			}
+		}
+		if selectedOK {
+			fmt.Fprintf(stderr, "namedWispWake: %s matched by wisp %s (store=%s status=%s)\n", identity, selected.WispID, selected.StoreRef, selected.Status) //nolint:errcheck
+			demand[identity] = selected
 		}
 	}
 	if len(demand) == 0 {
 		return nil, partial
 	}
 	return demand, partial
+}
+
+func namedSessionWispDemandSourceNewer(candidate, current NamedSessionWispDemandSource, currentOK bool) bool {
+	if !currentOK {
+		return true
+	}
+	if candidate.CreatedAt.After(current.CreatedAt) {
+		return true
+	}
+	if candidate.CreatedAt.Equal(current.CreatedAt) {
+		return candidate.ReferenceID() > current.ReferenceID()
+	}
+	return false
 }
 
 func namedSessionWispWakeStore(

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -84,6 +84,8 @@ type defaultScaleCheckTarget struct {
 	err      error
 }
 
+const namedSessionWispWakeProbeLimit = 25
+
 var errPoolSessionCreateBudgetExhausted = errors.New("pool session create budget exhausted")
 
 // poolSessionCreateFairShareCounter rotates scarce create tokens across
@@ -580,6 +582,15 @@ func buildDesiredStateWithSessionBeads(
 			break
 		}
 	}
+	if store != nil && len(namedSpecs) > 0 {
+		wispDemand, wispPartial := namedSessionPatrolWispWakeDemand(cityPath, cfg, store, rigStores, namedSpecs, namedWorkReady, stderr)
+		if wispPartial {
+			storePartial = true
+		}
+		for identity := range wispDemand {
+			namedWorkReady[identity] = true
+		}
+	}
 	if len(assignedWorkBeads) > 0 {
 		fmt.Fprintf(stderr, "namedWorkReady: %d assigned beads, %d named specs, ready=%v\n", len(assignedWorkBeads), len(namedSpecs), namedWorkReady) //nolint:errcheck
 	}
@@ -848,6 +859,119 @@ func collectAssignedWorkBeadsWithStores(
 		}
 	}
 	return result, resultStores, resultStoreRefs, partial
+}
+
+func namedSessionPatrolWispWakeDemand(
+	cityPath string,
+	cfg *config.City,
+	cityStore beads.Store,
+	rigStores map[string]beads.Store,
+	namedSpecs map[string]namedSessionSpec,
+	alreadyReady map[string]bool,
+	stderr io.Writer,
+) (map[string]bool, bool) {
+	if cfg == nil || cityStore == nil || len(namedSpecs) == 0 {
+		return nil, false
+	}
+	identities := make([]string, 0, len(namedSpecs))
+	for identity := range namedSpecs {
+		identities = append(identities, identity)
+	}
+	sort.Strings(identities)
+
+	var partial bool
+	demand := make(map[string]bool)
+	for _, identity := range identities {
+		spec := namedSpecs[identity]
+		if spec.Mode != "on_demand" || alreadyReady[identity] {
+			continue
+		}
+		store, storeRef, ok := namedSessionWispWakeStore(cityPath, cfg, cityStore, rigStores, spec)
+		if !ok {
+			partial = true
+			fmt.Fprintf(stderr, "namedWispWake: %s reachable store %q unavailable\n", identity, storeRef) //nolint:errcheck
+			continue
+		}
+		for _, status := range []string{"in_progress", "open"} {
+			rows, err := listForControllerDemand(store, beads.ListQuery{
+				Status:   status,
+				Assignee: identity,
+				Limit:    namedSessionWispWakeProbeLimit,
+				TierMode: beads.TierWisps,
+			})
+			if err != nil {
+				partial = true
+				log.Printf("namedWispWake: List(%s, assignee=%q, wisps): %v", status, identity, err)
+				if !beads.IsPartialResult(err) || len(rows) == 0 {
+					continue
+				}
+			}
+			for _, row := range rows {
+				if !isPatrolWispWakeCandidate(row) {
+					continue
+				}
+				fmt.Fprintf(stderr, "namedWispWake: %s matched by wisp %s (store=%s status=%s)\n", identity, row.ID, storeRef, row.Status) //nolint:errcheck
+				demand[identity] = true
+				break
+			}
+			if demand[identity] {
+				break
+			}
+		}
+	}
+	if len(demand) == 0 {
+		return nil, partial
+	}
+	return demand, partial
+}
+
+func namedSessionWispWakeStore(
+	cityPath string,
+	cfg *config.City,
+	cityStore beads.Store,
+	rigStores map[string]beads.Store,
+	spec namedSessionSpec,
+) (beads.Store, string, bool) {
+	storeRef := assignedWorkStoreRefForAgent(cityPath, cfg, spec.Agent)
+	if storeRef == "" {
+		return cityStore, "", cityStore != nil
+	}
+	if rigStores == nil {
+		return nil, storeRef, false
+	}
+	store := rigStores[storeRef]
+	return store, storeRef, store != nil
+}
+
+func isPatrolWispWakeCandidate(bead beads.Bead) bool {
+	if !bead.Ephemeral {
+		return false
+	}
+	if bead.Status != "open" && bead.Status != "in_progress" {
+		return false
+	}
+	values := []string{
+		bead.Title,
+		bead.Ref,
+		bead.Metadata["formula"],
+		bead.Metadata["gc.formula"],
+		bead.Metadata["wisp_type"],
+		bead.Metadata["gc.wisp_type"],
+	}
+	for _, value := range values {
+		if isPatrolFormulaSignal(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPatrolFormulaSignal(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	return value == "patrol" || strings.HasSuffix(value, "-patrol") || strings.HasSuffix(value, ".patrol")
 }
 
 func assignedWorkReadyLimit(cfg *config.City) int {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -84,7 +85,11 @@ type defaultScaleCheckTarget struct {
 	err      error
 }
 
-const namedSessionWispWakeProbeLimit = 25
+const (
+	namedSessionWispWakeProbeLimit  = 25
+	namedSessionWispWakeReadBudget  = 250 * time.Millisecond
+	namedSessionWispWakeTotalBudget = time.Second
+)
 
 var errPoolSessionCreateBudgetExhausted = errors.New("pool session create budget exhausted")
 
@@ -881,7 +886,16 @@ func namedSessionPatrolWispWakeDemand(
 
 	var partial bool
 	demand := make(map[string]bool)
+	probeCtx, cancel := context.WithTimeout(context.Background(), namedSessionWispWakeTotalBudget)
+	defer cancel()
+	readPolicy := beads.RuntimeReadPolicy(beads.ReadClassHotDegradedOK, "controller.named-session.wisp-wake")
+	readPolicy.Timeout = namedSessionWispWakeReadBudget
 	for _, identity := range identities {
+		if err := probeCtx.Err(); err != nil {
+			partial = true
+			log.Printf("namedWispWake: aggregate probe budget exhausted before assignee=%q: %v", identity, err)
+			break
+		}
 		spec := namedSpecs[identity]
 		if spec.Mode != "on_demand" || alreadyReady[identity] {
 			continue
@@ -893,18 +907,22 @@ func namedSessionPatrolWispWakeDemand(
 			continue
 		}
 		for _, status := range []string{"in_progress", "open"} {
-			rows, err := listForControllerDemand(store, beads.ListQuery{
-				Status:   status,
-				Assignee: identity,
-				Limit:    namedSessionWispWakeProbeLimit,
-				TierMode: beads.TierWisps,
-			})
+			if err := probeCtx.Err(); err != nil {
+				partial = true
+				log.Printf("namedWispWake: aggregate probe budget exhausted for assignee=%q status=%s: %v", identity, status, err)
+				break
+			}
+			rows, err := beads.RuntimeList(probeCtx, store, beads.ListQuery{
+				Status:     status,
+				Assignee:   identity,
+				Limit:      namedSessionWispWakeProbeLimit,
+				TierMode:   beads.TierWisps,
+				SkipLabels: true,
+			}, readPolicy)
 			if err != nil {
 				partial = true
-				log.Printf("namedWispWake: List(%s, assignee=%q, wisps): %v", status, identity, err)
-				if !beads.IsPartialResult(err) || len(rows) == 0 {
-					continue
-				}
+				log.Printf("namedWispWake: degraded runtime read status=%s assignee=%q store=%q: %v", status, identity, storeRef, err)
+				continue
 			}
 			for _, row := range rows {
 				if !isPatrolWispWakeCandidate(row) {
@@ -1180,19 +1198,13 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 		// unassigned + matching-routed_to checks apply below as for the
 		// Ready source.
 		//
-		// Live: true skips the CachingStore in-memory snapshot and reads
-		// the backing store directly. The cache populates from PrimeActive
-		// at supervisor startup and is maintained by the event stream, but
-		// gc order run is a sibling subprocess so the cache lag would
-		// otherwise stretch demand observation by an unbounded number of
-		// reconcile ticks. Mirrors openSessionBeadExists in
-		// adoption_barrier.go, which uses Live: true for the same
-		// cross-process freshness reason.
-		demand, demandErr := group.store.List(beads.ListQuery{
+		// RuntimeList uses the bounded hot-read contract. It can use cache or
+		// indexed coverage, but it must not fall through to hydrated CLI listing
+		// from the controller tick.
+		demand, demandErr := beads.RuntimeList(context.Background(), group.store, beads.ListQuery{
 			Status:   "open",
 			Metadata: poolDemandMetadataPair(),
-			Live:     true,
-		})
+		}, beads.RuntimeReadPolicy(beads.ReadClassHotDegradedOK, "controller.default-scale.pool-demand"))
 		if demandErr != nil {
 			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: List(%s): %w", key, strings.Join(sortedStringSet(group.templates), ","), poolDemandMetadataKey, demandErr))
 			partialTemplates = markScaleCheckPartialSet(partialTemplates, group.templates)
@@ -1418,22 +1430,16 @@ func sortedStringSet(values map[string]struct{}) []string {
 }
 
 func listForControllerDemand(store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
-	if _, ok := store.(interface {
-		CachedList(beads.ListQuery) ([]beads.Bead, bool)
-	}); ok {
-		cacheQuery := query
-		cacheQuery.Live = false
-		return store.List(cacheQuery)
-	}
-	liveQuery := query
-	liveQuery.Live = true
-	return store.List(liveQuery)
+	query.Live = false
+	return beads.RuntimeList(context.Background(), store, query,
+		beads.RuntimeReadPolicy(beads.ReadClassHotDegradedOK, "controller.demand.list"))
 }
 
 func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
 	// Controller demand reads are intentionally cache-tolerant, not
-	// authoritative lifecycle gates; CachedReady falls back whenever the cache
-	// has dirty or unknown dependency coverage.
+	// authoritative lifecycle gates. CachedReady answers only when the cache
+	// has known dependency coverage; otherwise RuntimeReady reports a degraded
+	// hot read instead of invoking the hydrated ready path from the tick.
 	if cached, ok := store.(interface {
 		CachedReady() ([]beads.Bead, bool)
 	}); ok {
@@ -1441,7 +1447,8 @@ func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
 			return ready, nil
 		}
 	}
-	return beads.ReadyLive(store)
+	return beads.RuntimeReady(context.Background(), store, beads.ReadyQuery{},
+		beads.RuntimeReadPolicy(beads.ReadClassHotDegradedOK, "controller.demand.ready"))
 }
 
 func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([]beads.Bead, error) {
@@ -1452,7 +1459,8 @@ func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([
 			return filterReadyForControllerDemand(ready, query), nil
 		}
 	}
-	return store.Ready(query)
+	return beads.RuntimeReady(context.Background(), store, query,
+		beads.RuntimeReadPolicy(beads.ReadClassHotDegradedOK, "controller.demand.ready"))
 }
 
 func filterReadyForControllerDemand(ready []beads.Bead, query beads.ReadyQuery) []beads.Bead {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4777,6 +4777,15 @@ func TestBuildDesiredState_OnDemandNamedSession_PatrolWispMaterializesNamedSessi
 	if err != nil {
 		t.Fatalf("create patrol wisp: %v", err)
 	}
+	inProgress := "in_progress"
+	assignee := "riga/refinery"
+	if err := rigStore.Update(wisp.ID, beads.UpdateOpts{Status: &inProgress, Assignee: &assignee}); err != nil {
+		t.Fatalf("mark patrol wisp in progress: %v", err)
+	}
+	wisp, err = rigStore.Get(wisp.ID)
+	if err != nil {
+		t.Fatalf("get patrol wisp: %v", err)
+	}
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
@@ -4800,6 +4809,16 @@ func TestBuildDesiredState_OnDemandNamedSession_PatrolWispMaterializesNamedSessi
 	)
 	if !dsResult.NamedSessionDemand["riga/refinery"] {
 		t.Fatal("NamedSessionDemand[riga/refinery] = false for assigned patrol wisp")
+	}
+	source, ok := dsResult.NamedSessionWispDemand["riga/refinery"]
+	if !ok {
+		t.Fatal("NamedSessionWispDemand[riga/refinery] missing for assigned patrol wisp")
+	}
+	if source.WispID != wisp.ID || source.StoreRef != "riga" || source.Status != "in_progress" {
+		t.Fatalf("NamedSessionWispDemand[riga/refinery] = %+v, want wisp=%s store=riga status=in_progress", source, wisp.ID)
+	}
+	if got := source.ReferenceID(); got != "rig:riga:"+wisp.ID {
+		t.Fatalf("NamedSessionWispDemand reference = %q, want %q", got, "rig:riga:"+wisp.ID)
 	}
 	var refineryEntries []TemplateParams
 	for _, tp := range dsResult.State {
@@ -5066,7 +5085,7 @@ func TestBuildDesiredState_OnDemandNamedSession_PatrolWispProbeDoesNotUseHydrate
 	if calls != 0 {
 		t.Fatalf("bd runner calls = %d, want 0 for patrol-wisp hot probe", calls)
 	}
-	if demand["refinery"] {
+	if _, ok := demand["refinery"]; ok {
 		t.Fatal("wisp demand[refinery] = true from degraded/unproven patrol-wisp read")
 	}
 	if !partial {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -136,6 +136,37 @@ func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, err
 	return s.Store.List(query)
 }
 
+type demandTierRecordingStore struct {
+	*beads.MemStore
+	mu              sync.Mutex
+	wispTierLists   int
+	wispTierQueries []beads.ListQuery
+}
+
+func (s *demandTierRecordingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.TierMode == beads.TierWisps {
+		s.mu.Lock()
+		s.wispTierLists++
+		s.wispTierQueries = append(s.wispTierQueries, query)
+		s.mu.Unlock()
+	}
+	return s.MemStore.List(query)
+}
+
+func (s *demandTierRecordingStore) WispTierLists() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.wispTierLists
+}
+
+func (s *demandTierRecordingStore) WispTierQueries() []beads.ListQuery {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]beads.ListQuery, len(s.wispTierQueries))
+	copy(out, s.wispTierQueries)
+	return out
+}
+
 type demandRefreshFailStore struct {
 	beads.Store
 	failNextGet         bool
@@ -326,6 +357,45 @@ func TestCollectAssignedWorkBeadsFallsBackLiveWhenCachedInProgressDirty(t *testi
 	}
 	if backing.liveInProgressLists != 1 {
 		t.Fatalf("live in_progress list calls = %d, want dirty cache fallback", backing.liveInProgressLists)
+	}
+}
+
+func TestCollectAssignedWorkBeadsDoesNotReadWispTierForDemand(t *testing.T) {
+	store := &demandTierRecordingStore{MemStore: beads.NewMemStore()}
+	work, err := store.Create(beads.Bead{
+		Title:    "active handoff",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("create active bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:     "refinery patrol",
+		Type:      "molecule",
+		Status:    "in_progress",
+		Assignee:  "repo/refinery",
+		Ephemeral: true,
+	}); err != nil {
+		t.Fatalf("create ephemeral wisp: %v", err)
+	}
+
+	got, partial := collectAssignedWorkBeads(&config.City{
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+			Dir:      "repo",
+			Mode:     "on_demand",
+		}},
+	}, store)
+	if partial {
+		t.Fatal("collectAssignedWorkBeads reported partial results")
+	}
+	if store.WispTierLists() != 0 {
+		t.Fatalf("wisp-tier demand list calls = %d, want 0", store.WispTierLists())
+	}
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want only issue-tier work %s", got, work.ID)
 	}
 }
 
@@ -4668,6 +4738,277 @@ func TestBuildDesiredState_OnDemandNamedSession_DirectAssigneeMaterializes(t *te
 	}
 	if !found {
 		t.Fatal("direct assignee should materialize on-demand named session")
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_PatrolWispMaterializesNamedSessionOnly(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("create rig dir: %v", err)
+	}
+	cityStore := &demandTierRecordingStore{MemStore: beads.NewMemStore()}
+	rigStore := &demandTierRecordingStore{MemStore: beads.NewMemStore()}
+	wisp, err := rigStore.Create(beads.Bead{
+		Title:     "refinery patrol",
+		Type:      "task",
+		Status:    "in_progress",
+		Assignee:  "riga/refinery",
+		Ref:       "mol-refinery-patrol",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"formula": "mol-refinery-patrol",
+			"gc.kind": "wisp",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create patrol wisp: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			Dir:               "riga",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+			Dir:      "riga",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"riga": rigStore}, nil, nil, io.Discard,
+	)
+	if !dsResult.NamedSessionDemand["riga/refinery"] {
+		t.Fatal("NamedSessionDemand[riga/refinery] = false for assigned patrol wisp")
+	}
+	var refineryEntries []TemplateParams
+	for _, tp := range dsResult.State {
+		if tp.ConfiguredNamedIdentity == "riga/refinery" || tp.TemplateName == "riga/refinery" {
+			refineryEntries = append(refineryEntries, tp)
+		}
+	}
+	if len(refineryEntries) != 1 {
+		t.Fatalf("refinery desired entries = %d, want exactly one named session: %+v", len(refineryEntries), refineryEntries)
+	}
+	for _, bead := range dsResult.AssignedWorkBeads {
+		if bead.ID == wisp.ID {
+			t.Fatalf("assigned patrol wisp %s leaked into AssignedWorkBeads: %+v", wisp.ID, dsResult.AssignedWorkBeads)
+		}
+	}
+	if got := dsResult.ScaleCheckCounts["riga/refinery"]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[riga/refinery] = %d, want 0 for named-session wisp wake", got)
+	}
+	if cityStore.WispTierLists() != 0 {
+		t.Fatalf("city store wisp-tier probes = %d, want 0 for rig-scoped named session", cityStore.WispTierLists())
+	}
+	queries := rigStore.WispTierQueries()
+	if len(queries) == 0 {
+		t.Fatal("rig store wisp-tier probe did not run")
+	}
+	first := queries[0]
+	if first.Assignee != "riga/refinery" || first.Status != "in_progress" || first.Limit != namedSessionWispWakeProbeLimit || first.TierMode != beads.TierWisps {
+		t.Fatalf("first wisp probe query = %+v, want assignee/status-bounded TierWisps Limit=%d", first, namedSessionWispWakeProbeLimit)
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_PatrolWispProbeChecksBoundedPageAndTitle(t *testing.T) {
+	cityPath := t.TempDir()
+	store := &demandTierRecordingStore{MemStore: beads.NewMemStore()}
+	if _, err := store.Create(beads.Bead{
+		Title:     "mol-refinery-work",
+		Status:    "in_progress",
+		Assignee:  "refinery",
+		Ephemeral: true,
+	}); err != nil {
+		t.Fatalf("create non-patrol wisp: %v", err)
+	}
+	wisp, err := store.Create(beads.Bead{
+		Title:     "mol-refinery-patrol",
+		Status:    "in_progress",
+		Assignee:  "refinery",
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("create title-only patrol wisp: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+			Mode:     "on_demand",
+		}},
+	}
+
+	var stderr bytes.Buffer
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, &stderr)
+	if !dsResult.NamedSessionDemand["refinery"] {
+		t.Fatal("NamedSessionDemand[refinery] = false when patrol wisp follows a non-patrol wisp in the bounded page")
+	}
+	if !strings.Contains(stderr.String(), "matched by wisp "+wisp.ID) {
+		t.Fatalf("stderr did not show patrol wisp match for %s:\n%s", wisp.ID, stderr.String())
+	}
+	queries := store.WispTierQueries()
+	var sawInProgress bool
+	for _, query := range queries {
+		if query.Status == "in_progress" && query.Assignee == "refinery" && query.TierMode == beads.TierWisps {
+			sawInProgress = true
+			if query.Limit != namedSessionWispWakeProbeLimit {
+				t.Fatalf("wisp probe limit = %d, want %d", query.Limit, namedSessionWispWakeProbeLimit)
+			}
+		}
+	}
+	if !sawInProgress {
+		t.Fatalf("wisp probe queries = %+v, want in_progress query", queries)
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_OpenPatrolWispMaterializes(t *testing.T) {
+	cityPath := t.TempDir()
+	store := &demandTierRecordingStore{MemStore: beads.NewMemStore()}
+	if _, err := store.Create(beads.Bead{
+		Title:     "mayor patrol",
+		Type:      "task",
+		Status:    "open",
+		Assignee:  "mayor",
+		Ref:       "mol-mayor-patrol",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"formula": "mol-mayor-patrol",
+			"gc.kind": "wisp",
+		},
+	}); err != nil {
+		t.Fatalf("create patrol wisp: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if !dsResult.NamedSessionDemand["mayor"] {
+		t.Fatal("NamedSessionDemand[mayor] = false for open assigned patrol wisp")
+	}
+	queries := store.WispTierQueries()
+	if len(queries) != 2 {
+		t.Fatalf("wisp probe queries = %+v, want in_progress miss then open hit", queries)
+	}
+	if queries[0].Status != "in_progress" || queries[1].Status != "open" {
+		t.Fatalf("wisp probe statuses = %+v, want in_progress then open", queries)
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_WispWakeRequiresMatchingAssigneeStoreAndPatrol(t *testing.T) {
+	tests := []struct {
+		name     string
+		storeRef string
+		assignee string
+		formula  string
+	}{
+		{
+			name:     "wrong assignee",
+			storeRef: "rig",
+			assignee: "riga/other",
+			formula:  "mol-refinery-patrol",
+		},
+		{
+			name:     "wrong store",
+			storeRef: "city",
+			assignee: "riga/refinery",
+			formula:  "mol-refinery-patrol",
+		},
+		{
+			name:     "non patrol formula",
+			storeRef: "rig",
+			assignee: "riga/refinery",
+			formula:  "mol-refinery-work",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			rigPath := filepath.Join(cityPath, "riga")
+			if err := os.MkdirAll(rigPath, 0o755); err != nil {
+				t.Fatalf("create rig dir: %v", err)
+			}
+			cityStore := &demandTierRecordingStore{MemStore: beads.NewMemStore()}
+			rigStore := &demandTierRecordingStore{MemStore: beads.NewMemStore()}
+			targetStore := rigStore
+			if tc.storeRef == "city" {
+				targetStore = cityStore
+			}
+			if _, err := targetStore.Create(beads.Bead{
+				Title:     "candidate wisp",
+				Type:      "task",
+				Status:    "in_progress",
+				Assignee:  tc.assignee,
+				Ref:       tc.formula,
+				Ephemeral: true,
+				Metadata: map[string]string{
+					"formula": tc.formula,
+					"gc.kind": "wisp",
+				},
+			}); err != nil {
+				t.Fatalf("create wisp: %v", err)
+			}
+			cfg := &config.City{
+				Workspace: config.Workspace{Name: "test-city"},
+				Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
+				Agents: []config.Agent{{
+					Name:              "refinery",
+					Dir:               "riga",
+					StartCommand:      "true",
+					MaxActiveSessions: intPtr(1),
+					WorkQuery:         "printf ''",
+				}},
+				NamedSessions: []config.NamedSession{{
+					Template: "refinery",
+					Dir:      "riga",
+					Mode:     "on_demand",
+				}},
+			}
+
+			dsResult := buildDesiredStateWithSessionBeads(
+				"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+				cityStore, map[string]beads.Store{"riga": rigStore}, nil, nil, io.Discard,
+			)
+			if dsResult.NamedSessionDemand["riga/refinery"] {
+				t.Fatalf("NamedSessionDemand[riga/refinery] = true for %s", tc.name)
+			}
+			for _, tp := range dsResult.State {
+				if tp.ConfiguredNamedIdentity == "riga/refinery" || tp.TemplateName == "riga/refinery" {
+					t.Fatalf("named session materialized for %s: %+v", tc.name, tp)
+				}
+			}
+			if cityStore.WispTierLists() != 0 {
+				t.Fatalf("city store wisp-tier probes = %d, want 0 for rig-scoped named session", cityStore.WispTierLists())
+			}
+			if rigStore.WispTierLists() == 0 {
+				t.Fatal("rig store wisp-tier probe did not run")
+			}
+		})
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -120,7 +120,7 @@ type demandListCountingStore struct {
 	beads.Store
 	liveInProgressLists int
 	liveOpenMolecules   int
-	livePoolDemand      int
+	poolDemandLists     int
 }
 
 func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
@@ -130,10 +130,22 @@ func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, err
 	if query.Live && query.Status == "open" && query.Type == "molecule" {
 		s.liveOpenMolecules++
 	}
-	if query.Live && query.Status == "open" && query.Metadata[poolDemandMetadataKey] == poolDemandMetadataValue {
-		s.livePoolDemand++
+	if query.Status == "open" && query.Metadata[poolDemandMetadataKey] == poolDemandMetadataValue {
+		s.poolDemandLists++
 	}
 	return s.Store.List(query)
+}
+
+type runtimeDemandCountingStore struct {
+	*beads.CachingStore
+	poolDemandRuntimeLists int
+}
+
+func (s *runtimeDemandCountingStore) RuntimeList(ctx context.Context, query beads.ListQuery, policy beads.ReadPolicy) ([]beads.Bead, error) {
+	if query.Status == "open" && query.Metadata[poolDemandMetadataKey] == poolDemandMetadataValue {
+		s.poolDemandRuntimeLists++
+	}
+	return s.CachingStore.RuntimeList(ctx, query, policy)
 }
 
 type demandTierRecordingStore struct {
@@ -222,7 +234,7 @@ func (s *partialAssignedWorkStore) List(query beads.ListQuery) ([]beads.Bead, er
 	if err != nil {
 		return nil, err
 	}
-	if s.partialInProgress && query.Status == "in_progress" && query.Live {
+	if s.partialInProgress && query.Status == "in_progress" {
 		return rows, &beads.PartialResultError{Op: "bd list", Err: errors.New("skipped corrupt in-progress bead")}
 	}
 	return rows, nil
@@ -605,11 +617,11 @@ func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
 // Regression for https://github.com/gastownhall/gascity/pull/2531
 // → https://github.com/gastownhall/gascity/pull/2556.
 //
-// Also asserts the Live: true cache-bypass behavior is load-bearing:
-// the demandListCountingStore's livePoolDemand counter must increment,
-// proving defaultScaleCheckCounts goes through to the backing store
-// rather than the CachingStore snapshot (which can lag for wisps
-// created by sibling subprocesses like gc order run).
+// Also asserts the runtime-list demand path is load-bearing: the
+// runtimeDemandCountingStore's counter must increment, proving
+// defaultScaleCheckCounts asks for the explicit gc.pool_demand metadata pair
+// rather than relying on Ready() to return workflow containers. A live cache
+// may satisfy that read without consulting the backing store.
 func TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag(t *testing.T) {
 	backing := &demandListCountingStore{Store: beads.NewMemStore()}
 	if _, err := backing.Create(beads.Bead{
@@ -624,11 +636,12 @@ func TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag(t *testing.T
 	if err := cache.PrimeActive(); err != nil {
 		t.Fatalf("PrimeActive: %v", err)
 	}
+	runtimeStore := &runtimeDemandCountingStore{CachingStore: cache}
 
 	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
 		template: "dog",
 		storeKey: "city",
-		store:    cache,
+		store:    runtimeStore,
 	}})
 	if len(errs) != 0 {
 		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
@@ -636,8 +649,8 @@ func TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag(t *testing.T
 	if got := counts["dog"]; got != 1 {
 		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1 (gc.pool_demand wisp must count as cron pool demand)", "dog", got)
 	}
-	if backing.livePoolDemand == 0 {
-		t.Fatalf("livePoolDemand list calls = 0, want >0 (defaultScaleCheckCounts must use Live: true to bypass the CachingStore snapshot, since cron pool orders fire from sibling subprocesses and the cache lags)")
+	if runtimeStore.poolDemandRuntimeLists == 0 {
+		t.Fatalf("poolDemandRuntimeLists = 0, want >0 (defaultScaleCheckCounts must query gc.pool_demand metadata through RuntimeList)")
 	}
 }
 
@@ -898,7 +911,7 @@ func TestDefaultScaleCheckCountsHonorsCachedWriteThroughDependencies(t *testing.
 	}
 }
 
-func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T) {
+func TestDefaultScaleCheckCountsDegradesWhenCachedEventDepsUnknown(t *testing.T) {
 	backing := &readyStaticStore{
 		Store: beads.NewMemStore(),
 		ready: []beads.Bead{{
@@ -922,14 +935,14 @@ func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T
 		storeKey: "rig:gascity",
 		store:    cache,
 	}})
-	if len(errs) != 0 {
-		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	if len(errs) == 0 {
+		t.Fatal("defaultScaleCheckCounts errs = nil, want degraded runtime ready error")
 	}
-	if got := counts["gascity/workflows.codex-max"]; got != 1 {
-		t.Fatalf("defaultScaleCheckCounts = %d, want live ready fallback count only", got)
+	if got := counts["gascity/workflows.codex-max"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want 0 when hot ready read degrades", got)
 	}
-	if backing.readyCalls != 1 {
-		t.Fatalf("backing Ready calls = %d, want one live ready fallback", backing.readyCalls)
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want no hydrated ready fallback", backing.readyCalls)
 	}
 }
 
@@ -5009,6 +5022,181 @@ func TestBuildDesiredState_OnDemandNamedSession_WispWakeRequiresMatchingAssignee
 				t.Fatal("rig store wisp-tier probe did not run")
 			}
 		})
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_PatrolWispProbeDoesNotUseHydratedFallback(t *testing.T) {
+	cityPath := t.TempDir()
+	var mu sync.Mutex
+	runnerCalls := 0
+	backing := beads.NewBdStore(cityPath, func(string, string, ...string) ([]byte, error) {
+		mu.Lock()
+		runnerCalls++
+		mu.Unlock()
+		return nil, errors.New("runner must not be called")
+	})
+	store := beads.NewCachingStoreForTest(backing, nil)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+			Mode:     "on_demand",
+		}},
+	}
+
+	spec, ok := findNamedSessionSpec(cfg, "test-city", "refinery")
+	if !ok {
+		t.Fatal("named session spec not found")
+	}
+	demand, partial := namedSessionPatrolWispWakeDemand(
+		cityPath, cfg, store, nil,
+		map[string]namedSessionSpec{"refinery": spec},
+		nil,
+		io.Discard,
+	)
+	mu.Lock()
+	calls := runnerCalls
+	mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("bd runner calls = %d, want 0 for patrol-wisp hot probe", calls)
+	}
+	if demand["refinery"] {
+		t.Fatal("wisp demand[refinery] = true from degraded/unproven patrol-wisp read")
+	}
+	if !partial {
+		t.Fatal("partial = false, want true when patrol-wisp runtime read degrades")
+	}
+}
+
+type slowPatrolWispRuntimeStore struct {
+	*beads.MemStore
+	delay time.Duration
+
+	mu      sync.Mutex
+	queries []beads.ListQuery
+}
+
+func (s *slowPatrolWispRuntimeStore) RuntimeList(ctx context.Context, query beads.ListQuery, policy beads.ReadPolicy) ([]beads.Bead, error) {
+	if query.TierMode != beads.TierWisps {
+		return s.List(query)
+	}
+	s.mu.Lock()
+	s.queries = append(s.queries, query)
+	s.mu.Unlock()
+
+	readCtx := ctx
+	cancel := func() {}
+	if policy.Timeout > 0 {
+		readCtx, cancel = context.WithTimeout(ctx, policy.Timeout)
+	}
+	defer cancel()
+	timer := time.NewTimer(s.delay)
+	defer timer.Stop()
+	select {
+	case <-readCtx.Done():
+		return nil, readCtx.Err()
+	case <-timer.C:
+		return s.List(query)
+	}
+}
+
+func (s *slowPatrolWispRuntimeStore) queryCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.queries)
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_PatrolWispProbeBudgetBoundsSlowStore(t *testing.T) {
+	cityPath := t.TempDir()
+	store := &slowPatrolWispRuntimeStore{
+		MemStore: beads.NewMemStore(),
+		delay:    10 * time.Second,
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+	}
+	for i := 0; i < 12; i++ {
+		name := fmt.Sprintf("worker%d", i)
+		cfg.Agents = append(cfg.Agents, config.Agent{
+			Name:              name,
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		})
+		cfg.NamedSessions = append(cfg.NamedSessions, config.NamedSession{
+			Template: name,
+			Mode:     "on_demand",
+		})
+	}
+
+	start := time.Now()
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		store, nil, nil, nil, io.Discard,
+	)
+	elapsed := time.Since(start)
+	if elapsed > namedSessionWispWakeTotalBudget+750*time.Millisecond {
+		t.Fatalf("buildDesiredState elapsed = %v, want bounded by aggregate patrol-wisp budget %v", elapsed, namedSessionWispWakeTotalBudget)
+	}
+	if store.queryCount() < 2 {
+		t.Fatalf("wisp runtime queries = %d, want multiple probes before aggregate budget", store.queryCount())
+	}
+	if len(dsResult.NamedSessionDemand) != 0 {
+		t.Fatalf("NamedSessionDemand = %#v, want no demand from timed-out patrol-wisp probes", dsResult.NamedSessionDemand)
+	}
+	if !dsResult.StoreQueryPartial {
+		t.Fatal("StoreQueryPartial = false, want true when aggregate patrol-wisp budget expires")
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_PatrolWispDoesNotEnterAssignedWorkBeads(t *testing.T) {
+	cityPath := t.TempDir()
+	store := &demandTierRecordingStore{MemStore: beads.NewMemStore()}
+	wisp, err := store.Create(beads.Bead{
+		Title:     "refinery patrol",
+		Type:      "task",
+		Status:    "in_progress",
+		Assignee:  "refinery",
+		Ref:       "refinery-patrol",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"formula": "refinery-patrol",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create patrol wisp: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if !dsResult.NamedSessionDemand["refinery"] {
+		t.Fatal("NamedSessionDemand[refinery] = false for assigned patrol wisp")
+	}
+	for _, bead := range dsResult.AssignedWorkBeads {
+		if bead.ID == wisp.ID {
+			t.Fatalf("patrol wisp %s leaked into AssignedWorkBeads: %+v", wisp.ID, dsResult.AssignedWorkBeads)
+		}
+	}
+	if got := dsResult.ScaleCheckCounts["refinery"]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[refinery] = %d, want 0 for patrol-wisp named-session wake", got)
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4850,6 +4850,76 @@ func TestBuildDesiredState_OnDemandNamedSession_PatrolWispMaterializesNamedSessi
 	}
 }
 
+func TestBuildDesiredState_OnDemandNamedSession_PatrolWispDemandSelectsNewestCandidate(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	oldWisp, err := store.Create(beads.Bead{
+		Title:     "mol-refinery-patrol",
+		Assignee:  "refinery",
+		Ref:       "mol-refinery-patrol",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"formula": "mol-refinery-patrol",
+			"gc.kind": "wisp",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create old patrol wisp: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(oldWisp.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark old patrol wisp in progress: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	newWisp, err := store.Create(beads.Bead{
+		Title:     "mol-refinery-patrol",
+		Assignee:  "refinery",
+		Ref:       "mol-refinery-patrol",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"formula": "mol-refinery-patrol",
+			"gc.kind": "wisp",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create new patrol wisp: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "refinery",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+			Mode:     "on_demand",
+		}},
+	}
+
+	spec, ok := findNamedSessionSpec(cfg, "test-city", "refinery")
+	if !ok {
+		t.Fatal("named session spec not found")
+	}
+	demand, partial := namedSessionPatrolWispWakeDemand(
+		cityPath, cfg, store, nil,
+		map[string]namedSessionSpec{"refinery": spec},
+		nil,
+		io.Discard,
+	)
+	if partial {
+		t.Fatal("partial = true, want false")
+	}
+	source, ok := demand["refinery"]
+	if !ok {
+		t.Fatal("wisp demand[refinery] missing")
+	}
+	if source.WispID != newWisp.ID || source.Status != "open" {
+		t.Fatalf("selected source = %+v, want newest open wisp %s over old in_progress %s", source, newWisp.ID, oldWisp.ID)
+	}
+}
+
 func TestBuildDesiredState_OnDemandNamedSession_PatrolWispProbeChecksBoundedPageAndTitle(t *testing.T) {
 	cityPath := t.TempDir()
 	store := &demandTierRecordingStore{MemStore: beads.NewMemStore()}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -2036,6 +2036,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		cr.dops,
 		awakeAssignedWorkBeads, rigStores, readyWaitSet, cr.sessionDrains, poolDesired,
 		result.NamedSessionDemand,
+		result.NamedSessionWispDemand,
 		result.snapshotQueryPartial(),
 		workSet, cityName,
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
@@ -2496,6 +2497,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		cr.sessionDrains,
 		poolDesired,
 		wfcResult.NamedSessionDemand,
+		wfcResult.NamedSessionWispDemand,
 		false, // storeQueryPartial: config-change path doesn't query work beads
 		nil,   // workSet: not computed for config-change reconcile
 		cr.cityName,

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -901,6 +901,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		sigCtx, cityPath, open, ds, cfgNames, cfg, sp, oneShotStore,
 		nil, awakeAssignedWorkBeads, rigStores, nil, dt, poolDesired,
 		dsResult.NamedSessionDemand,
+		dsResult.NamedSessionWispDemand,
 		dsResult.snapshotQueryPartial(),
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -44,6 +44,14 @@ const (
 	orderTrackingWatchdogMetadataInitiator = "controller-watchdog"
 	orderTrackingCloseVerifyAttempts       = 3
 	orderTrackingCloseVerifyRetryDelay     = 25 * time.Millisecond
+	orderDispatchSnapshotBudget            = 4 * time.Second
+	orderDispatchStoreReadBudget           = 1500 * time.Millisecond
+	orderDispatchSingleReadBudget          = 500 * time.Millisecond
+	orderDispatchTrackingWriteBudget       = time.Second
+	orderDispatchOpenReadLimit             = 1000
+	orderDispatchHistoryReadLimit          = 200
+	orderDispatchDescendantMaxDepth        = 4
+	orderDispatchDescendantMaxRows         = 500
 
 	// orphanedOrderTrackingCloseReason is the canonical close_reason
 	// stamped on orphan-sweep closes. It satisfies bd's
@@ -67,6 +75,18 @@ const (
 
 	completedOrderTrackingCloseReason = "order dispatch completed: tracking bead lifecycle finished"
 )
+
+func orderRunLabel(scopedName string) string {
+	return "order-run:" + scopedName
+}
+
+func scopedOrderTrackingLabel(scopedName string) string {
+	return labelOrderTracking + ":" + scopedName
+}
+
+func orderTrackingLabels(scopedName string) []string {
+	return []string{orderRunLabel(scopedName), labelOrderTracking, scopedOrderTrackingLabel(scopedName)}
+}
 
 var (
 	// shellExecPostCancelWaitDelay is os/exec's pipe-close wait after
@@ -266,6 +286,36 @@ type memoryOrderDispatcher struct {
 	inflightDone chan struct{} // closed when inflightN returns to 0; nil when idle
 }
 
+type orderDispatchCandidate struct {
+	order         orders.Order
+	target        execStoreTarget
+	store         beads.Store
+	storeKey      string
+	gateStores    []beads.Store
+	gateStoreKeys []string
+}
+
+type orderDispatchSnapshotInput struct {
+	storeKey     string
+	store        beads.Store
+	orders       map[string]struct{}
+	needsLastRun map[string]bool
+	needsCursor  map[string]bool
+}
+
+type orderDispatchSnapshots struct {
+	byStore map[string]*orderDispatchStoreSnapshot
+}
+
+type orderDispatchStoreSnapshot struct {
+	storeKey       string
+	capturedAt     time.Time
+	lastRunByOrder map[string]time.Time
+	cursorByOrder  map[string]uint64
+	openByOrder    map[string]bool
+	degraded       map[string][]error
+}
+
 // buildOrderDispatcher scans formula layers for orders and returns a
 // dispatcher. Returns nil if no auto-dispatchable orders are found.
 // Scans both city-level and per-rig orders. Rig orders get their Rig
@@ -372,8 +422,13 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 	if m.cfg != nil && citySuspended(m.cfg) {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	stores := make(map[string]beads.Store)
+	var candidates []orderDispatchCandidate
+	snapshotInputs := make(map[string]*orderDispatchSnapshotInput)
 
 	for _, a := range m.aa {
 		// Skip orders targeting suspended rigs.
@@ -411,55 +466,93 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
 		}
 		scoped := a.ScopedName()
-		hasOpenWork, err := m.hasOpenWorkInStoresStrict(storesForGate, scoped)
-		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
+		for idx, gateStore := range storesForGate {
+			if gateStore == nil {
+				continue
+			}
+			key := storeKeysForGate[idx]
+			input := snapshotInputs[key]
+			if input == nil {
+				input = &orderDispatchSnapshotInput{
+					storeKey:     key,
+					store:        gateStore,
+					orders:       make(map[string]struct{}),
+					needsLastRun: make(map[string]bool),
+					needsCursor:  make(map[string]bool),
+				}
+				snapshotInputs[key] = input
+			}
+			input.orders[scoped] = struct{}{}
+			if orderTriggerUsesLastRun(a) {
+				if cached, ok := m.cachedLastRunOnly(scoped, storeKeysForGate); ok && orderCachedLastRunSuppresses(a, now, cached) {
+					continue
+				}
+				input.needsLastRun[scoped] = true
+			}
+			if a.Trigger == "event" {
+				input.needsCursor[scoped] = true
+			}
+		}
+		candidates = append(candidates, orderDispatchCandidate{
+			order:         a,
+			target:        target,
+			store:         store,
+			storeKey:      storeKey,
+			gateStores:    storesForGate,
+			gateStoreKeys: storeKeysForGate,
+		})
+	}
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	snapshotCtx, cancel := context.WithTimeout(ctx, orderDispatchSnapshotBudget)
+	snapshots := buildOrderDispatchSnapshots(snapshotCtx, snapshotInputs, now)
+	cancel()
+
+	for _, candidate := range candidates {
+		a := candidate.order
+		scoped := a.ScopedName()
+		if err := snapshots.degradation(scoped, candidate.gateStoreKeys); err != nil {
+			m.recordOrderDispatchDeferred(scoped, fmt.Errorf("snapshot degraded: %w", err))
 			continue
 		}
-		if hasOpenWork {
+		if snapshots.hasOpenWork(scoped, candidate.gateStoreKeys) {
 			continue
 		}
 
-		baseLastRunFn := orders.LastRunAcrossStores(storesForGate...)
-		var lastRunErr error
-		var lastRunFromCache bool
 		lastRunFn := func(orderName string) (time.Time, error) {
-			last, fromCache, err := m.cachedLastRun(orderName, storeKeysForGate, baseLastRunFn)
-			if err != nil {
-				lastRunErr = err
+			if err := snapshots.degradation(orderName, candidate.gateStoreKeys); err != nil {
+				return time.Time{}, err
 			}
-			if fromCache {
-				lastRunFromCache = true
+			last := snapshots.lastRun(orderName, candidate.gateStoreKeys)
+			if cached, ok := m.cachedLastRunOnly(orderName, candidate.gateStoreKeys); ok && cached.After(last) {
+				last = cached
 			}
-			return last, err
+			return last, nil
 		}
-		cursorFn := orders.CursorAcrossStores(storesForGate...)
-		if a.Trigger == "event" {
-			cursor, err := bdCursorAcrossStores(a.ScopedName(), storesForGate...)
-			if err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: reading event cursor for %s: %v", a.ScopedName(), err)
-				continue
+		cursorFn := func(orderName string) uint64 {
+			if err := snapshots.degradation(orderName, candidate.gateStoreKeys); err != nil {
+				return 0
 			}
-			cursorFn = func(string) uint64 {
-				return cursor
-			}
+			return snapshots.cursor(orderName, candidate.gateStoreKeys)
 		}
-		triggerOpts, err := orderTriggerOptionsForTarget(cityPath, m.cfg, target, a)
+		triggerOpts, err := orderTriggerOptionsForTarget(cityPath, m.cfg, candidate.target, a)
 		if err != nil {
 			redacted := redactOrderEnvError(err, os.Environ())
 			msg := fmt.Sprintf("building trigger env: %s", redacted)
 			logDispatchError(m.stderr, "gc: order dispatch: building trigger env for %s: %s", a.ScopedName(), redacted)
 			// Leave this open so the existing open-work gate suppresses repeat
 			// ticks until the normal stale tracking sweep gives the order another try.
-			trackingBead, createErr := store.Create(beads.Bead{
-				Title:     "order:" + scoped,
-				Labels:    []string{"order-run:" + scoped, labelOrderTracking, labelTriggerEnvFailed},
-				Ephemeral: true,
+			trackingBead, createErr := createOrderTrackingBeadBounded(ctx, candidate.store, beads.Bead{
+				Title:  "order:" + scoped,
+				Labels: append(orderTrackingLabels(scoped), labelTriggerEnvFailed),
 			})
 			if createErr != nil {
 				logDispatchError(m.stderr, "gc: order dispatch: creating trigger env failure tracking bead for %s: %v", scoped, createErr)
 			} else {
-				m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
+				m.rememberLastRun(scoped, candidate.gateStoreKeys, trackingBead.CreatedAt)
 			}
 			m.rec.Record(events.Event{
 				Type:    events.OrderFailed,
@@ -470,60 +563,365 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			continue
 		}
 		result := orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
-		if lastRunErr != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
+		if err := snapshots.degradation(scoped, candidate.gateStoreKeys); err != nil {
+			m.recordOrderDispatchDeferred(scoped, fmt.Errorf("snapshot degraded after trigger evaluation: %w", err))
 			continue
+		}
+		if orderTriggerUsesLastRun(a) && !result.LastRun.IsZero() {
+			m.rememberLastRun(scoped, candidate.gateStoreKeys, result.LastRun)
 		}
 		if !result.Due {
-			continue
-		}
-		if lastRunFromCache && orderTriggerUsesLastRun(a) {
-			refreshedLastRun, err := baseLastRunFn(a.ScopedName())
-			if err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: refreshing last run for %s: %v", a.ScopedName(), err)
-				continue
-			}
-			if refreshedLastRun.After(result.LastRun) {
-				m.rememberLastRun(a.ScopedName(), storeKeysForGate, refreshedLastRun)
-				refreshedLastRunFn := func(string) (time.Time, error) {
-					return refreshedLastRun, nil
-				}
-				result = orders.CheckTriggerWithOptions(a, now, refreshedLastRunFn, m.ep, cursorFn, triggerOpts)
-				if !result.Due {
-					continue
-				}
-			}
-		}
-
-		// Skip dispatch if previous work hasn't been processed yet.
-		hasOpenWork, err = m.hasOpenWorkInStoresStrict(storesForGate, scoped)
-		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
-			continue
-		}
-		if hasOpenWork {
 			continue
 		}
 
 		// Create tracking bead synchronously BEFORE dispatch goroutine.
 		// This prevents the cooldown trigger from re-firing on the next tick.
-		trackingBead, err := store.Create(beads.Bead{
-			Title:     "order:" + scoped,
-			Labels:    []string{"order-run:" + scoped, labelOrderTracking},
-			Ephemeral: true,
+		trackingBead, err := createOrderTrackingBeadBounded(ctx, candidate.store, beads.Bead{
+			Title:  "order:" + scoped,
+			Labels: orderTrackingLabels(scoped),
 		})
 		if err != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v", scoped, err)
 			continue
 		}
-		m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
+		m.rememberLastRun(scoped, candidate.gateStoreKeys, trackingBead.CreatedAt)
 
 		// Fire with timeout; inflight tracks the spawned goroutine so
 		// drain can wait for tracking-bead outcome persistence before
 		// controller exit or config reload.
-		a := a // capture loop variable
+		orderToDispatch := a
 		m.addInflight()
-		m.launchDispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
+		m.launchDispatchOne(ctx, candidate.store, candidate.target, orderToDispatch, cityPath, trackingBead.ID)
+	}
+}
+
+func buildOrderDispatchSnapshots(ctx context.Context, inputs map[string]*orderDispatchSnapshotInput, now time.Time) orderDispatchSnapshots {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	keys := make([]string, 0, len(inputs))
+	for key := range inputs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := orderDispatchSnapshots{byStore: make(map[string]*orderDispatchStoreSnapshot, len(keys))}
+	for _, key := range keys {
+		input := inputs[key]
+		if input == nil || input.store == nil {
+			continue
+		}
+		storeCtx, cancel := context.WithTimeout(ctx, orderDispatchStoreReadBudget)
+		result.byStore[key] = buildOrderDispatchStoreSnapshot(storeCtx, input, now)
+		cancel()
+	}
+	return result
+}
+
+func buildOrderDispatchStoreSnapshot(ctx context.Context, input *orderDispatchSnapshotInput, now time.Time) *orderDispatchStoreSnapshot {
+	snapshot := &orderDispatchStoreSnapshot{
+		storeKey:       input.storeKey,
+		capturedAt:     now,
+		lastRunByOrder: make(map[string]time.Time),
+		cursorByOrder:  make(map[string]uint64),
+		openByOrder:    make(map[string]bool),
+		degraded:       make(map[string][]error),
+	}
+	names := make([]string, 0, len(input.orders))
+	for name := range input.orders {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			snapshot.addDegradation(name, "snapshot deadline", err)
+			continue
+		}
+		snapshot.captureOrder(ctx, input.store, name, input.needsLastRun[name], input.needsCursor[name])
+	}
+	return snapshot
+}
+
+func (s *orderDispatchStoreSnapshot) captureOrder(ctx context.Context, store beads.Store, scopedName string, needsLastRun, needsCursor bool) {
+	tracking, err := orderDispatchRuntimeList(ctx, store, beads.ListQuery{
+		Label: scopedOrderTrackingLabel(scopedName),
+		Limit: 1,
+	}, "order.dispatch.scoped-tracking")
+	if err != nil {
+		s.addDegradation(scopedName, "scoped order-tracking", err)
+		return
+	}
+	for _, b := range tracking {
+		if b.Status != "closed" {
+			s.openByOrder[scopedName] = true
+		}
+	}
+	if s.openByOrder[scopedName] {
+		return
+	}
+
+	openWork, err := orderDispatchRuntimeList(ctx, store, beads.ListQuery{
+		Label:    orderRunLabel(scopedName),
+		Limit:    orderDispatchOpenReadLimit,
+		Sort:     beads.SortCreatedDesc,
+		TierMode: beads.TierBoth,
+	}, "order.dispatch.open-work")
+	if err != nil {
+		s.addDegradation(scopedName, "checking open work", err)
+		return
+	}
+	if len(openWork) >= orderDispatchOpenReadLimit {
+		s.addDegradation(scopedName, "checking open work", fmt.Errorf("open work read hit cap %d", orderDispatchOpenReadLimit))
+	}
+	for _, b := range openWork {
+		if b.Status == "closed" {
+			continue
+		}
+		if beadLabelsContain(b.Labels, labelOrderTracking) {
+			s.openByOrder[scopedName] = true
+			continue
+		}
+		if !isOrderWispRootCandidate(b) {
+			continue
+		}
+		if isOrderRootOnlyWispCandidate(b) {
+			s.openByOrder[scopedName] = true
+			continue
+		}
+		hasOpen, descErr := orderDispatchHasOpenDescendants(ctx, store, b.ID)
+		if descErr != nil {
+			s.addDegradation(scopedName, "order wisp descendants", descErr)
+			return
+		}
+		if hasOpen {
+			s.openByOrder[scopedName] = true
+		}
+	}
+	if s.openByOrder[scopedName] {
+		return
+	}
+
+	if needsLastRun {
+		history, err := orderDispatchRuntimeList(ctx, store, beads.ListQuery{
+			Label:         orderRunLabel(scopedName),
+			Limit:         orderDispatchHistoryReadLimit,
+			IncludeClosed: true,
+			Sort:          beads.SortCreatedDesc,
+			TierMode:      beads.TierBoth,
+		}, "order.dispatch.order-run-history")
+		if err != nil {
+			s.addDegradation(scopedName, "order-run history", err)
+			return
+		}
+		if len(history) >= orderDispatchHistoryReadLimit {
+			s.addDegradation(scopedName, "order-run history", fmt.Errorf("history read hit cap %d", orderDispatchHistoryReadLimit))
+		}
+		for _, b := range history {
+			if b.CreatedAt.After(s.lastRunByOrder[scopedName]) {
+				s.lastRunByOrder[scopedName] = b.CreatedAt
+			}
+		}
+	}
+
+	if !needsCursor {
+		return
+	}
+	cursorRows, err := orderDispatchRuntimeList(ctx, store, beads.ListQuery{
+		Label:         "order:" + scopedName,
+		Limit:         orderDispatchHistoryReadLimit,
+		IncludeClosed: true,
+		Sort:          beads.SortCreatedDesc,
+		TierMode:      beads.TierBoth,
+	}, "order.dispatch.event-cursor")
+	if err != nil {
+		s.addDegradation(scopedName, "event cursor", err)
+		return
+	}
+	if len(cursorRows) >= orderDispatchHistoryReadLimit {
+		s.addDegradation(scopedName, "event cursor", fmt.Errorf("cursor read hit cap %d", orderDispatchHistoryReadLimit))
+	}
+	labelSets := make([][]string, 0, len(cursorRows))
+	for _, b := range cursorRows {
+		labelSets = append(labelSets, b.Labels)
+	}
+	s.cursorByOrder[scopedName] = orders.MaxSeqFromLabels(labelSets)
+}
+
+func orderDispatchHasOpenDescendants(ctx context.Context, store beads.Store, parentID string) (bool, error) {
+	if parentID == "" {
+		return false, nil
+	}
+	type queuedParent struct {
+		id    string
+		depth int
+	}
+	seen := map[string]struct{}{parentID: {}}
+	queue := []queuedParent{{id: parentID}}
+	rows := 0
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		next := queue[0]
+		queue = queue[1:]
+		if next.depth >= orderDispatchDescendantMaxDepth {
+			return false, fmt.Errorf("descendant depth hit cap %d", orderDispatchDescendantMaxDepth)
+		}
+		children, err := orderDispatchRuntimeList(ctx, store, beads.ListQuery{
+			ParentID:      next.id,
+			IncludeClosed: true,
+			Limit:         orderDispatchOpenReadLimit,
+			TierMode:      beads.TierBoth,
+		}, "order.dispatch.descendants")
+		if err != nil {
+			return false, err
+		}
+		rows += len(children)
+		if rows > orderDispatchDescendantMaxRows {
+			return false, fmt.Errorf("descendant rows hit cap %d", orderDispatchDescendantMaxRows)
+		}
+		for _, child := range children {
+			if child.ID == "" {
+				continue
+			}
+			if _, ok := seen[child.ID]; ok {
+				continue
+			}
+			seen[child.ID] = struct{}{}
+			if child.Status != "closed" {
+				return true, nil
+			}
+			queue = append(queue, queuedParent{id: child.ID, depth: next.depth + 1})
+		}
+	}
+	return false, nil
+}
+
+func orderDispatchRuntimeList(ctx context.Context, store beads.Store, query beads.ListQuery, caller string) ([]beads.Bead, error) {
+	if store == nil {
+		return nil, fmt.Errorf("nil store")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	readCtx, cancel := context.WithTimeout(ctx, orderDispatchSingleReadBudget)
+	defer cancel()
+	policy := beads.RuntimeReadPolicy(beads.ReadClassHotAuthoritative, caller)
+	policy.Timeout = orderDispatchSingleReadBudget
+	if query.Limit > 0 {
+		policy.MaxRows = query.Limit
+	}
+	type listResult struct {
+		rows []beads.Bead
+		err  error
+	}
+	done := make(chan listResult, 1)
+	go func() {
+		rows, err := beads.RuntimeList(readCtx, store, query, policy)
+		done <- listResult{rows: rows, err: err}
+	}()
+	select {
+	case result := <-done:
+		return result.rows, result.err
+	case <-readCtx.Done():
+		return nil, readCtx.Err()
+	}
+}
+
+func (s *orderDispatchStoreSnapshot) addDegradation(orderName, shape string, err error) {
+	if err == nil {
+		return
+	}
+	s.degraded[orderName] = append(s.degraded[orderName], fmt.Errorf("%s %s: %w", s.storeKey, shape, err))
+}
+
+func (s orderDispatchSnapshots) degradation(orderName string, storeKeys []string) error {
+	var errs []error
+	for _, key := range storeKeys {
+		snapshot := s.byStore[key]
+		if snapshot == nil {
+			errs = append(errs, fmt.Errorf("%s snapshot missing", key))
+			continue
+		}
+		errs = append(errs, snapshot.degraded[orderName]...)
+	}
+	return errors.Join(errs...)
+}
+
+func (s orderDispatchSnapshots) hasOpenWork(orderName string, storeKeys []string) bool {
+	for _, key := range storeKeys {
+		if snapshot := s.byStore[key]; snapshot != nil && snapshot.openByOrder[orderName] {
+			return true
+		}
+	}
+	return false
+}
+
+func (s orderDispatchSnapshots) lastRun(orderName string, storeKeys []string) time.Time {
+	var latest time.Time
+	for _, key := range storeKeys {
+		if snapshot := s.byStore[key]; snapshot != nil && snapshot.lastRunByOrder[orderName].After(latest) {
+			latest = snapshot.lastRunByOrder[orderName]
+		}
+	}
+	return latest
+}
+
+func (s orderDispatchSnapshots) cursor(orderName string, storeKeys []string) uint64 {
+	var latest uint64
+	for _, key := range storeKeys {
+		if snapshot := s.byStore[key]; snapshot != nil && snapshot.cursorByOrder[orderName] > latest {
+			latest = snapshot.cursorByOrder[orderName]
+		}
+	}
+	return latest
+}
+
+func (m *memoryOrderDispatcher) cachedLastRunOnly(orderName string, storeKeys []string) (time.Time, bool) {
+	key := orderHistoryCacheKey(orderName, storeKeys)
+	m.cacheMu.Lock()
+	defer m.cacheMu.Unlock()
+	if m.lastRunCache == nil {
+		return time.Time{}, false
+	}
+	last, ok := m.lastRunCache[key]
+	return last, ok
+}
+
+func (m *memoryOrderDispatcher) recordOrderDispatchDeferred(scoped string, err error) {
+	logDispatchError(m.stderr, "gc: order dispatch: deferring %s: %v", scoped, err)
+	if m.rec != nil {
+		m.rec.Record(events.Event{
+			Type:    events.OrderFailed,
+			Actor:   "controller",
+			Subject: scoped,
+			Message: fmt.Sprintf("deferred order dispatch: %v", err),
+		})
+	}
+}
+
+func createOrderTrackingBeadBounded(ctx context.Context, store beads.Store, bead beads.Bead) (beads.Bead, error) {
+	if store == nil {
+		return beads.Bead{}, fmt.Errorf("nil store")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	writeCtx, cancel := context.WithTimeout(ctx, orderDispatchTrackingWriteBudget)
+	defer cancel()
+	type createResult struct {
+		bead beads.Bead
+		err  error
+	}
+	done := make(chan createResult, 1)
+	go func() {
+		created, err := store.Create(bead)
+		done <- createResult{bead: created, err: err}
+	}()
+	select {
+	case result := <-done:
+		return result.bead, result.err
+	case <-writeCtx.Done():
+		return beads.Bead{}, writeCtx.Err()
 	}
 }
 
@@ -619,25 +1017,6 @@ func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target
 	return store, true
 }
 
-func (m *memoryOrderDispatcher) cachedLastRun(orderName string, storeKeys []string, read orders.LastRunFunc) (time.Time, bool, error) {
-	key := orderHistoryCacheKey(orderName, storeKeys)
-	m.cacheMu.Lock()
-	if m.lastRunCache != nil {
-		if last, ok := m.lastRunCache[key]; ok {
-			m.cacheMu.Unlock()
-			return last, true, nil
-		}
-	}
-	m.cacheMu.Unlock()
-
-	last, err := read(orderName)
-	if err != nil {
-		return time.Time{}, false, err
-	}
-	m.rememberLastRun(orderName, storeKeys, last)
-	return last, false, nil
-}
-
 func (m *memoryOrderDispatcher) rememberLastRun(orderName string, storeKeys []string, last time.Time) {
 	key := orderHistoryCacheKey(orderName, storeKeys)
 	m.cacheMu.Lock()
@@ -656,6 +1035,17 @@ func orderHistoryCacheKey(orderName string, storeKeys []string) string {
 
 func orderTriggerUsesLastRun(a orders.Order) bool {
 	return a.Trigger == "cooldown" || a.Trigger == "cron"
+}
+
+func orderCachedLastRunSuppresses(a orders.Order, now time.Time, cached time.Time) bool {
+	if cached.IsZero() {
+		return false
+	}
+	lastRunFn := func(string) (time.Time, error) {
+		return cached, nil
+	}
+	result := orders.CheckTriggerWithOptions(a, now, lastRunFn, nil, nil, orders.TriggerOptions{})
+	return !result.Due
 }
 
 func eventCursorLabels(scoped string, headSeq uint64) []string {
@@ -1016,18 +1406,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		)
 	}
 	if a.Pool != "" {
-		// Same metadata-pair the CLI path (cmd_order.go:doOrderRunWithJSON)
-		// writes — gc.routed_to so the worker's Tier-3 work_query and bd
-		// CLI tooling see the routing, plus poolDemandMetadataPair() so
-		// the supervisor's defaultScaleCheckCounts can count the wisp as
-		// scale_check demand. Without the second pair, supervisor-cron
-		// dispatched orders silently never spawn a pool worker because
-		// the molecule wisp is filtered out of Ready() by
-		// readyExcludeTypes (per PR #1154). See cmd/gc/pool_demand.go.
 		update.Metadata = map[string]string{"gc.routed_to": pool}
-		for k, v := range poolDemandMetadataPair() {
-			update.Metadata[k] = v
-		}
 	}
 	if err := store.Update(rootID, update); err != nil {
 		// Label failure is critical for duplicate-dispatch prevention.
@@ -1094,33 +1473,36 @@ func (m *memoryOrderDispatcher) rigSuspendedByName(rigName string) bool {
 	return false
 }
 
-// hasOpenWorkStrict reports whether any in-flight work exists for this
-// order — either a dispatchOne goroutine still running, or a wisp whose
-// step beads have not all been completed by the pool agent.
+// hasOpenWorkStrict reports whether any in-flight work exists for this order.
 //
-// Tracking beads carry both "order-run:<scoped>" and labelOrderTracking;
-// dispatchOne closes them via defer when dispatch returns. An open
-// tracking bead means a dispatchOne goroutine is in flight.
+// Tracking beads carry order-tracking:<scoped> as the hot single-flight label.
+// If that scoped label is present, the gate can avoid scanning the historical
+// order-run:<scoped> label. The order-run fallback is retained for legacy
+// tracking beads and wisp roots created before the scoped label existed.
 //
-// Wisp root beads also carry "order-run:<scoped>" (so gc order history
-// and the orders API feed can attribute the wisp to its order) but never
-// carry labelOrderTracking. Molecule roots never auto-close when their
-// step beads finish, so a leftover open root with all-closed children is
-// orphan state — counting it would permanently block re-dispatch
-// (ga-jra/ga-lo8c, where formula+pool orders stalled after a city restart
-// because the first auto-fire's wisp root tripped this check). But a
-// wisp root whose child step beads are still open IS in-flight work: the
-// pool agent has not yet executed the wisp. Counting those prevents the
-// cooldown gate from pouring duplicate wisps when the pool stalls
-// (tr-kds01, where 24h-interval digest wisps accumulated because the
-// pool never picked them up).
+// Wisp root beads also carry order-run:<scoped> so history/API feeds can
+// attribute the wisp to its order, but they never carry labelOrderTracking.
+// Molecule roots never auto-close when their step beads finish, so a leftover
+// open root with all-closed children is orphan state and must not permanently
+// block re-dispatch. A root whose children are still open is in-flight work and
+// must block duplicate pours.
 func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
+	tracking, err := store.List(beads.ListQuery{
+		Label: scopedOrderTrackingLabel(scopedName),
+		Limit: 1,
+	})
+	if err != nil {
+		return false, fmt.Errorf("listing scoped order-tracking beads: %w", err)
+	}
+	for _, b := range tracking {
+		if b.Status != "closed" {
+			return true, nil
+		}
+	}
+
 	results, err := store.List(beads.ListQuery{
-		Label: "order-run:" + scopedName,
+		Label: orderRunLabel(scopedName),
 		Sort:  beads.SortCreatedDesc,
-		// Tracking beads are ephemeral while wisp roots are issue-tier, so
-		// the single-flight gate must union both tiers.
-		TierMode: beads.TierBoth,
 	})
 	if err != nil {
 		return false, fmt.Errorf("listing order work beads: %w", err)
@@ -1138,7 +1520,7 @@ func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName 
 		if isOrderRootOnlyWispCandidate(b) {
 			return true, nil
 		}
-		hasOpenDescendants, err := storeHasOpenDescendants(store, b.ID)
+		hasOpenDescendants, err := storeHasOpenDescendants(store, b.ID, false)
 		if err != nil {
 			return false, fmt.Errorf("checking open descendants of wisp %s: %w", b.ID, err)
 		}
@@ -1163,18 +1545,21 @@ func isOrderRootOnlyWispCandidate(b beads.Bead) bool {
 // storeHasOpenDescendants reports whether any transitive child of parentID is
 // non-closed. It includes closed intermediate nodes so nested molecule work
 // remains visible after a direct child step has completed.
-func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
+func storeHasOpenDescendants(store beads.Store, parentID string, includeWisps bool) (bool, error) {
 	seen := map[string]struct{}{parentID: {}}
 	queue := []string{parentID}
 	for len(queue) > 0 {
 		parentID := queue[0]
 		queue = queue[1:]
 
-		children, err := store.List(beads.ListQuery{
+		query := beads.ListQuery{
 			ParentID:      parentID,
 			IncludeClosed: true,
-			TierMode:      beads.TierBoth,
-		})
+		}
+		if includeWisps {
+			query.TierMode = beads.TierBoth
+		}
+		children, err := store.List(query)
 		if err != nil {
 			return false, err
 		}
@@ -1195,29 +1580,11 @@ func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
 	return false, nil
 }
 
-func (m *memoryOrderDispatcher) hasOpenWorkInStoresStrict(stores []beads.Store, scopedName string) (bool, error) {
-	for _, store := range stores {
-		if store == nil {
-			continue
-		}
-		hasOpen, err := m.hasOpenWorkStrict(store, scopedName)
-		if err != nil {
-			return false, err
-		}
-		if hasOpen {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // sweepOrphanedOrderTracking closes any open order-tracking beads left
 // behind by a previous controller instance. Returns the count of beads
 // closed. This is non-fatal: dispatch proceeds even if the sweep fails.
 func sweepOrphanedOrderTracking(store beads.Store) (int, error) {
 	// ListByLabel without IncludeClosed returns only open beads.
-	// New tracking beads live in the wisps tier, but legacy issues-tier
-	// tracking beads may still exist after upgrade; sweep both.
 	all, err := store.ListByLabel(labelOrderTracking, 0, beads.WithBothTiers)
 	if err != nil {
 		return 0, fmt.Errorf("listing order-tracking beads: %w", err)
@@ -1328,7 +1695,7 @@ func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, staleA
 	if includeWispSubtrees && len(onlyOrders) == 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("include-wisps requires at least one order name")
 	}
-	all, err := store.ListByLabel(labelOrderTracking, 0, beads.WithBothTiers)
+	all, err := listOrderTrackingCandidates(store, onlyOrders)
 	if err != nil {
 		return orderTrackingSweepResult{}, fmt.Errorf("listing order-tracking beads: %w", err)
 	}
@@ -1380,6 +1747,41 @@ func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, staleA
 	return result, nil
 }
 
+func listOrderTrackingCandidates(store beads.Store, onlyOrders map[string]struct{}) ([]beads.Bead, error) {
+	if len(onlyOrders) == 0 {
+		return store.ListByLabel(labelOrderTracking, 0, beads.WithBothTiers)
+	}
+	seen := make(map[string]struct{})
+	var out []beads.Bead
+	var errs []error
+	for orderName := range onlyOrders {
+		for _, query := range []beads.ListQuery{
+			{Label: scopedOrderTrackingLabel(orderName), TierMode: beads.TierBoth},
+			{Label: orderRunLabel(orderName), TierMode: beads.TierBoth},
+		} {
+			items, err := store.List(query)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("listing %s: %w", query.Label, err))
+				continue
+			}
+			for _, b := range items {
+				if b.ID == "" {
+					continue
+				}
+				if _, ok := seen[b.ID]; ok {
+					continue
+				}
+				if !beadLabelsContain(b.Labels, labelOrderTracking) {
+					continue
+				}
+				seen[b.ID] = struct{}{}
+				out = append(out, b)
+			}
+		}
+	}
+	return out, errors.Join(errs...)
+}
+
 func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string) (int, error) {
 	roots, err := staleOrderWispRoots(store, cutoff, onlyOrders)
 	if err != nil {
@@ -1398,7 +1800,7 @@ func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders
 			continue
 		}
 		if !isOrderRootOnlyWispCandidate(root) {
-			openDescendants, err := storeHasOpenDescendants(store, root.ID)
+			openDescendants, err := storeHasOpenDescendants(store, root.ID, true)
 			if err != nil {
 				return 0, fmt.Errorf("checking stale wisp descendants of %s: %w", root.ID, err)
 			}
@@ -1568,6 +1970,9 @@ func openSubtreeOlderThan(subtree []beads.Bead, cutoff time.Time) bool {
 
 func orderNameFromTrackingBead(b beads.Bead) (string, bool) {
 	for _, label := range b.Labels {
+		if name, ok := strings.CutPrefix(label, labelOrderTracking+":"); ok && name != "" {
+			return name, true
+		}
 		if name, ok := strings.CutPrefix(label, "order-run:"); ok && name != "" {
 			return name, true
 		}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -26,9 +26,9 @@ import (
 
 func trackingBeads(t *testing.T, store beads.Store, label string) []beads.Bead {
 	t.Helper()
-	// Tracking beads dispatched by the production order dispatcher live in
-	// the ephemeral (wisps) tier; seeded test beads typically live in the
-	// issues tier. Query both so tests covering either path stay green.
+	// Some tests seed legacy wisp-tier tracking beads to exercise explicit
+	// recovery paths. Query both tiers here so assertions can inspect those
+	// fixtures without changing production hot-path queries.
 	all, err := store.ListByLabel(label, 0, beads.IncludeClosed, beads.WithBothTiers)
 	if err != nil {
 		t.Fatalf("ListByLabel(%q): %v", label, err)
@@ -80,6 +80,13 @@ type countingListStore struct {
 	beads.Store
 
 	includeClosedLists int
+}
+
+type slowOrderDispatchListStore struct {
+	beads.Store
+
+	slowLabel string
+	delay     time.Duration
 }
 
 func TestScanOrderSetSnapshotFSTracksAddChangeRemove(t *testing.T) {
@@ -218,6 +225,13 @@ func (s triggerEvaluationFailStore) List(query beads.ListQuery) ([]beads.Bead, e
 func (s *countingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	if query.IncludeClosed || query.Status == "closed" {
 		s.includeClosedLists++
+	}
+	return s.Store.List(query)
+}
+
+func (s slowOrderDispatchListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == s.slowLabel {
+		time.Sleep(s.delay)
 	}
 	return s.Store.List(query)
 }
@@ -378,9 +392,6 @@ func TestOrderDispatchResolvesPackBindingForPool(t *testing.T) {
 	work := workBeadByOrderLabel(t, store, "order-run:mol-dog-doctor")
 	if got := work.Metadata["gc.routed_to"]; got != "maintenance.dog" {
 		t.Errorf("gc.routed_to = %q, want %q (pack binding must qualify pool target)", got, "maintenance.dog")
-	}
-	if got := work.Metadata[poolDemandMetadataKey]; got != poolDemandMetadataValue {
-		t.Errorf("%s = %q, want %q (supervisor-cron-dispatched pool orders must carry the demand sentinel so defaultScaleCheckCounts can count the wisp despite readyExcludeTypes filtering molecules out of Ready() — see cmd/gc/pool_demand.go)", poolDemandMetadataKey, got, poolDemandMetadataValue)
 	}
 }
 
@@ -1333,6 +1344,91 @@ func TestOrderDispatchCachesAutoTrackingBeadCreatedAt(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchSnapshotSlowListDefersOneOrderWithoutBlockingUnrelated(t *testing.T) {
+	store := slowOrderDispatchListStore{
+		Store:     beads.NewMemStore(),
+		slowLabel: "order-run:aaa-slow",
+		delay:     2 * time.Second,
+	}
+	rec := &memRecorder{}
+	ran := make(map[string]bool)
+	fakeExec := func(_ context.Context, command, _ string, _ []string) ([]byte, error) {
+		ran[command] = true
+		return nil, nil
+	}
+	aa := []orders.Order{
+		{Name: "aaa-slow", Trigger: "cooldown", Interval: "1s", Exec: "aaa-slow"},
+		{Name: "zzz-fast", Trigger: "cooldown", Interval: "1s", Exec: "zzz-fast"},
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, rec)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	start := time.Now()
+	ad.dispatch(context.Background(), t.TempDir(), time.Now().Add(5*time.Second))
+	elapsed := time.Since(start)
+	ad.drain(context.Background())
+
+	if elapsed >= 5*time.Second {
+		t.Fatalf("dispatch elapsed = %v, want under 5s despite slow List", elapsed)
+	}
+	if ran["aaa-slow"] {
+		t.Fatal("slow degraded order ran; want it deferred for the tick")
+	}
+	if !ran["zzz-fast"] {
+		t.Fatal("unrelated fast order did not run after slow order degraded")
+	}
+	if !rec.hasSubject("aaa-slow") {
+		t.Fatal("degraded slow order did not record a deferral/failure event")
+	}
+}
+
+func TestOrderDispatchOpenCrossOrderDependencyDoesNotSuppressDifferentOrder(t *testing.T) {
+	store := beads.NewMemStore()
+	wo20, err := store.Create(beads.Bead{
+		Title:  "wo-020 active task",
+		Type:   "task",
+		Labels: []string{"order-run:wo-020"},
+	})
+	if err != nil {
+		t.Fatalf("create wo-020 task: %v", err)
+	}
+	blocker, err := store.Create(beads.Bead{
+		Title: "shared blocker",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	if err := store.DepAdd(wo20.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	ran := false
+	fakeExec := func(context.Context, string, string, []string) ([]byte, error) {
+		ran = true
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:     "wo-022",
+		Trigger:  "cooldown",
+		Interval: "1s",
+		Exec:     "wo-022",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now().Add(5*time.Second))
+	ad.drain(context.Background())
+
+	if !ran {
+		t.Fatal("wo-022 did not run; open work for another order must not suppress it")
+	}
+}
+
 // --- exec order dispatch tests ---
 
 func TestOrderDispatchExecDue(t *testing.T) {
@@ -1763,9 +1859,8 @@ func TestOrderDispatchTriggerEnvFailureTrackingSuppressesNonConditionBeforeEvalu
 		t.Run(tt.name, func(t *testing.T) {
 			baseStore := beads.NewMemStore()
 			if _, err := baseStore.Create(beads.Bead{
-				Title:     "order:" + tt.order.Name,
-				Labels:    []string{"order-run:" + tt.order.Name, labelOrderTracking, labelTriggerEnvFailed},
-				Ephemeral: true,
+				Title:  "order:" + tt.order.Name,
+				Labels: []string{"order-run:" + tt.order.Name, labelOrderTracking, labelTriggerEnvFailed},
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -2699,7 +2794,7 @@ func TestShellExecRunnerKillsProcessGroupOnTimeout(t *testing.T) {
 	oldSignalGrace := shellExecSignalGrace
 	shellExecSignalGrace = 100 * time.Millisecond
 	t.Cleanup(func() { shellExecSignalGrace = oldSignalGrace })
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	command := fmt.Sprintf("sh -c 'printf \"%%s\\n\" \"$$\" > %q; trap \"\" TERM; while :; do printf . >> %q; sleep 0.05; done' & wait", childPIDPath, heartbeatPath)
@@ -2991,12 +3086,11 @@ func TestOrderRigSuspendedFallsBackToOrderRigOnPoolResolutionError(t *testing.T)
 func TestSweepOrphanedOrderTracking_ClosesOpenTrackingBeads(t *testing.T) {
 	store := beads.NewMemStore()
 
-	// Create some open ephemeral tracking beads (simulating goroutines killed on restart).
+	// Create some open tracking beads (simulating goroutines killed on restart).
 	for _, name := range []string{"dolt-health", "gate-sweep", "beads-health"} {
 		_, err := store.Create(beads.Bead{
-			Title:     "order:" + name,
-			Labels:    []string{"order-run:" + name, labelOrderTracking},
-			Ephemeral: true,
+			Title:  "order:" + name,
+			Labels: []string{"order-run:" + name, labelOrderTracking},
 		})
 		if err != nil {
 			t.Fatalf("Create(%s): %v", name, err)
@@ -3012,9 +3106,8 @@ func TestSweepOrphanedOrderTracking_ClosesOpenTrackingBeads(t *testing.T) {
 
 	// Create one that's already closed (should be left alone).
 	b, err := store.Create(beads.Bead{
-		Title:     "order:old-sweep",
-		Labels:    []string{"order-run:old-sweep", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:old-sweep",
+		Labels: []string{"order-run:old-sweep", labelOrderTracking},
 	})
 	if err != nil {
 		t.Fatalf("Create(old-sweep): %v", err)
@@ -3040,7 +3133,7 @@ func TestSweepOrphanedOrderTracking_ClosesOpenTrackingBeads(t *testing.T) {
 		t.Fatalf("closed = %d, want 4", closed)
 	}
 
-	// Verify the open tracking beads in both tiers are now closed.
+	// Verify the open tracking beads are now closed.
 	all := trackingBeads(t, store, labelOrderTracking)
 	for _, b := range all {
 		if b.Status != "closed" {
@@ -3105,13 +3198,12 @@ func TestSweepStaleOrderTracking_ClosesOnlyOldOpenTrackingBeads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create(old): %v", err)
 	}
-	oldEphemeral, err := store.Create(beads.Bead{
-		Title:     "order:old-sweep-wisp-tier",
-		Labels:    []string{"order-run:old-sweep-wisp-tier", labelOrderTracking},
-		Ephemeral: true,
+	oldSecond, err := store.Create(beads.Bead{
+		Title:  "order:old-sweep-second",
+		Labels: []string{"order-run:old-sweep-second", labelOrderTracking},
 	})
 	if err != nil {
-		t.Fatalf("Create(old ephemeral): %v", err)
+		t.Fatalf("Create(old second): %v", err)
 	}
 	oldWork, err := store.Create(beads.Bead{
 		Title:  "real work",
@@ -3131,7 +3223,7 @@ func TestSweepStaleOrderTracking_ClosesOnlyOldOpenTrackingBeads(t *testing.T) {
 		t.Fatalf("Create(fresh): %v", err)
 	}
 
-	const expectedClosedTrackingBeads = 2 // issues-tier legacy bead + wisps-tier tracking bead
+	const expectedClosedTrackingBeads = 2
 	closed, err := sweepStaleOrderTracking(store, time.Now(), 100*time.Millisecond, nil, orderTrackingSweepMetadataInitiator)
 	if err != nil {
 		t.Fatalf("sweepStaleOrderTracking: %v", err)
@@ -3147,12 +3239,12 @@ func TestSweepStaleOrderTracking_ClosesOnlyOldOpenTrackingBeads(t *testing.T) {
 	if gotOld.Status != "closed" {
 		t.Fatalf("old tracking status = %s, want closed", gotOld.Status)
 	}
-	gotOldEphemeral, err := store.Get(oldEphemeral.ID)
+	gotOldSecond, err := store.Get(oldSecond.ID)
 	if err != nil {
-		t.Fatalf("Get(old ephemeral): %v", err)
+		t.Fatalf("Get(old second): %v", err)
 	}
-	if gotOldEphemeral.Status != "closed" {
-		t.Fatalf("old ephemeral tracking status = %s, want closed", gotOldEphemeral.Status)
+	if gotOldSecond.Status != "closed" {
+		t.Fatalf("old second tracking status = %s, want closed", gotOldSecond.Status)
 	}
 	gotFresh, err := store.Get(fresh.ID)
 	if err != nil {
@@ -3183,9 +3275,8 @@ func (s *noopCloseAllStore) CloseAll(_ []string, _ map[string]string) (int, erro
 func TestCloseOrderTrackingBeadErrorsWhenVerificationStillOpen(t *testing.T) {
 	base := beads.NewMemStore()
 	tracking, err := base.Create(beads.Bead{
-		Title:     "order:stuck",
-		Labels:    []string{"order-run:stuck", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:stuck",
+		Labels: []string{"order-run:stuck", labelOrderTracking},
 	})
 	if err != nil {
 		t.Fatalf("Create(tracking): %v", err)
@@ -3222,9 +3313,8 @@ func (s *flakyCloseAllStore) CloseAll(ids []string, metadata map[string]string) 
 func TestCloseOrderTrackingBeadRetriesTransientCloseConflict(t *testing.T) {
 	base := beads.NewMemStore()
 	tracking, err := base.Create(beads.Bead{
-		Title:     "order:retry",
-		Labels:    []string{"order-run:retry", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:retry",
+		Labels: []string{"order-run:retry", labelOrderTracking},
 	})
 	if err != nil {
 		t.Fatalf("Create(tracking): %v", err)
@@ -3284,9 +3374,8 @@ func TestSweepStaleOrderTrackingAcrossStoresClosesRigStoreAndUnblocksDispatch(t 
 		},
 	}
 	stale, err := rigStore.Create(beads.Bead{
-		Title:     "order:rig-digest:rig:frontend",
-		Labels:    []string{"order-run:rig-digest:rig:frontend", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:rig-digest:rig:frontend",
+		Labels: []string{"order-run:rig-digest:rig:frontend", labelOrderTracking},
 	})
 	if err != nil {
 		t.Fatalf("Create(stale): %v", err)
@@ -3340,17 +3429,15 @@ func TestSweepStaleOrderTrackingAcrossStoresContinuesAfterStoreError(t *testing.
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()
 	cityStale, err := cityStore.Create(beads.Bead{
-		Title:     "order:cleanup",
-		Labels:    []string{"order-run:cleanup", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:cleanup",
+		Labels: []string{"order-run:cleanup", labelOrderTracking},
 	})
 	if err != nil {
 		t.Fatalf("Create(city stale): %v", err)
 	}
 	rigStale, err := rigStore.Create(beads.Bead{
-		Title:     "order:cleanup:rig:frontend",
-		Labels:    []string{"order-run:cleanup:rig:frontend", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:cleanup:rig:frontend",
+		Labels: []string{"order-run:cleanup:rig:frontend", labelOrderTracking},
 	})
 	if err != nil {
 		t.Fatalf("Create(rig stale): %v", err)
@@ -3394,18 +3481,16 @@ func TestSweepStaleOrderTrackingAcrossStoresContinuesAfterStoreError(t *testing.
 func TestSweepStaleOrderTrackingClosesTriggerEnvFailedBeadsAndUnblocksDispatch(t *testing.T) {
 	store := beads.NewMemStore()
 	failed, err := store.Create(beads.Bead{
-		Title:     "order:pg-cooldown",
-		Labels:    []string{"order-run:pg-cooldown", labelOrderTracking, labelTriggerEnvFailed},
-		Ephemeral: true,
+		Title:  "order:pg-cooldown",
+		Labels: []string{"order-run:pg-cooldown", labelOrderTracking, labelTriggerEnvFailed},
 	})
 	if err != nil {
 		t.Fatalf("Create(trigger-env failed): %v", err)
 	}
 	time.Sleep(2 * time.Millisecond)
 	normal, err := store.Create(beads.Bead{
-		Title:     "order:pg-cooldown",
-		Labels:    []string{"order-run:pg-cooldown", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:pg-cooldown",
+		Labels: []string{"order-run:pg-cooldown", labelOrderTracking},
 	})
 	if err != nil {
 		t.Fatalf("Create(normal tracking): %v", err)
@@ -3460,9 +3545,8 @@ func TestSweepStaleOrderTrackingClosesTriggerEnvFailedBeadsAndUnblocksDispatch(t
 func TestCloseAndVerifyOrderTrackingBeadsStopsRetryOnContextCancel(t *testing.T) {
 	base := beads.NewMemStore()
 	tracking, err := base.Create(beads.Bead{
-		Title:     "order:canceled",
-		Labels:    []string{"order-run:canceled", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:canceled",
+		Labels: []string{"order-run:canceled", labelOrderTracking},
 	})
 	if err != nil {
 		t.Fatalf("Create(tracking): %v", err)
@@ -3491,6 +3575,51 @@ func orderFilterForTest(names ...string) map[string]struct{} {
 		out[name] = struct{}{}
 	}
 	return out
+}
+
+type failBroadOrderTrackingListStore struct {
+	beads.Store
+}
+
+func (s failBroadOrderTrackingListStore) ListByLabel(label string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	if label == labelOrderTracking {
+		return nil, fmt.Errorf("unexpected broad order-tracking scan")
+	}
+	return s.Store.ListByLabel(label, limit, opts...)
+}
+
+func TestSweepStaleOrderTrackingWithOrderFilterAvoidsBroadTrackingScan(t *testing.T) {
+	base := beads.NewMemStore()
+	tracking, err := base.Create(beads.Bead{
+		Title:  "order:digest",
+		Labels: orderTrackingLabels("digest"),
+	})
+	if err != nil {
+		t.Fatalf("Create(tracking): %v", err)
+	}
+	store := failBroadOrderTrackingListStore{Store: base}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		tracking.CreatedAt.Add(time.Hour),
+		time.Minute,
+		orderFilterForTest("digest"),
+		orderTrackingSweepMetadataInitiator,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.trackingClosed != 1 {
+		t.Fatalf("trackingClosed = %d, want 1", result.trackingClosed)
+	}
+	got, err := base.Get(tracking.ID)
+	if err != nil {
+		t.Fatalf("Get(tracking): %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("tracking status = %q, want closed", got.Status)
+	}
 }
 
 type parentLastCloseStore struct {
@@ -3945,9 +4074,8 @@ func TestStartupSweepPreservesTriggerEnvFailureMarker(t *testing.T) {
 	store := beads.NewMemStore()
 
 	marker, err := store.Create(beads.Bead{
-		Title:     "order:pg-cooldown",
-		Labels:    []string{"order-run:pg-cooldown", labelOrderTracking, labelTriggerEnvFailed},
-		Ephemeral: true,
+		Title:  "order:pg-cooldown",
+		Labels: []string{"order-run:pg-cooldown", labelOrderTracking, labelTriggerEnvFailed},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -4288,7 +4416,7 @@ func orderDispatchTestEnv(t *testing.T, envCh <-chan []string) map[string]string
 			}
 		}
 		return env
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for order exec env")
 	}
 	return nil
@@ -6473,10 +6601,11 @@ func TestLockedStderrWrapsNonNil(t *testing.T) {
 	}
 }
 
-// TestOrderDispatchTrackingBeadIsEphemeral asserts the dispatcher routes the
-// tracking bead to the wisps tier (Ephemeral=true), so each cooldown cycle
-// does not produce a full Dolt commit on the permanent issues tier.
-func TestOrderDispatchTrackingBeadIsEphemeral(t *testing.T) {
+// TestOrderDispatchTrackingBeadUsesIssuesTier asserts the dispatcher keeps
+// tracking beads on the issues tier. This protects the controller hot path
+// from wisp-tier reads while the order-tracking wisp visibility regression is
+// being unwound.
+func TestOrderDispatchTrackingBeadUsesIssuesTier(t *testing.T) {
 	store := beads.NewMemStore()
 
 	aa := []orders.Order{{
@@ -6506,33 +6635,34 @@ func TestOrderDispatchTrackingBeadIsEphemeral(t *testing.T) {
 	if tb == nil {
 		t.Fatal("no tracking bead found")
 	}
-	if !tb.Ephemeral {
-		t.Errorf("tracking bead Ephemeral = false, want true")
+	if tb.Ephemeral {
+		t.Errorf("tracking bead Ephemeral = true, want false")
 	}
-	// Tracking bead must NOT be visible to issues-tier-only queries —
-	// that is the whole point of routing it to the wisps tier.
 	issuesOnly, err := store.ListByLabel("order-run:wisp-order", 0, beads.IncludeClosed)
 	if err != nil {
 		t.Fatal(err)
 	}
+	foundTracking := false
 	for _, b := range issuesOnly {
 		if strings.HasPrefix(b.Title, "order:") {
-			t.Errorf("ephemeral tracking bead leaked into issues-tier query: %+v", b)
+			foundTracking = true
+			if b.Ephemeral {
+				t.Errorf("issues-tier tracking bead is marked ephemeral: %+v", b)
+			}
 		}
+	}
+	if !foundTracking {
+		t.Fatal("tracking bead missing from issues-tier query")
 	}
 }
 
-// TestOrderDispatchSingleFlightLockSeesEphemeralTracker is the regression
-// guard for the single-flight lock (`hasOpenWorkInStoresStrict`) after the
-// tracking bead moved to the wisps tier. If the lock query were not
-// tier-aware, the dispatcher would re-fire the same cooldown order on the
-// next tick.
-func TestOrderDispatchSingleFlightLockSeesEphemeralTracker(t *testing.T) {
+// TestOrderDispatchSingleFlightLockUsesIssuesTierTracker guards against
+// reintroducing wisp-tier reads in the single-flight lock.
+func TestOrderDispatchSingleFlightLockUsesIssuesTierTracker(t *testing.T) {
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{
-		Title:     "order:double-fire",
-		Labels:    []string{"order-run:double-fire", labelOrderTracking},
-		Ephemeral: true,
+		Title:  "order:double-fire",
+		Labels: orderTrackingLabels("double-fire"),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -6543,7 +6673,110 @@ func TestOrderDispatchSingleFlightLockSeesEphemeralTracker(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !hasOpen {
-		t.Fatal("single-flight lock missed ephemeral tracking bead — would dispatch again")
+		t.Fatal("single-flight lock missed issues-tier tracking bead")
+	}
+}
+
+type failWispTierListStore struct {
+	beads.Store
+}
+
+func (s failWispTierListStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.TierMode != beads.TierIssues {
+		return nil, fmt.Errorf("unexpected wisp-tier order scan: %+v", q)
+	}
+	return s.Store.List(q)
+}
+
+func TestOrderDispatchSingleFlightLockDoesNotReadWispTier(t *testing.T) {
+	base := beads.NewMemStore()
+	if _, err := base.Create(beads.Bead{
+		Title:  "order:double-fire",
+		Labels: orderTrackingLabels("double-fire"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &memoryOrderDispatcher{}
+	hasOpen, err := m.hasOpenWorkStrict(failWispTierListStore{Store: base}, "double-fire")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasOpen {
+		t.Fatal("single-flight lock missed issues-tier tracking bead")
+	}
+}
+
+type failLabelListStore struct {
+	beads.Store
+	failLabel string
+}
+
+func (s failLabelListStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.Label == s.failLabel {
+		return nil, fmt.Errorf("unexpected list for label %q", q.Label)
+	}
+	return s.Store.List(q)
+}
+
+func TestOrderDispatchSingleFlightLockUsesScopedTrackingLabel(t *testing.T) {
+	base := beads.NewMemStore()
+	if _, err := base.Create(beads.Bead{
+		Title:  "order:double-fire",
+		Labels: orderTrackingLabels("double-fire"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store := failLabelListStore{Store: base, failLabel: orderRunLabel("double-fire")}
+
+	m := &memoryOrderDispatcher{}
+	hasOpen, err := m.hasOpenWorkStrict(store, "double-fire")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasOpen {
+		t.Fatal("single-flight lock missed scoped tracking bead")
+	}
+}
+
+type countingLabelListStore struct {
+	beads.Store
+	counts map[string]int
+}
+
+func (s *countingLabelListStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.Label != "" {
+		if s.counts == nil {
+			s.counts = make(map[string]int)
+		}
+		s.counts[q.Label]++
+	}
+	return s.Store.List(q)
+}
+
+func TestOrderDispatchCachesOpenWorkGateWithinDispatch(t *testing.T) {
+	store := &countingLabelListStore{Store: beads.NewMemStore(), counts: make(map[string]int)}
+	ran := false
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		ran = true
+		return []byte("ok\n"), nil
+	}
+	aa := []orders.Order{{
+		Name:     "cache-test",
+		Trigger:  "cooldown",
+		Interval: "1s",
+		Exec:     "scripts/run.sh",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	if !ran {
+		t.Fatal("expected order to dispatch")
+	}
+	if got := store.counts[scopedOrderTrackingLabel("cache-test")]; got != 1 {
+		t.Fatalf("scoped tracking label queries = %d, want 1 cached open-work check", got)
 	}
 }
 

--- a/cmd/gc/runtime_read_contract_test.go
+++ b/cmd/gc/runtime_read_contract_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestControllerDemandListDoesNotFallbackToBdList(t *testing.T) {
+	var runnerCalls atomic.Int64
+	backing := beads.NewBdStore("/city", func(string, string, ...string) ([]byte, error) {
+		runnerCalls.Add(1)
+		return nil, errors.New("runner must not be called")
+	})
+	store := beads.NewCachingStoreForTest(backing, nil)
+
+	rows, err := listForControllerDemand(store, beads.ListQuery{Status: "open"})
+	if len(rows) != 0 {
+		t.Fatalf("rows = %+v, want none when runtime read degrades", rows)
+	}
+	if !beads.IsDegradedRead(err) {
+		t.Fatalf("err = %v, want degraded read", err)
+	}
+	if runnerCalls.Load() != 0 {
+		t.Fatalf("runner calls = %d, want 0", runnerCalls.Load())
+	}
+}
+
+func TestRuntimeReadStaticGuardForControllerHotPaths(t *testing.T) {
+	for _, path := range []string{"build_desired_state.go", "session_reconciler.go"} {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		text := string(body)
+		forbidden := []string{
+			"beads.ReadyLive(",
+			"Live: true",
+		}
+		for _, needle := range forbidden {
+			if strings.Contains(text, needle) {
+				t.Fatalf("%s contains %q; hot controller/session reads must use beads.RuntimeList/RuntimeReady", path, needle)
+			}
+		}
+	}
+}
+
+func TestControllerDemandReadyDoesNotFallbackToBdReady(t *testing.T) {
+	var runnerCalls atomic.Int64
+	backing := beads.NewBdStore("/city", func(string, string, ...string) ([]byte, error) {
+		runnerCalls.Add(1)
+		return nil, errors.New("runner must not be called")
+	})
+	store := beads.NewCachingStoreForTest(backing, nil)
+
+	rows, err := readyForControllerDemandQuery(store, beads.ReadyQuery{Assignee: "worker"})
+	if len(rows) != 0 {
+		t.Fatalf("rows = %+v, want none when runtime ready degrades", rows)
+	}
+	if !beads.IsDegradedRead(err) {
+		t.Fatalf("err = %v, want degraded read", err)
+	}
+	if runnerCalls.Load() != 0 {
+		t.Fatalf("runner calls = %d, want 0", runnerCalls.Load())
+	}
+}

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -70,7 +70,7 @@ type taskWorkDirLiveListCountingStore struct {
 }
 
 func (s *taskWorkDirLiveListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if query.Live && query.Status == "in_progress" && query.Assignee != "" {
+	if query.Status == "in_progress" && query.Assignee != "" {
 		s.liveInProgressAssigneeLists++
 	}
 	return s.Store.List(query)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -28,12 +28,79 @@ import (
 	"github.com/gastownhall/gascity/internal/telemetry"
 )
 
-const maxIdleSleepProbesPerTick = 3
+const (
+	maxIdleSleepProbesPerTick = 3
+
+	namedSessionPatrolWispNudgeSource        = "patrol-wisp"
+	namedSessionPatrolWispNudgeMessage       = "Patrol wisp is ready. Run gc hook to continue the assigned patrol iteration."
+	namedSessionPatrolWispNudgeRefMetadata   = "last_patrol_wisp_nudge_ref"
+	namedSessionPatrolWispNudgeEpochMetadata = "last_patrol_wisp_nudge_epoch"
+	namedSessionPatrolWispNudgeAtMetadata    = "last_patrol_wisp_nudge_at"
+)
 
 type wakeTarget struct {
 	session *beads.Bead
 	tp      TemplateParams
 	alive   bool
+}
+
+func maybeQueueNamedSessionPatrolWispNudge(
+	cityPath string,
+	store beads.Store,
+	sp runtime.Provider,
+	cfg *config.City,
+	target wakeTarget,
+	source NamedSessionWispDemandSource,
+	now time.Time,
+	stderr io.Writer,
+) {
+	if cityPath == "" || store == nil || sp == nil || target.session == nil {
+		return
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	refID := source.ReferenceID()
+	if refID == "" {
+		return
+	}
+	targetNudge := resolveNudgeTargetFromSessionBead(cityPath, cfg, *target.session)
+	continuationEpoch := strings.TrimSpace(targetNudge.continuationEpoch)
+	if strings.TrimSpace(target.session.Metadata[namedSessionPatrolWispNudgeRefMetadata]) == refID &&
+		strings.TrimSpace(target.session.Metadata[namedSessionPatrolWispNudgeEpochMetadata]) == continuationEpoch {
+		return
+	}
+	item := newQueuedNudgeWithOptions(
+		targetNudge.agentKey(),
+		namedSessionPatrolWispNudgeMessage,
+		namedSessionPatrolWispNudgeSource,
+		now,
+		queuedNudgeOptions{
+			SessionID:         targetNudge.sessionID,
+			ContinuationEpoch: targetNudge.continuationEpoch,
+			Reference:         &nudgeReference{Kind: namedSessionPatrolWispNudgeSource, ID: refID},
+		},
+	)
+	if err := enqueueQueuedNudgeWithStore(cityPath, store, item); err != nil {
+		fmt.Fprintf(stderr, "session reconciler: queueing patrol-wisp nudge for %s from %s: %v\n", targetNudge.agentKey(), refID, err) //nolint:errcheck
+		return
+	}
+	batch := map[string]string{
+		namedSessionPatrolWispNudgeRefMetadata:   refID,
+		namedSessionPatrolWispNudgeEpochMetadata: continuationEpoch,
+		namedSessionPatrolWispNudgeAtMetadata:    now.UTC().Format(time.RFC3339),
+	}
+	if err := store.SetMetadataBatch(target.session.ID, batch); err != nil {
+		fmt.Fprintf(stderr, "session reconciler: stamping patrol-wisp nudge for %s from %s: %v\n", targetNudge.agentKey(), refID, err) //nolint:errcheck
+		return
+	}
+	if target.session.Metadata == nil {
+		target.session.Metadata = make(map[string]string, len(batch))
+	}
+	for key, value := range batch {
+		target.session.Metadata[key] = value
+	}
+	maybeStartNudgePoller(targetNudge)
 }
 
 func lifecycleTimerBlocker(metadata map[string]string, now time.Time) string {
@@ -704,7 +771,7 @@ func reconcileSessionBeadsAtPath(
 ) int {
 	return reconcileSessionBeadsAtPathWithNamedDemand(
 		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt,
-		poolDesired, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
+		poolDesired, nil, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
 	)
 }
 
@@ -724,6 +791,7 @@ func reconcileSessionBeadsAtPathWithNamedDemand(
 	dt *drainTracker,
 	poolDesired map[string]int,
 	namedSessionDemand map[string]bool,
+	namedSessionWispDemand map[string]NamedSessionWispDemandSource,
 	storeQueryPartial bool,
 	workSet map[string]bool,
 	cityName string,
@@ -736,7 +804,7 @@ func reconcileSessionBeadsAtPathWithNamedDemand(
 ) int {
 	return reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt,
-		poolDesired, namedSessionDemand, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
+		poolDesired, namedSessionDemand, namedSessionWispDemand, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
 	)
 }
 
@@ -769,7 +837,7 @@ func reconcileSessionBeadsTraced(
 ) int {
 	return reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt,
-		poolDesired, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, trace,
+		poolDesired, nil, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, trace,
 		startOptions...,
 	)
 }
@@ -790,6 +858,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	dt *drainTracker,
 	poolDesired map[string]int,
 	namedSessionDemand map[string]bool,
+	namedSessionWispDemand map[string]NamedSessionWispDemandSource,
 	storeQueryPartial bool,
 	workSet map[string]bool,
 	cityName string,
@@ -2071,6 +2140,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if target.session.Metadata["sleep_intent"] == "idle-stop-pending" {
 				_ = store.SetMetadata(target.session.ID, "sleep_intent", "")
 				target.session.Metadata["sleep_intent"] = ""
+			}
+			if decision.Reason == "named-demand" && len(namedSessionWispDemand) > 0 {
+				identity := namedSessionIdentity(*target.session)
+				if identity == "" {
+					identity = strings.TrimSpace(target.tp.ConfiguredNamedIdentity)
+				}
+				if source, ok := namedSessionWispDemand[identity]; ok {
+					maybeQueueNamedSessionPatrolWispNudge(cityPath, store, sp, cfg, target, source, clk.Now(), stderr)
+				}
 			}
 		}
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -66,6 +66,9 @@ func maybeQueueNamedSessionPatrolWispNudge(
 	}
 	targetNudge := resolveNudgeTargetFromSessionBead(cityPath, cfg, *target.session)
 	continuationEpoch := strings.TrimSpace(targetNudge.continuationEpoch)
+	if err := supersedeStaleNamedSessionPatrolWispNudges(cityPath, store, targetNudge, refID, now); err != nil {
+		fmt.Fprintf(stderr, "session reconciler: superseding stale patrol-wisp nudges for %s from %s: %v\n", targetNudge.agentKey(), refID, err) //nolint:errcheck
+	}
 	if queued, err := namedSessionPatrolWispNudgeQueued(cityPath, targetNudge, refID, now); err != nil {
 		fmt.Fprintf(stderr, "session reconciler: checking queued patrol-wisp nudge for %s from %s: %v\n", targetNudge.agentKey(), refID, err) //nolint:errcheck
 	} else if queued {
@@ -120,6 +123,76 @@ func namedSessionPatrolWispNudgeQueued(cityPath string, target nudgeTarget, refI
 		}
 	}
 	return false, nil
+}
+
+func supersedeStaleNamedSessionPatrolWispNudges(cityPath string, store beads.Store, target nudgeTarget, refID string, now time.Time) error {
+	if cityPath == "" || refID == "" {
+		return nil
+	}
+	if store == nil {
+		store = openNudgeBeadStore(cityPath)
+	}
+	return withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
+		if err := recoverExpiredInFlightNudges(state, store, now); err != nil {
+			return err
+		}
+		if err := pruneExpiredQueuedNudges(state, store, now); err != nil {
+			return err
+		}
+		if err := pruneDeadQueuedNudges(state, store, now); err != nil {
+			return err
+		}
+		pending := state.Pending[:0]
+		for _, item := range state.Pending {
+			if stalePatrolWispNudgeMatchesTarget(item, target, refID) {
+				if err := markQueuedNudgeSuperseded(store, &state.Dead, item, now); err != nil {
+					return err
+				}
+				continue
+			}
+			pending = append(pending, item)
+		}
+		state.Pending = pending
+		inFlight := state.InFlight[:0]
+		for _, item := range state.InFlight {
+			if stalePatrolWispNudgeMatchesTarget(item, target, refID) {
+				if err := markQueuedNudgeSuperseded(store, &state.Dead, item, now); err != nil {
+					return err
+				}
+				continue
+			}
+			inFlight = append(inFlight, item)
+		}
+		state.InFlight = inFlight
+		sortQueuedNudges(state)
+		return nil
+	})
+}
+
+func markQueuedNudgeSuperseded(store beads.Store, dead *[]queuedNudge, item queuedNudge, now time.Time) error {
+	item.DeadAt = now.UTC()
+	item.LastError = "superseded"
+	*dead = append(*dead, item)
+	return markQueuedNudgeTerminal(store, item, "superseded", "superseded", "", now)
+}
+
+func stalePatrolWispNudgeMatchesTarget(item queuedNudge, target nudgeTarget, currentRefID string) bool {
+	if item.Source != namedSessionPatrolWispNudgeSource || item.Reference == nil {
+		return false
+	}
+	if item.Reference.Kind != namedSessionPatrolWispNudgeSource || item.Reference.ID == "" || item.Reference.ID == currentRefID {
+		return false
+	}
+	if !target.matchesQueueAgent(item.Agent) {
+		return false
+	}
+	if item.SessionID != "" && target.sessionID != "" && item.SessionID != target.sessionID {
+		return false
+	}
+	if item.ContinuationEpoch != "" && target.continuationEpoch != "" && item.ContinuationEpoch != target.continuationEpoch {
+		return false
+	}
+	return true
 }
 
 func queuedPatrolWispNudgeMatchesTarget(item queuedNudge, target nudgeTarget, refID string) bool {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2393,7 +2393,8 @@ func firstOpenAssignedWorkBeadInStoreByIdentifiers(store beads.Store, identifier
 				continue
 			}
 			seen[key] = struct{}{}
-			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: true})
+			items, err := beads.RuntimeList(context.Background(), store, beads.ListQuery{Assignee: assignee, Status: status},
+				beads.RuntimeReadPolicy(beads.ReadClassHotAuthoritative, "session.reconcile.assigned-work"))
 			if err != nil {
 				return beads.Bead{}, false, err
 			}
@@ -2519,7 +2520,8 @@ func collectSessionAssignedWorkIDs(cityPath string, cfg *config.City, store bead
 				if assignee == "" {
 					continue
 				}
-				items, err := s.List(beads.ListQuery{Assignee: assignee, Status: status, Live: true})
+				items, err := beads.RuntimeList(context.Background(), s, beads.ListQuery{Assignee: assignee, Status: status},
+					beads.RuntimeReadPolicy(beads.ReadClassHotDegradedOK, "session.stranded.assigned-work"))
 				if err != nil {
 					return err
 				}
@@ -2600,7 +2602,8 @@ func sessionHasOpenAssignedWorkInStoreByIdentifiers(store beads.Store, identifie
 				continue
 			}
 			seen[key] = struct{}{}
-			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: true})
+			items, err := beads.RuntimeList(context.Background(), store, beads.ListQuery{Assignee: assignee, Status: status},
+				beads.RuntimeReadPolicy(beads.ReadClassHotAuthoritative, "session.reconcile.assigned-work"))
 			if err != nil {
 				return false, err
 			}
@@ -3165,12 +3168,11 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 			continue
 		}
 		seen[assignee] = true
-		assigned, err := store.List(beads.ListQuery{
+		assigned, err := beads.RuntimeList(context.Background(), store, beads.ListQuery{
 			Assignee: assignee,
 			Status:   "in_progress",
-			Live:     true,
 			Sort:     beads.SortCreatedDesc,
-		})
+		}, beads.RuntimeReadPolicy(beads.ReadClassHotDegradedOK, "session.reconcile.task-workdir"))
 		if err != nil {
 			continue
 		}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -66,8 +66,9 @@ func maybeQueueNamedSessionPatrolWispNudge(
 	}
 	targetNudge := resolveNudgeTargetFromSessionBead(cityPath, cfg, *target.session)
 	continuationEpoch := strings.TrimSpace(targetNudge.continuationEpoch)
-	if strings.TrimSpace(target.session.Metadata[namedSessionPatrolWispNudgeRefMetadata]) == refID &&
-		strings.TrimSpace(target.session.Metadata[namedSessionPatrolWispNudgeEpochMetadata]) == continuationEpoch {
+	if queued, err := namedSessionPatrolWispNudgeQueued(cityPath, targetNudge, refID, now); err != nil {
+		fmt.Fprintf(stderr, "session reconciler: checking queued patrol-wisp nudge for %s from %s: %v\n", targetNudge.agentKey(), refID, err) //nolint:errcheck
+	} else if queued {
 		return
 	}
 	item := newQueuedNudgeWithOptions(
@@ -101,6 +102,40 @@ func maybeQueueNamedSessionPatrolWispNudge(
 		target.session.Metadata[key] = value
 	}
 	maybeStartNudgePoller(targetNudge)
+}
+
+func namedSessionPatrolWispNudgeQueued(cityPath string, target nudgeTarget, refID string, now time.Time) (bool, error) {
+	pending, inFlight, _, err := listQueuedNudgesForTarget(cityPath, target, now)
+	if err != nil {
+		return false, err
+	}
+	for _, item := range pending {
+		if queuedPatrolWispNudgeMatchesTarget(item, target, refID) {
+			return true, nil
+		}
+	}
+	for _, item := range inFlight {
+		if queuedPatrolWispNudgeMatchesTarget(item, target, refID) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func queuedPatrolWispNudgeMatchesTarget(item queuedNudge, target nudgeTarget, refID string) bool {
+	if item.Source != namedSessionPatrolWispNudgeSource || item.Reference == nil {
+		return false
+	}
+	if item.Reference.Kind != namedSessionPatrolWispNudgeSource || item.Reference.ID != refID {
+		return false
+	}
+	if item.SessionID != "" && target.sessionID != "" && item.SessionID != target.sessionID {
+		return false
+	}
+	if item.ContinuationEpoch != "" && target.continuationEpoch != "" && item.ContinuationEpoch != target.continuationEpoch {
+		return false
+	}
+	return true
 }
 
 func lifecycleTimerBlocker(metadata map[string]string, now time.Time) string {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3340,6 +3340,13 @@ func TestReconcileSessionBeads_OnDemandNamedSessionWakesFromRoutedSingletonTempl
 func TestReconcileSessionBeads_OnDemandNamedSessionQueuesPatrolWispNudgeForLiveSession(t *testing.T) {
 	env := newReconcilerTestEnv()
 	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS", "file")
+	if err := ensureScopedFileStoreLayout(cityPath); err != nil {
+		t.Fatalf("ensure scoped file store layout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityPath); err != nil {
+		t.Fatalf("ensure persisted scoped file store: %v", err)
+	}
 	env.cfg = &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Daemon:    config.DaemonConfig{NudgeDispatcher: "supervisor"},
@@ -3455,6 +3462,40 @@ func TestReconcileSessionBeads_OnDemandNamedSessionQueuesPatrolWispNudgeForLiveS
 	}
 	if pending[0].Reference == nil || pending[0].Reference.ID != "rig:rig-a:wisp-1" {
 		t.Fatalf("delivered same-wisp re-fire reference = %+v, want rig:rig-a:wisp-1", pending[0].Reference)
+	}
+
+	reloaded, err = env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session) before newer wisp demand: %v", err)
+	}
+	newerWispDemand := map[string]NamedSessionWispDemandSource{
+		"primary": {WispID: "wisp-2", StoreRef: "rig-a", Status: "in_progress"},
+	}
+	reconcileSessionBeadsAtPathWithNamedDemand(
+		context.Background(), cityPath, []beads.Bead{reloaded}, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, nil, nil, nil, nil, env.dt, nil,
+		map[string]bool{"primary": true}, newerWispDemand, false, nil, env.cfg.EffectiveCityName(),
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+	pending, inFlight, dead, err = listQueuedNudges(cityPath, "primary", env.clk.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges after newer patrol-wisp demand: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 {
+		t.Fatalf("newer patrol-wisp demand queue sizes pending=%d in_flight=%d dead=%d, want 1/0/*", len(pending), len(inFlight), len(dead))
+	}
+	if pending[0].Reference == nil || pending[0].Reference.ID != "rig:rig-a:wisp-2" {
+		t.Fatalf("newer patrol-wisp demand reference = %+v, want rig:rig-a:wisp-2", pending[0].Reference)
+	}
+	for _, stale := range append(append([]queuedNudge{}, pending...), inFlight...) {
+		if stale.Reference != nil && stale.Reference.ID == "rig:rig-a:wisp-1" {
+			t.Fatalf("stale patrol-wisp nudge remained deliverable: %+v", stale)
+		}
+	}
+	for _, terminal := range dead {
+		if terminal.Reference != nil && terminal.Reference.ID == "rig:rig-a:wisp-1" && terminal.LastError != "superseded" {
+			t.Fatalf("terminal stale patrol-wisp nudge = %+v, want superseded", terminal)
+		}
 	}
 }
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3428,6 +3428,34 @@ func TestReconcileSessionBeads_OnDemandNamedSessionQueuesPatrolWispNudgeForLiveS
 	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
 		t.Fatalf("duplicate tick queue sizes pending=%d in_flight=%d dead=%d, want 1/0/0", len(pending), len(inFlight), len(dead))
 	}
+
+	if err := withNudgeQueueState(cityPath, func(state *nudgeQueueState) error {
+		state.Pending = nil
+		state.InFlight = nil
+		return nil
+	}); err != nil {
+		t.Fatalf("clear delivered queued nudge: %v", err)
+	}
+	reloaded, err = env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session) after ack: %v", err)
+	}
+	reconcileSessionBeadsAtPathWithNamedDemand(
+		context.Background(), cityPath, []beads.Bead{reloaded}, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, nil, nil, nil, nil, env.dt, nil,
+		map[string]bool{"primary": true}, wispDemand, false, nil, env.cfg.EffectiveCityName(),
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+	pending, inFlight, dead, err = listQueuedNudges(cityPath, "primary", env.clk.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges after delivered same-wisp re-fire: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("delivered same-wisp re-fire queue sizes pending=%d in_flight=%d dead=%d, want 1/0/0", len(pending), len(inFlight), len(dead))
+	}
+	if pending[0].Reference == nil || pending[0].Reference.ID != "rig:rig-a:wisp-1" {
+		t.Fatalf("delivered same-wisp re-fire reference = %+v, want rig:rig-a:wisp-1", pending[0].Reference)
+	}
 }
 
 func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config.City, sessionName, identity, routedTo string) (int, bool) {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3337,6 +3337,99 @@ func TestReconcileSessionBeads_OnDemandNamedSessionWakesFromRoutedSingletonTempl
 	}
 }
 
+func TestReconcileSessionBeads_OnDemandNamedSessionQueuesPatrolWispNudgeForLiveSession(t *testing.T) {
+	env := newReconcilerTestEnv()
+	cityPath := t.TempDir()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Daemon:    config.DaemonConfig{NudgeDispatcher: "supervisor"},
+		Agents: []config.Agent{{
+			Name:         "worker",
+			StartCommand: "true",
+			Session:      config.SessionTransportACP,
+		}},
+		NamedSessions: []config.NamedSession{{Name: "primary", Template: "worker", Mode: "on_demand"}},
+	}
+	env.desiredState["primary"] = TemplateParams{
+		Command:                 "true",
+		SessionName:             "primary",
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "primary",
+		ConfiguredNamedMode:     "on_demand",
+	}
+	if err := env.sp.Start(context.Background(), "primary", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("Start(primary): %v", err)
+	}
+	session := env.createSessionBead("primary", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"agent_name":                 "worker",
+		"alias":                      "primary",
+		"transport":                  config.SessionTransportACP,
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "primary",
+		namedSessionModeMetadata:     "on_demand",
+		"state":                      "active",
+		"last_woke_at":               env.clk.Now().UTC().Format(time.RFC3339),
+		"continuation_epoch":         "epoch-1",
+	})
+
+	cfgNames := configuredSessionNames(env.cfg, env.cfg.EffectiveCityName(), env.store)
+	wispDemand := map[string]NamedSessionWispDemandSource{
+		"primary": {WispID: "wisp-1", StoreRef: "rig-a", Status: "in_progress"},
+	}
+	woken := reconcileSessionBeadsAtPathWithNamedDemand(
+		context.Background(), cityPath, []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, nil, nil, nil, nil, env.dt, nil,
+		map[string]bool{"primary": true}, wispDemand, false, nil, env.cfg.EffectiveCityName(),
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 for already-live named session", woken)
+	}
+
+	pending, inFlight, dead, err := listQueuedNudges(cityPath, "primary", env.clk.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("queue sizes pending=%d in_flight=%d dead=%d, want 1/0/0", len(pending), len(inFlight), len(dead))
+	}
+	got := pending[0]
+	if got.Agent != "primary" || got.Source != namedSessionPatrolWispNudgeSource || got.Message != namedSessionPatrolWispNudgeMessage {
+		t.Fatalf("queued nudge = %+v, want patrol-wisp nudge for primary", got)
+	}
+	if got.SessionID != session.ID || got.ContinuationEpoch != "epoch-1" {
+		t.Fatalf("queued nudge fence session=%q epoch=%q, want %q/epoch-1", got.SessionID, got.ContinuationEpoch, session.ID)
+	}
+	if got.Reference == nil || got.Reference.Kind != namedSessionPatrolWispNudgeSource || got.Reference.ID != "rig:rig-a:wisp-1" {
+		t.Fatalf("queued nudge reference = %+v, want patrol-wisp rig:rig-a:wisp-1", got.Reference)
+	}
+	reloaded, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if reloaded.Metadata[namedSessionPatrolWispNudgeRefMetadata] != "rig:rig-a:wisp-1" {
+		t.Fatalf("%s = %q, want rig:rig-a:wisp-1", namedSessionPatrolWispNudgeRefMetadata, reloaded.Metadata[namedSessionPatrolWispNudgeRefMetadata])
+	}
+	if reloaded.Metadata[namedSessionPatrolWispNudgeEpochMetadata] != "epoch-1" {
+		t.Fatalf("%s = %q, want epoch-1", namedSessionPatrolWispNudgeEpochMetadata, reloaded.Metadata[namedSessionPatrolWispNudgeEpochMetadata])
+	}
+
+	reconcileSessionBeadsAtPathWithNamedDemand(
+		context.Background(), cityPath, []beads.Bead{reloaded}, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, nil, nil, nil, nil, env.dt, nil,
+		map[string]bool{"primary": true}, wispDemand, false, nil, env.cfg.EffectiveCityName(),
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+	)
+	pending, inFlight, dead, err = listQueuedNudges(cityPath, "primary", env.clk.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudges after duplicate tick: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("duplicate tick queue sizes pending=%d in_flight=%d dead=%d, want 1/0/0", len(pending), len(inFlight), len(dead))
+	}
+}
+
 func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config.City, sessionName, identity, routedTo string) (int, bool) {
 	t.Helper()
 
@@ -3393,7 +3486,7 @@ func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config
 	woken := reconcileSessionBeadsAtPathWithNamedDemand(
 		context.Background(), cityPath, sessions, dsResult.State, cfgNames, cfg, sp,
 		store, nil, dsResult.AssignedWorkBeads, nil, nil, newDrainTracker(), poolDesired,
-		dsResult.NamedSessionDemand, dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
+		dsResult.NamedSessionDemand, nil, dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
 		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
 	)
 	return woken, sp.IsRunning(sessionName)

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -581,6 +581,7 @@ func TestSessionReconcilePhaseTraceUsesDistinctSites(t *testing.T) {
 		newDrainTracker(),
 		nil,
 		nil,
+		nil,
 		false,
 		nil,
 		"trace-town",

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -191,10 +191,11 @@ type PurgeResult struct {
 // BdStore implements Store by shelling out to the bd CLI (beads v0.55.1+).
 // It delegates all persistence to bd's embedded Dolt database.
 type BdStore struct {
-	dir         string          // city root directory (where .beads/ lives)
-	runner      CommandRunner   // injectable for testing
-	purgeRunner PurgeRunnerFunc // injectable for testing; nil uses exec default
-	idPrefix    string          // bead ID prefix owned by this store, without trailing "-"
+	dir           string          // city root directory (where .beads/ lives)
+	runner        CommandRunner   // injectable for testing
+	purgeRunner   PurgeRunnerFunc // injectable for testing; nil uses exec default
+	idPrefix      string          // bead ID prefix owned by this store, without trailing "-"
+	indexedReader IndexedLister   // optional read-only active list accelerator
 }
 
 const bdTransientWriteAttempts = 3
@@ -207,6 +208,77 @@ func NewBdStore(dir string, runner CommandRunner) *BdStore {
 // NewBdStoreWithPrefix creates a BdStore with an explicit owned bead ID prefix.
 func NewBdStoreWithPrefix(dir string, runner CommandRunner, idPrefix string) *BdStore {
 	return &BdStore{dir: dir, runner: runner, idPrefix: normalizeIDPrefix(idPrefix)}
+}
+
+// WithIndexedReader attaches a read-only active list accelerator.
+func (s *BdStore) WithIndexedReader(reader IndexedLister) *BdStore {
+	if s != nil {
+		s.indexedReader = reader
+	}
+	return s
+}
+
+// ListIndexed exposes the optional read-only indexed list path without falling
+// back to the Beads CLI.
+func (s *BdStore) ListIndexed(ctx context.Context, query ListQuery) (IndexedListResult, error) {
+	if s == nil || s.indexedReader == nil {
+		return IndexedListResult{}, ErrIndexedListUnsupported
+	}
+	return s.indexedReader.ListIndexed(ctx, query)
+}
+
+// CountIndexed exposes the optional read-only indexed count path without
+// falling back to the Beads CLI.
+func (s *BdStore) CountIndexed(ctx context.Context, query ListQuery) (int, error) {
+	if s == nil || s.indexedReader == nil {
+		return 0, ErrIndexedListUnsupported
+	}
+	counter, ok := s.indexedReader.(IndexedCounter)
+	if !ok {
+		return 0, ErrIndexedListUnsupported
+	}
+	return counter.CountIndexed(ctx, query)
+}
+
+// RuntimeList serves hot runtime reads through the indexed reader only. It
+// deliberately does not fall through to bd list/query when indexed coverage is
+// unavailable.
+func (s *BdStore) RuntimeList(ctx context.Context, query ListQuery, policy ReadPolicy) ([]Bead, error) {
+	policy = normalizeReadPolicy(policy)
+	if policy.AllowFallback {
+		return s.List(query)
+	}
+	if !query.HasFilter() && !query.AllowScan {
+		return nil, fmt.Errorf("runtime list: %w", ErrQueryRequiresScan)
+	}
+	if policy.MaxRows > 0 && query.Limit <= 0 {
+		query.Limit = policy.MaxRows
+	}
+	readCtx, cancel := contextWithReadPolicy(ctx, policy)
+	defer cancel()
+	result, err := s.ListIndexed(readCtx, query)
+	if err != nil {
+		return result.Beads, degradedRead(policy, "list", "indexed", "", err)
+	}
+	if !result.DependencyCoverage {
+		return result.Beads, degradedRead(policy, "list", "indexed", "dependency-incomplete", ErrIndexedListUnsupported)
+	}
+	if !result.LabelsCoverage {
+		return result.Beads, degradedRead(policy, "list", "indexed", "labels-incomplete", ErrIndexedListUnsupported)
+	}
+	items := applyListQuery(result.Beads, query)
+	return enforceRuntimeRowCap(items, policy, "list", "indexed")
+}
+
+// RuntimeReady has no safe direct BdStore implementation because bd ready is a
+// hydrated CLI command and indexed ready requires complete active-state
+// coverage. Controller hot paths should use CachingStore.RuntimeReady.
+func (s *BdStore) RuntimeReady(_ context.Context, query ReadyQuery, policy ReadPolicy) ([]Bead, error) {
+	policy = normalizeReadPolicy(policy)
+	if policy.AllowFallback {
+		return readyWithQuery(s, query)
+	}
+	return nil, degradedRead(policy, "ready", "indexed", "", ErrIndexedListUnsupported)
 }
 
 // IDPrefix returns the bead ID prefix owned by this store, without trailing "-".

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -98,9 +99,102 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	return c.backing.List(liveListQuery(query))
 }
 
+// RuntimeList serves hot runtime callers from cache or indexed SQL only. It
+// never delegates to the backing Store.List fallback path.
+func (c *CachingStore) RuntimeList(ctx context.Context, query ListQuery, policy ReadPolicy) ([]Bead, error) {
+	policy = normalizeReadPolicy(policy)
+	if policy.AllowFallback {
+		return c.List(query)
+	}
+	if !query.HasFilter() && !query.AllowScan {
+		return nil, fmt.Errorf("runtime cache list: %w", ErrQueryRequiresScan)
+	}
+	if cached, ok := c.runtimeCachedList(query, policy); ok {
+		return enforceRuntimeRowCap(cached, policy, "list", "cache")
+	}
+	if _, bd := c.backing.(*BdStore); !bd {
+		items, err := c.backing.List(liveListQuery(query))
+		if err != nil {
+			return items, err
+		}
+		return enforceRuntimeRowCap(items, policy, "list", "backing")
+	}
+	indexed, ok := c.backing.(IndexedLister)
+	if !ok {
+		return nil, degradedRead(policy, "list", "cache", "unavailable", ErrIndexedListUnsupported)
+	}
+	indexedQuery := liveListQuery(query)
+	if policy.MaxRows > 0 && indexedQuery.Limit <= 0 {
+		indexedQuery.Limit = policy.MaxRows
+	}
+	readCtx, cancel := contextWithReadPolicy(ctx, policy)
+	defer cancel()
+	result, err := indexed.ListIndexed(readCtx, indexedQuery)
+	if err != nil {
+		return result.Beads, degradedRead(policy, "list", "indexed", "", err)
+	}
+	if !result.DependencyCoverage {
+		return result.Beads, degradedRead(policy, "list", "indexed", "dependency-incomplete", ErrIndexedListUnsupported)
+	}
+	if !result.LabelsCoverage {
+		return result.Beads, degradedRead(policy, "list", "indexed", "labels-incomplete", ErrIndexedListUnsupported)
+	}
+	items := ApplyListQuery(result.Beads, query)
+	return enforceRuntimeRowCap(items, policy, "list", "indexed")
+}
+
+func (c *CachingStore) runtimeCachedList(query ListQuery, policy ReadPolicy) ([]Bead, bool) {
+	if policy.Class == ReadClassHotAuthoritative {
+		return nil, false
+	}
+	if query.TierMode != TierIssues || query.Live {
+		return nil, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return nil, false
+	}
+	if c.primePartialErr != nil {
+		return nil, false
+	}
+	if len(c.dirty) > 0 {
+		return nil, false
+	}
+	if query.IncludesClosed() {
+		return nil, false
+	}
+	cached := make([]Bead, 0, len(c.beads))
+	for _, b := range c.beads {
+		if !query.Matches(b) {
+			continue
+		}
+		cached = append(cached, cloneBead(b))
+	}
+	sortBeadsForQuery(cached, query.Sort)
+	if query.Limit > 0 && len(cached) > query.Limit {
+		cached = cached[:query.Limit]
+	}
+	return cached, true
+}
+
 func liveListQuery(query ListQuery) ListQuery {
 	query.Live = true
 	return query
+}
+
+// CountIndexed delegates cheap aggregate counts to the backing indexed store.
+// The in-memory cache intentionally holds only active rows, so all-status row
+// counts must be answered by the authoritative indexed reader.
+func (c *CachingStore) CountIndexed(ctx context.Context, query ListQuery) (int, error) {
+	if c == nil || c.backing == nil {
+		return 0, ErrIndexedListUnsupported
+	}
+	counter, ok := c.backing.(IndexedCounter)
+	if !ok {
+		return 0, ErrIndexedListUnsupported
+	}
+	return counter.CountIndexed(ctx, liveListQuery(query))
 }
 
 // CachedList returns query results from the in-memory cache only. The boolean
@@ -423,6 +517,39 @@ func (c *CachingStore) CachedReady() ([]Bead, bool) {
 		}
 	}
 	return result, true
+}
+
+// RuntimeReady serves controller/session hot ready checks from the cache read
+// model only. If the cache cannot prove dependency coverage, the read degrades
+// instead of invoking bd ready.
+func (c *CachingStore) RuntimeReady(_ context.Context, query ReadyQuery, policy ReadPolicy) ([]Bead, error) {
+	policy = normalizeReadPolicy(policy)
+	if policy.AllowFallback {
+		return readyWithQuery(c, query)
+	}
+	ready, ok := c.CachedReady()
+	if !ok {
+		return nil, degradedRead(policy, "ready", "cache", "dependency-incomplete", ErrIndexedListUnsupported)
+	}
+	ready = filterReadyQuery(ready, query)
+	return enforceRuntimeRowCap(ready, policy, "ready", "cache")
+}
+
+func filterReadyQuery(items []Bead, query ReadyQuery) []Bead {
+	if query == (ReadyQuery{}) {
+		return items
+	}
+	out := make([]Bead, 0, len(items))
+	for _, item := range items {
+		if query.Assignee != "" && item.Assignee != query.Assignee {
+			continue
+		}
+		out = append(out, item)
+		if query.Limit > 0 && len(out) >= query.Limit {
+			break
+		}
+	}
+	return out
 }
 
 func cachedBeadReady(statusByID map[string]string, deps []Dep) bool {

--- a/internal/beads/doltread/reader.go
+++ b/internal/beads/doltread/reader.go
@@ -1,0 +1,553 @@
+// Package doltread provides bounded read-only SQL views over Beads Dolt tables.
+package doltread
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// Config describes a resolved Dolt SQL target for one Beads scope.
+type Config struct {
+	Host     string
+	Port     int
+	Database string
+	User     string
+	Password string
+}
+
+// Reader serves supported active Beads list queries from bounded SQL reads.
+type Reader struct {
+	db *sql.DB
+}
+
+// Open creates a Reader with a small connection pool.
+func Open(cfg Config) (*Reader, error) {
+	db, err := sql.Open("mysql", buildDSN(cfg))
+	if err != nil {
+		return nil, fmt.Errorf("open indexed dolt reader: %w", err)
+	}
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(2)
+	db.SetConnMaxLifetime(30 * time.Second)
+	return &Reader{db: db}, nil
+}
+
+// New returns a Reader backed by db. Tests use this to avoid opening a network
+// connection.
+func New(db *sql.DB) *Reader {
+	return &Reader{db: db}
+}
+
+func buildDSN(cfg Config) string {
+	user := strings.TrimSpace(cfg.User)
+	if user == "" {
+		user = "root"
+	}
+	mysqlCfg := mysql.NewConfig()
+	mysqlCfg.User = user
+	mysqlCfg.Passwd = cfg.Password
+	mysqlCfg.Net = "tcp"
+	mysqlCfg.Addr = fmt.Sprintf("%s:%d", strings.TrimSpace(cfg.Host), cfg.Port)
+	mysqlCfg.DBName = strings.TrimSpace(cfg.Database)
+	mysqlCfg.ParseTime = true
+	mysqlCfg.Timeout = 10 * time.Second
+	mysqlCfg.ReadTimeout = 10 * time.Second
+	mysqlCfg.WriteTimeout = 10 * time.Second
+	mysqlCfg.AllowNativePasswords = true
+	return mysqlCfg.FormatDSN()
+}
+
+// Close closes the underlying SQL pool.
+func (r *Reader) Close() error {
+	if r == nil || r.db == nil {
+		return nil
+	}
+	return r.db.Close()
+}
+
+// ListIndexed returns supported rows with label and dependency enrichment.
+// Broad closed/history/full-text query shapes are intentionally unsupported and
+// must fall back to Beads CLI.
+func (r *Reader) ListIndexed(ctx context.Context, query beads.ListQuery) (beads.IndexedListResult, error) {
+	if r == nil || r.db == nil {
+		return beads.IndexedListResult{}, fmt.Errorf("indexed dolt reader unavailable")
+	}
+	if err := validateSupported(query); err != nil {
+		return beads.IndexedListResult{}, err
+	}
+
+	switch query.TierMode {
+	case beads.TierWisps:
+		return r.listTier(ctx, query, tierWisps, true)
+	case beads.TierBoth:
+		issuesQ := query
+		issuesQ.TierMode = beads.TierIssues
+		wispsQ := query
+		wispsQ.TierMode = beads.TierWisps
+
+		applyTierLimit := query.Limit > 0
+		issues, err := r.listTier(ctx, issuesQ, tierIssues, applyTierLimit)
+		if err != nil {
+			return issues, err
+		}
+		wisps, err := r.listTier(ctx, wispsQ, tierWisps, applyTierLimit)
+		if err != nil {
+			return wisps, err
+		}
+		return mergeTierResults(query, issues, wisps), nil
+	default:
+		return r.listTier(ctx, query, tierIssues, true)
+	}
+}
+
+// CountIndexed returns a cheap aggregate count for supported Beads table
+// filters. Unlike ListIndexed it does not hydrate labels or dependencies, so
+// broad all-status counts are safe for status/health summaries.
+func (r *Reader) CountIndexed(ctx context.Context, query beads.ListQuery) (int, error) {
+	if r == nil || r.db == nil {
+		return 0, fmt.Errorf("indexed dolt reader unavailable")
+	}
+	if err := validateSupportedStatus(query); err != nil {
+		return 0, err
+	}
+	switch query.TierMode {
+	case beads.TierWisps:
+		return r.countTier(ctx, query, tierWisps)
+	case beads.TierBoth:
+		issues, err := r.countTier(ctx, query, tierIssues)
+		if err != nil {
+			return 0, err
+		}
+		wisps, err := r.countTier(ctx, query, tierWisps)
+		if err != nil {
+			return 0, err
+		}
+		return issues + wisps, nil
+	default:
+		return r.countTier(ctx, query, tierIssues)
+	}
+}
+
+func validateSupported(query beads.ListQuery) error {
+	if err := validateSupportedStatus(query); err != nil {
+		return err
+	}
+	if query.IncludeClosed || query.Status == "closed" {
+		if !isBoundedHistoryQuery(query) {
+			return fmt.Errorf("%w: broad closed/history reads", beads.ErrIndexedListUnsupported)
+		}
+	}
+	return nil
+}
+
+func validateSupportedStatus(query beads.ListQuery) error {
+	switch query.Status {
+	case "", "open", "in_progress", "closed":
+	default:
+		return fmt.Errorf("%w: raw status %q", beads.ErrIndexedListUnsupported, query.Status)
+	}
+	return nil
+}
+
+func isBoundedHistoryQuery(query beads.ListQuery) bool {
+	if len(query.Metadata) > 0 {
+		return true
+	}
+	if query.Type == "session" || query.Label == "gc:session" {
+		return true
+	}
+	if query.ParentID != "" {
+		return true
+	}
+	if query.Limit <= 0 {
+		return false
+	}
+	return query.Label != "" ||
+		query.Type != "" ||
+		query.Assignee != "" ||
+		query.ParentID != "" ||
+		!query.CreatedBefore.IsZero()
+}
+
+type tierSpec struct {
+	beadTable  string
+	labelTable string
+	depTable   string
+	ephemeral  bool
+}
+
+var (
+	tierIssues = tierSpec{beadTable: "issues", labelTable: "labels", depTable: "dependencies"}
+	tierWisps  = tierSpec{beadTable: "wisps", labelTable: "wisp_labels", depTable: "wisp_dependencies", ephemeral: true}
+)
+
+func (r *Reader) listTier(ctx context.Context, query beads.ListQuery, tier tierSpec, applyLimit bool) (beads.IndexedListResult, error) {
+	sqlText, args := buildListSQL(query, tier, applyLimit)
+	rows, err := r.db.QueryContext(ctx, sqlText, args...)
+	if err != nil {
+		return beads.IndexedListResult{}, fmt.Errorf("indexed list %s: %w", tier.beadTable, err)
+	}
+	defer rows.Close() //nolint:errcheck // best-effort cleanup
+
+	items := make([]beads.Bead, 0)
+	for rows.Next() {
+		item, err := scanBead(rows.Scan, tier.ephemeral)
+		if err != nil {
+			return beads.IndexedListResult{}, fmt.Errorf("indexed list scan %s: %w", tier.beadTable, err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return beads.IndexedListResult{}, fmt.Errorf("indexed list rows %s: %w", tier.beadTable, err)
+	}
+
+	ids := beadIDs(items)
+	labelsCoverage := true
+	if !query.SkipLabels || query.Label != "" {
+		labelsByID, err := r.loadLabels(ctx, tier.labelTable, ids)
+		if err != nil {
+			return beads.IndexedListResult{Beads: items, LabelsCoverage: false}, err
+		}
+		for i := range items {
+			items[i].Labels = labelsByID[items[i].ID]
+		}
+	}
+	depsByID, err := r.loadDependencies(ctx, tier.depTable, ids)
+	if err != nil {
+		return beads.IndexedListResult{Beads: items, LabelsCoverage: labelsCoverage}, err
+	}
+	for i := range items {
+		items[i].Dependencies = depsByID[items[i].ID]
+		for _, dep := range items[i].Dependencies {
+			if dep.Type == "parent-child" {
+				items[i].ParentID = dep.DependsOnID
+				break
+			}
+		}
+	}
+
+	items = beads.ApplyListQuery(items, query)
+	return beads.IndexedListResult{
+		Beads:              items,
+		DepsByID:           depsByID,
+		DependencyCoverage: true,
+		LabelsCoverage:     labelsCoverage,
+	}, nil
+}
+
+func (r *Reader) countTier(ctx context.Context, query beads.ListQuery, tier tierSpec) (int, error) {
+	sqlText, args := buildCountSQL(query, tier)
+	var count int
+	if err := r.db.QueryRowContext(ctx, sqlText, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("indexed count %s: %w", tier.beadTable, err)
+	}
+	return count, nil
+}
+
+func buildWhereSQL(query beads.ListQuery, tier tierSpec) ([]string, []any) {
+	where := []string{}
+	args := []any{}
+
+	switch {
+	case query.Status == "closed":
+		where = append(where, "b.status = ?")
+		args = append(args, "closed")
+	case query.Status == "open":
+		where = append(where, "b.status NOT IN ('closed', 'in_progress')")
+	case query.Status == "in_progress":
+		where = append(where, "b.status = ?")
+		args = append(args, "in_progress")
+	case !query.IncludeClosed:
+		where = append(where, "b.status <> 'closed'")
+	}
+	if query.Type != "" {
+		where = append(where, "b.issue_type = ?")
+		args = append(args, query.Type)
+	}
+	if query.Assignee != "" {
+		where = append(where, "b.assignee = ?")
+		args = append(args, query.Assignee)
+	}
+	if query.Label != "" {
+		where = append(where, "EXISTS (SELECT 1 FROM "+tier.labelTable+" l WHERE l.issue_id = b.id AND l.label = ?)")
+		args = append(args, query.Label)
+	}
+	if query.ParentID != "" {
+		where = append(where, "EXISTS (SELECT 1 FROM "+tier.depTable+" d WHERE d.issue_id = b.id AND d.type = 'parent-child' AND "+dependencyTargetExpr("d")+" = ?)")
+		args = append(args, query.ParentID)
+	}
+	if !query.CreatedBefore.IsZero() {
+		where = append(where, "b.created_at < ?")
+		args = append(args, query.CreatedBefore)
+	}
+	if len(query.Metadata) > 0 {
+		keys := make([]string, 0, len(query.Metadata))
+		for key := range query.Metadata {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			where = append(where, "JSON_UNQUOTE(JSON_EXTRACT(b.metadata, ?)) = ?")
+			args = append(args, metadataJSONPath(key), query.Metadata[key])
+		}
+	}
+	if len(where) == 0 {
+		where = append(where, "1=1")
+	}
+	return where, args
+}
+
+func buildFromWhereSQL(query beads.ListQuery, tier tierSpec) (string, []string, []any) {
+	from := tier.beadTable + " b"
+	whereQuery := query
+	if query.Label != "" {
+		from = tier.labelTable + " l JOIN " + tier.beadTable + " b ON b.id = l.issue_id"
+		whereQuery.Label = ""
+	}
+	if query.ParentID != "" {
+		if query.Label == "" {
+			from = tier.depTable + " d JOIN " + tier.beadTable + " b ON b.id = d.issue_id AND d.type = 'parent-child'"
+		} else {
+			from += " JOIN " + tier.depTable + " d ON d.issue_id = b.id AND d.type = 'parent-child'"
+		}
+		whereQuery.ParentID = ""
+	}
+	where, args := buildWhereSQL(whereQuery, tier)
+	if query.Label != "" {
+		where = append(where, "l.label = ?")
+		args = append(args, query.Label)
+	}
+	if query.ParentID != "" {
+		where = append(where, dependencyTargetExpr("d")+" = ?")
+		args = append(args, query.ParentID)
+	}
+	return from, where, args
+}
+
+func buildListSQL(query beads.ListQuery, tier tierSpec, applyLimit bool) (string, []any) {
+	from, where, args := buildFromWhereSQL(query, tier)
+	order := "DESC"
+	if query.Sort == beads.SortCreatedAsc {
+		order = "ASC"
+	}
+	text := "SELECT b.id, b.title, b.description, b.status, b.priority, b.issue_type, b.assignee, b.created_at, b.external_ref, b.metadata FROM " +
+		from + " WHERE " + strings.Join(where, " AND ") +
+		" ORDER BY b.created_at " + order + ", b.id " + order
+	if applyLimit && query.Limit > 0 {
+		text += " LIMIT ?"
+		args = append(args, query.Limit)
+	}
+	return text, args
+}
+
+func buildCountSQL(query beads.ListQuery, tier tierSpec) (string, []any) {
+	from, where, args := buildFromWhereSQL(query, tier)
+	text := "SELECT COUNT(*) FROM " + from + " WHERE " + strings.Join(where, " AND ")
+	return text, args
+}
+
+func scanBead(scan func(dest ...any) error, ephemeral bool) (beads.Bead, error) {
+	var item beads.Bead
+	var description, assignee, externalRef sql.NullString
+	var priority sql.NullInt64
+	var metadataJSON []byte
+
+	if err := scan(
+		&item.ID,
+		&item.Title,
+		&description,
+		&item.Status,
+		&priority,
+		&item.Type,
+		&assignee,
+		&item.CreatedAt,
+		&externalRef,
+		&metadataJSON,
+	); err != nil {
+		return beads.Bead{}, err
+	}
+	item.Status = normalizeStatus(item.Status)
+	item.Description = description.String
+	item.Assignee = assignee.String
+	item.Ref = externalRef.String
+	item.Ephemeral = ephemeral
+	if priority.Valid {
+		p := int(priority.Int64)
+		item.Priority = &p
+	}
+	if len(metadataJSON) > 0 {
+		item.Metadata = parseMetadata(metadataJSON)
+	}
+	return item, nil
+}
+
+func parseMetadata(data []byte) map[string]string {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil || len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if s, ok := value.(string); ok {
+			out[key] = s
+			continue
+		}
+		if encoded, err := json.Marshal(value); err == nil {
+			out[key] = string(encoded)
+		}
+	}
+	return out
+}
+
+func normalizeStatus(status string) string {
+	switch status {
+	case "closed":
+		return "closed"
+	case "in_progress":
+		return "in_progress"
+	default:
+		return "open"
+	}
+}
+
+func (r *Reader) loadLabels(ctx context.Context, table string, ids []string) (map[string][]string, error) {
+	out := make(map[string][]string, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	query, args := inQuery("SELECT issue_id, label FROM "+table+" WHERE issue_id IN ", ids)
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return out, fmt.Errorf("indexed labels %s: %w", table, err)
+	}
+	defer rows.Close() //nolint:errcheck // best-effort cleanup
+	for rows.Next() {
+		var id, label string
+		if err := rows.Scan(&id, &label); err != nil {
+			return out, fmt.Errorf("indexed labels scan %s: %w", table, err)
+		}
+		out[id] = append(out[id], label)
+	}
+	if err := rows.Err(); err != nil {
+		return out, fmt.Errorf("indexed labels rows %s: %w", table, err)
+	}
+	return out, nil
+}
+
+func (r *Reader) loadDependencies(ctx context.Context, table string, ids []string) (map[string][]beads.Dep, error) {
+	out := make(map[string][]beads.Dep, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	query, args := inQuery("SELECT issue_id, "+dependencyTargetExpr("")+" AS depends_on_id, type FROM "+table+" WHERE issue_id IN ", ids)
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return out, fmt.Errorf("indexed dependencies %s: %w", table, err)
+	}
+	defer rows.Close() //nolint:errcheck // best-effort cleanup
+	for rows.Next() {
+		var dep beads.Dep
+		if err := rows.Scan(&dep.IssueID, &dep.DependsOnID, &dep.Type); err != nil {
+			return out, fmt.Errorf("indexed dependencies scan %s: %w", table, err)
+		}
+		if dep.IssueID == "" || dep.DependsOnID == "" {
+			continue
+		}
+		out[dep.IssueID] = append(out[dep.IssueID], dep)
+	}
+	if err := rows.Err(); err != nil {
+		return out, fmt.Errorf("indexed dependencies rows %s: %w", table, err)
+	}
+	return out, nil
+}
+
+func dependencyTargetExpr(alias string) string {
+	prefix := ""
+	if alias != "" {
+		prefix = alias + "."
+	}
+	return "COALESCE(" + prefix + "depends_on_issue_id, " + prefix + "depends_on_wisp_id, " + prefix + "depends_on_external)"
+}
+
+func metadataJSONPath(key string) string {
+	escaped := strings.ReplaceAll(key, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `$."` + escaped + `"`
+}
+
+func beadIDs(items []beads.Bead) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.ID != "" {
+			ids = append(ids, item.ID)
+		}
+	}
+	return ids
+}
+
+func inQuery(prefix string, ids []string) (string, []any) {
+	args := make([]any, len(ids))
+	parts := make([]string, len(ids))
+	for i, id := range ids {
+		args[i] = id
+		parts[i] = "?"
+	}
+	return prefix + "(" + strings.Join(parts, ",") + ")", args
+}
+
+func mergeTierResults(query beads.ListQuery, results ...beads.IndexedListResult) beads.IndexedListResult {
+	seen := map[string]struct{}{}
+	items := []beads.Bead{}
+	depsByID := map[string][]beads.Dep{}
+	labelsCoverage := true
+	dependencyCoverage := true
+	for _, result := range results {
+		labelsCoverage = labelsCoverage && result.LabelsCoverage
+		dependencyCoverage = dependencyCoverage && result.DependencyCoverage
+		for id, deps := range result.DepsByID {
+			depsByID[id] = deps
+		}
+		for _, item := range result.Beads {
+			if _, ok := seen[item.ID]; ok {
+				continue
+			}
+			seen[item.ID] = struct{}{}
+			items = append(items, item)
+		}
+	}
+	sortBeads(items, query.Sort)
+	if query.Limit > 0 && len(items) > query.Limit {
+		items = items[:query.Limit]
+	}
+	return beads.IndexedListResult{
+		Beads:              items,
+		DepsByID:           depsByID,
+		DependencyCoverage: dependencyCoverage,
+		LabelsCoverage:     labelsCoverage,
+	}
+}
+
+func sortBeads(items []beads.Bead, order beads.SortOrder) {
+	desc := order != beads.SortCreatedAsc
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			if desc {
+				return items[i].ID > items[j].ID
+			}
+			return items[i].ID < items[j].ID
+		}
+		if desc {
+			return items[i].CreatedAt.After(items[j].CreatedAt)
+		}
+		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	})
+}

--- a/internal/beads/indexed.go
+++ b/internal/beads/indexed.go
@@ -1,0 +1,30 @@
+package beads
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrIndexedListUnsupported reports that a ListQuery cannot be served by the
+// bounded active indexed reader and should use the authoritative Beads path.
+var ErrIndexedListUnsupported = errors.New("indexed list unsupported")
+
+// IndexedListResult carries indexed-reader rows plus coverage metadata for
+// enrichment that Beads CLI normally hydrates.
+type IndexedListResult struct {
+	Beads              []Bead
+	DepsByID           map[string][]Dep
+	DependencyCoverage bool
+	LabelsCoverage     bool
+}
+
+// IndexedLister is the read-only active Beads list acceleration contract.
+type IndexedLister interface {
+	ListIndexed(ctx context.Context, query ListQuery) (IndexedListResult, error)
+}
+
+// IndexedCounter is an optional companion to IndexedLister for cheap aggregate
+// counts that do not need the hydrated label/dependency payload from ListIndexed.
+type IndexedCounter interface {
+	CountIndexed(ctx context.Context, query ListQuery) (int, error)
+}

--- a/internal/beads/runtime_read.go
+++ b/internal/beads/runtime_read.go
@@ -1,0 +1,222 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ReadClass names the runtime contract for a bead read. Hot runtime classes
+// must not fall back to hydrated Beads CLI reads when cache or indexed SQL is
+// unavailable.
+type ReadClass string
+
+const (
+	// ReadClassHotAuthoritative is for controller/session decisions that must
+	// be correct before taking action but still cannot use hydrated CLI
+	// fallback.
+	ReadClassHotAuthoritative ReadClass = "hot-authoritative"
+	// ReadClassHotDegradedOK is for runtime summaries and demand hints that
+	// can return partial/degraded state.
+	ReadClassHotDegradedOK ReadClass = "hot-degraded-ok"
+	// ReadClassForegroundAuthoritative is for operator commands that may use
+	// the Beads CLI fallback path.
+	ReadClassForegroundAuthoritative ReadClass = "foreground-authoritative"
+	// ReadClassMaintenance is for serialized non-hot maintenance work.
+	ReadClassMaintenance ReadClass = "maintenance"
+)
+
+// Runtime read budgets. These are deliberately below the controller's default
+// five-second tick budget and below the Dolt MySQL transport timeout.
+const (
+	// HotAuthoritativeBudget bounds a hot authoritative caller.
+	HotAuthoritativeBudget = 3500 * time.Millisecond
+	// HotDegradedOKBudget bounds a hot degraded-ok caller.
+	HotDegradedOKBudget = 2 * time.Second
+	// MaintenanceReadBudget is the default SQL health/read probe budget for
+	// maintenance class reads.
+	MaintenanceReadBudget = 30 * time.Second
+)
+
+// ReadPolicy declares how a runtime caller is allowed to read bead state.
+type ReadPolicy struct {
+	Class         ReadClass
+	Caller        string
+	Timeout       time.Duration
+	MaxRows       int
+	AllowFallback bool
+}
+
+// RuntimeReadPolicy returns a policy with the documented default budget and
+// fallback behavior for class.
+func RuntimeReadPolicy(class ReadClass, caller string) ReadPolicy {
+	p := ReadPolicy{Class: class, Caller: caller}
+	switch class {
+	case ReadClassHotAuthoritative:
+		p.Timeout = HotAuthoritativeBudget
+		p.MaxRows = 500
+	case ReadClassHotDegradedOK:
+		p.Timeout = HotDegradedOKBudget
+		p.MaxRows = 250
+	case ReadClassMaintenance:
+		p.Timeout = MaintenanceReadBudget
+		p.AllowFallback = true
+	default:
+		p.Class = ReadClassForegroundAuthoritative
+		p.AllowFallback = true
+	}
+	return p
+}
+
+// DegradedReadError reports a bounded hot-read degradation. Callers should
+// defer unsafe actions or surface partial status instead of retrying through bd
+// CLI fallback.
+type DegradedReadError struct {
+	Class     ReadClass
+	Caller    string
+	Operation string
+	Route     string
+	Coverage  string
+	Err       error
+}
+
+func (e *DegradedReadError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	msg := "degraded runtime read"
+	if e.Caller != "" {
+		msg += " caller=" + e.Caller
+	}
+	if e.Operation != "" {
+		msg += " op=" + e.Operation
+	}
+	if e.Class != "" {
+		msg += " class=" + string(e.Class)
+	}
+	if e.Route != "" {
+		msg += " route=" + e.Route
+	}
+	if e.Coverage != "" {
+		msg += " coverage=" + e.Coverage
+	}
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	return msg
+}
+
+func (e *DegradedReadError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// IsDegradedRead reports whether err is a runtime degraded-read error.
+func IsDegradedRead(err error) bool {
+	var degraded *DegradedReadError
+	return errors.As(err, &degraded)
+}
+
+type runtimeLister interface {
+	RuntimeList(context.Context, ListQuery, ReadPolicy) ([]Bead, error)
+}
+
+type runtimeReadyer interface {
+	RuntimeReady(context.Context, ReadyQuery, ReadPolicy) ([]Bead, error)
+}
+
+// RuntimeList executes a list query under policy. Foreground/maintenance
+// policies preserve the existing authoritative store behavior. Hot policies use
+// cache or indexed routes only and return DegradedReadError instead of falling
+// through to hydrated bd list/query.
+func RuntimeList(ctx context.Context, store Store, query ListQuery, policy ReadPolicy) ([]Bead, error) {
+	if store == nil {
+		return nil, degradedRead(policy, "list", "none", "", errors.New("nil bead store"))
+	}
+	policy = normalizeReadPolicy(policy)
+	if policy.AllowFallback {
+		return store.List(query)
+	}
+	if runtimeStore, ok := store.(runtimeLister); ok {
+		return runtimeStore.RuntimeList(ctx, query, policy)
+	}
+	return store.List(query)
+}
+
+// RuntimeReady executes a ready-work lookup under policy. Hot policies use the
+// cache read model when available; they never call bd ready.
+func RuntimeReady(ctx context.Context, store Store, query ReadyQuery, policy ReadPolicy) ([]Bead, error) {
+	if store == nil {
+		return nil, degradedRead(policy, "ready", "none", "", errors.New("nil bead store"))
+	}
+	policy = normalizeReadPolicy(policy)
+	if policy.AllowFallback {
+		return readyWithQuery(store, query)
+	}
+	if runtimeStore, ok := store.(runtimeReadyer); ok {
+		return runtimeStore.RuntimeReady(ctx, query, policy)
+	}
+	return readyWithQuery(store, query)
+}
+
+func readyWithQuery(store Store, query ReadyQuery) ([]Bead, error) {
+	if query == (ReadyQuery{}) {
+		return store.Ready()
+	}
+	return store.Ready(query)
+}
+
+func normalizeReadPolicy(policy ReadPolicy) ReadPolicy {
+	if policy.Class == "" {
+		policy = RuntimeReadPolicy(ReadClassHotDegradedOK, policy.Caller)
+	}
+	defaulted := RuntimeReadPolicy(policy.Class, policy.Caller)
+	if policy.Timeout <= 0 {
+		policy.Timeout = defaulted.Timeout
+	}
+	if policy.MaxRows <= 0 {
+		policy.MaxRows = defaulted.MaxRows
+	}
+	policy.AllowFallback = policy.AllowFallback || defaulted.AllowFallback
+	return policy
+}
+
+func contextWithReadPolicy(ctx context.Context, policy ReadPolicy) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining <= policy.Timeout {
+			return context.WithCancel(ctx)
+		}
+	}
+	if policy.Timeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, policy.Timeout)
+}
+
+func degradedRead(policy ReadPolicy, op, route, coverage string, err error) error {
+	if err == nil {
+		err = errors.New("runtime read degraded")
+	}
+	return &DegradedReadError{
+		Class:     policy.Class,
+		Caller:    policy.Caller,
+		Operation: op,
+		Route:     route,
+		Coverage:  coverage,
+		Err:       err,
+	}
+}
+
+func enforceRuntimeRowCap(items []Bead, policy ReadPolicy, op, route string) ([]Bead, error) {
+	if policy.MaxRows <= 0 || len(items) < policy.MaxRows {
+		return items, nil
+	}
+	return items, degradedRead(policy, op, route, "row-cap", fmt.Errorf("runtime read returned %d rows at cap %d", len(items), policy.MaxRows))
+}


### PR DESCRIPTION
## Summary

Fixes #2674.

This PR makes assigned patrol wisps wake already-live on-demand named sessions through controller-owned queued nudges, while keeping patrol wisps out of generic assigned work, pool demand, and order-dispatch demand.

## Final Architecture

- Named-session patrol-wisp discovery stays in `namedSessionPatrolWispWakeDemand`, not generic assigned-work collection.
- The probe uses `beads.RuntimeList` with `ReadClassHotDegradedOK`, `TierMode: beads.TierWisps`, exact assignee identity, `status in {in_progress, open}`, bounded page size, skipped labels, per-read budget, and aggregate probe budget.
- Matching patrol wisps populate `NamedSessionWispDemand` only.
- The reconciler queues a `patrol-wisp` nudge for already-live named sessions at the current continuation epoch instead of trying to materialize a duplicate session.
- Pending/in-flight duplicate nudges for the same session/epoch/ref are suppressed, delivered/acked nudges can re-fire for the same still-active wisp, and stale queued refs for the same live session/epoch are terminalized as `superseded` when a newer patrol wisp wins selection.
- No feature flags, compatibility shims, canary-only paths, temporary workaround orders, or stale generated artifacts were introduced.

## Commits

- `c67b3631` hardens the bounded named-session patrol-wisp probe.
- `0d1068fa` queues patrol-wisp reminders for already-live named sessions.
- `f5150dd4` selects the newest matching patrol wisp across `open` and `in_progress` candidates.
- `6539d5f1` lets the same wisp re-fire after the previous queued item is delivered or acked.
- `fc7c8e5c` supersedes stale patrol-wisp queued reminders for the same live session/epoch when a newer patrol wisp becomes selected.

## Validation

Passed on `fix/named-session-patrol-wisp-wake` at `fc7c8e5c`:

```shell
gofmt -w cmd/gc/session_reconciler.go cmd/gc/session_reconciler_test.go
go test ./cmd/gc -run 'TestReconcileSessionBeads_OnDemandNamedSession.*PatrolWisp|TestBuildDesiredState_OnDemandNamedSession_.*PatrolWisp|TestDispatchAllQueuedNudgesDeliversToIdleACPSession' -count=1
make build
git diff --check
```

Also passed after cherry-picking into the live runtime branch as `1bb8b490`, and again on the later current runtime source commit `e4c62ea2`:

```shell
go test ./cmd/gc -run 'TestReconcileSessionBeads_OnDemandNamedSession.*PatrolWisp|TestBuildDesiredState_OnDemandNamedSession_.*PatrolWisp|TestDispatchAllQueuedNudgesDeliversToIdleACPSession' -count=1
git diff --check
```

Broad package validation was rerun:

```shell
go test ./cmd/gc -count=1
```

That full package command remains red in this local Darwin checkout after 381.261s on unrelated baseline failures, not on patrol-wisp wake tests. The observed baseline classes are Darwin `/proc/<pid>/exe` drift checks, `/private/tmp` vs `/tmp` path identity checks, Dolt leak-guard/process cleanup, GitRefSource ref stability, Kimi transcript path identity, scripts tempdir cleanup permission, and unrelated CLI fixture exits for deprecated or invalid flag combinations. Local capture: `/tmp/named-session-patrol-wisp-go-test-cmd-gc-final-fc7c8e5c.txt`.

## Live Runtime Cutover

Smoke cutover ran locally on 2026-05-27 by cherry-picking the final behavior into `mp/runtime-read-isolation-and-dolt-contention` at `1bb8b490`, installing `/Users/mike/go/bin/gc`, then restarting the supervisor/controller with:

```shell
gc supervisor stop --wait --wait-timeout 60s --json && gc supervisor start && gc start
```

A later unrelated runtime-read/doctor install advanced the current installed binary to `e4c62ea2`; that commit is a descendant of `1bb8b490` and keeps the patrol-wisp changes. The focused patrol-wisp suite re-passed on `e4c62ea2`.

Final runtime evidence:

- `go version -m /Users/mike/go/bin/gc` reports module version `v1.1.1-0.20260528000102-e4c62ea2d00f` with `vcs.modified=false`.
- Final supervisor check: PID `57283`, controller running, city health `usable=true`, `degraded=false`.
- Watch file from the `1bb8b490` smoke: `/tmp/named-session-patrol-wisp-live-watch-1bb8b490.tsv`.
- Queue details: `/tmp/named-session-patrol-wisp-nudge-detail-1bb8b490.json` and `/tmp/named-session-patrol-wisp-nudge-detail-after-delivery-1bb8b490.json`.
- Refinery pane captures: `/tmp/named-session-patrol-wisp-refinery-pane-1bb8b490.txt` and `/tmp/named-session-patrol-wisp-refinery-pane-after-delivery-1bb8b490.txt`.
- Supervisor log sample: `/tmp/named-session-patrol-wisp-supervisor-log-1bb8b490.txt`.

At 2026-05-27T23:45:33Z, live smoke saw two refinery patrol wisps (`vg-wisp-0tf67k`, `vg-wisp-i3t22c`). Queue detail showed the current ref pending and the stale ref dead with `last_error="superseded"`, so no duplicate stale deliverable reminder remained. At the safe boundary, the refinery pane displayed the deferred `[patrol-wisp]` reminder and the same live session ran `gc hook` without any manual `gc session nudge`. The session then continued through successor wisps `vg-wisp-ogeql1`, `vg-wisp-bijux4`, `vg-wisp-r5i86t`, and `vg-wisp-hgn8kc`.

Final queue cleanup evidence showed stale refs `i3t22c`, `0tf67k`, and `ogeql1` terminalized as `superseded`, no stuck in-flight patrol-wisp reminder, and one pending reminder only for the newest active refinery patrol wisp `vg-wisp-hgn8kc`.

## Cutover Cleanup

Runtime workaround check found no active `refinery-auto-wake`, witness, or deacon workaround order during this implementation. The live smoke used controller-queued patrol-wisp nudges only.

Rollback triggers remain: hydrated Beads CLI fallback in this hot path, patrol wisps leaking into generic demand/order-dispatch demand, duplicate order dispatches, or named-session patrol wisps no longer waking the configured live named session.

