### PR TITLE
doctor: use order history for firing freshness

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -6,12 +6,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/spf13/cobra"
 )
@@ -162,6 +164,20 @@ type buildDoctorChecksOpts struct {
 	SkipManagedDoltCheck bool
 }
 
+func doctorOrderFiringCurrentLastRunFunc(cityPath string, cfg *config.City, stderr io.Writer) doctor.OrderFiringCurrentLastRunFunc {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	resolveStores := cachedOrderHistoryStoresResolver(cityPath, cfg, stderr)
+	return func(order orders.Order) (time.Time, error) {
+		stores, err := resolveStores(order)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return orders.LastRunAcrossStores(stores...)(order.ScopedName())
+	}
+}
+
 func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts buildDoctorChecksOpts) []doctor.Check {
 	var checks []doctor.Check
 	register := func(c doctor.Check) {
@@ -202,7 +218,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewNamedAlwaysMinConflictCheck(cfg))
 		register(doctor.NewInstructionsFileCheck(cfg, cityPath))
 		register(doctor.NewSkillCollisionCheck(cfg, cityPath))
-		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath))
+		register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath, doctor.WithOrderFiringCurrentLastRunFunc(doctorOrderFiringCurrentLastRunFunc(cityPath, cfg, opts.Stderr))))
 		register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))
 		register(doctor.NewRigPackCoverageCheck(cfg, cityPath))
 		register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))

