### PR TITLE
Hotfix v1.2.1: dedupe builtin auto-includes

### DIFF
--- a/.github/scripts/install-dolt-archive.sh
+++ b/.github/scripts/install-dolt-archive.sh
@@ -56,6 +56,10 @@ esac
 platform_tuple="${os}-${arch}"
 expected_sha=""
 case "${version}:${platform_tuple}" in
+  2.1.0:linux-amd64) expected_sha="0cebb4ac85e7d67b306037735e855cc24939c4a27ae04d712989b325de321826" ;;
+  2.1.0:linux-arm64) expected_sha="a7685fc9c8f91c58093bf9fba1e70bcb7cf68337429db1aa27b9b58e93bc22c9" ;;
+  2.1.0:darwin-amd64) expected_sha="3c2a10a48c55a412e0c3e1424fffeac995e9c0d7124ad4d2406d0252b63c8f3f" ;;
+  2.1.0:darwin-arm64) expected_sha="aef502bb5ee277da60e1bc387e7c0989cbc57ac46c8f36645e8225c408408921" ;;
   2.0.3:linux-amd64) expected_sha="82445e0ef6f2366c78f959ffa225d9b47c78dd4dac9e19d4cd83c814b7dd5135" ;;
   2.0.3:linux-arm64) expected_sha="321ac97f0a44af32eff8004cadef841bc683f683101de96dea2deda6ad86f950" ;;
   2.0.3:darwin-amd64) expected_sha="592e37385313cabe3e96208e4b8edc3e7c05c18c22ee325415c65981320de584" ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     needs: runner-policy
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.1.0"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -172,7 +172,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.1.0"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -198,7 +198,7 @@ jobs:
       - runner-policy
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.1.0"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -297,7 +297,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.1.0"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -429,7 +429,7 @@ jobs:
             timeout_minutes: 15
             command: ./scripts/test-integration-shard rest-full-16-of-16
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.1.0"
       BD_VERSION: "v1.0.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -898,7 +898,7 @@ jobs:
       - name: Pack compatibility tests
         run: make test-acceptance
     env:
-      DOLT_VERSION: "2.0.3"
+      DOLT_VERSION: "2.1.0"
       BD_VERSION: "v1.0.4"
 
   # Dashboard SPA typecheck + tests + build. Runs on every push/PR

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -46,7 +46,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.1.0"
   BD_VERSION: "v1.0.4"
 
 # Trigger gate re-used by every job below via `if:`.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.1.0"
   BD_VERSION: "v1.0.4"
 
 jobs:

--- a/.github/workflows/ollama-acceptance-c.yml
+++ b/.github/workflows/ollama-acceptance-c.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.1.0"
   BD_VERSION: "v1.0.4"
   ANTHROPIC_BASE_URL: https://ollama.com
   ANTHROPIC_API_KEY: ""

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.1.0"
   BD_VERSION: "v1.0.4"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   release:
     name: Release
-    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
       contents: write
@@ -55,7 +55,7 @@ jobs:
 
   attest-release:
     name: Attest release
-    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     needs: release
     runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
@@ -108,7 +108,7 @@ jobs:
 
   update-homebrew-formula:
     name: Update Homebrew formula
-    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     needs: [release, attest-release]
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -38,7 +38,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  DOLT_VERSION: "2.0.3"
+  DOLT_VERSION: "2.1.0"
   BD_VERSION: "v1.0.4"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   published regular-usage pricing is unchanged from Opus 4.7: $5/MTok input
   and $25/MTok output.
 
+### Fixed
+
+- Built-in pack auto-includes now skip packs already reachable from rig pack
+  graphs, preventing duplicate maintenance agents when a rig pack imports a
+  built-in pack transitively.
+
 ## [1.2.0] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Claude Opus 4.8 is now listed in built-in Claude model choices and default
+  pricing. The `opus` model choice targets `claude-opus-4-8`; `opus-4-7`
+  remains available for cities that need the prior Opus target. Anthropic's
+  published regular-usage pricing is unchanged from Opus 4.7: $5/MTok input
+  and $25/MTok output.
+
 ## [1.2.0] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Gas City will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.1] - 2026-05-31
 
 ### Added
 
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Built-in pack auto-includes now skip packs already reachable from rig pack
   graphs, preventing duplicate maintenance agents when a rig pack imports a
   built-in pack transitively.
+- CI, docs, the managed minimum check, and install helpers now pin Dolt 2.1.0
+  so hotfix validation and runtime dependency checks use the same Dolt floor.
 
 ## [1.2.0] - 2026-05-25
 

