### PR TITLE
fix(beads): verify routed-metadata events against backing instead of dropping (#2210)

### DIFF
--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -70,11 +70,35 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		verifiedConflict = true
 		verifiedClosedBase = conflictBase
 	}
-	if fieldConflictCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
-		return
-	}
-	if dependencyConflictCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
-		return
+	if conflictsCached && eventType != "bead.closed" && locallyMutated && !recentlyLocal && !verifiedConflict {
+		// The bead is flagged locally mutated only because a prior applied
+		// event set its mutation seq (noteMutationLocked sets beadSeq on every
+		// applied event), or because of a local write older than the recency
+		// window. Backing reads are reliable here (no in-flight write-through),
+		// so verify the conflicting event against the backing store instead of
+		// dropping it outright: drop only genuinely stale events (which would
+		// clobber an unflushed local write); apply when the backing store
+		// already reflects the event — e.g. a gc.routed_to stamp written by
+		// `gc sling` in another process. Dropping unconditionally here stranded
+		// pool demand until an unrelated later event arrived after a reconcile
+		// cleared the mutation seq (gastownhall/gascity#2210).
+		matchesBacking, verifyErr := c.cacheEventMatchesBacking(patch.ID, patch, fields)
+		if verifyErr != nil {
+			c.recordProblem(fmt.Sprintf("verify %s event", eventType), verifyErr)
+			return
+		}
+		if !matchesBacking {
+			return
+		}
+		verifiedRecentLocal = true
+		verifiedRecentLocalBase = conflictBase
+	} else {
+		if fieldConflictCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
+			return
+		}
+		if dependencyConflictCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
+			return
+		}
 	}
 	if conflictsCached && recentlyLocal && !verifiedConflict {
 		verifiedRecentLocal = true
@@ -125,13 +149,20 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 					return
 				}
 			} else {
-				if _, locallyMutated := c.beadSeq[patch.ID]; fieldConflict && locallyMutated {
-					return
-				}
-				if _, locallyMutated := c.beadSeq[patch.ID]; dependencyConflict && locallyMutated {
-					return
-				}
+				_, locallyMutated := c.beadSeq[patch.ID]
+				// Re-check a genuine recent local write under the write lock to
+				// catch a write that landed between the read-lock verification
+				// and here; it wins unconditionally.
 				if recentLocalMutation(c.localBeadAt[patch.ID], time.Now()) &&
+					(!verifiedRecentLocal || beadChanged(current, verifiedRecentLocalBase, false)) {
+					return
+				}
+				// For a bead flagged locally mutated only by a prior event,
+				// apply the conflict only if it was verified against the
+				// backing store under the read lock and the cached bead has not
+				// changed since (no concurrent local write); otherwise drop and
+				// let reconciliation reconverge (gastownhall/gascity#2210).
+				if locallyMutated &&
 					(!verifiedRecentLocal || beadChanged(current, verifiedRecentLocalBase, false)) {
 					return
 				}

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -39,7 +39,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		depsKnown = true
 	}
 	currentDeps = cloneDeps(currentDeps)
-	_, locallyMutated := c.beadSeq[patch.ID]
+	seqBase, locallyMutated := c.beadSeq[patch.ID]
 	localBeadAt := c.localBeadAt[patch.ID]
 	recentlyLocal := recentLocalMutation(localBeadAt, now)
 	_, locallyDeleted := c.deletedSeq[patch.ID]
@@ -150,20 +150,29 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 				}
 			} else {
 				_, locallyMutated := c.beadSeq[patch.ID]
+				// A concurrent local write can land in the RUnlock->Lock window.
+				// beadChanged compares only the cached Bead, but DepAdd/DepRemove
+				// mutate c.deps and bump the mutation seq without touching
+				// c.beads[id], so a dep-only write slips that guard. The mutation
+				// seq advancing past the read-phase snapshot is the reliable
+				// signal that some local write intervened since the backing
+				// verification (gastownhall/gascity#2210).
+				changedSinceVerify := beadChanged(current, verifiedRecentLocalBase, false) ||
+					c.beadSeq[patch.ID] != seqBase
 				// Re-check a genuine recent local write under the write lock to
 				// catch a write that landed between the read-lock verification
 				// and here; it wins unconditionally.
 				if recentLocalMutation(c.localBeadAt[patch.ID], time.Now()) &&
-					(!verifiedRecentLocal || beadChanged(current, verifiedRecentLocalBase, false)) {
+					(!verifiedRecentLocal || changedSinceVerify) {
 					return
 				}
 				// For a bead flagged locally mutated only by a prior event,
 				// apply the conflict only if it was verified against the
-				// backing store under the read lock and the cached bead has not
-				// changed since (no concurrent local write); otherwise drop and
-				// let reconciliation reconverge (gastownhall/gascity#2210).
+				// backing store under the read lock and nothing changed since
+				// (no concurrent local write); otherwise drop and let
+				// reconciliation reconverge (gastownhall/gascity#2210).
 				if locallyMutated &&
-					(!verifiedRecentLocal || beadChanged(current, verifiedRecentLocalBase, false)) {
+					(!verifiedRecentLocal || changedSinceVerify) {
 					return
 				}
 			}

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -934,6 +934,113 @@ func TestCachingStoreApplyEventRechecksRecentLocalAfterGetRefresh(t *testing.T) 
 	}
 }
 
