### PR TITLE
fix(config): include rig-imported pack dirs when rendering prompts

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -104,7 +104,7 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 		rigs:            cfg.Rigs,
 		sessionTemplate: cfg.Workspace.SessionTemplate,
 		beaconTime:      beaconTime,
-		packDirs:        cfg.PackDirs,
+		packDirs:        cfg.AllPackDirs(),
 		packOverlayDirs: cfg.PackOverlayDirs,
 		rigOverlayDirs:  cfg.RigOverlayDirs,
 		globalFragments: cfg.Workspace.GlobalFragments,

--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -104,7 +104,7 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 		rigs:            cfg.Rigs,
 		sessionTemplate: cfg.Workspace.SessionTemplate,
 		beaconTime:      beaconTime,
-		packDirs:        cfg.AllPackDirs(),
+		packDirs:        cfg.PackDirs,
 		packOverlayDirs: cfg.PackOverlayDirs,
 		rigOverlayDirs:  cfg.RigOverlayDirs,
 		globalFragments: cfg.Workspace.GlobalFragments,

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -318,7 +318,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 				cfg.AgentDefaults.AppendFragments,
 			)
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, stderr,
-				cfg.PackDirs, fragments, nil)
+				cfg.AllPackDirs(), fragments, nil)
 			if prompt != "" {
 				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat, suppressHookPrompt)
 				return 0

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -317,8 +317,9 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 				a.InheritedAppendFragments,
 				cfg.AgentDefaults.AppendFragments,
 			)
+			packDirs := cfg.PackDirsForRig(ctx.RigName)
 			prompt := renderPrompt(fsys.OSFS{}, cityPath, cityName, a.PromptTemplate, ctx, cfg.Workspace.SessionTemplate, stderr,
-				cfg.AllPackDirs(), fragments, nil)
+				packDirs, fragments, nil)
 			if prompt != "" {
 				writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, prompt, hookMode, hookFormat, suppressHookPrompt)
 				return 0

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -143,6 +143,73 @@ schema = 2
 	}
 }
 
