### PR TITLE
fix(reconciler): honor min_active_sessions for asleep city-stop pool sessions

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -42,9 +42,10 @@ func buildAwakeInputFromReconciler(
 	for i := range cfg.Agents {
 		a := &cfg.Agents[i]
 		agent := AwakeAgent{
-			QualifiedName:  a.QualifiedName(),
-			Suspended:      isAgentEffectivelySuspended(cfg, a),
-			SleepAfterIdle: parseSleepDuration(a.SleepAfterIdle),
+			QualifiedName:     a.QualifiedName(),
+			Suspended:         isAgentEffectivelySuspended(cfg, a),
+			SleepAfterIdle:    parseSleepDuration(a.SleepAfterIdle),
+			MinActiveSessions: a.EffectiveMinActiveSessions(),
 		}
 		if len(a.DependsOn) > 0 {
 			agent.DependsOn = a.DependsOn

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -491,10 +491,13 @@ func findBeadBySessionName(beads []AwakeSessionBead, name string) *AwakeSessionB
 // template that may participate in the min_active_sessions guarantee. Named
 // and manual sessions are excluded (they carry their own keep-awake rules),
 // as are drained and closed beads (not live, not revivable here).
+// Dependency-only beads are excluded too: they wake exclusively via the
+// dependency gate, so they neither count toward the min nor are eligible for
+// min-active revival — matching collectActiveBeads.
 func isMinActivePoolBead(b AwakeSessionBead, template string) bool {
 	return b.Template == template &&
 		b.NamedIdentity == "" && !b.ConfiguredNamedSession &&
-		!b.ManualSession && !b.Drained && b.State != "closed"
+		!b.ManualSession && !b.Drained && !b.DependencyOnly && b.State != "closed"
 }
 
 // countMinActiveCovered counts pool session beads for template that already
@@ -514,7 +517,14 @@ func countMinActiveCovered(beads []AwakeSessionBead, desired map[string]string, 
 			}
 			continue
 		}
-		n++
+		// Only live beads (active/creating) count as covering the guarantee.
+		// Transitional or non-runnable states (suspended, draining,
+		// quarantined, failed-create, stopped, ...) do not — counting them
+		// would mask a real deficit and leave the pool cold when there are
+		// zero live sessions.
+		if b.State == "active" || b.State == "creating" {
+			n++
+		}
 	}
 	return n
 }

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -36,10 +37,11 @@ type AwakeInput struct {
 
 // AwakeAgent represents an [[agent]] config entry.
 type AwakeAgent struct {
-	QualifiedName  string   // e.g. "hello-world/polecat"
-	DependsOn      []string // template names this agent depends on
-	Suspended      bool
-	SleepAfterIdle time.Duration // 0 = disabled
+	QualifiedName     string   // e.g. "hello-world/polecat"
+	DependsOn         []string // template names this agent depends on
+	Suspended         bool
+	SleepAfterIdle    time.Duration // 0 = disabled
+	MinActiveSessions int           // effective min_active_sessions; 0 = no always-warm guarantee
 }
 
 // AwakeNamedSession represents a [[named_session]] config entry.
@@ -282,6 +284,37 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 	}
 
+	// Min-active-sessions wake: keep min_active_sessions pool sessions warm
+	// across a city-stop. A pool agent whose only instance is asleep with
+	// sleep_reason=city-stop is neither counted toward the min nor woken by
+	// the demand-driven passes above, so without this pass a
+	// min_active_sessions=1 agent stays cold indefinitely after gc stop &&
+	// gc start until work is explicitly slung to it. We revive the existing
+	// asleep city-stop bead rather than relying on a fresh spawn (no
+	// orphaned-bead churn), mirroring the named-always same-tick wake (#2367)
+	// on the pool min path. Scoped to sleep_reason=city-stop so idle_timeout
+	// and wake_mode semantics are unchanged. See #2739.
+	for _, agent := range input.Agents {
+		if agent.Suspended || agent.MinActiveSessions <= 0 {
+			continue
+		}
+		template := agent.QualifiedName
+		covered := countMinActiveCovered(input.SessionBeads, desired, template)
+		if covered >= agent.MinActiveSessions {
+			continue
+		}
+		for _, bead := range cityStopPoolBeads(input.SessionBeads, template) {
+			if covered >= agent.MinActiveSessions {
+				break
+			}
+			if _, already := desired[bead.SessionName]; already {
+				continue
+			}
+			desired[bead.SessionName] = "min-active"
+			covered++
+		}
+	}
+
 	// Step 2-3: Decide awake
 	result := make(map[string]AwakeDecision)
 
