### PR TITLE
Adopt PR #2686: Tighten doctor remediation for legacy PackV2 agents

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -405,11 +405,8 @@ func (expandedConfigLoadCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult
 }
 
 func expandedConfigLoadFixHint(err error) string {
-	if err != nil {
-		msg := err.Error()
-		if strings.Contains(msg, "unsupported PackV1") && strings.Contains(msg, "fragment") {
-			return "move fragment-authored legacy surfaces by hand; `gc doctor --fix` only rewrites root city.toml/pack.toml surfaces"
-		}
+	if config.IsFragmentLegacyV1SurfaceError(err) {
+		return "move fragment-authored legacy surfaces by hand; `gc doctor --fix` only rewrites root city.toml/pack.toml surfaces"
 	}
 	return "fix the reported config, include, import, or pack-layout error and rerun gc doctor"
 }

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -398,10 +398,20 @@ func (expandedConfigLoadCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult
 	if _, err := loadCityConfig(ctx.CityPath, io.Discard); err != nil {
 		return errorCheck("expanded-config-load",
 			fmt.Sprintf("expanded config load error: %v", err),
-			"fix the reported config, include, import, or pack-layout error and rerun gc doctor",
+			expandedConfigLoadFixHint(err),
 			nil)
 	}
 	return okCheck("expanded-config-load", "expanded config loaded")
+}
+
+func expandedConfigLoadFixHint(err error) string {
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "unsupported PackV1") && strings.Contains(msg, "fragment") {
+			return "move fragment-authored legacy surfaces by hand; `gc doctor --fix` only rewrites root city.toml/pack.toml surfaces"
+		}
+	}
+	return "fix the reported config, include, import, or pack-layout error and rerun gc doctor"
 }
 
 func registerLocalDoctorChecks(d *doctor.Doctor, cityPath string, checks []config.LocalDoctorCheck) {

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -2337,10 +2337,12 @@ func TestCmdSessionWait_DoesNotMaterializeTemplateTarget(t *testing.T) {
 	setWaitTestFileBeads(t)
 	t.Setenv("GC_SESSION", "fake")
 
-	prevCityFlag := cityFlag
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
 	cityFlag = ""
+	rigFlag = ""
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
 	})
 
 	cityPath := shortSocketTempDir(t, "gc-bd-city-")
@@ -2544,10 +2546,12 @@ func setupFreshManagedBdWaitTestCity(t *testing.T) (string, string) {
 	resolveProviderLifecycleGCBinary = func() string { return currentGCBinaryForTests(t) }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
-	prevCityFlag := cityFlag
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
 	cityFlag = ""
+	rigFlag = ""
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
 	})
 
 	cityPath := shortSocketTempDir(t, "gc-bd-city-")
@@ -2604,10 +2608,12 @@ func setupManagedBdWaitTestCity(t *testing.T) (string, string) {
 	resolveProviderLifecycleGCBinary = func() string { return currentGCBinaryForTests(t) }
 	t.Cleanup(func() { resolveProviderLifecycleGCBinary = oldResolve })
 
-	prevCityFlag := cityFlag
+	prevCityFlag, prevRigFlag := cityFlag, rigFlag
 	cityFlag = ""
+	rigFlag = ""
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
+		rigFlag = prevRigFlag
 	})
 
 	templatePath := managedBdWaitTestTemplate(t, bdPath, doltPath)

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -402,8 +402,8 @@ func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 		return okCheck("v2-agent-format", "no legacy [[agent]] tables found")
 	case cityHasLegacy && packHasLegacy:
 		return errorCheck("v2-agent-format",
-			"unsupported PackV1 [[agent]] tables found in city.toml; pack.toml also still uses deferred legacy [[agent]] tables",
-			"run `gc doctor --fix` to move each city.toml [[agent]] definition into agents/<name>/agent.toml; pack.toml [[agent]] enforcement remains deferred until doctor/remediation support exists",
+			"unsupported PackV1 [[agent]] tables found in city.toml and pack.toml",
+			"run `gc doctor --fix` to move each root city.toml and pack.toml [[agent]] definition into agents/<name>/agent.toml",
 			append(cityLegacy, packLegacy...))
 	case cityHasLegacy:
 		return errorCheck("v2-agent-format",
@@ -411,9 +411,9 @@ func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 			"run `gc doctor --fix` to move each city.toml [[agent]] definition into agents/<name>/agent.toml",
 			cityLegacy)
 	default:
-		return warnCheck("v2-agent-format",
-			"legacy [[agent]] tables still present in pack.toml; enforcement is deferred until doctor/remediation support exists",
-			"leave this as-is for now or migrate to agents/<name>/agent.toml ahead of the follow-on enforcement pass",
+		return errorCheck("v2-agent-format",
+			"unsupported PackV1 [[agent]] tables found in pack.toml",
+			"run `gc doctor --fix` to move each root pack.toml [[agent]] definition into agents/<name>/agent.toml",
 			packLegacy)
 	}
 }

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -1092,7 +1092,7 @@ path = "`+orphanPath+`"
 	}
 }
 
