### PR TITLE
fix: include wisp work in ready queries

### DIFF
--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -279,3 +279,49 @@ func TestSessionAssignmentIdentifiersForConfigConfiguredNamedSessionFallbackIsCo
 		})
 	}
 }
+
+func TestSessionHasOpenAssignedWorkIncludesReachableAssignedWisp(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name: "worker",
+			Dir:  "riga",
+		}},
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	session := beads.Bead{
+		ID:     "session-1",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"template":     "riga/worker",
+			"session_name": "worker-session",
+		},
+	}
+	wisp, err := rigStore.Create(beads.Bead{
+		ID:        "rig-wisp-work",
+		Title:     "active workflow step",
+		Type:      "task",
+		Status:    "in_progress",
+		Assignee:  session.Metadata["session_name"],
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create rig wisp work: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := rigStore.Update(wisp.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark rig wisp in progress: %v", err)
+	}
+
+	has, err := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, cityStore, map[string]beads.Store{"riga": rigStore}, session)
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkForReachableStore: %v", err)
+	}
+	if !has {
+		t.Fatal("reachable assigned wisp work should count before closing a session")
+	}
+}

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1104,6 +1104,7 @@ func bdRuntimeEnvWithError(cityPath string) (map[string]string, error) {
 	// stall bd create / gc mail send for the full 2m subprocess timeout on
 	// large datasets.
 	env["BD_EXPORT_AUTO"] = "false"
+	applyBdCLIRemoteSyncOptOut(env)
 	if !cityUsesBdStoreContract(cityPath) {
 		return env, nil
 	}
@@ -1151,6 +1152,7 @@ func cityRuntimeProcessEnvWithError(cityPath string) ([]string, error) {
 	var projectionErr error
 	if cityUsesBdStoreContract(cityPath) {
 		source := map[string]string{"BEADS_DOLT_AUTO_START": "0"}
+		applyBdCLIRemoteSyncOptOut(source)
 		if usedPostgres, err := applyCityPostgresBackendEnv(source, cityPath); err != nil {
 			clearProjectedDoltEnv(source)
 			clearProjectedPostgresEnv(source)
@@ -1163,7 +1165,7 @@ func cityRuntimeProcessEnvWithError(cityPath string) ([]string, error) {
 			}
 		}
 		keys := execProjectedBackendEnvKeys()
-		keys = append(keys, "BEADS_DOLT_AUTO_START")
+		keys = append(keys, "BEADS_DOLT_AUTO_START", "BD_DOLT_SYNC_CLI_REMOTES", "BEADS_DOLT_SYNC_CLI_REMOTES")
 		for _, key := range keys {
 			if value, ok := source[key]; ok {
 				overrides[key] = value
@@ -1171,6 +1173,14 @@ func cityRuntimeProcessEnvWithError(cityPath string) ([]string, error) {
 		}
 	}
 	return mergeRuntimeEnv(os.Environ(), overrides), projectionErr
+}
+
+func applyBdCLIRemoteSyncOptOut(env map[string]string) {
+	if env == nil {
+		return
+	}
+	env["BD_DOLT_SYNC_CLI_REMOTES"] = "false"
+	env["BEADS_DOLT_SYNC_CLI_REMOTES"] = "false"
 }
 
 func mirrorBeadsDoltEnv(env map[string]string) {
@@ -1243,11 +1253,13 @@ func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
 		"BEADS_DOLT_SERVER_HOST",
 		"BEADS_DOLT_SERVER_PORT",
 		"BEADS_DOLT_SERVER_USER",
+		"BEADS_DOLT_SYNC_CLI_REMOTES",
 		"BEADS_POSTGRES_DATABASE",
 		"BEADS_POSTGRES_HOST",
 		"BEADS_POSTGRES_PASSWORD",
 		"BEADS_POSTGRES_PORT",
 		"BEADS_POSTGRES_USER",
+		"BD_DOLT_SYNC_CLI_REMOTES",
 		"GC_CITY",
 		"GC_CITY_ROOT", // kept for stripping: no code emits this anymore, but inherited values must be cleaned
 		"GC_CITY_PATH",

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -192,6 +192,41 @@ func TestBdRuntimeEnvIncludesDoltHost(t *testing.T) {
 	}
 }
 
+func TestBdRuntimeEnvDisablesCLIRemoteSync(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("BD_DOLT_SYNC_CLI_REMOTES", "true")
+	t.Setenv("BEADS_DOLT_SYNC_CLI_REMOTES", "true")
+
+	env := mustBdRuntimeEnv(t, t.TempDir())
+	if got := env["BD_DOLT_SYNC_CLI_REMOTES"]; got != "false" {
+		t.Fatalf("BD_DOLT_SYNC_CLI_REMOTES = %q, want false", got)
+	}
+	if got := env["BEADS_DOLT_SYNC_CLI_REMOTES"]; got != "false" {
+		t.Fatalf("BEADS_DOLT_SYNC_CLI_REMOTES = %q, want false", got)
+	}
+}
+
+func TestCityRuntimeProcessEnvDisablesCLIRemoteSync(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("BD_DOLT_SYNC_CLI_REMOTES", "true")
+	t.Setenv("BEADS_DOLT_SYNC_CLI_REMOTES", "true")
+
+	env := mustCityRuntimeProcessEnv(t, t.TempDir())
+	values := map[string]string{}
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	if got := values["BD_DOLT_SYNC_CLI_REMOTES"]; got != "false" {
+		t.Fatalf("BD_DOLT_SYNC_CLI_REMOTES = %q, want false", got)
+	}
+	if got := values["BEADS_DOLT_SYNC_CLI_REMOTES"]; got != "false" {
+		t.Fatalf("BEADS_DOLT_SYNC_CLI_REMOTES = %q, want false", got)
+	}
+}
+
 func TestBdRuntimeEnvExternalHostSkipsLocalState(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT_HOST", "remote.example.com")

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -773,7 +773,7 @@ func collectAssignedWorkBeadsWithStores(
 			// unassigned pool work that needs to be reopened. This pass runs
 			// across every store before any ready handoff probes, so already
 			// active work never waits behind unrelated ready scans.
-			if inProgress, err := listForControllerDemand(source.store, beads.ListQuery{Status: "in_progress"}); err == nil {
+			if inProgress, err := listBothTiersForControllerDemand(source.store, beads.ListQuery{Status: "in_progress"}); err == nil {
 				appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
 			} else {
 				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
@@ -1306,59 +1306,16 @@ func sortedStringSet(values map[string]struct{}) []string {
 	return out
 }
 
-func listForControllerDemand(store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
-	if _, ok := store.(interface {
-		CachedList(beads.ListQuery) ([]beads.Bead, bool)
-	}); ok {
-		cacheQuery := query
-		cacheQuery.Live = false
-		return store.List(cacheQuery)
-	}
-	liveQuery := query
-	liveQuery.Live = true
-	return store.List(liveQuery)
+func listBothTiersForControllerDemand(store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
+	return beads.HandlesFor(store).Cached.List(query)
 }
 
 func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
-	// Controller demand reads are intentionally cache-tolerant, not
-	// authoritative lifecycle gates; CachedReady falls back whenever the cache
-	// has dirty or unknown dependency coverage.
-	if cached, ok := store.(interface {
-		CachedReady() ([]beads.Bead, bool)
-	}); ok {
-		if ready, ok := cached.CachedReady(); ok {
-			return ready, nil
-		}
-	}
-	return beads.ReadyLive(store)
+	return beads.HandlesFor(store).Cached.Ready()
 }
 
 func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([]beads.Bead, error) {
-	if cached, ok := store.(interface {
-		CachedReady() ([]beads.Bead, bool)
-	}); ok {
-		if ready, ok := cached.CachedReady(); ok {
-			return filterReadyForControllerDemand(ready, query), nil
-		}
-	}
-	return store.Ready(query)
-}
-
-func filterReadyForControllerDemand(ready []beads.Bead, query beads.ReadyQuery) []beads.Bead {
-	if query == (beads.ReadyQuery{}) {
-		return ready
-	}
-	result := make([]beads.Bead, 0, len(ready))
-	for _, bead := range ready {
-		if query.Assignee != "" && bead.Assignee != query.Assignee {
-			continue
-		}
-		result = append(result, bead)
-		if query.Limit > 0 && len(result) >= query.Limit {
-			break
-		}
-	}
-	return result
+	return beads.HandlesFor(store).Cached.Ready(query)
 }
 
 // mergeNamedSessionDemand ensures that named-session assignee demand is

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -118,14 +118,20 @@ func (s *blockingPoolCreateStore) Create(bead beads.Bead) (beads.Bead, error) {
 
 type demandListCountingStore struct {
 	beads.Store
-	liveInProgressLists int
-	liveOpenMolecules   int
-	livePoolDemand      int
+	liveInProgressIssueLists int
+	liveInProgressWispLists  int
+	liveOpenMolecules        int
+	livePoolDemand           int
 }
 
 func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	if query.Live && query.Status == "in_progress" {
-		s.liveInProgressLists++
+		switch query.TierMode {
+		case beads.TierWisps:
+			s.liveInProgressWispLists++
+		default:
+			s.liveInProgressIssueLists++
+		}
 	}
 	if query.Live && query.Status == "open" && query.Type == "molecule" {
 		s.liveOpenMolecules++
@@ -138,8 +144,9 @@ func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, err
 
 type demandRefreshFailStore struct {
 	beads.Store
-	failNextGet         bool
-	liveInProgressLists int
+	failNextGet              bool
+	liveInProgressIssueLists int
+	liveInProgressWispLists  int
 }
 
 func (s *demandRefreshFailStore) Get(id string) (beads.Bead, error) {
@@ -152,7 +159,12 @@ func (s *demandRefreshFailStore) Get(id string) (beads.Bead, error) {
 
 func (s *demandRefreshFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	if query.Live && query.Status == "in_progress" {
-		s.liveInProgressLists++
+		switch query.TierMode {
+		case beads.TierWisps:
+			s.liveInProgressWispLists++
+		default:
+			s.liveInProgressIssueLists++
+		}
 	}
 	return s.Store.List(query)
 }
@@ -191,7 +203,7 @@ func (s *partialAssignedWorkStore) List(query beads.ListQuery) ([]beads.Bead, er
 	if err != nil {
 		return nil, err
 	}
-	if s.partialInProgress && query.Status == "in_progress" && query.Live {
+	if s.partialInProgress && query.Status == "in_progress" {
 		return rows, &beads.PartialResultError{Op: "bd list", Err: errors.New("skipped corrupt in-progress bead")}
 	}
 	return rows, nil
@@ -236,6 +248,36 @@ func TestCollectAssignedWorkBeads_IncludesReadyOpenAssignedHandoff(t *testing.T)
 	}
 	if got[0].Assignee != "repo/refinery" || got[0].Status != "open" {
 		t.Fatalf("assigned handoff bead = assignee %q status %q, want repo/refinery open", got[0].Assignee, got[0].Status)
+	}
+}
+
+func TestCollectAssignedWorkBeadsIncludesAssignedInProgressWisp(t *testing.T) {
+	store := beads.NewMemStore()
+	wisp, err := store.Create(beads.Bead{
+		Title:     "active workflow step",
+		Type:      "task",
+		Status:    "in_progress",
+		Assignee:  "worker-session",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wisp work: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(wisp.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark wisp in progress: %v", err)
+	}
+
+	got, partial := collectAssignedWorkBeads(&config.City{}, store)
+
+	if partial {
+		t.Fatal("collectAssignedWorkBeads reported partial results")
+	}
+	if len(got) != 1 || got[0].ID != wisp.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want in-progress wisp %s", got, wisp.ID)
 	}
 }
 
@@ -291,12 +333,15 @@ func TestCollectAssignedWorkBeadsUsesCachedInProgressReadModel(t *testing.T) {
 	if len(got) != 1 || got[0].ID != work.ID {
 		t.Fatalf("collectAssignedWorkBeads returned %#v, want [%s]", got, work.ID)
 	}
-	if backing.liveInProgressLists != 0 {
-		t.Fatalf("live in_progress list calls = %d, want cached demand read", backing.liveInProgressLists)
+	if backing.liveInProgressIssueLists != 0 {
+		t.Fatalf("live issue in_progress list calls = %d, want cached demand read", backing.liveInProgressIssueLists)
+	}
+	if backing.liveInProgressWispLists != 0 {
+		t.Fatalf("live wisp in_progress list calls = %d, want cached demand read", backing.liveInProgressWispLists)
 	}
 }
 
-func TestCollectAssignedWorkBeadsFallsBackLiveWhenCachedInProgressDirty(t *testing.T) {
+func TestCollectAssignedWorkBeadsReprimesWhenCachedInProgressDirty(t *testing.T) {
 	backing := &demandRefreshFailStore{Store: beads.NewMemStore()}
 	work, err := backing.Create(beads.Bead{
 		Title: "handoff becomes active",
@@ -319,13 +364,16 @@ func TestCollectAssignedWorkBeadsFallsBackLiveWhenCachedInProgressDirty(t *testi
 
 	got, partial := collectAssignedWorkBeads(&config.City{}, cache)
 	if partial {
-		t.Fatal("collectAssignedWorkBeads reported partial with successful live fallback")
+		t.Fatal("collectAssignedWorkBeads reported partial with successful cache reprime")
 	}
 	if len(got) != 1 || got[0].ID != work.ID || got[0].Status != "in_progress" || got[0].Assignee != "repo/refinery" {
-		t.Fatalf("collectAssignedWorkBeads returned %#v, want live in-progress %s", got, work.ID)
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want reprime in-progress %s", got, work.ID)
 	}
-	if backing.liveInProgressLists != 1 {
-		t.Fatalf("live in_progress list calls = %d, want dirty cache fallback", backing.liveInProgressLists)
+	if backing.liveInProgressIssueLists != 0 {
+		t.Fatalf("live issue in_progress list calls = %d, want shared cache reprime", backing.liveInProgressIssueLists)
+	}
+	if backing.liveInProgressWispLists != 0 {
+		t.Fatalf("live wisp in_progress list calls = %d, want shared cache reprime", backing.liveInProgressWispLists)
 	}
 }
 
@@ -828,7 +876,7 @@ func TestDefaultScaleCheckCountsHonorsCachedWriteThroughDependencies(t *testing.
 	}
 }
 
-func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T) {
+func TestDefaultScaleCheckCountsMarksPartialWhenCachedEventDepsUnknown(t *testing.T) {
 	backing := &readyStaticStore{
 		Store: beads.NewMemStore(),
 		ready: []beads.Bead{{
@@ -842,8 +890,8 @@ func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T
 		}},
 	}
 	cache := beads.NewCachingStoreForTest(backing, nil)
-	if err := cache.PrimeActive(); err != nil {
-		t.Fatalf("PrimeActive: %v", err)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
 	}
 	cache.ApplyEvent("bead.created", []byte(`{"id":"gc-blocked","status":"open","metadata":{"gc.routed_to":"gascity/workflows.codex-max"}}`))
 
@@ -852,14 +900,14 @@ func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T
 		storeKey: "rig:gascity",
 		store:    cache,
 	}})
-	if len(errs) != 0 {
-		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	if len(errs) != 1 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v, want cache-unavailable partial", errs)
 	}
-	if got := counts["gascity/workflows.codex-max"]; got != 1 {
-		t.Fatalf("defaultScaleCheckCounts = %d, want live ready fallback count only", got)
+	if got := counts["gascity/workflows.codex-max"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want no live fallback count", got)
 	}
-	if backing.readyCalls != 1 {
-		t.Fatalf("backing Ready calls = %d, want one live ready fallback", backing.readyCalls)
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want no live ready fallback", backing.readyCalls)
 	}
 }
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -3909,7 +3909,7 @@ func TestOnFormulaCopiesSourcePriorityToCreatedBeads(t *testing.T) {
 		t.Fatal("workflow root has no descendants")
 	}
 
-	all, err := deps.Store.ListOpen()
+	all, err := deps.Store.List(beads.ListQuery{AllowScan: true, TierMode: beads.TierBoth})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -4004,7 +4004,7 @@ title = "Do work"
 	if got := root.Metadata["gc.root_store_ref"]; got != "city:test-city" {
 		t.Fatalf("root gc.root_store_ref = %q, want city:test-city", got)
 	}
-	all, err := deps.Store.ListOpen()
+	all, err := deps.Store.List(beads.ListQuery{AllowScan: true, TierMode: beads.TierBoth})
 	if err != nil {
 		t.Fatalf("list workflow beads: %v", err)
 	}
@@ -4040,7 +4040,7 @@ title = "Do work"
 		}
 	}
 	if assigned == 0 {
-		t.Fatal("expected at least one assigned workflow bead")
+		t.Fatalf("expected at least one assigned workflow bead; rows=%#v", all)
 	}
 	if !strings.Contains(stdout.String(), "Attached workflow") {
 		t.Fatalf("stdout = %q, want attached workflow message", stdout.String())

--- a/cmd/gc/graph_dispatch_mem_test.go
+++ b/cmd/gc/graph_dispatch_mem_test.go
@@ -143,6 +143,46 @@ func executeMemGraphWorkerBead(t *testing.T, store beads.Store, bead beads.Bead,
 	}
 }
 
+func memGraphReady(t *testing.T, store beads.Store) []beads.Bead {
+	t.Helper()
+
+	all, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true, TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatalf("List(graph ready): %v", err)
+	}
+	statusByID := make(map[string]string, len(all))
+	for _, bead := range all {
+		statusByID[bead.ID] = bead.Status
+	}
+
+	var ready []beads.Bead
+	for _, bead := range all {
+		if bead.Status != "open" || beads.IsReadyExcludedType(bead.Type) {
+			continue
+		}
+		deps, err := store.DepList(bead.ID, "down")
+		if err != nil {
+			t.Fatalf("DepList(%s, down): %v", bead.ID, err)
+		}
+		blocked := false
+		for _, dep := range deps {
+			switch dep.Type {
+			case "blocks", "waits-for", "conditional-blocks":
+			default:
+				continue
+			}
+			if statusByID[dep.DependsOnID] != "closed" {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			ready = append(ready, bead)
+		}
+	}
+	return ready
+}
+
 func runMemGraphWorkflowToCompletion(t *testing.T, store beads.Store, workflowID, sourceID, workerSession, cityPath, mode string) {
 	t.Helper()
 
@@ -152,10 +192,7 @@ func runMemGraphWorkflowToCompletion(t *testing.T, store beads.Store, workflowID
 			return
 		}
 
-		ready, err := store.Ready()
-		if err != nil {
-			t.Fatalf("Ready(): %v", err)
-		}
+		ready := memGraphReady(t, store)
 
 		progressed := false
 		for _, bead := range ready {
@@ -169,10 +206,7 @@ func runMemGraphWorkflowToCompletion(t *testing.T, store beads.Store, workflowID
 			progressed = progressed || result.Processed
 		}
 
-		ready, err = store.Ready()
-		if err != nil {
-			t.Fatalf("Ready() after control: %v", err)
-		}
+		ready = memGraphReady(t, store)
 		for {
 			bead, ok, err := selectExecutableGraphWorkerBead(ready, workerSession)
 			if err != nil {
@@ -183,10 +217,7 @@ func runMemGraphWorkflowToCompletion(t *testing.T, store beads.Store, workflowID
 			}
 			executeMemGraphWorkerBead(t, store, bead, sourceID, cityPath, mode)
 			progressed = true
-			ready, err = store.Ready()
-			if err != nil {
-				t.Fatalf("Ready() after worker step: %v", err)
-			}
+			ready = memGraphReady(t, store)
 		}
 
 		if progressed {
@@ -357,7 +388,11 @@ func TestGraphWorkflowInMemoryFailureRunsCleanup(t *testing.T) {
 		t.Fatalf("work_dir = %q, want empty after cleanup", got)
 	}
 
-	all, err := store.ListByMetadata(map[string]string{"gc.root_bead_id": workflowID}, 0, beads.IncludeClosed)
+	all, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": workflowID},
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+	})
 	if err != nil {
 		t.Fatalf("ListByMetadata(gc.root_bead_id=%q): %v", workflowID, err)
 	}
@@ -417,7 +452,7 @@ func TestGraphWorkflowInMemoryCreateExecuteWaitFlow(t *testing.T) {
 func TestGraphWorkflowInMemoryRouteUsesControlDispatcherForControlBeads(t *testing.T) {
 	store, _, workflowID := startMemScopedWorkflow(t)
 
-	all, err := store.ListOpen()
+	all, err := store.List(beads.ListQuery{AllowScan: true, TierMode: beads.TierBoth})
 	if err != nil {
 		t.Fatalf("List(): %v", err)
 	}

--- a/cmd/gc/lifecycle_live_query_test.go
+++ b/cmd/gc/lifecycle_live_query_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -175,6 +177,58 @@ func TestSessionHasOpenAssignedWorkInStore_UsesLiveOpenOwnership(t *testing.T) {
 	}
 	if hasAssignedWork {
 		t.Fatal("sessionHasOpenAssignedWorkInStore() = true, want false after external open-work reassignment")
+	}
+}
+
+type failLiveWispListStore struct {
+	beads.Store
+	mu   sync.Mutex
+	fail bool
+}
+
+func (s *failLiveWispListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.mu.Lock()
+	fail := s.fail
+	s.mu.Unlock()
+	if fail && query.Live && (query.TierMode == beads.TierWisps || query.TierMode == beads.TierBoth) {
+		return nil, errors.New("live wisp list should not be required")
+	}
+	return s.Store.List(query)
+}
+
+func (s *failLiveWispListStore) setFail(fail bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.fail = fail
+}
+
+func TestSessionHasOpenAssignedWorkInStore_UsesCachedWispOwnership(t *testing.T) {
+	t.Parallel()
+
+	backing := &failLiveWispListStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:     "wisp work",
+		Type:      "task",
+		Status:    "in_progress",
+		Assignee:  "sess-1",
+		Ephemeral: true,
+	}); err != nil {
+		t.Fatalf("Create(wisp): %v", err)
+	}
+
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	backing.setFail(true)
+
+	session := beads.Bead{ID: "sess-1"}
+	hasAssignedWork, err := sessionHasOpenAssignedWorkInStore(cache, session)
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkInStore: %v", err)
+	}
+	if !hasAssignedWork {
+		t.Fatal("sessionHasOpenAssignedWorkInStore() = false, want cached wisp ownership to count")
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4105,7 +4105,8 @@ func TestSweepOrphanedOrderTracking_RetryOnTransientError(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	// Fail the first 2 ListByLabel calls, succeed on the 3rd.
+	// Fail the first 2 ListByLabel calls, succeed on the 3rd. The successful
+	// sweep also scans the legacy tracking label.
 	fs := &countFailStore{Store: inner, failCount: 2}
 	closed, err := sweepOrphanedOrderTrackingRetry(fs, 3, time.Millisecond)
 	if err != nil {
@@ -4114,8 +4115,8 @@ func TestSweepOrphanedOrderTracking_RetryOnTransientError(t *testing.T) {
 	if closed != 1 {
 		t.Fatalf("closed = %d, want 1", closed)
 	}
-	if fs.calls != 3 {
-		t.Fatalf("ListByLabel calls = %d, want 3", fs.calls)
+	if fs.calls != 4 {
+		t.Fatalf("ListByLabel calls = %d, want 4", fs.calls)
 	}
 }
 
@@ -4167,8 +4168,8 @@ func TestSweepOrphanedOrderTracking_RetryOnPartialClose(t *testing.T) {
 	if n != 3 {
 		t.Fatalf("n = %d, want 3 (accumulated across retries)", n)
 	}
-	if fs.listCalls != 3 {
-		t.Fatalf("ListByLabel calls = %d, want 3 (retry on partial close)", fs.listCalls)
+	if fs.listCalls != 6 {
+		t.Fatalf("ListByLabel calls = %d, want 6 (current and legacy label scans per retry)", fs.listCalls)
 	}
 }
 

--- a/cmd/gc/pack_import_formula_order_test.go
+++ b/cmd/gc/pack_import_formula_order_test.go
@@ -213,7 +213,7 @@ source = "`+gastownPackDir+`"
 	if code != 0 {
 		t.Fatalf("doOrderRun = %d, want 0; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
 	}
-	runs, err := store.ListByLabel("order-run:digest-generate", 0)
+	runs, err := store.ListByLabel("order-run:digest-generate", 0, beads.WithBothTiers)
 	if err != nil {
 		t.Fatalf("store.ListByLabel(order-run:digest-generate): %v", err)
 	}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2648,19 +2648,45 @@ func sessionHasOpenAssignedWorkInStoreByIdentifiers(store beads.Store, identifie
 				continue
 			}
 			seen[key] = struct{}{}
-			items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: true})
-			if err != nil {
-				return false, err
+			if has, err := sessionHasOpenAssignedWorkForTier(store, assignee, status, beads.TierIssues, true); err != nil || has {
+				return has, err
 			}
-			for _, item := range items {
-				if sessionpkg.IsSessionBeadOrRepairable(item) {
-					continue
-				}
-				return true, nil
+			if has, err := sessionHasOpenAssignedWispWork(store, assignee, status); err != nil || has {
+				return has, err
 			}
 		}
 	}
 	return false, nil
+}
+
+func sessionHasOpenAssignedWispWork(store beads.Store, assignee, status string) (bool, error) {
+	query := beads.ListQuery{Assignee: assignee, Status: status, TierMode: beads.TierWisps}
+	if cache, ok := store.(interface {
+		CachedList(beads.ListQuery) ([]beads.Bead, bool)
+	}); ok {
+		if items, ok := cache.CachedList(query); ok {
+			return hasNonSessionAssignedWork(items), nil
+		}
+	}
+	return sessionHasOpenAssignedWorkForTier(store, assignee, status, beads.TierWisps, true)
+}
+
+func sessionHasOpenAssignedWorkForTier(store beads.Store, assignee, status string, tierMode beads.TierMode, live bool) (bool, error) {
+	items, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: live, TierMode: tierMode})
+	if err != nil {
+		return false, err
+	}
+	return hasNonSessionAssignedWork(items), nil
+}
+
+func hasNonSessionAssignedWork(items []beads.Bead) bool {
+	for _, item := range items {
+		if sessionpkg.IsSessionBeadOrRepairable(item) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // namedSessionActivityThreshold is the maximum age of the last reliable

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -746,6 +746,9 @@ func resolvedWorkerRuntimeTransport(info session.Info, resolved *config.Resolved
 	if strings.TrimSpace(info.Provider) == "acp" {
 		return "acp"
 	}
+	if strings.TrimSpace(configuredTransport) == config.SessionTransportTmux {
+		return config.SessionTransportTmux
+	}
 	if storedWorkerSessionProvesACPTransport(resolved, configuredTransport, info.Command, metadata) {
 		return "acp"
 	}

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -665,6 +665,25 @@ func TestResolvedWorkerRuntimeTransportUsesResumeMetadataForLegacyACPWithSameCom
 	}
 }
 
+func TestResolvedWorkerRuntimeTransportUsesConfiguredTmuxForCommandOnlyBead(t *testing.T) {
+	resolved := &config.ResolvedProvider{
+		Name:        "kimi",
+		Command:     "aimux",
+		Args:        []string{"run", "kimi"},
+		SupportsACP: true,
+		ACPCommand:  "kimi-acp",
+	}
+
+	got := resolvedWorkerRuntimeTransport(session.Info{
+		Template: "gascity/workflows.kimi",
+		Provider: "kimi",
+		Command:  "aimux run kimi -- --yolo --no-thinking --model kimi-k2.6",
+	}, resolved, config.SessionTransportTmux, nil)
+	if got != config.SessionTransportTmux {
+		t.Fatalf("resolvedWorkerRuntimeTransport() = %q, want tmux", got)
+	}
+}
+
 func TestResolvedWorkerRuntimeWithConfigErrorsForAmbiguousLegacyACPTransportWithSameCommand(t *testing.T) {
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1664,7 +1664,7 @@ func (s *BdStore) Children(parentID string, opts ...QueryOpt) ([]Bead, error) {
 // Ready returns open ready beads via bd ready.
 func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	q := readyQueryFromArgs(query)
-	args := []string{"ready", "--json"}
+	args := []string{"ready", "--json", "--include-ephemeral"}
 	if q.Assignee != "" {
 		args = append(args, "--assignee", q.Assignee)
 	}
@@ -1682,9 +1682,6 @@ func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	for i := range issues {
 		bead := issues[i].toBead()
 		if IsReadyExcludedType(bead.Type) {
-			continue
-		}
-		if bead.Ephemeral {
 			continue
 		}
 		if q.Assignee != "" && bead.Assignee != q.Assignee {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1630,7 +1630,7 @@ func TestBdStoreReadyReturnsPartialResultErrorOnCorruptEntries(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd ready --json --limit 0`: {
+		`bd ready --json --include-ephemeral --limit 0`: {
 			out: []byte(`[
 				{"id":"bd-good","title":"good","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
 				{"id":"bd-bad","title":"bad","status":"open","issue_type":"task","created_at":"not-a-time"}
@@ -1657,7 +1657,7 @@ func TestBdStoreReadyReturnsHardErrorWithoutUsableSurvivors(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd ready --json --limit 0`: {
+		`bd ready --json --include-ephemeral --limit 0`: {
 			out: []byte(`[
 				{"id":"bd-bad","title":"bad","status":"open","issue_type":"task","created_at":"not-a-time"}
 			]`),
@@ -1698,12 +1698,40 @@ func TestBdStoreListIncludesInfra(t *testing.T) {
 
 // --- Ready ---
 
+func TestBdStoreReadyIncludesEphemeralWork(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		return []byte(`[{"id":"bd-wisp","title":"wisp work","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","ephemeral":true}]`), nil
+	}
+
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.Ready()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundFlag := false
+	for _, arg := range gotArgs {
+		if arg == "--include-ephemeral" {
+			foundFlag = true
+			break
+		}
+	}
+	if !foundFlag {
+		t.Fatalf("Ready() args = %v, want --include-ephemeral so wisp work is visible", gotArgs)
+	}
+	if len(got) != 1 || got[0].ID != "bd-wisp" {
+		t.Fatalf("Ready() = %+v, want ephemeral wisp work bd-wisp", got)
+	}
+}
+
 func TestBdStoreReady(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte
 		err error
 	}{
-		`bd ready --json --limit 0`: {
+		`bd ready --json --include-ephemeral --limit 0`: {
 			out: []byte(`[{"id":"bd-aaa","title":"ready one","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`),
 		},
 	})
@@ -1725,7 +1753,7 @@ func TestBdStoreReadyWithAssigneeAndLimit(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd ready --json --assignee worker-1 --limit 3`: {
+		`bd ready --json --include-ephemeral --assignee worker-1 --limit 3`: {
 			out: []byte(`[
 				{"id":"bd-worker","title":"ready one","status":"open","issue_type":"task","assignee":"worker-1","created_at":"2025-01-15T10:30:00Z"},
 				{"id":"bd-other","title":"wrong assignee","status":"open","issue_type":"task","assignee":"worker-2","created_at":"2025-01-15T10:31:00Z"}
@@ -1750,7 +1778,7 @@ func TestBdStoreReadyFiltersInfraTypes(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd ready --json --limit 0`: {
+		`bd ready --json --include-ephemeral --limit 0`: {
 			out: []byte(`[
 				{"id":"bd-task","title":"ready one","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
 				{"id":"bd-session","title":"infra session","status":"open","issue_type":"session","created_at":"2025-01-15T10:31:00Z"}
@@ -1775,7 +1803,7 @@ func TestBdStoreReadyEmpty(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd ready --json --limit 0`: {out: []byte(`[]`)},
+		`bd ready --json --include-ephemeral --limit 0`: {out: []byte(`[]`)},
 	})
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.Ready()
@@ -1806,7 +1834,7 @@ func TestBdStoreReadyReturnsParseErrorOnMalformedJSON(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd ready --json --limit 0`: {
+		`bd ready --json --include-ephemeral --limit 0`: {
 			out: []byte(`{not json`),
 		},
 	})

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -11,6 +11,10 @@ import (
 // ErrNotFound is returned when a bead ID does not exist in the store.
 var ErrNotFound = errors.New("bead not found")
 
+// ErrCacheUnavailable is returned by cache-only read handles when the cache
+// cannot answer without consulting the backing store.
+var ErrCacheUnavailable = errors.New("bead cache unavailable")
+
 // ErrParentProjectionSuperseded reports that a parent update was overtaken by a
 // concurrent reparent before the caller's projection wait could converge.
 var ErrParentProjectionSuperseded = errors.New("parent projection superseded by concurrent update")

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -56,6 +56,10 @@ type CachingStore struct {
 	// cadences would flood logs. cacheReconcileSuccessLogWindow caps the
 	// rate at one line per minute, matching cacheProblemLogWindow.
 	lastReconcileLogAt time.Time
+	primeMu            sync.Mutex
+	primeRunning       bool
+	primeDone          chan struct{}
+	primeErr           error
 
 	// latencyWindow holds the most recent reconciliation bd-list
 	// durations for adaptive cadence decisions. Bounded at
@@ -314,8 +318,9 @@ func (c *CachingStore) noteLocalMutationLocked(ids ...string) uint64 {
 	return seq
 }
 
-// PrimeActive loads all non-closed beads (open + in_progress) into the
-// cache. These are fast indexed queries that populate enough data for
+// PrimeActive loads all non-closed beads (open + in_progress) across both
+// persistent issues and ephemeral wisps into the cache. These are fast indexed
+// queries that populate enough data for
 // startup paths without waiting for a full scan. The cache enters
 // cachePartial state: filtered active queries and Get hit cache for primed
 // beads, while closed-bead queries still delegate to the backing store.
@@ -327,7 +332,7 @@ func (c *CachingStore) PrimeActive() error {
 	var all []Bead
 	var partialErr error
 	for _, status := range []string{"open", "in_progress"} {
-		beads, err := c.backing.List(ListQuery{Status: status})
+		beads, err := c.backing.List(ListQuery{Status: status, TierMode: TierBoth})
 		if err != nil {
 			if !IsPartialResult(err) {
 				return fmt.Errorf("prime active (%s): %w", status, err)
@@ -387,7 +392,17 @@ func (c *CachingStore) PrimeActive() error {
 // Prime loads all active beads and deps from the backing store into memory.
 // Retries up to 3 times on failure since bd list can time out under
 // concurrent dolt load.
-func (c *CachingStore) Prime(_ context.Context) error {
+func (c *CachingStore) Prime(ctx context.Context) error {
+	done, owner := c.beginFullPrime()
+	if !owner {
+		return c.waitForFullPrimeDone(ctx, done)
+	}
+	err := c.prime(ctx)
+	c.finishFullPrime(done, err)
+	return err
+}
+
+func (c *CachingStore) prime(_ context.Context) error {
 	c.mu.RLock()
 	startSeq := c.mutationSeq
 	c.mu.RUnlock()
@@ -396,7 +411,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	var err error
 	var partialErr error
 	for attempt := 1; attempt <= 3; attempt++ {
-		all, err = c.backing.List(ListQuery{AllowScan: true, SkipLabels: true}) // active beads only (default)
+		all, err = c.backing.List(ListQuery{AllowScan: true, SkipLabels: true, TierMode: TierBoth}) // active beads only
 		if err == nil {
 			break
 		}
@@ -488,6 +503,63 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	c.markFreshLocked(now)
 	c.updateStatsLocked()
 	return nil
+}
+
+func (c *CachingStore) beginFullPrime() (chan struct{}, bool) {
+	c.primeMu.Lock()
+	defer c.primeMu.Unlock()
+	if c.primeRunning {
+		return c.primeDone, false
+	}
+	done := make(chan struct{})
+	c.primeRunning = true
+	c.primeDone = done
+	c.primeErr = nil
+	return done, true
+}
+
+func (c *CachingStore) finishFullPrime(done chan struct{}, err error) {
+	c.primeMu.Lock()
+	defer c.primeMu.Unlock()
+	if c.primeDone != done {
+		return
+	}
+	c.primeErr = err
+	c.primeRunning = false
+	close(done)
+}
+
+func (c *CachingStore) waitForFullPrimeDone(ctx context.Context, done chan struct{}) error {
+	if done == nil {
+		return ErrCacheUnavailable
+	}
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	c.primeMu.Lock()
+	defer c.primeMu.Unlock()
+	return c.primeErr
+}
+
+func (c *CachingStore) ensureFullPrime(ctx context.Context) error {
+	if c.cacheFullyPrimed() {
+		return nil
+	}
+	if err := c.Prime(ctx); err != nil {
+		return err
+	}
+	if !c.cacheFullyPrimed() {
+		return ErrCacheUnavailable
+	}
+	return nil
+}
+
+func (c *CachingStore) cacheFullyPrimed() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.state == cacheLive && c.primePartialErr == nil
 }
 
 // StartReconciler launches watchdog reconciliation. Cancel ctx to stop.

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -226,7 +226,7 @@ func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 	openBeads := make([]Bead, 0, len(c.beads))
 	for _, b := range c.beads {
 		statusByID[b.ID] = b.Status
-		if b.Status != "open" || b.Ephemeral || IsReadyExcludedType(b.Type) {
+		if b.Status != "open" || IsReadyExcludedType(b.Type) {
 			continue
 		}
 		if query.Assignee != "" && b.Assignee != query.Assignee {

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -1,0 +1,287 @@
+package beads
+
+import (
+	"context"
+	"fmt"
+)
+
+// CachedReader is the cache-only eventual-consistency read handle for beads.
+type CachedReader interface {
+	Get(id string) (Bead, error)
+	List(query ListQuery) ([]Bead, error)
+	Ready(query ...ReadyQuery) ([]Bead, error)
+	DepList(id, direction string) ([]Dep, error)
+}
+
+// LiveReader is the authoritative read handle for beads.
+type LiveReader interface {
+	Get(id string) (Bead, error)
+	List(query ListQuery) ([]Bead, error)
+	Ready(query ...ReadyQuery) ([]Bead, error)
+	DepList(id, direction string) ([]Dep, error)
+}
+
+// Writer is the mutation handle for beads.
+type Writer interface {
+	Create(b Bead) (Bead, error)
+	Update(id string, opts UpdateOpts) error
+	Close(id string) error
+	Reopen(id string) error
+	CloseAll(ids []string, metadata map[string]string) (int, error)
+	SetMetadata(id, key, value string) error
+	SetMetadataBatch(id string, kvs map[string]string) error
+	Delete(id string) error
+	DepAdd(issueID, dependsOnID, depType string) error
+	DepRemove(issueID, dependsOnID string) error
+}
+
+// StoreHandles groups explicit bead read and write capabilities.
+type StoreHandles struct {
+	Cached CachedReader
+	Live   LiveReader
+	Writer Writer
+}
+
+// HandlesFor returns explicit cached/live reader and writer handles for a
+// store. Stores with a native handle implementation keep their stronger
+// guarantees; plain stores use logical wrappers that hide tier selection from
+// callers.
+func HandlesFor(store Store) StoreHandles {
+	if provider, ok := store.(interface {
+		Handles() StoreHandles
+	}); ok {
+		return provider.Handles()
+	}
+	return StoreHandles{
+		Cached: logicalCachedStoreReader{store: store},
+		Live:   logicalLiveStoreReader{store: store},
+		Writer: store,
+	}
+}
+
+// Handles returns explicit cached/live reader and writer handles that share
+// this store's cache coordinator.
+func (c *CachingStore) Handles() StoreHandles {
+	return StoreHandles{
+		Cached: cachedStoreReader{store: c},
+		Live:   liveStoreReader{store: c},
+		Writer: c,
+	}
+}
+
+type logicalCachedStoreReader struct {
+	store Store
+}
+
+func (r logicalCachedStoreReader) Get(id string) (Bead, error) {
+	return r.store.Get(id)
+}
+
+func (r logicalCachedStoreReader) List(query ListQuery) ([]Bead, error) {
+	query.Live = false
+	query.TierMode = TierBoth
+	return r.store.List(query)
+}
+
+func (r logicalCachedStoreReader) Ready(query ...ReadyQuery) ([]Bead, error) {
+	return r.store.Ready(query...)
+}
+
+func (r logicalCachedStoreReader) DepList(id, direction string) ([]Dep, error) {
+	return r.store.DepList(id, direction)
+}
+
+type logicalLiveStoreReader struct {
+	store Store
+}
+
+func (r logicalLiveStoreReader) Get(id string) (Bead, error) {
+	return r.store.Get(id)
+}
+
+func (r logicalLiveStoreReader) List(query ListQuery) ([]Bead, error) {
+	query.Live = true
+	query.TierMode = TierBoth
+	return r.store.List(query)
+}
+
+func (r logicalLiveStoreReader) Ready(query ...ReadyQuery) ([]Bead, error) {
+	return r.store.Ready(query...)
+}
+
+func (r logicalLiveStoreReader) DepList(id, direction string) ([]Dep, error) {
+	return r.store.DepList(id, direction)
+}
+
+type cachedStoreReader struct {
+	store *CachingStore
+}
+
+func (r cachedStoreReader) Get(id string) (Bead, error) {
+	if err := r.store.ensureFullPrime(context.Background()); err != nil {
+		return Bead{}, err
+	}
+	return r.store.cachedGetOnly(id)
+}
+
+func (r cachedStoreReader) List(query ListQuery) ([]Bead, error) {
+	if err := r.store.ensureFullPrime(context.Background()); err != nil {
+		return nil, err
+	}
+	return r.store.cachedListOnly(logicalCachedListQuery(query))
+}
+
+func (r cachedStoreReader) Ready(query ...ReadyQuery) ([]Bead, error) {
+	if err := r.store.ensureFullPrime(context.Background()); err != nil {
+		return nil, err
+	}
+	return r.store.cachedReadyOnly(readyQueryFromArgs(query))
+}
+
+func (r cachedStoreReader) DepList(id, direction string) ([]Dep, error) {
+	if err := r.store.ensureFullPrime(context.Background()); err != nil {
+		return nil, err
+	}
+	return r.store.cachedDepListOnly(id, direction)
+}
+
+type liveStoreReader struct {
+	store *CachingStore
+}
+
+func (r liveStoreReader) Get(id string) (Bead, error) {
+	return r.store.backing.Get(id)
+}
+
+func (r liveStoreReader) List(query ListQuery) ([]Bead, error) {
+	query.Live = true
+	query.TierMode = TierBoth
+	return r.store.backing.List(query)
+}
+
+func (r liveStoreReader) Ready(query ...ReadyQuery) ([]Bead, error) {
+	return r.store.backing.Ready(query...)
+}
+
+func (r liveStoreReader) DepList(id, direction string) ([]Dep, error) {
+	return r.store.backing.DepList(id, direction)
+}
+
+func logicalCachedListQuery(query ListQuery) ListQuery {
+	query.Live = false
+	query.TierMode = TierBoth
+	return query
+}
+
+func (c *CachingStore) cachedGetOnly(id string) (Bead, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if _, deleted := c.deletedSeq[id]; deleted {
+		return Bead{}, ErrNotFound
+	}
+	if _, dirty := c.dirty[id]; dirty {
+		return Bead{}, fmt.Errorf("getting bead %q from cache: %w", id, ErrCacheUnavailable)
+	}
+	b, ok := c.beads[id]
+	if !ok {
+		return Bead{}, ErrNotFound
+	}
+	return cloneBead(b), nil
+}
+
+func (c *CachingStore) cachedListOnly(query ListQuery) ([]Bead, error) {
+	if !query.HasFilter() && !query.AllowScan {
+		return nil, fmt.Errorf("listing beads from cache: %w", ErrQueryRequiresScan)
+	}
+	if query.IncludesClosed() {
+		return nil, fmt.Errorf("listing closed beads from cache: %w", ErrCacheUnavailable)
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if (c.state != cacheLive && c.state != cachePartial) || c.primePartialErr != nil || len(c.dirty) > 0 {
+		return nil, fmt.Errorf("listing beads from cache: %w", ErrCacheUnavailable)
+	}
+	rows := make([]Bead, 0, len(c.beads))
+	for _, b := range c.beads {
+		if !query.Matches(b) {
+			continue
+		}
+		rows = append(rows, cloneBead(b))
+	}
+	sortBeadsForQuery(rows, query.Sort)
+	if query.Limit > 0 && len(rows) > query.Limit {
+		rows = rows[:query.Limit]
+	}
+	return rows, nil
+}
+
+func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if (c.state != cacheLive && c.state != cachePartial) || c.primePartialErr != nil || len(c.dirty) > 0 {
+		return nil, fmt.Errorf("reading ready beads from cache: %w", ErrCacheUnavailable)
+	}
+
+	statusByID := make(map[string]string, len(c.beads))
+	openBeads := make([]Bead, 0, len(c.beads))
+	for _, b := range c.beads {
+		statusByID[b.ID] = b.Status
+		if b.Status != "open" || b.Ephemeral || IsReadyExcludedType(b.Type) {
+			continue
+		}
+		if query.Assignee != "" && b.Assignee != query.Assignee {
+			continue
+		}
+		openBeads = append(openBeads, cloneBead(b))
+	}
+
+	result := make([]Bead, 0, len(openBeads))
+	for _, b := range openBeads {
+		deps, ok := c.deps[b.ID]
+		switch {
+		case ok:
+		case c.depsComplete:
+			deps = nil
+		default:
+			return nil, fmt.Errorf("reading ready deps from cache: %w", ErrCacheUnavailable)
+		}
+		if !cachedBeadReady(statusByID, deps) {
+			continue
+		}
+		result = append(result, cloneBead(b))
+		if query.Limit > 0 && len(result) >= query.Limit {
+			break
+		}
+	}
+	return result, nil
+}
+
+func (c *CachingStore) cachedDepListOnly(id, direction string) ([]Dep, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if (c.state != cacheLive && c.state != cachePartial) || c.primePartialErr != nil || len(c.dirty) > 0 {
+		return nil, fmt.Errorf("listing deps from cache: %w", ErrCacheUnavailable)
+	}
+	if direction == "" || direction == "down" {
+		deps, ok := c.deps[id]
+		if ok || c.depsComplete {
+			return cloneDeps(deps), nil
+		}
+		return nil, fmt.Errorf("listing deps from cache: %w", ErrCacheUnavailable)
+	}
+	if direction != "up" {
+		return nil, fmt.Errorf("listing deps from cache: unsupported direction %q", direction)
+	}
+	if !c.depsComplete {
+		return nil, fmt.Errorf("listing reverse deps from cache: %w", ErrCacheUnavailable)
+	}
+	var deps []Dep
+	for _, beadDeps := range c.deps {
+		for _, dep := range beadDeps {
+			if dep.DependsOnID == id {
+				deps = append(deps, dep)
+			}
+		}
+	}
+	return cloneDeps(deps), nil
+}

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -2314,7 +2314,7 @@ func TestCachingStoreBdPrimeActiveUsesListDependenciesForCachedReady(t *testing.
 	}
 }
 
-func TestCachingStoreReadySkipsEphemeralOpenTasks(t *testing.T) {
+func TestCachingStoreReadyIncludesEphemeralOpenTasks(t *testing.T) {
 	t.Parallel()
 
 	backing := NewMemStore()
@@ -2336,20 +2336,23 @@ func TestCachingStoreReadySkipsEphemeralOpenTasks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ready: %v", err)
 	}
-	if len(got) != 1 || got[0].ID != ready.ID {
-		t.Fatalf("Ready() = %+v, want only non-ephemeral task %s", got, ready.ID)
+	gotIDs := make(map[string]bool, len(got))
+	for _, bead := range got {
+		gotIDs[bead.ID] = true
+	}
+	if !gotIDs[ready.ID] || !gotIDs[ephemeral.ID] || len(gotIDs) != 2 {
+		t.Fatalf("Ready() = %+v, want regular %s and ephemeral %s", got, ready.ID, ephemeral.ID)
 	}
 	cached, ok := cache.CachedReady()
 	if !ok {
 		t.Fatal("CachedReady reported cache unavailable")
 	}
-	if len(cached) != 1 || cached[0].ID != ready.ID {
-		t.Fatalf("CachedReady() = %+v, want only non-ephemeral task %s", cached, ready.ID)
+	cachedIDs := make(map[string]bool, len(cached))
+	for _, bead := range cached {
+		cachedIDs[bead.ID] = true
 	}
-	for _, bead := range append(got, cached...) {
-		if bead.ID == ephemeral.ID {
-			t.Fatalf("ephemeral bead %s leaked into cached ready paths", ephemeral.ID)
-		}
+	if !cachedIDs[ready.ID] || !cachedIDs[ephemeral.ID] || len(cachedIDs) != 2 {
+		t.Fatalf("CachedReady() = %+v, want regular %s and ephemeral %s", cached, ready.ID, ephemeral.ID)
 	}
 }
 

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -169,6 +171,288 @@ func TestCachingStoreListLiveBypassesCache(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].ID != bead.ID {
 		t.Fatalf("List(in_progress, Live) = %+v, want %s from backing store", got, bead.ID)
+	}
+}
+
+func TestCachingStoreHandlesCachedReadsShareFullPrime(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	bead, err := mem.Create(Bead{Title: "cached work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing := &blockingPrimeListStore{
+		Store:   mem,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	handles := cache.Handles()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 3)
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		rows, err := handles.Cached.List(ListQuery{Status: "open"})
+		if err == nil && (len(rows) != 1 || rows[0].ID != bead.ID) {
+			err = fmt.Errorf("cached List rows = %#v, want %s", rows, bead.ID)
+		}
+		errs <- err
+	}()
+	go func() {
+		defer wg.Done()
+		rows, err := handles.Cached.Ready()
+		if err == nil && (len(rows) != 1 || rows[0].ID != bead.ID) {
+			err = fmt.Errorf("cached Ready rows = %#v, want %s", rows, bead.ID)
+		}
+		errs <- err
+	}()
+	go func() {
+		defer wg.Done()
+		if _, err := handles.Cached.DepList(bead.ID, "down"); err != nil {
+			errs <- err
+			return
+		}
+		errs <- nil
+	}()
+
+	select {
+	case <-backing.started:
+	case <-time.After(time.Second):
+		t.Fatal("cached reads did not start shared full prime")
+	}
+	time.Sleep(25 * time.Millisecond)
+	if got := backing.primeListCalls.Load(); got != 1 {
+		t.Fatalf("prime list calls while cached reads blocked = %d, want 1", got)
+	}
+
+	close(backing.release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := backing.primeListCalls.Load(); got != 1 {
+		t.Fatalf("total prime list calls = %d, want 1", got)
+	}
+}
+
+func TestCachingStoreHandlesCachedReadsWaitForFullPrimeAfterPrimeActive(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	bead, err := mem.Create(Bead{Title: "cached work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing := &blockingPrimeListStore{
+		Store:   mem,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		rows, err := cache.Handles().Cached.List(ListQuery{Status: "open"})
+		if err == nil && (len(rows) != 1 || rows[0].ID != bead.ID) {
+			err = fmt.Errorf("cached List rows = %#v, want %s", rows, bead.ID)
+		}
+		done <- err
+	}()
+
+	select {
+	case <-backing.started:
+	case err := <-done:
+		t.Fatalf("cached read returned before full prime: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("cached read did not start full prime after active prime")
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("cached read finished while full prime was blocked: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(backing.release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if got := backing.primeListCalls.Load(); got != 1 {
+		t.Fatalf("total prime list calls = %d, want 1", got)
+	}
+}
+
+func TestCachingStoreHandlesReadLogicalStoreWithoutTierFlags(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	issue, err := backing.Create(Bead{Title: "issue work"})
+	if err != nil {
+		t.Fatalf("Create issue: %v", err)
+	}
+	wisp, err := backing.Create(Bead{Title: "wisp work", Ephemeral: true})
+	if err != nil {
+		t.Fatalf("Create wisp: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+
+	cachedRows, err := cache.Handles().Cached.List(ListQuery{Status: "open"})
+	if err != nil {
+		t.Fatalf("Cached.List: %v", err)
+	}
+	assertHasBeadIDs(t, cachedRows, issue.ID, wisp.ID)
+
+	inProgress := "in_progress"
+	if err := backing.Update(wisp.ID, UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("Update backing wisp: %v", err)
+	}
+	liveRows, err := cache.Handles().Live.List(ListQuery{Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("Live.List: %v", err)
+	}
+	assertHasBeadIDs(t, liveRows, wisp.ID)
+}
+
+func TestHandlesForPlainStoreReadsLogicalBothTiers(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemStore()
+	issue, err := store.Create(Bead{Title: "issue work"})
+	if err != nil {
+		t.Fatalf("Create issue: %v", err)
+	}
+	wisp, err := store.Create(Bead{Title: "wisp work", Ephemeral: true})
+	if err != nil {
+		t.Fatalf("Create wisp: %v", err)
+	}
+
+	cachedRows, err := HandlesFor(store).Cached.List(ListQuery{Status: "open"})
+	if err != nil {
+		t.Fatalf("Cached.List: %v", err)
+	}
+	assertHasBeadIDs(t, cachedRows, issue.ID, wisp.ID)
+
+	liveRows, err := HandlesFor(store).Live.List(ListQuery{Status: "open"})
+	if err != nil {
+		t.Fatalf("Live.List: %v", err)
+	}
+	assertHasBeadIDs(t, liveRows, issue.ID, wisp.ID)
+}
+
+func TestCachingStoreListWispsUsesCacheByDefault(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	wisp, err := backing.Create(Bead{
+		Title:     "wisp work",
+		Assignee:  "worker",
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create wisp: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	status := "in_progress"
+	if err := backing.Update(wisp.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+
+	got, err := cache.List(ListQuery{Status: "open", Assignee: "worker", TierMode: TierWisps})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != wisp.ID {
+		t.Fatalf("List(open wisp) = %+v, want cached %s", got, wisp.ID)
+	}
+}
+
+type blockingPrimeListStore struct {
+	Store
+	started        chan struct{}
+	release        chan struct{}
+	startedOnce    sync.Once
+	primeListCalls atomic.Int64
+}
+
+func (s *blockingPrimeListStore) List(query ListQuery) ([]Bead, error) {
+	if query.AllowScan && query.SkipLabels {
+		s.primeListCalls.Add(1)
+		s.startedOnce.Do(func() { close(s.started) })
+		<-s.release
+	}
+	return s.Store.List(query)
+}
+
+func assertHasBeadIDs(t *testing.T, rows []Bead, want ...string) {
+	t.Helper()
+	got := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		got[row.ID] = true
+	}
+	for _, id := range want {
+		if !got[id] {
+			t.Fatalf("rows ids = %v rows=%#v, missing %s", got, rows, id)
+		}
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("rows ids = %v rows=%#v, want exactly %v", got, rows, want)
+	}
+}
+
+func TestCachingStoreListBothTiersUsesCachedWispsByDefault(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	issue, err := backing.Create(Bead{
+		Title:    "issue work",
+		Assignee: "worker",
+	})
+	if err != nil {
+		t.Fatalf("Create issue: %v", err)
+	}
+	wisp, err := backing.Create(Bead{
+		Title:     "wisp work",
+		Assignee:  "worker",
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create wisp: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	status := "in_progress"
+	if err := backing.Update(wisp.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+
+	got, err := cache.List(ListQuery{Status: "open", Assignee: "worker", TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, bead := range got {
+		ids[bead.ID] = true
+	}
+	if !ids[issue.ID] || !ids[wisp.ID] || len(got) != 2 {
+		t.Fatalf("List(open both tiers) ids = %v rows=%+v, want cached issue %s and wisp %s", ids, got, issue.ID, wisp.ID)
 	}
 }
 
@@ -1670,7 +1954,7 @@ func TestCachingStoreCloseAllMarksRefreshFailuresDirty(t *testing.T) {
 	}
 }
 
-func TestCachingStoreCachedListReturnsSnapshotWithDirtyEntries(t *testing.T) {
+func TestCachingStoreCachedListReflectsWriteThroughRefreshFailure(t *testing.T) {
 	t.Parallel()
 
 	backing := &refreshFailingStore{Store: NewMemStore()}
@@ -1691,24 +1975,26 @@ func TestCachingStoreCachedListReturnsSnapshotWithDirtyEntries(t *testing.T) {
 
 	rows, ok := cache.CachedList(ListQuery{Status: "open"})
 	if !ok {
-		t.Fatal("CachedList returned ok=false for dirty cache, want snapshot")
+		t.Fatal("CachedList returned ok=false after write-through update")
 	}
 	if len(rows) != 1 || rows[0].ID != bead.ID {
-		t.Fatalf("CachedList = %#v, want dirty snapshot row %s", rows, bead.ID)
+		t.Fatalf("CachedList = %#v, want row %s", rows, bead.ID)
 	}
-	if rows[0].Title == title {
-		t.Fatalf("CachedList returned refreshed title %q; test setup did not create a dirty stale snapshot", rows[0].Title)
+	if rows[0].Title != title {
+		t.Fatalf("CachedList title = %q, want write-through title %q", rows[0].Title, title)
 	}
 }
 
-func TestCachingStoreCachedListRefusesNonIssuesTierQueries(t *testing.T) {
+func TestCachingStoreCachedListSupportsActiveTierQueries(t *testing.T) {
 	t.Parallel()
 
 	backing := NewMemStore()
-	if _, err := backing.Create(Bead{Title: "plain", Labels: []string{"k"}}); err != nil {
+	plain, err := backing.Create(Bead{Title: "plain", Labels: []string{"k"}})
+	if err != nil {
 		t.Fatalf("Create plain: %v", err)
 	}
-	if _, err := backing.Create(Bead{Title: "wisp", Labels: []string{"k"}, Ephemeral: true}); err != nil {
+	wisp, err := backing.Create(Bead{Title: "wisp", Labels: []string{"k"}, Ephemeral: true})
+	if err != nil {
 		t.Fatalf("Create wisp: %v", err)
 	}
 	cache := NewCachingStoreForTest(backing, nil)
@@ -1716,10 +2002,23 @@ func TestCachingStoreCachedListRefusesNonIssuesTierQueries(t *testing.T) {
 		t.Fatalf("Prime: %v", err)
 	}
 
-	for _, tier := range []TierMode{TierWisps, TierBoth} {
-		if rows, ok := cache.CachedList(ListQuery{Label: "k", TierMode: tier}); ok {
-			t.Fatalf("CachedList tier %v ok=true rows=%#v, want ok=false", tier, rows)
-		}
+	wisps, ok := cache.CachedList(ListQuery{Label: "k", TierMode: TierWisps})
+	if !ok {
+		t.Fatal("CachedList wisps ok=false, want cached result")
+	}
+	if len(wisps) != 1 || wisps[0].ID != wisp.ID {
+		t.Fatalf("CachedList wisps = %#v, want %s", wisps, wisp.ID)
+	}
+	both, ok := cache.CachedList(ListQuery{Label: "k", TierMode: TierBoth})
+	if !ok {
+		t.Fatal("CachedList both ok=false, want cached result")
+	}
+	ids := map[string]bool{}
+	for _, row := range both {
+		ids[row.ID] = true
+	}
+	if len(both) != 2 || !ids[plain.ID] || !ids[wisp.ID] {
+		t.Fatalf("CachedList both ids = %v rows=%#v, want %s and %s", ids, both, plain.ID, wisp.ID)
 	}
 }
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -341,7 +341,7 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		openBeads := make([]Bead, 0, len(c.beads))
 		for _, b := range c.beads {
 			statusByID[b.ID] = b.Status
-			if b.Status == "open" && !b.Ephemeral && !IsReadyExcludedType(b.Type) {
+			if b.Status == "open" && !IsReadyExcludedType(b.Type) {
 				openBeads = append(openBeads, cloneBead(b))
 			}
 		}
@@ -393,7 +393,7 @@ func (c *CachingStore) CachedReady() ([]Bead, bool) {
 	openBeads := make([]Bead, 0, len(c.beads))
 	for _, b := range c.beads {
 		statusByID[b.ID] = b.Status
-		if b.Status == "open" && !b.Ephemeral && !IsReadyExcludedType(b.Type) {
+		if b.Status == "open" && !IsReadyExcludedType(b.Type) {
 			openBeads = append(openBeads, cloneBead(b))
 		}
 	}

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -15,13 +15,6 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
 	}
-	// The cache only holds the issues tier (PrimeActive/Prime call the
-	// backing store without a TierMode). Wisps and union queries must
-	// reach the backing store directly so we do not return a stale or
-	// incomplete snapshot of the wisps table.
-	if query.TierMode != TierIssues {
-		return c.backing.List(query)
-	}
 	if query.Live || query.ParentID != "" {
 		c.mu.RLock()
 		startSeq := c.mutationSeq
@@ -109,9 +102,6 @@ func liveListQuery(query ListQuery) ListQuery {
 // snapshot; callers must treat this as a read model that may lag writes or
 // reconciliation by one tick.
 func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
-	if query.TierMode != TierIssues {
-		return nil, false
-	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.state != cacheLive && c.state != cachePartial {

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -256,7 +256,7 @@ func (c *CachingStore) runReconciliation() {
 	c.mu.RUnlock()
 
 	bdStart := time.Now()
-	fresh, err := c.backing.List(ListQuery{AllowScan: true, SkipLabels: true})
+	fresh, err := c.backing.List(ListQuery{AllowScan: true, SkipLabels: true, TierMode: TierBoth})
 	bdLatency := time.Since(bdStart)
 	if err != nil {
 		c.mu.Lock()

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -545,7 +545,7 @@ func TestCachingStoreParentListDoesNotResurrectConcurrentDelete(t *testing.T) {
 	}
 }
 
-func TestCachingStoreDirtyGetPreservesConcurrentEvent(t *testing.T) {
+func TestCachingStoreUpdateRefreshFailureAppliesWriteThroughState(t *testing.T) {
 	mem := beads.NewMemStore()
 	original, err := mem.Create(beads.Bead{Title: "before"})
 	if err != nil {
@@ -565,59 +565,12 @@ func TestCachingStoreDirtyGetPreservesConcurrentEvent(t *testing.T) {
 		t.Fatalf("Update(first): %v", err)
 	}
 
-	stale, err := mem.Get(original.ID)
-	if err != nil {
-		t.Fatalf("Get(backing stale): %v", err)
-	}
-	backing.mu.Lock()
-	backing.stale = stale
-	backing.started = make(chan struct{})
-	backing.release = make(chan struct{})
-	backing.blockNextGet = true
-	backing.mu.Unlock()
-
-	gotCh := make(chan beads.Bead, 1)
-	errCh := make(chan error, 1)
-	go func() {
-		got, getErr := cs.Get(original.ID)
-		if getErr != nil {
-			errCh <- getErr
-			return
-		}
-		gotCh <- got
-	}()
-
-	<-backing.started
-	secondTitle := "after concurrent event"
-	if err := mem.Update(original.ID, beads.UpdateOpts{Title: &secondTitle}); err != nil {
-		t.Fatalf("Update(backing second): %v", err)
-	}
-	eventBead, err := mem.Get(original.ID)
-	if err != nil {
-		t.Fatalf("Get(backing second): %v", err)
-	}
-	payload, err := json.Marshal(eventBead)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	cs.ApplyEvent("bead.updated", payload)
-	close(backing.release)
-
-	select {
-	case getErr := <-errCh:
-		t.Fatalf("Get: %v", getErr)
-	case got := <-gotCh:
-		if got.Title != secondTitle {
-			t.Fatalf("Get title = %q, want %q", got.Title, secondTitle)
-		}
-	}
-
 	got, err := cs.Get(original.ID)
 	if err != nil {
-		t.Fatalf("Get cached: %v", err)
+		t.Fatalf("Get after refresh failure: %v", err)
 	}
-	if got.Title != secondTitle {
-		t.Fatalf("cached title = %q, want %q", got.Title, secondTitle)
+	if got.Title != firstTitle {
+		t.Fatalf("Get title after refresh failure = %q, want %q", got.Title, firstTitle)
 	}
 }
 
@@ -1061,34 +1014,19 @@ func (s *parentListRaceStore) List(query beads.ListQuery) ([]beads.Bead, error) 
 
 type dirtyGetRaceStore struct {
 	beads.Store
-	mu           sync.Mutex
-	failNextGet  bool
-	blockNextGet bool
-	started      chan struct{}
-	release      chan struct{}
-	stale        beads.Bead
+	mu          sync.Mutex
+	failNextGet bool
 }
 
 func (s *dirtyGetRaceStore) Get(id string) (beads.Bead, error) {
 	s.mu.Lock()
-	switch {
-	case s.failNextGet:
+	if s.failNextGet {
 		s.failNextGet = false
 		s.mu.Unlock()
 		return beads.Bead{}, errors.New("transient get failure")
-	case s.blockNextGet && id == s.stale.ID:
-		s.blockNextGet = false
-		started := s.started
-		release := s.release
-		stale := s.stale
-		s.mu.Unlock()
-		close(started)
-		<-release
-		return stale, nil
-	default:
-		s.mu.Unlock()
-		return s.Store.Get(id)
 	}
+	s.mu.Unlock()
+	return s.Store.Get(id)
 }
 
 type updateRefreshStore struct {

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -52,6 +52,20 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 	fresh, err := c.backing.Get(id)
 	if err != nil {
 		c.mu.Lock()
+		c.noteLocalMutationLocked(id)
+		if current, ok := c.beads[id]; ok {
+			fresh = applyUpdateOptsToBead(current, opts)
+			c.beads[id] = cloneBead(fresh)
+			c.deps[id] = depsFromBeadFields(fresh)
+			delete(c.dirty, id)
+			delete(c.deletedSeq, id)
+			c.markFreshLocked(time.Now())
+			c.updateStatsLocked()
+			c.mu.Unlock()
+			c.recordProblem("refresh bead after update", fmt.Errorf("%s: %w", id, err))
+			c.notifyChange("bead.updated", fresh)
+			return nil
+		}
 		c.dirty[id] = struct{}{}
 		c.mu.Unlock()
 		c.recordProblem("refresh bead after update", fmt.Errorf("%s: %w", id, err))

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -347,7 +347,7 @@ func (s *Store) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
 	}
 	result := all[:0]
 	for _, b := range all {
-		if !b.Ephemeral && !beads.IsReadyExcludedType(b.Type) {
+		if !beads.IsReadyExcludedType(b.Type) {
 			result = append(result, b)
 		}
 	}

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -177,8 +177,12 @@ func TestCreate_ephemeralRoundTripsThroughConformanceScript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ready: %v", err)
 	}
-	if len(ready) != 1 || ready[0].ID != regular.ID {
-		t.Fatalf("Ready() = %+v, want only non-ephemeral bead %s", ready, regular.ID)
+	readyIDs := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyIDs[bead.ID] = true
+	}
+	if !readyIDs[regular.ID] || !readyIDs[ephemeral.ID] || len(readyIDs) != 2 {
+		t.Fatalf("Ready() = %+v, want regular %s and ephemeral %s", ready, regular.ID, ephemeral.ID)
 	}
 
 	issuesOnly, err := s.ListByLabel("order-run:digest", 0)

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -271,9 +271,6 @@ func (m *MemStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		if b.Status != "open" {
 			continue
 		}
-		if b.Ephemeral {
-			continue
-		}
 		if IsReadyExcludedType(b.Type) {
 			continue
 		}

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -522,7 +522,7 @@ func TestMemStoreReadyPreservesBlocksWhenParentChildSharesPair(t *testing.T) {
 	}
 }
 
-func TestMemStoreReadySkipsEphemeralOpenTasks(t *testing.T) {
+func TestMemStoreReadyIncludesEphemeralOpenTasks(t *testing.T) {
 	s := beads.NewMemStore()
 
 	ready, err := s.Create(beads.Bead{Title: "ready", Type: "task"})
@@ -538,13 +538,12 @@ func TestMemStoreReadySkipsEphemeralOpenTasks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0].ID != ready.ID {
-		t.Fatalf("Ready() = %+v, want only non-ephemeral task %s", got, ready.ID)
-	}
+	gotByID := map[string]bool{}
 	for _, bead := range got {
-		if bead.ID == ephemeral.ID {
-			t.Fatalf("ephemeral bead %s leaked into Ready(): %+v", ephemeral.ID, got)
-		}
+		gotByID[bead.ID] = true
+	}
+	if !gotByID[ready.ID] || !gotByID[ephemeral.ID] || len(gotByID) != 2 {
+		t.Fatalf("Ready() = %+v, want regular %s and ephemeral %s", got, ready.ID, ephemeral.ID)
 	}
 }
 

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -501,7 +501,7 @@ func failedAttemptAttachRootID(store beads.Store, control beads.Bead, attemptNum
 	if rootID == "" {
 		rootID = control.ID
 	}
-	matches, err := store.List(beads.ListQuery{
+	matches, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
 		Metadata: map[string]string{
 			"gc.idempotency_key": fmt.Sprintf("%s:attempt:%d", control.ID, attemptNum),
 			"gc.root_bead_id":    rootID,

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -804,7 +804,11 @@ max_active_sessions = 1
 
 func assertSpawnedSpecClosedAndUnrouted(t *testing.T, store beads.Store, rootID, specFor string) {
 	t.Helper()
-	all, err := store.ListByMetadata(map[string]string{"gc.root_bead_id": rootID}, 0, beads.IncludeClosed)
+	all, err := store.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": rootID},
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+	})
 	if err != nil {
 		t.Fatalf("ListByMetadata(gc.root_bead_id=%q): %v", rootID, err)
 	}
@@ -1368,7 +1372,7 @@ func TestRetryIdempotencyKeyPreventsDoubleSpawn(t *testing.T) {
 // findAttemptByRef finds a bead with a matching gc.step_ref in the workflow.
 func findAttemptByRef(t *testing.T, store beads.Store, _, stepRef string) beads.Bead {
 	t.Helper()
-	all, err := store.ListOpen()
+	all, err := store.List(beads.ListQuery{AllowScan: true, TierMode: beads.TierBoth})
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -411,7 +411,7 @@ func loadScopeSnapshotWithBody(store beads.Store, rootID, scopeRef string, body 
 }
 
 func listByWorkflowRootAndScope(store beads.Store, rootID, scopeRef string) ([]beads.Bead, error) {
-	return store.List(beads.ListQuery{
+	return beads.HandlesFor(store).Live.List(beads.ListQuery{
 		Metadata: map[string]string{
 			"gc.root_bead_id": rootID,
 			"gc.scope_ref":    scopeRef,
@@ -421,7 +421,7 @@ func listByWorkflowRootAndScope(store beads.Store, rootID, scopeRef string) ([]b
 }
 
 func listActiveByWorkflowRootAndScope(store beads.Store, rootID, scopeRef string) ([]beads.Bead, error) {
-	return store.List(beads.ListQuery{
+	return beads.HandlesFor(store).Live.List(beads.ListQuery{
 		Metadata: map[string]string{
 			"gc.root_bead_id": rootID,
 			"gc.scope_ref":    scopeRef,
@@ -892,7 +892,7 @@ func sourceWorkflowChildSources(store beads.Store, sourceBeadID, sourceStoreRef,
 	if store == nil || sourceBeadID == "" {
 		return nil, nil
 	}
-	candidates, err := store.List(beads.ListQuery{
+	candidates, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
 		IncludeClosed: true,
 		Metadata: map[string]string{
 			"gc.source_bead_id": sourceBeadID,
@@ -1173,7 +1173,7 @@ func resolveScopeBodyOnce(store beads.Store, rootID, scopeRef string) (beads.Bea
 }
 
 func resolveScopeBodyByRole(store beads.Store, rootID, scopeRef string, includeClosed bool) (beads.Bead, bool, error) {
-	matches, err := store.List(beads.ListQuery{
+	matches, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
 		Metadata: map[string]string{
 			"gc.root_bead_id": rootID,
 			"gc.kind":         "scope",
@@ -1218,7 +1218,7 @@ func sortedPendingIDs(pending map[string]beads.Bead) []string {
 }
 
 func listByWorkflowRoot(store beads.Store, rootID string) ([]beads.Bead, error) {
-	all, err := store.List(beads.ListQuery{
+	all, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
 		Metadata:      map[string]string{"gc.root_bead_id": rootID},
 		IncludeClosed: true,
 	})

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -168,7 +168,7 @@ func ListLiveRoots(store beads.Store, sourceBeadID, sourceStoreRef, rootStoreRef
 	if store == nil || sourceBeadID == "" {
 		return nil, nil
 	}
-	roots, err := store.List(beads.ListQuery{
+	roots, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
 		Metadata: map[string]string{
 			"gc.source_bead_id": sourceBeadID,
 		},


### PR DESCRIPTION
## Summary
Minimal dependent draft PR cherry-picked from `27f611cc` on `feature/city-rescue-main-drain-v0`.

Base branch: `drain/cached-live-bead-store-handles` (#2750), because this slice changes cache-handle code introduced there.

## Tests
Not run; draft PR created for staged review and follow-up validation.

## Draft Notes
This PR is intentionally draft and has no auto-review label. Once #2750 is approved/merged, we can retarget this to `main`, mark it ready for review, and add `status/needs-review-auto`.