### PR TITLE
fix(orders): cron triggers catch up missed occurrences

### DIFF
--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -108,7 +108,14 @@ func checkCooldown(a Order, now time.Time, lastRunFn LastRunFunc) TriggerResult 
 	}
 }
 
-// checkCron uses simple minute-granularity matching against the schedule.
+// checkCron uses minute-granularity matching against the schedule, WITH
+// catch-up. A scheduled occurrence fires if either (a) the current minute
+// matches, or (b) a scheduled minute elapsed since the last run without the
+// controller evaluating during that exact minute. Catch-up mirrors cooldown's
+// elapsed-based behavior: without it, a cron order silently drops a slot
+// whenever no evaluation lands in its matching minute, which made a
+// "0 */4 * * *" order miss every boundary (gastown td-4kziysy) because the
+// controller's eval cadence rarely coincides with a once-per-4h minute.
 // Schedule format: "minute hour day-of-month month day-of-week" (5 fields).
 func checkCron(a Order, now time.Time, lastRunFn LastRunFunc) TriggerResult {
 	fields := strings.Fields(a.Schedule)
@@ -118,24 +125,47 @@ func checkCron(a Order, now time.Time, lastRunFn LastRunFunc) TriggerResult {
 
 	minute, hour, dom, month, dow := fields[0], fields[1], fields[2], fields[3], fields[4]
 
-	if !cronFieldMatches(minute, now.Minute()) ||
-		!cronFieldMatches(hour, now.Hour()) ||
-		!cronFieldMatches(dom, now.Day()) ||
-		!cronFieldMatches(month, int(now.Month())) ||
-		!cronFieldMatches(dow, int(now.Weekday())) {
-		return TriggerResult{Due: false, Reason: "cron: schedule not matched"}
+	matchesAt := func(t time.Time) bool {
+		return cronFieldMatches(minute, t.Minute()) &&
+			cronFieldMatches(hour, t.Hour()) &&
+			cronFieldMatches(dom, t.Day()) &&
+			cronFieldMatches(month, int(t.Month())) &&
+			cronFieldMatches(dow, int(t.Weekday()))
 	}
 
-	// Schedule matches — check if already run this minute.
 	last, err := lastRunFn(a.ScopedName())
 	if err != nil {
 		return TriggerResult{Due: false, Reason: fmt.Sprintf("error querying last run: %v", err)}
 	}
-	if !last.IsZero() && last.Truncate(time.Minute).Equal(now.Truncate(time.Minute)) {
-		return TriggerResult{Due: false, Reason: "cron: already run this minute", LastRun: last}
+
+	// (a) Current minute matches — fire unless already run this minute.
+	if matchesAt(now) {
+		if !last.IsZero() && last.Truncate(time.Minute).Equal(now.Truncate(time.Minute)) {
+			return TriggerResult{Due: false, Reason: "cron: already run this minute", LastRun: last}
+		}
+		return TriggerResult{Due: true, Reason: "cron: schedule matched", LastRun: last}
 	}
 
-	return TriggerResult{Due: true, Reason: "cron: schedule matched", LastRun: last}
+	// (b) Catch-up: the current minute does not match, but a scheduled minute
+	// may have elapsed since lastRun without an evaluation landing on it. Scan
+	// minute-by-minute from just after lastRun up to now; any match is a missed
+	// occurrence that is now due. Bounded lookback so a very old lastRun cannot
+	// spin (it is overdue regardless). Skipped when lastRun is zero (never run):
+	// such an order fires only on an exact match, never back-filling history.
+	if !last.IsZero() {
+		const maxCatchupLookback = 366 * 24 * time.Hour
+		start := last.Truncate(time.Minute).Add(time.Minute)
+		if floor := now.Add(-maxCatchupLookback).Truncate(time.Minute); start.Before(floor) {
+			start = floor
+		}
+		for t := start; !t.After(now); t = t.Add(time.Minute) {
+			if matchesAt(t) {
+				return TriggerResult{Due: true, Reason: "cron: caught up missed occurrence", LastRun: last}
+			}
+		}
+	}
+
+	return TriggerResult{Due: false, Reason: "cron: schedule not matched", LastRun: last}
 }
 
 // cronFieldMatches checks if a single cron field matches a value.

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -88,6 +88,23 @@ func TestCheckTriggerCronNotMatched(t *testing.T) {
 	}
 }
 
+func TestCheckTriggerCronCatchesUpMissedBoundary(t *testing.T) {
+	// Regression (gastown td-4kziysy): a scheduled occurrence elapsed since
+	// lastRun, but the controller evaluates at an off-schedule minute (its
+	// eval cadence did not land in the exact matching minute). Cron must CATCH
+	// UP and fire, the way cooldown's elapsed>=interval does. Unpatched
+	// checkCron returns "schedule not matched" here and silently drops the
+	// slot — which is why a "0 */4 * * *" order missed every boundary for days.
+	a := Order{Name: "stale-db", Trigger: "cron", Schedule: "0 */4 * * *"}
+	lastRun := time.Date(2026, 5, 29, 0, 0, 0, 0, time.UTC) // fired at the 00:00 boundary
+	now := time.Date(2026, 5, 29, 4, 1, 0, 0, time.UTC)     // 04:00 boundary passed; eval at 04:01 (off-minute)
+	lastRunFn := func(_ string) (time.Time, error) { return lastRun, nil }
+	result := CheckTrigger(a, now, lastRunFn, nil, nil)
+	if !result.Due {
+		t.Errorf("Due = false, want true (catch up the missed 04:00 occurrence); reason=%q", result.Reason)
+	}
+}
+
 func TestCheckTriggerCronAlreadyRunThisMinute(t *testing.T) {
 	a := Order{Name: "cleanup", Trigger: "cron", Schedule: "0 3 * * *"}
 	now := time.Date(2026, 2, 27, 3, 0, 30, 0, time.UTC)


### PR DESCRIPTION
## Problem
`internal/orders/triggers.go` `checkCron` uses stateless exact-minute matching — an order is `Due` only when the controller evaluates it *during* the matching minute. There is no catch-up, so a scheduled occurrence is silently dropped whenever no evaluation lands in that exact minute.

In a live deployment this made a `0 */4 * * *` order miss **every** 4-hour boundary for days: the controller's order-evaluation cadence rarely coincides with a narrow once-per-4h minute, so the `:00` minute is repeatedly skipped (the next eval at `:01` returns `"cron: schedule not matched"`, with no retry). Cooldown triggers are unaffected because `elapsed >= interval` catches up regardless of *when* the evaluation happens — which is exactly why cooldown orders fire reliably while the lone cron order never did.

## Fix
Give `checkCron` catch-up, mirroring cooldown's elapsed-based behavior:
- Current minute matches → fire (unchanged; retains the already-run-this-minute guard).
- Current minute doesn't match, but a scheduled minute elapsed since `lastRun` → fire (`"cron: caught up missed occurrence"`). Bounded lookback (≤366d) so a very old `lastRun` cannot spin. Skipped when `lastRun` is zero (never-run orders fire only on an exact match — no unbounded back-fill).

`cronFieldMatches` (including `*/N` step syntax) is unchanged — parsing was never the issue.

## Test
Adds `TestCheckTriggerCronCatchesUpMissedBoundary`: a `0 */4 * * *` order last run at the `00:00` boundary, evaluated at `04:01` after the `04:00` boundary passed. Fails before this change (`Due=false, "cron: schedule not matched"`), passes after. Full `internal/orders` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
