### PR TITLE
chore: pin Dolt to 2.0.7

### DIFF
--- a/.github/scripts/install-dolt-archive.sh
+++ b/.github/scripts/install-dolt-archive.sh
@@ -56,6 +56,10 @@ esac
 platform_tuple="${os}-${arch}"
 expected_sha=""
 case "${version}:${platform_tuple}" in
+  2.0.7:linux-amd64) expected_sha="8e09138596763896cbce0632cd6e779fa1df405334c6c148bc314539a3b9795a" ;;
+  2.0.7:linux-arm64) expected_sha="ebc6352c00bbdd4b1980c3fd7072ee6dde03b85cb8c1417ff1468af0d0d52cc4" ;;
+  2.0.7:darwin-amd64) expected_sha="4a054b3417b22a3f07ce2e98fc5e23db027cdfa6b2e9835790c11c4ab0fed0bb" ;;
+  2.0.7:darwin-arm64) expected_sha="69cee8fb7cd2de10689a45021e6c5e2f815514f33f722e121fcaa52c6c672169" ;;
   2.0.3:linux-amd64) expected_sha="82445e0ef6f2366c78f959ffa225d9b47c78dd4dac9e19d4cd83c814b7dd5135" ;;
   2.0.3:linux-arm64) expected_sha="321ac97f0a44af32eff8004cadef841bc683f683101de96dea2deda6ad86f950" ;;
   2.0.3:darwin-amd64) expected_sha="592e37385313cabe3e96208e4b8edc3e7c05c18c22ee325415c65981320de584" ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     needs: runner-policy
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.0.7"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -172,7 +172,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.0.7"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -198,7 +198,7 @@ jobs:
       - runner-policy
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.0.7"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -297,7 +297,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.0.7"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -429,7 +429,7 @@ jobs:
             timeout_minutes: 15
             command: ./scripts/test-integration-shard rest-full-16-of-16
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.0.7"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -898,7 +898,7 @@ jobs:
       - name: Pack compatibility tests
         run: make test-acceptance
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.0.7"
       BD_VERSION: "v1.0.4"
 
   # Dashboard SPA typecheck + tests + build. Runs on every push/PR

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -46,7 +46,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.0.7"
   BD_VERSION: "v1.0.4"
 
 # Trigger gate re-used by every job below via `if:`.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.0.7"
   BD_VERSION: "v1.0.4"
 
 jobs:

--- a/.github/workflows/ollama-acceptance-c.yml
+++ b/.github/workflows/ollama-acceptance-c.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.0.7"
   BD_VERSION: "v1.0.4"
   ANTHROPIC_BASE_URL: https://ollama.com
   ANTHROPIC_API_KEY: ""

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.0.7"
   BD_VERSION: "v1.0.4"
 
 jobs:

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -38,7 +38,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.0.7"
   BD_VERSION: "v1.0.4"
 
 jobs:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -30,6 +30,33 @@ vulnerabilities:
       - "usr/local/bin/kubectl"
     expired_at: 2026-06-12
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
+  - id: CVE-2026-39823
+    paths:
+      - "usr/bin/gh"
+      - "usr/local/bin/bd"
+      - "usr/local/bin/br"
+      - "usr/local/bin/dolt"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-06-12
+    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
+  - id: CVE-2026-39825
+    paths:
+      - "usr/bin/gh"
+      - "usr/local/bin/bd"
+      - "usr/local/bin/br"
+      - "usr/local/bin/dolt"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-06-12
+    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
+  - id: CVE-2026-39826
+    paths:
+      - "usr/bin/gh"
+      - "usr/local/bin/bd"
+      - "usr/local/bin/br"
+      - "usr/local/bin/dolt"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-06-12
+    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-39836
     paths:
       - "usr/bin/gh"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Gas City requires the following tools on your system. `gc init` and
 | jq | Always | — | `brew install jq` | `apt install jq` |
 | pgrep | Always | — | (included in macOS) | `apt install procps` |
 | lsof | Always | — | (included in macOS) | `apt install lsof` |
