### PR TITLE
Add tmux server lifecycle provider

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -318,6 +318,22 @@ type ProcessTableScanner interface {
 	TerminateRuntime(r LiveRuntime) error
 }
 
+// ServerLifecycleProvider is an optional extension for providers that own
+// server-level lifecycle alongside individual session management.
+//
+// This interface must not be added to [Provider]: providers backed by
+// subprocesses, Kubernetes, fakes, or other non-server runtimes do not have a
+// shared server to configure or tear down.
+type ServerLifecycleProvider interface {
+	// ConfigureServer applies server-level configuration. Implementations must
+	// be idempotent, and callers should treat errors as best-effort warnings.
+	ConfigureServer() error
+
+	// TeardownServer terminates the shared server after all sessions have been
+	// drained. Implementations should return nil when the server is already gone.
+	TeardownServer() error
+}
+
 // CopyEntry describes a file or directory to stage in the session's
 // working directory before the agent command starts.
 type CopyEntry struct {

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -40,6 +40,7 @@ var (
 	_ runtime.InterruptBoundaryWaitProvider = (*Provider)(nil)
 	_ runtime.InterruptedTurnResetProvider  = (*Provider)(nil)
 	_ runtime.ProcessTableScanner           = (*Provider)(nil)
+	_ runtime.ServerLifecycleProvider       = (*Provider)(nil)
 )
 
 // NewProvider returns a [Provider] backed by a real tmux installation
@@ -709,6 +710,16 @@ func (p *Provider) Attach(name string) error {
 // that are not part of the [runtime.Provider] interface.
 func (p *Provider) Tmux() *Tmux {
 	return p.tm
+}
+
+// ConfigureServer applies tmux server-level configuration.
+func (p *Provider) ConfigureServer() error {
+	return p.tm.ConfigureServer()
+}
+
+// TeardownServer terminates the tmux server after all sessions are drained.
+func (p *Provider) TeardownServer() error {
+	return p.tm.TeardownServer()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/runtime/tmux/lifecycle_test.go
+++ b/internal/runtime/tmux/lifecycle_test.go
@@ -1,0 +1,91 @@
+package tmux
+
+import (
+	"testing"
+)
+
+// TestConfigureServerSendsSetOptionExitEmptyOff verifies that ConfigureServer
+// issues set-option -g exit-empty off through the executor.
+func TestConfigureServerSendsSetOptionExitEmptyOff(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
+
+	if err := tm.ConfigureServer(); err != nil {
+		t.Fatalf("ConfigureServer() error = %v", err)
+	}
+
+	for _, call := range fe.calls {
+		if containsSetOptionExitEmptyWithValue(call, "off") {
+			return
+		}
+	}
+	t.Fatalf("ConfigureServer did not issue set-option -g exit-empty off; calls = %v", fe.calls)
+}
+
+// TestConfigureServerIsIdempotentViaSyncOnce verifies that calling ConfigureServer
+// multiple times on the same *Tmux issues set-option -g exit-empty off exactly once.
+// The configureOnce sync.Once field must enforce this property.
+func TestConfigureServerIsIdempotentViaSyncOnce(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
+
+	for i := 0; i < 5; i++ {
+		if err := tm.ConfigureServer(); err != nil {
+			t.Fatalf("ConfigureServer() call %d error = %v", i, err)
+		}
+	}
+
+	count := 0
+	for _, call := range fe.calls {
+		if containsSetOptionExitEmptyWithValue(call, "off") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("set-option -g exit-empty off issued %d times across 5 ConfigureServer calls, want exactly 1", count)
+	}
+}
+
+// TestTeardownServerCallsKillServer verifies that TeardownServer delegates to
+// tmux kill-server via the executor.
+func TestTeardownServerCallsKillServer(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
+
+	if err := tm.TeardownServer(); err != nil {
+		t.Fatalf("TeardownServer() error = %v", err)
+	}
+
+	for _, call := range fe.calls {
+		for _, arg := range call {
+			if arg == "kill-server" {
+				return
+			}
+		}
+	}
+	t.Fatalf("TeardownServer did not call kill-server; calls = %v", fe.calls)
+}
+
+// TestTeardownServerTreatsAlreadyGoneServerAsSuccess verifies that TeardownServer
+// returns nil when the tmux server is already gone (ErrNoServer), consistent with
+// KillServer's existing semantics.
+func TestTeardownServerTreatsAlreadyGoneServerAsSuccess(t *testing.T) {
+	fe := &fakeExecutor{err: ErrNoServer}
+	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
+
+	if err := tm.TeardownServer(); err != nil {
+		t.Fatalf("TeardownServer() = %v, want nil for already-gone server", err)
+	}
+}
+
+// containsSetOptionExitEmptyWithValue returns true if args contains the
+// sequence "set-option -g exit-empty <value>", possibly preceded by socket flags.
+func containsSetOptionExitEmptyWithValue(args []string, value string) bool {
+	for i, arg := range args {
+		if arg == "set-option" && i+3 < len(args) &&
+			args[i+1] == "-g" && args[i+2] == "exit-empty" && args[i+3] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -212,6 +212,7 @@ type Tmux struct {
 	exec                 executor
 	interactionDedup     *approvalDedup
 	interactionDedupOnce sync.Once
+	configureOnce        sync.Once
 	hiddenAttachMu       sync.Mutex
 	hiddenAttachClients  map[string]*hiddenAttachClient
 }
@@ -348,6 +349,7 @@ func (t *Tmux) NewSession(name, workDir string) error {
 	if err != nil {
 		return err
 	}
+	_ = t.ConfigureServer()
 	// tmux 3.3+ sets window-size=manual on detached sessions, locking them
 	// at 80x24 even after a client attaches. Reset to "latest" so the window
 	// adapts to the largest attached client.
@@ -377,6 +379,7 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 	if err != nil {
 		return err
 	}
+	_ = t.ConfigureServer()
 	// tmux 3.3+: reset window-size from manual to latest (see NewSession).
 	t.run("set-option", "-wt", name, "window-size", "latest") //nolint:errcheck // best-effort
 	return nil
@@ -436,6 +439,7 @@ func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env ma
 	if err != nil {
 		return err
 	}
+	_ = t.ConfigureServer()
 	// tmux 3.3+: reset window-size from manual to latest (see NewSession).
 	t.run("set-option", "-wt", name, "window-size", "latest") //nolint:errcheck // best-effort
 	return nil
@@ -897,6 +901,21 @@ func (t *Tmux) KillServer() error {
 		return nil // Already dead
 	}
 	return err
+}
+
+// ConfigureServer sets tmux server options required for Gas City lifecycle
+// ownership. It is idempotent per Tmux instance.
+func (t *Tmux) ConfigureServer() error {
+	var err error
+	t.configureOnce.Do(func() {
+		err = t.SetExitEmpty(false)
+	})
+	return err
+}
+
+// TeardownServer terminates the tmux server after all sessions are drained.
+func (t *Tmux) TeardownServer() error {
+	return t.KillServer()
 }
 
 // SetExitEmpty controls the tmux exit-empty server option.

--- a/release-gates/ga-tnse9j-server-lifecycle-provider-gate.md
+++ b/release-gates/ga-tnse9j-server-lifecycle-provider-gate.md
@@ -1,0 +1,41 @@
+# Release Gate: ServerLifecycleProvider and tmux server configuration
+
+- Deploy bead: `ga-tnse9j`
+- Source bead: `ga-yxnz9x.2`
+- Review bead: `ga-7mz8rt`
+- Branch: `builder/ga-yxnz9x.2-server-lifecycle`
+- Remote branch: `origin/builder/ga-yxnz9x.2-server-lifecycle`
+- Reviewed commit: `3e4ac7dca feat(runtime): add tmux server lifecycle provider`
+- Note: `docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer role criteria and the source bead acceptance checklist.
+
+## Gate Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-7mz8rt` shows a closed review bead with `REVIEW VERDICT: PASS` for commit `3e4ac7dca`. |
+| 2 | Acceptance criteria met | PASS | Checked source bead criteria against code and tests; details below. |
+| 3 | Tests pass | PASS | `go test -count=1 ./internal/runtime/tmux ./internal/runtime` passed; `go vet ./...` exited 0; `make test-fast-parallel` completed with `All fast jobs passed`. |
+| 4 | No high-severity review findings open | PASS | Review notes list informational findings only; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Branch was clean before gate creation; deployer rechecked clean status after committing this gate before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `65ac617b144e34ac8c1981485b8eccf9898a5873`. |
+| 7 | Single feature theme | PASS | Commit set is one runtime/tmux lifecycle provider slice touching `internal/runtime` and `internal/runtime/tmux` only. |
+
+## Acceptance Evidence
+
+| Source criterion | Result | Evidence |
+|---|---|---|
+| Add `runtime.ServerLifecycleProvider` as an optional extension interface in `internal/runtime/runtime.go` with exported doc comments. | PASS | `internal/runtime/runtime.go` defines exported `ServerLifecycleProvider` with doc comments for the interface and both methods. |
+| Do not add `ConfigureServer` or `TeardownServer` to the base `runtime.Provider` interface. | PASS | The base `Provider` interface remains unchanged; server lifecycle is a separate optional interface. |
+| Implement `ConfigureServer` and `TeardownServer` on `*tmux.Tmux` using existing `SetExitEmpty(false)` and `KillServer` primitives. | PASS | `internal/runtime/tmux/tmux.go` implements `ConfigureServer` via `SetExitEmpty(false)` and `TeardownServer` via `KillServer()`. |
+| Add a `sync.Once`-backed `configureOnce` field on `*Tmux`; do not use a bool flag. | PASS | `internal/runtime/tmux/tmux.go` adds `configureOnce sync.Once`; no bool flag is introduced for server configuration state. |
+| `ConfigureServer` is triggered after successful new-session creation in each `NewSession*` variant and is best-effort. | PASS | `NewSession`, `NewSessionWithCommand`, and `NewSessionWithCommandAndEnv` call `_ = t.ConfigureServer()` after successful `t.run(...)`. |
+| Non-tmux providers continue to compile unchanged. | PASS | `go test -count=1 ./internal/runtime` and `go vet ./...` passed; only tmux provider asserts the optional interface. |
+| No role names are introduced in Go source. | PASS | `git diff origin/main...HEAD -- internal/runtime/runtime.go internal/runtime/tmux/adapter.go internal/runtime/tmux/tmux.go` contains no added role-name strings. |
+| Targeted validator tests and relevant existing tmux/runtime tests pass. | PASS | `go test -count=1 ./internal/runtime/tmux ./internal/runtime` passed. |
+
+## Reviewer Notes
+
+- This PR adds a provider capability surface only; `runtime.Provider` itself remains unchanged.
+- `ConfigureServer` is best-effort at session creation and uses `sync.Once`, so a first-call failure is not retried on that `*Tmux` instance.
+- `TeardownServer` delegates to socket-scoped tmux execution through the existing `KillServer` path.
+- The `cmd/gc stop` teardown wiring remains out of scope for this bead and is tracked by the dependent stop-path bead.

--- a/release-gates/ga-tnse9j-server-lifecycle-provider-gate.md
+++ b/release-gates/ga-tnse9j-server-lifecycle-provider-gate.md
@@ -1,41 +1,58 @@
-# Release Gate: ServerLifecycleProvider and tmux server configuration
+# Release Gate: ServerLifecycleProvider and tmux Server Lifecycle
 
-- Deploy bead: `ga-tnse9j`
-- Source bead: `ga-yxnz9x.2`
-- Review bead: `ga-7mz8rt`
-- Branch: `builder/ga-yxnz9x.2-server-lifecycle`
-- Remote branch: `origin/builder/ga-yxnz9x.2-server-lifecycle`
-- Reviewed commit: `3e4ac7dca feat(runtime): add tmux server lifecycle provider`
-- Note: `docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer role criteria and the source bead acceptance checklist.
+Date: 2026-06-01
+Deploy bead: ga-cv6483
+Source review bead: ga-r3c4az
+PR: https://github.com/gastownhall/gascity/pull/2774
+Branch: builder/ga-yxnz9x.2-server-lifecycle
+Reviewed PR head before this gate refresh: 1682958f5dd16df177969958101bae380c5c0736
+Feature code commit: 7e20af490
+Base checked: origin/main b2b659d421ace115fcc47575b202c0a4541ad75a
 
-## Gate Criteria
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer prompt criteria and the source bead acceptance checklist.
+
+## Scope
+
+The release diff from current `origin/main` contains one runtime/tmux lifecycle provider slice plus this release gate:
+
+| Path | Status | Purpose |
+|---|---:|---|
+| `internal/runtime/runtime.go` | M | Adds optional `runtime.ServerLifecycleProvider`. |
+| `internal/runtime/tmux/adapter.go` | M | Exposes the optional lifecycle provider capability from the tmux provider adapter. |
+| `internal/runtime/tmux/tmux.go` | M | Configures tmux server `exit-empty off` after successful session creation and delegates teardown to socket-scoped `KillServer`. |
+| `internal/runtime/tmux/lifecycle_test.go` | A | Covers configure, idempotence, teardown delegation, and already-gone teardown success. |
+| `release-gates/ga-tnse9j-server-lifecycle-provider-gate.md` | A/M | Release gate evidence, refreshed for `ga-cv6483`. |
+
+## Gate Checklist
 
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
-| 1 | Review PASS present | PASS | `bd show ga-7mz8rt` shows a closed review bead with `REVIEW VERDICT: PASS` for commit `3e4ac7dca`. |
-| 2 | Acceptance criteria met | PASS | Checked source bead criteria against code and tests; details below. |
-| 3 | Tests pass | PASS | `go test -count=1 ./internal/runtime/tmux ./internal/runtime` passed; `go vet ./...` exited 0; `make test-fast-parallel` completed with `All fast jobs passed`. |
+| 1 | Review PASS present | PASS | `bd show ga-r3c4az` shows a closed review bead with `REVIEW VERDICT: PASS` for PR #2774 and commit `1682958f5`. |
+| 2 | Acceptance criteria met | PASS | Code adds an optional `ServerLifecycleProvider` extension without changing the base `Provider` interface; tmux implements `ConfigureServer` and `TeardownServer`; `ConfigureServer` uses `sync.Once`, calls `SetExitEmpty(false)`, and is invoked best-effort after successful session creation. |
+| 3 | Tests pass | PASS | Targeted runtime/tmux tests passed; `go vet ./...` passed; `make test-fast-parallel` passed with `All fast jobs passed`. |
 | 4 | No high-severity review findings open | PASS | Review notes list informational findings only; unresolved HIGH findings count is 0. |
-| 5 | Final branch is clean | PASS | Branch was clean before gate creation; deployer rechecked clean status after committing this gate before push. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `65ac617b144e34ac8c1981485b8eccf9898a5873`. |
-| 7 | Single feature theme | PASS | Commit set is one runtime/tmux lifecycle provider slice touching `internal/runtime` and `internal/runtime/tmux` only. |
+| 5 | Final branch is clean | PASS | Detached PR-head worktree was clean before gate refresh; final clean status is verified after committing this refreshed gate. |
+| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main` refreshed current base; `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `69a03f03f2c17085d4a0dac00fa5edf02b11ad2a`; `git diff --check origin/main...HEAD` exited 0. |
+| 7 | Single feature theme | PASS | Commit set is one runtime/tmux server lifecycle capability slice under `internal/runtime` and `internal/runtime/tmux`. |
 
 ## Acceptance Evidence
 
 | Source criterion | Result | Evidence |
 |---|---|---|
-| Add `runtime.ServerLifecycleProvider` as an optional extension interface in `internal/runtime/runtime.go` with exported doc comments. | PASS | `internal/runtime/runtime.go` defines exported `ServerLifecycleProvider` with doc comments for the interface and both methods. |
-| Do not add `ConfigureServer` or `TeardownServer` to the base `runtime.Provider` interface. | PASS | The base `Provider` interface remains unchanged; server lifecycle is a separate optional interface. |
-| Implement `ConfigureServer` and `TeardownServer` on `*tmux.Tmux` using existing `SetExitEmpty(false)` and `KillServer` primitives. | PASS | `internal/runtime/tmux/tmux.go` implements `ConfigureServer` via `SetExitEmpty(false)` and `TeardownServer` via `KillServer()`. |
-| Add a `sync.Once`-backed `configureOnce` field on `*Tmux`; do not use a bool flag. | PASS | `internal/runtime/tmux/tmux.go` adds `configureOnce sync.Once`; no bool flag is introduced for server configuration state. |
-| `ConfigureServer` is triggered after successful new-session creation in each `NewSession*` variant and is best-effort. | PASS | `NewSession`, `NewSessionWithCommand`, and `NewSessionWithCommandAndEnv` call `_ = t.ConfigureServer()` after successful `t.run(...)`. |
-| Non-tmux providers continue to compile unchanged. | PASS | `go test -count=1 ./internal/runtime` and `go vet ./...` passed; only tmux provider asserts the optional interface. |
-| No role names are introduced in Go source. | PASS | `git diff origin/main...HEAD -- internal/runtime/runtime.go internal/runtime/tmux/adapter.go internal/runtime/tmux/tmux.go` contains no added role-name strings. |
-| Targeted validator tests and relevant existing tmux/runtime tests pass. | PASS | `go test -count=1 ./internal/runtime/tmux ./internal/runtime` passed. |
+| Add `runtime.ServerLifecycleProvider` as an optional extension interface with exported doc comments. | PASS | `internal/runtime/runtime.go` defines exported `ServerLifecycleProvider` with method comments. |
+| Do not add server lifecycle methods to the base `runtime.Provider` interface. | PASS | `Provider` remains unchanged; lifecycle methods live only on the optional extension. |
+| Implement tmux server configuration and teardown using existing primitives. | PASS | `ConfigureServer` calls `SetExitEmpty(false)` and `TeardownServer` calls `KillServer()`. |
+| Make server configuration idempotent with `sync.Once`, not a bool flag. | PASS | `Tmux` includes `configureOnce sync.Once`; lifecycle tests verify one `set-option -g exit-empty off` call across repeated `ConfigureServer` calls. |
+| Trigger configuration after successful new-session creation and keep it best-effort. | PASS | `NewSession`, `NewSessionWithCommand`, and `NewSessionWithCommandAndEnv` call `_ = t.ConfigureServer()` only after successful `t.run(...)`. |
+| Preserve non-tmux provider compatibility. | PASS | `go test -count=1 ./internal/runtime/tmux ./internal/runtime` and `go vet ./...` passed. |
+| Avoid new hardcoded role names in Go source. | PASS | Added diff across changed runtime/tmux files contains no added `mayor`, `deacon`, or `polecat` role-name strings. |
+| Preserve tmux safety. | PASS | Teardown delegates to existing socket-scoped `KillServer`; no bare default-server cleanup path is introduced. |
 
-## Reviewer Notes
+## Test Evidence
 
-- This PR adds a provider capability surface only; `runtime.Provider` itself remains unchanged.
-- `ConfigureServer` is best-effort at session creation and uses `sync.Once`, so a first-call failure is not retried on that `*Tmux` instance.
-- `TeardownServer` delegates to socket-scoped tmux execution through the existing `KillServer` path.
-- The `cmd/gc stop` teardown wiring remains out of scope for this bead and is tracked by the dependent stop-path bead.
+- PASS: `go test -count=1 ./internal/runtime/tmux ./internal/runtime`
+- PASS: `go vet ./...`
+- PASS: `make test-fast-parallel`
+- PASS: `.githooks/pre-commit` is active via `core.hooksPath=.githooks`; commit hook runs `go test ./test/docsync`.
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

This adds an optional `runtime.ServerLifecycleProvider` capability for runtimes that own shared server lifecycle in addition to individual sessions. The tmux provider implements it so Gas City can configure the tmux server with `exit-empty off` after successful session creation and later tear the server down explicitly once sessions have been drained.

The base `runtime.Provider` interface stays unchanged, so non-server runtimes do not need lifecycle methods they cannot meaningfully implement.

## Review notes

- `ConfigureServer` is best-effort and guarded by `sync.Once` per `*tmux.Tmux` instance.
- `TeardownServer` delegates to the existing socket-scoped tmux `KillServer` path.
- This PR does not wire `cmd/gc stop` teardown behavior; that remains a separate stop-path slice.

## Test plan

- [x] `go test -count=1 ./internal/runtime/tmux ./internal/runtime`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-tnse9j-server-lifecycle-provider-gate.md`](release-gates/ga-tnse9j-server-lifecycle-provider-gate.md)
