### PR TITLE
fix(dolt): surface gc dolt sync push failure modes (timeout, stderr, exit codes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gc dolt sync` now emits per-mode diagnostics on push failure instead of a
   generic "push failed": a TIMEOUT message naming the ceiling and
   `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` on exit 124, the underlying exit code on
-  other failures, and the underlying dolt stderr.
+  other failures, and the underlying dolt stderr. The replayed stderr cannot
+  leak `GC_DOLT_PASSWORD`: the password reaches dolt via the `DOLT_CLI_PASSWORD`
+  environment variable, never as an argv flag. `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS`
+  rejects every numeric-zero form (`0`, `00`, `000`, …) — not just the literal
+  `0` — because GNU `timeout` treats a zero duration as "disable the timeout",
+  which would push unbounded. A failure to create the stderr-capture temp file
+  now degrades to a per-database error rather than aborting the whole run.
 
 ## [1.2.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` configures the SQL-mode push wall-clock
+  ceiling for `gc dolt sync` (default 1800s, replacing the prior fixed 120s
+  that SIGKILLed large first pushes). Metadata queries keep their own 120s
+  bound.
 - Claude Opus 4.8 is now listed in built-in Claude model choices and default
   pricing. The `opus` model choice targets `claude-opus-4-8`; `opus-4-7`
   remains available for cities that need the prior Opus target. Anthropic's
@@ -48,6 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching `gc mail send`. Operators should use `gc mail` commands or
   explicit both-tier/wisp-aware bead queries for mail visibility; default
   issue-tier `bd list` output and git sync do not include wisp-tier messages.
+
+### Fixed
+
+- `gc dolt sync` now emits per-mode diagnostics on push failure instead of a
+  generic "push failed": a TIMEOUT message naming the ceiling and
+  `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` on exit 124, the underlying exit code on
+  other failures, and the underlying dolt stderr.
 
 ## [1.2.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.0] - 2026-05-25
-
 ### Added
 
 - `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` configures the SQL-mode push wall-clock
   ceiling for `gc dolt sync` (default 1800s, replacing the prior fixed 120s
   that SIGKILLed large first pushes). Metadata queries keep their own 120s
   bound.
+
+### Fixed
+
+- `gc dolt sync` now emits per-mode diagnostics on push failure instead of a
+  generic "push failed": a TIMEOUT message naming the ceiling and
+  `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` on exit 124, the underlying exit code on
+  other failures, and the underlying dolt stderr. The replayed stderr cannot
+  leak `GC_DOLT_PASSWORD`: the password reaches dolt via the `DOLT_CLI_PASSWORD`
+  environment variable, never as an argv flag. `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS`
+  rejects every numeric-zero form (`0`, `00`, `000`, …) — not just the literal
+  `0` — because GNU `timeout` treats a zero duration as "disable the timeout",
+  which would push unbounded. A failure to create the stderr-capture temp file
+  now degrades to a per-database error rather than aborting the whole run.
+
+## [1.2.0] - 2026-05-25
+
+### Added
+
 - Claude Opus 4.8 is now listed in built-in Claude model choices and default
   pricing. The `opus` model choice targets `claude-opus-4-8`; `opus-4-7`
   remains available for cities that need the prior Opus target. Anthropic's
@@ -52,19 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching `gc mail send`. Operators should use `gc mail` commands or
   explicit both-tier/wisp-aware bead queries for mail visibility; default
   issue-tier `bd list` output and git sync do not include wisp-tier messages.
-
-### Fixed
-
-- `gc dolt sync` now emits per-mode diagnostics on push failure instead of a
-  generic "push failed": a TIMEOUT message naming the ceiling and
-  `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` on exit 124, the underlying exit code on
-  other failures, and the underlying dolt stderr. The replayed stderr cannot
-  leak `GC_DOLT_PASSWORD`: the password reaches dolt via the `DOLT_CLI_PASSWORD`
-  environment variable, never as an argv flag. `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS`
-  rejects every numeric-zero form (`0`, `00`, `000`, …) — not just the literal
-  `0` — because GNU `timeout` treats a zero duration as "disable the timeout",
-  which would push unbounded. A failure to create the stderr-capture temp file
-  now degrades to a per-database error rather than aborting the whole run.
 
 ## [1.2.0] - 2026-05-25
 

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -384,7 +384,12 @@ sync_database_sql() {
   # dolt's own stderr cannot echo it back. The -s guard skips an empty capture so
   # no spurious blank line is emitted.
   if [ -s "$push_err_tmp" ]; then
-    while IFS= read -r line; do
+    # `|| [ -n "$line" ]` flushes a final line that lacks a trailing newline:
+    # POSIX `read` returns non-zero at an unterminated EOF, so a terse
+    # newline-less dolt diagnostic (e.g. a SIGKILL-truncated `fatal: ...`) would
+    # otherwise be captured but never replayed — re-introducing the swallowed
+    # failure this command set out to surface.
+    while IFS= read -r line || [ -n "$line" ]; do
       printf '  %s: %s\n' "$name" "$line" >&2
     done < "$push_err_tmp"
   fi

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -75,18 +75,30 @@ data_dir="$DOLT_DATA_DIR"
 
 # Wall-clock bound for SQL-mode remote push (seconds). Defaults to 1800s; the
 # prior fixed 120s ceiling SIGKILLed large first pushes that succeed when issued
-# directly to the running sql-server. An explicitly-empty / non-numeric / 0
-# value is rejected (not silently defaulted) so a misconfigured bound fails loud
-# instead of producing a misleading "TIMEOUT after 0s". Validated before any
-# per-database logic so an invalid value aborts before any db is touched.
+# directly to the running sql-server. An explicitly-empty / non-numeric / any
+# numeric-zero value is rejected (not silently defaulted) so a misconfigured
+# bound fails loud instead of producing a misleading "TIMEOUT after 0s".
+# Validated before any per-database logic so an invalid value aborts before any
+# db is touched.
+#
+# A valid value is non-empty, all-digit, and has at least one non-zero digit.
+# Matching only the literal "0" would let leading-zero forms ("00", "000")
+# through; GNU `timeout` treats a 0 duration as "disable the timeout", which
+# would run the push UNBOUNDED — the exact anti-hang outcome this bound exists
+# to prevent. The first arm rejects empty/non-digit input; the second accepts
+# any all-digit string containing a non-zero digit; the default arm rejects the
+# remaining all-digit-but-all-zero forms.
 push_timeout="${GC_DOLT_SYNC_PUSH_TIMEOUT_SECS-1800}"
 case "$push_timeout" in
-  ''|*[!0-9]*|0)
-    printf 'gc dolt sync: invalid GC_DOLT_SYNC_PUSH_TIMEOUT_SECS=%s (must be a positive integer)\n' \
-      "$push_timeout" >&2
-    exit 2
-    ;;
+  ''|*[!0-9]*) push_timeout_valid=false ;;
+  *[1-9]*)     push_timeout_valid=true ;;
+  *)           push_timeout_valid=false ;;
 esac
