### PR TITLE
fix(dolt): fold foreign-managed exclusion into bounded zombie scan

### DIFF
--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -115,8 +115,13 @@ fi
 
 # Cache metadata file paths once (avoids repeated gc calls and word-splitting).
 _meta_cache=$(mktemp)
+# Scratch file for the zombie scan's matched-server filter. The foreign-managed
+# decision runs in a `... | while read` subshell (so $zombie_count can't be
+# mutated through the pipe); the survivors are spooled here and read back in
+# the parent shell.
+_zombie_scan_out=$(mktemp)
 metadata_files > "$_meta_cache"
-trap 'rm -f "$_meta_cache"' EXIT
+trap 'rm -f "$_meta_cache" "$_zombie_scan_out"' EXIT
 
 # Collect database info.
 #
@@ -238,6 +243,16 @@ fi
 # Rig-local Dolt servers (configured via dolt.port in config.yaml)
 # are legitimate — exclude any PID listening on a known rig port.
 #
+# Foreign Dolt servers (managed by OTHER cities on the same host) are
+# also legitimate. We recognize them by parsing `--config <path>` from
+# the process command line and checking the sibling dolt.pid for a
+# self-reference. Without this, every patrol in every city flags the
+# others as zombies on shared dev hosts. The `--config` parse happens
+# inside the single bounded `ps -eo` + awk pass below (it already has
+# the full args line in hand); only the sibling dolt.pid read is left
+# to the shell loop, which iterates O(matched sql-servers) — never
+# O(all pids/zombies) — so the bounded-fork invariant still holds.
+#
 # GC_HEALTH_SKIP_ZOMBIE_SCAN is a test-only escape hatch. Zombie
 # enumeration spawns one `ps` per matching process, which on shared
 # dev machines with many accumulated dolt processes dominates the
@@ -267,9 +282,12 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
   # the candidate PIDs from pgrep, then classify them in a single `ps`+`awk`
   # pass: keep candidates that are dolt sql-server processes, skip Z-state
   # zombies (a defunct dolt never carries sql-server args anyway), and exclude
-  # the managed city server and rig-local dolts.
+  # the managed city server and rig-local dolts. For each survivor the awk
+  # pass also extracts the dolt `--config <path>` (or `--config=<path>`) from
+  # the args line it already holds, and emits `pid<TAB>config_path` so the
+  # shell loop below can do the foreign-managed check without re-forking ps.
   candidate_pids=" $(pgrep -x dolt 2>/dev/null | tr '\n' ' ' || true)"
-  matched_pids=$(ps -eo pid=,stat=,args= 2>/dev/null | awk \
+  ps -eo pid=,stat=,args= 2>/dev/null | awk \
     -v server="$server_pid" -v rigs="$rig_dolt_pids" -v cands="$candidate_pids" '
     BEGIN {
       # Build an O(1) lookup set from the pgrep candidates once. The
@@ -287,12 +305,40 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
       if (index(rigs, " " pid " ") != 0) next     # a configured rig-local dolt
       if ($2 ~ /Z/) next                          # Z-state zombie: never a server
       if (index($0, "sql-server") == 0) next      # not a dolt sql-server
-      print pid
-    }' || true)
-  for p in $matched_pids; do
+      # Extract the dolt --config path from the args fields (args start at
+      # $3 after pid/stat). Accept both the space-separated `--config PATH`
+      # and the `--config=PATH` spellings. Emitted alongside the pid so the
+      # shell can read the sibling dolt.pid; empty when no --config is given.
+      config = ""
+      for (i = 3; i <= NF; i++) {
+        if ($i == "--config" && (i + 1) <= NF) { config = $(i+1); break }
+        if (index($i, "--config=") == 1) { config = substr($i, 10); break }
+      }
+      print pid "\t" config
+    }' > "$_zombie_scan_out" 2>/dev/null || true
+
+  # Iterate ONLY the matched sql-servers (O(matched servers)) the awk pass
+  # emitted — not the full candidate/zombie set. This loop is where the
+  # foreign-managed decision lives; keeping it bounded by the awk output is
+  # what preserves the bounded-fork invariant. Reading from the scratch file
+  # (not a pipe) keeps the loop in the parent shell so the zombie_count /
+  # zombie_pids accumulation survives.
+  _tab="$(printf '\t')"
+  while IFS="$_tab" read -r p config_path; do
+    [ -n "$p" ] || continue
+    # Foreign-managed check: if --config points at a yaml whose sibling
+    # dolt.pid claims this PID, the process is owned by another managed
+    # Dolt instance (another city on this host) — not a zombie.
+    if [ -n "$config_path" ] && [ -f "$config_path" ]; then
+      foreign_pid_file="$(dirname "$config_path")/dolt.pid"
+      if [ -f "$foreign_pid_file" ]; then
+        recorded_pid=$(head -1 "$foreign_pid_file" 2>/dev/null | tr -d ' \t\r\n')
+        [ "$recorded_pid" = "$p" ] && continue
+      fi
+    fi
     zombie_count=$((zombie_count + 1))
     zombie_pids="$zombie_pids $p"