-| dolt | Beads provider `bd` | 1.86.2 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
+| dolt | Beads provider `bd` | 2.0.7 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
 | bd | Beads provider `bd` | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | Beads provider `bd` | — | `brew install flock` | `apt install util-linux` |
 | gh | Optional GitHub gates | — | `brew install gh` | [cli.github.com](https://cli.github.com/) |
@@ -65,8 +65,9 @@ The `bd` (beads) provider is the default. To use a file-based store instead
 (no dolt/bd/flock needed), set `GC_BEADS=file` or add `[beads] provider = "file"`
 to your `city.toml`.
 
-Managed Dolt checks require a final Dolt 1.86.2 or newer. Earlier and
-pre-release builds can miss the upstream GC/writer deadlock fix in
+Managed Dolt checks require a final Dolt 2.0.7 or newer. Older and
+pre-release builds are below Gas City's managed bd/Dolt compatibility floor;
+releases before 1.86.2 can also miss the upstream GC/writer deadlock fix in
 dolthub/dolt commit `ccf7bde206`, which can hang `dolt_backup sync` under
 heavy write load.
 

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -261,7 +261,7 @@ func TestBuiltinDoltDoctorAllowsAtMinimumVersionWhenProbeSucceeds(t *testing.T) 
 		name string
 		body string
 	}{
-		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.2\\n'\n"},
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 2.0.7\\n'\n"},
 		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
 		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
 	} {
@@ -277,7 +277,7 @@ func TestBuiltinDoltDoctorAllowsAtMinimumVersionWhenProbeSucceeds(t *testing.T) 
 	if err != nil {
 		t.Fatalf("check-dolt unexpectedly rejected Dolt probe at minimum: %v\n%s", err, out)
 	}
-	if !strings.Contains(string(out), "dolt available (dolt version 1.86.2)") {
+	if !strings.Contains(string(out), "dolt available (dolt version 2.0.7)") {
 		t.Fatalf("check-dolt output = %s, want successful version probe", out)
 	}
 }
@@ -302,7 +302,7 @@ func TestBuiltinDoltDoctorBoundsVersionProbe(t *testing.T) {
 			name: "gtimeout",
 			body: "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$TIMEOUT_CAPTURE\"\nif [ \"$1\" = \"--kill-after=2\" ]; then\n  shift\nfi\nshift\nexec \"$@\"\n",
 		},
-		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.10\\n'\n"},
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 2.0.10\\n'\n"},
 		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
 		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
 	} {

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -793,7 +793,7 @@ func TestCheckHardDependenciesRejectsDoltPreReleaseAtFloor(t *testing.T) {
 	initRunVersion = func(binary string) (string, error) {
 		switch binary {
 		case "dolt":
-			return "dolt version 1.86.2-rc1", nil
+			return "dolt version 2.0.7-rc1", nil
 		case "bd":
 			return "bd version " + bdMinVersion, nil
 		case "flock", "tmux", "jq", "git", "pgrep", "lsof":
@@ -808,7 +808,7 @@ func TestCheckHardDependenciesRejectsDoltPreReleaseAtFloor(t *testing.T) {
 	if len(missing) != 1 {
 		t.Fatalf("missing deps = %#v, want only dolt prerelease rejection", missing)
 	}
-	if !strings.Contains(missing[0].name, "dolt") || !strings.Contains(missing[0].name, "1.86.2-rc1") {
+	if !strings.Contains(missing[0].name, "dolt") || !strings.Contains(missing[0].name, "2.0.7-rc1") {
 		t.Fatalf("missing dep = %#v, want dolt prerelease version in dependency name", missing[0])
 	}
 }

--- a/contrib/k8s/Dockerfile.base
+++ b/contrib/k8s/Dockerfile.base
@@ -12,7 +12,7 @@ FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG CLAUDE_CODE_VERSION=2.1.123
-ARG DOLT_VERSION=2.0.3
+ARG DOLT_VERSION=2.0.7
 
 # System packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/contrib/k8s/dolt-statefulset.yaml
+++ b/contrib/k8s/dolt-statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: init-user
-        image: dolthub/dolt:2.0.3
+        image: dolthub/dolt:2.0.7
         env:
         - name: HOME
           value: /tmp
@@ -56,7 +56,7 @@ spec:
           mountPath: /tmp
       containers:
       - name: dolt
-        image: dolthub/dolt:2.0.3
+        image: dolthub/dolt:2.0.7
         env:
         - name: HOME
           value: /tmp

--- a/deps.env
+++ b/deps.env
@@ -4,7 +4,7 @@
 # Update these when bumping automation/image pins. The internal/deps package
 # defines minimum compatible versions (may lag behind these pins).
 
-DOLT_VERSION=2.0.3
+DOLT_VERSION=2.0.7
 BD_REPO=gastownhall/beads
 BD_VERSION=v1.0.4
 BR_VERSION=0.1.20

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,15 +26,16 @@ for you; the other methods require manual installation.
 | tmux | Yes | — | `brew install tmux` | `apt install tmux` | Session management |
 | jq | Yes | — | `brew install jq` | `apt install jq` | JSON processing |
 | git | Yes | — | (built-in) | (built-in) | Version control |
-| dolt | Yes | 1.86.2 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
+| dolt | Yes | 2.0.7 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
 | bd (Beads CLI) | Yes | 1.0.0 | `brew install beads` | [releases](https://github.com/gastownhall/beads/releases) | Issue tracking |
 | flock | Yes | — | `brew install flock` | (built-in via util-linux) | File locking |
 | gh | Optional | — | `brew install gh` | [cli.github.com](https://cli.github.com/) | GitHub gate checks |
 | Go 1.25+ | Source only | 1.25 | `brew install go` | [golang.org](https://go.dev/dl/) | Compiler |
 | make | Source only | — | (built-in) | `apt install make` (or `build-essential`) | Drives `make install` |
 
-Use a final Dolt 1.86.2 or newer. Gas City's managed Dolt checks reject older
-and pre-release builds because they can miss the upstream GC/writer deadlock
+Use a final Dolt 2.0.7 or newer. Gas City's managed Dolt checks reject older
+and pre-release builds because they are below the managed bd/Dolt compatibility
+floor; releases before 1.86.2 can also miss the upstream GC/writer deadlock
 fix in dolthub/dolt commit `ccf7bde206`, which can hang `dolt_backup sync`
 under heavy write load.
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -102,7 +102,7 @@ check.
 
 | Tool | Min version | macOS | Linux |
 |------|-------------|-------|-------|
-| dolt | 1.86.2 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
+| dolt | 2.0.7 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
 | bd | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | -- | `brew install flock` | `apt install util-linux` |
 
@@ -134,8 +134,9 @@ durable versioned storage and is recommended for real work.
 
 ## Dolt Version Too Old
 
-Gas City requires a final Dolt 1.86.2 or newer. Older and pre-release builds
-can miss the upstream GC/writer deadlock fix in dolthub/dolt commit
+Gas City requires a final Dolt 2.0.7 or newer. Older and pre-release builds
+are below the managed bd/Dolt compatibility floor; releases before 1.86.2 can
+also miss the upstream GC/writer deadlock fix in dolthub/dolt commit
 `ccf7bde206`, which can hang `dolt_backup sync` under heavy write load. Check
 your version:
 

--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -34,10 +34,10 @@ and verifying the result.
 - **Free disk space.** Dolt GC rewrites chunks into a new store before
   swapping; budget at least **2× the current `.dolt/` size** in free space
   on the same filesystem.
-- **Final Dolt 1.86.2 or newer.** This matches the floor enforced by Gas
-  City's managed Dolt tooling and avoids the upstream GC/writer deadlock fixed
-  in dolthub/dolt commit `ccf7bde206`, which can hang `dolt_backup sync` under
-  heavy write load. Check with
+- **Final Dolt 2.0.7 or newer.** This matches the floor enforced by Gas
+  City's managed Dolt tooling. Releases before 1.86.2 also have the upstream
+  GC/writer deadlock fixed in dolthub/dolt commit `ccf7bde206`, which can hang
+  `dolt_backup sync` under heavy write load. Check with
   `dolt version`. If your binary rejects `--archive-level=1` (rare on
   modern releases), drop the flag and run plain
   `dolt gc` — archive compression is default-on in 1.75+ so the flag is
@@ -82,7 +82,7 @@ If GC finishes but the size barely moves, the chunks are nearly all live
 
 ## Prevention
 
-- **Keep Dolt at a final 1.86.2 or newer.** This matches Gas City's
+- **Keep Dolt at a final 2.0.7 or newer.** This matches Gas City's
   managed-Dolt floor; newer releases ship improved auto-GC heuristics and
   default archive compression.
 - **Let the dolt pack's `mol-dog-compactor` order run continuously.**

--- a/examples/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/dolt/assets/scripts/mol-dog-backup.sh
@@ -16,7 +16,7 @@ USER="${GC_DOLT_USER:-root}"
 OFFSITE_PATH="${GC_BACKUP_OFFSITE_PATH:-}"
 BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"
 SYSTEM_DBS="^(information_schema|mysql|dolt_cluster|__gc_probe|performance_schema|sys)$"
-MIN_DOLT_BACKUP_VERSION="1.86.2"
+MIN_DOLT_BACKUP_VERSION="2.0.7"
 
 dolt_sql() {
     DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" \
@@ -76,7 +76,7 @@ DOLT_VERSION="$(dolt version 2>/dev/null | awk 'NR == 1 {print $NF}' || true)"
 if ! dolt_version_at_least "$DOLT_VERSION" "$MIN_DOLT_BACKUP_VERSION"; then
     gc mail send mayor/ --from controller \
         -s "Backup dog: dolt-too-old for backup sync [HIGH]" \
-        -m "Skipping backup sync: dolt version ${DOLT_VERSION:-unknown} is below required ${MIN_DOLT_BACKUP_VERSION}. Older versions can hang the sql-server during dolt backup sync." \
+        -m "Skipping backup sync: dolt version ${DOLT_VERSION:-unknown} is below required ${MIN_DOLT_BACKUP_VERSION}. Gas City requires this managed Dolt floor before backup sync." \
         2>/dev/null || true
     SUMMARY="backup — dolt-too-old: ${DOLT_VERSION:-unknown}, required: $MIN_DOLT_BACKUP_VERSION"
     gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true

--- a/examples/dolt/doctor/check-dolt/run.sh
+++ b/examples/dolt/doctor/check-dolt/run.sh
@@ -80,11 +80,11 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
-# Require dolt >= 1.86.2 due to upstream GC/writer deadlock fix.
-# Older versions hang sql-server during dolt_backup('sync', ...) under
-# heavy concurrent write load; the watchdog then force-kills the server.
-# See dolthub/dolt commit ccf7bde206 (PR #10876).
-required="1.86.2"
+# Require the managed bd/Dolt compatibility floor. This preserves the
+# original guard for the upstream GC/writer deadlock fixed in dolthub/dolt
+# commit ccf7bde206 (PR #10876) and keeps managed backup sync on the pinned
+# Dolt release line.
+required="2.0.7"
 
 parse_dolt_version() {
     local input="$1"
@@ -140,7 +140,7 @@ if [ "$parse_status" -ne 0 ]; then
 fi
 if version_lt "$ver_str" "$required"; then
     echo "dolt $ver_str is too old (need >= $required) — upgrade required"
-    echo "Reason: <1.86.2 has a GC/writer deadlock that hangs sql-server during dolt_backup sync under heavy commit load. See dolthub/dolt commit ccf7bde206."
+    echo "Reason: Gas City requires final Dolt >= $required for managed bd/Dolt; releases before 1.86.2 also have a GC/writer deadlock that hangs sql-server during dolt_backup sync under heavy commit load. See dolthub/dolt commit ccf7bde206."
     echo "Install: https://github.com/dolthub/dolt/releases"
     exit 2
 fi

--- a/examples/dolt/doctor_test.go
+++ b/examples/dolt/doctor_test.go
@@ -126,20 +126,17 @@ func runDoctorCheck(t *testing.T, sandboxBin string) (int, string) {
 	return 0, ""
 }
 
-// TestDoctorCheckVersionFloor exercises the dolt >= 1.86.2
-// version-gate added in ga-iwec. The gate guards against an
+// TestDoctorCheckVersionFloor exercises the dolt >= 2.0.7
+// version gate. The original gate guards against an
 // upstream GC/writer deadlock fixed in dolthub/dolt commit
 // ccf7bde206 (PR #10876) — older binaries hang sql-server during
 // dolt_backup('sync', ...) under heavy commit load. The gate must:
 //
-//  1. Reject older minors (1.85.9) AND the specific deadlock-
-//     affected version (1.86.1), with an explainer pointing at
-//     ccf7bde206 so on-call has the upstream context.
-//  2. Accept the boundary 1.86.2 exactly.
-//  3. Accept versions where the minor segment is multi-digit
-//     (1.86.10); lexical string comparison would order 1.86.10
-//     before 1.86.2 and reject it.
-//  4. Accept the next major (2.0.0).
+//  1. Reject older pinned releases and the prior patch.
+//  2. Accept the boundary 2.0.7 exactly.
+//  3. Accept versions where a segment is multi-digit (2.0.10);
+//     lexical string comparison would order 2.0.10 before 2.0.7.
+//  4. Accept later minors and majors.
 //  5. Reject pre-release/dev builds at the floor, while accepting
 //     build metadata on a final release.
 //  6. Fail closed when `dolt version` produces empty or
@@ -155,92 +152,92 @@ func TestDoctorCheckVersionFloor(t *testing.T) {
 		wantOmit    []string
 	}{
 		{
-			name:        "older minor 1.85.9 rejected",
-			version:     "dolt version 1.85.9",
+			name:        "previous pinned 2.0.3 rejected",
+			version:     "dolt version 2.0.3",
 			wantExit:    2,
-			wantContain: []string{"too old", "1.85.9", "1.86.2", "ccf7bde206"},
+			wantContain: []string{"too old", "2.0.3", "2.0.7", "ccf7bde206"},
 		},
 		{
-			name:        "deadlock-affected 1.86.1 rejected",
-			version:     "dolt version 1.86.1",
+			name:        "previous patch 2.0.6 rejected",
+			version:     "dolt version 2.0.6",
 			wantExit:    2,
-			wantContain: []string{"too old", "1.86.1", "1.86.2", "ccf7bde206"},
+			wantContain: []string{"too old", "2.0.6", "2.0.7", "ccf7bde206"},
 		},
 		{
-			name:        "boundary 1.86.2 accepted",
-			version:     "dolt version 1.86.2",
+			name:        "boundary 2.0.7 accepted",
+			version:     "dolt version 2.0.7",
 			wantExit:    0,
-			wantContain: []string{"dolt available", "1.86.2", "flock ok", "lsof ok"},
+			wantContain: []string{"dolt available", "2.0.7", "flock ok", "lsof ok"},
 			wantOmit:    []string{"too old"},
 		},
 		{
-			name:        "multi-digit minor 1.86.10 accepted",
-			version:     "dolt version 1.86.10",
+			name:        "multi-digit patch 2.0.10 accepted",
+			version:     "dolt version 2.0.10",
 			wantExit:    0,
-			wantContain: []string{"dolt available", "1.86.10"},
+			wantContain: []string{"dolt available", "2.0.10"},
 			wantOmit:    []string{"too old"},
 		},
 		{
-			name:        "next major 2.0.0 accepted",
-			version:     "dolt version 2.0.0",
+			name:        "later minor 2.1.0 accepted",
+			version:     "dolt version 2.1.0",
 			wantExit:    0,
-			wantContain: []string{"dolt available", "2.0.0"},
+			wantContain: []string{"dolt available", "2.1.0"},
 			wantOmit:    []string{"too old"},
 		},
 		{
-			name:        "pre-release 1.86.2-rc1 rejected",
-			version:     "dolt version 1.86.2-rc1",
+			name:        "pre-release 2.0.7-rc1 rejected",
+			version:     "dolt version 2.0.7-rc1",
 			wantExit:    2,
-			wantContain: []string{"pre-release", "1.86.2-rc1", "1.86.2"},
+			wantContain: []string{"pre-release", "2.0.7-rc1", "2.0.7"},
 			wantOmit:    []string{"dolt available"},
 		},
 		{
-			name:        "pre-release with build metadata 1.86.2-rc1+build.5 rejected",
-			version:     "dolt version 1.86.2-rc1+build.5",
+			name:        "pre-release with build metadata 2.0.7-rc1+build.5 rejected",
+			version:     "dolt version 2.0.7-rc1+build.5",
 			wantExit:    2,
-			wantContain: []string{"pre-release", "1.86.2-rc1+build.5", "1.86.2"},
+			wantContain: []string{"pre-release", "2.0.7-rc1+build.5", "2.0.7"},
 			wantOmit:    []string{"dolt available"},
 		},
 		{
-			name:        "dev build 1.86.2-dev rejected",
-			version:     "dolt version 1.86.2-dev.0",
+			name:        "dev build 2.0.7-dev rejected",
+			version:     "dolt version 2.0.7-dev.0",
 			wantExit:    2,
-			wantContain: []string{"pre-release", "1.86.2-dev.0", "1.86.2"},
+			wantContain: []string{"pre-release", "2.0.7-dev.0", "2.0.7"},
 			wantOmit:    []string{"dolt available"},
 		},
 		{
-			name:        "pre-release above floor 1.99.0-rc1 rejected",
-			version:     "dolt version 1.99.0-rc1",
+			name:        "pre-release above floor 2.0.8-rc1 rejected",
+			version:     "dolt version 2.0.8-rc1",
 			wantExit:    2,
-			wantContain: []string{"pre-release", "1.99.0-rc1", "1.86.2"},
+			wantContain: []string{"pre-release", "2.0.8-rc1", "2.0.7"},
 			wantOmit:    []string{"dolt available"},
 		},
 		{
-			name:        "pre-release next major 2.0.0-rc1 rejected",
-			version:     "dolt version 2.0.0-rc1",
+			name:        "pre-release later minor 2.1.0-rc1 rejected",
+			version:     "dolt version 2.1.0-rc1",
 			wantExit:    2,
-			wantContain: []string{"pre-release", "2.0.0-rc1", "1.86.2"},
+			wantContain: []string{"pre-release", "2.1.0-rc1", "2.0.7"},
 			wantOmit:    []string{"dolt available"},
 		},
 		{
-			name:        "build metadata on 1.86.2 accepted",
-			version:     "dolt version 1.86.2+build.5",
+			name:        "build metadata on 2.0.7 accepted",
+			version:     "dolt version 2.0.7+build.5",
 			wantExit:    0,
-			wantContain: []string{"dolt available", "1.86.2+build.5"},
+			wantContain: []string{"dolt available", "2.0.7+build.5"},
 			wantOmit:    []string{"too old", "pre-release"},
 		},
 		{
-			name:        "hyphenated build metadata on 1.86.2 accepted",
-			version:     "dolt version 1.86.2+build-5",
+			name:        "hyphenated build metadata on 2.0.7 accepted",
+			version:     "dolt version 2.0.7+build-5",
 			wantExit:    0,
-			wantContain: []string{"dolt available", "1.86.2+build-5"},
+			wantContain: []string{"dolt available", "2.0.7+build-5"},
 			wantOmit:    []string{"too old", "pre-release"},
 		},
 		{
-			name:        "v-prefixed 1.86.2 accepted",
-			version:     "dolt version v1.86.2",
+			name:        "v-prefixed 2.0.7 accepted",
+			version:     "dolt version v2.0.7",
 			wantExit:    0,
-			wantContain: []string{"dolt available", "v1.86.2", "flock ok", "lsof ok"},
+			wantContain: []string{"dolt available", "v2.0.7", "flock ok", "lsof ok"},
 			wantOmit:    []string{"too old", "unrecognized"},
 		},
 		{
@@ -264,15 +261,15 @@ func TestDoctorCheckVersionFloor(t *testing.T) {
 			wantOmit:    []string{"too old"},
 		},
 		{
-			name:        "two-component 1.86 rejected",
-			version:     "dolt version 1.86",
+			name:        "two-component 2.0 rejected",
+			version:     "dolt version 2.0",
 			wantExit:    1,
 			wantContain: []string{"unrecognized dolt version output"},
 			wantOmit:    []string{"too old", "pre-release"},
 		},
 		{
 			name:        "leading whitespace output rejected",
-			version:     "  dolt version 1.85.9",
+			version:     "  dolt version 2.0.6",
 			wantExit:    1,
 			wantContain: []string{"unrecognized dolt version output"},
 			wantOmit:    []string{"too old", "pre-release"},
@@ -305,7 +302,7 @@ func TestDoctorCheckVersionFloor(t *testing.T) {
 
 func TestDoctorCheckVersionFloorDoesNotRequireVersionSort(t *testing.T) {
 	bin := doctorSandbox(t, doctorSandboxOpts{
-		dolt:         strPtr("dolt version 1.86.10"),
+		dolt:         strPtr("dolt version 2.0.10"),
 		includeFlock: true,
 		includeLsof:  true,
 	})
@@ -330,7 +327,7 @@ func TestDoctorCheckVersionFloorDoesNotRequireVersionSort(t *testing.T) {
 // servers onto the same data directory and corrupt state.
 func TestDoctorCheckMissingFlock(t *testing.T) {
 	bin := doctorSandbox(t, doctorSandboxOpts{
-		dolt:         strPtr("dolt version 1.86.2"),
+		dolt:         strPtr("dolt version 2.0.7"),
 		includeFlock: false,
 		includeLsof:  true,
 	})
@@ -350,7 +347,7 @@ func TestDoctorCheckMissingFlock(t *testing.T) {
 // state later.
 func TestDoctorCheckMissingLsof(t *testing.T) {
 	bin := doctorSandbox(t, doctorSandboxOpts{
-		dolt:         strPtr("dolt version 1.86.2"),
+		dolt:         strPtr("dolt version 2.0.7"),
 		includeFlock: true,
 		includeLsof:  false,
 	})

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -3019,7 +3019,7 @@ func TestBackupScriptDiscoversNamedBackupsAndSyncsArtifactsOffsite(t *testing.T)
 	}
 	binDir := t.TempDir()
 	_ = writeDogFakeGC(t, binDir)
-	doltLogPath := writeBackupFakeDolt(t, binDir, "1.86.2", 0, "prod")
+	doltLogPath := writeBackupFakeDolt(t, binDir, "2.0.7", 0, "prod")
 	rsyncLogPath := writeBackupFakeRsync(t, binDir)
 
 	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir, "GC_BACKUP_OFFSITE_PATH="+offsiteDir)
@@ -3061,7 +3061,7 @@ func TestBackupScriptIgnoresDocumentedSystemSchemasForAutoDiscoveryWithBSDGrep(t
 	binDir := t.TempDir()
 	_ = writeDogFakeGC(t, binDir)
 	writeBSDLikeGrep(t, binDir)
-	doltLogPath := writeBackupFakeDolt(t, binDir, "1.86.2", 0, "prod", "performance_schema", "sys")
+	doltLogPath := writeBackupFakeDolt(t, binDir, "2.0.7", 0, "prod", "performance_schema", "sys")
 
 	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir)
 	if !strings.Contains(out, "synced: 1/1") {
@@ -3086,7 +3086,7 @@ func TestBackupScriptCountsFailedDatabasesByDatabase(t *testing.T) {
 	}
 	binDir := t.TempDir()
 	gcLogPath := writeDogFakeGC(t, binDir)
-	_ = writeBackupFakeDolt(t, binDir, "1.86.2", 1)
+	_ = writeBackupFakeDolt(t, binDir, "2.0.7", 1)
 
 	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir, "GC_BACKUP_DATABASES=prod")
 	if !strings.Contains(out, "synced: 0/1") {

--- a/examples/dolt/formulas/mol-dog-backup.toml
+++ b/examples/dolt/formulas/mol-dog-backup.toml
@@ -38,19 +38,20 @@ default = ""
 id = "preflight"
 title = "Verify dolt version compatible with backup sync"
 description = """
-**Required:** dolt >= 1.86.2.
+**Required:** dolt >= 2.0.7.
 
-Older dolt versions have a GC/writer deadlock that hangs the sql-server
-during dolt_backup sync against databases under heavy concurrent write
-load (e.g. the gm bead store). The watchdog will kill the hung server
-and disrupt every dependent agent.
+Older dolt versions are below Gas City's managed bd/Dolt compatibility floor.
+Releases before 1.86.2 also have a GC/writer deadlock that hangs the
+sql-server during dolt_backup sync against databases under heavy concurrent
+write load. The watchdog will kill the hung server and disrupt every
+dependent agent.
 
 Run:
 ```bash
 dolt version | head -1
 ```
 
-If the version is < 1.86.2, abort the molecule and nudge the mayor to
+If the version is < 2.0.7, abort the molecule and nudge the mayor to
 upgrade dolt. Do NOT proceed to the sync step or close it as successful.
 
 Close this bead with:

--- a/examples/dolt/pack.toml
+++ b/examples/dolt/pack.toml
@@ -5,9 +5,9 @@
 #
 # Dog-backed formulas and orders rely on the city's maintenance pack.
 #
-# Minimum dolt version: 1.86.2. Earlier versions have a GC/writer deadlock
-# that hangs sql-server during dolt_backup sync under heavy concurrent write
-# load. See dolthub/dolt commit ccf7bde206 (PR #10876). The doctor check
+# Minimum dolt version: 2.0.7. This is the managed bd/Dolt compatibility
+# floor and preserves the original guard for the GC/writer deadlock fixed in
+# dolthub/dolt commit ccf7bde206 (PR #10876). The doctor check
 # (doctor/check-dolt) fails closed; mol-dog-backup preflight records the same
 # failure outcome, and the sync step checks it before running backup sync.
 

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -3578,24 +3578,24 @@ func TestCompareDoltVersion(t *testing.T) {
 
 func TestDoltVersionCheck_OK(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.86.2\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 2.0.7\n", nil }
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
-	if !strings.Contains(r.Message, "1.86.2") {
+	if !strings.Contains(r.Message, "2.0.7") {
 		t.Errorf("message = %q, want version in message", r.Message)
 	}
 }
 
 func TestDoltVersionCheck_OK_AtMinimum(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.86.2\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 2.0.7\n", nil }
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
-	if !strings.Contains(r.Message, "1.86.2") {
+	if !strings.Contains(r.Message, "2.0.7") {
 		t.Errorf("message = %q, want version in message", r.Message)
 	}
 }
@@ -3614,7 +3614,7 @@ func TestDoltVersionCheck_Error_BelowManagedConfigFloor(t *testing.T) {
 
 func TestDoltVersionCheck_Error_BelowMinimum(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.86.1\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 2.0.6\n", nil }
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusError {
 		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
@@ -3626,11 +3626,11 @@ func TestDoltVersionCheck_Error_BelowMinimum(t *testing.T) {
 
 func TestDoltVersionCheck_Error_PreReleaseAtFloor(t *testing.T) {
 	cases := []string{
-		"dolt version 1.86.2-rc1\n",
-		"dolt version 1.86.2-rc1+build.5\n",
-		"dolt version 1.86.2-dev.0\n",
-		"dolt version 1.99.0-rc1\n",
-		"dolt version 2.0.0-rc1\n",
+		"dolt version 2.0.7-rc1\n",
+		"dolt version 2.0.7-rc1+build.5\n",
+		"dolt version 2.0.7-dev.0\n",
+		"dolt version 2.0.8-rc1\n",
+		"dolt version 2.1.0-rc1\n",
 	}
 	for _, version := range cases {
 		t.Run(strings.TrimSpace(version), func(t *testing.T) {
@@ -3640,7 +3640,7 @@ func TestDoltVersionCheck_Error_PreReleaseAtFloor(t *testing.T) {
 			if r.Status != StatusError {
 				t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
 			}
-			if !strings.Contains(r.Message, "pre-release") || !strings.Contains(r.Message, "1.86.2") {
+			if !strings.Contains(r.Message, "pre-release") || !strings.Contains(r.Message, "2.0.7") {
 				t.Errorf("message = %q, want pre-release and minimum version text", r.Message)
 			}
 		})

--- a/internal/doltversion/doltversion.go
+++ b/internal/doltversion/doltversion.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ManagedMin is the minimum Dolt version required for managed bd/Dolt operation.
-const ManagedMin = "1.86.2"
+const ManagedMin = "2.0.7"
 
 var (
 	// ErrPreRelease reports a Dolt version that is not a final release.

--- a/internal/doltversion/doltversion_test.go
+++ b/internal/doltversion/doltversion_test.go
@@ -79,17 +79,21 @@ func TestParse(t *testing.T) {
 }
 
 func TestCheckFinalMinimum(t *testing.T) {
+	if ManagedMin != "2.0.7" {
+		t.Fatalf("ManagedMin = %q, want 2.0.7", ManagedMin)
+	}
+
 	tests := []struct {
 		name    string
 		input   string
 		wantErr error
 	}{
-		{name: "at floor", input: "dolt version 1.86.2"},
-		{name: "above floor", input: "dolt version 1.86.10"},
-		{name: "below floor", input: "dolt version 1.86.1", wantErr: ErrBelowMinimum},
-		{name: "pre-release at floor", input: "dolt version 1.86.2-rc1", wantErr: ErrPreRelease},
-		{name: "pre-release with build metadata at floor", input: "dolt version 1.86.2-rc1+build.5", wantErr: ErrPreRelease},
-		{name: "pre-release above floor", input: "dolt version 2.0.0-rc1", wantErr: ErrPreRelease},
+		{name: "at floor", input: "dolt version 2.0.7"},
+		{name: "above floor", input: "dolt version 2.0.8"},
+		{name: "below floor", input: "dolt version 2.0.6", wantErr: ErrBelowMinimum},
+		{name: "pre-release at floor", input: "dolt version 2.0.7-rc1", wantErr: ErrPreRelease},
+		{name: "pre-release with build metadata at floor", input: "dolt version 2.0.7-rc1+build.5", wantErr: ErrPreRelease},
+		{name: "pre-release above floor", input: "dolt version 2.0.8-rc1", wantErr: ErrPreRelease},
 	}
 
 	for _, tt := range tests {

--- a/scripts/dolt_version_pin_test.go
+++ b/scripts/dolt_version_pin_test.go
@@ -1,0 +1,65 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoltVersionPins(t *testing.T) {
+	const doltVersion = "2.0.7"
+	repoRoot := repoRoot(t)
+
+	assertContains := func(rel, want string) {
+		t.Helper()
+		content, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("%s missing %q", rel, want)
+		}
+	}
+	assertCount := func(rel, want string, count int) {
+		t.Helper()
+		content, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if got := strings.Count(string(content), want); got != count {
+			t.Fatalf("%s has %d copies of %q, want %d", rel, got, want, count)
+		}
+	}
+
+	assertContains("deps.env", "DOLT_VERSION="+doltVersion)
+	assertContains("contrib/k8s/Dockerfile.base", "ARG DOLT_VERSION="+doltVersion)
+	assertCount("contrib/k8s/dolt-statefulset.yaml", "image: dolthub/dolt:"+doltVersion, 2)
+
+	for _, platform := range []string{"linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64"} {
+		assertContains(".github/scripts/install-dolt-archive.sh", doltVersion+":"+platform)
+	}
+
+	workflowDir := filepath.Join(repoRoot, ".github", "workflows")
+	err := filepath.WalkDir(workflowDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".yml" {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(content), "DOLT_VERSION:") &&
+			!strings.Contains(string(content), `DOLT_VERSION: "`+doltVersion+`"`) {
+			rel, _ := filepath.Rel(repoRoot, path)
+			t.Fatalf("%s has DOLT_VERSION but is not pinned to %s", rel, doltVersion)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk workflows: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Pin CI, Docker, and k8s Dolt references to 2.0.7.
- Raise the managed bd/Dolt minimum version to 2.0.7 in Go and pack checks.
- Update docs and tests for the new Dolt floor.

## Tests
- bash -n .github/scripts/install-dolt-archive.sh examples/dolt/doctor/check-dolt/run.sh examples/dolt/assets/scripts/mol-dog-backup.sh
- go test ./internal/doltversion ./scripts ./examples/dolt ./internal/doctor ./cmd/gc -run 'Test(CheckFinalMinimum|DoltVersionPins|DoctorCheckVersionFloor|BuiltinDoltDoctorAllowsAtMinimumVersionWhenProbeSucceeds|BuiltinDoltDoctorBoundsVersionProbe|DoltVersionCheck_(OK|OK_AtMinimum|Error_BelowMinimum|Error_PreReleaseAtFloor)|CheckHardDependenciesRejectsDoltPreReleaseAtFloor|BackupScript(DiscoversNamedBackupsAndSyncsArtifactsOffsite|IgnoresDocumentedSystemSchemasForAutoDiscoveryWithBSDGrep|CountsFailedDatabasesByDatabase|SkipsOldDoltBeforeSync))' -count=1
- make test-fast-parallel
- go vet ./...
- .githooks/pre-commit
- DOLT_INSTALL_BIN_DIR=<tmp>/bin .github/scripts/install-dolt-archive.sh 2.0.7