+func TestDoPrimeScopesRigPackFragmentsByCurrentRig(t *testing.T) {
+	clearGCEnv(t)
+
+	cityDir := t.TempDir()
+	write := func(rel, data string) {
+		path := filepath.Join(cityDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+	write("pack.toml", "[pack]\nname = \"prompt-city\"\nschema = 2\n")
+	write("city.toml", `
+[workspace]
+name = "prompt-city"
+
+[[rigs]]
+name = "alpha"
+
+[rigs.imports.alpha]
+source = "./packs/alpha"
+
+[[rigs]]
+name = "bravo"
+
+[rigs.imports.bravo]
+source = "./packs/bravo"
+`)
+	write(".gc/site.toml", `
+workspace_name = "prompt-city"
+
+[[rig]]
+name = "alpha"
+path = "./rigs/alpha"
+
+[[rig]]
+name = "bravo"
+path = "./rigs/bravo"
+`)
+	write("agents/alpha-worker/agent.toml", "dir = \"alpha\"\nprompt_template = \"agents/alpha-worker/prompt.template.md\"\n")
+	write("agents/bravo-worker/agent.toml", "dir = \"bravo\"\nprompt_template = \"agents/bravo-worker/prompt.template.md\"\n")
+	write("agents/alpha-worker/prompt.template.md", `{{ template "work-query" . }}`)
+	write("agents/bravo-worker/prompt.template.md", `{{ template "work-query" . }}`)
+	write("packs/alpha/pack.toml", "[pack]\nname = \"alpha\"\nschema = 2\n")
+	write("packs/bravo/pack.toml", "[pack]\nname = \"bravo\"\nschema = 2\n")
+	write("packs/alpha/template-fragments/work-query.template.md", `{{ define "work-query" }}alpha-work-query{{ end }}`)
+	write("packs/bravo/template-fragments/work-query.template.md", `{{ define "work-query" }}bravo-work-query{{ end }}`)
+
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithMode([]string{"alpha-worker"}, &stdout, &stderr, false, true)
+	if code != 0 {
+		t.Fatalf("doPrime() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if got := stdout.String(); got != "alpha-work-query" {
+		t.Fatalf("stdout = %q, want alpha rig fragment; stderr=%q", got, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "bravo-work-query") {
+		t.Fatalf("stdout = %q, must not include bravo rig fragment", stdout.String())
+	}
+}
+
 func TestBuildPrimeContextPrefersGCAliasOverGCAgent(t *testing.T) {
 	// When GC_AGENT is a session bead ID, buildPrimeContext should prefer
 	// GC_ALIAS for AgentName so the prompt doesn't contain a bead ID.

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -1226,6 +1226,81 @@ func TestRenderPromptCityRootFragmentsPerAgentWins(t *testing.T) {
 	}
 }
 
+// TestRenderPromptResolvesRigPackFragment is the renderer-level regression
+// test for gascity#2676: a template fragment shipped in a rig-imported pack
+// (i.e. in cfg.RigPackDirs[<rig>], not cfg.PackDirs) must resolve when the
+// renderer is given the union slice via (*City).AllPackDirs(). Before the
+// fix the two callers in agent_build_params.go / cmd_prime.go passed only
+// cfg.PackDirs, so rig-pack fragments silently fell through and the renderer
+// emitted the raw `{{ template ... }}` directive in error fallback.
+func TestRenderPromptResolvesRigPackFragment(t *testing.T) {
+	f := fsys.NewFake()
+	// Rig-imported pack ships a template fragment.
+	rigPackDir := "/city/.gc/cache/repos/abc123/packs/gastown"
+	f.Files[rigPackDir+"/template-fragments/work-query.template.md"] = []byte(
+		`{{ define "work-query" }}rig-pack-work-query{{ end }}`)
+	// An imported agent's prompt references that fragment.
+	f.Files["/city/agents/polecat/prompt.template.md"] = []byte(
+		`{{ template "work-query" . }}`)
+
+	cfg := &config.City{
+		// PackDirs is intentionally empty: this city imports its pack
+		// at the rig level, not the city level. Pre-fix callers passed
+		// cfg.PackDirs here and the fragment was never registered.
+		PackDirs: nil,
+		RigPackDirs: map[string][]string{
+			"gastown": {rigPackDir},
+		},
+	}
+
+	// Post-fix call: cfg.AllPackDirs() includes the rig dir → fragment resolves.
+	got := renderPrompt(f, "/city", "", "agents/polecat/prompt.template.md",
+		PromptContext{AgentName: "polecat"}, "", io.Discard, cfg.AllPackDirs(), nil, nil)
+	if got != "rig-pack-work-query" {
+		t.Errorf("renderPrompt(cfg.AllPackDirs()) = %q, want %q",
+			got, "rig-pack-work-query")
+	}
+
+	// Sanity-check the pre-fix behavior: passing cfg.PackDirs alone (what
+	// the two call sites used before gascity#2676) must NOT resolve the
+	// fragment — otherwise this test wouldn't be guarding the fix. The
+	// renderer's error path emits the raw body and logs to stderr; either
+	// way the rendered output must not be the resolved fragment text.
+	gotBuggy := renderPrompt(f, "/city", "", "agents/polecat/prompt.template.md",
+		PromptContext{AgentName: "polecat"}, "", io.Discard, cfg.PackDirs, nil, nil)
+	if gotBuggy == "rig-pack-work-query" {
+		t.Errorf("pre-fix call with cfg.PackDirs unexpectedly resolved the rig-pack fragment; the regression guard is not actually guarding anything")
+	}
+}
+
+// TestRenderPromptResolvesMultiRigPackFragments verifies that fragments from
+// multiple rig-imported packs all reach the renderer when cfg.AllPackDirs()
+// is passed. Guards against an off-by-one or single-rig assumption in the
+// AllPackDirs union.
+func TestRenderPromptResolvesMultiRigPackFragments(t *testing.T) {
+	f := fsys.NewFake()
+	alphaDir := "/city/.gc/cache/repos/aaa/packs/alpha"
+	bravoDir := "/city/.gc/cache/repos/bbb/packs/bravo"
+	f.Files[alphaDir+"/template-fragments/a.template.md"] = []byte(
+		`{{ define "a" }}A{{ end }}`)
+	f.Files[bravoDir+"/template-fragments/b.template.md"] = []byte(
+		`{{ define "b" }}B{{ end }}`)
+	f.Files["/city/agents/x/prompt.template.md"] = []byte(
+		`{{ template "a" . }}-{{ template "b" . }}`)
+
+	cfg := &config.City{
+		RigPackDirs: map[string][]string{
+			"alpha": {alphaDir},
+			"bravo": {bravoDir},
+		},
+	}
+	got := renderPrompt(f, "/city", "", "agents/x/prompt.template.md",
+		PromptContext{}, "", io.Discard, cfg.AllPackDirs(), nil, nil)
+	if got != "A-B" {
+		t.Errorf("renderPrompt(multi-rig AllPackDirs) = %q, want %q", got, "A-B")
+	}
+}
+
 // TestRenderPromptCityRootFragmentsAbsentNoEffect is the regression-safety
 // check: when the city root has no template-fragments/ or prompts/shared/,
 // rendered output is byte-identical to pre-fix behavior (i.e. the new

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -1229,10 +1229,10 @@ func TestRenderPromptCityRootFragmentsPerAgentWins(t *testing.T) {
 // TestRenderPromptResolvesRigPackFragment is the renderer-level regression
 // test for gascity#2676: a template fragment shipped in a rig-imported pack
 // (i.e. in cfg.RigPackDirs[<rig>], not cfg.PackDirs) must resolve when the
-// renderer is given the union slice via (*City).AllPackDirs(). Before the
-// fix the two callers in agent_build_params.go / cmd_prime.go passed only
-// cfg.PackDirs, so rig-pack fragments silently fell through and the renderer
-// emitted the raw `{{ template ... }}` directive in error fallback.
+// renderer is given that rig's scoped pack directories. Before the fix the
+// two callers in agent_build_params.go / cmd_prime.go passed only cfg.PackDirs,
+// so rig-pack fragments silently fell through and the renderer emitted the raw
+// `{{ template ... }}` directive in error fallback.
 func TestRenderPromptResolvesRigPackFragment(t *testing.T) {
 	f := fsys.NewFake()
 	// Rig-imported pack ships a template fragment.
@@ -1253,11 +1253,12 @@ func TestRenderPromptResolvesRigPackFragment(t *testing.T) {
 		},
 	}
 
-	// Post-fix call: cfg.AllPackDirs() includes the rig dir → fragment resolves.
+	// Post-fix call: cfg.PackDirsForRig includes the current rig dir without
+	// exposing other rigs' pack fragments.
 	got := renderPrompt(f, "/city", "", "agents/polecat/prompt.template.md",
-		PromptContext{AgentName: "polecat"}, "", io.Discard, cfg.AllPackDirs(), nil, nil)
+		PromptContext{AgentName: "polecat"}, "", io.Discard, cfg.PackDirsForRig("gastown"), nil, nil)
 	if got != "rig-pack-work-query" {
-		t.Errorf("renderPrompt(cfg.AllPackDirs()) = %q, want %q",
+		t.Errorf("renderPrompt(cfg.PackDirsForRig()) = %q, want %q",
 			got, "rig-pack-work-query")
 	}
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -305,6 +305,10 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		p.appendFragments,
 	)
 	providerKey, providerDisplayName := providerInfoForAgent(cfgAgent, p.workspace, p.providers)
+	packDirs := p.packDirs
+	if p.city != nil {
+		packDirs = p.city.PackDirsForRig(rigName)
+	}
 	prompt = renderPrompt(p.fs, p.cityPath, p.cityName, cfgAgent.PromptTemplate, PromptContext{
 		CityRoot:            p.cityPath,
 		AgentName:           qualifiedName,
@@ -322,7 +326,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		ProviderDisplayName: providerDisplayName,
 		InstructionsFile:    instructionsFileForAgent(cfgAgent, p.workspace, p.providers),
 		Env:                 cfgAgent.Env,
-	}, p.sessionTemplate, p.stderr, p.packDirs, fragments, p.beadStore)
+	}, p.sessionTemplate, p.stderr, packDirs, fragments, p.beadStore)
 	hasHooks := config.AgentHasHooks(cfgAgent, p.workspace, resolved.Name, p.providers)
 	beacon := runtime.FormatBeaconAt(p.cityName, qualifiedName, !hasHooks, p.beaconTime)
 	suppressStartupPrompt := suppressStartupPromptForAgent(cfgAgent)

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -954,6 +954,68 @@ prompt_template = "agents/mayor/prompt.template.md"
 	}
 }
 
