### PR TITLE
Follow-up: share circuit-open session reason projection

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -1227,8 +1227,8 @@ func buildAttachmentCache(sessions []session.Info, observe ...func(session.Info)
 }
 
 const (
-	resetPendingReason = "reset-pending"
-	circuitOpenReason  = "circuit-open"
+	resetPendingReason = session.LifecycleReasonResetPending
+	circuitOpenReason  = session.LifecycleReasonCircuitOpen
 )
 
 // sessionReason computes the REASON column for a session in gc session list.
@@ -1254,14 +1254,11 @@ func sessionReason(s session.Info, beadIndex map[string]beads.Bead, cfg *config.
 	if lifecycle.BaseState == session.BaseStateArchived && !lifecycle.ContinuityEligible {
 		return "-"
 	}
-	if resetPendingReasonVisible(s, b, sp, now) {
-		return resetPendingReason
+	var isRunning func(string) bool
+	if sp != nil {
+		isRunning = sp.IsRunning
 	}
-	if circuitOpenReasonVisible(b) {
-		return circuitOpenReason
-	}
-
-	if reason := session.LifecycleDisplayReason(b.Status, b.Metadata, now); reason != "" {
+	if reason := session.LifecycleDisplayReasonWithLiveness(b.Status, b.Metadata, now, s.SessionName, isRunning); reason != "" {
 		return reason
 	}
 
@@ -1282,20 +1279,6 @@ func sessionReason(s session.Info, beadIndex map[string]beads.Bead, cfg *config.
 	}
 
 	return "-"
-}
-
-// resetPendingReasonVisible keeps the fallback renderer aligned with the API
-// lifecycle reason rules for live reset requests.
-func resetPendingReasonVisible(s session.Info, b beads.Bead, sp runtime.Provider, now time.Time) bool {
-	var isRunning func(string) bool
-	if sp != nil {
-		isRunning = sp.IsRunning
-	}
-	return session.LifecycleResetPendingReasonVisible(b.Status, b.Metadata, now, s.SessionName, isRunning)
-}
-
-func circuitOpenReasonVisible(b beads.Bead) bool {
-	return strings.TrimSpace(b.Metadata[sessionCircuitStateMetadata]) == circuitOpen.String()
 }
 
 func pinAwakeWakeReasonVisible(b beads.Bead, cfg *config.City, now time.Time) bool {

--- a/cmd/gc/session_circuit_breaker.go
+++ b/cmd/gc/session_circuit_breaker.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 // sessionCircuitBreakerConfig controls the breaker thresholds. Zero values
@@ -45,7 +46,7 @@ const (
 )
 
 const (
-	sessionCircuitStateMetadata             = "session_circuit_state"
+	sessionCircuitStateMetadata             = session.SessionCircuitStateMetadataKey
 	sessionCircuitRestartsMetadata          = "session_circuit_restarts"
 	sessionCircuitLastRestartMetadata       = "session_circuit_last_restart"
 	sessionCircuitLastProgressMetadata      = "session_circuit_last_progress"
@@ -110,9 +111,9 @@ const (
 func (k circuitBreakerStateKind) String() string {
 	switch k {
 	case circuitOpen:
-		return "CIRCUIT_OPEN"
+		return session.SessionCircuitStateOpen
 	default:
-		return "CIRCUIT_CLOSED"
+		return session.SessionCircuitStateClosed
 	}
 }
 

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1888,6 +1888,41 @@ func TestHandleSessionListShowsResetPendingForLiveRuntime(t *testing.T) {
 	}
 }
 
+func TestHandleSessionListShowsCircuitOpenReason(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "Circuit Open")
+	if err := fs.cityBeadStore.SetMetadataBatch(info.ID, map[string]string{
+		session.SessionCircuitStateMetadataKey: session.SessionCircuitStateOpen,
+		"sleep_reason":                         "user-hold",
+	}); err != nil {
+		t.Fatalf("set circuit metadata: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/sessions"), nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body struct {
+		Items []sessionResponse `json:"items"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Items) != 1 {
+		t.Fatalf("got %d items, want 1", len(body.Items))
+	}
+	if body.Items[0].Reason != session.LifecycleReasonCircuitOpen {
+		t.Fatalf("reason = %q, want circuit-open", body.Items[0].Reason)
+	}
+}
+
 func TestHandleSessionRename(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -214,7 +214,18 @@ func (v LifecycleView) HasWakeCause(cause WakeCause) bool {
 	return false
 }
 
-const lifecycleResetPendingReason = "reset-pending"
+const (
+	// LifecycleReasonResetPending is the shared display reason for a live reset request.
+	LifecycleReasonResetPending = "reset-pending"
+	// LifecycleReasonCircuitOpen is the shared display reason for an open session circuit breaker.
+	LifecycleReasonCircuitOpen = "circuit-open"
+	// SessionCircuitStateMetadataKey is the durable metadata key for session circuit breaker state.
+	SessionCircuitStateMetadataKey = "session_circuit_state"
+	// SessionCircuitStateOpen is the durable metadata value for an open session circuit breaker.
+	SessionCircuitStateOpen = "CIRCUIT_OPEN"
+	// SessionCircuitStateClosed is the durable metadata value for a closed session circuit breaker.
+	SessionCircuitStateClosed = "CIRCUIT_CLOSED"
+)
 
 // LifecycleDisplayReason returns the user-facing reason for a non-closed
 // session's current lifecycle posture.
@@ -242,7 +253,7 @@ func LifecycleDisplayReasonWithLiveness(status string, metadata map[string]strin
 		Now:      now,
 	})
 	if lifecycleResetPendingReasonVisible(view, metadata, sessionName, isRunning) {
-		return lifecycleResetPendingReason
+		return LifecycleReasonResetPending
 	}
 	return lifecycleDisplayReasonFromView(view, metadata)
 }
@@ -267,6 +278,9 @@ func lifecycleDisplayReasonFromView(view LifecycleView, metadata map[string]stri
 	}
 	if view.BaseState == BaseStateArchived && !view.ContinuityEligible {
 		return ""
+	}
+	if strings.TrimSpace(metadata[SessionCircuitStateMetadataKey]) == SessionCircuitStateOpen {
+		return LifecycleReasonCircuitOpen
 	}
 	if reason := strings.TrimSpace(metadata["sleep_reason"]); reason != "" {
 		staleTimedQuarantine := (reason == "quarantine" || reason == "context-churn" || reason == "rate_limit") &&

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -631,6 +631,14 @@ func TestLifecycleDisplayReasonUsesOnlyActiveLifecycleReasons(t *testing.T) {
 		want string
 	}{
 		{
+			name: "circuit open wins",
+			meta: map[string]string{
+				SessionCircuitStateMetadataKey: SessionCircuitStateOpen,
+				"sleep_reason":                 "user-hold",
+			},
+			want: LifecycleReasonCircuitOpen,
+		},
+		{
 			name: "sleep reason wins",
 			meta: map[string]string{
 				"sleep_reason":      "wait-hold",
@@ -746,6 +754,16 @@ func TestLifecycleDisplayReasonWithLivenessShowsResetPending(t *testing.T) {
 	})
 	if got != "reset-pending" {
 		t.Fatalf("LifecycleDisplayReasonWithLiveness = %q, want reset-pending", got)
+	}
+}
+
+func TestLifecycleDisplayReasonWithLivenessShowsCircuitOpenBeforeLifecycleReason(t *testing.T) {
+	got := LifecycleDisplayReasonWithLiveness("open", map[string]string{
+		SessionCircuitStateMetadataKey: SessionCircuitStateOpen,
+		"sleep_reason":                 "user-hold",
+	}, time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC), "", nil)
+	if got != LifecycleReasonCircuitOpen {
+		t.Fatalf("LifecycleDisplayReasonWithLiveness = %q, want circuit-open", got)
 	}
 }
 

--- a/release-gates/ga-wzx5d-reason-priority-coverage-gate.md
+++ b/release-gates/ga-wzx5d-reason-priority-coverage-gate.md
@@ -1,47 +1,50 @@
 # Release Gate: REASON priority coverage
 
-- Deploy bead: `ga-wzx5d`
-- Source bead: `ga-4arrr.1.3`
-- Branch: `builder/ga-4arrr-1-2`
-- Remote branch: `origin/builder/ga-4arrr-1-2`
-- Reviewed commit: `ed0660200 test(gc): cover session reason priority matrix`
-- Base checked: `origin/main`
-- Stack note: this branch builds on open PR #2538 (`builder/ga-k0n20-1-3`) for the reset-pending REASON display. PR #2538 is clean with CI green at gate time.
-- Manifest note: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses the deployer role criteria plus the source bead acceptance checklist.
+- Adopted PR: `gastownhall/gascity#2544`
+- Workflow root: `ga-mw3g4`
+- Source bead: `ga-chg2`
+- Branch worktree: `/data/projects/gascity/worktrees/ga-chg2`
+- Reviewed commit: this follow-up maintainer fix commit
+- Base checked: `refs/adopt-pr/ga-chg2/latest-base`
+- Review attempt: `2`
+- Final merge surface: follow-up branch from current `main`; original PR #2544 is already merged.
 
 ## Gate Criteria
 
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
-| 1 | Review PASS present | PASS | `bd show ga-wzx5d` notes include `Review verdict: PASS` from `gascity/reviewer` at `ed0660200`. |
-| 2 | Acceptance criteria met | PASS | The source bead requested coverage for reset-pending, circuit-open, `sleep_reason`, wake/config fallback, and reset-pending-over-circuit-open conflict. `cmd/gc/cmd_session_test.go` now has `TestSessionReason_PriorityMatrix` plus focused tests for reset-pending, circuit-open, and sleep-reason priority. |
-| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestSessionReason' -count=1` passed; `go vet ./...` passed; `make test-fast-parallel` completed with `All fast jobs passed`. |
-| 4 | No high-severity review findings open | PASS | Reviewer findings list is empty. The only note is a non-blocking observation about a defensive impossible-state test value. |
-| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before gate creation; deployer will recheck after committing this gate file before push. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` exited 0; `git merge-tree` reported `merged`; `git diff --check origin/main...HEAD` exited 0. |
+| 1 | Review findings addressed | PASS | Attempt 1 raised one major architectural consistency finding: CLI-only `circuit-open` REASON derivation could diverge from API/dashboard session projection. The fix moves the circuit metadata key, durable state values, and `circuit-open` display reason into `internal/session` and routes `gc session list` through `session.LifecycleDisplayReasonWithLiveness`. |
+| 2 | Acceptance criteria met | PASS | The priority stack is now reset-pending, circuit-open, lifecycle sleep/hold/quarantine reasons, then wake/config fallback. `cmd/gc/cmd_session_test.go` covers the CLI matrix, `internal/session/lifecycle_projection_test.go` covers the shared projection, and `internal/api/handler_sessions_test.go` covers the HTTP session list projection. |
+| 3 | Tests pass | PASS | Focused verification passed for the session projection fix on the follow-up branch based on current `main`. |
+| 4 | No high-severity review findings open | PASS | The major CLI/API projection drift finding is fixed. The stale release-gate evidence finding is fixed by this refreshed artifact. |
+| 5 | Final branch state is explicit | PASS | The original contributor commits are already merged by PR #2544; this follow-up branch carries only the maintainer fixup needed after adoption review. |
+| 6 | Diff hygiene checked | PASS | `git diff --check` is part of the pre-commit validation set for the final maintainer fixup. |
 
 ## Acceptance Evidence
 
 | Source criterion | Result | Evidence |
 |---|---|---|
-| Cover reset-pending priority. | PASS | `TestSessionReason_ResetPendingLiveRuntimeOverridesOtherReasons` and `TestSessionReason_PriorityMatrix/reset-pending beats circuit-open and sleep_reason` assert `restart_requested=true` on a live runtime displays `reset-pending` ahead of lower-priority reasons. |
-| Cover circuit-open priority. | PASS | `TestSessionReason_CircuitOpenMetadataVisible` and `TestSessionReason_PriorityMatrix/circuit-open beats sleep_reason` assert `session_circuit_state=CIRCUIT_OPEN` displays `circuit-open`. |
-| Cover `sleep_reason` fallback before wake/config reasons. | PASS | `TestSessionReason_SleepReasonOverridesWakeReason` and `TestSessionReason_PriorityMatrix/sleep_reason beats wake config` assert lifecycle display reasons win before wake reasons. |
-| Cover wake/config fallback and no-config fallback. | PASS | `TestSessionReason_PriorityMatrix/wake config remains fallback` and `TestSessionReason_PriorityMatrix/no config and no blocking reason falls back to dash` cover both tail cases. |
-| Avoid hardcoded production roles. | PASS | The production code adds reason helpers only. Tests use `config.Agent{Name: "worker"}` as local fixture data, not production role-conditioned logic. |
-| Affected package tests pass. | PASS | `go test ./cmd/gc -run 'TestSessionReason' -count=1` passed in `0.404s`. |
+| Cover reset-pending priority. | PASS | `TestSessionReason_ResetPendingLiveRuntimeOverridesOtherReasons`, `TestSessionReason_PriorityMatrix/reset-pending beats circuit open and sleep`, and `TestLifecycleDisplayReasonWithLivenessShowsResetPending` assert `restart_requested=true` on a live runtime displays `reset-pending` ahead of lower-priority reasons. |
+| Cover circuit-open priority. | PASS | `TestSessionReason_CircuitOpenMetadataVisible`, `TestSessionReason_PriorityMatrix/circuit-open beats sleep reason`, `TestLifecycleDisplayReasonUsesOnlyActiveLifecycleReasons/circuit open wins`, `TestLifecycleDisplayReasonWithLivenessShowsCircuitOpenBeforeLifecycleReason`, and `TestHandleSessionListShowsCircuitOpenReason` assert `session_circuit_state=CIRCUIT_OPEN` displays `circuit-open` through the shared session/API projection path. |
+| Cover `sleep_reason` fallback before wake/config reasons. | PASS | `TestSessionReason_SleepReasonOverridesWakeReason`, `TestSessionReason_PriorityMatrix/sleep reason beats wake config`, and `TestHandleSessionListIncludesReason` assert lifecycle display reasons win before wake reasons. |
+| Cover wake/config fallback and no-config fallback. | PASS | `TestSessionReason_PriorityMatrix/wake config falls through after blocking states` and `TestSessionReason_PriorityMatrix/no config fallback remains empty reason` cover both tail cases. |
+| Avoid hardcoded production roles. | PASS | Production code adds generic session projection constants and reason derivation only. Test fixture names such as `worker` are local data, not production role-conditioned logic. |
+| Preserve API metadata redaction. | PASS | The API still redacts `session_circuit_state`; only the typed `reason` field exposes `circuit-open`. |
 
 ## Validation
 
 | Command | Result |
 |---|---|
-| `go test ./cmd/gc -run 'TestSessionReason' -count=1` | PASS |
-| `go vet ./...` | PASS |
-| `make test-fast-parallel` | PASS (`fsys-darwin-compile`, `unit-core`, and `unit-cmd-gc` shards 1-6 passed; `All fast jobs passed`) |
-| `git diff --check origin/main...HEAD` | PASS |
+| `go test ./internal/session -run 'TestLifecycleDisplayReason' -count=1` | PASS |
+| `go test ./internal/api -run 'TestHandleSessionListShows(CircuitOpenReason\|ResetPendingForLiveRuntime\|IncludesReason)' -count=1` | PASS |
+| `go test ./cmd/gc -run TestSessionReason -count=1` | PASS |
+| `git diff --check refs/adopt-pr/ga-chg2/latest-base..HEAD` | PASS |
 
 ## Changed Files
 
 - `cmd/gc/cmd_session.go`
-- `cmd/gc/cmd_session_test.go`
-- `release-gates/ga-oeqam-reset-pending-session-reason-display-gate.md` (stack prerequisite from PR #2538)
+- `cmd/gc/session_circuit_breaker.go`
+- `internal/api/handler_sessions_test.go`
+- `internal/session/lifecycle_projection.go`
+- `internal/session/lifecycle_projection_test.go`
+- `release-gates/ga-wzx5d-reason-priority-coverage-gate.md`


### PR DESCRIPTION
This is the maintainer follow-up merge surface for adopted PR #2544 after the original contributor PR was already merged.\n\nOriginal PR: https://github.com/gastownhall/gascity/pull/2544\nOriginal title: Preserve session REASON priority ordering\nOriginal state during finalize: MERGED\nConfigured workflow base: main\nOriginal GitHub base: main\nBase mismatch: none\n\nWhy this follow-up exists:\n- Adoption review found that circuit-open REASON derivation was still CLI-local and could drift from the HTTP/dashboard session projection.\n- The original contributor commits are already preserved in merged PR #2544.\n- This branch carries only the maintainer fixup that moves circuit-open display reason handling into the shared session projection path and adds API/session coverage.\n\nLocal validation:\n- go test ./internal/session -run 'TestLifecycleDisplayReason' -count=1\n- go test ./internal/api -run 'TestHandleSessionListShows(CircuitOpenReason|ResetPendingForLiveRuntime|IncludesReason)' -count=1\n- go test ./cmd/gc -run TestSessionReason -count=1\n- git diff --check refs/adopt-pr/ga-chg2/latest-base..HEAD\n\nAdopted via /adopt-pr workflow. Original contributor commits preserved in #2544.