### PR TITLE
fix: dismiss startup dialogs in k8s sessions

### DIFF
--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -20,8 +20,17 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
-// Compile-time interface check.
-var _ runtime.Provider = (*Provider)(nil)
+// Compile-time interface checks.
+var (
+	_ runtime.Provider       = (*Provider)(nil)
+	_ runtime.DialogProvider = (*Provider)(nil)
+)
+
+const (
+	k8sStartupDialogPeekLines    = 120
+	k8sStartupDialogPollInterval = 100 * time.Millisecond
+	k8sStartupDialogInitialQuiet = 300 * time.Millisecond
+)
 
 // Provider is a native Kubernetes session provider using client-go.
 // Eliminates subprocess overhead by making direct API calls over reused
@@ -259,6 +268,14 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 	_, _ = p.ops.execInPod(ctx, podName, "agent",
 		[]string{"tmux", "pipe-pane", "-t", tmuxSession, "-o", "cat >> /tmp/agent-output.log"}, nil)
 
+	if k8sShouldAcceptStartupDialogs(cfg) {
+		_ = p.dismissStartupDialogs(ctx, name)
+		if err := ctx.Err(); err != nil {
+			cleanup("startup dialog dismissal canceled")
+			return fmt.Errorf("dismissing startup dialogs for session %q: %w", name, err)
+		}
+	}
+
 	// Run session_setup commands inside the pod.
 	for _, cmd := range cfg.SessionSetup {
 		if cmd == "" {
@@ -276,6 +293,14 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 		} else {
 			_, _ = p.ops.execInPod(ctx, podName, "agent",
 				[]string{"sh"}, strings.NewReader(string(script)))
+		}
+	}
+
+	if k8sShouldAcceptStartupDialogs(cfg) {
+		_ = p.dismissStartupDialogs(ctx, name)
+		if err := ctx.Err(); err != nil {
+			cleanup("startup dialog dismissal canceled")
+			return fmt.Errorf("dismissing startup dialogs for session %q: %w", name, err)
 		}
 	}
 
@@ -311,6 +336,14 @@ func (p *Provider) Start(ctx context.Context, name string, cfg runtime.Config) e
 		}
 	}
 
+	if k8sShouldAcceptStartupDialogs(cfg) {
+		_ = p.dismissStartupDialogs(ctx, name)
+		if err := ctx.Err(); err != nil {
+			cleanup("startup dialog dismissal canceled")
+			return fmt.Errorf("dismissing startup dialogs for session %q: %w", name, err)
+		}
+	}
+
 	// Send initial nudge if configured (matches tmux adapter step 6).
 	if cfg.Nudge != "" {
 		_ = p.Nudge(name, runtime.TextContent(cfg.Nudge))
@@ -324,6 +357,16 @@ func k8sRequiresPostStartLiveness(cfg runtime.Config) bool {
 		return false
 	}
 	return runtime.HasManagedStartupHints(cfg)
+}
+
+func k8sShouldAcceptStartupDialogs(cfg runtime.Config) bool {
+	if cfg.AcceptStartupDialogs != nil {
+		return *cfg.AcceptStartupDialogs
+	}
+	if len(cfg.ProcessNames) == 0 && !cfg.EmitsPermissionWarning {
+		return false
+	}
+	return true
 }
 
 // Stop deletes the pod for the named session. Idempotent.