+if [ "$push_timeout_valid" != true ]; then
+  printf 'gc dolt sync: invalid GC_DOLT_SYNC_PUSH_TIMEOUT_SECS=%s (must be a positive integer)\n' \
+    "$push_timeout" >&2
+  exit 2
+fi
 
 # Check if server is running.
 is_running() {
@@ -334,7 +346,15 @@ sync_database_sql() {
     push_query="USE \`$name\`; CALL DOLT_PUSH('$remote_name', '$refspec_arg')"
   fi
   push_rc=0
-  push_err_tmp=$(mktemp)
+  # Guard mktemp: under `set -e` a bare `$(mktemp)` failure (unwritable or
+  # exhausted TMPDIR) would abort the whole multi-db sync run with an opaque
+  # error — itself the swallowed/opaque-failure class this command set out to
+  # eliminate. Degrade to a per-db error so the loop reports this db and moves
+  # on rather than killing the run.
+  push_err_tmp=$(mktemp) || {
+    echo "  $name: ERROR: cannot create temp file for push diagnostics" >&2
+    return 1
+  }
   # Route push under push_timeout (not dolt_sql's 120s metadata ceiling) and
   # capture stderr so the underlying dolt diagnostic survives, preserving the
   # real exit code via `|| push_rc=$?`.

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -19,7 +19,17 @@
 #      on legacy setups.
 #   3. Fallback when active_branch() cannot be resolved (or in CLI mode): 'main'.
 #
-# Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_USER, GC_DOLT_PASSWORD
+# Environment:
+#   GC_CITY_PATH                          (required) — city root
+#   GC_DOLT_PORT                          (required) — managed dolt port
+#   GC_DOLT_USER                          (default: root)
+#   GC_DOLT_PASSWORD                      (optional)
+#   GC_DOLT_SYNC_PUSH_TIMEOUT_SECS
+#     (default: 1800) — wall-clock bound for SQL-mode remote push. Increase for
+#                     slow links or large first pushes (a multi-GB first push to
+#                     a fresh remote can exceed the prior fixed 120s ceiling).
+#                     Metadata queries (remote lookup, active branch) keep their
+#                     own 120s bound.
 set -e
 
 dry_run=false
@@ -62,6 +72,21 @@ PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 
 beads_bd="$GC_BEADS_BD_SCRIPT"
 data_dir="$DOLT_DATA_DIR"
+
+# Wall-clock bound for SQL-mode remote push (seconds). Defaults to 1800s; the
+# prior fixed 120s ceiling SIGKILLed large first pushes that succeed when issued
+# directly to the running sql-server. An explicitly-empty / non-numeric / 0
+# value is rejected (not silently defaulted) so a misconfigured bound fails loud
+# instead of producing a misleading "TIMEOUT after 0s". Validated before any
+# per-database logic so an invalid value aborts before any db is touched.
+push_timeout="${GC_DOLT_SYNC_PUSH_TIMEOUT_SECS-1800}"
+case "$push_timeout" in
+  ''|*[!0-9]*|0)
+    printf 'gc dolt sync: invalid GC_DOLT_SYNC_PUSH_TIMEOUT_SECS=%s (must be a positive integer)\n' \
+      "$push_timeout" >&2
+    exit 2
+    ;;
+esac
 
 # Check if server is running.
 is_running() {
@@ -160,11 +185,18 @@ refspec_parts() {
   printf '%s\n%s\n' "$l" "$r"
 }
 
+# dolt_sql QUERY [TIMEOUT_SECS] — run a SQL query against the live server under a
+# wall-clock bound. The optional second arg overrides the bound; it defaults to
+# 120s, which is sized for SHORT METADATA QUERIES ONLY (remote lookup,
+# active_branch). This is a load-bearing contract: any data-transfer operation
+# (e.g. DOLT_PUSH) MUST pass its own larger bound, or it will silently re-hit
+# this 120s ceiling and be SIGKILLed mid-transfer.
 dolt_sql() {
   query="$1"
+  tmo="${2:-120}"
   host="${GC_DOLT_HOST:-127.0.0.1}"
   export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
-  run_bounded 120 dolt --host "$host" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls \
+  run_bounded "$tmo" dolt --host "$host" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls \
     sql --result-format csv -q "$query"
 }
 
@@ -301,12 +333,42 @@ sync_database_sql() {
   else
     push_query="USE \`$name\`; CALL DOLT_PUSH('$remote_name', '$refspec_arg')"
   fi
-  if dolt_sql "$push_query" >/dev/null 2>&1; then
+  push_rc=0
+  push_err_tmp=$(mktemp)
+  # Route push under push_timeout (not dolt_sql's 120s metadata ceiling) and
+  # capture stderr so the underlying dolt diagnostic survives, preserving the
+  # real exit code via `|| push_rc=$?`.
+  dolt_sql "$push_query" "$push_timeout" >/dev/null 2>"$push_err_tmp" || push_rc=$?
+
+  if [ "$push_rc" -eq 0 ]; then
     echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote_url)"
+    rm -f "$push_err_tmp"
     return 0
   fi
 
-  echo "  $name: ERROR: push failed" >&2
+  if [ "$push_rc" -eq 124 ]; then
+    # Exit 124 is overloaded: a real wall-clock timeout (run_bounded via
+    # timeout/gtimeout, runtime.sh) AND the no-mechanism fall-through where
+    # neither timeout/gtimeout nor python3 exists and dolt never ran. A
+    # SIGKILLed client leaves no stderr; the no-mechanism path leaves the
+    # "cannot run bounded command" marker, so the stderr replay below
+    # disambiguates the two at zero extra mechanism.
+    echo "  $name: TIMEOUT after ${push_timeout}s — push manually or increase timeout (GC_DOLT_SYNC_PUSH_TIMEOUT_SECS)" >&2
+  else
+    echo "  $name: ERROR: push failed (exit $push_rc)" >&2
+  fi
+
+  # Replay the captured dolt stderr, prefixed with the db name for scannable
+  # multi-db output. Safe to emit unfiltered (RB6): the password reaches dolt via
+  # the DOLT_CLI_PASSWORD env var (see dolt_sql), never as an argv flag, so
+  # dolt's own stderr cannot echo it back. The -s guard skips an empty capture so
+  # no spurious blank line is emitted.
+  if [ -s "$push_err_tmp" ]; then
+    while IFS= read -r line; do
+      printf '  %s: %s\n' "$name" "$line" >&2
+    done < "$push_err_tmp"
+  fi
+  rm -f "$push_err_tmp"
   return 1
 }
 
@@ -347,17 +409,23 @@ sync_database_cli() {
     refspec_arg="$local_branch:$remote_branch"
   fi
 
+  # Capture the real exit code via `|| cli_rc=$?` on each branch BEFORE the
+  # success test — a post-`if` `$?` would read the compound's 0 and silently lose
+  # the failure code. `2>&1` is preserved so dolt's stderr still reaches the
+  # terminal (CLI mode has no wall-clock ceiling; exit 124 cannot occur here).
+  cli_rc=0
   if [ "$force" = true ]; then
-    if (cd "$d" && dolt push --force --set-upstream "$remote_name" "$refspec_arg" 2>&1); then
-      echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote)"
-      return 0
-    fi
-  elif (cd "$d" && dolt push "$remote_name" "$refspec_arg" 2>&1); then
+    (cd "$d" && dolt push --force --set-upstream "$remote_name" "$refspec_arg" 2>&1) || cli_rc=$?
+  else
+    (cd "$d" && dolt push "$remote_name" "$refspec_arg" 2>&1) || cli_rc=$?
+  fi
+
+  if [ "$cli_rc" -eq 0 ]; then
     echo "  $name: pushed $local_branch -> $remote_name:$remote_branch ($remote)"
     return 0
   fi
 
-  echo "  $name: ERROR: push failed" >&2
+  echo "  $name: ERROR: push failed (exit $cli_rc)" >&2
   return 1
 }
 

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -179,6 +179,55 @@ exit 0
 	}
 }
 
