### PR TITLE
docs(packv2): hide legacy pack source fields

### DIFF
--- a/cmd/gc/cmd_gendoc_test.go
+++ b/cmd/gc/cmd_gendoc_test.go
@@ -49,6 +49,32 @@ func TestGenDocProducesMarkdown(t *testing.T) {
 	}
 }
 
+func TestGenDocImportAddDocumentsSourceLanes(t *testing.T) {
+	var buf bytes.Buffer
+	root := newRootCmd(&buf, &buf)
+
+	var md bytes.Buffer
+	if err := docgen.RenderCLIMarkdown(&md, root); err != nil {
+		t.Fatalf("RenderCLIMarkdown: %v", err)
+	}
+
+	section, ok := cliDocSection(md.String(), "gc import add")
+	if !ok {
+		t.Fatal("missing gc import add section")
+	}
+	for _, want := range []string{
+		"local paths outside git worktrees",
+		"remote git repositories",
+		"remote git repository subpaths",
+		"Registry catalog handles are lookup shortcuts",
+		"source and optional version",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("gc import add docs missing %q:\n%s", want, section)
+		}
+	}
+}
+
 // TestCLIDocsFreshness verifies every non-hidden command in the live cobra
 // tree has a section in docs/reference/cli.md. Catches "added or renamed a
 // command without running go run ./cmd/genschema". Avoids strict byte-equal

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -101,6 +101,29 @@ func newImportAddCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add <source>",
 		Short: "Add a pack import",
+		Long: `Add a pack import.
+
+The source argument is resolved once and written as a durable [imports.<name>]
+entry using source plus optional version. Supported sources are:
+
+- local paths outside git worktrees: stored as plain paths, with no lock entry
+- local paths inside git worktrees at HEAD: promoted to a file:// repo source
+  with the pack subpath and locked to the current commit
+- remote git repositories: cloned and locked; --version accepts a semver
+  constraint or sha:<commit>
+- remote git repository subpaths: use source strings such as
+  github.com/org/repo//packs/foo or GitHub tree URLs
+
+Registry catalog handles are lookup shortcuts in this wave, not durable
+[imports.*] field values. After lookup, authored TOML stores the resolved
+source and optional version.`,
+		Example: `gc import add ./packs/review
+gc import add github.com/org/repo//packs/review --version '^1.2.0'
+gc import add https://github.com/org/repo/tree/main/packs/review --name review
+
+# For uncommitted packs inside a git worktree, edit TOML directly:
+# [imports.review]
+# source = "/Users/you/shared-packs/packs/review"`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			cityPath, err := resolveImportRoot()

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -124,7 +124,7 @@ gc import add https://github.com/org/repo/tree/main/packs/review --name review
 # For uncommitted packs inside a git worktree, edit TOML directly:
 # [imports.review]
 # source = "/Users/you/shared-packs/packs/review"`,
-		Args:  cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			cityPath, err := resolveImportRoot()
 			if err != nil {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1491,10 +1491,37 @@ gc import
 
 ## gc import add
 
-Add a pack import
+Add a pack import.
+
+The source argument is resolved once and written as a durable [imports.&lt;name&gt;]
+entry using source plus optional version. Supported sources are:
+
+- local paths outside git worktrees: stored as plain paths, with no lock entry
+- local paths inside git worktrees at HEAD: promoted to a file:// repo source
+  with the pack subpath and locked to the current commit
+- remote git repositories: cloned and locked; --version accepts a semver
+  constraint or sha:&lt;commit&gt;
+- remote git repository subpaths: use source strings such as
+  github.com/org/repo//packs/foo or GitHub tree URLs
+
+Registry catalog handles are lookup shortcuts in this wave, not durable
+[imports.*] field values. After lookup, authored TOML stores the resolved
+source and optional version.
 
 ```
 gc import add <source> [flags]
+```
+
+**Example:**
+
+```
+gc import add ./packs/review
+gc import add github.com/org/repo//packs/review --version '^1.2.0'
+gc import add https://github.com/org/repo/tree/main/packs/review --name review
+
+# For uncommitted packs inside a git worktree, edit TOML directly:
+# [imports.review]
+# source = "/Users/you/shared-packs/packs/review"
 ```
 
 | Flag | Type | Default | Description |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,6 +1,6 @@
 # Gas City Configuration
 
-Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility.
+Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility.
 
 > **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec).
 
