### PR TITLE
feat(doctor): add named session pool conflict check

### DIFF
--- a/internal/doctor/checks_named_session.go
+++ b/internal/doctor/checks_named_session.go
@@ -1,0 +1,85 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// NamedAlwaysMinConflictCheck warns when an agent both backs a mode="always"
+// named session and sets min_active_sessions > 0.
+type NamedAlwaysMinConflictCheck struct {
+	cfg *config.City
+}
+
+// NewNamedAlwaysMinConflictCheck creates a check for duplicate pool session
+// footguns caused by named sessions and pool minimums.
+func NewNamedAlwaysMinConflictCheck(cfg *config.City) *NamedAlwaysMinConflictCheck {
+	return &NamedAlwaysMinConflictCheck{cfg: cfg}
+}
+
+// Name returns the check identifier.
+func (c *NamedAlwaysMinConflictCheck) Name() string {
+	return "named-always-min-conflict"
+}
+
+// Run warns when any non-suspended agent backs a mode="always" named session
+// and has min_active_sessions > 0.
+func (c *NamedAlwaysMinConflictCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.cfg == nil {
+		r.Status = StatusOK
+		r.Message = "no config; nothing to check"
+		return r
+	}
+
+	alwaysSessions := map[string]string{}
+	for _, ns := range c.cfg.NamedSessions {
+		if ns.ModeOrDefault() == "always" {
+			alwaysSessions[ns.TemplateQualifiedName()] = ns.QualifiedName()
+		}
+	}
+	if len(alwaysSessions) == 0 {
+		r.Status = StatusOK
+		r.Message = "no mode=always named sessions"
+		return r
+	}
+
+	var details []string
+	for i := range c.cfg.Agents {
+		a := &c.cfg.Agents[i]
+		if a.Suspended {
+			continue
+		}
+		minimum := a.EffectiveMinActiveSessions()
+		if minimum <= 0 {
+			continue
+		}
+		nsName, ok := alwaysSessions[a.QualifiedName()]
+		if !ok {
+			continue
+		}
+		details = append(details, fmt.Sprintf(
+			"agent %q: min_active_sessions=%d with named_session %q mode=always; set min_active_sessions=0 to avoid a duplicate pool session",
+			a.QualifiedName(), minimum, nsName,
+		))
+	}
+
+	if len(details) == 0 {
+		r.Status = StatusOK
+		r.Message = "no named-always / min_active_sessions conflicts"
+		return r
+	}
+	r.Status = StatusWarning
+	r.Severity = SeverityAdvisory
+	r.Message = fmt.Sprintf("%d agent(s) combine mode=always with min_active_sessions>0", len(details))
+	r.Details = details
+	return r
+}
+
+// CanFix returns false because config authors must decide whether the
+// duplicate pool session is intentional.
+func (c *NamedAlwaysMinConflictCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *NamedAlwaysMinConflictCheck) Fix(_ *CheckContext) error { return nil }

