### PR TITLE
Refresh cached mail session routes

### DIFF
--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/mail"
@@ -22,6 +23,8 @@ const (
 	fromDisplayMetadataKey   = mail.FromDisplayMetadataKey
 	toSessionIDMetadataKey   = mail.ToSessionIDMetadataKey
 	toDisplayMetadataKey     = mail.ToDisplayMetadataKey
+
+	cachedSessionBeadRefreshInterval = 30 * time.Second
 )
 
 // Provider implements [mail.Provider] using [beads.Store] as the backend.
@@ -31,9 +34,12 @@ type Provider struct {
 }
 
 type sessionBeadCache struct {
-	mu      sync.Mutex
-	list    []beads.Bead
-	fetched bool
+	mu              sync.Mutex
+	list            []beads.Bead
+	fetchedAt       time.Time
+	refreshInterval time.Duration
+	now             func() time.Time
+	fetched         bool
 }
 
 // New returns a beadmail provider backed by the given store.
@@ -47,12 +53,13 @@ func New(store beads.Store) *Provider {
 // NewCached returns a beadmail provider backed by the given store with a
 // provider-local session enumeration cache. Command-scoped callers use this to
 // avoid repeated session scans during one command. Long-lived API providers use
-// it to keep steady-state mail reads cheap; they observe session-topology
-// changes when their owning controller rebuilds the provider.
+// it to keep steady-state mail reads cheap; they refresh session topology after
+// a bounded interval so new and closed sessions are observed without controller
+// restart.
 func NewCached(store beads.Store) *Provider {
 	return &Provider{
 		store:        store,
-		sessionCache: &sessionBeadCache{},
+		sessionCache: &sessionBeadCache{refreshInterval: cachedSessionBeadRefreshInterval},
 	}
 }
 
@@ -72,7 +79,8 @@ func (p *Provider) cachedSessionBeads() ([]beads.Bead, error) {
 func (c *sessionBeadCache) get(store beads.Store) ([]beads.Bead, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.fetched {
+	now := c.currentTime()
+	if c.fetched && c.isFresh(now) {
 		return c.list, nil
 	}
 	list, err := session.ListAllSessionBeads(store, beads.ListQuery{IncludeClosed: true})
@@ -80,8 +88,20 @@ func (c *sessionBeadCache) get(store beads.Store) ([]beads.Bead, error) {
 		return nil, err
 	}
 	c.list = list
+	c.fetchedAt = now
 	c.fetched = true
 	return list, nil
+}
+
+func (c *sessionBeadCache) currentTime() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+func (c *sessionBeadCache) isFresh(now time.Time) bool {
+	return c.refreshInterval > 0 && now.Sub(c.fetchedAt) < c.refreshInterval
 }
 
 // Send creates a message bead with subject in Title and body in Description.

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/mail"
@@ -2192,6 +2193,19 @@ func (s *countingSessionListStore) sessionListCallCount() int {
 	return s.sessionListCalls
 }
 
+func setCachedProviderClock(t *testing.T, p *Provider, start time.Time) func(time.Duration) {
+	t.Helper()
+	if p.sessionCache == nil {
+		t.Fatal("cached provider has nil session cache")
+	}
+	current := start
+	p.sessionCache.refreshInterval = time.Minute
+	p.sessionCache.now = func() time.Time { return current }
+	return func(d time.Duration) {
+		current = current.Add(d)
+	}
+}
+
 func TestProvider_DefaultProviderSeesNewHistoricalAliasSessionAcrossCalls(t *testing.T) {
 	// Pin: the default Provider is safe for long-lived shared use. If a lookup
 	// runs before the matching session exists, later lookups must see newly
@@ -2315,6 +2329,141 @@ func TestProviderCached_BroadSessionListCacheConcurrentAccess(t *testing.T) {
 	}
 	if got := store.sessionListCallCount(); got != 1 {
 		t.Errorf("broad gc:session List calls = %d, want 1 under concurrent access", got)
+	}
+}
+
+func TestProviderCached_RefreshSeesNewHistoricalAliasSession(t *testing.T) {
+	store := &countingSessionListStore{MemStore: beads.NewMemStore()}
+	p := NewCached(store)
+	advance := setCachedProviderClock(t, p, time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC))
+
+	if _, err := p.Inbox("old-route"); err != nil {
+		t.Fatalf("initial Inbox(old-route): %v", err)
+	}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-a",
+			"alias_history": "old-route",
+			"session_name":  "wf__a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	if _, err := p.Send("human", sessionBead.Metadata["alias"], "", "visible after refresh"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	advance(2 * time.Minute)
+
+	msgs, err := p.Inbox("old-route")
+	if err != nil {
+		t.Fatalf("refreshed Inbox(old-route): %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Body != "visible after refresh" {
+		t.Fatalf("Inbox(old-route) = %#v, want new session mail after refresh", msgs)
+	}
+	if got := store.sessionListCallCount(); got != 2 {
+		t.Errorf("broad gc:session List calls = %d, want initial scan plus refresh", got)
+	}
+}
+
+func TestProviderCached_RefreshRemovesClosedSessionFromLiveHistoricalMatch(t *testing.T) {
+	store := &countingSessionListStore{MemStore: beads.NewMemStore()}
+	p := NewCached(store)
+	advance := setCachedProviderClock(t, p, time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC))
+
+	oldSession, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-old",
+			"alias_history": "old-route",
+			"session_name":  "wf__old",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create old session: %v", err)
+	}
+	if _, err := p.Inbox("old-route"); err != nil {
+		t.Fatalf("prime Inbox(old-route): %v", err)
+	}
+	if _, err := p.Send("human", oldSession.Metadata["alias"], "", "stale closed session mail"); err != nil {
+		t.Fatalf("Send old: %v", err)
+	}
+	if err := store.Close(oldSession.ID); err != nil {
+		t.Fatalf("Close old session: %v", err)
+	}
+	newSession, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-new",
+			"alias_history": "old-route",
+			"session_name":  "wf__new",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create new session: %v", err)
+	}
+	if _, err := p.Send("human", newSession.Metadata["alias"], "", "live replacement mail"); err != nil {
+		t.Fatalf("Send new: %v", err)
+	}
+	advance(2 * time.Minute)
+
+	msgs, err := p.Inbox("old-route")
+	if err != nil {
+		t.Fatalf("refreshed Inbox(old-route): %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Body != "live replacement mail" {
+		t.Fatalf("Inbox(old-route) = %#v, want refreshed live replacement only", msgs)
+	}
+	if got := store.sessionListCallCount(); got != 2 {
+		t.Errorf("broad gc:session List calls = %d, want initial scan plus refresh", got)
+	}
+}
+
+func TestProviderCached_ExpiredRefreshConcurrentAccessScansOnce(t *testing.T) {
+	store := &countingSessionListStore{MemStore: beads.NewMemStore()}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-a",
+			"alias_history": "old-route",
+			"session_name":  "wf__a",
+		},
+	}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	p := NewCached(store)
+	advance := setCachedProviderClock(t, p, time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC))
+	if _, err := p.Inbox("old-route"); err != nil {
+		t.Fatalf("prime Inbox(old-route): %v", err)
+	}
+	advance(2 * time.Minute)
+
+	const workers = 16
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := p.Inbox("old-route")
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Inbox(old-route): %v", err)
+		}
+	}
+	if got := store.sessionListCallCount(); got != 2 {
+		t.Errorf("broad gc:session List calls = %d, want initial scan plus one concurrent refresh", got)
 	}
 }
 

