### PR TITLE
Handle store-slow mail reads explicitly

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -35,6 +35,7 @@ const (
 	mailInjectMaxMessages     = 3
 	mailInjectBodyPreviewSize = 240
 	mailInjectPreviewScanSize = 4096
+	mailCheckDegradedNotice   = "[mail check degraded — store slow; run 'gc mail inbox' when the factory load drops]"
 )
 
 type mailInboxJSONResult struct {
@@ -544,6 +545,9 @@ func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *
 		if !api.ShouldFallbackForRead(err) {
 			logRoute(stderr, cmdName, "api", "error")
 			if inject {
+				if api.IsStoreSlowError(err) {
+					_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", mailCheckDegradedNotice)
+				}
 				return 0
 			}
 			fmt.Fprintf(stderr, "gc mail check: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -32,10 +32,11 @@ import (
 type nudgeFunc func(recipient string) error
 
 const (
-	mailInjectMaxMessages     = 3
-	mailInjectBodyPreviewSize = 240
-	mailInjectPreviewScanSize = 4096
-	mailCheckDegradedNotice   = "[mail check degraded — store slow; run 'gc mail inbox' when the factory load drops]"
+	mailInjectMaxMessages          = 3
+	mailInjectBodyPreviewSize      = 240
+	mailInjectPreviewScanSize      = 4096
+	mailCheckDegradedNotice        = "[mail check degraded — store slow; run 'gc mail inbox' when the factory load drops]"
+	mailCheckPartialDegradedNotice = "[mail check degraded — partial provider read; run 'gc mail inbox' after the provider recovers]"
 )
 
 type mailInboxJSONResult struct {
@@ -539,6 +540,19 @@ func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *
 	if c != nil {
 		cr, err := c.ListMailInbox(recipient, "")
 		if err == nil {
+			if mailListHasPartial(cr.Body) {
+				logRoute(stderr, cmdName, "api", "error")
+				if inject {
+					notice := formatMailCheckPartialDegradedNotice()
+					if mailListHasStoreSlowPartial(cr.Body) {
+						notice = formatMailCheckDegradedNotice()
+					}
+					_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", notice)
+					return 0
+				}
+				fmt.Fprintf(stderr, "gc mail check: %s\n", mailListPartialErrorDetail(cr.Body)) //nolint:errcheck // best-effort stderr
+				return 1
+			}
 			logRoute(stderr, cmdName, "api", "")
 			return renderMailCheckFromAPI(cr, recipient, inject, hookFormat, stdout)
 		}
@@ -546,7 +560,7 @@ func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *
 			logRoute(stderr, cmdName, "api", "error")
 			if inject {
 				if api.IsStoreSlowError(err) {
-					_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", mailCheckDegradedNotice)
+					_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatMailCheckDegradedNotice())
 				}
 				return 0
 			}
@@ -565,8 +579,8 @@ func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *
 // Without --inject, returns 0 if mail exists and 1 if empty, matching the
 // local fallback contract; human output appends a stale-read banner when the
 // supervisor cache is > 30 s old.
-func renderMailCheckFromAPI(cr api.CachedRead[[]mail.Message], recipient string, inject bool, hookFormat string, stdout io.Writer) int {
-	messages := cr.Body
+func renderMailCheckFromAPI(cr api.CachedRead[api.MailListView], recipient string, inject bool, hookFormat string, stdout io.Writer) int {
+	messages := cr.Body.Items
 	if inject {
 		if len(messages) > 0 {
 			_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatInjectOutput(messages))
@@ -581,6 +595,53 @@ func renderMailCheckFromAPI(cr api.CachedRead[[]mail.Message], recipient string,
 		fmt.Fprintf(stdout, "(cache age: %.0fs — reconciler may be lagging)\n", cr.AgeSeconds) //nolint:errcheck // best-effort stdout
 	}
 	return 0
+}
+
+func mailListHasStoreSlowPartial(view api.MailListView) bool {
+	return mailPartialHasStoreSlow(view.Partial, view.PartialErrors)
+}
+
+func mailListHasPartial(view api.MailListView) bool {
+	return view.Partial || len(view.PartialErrors) > 0
+}
+
+func mailListPartialErrorDetail(view api.MailListView) string {
+	return mailPartialErrorDetail(view.PartialErrors, "partial mail read failed")
+}
+
+func mailCountHasPartial(view api.MailCountView) bool {
+	return view.Partial || len(view.PartialErrors) > 0
+}
+
+func mailCountPartialErrorDetail(view api.MailCountView) string {
+	return mailPartialErrorDetail(view.PartialErrors, "partial mail count failed")
+}
+
+func mailPartialHasStoreSlow(partial bool, partialErrors []string) bool {
+	if !partial {
+		return false
+	}
+	for _, msg := range partialErrors {
+		if strings.Contains(msg, api.StoreSlowErrorCode+":") || strings.HasPrefix(msg, api.StoreSlowErrorCode) {
+			return true
+		}
+	}
+	return false
+}
+
+func mailPartialErrorDetail(partialErrors []string, fallback string) string {
+	if len(partialErrors) == 0 {
+		return fallback
+	}
+	return strings.Join(partialErrors, "; ")
+}
+
+func formatMailCheckDegradedNotice() string {
+	return "<system-reminder>\n" + mailCheckDegradedNotice + "\n</system-reminder>\n"
+}
+
+func formatMailCheckPartialDegradedNotice() string {
+	return "<system-reminder>\n" + mailCheckPartialDegradedNotice + "\n</system-reminder>\n"
 }
 
 // doMailCheckFallback is the direct-bd path for `gc mail check`.
@@ -2427,6 +2488,11 @@ func routeMailCount(_ string, args []string, c *api.Client, nilReason string, js
 	if c != nil {
 		cr, err := c.CountMail(recipient, "")
 		if err == nil {
+			if mailCountHasPartial(cr.Body) {
+				logRoute(stderr, cmdName, "api", "error")
+				fmt.Fprintf(stderr, "gc mail count: %s\n", mailCountPartialErrorDetail(cr.Body)) //nolint:errcheck // best-effort stderr
+				return 1
+			}
 			logRoute(stderr, cmdName, "api", "")
 			if jsonOut {
 				if err := writeCLIJSONLine(stdout, mailCountJSONResult{

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3401,6 +3401,40 @@ func okMailCheckHandler(_ *testing.T) http.Handler {
 	})
 }
 
+func partialStoreSlowMailCheckHandler(_ *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-GC-Cache-Age-S", "2")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"items": []map[string]any{
+				{"id": "msg-1", "from": "alice", "to": "mayor", "subject": "hi", "body": "hello", "created_at": "2026-04-23T10:00:00Z", "read": false},
+			},
+			"total":   1,
+			"partial": true,
+			"partial_errors": []string{
+				"mail provider slow: store_slow: mail read timed out after 8s",
+			},
+		})
+	})
+}
+
+func partialProviderErrorMailCheckHandler(_ *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-GC-Cache-Age-S", "2")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"items": []map[string]any{
+				{"id": "msg-1", "from": "alice", "to": "mayor", "subject": "hi", "body": "hello", "created_at": "2026-04-23T10:00:00Z", "read": false},
+			},
+			"total":   1,
+			"partial": true,
+			"partial_errors": []string{
+				"mail provider beta: disk unavailable",
+			},
+		})
+	})
+}
+
 func okMailPeekHandler(_ *testing.T) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("X-GC-Cache-Age-S", "2")
@@ -3422,6 +3456,21 @@ func okMailCountHandler(_ *testing.T) http.Handler {
 		w.Header().Set("X-GC-Cache-Age-S", "2")
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{"total": 3, "unread": 1}) //nolint:errcheck
+	})
+}
+
+func partialStoreSlowMailCountHandler(_ *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-GC-Cache-Age-S", "2")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"total":   3,
+			"unread":  1,
+			"partial": true,
+			"partial_errors": []string{
+				"mail provider slow: store_slow: mail read timed out after 8s",
+			},
+		})
 	})
 }
 
@@ -3571,6 +3620,48 @@ func TestRouteMailCheck_SixRowMatrix(t *testing.T) {
 	}
 }
 
