### PR TITLE
fix(ci): bump bd archive version to v1.0.5

### DIFF
--- a/.github/scripts/install-bd-archive.sh
+++ b/.github/scripts/install-bd-archive.sh
@@ -57,6 +57,10 @@ version_no_v="${version#v}"
 platform_tuple="${os}_${arch}"
 expected_sha=""
 case "${version}:${platform_tuple}" in
+  v1.0.5:linux_amd64) expected_sha="24706f65c7131c7b3261388709ae8781c8db53f0795398f67aa40538750aacf3" ;;
+  v1.0.5:linux_arm64) expected_sha="ccae5eb4478876ae224687ba98baef46848e603470b241966b63ccd3e01129a4" ;;
+  v1.0.5:darwin_amd64) expected_sha="0b0b017a3f2b23a1a9b53056ff160de318ebbca6a991c3db5924f5f48390e490" ;;
+  v1.0.5:darwin_arm64) expected_sha="648a2d19d767e8700bee809d4667cb52be3443d877dadb8106be550396982f58" ;;
   v1.0.4:linux_amd64) expected_sha="643e602e27f666c8726abff0f22001e2b5883988fa960204bde20a3129d448a5" ;;
   v1.0.4:linux_arm64) expected_sha="48cdf571cd8b64bae81da829c1309e402bc12e6a4cc6b87606dfc9220b7ece60" ;;
   v1.0.4:darwin_amd64) expected_sha="8a52f7e54fe038d369cc9ea0e65f76853b75f5469c70c9c693d64671623c4ce9" ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
       DOLT_VERSION: "2.0.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.0.5"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -173,7 +173,7 @@ jobs:
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
       DOLT_VERSION: "2.0.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.0.5"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -199,7 +199,7 @@ jobs:
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
       DOLT_VERSION: "2.0.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.0.5"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -298,7 +298,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     env:
       DOLT_VERSION: "2.0.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.0.5"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -430,7 +430,7 @@ jobs:
             command: ./scripts/test-integration-shard rest-full-16-of-16
     env:
       DOLT_VERSION: "2.0.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.0.5"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-gascity-ubuntu
@@ -899,7 +899,7 @@ jobs:
         run: make test-acceptance
     env:
       DOLT_VERSION: "2.0.7"
-      BD_VERSION: "v1.0.4"
+      BD_VERSION: "v1.0.5"
 
   # Dashboard SPA typecheck + tests + build. Runs on every push/PR
   # so TS drift against the spec (e.g. a query param tightening from

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -47,7 +47,7 @@ concurrency:
 
 env:
   DOLT_VERSION: "2.0.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.0.5"
 
 # Trigger gate re-used by every job below via `if:`.
 # We want each job to run when EITHER:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   DOLT_VERSION: "2.0.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.0.5"
 
 jobs:
   tier-b:

--- a/.github/workflows/ollama-acceptance-c.yml
+++ b/.github/workflows/ollama-acceptance-c.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   DOLT_VERSION: "2.0.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.0.5"
   ANTHROPIC_BASE_URL: https://ollama.com
   ANTHROPIC_API_KEY: ""
   ANTHROPIC_AUTH_TOKEN: ${{ secrets.OLLAMA_API_KEY }}

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   DOLT_VERSION: "2.0.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.0.5"
 
 jobs:
   # Reuse the shared CI graph so RC inherits new parity checks automatically.

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -39,7 +39,7 @@ concurrency:
 
 env:
   DOLT_VERSION: "2.0.7"
-  BD_VERSION: "v1.0.4"
+  BD_VERSION: "v1.0.5"
 
 jobs:
   runner-policy:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -80,13 +80,3 @@ vulnerabilities:
       - "usr/local/bin/dolt"
     expired_at: 2026-06-07
     statement: Latest Dolt 1.88.0 still embeds github.com/apache/thrift v0.13.1; remove after a Dolt release includes thrift 0.23.0 or later.
-  - id: CVE-2026-34986
-    paths:
-      - "usr/local/bin/bd"
-    expired_at: 2026-06-12
-    statement: Latest bd v1.0.4 still embeds go-jose v4.1.3; remove after a beads release includes go-jose v4.1.4 or later.
-  - id: CVE-2026-41602
-    paths:
-      - "usr/local/bin/bd"
-    expired_at: 2026-06-07
-    statement: Latest bd v1.0.3 still embeds github.com/apache/thrift v0.19.0; remove after a beads release includes thrift 0.23.0 or later.

