### PR TITLE
fix(config): exclude foreign gc.run_target rows from gc.routed_to pool-demand fallback

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2665,18 +2665,63 @@ func bdReadyPoolDemandShell(key, target string) string {
 	return `bd ready --metadata-field ` + key + `=` + target + ` --unassigned --exclude-type=epic --json`
 }
 
+// poolDemandFallbackFilter returns a jq program that keeps only the rows for
+// which poolDemandKeys[keyIndex] is the effective routing key — every
+// higher-precedence key is empty or missing. bd ready has no key-absent
+// predicate, so the precedence the other reader sites apply per bead is
+// composed here in jq: a bead stamping both gc.run_target and gc.routed_to with
+// different values belongs to its gc.run_target pool, so the gc.routed_to
+// fallback must not surface (work_query) or count (scale_check) it as demand
+// for the routed_to pool once the preferred query drains empty. The preferred
+// key (index 0) is filter-free and is never passed here.
+func poolDemandFallbackFilter(keyIndex int) string {
+	conds := make([]string, 0, keyIndex)
+	for _, k := range poolDemandKeys[:keyIndex] {
+		conds = append(conds, `(.metadata["`+k+`"] // "") == ""`)
+	}
+	return `[.[] | select(` + strings.Join(conds, " and ") + `)]`
+}
+
 // poolDemandFirstRowProbes emits the work_query Tier 3 body for target: it