+// writeSyncFakeDoltPushEchoesArgs installs a fake dolt that, on the SQL-mode
+// DOLT_PUSH call, reports whether DOLT_CLI_PASSWORD was delivered via the
+// environment and echoes its own full argv to stderr (mimicking a dolt that
+// prints its command line in a connection diagnostic), then fails. This lets a
+// test prove the password reaches dolt via the env var (non-vacuous: the
+// 'cli-password-was-set' marker only fires when DOLT_CLI_PASSWORD is non-empty)
+// AND never as an argv flag — so the replayed argv cannot leak the secret (RB6).
+func writeSyncFakeDoltPushEchoesArgs(t *testing.T, dir string) {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+    printf 'name,url\norigin,https://example.invalid/repo\n'
+    exit 0
+    ;;
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\nmain\n'
+    exit 0
+    ;;
+  *DOLT_PUSH*)
+    [ -n "$DOLT_CLI_PASSWORD" ] && printf 'cli-password-was-set\n' >&2
+    printf 'push failed; dolt invoked with args: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+}
+
+// writeSyncFakeFailingMktemp installs a fake `mktemp` on PATH that always fails,
+// reproducing a broken/unwritable TMPDIR. sync only calls mktemp at the SQL push
+// site, so this exercises the per-db temp-file guard without affecting the
+// earlier metadata queries.
+func writeSyncFakeFailingMktemp(t *testing.T, dir string) {
+	t.Helper()
+	body := `#!/bin/sh
+echo "mktemp: failed to create file" >&2
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(dir, "mktemp"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake mktemp: %v", err)
+	}
+}
+
 func writeSyncFakeBeadsBD(t *testing.T, cityPath string) string {
 	t.Helper()
 	scriptDir := filepath.Join(cityPath, ".gc", "system", "packs", "bd", "assets", "scripts")
@@ -1216,6 +1265,162 @@ func TestSyncSQLPushTimeoutHonorsConfiguredCeiling(t *testing.T) {
 	}
 }
 
+// TestSyncSQLPushReplayDoesNotLeakPassword exercises credential non-exposure
+// (RB6) with a NON-EMPTY password. The fake dolt confirms it received the
+// password via DOLT_CLI_PASSWORD (the 'cli-password-was-set' marker makes the
+// test non-vacuous: it fires only when the env var is non-empty) and echoes its
+// own full argv to stderr; yet the secret value must never appear in any
+// replayed line because sync passes the password through the environment, never
+// as an argv flag. Converts the by-construction RB6 safety into exercised
+// safety on the security regression boundary.
+func TestSyncSQLPushReplayDoesNotLeakPassword(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	writeSyncFakeDoltPushEchoesArgs(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	const secret = "s3cr3t-push-token"
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD="+secret,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected push failure, output:\n%s", out)
+	}
+	// Non-vacuity guard: the password must actually have reached dolt via the
+	// env var, otherwise the no-leak assertion below proves nothing.
+	if !strings.Contains(string(out), "cli-password-was-set") {
+		t.Fatalf("expected the password to be delivered to dolt via DOLT_CLI_PASSWORD (test is vacuous otherwise), got:\n%s", out)
+	}
+	// The push diagnostic (with dolt's echoed argv) must be surfaced, but the
+	// secret value must not appear anywhere in the replayed output.
+	if !strings.Contains(string(out), "push failed; dolt invoked with args") {
+		t.Fatalf("expected the dolt push diagnostic to be replayed, got:\n%s", out)
+	}
+	if strings.Contains(string(out), secret) {
+		t.Fatalf("password leaked into sync output — it must reach dolt via DOLT_CLI_PASSWORD, never argv:\n%s", out)
+	}
+}
+
+// TestSyncSQLPushTimeoutReplaysNoMechanismMarker verifies the exit-124 branch
+// replays a non-empty captured stderr, surfacing the run_bounded "cannot run
+// bounded command" no-mechanism marker that is otherwise reported under the
+// (deliberately overloaded) TIMEOUT headline. Exercises the S3-on-124 mitigation
+// that disambiguates a real wall-clock timeout from the no-mechanism
+// fall-through.
+func TestSyncSQLPushTimeoutReplaysNoMechanismMarker(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	const marker = "dolt runtime: timeout/gtimeout/python3 not found; cannot run bounded command"
+	writeSyncFakeDoltPushFails(t, binDir, 124, marker)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected push failure, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "TIMEOUT after 1800s") {
+		t.Fatalf("expected the TIMEOUT headline on exit 124, got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "app: "+marker) {
+		t.Fatalf("expected the captured no-mechanism marker to be replayed (db-prefixed) on the 124 branch, got:\n%s", out)
+	}
+}
+
+// TestSyncSQLPushTempFileFailureDegradesPerDb verifies that a failure to create
+// the stderr-capture temp file degrades to a per-database error instead of an
+// opaque whole-run abort under `set -e` — the swallowed-failure class this bead
+// targets. A fake `mktemp` on PATH always fails; sync calls mktemp only at the
+// SQL push site, so the metadata queries still succeed and the guard is what is
+// exercised.
+func TestSyncSQLPushTempFileFailureDegradesPerDb(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDolt(t, binDir)
+	writeSyncFakeFailingMktemp(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit when the temp file cannot be created, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "app: ERROR: cannot create temp file") {
+		t.Fatalf("expected a per-db temp-file error instead of an opaque abort, got:\n%s", out)
+	}
+}
+
 // assertSyncRejectsInvalidPushTimeout drives one invalid-timeout scenario: it
 // runs sync with GC_DOLT_SYNC_PUSH_TIMEOUT_SECS=bad and asserts the script
 // aborts with exit 2 and a stderr diagnostic before any database is touched —
@@ -1287,6 +1492,22 @@ func TestSyncRejectsZeroPushTimeout(t *testing.T) {
 // is rejected with exit 2 (R5 input validation).
 func TestSyncRejectsEmptyPushTimeout(t *testing.T) {
 	assertSyncRejectsInvalidPushTimeout(t, "")
+}
+
+// TestSyncRejectsLeadingZeroPushTimeout verifies the leading-zero numeric-zero
+// form "00" is rejected with exit 2 before any dolt invocation. A guard matching
+// only the literal "0" lets "00" through, and GNU `timeout` treats a 0 duration
+// as "disable the timeout" — running the push UNBOUNDED and re-opening the
+// anti-hang hole RB2 exists to close (R5 input validation).
+func TestSyncRejectsLeadingZeroPushTimeout(t *testing.T) {
+	assertSyncRejectsInvalidPushTimeout(t, "00")
+}
+
+// TestSyncRejectsTripleZeroPushTimeout verifies a longer all-zeros form "000" is
+// also rejected with exit 2 — the zero-guard must reject every numeric-zero
+// spelling, not just the literal "0" (RB2; R5 input validation).
+func TestSyncRejectsTripleZeroPushTimeout(t *testing.T) {
+	assertSyncRejectsInvalidPushTimeout(t, "000")
 }
 
 // TestSyncCLIPushReportsExitCode verifies the CLI-mode plain push surfaces the

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -1,6 +1,7 @@
 package dolt_test
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -123,7 +124,7 @@ exit 0
 // failure case (timeout exit 124, transport exit 7, stderr replay, etc.) rather
 // than N hardcoded-exit functions. The remotes-lookup query must still succeed
 // or the push site is never reached.
-func writeSyncFakeDoltPushFails(t *testing.T, dir string, exitCode int, stderr string) string {
+func writeSyncFakeDoltPushFails(t *testing.T, dir string, exitCode int, stderr string) {
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")
 	stderrEmit := ""
@@ -151,14 +152,13 @@ exit 0
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
 		t.Fatalf("write fake dolt: %v", err)
 	}
-	return logPath
 }
 
 // writeSyncFakeDoltCLIPushFails installs a fake dolt for CLI-mode tests that
 // fails the `dolt push` invocation with the given exit code (writing a stderr
 // line). CLI mode resolves remotes/refspec from disk, so the push is the only
 // dolt call.
-func writeSyncFakeDoltCLIPushFails(t *testing.T, dir string, exitCode int) string {
+func writeSyncFakeDoltCLIPushFails(t *testing.T, dir string, exitCode int) {
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")
 	body := `#!/bin/sh
@@ -174,7 +174,6 @@ exit 0
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
 		t.Fatalf("write fake dolt: %v", err)
 	}
