### PR TITLE
fix(sling): correct dry-run display from bd mol cook to gc formula cook

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1669,7 +1669,7 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 		w("  wisp (ephemeral molecule) — a tree of step beads that guide the")
 		w("  agent through the workflow.")
 		w("")
-		cookCmd := fmt.Sprintf("bd mol cook --formula=%s", opts.BeadOrFormula)
+		cookCmd := fmt.Sprintf("gc formula cook %s", opts.BeadOrFormula)
 		if opts.Title != "" {
 			cookCmd += fmt.Sprintf(" --title=%s", opts.Title)
 		}
@@ -1726,7 +1726,7 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			w("  bead. The agent receives the original bead with the workflow")
 			w("  attached, rather than a standalone wisp.")
 			w("")
-			cookCmd := fmt.Sprintf("bd mol cook --formula=%s --on=%s", opts.OnFormula, previewBeadID)
+			cookCmd := fmt.Sprintf("gc formula cook %s --attach %s", opts.OnFormula, previewBeadID)
 			if opts.Title != "" {
 				cookCmd += fmt.Sprintf(" --title=%s", opts.Title)
 			}
@@ -1746,7 +1746,7 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			w("  Target " + a.QualifiedName() + " has a default_sling_formula configured.")
 			w("  A wisp will be attached automatically (use --no-formula to suppress).")
 			w("")
-			cookCmd := fmt.Sprintf("bd mol cook --formula=%s --on=%s", a.EffectiveDefaultSlingFormula(), previewBeadID)
+			cookCmd := fmt.Sprintf("gc formula cook %s --attach %s", a.EffectiveDefaultSlingFormula(), previewBeadID)
 			if opts.Title != "" {
 				cookCmd += fmt.Sprintf(" --title=%s", opts.Title)
 			}
