### PR TITLE
feat(pack): move bundled defaults into import registry

### DIFF
--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -445,9 +445,7 @@ func TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision(t *testing.T) {
 	cityDir := shortSocketTempDir(t, "gc-state-runtime-builtin-")
 	cleanupManagedDoltTestCity(t, cityDir)
 	tomlPath := filepath.Join(cityDir, "city.toml")
-	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
-		t.Fatalf("write initial city.toml: %v", err)
-	}
+	writeCityConfigForReloadTest(t, cityDir, config.DefaultCity("test"))
 
 	initial, err := tryReloadConfig(tomlPath, "test", cityDir)
 	if err != nil {
@@ -457,10 +455,9 @@ func TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision(t *testing.T) {
 	cs := newControllerState(context.Background(), initial.Cfg, runtime.NewFake(), events.NewFake(), "test", cityDir)
 
 	rigDir := t.TempDir()
-	updatedToml := fmt.Sprintf("[workspace]\nname = \"test\"\n\n[[rigs]]\nname = \"alpha\"\npath = %q\n", rigDir)
-	if err := os.WriteFile(tomlPath, []byte(updatedToml), 0o644); err != nil {
-		t.Fatalf("write updated city.toml: %v", err)
-	}
+	updatedCfg := config.DefaultCity("test")
+	updatedCfg.Rigs = []config.Rig{{Name: "alpha", Path: rigDir}}
+	writeCityConfigForReloadTest(t, cityDir, updatedCfg)
 	reloaded, err := tryReloadConfig(tomlPath, "test", cityDir)
 	if err != nil {
 		t.Fatalf("reloaded tryReloadConfig: %v", err)
@@ -483,9 +480,7 @@ func TestControllerStateMutationRefreshKeepsBuiltinOrdersAndClearsPending(t *tes
 	cityDir := shortSocketTempDir(t, "gc-state-mutation-builtin-")
 	cleanupManagedDoltTestCity(t, cityDir)
 	tomlPath := filepath.Join(cityDir, "city.toml")
-	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
-		t.Fatalf("write city.toml: %v", err)
-	}
+	writeCityConfigForReloadTest(t, cityDir, config.DefaultCity("test"))
 
 	initial, err := tryReloadConfig(tomlPath, "test", cityDir)
 	if err != nil {
@@ -513,6 +508,20 @@ func TestControllerStateMutationRefreshKeepsBuiltinOrdersAndClearsPending(t *tes
 		t.Fatal("pending mutation marker was not cleared by matching runtime update")
 	}
 	requireControllerStateOrder(t, cs, "gate-sweep")
+}
+
+func writeCityConfigForReloadTest(t *testing.T, cityDir string, cfg config.City) {
+	t.Helper()
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal city config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), data, 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := installInitImportsIfNeeded(fsys.OSFS{}, cityDir); err != nil {
+		t.Fatalf("install bundled imports: %v", err)
+	}
 }
 
 func requireControllerStateOrder(t *testing.T, cs *controllerState, want string) {

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -31,15 +31,29 @@ Describe what this agent should do here.
 // discover remote packs before fetching them.
 func loadCityConfig(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
 	tomlPath := filepath.Join(cityPath, "city.toml")
-	extras, err := builtinPackIncludesForConfigLoad(fsys.OSFS{}, tomlPath, resolveLoadCityConfigWarningWriter(warningWriter...))
-	if err != nil {
-		return nil, err
-	}
-	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath, extras...)
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
 	if err != nil {
 		return nil, err
 	}
 	emitLoadCityConfigWarnings(resolveLoadCityConfigWarningWriter(warningWriter...), prov)
+	applyFeatureFlags(cfg)
+	return cfg, nil
+}
+
+// loadCityConfigSuppressDeprecatedOrderWarnings performs a full config load
+// while suppressing only legacy order-path migration warnings.
+func loadCityConfigSuppressDeprecatedOrderWarnings(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	resolvedWarningWriter := resolveLoadCityConfigWarningWriter(warningWriter...)
+	cfg, prov, err := config.LoadWithIncludesOptions(
+		fsys.OSFS{},
+		tomlPath,
+		config.LoadOptions{SuppressDeprecatedOrderWarnings: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+	emitLoadCityConfigWarnings(resolvedWarningWriter, prov)
 	applyFeatureFlags(cfg)
 	return cfg, nil
 }
@@ -48,11 +62,7 @@ func loadCityConfig(cityPath string, warningWriter ...io.Writer) (*config.City, 
 // filesystem implementation. Used by functions that take an fsys.FS parameter
 // for unit testing.
 func loadCityConfigFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (*config.City, error) {
-	extras, err := builtinPackIncludesForConfigLoad(fs, tomlPath, resolveLoadCityConfigWarningWriter(warningWriter...))
-	if err != nil {
-		return nil, err
-	}
-	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath, extras...)
+	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath)
 	if err != nil {
 		return nil, err
 	}
@@ -61,17 +71,11 @@ func loadCityConfigFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (
 	return cfg, nil
 }
 
-// loadCityConfigWithoutBuiltinPackRefreshFS loads config using builtin packs
-// that are already materialized on disk. Completion paths use this to avoid
-// forcing refresh work on every shell invocation. That means completion may
-// briefly reflect stale builtin-pack content after an upgrade until a normal
-// gc command refreshes the generated packs.
+// loadCityConfigWithoutBuiltinPackRefreshFS loads config without performing
+// compatibility materialization under .gc/system/packs. Completion paths use
+// this same read-only behavior as the normal config load path.
 func loadCityConfigWithoutBuiltinPackRefreshFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (*config.City, error) {
-	var extras []string
-	if usesOSFS(fs) {
-		extras = builtinPackIncludes(filepath.Dir(tomlPath))
-	}
-	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath, extras...)
+	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 	"github.com/spf13/cobra"
 )
@@ -19,22 +20,14 @@ func loadConfigCommandCityConfig(cityPath string) (*config.City, *config.Provena
 }
 
 func loadCityConfigWithBuiltinPacks(cityPath string, includes ...string) (*config.City, *config.Provenance, error) {
-	allIncludes, err := cityConfigIncludesWithBuiltinPacks(cityPath, includes...)
-	if err != nil {
-		return nil, nil, err
+	if _, err := packman.InstallLockedBundledPacks(cityPath); err != nil {
+		return nil, nil, fmt.Errorf("refreshing bundled pack cache: %w", err)
 	}
-	return config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), allIncludes...)
+	return config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), includes...)
 }
 
-func cityConfigIncludesWithBuiltinPacks(cityPath string, includes ...string) ([]string, error) {
-	if err := MaterializeBuiltinPacks(cityPath); err != nil {
-		return nil, fmt.Errorf("materializing builtin packs: %w", err)
-	}
-	builtinIncludes := builtinPackIncludes(cityPath)
-	allIncludes := make([]string, 0, len(includes)+len(builtinIncludes))
-	allIncludes = append(allIncludes, includes...)
-	allIncludes = append(allIncludes, builtinIncludes...)
-	return allIncludes, nil
+func cityConfigIncludesWithBuiltinPacks(_ string, includes ...string) []string {
+	return append([]string(nil), includes...)
 }
 
 func newConfigCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/cmd_config_builtin_cache_test.go
+++ b/cmd/gc/cmd_config_builtin_cache_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/builtinpacks"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+func TestLoadCityConfigWithBuiltinPacksRepairsLockedBundledCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cityDir := t.TempDir()
+	source := builtinpacks.MustSource("bd")
+	commit := "synthetic-stale"
+
+	writeCityToml(t, cityDir, `[workspace]
+name = "demo"
+`)
+	writePackToml(t, cityDir, fmt.Sprintf(`[pack]
+name = "demo"
+schema = 1
+
+[imports.bd]
+source = %q
+version = "sha:%s"
+`, source, commit))
+	if err := packman.WriteLockfile(fsys.OSFS{}, cityDir, &packman.Lockfile{
+		Schema: packman.LockfileSchema,
+		Packs: map[string]packman.LockedPack{
+			source: {Version: "sha:" + commit, Commit: commit},
+		},
+	}); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	cacheDir, err := packman.RepoCachePath(source, commit)
+	if err != nil {
+		t.Fatalf("RepoCachePath: %v", err)
+	}
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, ".gc-bundled-pack-cache.toml"), []byte(fmt.Sprintf(`
+schema = 1
+repository = %q
+commit = %q
+content_hash = "sha256:stale"
+`, builtinpacks.Repository, commit)), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, _, err := loadCityConfigWithBuiltinPacks(cityDir); err != nil {
+		t.Fatalf("loadCityConfigWithBuiltinPacks: %v", err)
+	}
+	if err := builtinpacks.ValidateSyntheticRepo(cacheDir, commit); err != nil {
+		t.Fatalf("ValidateSyntheticRepo after load: %v", err)
+	}
+}

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -180,6 +180,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(c)
 	}
 	register(expandedConfigLoadCheck{})
+	register(newBuiltinPackRegistryMigrationCheck(cityPath))
 	register(&doctor.ImplicitImportCacheCheck{})
 	register(&doctor.DeprecatedAttachmentFieldsCheck{})
 

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -387,6 +387,9 @@ func collectAllImportsFS(fs fsys.FS, cityPath string) (map[string]config.Import,
 	if err != nil {
 		return nil, err
 	}
+	for name, imp := range cfg.Imports {
+		all["city:"+name] = imp
+	}
 	for _, rig := range cfg.Rigs {
 		for name, imp := range rig.Imports {
 			all["rig:"+rig.Name+":"+name] = imp

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/hooks"
 	"github.com/gastownhall/gascity/internal/overlay"
+	"github.com/gastownhall/gascity/internal/packman"
 	"github.com/spf13/cobra"
 )
 
@@ -248,8 +249,9 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 Runs an interactive wizard to choose a config template and coding agent
 provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
 the standard top-level directories, and .template.md prompt templates, then
-materializes builtin packs under .gc/system/packs. Use --provider to create the default minimal city
-non-interactively, or --file to initialize from an existing TOML config file.
+records bundled default packs as explicit pack registry imports. Use --provider
+to create the default minimal city non-interactively, or --file to initialize
+from an existing TOML config file.
 
 Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
 agent prompt files in the target directory (useful when bootstrapping a
@@ -783,6 +785,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return 1
 	}
 	cfg.Workspace.Name = cityName
+	applyDefaultBuiltinPackImports(cityPath, cfg)
 
 	// Create directory structure. With --preserve-existing, only refuse when
 	// the runtime scaffold is already in place — a pre-authored city.toml in
@@ -882,6 +885,10 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 			fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
 		}
 	}