@@ -352,7 +385,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		// assignments do not prevent idle sleep.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
 			!isAlwaysNamedSession(input.NamedSessions, bead) &&
-			desired[name] != "assigned-work" {
+			desired[name] != "assigned-work" && desired[name] != "min-active" {
 			agent, hasAgent := lookupAgent(bead.Template)
 			var idleTimeout time.Duration
 			switch {
@@ -452,6 +485,53 @@ func findBeadBySessionName(beads []AwakeSessionBead, name string) *AwakeSessionB
 		}
 	}
 	return nil
+}
+
+// isMinActivePoolBead reports whether a bead is a pool-managed instance of
+// template that may participate in the min_active_sessions guarantee. Named
+// and manual sessions are excluded (they carry their own keep-awake rules),
+// as are drained and closed beads (not live, not revivable here).
+func isMinActivePoolBead(b AwakeSessionBead, template string) bool {
+	return b.Template == template &&
+		b.NamedIdentity == "" && !b.ConfiguredNamedSession &&
+		!b.ManualSession && !b.Drained && b.State != "closed"
+}
+
+// countMinActiveCovered counts pool session beads for template that already
+// satisfy the min_active_sessions guarantee: non-asleep live beads
+// (active/creating) plus any bead an earlier pass already marked
+// desired-awake this tick. An asleep bead with no wake reason does not count —
+// that is precisely the deficit the min-active pass fills.
+func countMinActiveCovered(beads []AwakeSessionBead, desired map[string]string, template string) int {
+	n := 0
+	for _, b := range beads {
+		if !isMinActivePoolBead(b, template) {
+			continue
+		}
+		if b.State == "asleep" {
+			if _, awake := desired[b.SessionName]; awake {
+				n++
+			}
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// cityStopPoolBeads returns the asleep, city-stop pool beads for template in
+// deterministic order (by bead ID). These are the revival candidates for the
+// min_active_sessions wake — restricting to sleep_reason=city-stop keeps
+// idle_timeout / wake_mode semantics untouched.
+func cityStopPoolBeads(beads []AwakeSessionBead, template string) []AwakeSessionBead {
+	var out []AwakeSessionBead
+	for _, b := range beads {
+		if isMinActivePoolBead(b, template) && b.State == "asleep" && b.SleepReason == "city-stop" {
+			out = append(out, b)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
 }
 
 func isNamedSessionTemplate(named []AwakeNamedSession, template string) bool {

--- a/cmd/gc/compute_awake_set_min_active_test.go
+++ b/cmd/gc/compute_awake_set_min_active_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// These tests cover the min_active_sessions-aware wake path added for #2739:
+// a city-scoped pool agent whose only instance is asleep with
+// sleep_reason=city-stop must be revived so the always-warm guarantee
+// (min_active_sessions) survives a gc stop && gc start, even with no work
+// routed to it.
+
+// TestMinActive_AsleepCityStopWakes is the canonical #2739 case: a pool agent
+// configured min_active_sessions=1 whose only session is asleep(city-stop)
+// with no assigned work must be woken to satisfy the min.
+func TestMinActive_AsleepCityStopWakes(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "s-1", SessionName: "rig--pl", Template: "rig/pl",
+			State: "asleep", SleepReason: "city-stop",
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "rig--pl")
+	assertReason(t, result, "rig--pl", "min-active")
+}
+
+// TestMinActive_ActiveSatisfiesMin verifies a live (active) session counts
+// toward the min, so a coexisting asleep city-stop bead is NOT additionally
+// woken when min is already met.
+func TestMinActive_ActiveSatisfiesMin(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "s-live", SessionName: "rig--pl-1", Template: "rig/pl", State: "active"},
+			{ID: "s-cold", SessionName: "rig--pl-2", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+		},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl-2")
+}
+
+// TestMinActive_FillsDeficitAcrossMultiple verifies that when min=2 and one
+// session is live, exactly one additional city-stop bead is revived (not more).
+func TestMinActive_FillsDeficitAcrossMultiple(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 2}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "s-live", SessionName: "rig--pl-0", Template: "rig/pl", State: "active"},
+			{ID: "s-a", SessionName: "rig--pl-a", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+			{ID: "s-b", SessionName: "rig--pl-b", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+		},
+		Now: now,
+	})
+	woken := 0
+	for _, name := range []string{"rig--pl-a", "rig--pl-b"} {
+		if d, ok := result[name]; ok && d.ShouldWake {
+			woken++
+		}
+	}
+	if woken != 1 {
+		t.Errorf("min-active deficit fill woke %d city-stop beads, want exactly 1 (live=1, min=2)", woken)
+	}
+}
+
+// TestMinActive_OnlyCityStopReason verifies the wake is scoped to
+// sleep_reason=city-stop: an idle-timeout asleep bead is NOT revived by the
+// min-active pass (idle_timeout / wake_mode semantics are unchanged).
+func TestMinActive_OnlyCityStopReason(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "s-1", SessionName: "rig--pl", Template: "rig/pl",
+			State: "asleep", SleepReason: "idle-timeout",
+		}},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl")
+}
+
+// TestMinActive_NotResleptByIdleSuppression verifies the min-active wake is
+// exempt from idle-sleep suppression. A city-stop bead carries an old
+// IdleSince (the detach time), and the agent has a sleep_after_idle; without
+// the exemption the idle-sleep block would immediately flip the wake back to
+// asleep, defeating the fix.
+func TestMinActive_NotResleptByIdleSuppression(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1, SleepAfterIdle: time.Hour}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "s-1", SessionName: "rig--pl", Template: "rig/pl",
+			State: "asleep", SleepReason: "city-stop",
+			IdleSince: now.Add(-24 * time.Hour),
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "rig--pl")
+	assertReason(t, result, "rig--pl", "min-active")
+}
+
+// TestMinActive_SuspendedAgentNoWake verifies a suspended agent's asleep
+// city-stop bead is not revived.
+func TestMinActive_SuspendedAgentNoWake(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1, Suspended: true}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "s-1", SessionName: "rig--pl", Template: "rig/pl",
+			State: "asleep", SleepReason: "city-stop",
+		}},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl")
+}
+
+// TestMinActive_ZeroMinNoWake verifies that without min_active_sessions the
+// asleep city-stop bead stays asleep (no behavior change for min=0 agents).
+func TestMinActive_ZeroMinNoWake(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 0}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "s-1", SessionName: "rig--pl", Template: "rig/pl",
+			State: "asleep", SleepReason: "city-stop",
+		}},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl")
+}
+
+// TestMinActive_NamedBeadNotCountedAsPool verifies the min-active pass only
+// considers pool beads: a configured-named asleep city-stop bead is not
+// revived by the pool min path (named sessions have their own keep-awake
+// rules via the named-always / named-demand passes).
+func TestMinActive_NamedBeadNotCountedAsPool(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "s-1", SessionName: "rig--pl", Template: "rig/pl",
+			State: "asleep", SleepReason: "city-stop",
+			NamedIdentity: "rig/pl", ConfiguredNamedSession: true,
+		}},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl")
+}
+
+// TestBuildAwakeInputPropagatesMinActiveSessions verifies the reconciler
+// bridge threads an agent's effective min_active_sessions into AwakeAgent so
+// ComputeAwakeSet can honor the always-warm guarantee (#2739 wiring seam).
+func TestBuildAwakeInputPropagatesMinActiveSessions(t *testing.T) {
+	minSess := 1
+	input := buildAwakeInputFromReconciler(
+		&config.City{Agents: []config.Agent{{Name: "pl", MinActiveSessions: &minSess}}},
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		time.Now().UTC(),
+	)
+	var found bool
+	for _, a := range input.Agents {
+		if a.QualifiedName == "pl" {
+			found = true
+			if a.MinActiveSessions != 1 {
+				t.Errorf("AwakeAgent.MinActiveSessions = %d, want 1", a.MinActiveSessions)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("agent %q not present in AwakeInput.Agents", "pl")
+	}
+}
+
+// TestMinActive_HeldBeadNotWoken verifies hold suppression still wins: a
+// city-stop bead under an active hold is not revived by the min-active pass.
+func TestMinActive_HeldBeadNotWoken(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "s-1", SessionName: "rig--pl", Template: "rig/pl",
+			State: "asleep", SleepReason: "city-stop",
+			HeldUntil: now.Add(time.Hour),
+		}},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl")
+}