--- a/release-gates/ga-pxbjxw-bd-version-v1-0-5-gate.md
+++ b/release-gates/ga-pxbjxw-bd-version-v1-0-5-gate.md
@@ -1,0 +1,55 @@
+# Release Gate: BD_VERSION v1.0.5
+
+Verdict: PASS
+
+- Deploy bead: `ga-pxbjxw`
+- Source review bead: `ga-wl0hix`
+- Branch: `builder/ga-pxbjxw-bd-version-v1-0-5-clean`
+- Candidate HEAD before gate commit: `d1d3e8f61395e17311f90c132fb5b39c5b3d2276`
+- Current `origin/main`: `cd7fd56869c025c6970a551e071728b231cad9c8`
+- Merge base with `origin/main`: `f272db921759b3d8700d3eb7d79961ce24bc52eb`
+- Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses the deployer role release criteria from `gc prime` plus the repo testing guidance in `TESTING.md`.
+
+## Summary
+
+This branch bumps the pinned `bd` archive version used by CI and related workflows from v1.0.4 to v1.0.5, adds SHA-256 pins for the v1.0.5 release archives, and removes Trivy suppressions for vulnerabilities fixed by the new `bd` build.
+
+## Release Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-wl0hix` is closed with `VERDICT: PASS` and reviewer notes covering commit `a0dabf306`; deploy bead `ga-pxbjxw` records the clean rebuilt branch at `d1d3e8f61395e17311f90c132fb5b39c5b3d2276`. |
+| 2 | Acceptance criteria met | PASS | Deployer rechecked the final branch scope: 9 workflow `BD_VERSION` references now use v1.0.5, all 4 platform archive SHA-256 pins are present in `.github/scripts/install-bd-archive.sh`, and the patched `bd` CVE suppressions were removed from `.trivyignore.yaml` while unrelated suppressions were preserved. |
+| 3 | Tests pass | PASS | `bash -n .github/scripts/install-bd-archive.sh`, `git diff --check origin/main...HEAD`, `GOTOOLCHAIN=auto make build`, `GOTOOLCHAIN=auto make test`, `GOTOOLCHAIN=auto go vet ./...`, and `./bin/gc version` all exited 0. |
+| 4 | No high-severity review findings open | PASS | Review notes list security/spec/style as PASS and no HIGH findings. The earlier deploy gate failure was branch hygiene only; the builder rebuilt this clean branch and rerouted it for deploy. |
+| 5 | Final branch is clean | PASS | The clean deploy worktree had no uncommitted changes before this gate file was added. After committing the gate file, deployer re-runs `git status --short --branch` before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `804c8df7409a1ca47736418c951ee80d2e31e97a`, confirming no merge conflicts with current `origin/main`. |
+| 7 | Single feature theme | PASS | The PR diff is one CI/security maintenance theme: update `bd` archive pins and remove obsolete vulnerability suppressions. Touched paths are `.github/scripts/install-bd-archive.sh`, workflow files, and `.trivyignore.yaml`. |
+
+## Acceptance Evidence
+
+| Check | Evidence |
+|-------|----------|
+| Workflow version references | `.github/workflows/ci.yml`, `mac-regression.yml`, `nightly.yml`, `ollama-acceptance-c.yml`, `rc-gate.yml`, and `review-formulas.yml` pin `BD_VERSION` to v1.0.5. |
+| Archive integrity pins | `.github/scripts/install-bd-archive.sh` includes v1.0.5 SHA-256 entries for `linux_amd64`, `linux_arm64`, `darwin_amd64`, and `darwin_arm64`. |
+| Obsolete suppressions removed | `.trivyignore.yaml` no longer suppresses the `bd`-fixed `go-jose` and `thrift` findings; non-`bd` suppressions remain. |
+| Scope cleanliness | `git diff --name-only origin/main...HEAD` lists only the 8 expected CI/script/security-suppression files. |
+
+## Verification Commands
+
+| Command | Result |
+|---------|--------|
+| `gh auth status` | PASS: authenticated as `quad341` with repo/workflow scopes. |
+| `git fetch origin main` | PASS |
+| `git diff --name-only origin/main...HEAD` | PASS: expected 8-file CI/security scope. |
+| `git diff --check origin/main...HEAD` | PASS |
+| `git merge-tree --write-tree origin/main HEAD` | PASS |
+| `bash -n .github/scripts/install-bd-archive.sh` | PASS |
+| `GOTOOLCHAIN=auto make build` | PASS |
+| `./bin/gc version` | PASS: printed `dev`. |
+| `GOTOOLCHAIN=auto make test` | PASS: `observable go test: PASS`. |
+| `GOTOOLCHAIN=auto go vet ./...` | PASS |
+
+## Push Target
+
+Remote policy will be resolved immediately before push. If `origin` rejects a dry-run push with a permission error, the branch will be pushed to `fork` and the PR will use `quad341:builder/ga-pxbjxw-bd-version-v1-0-5-clean` as the head.


### PR DESCRIPTION
## What this changes

CI and release workflows now download `bd` v1.0.5 instead of v1.0.4. The archive installer also has SHA-256 pins for all supported v1.0.5 artifacts, so the pinned version can be verified without falling back to unsigned metadata.

The Trivy ignore list drops suppressions for the `bd`-bundled `go-jose` and `thrift` findings fixed by v1.0.5, while keeping unrelated suppressions that still apply.

## Review notes

- Check the workflow `BD_VERSION` updates across Linux, macOS, nightly, RC, Ollama acceptance, and review-formula jobs.
- Check the new archive hashes in `.github/scripts/install-bd-archive.sh` for all four platform targets.
- Check `.trivyignore.yaml` to confirm only the obsolete `bd` suppressions were removed.

## Test plan

- [x] `bash -n .github/scripts/install-bd-archive.sh`
- [x] `git diff --check origin/main...HEAD`
- [x] `GOTOOLCHAIN=auto make build`
- [x] `./bin/gc version`
- [x] `GOTOOLCHAIN=auto make test`
- [x] `GOTOOLCHAIN=auto go vet ./...`
- [x] Release gate: [`release-gates/ga-pxbjxw-bd-version-v1-0-5-gate.md`](release-gates/ga-pxbjxw-bd-version-v1-0-5-gate.md)