+func TestResolveTemplateScopesRigPackFragmentsByCurrentRig(t *testing.T) {
+	cityPath := t.TempDir()
+	write := func(rel, data string) {
+		path := filepath.Join(cityPath, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	write("agents/alpha-worker/prompt.template.md", `{{ template "work-query" . }}`)
+	write("agents/bravo-worker/prompt.template.md", `{{ template "work-query" . }}`)
+	write("packs/alpha/template-fragments/work-query.template.md", `{{ define "work-query" }}alpha-work-query{{ end }}`)
+	write("packs/bravo/template-fragments/work-query.template.md", `{{ define "work-query" }}bravo-work-query{{ end }}`)
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "stub"},
+		Providers: map[string]config.ProviderSpec{
+			"stub": {Command: "/bin/echo"},
+		},
+		Rigs: []config.Rig{
+			{Name: "alpha", Path: "rigs/alpha"},
+			{Name: "bravo", Path: "rigs/bravo"},
+		},
+		RigPackDirs: map[string][]string{
+			"alpha": {filepath.Join(cityPath, "packs", "alpha")},
+			"bravo": {filepath.Join(cityPath, "packs", "bravo")},
+		},
+	}
+	alphaAgent := config.Agent{
+		Name:           "worker",
+		Dir:            "alpha",
+		Provider:       "stub",
+		PromptTemplate: "agents/alpha-worker/prompt.template.md",
+	}
+	bravoAgent := config.Agent{
+		Name:           "worker",
+		Dir:            "bravo",
+		Provider:       "stub",
+		PromptTemplate: "agents/bravo-worker/prompt.template.md",
+	}
+
+	params := newAgentBuildParams("test", cityPath, cfg, nil, testBeaconTime, nil, io.Discard)
+	alpha, err := resolveTemplate(params, &alphaAgent, alphaAgent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate(alpha): %v", err)
+	}
+	if !strings.Contains(alpha.Prompt, "alpha-work-query") || strings.Contains(alpha.Prompt, "bravo-work-query") {
+		t.Fatalf("alpha prompt used wrong rig fragment: %q", alpha.Prompt)
+	}
+
+	bravo, err := resolveTemplate(params, &bravoAgent, bravoAgent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate(bravo): %v", err)
+	}
+	if !strings.Contains(bravo.Prompt, "bravo-work-query") || strings.Contains(bravo.Prompt, "alpha-work-query") {
+		t.Fatalf("bravo prompt used wrong rig fragment: %q", bravo.Prompt)
+	}
+}
+
 func TestResolveTemplateConventionAgentAppendFragments(t *testing.T) {
 	cityPath := t.TempDir()
 	write := func(rel, data string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2157,13 +2157,11 @@ func (c *City) FormulasDir() string {
 	return citylayout.FormulasRoot
 }
 
-// AllPackDirs returns the union of city-level and rig-level pack directories
-// (city dirs first, then sorted-by-rig-name dirs), deduplicated. Use this when
-// rendering prompts or scanning the full pack-fragment universe — a rig-imported
-// agent's prompt template can reference fragments declared in a rig-level pack,
-// so both sets must be in the parse context. Without this merge, rig-imported
-// template fragments silently fail to resolve and the renderer falls back to
-// emitting the raw `{{ ... }}` text, degrading every imported agent's prompt.
+// AllPackDirs returns the union of city-level and all rig-level pack directories
+// (city dirs first, then sorted-by-rig-name dirs), deduplicated. Use this for
+// global scans that intentionally need the full pack-fragment universe. Prompt
+// rendering for a specific rig should use PackDirsForRig so one rig's fragments
+// cannot override another rig's same-named fragments.
 func (c *City) AllPackDirs() []string {
 	var dirs []string
 	dirs = appendUnique(dirs, c.PackDirs...)
@@ -2174,6 +2172,19 @@ func (c *City) AllPackDirs() []string {
 	sort.Strings(rigNames)
 	for _, name := range rigNames {
 		dirs = appendUnique(dirs, c.RigPackDirs[name]...)
+	}
+	return dirs
+}
+
+// PackDirsForRig returns the city-level pack directories plus the pack
+// directories imported by rigName, deduplicated with city-level dirs kept first.
+// Use this when rendering prompts for one agent so rig-imported template
+// fragments are available without exposing fragments imported by other rigs.
+func (c *City) PackDirsForRig(rigName string) []string {
+	var dirs []string
+	dirs = appendUnique(dirs, c.PackDirs...)
+	if rigName != "" {
+		dirs = appendUnique(dirs, c.RigPackDirs[rigName]...)
 	}
 	return dirs
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2157,6 +2157,27 @@ func (c *City) FormulasDir() string {
 	return citylayout.FormulasRoot
 }
 
+// AllPackDirs returns the union of city-level and rig-level pack directories
+// (city dirs first, then sorted-by-rig-name dirs), deduplicated. Use this when
+// rendering prompts or scanning the full pack-fragment universe — a rig-imported
+// agent's prompt template can reference fragments declared in a rig-level pack,
+// so both sets must be in the parse context. Without this merge, rig-imported
+// template fragments silently fail to resolve and the renderer falls back to
+// emitting the raw `{{ ... }}` text, degrading every imported agent's prompt.
+func (c *City) AllPackDirs() []string {
+	var dirs []string
+	dirs = appendUnique(dirs, c.PackDirs...)
+	rigNames := make([]string, 0, len(c.RigPackDirs))
+	for name := range c.RigPackDirs {
+		rigNames = append(rigNames, name)
+	}
+	sort.Strings(rigNames)
+	for _, name := range rigNames {
+		dirs = appendUnique(dirs, c.RigPackDirs[name]...)
+	}
+	return dirs
+}
+
 // AgentDefaults provides city-level agent defaults declared via
 // [agent_defaults] in city.toml. The runtime currently applies
 // default_sling_formula and append_fragments; the remaining fields are

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6268,3 +6268,25 @@ func TestAllPackDirs_DeterministicAcrossCalls(t *testing.T) {
 		}
 	}
 }
+
+func TestPackDirsForRig(t *testing.T) {
+	c := &City{
+		PackDirs: []string{"/city/packs/a", "/shared/packs/common"},
+		RigPackDirs: map[string][]string{
+			"alpha": {"/shared/packs/common", "/rig/alpha/packs/x"},
+			"bravo": {"/rig/bravo/packs/y"},
+		},
+	}
+
+	got := c.PackDirsForRig("alpha")
+	want := []string{"/city/packs/a", "/shared/packs/common", "/rig/alpha/packs/x"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PackDirsForRig(alpha) = %v, want %v", got, want)
+	}
+
+	got = c.PackDirsForRig("missing")
+	want = []string{"/city/packs/a", "/shared/packs/common"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PackDirsForRig(missing) = %v, want %v", got, want)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6173,3 +6173,98 @@ printf 'TRACE=%%s\nARGS=%%s\n' "$GC_WORKFLOW_TRACE" "$*" > %q
 	}
 	return tracePath, args
 }
+
+// TestAllPackDirs covers (*City).AllPackDirs() — the union of PackDirs and
+// RigPackDirs that the prompt renderer relies on. Regression: rig-imported
+// pack template fragments were silently dropped before gascity#2676.
+func TestAllPackDirs(t *testing.T) {
+	cases := []struct {
+		name        string
+		packDirs    []string
+		rigPackDirs map[string][]string
+		want        []string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:     "city only",
+			packDirs: []string{"/city/packs/a", "/city/packs/b"},
+			want:     []string{"/city/packs/a", "/city/packs/b"},
+		},
+		{
+			name:        "rig only",
+			rigPackDirs: map[string][]string{"alpha": {"/rig/alpha/packs/x"}},
+			want:        []string{"/rig/alpha/packs/x"},
+		},
+		{
+			name:        "both city and rig",
+			packDirs:    []string{"/city/packs/a"},
+			rigPackDirs: map[string][]string{"alpha": {"/rig/alpha/packs/x"}},
+			want:        []string{"/city/packs/a", "/rig/alpha/packs/x"},
+		},
+		{
+			name:     "multiple rigs sorted by rig name",
+			packDirs: []string{"/city/packs/a"},
+			rigPackDirs: map[string][]string{
+				"zulu":  {"/rig/zulu/packs/z"},
+				"alpha": {"/rig/alpha/packs/x"},
+				"mike":  {"/rig/mike/packs/m"},
+			},
+			want: []string{
+				"/city/packs/a",
+				"/rig/alpha/packs/x",
+				"/rig/mike/packs/m",
+				"/rig/zulu/packs/z",
+			},
+		},
+		{
+			name:     "dedup across city and rig keeps first occurrence",
+			packDirs: []string{"/shared/packs/common", "/city/packs/a"},
+			rigPackDirs: map[string][]string{
+				"alpha": {"/shared/packs/common", "/rig/alpha/packs/x"},
+			},
+			want: []string{"/shared/packs/common", "/city/packs/a", "/rig/alpha/packs/x"},
+		},
+		{
+			name: "dedup within a single rig list",
+			rigPackDirs: map[string][]string{
+				"alpha": {"/rig/alpha/packs/x", "/rig/alpha/packs/x", "/rig/alpha/packs/y"},
+			},
+			want: []string{"/rig/alpha/packs/x", "/rig/alpha/packs/y"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &City{PackDirs: tc.packDirs, RigPackDirs: tc.rigPackDirs}
+			got := c.AllPackDirs()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("AllPackDirs() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAllPackDirs_DeterministicAcrossCalls guards against a Go map-iteration
+// regression: two consecutive calls must return byte-identical ordering even
+// when RigPackDirs has multiple entries.
+func TestAllPackDirs_DeterministicAcrossCalls(t *testing.T) {
+	c := &City{
+		PackDirs: []string{"/city/packs/a"},
+		RigPackDirs: map[string][]string{
+			"zulu":    {"/rig/zulu/packs/z"},
+			"alpha":   {"/rig/alpha/packs/x"},
+			"mike":    {"/rig/mike/packs/m"},
+			"bravo":   {"/rig/bravo/packs/b"},
+			"yankee":  {"/rig/yankee/packs/y"},
+			"charlie": {"/rig/charlie/packs/c"},
+		},
+	}
+	first := c.AllPackDirs()
+	for i := 0; i < 20; i++ {
+		got := c.AllPackDirs()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("AllPackDirs() not deterministic across calls:\n iter %d = %v\n first   = %v", i, got, first)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Rig-imported template fragments were silently dropped during prompt rendering. When a city imports a pack at the rig level (e.g. `[rigs.imports.gastown] source = "./packs/gastown"` in `city.toml`), the pack's directory lands in `cfg.RigPackDirs[<rig>]`, **not** in `cfg.PackDirs`. Two callers of `renderPrompt` were passing only `cfg.PackDirs`, so rig-pack template fragments never made it into the Go template parse context.

Downstream symptom: `tmpl.Execute()` errored on `{{ template "approval-fallacy-polecat" . }}` (and similar fragment-reference directives that live in the rig pack), the renderer fell back to emitting the raw template body, and every rig-imported agent got a degraded prompt with literal `{{ .WorkQuery }}` / `{{ .BindingPrefix }}` / `{{ .WorkDir }}` text instead of rendered values. Polecat/witness/refinery couldn't execute their WorkQuery because it was placeholder text — sessions exited cleanly thinking there was no work to claim.

City-level imports were unaffected because `cfg.PackDirs` is populated correctly for them.

## Root cause

Two call sites were using the city-only slice instead of the union:

- `cmd/gc/agent_build_params.go:107` — `packDirs: cfg.PackDirs`
- `cmd/gc/cmd_prime.go:320` — `renderPrompt(..., cfg.PackDirs, ...)`

`internal/config/compose.go:1385-1395` already merges both sets when assembling the agent fragment universe; the prompt renderer just wasn't using the merged view.

## Fix

Add `(*City).AllPackDirs()` in `internal/config/config.go` that returns the union of `c.PackDirs` and `c.RigPackDirs[*]` (city dirs first, then rig dirs sorted by rig name), deduped via `appendUnique`. Same logic as `compose.go:1385-1395`. Update the two call sites to use it.

Three files, +23/-2.

## Reproduction

City directory with `[rigs.imports.<rig>] source = "..."` in its `city.toml`. Before:

```
$ gc prime <rig>/<rig>.polecat 2>&1 | grep '{{'
... {{ .WorkQuery }} ... {{ .BindingPrefix }} ... {{ .WorkDir }} ...
```

After:

```
$ gc prime <rig>/<rig>.polecat 2>&1 | grep '{{'
(no output)
```

## Tests

Added in the follow-up commit on this PR (`9d79947`):

- **`internal/config/config_test.go` — `TestAllPackDirs`** (table-driven): empty, city-only, rig-only, both, multi-rig sorted-by-rig-name, dedup across city+rig (first occurrence wins), dedup within a single rig list.
- **`internal/config/config_test.go` — `TestAllPackDirs_DeterministicAcrossCalls`**: 20 consecutive calls on a 6-rig `RigPackDirs` map must return byte-identical ordering, guarding against a Go map-iteration regression in the union helper.
- **`cmd/gc/prompt_test.go` — `TestRenderPromptResolvesRigPackFragment`**: drops a `{{ define "work-query" }}` fragment into a rig-pack dir (cfg.RigPackDirs only, cfg.PackDirs empty), asserts `renderPrompt(..., cfg.AllPackDirs(), ...)` resolves the directive in an imported agent's prompt, and asserts the pre-fix call shape (`cfg.PackDirs`) does **not** resolve it — so the test would have failed before the parent commit.
- **`cmd/gc/prompt_test.go` — `TestRenderPromptResolvesMultiRigPackFragments`**: two rig-imported packs each contributing one fragment, both must resolve in a single render — guards against a single-rig assumption in the union.

`go test ./internal/config/... ./cmd/gc/...` passes for all new tests. Two pre-existing failures in `TestRigAnywhere_ResolveRigToContext` (macOS `/private/tmp` vs `/tmp` symlink resolution) are unrelated to this PR — they reproduce on `d1dc825` without these test additions.

## Checklist

- [x] Linked an issue, or explained why one is not needed — no existing issue; reporting + fixing together.
- [x] Added or updated tests for behavior changes — see Tests section above.
- [ ] Updated docs for user-facing changes — N/A, internal renderer plumbing.
- [ ] Called out breaking changes or migration notes — none; `AllPackDirs` is a new method; behavior change is strictly additive (rig-pack dirs now visible to the renderer, matching what `compose.go` already does for fragment assembly).
