### PR TITLE
fix(maintenance): preserve live session claims in orphan sweep

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -622,6 +622,113 @@ exit 1
 	}
 }
 
+func TestOrphanSweepPreservesPascalCaseLiveSessionIdentities(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+if [ "$1" = "--rig" ]; then
+  rig="$2"
+  shift 2
+else
+  rig=""
+fi
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: project/worker
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      if [ "$rig" = "project" ]; then
+        cat <<'EOF'
+{"sessions":[
+  {"ID":"vgc-live-id","SessionName":"project__worker-vgc-live-name","Alias":"project/worker-1","Template":"project/worker","State":"active","Closed":false},
+  {"ID":"vgc-stopped","SessionName":"project__worker-vgc-stopped","State":"stopped","Closed":false},
+  {"ID":"vgc-swept","SessionName":"project__worker-vgc-swept","State":"gc_swept","Closed":false},
+  {"ID":"vgc-closed","SessionName":"project__worker-vgc-closed","State":"closed","Closed":true}
+],"summary":{},"filters":{},"schema_version":"1"}
+EOF
+        exit 0
+      fi
+      printf '{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      if [ "$3" = "--rig" ] && [ "$4" = "project" ]; then
+        cat <<'EOF'
+[
+  {"id":"ga-live-by-id","status":"in_progress","assignee":"vgc-live-id"},
+  {"id":"ga-live-by-session-name","status":"in_progress","assignee":"project__worker-vgc-live-name"},
+  {"id":"ga-stopped-session","status":"in_progress","assignee":"vgc-stopped"},
+  {"id":"ga-swept-session","status":"in_progress","assignee":"project__worker-vgc-swept"},
+  {"id":"ga-closed-session","status":"in_progress","assignee":"vgc-closed"},
+  {"id":"ga-missing-session","status":"in_progress","assignee":"missing-session"}
+]
+EOF
+      else
+        printf '[]\n'
+      fi
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if !strings.Contains(string(out), "orphan-sweep: reset 4 orphaned beads") {
+		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	for _, preserved := range []string{"ga-live-by-id", "ga-live-by-session-name"} {
+		if strings.Contains(log, "bd update "+preserved+" ") {
+			t.Fatalf("live PascalCase session assignee %s was reset:\n%s", preserved, log)
+		}
+	}
+	for _, reset := range []string{"ga-stopped-session", "ga-swept-session", "ga-closed-session", "ga-missing-session"} {
+		if !strings.Contains(log, "bd update "+reset+" --status=open --assignee=") {
+			t.Fatalf("expected %s to be reset:\n%s", reset, log)
+		}
+	}
+}
+
 func TestOrphanSweepContinuesAfterSingleRigSessionListFailure(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -123,13 +123,25 @@ fi
 # Two bugs the chronic strip pattern (gastownhall/gascity#2363) revealed:
 # (1) The JSON shape is {"sessions":[...], "summary":..., "filters":..., "schema_version":...},
 #     so `.[]` iterated four top-level scalar keys instead of session objects.
-# (2) Field names are snake_case lower (.closed/.id/.session_name/.alias/.agent_name),
-#     not PascalCase. Combined, LIVE_SESSION_IDS was ALWAYS empty and every
-#     ephemeral assignee like gastown__polecat-gc-XXXXX got stripped on every tick.
+# (2) Field names vary by runtime/API path. Accept both snake_case
+#     (.closed/.id/.session_name/.alias/.agent_name) and PascalCase
+#     (.Closed/.ID/.SessionName/.Alias/.Template) so a schema casing change
+#     cannot make LIVE_SESSION_IDS empty and strip active pool claims.
 LIVE_SESSION_IDS=$(jq -r -s '
     .[] | .sessions[]?
-    | select(.closed == false)
-    | [.id, .session_name, .alias, .agent_name]
+    | select(
+        ((.closed // .Closed // false) == false)
+        and (((.state // .State // "") | ascii_downcase) != "closed")
+        and (((.state // .State // "") | ascii_downcase) != "stopped")
+        and (((.state // .State // "") | ascii_downcase) != "gc_swept")
+      )
+    | [
+        (.id // .ID),
+        (.session_name // .SessionName),
+        (.alias // .Alias),
+        (.agent_name // .AgentName // .template // .Template),
+        (.name // .Name)
+      ]
     | .[]
     | select(. != null and . != "")
 ' "$SESSION_TMP" 2>/dev/null) || exit 0


### PR DESCRIPTION
## Summary

- Preserve live session-owned work in `orphan-sweep.sh` when `gc session list --json` returns PascalCase session fields.
- Accept both snake_case and PascalCase identities (`id`/`ID`, `session_name`/`SessionName`, `alias`/`Alias`, `agent_name`/`AgentName`, `template`/`Template`, `name`/`Name`) and exclude closed, stopped, or `gc_swept` sessions.
- Add regression coverage proving live PascalCase `ID` and `SessionName` assignees are preserved while stopped, swept, closed, and missing sessions are still reset.

This closes a gap left after #2661. That PR improved assigned in-progress work visibility, but the maintenance-pack orphan sweep still had its own session-list parser and could miss live session identities when the JSON field casing changed.

No separate issue is linked because this is a narrow follow-up regression fix in the maintenance pack parser, with focused coverage in the same PR.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Validated on this PR branch:

- `git diff --check upstream/main..HEAD`
- `bash -n examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh`
- `go test ./examples/gastown -run 'TestOrphanSweepPreservesPascalCaseLiveSessionIdentities|TestOrphanSweep' -count=1`

Additional local validation on the fork commit that introduced the same patch:

- `go test ./cmd/gc ./internal/session ./internal/beads -count=1`
- `go test ./examples/gastown -run 'TestOrphanSweep' -count=1`
- `go test ./examples/gastown -count=1` was run and hit existing unrelated baseline failures in `TestPolecatFormulaHaltsOnAutoPushFalse` and `TestReaperCityDatabaseUsesShellFallbackWhenJSONParsersUnavailable`.
- A 61-minute local soak completed with 13 samples and 130 sampled commands: zero command failures, max sampled command latency 1.454s, `gc status` stayed `health.degraded=false`, Dolt contention counters stayed at zero, order dispatch continued, and there were zero `order:orphan-sweep` field changes after the soak start.
- During the soak, active pool-worker and debugger-plan claims owned by live unique session identities survived subsequent orphan-sweep cycles instead of being reopened.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

Docs: not user-facing; no docs changes required.

Breaking changes or migration notes: none. This preserves existing orphan cleanup for truly missing, closed, stopped, and `gc_swept` sessions while preventing false orphan resets for live sessions.
