### PR TITLE
fix(mail): keep TierBoth message reads on one bd list

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1396,7 +1396,7 @@ func (s *BdStore) Delete(id string) error {
 	return nil
 }
 
-// List returns beads matching the query via bd list.
+// List returns beads matching the query via bd list and bd query.
 func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("bd list: %w", ErrQueryRequiresScan)
@@ -1406,9 +1406,20 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	case TierWisps:
 		return s.listEphemeral(query)
 	case TierBoth:
+		if bdListCoversBothTiers(query) {
+			return s.listViaBDList(query)
+		}
 		return s.listBothTiers(query)
 	}
 
+	return s.listViaBDList(query)
+}
+
+func bdListCoversBothTiers(query ListQuery) bool {
+	return query.Type == "message"
+}
+
+func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 	limit := query.Limit
 	if query.Sort == SortCreatedAsc {
 		limit = 0
@@ -1472,9 +1483,8 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 }
 
 // listEphemeral reads only the wisps tier using `bd query "ephemeral=true AND
-// <filters>"`. bd list only scans the issues table; bd query is the canonical
-// way to reach the wisps table (mirrors gastown's internal/beads/beads.go
-// listEphemeral path).
+// <filters>"`. For most bead types, bd query is the canonical way to reach the
+// wisps table (mirrors gastown's internal/beads/beads.go listEphemeral path).
 func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
 	clauses := []string{"ephemeral=true"}
 	serverFilteredOnly := true

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3091,6 +3091,32 @@ func TestBdStoreListBothTiersAppliesCreatedBeforeBeforeMergedLimit(t *testing.T)
 	}
 }
 