--- a/cmd/gc/cmd_start_drift_test.go
+++ b/cmd/gc/cmd_start_drift_test.go
@@ -454,6 +454,8 @@ func TestDoStartJSONAlreadyRunningSupervisorKeepsStdoutJSONOnly(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GC_DOLT", "skip")
+			t.Setenv("GC_BEADS", "file")
 			cityPath, setCommit := driftCheckEnv(t, tc.supervisorBuildID)
 			setCommit(tc.localBuildID)
 			if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -260,7 +260,7 @@ func TestBuiltinDoltDoctorAllowsAtMinimumVersionWhenProbeSucceeds(t *testing.T) 
 		name string
 		body string
 	}{
-		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.2\\n'\n"},
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 2.1.0\\n'\n"},
 		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
 		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
 	} {
@@ -276,7 +276,7 @@ func TestBuiltinDoltDoctorAllowsAtMinimumVersionWhenProbeSucceeds(t *testing.T) 
 	if err != nil {
 		t.Fatalf("check-dolt unexpectedly rejected Dolt probe at minimum: %v\n%s", err, out)
 	}
-	if !strings.Contains(string(out), "dolt available (dolt version 1.86.2)") {
+	if !strings.Contains(string(out), "dolt available (dolt version 2.1.0)") {
 		t.Fatalf("check-dolt output = %s, want successful version probe", out)
 	}
 }
@@ -301,7 +301,7 @@ func TestBuiltinDoltDoctorBoundsVersionProbe(t *testing.T) {
 			name: "gtimeout",
 			body: "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$TIMEOUT_CAPTURE\"\nif [ \"$1\" = \"--kill-after=2\" ]; then\n  shift\nfi\nshift\nexec \"$@\"\n",
 		},
-		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 1.86.10\\n'\n"},
+		{name: "dolt", body: "#!/bin/sh\nprintf 'dolt version 2.1.1\\n'\n"},
 		{name: "flock", body: "#!/bin/sh\nexit 0\n"},
 		{name: "lsof", body: "#!/bin/sh\nexit 0\n"},
 	} {

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -793,7 +793,7 @@ func TestCheckHardDependenciesRejectsDoltPreReleaseAtFloor(t *testing.T) {
 	initRunVersion = func(binary string) (string, error) {
 		switch binary {
 		case "dolt":
-			return "dolt version 1.86.2-rc1", nil
+			return "dolt version 2.1.0-rc1", nil
 		case "bd":
 			return "bd version " + bdMinVersion, nil
 		case "flock", "tmux", "jq", "git", "pgrep", "lsof":
@@ -808,7 +808,7 @@ func TestCheckHardDependenciesRejectsDoltPreReleaseAtFloor(t *testing.T) {
 	if len(missing) != 1 {
 		t.Fatalf("missing deps = %#v, want only dolt prerelease rejection", missing)
 	}
-	if !strings.Contains(missing[0].name, "dolt") || !strings.Contains(missing[0].name, "1.86.2-rc1") {
+	if !strings.Contains(missing[0].name, "dolt") || !strings.Contains(missing[0].name, "2.1.0-rc1") {
 		t.Fatalf("missing dep = %#v, want dolt prerelease version in dependency name", missing[0])
 	}
 }

--- a/contrib/k8s/Dockerfile.base
+++ b/contrib/k8s/Dockerfile.base
@@ -12,7 +12,7 @@ FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG CLAUDE_CODE_VERSION=2.1.123
-ARG DOLT_VERSION=2.0.3
+ARG DOLT_VERSION=2.1.0
 
 # System packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/deps.env
+++ b/deps.env
@@ -4,7 +4,7 @@
 # Update these when bumping automation/image pins. The internal/deps package
 # defines minimum compatible versions (may lag behind these pins).
 
-DOLT_VERSION=2.0.3
+DOLT_VERSION=2.1.0
 BD_REPO=gastownhall/beads
 BD_VERSION=v1.0.4
 BR_VERSION=0.1.20

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,14 +26,14 @@ for you; the other methods require manual installation.
 | tmux | Yes | — | `brew install tmux` | `apt install tmux` | Session management |
 | jq | Yes | — | `brew install jq` | `apt install jq` | JSON processing |
 | git | Yes | — | (built-in) | (built-in) | Version control |
-| dolt | Yes | 1.86.2 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
+| dolt | Yes | 2.1.0 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) | Beads data plane |
 | bd (Beads CLI) | Yes | 1.0.0 | `brew install beads` | [releases](https://github.com/gastownhall/beads/releases) | Issue tracking |
 | flock | Yes | — | `brew install flock` | (built-in via util-linux) | File locking |
 | gh | Optional | — | `brew install gh` | [cli.github.com](https://cli.github.com/) | GitHub gate checks |
 | Go 1.25+ | Source only | 1.25 | `brew install go` | [golang.org](https://go.dev/dl/) | Compiler |
 | make | Source only | — | (built-in) | `apt install make` (or `build-essential`) | Drives `make install` |
 
-Use a final Dolt 1.86.2 or newer. Gas City's managed Dolt checks reject older
+Use a final Dolt 2.1.0 or newer. Gas City's managed Dolt checks reject older
 and pre-release builds because they can miss the upstream GC/writer deadlock
 fix in dolthub/dolt commit `ccf7bde206`, which can hang `dolt_backup sync`
 under heavy write load.

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -102,7 +102,7 @@ check.
 
 | Tool | Min version | macOS | Linux |
 |------|-------------|-------|-------|
-| dolt | 1.86.2 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
+| dolt | 2.1.0 or newer | `brew install dolt` | [releases](https://github.com/dolthub/dolt/releases) |
 | bd | 1.0.0 | [releases](https://github.com/gastownhall/beads/releases) | [releases](https://github.com/gastownhall/beads/releases) |
 | flock | -- | `brew install flock` | `apt install util-linux` |
 
@@ -134,7 +134,7 @@ durable versioned storage and is recommended for real work.
 
 ## Dolt Version Too Old
 
-Gas City requires a final Dolt 1.86.2 or newer. Older and pre-release builds
+Gas City requires a final Dolt 2.1.0 or newer. Older and pre-release builds
 can miss the upstream GC/writer deadlock fix in dolthub/dolt commit
 `ccf7bde206`, which can hang `dolt_backup sync` under heavy write load. Check
 your version:

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -384,7 +384,7 @@ ModelPricing is a complete pricing entry for a (Provider, Model) pair.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `provider` | string | **yes** |  | Provider is the LLM provider label (e.g. "claude", "codex", "gemini"). |
-| `model` | string | **yes** |  | Model is the provider-specific model identifier (e.g. "claude-opus-4-7"). |
+| `model` | string | **yes** |  | Model is the provider-specific model identifier (e.g. "claude-opus-4-8"). |
 | `tier` | Tier | **yes** |  | Tier holds the per-token-type rates. |
 | `last_verified` | string | **yes** |  | LastVerified is the date these rates were confirmed (YYYY-MM-DD). |
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1391,7 +1391,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-7\")."
+          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-8\")."
         },
         "tier": {
           "$ref": "#/$defs/Tier",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1391,7 +1391,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-7\")."
+          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-8\")."
         },
         "tier": {
           "$ref": "#/$defs/Tier",

--- a/docs/schema/pack-schema.json
+++ b/docs/schema/pack-schema.json
@@ -591,7 +591,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-7\")."
+          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-8\")."
         },
         "tier": {
           "$ref": "#/$defs/Tier",

--- a/docs/schema/pack-schema.txt
+++ b/docs/schema/pack-schema.txt
@@ -591,7 +591,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-7\")."
+          "description": "Model is the provider-specific model identifier (e.g. \"claude-opus-4-8\")."
         },
         "tier": {
           "$ref": "#/$defs/Tier",

--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -34,7 +34,7 @@ and verifying the result.
 - **Free disk space.** Dolt GC rewrites chunks into a new store before
   swapping; budget at least **2× the current `.dolt/` size** in free space
   on the same filesystem.
-- **Final Dolt 1.86.2 or newer.** This matches the floor enforced by Gas
+- **Final Dolt 2.1.0 or newer.** This matches the floor enforced by Gas
   City's managed Dolt tooling and avoids the upstream GC/writer deadlock fixed
   in dolthub/dolt commit `ccf7bde206`, which can hang `dolt_backup sync` under
   heavy write load. Check with
@@ -82,7 +82,7 @@ If GC finishes but the size barely moves, the chunks are nearly all live
 
 ## Prevention
 
-- **Keep Dolt at a final 1.86.2 or newer.** This matches Gas City's
+- **Keep Dolt at a final 2.1.0 or newer.** This matches Gas City's
   managed-Dolt floor; newer releases ship improved auto-GC heuristics and
   default archive compression.
 - **Let the dolt pack's `mol-dog-compactor` order run continuously.**

--- a/internal/api/event_payloads.go
+++ b/internal/api/event_payloads.go
@@ -310,7 +310,7 @@ type WorkerOperationEventPayload struct {
 	// best-effort. See the consumer contract on the type doc above.
 
 	// Model is the LLM model identifier observed in this operation
-	// (e.g. "claude-opus-4-7"). Sourced from session metadata.
+	// (e.g. "claude-opus-4-8"). Sourced from session metadata.
 	//
 	// Wired: TODO — follow-up will tail sessionlog at finish() to
 	// extract msg.Model.

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1544,12 +1544,13 @@ func trackWorkspace(prov *Provenance, meta toml.MetaData, source string) {
 }
 
 // resolvedPackNames collects pack names that are reachable from a set of
-// top-level include paths and imports. It walks legacy [pack].includes
-// transitively and follows V2 [imports] according to each import's transitive
-// setting so builtin system-pack injection can be skipped when a user pack
-// already brings the same pack into the city closure.
+// top-level include paths and imports. It walks legacy [pack].includes and V2
+// [imports] according to each import's transitive setting so builtin system-pack
+// injection can be skipped when a user pack already brings the same pack into
+// the city closure.
 func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string) map[string]bool {
 	names := make(map[string]bool, len(includes)+len(imports))
+	seenShallowDirs := make(map[string]bool)
 	expandedDirs := make(map[string]bool)
 
 	var visit func(ref, declDir string, transitive bool)
@@ -1562,6 +1563,16 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 		if absErr != nil {
 			absDir = dir
 		}
+		if transitive {
+			if expandedDirs[absDir] {
+				return
+			}
+		} else {
+			if seenShallowDirs[absDir] || expandedDirs[absDir] {
+				return
+			}
+		}
+
 		data, err := sysFS.ReadFile(filepath.Join(dir, packFile))
 		if err != nil {
 			return
@@ -1579,9 +1590,7 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 
 		names[pc.Pack.Name] = true
 		if !transitive {
-			return
-		}
-		if expandedDirs[absDir] {
+			seenShallowDirs[absDir] = true
 			return
 		}
 		expandedDirs[absDir] = true

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -415,7 +415,13 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	rootIncludes := append([]string{}, rootPackIncludes...)
 	rootIncludes = append(rootIncludes, root.Workspace.LegacyIncludes()...)
 	root.Workspace.SetLegacyIncludes(rootIncludes)
-	existingPacks := resolvedPackNames(root.Workspace.LegacyIncludes(), root.Imports, fs, cityRoot)
+
+	// Resolve named pack references before computing reachability so builtin
+	// injection sees the same cache paths that pack expansion will use.
+	resolveNamedPacks(root, cityRoot)
+	rootIncludes = root.Workspace.LegacyIncludes()
+
+	existingPacks := resolvedConfigPackNames(root, fs, cityRoot)
 	for _, inc := range packIncludes {
 		name := readPackNameFromDir(inc)
 		if name != "" && existingPacks[name] {
@@ -427,9 +433,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 
 	adjustPatchPaths(&root.Patches, cityRoot, cityRoot)
 	adjustRigOverridePaths(root.Rigs, cityRoot, cityRoot)
-
-	// Resolve named pack references to cache paths before any expansion.
-	resolveNamedPacks(root, cityRoot)
 
 	implicitImports, implicitPath, implicitData, implicitErr := readImplicitImportsWithData()
 	if implicitErr != nil {
@@ -1541,16 +1544,16 @@ func trackWorkspace(prov *Provenance, meta toml.MetaData, source string) {
 }
 
 // resolvedPackNames collects pack names that are reachable from a set of
-// top-level include paths and imports. It walks both legacy [pack].includes
-// and V2 [imports] transitively so builtin system-pack injection can be
-// skipped when a user pack already brings the same pack into the city
-// closure.
+// top-level include paths and imports. It walks legacy [pack].includes
+// transitively and follows V2 [imports] according to each import's transitive
+// setting so builtin system-pack injection can be skipped when a user pack
+// already brings the same pack into the city closure.
 func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string) map[string]bool {
 	names := make(map[string]bool, len(includes)+len(imports))
-	seenDirs := make(map[string]bool)
+	expandedDirs := make(map[string]bool)
 
-	var visit func(ref, declDir string)
-	visit = func(ref, declDir string) {
+	var visit func(ref, declDir string, transitive bool)
+	visit = func(ref, declDir string, transitive bool) {
 		dir, err := resolvePackRef(ref, declDir, cityRoot)
 		if err != nil {
 			return
@@ -1559,11 +1562,6 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 		if absErr != nil {
 			absDir = dir
 		}
-		if seenDirs[absDir] {
-			return
-		}
-		seenDirs[absDir] = true
-
 		data, err := sysFS.ReadFile(filepath.Join(dir, packFile))
 		if err != nil {
 			return
@@ -1580,20 +1578,47 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 		}
 
 		names[pc.Pack.Name] = true
+		if !transitive {
+			return
+		}
+		if expandedDirs[absDir] {
+			return
+		}
+		expandedDirs[absDir] = true
 		for _, sub := range pc.Pack.Includes {
-			visit(sub, dir)
+			visit(sub, dir, true)
 		}
 		for _, imp := range pc.Imports {
-			visit(imp.Source, dir)
+			visit(imp.Source, dir, imp.ImportIsTransitive())
 		}
 	}
 
 	for _, inc := range includes {
-		visit(inc, cityRoot)
+		visit(inc, cityRoot, true)
 	}
 	for _, imp := range imports {
-		visit(imp.Source, cityRoot)
+		visit(imp.Source, cityRoot, imp.ImportIsTransitive())
 	}
+	return names
+}
+
+// resolvedConfigPackNames collects all pack names reachable from the city,
+// rig, and default-rig pack graphs before builtin extra includes are injected.
+func resolvedConfigPackNames(cfg *City, sysFS fsys.FS, cityRoot string) map[string]bool {
+	names := resolvedPackNames(cfg.Workspace.LegacyIncludes(), cfg.Imports, sysFS, cityRoot)
+	add := func(more map[string]bool) {
+		for name := range more {
+			names[name] = true
+		}
+	}
+
+	for _, rig := range cfg.Rigs {
+		add(resolvedPackNames(rig.Includes, rig.Imports, sysFS, cityRoot))
+	}
+
+	add(resolvedPackNames(cfg.Workspace.LegacyDefaultRigIncludes(), nil, sysFS, cityRoot))
+	add(resolvedPackNames(nil, cfg.DefaultRigImports, sysFS, cityRoot))
+
 	return names
 }
 

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3027,6 +3027,194 @@ includes = ["packs/rigsup"]
 	}
 }
 
+func TestLoadWithIncludes_SkipsExtraIncludeReachableFromRigPackGraph(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/maintenance/agents/dog/agent.toml", `
+scope = "city"
+fallback = true
+`)
+
+	writeFile(t, dir, "packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, "packs/gastown/agents/polecat/agent.toml", `
+scope = "rig"
+`)
+
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "gascity"
+path = "/tmp/gascity"
+includes = ["packs/gastown"]
+`)
+
+	cfg, _, err := LoadWithIncludes(
+		fsys.OSFS{},
+		filepath.Join(dir, "city.toml"),
+		filepath.Join(dir, "packs", "maintenance"),
+	)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	for _, packDir := range cfg.PackDirs {
+		if filepath.Base(packDir) == "maintenance" {
+			t.Fatalf("maintenance was injected at city scope despite being reachable from rig pack graph: PackDirs=%v RigPackDirs=%v",
+				cfg.PackDirs, cfg.RigPackDirs)
+		}
+	}
+	if got := cfg.RigPackDirs["gascity"]; len(got) != 2 {
+		t.Fatalf("rig pack graph dirs = %v, want gastown plus transitive maintenance", got)
+	}
+}
+
+func TestLoadWithIncludes_SkipsExtraIncludeReachableFromNamedRigPackGraph(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/maintenance/agents/dog/agent.toml", `
+scope = "city"
+fallback = true
+`)
+
+	writeFile(t, dir, ".gc/cache/packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, ".gc/cache/packs/maintenance/agents/dog/agent.toml", `
+scope = "city"
+fallback = true
+`)
+
+	writeFile(t, dir, ".gc/cache/packs/gastown/pack.toml", `
+[pack]
+name = "gastown"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, ".gc/cache/packs/gastown/agents/polecat/agent.toml", `
+scope = "rig"
+`)
+
+	writeFile(t, dir, "city.toml", `
+[workspace]
+name = "test"
+
+[packs.gastown]
+source = "https://example.com/gastown.git"
+
+[[rigs]]
+name = "gascity"
+path = "/tmp/gascity"
+includes = ["gastown"]
+`)
+
+	cfg, _, err := LoadWithIncludes(
+		fsys.OSFS{},
+		filepath.Join(dir, "city.toml"),
+		filepath.Join(dir, "packs", "maintenance"),
+	)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	for _, packDir := range cfg.PackDirs {
+		if filepath.Base(packDir) == "maintenance" {
+			t.Fatalf("maintenance was injected at city scope despite being reachable from named rig pack graph: PackDirs=%v RigPackDirs=%v",
+				cfg.PackDirs, cfg.RigPackDirs)
+		}
+	}
+	if got := cfg.RigPackDirs["gascity"]; len(got) != 2 {
+		t.Fatalf("rig pack graph dirs = %v, want gastown plus transitive maintenance", got)
+	}
+}
+
+func TestResolvedPackNames_ExpandsRepeatedSourceWhenAnyVisitIsTransitive(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/shared/pack.toml", `
+[pack]
+name = "shared"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, "packs/wrapper/pack.toml", `
+[pack]
+name = "wrapper"
+schema = 2
+
+[imports.shared]
+source = "../shared"
+transitive = false
+`)
+
+	names := resolvedPackNames([]string{"packs/wrapper"}, map[string]Import{
+		"shared": {Source: "packs/shared"},
+	}, fsys.OSFS{}, dir)
+
+	if !names["maintenance"] {
+		t.Fatalf("maintenance missing after mixed shallow/deep visits: names=%v", names)
+	}
+}
+
+func TestResolvedPackNames_NonTransitiveImportDoesNotCollectDeepDependency(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/shared/pack.toml", `
+[pack]
+name = "shared"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+
+	transitiveFalse := false
+	names := resolvedPackNames(nil, map[string]Import{
+		"shared": {Source: "packs/shared", Transitive: &transitiveFalse},
+	}, fsys.OSFS{}, dir)
+
+	if !names["shared"] {
+		t.Fatalf("shared missing from non-transitive visit: names=%v", names)
+	}
+	if names["maintenance"] {
+		t.Fatalf("maintenance collected through non-transitive import: names=%v", names)
+	}
+}
+
 // agentNamesOf is a small test helper for readable failure messages.
 func agentNamesOf(agents []Agent) []string {
 	names := make([]string, 0, len(agents))

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3215,6 +3215,86 @@ source = "../maintenance"
 	}
 }
 
+func TestResolvedPackNames_NonTransitiveImportDoesNotExposeNestedPack(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/middle/pack.toml", `
+[pack]
+name = "middle"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, "packs/root/pack.toml", `
+[pack]
+name = "root"
+schema = 2
+
+[imports.middle]
+source = "../middle"
+transitive = false
+`)
+
+	names := resolvedPackNames([]string{"packs/root"}, nil, fsys.OSFS{}, dir)
+	if !names["middle"] {
+		t.Fatalf("middle pack was not recorded: names=%v", names)
+	}
+	if names["maintenance"] {
+		t.Fatalf("non-transitive import exposed nested maintenance pack: names=%v", names)
+	}
+}
+
+func TestResolvedPackNames_RevisitsPackReachedFirstThroughNonTransitiveImport(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/middle/pack.toml", `
+[pack]
+name = "middle"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, "packs/shallow/pack.toml", `
+[pack]
+name = "shallow"
+schema = 2
+
+[imports.middle]
+source = "../middle"
+transitive = false
+`)
+	writeFile(t, dir, "packs/deep/pack.toml", `
+[pack]
+name = "deep"
+schema = 2
+
+[imports.middle]
+source = "../middle"
+`)
+
+	for _, includes := range [][]string{
+		{"packs/shallow", "packs/deep"},
+		{"packs/deep", "packs/shallow"},
+	} {
+		names := resolvedPackNames(includes, nil, fsys.OSFS{}, dir)
+		if !names["maintenance"] {
+			t.Fatalf("includes %v did not resolve transitive maintenance after shallow visit: names=%v", includes, names)
+		}
+	}
+}
+
 // agentNamesOf is a small test helper for readable failure messages.
 func agentNamesOf(agents []Agent) []string {
 	names := make([]string, 0, len(agents))

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -70,6 +70,31 @@ func TestBuiltinProvidersClaude(t *testing.T) {
 	}
 }
 
+func TestBuiltinProvidersClaudeModelChoices(t *testing.T) {
+	p := BuiltinProviders()["claude"]
+	var model OptionChoice
+	var oldOpus OptionChoice
+	for _, opt := range p.OptionsSchema {
+		if opt.Key != "model" {
+			continue
+		}
+		for _, choice := range opt.Choices {
+			switch choice.Value {
+			case "opus":
+				model = choice
+			case "opus-4-7":
+				oldOpus = choice
+			}
+		}
+	}
+	if !reflect.DeepEqual(model.FlagArgs, []string{"--model", "claude-opus-4-8"}) {
+		t.Fatalf("opus FlagArgs = %v, want Opus 4.8", model.FlagArgs)
+	}
+	if !reflect.DeepEqual(oldOpus.FlagArgs, []string{"--model", "claude-opus-4-7"}) {
+		t.Fatalf("opus-4-7 FlagArgs = %v, want Opus 4.7 preserved", oldOpus.FlagArgs)
+	}
+}
+
 func TestBuiltinClaudeCommandString(t *testing.T) {
 	// After migration, claude's Args is nil. CommandString() returns just "claude".
 	// Schema-managed flags come from ResolveDefaultArgs() instead.

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -3578,24 +3578,24 @@ func TestCompareDoltVersion(t *testing.T) {
 
 func TestDoltVersionCheck_OK(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.86.2\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 2.1.1\n", nil }
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
-	if !strings.Contains(r.Message, "1.86.2") {
+	if !strings.Contains(r.Message, "2.1.1") {
 		t.Errorf("message = %q, want version in message", r.Message)
 	}
 }
 
 func TestDoltVersionCheck_OK_AtMinimum(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.86.2\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 2.1.0\n", nil }
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("status = %d, want OK; msg = %s", r.Status, r.Message)
 	}
-	if !strings.Contains(r.Message, "1.86.2") {
+	if !strings.Contains(r.Message, "2.1.0") {
 		t.Errorf("message = %q, want version in message", r.Message)
 	}
 }
@@ -3614,7 +3614,7 @@ func TestDoltVersionCheck_Error_BelowManagedConfigFloor(t *testing.T) {
 
 func TestDoltVersionCheck_Error_BelowMinimum(t *testing.T) {
 	c := NewDoltVersionCheck()
-	c.versionOutput = func() (string, error) { return "dolt version 1.86.1\n", nil }
+	c.versionOutput = func() (string, error) { return "dolt version 2.0.10\n", nil }
 	r := c.Run(&CheckContext{})
 	if r.Status != StatusError {
 		t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
@@ -3626,11 +3626,10 @@ func TestDoltVersionCheck_Error_BelowMinimum(t *testing.T) {
 
 func TestDoltVersionCheck_Error_PreReleaseAtFloor(t *testing.T) {
 	cases := []string{
-		"dolt version 1.86.2-rc1\n",
-		"dolt version 1.86.2-rc1+build.5\n",
-		"dolt version 1.86.2-dev.0\n",
-		"dolt version 1.99.0-rc1\n",
-		"dolt version 2.0.0-rc1\n",
+		"dolt version 2.1.0-rc1\n",
+		"dolt version 2.1.0-rc1+build.5\n",
+		"dolt version 2.1.0-dev.0\n",
+		"dolt version 2.1.1-rc1\n",
 	}
 	for _, version := range cases {
 		t.Run(strings.TrimSpace(version), func(t *testing.T) {
@@ -3640,7 +3639,7 @@ func TestDoltVersionCheck_Error_PreReleaseAtFloor(t *testing.T) {
 			if r.Status != StatusError {
 				t.Fatalf("status = %d, want Error; msg = %s", r.Status, r.Message)
 			}
-			if !strings.Contains(r.Message, "pre-release") || !strings.Contains(r.Message, "1.86.2") {
+			if !strings.Contains(r.Message, "pre-release") || !strings.Contains(r.Message, "2.1.0") {
 				t.Errorf("message = %q, want pre-release and minimum version text", r.Message)
 			}
 		})

--- a/internal/doltversion/doltversion.go
+++ b/internal/doltversion/doltversion.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ManagedMin is the minimum Dolt version required for managed bd/Dolt operation.
-const ManagedMin = "1.86.2"
+const ManagedMin = "2.1.0"
 
 var (
 	// ErrPreRelease reports a Dolt version that is not a final release.

--- a/internal/doltversion/doltversion_test.go
+++ b/internal/doltversion/doltversion_test.go
@@ -18,19 +18,19 @@ func TestParse(t *testing.T) {
 	}{
 		{
 			name:      "dolt version prefix",
-			input:     "dolt version 1.86.2",
-			wantRaw:   "1.86.2",
-			wantMajor: 1,
-			wantMinor: 86,
-			wantPatch: 2,
+			input:     "dolt version 2.1.0",
+			wantRaw:   "2.1.0",
+			wantMajor: 2,
+			wantMinor: 1,
+			wantPatch: 0,
 		},
 		{
 			name:      "build metadata",
-			input:     "dolt version 1.86.2+build-5",
-			wantRaw:   "1.86.2",
-			wantMajor: 1,
-			wantMinor: 86,
-			wantPatch: 2,
+			input:     "dolt version 2.1.0+build-5",
+			wantRaw:   "2.1.0",
+			wantMajor: 2,
+			wantMinor: 1,
+			wantPatch: 0,
 		},
 		{
 			name:       "pre-release",
@@ -43,11 +43,11 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:       "pre-release with build metadata",
-			input:      "dolt version 1.86.2-rc1+build.5",
-			wantRaw:    "1.86.2-rc1+build.5",
-			wantMajor:  1,
-			wantMinor:  86,
-			wantPatch:  2,
+			input:      "dolt version 2.1.0-rc1+build.5",
+			wantRaw:    "2.1.0-rc1+build.5",
+			wantMajor:  2,
+			wantMinor:  1,
+			wantPatch:  0,
 			wantPreRel: true,
 		},
 		{
@@ -84,12 +84,12 @@ func TestCheckFinalMinimum(t *testing.T) {
 		input   string
 		wantErr error
 	}{
-		{name: "at floor", input: "dolt version 1.86.2"},
-		{name: "above floor", input: "dolt version 1.86.10"},
-		{name: "below floor", input: "dolt version 1.86.1", wantErr: ErrBelowMinimum},
-		{name: "pre-release at floor", input: "dolt version 1.86.2-rc1", wantErr: ErrPreRelease},
-		{name: "pre-release with build metadata at floor", input: "dolt version 1.86.2-rc1+build.5", wantErr: ErrPreRelease},
-		{name: "pre-release above floor", input: "dolt version 2.0.0-rc1", wantErr: ErrPreRelease},
+		{name: "at floor", input: "dolt version 2.1.0"},
+		{name: "above floor", input: "dolt version 2.1.1"},
+		{name: "below floor", input: "dolt version 2.0.10", wantErr: ErrBelowMinimum},
+		{name: "pre-release at floor", input: "dolt version 2.1.0-rc1", wantErr: ErrPreRelease},
+		{name: "pre-release with build metadata at floor", input: "dolt version 2.1.0-rc1+build.5", wantErr: ErrPreRelease},
+		{name: "pre-release above floor", input: "dolt version 2.1.1-rc1", wantErr: ErrPreRelease},
 	}
 
 	for _, tt := range tests {

--- a/internal/pricing/build_test.go
+++ b/internal/pricing/build_test.go
@@ -7,7 +7,10 @@ import (
 func TestBuildRegistry_DefaultsOnly(t *testing.T) {
 	r := BuildRegistry(nil, nil)
 	if _, ok := r.Lookup("claude", "claude-opus-4-7"); !ok {
-		t.Fatal("expected default Claude pricing in registry")
+		t.Fatal("expected Opus 4.7 Claude pricing in registry")
+	}
+	if _, ok := r.Lookup("claude", "claude-opus-4-8"); !ok {
+		t.Fatal("expected Opus 4.8 Claude pricing in registry")
 	}
 }
 

--- a/internal/pricing/defaults.go
+++ b/internal/pricing/defaults.go
@@ -99,6 +99,18 @@ var claudeDefaults = []ModelPricing{
 			CacheCreationUSDPer1M: 6.25,
 		},
 	},
+	// Claude 4.8 Opus. Regular usage pricing is unchanged from Opus 4.7.
+	{
+		Provider:     "claude",
+		Model:        "claude-opus-4-8",
+		LastVerified: "2026-05-28",
+		Tier: Tier{
+			PromptUSDPer1M:        5.00,
+			CompletionUSDPer1M:    25.00,
+			CacheReadUSDPer1M:     0.50,
+			CacheCreationUSDPer1M: 6.25,
+		},
+	},
 	// Claude 4.5 Haiku.
 	{
 		Provider:     "claude",

--- a/internal/pricing/defaults_test.go
+++ b/internal/pricing/defaults_test.go
@@ -27,6 +27,7 @@ func TestDefaultPricingsCoverKnownClaudeModels(t *testing.T) {
 		"claude-opus-4",
 		"claude-sonnet-4-6",
 		"claude-opus-4-7",
+		"claude-opus-4-8",
 		"claude-haiku-4-5-20251001",
 	}
 	r := New(DefaultPricings())
@@ -61,6 +62,13 @@ func TestDefaultPricingsCurrentClaudeRates(t *testing.T) {
 		},
 		{
 			model:         "claude-opus-4-7",
+			prompt:        5.00,
+			completion:    25.00,
+			cacheRead:     0.50,
+			cacheCreation: 6.25,
+		},
+		{
+			model:         "claude-opus-4-8",
 			prompt:        5.00,
 			completion:    25.00,
 			cacheRead:     0.50,

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -52,7 +52,7 @@ func (t Tier) IsZero() bool {
 type ModelPricing struct {
 	// Provider is the LLM provider label (e.g. "claude", "codex", "gemini").
 	Provider string `toml:"provider" json:"provider"`
-	// Model is the provider-specific model identifier (e.g. "claude-opus-4-7").
+	// Model is the provider-specific model identifier (e.g. "claude-opus-4-8").
 	Model string `toml:"model" json:"model"`
 	// Tier holds the per-token-type rates.
 	Tier Tier `toml:"tier" json:"tier"`

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -144,7 +144,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
-					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-7"}, FlagAliases: [][]string{{"-m", "claude-opus-4-7"}}},
+					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-8"}, FlagAliases: [][]string{{"-m", "claude-opus-4-8"}}},
+					{Value: "opus-4-7", Label: "Opus 4.7", FlagArgs: []string{"--model", "claude-opus-4-7"}, FlagAliases: [][]string{{"-m", "claude-opus-4-7"}}},
 					{Value: "sonnet", Label: "Sonnet", FlagArgs: []string{"--model", "claude-sonnet-4-6"}, FlagAliases: [][]string{{"-m", "claude-sonnet-4-6"}}},
 					{Value: "haiku", Label: "Haiku", FlagArgs: []string{"--model", "claude-haiku-4-5-20251001"}, FlagAliases: [][]string{{"-m", "claude-haiku-4-5-20251001"}}},
 				},

--- a/scripts/dolt_version_pin_test.go
+++ b/scripts/dolt_version_pin_test.go
@@ -1,0 +1,70 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoltVersionPins(t *testing.T) {
+	const doltVersion = "2.1.0"
+
+	root := doltVersionPinRepoRoot(t)
+	assertContains(t, filepath.Join(root, "deps.env"), "DOLT_VERSION="+doltVersion)
+	assertContains(t, filepath.Join(root, "contrib/k8s/Dockerfile.base"), "ARG DOLT_VERSION="+doltVersion)
+	assertContains(t, filepath.Join(root, "internal/doltversion/doltversion.go"), `ManagedMin = "`+doltVersion+`"`)
+	assertContains(t, filepath.Join(root, ".github/scripts/install-dolt-archive.sh"), doltVersion+":linux-amd64")
+	assertContains(t, filepath.Join(root, ".github/scripts/install-dolt-archive.sh"), doltVersion+":linux-arm64")
+	assertContains(t, filepath.Join(root, ".github/scripts/install-dolt-archive.sh"), doltVersion+":darwin-amd64")
+	assertContains(t, filepath.Join(root, ".github/scripts/install-dolt-archive.sh"), doltVersion+":darwin-arm64")
+
+	workflowDir := filepath.Join(root, ".github/workflows")
+	entries, err := os.ReadDir(workflowDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", workflowDir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yml") {
+			continue
+		}
+		path := filepath.Join(workflowDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", path, err)
+		}
+		if strings.Contains(string(content), "DOLT_VERSION:") &&
+			!strings.Contains(string(content), `DOLT_VERSION: "`+doltVersion+`"`) {
+			t.Fatalf("%s has DOLT_VERSION but is not pinned to %s", path, doltVersion)
+		}
+	}
+}
+
+func doltVersionPinRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root")
+		}
+		dir = parent
+	}
+}
+
+func assertContains(t *testing.T, path, want string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	if !strings.Contains(string(content), want) {
+		t.Fatalf("%s does not contain %q", path, want)
+	}
+}


### PR DESCRIPTION
## Summary
- cherry-picks Opus 4.8 model support from `0fe010f02` for the v1.2.1 hotfix line
- cherry-picks the issue #2735 fix from `b17bb30f1` so builtin auto-includes are idempotent against the full rig pack graph
- prevents duplicate maintenance dogs when a rig pack already imports the builtin maintenance pack transitively

## Verification
- `go test ./internal/config -run 'TestLoadWithIncludes_SkipsExtraIncludeReachableFromRigPackGraph|TestProviderModelCanonicalization|TestDefaultProviderModels' -count=1`
- `go test ./internal/pricing ./internal/worker/builtin -count=1`
- `go vet ./...`
- `make test`
