### PR TITLE
Add supervisor startup crash smoke

### DIFF
--- a/cmd/gc/supervisor_startup_crash_integration_test.go
+++ b/cmd/gc/supervisor_startup_crash_integration_test.go
@@ -33,6 +33,7 @@ func TestSupervisorManagedProviderStartupCrashSmoke(t *testing.T) {
 		"#!/bin/sh",
 		"printf '%s\\n' 'WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)' >&2",
 		"printf '%s\\n' 'Error: Operation not permitted (os error 1)' >&2",
+		"sleep 1",
 		"exit 1",
 		"",
 	}, "\n")), 0o755); err != nil {

--- a/cmd/gc/supervisor_startup_crash_integration_test.go
+++ b/cmd/gc/supervisor_startup_crash_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/test/tmuxtest"
+)
+
+func TestSupervisorManagedProviderStartupCrashSmoke(t *testing.T) {
+	tmuxtest.RequireTmux(t)
+
+	guard := tmuxtest.NewGuard(t)
+	workDir := t.TempDir()
+	crashScript := filepath.Join(workDir, "codex-like-startup-crash.sh")
+	if err := os.WriteFile(crashScript, []byte(strings.Join([]string{
+		"#!/bin/sh",
+		"printf '%s\\n' 'WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)' >&2",
+		"printf '%s\\n' 'Error: Operation not permitted (os error 1)' >&2",
+		"exit 1",
+		"",
+	}, "\n")), 0o755); err != nil {
+		t.Fatalf("write crash script: %v", err)
+	}
+
+	sp, err := newSessionProviderByName("", config.SessionConfig{
+		Socket:             guard.SocketName(),
+		SetupTimeout:       "2s",
+		NudgeReadyTimeout:  "500ms",
+		NudgeRetryInterval: "25ms",
+		NudgeLockTimeout:   "500ms",
+	}, guard.CityName(), workDir)
+	if err != nil {
+		t.Fatalf("new tmux provider: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	sessionName := guard.SessionName("mayor")
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"agent_name":                 "mayor",
+			"template":                   "mayor",
+			"state":                      "asleep",
+			"wake_attempts":              "4",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "mayor",
+			namedSessionModeMetadata:     "always",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	prepared := preparedStart{
+		candidate: startCandidate{
+			session: &sessionBead,
+			tp: TemplateParams{
+				Command:                 crashScript,
+				SessionName:             sessionName,
+				TemplateName:            "mayor",
+				ConfiguredNamedIdentity: "mayor",
+				ConfiguredNamedMode:     "always",
+			},
+		},
+		cfg: runtime.Config{
+			Command:           crashScript,
+			WorkDir:           workDir,
+			ReadyPromptPrefix: "never-ready>",
+			ReadyDelayMs:      10,
+			ProviderName:      "codex",
+		},
+	}
+
+	results := executePreparedStartWave(context.Background(), []preparedStart{prepared}, sp, store, 2*time.Second)
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	result := results[0]
+	if result.err == nil {
+		t.Fatal("startup result err = nil, want provider startup failure")
+	}
+	if !strings.Contains(result.err.Error(), "Operation not permitted (os error 1)") {
+		t.Fatalf("startup error missing provider output:\n%v", result.err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	clk := &clock.Fake{Time: time.Now().UTC()}
+	if commitStartResult(result, store, clk, events.Discard, 0, &stdout, &stderr) {
+		t.Fatalf("commitStartResult reported wake success; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	updated, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("reload session bead: %v", err)
+	}
+	if got := updated.Metadata["quarantined_until"]; got == "" {
+		t.Fatalf("quarantined_until empty after startup crash; metadata=%v", updated.Metadata)
+	}
+	if got := updated.Metadata["sleep_reason"]; got != "quarantine" {
+		t.Fatalf("sleep_reason = %q, want quarantine", got)
+	}
+
+	info := sessionpkg.Info{
+		ID:          updated.ID,
+		Template:    "mayor",
+		State:       sessionpkg.StateAsleep,
+		SessionName: sessionName,
+	}
+	reason := sessionReason(info, map[string]beads.Bead{updated.ID: updated}, nil, sp, nil, nil)
+	if reason != "startup-failure" {
+		t.Fatalf("sessionReason = %q, want startup-failure; metadata=%v", reason, updated.Metadata)
+	}
+
+	attachStart := time.Now()
+	attachErr := sp.Attach(sessionName)
+	if attachErr == nil {
+		t.Fatal("Attach succeeded, want dead startup pane refusal")
+	}
+	if time.Since(attachStart) > 750*time.Millisecond {
+		t.Fatalf("Attach took %s, want fast refusal; err=%v", time.Since(attachStart), attachErr)
+	}
+	if !errors.Is(attachErr, runtime.ErrSessionNotFound) &&
+		!strings.Contains(attachErr.Error(), "not running") &&
+		!strings.Contains(attachErr.Error(), "session not found") {
+		t.Fatalf("Attach error = %v, want missing/dead session context", attachErr)
+	}
+}

--- a/cmd/gc/supervisor_startup_crash_integration_test.go
+++ b/cmd/gc/supervisor_startup_crash_integration_test.go
@@ -24,6 +24,8 @@ import (
 func TestSupervisorManagedProviderStartupCrashSmoke(t *testing.T) {
 	tmuxtest.RequireTmux(t)
 
+	const startupCrashTimeout = 10 * time.Second
+
 	guard := tmuxtest.NewGuard(t)
 	workDir := t.TempDir()
 	crashScript := filepath.Join(workDir, "codex-like-startup-crash.sh")
@@ -39,7 +41,7 @@ func TestSupervisorManagedProviderStartupCrashSmoke(t *testing.T) {
 
 	sp, err := newSessionProviderByName("", config.SessionConfig{
 		Socket:             guard.SocketName(),
-		SetupTimeout:       "2s",
+		SetupTimeout:       startupCrashTimeout.String(),
 		NudgeReadyTimeout:  "500ms",
 		NudgeRetryInterval: "25ms",
 		NudgeLockTimeout:   "500ms",
@@ -89,7 +91,7 @@ func TestSupervisorManagedProviderStartupCrashSmoke(t *testing.T) {
 		},
 	}
 
-	results := executePreparedStartWave(context.Background(), []preparedStart{prepared}, sp, store, 2*time.Second)
+	results := executePreparedStartWave(context.Background(), []preparedStart{prepared}, sp, store, startupCrashTimeout)
 	if len(results) != 1 {
 		t.Fatalf("results = %d, want 1", len(results))
 	}

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1850,6 +1850,44 @@ func TestHandleSessionListIncludesReason(t *testing.T) {
 	}
 }
 
+func TestHandleSessionListShowsAlwaysStartupFailureReason(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "Mayor")
+	if err := fs.cityBeadStore.SetMetadataBatch(info.ID, map[string]string{
+		"state":                 "asleep",
+		"configured_named_mode": "always",
+		"sleep_reason":          "context-churn",
+		"churn_count":           "3",
+		"quarantined_until":     time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("set startup failure metadata: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/sessions"), nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body struct {
+		Items []sessionResponse `json:"items"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Items) != 1 {
+		t.Fatalf("got %d items, want 1", len(body.Items))
+	}
+	if body.Items[0].Reason != "startup-failure" {
+		t.Fatalf("reason = %q, want startup-failure", body.Items[0].Reason)
+	}
+}
+
 func TestHandleSessionListShowsResetPendingForLiveRuntime(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -311,9 +311,13 @@ func lifecycleDisplayReasonFromView(view LifecycleView, metadata map[string]stri
 }
 
 func lifecycleStartupFailureReasonVisible(view LifecycleView, metadata map[string]string, reason string) bool {
-	return reason == "context-churn" &&
-		view.HasBlocker(BlockerQuarantined) &&
-		strings.TrimSpace(metadata[NamedSessionModeMetadata]) == "always"
+	if !view.HasBlocker(BlockerQuarantined) || strings.TrimSpace(metadata[NamedSessionModeMetadata]) != "always" {
+		return false
+	}
+	if reason == "context-churn" {
+		return true
+	}
+	return reason == "quarantine" && strings.TrimSpace(metadata["wake_attempts"]) != "" && strings.TrimSpace(metadata["wake_attempts"]) != "0"
 }
 
 func lifecycleResetPendingReasonVisible(view LifecycleView, metadata map[string]string, sessionName string, isRunning func(string) bool) bool {

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -225,6 +225,8 @@ const (
 	SessionCircuitStateOpen = "CIRCUIT_OPEN"
 	// SessionCircuitStateClosed is the durable metadata value for a closed session circuit breaker.
 	SessionCircuitStateClosed = "CIRCUIT_CLOSED"
+
+	lifecycleStartupFailureReason = "startup-failure"
 )
 
 // LifecycleDisplayReason returns the user-facing reason for a non-closed
@@ -289,6 +291,9 @@ func lifecycleDisplayReasonFromView(view LifecycleView, metadata map[string]stri
 		staleTimedHold := reason == "user-hold" &&
 			strings.TrimSpace(metadata["held_until"]) != "" &&
 			!view.HasBlocker(BlockerHeld)
+		if !staleTimedQuarantine && lifecycleStartupFailureReasonVisible(view, metadata, reason) {
+			return lifecycleStartupFailureReason
+		}
 		if !staleTimedQuarantine && !staleTimedHold {
 			return reason
 		}
@@ -303,6 +308,12 @@ func lifecycleDisplayReasonFromView(view LifecycleView, metadata map[string]stri
 		return "user-hold"
 	}
 	return ""
+}
+
+func lifecycleStartupFailureReasonVisible(view LifecycleView, metadata map[string]string, reason string) bool {
+	return reason == "context-churn" &&
+		view.HasBlocker(BlockerQuarantined) &&
+		strings.TrimSpace(metadata[NamedSessionModeMetadata]) == "always"
 }
 
 func lifecycleResetPendingReasonVisible(view LifecycleView, metadata map[string]string, sessionName string, isRunning func(string) bool) bool {

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -689,6 +689,17 @@ func TestLifecycleDisplayReasonUsesOnlyActiveLifecycleReasons(t *testing.T) {
 			want: "startup-failure",
 		},
 		{
+			name: "always named startup wake failure quarantine is explicit",
+			meta: map[string]string{
+				"state":                 "asleep",
+				"configured_named_mode": "always",
+				"sleep_reason":          "quarantine",
+				"wake_attempts":         "5",
+				"quarantined_until":     future,
+			},
+			want: "startup-failure",
+		},
+		{
 			name: "expired rate-limit reason is not visible",
 			meta: map[string]string{
 				"sleep_reason":      "rate_limit",

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -678,6 +678,17 @@ func TestLifecycleDisplayReasonUsesOnlyActiveLifecycleReasons(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "always named startup churn quarantine is explicit",
+			meta: map[string]string{
+				"state":                 "asleep",
+				"configured_named_mode": "always",
+				"sleep_reason":          "context-churn",
+				"churn_count":           "3",
+				"quarantined_until":     future,
+			},
+			want: "startup-failure",
+		},
+		{
 			name: "expired rate-limit reason is not visible",
 			meta: map[string]string{
 				"sleep_reason":      "rate_limit",


### PR DESCRIPTION
## Summary
- add an integration-tag smoke for a tmux-backed, supervisor-shaped provider startup crash that prints the macOS EPERM failure and exits
- verify startup diagnostics include provider output, wake-failure quarantine surfaces as startup-failure, and attach refuses quickly
- this PR is stacked on the existing dependent fixes: #2685, #2693, and #2697

Fixes azanar/gascity#28.

## Tests
- go test ./internal/runtime/tmux -count=1
- go test ./internal/session ./internal/api -count=1
- go test -tags integration ./cmd/gc -run TestSupervisorManagedProviderStartupCrashSmoke -count=1
- git diff --check