-	return logPath
 }
 
 func writeSyncFakeBeadsBD(t *testing.T, cityPath string) string {
@@ -999,7 +998,7 @@ func TestSyncSQLPushTimeoutReportsTimeout(t *testing.T) {
 	}
 
 	binDir := t.TempDir()
-	_ = writeSyncFakeDoltPushFails(t, binDir, 124, "")
+	writeSyncFakeDoltPushFails(t, binDir, 124, "")
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
@@ -1047,7 +1046,7 @@ func TestSyncSQLPushReportsExitCode(t *testing.T) {
 	}
 
 	binDir := t.TempDir()
-	_ = writeSyncFakeDoltPushFails(t, binDir, 7, "")
+	writeSyncFakeDoltPushFails(t, binDir, 7, "")
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
@@ -1093,7 +1092,7 @@ func TestSyncSQLPushReplaysStderr(t *testing.T) {
 	}
 
 	binDir := t.TempDir()
-	_ = writeSyncFakeDoltPushFails(t, binDir, 1, "fatal: authentication required")
+	writeSyncFakeDoltPushFails(t, binDir, 1, "fatal: authentication required")
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
@@ -1139,7 +1138,7 @@ func TestSyncSQLPushEmptyStderrNoBlankLines(t *testing.T) {
 	}
 
 	binDir := t.TempDir()
-	_ = writeSyncFakeDoltPushFails(t, binDir, 9, "")
+	writeSyncFakeDoltPushFails(t, binDir, 9, "")
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
@@ -1184,7 +1183,7 @@ func TestSyncSQLPushTimeoutHonorsConfiguredCeiling(t *testing.T) {
 	}
 
 	binDir := t.TempDir()
-	_ = writeSyncFakeDoltPushFails(t, binDir, 124, "")
+	writeSyncFakeDoltPushFails(t, binDir, 124, "")
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
@@ -1260,7 +1259,8 @@ func TestSyncRejectsInvalidPushTimeout(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected exit 2 for invalid timeout %q, output:\n%s", bad, out)
 			}
-			if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 2 {
+			var ee *exec.ExitError
+			if !errors.As(err, &ee) || ee.ExitCode() != 2 {
 				t.Fatalf("expected exit code 2 for invalid timeout %q, got %v:\n%s", bad, err, out)
 			}
 			if !strings.Contains(string(out), "invalid GC_DOLT_SYNC_PUSH_TIMEOUT_SECS") {
@@ -1291,7 +1291,7 @@ func TestSyncCLIPushReportsExitCode(t *testing.T) {
 	}
 
 	binDir := t.TempDir()
-	_ = writeSyncFakeDoltCLIPushFails(t, binDir, 3)
+	writeSyncFakeDoltCLIPushFails(t, binDir, 3)
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
@@ -1336,7 +1336,7 @@ func TestSyncCLIForcePushReportsExitCode(t *testing.T) {
 	}
 
 	binDir := t.TempDir()
-	_ = writeSyncFakeDoltCLIPushFails(t, binDir, 5)
+	writeSyncFakeDoltCLIPushFails(t, binDir, 5)
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app", "--force")

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -115,6 +116,67 @@ exit 0
 	return logPath
 }
 
+// writeSyncFakeDoltPushFails installs a fake dolt that answers the SQL-mode
+// remote-lookup and active-branch queries normally but fails the DOLT_PUSH call
+// with the given exit code, writing stderr (when non-empty) to its own stderr.
+// It is parameterized by (exitCode, stderr) so one helper covers every SQL push
+// failure case (timeout exit 124, transport exit 7, stderr replay, etc.) rather
+// than N hardcoded-exit functions. The remotes-lookup query must still succeed
+// or the push site is never reached.
+func writeSyncFakeDoltPushFails(t *testing.T, dir string, exitCode int, stderr string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	stderrEmit := ""
+	if stderr != "" {
+		stderrEmit = "printf '%s\\n' '" + stderr + "' >&2"
+	}
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+    printf 'name,url\norigin,https://example.invalid/repo\n'
+    exit 0
+    ;;
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\nmain\n'
+    exit 0
+    ;;
+  *DOLT_PUSH*)
+    ` + stderrEmit + `
+    exit ` + strconv.Itoa(exitCode) + `
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return logPath
+}
+
+// writeSyncFakeDoltCLIPushFails installs a fake dolt for CLI-mode tests that
+// fails the `dolt push` invocation with the given exit code (writing a stderr
+// line). CLI mode resolves remotes/refspec from disk, so the push is the only
+// dolt call.
+func writeSyncFakeDoltCLIPushFails(t *testing.T, dir string, exitCode int) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"push "*)
+    printf 'remote rejected push\n' >&2
+    exit ` + strconv.Itoa(exitCode) + `
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return logPath
+}
+
 func writeSyncFakeBeadsBD(t *testing.T, cityPath string) string {
 	t.Helper()
 	scriptDir := filepath.Join(cityPath, ".gc", "system", "packs", "bd", "assets", "scripts")
@@ -165,6 +227,12 @@ func TestSyncUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	// The success line is a parsed contract — assert it byte-for-byte so a
+	// format change is caught here rather than breaking downstream consumers.
+	if !strings.Contains(string(out), "  app: pushed main -> origin:main (https://example.invalid/repo)") {
+		t.Fatalf("output missing byte-for-byte success line:\n%s", out)
 	}
 
 	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
@@ -911,5 +979,385 @@ func TestSyncWarnsWhenActiveBranchFallbacksToMain(t *testing.T) {
 	log := string(data)
 	if !strings.Contains(log, "CALL DOLT_PUSH('origin', 'main')") {
 		t.Fatalf("fallback should push main after warning\nlog:\n%s\noutput:\n%s", log, out)
+	}
+}
+
+// TestSyncSQLPushTimeoutReportsTimeout verifies that an exit-124 push (the
+// run_bounded timeout convention) is reported as a TIMEOUT naming the ceiling
+// and env var, and is NOT collapsed into the generic non-timeout error (R1).
+func TestSyncSQLPushTimeoutReportsTimeout(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDoltPushFails(t, binDir, 124, "")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected push failure, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "TIMEOUT after 1800s") {
+		t.Fatalf("expected TIMEOUT message naming the 1800s ceiling, got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "GC_DOLT_SYNC_PUSH_TIMEOUT_SECS") {
+		t.Fatalf("expected TIMEOUT message to name the env var, got:\n%s", out)
+	}
+	if strings.Contains(string(out), "ERROR: push failed (exit") {
+		t.Fatalf("timeout must not be reported as a generic exit-code failure:\n%s", out)
+	}
+}
+
+// TestSyncSQLPushReportsExitCode verifies a non-124 SQL push failure reports the
+// underlying exit code and is distinguishable from a timeout (R3).
+func TestSyncSQLPushReportsExitCode(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDoltPushFails(t, binDir, 7, "")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected push failure, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "ERROR: push failed (exit 7)") {
+		t.Fatalf("expected exit-code-7 failure message, got:\n%s", out)
+	}
+	if strings.Contains(string(out), "TIMEOUT") {
+		t.Fatalf("non-124 failure must not be reported as a timeout:\n%s", out)
+	}
+}
+
+// TestSyncSQLPushReplaysStderr verifies the underlying dolt stderr is surfaced
+// on push failure (R2). Runs on the empty-password harness so the assertion is
+// non-vacuous (RB6 — the credential-safe replay actually emits the line).
+func TestSyncSQLPushReplaysStderr(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDoltPushFails(t, binDir, 1, "fatal: authentication required")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected push failure, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "fatal: authentication required") {
+		t.Fatalf("expected underlying dolt stderr to be surfaced, got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "app: fatal: authentication required") {
+		t.Fatalf("replayed stderr should be prefixed with the db name, got:\n%s", out)
+	}
+}
+
+// TestSyncSQLPushEmptyStderrNoBlankLines verifies a failure with empty stderr
+// emits exactly one structured error line and no spurious db-prefixed blank
+// lines (AC4 — guards the replay-loop no-op).
+func TestSyncSQLPushEmptyStderrNoBlankLines(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDoltPushFails(t, binDir, 9, "")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected push failure, output:\n%s", out)
+	}
+	if n := strings.Count(string(out), "ERROR: push failed (exit 9)"); n != 1 {
+		t.Fatalf("expected exactly one structured error line, got %d:\n%s", n, out)
+	}
+	if strings.Contains(string(out), "  app: \n") {
+		t.Fatalf("empty stderr must not produce a db-prefixed blank line:\n%s", out)
+	}
+}
+
+// TestSyncSQLPushTimeoutHonorsConfiguredCeiling verifies the TIMEOUT message
+// names the configured ceiling, not a hardcoded default (R1/R5, AC2).
+func TestSyncSQLPushTimeoutHonorsConfiguredCeiling(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDoltPushFails(t, binDir, 124, "")
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS=3600",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected push failure, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "TIMEOUT after 3600s") {
+		t.Fatalf("expected TIMEOUT message to name the configured 3600s ceiling, got:\n%s", out)
+	}
+	if strings.Contains(string(out), "1800s") {
+		t.Fatalf("TIMEOUT message must not name the hardcoded default when overridden:\n%s", out)
+	}
+}
+
+// TestSyncRejectsInvalidPushTimeout verifies that an invalid
+// GC_DOLT_SYNC_PUSH_TIMEOUT_SECS aborts with exit 2 and a stderr diagnostic
+// before any database is touched — dolt is never invoked (R5 input validation).
+func TestSyncRejectsInvalidPushTimeout(t *testing.T) {
+	for _, bad := range []string{"abc", "0", ""} {
+		bad := bad
+		name := bad
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := repoRoot(t)
+			script := filepath.Join(root, syncScript)
+
+			port, cleanup := startReachableTCPListener(t)
+			defer cleanup()
+
+			cityPath := t.TempDir()
+			dataDir := filepath.Join(cityPath, "data")
+			if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+				t.Fatalf("mkdir db: %v", err)
+			}
+
+			binDir := t.TempDir()
+			doltLog := writeSyncFakeDolt(t, binDir)
+			_ = writeSyncFakeBeadsBD(t, cityPath)
+
+			cmd := exec.Command("sh", script, "--db", "app")
+			cmd.Env = append(filteredEnv(
+				"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+				"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+				"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+			),
+				"PATH="+binDir+":"+os.Getenv("PATH"),
+				"GC_CITY_PATH="+cityPath,
+				"GC_PACK_DIR="+root,
+				"GC_DOLT_DATA_DIR="+dataDir,
+				fmt.Sprintf("GC_DOLT_PORT=%d", port),
+				"GC_DOLT_USER=root",
+				"GC_DOLT_PASSWORD=",
+				"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS="+bad,
+			)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected exit 2 for invalid timeout %q, output:\n%s", bad, out)
+			}
+			if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 2 {
+				t.Fatalf("expected exit code 2 for invalid timeout %q, got %v:\n%s", bad, err, out)
+			}
+			if !strings.Contains(string(out), "invalid GC_DOLT_SYNC_PUSH_TIMEOUT_SECS") {
+				t.Fatalf("expected validation diagnostic for %q, got:\n%s", bad, out)
+			}
+			if data, rerr := os.ReadFile(doltLog); rerr == nil && strings.TrimSpace(string(data)) != "" {
+				t.Fatalf("dolt must not be invoked when the timeout is invalid (%q), log:\n%s", bad, data)
+			}
+		})
+	}
+}
+
+// TestSyncCLIPushReportsExitCode verifies the CLI-mode plain push surfaces the
+// underlying exit code instead of a generic message (R4).
+func TestSyncCLIPushReportsExitCode(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	dbDir := filepath.Join(dataDir, "app")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
+		t.Fatalf("write remotes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDoltCLIPushFails(t, binDir, 3)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_PORT=1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected CLI push failure, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "ERROR: push failed (exit 3)") {
+		t.Fatalf("expected CLI exit-code-3 failure message, got:\n%s", out)
+	}
+}
+
+// TestSyncCLIForcePushReportsExitCode verifies the CLI-mode --force branch
+// independently captures and reports its exit code — it could otherwise ship
+// still swallowing $? (R4; observability force-branch coverage).
+func TestSyncCLIForcePushReportsExitCode(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	dbDir := filepath.Join(dataDir, "app")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
+		t.Fatalf("write remotes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	_ = writeSyncFakeDoltCLIPushFails(t, binDir, 5)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app", "--force")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_PORT=1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected CLI --force push failure, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "ERROR: push failed (exit 5)") {
+		t.Fatalf("expected CLI --force exit-code-5 failure message, got:\n%s", out)
 	}
 }

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -129,7 +129,10 @@ func writeSyncFakeDoltPushFails(t *testing.T, dir string, exitCode int, stderr s
 	logPath := filepath.Join(dir, "dolt.log")
 	stderrEmit := ""
 	if stderr != "" {
-		stderrEmit = "printf '%s\\n' '" + stderr + "' >&2"
+		// Escape single quotes so an arbitrary stderr value cannot break out
+		// of the single-quoted shell literal: ' becomes '\''.
+		escaped := strings.ReplaceAll(stderr, "'", `'\''`)
+		stderrEmit = "printf '%s\\n' '" + escaped + "' >&2"
 	}
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
@@ -1213,64 +1216,77 @@ func TestSyncSQLPushTimeoutHonorsConfiguredCeiling(t *testing.T) {
 	}
 }
 