+	if err := installInitImportsIfNeeded(fs, cityPath); err != nil {
+		fmt.Fprintf(stderr, "gc init: installing imports: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, filepath.Join(cityPath, "city.toml"), &cityCfg, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -980,6 +987,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		cfg = config.DefaultCity(cityName)
 	}
 	applyBootstrapProfile(&cfg, wiz.bootstrapProfile)
+	applyDefaultBuiltinPackImports(cityPath, &cfg)
 	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
 
 	// Write prompt files only for the agents declared by the init template.
@@ -1028,6 +1036,10 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	}
 	if !wroteCity {
 		fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
+	}
+	if err := installInitImportsIfNeeded(fs, cityPath); err != nil {
+		fmt.Fprintf(stderr, "gc init: installing imports: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
 	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, tomlPath, &cityCfg, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1122,6 +1134,53 @@ func shouldBootstrapScopedFileStore(cfg *config.City) bool {
 		return false
 	}
 	return strings.TrimSpace(cfg.Beads.Provider) == "file"
+}
+
+func applyDefaultBuiltinPackImports(cityPath string, cfg *config.City) {
+	if cfg == nil {
+		return
+	}
+	includeGastown := false
+	if _, ok := cfg.Imports["gastown"]; ok {
+		includeGastown = true
+	}
+	config.AddDefaultBuiltinImports(cfg, initShouldIncludeBDImport(cityPath, cfg), includeGastown)
+}
+
+func initShouldIncludeBDImport(cityPath string, cfg *config.City) bool {
+	if v := strings.TrimSpace(os.Getenv("GC_BEADS")); v != "" {
+		return providerUsesBdStoreContract(normalizeRawBeadsProvider(cityPath, v))
+	}
+	if cfg == nil {
+		return true
+	}
+	return providerUsesBdStoreContract(strings.TrimSpace(cfg.Beads.Provider))
+}
+
+func installInitImportsIfNeeded(fs fsys.FS, cityPath string) error {
+	if !canInstallImportsForFS(fs, cityPath) {
+		return nil
+	}
+	imports, err := collectAllImportsFS(fs, cityPath)
+	if err != nil {
+		return err
+	}
+	if len(imports) == 0 {
+		return nil
+	}
+	lock, err := syncImports(cityPath, imports, packman.InstallResolveIfNeeded)
+	if err != nil {
+		return err
+	}
+	return writeImportLockfile(fs, cityPath, lock)
+}
+
+func canInstallImportsForFS(fs fsys.FS, cityPath string) bool {
+	if usesOSFS(fs) {
+		return true
+	}
+	_, err := os.Stat(filepath.Join(cityPath, citylayout.CityConfigFile))
+	return err == nil
 }
 
 func bootstrapScopedFileProviderCityFS(fs fsys.FS, cityPath string) error {
@@ -1331,6 +1390,10 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 	cfg, cityName, cityPrefix, persistSiteIdentity, err := rewriteCopiedInitFromIdentity(fs, cityPath, nameOverride)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := installInitImportsIfNeeded(fs, cityPath); err != nil {
+		fmt.Fprintf(stderr, "gc init: installing imports: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if persistSiteIdentity {

--- a/cmd/gc/cmd_internal_materialize_skills_test.go
+++ b/cmd/gc/cmd_internal_materialize_skills_test.go
@@ -73,8 +73,10 @@ provider = "file"
 	if !ok {
 		t.Fatal("materialize.VendorSink(claude) = not found")
 	}
+	// Builtin packs now enter city config through imports, but this unit only
+	// exercises the city-local skill tree.
 	wantStdout := fmt.Sprintf(
-		"materialized 8 skill(s) into %s: core.gc-agents, core.gc-city, core.gc-dashboard, core.gc-dispatch, core.gc-mail, core.gc-rigs, core.gc-work, plan\n",
+		"materialized 1 skill(s) into %s: plan\n",
 		filepath.Join(absWorkdir, sinkDir),
 	)
 	if stdout.String() != wantStdout {

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -327,7 +327,8 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			// (if unusual) minimal config — emit the default fallback.
 		}
 		// Agents without a prompt_template: read a builtin prompt shipped by
-		// the core bootstrap pack, materialized under .gc/system/packs/core/.
+		// the explicit core bundled-pack import, falling back to the legacy
+		// .gc/system/packs compatibility path when needed.
 		// When formula_v2 is enabled, all agents use graph-worker.md.
 		// Otherwise pool agents use pool-worker.md.
 		// Pool instances have Pool=nil after resolution, so also check the
@@ -335,12 +336,12 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		if a.PromptTemplate == "" {
 			promptFile := ""
 			if cfg.Daemon.FormulaV2 {
-				promptFile = citylayout.SystemPacksRoot + "/core/assets/prompts/graph-worker.md"
+				promptFile = corePromptPathForPrime(cityPath, cfg, "graph-worker.md")
 			} else if a.SupportsInstanceExpansion() || isPoolInstance(cfg, a) {
-				promptFile = citylayout.SystemPacksRoot + "/core/assets/prompts/pool-worker.md"
+				promptFile = corePromptPathForPrime(cityPath, cfg, "pool-worker.md")
 			}
 			if promptFile != "" {
-				if content, fErr := os.ReadFile(filepath.Join(cityPath, promptFile)); fErr == nil {
+				if content, fErr := os.ReadFile(promptFile); fErr == nil {
 					writePrimePromptWithFormat(stdout, cityName, ctx.AgentName, string(content), hookMode, hookFormat, suppressHookPrompt)
 					return 0
 				}
@@ -354,6 +355,21 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	// the correct output even under --strict.
 	writePrimePromptWithFormat(stdout, cityName, agentName, defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
 	return 0
+}
+
+func corePromptPathForPrime(cityPath string, cfg *config.City, name string) string {
+	if cfg != nil {
+		dirs := append([]string{}, cfg.ExplicitImportPackDirs...)
+		dirs = append(dirs, cfg.BootstrapImportPackDirs...)
+		dirs = append(dirs, cfg.ImplicitImportPackDirs...)
+		dirs = append(dirs, cfg.PackDirs...)
+		for _, dir := range dirs {
+			if filepath.Base(dir) == "core" {
+				return filepath.Join(dir, "assets", "prompts", name)
+			}
+		}
+	}
+	return filepath.Join(cityPath, citylayout.SystemPacksRoot, "core", "assets", "prompts", name)
 }
 
 func primeAgentCandidates(agentName string, hookMode bool, cityPath string) []string {

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -117,8 +117,8 @@ func listVisibleSkillEntries(cityPath string, cfg *config.City, store beads.Stor
 	entries := discoverSkillEntries(cityPath, "city")
 	// Legacy implicit-import compatibility packs may still contribute
 	// shared skills on upgraded installs. Keep surfacing them here while
-	// the compatibility path exists; normal launch-time system packs come
-	// from .gc/system/packs and are not part of this listing.
+	// the compatibility path exists; normal bundled packs come from explicit
+	// imports and are handled by discoverImportedSkillEntries below.
 	entries = append(entries, discoverBootstrapSkillEntries()...)
 	if strings.TrimSpace(agentName) == "" && strings.TrimSpace(sessionID) == "" {
 		entries = append(entries, discoverImportedSkillEntries(sharedSkillCatalogInputs(cfg, currentRigContext(cfg)))...)

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -84,9 +84,6 @@ func supervisorCityStopTimeout(cityPath string) time.Duration {
 }
 
 func effectiveCityName(cityPath string) (string, error) {
-	if err := MaterializeBuiltinPacks(cityPath); err != nil {
-		return "", fmt.Errorf("materializing builtin packs: %w", err)
-	}
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
 	if err != nil {

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/builtinpacks"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
@@ -464,11 +465,19 @@ func TestEffectiveCityNameUsesWorkspaceSiteBinding(t *testing.T) {
 	}
 }
 
-func writeCityWithUnmaterializedGastownImport(t *testing.T) string {
+func writeCityWithBundledGastownImport(t *testing.T) string {
 	t.Helper()
 
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := builtinpacks.MustSource("gastown")
+	commit := "abc123"
+	cacheDir := filepath.Join(home, ".gc", "cache", "repos", config.RepoCacheKey(source, commit))
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
@@ -479,16 +488,26 @@ name = "bright-lights"
 schema = 2
 
 [imports.gastown]
-source = ".gc/system/packs/gastown"
+source = "` + source + `"
 `
 	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lockToml := `schema = 1
+
+[packs."` + source + `"]
+version = "sha:` + commit + `"
+commit = "` + commit + `"
+fetched = "1970-01-01T00:00:01Z"
+`
+	if err := os.WriteFile(filepath.Join(cityPath, "packs.lock"), []byte(lockToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	return cityPath
 }
 
-func TestEffectiveCityNameMaterializesBuiltinPackImportsBeforeLoad(t *testing.T) {
-	cityPath := writeCityWithUnmaterializedGastownImport(t)
+func TestEffectiveCityNameLoadsBundledPackImportsFromRegistry(t *testing.T) {
+	cityPath := writeCityWithBundledGastownImport(t)
 
 	name, err := effectiveCityName(cityPath)
 	if err != nil {
@@ -497,13 +516,13 @@ func TestEffectiveCityNameMaterializesBuiltinPackImportsBeforeLoad(t *testing.T)
 	if name != "bright-lights" {
 		t.Fatalf("effectiveCityName = %q, want %q", name, "bright-lights")
 	}
-	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); err != nil {
-		t.Fatalf("expected gastown builtin pack to be materialized before config load: %v", err)
+	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); !os.IsNotExist(err) {
+		t.Fatalf("gastown should not be materialized under .gc/system/packs during config load: %v", err)
 	}
 }
 
-func TestLoadSupervisorCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *testing.T) {
-	cityPath := writeCityWithUnmaterializedGastownImport(t)
+func TestLoadSupervisorCityConfigLoadsBundledPackImportsFromRegistry(t *testing.T) {
+	cityPath := writeCityWithBundledGastownImport(t)
 
 	cfg, _, err := loadSupervisorCityConfig(cityPath)
 	if err != nil {
@@ -512,13 +531,13 @@ func TestLoadSupervisorCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *tes
 	if cfg.Workspace.Name != "bright-lights" {
 		t.Fatalf("workspace name = %q, want %q", cfg.Workspace.Name, "bright-lights")
 	}
-	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); err != nil {
-		t.Fatalf("expected gastown builtin pack to be materialized before supervisor config load: %v", err)
+	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); !os.IsNotExist(err) {
+		t.Fatalf("gastown should not be materialized under .gc/system/packs during supervisor config load: %v", err)
 	}
 }
 
-func TestLoadStartCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *testing.T) {
-	cityPath := writeCityWithUnmaterializedGastownImport(t)
+func TestLoadStartCityConfigLoadsBundledPackImportsFromRegistry(t *testing.T) {
+	cityPath := writeCityWithBundledGastownImport(t)
 
 	cfg, _, err := loadStartCityConfig(cityPath)
 	if err != nil {
@@ -527,13 +546,13 @@ func TestLoadStartCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *testing.
 	if cfg.Workspace.Name != "bright-lights" {
 		t.Fatalf("workspace name = %q, want %q", cfg.Workspace.Name, "bright-lights")
 	}
-	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); err != nil {
-		t.Fatalf("expected gastown builtin pack to be materialized before start config load: %v", err)
+	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); !os.IsNotExist(err) {
+		t.Fatalf("gastown should not be materialized under .gc/system/packs during start config load: %v", err)
 	}
 }
 
 func TestLoadStartCityConfigBuiltinGastownMayorHasNoStartupNudge(t *testing.T) {
-	cityPath := writeCityWithUnmaterializedGastownImport(t)
+	cityPath := writeCityWithBundledGastownImport(t)
 
 	cfg, _, err := loadStartCityConfig(cityPath)
 	if err != nil {
@@ -553,18 +572,13 @@ func TestLoadStartCityConfigBuiltinGastownMayorHasNoStartupNudge(t *testing.T) {
 	if mayor.Nudge != "" {
 		t.Fatalf("builtin gastown mayor nudge = %q, want empty for always-on resident coordinator", mayor.Nudge)
 	}
-
-	data, err := os.ReadFile(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "agents", "mayor", "agent.toml"))
-	if err != nil {
-		t.Fatalf("read materialized mayor agent.toml: %v", err)
-	}
-	if strings.Contains(string(data), "nudge =") {
-		t.Fatalf("materialized builtin mayor agent.toml should not contain a startup nudge:\n%s", string(data))
+	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); !os.IsNotExist(err) {
+		t.Fatalf("gastown should not be materialized under .gc/system/packs during start config load: %v", err)
 	}
 }
 
-func TestLoadSlingCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *testing.T) {
-	cityPath := writeCityWithUnmaterializedGastownImport(t)
+func TestLoadSlingCityConfigLoadsBundledPackImportsFromRegistry(t *testing.T) {
+	cityPath := writeCityWithBundledGastownImport(t)
 
 	cfg, _, err := loadSlingCityConfig(cityPath)
 	if err != nil {
@@ -573,13 +587,13 @@ func TestLoadSlingCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *testing.
 	if cfg.Workspace.Name != "bright-lights" {
 		t.Fatalf("workspace name = %q, want %q", cfg.Workspace.Name, "bright-lights")
 	}
-	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); err != nil {
-		t.Fatalf("expected gastown builtin pack to be materialized before sling config load: %v", err)
+	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); !os.IsNotExist(err) {
+		t.Fatalf("gastown should not be materialized under .gc/system/packs during sling config load: %v", err)
 	}
 }
 
-func TestLoadConfigCommandCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *testing.T) {
-	cityPath := writeCityWithUnmaterializedGastownImport(t)
+func TestLoadConfigCommandCityConfigLoadsBundledPackImportsFromRegistry(t *testing.T) {
+	cityPath := writeCityWithBundledGastownImport(t)
 
 	cfg, _, err := loadConfigCommandCityConfig(cityPath)
 	if err != nil {
@@ -588,15 +602,15 @@ func TestLoadConfigCommandCityConfigMaterializesBuiltinPackImportsBeforeLoad(t *
 	if cfg.Workspace.Name != "bright-lights" {
 		t.Fatalf("workspace name = %q, want %q", cfg.Workspace.Name, "bright-lights")
 	}
-	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); err != nil {
-		t.Fatalf("expected gastown builtin pack to be materialized before config command load: %v", err)
+	if _, err := os.Stat(filepath.Join(cityPath, citylayout.SystemPacksRoot, "gastown", "pack.toml")); !os.IsNotExist(err) {
+		t.Fatalf("gastown should not be materialized under .gc/system/packs during config command load: %v", err)
 	}
 }
 
-func TestRegisterCityWithSupervisorNameOverrideMaterializesBuiltinPackImports(t *testing.T) {
+func TestRegisterCityWithSupervisorNameOverrideLoadsBundledPackImportsFromRegistry(t *testing.T) {
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)
-	cityPath := writeCityWithUnmaterializedGastownImport(t)
+	cityPath := writeCityWithBundledGastownImport(t)
 
 	withSupervisorTestHooks(
 		t,

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -897,10 +897,7 @@ func tryReloadConfig(tomlPath, lockedWorkspaceName, cityRoot string) (*reloadRes
 		return nil, fmt.Errorf("fetching packs: %w", err)
 	}
 
-	allIncludes, err := cityConfigIncludesWithBuiltinPacks(cityRoot, extraConfigFiles...)
-	if err != nil {
-		return nil, err
-	}
+	allIncludes := cityConfigIncludesWithBuiltinPacks(cityRoot, extraConfigFiles...)
 	newCfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath, allIncludes...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing city.toml: %w", err)

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -2198,21 +2199,29 @@ func (osFS) Rename(oldpath, newpath string) error                 { return os.Re
 func (osFS) Remove(name string) error                             { return os.Remove(name) }
 
 // TestTryReloadConfig_IncludesBuiltinPackOrders verifies that the controller's
-// config reload path includes builtin pack formula layers so the order
-// dispatcher sees orders from all embedded packs (core, maintenance, bd, dolt).
-// Regression test for gc-4624: dolt pack orders never fired because
-// tryReloadConfig did not pass builtinPackIncludes to LoadWithIncludes.
+// config reload path sees orders from explicitly installed bundled defaults
+// (core, maintenance, bd, dolt).
 func TestTryReloadConfig_IncludesBuiltinPackOrders(t *testing.T) {
 	configureTestDoltIdentityEnv(t)
 	t.Setenv("GC_BEADS", "")
 
 	dir := shortSocketTempDir(t, "gc-reload-orders-")
 	tomlPath := filepath.Join(dir, "city.toml")
+	cfg := config.DefaultCity("test")
+	config.AddDefaultBuiltinImports(&cfg, true, false)
+	packCfg, _ := splitInitConfig("test", &cfg)
+	packData, err := marshalInitPackConfig(packCfg)
+	if err != nil {
+		t.Fatalf("marshal pack config: %v", err)
+	}
 	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test\"\nschema = 1\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), packData, 0o644); err != nil {
 		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	if err := installInitImportsIfNeeded(fsys.OSFS{}, dir); err != nil {
+		t.Fatalf("install bundled imports: %v", err)
 	}
 
 	result, err := tryReloadConfig(tomlPath, "test", dir)

--- a/cmd/gc/doctor_builtin_pack_registry.go
+++ b/cmd/gc/doctor_builtin_pack_registry.go
@@ -1,0 +1,310 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/builtinpacks"
+	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+type builtinPackRegistryMigrationCheck struct {
+	cityPath string
+}
+
+func newBuiltinPackRegistryMigrationCheck(cityPath string) *builtinPackRegistryMigrationCheck {
+	return &builtinPackRegistryMigrationCheck{cityPath: cityPath}
+}
+
+func (c *builtinPackRegistryMigrationCheck) Name() string { return "builtin-pack-registry" }
+
+func (c *builtinPackRegistryMigrationCheck) CanFix() bool { return true }
+
+func (c *builtinPackRegistryMigrationCheck) WarmupEligible() bool { return false }
+
+func (c *builtinPackRegistryMigrationCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	r := &doctor.CheckResult{Name: c.Name()}
+	issues, err := inspectBuiltinPackRegistryMigration(c.cityPath)
+	if err != nil {
+		r.Status = doctor.StatusError
+		r.Message = fmt.Sprintf("inspecting bundled pack imports: %v", err)
+		return r
+	}
+	if len(issues.legacyRefs) == 0 && len(issues.missingDefaults) == 0 {
+		r.Status = doctor.StatusOK
+		r.Message = "bundled pack imports use the pack registry"
+		return r
+	}
+	r.Status = doctor.StatusError
+	r.Message = "bundled pack imports need registry migration"
+	for _, detail := range issues.legacyRefs {
+		r.Details = append(r.Details, "legacy source: "+detail)
+	}
+	for _, name := range issues.missingDefaults {
+		r.Details = append(r.Details, "missing explicit default import: "+name)
+	}
+	r.FixHint = `run "gc doctor --fix" to rewrite .gc/system/packs sources and add missing bundled imports`
+	return r
+}
+
+func (c *builtinPackRegistryMigrationCheck) Fix(_ *doctor.CheckContext) error {
+	cityCfg, err := loadCityConfigForBuiltinPackMigration(c.cityPath)
+	if err != nil {
+		return err
+	}
+	packCfg, packExists, err := loadPackConfigForBuiltinPackMigration(c.cityPath)
+	if err != nil {
+		return err
+	}
+
+	rewriteImportSources(c.cityPath, packCfg.Imports)
+	rewriteImportSources(c.cityPath, packCfg.Defaults.Rig.Imports)
+	rewriteImportSources(c.cityPath, cityCfg.Imports)
+	for i := range cityCfg.Rigs {
+		rewriteImportSources(c.cityPath, cityCfg.Rigs[i].Imports)
+	}
+
+	present := bundledImportNames(cityCfg, packCfg)
+	includeGastown := present["gastown"]
+	required := requiredDefaultBuiltinImportNames(c.cityPath, cityCfg, includeGastown)
+	if packCfg.Imports == nil {
+		packCfg.Imports = make(map[string]config.Import)
+	}
+	for _, name := range required {
+		if present[name] {
+			continue
+		}
+		packCfg.Imports[name] = config.Import{Source: builtinpacks.MustSource(name)}
+		present[name] = true
+	}
+
+	if err := writeBuiltinMigrationCityConfig(c.cityPath, cityCfg); err != nil {
+		return err
+	}
+	if packExists || len(packCfg.Imports) > 0 || len(packCfg.Defaults.Rig.Imports) > 0 {
+		if err := writeBuiltinMigrationPackConfig(c.cityPath, packCfg); err != nil {
+			return err
+		}
+	}
+	return ensureBundledImportLockEntries(c.cityPath, collectBundledImportsForLock(cityCfg, packCfg))
+}
+
+type builtinPackRegistryIssues struct {
+	legacyRefs      []string
+	missingDefaults []string
+}
+
+func inspectBuiltinPackRegistryMigration(cityPath string) (builtinPackRegistryIssues, error) {
+	cityCfg, err := loadCityConfigForBuiltinPackMigration(cityPath)
+	if err != nil {
+		return builtinPackRegistryIssues{}, err
+	}
+	packCfg, _, err := loadPackConfigForBuiltinPackMigration(cityPath)
+	if err != nil {
+		return builtinPackRegistryIssues{}, err
+	}
+
+	var issues builtinPackRegistryIssues
+	issues.legacyRefs = append(issues.legacyRefs, legacyImportDetails(cityPath, "pack.toml imports", packCfg.Imports)...)
+	issues.legacyRefs = append(issues.legacyRefs, legacyImportDetails(cityPath, "pack.toml defaults.rig.imports", packCfg.Defaults.Rig.Imports)...)
+	issues.legacyRefs = append(issues.legacyRefs, legacyImportDetails(cityPath, "city.toml imports", cityCfg.Imports)...)
+	for _, rig := range cityCfg.Rigs {
+		label := fmt.Sprintf("city.toml rig %q imports", rig.Name)
+		issues.legacyRefs = append(issues.legacyRefs, legacyImportDetails(cityPath, label, rig.Imports)...)
+	}
+	sort.Strings(issues.legacyRefs)
+
+	present := bundledImportNames(cityCfg, packCfg)
+	required := requiredDefaultBuiltinImportNames(cityPath, cityCfg, present["gastown"])
+	for _, name := range required {
+		if !present[name] {
+			issues.missingDefaults = append(issues.missingDefaults, name)
+		}
+	}
+	sort.Strings(issues.missingDefaults)
+	return issues, nil
+}
+
+func loadCityConfigForBuiltinPackMigration(cityPath string) (*config.City, error) {
+	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func loadPackConfigForBuiltinPackMigration(cityPath string) (initPackConfig, bool, error) {
+	path := filepath.Join(cityPath, "pack.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return newInitPackConfig(filepath.Base(filepath.Clean(cityPath))), false, nil
+		}
+		return initPackConfig{}, false, fmt.Errorf("reading pack.toml: %w", err)
+	}
+	cfg := newInitPackConfig(filepath.Base(filepath.Clean(cityPath)))
+	if _, err := toml.Decode(string(data), &cfg); err != nil {
+		return initPackConfig{}, true, fmt.Errorf("parsing pack.toml: %w", err)
+	}
+	if cfg.Pack.Name == "" {
+		cfg.Pack.Name = filepath.Base(filepath.Clean(cityPath))
+	}
+	if cfg.Pack.Schema == 0 {
+		cfg.Pack.Schema = initPackSchemaVersion
+	}
+	return cfg, true, nil
+}
+
+func legacyImportDetails(cityPath, label string, imports map[string]config.Import) []string {
+	var details []string
+	for name, imp := range imports {
+		if packName, ok := legacySystemPackSourceName(cityPath, imp.Source); ok {
+			details = append(details, fmt.Sprintf("%s.%s %q -> %s", label, name, imp.Source, builtinpacks.MustSource(packName)))
+		}
+	}
+	return details
+}
+
+func rewriteImportSources(cityPath string, imports map[string]config.Import) {
+	for name, imp := range imports {
+		packName, ok := legacySystemPackSourceName(cityPath, imp.Source)
+		if !ok {
+			continue
+		}
+		imp.Source = builtinpacks.MustSource(packName)
+		imports[name] = imp
+	}
+}
+
+func bundledImportNames(cityCfg *config.City, packCfg initPackConfig) map[string]bool {
+	present := make(map[string]bool)
+	add := func(imports map[string]config.Import) {
+		for _, imp := range imports {
+			if name, ok := builtinpacks.NameForSource(imp.Source); ok {
+				present[name] = true
+			}
+			if name, ok := legacySystemPackSourceName("", imp.Source); ok {
+				present[name] = true
+			}
+		}
+	}
+	add(packCfg.Imports)
+	add(packCfg.Defaults.Rig.Imports)
+	if cityCfg != nil {
+		add(cityCfg.Imports)
+		for _, rig := range cityCfg.Rigs {
+			add(rig.Imports)
+		}
+	}
+	return present
+}
+
+func requiredDefaultBuiltinImportNames(cityPath string, cfg *config.City, includeGastown bool) []string {
+	var names []string
+	names = append(names, "core")
+	if initShouldIncludeBDImport(cityPath, cfg) {
+		names = append(names, "bd")
+	}
+	if includeGastown {
+		names = append(names, "gastown")
+		return names
+	}
+	names = append(names, "maintenance")
+	return names
+}
+
+func collectBundledImportsForLock(cityCfg *config.City, packCfg initPackConfig) map[string]config.Import {
+	out := make(map[string]config.Import)
+	add := func(imports map[string]config.Import) {
+		for name, imp := range imports {
+			if builtinpacks.IsSource(imp.Source) {
+				out[name] = imp
+			}
+		}
+	}
+	add(packCfg.Imports)
+	add(packCfg.Defaults.Rig.Imports)
+	if cityCfg != nil {
+		add(cityCfg.Imports)
+		for _, rig := range cityCfg.Rigs {
+			add(rig.Imports)
+		}
+	}
+	return out
+}
+
+func legacySystemPackSourceName(cityPath, source string) (string, bool) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "", false
+	}
+	if filepath.IsAbs(source) && cityPath != "" {
+		rel, err := filepath.Rel(cityPath, source)
+		if err == nil {
+			source = rel
+		}
+	}
+	clean := filepath.ToSlash(filepath.Clean(source))
+	clean = strings.TrimPrefix(clean, "./")
+	prefix := filepath.ToSlash(citylayout.SystemPacksRoot) + "/"
+	if !strings.HasPrefix(clean, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(clean, prefix)
+	name := strings.Split(rest, "/")[0]
+	if _, ok := builtinpacks.Source(name); !ok {
+		return "", false
+	}
+	return name, true
+}
+
+func writeBuiltinMigrationCityConfig(cityPath string, cfg *config.City) error {
+	data, err := cfg.Marshal()
+	if err != nil {
+		return err
+	}
+	return fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), data, 0o644)
+}
+
+func writeBuiltinMigrationPackConfig(cityPath string, cfg initPackConfig) error {
+	data, err := marshalInitPackConfig(cfg)
+	if err != nil {
+		return err
+	}
+	return fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, filepath.Join(cityPath, "pack.toml"), data, 0o644)
+}
+
+func ensureBundledImportLockEntries(cityPath string, imports map[string]config.Import) error {
+	if len(imports) == 0 {
+		return nil
+	}
+	lock, err := packman.ReadLockfile(fsys.OSFS{}, cityPath)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	for _, imp := range imports {
+		resolved, err := packman.ResolveVersion(imp.Source, imp.Version)
+		if err != nil {
+			return fmt.Errorf("resolving bundled import %s: %w", imp.Source, err)
+		}
+		if _, err := packman.EnsureRepoInCache(imp.Source, resolved.Commit); err != nil {
+			return fmt.Errorf("installing bundled import %s: %w", imp.Source, err)
+		}
+		lock.Packs[imp.Source] = packman.LockedPack{
+			Version: resolved.Version,
+			Commit:  resolved.Commit,
+			Fetched: now,
+		}
+	}
+	return packman.WriteLockfile(fsys.OSFS{}, cityPath, lock)
+}

--- a/cmd/gc/doctor_builtin_pack_registry_test.go
+++ b/cmd/gc/doctor_builtin_pack_registry_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/builtinpacks"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
+)
+
+func TestBuiltinPackRegistryMigrationCheckReportsLegacyAndMissingDefaults(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, `[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`)
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 2
+
+[imports.gastown]
+source = ".gc/system/packs/gastown"
+`)
+
+	result := newBuiltinPackRegistryMigrationCheck(cityDir).Run(&doctor.CheckContext{CityPath: cityDir})
+	if result.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error; result=%#v", result.Status, result)
+	}
+	joined := strings.Join(append([]string{result.Message}, result.Details...), "\n")
+	if !strings.Contains(joined, ".gc/system/packs/gastown") {
+		t.Fatalf("result missing legacy source detail: %#v", result)
+	}
+	if !strings.Contains(joined, "core") {
+		t.Fatalf("result missing core default detail: %#v", result)
+	}
+	if result.FixHint == "" || !newBuiltinPackRegistryMigrationCheck(cityDir).CanFix() {
+		t.Fatalf("result = %#v, want fix hint and fixable check", result)
+	}
+}
+
+func TestBuiltinPackRegistryMigrationCheckFixRewritesAndInstallsBundledImports(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cityDir := t.TempDir()
+	writeCityToml(t, cityDir, `[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+
+[imports.core]
+source = ".gc/system/packs/core"
+
+[[rigs]]
+name = "frontend"
+path = "../frontend"
+
+[rigs.imports.gastown]
+source = ".gc/system/packs/gastown"
+`)
+	writePackToml(t, cityDir, `[pack]
+name = "demo"
+schema = 2
+
+[imports.gastown]
+source = ".gc/system/packs/gastown"
+
+[defaults.rig.imports.gastown]
+source = ".gc/system/packs/gastown"
+`)
+
+	check := newBuiltinPackRegistryMigrationCheck(cityDir)
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	result := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status after fix = %v, want OK; result=%#v", result.Status, result)
+	}
+
+	var packCfg initPackConfig
+	packData, err := os.ReadFile(filepath.Join(cityDir, "pack.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := toml.Decode(string(packData), &packCfg); err != nil {
+		t.Fatalf("decode pack.toml: %v", err)
+	}
+	if got := packCfg.Imports["gastown"].Source; got != builtinpacks.MustSource("gastown") {
+		t.Fatalf("pack imports.gastown.source = %q", got)
+	}
+	if got := packCfg.Defaults.Rig.Imports["gastown"].Source; got != builtinpacks.MustSource("gastown") {
+		t.Fatalf("defaults.rig.imports.gastown.source = %q", got)
+	}
+
+	cityCfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("load city.toml: %v", err)
+	}
+	if got := cityCfg.Imports["core"].Source; got != builtinpacks.MustSource("core") {
+		t.Fatalf("city imports.core.source = %q", got)
+	}
+	if got := cityCfg.Rigs[0].Imports["gastown"].Source; got != builtinpacks.MustSource("gastown") {
+		t.Fatalf("rig imports.gastown.source = %q", got)
+	}
+
+	lock, err := packman.ReadLockfile(fsys.OSFS{}, cityDir)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	for _, source := range []string{builtinpacks.MustSource("core"), builtinpacks.MustSource("gastown")} {
+		entry, ok := lock.Packs[source]
+		if !ok || entry.Commit == "" {
+			t.Fatalf("lock missing %s: %#v", source, lock.Packs)
+		}
+		cacheDir, err := packman.RepoCachePath(source, entry.Commit)
+		if err != nil {
+			t.Fatalf("RepoCachePath: %v", err)
+		}
+		if err := builtinpacks.ValidateSyntheticRepo(cacheDir, entry.Commit); err != nil {
+			t.Fatalf("synthetic cache for %s: %v", source, err)
+		}
+	}
+}

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/builtinpacks"
@@ -22,28 +19,11 @@ const (
 	legacyOrderConfigFile = "order.toml"
 )
 
-// builtinPacks lists all packs embedded in the gc binary. These are
-// materialized to .gc/system/packs/ on every gc start and gc init.
+// builtinPacks lists all packs embedded in the gc binary. New city config
+// installs these through the pack registry; .gc/system/packs remains a
+// compatibility/materialized-assets location for legacy configs and managed
+// provider scripts.
 var builtinPacks = builtinpacks.All()
-
-var builtinPackRefreshCache sync.Map
-
-type builtinPackRefreshState struct {
-	mu          sync.Mutex
-	ready       bool
-	lastWarning string
-}
-
-type builtinPackRefreshResult struct {
-	ready   bool
-	warning error
-	fatal   error
-}
-
-type builtinPackFile struct {
-	data []byte
-	perm os.FileMode
-}
 
 // MaterializeBuiltinPacks writes all embedded pack files to
 // .gc/system/packs/{name}/ in the city directory. Files whose content and mode
@@ -80,17 +60,6 @@ func MaterializeBuiltinPacks(cityPath string) error {
 	return nil
 }
 
-func builtinPackIncludesForConfigLoad(fs fsys.FS, tomlPath string, warningWriter io.Writer) ([]string, error) {
-	if !usesOSFS(fs) {
-		return nil, nil
-	}
-	cityPath := filepath.Dir(tomlPath)
-	if err := ensureBuiltinPacksReadyForConfigLoad(cityPath, warningWriter); err != nil {
-		return nil, err
-	}
-	return builtinPackIncludes(cityPath), nil
-}
-
 func usesOSFS(fs fsys.FS) bool {
 	switch fs.(type) {
 	case fsys.OSFS, *fsys.OSFS:
@@ -98,125 +67,6 @@ func usesOSFS(fs fsys.FS) bool {
 	default:
 		return false
 	}
-}
-
-func ensureBuiltinPacksReadyForConfigLoad(cityPath string, warningWriter io.Writer) error {
-	key := normalizePathForCompare(cityPath)
-	stateAny, _ := builtinPackRefreshCache.LoadOrStore(key, &builtinPackRefreshState{})
-	state := stateAny.(*builtinPackRefreshState)
-	state.mu.Lock()
-	defer state.mu.Unlock()
-	if state.ready {
-		if len(unusableRequiredBuiltinPackNames(cityPath)) == 0 {
-			return nil
-		}
-		state.ready = false
-	}
-	result := materializeBuiltinPacksForConfigLoad(cityPath)
-	if result.fatal != nil {
-		state.lastWarning = ""
-		return result.fatal
-	}
-	if result.warning != nil {
-		const warningKey = "builtin-pack-refresh-incomplete"
-		if state.lastWarning != warningKey {
-			emitBuiltinPackRefreshWarning(warningWriter, result.warning)
-			state.lastWarning = warningKey
-		}
-		return nil
-	}
-	if result.ready {
-		state.ready = true
-		state.lastWarning = ""
-	}
-	return nil
-}
-
-func materializeBuiltinPacksForConfigLoad(cityPath string) builtinPackRefreshResult {
-	if err := MaterializeBuiltinPacks(cityPath); err != nil {
-		if missing := unusableRequiredBuiltinPackNames(cityPath); len(missing) > 0 {
-			return builtinPackRefreshResult{
-				fatal: fmt.Errorf("materializing builtin packs: required builtin packs remain unusable (%s): %w", strings.Join(missing, ", "), err),
-			}
-		}
-		return builtinPackRefreshResult{
-			warning: fmt.Errorf("builtin pack refresh incomplete; using existing materialized packs: %w", err),
-		}
-	}
-	return builtinPackRefreshResult{ready: true}
-}
-
-func unusableRequiredBuiltinPackNames(cityPath string) []string {
-	systemRoot := filepath.Join(cityPath, citylayout.SystemPacksRoot)
-	var missing []string
-	for _, name := range requiredBuiltinPackNames(cityPath) {
-		bp, ok := builtinPackByName(name)
-		if !ok || !packContainsEmbeddedState(bp.FS, filepath.Join(systemRoot, name)) {
-			missing = append(missing, name)
-		}
-	}
-	return missing
-}
-
-func builtinPackByName(name string) (builtinpacks.Pack, bool) {
-	for _, bp := range builtinPacks {
-		if bp.Name == name {
-			return bp, true
-		}
-	}
-	return builtinpacks.Pack{}, false
-}
-
-func packContainsEmbeddedState(embedded fs.FS, dstDir string) bool {
-	manifest, err := embeddedPackManifest(embedded)
-	if err != nil {
-		return false
-	}
-	return packContainsEmbeddedManifest(manifest, dstDir)
-}
-
-func packContainsEmbeddedManifest(manifest map[string]builtinPackFile, dstDir string) bool {
-	fi, err := os.Stat(dstDir)
-	if err != nil || !fi.IsDir() {
-		return false
-	}
-	for rel, want := range manifest {
-		dstPath := filepath.Join(dstDir, filepath.FromSlash(rel))
-		info, err := os.Lstat(dstPath)
-		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != want.perm {
-			return false
-		}
-		got, err := os.ReadFile(dstPath)
-		if err != nil || !bytes.Equal(got, want.data) {
-			return false
-		}
-	}
-	return true
-}
-
-func embeddedPackManifest(embedded fs.FS) (map[string]builtinPackFile, error) {
-	manifest := make(map[string]builtinPackFile)
-	err := fs.WalkDir(embedded, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		data, err := fs.ReadFile(embedded, path)
-		if err != nil {
-			return fmt.Errorf("reading embedded %s: %w", path, err)
-		}
-		manifest[filepath.ToSlash(path)] = builtinPackFile{
-			data: data,
-			perm: builtinpacks.MaterializedFileMode(path),
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return manifest, nil
 }
 
 // requiredBuiltinPackSet returns the set of builtin pack names that must stay
@@ -250,25 +100,10 @@ func requiredBuiltinPackNames(cityPath string) []string {
 	return required
 }
 
-func emitBuiltinPackRefreshWarning(w io.Writer, err error) {
-	if w == nil || err == nil {
-		return
-	}
-	fmt.Fprintf(w, "warning: %v\n", err) //nolint:errcheck // best-effort warning emission
-}
-
-// builtinPackIncludes returns the system pack paths that should be
-// auto-included in config loading. These are appended as extraIncludes
-// to LoadWithIncludes so they go through normal pack expansion
-// (ExpandCityPacks) with dedup/fallback resolution.
-//
-// Core and maintenance are always included. Core ships the role prompts
-// referenced by implicit agents and the overlay/per-provider hook files,
-// so its content must reach PackOverlayDirs even when the user has never
-// run `gc init` (and therefore has no implicit-import.toml written to
-// $GC_HOME). When the beads provider is "bd" (the default), include bd
-// and let its own pack includes pull in dolt transitively. Gastown is
-// never auto-included — it requires an explicit workspace.includes entry.
+// builtinPackIncludes returns the legacy compatibility include set for
+// materialized .gc/system/packs content. Normal config loading no longer
+// calls this helper; new and migrated cities use explicit bundled imports
+// resolved through packs.lock and the pack registry cache.
 func builtinPackIncludes(cityPath string) []string {
 	systemRoot := filepath.Join(cityPath, citylayout.SystemPacksRoot)
 

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -261,7 +260,7 @@ func TestBuiltinDoltDoctorAllowsAtMinimumVersionWhenProbeSucceeds(t *testing.T) 
 		name string
 		body string
 	}{
-		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 2.0.7\\n'\n"},
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.2\\n'\n"},
 		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
 		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
 	} {
@@ -277,7 +276,7 @@ func TestBuiltinDoltDoctorAllowsAtMinimumVersionWhenProbeSucceeds(t *testing.T) 
 	if err != nil {
 		t.Fatalf("check-dolt unexpectedly rejected Dolt probe at minimum: %v\n%s", err, out)
 	}
-	if !strings.Contains(string(out), "dolt available (dolt version 2.0.7)") {
+	if !strings.Contains(string(out), "dolt available (dolt version 1.86.2)") {
 		t.Fatalf("check-dolt output = %s, want successful version probe", out)
 	}
 }
@@ -302,7 +301,7 @@ func TestBuiltinDoltDoctorBoundsVersionProbe(t *testing.T) {
 			name: "gtimeout",
 			body: "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$TIMEOUT_CAPTURE\"\nif [ \"$1\" = \"--kill-after=2\" ]; then\n  shift\nfi\nshift\nexec \"$@\"\n",
 		},
-		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 2.0.10\\n'\n"},
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.10\\n'\n"},
 		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
 		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
 	} {
@@ -462,15 +461,6 @@ func TestMaterializeBuiltinPacksPiHookUsesCurrentExtensionAPI(t *testing.T) {
 	}
 }
 
-// TestMaterializeBuiltinPacksReplacesStaleMaterializedPiHook pins the
-// canonical-sync contract for required packs under Option B
-// (gastownhall/gascity#2429): the operator-edit-protection introduced for
-// that issue is scoped to non-required packs, so a stale correct-mode file in
-// the required core pack is refreshed to the embedded content rather than
-// preserved. This keeps required packs (core, maintenance, bd/dolt) in
-// lockstep with the binary while still protecting operator-authored formula
-// TOMLs and command scripts in non-required packs (covered by
-// TestMaterializeFS_PreservesExistingFiles).
 func TestMaterializeBuiltinPacksReplacesStaleMaterializedPiHook(t *testing.T) {
 	dir := t.TempDir()
 	hookPath := materializedPiHookPath(dir)
@@ -492,17 +482,12 @@ module.exports = {
 		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
 	}
 
-	// The Pi hook lives in the required core pack. Under Option B
-	// (gastownhall/gascity#2429) operator-edit preservation is scoped to
-	// non-required packs; required packs are kept in lockstep with the binary,
-	// so a stale correct-mode hook is refreshed to the embedded content rather
-	// than preserved.
 	data := readMaterializedPiHook(t, dir)
 	if data == string(stale) {
-		t.Fatalf("stale Pi hook in required core pack was preserved — required packs must be refreshed.\ngot:\n%s", data)
+		t.Fatal("stale materialized Pi hook was preserved; expected core pack materialization to repair it")
 	}
 	if !strings.Contains(data, `pi.on("session_start"`) {
-		t.Fatalf("refreshed Pi hook does not use current extension API:\n%s", data)
+		t.Fatalf("repaired materialized Pi hook does not use current extension API:\n%s", data)
 	}
 }
 
@@ -837,7 +822,7 @@ func TestMaterializeBuiltinPacks_PruneIgnoresAtomicTempFilesForDesiredAssets(t *
 	}
 }
 
-func TestLoadCityConfigMaterializesBuiltinPacks(t *testing.T) {
+func TestLoadCityConfigDoesNotMaterializeBuiltinPacks(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
 		t.Fatal(err)
@@ -847,37 +832,27 @@ func TestLoadCityConfigMaterializesBuiltinPacks(t *testing.T) {
 		t.Fatalf("loadCityConfig() error: %v", err)
 	}
 
-	for _, path := range []string{
-		filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml"),
-		filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact", "run.sh"),
-	} {
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("builtin pack file missing after loadCityConfig: %v", err)
-		}
+	if _, err := os.Stat(filepath.Join(dir, citylayout.SystemPacksRoot)); !os.IsNotExist(err) {
+		t.Fatalf("loadCityConfig materialized hidden builtin packs: %v", err)
 	}
 }
 
-func TestLoadCityConfigForRegistryMaterializesBuiltinPacks(t *testing.T) {
+func TestLoadCityConfigSuppressDeprecatedOrderWarningsDoesNotMaterializeBuiltinPacks(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := loadCityConfig(dir, io.Discard); err != nil {
-		t.Fatalf("loadCityConfig() error: %v", err)
+	if _, err := loadCityConfigSuppressDeprecatedOrderWarnings(dir); err != nil {
+		t.Fatalf("loadCityConfigSuppressDeprecatedOrderWarnings() error: %v", err)
 	}
 
-	for _, path := range []string{
-		filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml"),
-		filepath.Join(dir, citylayout.SystemPacksRoot, "bd", "pack.toml"),
-	} {
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("builtin pack file missing after suppress-warnings load: %v", err)
-		}
+	if _, err := os.Stat(filepath.Join(dir, citylayout.SystemPacksRoot)); !os.IsNotExist(err) {
+		t.Fatalf("suppress-warnings load materialized hidden builtin packs: %v", err)
 	}
 }
 
-func TestLoadCityConfigFSMaterializesBuiltinPacksForOSFS(t *testing.T) {
+func TestLoadCityConfigFSDoesNotMaterializeBuiltinPacksForOSFS(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
 		t.Fatal(err)
@@ -887,13 +862,8 @@ func TestLoadCityConfigFSMaterializesBuiltinPacksForOSFS(t *testing.T) {
 		t.Fatalf("loadCityConfigFS(OSFS) error: %v", err)
 	}
 
-	for _, path := range []string{
-		filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml"),
-		filepath.Join(dir, citylayout.SystemPacksRoot, "bd", "pack.toml"),
-	} {
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("builtin pack file missing after loadCityConfigFS(OSFS): %v", err)
-		}
+	if _, err := os.Stat(filepath.Join(dir, citylayout.SystemPacksRoot)); !os.IsNotExist(err) {
+		t.Fatalf("loadCityConfigFS materialized hidden builtin packs: %v", err)
 	}
 }
 
@@ -915,306 +885,35 @@ func TestLoadCityConfigWithoutBuiltinPackRefreshFSDoesNotMaterializeBuiltinPacks
 	}
 }
 
-func TestLoadCityConfigFallsBackToExistingBuiltinPacksWhenRefreshFails(t *testing.T) {
+func TestLoadCityConfigLeavesExistingSystemPacksUntouched(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
 		t.Fatal(err)
 	}
 	if err := MaterializeBuiltinPacks(dir); err != nil {
 		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
-	}
-
-	// dolt is a non-required pack, so a failed refresh is non-fatal:
-	// loadCityConfig falls back to the existing materialized packs and emits a
-	// warning. Under Option B (gastownhall/gascity#2429) a correct-mode edited
-	// file is preserved with no write attempt, so the refresh failure is driven
-	// by a missing file the materializer must rewrite (scaffolding) while the
-	// directory is read-only.
-	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact")
-	targetFile := filepath.Join(targetDir, "run.sh")
-	wantContent, err := os.ReadFile(targetFile)
-	if err != nil {
-		t.Fatalf("ReadFile(initial run.sh): %v", err)
-	}
-	if err := os.Remove(targetFile); err != nil {
-		t.Fatalf("Remove(run.sh): %v", err)
-	}
-	if err := os.Chmod(targetDir, 0o555); err != nil {
-		t.Fatalf("Chmod(%s): %v", targetDir, err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chmod(targetDir, 0o755)
-	})
-
-	var stderr bytes.Buffer
-	if _, err := loadCityConfig(dir, &stderr); err != nil {
-		t.Fatalf("loadCityConfig() fallback error: %v", err)
-	}
-	if !strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
-		t.Fatalf("expected suppressed refresh warning, got %q", stderr.String())
-	}
-
-	if _, err := os.Stat(targetFile); !os.IsNotExist(err) {
-		t.Fatalf("run.sh should remain missing during read-only fallback; stat err=%v", err)
-	}
-
-	if err := os.Chmod(targetDir, 0o755); err != nil {
-		t.Fatalf("Chmod(%s): %v", targetDir, err)
-	}
-	stderr.Reset()
-	if _, err := loadCityConfig(dir, &stderr); err != nil {
-		t.Fatalf("loadCityConfig() retry error: %v", err)
-	}
-	got, err := os.ReadFile(targetFile)
-	if err != nil {
-		t.Fatalf("ReadFile(run.sh) after retry: %v", err)
-	}
-	if !bytes.Equal(got, wantContent) {
-		t.Fatalf("run.sh did not refresh after retry; got %q", got)
-	}
-	if strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
-		t.Fatalf("unexpected refresh warning after retry: %q", stderr.String())
-	}
-}
-
-func TestLoadCityConfigDeduplicatesBuiltinPackRefreshWarningsPerProcess(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
-		t.Fatal(err)
-	}
-	if err := MaterializeBuiltinPacks(dir); err != nil {
-		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
-	}
-
-	// Missing non-required file forces a scaffolding write that fails while the
-	// directory is read-only (see Option B note in
-	// TestLoadCityConfigFallsBackToExistingBuiltinPacksWhenRefreshFails).
-	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact")
-	targetFile := filepath.Join(targetDir, "run.sh")
-	if err := os.Remove(targetFile); err != nil {
-		t.Fatalf("Remove(run.sh): %v", err)
-	}
-	if err := os.Chmod(targetDir, 0o555); err != nil {
-		t.Fatalf("Chmod(%s): %v", targetDir, err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chmod(targetDir, 0o755)
-	})
-
-	var stderr bytes.Buffer
-	for i := 0; i < 2; i++ {
-		if _, err := loadCityConfig(dir, &stderr); err != nil {
-			t.Fatalf("loadCityConfig() fallback attempt %d error: %v", i+1, err)
-		}
-	}
-
-	if got := strings.Count(stderr.String(), "builtin pack refresh incomplete"); got != 1 {
-		t.Fatalf("warning count = %d, want 1; stderr=%q", got, stderr.String())
-	}
-}
-
-func TestLoadCityConfigForRegistryDoesNotSuppressBuiltinPackRefreshWarnings(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
-		t.Fatal(err)
-	}
-	if err := MaterializeBuiltinPacks(dir); err != nil {
-		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
-	}
-
-	// Missing non-required file forces a scaffolding write that fails while the
-	// directory is read-only (see Option B note in
-	// TestLoadCityConfigFallsBackToExistingBuiltinPacksWhenRefreshFails).
-	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact")
-	targetFile := filepath.Join(targetDir, "run.sh")
-	if err := os.Remove(targetFile); err != nil {
-		t.Fatalf("Remove(run.sh): %v", err)
-	}
-	if err := os.Chmod(targetDir, 0o555); err != nil {
-		t.Fatalf("Chmod(%s): %v", targetDir, err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chmod(targetDir, 0o755)
-	})
-
-	origDefaultWarningWriter := loadCityConfigDefaultWarningWriter
-	var stderr bytes.Buffer
-	loadCityConfigDefaultWarningWriter = func() io.Writer { return &stderr }
-	t.Cleanup(func() {
-		loadCityConfigDefaultWarningWriter = origDefaultWarningWriter
-	})
-
-	if _, err := loadCityConfig(dir); err != nil {
-		t.Fatalf("loadCityConfig() fallback error: %v", err)
-	}
-	if !strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
-		t.Fatalf("expected builtin pack refresh warning, got %q", stderr.String())
-	}
-}
-
-func TestLoadCityConfigFailsWhenRequiredBuiltinPackRefreshFails(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
-		t.Fatal(err)
-	}
-	if err := MaterializeBuiltinPacks(dir); err != nil {
-		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
-	}
-
-	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "bd")
-	targetFile := filepath.Join(targetDir, "pack.toml")
-	if err := os.Remove(targetFile); err != nil {
-		t.Fatalf("Remove(%s): %v", targetFile, err)
-	}
-	if err := os.Chmod(targetDir, 0o555); err != nil {
-		t.Fatalf("Chmod(%s): %v", targetDir, err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chmod(targetDir, 0o755)
-	})
-
-	if _, err := loadCityConfig(dir); err == nil {
-		t.Fatal("loadCityConfig() error = nil, want required builtin pack refresh failure")
-	} else if !strings.Contains(err.Error(), "materializing builtin packs") {
-		t.Fatalf("loadCityConfig() error = %v, want materialization failure", err)
-	}
-}
-
-func TestLoadCityConfigFailsWhenRequiredBuiltinPackRemainsPartiallyMaterialized(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
-		t.Fatal(err)
-	}
-	if err := MaterializeBuiltinPacks(dir); err != nil {
-		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
-	}
-
-	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "assets", "prompts")
-	targetFile := filepath.Join(targetDir, "pool-worker.md")
-	if err := os.Remove(targetFile); err != nil {
-		t.Fatalf("Remove(%s): %v", targetFile, err)
-	}
-	if err := os.Chmod(targetDir, 0o555); err != nil {
-		t.Fatalf("Chmod(%s): %v", targetDir, err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chmod(targetDir, 0o755)
-	})
-
-	if _, err := loadCityConfig(dir); err == nil {
-		t.Fatal("loadCityConfig() error = nil, want partial required builtin pack failure")
-	} else if !strings.Contains(err.Error(), "required builtin packs remain unusable (core)") {
-		t.Fatalf("loadCityConfig() error = %v, want unusable core pack failure", err)
-	}
-}
-
-func TestLoadCityConfigFailsWhenRequiredBuiltinPackRefreshLeavesStaleContent(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
-		t.Fatal(err)
-	}
-	if err := MaterializeBuiltinPacks(dir); err != nil {
-		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
-	}
-
-	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "assets", "prompts")
-	targetFile := filepath.Join(targetDir, "pool-worker.md")
-	if err := os.WriteFile(targetFile, []byte("stale core prompt\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(%s): %v", targetFile, err)
-	}
-	if err := os.Chmod(targetDir, 0o555); err != nil {
-		t.Fatalf("Chmod(%s): %v", targetDir, err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chmod(targetDir, 0o755)
-	})
-
-	if _, err := loadCityConfig(dir); err == nil {
-		t.Fatal("loadCityConfig() error = nil, want stale required builtin pack failure")
-	} else if !strings.Contains(err.Error(), "required builtin packs remain unusable (core)") {
-		t.Fatalf("loadCityConfig() error = %v, want unusable core pack failure", err)
-	}
-}
-
-func TestLoadCityConfigFallsBackWhenRequiredBuiltinPackHasOnlyExtraStaleFiles(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
-		t.Fatal(err)
-	}
-	if err := MaterializeBuiltinPacks(dir); err != nil {
-		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
-	}
-
-	staleDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "stale")
-	if err := os.MkdirAll(staleDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(%s): %v", staleDir, err)
-	}
-	staleFile := filepath.Join(staleDir, "leftover.txt")
-	if err := os.WriteFile(staleFile, []byte("obsolete\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(%s): %v", staleFile, err)
-	}
-	if err := os.Chmod(staleDir, 0o555); err != nil {
-		t.Fatalf("Chmod(%s): %v", staleDir, err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chmod(staleDir, 0o755)
-	})
-
-	var stderr bytes.Buffer
-	if _, err := loadCityConfig(dir, &stderr); err != nil {
-		t.Fatalf("loadCityConfig() fallback error = %v, want warning-only fallback", err)
-	}
-	if !strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
-		t.Fatalf("expected builtin pack refresh warning, got %q", stderr.String())
-	}
-	if _, err := os.Stat(staleFile); err != nil {
-		t.Fatalf("expected extra stale file to remain after fallback, got stat error %v", err)
-	}
-}
-
-func TestLoadCityConfigRevalidatesRequiredBuiltinPacksAfterReadyCacheSuccess(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := loadCityConfig(dir); err != nil {
-		t.Fatalf("loadCityConfig() initial error: %v", err)
-	}
-
-	targetFile := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml")
-	if err := os.Remove(targetFile); err != nil {
-		t.Fatalf("Remove(%s): %v", targetFile, err)
-	}
-
-	if _, err := loadCityConfig(dir); err != nil {
-		t.Fatalf("loadCityConfig() repair error: %v", err)
-	}
-	if _, err := os.Stat(targetFile); err != nil {
-		t.Fatalf("required pack file missing after ready-cache revalidation: %v", err)
-	}
-}
-
-func TestLoadCityConfigRevalidatesRequiredBuiltinPackContentsAfterReadyCacheSuccess(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := loadCityConfig(dir); err != nil {
-		t.Fatalf("loadCityConfig() initial error: %v", err)
 	}
 
 	targetFile := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "assets", "prompts", "pool-worker.md")
