### PR TITLE
test(pack): smoke main registry imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,11 +264,12 @@ test-fsys-darwin-compile:
 ## test-pack-registry-live: run the opt-in gascity-packs registry canary
 test-pack-registry-live:
 	@if [ -z "$${GC_TEST_GASCITY_PACKS_REGISTRY:-}" ]; then \
-		echo "Set GC_TEST_GASCITY_PACKS_REGISTRY to a gascity-packs registry.toml source"; \
-		echo "Example: GC_TEST_GASCITY_PACKS_REGISTRY=/Users/dbox/repos/gc/wt/gascity-packs-public-builtins/registry.toml make test-pack-registry-live"; \
+		echo "Set GC_TEST_GASCITY_PACKS_REGISTRY to main or a gascity-packs registry.toml source"; \
+		echo "Example: GC_TEST_GASCITY_PACKS_REGISTRY=main make test-pack-registry-live"; \
 		exit 2; \
 	fi
 	$(TEST_ENV) GC_TEST_GASCITY_PACKS_REGISTRY="$${GC_TEST_GASCITY_PACKS_REGISTRY}" go test ./cmd/gc -run '^TestPackRegistryLiveGascityPacksCatalog$$' -count=1
+	$(TEST_ENV) GC_TEST_GASCITY_PACKS_REGISTRY="$${GC_TEST_GASCITY_PACKS_REGISTRY}" go test -tags acceptance_a -timeout 10m ./test/acceptance -run '^TestPackRegistryLiveImportsEveryCatalogPack$$' -count=1
 
 ## test-cmd-gc-process: run the full non-short cmd/gc suite, including the
 ## process-backed lifecycle coverage routed out of the default fast loop

--- a/cmd/gc/cmd_pack_registry.go
+++ b/cmd/gc/cmd_pack_registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -435,7 +436,7 @@ func doPackRegistrySearch(query, registry string, refresh bool, limit int, all b
 				fmt.Fprintf(stderr, "warning: registry %s refresh failed: %v\n", reg.Name, err) //nolint:errcheck
 			}
 		}
-		catalog, _, err := packregistry.ReadCachedRegistryCatalog(home, reg)
+		catalog, err := readPackRegistryCatalogForCommand(context.Background(), home, reg, !refresh)
 		if err != nil {
 			failures++
 			cacheFailures = append(cacheFailures, packRegistryFailureJSON{Name: reg.Name, Message: err.Error()})
@@ -544,7 +545,7 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 				fmt.Fprintf(stderr, "warning: registry %s refresh failed: %v\n", reg.Name, err) //nolint:errcheck
 			}
 		}
-		catalog, _, err := packregistry.ReadCachedRegistryCatalog(home, reg)
+		catalog, err := readPackRegistryCatalogForCommand(context.Background(), home, reg, !refresh)
 		if err != nil {
 			unavailable = append(unavailable, reg.Name)
 			continue
@@ -609,6 +610,17 @@ func doPackRegistryShow(target string, refresh bool, jsonOutput bool, stdout, st
 		}
 	}
 	return 0
