### PR TITLE
perf: default control bd writes to no-history

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -159,7 +159,7 @@ func scopeIsGCManaged(scopeRoot string) bool {
 
 func controlBdStoreForCity(dir, cityPath string, cfg *config.City) *beads.BdStore {
 	reapStaleBdExportJSONL(dir)
-	return beads.NewBdStoreWithPrefix(dir, controlBdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
+	return beads.NewBdStoreWithPrefixAndOptions(dir, controlBdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg), beads.BdStoreOptions{NoHistory: true})
 }
 
 func controlBdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...string) *beads.BdStore {
@@ -173,7 +173,7 @@ func controlBdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix
 		}
 	}
 	reapStaleBdExportJSONL(rigDir)
-	return beads.NewBdStoreWithPrefix(rigDir, controlBdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+	return beads.NewBdStoreWithPrefixAndOptions(rigDir, controlBdCommandRunnerForRig(cityPath, cfg, rigDir), prefix, beads.BdStoreOptions{NoHistory: true})
 }
 
 func controlBdCommandRunnerForCity(cityPath string) beads.CommandRunner {

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -858,6 +858,9 @@
               "null"
             ]
           },
+          "no_history": {
+            "type": "boolean"
+          },
           "parent": {
             "type": "string"
           },

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -858,6 +858,9 @@
               "null"
             ]
           },
+          "no_history": {
+            "type": "boolean"
+          },
           "parent": {
             "type": "string"
           },

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -511,6 +511,7 @@ type Bead struct {
 	Labels       *[]string          `json:"labels,omitempty"`
 	Metadata     *map[string]string `json:"metadata,omitempty"`
 	Needs        *[]string          `json:"needs,omitempty"`
+	NoHistory    *bool              `json:"no_history,omitempty"`
 	Parent       *string            `json:"parent,omitempty"`
 	Priority     *int64             `json:"priority,omitempty"`
 	Ref          *string            `json:"ref,omitempty"`

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -858,6 +858,9 @@
               "null"
             ]
           },
+          "no_history": {
+            "type": "boolean"
+          },
           "parent": {
             "type": "string"
           },

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -215,9 +215,17 @@ type BdStore struct {
 	runner      CommandRunner   // injectable for testing
 	purgeRunner PurgeRunnerFunc // injectable for testing; nil uses exec default
 	idPrefix    string          // bead ID prefix owned by this store, without trailing "-"
+	storage     BdStoreOptions
 }
 
 const bdTransientWriteAttempts = 3