+func TestRouteMailCountPartialStoreSlowHumanReturnsError(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(partialStoreSlowMailCountHandler(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailCount(cityPath, []string{"mayor"}, c, "", false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if !strings.Contains(stderr.String(), "store_slow: mail read timed out after 8s") {
+		t.Fatalf("stderr missing store_slow partial detail:\n%s", stderr.String())
+	}
+}
+
+func TestRouteMailCountPartialStoreSlowJSONReturnsError(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(partialStoreSlowMailCountHandler(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailCount(cityPath, []string{"mayor"}, c, "", true, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if !strings.Contains(stderr.String(), "store_slow: mail read timed out after 8s") {
+		t.Fatalf("stderr missing store_slow partial detail:\n%s", stderr.String())
+	}
+}
+
 func TestRouteMailCheckInjectStoreSlowEmitsDegradedNotice(t *testing.T) {
 	cityPath := writeMailTestCity(t)
 	t.Setenv("GC_DEBUG", "1")
@@ -3583,12 +3674,93 @@ func TestRouteMailCheckInjectStoreSlowEmitsDegradedNotice(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
-	if got, want := stdout.String(), mailCheckDegradedNotice; got != want {
+	if got, want := stdout.String(), expectedMailCheckDegradedInjectOutput(); got != want {
 		t.Fatalf("stdout = %q, want exact degraded notice %q", got, want)
 	}
 	assertMailRouteLog(t, stderr.String(), "api", "error")
 	if strings.Contains(stderr.String(), "gc mail check:") {
 		t.Fatalf("inject mode surfaced store_slow as stderr error:\n%s", stderr.String())
+	}
+}
+
+func TestRouteMailCheckPartialStoreSlowInjectEmitsDegradedNotice(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(partialStoreSlowMailCheckHandler(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailCheck(cityPath, []string{"mayor"}, true, "", c, "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if got, want := stdout.String(), expectedMailCheckDegradedInjectOutput(); got != want {
+		t.Fatalf("stdout = %q, want exact degraded notice %q", got, want)
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+}
+
+func TestRouteMailCheckPartialStoreSlowNonInjectReturnsError(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(partialStoreSlowMailCheckHandler(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailCheck(cityPath, []string{"mayor"}, false, "", c, "", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if !strings.Contains(stderr.String(), "store_slow: mail read timed out after 8s") {
+		t.Fatalf("stderr missing store_slow partial detail:\n%s", stderr.String())
+	}
+}
+
+func TestRouteMailCheckPartialProviderErrorInjectEmitsDegradedNotice(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(partialProviderErrorMailCheckHandler(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailCheck(cityPath, []string{"mayor"}, true, "", c, "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if got, want := stdout.String(), expectedMailCheckPartialDegradedInjectOutput(); got != want {
+		t.Fatalf("stdout = %q, want exact degraded notice %q", got, want)
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if strings.Contains(stderr.String(), "gc mail check:") {
+		t.Fatalf("inject mode surfaced partial read as stderr error:\n%s", stderr.String())
+	}
+}
+
+func TestRouteMailCheckPartialProviderErrorNonInjectReturnsError(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(partialProviderErrorMailCheckHandler(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailCheck(cityPath, []string{"mayor"}, false, "", c, "", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if !strings.Contains(stderr.String(), "mail provider beta: disk unavailable") {
+		t.Fatalf("stderr missing partial provider detail:\n%s", stderr.String())
 	}
 }
 
@@ -3608,6 +3780,38 @@ func TestRouteMailCheckStoreSlowNonInjectReturnsError(t *testing.T) {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
 	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if !strings.Contains(stderr.String(), "store_slow: mail read timed out after 8s") {
+		t.Fatalf("stderr missing store_slow detail:\n%s", stderr.String())
+	}
+}
+
+func expectedMailCheckDegradedInjectOutput() string {
+	return "<system-reminder>\n" + mailCheckDegradedNotice + "\n</system-reminder>\n"
+}
+
+func expectedMailCheckPartialDegradedInjectOutput() string {
+	return "<system-reminder>\n" + mailCheckPartialDegradedNotice + "\n</system-reminder>\n"
+}
+
+func TestRouteMailPeekStoreSlowDoesNotFallback(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(mailProblemHandler(http.StatusServiceUnavailable, "store_slow: mail read timed out after 8s")(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailPeek(cityPath, []string{"msg-1"}, c, "", false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if strings.Contains(stderr.String(), "route=fallback") {
+		t.Fatalf("store_slow peek fell back to local store:\n%s", stderr.String())
+	}
 	if !strings.Contains(stderr.String(), "store_slow: mail read timed out after 8s") {
 		t.Fatalf("stderr missing store_slow detail:\n%s", stderr.String())
 	}
@@ -3814,14 +4018,16 @@ func TestRouteMailCheck_StaleBannerOver30s(t *testing.T) {
 }
 
 func TestRenderMailCheckFromAPIInjectCodexUsesUserPromptSubmit(t *testing.T) {
-	cr := api.CachedRead[[]mail.Message]{
-		Body: []mail.Message{{
-			ID:        "msg-1",
-			From:      "human",
-			To:        "mayor",
-			Body:      "review this",
-			CreatedAt: time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
-		}},
+	cr := api.CachedRead[api.MailListView]{
+		Body: api.MailListView{
+			Items: []mail.Message{{
+				ID:        "msg-1",
+				From:      "human",
+				To:        "mayor",
+				Body:      "review this",
+				CreatedAt: time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+			}},
+		},
 	}
 
 	var stdout bytes.Buffer

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3571,6 +3571,48 @@ func TestRouteMailCheck_SixRowMatrix(t *testing.T) {
 	}
 }
 
+func TestRouteMailCheckInjectStoreSlowEmitsDegradedNotice(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(mailProblemHandler(http.StatusServiceUnavailable, "store_slow: mail read timed out after 8s")(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailCheck(cityPath, []string{"mayor"}, true, "", c, "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if got, want := stdout.String(), mailCheckDegradedNotice; got != want {
+		t.Fatalf("stdout = %q, want exact degraded notice %q", got, want)
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if strings.Contains(stderr.String(), "gc mail check:") {
+		t.Fatalf("inject mode surfaced store_slow as stderr error:\n%s", stderr.String())
+	}
+}
+
+func TestRouteMailCheckStoreSlowNonInjectReturnsError(t *testing.T) {
+	cityPath := writeMailTestCity(t)
+	t.Setenv("GC_DEBUG", "1")
+	srv := httptest.NewServer(mailProblemHandler(http.StatusServiceUnavailable, "store_slow: mail read timed out after 8s")(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	code := routeMailCheck(cityPath, []string{"mayor"}, false, "", c, "", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	assertMailRouteLog(t, stderr.String(), "api", "error")
+	if !strings.Contains(stderr.String(), "store_slow: mail read timed out after 8s") {
+		t.Fatalf("stderr missing store_slow detail:\n%s", stderr.String())
+	}
+}
+
 func TestRouteMailPeek_SixRowMatrix(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -87,8 +87,29 @@ func (e *cacheNotLiveError) Error() string {
 	return e.msg
 }
 
+// storeSlowError indicates the supervisor returned 503 because a mail read
+// exceeded its internal store deadline. It is intentionally not fallbackable:
+// the local store path is affected by the same contention.
+type storeSlowError struct {
+	msg string
+}
+
+func (e *storeSlowError) Error() string {
+	if e.msg == "" {
+		return "store slow: try again when load drops"
+	}
+	return e.msg
+}
+
+// IsStoreSlowError reports whether err originated from an API mail store
+// timeout. Callers must not fall back to the local store for this error.
+func IsStoreSlowError(err error) bool {
+	var sse *storeSlowError
+	return errors.As(err, &sse)
+}
+
 // serverError indicates a generic 5xx API response without a recognized
-// detail prefix (cache_not_live / read_only / not_found). Read-path callers
+// 503 detail prefix such as cache_not_live or store_slow. Read-path callers
 // classify it as fallbackable via ShouldFallbackForRead so the CLI lands on
 // direct bd when the supervisor is unhealthy. Mutation callers continue to
 // surface it as a hard error (ShouldFallback returns false) because writes
@@ -1139,12 +1160,21 @@ func apiErrorFromResponse(status int, pd *genclient.ErrorModel) error {
 		}
 		return &readOnlyError{msg: msg}
 	}
-	if status == http.StatusServiceUnavailable && strings.HasPrefix(detail, "cache_not_live") {
-		msg := detail
-		if msg == "" {
-			msg = "cache not yet live"
+	if status == http.StatusServiceUnavailable {
+		if strings.HasPrefix(detail, "cache_not_live") {
+			msg := detail
+			if msg == "" {
+				msg = "cache not yet live"
+			}
+			return &cacheNotLiveError{msg: msg}
 		}
-		return &cacheNotLiveError{msg: msg}
+		if strings.HasPrefix(detail, "store_slow") {
+			msg := detail
+			if msg == "" {
+				msg = "store slow: try again when load drops"
+			}
+			return &storeSlowError{msg: msg}
+		}
 	}
 	// Generic 5xx (500/501/502/504/... plus 503 without a cache_not_live
 	// prefix) wraps into a serverError so read-path callers can classify it

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -94,6 +94,10 @@ type storeSlowError struct {
 	msg string
 }
 
+// StoreSlowErrorCode is the stable problem-detail prefix for mail read
+// timeouts that must not fall back to the local store path.
+const StoreSlowErrorCode = "store_slow"
+
 func (e *storeSlowError) Error() string {
 	if e.msg == "" {
 		return "store slow: try again when load drops"
@@ -174,8 +178,9 @@ func ShouldFallback(err error) bool {
 // ShouldFallbackForRead(err) is true. The set is closed: "cache-not-live",
 // "read-only", "client-init", "conn-refused". Generic 5xx server errors
 // collapse to "conn-refused" since from the CLI's read-path perspective an
-// unhealthy server is equivalent to an unreachable one. Returns "unknown"
-// for non-fallbackable errors so callers that invoke FallbackReason
+// unhealthy server is equivalent to an unreachable one. Non-fallbackable error
+// types such as store_slow are intentionally absent from this set. Returns
+// "unknown" for non-fallbackable errors so callers that invoke FallbackReason
 // unconditionally produce a token instead of panicking; gate on
 // ShouldFallbackForRead first to avoid that sentinel.
 func FallbackReason(err error) string {
@@ -790,13 +795,15 @@ func (c *Client) GetStatus() (CachedRead[StatusView], error) {
 // ListMailInbox fetches unread messages for the given agent recipient via
 // GET /v0/city/{cityName}/mail. An empty agent lets the server choose the
 // default caller identity (same resolution path the CLI would take locally).
-// rig narrows the query to a single rig's provider when set. The
+// rig narrows the query to a single rig's provider when set. The returned
+// MailListView preserves partial aggregate-read metadata so callers do not
+// silently treat a degraded all-rig read as authoritative. The
 // CachedRead.AgeSeconds field carries the supervisor CachingStore age so
 // callers can surface _cache_age_s on --json output and a staleness banner
 // on human output.
-func (c *Client) ListMailInbox(agent, rig string) (CachedRead[[]mail.Message], error) {
+func (c *Client) ListMailInbox(agent, rig string) (CachedRead[MailListView], error) {
 	if err := c.requireCityScope(); err != nil {
-		return CachedRead[[]mail.Message]{}, err
+		return CachedRead[MailListView]{}, err
 	}
 	params := &genclient.GetV0CityByCityNameMailParams{}
 	if agent != "" {
@@ -807,16 +814,16 @@ func (c *Client) ListMailInbox(agent, rig string) (CachedRead[[]mail.Message], e
 	}
 	resp, err := c.cw.GetV0CityByCityNameMailWithResponse(context.Background(), c.cityName, params)
 	if err != nil {
-		return CachedRead[[]mail.Message]{}, &connError{err: fmt.Errorf("request failed: %w", err)}
+		return CachedRead[MailListView]{}, &connError{err: fmt.Errorf("request failed: %w", err)}
 	}
 	if resp == nil {
-		return CachedRead[[]mail.Message]{}, &connError{err: fmt.Errorf("nil response")}
+		return CachedRead[MailListView]{}, &connError{err: fmt.Errorf("nil response")}
 	}
 	if err := apiErrorFromResponse(resp.StatusCode(), resp.ApplicationproblemJSONDefault); err != nil {
-		return CachedRead[[]mail.Message]{}, err
+		return CachedRead[MailListView]{}, err
 	}
-	return CachedRead[[]mail.Message]{
-		Body:       mailMessagesFromGenList(resp.JSON200),
+	return CachedRead[MailListView]{
+		Body:       mailListFromGen(resp.JSON200),
 		AgeSeconds: cacheAgeFromResponse(resp.HTTPResponse),
 	}, nil
 }
@@ -1168,7 +1175,7 @@ func apiErrorFromResponse(status int, pd *genclient.ErrorModel) error {
 			}
 			return &cacheNotLiveError{msg: msg}
 		}
-		if strings.HasPrefix(detail, "store_slow") {
+		if strings.HasPrefix(detail, StoreSlowErrorCode) {
 			msg := detail
 			if msg == "" {
 				msg = "store slow: try again when load drops"
@@ -1176,10 +1183,10 @@ func apiErrorFromResponse(status int, pd *genclient.ErrorModel) error {
 			return &storeSlowError{msg: msg}
 		}
 	}
-	// Generic 5xx (500/501/502/504/... plus 503 without a cache_not_live
-	// prefix) wraps into a serverError so read-path callers can classify it
-	// as fallbackable via ShouldFallbackForRead. Mutation callers continue
-	// to see it as non-fallbackable (ShouldFallback excludes it).
+	// Generic 5xx (500/501/502/504/... plus 503 without a cache_not_live or
+	// store_slow prefix) wraps into a serverError so read-path callers can
+	// classify it as fallbackable via ShouldFallbackForRead. Mutation callers
+	// continue to see it as non-fallbackable (ShouldFallback excludes it).
 	if status >= 500 {
 		msg := detail
 		if msg == "" {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1265,6 +1265,34 @@ func TestClientListMailInbox_CacheNotLiveFallback(t *testing.T) {
 	}
 }
 
+func TestClientListMailInbox_StoreSlowDoesNotFallback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"title":  "Service Unavailable",
+			"status": http.StatusServiceUnavailable,
+			"detail": "store_slow: mail read timed out after 8s",
+		})
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	_, err := c.ListMailInbox("mayor", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !IsStoreSlowError(err) {
+		t.Fatalf("IsStoreSlowError = false for store_slow response: %v", err)
+	}
+	if ShouldFallbackForRead(err) {
+		t.Errorf("ShouldFallbackForRead = true for store_slow: %v", err)
+	}
+	if ShouldFallback(err) {
+		t.Errorf("ShouldFallback = true for store_slow: %v", err)
+	}
+}
+
 func TestClientListMailInbox_ConnErrorFallback(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	ts.Close()
@@ -1395,6 +1423,34 @@ func TestClientCountMail_CacheNotLiveFallback(t *testing.T) {
 	}
 	if !ShouldFallback(err) {
 		t.Errorf("ShouldFallback = false for cache-not-live: %v", err)
+	}
+}
+
+func TestClientCountMail_StoreSlowDoesNotFallback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"title":  "Service Unavailable",
+			"status": http.StatusServiceUnavailable,
+			"detail": "store_slow: mail read timed out after 8s",
+		})
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	_, err := c.CountMail("mayor", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !IsStoreSlowError(err) {
+		t.Fatalf("IsStoreSlowError = false for store_slow response: %v", err)
+	}
+	if ShouldFallbackForRead(err) {
+		t.Errorf("ShouldFallbackForRead = true for store_slow: %v", err)
+	}
+	if ShouldFallback(err) {
+		t.Errorf("ShouldFallback = true for store_slow: %v", err)
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1222,7 +1222,9 @@ func TestClientListMailInbox(t *testing.T) {
 			"items": []map[string]any{
 				{"id": "msg-1", "from": "alice", "to": "mayor", "subject": "hi", "body": "hello", "created_at": "2026-04-23T10:00:00Z", "read": false},
 			},
-			"total": 1,
+			"total":          1,
+			"partial":        true,
+			"partial_errors": []string{"mail provider slow: store_slow: mail read timed out after 8s"},
 		})
 	}))
 	defer ts.Close()
@@ -1232,8 +1234,14 @@ func TestClientListMailInbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListMailInbox: %v", err)
 	}
-	if len(got.Body) != 1 || got.Body[0].ID != "msg-1" || got.Body[0].From != "alice" {
+	if len(got.Body.Items) != 1 || got.Body.Items[0].ID != "msg-1" || got.Body.Items[0].From != "alice" {
 		t.Errorf("got.Body = %+v", got.Body)
+	}
+	if got.Body.Total != 1 || !got.Body.Partial {
+		t.Errorf("list metadata = total:%d partial:%v, want total:1 partial:true", got.Body.Total, got.Body.Partial)
+	}
+	if len(got.Body.PartialErrors) != 1 || !strings.Contains(got.Body.PartialErrors[0], "store_slow:") {
+		t.Errorf("PartialErrors = %v, want store_slow entry", got.Body.PartialErrors)
 	}
 	if got.AgeSeconds != 2 {
 		t.Errorf("AgeSeconds = %v, want 2", got.AgeSeconds)
@@ -1358,6 +1366,34 @@ func TestClientGetMail_CacheNotLiveFallback(t *testing.T) {
 	}
 	if !ShouldFallback(err) {
 		t.Errorf("ShouldFallback = false for cache-not-live: %v", err)
+	}
+}
+
+func TestClientGetMail_StoreSlowDoesNotFallback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+			"title":  "Service Unavailable",
+			"status": http.StatusServiceUnavailable,
+			"detail": "store_slow: mail read timed out after 8s",
+		})
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	_, err := c.GetMail("msg-1", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !IsStoreSlowError(err) {
+		t.Fatalf("IsStoreSlowError = false for store_slow response: %v", err)
+	}
+	if ShouldFallbackForRead(err) {
+		t.Errorf("ShouldFallbackForRead = true for store_slow: %v", err)
+	}
+	if ShouldFallback(err) {
+		t.Errorf("ShouldFallback = true for store_slow: %v", err)
 	}
 }
 

--- a/internal/api/decode_mail.go
+++ b/internal/api/decode_mail.go
@@ -15,6 +15,16 @@ type MailCountView struct {
 	PartialErrors []string
 }
 
+// MailListView is the CLI-facing shape for `gc mail check`. It mirrors the
+// mail-list response body so callers can distinguish authoritative empty
+// mailboxes from partial aggregate reads.
+type MailListView struct {
+	Items         []mail.Message
+	Total         int
+	Partial       bool
+	PartialErrors []string
+}
+
 // mailMessageFromGen translates one genclient.Message into mail.Message.
 // Optional pointer fields are dereferenced safely.
 func mailMessageFromGen(g genclient.Message) mail.Message {
@@ -49,13 +59,30 @@ func mailMessageFromGen(g genclient.Message) mail.Message {
 // []mail.Message. Returns an empty slice (never nil) when the body is missing
 // or holds no items so callers can uniformly format the empty case.
 func mailMessagesFromGenList(body *genclient.MailListBody) []mail.Message {
-	if body == nil || body.Items == nil {
-		return []mail.Message{}
+	return mailListFromGen(body).Items
+}
+
+// mailListFromGen translates the genclient list body into a MailListView.
+// A nil body decodes to an empty, non-nil Items slice.
+func mailListFromGen(body *genclient.MailListBody) MailListView {
+	out := MailListView{Items: []mail.Message{}}
+	if body == nil {
+		return out
+	}
+	out.Total = int(body.Total)
+	if body.Partial != nil {
+		out.Partial = *body.Partial
+	}
+	if body.PartialErrors != nil {
+		out.PartialErrors = append([]string(nil), *body.PartialErrors...)
+	}
+	if body.Items == nil {
+		return out
 	}
 	items := *body.Items
-	out := make([]mail.Message, 0, len(items))
+	out.Items = make([]mail.Message, 0, len(items))
 	for _, item := range items {
-		out = append(out, mailMessageFromGen(item))
+		out.Items = append(out.Items, mailMessageFromGen(item))
 	}
 	return out
 }

--- a/internal/api/decode_mail_test.go
+++ b/internal/api/decode_mail_test.go
@@ -106,6 +106,32 @@ func TestMailMessagesFromGenList_PartialMissingFields(t *testing.T) {
 	}
 }
 
+func TestMailListFromGenPreservesPartialMetadata(t *testing.T) {
+	partial := true
+	partialErrs := []string{"mail provider slow: store_slow: mail read timed out after 8s"}
+	body := &genclient.MailListBody{
+		Items:         &[]genclient.Message{},
+		Total:         7,
+		Partial:       &partial,
+		PartialErrors: &partialErrs,
+	}
+
+	got := mailListFromGen(body)
+
+	if got.Total != 7 {
+		t.Fatalf("Total = %d, want 7", got.Total)
+	}
+	if got.Items == nil || len(got.Items) != 0 {
+		t.Fatalf("Items = %+v, want empty non-nil slice", got.Items)
+	}
+	if !got.Partial {
+		t.Fatal("Partial = false, want true")
+	}
+	if len(got.PartialErrors) != 1 || got.PartialErrors[0] != partialErrs[0] {
+		t.Fatalf("PartialErrors = %v, want %v", got.PartialErrors, partialErrs)
+	}
+}
+
 func TestMailCountFromGen_Valid(t *testing.T) {
 	partial := true
 	partialErrs := []string{"rig a: boom"}

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -380,7 +380,7 @@ func uniqueMailRecipients(recipients []string) []string {
 		return []string{""}
 	}
 	seen := make(map[string]bool, len(recipients))
-	unique := recipients[:0]
+	unique := make([]string, 0, len(recipients))
 	for _, recipient := range recipients {
 		if seen[recipient] {
 			continue
@@ -396,7 +396,7 @@ func uniqueMailRecipients(recipients []string) []string {
 
 func uniqueNonEmptyMailRecipients(recipients []string) []string {
 	seen := make(map[string]bool, len(recipients))
-	unique := recipients[:0]
+	unique := make([]string, 0, len(recipients))
 	for _, recipient := range recipients {
 		recipient = strings.TrimSpace(recipient)
 		if recipient == "" || seen[recipient] {

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
@@ -84,6 +85,21 @@ func (p *exactRecipientMailProvider) unread(recipient string) []mail.Message {
 		}
 	}
 	return out
+}
+
+type blockingMailProvider struct {
+	exactRecipientMailProvider
+	release <-chan struct{}
+}
+
+func (p *blockingMailProvider) Inbox(string) ([]mail.Message, error) {
+	<-p.release
+	return nil, nil
+}
+
+func (p *blockingMailProvider) Count(string) (int, int, error) {
+	<-p.release
+	return 0, 0, nil
 }
 
 type multiRecipientInboxMailProvider struct {
@@ -321,6 +337,64 @@ func TestMailCount(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
 	if resp["unread"] != 2 {
 		t.Errorf("unread = %d, want 2", resp["unread"])
+	}
+}
+
+func TestMailListRigStoreSlowReturnsTyped503(t *testing.T) {
+	state := newFakeState(t)
+	release := make(chan struct{})
+	state.cityMailProv = &blockingMailProvider{release: release}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(release)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?agent=worker&rig=myrig"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertStoreSlowProblem(t, rec)
+}
+
+func TestMailCountRigStoreSlowReturnsTyped503(t *testing.T) {
+	state := newFakeState(t)
+	release := make(chan struct{})
+	state.cityMailProv = &blockingMailProvider{release: release}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(release)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail/count?agent=worker&rig=myrig"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertStoreSlowProblem(t, rec)
+}
+
+func assertStoreSlowProblem(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	var problem struct {
+		Detail string `json:"detail"`
+		Status int    `json:"status"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode problem: %v; body: %s", err, rec.Body.String())
+	}
+	if problem.Status != http.StatusServiceUnavailable {
+		t.Fatalf("problem status = %d, want %d", problem.Status, http.StatusServiceUnavailable)
+	}
+	if !strings.HasPrefix(problem.Detail, "store_slow:") {
+		t.Fatalf("detail = %q, want store_slow prefix", problem.Detail)
 	}
 }
 

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -2,14 +2,17 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/api/genclient"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/mail"
@@ -97,9 +100,57 @@ func (p *blockingMailProvider) Inbox(string) ([]mail.Message, error) {
 	return nil, nil
 }
 
+func (p *blockingMailProvider) Get(string) (mail.Message, error) {
+	<-p.release
+	return mail.Message{}, nil
+}
+
 func (p *blockingMailProvider) Count(string) (int, int, error) {
 	<-p.release
 	return 0, 0, nil
+}
+
+func (p *blockingMailProvider) All(string) ([]mail.Message, error) {
+	<-p.release
+	return nil, nil
+}
+
+func (p *blockingMailProvider) Thread(string) ([]mail.Message, error) {
+	<-p.release
+	return nil, nil
+}
+
+type panicMailProvider struct {
+	exactRecipientMailProvider
+}
+
+func (p *panicMailProvider) Inbox(string) ([]mail.Message, error) {
+	panic("mail inbox exploded")
+}
+
+func (p *panicMailProvider) Count(string) (int, int, error) {
+	panic("mail count exploded")
+}
+
+func (p *panicMailProvider) All(string) ([]mail.Message, error) {
+	panic("mail all exploded")
+}
+
+func (p *panicMailProvider) Get(string) (mail.Message, error) {
+	panic("mail get exploded")
+}
+
+func (p *panicMailProvider) Thread(string) ([]mail.Message, error) {
+	panic("mail thread exploded")
+}
+
+type threadMailProvider struct {
+	exactRecipientMailProvider
+	messages []mail.Message
+}
+
+func (p *threadMailProvider) Thread(string) ([]mail.Message, error) {
+	return append([]mail.Message(nil), p.messages...), nil
 }
 
 type multiRecipientInboxMailProvider struct {
@@ -114,6 +165,19 @@ func (p *multiRecipientInboxMailProvider) Inbox(recipient string) ([]mail.Messag
 func (p *multiRecipientInboxMailProvider) InboxRecipients(recipients []string) ([]mail.Message, error) {
 	p.calls = append(p.calls, append([]string(nil), recipients...))
 	return []mail.Message{{ID: "multi-1", To: strings.Join(recipients, ",")}}, nil
+}
+
+type multiProviderFakeState struct {
+	*fakeState
+	providers map[string]mail.Provider
+}
+
+func (f *multiProviderFakeState) MailProvider(rig string) mail.Provider {
+	return f.providers[rig]
+}
+
+func (f *multiProviderFakeState) MailProviders() map[string]mail.Provider {
+	return f.providers
 }
 
 func TestMailInboxForRecipientsUsesMultiRecipientProvider(t *testing.T) {
@@ -147,6 +211,34 @@ func TestMailInboxForRecipientsFallbackDedupesMessages(t *testing.T) {
 	}
 	if len(msgs) != 3 {
 		t.Fatalf("messages = %#v, want 3 deduped fallback messages", msgs)
+	}
+}
+
+func TestUniqueMailRecipientsDoesNotMutateInput(t *testing.T) {
+	recipients := []string{"sky", "sky", "mayor"}
+	original := append([]string(nil), recipients...)
+
+	got := uniqueMailRecipients(recipients)
+
+	if !reflect.DeepEqual(got, []string{"sky", "mayor"}) {
+		t.Fatalf("uniqueMailRecipients = %#v, want sky/mayor", got)
+	}
+	if !reflect.DeepEqual(recipients, original) {
+		t.Fatalf("input mutated to %#v, want %#v", recipients, original)
+	}
+}
+
+func TestUniqueNonEmptyMailRecipientsDoesNotMutateInput(t *testing.T) {
+	recipients := []string{" sky ", "", "mayor"}
+	original := append([]string(nil), recipients...)
+
+	got := uniqueNonEmptyMailRecipients(recipients)
+
+	if !reflect.DeepEqual(got, []string{"sky", "mayor"}) {
+		t.Fatalf("uniqueNonEmptyMailRecipients = %#v, want sky/mayor", got)
+	}
+	if !reflect.DeepEqual(recipients, original) {
+		t.Fatalf("input mutated to %#v, want %#v", recipients, original)
 	}
 }
 
@@ -376,6 +468,407 @@ func TestMailCountRigStoreSlowReturnsTyped503(t *testing.T) {
 	h.ServeHTTP(rec, req)
 
 	assertStoreSlowProblem(t, rec)
+}
+
+func TestMailGetRigStoreSlowReturnsTyped503(t *testing.T) {
+	state := newFakeState(t)
+	release := make(chan struct{})
+	state.cityMailProv = &blockingMailProvider{release: release}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(release)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail/msg-1?rig=myrig"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertStoreSlowProblem(t, rec)
+}
+
+func TestMailListRigProviderPanicReturns500(t *testing.T) {
+	state := newFakeState(t)
+	state.cityMailProv = &panicMailProvider{}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?agent=worker&rig=myrig"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "mail provider read panicked") {
+		t.Fatalf("body missing recovered panic detail: %s", rec.Body.String())
+	}
+}
+
+func TestMailListAllRigsProviderPanicReturnsPartial(t *testing.T) {
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"fast": &exactRecipientMailProvider{messages: map[string][]mail.Message{
+				"worker": {{ID: "fast-1", To: "worker", Subject: "ready"}},
+			}},
+			"panic": &panicMailProvider{},
+		},
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?agent=worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Items         []mail.Message `json:"items"`
+		Partial       bool           `json:"partial"`
+		PartialErrors []string       `json:"partial_errors"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if len(body.Items) != 1 || body.Items[0].Rig != "fast" {
+		t.Fatalf("items = %+v, want one fast-rig message", body.Items)
+	}
+	if !body.Partial {
+		t.Fatalf("partial = false, want true; errors = %v", body.PartialErrors)
+	}
+	if len(body.PartialErrors) != 1 || !strings.Contains(body.PartialErrors[0], "mail provider read panicked") {
+		t.Fatalf("partial_errors = %v, want recovered panic detail", body.PartialErrors)
+	}
+}
+
+func TestMailListAllRigsStoreSlowReturnsPartial(t *testing.T) {
+	release := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"fast": &exactRecipientMailProvider{messages: map[string][]mail.Message{
+				"worker": {{ID: "fast-1", To: "worker", Subject: "ready"}},
+			}},
+			"slow": &blockingMailProvider{release: release},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(release)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?agent=worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertPartialMailListStoreSlow(t, rec)
+}
+
+func TestMailListAllStatusStoreSlowReturnsPartial(t *testing.T) {
+	release := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"fast": &exactRecipientMailProvider{messages: map[string][]mail.Message{
+				"worker": {{ID: "fast-1", To: "worker", Subject: "ready", Read: true}},
+			}},
+			"slow": &blockingMailProvider{release: release},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(release)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?agent=worker&status=all"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertPartialMailListStoreSlow(t, rec)
+}
+
+func TestMailCountAllRigsStoreSlowReturnsPartial(t *testing.T) {
+	release := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"fast": &exactRecipientMailProvider{messages: map[string][]mail.Message{
+				"worker": {{ID: "fast-1", To: "worker", Subject: "ready"}},
+			}},
+			"slow": &blockingMailProvider{release: release},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(release)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail/count?agent=worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Total         int      `json:"total"`
+		Unread        int      `json:"unread"`
+		Partial       bool     `json:"partial"`
+		PartialErrors []string `json:"partial_errors"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if body.Total != 1 || body.Unread != 1 {
+		t.Fatalf("counts = total:%d unread:%d, want total:1 unread:1", body.Total, body.Unread)
+	}
+	assertPartialStoreSlow(t, body.Partial, body.PartialErrors)
+}
+
+func TestMailListAllRigsStoreSlowAllFailedReturnsTyped503(t *testing.T) {
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"slow-a": &blockingMailProvider{release: releaseA},
+			"slow-b": &blockingMailProvider{release: releaseB},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(releaseA)
+		close(releaseB)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?agent=worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertStoreSlowProblem(t, rec)
+}
+
+func TestMailListAllStatusStoreSlowAllFailedReturnsTyped503(t *testing.T) {
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"slow-a": &blockingMailProvider{release: releaseA},
+			"slow-b": &blockingMailProvider{release: releaseB},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(releaseA)
+		close(releaseB)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail?agent=worker&status=all"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertStoreSlowProblem(t, rec)
+}
+
+func TestMailCountAllRigsStoreSlowAllFailedReturnsTyped503(t *testing.T) {
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"slow-a": &blockingMailProvider{release: releaseA},
+			"slow-b": &blockingMailProvider{release: releaseB},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(releaseA)
+		close(releaseB)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail/count?agent=worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertStoreSlowProblem(t, rec)
+}
+
+func TestMailThreadRigStoreSlowReturnsTyped503(t *testing.T) {
+	state := newFakeState(t)
+	release := make(chan struct{})
+	state.cityMailProv = &blockingMailProvider{release: release}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(release)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail/thread/thread-1?rig=myrig"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertStoreSlowProblem(t, rec)
+}
+
+func TestMailThreadAllRigsStoreSlowReturnsPartial(t *testing.T) {
+	release := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"fast": &threadMailProvider{messages: []mail.Message{{ID: "fast-1", ThreadID: "thread-1"}}},
+			"slow": &blockingMailProvider{release: release},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(release)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail/thread/thread-1"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertPartialMailListStoreSlow(t, rec)
+}
+
+func TestMailThreadAllRigsStoreSlowAllFailedReturnsTyped503(t *testing.T) {
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"slow-a": &blockingMailProvider{release: releaseA},
+			"slow-b": &blockingMailProvider{release: releaseB},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 5 * time.Millisecond
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(releaseA)
+		close(releaseB)
+	})
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/mail/thread/thread-1"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assertStoreSlowProblem(t, rec)
+}
+
+func TestClientMailListAllRigsMultipleStoreSlowReturnsTyped503BeforeClientTimeout(t *testing.T) {
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	releaseC := make(chan struct{})
+	state := &multiProviderFakeState{
+		fakeState: newFakeState(t),
+		providers: map[string]mail.Provider{
+			"slow-a": &blockingMailProvider{release: releaseA},
+			"slow-b": &blockingMailProvider{release: releaseB},
+			"slow-c": &blockingMailProvider{release: releaseC},
+		},
+	}
+	oldDeadline := mailReadDeadline
+	mailReadDeadline = 100 * time.Millisecond
+	ts := httptest.NewServer(newTestCityHandler(t, state))
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() {
+		mailReadDeadline = oldDeadline
+		close(releaseA)
+		close(releaseB)
+		close(releaseC)
+	})
+	c := newTestCityScopedClientWithTimeout(t, ts.URL, state.CityName(), 250*time.Millisecond)
+
+	_, err := c.ListMailInbox("worker", "")
+	if err == nil {
+		t.Fatal("ListMailInbox succeeded, want typed store_slow error")
+	}
+	if !IsStoreSlowError(err) {
+		t.Fatalf("ListMailInbox error = %v, want typed store_slow before client timeout", err)
+	}
+	if ShouldFallbackForRead(err) {
+		t.Fatalf("ShouldFallbackForRead = true for typed store_slow error: %v", err)
+	}
+}
+
+func newTestCityScopedClientWithTimeout(t *testing.T, baseURL, cityName string, timeout time.Duration) *Client {
+	t.Helper()
+	cw, err := genclient.NewClientWithResponses(
+		baseURL,
+		genclient.WithHTTPClient(&http.Client{Timeout: timeout}),
+		genclient.WithRequestEditorFn(func(_ context.Context, req *http.Request) error {
+			req.Header.Set("X-GC-Request", "true")
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewClientWithResponses: %v", err)
+	}
+	return &Client{cw: cw, baseURL: baseURL, cityName: cityName}
+}
+
+func assertPartialMailListStoreSlow(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Items         []mail.Message `json:"items"`
+		Partial       bool           `json:"partial"`
+		PartialErrors []string       `json:"partial_errors"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if len(body.Items) != 1 || body.Items[0].Rig != "fast" {
+		t.Fatalf("items = %+v, want one fast-rig message", body.Items)
+	}
+	assertPartialStoreSlow(t, body.Partial, body.PartialErrors)
+}
+
+func assertPartialStoreSlow(t *testing.T, partial bool, partialErrors []string) {
+	t.Helper()
+	if !partial {
+		t.Fatalf("partial = false, want true; errors = %v", partialErrors)
+	}
+	if len(partialErrors) == 0 {
+		t.Fatal("partial_errors empty, want store_slow entry")
+	}
+	for _, msg := range partialErrors {
+		if strings.Contains(msg, "store_slow:") {
+			return
+		}
+	}
+	t.Fatalf("partial_errors = %v, want store_slow entry", partialErrors)
 }
 
 func assertStoreSlowProblem(t *testing.T, rec *httptest.ResponseRecorder) {

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -10,6 +11,71 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/mail"
 )
+
+// mailReadDeadline is shorter than the API client's 10s timeout so typed
+// store_slow problem details can reach the CLI before transport timeout.
+var mailReadDeadline = 8 * time.Second
+
+type mailReadTimeoutError struct {
+	d time.Duration
+}
+
+func (e *mailReadTimeoutError) Error() string {
+	return fmt.Sprintf("store_slow: mail read timed out after %s", e.d)
+}
+
+type mailReadResult[T any] struct {
+	value T
+	err   error
+}
+
+type mailReadCounts struct {
+	Total  int
+	Unread int
+}
+
+// withMailReadDeadline bounds mail store reads whose provider interface has
+// no context parameter. If the deadline fires, the provider goroutine may keep
+// running until the store call returns; its result is discarded through the
+// buffered channel.
+func withMailReadDeadline[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+	var zero T
+	deadline := mailReadDeadline
+	if deadline <= 0 {
+		return fn()
+	}
+	ch := make(chan mailReadResult[T], 1)
+	go func() {
+		value, err := fn()
+		ch <- mailReadResult[T]{value: value, err: err}
+	}()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	select {
+	case res := <-ch:
+		return res.value, res.err
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	case <-timer.C:
+		return zero, &mailReadTimeoutError{d: deadline}
+	}
+}
+
+func mailReadAPIError(err error) error {
+	var timeoutErr *mailReadTimeoutError
+	if errors.As(err, &timeoutErr) {
+		return huma.Error503ServiceUnavailable(timeoutErr.Error())
+	}
+	return huma.Error500InternalServerError(err.Error())
+}
+
+func allMailProvidersFailedError(partialErrs []string, storeSlow bool) error {
+	detail := "all mail providers failed: " + strings.Join(partialErrs, "; ")
+	if storeSlow {
+		detail = "store_slow: " + detail
+	}
+	return huma.Error503ServiceUnavailable(detail)
+}
 
 // humaHandleMailList is the Huma-typed handler for GET /v0/mail.
 func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (*MailListOutput, error) {
@@ -52,9 +118,11 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 					Body:      MailListBody{Items: []mail.Message{}, Total: 0},
 				}, nil
 			}
-			msgs, err := mailInboxForRecipients(mp, agents)
+			msgs, err := withMailReadDeadline(ctx, func() ([]mail.Message, error) {
+				return mailInboxForRecipients(mp, agents)
+			})
 			if err != nil {
-				return nil, huma.Error500InternalServerError(err.Error())
+				return nil, mailReadAPIError(err)
 			}
 			if msgs == nil {
 				msgs = []mail.Message{}
@@ -85,16 +153,21 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 		providers := s.state.MailProviders()
 		var allMsgs []mail.Message
 		var partialErrs []string
+		partialStoreSlow := false
 		for _, name := range sortedProviderNames(providers) {
-			msgs, err := mailInboxForRecipients(providers[name], agents)
+			msgs, err := withMailReadDeadline(ctx, func() ([]mail.Message, error) {
+				return mailInboxForRecipients(providers[name], agents)
+			})
 			if err != nil {
+				var timeoutErr *mailReadTimeoutError
+				partialStoreSlow = partialStoreSlow || errors.As(err, &timeoutErr)
 				partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
 				continue
 			}
 			allMsgs = append(allMsgs, tagRig(msgs, name)...)
 		}
 		if len(partialErrs) == len(providers) && len(providers) > 0 {
-			return nil, huma.Error503ServiceUnavailable("all mail providers failed: " + strings.Join(partialErrs, "; "))
+			return nil, allMailProvidersFailedError(partialErrs, partialStoreSlow)
 		}
 		if allMsgs == nil {
 			allMsgs = []mail.Message{}
@@ -131,9 +204,11 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 					Body:      MailListBody{Items: []mail.Message{}, Total: 0},
 				}, nil
 			}
-			msgs, err := mailAllForRecipients(mp, agents)
+			msgs, err := withMailReadDeadline(ctx, func() ([]mail.Message, error) {
+				return mailAllForRecipients(mp, agents)
+			})
 			if err != nil {
-				return nil, huma.Error500InternalServerError(err.Error())
+				return nil, mailReadAPIError(err)
 			}
 			if msgs == nil {
 				msgs = []mail.Message{}
@@ -164,16 +239,21 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 		providers := s.state.MailProviders()
 		var allMsgs []mail.Message
 		var partialErrs []string
+		partialStoreSlow := false
 		for _, name := range sortedProviderNames(providers) {
-			msgs, err := mailAllForRecipients(providers[name], agents)
+			msgs, err := withMailReadDeadline(ctx, func() ([]mail.Message, error) {
+				return mailAllForRecipients(providers[name], agents)
+			})
 			if err != nil {
+				var timeoutErr *mailReadTimeoutError
+				partialStoreSlow = partialStoreSlow || errors.As(err, &timeoutErr)
 				partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
 				continue
 			}
 			allMsgs = append(allMsgs, tagRig(msgs, name)...)
 		}
 		if len(partialErrs) == len(providers) && len(providers) > 0 {
-			return nil, huma.Error503ServiceUnavailable("all mail providers failed: " + strings.Join(partialErrs, "; "))
+			return nil, allMailProvidersFailedError(partialErrs, partialStoreSlow)
 		}
 		if allMsgs == nil {
 			allMsgs = []mail.Message{}
@@ -310,13 +390,16 @@ func (s *Server) humaHandleMailCount(ctx context.Context, input *MailCountInput)
 			resp.Body.Unread = 0
 			return resp, nil
 		}
-		total, unread, err := mailCountForRecipients(mp, agents)
+		counts, err := withMailReadDeadline(ctx, func() (mailReadCounts, error) {
+			total, unread, err := mailCountForRecipients(mp, agents)
+			return mailReadCounts{Total: total, Unread: unread}, err
+		})
 		if err != nil {
-			return nil, huma.Error500InternalServerError(err.Error())
+			return nil, mailReadAPIError(err)
 		}
 		resp := &MailCountOutput{CacheAgeS: cacheAge}
-		resp.Body.Total = total
-		resp.Body.Unread = unread
+		resp.Body.Total = counts.Total
+		resp.Body.Unread = counts.Unread
 		return resp, nil
 	}
 
@@ -326,17 +409,23 @@ func (s *Server) humaHandleMailCount(ctx context.Context, input *MailCountInput)
 	providers := s.state.MailProviders()
 	var totalAll, unreadAll int
 	var partialErrs []string
+	partialStoreSlow := false
 	for _, name := range sortedProviderNames(providers) {
-		total, unread, err := mailCountForRecipients(providers[name], agents)
+		counts, err := withMailReadDeadline(ctx, func() (mailReadCounts, error) {
+			total, unread, err := mailCountForRecipients(providers[name], agents)
+			return mailReadCounts{Total: total, Unread: unread}, err
+		})
 		if err != nil {
+			var timeoutErr *mailReadTimeoutError
+			partialStoreSlow = partialStoreSlow || errors.As(err, &timeoutErr)
 			partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
 			continue
 		}
-		totalAll += total
-		unreadAll += unread
+		totalAll += counts.Total
+		unreadAll += counts.Unread
 	}
 	if len(partialErrs) == len(providers) && len(providers) > 0 {
-		return nil, huma.Error503ServiceUnavailable("all mail providers failed: " + strings.Join(partialErrs, "; "))
+		return nil, allMailProvidersFailedError(partialErrs, partialStoreSlow)
 	}
 	resp := &MailCountOutput{CacheAgeS: cacheAge}
 	resp.Body.Total = totalAll

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -21,7 +21,7 @@ type mailReadTimeoutError struct {
 }
 
 func (e *mailReadTimeoutError) Error() string {
-	return fmt.Sprintf("store_slow: mail read timed out after %s", e.d)
+	return fmt.Sprintf("%s: mail read timed out after %s", StoreSlowErrorCode, e.d)
 }
 
 type mailReadResult[T any] struct {
@@ -32,6 +32,18 @@ type mailReadResult[T any] struct {
 type mailReadCounts struct {
 	Total  int
 	Unread int
+}
+
+type mailGetResult struct {
+	Message mail.Message
+	Rig     string
+	Found   bool
+}
+
+type mailProviderReadResult[T any] struct {
+	name  string
+	value T
+	err   error
 }
 
 // withMailReadDeadline bounds mail store reads whose provider interface has
@@ -46,6 +58,11 @@ func withMailReadDeadline[T any](ctx context.Context, fn func() (T, error)) (T, 
 	}
 	ch := make(chan mailReadResult[T], 1)
 	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				ch <- mailReadResult[T]{err: fmt.Errorf("mail provider read panicked: %v", recovered)}
+			}
+		}()
 		value, err := fn()
 		ch <- mailReadResult[T]{value: value, err: err}
 	}()
@@ -59,6 +76,83 @@ func withMailReadDeadline[T any](ctx context.Context, fn func() (T, error)) (T, 
 	case <-timer.C:
 		return zero, &mailReadTimeoutError{d: deadline}
 	}
+}
+
+// withMailProviderReadDeadline runs aggregate provider reads under one shared
+// deadline, keeping all-rig API responses inside the API client's timeout.
+func withMailProviderReadDeadline[T any](ctx context.Context, providers map[string]mail.Provider, fn func(mail.Provider) (T, error)) []mailProviderReadResult[T] {
+	names := sortedProviderNames(providers)
+	if len(names) == 0 {
+		return nil
+	}
+
+	ch := make(chan mailProviderReadResult[T], len(names))
+	for _, name := range names {
+		name := name
+		provider := providers[name]
+		go func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					ch <- mailProviderReadResult[T]{name: name, err: fmt.Errorf("mail provider read panicked: %v", recovered)}
+				}
+			}()
+			value, err := fn(provider)
+			ch <- mailProviderReadResult[T]{name: name, value: value, err: err}
+		}()
+	}
+
+	results := make(map[string]mailReadResult[T], len(names))
+	pending := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		pending[name] = struct{}{}
+	}
+
+	deadline := mailReadDeadline
+	var timer *time.Timer
+	var timeout <-chan time.Time
+	if deadline > 0 {
+		timer = time.NewTimer(deadline)
+		defer timer.Stop()
+		timeout = timer.C
+	}
+
+	for len(pending) > 0 {
+		select {
+		case res := <-ch:
+			if _, ok := pending[res.name]; !ok {
+				continue
+			}
+			delete(pending, res.name)
+			results[res.name] = mailReadResult[T]{value: res.value, err: res.err}
+		case <-ctx.Done():
+			var zero T
+			for _, name := range names {
+				if _, ok := pending[name]; ok {
+					results[name] = mailReadResult[T]{value: zero, err: ctx.Err()}
+				}
+			}
+			return orderedMailProviderReadResults(names, results)
+		case <-timeout:
+			var zero T
+			for _, name := range names {
+				if _, ok := pending[name]; ok {
+					results[name] = mailReadResult[T]{value: zero, err: &mailReadTimeoutError{d: deadline}}
+				}
+			}
+			return orderedMailProviderReadResults(names, results)
+		}
+	}
+
+	return orderedMailProviderReadResults(names, results)
+}
+
+func orderedMailProviderReadResults[T any](names []string, results map[string]mailReadResult[T]) []mailProviderReadResult[T] {
+	ordered := make([]mailProviderReadResult[T], 0, len(names))
+	for _, name := range names {
+		res := results[name]
+		ordered = append(ordered, mailProviderReadResult[T]{name: name, value: res.value, err: res.err})
+	}
+	return ordered
 }
 
 func mailReadAPIError(err error) error {
@@ -154,17 +248,16 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 		var allMsgs []mail.Message
 		var partialErrs []string
 		partialStoreSlow := false
-		for _, name := range sortedProviderNames(providers) {
-			msgs, err := withMailReadDeadline(ctx, func() ([]mail.Message, error) {
-				return mailInboxForRecipients(providers[name], agents)
-			})
-			if err != nil {
+		for _, res := range withMailProviderReadDeadline(ctx, providers, func(provider mail.Provider) ([]mail.Message, error) {
+			return mailInboxForRecipients(provider, agents)
+		}) {
+			if res.err != nil {
 				var timeoutErr *mailReadTimeoutError
-				partialStoreSlow = partialStoreSlow || errors.As(err, &timeoutErr)
-				partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
+				partialStoreSlow = partialStoreSlow || errors.As(res.err, &timeoutErr)
+				partialErrs = append(partialErrs, "mail provider "+res.name+": "+res.err.Error())
 				continue
 			}
-			allMsgs = append(allMsgs, tagRig(msgs, name)...)
+			allMsgs = append(allMsgs, tagRig(res.value, res.name)...)
 		}
 		if len(partialErrs) == len(providers) && len(providers) > 0 {
 			return nil, allMailProvidersFailedError(partialErrs, partialStoreSlow)
@@ -240,17 +333,16 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 		var allMsgs []mail.Message
 		var partialErrs []string
 		partialStoreSlow := false
-		for _, name := range sortedProviderNames(providers) {
-			msgs, err := withMailReadDeadline(ctx, func() ([]mail.Message, error) {
-				return mailAllForRecipients(providers[name], agents)
-			})
-			if err != nil {
+		for _, res := range withMailProviderReadDeadline(ctx, providers, func(provider mail.Provider) ([]mail.Message, error) {
+			return mailAllForRecipients(provider, agents)
+		}) {
+			if res.err != nil {
 				var timeoutErr *mailReadTimeoutError
-				partialStoreSlow = partialStoreSlow || errors.As(err, &timeoutErr)
-				partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
+				partialStoreSlow = partialStoreSlow || errors.As(res.err, &timeoutErr)
+				partialErrs = append(partialErrs, "mail provider "+res.name+": "+res.err.Error())
 				continue
 			}
-			allMsgs = append(allMsgs, tagRig(msgs, name)...)
+			allMsgs = append(allMsgs, tagRig(res.value, res.name)...)
 		}
 		if len(partialErrs) == len(providers) && len(providers) > 0 {
 			return nil, allMailProvidersFailedError(partialErrs, partialStoreSlow)
@@ -286,33 +378,41 @@ func (s *Server) humaHandleMailList(ctx context.Context, input *MailListInput) (
 }
 
 // humaHandleMailGet is the Huma-typed handler for GET /v0/mail/{id}.
-func (s *Server) humaHandleMailGet(_ context.Context, input *MailGetInput) (*IndexOutput[mail.Message], error) {
+func (s *Server) humaHandleMailGet(ctx context.Context, input *MailGetInput) (*IndexOutput[mail.Message], error) {
 	cityStore := s.state.CityBeadStore()
 	if err := cacheLiveOr503(cityStore); err != nil {
 		return nil, err
 	}
 	id := input.ID
 	rig := input.Rig
-	mp, resolvedRig, err := s.findMailProviderForMessage(id, rig)
-	if err != nil {
-		return nil, huma.Error500InternalServerError(err.Error())
-	}
-	if mp == nil {
-		return nil, huma.Error404NotFound("message " + id + " not found")
-	}
-
-	msg, err := mp.Get(id)
+	result, err := withMailReadDeadline(ctx, func() (mailGetResult, error) {
+		mp, resolvedRig, err := s.findMailProviderForMessage(id, rig)
+		if err != nil {
+			return mailGetResult{}, err
+		}
+		if mp == nil {
+			return mailGetResult{}, nil
+		}
+		msg, err := mp.Get(id)
+		if err != nil {
+			return mailGetResult{}, err
+		}
+		return mailGetResult{Message: msg, Rig: resolvedRig, Found: true}, nil
+	})
 	if err != nil {
 		if errors.Is(err, mail.ErrNotFound) {
 			return nil, huma.Error404NotFound(err.Error())
 		}
-		return nil, huma.Error500InternalServerError(err.Error())
+		return nil, mailReadAPIError(err)
 	}
-	msg.Rig = resolvedRig
+	if !result.Found {
+		return nil, huma.Error404NotFound("message " + id + " not found")
+	}
+	result.Message.Rig = result.Rig
 	return &IndexOutput[mail.Message]{
 		Index:     s.latestIndex(),
 		CacheAgeS: cacheAgeSeconds(cityStore),
-		Body:      msg,
+		Body:      result.Message,
 	}, nil
 }
 
@@ -410,19 +510,18 @@ func (s *Server) humaHandleMailCount(ctx context.Context, input *MailCountInput)
 	var totalAll, unreadAll int
 	var partialErrs []string
 	partialStoreSlow := false
-	for _, name := range sortedProviderNames(providers) {
-		counts, err := withMailReadDeadline(ctx, func() (mailReadCounts, error) {
-			total, unread, err := mailCountForRecipients(providers[name], agents)
-			return mailReadCounts{Total: total, Unread: unread}, err
-		})
-		if err != nil {
+	for _, res := range withMailProviderReadDeadline(ctx, providers, func(provider mail.Provider) (mailReadCounts, error) {
+		total, unread, err := mailCountForRecipients(provider, agents)
+		return mailReadCounts{Total: total, Unread: unread}, err
+	}) {
+		if res.err != nil {
 			var timeoutErr *mailReadTimeoutError
-			partialStoreSlow = partialStoreSlow || errors.As(err, &timeoutErr)
-			partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
+			partialStoreSlow = partialStoreSlow || errors.As(res.err, &timeoutErr)
+			partialErrs = append(partialErrs, "mail provider "+res.name+": "+res.err.Error())
 			continue
 		}
-		totalAll += counts.Total
-		unreadAll += counts.Unread
+		totalAll += res.value.Total
+		unreadAll += res.value.Unread
 	}
 	if len(partialErrs) == len(providers) && len(providers) > 0 {
 		return nil, allMailProvidersFailedError(partialErrs, partialStoreSlow)
@@ -436,7 +535,7 @@ func (s *Server) humaHandleMailCount(ctx context.Context, input *MailCountInput)
 }
 
 // humaHandleMailThread is the Huma-typed handler for GET /v0/mail/thread/{id}.
-func (s *Server) humaHandleMailThread(_ context.Context, input *MailThreadInput) (*MailListOutput, error) {
+func (s *Server) humaHandleMailThread(ctx context.Context, input *MailThreadInput) (*MailListOutput, error) {
 	threadID := input.ID
 	rig := input.Rig
 	index := s.latestIndex()
@@ -446,9 +545,11 @@ func (s *Server) humaHandleMailThread(_ context.Context, input *MailThreadInput)
 		if mp == nil {
 			return nil, huma.Error404NotFound("rig " + rig + " not found")
 		}
-		msgs, err := mp.Thread(threadID)
+		msgs, err := withMailReadDeadline(ctx, func() ([]mail.Message, error) {
+			return mp.Thread(threadID)
+		})
 		if err != nil {
-			return nil, huma.Error500InternalServerError(err.Error())
+			return nil, mailReadAPIError(err)
 		}
 		if msgs == nil {
 			msgs = []mail.Message{}
@@ -466,16 +567,20 @@ func (s *Server) humaHandleMailThread(_ context.Context, input *MailThreadInput)
 	providers := s.state.MailProviders()
 	var allMsgs []mail.Message
 	var partialErrs []string
-	for _, name := range sortedProviderNames(providers) {
-		msgs, err := providers[name].Thread(threadID)
-		if err != nil {
-			partialErrs = append(partialErrs, "mail provider "+name+": "+err.Error())
+	partialStoreSlow := false
+	for _, res := range withMailProviderReadDeadline(ctx, providers, func(provider mail.Provider) ([]mail.Message, error) {
+		return provider.Thread(threadID)
+	}) {
+		if res.err != nil {
+			var timeoutErr *mailReadTimeoutError
+			partialStoreSlow = partialStoreSlow || errors.As(res.err, &timeoutErr)
+			partialErrs = append(partialErrs, "mail provider "+res.name+": "+res.err.Error())
 			continue
 		}
-		allMsgs = append(allMsgs, tagRig(msgs, name)...)
+		allMsgs = append(allMsgs, tagRig(res.value, res.name)...)
 	}
 	if len(partialErrs) == len(providers) && len(providers) > 0 {
-		return nil, huma.Error503ServiceUnavailable("all mail providers failed: " + strings.Join(partialErrs, "; "))
+		return nil, allMailProvidersFailedError(partialErrs, partialStoreSlow)
 	}
 	if allMsgs == nil {
 		allMsgs = []mail.Message{}

--- a/release-gates/ga-sfn3cf-store-slow-mail-gate.md
+++ b/release-gates/ga-sfn3cf-store-slow-mail-gate.md
@@ -1,0 +1,60 @@
+# Release gate: ga-sfn3cf store-slow mail handling
+
+**Deploy bead:** `ga-sfn3cf` — needs-deploy: store-slow mail read handling
+**Source review bead:** `ga-e1kvn6` — Review: store-slow mail read handling
+**Source branch:** `builder/ga-bqldr7.1-store-slow-mail`
+**Deploy branch:** `deploy/ga-sfn3cf-store-slow-mail`
+**Reviewed feature HEAD:** `eb31b2303`
+**Verdict:** **PASS**
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Source review bead `ga-e1kvn6` is closed with `REVIEW VERDICT: PASS`; deploy bead `ga-sfn3cf` records reviewer PASS for `eb31b2303`. Single-pass review is accepted while gemini second-pass is disabled. |
+| 2 | Acceptance criteria met | PASS | Store-slow mail reads are deadline-wrapped for list/count, return typed `503 store_slow` responses, map to exported non-fallbackable `IsStoreSlowError`, degrade `gc mail check --inject` without failing, and surface non-inject errors. Focused API/CLI tests pass. |
+| 3 | Tests pass | PASS | `make test-fast-parallel`, `go vet ./...`, focused store-slow API/CLI tests, `make dashboard-check`, and dashboard preview smoke all pass on the deploy branch. |
+| 4 | No high-severity review findings open | PASS | Review notes contain one low/non-blocking future-interface note about deadline goroutine lifetime with buffered channel protection. 0 HIGH findings. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file; after the gate commit the deployer rechecks clean status before PR creation. `make dashboard-check` regenerated files without leaving a diff. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree --quiet HEAD origin/main` exits 0 before the gate commit, with no merge conflicts. |
+| 7 | Single feature theme | PASS | Commit set is one mail-read error-handling theme across the API adapter and CLI mail command. The files changed are `cmd/gc/cmd_mail.go`, `internal/api/client.go`, `internal/api/huma_handlers_mail.go`, and their focused tests. |
+
+## Test Runs
+
+Commands run by deployer on `deploy/ga-sfn3cf-store-slow-mail` at reviewed feature HEAD `eb31b2303`:
+
+```text
+$ make test-fast-parallel
+All fast jobs passed
+
+$ go vet ./...
+(clean)
+
+$ go test ./internal/api ./cmd/gc -run 'Test(MailListRigStoreSlowReturnsTyped503|MailCountRigStoreSlowReturnsTyped503|ClientListMailInbox_StoreSlowDoesNotFallback|ClientCountMail_StoreSlowDoesNotFallback|RouteMailCheckInjectStoreSlowEmitsDegradedNotice|RouteMailCheckStoreSlowNonInjectReturnsError|InboxUsesSingleIssuesTierMessageScanAcrossRoutes|ProviderCached_BroadSessionListCacheConcurrentAccess|NewMailProviderUsesCachedBeadmailProvider)$'
+ok  	github.com/gastownhall/gascity/internal/api	0.066s
+ok  	github.com/gastownhall/gascity/cmd/gc	0.336s
+
+$ make dashboard-check
+openapi-ts generation, Vite build, TypeScript typecheck, and go test ./cmd/gc/dashboard/... pass
+
+$ npm run preview -- --host 127.0.0.1 --port 4177
+served http://127.0.0.1:4177/; curl -fsS returned 0
+```
+
+## Commits In Scope
+
+```text
+eb31b2303 fix: handle store-slow mail reads (refs ga-bqldr7.1)
+8e95e6849 test: red store-slow mail handling (refs ga-bqldr7.1)
+```
+
+## Files In Scope
+
+```text
+cmd/gc/cmd_mail.go
+cmd/gc/cmd_mail_test.go
+internal/api/client.go
+internal/api/client_test.go
+internal/api/handler_mail_test.go
+internal/api/huma_handlers_mail.go
+```

--- a/release-gates/ga-sfn3cf-store-slow-mail-gate.md
+++ b/release-gates/ga-sfn3cf-store-slow-mail-gate.md
@@ -1,51 +1,70 @@
 # Release gate: ga-sfn3cf store-slow mail handling
 
-**Deploy bead:** `ga-sfn3cf` — needs-deploy: store-slow mail read handling
-**Source review bead:** `ga-e1kvn6` — Review: store-slow mail read handling
+**Deploy bead:** `ga-sfn3cf` - needs-deploy: store-slow mail read handling
+**Source review bead:** `ga-e1kvn6` - Review: store-slow mail read handling
 **Source branch:** `builder/ga-bqldr7.1-store-slow-mail`
 **Deploy branch:** `deploy/ga-sfn3cf-store-slow-mail`
-**Reviewed feature HEAD:** `eb31b2303`
+**Reviewed code HEAD:** `01c871aa6` - `fix: address store-slow mail review findings`
+**Evidence refresh:** 2026-05-30, adopt-pr review loop attempt 5
 **Verdict:** **PASS**
+
+This gate was refreshed after review attempt 5 found stale evidence from
+`eb31b2303`. The commands below were rerun in the adopted PR worktree at code
+HEAD `01c871aa6`; this artifact correction changes only this release-gate file.
 
 ## Criteria
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
-| 1 | Review PASS present | PASS | Source review bead `ga-e1kvn6` is closed with `REVIEW VERDICT: PASS`; deploy bead `ga-sfn3cf` records reviewer PASS for `eb31b2303`. Single-pass review is accepted while gemini second-pass is disabled. |
-| 2 | Acceptance criteria met | PASS | Store-slow mail reads are deadline-wrapped for list/count, return typed `503 store_slow` responses, map to exported non-fallbackable `IsStoreSlowError`, degrade `gc mail check --inject` without failing, and surface non-inject errors. Focused API/CLI tests pass. |
-| 3 | Tests pass | PASS | `make test-fast-parallel`, `go vet ./...`, focused store-slow API/CLI tests, `make dashboard-check`, and dashboard preview smoke all pass on the deploy branch. |
-| 4 | No high-severity review findings open | PASS | Review notes contain one low/non-blocking future-interface note about deadline goroutine lifetime with buffered channel protection. 0 HIGH findings. |
-| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file; after the gate commit the deployer rechecks clean status before PR creation. `make dashboard-check` regenerated files without leaving a diff. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree --quiet HEAD origin/main` exits 0 before the gate commit, with no merge conflicts. |
-| 7 | Single feature theme | PASS | Commit set is one mail-read error-handling theme across the API adapter and CLI mail command. The files changed are `cmd/gc/cmd_mail.go`, `internal/api/client.go`, `internal/api/huma_handlers_mail.go`, and their focused tests. |
+| 1 | Review PASS present | PASS | Earlier source review bead `ga-e1kvn6` is closed with `REVIEW VERDICT: PASS`; the post-review fix commit `01c871aa6` resolves the later review-loop blocker/major findings. |
+| 2 | Acceptance criteria met | PASS | Store-slow mail reads are deadline-wrapped for list/count/thread/get, return typed `503 store_slow` responses, map to exported non-fallbackable `IsStoreSlowError`, degrade `gc mail check --inject` without failing, and surface non-inject errors. Focused API/CLI tests pass against `01c871aa6`. |
+| 3 | Tests pass | PASS | `git diff --check`, focused store-slow API/CLI tests, focused aggregate mail `go test -race`, `make test-fast-parallel`, `go vet ./...`, `make dashboard-check`, and dashboard preview smoke all pass in the adopted PR worktree. |
+| 4 | No high-severity review findings open | PASS | Attempt 5 validated the previous blocker and majors as resolved. The only gating attempt-5 finding was stale release-gate evidence, corrected here. Minor/non-gating follow-ups remain optional. |
+| 5 | Final branch is clean | PASS | `git status --short` was clean after validation and before this gate-file update; `make dashboard-check` regenerated files without leaving a diff. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` exits 0 on the adopted PR worktree before this gate-file update. |
+| 7 | Single feature theme | PASS | Commit set is one mail-read error-handling theme across the API adapter, mail decode/client surfaces, CLI mail command, focused tests, and this release gate. |
 
 ## Test Runs
 
-Commands run by deployer on `deploy/ga-sfn3cf-store-slow-mail` at reviewed feature HEAD `eb31b2303`:
+Commands run in `/data/projects/gascity/worktrees/ga-qr612` at reviewed code
+HEAD `01c871aa6`:
 
 ```text
+$ git diff --check 9cc93c7b44225e3ceeee3efcfc81d6047fc4deb0..HEAD
+(clean)
+
+$ go test ./internal/api ./cmd/gc -run 'Test(MailGetRigStoreSlowReturnsTyped503|MailListRigProviderPanicReturns500|MailListAllRigsProviderPanicReturnsPartial|ClientGetMail_StoreSlowDoesNotFallback|RouteMailPeekStoreSlowDoesNotFallback|RouteMailCheckPartialProviderErrorInjectEmitsDegradedNotice|RouteMailCheckPartialProviderErrorNonInjectReturnsError|MailCountAllRigsStoreSlowAllFailedReturnsTyped503|MailListAllRigsStoreSlowAllFailedReturnsTyped503|MailListAllStatusStoreSlowAllFailedReturnsTyped503|MailCountRigStoreSlowReturnsTyped503|MailListRigStoreSlowReturnsTyped503|MailThreadRigStoreSlowReturnsTyped503)$' -count=1
+ok  	github.com/gastownhall/gascity/internal/api	0.286s
+ok  	github.com/gastownhall/gascity/cmd/gc	2.221s
+
+$ go test -race ./internal/api -run 'Test(MailCountAllRigsStoreSlowAllFailedReturnsTyped503|MailListAllRigsProviderPanicReturnsPartial|MailListRigProviderPanicReturns500|MailGetRigStoreSlowReturnsTyped503|UniqueMailRecipientsDoesNotMutateInput|UniqueNonEmptyMailRecipientsDoesNotMutateInput)$' -count=1
+ok  	github.com/gastownhall/gascity/internal/api	1.514s
+
 $ make test-fast-parallel
 All fast jobs passed
 
 $ go vet ./...
 (clean)
 
-$ go test ./internal/api ./cmd/gc -run 'Test(MailListRigStoreSlowReturnsTyped503|MailCountRigStoreSlowReturnsTyped503|ClientListMailInbox_StoreSlowDoesNotFallback|ClientCountMail_StoreSlowDoesNotFallback|RouteMailCheckInjectStoreSlowEmitsDegradedNotice|RouteMailCheckStoreSlowNonInjectReturnsError|InboxUsesSingleIssuesTierMessageScanAcrossRoutes|ProviderCached_BroadSessionListCacheConcurrentAccess|NewMailProviderUsesCachedBeadmailProvider)$'
-ok  	github.com/gastownhall/gascity/internal/api	0.066s
-ok  	github.com/gastownhall/gascity/cmd/gc	0.336s
-
 $ make dashboard-check
 openapi-ts generation, Vite build, TypeScript typecheck, and go test ./cmd/gc/dashboard/... pass
 
 $ npm run preview -- --host 127.0.0.1 --port 4177
 served http://127.0.0.1:4177/; curl -fsS returned 0
+
+$ git merge-tree --write-tree HEAD origin/main
+(exits 0)
 ```
 
 ## Commits In Scope
 
+These are the evidence-time hashes at reviewed code HEAD `01c871aa6`.
+
 ```text
-eb31b2303 fix: handle store-slow mail reads (refs ga-bqldr7.1)
-8e95e6849 test: red store-slow mail handling (refs ga-bqldr7.1)
+f80d06e9b test: red store-slow mail handling (refs ga-bqldr7.1)
+32899eb00 fix: handle store-slow mail reads (refs ga-bqldr7.1)
+122ecaa36 chore: release gate PASS for ga-sfn3cf
+01c871aa6 fix: address store-slow mail review findings
 ```
 
 ## Files In Scope
@@ -55,6 +74,10 @@ cmd/gc/cmd_mail.go
 cmd/gc/cmd_mail_test.go
 internal/api/client.go
 internal/api/client_test.go
+internal/api/decode_mail.go
+internal/api/decode_mail_test.go
+internal/api/handler_mail.go
 internal/api/handler_mail_test.go
 internal/api/huma_handlers_mail.go
+release-gates/ga-sfn3cf-store-slow-mail-gate.md
 ```


### PR DESCRIPTION
## What this changes

Mail list and count reads now treat a slow backing store as a typed `store_slow` condition instead of letting the CLI or API path hang until a generic client timeout. API callers get a `503` with the `store_slow:` prefix, and the generated client maps that response to `IsStoreSlowError` so fallback logic does not silently hide store pressure.

For `gc mail check`, inject mode now emits a degraded notice and exits successfully when the store is slow, while the normal non-inject path still surfaces the error and exits non-zero. Long-poll wait paths are left alone so only the bounded store read is deadline-wrapped.

## Review notes

- The API behavior is in `internal/api/huma_handlers_mail.go`; client classification is in `internal/api/client.go`.
- CLI handling is limited to `cmd/gc/cmd_mail.go`.
- No new endpoints, config fields, or OpenAPI wire shapes are introduced; `make dashboard-check` leaves generation clean.
- The timeout wrapper uses the existing provider interface, so the underlying goroutine can finish after the caller returns; the channel is buffered so it cannot block on send.

## Test plan

- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `go test ./internal/api ./cmd/gc -run 'Test(MailListRigStoreSlowReturnsTyped503|MailCountRigStoreSlowReturnsTyped503|ClientListMailInbox_StoreSlowDoesNotFallback|ClientCountMail_StoreSlowDoesNotFallback|RouteMailCheckInjectStoreSlowEmitsDegradedNotice|RouteMailCheckStoreSlowNonInjectReturnsError|InboxUsesSingleIssuesTierMessageScanAcrossRoutes|ProviderCached_BroadSessionListCacheConcurrentAccess|NewMailProviderUsesCachedBeadmailProvider)$'`
- [x] `make dashboard-check`
- [x] Dashboard preview smoke on `127.0.0.1:4177`
- [x] Release gate: [`release-gates/ga-sfn3cf-store-slow-mail-gate.md`](release-gates/ga-sfn3cf-store-slow-mail-gate.md)