-// tries each routing key in poolDemandKeys precedence order at --limit=1,
-// printing the first non-empty JSON array and exiting 0. Used for both the
-// primary and legacy workflow-control targets. The caller appends a terminal
-// fallthrough (e.g. printf "[]") for the all-empty case.
+// tries each routing key in poolDemandKeys precedence order, printing the first
+// non-empty JSON array and exiting 0. Used for both the primary and legacy
+// workflow-control targets. The caller appends a terminal fallthrough (e.g.
+// printf "[]") for the all-empty case.
+//
+// The preferred key lets bd stop at the first row (--limit=1). Fallback keys
+// cannot: a --limit=1 row could be one poolDemandFallbackFilter must drop (it
+// also carries a higher-precedence key) while a valid row is left unreturned,
+// so they fetch the matches, filter, and take the first in jq. The jq program
+// is single-quoted with each embedded quote escaped (the close-escape-reopen
+// idiom) because the whole work_query body is itself single-quoted in the
+// `sh -c '...'` wrapper.
 func poolDemandFirstRowProbes(target string) string {
 	var b strings.Builder
-	for _, key := range poolDemandKeys {
-		b.WriteString(`r=$(` + bdReadyPoolDemandShell(key, target) + ` --limit=1 2>/dev/null); `)
+	for i, key := range poolDemandKeys {
+		if i == 0 {
+			b.WriteString(`r=$(` + bdReadyPoolDemandShell(key, target) + ` --limit=1 2>/dev/null); `)
+		} else {
+			b.WriteString(`r=$(` + bdReadyPoolDemandShell(key, target) +
+				` 2>/dev/null | jq -c '\''` + poolDemandFallbackFilter(i) + `[0:1]'\'' 2>/dev/null); `)
+		}
 		b.WriteString(`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; `)
 	}
 	return b.String()
+}
+
+// poolDemandCountAssign emits a shell snippet assigning the count-form ready
+// JSON for poolDemandKeys[i] into shell variable v. The bd query runs in its
+// own command substitution so a non-zero exit propagates through the caller's
+// && chain (the default scale_check must surface bd failures, never mask them
+// as zero — TestEffectiveScaleCheckUsesReadyOnly). Fallback keys then drop rows
+// whose higher-precedence keys are set, via a second assignment over the
+// already-captured JSON so bd's exit status is preserved.
+func poolDemandCountAssign(v string, i int, target string) string {
+	assign := v + `=$(` + bdReadyPoolDemandShell(poolDemandKeys[i], target) + ` --limit 0)`
+	if i == 0 {
+		return assign
+	}
+	return assign + ` && ` + v + `=$(printf '%s' "$` + v + `" | jq -c '` + poolDemandFallbackFilter(i) + `')`
 }
 
 // poolDemandCountShell emits the reconciler count-form for target: it counts
@@ -2685,7 +2730,9 @@ func poolDemandFirstRowProbes(target string) string {
 // the array length. Precedence mirrors poolDemandFirstRowProbes so the
 // reconciler's spawn decision and the worker's claim decision agree — the
 // worker drains the preferred tier first, then the count surfaces the fallback
-// tier on the next pass.
+// tier on the next pass. Fallback keys drop rows whose higher-precedence keys
+// are set (poolDemandCountAssign) so a bead carrying both keys is counted only
+// as demand for its preferred-key pool.
 //
 // Unlike the work_query probes, this form must NOT redirect bd stderr or
 // default to zero: a failed `bd ready` has to surface as an error rather than
@@ -2697,10 +2744,9 @@ func poolDemandCountShell(target string) string {
 	last := len(keys) - 1
 	// Least-preferred key assigns unconditionally; its bd failure propagates
 	// through the outer &&.
-	expr := `ready_json=$(` + bdReadyPoolDemandShell(keys[last], target) + ` --limit 0)`
+	expr := poolDemandCountAssign("ready_json", last, target)
 	for i := last - 1; i >= 0; i-- {
-		query := bdReadyPoolDemandShell(keys[i], target) + ` --limit 0`
-		expr = `cur=$(` + query + `) && ` +
+		expr = poolDemandCountAssign("cur", i, target) + ` && ` +
 			`if [ "$cur" != "[]" ]; then ready_json="$cur"; else ` + expr + `; fi`
 	}
 	return expr + ` && printf '%s\n' "$ready_json" | jq 'length'`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1484,7 +1484,7 @@ func TestEffectiveWorkQueryDefault(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.run_target=mayor --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 run_target: %q", got)
 	}
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=mayor --unassigned --exclude-type=epic --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=mayor --unassigned --exclude-type=epic --json") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to fallback: %q", got)
 	}
 	if !strings.Contains(got, `"$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"`) {
@@ -1504,7 +1504,7 @@ func TestEffectiveWorkQueryCustom(t *testing.T) {
 func TestEffectiveWorkQueryWithDir(t *testing.T) {
 	a := Agent{Name: "polecat", Dir: "hello-world"}
 	got := a.EffectiveWorkQuery()
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --exclude-type=epic --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --exclude-type=epic --json") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
 }
@@ -1512,7 +1512,7 @@ func TestEffectiveWorkQueryWithDir(t *testing.T) {
 func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 	a := Agent{Name: "polecat", Dir: "hello-world", MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3)}
 	got := a.EffectiveWorkQuery()
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --exclude-type=epic --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --exclude-type=epic --json") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
 	if strings.Contains(got, "--type=molecule") {
@@ -1565,7 +1565,7 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 		PoolName: "hello-world/dog",
 	}
 	got := a.EffectiveWorkQuery()
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --exclude-type=epic --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --exclude-type=epic --json") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to with pool name: %q", got)
 	}
 	if strings.Contains(got, "--type=molecule") {
@@ -1576,7 +1576,7 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 func TestEffectiveWorkQueryPoolNoPoolName(t *testing.T) {
 	a := Agent{Name: "dog", Dir: "hello-world", MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3)}
 	got := a.EffectiveWorkQuery()
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --exclude-type=epic --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --exclude-type=epic --json") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
 }
@@ -1627,14 +1627,17 @@ esac
 }
 
 func TestEffectiveWorkQueryControlDispatcherClaimsLegacyUnassignedRoute(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available; the gc.routed_to fallback probe is a jq pipeline")
+	}
 	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
 	out := runEffectiveWorkQuery(t, a, nil, `#!/bin/sh
 set -eu
 case "$*" in
-  "ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json --limit=1")
+  "ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json")
     printf '[]'
     ;;
-  "ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --exclude-type=epic --json --limit=1")
+  "ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --exclude-type=epic --json")
     printf '[{"id":"ga-legacy-route"}]'
     ;;
   *)
@@ -1785,6 +1788,9 @@ esac
 // gc.routed_to (gc.run_target unset) — e.g. the legacy --formula wisp path
 // that the #2763 reader change must not regress.
 func TestEffectiveWorkQueryFallsBackToRoutedTo(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available; the gc.routed_to fallback probe is a jq pipeline")
+	}
 	a := Agent{Name: "worker", Dir: "hello-world"}
 	out := runEffectiveWorkQuery(t, a, map[string]string{
 		"GC_SESSION_ORIGIN": "ephemeral",
@@ -1852,6 +1858,83 @@ esac
 `)
 	if strings.TrimSpace(out) != "2" {
 		t.Fatalf("EffectivePoolDemandQuery() count = %q, want 2 (run_target demand)", strings.TrimSpace(out))
+	}
+}
+
+// TestEffectivePoolDemandQueryFallsBackToRoutedTo verifies the count-form still
+// counts a legacy root stamped only with gc.routed_to (no gc.run_target), so
+// the #2769 fallback guard does not regress the compatibility path.
+func TestEffectivePoolDemandQueryFallsBackToRoutedTo(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available; count-form exercises a jq pipeline")
+	}
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	out := runShellWithFakeBd(t, a.EffectivePoolDemandQuery(), nil, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--metadata-field gc.run_target=hello-world/worker"*) printf '[]' ;;
+  *"--metadata-field gc.routed_to=hello-world/worker"*)
+    printf '[{"id":"legacy-a"},{"id":"legacy-b"}]'
+    ;;
+  *) printf '[]' ;;
+esac
+`)
+	if strings.TrimSpace(out) != "2" {
+		t.Fatalf("EffectivePoolDemandQuery() count = %q, want 2 (routed_to fallback demand)", strings.TrimSpace(out))
+	}
+}
+
+// TestEffectivePoolDemandQueryFallbackDropsForeignRunTarget is the count-form
+// half of the #2769 fix the copilot review flagged: a gc.routed_to match that
+// also carries a gc.run_target for another pool belongs to that pool, so it
+// must not be counted as demand here once the preferred query drains empty.
+func TestEffectivePoolDemandQueryFallbackDropsForeignRunTarget(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available; count-form exercises a jq pipeline")
+	}
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	out := runShellWithFakeBd(t, a.EffectivePoolDemandQuery(), nil, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--metadata-field gc.run_target=hello-world/worker"*) printf '[]' ;;
+  *"--metadata-field gc.routed_to=hello-world/worker"*)
+    printf '[{"id":"foreign","metadata":{"gc.run_target":"hello-world/other","gc.routed_to":"hello-world/worker"}}]'
+    ;;
+  *) printf '[]' ;;
+esac
+`)
+	if strings.TrimSpace(out) != "0" {
+		t.Fatalf("EffectivePoolDemandQuery() count = %q, want 0 (foreign gc.run_target excluded)", strings.TrimSpace(out))
+	}
+}
+
+// TestEffectiveWorkQueryFallbackDropsForeignRunTarget is the worker-claim half
+// of the #2769 fix: a bead carrying gc.routed_to=<this pool> but a gc.run_target
+// pointing at a DIFFERENT pool belongs to its gc.run_target pool (per-bead
+// precedence). The gc.routed_to fallback must not surface it here once the
+// preferred query is empty, or the wrong pool claims the work.
+func TestEffectiveWorkQueryFallbackDropsForeignRunTarget(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available; the gc.routed_to fallback probe is a jq pipeline")
+	}
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--metadata-field gc.run_target=hello-world/worker"*) printf '[]' ;;
+  *"--metadata-field gc.routed_to=hello-world/worker"*)
+    printf '[{"id":"foreign-root","metadata":{"gc.run_target":"hello-world/other","gc.routed_to":"hello-world/worker"}}]'
+    ;;
+  *) printf '[]' ;;
+esac
+`)
+	if strings.Contains(out, "foreign-root") {
+		t.Fatalf("EffectiveWorkQuery() surfaced a bead whose gc.run_target points to another pool: %q", out)
+	}
+	if got := strings.TrimSpace(out); got != "[]" {
+		t.Fatalf("EffectiveWorkQuery() = %q, want terminal [] (no claimable demand)", got)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #2769 (which merged the #2763 fix: pool work-query prefers `gc.run_target` with a `gc.routed_to` fallback). A Copilot review on #2769 flagged — after the squash merge landed — that the `gc.routed_to` fallback can surface a bead whose `gc.run_target` points at a **different** pool, letting the wrong pool claim the work and the reconciler miscount demand. The merge raced ahead of the fix, so `main` currently carries the gap.

## What this changes

`bd ready --metadata-field gc.routed_to=<target>` matches any bead routed to `<target>`, including one that also carries `gc.run_target` for another pool. The other reader sites apply `run_target`/`routed_to` precedence per bead, so such a bead belongs to its `gc.run_target` pool — surfacing it for the `gc.routed_to` pool after the preferred query drains lets the wrong pool claim it.

`bd ready` has no key-absent predicate, so the per-bead precedence is composed in jq: the fallback now drops rows whose higher-precedence keys are set (`poolDemandFallbackFilter`), applied to both the worker claim path (`poolDemandFirstRowProbes`) and the reconciler count-form (`poolDemandCountShell`). The preferred `gc.run_target` query stays filter-free.

The `work_query` fallback drops `--limit=1` in favor of fetch + filter + take-first (a single returned row could be one the filter must drop); the count-form keeps its error-propagating `&&` chain (filters a captured var, no `bd | jq` pipe).

## Testing

- `go build ./...`, `go vet ./...`, golangci-lint: clean; gofumpt clean on touched files
- targeted `internal/config` + `cmd/gc` tests pass; added fallback-precedence coverage in `config_test.go`
- one pre-existing failure (`TestDoStartJSONAlreadyRunningSupervisorKeepsStdoutJSONOnly`, cmd/gc) is baseline noise from a local dolt version skew (v1.86.2 < v2.0.7+) in an untouched package — fails identically on `main`, not a regression