@@ -467,6 +510,78 @@ func (p *Provider) SendKeys(name string, keys ...string) error {
 	args = append(args, keys...)
 	_, _ = p.ops.execInPod(ctx, podName, "agent", args, nil)
 	return nil
+}
+
+func (p *Provider) dismissStartupDialogs(ctx context.Context, name string) error {
+	return p.DismissKnownDialogs(ctx, name, runtime.StartupDialogTimeout())
+}
+
+// DismissKnownDialogs best-effort clears known startup dialogs on a Kubernetes
+// hosted tmux session using the same shared dialog rules as local providers.
+func (p *Provider) DismissKnownDialogs(ctx context.Context, name string, timeout time.Duration) error {
+	if timeout <= 0 {
+		return nil
+	}
+
+	streamCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	snapshots := make(chan string, 8)
+	go p.streamStartupSnapshots(streamCtx, name, snapshots)
+
+	_, err := runtime.AcceptStartupDialogsFromStreamWithStatus(ctx, timeout, snapshots,
+		func(keys ...string) error { return p.SendKeys(name, keys...) },
+	)
+	return err
+}
+
+func (p *Provider) streamStartupSnapshots(ctx context.Context, name string, snapshots chan<- string) {
+	defer close(snapshots)
+
+	ticker := time.NewTicker(k8sStartupDialogPollInterval)
+	defer ticker.Stop()
+	initialQuiet := time.NewTimer(k8sStartupDialogInitialQuiet)
+	defer initialQuiet.Stop()
+
+	var last string
+	observedContent := false
+	lastChange := time.Now()
+	for {
+		content, err := p.Peek(name, k8sStartupDialogPeekLines)
+		if err != nil {
+			return
+		}
+		if content != last {
+			last = content
+			if strings.TrimSpace(content) != "" {
+				observedContent = true
+				lastChange = time.Now()
+				select {
+				case snapshots <- content:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		if !observedContent {
+			select {
+			case <-ctx.Done():
+				return
+			case <-initialQuiet.C:
+				return
+			case <-ticker.C:
+				continue
+			}
+		}
+		if time.Since(lastChange) >= k8sStartupDialogInitialQuiet {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 // RunLive re-applies session_live commands. Not yet supported for K8s.

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -363,10 +363,39 @@ func k8sShouldAcceptStartupDialogs(cfg runtime.Config) bool {
 	if cfg.AcceptStartupDialogs != nil {
 		return *cfg.AcceptStartupDialogs
 	}
+	if k8sProviderMayPromptForStartupDialog(cfg.ProviderName) ||
+		k8sProviderMayPromptForStartupDialog(cfg.ProviderOverlayName) ||
+		k8sCommandMayPromptForStartupDialog(cfg.Command) {
+		return true
+	}
+	for _, provider := range cfg.InstallAgentHooks {
+		if k8sProviderMayPromptForStartupDialog(provider) {
+			return true
+		}
+	}
 	if len(cfg.ProcessNames) == 0 && !cfg.EmitsPermissionWarning {
 		return false
 	}
 	return true
+}
+
+func k8sProviderMayPromptForStartupDialog(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "claude", "codex", "gemini", "kimi":
+		return true
+	default:
+		return false
+	}
+}
+
+func k8sCommandMayPromptForStartupDialog(command string) bool {
+	command = strings.ToLower(command)
+	for _, token := range []string{"claude", "codex", "gemini", "kimi"} {
+		if strings.Contains(command, token) {
+			return true
+		}
+	}
+	return false
 }
 
 // Stop deletes the pod for the named session. Idempotent.

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -29,7 +29,7 @@ var (
 const (
 	k8sStartupDialogPeekLines    = 120
 	k8sStartupDialogPollInterval = 100 * time.Millisecond
-	k8sStartupDialogInitialQuiet = 300 * time.Millisecond
+	k8sStartupDialogContentQuiet = 300 * time.Millisecond
 )
 
 // Provider is a native Kubernetes session provider using client-go.
@@ -569,8 +569,6 @@ func (p *Provider) streamStartupSnapshots(ctx context.Context, name string, snap
 
 	ticker := time.NewTicker(k8sStartupDialogPollInterval)
 	defer ticker.Stop()
-	initialQuiet := time.NewTimer(k8sStartupDialogInitialQuiet)
-	defer initialQuiet.Stop()
 
 	var last string
 	observedContent := false
@@ -596,13 +594,11 @@ func (p *Provider) streamStartupSnapshots(ctx context.Context, name string, snap
 			select {
 			case <-ctx.Done():
 				return
-			case <-initialQuiet.C:
-				return
 			case <-ticker.C:
 				continue
 			}
 		}
-		if time.Since(lastChange) >= k8sStartupDialogInitialQuiet {
+		if time.Since(lastChange) >= k8sStartupDialogContentQuiet {
 			return
 		}
 		select {

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -1864,6 +1864,100 @@ func TestStartSucceedsWhenSessionStaysAlive(t *testing.T) {
 	}
 }
 
+func TestStartDismissesCodexTrustDialogBeforeNudge(t *testing.T) {
+	fake := newFakeK8sOps()
+	p := newProviderWithOps(fake)
+	p.postStartSettle = 0
+
+	trustAccepted := false
+	fake.execFunc = func(_ string, cmd []string) (string, error) {
+		if len(cmd) >= 3 && cmd[0] == "tmux" && cmd[1] == "has-session" {
+			return "", nil
+		}
+		if len(cmd) >= 2 && cmd[0] == "tmux" && cmd[1] == "capture-pane" {
+			if trustAccepted {
+				return "codex >\n", nil
+			}
+			return "Do you trust the contents of this directory?\n1. Yes, continue\n2. No, quit\nPress enter to continue\n", nil
+		}
+		if len(cmd) == 5 && cmd[0] == "tmux" && cmd[1] == "send-keys" && cmd[4] == "Enter" && !trustAccepted {
+			trustAccepted = true
+		}
+		return "", nil
+	}
+
+	cfg := runtime.Config{
+		Command:      "codex --dangerously-bypass-approvals-and-sandbox",
+		Env:          map[string]string{"GC_AGENT": "gastown.dog", "GC_CITY": "/workspace/cities/demo"},
+		ProcessNames: []string{"codex"},
+		Nudge:        "Check for assigned work.",
+	}
+	if err := p.Start(context.Background(), "gc-test-agent", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !trustAccepted {
+		t.Fatal("Start did not accept the Codex workspace trust dialog")
+	}
+
+	firstDialogEnter := -1
+	firstNudgeText := -1
+	for i, c := range fake.calls {
+		if c.method != "execInPod" || len(c.cmd) < 5 || c.cmd[0] != "tmux" || c.cmd[1] != "send-keys" {
+			continue
+		}
+		if len(c.cmd) == 5 && c.cmd[4] == "Enter" && firstDialogEnter == -1 {
+			firstDialogEnter = i
+		}
+		if len(c.cmd) >= 6 && c.cmd[4] == "-l" && c.cmd[5] == cfg.Nudge && firstNudgeText == -1 {
+			firstNudgeText = i
+		}
+	}
+	if firstDialogEnter == -1 {
+		t.Fatal("Start did not send Enter to dismiss the trust dialog")
+	}
+	if firstNudgeText == -1 {
+		t.Fatal("Start did not send the configured nudge")
+	}
+	if firstDialogEnter > firstNudgeText {
+		t.Fatalf("trust dialog Enter call index %d occurred after nudge text index %d", firstDialogEnter, firstNudgeText)
+	}
+}
+
+func TestStartHonorsAcceptStartupDialogsFalse(t *testing.T) {
+	fake := newFakeK8sOps()
+	p := newProviderWithOps(fake)
+	p.postStartSettle = 0
+
+	fake.execFunc = func(_ string, cmd []string) (string, error) {
+		if len(cmd) >= 3 && cmd[0] == "tmux" && cmd[1] == "has-session" {
+			return "", nil
+		}
+		if len(cmd) >= 2 && cmd[0] == "tmux" && cmd[1] == "capture-pane" {
+			return "Do you trust the contents of this directory?\nPress enter to continue\n", nil
+		}
+		return "", nil
+	}
+
+	accept := false
+	cfg := runtime.Config{
+		Command:              "codex --dangerously-bypass-approvals-and-sandbox",
+		Env:                  map[string]string{"GC_AGENT": "gastown.dog", "GC_CITY": "/workspace/cities/demo"},
+		ProcessNames:         []string{"codex"},
+		AcceptStartupDialogs: &accept,
+	}
+	if err := p.Start(context.Background(), "gc-test-agent", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	for _, c := range fake.calls {
+		if c.method == "execInPod" && len(c.cmd) >= 2 && c.cmd[0] == "tmux" && c.cmd[1] == "capture-pane" {
+			t.Fatalf("Start captured pane despite AcceptStartupDialogs=false: %#v", c.cmd)
+		}
+		if c.method == "execInPod" && len(c.cmd) >= 2 && c.cmd[0] == "tmux" && c.cmd[1] == "send-keys" {
+			t.Fatalf("Start sent keys despite AcceptStartupDialogs=false: %#v", c.cmd)
+		}
+	}
+}
+
 func TestStartHonorsCancellationDuringPostStartSettle(t *testing.T) {
 	fake := newFakeK8sOps()
 	p := newProviderWithOps(fake)

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -1976,6 +1976,49 @@ func TestStartDismissesCodexDialogsForProviderWithoutStartupHints(t *testing.T) 
 	}
 }
 
+func TestStartWaitsForDelayedCodexTrustDialog(t *testing.T) {
+	fake := newFakeK8sOps()
+	p := newProviderWithOps(fake)
+	p.postStartSettle = 0
+
+	blankCaptures := 0
+	trustAccepted := false
+	fake.execFunc = func(_ string, cmd []string) (string, error) {
+		if len(cmd) >= 3 && cmd[0] == "tmux" && cmd[1] == "has-session" {
+			return "", nil
+		}
+		if len(cmd) >= 2 && cmd[0] == "tmux" && cmd[1] == "capture-pane" {
+			if trustAccepted {
+				return "codex >\n", nil
+			}
+			if blankCaptures < 5 {
+				blankCaptures++
+				return "\n", nil
+			}
+			return "Do you trust the contents of this directory?\n1. Yes, continue\n2. No, quit\nPress enter to continue\n", nil
+		}
+		if len(cmd) == 5 && cmd[0] == "tmux" && cmd[1] == "send-keys" && cmd[4] == "Enter" {
+			trustAccepted = true
+		}
+		return "", nil
+	}
+
+	cfg := runtime.Config{
+		Command:      "codex --dangerously-bypass-approvals-and-sandbox",
+		ProviderName: "codex",
+		Env:          map[string]string{"GC_AGENT": "gastown.dog", "GC_CITY": "/workspace/cities/demo"},
+	}
+	if err := p.Start(context.Background(), "gc-test-agent", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if blankCaptures < 5 {
+		t.Fatalf("blank captures = %d, want delayed trust dialog after initial blank pane", blankCaptures)
+	}
+	if !trustAccepted {
+		t.Fatal("Start returned before accepting the delayed Codex workspace trust dialog")
+	}
+}
+
 func TestStartHonorsAcceptStartupDialogsFalse(t *testing.T) {
 	fake := newFakeK8sOps()
 	p := newProviderWithOps(fake)

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -1923,6 +1923,59 @@ func TestStartDismissesCodexTrustDialogBeforeNudge(t *testing.T) {
 	}
 }
 
+func TestStartDismissesCodexDialogsForProviderWithoutStartupHints(t *testing.T) {
+	fake := newFakeK8sOps()
+	p := newProviderWithOps(fake)
+	p.postStartSettle = 0
+
+	state := "trust"
+	var keys [][]string
+	hookDownSent := false
+	fake.execFunc = func(_ string, cmd []string) (string, error) {
+		if len(cmd) >= 3 && cmd[0] == "tmux" && cmd[1] == "has-session" {
+			return "", nil
+		}
+		if len(cmd) >= 2 && cmd[0] == "tmux" && cmd[1] == "capture-pane" {
+			switch state {
+			case "trust":
+				return "Do you trust the contents of this directory?\n1. Yes, continue\n2. No, quit\nPress enter to continue\n", nil
+			case "hooks":
+				return "Hooks need review\n1. Review hooks\n2. Trust all and continue\n3. Continue without trusting\nPress enter to confirm or esc to go back\n", nil
+			default:
+				return "codex >\n", nil
+			}
+		}
+		if len(cmd) >= 4 && cmd[0] == "tmux" && cmd[1] == "send-keys" {
+			sent := append([]string(nil), cmd[4:]...)
+			keys = append(keys, sent)
+			switch {
+			case state == "trust" && len(sent) == 1 && sent[0] == "Enter":
+				state = "hooks"
+			case state == "hooks" && len(sent) == 1 && sent[0] == "Down":
+				hookDownSent = true
+			case state == "hooks" && hookDownSent && len(sent) == 1 && sent[0] == "Enter":
+				state = "ready"
+			}
+		}
+		return "", nil
+	}
+
+	cfg := runtime.Config{
+		Command:      "codex --dangerously-bypass-approvals-and-sandbox",
+		ProviderName: "codex",
+		Env:          map[string]string{"GC_AGENT": "gastown.dog", "GC_CITY": "/workspace/cities/demo"},
+	}
+	if err := p.Start(context.Background(), "gc-test-agent", cfg); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if state != "ready" {
+		t.Fatalf("dialog state = %q, want ready; sent keys = %#v", state, keys)
+	}
+	if len(keys) < 2 {
+		t.Fatalf("sent keys = %#v, want trust and hook-review dismissal", keys)
+	}
+}
+
 func TestStartHonorsAcceptStartupDialogsFalse(t *testing.T) {
 	fake := newFakeK8sOps()
 	p := newProviderWithOps(fake)
@@ -1955,6 +2008,43 @@ func TestStartHonorsAcceptStartupDialogsFalse(t *testing.T) {
 		if c.method == "execInPod" && len(c.cmd) >= 2 && c.cmd[0] == "tmux" && c.cmd[1] == "send-keys" {
 			t.Fatalf("Start sent keys despite AcceptStartupDialogs=false: %#v", c.cmd)
 		}
+	}
+}
+
+func TestK8sShouldAcceptStartupDialogsUsesProviderDefaults(t *testing.T) {
+	accept := false
+	tests := []struct {
+		name string
+		cfg  runtime.Config
+		want bool
+	}{
+		{
+			name: "codex provider without other startup hints",
+			cfg:  runtime.Config{ProviderName: "codex", Command: "codex"},
+			want: true,
+		},
+		{
+			name: "codex command without provider name",
+			cfg:  runtime.Config{Command: "codex --dangerously-bypass-approvals-and-sandbox"},
+			want: true,
+		},
+		{
+			name: "explicit false remains opt out",
+			cfg:  runtime.Config{ProviderName: "codex", Command: "codex", AcceptStartupDialogs: &accept},
+			want: false,
+		},
+		{
+			name: "plain shell command remains fire and forget",
+			cfg:  runtime.Config{Command: "sh -c 'echo done'"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := k8sShouldAcceptStartupDialogs(tt.cfg); got != tt.want {
+				t.Fatalf("k8sShouldAcceptStartupDialogs() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds Kubernetes runtime provider support for the shared startup-dialog dismissal path.
- Runs K8s startup-dialog checks before setup, after setup, and before the initial nudge so hosted interactive sessions do not strand at trust or permission prompts.
- Treats known interactive provider families (`codex`, `claude`, `gemini`, `kimi`) as dialog-managed by default in Kubernetes even when an agent template does not provide `process_names`, session setup, or an initial nudge.
- Keeps polling an initially blank K8s tmux pane until the startup-dialog timeout instead of treating 300ms of blank output as proof that no dialog will appear.
- Preserves the existing `accept_startup_dialogs = false` opt-out and still closes promptly once content has appeared and then gone quiet.

## Linked Issue

No separate issue: this is a provider parity bug fix. The tmux and exec providers already use the shared startup-dialog handling; the Kubernetes provider had `Peek` and `SendKeys` but did not wire them into startup. The follow-up commits close K8s-only gaps where an interactive provider template names a provider family but omits startup hints, and where tmux is ready before the provider has painted its first trust/hook prompt.

## Reproduction / Validation

Environment: macOS arm64 local development checkout, upstream branch based on current `upstream/main`.

The failure mode is a K8s-hosted interactive provider session reaching a workspace trust prompt or hook-review prompt before its initial prompt/nudge is delivered. The session remains alive but does not process automation until a human accepts the prompt.

Two additional K8s-specific cases are covered:

- A provider template declares an interactive provider such as `codex` but does not set `process_names`, session setup, an initial nudge, or `accept_startup_dialogs`. Kubernetes should still apply the shared dialog classifier for those known interactive provider families; plain shell commands remain fire-and-forget unless they opt into startup dialog handling.
- A pod reaches tmux readiness while the pane is still blank, then paints a trust dialog after the previous 300ms initial-quiet window. Blank output is not a terminal state for interactive providers, so the K8s provider now waits for the normal startup-dialog timeout before concluding that no dialog appeared.

## Tests

Passed:

```bash
go test ./internal/runtime/k8s -count=1
go test ./internal/runtime -run 'Dialog|AcceptStartup|Fingerprint|Runtime' -count=1
go test ./cmd/gc -run 'K8s|SubmitDefaultCodex|TemplateResolve' -count=1
go test ./cmd/gc -run '^TestProbeLiveSessions_TimesOut$' -count=1
```

Focused regression tests added:

- K8s `Start` dismisses a Codex workspace trust prompt before sending the configured nudge.
- K8s `Start` dismisses Codex workspace trust and hook-review prompts for a provider template without startup hints.
- K8s `Start` waits for a delayed Codex trust prompt after an initially blank tmux pane.
- K8s `Start` honors `AcceptStartupDialogs=false` and does not peek/send keys when disabled.
- K8s startup-dialog policy enables known interactive provider families by default and leaves plain shell commands disabled.

Full local fast hook caveat: a local fork pre-commit `test-fast-parallel` attempt exposed unrelated macOS/Dolt timing flakes that reproduced outside this patch scope. A focused `cmd/gc` run later hit `TestProbeLiveSessions_TimesOut` at 259ms against a 250ms ceiling; the same test passed when rerun directly.

## Second-Order Effects

- Local tmux and exec providers are unchanged.
- Kubernetes sessions use the same shared dialog classifier as other providers.
- The explicit opt-out remains authoritative.
- Plain shell commands are not forced into dialog handling unless existing hints or explicit opt-in are present.
- Empty panes for dialog-managed K8s sessions wait for the startup-dialog timeout; non-dialog-managed commands are unaffected.
- Once content has appeared, quiet panes still close quickly to avoid waiting the full timeout after normal readiness.
- No pack, city, or deployment-specific behavior is introduced.

## Privacy Scrub

- No private city names, rig names, agent names, production logs, or local customer data are included.
