### PR TITLE
fix(dispatch): batch scope cleanup updates

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -787,6 +787,64 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 	return nil
 }
 
+// UpdateAll modifies the same fields on multiple beads via one bd update
+// invocation. It is intended for controller hot paths that need the semantics
+// of bd update, not bd close, across a batch of known bead IDs.
+func (s *BdStore) UpdateAll(ids []string, opts UpdateOpts) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	args := append([]string{"update", "--json"}, ids...)
+	baseLen := len(args)
+	if opts.Title != nil {
+		args = append(args, "--title", *opts.Title)
+	}
+	if opts.Status != nil {
+		args = append(args, "--status", *opts.Status)
+	}
+	if opts.Type != nil {
+		args = append(args, "--type", *opts.Type)
+	}
+	if opts.Priority != nil {
+		args = append(args, "--priority", strconv.Itoa(*opts.Priority))
+	}
+	if opts.Description != nil {
+		args = append(args, "--description", *opts.Description)
+	}
+	if opts.ParentID != nil {
+		args = append(args, "--parent", *opts.ParentID)
+	}
+	if opts.Assignee != nil {
+		args = append(args, "--assignee", *opts.Assignee)
+	}
+	if len(opts.Metadata) > 0 {
+		keys := make([]string, 0, len(opts.Metadata))
+		for k := range opts.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = append(args, "--set-metadata", k+"="+opts.Metadata[k])
+		}
+	}
+	for _, l := range opts.Labels {
+		args = append(args, "--add-label", l)
+	}
+	for _, l := range opts.RemoveLabels {
+		args = append(args, "--remove-label", l)
+	}
+	if len(args) == baseLen {
+		return 0, nil
+	}
+	if err := s.runBDTransientWrite(args...); err != nil {
+		if isBdNotFound(err) {
+			return 0, fmt.Errorf("batch updating beads %v: %w", ids, ErrNotFound)
+		}
+		return 0, fmt.Errorf("batch updating beads %v: %w", ids, err)
+	}
+	return len(ids), nil
+}
+
 // WaitForParentProjection blocks until bd's parent-child listing projection
 // reflects a successful reparent from oldParentID to newParentID for id.
 func (s *BdStore) WaitForParentProjection(ctx context.Context, id, oldParentID, newParentID string) error {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -914,6 +914,49 @@ func TestBdStoreTxPreservesAddsAndRemovesLabels(t *testing.T) {
 	}
 }
 
