### PR TITLE
fix(cmd/gc): surface formula show/cook compile errors

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -101,30 +101,25 @@ Examples:
 
 			cityPath, err := resolveCity()
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula show", jsonOutput, err)
 			}
 			cfg, err := loadCityConfig(cityPath, stderr)
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula show", jsonOutput, err)
 			}
 			scope, err := resolveFormulaScope(cfg, cityPath)
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula show", jsonOutput, err)
 			}
 			searchPaths := scope.searchPaths
 			rigVars := rigFormulaVarsForScope(cfg, cityPath)
 			recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), name, searchPaths, compileVars)
 			if err != nil {
-				// The root command sets SilenceErrors, so a raw error return
-				// here would exit 1 with no diagnostic. Surface the compile
-				// failure (e.g. a graph.v2 formula when [daemon] formula_v2 is
-				// disabled) on stderr and return the already-printed sentinel.
-				fmt.Fprintf(stderr, "gc formula show: %v\n", err) //nolint:errcheck // best-effort stderr
-				return errExit
+				return formulaCommandError(stderr, "gc formula show", jsonOutput, err)
 			}
 			if len(vars) > 0 {
 				if err := formula.ValidateProvidedVarDefs(recipe.Vars, vars); err != nil {
-					return err
+					return formulaCommandError(stderr, "gc formula show", jsonOutput, err)
 				}
 			}
 
