### PR TITLE
fix(k8s): wait for exec endpoint readiness before staging

### DIFF
--- a/internal/runtime/k8s/name.go
+++ b/internal/runtime/k8s/name.go
@@ -20,8 +20,8 @@ const tmuxSession = "main"
 // workspace initialization and start its tmux session. Running pods younger
 // than this with dead tmux are treated as still initializing, not stale.
 // Covers the full startup chain: waitForInitContainer (60s) +
-// waitForPodRunning (120s) + waitForTmux (60s).
-const startupGracePeriod = 240 * time.Second
+// waitForExecReady (120s) + waitForPodRunning (120s) + waitForTmux (60s).
+const startupGracePeriod = 360 * time.Second
 
 // SanitizeName converts a session name to a valid K8s resource name.
 // K8s names: lowercase, alphanumeric + '-', max 63 chars, must start/end

--- a/internal/runtime/k8s/staging.go
+++ b/internal/runtime/k8s/staging.go
@@ -22,6 +22,12 @@ func stageFiles(ctx context.Context, ops k8sOps, podName string, cfg runtime.Con
 		return err
 	}
 
+	// Wait for exec endpoint to be ready. The kubelet reports Running
+	// before the CRI exec handler is set up, so we poll a trivial command.
+	if err := waitForExecReady(ctx, ops, podName, "stage", 120*time.Second); err != nil {
+		return err
+	}
+
 	// Copy rig work_dir into the pod.
 	podWorkDir := "/workspace"
 	if ctrlCity != "" && cfg.WorkDir != "" && cfg.WorkDir != ctrlCity {
@@ -143,6 +149,22 @@ func waitForInitContainer(ctx context.Context, ops k8sOps, podName string, timeo
 		time.Sleep(time.Second)
 	}
 	return fmt.Errorf("init container not running in pod %s after %s", podName, timeout)
+}
+
+// waitForExecReady polls exec with a trivial command until it succeeds.
+// The kubelet reports a container as Running before the CRI exec handler
+// (SPDY) is fully set up, causing "container not found" errors if we
+// exec too early. This is especially common on K3s with containerd.
+func waitForExecReady(ctx context.Context, ops k8sOps, podName, container string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		_, err := ops.execInPod(ctx, podName, container, []string{"true"}, nil)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("exec not ready in %s/%s after %s", podName, container, timeout)
 }
 
 // copyDirToPod copies a local directory into the pod via tar-based exec.

