### PR TITLE
fix(session): reap phantom pending-create session beads (gc-5tyf5)

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1795,14 +1795,22 @@ func reapStaleSessionBeads(
 		if sn == "" {
 			continue
 		}
-		// Only reap beads stuck in the creating state after their one-shot
-		// pending_create_claim has already been cleared. The pending create
-		// claim is authoritative across the lifecycle model: it keeps an
-		// in-flight or partially-healed start eligible for retry even when
-		// the bead's cached state has already moved past creating.
+		// Only reap beads stuck in the creating state. Sessions past creating
+		// may hold work claims; reaping them would orphan in_progress beads
+		// because the assignee link to a live session is the only signal the
+		// reconciler has for resume-after-restart. A still-creating bead has
+		// not completed startup, so it is guaranteed not to hold a claim
+		// (claiming is the first thing a worker does after startup).
+		//
+		// pending_create_claim=true no longer exempts a bead from reaping. The
+		// claim keeps an in-flight start eligible for retry, but a bead whose
+		// rollback never completes (e.g. a transient store error on closeBead)
+		// stays creating with the claim set and a dead tmux indefinitely — the
+		// phantom-accumulation leak (gc-5tyf5). Such beads are instead held to
+		// a longer grace window below so legitimate retries still complete
+		// first.
 		state := strings.TrimSpace(b.Metadata["state"])
-		pendingCreate := strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true"
-		if state != "creating" || pendingCreate {
+		if state != "creating" {
 			continue
 		}
 		// Don't reap beads with an active drain — the drainTracker is
@@ -1826,8 +1834,19 @@ func reapStaleSessionBeads(
 		// timeout. Use the latest known start boundary, not just CreatedAt,
 		// because a long-lived bead may have been woken moments ago.
 		// Zero CreatedAt means unknown age — skip conservatively.
+		//
+		// pending_create beads get the longer stalePendingCreateTimeout window
+		// because the reconciler may still be retrying their start or rollback;
+		// they are only reaped once they have leaked past that grace.
 		startedAt, ok := staleReapStartBoundary(b)
-		if !ok || now.Sub(startedAt) < staleCreatingStateTimeout {
+		if !ok {
+			continue
+		}
+		grace := staleCreatingStateTimeout
+		if strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true" {
+			grace = stalePendingCreateTimeout
+		}
+		if now.Sub(startedAt) < grace {
 			continue
 		}
 		if closeBead(store, b.ID, "stale-session", now.UTC(), stderr) {

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1834,20 +1834,36 @@ func reapStaleSessionBeads(
 		// timeout. Use the latest known start boundary, not just CreatedAt,
 		// because a long-lived bead may have been woken moments ago.
 		// Zero CreatedAt means unknown age — skip conservatively.
-		//
-		// pending_create beads get the longer stalePendingCreateTimeout window
-		// because the reconciler may still be retrying their start or rollback;
-		// they are only reaped once they have leaked past that grace.
 		startedAt, ok := staleReapStartBoundary(b)
 		if !ok {
 			continue
 		}
-		grace := staleCreatingStateTimeout
-		if strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true" {
-			grace = stalePendingCreateTimeout
-		}
-		if now.Sub(startedAt) < grace {
-			continue
+		pendingCreate := strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true"
+		// Never-started pending creates (pending_create_claim=true with no
+		// last_woke_at) have not reached preWakeCommit, so their start may
+		// still be in flight behind a busy pool start queue. Defer entirely to
+		// the reconciler's authoritative never-started lease
+		// (pendingCreateNeverStartedTimeout, 10m) rather than the shorter
+		// stalePendingCreateTimeout: reaping mid-start would close the bead out
+		// from under an active lease and let the reconciler spawn a replacement
+		// that double-binds the same tmux session name. Once that lease
+		// expires the phantom is still reaped (gc-5tyf5), just later.
+		if pendingCreate && strings.TrimSpace(b.Metadata["last_woke_at"]) == "" {
+			if !pendingCreateNeverStartedLeaseExpired(b, clk) {
+				continue
+			}
+		} else {
+			// Started (reached preWakeCommit) pending creates get the longer
+			// stalePendingCreateTimeout window because the reconciler may still
+			// be retrying their start or rollback; plain creating beads use the
+			// short staleCreatingStateTimeout.
+			grace := staleCreatingStateTimeout
+			if pendingCreate {
+				grace = stalePendingCreateTimeout
+			}
+			if now.Sub(startedAt) < grace {
+				continue
+			}
 		}
 		if closeBead(store, b.ID, "stale-session", now.UTC(), stderr) {
 			fmt.Fprintf(stderr, "WARN: reconciler: reaped stuck-creating session bead %s — tmux session %q not found\n", b.ID, sn) //nolint:errcheck

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -5211,8 +5211,9 @@ func TestReapStaleSessionBeads(t *testing.T) {
 	// is deterministic regardless of wall-clock latency.
 	type clockMode int
 	const (
-		clockPastGrace   clockMode = iota // 2 min past bead creation
-		clockWithinGrace                  // 30s past bead creation
+		clockPastGrace        clockMode = iota // 2 min past bead creation
+		clockWithinGrace                       // 30s past bead creation
+		clockPastPendingGrace                  // 6 min past bead creation
 	)
 
 	tests := []struct {
@@ -5241,7 +5242,12 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			wantOpen:   0,
 		},
 		{
-			name: "pending_create_creating_kept",
+			name: "pending_create_creating_within_pending_grace_kept",
+			// A pending_create bead survives the normal creating-state
+			// timeout: the reconciler may still be retrying the start or its
+			// rollback, so it gets the longer stalePendingCreateTimeout window
+			// (clockPastGrace is 2 min, past the 1-min creating timeout but
+			// within the longer pending-create grace).
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
@@ -5256,6 +5262,27 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			clock:      clockPastGrace,
 			wantReaped: 0,
 			wantOpen:   1,
+		},
+		{
+			name: "pending_create_creating_past_pending_grace_reaped",
+			// gc-5tyf5: the phantom-accumulation leak. A pool bead stuck in
+			// creating with pending_create_claim=true and a dead tmux (e.g. a
+			// failed rollback) must eventually be reaped once it is past the
+			// longer pending-create grace, instead of leaking forever.
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name":         "worker-1",
+					"state":                "creating",
+					"pending_create_claim": "true",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastPendingGrace,
+			wantReaped: 1,
+			wantOpen:   0,
 		},
 		{
 			name: "pending_create_active_kept",
@@ -5489,6 +5516,8 @@ func TestReapStaleSessionBeads(t *testing.T) {
 				clk = &clock.Fake{Time: firstCreatedAt.Add(2 * time.Minute)}
 			case clockWithinGrace:
 				clk = &clock.Fake{Time: firstCreatedAt.Add(30 * time.Second)}
+			case clockPastPendingGrace:
+				clk = &clock.Fake{Time: firstCreatedAt.Add(6 * time.Minute)}
 			}
 
 			// Set up drain tracker with draining beads.

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -5211,9 +5211,10 @@ func TestReapStaleSessionBeads(t *testing.T) {
 	// is deterministic regardless of wall-clock latency.
 	type clockMode int
 	const (
-		clockPastGrace        clockMode = iota // 2 min past bead creation
-		clockWithinGrace                       // 30s past bead creation
-		clockPastPendingGrace                  // 6 min past bead creation
+		clockPastGrace             clockMode = iota // 2 min past bead creation
+		clockWithinGrace                            // 30s past bead creation
+		clockPastPendingGrace                       // 6 min past bead creation
+		clockPastNeverStartedGrace                  // 11 min past bead creation
 	)
 
 	tests := []struct {
@@ -5242,12 +5243,14 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			wantOpen:   0,
 		},
 		{
-			name: "pending_create_creating_within_pending_grace_kept",
-			// A pending_create bead survives the normal creating-state
-			// timeout: the reconciler may still be retrying the start or its
-			// rollback, so it gets the longer stalePendingCreateTimeout window
-			// (clockPastGrace is 2 min, past the 1-min creating timeout but
-			// within the longer pending-create grace).
+			name: "pending_create_never_started_within_grace_kept",
+			// A never-started pending_create bead (no last_woke_at) survives the
+			// normal creating-state timeout: it has not reached preWakeCommit so
+			// its start may still be in flight behind a busy pool queue. It is
+			// held to the reconciler's never-started lease
+			// (pendingCreateNeverStartedTimeout, 10m), not the shorter
+			// stalePendingCreateTimeout (clockPastGrace is 2 min, past the 1-min
+			// creating timeout but well within the 10-min never-started window).
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
@@ -5264,11 +5267,13 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			wantOpen:   1,
 		},
 		{
-			name: "pending_create_creating_past_pending_grace_reaped",
-			// gc-5tyf5: the phantom-accumulation leak. A pool bead stuck in
-			// creating with pending_create_claim=true and a dead tmux (e.g. a
-			// failed rollback) must eventually be reaped once it is past the
-			// longer pending-create grace, instead of leaking forever.
+			name: "pending_create_never_started_past_never_started_grace_reaped",
+			// gc-5tyf5: the phantom-accumulation leak. A never-started pool bead
+			// stuck in creating with pending_create_claim=true and a dead tmux
+			// (e.g. a failed rollback) must eventually be reaped — but only once
+			// it is past the never-started window (10m), not the shorter 5-min
+			// pending grace, so a slow provider.Start() is never reaped out from
+			// under the reconciler's still-active never-started lease.
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
@@ -5280,7 +5285,7 @@ func TestReapStaleSessionBeads(t *testing.T) {
 				},
 			}},
 			running:    nil,
-			clock:      clockPastPendingGrace,
+			clock:      clockPastNeverStartedGrace,
 			wantReaped: 1,
 			wantOpen:   0,
 		},
@@ -5518,6 +5523,8 @@ func TestReapStaleSessionBeads(t *testing.T) {
 				clk = &clock.Fake{Time: firstCreatedAt.Add(30 * time.Second)}
 			case clockPastPendingGrace:
 				clk = &clock.Fake{Time: firstCreatedAt.Add(6 * time.Minute)}
+			case clockPastNeverStartedGrace:
+				clk = &clock.Fake{Time: firstCreatedAt.Add(11 * time.Minute)}
 			}
 
 			// Set up drain tracker with draining beads.
@@ -5599,6 +5606,90 @@ func TestReapStaleSessionBeads_HonorsRecentWakeGrace(t *testing.T) {
 	}
 	if len(open) != 1 {
 		t.Fatalf("open beads = %d, want 1", len(open))
+	}
+}
+
+// TestReapStaleSessionBeads_NeverStartedPendingCreateNotReapedInPendingWindow
+// pins the gc-5tyf5 over-reaping fix: a never-started pending-create bead (no
+// last_woke_at) sitting at 7 minutes — past the 5-minute stalePendingCreateTimeout
+// but within the 10-minute never-started lease — must NOT be reaped. Reaping it
+// would close the bead out from under a slow but still-in-flight provider.Start(),
+// letting the reconciler spawn a replacement that double-binds the tmux name.
+func TestReapStaleSessionBeads_NeverStartedPendingCreateNotReapedInPendingWindow(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	created, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "worker-1",
+			"state":                "creating",
+			"pending_create_claim": "true",
+			// No last_woke_at: this start never reached preWakeCommit.
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// 7 minutes: past stalePendingCreateTimeout (5m) but within the
+	// never-started lease (pendingCreateNeverStartedTimeout, 10m).
+	now := created.CreatedAt.Add(7 * time.Minute)
+
+	var stderr bytes.Buffer
+	if got := reapStaleSessionBeads(store, sp, nil, &clock.Fake{Time: now}, &stderr); got != 0 {
+		t.Fatalf("reapStaleSessionBeads() = %d, want 0 (never-started bead within 10m lease must survive)\nstderr: %s", got, stderr.String())
+	}
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	if len(open) != 1 {
+		t.Fatalf("open beads = %d, want 1", len(open))
+	}
+}
+
+// TestReapStaleSessionBeads_StartedPendingCreateReapedPastPendingGrace pins the
+// other half of the gc-5tyf5 fix: a started pending-create bead (one that
+// reached preWakeCommit and recorded last_woke_at) stuck creating with a dead
+// tmux IS reaped once it is past the 5-minute stalePendingCreateTimeout. The
+// faster reap is boylec's intended behavior for started-but-stuck creates; it
+// applies only because last_woke_at is present.
+func TestReapStaleSessionBeads_StartedPendingCreateReapedPastPendingGrace(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	created, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "worker-1",
+			"state":                "creating",
+			"pending_create_claim": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	now := created.CreatedAt.Add(7 * time.Minute)
+	// last_woke_at recorded 1 minute after creation (start reached preWakeCommit)
+	// and now 6 minutes stale: this bead is "started" and governed by the
+	// 5-minute pending grace, which its start boundary is now past.
+	startedWoke := created.CreatedAt.Add(1 * time.Minute).UTC().Format(time.RFC3339)
+	if err := store.SetMetadata(created.ID, "last_woke_at", startedWoke); err != nil {
+		t.Fatalf("SetMetadata(last_woke_at): %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if got := reapStaleSessionBeads(store, sp, nil, &clock.Fake{Time: now}, &stderr); got != 1 {
+		t.Fatalf("reapStaleSessionBeads() = %d, want 1 (started bead past 5m pending grace must be reaped)\nstderr: %s", got, stderr.String())
+	}
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	if len(open) != 0 {
+		t.Fatalf("open beads = %d, want 0", len(open))
 	}
 }
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -190,12 +190,15 @@ func sessionStartRequested(session beads.Bead, clk clock.Clock) bool {
 const staleCreatingStateTimeout = time.Minute
 
 // stalePendingCreateTimeout is the longer grace window applied by
-// reapStaleSessionBeads to beads still holding pending_create_claim=true. A
-// pending-create bead may legitimately be mid-start or mid-rollback, so it is
-// given more time than a plain creating bead before being reaped. Without an
-// upper bound, a bead whose rollback never completes (e.g. a transient store
-// error on closeBead) would stay open as a phantom forever — the leak tracked
-// by gc-5tyf5.
+// reapStaleSessionBeads to a started pending-create bead — one that holds
+// pending_create_claim=true AND has a last_woke_at (it reached preWakeCommit).
+// Such a bead may legitimately be mid-start or mid-rollback, so it is given
+// more time than a plain creating bead before being reaped. Without an upper
+// bound, a bead whose rollback never completes (e.g. a transient store error
+// on closeBead) would stay open as a phantom forever — the leak tracked by
+// gc-5tyf5. Never-started pending creates (no last_woke_at) instead defer to
+// pendingCreateNeverStartedTimeout, so a slow provider.Start() is not reaped
+// out from under the reconciler's still-active never-started lease.
 const stalePendingCreateTimeout = 5 * time.Minute
 
 func sessionMetadataState(session beads.Bead) string {

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -189,6 +189,15 @@ func sessionStartRequested(session beads.Bead, clk clock.Clock) bool {
 // reached preWakeCommit use pendingCreateNeverStartedTimeout instead.
 const staleCreatingStateTimeout = time.Minute
 
+// stalePendingCreateTimeout is the longer grace window applied by
+// reapStaleSessionBeads to beads still holding pending_create_claim=true. A
+// pending-create bead may legitimately be mid-start or mid-rollback, so it is
+// given more time than a plain creating bead before being reaped. Without an
+// upper bound, a bead whose rollback never completes (e.g. a transient store
+// error on closeBead) would stay open as a phantom forever — the leak tracked
+// by gc-5tyf5.
+const stalePendingCreateTimeout = 5 * time.Minute
+
 func sessionMetadataState(session beads.Bead) string {
 	switch state := strings.TrimSpace(session.Metadata["state"]); state {
 	case "awake":


### PR DESCRIPTION
Ports the gc-1bz9s fix (76883ef1a) to upstream — it never merged before, and
`origin/main` still carries commit 638b28405's blanket `pending_create_claim`
skip, which leaves dead pool sessions stuck in `state=creating` accumulating
as phantoms forever.

## Problem

`reapStaleSessionBeads` unconditionally skips any bead with
`pending_create_claim=true`. A pool session bead that gets stuck in
`state=creating` with the claim still set and a dead tmux — e.g. when a
pending-create rollback's `closeBead` fails on a transient store error —
is therefore never reaped. It accumulates as a phantom and pollutes the
work-ready pool.

## Fix

- `pending_create` beads are no longer exempt from reaping but get a longer
  grace window (`stalePendingCreateTimeout`, 5m) so legitimate in-flight
  starts and rollbacks still complete first.
- The `state != "creating"` hard-skip is kept, so beads that completed
  startup (and may hold `in_progress` claims) are never reaped here.

## Verified

- Targeted reaper tests (TDD, in `cmd/gc/session_beads_test.go`).
- Full serial `go test ./cmd/gc/...` passes (7 min on the local box).
- `go vet ./...` and `go build ./...` clean.

Fixes: gc-5tyf5