--- a/cmd/gc/cmd_doctor_order_firing_test.go
+++ b/cmd/gc/cmd_doctor_order_firing_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+func TestBuildDoctorChecksOrderFiringCurrentUsesOrderRunHistory(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	t.Chdir(cityDir)
+	mustWriteDoctorOrderFiringTestFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+`)
+	if err := os.MkdirAll(filepath.Join(cityDir, "orders"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "formulas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteDoctorOrderFiringTestFile(t, filepath.Join(cityDir, "orders", "mol-dog-stale-db.toml"), `[order]
+exec = "true"
+trigger = "cron"
+schedule = "0 */4 * * *"
+`)
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore: %v", err)
+	}
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "manual run mol-dog-stale-db",
+		Type:   "molecule",
+		Labels: []string{"order-run:mol-dog-stale-db"},
+	}); err != nil {
+		t.Fatalf("create recent order-run bead: %v", err)
+	}
+
+	now := time.Now().UTC()
+	rec, err := events.NewFileRecorder(filepath.Join(cityDir, ".gc", "events.jsonl"), io.Discard)
+	if err != nil {
+		t.Fatalf("NewFileRecorder: %v", err)
+	}
+	rec.Record(events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)})
+	rec.Record(events.Event{Type: events.OrderFired, Subject: "mol-dog-stale-db", Ts: now.Add(-13 * time.Hour)})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close recorder: %v", err)
+	}
+
+	cfg := &config.City{FormulaLayers: config.FormulaLayers{City: []string{filepath.Join(cityDir, "formulas")}}}
+	var stderr bytes.Buffer
+	var check doctor.Check
+	for _, candidate := range buildDoctorChecks(cityDir, cfg, nil, buildDoctorChecksOpts{Stderr: &stderr}) {
+		if candidate.Name() == "order-firing-current" {
+			check = candidate
+			break
+		}
+	}
+	if check == nil {
+		t.Fatal("order-firing-current check not registered")
+	}
+	result := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want OK because order-run history is fresh; msg = %s; details = %v; stderr = %s", result.Status, result.Message, result.Details, stderr.String())
+	}
+}
+
+func mustWriteDoctorOrderFiringTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -20,20 +20,39 @@ const (
 	orderFiringInspectHintFmt = "Inspect with: gc order check && gc order history %s"
 )
 
+// OrderFiringCurrentLastRunFunc reports the newest persisted run time for an order.
+type OrderFiringCurrentLastRunFunc func(order orders.Order) (time.Time, error)
+
+// OrderFiringCurrentOption configures the scheduled-order freshness check.
+type OrderFiringCurrentOption func(*OrderFiringCurrentCheck)
+
+// WithOrderFiringCurrentLastRunFunc lets callers provide the same order-run
+// history source used by `gc order history` so doctor can classify manual runs.
+func WithOrderFiringCurrentLastRunFunc(fn OrderFiringCurrentLastRunFunc) OrderFiringCurrentOption {
+	return func(c *OrderFiringCurrentCheck) {
+		c.lastRun = fn
+	}
+}
+
 // OrderFiringCurrentCheck reports scheduled orders whose last firing is stale.
 type OrderFiringCurrentCheck struct {
 	cfg      *config.City
 	cityPath string
 	clock    func() time.Time
+	lastRun  OrderFiringCurrentLastRunFunc
 }
 
 // NewOrderFiringCurrentCheck creates a check for cron and cooldown order freshness.
-func NewOrderFiringCurrentCheck(cfg *config.City, cityPath string) *OrderFiringCurrentCheck {
-	return &OrderFiringCurrentCheck{
+func NewOrderFiringCurrentCheck(cfg *config.City, cityPath string, opts ...OrderFiringCurrentOption) *OrderFiringCurrentCheck {
+	check := &OrderFiringCurrentCheck{
 		cfg:      cfg,
 		cityPath: cityPath,
 		clock:    time.Now,
 	}
+	for _, opt := range opts {
+		opt(check)
+	}
+	return check
 }
 
 // Name returns the check identifier shown by gc doctor.
@@ -96,9 +115,13 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 	// Track severity contributions across error-level entries. Warnings should
 	// stay visible without converting an advisory error into a blocking gate.
 	var blockingErrors, advisoryErrors int
+	suspendedRigs := orderFiringCurrentSuspendedRigs(c.cfg)
 
 	for _, order := range allOrders {
 		if order.Trigger != "cron" && order.Trigger != "cooldown" {
+			continue
+		}
+		if orderFiringCurrentOrderSuspended(suspendedRigs, order) {
 			continue
 		}
 		monitored++
@@ -112,7 +135,17 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 			blockingErrors++
 			continue
 		}
-		status, severity, detail := classifyOrderFiring(order, now, expected, latestOrderFiredAt(firedEvents, order.ScopedName()), startedAt)
+		lastFired, err := c.latestOrderFiredAt(firedEvents, order)
+		if err != nil {
+			worst = worseStatus(worst, StatusError)
+			result.Details = append(result.Details, fmt.Sprintf("%s: cannot read order history: %v", orderDisplayName(order), err))
+			if firstNonOK == "" {
+				firstNonOK = orderHistoryHintTarget(order)
+			}
+			blockingErrors++
+			continue
+		}
+		status, severity, detail := classifyOrderFiring(order, now, expected, lastFired, startedAt)
 		worst = worseStatus(worst, status)
 		result.Details = append(result.Details, detail)
 		if status != StatusOK {
@@ -154,17 +187,137 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 }
 
 func scanOrderFiringCurrentOrders(cityPath string, cfg *config.City) ([]orders.Order, error) {
-	allOrders, err := orderdiscovery.ScanAll(cityPath, cfg, orderdiscovery.ScanOptions{
+	scanCfg := orderFiringCurrentScanConfig(cfg)
+	scanCfg = orderFiringCurrentPruneSuspendedOnlyWildcardOverrides(cityPath, cfg, scanCfg)
+	allOrders, err := orderdiscovery.ScanAll(cityPath, scanCfg, orderFiringCurrentScanOptions(cityPath))
+	if err != nil {
+		return nil, err
+	}
+	return orders.FilterEnabled(allOrders), nil
+}
+
+func orderFiringCurrentScanOptions(cityPath string) orderdiscovery.ScanOptions {
+	return orderdiscovery.ScanOptions{
 		OnValidateError: func(orderName string, err error) error {
 			log.Printf("gc doctor: skipping invalid order %s for %s: %v", orderName, cityPath, err)
 			return nil
 		},
 		ValidateOrder: orders.ValidateExecEnvOverrides,
-	})
-	if err != nil {
-		return nil, err
 	}
-	return orders.FilterEnabled(allOrders), nil
+}
+
+func orderFiringCurrentScanConfig(cfg *config.City) *config.City {
+	if cfg == nil {
+		return nil
+	}
+	suspended := orderFiringCurrentSuspendedRigs(cfg)
+	if len(suspended) == 0 {
+		return cfg
+	}
+	clone := *cfg
+	if len(cfg.FormulaLayers.Rigs) > 0 {
+		clone.FormulaLayers.Rigs = make(map[string][]string, len(cfg.FormulaLayers.Rigs))
+		for rigName, layers := range cfg.FormulaLayers.Rigs {
+			if suspended[rigName] {
+				continue
+			}
+			clone.FormulaLayers.Rigs[rigName] = layers
+		}
+	}
+	if len(cfg.RigPackDirs) > 0 {
+		clone.RigPackDirs = make(map[string][]string, len(cfg.RigPackDirs))
+		for rigName, dirs := range cfg.RigPackDirs {
+			if suspended[rigName] {
+				continue
+			}
+			clone.RigPackDirs[rigName] = dirs
+		}
+	}
+	if len(cfg.Orders.Overrides) > 0 {
+		clone.Orders.Overrides = make([]config.OrderOverride, 0, len(cfg.Orders.Overrides))
+		for _, override := range cfg.Orders.Overrides {
+			if suspended[strings.TrimSpace(override.Rig)] {
+				continue
+			}
+			clone.Orders.Overrides = append(clone.Orders.Overrides, override)
+		}
+	}
+	return &clone
+}
+
+func orderFiringCurrentPruneSuspendedOnlyWildcardOverrides(cityPath string, originalCfg, scanCfg *config.City) *config.City {
+	if originalCfg == nil || scanCfg == nil || len(scanCfg.Orders.Overrides) == 0 {
+		return scanCfg
+	}
+	suspended := orderFiringCurrentSuspendedRigs(originalCfg)
+	if len(suspended) == 0 {
+		return scanCfg
+	}
+	activeOrders, err := orderFiringCurrentScanWithoutOverrides(cityPath, scanCfg)
+	if err != nil {
+		return scanCfg
+	}
+	allOrders, err := orderFiringCurrentScanWithoutOverrides(cityPath, originalCfg)
+	if err != nil {
+		return scanCfg
+	}
+	activeNames := map[string]bool{}
+	for _, order := range activeOrders {
+		activeNames[order.Name] = true
+	}
+	suspendedOnlyNames := map[string]bool{}
+	for _, order := range allOrders {
+		if order.Name == "" || !suspended[order.Rig] || activeNames[order.Name] {
+			continue
+		}
+		suspendedOnlyNames[order.Name] = true
+	}
+	if len(suspendedOnlyNames) == 0 {
+		return scanCfg
+	}
+	clone := *scanCfg
+	clone.Orders.Overrides = make([]config.OrderOverride, 0, len(scanCfg.Orders.Overrides))
+	for _, override := range scanCfg.Orders.Overrides {
+		if strings.TrimSpace(override.Rig) == orders.RigWildcard && suspendedOnlyNames[strings.TrimSpace(override.Name)] {
+			continue
+		}
+		clone.Orders.Overrides = append(clone.Orders.Overrides, override)
+	}
+	return &clone
+}
+
+func orderFiringCurrentScanWithoutOverrides(cityPath string, cfg *config.City) ([]orders.Order, error) {
+	if cfg == nil {
+		return orderdiscovery.ScanAll(cityPath, nil, orderFiringCurrentScanOptions(cityPath))
+	}
+	clone := *cfg
+	clone.Orders.Overrides = nil
+	return orderdiscovery.ScanAll(cityPath, &clone, orderFiringCurrentScanOptions(cityPath))
+}
+
+func orderFiringCurrentSuspendedRigs(cfg *config.City) map[string]bool {
+	out := make(map[string]bool)
+	if cfg == nil {
+		return out
+	}
+	for _, rig := range cfg.Rigs {
+		if rig.Suspended && strings.TrimSpace(rig.Name) != "" {
+			out[rig.Name] = true
+		}
+	}
+	return out
+}
+
+func orderFiringCurrentOrderSuspended(suspended map[string]bool, order orders.Order) bool {
+	if suspended[order.Rig] {
+		return true
+	}
+	// Defensive support for legacy qualified pool values. Bare pool names parse
+	// with an empty rig and intentionally do not imply suspension by themselves.
+	if rigName, _ := config.ParseQualifiedName(order.Pool); rigName != "" && suspended[rigName] {
+		return true
+	}
+	return false
 }
 
 func expectedIntervalForOrder(order orders.Order, cronCache map[string]time.Duration) (time.Duration, error) {
@@ -376,6 +529,21 @@ func latestControllerStartedAt(eventPath string) (time.Time, error) {
 		if event.Ts.After(latest) {
 			latest = event.Ts
 		}
+	}
+	return latest, nil
+}
+
+func (c *OrderFiringCurrentCheck) latestOrderFiredAt(evts []events.Event, order orders.Order) (time.Time, error) {
+	latest := latestOrderFiredAt(evts, order.ScopedName())
+	if c.lastRun == nil {
+		return latest, nil
+	}
+	runAt, err := c.lastRun(order)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if runAt.After(latest) {
+		return runAt, nil
 	}
 	return latest, nil
 }

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/orders"
 )
 
 func TestOrderFiringCurrent_NeverFired_BeyondUptime(t *testing.T) {
@@ -158,6 +160,127 @@ func TestOrderFiringCurrent_FiredRecently(t *testing.T) {
 	}
 	if !strings.Contains(strings.Join(result.Details, "\n"), "last fired 1h ago, expected every 4h") {
 		t.Fatalf("details = %v, want recent-fire detail", result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_UsesNewestOrderRunHistory(t *testing.T) {
+	// Manual `gc order run` creates order-run beads even when no controller
+	// order.fired event is emitted. Doctor must therefore merge bead history
+	// with event history and select the newest execution, not a stale event.
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "mol-dog-stale-db", "cron", "0 */4 * * *")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "mol-dog-stale-db", Ts: now.Add(-13 * time.Hour)},
+	)
+	store := beads.NewMemStoreFrom(2, []beads.Bead{
+		{
+			ID:        "old-run",
+			Title:     "old mol-dog-stale-db",
+			Status:    "closed",
+			Type:      "molecule",
+			Labels:    []string{"order-run:mol-dog-stale-db"},
+			CreatedAt: now.Add(-13 * time.Hour),
+		},
+		{
+			ID:        "new-run",
+			Title:     "new mol-dog-stale-db",
+			Status:    "closed",
+			Type:      "molecule",
+			Labels:    []string{"order-run:mol-dog-stale-db"},
+			CreatedAt: now.Add(-1 * time.Hour),
+		},
+	}, nil)
+
+	check := NewOrderFiringCurrentCheck(cfg, cityPath, WithOrderFiringCurrentLastRunFunc(func(order orders.Order) (time.Time, error) {
+		return orders.LastRunFuncForStore(store)(order.ScopedName())
+	}))
+	check.clock = func() time.Time { return now }
+	result := check.Run(&CheckContext{CityPath: cityPath})
+
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if !strings.Contains(strings.Join(result.Details, "\n"), "last fired 1h ago, expected every 4h") {
+		t.Fatalf("details = %v, want newest order-run bead to win over stale event", result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_SkipsSuspendedRigOrders(t *testing.T) {
+	// The dispatcher intentionally skips suspended rigs. Doctor should not turn
+	// their paused recurring orders into blocking stale-order failures.
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	rigPath := filepath.Join(cityPath, "rigs", "parked")
+	rigFormulas := filepath.Join(rigPath, "formulas")
+	rigOrders := filepath.Join(rigPath, "orders")
+	if err := os.MkdirAll(rigOrders, 0o755); err != nil {
+		t.Fatalf("creating rig orders dir: %v", err)
+	}
+	cfg.Rigs = []config.Rig{{Name: "parked", Path: rigPath, Suspended: true}}
+	cfg.FormulaLayers.Rigs = map[string][]string{"parked": {cfg.FormulaLayers.City[0], rigFormulas}}
+	writeOrderFiringTestOrderInDir(t, rigOrders, "gate-sweep", "cooldown", "1m")
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "gate-sweep:rig:parked", Ts: now.Add(-24 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK for paused rig; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	if strings.Contains(strings.Join(result.Details, "\n"), "parked") {
+		t.Fatalf("details = %v, suspended rig order should be skipped", result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_SkipsSuspendedRigOverrides(t *testing.T) {
+	// Suspended rig orders are pruned from the doctor scan; matching overrides
+	// must be pruned with them so a harmless paused rig does not become a scan
+	// error before the stale-order filter can skip it.
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	rigPath := filepath.Join(cityPath, "rigs", "parked")
+	rigFormulas := filepath.Join(rigPath, "formulas")
+	rigOrders := filepath.Join(rigPath, "orders")
+	if err := os.MkdirAll(rigOrders, 0o755); err != nil {
+		t.Fatalf("creating rig orders dir: %v", err)
+	}
+	cfg.Rigs = []config.Rig{{Name: "parked", Path: rigPath, Suspended: true}}
+	cfg.FormulaLayers.Rigs = map[string][]string{"parked": {cfg.FormulaLayers.City[0], rigFormulas}}
+	interval := "2m"
+	cfg.Orders.Overrides = []config.OrderOverride{{Name: "gate-sweep", Rig: "parked", Interval: &interval}}
+	writeOrderFiringTestOrderInDir(t, rigOrders, "gate-sweep", "cooldown", "1m")
+	writeOrderFiringTestEvents(t, cityPath, events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)})
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK for paused rig override; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_SkipsWildcardOverridesForSuspendedOnlyOrders(t *testing.T) {
+	// Wildcard overrides should not turn a suspended-only order into a scan
+	// error after the doctor prunes that suspended rig from the active view.
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	rigPath := filepath.Join(cityPath, "rigs", "parked")
+	rigFormulas := filepath.Join(rigPath, "formulas")
+	rigOrders := filepath.Join(rigPath, "orders")
+	if err := os.MkdirAll(rigOrders, 0o755); err != nil {
+		t.Fatalf("creating rig orders dir: %v", err)
+	}
+	cfg.Rigs = []config.Rig{{Name: "parked", Path: rigPath, Suspended: true}}
+	cfg.FormulaLayers.Rigs = map[string][]string{"parked": {cfg.FormulaLayers.City[0], rigFormulas}}
+	interval := "2m"
+	cfg.Orders.Overrides = []config.OrderOverride{{Name: "gate-sweep", Rig: orders.RigWildcard, Interval: &interval}}
+	writeOrderFiringTestOrderInDir(t, rigOrders, "gate-sweep", "cooldown", "1m")
+	writeOrderFiringTestEvents(t, cityPath, events.Event{Type: events.ControllerStarted, Ts: now.Add(-24 * time.Hour)})
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK for wildcard override targeting only a paused rig; msg = %s; details = %v", result.Status, result.Message, result.Details)
 	}
 }
 
@@ -383,6 +506,11 @@ func orderFiringTestCity(t *testing.T) (string, *config.City) {
 
 func writeOrderFiringTestOrder(t *testing.T, cityPath, name, trigger, timing string) {
 	t.Helper()
+	writeOrderFiringTestOrderInDir(t, filepath.Join(cityPath, "orders"), name, trigger, timing)
+}
+
+func writeOrderFiringTestOrderInDir(t *testing.T, orderDir, name, trigger, timing string) {
+	t.Helper()
 	var body string
 	switch trigger {
 	case "cron":
@@ -415,7 +543,7 @@ exec = "true"
 trigger = "` + trigger + `"
 `
 	}
