### PR TITLE
fix(doctor): guard local-only Dolt remotes

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -19,6 +19,7 @@ var (
 	newDoctorDoltServerCheck    = doctor.NewDoltServerCheck
 	newDoctorRigDoltServerCheck = doctor.NewRigDoltServerCheck
 	newDoctorDoltBackupCheck    = doctor.NewDoltBackupCheck
+	newDoctorDoltLocalOnlyCheck = doctor.NewDoltLocalOnlyRemoteCheck
 )
 
 func newDoctorCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -313,6 +314,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 			// skip non-managed-bdstore rigs and GC_DOLT=skip environments.
 			if rigUsesManagedBdStoreContract(cityPath, rig) && !gcDoltSkip() {
 				register(newDoctorDoltBackupCheck(cityPath, rig, managedDoltDataDir))
+				register(newDoctorDoltLocalOnlyCheck(cityPath, rig, managedDoltDataDir))
 			}
 		}
 	}

--- a/cmd/gc/cmd_doctor_dolt_local_only_test.go
+++ b/cmd/gc/cmd_doctor_dolt_local_only_test.go
@@ -1,0 +1,203 @@
+package main
+
+// RED tests for the dolt-local-only-remote doctor check registration in
+// cmd_doctor.go (ga-673qo6.1).
+//
+// These tests must fail to compile until the builder implements:
+//   - cmd/gc/cmd_doctor.go: newDoctorDoltLocalOnlyCheck var + registration
+//     after newDoctorDoltBackupCheck at the managed-bdstore gate.
+//   - internal/doctor/checks_dolt_local_only.go: DoltLocalOnlyRemoteCheck
+//     and NewDoltLocalOnlyRemoteCheck (see checks_dolt_local_only_test.go).
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+const cityTomlWithManagedRigs = `[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "managed"
+path = "managed"
+prefix = "ma"
+
+[[rigs]]
+name = "filebacked"
+path = "filebacked"
+prefix = "fi"
+
+[[rigs]]
+name = "suspended"
+path = "suspended"
+prefix = "su"
+suspended = true
+`
+
+// TestDoDoctorRegistersLocalOnlyRemoteCheckForActiveManagedRigs verifies that
+// the dolt-local-only-remote check is registered for each active managed-dolt
+// rig, mirroring the gate used for newDoctorDoltBackupCheck.
+func TestDoDoctorRegistersLocalOnlyRemoteCheckForActiveManagedRigs(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityTomlWithManagedRigs), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"managed", "filebacked", "suspended"} {
+		if err := os.MkdirAll(filepath.Join(cityDir, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"managed", "suspended"} {
+		rigDir := filepath.Join(cityDir, name)
+		if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "metadata.json"), contract.MetadataState{
+			Database:     "dolt",
+			Backend:      "dolt",
+			DoltMode:     "server",
+			DoltDatabase: name,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	doltDataDir := filepath.Join(cityDir, "runtime-dolt")
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_DOLT_DATA_DIR", doltDataDir)
+	oldCityFlag := cityFlag
+	cityFlag = cityDir
+	t.Cleanup(func() { cityFlag = oldCityFlag })
+
+	oldCityCheck := newDoctorDoltServerCheck
+	oldRigCheck := newDoctorRigDoltServerCheck
+	oldBackupCheck := newDoctorDoltBackupCheck
+	oldLocalOnlyCheck := newDoctorDoltLocalOnlyCheck
+	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
+		return doctor.NewDoltServerCheck(cityPath, true)
+	}
+	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
+		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
+	}
+	newDoctorDoltBackupCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltBackupCheck {
+		return doctor.NewDoltBackupCheck(cityPath, rig, dataDir)
+	}
+	registered := map[string]string{}
+	newDoctorDoltLocalOnlyCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltLocalOnlyRemoteCheck {
+		registered[rig.Name] = dataDir
+		return doctor.NewDoltLocalOnlyRemoteCheck(cityPath, rig, dataDir)
+	}
+	t.Cleanup(func() {
+		newDoctorDoltServerCheck = oldCityCheck
+		newDoctorRigDoltServerCheck = oldRigCheck
+		newDoctorDoltBackupCheck = oldBackupCheck
+		newDoctorDoltLocalOnlyCheck = oldLocalOnlyCheck
+	})
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+
+	if len(registered) != 1 {
+		t.Fatalf("registered dolt-local-only checks = %#v, want exactly the active managed rig", registered)
+	}
+	if got := registered["managed"]; got != doltDataDir {
+		t.Fatalf("managed rig data dir = %q, want %q", got, doltDataDir)
+	}
+	if _, ok := registered["filebacked"]; ok {
+		t.Fatalf("file-backed rig should not register dolt-local-only check: %#v", registered)
+	}
+	if _, ok := registered["suspended"]; ok {
+		t.Fatalf("suspended rig should not register dolt-local-only check: %#v", registered)
+	}
+}
+
+// TestDoDoctorSkipsLocalOnlyCheckWhenGCDoltSkip verifies that the
+// dolt-local-only-remote check is not registered when GC_DOLT=skip, matching
+// the behaviour of the existing dolt-backup check.
+func TestDoDoctorSkipsLocalOnlyCheckWhenGCDoltSkip(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "managed")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[[rigs]]
+name = "managed"
+path = "managed"
+prefix = "ma"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "metadata.json"), contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "managed",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_DOLT", "skip")
+	oldCityFlag := cityFlag
+	cityFlag = cityDir
+	t.Cleanup(func() { cityFlag = oldCityFlag })
+
+	oldCityCheck := newDoctorDoltServerCheck
+	oldRigCheck := newDoctorRigDoltServerCheck
+	oldBackupCheck := newDoctorDoltBackupCheck
+	oldLocalOnlyCheck := newDoctorDoltLocalOnlyCheck
+	registered := 0
+	newDoctorDoltServerCheck = func(cityPath string, _ bool) *doctor.DoltServerCheck {
+		return doctor.NewDoltServerCheck(cityPath, true)
+	}
+	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
+		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
+	}
+	newDoctorDoltBackupCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltBackupCheck {
+		return doctor.NewDoltBackupCheck(cityPath, rig, dataDir)
+	}
+	newDoctorDoltLocalOnlyCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltLocalOnlyRemoteCheck {
+		registered++
+		return doctor.NewDoltLocalOnlyRemoteCheck(cityPath, rig, dataDir)
+	}
+	t.Cleanup(func() {
+		newDoctorDoltServerCheck = oldCityCheck
+		newDoctorRigDoltServerCheck = oldRigCheck
+		newDoctorDoltBackupCheck = oldBackupCheck
+		newDoctorDoltLocalOnlyCheck = oldLocalOnlyCheck
+	})
+
+	var stdout, stderr bytes.Buffer
+	_ = doDoctor(false, false, false, false, &stdout, &stderr)
+
+	if registered != 0 {
+		t.Fatalf("registered %d dolt-local-only checks, want 0 when GC_DOLT=skip", registered)
+	}
+}