-	if err := os.Remove(targetFile); err != nil {
-		t.Fatalf("Remove(%s): %v", targetFile, err)
+	staleContent := []byte("stale core prompt\n")
+	if err := os.WriteFile(targetFile, staleContent, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", targetFile, err)
 	}
 
-	if _, err := loadCityConfig(dir); err != nil {
-		t.Fatalf("loadCityConfig() repair error: %v", err)
+	var stderr bytes.Buffer
+	if _, err := loadCityConfig(dir, &stderr); err != nil {
+		t.Fatalf("loadCityConfig() error: %v", err)
 	}
-	if _, err := os.Stat(targetFile); err != nil {
-		t.Fatalf("required builtin asset missing after ready-cache content revalidation: %v", err)
+	if strings.Contains(stderr.String(), "builtin pack refresh") {
+		t.Fatalf("unexpected builtin pack refresh warning: %q", stderr.String())
+	}
+
+	got, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", targetFile, err)
+	}
+	if !bytes.Equal(got, staleContent) {
+		t.Fatalf("system pack content changed during config load: %q", got)
 	}
 }
 
@@ -1319,8 +1018,8 @@ func TestBuiltinPackIncludes_NonBdProvider(t *testing.T) {
 	t.Setenv("GC_BEADS", "")
 	includes := builtinPackIncludes(dir)
 
-	// Core and maintenance are always auto-included; bd/dolt are gated
-	// on a bd-compatible provider.
+	// Core and maintenance remain in the legacy compatibility include set;
+	// bd/dolt are gated on a bd-compatible provider.
 	if len(includes) != 2 {
 		t.Fatalf("builtinPackIncludes() = %v, want 2 entries (core + maintenance)", includes)
 	}
@@ -1342,8 +1041,8 @@ func TestBuiltinPackIncludes_ExecGcBeadsBdOverrideIncludesBdAndDolt(t *testing.T
 
 	t.Setenv("GC_BEADS", "exec:/tmp/gc-beads-bd")
 	includes := builtinPackIncludes(dir)
-	// core + maintenance + bd + dolt = 4 entries. Core and maintenance are
-	// always auto-included; bd and dolt arrive via the exec-override path.
+	// core + maintenance + bd + dolt = 4 compatibility entries. Core and
+	// maintenance are always present; bd and dolt arrive via the exec override.
 	if len(includes) != 4 {
 		t.Fatalf("builtinPackIncludes() = %v, want 4 entries when GC_BEADS=exec:gc-beads-bd", includes)
 	}
@@ -1369,8 +1068,8 @@ func TestBuiltinPackIncludes_EnvOverride(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	includes := builtinPackIncludes(dir)
 
-	// Core and maintenance are always auto-included; bd/dolt are gated on
-	// a bd-compatible provider.
+	// Core and maintenance remain in the legacy compatibility include set;
+	// bd/dolt are gated on a bd-compatible provider.
 	if len(includes) != 2 {
 		t.Fatalf("builtinPackIncludes() = %v, want 2 entries when GC_BEADS=file", includes)
 	}
@@ -1485,14 +1184,6 @@ func TestBuiltinPackIncludes_AlwaysIncludesMaintenance(t *testing.T) {
 	}
 }
 
-// TestMaterializeFS_PreservesExistingFiles asserts that an existing on-disk
-// file is not overwritten by a subsequent materialize call. This is the
-// regression guard for gastownhall/gascity#2429 — `gc bd …` subcommands
-// were silently reverting operator-edited pack files via materializeFS's
-// blind overwrite on every invocation.
-//
-// Without the fix, the second materializeFS call rewrites b.txt back to
-// the embedded "embedded-b" bytes and the assertion fails.
 func TestMaterializeFS_PreservesExistingFiles(t *testing.T) {
 	dst := t.TempDir()
 	embedded := fstest.MapFS{
@@ -1501,7 +1192,6 @@ func TestMaterializeFS_PreservesExistingFiles(t *testing.T) {
 		"sub/c.txt": {Data: []byte("embedded-c"), Mode: 0o644},
 	}
 
-	// Initial materialize: writes all three files since dst is empty.
 	desired, err := materializeFS(embedded, dst, true)
 	if err != nil {
 		t.Fatalf("first materializeFS: %v", err)
@@ -1520,13 +1210,11 @@ func TestMaterializeFS_PreservesExistingFiles(t *testing.T) {
 		}
 	}
 
-	// Operator edits b.txt — the data-loss scenario in the bug report.
-	const operatorBytes = "OPERATOR EDIT — must survive next materializeFS"
+	const operatorBytes = "OPERATOR EDIT - must survive next materializeFS"
 	if err := os.WriteFile(filepath.Join(dst, "b.txt"), []byte(operatorBytes), 0o644); err != nil {
 		t.Fatalf("operator edit: %v", err)
 	}
 
-	// Second materialize: should NOT overwrite the operator's edit.
 	if _, err := materializeFS(embedded, dst, true); err != nil {
 		t.Fatalf("second materializeFS: %v", err)
 	}
@@ -1538,7 +1226,6 @@ func TestMaterializeFS_PreservesExistingFiles(t *testing.T) {
 		t.Fatalf("operator edit lost: got %q, want %q", got, operatorBytes)
 	}
 
-	// Unchanged files (a.txt, sub/c.txt) remain present and intact.
 	for _, want := range []string{"a.txt", "sub/c.txt"} {
 		got, err := os.ReadFile(filepath.Join(dst, filepath.FromSlash(want)))
 		if err != nil {
@@ -1550,9 +1237,6 @@ func TestMaterializeFS_PreservesExistingFiles(t *testing.T) {
 		}
 	}
 
-	// Delete the operator-edited file; the next materialize should rewrite
-	// the embedded content (initial-scaffolding semantics still apply when
-	// a file is missing).
 	if err := os.Remove(filepath.Join(dst, "b.txt")); err != nil {
 		t.Fatalf("remove b.txt: %v", err)
 	}

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -73,6 +73,12 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 		fmt.Fprintf(stderr, "%s: fetching packs: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if _, rawErr := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); rawErr == nil {
+		if err := installInitImportsIfNeeded(fsys.OSFS{}, cityPath); err != nil {
+			fmt.Fprintf(stderr, "%s: installing imports: %v\n", opts.commandName, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	}
 	if !opts.skipProviderReadiness {
 		if err := runInitProviderPreflight(cityPath, stdout, stderr, opts.commandName); err != nil {
 			return 1

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/builtinpacks"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
@@ -243,14 +244,19 @@ func newTestscriptParams(t *testing.T, files ...string) testscript.Params {
 		Dir:         "testdata",
 		WorkdirRoot: shortSocketTempDir(t, "gc-testscript-"),
 		Setup: func(env *testscript.Env) error {
+			home := filepath.Join(env.WorkDir, "home")
 			gcHome := filepath.Join(env.WorkDir, ".gc-home")
 			runtimeDir := filepath.Join(env.WorkDir, ".runtime")
+			if err := os.MkdirAll(home, 0o755); err != nil {
+				return err
+			}
 			if err := os.MkdirAll(gcHome, 0o755); err != nil {
 				return err
 			}
 			if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
 				return err
 			}
+			env.Setenv("HOME", home)
 			env.Setenv("GC_HOME", gcHome)
 			env.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 			return nil
@@ -2615,6 +2621,19 @@ func mapKeys(m map[string]TemplateParams) []string {
 
 // --- gc init (doInit with fsys.Fake) ---
 
+func loadFakeInitPackConfig(t *testing.T, f *fsys.Fake, cityPath string) initPackConfig {
+	t.Helper()
+	data, ok := f.Files[filepath.Join(cityPath, "pack.toml")]
+	if !ok {
+		t.Fatalf("%s/pack.toml not written", cityPath)
+	}
+	var cfg initPackConfig
+	if _, err := toml.Decode(string(data), &cfg); err != nil {
+		t.Fatalf("parsing %s/pack.toml: %v", cityPath, err)
+	}
+	return cfg
+}
+
 func TestDoInitSuccess(t *testing.T) {
 	f := fsys.NewFake()
 	// No pre-existing files — doInit creates everything from scratch.
@@ -2685,26 +2704,23 @@ func TestDoInitSuccess(t *testing.T) {
 		t.Errorf("fresh init should not emit inline [[agent]] entries into pack.toml:\n%s", packToml)
 	}
 
-	// Verify the composed config loads correctly from pack.toml + city.toml.
-	// The mayor comes from the scaffolded agents/<name>/ tree, while the
-	// named session still lives in pack.toml. workspace name lives in
-	// .gc/site.toml as the machine-local binding.
-	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
+	// Verify the pack-first scaffold directly. Remote bundled imports are
+	// installed through the OS-backed pack registry, so fake-FS init tests
+	// assert the written pack and site-binding artifacts without expanding
+	// those imports.
+	site, err := config.LoadSiteBinding(f, "/bright-lights")
 	if err != nil {
-		t.Fatalf("loading written config: %v", err)
+		t.Fatalf("loading site binding: %v", err)
 	}
-	if cfg.ResolvedWorkspaceName != "bright-lights" {
-		t.Errorf("ResolvedWorkspaceName = %q, want %q", cfg.ResolvedWorkspaceName, "bright-lights")
+	if site.WorkspaceName != "bright-lights" {
+		t.Errorf("site.WorkspaceName = %q, want %q", site.WorkspaceName, "bright-lights")
 	}
-	explicit := explicitAgents(cfg.Agents)
-	if len(explicit) != 1 {
-		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicit))
+	packCfg := loadFakeInitPackConfig(t, f, "/bright-lights")
+	if len(packCfg.Agents) != 0 {
+		t.Fatalf("len(packCfg.Agents) = %d, want 0 for convention-scaffolded init", len(packCfg.Agents))
 	}
-	if explicit[0].Name != "mayor" {
-		t.Errorf("explicitAgents[0].Name = %q, want %q", explicit[0].Name, "mayor")
-	}
-	if !strings.HasSuffix(explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
-		t.Errorf("explicitAgents[0].PromptTemplate = %q, want suffix %q", explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
+	if len(packCfg.NamedSessions) != 1 || packCfg.NamedSessions[0].Template != "mayor" {
+		t.Fatalf("NamedSessions = %v, want mayor named session", packCfg.NamedSessions)
 	}
 	if _, ok := f.Files[filepath.Join("/bright-lights", "formulas", "mol-scoped-work.toml")]; ok {
 		t.Fatal("doInit should not seed builtin formulas into city-local formulas/")
@@ -2736,6 +2752,14 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 name = "bright-lights"
 schema = 2
 
+[imports]
+[imports.bd]
+source = "https://github.com/gastownhall/gascity.git//examples/bd"
+[imports.core]
+source = "https://github.com/gastownhall/gascity.git//internal/bootstrap/packs/core"
+[imports.maintenance]
+source = "https://github.com/gastownhall/gascity.git//examples/gastown/packs/maintenance"
+
 [[named_session]]
 template = "mayor"
 mode = "always"
@@ -2763,7 +2787,7 @@ func TestDoInitGastownWritesCanonicalPackV2Shape(t *testing.T) {
 	}
 
 	packToml := string(f.Files[filepath.Join("/bright-lights", "pack.toml")])
-	if !strings.Contains(packToml, "[imports.gastown]") || !strings.Contains(packToml, `source = ".gc/system/packs/gastown"`) {
+	if !strings.Contains(packToml, "[imports.gastown]") || !strings.Contains(packToml, `source = "`+builtinpacks.MustSource("gastown")+`"`) {
 		t.Fatalf("pack.toml missing gastown import:\n%s", packToml)
 	}
 	if strings.Contains(packToml, `append_fragments = ["command-glossary", "operational-awareness"]`) {
@@ -3266,8 +3290,7 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 	}
 
 	// Verify written raw city.toml keeps the provider (runtime-local) and
-	// the composed config (city.toml + pack.toml) still surfaces the mayor
-	// agent from the scaffolded agents/<name>/ tree.
+	// init still writes the convention-discoverable mayor prompt scaffold.
 	data := f.Files[filepath.Join("/bright-lights", "city.toml")]
 	raw, err := config.Parse(data)
 	if err != nil {
@@ -3276,19 +3299,8 @@ func TestDoInitWithWizardConfig(t *testing.T) {
 	if raw.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", raw.Workspace.Provider, "claude")
 	}
-	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
-	if err != nil {
-		t.Fatalf("loading written config: %v", err)
-	}
-	explicit := explicitAgents(cfg.Agents)
-	if len(explicit) != 1 {
-		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicit))
-	}
-	if explicit[0].Name != "mayor" {
-		t.Errorf("explicitAgents[0].Name = %q, want %q", explicit[0].Name, "mayor")
-	}
-	if !strings.HasSuffix(explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
-		t.Errorf("explicitAgents[0].PromptTemplate = %q, want suffix %q", explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
+	if _, ok := f.Files[filepath.Join("/bright-lights", "agents", "mayor", "prompt.template.md")]; !ok {
+		t.Fatal("agents/mayor/prompt.template.md not written")
 	}
 	// Verify provider appears in TOML.
 	if !strings.Contains(string(data), `provider = "claude"`) {
@@ -3310,9 +3322,8 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 		t.Fatalf("doInit = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	// Verify raw city.toml carries start_command and no provider; the
-	// composed config then surfaces the mayor agent from convention
-	// discovery.
+	// Verify raw city.toml carries start_command and no provider; init still
+	// writes the convention-discoverable mayor prompt scaffold.
 	data := f.Files[filepath.Join("/bright-lights", "city.toml")]
 	raw, err := config.Parse(data)
 	if err != nil {
@@ -3324,12 +3335,8 @@ func TestDoInitWithCustomCommand(t *testing.T) {
 	if raw.Workspace.Provider != "" {
 		t.Errorf("Workspace.Provider = %q, want empty", raw.Workspace.Provider)
 	}
-	cfg, err := loadCityConfigFS(f, filepath.Join("/bright-lights", "city.toml"))
-	if err != nil {
-		t.Fatalf("loading written config: %v", err)
-	}
-	if len(explicitAgents(cfg.Agents)) != 1 {
-		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicitAgents(cfg.Agents)))
+	if _, ok := f.Files[filepath.Join("/bright-lights", "agents", "mayor", "prompt.template.md")]; !ok {
+		t.Fatal("agents/mayor/prompt.template.md not written")
 	}
 }
 
@@ -3406,16 +3413,8 @@ func TestDoInitWithCustomTemplate(t *testing.T) {
 	if raw.Workspace.Provider != "" {
 		t.Errorf("Workspace.Provider = %q, want empty", raw.Workspace.Provider)
 	}
-	cfg, err := loadCityConfigFS(f, filepath.Join("/my-city", "city.toml"))
-	if err != nil {
-		t.Fatalf("loading written config: %v", err)
-	}
-	explicit := explicitAgents(cfg.Agents)
-	if len(explicit) != 1 {
-		t.Fatalf("len(explicitAgents) = %d, want 1", len(explicit))
-	}
-	if explicit[0].Name != "mayor" {
-		t.Errorf("explicitAgents[0].Name = %q, want %q", explicit[0].Name, "mayor")
+	if _, ok := f.Files[filepath.Join("/my-city", "agents", "mayor", "prompt.template.md")]; !ok {
+		t.Fatal("agents/mayor/prompt.template.md not written")
 	}
 }
 
@@ -3664,7 +3663,7 @@ scale_check = "echo 3"
 	if !strings.HasSuffix(mayor.PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
 		t.Errorf("mayor.PromptTemplate = %q, want suffix %q", mayor.PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
 	}
-	if !strings.HasSuffix(dog.PromptTemplate, filepath.Join(".gc", "system", "packs", "maintenance", "agents", "dog", "prompt.template.md")) {
+	if !strings.HasSuffix(dog.PromptTemplate, filepath.Join("examples", "gastown", "packs", "maintenance", "agents", "dog", "prompt.template.md")) {
 		t.Errorf("dog.PromptTemplate = %q, want maintenance dog prompt", dog.PromptTemplate)
 	}
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1077,9 +1077,7 @@ source = "`+doltDir+`"
 		"mol-dog-backup":     "$PACK_DIR/assets/scripts/mol-dog-backup.sh",
 		"mol-dog-compactor":  "gc dolt compact",
 		"mol-dog-doctor":     "$PACK_DIR/assets/scripts/mol-dog-doctor.sh",
-		"mol-dog-jsonl":      "$PACK_DIR/assets/scripts/jsonl-export.sh",
 		"mol-dog-phantom-db": "$PACK_DIR/assets/scripts/mol-dog-phantom-db.sh",
-		"mol-dog-reaper":     "$PACK_DIR/assets/scripts/reaper.sh",
 	}
 	gotExecDogOrders := map[string]bool{}
 	const wantFormulaDogOrders = 1
@@ -1126,8 +1124,8 @@ source = "`+doltDir+`"
 		if err != nil {
 			t.Fatalf("qualifyOrderPool(%s): %v", a.Name, err)
 		}
-		if got != "dog" {
-			t.Fatalf("qualifyOrderPool(%s) = %q, want local maintenance dog", a.Name, got)
+		if got != "ops.dog" {
+			t.Fatalf("qualifyOrderPool(%s) = %q, want imported maintenance dog", a.Name, got)
 		}
 	}
 	if gotFormulaDogOrders != wantFormulaDogOrders {

--- a/cmd/gc/testdata/pack-v2-imports.txtar
+++ b/cmd/gc/testdata/pack-v2-imports.txtar
@@ -10,6 +10,9 @@ env GC_BEADS=file
 env GC_DOLT=skip
 env GC_SESSION=fake
 
+mkdir $WORK/home
+env HOME=$WORK/home
+
 cd $WORK/city
 
 chmod 755 $WORK/city/assets/ops/commands/status/run.sh

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1561,8 +1561,9 @@ Create a new Gas City workspace in the given directory (or cwd).
 Runs an interactive wizard to choose a config template and coding agent
 provider. Creates the .gc/ runtime directory plus pack.toml, city.toml,
 the standard top-level directories, and .template.md prompt templates, then
-materializes builtin packs under .gc/system/packs. Use --provider to create the default minimal city
-non-interactively, or --file to initialize from an existing TOML config file.
+records bundled default packs as explicit pack registry imports. Use --provider
+to create the default minimal city non-interactively, or --file to initialize
+from an existing TOML config file.
 
 Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
 agent prompt files in the target directory (useful when bootstrapping a

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,5 +1,6 @@
 // Package bootstrap reconciles legacy user-global implicit-import state for
-// compatibility tooling. Launch-time system packs now come from .gc/system/packs.
+// compatibility tooling. Launch-time bundled packs now come from explicit pack
+// registry imports.
 package bootstrap
 
 import (
@@ -33,9 +34,9 @@ type Entry struct {
 }
 
 // BootstrapPacks is the currently-supported compatibility set. It is empty for
-// the gc import launch path: cities rely on .gc/system/packs and explicit
-// [imports], not user-global implicit imports. Tests may override this list to
-// exercise the compatibility materialization path.
+// the gc import launch path: cities rely on explicit [imports], not
+// user-global implicit imports. Tests may override this list to exercise the
+// compatibility materialization path.
 var BootstrapPacks []Entry
 
 // RetiredBootstrapPacks are legacy implicit imports that older gc releases

--- a/internal/builtinpacks/metadata.go
+++ b/internal/builtinpacks/metadata.go
@@ -1,0 +1,91 @@
+package builtinpacks
+
+import (
+	"fmt"
+	"regexp"
+	"runtime/debug"
+	"strings"
+)
+
+var goPseudoVersionSuffixes = []*regexp.Regexp{
+	regexp.MustCompile(`^(.*)\.0\.\d{14}-[0-9a-f]{12,}$`),
+	regexp.MustCompile(`^(.*)-0\.\d{14}-[0-9a-f]{12,}$`),
+	regexp.MustCompile(`^(.*)-\d{14}-[0-9a-f]{12,}$`),
+}
+
+// CurrentResolution returns the version and commit used for synthetic bundled
+// pack lock entries.
+func CurrentResolution() (version, commit string, err error) {
+	info, ok := debug.ReadBuildInfo()
+	version = "dev"
+	commit = "unknown"
+	if ok && info != nil {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			version = normalizeBuildVersion(info.Main.Version)
+		}
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				if setting.Value != "" {
+					commit = setting.Value
+				}
+			case "vcs.modified":
+				if setting.Value == "true" && commit != "unknown" {
+					commit += "-dirty"
+				}
+			}
+		}
+	}
+	if commit == "unknown" {
+		hash, hashErr := SyntheticContentHash()
+		if hashErr != nil {
+			return "", "", hashErr
+		}
+		commit = "synthetic-" + strings.TrimPrefix(hash, "sha256:")[:12]
+	}
+	if version == "" || version == "dev" {
+		version = "sha:" + commit
+	}
+	return version, commit, nil
+}
+
+func normalizeBuildVersion(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" || v == "(devel)" || v == "0.0.0" {
+		return "dev"
+	}
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+	for _, re := range goPseudoVersionSuffixes {
+		if m := re.FindStringSubmatch(v); len(m) == 2 {
+			v = m[1]
+			break
+		}
+	}
+	if v == "" {
+		return "dev"
+	}
+	return v
+}
+
+// ResolveCurrent applies an optional pack import version constraint to the
+// current bundled pack resolution.
+func ResolveCurrent(constraint string, match func(version, constraint string) bool) (version, commit string, err error) {
+	if strings.HasPrefix(constraint, "sha:") {
+		commit := strings.TrimPrefix(constraint, "sha:")
+		if commit == "" {
+			return "", "", fmt.Errorf("empty sha constraint")
+		}
+		return constraint, commit, nil
+	}
+	version, commit, err = CurrentResolution()
+	if err != nil {
+		return "", "", err
+	}
+	if constraint != "" && !match(version, constraint) {
+		return "", "", fmt.Errorf("bundled pack version %q does not satisfy constraint %q", version, constraint)
+	}
+	return version, commit, nil
+}

--- a/internal/config/bundled_import_test.go
+++ b/internal/config/bundled_import_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/builtinpacks"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 func TestResolveLockedRemoteImportAcceptsBundledSyntheticCache(t *testing.T) {
@@ -193,6 +194,37 @@ func TestValidateInstalledRemoteCacheTreatsBundledGitENOTDIRAsNonCheckout(t *tes
 	}
 	if strings.Contains(err.Error(), "checking cached import") {
 		t.Fatalf("error = %v, want ENOTDIR classified as non-checkout", err)
+	}
+}
+
+func TestLoadWithIncludesAcceptsSyntheticBundledImportCache(t *testing.T) {
+	home, cityDir := setupBundledImportTest(t)
+	source := bundledPackSource()
+	commit := "abc123def456abc123def456abc123def456abc123de"
+	cacheDir := bundledRepoCacheDir(home, source, commit)
+	if err := builtinpacks.MaterializeSyntheticRepo(cacheDir, commit); err != nil {
+		t.Fatalf("MaterializeSyntheticRepo: %v", err)
+	}
+	writeTestFile(t, cityDir, "city.toml", "[workspace]\n")
+	writeTestFile(t, cityDir, "pack.toml", fmt.Sprintf(`
+[pack]
+name = "city"
+schema = 2
+
+[imports.core]
+source = %q
+`, source))
+	writeBundledImportLock(t, cityDir, source, commit)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if len(cfg.ExplicitImportPackDirs) == 0 {
+		t.Fatal("ExplicitImportPackDirs is empty")
+	}
+	if got := filepath.ToSlash(cfg.ExplicitImportPackDirs[0]); !strings.HasSuffix(got, "internal/bootstrap/packs/core") {
+		t.Fatalf("ExplicitImportPackDirs[0] = %q, want core cache subpath", cfg.ExplicitImportPackDirs[0])
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/builtinpacks"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
@@ -3044,7 +3045,7 @@ func InjectImplicitAgents(cfg *City) {
 	// then any custom providers in sorted order.
 	providers := configuredProviderOrder(configured)
 
-	promptTemplate := citylayout.SystemPacksRoot + "/core/assets/prompts/pool-worker.md"
+	promptTemplate := corePromptTemplatePath(cfg, "pool-worker.md")
 
 	slingFormula := cfg.AgentDefaults.DefaultSlingFormula
 	if slingFormula == "" {
@@ -3083,6 +3084,26 @@ func InjectImplicitAgents(cfg *City) {
 	}
 
 	injectControlDispatcherAgents(cfg, existing)
+}
+
+func corePromptTemplatePath(cfg *City, name string) string {
+	if cfg != nil {
+		for _, dir := range corePackSearchDirs(cfg) {
+			if readPackNameFromDir(dir) == "core" {
+				return filepath.Join(dir, "assets", "prompts", name)
+			}
+		}
+	}
+	return citylayout.SystemPacksRoot + "/core/assets/prompts/" + name
+}
+
+func corePackSearchDirs(cfg *City) []string {
+	var dirs []string
+	dirs = append(dirs, cfg.ExplicitImportPackDirs...)
+	dirs = append(dirs, cfg.BootstrapImportPackDirs...)
+	dirs = append(dirs, cfg.ImplicitImportPackDirs...)
+	dirs = append(dirs, cfg.PackDirs...)
+	return dirs
 }
 
 // ApplyAgentDefaults applies [agent_defaults] values to all agents that
@@ -3588,11 +3609,13 @@ func ValidateRigs(rigs []Rig, hqPrefix string) error {
 // DefaultCity returns a City with the given name and a single default
 // agent named "mayor". This is the config written by "gc init".
 func DefaultCity(name string) City {
-	return City{
+	c := City{
 		Workspace:     Workspace{Name: name},
 		Agents:        []Agent{{Name: "mayor", PromptTemplate: "prompts/mayor.md"}},
 		NamedSessions: []NamedSession{{Template: "mayor", Mode: "always"}},
 	}
+	AddDefaultBuiltinImports(&c, false, false)
+	return c
 }
 
 func defaultInstallAgentHooksForProvider(provider string) []string {
@@ -3616,13 +3639,15 @@ func WizardCity(name, provider, startCommand string) City {
 		ws.Provider = provider
 		ws.InstallAgentHooks = defaultInstallAgentHooksForProvider(provider)
 	}
-	return City{
+	c := City{
 		Workspace: ws,
 		Agents: []Agent{
 			{Name: "mayor", PromptTemplate: "prompts/mayor.md"},
 		},
 		NamedSessions: []NamedSession{{Template: "mayor", Mode: "always"}},
 	}
+	AddDefaultBuiltinImports(&c, false, false)
+	return c
 }
 
 // GastownCity returns a City configured for the gastown orchestration pack.
@@ -3643,13 +3668,10 @@ func GastownCity(name, provider, startCommand string) City {
 		ws.InstallAgentHooks = defaultInstallAgentHooksForProvider(provider)
 	}
 	maxRestarts := 5
-	return City{
+	c := City{
 		Workspace: ws,
-		Imports: map[string]Import{
-			"gastown": {Source: ".gc/system/packs/gastown"},
-		},
 		DefaultRigImports: map[string]Import{
-			"gastown": {Source: ".gc/system/packs/gastown"},
+			"gastown": {Source: builtinpacks.MustSource("gastown")},
 		},
 		DefaultRigImportOrder: []string{"gastown"},
 		Daemon: DaemonConfig{
@@ -3659,6 +3681,36 @@ func GastownCity(name, provider, startCommand string) City {
 			ShutdownTimeout: "5s",
 		},
 	}
+	AddDefaultBuiltinImports(&c, false, true)
+	return c
+}
+
+// AddDefaultBuiltinImports adds the bundled default pack imports to cfg.
+// Core is always explicit. Maintenance is explicit unless the Gastown pack is
+// also explicit, because Gastown imports maintenance itself. The bd pack is
+// optional because file-backed cities do not need bd/Dolt operations.
+func AddDefaultBuiltinImports(cfg *City, includeBD, includeGastown bool) {
+	if cfg == nil {
+		return
+	}
+	if cfg.Imports == nil {
+		cfg.Imports = make(map[string]Import)
+	}
+	add := func(name string) {
+		if _, exists := cfg.Imports[name]; exists {
+			return
+		}
+		cfg.Imports[name] = Import{Source: builtinpacks.MustSource(name)}
+	}
+	add("core")
+	if includeBD {
+		add("bd")
+	}
+	if includeGastown {
+		add("gastown")
+		return
+	}
+	add("maintenance")
 }
 
 // Marshal encodes a City to TOML bytes.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/builtinpacks"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
@@ -83,7 +84,7 @@ func TestMarshalDefaultCityFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	want := "[workspace]\nname = \"bright-lights\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n\n[[named_session]]\ntemplate = \"mayor\"\nmode = \"always\"\n"
+	want := "[workspace]\nname = \"bright-lights\"\n\n[imports]\n[imports.core]\nsource = \"https://github.com/gastownhall/gascity.git//internal/bootstrap/packs/core\"\n[imports.maintenance]\nsource = \"https://github.com/gastownhall/gascity.git//examples/gastown/packs/maintenance\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n\n[[named_session]]\ntemplate = \"mayor\"\nmode = \"always\"\n"
 	if string(data) != want {
 		t.Errorf("Marshal output:\ngot:\n%s\nwant:\n%s", data, want)
 	}
@@ -862,11 +863,13 @@ func TestGastownCity(t *testing.T) {
 	if c.Workspace.Provider != "claude" {
 		t.Errorf("Workspace.Provider = %q, want %q", c.Workspace.Provider, "claude")
 	}
-	if len(c.Imports) != 1 || c.Imports["gastown"].Source != ".gc/system/packs/gastown" {
-		t.Errorf("Imports = %v, want gastown=.gc/system/packs/gastown", c.Imports)
+	if len(c.Imports) != 2 ||
+		c.Imports["core"].Source != builtinpacks.MustSource("core") ||
+		c.Imports["gastown"].Source != builtinpacks.MustSource("gastown") {
+		t.Errorf("Imports = %v, want core and gastown bundled imports", c.Imports)
 	}
-	if len(c.DefaultRigImports) != 1 || c.DefaultRigImports["gastown"].Source != ".gc/system/packs/gastown" {
-		t.Errorf("DefaultRigImports = %v, want gastown=.gc/system/packs/gastown", c.DefaultRigImports)
+	if len(c.DefaultRigImports) != 1 || c.DefaultRigImports["gastown"].Source != builtinpacks.MustSource("gastown") {
+		t.Errorf("DefaultRigImports = %v, want gastown bundled import", c.DefaultRigImports)
 	}
 	if len(c.Workspace.GlobalFragments) != 2 {
 		t.Errorf("Workspace.GlobalFragments = %v, want 2 entries", c.Workspace.GlobalFragments)
@@ -914,8 +917,10 @@ func TestGastownCityRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse(Marshal output): %v", err)
 	}
-	if len(got.Imports) != 1 || got.Imports["gastown"].Source != ".gc/system/packs/gastown" {
-		t.Errorf("round-trip Imports = %v, want gastown=.gc/system/packs/gastown", got.Imports)
+	if len(got.Imports) != 2 ||
+		got.Imports["core"].Source != builtinpacks.MustSource("core") ||
+		got.Imports["gastown"].Source != builtinpacks.MustSource("gastown") {
+		t.Errorf("round-trip Imports = %v, want core and gastown bundled imports", got.Imports)
 	}
 	if got.Workspace.Provider != "claude" {
 		t.Errorf("round-trip Provider = %q, want %q", got.Workspace.Provider, "claude")

--- a/internal/config/import_test.go
+++ b/internal/config/import_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/builtinpacks"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
@@ -787,6 +788,58 @@ fetched = "2026-04-10T00:00:00Z"
 	}
 	if !strings.Contains(err.Error(), "locked but not cached") || !strings.Contains(err.Error(), `run "gc import install"`) {
 		t.Fatalf("error = %v, want locked-but-not-cached install hint", err)
+	}
+}
+
+func TestImport_BundledRemoteImportInvalidSyntheticCacheReportsValidationError(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	t.Setenv("HOME", home)
+
+	cityDir := filepath.Join(dir, "city")
+	mustMkdirAll(t, cityDir, 0o755)
+
+	source := builtinpacks.MustSource("bd")
+	commit := "synthetic-stale"
+	cacheDir := filepath.Join(home, ".gc", "cache", "repos", RepoCacheKey(source, commit))
+	mustMkdirAll(t, cacheDir, 0o755)
+	writeTestFile(t, cacheDir, ".gc-bundled-pack-cache.toml", fmt.Sprintf(`
+schema = 1
+repository = %q
+commit = %q
+content_hash = "sha256:stale"
+`, builtinpacks.Repository, commit))
+
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+`)
+	writeTestFile(t, cityDir, "pack.toml", fmt.Sprintf(`
+[pack]
+name = "test"
+schema = 1
+
+[imports.bd]
+source = %q
+version = "sha:%s"
+`, source, commit))
+	writeTestFile(t, cityDir, "packs.lock", fmt.Sprintf(`
+schema = 1
+
+[packs.%q]
+version = "sha:%s"
+commit = %q
+fetched = "2026-04-10T00:00:00Z"
+`, source, commit, commit))
+
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err == nil {
+		t.Fatal("expected invalid synthetic cache error")
+	}
+	if !strings.Contains(err.Error(), "synthetic cache is invalid") ||
+		!strings.Contains(err.Error(), "bundled pack cache content hash") ||
+		strings.Contains(err.Error(), "locked but not cached") {
+		t.Fatalf("error = %v, want synthetic validation error without locked-but-not-cached fallback", err)
 	}
 }
 

--- a/internal/packman/install.go
+++ b/internal/packman/install.go
@@ -97,6 +97,33 @@ func InstallLocked(cityRoot string) (*Lockfile, error) {
 	return lock, nil
 }
 
+// InstallLockedBundledPacks restores only bundled pack entries recorded in
+// packs.lock into the shared cache. It never fetches arbitrary remote imports.
+func InstallLockedBundledPacks(cityRoot string) (*Lockfile, error) {
+	lock, err := ReadLockfile(fsys.OSFS{}, cityRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	sources := make([]string, 0, len(lock.Packs))
+	for source := range lock.Packs {
+		if builtinpacks.IsSource(source) {
+			sources = append(sources, source)
+		}
+	}
+	sort.Strings(sources)
+	for _, source := range sources {
+		pack := lock.Packs[source]
+		if pack.Commit == "" {
+			return nil, fmt.Errorf("lock entry %q is missing commit", source)
+		}
+		if _, err := EnsureRepoInCache(source, pack.Commit); err != nil {
+			return nil, err
+		}
+	}
+	return lock, nil
+}
+
 // SyncLock resolves the reachable remote-import closure and returns the updated lock.
 func SyncLock(cityRoot string, imports map[string]config.Import, mode InstallMode) (*Lockfile, error) {
 	return syncLock(cityRoot, imports, mode, nil)

--- a/internal/packman/resolve.go
+++ b/internal/packman/resolve.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/gastownhall/gascity/internal/builtinpacks"
 )
 
 // ErrNoSemverTags reports that a source has no semver tags to resolve.
@@ -20,6 +22,13 @@ type ResolvedVersion struct {
 // ResolveVersion discovers tags for source and selects the highest tag matching constraint.
 // Empty constraint means "latest stable semver tag". "sha:<hex>" bypasses tag discovery.
 func ResolveVersion(source, constraint string) (ResolvedVersion, error) {
+	if builtinpacks.IsSource(source) {
+		version, commit, err := builtinpacks.ResolveCurrent(constraint, matchesConstraint)
+		if err != nil {
+			return ResolvedVersion{}, err
+		}
+		return ResolvedVersion{Version: version, Commit: commit}, nil
+	}
 	if strings.HasPrefix(constraint, "sha:") {
 		commit := strings.TrimPrefix(constraint, "sha:")
 		if commit == "" {


### PR DESCRIPTION
## Summary
- Move the default bundled packs into explicit registry-backed imports for new city config.
- Add canonical builtin pack source metadata plus doctor coverage for registry migration state.
- Keep `.gc/system/packs` materialization as a compatibility path and isolate `HOME` in testscript tests so bundled-pack cache state does not leak.

## Tests
- `go test ./cmd/gc -run 'TestLoadCityConfigDoesNotMaterializeBuiltinPacks|TestLoadCityConfigLeavesExistingSystemPacksUntouched|TestMaterializeFS_PreservesExistingFiles|TestBuiltinPacksUseCanonicalRegistry|TestBuiltinPackRegistry'`

## Draft Notes
This is intentionally a draft because there are open questions to address before review/merge.

I did not add `status/needs-review-auto` yet because this PR should not enter automated review while those questions are still open.

The broad pre-commit hook was not rerun for this draft. The earlier broad run failed in current-main integration around:
- `TestBuiltinDoltDoctorAllowsAtMinimumVersionWhenProbeSucceeds`
- `TestDirectJSONWriterPayloadsValidateDeclaredSchemas`
- `TestCmdSlingDefaultFormulaDoesNotMaterializePoolSession`
- `TestBuiltinDoltDoctorBoundsVersionProbe`
- `TestDoctorJSONSuccessIsParseableJSONOnly`
- `TestBuildDoctorChecks_NameSetUnchanged`
