### PR TITLE
fix(dolt): defer ambiguous compact writer races

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -20,10 +20,11 @@
 #   3. Commit everything as a single "compaction: flatten history" commit.
 #   4. Re-check post-flatten row counts, table value hashes, and database
 #      value hash. Row-count decreases fail before full GC. Row-count
-#      increases are treated as concurrent-writer evidence and allowed to
-#      continue only when table and database value hashes stay stable. Any
-#      value-hash drift, table-list drift, or row-count decrease is
-#      quarantined before full GC.
+#      increases with stable value hashes can continue to full GC. Pure
+#      row-count increase plus value-hash drift is the ambiguous concurrent-
+#      writer case and is deferred to pending GC instead of quarantined. Any
+#      table-list drift, probe failure, same-count value-hash drift, or
+#      row-count decrease is quarantined before full GC.
 #   4a. Local-verify HEAD-stability gate. The pre-flight stability loop cannot
 #      close the residual window between its final HEAD check and the flatten,
 #      nor the window during post-flatten verify, so a normal MVCC writer (the
@@ -32,15 +33,15 @@
 #      otherwise looks identical to the ambiguous gain+drift corruption signal.
 #      Quarantining that false positive blocks all future GC of the db and
 #      starves DOLT_GC until host memory is exhausted. So, mirroring the remote-
-#      push path's HEAD-stability defer, the gain+drift case is downgraded from
-#      a blocking quarantine to a skip-and-retry-next-run ONLY when a concurrent
-#      writer is proven. A writer is proven (and distinguished from the flatten's
-#      OWN commit) when either HEAD captured immediately before the mutating
-#      reset differs from the stable pre-flight HEAD (a writer landed in the
-#      preflight->reset window, before the flatten committed), or HEAD captured
-#      after verify moved past the flatten's own commit (a writer landed during/
-#      after verify). All other failures — and gain+drift with a stable HEAD —
-#      still quarantine. Probe failure leaves the race unproven and quarantines.
+#      push path's HEAD-stability defer, pure gain+drift is downgraded from a
+#      blocking quarantine to a skip-and-retry-next-run. A writer is proven (and
+#      distinguished from the flatten's OWN commit) when either HEAD captured
+#      immediately before the mutating reset differs from the stable pre-flight
+#      HEAD (a writer landed in the preflight->reset window, before the flatten
+#      committed), or HEAD captured after verify moved past the flatten's own
+#      commit (a writer landed during/after verify). The residual probe->reset
+#      window cannot be observed after the fact, so pure gain+drift defers even
+#      when HEAD is stable. All stricter failure categories still quarantine.
 #   5. Run CALL DOLT_GC('--full') to reclaim chunks orphaned by the flatten.
 #
 # Remote push failures are recorded in compact-pending-push markers and do not
@@ -694,10 +695,10 @@ preflight_counts() {
 }
 
 # verify_counts — re-count/re-hash and compare against the pre-flight file.
