### PR TITLE
Seed default pack registry -auto

### DIFF
--- a/cmd/gc/cmd_pack_registry.go
+++ b/cmd/gc/cmd_pack_registry.go
@@ -243,7 +243,12 @@ type packRegistryReleaseJSON struct {
 }
 
 func doPackRegistryList(jsonOutput bool, stdout, stderr io.Writer) int {
-	cfg, err := packregistry.LoadConfig(gchome.Default())
+	home := gchome.Default()
+	if err := packregistry.EnsureDefaultRegistryConfig(home); err != nil {
+		fmt.Fprintf(stderr, "gc pack registry list: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	cfg, err := packregistry.LoadConfig(home)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc pack registry list: %v\n", err) //nolint:errcheck
 		return 1
@@ -339,6 +344,10 @@ func doPackRegistryRemove(name string, jsonOutput bool, stdout, stderr io.Writer
 
 func doPackRegistryRefresh(name string, jsonOutput bool, stdout, stderr io.Writer) int {
 	home := gchome.Default()
+	if err := packregistry.EnsureDefaultRegistryConfig(home); err != nil {
+		fmt.Fprintf(stderr, "gc pack registry refresh: %v\n", err) //nolint:errcheck
+		return 1
+	}
 	cfg, err := packregistry.LoadConfig(home)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc pack registry refresh: %v\n", err) //nolint:errcheck
@@ -414,6 +423,10 @@ type registrySearchResult struct {
 
 func doPackRegistrySearch(query, registry string, refresh bool, limit int, all bool, jsonOutput bool, stdout, stderr io.Writer) int {
 	home := gchome.Default()
+	if err := packregistry.EnsureDefaultRegistryConfig(home); err != nil {
+		fmt.Fprintf(stderr, "gc pack registry search: %v\n", err) //nolint:errcheck
+		return 1
+	}
 	cfg, err := packregistry.LoadConfig(home)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc pack registry search: %v\n", err) //nolint:errcheck
@@ -519,6 +532,10 @@ func doPackRegistrySearch(query, registry string, refresh bool, limit int, all b
 
 func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, stderr io.Writer) int {
 	home := gchome.Default()
+	if err := packregistry.EnsureDefaultRegistryConfig(home); err != nil {
+		fmt.Fprintf(stderr, "gc pack registry show: %v\n", err) //nolint:errcheck
+		return 1
+	}
 	cfg, err := packregistry.LoadConfig(home)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc pack registry show: %v\n", err) //nolint:errcheck

--- a/cmd/gc/cmd_pack_registry.go
+++ b/cmd/gc/cmd_pack_registry.go
@@ -295,6 +295,12 @@ func doPackRegistryAdd(name, source string, noValidate, jsonOutput bool, stdout,
 		}
 		catalogData = data
 	}
+	if name != packregistry.DefaultRegistryName {
+		if err := packregistry.EnsureDefaultRegistryConfig(home); err != nil {
+			fmt.Fprintf(stderr, "gc pack registry add: %v\n", err) //nolint:errcheck
+			return 1
+		}
+	}
 	if err := packregistry.AddRegistryWithCache(home, reg, catalogData); err != nil {
 		fmt.Fprintf(stderr, "gc pack registry add: %v\n", err) //nolint:errcheck
 		return 1
@@ -318,6 +324,16 @@ func doPackRegistryAdd(name, source string, noValidate, jsonOutput bool, stdout,
 
 func doPackRegistryRemove(name string, jsonOutput bool, stdout, stderr io.Writer) int {
 	home := gchome.Default()
+	if err := packregistry.ValidateRegistryName(name); err != nil {
+		fmt.Fprintf(stderr, "gc pack registry remove: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	if name == packregistry.DefaultRegistryName {
+		if err := packregistry.EnsureDefaultRegistryConfig(home); err != nil {
+			fmt.Fprintf(stderr, "gc pack registry remove: %v\n", err) //nolint:errcheck
+			return 1
+		}
+	}
 	removed, err := packregistry.RemoveRegistry(home, name)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc pack registry remove: %v\n", err) //nolint:errcheck

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -142,6 +142,13 @@ func TestPackRegistryCommandsPreRegisterDefaultRegistryOnVanillaHome(t *testing.
 	if !strings.Contains(stdout.String(), packregistry.DefaultRegistryName) || !strings.Contains(stdout.String(), packregistry.DefaultRegistrySource) {
 		t.Fatalf("list output = %q, want default main registry", stdout.String())
 	}
+	cfg, err := packregistry.LoadConfig(home)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Registries) != 1 || cfg.Registries[0] != packregistry.DefaultRegistry() {
+		t.Fatalf("registries = %+v, want default registry", cfg.Registries)
+	}
 
 	if err := packregistry.WriteCatalogCache(home, packregistry.DefaultRegistryName, []byte(packRegistryTestCatalog)); err != nil {
 		t.Fatalf("WriteCatalogCache(default main): %v", err)

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -164,6 +164,60 @@ func TestPackRegistryCommandsPreRegisterDefaultRegistryOnVanillaHome(t *testing.
 	}
 }
 
+func TestPackRegistryAddFreshHomePreservesDefaultRegistry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GC_HOME", home)
+	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
+
+	var stdout, stderr bytes.Buffer
+	if code := doPackRegistryAdd("local", catalogDir, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	cfg, err := packregistry.LoadConfig(home)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Registries) != 2 {
+		t.Fatalf("registries = %+v, want default and local", cfg.Registries)
+	}
+	got := map[string]string{}
+	for _, reg := range cfg.Registries {
+		got[reg.Name] = reg.Source
+	}
+	if got[packregistry.DefaultRegistryName] != packregistry.DefaultRegistrySource {
+		t.Fatalf("default registry source = %q, want %q", got[packregistry.DefaultRegistryName], packregistry.DefaultRegistrySource)
+	}
+	if got["local"] != catalogDir {
+		t.Fatalf("local registry source = %q, want %q", got["local"], catalogDir)
+	}
+}
+
+func TestPackRegistryRemoveMainFreshHomeWritesExplicitEmptyConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GC_HOME", home)
+
+	var stdout, stderr bytes.Buffer
+	if code := doPackRegistryRemove(packregistry.DefaultRegistryName, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("remove code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	cfg, err := packregistry.LoadConfig(home)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Registries) != 0 {
+		t.Fatalf("registries = %+v, want explicit empty config", cfg.Registries)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := doPackRegistryList(false, &stdout, &stderr); code != 0 {
+		t.Fatalf("list code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No pack registries configured.") {
+		t.Fatalf("list output = %q, want explicit empty config to remain unseeded", stdout.String())
+	}
+}
+
 func TestPackRegistryShowBareNameAmbiguous(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)

--- a/internal/packregistry/config.go
+++ b/internal/packregistry/config.go
@@ -39,6 +39,11 @@ type Registry struct {
 	Source string `toml:"source"`
 }
 
+// DefaultRegistry returns the first-party public pack registry.
+func DefaultRegistry() Registry {
+	return Registry{Name: DefaultRegistryName, Source: DefaultRegistrySource}
+}
+
 // ConfigPath returns the registries.toml path for a Gas City home.
 func ConfigPath(home string) string {
 	return gchome.RegistriesPath(home)
@@ -72,6 +77,19 @@ func LoadConfig(home string) (Config, error) {
 	}
 	cfg.Registries = append([]Registry(nil), cfg.Registry...)
 	return cfg, validateConfig(cfg)
+}
+
+// EnsureDefaultRegistryConfig writes the first-party registry config for a fresh Gas City home.
+func EnsureDefaultRegistryConfig(home string) error {
+	return WithConfigLock(home, func() error {
+		path := ConfigPath(home)
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("checking registries.toml: %w", err)
+		}
+		return SaveConfig(home, Config{Registries: []Registry{DefaultRegistry()}})
+	})
 }
 
 // SaveConfig validates and writes registry configuration.

--- a/internal/packregistry/config_test.go
+++ b/internal/packregistry/config_test.go
@@ -99,6 +99,37 @@ func TestLoadConfigExplicitEmptyFileReturnsEmptyConfig(t *testing.T) {
 	}
 }
 
+func TestEnsureDefaultRegistryConfigCreatesFreshConfig(t *testing.T) {
+	home := t.TempDir()
+	if err := EnsureDefaultRegistryConfig(home); err != nil {
+		t.Fatalf("EnsureDefaultRegistryConfig: %v", err)
+	}
+	cfg, err := LoadConfig(home)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Registries) != 1 || cfg.Registries[0] != DefaultRegistry() {
+		t.Fatalf("registries = %+v, want default registry", cfg.Registries)
+	}
+}
+
+func TestEnsureDefaultRegistryConfigPreservesExistingEmptyConfig(t *testing.T) {
+	home := t.TempDir()
+	if err := SaveConfig(home, Config{}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	if err := EnsureDefaultRegistryConfig(home); err != nil {
+		t.Fatalf("EnsureDefaultRegistryConfig: %v", err)
+	}
+	cfg, err := LoadConfig(home)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Registries) != 0 {
+		t.Fatalf("registries = %+v, want none", cfg.Registries)
+	}
+}
+
 func TestLoadConfigPreservesExistingFile(t *testing.T) {
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Dir(ConfigPath(home)), 0o755); err != nil {


### PR DESCRIPTION
## Summary\n- Materialize a default `main` pack registry for fresh GC_HOME values\n- Point the default registry at the public gascity-packs `registry.toml` raw URL\n- Keep existing or deliberately empty registries.toml files untouched\n\n## Validation\n- `go test ./internal/packregistry ./cmd/gc -run 'Test(EnsureDefaultRegistryConfig|LoadConfig|Config|PackRegistry)' -count=1`\n- `GC_TEST_GASCITY_PACKS_REGISTRY=https://raw.githubusercontent.com/gastownhall/gascity-packs/main/registry.toml make test-pack-registry-live`\n- fresh `GC_HOME` smoke: `gc pack registry list` writes/shows `main`; `gc pack registry refresh` refreshes 5 packs; `gc pack registry search --all` lists gascity/gastown/discord/github-intake/slack`\n\nNote: a broader `go test ./cmd/gc ./internal/packregistry -count=1` produced no output for a couple minutes and was stopped; the focused registry coverage above passed.