### PR TITLE
fix(codex): isolate managed session home

### DIFF
--- a/cmd/gc/cmd_internal_codex_home_test.go
+++ b/cmd/gc/cmd_internal_codex_home_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInternalCodexHomeStagesAuthAndTrust(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	homeDir := t.TempDir()
+	workdir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("HOME", homeDir)
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(homeDir, ".codex"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(home .codex): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(homeDir, ".codex", "auth.json"), []byte(`{"token":"abc"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(auth.json): %v", err)
+	}
+
+	toml := `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "mayor"
+provider = "codex"
+start_command = "codex"
+
+[[named_session]]
+template = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "codex-home",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	authPath := filepath.Join(workdir, ".codex", "auth.json")
+	if _, err := os.Stat(authPath); err != nil {
+		t.Fatalf("stat(%s): %v", authPath, err)
+	}
+	data, err := os.ReadFile(filepath.Join(workdir, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml): %v", err)
+	}
+	header := `[projects.` + `"` + workdir + `"` + `]`
+	if !strings.Contains(string(data), header) {
+		t.Fatalf("config.toml missing trust header %q: %s", header, string(data))
+	}
+	if !strings.Contains(string(data), `trust_level = "trusted"`) {
+		t.Fatalf("config.toml missing trust_level: %s", string(data))
+	}
+}
+
+func TestInternalCodexHomeAlsoTrustsGitRoot(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	homeDir := t.TempDir()
+	repoRoot := t.TempDir()
+	workdir := filepath.Join(repoRoot, ".gc", "agents", "mayor")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("HOME", homeDir)
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(homeDir, ".codex"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(home .codex): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(homeDir, ".codex", "auth.json"), []byte(`{"token":"abc"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(auth.json): %v", err)
+	}
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workdir): %v", err)
+	}
+	runExternal(t, repoRoot, "git", "init", "-q")
+
+	toml := `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "mayor"
+provider = "codex"
+start_command = "codex"
+
+[[named_session]]
+template = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "codex-home",
+		"--agent", "mayor",
+		"--workdir", workdir,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(workdir, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml): %v", err)
+	}
+	workdirHeader := `[projects.` + `"` + workdir + `"` + `]`
+	if !strings.Contains(string(data), workdirHeader) {
+		t.Fatalf("config.toml missing workdir trust header %q: %s", workdirHeader, string(data))
+	}
+	repoRootHeader := `[projects.` + `"` + repoRoot + `"` + `]`
+	if !strings.Contains(string(data), repoRootHeader) {
+		t.Fatalf("config.toml missing repo-root trust header %q: %s", repoRootHeader, string(data))
+	}
+}
+
+func TestInternalCodexHomeFreshClearsPersistentSessionState(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	homeDir := t.TempDir()
+	workdir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("HOME", homeDir)
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(homeDir, ".codex"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(home .codex): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(homeDir, ".codex", "auth.json"), []byte(`{"token":"abc"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(auth.json): %v", err)
+	}
+
+	toml := `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "mayor"
+provider = "codex"
+wake_mode = "fresh"
+start_command = "codex"
+
+[[named_session]]
+template = "mayor"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	codexDir := filepath.Join(workdir, ".codex")
+	if err := os.MkdirAll(filepath.Join(codexDir, "sessions", "2026"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(sessions): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(codexDir, "shell_snapshots"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(shell_snapshots): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "history.jsonl"), []byte("stale\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(history): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "state_5.sqlite"), []byte("sqlite"), 0o600); err != nil {
+		t.Fatalf("WriteFile(state): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "state_5.sqlite-wal"), []byte("wal"), 0o600); err != nil {
+		t.Fatalf("WriteFile(state wal): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "logs_2.sqlite"), []byte("logs"), 0o600); err != nil {
+		t.Fatalf("WriteFile(logs): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "sessions", "2026", "stale.jsonl"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("WriteFile(session): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "shell_snapshots", "stale.sh"), []byte("echo stale"), 0o600); err != nil {
+		t.Fatalf("WriteFile(snapshot): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{
+		"internal", "codex-home",
+		"--agent", "mayor",
+		"--workdir", workdir,
+		"--fresh",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(codexDir, "auth.json")); err != nil {
+		t.Fatalf("auth.json missing after fresh stage: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(codexDir, "config.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml): %v", err)
+	}
+	header := `[projects.` + `"` + workdir + `"` + `]`
+	if !strings.Contains(string(data), header) {
+		t.Fatalf("config.toml missing trust header %q: %s", header, string(data))
+	}
+
+	for _, stale := range []string{
+		filepath.Join(codexDir, "history.jsonl"),
+		filepath.Join(codexDir, "state_5.sqlite"),
+		filepath.Join(codexDir, "state_5.sqlite-wal"),
+		filepath.Join(codexDir, "logs_2.sqlite"),
+		filepath.Join(codexDir, "sessions"),
+		filepath.Join(codexDir, "shell_snapshots"),
+	} {
+		if _, err := os.Stat(stale); !os.IsNotExist(err) {
+			t.Fatalf("stale Codex state should be removed on fresh stage: %s err=%v", stale, err)
+		}
+	}
+}

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -24,6 +24,7 @@ func newInternalCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short:  "Internal gc subcommands (not for direct human use)",
 		Hidden: true,
 	}
+	cmd.AddCommand(newInternalCodexHomeCmd(stdout, stderr))
 	cmd.AddCommand(newInternalMaterializeSkillsCmd(stdout, stderr))
 	cmd.AddCommand(newInternalProjectMCPCmd(stdout, stderr))
 	return cmd

--- a/cmd/gc/codex_integration.go
+++ b/cmd/gc/codex_integration.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/shellquote"
+	"github.com/spf13/cobra"
+)
+
+func codexHomePath(workdir string) string {
+	return filepath.Join(workdir, ".codex")
+}
+
+func appendCodexHomePreStart(prestart []string, agentName, workDir string, fresh bool) []string {
+	cmd := `"${GC_BIN:-gc}" internal codex-home --agent ` +
+		shellquote.Join([]string{agentName}) +
+		` --workdir ` + shellquote.Join([]string{workDir})
+	if fresh {
+		cmd += ` --fresh`
+	}
+	return append(prestart, cmd)
+}
+
+func newInternalCodexHomeCmd(stdout, stderr io.Writer) *cobra.Command {
+	var agentName, workdir string
+	var fresh bool
+	cmd := &cobra.Command{
+		Use:    "codex-home",
+		Short:  "Stage isolated Codex state for one managed session",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if strings.TrimSpace(agentName) == "" {
+				fmt.Fprintln(stderr, "gc internal codex-home: --agent is required") //nolint:errcheck
+				return errExit
+			}
+			if strings.TrimSpace(workdir) == "" {
+				fmt.Fprintln(stderr, "gc internal codex-home: --workdir is required") //nolint:errcheck
+				return errExit
+			}
+			cityPath, err := resolveCity()
+			if err != nil {
+				fmt.Fprintf(stderr, "gc internal codex-home: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			cfg, err := loadCityConfig(cityPath, stderr)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc internal codex-home: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
+			if !ok {
+				fmt.Fprintf(stderr, "gc internal codex-home: unknown agent %q\n", agentName) //nolint:errcheck
+				return errExit
+			}
+			if effectiveAgentProviderFamily(&agent, cfg.Workspace.Provider, cfg.Providers) != "codex" {
+				fmt.Fprintf(stdout, "gc internal codex-home: provider %q does not require Codex staging; skipping\n", agent.Provider) //nolint:errcheck
+				return nil
+			}
+			if err := stageCodexHomeIntoWorkdir(workdir, fresh); err != nil {
+				fmt.Fprintf(stderr, "gc internal codex-home: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&agentName, "agent", "", "qualified agent identity (dir/name or name)")
+	cmd.Flags().StringVar(&workdir, "workdir", "", "agent working directory")
+	cmd.Flags().BoolVar(&fresh, "fresh", false, "clear persisted Codex interactive session state before launch")
+	return cmd
+}
+
+func stageCodexHomeIntoWorkdir(workdir string, fresh bool) error {
+	absWorkdir, err := filepath.Abs(workdir)
+	if err != nil {
+		return fmt.Errorf("resolve workdir: %w", err)
+	}
+	codexDir := codexHomePath(absWorkdir)
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		return fmt.Errorf("create codex home: %w", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve host home: %w", err)
+	}
+	if err := copyFileIfExists(filepath.Join(home, ".codex", "auth.json"), filepath.Join(codexDir, "auth.json"), 0o600); err != nil {
+		return fmt.Errorf("stage auth.json: %w", err)
+	}
+	trustTargets := expandTrustTargets(absWorkdir)
+	if gitRoot, err := gitProjectRoot(absWorkdir); err == nil && gitRoot != "" {
+		trustTargets = appendUniqueTrustTarget(trustTargets, gitRoot)
+		trustTargets = appendTrustRealPath(trustTargets, gitRoot)
+	}
+	for _, target := range trustTargets {
+		if err := seedCodexProjectTrust(filepath.Join(codexDir, "config.toml"), target); err != nil {
+			return fmt.Errorf("seed trust for %s: %w", target, err)
+		}
+	}
+	if fresh {
+		if err := clearCodexSessionState(codexDir); err != nil {
+			return fmt.Errorf("clear fresh session state: %w", err)
+		}
+	}
+	return nil
+}
+
+func gitProjectRoot(dir string) (string, error) {
+	if root, ok := findLiteralGitRoot(dir); ok {
+		return root, nil
+	}
+	return "", fmt.Errorf("git root not found for %s", dir)
+}
+
+func findLiteralGitRoot(dir string) (string, bool) {
+	current := filepath.Clean(dir)
+	for {
+		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
+			return current, true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", false
+		}
+		current = parent
+	}
+}
+
+func expandTrustTargets(path string) []string {
+	targets := []string{}
+	targets = appendUniqueTrustTarget(targets, path)
+	return appendTrustRealPath(targets, path)
+}
+
+func appendTrustRealPath(targets []string, path string) []string {
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil || strings.TrimSpace(realPath) == "" {
+		return targets
+	}
+	return appendUniqueTrustTarget(targets, realPath)
+}
+
+func appendUniqueTrustTarget(targets []string, path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return targets
+	}
+	for _, existing := range targets {
+		if existing == path {
+			return targets
+		}
+	}
+	return append(targets, path)
+}
+
+func clearCodexSessionState(codexDir string) error {
+	stalePaths := []string{
+		"history.jsonl",
+		"logs_2.sqlite",
+		"logs_2.sqlite-shm",
+		"logs_2.sqlite-wal",
+		"sessions",
+		"shell_snapshots",
+		"state_5.sqlite",
+		"state_5.sqlite-shm",
+		"state_5.sqlite-wal",
+	}
+	for _, rel := range stalePaths {
+		if err := os.RemoveAll(filepath.Join(codexDir, rel)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFileIfExists(src, dst string, perm os.FileMode) error {
+	data, err := os.ReadFile(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, perm)
+}
+
+func seedCodexProjectTrust(configPath, projectDir string) error {
+	projectDir = strings.TrimSpace(projectDir)
+	if projectDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	header := fmt.Sprintf("[projects.%s]", strconv.Quote(projectDir))
+	if strings.Contains(string(data), header) {
+		return nil
+	}
+	var b strings.Builder
+	b.Write(data)
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		b.WriteByte('\n')
+	}
+	fmt.Fprintf(&b, "\n%s\ntrust_level = %q\n", header, "trusted")
+	return os.WriteFile(configPath, []byte(b.String()), 0o600)
+}

--- a/cmd/gc/codex_integration_test.go
+++ b/cmd/gc/codex_integration_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestResolveTemplateInjectsCodexHomePreStart(t *testing.T) {
+	cityPath := t.TempDir()
+	params := &agentBuildParams{
+		cityName:  "city",
+		cityPath:  cityPath,
+		workspace: &config.Workspace{Provider: "codex"},
+		providers: map[string]config.ProviderSpec{
+			"codex": {Command: "codex", PromptMode: "none"},
+		},
+		lookPath:        stubLookPath,
+		fs:              fsys.OSFS{},
+		rigs:            nil,
+		beaconTime:      time.Unix(0, 0),
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+		sessionProvider: "tmux",
+	}
+	agent := &config.Agent{
+		Name:     "mayor",
+		Scope:    "city",
+		Provider: "codex",
+		WakeMode: "fresh",
+	}
+
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	found := false
+	for _, entry := range tp.Hints.PreStart {
+		if strings.Contains(entry, "internal codex-home") {
+			found = true
+			if !strings.Contains(entry, "--agent mayor") {
+				t.Fatalf("codex-home PreStart missing agent flag: %q", entry)
+			}
+			if !strings.Contains(entry, "--workdir") {
+				t.Fatalf("codex-home PreStart missing workdir flag: %q", entry)
+			}
+			if !strings.Contains(entry, "--fresh") {
+				t.Fatalf("codex-home PreStart missing fresh flag for fresh wake mode: %q", entry)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected codex-home PreStart, got %v", tp.Hints.PreStart)
+	}
+}

--- a/cmd/gc/phase2_reporting_test.go
+++ b/cmd/gc/phase2_reporting_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/shellquote"
 	workertest "github.com/gastownhall/gascity/internal/worker/workertest"
 )
 
@@ -119,9 +120,9 @@ func startupRuntimeConfigMaterializationResult(tc phase2ProviderCase, tp Templat
 	case !startupNudgeMatches(tc, cfg.Nudge):
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			fmt.Sprintf("cfg.Nudge = %q, want startup nudge plus %q", cfg.Nudge, "nudge-"+tc.family)).WithEvidence(evidence)
-	case !reflect.DeepEqual(cfg.PreStart, []string{"echo pre-" + tc.family}):
+	case !reflect.DeepEqual(cfg.PreStart, phase2ExpectedPreStart(tc, cfg)):
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
-			fmt.Sprintf("cfg.PreStart = %v, want %v", cfg.PreStart, []string{"echo pre-" + tc.family})).WithEvidence(evidence)
+			fmt.Sprintf("cfg.PreStart = %v, want %v", cfg.PreStart, phase2ExpectedPreStart(tc, cfg))).WithEvidence(evidence)
 	case !reflect.DeepEqual(cfg.SessionSetup, []string{"echo setup-" + tc.family}):
 		return workertest.Fail(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			fmt.Sprintf("cfg.SessionSetup = %v, want %v", cfg.SessionSetup, []string{"echo setup-" + tc.family})).WithEvidence(evidence)
@@ -138,6 +139,14 @@ func startupRuntimeConfigMaterializationResult(tc phase2ProviderCase, tp Templat
 		return workertest.Pass(tc.profileID, workertest.RequirementStartupRuntimeConfigMaterialization,
 			"templateParamsToConfig preserved the resolved startup materialization").WithEvidence(evidence)
 	}
+}
+
+func phase2ExpectedPreStart(tc phase2ProviderCase, cfg runtime.Config) []string {
+	preStart := []string{"echo pre-" + tc.family}
+	if tc.family == "codex" {
+		preStart = append(preStart, `"${GC_BIN:-gc}" internal codex-home --agent worker --workdir `+shellquote.Join([]string{cfg.WorkDir}))
+	}
+	return preStart
 }
 
 func phase2BoolPtrsEqual(a, b *bool) bool {

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -376,6 +376,12 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		}
 	}
 
+	wsProvider := ""
+	if p.workspace != nil {
+		wsProvider = p.workspace.Provider
+	}
+	agentProviderFamily := effectiveAgentProviderFamily(cfgAgent, wsProvider, p.providers)
+
 	// Step 10: Merge environment layers. Workspace.Env sits between
 	// passthrough and provider so a per-provider/agent/patch entry can
 	// still override a workspace-wide default.
@@ -386,6 +392,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	env := mergeEnv(passthroughEnv(), expandEnvMap(workspaceEnv), expandEnvMap(resolved.Env), expandEnvMap(cfgAgent.Env), agentEnv)
 	prependGCBinDirToPATH(env, env["GC_BIN"])
 	env = convergence.ScrubTokenEnv(env)
+	if agentProviderFamily == "codex" {
+		env["CODEX_HOME"] = codexHomePath(workDir)
+	}
 
 	// Step 11: Expand session setup templates.
 	configDir := p.cityPath
@@ -411,6 +420,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	resolvedScript := config.ResolveSessionSetupScriptPath(p.cityPath, cfgAgent.SourceDir, cfgAgent.SessionSetupScript)
 	expandedPreStart := expandSessionSetup(cfgAgent.PreStart, setupCtx)
 	expandedLive := expandSessionSetup(cfgAgent.SessionLive, setupCtx)
+	if agentProviderFamily == "codex" && isStage2EligibleSession(p.sessionProvider, cfgAgent) {
+		expandedPreStart = appendCodexHomePreStart(expandedPreStart, qualifiedName, workDir, cfgAgent.EffectiveWakeMode() == "fresh")
+	}
 
 	// Step 11b: Skill materialization integration (per engdocs
 	// skill-materialization.md § "When FingerprintExtra[\"skills:*\"]
@@ -424,10 +436,6 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if isStage2EligibleSession(p.sessionProvider, cfgAgent) {
 		scopeRoot := agentScopeRoot(cfgAgent, p.cityPath, p.rigs)
 		canonWorkDir := canonicaliseFilePath(workDir, p.cityPath)
-		wsProvider := ""
-		if p.workspace != nil {
-			wsProvider = p.workspace.Provider
-		}
 		sharedCatalog := p.sharedSkillCatalogSnapshotForAgent(cfgAgent)
 		desired := effectiveSkillsForAgent(sharedCatalog, cfgAgent, wsProvider, p.providers, p.stderr)
 		if len(desired) > 0 {


### PR DESCRIPTION
Clean replacement for #2384.

This keeps only the focused Codex managed-session home isolation change on top of current upstream/main, without the unrelated branch stack from the original PR.

Verification:
- go test ./cmd/gc -run 'Test(ResolveTemplateInjectsCodexHomePreStart|InternalCodexHomeStagesAuthAndTrust|InternalCodexHomeAlsoTrustsGitRoot|InternalCodexHomeFreshClearsPersistentSessionState)$'