### PR TITLE
fix(orphan-sweep): resolve bare short-form assignee of a live agent

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -264,6 +264,145 @@ exit 1
 	}
 }
 
+// orphanSweepBareShortFormGCStub writes a gc stub whose only live session is
+// the qualified agent "thriva/devpipeline.backend_dev", while the sole
+// in-progress bead is assigned to the bare short form "backend_dev". When
+// sessionLive is false the session list is empty, so the canonical agent looks
+// dead. The bare assignee never matches a configured name, a pool template, a
+// dot-stripped form, or a live session identity directly — it can only be
+// resolved through the qualified-agent-is-live path under test.
+func orphanSweepBareShortFormGCStub(t *testing.T, binDir string, sessionLive bool) {
+	t.Helper()
+	sessionList := `{"sessions":[],"summary":{},"filters":{},"schema_version":"1"}`
+	if sessionLive {
+		sessionList = `{"sessions":[` +
+			`{"id":"mc-bare-live","session_name":"thriva__devpipeline-backend-dev",` +
+			`"alias":"backend_dev-1","agent_name":"thriva/devpipeline.backend_dev","closed":false}` +
+			`],"summary":{},"filters":{},"schema_version":"1"}`
+	}
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+if [ "$1" = "--rig" ]; then
+  shift 2
+fi
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: thriva/devpipeline.backend_dev
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true}]}\n'
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '%s\n' '`+sessionList+`'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      cat <<'EOF'
+[
+  {"id":"ga-bare","status":"in_progress","assignee":"backend_dev"}
+]
+EOF
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+}
+
+// TestOrphanSweepPreservesBareShortFormOfLiveQualifiedAgent verifies that a
+// bead assigned to the bare short form "backend_dev" is preserved when the
+// configured qualified agent "thriva/devpipeline.backend_dev" has a live
+// session known only by its qualified name. Without the qualified-agent-is-live
+// resolution, the live owner's in-progress work would be reset every cycle.
+func TestOrphanSweepPreservesBareShortFormOfLiveQualifiedAgent(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	orphanSweepBareShortFormGCStub(t, binDir, true)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if strings.Contains(string(out), "orphan-sweep: reset") {
+		t.Fatalf("live qualified agent's bare-short-form assignee was swept:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if log := string(logData); strings.Contains(log, "bd update ga-bare ") {
+		t.Fatalf("bare-short-form bead of live qualified agent was reset:\n%s", log)
+	}
+}
+
+// TestOrphanSweepResetsBareShortFormWhenQualifiedAgentDead is the negative
+// control for TestOrphanSweepPreservesBareShortFormOfLiveQualifiedAgent: with
+// no live session for the qualified agent, the same bare "backend_dev" bead is
+// a genuine orphan and must still be reset. This proves the live-owner
+// preservation did not weaken the sweep.
+func TestOrphanSweepResetsBareShortFormWhenQualifiedAgentDead(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	orphanSweepBareShortFormGCStub(t, binDir, false)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if !strings.Contains(string(out), "orphan-sweep: reset 1 orphaned beads") {
+		t.Fatalf("dead qualified agent's bare-short-form bead was not swept:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if log := string(logData); !strings.Contains(log, "bd update ga-bare --status=open --assignee=") {
+		t.Fatalf("orphan bead was not reset:\n%s", log)
+	}
+}
+
 func TestOrphanSweepConfigShowFallbackPreservesQualifiedAssignees(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -308,6 +308,14 @@ EOF
     fi
     ;;
   bd)
+    if [ "$2" = "show" ] && [ "$3" = "ga-bare" ] && [ "$4" = "--json" ]; then
+      cat <<'EOF'
+[
+  {"id":"ga-bare","status":"in_progress","assignee":"backend_dev"}
+]
+EOF
+      exit 0
+    fi
     if [ "$2" = "list" ]; then
       cat <<'EOF'
 [
@@ -316,7 +324,8 @@ EOF
 EOF
       exit 0
     fi
-    if [ "$2" = "update" ]; then
+    if [ "$2" = "release-if-current" ]; then
+      printf 'released\n'
       exit 0
     fi
     ;;
@@ -359,7 +368,7 @@ func TestOrphanSweepPreservesBareShortFormOfLiveQualifiedAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
-	if log := string(logData); strings.Contains(log, "bd update ga-bare ") {
+	if log := string(logData); strings.Contains(log, "bd release-if-current ga-bare ") {
 		t.Fatalf("bare-short-form bead of live qualified agent was reset:\n%s", log)
 	}
 }
@@ -398,7 +407,7 @@ func TestOrphanSweepResetsBareShortFormWhenQualifiedAgentDead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
-	if log := string(logData); !strings.Contains(log, "bd update ga-bare --status=open --assignee=") {
+	if log := string(logData); !strings.Contains(log, "bd release-if-current ga-bare backend_dev") {
 		t.Fatalf("orphan bead was not reset:\n%s", log)
 	}
 }

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -305,6 +305,23 @@ is_known_agent() {
     # is currently running with a matching ID, SessionName, Alias, or
     # AgentName. Mirrors liveOpenSessionAssignmentExists in the Go path.
     if live_session_match "$name"; then return 0; fi
+    # Bare short-form assignee whose canonical agent is LIVE: an assignee like
+    # "backend_dev" can be the last-dot segment of a configured qualified agent
+    # ("thriva/devpipeline.backend_dev") whose live session is known only by the
+    # qualified name. Without this, such an assignee looks like a dead agent and
+    # the LIVE owner's in-progress work is reset every cycle. Match the assignee
+    # against each configured agent's short form, and accept ONLY when that
+    # qualified agent currently has a live session (so genuinely dead-agent work
+    # still resets). Mirrors the Go reconciler's multi-identity resolution
+    # (sessionBeadAssigneeIdentities / liveOpenSessionAssignmentExists).
+    if [ -n "$name" ] && [ -n "$AGENTS" ]; then
+        while IFS= read -r _cfg_agent; do
+            [ -z "$_cfg_agent" ] && continue
+            if [ "${_cfg_agent##*.}" = "$name" ] && live_session_match "$_cfg_agent"; then
+                return 0
+            fi
+        done <<<"$AGENTS"
+    fi
     return 1
 }
 


### PR DESCRIPTION
## Problem
`examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh` `is_known_agent` resolves an assignee against configured agent template names + live-session identities, then resets in-progress beads it can't match. But a **bare short-form assignee** (e.g. `backend_dev`) is NOT matched when the configured agent is qualified (`thriva/devpipeline.backend_dev`) and the live session is known only by the qualified name — so the sweep treats a LIVE owner as dead and **resets its in-progress work every cycle**.

Observed in production: implementer agents that claimed with a bare `--assignee=<template>` had their in-progress work repeatedly reset (a spawn-storm — one bead reset 15+ times) because orphan-sweep ran each cycle and didn't recognize the bare assignee as the live qualified agent. The Go reconciler `releaseOrphanedPoolAssignments` already resolves multiple identities (`sessionBeadAssigneeIdentities` + `liveOpenSessionAssignmentExists`); the shell sweep lacked the equivalent.

## Fix
Add a final resolution step to `is_known_agent`: match the bare assignee against each configured agent's last-dot short form, and accept it **only when that qualified agent currently has a live session** (via the existing `live_session_match`). Genuinely dead-agent work still resets (no live session → not matched → reset), preserving the sweep's purpose. Mirrors the Go reconciler's multi-identity resolution.

## Confirm
- Isolated logic verification: `backend_dev` with a live `thriva/devpipeline.backend_dev` session → known (not reset); a non-live agent's short form → reset; an unknown name → reset.
- Deployed as a local overlay in our city for hours: the reset storm stopped immediately; live in-progress work is no longer falsely reset, and genuinely-orphaned beads still return to the pool.
- No existing test covers the shell `is_known_agent` (the Go `test_orphan_sweep_*` tests cover `sweepOrphanPIDPrefixedDirs`, a different function). Happy to add a shell/Go test for `is_known_agent` if you point me at the preferred harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