@@ -270,15 +265,15 @@ func newFormulaCatalogCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cityPath, err := resolveCity()
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula catalog", jsonOutput, err)
 			}
 			cfg, err := loadCityConfig(cityPath, stderr)
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula catalog", jsonOutput, err)
 			}
 			scope, err := resolveFormulaScope(cfg, cityPath)
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula catalog", jsonOutput, err)
 			}
 			entries, warnings := formulaCatalogEntries(scope.searchPaths)
 			if jsonOutput {
@@ -497,6 +492,14 @@ func formulaSearchPathsForList(cfg *config.City) []string {
 	return all
 }
 
+func formulaCommandError(stderr io.Writer, command string, jsonOutput bool, err error) error {
+	if err == nil || jsonOutput {
+		return err
+	}
+	fmt.Fprintf(stderr, "%s: %v\n", command, err) //nolint:errcheck // best-effort stderr
+	return errExit
+}
+
 func formulaShowJSONFromRecipe(recipe *formula.Recipe, cityPath string, scope formulaScope, rigVars, providedVars, displayVars map[string]string) formulaShowJSON {
 	out := formulaShowJSON{
 		SchemaVersion: "1",
@@ -595,19 +598,19 @@ bead into a sub-workflow at runtime.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cityPath, err := resolveCity()
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
 			cfg, err := loadCityConfig(cityPath, stderr)
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
 			scope, err := resolveFormulaScope(cfg, cityPath)
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
 			store, err := openStoreAtForCity(scope.storeRoot, cityPath)
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
 
 			cookVars := parseFormulaVars(vars)
@@ -615,10 +618,7 @@ bead into a sub-workflow at runtime.`,
 			if attach != "" {
 				recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), args[0], scope.searchPaths, cookVars)
 				if err != nil {
-					// SilenceErrors on the root would drop a raw error return,
-					// exiting 1 with no diagnostic. Surface it on stderr.
-					fmt.Fprintf(stderr, "gc formula cook: compile: %v\n", err) //nolint:errcheck // best-effort stderr
-					return errExit
+					return formulaCommandError(stderr, "gc formula cook: compile", jsonOutput, err)
 				}
 
 				result, err := molecule.Attach(cmd.Context(), store, recipe, attach, molecule.AttachOptions{
@@ -626,7 +626,7 @@ bead into a sub-workflow at runtime.`,
 					Vars:  cookVars,
 				})
 				if err != nil {
-					return err
+					return formulaCommandError(stderr, "gc formula cook: attach", jsonOutput, err)
 				}
 
 				if jsonOutput {
@@ -659,20 +659,17 @@ bead into a sub-workflow at runtime.`,
 				Vars:  cookVars,
 			})
 			if err != nil {
-				// SilenceErrors on the root would drop a raw error return,
-				// exiting 1 with no diagnostic (e.g. a graph.v2 formula when
-				// [daemon] formula_v2 is disabled). Surface it on stderr.
-				fmt.Fprintf(stderr, "gc formula cook: %v\n", err) //nolint:errcheck // best-effort stderr
-				return errExit
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
 
 			rootMeta, err := parseMetadataArgs(metadata)
 			if err != nil {
-				return err
+				return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 			}
 			if len(rootMeta) > 0 {
 				if err := store.SetMetadataBatch(result.RootID, rootMeta); err != nil {
-					return fmt.Errorf("setting root metadata on %s: %w", result.RootID, err)
+					err := fmt.Errorf("setting root metadata on %s: %w", result.RootID, err)
+					return formulaCommandError(stderr, "gc formula cook", jsonOutput, err)
 				}
 			}
 

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -115,7 +115,12 @@ Examples:
 			rigVars := rigFormulaVarsForScope(cfg, cityPath)
 			recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), name, searchPaths, compileVars)
 			if err != nil {
-				return err
+				// The root command sets SilenceErrors, so a raw error return
+				// here would exit 1 with no diagnostic. Surface the compile
+				// failure (e.g. a graph.v2 formula when [daemon] formula_v2 is
+				// disabled) on stderr and return the already-printed sentinel.
+				fmt.Fprintf(stderr, "gc formula show: %v\n", err) //nolint:errcheck // best-effort stderr
+				return errExit
 			}
 			if len(vars) > 0 {
 				if err := formula.ValidateProvidedVarDefs(recipe.Vars, vars); err != nil {
@@ -610,7 +615,10 @@ bead into a sub-workflow at runtime.`,
 			if attach != "" {
 				recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), args[0], scope.searchPaths, cookVars)
 				if err != nil {
-					return fmt.Errorf("compile: %w", err)
+					// SilenceErrors on the root would drop a raw error return,
+					// exiting 1 with no diagnostic. Surface it on stderr.
+					fmt.Fprintf(stderr, "gc formula cook: compile: %v\n", err) //nolint:errcheck // best-effort stderr
+					return errExit
 				}
 
 				result, err := molecule.Attach(cmd.Context(), store, recipe, attach, molecule.AttachOptions{
@@ -651,7 +659,11 @@ bead into a sub-workflow at runtime.`,
 				Vars:  cookVars,
 			})
 			if err != nil {
-				return err
+				// SilenceErrors on the root would drop a raw error return,
+				// exiting 1 with no diagnostic (e.g. a graph.v2 formula when
+				// [daemon] formula_v2 is disabled). Surface it on stderr.
+				fmt.Fprintf(stderr, "gc formula cook: %v\n", err) //nolint:errcheck // best-effort stderr
+				return errExit
 			}
 
 			rootMeta, err := parseMetadataArgs(metadata)

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -551,6 +552,80 @@ func TestFormulaCatalogCommandJSONFromEntries(t *testing.T) {
 	if len(got.Warnings) != 1 || got.Warnings[0].Code != "formula_catalog_parse_failed" {
 		t.Fatalf("warnings = %+v", got.Warnings)
 	}
+}
+
+func TestFormulaCatalogCommandSetupErrorsSurfaceDiagnostics(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "catalog-test"
+provider = "claude"
+
+[[agent]]
+name = "worker"
+start_command = "echo hello"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	t.Chdir(cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	t.Run("text", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := run([]string{"--city", cityDir, "--rig", "ghost", "formula", "catalog"}, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1\nstdout=%s\nstderr=%s", code, stdout.String(), stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("stdout = %q, want empty", stdout.String())
+		}
+		if got := stderr.String(); !strings.Contains(got, "gc formula catalog:") || !strings.Contains(got, `rig "ghost" not found`) {
+			t.Fatalf("stderr = %q, want command-scoped rig diagnostic", got)
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := run([]string{"--city", cityDir, "--rig", "ghost", "formula", "catalog", "--json"}, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1\nstdout=%s\nstderr=%s", code, stdout.String(), stderr.String())
+		}
+		if stderr.Len() != 0 {
+			t.Fatalf("stderr = %q, want empty", stderr.String())
+		}
+		if got := stdout.String(); !strings.Contains(got, `"ok":false`) || !strings.Contains(got, `rig \"ghost\" not found`) {
+			t.Fatalf("stdout = %q, want structured raw rig diagnostic", got)
+		}
+		if strings.Contains(stdout.String(), "command failed; see stderr for diagnostics") {
+			t.Fatalf("stdout = %q, want specific diagnostic instead of errExit fallback", stdout.String())
+		}
+	})
+
+	t.Run("subcommand returns errExit after text diagnostic", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		prevCityFlag, prevRigFlag := cityFlag, rigFlag
+		t.Cleanup(func() {
+			cityFlag = prevCityFlag
+			rigFlag = prevRigFlag
+		})
+		cityFlag = cityDir
+		rigFlag = "ghost"
+
+		cmd := newFormulaCatalogCmd(&stdout, &stderr)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		err := cmd.Execute()
+		if !errors.Is(err, errExit) {
+			t.Fatalf("error = %v, want errExit", err)
+		}
+		if got := stderr.String(); !strings.Contains(got, "gc formula catalog:") || !strings.Contains(got, `rig "ghost" not found`) {
+			t.Fatalf("stderr = %q, want command-scoped rig diagnostic", got)
+		}
+	})
 }
 
 func writeFormulaTestFile(t *testing.T, dir, name, content string) {

--- a/cmd/gc/cmd_formula_tutorial_regression_test.go
+++ b/cmd/gc/cmd_formula_tutorial_regression_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -239,17 +240,18 @@ title = "[{{epic}}] Deploy {{env}}"
 
 	t.Chdir(cityDir)
 
-	cmd := newFormulaShowCmd(&bytes.Buffer{}, &bytes.Buffer{})
+	stderr := &bytes.Buffer{}
+	cmd := newFormulaShowCmd(&bytes.Buffer{}, stderr)
 	cmd.SetArgs([]string{"enum-vars", "--var", "env=staging"})
 	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("formula show should reject invalid provided vars")
+	if !errors.Is(err, errExit) {
+		t.Fatalf("error = %v, want errExit", err)
 	}
-	if !strings.Contains(err.Error(), `variable "env": value "staging" not in allowed values`) {
-		t.Fatalf("error = %v, want invalid env", err)
+	if !strings.Contains(stderr.String(), `variable "env": value "staging" not in allowed values`) {
+		t.Fatalf("stderr = %q, want invalid env", stderr.String())
 	}
-	if strings.Contains(err.Error(), `variable "epic" is required`) {
-		t.Fatalf("formula show should not require missing runtime vars while validating provided vars: %v", err)
+	if strings.Contains(stderr.String(), `variable "epic" is required`) {
+		t.Fatalf("formula show should not require missing runtime vars while validating provided vars: %s", stderr.String())
 	}
 }
 

--- a/cmd/gc/testdata/formula-show-graph-v2.txtar
+++ b/cmd/gc/testdata/formula-show-graph-v2.txtar
@@ -19,12 +19,38 @@ stderr 'graph\.v2'
 stderr 'formula_v2'
 ! stdout 'Formula: graphwf'
 
+# The structured failure contract must retain the specific compile reason for
+# programmatic callers.
+! exec gc formula show graphwf --json
+stdout '"ok":false'
+stdout 'graph\.v2'
+stdout 'formula_v2'
+! stdout 'command failed; see stderr for diagnostics'
+
 # cook must also surface the diagnostic rather than dying silently.
 # (run inside the no-v2 city so the graph.v2 gate is the failure, not a
 # missing-formula lookup).
 ! exec gc formula cook graphwf
 stderr 'graph\.v2'
 stderr 'formula_v2'
+
+! exec gc formula cook graphwf --json
+stdout '"ok":false'
+stdout 'graph\.v2'
+stdout 'formula_v2'
+! stdout 'command failed; see stderr for diagnostics'
+
+# The attach mode has a separate compile branch. Compile happens before attach
+# lookup, so no real bead is needed to cover the diagnostic path.
+! exec gc formula cook graphwf --attach missing-root
+stderr 'graph\.v2'
+stderr 'formula_v2'
+
+! exec gc formula cook graphwf --attach missing-root --json
+stdout '"ok":false'
+stdout 'graph\.v2'
+stdout 'formula_v2'
+! stdout 'command failed; see stderr for diagnostics'
 
 # --- formula_v2 enabled: show compiles and prints the recipe ---
 # (graph.v2 expansion adds synthetic spec/attempt/finalize steps, so the
@@ -37,6 +63,30 @@ stdout 'Formula: graphwf'
 stdout 'Steps \('
 stdout 'Run a lane'
 stdout 'Synthesize'
+
+# Adjacent non-compile errors in the same commands must also surface in text
+# mode instead of returning raw errors that SilenceErrors hides.
+! exec gc formula show graphwf --var mode=bad
+stderr 'gc formula show:'
+stderr 'variable "mode"'
+stderr 'not in allowed values'
+! stdout .
+
+! exec gc formula show graphwf --var mode=bad --json
+stdout '"ok":false'
+stdout 'variable.*mode'
+stdout 'not in allowed values'
+! stderr .
+
+! exec gc formula cook graphwf --attach missing-root
+stderr 'gc formula cook:'
+stderr 'missing-root'
+! stdout .
+
+! exec gc formula cook graphwf --attach missing-root --json
+stdout '"ok":false'
+stdout 'missing-root'
+! stderr .
 
 -- city.toml --
 [workspace]
@@ -52,6 +102,12 @@ formula = "graphwf"
 description = "A graph.v2 workflow"
 version = 2
 contract = "graph.v2"
+
+[vars]
+[vars.mode]
+description = "Mode"
+default = "ok"
+enum = ["ok"]
 
 [[steps]]
 id = "lane"
@@ -80,6 +136,12 @@ formula = "graphwf"
 description = "A graph.v2 workflow"
 version = 2
 contract = "graph.v2"
+
+[vars]
+[vars.mode]
+description = "Mode"
+default = "ok"
+enum = ["ok"]
 
 [[steps]]
 id = "lane"

--- a/cmd/gc/testdata/formula-show-graph-v2.txtar
+++ b/cmd/gc/testdata/formula-show-graph-v2.txtar
@@ -1,0 +1,92 @@
+# gc formula show — a graph.v2 formula must not fail silently.
+#
+# Regression test for the silent exit-1: `gc formula show` on a formula
+# that declares `contract = "graph.v2"` returned the compile error
+# ("formula_v2 is disabled") raw from RunE, where the root command's
+# SilenceErrors swallowed it — producing exit 1 with empty stdout AND
+# empty stderr. The fix prints the compile error to stderr (and the same
+# applies to `gc formula cook`).
+
+env GC_BEADS=file
+env GC_DOLT=skip
+env GC_SESSION=fake
+
+# --- formula_v2 disabled (default): show must emit an actionable diagnostic, not fail silently ---
+exec gc init --file $WORK/city.toml $WORK/no-v2
+cd $WORK/no-v2
+! exec gc formula show graphwf
+stderr 'graph\.v2'
+stderr 'formula_v2'
+! stdout 'Formula: graphwf'
+
+# cook must also surface the diagnostic rather than dying silently.
+# (run inside the no-v2 city so the graph.v2 gate is the failure, not a
+# missing-formula lookup).
+! exec gc formula cook graphwf
+stderr 'graph\.v2'
+stderr 'formula_v2'
+
+# --- formula_v2 enabled: show compiles and prints the recipe ---
+# (graph.v2 expansion adds synthetic spec/attempt/finalize steps, so the
+# step count is intentionally not asserted exactly — only that the recipe
+# rendered with its header and user-defined step titles.)
+exec gc init --file $WORK/city-v2.toml $WORK/with-v2
+cd $WORK/with-v2
+exec gc formula show graphwf
+stdout 'Formula: graphwf'
+stdout 'Steps \('
+stdout 'Run a lane'
+stdout 'Synthesize'
+
+-- city.toml --
+[workspace]
+name = "no-v2"
+provider = "claude"
+
+[[agent]]
+name = "worker"
+start_command = "echo hello"
+
+-- no-v2/formulas/graphwf.toml --
+formula = "graphwf"
+description = "A graph.v2 workflow"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "lane"
+title = "Run a lane"
+type = "task"
+
+[[steps]]
+id = "synth"
+title = "Synthesize"
+needs = ["lane"]
+
+-- city-v2.toml --
+[workspace]
+name = "with-v2"
+provider = "claude"
+
+[daemon]
+formula_v2 = true
+
+[[agent]]
+name = "worker"
+start_command = "echo hello"
+
+-- with-v2/formulas/graphwf.toml --
+formula = "graphwf"
+description = "A graph.v2 workflow"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "lane"
+title = "Run a lane"
+type = "task"
+
+[[steps]]
+id = "synth"
+title = "Synthesize"
+needs = ["lane"]


### PR DESCRIPTION
## Summary

- print formula compile errors to stderr before returning errExit when the root command would otherwise suppress them
- cover graph.v2 formula show and cook failures with a txtar regression
- keep formula_v2-enabled show behavior rendering normally

## Root cause

The root command uses SilenceErrors, so returning compile errors directly from `gc formula show` / `gc formula cook` could exit 1 with empty stdout and stderr. This made graph.v2 validation failures look like silent failures.

Closes #1381

## Verification

- `git diff --check origin/main..HEAD`
- `env GC_FAST_UNIT=0 go test -count=1 -timeout 10m ./cmd/gc -run 'TestTutorial01/formula-show-graph-v2'`\n- `go test -count=1 -timeout 10m ./cmd/gc -run 'Test.*Formula'`