-# Row-count decreases fail. Row-count increases are recorded as concurrent
-# writer evidence only when the table value hash stays stable. Any table hash
-# drift is quarantined before full GC because row-count gain alone cannot prove
-# pre-flight rows remain reachable. Sets category flags plus
+# Row-count decreases fail. Row-count increases with stable hashes can continue.
+# Row-count increases plus table hash drift are recorded as the ambiguous writer
+# race case so the caller can defer to pending GC. Other hash drift, table-list
+# drift, and probe failures quarantine before full GC. Sets category flags plus
 # verify_counts_failure_reason and verify_counts_failure_guidance for callers.
 verify_counts() {
   db="$1"
@@ -782,7 +783,7 @@ verify_counts() {
     if [ "$actual_hash" != "$expected_hash" ]; then
       if [ "$table_gained_rows" = "1" ]; then
         verify_counts_saw_gain_hash_drift=1
-        printf 'compact: db=%s table=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
+        printf 'compact: db=%s table=%s value hash changed with row-count increase before=%s after=%s — defer or quarantine after writer-race classification\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
         if [ "$fail" -ne 1 ]; then
           fail=1
@@ -1593,13 +1594,14 @@ flatten_database() {
 
   # Race window: between the `head` capture above and the flatten transaction
   # below, a busy database (notably hq, where many writers commit constantly)
-  # may move HEAD. The post-flatten value-hash check then fails and the DB is
-  # quarantined. Retry preflight up to 3 times with jittered 1-5s sleep,
+  # may move HEAD. The post-flatten value-hash check then fails or defers,
+  # depending on the integrity category. Retry preflight up to 3 times with
+  # jittered 1-5s sleep,
   # refreshing HEAD between attempts; require HEAD to stay stable across a
   # preflight gather before flattening. This narrows but does not eliminate the
-  # race: a writer can still commit between the final HEAD check and DOLT_RESET,
-  # in which case post-flatten quarantine catches the run and the next order can
-  # retry.
+  # race: a writer can still commit between the final HEAD check and DOLT_RESET.
+  # Pure row-count gain plus hash drift is deferred to pending GC so the next
+  # order can retry; stricter integrity failures still quarantine.
   preflight_tmp=$(mktemp)
   preflight_max_attempts=3
   preflight_attempt=1
@@ -1675,8 +1677,9 @@ flatten_database() {
   # DOLT_RESET/DOLT_COMMIT — any difference from "$head" here can only be an
   # external writer that committed inside the residual preflight->reset window,
   # never the flatten's own commit (which has not happened yet). An empty/failed
-  # probe leaves head_before_reset empty, which the writer-race gate treats as
-  # "unproven" and therefore falls back to the safe quarantine behavior.
+  # probe leaves head_before_reset empty, which keeps the writer-race proof
+  # unavailable. Pure gain+drift may still defer; stricter failure categories
+  # still fall back to quarantine.
   head_before_reset=$(head_commit "$db" || true)
 
   # Soft-reset to root + commit-everything is the flatten transaction.
@@ -1719,8 +1722,8 @@ flatten_database() {
   # beads/mail workload) can commit to this db inside the flatten window, which
   # legitimately adds rows and changes value hashes versus the pre-flight
   # snapshot. That is a benign, self-healing condition — the next scheduled run
-  # retries — and must NOT be quarantined (a quarantine marker blocks all future
-  # GC of the db and is the production memory-exhaustion bug).
+  # retries — and must NOT be permanently quarantined (a quarantine marker blocks
+  # all future GC of the db and is the production memory-exhaustion bug).
   #
   # We distinguish a writer commit from the flatten's OWN commit using two
   # independent signals, both anchored so the flatten's own commit never trips
@@ -1733,7 +1736,8 @@ flatten_database() {
   #     the flatten and this probe, so only an external writer can have moved it.
   # Either signal proves a concurrent writer. If a HEAD probe fails/returns
   # empty we leave the corresponding value empty and the equality below cannot
-  # become true, so an unprovable race safely falls through to quarantine.
+  # become true. The pure gain+drift case still defers because the final
+  # probe->reset window cannot be closed; all stricter failures quarantine.
   post_verify_head=$(head_commit "$db" || true)
   writer_race_detected=0
   if [ -n "$head" ] && [ -n "$head_before_reset" ] && [ "$head_before_reset" != "$head" ]; then
@@ -1747,19 +1751,24 @@ flatten_database() {
   if [ "$verify_counts_rc" -ne 0 ]; then
     integrity_reason="${verify_counts_failure_reason:-post-flatten integrity check failed}"
     integrity_guidance="${verify_counts_failure_guidance:-post-flatten integrity check failed; investigate before re-running}"
-    # Downgrade quarantine -> defer ONLY for the ambiguous gain+drift case when
-    # a concurrent writer is proven. Every other integrity failure (row-count
-    # decrease, same-count hash drift, table-list drift, probe failure) and the
-    # gain+drift case with a stable HEAD still quarantine below unchanged.
-    if [ "$writer_race_detected" = "1" ] && \
-       [ "${verify_counts_saw_gain:-0}" = "1" ] && \
+    # Downgrade quarantine -> defer for the pure ambiguous gain+drift case.
+    # A stable HEAD does not prove corruption because a writer can land in the
+    # residual window between the last pre-reset HEAD probe and DOLT_RESET.
+    # Every stricter integrity failure (row-count decrease, same-count hash
+    # drift, table-list drift, probe failure) still quarantines below unchanged.
+    if [ "${verify_counts_saw_gain:-0}" = "1" ] && \
        [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] && \
        [ "${verify_counts_saw_row_decrease:-0}" != "1" ] && \
        [ "${verify_counts_saw_same_count_hash_drift:-0}" != "1" ] && \
        [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \
        [ "${verify_counts_saw_probe_failure:-0}" != "1" ]; then
-      printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — table value hash drift with row-count increase is concurrent-writer data, not corruption; deferring, will retry next run\n' \
-        "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
+      if [ "$writer_race_detected" = "1" ]; then
+        printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — table value hash drift with row-count increase is concurrent-writer data, not corruption; deferring, will retry next run\n' \
+          "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
+      else
+        printf 'compact: db=%s possible writer race during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — table value hash drift with row-count increase hit the unobservable pre-reset window; deferring, will retry next run\n' \
+          "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
+      fi
       if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
         "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
         "$compacted_from_head" "$local_branch" "$remote_branch"; then
@@ -1845,32 +1854,26 @@ flatten_database() {
       return 0
     fi
     if [ "${verify_counts_saw_gain:-0}" = "1" ]; then
-      # Same writer-race downgrade as the per-table gain+drift case above: a
-      # proven concurrent writer that added rows also shifts the whole-database
-      # value hash. Defer instead of quarantining. A stable-HEAD gain+drift here
-      # is still a genuine anomaly and quarantines unchanged.
+      # Same downgrade as the per-table gain+drift case above: a concurrent
+      # writer that added rows also shifts the whole-database value hash. The
+      # residual pre-reset window can leave HEAD stable even though writer data
+      # was included in the flatten, so pure gain+drift defers instead of
+      # quarantining.
       if [ "$writer_race_detected" = "1" ]; then
         printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — database value hash drift with row-count increase is concurrent-writer data, not corruption; deferring, will retry next run\n' \
           "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
-        if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
-          "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
-          "$compacted_from_head" "$local_branch" "$remote_branch"; then
-          rm -f "$preflight_tmp"
-          return 1
-        fi
-        rm -f "$preflight_tmp"
-        return 0
+      else
+        printf 'compact: db=%s possible writer race during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s) — database value hash drift with row-count increase hit the unobservable pre-reset window; deferring, will retry next run\n' \
+          "$db" "$head" "${head_before_reset:-<empty>}" "$flatten_head" "${post_verify_head:-<empty>}" >&2
       fi
-      printf 'compact: db=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
-        "$db" "$preflight_hash" "$postflight_hash" >&2
-      write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed with row-count increase" || {
-        preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+        "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+        "$compacted_from_head" "$local_branch" "$remote_branch"; then
         rm -f "$preflight_tmp"
         return 1
-      }
-      preserve_head_after_integrity_failure "$db" "$flatten_head" || true
+      fi
       rm -f "$preflight_tmp"
-      return 1
+      return 0
     else
       printf 'compact: db=%s value hash changed without row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
         "$db" "$preflight_hash" "$postflight_hash" >&2

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -1804,16 +1804,13 @@ func TestCompactScriptAllowsRowCountIncreaseWithStableValueHashes(t *testing.T) 
 	}
 }
 
-func TestCompactScriptQuarantinesSameTableRowGainWithValueHashDriftBeforeFullGC(t *testing.T) {
+func TestCompactScriptDefersSameTableRowGainWithValueHashDriftBeforeFullGC(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
-	out, err := fixture.run(t, "same_table_replacement_with_row_gain", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
-	if err == nil {
-		t.Fatalf("compact succeeded despite same-table row-count gain with value-hash drift:\n%s", out)
-	}
+	out, runErr := fixture.run(t, "same_table_replacement_with_row_gain", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
 	if !strings.Contains(out, "table=beads gained rows during flatten") ||
 		!strings.Contains(out, "value hash changed with row-count increase") ||
-		!strings.Contains(out, "post-flatten INTEGRITY check failed") {
-		t.Fatalf("output missing same-table drift quarantine notices:\n%s", out)
+		!strings.Contains(out, "possible writer race during flatten") {
+		t.Fatalf("output missing same-table gain+drift defer notices:\n%s", out)
 	}
 	data, err := os.ReadFile(fixture.doltLog)
 	if err != nil {
@@ -1823,13 +1820,7 @@ func TestCompactScriptQuarantinesSameTableRowGainWithValueHashDriftBeforeFullGC(
 	if !strings.Contains(log, "DOLT_HASHOF_TABLE('beads')") {
 		t.Fatalf("same-table row-count gain test should probe table value hash:\n%s", log)
 	}
-	if strings.Contains(log, "DOLT_GC") {
-		t.Fatalf("same-table row-count gain with value-hash drift must block full GC:\n%s", log)
-	}
-	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
-	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table value hash changed with row-count increase" {
-		t.Fatalf("quarantine reason should identify gained-table hash drift, got %q", reason)
-	}
+	assertCompactWriterRaceDeferred(t, fixture, out, runErr)
 }
 
 func TestCompactScriptQuarantinesMixedRowGainAndSameCountHashDriftBeforeFullGC(t *testing.T) {
@@ -1892,33 +1883,33 @@ func TestCompactScriptQuarantinesMixedSignalsDespiteWriterRace(t *testing.T) {
 	}
 }
 
-// assertCompactWriterRaceDeferred encodes the shared expectations for a proven
-// writer-race defer: the gain+drift quarantine is downgraded to a skip, so the
-// run exits 0, logs the defer message, writes NO quarantine marker, and does not
-// run DOLT_GC (GC is left for the next run after the writer settles).
+// assertCompactWriterRaceDeferred encodes the shared expectations for a
+// gain+drift defer: the ambiguous quarantine is downgraded to a skip, so the run
+// exits 0, logs the defer message, writes NO quarantine marker, and does not run
+// DOLT_GC (GC is left for the next run after the writer settles).
 func assertCompactWriterRaceDeferred(t *testing.T, fixture compactScriptFixture, out string, err error) {
 	t.Helper()
 	if err != nil {
-		t.Fatalf("writer-race defer must exit 0 (skip, not failure): %v\n%s", err, out)
+		t.Fatalf("gain+drift defer must exit 0 (skip, not failure): %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "writer race detected during flatten") ||
+	if (!strings.Contains(out, "writer race detected during flatten") && !strings.Contains(out, "possible writer race during flatten")) ||
 		!strings.Contains(out, "deferring, will retry next run") {
-		t.Fatalf("output missing writer-race defer message:\n%s", out)
+		t.Fatalf("output missing gain+drift defer message:\n%s", out)
 	}
 	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
 	if _, statErr := os.Stat(quarantine); !os.IsNotExist(statErr) {
-		t.Fatalf("writer-race defer must NOT write a quarantine marker; stat=%v", statErr)
+		t.Fatalf("gain+drift defer must NOT write a quarantine marker; stat=%v", statErr)
 	}
 	pendingGC := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
 	if reason := compactMarkerValue(t, pendingGC, "reason"); reason != "writer race during flatten deferred full GC" {
-		t.Fatalf("writer-race defer should record pending-GC retry marker, got reason %q", reason)
+		t.Fatalf("gain+drift defer should record pending-GC retry marker, got reason %q", reason)
 	}
 	data, readErr := os.ReadFile(fixture.doltLog)
 	if readErr != nil {
 		t.Fatalf("read dolt log: %v", readErr)
 	}
 	if strings.Contains(string(data), "DOLT_GC") {
-		t.Fatalf("writer-race defer must skip GC this run:\n%s", string(data))
+		t.Fatalf("gain+drift defer must skip GC this run:\n%s", string(data))
 	}
 }
 
@@ -2106,32 +2097,20 @@ func TestCompactScriptWriterRaceGateUsesFlagNotReasonText(t *testing.T) {
 	}
 }
 
-// Control: the same gain+drift signal with a STABLE HEAD (no writer proven) is a
-// genuine anomaly and must still write the blocking quarantine marker and fail.
-// This guards against the writer-race gate weakening real-corruption detection.
-func TestCompactScriptStillQuarantinesGainAndHashDriftWithStableHead(t *testing.T) {
+// Control for the residual probe->reset race: the same gain+drift signal with a
+// stable HEAD is no longer treated as proven corruption because a writer can
+// still land inside the unobservable window. It must defer to pending GC without
+// running full GC and without installing a permanent quarantine marker.
+func TestCompactScriptDefersGainAndHashDriftWithStableHead(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	out, err := fixture.run(t, "same_table_replacement_with_row_gain", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
-	if err == nil {
-		t.Fatalf("stable-HEAD gain+drift must remain a blocking failure:\n%s", out)
-	}
 	if strings.Contains(out, "writer race detected") {
-		t.Fatalf("stable HEAD must not be misclassified as a writer race:\n%s", out)
+		t.Fatalf("stable HEAD must not be reported as a proven writer race:\n%s", out)
 	}
-	if !strings.Contains(out, "post-flatten INTEGRITY check failed") {
-		t.Fatalf("stable-HEAD gain+drift should escalate as an integrity failure:\n%s", out)
+	if !strings.Contains(out, "possible writer race during flatten") {
+		t.Fatalf("stable-HEAD gain+drift should report the unobservable race window:\n%s", out)
 	}
-	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
-	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten table value hash changed with row-count increase" {
-		t.Fatalf("stable-HEAD gain+drift must quarantine with the gain+drift reason, got %q", reason)
-	}
-	data, readErr := os.ReadFile(fixture.doltLog)
-	if readErr != nil {
-		t.Fatalf("read dolt log: %v", readErr)
-	}
-	if strings.Contains(string(data), "DOLT_GC") {
-		t.Fatalf("stable-HEAD gain+drift must block full GC:\n%s", string(data))
-	}
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
 }
 
 func TestCompactScriptFailsOnRowCountDecreaseBeforeGC(t *testing.T) {
@@ -2246,27 +2225,15 @@ func TestCompactScriptQuarantinesPostFlattenInvalidTableNameBeforeFullGC(t *test
 	}
 }
 
-func TestCompactScriptPreservesRowGainReasonForDatabaseHashDrift(t *testing.T) {
+func TestCompactScriptDefersRowGainDatabaseHashDrift(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	out, err := fixture.run(t, "row_count_gain_with_db_hash_drift", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
-	if err == nil {
-		t.Fatalf("compact succeeded despite database value-hash drift after row-count gain:\n%s", out)
-	}
 	if !strings.Contains(out, "gained rows during flatten") ||
-		!strings.Contains(out, "value hash changed with row-count increase") {
-		t.Fatalf("output missing row-count-gain database hash drift reason:\n%s", out)
+		!strings.Contains(out, "database value hash drift with row-count increase") ||
+		!strings.Contains(out, "possible writer race during flatten") {
+		t.Fatalf("output missing row-count-gain database hash defer reason:\n%s", out)
 	}
-	logData, err := os.ReadFile(fixture.doltLog)
-	if err != nil {
-		t.Fatalf("read dolt log: %v", err)
-	}
-	if strings.Contains(string(logData), "DOLT_GC") {
-		t.Fatalf("database hash drift after row-count gain must block full GC:\n%s", logData)
-	}
-	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
-	if reason := compactMarkerValue(t, marker, "reason"); reason != "post-flatten value hash changed with row-count increase" {
-		t.Fatalf("quarantine reason should identify DB hash drift after row-count gain, got %q", reason)
-	}
+	assertCompactWriterRaceDeferred(t, fixture, out, err)
 }
 
 func TestCompactScriptPreservesNoGainReasonForDatabaseHashDrift(t *testing.T) {


### PR DESCRIPTION
## Summary

- Change `gc dolt compact` so the pure row-count increase plus value-hash drift case defers to the existing pending-GC retry path instead of writing a permanent quarantine marker.
- Keep quarantine behavior for stronger integrity signals: row-count decreases, same-count value-hash drift, table-list drift, probe failures, and mixed hard-failure categories.
- This is a follow-up to #2348 and #2350. PR #2350 correctly prioritized data safety, but its current stable-HEAD gain+drift path can still leave busy cities permanently quarantined because the final HEAD probe cannot observe a writer that lands in the residual probe-to-reset window.

## Problem

On active cities, a normal writer can land between the last pre-reset HEAD probe and `DOLT_RESET`. The flatten commit can then legitimately include additional rows, so post-flatten row counts and value hashes differ from the preflight snapshot even though this is concurrent-writer data rather than corruption.

The current script treats that stable-HEAD gain+drift case as unproven and writes `compact-quarantine/<db>`. That marker blocks all future compaction and GC for the database until a human removes it, so routine writer races can turn into unbounded Dolt storage growth.

## Solution

- Reclassify only the pure ambiguous gain+drift case as a defer.
- Write the existing `compact-pending-gc` marker and skip full GC during the racing run.
- Leave the post-flatten HEAD in place, matching the existing writer-race defer behavior.
- Let the next compactor run retry full GC through the pending-GC path.
- Preserve blocking quarantine for all harder integrity categories and mixed-signal cases.

## Reproduction / Validation

Duplicate search found existing public issue #2348 and related PRs #2350 / #2687, so no new issue was filed.

Version evidence from local validation:

- Upstream base: `cd7fd56869c025c6970a551e071728b231cad9c8`
- PR head: `fa337faea74ca7781b1a7565b6b3490516834095`
- Go: `go1.26.3 darwin/arm64`
- Dolt: `2.0.7`
- Beads: `HEAD-f8b9400 (Homebrew)`
- `gc version`: `dev`

## Testing

- [ ] `make check`
  - Not green locally. The pre-commit fast suite was attempted and failed outside this patch's focused surface: full `examples/dolt` hit `TestCompactScriptUsesExplicitRemote` / `TestCompactScriptPreservesPendingPushCreatedAtAcrossUnresolvedRetries`, and `examples/gastown` hit `TestReaperDoesNotCountFailedPurgeAsSuccess` timeout. The focused compactor tests below passed and are the validation signal for this PR.
- [ ] `make check-docs` if docs, navigation, or links changed
  - Not applicable; no docs/navigation/link changes.
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
  - Not run; this change is scoped to the embedded Dolt pack script.

Focused validation run on the PR branch:

- `git diff --check upstream/main..HEAD` — pass
- `go test ./examples/dolt -run CompactScript -count=1` — pass (`ok`, 228.858s)
- `go test -tags dolt_integration ./examples/dolt -run 'TestCompactScriptRealDolt(RemotePush|ConcurrentWriter)' -count=1` — pass (`ok`, 9.482s)

## Second-Order Effects

- Row-count decreases still quarantine before full GC.
- Same-count table or database value-hash drift still quarantines before full GC.
- Table-list drift, invalid table names, row-count probe failures, table-list probe failures, and value-hash probe failures still quarantine before full GC.
- Mixed signals still quarantine even when a writer race is proven.
- The changed pure gain+drift path does not run full GC immediately; it defers through `compact-pending-gc`, avoiding immediate destructive cleanup during the ambiguous run.
- The pending-GC retry path is already covered by existing tests and remains the mechanism that clears old history after the race window has passed.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
  - Not applicable; no user-facing docs changed.
- [x] Called out breaking changes or migration notes
  - No breaking changes. Existing quarantine markers still require manual review/removal; this PR changes future classification for the pure ambiguous writer-race case.