@@ -15,7 +15,6 @@ City is the top-level configuration for a Gas City instance.
 | `include` | []string |  |  | Include lists config fragment files to merge into this config. Processed by LoadWithIncludes; not recursive (fragments cannot include). |
 | `workspace` | Workspace | **yes** |  | Workspace holds city-level metadata (name, default provider). |
 | `providers` | map[string]ProviderSpec |  |  | Providers defines named provider presets for agent startup. |
-| `packs` | map[string]PackSource |  |  | Packs defines named remote pack sources fetched via git (V1 mechanism). |
 | `imports` | map[string]Import |  |  | Imports defines named pack imports (V2 mechanism). Each key is a binding name; the value specifies the source and optional version, export, and transitive controls. Processed during ExpandCityPacks. |
 | `defaults` | PackDefaults |  |  | Defaults holds city-level defaults that seed generated config. The canonical default-rig import table is [defaults.rig.imports]. |
 | `agent` | []Agent |  |  | Agents lists all configured agents in this city. Optional: PackV2 cities compose agents through [imports.*] and ship without any [[agent]] block. |
@@ -353,8 +352,8 @@ Import defines a named import of another pack.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `source` | string | **yes** |  | Source is the pack location: a local relative path (e.g., "./assets/imports/gastown") or a remote URL (e.g., "github.com/gastownhall/gastown"). Local paths have no version. |
-| `version` | string |  |  | Version is a semver constraint for remote imports (e.g., "^1.2"). Empty for local paths. "sha:&lt;hex&gt;" for commit pinning. |
+| `source` | string | **yes** |  | Source is the durable authored pack location: a local path, a remote git URL, or a remote git URL with a monorepo subpath such as "github.com/org/repo//packs/foo". Registry handles are lookup-only in this release wave; authored [imports.*] entries store the resolved source plus optional version. |
+| `version` | string |  |  | Version is an optional semver constraint for git-backed imports (e.g., "^1.2"). Empty for local paths. "sha:&lt;hex&gt;" pins a specific commit. |
 | `export` | boolean |  |  | Export re-exports this import's contents into the parent pack's namespace. Consumers of the parent get this import's agents flattened under the parent's binding name. |
 | `transitive` | boolean |  |  | Transitive controls whether this import's own imports are visible to the consumer. Defaults to true (transitive). Set to false to suppress transitive resolution for this specific import. |
 | `shadow` | string |  |  | Shadow controls shadow warnings when the importer defines an agent with the same name as one from this import. "warn" (default) emits a warning; "silent" suppresses it. Enum: `warn`, `silent` |
@@ -470,16 +469,6 @@ PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs crea
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `imports` | map[string]Import |  |  |  |
-
-## PackSource
-
-PackSource defines a remote pack repository.
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `source` | string | **yes** |  | Source is the git repository URL. |
-| `ref` | string |  |  | Ref is the git ref to checkout (branch, tag, or commit). Defaults to HEAD. |
-| `path` | string |  |  | Path is a subdirectory within the repo containing the pack files. |
 
 ## Patches
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -977,13 +977,6 @@
           "type": "object",
           "description": "Providers defines named provider presets for agent startup."
         },
