### PR TITLE
fix: allow absolute ralph check paths

### DIFF
--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -183,10 +183,11 @@ func containedIn(absPath, root string) bool {
 // For relative paths, both the lexically-joined and the symlink-resolved
 // targets must land inside envelope OR base — defending against both
 // `../`-style traversal and symlinks that escape containment after
-// resolution. Absolute paths skip containment in this function; callers
-// (e.g. internal/dispatch/ralph.go) must validate absolute-string inputs
-// before passing them in. Returns the canonical absolute path after
-// symlink resolution and an exec-eligible file check.
+// resolution. Absolute paths skip containment in this function because
+// imported and registry-installed packs can live outside the city/store roots.
+// Callers must only pass absolute paths from surfaces they trust. Returns the
+// canonical absolute path after symlink resolution and an exec-eligible file
+// check.
 func ResolveConditionPath(envelope, base, conditionPath string) (string, error) {
 	if conditionPath == "" {
 		return "", fmt.Errorf("resolving gate condition path: empty path")

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -154,15 +154,6 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	if checkPath == "" {
 		return convergence.GateResult{}, fmt.Errorf("%s: missing gc.check_path", bead.ID)
 	}
-	// gc.check_path comes from formula metadata after variable substitution
-	// (internal/formula/expand.go), and sling API `vars` can flow into that
-	// substitution. Enforce the relative-path contract at this boundary so
-	// an absolute string synthesized via vars cannot bypass containment in
-	// convergence.ResolveConditionPath (which intentionally trusts callers
-	// to vouch for absolute inputs).
-	if filepath.IsAbs(checkPath) {
-		return convergence.GateResult{}, fmt.Errorf("%s: gc.check_path must be relative, got absolute %q", bead.ID, checkPath)
-	}
 	cityPath := opts.CityPath
 	if cityPath == "" {
 		cityPath = resolveInheritedMetadata(store, bead, "gc.city_path")

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -196,9 +196,16 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	// gastownhall/gascity#2320 storePath (a rig subtree) was passed as both,
 	// causing relative gc.check_path values to be looked up under the rig
 	// tree even when the script lives in the city tree.
+	trustedAbsRoots := ralphCheckTrustedAbsoluteRoots(cityPath, storePath, opts.FormulaSearchPaths)
+	if filepath.IsAbs(checkPath) && !pathWithinAny(checkPath, trustedAbsRoots) {
+		return convergence.GateResult{}, fmt.Errorf("%s: absolute gc.check_path %q escapes trusted roots", bead.ID, checkPath)
+	}
 	scriptPath, err := convergence.ResolveConditionPath(cityPath, scriptBase, checkPath)
 	if err != nil {
 		return convergence.GateResult{}, fmt.Errorf("%s: resolving check path: %w", bead.ID, err)
+	}
+	if filepath.IsAbs(checkPath) && !pathWithinAny(scriptPath, trustedAbsRoots) {
+		return convergence.GateResult{}, fmt.Errorf("%s: resolved gc.check_path %q escapes trusted roots", bead.ID, scriptPath)
 	}
 
 	timeout := convergence.DefaultGateTimeout
@@ -247,6 +254,47 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 		ArtifactDir: artifactDir,
 	}, timeout, 0)
 	return result, nil
+}
+
+func ralphCheckTrustedAbsoluteRoots(cityPath, storePath string, formulaSearchPaths []string) []string {
+	roots := make([]string, 0, 2+2*len(formulaSearchPaths))
+	add := func(root string) {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			return
+		}
+		normalized := pathutil.NormalizePathForCompare(root)
+		for _, existing := range roots {
+			if pathutil.SamePath(existing, normalized) {
+				return
+			}
+		}
+		roots = append(roots, normalized)
+	}
+	add(cityPath)
+	add(storePath)
+	// Pack-authored checks may live beside a formula layer's formulas/ dir.
+	for _, formulaPath := range formulaSearchPaths {
+		formulaPath = strings.TrimSpace(formulaPath)
+		if formulaPath == "" {
+			continue
+		}
+		clean := filepath.Clean(formulaPath)
+		add(clean)
+		if filepath.Base(clean) == "formulas" {
+			add(filepath.Dir(clean))
+		}
+	}
+	return roots
+}
+
+func pathWithinAny(path string, roots []string) bool {
+	for _, root := range roots {
+		if pathutil.PathWithin(root, path) {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveRalphCheckMoleculePaths derives the molecule root directory and the

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -7273,6 +7273,8 @@ func TestRunRalphCheckRejectsPathTraversalAboveCityPath(t *testing.T) {
 // expansion may produce an absolute gc.check_path.
 func TestRunRalphCheckAllowsAbsoluteCheckPath(t *testing.T) {
 	parent := t.TempDir()
+	home := filepath.Join(parent, "home")
+	t.Setenv("HOME", home)
 	cityPath := filepath.Join(parent, "city")
 	storePath := filepath.Join(parent, "rig")
 	if err := os.MkdirAll(cityPath, 0o755); err != nil {
@@ -7281,9 +7283,9 @@ func TestRunRalphCheckAllowsAbsoluteCheckPath(t *testing.T) {
 	if err := os.MkdirAll(storePath, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	packDir := filepath.Join(parent, "registry-cache", "packs", "workflows")
-	if err := os.MkdirAll(packDir, 0o755); err != nil {
-		t.Fatalf("mkdir pack dir: %v", err)
+	packDir := filepath.Join(home, ".gc", "cache", "repos", "pack-key", "packs", "workflows")
+	if err := os.MkdirAll(filepath.Join(packDir, "formulas"), 0o755); err != nil {
+		t.Fatalf("mkdir pack formulas: %v", err)
 	}
 	checkScript := filepath.Join(packDir, "check.sh")
 	if err := os.WriteFile(checkScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
@@ -7302,14 +7304,189 @@ func TestRunRalphCheckAllowsAbsoluteCheckPath(t *testing.T) {
 	subject := beads.Bead{ID: "run-abs", Type: "task"}
 
 	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
-		CityPath:  cityPath,
-		StorePath: storePath,
+		CityPath:           cityPath,
+		StorePath:          storePath,
+		FormulaSearchPaths: []string{filepath.Join(packDir, "formulas")},
 	})
 	if err != nil {
 		t.Fatalf("absolute check path should be accepted: %v", err)
 	}
 	if result.Outcome != convergence.GatePass {
 		t.Fatalf("outcome = %q, want %q; stdout=%q stderr=%q", result.Outcome, convergence.GatePass, result.Stdout, result.Stderr)
+	}
+}
+
+func TestRunRalphCheckAllowsAbsoluteCheckPathUnderFormulaPackRoot(t *testing.T) {
+	parent := t.TempDir()
+	t.Setenv("HOME", filepath.Join(parent, "home"))
+	cityPath := filepath.Join(parent, "city")
+	storePath := filepath.Join(parent, "rig")
+	localPackRoot := filepath.Join(parent, "local-workflows-pack")
+	for _, dir := range []string{cityPath, storePath, filepath.Join(localPackRoot, "formulas"), filepath.Join(localPackRoot, "assets", "scripts", "checks")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	checkScript := filepath.Join(localPackRoot, "assets", "scripts", "checks", "review-approved.sh")
+	if err := os.WriteFile(checkScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write check script: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-local-pack",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    checkScript,
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-local-pack", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:           cityPath,
+		StorePath:          storePath,
+		FormulaSearchPaths: []string{filepath.Join(localPackRoot, "formulas")},
+	})
+	if err != nil {
+		t.Fatalf("absolute check path under formula pack root should be accepted: %v", err)
+	}
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("outcome = %q, want %q; stdout=%q stderr=%q", result.Outcome, convergence.GatePass, result.Stdout, result.Stderr)
+	}
+}
+
+func TestRunRalphCheckRejectsAbsoluteCheckPathUnderUnrelatedCachedPack(t *testing.T) {
+	parent := t.TempDir()
+	home := filepath.Join(parent, "home")
+	t.Setenv("HOME", home)
+	cityPath := filepath.Join(parent, "city")
+	storePath := filepath.Join(parent, "rig")
+	activePackRoot := filepath.Join(home, ".gc", "cache", "repos", "active-key", "packs", "workflows")
+	otherPackRoot := filepath.Join(home, ".gc", "cache", "repos", "other-key", "packs", "workflows")
+	for _, dir := range []string{cityPath, storePath, filepath.Join(activePackRoot, "formulas"), filepath.Join(otherPackRoot, "assets", "scripts")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	checkScript := filepath.Join(otherPackRoot, "assets", "scripts", "check.sh")
+	if err := os.WriteFile(checkScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write check script: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-other-pack",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    checkScript,
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-other-pack", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:           cityPath,
+		StorePath:          storePath,
+		FormulaSearchPaths: []string{filepath.Join(activePackRoot, "formulas")},
+	})
+	if err == nil {
+		t.Fatalf("expected unrelated cached pack rejection, got outcome=%q stdout=%q", result.Outcome, result.Stdout)
+	}
+	if !strings.Contains(err.Error(), "trusted roots") {
+		t.Errorf("expected trusted roots error, got: %v", err)
+	}
+}
+
+func TestRunRalphCheckRejectsAbsoluteCheckPathOutsideTrustedRoots(t *testing.T) {
+	parent := t.TempDir()
+	home := filepath.Join(parent, "home")
+	t.Setenv("HOME", home)
+	cityPath := filepath.Join(parent, "city")
+	storePath := filepath.Join(parent, "rig")
+	outsideDir := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatalf("mkdir city: %v", err)
+	}
+	if err := os.MkdirAll(storePath, 0o755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	checkScript := filepath.Join(outsideDir, "check.sh")
+	if err := os.WriteFile(checkScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write check script: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-abs-outside",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    checkScript,
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-abs-outside", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:  cityPath,
+		StorePath: storePath,
+	})
+	if err == nil {
+		t.Fatalf("expected absolute check path rejection, got outcome=%q stdout=%q", result.Outcome, result.Stdout)
+	}
+	if !strings.Contains(err.Error(), "trusted roots") {
+		t.Errorf("expected trusted roots error, got: %v", err)
+	}
+}
+
+func TestRunRalphCheckRejectsAbsoluteCheckPathSymlinkOutsideTrustedRoots(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	parent := t.TempDir()
+	home := filepath.Join(parent, "home")
+	t.Setenv("HOME", home)
+	cityPath := filepath.Join(parent, "city")
+	storePath := filepath.Join(parent, "rig")
+	packDir := filepath.Join(home, ".gc", "cache", "repos", "pack-key")
+	outsideDir := filepath.Join(parent, "outside")
+	for _, dir := range []string{cityPath, storePath, packDir, outsideDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	outsideScript := filepath.Join(outsideDir, "check.sh")
+	if err := os.WriteFile(outsideScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write outside check script: %v", err)
+	}
+	checkLink := filepath.Join(packDir, "check.sh")
+	if err := os.Symlink(outsideScript, checkLink); err != nil {
+		t.Fatalf("symlink check script: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-abs-symlink-outside",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    checkLink,
+			"gc.check_timeout": "30s",
+		},
+	}
+	subject := beads.Bead{ID: "run-abs-symlink-outside", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+		CityPath:  cityPath,
+		StorePath: storePath,
+	})
+	if err == nil {
+		t.Fatalf("expected symlinked absolute check path rejection, got outcome=%q stdout=%q", result.Outcome, result.Stdout)
+	}
+	if !strings.Contains(err.Error(), "trusted roots") {
+		t.Errorf("expected trusted roots error, got: %v", err)
 	}
 }
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -7268,17 +7268,10 @@ func TestRunRalphCheckRejectsPathTraversalAboveCityPath(t *testing.T) {
 	}
 }
 
-// TestRunRalphCheckRejectsAbsoluteCheckPath pins the contract that
-// gc.check_path must be relative. Sling API vars
-// (internal/api/handler_sling.go → internal/molecule → bead metadata)
-// can flow through formula variable substitution
-// (internal/formula/expand.go) and synthesize an absolute string into
-// gc.check_path. convergence.ResolveConditionPath intentionally skips
-// containment for absolute conditionPath values (callers vouch), so
-// ralph.go must reject the absolute form at the metadata boundary or
-// the OR-containment relaxation in gastownhall/gascity#2354 becomes a
-// full bypass for callers who can influence vars.
-func TestRunRalphCheckRejectsAbsoluteCheckPath(t *testing.T) {
+// TestRunRalphCheckAllowsAbsoluteCheckPath pins the registry/import-pack
+// behavior: packs can be installed outside the city/store roots, so formula
+// expansion may produce an absolute gc.check_path.
+func TestRunRalphCheckAllowsAbsoluteCheckPath(t *testing.T) {
 	parent := t.TempDir()
 	cityPath := filepath.Join(parent, "city")
 	storePath := filepath.Join(parent, "rig")
@@ -7288,9 +7281,13 @@ func TestRunRalphCheckRejectsAbsoluteCheckPath(t *testing.T) {
 	if err := os.MkdirAll(storePath, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	outside := filepath.Join(parent, "outside.sh")
-	if err := os.WriteFile(outside, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write outside: %v", err)
+	packDir := filepath.Join(parent, "registry-cache", "packs", "workflows")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatalf("mkdir pack dir: %v", err)
+	}
+	checkScript := filepath.Join(packDir, "check.sh")
+	if err := os.WriteFile(checkScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write check script: %v", err)
 	}
 
 	store := beads.NewMemStore()
@@ -7298,21 +7295,21 @@ func TestRunRalphCheckRejectsAbsoluteCheckPath(t *testing.T) {
 		ID:   "check-abs",
 		Type: "task",
 		Metadata: map[string]string{
-			"gc.check_path":    outside,
+			"gc.check_path":    checkScript,
 			"gc.check_timeout": "30s",
 		},
 	}
 	subject := beads.Bead{ID: "run-abs", Type: "task"}
 
-	_, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
+	result, err := runRalphCheck(store, check, subject, 1, ProcessOptions{
 		CityPath:  cityPath,
 		StorePath: storePath,
 	})
-	if err == nil {
-		t.Fatal("expected absolute-path rejection, got nil")
+	if err != nil {
+		t.Fatalf("absolute check path should be accepted: %v", err)
 	}
-	if !strings.Contains(err.Error(), "must be relative") {
-		t.Errorf("expected absolute-path error, got: %v", err)
+	if result.Outcome != convergence.GatePass {
+		t.Fatalf("outcome = %q, want %q; stdout=%q stderr=%q", result.Outcome, convergence.GatePass, result.Stdout, result.Stderr)
 	}
 }
 

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -813,9 +813,10 @@ func (p *Provider) messageCandidatesForRoutes(routes []string) ([]beads.Bead, er
 }
 
 // messageCandidatesAll returns all open message beads matching any route.
-// Empty routes return all open messages. Message reads need TierBoth because
-// bd stores current message beads as wisps while older stores can still have
-// issue-tier messages.
+// TierBoth is one logical query; BdStore may satisfy it with separate
+// issue-tier and wisp-tier reads before deduping. Empty routes return all open
+// messages. Live reads are required so command-visible mail sees fresh wisps
+// even when the active store cache was primed earlier.
 func (p *Provider) messageCandidatesAll(routes []string) ([]beads.Bead, error) {
 	all, err := p.store.List(beads.ListQuery{
 		Type:      "message",

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -400,7 +400,7 @@ func TestMessageQueriesUseBothTiers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
-	if len(inbox) != 2 || !messagesContain(inbox, wisp.ID) || !messagesContain(inbox, msg.ID) {
+	if len(inbox) != 2 || !hasMailMessageID(inbox, wisp.ID) || !hasMailMessageID(inbox, msg.ID) {
 		t.Fatalf("Check = %#v, want wisp %s and issue %s", inbox, wisp.ID, msg.ID)
 	}
 
@@ -408,7 +408,7 @@ func TestMessageQueriesUseBothTiers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("All: %v", err)
 	}
-	if len(all) != 2 || !messagesContain(all, wisp.ID) || !messagesContain(all, msg.ID) {
+	if len(all) != 2 || !hasMailMessageID(all, wisp.ID) || !hasMailMessageID(all, msg.ID) {
 		t.Fatalf("All = %#v, want wisp %s and issue %s", all, wisp.ID, msg.ID)
 	}
 
@@ -424,14 +424,14 @@ func TestMessageQueriesUseBothTiers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Thread: %v", err)
 	}
-	if len(thread) != 1 {
-		t.Fatalf("Thread = %#v, want one thread message", thread)
+	if len(thread) != 1 || thread[0].ID != wisp.ID {
+		t.Fatalf("Thread = %#v, want wisp thread message %s", thread, wisp.ID)
 	}
 }
 
-func messagesContain(messages []mail.Message, id string) bool {
-	for _, msg := range messages {
-		if msg.ID == id {
+func hasMailMessageID(messages []mail.Message, id string) bool {
+	for _, message := range messages {
+		if message.ID == id {
 			return true
 		}
 	}
@@ -999,6 +999,38 @@ func TestArchive(t *testing.T) {
 
 	if _, err := store.Get(sent.ID); !errors.Is(err, beads.ErrNotFound) {
 		t.Fatalf("store.Get(%s) err = %v, want ErrNotFound", sent.ID, err)
+	}
+}
+
+func TestArchiveCandidatesUseBothTiers(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	wisp, err := store.Create(beads.Bead{
+		Title:       "dismiss wisp",
+		Type:        "message",
+		Assignee:    "mayor",
+		From:        "human",
+		Description: "wisp body",
+		Ephemeral:   true,
+	})
+	if err != nil {
+		t.Fatalf("Create ephemeral message: %v", err)
+	}
+	issue, err := p.Send("human", "mayor", "dismiss issue", "issues body")
+	if err != nil {
+		t.Fatalf("Send issues-tier message: %v", err)
+	}
+
+	matches, err := p.ArchiveCandidates(ArchiveFilter{
+		Recipients:    []string{"mayor"},
+		SubjectPrefix: "dismiss",
+	})
+	if err != nil {
+		t.Fatalf("ArchiveCandidates: %v", err)
+	}
+	if len(matches) != 2 || !hasMailMessageID(matches, issue.ID) || !hasMailMessageID(matches, wisp.ID) {
+		t.Fatalf("ArchiveCandidates = %#v, want issues-tier message %s and wisp message %s", matches, issue.ID, wisp.ID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the stale relative-only guard for `gc.check_path` in Ralph checks
- allow absolute check paths produced by imported/registry pack expansion
- update the regression test and condition-path comment to match the pack-location model

## Tests
- `go test ./internal/dispatch -run 'TestRunRalphCheckAllowsAbsoluteCheckPath|TestRunRalphCheckRejectsPathTraversalAboveCityPath|TestRunRalphCheckRejectsAbsoluteWorkDirOutsideRoots'`\n- `go test ./internal/convergence`\n- `go test ./internal/dispatch ./internal/convergence ./internal/formula ./internal/molecule`\n- `go test ./cmd/gc -run '^$'`