+}
+
+func readPackRegistryCatalogForCommand(ctx context.Context, home string, reg packregistry.Registry, refreshMissing bool) (packregistry.Catalog, error) {
+	catalog, _, err := packregistry.ReadCachedRegistryCatalog(home, reg)
+	if err == nil {
+		return catalog, nil
+	}
+	if !refreshMissing || !os.IsNotExist(err) {
+		return packregistry.Catalog{}, err
+	}
+	return packregistry.RefreshRegistry(ctx, home, reg, packregistry.FetchOptions{})
 }
 
 func warnStaleRegistryCache(home, registry string, stderr io.Writer) {

--- a/cmd/gc/cmd_pack_registry_json_test.go
+++ b/cmd/gc/cmd_pack_registry_json_test.go
@@ -14,6 +14,7 @@ import (
 func TestPackRegistryJSONOutputMatchesSchemas(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 
 	runPackRegistryJSONAndValidate(t, []string{"pack", "registry", "add", "main", catalogDir, "--json"})
@@ -27,6 +28,7 @@ func TestPackRegistryJSONOutputMatchesSchemas(t *testing.T) {
 func TestPackRegistryJSONOutputMatchesSchemasForFlagCombinations(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	goodDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 	otherDir := writeRegistryCatalog(t, packRegistryOtherCatalog)
 
@@ -45,6 +47,7 @@ func TestPackRegistryJSONOutputMatchesSchemasForFlagCombinations(t *testing.T) {
 func TestPackRegistryJSONFailureMatchesFailureSchema(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 	otherDir := writeRegistryCatalog(t, packRegistryOtherCatalog)
 
@@ -72,6 +75,7 @@ func TestPackRegistryJSONFailureMatchesFailureSchema(t *testing.T) {
 func TestPackRegistryRefreshJSONAllFailuresUsesResultSchemaWithNonzeroExit(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	runPackRegistryJSONAndValidate(t, []string{"pack", "registry", "add", "bad", filepath.Join(t.TempDir(), "missing"), "--no-validate", "--json"})
 	runPackRegistryJSONAndValidateExitCode(t, []string{"pack", "registry", "refresh", "--json"}, 1)
 }

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -143,13 +143,17 @@ func TestPackRegistryCommandsPreRegisterDefaultRegistryOnVanillaHome(t *testing.
 		t.Fatalf("list output = %q, want default main registry", stdout.String())
 	}
 
+	if err := packregistry.WriteCatalogCache(home, packregistry.DefaultRegistryName, []byte(packRegistryTestCatalog)); err != nil {
+		t.Fatalf("WriteCatalogCache(default main): %v", err)
+	}
+
 	stdout.Reset()
 	stderr.Reset()
-	if code := doPackRegistrySearch("gastown", "", false, 50, false, false, &stdout, &stderr); code != 0 {
+	if code := doPackRegistrySearch("light", "", false, 50, false, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("search code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "gastown") || strings.Contains(stderr.String(), "cache unavailable") {
-		t.Fatalf("search output = stdout=%q stderr=%q, want default main results without cache warning", stdout.String(), stderr.String())
+	if !strings.Contains(stdout.String(), "lighthouse") || strings.Contains(stderr.String(), "cache unavailable") {
+		t.Fatalf("search output = stdout=%q stderr=%q, want default main cached results without cache warning", stdout.String(), stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -77,10 +77,11 @@ source_kind = "git"
 func TestPackRegistryAddListSearchShowRemove(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 
 	var stdout, stderr bytes.Buffer
-	if code := doPackRegistryAdd("main", catalogDir, false, false, &stdout, &stderr); code != 0 {
+	if code := doPackRegistryAdd("local", catalogDir, false, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
 
@@ -89,7 +90,7 @@ func TestPackRegistryAddListSearchShowRemove(t *testing.T) {
 	if code := doPackRegistryList(false, &stdout, &stderr); code != 0 {
 		t.Fatalf("list code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "main") || !strings.Contains(stdout.String(), catalogDir) {
+	if !strings.Contains(stdout.String(), "local") || !strings.Contains(stdout.String(), catalogDir) {
 		t.Fatalf("list output missing registry: %q", stdout.String())
 	}
 
@@ -107,16 +108,16 @@ func TestPackRegistryAddListSearchShowRemove(t *testing.T) {
 	if code := doPackRegistryShow("lighthouse", false, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("show code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "main:lighthouse") || !strings.Contains(stdout.String(), "1.2.0") {
+	if !strings.Contains(stdout.String(), "local:lighthouse") || !strings.Contains(stdout.String(), "1.2.0") {
 		t.Fatalf("unexpected show output: %q", stdout.String())
 	}
 
 	stdout.Reset()
 	stderr.Reset()
-	if code := doPackRegistryRemove("main", false, &stdout, &stderr); code != 0 {
+	if code := doPackRegistryRemove("local", false, &stdout, &stderr); code != 0 {
 		t.Fatalf("remove code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if _, err := os.Stat(filepath.Join(home, "registry-cache", "main")); err != nil {
+	if _, err := os.Stat(filepath.Join(home, "registry-cache", "local")); err != nil {
 		t.Fatalf("registry cache pruned during remove, stat err=%v", err)
 	}
 
@@ -125,12 +126,12 @@ func TestPackRegistryAddListSearchShowRemove(t *testing.T) {
 	if code := doPackRegistryRefresh("", false, &stdout, &stderr); code != 0 {
 		t.Fatalf("refresh after remove code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if _, err := os.Stat(filepath.Join(home, "registry-cache", "main")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(home, "registry-cache", "local")); !os.IsNotExist(err) {
 		t.Fatalf("registry cache not pruned by refresh, stat err=%v", err)
 	}
 }
 
-func TestPackRegistryCommandsDoNotImplicitlySeedDefaultRegistry(t *testing.T) {
+func TestPackRegistryCommandsPreRegisterDefaultRegistryOnVanillaHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
 
@@ -138,11 +139,8 @@ func TestPackRegistryCommandsDoNotImplicitlySeedDefaultRegistry(t *testing.T) {
 	if code := doPackRegistryList(false, &stdout, &stderr); code != 0 {
 		t.Fatalf("list code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "No pack registries configured.") {
-		t.Fatalf("list output = %q, want no registries message", stdout.String())
-	}
-	if _, err := os.Stat(packregistry.ConfigPath(home)); !os.IsNotExist(err) {
-		t.Fatalf("registry list should not seed registries.toml, stat err = %v", err)
+	if !strings.Contains(stdout.String(), packregistry.DefaultRegistryName) || !strings.Contains(stdout.String(), packregistry.DefaultRegistrySource) {
+		t.Fatalf("list output = %q, want default main registry", stdout.String())
 	}
 
 	stdout.Reset()
@@ -150,8 +148,8 @@ func TestPackRegistryCommandsDoNotImplicitlySeedDefaultRegistry(t *testing.T) {
 	if code := doPackRegistrySearch("gastown", "", false, 50, false, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("search code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "No registry packs found.") {
-		t.Fatalf("search output = %q, want no packs message", stdout.String())
+	if !strings.Contains(stdout.String(), "gastown") || strings.Contains(stderr.String(), "cache unavailable") {
+		t.Fatalf("search output = stdout=%q stderr=%q, want default main results without cache warning", stdout.String(), stderr.String())
 	}
 }
 
@@ -160,6 +158,7 @@ func TestPackRegistryShowBareNameAmbiguous(t *testing.T) {
 	t.Setenv("GC_HOME", home)
 	mainDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 	otherDir := writeRegistryCatalog(t, packRegistryOtherCatalog)
+	writeEmptyRegistryConfig(t, home)
 
 	var stdout, stderr bytes.Buffer
 	if code := doPackRegistryAdd("main", mainDir, false, false, &stdout, &stderr); code != 0 {
@@ -190,6 +189,7 @@ func TestPackRegistryShowBareNameAmbiguous(t *testing.T) {
 func TestPackRegistryAddDuplicateDoesNotPoisonCache(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	mainDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 	otherDir := writeRegistryCatalog(t, packRegistryOtherCatalog)
 
@@ -214,6 +214,7 @@ func TestPackRegistryAddDuplicateDoesNotPoisonCache(t *testing.T) {
 func TestPackRegistryAddNoValidateInvalidatesReusedNameCache(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 
 	var stdout, stderr bytes.Buffer
@@ -247,6 +248,7 @@ func TestPackRegistryAddNoValidateInvalidatesReusedNameCache(t *testing.T) {
 func TestPackRegistryLatestUsesHighestNonWithdrawnSemver(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	catalogDir := writeRegistryCatalog(t, packRegistryUnsortedCatalog)
 
 	var stdout, stderr bytes.Buffer
@@ -266,6 +268,7 @@ func TestPackRegistryLatestUsesHighestNonWithdrawnSemver(t *testing.T) {
 func TestPackRegistrySearchPartialReachabilityWarns(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	goodDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 	var stdout, stderr bytes.Buffer
 	if code := doPackRegistryAdd("good", goodDir, false, false, &stdout, &stderr); code != 0 {
@@ -290,6 +293,7 @@ func TestPackRegistrySearchPartialReachabilityWarns(t *testing.T) {
 func TestPackRegistrySearchAllCachesUnavailableFails(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	var stdout, stderr bytes.Buffer
 	if code := doPackRegistryAdd("bad", filepath.Join(t.TempDir(), "missing"), true, false, &stdout, &stderr); code != 0 {
 		t.Fatalf("add bad: %d %s", code, stderr.String())
@@ -305,9 +309,33 @@ func TestPackRegistrySearchAllCachesUnavailableFails(t *testing.T) {
 	}
 }
 
+func TestPackRegistrySearchRefreshesMissingCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
+	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
+	var stdout, stderr bytes.Buffer
+	if code := doPackRegistryAdd("main", catalogDir, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("add main: %d %s", code, stderr.String())
+	}
+	if err := os.Remove(filepath.Join(home, "registry-cache", "main", "registry.toml")); err != nil {
+		t.Fatalf("Remove cache: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := doPackRegistrySearch("light", "", false, 50, false, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("search code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "lighthouse") || strings.Contains(stderr.String(), "cache unavailable") {
+		t.Fatalf("search did not refresh missing cache cleanly stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
 func TestPackRegistrySearchRefreshFallsBackToCache(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 	var stdout, stderr bytes.Buffer
 	if code := doPackRegistryAdd("main", catalogDir, false, false, &stdout, &stderr); code != 0 {
@@ -330,6 +358,7 @@ func TestPackRegistrySearchRefreshFallsBackToCache(t *testing.T) {
 func TestPackRegistryShowUnqualifiedFailsClosedWithUnavailableRegistry(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
+	writeEmptyRegistryConfig(t, home)
 	goodDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 	var stdout, stderr bytes.Buffer
 	if code := doPackRegistryAdd("good", goodDir, false, false, &stdout, &stderr); code != 0 {
@@ -361,6 +390,7 @@ func TestPackRegistrySearchWarnsOnStaleCache(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)
 	t.Setenv("GC_REGISTRY_FRESHNESS", "1s")
+	writeEmptyRegistryConfig(t, home)
 	catalogDir := writeRegistryCatalog(t, packRegistryTestCatalog)
 	var stdout, stderr bytes.Buffer
 	if code := doPackRegistryAdd("main", catalogDir, false, false, &stdout, &stderr); code != 0 {
@@ -404,8 +434,15 @@ func TestPackRegistryLiveGascityPacksCatalog(t *testing.T) {
 	t.Setenv("GC_HOME", home)
 
 	var stdout, stderr bytes.Buffer
-	if code := doPackRegistryAdd("main", source, false, false, &stdout, &stderr); code != 0 {
-		t.Fatalf("add gascity-packs registry code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	if source == packregistry.DefaultRegistryName {
+		if code := doPackRegistryRefresh(packregistry.DefaultRegistryName, false, &stdout, &stderr); code != 0 {
+			t.Fatalf("refresh gascity-packs registry code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+	} else {
+		writeEmptyRegistryConfig(t, home)
+		if code := doPackRegistryAdd(packregistry.DefaultRegistryName, source, false, false, &stdout, &stderr); code != 0 {
+			t.Fatalf("add gascity-packs registry code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
 	}
 
 	stdout.Reset()
@@ -440,4 +477,11 @@ func writeRegistryCatalog(t *testing.T, body string) string {
 		t.Fatalf("WriteFile(registry.toml): %v", err)
 	}
 	return dir
+}
+
+func writeEmptyRegistryConfig(t *testing.T, home string) {
+	t.Helper()
+	if err := packregistry.SaveConfig(home, packregistry.Config{}); err != nil {
+		t.Fatalf("SaveConfig(empty): %v", err)
+	}
 }

--- a/internal/packregistry/config.go
+++ b/internal/packregistry/config.go
@@ -17,6 +17,13 @@ import (
 // ConfigSchema is the supported registries.toml schema version.
 const ConfigSchema = 1
 
+const (
+	// DefaultRegistryName is the built-in public pack registry name.
+	DefaultRegistryName = "main"
+	// DefaultRegistrySource is the public gascity-packs registry catalog.
+	DefaultRegistrySource = "https://raw.githubusercontent.com/gastownhall/gascity-packs/main/registry.toml"
+)
+
 var registryNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
 // Config is the parsed registry configuration stored under the Gas City home.
@@ -44,7 +51,13 @@ func LoadConfig(home string) (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return Config{Schema: ConfigSchema}, nil
+			return Config{
+				Schema: ConfigSchema,
+				Registries: []Registry{{
+					Name:   DefaultRegistryName,
+					Source: DefaultRegistrySource,
+				}},
+			}, nil
 		}
 		return cfg, fmt.Errorf("reading registries.toml: %w", err)
 	}

--- a/internal/packregistry/config_test.go
+++ b/internal/packregistry/config_test.go
@@ -49,6 +49,7 @@ func TestLoadConfigValidatesRegistrySources(t *testing.T) {
 
 func TestAddRegistryWithCacheDoesNotConfigureWhenCacheWriteFails(t *testing.T) {
 	home := t.TempDir()
+	saveEmptyConfigForTest(t, home)
 	cacheParent := filepath.Join(home, "registry-cache", "main")
 	if err := os.MkdirAll(filepath.Dir(cacheParent), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
@@ -69,8 +70,23 @@ func TestAddRegistryWithCacheDoesNotConfigureWhenCacheWriteFails(t *testing.T) {
 	}
 }
 
-func TestLoadConfigAbsentReturnsEmptyConfig(t *testing.T) {
+func TestLoadConfigAbsentReturnsDefaultRegistry(t *testing.T) {
 	home := t.TempDir()
+	cfg, err := LoadConfig(home)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Schema != ConfigSchema {
+		t.Fatalf("schema = %d, want %d", cfg.Schema, ConfigSchema)
+	}
+	if len(cfg.Registries) != 1 || cfg.Registries[0].Name != DefaultRegistryName || cfg.Registries[0].Source != DefaultRegistrySource {
+		t.Fatalf("registries = %+v, want default main registry", cfg.Registries)
+	}
+}
+
+func TestLoadConfigExplicitEmptyFileReturnsEmptyConfig(t *testing.T) {
+	home := t.TempDir()
+	saveEmptyConfigForTest(t, home)
 	cfg, err := LoadConfig(home)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
@@ -124,6 +140,7 @@ func TestValidateRegistryName(t *testing.T) {
 
 func TestConcurrentAddRegistryWritesValidTOML(t *testing.T) {
 	home := t.TempDir()
+	saveEmptyConfigForTest(t, home)
 	var wg sync.WaitGroup
 	errCh := make(chan error, 8)
 	for _, name := range []string{"r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"} {
@@ -151,9 +168,7 @@ func TestConcurrentAddRegistryWritesValidTOML(t *testing.T) {
 
 func TestConfigLockIgnoresUnlockedSidecarFile(t *testing.T) {
 	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Dir(ConfigPath(home)), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
+	saveEmptyConfigForTest(t, home)
 	if err := os.WriteFile(ConfigPath(home)+".lock", []byte("stale\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(lock): %v", err)
 	}
@@ -195,5 +210,12 @@ func TestAtomicWritePreservesPreviousOnRenameError(t *testing.T) {
 	}
 	if string(after) != string(before) {
 		t.Fatalf("config changed after failed save:\n before=%s\n after=%s", before, after)
+	}
+}
+
+func saveEmptyConfigForTest(t *testing.T, home string) {
+	t.Helper()
+	if err := SaveConfig(home, Config{}); err != nil {
+		t.Fatalf("SaveConfig(empty): %v", err)
 	}
 }

--- a/test/acceptance/pack_registry_live_test.go
+++ b/test/acceptance/pack_registry_live_test.go
@@ -1,0 +1,187 @@
+//go:build acceptance_a
+
+package acceptance_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/deps"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packman"
+	"github.com/gastownhall/gascity/internal/packregistry"
+	"github.com/gastownhall/gascity/internal/remotesource"
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+func TestPackRegistryMainIsPreRegisteredOnVanillaInstall(t *testing.T) {
+	env := newIsolatedAcceptanceEnv(t)
+
+	out, err := helpers.RunGC(env, "", "pack", "registry", "list")
+	if err != nil {
+		t.Fatalf("gc pack registry list failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, packregistry.DefaultRegistryName) || !strings.Contains(out, packregistry.DefaultRegistrySource) {
+		t.Fatalf("default registry not listed as main:\n%s", out)
+	}
+}
+
+func TestPackRegistryLiveImportsEveryCatalogPack(t *testing.T) {
+	source := strings.TrimSpace(os.Getenv("GC_TEST_GASCITY_PACKS_REGISTRY"))
+	if source == "" {
+		t.Skip("set GC_TEST_GASCITY_PACKS_REGISTRY to a gascity-packs registry.toml source to run this live import smoke test")
+	}
+	env := newIsolatedAcceptanceEnv(t)
+	var out string
+
+	if source == packregistry.DefaultRegistryName {
+		var err error
+		out, err = helpers.RunGC(env, "", "pack", "registry", "refresh", packregistry.DefaultRegistryName)
+		if err != nil {
+			t.Fatalf("gc pack registry refresh main failed: %v\n%s", err, out)
+		}
+	} else {
+		var err error
+		out, err = helpers.RunGC(env, "", "pack", "registry", "remove", packregistry.DefaultRegistryName)
+		if err != nil {
+			t.Fatalf("gc pack registry remove main failed: %v\n%s", err, out)
+		}
+		out, err = helpers.RunGC(env, "", "pack", "registry", "add", packregistry.DefaultRegistryName, source)
+		if err != nil {
+			t.Fatalf("gc pack registry add main failed: %v\n%s", err, out)
+		}
+	}
+
+	cfg, err := packregistry.LoadConfig(env.Get("GC_HOME"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	regs, err := selectAcceptanceRegistries(cfg.Registries, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalog, _, err := packregistry.ReadCachedRegistryCatalog(env.Get("GC_HOME"), regs[0])
+	if err != nil {
+		t.Fatalf("ReadCachedRegistryCatalog(main): %v", err)
+	}
+	if len(catalog.Packs) == 0 {
+		t.Fatal("main registry catalog has no packs")
+	}
+
+	c := helpers.NewCity(t, env)
+	c.WriteConfig("[workspace]\nname = \"pack-registry-smoke\"\n")
+	c.AppendToPack("[pack]\nname = \"pack-registry-smoke\"\nschema = 1\n")
+	type expectedPack struct {
+		Name    string
+		Source  string
+		Version string
+		Commit  string
+	}
+	var expected []expectedPack
+	for _, pack := range catalog.Packs {
+		release, ok := latestAcceptanceRelease(pack)
+		if !ok {
+			t.Fatalf("registry pack %q has no active release", pack.Name)
+		}
+		binding := strings.ReplaceAll(pack.Name, "/", "-")
+		version := "sha:" + release.Commit
+		out, err := c.GC("import", "add", pack.Source, "--name", binding, "--version", version)
+		if err != nil {
+			t.Fatalf("gc import add %s failed: %v\n%s", pack.Name, err, out)
+		}
+		expected = append(expected, expectedPack{
+			Name:    pack.Name,
+			Source:  pack.Source,
+			Version: version,
+			Commit:  release.Commit,
+		})
+	}
+
+	packToml := c.ReadFile("pack.toml")
+	for _, pack := range expected {
+		binding := strings.ReplaceAll(pack.Name, "/", "-")
+		if !strings.Contains(packToml, fmt.Sprintf("[imports.%s]", binding)) &&
+			!strings.Contains(packToml, fmt.Sprintf("[imports.%s]", strconv.Quote(binding))) {
+			t.Fatalf("pack.toml missing import binding for %s:\n%s", pack.Name, packToml)
+		}
+	}
+
+	out, err = c.GC("import", "install")
+	if err != nil {
+		t.Fatalf("gc import install failed: %v\n%s", err, out)
+	}
+	out, err = c.GC("import", "check")
+	if err != nil {
+		t.Fatalf("gc import check failed: %v\n%s", err, out)
+	}
+	out, err = c.GC("config", "show", "--validate")
+	if err != nil {
+		t.Fatalf("gc config show --validate failed: %v\n%s", err, out)
+	}
+
+	lock, err := packman.ReadLockfile(fsys.OSFS{}, c.Dir)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	for _, pack := range expected {
+		locked, ok := lock.Packs[pack.Source]
+		if !ok {
+			t.Fatalf("packs.lock missing source for registry pack %s (%s)", pack.Name, pack.Source)
+		}
+		if locked.Version != pack.Version || locked.Commit != pack.Commit {
+			t.Fatalf("packs.lock entry for %s = version %q commit %q, want %q %q", pack.Name, locked.Version, locked.Commit, pack.Version, pack.Commit)
+		}
+		cachePath, err := packman.RepoCachePath(pack.Source, pack.Commit)
+		if err != nil {
+			t.Fatalf("RepoCachePath(%s): %v", pack.Name, err)
+		}
+		packPath := filepath.Join(cachePath, remotesource.Parse(pack.Source).Subpath, "pack.toml")
+		if _, err := os.Stat(packPath); err != nil {
+			t.Fatalf("cached pack %s missing pack.toml at %s: %v", pack.Name, packPath, err)
+		}
+	}
+}
+
+func newIsolatedAcceptanceEnv(t *testing.T) *helpers.Env {
+	t.Helper()
+	root := helpers.TempDir(t)
+	gcHome := filepath.Join(root, "gc-home")
+	runtimeDir := filepath.Join(root, "runtime")
+	for _, dir := range []string{gcHome, runtimeDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("creating %s: %v", dir, err)
+		}
+	}
+	if err := helpers.WriteSupervisorConfig(gcHome); err != nil {
+		t.Fatalf("acceptance: %v", err)
+	}
+	return helpers.NewEnv(testEnv.Get("GC_ACCEPTANCE_GC_BIN"), gcHome, runtimeDir)
+}
+
+func latestAcceptanceRelease(pack packregistry.CatalogPack) (packregistry.CatalogRelease, bool) {
+	var latest packregistry.CatalogRelease
+	ok := false
+	for _, release := range pack.Releases {
+		if release.Withdrawn {
+			continue
+		}
+		if !ok || deps.CompareVersions(latest.Version, release.Version) < 0 {
+			latest = release
+			ok = true
+		}
+	}
+	return latest, ok
+}
+
+func selectAcceptanceRegistries(regs []packregistry.Registry, name string) ([]packregistry.Registry, error) {
+	for _, reg := range regs {
+		if reg.Name == name {
+			return []packregistry.Registry{reg}, nil
+		}
+	}
+	return nil, fmt.Errorf("registry %q is not configured", name)
+}


### PR DESCRIPTION
## Summary

- preregister the public `main` pack registry for vanilla `GC_HOME` installs
- make registry search/show populate a missing catalog cache on first use
- add an opt-in acceptance smoke test that imports every pack from the main registry, installs/checks imports, and verifies each cached pack

## Why

A fresh install could list the default registry but had no cached catalog, so `gc pack registry search` failed until the user knew to refresh manually. The live acceptance test now exercises the path Donna asked for: use the configured `main` registry, import every catalog pack, and smoke the resulting installation.

## Validation

- `go test ./cmd/gc -run 'TestPackRegistry' -count=1`
- `go test ./internal/packregistry -count=1`
- `GC_TEST_GASCITY_PACKS_REGISTRY=main make test-pack-registry-live`
- cold-home manual smoke: `GC_HOME=$(mktemp -d) go run ./cmd/gc pack registry search gastown`