+func TestCachingStoreApplyEventDropsRoutedEventOnConcurrentDepWrite(t *testing.T) {
+	// Regression for gastownhall/gascity#2210 follow-up: the verified-backing
+	// path applies a conflicting metadata event for a bead flagged locally
+	// mutated only by a prior event. DepAdd/DepRemove mutate c.deps and bump the
+	// mutation seq WITHOUT touching c.beads[id], so a concurrent dep write that
+	// lands in the RUnlock->Lock window is invisible to the beadChanged guard
+	// (which compares only the cached Bead) and gets clobbered by
+	// updateEventDepsLocked. Snapshotting the mutation seq closes that hole: the
+	// event must drop and let reconciliation reconverge, leaving the concurrent
+	// dep write intact. Cover both the structured "dependencies" and the legacy
+	// "needs" payload representations.
+	cases := []struct {
+		name         string
+		created      Bead   // bead as the backing store first sees it (with deps)
+		newDependsOn string // the dependency a concurrent DepAdd installs in the window
+	}{
+		{
+			name:         "dependencies",
+			created:      Bead{Title: "route me", Dependencies: []Dep{{DependsOnID: "dep-1", Type: "blocks"}}},
+			newDependsOn: "dep-2",
+		},
+		{
+			name:         "needs",
+			created:      Bead{Title: "route me", Needs: []string{"need-1"}},
+			newDependsOn: "need-2",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			backing := NewMemStore()
+
+			cache := NewCachingStoreForTest(backing, nil)
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+
+			// `gc bd create` writes the bead (with its deps) to the backing store
+			// in another process; the controller learns it via a bead.created
+			// event. Create after Prime so the apply sets the mutation seq
+			// (locallyMutated) with no local write and seeds c.deps.
+			created, err := backing.Create(tc.created)
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			createdJSON, err := json.Marshal(created)
+			if err != nil {
+				t.Fatalf("marshal created: %v", err)
+			}
+			cache.ApplyEvent("bead.created", json.RawMessage(createdJSON))
+
+			// `gc sling` stamps gc.routed_to in the backing store and emits a
+			// bead.updated event carrying the full bead (same deps, now routed).
+			if err := backing.SetMetadata(created.ID, "gc.routed_to", "pool/polecat"); err != nil {
+				t.Fatalf("SetMetadata: %v", err)
+			}
+			routed, err := backing.Get(created.ID)
+			if err != nil {
+				t.Fatalf("Get backing: %v", err)
+			}
+			routedJSON, err := json.Marshal(routed)
+			if err != nil {
+				t.Fatalf("marshal routed: %v", err)
+			}
+
+			beforeCommit := make(chan struct{})
+			releaseCommit := make(chan struct{})
+			cache.applyEventBeforeCommitForTest = func() {
+				close(beforeCommit)
+				<-releaseCommit
+			}
+
+			done := make(chan struct{})
+			go func() {
+				cache.ApplyEvent("bead.updated", json.RawMessage(routedJSON))
+				close(done)
+			}()
+
+			// A concurrent dep write lands after the routed event verified
+			// against the backing store but before it commits.
+			<-beforeCommit
+			if err := cache.DepAdd(created.ID, tc.newDependsOn, "blocks"); err != nil {
+				t.Fatalf("concurrent DepAdd: %v", err)
+			}
+			close(releaseCommit)
+			<-done
+
+			cache.mu.RLock()
+			deps := cloneDeps(cache.deps[created.ID])
+			cache.mu.RUnlock()
+
+			found := false
+			for _, d := range deps {
+				if d.DependsOnID == tc.newDependsOn {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("concurrent dep %q clobbered by routed event; cached deps=%+v (event must drop and let reconciliation reconverge — #2210)",
+					tc.newDependsOn, deps)
+			}
+		})
+	}
+}
+
 func TestCachingStoreRunReconciliationRecordsProblemAndDegrades(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -2695,3 +2695,67 @@ func containsString(values []string, want string) bool {
 	}
 	return false
 }