--- a/cmd/gc/compute_awake_set_min_active_test.go
+++ b/cmd/gc/compute_awake_set_min_active_test.go
@@ -184,3 +184,70 @@ func TestMinActive_HeldBeadNotWoken(t *testing.T) {
 	})
 	assertAsleep(t, result, "rig--pl")
 }
+
+// TestMinActive_DependencyOnlyDoesNotCount verifies a dependency-only session
+// does not satisfy the min_active_sessions guarantee even while live: it is
+// excluded from the min-active pool (it wakes only via dependency gating), so
+// a coexisting asleep city-stop pool bead must still be revived to cover the
+// min. Without excluding dependency-only beads from the coverage count, the
+// live dependency-only bead would mask the deficit and leave the pool cold.
+func TestMinActive_DependencyOnlyDoesNotCount(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "s-dep", SessionName: "rig--pl-dep", Template: "rig/pl", State: "active", DependencyOnly: true},
+			{ID: "s-cold", SessionName: "rig--pl-pool", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+		},
+		Now: now,
+	})
+	assertAwake(t, result, "rig--pl-pool")
+	assertReason(t, result, "rig--pl-pool", "min-active")
+}
+
+// TestMinActive_DependencyOnlyNotRevived verifies the min-active pass never
+// revives a dependency-only bead: when the only city-stop pool candidate is
+// dependency-only, the deficit cannot be filled by it (dependency-only
+// sessions wake exclusively via dependency gating).
+func TestMinActive_DependencyOnlyNotRevived(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{{
+			ID: "s-1", SessionName: "rig--pl", Template: "rig/pl",
+			State: "asleep", SleepReason: "city-stop", DependencyOnly: true,
+		}},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl")
+}
+
+// TestMinActive_SuspendedDoesNotCount verifies that a non-live, non-asleep
+// state (here: suspended) does NOT satisfy the min_active_sessions guarantee.
+// Only active/creating beads count as covered; a suspended sibling must not
+// mask the deficit, so the asleep city-stop pool bead is still revived.
+func TestMinActive_SuspendedDoesNotCount(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "s-susp", SessionName: "rig--pl-susp", Template: "rig/pl", State: "suspended"},
+			{ID: "s-cold", SessionName: "rig--pl-pool", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+		},
+		Now: now,
+	})
+	assertAwake(t, result, "rig--pl-pool")
+	assertReason(t, result, "rig--pl-pool", "min-active")
+}
+
+// TestMinActive_CreatingCounts verifies a creating bead counts as live toward
+// the min (a session mid-spawn is on its way to active), so a coexisting
+// asleep city-stop bead is not additionally woken.
+func TestMinActive_CreatingCounts(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "s-new", SessionName: "rig--pl-1", Template: "rig/pl", State: "creating"},
+			{ID: "s-cold", SessionName: "rig--pl-2", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+		},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl-2")
+}