-// TestSyncRejectsInvalidPushTimeout verifies that an invalid
-// GC_DOLT_SYNC_PUSH_TIMEOUT_SECS aborts with exit 2 and a stderr diagnostic
-// before any database is touched — dolt is never invoked (R5 input validation).
-func TestSyncRejectsInvalidPushTimeout(t *testing.T) {
-	for _, bad := range []string{"abc", "0", ""} {
-		bad := bad
-		name := bad
-		if name == "" {
-			name = "empty"
-		}
-		t.Run(name, func(t *testing.T) {
-			root := repoRoot(t)
-			script := filepath.Join(root, syncScript)
+// assertSyncRejectsInvalidPushTimeout drives one invalid-timeout scenario: it
+// runs sync with GC_DOLT_SYNC_PUSH_TIMEOUT_SECS=bad and asserts the script
+// aborts with exit 2 and a stderr diagnostic before any database is touched —
+// dolt is never invoked (R5 input validation). Parameterized by the bad value
+// so each scenario keeps its own standalone test func (no table-driven block).
+func assertSyncRejectsInvalidPushTimeout(t *testing.T, bad string) {
+	t.Helper()
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
 
-			port, cleanup := startReachableTCPListener(t)
-			defer cleanup()
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
 
-			cityPath := t.TempDir()
-			dataDir := filepath.Join(cityPath, "data")
-			if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
-				t.Fatalf("mkdir db: %v", err)
-			}
-
-			binDir := t.TempDir()
-			doltLog := writeSyncFakeDolt(t, binDir)
-			_ = writeSyncFakeBeadsBD(t, cityPath)
-
-			cmd := exec.Command("sh", script, "--db", "app")
-			cmd.Env = append(filteredEnv(
-				"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-				"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-				"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-			),
-				"PATH="+binDir+":"+os.Getenv("PATH"),
-				"GC_CITY_PATH="+cityPath,
-				"GC_PACK_DIR="+root,
-				"GC_DOLT_DATA_DIR="+dataDir,
-				fmt.Sprintf("GC_DOLT_PORT=%d", port),
-				"GC_DOLT_USER=root",
-				"GC_DOLT_PASSWORD=",
-				"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS="+bad,
-			)
-			out, err := cmd.CombinedOutput()
-			if err == nil {
-				t.Fatalf("expected exit 2 for invalid timeout %q, output:\n%s", bad, out)
-			}
-			var ee *exec.ExitError
-			if !errors.As(err, &ee) || ee.ExitCode() != 2 {
-				t.Fatalf("expected exit code 2 for invalid timeout %q, got %v:\n%s", bad, err, out)
-			}
-			if !strings.Contains(string(out), "invalid GC_DOLT_SYNC_PUSH_TIMEOUT_SECS") {
-				t.Fatalf("expected validation diagnostic for %q, got:\n%s", bad, out)
-			}
-			if data, rerr := os.ReadFile(doltLog); rerr == nil && strings.TrimSpace(string(data)) != "" {
-				t.Fatalf("dolt must not be invoked when the timeout is invalid (%q), log:\n%s", bad, data)
-			}
-		})
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
 	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS="+bad,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected exit 2 for invalid timeout %q, output:\n%s", bad, out)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) || ee.ExitCode() != 2 {
+		t.Fatalf("expected exit code 2 for invalid timeout %q, got %v:\n%s", bad, err, out)
+	}
+	if !strings.Contains(string(out), "invalid GC_DOLT_SYNC_PUSH_TIMEOUT_SECS") {
+		t.Fatalf("expected validation diagnostic for %q, got:\n%s", bad, out)
+	}
+	if data, rerr := os.ReadFile(doltLog); rerr == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("dolt must not be invoked when the timeout is invalid (%q), log:\n%s", bad, data)
+	}
+}
+
+// TestSyncRejectsNonNumericPushTimeout verifies a non-numeric
+// GC_DOLT_SYNC_PUSH_TIMEOUT_SECS is rejected with exit 2 (R5 input validation).
+func TestSyncRejectsNonNumericPushTimeout(t *testing.T) {
+	assertSyncRejectsInvalidPushTimeout(t, "abc")
+}
+
+// TestSyncRejectsZeroPushTimeout verifies a zero GC_DOLT_SYNC_PUSH_TIMEOUT_SECS
+// is rejected with exit 2 — a 0s ceiling would SIGKILL the push immediately and
+// emit a misleading TIMEOUT message (R5 input validation).
+func TestSyncRejectsZeroPushTimeout(t *testing.T) {
+	assertSyncRejectsInvalidPushTimeout(t, "0")
+}
+
+// TestSyncRejectsEmptyPushTimeout verifies an empty GC_DOLT_SYNC_PUSH_TIMEOUT_SECS
+// is rejected with exit 2 (R5 input validation).
+func TestSyncRejectsEmptyPushTimeout(t *testing.T) {
+	assertSyncRejectsInvalidPushTimeout(t, "")
 }
 
 // TestSyncCLIPushReportsExitCode verifies the CLI-mode plain push surfaces the

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -14,6 +14,23 @@ import (
 
 const syncScript = "commands/sync/run.sh"
 
+// syncFilteredEnv returns os.Environ() with every env var the sync script reads
+// stripped, so a test's GC_DOLT_* config is exactly what the test sets and never
+// what the developer/CI happens to export. GC_DOLT_SYNC_PUSH_TIMEOUT_SECS is in
+// the set because its validator (run.sh) now runs unconditionally on every
+// invocation and exits 2 on any invalid value — an ambient invalid value would
+// otherwise flip success-path tests red and make the refspec-failure tests pass
+// for the wrong reason. Centralizing the key list here keeps every sync test
+// hermetic against the same surface and prevents the strip-set from drifting
+// per call site.
+func syncFilteredEnv() []string {
+	return filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
+	)
+}
+
 func startReachableTCPListener(t *testing.T) (int, func()) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -157,6 +174,40 @@ exit 0
 	}
 }
 