+
+// BdStoreOptions configures default storage behavior for beads created through
+// a BdStore. Explicit bead or graph flags are still honored.
+type BdStoreOptions struct {
+	Ephemeral bool
+	NoHistory bool
+}
 
 // NewBdStore creates a BdStore rooted at dir using the given runner.
 func NewBdStore(dir string, runner CommandRunner) *BdStore {
@@ -226,7 +234,20 @@ func NewBdStore(dir string, runner CommandRunner) *BdStore {
 
 // NewBdStoreWithPrefix creates a BdStore with an explicit owned bead ID prefix.
 func NewBdStoreWithPrefix(dir string, runner CommandRunner, idPrefix string) *BdStore {
-	return &BdStore{dir: dir, runner: runner, idPrefix: normalizeIDPrefix(idPrefix)}
+	return NewBdStoreWithPrefixAndOptions(dir, runner, idPrefix, BdStoreOptions{})
+}
+
+// NewBdStoreWithPrefixAndOptions creates a BdStore with an explicit owned bead
+// ID prefix and default storage behavior.
+func NewBdStoreWithPrefixAndOptions(dir string, runner CommandRunner, idPrefix string, opts BdStoreOptions) *BdStore {
+	return &BdStore{dir: dir, runner: runner, idPrefix: normalizeIDPrefix(idPrefix), storage: opts}
+}
+
+func (s *BdStore) effectiveCreateStorage(b Bead) (ephemeral bool, noHistory bool) {
+	if b.Ephemeral || b.NoHistory {
+		return b.Ephemeral, b.NoHistory
+	}
+	return s.storage.Ephemeral, s.storage.NoHistory
 }
 
 // IDPrefix returns the bead ID prefix owned by this store, without trailing "-".
@@ -456,6 +477,7 @@ type bdIssue struct {
 	Metadata     StringMap    `json:"metadata,omitempty"`
 	Dependencies []bdIssueDep `json:"dependencies,omitempty"`
 	Ephemeral    bool         `json:"ephemeral,omitempty"`
+	NoHistory    bool         `json:"no_history,omitempty"`
 }
 
 type bdIssueDep struct {
@@ -581,6 +603,7 @@ func (b *bdIssue) toBead() Bead {
 		Metadata:     b.Metadata,
 		Dependencies: deps,
 		Ephemeral:    b.Ephemeral,
+		NoHistory:    b.NoHistory,
 	}
 }
 
@@ -643,6 +666,10 @@ func mapBdStatus(s string) string {
 
 // Create persists a new bead via bd create.
 func (s *BdStore) Create(b Bead) (Bead, error) {
+	effectiveEphemeral, effectiveNoHistory := s.effectiveCreateStorage(b)
+	if effectiveEphemeral && effectiveNoHistory {
+		return Bead{}, fmt.Errorf("bd create: ephemeral and no-history storage are mutually exclusive")
+	}
 	typ := b.Type
 	if typ == "" {
 		typ = "task"
@@ -669,8 +696,11 @@ func (s *BdStore) Create(b Bead) (Bead, error) {
 	if b.ParentID != "" {
 		args = append(args, "--parent", b.ParentID)
 	}
-	if b.Ephemeral {
+	if effectiveEphemeral {
 		args = append(args, "--ephemeral")
+	}
+	if effectiveNoHistory {
+		args = append(args, "--no-history")
 	}
 	metadata := maps.Clone(b.Metadata)
 	if b.From != "" {
@@ -710,6 +740,12 @@ func (s *BdStore) Create(b Bead) (Bead, error) {
 		if created.Metadata == nil {
 			created.Metadata = maps.Clone(metadata)
 		}
+	}
+	if effectiveEphemeral {
+		created.Ephemeral = true
+	}
+	if effectiveNoHistory {
+		created.NoHistory = true
 	}
 	return created, nil
 }

--- a/internal/beads/bdstore_graph_apply.go
+++ b/internal/beads/bdstore_graph_apply.go
@@ -14,8 +14,12 @@ func (s *BdStore) ApplyGraphPlan(_ context.Context, plan *GraphApplyPlan) (*Grap
 	if plan == nil {
 		return nil, fmt.Errorf("graph apply plan is nil")
 	}
+	effective := *plan
+	if !effective.NoHistory {
+		effective.NoHistory = s.storage.NoHistory
+	}
 
-	data, err := json.Marshal(plan)
+	data, err := json.Marshal(&effective)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling graph apply plan: %w", err)
 	}
@@ -40,7 +44,11 @@ func (s *BdStore) ApplyGraphPlan(_ context.Context, plan *GraphApplyPlan) (*Grap
 		return nil, fmt.Errorf("closing graph apply temp file: %w", err)
 	}
 
-	out, err := s.runner(s.dir, "bd", "create", "--graph", tmpPath, "--json")
+	args := []string{"create", "--graph", tmpPath, "--json"}
+	if effective.NoHistory {
+		args = append(args, "--no-history")
+	}
+	out, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
 		return nil, fmt.Errorf("bd create --graph: %w", err)
 	}
@@ -49,7 +57,7 @@ func (s *BdStore) ApplyGraphPlan(_ context.Context, plan *GraphApplyPlan) (*Grap
 	if err := json.Unmarshal(extractJSON(out), &result); err != nil {
 		return nil, fmt.Errorf("bd create --graph: parsing JSON: %w", err)
 	}
-	if err := ValidateGraphApplyResult(plan, &result); err != nil {
+	if err := ValidateGraphApplyResult(&effective, &result); err != nil {
 		return nil, fmt.Errorf("bd create --graph: %w", err)
 	}
 	return &result, nil

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -147,6 +147,75 @@ func TestBdStoreCreatePassesDeps(t *testing.T) {
 	}
 }
 
+func TestBdStoreCreatePassesNoHistory(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`{"id":"bd-x","title":"test","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","no_history":true}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	created, err := s.Create(beads.Bead{Title: "test", NoHistory: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--no-history") {
+		t.Errorf("args = %q, want --no-history", args)
+	}
+	if created.Ephemeral {
+		t.Fatalf("created.Ephemeral = true, want false")
+	}
+	if !created.NoHistory {
+		t.Fatalf("created.NoHistory = false, want true")
+	}
+}
+
+func TestBdStoreCreateInheritsNoHistoryDefault(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`{"id":"bd-x","title":"test","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}`), nil
+	}
+	s := beads.NewBdStoreWithPrefixAndOptions("/city", runner, "", beads.BdStoreOptions{NoHistory: true})
+	created, err := s.Create(beads.Bead{Title: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--no-history") {
+		t.Errorf("args = %q, want --no-history", args)
+	}
+	if created.Ephemeral {
+		t.Fatalf("created.Ephemeral = true, want false")
+	}
+	if !created.NoHistory {
+		t.Fatalf("created.NoHistory = false, want true")
+	}
+}
+
+func TestBdStoreCreateExplicitStorageOverridesDefault(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`{"id":"bd-x","title":"test","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","ephemeral":true}`), nil
+	}
+	s := beads.NewBdStoreWithPrefixAndOptions("/city", runner, "", beads.BdStoreOptions{NoHistory: true})
+	created, err := s.Create(beads.Bead{Title: "test", Ephemeral: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if strings.Contains(args, "--no-history") {
+		t.Fatalf("args = %q, did not want --no-history", args)
+	}
+	if !strings.Contains(args, "--ephemeral") {
+		t.Fatalf("args = %q, want --ephemeral", args)
+	}
+	if !created.Ephemeral || created.NoHistory {
+		t.Fatalf("created flags = ephemeral:%v no_history:%v, want true/false", created.Ephemeral, created.NoHistory)
+	}
+}
+
 func TestBdStoreCreatePassesPriority(t *testing.T) {
 	var gotArgs []string
 	runner := func(_, _ string, args ...string) ([]byte, error) {
@@ -2851,6 +2920,47 @@ func TestBdStoreApplyGraphPlan(t *testing.T) {
 	}
 	if matches, _ := filepath.Glob(filepath.Join(dir, ".gc", "tmp", "graph-apply-*.json")); len(matches) != 0 {
 		t.Fatalf("temp graph apply files were not cleaned up: %v", matches)
+	}
+}
+
+func TestBdStoreApplyGraphPlanInheritsNoHistoryDefault(t *testing.T) {
+	dir := t.TempDir()
+	var capturedPlan beads.GraphApplyPlan
+	var gotArgs []string
+	runner := func(cmdDir, name string, args ...string) ([]byte, error) {
+		if cmdDir != dir {
+			t.Fatalf("runner dir = %q, want %q", cmdDir, dir)
+		}
+		if name != "bd" {
+			t.Fatalf("runner name = %q, want bd", name)
+		}
+		gotArgs = append([]string(nil), args...)
+		data, err := os.ReadFile(args[2])
+		if err != nil {
+			t.Fatalf("reading plan file: %v", err)
+		}
+		if err := json.Unmarshal(data, &capturedPlan); err != nil {
+			t.Fatalf("unmarshal plan file: %v", err)
+		}
+		return []byte(`{"ids":{"root":"bd-1"}}`), nil
+	}
+
+	s := beads.NewBdStoreWithPrefixAndOptions(dir, runner, "", beads.BdStoreOptions{NoHistory: true})
+	result, err := s.ApplyGraphPlan(t.Context(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{{Key: "root", Title: "Root"}},
+	})
+	if err != nil {
+		t.Fatalf("ApplyGraphPlan: %v", err)
+	}
+	if got := result.IDs["root"]; got != "bd-1" {
+		t.Fatalf("result ID = %q, want bd-1", got)
+	}
+	if !capturedPlan.NoHistory {
+		t.Fatalf("capturedPlan.NoHistory = false, want true")
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--no-history") {
+		t.Fatalf("args = %q, want --no-history", args)
 	}
 }
 

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -40,6 +40,9 @@ type Bead struct {
 	// garbage collection. Reads must opt in via ListQuery.TierMode (or the
 	// WithEphemeral/WithBothTiers QueryOpts on the legacy label helpers).
 	Ephemeral bool `json:"ephemeral,omitempty"`
+	// NoHistory routes the bead to durable wisp-backed storage without git
+	// history tracking on Create.
+	NoHistory bool `json:"no_history,omitempty"`
 }
 
 // UpdateOpts specifies which fields to change. Nil pointers are skipped.

--- a/internal/beads/graph_apply.go
+++ b/internal/beads/graph_apply.go
@@ -16,6 +16,7 @@ type GraphApplyStore interface {
 // Keys are caller-defined stable identifiers (for example recipe step IDs).
 type GraphApplyPlan struct {
 	CommitMessage string           `json:"commit_message,omitempty"`
+	NoHistory     bool             `json:"no_history,omitempty"`
 	Nodes         []GraphApplyNode `json:"nodes"`
 	Edges         []GraphApplyEdge `json:"edges,omitempty"`
 }


### PR DESCRIPTION
## Summary
Independent draft PR adapted from `d23fda264` on `feature/city-rescue-main-drain-v0`.

Base branch: `main`.

This keeps the no-history default behavior separate from the graph-ephemeral support in #2746. In particular, this PR adds `no_history` support/defaults for control `BdStore` writes and graph creation without pulling in the broader graph-ephemeral fallback changes.

## Tests
- `go test ./internal/beads -run 'TestBdStoreCreatePassesNoHistory|TestBdStoreCreateInheritsNoHistoryDefault|TestBdStoreCreateExplicitStorageOverridesDefault|TestBdStoreApplyGraphPlanInheritsNoHistoryDefault'`

## Draft Notes
This PR is intentionally draft and has no auto-review label. Once approved, we can mark it ready for review and add `status/needs-review-auto`.