### PR TITLE
fix(docs): remove rejected import tree example

### DIFF
--- a/cmd/gc/cmd_gendoc_test.go
+++ b/cmd/gc/cmd_gendoc_test.go
@@ -75,6 +75,38 @@ func TestGenDocImportAddDocumentsSourceLanes(t *testing.T) {
 	}
 }
 
+func TestGenDocImportAddExamplesAvoidRejectedSourceRefs(t *testing.T) {
+	var buf bytes.Buffer
+	root := newRootCmd(&buf, &buf)
+
+	var md bytes.Buffer
+	if err := docgen.RenderCLIMarkdown(&md, root); err != nil {
+		t.Fatalf("RenderCLIMarkdown: %v", err)
+	}
+
+	section, ok := cliDocSection(md.String(), "gc import add")
+	if !ok {
+		t.Fatal("missing gc import add section")
+	}
+	if strings.Contains(section, "GitHub tree") {
+		t.Fatalf("gc import add docs mention rejected GitHub tree URLs:\n%s", section)
+	}
+	for _, line := range strings.Split(section, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "gc import add ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			t.Fatalf("gc import add example missing source: %q", line)
+		}
+		source := fields[3]
+		if isRemoteImportSource(source) && hasRepositoryRefInSource(source) {
+			t.Fatalf("gc import add example uses rejected source ref %q in:\n%s", source, section)
+		}
+	}
+}
+
 // TestCLIDocsFreshness verifies every non-hidden command in the live cobra
 // tree has a section in docs/reference/cli.md. Catches "added or renamed a
 // command without running go run ./cmd/genschema". Avoids strict byte-equal

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -112,14 +112,13 @@ entry using source plus optional version. Supported sources are:
 - remote git repositories: cloned and locked; --version accepts a semver
   constraint or sha:<commit>
 - remote git repository subpaths: use source strings such as
-  github.com/org/repo//packs/foo or GitHub tree URLs
+  github.com/org/repo//packs/foo
 
 Registry catalog handles are lookup shortcuts in this wave, not durable
 [imports.*] field values. After lookup, authored TOML stores the resolved
 source and optional version.`,
 		Example: `gc import add ./packs/review
 gc import add github.com/org/repo//packs/review --version '^1.2.0'
-gc import add https://github.com/org/repo/tree/main/packs/review --name review
 
 # For uncommitted packs inside a git worktree, edit TOML directly:
 # [imports.review]

--- a/cmd/gc/cmd_import_test.go
+++ b/cmd/gc/cmd_import_test.go
@@ -378,6 +378,54 @@ func TestDoImportAddRejectsGitHubTreeSource(t *testing.T) {
 	}
 }
 
