### PR TITLE
Report tmux startup dead-pane diagnostics

### DIFF
--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -777,8 +777,11 @@ func ignoreDeadlineIfSessionAlive(ops startOps, name string, err error) error {
 	if hasErr != nil {
 		return fmt.Errorf("verifying session after ready deadline: %w", hasErr)
 	}
-	if alive {
+	if alive && ops.isSessionRunning(name) {
 		return nil
+	}
+	if alive {
+		return startupDeadSessionError(ops, name)
 	}
 	return err
 }
@@ -800,10 +803,13 @@ func failIfSessionDiedDuringStartupProbe(ops startOps, name string) error {
 	if err != nil {
 		return fmt.Errorf("verifying session after startup probe: %w", err)
 	}
-	if alive {
+	if alive && ops.isSessionRunning(name) {
 		return nil
 	}
-	return startupDeadSessionError(ops, name)
+	if alive {
+		return startupDeadSessionError(ops, name)
+	}
+	return nil
 }
 
 // doStartSession is the pure startup orchestration logic.
@@ -897,7 +903,7 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 	if err != nil {
 		return fmt.Errorf("verifying session: %w", err)
 	}
-	if !alive {
+	if !alive || !ops.isSessionRunning(name) {
 		return startupDeadSessionError(ops, name)
 	}
 

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -660,6 +660,7 @@ type startOps interface {
 	acceptStartupDialogs(ctx context.Context, name string) error
 	waitForReady(ctx context.Context, name string, rc *RuntimeConfig, timeout time.Duration) error
 	hasSession(name string) (bool, error)
+	capturePane(name string, lines int) (string, error)
 	sendKeys(name, text string) error
 	setRemainOnExit(name string) error
 	runSetupCommand(ctx context.Context, cmd string, env map[string]string, timeout time.Duration) error
@@ -720,6 +721,10 @@ func (o *tmuxStartOps) hasSession(name string) (bool, error) {
 	return o.tm.HasSession(name)
 }
 
+func (o *tmuxStartOps) capturePane(name string, lines int) (string, error) {
+	return o.tm.CapturePane(name, lines)
+}
+
 func (o *tmuxStartOps) sendKeys(name, text string) error {
 	return o.tm.NudgeSession(name, text)
 }
@@ -776,6 +781,29 @@ func ignoreDeadlineIfSessionAlive(ops startOps, name string, err error) error {
 		return nil
 	}
 	return err
+}
+
+func startupDeadSessionError(ops startOps, name string) error {
+	pane, err := ops.capturePane(name, 80)
+	if err != nil {
+		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
+	}
+	pane = strings.TrimSpace(pane)
+	if pane == "" {
+		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
+	}
+	return fmt.Errorf("%w: session %q; last pane output:\n%s", runtime.ErrSessionDiedDuringStartup, name, pane)
+}
+
+func failIfSessionDiedDuringStartupProbe(ops startOps, name string) error {
+	alive, err := ops.hasSession(name)
+	if err != nil {
+		return fmt.Errorf("verifying session after startup probe: %w", err)
+	}
+	if alive {
+		return nil
+	}
+	return startupDeadSessionError(ops, name)
 }
 
 // doStartSession is the pure startup orchestration logic.
@@ -844,7 +872,11 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 			ReadyDelayMs:      cfg.ReadyDelayMs,
 			ProcessNames:      cfg.ProcessNames,
 		}}
-		_ = ops.waitForReady(ctx, name, rc, startupReadyProbeTimeout(cfg)) // best-effort
+		if err := ops.waitForReady(ctx, name, rc, startupReadyProbeTimeout(cfg)); err != nil {
+			if deadErr := failIfSessionDiedDuringStartupProbe(ops, name); deadErr != nil {
+				return deadErr
+			}
+		}
 		if err := ctx.Err(); err != nil {
 			return ignoreDeadlineIfSessionAlive(ops, name, err)
 		}
@@ -866,7 +898,7 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 		return fmt.Errorf("verifying session: %w", err)
 	}
 	if !alive {
-		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
+		return startupDeadSessionError(ops, name)
 	}
 
 	// Step 5.5: Run session setup commands and script.

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -312,6 +312,7 @@ func TestDoStartSession_FullSequence(t *testing.T) {
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	// Verify createSession got full config.
@@ -528,9 +529,11 @@ func TestDoStartSession_SessionDiesDuringStartup(t *testing.T) {
 }
 
 func TestDoStartSession_ReadyDeadlineWithDeadPaneReportsProviderCrash(t *testing.T) {
+	running := false
 	ops := &fakeStartOps{
-		waitReadyErr:     context.DeadlineExceeded,
-		hasSessionResult: false,
+		waitReadyErr:           context.DeadlineExceeded,
+		hasSessionResult:       true,
+		isSessionRunningResult: &running,
 		capturePaneText: "WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\n" +
 			"Error: Operation not permitted (os error 1)\n" +
 			"Pane is dead",
@@ -564,6 +567,7 @@ func TestDoStartSession_ReadyDeadlineWithDeadPaneReportsProviderCrash(t *testing
 		"acceptStartupDialogs",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 		"capturePane",
 	})
 }
@@ -615,6 +619,7 @@ func TestDoStartSession_ProcessNamesOnly(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	// Verify isRuntimeRunning sees the process names in zombie detection path.
@@ -645,6 +650,7 @@ func TestDoStartSession_KimiSkipsStartupDialogAcceptance(t *testing.T) {
 		"waitForCommand",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -674,6 +680,7 @@ func TestDoStartSessionReturnsNudgeDeliveryError(t *testing.T) {
 		"createSession",
 		"setRemainOnExit",
 		"hasSession",
+		"isSessionRunning",
 		"sendKeys",
 	})
 }
@@ -699,6 +706,7 @@ func TestDoStartSession_AcceptStartupDialogsOnly(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -779,6 +787,7 @@ func TestDoStartSession_ReadyPromptPrefixOnly(t *testing.T) {
 		"setRemainOnExit",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	// Verify RuntimeConfig carries the prefix.
@@ -808,6 +817,7 @@ func TestDoStartSession_ReadyDelayOnly(t *testing.T) {
 		"setRemainOnExit",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	// Verify RuntimeConfig carries the delay.
@@ -848,6 +858,7 @@ func TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive(t *tes
 		"acceptStartupDialogs",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -887,6 +898,7 @@ func TestDoStartSession_TreatsDeadlineAfterPostReadyAsSuccessWhenSessionAlive(t 
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -913,6 +925,7 @@ func TestDoStartSession_EmitsPermissionWarningOnly(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -941,6 +954,7 @@ func TestDoStartSession_ProcessNamesAndReadyPrefix(t *testing.T) {
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -969,6 +983,7 @@ func TestDoStartSession_CursorReadinessHintsTriggerRuntimeWait(t *testing.T) {
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	wfr := ops.calls[4]
@@ -1007,6 +1022,7 @@ func TestDoStartSession_ProcessNamesAndReadyDelayRechecksDialogs(t *testing.T) {
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -1121,16 +1137,17 @@ func TestDoStartSession_SessionSetupRunsAfterAlive(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 		"runSetupCommand",
 		"runSetupCommand",
 	})
 
 	// Verify both commands were recorded.
-	cmd1 := ops.calls[6]
+	cmd1 := ops.calls[7]
 	if cmd1.command != "tmux set-option -t test status-style 'bg=blue'" {
 		t.Errorf("setup cmd[0] = %q, want status-style command", cmd1.command)
 	}
-	cmd2 := ops.calls[7]
+	cmd2 := ops.calls[8]
 	if cmd2.command != "tmux set-option -t test mouse on" {
 		t.Errorf("setup cmd[1] = %q, want mouse command", cmd2.command)
 	}
@@ -1167,22 +1184,23 @@ func TestDoStartSession_SessionSetupScriptRunsAfterCommands(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 		"runSetupCommand",
 		"runSetupCommand",
 		"sendKeys",
 	})
 
 	// First runSetupCommand = inline command.
-	if ops.calls[6].command != "tmux set mouse on" {
-		t.Errorf("setup[0] = %q, want inline command", ops.calls[6].command)
+	if ops.calls[7].command != "tmux set mouse on" {
+		t.Errorf("setup[0] = %q, want inline command", ops.calls[7].command)
 	}
 	// Second runSetupCommand = script.
-	if ops.calls[7].command != "/city/scripts/setup.sh" {
-		t.Errorf("setup[1] = %q, want script", ops.calls[7].command)
+	if ops.calls[8].command != "/city/scripts/setup.sh" {
+		t.Errorf("setup[1] = %q, want script", ops.calls[8].command)
 	}
 	// sendKeys = nudge.
-	if ops.calls[8].command != "start working" {
-		t.Errorf("nudge = %q, want %q", ops.calls[8].command, "start working")
+	if ops.calls[9].command != "start working" {
+		t.Errorf("nudge = %q, want %q", ops.calls[9].command, "start working")
 	}
 }
 
@@ -1311,7 +1329,7 @@ func TestDoStartSession_PreStartRunsBeforeCreate(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	assertCallSequence(t, ops, []string{"runSetupCommand", "createSession", "setRemainOnExit", "hasSession"})
+	assertCallSequence(t, ops, []string{"runSetupCommand", "createSession", "setRemainOnExit", "hasSession", "isSessionRunning"})
 
 	pre := ops.calls[0]
 	if pre.command != "setup-worktree" {

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -167,7 +167,7 @@ func (f *fakeStartOps) setRemainOnExit(name string) error {
 	return f.setRemainOnExitErr
 }
 
-func (f *fakeStartOps) capturePane(name string, lines int) (string, error) {
+func (f *fakeStartOps) capturePane(name string, _ int) (string, error) {
 	f.calls = append(f.calls, startCall{method: "capturePane", name: name})
 	return f.capturePaneText, f.capturePaneErr
 }

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -62,6 +62,8 @@ type fakeStartOps struct {
 	setRemainOnExitErr       error
 	runSetupCommandErr       error
 	sendKeysErr              error
+	capturePaneText          string
+	capturePaneErr           error
 }
 
 type errReader struct{}
@@ -163,6 +165,11 @@ func (f *fakeStartOps) sendKeys(name, text string) error {
 func (f *fakeStartOps) setRemainOnExit(name string) error {
 	f.calls = append(f.calls, startCall{method: "setRemainOnExit", name: name})
 	return f.setRemainOnExitErr
+}
+
+func (f *fakeStartOps) capturePane(name string, lines int) (string, error) {
+	f.calls = append(f.calls, startCall{method: "capturePane", name: name})
+	return f.capturePaneText, f.capturePaneErr
 }
 
 func (f *fakeStartOps) runSetupCommand(_ context.Context, cmd string, env map[string]string, timeout time.Duration) error {
@@ -518,6 +525,47 @@ func TestDoStartSession_SessionDiesDuringStartup(t *testing.T) {
 	if !errors.Is(err, runtime.ErrSessionDiedDuringStartup) {
 		t.Errorf("error = %v, want ErrSessionDiedDuringStartup", err)
 	}
+}
+
+func TestDoStartSession_ReadyDeadlineWithDeadPaneReportsProviderCrash(t *testing.T) {
+	ops := &fakeStartOps{
+		waitReadyErr:     context.DeadlineExceeded,
+		hasSessionResult: false,
+		capturePaneText: "WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\n" +
+			"Error: Operation not permitted (os error 1)\n" +
+			"Pane is dead",
+	}
+
+	cfg := runtime.Config{
+		Command:           "codex",
+		ProcessNames:      []string{"codex"},
+		ReadyPromptPrefix: "› ",
+	}
+
+	err := doStartSession(context.Background(), ops, "mayor", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, runtime.ErrSessionDiedDuringStartup) {
+		t.Fatalf("error = %v, want ErrSessionDiedDuringStartup", err)
+	}
+	if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("error = %v, should not surface generic deadline after pane died", err)
+	}
+	for _, want := range []string{"session \"mayor\"", "Operation not permitted", "Pane is dead"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
+		}
+	}
+	assertCallSequence(t, ops, []string{
+		"createSession",
+		"setRemainOnExit",
+		"waitForCommand",
+		"acceptStartupDialogs",
+		"waitForReady",
+		"hasSession",
+		"capturePane",
+	})
 }
 
 func TestDoStartSession_HasSessionError(t *testing.T) {


### PR DESCRIPTION
## Summary

- Detect dead tmux panes immediately after managed-startup readiness probes report an error.
- Preserve the last pane output in `ErrSessionDiedDuringStartup` errors.
- Add a regression test for a Codex-like provider crash where the pane contains an EPERM/PATH failure.

## Why

When a provider process exits early under tmux with `remain-on-exit`, startup can otherwise collapse into a generic deadline/context failure. Operators need the actual provider crash text to diagnose the failure without manually capturing the pane.

## Tests

- `go test ./internal/runtime/tmux -count=1`
- `go test ./cmd/gc -run 'Test.*Start|Test.*Reconcile|Test.*Session' -count=1`
- `git diff --check`

Note: one earlier broad command-layer run hit a transient unrelated timing failure in `TestStopManagedCityDoesNotUseStartupOrDriftTimeouts`; rerunning the same command-layer selection passed.
