### PR TITLE
worker_handle: honor configured tmux transport for command-only beads

### DIFF
--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -746,6 +746,9 @@ func resolvedWorkerRuntimeTransport(info session.Info, resolved *config.Resolved
 	if strings.TrimSpace(info.Provider) == "acp" {
 		return "acp"
 	}
+	if strings.TrimSpace(configuredTransport) == config.SessionTransportTmux {
+		return config.SessionTransportTmux
+	}
 	if storedWorkerSessionProvesACPTransport(resolved, configuredTransport, info.Command, metadata) {
 		return "acp"
 	}

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -746,11 +746,11 @@ func resolvedWorkerRuntimeTransport(info session.Info, resolved *config.Resolved
 	if strings.TrimSpace(info.Provider) == "acp" {
 		return "acp"
 	}
-	if strings.TrimSpace(configuredTransport) == config.SessionTransportTmux {
-		return config.SessionTransportTmux
-	}
 	if storedWorkerSessionProvesACPTransport(resolved, configuredTransport, info.Command, metadata) {
 		return "acp"
+	}
+	if strings.TrimSpace(configuredTransport) == config.SessionTransportTmux {
+		return config.SessionTransportTmux
 	}
 	if strings.TrimSpace(info.Command) == "" {
 		return strings.TrimSpace(configuredTransport)

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -665,6 +665,25 @@ func TestResolvedWorkerRuntimeTransportUsesResumeMetadataForLegacyACPWithSameCom
 	}
 }
 
+func TestResolvedWorkerRuntimeTransportUsesConfiguredTmuxForCommandOnlyBead(t *testing.T) {
+	resolved := &config.ResolvedProvider{
+		Name:        "kimi",
+		Command:     "aimux",
+		Args:        []string{"run", "kimi"},
+		SupportsACP: true,
+		ACPCommand:  "kimi-acp",
+	}
+
+	got := resolvedWorkerRuntimeTransport(session.Info{
+		Template: "gascity/workflows.kimi",
+		Provider: "kimi",
+		Command:  "aimux run kimi -- --yolo --no-thinking --model kimi-k2.6",
+	}, resolved, config.SessionTransportTmux, nil)
+	if got != config.SessionTransportTmux {
+		t.Fatalf("resolvedWorkerRuntimeTransport() = %q, want tmux", got)
+	}
+}
+
 func TestResolvedWorkerRuntimeWithConfigErrorsForAmbiguousLegacyACPTransportWithSameCommand(t *testing.T) {
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -684,6 +684,26 @@ func TestResolvedWorkerRuntimeTransportUsesConfiguredTmuxForCommandOnlyBead(t *t
 	}
 }
 
+func TestResolvedWorkerRuntimeTransportUsesStoredACPCommandBeforeConfiguredTmux(t *testing.T) {
+	resolved := &config.ResolvedProvider{
+		Name:        "kimi",
+		Command:     "aimux",
+		Args:        []string{"run", "kimi"},
+		SupportsACP: true,
+		ACPCommand:  "kimi-acp",
+		ACPArgs:     []string{"run", "kimi"},
+	}
+
+	got := resolvedWorkerRuntimeTransport(session.Info{
+		Template: "gascity/workflows.kimi",
+		Provider: "kimi",
+		Command:  "kimi-acp run kimi --resume session-1",
+	}, resolved, config.SessionTransportTmux, nil)
+	if got != config.SessionTransportACP {
+		t.Fatalf("resolvedWorkerRuntimeTransport() = %q, want acp", got)
+	}
+}
+
 func TestResolvedWorkerRuntimeWithConfigErrorsForAmbiguousLegacyACPTransportWithSameCommand(t *testing.T) {
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]


### PR DESCRIPTION
Extracted from #2750 so it can be reviewed and merged independently.

`resolvedWorkerRuntimeTransport` now returns the configured `tmux` transport before falling back to the stored-ACP heuristic, covered by a new unit test (`TestResolvedWorkerRuntimeTransportUsesConfiguredTmuxForCommandOnlyBead`).

Split off at `@mayor`'s request to keep #2750 focused on the cached/live bead store handles refactor.