+func TestBdStoreUpdateAllBatchesIDsAndRetriesTransientWrite(t *testing.T) {
+	var calls [][]string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			return nil, fmt.Errorf("unexpected command name %q", name)
+		}
+		calls = append(calls, append([]string(nil), args...))
+		if len(calls) == 1 {
+			return nil, fmt.Errorf("Error 1213 (40001): serialization failure")
+		}
+		return nil, nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	status := "closed"
+	updated, err := s.UpdateAll([]string{"bd-1", "bd-2"}, beads.UpdateOpts{
+		Status: &status,
+		Metadata: map[string]string{
+			"phase":      "abort",
+			"gc.outcome": "skipped",
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateAll: %v", err)
+	}
+	if updated != 2 {
+		t.Fatalf("updated = %d, want 2", updated)
+	}
+	want := []string{
+		"update", "--json", "bd-1", "bd-2",
+		"--status", "closed",
+		"--set-metadata", "gc.outcome=skipped",
+		"--set-metadata", "phase=abort",
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls = %d, want 2 transient retry attempts", len(calls))
+	}
+	for i, got := range calls {
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("call[%d] = %v, want %v", i, got, want)
+		}
+	}
+}
+
 func TestBdStoreWaitForParentProjection(t *testing.T) {
 	var mu sync.Mutex
 	showCalls := 0

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -517,6 +517,16 @@ func (fs *FileStore) DepList(id, direction string) ([]Dep, error) {
 	return fs.MemStore.DepList(id, direction)
 }
 
+// DepListBatch reloads the on-disk store before listing batched dependencies.
+func (fs *FileStore) DepListBatch(ids []string) (map[string][]Dep, error) {
+	fs.fmu.Lock()
+	defer fs.fmu.Unlock()
+	if err := fs.refreshReadStateLocked(); err != nil {
+		return nil, err
+	}
+	return fs.MemStore.DepListBatch(ids)
+}
+
 // memSnapshot holds a snapshot of MemStore state for rollback.
 type memSnapshot struct {
 	seq   int

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -483,3 +483,20 @@ func (m *MemStore) DepList(id, direction string) ([]Dep, error) {
 	}
 	return result, nil
 }
+
+// DepListBatch returns "down" dependencies for multiple beads from memory.
+func (m *MemStore) DepListBatch(ids []string) (map[string][]Dep, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	idSet := make(map[string]struct{}, len(ids))
+	result := make(map[string][]Dep, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+	for _, d := range m.deps {
+		if _, ok := idSet[d.IssueID]; ok {
+			result[d.IssueID] = append(result[d.IssueID], d)
+		}
+	}
+	return result, nil
+}

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -583,26 +583,29 @@ func (s scopeSnapshot) skipOpenScopeMembers(store beads.Store, skipControlID str
 
 	skipped := 0
 	for len(pending) > 0 {
-		progress := false
-		for _, id := range sortedPendingIDs(pending) {
-			if !canSkipScopeMember(store, id, pending) {
+		ids := sortedPendingIDs(pending)
+		depsByID, err := loadDownDepsForScopeSkip(store, ids)
+		if err != nil {
+			return skipped, err
+		}
+		skippable := make([]string, 0, len(ids))
+		for _, id := range ids {
+			if !canSkipScopeMemberWithDeps(depsByID[id], pending) {
 				continue
 			}
-			status := "closed"
-			if err := store.Update(id, beads.UpdateOpts{
-				Status:   &status,
-				Metadata: map[string]string{"gc.outcome": "skipped"},
-			}); err != nil {
-				return skipped, fmt.Errorf("closing bead %q: %w", id, err)
-			}
+			skippable = append(skippable, id)
+		}
+		if len(skippable) == 0 {
+			return skipped, fmt.Errorf("unable to skip remaining scope members: %v", ids)
+		}
+		closed, err := skipScopeMembers(store, skippable)
+		if err != nil {
+			return skipped + closed, err
+		}
+		for _, id := range skippable {
 			delete(pending, id)
-			skipped++
-			progress = true
 		}
-		if progress {
-			continue
-		}
-		return skipped, fmt.Errorf("unable to skip remaining scope members: %v", sortedPendingIDs(pending))
+		skipped += closed
 	}
 
 	return skipped, nil
@@ -1192,11 +1195,7 @@ func resolveScopeBodyByRole(store beads.Store, rootID, scopeRef string, includeC
 	return beads.Bead{}, false, nil
 }
 
-func canSkipScopeMember(store beads.Store, beadID string, pending map[string]beads.Bead) bool {
-	deps, err := store.DepList(beadID, "down")
-	if err != nil {
-		return false
-	}
+func canSkipScopeMemberWithDeps(deps []beads.Dep, pending map[string]beads.Bead) bool {
 	for _, dep := range deps {
 		if dep.Type != "blocks" {
 			continue
@@ -1206,6 +1205,62 @@ func canSkipScopeMember(store beads.Store, beadID string, pending map[string]bea
 		}
 	}
 	return true
+}
+
+type scopeSkipDepBatchLister interface {
+	DepListBatch(ids []string) (map[string][]beads.Dep, error)
+}
+
+func loadDownDepsForScopeSkip(store beads.Store, ids []string) (map[string][]beads.Dep, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if batch, ok := store.(scopeSkipDepBatchLister); ok {
+		deps, err := batch.DepListBatch(ids)
+		if err != nil {
+			return nil, fmt.Errorf("batch listing scope skip deps: %w", err)
+		}
+		if deps == nil {
+			deps = make(map[string][]beads.Dep, len(ids))
+		}
+		return deps, nil
+	}
+	depsByID := make(map[string][]beads.Dep, len(ids))
+	for _, id := range ids {
+		deps, err := store.DepList(id, "down")
+		if err != nil {
+			return nil, fmt.Errorf("listing deps for scope skip bead %q: %w", id, err)
+		}
+		depsByID[id] = deps
+	}
+	return depsByID, nil
+}
+
+type scopeSkipBatchUpdater interface {
+	UpdateAll(ids []string, opts beads.UpdateOpts) (int, error)
+}
+
+func skipScopeMembers(store beads.Store, ids []string) (int, error) {
+	status := "closed"
+	opts := beads.UpdateOpts{
+		Status:   &status,
+		Metadata: map[string]string{"gc.outcome": "skipped"},
+	}
+	if batch, ok := store.(scopeSkipBatchUpdater); ok {
+		updated, err := batch.UpdateAll(ids, opts)
+		if err != nil {
+			return updated, fmt.Errorf("closing skipped scope beads %v: %w", ids, err)
+		}
+		return updated, nil
+	}
+	closed := 0
+	for _, id := range ids {
+		if err := store.Update(id, opts); err != nil {
+			return closed, fmt.Errorf("closing bead %q: %w", id, err)
+		}
+		closed++
+	}
+	return closed, nil
 }
 
 func sortedPendingIDs(pending map[string]beads.Bead) []string {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -446,6 +446,113 @@ func TestProcessScopeCheckAbortsScopeOnFailure(t *testing.T) {
 	}
 }
 
+func TestSkipOpenScopeMembersBatchesDependencyChecksAndUpdates(t *testing.T) {
+	t.Parallel()
+
+	store := &scopeSkipBatchStore{MemStore: beads.NewMemStore()}
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": "wf-1",
+			"gc.step_ref":     "demo.body",
+		},
+	})
+	failed := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "preflight",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "fail",
+		},
+	})
+	control := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for preflight",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	futureMember := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "implement",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+		},
+	})
+	futureControl := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for implement",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	independent := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "independent cleanup marker",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": "wf-1",
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+		},
+	})
+
+	mustDepAdd(t, store, futureMember.ID, control.ID, "blocks")
+	mustDepAdd(t, store, futureControl.ID, futureMember.ID, "blocks")
+
+	snapshot := scopeSnapshot{
+		rootID:      "wf-1",
+		scopeRef:    "body",
+		allComplete: true,
+		members:     []beads.Bead{body, failed, control, futureMember, futureControl, independent},
+		body:        body,
+	}
+	skipped, err := snapshot.skipOpenScopeMembers(store, control.ID)
+	if err != nil {
+		t.Fatalf("skipOpenScopeMembers: %v", err)
+	}
+	if skipped != 3 {
+		t.Fatalf("skipped = %d, want 3", skipped)
+	}
+	if store.depListCalls != 0 {
+		t.Fatalf("DepList calls = %d, want 0 when batch dep listing is available", store.depListCalls)
+	}
+	if store.depListBatchCalls != 2 {
+		t.Fatalf("DepListBatch calls = %d, want 2 dependency waves", store.depListBatchCalls)
+	}
+	if store.updateCalls != 0 {
+		t.Fatalf("Update calls = %d, want 0 when batch update is available", store.updateCalls)
+	}
+	if store.updateAllCalls != 2 {
+		t.Fatalf("UpdateAll calls = %d, want 2 dependency waves", store.updateAllCalls)
+	}
+	if got := []int{len(store.updateAllIDs[0]), len(store.updateAllIDs[1])}; !slices.Equal(got, []int{2, 1}) {
+		t.Fatalf("UpdateAll wave sizes = %v, want [2 1]", got)
+	}
+	for _, beadID := range []string{futureMember.ID, futureControl.ID, independent.ID} {
+		member := mustGetBead(t, store, beadID)
+		if member.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", beadID, member.Status)
+		}
+		if got := member.Metadata["gc.outcome"]; got != "skipped" {
+			t.Fatalf("%s outcome = %q, want skipped", beadID, got)
+		}
+	}
+}
+
 func TestProcessScopeCheckTreatsRetryAttemptFailureAsNonTerminalForScope(t *testing.T) {
 	t.Parallel()
 
@@ -1209,6 +1316,15 @@ type countingListStore struct {
 	queries   []beads.ListQuery
 }
 
+type scopeSkipBatchStore struct {
+	*beads.MemStore
+	depListCalls      int
+	depListBatchCalls int
+	updateCalls       int
+	updateAllCalls    int
+	updateAllIDs      [][]string
+}
+
 type scopeBodyVanishAfterFirstResolveStore struct {
 	*beads.MemStore
 	mu       sync.Mutex
@@ -1234,6 +1350,34 @@ func (s *countingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	s.listCalls++
 	s.queries = append(s.queries, query)
 	return s.MemStore.List(query)
+}
+
+func (s *scopeSkipBatchStore) DepList(id, direction string) ([]beads.Dep, error) {
+	s.depListCalls++
+	return s.MemStore.DepList(id, direction)
+}
+
+func (s *scopeSkipBatchStore) DepListBatch(ids []string) (map[string][]beads.Dep, error) {
+	s.depListBatchCalls++
+	return s.MemStore.DepListBatch(ids)
+}
+
+func (s *scopeSkipBatchStore) Update(id string, opts beads.UpdateOpts) error {
+	s.updateCalls++
+	return s.MemStore.Update(id, opts)
+}
+
+func (s *scopeSkipBatchStore) UpdateAll(ids []string, opts beads.UpdateOpts) (int, error) {
+	s.updateAllCalls++
+	s.updateAllIDs = append(s.updateAllIDs, slices.Clone(ids))
+	updated := 0
+	for _, id := range ids {
+		if err := s.MemStore.Update(id, opts); err != nil {
+			return updated, err
+		}
+		updated++
+	}
+	return updated, nil
 }
 
 func (s *scopeBodyVanishAfterFirstResolveStore) List(query beads.ListQuery) ([]beads.Bead, error) {


### PR DESCRIPTION
## Summary
- add batched dependency listing for in-memory and file-backed bead stores
- add BdStore.UpdateAll for one-command multi-bead updates
- use batch dep reads and updates while skipping open workflow scope members

## Tests
- go test ./internal/beads -run 'TestBdStoreUpdateAll|Test.*DepListBatch' -count=1\n- go test ./internal/dispatch -run 'TestSkipOpenScopeMembersBatchesDependencyChecksAndUpdates|TestProcessScope' -count=1