### PR DESCRIPTION
## Summary

Fixes #2739. The session reconciler did not honor `min_active_sessions` for a **pool agent** whose only instance was `asleep` with `sleep_reason=city-stop`. The asleep instance neither counted toward the min nor got woken/replaced, so a `min_active_sessions=1` pool agent stayed cold indefinitely after a `gc stop && gc start` until work was explicitly slung to it.

Same bug family as #1493 (named-always post-churn) and #2094 (named on-demand after `gc stop && gc start`) — "a `city-stop` asleep session never auto-wakes" — but on the pool / `min_active_sessions` code path, which those fixes did not cover. `#2555` ("wake known pool identities with assigned work") addressed the *with-work* resume path; this covers the **`min_active_sessions`-without-work** facet.

## Root cause

`min_active_sessions` was consulted only in `applyNestedCaps` (`cmd/gc/pool_desired_state.go`) min-fill. An `asleep`/`city-stop` session with no assigned work contributes zero to the supply count, and `ComputeAwakeSet` was not `min_active_sessions`-aware — so no wake reason was produced for the idle city-stop bead. Net: neither counted nor woken.

## Fix

Makes `ComputeAwakeSet` (`cmd/gc/compute_awake_set.go`) `min_active_sessions`-aware: when live (non-asleep) sessions for a template fall below `min_active_sessions`, it injects a wake reason that revives the asleep `city-stop` bead — reusing the existing instance rather than spawning a churned replacement, and converging this bug family onto one wake rule.

## Test

`cmd/gc/compute_awake_set_min_active_test.go` (+186) covers the asleep-city-stop-below-min wake path.

## Changed files

- `cmd/gc/compute_awake_set.go` (+90)
- `cmd/gc/compute_awake_bridge.go` (+7)
- `cmd/gc/compute_awake_set_min_active_test.go` (+186, new)
