### PR TITLE
fix: disable Dolt adaptive encoding for beads hotfix

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1059,7 +1059,9 @@ func isRecoverableManagedDoltEnvError(err error) bool {
 }
 
 func cityRuntimeEnvMapForCity(cityPath string) map[string]string {
-	return citylayout.CityRuntimeEnvMapForRuntimeDir(cityPath, citylayout.TrustedAmbientCityRuntimeDir(cityPath))
+	env := citylayout.CityRuntimeEnvMapForRuntimeDir(cityPath, citylayout.TrustedAmbientCityRuntimeDir(cityPath))
+	applyDoltAdaptiveEncodingMitigationEnv(env)
+	return env
 }
 
 // cityIdentityAnchorsForCity returns only the three identity anchors
@@ -1173,6 +1175,7 @@ func mergeRuntimeEnv(environ []string, overrides map[string]string) []string {
 		"BEADS_POSTGRES_PASSWORD",
 		"BEADS_POSTGRES_PORT",
 		"BEADS_POSTGRES_USER",
+		doltAdaptiveEncodingEnvKey,
 		"GC_CITY",
 		"GC_CITY_ROOT", // kept for stripping: no code emits this anymore, but inherited values must be cleaned
 		"GC_CITY_PATH",

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -53,6 +53,17 @@ func mustSessionBackendEnv(t *testing.T, cityPath, rigRoot string, rigs []config
 	return env
 }
 
+func envEntriesMap(entries []string) map[string]string {
+	out := map[string]string{}
+	for _, entry := range entries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
 func requireErrorContains(t *testing.T, err error, want string) {
 	t.Helper()
 	if err == nil {
@@ -81,6 +92,24 @@ func TestCityRuntimeProcessEnvStripsAmbientGCDolt(t *testing.T) {
 	for _, entry := range env {
 		if strings.HasPrefix(entry, "GC_DOLT=") {
 			t.Fatalf("cityRuntimeProcessEnv leaked ambient GC_DOLT control var: %q", entry)
+		}
+	}
+}
+
+func TestDoltAdaptiveEncodingMitigationProjectedAcrossRuntimeEnvs(t *testing.T) {
+	t.Setenv(doltAdaptiveEncodingEnvKey, "true")
+	t.Setenv("GC_BEADS", "bd")
+
+	cityPath := t.TempDir()
+	for name, env := range map[string]map[string]string{
+		"city runtime":    cityRuntimeEnvMapForCity(cityPath),
+		"bd runtime":      mustBdRuntimeEnv(t, cityPath),
+		"session backend": mustSessionBackendEnv(t, cityPath, "", nil),
+		"managed dolt":    envEntriesMap(doltServerEnv([]string{doltAdaptiveEncodingEnvKey + "=true", "PATH=/bin"})),
+		"process":         envEntriesMap(mustCityRuntimeProcessEnv(t, cityPath)),
+	} {
+		if got := env[doltAdaptiveEncodingEnvKey]; got != doltAdaptiveEncodingDisabledValue {
+			t.Fatalf("%s %s = %q, want %q", name, doltAdaptiveEncodingEnvKey, got, doltAdaptiveEncodingDisabledValue)
 		}
 	}
 }

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -416,6 +416,26 @@ func TestGcBeadsBdReadOnlyFallbackDoesNotTargetLegacyProbeDatabase(t *testing.T)
 	}
 }
 
+func TestGcBeadsBdPinsDoltAdaptiveEncodingOff(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	scriptData, err := os.ReadFile(gcBeadsBdScriptPath(cityPath))
+	if err != nil {
+		t.Fatalf("ReadFile(gc-beads-bd): %v", err)
+	}
+	script := string(scriptData)
+	for _, want := range []string{
+		"DOLT_USE_ADAPTIVE_ENCODING=false",
+		"export DOLT_USE_ADAPTIVE_ENCODING",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("gc-beads-bd script missing %q", want)
+		}
+	}
+}
+
 func TestGcBeadsBdShellFallbackSanitizesArchiveLevel(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -65,6 +65,15 @@ func TestPassthroughEnvPicksUpGCBeads(t *testing.T) {
 	}
 }
 
+func TestPassthroughEnvPinsDoltAdaptiveEncodingOff(t *testing.T) {
+	t.Setenv(doltAdaptiveEncodingEnvKey, "true")
+	got := passthroughEnv()
+	if got[doltAdaptiveEncodingEnvKey] != doltAdaptiveEncodingDisabledValue {
+		t.Fatalf("passthroughEnv()[%s] = %q, want %q",
+			doltAdaptiveEncodingEnvKey, got[doltAdaptiveEncodingEnvKey], doltAdaptiveEncodingDisabledValue)
+	}
+}
+
 func TestPassthroughEnvOmitsUnset(t *testing.T) {
 	t.Setenv("GC_DOLT", "")
 	got := passthroughEnv()

--- a/cmd/gc/dolt_env.go
+++ b/cmd/gc/dolt_env.go
@@ -3,8 +3,23 @@ package main
 import (
 	"os"
 	"strings"
+
+	"github.com/gastownhall/gascity/internal/processenv"
+)
+
+const (
+	doltAdaptiveEncodingEnvKey        = processenv.DoltAdaptiveEncodingEnvKey
+	doltAdaptiveEncodingDisabledValue = processenv.DoltAdaptiveEncodingDisabledValue
 )
 
 func gcDoltSkip() bool {
 	return strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip"
+}
+
+func applyDoltAdaptiveEncodingMitigationEnv(env map[string]string) {
+	processenv.ApplyDoltAdaptiveEncodingMitigation(env)
+}
+
+func withDoltAdaptiveEncodingMitigationEnv(environ []string) []string {
+	return processenv.WithDoltAdaptiveEncodingMitigation(environ)
 }

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -762,5 +762,5 @@ func managedDoltTestParentDone(rawFD string) (<-chan struct{}, func(), error) {
 // doltServerEnv returns the environment applied to every managed dolt
 // sql-server we launch.
 func doltServerEnv(parent []string) []string {
-	return append([]string(nil), parent...)
+	return withDoltAdaptiveEncodingMitigationEnv(parent)
 }

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -60,10 +60,26 @@ func TestDoltServerEnv_RespectsUserOverride(t *testing.T) {
 }
 
 func TestDoltServerEnv_PreservesEmptyUserValue(t *testing.T) {
-	parent := []string{"DOLT_GC_SCHEDULER="}
+	parent := []string{"DOLT_GC_SCHEDULER=", doltAdaptiveEncodingEnvKey + "=true"}
 	out := doltServerEnv(parent)
-	if len(out) != 1 || out[0] != "DOLT_GC_SCHEDULER=" {
+	schedulerCount := 0
+	adaptiveCount := 0
+	for _, entry := range out {
+		switch entry {
+		case "DOLT_GC_SCHEDULER=":
+			schedulerCount++
+		case doltAdaptiveEncodingEnvKey + "=" + doltAdaptiveEncodingDisabledValue:
+			adaptiveCount++
+		case doltAdaptiveEncodingEnvKey + "=true":
+			t.Fatalf("adaptive encoding ambient true leaked into managed Dolt env: %v", out)
+		}
+	}
+	if schedulerCount != 1 {
 		t.Fatalf("explicit empty-value env not preserved: %v", out)
+	}
+	if adaptiveCount != 1 {
+		t.Fatalf("managed Dolt env should include exactly one %s=%s entry: %v",
+			doltAdaptiveEncodingEnvKey, doltAdaptiveEncodingDisabledValue, out)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -591,6 +591,7 @@ func sessionBackendEnvWithError(cityPath, rigRoot string, rigs []config.Rig) (ma
 		// agent's cwd with the wrong data_dir.
 		"BEADS_DOLT_AUTO_START": "0",
 	}
+	applyDoltAdaptiveEncodingMitigationEnv(env)
 	// Explicit empty values let tmux unset stale Dolt vars inherited from
 	// the server environment when the current city/rig does not use them.
 	setProjectedDoltEnvEmpty(env)

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -288,6 +288,7 @@ func resolvedWorkerSessionConfigWithConfig(
 	if strings.TrimSpace(cityPath) != "" {
 		sessionEnv = mergeEnv(sessionEnv, cityIdentityAnchorsForCity(cityPath))
 	}
+	applyDoltAdaptiveEncodingMitigationEnv(sessionEnv)
 	return worker.NormalizeResolvedSessionConfig(worker.ResolvedSessionConfig{
 		Alias:        alias,
 		ExplicitName: explicitName,
@@ -522,6 +523,7 @@ func resolvedWorkerRuntimeWithConfigAndMetadata(cityPath string, cfg *config.Cit
 	// overwritten with the city-uniform default here. template_resolve.go
 	// owns the qualified override for the CLI create path.
 	sessionEnv := mergeEnv(providerProcessPassthroughEnv(), resolved.Env, cityIdentityAnchorsForCity(cityPath))
+	applyDoltAdaptiveEncodingMitigationEnv(sessionEnv)
 	// Resolve session_live so resumed sessions get re-themed (status bar,
 	// keybindings) the same way reconciler-started sessions do. Without this,
 	// `gc session attach` recreates the tmux runtime with an empty

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -20,6 +20,12 @@
 
 set -e
 
+# Temporary Dolt corruption mitigation for dolthub/dolt#11131. Force legacy
+# text/blob encoding for every managed dolt, dolt CLI, and bd process launched
+# through this bridge until upstream ships a fixed schema-change path.
+DOLT_USE_ADAPTIVE_ENCODING=false
+export DOLT_USE_ADAPTIVE_ENCODING
+
 # --- Configuration ---
 
 # DOLT_PORT is set after derived paths are resolved (see allocate_port below).

--- a/internal/api/session_resolved_config_test.go
+++ b/internal/api/session_resolved_config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/processenv"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -244,8 +245,9 @@ func TestResolvedSessionConfigForProviderCityAnchorsBeatConflictingProviderEnv(t
 			Name:    "stub",
 			Command: "/bin/echo",
 			Env: map[string]string{
-				"GC_CITY":      "/wrong/city",
-				"GC_CITY_PATH": "/wrong/city",
+				"GC_CITY":                             "/wrong/city",
+				"GC_CITY_PATH":                        "/wrong/city",
+				processenv.DoltAdaptiveEncodingEnvKey: "true",
 			},
 		},
 		"",
@@ -260,6 +262,14 @@ func TestResolvedSessionConfigForProviderCityAnchorsBeatConflictingProviderEnv(t
 	}
 	if got := cfg.Runtime.SessionEnv["GC_CITY_PATH"]; got != cityPath {
 		t.Errorf("SessionEnv[GC_CITY_PATH] = %q, want %q (city anchor must win over provider env)", got, cityPath)
+	}
+	if got := cfg.Runtime.SessionEnv[processenv.DoltAdaptiveEncodingEnvKey]; got != processenv.DoltAdaptiveEncodingDisabledValue {
+		t.Errorf("SessionEnv[%s] = %q, want %q",
+			processenv.DoltAdaptiveEncodingEnvKey, got, processenv.DoltAdaptiveEncodingDisabledValue)
+	}
+	if got := cfg.Runtime.Hints.Env[processenv.DoltAdaptiveEncodingEnvKey]; got != processenv.DoltAdaptiveEncodingDisabledValue {
+		t.Errorf("Hints.Env[%s] = %q, want %q",
+			processenv.DoltAdaptiveEncodingEnvKey, got, processenv.DoltAdaptiveEncodingDisabledValue)
 	}
 }
 

--- a/internal/api/session_runtime.go
+++ b/internal/api/session_runtime.go
@@ -52,6 +52,7 @@ func cityAnchoredSessionEnv(cityPath string, providerEnv map[string]string) map[
 	for k, v := range anchors {
 		out[k] = v
 	}
+	processenv.ApplyDoltAdaptiveEncodingMitigation(out)
 	return out
 }
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/processenv"
 	"github.com/gastownhall/gascity/internal/telemetry"
 )
 
@@ -92,9 +93,13 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 		cmd.Cancel = func() error {
 			return killCommandTree(cmd)
 		}
-		if len(env) > 0 {
-			cmd.Env = mergeEnv(os.Environ(), env)
+		baseEnv := processenv.WithDoltAdaptiveEncodingMitigation(os.Environ())
+		overrides := maps.Clone(env)
+		if overrides == nil {
+			overrides = map[string]string{}
 		}
+		processenv.ApplyDoltAdaptiveEncodingMitigation(overrides)
+		cmd.Env = mergeEnv(baseEnv, overrides)
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
 		out, err := cmd.Output()

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/processenv"
 )
 
 // fakeRunner returns a CommandRunner that returns canned output for specific
@@ -2607,6 +2608,7 @@ func TestBdStoreDepListEmpty(t *testing.T) {
 func TestExecCommandRunnerWithEnvOverridesInheritedValues(t *testing.T) {
 	t.Setenv("GC_CITY_PATH", "/wrong")
 	t.Setenv("GC_DOLT_PORT", "9999")
+	t.Setenv(processenv.DoltAdaptiveEncodingEnvKey, "true")
 
 	dir := t.TempDir()
 	runner := beads.ExecCommandRunnerWithEnv(map[string]string{
@@ -2614,20 +2616,23 @@ func TestExecCommandRunnerWithEnvOverridesInheritedValues(t *testing.T) {
 		"GC_DOLT_PORT": "31364",
 	})
 
-	out, err := runner(dir, "sh", "-c", `printf '%s\n%s\n' "$GC_CITY_PATH" "$GC_DOLT_PORT"`)
+	out, err := runner(dir, "sh", "-c", `printf '%s\n%s\n%s\n' "$GC_CITY_PATH" "$GC_DOLT_PORT" "$DOLT_USE_ADAPTIVE_ENCODING"`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("lines = %q, want 2 lines", string(out))
+	if len(lines) != 3 {
+		t.Fatalf("lines = %q, want 3 lines", string(out))
 	}
 	if lines[0] != "/city" {
 		t.Fatalf("GC_CITY_PATH = %q, want %q", lines[0], "/city")
 	}
 	if lines[1] != "31364" {
 		t.Fatalf("GC_DOLT_PORT = %q, want %q", lines[1], "31364")
+	}
+	if lines[2] != processenv.DoltAdaptiveEncodingDisabledValue {
+		t.Fatalf("%s = %q, want %q", processenv.DoltAdaptiveEncodingEnvKey, lines[2], processenv.DoltAdaptiveEncodingDisabledValue)
 	}
 	if _, err := os.Stat(dir); err != nil {
 		t.Fatalf("runner should preserve working dir usability: %v", err)

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/processenv"
 )
 
 // Store implements [beads.Store] by delegating each operation to a
@@ -44,7 +45,13 @@ func NewStore(script string) *Store {
 }
 
 func execProcessEnv(overrides map[string]string) []string {
-	out := make([]string, 0, len(os.Environ())+len(overrides))
+	projected := make(map[string]string, len(overrides)+1)
+	for key, value := range overrides {
+		projected[key] = value
+	}
+	processenv.ApplyDoltAdaptiveEncodingMitigation(projected)
+
+	out := make([]string, 0, len(os.Environ())+len(projected))
 	for _, entry := range os.Environ() {
 		key, _, ok := strings.Cut(entry, "=")
 		if !ok || stripExecEnvKey(key) {
@@ -52,20 +59,20 @@ func execProcessEnv(overrides map[string]string) []string {
 		}
 		out = append(out, entry)
 	}
-	keys := make([]string, 0, len(overrides))
-	for key := range overrides {
+	keys := make([]string, 0, len(projected))
+	for key := range projected {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		out = append(out, key+"="+overrides[key])
+		out = append(out, key+"="+projected[key])
 	}
 	return out
 }
 
 func stripExecEnvKey(key string) bool {
 	switch key {
-	case "GC_BEADS_PREFIX", "GC_CITY", "GC_CITY_PATH", "GC_CITY_ROOT", "GC_CITY_RUNTIME_DIR", "GC_PROVIDER", "GC_RIG", "GC_RIG_ROOT", "GC_STORE_ROOT", "GC_STORE_SCOPE":
+	case processenv.DoltAdaptiveEncodingEnvKey, "GC_BEADS_PREFIX", "GC_CITY", "GC_CITY_PATH", "GC_CITY_ROOT", "GC_CITY_RUNTIME_DIR", "GC_PROVIDER", "GC_RIG", "GC_RIG_ROOT", "GC_STORE_ROOT", "GC_STORE_SCOPE":
 		return true
 	}
 	return strings.HasPrefix(key, "BEADS_") || strings.HasPrefix(key, "GC_DOLT_")

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/beadstest"
+	"github.com/gastownhall/gascity/internal/processenv"
 )
 
 // writeScript creates an executable shell script in dir and returns its path.
@@ -1004,12 +1005,13 @@ func TestRunSanitizesAmbientLegacyAndStoreTargetEnv(t *testing.T) {
 	t.Setenv("GC_STORE_SCOPE", "city")
 	t.Setenv("GC_BEADS_PREFIX", "ambient")
 	t.Setenv("GC_PROVIDER", "ambient-provider")
+	t.Setenv(processenv.DoltAdaptiveEncodingEnvKey, "true")
 
 	script := writeScript(t, dir, `
 case "$1" in
   create)
-    printf 'BEADS_DIR=%s\nGC_DOLT_HOST=%s\nGC_STORE_ROOT=%s\nGC_STORE_SCOPE=%s\nGC_BEADS_PREFIX=%s\nGC_PROVIDER=%s\nGC_RIG=%s\nGC_RIG_ROOT=%s\n' \
-      "${BEADS_DIR:-}" "${GC_DOLT_HOST:-}" "${GC_STORE_ROOT:-}" "${GC_STORE_SCOPE:-}" "${GC_BEADS_PREFIX:-}" "${GC_PROVIDER:-}" "${GC_RIG:-}" "${GC_RIG_ROOT:-}" > "`+outFile+`"
+    printf 'BEADS_DIR=%s\nGC_DOLT_HOST=%s\nDOLT_USE_ADAPTIVE_ENCODING=%s\nGC_STORE_ROOT=%s\nGC_STORE_SCOPE=%s\nGC_BEADS_PREFIX=%s\nGC_PROVIDER=%s\nGC_RIG=%s\nGC_RIG_ROOT=%s\n' \
+      "${BEADS_DIR:-}" "${GC_DOLT_HOST:-}" "${DOLT_USE_ADAPTIVE_ENCODING:-}" "${GC_STORE_ROOT:-}" "${GC_STORE_SCOPE:-}" "${GC_BEADS_PREFIX:-}" "${GC_PROVIDER:-}" "${GC_RIG:-}" "${GC_RIG_ROOT:-}" > "`+outFile+`"
     cat >/dev/null
     echo '{"id":"EX-1","title":"test","status":"open","type":"task","created_at":"2026-02-27T10:00:00Z"}'
     ;;
@@ -1038,6 +1040,7 @@ esac
 	for _, want := range []string{
 		"BEADS_DIR=\n",
 		"GC_DOLT_HOST=\n",
+		processenv.DoltAdaptiveEncodingEnvKey + "=" + processenv.DoltAdaptiveEncodingDisabledValue + "\n",
 		"GC_STORE_ROOT=/scope/root\n",
 		"GC_STORE_SCOPE=rig\n",
 		"GC_BEADS_PREFIX=fe\n",

--- a/internal/processenv/provider.go
+++ b/internal/processenv/provider.go
@@ -10,6 +10,39 @@ import (
 	"github.com/gastownhall/gascity/internal/telemetry"
 )
 
+const (
+	// DoltAdaptiveEncodingEnvKey is temporarily pinned off for all GC-managed
+	// Dolt and beads processes while dolthub/dolt#11131 is unresolved.
+	DoltAdaptiveEncodingEnvKey = "DOLT_USE_ADAPTIVE_ENCODING"
+	// DoltAdaptiveEncodingDisabledValue disables Dolt adaptive text/blob encoding.
+	DoltAdaptiveEncodingDisabledValue = "false"
+
+	doltAdaptiveEncodingEnvKeyWithEquals = DoltAdaptiveEncodingEnvKey + "="
+)
+
+// ApplyDoltAdaptiveEncodingMitigation pins Dolt's adaptive text/blob encoding
+// off in an env map. This prevents legacy TEXT rows from being reinterpreted
+// as adaptive values during metadata-only TEXT->LONGTEXT migrations.
+func ApplyDoltAdaptiveEncodingMitigation(env map[string]string) {
+	if env == nil {
+		return
+	}
+	env[DoltAdaptiveEncodingEnvKey] = DoltAdaptiveEncodingDisabledValue
+}
+
+// WithDoltAdaptiveEncodingMitigation returns environ with any inherited Dolt
+// adaptive-encoding setting replaced by the temporary safe value.
+func WithDoltAdaptiveEncodingMitigation(environ []string) []string {
+	out := make([]string, 0, len(environ)+1)
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, doltAdaptiveEncodingEnvKeyWithEquals) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return append(out, doltAdaptiveEncodingEnvKeyWithEquals+DoltAdaptiveEncodingDisabledValue)
+}
+
 // providerCredentialEnvPrefixes lists provider-specific env-var name prefixes
 // whose values are treated as agent-provider credentials and forwarded into
 // the supervisor's persistent env and spawned agent processes.
@@ -157,5 +190,6 @@ func ProviderProcessPassthroughEnv() map[string]string {
 	}
 	m["CLAUDECODE"] = ""
 	m["CLAUDE_CODE_ENTRYPOINT"] = ""
+	ApplyDoltAdaptiveEncodingMitigation(m)
 	return m
 }

--- a/internal/processenv/provider_test.go
+++ b/internal/processenv/provider_test.go
@@ -58,18 +58,19 @@ func TestProviderProcessPassthroughEnvIncludesProviderAndRuntimeBaseline(t *test
 	got := ProviderProcessPassthroughEnv()
 
 	for key, want := range map[string]string{
-		"HOME":                   homeDir,
-		"PATH":                   "/usr/local/bin:/usr/bin:/bin",
-		"LANG":                   "en_US.UTF-8",
-		"LC_ALL":                 "",
-		"LC_CTYPE":               "",
-		"XDG_CONFIG_HOME":        filepath.Join(homeDir, ".config"),
-		"XDG_STATE_HOME":         filepath.Join(homeDir, ".local", "state"),
-		"ANTHROPIC_AUTH_TOKEN":   "test-anthropic-token",
-		"OLLAMA_API_KEY":         "test-ollama-token",
-		"AWS_ACCESS_KEY_ID":      "test-aws-key",
-		"CLAUDECODE":             "",
-		"CLAUDE_CODE_ENTRYPOINT": "",
+		"HOME":                     homeDir,
+		"PATH":                     "/usr/local/bin:/usr/bin:/bin",
+		"LANG":                     "en_US.UTF-8",
+		"LC_ALL":                   "",
+		"LC_CTYPE":                 "",
+		"XDG_CONFIG_HOME":          filepath.Join(homeDir, ".config"),
+		"XDG_STATE_HOME":           filepath.Join(homeDir, ".local", "state"),
+		"ANTHROPIC_AUTH_TOKEN":     "test-anthropic-token",
+		"OLLAMA_API_KEY":           "test-ollama-token",
+		"AWS_ACCESS_KEY_ID":        "test-aws-key",
+		"CLAUDECODE":               "",
+		"CLAUDE_CODE_ENTRYPOINT":   "",
+		DoltAdaptiveEncodingEnvKey: DoltAdaptiveEncodingDisabledValue,
 	} {
 		if got[key] != want {
 			t.Errorf("ProviderProcessPassthroughEnv()[%s] = %q, want %q", key, got[key], want)
@@ -77,6 +78,34 @@ func TestProviderProcessPassthroughEnvIncludesProviderAndRuntimeBaseline(t *test
 	}
 	if _, ok := got["AWS_PAGER"]; ok {
 		t.Errorf("ProviderProcessPassthroughEnv()[AWS_PAGER] = %q, want absent", got["AWS_PAGER"])
+	}
+}
+
+func TestDoltAdaptiveEncodingMitigationOverridesAmbient(t *testing.T) {
+	t.Setenv(DoltAdaptiveEncodingEnvKey, "true")
+
+	got := ProviderProcessPassthroughEnv()
+	if got[DoltAdaptiveEncodingEnvKey] != DoltAdaptiveEncodingDisabledValue {
+		t.Fatalf("ProviderProcessPassthroughEnv()[%s] = %q, want %q",
+			DoltAdaptiveEncodingEnvKey, got[DoltAdaptiveEncodingEnvKey], DoltAdaptiveEncodingDisabledValue)
+	}
+
+	entries := WithDoltAdaptiveEncodingMitigation([]string{
+		"PATH=/bin",
+		DoltAdaptiveEncodingEnvKey + "=true",
+		"HOME=/tmp/gc",
+	})
+	seen := 0
+	for _, entry := range entries {
+		if entry == DoltAdaptiveEncodingEnvKey+"="+DoltAdaptiveEncodingDisabledValue {
+			seen++
+		}
+		if entry == DoltAdaptiveEncodingEnvKey+"=true" {
+			t.Fatalf("WithDoltAdaptiveEncodingMitigation leaked ambient true entry: %v", entries)
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("WithDoltAdaptiveEncodingMitigation emitted %d mitigation entries, want 1: %v", seen, entries)
 	}
 }
 


### PR DESCRIPTION
## Summary

Pins `DOLT_USE_ADAPTIVE_ENCODING=false` anywhere Gas City can launch or project a Dolt/beads environment while dolthub/dolt#11131 is unresolved.

This covers:
- managed `dolt sql-server` environment
- bd subprocess runner environment
- exec beads provider environment
- provider passthrough / city runtime / session backend / worker session environments
- API resolved session env/hints
- materialized `gc-beads-bd.sh` bridge script

The guard strips any inherited `DOLT_USE_ADAPTIVE_ENCODING=true` and appends the safe value, so an ambient shell or provider config cannot re-enable adaptive text/blob encoding for these paths.

## Why

The Dolt bug is triggered when legacy/non-adaptive `TEXT` rows are later widened with a metadata-only `TEXT -> LONGTEXT` schema change under adaptive encoding. Dolt changes the descriptor from legacy string-address encoding to adaptive encoding without rewriting existing values, and reads can panic with `invalid hash length: 19`.

Until Dolt ships the upstream fix, keeping adaptive text/blob encoding disabled for all managed Dolt and beads calls avoids creating or reinterpreting those mixed descriptor/value states.

## Verification

Automated:
- `go test ./internal/processenv ./internal/beads ./internal/beads/exec ./internal/api ./cmd/gc`
- commit hook: `lint-changed`, generated reference/schema check, `go vet ./...`, `scripts/test-local-parallel fast`

Manual Dolt primitive mitigation check on Dolt 2.0.8:
- `DOLT_BIN=/tmp/dolt-v2.0.8 DOLT_USE_ADAPTIVE_ENCODING=false REPO=/tmp/dolt-11131-guard-check /tmp/repro-dolt-11131-legacy-text-to-longtext.sh`
- Result: both pre- and post-`TEXT -> LONGTEXT` reads returned row lengths `60000` and `19` with no panic.

Manual server-mode beads check on Dolt 2.0.8:
- Started `dolt sql-server` with `DOLT_USE_ADAPTIVE_ENCODING=false`
- Ran `bd init --server --external ...` with `DOLT_USE_ADAPTIVE_ENCODING=false`
- Ran `bd sql` to create `TEXT`, insert 60k + 19-byte rows, alter to `LONGTEXT`, and select lengths
- Result CSV:

```csv
id,len
1,60000
2,19
```