### PR TITLE
Refuse tmux attach to dead panes

### DIFF
--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -631,16 +631,19 @@ func (p *Provider) CopyTo(name, src, relDst string) error {
 }
 
 // Attach connects the user's terminal to the named tmux session.
-// This hands stdin/stdout/stderr to tmux and blocks until detach.
+// It returns [runtime.ErrSessionNotFound] when the session is absent and
+// refuses to attach to tmux remain-on-exit dead panes with a tmux-specific
+// message-only error. Pane-state query failures fall through to tmux attach.
 func (p *Provider) Attach(name string) error {
-	if !p.tm.IsSessionRunning(name) {
-		has, err := p.tm.HasSession(name)
-		if err != nil {
-			return fmt.Errorf("checking tmux session before attach: %w", err)
-		}
-		if !has {
-			return fmt.Errorf("%w: %s", ErrSessionNotFound, name)
-		}
+	has, err := p.tm.HasSession(name)
+	if err != nil {
+		return fmt.Errorf("checking tmux session before attach: %w", err)
+	}
+	if !has {
+		return fmt.Errorf("%w: %w: %s", runtime.ErrSessionNotFound, ErrSessionNotFound, name)
+	}
+	dead, err := p.tm.IsPaneDead(name)
+	if err == nil && dead {
 		return fmt.Errorf("refusing to attach to dead pane for session %q", name)
 	}
 	args := []string{"-u"}

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -633,6 +633,16 @@ func (p *Provider) CopyTo(name, src, relDst string) error {
 // Attach connects the user's terminal to the named tmux session.
 // This hands stdin/stdout/stderr to tmux and blocks until detach.
 func (p *Provider) Attach(name string) error {
+	if !p.tm.IsSessionRunning(name) {
+		has, err := p.tm.HasSession(name)
+		if err != nil {
+			return fmt.Errorf("checking tmux session before attach: %w", err)
+		}
+		if !has {
+			return fmt.Errorf("%w: %s", ErrSessionNotFound, name)
+		}
+		return fmt.Errorf("refusing to attach to dead pane for session %q", name)
+	}
 	args := []string{"-u"}
 	if p.cfg.SocketName != "" {
 		args = append(args, "-L", p.cfg.SocketName)

--- a/internal/runtime/tmux/adapter_unit_test.go
+++ b/internal/runtime/tmux/adapter_unit_test.go
@@ -1,8 +1,11 @@
 package tmux
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/runtime"
 )
 
 func TestProviderAttachRefusesDeadPane(t *testing.T) {
@@ -22,6 +25,48 @@ func TestProviderAttachRefusesDeadPane(t *testing.T) {
 	for _, call := range fe.calls {
 		if strings.Contains(strings.Join(call, " "), "attach-session") {
 			t.Fatalf("Attach attempted tmux attach-session for dead pane: %v", fe.calls)
+		}
+	}
+}
+
+func TestProviderAttachMissingSessionWrapsRuntimeSentinel(t *testing.T) {
+	fe := &fakeExecutor{
+		err: ErrSessionNotFound,
+	}
+	p := NewProviderWithConfig(Config{SocketName: "x"})
+	p.tm.exec = fe
+
+	err := p.Attach("runner")
+	if !errors.Is(err, runtime.ErrSessionNotFound) {
+		t.Fatalf("Attach error = %v, want runtime.ErrSessionNotFound", err)
+	}
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("Attach error = %v, want tmux ErrSessionNotFound", err)
+	}
+	for _, call := range fe.calls {
+		if strings.Contains(strings.Join(call, " "), "attach-session") {
+			t.Fatalf("Attach attempted tmux attach-session for missing session: %v", fe.calls)
+		}
+	}
+}
+
+func TestProviderAttachReportsHasSessionError(t *testing.T) {
+	fe := &fakeExecutor{
+		err: errors.New("tmux unavailable"),
+	}
+	p := NewProviderWithConfig(Config{SocketName: "x"})
+	p.tm.exec = fe
+
+	err := p.Attach("runner")
+	if err == nil {
+		t.Fatal("Attach = nil, want has-session error")
+	}
+	if !strings.Contains(err.Error(), "checking tmux session before attach") {
+		t.Fatalf("Attach error = %v, want checking context", err)
+	}
+	for _, call := range fe.calls {
+		if strings.Contains(strings.Join(call, " "), "attach-session") {
+			t.Fatalf("Attach attempted tmux attach-session after has-session error: %v", fe.calls)
 		}
 	}
 }

--- a/internal/runtime/tmux/adapter_unit_test.go
+++ b/internal/runtime/tmux/adapter_unit_test.go
@@ -1,0 +1,27 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProviderAttachRefusesDeadPane(t *testing.T) {
+	fe := &fakeExecutor{
+		outs: []string{"", "1"},
+	}
+	p := NewProviderWithConfig(Config{SocketName: "x"})
+	p.tm.exec = fe
+
+	err := p.Attach("runner")
+	if err == nil {
+		t.Fatal("Attach = nil, want dead pane error")
+	}
+	if !strings.Contains(err.Error(), "dead pane") {
+		t.Fatalf("Attach error = %v, want dead pane context", err)
+	}
+	for _, call := range fe.calls {
+		if strings.Contains(strings.Join(call, " "), "attach-session") {
+			t.Fatalf("Attach attempted tmux attach-session for dead pane: %v", fe.calls)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Refuse `tmux attach-session` when the target tmux session only has a dead remain-on-exit pane.
- Return a clear dead-pane error instead of handing the operator to an unusable pane.
- Add a unit regression test that verifies attach does not invoke `tmux attach-session` for a dead pane.

## Tests

- `go test ./internal/runtime/tmux -run TestProviderAttachRefusesDeadPane -count=1`
- `go test ./internal/runtime/tmux -count=1`
- `go test ./internal/session -run 'TestAttach|Test.*Session' -count=1`
- `go test ./cmd/gc -run 'Test.*Attach|Test.*Session' -count=1`
- `git diff --check`