+// writeSyncFakeDoltPushFailsNoTrailingNewline installs a fake dolt whose
+// SQL-mode DOLT_PUSH failure writes a two-line stderr whose FINAL line lacks a
+// trailing newline (a terse dolt diagnostic or a SIGKILL-truncated write). Every
+// other helper emits via `printf '%s\n'`, so only this one exercises the
+// replay loop's last-line flush: a `while read` without the `|| [ -n "$line" ]`
+// guard would drop the unterminated final line — the swallowed-failure class
+// this command set exists to surface.
+func writeSyncFakeDoltPushFailsNoTrailingNewline(t *testing.T, dir string, exitCode int) {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+    printf 'name,url\norigin,https://example.invalid/repo\n'
+    exit 0
+    ;;
+  *"SELECT active_branch()"*)
+    printf 'active_branch()\nmain\n'
+    exit 0
+    ;;
+  *DOLT_PUSH*)
+    printf 'error: push diagnostics follow\n' >&2
+    printf '%s' 'fatal: last line no newline' >&2
+    exit ` + strconv.Itoa(exitCode) + `
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+}
+
 // writeSyncFakeDoltCLIPushFails installs a fake dolt for CLI-mode tests that
 // fails the `dolt push` invocation with the given exit code (writing a stderr
 // line). CLI mode resolves remotes/refspec from disk, so the push is the only