--- a/cmd/gc/cmd_doctor_dolt_local_only_test.go
+++ b/cmd/gc/cmd_doctor_dolt_local_only_test.go
@@ -93,9 +93,7 @@ func TestDoDoctorRegistersLocalOnlyRemoteCheckForActiveManagedRigs(t *testing.T)
 	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
 		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
 	}
-	newDoctorDoltBackupCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltBackupCheck {
-		return doctor.NewDoltBackupCheck(cityPath, rig, dataDir)
-	}
+	newDoctorDoltBackupCheck = doctor.NewDoltBackupCheck
 	registered := map[string]string{}
 	newDoctorDoltLocalOnlyCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltLocalOnlyRemoteCheck {
 		registered[rig.Name] = dataDir
@@ -127,7 +125,7 @@ func TestDoDoctorRegistersLocalOnlyRemoteCheckForActiveManagedRigs(t *testing.T)
 
 // TestDoDoctorSkipsLocalOnlyCheckWhenGCDoltSkip verifies that the
 // dolt-local-only-remote check is not registered when GC_DOLT=skip, matching
-// the behaviour of the existing dolt-backup check.
+// the behavior of the existing dolt-backup check.
 func TestDoDoctorSkipsLocalOnlyCheckWhenGCDoltSkip(t *testing.T) {
 	clearInheritedBeadsEnv(t)
 
@@ -180,9 +178,7 @@ prefix = "ma"
 	newDoctorRigDoltServerCheck = func(cityPath string, rig config.Rig, _ bool) *doctor.RigDoltServerCheck {
 		return doctor.NewRigDoltServerCheck(cityPath, rig, true)
 	}
-	newDoctorDoltBackupCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltBackupCheck {
-		return doctor.NewDoltBackupCheck(cityPath, rig, dataDir)
-	}
+	newDoctorDoltBackupCheck = doctor.NewDoltBackupCheck
 	newDoctorDoltLocalOnlyCheck = func(cityPath string, rig config.Rig, dataDir string) *doctor.DoltLocalOnlyRemoteCheck {
 		registered++
 		return doctor.NewDoltLocalOnlyRemoteCheck(cityPath, rig, dataDir)

--- a/internal/doctor/checks_dolt_backup.go
+++ b/internal/doctor/checks_dolt_backup.go
@@ -103,11 +103,7 @@ func (c *DoltBackupCheck) CanFix() bool { return false }
 func (c *DoltBackupCheck) Fix(_ *CheckContext) error { return nil }
 
 func (c *DoltBackupCheck) normalizedRigPath() string {
-	rigPath := c.rig.Path
-	if !filepath.IsAbs(rigPath) {
-		rigPath = filepath.Join(c.cityPath, rigPath)
-	}
-	return rigPath
+	return normalizedRigPath(c.cityPath, c.rig)
 }
 
 // resolveDBName returns the rig's Dolt database name from
@@ -116,24 +112,36 @@ func (c *DoltBackupCheck) normalizedRigPath() string {
 // for rigs whose metadata never landed — the operator can correct the
 // db name in the suggested command if needed.
 func (c *DoltBackupCheck) resolveDBName(rigPath string) (string, []string) {
+	return resolveDoltDBName(c.rig, rigPath)
+}
+
+func normalizedRigPath(cityPath string, rig config.Rig) string {
+	rigPath := rig.Path
+	if !filepath.IsAbs(rigPath) {
+		rigPath = filepath.Join(cityPath, rigPath)
+	}
+	return rigPath
+}
+
+func resolveDoltDBName(rig config.Rig, rigPath string) (string, []string) {
 	metadataPath := filepath.Join(rigPath, ".beads", "metadata.json")
 	data, err := os.ReadFile(metadataPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return c.rig.Name, nil
+			return rig.Name, nil
 		}
-		return c.rig.Name, []string{fmt.Sprintf("read metadata.json: %v; using rig name %q", err, c.rig.Name)}
+		return rig.Name, []string{fmt.Sprintf("read metadata.json: %v; using rig name %q", err, rig.Name)}
 	}
 	var meta struct {
 		DoltDatabase string `json:"dolt_database"`
 	}
 	if err := json.Unmarshal(data, &meta); err != nil {
-		return c.rig.Name, []string{fmt.Sprintf("parse metadata.json: %v; using rig name %q", err, c.rig.Name)}
+		return rig.Name, []string{fmt.Sprintf("parse metadata.json: %v; using rig name %q", err, rig.Name)}
 	}
 	if s := strings.TrimSpace(meta.DoltDatabase); s != "" {
 		return s, nil
 	}
-	return c.rig.Name, nil
+	return rig.Name, nil
 }
 
 // backupRemoteRegistered reports whether

--- a/internal/doctor/checks_dolt_local_only.go
+++ b/internal/doctor/checks_dolt_local_only.go
@@ -1,0 +1,294 @@
+package doctor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// DoltLocalOnlyRemoteCheck verifies that local-only managed Dolt rigs do not
+// retain off-box Dolt remotes reintroduced from the CLI repo state.
+type DoltLocalOnlyRemoteCheck struct {
+	cityPath     string
+	rig          config.Rig
+	doltDataDir  string
+	removeRemote func(rigPath, remoteName string) error
+}
+
+// NewDoltLocalOnlyRemoteCheck creates a per-rig local-only Dolt remote check.
+func NewDoltLocalOnlyRemoteCheck(cityPath string, rig config.Rig, doltDataDir string) *DoltLocalOnlyRemoteCheck {
+	if strings.TrimSpace(doltDataDir) == "" {
+		doltDataDir = filepath.Join(cityPath, ".beads", "dolt")
+	}
+	return &DoltLocalOnlyRemoteCheck{
+		cityPath:     cityPath,
+		rig:          rig,
+		doltDataDir:  doltDataDir,
+		removeRemote: removeDoltRemote,
+	}
+}
+
+// Name returns the check identifier ("rig:<name>:dolt-local-only-remote").
+func (c *DoltLocalOnlyRemoteCheck) Name() string {
+	return "rig:" + c.rig.Name + ":dolt-local-only-remote"
+}
+
+// Run executes the check.
+func (c *DoltLocalOnlyRemoteCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	rigPath := normalizedRigPath(c.cityPath, c.rig)
+
+	localOnly, configured, err := rigDoltLocalOnly(rigPath)
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("rig %q: cannot read dolt local-only config", c.rig.Name)
+		r.Details = []string{err.Error()}
+		return r
+	}
+	if !configured {
+		r.Status = StatusOK
+		r.Message = "dolt local-only not configured"
+		return r
+	}
+	if !localOnly {
+		r.Status = StatusOK
+		r.Message = "dolt local-only disabled"
+		return r
+	}
+
+	offBox, details, err := c.offBoxRemotes(rigPath)
+	r.Details = append(r.Details, details...)
+	if err != nil {
+		r.Status = StatusWarning
+		r.Message = fmt.Sprintf("rig %q: cannot inspect Dolt repo_state.json", c.rig.Name)
+		r.Details = append(r.Details, err.Error())
+		return r
+	}
+	if len(offBox) == 0 {
+		r.Status = StatusOK
+		r.Message = "dolt local-only remote state OK"
+		return r
+	}
+
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("rig %q: dolt.local-only is true but off-box Dolt remote(s) are registered: %s",
+		c.rig.Name, localOnlyRemoteNames(offBox))
+	r.FixHint = localOnlyRemoteFixHint(offBox)
+	return r
+}
+
+// CanFix returns true only when local-only mode is explicitly enabled.
+func (c *DoltLocalOnlyRemoteCheck) CanFix() bool {
+	rigPath := normalizedRigPath(c.cityPath, c.rig)
+	localOnly, _, err := rigDoltLocalOnly(rigPath)
+	return err == nil && localOnly
+}
+
+// Fix removes only off-box Dolt remotes from a local-only rig.
+func (c *DoltLocalOnlyRemoteCheck) Fix(_ *CheckContext) error {
+	rigPath := normalizedRigPath(c.cityPath, c.rig)
+	localOnly, _, err := rigDoltLocalOnly(rigPath)
+	if err != nil {
+		return err
+	}
+	if !localOnly {
+		return nil
+	}
+	offBox, _, err := c.offBoxRemotes(rigPath)
+	if err != nil {
+		return err
+	}
+	for _, remote := range offBox {
+		if err := c.removeRemote(rigPath, remote.Name); err != nil {
+			return fmt.Errorf("removing dolt remote %q: %w", remote.Name, err)
+		}
+	}
+	return nil
+}
+
+func (c *DoltLocalOnlyRemoteCheck) offBoxRemotes(rigPath string) ([]doltRemoteState, []string, error) {
+	dbName, details := resolveDoltDBName(c.rig, rigPath)
+	remotes, err := readDoltRepoStateRemotes(c.doltDataDir, dbName)
+	if err != nil {
+		return nil, details, err
+	}
+	var offBox []doltRemoteState
+	for _, remote := range remotes {
+		if isOffBoxDoltRemoteURL(remote.URL) {
+			offBox = append(offBox, remote)
+		}
+	}
+	sortDoltRemotes(offBox)
+	return offBox, details, nil
+}
+
+func rigDoltLocalOnly(rigPath string) (bool, bool, error) {
+	configPath := filepath.Join(rigPath, ".beads", "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, false, nil
+		}
+		return false, false, fmt.Errorf("read %s: %w", configPath, err)
+	}
+	var cfg map[string]any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return false, true, fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	value, ok := lookupConfigValue(cfg, "dolt.local-only")
+	if !ok {
+		return false, false, nil
+	}
+	enabled, ok := boolish(value)
+	if !ok {
+		return false, true, fmt.Errorf("parse %s dolt.local-only: expected boolean, got %T", configPath, value)
+	}
+	return enabled, true, nil
+}
+
+func lookupConfigValue(cfg map[string]any, key string) (any, bool) {
+	if value, ok := cfg[key]; ok {
+		return value, true
+	}
+	parts := strings.Split(key, ".")
+	var current any = cfg
+	for _, part := range parts {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func boolish(value any) (bool, bool) {
+	switch v := value.(type) {
+	case bool:
+		return v, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "1", "true", "yes", "on":
+			return true, true
+		case "0", "false", "no", "off":
+			return false, true
+		default:
+			return false, false
+		}
+	default:
+		return false, false
+	}
+}
+
+type doltRemoteState struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+func readDoltRepoStateRemotes(doltDataDir, dbName string) ([]doltRemoteState, error) {
+	statePath := filepath.Join(doltDataDir, dbName, ".dolt", "repo_state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var state struct {
+		Remotes map[string]doltRemoteState `json:"remotes"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", statePath, err)
+	}
+	remotes := make([]doltRemoteState, 0, len(state.Remotes))
+	for name, remote := range state.Remotes {
+		if strings.TrimSpace(remote.Name) == "" {
+			remote.Name = name
+		}
+		remotes = append(remotes, remote)
+	}
+	sortDoltRemotes(remotes)
+	return remotes, nil
+}
+
+func isOffBoxDoltRemoteURL(rawURL string) bool {
+	url := strings.ToLower(strings.TrimSpace(rawURL))
+	if url == "" || strings.HasPrefix(url, "file://") {
+		return false
+	}
+	if strings.HasPrefix(url, "/") || strings.HasPrefix(url, "./") || strings.HasPrefix(url, "../") {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(url, "git+https://"):
+		return true
+	case strings.HasPrefix(url, "git+http://"):
+		return true
+	case strings.HasPrefix(url, "git+ssh://"):
+		return true
+	case strings.HasPrefix(url, "https://"):
+		return true
+	case strings.HasPrefix(url, "http://"):
+		return true
+	case strings.HasPrefix(url, "ssh://"):
+		return true
+	case strings.HasPrefix(url, "dolthub://"):
+		return true
+	case strings.HasPrefix(url, "s3://"):
+		return true
+	case strings.HasPrefix(url, "gs://"):
+		return true
+	case strings.HasPrefix(url, "az://"):
+		return true
+	case strings.Contains(url, "@") && strings.Contains(url, ":"):
+		return true
+	default:
+		return false
+	}
+}
+
+func sortDoltRemotes(remotes []doltRemoteState) {
+	sort.Slice(remotes, func(i, j int) bool {
+		return remotes[i].Name < remotes[j].Name
+	})
+}
+
+func localOnlyRemoteNames(remotes []doltRemoteState) string {
+	names := make([]string, 0, len(remotes))
+	for _, remote := range remotes {
+		names = append(names, remote.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func localOnlyRemoteFixHint(remotes []doltRemoteState) string {
+	lines := make([]string, 0, len(remotes)+1)
+	lines = append(lines, "remove off-box Dolt remote(s):")
+	for _, remote := range remotes {
+		lines = append(lines, "  bd dolt remote remove "+remote.Name)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func removeDoltRemote(rigPath, remoteName string) error {
+	cmd := exec.Command("bd", "--sandbox", "dolt", "remote", "remove", remoteName)
+	cmd.Dir = rigPath
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bd --sandbox dolt remote remove %s: %w: %s", remoteName, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/doctor/checks_dolt_local_only_test.go
+++ b/internal/doctor/checks_dolt_local_only_test.go
@@ -2,7 +2,7 @@ package doctor
 
 // RED tests for internal/doctor/checks_dolt_local_only.go (ga-673qo6.1).
 //
-// These tests define the expected behaviour of DoltLocalOnlyRemoteCheck and
+// These tests define the expected behavior of DoltLocalOnlyRemoteCheck and
 // must fail to compile until the builder implements:
 //   - internal/doctor/checks_dolt_local_only.go with DoltLocalOnlyRemoteCheck,
 //     NewDoltLocalOnlyRemoteCheck, and the injectable removeRemote field.
@@ -416,7 +416,7 @@ func TestDoltLocalOnlyRemoteCheck_Fix_CallsRemoveForOffBoxRemotes(t *testing.T) 
 	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
 
 	var removeCalls []string
-	c.removeRemote = func(rigPath, remoteName string) error {
+	c.removeRemote = func(_ string, remoteName string) error {
 		removeCalls = append(removeCalls, remoteName)
 		return nil
 	}
@@ -451,7 +451,7 @@ func TestDoltLocalOnlyRemoteCheck_Fix_PropagatesRemoveError(t *testing.T) {
 	rig := config.Rig{Name: "testrig", Path: rigPath}
 	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
 	removeErr := errors.New("bd dolt remote remove: server not reachable")
-	c.removeRemote = func(rigPath, remoteName string) error {
+	c.removeRemote = func(_ string, _ string) error {
 		return removeErr
 	}
 

--- a/internal/doctor/checks_dolt_local_only_test.go
+++ b/internal/doctor/checks_dolt_local_only_test.go
@@ -1,0 +1,515 @@
+package doctor
+
+// RED tests for internal/doctor/checks_dolt_local_only.go (ga-673qo6.1).
+//
+// These tests define the expected behaviour of DoltLocalOnlyRemoteCheck and
+// must fail to compile until the builder implements:
+//   - internal/doctor/checks_dolt_local_only.go with DoltLocalOnlyRemoteCheck,
+//     NewDoltLocalOnlyRemoteCheck, and the injectable removeRemote field.
+//
+// Re-entry paths covered (both vectors from ga-d457b):
+//   Path 1 (normal store open remote sync): bd auto-push re-derives the git
+//     origin remote and re-adds it to dolt_remotes on every bd write, even
+//     with dolt.auto-push:false set (blocks PUSH, not re-registration). Any
+//     bd write causes origin to reappear in repo_state.json.
+//   Path 2 (bd init/reattach wiring): bd init or gc rig reattach reads git
+//     remotes from the working tree and wires them into Dolt's dolt_remotes
+//     table, re-adding origin after a one-time CALL DOLT_REMOTE remove.
+//
+// Both paths leave the same artifact — a remote entry in
+// <doltDataDir>/<db>/.dolt/repo_state.json — so one doctor check detects both.
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// writeRigConfigYAML writes .beads/config.yaml with the given content.
+func writeRigConfigYAML(t *testing.T, rigPath, content string) {
+	t.Helper()
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("create .beads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+}
+
+// writeRepoStateWithRemotes writes a minimal repo_state.json under
+// <doltDataDir>/<dbName>/.dolt/ with the given remotes map.
+// Each entry in remotes maps remote name → URL.
+func writeRepoStateWithRemotes(t *testing.T, doltDataDir, dbName string, remotes map[string]string) {
+	t.Helper()
+	doltDir := filepath.Join(doltDataDir, dbName, ".dolt")
+	if err := os.MkdirAll(doltDir, 0o700); err != nil {
+		t.Fatalf("create .dolt dir: %v", err)
+	}
+	remotesMap := make(map[string]any, len(remotes))
+	for name, url := range remotes {
+		remotesMap[name] = map[string]any{
+			"name":        name,
+			"url":         url,
+			"fetch_specs": []string{"refs/heads/*:refs/remotes/" + name + "/*"},
+			"params":      map[string]any{},
+		}
+	}
+	state := map[string]any{
+		"head":     "refs/heads/main",
+		"remotes":  remotesMap,
+		"backups":  map[string]any{},
+		"branches": map[string]any{},
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal repo_state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, "repo_state.json"), data, 0o600); err != nil {
+		t.Fatalf("write repo_state.json: %v", err)
+	}
+}
+
+const localOnlyConfigYAML = `issue_prefix: ga
+dolt.local-only: true
+dolt.auto-push: false
+no-push: true
+export.auto: false
+`
+
+const localOnlyFalseConfigYAML = `issue_prefix: ga
+dolt.local-only: false
+`
+
+// TestDoltLocalOnlyRemoteCheck_Name verifies the canonical check identifier.
+func TestDoltLocalOnlyRemoteCheck_Name(t *testing.T) {
+	rig := config.Rig{Name: "gascity", Path: t.TempDir()}
+	c := NewDoltLocalOnlyRemoteCheck(t.TempDir(), rig, filepath.Join(t.TempDir(), ".beads", "dolt"))
+	want := "rig:gascity:dolt-local-only-remote"
+	if got := c.Name(); got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_NoConfig_OK verifies that a rig with no
+// .beads/config.yaml is treated as StatusOK — local-only is not configured so
+// any remote is legitimate.
+func TestDoltLocalOnlyRemoteCheck_NoConfig_OK(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"origin": "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK (local-only not configured)", r.Status, r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_LocalOnlyFalse_OK verifies that a rig with
+// dolt.local-only: false (remote sync intentional) does not warn even when
+// an off-box remote is present.
+func TestDoltLocalOnlyRemoteCheck_LocalOnlyFalse_OK(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyFalseConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"origin": "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK (remote sync is legitimate when not local-only)", r.Status, r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_LocalOnlyTrue_NoRepoState_OK verifies that
+// dolt.local-only: true with no repo_state.json (fresh db) is StatusOK.
+func TestDoltLocalOnlyRemoteCheck_LocalOnlyTrue_NoRepoState_OK(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	// No repo_state.json written — database has no remotes.
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK (no repo_state → no remotes)", r.Status, r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_LocalOnlyTrue_EmptyRemotes_OK verifies that
+// dolt.local-only: true with an empty remotes map is StatusOK. This is the
+// expected state after a successful one-time CALL DOLT_REMOTE remove.
+func TestDoltLocalOnlyRemoteCheck_LocalOnlyTrue_EmptyRemotes_OK(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", nil) // no remotes
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK (empty remotes is the desired state)", r.Status, r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_LocalOnlyTrue_LocalBackupOnly_OK verifies that
+// a local file:// backup remote is not treated as an off-box sync remote.
+// The <db>-backup convention is used by mol-dog-backup for local snapshots;
+// it is neither an off-box sync vector nor a violation of local-only policy.
+func TestDoltLocalOnlyRemoteCheck_LocalOnlyTrue_LocalBackupOnly_OK(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"testdb-backup": "file://" + filepath.Join(cityPath, ".dolt-backup", "testdb"),
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d (%s), want StatusOK (local file:// backup remote is not an off-box sync vector)", r.Status, r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_StoreWriteReEntry_GitPlusHttps_Warns covers
+// Path 1 (normal store open remote sync): bd re-derives origin from the git
+// working tree and re-adds it on every bd write (git+https URL scheme).
+// After the one-time CALL DOLT_REMOTE remove, the next bd update recreates:
+//
+//	origin | git+https://github.com/gastownhall/gascity.git
+//
+// The guard must detect this and surface it as StatusWarning.
+func TestDoltLocalOnlyRemoteCheck_StoreWriteReEntry_GitPlusHttps_Warns(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"origin": "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning; message=%s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "origin") {
+		t.Errorf("Message should name the offending remote %q: %s", "origin", r.Message)
+	}
+	if !strings.Contains(r.FixHint, "bd dolt remote remove origin") {
+		t.Errorf("FixHint should contain 'bd dolt remote remove origin': %s", r.FixHint)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_InitWiringReEntry_HttpsRemote_Warns covers
+// Path 2 (bd init/reattach wiring): bd init reads git config and wires the
+// git remote as a Dolt remote (upstream cmd/bd/sync_git.go AddRemote site).
+// After a one-time cleanup, the next gc start / gc rig reattach re-adds:
+//
+//	origin | https://github.com/gastownhall/gascity.git
+//
+// The guard must detect the plain https URL and surface it as StatusWarning.
+func TestDoltLocalOnlyRemoteCheck_InitWiringReEntry_HttpsRemote_Warns(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"origin": "https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning; message=%s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "origin") {
+		t.Errorf("Message should name the offending remote %q: %s", "origin", r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_SshRemote_Warns verifies that an SSH remote
+// URL is also treated as an off-box sync vector under local-only policy.
+func TestDoltLocalOnlyRemoteCheck_SshRemote_Warns(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"upstream": "ssh://git@github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning for ssh:// remote; message=%s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "upstream") {
+		t.Errorf("Message should name the offending remote 'upstream': %s", r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_MultipleOffBoxRemotes_Warns verifies that
+// multiple off-box remotes are all reported (both URLs reappear via V1/V2).
+func TestDoltLocalOnlyRemoteCheck_MultipleOffBoxRemotes_Warns(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"origin":   "git+https://github.com/gastownhall/gascity.git",
+		"upstream": "https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning for multiple off-box remotes; message=%s", r.Status, r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_MixedRemotes_Warns verifies that a mix of
+// local backup and off-box sync remotes still triggers StatusWarning (the
+// off-box remote is the violation; the local backup is fine).
+func TestDoltLocalOnlyRemoteCheck_MixedRemotes_Warns(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"testdb-backup": "file://" + filepath.Join(cityPath, ".dolt-backup", "testdb"),
+		"origin":        "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning (off-box remote present alongside local backup); message=%s",
+			r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "origin") {
+		t.Errorf("Message should name the off-box remote 'origin', not the backup: %s", r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_CanFix_LocalOnly verifies CanFix returns true
+// when the rig is configured for local-only. The explicit flag makes
+// auto-strip safe (unambiguous operator intent, unlike warn-only).
+func TestDoltLocalOnlyRemoteCheck_CanFix_LocalOnly(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, filepath.Join(cityPath, ".beads", "dolt"))
+	if !c.CanFix() {
+		t.Fatal("CanFix() = false, want true when dolt.local-only: true (explicit flag makes auto-strip safe)")
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_CanFix_NotConfigured verifies CanFix returns
+// false when local-only is not configured (remote sync may be intentional).
+func TestDoltLocalOnlyRemoteCheck_CanFix_NotConfigured(t *testing.T) {
+	rig := config.Rig{Name: "testrig", Path: t.TempDir()}
+	c := NewDoltLocalOnlyRemoteCheck(t.TempDir(), rig, filepath.Join(t.TempDir(), ".beads", "dolt"))
+	if c.CanFix() {
+		t.Fatal("CanFix() = true, want false when dolt.local-only not configured")
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_Fix_CallsRemoveForOffBoxRemotes verifies that
+// Fix() calls the injectable remove function for each off-box sync remote, and
+// does not call it for local file:// backup remotes.
+func TestDoltLocalOnlyRemoteCheck_Fix_CallsRemoveForOffBoxRemotes(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"origin":        "git+https://github.com/gastownhall/gascity.git",
+		"testdb-backup": "file://" + filepath.Join(cityPath, ".dolt-backup", "testdb"),
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+
+	var removeCalls []string
+	c.removeRemote = func(rigPath, remoteName string) error {
+		removeCalls = append(removeCalls, remoteName)
+		return nil
+	}
+
+	if err := c.Fix(&CheckContext{CityPath: cityPath}); err != nil {
+		t.Fatalf("Fix() error: %v", err)
+	}
+
+	if len(removeCalls) != 1 {
+		t.Fatalf("removeRemote called %d times, want 1; calls=%v", len(removeCalls), removeCalls)
+	}
+	if removeCalls[0] != "origin" {
+		t.Errorf("removeRemote called with %q, want %q", removeCalls[0], "origin")
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_Fix_PropagatesRemoveError verifies that Fix()
+// surfaces errors from the remove function rather than silently swallowing them.
+func TestDoltLocalOnlyRemoteCheck_Fix_PropagatesRemoveError(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "testdb")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "testdb", map[string]string{
+		"origin": "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	removeErr := errors.New("bd dolt remote remove: server not reachable")
+	c.removeRemote = func(rigPath, remoteName string) error {
+		return removeErr
+	}
+
+	err := c.Fix(&CheckContext{CityPath: cityPath})
+	if err == nil {
+		t.Fatal("Fix() should propagate error from removeRemote")
+	}
+	if !strings.Contains(err.Error(), "server not reachable") {
+		t.Errorf("error should contain remove error detail, got: %v", err)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_RelativeRigPath verifies that a relative rig
+// path is resolved against cityPath when reading config.yaml.
+func TestDoltLocalOnlyRemoteCheck_RelativeRigPath(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rigs", "gascity")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "ga")
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "ga", map[string]string{
+		"origin": "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "gascity", Path: filepath.Join("rigs", "gascity")}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning with relative rig path; message=%s", r.Status, r.Message)
+	}
+}
+
+// TestDoltLocalOnlyRemoteCheck_DBNameFromMetadata verifies that the check
+// resolves the Dolt database name from .beads/metadata.json when present,
+// so the repo_state.json lookup uses the correct database directory.
+func TestDoltLocalOnlyRemoteCheck_DBNameFromMetadata(t *testing.T) {
+	cityPath := t.TempDir()
+	doltDataDir := filepath.Join(cityPath, ".beads", "dolt")
+	rigPath := filepath.Join(cityPath, "rig")
+	if err := os.MkdirAll(rigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeRigMetadata(t, rigPath, "customdb") // pinned dolt_database != rig.Name
+	writeRigConfigYAML(t, rigPath, localOnlyConfigYAML)
+	writeRepoStateWithRemotes(t, doltDataDir, "customdb", map[string]string{
+		"origin": "git+https://github.com/gastownhall/gascity.git",
+	})
+
+	rig := config.Rig{Name: "testrig", Path: rigPath}
+	c := NewDoltLocalOnlyRemoteCheck(cityPath, rig, doltDataDir)
+	r := c.Run(&CheckContext{CityPath: cityPath})
+
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want StatusWarning (resolved db=customdb from metadata); message=%s",
+			r.Status, r.Message)
+	}
+}

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -78,6 +78,10 @@ func (c *DoltBackupCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *DoltLocalOnlyRemoteCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *DoltVersionCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the


### PR DESCRIPTION
## What this changes

Adds a `gc doctor` check for managed Dolt rigs that have `dolt.local-only: true`. The check detects off-box Dolt SQL remotes such as `origin` and can remove only those unsafe remotes, while preserving default non-local behavior and local file remotes.

This also includes the validator's regression coverage for the local-only origin reappearance path.

## Review notes

- Main implementation is in `internal/doctor/checks_dolt_local_only.go`.
- Registration is gated through the existing managed-Dolt doctor path in `cmd/gc/cmd_doctor.go`.
- The direct push to `main` was rejected by repository rules, so this PR is the merge path.

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `.githooks/pre-commit`

Bead: ga-673qo6.2
