### PR TITLE
feat(k8s): mount git credentials secret in agent pods

### DIFF
--- a/internal/runtime/k8s/pod.go
+++ b/internal/runtime/k8s/pod.go
@@ -20,6 +20,7 @@ import (
 const (
 	podManagedDoltHost = "dolt.gc.svc.cluster.local"
 	podManagedDoltPort = "3307"
+	gitSecretName      = "git-credentials"
 )
 
 func controllerCityPath(cfgEnv map[string]string) string {
@@ -271,6 +272,17 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 			},
 		},
 	})
+	mainVolMounts = append(mainVolMounts, corev1.VolumeMount{
+		Name: "git-credentials", MountPath: "/tmp/git-secret", ReadOnly: true,
+	})
+	volumes = append(volumes, corev1.Volume{
+		Name: "git-credentials", VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: gitSecretName,
+				Optional:   boolPtr(true),
+			},
+		},
+	})
 
 	// If GC_CITY differs from work_dir, add a city volume (not needed when prebaked).
 	if !p.prebaked && ctrlCity != "" && ctrlCity != cfg.WorkDir {
@@ -451,18 +463,23 @@ func buildPodEnv(cfgEnv map[string]string, podWorkDir, managedServiceHost, manag
 	}
 
 	// Inject GITHUB_TOKEN from optional K8s secret for git push in pods.
-	env = append(env, corev1.EnvVar{
-		Name: "GITHUB_TOKEN",
+	env = append(env, gitTokenEnv("GITHUB_TOKEN"))
+	env = append(env, gitTokenEnv("GH_TOKEN"))
+
+	return env, nil
+}
+
+func gitTokenEnv(name string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
 		ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: "git-credentials"},
+				LocalObjectReference: corev1.LocalObjectReference{Name: gitSecretName},
 				Key:                  "token",
 				Optional:             boolPtr(true),
 			},
 		},
-	})
-
-	return env, nil
+	}
 }
 
 // needsStaging returns true if the session config requires file staging

--- a/internal/runtime/k8s/pod_test.go
+++ b/internal/runtime/k8s/pod_test.go
@@ -141,3 +141,81 @@ func TestBuildPod_ClonesSchedulingFields(t *testing.T) {
 		t.Fatalf("provider affinity value mutated to %q", values[0])
 	}
 }
+
+func TestBuildPod_MountsGitCredentialSecret(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash"}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+
+	mount, ok := volumeMountByName(pod.Spec.Containers[0].VolumeMounts, "git-credentials")
+	if !ok {
+		t.Fatal("missing git-credentials volume mount")
+	}
+	if mount.MountPath != "/tmp/git-secret" || !mount.ReadOnly {
+		t.Fatalf("git-credentials mount = %#v, want readonly /tmp/git-secret", mount)
+	}
+
+	volume, ok := volumeByName(pod.Spec.Volumes, "git-credentials")
+	if !ok || volume.Secret == nil {
+		t.Fatalf("missing git-credentials secret volume: %#v", volume)
+	}
+	if volume.Secret.SecretName != "git-credentials" {
+		t.Fatalf("git secret name = %q, want git-credentials", volume.Secret.SecretName)
+	}
+	if volume.Secret.Optional == nil || !*volume.Secret.Optional {
+		t.Fatal("git secret should be optional")
+	}
+}
+
+func TestBuildPodEnv_GitHubTokenEnvSupportsGitAndGHCLI(t *testing.T) {
+	env, err := buildPodEnv(map[string]string{}, "/workspace", podManagedDoltHost, podManagedDoltPort)
+	if err != nil {
+		t.Fatalf("buildPodEnv: %v", err)
+	}
+
+	for _, name := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		v, ok := envByName(env, name)
+		if !ok {
+			t.Fatalf("missing %s env", name)
+		}
+		if v.ValueFrom == nil || v.ValueFrom.SecretKeyRef == nil {
+			t.Fatalf("%s does not come from a secret: %#v", name, v)
+		}
+		ref := v.ValueFrom.SecretKeyRef
+		if ref.Name != "git-credentials" || ref.Key != "token" {
+			t.Fatalf("%s secret ref = %s/%s, want git-credentials/token", name, ref.Name, ref.Key)
+		}
+		if ref.Optional == nil || !*ref.Optional {
+			t.Fatalf("%s secret ref should be optional", name)
+		}
+	}
+}
+
+func volumeMountByName(mounts []corev1.VolumeMount, name string) (corev1.VolumeMount, bool) {
+	for _, mount := range mounts {
+		if mount.Name == name {
+			return mount, true
+		}
+	}
+	return corev1.VolumeMount{}, false
+}
+
+func volumeByName(volumes []corev1.Volume, name string) (corev1.Volume, bool) {
+	for _, volume := range volumes {
+		if volume.Name == name {
+			return volume, true
+		}
+	}
+	return corev1.Volume{}, false
+}
+
+func envByName(env []corev1.EnvVar, name string) (corev1.EnvVar, bool) {
+	for _, v := range env {
+		if v.Name == name {
+			return v, true
+		}
+	}
+	return corev1.EnvVar{}, false
+}


### PR DESCRIPTION
## Summary

- mount the optional `git-credentials` Kubernetes Secret into agent pods at `/tmp/git-secret`
- keep the existing optional `GITHUB_TOKEN` projection from `git-credentials/token` and also project the same key as `GH_TOKEN` for GitHub CLI compatibility
- add focused pod/env tests that prove the mounted secret is optional/read-only and that both token env vars keep the existing optional secret semantics

## Linked Issue

No separate issue. This is a narrow K8s runtime credential-materialization extension. Related to #2339 in that both improve pod mount support, but this PR only covers the existing `git-credentials` secret.

## Architecture / Compatibility

This extends only the Kubernetes session provider. Local/tmux sessions and non-Kubernetes users are unchanged.

The new secret volume is optional, so clusters without a `git-credentials` Secret keep the current startup behavior. Existing static-token deployments continue to work through the optional `token` key. Deployments that need file-backed credentials, such as short-lived GitHub App token materializers, can mount `github-app.json` or other files in the same optional secret without replacing local workflows or requiring static token env vars.

## Testing

- PASS: `go test ./internal/runtime/k8s -run 'GitCredential|GitHubToken|BuildPod' -count=1`
- PASS: `go test ./internal/runtime/k8s -count=1`
- PASS: `git diff --check upstream/main..HEAD`

## Breaking Changes

None. The new secret volume and env var are optional; clusters without `git-credentials` keep the previous behavior.
