### PR TITLE
Add bead storage policy routing

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -127,11 +127,13 @@ func newControllerState(
 	return cs
 }
 
-// wrapWithCachingStore wraps a Store with a CachingStore that primes
-// and starts a background reconciler.
+// wrapWithCachingStore wraps a BdStore with a CachingStore that primes
+// and starts a background reconciler. Non-BdStore stores are returned as-is.
 func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Provider) beads.Store {
-	if store == nil {
-		return nil
+	baseStore, policyStore, policyWrapped := unwrapBeadPolicyStore(store)
+	bdStore, ok := baseStore.(*beads.BdStore)
+	if !ok {
+		return store
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -150,7 +152,7 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 			})
 		}
 	}
-	cs := beads.NewCachingStore(store, onChange)
+	cs := beads.NewCachingStore(bdStore, onChange)
 	// Pre-prime active beads synchronously (~1-2s, indexed queries).
 	// Loads open + in_progress beads — enough for the startup path
 	// (adoption, session snapshot, desired state) so the city can
@@ -159,6 +161,9 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 		log.Printf("caching-store: pre-prime failed: %v", err)
 	}
 	if ctx.Done() == nil {
+		if policyWrapped {
+			return wrapStoreWithBeadPolicies(cs, policyStore.cfg)
+		}
 		return cs
 	}
 	// Full prime runs async — backfills remaining beads for List()
@@ -174,6 +179,9 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 		}
 		cs.StartReconciler(ctx, beads.WithStaggerAuto(), os.Getenv("GC_AGENT"))
 	}()
+	if policyWrapped {
+		return wrapStoreWithBeadPolicies(cs, policyStore.cfg)
+	}
 	return cs
 }
 
@@ -209,13 +217,13 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 			// Legacy file mode aliases every rig to the same backing store, so
 			// the cache handle must be shared too for immediate cross-rig reads.
 			if sharedLegacyCachedStore == nil {
-				sharedLegacyCachedStore = wrapWithCachingStore(cs.cacheCtx, sharedLegacyFileStore, cs.eventProv)
+				sharedLegacyCachedStore = wrapWithCachingStore(cs.cacheCtx, wrapStoreWithBeadPolicies(sharedLegacyFileStore, cfg), cs.eventProv)
 			}
 			stores[rig.Name] = sharedLegacyCachedStore
 			continue
 		}
 		store = cs.openRigStore(scopeProvider, rig.Name, scopeRoot, rig.EffectivePrefix(), cfg)
-		stores[rig.Name] = wrapWithCachingStore(cs.cacheCtx, store, cs.eventProv)
+		stores[rig.Name] = wrapWithCachingStore(cs.cacheCtx, wrapStoreWithBeadPolicies(store, cfg), cs.eventProv)
 	}
 	return stores
 }

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -1512,8 +1512,9 @@ prefix = "fe"
 	if err != nil {
 		t.Fatalf("openStoreAtForCity(rig): %v", err)
 	}
-	if _, ok := store.(*beads.BdStore); !ok {
-		t.Fatalf("openStoreAtForCity(rig) returned %T, want *beads.BdStore", store)
+	baseStore, _, _ := unwrapBeadPolicyStore(store)
+	if _, ok := baseStore.(*beads.BdStore); !ok {
+		t.Fatalf("openStoreAtForCity(rig) returned %T wrapping %T, want *beads.BdStore", store, baseStore)
 	}
 }
 
@@ -1544,8 +1545,9 @@ prefix = "fe"
 	if err != nil {
 		t.Fatalf("openStoreAtForCity(rig): %v", err)
 	}
-	if _, ok := store.(*beads.FileStore); !ok {
-		t.Fatalf("openStoreAtForCity(rig) returned %T, want *beads.FileStore", store)
+	baseStore, _, _ := unwrapBeadPolicyStore(store)
+	if _, ok := baseStore.(*beads.FileStore); !ok {
+		t.Fatalf("openStoreAtForCity(rig) returned %T wrapping %T, want *beads.FileStore", store, baseStore)
 	}
 }
 
@@ -1810,9 +1812,10 @@ exit 0
 	if err != nil {
 		t.Fatalf("openStoreAtForCity: %v", err)
 	}
