### PR TITLE
[BLOCKED: Beads 1.0.5] fix(beads): enable graph apply for bd store

### DIFF
--- a/internal/beads/bdstore_graph_apply.go
+++ b/internal/beads/bdstore_graph_apply.go
@@ -54,3 +54,10 @@ func (s *BdStore) ApplyGraphPlan(_ context.Context, plan *GraphApplyPlan) (*Grap
 	}
 	return &result, nil
 }
+
+// SupportsEphemeralGraphApply reports whether this store can apply a whole
+// graph directly into ephemeral storage. Current bd graph create preserves the
+// requested storage tier, so Gas City can use the atomic graph path.
+func (s *BdStore) SupportsEphemeralGraphApply() bool {
+	return true
+}

--- a/internal/beads/bdstore_graph_apply_test.go
+++ b/internal/beads/bdstore_graph_apply_test.go
@@ -1,0 +1,14 @@
+package beads_test
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestBdStoreSupportsEphemeralGraphApply(t *testing.T) {
+	store := beads.NewBdStore(t.TempDir(), nil)
+	if !store.SupportsEphemeralGraphApply() {
+		t.Fatal("SupportsEphemeralGraphApply() = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary
Independent draft PR adapted from `3c490348` on `feature/city-rescue-main-drain-v0`.

Base branch: `main`.

On current `main`, this is isolated to the BdStore graph-apply support flag plus regression coverage. The caller-side graph-ephemeral fallback remains separate in #2746.

## Tests
- `go test ./internal/beads -run TestBdStoreSupportsEphemeralGraphApply`

## Draft Notes
This PR is intentionally draft and has no auto-review label. Once approved, we can mark it ready for review and add `status/needs-review-auto`.