### PR TITLE
Tighten doctor remediation for legacy PackV2 agents

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -394,10 +394,20 @@ func (expandedConfigLoadCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult
 	if _, err := loadCityConfig(ctx.CityPath, io.Discard); err != nil {
 		return errorCheck("expanded-config-load",
 			fmt.Sprintf("expanded config load error: %v", err),
-			"fix the reported config, include, import, or pack-layout error and rerun gc doctor",
+			expandedConfigLoadFixHint(err),
 			nil)
 	}
 	return okCheck("expanded-config-load", "expanded config loaded")
+}
+
+func expandedConfigLoadFixHint(err error) string {
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "unsupported PackV1") && strings.Contains(msg, "fragment") {
+			return "move fragment-authored legacy surfaces by hand; `gc doctor --fix` only rewrites root city.toml/pack.toml surfaces"
+		}
+	}
+	return "fix the reported config, include, import, or pack-layout error and rerun gc doctor"
 }
 
 // doctorJSONResult mirrors doctor.CheckResult for JSON output. Keeping the

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -402,8 +402,8 @@ func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 		return okCheck("v2-agent-format", "no legacy [[agent]] tables found")
 	case cityHasLegacy && packHasLegacy:
 		return errorCheck("v2-agent-format",
-			"unsupported PackV1 [[agent]] tables found in city.toml; pack.toml also still uses deferred legacy [[agent]] tables",
-			"run `gc doctor --fix` to move each city.toml [[agent]] definition into agents/<name>/agent.toml; pack.toml [[agent]] enforcement remains deferred until doctor/remediation support exists",
+			"unsupported PackV1 [[agent]] tables found in city.toml and pack.toml",
+			"run `gc doctor --fix` to move each root city.toml and pack.toml [[agent]] definition into agents/<name>/agent.toml",
 			append(cityLegacy, packLegacy...))
 	case cityHasLegacy:
 		return errorCheck("v2-agent-format",
@@ -411,9 +411,9 @@ func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 			"run `gc doctor --fix` to move each city.toml [[agent]] definition into agents/<name>/agent.toml",
 			cityLegacy)
 	default:
-		return warnCheck("v2-agent-format",
-			"legacy [[agent]] tables still present in pack.toml; enforcement is deferred until doctor/remediation support exists",
-			"leave this as-is for now or migrate to agents/<name>/agent.toml ahead of the follow-on enforcement pass",
+		return errorCheck("v2-agent-format",
+			"unsupported PackV1 [[agent]] tables found in pack.toml",
+			"run `gc doctor --fix` to move each root pack.toml [[agent]] definition into agents/<name>/agent.toml",
 			packLegacy)
 	}
 }

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -1092,7 +1092,7 @@ path = "`+orphanPath+`"
 	}
 }
 
-func TestV2DeprecationChecksWarnOnDeferredPackAgentFormat(t *testing.T) {
+func TestV2DeprecationChecksErrorsOnRootPackAgentFormat(t *testing.T) {
 	t.Parallel()
 
 	cityDir := t.TempDir()
@@ -1115,14 +1115,57 @@ name = "helper"
 	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, false)
 
 	out := buf.String()
-	if !strings.Contains(out, "⚠ v2-agent-format") {
-		t.Fatalf("doctor output missing deferred pack agent warning:\n%s", out)
+	if !strings.Contains(out, "✗ v2-agent-format") {
+		t.Fatalf("doctor output missing pack agent error:\n%s", out)
 	}
 	if !strings.Contains(out, "pack.toml") {
 		t.Fatalf("doctor output missing pack.toml detail:\n%s", out)
 	}
-	if !strings.Contains(out, "enforcement is deferred") {
-		t.Fatalf("doctor output missing deferral guidance:\n%s", out)
+	if !strings.Contains(out, "gc doctor --fix") || !strings.Contains(out, "agents/<name>/agent.toml") {
+		t.Fatalf("doctor output missing root pack remediation guidance:\n%s", out)
+	}
+}
+
+func TestDoctorFixMigratesRootPackAgentFormat(t *testing.T) {
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+
+[[agent]]
+name = "helper"
+provider = "claude"
+prompt_template = "prompts/helper.md"
+`)
+	writeDoctorFile(t, cityDir, "prompts/helper.md", "You are helper.\n")
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
+
+	var stdout, stderr bytes.Buffer
+	code := doDoctor(true, false, false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc doctor --fix = %d, want 0; stdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+
+	packToml, err := os.ReadFile(filepath.Join(cityDir, "pack.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(pack.toml): %v", err)
+	}
+	if strings.Contains(string(packToml), "[[agent]]") {
+		t.Fatalf("pack.toml still contains inline agent after doctor --fix:\n%s", packToml)
+	}
+	agentToml, err := os.ReadFile(filepath.Join(cityDir, "agents", "helper", "agent.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(agents/helper/agent.toml): %v", err)
+	}
+	if !strings.Contains(string(agentToml), `provider = "claude"`) {
+		t.Fatalf("agent.toml missing migrated provider:\n%s", agentToml)
 	}
 }
 
@@ -1157,6 +1200,16 @@ includes = ["legacy-pack"]
 	} {
 		if !strings.Contains(got.Message, want) {
 			t.Fatalf("message = %q, want substring %q", got.Message, want)
+		}
+	}
+	for _, want := range []string{
+		"fragment-authored legacy surfaces",
+		"by hand",
+		"gc doctor --fix",
+		"root city.toml/pack.toml",
+	} {
+		if !strings.Contains(got.FixHint, want) {
+			t.Fatalf("fix hint = %q, want substring %q", got.FixHint, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Treat root pack.toml PackV1 [[agent]] tables as a doctor error now that gc doctor --fix can migrate them into agents/<name>/agent.toml.
- Add an explicit doctor --fix coverage case for root pack.toml agent migration.
- Clarify expanded-config-load guidance for fragment-authored legacy surfaces: root city.toml/pack.toml can use gc doctor --fix, fragments still require hand migration.

## Validation
- gofmt -w cmd/gc/cmd_doctor.go cmd/gc/doctor_v2_checks.go cmd/gc/doctor_v2_checks_test.go
- go test ./cmd/gc -run 'TestV2DeprecationChecksErrorsOnRootPackAgentFormat|TestDoctorFixMigratesRootPackAgentFormat|TestExpandedConfigLoadCheckReportsSchema2FragmentErrors' -count=1
- git diff --check

## Note
A broader go test ./cmd/gc run was attempted locally and failed before/away from this slice on machine-local dependencies/state: Dolt v2.0.6 is installed where tests require v2.0.7+, and local /Users/dbox/repos/gc/.gc/system pack state contains a legacy [formulas].dir surface. The new/changed doctor tests passed in isolation.