### PR TITLE
fix: honor Antigravity transcript cursors

### DIFF
--- a/internal/sessionlog/antigravity_reader.go
+++ b/internal/sessionlog/antigravity_reader.go
@@ -70,6 +70,19 @@ func ReadAntigravityFile(path string, tailCompactions int) (*Session, error) {
 	return sess, nil
 }
 
+// ReadAntigravityFilePage parses an agy trajectory JSONL log and applies
+// message-ID pagination using the stable agy-N entry IDs emitted by the reader.
+func ReadAntigravityFilePage(path string, tailCompactions int, beforeMessageID, afterMessageID string) (*Session, error) {
+	sess, err := readAntigravityFile(path, false)
+	if err != nil {
+		return nil, err
+	}
+	paginated, info := sliceAtCompactBoundaries(sess.Messages, tailCompactions, beforeMessageID, afterMessageID)
+	sess.Messages = paginated
+	sess.Pagination = info
+	return sess, nil
+}
+
 // ReadAntigravityFileRaw parses an agy trajectory JSONL log without display type filtering.
 func ReadAntigravityFileRaw(path string, tailCompactions int) (*Session, error) {
 	sess, err := readAntigravityFile(path, true)
@@ -81,6 +94,19 @@ func ReadAntigravityFileRaw(path string, tailCompactions int) (*Session, error) 
 		sess.Messages = paginated
 		sess.Pagination = info
 	}
+	return sess, nil
+}
+
+// ReadAntigravityFileRawPage parses an agy trajectory JSONL log without
+// display type filtering and applies message-ID pagination.
+func ReadAntigravityFileRawPage(path string, tailCompactions int, beforeMessageID, afterMessageID string) (*Session, error) {
+	sess, err := readAntigravityFile(path, true)
+	if err != nil {
+		return nil, err
+	}
+	paginated, info := sliceAtCompactBoundaries(sess.Messages, tailCompactions, beforeMessageID, afterMessageID)
+	sess.Messages = paginated
+	sess.Pagination = info
 	return sess, nil
 }
 
@@ -267,7 +293,7 @@ func consumeAgyPendingCallID(pendingCallIDs *[]string, preferred string) string 
 				return preferred
 			}
 		}
