### PR TITLE
Add Claude Opus 4.8 model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Claude Opus 4.8 is now listed in built-in Claude model choices and default
+  pricing. The `opus` model choice targets `claude-opus-4-8`; `opus-4-7`
+  remains available for cities that need the prior Opus target. Anthropic's
+  published regular-usage pricing is unchanged from Opus 4.7: $5/MTok input
+  and $25/MTok output.
+
 ## [1.2.0] - 2026-05-25
 
 ### Added

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -385,7 +385,7 @@ ModelPricing is a complete pricing entry for a (Provider, Model) pair.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `provider` | string | **yes** |  | Provider is the LLM provider label (e.g. "claude", "codex", "gemini"). |
-| `model` | string | **yes** |  | Model is the provider-specific model identifier (e.g. "claude-opus-4-7"). |
+| `model` | string | **yes** |  | Model is the provider-specific model identifier (e.g. "claude-opus-4-8"). |
 | `tier` | Tier | **yes** |  | Tier holds the per-token-type rates. |
 | `last_verified` | string | **yes** |  | LastVerified is the date these rates were confirmed (YYYY-MM-DD). |
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1395,7 +1395,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-7\")."
+          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-8\")."
         },
         "tier": {
           "$ref": "#/$defs/Tier",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1395,7 +1395,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-7\")."
+          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-8\")."
         },
         "tier": {
           "$ref": "#/$defs/Tier",

--- a/docs/schema/pack-schema.json
+++ b/docs/schema/pack-schema.json
@@ -591,7 +591,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-7\")."
+          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-8\")."
         },
         "tier": {
           "$ref": "#/$defs/Tier",

--- a/docs/schema/pack-schema.txt
+++ b/docs/schema/pack-schema.txt
@@ -591,7 +591,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-7\")."
+          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-8\")."
         },
         "tier": {
           "$ref": "#/$defs/Tier",

--- a/internal/api/event_payloads.go
+++ b/internal/api/event_payloads.go
@@ -317,7 +317,7 @@ type WorkerOperationEventPayload struct {
 	// best-effort. See the consumer contract on the type doc above.
 
 	// Model is the LLM model identifier observed in this operation
-	// (e.g. "claude-opus-4-7"). Sourced from session metadata.
+	// (e.g. "claude-opus-4-8"). Sourced from session metadata.
 	//
 	// Wired: TODO — follow-up will tail sessionlog at finish() to
 	// extract msg.Model.

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -70,6 +70,31 @@ func TestBuiltinProvidersClaude(t *testing.T) {
 	}
 }
 
+func TestBuiltinProvidersClaudeModelChoices(t *testing.T) {
+	p := BuiltinProviders()["claude"]
+	var model OptionChoice
+	var oldOpus OptionChoice
+	for _, opt := range p.OptionsSchema {
+		if opt.Key != "model" {
+			continue
+		}
+		for _, choice := range opt.Choices {
+			switch choice.Value {
+			case "opus":
+				model = choice
+			case "opus-4-7":
+				oldOpus = choice
+			}
+		}
+	}
+	if !reflect.DeepEqual(model.FlagArgs, []string{"--model", "claude-opus-4-8"}) {
+		t.Fatalf("opus FlagArgs = %v, want Opus 4.8", model.FlagArgs)
+	}
+	if !reflect.DeepEqual(oldOpus.FlagArgs, []string{"--model", "claude-opus-4-7"}) {
+		t.Fatalf("opus-4-7 FlagArgs = %v, want Opus 4.7 preserved", oldOpus.FlagArgs)
+	}
+}
+
 func TestBuiltinClaudeCommandString(t *testing.T) {
 	// After migration, claude's Args is nil. CommandString() returns just "claude".
 	// Schema-managed flags come from ResolveDefaultArgs() instead.

--- a/internal/pricing/build_test.go
+++ b/internal/pricing/build_test.go
@@ -7,7 +7,10 @@ import (
 func TestBuildRegistry_DefaultsOnly(t *testing.T) {
 	r := BuildRegistry(nil, nil)
 	if _, ok := r.Lookup("claude", "claude-opus-4-7"); !ok {
-		t.Fatal("expected default Claude pricing in registry")
+		t.Fatal("expected Opus 4.7 Claude pricing in registry")
+	}
+	if _, ok := r.Lookup("claude", "claude-opus-4-8"); !ok {
+		t.Fatal("expected Opus 4.8 Claude pricing in registry")
 	}
 }
 

--- a/internal/pricing/defaults.go
+++ b/internal/pricing/defaults.go
@@ -99,6 +99,18 @@ var claudeDefaults = []ModelPricing{
 			CacheCreationUSDPer1M: 6.25,
 		},
 	},
+	// Claude 4.8 Opus. Regular usage pricing is unchanged from Opus 4.7.
+	{
+		Provider:     "claude",
+		Model:        "claude-opus-4-8",
+		LastVerified: "2026-05-28",
+		Tier: Tier{
+			PromptUSDPer1M:        5.00,
+			CompletionUSDPer1M:    25.00,
+			CacheReadUSDPer1M:     0.50,
+			CacheCreationUSDPer1M: 6.25,
+		},
+	},
 	// Claude 4.5 Haiku.
 	{
 		Provider:     "claude",

--- a/internal/pricing/defaults_test.go
+++ b/internal/pricing/defaults_test.go
@@ -27,6 +27,7 @@ func TestDefaultPricingsCoverKnownClaudeModels(t *testing.T) {
 		"claude-opus-4",
 		"claude-sonnet-4-6",
 		"claude-opus-4-7",
+		"claude-opus-4-8",
 		"claude-haiku-4-5-20251001",
 	}
 	r := New(DefaultPricings())
@@ -61,6 +62,13 @@ func TestDefaultPricingsCurrentClaudeRates(t *testing.T) {
 		},
 		{
 			model:         "claude-opus-4-7",
+			prompt:        5.00,
+			completion:    25.00,
+			cacheRead:     0.50,
+			cacheCreation: 6.25,
+		},
+		{
+			model:         "claude-opus-4-8",
 			prompt:        5.00,
 			completion:    25.00,
 			cacheRead:     0.50,

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -52,7 +52,7 @@ func (t Tier) IsZero() bool {
 type ModelPricing struct {
 	// Provider is the LLM provider label (e.g. "claude", "codex", "gemini").
 	Provider string `toml:"provider" json:"provider"`
-	// Model is the provider-specific model identifier (e.g. "claude-opus-4-7").
+	// Model is the provider-specific model identifier (e.g. "claude-opus-4-8").
 	Model string `toml:"model" json:"model"`
 	// Tier holds the per-token-type rates.
 	Tier Tier `toml:"tier" json:"tier"`

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -144,7 +144,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
-					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-7"}, FlagAliases: [][]string{{"-m", "claude-opus-4-7"}}},
+					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-8"}, FlagAliases: [][]string{{"-m", "claude-opus-4-8"}}},
+					{Value: "opus-4-7", Label: "Opus 4.7", FlagArgs: []string{"--model", "claude-opus-4-7"}, FlagAliases: [][]string{{"-m", "claude-opus-4-7"}}},
 					{Value: "sonnet", Label: "Sonnet", FlagArgs: []string{"--model", "claude-sonnet-4-6"}, FlagAliases: [][]string{{"-m", "claude-sonnet-4-6"}}},
 					{Value: "haiku", Label: "Haiku", FlagArgs: []string{"--model", "claude-haiku-4-5-20251001"}, FlagAliases: [][]string{{"-m", "claude-haiku-4-5-20251001"}}},
 				},


### PR DESCRIPTION
## Summary
- add `claude-opus-4-8` to default Claude pricing while preserving `claude-opus-4-7`
- update the built-in Claude model menu so `opus` targets Opus 4.8 and `opus-4-7` remains selectable
- regenerate config schema/reference docs and note the addition in the changelog

## Source
- Anthropic announced Claude Opus 4.8 on 2026-05-28 with regular pricing unchanged from Opus 4.7: $5/MTok input and $25/MTok output; API model id `claude-opus-4-8`.

## Verification
- `go test ./internal/pricing ./internal/config ./internal/api -count=1`
- `go test ./internal/reliability ./cmd/gc -run "Reliability|AnalyzeReliability" -count=1`
- `go test ./internal/reliability -count=1`
- `.githooks/pre-commit` during commit: lint-changed, `go run ./cmd/genschema`, `go vet ./...`, `make test-fast-parallel`, `go test ./test/docsync`

Refs ga-516sy4