### PR TITLE
docs: fix JSONL archive backup path command

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -271,8 +271,8 @@ bead content and should not be shared across cities). Then:
 # Create a private repo on your git host (example: GitHub via gh)
 gh repo create my-city-jsonl-archive --private
 
-# Point the archive at it
-ARCHIVE=$(gc config get state_dir)/packs/maintenance/jsonl-archive
+# Point the archive at it (run from anywhere inside your city)
+ARCHIVE="$(gc status --json | jq -r '.city_path')/.gc/runtime/packs/maintenance/jsonl-archive"
 git -C "$ARCHIVE" remote add origin git@github.com:<you>/my-city-jsonl-archive.git
 
 # Seed the remote with the existing local history


### PR DESCRIPTION
## Summary

- Replace the invalid `gc config get state_dir` troubleshooting command with a single `ARCHIVE` assignment based on `gc status --json` city-root discovery.
- Keep the documented JSONL archive path aligned with the current maintenance pack runtime location: `.gc/runtime/packs/maintenance/jsonl-archive`.
- Avoid telling operators to run a config subcommand that no longer exists.

No public issue; this is a docs-only correction found while verifying the troubleshooting guide.

## Testing

- [ ] `make check` (not run; docs-only change)
- [x] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed (not applicable)

Additional validation performed:

- `go test ./test/docsync -run Test -count=1`
- `make check-docs`

## Checklist

- [x] Linked an issue, or explained why one is not needed (no public issue; docs-only correction)
- [x] Added or updated tests for behavior changes (docs sync coverage)
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes (none)

