### PR TITLE
fix(k8s): accept staged workspace ready marker

### DIFF
--- a/internal/runtime/k8s/pod.go
+++ b/internal/runtime/k8s/pod.go
@@ -221,7 +221,7 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 	credCopy := `mkdir -p $HOME/.claude && cp -rL /tmp/claude-secret/. $HOME/.claude/ 2>/dev/null; git config --global --add safe.directory '*' 2>/dev/null; `
 	wsWait := ""
 	if !p.prebaked {
-		wsWait = `while [ ! -f /workspace/.gc-workspace-ready ]; do sleep 0.5; done; `
+		wsWait = `while [ ! -f /workspace/.gc-workspace-ready ] && [ ! -f /workspace/.gc-ready ]; do sleep 0.5; done; `
 	}
 
 	var tmuxCmd string

--- a/internal/runtime/k8s/pod_test.go
+++ b/internal/runtime/k8s/pod_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -139,5 +140,21 @@ func TestBuildPod_ClonesSchedulingFields(t *testing.T) {
 	values := p.affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Values
 	if values[0] != "gpu" {
 		t.Fatalf("provider affinity value mutated to %q", values[0])
+	}
+}
+
+func TestBuildPod_WaitsForEitherWorkspaceReadyMarker(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash"}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+
+	args := pod.Spec.Containers[0].Args
+	if len(args) != 1 {
+		t.Fatalf("container args = %v, want one shell command", args)
+	}
+	if !strings.Contains(args[0], `/workspace/.gc-workspace-ready ] && [ ! -f /workspace/.gc-ready`) {
+		t.Fatalf("entrypoint does not accept both workspace ready markers: %s", args[0])
 	}
 }


### PR DESCRIPTION
## Summary

- Make Kubernetes agent entrypoints accept either staged workspace readiness marker: `/workspace/.gc-workspace-ready` or `/workspace/.gc-ready`.
- This matches the current k8s staging init container, which waits on and writes `/workspace/.gc-ready`, and prevents newly-created agent pods from waiting forever on the legacy marker.
- Adds a focused pod-building regression test for the generated entrypoint command.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- [x] `go test ./internal/runtime/k8s -run 'ReadyMarker|BuildPod' -count=1`
- [x] `go test ./internal/runtime/k8s -count=1`

`make check` was not used as the merge gate for this small k8s slice because the local broad fast suite has existing baseline failures outside this patch area. The focused package validation above passed on this branch.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No separate issue is needed for this one-line compatibility fix: the failure and expected behavior are fully described in this PR, and the added regression test covers the contract. No docs or migration steps are required; this is backward-compatible with both marker names.