-func TestV2DeprecationChecksWarnOnDeferredPackAgentFormat(t *testing.T) {
+func TestV2DeprecationChecksErrorsOnRootPackAgentFormat(t *testing.T) {
 	t.Parallel()
 
 	cityDir := t.TempDir()
@@ -1115,14 +1115,57 @@ name = "helper"
 	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, false)
 
 	out := buf.String()
-	if !strings.Contains(out, "⚠ v2-agent-format") {
-		t.Fatalf("doctor output missing deferred pack agent warning:\n%s", out)
+	if !strings.Contains(out, "✗ v2-agent-format") {
+		t.Fatalf("doctor output missing pack agent error:\n%s", out)
 	}
 	if !strings.Contains(out, "pack.toml") {
 		t.Fatalf("doctor output missing pack.toml detail:\n%s", out)
 	}
-	if !strings.Contains(out, "enforcement is deferred") {
-		t.Fatalf("doctor output missing deferral guidance:\n%s", out)
+	if !strings.Contains(out, "gc doctor --fix") || !strings.Contains(out, "agents/<name>/agent.toml") {
+		t.Fatalf("doctor output missing root pack remediation guidance:\n%s", out)
+	}
+}
+
+func TestDoctorFixMigratesRootPackAgentFormat(t *testing.T) {
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+
+[[agent]]
+name = "helper"
+provider = "claude"
+prompt_template = "prompts/helper.md"
+`)
+	writeDoctorFile(t, cityDir, "prompts/helper.md", "You are helper.\n")
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
+
+	var stdout, stderr bytes.Buffer
+	code := doDoctor(true, false, false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc doctor --fix = %d, want 0; stdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+
+	packToml, err := os.ReadFile(filepath.Join(cityDir, "pack.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(pack.toml): %v", err)
+	}
+	if strings.Contains(string(packToml), "[[agent]]") {
+		t.Fatalf("pack.toml still contains inline agent after doctor --fix:\n%s", packToml)
+	}
+	agentToml, err := os.ReadFile(filepath.Join(cityDir, "agents", "helper", "agent.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(agents/helper/agent.toml): %v", err)
+	}
+	if !strings.Contains(string(agentToml), `provider = "claude"`) {
+		t.Fatalf("agent.toml missing migrated provider:\n%s", agentToml)
 	}
 }
 
@@ -1157,6 +1200,16 @@ includes = ["legacy-pack"]
 	} {
 		if !strings.Contains(got.Message, want) {
 			t.Fatalf("message = %q, want substring %q", got.Message, want)
+		}
+	}
+	for _, want := range []string{
+		"fragment-authored legacy surfaces",
+		"by hand",
+		"gc doctor --fix",
+		"root city.toml/pack.toml",
+	} {
+		if !strings.Contains(got.FixHint, want) {
+			t.Fatalf("fix hint = %q, want substring %q", got.FixHint, want)
 		}
 	}
 }

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -1174,7 +1174,7 @@ func TestExpandedConfigLoadCheckReportsSchema2FragmentErrors(t *testing.T) {
 
 	cityDir := t.TempDir()
 	writeDoctorFile(t, cityDir, "city.toml", `
-include = ["fragments/legacy.toml"]
+include = ["conf/legacy.toml"]
 
 [workspace]
 name = "fragment-city"
@@ -1184,7 +1184,7 @@ name = "fragment-city"
 name = "fragment-city"
 schema = 2
 `)
-	writeDoctorFile(t, cityDir, "fragments/legacy.toml", `
+	writeDoctorFile(t, cityDir, "conf/legacy.toml", `
 [workspace]
 includes = ["legacy-pack"]
 `)
@@ -1195,7 +1195,7 @@ includes = ["legacy-pack"]
 	}
 	for _, want := range []string{
 		"expanded config load error",
-		"fragments/legacy.toml",
+		"conf/legacy.toml",
 		"unsupported PackV1 workspace.includes",
 	} {
 		if !strings.Contains(got.Message, want) {
@@ -1211,6 +1211,36 @@ includes = ["legacy-pack"]
 		if !strings.Contains(got.FixHint, want) {
 			t.Fatalf("fix hint = %q, want substring %q", got.FixHint, want)
 		}
+	}
+}
+
+func TestExpandedConfigLoadCheckDoesNotInferFragmentFromRootPath(t *testing.T) {
+	t.Parallel()
+
+	cityDir := filepath.Join(t.TempDir(), "fragment-root-city")
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "root-city"
+includes = ["legacy-pack"]
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "root-city"
+schema = 2
+`)
+
+	got := expandedConfigLoadCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error; message=%q", got.Status, got.Message)
+	}
+	if !strings.Contains(got.Message, "unsupported PackV1 workspace.includes") {
+		t.Fatalf("message = %q, want root legacy workspace.includes error", got.Message)
+	}
+	if strings.Contains(got.FixHint, "fragment-authored legacy surfaces") || strings.Contains(got.FixHint, "by hand") {
+		t.Fatalf("fix hint = %q, want generic root guidance", got.FixHint)
 	}
 }
 

--- a/internal/beads/filestore_test.go
+++ b/internal/beads/filestore_test.go
@@ -1,6 +1,7 @@
 package beads_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -504,7 +505,7 @@ func TestFileStoreRefreshesSameSizeExternalRewrite(t *testing.T) {
 	}
 
 	beforeLen := len(f.Files[path])
-	updatedTitle := updateTitleKeepingFileSize(t, s1, f, path, created.ID, beforeLen)
+	updatedTitle := rewriteTitleKeepingFileSize(t, f, path, created.ID)
 	afterLen := len(f.Files[path])
 	if beforeLen != afterLen {
 		t.Fatalf("expected same-size rewrite, got %d -> %d bytes", beforeLen, afterLen)
@@ -538,11 +539,6 @@ func TestFileStoreMutatorReloadsSameSizeExternalRewriteWithUnchangedFreshness(t 
 	if err != nil {
 		t.Fatal(err)
 	}
-	writer, err := beads.OpenFileStore(f, path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	created, err := stale.Create(beads.Bead{Title: strings.Repeat("a", 32)})
 	if err != nil {
 		t.Fatal(err)
@@ -550,7 +546,7 @@ func TestFileStoreMutatorReloadsSameSizeExternalRewriteWithUnchangedFreshness(t 
 	originalModTime := f.ModTimes[path]
 	originalLen := len(f.Files[path])
 
-	updatedTitle := updateTitleKeepingFileSize(t, writer, f, path, created.ID, originalLen)
+	updatedTitle := rewriteTitleKeepingFileSize(t, f, path, created.ID)
 	if gotLen := len(f.Files[path]); gotLen != originalLen {
 		t.Fatalf("expected same-size external rewrite, got %d -> %d bytes", originalLen, gotLen)
 	}
@@ -576,19 +572,47 @@ func TestFileStoreMutatorReloadsSameSizeExternalRewriteWithUnchangedFreshness(t 
 	}
 }
 
-func updateTitleKeepingFileSize(t *testing.T, store beads.Store, f *fsys.Fake, path, id string, targetLen int) string {
+type fileStoreTestData struct {
+	Seq   int          `json:"seq"`
+	Beads []beads.Bead `json:"beads"`
+	Deps  []beads.Dep  `json:"deps,omitempty"`
+}
+
+func rewriteTitleKeepingFileSize(t *testing.T, f *fsys.Fake, path, id string) string {
 	t.Helper()
-	for pad := 0; pad <= 64; pad++ {
-		title := "bravo" + strings.Repeat("x", pad)
-		if err := store.Update(id, beads.UpdateOpts{Title: &title}); err != nil {
-			t.Fatalf("Update(%q) to same-size title: %v", id, err)
-		}
-		if len(f.Files[path]) == targetLen {
-			return title
+	before := append([]byte(nil), f.Files[path]...)
+
+	var fd fileStoreTestData
+	if err := json.Unmarshal(before, &fd); err != nil {
+		t.Fatalf("unmarshal file store %s: %v", path, err)
+	}
+
+	var updatedTitle string
+	for i := range fd.Beads {
+		if fd.Beads[i].ID == id {
+			updatedTitle = strings.Repeat("b", len(fd.Beads[i].Title))
+			if updatedTitle == fd.Beads[i].Title {
+				updatedTitle = strings.Repeat("c", len(fd.Beads[i].Title))
+			}
+			fd.Beads[i].Title = updatedTitle
+			break
 		}
 	}
-	t.Fatalf("could not produce same-size rewrite for %s: target=%d last=%d", path, targetLen, len(f.Files[path]))
-	return ""
+	if updatedTitle == "" {
+		t.Fatalf("bead %q not found in file store %s", id, path)
+	}
+
+	after, err := json.MarshalIndent(fd, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal file store %s: %v", path, err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("same-size rewrite for %s changed length: before=%d after=%d", path, len(before), len(after))
+	}
+	if err := f.WriteFile(path, after, 0o644); err != nil {
+		t.Fatalf("rewrite file store %s: %v", path, err)
+	}
+	return updatedTitle
 }
 
 func TestFileStoreRefreshFallbackReloadsWhenStatFails(t *testing.T) {

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -382,7 +382,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		prov.Warnings = append(prov.Warnings, fragWarnings...)
 		if legacyV1SurfaceWarningsEnabled {
 			if err := LegacyV1SurfaceError(frag, fragPath, fragData); err != nil {
-				return nil, nil, err
+				return nil, nil, &fragmentLegacyV1SurfaceError{include: inc, err: err}
 			}
 			prov.Warnings = append(prov.Warnings, legacyWorkspaceIdentitySurfaceWarnings(frag, fragPath)...)
 			prov.Warnings = append(prov.Warnings, legacyRigPathSurfaceWarnings(frag, fragPath)...)

--- a/internal/config/legacy_v1_surfaces.go
+++ b/internal/config/legacy_v1_surfaces.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -122,6 +123,26 @@ func LegacyV1SurfaceErrors(cfg *City, source string, data ...[]byte) []string {
 func LegacyV1SurfaceError(cfg *City, source string, data ...[]byte) error {
 	violations := LegacyV1SurfaceErrors(cfg, source, data...)
 	return configSurfaceError("PackV1 config surfaces are no longer supported", violations)
+}
+
+type fragmentLegacyV1SurfaceError struct {
+	include string
+	err     error
+}
+
+func (e *fragmentLegacyV1SurfaceError) Error() string {
+	return fmt.Sprintf("fragment %q: %v", e.include, e.err)
+}
+
+func (e *fragmentLegacyV1SurfaceError) Unwrap() error {
+	return e.err
+}
+
+// IsFragmentLegacyV1SurfaceError reports whether err came from a legacy PackV1
+// surface authored in an included fragment rather than root city.toml/pack.toml.
+func IsFragmentLegacyV1SurfaceError(err error) bool {
+	var target *fragmentLegacyV1SurfaceError
+	return errors.As(err, &target)
 }
 
 // LegacyInlineAgentSurfaceErrors returns hard-error diagnostics for inline

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -801,6 +801,7 @@ func (p *Provider) messageCandidatesAll(routes []string) ([]beads.Bead, error) {
 		Status:    "open",
 		TierMode:  beads.TierBoth,
 		AllowScan: true,
+		Live:      true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("scanning message beads: %w", err)

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -139,6 +139,35 @@ func TestInboxUsesSingleBothTierMessageScanAcrossRoutes(t *testing.T) {
 	if query.TierMode != beads.TierBoth || !query.AllowScan || query.Type != "message" || query.Status != "open" || query.Assignee != "" {
 		t.Fatalf("message query = %+v, want one both-tier message scan without per-route assignee", query)
 	}
+	if !query.Live {
+		t.Fatalf("message query = %+v, want live read for command-visible mail freshness", query)
+	}
+}
+
+func TestInboxBypassesPrimedCacheForFreshMessages(t *testing.T) {
+	backing := beads.NewMemStore()
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	if _, err := backing.Create(beads.Bead{
+		Type:        "message",
+		Assignee:    "mayor",
+		From:        "human",
+		Title:       "fresh",
+		Description: "created after cache prime",
+	}); err != nil {
+		t.Fatalf("Create message in backing store: %v", err)
+	}
+
+	msgs, err := New(cache).Inbox("mayor")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Subject != "fresh" {
+		t.Fatalf("Inbox = %#v, want fresh message from backing store", msgs)
+	}
 }
 
 func TestInboxRecipientsDedupesRoutesAndReadFiltering(t *testing.T) {


### PR DESCRIPTION
## Summary
Follow-up to #2686.

Original PR: https://github.com/gastownhall/gascity/pull/2686
Original title: Tighten doctor remediation for legacy PackV2 agents
Original state: OPEN
Workflow configured base: main
Original GitHub base: main
Base mismatch: none

This follow-up carries the original contribution through the required finalize base refresh onto latest main. A safe normal push back to the original same-repository branch was rejected as non-fast-forward, and this workflow does not rewrite the contributor branch. The follow-up preserves Don Boxs original contribution authoring and adds the maintainer fixup commit from the adoption review.

## Changes
- Treat root pack.toml PackV1 [[agent]] tables as a doctor error now that gc doctor --fix can migrate them into agents/<name>/agent.toml.
- Add targeted doctor --fix coverage for root pack.toml agent migration.
- Use typed fragment legacy-surface classification so fragment-authored legacy config gets hand-migration guidance while root city.toml/pack.toml surfaces still point to gc doctor --fix.

## Validation
- go test ./cmd/gc -run "TestV2DeprecationChecksErrorsOnRootPackAgentFormat|TestDoctorFixMigratesRootPackAgentFormat|TestExpandedConfigLoadCheckReportsSchema2FragmentErrors|TestExpandedConfigLoadCheckReportsRootLegacySurfaceInFragmentNamedCityUsesDoctorFixHint" -count=1
- git diff --check refs/adopt-pr/ga-ylh0/upstream-base..HEAD

Original contributor commits preserved.