### PR TITLE
fix(dolt): add bare-GC mode to gc dolt compact (#2615)

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -84,6 +84,27 @@
 #                                         replaced by '_' to derive the env
 #                                         key; DB names that differ only by
 #                                         '-' vs '_' share that key.
+#   GC_DOLT_COMPACT_BARE_GC               (optional) — when set to a truthy
+#                                         value (1, true, yes — matching
+#                                         the GC_DOLT_MANAGED_LOCAL style),
+#                                         skip the commit-count threshold
+#                                         AND the flatten/full-GC path
+#                                         entirely, and run a bare
+#                                         CALL DOLT_GC() on each
+#                                         discovered database. Decouples
+#                                         the working-set GC pass (which
+#                                         resets the NBS journal range
+#                                         index that grows with write
+#                                         churn) from the threshold-gated
+#                                         flatten, so a memory-pressure
+#                                         caller can run a short-cadence
+#                                         GC without rewriting history.
+#                                         Honors GC_DOLT_COMPACT_ONLY_DBS,
+#                                         GC_DOLT_COMPACT_DRY_RUN, and the
+#                                         per-db quarantine marker; does
+#                                         NOT write pending-GC /
+#                                         pending-push markers (those are
+#                                         flatten-remediation state).
 set -eu
 
 : "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
@@ -156,6 +177,20 @@ pending_push_max_age_secs="${GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS:-172800}"
 compact_remote="${GC_DOLT_COMPACT_REMOTE:-}"
 dry_run="${GC_DOLT_COMPACT_DRY_RUN:-}"
 only_dbs="${GC_DOLT_COMPACT_ONLY_DBS:-}"
+bare_gc_input="${GC_DOLT_COMPACT_BARE_GC:-}"
+case "$bare_gc_input" in
+  ''|0|false|FALSE|no|NO)
+    bare_gc=0
+    ;;
+  1|true|TRUE|yes|YES)
+    bare_gc=1
+    ;;
+  *)
+    printf 'compact: invalid GC_DOLT_COMPACT_BARE_GC=%s (must be 1/true/yes or 0/false/no)\n' \
+      "$bare_gc_input" >&2
+    exit 2
+    ;;
+esac
 
 case "$threshold_commits" in
   ''|*[!0-9]*)
@@ -1911,6 +1946,48 @@ flatten_database() {
   return 1
 }
 
