### PR TITLE
fix(config): pool work-query prefers gc.run_target with gc.routed_to fallback

### DIFF
--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -491,6 +491,54 @@ esac
 	}
 }
 
+// TestCmdHookClaimsRunTargetOnlyRoot is the #2763 end-to-end regression: a
+// graph.v2 workflow root routed to a pool stamps only gc.run_target (no
+// gc.routed_to), yet `gc hook <pool>` must surface it. Before the reader fix
+// the worker's claim query matched only gc.routed_to, so the routed root was
+// never claimed and the spawned worker idle-reaped with the work orphaned.
+func TestCmdHookClaimsRunTargetOnlyRoot(t *testing.T) {
+	disableManagedDoltRecoveryForTest(t)
+	clearInheritedCityRoutingEnv(t)
+	cityDir := t.TempDir()
+	fakeBin := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Fake bd returns the routed root only for the gc.run_target predicate;
+	// gc.routed_to (and every other query) yields an empty queue.
+	script := `#!/bin/sh
+case "$*" in
+  *"--metadata-field gc.run_target=worker"*) printf '[{"id":"graph-root","title":"run_target work"}]' ;;
+  *) printf '[]' ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(fakeBin, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_SESSION_ORIGIN", "ephemeral")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHook([]string{"worker"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHook(worker) = %d, want 0; stdout=%q stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"graph-root"`) {
+		t.Fatalf("gc hook did not surface the run_target-only graph root: stdout=%q", stdout.String())
+	}
+}
+
 func TestHookInjectAlwaysExitsZero(t *testing.T) {
 	// Even on command failure, inject mode exits 0.
 	runner := func(string, string) (string, error) { return "", fmt.Errorf("command failed") }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2633,18 +2633,77 @@ func (a *Agent) AttachEnabled() bool {
 	return a.Attach == nil || *a.Attach
 }
 
+// poolDemandKeys lists the routing metadata keys the pool-demand predicate
+// consults, in precedence order. gc.run_target — the canonical per-step
+// target stamped by the graph.v2 stamper (and, since #2386, the legacy
+// stamper) — is preferred; gc.routed_to is the compatibility fallback for
+// beads authored before the gc.run_target migration. The worker claim path
+// (EffectiveWorkQuery Tier 3) and the reconciler demand path
+// (EffectivePoolDemandQuery) walk these in the same order so that a graph.v2
+// workflow root stamping only gc.run_target is both spawned-for and
+// claimable (#2763 — completes the reader migration #2386 began;
+// bdReadyPoolDemandShell was the one reader site it missed).
+var poolDemandKeys = []string{"gc.run_target", "gc.routed_to"}
+
 // bdReadyPoolDemandShell returns the bd ready predicate for unassigned,
-// non-epic pool demand routed to target. This is the one-source-of-truth for the
-// "is there work on this routed queue?" question that both the worker (via
-// EffectiveWorkQuery Tier 3) and the reconciler (via EffectivePoolDemandQuery,
-// count-form) ask. Diverging the two re-introduces the protocol-mismatch class;
-// see the "scale_check ↔ work_query correspondence" note in
-// engdocs/architecture/dispatch.md.
+// non-epic pool demand matched on metadata field key=target. This is the
+// one-source-of-truth for the "is there work on this routed queue?" question
+// that both the worker (via EffectiveWorkQuery Tier 3) and the reconciler (via
+// EffectivePoolDemandQuery, count-form) ask. Diverging the two re-introduces
+// the protocol-mismatch class; see the "scale_check ↔ work_query
+// correspondence" note in engdocs/architecture/dispatch.md.
+//
+// bd ready cannot express a single "match key A or key B" predicate
+// (--metadata-field is AND-combined and there is no key-absent filter), so the
+// run_target/routed_to precedence is composed at the shell layer by
+// poolDemandFirstRowProbes (work_query) and poolDemandCountShell (count-form),
+// which call this helper once per key in poolDemandKeys order.
 //
 // Callers append their own bd flags (--limit=1 for first-row work_query;
-// piped to jq 'length' for the count-form) and shell handling.
-func bdReadyPoolDemandShell(target string) string {
-	return `bd ready --metadata-field gc.routed_to=` + target + ` --unassigned --exclude-type=epic --json`
+// --limit 0 piped to jq 'length' for the count-form) and shell handling.
+func bdReadyPoolDemandShell(key, target string) string {
+	return `bd ready --metadata-field ` + key + `=` + target + ` --unassigned --exclude-type=epic --json`
+}
+
+// poolDemandFirstRowProbes emits the work_query Tier 3 body for target: it
+// tries each routing key in poolDemandKeys precedence order at --limit=1,
+// printing the first non-empty JSON array and exiting 0. Used for both the
+// primary and legacy workflow-control targets. The caller appends a terminal
+// fallthrough (e.g. printf "[]") for the all-empty case.
+func poolDemandFirstRowProbes(target string) string {
+	var b strings.Builder
+	for _, key := range poolDemandKeys {
+		b.WriteString(`r=$(` + bdReadyPoolDemandShell(key, target) + ` --limit=1 2>/dev/null); `)
+		b.WriteString(`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; `)
+	}
+	return b.String()
+}
+
+// poolDemandCountShell emits the reconciler count-form for target: it counts
+// ready demand under the first routing key in poolDemandKeys that yields a
+// non-empty result (gc.run_target preferred, gc.routed_to fallback) and prints
+// the array length. Precedence mirrors poolDemandFirstRowProbes so the
+// reconciler's spawn decision and the worker's claim decision agree — the
+// worker drains the preferred tier first, then the count surfaces the fallback
+// tier on the next pass.
+//
+// Unlike the work_query probes, this form must NOT redirect bd stderr or
+// default to zero: a failed `bd ready` has to surface as an error rather than
+// masquerade as "no demand", which would silently stop the pool from spawning.
+// Every query is chained with && so any non-zero bd exit short-circuits the
+// whole expression (TestEffectiveScaleCheckUsesReadyOnly).
+func poolDemandCountShell(target string) string {
+	keys := poolDemandKeys
+	last := len(keys) - 1
+	// Least-preferred key assigns unconditionally; its bd failure propagates
+	// through the outer &&.
+	expr := `ready_json=$(` + bdReadyPoolDemandShell(keys[last], target) + ` --limit 0)`
+	for i := last - 1; i >= 0; i-- {
+		query := bdReadyPoolDemandShell(keys[i], target) + ` --limit 0`
+		expr = `cur=$(` + query + `) && ` +
+			`if [ "$cur" != "[]" ]; then ready_json="$cur"; else ` + expr + `; fi`
+	}
+	return expr + ` && printf '%s\n' "$ready_json" | jq 'length'`
 }
 
 func (a *Agent) poolDemandTarget() string {
@@ -2704,13 +2763,13 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`done; ` +
 			// Tier 3: ready unassigned routed to this config (shared routed queue).
+			// Prefers gc.run_target, falls back to gc.routed_to (poolDemandKeys).
 			// Only ephemeral sessions and controller probes consume generic config demand.
 			`case "$GC_SESSION_ORIGIN" in ` +
 			`ephemeral|"") ;; ` +
 			`*) exit 0 ;; ` +
 			`esac; ` +
-			`r=$(` + bdReadyPoolDemandShell(target) + ` --limit=1 2>/dev/null); ` +
-			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+			poolDemandFirstRowProbes(target) +
 			`printf "[]"'`
 	}
 	return `sh -c '` +
@@ -2737,15 +2796,16 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`done; ` +
 		`done; ` +
 		// Tier 3: ready unassigned routed to this config (shared routed queue),
-		// then the legacy workflow-control route for pre-rename graphs.
+		// then the legacy workflow-control route for pre-rename graphs. Each
+		// target prefers gc.run_target, falling back to gc.routed_to (poolDemandKeys).
 		// Only ephemeral sessions and controller probes consume generic config demand.
 		`case "$GC_SESSION_ORIGIN" in ` +
 		`ephemeral|"") ;; ` +
 		`*) exit 0 ;; ` +
 		`esac; ` +
-		`r=$(` + bdReadyPoolDemandShell(target) + ` --limit=1 2>/dev/null); ` +
-		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
-		bdReadyPoolDemandShell(legacyTarget) + ` --limit=1 2>/dev/null'`
+		poolDemandFirstRowProbes(target) +
+		poolDemandFirstRowProbes(legacyTarget) +
+		`printf "[]"'`
 }
 
 func legacyWorkflowControlQualifiedName(target string) string {
@@ -2827,8 +2887,7 @@ func (a *Agent) EffectivePoolDemandQuery() string {
 		return a.ScaleCheck
 	}
 	target := a.poolDemandTarget()
-	return `ready_json=$(` + bdReadyPoolDemandShell(target) +
-		` --limit 0) && printf '%s\n' "$ready_json" | jq 'length'`
+	return poolDemandCountShell(target)
 }
 
 // EffectiveScaleCheck returns the scale check command for this agent.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1479,9 +1479,13 @@ func TestPoolRoundTrip(t *testing.T) {
 func TestEffectiveWorkQueryDefault(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveWorkQuery()
-	// Tiered query: check that tier 3 (routed_to) and tier 1-2 (assignee resolution) are present.
+	// Tiered query: check that tier 3 (run_target preferred, routed_to fallback)
+	// and tier 1-2 (assignee resolution) are present.
+	if !strings.Contains(got, "bd ready --metadata-field gc.run_target=mayor --unassigned --exclude-type=epic --json --limit=1") {
+		t.Errorf("EffectiveWorkQuery() missing tier 3 run_target: %q", got)
+	}
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=mayor --unassigned --exclude-type=epic --json --limit=1") {
-		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
+		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to fallback: %q", got)
 	}
 	if !strings.Contains(got, `"$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"`) {
 		t.Errorf("EffectiveWorkQuery() missing multi-identifier resolution: %q", got)
@@ -1671,6 +1675,7 @@ func TestEffectiveWorkQueryExcludesEpics(t *testing.T) {
 	wantSnippets := []string{
 		`bd list --status in_progress --assignee="$id" --exclude-type=epic --json`,
 		`bd ready --assignee="$id" --exclude-type=epic --json`,
+		`bd ready --metadata-field gc.run_target=hello-world/worker --unassigned --exclude-type=epic --json`,
 		`bd ready --metadata-field gc.routed_to=hello-world/worker --unassigned --exclude-type=epic --json`,
 	}
 	for _, want := range wantSnippets {
@@ -1689,7 +1694,9 @@ func TestEffectiveWorkQueryExcludesEpicsControlDispatcher(t *testing.T) {
 	wantSnippets := []string{
 		`bd list --status in_progress --assignee="$cand" --exclude-type=epic --json`,
 		`bd ready --assignee="$cand" --exclude-type=epic --json`,
+		`bd ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json`,
 		`bd ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json`,
+		`bd ready --metadata-field gc.run_target=gascity/workflow-control --unassigned --exclude-type=epic --json`,
 		`bd ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --exclude-type=epic --json`,
 	}
 	for _, want := range wantSnippets {
@@ -1746,6 +1753,108 @@ esac
 	}
 }
 
+// TestEffectiveWorkQueryPrefersRunTarget is the #2763 regression: the worker
+// claim path (EffectiveWorkQuery Tier 3) must return a graph.v2 workflow root
+// that stamps only gc.run_target (gc.routed_to unset). Before the fix the
+// reconciler spawned the worker on gc.run_target demand but the worker's claim
+// query read only gc.routed_to and saw an empty queue, so the root was never
+// claimed and the worker idle-reaped — silently orphaning the work. The fake
+// bd returns work solely for the gc.run_target predicate.
+func TestEffectiveWorkQueryPrefersRunTarget(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--metadata-field gc.run_target=hello-world/worker"*)
+    printf '[{"id":"graph-root","issue_type":"workflow"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if !strings.Contains(out, "graph-root") {
+		t.Fatalf("EffectiveWorkQuery() did not claim the run_target-only graph root: %q", out)
+	}
+}
+
+// TestEffectiveWorkQueryFallsBackToRoutedTo verifies the gc.routed_to
+// compatibility fallback still claims legacy roots stamped only with
+// gc.routed_to (gc.run_target unset) — e.g. the legacy --formula wisp path
+// that the #2763 reader change must not regress.
+func TestEffectiveWorkQueryFallsBackToRoutedTo(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--metadata-field gc.run_target=hello-world/worker"*) printf '[]' ;;
+  *"--metadata-field gc.routed_to=hello-world/worker"*)
+    printf '[{"id":"legacy-root","issue_type":"wisp"}]'
+    ;;
+  *) printf '[]' ;;
+esac
+`)
+	if !strings.Contains(out, "legacy-root") {
+		t.Fatalf("EffectiveWorkQuery() did not claim the routed_to-only legacy root: %q", out)
+	}
+}
+
+// TestEffectiveWorkQueryRunTargetWinsOverRoutedTo locks the precedence: when a
+// bead matches both keys, the preferred gc.run_target result is claimed and the
+// gc.routed_to result is not surfaced.
+func TestEffectiveWorkQueryRunTargetWinsOverRoutedTo(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--metadata-field gc.run_target=hello-world/worker"*)
+    printf '[{"id":"run-target-root","issue_type":"workflow"}]'
+    ;;
+  *"--metadata-field gc.routed_to=hello-world/worker"*)
+    printf '[{"id":"routed-to-root","issue_type":"wisp"}]'
+    ;;
+  *) printf '[]' ;;
+esac
+`)
+	if !strings.Contains(out, "run-target-root") {
+		t.Fatalf("EffectiveWorkQuery() did not prefer the gc.run_target root: %q", out)
+	}
+	if strings.Contains(out, "routed-to-root") {
+		t.Fatalf("EffectiveWorkQuery() surfaced the gc.routed_to root despite a run_target match: %q", out)
+	}
+}
+
+// TestEffectivePoolDemandQueryPrefersRunTarget verifies the spawn-side half of
+// the #2763 symmetry: the reconciler count-form counts gc.run_target demand for
+// a graph.v2 root that stamps only gc.run_target, so it keeps the worker it
+// spawned alive rather than treating the queue as empty.
+func TestEffectivePoolDemandQueryPrefersRunTarget(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available; count-form exercises a jq pipeline")
+	}
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	out := runShellWithFakeBd(t, a.EffectivePoolDemandQuery(), nil, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--metadata-field gc.run_target=hello-world/worker"*)
+    printf '[{"id":"a"},{"id":"b"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if strings.TrimSpace(out) != "2" {
+		t.Fatalf("EffectivePoolDemandQuery() count = %q, want 2 (run_target demand)", strings.TrimSpace(out))
+	}
+}
+
 func TestDefaultPoolCheckUsesPoolName(t *testing.T) {
 	a := Agent{
 		Name:              "dog-1",
@@ -1787,7 +1896,8 @@ func TestDefaultPoolCheckUsesBdReady(t *testing.T) {
 // "is there work on this routed queue?" predicate from the same
 // bdReadyPoolDemandShell helper. Adding a tier to one without updating
 // the other re-introduces the spawn-storm bug — this test ensures both
-// reference the identical predicate string for the same target.
+// reference the identical per-key predicate string for every routing key
+// in poolDemandKeys (gc.run_target preferred, gc.routed_to fallback; #2763).
 func TestPoolDemandPredicateSharedWithWorkQuery(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1811,16 +1921,16 @@ func TestPoolDemandPredicateSharedWithWorkQuery(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			predicate := bdReadyPoolDemandShell(tt.target)
-
 			wq := tt.agent.EffectiveWorkQuery()
-			if !strings.Contains(wq, predicate) {
-				t.Errorf("EffectiveWorkQuery() missing shared predicate %q in %q", predicate, wq)
-			}
-
 			demand := tt.agent.EffectivePoolDemandQuery()
-			if !strings.Contains(demand, predicate) {
-				t.Errorf("EffectivePoolDemandQuery() missing shared predicate %q in %q", predicate, demand)
+			for _, key := range poolDemandKeys {
+				predicate := bdReadyPoolDemandShell(key, tt.target)
+				if !strings.Contains(wq, predicate) {
+					t.Errorf("EffectiveWorkQuery() missing shared predicate %q in %q", predicate, wq)
+				}
+				if !strings.Contains(demand, predicate) {
+					t.Errorf("EffectivePoolDemandQuery() missing shared predicate %q in %q", predicate, demand)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #2763. Completes the `gc.run_target` reader migration started by #2386: the pool worker's work-query (`bdReadyPoolDemandShell`) now prefers `gc.run_target` with a `gc.routed_to` fallback. Previously it read only `gc.routed_to`, so under `formula_v2` a graph.v2 workflow root (which stamps `gc.run_target` only) was **spawned-for** by scale_check but **never claimed** by the worker — the worker found an empty queue, sat idle, and was idle-reaped, silently orphaning the work.

## Root cause

`bdReadyPoolDemandShell` (`internal/config/config.go`) matched only `gc.routed_to`. #2386 migrated the scale_check / named-session / pool-desired-state readers to prefer `gc.run_target`, but missed this one — the worker claim path. Graph.v2 workflow roots stamp `gc.run_target` only (the legacy `--formula` path stamps `gc.routed_to`, which is why that path was unaffected). Net: scale_check spawned a worker on `run_target` demand, but the worker's claim query read `routed_to` and saw nothing.

## Fix

`bdReadyPoolDemandShell` now matches `gc.run_target` with `gc.routed_to` fallback, so both the spawn decision and the claim decision read the same field. Both reader call sites (worker claim Tier 3, scale_check) derive from this helper, so they stay consistent.

## Test

- `cmd/gc/cmd_hook_test.go`: a graph.v2 root with only `gc.run_target` set is returned by `gc hook` for that pool.
- `internal/config/config_test.go`: covers the run_target-preferred / routed_to-fallback predicate.

## Changed files

- `internal/config/config.go` (+93)
- `internal/config/config_test.go` (+132)
- `cmd/gc/cmd_hook_test.go` (+48)