--- a/internal/doctor/checks_named_session_test.go
+++ b/internal/doctor/checks_named_session_test.go
@@ -1,0 +1,141 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestNamedAlwaysMinConflictCheckOKCases(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.City
+	}{
+		{
+			name: "no named sessions",
+			cfg: &config.City{
+				Agents: []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(1)}},
+			},
+		},
+		{
+			name: "on demand named session with pool minimum",
+			cfg: &config.City{
+				NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "on_demand"}},
+				Agents:        []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(1)}},
+			},
+		},
+		{
+			name: "always named session without pool minimum",
+			cfg: &config.City{
+				NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "always"}},
+				Agents:        []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(0)}},
+			},
+		},
+		{
+			name: "suspended agent is ignored",
+			cfg: &config.City{
+				NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "always"}},
+				Agents: []config.Agent{{
+					Name:              "agent-a",
+					MinActiveSessions: intPtr(1),
+					Suspended:         true,
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewNamedAlwaysMinConflictCheck(tt.cfg).Run(&CheckContext{})
+			if r.Status != StatusOK {
+				t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+			}
+			if r.Severity != SeverityBlocking {
+				t.Fatalf("Severity = %v, want default SeverityBlocking for OK result", r.Severity)
+			}
+		})
+	}
+}
+
+func TestNamedAlwaysMinConflictCheckWarnsWithAdvisorySeverity(t *testing.T) {
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "always"}},
+		Agents:        []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(1)}},
+	}
+
+	r := NewNamedAlwaysMinConflictCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want SeverityAdvisory", r.Severity)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("Details = %d, want 1: %v", len(r.Details), r.Details)
+	}
+	detail := r.Details[0]
+	for _, want := range []string{
+		`agent "agent-a"`,
+		"min_active_sessions=1",
+		`named_session "primary"`,
+		"set min_active_sessions=0 to avoid a duplicate pool session",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("Details[0] = %q, want to contain %q", detail, want)
+		}
+	}
+}
+
+func TestNamedAlwaysMinConflictCheckWarnsForMinTwo(t *testing.T) {
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "always"}},
+		Agents:        []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(2)}},
+	}
+
+	r := NewNamedAlwaysMinConflictCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 || !strings.Contains(r.Details[0], "min_active_sessions=2") {
+		t.Fatalf("Details = %v, want min_active_sessions=2 warning", r.Details)
+	}
+}
+
+func TestNamedAlwaysMinConflictCheckReportsTwoAgents(t *testing.T) {
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{
+			{Name: "primary-a", Template: "agent-a", Mode: "always"},
+			{Name: "primary-b", Template: "agent-b", Mode: "always"},
+		},
+		Agents: []config.Agent{
+			{Name: "agent-a", MinActiveSessions: intPtr(1)},
+			{Name: "agent-b", MinActiveSessions: intPtr(2)},
+		},
+	}
+
+	r := NewNamedAlwaysMinConflictCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want SeverityAdvisory", r.Severity)
+	}
+	if len(r.Details) != 2 {
+		t.Fatalf("Details = %d, want 2: %v", len(r.Details), r.Details)
+	}
+	for _, want := range []string{`agent "agent-a"`, `named_session "primary-a"`} {
+		if !strings.Contains(r.Details[0], want) {
+			t.Fatalf("Details[0] = %q, want to contain %q", r.Details[0], want)
+		}
+	}
+	for _, want := range []string{`agent "agent-b"`, `named_session "primary-b"`} {
+		if !strings.Contains(r.Details[1], want) {
+			t.Fatalf("Details[1] = %q, want to contain %q", r.Details[1], want)
+		}
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -110,6 +110,10 @@ func (c *NestedWorktreePruneCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *NamedAlwaysMinConflictCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *OrderFiringCurrentCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the

--- a/release-gates/ga-6gi0gn-named-session-pool-conflict-gate.md
+++ b/release-gates/ga-6gi0gn-named-session-pool-conflict-gate.md
@@ -1,0 +1,38 @@
+# Release gate: ga-6gi0gn named session pool conflict check
+
+Status: PASS
+
+Evaluated: 2026-05-30
+
+Bead: ga-6gi0gn
+Source review bead: ga-xj36nq
+Branch: builder/ga-ihrikr.1-named-session-doctor
+Reviewed head: 8f1e169ed6445ff9b014015dfaa856c39d13da81
+
+Release criteria source: deployer role prompt. `docs/PROJECT_MANIFEST.md`
+was not present in this worktree.
+
+## Gate checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-xj36nq` records reviewer PASS for `builder/ga-ihrikr.1-named-session-doctor` at `8f1e169ed6445ff9b014015dfaa856c39d13da81`. |
+| 2 | Acceptance criteria met | PASS | `internal/doctor/checks_named_session.go` adds `NamedAlwaysMinConflictCheck`, warns only for non-suspended agents with `mode="always"` named sessions and `min_active_sessions > 0`, returns advisory severity, and cannot auto-fix. Tests cover no-session, on-demand, zero-minimum, suspended-agent, min=1, min=2, and two-agent cases. |
+| 3 | Tests pass | PASS | `go test ./internal/doctor -run TestNamedAlwaysMinConflictCheck -count=1`; `make test-fast-parallel`; `go vet ./...`. |
+| 4 | No high-severity review findings open | PASS | Review notes list one INFO finding only; no HIGH findings are open. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before writing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` returned tree `0643fc6b184660629f2593db557742fdd128a04e` with no conflicts. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem (`internal/doctor`) for one behavior: detecting named-session/pool-minimum duplicate-session configuration. |
+
+## Test evidence
+
+```text
+go test ./internal/doctor -run TestNamedAlwaysMinConflictCheck -count=1
+ok  	github.com/gastownhall/gascity/internal/doctor	0.003s
+
+make test-fast-parallel
+All fast jobs passed
+
+go vet ./...
+PASS
+```


### PR DESCRIPTION
## What this changes

This adds the doctor check implementation for a named-session configuration footgun: an agent that backs a `mode = "always"` named session while also setting `min_active_sessions > 0`. That combination can create both the named session and an extra pool-managed session for the same agent.

The check reports an advisory warning with the affected agent, pool minimum, and named session. It ignores suspended agents, does not run during `gc start` warmup, and does not auto-fix because config authors need to decide whether the duplicate session is intentional.

## Review notes

- This PR adds the check and unit coverage under `internal/doctor`; it does not register the check in `buildDoctorChecks()` yet. Registration is the next stacked change.
- The warning is advisory, not blocking.
- The check is intentionally not warmup-eligible and cannot auto-fix.

## Test plan

- [x] `go test ./internal/doctor -run TestNamedAlwaysMinConflictCheck -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-6gi0gn-named-session-pool-conflict-gate.md`](release-gates/ga-6gi0gn-named-session-pool-conflict-gate.md)
