### PR TITLE
[codex] Fix post-claim Gas City drain cancellation

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1146,8 +1146,8 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							hasAssignedWork = true
 						}
 						if providerAlive && hasAssignedWork {
-							if cancelOrphanedSessionDrainForAssignedWork(*session, sp, dt) ||
-								cancelRecoveredOrphanedDrainForAssignedWork(*session, sp, name) {
+							if cancelSessionDrainForAssignedWork(*session, sp, dt) ||
+								cancelRecoveredSessionDrainForAssignedWork(*session, sp, name) {
 								_ = dops.clearDrain(name)
 								template := normalizedSessionTemplate(*session, cfg)
 								if template == "" {
@@ -1363,6 +1363,27 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "pending", "cancel_reconciler_ack", nil, nil, "")
 						}
 						continue
+					}
+					if reconcilerOwnedAck && ackReason == "config-drift" && alive {
+						hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
+						if assignedErr != nil {
+							fmt.Fprintf(stderr, "session reconciler: checking assigned work for config-drift drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
+							hasAssignedWork = true
+						}
+						if hasAssignedWork {
+							drainCancelled := cancelSessionDrainForAssignedWork(*session, sp, dt) ||
+								cancelRecoveredSessionDrainForAssignedWork(*session, sp, name)
+							if !drainCancelled {
+								_ = clearReconcilerDrainAckMetadata(sp, name)
+							}
+							if trace != nil {
+								trace.recordDecision("reconciler.session.drain_ack", tp.TemplateName, name, "config_drift_assigned_work", "cancel_reconciler_ack", traceRecordPayload{
+									"drain_canceled":     drainCancelled,
+									"live_assigned_work": true,
+								}, nil, "")
+							}
+							continue
+						}
 					}
 					if alive {
 						if markDrainAckStopPending(session, store, clk, stderr) {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -4003,6 +4003,84 @@ func TestReconcileSessionBeads_ConfigDriftDeferredOnLiveAssignedWork(t *testing.
 	}
 }
 
+func TestReconcileSessionBeads_DrainAckedConfigDriftCanceledForAssignedWork(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	work, err := env.store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+
+	ds := &drainState{
+		startedAt:  env.clk.Now().Add(-defaultDrainTimeout),
+		deadline:   env.clk.Now().Add(30 * time.Second),
+		reason:     "config-drift",
+		generation: 1,
+		ackSet:     true,
+	}
+	env.dt.set(session.ID, ds)
+	if err := setReconcilerDrainAckMetadata(env.sp, "worker", ds); err != nil {
+		t.Fatalf("setReconcilerDrainAckMetadata: %v", err)
+	}
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		[]beads.Bead{work},
+		nil,
+		nil,
+		env.dt,
+		map[string]int{"worker": 1},
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("assigned-work config-drift drain should be canceled before stopping the running session")
+	}
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("drain = %+v, want canceled", ds)
+	}
+	if ack, _ := env.sp.GetMeta("worker", "GC_DRAIN_ACK"); ack != "" {
+		t.Fatalf("GC_DRAIN_ACK = %q, want cleared", ack)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state_reason"] == sessionpkg.DrainAckStopPendingReason {
+		t.Fatalf("state_reason = %q, want no drain-ack stop pending", got.Metadata["state_reason"])
+	}
+}
+
 func TestReconcileSessionBeads_NoDriftWhenHashMatches(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -250,12 +250,17 @@ func cancelSessionDrainForPending(session beads.Bead, sp runtime.Provider, dt *d
 	return cancelSessionDrainIf(session, sp, dt, pendingDrainReasonCancelable)
 }
 
-func cancelOrphanedSessionDrainForAssignedWork(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
-	return cancelSessionDrainIf(session, sp, dt, func(reason string) bool {
-		// Only concrete assigned work overrides an orphan drain; generic
-		// work-query and named-demand wakeups intentionally do not.
-		return reason == "orphaned"
-	})
+func assignedWorkDrainReasonCancelable(reason string) bool {
+	switch reason {
+	case "orphaned", "config-drift":
+		return true
+	default:
+		return false
+	}
+}
+
+func cancelSessionDrainForAssignedWork(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
+	return cancelSessionDrainIf(session, sp, dt, assignedWorkDrainReasonCancelable)
 }
 
 func cancelSessionConfigDriftDrain(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
@@ -371,9 +376,9 @@ func cancelRecoveredReconcilerAckedDrain(session beads.Bead, sp runtime.Provider
 	return true
 }
 
-func cancelRecoveredOrphanedDrainForAssignedWork(session beads.Bead, sp runtime.Provider, name string) bool {
+func cancelRecoveredSessionDrainForAssignedWork(session beads.Bead, sp runtime.Provider, name string) bool {
 	reason, ok := reconcilerDrainAckMatchesSession(session, sp, name)
-	if !ok || reason != "orphaned" {
+	if !ok || !assignedWorkDrainReasonCancelable(reason) {
 		return false
 	}
 	_ = clearReconcilerDrainAckMetadata(sp, name)
@@ -497,8 +502,8 @@ func advanceSessionDrainsWithSessionsTraced(
 		if eval, ok := wakeEvals[session.ID]; ok &&
 			eval.Reason == "assigned-work" &&
 			containsWakeReason(eval.Reasons, WakeWork) &&
-			ds.reason == "orphaned" {
-			if cancelOrphanedSessionDrainForAssignedWork(*session, sp, dt) {
+			assignedWorkDrainReasonCancelable(ds.reason) {
+			if cancelSessionDrainForAssignedWork(*session, sp, dt) {
 				if trace != nil {
 					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplate(*session, cfg), name, ds.reason, "cancel_assigned_work", nil, nil, "")
 				}

--- a/cmd/gc/session_wake_test.go
+++ b/cmd/gc/session_wake_test.go
@@ -1192,6 +1192,66 @@ func TestAdvanceSessionDrains_ConfigDriftCancelableOnPendingWake(t *testing.T) {
 	}
 }
 
+func TestAdvanceSessionDrains_ConfigDriftCanceledForAssignedWork(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	dt := newDrainTracker()
+
+	if err := sp.Start(context.Background(), "test-session", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	b, err := store.Create(beads.Bead{
+		Title:  "test",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "test-session",
+			"template":     "worker",
+			"generation":   "3",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+
+	ds := &drainState{
+		startedAt:  now.Add(-10 * time.Second),
+		deadline:   now.Add(20 * time.Second),
+		reason:     "config-drift",
+		generation: 3,
+		ackSet:     true,
+	}
+	dt.set(b.ID, ds)
+	if err := setReconcilerDrainAckMetadata(sp, "test-session", ds); err != nil {
+		t.Fatalf("setReconcilerDrainAckMetadata: %v", err)
+	}
+
+	advanceSessionDrainsWithSessionsTraced(dt, sp, store, func(id string) *beads.Bead {
+		got, _ := store.Get(id)
+		return &got
+	}, []beads.Bead{b}, map[string]wakeEvaluation{
+		b.ID: {Reason: "assigned-work", Reasons: []WakeReason{WakeWork}, HasAssignedWork: true},
+	}, &config.City{Agents: []config.Agent{{Name: "worker"}}}, map[string]int{"worker": 1}, nil, nil, clk, nil)
+
+	if dt.get(b.ID) != nil {
+		t.Fatal("config-drift drain should be canceled when assigned work appears")
+	}
+	if ack, _ := sp.GetMeta("test-session", "GC_DRAIN_ACK"); ack != "" {
+		t.Fatalf("GC_DRAIN_ACK = %q, want cleared after assigned-work cancellation", ack)
+	}
+	if !sp.IsRunning("test-session") {
+		t.Fatal("session should stay running after assigned-work cancellation")
+	}
+	for _, call := range sp.Calls {
+		if call.Method == "Stop" || call.Method == "Interrupt" {
+			t.Fatalf("runtime call %s should not happen after assigned-work cancellation; calls=%#v", call.Method, sp.Calls)
+		}
+	}
+}
+
 func TestAdvanceSessionDrains_TimeoutTokenMismatch(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}


### PR DESCRIPTION
## Summary
- cancel config-drift drains when concrete assigned work appears, matching existing orphan-drain behavior
- clear recovered reconciler drain-ack metadata for assigned-work config drift instead of stopping the live session
- add focused regression coverage for wake and reconciler drain-ack paths

## Validation
- PASS: GC_FAST_UNIT=1 go test ./cmd/gc -run 'TestAdvanceSessionDrains_ConfigDriftCanceledForAssignedWork|TestReconcileSessionBeads_DrainAckedConfigDriftCanceledForAssignedWork|TestReconcileSessionBeads_ConfigDriftDeferredOnLiveAssignedWork|TestReconcileSessionBeads_DrainAckedOrphanCanceledForAssignedWork|TestAdvanceSessionDrains_ConfigDriftCancelableOnPendingWake' -count=1
- PASS: git diff --check
- PASS: pre-commit changed-package lint reached 0 issues
- PASS: pre-commit go vet ./... completed before the fast sweep
- NOTE: pre-commit fast sweep failed in unrelated existing/environmental areas: missing mail schema fixture files, test PATH missing dirname in maintenance script tests, shutdown timeout assertions, k8s jq syntax, and convergence condition timeouts