### PR TITLE
fix(config): revisit shallow pack imports during auto-include dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching `gc mail send`. Operators should use `gc mail` commands or
   explicit both-tier/wisp-aware bead queries for mail visibility; default
   issue-tier `bd list` output and git sync do not include wisp-tier messages.
+- Built-in pack auto-includes now skip packs already reachable from rig pack
+  graphs, preventing duplicate maintenance agents when a rig pack imports a
+  built-in pack transitively.
 
 ## [1.2.0] - 2026-05-25
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1552,12 +1552,13 @@ func trackWorkspace(prov *Provenance, meta toml.MetaData, source string) {
 }
 
 // resolvedPackNames collects pack names that are reachable from a set of
-// top-level include paths and imports. It walks legacy [pack].includes
-// transitively and follows V2 [imports] according to each import's transitive
-// setting so builtin system-pack injection can be skipped when a user pack
-// already brings the same pack into the city closure.
+// top-level include paths and imports. It walks legacy [pack].includes and V2
+// [imports] according to each import's transitive setting so builtin system-pack
+// injection can be skipped when a user pack already brings the same pack into
+// the city closure.
 func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.FS, cityRoot string) map[string]bool {
 	names := make(map[string]bool, len(includes)+len(imports))
+	seenShallowDirs := make(map[string]bool)
 	expandedDirs := make(map[string]bool)
 
 	var visit func(ref, declDir string, transitive bool)
@@ -1570,6 +1571,16 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 		if absErr != nil {
 			absDir = dir
 		}
+		if transitive {
+			if expandedDirs[absDir] {
+				return
+			}
+		} else {
+			if seenShallowDirs[absDir] || expandedDirs[absDir] {
+				return
+			}
+		}
+
 		data, err := sysFS.ReadFile(filepath.Join(dir, packFile))
 		if err != nil {
 			return
@@ -1587,9 +1598,7 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 
 		names[pc.Pack.Name] = true
 		if !transitive {
-			return
-		}
-		if expandedDirs[absDir] {
+			seenShallowDirs[absDir] = true
 			return
 		}
 		expandedDirs[absDir] = true

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -3215,6 +3215,86 @@ source = "../maintenance"
 	}
 }
 
+func TestResolvedPackNames_NonTransitiveImportDoesNotExposeNestedPack(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/middle/pack.toml", `
+[pack]
+name = "middle"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, "packs/root/pack.toml", `
+[pack]
+name = "root"
+schema = 2
+
+[imports.middle]
+source = "../middle"
+transitive = false
+`)
+
+	names := resolvedPackNames([]string{"packs/root"}, nil, fsys.OSFS{}, dir)
+	if !names["middle"] {
+		t.Fatalf("middle pack was not recorded: names=%v", names)
+	}
+	if names["maintenance"] {
+		t.Fatalf("non-transitive import exposed nested maintenance pack: names=%v", names)
+	}
+}
+
+func TestResolvedPackNames_RevisitsPackReachedFirstThroughNonTransitiveImport(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "packs/maintenance/pack.toml", `
+[pack]
+name = "maintenance"
+schema = 2
+`)
+	writeFile(t, dir, "packs/middle/pack.toml", `
+[pack]
+name = "middle"
+schema = 2
+
+[imports.maintenance]
+source = "../maintenance"
+`)
+	writeFile(t, dir, "packs/shallow/pack.toml", `
+[pack]
+name = "shallow"
+schema = 2
+
+[imports.middle]
+source = "../middle"
+transitive = false
+`)
+	writeFile(t, dir, "packs/deep/pack.toml", `
+[pack]
+name = "deep"
+schema = 2
+
+[imports.middle]
+source = "../middle"
+`)
+
+	for _, includes := range [][]string{
+		{"packs/shallow", "packs/deep"},
+		{"packs/deep", "packs/shallow"},
+	} {
+		names := resolvedPackNames(includes, nil, fsys.OSFS{}, dir)
+		if !names["maintenance"] {
+			t.Fatalf("includes %v did not resolve transitive maintenance after shallow visit: names=%v", includes, names)
+		}
+	}
+}
+
 // agentNamesOf is a small test helper for readable failure messages.
 func agentNamesOf(agents []Agent) []string {
 	names := make([]string, 0, len(agents))


### PR DESCRIPTION
## Summary
- keep builtin auto-include graph traversal idempotent when a pack is first reached through a non-transitive import
- allow a later transitive path to revisit the same pack directory so nested packs are included in the dedupe graph when appropriate
- add regression coverage for both non-transitive shielding and shallow-first/deep-later include ordering

## Stack
This is stacked on #2788. After #2788 lands on main, this PR should be retargeted/rebased to main and merged before cherry-picking to hotfix/v1.2.1.

## Verification
- pre-commit hook during commit: lint-changed ./internal/config, generated docs/schema checks, go vet ./..., make test-fast-parallel, go test ./test/docsync

Refs #2735