### PR TITLE
feat(refinery): auto-pick merge strategy from target (main → PR, else → direct)

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -17,6 +17,14 @@ merge review.
 The polecat sets `metadata.branch` and `metadata.target` on the work bead
 and reassigns it to the refinery. The refinery merges and closes.
 
+**You do not choose the merge strategy — the refinery auto-picks it from
+`metadata.target`.** When the target is the repo's default branch (`main`),
+the refinery opens a pull request so CI + review gate the change. For any
+other target — e.g. an integration/convoy branch whose own PR into main is
+the gate — the refinery fast-forward merges directly. Override per work bead
+with `metadata.merge_strategy=mr` (force PR) or `metadata.merge_strategy=direct`
+(force direct merge) only when the default is wrong.
+
 **NEVER CLOSE BEADS.** You must not run `bd close` or set status=closed.
 Even if you believe the code is already merged, reassign to refinery —
 only the refinery verifies merges and closes beads.
@@ -44,7 +52,7 @@ refinery. Resume the existing branch — don't redo all the work.
 | Unsure what to do | Mail Witness, don't guess |"""
 formula = "mol-polecat-work"
 extends = ["mol-polecat-base"]
-version = 10
+version = 11
 
 [vars]
 [vars.binding_prefix]

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -19,9 +19,13 @@ No separate MR beads. The polecat sets metadata (branch, target) on
 the work bead and assigns it to the refinery. On rejection, the
 refinery puts the bead back in the pool with rejection metadata.
 
-Merge strategy is per-work-bead metadata:
-- `direct` (default): fast-forward merge to target and push
-- `mr` / `pr`: publish a GitHub pull request instead of landing directly
+Merge strategy is auto-picked from the work bead's `target` (override with
+`metadata.merge_strategy`):
+- target is the repo default branch (`main`) → `mr`: publish a GitHub pull
+  request so CI + review gate the change
+- any other target (integration/convoy branch whose own PR is the gate) →
+  `direct`: fast-forward merge to target and push
+- `metadata.merge_strategy=direct|mr` overrides the auto-pick (`pr` aliases `mr`)
 
 In `mr` mode, refinery treats PR publication as the terminal handoff for
 the direct-bead workflow: it records the PR URL on the work bead and
@@ -29,7 +33,7 @@ closes the bead once the PR is verified.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-refinery-patrol"
-version = 4
+version = 5
 contract = "graph.v2"
 
 [vars]
@@ -386,7 +390,21 @@ Read the merge target and merge strategy from the work bead metadata:
 ```bash
 BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
 TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
-MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"')
+MERGE_STRATEGY_RAW=$(gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // empty')
+if [ -z "$MERGE_STRATEGY_RAW" ] || [ "$MERGE_STRATEGY_RAW" = "null" ]; then
+  # No explicit override — auto-pick from the target. The repo default
+  # branch (main) gets a PR so CI + review gate the change. Any other
+  # target is an integration/convoy branch whose own PR into main is the
+  # gate, so children fast-forward directly into it.
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
+  if [ "$TARGET" = "$DEFAULT_BRANCH" ] || [ "$TARGET" = "main" ]; then
+    MERGE_STRATEGY="mr"
+  else
+    MERGE_STRATEGY="direct"
+  fi
+else
+  MERGE_STRATEGY="$MERGE_STRATEGY_RAW"
+fi
 EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
 ORIGIN_REPO_ERROR=""
 if command -v gh >/dev/null 2>&1; then


### PR DESCRIPTION
## What

The refinery now auto-picks the merge strategy from the work bead's `target` instead of defaulting every bead to `direct`:

| target | strategy | why |
|--------|----------|-----|
| repo default branch (`main`) | `mr` — open a PR | CI + review gate the change |
| any other branch (integration/convoy) | `direct` — fast-forward + push | that branch's own PR into main is the gate |

`metadata.merge_strategy=mr|direct` still overrides the auto-pick (escape hatch). The `pr`->`mr` alias and `existing_pr` handling are unchanged; the auto-pick only ever yields `mr`/`direct`.

## Why

Per mayor direction (2026-05-29): polecats hand off to the refinery, and the refinery should open a PR when landing on `main` but merge directly otherwise. The active TCL-migration convoy (PR #2660, branch `dev-tcl-migration-2026-05-29`) has in-flight beads where today a polecat/mayor must remember *not* to set `merge_strategy=mr` so the refinery direct-merges into the convoy branch. With auto-pick the default does the right thing — children land cleanly into the integration branch, and the integration PR runs the full gate against `main`.

## Changes

- **`mol-refinery-patrol.toml`** (v4 -> v5): the `merge-push` step auto-picks strategy from `$TARGET` (which is read one line above, defaulting to the configured `target_branch`); top-level description updated.
- **`mol-polecat-work.toml`** (v10 -> v11): documents that the refinery auto-picks the strategy from `metadata.target` (the polecat does not choose it).

## Audit (work-order task 3)

Audited the other polecat-spawning core formulas for refinery-bypass (direct PR-create / direct base merge / self-close):

- **mol-polecat-base** — clean: no `gh pr create`, no direct base push/merge, no bead close; explicitly forbids pushing to base. No change.
- **mol-polecat-commit** — intentional direct-commit variant (pushes to base + closes the bead by design). Left as-is per the work order.
- **mol-do-work** — intentional minimal "read bead, do work, close" molecule ("No git branching, no worktree isolation, no refinery handoff" by design). No change.
- **mol-scoped-work** — the deliberately city-agnostic v2 prototype; its `submit` step is explicitly *example-only* ("intentionally generic so cities can opt into the graph contract without inheriting Gastown's exact human workflow"). The refinery is a Gastown construct, so hardcoding a refinery handoff into a core formula would be wrong. No change.

Conclusion: none of the core formulas need modification for this work.

## Test plan

- [ ] Sling a bead with `metadata.target=main`, no `merge_strategy` -> refinery opens a PR
- [ ] Sling a bead with `metadata.target=dev-some-integration-branch` -> refinery fast-forwards directly
- [ ] `metadata.merge_strategy=mr` with target != main -> still opens a PR (override honored)
- [ ] `metadata.merge_strategy=direct` with target = main -> still direct-merges (escape hatch)
- [ ] Existing in-flight `merge_strategy=mr` beads keep working

After merge: re-project into installations via `gc pack` reload.

Work bead: `gc-h9epcuc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
