### PR TITLE
fix(scale_check): prefer run_target for pool demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1032,12 +1032,7 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
-			// gc.run_target (per-step) takes precedence over gc.routed_to
-			// (convoy-wide default). See dispatch/fanout.go and adaf6ec.
-			template := strings.TrimSpace(b.Metadata["gc.run_target"])
-			if template == "" {
-				template = strings.TrimSpace(b.Metadata["gc.routed_to"])
-			}
+			template := scaleCheckRouteTarget(b)
 			if _, ok := group.templates[template]; !ok {
 				continue
 			}
@@ -1085,7 +1080,7 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
-			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
+			template := scaleCheckRouteTarget(b)
 			if _, ok := group.templates[template]; !ok {
 				continue
 			}
@@ -1181,15 +1176,7 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
-			// gc.run_target (per-step) takes precedence over gc.routed_to
-			// (convoy-wide default). Without this, every child of a
-			// tellus-dev convoy looks routed to the convoy entry agent
-			// and named-singleton demand (architect/product-owner/...)
-			// is never computed. See dispatch/fanout.go and adaf6ec.
-			routedTo := strings.TrimSpace(b.Metadata["gc.run_target"])
-			if routedTo == "" {
-				routedTo = strings.TrimSpace(b.Metadata["gc.routed_to"])
-			}
+			routedTo := scaleCheckRouteTarget(b)
 			if routedTo == "" {
 				continue
 			}
@@ -1210,6 +1197,16 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 		}
 	}
 	return demand, partialTemplates, errs
+}
+
+func scaleCheckRouteTarget(b beads.Bead) string {
+	// gc.run_target is the per-step execution target. It takes precedence
+	// over gc.routed_to, which can be a convoy-wide/default route stamped on
+	// every child. Keep scale-check readers aligned with dispatch/fanout.go.
+	if target := strings.TrimSpace(b.Metadata["gc.run_target"]); target != "" {
+		return target
+	}
+	return strings.TrimSpace(b.Metadata["gc.routed_to"])
 }
 
 func markScaleCheckPartialTemplate(partials map[string]bool, template string) map[string]bool {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -422,6 +422,40 @@ func TestDefaultScaleCheckCountsCountsUnassignedRoutedPoolWork(t *testing.T) {
 	}
 }
 
+func TestDefaultScaleCheckCountsReadyPrefersRunTarget(t *testing.T) {
+	const template = "gascity/reviewer"
+	backing := beads.NewMemStore()
+	if _, err := backing.Create(beads.Bead{
+		Title:  "workflow child",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to":  "gascity/entry",
+			"gc.run_target": template,
+		},
+	}); err != nil {
+		t.Fatalf("create routed bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{
+		{template: template, storeKey: "rig:gascity", store: cache},
+		{template: "gascity/entry", storeKey: "rig:gascity", store: cache},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1 from gc.run_target", template, got)
+	}
+	if got := counts["gascity/entry"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[gascity/entry] = %d, want 0 because gc.run_target wins", got)
+	}
+}
+
 func TestDefaultScaleCheckCountsDoesNotTreatTemplateAssigneeAsDemand(t *testing.T) {
 	const template = "gascity/reviewer"
 	backing := beads.NewMemStore()
@@ -568,6 +602,42 @@ func TestDefaultScaleCheckCountsCountsCronPoolDemandViaMetadataFlag(t *testing.T
 	}
 	if backing.livePoolDemand == 0 {
 		t.Fatalf("livePoolDemand list calls = 0, want >0 (defaultScaleCheckCounts must use Live: true to bypass the CachingStore snapshot, since cron pool orders fire from sibling subprocesses and the cache lags)")
+	}
+}
+
+func TestDefaultScaleCheckCountsCronPoolDemandPrefersRunTarget(t *testing.T) {
+	const template = "dog"
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	metadata := poolWispMetadata("entry-agent")
+	metadata["gc.run_target"] = template
+	if _, err := backing.Create(beads.Bead{
+		Title:    "mol-dog-stale-db",
+		Type:     "molecule",
+		Status:   "open",
+		Metadata: metadata,
+	}); err != nil {
+		t.Fatalf("create pool-order wisp: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{
+		{template: template, storeKey: "city", store: cache},
+		{template: "entry-agent", storeKey: "city", store: cache},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 1 from gc.run_target pool demand", template, got)
+	}
+	if got := counts["entry-agent"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[entry-agent] = %d, want 0 because gc.run_target wins", got)
+	}
+	if backing.livePoolDemand == 0 {
+		t.Fatalf("livePoolDemand list calls = 0, want >0 for Source 2")
 	}
 }
 
@@ -958,6 +1028,45 @@ func TestDefaultNamedSessionDemandUsesPartialReadyRows(t *testing.T) {
 	}
 	if !partialTemplates["worker"] {
 		t.Fatalf("partialTemplates = %v, want worker marked partial", partialTemplates)
+	}
+}
+
+func TestDefaultNamedSessionDemandPrefersRunTarget(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "workflow child",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to":  "entry-agent",
+			"gc.run_target": "worker",
+		},
+	}); err != nil {
+		t.Fatalf("create routed bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name: "worker",
+		}, {
+			Name: "entry-agent",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "primary",
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+	}
+
+	demand, _, errs := defaultNamedSessionDemand([]defaultScaleCheckTarget{
+		{template: "worker", storeKey: "city", store: store},
+		{template: "entry-agent", storeKey: "city", store: store},
+	}, cfg, "test-city")
+	if len(errs) != 0 {
+		t.Fatalf("defaultNamedSessionDemand errs = %v", errs)
+	}
+	if !demand["primary"] {
+		t.Fatalf("defaultNamedSessionDemand[primary] = false, want gc.run_target to materialize named session")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a shared scale-check route-target helper that prefers gc.run_target over gc.routed_to
- apply the fallback to the gc.pool_demand Source 2 demand-list path
- add regressions for Ready, named-session demand, and cron pool-demand precedence

## Validation
- go test ./cmd/gc -run 'TestDefaultScaleCheckCounts(ReadyPrefersRunTarget|CronPoolDemandPrefersRunTarget)|TestDefaultNamedSessionDemandPrefersRunTarget' -count=1
- go test ./cmd/gc -run 'TestDefaultScaleCheckCounts|TestDefaultNamedSessionDemand' -count=1
- go vet ./...
- .githooks/pre-commit