### PR TITLE
fix(session): release work beads on gc session close (#2625)

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1699,6 +1699,15 @@ func cmdSessionClose(args []string, stdout, stderr io.Writer, jsonOutput ...bool
 		fmt.Fprintf(stderr, "gc session close: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	// Capture the session bead state BEFORE close so we have its assignment
+	// identifiers (session_name, alias, etc.) for the post-close work-release
+	// pass. Lookup is best-effort: if the session bead is already missing we
+	// fall back to a synthetic shell carrying only the resolved session ID.
+	closedSessionBead, sessionBeadErr := store.Get(sessionID)
+	if sessionBeadErr != nil {
+		closedSessionBead = beads.Bead{ID: sessionID}
+	}
+
 	closeResult, err := handle.CloseDetailed(context.Background())
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session close: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1709,6 +1718,17 @@ func cmdSessionClose(args []string, stdout, stderr io.Writer, jsonOutput ...bool
 			fmt.Fprintf(stderr, "gc session close: warning: withdrawing queued wait nudges: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
 	}
+
+	// Release any work beads still assigned to the closed session so the
+	// pool scale-check picks up the freed demand on the next reconcile tick.
+	// Each Update fires the bd on_update hook, which emits a bead.updated
+	// event the supervisor's CachingStore absorbs — the cache-update event
+	// the close path was previously missing (gastownhall/gascity#2625).
+	var rigStores map[string]beads.Store
+	if cityErr == nil && cfg != nil {
+		rigStores = buildStandaloneRigStores(cfg, cityPath, stderr)
+	}
+	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, closedSessionBead, "", stderr)
 
 	if asJSON {
 		if err := writeSessionActionJSON(stdout, sessionActionResult{

--- a/cmd/gc/cmd_session_close_release_test.go
+++ b/cmd/gc/cmd_session_close_release_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// TestCmdSessionCloseReleasesAssignedWorkBeads is a regression for
+// gastownhall/gascity#2625. After `gc session close`, any work bead still
+// assigned to the closed session must be released (Assignee cleared, Status
+// reset to open) so the pool scale-check picks up the freed demand on the
+// next reconcile tick. Without it, Source-1 CachedReady stays stale, the
+// pool scale-check sees scaleCount=0, and no fresh worker spawns even
+// though the demand is admittable.
+func TestCmdSessionCloseReleasesAssignedWorkBeads(t *testing.T) {
+	cityDir := t.TempDir()
+	writePhase0InterfaceCity(t, cityDir, `[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "worker"
+start_command = "true"
+max_active_sessions = 1
+`)
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_DIR", t.TempDir())
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "stranded worker",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "worker-stranded",
+			"template":     "worker",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session bead): %v", err)
+	}
+
+	work, err := store.Create(beads.Bead{
+		Title:    "admittable demand",
+		Type:     "task",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create(work bead): %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionClose([]string{sessionBead.ID}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionClose = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	reopened, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("reopen city store: %v", err)
+	}
+
+	gotSession, err := reopened.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("Get(session bead): %v", err)
+	}
+	if gotSession.Status != "closed" {
+		t.Errorf("session bead status = %q, want closed", gotSession.Status)
+	}
+
+	gotWork, err := reopened.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get(work bead): %v", err)
+	}
+	if gotWork.Assignee != "" {
+		t.Errorf("work bead Assignee = %q, want empty (released after session close)", gotWork.Assignee)
+	}
+	if gotWork.Status != "open" {
+		t.Errorf("work bead Status = %q, want open (reset so the routed queue can re-pick it)", gotWork.Status)
+	}
+}

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -2685,6 +2685,88 @@ func findTestBead(items []beads.Bead, id string) (beads.Bead, bool) {
 	return beads.Bead{}, false
 }
 
+// TestCachingStoreCachedReadyReflectsRoutedWorkReleaseAfterSessionClose is a
+// regression for gastownhall/gascity#2625. When `gc session close` releases a
+// routed in-progress work bead (Assignee cleared, Status reset to open) — the
+// path the close-time release Update takes — Source-1 of
+// defaultScaleCheckCounts (cmd/gc/build_desired_state.go:1309
+// readyForControllerDemand → CachedReady) must observe the released bead on
+// the next read. Without it, the pool scale-check sees scaleCount=0 and no
+// fresh worker spawns even though the demand is admittable.
+//
+// Asserts that the existing CachingStore.Update write-through path emits the
+// cache-update event for the released row — closing the loop that
+// cmd/gc/cmd_session.go cmdSessionClose relies on.
+func TestCachingStoreCachedReadyReflectsRoutedWorkReleaseAfterSessionClose(t *testing.T) {
+	t.Parallel()
+	backing := beads.NewMemStore()
+
+	work, err := backing.Create(beads.Bead{
+		Title:    "routed work assigned to soon-to-close session",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	assignee := "sess-1"
+	inProgress := "in_progress"
+	if err := backing.Update(work.ID, beads.UpdateOpts{
+		Assignee: &assignee,
+		Status:   &inProgress,
+	}); err != nil {
+		t.Fatalf("assign work to session: %v", err)
+	}
+
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable before release")
+	}
+	for _, b := range ready {
+		if b.ID == work.ID {
+			t.Fatalf("CachedReady returned still-assigned in_progress work bead %s before release", b.ID)
+		}
+	}
+
+	empty := ""
+	open := "open"
+	if err := cache.Update(work.ID, beads.UpdateOpts{
+		Assignee: &empty,
+		Status:   &open,
+	}); err != nil {
+		t.Fatalf("release work bead: %v", err)
+	}
+
+	ready, ok = cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after release")
+	}
+	var found *beads.Bead
+	for i := range ready {
+		if ready[i].ID == work.ID {
+			found = &ready[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("CachedReady missing released work bead %s after Update; got %d beads", work.ID, len(ready))
+	}
+	if strings.TrimSpace(found.Assignee) != "" {
+		t.Errorf("released work bead Assignee = %q, want empty", found.Assignee)
+	}
+	if found.Status != "open" {
+		t.Errorf("released work bead Status = %q, want open", found.Status)
+	}
+	if found.Metadata["gc.routed_to"] != "worker" {
+		t.Errorf("released work bead routed_to = %q, want worker", found.Metadata["gc.routed_to"])
+	}
+}
+
 func strPtr(s string) *string { return &s }
 
 func containsString(values []string, want string) bool {


### PR DESCRIPTION
## Summary

Fixes #2625 — pool scale-check does not re-admit demand after session close + supervisor reload.

When `gc session close` returned, the work bead's `assignee` and `status` were left in their old in_progress state in the backing store. The reconciler's pool-demand path reads via `defaultScaleCheckCounts` → `readyForControllerDemand` (`build_desired_state.go:1309`), which queries the cache-tolerant `CachedReady` snapshot rather than `Live:true`. The stale row in `c.beads` left `scaleCount=0` and the pool stayed cold; `gc supervisor reload` re-ticked the same cached path. (`gc sling` worked because it stamps `gc.pool_demand` via `Live:true`, bypassing the stale cache.)

## Fix (Option C — close-time release with event emission)

- After `handle.CloseDetailed` succeeds in `cmdSessionClose`, call the existing `unclaimWorkAssignedToRetiredSessionBead` against the pre-close session bead snapshot plus the city's rig stores.
- Each release `Update` fires the bd `on_update` hook, which emits `bead.updated` to the event bus. The supervisor's `CachingStore.ApplyEvent` absorbs it and invalidates the relevant `c.beads` row.
- Next reconcile tick sees the freed demand via Source-1 `CachedReady` and the pool scales up.

This is more targeted than the broader cache-invalidate-on-close alternative — only the released bead's row is invalidated, no global flush.

## Tests

1. **`TestCmdSessionCloseReleasesAssignedWorkBeads`** (`cmd/gc/cmd_session_close_release_test.go`)
   - Stamps a routed work bead `Assignee=session-X`, `Status=in_progress`, `gc.routed_to=worker`.
   - Calls `cmdSessionClose` with the session bead ID.
   - RED on prior code (Assignee stays = session ID, Status stays = in_progress).
   - GREEN after the release call is wired (Assignee="", Status="open").

2. **`TestCachingStoreCachedReadyReflectsRoutedWorkReleaseAfterSessionClose`** (`internal/beads/caching_store_test.go`)
   - Regression guard: stamps a routed in_progress assigned bead, primes the cache, verifies `CachedReady` excludes it.
   - Calls `cache.Update` with `Assignee=""` and `Status="open"` — the path the close-time release takes.
   - Asserts `CachedReady` now surfaces the bead with the released fields.

## Gates

- `make build` pass; `go vet ./...` clean; `make lint` 0 issues
- `go test ./cmd/gc/ ./internal/beads/ ./internal/session/ ./internal/worker/` all pass
  - one host-pinned baseline failure (`TestDoStartJSONAlreadyRunningSupervisorKeepsStdoutJSONOnly` — dolt v1.86.2 vs required v2.0.7+ pinned in `0f50effe7`) — also fails on clean `main`, not a regression here

## Scope

- Does NOT touch the reconciler's `releaseOrphanedPoolAssignments` patrol path — that continues to be the fallback if the close-time release ever misses a bead.
- Does NOT address the secondary "adopting sessions" pattern observed by @reggieperry in the issue comments — that's a separate bug.
