### PR TITLE
fix(cmd/gc): teardown tmux server after orphan stop

### DIFF
--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -300,6 +300,8 @@ func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr i
 	// not in the current config).
 	stopOrphans(sp, desired, cfg, store, graceTimeout, recorder, stdout, stderr)
 
+	teardownServerForStop(sp, stderr)
+
 	// Stop bead store's backing service after agents.
 	if err := shutdownBeadsProviderForStop(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -307,6 +309,16 @@ func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr i
 	}
 
 	return code
+}
+
+func teardownServerForStop(sp runtime.Provider, stderr io.Writer) {
+	lifecycle, ok := sp.(runtime.ServerLifecycleProvider)
+	if !ok {
+		return
+	}
+	if err := lifecycle.TeardownServer(); err != nil {
+		fmt.Fprintf(stderr, "gc stop: teardown server: %v\n", err) //nolint:errcheck // best-effort stderr
+	}
 }
 
 func markCityStopSessionSleepReason(store beads.Store, stderr io.Writer) {

--- a/cmd/gc/cmd_stop_server_lifecycle_test.go
+++ b/cmd/gc/cmd_stop_server_lifecycle_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// lifecycleOrderProvider wraps runtime.Fake and additionally implements
+// runtime.ServerLifecycleProvider. It records the order of ListRunning and
+// TeardownServer calls so ordering tests can verify the stop-path sequence.
+type lifecycleOrderProvider struct {
+	*runtime.Fake
+	mu          sync.Mutex
+	events      []string
+	teardownErr error
+}
+
+func (p *lifecycleOrderProvider) ListRunning(prefix string) ([]string, error) {
+	p.mu.Lock()
+	p.events = append(p.events, "ListRunning")
+	p.mu.Unlock()
+	return p.Fake.ListRunning(prefix)
+}
+
+func (p *lifecycleOrderProvider) ConfigureServer() error {
+	return nil
+}
+
+func (p *lifecycleOrderProvider) TeardownServer() error {
+	p.mu.Lock()
+	p.events = append(p.events, "TeardownServer")
+	p.mu.Unlock()
+	return p.teardownErr
+}
+
+// Compile-time assertions: lifecycleOrderProvider satisfies both interfaces.
+var (
+	_ runtime.Provider                = (*lifecycleOrderProvider)(nil)
+	_ runtime.ServerLifecycleProvider = (*lifecycleOrderProvider)(nil)
+)
+
+// TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown is a
+// coordination test that verifies the stop-path ordering contract in
+// cmdStopBody: TeardownServer is called after stopOrphans has run its
+// ListRunning sweep AND before the bead-provider shutdown.
+//
+// Expected sequence: doStop -> stopOrphans (ListRunning) -> TeardownServer -> shutdownBeadsProvider
+func TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "lifecycle-order-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "0s"},
+	}
+	writeStopLifecycleCityConfig(t, cityDir, cfg)
+
+	sp := &lifecycleOrderProvider{Fake: runtime.NewFake()}
+
+	var orderMu sync.Mutex
+	var shutdownCalled bool
+	var eventsAtShutdown []string
+	overrideShutdownBeadsProviderForStop(t, func(string) error {
+		sp.mu.Lock()
+		snapshot := make([]string, len(sp.events))
+		copy(snapshot, sp.events)
+		sp.mu.Unlock()
+
+		orderMu.Lock()
+		shutdownCalled = true
+		eventsAtShutdown = snapshot
+		orderMu.Unlock()
+		return nil
+	})
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	sessionProviderForStopCity = func(*config.City, string) runtime.Provider { return sp }
+
+	var stdout, stderr lockedBuffer
+	code := cmdStopBody(cityDir, cfg, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdStopBody() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	sp.mu.Lock()
+	allProviderEvents := make([]string, len(sp.events))
+	copy(allProviderEvents, sp.events)
+	sp.mu.Unlock()
+
+	orderMu.Lock()
+	called := shutdownCalled
+	snapshot := eventsAtShutdown
+	orderMu.Unlock()
+
+	// TeardownServer must be present.
+	teardownIdx := -1
+	for i, e := range allProviderEvents {
+		if e == "TeardownServer" {
+			teardownIdx = i
+			break
+		}
+	}
+	if teardownIdx < 0 {
+		t.Fatalf("TeardownServer was never called; provider events = %v", allProviderEvents)
+	}
+
+	// TeardownServer must precede the bead-provider shutdown.
+	if called {
+		found := false
+		for _, e := range snapshot {
+			if e == "TeardownServer" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("TeardownServer must occur before bead-provider shutdown; events at shutdown = %v, all provider events = %v",
+				snapshot, allProviderEvents)
+		}
+	}
+
+	// TeardownServer must follow at least one ListRunning (the orphan sweep).
+	listRunningBeforeTeardown := false
+	for _, e := range allProviderEvents[:teardownIdx] {
+		if e == "ListRunning" {
+			listRunningBeforeTeardown = true
+			break
+		}
+	}
+	if !listRunningBeforeTeardown {
+		t.Fatalf("TeardownServer called before any ListRunning (orphan sweep must precede teardown); events = %v", allProviderEvents)
+	}
+}
+
+// TestCmdStopBodySkipsTeardownForNonLifecycleProvider verifies that cmdStopBody
+// completes successfully when the session provider does not implement
+// runtime.ServerLifecycleProvider. The type assertion must yield ok=false and
+// skip teardown silently: no panic, no error in stderr.
+//
+// This is the normal case for non-tmux providers (subprocess, exec, K8s, Fake).
+func TestCmdStopBodySkipsTeardownForNonLifecycleProvider(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "no-lifecycle-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "0s"},
+	}
+	writeStopLifecycleCityConfig(t, cityDir, cfg)
+
+	// Verify that runtime.Fake does NOT implement ServerLifecycleProvider.
+	// This guards against a future change that accidentally adds the interface
+	// to Fake (which would defeat the skip path and change non-tmux behavior).
+	var baseProvider runtime.Provider = runtime.NewFake()
+	if _, ok := baseProvider.(runtime.ServerLifecycleProvider); ok {
+		t.Fatal("runtime.Fake must not implement runtime.ServerLifecycleProvider; " +
+			"non-lifecycle providers must skip teardown via ok=false type assertion")
+	}
+
+	overrideShutdownBeadsProviderForStop(t, func(string) error { return nil })
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	sessionProviderForStopCity = func(*config.City, string) runtime.Provider {
+		return runtime.NewFake()
+	}
+
+	var stdout, stderr lockedBuffer
+	code := cmdStopBody(cityDir, cfg, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdStopBody() = %d, want 0 for non-lifecycle provider; stdout=%q stderr=%q",
+			code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout = %q, want City stopped.", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "teardown server") {
+		t.Fatalf("stderr = %q, unexpected teardown error for non-lifecycle provider", stderr.String())
+	}
+}
+
+// TestCmdStopBodyReportsTeardownErrorWithoutFailing verifies that tmux server
+// teardown is best-effort: a provider error is visible to the operator but does
+// not change the stop exit code.
+func TestCmdStopBodyReportsTeardownErrorWithoutFailing(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "lifecycle-error-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "0s"},
+	}
+	writeStopLifecycleCityConfig(t, cityDir, cfg)
+
+	sp := &lifecycleOrderProvider{
+		Fake:        runtime.NewFake(),
+		teardownErr: errors.New("provider-stop-failed"),
+	}
+
+	overrideShutdownBeadsProviderForStop(t, func(string) error { return nil })
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	sessionProviderForStopCity = func(*config.City, string) runtime.Provider { return sp }
+
+	var stdout, stderr lockedBuffer
+	code := cmdStopBody(cityDir, cfg, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdStopBody() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout = %q, want City stopped.", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "gc stop: teardown server: provider-stop-failed") {
+		t.Fatalf("stderr = %q, want teardown server warning", stderr.String())
+	}
+}
+
+func writeStopLifecycleCityConfig(t *testing.T, cityDir string, cfg *config.City) {
+	t.Helper()
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -318,6 +318,22 @@ type ProcessTableScanner interface {
 	TerminateRuntime(r LiveRuntime) error
 }
 
+// ServerLifecycleProvider is an optional extension for providers that own
+// server-level lifecycle alongside individual session management.
+//
+// This interface must not be added to [Provider]: providers backed by
+// subprocesses, Kubernetes, fakes, or other non-server runtimes do not have a
+// shared server to configure or tear down.
+type ServerLifecycleProvider interface {
+	// ConfigureServer applies server-level configuration. Implementations must
+	// be idempotent, and callers should treat errors as best-effort warnings.
+	ConfigureServer() error
+
+	// TeardownServer terminates the shared server after all sessions have been
+	// drained. Implementations should return nil when the server is already gone.
+	TeardownServer() error
+}
+
 // CopyEntry describes a file or directory to stage in the session's
 // working directory before the agent command starts.
 type CopyEntry struct {

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -40,6 +40,7 @@ var (
 	_ runtime.InterruptBoundaryWaitProvider = (*Provider)(nil)
 	_ runtime.InterruptedTurnResetProvider  = (*Provider)(nil)
 	_ runtime.ProcessTableScanner           = (*Provider)(nil)
+	_ runtime.ServerLifecycleProvider       = (*Provider)(nil)
 )
 
 // NewProvider returns a [Provider] backed by a real tmux installation
@@ -709,6 +710,16 @@ func (p *Provider) Attach(name string) error {
 // that are not part of the [runtime.Provider] interface.
 func (p *Provider) Tmux() *Tmux {
 	return p.tm
+}
+
+// ConfigureServer applies tmux server-level configuration.
+func (p *Provider) ConfigureServer() error {
+	return p.tm.ConfigureServer()
+}
+
+// TeardownServer terminates the tmux server after all sessions are drained.
+func (p *Provider) TeardownServer() error {
+	return p.tm.TeardownServer()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/runtime/tmux/lifecycle_test.go
+++ b/internal/runtime/tmux/lifecycle_test.go
@@ -1,0 +1,91 @@
+package tmux
+
+import (
+	"testing"
+)
+
+// TestConfigureServerSendsSetOptionExitEmptyOff verifies that ConfigureServer
+// issues set-option -g exit-empty off through the executor.
+func TestConfigureServerSendsSetOptionExitEmptyOff(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
+
+	if err := tm.ConfigureServer(); err != nil {
+		t.Fatalf("ConfigureServer() error = %v", err)
+	}
+
+	for _, call := range fe.calls {
+		if containsSetOptionExitEmptyWithValue(call, "off") {
+			return
+		}
+	}
+	t.Fatalf("ConfigureServer did not issue set-option -g exit-empty off; calls = %v", fe.calls)
+}
+
+// TestConfigureServerIsIdempotentViaSyncOnce verifies that calling ConfigureServer
+// multiple times on the same *Tmux issues set-option -g exit-empty off exactly once.
+// The configureOnce sync.Once field must enforce this property.
+func TestConfigureServerIsIdempotentViaSyncOnce(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
+
+	for i := 0; i < 5; i++ {
+		if err := tm.ConfigureServer(); err != nil {
+			t.Fatalf("ConfigureServer() call %d error = %v", i, err)
+		}
+	}
+
+	count := 0
+	for _, call := range fe.calls {
+		if containsSetOptionExitEmptyWithValue(call, "off") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("set-option -g exit-empty off issued %d times across 5 ConfigureServer calls, want exactly 1", count)
+	}
+}
+
+// TestTeardownServerCallsKillServer verifies that TeardownServer delegates to
+// tmux kill-server via the executor.
+func TestTeardownServerCallsKillServer(t *testing.T) {
+	fe := &fakeExecutor{}
+	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
+
+	if err := tm.TeardownServer(); err != nil {
+		t.Fatalf("TeardownServer() error = %v", err)
+	}
+
+	for _, call := range fe.calls {
+		for _, arg := range call {
+			if arg == "kill-server" {
+				return
+			}
+		}
+	}
+	t.Fatalf("TeardownServer did not call kill-server; calls = %v", fe.calls)
+}
+
+// TestTeardownServerTreatsAlreadyGoneServerAsSuccess verifies that TeardownServer
+// returns nil when the tmux server is already gone (ErrNoServer), consistent with
+// KillServer's existing semantics.
+func TestTeardownServerTreatsAlreadyGoneServerAsSuccess(t *testing.T) {
+	fe := &fakeExecutor{err: ErrNoServer}
+	tm := &Tmux{cfg: DefaultConfig(), exec: fe}
+
+	if err := tm.TeardownServer(); err != nil {
+		t.Fatalf("TeardownServer() = %v, want nil for already-gone server", err)
+	}
+}
+
+// containsSetOptionExitEmptyWithValue returns true if args contains the
+// sequence "set-option -g exit-empty <value>", possibly preceded by socket flags.
+func containsSetOptionExitEmptyWithValue(args []string, value string) bool {
+	for i, arg := range args {
+		if arg == "set-option" && i+3 < len(args) &&
+			args[i+1] == "-g" && args[i+2] == "exit-empty" && args[i+3] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -212,6 +212,7 @@ type Tmux struct {
 	exec                 executor
 	interactionDedup     *approvalDedup
 	interactionDedupOnce sync.Once
+	configureOnce        sync.Once
 	hiddenAttachMu       sync.Mutex
 	hiddenAttachClients  map[string]*hiddenAttachClient
 }
@@ -348,6 +349,7 @@ func (t *Tmux) NewSession(name, workDir string) error {
 	if err != nil {
 		return err
 	}
+	_ = t.ConfigureServer()
 	// tmux 3.3+ sets window-size=manual on detached sessions, locking them
 	// at 80x24 even after a client attaches. Reset to "latest" so the window
 	// adapts to the largest attached client.
@@ -377,6 +379,7 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 	if err != nil {
 		return err
 	}
+	_ = t.ConfigureServer()
 	// tmux 3.3+: reset window-size from manual to latest (see NewSession).
 	t.run("set-option", "-wt", name, "window-size", "latest") //nolint:errcheck // best-effort
 	return nil
@@ -436,6 +439,7 @@ func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env ma
 	if err != nil {
 		return err
 	}
+	_ = t.ConfigureServer()
 	// tmux 3.3+: reset window-size from manual to latest (see NewSession).
 	t.run("set-option", "-wt", name, "window-size", "latest") //nolint:errcheck // best-effort
 	return nil
@@ -897,6 +901,21 @@ func (t *Tmux) KillServer() error {
 		return nil // Already dead
 	}
 	return err
+}
+
+// ConfigureServer sets tmux server options required for Gas City lifecycle
+// ownership. It is idempotent per Tmux instance.
+func (t *Tmux) ConfigureServer() error {
+	var err error
+	t.configureOnce.Do(func() {
+		err = t.SetExitEmpty(false)
+	})
+	return err
+}
+
+// TeardownServer terminates the tmux server after all sessions are drained.
+func (t *Tmux) TeardownServer() error {
+	return t.KillServer()
 }
 
 // SetExitEmpty controls the tmux exit-empty server option.

--- a/release-gates/ga-sinlbg-tmux-server-teardown-gate.md
+++ b/release-gates/ga-sinlbg-tmux-server-teardown-gate.md
@@ -1,0 +1,60 @@
+# Release Gate: ga-sinlbg
+
+Bead: ga-sinlbg - needs-deploy: tmux server teardown after stop orphans
+Branch: builder/ga-yxnz9x.3-stop-teardown
+Head: b1edf7792dae2f838129ff85036bc0516c5e5ba9
+Base checked: origin/main at f3012f1daa852186723bcabd2cd189c7577ba4e1
+Gate run: 2026-05-29T21:39:01-07:00
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this worktree. This gate
+uses the deployer release criteria from the agent instructions and the local
+test-command guidance in `TESTING.md`.
+
+## Commit Set
+
+| Commit | Scope | Summary |
+| --- | --- | --- |
+| 3e4ac7dca | internal/runtime, internal/runtime/tmux | feat(runtime): add tmux server lifecycle provider |
+| b1edf7792 | cmd/gc | fix(cmd/gc): teardown server after orphan stop |
+
+Stack context: PR #2774 is the prerequisite ServerLifecycleProvider PR and is
+still open. This branch includes the provider commit because the stop teardown
+implementation depends on it; human merge order should keep #2774 before this
+PR.
+
+## Checklist
+
+| # | Criterion | Result | Evidence |
+| --- | --- | --- | --- |
+| 1 | Review PASS present | PASS | Review bead ga-ojymf7 is closed with `REVIEW VERDICT: PASS`; deploy bead description records reviewer PASS for `builder/ga-yxnz9x.3-stop-teardown`. |
+| 2 | Acceptance criteria met | PASS | `cmdStopBody` stop teardown behavior is covered by focused tests for ordering, non-lifecycle providers, and non-fatal teardown errors. Changed paths are limited to `cmd/gc` and `internal/runtime`; no API, OpenAPI, event payload, or config schema files changed. |
+| 3 | Tests pass | PASS | Focused cmd/gc stop tests passed; `go test -count=1 ./internal/runtime/tmux ./internal/runtime` passed; `make test-fast-parallel` passed (`All fast jobs passed`); `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Review notes for ga-ojymf7 record 0 blockers and 0 warnings. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty before writing this gate file. The branch will be rechecked after committing the gate file and before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `44dbc331c106251f9ecba95fcd27900599408d2e`. |
+| 7 | Single feature theme | PASS | The commits form one tmux server lifecycle teardown stack: the `cmd/gc stop` teardown behavior depends on the runtime provider surface from the prerequisite commit. |
+
+## Test Log
+
+```text
+$ go test -count=1 ./cmd/gc -run 'TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown|TestCmdStopBodySkipsTeardownForNonLifecycleProvider|TestCmdStopBodyReportsTeardownErrorWithoutFailing|TestCmdStop'
+ok  	github.com/gastownhall/gascity/cmd/gc	5.129s
+
+$ go test -count=1 ./internal/runtime/tmux ./internal/runtime
+ok  	github.com/gastownhall/gascity/internal/runtime/tmux	1.158s
+ok  	github.com/gastownhall/gascity/internal/runtime	20.819s
+
+$ make test-fast-parallel
+[fsys-darwin-compile] ok
+[unit-cmd-gc-2-of-6] ok
+[unit-cmd-gc-4-of-6] ok
+[unit-cmd-gc-3-of-6] ok
+[unit-cmd-gc-5-of-6] ok
+[unit-core] ok
+[unit-cmd-gc-6-of-6] ok
+[unit-cmd-gc-1-of-6] ok
+All fast jobs passed
+
+$ go vet ./...
+# no output
+```


### PR DESCRIPTION
## What this changes

`gc stop` now asks tmux-backed runtime providers to tear down their dedicated tmux server after orphan session cleanup finishes and before bead-provider shutdown. That keeps orphan cleanup in charge of session shutdown while still letting stop clean up the tmux server when `exit-empty` is disabled.

The stacked runtime change adds a narrow `ServerLifecycleProvider` surface for providers that know how to configure and tear down their own server. Providers that do not implement it are skipped silently, and teardown errors are reported on stderr without changing the stop exit code.

## Review notes

- This branch is stacked behind #2774; merge that PR first. Until it lands, GitHub will show the provider-surface commit in this PR's diff.
- Tmux cleanup remains socket-scoped through the provider; this does not add a bare `tmux kill-server` path.
- No API, OpenAPI, event payload, or config schema changes are expected.

## Test plan

- [x] `go test -count=1 ./cmd/gc -run 'TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown|TestCmdStopBodySkipsTeardownForNonLifecycleProvider|TestCmdStopBodyReportsTeardownErrorWithoutFailing|TestCmdStop'`
- [x] `go test -count=1 ./internal/runtime/tmux ./internal/runtime`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-sinlbg-tmux-server-teardown-gate.md`](release-gates/ga-sinlbg-tmux-server-teardown-gate.md)