-  done
+  done < "$_zombie_scan_out"
 fi
 
 # Output.

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -885,6 +885,221 @@ func TestHealthScriptZombieScanExcludesRigLocalServers(t *testing.T) {
 	}
 }
 
+// TestHealthScriptZombieScanExcludesForeignManagedServers verifies that
+// Dolt servers managed by OTHER cities on the same host are not flagged
+// as zombies. Regression guard for the bug where deacon patrol in every
+// city on a shared dev host counted the other cities' Dolt servers as
+// zombies, because the rig-local PID filter only sees rigs of the calling
+// city. The scan extracts `--config <path>` from the args column of the
+// single bounded `ps -eo` pass and checks for a sibling `dolt.pid`
+// claiming the PID — the same shape gc itself uses when it manages Dolt
+// for any city. This drives the bounded pass (its awk + the matched-server
+// shell loop), NOT a per-PID `ps -p` shim.
+func TestHealthScriptZombieScanExcludesForeignManagedServers(t *testing.T) {
+	cityPath := t.TempDir()
+	foreignCityPath := t.TempDir()
+	fakeBin := t.TempDir()
+
+	mainPort := "19903"
+	mainPID := "424301"
+	foreignPID := "424302"
+	zombiePID := "424303"
+
+	// Foreign city: dolt-config.yaml + dolt.pid sibling claiming foreignPID.
+	foreignDoltDir := filepath.Join(foreignCityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(foreignDoltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreignConfigPath := filepath.Join(foreignDoltDir, "dolt-config.yaml")
+	if err := os.WriteFile(foreignConfigPath, []byte("# foreign city dolt config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreignDoltDir, "dolt.pid"),
+		[]byte(foreignPID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// City .beads directory with metadata.
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"dolt_database":"city"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake gc: fail so metadata_files() falls back to find.
+	writeExecutable(t, filepath.Join(fakeBin, "gc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake pgrep: returns main PID, foreign PID, and a true zombie PID.
+	writeExecutable(t, filepath.Join(fakeBin, "pgrep"),
+		fmt.Sprintf("#!/bin/sh\necho %s\necho %s\necho %s\n", mainPID, foreignPID, zombiePID))
+
+	// Fake lsof: maps main port to mainPID.
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"),
+		fmt.Sprintf(`#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    -iTCP:%s) echo %s; exit 0 ;;
+  esac
+done
+exit 1
+`, mainPort, mainPID))
+
+	// Fake ps: the bounded scan calls `ps -eo pid=,stat=,args=`. Emit the
+	// foreign PID's args line WITH `--config <path>` so the awk pass extracts
+	// it; the others are plain sql-servers. Also answer the `-p <pid> -o pid=`
+	// liveness probe used by managed_runtime_listener_pid.
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "-eo" ]; then
+  echo "%s Sl dolt sql-server"
+  echo "%s Sl dolt sql-server --config %s"
+  echo "%s Sl dolt sql-server"
+  exit 0
+fi
+if [ "$1" = "-p" ] && [ "$3" = "-o" ] && [ "$4" = "pid=" ]; then
+  printf ' %%s\n' "$2"
+  exit 0
+fi
+exit 1
+`, mainPID, foreignPID, foreignConfigPath, zombiePID))
+
+	// Fake nc: unreachable (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake dolt: SELECT 1 fails (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(
+		filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT",
+			"GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+mainPort,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
+	}
+	output := string(out)
+
+	// Only the true zombie (424303) should be counted; foreign-managed is excluded.
+	if !strings.Contains(output, `"zombie_count": 1`) {
+		t.Errorf("expected zombie_count 1; got:\n%s", output)
+	}
+	if strings.Contains(output, foreignPID) {
+		t.Errorf("foreign-managed Dolt PID %s should not be in zombie_pids; got:\n%s", foreignPID, output)
+	}
+	if !strings.Contains(output, zombiePID) {
+		t.Errorf("true zombie PID %s should be in zombie_pids; got:\n%s", zombiePID, output)
+	}
+}
+
+// TestHealthScriptZombieScanFlagsMismatchedForeignPidFile verifies that
+// when a foreign --config exists but the sibling dolt.pid does NOT match
+// the candidate PID (the recorded process died, a stranger reused the
+// PID, etc.), the candidate is still treated as a zombie. The foreign
+// recognition logic must self-validate against the sibling pid file
+// rather than trust the config-file path alone. Like the test above this
+// drives the bounded `ps -eo` pass, not a per-PID `ps -p` shim.
+func TestHealthScriptZombieScanFlagsMismatchedForeignPidFile(t *testing.T) {
+	cityPath := t.TempDir()
+	foreignCityPath := t.TempDir()
+	fakeBin := t.TempDir()
+
+	mainPort := "19904"
+	mainPID := "424401"
+	suspectPID := "424402"
+	// dolt.pid records a different PID — the sibling claim doesn't match
+	// the candidate, so the candidate is still a zombie.
+	recordedPID := "424499"
+
+	foreignDoltDir := filepath.Join(foreignCityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(foreignDoltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreignConfigPath := filepath.Join(foreignDoltDir, "dolt-config.yaml")
+	if err := os.WriteFile(foreignConfigPath, []byte("# foreign city dolt config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreignDoltDir, "dolt.pid"),
+		[]byte(recordedPID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"dolt_database":"city"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeExecutable(t, filepath.Join(fakeBin, "gc"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(fakeBin, "pgrep"),
+		fmt.Sprintf("#!/bin/sh\necho %s\necho %s\n", mainPID, suspectPID))
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"),
+		fmt.Sprintf(`#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    -iTCP:%s) echo %s; exit 0 ;;
+  esac
+done
+exit 1
+`, mainPort, mainPID))
+	// Bounded `ps -eo` pass: the suspect PID carries `--config <path>` but
+	// its sibling dolt.pid records a different PID, so the foreign-managed
+	// check must NOT exclude it.
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "-eo" ]; then
+  echo "%s Sl dolt sql-server"
+  echo "%s Sl dolt sql-server --config %s"
+  exit 0
+fi
+if [ "$1" = "-p" ] && [ "$3" = "-o" ] && [ "$4" = "pid=" ]; then
+  printf ' %%s\n' "$2"
+  exit 0
+fi
+exit 1
+`, mainPID, suspectPID, foreignConfigPath))
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(
+		filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT",
+			"GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+mainPort,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
+	}
+	output := string(out)
+
+	if !strings.Contains(output, `"zombie_count": 1`) {
+		t.Errorf("expected zombie_count 1 (PID-mismatched config does not protect from zombie status); got:\n%s", output)
+	}
+	if !strings.Contains(output, suspectPID) {
+		t.Errorf("suspect PID %s with mismatched dolt.pid should still be flagged as zombie; got:\n%s", suspectPID, output)
+	}
+}
+
 // TestHealthScriptZombieScanIsBoundedFork is the regression guard for #2482:
 // the zombie scan must enumerate the process table a bounded number of times,
 // independent of how many dolt processes (especially Z-state zombies) exist.


### PR DESCRIPTION
## Summary

The Dolt health command's zombie scan excludes Dolt servers managed by other cities on the same host (identified by a `--config <path>` whose sibling `dolt.pid` claims the PID), so health checks on a shared dev host don't flag each other's servers as zombies. The earlier form of this exclusion ran one `ps -p <pid>` per candidate to read the `--config` path — reintroducing the per-PID fork storm the scan was rewritten (in #2482 / #2618) to avoid. This folds the exclusion into the existing single bounded `ps -eo pid=,stat=,args=` + awk pass.

## Change

- `examples/dolt/commands/health/run.sh`: the awk pass already holds each process's full args line, so it now also extracts the dolt `--config` path (both `--config PATH` and `--config=PATH`) and emits `pid<TAB>config_path`. A shell loop over only the matched sql-servers — O(matched servers), not O(all pids) — reads the sibling `dolt.pid` and makes the foreign-managed decision. A `--config` whose sibling `dolt.pid` does not match the candidate PID is still counted as a zombie. No per-PID `ps` is introduced, so `TestHealthScriptZombieScanIsBoundedFork` (perPIDForks == 0) stays green.
- `examples/dolt/health_test.go`: the foreign-managed tests are written against the `ps -eo` interface (exclusion of a self-referential foreign server; the mismatched-`dolt.pid` case still flagged).

## Test plan

- [x] `go test ./examples/dolt/...` — pass, incl. `TestHealthScriptZombieScanIsBoundedFork`, `…ExcludesForeignManagedServers`, `…FlagsMismatchedForeignPidFile`, `…ExcludesRigLocalServers`
- [x] `go build ./examples/dolt/... ./cmd/gc/...` + `gofmt -l` + `go vet ./examples/dolt/...` — clean

## Context

Split out from #2332 per the review there: this reworks the dolt-health portion onto the bounded scan; the other changes in #2332 are handled separately. The approach (awk extracts the config path, the shell does the bounded sibling-pid read) follows @quad341's suggested shape.
