### PR TITLE
Clarify always startup failure status

### DIFF
--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1850,6 +1850,44 @@ func TestHandleSessionListIncludesReason(t *testing.T) {
 	}
 }
 
+func TestHandleSessionListShowsAlwaysStartupFailureReason(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "Mayor")
+	if err := fs.cityBeadStore.SetMetadataBatch(info.ID, map[string]string{
+		"state":                 "asleep",
+		"configured_named_mode": "always",
+		"sleep_reason":          "context-churn",
+		"churn_count":           "3",
+		"quarantined_until":     time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("set startup failure metadata: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/sessions"), nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body struct {
+		Items []sessionResponse `json:"items"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Items) != 1 {
+		t.Fatalf("got %d items, want 1", len(body.Items))
+	}
+	if body.Items[0].Reason != "startup-failure" {
+		t.Fatalf("reason = %q, want startup-failure", body.Items[0].Reason)
+	}
+}
+
 func TestHandleSessionListShowsResetPendingForLiveRuntime(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -311,9 +311,13 @@ func lifecycleDisplayReasonFromView(view LifecycleView, metadata map[string]stri
 }
 
 func lifecycleStartupFailureReasonVisible(view LifecycleView, metadata map[string]string, reason string) bool {
-	return reason == "context-churn" &&
-		view.HasBlocker(BlockerQuarantined) &&
-		strings.TrimSpace(metadata[NamedSessionModeMetadata]) == "always"
+	if !view.HasBlocker(BlockerQuarantined) || strings.TrimSpace(metadata[NamedSessionModeMetadata]) != "always" {
+		return false
+	}
+	if reason == "context-churn" {
+		return true
+	}
+	return reason == "quarantine" && strings.TrimSpace(metadata["wake_attempts"]) != "" && strings.TrimSpace(metadata["wake_attempts"]) != "0"
 }
 
 func lifecycleResetPendingReasonVisible(view LifecycleView, metadata map[string]string, sessionName string, isRunning func(string) bool) bool {

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -225,6 +225,8 @@ const (
 	SessionCircuitStateOpen = "CIRCUIT_OPEN"
 	// SessionCircuitStateClosed is the durable metadata value for a closed session circuit breaker.
 	SessionCircuitStateClosed = "CIRCUIT_CLOSED"
+
+	lifecycleStartupFailureReason = "startup-failure"
 )
 
 // LifecycleDisplayReason returns the user-facing reason for a non-closed
@@ -289,6 +291,9 @@ func lifecycleDisplayReasonFromView(view LifecycleView, metadata map[string]stri
 		staleTimedHold := reason == "user-hold" &&
 			strings.TrimSpace(metadata["held_until"]) != "" &&
 			!view.HasBlocker(BlockerHeld)
+		if !staleTimedQuarantine && lifecycleStartupFailureReasonVisible(view, metadata, reason) {
+			return lifecycleStartupFailureReason
+		}
 		if !staleTimedQuarantine && !staleTimedHold {
 			return reason
 		}
@@ -303,6 +308,12 @@ func lifecycleDisplayReasonFromView(view LifecycleView, metadata map[string]stri
 		return "user-hold"
 	}
 	return ""
+}
+
+func lifecycleStartupFailureReasonVisible(view LifecycleView, metadata map[string]string, reason string) bool {
+	return reason == "context-churn" &&
+		view.HasBlocker(BlockerQuarantined) &&
+		strings.TrimSpace(metadata[NamedSessionModeMetadata]) == "always"
 }
 
 func lifecycleResetPendingReasonVisible(view LifecycleView, metadata map[string]string, sessionName string, isRunning func(string) bool) bool {

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -689,6 +689,17 @@ func TestLifecycleDisplayReasonUsesOnlyActiveLifecycleReasons(t *testing.T) {
 			want: "startup-failure",
 		},
 		{
+			name: "always named startup wake failure quarantine is explicit",
+			meta: map[string]string{
+				"state":                 "asleep",
+				"configured_named_mode": "always",
+				"sleep_reason":          "quarantine",
+				"wake_attempts":         "5",
+				"quarantined_until":     future,
+			},
+			want: "startup-failure",
+		},
+		{
 			name: "expired rate-limit reason is not visible",
 			meta: map[string]string{
 				"sleep_reason":      "rate_limit",

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -678,6 +678,17 @@ func TestLifecycleDisplayReasonUsesOnlyActiveLifecycleReasons(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "always named startup churn quarantine is explicit",
+			meta: map[string]string{
+				"state":                 "asleep",
+				"configured_named_mode": "always",
+				"sleep_reason":          "context-churn",
+				"churn_count":           "3",
+				"quarantined_until":     future,
+			},
+			want: "startup-failure",
+		},
+		{
 			name: "expired rate-limit reason is not visible",
 			meta: map[string]string{
 				"sleep_reason":      "rate_limit",


### PR DESCRIPTION
## Summary
- show active always-named context-churn quarantine as startup-failure instead of raw context-churn
- keep expired churn quarantine reasons hidden and leave non-always churn display unchanged
- add API list coverage for the exposed session reason

Fixes azanar/gascity#29.

## Tests
- go test ./internal/session -run TestLifecycleDisplayReasonUsesOnlyActiveLifecycleReasons -count=1
- go test ./internal/session -run TestLifecycleDisplayReason -count=1
- go test ./internal/api -run TestHandleSessionListShowsAlwaysStartupFailureReason -count=1
- go test ./internal/api -run TestHandleSessionListIncludesReason -count=1
- go test ./internal/api -run TestHandleSessionListShowsResetPendingForLiveRuntime -count=1
- go test ./internal/session ./internal/api -count=1
- git diff --check