+bare_gc_database() {
+  db="$1"
+
+  if [ -n "$only_dbs" ]; then
+    case ",$only_dbs," in
+      *,"$db",*) ;;
+      *)
+        printf 'compact: db=%s not in GC_DOLT_COMPACT_ONLY_DBS — skip\n' "$db"
+        return 0
+        ;;
+    esac
+  fi
+
+  if has_compact_marker "$quarantine_dir" "$db"; then
+    printf 'compact: db=%s integrity quarantine marker exists — manual intervention required before compaction or GC\n' \
+      "$db" >&2
+    return 1
+  fi
+
+  if [ -n "$dry_run" ]; then
+    printf 'compact: db=%s — dry-run (would bare GC)\n' "$db"
+    return 0
+  fi
+
+  start=$(date +%s)
+  gc_rc=0
+  gc_err_tmp=$(mktemp)
+  dolt_query "$db" "CALL DOLT_GC()" >/dev/null 2>"$gc_err_tmp" || gc_rc=$?
+  elapsed=$(( $(date +%s) - start ))
+  if [ "$gc_rc" -ne 0 ]; then
+    printf 'compact: db=%s bare-gc failed rc=%s duration=%ss\n' \
+      "$db" "$gc_rc" "$elapsed" >&2
+    emit_error_file "$db" "$gc_err_tmp"
+    rm -f "$gc_err_tmp"
+    return 1
+  fi
+  rm -f "$gc_err_tmp"
+
+  printf 'compact: db=%s bare-gc duration=%ss — ok\n' "$db" "$elapsed"
+  return 0
+}
+
 # shellcheck disable=SC2317
 cleanup() {
   if [ "$flock_acquired" = "1" ]; then
@@ -2080,6 +2157,21 @@ main() {
   done < "$_db_tmp"
 
   failed_count=0
+  if [ "$bare_gc" = "1" ]; then
+    while IFS= read -r db; do
+      [ -n "$db" ] || continue
+      if ! bare_gc_database "$db"; then
+        failed_count=$((failed_count + 1))
+      fi
+    done < "$_unique_db_tmp"
+
+    if [ "$failed_count" -gt 0 ]; then
+      printf 'compact: %s database(s) failed bare GC\n' "$failed_count" >&2
+      exit 1
+    fi
+    exit 0
+  fi
+
   while IFS= read -r db; do
     [ -n "$db" ] || continue
     if ! flatten_database "$db"; then

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -164,6 +164,7 @@ func (f compactScriptFixture) run(t *testing.T, mode string, extraEnv ...string)
 		"GC_DOLT_COMPACT_DRY_RUN",
 		"GC_DOLT_COMPACT_ONLY_DBS",
 		"GC_DOLT_COMPACT_REMOTE",
+		"GC_DOLT_COMPACT_BARE_GC",
 		"GC_FAKE_DOLT_COMPACT_MODE",
 		"GC_FAKE_DOLT_COUNT_FILE",
 		"GC_FAKE_DOLT_STATE_FILE",

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -2827,6 +2827,203 @@ func TestCompactScriptTableNameDoesNotClobberDatabaseName(t *testing.T) {
 	}
 }
 
+// Bare-GC mode (issue #2615): GC_DOLT_COMPACT_BARE_GC=1 must bypass the
+// threshold + flatten path and run a single bare CALL DOLT_GC() per
+// discovered database. The full DOLT_GC --full path is the wrong tool for
+// the NBS journal range index — a working-set GC (bare DOLT_GC()) resets
+// the index without rewriting history.
+
+func TestCompactScriptBareGCBypassesThresholdAndSkipsFlatten(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "below_threshold",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_BARE_GC=1")
+	if err != nil {
+		t.Fatalf("bare-gc compact failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "db=beads bare-gc duration=") {
+		t.Fatalf("bare-gc output missing success line:\n%s", out)
+	}
+	if strings.Contains(out, "below_threshold=") {
+		t.Fatalf("bare-gc must skip the threshold gate:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	for _, forbidden := range []string{"DOLT_RESET", "DOLT_COMMIT", "DOLT_PUSH", "DOLT_FETCH"} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("bare-gc must not issue %s:\n%s", forbidden, log)
+		}
+	}
+	if !strings.Contains(log, "CALL DOLT_GC()") {
+		t.Fatalf("bare-gc must issue bare CALL DOLT_GC():\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_GC('--full')") {
+		t.Fatalf("bare-gc must NOT run --full:\n%s", log)
+	}
+}
+
+func TestCompactScriptBareGCDryRunSkipsMutations(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_BARE_GC=1",
+		"GC_DOLT_COMPACT_DRY_RUN=1")
+	if err != nil {
+		t.Fatalf("bare-gc dry-run failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "dry-run (would bare GC)") {
+		t.Fatalf("bare-gc dry-run output missing explanation:\n%s", out)
+	}
+	// Bare-GC dry-run issues no dolt queries at all, so the fake dolt log
+	// may not exist. Tolerate that and assert only on presence.
+	if logData, err := os.ReadFile(fixture.doltLog); err == nil {
+		if strings.Contains(string(logData), "DOLT_GC") {
+			t.Fatalf("bare-gc dry-run must not issue DOLT_GC:\n%s", logData)
+		}
+	}
+}
+
+func TestCompactScriptBareGCHonorsOnlyDBsAllowlist(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	if err := os.MkdirAll(filepath.Join(fixture.dataDir, "cache", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir cache db: %v", err)
+	}
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_BARE_GC=1",
+		"GC_DOLT_COMPACT_ONLY_DBS=beads")
+	if err != nil {
+		t.Fatalf("bare-gc allowlist compact failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "db=cache not in GC_DOLT_COMPACT_ONLY_DBS") {
+		t.Fatalf("bare-gc output missing allowlist skip:\n%s", out)
+	}
+	if !strings.Contains(out, "db=beads bare-gc duration=") {
+		t.Fatalf("bare-gc output missing success for allowlisted db:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "db=cache query=") {
+		t.Fatalf("non-allowlisted database should not receive dolt queries:\n%s", log)
+	}
+	if !strings.Contains(log, "db=beads query=CALL DOLT_GC()") {
+		t.Fatalf("allowlisted database was not bare-GC'd:\n%s", log)
+	}
+}
+
+func TestCompactScriptBareGCRefusesQuarantinedDatabase(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	quarantineMarker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if err := os.MkdirAll(filepath.Dir(quarantineMarker), 0o755); err != nil {
+		t.Fatalf("mkdir quarantine dir: %v", err)
+	}
+	if err := os.WriteFile(quarantineMarker, []byte("db=beads\nreason=test\ncreated_at=2026-05-01T00:00:00Z\n"), 0o600); err != nil {
+		t.Fatalf("write quarantine marker: %v", err)
+	}
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_BARE_GC=1")
+	if err == nil {
+		t.Fatalf("bare-gc must fail when quarantine marker exists:\n%s", out)
+	}
+	if !strings.Contains(out, "integrity quarantine marker exists") {
+		t.Fatalf("bare-gc output missing quarantine explanation:\n%s", out)
+	}
+	// Quarantine refusal exits before any dolt query, so the fake dolt log
+	// may not exist. Tolerate that and assert only on presence.
+	if logData, err := os.ReadFile(fixture.doltLog); err == nil {
+		if strings.Contains(string(logData), "DOLT_GC") {
+			t.Fatalf("quarantined database must not be bare-GC'd:\n%s", logData)
+		}
+	}
+}
+
+func TestCompactScriptBareGCSurfacesDoltGCFailureStderr(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "gc_failure",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_BARE_GC=1")
+	if err == nil {
+		t.Fatalf("bare-gc must fail when DOLT_GC fails:\n%s", out)
+	}
+	if !strings.Contains(out, "gc exploded") {
+		t.Fatalf("bare-gc output missing Dolt GC stderr:\n%s", out)
+	}
+	if !strings.Contains(out, "bare-gc failed rc=") {
+		t.Fatalf("bare-gc output missing failure summary:\n%s", out)
+	}
+	if !strings.Contains(out, "1 database(s) failed bare GC") {
+		t.Fatalf("bare-gc output missing per-run failure tally:\n%s", out)
+	}
+	// Bare GC must NOT write flatten-bookkeeping markers — those describe
+	// flatten remediation state that bare GC never enters.
+	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
+	if _, err := os.Stat(pendingGC); !os.IsNotExist(err) {
+		t.Fatalf("bare-gc failure must not write pending-GC marker, stat err=%v", err)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
+		t.Fatalf("bare-gc failure must not write pending-push marker, stat err=%v", err)
+	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if _, err := os.Stat(quarantine); !os.IsNotExist(err) {
+		t.Fatalf("bare-gc failure must not write quarantine marker, stat err=%v", err)
+	}
+}
+
+func TestCompactScriptBareGCRejectsInvalidValue(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_BARE_GC=bogus")
+	if err == nil {
+		t.Fatalf("bare-gc must reject invalid value:\n%s", out)
+	}
+	if !strings.Contains(out, "invalid GC_DOLT_COMPACT_BARE_GC=bogus") {
+		t.Fatalf("bare-gc output missing invalid-value diagnostic:\n%s", out)
+	}
+	// Invalid env exits during validation, before any dolt query, so the
+	// fake dolt log may not exist. Tolerate that and assert only on
+	// presence.
+	if logData, err := os.ReadFile(fixture.doltLog); err == nil {
+		if strings.Contains(string(logData), "DOLT_GC") {
+			t.Fatalf("invalid env value must exit before any DOLT_GC call:\n%s", logData)
+		}
+	}
+}
+
+func TestCompactScriptBareGCDisabledWhenEnvFalsy(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "below_threshold",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_BARE_GC=0")
+	if err != nil {
+		t.Fatalf("falsy bare-gc compact failed: %v\n%s", err, out)
+	}
+	// Falsy bare-gc must fall through to the normal threshold-gated path:
+	// in below_threshold mode that means the standard "below_threshold" skip
+	// line, NOT a bare-GC success.
+	if !strings.Contains(out, "below_threshold=500") {
+		t.Fatalf("falsy bare-gc must defer to the threshold path:\n%s", out)
+	}
+	if strings.Contains(out, "bare-gc") {
+		t.Fatalf("falsy bare-gc must not execute the bare-GC path:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(logData), "DOLT_GC") {
+		t.Fatalf("falsy bare-gc + below threshold must not call DOLT_GC:\n%s", logData)
+	}
+}
+
 func TestPhantomDBScriptEscalatesAndPreservesAllDatabases(t *testing.T) {
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "dolt-data")


### PR DESCRIPTION
## What

Add `GC_DOLT_COMPACT_BARE_GC` to `examples/dolt/commands/compact/run.sh`. When the env var is truthy, the script skips the commit-count threshold AND the flatten + full-GC path, and runs a bare `CALL DOLT_GC()` on every discovered (non-system) database — bounded by `GC_DOLT_COMPACT_CALL_TIMEOUT_SECS`, honoring `GC_DOLT_COMPACT_ONLY_DBS`, `GC_DOLT_COMPACT_DRY_RUN`, and the integrity quarantine marker. No `--full`, no flatten, no remote push, no pending-* markers (those describe flatten-remediation state that bare GC never enters).

Default behavior with the variable unset is byte-identical to today.

## Why

`gc dolt compact` only does anything when a database has crossed `GC_DOLT_COMPACT_THRESHOLD_COMMITS` (default 2000). Cities whose databases are all below the threshold therefore never get any `DOLT_GC`, and the managed Dolt server's NBS journal range index — which grows with write *churn*, not graph length — keeps growing until `dolt-rss-guard` graceful-restarts the server. Commit count is the wrong gate for that cost.

Lowering the threshold is not a fix (wrong metric; also re-opens the writer-race window #2564 already closed). What's needed is a working-set `DOLT_GC()` pass that is decoupled from flatten.

Fixes #2615.

## What this PR does NOT do (explicit scope cut)

Issue #2615 lists three "maintainer's call" directions:

- **(A)** `dolt-rss-guard` issues `CALL DOLT_GC()` at a soft threshold before the hard restart.
- **(B)** A new periodic GC order (~30-60 min) decoupled from flatten.
- **(C)** A bare-GC mode in `gc dolt compact`.

This PR is **(C) only**. It adds the *mechanism* — a bare-GC mode toggle on the existing compact script — so the maintainer can wire (A) or (B) on top without re-implementing GC orchestration. **The scheduling / wiring step is intentionally left out.** I picked (C) because:

- It's the smallest contained change (one new env-gated branch in one existing script).
- It reuses every existing primitive (lock acquisition, db discovery, allowlist filter, system-db skip, dry-run gate, quarantine marker, managed-port resolution).
- It is orthogonal to (A) and (B): either can call the mode unchanged.

Happy to fold the scheduling into this PR, change the public surface (e.g. expose as a `gc dolt` subcommand flag rather than an env var), or close in favor of a different direction — whichever you'd prefer.

## How it works

- `GC_DOLT_COMPACT_BARE_GC` accepts `1|true|TRUE|yes|YES` (truthy) or `0|false|FALSE|no|NO`/unset (falsy). Anything else exits 2 with a diagnostic, matching the existing `GC_DOLT_COMPACT_*` validation style.
- In `main()`, after the cross-city flock + db discovery, if the mode is truthy the script iterates each discovered db and calls a new `bare_gc_database()` helper that:
  - honors `GC_DOLT_COMPACT_ONLY_DBS` (same case-statement as `flatten_database`),
  - refuses when a quarantine marker exists for the db (manual intervention still required),
  - honors `GC_DOLT_COMPACT_DRY_RUN` (prints `dry-run (would bare GC)` and returns 0),
  - runs `CALL DOLT_GC()` via the existing `dolt_query` (no `--full`, bounded by `GC_DOLT_COMPACT_CALL_TIMEOUT_SECS`),
  - emits `compact: db=<db> bare-gc duration=<n>s — ok` on success and `compact: db=<db> bare-gc failed rc=<rc> duration=<n>s` (followed by the underlying stderr) on failure.
- The aggregate line is `compact: <n> database(s) failed bare GC` with the same exit-1-on-any-failure semantics as the flatten path.
- `bare_gc_database()` does NOT write `compact-pending-gc/` or `compact-pending-push/` markers — those describe flatten-remediation state that bare GC never enters.

## Tests

7 new tests, all in `examples/dolt/dog_exec_scripts_test.go`, all using the existing `compactScriptFixture` and the existing fake-dolt harness:

- `TestCompactScriptBareGCBypassesThresholdAndSkipsFlatten` — bypasses threshold, calls `CALL DOLT_GC()` (not `--full`), does NOT call `DOLT_RESET`/`DOLT_COMMIT`/`DOLT_PUSH`/`DOLT_FETCH`.
- `TestCompactScriptBareGCDryRunSkipsMutations` — bare-GC + dry-run = no DOLT_GC call.
- `TestCompactScriptBareGCHonorsOnlyDBsAllowlist` — non-allowlisted db is skipped without queries.
- `TestCompactScriptBareGCRefusesQuarantinedDatabase` — pre-existing quarantine marker blocks the bare-GC path.
- `TestCompactScriptBareGCSurfacesDoltGCFailureStderr` — DOLT_GC failure: stderr surfaced, exit non-zero, no flatten-remediation markers written.
- `TestCompactScriptBareGCRejectsInvalidValue` — invalid env value exits 2 before any DOLT call.
- `TestCompactScriptBareGCDisabledWhenEnvFalsy` — `=0` falls through to the normal threshold-gated path.

Also adds `GC_DOLT_COMPACT_BARE_GC` to the `compactScriptFixture.run` env-blocklist so an inherited shell value cannot leak into existing `TestCompactScript*` tests (surfaced by self-review).

## Pre-push gates

Verified locally on `upstream/main` (`0f50effe7 chore: pin Dolt to 2.0.7 (#2683)`):

- `make check` (`fmt-check` + `lint` + `vet` + `check-routed-test-rows` + `test ./...`) — green.
- `go test ./examples/dolt/... -count=1` (including the new tests, with the parent shell setting `GC_DOLT_COMPACT_BARE_GC=1` to prove the env-blocklist scrub works) — green.
- No docs / schema / dashboard files touched; `make check-docs` and `make dashboard-check` not applicable.

## Diff size

2 files changed, 290 insertions(+), 0 deletions(-). One commit per the contributor convention; the test-isolation fix is split into a follow-up commit for review clarity.

```
examples/dolt/commands/compact/run.sh  |  92 +++++++++++++++
examples/dolt/dog_exec_scripts_test.go | 198 +++++++++++++++++++++++++++++++++
```
