### PR TITLE
feat(formula): add catalog discovery command

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -23,6 +23,7 @@ func newFormulaCmd(stdout, stderr io.Writer) *cobra.Command {
 
 	cmd.AddCommand(newFormulaListCmd(stdout, stderr))
 	cmd.AddCommand(newFormulaShowCmd(stdout, stderr))
+	cmd.AddCommand(newFormulaCatalogCmd(stdout, stderr))
 	cmd.AddCommand(newFormulaCookCmd(stdout, stderr))
 	return cmd
 }
@@ -256,6 +257,42 @@ Examples:
 	return cmd
 }
 
+func newFormulaCatalogCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:    "catalog",
+		Short:  "List formulas opted into agent workflow discovery",
+		Hidden: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cityPath, err := resolveCity()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadCityConfig(cityPath, stderr)
+			if err != nil {
+				return err
+			}
+			scope, err := resolveFormulaScope(cfg, cityPath)
+			if err != nil {
+				return err
+			}
+			entries, err := formulaCatalogEntries(scope.searchPaths)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return writeCLIJSONLine(stdout, formulaCatalogJSONFromEntries(entries))
+			}
+			for _, entry := range entries {
+				_, _ = fmt.Fprintf(stdout, "%s\t%s\n", entry.Name, entry.Description)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "emit JSON")
+	return cmd
+}
+
 type formulaListJSON struct {
 	SchemaVersion string                 `json:"schema_version"`
 	OK            bool                   `json:"ok"`
@@ -273,6 +310,19 @@ type formulaListRowJSON struct {
 
 type formulaListSummaryJSON struct {
 	Count int `json:"count"`
+}
+
+type formulaCatalogJSON struct {
+	SchemaVersion string                    `json:"schema_version"`
+	OK            bool                      `json:"ok"`
+	Formulas      []formulaCatalogEntryJSON `json:"formulas"`
+	Summary       formulaListSummaryJSON    `json:"summary"`
+	Warnings      []jsonContractWarning     `json:"warnings,omitempty"`
+}
+
+type formulaCatalogEntryJSON struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
 }
 
 type formulaShowJSON struct {
@@ -339,6 +389,11 @@ func listFormulaRows(warningWriter ...io.Writer) (string, []string, []formulaLis
 	}
 	paths := formulaSearchPathsForList(cfg)
 
+	rows := formulaRowsForSearchPaths(paths)
+	return cityPath, paths, rows
+}
+
+func formulaRowsForSearchPaths(paths []string) []formulaListRowJSON {
 	// Scan search paths for canonical and legacy formula TOML files,
 	// deduplicating by name (last path wins, matching formula layer
 	// resolution order).
@@ -370,7 +425,58 @@ func listFormulaRows(warningWriter ...io.Writer) (string, []string, []formulaLis
 	for _, name := range names {
 		rows = append(rows, formulaListRowJSON{Name: name, Source: winners[name]})
 	}
-	return cityPath, paths, rows
+	return rows
+}
+
+func formulaCatalogEntries(searchPaths []string) ([]formulaCatalogEntryJSON, error) {
+	rows := formulaRowsForSearchPaths(searchPaths)
+	parser := formula.NewParser(searchPaths...).SetSource(formula.SourceFromEnv())
+
+	entries := make([]formulaCatalogEntryJSON, 0, len(rows))
+	seen := make(map[string]string)
+	for _, row := range rows {
+		parsed, err := parser.ParseFile(row.Source)
+		if err != nil {
+			return nil, fmt.Errorf("read formula catalog metadata for %q: %w", row.Name, err)
+		}
+		if parsed.Catalog == nil {
+			continue
+		}
+
+		name := strings.TrimSpace(parsed.Catalog.Name)
+		if name == "" {
+			return nil, fmt.Errorf("formula %q: catalog.name is required", row.Name)
+		}
+		if name != row.Name {
+			return nil, fmt.Errorf("formula %q: catalog.name %q must match formula name %q", row.Name, name, row.Name)
+		}
+		description := strings.TrimSpace(parsed.Catalog.Description)
+		if description == "" {
+			return nil, fmt.Errorf("formula %q: catalog.description is required", row.Name)
+		}
+		if previous, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate catalog formula name %q in %q and %q", name, previous, row.Name)
+		}
+		seen[name] = row.Name
+		entries = append(entries, formulaCatalogEntryJSON{
+			Name:        name,
+			Description: description,
+		})
+	}
+
+	slices.SortFunc(entries, func(a, b formulaCatalogEntryJSON) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return entries, nil
+}
+
+func formulaCatalogJSONFromEntries(entries []formulaCatalogEntryJSON) formulaCatalogJSON {
+	return formulaCatalogJSON{
+		SchemaVersion: "1",
+		OK:            true,
+		Formulas:      entries,
+		Summary:       formulaListSummaryJSON{Count: len(entries)},
+	}
 }
 
 func formulaSearchPathsForList(cfg *config.City) []string {

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -276,12 +275,12 @@ func newFormulaCatalogCmd(stdout, stderr io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			entries, err := formulaCatalogEntries(scope.searchPaths)
-			if err != nil {
-				return err
-			}
+			entries, warnings := formulaCatalogEntries(scope.searchPaths)
 			if jsonOutput {
-				return writeCLIJSONLine(stdout, formulaCatalogJSONFromEntries(entries))
+				return writeCLIJSONLine(stdout, formulaCatalogJSONFromEntries(entries, warnings))
+			}
+			for _, warning := range warnings {
+				_, _ = fmt.Fprintln(stderr, warning.Message)
 			}
 			for _, entry := range entries {
 				_, _ = fmt.Fprintf(stdout, "%s\t%s\n", entry.Name, entry.Description)
@@ -394,26 +393,11 @@ func listFormulaRows(warningWriter ...io.Writer) (string, []string, []formulaLis
 }
 
 func formulaRowsForSearchPaths(paths []string) []formulaListRowJSON {
-	// Scan search paths for canonical and legacy formula TOML files,
-	// deduplicating by name (last path wins, matching formula layer
-	// resolution order).
-	winners := make(map[string]string)
-	for _, dir := range paths {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			name, ok := formula.TrimTOMLFilename(e.Name())
-			if !ok {
-				continue
-			}
-			winners[name] = filepath.Join(dir, e.Name())
-		}
-	}
+	return formulaRowsForSearchPathsWithSource(formula.FSSource{}, paths)
+}
+
+func formulaRowsForSearchPathsWithSource(src formula.Source, paths []string) []formulaListRowJSON {
+	winners := formula.ResolveAllWithSource(src, paths)
 
 	names := make([]string, 0, len(winners))
 	for name := range winners {
@@ -428,16 +412,17 @@ func formulaRowsForSearchPaths(paths []string) []formulaListRowJSON {
 	return rows
 }
 
-func formulaCatalogEntries(searchPaths []string) ([]formulaCatalogEntryJSON, error) {
-	rows := formulaRowsForSearchPaths(searchPaths)
+func formulaCatalogEntries(searchPaths []string) ([]formulaCatalogEntryJSON, []jsonContractWarning) {
 	parser := formula.NewParser(searchPaths...).SetSource(formula.SourceFromEnv())
+	rows := formulaRowsForSearchPathsWithSource(parser.Source(), searchPaths)
 
 	entries := make([]formulaCatalogEntryJSON, 0, len(rows))
-	seen := make(map[string]string)
+	warnings := make([]jsonContractWarning, 0)
 	for _, row := range rows {
 		parsed, err := parser.ParseFile(row.Source)
 		if err != nil {
-			return nil, fmt.Errorf("read formula catalog metadata for %q: %w", row.Name, err)
+			warnings = append(warnings, formulaCatalogWarning("formula_catalog_parse_failed", row.Name, err))
+			continue
 		}
 		if parsed.Catalog == nil {
 			continue
@@ -445,19 +430,18 @@ func formulaCatalogEntries(searchPaths []string) ([]formulaCatalogEntryJSON, err
 
 		name := strings.TrimSpace(parsed.Catalog.Name)
 		if name == "" {
-			return nil, fmt.Errorf("formula %q: catalog.name is required", row.Name)
+			warnings = append(warnings, formulaCatalogWarning("formula_catalog_invalid_metadata", row.Name, fmt.Errorf("catalog.name is required")))
+			continue
 		}
 		if name != row.Name {
-			return nil, fmt.Errorf("formula %q: catalog.name %q must match formula name %q", row.Name, name, row.Name)
+			warnings = append(warnings, formulaCatalogWarning("formula_catalog_invalid_metadata", row.Name, fmt.Errorf("catalog.name %q must match formula name %q", name, row.Name)))
+			continue
 		}
 		description := strings.TrimSpace(parsed.Catalog.Description)
 		if description == "" {
-			return nil, fmt.Errorf("formula %q: catalog.description is required", row.Name)
+			warnings = append(warnings, formulaCatalogWarning("formula_catalog_invalid_metadata", row.Name, fmt.Errorf("catalog.description is required")))
+			continue
 		}
-		if previous, ok := seen[name]; ok {
-			return nil, fmt.Errorf("duplicate catalog formula name %q in %q and %q", name, previous, row.Name)
-		}
-		seen[name] = row.Name
 		entries = append(entries, formulaCatalogEntryJSON{
 			Name:        name,
 			Description: description,
@@ -467,15 +451,23 @@ func formulaCatalogEntries(searchPaths []string) ([]formulaCatalogEntryJSON, err
 	slices.SortFunc(entries, func(a, b formulaCatalogEntryJSON) int {
 		return strings.Compare(a.Name, b.Name)
 	})
-	return entries, nil
+	return entries, warnings
 }
 
-func formulaCatalogJSONFromEntries(entries []formulaCatalogEntryJSON) formulaCatalogJSON {
+func formulaCatalogWarning(code, name string, err error) jsonContractWarning {
+	return jsonContractWarning{
+		Code:    code,
+		Message: fmt.Sprintf("skipping formula %q: %v", name, err),
+	}
+}
+
+func formulaCatalogJSONFromEntries(entries []formulaCatalogEntryJSON, warnings []jsonContractWarning) formulaCatalogJSON {
 	return formulaCatalogJSON{
 		SchemaVersion: "1",
 		OK:            true,
 		Formulas:      entries,
 		Summary:       formulaListSummaryJSON{Count: len(entries)},
+		Warnings:      warnings,
 	}
 }
 

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -312,3 +312,148 @@ func TestFormulaShowJSONFromRecipe(t *testing.T) {
 		t.Fatalf("steps = %+v", got.Steps)
 	}
 }
+
+func TestFormulaCatalogEntriesUseResolvedWinnersAndSort(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+
+	writeFormulaTestFile(t, cityDir, "build-run", `formula = "build-run"
+description = "city build"
+
+[catalog]
+name = "build-run"
+description = "City build workflow"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+	writeFormulaTestFile(t, cityDir, "internal-helper", `formula = "internal-helper"
+description = "not user runnable"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+	writeFormulaTestFile(t, rigDir, "review", `formula = "review"
+description = "review"
+
+[catalog]
+name = "review"
+description = "Review a completed implementation."
+
+[[steps]]
+id = "review"
+title = "Review"
+`)
+	writeFormulaTestFile(t, rigDir, "build-run", `formula = "build-run"
+description = "rig build"
+
+[catalog]
+name = "build-run"
+description = "Rig-specific build workflow"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+
+	got, err := formulaCatalogEntries([]string{cityDir, rigDir})
+	if err != nil {
+		t.Fatalf("formulaCatalogEntries: %v", err)
+	}
+	want := []formulaCatalogEntryJSON{
+		{Name: "build-run", Description: "Rig-specific build workflow"},
+		{Name: "review", Description: "Review a completed implementation."},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("catalog entries = %+v, want %+v", got, want)
+	}
+}
+
+func TestFormulaCatalogEntriesRejectInvalidMetadata(t *testing.T) {
+	t.Run("name mismatch", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFormulaTestFile(t, dir, "build-run", `formula = "build-run"
+
+[catalog]
+name = "build"
+description = "Build workflow"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+
+		_, err := formulaCatalogEntries([]string{dir})
+		if err == nil {
+			t.Fatal("expected catalog name mismatch error")
+		}
+		if !strings.Contains(err.Error(), `catalog.name "build" must match formula name "build-run"`) {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("missing description", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFormulaTestFile(t, dir, "review", `formula = "review"
+
+[catalog]
+name = "review"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+
+		_, err := formulaCatalogEntries([]string{dir})
+		if err == nil {
+			t.Fatal("expected missing catalog description error")
+		}
+		if !strings.Contains(err.Error(), `catalog.description is required`) {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestFormulaCatalogCommandJSONFromEntries(t *testing.T) {
+	var stdout bytes.Buffer
+	payload := formulaCatalogJSONFromEntries([]formulaCatalogEntryJSON{
+		{Name: "build-run", Description: "Build workflow"},
+	})
+	if err := writeCLIJSONLine(&stdout, payload); err != nil {
+		t.Fatalf("writeCLIJSONLine: %v", err)
+	}
+
+	var got struct {
+		SchemaVersion string `json:"schema_version"`
+		OK            bool   `json:"ok"`
+		Formulas      []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Source      string `json:"source"`
+		} `json:"formulas"`
+		Summary struct {
+			Count int `json:"count"`
+		} `json:"summary"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("formula catalog JSON is invalid: %v\n%s", err, stdout.String())
+	}
+	if got.SchemaVersion != "1" || !got.OK || got.Summary.Count != 1 {
+		t.Fatalf("payload = %+v", got)
+	}
+	if len(got.Formulas) != 1 || got.Formulas[0].Name != "build-run" || got.Formulas[0].Description != "Build workflow" {
+		t.Fatalf("formulas = %+v", got.Formulas)
+	}
+	if got.Formulas[0].Source != "" {
+		t.Fatalf("catalog JSON leaked source path: %+v", got.Formulas[0])
+	}
+}
+
+func writeFormulaTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write formula %s: %v", name, err)
+	}
+}

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -358,9 +359,9 @@ id = "run"
 title = "Run"
 `)
 
-	got, err := formulaCatalogEntries([]string{cityDir, rigDir})
-	if err != nil {
-		t.Fatalf("formulaCatalogEntries: %v", err)
+	got, warnings := formulaCatalogEntries([]string{cityDir, rigDir})
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %+v, want none", warnings)
 	}
 	want := []formulaCatalogEntryJSON{
 		{Name: "build-run", Description: "Rig-specific build workflow"},
@@ -371,7 +372,98 @@ title = "Run"
 	}
 }
 
-func TestFormulaCatalogEntriesRejectInvalidMetadata(t *testing.T) {
+func TestFormulaCatalogEntriesUseFormulaRefForDiscovery(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	root := t.TempDir()
+	runGitForFormulaTest(t, root, "init", "-b", "main")
+	runGitForFormulaTest(t, root, "config", "user.email", "test@example.com")
+	runGitForFormulaTest(t, root, "config", "user.name", "test")
+	runGitForFormulaTest(t, root, "config", "commit.gpgsign", "false")
+
+	formulaDir := filepath.Join(root, "formulas")
+	writeFormulaTestFile(t, formulaDir, "from-ref", `formula = "from-ref"
+
+[catalog]
+name = "from-ref"
+description = "Committed workflow"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+	runGitForFormulaTest(t, root, "add", "formulas/from-ref.formula.toml")
+	runGitForFormulaTest(t, root, "commit", "-m", "add committed catalog formula")
+	runGitForFormulaTest(t, root, "checkout", "-b", "feature")
+	if err := os.Remove(filepath.Join(formulaDir, "from-ref.formula.toml")); err != nil {
+		t.Fatalf("remove committed formula from working tree: %v", err)
+	}
+	writeFormulaTestFile(t, formulaDir, "working-only", `formula = "working-only"
+
+[catalog]
+name = "working-only"
+description = "Uncommitted workflow"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+	t.Setenv("GC_FORMULA_REF", "main")
+
+	got, warnings := formulaCatalogEntries([]string{formulaDir})
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %+v, want none", warnings)
+	}
+	want := []formulaCatalogEntryJSON{{Name: "from-ref", Description: "Committed workflow"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("catalog entries = %+v, want %+v", got, want)
+	}
+}
+
+func TestFormulaCatalogEntriesWarnForPerFileFailures(t *testing.T) {
+	dir := t.TempDir()
+	writeFormulaTestFile(t, dir, "build-run", `formula = "build-run"
+
+[catalog]
+name = "build-run"
+description = "Build workflow"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+	writeFormulaTestFile(t, dir, "broken-helper", `formula = "broken-helper"
+[catalog
+`)
+	writeFormulaTestFile(t, dir, "bad-catalog", `formula = "bad-catalog"
+
+[catalog]
+name = "other-name"
+description = "Bad metadata"
+
+[[steps]]
+id = "run"
+title = "Run"
+`)
+
+	got, warnings := formulaCatalogEntries([]string{dir})
+	want := []formulaCatalogEntryJSON{{Name: "build-run", Description: "Build workflow"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("catalog entries = %+v, want %+v", got, want)
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("warnings len = %d, want 2: %+v", len(warnings), warnings)
+	}
+	if warnings[0].Code == "" || warnings[0].Message == "" {
+		t.Fatalf("warning[0] = %+v, want structured code and message", warnings[0])
+	}
+	if warnings[1].Code == "" || warnings[1].Message == "" {
+		t.Fatalf("warning[1] = %+v, want structured code and message", warnings[1])
+	}
+}
+
+func TestFormulaCatalogEntriesWarnForInvalidMetadata(t *testing.T) {
 	t.Run("name mismatch", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFormulaTestFile(t, dir, "build-run", `formula = "build-run"
@@ -385,12 +477,15 @@ id = "run"
 title = "Run"
 `)
 
-		_, err := formulaCatalogEntries([]string{dir})
-		if err == nil {
-			t.Fatal("expected catalog name mismatch error")
+		got, warnings := formulaCatalogEntries([]string{dir})
+		if len(got) != 0 {
+			t.Fatalf("catalog entries = %+v, want none", got)
 		}
-		if !strings.Contains(err.Error(), `catalog.name "build" must match formula name "build-run"`) {
-			t.Fatalf("error = %v", err)
+		if len(warnings) != 1 {
+			t.Fatalf("warnings len = %d, want 1: %+v", len(warnings), warnings)
+		}
+		if !strings.Contains(warnings[0].Message, `catalog.name "build" must match formula name "build-run"`) {
+			t.Fatalf("warning = %+v", warnings[0])
 		}
 	})
 
@@ -406,12 +501,15 @@ id = "run"
 title = "Run"
 `)
 
-		_, err := formulaCatalogEntries([]string{dir})
-		if err == nil {
-			t.Fatal("expected missing catalog description error")
+		got, warnings := formulaCatalogEntries([]string{dir})
+		if len(got) != 0 {
+			t.Fatalf("catalog entries = %+v, want none", got)
 		}
-		if !strings.Contains(err.Error(), `catalog.description is required`) {
-			t.Fatalf("error = %v", err)
+		if len(warnings) != 1 {
+			t.Fatalf("warnings len = %d, want 1: %+v", len(warnings), warnings)
+		}
+		if !strings.Contains(warnings[0].Message, `catalog.description is required`) {
+			t.Fatalf("warning = %+v", warnings[0])
 		}
 	})
 }
@@ -420,7 +518,7 @@ func TestFormulaCatalogCommandJSONFromEntries(t *testing.T) {
 	var stdout bytes.Buffer
 	payload := formulaCatalogJSONFromEntries([]formulaCatalogEntryJSON{
 		{Name: "build-run", Description: "Build workflow"},
-	})
+	}, []jsonContractWarning{{Code: "formula_catalog_parse_failed", Message: "skipped broken-helper"}})
 	if err := writeCLIJSONLine(&stdout, payload); err != nil {
 		t.Fatalf("writeCLIJSONLine: %v", err)
 	}
@@ -436,6 +534,7 @@ func TestFormulaCatalogCommandJSONFromEntries(t *testing.T) {
 		Summary struct {
 			Count int `json:"count"`
 		} `json:"summary"`
+		Warnings []jsonContractWarning `json:"warnings"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("formula catalog JSON is invalid: %v\n%s", err, stdout.String())
@@ -449,11 +548,26 @@ func TestFormulaCatalogCommandJSONFromEntries(t *testing.T) {
 	if got.Formulas[0].Source != "" {
 		t.Fatalf("catalog JSON leaked source path: %+v", got.Formulas[0])
 	}
+	if len(got.Warnings) != 1 || got.Warnings[0].Code != "formula_catalog_parse_failed" {
+		t.Fatalf("warnings = %+v", got.Warnings)
+	}
 }
 
 func writeFormulaTestFile(t *testing.T, dir, name, content string) {
 	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir formula dir: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0o644); err != nil {
 		t.Fatalf("write formula %s: %v", name, err)
+	}
+}
+
+func runGitForFormulaTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
 }

--- a/cmd/gc/json_runtime_schema_test.go
+++ b/cmd/gc/json_runtime_schema_test.go
@@ -131,6 +131,7 @@ func TestJSONResultStructsExposeExplicitOKField(t *testing.T) {
 		{name: "handoff", value: handoffJSONResult{}},
 		{name: "build-image", value: buildImageJSONResult{}},
 		{name: "mcp list", value: projectedMCPJSON{}},
+		{name: "formula catalog", value: formulaCatalogJSON{}},
 		{name: "formula list", value: formulaListJSON{}},
 		{name: "formula show", value: formulaShowJSON{}},
 		{name: "event emit", value: eventEmitJSONResult{}},
@@ -157,6 +158,7 @@ func TestFixedResultSchemasPinSchemaVersion(t *testing.T) {
 	for _, command := range [][]string{
 		{"handoff"},
 		{"build-image"},
+		{"formula", "catalog"},
 		{"formula", "list"},
 		{"formula", "show"},
 		{"event", "emit"},

--- a/cmd/gc/json_runtime_schema_test.go
+++ b/cmd/gc/json_runtime_schema_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -186,6 +187,38 @@ func TestFixedResultSchemasPinSchemaVersion(t *testing.T) {
 	}
 }
 
+func TestFormulaWarningSchemasRequireCodeAndMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		command []string
+		payload string
+	}{
+		{
+			name:    "catalog",
+			command: []string{"formula", "catalog"},
+			payload: `{"schema_version":"1","ok":true,"formulas":[],"summary":{"count":0},"warnings":[{"message":"missing code"}]}`,
+		},
+		{
+			name:    "list",
+			command: []string{"formula", "list"},
+			payload: `{"schema_version":"1","ok":true,"search_paths":[],"formulas":[],"summary":{"count":0},"warnings":[{"message":"missing code"}]}`,
+		},
+		{
+			name:    "show",
+			command: []string{"formula", "show"},
+			payload: `{"schema_version":"1","ok":true,"name":"build","search_paths":[],"steps":[],"warnings":[{"message":"missing code"}]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateJSONAgainstResultSchemaE(tc.command, []byte(tc.payload)); err == nil {
+				t.Fatalf("schema for %v accepted a warning without code", tc.command)
+			}
+		})
+	}
+}
+
 func assertTopLevelOKTrue(t *testing.T, data []byte) {
 	t.Helper()
 	var payload map[string]any
@@ -199,28 +232,35 @@ func assertTopLevelOKTrue(t *testing.T, data []byte) {
 
 func validateJSONAgainstResultSchema(t *testing.T, command []string, data []byte) {
 	t.Helper()
+	if err := validateJSONAgainstResultSchemaE(command, data); err != nil {
+		t.Fatalf("payload for %v does not validate: %v\n%s", command, err, string(data))
+	}
+}
+
+func validateJSONAgainstResultSchemaE(command []string, data []byte) error {
 	rawSchema, err := readBuiltinSchema(command, jsonSchemaResultRole)
 	if err != nil {
-		t.Fatalf("read schema for %v: %v", command, err)
+		return fmt.Errorf("read schema for %v: %w", command, err)
 	}
 	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(rawSchema))
 	if err != nil {
-		t.Fatalf("parse schema for %v: %v", command, err)
+		return fmt.Errorf("parse schema for %v: %w", command, err)
 	}
 	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
 	if err != nil {
-		t.Fatalf("parse payload for %v: %v\n%s", command, err, string(data))
+		return fmt.Errorf("parse payload for %v: %w", command, err)
 	}
 	compiler := jsonschema.NewCompiler()
 	schemaURL := strings.Join(command, "/") + "/result.schema.json"
 	if err := compiler.AddResource(schemaURL, schemaDoc); err != nil {
-		t.Fatalf("add schema resource for %v: %v", command, err)
+		return fmt.Errorf("add schema resource for %v: %w", command, err)
 	}
 	compiled, err := compiler.Compile(schemaURL)
 	if err != nil {
-		t.Fatalf("compile schema for %v: %v", command, err)
+		return fmt.Errorf("compile schema for %v: %w", command, err)
 	}
 	if err := compiled.Validate(instance); err != nil {
-		t.Fatalf("payload for %v does not validate: %v\n%s", command, err, string(data))
+		return err
 	}
+	return nil
 }

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -223,6 +223,7 @@ func (p *Parser) Resolve(formula *Formula) (*Formula, error) {
 	merged := &Formula{
 		Formula:     formula.Formula,
 		Description: formula.Description,
+		Catalog:     formula.Catalog,
 		Version:     formula.Version,
 		Contract:    formula.Contract,
 		Type:        formula.Type,

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -904,6 +904,93 @@ func TestResolve_InheritsGraphContractFromParent(t *testing.T) {
 	}
 }
 
+func TestResolve_PreservesChildCatalogWithoutInheritingParentCatalog(t *testing.T) {
+	dir := t.TempDir()
+	formulaDir := filepath.Join(dir, ".beads", "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	parent := `{
+  "formula": "catalog-parent",
+  "version": 1,
+  "type": "workflow",
+  "catalog": {
+    "name": "catalog-parent",
+    "description": "Parent workflow"
+  },
+  "steps": [
+    {"id": "parent", "title": "Parent"}
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(formulaDir, "catalog-parent.formula.json"), []byte(parent), 0o644); err != nil {
+		t.Fatalf("write parent: %v", err)
+	}
+
+	childWithCatalog := `{
+  "formula": "catalog-child",
+  "version": 1,
+  "type": "workflow",
+  "extends": ["catalog-parent"],
+  "catalog": {
+    "name": "catalog-child",
+    "description": "Child workflow"
+  },
+  "steps": [
+    {"id": "child", "title": "Child"}
+  ]
+}`
+	childWithCatalogPath := filepath.Join(formulaDir, "catalog-child.formula.json")
+	if err := os.WriteFile(childWithCatalogPath, []byte(childWithCatalog), 0o644); err != nil {
+		t.Fatalf("write child with catalog: %v", err)
+	}
+
+	childWithoutCatalog := `{
+  "formula": "internal-child",
+  "version": 1,
+  "type": "workflow",
+  "extends": ["catalog-parent"],
+  "steps": [
+    {"id": "child", "title": "Child"}
+  ]
+}`
+	childWithoutCatalogPath := filepath.Join(formulaDir, "internal-child.formula.json")
+	if err := os.WriteFile(childWithoutCatalogPath, []byte(childWithoutCatalog), 0o644); err != nil {
+		t.Fatalf("write child without catalog: %v", err)
+	}
+
+	p := NewParser(formulaDir)
+	parsedWithCatalog, err := p.ParseFile(childWithCatalogPath)
+	if err != nil {
+		t.Fatalf("ParseFile child with catalog: %v", err)
+	}
+	resolvedWithCatalog, err := p.Resolve(parsedWithCatalog)
+	if err != nil {
+		t.Fatalf("Resolve child with catalog: %v", err)
+	}
+	if resolvedWithCatalog.Catalog == nil {
+		t.Fatalf("resolved child catalog is nil")
+	}
+	if got := resolvedWithCatalog.Catalog.Name; got != "catalog-child" {
+		t.Fatalf("resolved child catalog name = %q, want catalog-child", got)
+	}
+	if got := resolvedWithCatalog.Catalog.Description; got != "Child workflow" {
+		t.Fatalf("resolved child catalog description = %q, want Child workflow", got)
+	}
+
+	parsedWithoutCatalog, err := p.ParseFile(childWithoutCatalogPath)
+	if err != nil {
+		t.Fatalf("ParseFile child without catalog: %v", err)
+	}
+	resolvedWithoutCatalog, err := p.Resolve(parsedWithoutCatalog)
+	if err != nil {
+		t.Fatalf("Resolve child without catalog: %v", err)
+	}
+	if resolvedWithoutCatalog.Catalog != nil {
+		t.Fatalf("resolved child without catalog inherited %+v, want nil", resolvedWithoutCatalog.Catalog)
+	}
+}
+
 func TestResolve_ExpansionExtendsPreservesTemplateAndInheritedContract(t *testing.T) {
 	dir := t.TempDir()
 	formulaDir := filepath.Join(dir, ".beads", "formulas")

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -68,6 +68,9 @@ type Formula struct {
 	// Description explains what this formula does.
 	Description string `json:"description,omitempty"`
 
+	// Catalog opts the formula into user-facing workflow discovery.
+	Catalog *CatalogMetadata `json:"catalog,omitempty" toml:"catalog,omitempty"`
+
 	// Version is the formula revision.
 	// It is intentionally not a graph.v2 opt-in: legacy molecule formulas use
 	// this field for their own revisions and must keep hierarchy-first
@@ -123,6 +126,15 @@ type Formula struct {
 
 	// Source tracks where this formula was loaded from (set by parser).
 	Source string `json:"source,omitempty"`
+}
+
+// CatalogMetadata describes a formula exposed through gc formula catalog.
+type CatalogMetadata struct {
+	// Name is the runnable formula name shown in the catalog.
+	Name string `json:"name,omitempty" toml:"name,omitempty"`
+
+	// Description explains when to run the formula.
+	Description string `json:"description,omitempty" toml:"description,omitempty"`
 }
 
 // VarDef defines a template variable with optional validation.

--- a/schemas/formula/catalog/result.schema.json
+++ b/schemas/formula/catalog/result.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "ok",
+    "formulas",
+    "summary"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1"
+    },
+    "ok": {
+      "const": true
+    },
+    "formulas": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "description"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "count"
+      ],
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/formula/catalog/result.schema.json
+++ b/schemas/formula/catalog/result.schema.json
@@ -50,7 +50,21 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
       }
     }
   },

--- a/schemas/formula/list/result.schema.json
+++ b/schemas/formula/list/result.schema.json
@@ -58,7 +58,21 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
       }
     }
   },

--- a/schemas/formula/show/result.schema.json
+++ b/schemas/formula/show/result.schema.json
@@ -161,7 +161,21 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
       }
     }
   },


### PR DESCRIPTION
## Summary
- add hidden `gc formula catalog` for workflow-discovery metadata
- add `[catalog]` formula metadata parsing and validation
- add JSON result schema and unit coverage for catalog filtering/sorting/errors

## Tests
- go test ./internal/formula
- go test ./cmd/gc -run 'TestFormulaCatalog|TestFixedResultSchemasPinSchemaVersion|TestJSONResultStructsExposeExplicitOKField'\n- make test-fast-parallel\n- go vet ./...\n- .githooks/pre-commit\n\n## Note\n- `go run ./cmd/gc --city /data/projects/maintainer-city formula catalog --json` was blocked by that city cache needing `gc import install`; unit and schema coverage passed against this branch.