+func TestBdStoreListBothTiersMessageUsesSingleBdListWithoutTierFiltering(t *testing.T) {
+	var calls []string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		full := name + " " + strings.Join(args, " ")
+		calls = append(calls, full)
+		switch {
+		case strings.HasPrefix(full, "bd list "):
+			return []byte(`[{"id":"bd-msg","title":"message","status":"open","issue_type":"message","assignee":"mayor","created_at":"2026-05-01T00:00:00Z","ephemeral":true}]`), nil
+		case strings.HasPrefix(full, "bd query "):
+			t.Fatalf("message TierBoth list issued bd query: %v", calls)
+		}
+		return nil, fmt.Errorf("unexpected: %s", full)
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{Type: "message", Status: "open", TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("got %d runner calls, want 1: %v", len(calls), calls)
+	}
+	if len(got) != 1 || got[0].ID != "bd-msg" || !got[0].Ephemeral {
+		t.Fatalf("got = %+v, want TierBoth bd message row bd-msg with Ephemeral=true", got)
+	}
+}
+
 func TestBdStoreListIssuesTierDoesNotIssueQuery(t *testing.T) {
 	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -24,13 +24,10 @@ const (
 // TierMode selects which storage tier(s) a List query reads from.
 // The zero value is TierIssues.
 //
-// For BdStore, where issues and wisps live in physically separate Dolt
-// tables, TierIssues is naturally tier-restricted by the underlying
-// `bd list` call. For in-memory stores (MemStore, ApplyListQuery) where
-// both tiers may share a single backing slice, Matches now filters out
-// any bead with Ephemeral=true under TierIssues. Pre-PR, such a query
-// would have returned ephemeral rows mixed in; callers that relied on
-// that behavior must opt into TierBoth explicitly.
+// TierIssues is the permanent tier and filters out Ephemeral rows when a store
+// returns them to the caller. TierBoth is a logical union; implementations may
+// satisfy it through a single backend query when the backing store exposes a
+// supported union surface for the requested bead type.
 type TierMode int
 
 const (

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -792,9 +792,9 @@ func (p *Provider) messageCandidatesForRoutes(routes []string) ([]beads.Bead, er
 }
 
 // messageCandidatesAll returns all open message beads matching any route.
-// Empty routes return all open messages. bd stores message beads as wisps, but
-// older stores can still have issue-tier messages, so mail reads must union
-// both tiers.
+// Empty routes return all open messages. Message reads need TierBoth because
+// bd stores current message beads as wisps while older stores can still have
+// issue-tier messages.
 func (p *Provider) messageCandidatesAll(routes []string) ([]beads.Bead, error) {
 	all, err := p.store.List(beads.ListQuery{
 		Type:      "message",

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -279,13 +279,10 @@ func TestCheckDoesNotUseMessageLabelSupplement(t *testing.T) {
 			return []byte(`[]`), nil
 		}
 		if strings.Contains(cmd, "bd query --json") {
-			if !strings.Contains(cmd, "ephemeral=true") || !strings.Contains(cmd, "type=message") {
-				t.Fatalf("mail check used unexpected wisp query: %s", cmd)
-			}
-			return []byte(`[]`), nil
+			t.Fatalf("mail check used supplemental wisp query: %s", cmd)
 		}
 		if strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=message") && strings.Contains(cmd, "--status=open") {
-			return []byte(`[{"id":"msg-1","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"mayor","from":"human","created_at":"2026-01-02T03:04:05Z","labels":["gc:message"]}]`), nil
+			return []byte(`[{"id":"msg-1","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"mayor","from":"human","created_at":"2026-01-02T03:04:05Z","ephemeral":true,"labels":["gc:message"]}]`), nil
 		}
 		return nil, errors.New("unexpected command: " + cmd)
 	}
@@ -300,9 +297,9 @@ func TestCheckDoesNotUseMessageLabelSupplement(t *testing.T) {
 	}
 }
 
-func TestCheckSupportsSlashRecipientWithWispTier(t *testing.T) {
+func TestCheckUsesSingleBothTierScanForSlashRecipient(t *testing.T) {
 	recipient := "gascity/workflows.codex-max"
-	sawWispQuery := false
+	var messageListCalls int
 	runner := func(_ string, name string, args ...string) ([]byte, error) {
 		cmd := name + " " + strings.Join(args, " ")
 		switch {
@@ -313,16 +310,13 @@ func TestCheckSupportsSlashRecipientWithWispTier(t *testing.T) {
 		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=session"):
 			return []byte(`[]`), nil
 		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=message") && strings.Contains(cmd, "--status=open"):
-			return []byte(`[]`), nil
-		case strings.Contains(cmd, "bd query --json"):
-			if strings.Contains(cmd, "assignee=") {
-				t.Fatalf("slash recipient used per-assignee wisp query: %s", cmd)
+			if strings.Contains(cmd, "--assignee=") {
+				t.Fatalf("slash recipient used per-assignee message query: %s", cmd)
 			}
-			if !strings.Contains(cmd, "ephemeral=true") || !strings.Contains(cmd, "type=message") {
-				t.Fatalf("mail check used unexpected wisp query: %s", cmd)
-			}
-			sawWispQuery = true
+			messageListCalls++
 			return []byte(`[{"id":"msg-w","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"gascity/workflows.codex-max","from":"human","created_at":"2026-01-02T03:04:05Z","ephemeral":true}]`), nil
+		case strings.Contains(cmd, "bd query --json"):
+			t.Fatalf("slash recipient used supplemental wisp query: %s", cmd)
 		}
 		return nil, errors.New("unexpected command: " + cmd)
 	}
@@ -332,11 +326,44 @@ func TestCheckSupportsSlashRecipientWithWispTier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
-	if !sawWispQuery {
-		t.Fatal("Check did not query wisps tier")
+	if messageListCalls != 1 {
+		t.Fatalf("message list calls = %d, want 1", messageListCalls)
 	}
 	if len(msgs) != 1 || msgs[0].ID != "msg-w" {
 		t.Fatalf("Check = %#v, want msg-w", msgs)
+	}
+}
+
+func TestCheckUsesSingleBothTierBdMessageScan(t *testing.T) {
+	var messageListCalls int
+	runner := func(_ string, name string, args ...string) ([]byte, error) {
+		cmd := name + " " + strings.Join(args, " ")
+		switch {
+		case strings.Contains(cmd, "bd show --json mayor"):
+			return nil, errors.New("not found")
+		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--metadata-field"):
+			return []byte(`[]`), nil
+		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=session"):
+			return []byte(`[]`), nil
+		case strings.Contains(cmd, "bd query --json"):
+			t.Fatalf("mail check used supplemental bd query: %s", cmd)
+		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=message") && strings.Contains(cmd, "--status=open"):
+			messageListCalls++
+			return []byte(`[{"id":"msg-1","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"mayor","from":"human","created_at":"2026-01-02T03:04:05Z","ephemeral":true}]`), nil
+		}
+		return nil, errors.New("unexpected command: " + cmd)
+	}
+	p := New(beads.NewBdStore(t.TempDir(), runner))
+
+	msgs, err := p.Check("mayor")
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if messageListCalls != 1 {
+		t.Fatalf("message list calls = %d, want 1", messageListCalls)
+	}
+	if len(msgs) != 1 || msgs[0].ID != "msg-1" {
+		t.Fatalf("Check = %#v, want msg-1", msgs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep beadmail reads on the existing `TierBoth` contract
- teach `BdStore` that `TierBoth + type=message` is covered by one supported `bd list --type=message` call
- preserve strict issue-tier filtering for normal `TierIssues` queries and keep non-message `TierBoth` on the two-tier union path

## Verification
- go test ./internal/beads -count=1
- go test ./internal/mail/beadmail -count=1
- go vet ./...
- env GC_FAST_UNIT=0 GO_TEST_COUNT=1 GO_TEST_TIMEOUT=20m ./scripts/test-go-test-shard ./cmd/gc 3 12
- make test-fast-parallel
