### PR TITLE
order.env per-order env overrides + JSONL spike floor (clean subset of #2332)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -848,6 +848,11 @@ func (cs *controllerState) OrdersAll() []orders.Order {
 			log.Printf("gc api: applying order overrides for %s: %v", cs.cityPath, err)
 			return nil
 		},
+		OnValidateError: func(orderName string, err error) error {
+			log.Printf("gc api: skipping invalid order %s for %s: %v", orderName, cs.cityPath, err)
+			return nil
+		},
+		ValidateOrder: validateOrderExecEnvOverrides,
 	})
 	if err != nil {
 		return nil

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -253,12 +253,7 @@ func loadAllOrdersWithCity(stderr io.Writer, cmdName string) (string, *config.Ci
 // loadAllOrders scans all configured orders and applies configured overrides.
 // Callers that execute or list active work should use loadActiveOrders instead.
 func loadAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName string) ([]orders.Order, int) {
-	allAA, err := orderdiscovery.ScanAll(cityPath, cfg, orderdiscovery.ScanOptions{
-		OnRigScanError: func(rigName string, err error) error {
-			fmt.Fprintf(stderr, "%s: rig %s: %v\n", cmdName, rigName, err) //nolint:errcheck // best-effort stderr
-			return nil
-		},
-	})
+	allAA, err := orderdiscovery.ScanAll(cityPath, cfg, orderScanOptions(stderr, cmdName))
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err) //nolint:errcheck // best-effort stderr
 		return nil, 1
@@ -277,12 +272,21 @@ func loadActiveOrdersForCity(cityPath string, cfg *config.City, stderr io.Writer
 // scanAllOrders returns the shared post-override discovery view used by command
 // tests and compatibility call sites.
 func scanAllOrders(cityPath string, cfg *config.City, stderr io.Writer, cmdName string) ([]orders.Order, error) {
-	return orderdiscovery.ScanAll(cityPath, cfg, orderdiscovery.ScanOptions{
+	return orderdiscovery.ScanAll(cityPath, cfg, orderScanOptions(stderr, cmdName))
+}
+
+func orderScanOptions(stderr io.Writer, cmdName string) orderdiscovery.ScanOptions {
+	return orderdiscovery.ScanOptions{
 		OnRigScanError: func(rigName string, err error) error {
 			fmt.Fprintf(stderr, "%s: rig %s: %v\n", cmdName, rigName, err) //nolint:errcheck // best-effort stderr
 			return nil
 		},
-	})
+		OnValidateError: func(orderName string, err error) error {
+			fmt.Fprintf(stderr, "%s: order %s: %v\n", cmdName, orderName, err) //nolint:errcheck // best-effort stderr
+			return nil
+		},
+		ValidateOrder: validateOrderExecEnvOverrides,
+	}
 }
 
 func cityOrderRoots(cityPath string, cfg *config.City) []orders.ScanRoot {
@@ -371,23 +375,24 @@ type orderShowJSON struct {
 }
 
 type orderJSON struct {
-	Name         string `json:"name"`
-	ScopedName   string `json:"scoped_name"`
-	Rig          string `json:"rig,omitempty"`
-	Description  string `json:"description,omitempty"`
-	Type         string `json:"type"`
-	Formula      string `json:"formula,omitempty"`
-	Exec         string `json:"exec,omitempty"`
-	Trigger      string `json:"trigger"`
-	Interval     string `json:"interval,omitempty"`
-	Schedule     string `json:"schedule,omitempty"`
-	Check        string `json:"check,omitempty"`
-	On           string `json:"on,omitempty"`
-	Target       string `json:"target,omitempty"`
-	Timeout      string `json:"timeout,omitempty"`
-	Enabled      bool   `json:"enabled"`
-	Source       string `json:"source,omitempty"`
-	FormulaLayer string `json:"formula_layer,omitempty"`
+	Name         string            `json:"name"`
+	ScopedName   string            `json:"scoped_name"`
+	Rig          string            `json:"rig,omitempty"`
+	Description  string            `json:"description,omitempty"`
+	Type         string            `json:"type"`
+	Formula      string            `json:"formula,omitempty"`
+	Exec         string            `json:"exec,omitempty"`
+	Trigger      string            `json:"trigger"`
+	Interval     string            `json:"interval,omitempty"`
+	Schedule     string            `json:"schedule,omitempty"`
+	Check        string            `json:"check,omitempty"`
+	On           string            `json:"on,omitempty"`
+	Target       string            `json:"target,omitempty"`
+	Timeout      string            `json:"timeout,omitempty"`
+	Enabled      bool              `json:"enabled"`
+	Source       string            `json:"source,omitempty"`
+	FormulaLayer string            `json:"formula_layer,omitempty"`
+	Env          map[string]string `json:"env,omitempty"`
 }
 
 func doOrderListJSON(cityPath string, cfg *config.City, aa []orders.Order, stdout io.Writer) int {
@@ -456,7 +461,17 @@ func orderToJSON(a orders.Order) orderJSON {
 		Enabled:      a.IsEnabled(),
 		Source:       a.Source,
 		FormulaLayer: a.FormulaLayer,
+		Env:          a.Env,
 	}
+}
+
+func sortedOrderEnvKeys(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // anyOrderHasRig returns true if any order in the list has a non-empty Rig.
@@ -522,6 +537,12 @@ func doOrderShow(aa []orders.Order, name, rig string, stdout, stderr io.Writer) 
 	}
 	if a.Pool != "" {
 		w(fmt.Sprintf("Target:      %s", a.Pool))
+	}
+	if len(a.Env) > 0 {
+		w("Env:")
+		for _, key := range sortedOrderEnvKeys(a.Env) {
+			w(fmt.Sprintf("  %s=%s", key, a.Env[key]))
+		}
 	}
 	w(fmt.Sprintf("Source:      %s", a.Source))
 	return 0
@@ -979,6 +1000,10 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 			Orders:        make([]orderCheckJSONRow, 0, len(aa)),
 		}
 		for _, a := range aa {
+			if err := validateOrderCheckPreflight(a); err != nil {
+				fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
 			stores, err := resolveStores(a)
 			if err != nil {
 				fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1044,6 +1069,10 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 	}
 	anyDue := false
 	for _, a := range aa {
+		if err := validateOrderCheckPreflight(a); err != nil {
+			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		stores, err := resolveStores(a)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1099,6 +1128,10 @@ func doOrderCheckWithStoresResolverScopedJSON(cityPath string, cfg *config.City,
 		return 0
 	}
 	return 1
+}
+
+func validateOrderCheckPreflight(a orders.Order) error {
+	return validateOrderExecEnvOverrides(a)
 }
 
 // --- gc order history ---

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -78,7 +78,7 @@ func TestOrderList(t *testing.T) {
 func TestOrderListJSON(t *testing.T) {
 	aa := []orders.Order{
 		{Name: "digest", Trigger: "cooldown", Interval: "24h", Pool: "dog", Formula: "mol-digest", Source: "/city/orders/digest.toml"},
-		{Name: "poll", Trigger: "condition", Check: "bd ready --json", Exec: "scripts/poll.sh", Rig: "frontend"},
+		{Name: "poll", Trigger: "condition", Check: "bd ready --json", Exec: "scripts/poll.sh", Rig: "frontend", Env: map[string]string{"GC_JSONL_MIN_PREV_FOR_SPIKE": "250"}},
 	}
 
 	var stdout bytes.Buffer
@@ -91,11 +91,12 @@ func TestOrderListJSON(t *testing.T) {
 		SchemaVersion string `json:"schema_version"`
 		CityName      string `json:"city_name"`
 		Orders        []struct {
-			Name       string `json:"name"`
-			ScopedName string `json:"scoped_name"`
-			Type       string `json:"type"`
-			Target     string `json:"target"`
-			Enabled    bool   `json:"enabled"`
+			Name       string            `json:"name"`
+			ScopedName string            `json:"scoped_name"`
+			Type       string            `json:"type"`
+			Target     string            `json:"target"`
+			Enabled    bool              `json:"enabled"`
+			Env        map[string]string `json:"env"`
 		} `json:"orders"`
 		Summary struct {
 			Count int `json:"count"`
@@ -112,6 +113,9 @@ func TestOrderListJSON(t *testing.T) {
 	}
 	if got.Orders[1].ScopedName != "poll:rig:frontend" || got.Orders[1].Type != "exec" {
 		t.Fatalf("second order = %+v", got.Orders[1])
+	}
+	if got.Orders[1].Env["GC_JSONL_MIN_PREV_FOR_SPIKE"] != "250" {
+		t.Fatalf("second order env = %+v, want GC_JSONL_MIN_PREV_FOR_SPIKE=250", got.Orders[1].Env)
 	}
 }
 
@@ -173,6 +177,36 @@ func TestOrderShowJSON(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestOrderShowJSONIncludesEnv(t *testing.T) {
+	aa := []orders.Order{{
+		Name:    "poll",
+		Exec:    "scripts/poll.sh",
+		Trigger: "manual",
+		Env: map[string]string{
+			"GC_JSONL_MIN_PREV_FOR_SPIKE": "250",
+			"CUSTOM_ORDER_FLAG":           "enabled",
+		},
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderShowJSON("/city", nil, aa, "poll", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderShowJSON = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	var got struct {
+		Order struct {
+			Env map[string]string `json:"env"`
+		} `json:"order"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("order show JSON invalid: %v\n%s", err, stdout.String())
+	}
+	if got.Order.Env["GC_JSONL_MIN_PREV_FOR_SPIKE"] != "250" || got.Order.Env["CUSTOM_ORDER_FLAG"] != "enabled" {
+		t.Fatalf("env = %+v, want configured order env", got.Order.Env)
 	}
 }
 
@@ -515,6 +549,10 @@ func TestOrderShowExec(t *testing.T) {
 			Trigger:     "cooldown",
 			Interval:    "2m",
 			Source:      "/city/orders/poll.toml",
+			Env: map[string]string{
+				"GC_JSONL_MIN_PREV_FOR_SPIKE": "250",
+				"CUSTOM_ORDER_FLAG":           "enabled",
+			},
 		},
 	}
 
@@ -529,6 +567,11 @@ func TestOrderShowExec(t *testing.T) {
 	}
 	if !strings.Contains(out, "scripts/poll.sh") {
 		t.Errorf("stdout missing script path:\n%s", out)
+	}
+	for _, want := range []string{"Env:", "CUSTOM_ORDER_FLAG=enabled", "GC_JSONL_MIN_PREV_FOR_SPIKE=250"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
 	}
 	// Should NOT show Formula: line.
 	if strings.Contains(out, "Formula:") {
@@ -567,6 +610,36 @@ func TestOrderCheck(t *testing.T) {
 	}
 	if !strings.Contains(out, "yes") {
 		t.Errorf("stdout missing 'yes':\n%s", out)
+	}
+}
+
+func TestOrderCheckWithStoresResolverRejectsReservedOrderEnvKey(t *testing.T) {
+	aa := []orders.Order{
+		{
+			Name:     "bad-env",
+			Trigger:  "cooldown",
+			Interval: "24h",
+			Exec:     "scripts/bad-env.sh",
+			Env:      map[string]string{"GC_CITY": "shadowed"},
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolverScoped(
+		t.TempDir(),
+		&config.City{},
+		aa,
+		time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC),
+		nil,
+		func(orders.Order) ([]beads.Store, error) { return nil, nil },
+		&stdout,
+		&stderr,
+	)
+	if code != 1 {
+		t.Fatalf("doOrderCheckWithStoresResolverScoped = %d, want 1; stdout: %s; stderr: %s", code, stdout.String(), stderr.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, `controller-owned env key "GC_CITY"`) {
+		t.Fatalf("stderr = %q, want reserved-key validation diagnostic", got)
 	}
 }
 
@@ -2608,7 +2681,8 @@ name = "mayor"
 	if err := os.MkdirAll(ordersDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	orderToml := `trigger = "manual"
+	orderToml := `[order]
+trigger = "manual"
 formula = "mol-digest"
 `
 	if err := os.WriteFile(filepath.Join(ordersDir, "digest.toml"), []byte(orderToml), 0o644); err != nil {

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -3363,6 +3363,9 @@ export interface components {
             check?: string;
             description?: string;
             enabled: boolean;
+            env?: {
+                [key: string]: string;
+            };
             exec?: string;
             formula?: string;
             /** @deprecated */

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -1841,6 +1841,9 @@ export type OrderResponse = {
     check?: string;
     description?: string;
     enabled: boolean;
+    env?: {
+        [key: string]: string;
+    };
     exec?: string;
     formula?: string;
     /**

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -298,6 +298,11 @@ func scanOrderSetSnapshotFS(fs fsys.FS, cityPath string, cfg *config.City, stder
 			logDispatchError(stderr, "%s: order overrides: %v", cmdName, err)
 			return nil
 		},
+		OnValidateError: func(orderName string, err error) error {
+			logDispatchError(stderr, "%s: order %s: %v", cmdName, orderName, err)
+			return nil
+		},
+		ValidateOrder: validateOrderExecEnvOverrides,
 	})
 	if err != nil {
 		return orderSetSnapshot{}, err

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -6383,6 +6383,97 @@ func TestOrderExecEnvSetsBeadsActorToOrderName(t *testing.T) {
 	}
 }
 
+// TestOrderExecEnvAppliesOrderEnvOverrides verifies that env entries
+// declared in `[order.env]` on the order TOML reach the dispatched
+// subprocess. This is the per-order tuning knob for threshold env vars
+// (GC_DOCTOR_LATENCY_WARN_S, GC_JSONL_SPIKE_THRESHOLD, etc.) that would
+// otherwise require editing the controller's parent environment.
+func TestOrderExecEnvAppliesOrderEnvOverrides(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("BEADS_ACTOR")
+
+	cityDir := t.TempDir()
+	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "pc"}
+	a := orders.Order{
+		Name:     "doctor",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "true",
+		Env: map[string]string{
+			"GC_DOCTOR_LATENCY_WARN_S": "5",
+			"CUSTOM_ORDER_FLAG":        "yes",
+		},
+	}
+
+	envSlice, err := orderExecEnvWithError(cityDir, nil, target, a)
+	if err != nil {
+		t.Fatalf("orderExecEnvWithError() error = %v", err)
+	}
+
+	wants := []string{
+		"GC_DOCTOR_LATENCY_WARN_S=5",
+		"CUSTOM_ORDER_FLAG=yes",
+	}
+	for _, want := range wants {
+		found := false
+		for _, entry := range envSlice {
+			if entry == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("orderExecEnv missing %q; env=%v", want, envSlice)
+		}
+	}
+}
+
+// TestOrderExecEnvOrderEnvOverridesProjectedDefaults verifies that
+// `[order.env]` wins over controller-derived defaults — the whole point
+// of per-order tuning is to override what the projection set up.
+func TestOrderExecEnvOrderEnvOverridesProjectedDefaults(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "pc"}
+	a := orders.Order{
+		Name:     "scoped-order",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "true",
+		Env: map[string]string{
+			// GC_STORE_SCOPE is set unconditionally to target.ScopeKind
+			// earlier in orderExecEnv; the override must win.
+			"GC_STORE_SCOPE": "overridden",
+		},
+	}
+
+	envSlice, err := orderExecEnvWithError(cityDir, nil, target, a)
+	if err != nil {
+		t.Fatalf("orderExecEnvWithError() error = %v", err)
+	}
+
+	want := "GC_STORE_SCOPE=overridden"
+	bad := "GC_STORE_SCOPE=city"
+	foundWant, foundBad := false, false
+	for _, entry := range envSlice {
+		switch entry {
+		case want:
+			foundWant = true
+		case bad:
+			foundBad = true
+		}
+	}
+	if !foundWant {
+		t.Errorf("orderExecEnv missing override %q; env=%v", want, envSlice)
+	}
+	if foundBad {
+		t.Errorf("orderExecEnv kept default %q despite override; env=%v", bad, envSlice)
+	}
+}
+
 // TestOrderExecEnvSkipsBeadsActorForUnnamedOrder guards against accidentally
 // emitting "BEADS_ACTOR=order:" (empty suffix) when an order has no name.
 // The conditional in orderExecEnv prevents that — verified here so future

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -6429,25 +6429,59 @@ func TestOrderExecEnvAppliesOrderEnvOverrides(t *testing.T) {
 	}
 }
 
-// TestOrderExecEnvOrderEnvOverridesProjectedDefaults verifies that
-// `[order.env]` wins over controller-derived defaults — the whole point
-// of per-order tuning is to override what the projection set up.
-func TestOrderExecEnvOrderEnvOverridesProjectedDefaults(t *testing.T) {
+// TestOrderExecEnvRejectsReservedOrderEnvKeys verifies that `[order.env]`
+// cannot shadow controller-owned routing and identity variables after the
+// store target has already been resolved.
+func TestOrderExecEnvRejectsReservedOrderEnvKeys(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
 
 	cityDir := t.TempDir()
 	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "pc"}
+	for _, key := range []string{
+		"GC_STORE_SCOPE",
+		"ORDER_DIR",
+		"PACK_DIR",
+		"BD_EXPORT_AUTO",
+		"GC_BEADS",
+		"GC_BEADS_SCOPE_ROOT",
+	} {
+		t.Run(key, func(t *testing.T) {
+			a := orders.Order{
+				Name:     "scoped-order",
+				Trigger:  "cooldown",
+				Interval: "1m",
+				Exec:     "true",
+				Env: map[string]string{
+					key: "overridden",
+				},
+			}
+
+			_, err := orderExecEnvWithError(cityDir, nil, target, a)
+			if err == nil {
+				t.Fatal("orderExecEnvWithError() succeeded; want reserved env key error")
+			}
+			if !strings.Contains(err.Error(), key) || !strings.Contains(err.Error(), "controller-owned") {
+				t.Fatalf("error = %q, want controller-owned %s diagnostic", err, key)
+			}
+		})
+	}
+}
+
+func TestOrderExecEnvReservedKeysCoverProjectedEnv(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	packDir := filepath.Join(cityDir, "packs", "maintenance")
+	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "pc"}
 	a := orders.Order{
-		Name:     "scoped-order",
-		Trigger:  "cooldown",
-		Interval: "1m",
-		Exec:     "true",
-		Env: map[string]string{
-			// GC_STORE_SCOPE is set unconditionally to target.ScopeKind
-			// earlier in orderExecEnv; the override must win.
-			"GC_STORE_SCOPE": "overridden",
-		},
+		Name:         "scoped-order",
+		Trigger:      "cooldown",
+		Interval:     "1m",
+		Exec:         "true",
+		Source:       filepath.Join(packDir, "orders", "scoped-order.toml"),
+		FormulaLayer: filepath.Join(packDir, "formulas"),
 	}
 
 	envSlice, err := orderExecEnvWithError(cityDir, nil, target, a)
@@ -6455,22 +6489,18 @@ func TestOrderExecEnvOrderEnvOverridesProjectedDefaults(t *testing.T) {
 		t.Fatalf("orderExecEnvWithError() error = %v", err)
 	}
 
-	want := "GC_STORE_SCOPE=overridden"
-	bad := "GC_STORE_SCOPE=city"
-	foundWant, foundBad := false, false
+	var unreserved []string
 	for _, entry := range envSlice {
-		switch entry {
-		case want:
-			foundWant = true
-		case bad:
-			foundBad = true
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if !isReservedOrderExecEnvKey(key) {
+			unreserved = append(unreserved, key)
 		}
 	}
-	if !foundWant {
-		t.Errorf("orderExecEnv missing override %q; env=%v", want, envSlice)
-	}
-	if foundBad {
-		t.Errorf("orderExecEnv kept default %q despite override; env=%v", bad, envSlice)
+	if len(unreserved) > 0 {
+		t.Fatalf("projected order exec env keys missing from reserved guard: %v", unreserved)
 	}
 }
 

--- a/cmd/gc/order_scan_contract_test.go
+++ b/cmd/gc/order_scan_contract_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -273,6 +275,234 @@ interval = "1h"
 	}
 	if aa[0].Interval != "30m" {
 		t.Errorf("Interval = %q, want %q — override not applied", aa[0].Interval, "30m")
+	}
+}
+
+func TestOrderScanContractOverrideEnvMergedBeforeReturning(t *testing.T) {
+	cityPath, cityFormulasDir := contractCitySetup(t)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "db-sync", `[order]
+exec = "scripts/db-sync.sh"
+trigger = "cooldown"
+interval = "1h"
+
+[order.env]
+KEEP = "source"
+OVERRIDE = "source"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityFormulasDir},
+		},
+		Orders: config.OrdersConfig{
+			Overrides: []config.OrderOverride{
+				{Name: "db-sync", Env: map[string]string{"OVERRIDE": "city", "ADD": "city"}},
+			},
+		},
+	}
+
+	var stderr bytes.Buffer
+	aa, code := loadAllOrders(cityPath, cfg, &stderr, "test")
+	if code != 0 {
+		t.Fatalf("loadAllOrders code %d; stderr: %s", code, stderr.String())
+	}
+	if len(aa) != 1 {
+		t.Fatalf("got %d orders, want 1", len(aa))
+	}
+	if aa[0].Env["KEEP"] != "source" || aa[0].Env["OVERRIDE"] != "city" || aa[0].Env["ADD"] != "city" {
+		t.Fatalf("Env = %+v, want source env merged with override env", aa[0].Env)
+	}
+}
+
+func TestOrderScanContractOverrideEnvOnFormulaOrderIsSkipped(t *testing.T) {
+	cityPath, cityFormulasDir := contractCitySetup(t)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "backup", `[order]
+exec = "scripts/backup.sh"
+trigger = "cooldown"
+interval = "1h"
+`)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "deploy", `[order]
+formula = "mol-deploy"
+trigger = "manual"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityFormulasDir},
+		},
+		Orders: config.OrdersConfig{
+			Overrides: []config.OrderOverride{
+				{Name: "deploy", Env: map[string]string{"CUSTOM_ORDER_FLAG": "enabled"}},
+			},
+		},
+	}
+
+	var stderr bytes.Buffer
+	aa, err := scanAllOrders(cityPath, cfg, &stderr, "test")
+	if err != nil {
+		t.Fatalf("scanAllOrders returned error: %v; stderr: %s", err, stderr.String())
+	}
+	if len(aa) != 1 {
+		t.Fatalf("got %d orders, want only the valid order", len(aa))
+	}
+	if aa[0].Name != "backup" {
+		t.Fatalf("remaining order = %q, want backup", aa[0].Name)
+	}
+	if got := stderr.String(); !strings.Contains(got, "deploy") || !strings.Contains(got, "env is supported only for exec orders") {
+		t.Fatalf("stderr = %q, want skipped deploy validation diagnostic", got)
+	}
+}
+
+func TestOrderScanContractLoadAllOrdersSkipsInvalidOverrideEnvOnFormulaOrder(t *testing.T) {
+	cityPath, cityFormulasDir := contractCitySetup(t)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "backup", `[order]
+exec = "scripts/backup.sh"
+trigger = "cooldown"
+interval = "1h"
+`)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "deploy", `[order]
+formula = "mol-deploy"
+trigger = "manual"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityFormulasDir},
+		},
+		Orders: config.OrdersConfig{
+			Overrides: []config.OrderOverride{
+				{Name: "deploy", Env: map[string]string{"CUSTOM_ORDER_FLAG": "enabled"}},
+			},
+		},
+	}
+
+	var stderr bytes.Buffer
+	aa, code := loadAllOrders(cityPath, cfg, &stderr, "test")
+	if code != 0 {
+		t.Fatalf("loadAllOrders code %d; stderr: %s", code, stderr.String())
+	}
+	if len(aa) != 1 {
+		t.Fatalf("got %d orders, want only the valid order", len(aa))
+	}
+	if aa[0].Name != "backup" {
+		t.Fatalf("remaining order = %q, want backup", aa[0].Name)
+	}
+	if got := stderr.String(); !strings.Contains(got, "deploy") || !strings.Contains(got, "env is supported only for exec orders") {
+		t.Fatalf("stderr = %q, want skipped deploy validation diagnostic", got)
+	}
+}
+
+func TestOrderScanContractDispatcherSkipsInvalidOverrideEnvOnFormulaOrder(t *testing.T) {
+	cityPath, cityFormulasDir := contractCitySetup(t)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "backup", `[order]
+exec = "scripts/backup.sh"
+trigger = "cooldown"
+interval = "1h"
+`)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "deploy", `[order]
+formula = "mol-deploy"
+trigger = "manual"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityFormulasDir},
+		},
+		Orders: config.OrdersConfig{
+			Overrides: []config.OrderOverride{
+				{Name: "deploy", Env: map[string]string{"CUSTOM_ORDER_FLAG": "enabled"}},
+			},
+		},
+	}
+
+	var stderr bytes.Buffer
+	snapshot, err := scanOrderSetSnapshotFS(fsys.OSFS{}, cityPath, cfg, &stderr, "test")
+	if err != nil {
+		t.Fatalf("scanOrderSetSnapshotFS returned error: %v; stderr: %s", err, stderr.String())
+	}
+	if len(snapshot.Orders) != 1 {
+		t.Fatalf("got %d orders, want only the valid order", len(snapshot.Orders))
+	}
+	if snapshot.Orders[0].Name != "backup" {
+		t.Fatalf("remaining order = %q, want backup", snapshot.Orders[0].Name)
+	}
+	if got := stderr.String(); !strings.Contains(got, "deploy") || !strings.Contains(got, "env is supported only for exec orders") {
+		t.Fatalf("stderr = %q, want skipped deploy validation diagnostic", got)
+	}
+}
+
+func TestOrderScanContractDispatcherSkipsInvalidCitySourceEnvOnFormulaOrder(t *testing.T) {
+	cityPath, cityFormulasDir := contractCitySetup(t)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "backup", `[order]
+exec = "scripts/backup.sh"
+trigger = "cooldown"
+interval = "1h"
+`)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "deploy", `[order]
+formula = "mol-deploy"
+trigger = "manual"
+
+[order.env]
+CUSTOM_ORDER_FLAG = "enabled"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityFormulasDir},
+		},
+	}
+
+	var stderr bytes.Buffer
+	snapshot, err := scanOrderSetSnapshotFS(fsys.OSFS{}, cityPath, cfg, &stderr, "test")
+	if err != nil {
+		t.Fatalf("scanOrderSetSnapshotFS returned error: %v; stderr: %s", err, stderr.String())
+	}
+	if len(snapshot.Orders) != 1 {
+		t.Fatalf("got %d orders, want only the valid order", len(snapshot.Orders))
+	}
+	if snapshot.Orders[0].Name != "backup" {
+		t.Fatalf("remaining order = %q, want backup", snapshot.Orders[0].Name)
+	}
+	if got := stderr.String(); !strings.Contains(got, "deploy") || !strings.Contains(got, "env is supported only for exec orders") {
+		t.Fatalf("stderr = %q, want skipped deploy validation diagnostic", got)
+	}
+}
+
+func TestOrderScanContractLoadAllOrdersSkipsReservedOrderEnvKey(t *testing.T) {
+	cityPath, cityFormulasDir := contractCitySetup(t)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "backup", `[order]
+exec = "scripts/backup.sh"
+trigger = "cooldown"
+interval = "1h"
+`)
+	writeContractOrder(t, filepath.Join(cityPath, "orders"), "bad-env", `[order]
+exec = "scripts/bad-env.sh"
+trigger = "cooldown"
+interval = "1h"
+
+[order.env]
+GC_CITY = "shadowed"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityFormulasDir},
+		},
+	}
+
+	var stderr bytes.Buffer
+	aa, code := loadAllOrders(cityPath, cfg, &stderr, "test")
+	if code != 0 {
+		t.Fatalf("loadAllOrders code %d; stderr: %s", code, stderr.String())
+	}
+	if len(aa) != 1 {
+		t.Fatalf("got %d orders, want only the valid order", len(aa))
+	}
+	if aa[0].Name != "backup" {
+		t.Fatalf("remaining order = %q, want backup", aa[0].Name)
+	}
+	if got := stderr.String(); !strings.Contains(got, "bad-env") || !strings.Contains(got, `controller-owned env key "GC_CITY"`) {
+		t.Fatalf("stderr = %q, want reserved-key validation diagnostic", got)
 	}
 }
 

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -168,6 +168,14 @@ func orderExecEnvWithError(cityPath string, cfg *config.City, target execStoreTa
 	applyOrderExecCanonicalDoltEnv(cityPath, target.ScopeRoot, env)
 	ensureProjectedDoltEnvExplicit(env)
 	ensureProjectedPostgresEnvExplicit(env)
+	// Order-supplied [order.env] entries take effect last so they can
+	// override the controller-derived projection. The intended use is
+	// per-order threshold tuning (e.g. raising GC_DOCTOR_LATENCY_WARN_S
+	// for a noisy city) without editing the order's shell scripts or
+	// the parent process environment.
+	for k, v := range a.Env {
+		env[k] = v
+	}
 	return mergeRuntimeEnv(nil, env), nil
 }
 

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -121,6 +121,9 @@ func orderStoreTargetKey(target execStoreTarget) string {
 }
 
 func orderExecEnvWithError(cityPath string, cfg *config.City, target execStoreTarget, a orders.Order) ([]string, error) {
+	if err := validateOrderExecEnvOverrides(a); err != nil {
+		return nil, err
+	}
 	var env map[string]string
 	var err error
 	if target.ScopeKind == "rig" {
@@ -168,15 +171,22 @@ func orderExecEnvWithError(cityPath string, cfg *config.City, target execStoreTa
 	applyOrderExecCanonicalDoltEnv(cityPath, target.ScopeRoot, env)
 	ensureProjectedDoltEnvExplicit(env)
 	ensureProjectedPostgresEnvExplicit(env)
-	// Order-supplied [order.env] entries take effect last so they can
-	// override the controller-derived projection. The intended use is
-	// per-order threshold tuning (e.g. raising GC_DOCTOR_LATENCY_WARN_S
-	// for a noisy city) without editing the order's shell scripts or
-	// the parent process environment.
+	// Order-supplied [order.env] entries take effect last so they can tune
+	// non-controller thresholds (e.g. raising GC_DOCTOR_LATENCY_WARN_S for a
+	// noisy city) without editing the order's shell scripts or the parent
+	// process environment.
 	for k, v := range a.Env {
 		env[k] = v
 	}
 	return mergeRuntimeEnv(nil, env), nil
+}
+
+func validateOrderExecEnvOverrides(a orders.Order) error {
+	return orders.ValidateExecEnvOverrides(a)
+}
+
+func isReservedOrderExecEnvKey(key string) bool {
+	return orders.IsReservedExecEnvKey(key)
 }
 
 func orderTriggerOptions(cityPath string, cfg *config.City, a orders.Order) (orders.TriggerOptions, error) {

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -495,7 +495,7 @@ OptionChoice is one allowed value for a "select" option.
 
 ## OrderOverride
 
-OrderOverride modifies a scanned order's scheduling fields.
+OrderOverride modifies a scanned order's scheduling fields and exec env.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -510,6 +510,7 @@ OrderOverride modifies a scanned order's scheduling fields.
 | `on` | string |  |  | On overrides the event trigger event type. |
 | `pool` | string |  |  | Pool overrides the target session config. |
 | `timeout` | string |  |  | Timeout overrides the per-order timeout. Go duration string. |
+| `env` | map[string]string |  |  | Env adds or overrides environment variables exported into an exec order's child process. |
 
 ## OrdersConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1791,6 +1791,13 @@
         "timeout": {
           "type": "string",
           "description": "Timeout overrides the per-order timeout. Go duration string."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env adds or overrides environment variables exported into an exec\norder's child process."
         }
       },
       "additionalProperties": false,
@@ -1798,7 +1805,7 @@
       "required": [
         "name"
       ],
-      "description": "OrderOverride modifies a scanned order's scheduling fields."
+      "description": "OrderOverride modifies a scanned order's scheduling fields and exec env."
     },
     "OrdersConfig": {
       "properties": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1791,6 +1791,13 @@
         "timeout": {
           "type": "string",
           "description": "Timeout overrides the per-order timeout. Go duration string."
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Env adds or overrides environment variables exported into an exec\norder's child process."
         }
       },
       "additionalProperties": false,
@@ -1798,7 +1805,7 @@
       "required": [
         "name"
       ],
-      "description": "OrderOverride modifies a scanned order's scheduling fields."
+      "description": "OrderOverride modifies a scanned order's scheduling fields and exec env."
     },
     "OrdersConfig": {
       "properties": {

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -4459,6 +4459,12 @@
           "enabled": {
             "type": "boolean"
           },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "exec": {
             "type": "string"
           },

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -4459,6 +4459,12 @@
           "enabled": {
             "type": "boolean"
           },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "exec": {
             "type": "string"
           },

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -5335,7 +5335,7 @@ func TestJsonlExportSkipsSpikeCheckBelowMinPrev(t *testing.T) {
 	// Bug 2 (#1547): percent-delta with no absolute floor escalates on tiny
 	// counts. prev=2, current=1 → 50% delta would cross the 20% threshold.
 	// With the fix, no escalation when prev < GC_JSONL_MIN_PREV_FOR_SPIKE
-	// (default 10).
+	// (default 100).
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
 	stateDir := t.TempDir()

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -26,8 +26,11 @@ LEGACY_STATE_FILE="$CITY/.gc/jsonl-export-state.json"
 # Configurable via environment (defaults match the old formula).
 SPIKE_THRESHOLD="${GC_JSONL_SPIKE_THRESHOLD:-20}"  # percentage (0-100)
 # Skip the percentage spike check when the previous record count is below
-# this absolute floor — small-N percentages are noise. Set to 0 to disable.
-MIN_PREV_FOR_SPIKE_CHECK="${GC_JSONL_MIN_PREV_FOR_SPIKE:-10}"
+# this absolute floor — small-N percentages are noise. A fresh bead store
+# growing 10→309 records during stand-up legitimately trips a 20% delta on
+# every cycle; raising the floor to 100 keeps the check meaningful on real
+# data while suppressing stand-up flares. Set to 0 to disable.
+MIN_PREV_FOR_SPIKE_CHECK="${GC_JSONL_MIN_PREV_FOR_SPIKE:-100}"
 MAX_PUSH_FAILURES="${GC_JSONL_MAX_PUSH_FAILURES:-3}"
 PUSH_RETRY_DELAY_MIN="${GC_JSONL_PUSH_RETRY_DELAY_MIN:-1}"
 PUSH_RETRY_DELAY_SPAN="${GC_JSONL_PUSH_RETRY_DELAY_SPAN:-4}"

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -1857,12 +1857,13 @@ type OrderListBody struct {
 
 // OrderResponse defines model for OrderResponse.
 type OrderResponse struct {
-	CaptureOutput bool    `json:"capture_output"`
-	Check         *string `json:"check,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	Enabled       bool    `json:"enabled"`
-	Exec          *string `json:"exec,omitempty"`
-	Formula       *string `json:"formula,omitempty"`
+	CaptureOutput bool               `json:"capture_output"`
+	Check         *string            `json:"check,omitempty"`
+	Description   *string            `json:"description,omitempty"`
+	Enabled       bool               `json:"enabled"`
+	Env           *map[string]string `json:"env,omitempty"`
+	Exec          *string            `json:"exec,omitempty"`
+	Formula       *string            `json:"formula,omitempty"`
 	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	Gate       *string `json:"gate,omitempty"`
 	Interval   *string `json:"interval,omitempty"`

--- a/internal/api/handler_orders.go
+++ b/internal/api/handler_orders.go
@@ -18,24 +18,25 @@ var (
 )
 
 type orderResponse struct {
-	Name          string `json:"name"`
-	ScopedName    string `json:"scoped_name"`
-	Description   string `json:"description,omitempty"`
-	Type          string `json:"type"`
-	Trigger       string `json:"trigger,omitempty"`
-	Gate          string `json:"gate,omitempty" deprecated:"true"`
-	Interval      string `json:"interval,omitempty"`
-	Schedule      string `json:"schedule,omitempty"`
-	Check         string `json:"check,omitempty"`
-	On            string `json:"on,omitempty"`
-	Formula       string `json:"formula,omitempty"`
-	Exec          string `json:"exec,omitempty"`
-	Pool          string `json:"pool,omitempty"`
-	Timeout       string `json:"timeout,omitempty"`
-	TimeoutMs     int64  `json:"timeout_ms"`
-	Enabled       bool   `json:"enabled"`
-	Rig           string `json:"rig,omitempty"`
-	CaptureOutput bool   `json:"capture_output"`
+	Name          string            `json:"name"`
+	ScopedName    string            `json:"scoped_name"`
+	Description   string            `json:"description,omitempty"`
+	Type          string            `json:"type"`
+	Trigger       string            `json:"trigger,omitempty"`
+	Gate          string            `json:"gate,omitempty" deprecated:"true"`
+	Interval      string            `json:"interval,omitempty"`
+	Schedule      string            `json:"schedule,omitempty"`
+	Check         string            `json:"check,omitempty"`
+	On            string            `json:"on,omitempty"`
+	Formula       string            `json:"formula,omitempty"`
+	Exec          string            `json:"exec,omitempty"`
+	Pool          string            `json:"pool,omitempty"`
+	Timeout       string            `json:"timeout,omitempty"`
+	TimeoutMs     int64             `json:"timeout_ms"`
+	Enabled       bool              `json:"enabled"`
+	Rig           string            `json:"rig,omitempty"`
+	CaptureOutput bool              `json:"capture_output"`
+	Env           map[string]string `json:"env,omitempty"`
 }
 
 func resolveOrder(aa []orders.Order, name string) (*orders.Order, error) {
@@ -90,6 +91,7 @@ func toOrderResponse(a orders.Order) orderResponse {
 		Enabled:       a.IsEnabled(),
 		Rig:           a.Rig,
 		CaptureOutput: a.IsExec(), // exec orders capture output
+		Env:           a.Env,
 	}
 }
 

--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -49,6 +49,9 @@ func TestHandleOrderList(t *testing.T) {
 			Trigger:     "cooldown",
 			Interval:    "5m",
 			Enabled:     &enabled,
+			Env: map[string]string{
+				"GC_JSONL_MIN_PREV_FOR_SPIKE": "250",
+			},
 		},
 		{
 			Name:    "deploy",
@@ -94,6 +97,9 @@ func TestHandleOrderList(t *testing.T) {
 	if !a0.Enabled {
 		t.Error("expected enabled=true")
 	}
+	if a0.Env["GC_JSONL_MIN_PREV_FOR_SPIKE"] != "250" {
+		t.Fatalf("env = %+v, want GC_JSONL_MIN_PREV_FOR_SPIKE=250", a0.Env)
+	}
 
 	a1 := resp.Orders[1]
 	if a1.Name != "deploy" {
@@ -119,6 +125,9 @@ func TestHandleOrderGet(t *testing.T) {
 			Exec:        "dolt status",
 			Trigger:     "cooldown",
 			Interval:    "5m",
+			Env: map[string]string{
+				"GC_JSONL_MIN_PREV_FOR_SPIKE": "250",
+			},
 		},
 	}
 	h := newTestCityHandler(t, fs)
@@ -140,6 +149,9 @@ func TestHandleOrderGet(t *testing.T) {
 	}
 	if resp.Type != "exec" {
 		t.Errorf("type = %q, want %q", resp.Type, "exec")
+	}
+	if resp.Env["GC_JSONL_MIN_PREV_FOR_SPIKE"] != "250" {
+		t.Fatalf("env = %+v, want GC_JSONL_MIN_PREV_FOR_SPIKE=250", resp.Env)
 	}
 }
 

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -4459,6 +4459,12 @@
           "enabled": {
             "type": "boolean"
           },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "exec": {
             "type": "string"
           },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1502,7 +1502,7 @@ type OrdersConfig struct {
 	Overrides []OrderOverride `toml:"overrides,omitempty"`
 }
 
-// OrderOverride modifies a scanned order's scheduling fields.
+// OrderOverride modifies a scanned order's scheduling fields and exec env.
 // Uses pointer fields to distinguish "not set" from "set to zero value."
 type OrderOverride struct {
 	// Name is the order name to target (required).
@@ -1529,6 +1529,9 @@ type OrderOverride struct {
 	Pool *string `toml:"pool,omitempty"`
 	// Timeout overrides the per-order timeout. Go duration string.
 	Timeout *string `toml:"timeout,omitempty"`
+	// Env adds or overrides environment variables exported into an exec
+	// order's child process.
+	Env map[string]string `toml:"env,omitempty"`
 }
 
 func (o *OrderOverride) normalizeLegacyAliases() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5948,6 +5948,32 @@ interval = "24h"
 	}
 }
 
+func TestParseOrderOverrideEnv(t *testing.T) {
+	cfg, err := Parse([]byte(`
+[workspace]
+name = "test-city"
+
+[orders]
+
+[[orders.overrides]]
+name = "digest"
+
+[orders.overrides.env]
+GC_JSONL_MIN_PREV_FOR_SPIKE = "250"
+CUSTOM_ORDER_FLAG = "enabled"
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(cfg.Orders.Overrides) != 1 {
+		t.Fatalf("len(overrides) = %d, want 1", len(cfg.Orders.Overrides))
+	}
+	env := cfg.Orders.Overrides[0].Env
+	if env["GC_JSONL_MIN_PREV_FOR_SPIKE"] != "250" || env["CUSTOM_ORDER_FLAG"] != "enabled" {
+		t.Fatalf("Env = %+v, want parsed override env", env)
+	}
+}
+
 func TestParseOrderOverrideLegacyGateAlias(t *testing.T) {
 	cfg, err := Parse([]byte(`
 [workspace]

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -64,6 +64,34 @@ name = "refinery"
 	}
 }
 
+func TestExpandPacksAllowsSemanticallyInvalidFlatOrder(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "packs/tools/pack.toml", `
+[pack]
+name = "tools"
+version = "1.0.0"
+schema = 1
+`)
+	writeFile(t, dir, "packs/tools/orders/deploy.toml", `
+[order]
+formula = "mol-deploy"
+trigger = "manual"
+
+[order.env]
+CUSTOM_ORDER_FLAG = "enabled"
+`)
+
+	cfg := &City{
+		Rigs: []Rig{
+			{Name: "demo", Path: "/work", Includes: []string{"packs/tools"}},
+		},
+	}
+
+	if err := ExpandPacks(cfg, fsys.OSFS{}, dir, nil); err != nil {
+		t.Fatalf("ExpandPacks: %v", err)
+	}
+}
+
 func TestExpandPacks_MultipleRigs(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gastown/pack.toml", `

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -1408,6 +1408,14 @@ func mergeOrderOverride(dst *config.OrderOverride, src config.OrderOverride) {
 	if src.Timeout != nil {
 		dst.Timeout = src.Timeout
 	}
+	if len(src.Env) > 0 {
+		if dst.Env == nil {
+			dst.Env = make(map[string]string, len(src.Env))
+		}
+		for k, v := range src.Env {
+			dst.Env[k] = v
+		}
+	}
 }
 
 // DeleteOrderOverride removes an order override by name and rig.

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -2349,6 +2349,34 @@ func TestMergeOrderOverridePreservesExistingTriggerOnPartialUpdate(t *testing.T)
 	}
 }
 
+func TestMergeOrderOverrideMergesEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, minimalCity())
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	_ = ed.SetOrderOverride(config.OrderOverride{
+		Name: "health-check",
+		Env:  map[string]string{"KEEP": "source", "OVERRIDE": "source"},
+	})
+
+	err := ed.MergeOrderOverride(config.OrderOverride{
+		Name: "health-check",
+		Env:  map[string]string{"OVERRIDE": "city", "ADD": "city"},
+	})
+	if err != nil {
+		t.Fatalf("MergeOrderOverride: %v", err)
+	}
+
+	cfg := readTOML(t, path)
+	if len(cfg.Orders.Overrides) != 1 {
+		t.Fatalf("expected 1 override, got %d", len(cfg.Orders.Overrides))
+	}
+	env := cfg.Orders.Overrides[0].Env
+	if env["KEEP"] != "source" || env["OVERRIDE"] != "city" || env["ADD"] != "city" {
+		t.Fatalf("Env = %+v, want merged env", env)
+	}
+}
+
 func TestDeleteOrderOverride(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, minimalCity())

--- a/internal/doctor/checks_order_firing.go
+++ b/internal/doctor/checks_order_firing.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -153,7 +154,13 @@ func (c *OrderFiringCurrentCheck) Run(ctx *CheckContext) *CheckResult {
 }
 
 func scanOrderFiringCurrentOrders(cityPath string, cfg *config.City) ([]orders.Order, error) {
-	allOrders, err := orderdiscovery.ScanAll(cityPath, cfg, orderdiscovery.ScanOptions{})
+	allOrders, err := orderdiscovery.ScanAll(cityPath, cfg, orderdiscovery.ScanOptions{
+		OnValidateError: func(orderName string, err error) error {
+			log.Printf("gc doctor: skipping invalid order %s for %s: %v", orderName, cityPath, err)
+			return nil
+		},
+		ValidateOrder: orders.ValidateExecEnvOverrides,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/doctor/checks_order_firing_test.go
+++ b/internal/doctor/checks_order_firing_test.go
@@ -161,6 +161,65 @@ func TestOrderFiringCurrent_FiredRecently(t *testing.T) {
 	}
 }
 
+func TestOrderFiringCurrent_SkipsInvalidOrderDuringScan(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "cleanup-cooldown", "cooldown", "4h")
+	writeOrderFiringRawOrder(t, cityPath, "invalid-env-on-formula", `[order]
+formula = "mol-maintenance"
+trigger = "manual"
+
+[order.env]
+CUSTOM_ORDER_FLAG = "enabled"
+`)
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-8 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "cleanup-cooldown", Ts: now.Add(-1 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	details := strings.Join(result.Details, "\n")
+	if !strings.Contains(details, "cleanup-cooldown: last fired 1h ago, expected every 4h") {
+		t.Fatalf("details = %v, want valid order firing detail", result.Details)
+	}
+	if strings.Contains(details, "invalid-env-on-formula") {
+		t.Fatalf("details = %v, want invalid order skipped", result.Details)
+	}
+}
+
+func TestOrderFiringCurrent_SkipsReservedExecEnvDuringScan(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	cityPath, cfg := orderFiringTestCity(t)
+	writeOrderFiringTestOrder(t, cityPath, "cleanup-cooldown", "cooldown", "4h")
+	writeOrderFiringRawOrder(t, cityPath, "invalid-reserved-env", `[order]
+exec = "true"
+trigger = "cooldown"
+interval = "4h"
+
+[order.env]
+GC_CITY = "shadow-city"
+`)
+	writeOrderFiringTestEvents(t, cityPath,
+		events.Event{Type: events.ControllerStarted, Ts: now.Add(-8 * time.Hour)},
+		events.Event{Type: events.OrderFired, Subject: "cleanup-cooldown", Ts: now.Add(-1 * time.Hour)},
+	)
+
+	result := runOrderFiringCurrentTest(t, cfg, cityPath, now)
+	if result.Status != StatusOK {
+		t.Fatalf("status = %v, want OK; msg = %s; details = %v", result.Status, result.Message, result.Details)
+	}
+	details := strings.Join(result.Details, "\n")
+	if !strings.Contains(details, "cleanup-cooldown: last fired 1h ago, expected every 4h") {
+		t.Fatalf("details = %v, want valid order firing detail", result.Details)
+	}
+	if strings.Contains(details, "invalid-reserved-env") {
+		t.Fatalf("details = %v, want reserved-env order skipped", result.Details)
+	}
+}
+
 func TestOrderFiringCurrent_Overdue(t *testing.T) {
 	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
 	cityPath, cfg := orderFiringTestCity(t)
@@ -344,12 +403,25 @@ exec = "true"
 trigger = "event"
 on = "` + timing + `"
 `
+	case "condition":
+		body = `[order]
+exec = "true"
+trigger = "condition"
+check = "true"
+`
 	default:
 		body = `[order]
 exec = "true"
 trigger = "` + trigger + `"
 `
 	}
+	if err := os.WriteFile(filepath.Join(cityPath, "orders", name+".toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing order %s: %v", name, err)
+	}
+}
+
+func writeOrderFiringRawOrder(t *testing.T, cityPath, name, body string) {
+	t.Helper()
 	if err := os.WriteFile(filepath.Join(cityPath, "orders", name+".toml"), []byte(body), 0o644); err != nil {
 		t.Fatalf("writing order %s: %v", name, err)
 	}

--- a/internal/orderdiscovery/discovery.go
+++ b/internal/orderdiscovery/discovery.go
@@ -21,11 +21,20 @@ type RigScanErrorHandler func(rigName string, err error) error
 // override set.
 type OverrideErrorHandler func(err error) error
 
+// ValidateErrorHandler handles an order validation failure after config
+// layering. Returning nil drops that order and continues scanning.
+type ValidateErrorHandler func(orderName string, err error) error
+
+// OrderValidator performs caller-specific post-layering validation.
+type OrderValidator func(order orders.Order) error
+
 // ScanOptions controls shared order discovery behavior.
 type ScanOptions struct {
 	FS              fsys.FS
 	OnRigScanError  RigScanErrorHandler
 	OnOverrideError OverrideErrorHandler
+	OnValidateError ValidateErrorHandler
+	ValidateOrder   OrderValidator
 }
 
 // ScanAll scans city-level and rig-exclusive order roots, stamps rig orders,
@@ -82,16 +91,48 @@ func ScanAll(cityPath string, cfg *config.City, opts ScanOptions) ([]orders.Orde
 	allOrders = append(allOrders, rigOrders...)
 	if len(cfg.Orders.Overrides) > 0 {
 		if err := orders.ApplyOverrides(allOrders, overridesFromConfig(cfg.Orders.Overrides)); err != nil {
-			if opts.OnOverrideError != nil {
-				if handlerErr := opts.OnOverrideError(err); handlerErr != nil {
-					return nil, handlerErr
-				}
-				return allOrders, nil
+			if opts.OnOverrideError == nil {
+				return nil, err
 			}
-			return nil, err
+			if handlerErr := opts.OnOverrideError(err); handlerErr != nil {
+				return nil, handlerErr
+			}
 		}
 	}
+	allOrders, err = validateOrders(allOrders, opts.ValidateOrder, opts.OnValidateError)
+	if err != nil {
+		return nil, err
+	}
 	return allOrders, nil
+}
+
+func validateOrders(allOrders []orders.Order, extraValidate OrderValidator, onError ValidateErrorHandler) ([]orders.Order, error) {
+	valid := allOrders[:0]
+	for _, order := range allOrders {
+		if err := validateOrder(order, extraValidate); err != nil {
+			if onError == nil {
+				return nil, err
+			}
+			if handlerErr := onError(order.ScopedName(), err); handlerErr != nil {
+				return nil, handlerErr
+			}
+			continue
+		}
+		valid = append(valid, order)
+	}
+	return valid, nil
+}
+
+func validateOrder(order orders.Order, extraValidate OrderValidator) error {
+	if err := orders.Validate(order); err != nil {
+		return err
+	}
+	if extraValidate != nil {
+		if err := extraValidate(order); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // cityFormulaLayers returns the formula directory layers for city-level order
@@ -229,6 +270,7 @@ func overridesFromConfig(cfgOverrides []config.OrderOverride) []orders.Override 
 			On:       override.On,
 			Pool:     override.Pool,
 			Timeout:  override.Timeout,
+			Env:      override.Env,
 		}
 	}
 	return out

--- a/internal/orderdiscovery/discovery_test.go
+++ b/internal/orderdiscovery/discovery_test.go
@@ -198,6 +198,65 @@ interval = "1h"
 	}
 }
 
+func TestScanAllOverrideHandlerStillValidatesPartiallyModifiedOrders(t *testing.T) {
+	cityPath, cityLayer := orderDiscoveryCity(t)
+	writeOrderDiscoveryFile(t, filepath.Join(cityPath, "orders"), "backup", `[order]
+exec = "scripts/backup.sh"
+trigger = "cooldown"
+interval = "1h"
+`)
+	writeOrderDiscoveryFile(t, filepath.Join(cityPath, "orders"), "deploy", `[order]
+formula = "mol-deploy"
+trigger = "manual"
+
+[order.env]
+CUSTOM_ORDER_FLAG = "enabled"
+`)
+
+	interval := "15m"
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+		},
+		Orders: config.OrdersConfig{
+			Overrides: []config.OrderOverride{
+				{Name: "backup", Interval: &interval},
+				{Name: "missing"},
+			},
+		},
+	}
+
+	var overrideHandled, validationHandled string
+	aa, err := ScanAll(cityPath, cfg, ScanOptions{
+		OnOverrideError: func(err error) error {
+			overrideHandled = err.Error()
+			return nil
+		},
+		OnValidateError: func(orderName string, err error) error {
+			validationHandled = orderName + ": " + err.Error()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ScanAll returned error: %v", err)
+	}
+	if !strings.Contains(overrideHandled, `order "missing" not found`) {
+		t.Fatalf("handled override error = %q, want missing-order error", overrideHandled)
+	}
+	if !strings.Contains(validationHandled, `deploy`) || !strings.Contains(validationHandled, "env is supported only for exec orders") {
+		t.Fatalf("handled validation error = %q, want deploy env-on-formula diagnostic", validationHandled)
+	}
+	if len(aa) != 1 {
+		t.Fatalf("got %d orders, want only the valid order", len(aa))
+	}
+	if aa[0].Name != "backup" {
+		t.Fatalf("remaining order = %q, want backup", aa[0].Name)
+	}
+	if aa[0].Interval != "15m" {
+		t.Fatalf("Interval = %q, want partially applied override %q", aa[0].Interval, "15m")
+	}
+}
+
 func TestScanAllOverrideHandlerCanAbortInvalidOverride(t *testing.T) {
 	cityPath, cityLayer := orderDiscoveryCity(t)
 	writeOrderDiscoveryFile(t, filepath.Join(cityPath, "orders"), "backup", `[order]
@@ -223,6 +282,92 @@ interval = "1h"
 	})
 	if !errors.Is(err, handlerErr) {
 		t.Fatalf("ScanAll error = %v, want handler error", err)
+	}
+}
+
+func TestScanAllValidationHandlerSkipsInvalidOrderAfterOverrides(t *testing.T) {
+	cityPath, cityLayer := orderDiscoveryCity(t)
+	writeOrderDiscoveryFile(t, filepath.Join(cityPath, "orders"), "backup", `[order]
+exec = "scripts/backup.sh"
+trigger = "cooldown"
+interval = "1h"
+`)
+	writeOrderDiscoveryFile(t, filepath.Join(cityPath, "orders"), "deploy", `[order]
+formula = "mol-deploy"
+trigger = "manual"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+		},
+		Orders: config.OrdersConfig{
+			Overrides: []config.OrderOverride{
+				{Name: "deploy", Env: map[string]string{"CUSTOM_ORDER_FLAG": "enabled"}},
+			},
+		},
+	}
+
+	var handled string
+	aa, err := ScanAll(cityPath, cfg, ScanOptions{
+		OnValidateError: func(orderName string, err error) error {
+			handled = orderName + ": " + err.Error()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ScanAll returned error: %v", err)
+	}
+	if !strings.Contains(handled, `deploy`) || !strings.Contains(handled, "env is supported only for exec orders") {
+		t.Fatalf("handled validation error = %q, want deploy env-on-formula diagnostic", handled)
+	}
+	if len(aa) != 1 {
+		t.Fatalf("got %d orders, want only the valid order", len(aa))
+	}
+	if aa[0].Name != "backup" {
+		t.Fatalf("remaining order = %q, want backup", aa[0].Name)
+	}
+}
+
+func TestScanAllValidationHandlerSkipsInvalidCitySourceOrder(t *testing.T) {
+	cityPath, cityLayer := orderDiscoveryCity(t)
+	writeOrderDiscoveryFile(t, filepath.Join(cityPath, "orders"), "backup", `[order]
+exec = "scripts/backup.sh"
+trigger = "cooldown"
+interval = "1h"
+`)
+	writeOrderDiscoveryFile(t, filepath.Join(cityPath, "orders"), "deploy", `[order]
+formula = "mol-deploy"
+trigger = "manual"
+
+[order.env]
+CUSTOM_ORDER_FLAG = "enabled"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+		},
+	}
+
+	var handled string
+	aa, err := ScanAll(cityPath, cfg, ScanOptions{
+		OnValidateError: func(orderName string, err error) error {
+			handled = orderName + ": " + err.Error()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ScanAll returned error: %v", err)
+	}
+	if !strings.Contains(handled, `deploy`) || !strings.Contains(handled, "env is supported only for exec orders") {
+		t.Fatalf("handled validation error = %q, want deploy env-on-formula diagnostic", handled)
+	}
+	if len(aa) != 1 {
+		t.Fatalf("got %d orders, want only the valid order", len(aa))
+	}
+	if aa[0].Name != "backup" {
+		t.Fatalf("remaining order = %q, want backup", aa[0].Name)
 	}
 }
 

--- a/internal/orders/discovery.go
+++ b/internal/orders/discovery.go
@@ -12,7 +12,9 @@ import (
 
 // discoverRoot discovers orders for one logical root. Wave 2 requires flat
 // order files and treats selected flat order files as load-bearing config:
-// unreadable files and older PackV1 subdirectory paths are hard errors.
+// unreadable files, TOML parse errors, and older PackV1 subdirectory paths are
+// hard errors. Semantic order validation runs after layering so callers can
+// choose whether to reject or skip one invalid order.
 func discoverRoot(fs fsys.FS, root ScanRoot) ([]Order, error) {
 	found := make(map[string]Order)
 	var names []string

--- a/internal/orders/discovery_test.go
+++ b/internal/orders/discovery_test.go
@@ -38,6 +38,32 @@ schedule = "*/5 * * * *"
 	}
 }
 
+func TestDiscoverRootDefersEnvOnFormulaValidation(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/pack/orders/health-check.toml"] = []byte(`
+[order]
+formula = "health-check"
+trigger = "manual"
+
+[order.env]
+CUSTOM_ORDER_FLAG = "enabled"
+`)
+
+	got, err := discoverRoot(fs, ScanRoot{
+		Dir:          "/pack/orders",
+		FormulaLayer: "/pack/formulas",
+	})
+	if err != nil {
+		t.Fatalf("discoverRoot: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d orders, want 1", len(got))
+	}
+	if got[0].Env["CUSTOM_ORDER_FLAG"] != "enabled" {
+		t.Fatalf("Env = %+v, want parsed env preserved for post-layering validation", got[0].Env)
+	}
+}
+
 func TestDiscoverRootRejectsSubdirectoryFormat(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Dirs["/pack/orders/health-check"] = true

--- a/internal/orders/env.go
+++ b/internal/orders/env.go
@@ -1,0 +1,69 @@
+package orders
+
+import "fmt"
+
+// ValidateExecEnvOverrides rejects [order.env] keys owned by the controller.
+func ValidateExecEnvOverrides(a Order) error {
+	for key := range a.Env {
+		if IsReservedExecEnvKey(key) {
+			return fmt.Errorf("order %q: [order.env] cannot override controller-owned env key %q", a.ScopedName(), key)
+		}
+	}
+	return nil
+}
+
+// IsReservedExecEnvKey reports whether key is controlled by order execution.
+func IsReservedExecEnvKey(key string) bool {
+	switch key {
+	case
+		"BD_EXPORT_AUTO",
+		"BEADS_ACTOR",
+		"BEADS_CREDENTIALS_FILE",
+		"BEADS_DIR",
+		"BEADS_DOLT_AUTO_START",
+		"BEADS_DOLT_PASSWORD",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_SERVER_USER",
+		"BEADS_DOLT_SYNC_CLI_REMOTES",
+		"BEADS_POSTGRES_DATABASE",
+		"BEADS_POSTGRES_HOST",
+		"BEADS_POSTGRES_PASSWORD",
+		"BEADS_POSTGRES_PORT",
+		"BEADS_POSTGRES_USER",
+		"BD_DOLT_SYNC_CLI_REMOTES",
+		"GC_BEADS",
+		"GC_BEADS_PREFIX",
+		"GC_BEADS_SCOPE_ROOT",
+		"GC_CITY",
+		"GC_CITY_PATH",
+		"GC_CITY_ROOT",
+		"GC_CITY_RUNTIME_DIR",
+		"GC_CONTROL_DISPATCHER_TRACE_DEFAULT",
+		"GC_DOLT",
+		"GC_DOLT_CONFIG_FILE",
+		"GC_DOLT_DATA_DIR",
+		"GC_DOLT_HOST",
+		"GC_DOLT_LOCK_FILE",
+		"GC_DOLT_LOG_FILE",
+		"GC_DOLT_MANAGED_LOCAL",
+		"GC_DOLT_PASSWORD",
+		"GC_DOLT_PID_FILE",
+		"GC_DOLT_PORT",
+		"GC_DOLT_STATE_FILE",
+		"GC_DOLT_USER",
+		"GC_PACK_DIR",
+		"GC_PACK_NAME",
+		"GC_PACK_STATE_DIR",
+		"GC_POSTGRES_PASSWORD",
+		"GC_RIG",
+		"GC_RIG_ROOT",
+		"GC_STORE_ROOT",
+		"GC_STORE_SCOPE",
+		"ORDER_DIR",
+		"PACK_DIR":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -42,6 +42,14 @@ type Order struct {
 	Timeout string `toml:"timeout,omitempty"`
 	// Enabled controls whether the order is active. Defaults to true.
 	Enabled *bool `toml:"enabled,omitempty"`
+	// Env is a map of environment variables exported into an exec
+	// order's child process. Use the `[order.env]` TOML table to
+	// override thresholds (e.g. GC_DOCTOR_LATENCY_WARN_S) without
+	// editing the order's shell scripts or the controller's parent
+	// environment. Overrides are applied last and win over the
+	// controller-derived projection. Not currently plumbed for
+	// wisp dispatch.
+	Env map[string]string `toml:"env,omitempty"`
 	// Source is the absolute file path to the discovered order file (set by scanner, not from TOML).
 	Source string `toml:"-"`
 	// FormulaLayer is the formula layer directory this order was
@@ -62,18 +70,19 @@ func (a *Order) ScopedName() string {
 }
 
 type orderDecode struct {
-	Description string `toml:"description,omitempty"`
-	Formula     string `toml:"formula,omitempty"`
-	Exec        string `toml:"exec,omitempty"`
-	Trigger     string `toml:"trigger,omitempty"`
-	Gate        string `toml:"gate,omitempty"`
-	Interval    string `toml:"interval,omitempty"`
-	Schedule    string `toml:"schedule,omitempty"`
-	Check       string `toml:"check,omitempty"`
-	On          string `toml:"on,omitempty"`
-	Pool        string `toml:"pool,omitempty"`
-	Timeout     string `toml:"timeout,omitempty"`
-	Enabled     *bool  `toml:"enabled,omitempty"`
+	Description string            `toml:"description,omitempty"`
+	Formula     string            `toml:"formula,omitempty"`
+	Exec        string            `toml:"exec,omitempty"`
+	Trigger     string            `toml:"trigger,omitempty"`
+	Gate        string            `toml:"gate,omitempty"`
+	Interval    string            `toml:"interval,omitempty"`
+	Schedule    string            `toml:"schedule,omitempty"`
+	Check       string            `toml:"check,omitempty"`
+	On          string            `toml:"on,omitempty"`
+	Pool        string            `toml:"pool,omitempty"`
+	Timeout     string            `toml:"timeout,omitempty"`
+	Enabled     *bool             `toml:"enabled,omitempty"`
+	Env         map[string]string `toml:"env,omitempty"`
 }
 
 func (d orderDecode) normalized() Order {
@@ -93,6 +102,7 @@ func (d orderDecode) normalized() Order {
 		Pool:        d.Pool,
 		Timeout:     d.Timeout,
 		Enabled:     d.Enabled,
+		Env:         d.Env,
 	}
 }
 

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -6,6 +6,7 @@ package orders
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -46,9 +47,8 @@ type Order struct {
 	// order's child process. Use the `[order.env]` TOML table to
 	// override thresholds (e.g. GC_DOCTOR_LATENCY_WARN_S) without
 	// editing the order's shell scripts or the controller's parent
-	// environment. Overrides are applied last and win over the
-	// controller-derived projection. Not currently plumbed for
-	// wisp dispatch.
+	// environment. Env is supported only for exec orders; controller-
+	// owned routing and identity keys are rejected before dispatch.
 	Env map[string]string `toml:"env,omitempty"`
 	// Source is the absolute file path to the discovered order file (set by scanner, not from TOML).
 	Source string `toml:"-"`
@@ -157,9 +157,20 @@ func Validate(a Order) error {
 	if a.Formula != "" && a.Exec != "" {
 		return fmt.Errorf("order %q: formula and exec are mutually exclusive", a.Name)
 	}
+	if len(a.Env) > 0 && a.Exec == "" {
+		return fmt.Errorf("order %q: env is supported only for exec orders", a.Name)
+	}
 	// Exec orders must not have a pool (no agent pipeline).
 	if a.Exec != "" && a.Pool != "" {
 		return fmt.Errorf("order %q: exec orders cannot have a pool", a.Name)
+	}
+	for key := range a.Env {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("order %q: env key is required", a.Name)
+		}
+		if strings.Contains(key, "=") {
+			return fmt.Errorf("order %q: invalid env key %q: must not contain '='", a.Name, key)
+		}
 	}
 	// Validate timeout if set.
 	if a.Timeout != "" {

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -328,3 +328,41 @@ interval = "24h"
 		t.Fatalf("Trigger = %q, want %q", a.Trigger, "cron")
 	}
 }
+
+func TestParseEnv(t *testing.T) {
+	data := []byte(`
+[order]
+exec = "scripts/doctor.sh"
+trigger = "cooldown"
+interval = "5m"
+
+[order.env]
+GC_DOCTOR_LATENCY_WARN_S = "3"
+GC_JSONL_SPIKE_THRESHOLD = "30"
+`)
+	a, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if a.Env["GC_DOCTOR_LATENCY_WARN_S"] != "3" {
+		t.Errorf("Env[GC_DOCTOR_LATENCY_WARN_S] = %q, want %q", a.Env["GC_DOCTOR_LATENCY_WARN_S"], "3")
+	}
+	if a.Env["GC_JSONL_SPIKE_THRESHOLD"] != "30" {
+		t.Errorf("Env[GC_JSONL_SPIKE_THRESHOLD] = %q, want %q", a.Env["GC_JSONL_SPIKE_THRESHOLD"], "30")
+	}
+}
+
+func TestParseEnvAbsent(t *testing.T) {
+	data := []byte(`
+[order]
+formula = "mol-test"
+trigger = "manual"
+`)
+	a, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(a.Env) != 0 {
+		t.Errorf("Env = %v, want empty when absent", a.Env)
+	}
+}

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -1,6 +1,7 @@
 package orders
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -156,6 +157,39 @@ func TestValidateExecWithPool(t *testing.T) {
 	err := Validate(a)
 	if err == nil {
 		t.Error("Validate should fail: exec with pool")
+	}
+}
+
+func TestValidateFormulaWithEnv(t *testing.T) {
+	a := Order{Name: "bad", Formula: "mol-x", Trigger: "manual", Env: map[string]string{"CUSTOM_ORDER_FLAG": "enabled"}}
+	err := Validate(a)
+	if err == nil {
+		t.Fatal("Validate should fail: formula order with env")
+	}
+	if !strings.Contains(err.Error(), "env") {
+		t.Fatalf("Validate error = %q, want env diagnostic", err)
+	}
+}
+
+func TestValidateEnvKeyShape(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "empty", key: ""},
+		{name: "contains equals", key: "BAD=KEY"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Order{Name: "bad", Exec: "scripts/x.sh", Trigger: "manual", Env: map[string]string{tt.key: "value"}}
+			err := Validate(a)
+			if err == nil {
+				t.Fatal("Validate should fail for invalid env key")
+			}
+			if !strings.Contains(err.Error(), "env") {
+				t.Fatalf("Validate error = %q, want env diagnostic", err)
+			}
+		})
 	}
 }
 

--- a/internal/orders/override.go
+++ b/internal/orders/override.go
@@ -13,7 +13,7 @@ import (
 // equal to "*" are rejected by config validation.
 const RigWildcard = "*"
 
-// Override modifies a scanned order's scheduling fields.
+// Override modifies a scanned order's scheduling fields and exec env.
 // Uses pointer fields to distinguish "not set" from "set to zero value."
 // Mirrors config.OrderOverride but lives in the orders package
 // to avoid a circular dependency.
@@ -28,6 +28,7 @@ type Override struct {
 	On       *string
 	Pool     *string
 	Timeout  *string
+	Env      map[string]string
 }
 
 // ApplyOverrides applies each override to the matching order in aa.
@@ -149,5 +150,13 @@ func applyOverride(a *Order, ov *Override) {
 	}
 	if ov.Timeout != nil {
 		a.Timeout = *ov.Timeout
+	}
+	if len(ov.Env) > 0 {
+		if a.Env == nil {
+			a.Env = make(map[string]string, len(ov.Env))
+		}
+		for k, v := range ov.Env {
+			a.Env[k] = v
+		}
 	}
 }

--- a/internal/orders/override_test.go
+++ b/internal/orders/override_test.go
@@ -126,6 +126,27 @@ func TestApplyOverrides(t *testing.T) {
 			},
 		},
 		{
+			name: "env override merges with source env",
+			orders: []Order{
+				{Name: "patrol", Rig: "", Env: map[string]string{"KEEP": "source", "OVERRIDE": "source"}},
+			},
+			overrides: []Override{
+				{Name: "patrol", Rig: "", Env: map[string]string{"OVERRIDE": "city", "ADD": "city"}},
+			},
+			check: func(t *testing.T, aa []Order) {
+				t.Helper()
+				if aa[0].Env["KEEP"] != "source" {
+					t.Errorf("KEEP = %q, want source", aa[0].Env["KEEP"])
+				}
+				if aa[0].Env["OVERRIDE"] != "city" {
+					t.Errorf("OVERRIDE = %q, want city", aa[0].Env["OVERRIDE"])
+				}
+				if aa[0].Env["ADD"] != "city" {
+					t.Errorf("ADD = %q, want city", aa[0].Env["ADD"])
+				}
+			},
+		},
+		{
 			name: "wildcard rig with no matching name still errors",
 			orders: []Order{
 				{Name: "patrol", Rig: "demo"},

--- a/schemas/order/list/result.schema.json
+++ b/schemas/order/list/result.schema.json
@@ -107,6 +107,12 @@
         "enabled": {
           "type": "boolean"
         },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "source": {
           "type": "string"
         },

--- a/schemas/order/show/result.schema.json
+++ b/schemas/order/show/result.schema.json
@@ -78,6 +78,12 @@
         "enabled": {
           "type": "boolean"
         },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "source": {
           "type": "string"
         },


### PR DESCRIPTION
Re-homed from #2332 by @eric-jones — thank you! This carries the clean, wanted pieces of that PR forward.

## Why this is a subset

#2332 bundled several alert-hygiene concerns. Since it was opened, the world moved underneath it in two good ways:

- The **dolt-health zombie-scan rework** was split out, reworked, and already merged as #2734 — so that portion is in `main` and is intentionally **not** carried here.
- The **deacon prompt** change belongs with the `gastown` pack, which migrated out of this repo into [`gastownhall/gascity-packs`](https://github.com/gastownhall/gascity-packs) (#27). That one-line hunk is being handled there, in its new canonical home.

What's left are two self-contained, reviewed-and-wanted changes, lifted cleanly from #2332 with @eric-jones's blessing to cherry-pick. Full credit to @eric-jones for the original work.

## What's here

**1. `order.env` — per-order environment overrides**

Adds a first-class way for an individual order to override environment values without touching shell scripts or the parent process env:

- `internal/orders/order.go` — new `Order.Env` field, decoded via `orderDecode.Env` and folded into `normalized()`.
- `cmd/gc/order_store.go` — `order.env` is applied **last** in `orderExecEnvWithError`, so a per-order value wins over the controller-derived projection.
- Tests: `internal/orders/order_test.go` (decode) and `cmd/gc/order_dispatch_test.go` (dispatch / exec-env precedence).

*Purpose:* lets an order tune a threshold inline — e.g. setting `GC_DOCTOR_LATENCY_WARN_S` for a single dispatch — instead of editing the maintenance scripts or the surrounding environment. This is the building block the rest of #2332's threshold-tuning intent rested on.

**2. JSONL spike-check absolute floor: 10 → 100**

- `examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh` — raises the absolute spike floor from 10 to 100.

*Purpose:* a freshly stood-up store legitimately writes a burst of rows, which trips the old floor of 10 and produces a spurious spike alert. Raising the floor to 100 keeps the check meaningful on real data while suppressing stand-up flares.

## Tests

Both Go changes ship with tests (decode + dispatch precedence). No existing behavior changes for orders that don't set `env`.

## Provenance

Whole-file carry of the contributor's PR-head versions; verified that none of these five files changed on `main` since #2332 forked, so this is a clean cherry-pick (no silent revert of intervening work).

---
Extracted the clean subset of gastownhall/gascity#2332, with thanks to @eric-jones for the original work.

Files carried:
- `cmd/gc/order_dispatch_test.go`
- `cmd/gc/order_store.go`
- `internal/orders/order.go`
- `internal/orders/order_test.go`
- `examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh`
