### PR TITLE
fix(reconciler): address min-active review findings

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -209,6 +209,8 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 				reasons = []WakeReason{WakeWait}
 			case "assigned-work", "named-demand", "work-query":
 				reasons = []WakeReason{WakeWork}
+			case "min-active":
+				reasons = []WakeReason{WakeConfig}
 			default:
 				reasons = []WakeReason{WakeConfig}
 			}

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -103,6 +103,26 @@ func TestAwakeSetToWakeEvalsPreservesDecisionReason(t *testing.T) {
 	}
 }
 
+func TestAwakeSetToWakeEvalsMapsMinActiveToWakeConfig(t *testing.T) {
+	evals := awakeSetToWakeEvals(
+		map[string]AwakeDecision{
+			"s-worker": {ShouldWake: true, Reason: "min-active"},
+		},
+		[]AwakeSessionBead{{
+			ID:          "mc-session-1",
+			SessionName: "s-worker",
+		}},
+	)
+
+	got := evals["mc-session-1"]
+	if got.Reason != "min-active" {
+		t.Fatalf("Reason = %q, want min-active", got.Reason)
+	}
+	if !containsWakeReason(got.Reasons, WakeConfig) {
+		t.Fatalf("Reasons = %v, want WakeConfig", got.Reasons)
+	}
+}
+
 func TestBuildAwakeInputFromReconcilerCarriesNamedSessionDemand(t *testing.T) {
 	now := time.Now().UTC()
 	cfg := &config.City{

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -299,7 +299,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			continue
 		}
 		template := agent.QualifiedName
-		covered := countMinActiveCovered(input.SessionBeads, desired, template)
+		covered := countMinActiveCovered(input.SessionBeads, desired, template, input.Now)
 		if covered >= agent.MinActiveSessions {
 			continue
 		}
@@ -308,6 +308,9 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 				break
 			}
 			if _, already := desired[bead.SessionName]; already {
+				continue
+			}
+			if minActiveHardBlocked(bead, input.Now) {
 				continue
 			}
 			desired[bead.SessionName] = "min-active"
@@ -500,15 +503,24 @@ func isMinActivePoolBead(b AwakeSessionBead, template string) bool {
 		!b.ManualSession && !b.Drained && !b.DependencyOnly && b.State != "closed"
 }
 
+func minActiveHardBlocked(b AwakeSessionBead, now time.Time) bool {
+	return b.WaitHold ||
+		(!b.HeldUntil.IsZero() && now.Before(b.HeldUntil)) ||
+		(!b.QuarantinedUntil.IsZero() && now.Before(b.QuarantinedUntil))
+}
+
 // countMinActiveCovered counts pool session beads for template that already
 // satisfy the min_active_sessions guarantee: non-asleep live beads
 // (active/creating) plus any bead an earlier pass already marked
 // desired-awake this tick. An asleep bead with no wake reason does not count —
 // that is precisely the deficit the min-active pass fills.
