### PR TITLE
fix(gastown): remove dirname dependency from orphan sweep

### DIFF
--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -12,7 +12,10 @@
 set -euo pipefail
 
 # Trace bd invocations to $GC_BD_TRACE when set (no-op otherwise).
-__SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+case "${BASH_SOURCE[0]}" in
+    */*) __SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)" ;;
+    *) __SCRIPT_DIR="$(pwd)" ;;
+esac
 # shellcheck disable=SC1091
 . "$__SCRIPT_DIR/_bd_trace.sh" "orphan-sweep"
 


### PR DESCRIPTION
## Summary
- replace orphan-sweep.sh script directory discovery with bash-only parameter expansion
- keep _bd_trace.sh sourcing adjacent to the script without requiring dirname in cleanroom PATH

## Tests
- RED verified before fix: go test ./examples/gastown -run TestOrphanSweepPreservesProtectedInProgressEphemeralMoleculeWisp -count=1
- PASS: go test ./examples/gastown -run TestOrphanSweepPreservesProtectedInProgressEphemeralMoleculeWisp -count=1
- PASS: go vet ./...
- PASS: make test-fast-parallel

Bead: ga-fd10ew

---
## Regression provenance
The `dirname`-based `__SCRIPT_DIR` resolution + `_bd_trace.sh` sourcing were introduced by **#2485** ("Expand beads trace logging", commit `b7d35bb2b`). Before #2485, `orphan-sweep.sh` shelled out to no external command at load time; #2485's `$(dirname …)` requires the `dirname` binary, which the cleanroom test's minimal `PATH` does not provide → `set -e` aborts with exit 1. This PR removes that dependency via pure-bash `${BASH_SOURCE[0]%/*}`.
