### PR TITLE
fix(mail): cache API beadmail session-route lookups

### DIFF
--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -670,15 +670,17 @@ func mailProviderNameForCity(cityPath string) string {
 
 // newMailProvider returns a mail.Provider based on the mail provider name
 // (env var → city.toml → default) and the given bead store (used as the
-// default backend). Shared callers such as the API use the stateless beadmail
-// provider so long-lived instances observe fresh session state.
+// default backend). Shared callers such as the API use the cached beadmail
+// provider so repeated mail reads reuse one session-topology enumeration.
+// The cache lasts for the provider lifetime; topology refresh for long-lived
+// providers is handled by rebuilding the provider.
 //
 //   - "fake" → in-memory fake (all ops succeed)
 //   - "fail" → broken fake (all ops return errors)
 //   - "exec:<script>" → user-supplied script (absolute path or PATH lookup)
 //   - default → beadmail (backed by beads.Store, no subprocess)
 func newMailProvider(store beads.Store) mail.Provider {
-	return newMailProviderNamed(mailProviderName(), store, false)
+	return newMailProviderNamed(mailProviderName(), store, true)
 }
 
 func newCommandMailProvider(store beads.Store) mail.Provider {

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/agent"
@@ -13,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessiont3bridge "github.com/gastownhall/gascity/internal/runtime/t3bridge"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 func TestTmuxConfigFromSessionDefaultsSocketToCityName(t *testing.T) {
@@ -74,6 +76,52 @@ func TestRawBeadsProviderNormalizesManagedExecEnv(t *testing.T) {
 
 	if got := rawBeadsProvider(cityPath); got != "bd" {
 		t.Fatalf("rawBeadsProvider() = %q, want bd", got)
+	}
+}
+
+type apiMailCacheCountingStore struct {
+	*beads.MemStore
+	mu               sync.Mutex
+	sessionListCalls int
+}
+
+func (s *apiMailCacheCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.mu.Lock()
+		s.sessionListCalls++
+		s.mu.Unlock()
+	}
+	return s.MemStore.List(query)
+}
+
+func (s *apiMailCacheCountingStore) sessionListCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sessionListCalls
+}
+
+func TestNewMailProviderUsesCachedBeadmailProvider(t *testing.T) {
+	t.Setenv("GC_MAIL", "")
+	store := &apiMailCacheCountingStore{MemStore: beads.NewMemStore()}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-a",
+			"alias_history": "old-route",
+			"session_name":  "wf__a",
+		},
+	}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	provider := newMailProvider(store)
+	for _, recipient := range []string{"old-route", "old-route", "old-route"} {
+		if _, err := provider.Inbox(recipient); err != nil {
+			t.Fatalf("Inbox(%q): %v", recipient, err)
+		}
+	}
+	if got := store.sessionListCallCount(); got != 1 {
+		t.Fatalf("broad gc:session List calls = %d, want 1 from cached API mail provider", got)
 	}
 }
 

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -45,7 +45,10 @@ func New(store beads.Store) *Provider {
 }
 
 // NewCached returns a beadmail provider backed by the given store with a
-// provider-local session enumeration cache for command-scoped reuse.
+// provider-local session enumeration cache. Command-scoped callers use this to
+// avoid repeated session scans during one command. Long-lived API providers use
+// it to keep steady-state mail reads cheap; they observe session-topology
+// changes when their owning controller rebuilds the provider.
 func NewCached(store beads.Store) *Provider {
 	return &Provider{
 		store:        store,

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -3,6 +3,7 @@ package beadmail
 import (
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -1886,14 +1887,23 @@ func TestCheck(t *testing.T) {
 // across multiple Inbox calls in a single command invocation.
 type countingSessionListStore struct {
 	*beads.MemStore
+	mu               sync.Mutex
 	sessionListCalls int
 }
 
 func (s *countingSessionListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.mu.Lock()
 		s.sessionListCalls++
+		s.mu.Unlock()
 	}
 	return s.MemStore.List(query)
+}
+
+func (s *countingSessionListStore) sessionListCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sessionListCalls
 }
 
 func TestProvider_DefaultProviderSeesNewHistoricalAliasSessionAcrossCalls(t *testing.T) {
@@ -1933,8 +1943,8 @@ func TestProvider_DefaultProviderSeesNewHistoricalAliasSessionAcrossCalls(t *tes
 	if msgs[0].Body != "for old route" {
 		t.Fatalf("Inbox(old-route) body = %q, want %q", msgs[0].Body, "for old route")
 	}
-	if store.sessionListCalls != 2 {
-		t.Errorf("broad gc:session List calls = %d, want 2 (default provider must refetch per call to avoid stale shared state)", store.sessionListCalls)
+	if got := store.sessionListCallCount(); got != 2 {
+		t.Errorf("broad gc:session List calls = %d, want 2 (default provider must refetch per call to avoid stale shared state)", got)
 	}
 }
 
@@ -1979,8 +1989,46 @@ func TestProviderCached_BroadSessionListCachedAcrossInboxCalls(t *testing.T) {
 		}
 	}
 
-	if store.sessionListCalls != 1 {
-		t.Errorf("broad gc:session List calls = %d, want 1 (Provider must cache the enumeration)", store.sessionListCalls)
+	if got := store.sessionListCallCount(); got != 1 {
+		t.Errorf("broad gc:session List calls = %d, want 1 (Provider must cache the enumeration)", got)
+	}
+}
+
+func TestProviderCached_BroadSessionListCacheConcurrentAccess(t *testing.T) {
+	store := &countingSessionListStore{MemStore: beads.NewMemStore()}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-a",
+			"alias_history": "old-route",
+			"session_name":  "wf__a",
+		},
+	}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	p := NewCached(store)
+
+	const workers = 16
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := p.Inbox("old-route")
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Inbox(old-route): %v", err)
+		}
+	}
+	if got := store.sessionListCallCount(); got != 1 {
+		t.Errorf("broad gc:session List calls = %d, want 1 under concurrent access", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Use a cached mail provider for the API server's beadmail session-route lookups, so mail reads don't re-enumerate session beads (and fork `bd`) on every request. Part of the mail-contention fix series that addresses slow/timed-out mail reads under factory load.

## Tests
Reviewer-verified: `go build ./...`, `go vet`, `gofmt`, targeted `go test` (api mail cache + session-route cases) — all green.