-func countMinActiveCovered(beads []AwakeSessionBead, desired map[string]string, template string) int {
+func countMinActiveCovered(beads []AwakeSessionBead, desired map[string]string, template string, now time.Time) int {
 	n := 0
 	for _, b := range beads {
 		if !isMinActivePoolBead(b, template) {
+			continue
+		}
+		if minActiveHardBlocked(b, now) {
 			continue
 		}
 		if b.State == "asleep" {

--- a/cmd/gc/compute_awake_set_min_active_test.go
+++ b/cmd/gc/compute_awake_set_min_active_test.go
@@ -185,6 +185,56 @@ func TestMinActive_HeldBeadNotWoken(t *testing.T) {
 	assertAsleep(t, result, "rig--pl")
 }
 
+// TestMinActive_HeldCandidateDoesNotConsumeCoverage verifies a held city-stop
+// candidate does not consume the only min-active slot when an eligible sibling
+// can satisfy the guarantee instead.
+func TestMinActive_HeldCandidateDoesNotConsumeCoverage(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "s-a", SessionName: "rig--pl-held", Template: "rig/pl", State: "asleep", SleepReason: "city-stop", HeldUntil: now.Add(time.Hour)},
+			{ID: "s-b", SessionName: "rig--pl-ready", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+		},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl-held")
+	assertAwake(t, result, "rig--pl-ready")
+	assertReason(t, result, "rig--pl-ready", "min-active")
+}
+
+// TestMinActive_QuarantinedCandidateDoesNotConsumeCoverage mirrors the held
+// replacement case for crash-loop quarantine, which is also a hard blocker.
+func TestMinActive_QuarantinedCandidateDoesNotConsumeCoverage(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "s-a", SessionName: "rig--pl-quarantined", Template: "rig/pl", State: "asleep", SleepReason: "city-stop", QuarantinedUntil: now.Add(time.Hour)},
+			{ID: "s-b", SessionName: "rig--pl-ready", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+		},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl-quarantined")
+	assertAwake(t, result, "rig--pl-ready")
+	assertReason(t, result, "rig--pl-ready", "min-active")
+}
+
+// TestMinActive_WaitHoldCandidateDoesNotConsumeCoverage mirrors the held
+// replacement case for a user-issued wait hold, which suppresses ordinary
+// demand-driven wakes until the durable wait is ready.
+func TestMinActive_WaitHoldCandidateDoesNotConsumeCoverage(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "rig/pl", MinActiveSessions: 1}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "s-a", SessionName: "rig--pl-waiting", Template: "rig/pl", State: "asleep", SleepReason: "city-stop", WaitHold: true},
+			{ID: "s-b", SessionName: "rig--pl-ready", Template: "rig/pl", State: "asleep", SleepReason: "city-stop"},
+		},
+		Now: now,
+	})
+	assertAsleep(t, result, "rig--pl-waiting")
+	assertAwake(t, result, "rig--pl-ready")
+	assertReason(t, result, "rig--pl-ready", "min-active")
+}
+
 // TestMinActive_DependencyOnlyDoesNotCount verifies a dependency-only session
 // does not satisfy the min_active_sessions guarantee even while live: it is
 // excluded from the min-active pool (it wakes only via dependency gating), so

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -620,6 +620,24 @@ func pendingResumePreservingNamedRestart(session beads.Bead, clk clock.Clock, st
 	return true
 }
 
+func wakeDemandOverridesSleepSuppression(
+	decision AwakeDecision,
+	eval wakeEvaluation,
+	policy resolvedSessionSleepPolicy,
+	poolDesired map[string]int,
+	template string,
+	hasExplicitSleepIntent bool,
+) bool {
+	if hasExplicitSleepIntent {
+		return false
+	}
+	hasDemand := poolDesired[template] > 0 || eval.HasAssignedWork
+	if hasDemand && policy.Class == config.SessionSleepNonInteractive {
+		return true
+	}
+	return decision.Reason == "min-active" && containsWakeReason(eval.Reasons, WakeConfig)
+}
+
 // reconcileSessionBeads performs bead-driven reconciliation using wake/sleep
 // semantics. For each session bead, it determines if the session should be
 // awake (has a matching entry in the desired state) and manages lifecycle
@@ -1966,15 +1984,17 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		if decision.ShouldWake && !pendingInteractionReady(sp, name) && target.session.Metadata["pin_awake"] != "true" && configWakeSuppressed(*target.session, policy, sp, clk) {
 			// Active demand (poolDesired > 0 or direct assigned work)
 			// overrides sleep suppression for non-interactive sessions
-			// (matching the old evaluateWakeReasons behavior). Interactive
-			// sessions honor their idle window regardless of demand — an
-			// idle chat session should still sleep to release resources.
+			// (matching the old evaluateWakeReasons behavior). Min-active
+			// city-stop revival is also config demand: stale detach metadata
+			// from before gc stop must not cancel the post-start guarantee.
+			// Other interactive sessions honor their idle window regardless
+			// of demand — an idle chat session should still sleep to release
+			// resources.
 			// Explicit sleep_intent always wins — if the session has
 			// signaled it wants to sleep, honor that regardless of demand.
 			template := normalizedSessionTemplate(*target.session, cfg)
-			hasDemand := poolDesired[template] > 0 || eval.HasAssignedWork
 			hasExplicitSleepIntent := target.session.Metadata["sleep_intent"] != ""
-			demandOverrides := hasDemand && policy.Class == config.SessionSleepNonInteractive && !hasExplicitSleepIntent
+			demandOverrides := wakeDemandOverridesSleepSuppression(decision, eval, policy, poolDesired, template, hasExplicitSleepIntent)
 			if !demandOverrides {
 				eval.ConfigSuppressed = true
 				eval.Reasons = nil // Clear reasons so Phase 2 does not cancel the drain.

--- a/cmd/gc/session_sleep_test.go
+++ b/cmd/gc/session_sleep_test.go
@@ -356,6 +356,62 @@ func TestReconcileSessionBeads_AssignedNamedSessionByBeadIDOverridesNonInteracti
 	}
 }
 
