### PR TITLE
Add local-only Beads config for gascity

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,10 @@
+issue_prefix: ga
+issue-prefix: ga
+dolt.auto-start: false
+dolt.local-only: true
+dolt.auto-push: false
+no-push: true
+export.auto: false
+gc.endpoint_origin: inherited_city
+gc.endpoint_status: verified
+types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step

--- a/release-gates/ga-qn7lno-dolt-local-only-gate.md
+++ b/release-gates/ga-qn7lno-dolt-local-only-gate.md
@@ -1,0 +1,36 @@
+# Release gate - gascity Beads local-only config (ga-qn7lno / ga-o8pmyw.1)
+
+**Verdict:** PASS
+
+- Deployer bead: `ga-qn7lno` (review of source bead `ga-o8pmyw.1`)
+- Branch: `release/ga-qn7lno-dolt-local-only`
+- Implementation commit: `58cd64b09` cherry-picked from reviewed commit `61095ea9f`
+- Base: `origin/main` at `81df5a3cc`
+- Diff before gate file: `.beads/config.yaml` only, 10 inserted lines
+- Project manifest: `docs/PROJECT_MANIFEST.md` is not present in this repo; no extra project-specific release criteria were found.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `ga-qn7lno` notes contain `Review verdict: PASS` from `gascity/reviewer` for commit `61095ea9f`. |
+| 2 | Acceptance criteria met | PASS | `.beads/config.yaml` contains `dolt.local-only: true`, preserves `dolt.auto-push: false` and `no-push: true`, and source bead `ga-o8pmyw.1` records the exact observed config lines. Deployer did not run `bd dolt push`. |
+| 3 | Tests pass | PASS | `make test` passed on the assembled branch (`observable go test: PASS log=/tmp/gascity-test.jsonl.uGmx7R`). `go vet ./...` also passed. |
+| 4 | No high-severity review findings open | PASS | Review notes contain no HIGH findings; reviewer listed only confirming findings and a PASS verdict. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file; after this file is committed, the branch contains only the reviewed config change plus this release gate. |
+| 6 | Branch diverges cleanly from main | PASS | Branch was created with `git checkout -B release/ga-qn7lno-dolt-local-only origin/main`; `git cherry-pick 61095ea9f` completed without conflict; `origin/main` is an ancestor of HEAD. |
+| 7 | Single feature theme | PASS | The commit set touches only the Beads safety config for the Gas City repo (`.beads/config.yaml`), one subsystem and one operator-visible behavior: local-only Dolt sync protection. |
+
+## Validation
+
+- `git fetch origin main` - PASS
+- `git cherry-pick 61095ea9f` - PASS, no conflicts
+- `sed -n '1,80p' .beads/config.yaml` - confirmed `dolt.local-only: true`, `dolt.auto-push: false`, and `no-push: true`
+- `git diff --check origin/main...HEAD` - PASS
+- `make test` - PASS
+- `go vet ./...` - PASS
+- `git merge-base --is-ancestor origin/main HEAD` - PASS
+
+## Push target
+
+`git push --dry-run origin HEAD` succeeded; push target is `origin`.


### PR DESCRIPTION
## What this changes

Adds a repository-level `.beads/config.yaml` for Gas City that marks the Beads/Dolt store as local-only. It preserves the disabled auto-push and no-push settings so normal Beads operations do not try to publish this local store.

Operators get explicit local-only protection checked into the repo instead of relying on ambient local state. This is a config-only change; no Go runtime behavior or public API changes.

## Review notes

- New file `.beads/config.yaml` includes the Gas City issue prefix plus the existing Beads safety values.
- The important safety knobs are `dolt.local-only: true`, `dolt.auto-push: false`, and `no-push: true`.
- No generated files, API schemas, or Go code paths change.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] Release gate: [`release-gates/ga-qn7lno-dolt-local-only-gate.md`](release-gates/ga-qn7lno-dolt-local-only-gate.md)