--- a/release-gates/ga-qlyszz-mail-cache-refresh-gate.md
+++ b/release-gates/ga-qlyszz-mail-cache-refresh-gate.md
@@ -1,0 +1,49 @@
+# Release gate: ga-qlyszz mail cache refresh
+
+**Deploy bead:** `ga-qlyszz` — needs-deploy: cached mail session route refresh
+**Source review bead:** `ga-dqlij2` — Review: cached mail session route refresh
+**Source branch:** `builder/ga-inf8lf.2-mail-cache-refresh`
+**Deploy branch:** `deploy/ga-qlyszz-mail-cache-refresh`
+**Reviewed feature HEAD:** `290d58d0a`
+**Verdict:** **PASS**
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead `ga-dqlij2` is closed with `REVIEWER VERDICT: PASS`; deploy bead `ga-qlyszz` records reviewer PASS for `290d58d0a`. Single-pass review is accepted while gemini second-pass is disabled. |
+| 2 | Acceptance criteria met | PASS | Acceptance coverage verified in `internal/mail/beadmail`: cached providers refresh live/historical session routes after the bounded interval, remove closed-session routes, keep steady-state reads cached, and serialize concurrent refreshes. Focused acceptance tests pass; see test runs. |
+| 3 | Tests pass | PASS | `make test-fast-parallel`, `go vet ./...`, and focused beadmail acceptance tests all pass on the deploy branch. |
+| 4 | No high-severity review findings open | PASS | Review notes list informational findings only: broad scan trade-off, zero refresh interval behavior for non-cached provider, serialized refresh mutex, and optional `MultiRecipientInboxer` dispatch. 0 HIGH findings. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file; after the gate commit the deployer rechecks clean status before PR creation. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree --quiet HEAD origin/main` exits 0 before the gate commit, with no merge conflicts. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem: cached session-route discovery for beadmail providers in `internal/mail/beadmail`. The only files changed are `beadmail.go` and `beadmail_test.go`. |
+
+## Test Runs
+
+Commands run by deployer on `deploy/ga-qlyszz-mail-cache-refresh` at reviewed feature HEAD `290d58d0a`:
+
+```text
+$ make test-fast-parallel
+All fast jobs passed
+
+$ go vet ./...
+(clean)
+
+$ go test ./internal/mail/beadmail -run 'TestProviderCached_(RefreshSeesNewHistoricalAliasSession|RefreshRemovesClosedSessionFromLiveHistoricalMatch|ExpiredRefreshConcurrentAccessScansOnce|BroadSessionListCacheConcurrentAccess)$'
+ok  	github.com/gastownhall/gascity/internal/mail/beadmail	0.006s
+```
+
+## Commits In Scope
+
+```text
+290d58d0a fix: refresh cached mail session routes (refs ga-inf8lf.2)
+4cd12f8a9 test: red cached mail session refresh (refs ga-inf8lf.2)
+```
+
+## Files In Scope
+
+```text
+internal/mail/beadmail/beadmail.go
+internal/mail/beadmail/beadmail_test.go
+```


### PR DESCRIPTION
## What this changes

Long-lived cached mail providers now refresh their session-route list on a bounded interval instead of keeping the startup snapshot indefinitely. Operators using `gc mail read` or API-backed mail reads can see newly started sessions and stop routing to closed sessions without paying for a broad session scan on every steady-state read.

The change keeps cached providers fast on cache hits and leaves non-cached providers with their existing always-refresh behavior. Concurrent refreshes are serialized so a slow store does not trigger duplicate broad scans under load.

## Review notes

- The behavior lives in `internal/mail/beadmail`, especially the cached provider session-bead cache and route lookup path.
- There are no config, command-line, or HTTP wire-shape changes.
- The main edge cases are new-session visibility, closed-session removal, cache-hit behavior, and concurrent refresh behavior.

## Test plan

- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go test ./internal/mail/beadmail -run 'TestProviderCached_(RefreshSeesNewHistoricalAliasSession|RefreshRemovesClosedSessionFromLiveHistoricalMatch|ExpiredRefreshConcurrentAccessScansOnce|BroadSessionListCacheConcurrentAccess)$'`
- [x] Release gate: [`release-gates/ga-qlyszz-mail-cache-refresh-gate.md`](release-gates/ga-qlyszz-mail-cache-refresh-gate.md)
