### PR TITLE
chore(deps): adopt mcp-agent-mail security floors

### DIFF
--- a/.github/requirements/mcp-agent-mail.in
+++ b/.github/requirements/mcp-agent-mail.in
@@ -8,6 +8,18 @@ mcp-agent-mail @ https://github.com/Dicklesworthstone/mcp_agent_mail/archive/327
 # line once mcp-agent-mail upstream pins GitPython>=3.1.50 itself.
 gitpython>=3.1.50
 
+# Security floor: urllib3 < 2.7.0 has GHSA-mf9v-mfxr-j63j (HIGH,
+# decompression-bomb safeguards bypassed in parts of the streaming API)
+# and GHSA-qccp-gfcp-xxvc (HIGH, sensitive headers forwarded across
+# origins in proxied low-level redirects). Pinning floor at 2.7.0 until
+# transitive constraints pull a patched version on their own.
+urllib3>=2.7.0
+
+# Security floor: idna < 3.15 has GHSA-65pc-fj4g-8rjx (MEDIUM, IDNA
+# bypass of the CVE-2024-3651 fix). Drop once transitive constraints
+# carry the patched version themselves.
+idna>=3.15
+
 # Authlib and FastMCP security floors live in
 # .github/requirements/mcp-agent-mail.overrides.txt because mcp-agent-mail
 # v0.3.2 still caps Authlib below the fixed release.

--- a/.github/requirements/mcp-agent-mail.txt
+++ b/.github/requirements/mcp-agent-mail.txt
@@ -1063,10 +1063,11 @@ hyperframe==6.1.0 \
     --hash=sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5 \
     --hash=sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08
     # via h2
-idna==3.13 \
-    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
-    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
+idna==3.16 \
+    --hash=sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5 \
+    --hash=sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d
     # via
+    #   -r .github/requirements/mcp-agent-mail.in
     #   anyio
     #   email-validator
     #   httpx
@@ -2669,10 +2670,12 @@ uncalled-for==0.3.2 \
     --hash=sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e \
     --hash=sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2
     # via fastmcp-slim
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
-    # via requests
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+    # via
+    #   -r .github/requirements/mcp-agent-mail.in
+    #   requests
 uvicorn==0.46.0 \
     --hash=sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048 \
     --hash=sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -75,6 +75,33 @@ vulnerabilities:
       - "usr/local/bin/kubectl"
     expired_at: 2026-06-12
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
+  - id: CVE-2026-39823
+    paths:
+      - "usr/bin/gh"
+      - "usr/local/bin/bd"
+      - "usr/local/bin/br"
+      - "usr/local/bin/dolt"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-06-12
+    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
+  - id: CVE-2026-39825
+    paths:
+      - "usr/bin/gh"
+      - "usr/local/bin/bd"
+      - "usr/local/bin/br"
+      - "usr/local/bin/dolt"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-06-12
+    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
+  - id: CVE-2026-39826
+    paths:
+      - "usr/bin/gh"
+      - "usr/local/bin/bd"
+      - "usr/local/bin/br"
+      - "usr/local/bin/dolt"
+      - "usr/local/bin/kubectl"
+    expired_at: 2026-06-12
+    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
   - id: CVE-2026-44431
     paths:
       - "usr/local/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/METADATA"

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -75,43 +75,6 @@ vulnerabilities:
       - "usr/local/bin/kubectl"
     expired_at: 2026-06-12
     statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
-  - id: CVE-2026-39823
-    paths:
-      - "usr/bin/gh"
-      - "usr/local/bin/bd"
-      - "usr/local/bin/br"
-      - "usr/local/bin/dolt"
-      - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
-    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
-  - id: CVE-2026-39825
-    paths:
-      - "usr/bin/gh"
-      - "usr/local/bin/bd"
-      - "usr/local/bin/br"
-      - "usr/local/bin/dolt"
-      - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
-    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
-  - id: CVE-2026-39826
-    paths:
-      - "usr/bin/gh"
-      - "usr/local/bin/bd"
-      - "usr/local/bin/br"
-      - "usr/local/bin/dolt"
-      - "usr/local/bin/kubectl"
-    expired_at: 2026-06-12
-    statement: Upstream gh, bd, br, dolt, and kubectl embed Go 1.26.2 stdlib; remove once each rebuilds against 1.26.3+ (or 1.25.10+).
-  - id: CVE-2026-44431
-    paths:
-      - "usr/local/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/METADATA"
-    expired_at: 2026-06-12
-    statement: mcp-agent-mail v0.3.2 transitive pin keeps urllib3 on 2.6.3; remove after upstream accepts urllib3 2.7.0 or later.
-  - id: CVE-2026-44432
-    paths:
-      - "usr/local/lib/python3.12/site-packages/urllib3-2.6.3.dist-info/METADATA"
-    expired_at: 2026-06-12
-    statement: mcp-agent-mail v0.3.2 transitive pin keeps urllib3 on 2.6.3; remove after upstream accepts urllib3 2.7.0 or later.
   - id: CVE-2026-41602
     paths:
       - "usr/local/bin/dolt"
@@ -120,8 +83,8 @@ vulnerabilities:
   - id: CVE-2026-34986
     paths:
       - "usr/local/bin/bd"
-    expired_at: 2026-05-29
-    statement: Latest bd v1.0.3 still embeds go-jose v4.1.3; remove after a beads release includes go-jose v4.1.4 or later.
+    expired_at: 2026-06-12
+    statement: Latest bd v1.0.4 still embeds go-jose v4.1.3; remove after a beads release includes go-jose v4.1.4 or later.
   - id: CVE-2026-41602
     paths:
       - "usr/local/bin/bd"


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/2680.

Original PR title: chore(deps): bump urllib3 and idna security floors for mcp-agent-mail
Original PR state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

This maintainer follow-up carries the original mcp-agent-mail dependency security floor work through the current `main` base. The normal update to the contributor fork branch was rejected as non-fast-forward after the required base refresh replayed the adopted patch, so this branch provides a safe merge surface without force-pushing the contributor branch.

Included changes:
- Preserve the contributor's mcp-agent-mail security floor updates for `urllib3>=2.7.0` and `idna>=3.15`, with the hashed lock resolving to `urllib3==2.7.0` and `idna==3.16`.
- Preserve the Go 1.26.2 stdlib Trivy suppressions needed for upstream binaries while they are waiting on rebuilt releases.
- Remove obsolete urllib3 2.6.3 Trivy suppressions and refresh the bd/go-jose suppression expiry after review found the old ignore state would drift.

Review summary:
- The final adopted patch was replayed onto current `main` with the same stable patch ID.
- The review/fix loop resolved the stale urllib3 suppression issue, duplicate Go stdlib suppression issue, and expired bd/go-jose suppression issue.
- Remaining notes are non-gating cleanup for adjacent Trivy suppression statements: verify the bd thrift statement version and the Dolt thrift statement version in a later maintenance pass.

Validation:
- `git diff --check refs/adopt-pr/ga-kw7lr/upstream-base..HEAD`
- Adopt-pr approval guard passed for the refreshed final head.