-	if err := os.WriteFile(filepath.Join(cityPath, "orders", name+".toml"), []byte(body), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(orderDir, name+".toml"), []byte(body), 0o644); err != nil {
 		t.Fatalf("writing order %s: %v", name, err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #2725.

`order-firing-current` currently reports false stale failures in two cases:

- scheduled orders for suspended rigs, even though the dispatcher intentionally skips suspended rig orders
- orders manually run via `gc order run`, where `gc order history` shows a fresh `order-run:<name>` bead but doctor only considers stale `order.fired` events

This PR makes `gc doctor` align with the existing order execution model:

- skips `order-firing-current` for suspended cities and suspended rig orders, including overrides that target suspended rigs and wildcard overrides that only match suspended-rig orders
- consults order-run bead history via the same order-history store resolution used by `gc order history`
- classifies freshness from the newest of `order.fired` events and `order-run:<scopedName>` bead history
- caches suspended-rig lookup once per doctor run and documents the defensive pool-qualified rig fallback
- adds regression coverage for the false-positive paths, suspended-rig override cases, and `cmd/gc` wiring through `buildDoctorChecks`

## Testing

- [x] `go test ./cmd/gc ./internal/doctor -run 'OrderFiring|Doctor' -count=1`
- [x] `go test ./cmd/gc ./internal/doctor ./internal/beads ./internal/api -run 'Order|OrderFiring|ListAnyLabel|Decode' -count=1`
- [x] `go vet ./cmd/gc ./internal/doctor`
- [x] `make check`
- [x] GitHub required checks passed on `ff6715b94`
- [x] `make check-docs` not applicable — no docs, navigation, or links changed
- [x] `make test-integration` not applicable locally — doctor-only behavior fix with unit/package coverage; GitHub integration checks passed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes, or explained why not needed
  - No docs update: this corrects doctor behavior to match existing order-history and suspended-rig semantics.
- [x] Called out breaking changes or migration notes
  - No breaking changes or migration required.
