### PR TITLE
fix: let pending creates bypass session sleep

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2275,7 +2275,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		eval.Policy = policy
 		name := target.session.Metadata["session_name"]
 		decision := awakeDecisions[name]
-		if decision.ShouldWake && !pendingInteractionReady(sp, name) && target.session.Metadata["pin_awake"] != "true" && configWakeSuppressed(*target.session, policy, sp, clk) {
+		if decision.ShouldWake && decision.Reason != "pending-create" && !pendingInteractionReady(sp, name) && target.session.Metadata["pin_awake"] != "true" && configWakeSuppressed(*target.session, policy, sp, clk) {
+			// Pending creates represent an in-flight start and must not be
+			// suppressed by stale sleep metadata while waiting for op=start.
 			// Direct assigned work overrides sleep suppression for every
 			// sleep class — the assignment is session-specific, so a pool
 			// sibling cannot serve it. Pool-scale demand (poolDesired > 0)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -6102,6 +6102,55 @@ func TestReconcileSessionBeads_ConvergesPendingCreateWhenRuntimeMatchesBead(t *t
 	}
 }
 
+func TestReconcileSessionBeads_PendingCreateBypassesSessionSleepSuppression(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		SessionSleep: config.SessionSleepConfig{
+			InteractiveResume: "0s",
+		},
+		Agents: []config.Agent{{
+			Name:         "worker",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "on_demand",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.markSessionCreating(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"pending_create_claim":       "true",
+	})
+
+	if woken := env.reconcile([]beads.Bead{session}); woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["state"] != "active" {
+		t.Fatalf("state = %q, want active", got.Metadata["state"])
+	}
+}
+
 func TestReconcileSessionBeads_PreservesNeverStartedPendingCreateBeforeLeaseExpires(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary
- keep pending-create wake decisions from being suppressed by session-sleep policy
- add a regression for an on-demand named session stuck in creating with pending_create_claim=true

## Tests
- go test ./cmd/gc -run 'TestReconcileSessionBeads_(PendingCreateBypassesSessionSleepSuppression|ConvergesPendingCreateWhenRuntimeMatchesBead|RollsBackPendingCreateOnProviderError|ConvergesPendingCreateOnLateSuccessStartError|HealsRunningPendingCreateToActive)|TestWakeReasonsNonInteractiveImmediateUsesHardWakeReasons|TestPhase2ReconcileSessionBeads_PinWakesThroughSessionSleepSuppression' -count=1