-        "packs": {
-          "additionalProperties": {
-            "$ref": "#/$defs/PackSource"
-          },
-          "type": "object",
-          "description": "Packs defines named remote pack sources fetched via git (V1 mechanism)."
-        },
         "imports": {
           "additionalProperties": {
             "$ref": "#/$defs/Import"
@@ -1333,11 +1326,11 @@
       "properties": {
         "source": {
           "type": "string",
-          "description": "Source is the pack location: a local relative path (e.g.,\n\"./assets/imports/gastown\") or a remote URL (e.g.,\n\"github.com/gastownhall/gastown\"). Local paths have no version."
+          "description": "Source is the durable authored pack location: a local path, a remote git\nURL, or a remote git URL with a monorepo subpath such as\n\"github.com/org/repo//packs/foo\". Registry handles are lookup-only in\nthis release wave; authored [imports.*] entries store the resolved source\nplus optional version."
         },
         "version": {
           "type": "string",
-          "description": "Version is a semver constraint for remote imports (e.g., \"^1.2\").\nEmpty for local paths. \"sha:\u003chex\u003e\" for commit pinning."
+          "description": "Version is an optional semver constraint for git-backed imports (e.g.,\n\"^1.2\"). Empty for local paths. \"sha:\u003chex\u003e\" pins a specific commit."
         },
         "export": {
           "type": "boolean",
@@ -1649,28 +1642,6 @@
       "additionalProperties": false,
       "type": "object",
       "description": "PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack."
-    },
-    "PackSource": {
-      "properties": {
-        "source": {
-          "type": "string",
-          "description": "Source is the git repository URL."
-        },
-        "ref": {
-          "type": "string",
-          "description": "Ref is the git ref to checkout (branch, tag, or commit). Defaults to HEAD."
-        },
-        "path": {
-          "type": "string",
-          "description": "Path is a subdirectory within the repo containing the pack files."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "source"
-      ],
-      "description": "PackSource defines a remote pack repository."
     },
     "Patches": {
       "properties": {
@@ -2425,5 +2396,5 @@
     }
   },
   "title": "Gas City Configuration",
-  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
+  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 }

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -977,13 +977,6 @@
           "type": "object",
           "description": "Providers defines named provider presets for agent startup."
         },
-        "packs": {
-          "additionalProperties": {
-            "$ref": "#/$defs/PackSource"
-          },
-          "type": "object",
-          "description": "Packs defines named remote pack sources fetched via git (V1 mechanism)."
-        },
         "imports": {
           "additionalProperties": {
             "$ref": "#/$defs/Import"
@@ -1333,11 +1326,11 @@
       "properties": {
         "source": {
           "type": "string",
-          "description": "Source is the pack location: a local relative path (e.g.,\n\"./assets/imports/gastown\") or a remote URL (e.g.,\n\"github.com/gastownhall/gastown\"). Local paths have no version."
+          "description": "Source is the durable authored pack location: a local path, a remote git\nURL, or a remote git URL with a monorepo subpath such as\n\"github.com/org/repo//packs/foo\". Registry handles are lookup-only in\nthis release wave; authored [imports.*] entries store the resolved source\nplus optional version."
         },
         "version": {
           "type": "string",
-          "description": "Version is a semver constraint for remote imports (e.g., \"^1.2\").\nEmpty for local paths. \"sha:\u003chex\u003e\" for commit pinning."
+          "description": "Version is an optional semver constraint for git-backed imports (e.g.,\n\"^1.2\"). Empty for local paths. \"sha:\u003chex\u003e\" pins a specific commit."
         },
         "export": {
           "type": "boolean",
@@ -1649,28 +1642,6 @@
       "additionalProperties": false,
       "type": "object",
       "description": "PackRigDefaults holds the [defaults.rig] block — defaults applied to rigs created from this pack."
-    },
-    "PackSource": {
-      "properties": {
-        "source": {
-          "type": "string",
-          "description": "Source is the git repository URL."
-        },
-        "ref": {
-          "type": "string",
-          "description": "Ref is the git ref to checkout (branch, tag, or commit). Defaults to HEAD."
-        },
-        "path": {
-          "type": "string",
-          "description": "Path is a subdirectory within the repo containing the pack files."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "source"
-      ],
-      "description": "PackSource defines a remote pack repository."
     },
     "Patches": {
       "properties": {
@@ -2425,5 +2396,5 @@
     }
   },
   "title": "Gas City Configuration",
-  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
+  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 }

--- a/docs/schema/pack-schema.json
+++ b/docs/schema/pack-schema.json
@@ -569,11 +569,11 @@
       "properties": {
         "source": {
           "type": "string",
-          "description": "Source is the pack location: a local relative path (e.g.,\n\"./assets/imports/gastown\") or a remote URL (e.g.,\n\"github.com/gastownhall/gastown\"). Local paths have no version."
+          "description": "Source is the durable authored pack location: a local path, a remote git\nURL, or a remote git URL with a monorepo subpath such as\n\"github.com/org/repo//packs/foo\". Registry handles are lookup-only in\nthis release wave; authored [imports.*] entries store the resolved source\nplus optional version."
         },
         "version": {
           "type": "string",
-          "description": "Version is a semver constraint for remote imports (e.g., \"^1.2\").\nEmpty for local paths. \"sha:\u003chex\u003e\" for commit pinning."
+          "description": "Version is an optional semver constraint for git-backed imports (e.g.,\n\"^1.2\"). Empty for local paths. \"sha:\u003chex\u003e\" pins a specific commit."
         },
         "export": {
           "type": "boolean",

--- a/docs/schema/pack-schema.txt
+++ b/docs/schema/pack-schema.txt
@@ -569,11 +569,11 @@
       "properties": {
         "source": {
           "type": "string",
-          "description": "Source is the pack location: a local relative path (e.g.,\n\"./assets/imports/gastown\") or a remote URL (e.g.,\n\"github.com/gastownhall/gastown\"). Local paths have no version."
+          "description": "Source is the durable authored pack location: a local path, a remote git\nURL, or a remote git URL with a monorepo subpath such as\n\"github.com/org/repo//packs/foo\". Registry handles are lookup-only in\nthis release wave; authored [imports.*] entries store the resolved source\nplus optional version."
         },
         "version": {
           "type": "string",
-          "description": "Version is a semver constraint for remote imports (e.g., \"^1.2\").\nEmpty for local paths. \"sha:\u003chex\u003e\" for commit pinning."
+          "description": "Version is an optional semver constraint for git-backed imports (e.g.,\n\"^1.2\"). Empty for local paths. \"sha:\u003chex\u003e\" pins a specific commit."
         },
         "export": {
           "type": "boolean",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,10 +170,10 @@ type City struct {
 	Providers map[string]ProviderSpec `toml:"providers,omitempty"`
 	// Packs defines named remote pack sources fetched via git (V1 mechanism).
 	//
-	// Deprecated: accepted for legacy migration and fetch/list compatibility
-	// only. PackV2 authored config uses [imports.*] with source plus optional
-	// version, so this legacy surface is intentionally omitted from generated
-	// public schemas and reference docs.
+	// Legacy pack source map, accepted for migration and fetch/list
+	// compatibility only. PackV2 authored config uses [imports.*] with source
+	// plus optional version, so this legacy surface is intentionally omitted
+	// from generated public schemas and reference docs.
 	Packs map[string]PackSource `toml:"packs,omitempty" jsonschema:"-"`
 	// Imports defines named pack imports (V2 mechanism). Each key is a
 	// binding name; the value specifies the source and optional version,
@@ -681,7 +681,7 @@ type AgentOverride struct {
 // PackSource defines a legacy remote pack repository.
 // Referenced by name in V1 pack fields and fetched into the cache.
 //
-// Deprecated: retained for legacy migration and fetch/list compatibility.
+// PackSource is retained for legacy migration and fetch/list compatibility.
 // PackV2 authored imports use Import.Source and Import.Version instead.
 type PackSource struct {
 	// Source is the git repository URL.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,7 +169,12 @@ type City struct {
 	// Providers defines named provider presets for agent startup.
 	Providers map[string]ProviderSpec `toml:"providers,omitempty"`
 	// Packs defines named remote pack sources fetched via git (V1 mechanism).
-	Packs map[string]PackSource `toml:"packs,omitempty"`
+	//
+	// Deprecated: accepted for legacy migration and fetch/list compatibility
+	// only. PackV2 authored config uses [imports.*] with source plus optional
+	// version, so this legacy surface is intentionally omitted from generated
+	// public schemas and reference docs.
+	Packs map[string]PackSource `toml:"packs,omitempty" jsonschema:"-"`
 	// Imports defines named pack imports (V2 mechanism). Each key is a
 	// binding name; the value specifies the source and optional version,
 	// export, and transitive controls. Processed during ExpandCityPacks.
@@ -673,8 +678,11 @@ type AgentOverride struct {
 	OptionDefaults map[string]string `toml:"option_defaults,omitempty"`
 }
 
-// PackSource defines a remote pack repository.
-// Referenced by name in rig pack fields and fetched into the cache.
+// PackSource defines a legacy remote pack repository.
+// Referenced by name in V1 pack fields and fetched into the cache.
+//
+// Deprecated: retained for legacy migration and fetch/list compatibility.
+// PackV2 authored imports use Import.Source and Import.Version instead.
 type PackSource struct {
 	// Source is the git repository URL.
 	Source string `toml:"source" jsonschema:"required"`
@@ -689,12 +697,14 @@ type PackSource struct {
 // name (the TOML key), a source (local path or remote URL), and
 // optional version/export/transitive controls.
 type Import struct {
-	// Source is the pack location: a local relative path (e.g.,
-	// "./assets/imports/gastown") or a remote URL (e.g.,
-	// "github.com/gastownhall/gastown"). Local paths have no version.
+	// Source is the durable authored pack location: a local path, a remote git
+	// URL, or a remote git URL with a monorepo subpath such as
+	// "github.com/org/repo//packs/foo". Registry handles are lookup-only in
+	// this release wave; authored [imports.*] entries store the resolved source
+	// plus optional version.
 	Source string `toml:"source" jsonschema:"required"`
-	// Version is a semver constraint for remote imports (e.g., "^1.2").
-	// Empty for local paths. "sha:<hex>" for commit pinning.
+	// Version is an optional semver constraint for git-backed imports (e.g.,
+	// "^1.2"). Empty for local paths. "sha:<hex>" pins a specific commit.
 	Version string `toml:"version,omitempty"`
 	// Export re-exports this import's contents into the parent pack's
 	// namespace. Consumers of the parent get this import's agents

--- a/internal/docgen/schema.go
+++ b/internal/docgen/schema.go
@@ -73,7 +73,7 @@ func GenerateCitySchema() (*jsonschema.Schema, error) {
 	s.Title = "Gas City Configuration"
 	s.Description = "Schema for city.toml — the PackV2 deployment file for a Gas City instance. " +
 		"Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. " +
-		"Use [imports.*] for PackV2 composition; legacy includes, [packs.*], and [[agent]] fields remain visible for migration compatibility.\n\n" +
+		"Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility.\n\n" +
 		"> **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 	return s, nil
 }

--- a/internal/docgen/schema_test.go
+++ b/internal/docgen/schema_test.go
@@ -217,6 +217,32 @@ func TestCitySchemaCityAgentNotRequired(t *testing.T) {
 	}
 }
 
+func TestCitySchemaOmitsLegacyPackSourceSurface(t *testing.T) {
+	s, err := GenerateCitySchema()
+	if err != nil {
+		t.Fatalf("GenerateCitySchema: %v", err)
+	}
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	cityProps := defProperties(t, raw, "City")
+	if _, ok := cityProps["packs"]; ok {
+		t.Fatal("City schema exposes legacy [packs.*] surface")
+	}
+	defs := raw["$defs"].(map[string]interface{})
+	if _, ok := defs["PackSource"]; ok {
+		t.Fatal("City schema exposes legacy PackSource ref/path surface")
+	}
+}
+
 func TestGeneratePackSchema(t *testing.T) {
 	s, err := GeneratePackSchema()
 	if err != nil {


### PR DESCRIPTION
## Summary

- hide legacy `[packs.*]` / `PackSource` from generated public city config schema and reference docs
- update generated schema/reference wording so PackV2 authored imports use durable `source` plus optional `version`
- expand `gc import add` help and generated CLI reference with supported source lanes and the registry-handle lookup-only rule

Closes #2322.
Touches #2118 and #1096.

## Validation

- `go run ./cmd/genschema`
- `git diff --check`
- `go test ./internal/docgen -run 'TestGenerateCitySchema|TestCitySchemaOmitsLegacyPackSourceSurface|TestCitySchemaDescriptions' -count=1`
- `go test ./cmd/gc -run 'TestGenDocProducesMarkdown|TestGenDocImportAddDocumentsSourceLanes|TestCLIDocsFreshness' -count=1`