-	bdStore, ok := store.(*beads.BdStore)
+	baseStore, _, _ := unwrapBeadPolicyStore(store)
+	bdStore, ok := baseStore.(*beads.BdStore)
 	if !ok {
-		t.Fatalf("openStoreAtForCity returned %T, want *beads.BdStore", store)
+		t.Fatalf("openStoreAtForCity returned %T wrapping %T, want *beads.BdStore", store, baseStore)
 	}
 	if err := bdStore.Init("myrig", "", ""); err != nil {
 		t.Fatalf("bd store init: %v", err)

--- a/cmd/gc/bead_policy_store.go
+++ b/cmd/gc/bead_policy_store.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+const (
+	beadStorageHistory   = config.BeadStorageHistory
+	beadStorageNoHistory = config.BeadStorageNoHistory
+	beadStorageEphemeral = config.BeadStorageEphemeral
+)
+
+type beadPolicyStore struct {
+	beads.Store
+	cfg *config.City
+
+	mu               sync.Mutex
+	wispRootStorage  map[string]string
+	wispRootPolicies map[string]string
+}
+
+type beadPolicyGraphStore struct {
+	*beadPolicyStore
+	applier beads.GraphApplyStore
+}
+
+func wrapStoreWithBeadPolicies(store beads.Store, cfg *config.City) beads.Store {
+	if store == nil {
+		return nil
+	}
+	policyStore := &beadPolicyStore{
+		Store:            store,
+		cfg:              cfg,
+		wispRootStorage:  make(map[string]string),
+		wispRootPolicies: make(map[string]string),
+	}
+	if applier, ok := store.(beads.GraphApplyStore); ok {
+		return &beadPolicyGraphStore{
+			beadPolicyStore: policyStore,
+			applier:         applier,
+		}
+	}
+	return policyStore
+}
+
+func unwrapBeadPolicyStore(store beads.Store) (beads.Store, *beadPolicyStore, bool) {
+	switch s := store.(type) {
+	case *beadPolicyGraphStore:
+		return s.Store, s.beadPolicyStore, true
+	case *beadPolicyStore:
+		return s.Store, s, true
+	default:
+		return store, nil, false
+	}
+}
+
+func (s *beadPolicyStore) Create(b beads.Bead) (beads.Bead, error) {
+	policyName, storage := s.policyForCreate(b)
+	if storage != "" {
+		b = applyBeadStorage(b, storage)
+	}
+	created, err := s.Store.Create(b)
+	if err != nil {
+		return created, err
+	}
+	if policyName == beadPolicyWisp && created.ID != "" {
+		s.mu.Lock()
+		s.wispRootStorage[created.ID] = storage
+		s.wispRootPolicies[created.ID] = policyName
+		s.mu.Unlock()
+	}
+	return created, nil
+}
+
+func (s *beadPolicyStore) policyForCreate(b beads.Bead) (string, string) {
+	if rootID := strings.TrimSpace(b.Metadata["gc.root_bead_id"]); rootID != "" {
+		s.mu.Lock()
+		storage := s.wispRootStorage[rootID]
+		policyName := s.wispRootPolicies[rootID]
+		s.mu.Unlock()
+		if storage != "" {
+			return policyName, storage
+		}
+	}
+	policyName := policyNameForBead(b)
+	if policyName == "" {
+		return "", ""
+	}
+	return policyName, effectiveBeadStorage(s.cfg, policyName)
+}
+
+func (s *beadPolicyGraphStore) ApplyGraphPlan(ctx context.Context, plan *beads.GraphApplyPlan) (*beads.GraphApplyResult, error) {
+	if plan == nil {
+		return s.applier.ApplyGraphPlan(ctx, plan)
+	}
+	policyName := policyNameForGraphPlan(plan)
+	if policyName == "" {
+		return s.applier.ApplyGraphPlan(ctx, plan)
+	}
+	storage := effectiveBeadStorage(s.cfg, policyName)
+	next := *plan
+	next = applyGraphStorage(next, storage)
+	return s.applier.ApplyGraphPlan(ctx, &next)
+}
+
+func policyNameForGraphPlan(plan *beads.GraphApplyPlan) string {
+	for _, node := range plan.Nodes {
+		if hasBeadLabel(node.Labels, molecule.WispLabel) || node.Metadata["gc.kind"] == "wisp" {
+			return beadPolicyWisp
+		}
+	}
+	return ""
+}
+
+func policyNameForBead(b beads.Bead) string {
+	switch {
+	case hasBeadLabel(b.Labels, molecule.WispLabel) || b.Metadata["gc.kind"] == "wisp":
+		return beadPolicyWisp
+	case hasBeadLabel(b.Labels, labelOrderTracking):
+		return beadPolicyOrderTracking
+	case hasBeadLabel(b.Labels, session.LabelSession) || b.Type == session.BeadType:
+		return beadPolicySession
+	case hasBeadLabel(b.Labels, session.WaitBeadLabel):
+		return beadPolicyWait
+	case hasBeadLabel(b.Labels, nudgeBeadLabel):
+		return beadPolicyNudge
+	default:
+		return ""
+	}
+}
+
+func effectiveBeadStorage(cfg *config.City, policyName string) string {
+	if cfg != nil {
+		if policy, ok := cfg.Beads.Policies[policyName]; ok {
+			if storage := normalizeBeadStorage(policy.Storage); storage != "" {
+				if config.ValidBeadPolicyStorage(storage) {
+					return storage
+				}
+				return defaultBeadStorage(policyName)
+			}
+		}
+	}
+	return defaultBeadStorage(policyName)
+}
+
+func defaultBeadStorage(policyName string) string {
+	switch policyName {
+	case beadPolicyWisp, beadPolicyOrderTracking:
+		return beadStorageEphemeral
+	case beadPolicySession, beadPolicyWait, beadPolicyNudge:
+		return beadStorageNoHistory
+	default:
+		return ""
+	}
+}
+
+func normalizeBeadStorage(storage string) string {
+	return config.NormalizeBeadPolicyStorage(storage)
+}
+
+func applyBeadStorage(b beads.Bead, storage string) beads.Bead {
+	switch normalizeBeadStorage(storage) {
+	case beadStorageEphemeral:
+		b.Ephemeral = true
+		b.NoHistory = false
+	case beadStorageNoHistory:
+		b.Ephemeral = false
+		b.NoHistory = true
+	case beadStorageHistory:
+		b.Ephemeral = false
+		b.NoHistory = false
+	}
+	return b
+}
+
+func applyGraphStorage(plan beads.GraphApplyPlan, storage string) beads.GraphApplyPlan {
+	switch normalizeBeadStorage(storage) {
+	case beadStorageEphemeral:
+		plan.Ephemeral = true
+		plan.NoHistory = false
+	case beadStorageNoHistory:
+		plan.Ephemeral = false
+		plan.NoHistory = true
+	case beadStorageHistory:
+		plan.Ephemeral = false
+		plan.NoHistory = false
+	}
+	return plan
+}
+
+func hasBeadLabel(labels []string, label string) bool {
+	return slices.Contains(labels, label)
+}

--- a/cmd/gc/bead_policy_store_test.go
+++ b/cmd/gc/bead_policy_store_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+type captureCreateStore struct {
+	beads.Store
+	created []beads.Bead
+}
+
+func (s *captureCreateStore) Create(b beads.Bead) (beads.Bead, error) {
+	s.created = append(s.created, b)
+	return s.Store.Create(b)
+}
+
+type captureGraphStore struct {
+	beads.Store
+	plan *beads.GraphApplyPlan
+}
+
+func (s *captureGraphStore) ApplyGraphPlan(_ context.Context, plan *beads.GraphApplyPlan) (*beads.GraphApplyResult, error) { //nolint:unparam // interface compliance; error always nil in spy
+	next := *plan
+	s.plan = &next
+	ids := make(map[string]string, len(plan.Nodes))
+	for _, node := range plan.Nodes {
+		ids[node.Key] = "bd-" + node.Key
+	}
+	return &beads.GraphApplyResult{IDs: ids}, nil
+}
+
+func TestBeadPolicyStoreAppliesDefaultStorageForAllowlistedCreates(t *testing.T) {
+	backing := &captureCreateStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want string
+	}{
+		{
+			name: "session",
+			bead: beads.Bead{Title: "session", Type: session.BeadType, Labels: []string{session.LabelSession}},
+			want: beadStorageNoHistory,
+		},
+		{
+			name: "wait",
+			bead: beads.Bead{Title: "wait", Type: session.WaitBeadType, Labels: []string{session.WaitBeadLabel}},
+			want: beadStorageNoHistory,
+		},
+		{
+			name: "nudge",
+			bead: beads.Bead{Title: "nudge", Type: nudgeBeadType, Labels: []string{nudgeBeadLabel}},
+			want: beadStorageNoHistory,
+		},
+		{
+			name: "order tracking",
+			bead: beads.Bead{Title: "order:daily", Labels: orderTrackingLabels("daily")},
+			want: beadStorageEphemeral,
+		},
+		{
+			name: "wisp root",
+			bead: beads.Bead{Title: "wisp", Labels: []string{molecule.WispLabel}},
+			want: beadStorageEphemeral,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			backing.created = nil
+			if _, err := store.Create(tt.bead); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if len(backing.created) != 1 {
+				t.Fatalf("captured creates = %d, want 1", len(backing.created))
+			}
+			assertBeadStorage(t, backing.created[0], tt.want)
+		})
+	}
+}
+
+func TestBeadPolicyStoreStorageOverrides(t *testing.T) {
+	backing := &captureCreateStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{
+		Beads: config.BeadsConfig{Policies: map[string]config.BeadPolicyConfig{
+			beadPolicySession:       {Storage: beadStorageHistory},
+			beadPolicyOrderTracking: {Storage: beadStorageNoHistory},
+		}},
+	})
+
+	if _, err := store.Create(beads.Bead{
+		Title:     "session",
+		Type:      session.BeadType,
+		Labels:    []string{session.LabelSession},
+		Ephemeral: true,
+	}); err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+	assertBeadStorage(t, backing.created[0], beadStorageHistory)
+
+	if _, err := store.Create(beads.Bead{
+		Title:  "order:daily",
+		Labels: orderTrackingLabels("daily"),
+	}); err != nil {
+		t.Fatalf("Create(order tracking): %v", err)
+	}
+	assertBeadStorage(t, backing.created[1], beadStorageNoHistory)
+}
+
+func TestBeadPolicyStoreAppliesWispRootStorageToSequentialChildren(t *testing.T) {
+	backing := &captureCreateStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{
+		Beads: config.BeadsConfig{Policies: map[string]config.BeadPolicyConfig{
+			beadPolicyWisp: {Storage: beadStorageNoHistory},
+		}},
+	})
+
+	root, err := store.Create(beads.Bead{Title: "root", Labels: []string{molecule.WispLabel}})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "child",
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	}); err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+
+	if len(backing.created) != 2 {
+		t.Fatalf("captured creates = %d, want 2", len(backing.created))
+	}
+	assertBeadStorage(t, backing.created[0], beadStorageNoHistory)
+	assertBeadStorage(t, backing.created[1], beadStorageNoHistory)
+}
+
+func TestBeadPolicyGraphStoreAppliesWispStorageToGraphPlan(t *testing.T) {
+	backing := &captureGraphStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{
+		Beads: config.BeadsConfig{Policies: map[string]config.BeadPolicyConfig{
+			beadPolicyWisp: {Storage: beadStorageNoHistory},
+		}},
+	})
+	applier, ok := store.(beads.GraphApplyStore)
+	if !ok {
+		t.Fatal("wrapped graph store does not implement GraphApplyStore")
+	}
+
+	_, err := applier.ApplyGraphPlan(context.Background(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{
+			{Key: "root", Title: "Root", Labels: []string{molecule.WispLabel}},
+			{Key: "child", Title: "Child", MetadataRefs: map[string]string{"gc.root_bead_id": "root"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyGraphPlan: %v", err)
+	}
+	if backing.plan == nil {
+		t.Fatal("graph plan was not captured")
+	}
+	if !backing.plan.NoHistory || backing.plan.Ephemeral {
+		t.Fatalf("plan storage = ephemeral:%v no_history:%v, want no-history graph", backing.plan.Ephemeral, backing.plan.NoHistory)
+	}
+}
+
+func TestPolicyReadPathsIncludeHistoryAndNoHistoryRows(t *testing.T) {
+	runner := func(_ string, name string, args ...string) ([]byte, error) {
+		cmd := name + " " + strings.Join(args, " ")
+		switch cmd {
+		case "bd list --json --label=gc:session --include-infra --include-gates --limit 0":
+			return []byte(`[
+				{"id":"bd-old-session","title":"old session","status":"open","issue_type":"session","created_at":"2026-05-01T00:00:00Z","labels":["gc:session"],"metadata":{"session_name":"old"}},
+				{"id":"bd-new-session","title":"new session","status":"open","issue_type":"session","created_at":"2026-05-01T00:00:01Z","labels":["gc:session"],"metadata":{"session_name":"new"},"no_history":true}
+			]`), nil
+		case "bd list --json --label=gc:wait --include-infra --include-gates --limit 1001":
+			return []byte(`[
+				{"id":"bd-old-wait","title":"old wait","status":"open","issue_type":"gate","created_at":"2026-05-01T00:00:00Z","labels":["gc:wait"],"metadata":{"session_id":"s1"}},
+				{"id":"bd-new-wait","title":"new wait","status":"open","issue_type":"gate","created_at":"2026-05-01T00:00:01Z","labels":["gc:wait"],"metadata":{"session_id":"s2"},"no_history":true}
+			]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: %s", cmd)
+		}
+	}
+	store := beads.NewBdStore("/city", runner)
+
+	sessions, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("sessions = %+v, want history and no-history rows", sessions)
+	}
+	if !sessions[1].NoHistory {
+		t.Fatalf("new session row = %+v, want no_history parsed", sessions[1])
+	}
+
+	waits, err := loadWaitBeads(store)
+	if err != nil {
+		t.Fatalf("loadWaitBeads: %v", err)
+	}
+	if len(waits) != 2 {
+		t.Fatalf("waits = %+v, want history and no-history rows", waits)
+	}
+	foundNoHistoryWait := false
+	for _, wait := range waits {
+		if wait.ID == "bd-new-wait" {
+			foundNoHistoryWait = wait.NoHistory
+			break
+		}
+	}
+	if !foundNoHistoryWait {
+		t.Fatalf("waits = %+v, want bd-new-wait with no_history parsed", waits)
+	}
+}
+
+func assertBeadStorage(t *testing.T, b beads.Bead, want string) {
+	t.Helper()
+	switch want {
+	case beadStorageHistory:
+		if b.Ephemeral || b.NoHistory {
+			t.Fatalf("bead storage = ephemeral:%v no_history:%v, want history", b.Ephemeral, b.NoHistory)
+		}
+	case beadStorageEphemeral:
+		if !b.Ephemeral || b.NoHistory {
+			t.Fatalf("bead storage = ephemeral:%v no_history:%v, want ephemeral", b.Ephemeral, b.NoHistory)
+		}
+	case beadStorageNoHistory:
+		if b.Ephemeral || !b.NoHistory {
+			t.Fatalf("bead storage = ephemeral:%v no_history:%v, want no-history", b.Ephemeral, b.NoHistory)
+		}
+	default:
+		t.Fatalf("unknown expected storage %q", want)
+	}
+}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -204,11 +204,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 	it := buildIdleTracker(p.Cfg, p.CityName, p.CityPath, p.SP)
 	mat := buildMaxSessionAgeTracker(p.Cfg, p.CityName, p.SP)
 
-	var wg wispGC
-	if p.Cfg.Daemon.WispGCEnabled() {
-		wg = newWispGC(p.Cfg.Daemon.WispGCIntervalDuration(),
-			p.Cfg.Daemon.WispTTLDuration())
-	}
+	wg := newWispGCFromConfig(p.Cfg)
 
 	managedDoltHealth := p.ManagedDoltHealth
 	if managedDoltHealth == nil {
@@ -1668,12 +1664,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	cr.it = buildIdleTracker(nextCfg, cr.cityName, cr.cityPath, nextSp)
 	cr.mat = buildMaxSessionAgeTracker(nextCfg, cr.cityName, nextSp)
 
-	if nextCfg.Daemon.WispGCEnabled() {
-		cr.wg = newWispGC(nextCfg.Daemon.WispGCIntervalDuration(),
-			nextCfg.Daemon.WispTTLDuration())
-	} else {
-		cr.wg = nil
-	}
+	cr.wg = newWispGCFromConfig(nextCfg)
 
 	// Drain the outgoing dispatcher before replacing it so in-flight
 	// dispatchOne goroutines persist their tracking-bead outcomes against

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2866,8 +2866,9 @@ func TestOpenControlStoreAtForCityPreservesFileAndExecProviderStores(t *testing.
 		if err != nil {
 			t.Fatalf("openControlStoreAtForCity(file): %v", err)
 		}
-		if _, ok := store.(*beads.FileStore); !ok {
-			t.Fatalf("control store = %T, want *beads.FileStore for file provider", store)
+		baseStore, _, _ := unwrapBeadPolicyStore(store)
+		if _, ok := baseStore.(*beads.FileStore); !ok {
+			t.Fatalf("control store = %T wrapping %T, want *beads.FileStore for file provider", store, baseStore)
 		}
 	})
 

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -740,7 +740,7 @@ func doOrderRunExecTracked(a orders.Order, cityPath string, cfg *config.City, st
 	}
 	tracking, err := store.Create(beads.Bead{
 		Title:     "order:" + scoped,
-		Labels:    []string{"order-run:" + scoped, labelOrderTracking},
+		Labels:    orderTrackingLabels(scoped),
 		Ephemeral: true,
 	})
 	if err != nil {

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1550,9 +1550,9 @@ title = "Do work"
 	if code != 0 {
 		t.Fatalf("doOrderRun = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	all, err := store.ListOpen()
+	all, err := store.List(beads.ListQuery{AllowScan: true, TierMode: beads.TierBoth})
 	if err != nil {
-		t.Fatalf("store.ListOpen(): %v", err)
+		t.Fatalf("store.List(): %v", err)
 	}
 
 	foundWorker := false

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -1802,10 +1802,6 @@ func readSessionCircuitResetSocketReply(t *testing.T, conn net.Conn) sessionCirc
 }
 
 func TestControllerReloadInvalidConfig(t *testing.T) {
-	old := debounceDelay
-	debounceDelay = 5 * time.Millisecond
-	t.Cleanup(func() { debounceDelay = old })
-
 	dir := shortSocketTempDir(t, "gc-reload-invalid-")
 	tomlPath := writeCityTOML(t, dir, "test", "mayor")
 	disableManagedDoltRecoveryForTest(t)
@@ -1816,60 +1812,30 @@ func TestControllerReloadInvalidConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sp := runtime.NewFake()
-	var reconcileCount atomic.Int32
-	buildFn := func(c *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
-		reconcileCount.Add(1)
-		ds := make(map[string]TemplateParams)
-		for _, a := range c.Agents {
-			ds[a.Name] = TemplateParams{
-				SessionName:  a.Name,
-				TemplateName: a.Name,
-				Command:      "echo hello",
-			}
-		}
-		return DesiredStateResult{State: ds}
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	var stdout, stderr bytes.Buffer
-
-	done := make(chan struct{})
-	go func() {
-		controllerLoop(ctx, 20*time.Millisecond, cfg, "test", tomlPath, nil,
-			buildFn, sp, nil, nil, nil, nil, nil, events.Discard, nil, nil, nil, nil, &stdout, &stderr)
-		close(done)
-	}()
-
-	// Wait for initial reconcile.
-	for reconcileCount.Load() < 1 {
-		time.Sleep(5 * time.Millisecond)
+	cr := &CityRuntime{
+		cityPath:  dir,
+		cityName:  "test",
+		tomlPath:  tomlPath,
+		cfg:       cfg,
+		logPrefix: "gc start",
+		stdout:    &stdout,
+		stderr:    &stderr,
 	}
 
 	// Write invalid TOML.
 	if err := os.WriteFile(tomlPath, []byte("[[[ bad toml"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	lastProviderName := cfg.Session.Provider
+	reply := cr.reloadConfigTraced(context.Background(), &lastProviderName, dir, nil, reloadSourceWatch)
 
-	deadline := time.After(3 * time.Second)
-	for !strings.Contains(stderr.String(), "config reload") {
-		select {
-		case <-deadline:
-			t.Fatalf("timed out waiting for invalid config reload; reconciles=%d stdout=%q stderr=%q",
-				reconcileCount.Load(), stdout.String(), stderr.String())
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
+	if reply.Outcome != reloadOutcomeFailed {
+		t.Fatalf("reload outcome = %q, want %q; reply=%+v", reply.Outcome, reloadOutcomeFailed, reply)
 	}
-
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for controllerLoop to exit")
+	if reply.Error == "" {
+		t.Fatal("reload error empty, want parse error")
 	}
-
 	if !strings.Contains(stderr.String(), "config reload") {
 		t.Errorf("expected config reload error in stderr, got: %s", stderr.String())
 	}

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2161,6 +2161,7 @@ export interface components {
                 [key: string]: string;
             };
             needs?: string[] | null;
+            no_history?: boolean;
             parent?: string;
             /** Format: int64 */
             priority?: number;

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -266,6 +266,7 @@ export type Bead = {
         [key: string]: string;
     };
     needs?: Array<string> | null;
+    no_history?: boolean;
     parent?: string;
     priority?: number;
     ref?: string;

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1156,6 +1156,7 @@ func openStoreAtForCity(storePath, cityPath string) (beads.Store, error) {
 	if runtimeCityPath == "" {
 		runtimeCityPath = cityForStoreDir(storePath)
 	}
+	cfg, _ := loadCityConfig(runtimeCityPath, io.Discard)
 	scopeRoot := resolveStoreScopeRoot(runtimeCityPath, storePath)
 	provider := rawBeadsProviderForScope(scopeRoot, runtimeCityPath)
 	if strings.HasPrefix(provider, "exec:") {
@@ -1185,17 +1186,23 @@ func openStoreAtForCity(storePath, cityPath string) (beads.Store, error) {
 		}
 		store := beadsexec.NewStore(strings.TrimPrefix(provider, "exec:"))
 		store.SetEnv(env)
-		return store, nil
+		return wrapStoreWithBeadPolicies(store, cfg), nil
 	}
+	var store beads.Store
+	var err error
 	switch provider {
 	case "file":
-		return openCompatibleFileStore(scopeRoot, runtimeCityPath)
+		store, err = openCompatibleFileStore(scopeRoot, runtimeCityPath)
 	default: // "bd" or unrecognized → use bd
 		if _, err := exec.LookPath("bd"); err != nil {
 			return nil, fmt.Errorf("bd not found in PATH (install beads or set GC_BEADS=file)")
 		}
-		return openBdStoreAt(scopeRoot, runtimeCityPath)
+		store = openBdStoreAt(scopeRoot, runtimeCityPath)
 	}
+	if err != nil {
+		return nil, err
+	}
+	return wrapStoreWithBeadPolicies(store, cfg), nil
 }
 
 // resolveStoreScopeRoot resolves a store's scope root under cityPath.
@@ -1216,13 +1223,13 @@ func resolveStoreScopeRoot(cityPath, storePath string) string {
 	return filepath.Clean(scopeRoot)
 }
 
-func openBdStoreAt(storePath, cityPath string) (beads.Store, error) {
+func openBdStoreAt(storePath, cityPath string) beads.Store {
 	if filepath.Clean(storePath) == filepath.Clean(cityPath) {
-		return bdStoreForCity(storePath, cityPath), nil
+		return bdStoreForCity(storePath, cityPath)
 	}
 	cfg, err := loadCityConfig(cityPath, io.Discard)
 	if err != nil {
 		cfg = nil
 	}
-	return bdStoreForRig(storePath, cityPath, cfg), nil
+	return bdStoreForRig(storePath, cityPath, cfg)
 }

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	labelOrderTracking    = "order-tracking"
-	labelTriggerEnvFailed = "trigger-env-failed"
+	labelOrderTracking       = "gc:order-tracking"
+	legacyLabelOrderTracking = "order-tracking"
+	labelTriggerEnvFailed    = "trigger-env-failed"
 
 	orderTrackingSweepOrder                = "order-tracking-sweep"
 	defaultOrderTrackingSweepStaleAfter    = 10 * time.Minute
@@ -509,7 +510,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		// This prevents the cooldown trigger from re-firing on the next tick.
 		trackingBead, err := store.Create(beads.Bead{
 			Title:     "order:" + scoped,
-			Labels:    []string{"order-run:" + scoped, labelOrderTracking},
+			Labels:    orderTrackingLabels(scoped),
 			Ephemeral: true,
 		})
 		if err != nil {
@@ -1114,6 +1115,32 @@ func (m *memoryOrderDispatcher) rigSuspendedByName(rigName string) bool {
 // cooldown gate from pouring duplicate wisps when the pool stalls
 // (tr-kds01, where 24h-interval digest wisps accumulated because the
 // pool never picked them up).
+func orderTrackingLabels(scopedName string) []string {
+	return []string{"order-run:" + scopedName, labelOrderTracking}
+}
+
+func listOrderTrackingBeads(store beads.Store) ([]beads.Bead, error) {
+	entries := make([]beads.Bead, 0)
+	seen := make(map[string]struct{})
+	for _, label := range []string{labelOrderTracking, legacyLabelOrderTracking} {
+		items, err := store.ListByLabel(label, 0, beads.WithBothTiers)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items {
+			if item.ID == "" {
+				continue
+			}
+			if _, ok := seen[item.ID]; ok {
+				continue
+			}
+			seen[item.ID] = struct{}{}
+			entries = append(entries, item)
+		}
+	}
+	return entries, nil
+}
+
 func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
 	results, err := store.List(beads.ListQuery{
 		Label: "order-run:" + scopedName,
@@ -1218,7 +1245,7 @@ func sweepOrphanedOrderTracking(store beads.Store) (int, error) {
 	// ListByLabel without IncludeClosed returns only open beads.
 	// New tracking beads live in the wisps tier, but legacy issues-tier
 	// tracking beads may still exist after upgrade; sweep both.
-	all, err := store.ListByLabel(labelOrderTracking, 0, beads.WithBothTiers)
+	all, err := listOrderTrackingBeads(store)
 	if err != nil {
 		return 0, fmt.Errorf("listing order-tracking beads: %w", err)
 	}
@@ -1328,7 +1355,7 @@ func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, staleA
 	if includeWispSubtrees && len(onlyOrders) == 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("include-wisps requires at least one order name")
 	}
-	all, err := store.ListByLabel(labelOrderTracking, 0, beads.WithBothTiers)
+	all, err := listOrderTrackingBeads(store)
 	if err != nil {
 		return orderTrackingSweepResult{}, fmt.Errorf("listing order-tracking beads: %w", err)
 	}

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -6,17 +6,20 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
-// wispGC performs mechanical garbage collection of closed molecules that
-// have exceeded their TTL. Follows the nil-guard tracker pattern used by
-// crashTracker and idleTracker: nil means disabled.
+// wispGC performs mechanical garbage collection of closed GC-owned beads that
+// have exceeded their retention policy. Follows the nil-guard tracker pattern
+// used by crashTracker and idleTracker: nil means disabled.
 type wispGC interface {
 	// shouldRun returns true if enough time has elapsed since the last run.
 	shouldRun(now time.Time) bool
 
-	// runGC lists closed molecules, deletes those older than TTL, and returns
-	// the count of purged entries. Errors from individual deletes are
+	// runGC lists closed policy-owned beads, deletes those past retention, and
+	// returns the count of purged entries. Errors from individual deletes are
 	// best-effort and surfaced without stopping the purge; the returned error
 	// also covers list failures.
 	runGC(store beads.Store, now time.Time) (int, error)
@@ -25,19 +28,155 @@ type wispGC interface {
 // memoryWispGC is the production implementation of wispGC.
 type memoryWispGC struct {
 	interval time.Duration
-	ttl      time.Duration
+	policies []beadGCPolicy
 	lastRun  time.Time
 }
 
-// newWispGC creates a wisp GC tracker. Returns nil if disabled (interval or
-// TTL is zero). Callers nil-guard before use.
+type beadGCPolicy struct {
+	name     string
+	ttl      time.Duration
+	queries  []beads.ListQuery
+	deleteFn func(beads.Store, string) error
+}
+
+const (
+	beadPolicyWisp          = "wisp"
+	beadPolicyOrderTracking = "order_tracking"
+	beadPolicySession       = "session"
+	beadPolicyWait          = "wait"
+	beadPolicyNudge         = "nudge"
+)
+
+// newWispGC creates a legacy-compatible wisp GC tracker. Returns nil if
+// disabled (interval or TTL is zero). Callers nil-guard before use.
 func newWispGC(interval, ttl time.Duration) wispGC {
 	if interval <= 0 || ttl <= 0 {
 		return nil
 	}
+	return newWispGCWithPolicies(interval, legacyWispGCPolicies(ttl))
+}
+
+func newWispGCFromConfig(cfg *config.City) wispGC {
+	if cfg == nil {
+		return nil
+	}
+	interval := cfg.Daemon.WispGCIntervalDuration()
+	if interval <= 0 {
+		return nil
+	}
+	policies := configuredWispGCPolicies(cfg.Daemon.WispTTLDuration(), cfg.Beads.Policies)
+	return newWispGCWithPolicies(interval, policies)
+}
+
+func newWispGCWithPolicies(interval time.Duration, policies []beadGCPolicy) wispGC {
+	if interval <= 0 || len(policies) == 0 {
+		return nil
+	}
 	return &memoryWispGC{
 		interval: interval,
-		ttl:      ttl,
+		policies: policies,
+	}
+}
+
+func legacyWispGCPolicies(ttl time.Duration) []beadGCPolicy {
+	return []beadGCPolicy{
+		{
+			name: beadPolicyWisp,
+			ttl:  ttl,
+			queries: []beads.ListQuery{
+				{
+					Status:   "closed",
+					Label:    molecule.WispLabel,
+					TierMode: beads.TierBoth,
+				},
+				{
+					Status:   "closed",
+					Type:     "molecule",
+					TierMode: beads.TierBoth,
+				},
+			},
+			deleteFn: deleteExpiredBeadClosure,
+		},
+		{
+			name: beadPolicyOrderTracking,
+			ttl:  ttl,
+			queries: []beads.ListQuery{
+				{
+					Status:   "closed",
+					Label:    labelOrderTracking,
+					TierMode: beads.TierBoth,
+				},
+				{
+					Status:   "closed",
+					Label:    legacyLabelOrderTracking,
+					TierMode: beads.TierBoth,
+				},
+			},
+			deleteFn: deleteWorkflowBead,
+		},
+	}
+}
+
+func configuredWispGCPolicies(defaultTTL time.Duration, overrides map[string]config.BeadPolicyConfig) []beadGCPolicy {
+	specs := []beadGCPolicy{
+		legacyWispGCPolicies(defaultTTL)[0],
+		legacyWispGCPolicies(defaultTTL)[1],
+		{
+			name: beadPolicySession,
+			queries: []beads.ListQuery{
+				{
+					Status:   "closed",
+					Type:     session.BeadType,
+					Label:    session.LabelSession,
+					TierMode: beads.TierBoth,
+				},
+			},
+			deleteFn: deleteWorkflowBead,
+		},
+		{
+			name: beadPolicyWait,
+			queries: []beads.ListQuery{
+				{
+					Status:   "closed",
+					Label:    session.WaitBeadLabel,
+					TierMode: beads.TierBoth,
+				},
+			},
+			deleteFn: deleteWorkflowBead,
+		},
+		{
+			name: beadPolicyNudge,
+			queries: []beads.ListQuery{
+				{
+					Status:   "closed",
+					Label:    nudgeBeadLabel,
+					TierMode: beads.TierBoth,
+				},
+			},
+			deleteFn: deleteWorkflowBead,
+		},
+	}
+	policies := make([]beadGCPolicy, 0, len(specs))
+	for _, spec := range specs {
+		ttl := effectiveBeadGCPolicyTTL(spec.name, defaultTTL, overrides)
+		if ttl <= 0 {
+			continue
+		}
+		spec.ttl = ttl
+		policies = append(policies, spec)
+	}
+	return policies
+}
+
+func effectiveBeadGCPolicyTTL(name string, defaultTTL time.Duration, overrides map[string]config.BeadPolicyConfig) time.Duration {
+	if policy, ok := overrides[name]; ok && policy.DeleteAfterClose != "" {
+		return policy.DeleteAfterCloseDuration()
+	}
+	switch name {
+	case beadPolicyWisp, beadPolicyOrderTracking:
+		return defaultTTL
+	default:
+		return 0
 	}
 }
 
@@ -48,33 +187,35 @@ func (m *memoryWispGC) shouldRun(now time.Time) bool {
 func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 	m.lastRun = now
 	if store == nil {
-		return 0, fmt.Errorf("listing closed molecules: bead store unavailable")
+		return 0, fmt.Errorf("listing closed GC policy beads: bead store unavailable")
 	}
 
-	entries, err := closedWispGCEntries(store)
-	if err != nil {
-		return 0, err
+	purged := 0
+	var runErr error
+	for _, policy := range m.policies {
+		cutoff := now.Add(-policy.ttl)
+		entries, err := policy.list(store, cutoff)
+		if err != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("listing closed %s beads: %w", policy.name, err))
+			continue
+		}
+		policyPurged, deleteErr := purgeExpiredBeads(store, entries, cutoff, policy.deleteFn)
+		purged += policyPurged
+		runErr = errors.Join(runErr, deleteErr)
 	}
 
-	cutoff := now.Add(-m.ttl)
-	purged, deleteErr := purgeExpiredBeadClosures(store, entries, cutoff)
-
-	trackEntries, trackErr := store.List(beads.ListQuery{Status: "closed", Label: labelOrderTracking, TierMode: beads.TierBoth})
-	if trackErr == nil {
-		trackPurged, trackDeleteErr := purgeExpiredBeadRoots(store, trackEntries, cutoff)
-		purged += trackPurged
-		deleteErr = errors.Join(deleteErr, trackDeleteErr)
-	} else {
-		deleteErr = errors.Join(deleteErr, fmt.Errorf("listing closed order-tracking beads: %w", trackErr))
-	}
-
-	return purged, deleteErr
+	return purged, runErr
 }
 
-func closedWispGCEntries(store beads.Store) ([]beads.Bead, error) {
+func (p beadGCPolicy) list(store beads.Store, cutoff time.Time) ([]beads.Bead, error) {
 	entries := make([]beads.Bead, 0)
 	seen := make(map[string]struct{})
-	appendUnique := func(items []beads.Bead) {
+	for _, query := range p.queries {
+		query.ClosedBefore = cutoff
+		items, err := store.List(query)
+		if err != nil {
+			return nil, err
+		}
 		for _, item := range items {
 			if item.ID == "" {
 				continue
@@ -86,32 +227,14 @@ func closedWispGCEntries(store beads.Store) ([]beads.Bead, error) {
 			entries = append(entries, item)
 		}
 	}
-	molecules, err := store.List(beads.ListQuery{Status: "closed", Type: "molecule"})
-	if err != nil {
-		return nil, fmt.Errorf("listing closed molecule roots: %w", err)
-	}
-	appendUnique(molecules)
-	wisps, err := store.List(beads.ListQuery{Status: "closed", Metadata: map[string]string{"gc.kind": "wisp"}})
-	if err != nil {
-		return nil, fmt.Errorf("listing closed wisp roots: %w", err)
-	}
-	appendUnique(wisps)
 	return entries, nil
-}
-
-func purgeExpiredBeadClosures(store beads.Store, entries []beads.Bead, cutoff time.Time) (int, error) {
-	return purgeExpiredBeads(store, entries, cutoff, deleteExpiredBeadClosure)
-}
-
-func purgeExpiredBeadRoots(store beads.Store, entries []beads.Bead, cutoff time.Time) (int, error) {
-	return purgeExpiredBeads(store, entries, cutoff, deleteWorkflowBead)
 }
 
 func purgeExpiredBeads(store beads.Store, entries []beads.Bead, cutoff time.Time, deleteFn func(beads.Store, string) error) (int, error) {
 	purged := 0
 	var deleteErr error
 	for _, entry := range entries {
-		if entry.CreatedAt.IsZero() || !entry.CreatedAt.Before(cutoff) {
+		if entry.ClosedAt.IsZero() || !entry.ClosedAt.Before(cutoff) {
 			continue
 		}
 		if err := deleteFn(store, entry.ID); err != nil {

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 func TestWispGC_NilSafe(t *testing.T) {
@@ -51,7 +54,7 @@ func TestWispGC_PurgesExpiredMolecules(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
 		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
-		makeGCBeadWithMetadata("wisp-1", now.Add(-2*time.Hour), "closed", "task", map[string]string{"gc.kind": "wisp"}),
+		makeGCBeadWithLabels("labeled-wisp-1", now.Add(-2*time.Hour), "closed", "task", molecule.WispLabel),
 		makeGCBead("mol-2", now.Add(-30*time.Minute), "closed", "molecule"),
 		makeGCBead("mol-3", now.Add(-3*time.Hour), "closed", "molecule"),
 	})
@@ -64,7 +67,7 @@ func TestWispGC_PurgesExpiredMolecules(t *testing.T) {
 	if purged != 3 {
 		t.Fatalf("purged = %d, want 3", purged)
 	}
-	assertDeletedIDs(t, store.deletedIDs, "mol-1", "wisp-1", "mol-3")
+	assertDeletedIDs(t, store.deletedIDs, "labeled-wisp-1", "mol-1", "mol-3")
 }
 
 func TestWispGC_NothingExpired(t *testing.T) {
@@ -83,6 +86,75 @@ func TestWispGC_NothingExpired(t *testing.T) {
 	}
 	if len(store.deletedIDs) != 0 {
 		t.Fatalf("deleted = %v, want none", store.deletedIDs)
+	}
+}
+
+func TestWispGC_UsesClosedAtNotCreatedAt(t *testing.T) {
+	now := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	store := newGCStore([]beads.Bead{
+		{
+			ID:        "created-old-closed-new",
+			Status:    "closed",
+			Type:      "molecule",
+			CreatedAt: now.Add(-48 * time.Hour),
+			ClosedAt:  now.Add(-10 * time.Minute),
+		},
+		{
+			ID:        "created-new-closed-old",
+			Status:    "closed",
+			Type:      "molecule",
+			CreatedAt: now.Add(-10 * time.Minute),
+			ClosedAt:  now.Add(-48 * time.Hour),
+		},
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "created-new-closed-old")
+	if _, err := store.Get("created-old-closed-new"); err != nil {
+		t.Fatalf("newly closed old bead was deleted: %v", err)
+	}
+}
+
+func TestWispGC_ConfiguredPoliciesDeleteAllowlistedSessionWaitAndNudgeBeads(t *testing.T) {
+	now := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	store := newGCStore([]beads.Bead{
+		makeClosedGCBeadWithLabels("session-old", now.Add(-48*time.Hour), "session", session.LabelSession),
+		makeClosedGCBeadWithLabels("wait-old", now.Add(-48*time.Hour), session.WaitBeadType, session.WaitBeadLabel),
+		makeClosedGCBeadWithLabels("nudge-old", now.Add(-48*time.Hour), "chore", nudgeBeadLabel),
+		makeClosedGCBeadWithLabels("session-new", now.Add(-10*time.Minute), "session", session.LabelSession),
+		makeClosedGCBeadWithLabels("user-old", now.Add(-48*time.Hour), "task", "user-label"),
+	})
+	wg := newWispGCFromConfig(&config.City{
+		Daemon: config.DaemonConfig{WispGCInterval: "5m"},
+		Beads: config.BeadsConfig{Policies: map[string]config.BeadPolicyConfig{
+			"session": {DeleteAfterClose: "24h"},
+			"wait":    {DeleteAfterClose: "24h"},
+			"nudge":   {DeleteAfterClose: "24h"},
+		}},
+	})
+	if wg == nil {
+		t.Fatal("newWispGCFromConfig returned nil")
+	}
+
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 3 {
+		t.Fatalf("purged = %d, want 3", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "nudge-old", "session-old", "wait-old")
+	for _, id := range []string{"session-new", "user-old"} {
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("%s was incorrectly deleted: %v", id, err)
+		}
 	}
 }
 
@@ -373,7 +445,8 @@ func TestWispGC_PurgesLegacyIssuesTierTrackingBeads(t *testing.T) {
 			Status:    "closed",
 			Type:      "task",
 			CreatedAt: now.Add(-3 * time.Hour),
-			Labels:    []string{labelOrderTracking},
+			ClosedAt:  now.Add(-3 * time.Hour),
+			Labels:    []string{legacyLabelOrderTracking},
 		},
 	})
 
@@ -451,6 +524,43 @@ func TestWispGC_ListErrorFailsRun(t *testing.T) {
 	}
 }
 
+func TestWispGC_QueriesUseClosedBeforeAndIndexedOwnershipLabels(t *testing.T) {
+	now := time.Now()
+	store := newGCStore(nil)
+
+	wg := newWispGC(5*time.Minute, time.Hour)
+	if _, err := wg.runGC(store, now); err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+
+	wantCutoff := now.Add(-time.Hour)
+	seen := map[string]bool{}
+	for _, query := range store.listQueries {
+		if !query.ClosedBefore.Equal(wantCutoff) {
+			t.Fatalf("ClosedBefore = %s, want %s in query %+v", query.ClosedBefore, wantCutoff, query)
+		}
+		if len(query.Metadata) != 0 {
+			t.Fatalf("query used metadata filter on hot GC path: %+v", query)
+		}
+		switch {
+		case query.Label != "":
+			seen["label:"+query.Label] = true
+		case query.Type != "":
+			seen["type:"+query.Type] = true
+		}
+	}
+	for _, key := range []string{
+		"label:" + molecule.WispLabel,
+		"label:" + labelOrderTracking,
+		"label:" + legacyLabelOrderTracking,
+		"type:molecule",
+	} {
+		if !seen[key] {
+			t.Fatalf("missing GC query %s; got %+v", key, store.listQueries)
+		}
+	}
+}
+
 type gcQueryKey struct {
 	Status   string
 	Type     string
@@ -461,6 +571,7 @@ type gcQueryKey struct {
 type gcTestStore struct {
 	*beads.MemStore
 	listErrors   map[gcQueryKey]error
+	listQueries  []beads.ListQuery
 	deleteErrors map[string]error
 	deletedIDs   []string
 }
@@ -474,6 +585,7 @@ func newGCStore(existing []beads.Bead) *gcTestStore {
 }
 
 func (s *gcTestStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.listQueries = append(s.listQueries, query)
 	if err := s.listErrors[gcQueryKey{Status: query.Status, Type: query.Type, Label: query.Label, Metadata: metadataQueryKey(query.Metadata)}]; err != nil {
 		return nil, err
 	}
@@ -511,15 +623,36 @@ func makeGCBeadWithLabels(id string, createdAt time.Time, status, beadType strin
 		Status:    status,
 		Type:      beadType,
 		CreatedAt: createdAt,
+		ClosedAt:  closedAtForStatus(status, createdAt),
 		Labels:    labels,
 		Ephemeral: ephemeral,
 	}
 }
 
-func makeGCBeadWithMetadata(id string, createdAt time.Time, status, beadType string, metadata map[string]string) beads.Bead {
-	bead := makeGCBead(id, createdAt, status, beadType)
-	bead.Metadata = metadata
-	return bead
+func makeClosedGCBeadWithLabels(id string, closedAt time.Time, beadType string, labels ...string) beads.Bead {
+	ephemeral := false
+	for _, l := range labels {
+		if l == labelOrderTracking {
+			ephemeral = true
+			break
+		}
+	}
+	return beads.Bead{
+		ID:        id,
+		Status:    "closed",
+		Type:      beadType,
+		CreatedAt: closedAt.Add(-time.Hour),
+		ClosedAt:  closedAt,
+		Labels:    labels,
+		Ephemeral: ephemeral,
+	}
+}
+
+func closedAtForStatus(status string, createdAt time.Time) time.Time {
+	if status != "closed" {
+		return time.Time{}
+	}
+	return createdAt
 }
 
 func metadataQueryKey(metadata map[string]string) string {

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -242,6 +242,15 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `scale_check` | string |  |  | ScaleCheck overrides the command template whose output reports new unassigned session demand for bead-backed reconciliation. Supports the same Go template placeholders as Agent.scale_check. |
 | `option_defaults` | map[string]string |  |  | OptionDefaults adds or overrides provider option defaults for this agent. Keys are option keys, values are choice values. Merges additively (patch keys win over existing agent keys). Example: option_defaults = &#123; model = "sonnet" &#125; |
 
+## BeadPolicyConfig
+
+BeadPolicyConfig holds storage and retention defaults for a named bead use.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `storage` | string |  |  | Storage selects the intended persistence tier: "history", "no_history", or "ephemeral". Creation paths apply this incrementally as they opt in. Enum: `history`, `no_history`, `ephemeral` |
+| `delete_after_close` | string |  |  | DeleteAfterClose deletes matching GC-owned beads after they have been closed for this duration. Empty means the policy is not GC-managed. |
+
 ## BeadsConfig
 
 BeadsConfig holds bead store settings.
@@ -249,6 +258,7 @@ BeadsConfig holds bead store settings.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `provider` | string |  | `bd` | Provider selects the bead store backend: "bd" (default), "file", or "exec:&lt;script&gt;" for a user-supplied script. |
+| `policies` | map[string]BeadPolicyConfig |  |  | Policies defines per-bead-use storage and garbage-collection defaults. Policy names are interpreted by higher-level systems; unknown names are preserved so packs can stage future policy classes without breaking load. |
 
 ## ChatSessionsConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -910,12 +910,39 @@
       ],
       "description": "AgentPatch modifies an existing agent identified by (Dir, Name)."
     },
+    "BeadPolicyConfig": {
+      "properties": {
+        "storage": {
+          "type": "string",
+          "enum": [
+            "history",
+            "no_history",
+            "ephemeral"
+          ],
+          "description": "Storage selects the intended persistence tier: \"history\", \"no_history\",\nor \"ephemeral\". Creation paths apply this incrementally as they opt in."
+        },
+        "delete_after_close": {
+          "type": "string",
+          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Empty means the policy is not GC-managed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "BeadPolicyConfig holds storage and retention defaults for a named bead use."
+    },
     "BeadsConfig": {
       "properties": {
         "provider": {
           "type": "string",
           "description": "Provider selects the bead store backend: \"bd\" (default), \"file\",\nor \"exec:\u003cscript\u003e\" for a user-supplied script.",
           "default": "bd"
+        },
+        "policies": {
+          "additionalProperties": {
+            "$ref": "#/$defs/BeadPolicyConfig"
+          },
+          "type": "object",
+          "description": "Policies defines per-bead-use storage and garbage-collection defaults.\nPolicy names are interpreted by higher-level systems; unknown names are\npreserved so packs can stage future policy classes without breaking load."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -910,12 +910,39 @@
       ],
       "description": "AgentPatch modifies an existing agent identified by (Dir, Name)."
     },
+    "BeadPolicyConfig": {
+      "properties": {
+        "storage": {
+          "type": "string",
+          "enum": [
+            "history",
+            "no_history",
+            "ephemeral"
+          ],
+          "description": "Storage selects the intended persistence tier: \"history\", \"no_history\",\nor \"ephemeral\". Creation paths apply this incrementally as they opt in."
+        },
+        "delete_after_close": {
+          "type": "string",
+          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Empty means the policy is not GC-managed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "BeadPolicyConfig holds storage and retention defaults for a named bead use."
+    },
     "BeadsConfig": {
       "properties": {
         "provider": {
           "type": "string",
           "description": "Provider selects the bead store backend: \"bd\" (default), \"file\",\nor \"exec:\u003cscript\u003e\" for a user-supplied script.",
           "default": "bd"
+        },
+        "policies": {
+          "additionalProperties": {
+            "$ref": "#/$defs/BeadPolicyConfig"
+          },
+          "type": "object",
+          "description": "Policies defines per-bead-use storage and garbage-collection defaults.\nPolicy names are interpreted by higher-level systems; unknown names are\npreserved so packs can stage future policy classes without breaking load."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -806,6 +806,10 @@
           "assignee": {
             "type": "string"
           },
+          "closed_at": {
+            "format": "date-time",
+            "type": "string"
+          },
           "created_at": {
             "format": "date-time",
             "type": "string"

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -806,6 +806,10 @@
           "assignee": {
             "type": "string"
           },
+          "closed_at": {
+            "format": "date-time",
+            "type": "string"
+          },
           "created_at": {
             "format": "date-time",
             "type": "string"

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -501,6 +501,7 @@ type AsyncAcceptedResponse struct {
 // Bead defines model for Bead.
 type Bead struct {
 	Assignee     *string            `json:"assignee,omitempty"`
+	ClosedAt     *time.Time         `json:"closed_at,omitempty"`
 	CreatedAt    time.Time          `json:"created_at"`
 	Dependencies *[]Dep             `json:"dependencies,omitempty"`
 	Description  *string            `json:"description,omitempty"`

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -806,6 +806,10 @@
           "assignee": {
             "type": "string"
           },
+          "closed_at": {
+            "format": "date-time",
+            "type": "string"
+          },
           "created_at": {
             "format": "date-time",
             "type": "string"

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -467,17 +467,19 @@ type bdIssue struct {
 	IssueType    string       `json:"issue_type"`
 	Priority     *int         `json:"priority,omitempty"`
 	CreatedAt    time.Time    `json:"created_at"`
+	UpdatedAt    *time.Time   `json:"updated_at,omitempty"`
+	ClosedAt     *time.Time   `json:"closed_at,omitempty"`
 	Assignee     string       `json:"assignee"`
 	From         string       `json:"from"`
 	ParentID     string       `json:"parent"`
-	Ephemeral    bool         `json:"ephemeral"`
-	NoHistory    bool         `json:"no_history"`
 	Ref          string       `json:"ref"`
 	Needs        []string     `json:"needs"`
 	Description  string       `json:"description"`
 	Labels       []string     `json:"labels"`
 	Metadata     StringMap    `json:"metadata,omitempty"`
 	Dependencies []bdIssueDep `json:"dependencies,omitempty"`
+	Ephemeral    bool         `json:"ephemeral,omitempty"`
+	NoHistory    bool         `json:"no_history,omitempty"`
 }
 
 type bdIssueDep struct {
@@ -586,7 +588,7 @@ func (b *bdIssue) toBead() Bead {
 			}
 		}
 	}
-	return Bead{
+	bead := Bead{
 		ID:           b.ID,
 		Title:        b.Title,
 		Status:       mapBdStatus(b.Status),
@@ -605,6 +607,13 @@ func (b *bdIssue) toBead() Bead {
 		Metadata:     b.Metadata,
 		Dependencies: deps,
 	}
+	if b.UpdatedAt != nil {
+		bead.UpdatedAt = b.UpdatedAt.Truncate(time.Second)
+	}
+	if b.ClosedAt != nil {
+		bead.ClosedAt = b.ClosedAt.Truncate(time.Second)
+	}
+	return bead
 }
 
 func (b *bdIssue) normalizedDependencies() []Dep {
@@ -1468,6 +1477,12 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	if !query.CreatedBefore.IsZero() {
 		args = append(args, "--created-before", query.CreatedBefore.Format(time.RFC3339Nano))
 	}
+	if !query.UpdatedBefore.IsZero() {
+		args = append(args, "--updated-before", query.UpdatedBefore.Format(time.RFC3339Nano))
+	}
+	if !query.ClosedBefore.IsZero() {
+		args = append(args, "--closed-before", query.ClosedBefore.Format(time.RFC3339Nano))
+	}
 	args = append(args, "--include-infra", "--include-gates", "--limit", fmt.Sprintf("%d", limit))
 	if query.ParentID != "" {
 		args = append(args, "--parent", query.ParentID)
@@ -1519,6 +1534,9 @@ func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
 	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "type", query.Type)
 	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "assignee", query.Assignee)
 	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "parent", query.ParentID)
+	clauses, serverFilteredOnly = appendBdQueryBeforeClause(clauses, serverFilteredOnly, "created", query.CreatedBefore)
+	clauses, serverFilteredOnly = appendBdQueryBeforeClause(clauses, serverFilteredOnly, "updated", query.UpdatedBefore)
+	clauses, serverFilteredOnly = appendBdQueryBeforeClause(clauses, serverFilteredOnly, "closed", query.ClosedBefore)
 
 	args := []string{"query", "--json", strings.Join(clauses, " AND ")}
 	if query.IncludeClosed || query.Status == "closed" {
@@ -1555,7 +1573,7 @@ func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
 }
 
 func canApplyWispsServerLimit(query ListQuery) bool {
-	return query.Sort == SortDefault && query.CreatedBefore.IsZero() && len(query.Metadata) == 0
+	return query.Sort == SortDefault && len(query.Metadata) == 0
 }
 
 func appendBdQueryClause(clauses []string, serverFilteredOnly bool, field, value string) ([]string, bool) {
@@ -1566,6 +1584,17 @@ func appendBdQueryClause(clauses []string, serverFilteredOnly bool, field, value
 		return clauses, false
 	}
 	return append(clauses, field+"="+value), serverFilteredOnly
+}
+
+func appendBdQueryBeforeClause(clauses []string, serverFilteredOnly bool, field string, before time.Time) ([]string, bool) {
+	if before.IsZero() {
+		return clauses, serverFilteredOnly
+	}
+	value := before.Format(time.RFC3339Nano)
+	if !isBareBdQueryValue(value) {
+		return clauses, false
+	}
+	return append(clauses, field+"<"+value), serverFilteredOnly
 }
 
 // isBareBdQueryValue reports whether value can be emitted unquoted into the bd
@@ -1637,8 +1666,9 @@ func (s *BdStore) listBothTiers(query ListQuery) ([]Bead, error) {
 		return merged, fmt.Errorf("bd list both tiers: issues tier: %w", issuesErr)
 	case wispsErr != nil:
 		return merged, fmt.Errorf("bd list both tiers: wisps tier: %w", wispsErr)
+	default:
+		return merged, nil
 	}
-	return merged, nil
 }
 
 // ListOpen returns non-closed beads via bd list. Pass a status to filter further.

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2975,12 +2975,6 @@ func TestBdStoreApplyGraphPlanInheritsNoHistoryDefault(t *testing.T) {
 	if got := result.IDs["root"]; got != "bd-1" {
 		t.Fatalf("result ID = %q, want bd-1", got)
 	}
-	if !capturedPlan.NoHistory {
-		t.Fatalf("capturedPlan.NoHistory = false, want true")
-	}
-	if capturedPlan.Ephemeral {
-		t.Fatalf("capturedPlan.Ephemeral = true, want false")
-	}
 	args := strings.Join(gotArgs, " ")
 	if !strings.Contains(args, "--no-history") {
 		t.Fatalf("args = %q, want --no-history", args)

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -26,6 +26,7 @@ type Bead struct {
 	CreatedAt time.Time `json:"created_at"`
 	// UpdatedAt is zero for legacy beads; UpdatedBefore falls back to CreatedAt.
 	UpdatedAt    time.Time         `json:"updated_at,omitempty,omitzero"`
+	ClosedAt     time.Time         `json:"closed_at,omitempty,omitzero"`
 	Assignee     string            `json:"assignee,omitempty"`
 	From         string            `json:"from,omitempty"`
 	ParentID     string            `json:"parent,omitempty"`      // step → molecule; matches bd wire format

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -154,7 +154,7 @@ func (w *beadWire) toBead() beads.Bead {
 		cloned := *w.Priority
 		priority = &cloned
 	}
-	return beads.Bead{
+	bead := beads.Bead{
 		ID:          w.ID,
 		Title:       w.Title,
 		Status:      w.Status,
@@ -170,7 +170,15 @@ func (w *beadWire) toBead() beads.Bead {
 		Labels:      w.Labels,
 		Metadata:    coerceMetadata(w.Metadata),
 		Ephemeral:   w.Ephemeral,
+		NoHistory:   w.NoHistory,
 	}
+	if w.UpdatedAt != nil {
+		bead.UpdatedAt = *w.UpdatedAt
+	}
+	if w.ClosedAt != nil {
+		bead.ClosedAt = *w.ClosedAt
+	}
+	return bead
 }
 
 // coerceMetadata converts raw JSON metadata values to strings. Backing stores
@@ -308,7 +316,7 @@ func (s *Store) List(query beads.ListQuery) ([]beads.Bead, error) {
 		if query.Type != "" {
 			args = append(args, "--type="+query.Type)
 		}
-		if query.Limit > 0 && query.CreatedBefore.IsZero() {
+		if query.Limit > 0 && query.CreatedBefore.IsZero() && query.UpdatedBefore.IsZero() && query.ClosedBefore.IsZero() {
 			args = append(args, "--limit="+strconv.Itoa(query.Limit))
 		}
 		out, err = s.run(nil, args...)

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -206,6 +206,50 @@ func TestCreate_ephemeralRoundTripsThroughConformanceScript(t *testing.T) {
 	}
 }
 
+func TestCreate_noHistoryRoundTripsThroughConformanceScript(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available")
+	}
+	scriptPath, err := filepath.Abs(filepath.Join("testdata", "conformance.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(scriptPath)
+	s.SetEnv(storeTargetEnv(t.TempDir()))
+
+	created, err := s.Create(beads.Bead{
+		Title:     "session bead",
+		Type:      "session",
+		Labels:    []string{"gc:session"},
+		NoHistory: true,
+	})
+	if err != nil {
+		t.Fatalf("Create(no-history): %v", err)
+	}
+	if !created.NoHistory {
+		t.Fatalf("created.NoHistory = false, want true")
+	}
+	if created.Ephemeral {
+		t.Fatalf("created.Ephemeral = true, want false")
+	}
+	got, err := s.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get(no-history): %v", err)
+	}
+	if !got.NoHistory || got.Ephemeral {
+		t.Fatalf("Get(%s) = %+v, want no_history without ephemeral", created.ID, got)
+	}
+
+	listed, err := s.ListByLabel("gc:session", 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != created.ID || !listed[0].NoHistory {
+		t.Fatalf("ListByLabel = %+v, want no-history session", listed)
+	}
+}
+
 func TestCreate_metadataReachesScript(t *testing.T) {
 	dir := t.TempDir()
 	outFile := filepath.Join(dir, "stdin.json")

--- a/internal/beads/exec/json.go
+++ b/internal/beads/exec/json.go
@@ -26,6 +26,7 @@ type createRequest struct {
 	From        string            `json:"from,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 	Ephemeral   bool              `json:"ephemeral,omitempty"`
+	NoHistory   bool              `json:"no_history,omitempty"`
 }
 
 // updateRequest is the JSON wire format sent on stdin for update operations.
@@ -56,6 +57,8 @@ type beadWire struct {
 	Type        string                     `json:"type"`
 	Priority    *int                       `json:"priority,omitempty"`
 	CreatedAt   time.Time                  `json:"created_at"`
+	UpdatedAt   *time.Time                 `json:"updated_at,omitempty"`
+	ClosedAt    *time.Time                 `json:"closed_at,omitempty"`
 	Assignee    string                     `json:"assignee"`
 	From        string                     `json:"from"`
 	ParentID    string                     `json:"parent_id"`
@@ -65,6 +68,7 @@ type beadWire struct {
 	Labels      []string                   `json:"labels"`
 	Metadata    map[string]json.RawMessage `json:"metadata,omitempty"`
 	Ephemeral   bool                       `json:"ephemeral,omitempty"`
+	NoHistory   bool                       `json:"no_history,omitempty"`
 }
 
 // marshalCreate converts a Bead to JSON for the exec script's create operation.
@@ -82,6 +86,7 @@ func marshalCreate(b beads.Bead) ([]byte, error) {
 		From:        b.From,
 		Metadata:    b.Metadata,
 		Ephemeral:   b.Ephemeral,
+		NoHistory:   b.NoHistory,
 	}
 	return json.Marshal(r)
 }

--- a/internal/beads/exec/testdata/conformance.sh
+++ b/internal/beads/exec/testdata/conformance.sh
@@ -85,6 +85,11 @@ create)
 	ref=$(echo "$input" | jq -r '.ref // ""')
 	description=$(echo "$input" | jq -r '.description // ""')
 	ephemeral=$(echo "$input" | jq -r '.ephemeral // false')
+	no_history=$(echo "$input" | jq -r '.no_history // false')
+	if [[ "$ephemeral" == "true" && "$no_history" == "true" ]]; then
+		echo "ephemeral and no_history are mutually exclusive" >&2
+		exit 1
+	fi
 	created_at=$(now)
 
 	# Build labels array from input, including metadata as meta: labels.
@@ -113,6 +118,7 @@ create)
 		--arg description "$description" \
 		--argjson labels "$labels" \
 		--argjson ephemeral "$ephemeral" \
+		--argjson no_history "$no_history" \
 		'{
         id: $id,
         title: $title,
@@ -126,7 +132,8 @@ create)
         needs: $needs,
         description: $description,
         labels: $labels,
-        ephemeral: $ephemeral
+        ephemeral: $ephemeral,
+        no_history: $no_history
       }' >"$STATE_ROOT/$id.json"
 
 	# Output the created bead (normalized: meta: labels → .metadata map).

--- a/internal/beads/graph_apply.go
+++ b/internal/beads/graph_apply.go
@@ -16,10 +16,14 @@ type GraphApplyStore interface {
 // Keys are caller-defined stable identifiers (for example recipe step IDs).
 type GraphApplyPlan struct {
 	CommitMessage string           `json:"commit_message,omitempty"`
-	Ephemeral     bool             `json:"ephemeral,omitempty"`
-	NoHistory     bool             `json:"no_history,omitempty"`
 	Nodes         []GraphApplyNode `json:"nodes"`
 	Edges         []GraphApplyEdge `json:"edges,omitempty"`
+	// Ephemeral applies Beads' --ephemeral graph-create storage mode to every
+	// node. It is transported as a bd CLI flag, not as part of the graph JSON.
+	Ephemeral bool `json:"-"`
+	// NoHistory applies Beads' --no-history graph-create storage mode to every
+	// node. It is transported as a bd CLI flag, not as part of the graph JSON.
+	NoHistory bool `json:"-"`
 }
 
 // EphemeralGraphApplyStore reports whether a GraphApplyStore can create an

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -21,8 +21,8 @@ const (
 	SortCreatedDesc SortOrder = "created_desc"
 )
 
-// TierMode selects which storage tier(s) a List query reads from.
-// The zero value is TierIssues.
+// TierMode selects which storage tier(s) a List query reads from. The zero
+// value is TierIssues.
 //
 // For BdStore, where issues and wisps live in physically separate Dolt
 // tables, TierIssues is naturally tier-restricted by the underlying
@@ -34,9 +34,9 @@ const (
 type TierMode int
 
 const (
-	// TierIssues reads only the permanent (issues) tier. Default.
+	// TierIssues reads only the permanent issues tier. Default.
 	TierIssues TierMode = iota
-	// TierWisps reads only the ephemeral (wisps) tier.
+	// TierWisps reads only the ephemeral wisps tier.
 	TierWisps
 	// TierBoth unions the issues and wisps tiers, deduping by ID and
 	// preserving the query's sort.
@@ -72,6 +72,7 @@ type ListQuery struct {
 	// Legacy beads with zero UpdatedAt fall back to CreatedAt. Purge callers
 	// using CachingStore must also set Live: true to avoid stale cached timestamps.
 	UpdatedBefore time.Time
+	ClosedBefore  time.Time
 	Limit         int
 	IncludeClosed bool
 	AllowScan     bool
@@ -113,7 +114,8 @@ func (q ListQuery) HasFilter() bool {
 		q.ParentID != "" ||
 		len(q.Metadata) > 0 ||
 		!q.CreatedBefore.IsZero() ||
-		!q.UpdatedBefore.IsZero()
+		!q.UpdatedBefore.IsZero() ||
+		!q.ClosedBefore.IsZero()
 }
 
 // IncludesClosed reports whether the query may return closed beads.
@@ -161,6 +163,9 @@ func (q ListQuery) Matches(b Bead) bool {
 		return false
 	}
 	if !q.UpdatedBefore.IsZero() && !beadUpdatedReferenceTime(b).Before(q.UpdatedBefore) {
+		return false
+	}
+	if !q.ClosedBefore.IsZero() && (b.ClosedAt.IsZero() || !b.ClosedAt.Before(q.ClosedBefore)) {
 		return false
 	}
 	return true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1159,6 +1159,59 @@ type BeadsConfig struct {
 	// Provider selects the bead store backend: "bd" (default), "file",
 	// or "exec:<script>" for a user-supplied script.
 	Provider string `toml:"provider,omitempty" jsonschema:"default=bd"`
+	// Policies defines per-bead-use storage and garbage-collection defaults.
+	// Policy names are interpreted by higher-level systems; unknown names are
+	// preserved so packs can stage future policy classes without breaking load.
+	Policies map[string]BeadPolicyConfig `toml:"policies,omitempty"`
+}
+
+// BeadPolicyConfig holds storage and retention defaults for a named bead use.
+type BeadPolicyConfig struct {
+	// Storage selects the intended persistence tier: "history", "no_history",
+	// or "ephemeral". Creation paths apply this incrementally as they opt in.
+	Storage string `toml:"storage,omitempty" jsonschema:"enum=history,enum=no_history,enum=ephemeral"`
+	// DeleteAfterClose deletes matching GC-owned beads after they have been
+	// closed for this duration. Empty means the policy is not GC-managed.
+	DeleteAfterClose string `toml:"delete_after_close,omitempty"`
+}
+
+const (
+	// BeadStorageHistory stores beads in the normal history-tracked table.
+	BeadStorageHistory = "history"
+	// BeadStorageNoHistory stores beads without Dolt history while keeping
+	// non-ephemeral semantics.
+	BeadStorageNoHistory = "no_history"
+	// BeadStorageEphemeral stores beads as ephemeral wisps.
+	BeadStorageEphemeral = "ephemeral"
+)
+
+// NormalizeBeadPolicyStorage canonicalizes a bead policy storage value.
+func NormalizeBeadPolicyStorage(storage string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(storage)), "-", "_")
+}
+
+// ValidBeadPolicyStorage reports whether storage is one of the supported
+// Beads storage classes. Empty storage is valid and means use the default.
+func ValidBeadPolicyStorage(storage string) bool {
+	switch NormalizeBeadPolicyStorage(storage) {
+	case "", BeadStorageHistory, BeadStorageNoHistory, BeadStorageEphemeral:
+		return true
+	default:
+		return false
+	}
+}
+
+// DeleteAfterCloseDuration returns DeleteAfterClose as a duration. The parser
+// accepts Go durations plus whole-day "d" units, e.g. "7d" and "1d12h".
+func (p BeadPolicyConfig) DeleteAfterCloseDuration() time.Duration {
+	if p.DeleteAfterClose == "" {
+		return 0
+	}
+	dur, err := parseConfigDurationWithDays(p.DeleteAfterClose)
+	if err != nil {
+		return 0
+	}
+	return dur
 }
 
 // SessionConfig holds session provider settings.
@@ -2086,7 +2139,7 @@ func (d *DaemonConfig) WispTTLDuration() time.Duration {
 	if d.WispTTL == "" {
 		return 0
 	}
-	dur, err := time.ParseDuration(d.WispTTL)
+	dur, err := parseConfigDurationWithDays(d.WispTTL)
 	if err != nil {
 		return 0
 	}
@@ -2097,6 +2150,47 @@ func (d *DaemonConfig) WispTTLDuration() time.Duration {
 // and wisp_ttl must be set to non-zero durations.
 func (d *DaemonConfig) WispGCEnabled() bool {
 	return d.WispGCIntervalDuration() > 0 && d.WispTTLDuration() > 0
+}
+
+// parseConfigDurationWithDays extends time.ParseDuration with a whole-day "d"
+// unit. It accepts ordinary Go durations unchanged and supports one leading day
+// component such as "7d" or "1d12h".
+func parseConfigDurationWithDays(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	dayIdx := strings.IndexByte(raw, 'd')
+	if dayIdx < 0 {
+		return time.ParseDuration(raw)
+	}
+	days, err := parsePositiveDurationDays(raw[:dayIdx])
+	if err != nil {
+		return 0, err
+	}
+	rest := raw[dayIdx+1:]
+	if rest == "" {
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	dur, err := time.ParseDuration(rest)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(days)*24*time.Hour + dur, nil
+}
+
+func parsePositiveDurationDays(raw string) (int64, error) {
+	if raw == "" {
+		return 0, fmt.Errorf("missing day count")
+	}
+	var days int64
+	for _, r := range raw {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("invalid day count %q", raw)
+		}
+		days = days*10 + int64(r-'0')
+	}
+	return days, nil
 }
 
 // FormulasDir returns the formulas directory, defaulting to "formulas".

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -56,6 +56,15 @@ func ValidateDurations(cfg *City, source string) []string {
 	// Events config durations.
 	check("[events.rotation]", "archive_retain_age", cfg.Events.Rotation.ArchiveRetainAge)
 
+	for name, policy := range cfg.Beads.Policies {
+		check(fmt.Sprintf("[beads.policies.%s]", name), "delete_after_close", policy.DeleteAfterClose)
+		if !ValidBeadPolicyStorage(policy.Storage) {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s: [beads.policies.%s] storage = %q is not valid: must be one of %q, %q, or %q",
+				source, name, policy.Storage, BeadStorageHistory, BeadStorageNoHistory, BeadStorageEphemeral))
+		}
+	}
+
 	// Chat sessions config durations.
 	check("[chat_sessions]", "idle_timeout", cfg.ChatSessions.IdleTimeout)
 

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -92,6 +92,46 @@ func TestValidateDurationsBadDaemonFields(t *testing.T) {
 	}
 }
 
+func TestValidateDurationsBadBeadPolicy(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				"session": {DeleteAfterClose: "7days"},
+			},
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "[beads.policies.session]") {
+		t.Errorf("warning should mention bead policy: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "delete_after_close") {
+		t.Errorf("warning should mention field: %s", warnings[0])
+	}
+}
+
+func TestValidateDurationsBadBeadPolicyStorage(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				"session": {Storage: "forever-ish"},
+			},
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "[beads.policies.session]") {
+		t.Errorf("warning should mention bead policy: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "storage") {
+		t.Errorf("warning should mention field: %s", warnings[0])
+	}
+}
+
 func TestValidateDurationsBadPoolDrainTimeout(t *testing.T) {
 	cfg := &City{
 		Agents: []Agent{

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -142,7 +142,6 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 
 	plan := &beads.GraphApplyPlan{
 		CommitMessage: fmt.Sprintf("gc: instantiate %s", recipe.Name),
-		Ephemeral:     true,
 		Nodes:         make([]beads.GraphApplyNode, 0, len(recipe.Steps)),
 		Edges:         make([]beads.GraphApplyEdge, 0, len(recipe.Deps)),
 	}
@@ -175,6 +174,7 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				}
 				node.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
+			labelWispGraphNode(&node, step)
 		} else {
 			// graph.v2 workflows and their retry/Ralph attempt sub-recipes
 			// use step beads as independently routable actionable work, not
@@ -320,7 +320,6 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 
 	plan := &beads.GraphApplyPlan{
 		CommitMessage: fmt.Sprintf("gc: instantiate fragment into %s", opts.RootID),
-		Ephemeral:     true,
 		Nodes:         make([]beads.GraphApplyNode, 0, len(recipe.Steps)),
 		Edges:         make([]beads.GraphApplyEdge, 0, len(recipe.Deps)+len(opts.ExternalDeps)),
 	}
@@ -421,6 +420,13 @@ func recipeStepToGraphNode(step formula.RecipeStep, vars map[string]string, prio
 		Labels:      slices.Clone(b.Labels),
 		Metadata:    maps.Clone(b.Metadata),
 	}, nil
+}
+
+func labelWispGraphNode(node *beads.GraphApplyNode, step formula.RecipeStep) {
+	if step.Metadata["gc.kind"] != "wisp" {
+		return
+	}
+	node.Labels = appendLabelOnce(node.Labels, WispLabel)
 }
 
 func setNodeParentRef(nodes []beads.GraphApplyNode, stepID, parentKey, parentID string) {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -55,6 +55,9 @@ type Options struct {
 const (
 	graphApplyTransientRetryDelay = 500 * time.Millisecond
 
+	// WispLabel marks GC-owned wisp root beads.
+	WispLabel = "gc:wisp"
+
 	// DeferredAssigneeMetadataKey stores an assignee withheld during speculative
 	// molecule creation. Activating the molecule restores the value as Assignee.
 	DeferredAssigneeMetadataKey = "gc.deferred_assignee"
@@ -517,8 +520,8 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 		b := stepToBead(step, vars, priorityOverride)
 		if graphWorkflow {
 			b.Ephemeral = true
-			deferBeadRouting(&b)
-		} else if opts.DeferAssignees {
+		}
+		if opts.DeferAssignees || graphWorkflow {
 			deferBeadRouting(&b)
 		}
 		hasFutureBlocker := false
@@ -556,6 +559,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				}
 				b.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
+			labelWispRoot(&b, step)
 		} else {
 			// graph.v2 workflows and their retry/Ralph attempt sub-recipes
 			// use step beads as independently routable actionable work, not
@@ -754,7 +758,6 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 		// fanout-expanded fragment beads are actionable work that pool
 		// workers claim from `bd ready`. Do not apply nonRootStepBeadType
 		// here (#1039).
-		b.Ephemeral = true
 		deferBeadRouting(&b)
 		hasFutureBlocker := false
 		for _, dep := range recipe.Deps {
@@ -999,6 +1002,22 @@ func preserveExecutableRootType(step formula.RecipeStep) bool {
 	default:
 		return false
 	}
+}
+
+func labelWispRoot(b *beads.Bead, step formula.RecipeStep) {
+	if step.Metadata["gc.kind"] != "wisp" {
+		return
+	}
+	b.Labels = appendLabelOnce(b.Labels, WispLabel)
+}
+
+func appendLabelOnce(labels []string, label string) []string {
+	for _, existing := range labels {
+		if existing == label {
+			return labels
+		}
+	}
+	return append(labels, label)
 }
 
 func validateTimeoutMetadataVars(stepID string, metadata map[string]string) error {


### PR DESCRIPTION
## Summary
Draft stack slice cherry-picked from `364b2899` on `feature/city-rescue-main-drain-v0`.

Base branch for this stack slice: `drain/quarantine-malformed-control-scope-beads`.

## Conflict Resolution
Resolved bead query conflicts by preserving the existing `UpdatedBefore` legacy fallback-to-`CreatedAt` behavior while adding `ClosedAt`/`ClosedBefore` support from this slice.

## Tests
Not run; draft PR created for staged review and follow-up validation.

## Draft Notes
This PR is intentionally draft and has no auto-review label. Once the preceding stack slice is accepted, we can mark this ready for review and add `status/needs-review-auto`.