### PR TITLE
fix(gastown): require branch metadata in refinery find-work query

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -172,7 +172,7 @@ description = """
 Search for work beads assigned to you with branch metadata:
 ```bash
 WORK=$(gc bd list ${GC_RIG:+--rig="$GC_RIG"} --assignee=$GC_AGENT --status=open \
-  --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
+  --exclude-type=epic --has-metadata-key=branch --limit=1 --json | jq -r '.[0].id // empty')
 ```
 
 `${GC_RIG:+--rig="$GC_RIG"}` scopes the query to this refinery's rig


### PR DESCRIPTION
## Summary

The refinery's find-work query in `mol-refinery-patrol` excluded only `epic`-type
beads, so it could surface beads that are not merge candidates — for example
patrol wisps (`type=molecule`) — as if they were ready to merge. The step's own
prose already states the intent ("work beads assigned to you **with branch
metadata**"), but the query did not enforce it.

## Change

Filter positively: require `metadata.branch` on the find-work query, so it returns
only beads that actually have a branch to land. A bead without a branch is never a
merge candidate, so this is robust without having to enumerate which container
types to exclude.

```diff
-  --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
+  --exclude-type=epic --has-metadata-key=branch --limit=1 --json | jq -r '.[0].id // empty')
```

## Alternative considered

We also considered simply extending the type denylist to
`--exclude-type=epic,molecule`. We chose the positive `--has-metadata-key=branch`
filter instead, for two reasons:

- Molecules are used for many things, and we were not confident that excluding the
  whole type is always correct. A positive "has a branch" filter sidesteps that
  question — it is correct regardless of which types do or don't carry branches.
- It matches the step's stated intent ("with branch metadata") directly.

That said, if `epic` and `molecule` are intended as isomorphic container types that
should never carry a mergeable branch, an explicit `--exclude-type=epic,molecule`
is also reasonable — we would defer to maintainer preference there.

## What this does not solve

Nothing beyond the find-work surface; the downstream rebase/merge steps already
read `metadata.branch` and are unaffected.

## Test plan

- `go test ./examples/gastown/` — passes (the example pack tests load and validate
  the formula).
- Note: CI on this repo currently shows a known, unrelated failure in
  `TestOrphanSweepPreservesProtectedInProgressEphemeralMoleculeWisp` (orphan-sweep)
  that fails on `origin/main` independent of this change.
