### PR TITLE
docs: use GitHub raw URLs for schema downloads

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,26 +70,6 @@
       "destination": "/guides/migrating-to-pack-vnext"
     },
     {
-      "source": "/schema/openapi.txt",
-      "destination": "/schema/openapi.json",
-      "permanent": false
-    },
-    {
-      "source": "/schema/events.txt",
-      "destination": "/schema/events.json",
-      "permanent": false
-    },
-    {
-      "source": "/schema/city-schema.txt",
-      "destination": "/schema/city-schema.json",
-      "permanent": false
-    },
-    {
-      "source": "/schema/pack-schema.txt",
-      "destination": "/schema/pack-schema.json",
-      "permanent": false
-    },
-    {
       "source": "/tutorials/01-cities-and-rigs.md",
       "destination": "/tutorials/01-cities-and-rigs"
     },

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -7,13 +7,13 @@ The `gc` supervisor exposes a single, typed HTTP control plane
 described by an OpenAPI 3.1 document. Everything the CLI does, any
 third-party client can do too — there is no hidden surface.
 
-## Download the spec
+## Get the spec
 
-- **<a href="/schema/openapi.txt" download="openapi.json">Download openapi.json</a>** —
+- **<a href="https://raw.githubusercontent.com/gastownhall/gascity/main/docs/schema/openapi.json" target="_blank" rel="noopener">openapi.json</a>** —
   the authoritative contract. Drop it into Stoplight, Postman,
   Swagger UI, or any OpenAPI-aware tool to browse operations
   interactively.
-- **<a href="/schema/events.txt" download="events.json">Download events.json</a>** —
+- **<a href="https://raw.githubusercontent.com/gastownhall/gascity/main/docs/schema/events.json" target="_blank" rel="noopener">events.json</a>** —
   the `gc events` JSONL line schema. It references DTO components in
   `openapi.json`, so the API remains the source of truth.
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -156,7 +156,7 @@ payload objects. For example, use
 
 ## Machine-Readable Schema
 
-The downloadable <a href="/schema/events.txt" download="events.json">events.json</a>
+The <a href="https://raw.githubusercontent.com/gastownhall/gascity/main/docs/schema/events.json" target="_blank" rel="noopener">events.json</a>
 schema validates one JSON object line from list, watch, or follow mode. It
 contains only framing metadata and `$ref`s into `openapi.json`:
 

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -4,16 +4,15 @@ description: Machine-readable schema artifacts published with the Gas City docs.
 ---
 
 This section publishes generated schema artifacts for tooling. The canonical
-JSON files stay in `docs/schema/`, and the download links below use text mirrors
-with hosted redirects so local preview and production both offer a working file
-download.
+JSON files stay in `docs/schema/`, and the links below open the GitHub-hosted
+raw artifacts so they work in both local preview and production.
 
 ## OpenAPI 3.1
 
 The supervisor HTTP and SSE control plane is published as a raw OpenAPI
 document:
 
-- <a href="/schema/openapi.txt" download="openapi.json">Download <code>openapi.json</code></a>
+- <a href="https://raw.githubusercontent.com/gastownhall/gascity/main/docs/schema/openapi.json" target="_blank" rel="noopener"><code>openapi.json</code></a>
 
 Use this file with Swagger UI, Stoplight, Postman, or client generators. To
 regenerate it from the live supervisor schema:
@@ -30,7 +29,7 @@ the [Supervisor REST API](/reference/api) page.
 `gc events` list/watch/follow output is published as a small JSON Schema that
 references the OpenAPI DTO components instead of duplicating their fields:
 
-- <a href="/schema/events.txt" download="events.json">Download <code>events.json</code></a>
+- <a href="https://raw.githubusercontent.com/gastownhall/gascity/main/docs/schema/events.json" target="_blank" rel="noopener"><code>events.json</code></a>
 
 Use this file to validate one JSON object line emitted by `gc events`,
 `gc events --watch`, or `gc events --follow`. Cursor mode is intentionally
@@ -46,7 +45,7 @@ behavior, heartbeat suppression, and cursor formats, see
 The `city.toml` configuration schema is also published as a raw JSON Schema
 document:
 
-- <a href="/schema/city-schema.txt" download="city-schema.json">Download <code>city-schema.json</code></a>
+- <a href="https://raw.githubusercontent.com/gastownhall/gascity/main/docs/schema/city-schema.json" target="_blank" rel="noopener"><code>city-schema.json</code></a>
 
 Use this file for validation, editor integration, and external tooling. To
 regenerate it:

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -25,8 +25,9 @@ func repoRoot() string {
 }
 
 var (
-	markdownLinkRE = regexp.MustCompile(`\[[^][]+\]\(([^)]+)\)`)
-	schemaHrefRE   = regexp.MustCompile(`href="/schema/([^"#?]+)"`)
+	markdownLinkRE    = regexp.MustCompile(`\[[^][]+\]\(([^)]+)\)`)
+	schemaHrefRE      = regexp.MustCompile(`href="[^"]*?/schema/([^"#?]+)"`)
+	schemaGitHubRawRE = regexp.MustCompile(`href="https://raw\.githubusercontent\.com/gastownhall/gascity/main/docs/schema/([^"#?]+)"`)
 )
 
 // docTreeDirs lists the top-level directories that are documentation trees
