### PR TITLE
fix(mail): align wisp-tier mail creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   published regular-usage pricing is unchanged from Opus 4.7: $5/MTok input
   and $25/MTok output.
 
+### Fixed
+
+- `gc mail reply` and `gc handoff` now store created mail in the wisp tier,
+  matching `gc mail send`. Operators should use `gc mail` commands or
+  explicit both-tier/wisp-aware bead queries for mail visibility; default
+  issue-tier `bd list` output and git sync do not include wisp-tier messages.
+
 ## [1.2.0] - 2026-05-25
 
 ### Added

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -307,6 +307,7 @@ func createHandoffMail(store beads.Store, rec events.Recorder, senderAddress, re
 		From:        senderDisplay,
 		Labels:      []string{"thread:" + handoffThreadID()},
 		Metadata:    metadata,
+		Ephemeral:   true,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -17,6 +17,47 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+func listOpenMessagesBothTiers(t *testing.T, store beads.Store) []beads.Bead {
+	t.Helper()
+	all, err := store.List(beads.ListQuery{
+		Type:      "message",
+		Status:    "open",
+		TierMode:  beads.TierBoth,
+		AllowScan: true,
+	})
+	if err != nil {
+		t.Fatalf("List messages: %v", err)
+	}
+	return all
+}
+
+func listOpenMessagesInTier(t *testing.T, store beads.Store, tier beads.TierMode) []beads.Bead {
+	t.Helper()
+	all, err := store.List(beads.ListQuery{
+		Type:      "message",
+		Status:    "open",
+		TierMode:  tier,
+		AllowScan: true,
+	})
+	if err != nil {
+		t.Fatalf("List messages in tier %v: %v", tier, err)
+	}
+	return all
+}
+
+func listOpenBeadsBothTiers(t *testing.T, store beads.Store) []beads.Bead {
+	t.Helper()
+	all, err := store.List(beads.ListQuery{
+		Status:    "open",
+		TierMode:  beads.TierBoth,
+		AllowScan: true,
+	})
+	if err != nil {
+		t.Fatalf("List open beads: %v", err)
+	}
+	return all
+}
+
 func TestHandoffSuccess(t *testing.T) {
 	store := beads.NewMemStore()
 	rec := events.NewFake()
@@ -30,7 +71,7 @@ func TestHandoffSuccess(t *testing.T) {
 	}
 
 	// Verify mail bead created.
-	all, _ := store.ListOpen()
+	all := listOpenMessagesBothTiers(t, store)
 	if len(all) != 1 {
 		t.Fatalf("got %d beads, want 1", len(all))
 	}
@@ -49,6 +90,12 @@ func TestHandoffSuccess(t *testing.T) {
 	}
 	if b.Description != "" {
 		t.Errorf("Description = %q, want empty", b.Description)
+	}
+	if !b.Ephemeral {
+		t.Errorf("Ephemeral = false, want true")
+	}
+	if issueMessages := listOpenMessagesInTier(t, store, beads.TierIssues); len(issueMessages) != 0 {
+		t.Fatalf("issue-tier messages = %#v, want none", issueMessages)
 	}
 
 	// Verify restart-requested flag set.
@@ -193,10 +240,7 @@ func TestCmdHandoffAutoSendsMailWithoutBlocking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	all, err := store.ListOpen()
-	if err != nil {
-		t.Fatalf("ListOpen: %v", err)
-	}
+	all := listOpenMessagesBothTiers(t, store)
 	if len(all) != 1 {
 		t.Fatalf("got %d open beads, want 1", len(all))
 	}
@@ -254,10 +298,7 @@ func TestCmdHandoffAutoHookFormatCodex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	all, err := store.ListOpen()
-	if err != nil {
-		t.Fatalf("ListOpen: %v", err)
-	}
+	all := listOpenMessagesBothTiers(t, store)
 	if len(all) != 1 {
 		t.Fatalf("open beads = %d, want handoff mail", len(all))
 	}
@@ -278,10 +319,7 @@ func TestDoHandoffAutoReportsHookOutputWriteError(t *testing.T) {
 	if !strings.Contains(stderr.String(), "writing hook output") {
 		t.Fatalf("stderr = %q, want hook output write error", stderr.String())
 	}
-	all, err := store.ListOpen()
-	if err != nil {
-		t.Fatalf("ListOpen: %v", err)
-	}
+	all := listOpenMessagesBothTiers(t, store)
 	if len(all) != 1 {
 		t.Fatalf("open beads = %d, want handoff mail still created", len(all))
 	}
@@ -312,10 +350,7 @@ func TestCmdHandoffAutoUsesDefaultSubject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	all, err := store.ListOpen()
-	if err != nil {
-		t.Fatalf("ListOpen: %v", err)
-	}
+	all := listOpenMessagesBothTiers(t, store)
 	if len(all) != 1 {
 		t.Fatalf("got %d open beads, want 1", len(all))
 	}
@@ -390,7 +425,7 @@ func TestDoHandoff_Regression744_NamedSessionSkipsRestart(t *testing.T) {
 	}
 
 	mailFound := false
-	all, _ := store.ListOpen()
+	all := listOpenMessagesBothTiers(t, store)
 	for _, got := range all {
 		if got.Title == "HANDOFF: context full" && got.Type == "message" {
 			mailFound = true
@@ -528,7 +563,7 @@ func TestHandoffWithMessage(t *testing.T) {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
 
-	all, _ := store.ListOpen()
+	all := listOpenMessagesBothTiers(t, store)
 	if len(all) != 1 {
 		t.Fatalf("got %d beads, want 1", len(all))
 	}
@@ -608,7 +643,7 @@ func TestHandoffMissingSubject(t *testing.T) {
 	}
 
 	// Verify no side effects.
-	all, _ := store.ListOpen()
+	all := listOpenBeadsBothTiers(t, store)
 	if len(all) != 0 {
 		t.Errorf("got %d beads, want 0", len(all))
 	}
@@ -654,7 +689,7 @@ func TestHandoffRemoteRunning(t *testing.T) {
 	}
 
 	// Verify mail sent to target.
-	all, _ := store.ListOpen()
+	all := listOpenMessagesBothTiers(t, store)
 	if len(all) != 1 {
 		t.Fatalf("got %d beads, want 1", len(all))
 	}
@@ -772,7 +807,7 @@ func TestHandoffRemoteNotRunning(t *testing.T) {
 	}
 
 	// Mail still sent even if session not running.
-	all, _ := store.ListOpen()
+	all := listOpenMessagesBothTiers(t, store)
 	if len(all) != 1 {
 		t.Fatalf("got %d beads, want 1", len(all))
 	}
@@ -839,10 +874,7 @@ func TestCmdHandoffRemoteDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *
 	if err != nil {
 		t.Fatalf("openCityStoreAt after handoff: %v", err)
 	}
-	all, err := storeAfter.ListOpen()
-	if err != nil {
-		t.Fatalf("ListOpen: %v", err)
-	}
+	all := listOpenMessagesBothTiers(t, storeAfter)
 	var msg beads.Bead
 	found := false
 	for _, b := range all {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -719,9 +719,14 @@ func TestCmdMailSendToControllerRecipientIsRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openCityStoreAt after send: %v", err)
 	}
-	all, err := storeAfter.ListOpen()
+	all, err := storeAfter.List(beads.ListQuery{
+		Type:      "message",
+		Status:    "open",
+		TierMode:  beads.TierBoth,
+		AllowScan: true,
+	})
 	if err != nil {
-		t.Fatalf("ListOpen: %v", err)
+		t.Fatalf("List messages: %v", err)
 	}
 	for _, b := range all {
 		if b.Type == "message" {

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -454,6 +454,7 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 		From:        from,
 		Labels:      labels,
 		Metadata:    metadata,
+		Ephemeral:   true,
 	})
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail reply: %w", err)

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1286,6 +1286,42 @@ func TestReply(t *testing.T) {
 	if reply.ReplyTo != sent.ID {
 		t.Errorf("Reply ReplyTo = %q, want %q", reply.ReplyTo, sent.ID)
 	}
+
+	wispMessages, err := store.List(beads.ListQuery{
+		Type:     "message",
+		Status:   "open",
+		TierMode: beads.TierWisps,
+	})
+	if err != nil {
+		t.Fatalf("List wisp-tier messages: %v", err)
+	}
+	if len(wispMessages) != 2 {
+		t.Fatalf("wisp-tier messages = %d, want sent message and reply", len(wispMessages))
+	}
+	replyInWisps := false
+	for _, b := range wispMessages {
+		if b.ID == reply.ID {
+			replyInWisps = true
+			if !b.Ephemeral {
+				t.Fatalf("reply Ephemeral = false, want true")
+			}
+		}
+	}
+	if !replyInWisps {
+		t.Fatalf("reply %s not found in wisp-tier messages: %#v", reply.ID, wispMessages)
+	}
+
+	issueMessages, err := store.List(beads.ListQuery{
+		Type:     "message",
+		Status:   "open",
+		TierMode: beads.TierIssues,
+	})
+	if err != nil {
+		t.Fatalf("List issue-tier messages: %v", err)
+	}
+	if len(issueMessages) != 0 {
+		t.Fatalf("issue-tier messages = %#v, want none", issueMessages)
+	}
 }
 
 // TestReplyDerivesSubjectFromOriginal ensures an empty subject is replaced


### PR DESCRIPTION
Post-merge remediation for #2652.

Addresses the review findings by:
- storing gc mail reply messages in the wisp tier, matching gc mail send
- storing gc handoff mail in the wisp tier
- hardening mail and handoff tests to query both tiers and assert issue-tier absence where relevant
- documenting the mail visibility and git-sync implications in the changelog

Verification:
- go test ./internal/mail/beadmail -run 'TestReply|TestThreadAcceptsMessageIDOfReply|TestMessageCreatedInWispTier|TestMessageQueriesUseBothTiers' -count=1
- go test ./cmd/gc -run 'TestCmdMailSendToControllerRecipientIsRejected|TestHandoffSuccess|TestCmdHandoffAutoSendsMailWithoutBlocking|TestCmdHandoffAutoHookFormatCodex|TestDoHandoffAutoReportsHookOutputWriteError|TestCmdHandoffAutoUsesDefaultSubject|TestDoHandoff_Regression744_NamedSessionSkipsRestart|TestHandoffWithMessage|TestHandoffMissingSubject|TestHandoffRemoteRunning|TestHandoffRemoteNotRunning|TestCmdHandoffRemoteDefaultSenderFallsBackToGCAliasWhenSessionIDMissing' -count=1
- go vet ./...
- make test-fast-parallel
- go test ./test/docsync