@@ -1835,7 +1835,7 @@ func dryRunBatch(opts slingOpts, deps slingDeps, stdout, _ io.Writer,
 		w("Attach formula (per open child):")
 		w("  Would run:")
 		for _, c := range open {
-			w("    bd mol cook --formula=" + opts.OnFormula + " --on=" + c.ID)
+			w("    gc formula cook " + opts.OnFormula + " --attach " + c.ID)
 		}
 		w("")
 	} else if !opts.NoFormula && a.EffectiveDefaultSlingFormula() != "" {
@@ -1843,7 +1843,7 @@ func dryRunBatch(opts slingOpts, deps slingDeps, stdout, _ io.Writer,
 		w("  Formula: " + a.EffectiveDefaultSlingFormula())
 		w("  Would run:")
 		for _, c := range open {
-			w("    bd mol cook --formula=" + a.EffectiveDefaultSlingFormula() + " --on=" + c.ID)
+			w("    gc formula cook " + a.EffectiveDefaultSlingFormula() + " --attach " + c.ID)
 		}
 		w("")
 	}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -3544,7 +3544,6 @@ func TestCheckBeadStateForceSkipsCheck(t *testing.T) {
 
 func TestCheckBeadStateFormulaChecksResolvedBead(t *testing.T) {
 	runner := newFakeRunner()
-	runner.on("bd mol cook", "WP-99\n", nil)
 	sp := runtime.NewFake()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
@@ -3730,7 +3729,6 @@ func TestDoSlingBatchRegularBeadPassthrough(t *testing.T) {
 
 func TestDoSlingBatchFormulaPassthrough(t *testing.T) {
 	runner := newFakeRunner()
-	runner.on("bd mol cook", "WP-1\n", nil)
 	sp := runtime.NewFake()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
@@ -5275,7 +5273,6 @@ func TestOnFormulaCleanBead(t *testing.T) {
 
 func TestOnFormulaNilQuerier(t *testing.T) {
 	runner := newFakeRunner()
-	runner.on("bd mol cook", "WP-1\n", nil)
 	sp := runtime.NewFake()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
@@ -5765,7 +5762,6 @@ func TestBatchOnPartialCookFailure(t *testing.T) {
 
 func TestBatchOnNudgeOnce(t *testing.T) {
 	runner := newFakeRunner()
-	runner.on("bd mol cook", "WP-1\n", nil)
 	sp := runtime.NewFake()
 	_ = sp.Start(context.Background(), "mayor", runtime.Config{})
 	sp.Calls = nil
@@ -5946,7 +5942,7 @@ func TestDryRunFormula(t *testing.T) {
 	if !strings.Contains(out, "Name: code-review") {
 		t.Errorf("stdout missing formula name: %s", out)
 	}
-	if !strings.Contains(out, "Would run: bd mol cook --formula=code-review") {
+	if !strings.Contains(out, "Would run: gc formula cook code-review") {
 		t.Errorf("stdout missing cook command: %s", out)
 	}
 	if !strings.Contains(out, "'<wisp-root>'") {
@@ -5980,7 +5976,7 @@ func TestDryRunOnFormula(t *testing.T) {
 	if !strings.Contains(out, "Attach formula:") {
 		t.Errorf("stdout missing attach section: %s", out)
 	}
-	if !strings.Contains(out, "Would run: bd mol cook --formula=code-review --on=BL-42") {
+	if !strings.Contains(out, "Would run: gc formula cook code-review --attach BL-42") {
 		t.Errorf("stdout missing cook command: %s", out)
 	}
 	if !strings.Contains(out, "Pre-check: BL-42 has no existing molecule/wisp children") {
@@ -6190,7 +6186,7 @@ func TestDryRunLeafTaskViaBatchDispatchOnFormula(t *testing.T) {
 	if !strings.Contains(out, "Attach formula:") {
 		t.Errorf("stdout missing single-bead attach section: %s", out)
 	}
-	if !strings.Contains(out, "Would run: bd mol cook --formula=code-review --on=BL-42") {
+	if !strings.Contains(out, "Would run: gc formula cook code-review --attach BL-42") {
 		t.Errorf("stdout missing cook command: %s", out)
 	}
 	if !strings.Contains(out, "bd update 'BL-42' --set-metadata gc.routed_to=hw/polecat") {
@@ -6229,13 +6225,13 @@ func TestDryRunBatchOnFormula(t *testing.T) {
 	}
 	out := stdout.String()
 	// Per-child cook commands.
-	if !strings.Contains(out, "bd mol cook --formula=code-review --on=BL-1") {
+	if !strings.Contains(out, "gc formula cook code-review --attach BL-1") {
 		t.Errorf("stdout missing BL-1 cook command: %s", out)
 	}
-	if !strings.Contains(out, "bd mol cook --formula=code-review --on=BL-3") {
+	if !strings.Contains(out, "gc formula cook code-review --attach BL-3") {
 		t.Errorf("stdout missing BL-3 cook command: %s", out)
 	}
-	if strings.Contains(out, "bd mol cook --formula=code-review --on=BL-2") {
+	if strings.Contains(out, "gc formula cook code-review --attach BL-2") {
 		t.Errorf("stdout should not cook for closed BL-2: %s", out)
 	}
 	// Route commands.
@@ -6771,7 +6767,6 @@ func TestDoSlingIdempotentForceOverrides(t *testing.T) {
 
 func TestDoSlingIdempotentWithOnFormula(t *testing.T) {
 	runner := newFakeRunner()
-	runner.on("bd mol cook", "WP-1\n", nil)
 	sp := runtime.NewFake()
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
@@ -7191,7 +7186,6 @@ func TestDryRunBatchCrossRigSection(t *testing.T) {
 
 func TestDoSlingCrossRigFormulaExempt(t *testing.T) {
 	runner := newFakeRunner()
-	runner.on("bd mol cook", "WP-1\n", nil)
 	sp := runtime.NewFake()
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
@@ -7273,7 +7267,6 @@ func TestDoSlingOnFormulaCrossRigBlocked(t *testing.T) {
 
 func TestDoSlingOnFormulaCrossRigForceOverrides(t *testing.T) {
 	runner := newFakeRunner()
-	runner.on("bd mol cook", "WP-1\n", nil)
 	sp := runtime.NewFake()
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},


### PR DESCRIPTION
## Summary

- `gc sling --dry-run --formula=X` was displaying `Would run: bd mol cook --formula=X` which is not a valid `bd` command (`bd mol cook` does not exist in bd 1.0.4)
- The correct equivalent command is `gc formula cook X` (which calls `molecule.Instantiate()` internally)
- Same fix applies to the `--on` / `--attach` variant: `bd mol cook --formula=X --on=Y` → `gc formula cook X --attach Y`

## Changes

- `cmd/gc/cmd_sling.go`: 5 dry-run format strings updated
- `cmd/gc/cmd_sling_test.go`: 6 dry-run output assertions updated; 7 dead `runner.on("bd mol cook", ...)` mocks removed (formula instantiation is done in-process via `molecule.Instantiate()` — the runner is never called)

## Test plan

- [ ] `go test ./cmd/gc/...` passes (all existing tests green, no new tests needed — existing dry-run tests now assert the correct command string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)