@@ -49,9 +50,8 @@ var knownBrokenLinks = map[string]bool{
 	"contrib/session-scripts/README.md -> ../../docs/k8s-guide.md": true,
 }
 
-func TestSchemaDownloadLinksUseTxtMirrorsWithHostedRedirects(t *testing.T) {
+func TestSchemaDownloadLinksUseGitHubRaw(t *testing.T) {
 	root := repoRoot()
-	redirects := schemaRedirects(t, root)
 	docs := []string{
 		"docs/reference/api.md",
 		"docs/reference/events.md",
@@ -66,77 +66,21 @@ func TestSchemaDownloadLinksUseTxtMirrorsWithHostedRedirects(t *testing.T) {
 		}
 		for _, match := range schemaHrefRE.FindAllStringSubmatch(string(data), -1) {
 			target := match[1]
-			if filepath.Ext(target) != ".txt" {
-				t.Errorf("%s links /schema/%s; local Mintlify preview serves schema downloads through .txt mirrors", rel, target)
+			if filepath.Ext(target) != ".json" {
+				t.Errorf("%s links /schema/%s; schema downloads must use .json", rel, target)
 				continue
 			}
-			txtArtifact := filepath.Join(root, "docs", "schema", filepath.FromSlash(target))
-			if _, err := os.Stat(txtArtifact); err != nil {
-				t.Errorf("%s links /schema/%s but %s is not committed: %v", rel, target, txtArtifact, err)
+			ghMatch := schemaGitHubRawRE.FindStringSubmatch(match[0])
+			if ghMatch == nil {
+				t.Errorf("%s links /schema/%s via relative path; use GitHub raw URL so downloads work in both local preview and production", rel, target)
+				continue
 			}
-
-			jsonTarget := strings.TrimSuffix(target, ".txt") + ".json"
-			jsonArtifact := filepath.Join(root, "docs", "schema", filepath.FromSlash(jsonTarget))
-			if _, err := os.Stat(jsonArtifact); err != nil {
-				t.Errorf("%s links /schema/%s but hosted redirect target %s is not committed: %v", rel, target, jsonArtifact, err)
-			}
-
-			source := "/schema/" + target
-			destination := "/schema/" + jsonTarget
-			if redirects[source] != destination {
-				t.Errorf("docs.json redirects[%q] = %q, want %q", source, redirects[source], destination)
+			artifact := filepath.Join(root, "docs", "schema", filepath.FromSlash(target))
+			if _, err := os.Stat(artifact); err != nil {
+				t.Errorf("%s links /schema/%s but %s is not committed: %v", rel, target, artifact, err)
 			}
 		}
 	}
-}
-
-func TestSchemaTxtMirrorsRedirectToHostedJSONArtifacts(t *testing.T) {
-	root := repoRoot()
-	redirects := schemaRedirects(t, root)
-	entries, err := os.ReadDir(filepath.Join(root, "docs", "schema"))
-	if err != nil {
-		t.Fatalf("read docs/schema: %v", err)
-	}
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || filepath.Ext(name) != ".txt" {
-			continue
-		}
-		jsonName := strings.TrimSuffix(name, ".txt") + ".json"
-		jsonPath := filepath.Join(root, "docs", "schema", jsonName)
-		if _, err := os.Stat(jsonPath); err != nil {
-			t.Errorf("docs/schema/%s has no JSON artifact for hosted redirect: %v", name, err)
-			continue
-		}
-
-		source := "/schema/" + name
-		destination := "/schema/" + jsonName
-		if redirects[source] != destination {
-			t.Errorf("docs.json redirects[%q] = %q, want %q", source, redirects[source], destination)
-		}
-	}
-}
-
-func schemaRedirects(t *testing.T, root string) map[string]string {
-	t.Helper()
-	data, err := os.ReadFile(filepath.Join(root, "docs", "docs.json"))
-	if err != nil {
-		t.Fatalf("read docs/docs.json: %v", err)
-	}
-	var docs struct {
-		Redirects []struct {
-			Source      string `json:"source"`
-			Destination string `json:"destination"`
-		} `json:"redirects"`
-	}
-	if err := json.Unmarshal(data, &docs); err != nil {
-		t.Fatalf("parse docs/docs.json: %v", err)
-	}
-	redirects := make(map[string]string, len(docs.Redirects))
-	for _, redirect := range docs.Redirects {
-		redirects[redirect.Source] = redirect.Destination
-	}
-	return redirects
 }
 
 func allDocsMarkdownFiles(root string) ([]string, error) {


### PR DESCRIPTION
## Summary
- Switch all schema download links to GitHub raw URLs so they work in both `mintlify dev` (local) and production
- Add `target="_blank"` to bypass Mintlify's SPA router click interception
- Remove dead `.txt` → `.json` redirect entries from `docs.json`
- Update docsync test to enforce GitHub raw URL pattern

## Why
Mintlify dev doesn't serve `.json` files locally. Mintlify production doesn't serve `.txt` (non-Enterprise). No single relative path works in both environments. GitHub raw URLs bypass both limitations.

Closes #2596

🤖 Generated with [Claude Code](https://claude.com/claude-code)