### PR TITLE
fix(orders): budget order dispatch per tick

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -237,7 +237,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 	// errors immediately after ensureBeadsProvider returns (#753).
 	if sweepStore, err := newCityRuntimeOpenSweepStore(p.CityPath, p.CityPath); err != nil {
 		fmt.Fprintf(p.Stderr, "gc start: order tracking sweep: %v\n", err) //nolint:errcheck // best-effort stderr
-	} else if n, err := sweepOrphanedOrderTrackingRetry(sweepStore, 3, time.Second); err != nil {
+	} else if n, err := sweepOrphanedOrderTrackingRetryLimit(sweepStore, 3, time.Second, orderTrackingSweepCloseBudget); err != nil {
 		fmt.Fprintf(p.Stderr, "gc start: order tracking sweep (closed %d): %v\n", n, err) //nolint:errcheck // best-effort stderr
 	} else if n > 0 {
 		fmt.Fprintf(p.Stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
@@ -1318,7 +1318,7 @@ func (cr *CityRuntime) runOrderTrackingSweepWatchdog(now time.Time) {
 	// The staleAfter cutoff still protects in-flight dispatches regardless of
 	// which order they belong to, so a direct all-orders sweep is safe and
 	// recovers the jam without depending on any single order being scheduled.
-	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, now, orderTrackingSweepWatchdogStaleAfter, nil, orderTrackingWatchdogMetadataInitiator, false)
+	result, sweepErr := sweepStaleOrderTrackingAcrossStoresLimit(stores, now, orderTrackingSweepWatchdogStaleAfter, nil, orderTrackingWatchdogMetadataInitiator, false, orderTrackingSweepCloseBudget)
 	if err := errors.Join(storeErr, sweepErr); err != nil {
 		if cr.stderr != nil {
 			fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1692,7 +1692,6 @@ func TestOrderTrackingSweepWatchdogAllowsSweepOrderToCleanStaleTracking(t *testi
 			freshMerge.CreatedAt.Add(25*time.Millisecond),
 			50*time.Millisecond,
 			nil,
-			orderTrackingSweepMetadataInitiator,
 			false,
 		)
 		return nil, err

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1599,6 +1599,46 @@ func TestOrderTrackingSweepWatchdogClosesAllStaleTracking(t *testing.T) {
 	}
 }
 
+func TestOrderTrackingSweepWatchdogUsesCloseBudget(t *testing.T) {
+	store := beads.NewMemStore()
+	ids := make([]string, 0, orderTrackingSweepCloseBudget+1)
+	for i := range orderTrackingSweepCloseBudget + 1 {
+		b, err := store.Create(beads.Bead{
+			Title:     fmt.Sprintf("order:stale-%d", i),
+			Labels:    []string{fmt.Sprintf("order-run:stale-%d", i), labelOrderTracking},
+			Ephemeral: true,
+		})
+		if err != nil {
+			t.Fatalf("Create(stale-%d): %v", i, err)
+		}
+		ids = append(ids, b.ID)
+	}
+
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
+	}
+	cr.runOrderTrackingSweepWatchdog(time.Now().Add(orderTrackingSweepWatchdogStaleAfter + time.Second))
+
+	closed := 0
+	for _, id := range ids {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status == "closed" {
+			closed++
+		}
+	}
+	if closed != orderTrackingSweepCloseBudget {
+		t.Fatalf("closed = %d, want %d", closed, orderTrackingSweepCloseBudget)
+	}
+}
+
 func TestOrderTrackingSweepWatchdogAllowsSweepOrderToCleanStaleTracking(t *testing.T) {
 	store := beads.NewMemStore()
 	sweepTracking, err := store.Create(beads.Bead{

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -192,6 +192,8 @@ func newOrderSweepTrackingCmd(stdout, stderr io.Writer) *cobra.Command {
 
 This is intended for maintenance exec orders. It only closes tracking beads
 older than --stale-after so a fresh in-flight order is not interrupted.
+The manual command runs to completion; controller startup and watchdog sweeps
+use bounded cleanup to avoid spending an unbounded tick on stale work.
 
 Use --include-wisps for operator recovery of abandoned order-run wisp
 subtrees whose open descendants are also older than --stale-after. Pass one
@@ -1503,7 +1505,7 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 		}
 		return 1
 	}
-	result, sweepErr := sweepStaleOrderTrackingAcrossStoresLimit(stores, time.Now(), staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWisps, orderTrackingSweepCloseBudget)
+	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, time.Now(), staleAfter, onlyOrders, includeWisps)
 	if err := errors.Join(openErr, sweepErr); err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
 		if result.storesSwept == 0 {

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1503,7 +1503,7 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 		}
 		return 1
 	}
-	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, time.Now(), staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWisps)
+	result, sweepErr := sweepStaleOrderTrackingAcrossStoresLimit(stores, time.Now(), staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWisps, orderTrackingSweepCloseBudget)
 	if err := errors.Join(openErr, sweepErr); err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
 		if result.storesSwept == 0 {

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1219,6 +1219,74 @@ prefix = "fe"
 	}
 }
 
