### PR TITLE
feat(formula): shadow description assets by layer

### DIFF
--- a/docs/reference/formula.md
+++ b/docs/reference/formula.md
@@ -71,8 +71,8 @@ Use `description_file` when a step's instructions should live in a separate
 Markdown file instead of inline TOML. Non-asset paths resolve relative to the
 formula file.
 
-Asset paths resolve through the same low-to-high formula layer order as the
-formula itself. For example, a bundled formula can reference:
+Paths using `../assets/...` resolve through the same low-to-high formula layer
+order as the formula itself. For example, a bundled formula can reference:
 
 ```toml
 description_file = "../assets/workflows/review/local-review.md"
@@ -86,7 +86,11 @@ assets/workflows/review/local-review.md
 ```
 
 The formula structure and step IDs remain inherited from the lower-priority
-pack; only the description file content is shadowed.
+pack; only the description file content is shadowed. Other relative or absolute
+paths that happen to contain an `assets` segment still use normal
+formula-relative or absolute path resolution. Description file reads use the
+same configured source as formula reads, so a parser pinned to a git ref also
+reads committed description file content from that ref.
 
 ## Graph.v2 Review Quorum Formula
 

--- a/docs/reference/formula.md
+++ b/docs/reference/formula.md
@@ -65,6 +65,29 @@ molecule.
 | `check` | object | Runtime retry: `max_attempts` with a `check` script after each attempt |
 | `timeout` | duration string | Default timeout for this step's `check` script; `check.check.timeout` takes precedence |
 
+### Description Files
+
+Use `description_file` when a step's instructions should live in a separate
+Markdown file instead of inline TOML. Non-asset paths resolve relative to the
+formula file.
+
+Asset paths resolve through the same low-to-high formula layer order as the
+formula itself. For example, a bundled formula can reference:
+
+```toml
+description_file = "../assets/workflows/review/local-review.md"
+```
+
+A city or higher-priority pack can override only that prose by providing the
+same asset path next to its formula layer:
+
+```text
+assets/workflows/review/local-review.md
+```
+
+The formula structure and step IDs remain inherited from the lower-priority
+pack; only the description file content is shadowed.
+
 ## Graph.v2 Review Quorum Formula
 
 The core pack includes `mol-review-quorum`, a Gas City-owned review quorum

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -640,9 +640,9 @@ func ApplyDefaults(formula *Formula, values map[string]string) map[string]string
 
 // resolveDescriptionFiles walks all steps and replaces DescriptionFile
 // with the file's contents. Non-asset paths are resolved relative to baseDir
