### PR TITLE
ci: use GitHub-hosted runners for releases

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -26,7 +26,7 @@ jobs:
   rc-release:
     name: Draft RC release
     if: ${{ github.repository == 'gastownhall/gascity' }}
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   release:
     name: Release
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
@@ -57,7 +57,7 @@ jobs:
     name: Attest release
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     needs: release
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       attestations: write
       contents: write
@@ -110,7 +110,7 @@ jobs:
     name: Update Homebrew formula
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     needs: [release, attest-release]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- move RC and stable release publishing jobs to ubuntu-latest
- avoid release publication getting stuck behind Blacksmith runner capacity

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/rc-release.yml .github/workflows/release.yml
- goreleaser check
- git diff --check