### PR TITLE
fix(maintenance): preserve live session claims in orphan sweep

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -622,6 +622,113 @@ exit 1
 	}
 }
 
+func TestOrphanSweepPreservesPascalCaseLiveSessionIdentities(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+if [ "$1" = "--rig" ]; then
+  rig="$2"
+  shift 2
+else
+  rig=""
+fi
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      if [ "$rig" = "project" ]; then
+        cat <<'EOF'
+{"sessions":[
+  {"ID":"vgc-live-id","SessionName":"project__worker-vgc-live-name","Alias":"project/worker-1","Template":"project/worker","State":"active","Closed":false},
+  {"ID":"vgc-stopped","SessionName":"project__worker-vgc-stopped","State":"stopped","Closed":false},
+  {"ID":"vgc-swept","SessionName":"project__worker-vgc-swept","State":"gc_swept","Closed":false},
+  {"ID":"vgc-closed","SessionName":"project__worker-vgc-closed","State":"closed","Closed":true}
+],"summary":{},"filters":{},"schema_version":"1"}
+EOF
+        exit 0
+      fi
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      if [ "$3" = "--rig" ] && [ "$4" = "project" ]; then
+        cat <<'EOF'
+[
+  {"id":"ga-live-by-id","status":"in_progress","assignee":"vgc-live-id"},
+  {"id":"ga-live-by-session-name","status":"in_progress","assignee":"project__worker-vgc-live-name"},
+  {"id":"ga-stopped-session","status":"in_progress","assignee":"vgc-stopped"},
+  {"id":"ga-swept-session","status":"in_progress","assignee":"project__worker-vgc-swept"},
+  {"id":"ga-closed-session","status":"in_progress","assignee":"vgc-closed"},
+  {"id":"ga-missing-session","status":"in_progress","assignee":"missing-session"}
+]
+EOF
+      else
+        printf '[]\n'
+      fi
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if !strings.Contains(string(out), "orphan-sweep: reset 4 orphaned beads") {
+		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	for _, preserved := range []string{"ga-live-by-id", "ga-live-by-session-name"} {
+		if strings.Contains(log, "bd update "+preserved+" ") {
+			t.Fatalf("live PascalCase session assignee %s was reset:\n%s", preserved, log)
+		}
+	}
+	for _, reset := range []string{"ga-stopped-session", "ga-swept-session", "ga-closed-session", "ga-missing-session"} {
+		if !strings.Contains(log, "bd update "+reset+" --status=open --assignee=") {
+			t.Fatalf("expected %s to be reset:\n%s", reset, log)
+		}
+	}
+}
+
 func TestOrphanSweepContinuesAfterSingleRigSessionListFailure(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -115,13 +115,25 @@ fi
 # Two bugs the chronic strip pattern (gastownhall/gascity#2363) revealed:
 # (1) The JSON shape is {"sessions":[...], "summary":..., "filters":..., "schema_version":...},
 #     so `.[]` iterated four top-level scalar keys instead of session objects.
-# (2) Field names are snake_case lower (.closed/.id/.session_name/.alias/.agent_name),
-#     not PascalCase. Combined, LIVE_SESSION_IDS was ALWAYS empty and every
-#     ephemeral assignee like gastown__polecat-gc-XXXXX got stripped on every tick.
+# (2) Field names vary by runtime/API path. Accept both snake_case
+#     (.closed/.id/.session_name/.alias/.agent_name) and PascalCase
+#     (.Closed/.ID/.SessionName/.Alias/.Template) so a schema casing change
+#     cannot make LIVE_SESSION_IDS empty and strip active pool claims.
 LIVE_SESSION_IDS=$(jq -r -s '
     .[] | .sessions[]?
-    | select(.closed == false)
-    | [.id, .session_name, .alias, .agent_name]
+    | select(
+        ((.closed // .Closed // false) == false)
+        and (((.state // .State // "") | ascii_downcase) != "closed")
+        and (((.state // .State // "") | ascii_downcase) != "stopped")
+        and (((.state // .State // "") | ascii_downcase) != "gc_swept")
+      )
+    | [
+        (.id // .ID),
+        (.session_name // .SessionName),
+        (.alias // .Alias),
+        (.agent_name // .AgentName // .template // .Template),
+        (.name // .Name)
+      ]
     | .[]
     | select(. != null and . != "")
 ' "$SESSION_TMP" 2>/dev/null) || exit 0


### PR DESCRIPTION
## Summary

- Teach `orphan-sweep.sh` to recognize live session identities from both snake_case and PascalCase `gc session list --json` rows.
- Keep stopped, closed, and `gc_swept` sessions excluded from the live-session identity set.
- Add a regression test proving active work assigned to live session IDs/session names is preserved while stopped, swept, closed, or missing session assignees are reset.

Linked issue: none. This is a narrow maintenance-script bug fix with a self-contained regression test; no public issue exists yet.

## Problem

`orphan-sweep.sh` builds a set of live session identities before reopening in-progress work assigned to sessions that no longer exist. The script expected only snake_case fields such as `.closed`, `.id`, `.session_name`, `.alias`, and `.agent_name`.

Some runtime/API session-list paths can return PascalCase fields such as `.Closed`, `.ID`, `.SessionName`, `.Alias`, `.Template`, and `.State`. In that shape, the old `select(.closed == false)` filter dropped live rows, making the live-session identity set empty. The sweep could then falsely reopen work that was still assigned to a live concrete session.

## Solution

- Accept both snake_case and PascalCase session JSON fields when extracting live session identities.
- Treat `closed`, `stopped`, and `gc_swept` state values as non-live even if a row is present.
- Preserve the existing `live_session_match()` and known-agent logic.
- Cover the failure mode with `TestOrphanSweepPreservesPascalCaseLiveSessionIdentities`.

## Reproduction / Validation

The regression test stubs `gc session list --json` with PascalCase rows and `gc bd list` with in-progress work assigned to:

- a live session ID,
- a live session name,
- a stopped session,
- a swept session,
- a closed session,
- and a missing session.

The test proves only the stopped/swept/closed/missing assignments are reset.

## Tests

- [ ] `make check`
  - Not run for this narrow follow-up.
- [ ] `make check-docs`
  - Not applicable; no docs changed.
- [ ] `make test-integration`
  - Not run; this is a deterministic script regression test with a stubbed `gc` executable.
- [x] `git diff --check upstream/main..HEAD`
- [x] `bash -n examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh`
- [x] `go test ./examples/gastown -run 'TestOrphanSweep' -count=1`
- [ ] `go test ./cmd/gc ./internal/session ./internal/beads -count=1`
  - `cmd/gc` passed in 382.522s.
  - `internal/session` passed in 7.366s.
  - `internal/beads` failed on `TestExecCommandRunnerStopsBDSlowTimerForFastBDCommand`; the same failure reproduced on a clean `upstream/main` worktree. A one-off `TestFileStoreMutatorReloadsSameSizeExternalRewriteWithUnchangedFreshness` setup failure appeared in the broad run but was not repeatable in the focused rerun.

## Second-Order Effects

- Existing snake_case session JSON remains supported.
- PascalCase session JSON no longer causes the live-session set to collapse to empty.
- Stopped, closed, and swept sessions remain eligible for orphan cleanup.
- The change is limited to the maintenance pack script and its tests; it does not change session-list output contracts.

## Privacy Scrub

- No private city names.
- No private rig names.
- No private custom agent names.
- No local absolute evidence paths.
- No production logs or private work-item identifiers.