--- a/internal/runtime/k8s/staging.go
+++ b/internal/runtime/k8s/staging.go
@@ -24,7 +24,7 @@ func stageFiles(ctx context.Context, ops k8sOps, podName string, cfg runtime.Con
 
 	// Wait for exec endpoint to be ready. The kubelet reports Running
 	// before the CRI exec handler is set up, so we poll a trivial command.
-	if err := waitForExecReady(ctx, ops, podName, "stage", 120*time.Second); err != nil {
+	if err := waitForExecReady(ctx, ops, podName, 120*time.Second); err != nil {
 		return err
 	}
 
@@ -155,14 +155,38 @@ func waitForInitContainer(ctx context.Context, ops k8sOps, podName string, timeo
 // The kubelet reports a container as Running before the CRI exec handler
 // (SPDY) is fully set up, causing "container not found" errors if we
 // exec too early. This is especially common on K3s with containerd.
-func waitForExecReady(ctx context.Context, ops k8sOps, podName, container string, timeout time.Duration) error {
+func waitForExecReady(ctx context.Context, ops k8sOps, podName string, timeout time.Duration) error {
+	const container = "stage"
+
 	deadline := time.Now().Add(timeout)
+	var lastErr error
 	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		_, err := ops.execInPod(ctx, podName, container, []string{"true"}, nil)
 		if err == nil {
 			return nil
 		}
-		time.Sleep(500 * time.Millisecond)
+		lastErr = err
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		delay := 500 * time.Millisecond
+		if remaining := time.Until(deadline); remaining < delay {
+			delay = remaining
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("exec not ready in %s/%s after %s: %w", podName, container, timeout, lastErr)
 	}
 	return fmt.Errorf("exec not ready in %s/%s after %s", podName, container, timeout)
 }

--- a/internal/runtime/k8s/staging_test.go
+++ b/internal/runtime/k8s/staging_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/runtime"
 	corev1 "k8s.io/api/core/v1"
@@ -277,6 +278,94 @@ func TestStageFilesPropagatesFatalProviderOverlayError(t *testing.T) {
 	}
 }
 
+func TestWaitForExecReadySucceedsImmediately(t *testing.T) {
+	ops := &execReadyOps{}
+
+	if err := waitForExecReady(context.Background(), ops, "pod", time.Second); err != nil {
+		t.Fatalf("waitForExecReady: %v", err)
+	}
+	if got := ops.calls; got != 1 {
+		t.Fatalf("exec calls = %d, want 1", got)
+	}
+	if got := ops.commands[0]; len(got) != 1 || got[0] != "true" {
+		t.Fatalf("probe command = %v, want [true]", got)
+	}
+}
+
+func TestWaitForExecReadyRetriesTransientErrors(t *testing.T) {
+	ops := &execReadyOps{
+		errors: []error{
+			errors.New("container not found"),
+			errors.New("container not found"),
+			nil,
+		},
+	}
+
+	if err := waitForExecReady(context.Background(), ops, "pod", 2*time.Second); err != nil {
+		t.Fatalf("waitForExecReady: %v", err)
+	}
+	if got := ops.calls; got != 3 {
+		t.Fatalf("exec calls = %d, want 3", got)
+	}
+}
+
+func TestWaitForExecReadyTimeoutPreservesLastError(t *testing.T) {
+	ops := &execReadyOps{errors: []error{errors.New("spdy endpoint unavailable")}}
+
+	err := waitForExecReady(context.Background(), ops, "pod", time.Millisecond)
+	if err == nil {
+		t.Fatal("waitForExecReady succeeded, want timeout error")
+	}
+	if !strings.Contains(err.Error(), "exec not ready in pod/stage after 1ms") {
+		t.Fatalf("error = %q, want timeout context", err)
+	}
+	if !errors.Is(err, ops.errors[0]) {
+		t.Fatalf("error = %v, want wrapped last exec error %v", err, ops.errors[0])
+	}
+}
+
+func TestWaitForExecReadyReturnsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ops := &execReadyOps{errors: []error{errors.New("container not found")}}
+	cancel()
+
+	err := waitForExecReady(ctx, ops, "pod", time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForExecReady error = %v, want context.Canceled", err)
+	}
+	if got := ops.calls; got != 0 {
+		t.Fatalf("exec calls after context cancellation = %d, want 0", got)
+	}
+}
+
+func TestWaitForExecReadyReturnsContextCancellationDuringDelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	firstProbe := make(chan struct{})
+	ops := &execReadyOps{
+		errors: []error{errors.New("container not found")},
+		afterExec: func() {
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				cancel()
+			}()
+		},
+		firstProbeCh: firstProbe,
+	}
+
+	err := waitForExecReady(ctx, ops, "pod", time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForExecReady error = %v, want context.Canceled", err)
+	}
+	select {
+	case <-firstProbe:
+	default:
+		t.Fatal("exec probe was not attempted before cancellation")
+	}
+	if got := ops.calls; got != 1 {
+		t.Fatalf("exec calls = %d, want 1", got)
+	}
+}
+
 type capturingStageOps struct {
 	files map[string]string
 }
@@ -329,6 +418,45 @@ func (o *capturingStageOps) execInPod(_ context.Context, _, _ string, cmd []stri
 			}
 			o.files[path.Join(cmd[4], hdr.Name)] = string(data)
 		}
+	}
+	return "", nil
+}
+
+type execReadyOps struct {
+	errors       []error
+	calls        int
+	commands     [][]string
+	afterExec    func()
+	firstProbeCh chan<- struct{}
+}
+
+func (o *execReadyOps) createPod(context.Context, *corev1.Pod) (*corev1.Pod, error) {
+	return nil, nil
+}
+
+func (o *execReadyOps) getPod(context.Context, string) (*corev1.Pod, error) {
+	return nil, nil
+}
+
+func (o *execReadyOps) deletePod(context.Context, string, int64) error {
+	return nil
+}
+
+func (o *execReadyOps) listPods(context.Context, string, string) ([]corev1.Pod, error) {
+	return nil, nil
+}
+
+func (o *execReadyOps) execInPod(_ context.Context, _, _ string, cmd []string, _ io.Reader) (string, error) {
+	o.calls++
+	o.commands = append(o.commands, append([]string(nil), cmd...))
+	if o.firstProbeCh != nil && o.calls == 1 {
+		close(o.firstProbeCh)
+	}
+	if o.afterExec != nil {
+		o.afterExec()
+	}
+	if o.calls <= len(o.errors) {
+		return "", o.errors[o.calls-1]
 	}
 	return "", nil
 }


### PR DESCRIPTION
## Summary
- Adds `waitForExecReady()` to poll exec with a trivial command before staging files into a pod
- Works around K3s/containerd race where kubelet reports container Running before CRI exec handler (SPDY) is ready

## Test plan
- [ ] Verify agent pods on K3s no longer fail with "container not found (stage)" on startup
- [ ] Confirm staging still completes within normal timeframe (polls every 500ms, 120s timeout)

Closes #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)