+func TestDoImportAddGitHubSubpathWithVersionWritesImport(t *testing.T) {
+	clearGCEnv(t)
+	dir := t.TempDir()
+	writeCityToml(t, dir, "[workspace]\nname = \"demo\"\n")
+
+	prevSync := syncImports
+	t.Cleanup(func() {
+		syncImports = prevSync
+	})
+	source := "github.com/example/tools//packs/review"
+	syncImports = func(_ string, imports map[string]config.Import, _ packman.InstallMode) (*packman.Lockfile, error) {
+		imp, ok := imports["pack:review"]
+		if !ok {
+			t.Fatalf("missing imports.pack:review in %#v", imports)
+		}
+		if imp.Source != source {
+			t.Fatalf("Source = %q, want %q", imp.Source, source)
+		}
+		if imp.Version != "^1.2.0" {
+			t.Fatalf("Version = %q, want ^1.2.0", imp.Version)
+		}
+		return &packman.Lockfile{
+			Schema: packman.LockfileSchema,
+			Packs: map[string]packman.LockedPack{
+				source: {Version: "1.2.3", Commit: "abc123"},
+			},
+		}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doImportAdd(fsys.OSFS{}, dir, source, "", "^1.2.0", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+
+	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(dir, "pack.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	imp := cfg.Imports["review"]
+	if imp.Source != source {
+		t.Fatalf("Source = %q, want %q", imp.Source, source)
+	}
+	if imp.Version != "^1.2.0" {
+		t.Fatalf("Version = %q, want ^1.2.0", imp.Version)
+	}
+}
+
 func TestDoImportAddPlainDirectoryOmitsVersion(t *testing.T) {
 	clearGCEnv(t)
 	dir := t.TempDir()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1502,7 +1502,7 @@ entry using source plus optional version. Supported sources are:
 - remote git repositories: cloned and locked; --version accepts a semver
   constraint or sha:&lt;commit&gt;
 - remote git repository subpaths: use source strings such as
-  github.com/org/repo//packs/foo or GitHub tree URLs
+  github.com/org/repo//packs/foo
 
 Registry catalog handles are lookup shortcuts in this wave, not durable
 [imports.*] field values. After lookup, authored TOML stores the resolved
@@ -1517,7 +1517,6 @@ gc import add <source> [flags]
 ```
 gc import add ./packs/review
 gc import add github.com/org/repo//packs/review --version '^1.2.0'
-gc import add https://github.com/org/repo/tree/main/packs/review --name review
 
 # For uncommitted packs inside a git worktree, edit TOML directly:
 # [imports.review]

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,6 +1,6 @@
 # Gas City Configuration
 
-Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility.
+Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility. Legacy [packs.*] entries are still accepted by the runtime for migration/fetch compatibility but are intentionally omitted from this public schema.
 
 > **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec).
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -2401,5 +2401,5 @@
     }
   },
   "title": "Gas City Configuration",
-  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
+  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility. Legacy [packs.*] entries are still accepted by the runtime for migration/fetch compatibility but are intentionally omitted from this public schema.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 }

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -2401,5 +2401,5 @@
     }
   },
   "title": "Gas City Configuration",
-  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
+  "description": "Schema for city.toml — the PackV2 deployment file for a Gas City instance. Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility. Legacy [packs.*] entries are still accepted by the runtime for migration/fetch compatibility but are intentionally omitted from this public schema.\n\n\u003e **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 }

--- a/internal/docgen/schema.go
+++ b/internal/docgen/schema.go
@@ -73,7 +73,8 @@ func GenerateCitySchema() (*jsonschema.Schema, error) {
 	s.Title = "Gas City Configuration"
 	s.Description = "Schema for city.toml — the PackV2 deployment file for a Gas City instance. " +
 		"Pack definitions live in pack.toml and conventional pack directories such as agents/, formulas/, orders/, and commands/. " +
-		"Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility.\n\n" +
+		"Use [imports.*] for PackV2 composition; legacy includes and [[agent]] fields remain visible for migration compatibility. " +
+		"Legacy [packs.*] entries are still accepted by the runtime for migration/fetch compatibility but are intentionally omitted from this public schema.\n\n" +
 		"> **PackV2 format source of truth:** The public PackV2 format and loader semantics are specified in [Gas City Pack Specification (2.0)](/specs/pack-spec)."
 	return s, nil
 }


### PR DESCRIPTION
Follow-up for #2782.

Original PR: https://github.com/gastownhall/gascity/pull/2782
Original title: docs(packv2): hide legacy pack source fields
Original state: MERGED
Configured workflow base: main
Original GitHub base: main
Base mismatch: none

PR #2782 merged before the adoption workflow could publish the reviewed
maintainer fixup. This follow-up carries only that maintainer-side fix on top
of current `main`; the contributor's original commits remain preserved in the
already-merged PR.

## Changes

- Removes the rejected GitHub `/tree/` URL example from `gc import add` help.
- Keeps the accepted repository subpath form documented.
- Adds/keeps regression coverage for generated CLI docs, rejected source refs,
  and accepted GitHub subpaths with `--version`.

## Validation

- `go test ./cmd/gc ./internal/docgen`
- `go test ./cmd/gc ./internal/docgen -run 'Test(GenDocImportAddDocumentsSourceLanes|GenDocImportAddExamplesAvoidRejectedSourceRefs|CLIDocsFreshness|DoImportAddRejectsRepositoryRefInSource|DoImportAddRejectsGitHubTreeSource|DoImportAddGitHubSubpathWithVersionWritesImport|HasRepositoryRefInSource|CitySchemaOmitsLegacyPackSourceSurface)'`
