### PR TITLE
fix(tmux): adopt startup dead-pane diagnostics

### DIFF
--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -694,6 +694,7 @@ const (
 	minReadyProbeTimeout     = 5 * time.Second
 	maxReadyProbeTimeout     = 60 * time.Second
 	readyProbeSlack          = 5 * time.Second
+	startupPaneCaptureLines  = 80
 )
 
 func (o *tmuxStartOps) createSession(name, workDir, command string, env map[string]string) error {
@@ -813,15 +814,19 @@ func ignoreDeadlineIfSessionAlive(ops startOps, name string, err error) error {
 }
 
 func startupDeadSessionError(ops startOps, name string) error {
-	pane, err := ops.capturePane(name, 80)
+	pane, err := ops.capturePane(name, startupPaneCaptureLines)
 	if err != nil {
-		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
+		return startupSessionDiedError(name)
 	}
 	pane = strings.TrimSpace(pane)
 	if pane == "" {
-		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
+		return startupSessionDiedError(name)
 	}
 	return fmt.Errorf("%w: session %q; last pane output:\n%s", runtime.ErrSessionDiedDuringStartup, name, pane)
+}
+
+func startupSessionDiedError(name string) error {
+	return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
 }
 
 func failIfSessionDiedDuringStartupProbe(ops startOps, name string) error {
@@ -934,7 +939,10 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 	if err != nil {
 		return fmt.Errorf("verifying session: %w", err)
 	}
-	if !alive || !ops.isSessionRunning(name) {
+	if !alive {
+		return startupSessionDiedError(name)
+	}
+	if !ops.isSessionRunning(name) {
 		return startupDeadSessionError(ops, name)
 	}
 

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -679,6 +679,7 @@ type startOps interface {
 	acceptStartupDialogs(ctx context.Context, name string) error
 	waitForReady(ctx context.Context, name string, rc *RuntimeConfig, timeout time.Duration) error
 	hasSession(name string) (bool, error)
+	capturePane(name string, lines int) (string, error)
 	sendKeys(name, text string) error
 	setRemainOnExit(name string) error
 	disableMouseAndActivity(name string) error
@@ -738,6 +739,10 @@ func (o *tmuxStartOps) waitForReady(ctx context.Context, name string, rc *Runtim
 
 func (o *tmuxStartOps) hasSession(name string) (bool, error) {
 	return o.tm.HasSession(name)
+}
+
+func (o *tmuxStartOps) capturePane(name string, lines int) (string, error) {
+	return o.tm.CapturePane(name, lines)
 }
 
 func (o *tmuxStartOps) sendKeys(name, text string) error {
@@ -802,6 +807,29 @@ func ignoreDeadlineIfSessionAlive(ops startOps, name string, err error) error {
 		return nil
 	}
 	return err
+}
+
+func startupDeadSessionError(ops startOps, name string) error {
+	pane, err := ops.capturePane(name, 80)
+	if err != nil {
+		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
+	}
+	pane = strings.TrimSpace(pane)
+	if pane == "" {
+		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
+	}
+	return fmt.Errorf("%w: session %q; last pane output:\n%s", runtime.ErrSessionDiedDuringStartup, name, pane)
+}
+
+func failIfSessionDiedDuringStartupProbe(ops startOps, name string) error {
+	alive, err := ops.hasSession(name)
+	if err != nil {
+		return fmt.Errorf("verifying session after startup probe: %w", err)
+	}
+	if alive {
+		return nil
+	}
+	return startupDeadSessionError(ops, name)
 }
 
 // doStartSession is the pure startup orchestration logic.
@@ -875,7 +903,11 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 			ReadyDelayMs:      cfg.ReadyDelayMs,
 			ProcessNames:      cfg.ProcessNames,
 		}}
-		_ = ops.waitForReady(ctx, name, rc, startupReadyProbeTimeout(cfg)) // best-effort
+		if err := ops.waitForReady(ctx, name, rc, startupReadyProbeTimeout(cfg)); err != nil {
+			if deadErr := failIfSessionDiedDuringStartupProbe(ops, name); deadErr != nil {
+				return deadErr
+			}
+		}
 		if err := ctx.Err(); err != nil {
 			return ignoreDeadlineIfSessionAlive(ops, name, err)
 		}
@@ -897,7 +929,7 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 		return fmt.Errorf("verifying session: %w", err)
 	}
 	if !alive {
-		return fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, name)
+		return startupDeadSessionError(ops, name)
 	}
 
 	// Step 5.5: Run session setup commands and script.

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -803,8 +803,11 @@ func ignoreDeadlineIfSessionAlive(ops startOps, name string, err error) error {
 	if hasErr != nil {
 		return fmt.Errorf("verifying session after ready deadline: %w", hasErr)
 	}
-	if alive {
+	if alive && ops.isSessionRunning(name) {
 		return nil
+	}
+	if alive {
+		return startupDeadSessionError(ops, name)
 	}
 	return err
 }
@@ -826,10 +829,13 @@ func failIfSessionDiedDuringStartupProbe(ops startOps, name string) error {
 	if err != nil {
 		return fmt.Errorf("verifying session after startup probe: %w", err)
 	}
-	if alive {
+	if alive && ops.isSessionRunning(name) {
 		return nil
 	}
-	return startupDeadSessionError(ops, name)
+	if alive {
+		return startupDeadSessionError(ops, name)
+	}
+	return nil
 }
 
 // doStartSession is the pure startup orchestration logic.
@@ -928,7 +934,7 @@ func doStartSession(ctx context.Context, ops startOps, name string, cfg runtime.
 	if err != nil {
 		return fmt.Errorf("verifying session: %w", err)
 	}
-	if !alive {
+	if !alive || !ops.isSessionRunning(name) {
 		return startupDeadSessionError(ops, name)
 	}
 

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -63,6 +63,8 @@ type fakeStartOps struct {
 	disableMouseAndActivityErr error
 	runSetupCommandErr         error
 	sendKeysErr                error
+	capturePaneText            string
+	capturePaneErr             error
 }
 
 type errReader struct{}
@@ -169,6 +171,11 @@ func (f *fakeStartOps) setRemainOnExit(name string) error {
 func (f *fakeStartOps) disableMouseAndActivity(name string) error {
 	f.calls = append(f.calls, startCall{method: "disableMouseAndActivity", name: name})
 	return f.disableMouseAndActivityErr
+}
+
+func (f *fakeStartOps) capturePane(name string, lines int) (string, error) {
+	f.calls = append(f.calls, startCall{method: "capturePane", name: name})
+	return f.capturePaneText, f.capturePaneErr
 }
 
 func (f *fakeStartOps) runSetupCommand(_ context.Context, cmd string, env map[string]string, timeout time.Duration) error {
@@ -579,6 +586,47 @@ func TestDoStartSession_SessionDiesDuringStartup(t *testing.T) {
 	if !errors.Is(err, runtime.ErrSessionDiedDuringStartup) {
 		t.Errorf("error = %v, want ErrSessionDiedDuringStartup", err)
 	}
+}
+
+func TestDoStartSession_ReadyDeadlineWithDeadPaneReportsProviderCrash(t *testing.T) {
+	ops := &fakeStartOps{
+		waitReadyErr:     context.DeadlineExceeded,
+		hasSessionResult: false,
+		capturePaneText: "WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\n" +
+			"Error: Operation not permitted (os error 1)\n" +
+			"Pane is dead",
+	}
+
+	cfg := runtime.Config{
+		Command:           "codex",
+		ProcessNames:      []string{"codex"},
+		ReadyPromptPrefix: "› ",
+	}
+
+	err := doStartSession(context.Background(), ops, "mayor", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, runtime.ErrSessionDiedDuringStartup) {
+		t.Fatalf("error = %v, want ErrSessionDiedDuringStartup", err)
+	}
+	if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("error = %v, should not surface generic deadline after pane died", err)
+	}
+	for _, want := range []string{"session \"mayor\"", "Operation not permitted", "Pane is dead"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
+		}
+	}
+	assertCallSequence(t, ops, []string{
+		"createSession",
+		"setRemainOnExit",
+		"waitForCommand",
+		"acceptStartupDialogs",
+		"waitForReady",
+		"hasSession",
+		"capturePane",
+	})
 }
 
 func TestDoStartSession_HasSessionError(t *testing.T) {

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -173,7 +173,7 @@ func (f *fakeStartOps) disableMouseAndActivity(name string) error {
 	return f.disableMouseAndActivityErr
 }
 
-func (f *fakeStartOps) capturePane(name string, lines int) (string, error) {
+func (f *fakeStartOps) capturePane(name string, _ int) (string, error) {
 	f.calls = append(f.calls, startCall{method: "capturePane", name: name})
 	return f.capturePaneText, f.capturePaneErr
 }
@@ -228,6 +228,20 @@ func methodIndex(methods []string, method string) int {
 		}
 	}
 	return -1
+}
+
+func callsByMethod(t *testing.T, ops *fakeStartOps, method string, wantCount int) []startCall {
+	t.Helper()
+	var matches []startCall
+	for _, call := range ops.calls {
+		if call.method == method {
+			matches = append(matches, call)
+		}
+	}
+	if len(matches) != wantCount {
+		t.Fatalf("%s calls = %d, want %d; all calls = %v", method, len(matches), wantCount, ops.callMethods())
+	}
+	return matches
 }
 
 // ---------------------------------------------------------------------------
@@ -589,6 +603,41 @@ func TestDoStartSession_SessionDiesDuringStartup(t *testing.T) {
 	}
 }
 
+func TestDoStartSession_MissingFinalSessionDoesNotCapturePrefixSibling(t *testing.T) {
+	ops := &fakeStartOps{
+		hasSessionResult: false,
+		capturePaneText:  "prefix sibling output must not leak",
+	}
+
+	cfg := runtime.Config{
+		Command:      "codex",
+		ProcessNames: []string{"codex"},
+	}
+
+	err := doStartSession(context.Background(), ops, "mayor", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, runtime.ErrSessionDiedDuringStartup) {
+		t.Fatalf("error = %v, want ErrSessionDiedDuringStartup", err)
+	}
+	if !strings.Contains(err.Error(), "session \"mayor\"") {
+		t.Fatalf("error = %v, want session name", err)
+	}
+	if strings.Contains(err.Error(), "prefix sibling output") || strings.Contains(err.Error(), "last pane output") {
+		t.Fatalf("error = %v, should not include pane output for missing exact session", err)
+	}
+	assertCallSequence(t, ops, []string{
+		"createSession",
+		"setRemainOnExit",
+		"disableMouseAndActivity",
+		"waitForCommand",
+		"acceptStartupDialogs",
+		"acceptStartupDialogs",
+		"hasSession",
+	})
+}
+
 func TestDoStartSession_ReadyDeadlineWithDeadPaneReportsProviderCrash(t *testing.T) {
 	running := false
 	ops := &fakeStartOps{
@@ -624,9 +673,87 @@ func TestDoStartSession_ReadyDeadlineWithDeadPaneReportsProviderCrash(t *testing
 	assertCallSequence(t, ops, []string{
 		"createSession",
 		"setRemainOnExit",
+		"disableMouseAndActivity",
 		"waitForCommand",
 		"acceptStartupDialogs",
 		"waitForReady",
+		"hasSession",
+		"isSessionRunning",
+		"capturePane",
+	})
+}
+
+func TestDoStartSession_FinalDeadPaneReportsProviderCrash(t *testing.T) {
+	running := false
+	ops := &fakeStartOps{
+		hasSessionResult:       true,
+		isSessionRunningResult: &running,
+		capturePaneText:        "panic: startup failed\nPane is dead",
+	}
+
+	cfg := runtime.Config{
+		Command:      "codex",
+		ProcessNames: []string{"codex"},
+	}
+
+	err := doStartSession(context.Background(), ops, "mayor", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, runtime.ErrSessionDiedDuringStartup) {
+		t.Fatalf("error = %v, want ErrSessionDiedDuringStartup", err)
+	}
+	for _, want := range []string{"session \"mayor\"", "startup failed", "Pane is dead"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
+		}
+	}
+	assertCallSequence(t, ops, []string{
+		"createSession",
+		"setRemainOnExit",
+		"disableMouseAndActivity",
+		"waitForCommand",
+		"acceptStartupDialogs",
+		"acceptStartupDialogs",
+		"hasSession",
+		"isSessionRunning",
+		"capturePane",
+	})
+}
+
+func TestDoStartSession_FinalDeadPaneCaptureErrorFallsBack(t *testing.T) {
+	running := false
+	ops := &fakeStartOps{
+		hasSessionResult:       true,
+		isSessionRunningResult: &running,
+		capturePaneErr:         errors.New("capture failed"),
+	}
+
+	cfg := runtime.Config{
+		Command:      "codex",
+		ProcessNames: []string{"codex"},
+	}
+
+	err := doStartSession(context.Background(), ops, "mayor", cfg, DefaultConfig().SetupTimeout)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, runtime.ErrSessionDiedDuringStartup) {
+		t.Fatalf("error = %v, want ErrSessionDiedDuringStartup", err)
+	}
+	if !strings.Contains(err.Error(), "session \"mayor\"") {
+		t.Fatalf("error = %v, want session name", err)
+	}
+	if strings.Contains(err.Error(), "last pane output") || strings.Contains(err.Error(), "capture failed") {
+		t.Fatalf("error = %v, want fallback without pane/capture detail", err)
+	}
+	assertCallSequence(t, ops, []string{
+		"createSession",
+		"setRemainOnExit",
+		"disableMouseAndActivity",
+		"waitForCommand",
+		"acceptStartupDialogs",
+		"acceptStartupDialogs",
 		"hasSession",
 		"isSessionRunning",
 		"capturePane",
@@ -1216,12 +1343,12 @@ func TestDoStartSession_SessionSetupRunsAfterAlive(t *testing.T) {
 		"runSetupCommand",
 	})
 
-	// Verify both commands were recorded.
-	cmd1 := ops.calls[7]
+	setupCalls := callsByMethod(t, ops, "runSetupCommand", 2)
+	cmd1 := setupCalls[0]
 	if cmd1.command != "tmux set-option -t test status-style 'bg=blue'" {
 		t.Errorf("setup cmd[0] = %q, want status-style command", cmd1.command)
 	}
-	cmd2 := ops.calls[8]
+	cmd2 := setupCalls[1]
 	if cmd2.command != "tmux set-option -t test mouse on" {
 		t.Errorf("setup cmd[1] = %q, want mouse command", cmd2.command)
 	}
@@ -1265,17 +1392,20 @@ func TestDoStartSession_SessionSetupScriptRunsAfterCommands(t *testing.T) {
 		"sendKeys",
 	})
 
+	setupCalls := callsByMethod(t, ops, "runSetupCommand", 2)
+	nudgeCalls := callsByMethod(t, ops, "sendKeys", 1)
+
 	// First runSetupCommand = inline command.
-	if ops.calls[7].command != "tmux set mouse on" {
-		t.Errorf("setup[0] = %q, want inline command", ops.calls[7].command)
+	if setupCalls[0].command != "tmux set mouse on" {
+		t.Errorf("setup[0] = %q, want inline command", setupCalls[0].command)
 	}
 	// Second runSetupCommand = script.
-	if ops.calls[8].command != "/city/scripts/setup.sh" {
-		t.Errorf("setup[1] = %q, want script", ops.calls[8].command)
+	if setupCalls[1].command != "/city/scripts/setup.sh" {
+		t.Errorf("setup[1] = %q, want script", setupCalls[1].command)
 	}
 	// sendKeys = nudge.
-	if ops.calls[9].command != "start working" {
-		t.Errorf("nudge = %q, want %q", ops.calls[9].command, "start working")
+	if nudgeCalls[0].command != "start working" {
+		t.Errorf("nudge = %q, want %q", nudgeCalls[0].command, "start working")
 	}
 }
 

--- a/internal/runtime/tmux/startup_test.go
+++ b/internal/runtime/tmux/startup_test.go
@@ -372,6 +372,7 @@ func TestDoStartSession_FullSequence(t *testing.T) {
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	// Verify createSession got full config.
@@ -589,9 +590,11 @@ func TestDoStartSession_SessionDiesDuringStartup(t *testing.T) {
 }
 
 func TestDoStartSession_ReadyDeadlineWithDeadPaneReportsProviderCrash(t *testing.T) {
+	running := false
 	ops := &fakeStartOps{
-		waitReadyErr:     context.DeadlineExceeded,
-		hasSessionResult: false,
+		waitReadyErr:           context.DeadlineExceeded,
+		hasSessionResult:       true,
+		isSessionRunningResult: &running,
 		capturePaneText: "WARNING: proceeding, even though we could not update PATH: Operation not permitted (os error 1)\n" +
 			"Error: Operation not permitted (os error 1)\n" +
 			"Pane is dead",
@@ -625,6 +628,7 @@ func TestDoStartSession_ReadyDeadlineWithDeadPaneReportsProviderCrash(t *testing
 		"acceptStartupDialogs",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 		"capturePane",
 	})
 }
@@ -677,6 +681,7 @@ func TestDoStartSession_ProcessNamesOnly(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	// Verify isRuntimeRunning sees the process names in zombie detection path.
@@ -708,6 +713,7 @@ func TestDoStartSession_KimiSkipsStartupDialogAcceptance(t *testing.T) {
 		"waitForCommand",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -738,6 +744,7 @@ func TestDoStartSessionReturnsNudgeDeliveryError(t *testing.T) {
 		"setRemainOnExit",
 		"disableMouseAndActivity",
 		"hasSession",
+		"isSessionRunning",
 		"sendKeys",
 	})
 }
@@ -764,6 +771,7 @@ func TestDoStartSession_AcceptStartupDialogsOnly(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -845,6 +853,7 @@ func TestDoStartSession_ReadyPromptPrefixOnly(t *testing.T) {
 		"disableMouseAndActivity",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	// Verify RuntimeConfig carries the prefix.
@@ -875,6 +884,7 @@ func TestDoStartSession_ReadyDelayOnly(t *testing.T) {
 		"disableMouseAndActivity",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	// Verify RuntimeConfig carries the delay.
@@ -916,6 +926,7 @@ func TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive(t *tes
 		"acceptStartupDialogs",
 		"waitForReady",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -956,6 +967,7 @@ func TestDoStartSession_TreatsDeadlineAfterPostReadyAsSuccessWhenSessionAlive(t 
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -983,6 +995,7 @@ func TestDoStartSession_EmitsPermissionWarningOnly(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -1012,6 +1025,7 @@ func TestDoStartSession_ProcessNamesAndReadyPrefix(t *testing.T) {
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -1041,6 +1055,7 @@ func TestDoStartSession_CursorReadinessHintsTriggerRuntimeWait(t *testing.T) {
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 
 	wfr := ops.calls[5]
@@ -1080,6 +1095,7 @@ func TestDoStartSession_ProcessNamesAndReadyDelayRechecksDialogs(t *testing.T) {
 		"waitForReady",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 	})
 }
 
@@ -1195,6 +1211,7 @@ func TestDoStartSession_SessionSetupRunsAfterAlive(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 		"runSetupCommand",
 		"runSetupCommand",
 	})
@@ -1242,6 +1259,7 @@ func TestDoStartSession_SessionSetupScriptRunsAfterCommands(t *testing.T) {
 		"acceptStartupDialogs",
 		"acceptStartupDialogs",
 		"hasSession",
+		"isSessionRunning",
 		"runSetupCommand",
 		"runSetupCommand",
 		"sendKeys",
@@ -1386,7 +1404,7 @@ func TestDoStartSession_PreStartRunsBeforeCreate(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	assertCallSequence(t, ops, []string{"runSetupCommand", "createSession", "setRemainOnExit", "disableMouseAndActivity", "hasSession"})
+	assertCallSequence(t, ops, []string{"runSetupCommand", "createSession", "setRemainOnExit", "disableMouseAndActivity", "hasSession", "isSessionRunning"})
 
 	pre := ops.calls[0]
 	if pre.command != "setup-worktree" {


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/2685.

Original PR title: Report tmux startup dead-pane diagnostics
Original PR state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

This maintainer follow-up carries the original tmux startup diagnostic work through the current `main` base. The normal update to the contributor fork branch was rejected as non-fast-forward after the required base refresh replayed the adopted patch, so this branch provides a safe merge surface without force-pushing the contributor branch.

Included changes:
- Report tmux startup dead-pane diagnostics instead of collapsing that path into a generic startup timeout.
- Detect dead tmux panes during startup readiness probes and preserve the last pane output in `ErrSessionDiedDuringStartup`.
- Add regression coverage for the startup probe failure path and keep the tmux startup tests lint-clean after the current-base replay.

Review summary:
- The final adopted patch was replayed onto current `main` with the same stable patch ID.
- The review/fix loop validated immediate dead-pane detection, preserved pane output, and regression coverage for the EPERM/PATH crash path.
- Remaining notes are non-gating: the error text is intentionally longer because it carries the diagnostic payload, and future tmux changes should keep the tmux startup tests green.

Validation:
- `git diff --check refs/adopt-pr/ga-wtrau/upstream-base..HEAD`
- `go test ./internal/runtime/tmux`
- Adopt-pr approval guard passed for the refreshed final head.