@@ -263,10 +314,7 @@ func TestSyncUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
 	bdLog := writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -331,10 +379,7 @@ func TestSyncForceUsesSetUpstreamWithLiveSQL(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app", "--force")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -377,10 +422,7 @@ func TestSyncForceUsesResolvedActiveBranchWithLiveSQL(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app", "--force")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -423,10 +465,7 @@ func TestSyncForceUsesRefspecEnvOverrideWithLiveSQL(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app", "--force")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -470,10 +509,7 @@ func TestSyncDryRunShowsResolvedActiveBranch(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app", "--dry-run")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -514,10 +550,7 @@ func TestSyncSkipsDatabasesWithNoSyncMarker(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -557,10 +590,7 @@ func TestSyncReportsLiveSQLRemoteLookupFailure(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -613,10 +643,7 @@ func TestSyncCLIFallbackPushesOriginMain(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -661,10 +688,7 @@ func TestSyncPushesActiveBranchWhenSet(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -713,10 +737,7 @@ func TestSyncRefspecEnvOverride(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -762,10 +783,7 @@ func TestSyncRefspecEnvOverrideHyphenInDBName(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "my-app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -817,10 +835,7 @@ func TestSyncCLIFallbackReadsRepoStateForActiveBranch(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -873,10 +888,7 @@ func TestSyncCLIFallbackIgnoresNestedRepoStateHead(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -924,10 +936,7 @@ func TestSyncRefspecInvalidOverrideFails(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -964,10 +973,7 @@ func TestSyncRefspecOptionShapedOverrideFails(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1004,10 +1010,7 @@ func TestSyncWarnsWhenActiveBranchFallbacksToMain(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1054,11 +1057,7 @@ func TestSyncSQLPushTimeoutReportsTimeout(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1102,11 +1101,7 @@ func TestSyncSQLPushReportsExitCode(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1148,11 +1143,7 @@ func TestSyncSQLPushReplaysStderr(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1170,6 +1161,53 @@ func TestSyncSQLPushReplaysStderr(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "app: fatal: authentication required") {
 		t.Fatalf("replayed stderr should be prefixed with the db name, got:\n%s", out)
+	}
+}
+
+// TestSyncSQLPushReplaysStderrFinalLineWithoutTrailingNewline verifies the
+// stderr replay surfaces a final line that lacks a trailing newline — a terse
+// dolt diagnostic or a SIGKILL-truncated write. POSIX `read` returns non-zero
+// at an unterminated EOF, so without the loop's `|| [ -n "$line" ]` flush the
+// last line is captured but never replayed, re-introducing the swallowed
+// failure this command set exists to surface.
+func TestSyncSQLPushReplaysStderrFinalLineWithoutTrailingNewline(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	writeSyncFakeDoltPushFailsNoTrailingNewline(t, binDir, 1)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(syncFilteredEnv(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected push failure, output:\n%s", out)
+	}
+	// The newline-less final line must still be surfaced, db-prefixed.
+	if !strings.Contains(string(out), "app: fatal: last line no newline") {
+		t.Fatalf("replay dropped the final stderr line lacking a trailing newline, got:\n%s", out)
+	}
+	// The preceding (newline-terminated) line must survive too.
+	if !strings.Contains(string(out), "app: error: push diagnostics follow") {
+		t.Fatalf("expected the first stderr line to be surfaced, got:\n%s", out)
 	}
 }
 
@@ -1194,11 +1232,7 @@ func TestSyncSQLPushEmptyStderrNoBlankLines(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1239,11 +1273,7 @@ func TestSyncSQLPushTimeoutHonorsConfiguredCeiling(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1292,11 +1322,7 @@ func TestSyncSQLPushReplayDoesNotLeakPassword(t *testing.T) {
 
 	const secret = "s3cr3t-push-token"
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1349,11 +1375,7 @@ func TestSyncSQLPushTimeoutReplaysNoMechanismMarker(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1399,11 +1421,7 @@ func TestSyncSQLPushTempFileFailureDegradesPerDb(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1445,11 +1463,7 @@ func assertSyncRejectsInvalidPushTimeout(t *testing.T, bad string) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1532,11 +1546,7 @@ func TestSyncCLIPushReportsExitCode(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -1577,11 +1587,7 @@ func TestSyncCLIForcePushReportsExitCode(t *testing.T) {
 	_ = writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", script, "--db", "app", "--force")
-	cmd.Env = append(filteredEnv(
-		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
-		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
-		"GC_DOLT_SYNC_PUSH_TIMEOUT_SECS",
-	),
+	cmd.Env = append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,


### PR DESCRIPTION
## Summary

`gc dolt sync` collapsed every SQL-mode push failure into a single generic `ERROR: push failed`. The push ran through the shared `dolt_sql` helper, which wraps every call in a fixed 120s `run_bounded` ceiling sized for short metadata queries, then discarded both stdout and stderr (`>/dev/null 2>&1`). So a large first push that exceeded 120s was SIGKILLed (exit 124) and reported identically to an auth rejection, a transport error, or a SQL exception — with every underlying diagnostic swallowed. CLI mode already passed dolt's stderr through (`2>&1`) but likewise emitted only the generic message with no exit code. This change makes push failures legible: it distinguishes timeout from exit-code from CLI-mode failures, replays the underlying dolt stderr, and gives the push its own configurable, validated wall-clock bound. Fixes #2637.

## What changed

- **`examples/dolt/commands/sync/run.sh`**
  - New `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` (default `1800`s) bounds the SQL-mode push, replacing the prior fixed 120s. Validated up front, before any per-database logic, and rejected with exit 2 if empty / non-numeric / any all-zero form.
  - `dolt_sql QUERY [TIMEOUT_SECS]` now takes an optional bound (default 120s). The SQL push passes `$push_timeout`; metadata queries keep 120s. A comment pins `dolt_sql`'s "short-metadata-queries-only" contract so a future data-transfer caller does not silently re-hit the ceiling.
  - The SQL push site captures stderr to a temp file and preserves the real exit code: a `TIMEOUT after Ns …` message naming the ceiling and the env var on exit 124; `ERROR: push failed (exit N)` otherwise; then the captured dolt stderr, replayed db-prefixed. A failed `mktemp` degrades to a per-db error instead of aborting the whole run under `set -e`.
  - The CLI push branches capture the real exit code (`|| cli_rc=$?` on each branch, before the success test) and emit `ERROR: push failed (exit N)`; the existing `2>&1` is preserved.
  - The header `Environment:` block is expanded to per-var form and documents the new variable.
- **`examples/dolt/sync_test.go`** — adds coverage for each failure mode: SQL timeout (exit 124) reported as TIMEOUT and not as a generic exit; non-124 exit reported with its code and not as a timeout; stderr replayed db-prefixed; configured ceiling honored in the message; all numeric-zero forms rejected with exit 2 before dolt is invoked; CLI exit code surfaced; empty-stderr emits no spurious blank line; newline-less final stderr line still replayed; a non-vacuous credential-non-exposure test; the no-mechanism-marker replay on the 124 branch; and the `mktemp`-failure per-db degrade. The pre-existing success-path test gains a byte-for-byte success-line assertion. All call sites route their environment through a single `syncFilteredEnv()` helper.
- **`CHANGELOG.md`** — `Added` (the new timeout variable) and `Fixed` (per-mode push diagnostics) entries under `[Unreleased]`.

## Behavior / regression boundaries

- **Failure modes distinguished.** Exit 124 → `TIMEOUT after <ceiling>s — push manually or increase timeout (GC_DOLT_SYNC_PUSH_TIMEOUT_SECS)`. Any other non-zero exit → `ERROR: push failed (exit N)`. CLI mode has no wall-clock ceiling, so exit 124 cannot arise there; it surfaces the exit code only. The 124 branch is overloaded by design (a real wall-clock timeout and the no-mechanism fall-through where no `timeout`/`gtimeout`/`python3` exists), and the unconditional stderr replay disambiguates the two via `run_bounded`'s `cannot run bounded command` marker.
- **Underlying stderr surfaced.** dolt's stderr is captured and replayed db-prefixed for scannable multi-db output. A final line lacking a trailing newline is still flushed (POSIX `read` returns non-zero at an unterminated EOF), and an empty capture is suppressed so no blank line is emitted.
- **Configurable and validated bound.** `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` defaults to 1800s and is validated before any database is touched. Every numeric-zero spelling (`0`, `00`, `000`, …) is rejected — not just the literal `0` — because GNU `timeout` treats a zero duration as "disable the timeout", which would run the push unbounded and defeat the anti-hang invariant the bound exists to uphold.
- **Credentials never exposed.** The replayed stderr cannot leak the password: it reaches dolt via the `DOLT_CLI_PASSWORD` environment variable, never as an argv flag, so dolt's own stderr cannot echo it back.
- **Preserved.** The successful-push output line is byte-for-byte unchanged; the push stays bounded (loosened default, not removed); dry-run / no-remote / `.no-sync` / refspec-override behavior is untouched; the script still exits non-zero when any push fails; CLI stderr still reaches the terminal.

## Testing

From independent verification (all on the `examples/dolt` package):

- `gofmt`: clean.
- `go vet ./examples/dolt/`: clean (exit 0).
- `go test`: 178/178 pass, 0 fail.
- Behavior checks against the built script:
  - `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS=00` rejected with exit 2 and the diagnostic, dolt never invoked; literal `0` likewise; a valid `5` proceeds and pushes (validator does not over-reject).
  - A simulated non-124 failure (exit 7) replays `app: ERROR: push failed (exit 7)` plus the dolt stderr line with no spurious TIMEOUT; an exit-124 failure produces the TIMEOUT message naming the configured ceiling and the env var, not the generic exit line.
  - A non-vacuous credential check (fake dolt confirms it received the secret via `DOLT_CLI_PASSWORD` and echoes its argv) shows the diagnostic is replayed but the secret value never appears in output.

## Review Story

The change was reviewed across ten independent viewpoints with an adjudicating judge. All three files were in scope; there is no Go package surface. Conformance tracing confirmed every plan item and every requirement / regression boundary covered, blast radius matched the prediction (three files, sibling dolt commands untouched), and the concurrency lens was SKIPPED (no concurrency surface).

Round 1 surfaced three MAJOR findings, all resolved. A leading-zero validation bypass meant `00`/`000` slipped past the guard and reached `timeout`, which treats a zero duration as "disable the timeout" — an unbounded push; this was closed with a three-arm validator that rejects every all-zero form before any dolt invocation, plus negative tests. Credential non-exposure had been only vacuously tested (every test ran with an empty password), so the by-construction safety was never exercised on the replay path; a non-vacuous test now sets a real secret, proves it reached dolt via `DOLT_CLI_PASSWORD`, and asserts it never appears in replayed output. Two recommended hardening items were also folded in: the `mktemp`-failure per-db degrade, and a test for the no-mechanism-marker replay on the 124 branch.

Round 2 found three new MAJORs, again all resolved. The hostile code-review reproduced a trailing-newline drop in the stderr replay loop — POSIX `read` discards an unterminated final line, so a terse newline-less dolt diagnostic (precisely the swallowed-failure class this change targets) was captured but never replayed; fixed with the last-line-safe `|| [ -n "$line" ]` idiom and a dedicated newline-less negative test. The now-global timeout validator made the pre-existing tests non-hermetic — the env filter is a blocklist and the new variable was stripped only in the new tests; this was closed by routing all sync test call sites through a single `syncFilteredEnv()` helper, giving the strip-set one source of truth. And both CHANGELOG entries had landed inside the shipped, dated version block instead of `[Unreleased]`; they were relocated.

Round 2 reached a pass verdict. One finding was raised above MINOR and, on investigation, downgraded: the new `syncFilteredEnv` docstring claims it strips every env var the script reads, but the open-ended `GC_DOLT_REFSPEC_<DB>` namespace is not covered by a static blocklist. Verified against the base, this non-coverage is pre-existing and the refspec read is unchanged by the diff — no previously-green test is turned red — so the PR-attributable part is a documentation-accuracy nit, not a regression. It is recorded as a non-blocking follow-up. Remaining lower-severity observations (exit-137 not labeled TIMEOUT; the overloaded-124 headline; `--help` not enumerating env vars, consistent with the file's long-standing convention; a whitespace-only-stderr edge) were reviewed and overridden as pattern-consistent or benign.

## Review process note

This change was reviewed via a manually-orchestrated review council (10 independent reviewer lenses plus an adjudicating judge plus independent verification, all on Opus) because the automated council runtime was temporarily unavailable. Round 1 surfaced 3 MAJOR findings, all resolved; round 2 reached a pass verdict.

## Known follow-up (non-blocking)

The `syncFilteredEnv` docstring states it strips "every env var the sync script reads," but the DB-name-keyed `GC_DOLT_REFSPEC_<DB>` namespace cannot be covered by a static blocklist. This coverage gap is pre-existing and unchanged by this PR (the refspec read predates it and is untouched), so it is not a regression. A small docstring/scope clarification will follow — either softening the docstring to name the fixed `GC_DOLT_*` keys it covers, or extending the strip-set with the concrete `GC_DOLT_REFSPEC_*` keys the tests use.

---

<sub>(internal ref: ga-egfngk)</sub>