+
+// TestCachingStoreAppliesRoutedMetadataEventAfterPriorEventMutation reproduces
+// gastownhall/gascity#2210: a bead.updated event that stamps gc.routed_to
+// (written to the backing store by `gc sling` in another process) must be
+// applied to the cache even when the bead is already "locally mutated" by a
+// PRIOR applied event. ApplyEvent marks every applied event with a mutation
+// seq (noteMutationLocked), so a bead the controller learned about via an
+// earlier bead.created event is flagged locallyMutated without any pending
+// local write. Previously a metadata-changing event on such a bead was dropped
+// outright as a conflict, so the controller cache never learned gc.routed_to,
+// pool demand stayed at 0, and no session spawned until an unrelated later
+// event arrived after a reconcile cleared the mutation seq.
+//
+// The drop must still protect genuine recent local writes (those go through
+// noteLocalMutationLocked and set localBeadAt); this test only covers the
+// prior-event case, where the backing store already reflects the event and a
+// verification read is reliable.
+func TestCachingStoreAppliesRoutedMetadataEventAfterPriorEventMutation(t *testing.T) {
+	t.Parallel()
+	backing := beads.NewMemStore()
+
+	cs := beads.NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// `gc bd create` writes the bead to the backing store (dolt) in another
+	// process; the controller learns about it via a bead.created event. Create
+	// after Prime so the event is the cache's first sight of the bead and its
+	// apply sets the mutation seq (locallyMutated) without any local write.
+	created, err := backing.Create(beads.Bead{Title: "route me"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	createdJSON, err := json.Marshal(created)
+	if err != nil {
+		t.Fatalf("marshal created: %v", err)
+	}
+	cs.ApplyEvent("bead.created", json.RawMessage(createdJSON))
+
+	// `gc sling <pool> <bead>` stamps gc.routed_to in the backing store and
+	// emits a bead.updated event carrying the full bead (now routed).
+	if err := backing.SetMetadata(created.ID, "gc.routed_to", "pool/polecat"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	routed, err := backing.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get backing: %v", err)
+	}
+	routedJSON, err := json.Marshal(routed)
+	if err != nil {
+		t.Fatalf("marshal routed: %v", err)
+	}
+	cs.ApplyEvent("bead.updated", json.RawMessage(routedJSON))
+
+	got, err := cs.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["gc.routed_to"] != "pool/polecat" {
+		t.Fatalf("gc.routed_to after sling-stamp event = %q, want %q (event dropped; pool demand stranded — #2210)",
+			got.Metadata["gc.routed_to"], "pool/polecat")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2210 — control-dispatcher does not reconcile pool demand on initial sling event (`gc.routed_to` stamp); requires a second bd event to spawn.

`CachingStore.ApplyEvent` was dropping the `bead.updated` event that carried the `gc.routed_to` stamp because the bead was flagged `locallyMutated`. Pool demand never recomputed and the slot stayed cold until a later unrelated bd event arrived. This split the `locallyMutated` marker into two cases and verifies events against the backing store when the local-mutation signal isn't an actual pending local write.

## Root cause

`noteMutationLocked` sets the per-bead mutation seq on every applied event, so a bead the controller learned about via an earlier `bead.created` event is flagged `locallyMutated` with no pending local write. The `gc.routed_to` stamp — written to the backing store by `gc sling` in another process, then delivered as a `bead.updated` event — was discarded; the controller cache never learned the routing and pool demand stayed at 0. A later event only worked because a patrol reconcile had cleared the mutation seq by then — matching the reported "wait 60s+, then a second event spawns the pool".

## Fix

Distinguish the two reasons the local-mutation marker is set:

- A genuine local write within the recency window (set via `noteLocalMutationLocked`) keeps dropping conflicting events unconditionally: the backing store may still return a stale row from write-through replication lag, so a verification read is unreliable.
- A bead marked locally-mutated only by a prior applied event (or a local write older than the window) now verifies the conflicting event against the backing store and applies it when the backing store already reflects it, dropping only genuinely stale events.

The locked-phase recheck mirrors the same split so a write that lands between the read-lock verification and the commit still wins.

## Dep-race fixup (Codex grounded review)

A Codex grounded second-opinion review caught a regression introduced by the new locked-phase guards: `beadChanged()` only checked a Bead-only snapshot (`verifiedRecentLocalBase`), but `DepAdd`/`DepRemove` (`internal/beads/caching_store_writes.go:585,625`) mutate `c.deps` and call `noteLocalMutationLocked` WITHOUT touching `c.beads[id]`. A concurrent DepAdd in the RUnlock→Lock window slipped both guards and got clobbered by `updateEventDepsLocked`.

The fixup snapshots `c.beadSeq[id]` alongside `conflictBase` in the read phase and drops the event if the seq advanced (`changedSinceVerify`) in the locked phase, letting reconciliation reconverge.

## Tests

- **`TestCachingStoreAppliesRoutedMetadataEventAfterPriorEventMutation`** — reproduces the dropped `gc.routed_to` event (fails on the prior behaviour, passes with the original fix).
- **`TestCachingStoreApplyEventDropsRoutedEventOnConcurrentDepWrite`** (`/dependencies` + `/needs` payload variants) — injects a concurrent `DepAdd` via `applyEventBeforeCommitForTest`; fails on the original fix alone (event clobbered), passes after the dep-race fixup.

Existing stale-event protections (`ApplyEventRechecksLocalMutationBeforeCommit`, `ApplyEventRechecksRecentLocalAfterGetRefresh`, full `IgnoresStale*` suite) are unchanged and still pass.

## Gates

On `internal/beads`:
- `go build ./...` pass
- `go vet ./...` clean
- `go test -race ./internal/beads/` pass
- `golangci-lint` 0 issues