-// (the formula file's directory). Paths that reference assets/ are resolved
-// through formula layer order so city assets can shadow pack assets while the
-// formula itself remains inherited from a lower-priority pack.
+// (the formula file's directory). Paths using the documented ../assets/ form
+// are resolved through formula layer order so city assets can shadow pack
+// assets while the formula itself remains inherited from a lower-priority pack.
 func (p *Parser) resolveDescriptionFiles(steps []*Step, baseDir string) {
 	for _, step := range steps {
 		if step == nil {
@@ -689,21 +689,15 @@ func (p *Parser) readDescriptionFile(rawPath, baseDir string) ([]byte, bool) {
 
 func descriptionAssetRelPath(rawPath string) (string, bool) {
 	path := filepath.ToSlash(filepath.Clean(rawPath))
-	parts := strings.Split(path, "/")
-	for i, part := range parts {
-		if part != "assets" {
-			continue
-		}
-		if i == len(parts)-1 {
-			return "", false
-		}
-		rel := strings.Join(parts[i+1:], "/")
-		if rel == "." || rel == "" || strings.HasPrefix(rel, "../") {
-			return "", false
-		}
-		return rel, true
+	const assetPrefix = "../assets/"
+	if !strings.HasPrefix(path, assetPrefix) {
+		return "", false
 	}
-	return "", false
+	rel := strings.TrimPrefix(path, assetPrefix)
+	if rel == "." || rel == "" || strings.HasPrefix(rel, "../") {
+		return "", false
+	}
+	return rel, true
 }
 
 // SetSourceInfo populates the SourceFormula and SourcePath fields on each

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -146,10 +146,11 @@ func (p *Parser) ParseFile(path string) (*Formula, error) {
 	// Set source tracing info on all steps (gt-8tmz.18)
 	SetSourceInfo(formula)
 
-	// Resolve description_file references relative to the formula file's directory.
+	// Resolve description_file references relative to the formula file's directory,
+	// with asset references shadowed through the parser's formula layer order.
 	formulaDir := filepath.Dir(absPath)
-	resolveDescriptionFiles(formula.Steps, formulaDir)
-	resolveDescriptionFiles(formula.Template, formulaDir)
+	p.resolveDescriptionFiles(formula.Steps, formulaDir)
+	p.resolveDescriptionFiles(formula.Template, formulaDir)
 
 	p.cache[absPath] = formula
 
@@ -637,31 +638,72 @@ func ApplyDefaults(formula *Formula, values map[string]string) map[string]string
 	return result
 }
 
-// SetSourceInfo sets SourceFormula and SourceLocation on all steps in a formula.
-// Called after parsing to enable source tracing during cooking (gt-8tmz.18).
 // resolveDescriptionFiles walks all steps and replaces DescriptionFile
-// with the file's contents. Paths are resolved relative to baseDir
-// (the formula file's directory).
-func resolveDescriptionFiles(steps []*Step, baseDir string) {
+// with the file's contents. Non-asset paths are resolved relative to baseDir
+// (the formula file's directory). Paths that reference assets/ are resolved
+// through formula layer order so city assets can shadow pack assets while the
+// formula itself remains inherited from a lower-priority pack.
+func (p *Parser) resolveDescriptionFiles(steps []*Step, baseDir string) {
 	for _, step := range steps {
-		if step == nil || step.DescriptionFile == "" {
+		if step == nil {
 			continue
 		}
-		path := step.DescriptionFile
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(baseDir, path)
+		if step.DescriptionFile != "" {
+			data, ok := p.readDescriptionFile(step.DescriptionFile, baseDir)
+			if ok {
+				step.Description = string(data)
+			}
+			step.DescriptionFile = "" // consumed; don't serialize
 		}
-		// #nosec G304 -- path comes from formula author, same trust as description
-		data, err := os.ReadFile(path)
-		if err == nil {
-			step.Description = string(data)
-		}
-		step.DescriptionFile = "" // consumed; don't serialize
 		if len(step.Children) > 0 {
-			resolveDescriptionFiles(step.Children, baseDir)
+			p.resolveDescriptionFiles(step.Children, baseDir)
+		}
+		if step.Loop != nil && len(step.Loop.Body) > 0 {
+			p.resolveDescriptionFiles(step.Loop.Body, baseDir)
 		}
 	}
-	// Also handle template steps (expansion formulas).
+}
+
+func (p *Parser) readDescriptionFile(rawPath, baseDir string) ([]byte, bool) {
+	if assetRel, ok := descriptionAssetRelPath(rawPath); ok {
+		var winner string
+		for _, layer := range p.searchPaths {
+			candidate := filepath.Join(filepath.Dir(layer), "assets", filepath.FromSlash(assetRel))
+			if p.source.Stat(candidate) {
+				winner = candidate
+			}
+		}
+		if winner != "" {
+			data, err := p.source.ReadFile(winner)
+			return data, err == nil
+		}
+	}
+
+	path := rawPath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	data, err := p.source.ReadFile(path)
+	return data, err == nil
+}
+
+func descriptionAssetRelPath(rawPath string) (string, bool) {
+	path := filepath.ToSlash(filepath.Clean(rawPath))
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if part != "assets" {
+			continue
+		}
+		if i == len(parts)-1 {
+			return "", false
+		}
+		rel := strings.Join(parts[i+1:], "/")
+		if rel == "." || rel == "" || strings.HasPrefix(rel, "../") {
+			return "", false
+		}
+		return rel, true
+	}
+	return "", false
 }
 
 // SetSourceInfo populates the SourceFormula and SourcePath fields on each

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -186,6 +186,185 @@ description_file = "descriptions/work.md"
 	}
 }
 
+func TestLoadByNameDescriptionFileKeepsFormulaLocalAssetsPath(t *testing.T) {
+	tmp := t.TempDir()
+	coreFormulas := filepath.Join(tmp, "core", "formulas")
+	coreAssets := filepath.Join(tmp, "core", "assets")
+	cityFormulas := filepath.Join(tmp, "city", "formulas")
+	cityAssets := filepath.Join(tmp, "city", "assets")
+	formulaLocalAssets := filepath.Join(coreFormulas, "assets")
+	for _, dir := range []string{coreFormulas, coreAssets, cityFormulas, cityAssets, formulaLocalAssets} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	formulaText := `
+formula = "local-assets"
+
+[[steps]]
+id = "work"
+title = "Do work"
+description_file = "assets/work.md"
+`
+	if err := os.WriteFile(filepath.Join(coreFormulas, "local-assets.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaLocalAssets, "work.md"), []byte("formula-local assets instructions"), 0o644); err != nil {
+		t.Fatalf("write formula-local asset: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coreAssets, "work.md"), []byte("core pack asset instructions"), 0o644); err != nil {
+		t.Fatalf("write core asset: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityAssets, "work.md"), []byte("city pack asset instructions"), 0o644); err != nil {
+		t.Fatalf("write city asset: %v", err)
+	}
+
+	p := NewParser(coreFormulas, cityFormulas)
+	formula, err := p.LoadByName("local-assets")
+	if err != nil {
+		t.Fatalf("LoadByName(local-assets): %v", err)
+	}
+	if got := formula.Steps[0].Description; got != "formula-local assets instructions" {
+		t.Fatalf("description = %q, want formula-local assets path", got)
+	}
+}
+
+func TestLoadByNameDescriptionFileKeepsAbsoluteAssetsPath(t *testing.T) {
+	tmp := t.TempDir()
+	formulas := filepath.Join(tmp, "pack", "formulas")
+	packAssets := filepath.Join(tmp, "pack", "assets")
+	explicitAssets := filepath.Join(tmp, "explicit", "assets")
+	for _, dir := range []string{formulas, packAssets, explicitAssets} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	absoluteDescription := filepath.Join(explicitAssets, "work.md")
+	formulaText := fmt.Sprintf(`
+formula = "absolute-assets"
+
+[[steps]]
+id = "work"
+title = "Do work"
+description_file = %q
+`, absoluteDescription)
+	if err := os.WriteFile(filepath.Join(formulas, "absolute-assets.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(absoluteDescription, []byte("explicit absolute instructions"), 0o644); err != nil {
+		t.Fatalf("write absolute description: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packAssets, "work.md"), []byte("pack asset instructions"), 0o644); err != nil {
+		t.Fatalf("write pack asset: %v", err)
+	}
+
+	p := NewParser(formulas)
+	formula, err := p.LoadByName("absolute-assets")
+	if err != nil {
+		t.Fatalf("LoadByName(absolute-assets): %v", err)
+	}
+	if got := formula.Steps[0].Description; got != "explicit absolute instructions" {
+		t.Fatalf("description = %q, want explicit absolute path", got)
+	}
+}
+
+func TestLoadByNameDescriptionFileResolvesLoopBody(t *testing.T) {
+	tmp := t.TempDir()
+	formulas := filepath.Join(tmp, "pack", "formulas")
+	descriptions := filepath.Join(formulas, "descriptions")
+	if err := os.MkdirAll(descriptions, 0o755); err != nil {
+		t.Fatalf("mkdir descriptions: %v", err)
+	}
+
+	formulaText := `
+formula = "loop-description"
+
+[[steps]]
+id = "loop"
+title = "Loop"
+
+[steps.loop]
+count = 1
+
+[[steps.loop.body]]
+id = "work"
+title = "Do work"
+description_file = "descriptions/work.md"
+`
+	if err := os.WriteFile(filepath.Join(formulas, "loop-description.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(descriptions, "work.md"), []byte("loop body instructions"), 0o644); err != nil {
+		t.Fatalf("write loop description: %v", err)
+	}
+
+	p := NewParser(formulas)
+	formula, err := p.LoadByName("loop-description")
+	if err != nil {
+		t.Fatalf("LoadByName(loop-description): %v", err)
+	}
+	if got := formula.Steps[0].Loop.Body[0].Description; got != "loop body instructions" {
+		t.Fatalf("loop body description = %q, want resolved description file", got)
+	}
+}
+
+func TestDescriptionAssetRelPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "documented pack asset",
+			raw:    "../assets/workflows/review/local-review.md",
+			want:   "workflows/review/local-review.md",
+			wantOK: true,
+		},
+		{
+			name:   "cleans path inside asset tree",
+			raw:    "../assets/workflows/../review/local-review.md",
+			want:   "review/local-review.md",
+			wantOK: true,
+		},
+		{
+			name: "formula local assets directory",
+			raw:  "assets/work.md",
+		},
+		{
+			name: "nested relative assets directory",
+			raw:  "nested/assets/work.md",
+		},
+		{
+			name: "absolute assets directory",
+			raw:  filepath.Join(string(os.PathSeparator), "tmp", "assets", "work.md"),
+		},
+		{
+			name: "asset root only",
+			raw:  "../assets",
+		},
+		{
+			name: "traversal escapes asset tree",
+			raw:  "../assets/../work.md",
+		},
+		{
+			name: "empty path",
+			raw:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := descriptionAssetRelPath(tt.raw)
+			if ok != tt.wantOK || got != tt.want {
+				t.Fatalf("descriptionAssetRelPath(%q) = %q, %v; want %q, %v", tt.raw, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
 func TestValidate_ValidFormula(t *testing.T) {
 	formula := &Formula{
 		Formula: "mol-valid",

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -78,6 +78,114 @@ func TestParse_BasicFormula(t *testing.T) {
 	}
 }
 
+func TestLoadByNameDescriptionFileUsesHighestPriorityAssetLayer(t *testing.T) {
+	tmp := t.TempDir()
+	coreFormulas := filepath.Join(tmp, "core", "formulas")
+	coreAssets := filepath.Join(tmp, "core", "assets", "workflows", "review")
+	cityFormulas := filepath.Join(tmp, "city", "formulas")
+	cityAssets := filepath.Join(tmp, "city", "assets", "workflows", "review")
+	for _, dir := range []string{coreFormulas, coreAssets, cityFormulas, cityAssets} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	formulaText := `
+formula = "review"
+
+[[steps]]
+id = "local-review"
+title = "Review locally"
+description_file = "../assets/workflows/review/local-review.md"
+`
+	if err := os.WriteFile(filepath.Join(coreFormulas, "review.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coreAssets, "local-review.md"), []byte("core review instructions"), 0o644); err != nil {
+		t.Fatalf("write core asset: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityAssets, "local-review.md"), []byte("city review instructions"), 0o644); err != nil {
+		t.Fatalf("write city asset: %v", err)
+	}
+
+	p := NewParser(coreFormulas, cityFormulas)
+	formula, err := p.LoadByName("review")
+	if err != nil {
+		t.Fatalf("LoadByName(review): %v", err)
+	}
+	if got := formula.Steps[0].Description; got != "city review instructions" {
+		t.Fatalf("description = %q, want city asset shadow", got)
+	}
+}
+
+func TestLoadByNameDescriptionFileFallsBackToFormulaPackAsset(t *testing.T) {
+	tmp := t.TempDir()
+	coreFormulas := filepath.Join(tmp, "core", "formulas")
+	coreAssets := filepath.Join(tmp, "core", "assets", "workflows", "triage")
+	cityFormulas := filepath.Join(tmp, "city", "formulas")
+	for _, dir := range []string{coreFormulas, coreAssets, cityFormulas} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	formulaText := `
+formula = "triage"
+
+[[steps]]
+id = "classify"
+title = "Classify work"
+description_file = "../assets/workflows/triage/classify.md"
+`
+	if err := os.WriteFile(filepath.Join(coreFormulas, "triage.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coreAssets, "classify.md"), []byte("core triage instructions"), 0o644); err != nil {
+		t.Fatalf("write core asset: %v", err)
+	}
+
+	p := NewParser(coreFormulas, cityFormulas)
+	formula, err := p.LoadByName("triage")
+	if err != nil {
+		t.Fatalf("LoadByName(triage): %v", err)
+	}
+	if got := formula.Steps[0].Description; got != "core triage instructions" {
+		t.Fatalf("description = %q, want core asset fallback", got)
+	}
+}
+
+func TestLoadByNameDescriptionFileKeepsRelativeNonAssetBehavior(t *testing.T) {
+	tmp := t.TempDir()
+	formulas := filepath.Join(tmp, "pack", "formulas")
+	if err := os.MkdirAll(filepath.Join(formulas, "descriptions"), 0o755); err != nil {
+		t.Fatalf("mkdir descriptions: %v", err)
+	}
+
+	formulaText := `
+formula = "relative"
+
+[[steps]]
+id = "work"
+title = "Do work"
+description_file = "descriptions/work.md"
+`
+	if err := os.WriteFile(filepath.Join(formulas, "relative.toml"), []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulas, "descriptions", "work.md"), []byte("relative instructions"), 0o644); err != nil {
+		t.Fatalf("write relative description: %v", err)
+	}
+
+	p := NewParser(formulas)
+	formula, err := p.LoadByName("relative")
+	if err != nil {
+		t.Fatalf("LoadByName(relative): %v", err)
+	}
+	if got := formula.Steps[0].Description; got != "relative instructions" {
+		t.Fatalf("description = %q, want relative description file", got)
+	}
+}
+
 func TestValidate_ValidFormula(t *testing.T) {
 	formula := &Formula{
 		Formula: "mol-valid",

--- a/internal/formula/source_test.go
+++ b/internal/formula/source_test.go
@@ -384,6 +384,41 @@ func TestParserHonorsSetSourceForLoadByName(t *testing.T) {
 	}
 }
 
+func TestParserHonorsSetSourceForDescriptionFile(t *testing.T) {
+	gitOK(t)
+	root := initRepo(t)
+	formulaDir := filepath.Join(root, "formulas")
+	if err := os.MkdirAll(filepath.Join(formulaDir, "descriptions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, root, "formulas/mol.toml", "formula = \"mol\"\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\ndescription_file = \"descriptions/work.md\"\n")
+	commitFile(t, root, "formulas/descriptions/work.md", "COMMITTED")
+	commitOnBranch(t, root, "main", "init")
+
+	runGit(t, root, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(formulaDir, "descriptions", "work.md"), []byte("FEATURE-DRAFT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fsParser := NewParser(formulaDir)
+	fsFormula, err := fsParser.LoadByName("mol")
+	if err != nil {
+		t.Fatalf("FSSource LoadByName: %v", err)
+	}
+	if got := fsFormula.Steps[0].Description; got != "FEATURE-DRAFT" {
+		t.Fatalf("FSSource description = %q, want FEATURE-DRAFT", got)
+	}
+
+	refParser := NewParser(formulaDir).SetSource(NewGitRefSource("main"))
+	refFormula, err := refParser.LoadByName("mol")
+	if err != nil {
+		t.Fatalf("GitRefSource LoadByName: %v", err)
+	}
+	if got := refFormula.Steps[0].Description; got != "COMMITTED" {
+		t.Fatalf("GitRefSource description = %q, want COMMITTED", got)
+	}
+}
+
 // TestResolveWithSourcePrecedence verifies the layered last-wins
 // semantic is preserved when Source is parameterized. Highest-priority
 // layer that contains a Stat-hit wins, exactly as the legacy Resolve


### PR DESCRIPTION
## Summary
- Resolves `description_file` paths under `assets/` through formula layer search paths so city assets can shadow base pack behavior.
- Keeps non-asset `description_file` paths relative to the defining formula file.
- Adds parser tests for highest-priority layer shadowing, fallback to the formula pack asset, and legacy relative-path behavior.

## Tests
- `go test ./internal/formula -count=1`
- `go test ./cmd/gc -run 'Test.*Formula' -count=1`

Note: the pre-commit hook was run before commit and hit an unrelated timing failure in `cmd/gc` (`TestProbeLiveSessions_TimesOut`); a direct rerun of that test passed.