### PR TITLE
Fix duplicate builtin pack auto-includes from rig graphs

### DIFF
--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -415,7 +415,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	rootIncludes := append([]string{}, rootPackIncludes...)
 	rootIncludes = append(rootIncludes, root.Workspace.LegacyIncludes()...)
 	root.Workspace.SetLegacyIncludes(rootIncludes)
-	existingPacks := resolvedPackNames(root.Workspace.LegacyIncludes(), root.Imports, fs, cityRoot)
+	existingPacks := resolvedConfigPackNames(root, fs, cityRoot)
 	for _, inc := range packIncludes {
 		name := readPackNameFromDir(inc)
 		if name != "" && existingPacks[name] {
@@ -1557,8 +1557,8 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 	names := make(map[string]bool, len(includes)+len(imports))
 	seenDirs := make(map[string]bool)
 
-	var visit func(ref, declDir string)
-	visit = func(ref, declDir string) {
+	var visit func(ref, declDir string, transitive bool)
+	visit = func(ref, declDir string, transitive bool) {
 		dir, err := resolvePackRef(ref, declDir, cityRoot)
 		if err != nil {
 			return
@@ -1588,20 +1588,41 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 		}
 
 		names[pc.Pack.Name] = true
+		if !transitive {
+			return
+		}
 		for _, sub := range pc.Pack.Includes {
-			visit(sub, dir)
+			visit(sub, dir, true)
 		}
 		for _, imp := range pc.Imports {
-			visit(imp.Source, dir)
+			visit(imp.Source, dir, imp.ImportIsTransitive())
 		}
 	}
 
 	for _, inc := range includes {
-		visit(inc, cityRoot)
+		visit(inc, cityRoot, true)
 	}
 	for _, imp := range imports {
-		visit(imp.Source, cityRoot)
+		visit(imp.Source, cityRoot, imp.ImportIsTransitive())
 	}
+	return names
+}
+
+func resolvedConfigPackNames(cfg *City, sysFS fsys.FS, cityRoot string) map[string]bool {
+	names := resolvedPackNames(cfg.Workspace.LegacyIncludes(), cfg.Imports, sysFS, cityRoot)
+	add := func(more map[string]bool) {
+		for name := range more {
+			names[name] = true
+		}
+	}
+
+	for _, rig := range cfg.Rigs {
+		add(resolvedPackNames(rig.Includes, rig.Imports, sysFS, cityRoot))
+	}
+
+	add(resolvedPackNames(cfg.Workspace.LegacyDefaultRigIncludes(), nil, sysFS, cityRoot))
+	add(resolvedPackNames(nil, cfg.DefaultRigImports, sysFS, cityRoot))
+
 	return names
 }
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -415,6 +415,12 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	rootIncludes := append([]string{}, rootPackIncludes...)
 	rootIncludes = append(rootIncludes, root.Workspace.LegacyIncludes()...)
 	root.Workspace.SetLegacyIncludes(rootIncludes)
+
+	// Resolve named pack references before computing reachability so builtin
+	// injection sees the same cache paths that pack expansion will use.
+	resolveNamedPacks(root, cityRoot)
+	rootIncludes = root.Workspace.LegacyIncludes()
+
 	existingPacks := resolvedConfigPackNames(root, fs, cityRoot)
 	for _, inc := range packIncludes {
 		name := readPackNameFromDir(inc)
@@ -427,9 +433,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 
 	adjustPatchPaths(&root.Patches, cityRoot, cityRoot)
 	adjustRigOverridePaths(root.Rigs, cityRoot, cityRoot)
-
-	// Resolve named pack references to cache paths before any expansion.
-	resolveNamedPacks(root, cityRoot)
 
 	implicitImports, implicitPath, implicitData, implicitErr := readImplicitImportsWithData()
 	if implicitErr != nil {
@@ -1549,13 +1552,13 @@ func trackWorkspace(prov *Provenance, meta toml.MetaData, source string) {
 }
 
 // resolvedPackNames collects pack names that are reachable from a set of
-// top-level include paths and imports. It walks both legacy [pack].includes
-// and V2 [imports] transitively so builtin system-pack injection can be
-// skipped when a user pack already brings the same pack into the city
-// closure.
+// top-level include paths and imports. It walks legacy [pack].includes
+// transitively and follows V2 [imports] according to each import's transitive
+// setting so builtin system-pack injection can be skipped when a user pack
+// already brings the same pack into the city closure.
 func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string) map[string]bool {
 	names := make(map[string]bool, len(includes)+len(imports))
-	seenDirs := make(map[string]bool)
+	expandedDirs := make(map[string]bool)
 
 	var visit func(ref, declDir string, transitive bool)
 	visit = func(ref, declDir string, transitive bool) {
@@ -1567,11 +1570,6 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 		if absErr != nil {
 			absDir = dir
 		}
-		if seenDirs[absDir] {
-			return
-		}
-		seenDirs[absDir] = true
-
 		data, err := sysFS.ReadFile(filepath.Join(dir, packFile))
 		if err != nil {
 			return
@@ -1591,6 +1589,10 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 		if !transitive {
 			return
 		}
+		if expandedDirs[absDir] {
+			return
+		}
+		expandedDirs[absDir] = true
 		for _, sub := range pc.Pack.Includes {
 			visit(sub, dir, true)
 		}
@@ -1608,6 +1610,8 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 	return names
 }
 
+// resolvedConfigPackNames collects all pack names reachable from the city,
+// rig, and default-rig pack graphs before builtin extra includes are injected.
 func resolvedConfigPackNames(cfg *City, sysFS fsys.FS, cityRoot string) map[string]bool {
 	names := resolvedPackNames(cfg.Workspace.LegacyIncludes(), cfg.Imports, sysFS, cityRoot)
 	add := func(more map[string]bool) {

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3027,6 +3027,61 @@ includes = ["packs/rigsup"]
 	}
 }
 
+func TestLoadWithIncludes_SkipsExtraIncludeReachableFromRigPackGraph(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/maintenance/agents/dog/agent.toml", `
+scope = "city"
+fallback = true
+`)
+
+	writeFile(t, dir, "packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, "packs/gastown/agents/polecat/agent.toml", `
+scope = "rig"
+`)
+
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "gascity"
+path = "/tmp/gascity"
+includes = ["packs/gastown"]
+`)
+
+	cfg, _, err := LoadWithIncludes(
+		fsys.OSFS{},
+		filepath.Join(dir, "city.toml"),
+		filepath.Join(dir, "packs", "maintenance"),
+	)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	for _, packDir := range cfg.PackDirs {
+		if filepath.Base(packDir) == "maintenance" {
+			t.Fatalf("maintenance was injected at city scope despite being reachable from rig pack graph: PackDirs=%v RigPackDirs=%v",
+				cfg.PackDirs, cfg.RigPackDirs)
+		}
+	}
+	if got := cfg.RigPackDirs["gascity"]; len(got) != 2 {
+		t.Fatalf("rig pack graph dirs = %v, want gastown plus transitive maintenance", got)
+	}
+}
+
 // agentNamesOf is a small test helper for readable failure messages.
 func agentNamesOf(agents []Agent) []string {
 	names := make([]string, 0, len(agents))

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3082,6 +3082,139 @@ includes = ["packs/gastown"]
 	}
 }
 
+func TestLoadWithIncludes_SkipsExtraIncludeReachableFromNamedRigPackGraph(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/maintenance/agents/dog/agent.toml", `
+scope = "city"
+fallback = true
+`)
+
+	writeFile(t, dir, ".gc/cache/packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, ".gc/cache/packs/maintenance/agents/dog/agent.toml", `
+scope = "city"
+fallback = true
+`)
+
+	writeFile(t, dir, ".gc/cache/packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, ".gc/cache/packs/gastown/agents/polecat/agent.toml", `
+scope = "rig"
+`)
+
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+
+[packs.gastown]
+source = "https://example.com/gastown.git"
+
+[[rigs]]
+name = "gascity"
+path = "/tmp/gascity"
+includes = ["gastown"]
+`)
+
+	cfg, _, err := LoadWithIncludes(
+		fsys.OSFS{},
+		filepath.Join(dir, "city.toml"),
+		filepath.Join(dir, "packs", "maintenance"),
+	)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	for _, packDir := range cfg.PackDirs {
+		if filepath.Base(packDir) == "maintenance" {
+			t.Fatalf("maintenance was injected at city scope despite being reachable from named rig pack graph: PackDirs=%v RigPackDirs=%v",
+				cfg.PackDirs, cfg.RigPackDirs)
+		}
+	}
+	if got := cfg.RigPackDirs["gascity"]; len(got) != 2 {
+		t.Fatalf("rig pack graph dirs = %v, want gastown plus transitive maintenance", got)
+	}
+}
+
+func TestResolvedPackNames_ExpandsRepeatedSourceWhenAnyVisitIsTransitive(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/shared/pack.toml", `
+[pack]
+name = "shared"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, "packs/wrapper/pack.toml", `
+[pack]
+name = "wrapper"
+schema = 2
+
+[imports.shared]
+source = "../shared"
+transitive = false
+`)
+
+	names := resolvedPackNames([]string{"packs/wrapper"}, map[string]Import{
+		"shared": {Source: "packs/shared"},
+	}, fsys.OSFS{}, dir)
+
+	if !names["maintenance"] {
+		t.Fatalf("maintenance missing after mixed shallow/deep visits: names=%v", names)
+	}
+}
+
+func TestResolvedPackNames_NonTransitiveImportDoesNotCollectDeepDependency(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/shared/pack.toml", `
+[pack]
+name = "shared"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+
+	transitiveFalse := false
+	names := resolvedPackNames(nil, map[string]Import{
+		"shared": {Source: "packs/shared", Transitive: &transitiveFalse},
+	}, fsys.OSFS{}, dir)
+
+	if !names["shared"] {
+		t.Fatalf("shared missing from non-transitive visit: names=%v", names)
+	}
+	if names["maintenance"] {
+		t.Fatalf("maintenance collected through non-transitive import: names=%v", names)
+	}
+}
+
 // agentNamesOf is a small test helper for readable failure messages.
 func agentNamesOf(agents []Agent) []string {
 	names := make([]string, 0, len(agents))


### PR DESCRIPTION
## Summary
- make builtin auto-include de-duping consider the full configured pack graph, including rig includes/imports and default-rig includes/imports
- preserve non-transitive import semantics when collecting reachable pack names
- add regression coverage for the issue #2735 duplicate-dog path where maintenance is imported by a rig pack and also presented as an extra include

Fixes the duplicate dogs case from #2735.

## Tests
- go test ./internal/config -run TestLoadWithIncludes_SkipsExtraIncludeReachableFromRigPackGraph -count=1
- go test ./internal/config -run 'TestLoadWithIncludes_SkipsExtraIncludeReachableFromRigPackGraph|TestExpandPacks_HoistDoesNotDuplicateCityScopeAgent|TestLoadWithIncludes_ExtraIncludesDirectoryBecomesPack' -count=1\n- go test ./internal/config -count=1\n- git diff --check\n- go vet ./...\n- make test\n- make test-fast-parallel\n- .githooks/pre-commit via git commit\n