+func TestReconcilerWakeDemandOverridesSleepSuppressionForMinActive(t *testing.T) {
+	policy := resolvedSessionSleepPolicy{Class: config.SessionSleepInteractiveResume}
+	decision := AwakeDecision{ShouldWake: true, Reason: "min-active"}
+	eval := wakeEvaluation{Reasons: []WakeReason{WakeConfig}}
+
+	if !wakeDemandOverridesSleepSuppression(decision, eval, policy, nil, "worker", false) {
+		t.Fatal("min-active config wake should override stale interactive sleep suppression")
+	}
+	if wakeDemandOverridesSleepSuppression(decision, eval, policy, nil, "worker", true) {
+		t.Fatal("explicit sleep intent should still override min-active demand")
+	}
+
+	scaledDemand := AwakeDecision{ShouldWake: true, Reason: "scaled:demand"}
+	if wakeDemandOverridesSleepSuppression(scaledDemand, eval, policy, map[string]int{"worker": 1}, "worker", false) {
+		t.Fatal("ordinary interactive pool demand should still honor sleep suppression")
+	}
+}
+
+func TestReconcileSessionBeads_MinActiveCityStopWakeBypassesInteractiveSleepSuppression(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		SessionSleep: config.SessionSleepConfig{
+			InteractiveResume: "60s",
+		},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(1),
+		}},
+	}
+	env.addDesired("worker", "worker", false)
+	session := env.createSessionBead("worker", "worker")
+	stale := env.clk.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		"state":        "asleep",
+		"sleep_reason": "city-stop",
+		"detached_at":  stale,
+		"last_woke_at": stale,
+	})
+
+	woken := env.reconcileWithPoolDesired([]beads.Bead{session}, map[string]int{"worker": 1})
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1; stderr=%s", woken, env.stderr.String())
+	}
+	if !env.sp.IsRunning("worker") {
+		t.Fatal("worker should start for min-active city-stop revival")
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got.Metadata["config_wake_suppressed"] == "true" {
+		t.Fatal("min-active city-stop wake was suppressed by interactive sleep policy")
+	}
+}
+
 func TestReconcileSessionBeads_AssignedWorkWithReadyWaitOverridesNonInteractiveSleepPolicy(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{


### PR DESCRIPTION
## Summary

Follow-up for https://github.com/gastownhall/gascity/pull/2744, which has already been merged.

This carries the maintainer review fixup from the adopt-PR workflow onto current `main`. The original PR fixed `min_active_sessions` not waking asleep `city-stop` pool sessions; this follow-up hardens that behavior after review by:

- skipping held, quarantined, and wait-held city-stop candidates when filling the min-active deficit;
- mapping the explicit `min-active` wake reason to config wake demand in the reconciler bridge;
- preventing stale city-stop detach metadata from cancelling min-active wake through interactive sleep suppression;
- adding focused coverage for the blocked-candidate and sleep-suppression cases.

## Original PR

- Original PR: https://github.com/gastownhall/gascity/pull/2744
- Original title: fix(reconciler): honor min_active_sessions for asleep city-stop pool sessions
- Original state: MERGED
- Configured workflow base: main
- Original GitHub base: main
- Base mismatch: none

## Maintainer Changes

- `23bc6a23e` fix: address min-active review findings
- Diff stat: 6 files changed, 167 insertions(+), 7 deletions(-)

## Review And Validation

The adoption review requested two maintainer fixes: avoid consuming min-active coverage with blocked city-stop candidates, and carry the `min-active` wake signal through the reconciler sleep-policy override. The final review approved the fixup and validated the new targeted tests.

Local validation on the refreshed head:

```bash
go test ./cmd/gc -run 'TestMinActive_|TestAwakeSetToWakeEvalsMapsMinActiveToWakeConfig|TestReconcilerWakeDemandOverridesSleepSuppressionForMinActive|TestReconcileSessionBeads_MinActiveCityStopWakeBypassesInteractiveSleepSuppression'
```

The adopt-PR base refresh replayed the fixup onto current `main` with the same patch-id.