-		return preferred
+		return ""
 	}
 	if len(*pendingCallIDs) == 0 {
 		return ""
@@ -359,7 +385,9 @@ func antigravitySessionID(path string) string {
 // nested brain layout. workDir is accepted for signature symmetry with the
 // other provider keyed lookups; the agy conversation id is globally unique, so
 // it is not needed to disambiguate the transcript path.
-func FindAntigravitySessionFileByID(searchPaths []string, _, sessionID string) string {
+func FindAntigravitySessionFileByID(searchPaths []string, workDir, sessionID string) string {
+	_ = workDir
+
 	sessionID = safeAntigravitySessionDirName(sessionID)
 	if sessionID == "" {
 		return ""

--- a/internal/sessionlog/antigravity_reader_test.go
+++ b/internal/sessionlog/antigravity_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -286,6 +287,37 @@ func TestReadAntigravityFileCorrelatesExplicitOutOfOrderToolResults(t *testing.T
 	}
 }
 
+func TestReadAntigravityFileTreatsUnmatchedExplicitResultIDsAsSystem(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	body := `{"step_index":1,"type":"PLANNER_RESPONSE","created_at":"2026-04-04T09:00:01Z","content":"checking","tool_calls":[{"id":"call-a","name":"Read","args":{"path":"a.txt"}}]}` + "\n" +
+		`{"step_index":2,"type":"READ_FILE","created_at":"2026-04-04T09:00:02Z","tool_call_id":"call-a","content":"contents of a"}` + "\n" +
+		`{"step_index":3,"type":"READ_FILE","created_at":"2026-04-04T09:00:03Z","tool_call_id":"call-a","content":"duplicate result"}` + "\n" +
+		`{"step_index":4,"type":"READ_FILE","created_at":"2026-04-04T09:00:04Z","call_id":"call-unknown","content":"unknown result"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	sess, err := ReadAntigravityFileRaw(path, 0)
+	if err != nil {
+		t.Fatalf("ReadAntigravityFileRaw: %v", err)
+	}
+	if len(sess.Messages) != 4 {
+		t.Fatalf("messages = %d, want 4", len(sess.Messages))
+	}
+	if sess.Messages[1].Type != "result" || sess.Messages[1].ToolUseID != "call-a" {
+		t.Fatalf("first result = type %q tool_use_id %q, want result call-a", sess.Messages[1].Type, sess.Messages[1].ToolUseID)
+	}
+	if sess.Messages[2].Type != "system" || sess.Messages[2].ToolUseID != "" {
+		t.Fatalf("duplicate explicit result = type %q tool_use_id %q, want unmatched system entry", sess.Messages[2].Type, sess.Messages[2].ToolUseID)
+	}
+	if sess.Messages[3].Type != "system" || sess.Messages[3].ToolUseID != "" {
+		t.Fatalf("unknown explicit result = type %q tool_use_id %q, want unmatched system entry", sess.Messages[3].Type, sess.Messages[3].ToolUseID)
+	}
+	if sess.OrphanedToolUseIDs != nil {
+		t.Fatalf("OrphanedToolUseIDs = %#v, want nil after matched call-a", sess.OrphanedToolUseIDs)
+	}
+}
+
 func TestReadAntigravityFileReportsOpenToolUseTail(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "transcript.jsonl")
 	body := `{"step_index":1,"type":"PLANNER_RESPONSE","created_at":"2026-04-04T09:00:01Z","content":"checking","tool_calls":[{"id":"call-open","name":"Read","args":{"path":"README.md"}}]}` + "\n"
@@ -349,6 +381,49 @@ func TestReadAntigravityFileNormalizesInteractions(t *testing.T) {
 	}
 }
 
+func TestReadProviderFileAntigravityAppliesMessageIDCursors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	body := `{"step_index":0,"type":"USER_INPUT","created_at":"2026-04-04T09:00:00Z","content":"first"}` + "\n" +
+		`{"step_index":1,"type":"PLANNER_RESPONSE","created_at":"2026-04-04T09:00:01Z","content":"second"}` + "\n" +
+		`{"step_index":2,"type":"USER_INPUT","created_at":"2026-04-04T09:00:02Z","content":"third"}` + "\n" +
+		`{"step_index":3,"type":"PLANNER_RESPONSE","created_at":"2026-04-04T09:00:03Z","content":"fourth"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	newer, err := ReadProviderFileNewer("antigravity/tmux-cli", path, 0, "agy-1")
+	if err != nil {
+		t.Fatalf("ReadProviderFileNewer: %v", err)
+	}
+	if got := antigravityEntryIDs(newer.Messages); !reflect.DeepEqual(got, []string{"agy-2", "agy-3"}) {
+		t.Fatalf("newer Antigravity message IDs = %v, want [agy-2 agy-3]", got)
+	}
+
+	older, err := ReadProviderFileOlder("antigravity/tmux-cli", path, 0, "agy-2")
+	if err != nil {
+		t.Fatalf("ReadProviderFileOlder: %v", err)
+	}
+	if got := antigravityEntryIDs(older.Messages); !reflect.DeepEqual(got, []string{"agy-0", "agy-1"}) {
+		t.Fatalf("older Antigravity message IDs = %v, want [agy-0 agy-1]", got)
+	}
+
+	rawNewer, err := ReadProviderFileRawNewer("antigravity/tmux-cli", path, 0, "agy-2")
+	if err != nil {
+		t.Fatalf("ReadProviderFileRawNewer: %v", err)
+	}
+	if got := antigravityEntryIDs(rawNewer.Messages); !reflect.DeepEqual(got, []string{"agy-3"}) {
+		t.Fatalf("raw newer Antigravity message IDs = %v, want [agy-3]", got)
+	}
+
+	rawOlder, err := ReadProviderFileRawOlder("antigravity/tmux-cli", path, 0, "agy-3")
+	if err != nil {
+		t.Fatalf("ReadProviderFileRawOlder: %v", err)
+	}
+	if got := antigravityEntryIDs(rawOlder.Messages); !reflect.DeepEqual(got, []string{"agy-0", "agy-1", "agy-2"}) {
+		t.Fatalf("raw older Antigravity message IDs = %v, want [agy-0 agy-1 agy-2]", got)
+	}
+}
+
 func TestFindAntigravitySessionFileHonorsSearchPaths(t *testing.T) {
 	// Point HOME at an empty dir so only the configured search path can match.
 	t.Setenv("HOME", t.TempDir())
@@ -380,4 +455,12 @@ func TestFindAntigravitySessionFileHonorsSearchPaths(t *testing.T) {
 	if got != transcriptPath {
 		t.Fatalf("FindAntigravitySessionFile() = %q, want %q", got, transcriptPath)
 	}
+}
+
+func antigravityEntryIDs(entries []*Entry) []string {
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		ids = append(ids, entry.UUID)
+	}
+	return ids
 }

--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -281,8 +281,8 @@ func ReadFileRawOlder(path string, tailCompactions int, beforeMessageID string) 
 }
 
 // ReadProviderFileOlder reads an older page of a provider-specific transcript.
-// Codex and Pi sessions do not currently support message-ID pagination, so the
-// full provider transcript is returned.
+// Provider families without page-aware readers return the full provider
+// transcript.
 func ReadProviderFileOlder(provider, path string, tailCompactions int, beforeMessageID string) (*Session, error) {
 	switch ProviderFamily(provider) {
 	case "codex":
@@ -296,15 +296,15 @@ func ReadProviderFileOlder(provider, path string, tailCompactions int, beforeMes
 	case "pi":
 		return ReadPiFile(path, tailCompactions)
 	case "antigravity":
-		return ReadAntigravityFile(path, tailCompactions)
+		return ReadAntigravityFilePage(path, tailCompactions, beforeMessageID, "")
 	default:
 		return ReadFileOlder(path, tailCompactions, beforeMessageID)
 	}
 }
 
 // ReadProviderFileRawOlder reads an older page of a provider-specific raw
-// transcript. Codex and Pi sessions do not currently support message-ID
-// pagination, so the full provider transcript is returned.
+// transcript. Provider families without page-aware readers return the full
+// provider transcript.
 func ReadProviderFileRawOlder(provider, path string, tailCompactions int, beforeMessageID string) (*Session, error) {
 	switch ProviderFamily(provider) {
 	case "codex":
@@ -318,7 +318,7 @@ func ReadProviderFileRawOlder(provider, path string, tailCompactions int, before
 	case "pi":
 		return ReadPiFile(path, tailCompactions)
 	case "antigravity":
-		return ReadAntigravityFileRaw(path, tailCompactions)
+		return ReadAntigravityFileRawPage(path, tailCompactions, beforeMessageID, "")
 	default:
 		return ReadFileRawOlder(path, tailCompactions, beforeMessageID)
 	}
@@ -381,8 +381,8 @@ func ReadFileRawNewer(path string, tailCompactions int, afterMessageID string) (
 }
 
 // ReadProviderFileNewer reads a newer page of a provider-specific transcript.
-// Codex and Pi sessions do not currently support message-ID pagination, so the
-// full provider transcript is returned.
+// Provider families without page-aware readers return the full provider
+// transcript.
 func ReadProviderFileNewer(provider, path string, tailCompactions int, afterMessageID string) (*Session, error) {
 	switch ProviderFamily(provider) {
 	case "codex":
@@ -396,15 +396,15 @@ func ReadProviderFileNewer(provider, path string, tailCompactions int, afterMess
 	case "pi":
 		return ReadPiFile(path, tailCompactions)
 	case "antigravity":
-		return ReadAntigravityFile(path, tailCompactions)
+		return ReadAntigravityFilePage(path, tailCompactions, "", afterMessageID)
 	default:
 		return ReadFileNewer(path, tailCompactions, afterMessageID)
 	}
 }
 
 // ReadProviderFileRawNewer reads a newer page of a provider-specific raw
-// transcript. Codex and Pi sessions do not currently support message-ID
-// pagination, so the full provider transcript is returned.
+// transcript. Provider families without page-aware readers return the full
+// provider transcript.
 func ReadProviderFileRawNewer(provider, path string, tailCompactions int, afterMessageID string) (*Session, error) {
 	switch ProviderFamily(provider) {
 	case "codex":
@@ -418,7 +418,7 @@ func ReadProviderFileRawNewer(provider, path string, tailCompactions int, afterM
 	case "pi":
 		return ReadPiFile(path, tailCompactions)
 	case "antigravity":
-		return ReadAntigravityFileRaw(path, tailCompactions)
+		return ReadAntigravityFileRawPage(path, tailCompactions, "", afterMessageID)
 	default:
 		return ReadFileRawNewer(path, tailCompactions, afterMessageID)
 	}

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -458,6 +458,9 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		ResumeStyle:      "flag",
 	},
 	"antigravity": {
+		// Antigravity does not currently expose a provider hook mechanism
+		// that Gas City can install; nudges still drain via the supervisor
+		// dispatcher / per-session poller.
 		DisplayName: "Antigravity",
 		Command:     "agy",
 		OptionDefaults: map[string]string{

--- a/internal/worker/sessionlog_adapter_test.go
+++ b/internal/worker/sessionlog_adapter_test.go
@@ -113,6 +113,46 @@ func TestSessionLogAdapterLoadHistoryAntigravityCompletedToolUseIDs(t *testing.T
 	}
 }
 
+func TestSessionLogAdapterReadTranscriptAntigravityHonorsCursors(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	writeLines(t, path,
+		`{"step_index":0,"type":"USER_INPUT","created_at":"2026-04-04T09:00:00Z","content":"first"}`,
+		`{"step_index":1,"type":"PLANNER_RESPONSE","created_at":"2026-04-04T09:00:01Z","content":"second"}`,
+		`{"step_index":2,"type":"USER_INPUT","created_at":"2026-04-04T09:00:02Z","content":"third"}`,
+		`{"step_index":3,"type":"PLANNER_RESPONSE","created_at":"2026-04-04T09:00:03Z","content":"fourth"}`,
+	)
+
+	older, err := SessionLogAdapter{}.ReadTranscript(TranscriptRequest{
+		Provider:       "antigravity/tmux-cli",
+		TranscriptPath: path,
+		BeforeEntryID:  "agy-2",
+	})
+	if err != nil {
+		t.Fatalf("ReadTranscript older: %v", err)
+	}
+	if got := transcriptEntryIDs(older); strings.Join(got, ",") != "agy-0,agy-1" {
+		t.Fatalf("older Antigravity transcript IDs = %v, want [agy-0 agy-1]", got)
+	}
+
+	rawNewer, err := SessionLogAdapter{}.ReadTranscript(TranscriptRequest{
+		Provider:       "antigravity/tmux-cli",
+		TranscriptPath: path,
+		AfterEntryID:   "agy-2",
+		Raw:            true,
+	})
+	if err != nil {
+		t.Fatalf("ReadTranscript raw newer: %v", err)
+	}
+	if got := transcriptEntryIDs(rawNewer); strings.Join(got, ",") != "agy-3" {
+		t.Fatalf("raw newer Antigravity transcript IDs = %v, want [agy-3]", got)
+	}
+	if len(rawNewer.RawMessages) != 1 {
+		t.Fatalf("raw newer RawMessages = %d, want 1", len(rawNewer.RawMessages))
+	}
+}
+
 func TestSessionLogAdapterDiscoverTranscriptExplicitIDFailsClosed(t *testing.T) {
 	t.Parallel()
 
@@ -134,6 +174,14 @@ func TestSessionLogAdapterDiscoverTranscriptExplicitIDFailsClosed(t *testing.T) 
 	if discovered != "" {
 		t.Fatalf("DiscoverTranscript() = %q, want empty string when explicit session ID is missing", discovered)
 	}
+}
+
+func transcriptEntryIDs(result *TranscriptResult) []string {
+	ids := make([]string, 0, len(result.Session.Messages))
+	for _, entry := range result.Session.Messages {
+		ids = append(ids, entry.UUID)
+	}
+	return ids
 }
 
 func TestSessionLogAdapterDiscoverTranscriptKimiKeyedMissFailsClosed(t *testing.T) {


### PR DESCRIPTION
Post-merge follow-up for #2682.

## Summary
- Adds page-aware Antigravity transcript readers for before/after cursor requests.
- Wires Antigravity raw and normalized provider dispatch through those readers.
- Treats duplicate or unknown explicit Antigravity tool result IDs as unmatched output instead of fabricating orphaned tool results.
- Documents the current Antigravity hook-support gap in the built-in provider spec.

## Verification
- go test ./internal/sessionlog
- go test ./internal/worker -run 'TestSessionLogAdapter(ReadTranscriptAntigravityHonorsCursors|LoadHistoryAntigravity)'\n- go test ./internal/worker/builtin\n- go test ./internal/sessionlog ./internal/worker/...\n- go vet ./...\n- make test-fast-parallel\n- pre-commit hook ran changed-package lint, generation checks, vet, and fast baseline\n\nNote: live `agy` CLI flag smoke coverage could not be run in this environment because `agy` is not installed.