### PR TITLE
ci: add draft RC release workflow

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -1,0 +1,128 @@
+name: RC Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*-rc*"
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "RC tag to create or publish, e.g. v1.2.0-rc1"
+        required: true
+        type: string
+      target_ref:
+        description: "Commit SHA, branch, or tag to build when creating the RC tag"
+        required: true
+        default: "release/v1.2.0"
+        type: string
+
+concurrency:
+  group: rc-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  rc-release:
+    name: Draft RC release
+    if: ${{ github.repository == 'gastownhall/gascity' }}
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout dispatch target
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.target_ref }}
+          fetch-depth: 0
+
+      - name: Checkout pushed tag
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Resolve RC tag
+        id: rc
+        env:
+          DISPATCH_TAG: ${{ inputs.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$DISPATCH_TAG"
+          else
+            tag="$GITHUB_REF_NAME"
+          fi
+
+          if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+            echo "ERROR: RC tag must match vMAJOR.MINOR.PATCH-rcN, got: $tag" >&2
+            exit 1
+          fi
+
+          commit="$(git rev-parse HEAD)"
+          git fetch --force --tags origin
+
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$tag")"
+            if [ "$tagged_commit" != "$commit" ]; then
+              echo "ERROR: tag $tag points at $tagged_commit, not checked-out commit $commit" >&2
+              exit 1
+            fi
+            echo "Using existing tag $tag at $commit"
+          else
+            if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+              echo "ERROR: push event for $tag did not leave a local tag ref" >&2
+              exit 1
+            fi
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "$tag" -m "Release $tag" "$commit"
+            git push origin "refs/tags/$tag"
+            echo "Created tag $tag at $commit"
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+      - name: Reject replace directives in go.mod
+        run: |
+          if grep -qE '^replace\s' go.mod; then
+            echo "ERROR: go.mod contains replace directives; aborting RC release." >&2
+            grep -n '^replace' go.mod
+            exit 1
+          fi
+
+      - name: Run GoReleaser draft prerelease
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
+        with:
+          version: "~> v2"
+          args: release --clean --draft --skip=announce
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.rc.outputs.tag }}
+
+      - name: Summarize RC release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.rc.outputs.tag }}
+          TARGET_COMMIT: ${{ steps.rc.outputs.commit }}
+        run: |
+          set -euo pipefail
+          url="$(gh release view "$TAG_NAME" --json url --jq .url)"
+          {
+            echo "### Draft RC release"
+            echo
+            echo "- Tag: \`$TAG_NAME\`"
+            echo "- Commit: \`$TARGET_COMMIT\`"
+            echo "- Release: $url"
+            echo
+            echo "This workflow creates a draft prerelease only. It does not update the Homebrew tap or mark the release latest."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   release:
     name: Release
-    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
       contents: write
@@ -55,7 +55,7 @@ jobs:
 
   attest-release:
     name: Attest release
-    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     needs: release
     runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
@@ -108,7 +108,7 @@ jobs:
 
   update-homebrew-formula:
     name: Update Homebrew formula
-    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     needs: [release, attest-release]
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,7 @@
 | Channel | Mechanism | Automatic? |
 |---------|-----------|------------|
 | **GitHub Release** | GoReleaser via `release.yml` on tag push | Yes |
+| **GitHub draft prerelease** | GoReleaser via `rc-release.yml` on RC tag push or manual dispatch | Yes |
 | **Homebrew tap** (`gastownhall/gascity`) | `release.yml` writes an asset-based formula after archives upload | Yes |
 | **Homebrew core** (`Homebrew/homebrew-core`) | BrewTestBot autobump, once listed | Yes (~3h delay) |
 
@@ -19,6 +20,35 @@ The homebrew-core submission is [in progress](https://github.com/Homebrew/homebr
 ```
 
 This rewrites the `[Unreleased]` section of `CHANGELOG.md` into `[X.Y.Z] - YYYY-MM-DD`, commits, tags `vX.Y.Z`, and pushes. GitHub Actions takes it from there.
+
+### Release candidates
+
+Use the **RC Release** workflow to produce downloadable release-candidate
+archives for manual verification without updating Homebrew or publishing the
+stable release.
+
+Recommended path:
+
+1. Run the RC gate on the intended release branch or commit.
+2. Open **Actions → RC Release → Run workflow**.
+3. Set `tag_name` to an RC tag such as `v1.2.0-rc1`.
+4. Set `target_ref` to the exact RC-gate-passing commit SHA.
+
+The workflow creates the annotated RC tag if needed, builds GoReleaser
+archives for linux/darwin × amd64/arm64, and creates a GitHub **draft
+prerelease** with generated GoReleaser notes and downloadable assets. It does
+not update the Homebrew tap, create attestations, or mark the release latest.
+
+You can also push an existing RC tag manually:
+
+```bash
+git tag -a vX.Y.Z-rcN <commit> -m "Release vX.Y.Z-rcN"
+git push origin vX.Y.Z-rcN
+```
+
+Pushing an RC tag triggers `rc-release.yml`. The stable `release.yml` jobs
+skip tags containing a prerelease suffix, so RC tags do not run the Homebrew
+or stable publishing path.
 
 ### Manual
 
@@ -41,10 +71,11 @@ Version numbers live **only** in the git tag — there is no `Version` constant 
 
 ## What Happens After Tag Push
 
-`.github/workflows/release.yml` fires on any `v*` tag and runs, in order:
+`.github/workflows/release.yml` fires on stable `vMAJOR.MINOR.PATCH` tags and
+runs, in order:
 
 1. **Reject `replace` directives in `go.mod`** — they break `go install ...@latest` and bottle builds in homebrew-core.
-2. **`make check-version-tag`** — asserts the tag is a clean `vMAJOR.MINOR.PATCH` with no pre-release suffix. RC/beta tags will fail the release. Pre-release tags should be cut on a dedicated branch or not trigger this workflow.
+2. **`make check-version-tag`** — asserts the tag is a clean `vMAJOR.MINOR.PATCH` with no pre-release suffix. RC/beta tags are handled by `rc-release.yml` instead.
 3. **GoReleaser** — builds binaries for linux/darwin × amd64/arm64 and creates the GitHub Release with grouped changelog (`feat:` → Features, `fix:` → Bug Fixes, others → Others).
 4. **Release attestations** — downloads the published checksum manifest, uploads an SPDX SBOM asset, and creates GitHub artifact attestations for the release archives.
 5. **Homebrew tap update** — downloads the published checksums and writes an asset-based formula to `gastownhall/homebrew-gascity`.
@@ -100,9 +131,11 @@ Manual `brew bump-formula-pr` is refused for autobump formulae. If the bot stall
 
 ## Troubleshooting
 
-### `make check-version-tag` fails with "pre-release suffix"
+### Stable release workflow skipped an RC tag
 
-The tag has a suffix (`-rc1`, `-beta`, `-alpha.1`). The release workflow only publishes stable releases. Either retag without the suffix, or don't trigger `release.yml` for this tag.
+This is expected. Tags with suffixes such as `-rc1`, `-beta`, or `-alpha.1`
+are intentionally excluded from the stable `release.yml` publishing jobs. Use
+the **RC Release** workflow for release candidates.
 
 ### GoReleaser fails with "replace directives"
 


### PR DESCRIPTION
## Summary
- add an RC Release workflow for vX.Y.Z-rcN tags and manual dispatch
- publish GoReleaser-built RC archives as a GitHub draft prerelease only
- skip stable release/Homebrew jobs for prerelease tag suffixes
- document the RC flow in RELEASING.md

## Verification
- goreleaser check
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/rc-release.yml .github/workflows/release.yml
- yq parsed both workflow files
- git diff --check
- pre-commit hook ran test/docsync during commit
