### PR TITLE
feat(doctor): register named session conflict check

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -199,6 +199,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))
 		register(doctor.NewDurationRangeCheck(cfg))
 		register(doctor.NewProviderParityCheck(cfg))
+		register(doctor.NewNamedAlwaysMinConflictCheck(cfg))
 		register(doctor.NewInstructionsFileCheck(cfg, cityPath))
 		register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath))

--- a/cmd/gc/cmd_doctor_extract_test.go
+++ b/cmd/gc/cmd_doctor_extract_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
 )
 
 func TestBuildDoctorChecks_NameSetUnchanged(t *testing.T) {
@@ -22,10 +23,7 @@ func TestBuildDoctorChecks_NameSetUnchanged(t *testing.T) {
 		SkipCityDoltCheck:    true,
 		SkipManagedDoltCheck: true,
 	})
-	var names []string
-	for _, check := range checks {
-		names = append(names, check.Name())
-	}
+	names := doctorCheckNames(checks)
 
 	data, err := os.ReadFile(filepath.Join("testdata", "doctor_check_names.golden"))
 	if err != nil {
@@ -36,4 +34,74 @@ func TestBuildDoctorChecks_NameSetUnchanged(t *testing.T) {
 	if got != want {
 		t.Fatalf("doctor check names changed\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
+}
+
+func TestBuildDoctorChecksRegistersNamedAlwaysMinConflictCheck(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_DOLT", "skip")
+	cfg := &config.City{Workspace: config.Workspace{Name: "demo"}}
+
+	names := doctorCheckNames(buildDoctorChecks(cityDir, cfg, nil, buildDoctorChecksOpts{
+		ControllerRunning:    false,
+		SkipCityDoltCheck:    true,
+		SkipManagedDoltCheck: true,
+	}))
+
+	providerParity := doctorCheckIndex(names, "provider-parity")
+	if providerParity < 0 {
+		t.Fatalf("provider-parity check missing: %v", names)
+	}
+	got := doctorCheckIndex(names, "named-always-min-conflict")
+	if got != providerParity+1 {
+		t.Fatalf("named-always-min-conflict index = %d, want immediately after provider-parity at %d; names=%v", got, providerParity, names)
+	}
+}
+
+func TestBuildDoctorChecksSkipsNamedAlwaysMinConflictCheckWithoutConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_DOLT", "skip")
+
+	tests := []struct {
+		name   string
+		cfg    *config.City
+		cfgErr error
+	}{
+		{name: "nil config", cfg: nil, cfgErr: nil},
+		{name: "config load error", cfg: &config.City{Workspace: config.Workspace{Name: "demo"}}, cfgErr: os.ErrInvalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			names := doctorCheckNames(buildDoctorChecks(cityDir, tt.cfg, tt.cfgErr, buildDoctorChecksOpts{
+				ControllerRunning:    false,
+				SkipCityDoltCheck:    true,
+				SkipManagedDoltCheck: true,
+			}))
+			if got := doctorCheckIndex(names, "named-always-min-conflict"); got >= 0 {
+				t.Fatalf("named-always-min-conflict registered at %d, want absent; names=%v", got, names)
+			}
+		})
+	}
+}
+
+func doctorCheckNames(checks []doctor.Check) []string {
+	names := make([]string, 0, len(checks))
+	for _, check := range checks {
+		names = append(names, check.Name())
+	}
+	return names
+}
+
+func doctorCheckIndex(names []string, want string) int {
+	for i, name := range names {
+		if name == want {
+			return i
+		}
+	}
+	return -1
 }

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -23,6 +23,7 @@ builtin-pack-family
 config-semantics
 duration-range
 provider-parity
+named-always-min-conflict
 instructions-file
 skill-collision
 order-firing-current

--- a/internal/doctor/checks_named_session.go
+++ b/internal/doctor/checks_named_session.go
@@ -1,0 +1,85 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// NamedAlwaysMinConflictCheck warns when an agent both backs a mode="always"
+// named session and sets min_active_sessions > 0.
+type NamedAlwaysMinConflictCheck struct {
+	cfg *config.City
+}
+
+// NewNamedAlwaysMinConflictCheck creates a check for duplicate pool session
+// footguns caused by named sessions and pool minimums.
+func NewNamedAlwaysMinConflictCheck(cfg *config.City) *NamedAlwaysMinConflictCheck {
+	return &NamedAlwaysMinConflictCheck{cfg: cfg}
+}
+
+// Name returns the check identifier.
+func (c *NamedAlwaysMinConflictCheck) Name() string {
+	return "named-always-min-conflict"
+}
+
+// Run warns when any non-suspended agent backs a mode="always" named session
+// and has min_active_sessions > 0.
+func (c *NamedAlwaysMinConflictCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.cfg == nil {
+		r.Status = StatusOK
+		r.Message = "no config; nothing to check"
+		return r
+	}
+
+	alwaysSessions := map[string]string{}
+	for _, ns := range c.cfg.NamedSessions {
+		if ns.ModeOrDefault() == "always" {
+			alwaysSessions[ns.TemplateQualifiedName()] = ns.QualifiedName()
+		}
+	}
+	if len(alwaysSessions) == 0 {
+		r.Status = StatusOK
+		r.Message = "no mode=always named sessions"
+		return r
+	}
+
+	var details []string
+	for i := range c.cfg.Agents {
+		a := &c.cfg.Agents[i]
+		if a.Suspended {
+			continue
+		}
+		minimum := a.EffectiveMinActiveSessions()
+		if minimum <= 0 {
+			continue
+		}
+		nsName, ok := alwaysSessions[a.QualifiedName()]
+		if !ok {
+			continue
+		}
+		details = append(details, fmt.Sprintf(
+			"agent %q: min_active_sessions=%d with named_session %q mode=always; set min_active_sessions=0 to avoid a duplicate pool session",
+			a.QualifiedName(), minimum, nsName,
+		))
+	}
+
+	if len(details) == 0 {
+		r.Status = StatusOK
+		r.Message = "no named-always / min_active_sessions conflicts"
+		return r
+	}
+	r.Status = StatusWarning
+	r.Severity = SeverityAdvisory
+	r.Message = fmt.Sprintf("%d agent(s) combine mode=always with min_active_sessions>0", len(details))
+	r.Details = details
+	return r
+}
+
+// CanFix returns false because config authors must decide whether the
+// duplicate pool session is intentional.
+func (c *NamedAlwaysMinConflictCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *NamedAlwaysMinConflictCheck) Fix(_ *CheckContext) error { return nil }

--- a/internal/doctor/checks_named_session_test.go
+++ b/internal/doctor/checks_named_session_test.go
@@ -1,0 +1,141 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestNamedAlwaysMinConflictCheckOKCases(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.City
+	}{
+		{
+			name: "no named sessions",
+			cfg: &config.City{
+				Agents: []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(1)}},
+			},
+		},
+		{
+			name: "on demand named session with pool minimum",
+			cfg: &config.City{
+				NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "on_demand"}},
+				Agents:        []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(1)}},
+			},
+		},
+		{
+			name: "always named session without pool minimum",
+			cfg: &config.City{
+				NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "always"}},
+				Agents:        []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(0)}},
+			},
+		},
+		{
+			name: "suspended agent is ignored",
+			cfg: &config.City{
+				NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "always"}},
+				Agents: []config.Agent{{
+					Name:              "agent-a",
+					MinActiveSessions: intPtr(1),
+					Suspended:         true,
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewNamedAlwaysMinConflictCheck(tt.cfg).Run(&CheckContext{})
+			if r.Status != StatusOK {
+				t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+			}
+			if r.Severity != SeverityBlocking {
+				t.Fatalf("Severity = %v, want default SeverityBlocking for OK result", r.Severity)
+			}
+		})
+	}
+}
+
+func TestNamedAlwaysMinConflictCheckWarnsWithAdvisorySeverity(t *testing.T) {
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "always"}},
+		Agents:        []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(1)}},
+	}
+
+	r := NewNamedAlwaysMinConflictCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want SeverityAdvisory", r.Severity)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("Details = %d, want 1: %v", len(r.Details), r.Details)
+	}
+	detail := r.Details[0]
+	for _, want := range []string{
+		`agent "agent-a"`,
+		"min_active_sessions=1",
+		`named_session "primary"`,
+		"set min_active_sessions=0 to avoid a duplicate pool session",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("Details[0] = %q, want to contain %q", detail, want)
+		}
+	}
+}
+
+func TestNamedAlwaysMinConflictCheckWarnsForMinTwo(t *testing.T) {
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{{Name: "primary", Template: "agent-a", Mode: "always"}},
+		Agents:        []config.Agent{{Name: "agent-a", MinActiveSessions: intPtr(2)}},
+	}
+
+	r := NewNamedAlwaysMinConflictCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 || !strings.Contains(r.Details[0], "min_active_sessions=2") {
+		t.Fatalf("Details = %v, want min_active_sessions=2 warning", r.Details)
+	}
+}
+
+func TestNamedAlwaysMinConflictCheckReportsTwoAgents(t *testing.T) {
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{
+			{Name: "primary-a", Template: "agent-a", Mode: "always"},
+			{Name: "primary-b", Template: "agent-b", Mode: "always"},
+		},
+		Agents: []config.Agent{
+			{Name: "agent-a", MinActiveSessions: intPtr(1)},
+			{Name: "agent-b", MinActiveSessions: intPtr(2)},
+		},
+	}
+
+	r := NewNamedAlwaysMinConflictCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if r.Severity != SeverityAdvisory {
+		t.Fatalf("Severity = %v, want SeverityAdvisory", r.Severity)
+	}
+	if len(r.Details) != 2 {
+		t.Fatalf("Details = %d, want 2: %v", len(r.Details), r.Details)
+	}
+	for _, want := range []string{`agent "agent-a"`, `named_session "primary-a"`} {
+		if !strings.Contains(r.Details[0], want) {
+			t.Fatalf("Details[0] = %q, want to contain %q", r.Details[0], want)
+		}
+	}
+	for _, want := range []string{`agent "agent-b"`, `named_session "primary-b"`} {
+		if !strings.Contains(r.Details[1], want) {
+			t.Fatalf("Details[1] = %q, want to contain %q", r.Details[1], want)
+		}
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -110,6 +110,10 @@ func (c *NestedWorktreePruneCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *NamedAlwaysMinConflictCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *OrderFiringCurrentCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the

--- a/release-gates/ga-oi3b1h-register-named-session-doctor-check-gate.md
+++ b/release-gates/ga-oi3b1h-register-named-session-doctor-check-gate.md
@@ -1,0 +1,53 @@
+# Release gate: ga-oi3b1h
+
+**Bead:** ga-oi3b1h - needs-deploy: register named session doctor check  
+**Source review bead:** ga-lxpw04  
+**Branch:** `builder/ga-ihrikr.2-register-named-session-doctor`  
+**Code HEAD before gate:** `2f4aa7371f019d5003d3086023f62098ed8cb549`  
+**Base:** `origin/main` at `fa150384f`  
+**Stack note:** depends on open base PR #2762 (`builder/ga-ihrikr.1-named-session-doctor`)  
+**Verdict:** **PASS**
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-lxpw04` is closed with reviewer PASS from `gascity/reviewer`; deploy bead records reviewed + PASSED evidence. |
+| 2 | Acceptance criteria met | PASS | `buildDoctorChecks` now registers `NamedAlwaysMinConflictCheck`, the check remains absent when city config is unavailable, and the doctor check-name golden file is updated. |
+| 3 | Tests pass | PASS | See "Test runs" below. |
+| 4 | No high-severity review findings open | PASS | Review notes report no findings; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` is clean before writing this gate file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exits 0 and writes tree `de41f0f589e997d4e2dda476d823ca680e52015a`. |
+| 7 | Single feature theme | PASS | The PR diff is limited to named-session doctor conflict detection and its registration tests/golden file. |
+
+## Test Runs
+
+```
+$ go test ./internal/doctor -run TestNamedAlwaysMinConflictCheck -count=1
+ok  	github.com/gastownhall/gascity/internal/doctor	0.005s
+
+$ go test ./cmd/gc -run 'TestBuildDoctorChecks_(NameSetUnchanged|RegistersNamedAlwaysMinConflictCheck|SkipsNamedAlwaysMinConflictCheckWithoutConfig)' -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	1.061s
+
+$ go vet ./...
+(clean)
+
+$ make test-fast-parallel
+All fast jobs passed
+```
+
+## Diff Scope
+
+GitHub PR diff (`origin/main...HEAD`) is six files:
+
+```
+cmd/gc/cmd_doctor.go
+cmd/gc/cmd_doctor_extract_test.go
+cmd/gc/testdata/doctor_check_names.golden
+internal/doctor/checks_named_session.go
+internal/doctor/checks_named_session_test.go
+internal/doctor/warmup_eligible.go
+```
+
+The first three files are the registration slice for this deploy bead. The
+last three are the open base PR #2762, which must merge first.

--- a/release-gates/ga-oi3b1h-register-named-session-doctor-check-gate.md
+++ b/release-gates/ga-oi3b1h-register-named-session-doctor-check-gate.md
@@ -1,11 +1,11 @@
 # Release gate: ga-oi3b1h
 
-**Bead:** ga-oi3b1h - needs-deploy: register named session doctor check  
-**Source review bead:** ga-lxpw04  
-**Branch:** `builder/ga-ihrikr.2-register-named-session-doctor`  
-**Code HEAD before gate:** `2f4aa7371f019d5003d3086023f62098ed8cb549`  
-**Base:** `origin/main` at `fa150384f`  
-**Stack note:** depends on open base PR #2762 (`builder/ga-ihrikr.1-named-session-doctor`)  
+**Bead:** ga-oi3b1h - needs-deploy: register named session doctor check
+**Source review bead:** ga-lxpw04
+**Branch:** `builder/ga-ihrikr.2-register-named-session-doctor`
+**Code HEAD before gate:** `2f4aa7371f019d5003d3086023f62098ed8cb549`
+**Base:** `origin/main` at `fa150384f`
+**Stack note:** depends on open base PR #2762 (`builder/ga-ihrikr.1-named-session-doctor`)
 **Verdict:** **PASS**
 
 ## Criteria


### PR DESCRIPTION
## What this changes

`gc doctor` now runs the named-session pool conflict check as part of its normal check set. Operators get an advisory when one configured agent is kept awake as a named session and also contributes to pool minimums, which makes overlapping session demand visible during doctor runs.

The check logic stays in `internal/doctor`; this PR only wires it into `buildDoctorChecks` when city config is available and updates the check-name golden coverage.

## Review notes

- Stacked on PR #2762, which adds the check implementation. Merge #2762 first; after that, this PR narrows to registration and golden-file coverage.
- Advisory only: no automatic config rewrite, no warmup behavior change, and no new fix path.
- No API, schema, dashboard, or migration changes.

## Test plan

- [x] `go test ./internal/doctor -run TestNamedAlwaysMinConflictCheck -count=1`
- [x] `go test ./cmd/gc -run 'TestBuildDoctorChecks_(NameSetUnchanged|RegistersNamedAlwaysMinConflictCheck|SkipsNamedAlwaysMinConflictCheckWithoutConfig)' -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-oi3b1h-register-named-session-doctor-check-gate.md`](release-gates/ga-oi3b1h-register-named-session-doctor-check-gate.md)