+func TestCmdOrderSweepTrackingUsesCloseBudget(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_CITY_ROOT", cityDir)
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Chdir(cityDir)
+
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+`)
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	ids := make([]string, 0, orderTrackingSweepCloseBudget+1)
+	for i := range orderTrackingSweepCloseBudget + 1 {
+		stale, err := store.Create(beads.Bead{
+			Title:     fmt.Sprintf("order:cleanup-%d", i),
+			Labels:    []string{fmt.Sprintf("order-run:cleanup-%d", i), labelOrderTracking},
+			Ephemeral: true,
+		})
+		if err != nil {
+			t.Fatalf("Create(stale-%d): %v", i, err)
+		}
+		ids = append(ids, stale.ID)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdOrderSweepTracking(time.Nanosecond, false, false, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdOrderSweepTracking = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	reopened, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reopen): %v", err)
+	}
+	closed := 0
+	for _, id := range ids {
+		got, err := reopened.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status == "closed" {
+			closed++
+		}
+	}
+	if closed != orderTrackingSweepCloseBudget {
+		t.Fatalf("closed = %d, want %d", closed, orderTrackingSweepCloseBudget)
+	}
+	want := fmt.Sprintf("closed %d stale order-tracking bead", orderTrackingSweepCloseBudget)
+	if !strings.Contains(stdout.String(), want) {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
 func TestCmdOrderSweepTrackingFailsWhenTargetedRigStoreOpenFails(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1219,7 +1219,7 @@ prefix = "fe"
 	}
 }
 
-func TestCmdOrderSweepTrackingUsesCloseBudget(t *testing.T) {
+func TestSweepOrderTrackingCommandClosesAllStaleTracking(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 
@@ -1278,10 +1278,10 @@ prefix = "ct"
 			closed++
 		}
 	}
-	if closed != orderTrackingSweepCloseBudget {
-		t.Fatalf("closed = %d, want %d", closed, orderTrackingSweepCloseBudget)
+	if closed != len(ids) {
+		t.Fatalf("closed = %d, want %d", closed, len(ids))
 	}
-	want := fmt.Sprintf("closed %d stale order-tracking bead", orderTrackingSweepCloseBudget)
+	want := fmt.Sprintf("closed %d stale order-tracking bead", len(ids))
 	if !strings.Contains(stdout.String(), want) {
 		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 	}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -337,7 +337,7 @@ func init() {
 	sweepOrphanPIDPrefixedDirs(tmpRoot, testSlingFormulaDirPrefix)
 	sweepOrphanPIDPrefixedDirs(tmpRoot, testSlingCityDirPrefix)
 
-	dir, err := os.MkdirTemp("", pidPrefixedTempPattern(testSlingFormulaDirPrefix))
+	dir, err := os.MkdirTemp("", "gc-shared-test-formulas-*")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1656,8 +1656,18 @@ func sweepOrphanedOrderTrackingRetryLimit(store beads.Store, attempts int, backo
 	total := 0
 	var err error
 	for i := range attempts {
+		remainingLimit := limit
+		if limit > 0 {
+			remainingLimit = limit - total
+			if remainingLimit <= 0 {
+				if err != nil {
+					return total, fmt.Errorf("sweep reached close budget after partial close: %w", err)
+				}
+				return total, nil
+			}
+		}
 		var n int
-		n, err = sweepOrphanedOrderTrackingLimit(store, limit)
+		n, err = sweepOrphanedOrderTrackingLimit(store, remainingLimit)
 		total += n
 		if err == nil {
 			return total, nil

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -66,6 +66,10 @@ const (
 	staleOrderWispCloseReason     = "order-tracking sweep: stale order wisp subtree exceeded retention window"
 
 	completedOrderTrackingCloseReason = "order dispatch completed: tracking bead lifecycle finished"
+
+	orderTrackingHistoryIndexLimit   = 2048
+	defaultMaxOrderDispatchesPerTick = 4
+	orderTrackingSweepCloseBudget    = 4
 )
 
 var (
@@ -246,17 +250,19 @@ type orderSetSnapshot struct {
 // ctx OR dispatchCtx is done (see launchDispatchOne). cancel() cancels
 // dispatchCtx.
 type memoryOrderDispatcher struct {
-	aa           []orders.Order
-	storeFn      orderStoreFunc
-	ep           events.Provider
-	execRun      ExecRunner
-	rec          events.Recorder
-	stderr       io.Writer
-	maxTimeout   time.Duration
-	cfg          *config.City
-	cityName     string
-	cacheMu      sync.Mutex
-	lastRunCache map[string]time.Time
+	aa                   []orders.Order
+	storeFn              orderStoreFunc
+	ep                   events.Provider
+	execRun              ExecRunner
+	rec                  events.Recorder
+	stderr               io.Writer
+	maxTimeout           time.Duration
+	maxDispatchesPerTick int
+	nextDispatchStart    int
+	cfg                  *config.City
+	cityName             string
+	cacheMu              sync.Mutex
+	lastRunCache         map[string]time.Time
 
 	dispatchCtx    context.Context
 	dispatchCancel context.CancelFunc
@@ -360,15 +366,16 @@ func buildOrderDispatcherFromOrderSet(cityPath string, cfg *config.City, allAA [
 		storeFn: func(target execStoreTarget) (beads.Store, error) {
 			return openStoreAtForCity(target.ScopeRoot, cityPath)
 		},
-		ep:             ep,
-		execRun:        shellExecRunner,
-		rec:            rec,
-		stderr:         lockedStderr(stderr),
-		maxTimeout:     cfg.Orders.MaxTimeoutDuration(),
-		cfg:            cfg,
-		cityName:       loadedCityName(cfg, cityPath),
-		dispatchCtx:    dispatchCtx,
-		dispatchCancel: dispatchCancel,
+		ep:                   ep,
+		execRun:              shellExecRunner,
+		rec:                  rec,
+		stderr:               lockedStderr(stderr),
+		maxTimeout:           cfg.Orders.MaxTimeoutDuration(),
+		maxDispatchesPerTick: defaultMaxOrderDispatchesPerTick,
+		cfg:                  cfg,
+		cityName:             loadedCityName(cfg, cityPath),
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       dispatchCancel,
 	}
 }
 
@@ -379,8 +386,20 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 	}
 
 	stores := make(map[string]beads.Store)
+	dispatched := 0
 
-	for _, a := range m.aa {
+	total := len(m.aa)
+	if total == 0 {
+		return
+	}
+	start := 0
+	if m.maxDispatchesPerTick > 0 {
+		start = m.nextDispatchStart % total
+	}
+
+	for offset := 0; offset < total; offset++ {
+		idx := (start + offset) % total
+		a := m.aa[idx]
 		// Skip orders targeting suspended rigs.
 		if m.orderRigSuspended(a) {
 			continue
@@ -526,9 +545,15 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		// Fire with timeout; inflight tracks the spawned goroutine so
 		// drain can wait for tracking-bead outcome persistence before
 		// controller exit or config reload.
-		a := a // capture loop variable
 		m.addInflight()
 		m.launchDispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
+		dispatched++
+		if m.maxDispatchesPerTick > 0 {
+			m.nextDispatchStart = (idx + 1) % total
+		}
+		if m.maxDispatchesPerTick > 0 && dispatched >= m.maxDispatchesPerTick {
+			return
+		}
 	}
 }
 
@@ -1220,6 +1245,10 @@ func (m *memoryOrderDispatcher) hasOpenWorkInStoresStrict(stores []beads.Store, 
 // behind by a previous controller instance. Returns the count of beads
 // closed. This is non-fatal: dispatch proceeds even if the sweep fails.
 func sweepOrphanedOrderTracking(store beads.Store) (int, error) {
+	return sweepOrphanedOrderTrackingLimit(store, 0)
+}
+
+func sweepOrphanedOrderTrackingLimit(store beads.Store, limit int) (int, error) {
 	// ListByLabel without IncludeClosed returns only open beads.
 	// New tracking beads live in the wisps tier, but legacy issues-tier
 	// tracking beads may still exist after upgrade; sweep both.
@@ -1236,6 +1265,9 @@ func sweepOrphanedOrderTracking(store beads.Store) (int, error) {
 			continue
 		}
 		ids = append(ids, b.ID)
+		if limit > 0 && len(ids) >= limit {
+			break
+		}
 	}
 	if len(ids) == 0 {
 		return 0, nil
@@ -1269,11 +1301,20 @@ type orderTrackingSweepResult struct {
 // timestamp is older than staleAfter. When onlyOrders is non-empty, it only
 // closes tracking beads for those scoped order names.
 func sweepStaleOrderTracking(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string) (int, error) {
-	result, err := sweepStaleOrderTrackingWithOptions(store, now, staleAfter, onlyOrders, initiator, false)
+	result, err := sweepStaleOrderTrackingWithOptionsLimit(store, now, staleAfter, onlyOrders, initiator, false, 0)
+	return result.trackingClosed, err
+}
+
+func sweepStaleOrderTrackingLimit(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, limit int) (int, error) {
+	result, err := sweepStaleOrderTrackingWithOptionsLimit(store, now, staleAfter, onlyOrders, initiator, false, limit)
 	return result.trackingClosed, err
 }
 
 func sweepStaleOrderTrackingAcrossStores(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingAcrossStoresLimit(stores, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, 0)
+}
+
+func sweepStaleOrderTrackingAcrossStoresLimit(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")
 	}
@@ -1286,7 +1327,14 @@ func sweepStaleOrderTrackingAcrossStores(stores []beads.Store, now time.Time, st
 		if store == nil {
 			continue
 		}
-		partial, err := sweepStaleOrderTrackingWithOptions(store, now, staleAfter, onlyOrders, initiator, includeWispSubtrees)
+		remainingLimit := 0
+		if limit > 0 {
+			remainingLimit = limit - result.trackingClosed
+			if remainingLimit <= 0 {
+				break
+			}
+		}
+		partial, err := sweepStaleOrderTrackingWithOptionsLimit(store, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, remainingLimit)
 		result.trackingClosed += partial.trackingClosed
 		result.wispClosed += partial.wispClosed
 		if err != nil {
@@ -1326,7 +1374,11 @@ func orderTrackingSweepStoreLabel(store beads.Store, index int) string {
 	return fmt.Sprintf("store %d", index+1)
 }
 
-func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
+func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingWithOptionsLimit(store, now, time.Minute, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0)
+}
+
+func sweepStaleOrderTrackingWithOptionsLimit(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")
 	}
@@ -1355,6 +1407,9 @@ func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, staleA
 			continue
 		}
 		ids = append(ids, b.ID)
+		if limit > 0 && len(ids) >= limit {
+			break
+		}
 	}
 	if len(ids) == 0 {
 		if !includeWispSubtrees {
@@ -1591,6 +1646,10 @@ func orderNameFromTrackingBead(b beads.Bead) (string, bool) {
 // beads (see internal/beads/beads.go). The wrapper sleeps for up to
 // attempts*backoff in the worst case.
 func sweepOrphanedOrderTrackingRetry(store beads.Store, attempts int, backoff time.Duration) (int, error) { //nolint:unparam // attempts is configurable for testability
+	return sweepOrphanedOrderTrackingRetryLimit(store, attempts, backoff, 0)
+}
+
+func sweepOrphanedOrderTrackingRetryLimit(store beads.Store, attempts int, backoff time.Duration, limit int) (int, error) { //nolint:unparam // attempts is configurable for testability
 	if attempts <= 0 {
 		attempts = 1
 	}
@@ -1598,7 +1657,7 @@ func sweepOrphanedOrderTrackingRetry(store beads.Store, attempts int, backoff ti
 	var err error
 	for i := range attempts {
 		var n int
-		n, err = sweepOrphanedOrderTracking(store)
+		n, err = sweepOrphanedOrderTrackingLimit(store, limit)
 		total += n
 		if err == nil {
 			return total, nil

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -67,7 +67,6 @@ const (
 
 	completedOrderTrackingCloseReason = "order dispatch completed: tracking bead lifecycle finished"
 
-	orderTrackingHistoryIndexLimit   = 2048
 	defaultMaxOrderDispatchesPerTick = 4
 	orderTrackingSweepCloseBudget    = 4
 )
@@ -386,7 +385,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 	}
 
 	stores := make(map[string]beads.Store)
-	dispatched := 0
+	budgetSpent := 0
 
 	total := len(m.aa)
 	if total == 0 {
@@ -395,6 +394,13 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 	start := 0
 	if m.maxDispatchesPerTick > 0 {
 		start = m.nextDispatchStart % total
+	}
+	spendDispatchBudget := func(idx int) bool {
+		budgetSpent++
+		if m.maxDispatchesPerTick > 0 {
+			m.nextDispatchStart = (idx + 1) % total
+		}
+		return m.maxDispatchesPerTick > 0 && budgetSpent >= m.maxDispatchesPerTick
 	}
 
 	for offset := 0; offset < total; offset++ {
@@ -491,6 +497,9 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 				Subject: a.ScopedName(),
 				Message: msg,
 			})
+			if spendDispatchBudget(idx) {
+				return
+			}
 			continue
 		}
 		result := orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
@@ -547,11 +556,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		// controller exit or config reload.
 		m.addInflight()
 		m.launchDispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
-		dispatched++
-		if m.maxDispatchesPerTick > 0 {
-			m.nextDispatchStart = (idx + 1) % total
-		}
-		if m.maxDispatchesPerTick > 0 && dispatched >= m.maxDispatchesPerTick {
+		if spendDispatchBudget(idx) {
 			return
 		}
 	}
@@ -1310,10 +1315,13 @@ func sweepStaleOrderTrackingLimit(store beads.Store, now time.Time, staleAfter t
 	return result.trackingClosed, err
 }
 
-func sweepStaleOrderTrackingAcrossStores(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
-	return sweepStaleOrderTrackingAcrossStoresLimit(stores, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, 0)
+func sweepStaleOrderTrackingAcrossStores(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingAcrossStoresLimit(stores, now, staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0)
 }
 
+// sweepStaleOrderTrackingAcrossStoresLimit applies limit only to
+// order-tracking bead closes. Wisp subtree recovery is operator-scoped by
+// order name and closes complete stale subtrees when explicitly requested.
 func sweepStaleOrderTrackingAcrossStoresLimit(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")
@@ -1374,10 +1382,9 @@ func orderTrackingSweepStoreLabel(store beads.Store, index int) string {
 	return fmt.Sprintf("store %d", index+1)
 }
 
-func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
-	return sweepStaleOrderTrackingWithOptionsLimit(store, now, time.Minute, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0)
-}
-
+// sweepStaleOrderTrackingWithOptionsLimit applies limit only to
+// order-tracking bead closes. Wisp subtree recovery is order-scoped and closes
+// complete stale subtrees when includeWispSubtrees is set.
 func sweepStaleOrderTrackingWithOptionsLimit(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1210,6 +1210,90 @@ func TestOrderDispatchMultiple(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchRespectsMaxDispatchesPerTick(t *testing.T) {
+	store := beads.NewMemStore()
+	var aa []orders.Order
+	for i := 0; i < 5; i++ {
+		aa = append(aa, orders.Order{
+			Name:     fmt.Sprintf("order-%d", i),
+			Trigger:  "cooldown",
+			Interval: "1m",
+			Exec:     "true",
+		})
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, func(context.Context, string, string, []string) ([]byte, error) {
+		return []byte("ok\n"), nil
+	}, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	m := ad.(*memoryOrderDispatcher)
+	m.maxDispatchesPerTick = 2
+
+	now := time.Date(2026, 5, 19, 2, 30, 0, 0, time.UTC)
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	if got := countOrderTrackingRuns(t, store); got != 2 {
+		t.Fatalf("tracking runs after first tick = %d, want 2", got)
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), now.Add(time.Second))
+	ad.drain(context.Background())
+	if got := countOrderTrackingRuns(t, store); got != 4 {
+		t.Fatalf("tracking runs after second tick = %d, want 4", got)
+	}
+}
+
+func TestOrderDispatchBudgetRotatesAcrossAlwaysDueOrders(t *testing.T) {
+	store := beads.NewMemStore()
+	var aa []orders.Order
+	for i := 0; i < 5; i++ {
+		aa = append(aa, orders.Order{
+			Name:    fmt.Sprintf("condition-%d", i),
+			Trigger: "condition",
+			Check:   "true",
+			Exec:    "true",
+		})
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, func(context.Context, string, string, []string) ([]byte, error) {
+		return []byte("ok\n"), nil
+	}, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	m := ad.(*memoryOrderDispatcher)
+	m.maxDispatchesPerTick = 2
+
+	now := time.Date(2026, 5, 19, 2, 30, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		ad.dispatch(context.Background(), t.TempDir(), now.Add(time.Duration(i)*time.Second))
+		ad.drain(context.Background())
+	}
+
+	for i := 0; i < 5; i++ {
+		label := fmt.Sprintf("order-run:condition-%d", i)
+		if got := len(trackingBeads(t, store, label)); got == 0 {
+			t.Fatalf("%s did not dispatch under a rotating budget", label)
+		}
+	}
+}
+
+func countOrderTrackingRuns(t *testing.T, store beads.Store) int {
+	t.Helper()
+	all, err := store.ListByLabel(labelOrderTracking, 0, beads.IncludeClosed, beads.WithBothTiers)
+	if err != nil {
+		t.Fatalf("ListByLabel(%q): %v", labelOrderTracking, err)
+	}
+	count := 0
+	for _, b := range all {
+		if strings.HasPrefix(b.Title, "order:") {
+			count++
+		}
+	}
+	return count
+}
+
 func TestOrderDispatchCachesLastRunBetweenDispatches(t *testing.T) {
 	store := &countingListStore{Store: beads.NewMemStore()}
 
@@ -3060,6 +3144,48 @@ func TestSweepOrphanedOrderTracking_ClosesOpenTrackingBeads(t *testing.T) {
 	}
 }
 
+func TestSweepOrphanedOrderTrackingLimit_ClosesAtMostBudget(t *testing.T) {
+	store := beads.NewMemStore()
+
+	ids := make([]string, 0, 5)
+	for _, name := range []string{"one", "two", "three", "four", "five"} {
+		b, err := store.Create(beads.Bead{
+			Title:     "order:" + name,
+			Labels:    []string{"order-run:" + name, labelOrderTracking},
+			Ephemeral: true,
+		})
+		if err != nil {
+			t.Fatalf("Create(%s): %v", name, err)
+		}
+		ids = append(ids, b.ID)
+	}
+
+	closed, err := sweepOrphanedOrderTrackingLimit(store, 2)
+	if err != nil {
+		t.Fatalf("sweepOrphanedOrderTrackingLimit: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("closed = %d, want 2", closed)
+	}
+
+	closedCount := 0
+	for _, id := range ids {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status == "closed" {
+			closedCount++
+			if got.Metadata["close_reason"] != orphanedOrderTrackingCloseReason {
+				t.Fatalf("close_reason for %s = %q, want %q", id, got.Metadata["close_reason"], orphanedOrderTrackingCloseReason)
+			}
+		}
+	}
+	if closedCount != 2 {
+		t.Fatalf("closed tracking beads = %d, want 2", closedCount)
+	}
+}
+
 func TestSweepOrphanedOrderTracking_NoOrphans(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -3332,6 +3458,13 @@ func (s *failingListOrderTrackingStore) ListByLabel(label string, limit int, opt
 	return s.Store.ListByLabel(label, limit, opts...)
 }
 
+func (s *failingListOrderTrackingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == labelOrderTracking {
+		return nil, s.err
+	}
+	return s.Store.List(query)
+}
+
 func TestSweepStaleOrderTrackingAcrossStoresContinuesAfterStoreError(t *testing.T) {
 	failingStore := &failingListOrderTrackingStore{
 		Store: beads.NewMemStore(),
@@ -3414,9 +3547,7 @@ func TestSweepStaleOrderTrackingClosesTriggerEnvFailedBeadsAndUnblocksDispatch(t
 	result, err := sweepStaleOrderTrackingWithOptions(
 		store,
 		normal.CreatedAt.Add(time.Hour),
-		time.Minute,
 		nil,
-		orderTrackingSweepMetadataInitiator,
 		false,
 	)
 	if err != nil {
@@ -3543,9 +3674,7 @@ func TestSweepStaleOrderTrackingWithWispsRequiresOrderFilter(t *testing.T) {
 	result, err := sweepStaleOrderTrackingWithOptions(
 		store,
 		time.Now(),
-		time.Minute,
 		nil,
-		orderTrackingSweepMetadataInitiator,
 		true,
 	)
 	if err == nil {
@@ -3613,9 +3742,7 @@ func TestSweepStaleOrderTrackingWithWispsClosesOldOpenWispSubtree(t *testing.T) 
 	result, err := sweepStaleOrderTrackingWithOptions(
 		store,
 		wispRoot.CreatedAt.Add(time.Hour),
-		time.Minute,
 		orderFilterForTest("digest"),
-		orderTrackingSweepMetadataInitiator,
 		true,
 	)
 	if err != nil {
@@ -3676,9 +3803,7 @@ func TestSweepStaleOrderTrackingWithoutWispsLeavesOpenWispSubtree(t *testing.T) 
 	result, err := sweepStaleOrderTrackingWithOptions(
 		store,
 		wispRoot.CreatedAt.Add(time.Hour),
-		time.Minute,
 		nil,
-		orderTrackingSweepMetadataInitiator,
 		false,
 	)
 	if err != nil {
@@ -3726,9 +3851,7 @@ func TestSweepStaleOrderTrackingWithWispsClosesDeepestFirst(t *testing.T) {
 	result, err := sweepStaleOrderTrackingWithOptions(
 		store,
 		wispRoot.CreatedAt.Add(time.Hour),
-		time.Minute,
 		orderFilterForTest("digest"),
-		orderTrackingSweepMetadataInitiator,
 		true,
 	)
 	if err != nil {
@@ -3767,9 +3890,7 @@ func TestSweepStaleOrderTrackingWithWispsClosesRootOnlyWisp(t *testing.T) {
 	result, err := sweepStaleOrderTrackingWithOptions(
 		store,
 		wispRoot.CreatedAt.Add(time.Hour),
-		time.Minute,
 		orderFilterForTest("digest"),
-		orderTrackingSweepMetadataInitiator,
 		true,
 	)
 	if err != nil {
@@ -3894,6 +4015,52 @@ func TestSweepStaleOrderTrackingWithWispsPropagatesCloseOrderError(t *testing.T)
 	}
 	if !strings.Contains(err.Error(), "ordering stale order wisp closes") {
 		t.Fatalf("err = %q, want close-order context", err)
+	}
+}
+
+func TestSweepStaleOrderTrackingLimit_ClosesAtMostBudget(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Now()
+
+	ids := make([]string, 0, 4)
+	for _, name := range []string{"one", "two", "three", "four"} {
+		b, err := store.Create(beads.Bead{
+			Title:     "order:" + name,
+			Labels:    []string{"order-run:" + name, labelOrderTracking},
+			Ephemeral: true,
+		})
+		if err != nil {
+			t.Fatalf("Create(%s): %v", name, err)
+		}
+		ids = append(ids, b.ID)
+	}
+
+	closed, err := sweepStaleOrderTrackingLimit(store, now.Add(time.Hour), time.Minute, nil, orderTrackingWatchdogMetadataInitiator, 3)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingLimit: %v", err)
+	}
+	if closed != 3 {
+		t.Fatalf("closed = %d, want 3", closed)
+	}
+
+	closedCount := 0
+	for _, id := range ids {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status == "closed" {
+			closedCount++
+			if got.Metadata["close_reason"] != staleOrderTrackingCloseReason {
+				t.Fatalf("close_reason for %s = %q, want %q", id, got.Metadata["close_reason"], staleOrderTrackingCloseReason)
+			}
+			if got.Metadata["order_tracking_sweep_by"] != orderTrackingWatchdogMetadataInitiator {
+				t.Fatalf("order_tracking_sweep_by for %s = %q, want %q", id, got.Metadata["order_tracking_sweep_by"], orderTrackingWatchdogMetadataInitiator)
+			}
+		}
+	}
+	if closedCount != 3 {
+		t.Fatalf("closed tracking beads = %d, want 3", closedCount)
 	}
 }
 
@@ -4257,13 +4424,14 @@ func buildOrderDispatcherFromListExec(aa []orders.Order, store beads.Store, ep e
 		storeFn: func(_ execStoreTarget) (beads.Store, error) {
 			return store, nil
 		},
-		ep:             ep,
-		execRun:        execRun,
-		rec:            rec,
-		stderr:         lockedStderr(&bytes.Buffer{}),
-		cfg:            cfg,
-		dispatchCtx:    dispatchCtx,
-		dispatchCancel: dispatchCancel,
+		ep:                   ep,
+		execRun:              execRun,
+		rec:                  rec,
+		stderr:               lockedStderr(&bytes.Buffer{}),
+		maxDispatchesPerTick: defaultMaxOrderDispatchesPerTick,
+		cfg:                  cfg,
+		dispatchCtx:          dispatchCtx,
+		dispatchCancel:       dispatchCancel,
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1820,6 +1820,86 @@ dolt.auto-start: false
 	}
 }
 
+func TestOrderDispatchTriggerEnvFailuresRespectMaxDispatchesPerTick(t *testing.T) {
+	clearAmbientPostgresEnv(t)
+	t.Setenv("GC_BEADS", "bd")
+
+	cityDir := t.TempDir()
+	writePGScopeFixture(t, cityDir, "")
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "config.yaml"), []byte(`issue_prefix: city
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewMemStore()
+	var rec memRecorder
+	var aa []orders.Order
+	for i := 0; i < 5; i++ {
+		aa = append(aa, orders.Order{
+			Name:    fmt.Sprintf("pg-condition-%d", i),
+			Trigger: "condition",
+			Check:   "true",
+			Exec:    "true",
+		})
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, &rec)
+	mad := ad.(*memoryOrderDispatcher)
+	mad.maxDispatchesPerTick = 2
+
+	now := time.Date(2026, 5, 19, 2, 30, 0, 0, time.UTC)
+	mad.dispatch(context.Background(), cityDir, now)
+	mad.drain(context.Background())
+
+	if got := countOrderTrackingRuns(t, store); got != 2 {
+		t.Fatalf("tracking runs after first tick = %d, want 2", got)
+	}
+	if got := countRecordedOrderFailedEvents(t, &rec); got != 2 {
+		t.Fatalf("order.failed events after first tick = %d, want 2", got)
+	}
+
+	mad.dispatch(context.Background(), cityDir, now.Add(time.Second))
+	mad.drain(context.Background())
+	if got := countOrderTrackingRuns(t, store); got != 4 {
+		t.Fatalf("tracking runs after second tick = %d, want 4", got)
+	}
+	if got := countRecordedOrderFailedEvents(t, &rec); got != 4 {
+		t.Fatalf("order.failed events after second tick = %d, want 4", got)
+	}
+
+	mad.dispatch(context.Background(), cityDir, now.Add(2*time.Second))
+	mad.drain(context.Background())
+	if got := countOrderTrackingRuns(t, store); got != 5 {
+		t.Fatalf("tracking runs after third tick = %d, want 5", got)
+	}
+	if got := countRecordedOrderFailedEvents(t, &rec); got != 5 {
+		t.Fatalf("order.failed events after third tick = %d, want 5", got)
+	}
+	for i := 0; i < 5; i++ {
+		label := fmt.Sprintf("order-run:pg-condition-%d", i)
+		if got := len(trackingBeads(t, store, label)); got != 1 {
+			t.Fatalf("%s tracking markers = %d, want 1", label, got)
+		}
+	}
+}
+
+func countRecordedOrderFailedEvents(t *testing.T, rec *memRecorder) int {
+	t.Helper()
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	count := 0
+	for _, event := range rec.events {
+		if event.Type == events.OrderFailed {
+			count++
+		}
+	}
+	return count
+}
+
 func TestOrderDispatchTriggerEnvFailureTrackingSuppressesNonConditionBeforeEvaluation(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -3454,7 +3534,6 @@ func TestSweepStaleOrderTrackingAcrossStoresClosesRigStoreAndUnblocksDispatch(t 
 		stale.CreatedAt.Add(time.Hour),
 		time.Minute,
 		orderFilterForTest("rig-digest:rig:frontend"),
-		orderTrackingSweepMetadataInitiator,
 		false,
 	)
 	if err != nil {
@@ -3519,7 +3598,6 @@ func TestSweepStaleOrderTrackingAcrossStoresContinuesAfterStoreError(t *testing.
 		cityStale.CreatedAt.Add(time.Hour),
 		time.Minute,
 		nil,
-		orderTrackingSweepMetadataInitiator,
 		false,
 	)
 	if err == nil {
@@ -3846,6 +3924,10 @@ func TestSweepStaleOrderTrackingWithoutWispsLeavesOpenWispSubtree(t *testing.T) 
 	}
 }
 
+func sweepStaleOrderTrackingWithOptions(store beads.Store, now time.Time, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingWithOptionsLimit(store, now, time.Minute, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0)
+}
+
 func TestSweepStaleOrderTrackingWithWispsClosesDeepestFirst(t *testing.T) {
 	base := beads.NewMemStore()
 	store := parentLastCloseStore{Store: base}
@@ -3888,6 +3970,71 @@ func TestSweepStaleOrderTrackingWithWispsClosesDeepestFirst(t *testing.T) {
 
 	for _, id := range []string{wispRoot.ID, child.ID, grandchild.ID} {
 		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingLimitOnlyAppliesToTrackingBeads(t *testing.T) {
+	store := beads.NewMemStore()
+
+	for _, name := range []string{"digest", "digest-retry"} {
+		_, err := store.Create(beads.Bead{
+			Title:     "order:" + name,
+			Labels:    []string{"order-run:" + name, labelOrderTracking},
+			Ephemeral: true,
+		})
+		if err != nil {
+			t.Fatalf("Create(tracking %s): %v", name, err)
+		}
+	}
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "draft-digest",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	grandchild, err := store.Create(beads.Bead{
+		Title:    "nested-step-still-running",
+		ParentID: child.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(grandchild): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptionsLimit(
+		store,
+		time.Now().Add(time.Hour),
+		time.Minute,
+		orderFilterForTest("digest", "digest-retry"),
+		orderTrackingSweepMetadataInitiator,
+		true,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptionsLimit: %v", err)
+	}
+	if result.trackingClosed != 1 {
+		t.Fatalf("trackingClosed = %d, want 1", result.trackingClosed)
+	}
+	if result.wispClosed != 3 {
+		t.Fatalf("wispClosed = %d, want 3", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, child.ID, grandchild.ID} {
+		got, err := store.Get(id)
 		if err != nil {
 			t.Fatalf("Get(%s): %v", id, err)
 		}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -3186,6 +3186,31 @@ func TestSweepOrphanedOrderTrackingLimit_ClosesAtMostBudget(t *testing.T) {
 	}
 }
 
+func TestSweepOrphanedOrderTrackingRetryLimitSpendsRemainingBudget(t *testing.T) {
+	inner := beads.NewMemStore()
+	for _, name := range []string{"one", "two", "three", "four"} {
+		_, err := inner.Create(beads.Bead{
+			Title:  "order:" + name,
+			Labels: []string{"order-run:" + name, labelOrderTracking},
+		})
+		if err != nil {
+			t.Fatalf("Create(%s): %v", name, err)
+		}
+	}
+
+	fs := &closeFailStore{Store: inner, closeN: 1}
+	n, err := sweepOrphanedOrderTrackingRetryLimit(fs, 3, time.Millisecond, 2)
+	if err == nil {
+		t.Fatal("expected error from partial close failure")
+	}
+	if n != 2 {
+		t.Fatalf("n = %d, want 2", n)
+	}
+	if fs.listCalls != 1 {
+		t.Fatalf("ListByLabel calls = %d, want 1 (budget exhaustion should stop retries)", fs.listCalls)
+	}
+}
+
 func TestSweepOrphanedOrderTracking_NoOrphans(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2139,6 +2139,8 @@ Close stale open order-tracking beads.
 
 This is intended for maintenance exec orders. It only closes tracking beads
 older than --stale-after so a fresh in-flight order is not interrupted.
+The manual command runs to completion; controller startup and watchdog sweeps
+use bounded cleanup to avoid spending an unbounded tick on stale work.
 
 Use --include-wisps for operator recovery of abandoned order-run wisp
 subtrees whose open descendants are also older than --stale-after. Pass one


### PR DESCRIPTION
## Summary
- cap automatic order dispatches per controller tick
- rotate the dispatch start index so always-due orders make progress fairly
- add limit-aware order-tracking sweep helpers for bounded cleanup paths

## Tests
- go test ./cmd/gc -run 'TestOrderDispatch|TestSweep.*OrderTracking|TestOrderTracking' -count=1