### PR TITLE
fix(rig): store runtime suspension in site binding

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -846,14 +846,14 @@ func (cs *controllerState) ResumeAgent(name string) error {
 	})
 }
 
-// SuspendRig writes suspended=true on the rig in city.toml.
+// SuspendRig writes a machine-local runtime suspension override for the rig.
 func (cs *controllerState) SuspendRig(name string) error {
 	return cs.mutateAndPoke(func() error {
 		return cs.editor.SuspendRig(name)
 	})
 }
 
-// ResumeRig clears suspended on the rig in city.toml.
+// ResumeRig writes a machine-local runtime resume override for the rig.
 func (cs *controllerState) ResumeRig(name string) error {
 	return cs.mutateAndPoke(func() error {
 		return cs.editor.ResumeRig(name)

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2452,6 +2452,9 @@ func TestControllerStateMutationsPokeController(t *testing.T) {
 			if err != nil {
 				t.Fatalf("reload config: %v", err)
 			}
+			if _, err := config.ApplySiteBindings(fsys.OSFS{}, filepath.Dir(tomlPath), got); err != nil {
+				t.Fatalf("apply site bindings: %v", err)
+			}
 			tc.verify(t, got)
 		})
 	}

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -1182,7 +1182,7 @@ func newRigSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "suspend [name]",
 		Short: "Suspend a rig (reconciler will skip its agents)",
-		Long: `Suspend a rig by setting suspended=true in city.toml.
+		Long: `Suspend a rig by setting a local runtime override in .gc/site.toml.
 
 All agents scoped to the suspended rig are effectively suspended —
 the reconciler skips them and gc hook returns empty. The rig's beads
@@ -1249,7 +1249,7 @@ func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
 	return doRigSuspend(fsys.OSFS{}, cityPath, rigName, stdout, stderr)
 }
 
-// doRigSuspend sets suspended=true on the named rig in city.toml.
+// doRigSuspend sets a local runtime suspended=true override for the named rig.
 // Accepts an injected FS for testability.
 func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer) int {
 	tomlPath := filepath.Join(cityPath, "city.toml")
@@ -1260,9 +1260,10 @@ func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer
 	}
 
 	found := false
-	for i := range cfg.Rigs {
-		if cfg.Rigs[i].Name == rigName {
-			cfg.Rigs[i].Suspended = true
+	rigPath := ""
+	for _, rig := range cfg.Rigs {
+		if rig.Name == rigName {
+			rigPath = rig.Path
 			found = true
 			break
 		}
@@ -1272,7 +1273,7 @@ func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer
 		return 1
 	}
 
-	if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
+	if err := config.PersistRigSuspensionOverride(fs, cityPath, rigName, rigPath, true); err != nil {
 		fmt.Fprintf(stderr, "gc rig suspend: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -1286,7 +1287,7 @@ func newRigResumeCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "resume [name]",
 		Short: "Resume a suspended rig",
-		Long: `Resume a suspended rig by clearing suspended in city.toml.
+		Long: `Resume a suspended rig by setting a local runtime override in .gc/site.toml.
 
 The reconciler will start the rig's agents on its next tick.`,
 		Args: cobra.ArbitraryArgs,
@@ -1351,7 +1352,7 @@ func cmdRigResume(args []string, stdout, stderr io.Writer) int {
 	return doRigResume(fsys.OSFS{}, cityPath, rigName, stdout, stderr)
 }
 
-// doRigResume clears suspended on the named rig in city.toml.
+// doRigResume sets a local runtime suspended=false override for the named rig.
 // Accepts an injected FS for testability.
 func doRigResume(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer) int {
 	tomlPath := filepath.Join(cityPath, "city.toml")
@@ -1362,9 +1363,10 @@ func doRigResume(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer)
 	}
 
 	found := false
-	for i := range cfg.Rigs {
-		if cfg.Rigs[i].Name == rigName {
-			cfg.Rigs[i].Suspended = false
+	rigPath := ""
+	for _, rig := range cfg.Rigs {
+		if rig.Name == rigName {
+			rigPath = rig.Path
 			found = true
 			break
 		}
@@ -1374,7 +1376,7 @@ func doRigResume(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer)
 		return 1
 	}
 
-	if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
+	if err := config.PersistRigSuspensionOverride(fs, cityPath, rigName, rigPath, false); err != nil {
 		fmt.Fprintf(stderr, "gc rig resume: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1025,13 +1025,29 @@ func TestDoRigSuspend(t *testing.T) {
 		t.Errorf("output = %q, want suspend message", stdout.String())
 	}
 
-	// Verify config written with suspended=true.
-	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	raw, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw.Rigs) != 1 || raw.Rigs[0].Suspended {
+		t.Errorf("city.toml should remain source-owned, got %+v", raw.Rigs)
+	}
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(cfg.Rigs) != 1 || !cfg.Rigs[0].Suspended {
-		t.Errorf("rig should be suspended, got %+v", cfg.Rigs)
+		t.Errorf("effective rig should be suspended, got %+v", cfg.Rigs)
+	}
+	binding, err := config.LoadSiteBinding(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(binding.Rigs) != 1 || binding.Rigs[0].Suspended == nil || !*binding.Rigs[0].Suspended {
+		t.Fatalf("site binding should contain suspended=true override, got %+v", binding.Rigs)
+	}
+	if binding.Rigs[0].Path != "/some/path" {
+		t.Fatalf("site binding path = %q, want preserved path", binding.Rigs[0].Path)
 	}
 }
 
@@ -1077,13 +1093,26 @@ func TestDoRigResume(t *testing.T) {
 		t.Errorf("output = %q, want resume message", stdout.String())
 	}
 
-	// Verify config written with suspended=false.
-	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	raw, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw.Rigs) != 1 || !raw.Rigs[0].Suspended {
+		t.Errorf("city.toml authored suspended default should be preserved, got %+v", raw.Rigs)
+	}
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(cfg.Rigs) != 1 || cfg.Rigs[0].Suspended {
-		t.Errorf("rig should not be suspended, got %+v", cfg.Rigs)
+		t.Errorf("effective rig should not be suspended, got %+v", cfg.Rigs)
+	}
+	binding, err := config.LoadSiteBinding(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(binding.Rigs) != 1 || binding.Rigs[0].Suspended == nil || *binding.Rigs[0].Suspended {
+		t.Fatalf("site binding should contain suspended=false override, got %+v", binding.Rigs)
 	}
 }
 
@@ -2357,6 +2386,13 @@ dir = "myrig"
 	if strings.Contains(data, "pack-worker") {
 		t.Errorf("city.toml should NOT contain expanded pack agent:\n%s", data)
 	}
+	if strings.Contains(data, "suspended") {
+		t.Errorf("city.toml should not contain runtime rig suspension state:\n%s", data)
+	}
+	site := string(f.Files[config.SiteBindingPath("/city")])
+	if !strings.Contains(site, "suspended = true") {
+		t.Errorf("site.toml should contain runtime suspension override:\n%s", site)
+	}
 }
 
 func TestDoRigResumePreservesConfig(t *testing.T) {
@@ -2390,6 +2426,13 @@ dir = "myrig"
 	}
 	if strings.Contains(data, "pack-worker") {
 		t.Errorf("city.toml should NOT contain expanded pack agent:\n%s", data)
+	}
+	if !strings.Contains(data, "suspended = true") {
+		t.Errorf("city.toml should preserve authored suspended default:\n%s", data)
+	}
+	site := string(f.Files[config.SiteBindingPath("/city")])
+	if !strings.Contains(site, "suspended = false") {
+		t.Errorf("site.toml should contain runtime resume override:\n%s", site)
 	}
 }
 

--- a/cmd/gc/command_context_test.go
+++ b/cmd/gc/command_context_test.go
@@ -207,9 +207,16 @@ func TestRigAnywhere_CmdRigSuspendFromRigDir(t *testing.T) {
 				t.Fatalf("stdout = %q, want rig suspend confirmation", stdout.String())
 			}
 
-			cfg, err := config.Load(fsys.OSFS{}, filepath.Join(fx.cityPath, "city.toml"))
+			raw, err := config.Load(fsys.OSFS{}, filepath.Join(fx.cityPath, "city.toml"))
 			if err != nil {
 				t.Fatalf("load city config: %v", err)
+			}
+			if len(raw.Rigs) != 1 || raw.Rigs[0].Suspended {
+				t.Fatalf("city.toml suspended = %v, want source-owned false/omitted", raw.Rigs)
+			}
+			cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(fx.cityPath, "city.toml"))
+			if err != nil {
+				t.Fatalf("load effective city config: %v", err)
 			}
 			if len(cfg.Rigs) != 1 || !cfg.Rigs[0].Suspended {
 				t.Fatalf("rig suspended = %v, want true", cfg.Rigs)
@@ -281,9 +288,16 @@ func TestRigAnywhere_CmdRigResumeFromRigDir(t *testing.T) {
 				t.Fatalf("stdout = %q, want rig resume confirmation", stdout.String())
 			}
 
-			cfg, err := config.Load(fsys.OSFS{}, filepath.Join(fx.cityPath, "city.toml"))
+			raw, err := config.Load(fsys.OSFS{}, filepath.Join(fx.cityPath, "city.toml"))
 			if err != nil {
 				t.Fatalf("load city config: %v", err)
+			}
+			if len(raw.Rigs) != 1 || !raw.Rigs[0].Suspended {
+				t.Fatalf("city.toml suspended = %v, want authored true preserved", raw.Rigs)
+			}
+			cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(fx.cityPath, "city.toml"))
+			if err != nil {
+				t.Fatalf("load effective city config: %v", err)
 			}
 			if len(cfg.Rigs) != 1 || cfg.Rigs[0].Suspended {
 				t.Fatalf("rig suspended = %v, want false", cfg.Rigs)

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -836,6 +836,12 @@ func shouldIgnoreConfigWatchEvent(path string) bool {
 	if clean == "" || clean == "." {
 		return false
 	}
+	// .gc is runtime-owned and normally ignored by the config watcher, but
+	// .gc/site.toml is part of the effective config because LoadWithIncludes
+	// overlays it onto workspace and rig settings.
+	if filepath.Base(clean) == "site.toml" && filepath.Base(filepath.Dir(clean)) == ".gc" {
+		return false
+	}
 	sepGC := string(filepath.Separator) + ".gc"
 	sepBeads := string(filepath.Separator) + ".beads"
 	return clean == ".gc" ||

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -913,6 +913,67 @@ func TestWatchConfigDirs_CityRootIgnoresRuntimeTraceWrites(t *testing.T) {
 	}
 }
 
+func TestWatchConfigDirs_RuntimeSiteBindingWritesDirty(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	dir := t.TempDir()
+	runtimeDir := filepath.Join(dir, ".gc")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll runtime dir: %v", err)
+	}
+	sitePath := filepath.Join(runtimeDir, "site.toml")
+	if err := os.WriteFile(sitePath, []byte("workspace_name = \"before\"\n"), 0o644); err != nil {
+		t.Fatalf("seed site binding: %v", err)
+	}
+	runtimeStatePath := filepath.Join(runtimeDir, "runtime-state.json")
+
+	if shouldIgnoreConfigWatchEvent(sitePath) {
+		t.Fatalf("shouldIgnoreConfigWatchEvent(%q) = true, want false", sitePath)
+	}
+	if !shouldIgnoreConfigWatchEvent(runtimeStatePath) {
+		t.Fatalf("shouldIgnoreConfigWatchEvent(%q) = false, want true", runtimeStatePath)
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 1)
+	var stderr bytes.Buffer
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: runtimeDir}}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	select {
+	case <-pokeCh:
+	default:
+	}
+	dirty.Store(false)
+
+	if err := os.WriteFile(sitePath, []byte("workspace_name = \"after\"\n"), 0o644); err != nil {
+		t.Fatalf("rewrite site binding: %v", err)
+	}
+	select {
+	case <-pokeCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for watcher poke after site binding write; stderr=%q", stderr.String())
+	}
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after site binding write; stderr=%q", stderr.String())
+	}
+
+	dirty.Store(false)
+	if err := os.WriteFile(runtimeStatePath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write runtime state: %v", err)
+	}
+	select {
+	case <-pokeCh:
+		t.Fatalf("unexpected watcher poke after runtime state write; stderr=%q", stderr.String())
+	case <-time.After(250 * time.Millisecond):
+	}
+	if dirty.Load() {
+		t.Fatalf("dirty flag set after runtime state write; stderr=%q", stderr.String())
+	}
+}
+
 func TestWatchConfigDirs_SymlinkSeedDirWatchesNestedPreExistingDir(t *testing.T) {
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2539,7 +2539,7 @@ gc rig restart [name]
 
 ## gc rig resume
 
-Resume a suspended rig by clearing suspended in city.toml.
+Resume a suspended rig by setting a local runtime override in .gc/site.toml.
 
 The reconciler will start the rig's agents on its next tick.
 
@@ -2605,7 +2605,7 @@ gc rig status [name] [flags]
 
 ## gc rig suspend
 
-Suspend a rig by setting suspended=true in city.toml.
+Suspend a rig by setting a local runtime override in .gc/site.toml.
 
 All agents scoped to the suspended rig are effectively suspended —
 the reconciler skips them and gc hook returns empty. The rig's beads

--- a/internal/config/revision.go
+++ b/internal/config/revision.go
@@ -49,6 +49,12 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 		h.Write([]byte{0})    //nolint:errcheck // hash.Write never errors
 	}
 
+	// Hash machine-local site bindings because LoadWithIncludes overlays
+	// .gc/site.toml onto the effective workspace and rig config. Without
+	// this, rig suspend/resume and path-binding changes can leave a running
+	// controller with stale effective config even after gc reload.
+	writeOptionalRevisionFile(h, prov, fs, "site-binding", SiteBindingPath(cityRoot))
+
 	// Hash rig pack directory contents (all pack sources).
 	rigs := cfg.Rigs
 	for _, r := range rigs {
@@ -123,9 +129,17 @@ func (p *Provenance) captureRevisionSnapshot(fs fsys.FS, cfg *City, cityRoot str
 		fileContents: make(map[string][]byte),
 		fileKnown:    make(map[string]bool),
 	}
+	recordFile := func(path string) {
+		snap.fileKnown[path] = true
+		if data, err := fs.ReadFile(path); err == nil {
+			snap.fileContents[path] = cloneBytes(data)
+		}
+	}
 	recordDir := func(label, dir string) {
 		snap.dirHashes[label] = PackContentHashRecursive(fs, dir)
 	}
+
+	recordFile(SiteBindingPath(cityRoot))
 
 	for _, r := range cfg.Rigs {
 		for _, ref := range r.Includes {
@@ -139,10 +153,7 @@ func (p *Provenance) captureRevisionSnapshot(fs fsys.FS, cfg *City, cityRoot str
 	}
 	if tracksPackV2Imports(cfg) {
 		lockPath := filepath.Join(cityRoot, "packs.lock")
-		snap.fileKnown[lockPath] = true
-		if data, err := fs.ReadFile(lockPath); err == nil {
-			snap.fileContents[lockPath] = cloneBytes(data)
-		}
+		recordFile(lockPath)
 	}
 	for _, dir := range cfg.PackDirs {
 		if strings.TrimSpace(dir) == "" {
@@ -192,6 +203,21 @@ func writeRevisionDirHash(h hash.Hash, prov *Provenance, label string, fs fsys.F
 		topoHash = PackContentHashRecursive(fs, dir)
 	}
 	writeRevisionBytes(h, label, []byte(topoHash))
+}
+
+func writeOptionalRevisionFile(h hash.Hash, prov *Provenance, fs fsys.FS, label, path string) {
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	if data, known, exists := revisionSnapshotFile(prov, path); known {
+		if exists {
+			writeRevisionBytes(h, label+":"+path, data)
+		}
+		return
+	}
+	if data, err := fs.ReadFile(path); err == nil {
+		writeRevisionBytes(h, label+":"+path, data)
+	}
 }
 
 func writeRevisionBytes(h hash.Hash, label string, data []byte) {
@@ -266,6 +292,11 @@ func WatchTargets(prov *Provenance, cfg *City, cityRoot string) []WatchTarget {
 		for _, src := range prov.Sources {
 			dir := filepath.Dir(src)
 			addTarget(dir, false, pathutil.SamePath(dir, cityRoot))
+		}
+	}
+	if siteDir := filepath.Dir(SiteBindingPath(cityRoot)); strings.TrimSpace(siteDir) != "" {
+		if info, err := os.Stat(siteDir); err == nil && info.IsDir() {
+			addTarget(siteDir, false, false)
 		}
 	}
 

--- a/internal/config/revision_test.go
+++ b/internal/config/revision_test.go
@@ -81,6 +81,84 @@ name = "changed"
 	}
 }
 
+func TestRevision_UsesLoadedSiteBindingSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	writeFile(t, dir, "city.toml", `
+[[rigs]]
+name = "frontend"
+`)
+	writeFile(t, dir, ".gc/site.toml", `
+[[rig]]
+name = "frontend"
+path = "/site/frontend-one"
+`)
+
+	cfg, prov, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if cfg.Rigs[0].Path != "/site/frontend-one" {
+		t.Fatalf("loaded rig path = %q, want original site binding", cfg.Rigs[0].Path)
+	}
+	loadedRevision := Revision(fsys.OSFS{}, prov, cfg, dir)
+
+	writeFile(t, dir, ".gc/site.toml", `
+[[rig]]
+name = "frontend"
+path = "/site/frontend-two"
+`)
+	afterWriteRevision := Revision(fsys.OSFS{}, prov, cfg, dir)
+	if afterWriteRevision != loadedRevision {
+		t.Fatalf("revision changed after site binding write; got %q, want loaded snapshot %q", afterWriteRevision, loadedRevision)
+	}
+
+	reloadedCfg, reloadedProv, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("reloading config: %v", err)
+	}
+	if reloadedCfg.Rigs[0].Path != "/site/frontend-two" {
+		t.Fatalf("reloaded rig path = %q, want changed site binding", reloadedCfg.Rigs[0].Path)
+	}
+	reloadedRevision := Revision(fsys.OSFS{}, reloadedProv, reloadedCfg, dir)
+	if reloadedRevision == loadedRevision {
+		t.Fatal("revision did not change after reloading changed site binding")
+	}
+}
+
+func TestRevision_ChangesWhenSiteBindingAppears(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	writeFile(t, dir, "city.toml", `
+[[rigs]]
+name = "frontend"
+path = "/legacy/frontend"
+`)
+
+	cfg, prov, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes without site binding: %v", err)
+	}
+	withoutSiteBinding := Revision(fsys.OSFS{}, prov, cfg, dir)
+
+	writeFile(t, dir, ".gc/site.toml", `
+[[rig]]
+name = "frontend"
+path = "/site/frontend"
+`)
+	reloadedCfg, reloadedProv, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes with site binding: %v", err)
+	}
+	if reloadedCfg.Rigs[0].Path != "/site/frontend" {
+		t.Fatalf("reloaded rig path = %q, want site binding", reloadedCfg.Rigs[0].Path)
+	}
+	withSiteBinding := Revision(fsys.OSFS{}, reloadedProv, reloadedCfg, dir)
+	if withSiteBinding == withoutSiteBinding {
+		t.Fatal("revision did not change after site binding was created")
+	}
+}
+
 func TestRevision_UsesLoadedSnapshotForResolvedInputs(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -477,6 +555,33 @@ func TestWatchDirs_ConfigOnly(t *testing.T) {
 	}
 	if dirs[0] != dir {
 		t.Errorf("dir = %q, want %q", dirs[0], dir)
+	}
+}
+
+func TestWatchTargets_IncludesSiteBindingDirWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".gc/site.toml", `workspace_name = "site-city"
+`)
+	prov := &Provenance{
+		Sources: []string{filepath.Join(dir, "city.toml")},
+	}
+
+	targets := WatchTargets(prov, &City{}, dir)
+	var found bool
+	for _, target := range targets {
+		if target.Path != filepath.Join(dir, ".gc") {
+			continue
+		}
+		found = true
+		if target.Recursive {
+			t.Fatalf("site binding watch target = %#v, want shallow watch", target)
+		}
+		if target.DiscoverConventions {
+			t.Fatalf("site binding watch target = %#v, want no convention discovery", target)
+		}
+	}
+	if !found {
+		t.Fatalf("watch targets = %#v, want .gc site binding dir", targets)
 	}
 }
 

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -159,8 +159,9 @@ type SiteBinding struct {
 
 // RigSiteBinding binds a declared rig name to a machine-local path.
 type RigSiteBinding struct {
-	Name string `toml:"name"`
-	Path string `toml:"path,omitempty"`
+	Name      string `toml:"name"`
+	Path      string `toml:"path,omitempty"`
+	Suspended *bool  `toml:"suspended,omitempty"`
 }
 
 // LoadSiteBinding reads .gc/site.toml. Missing files return an empty binding.
@@ -184,17 +185,17 @@ func LoadSiteBinding(fs fsys.FS, cityRoot string) (*SiteBinding, error) {
 // precedence, but legacy city.toml rig paths still flow through as a
 // compatibility fallback until users migrate them into .gc/site.toml.
 func ApplySiteBindings(fs fsys.FS, cityRoot string, cfg *City) ([]string, error) {
-	return applySiteBindings(fs, cityRoot, cfg, false)
+	return applySiteBindings(fs, cityRoot, cfg, false, true)
 }
 
 // ApplySiteBindingsForEdit overlays .gc/site.toml for config-edit flows but
 // retains raw city.toml paths as a fallback so edit commands can migrate them
 // into .gc/site.toml on write.
 func ApplySiteBindingsForEdit(fs fsys.FS, cityRoot string, cfg *City) ([]string, error) {
-	return applySiteBindings(fs, cityRoot, cfg, true)
+	return applySiteBindings(fs, cityRoot, cfg, true, false)
 }
 
-func applySiteBindings(fs fsys.FS, cityRoot string, cfg *City, keepLegacy bool) ([]string, error) {
+func applySiteBindings(fs fsys.FS, cityRoot string, cfg *City, keepLegacy, applyRuntimeState bool) ([]string, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -203,14 +204,16 @@ func applySiteBindings(fs fsys.FS, cityRoot string, cfg *City, keepLegacy bool) 
 		return nil, err
 	}
 	applyWorkspaceIdentityBinding(cityRoot, binding, cfg)
-	paths := make(map[string]string, len(binding.Rigs))
+	bindings := make(map[string]RigSiteBinding, len(binding.Rigs))
 	for _, rig := range binding.Rigs {
 		name := strings.TrimSpace(rig.Name)
 		path := strings.TrimSpace(rig.Path)
-		if name == "" || path == "" {
+		if name == "" {
 			continue
 		}
-		paths[name] = path
+		rig.Name = name
+		rig.Path = path
+		bindings[name] = rig
 	}
 
 	var warnings []string
@@ -219,23 +222,26 @@ func applySiteBindings(fs fsys.FS, cityRoot string, cfg *City, keepLegacy bool) 
 		name := cfg.Rigs[i].Name
 		seen[name] = struct{}{}
 		legacyPath := strings.TrimSpace(cfg.Rigs[i].Path)
-		if path, ok := paths[name]; ok {
-			cfg.Rigs[i].Path = path
-			continue
-		}
-		if keepLegacy || legacyPath != "" {
+		binding, hasBinding := bindings[name]
+		switch {
+		case hasBinding && binding.Path != "":
+			cfg.Rigs[i].Path = binding.Path
+		case keepLegacy || legacyPath != "":
 			cfg.Rigs[i].Path = legacyPath
 			if legacyPath != "" && !keepLegacy {
 				warnings = append(warnings, legacyRigPathSiteBindingWarning(name))
 			}
-			continue
+		default:
+			cfg.Rigs[i].Path = ""
+			if !keepLegacy {
+				warnings = append(warnings, missingRigSiteBindingWarning(name))
+			}
 		}
-		cfg.Rigs[i].Path = ""
-		if !keepLegacy {
-			warnings = append(warnings, missingRigSiteBindingWarning(name))
+		if applyRuntimeState && hasBinding && binding.Suspended != nil {
+			cfg.Rigs[i].Suspended = *binding.Suspended
 		}
 	}
-	for name := range paths {
+	for name := range bindings {
 		if _, ok := seen[name]; ok {
 			continue
 		}
@@ -298,6 +304,16 @@ func persistRigSiteBindings(fs fsys.FS, cityRoot string, rigs []Rig, removedRigN
 	if err != nil {
 		return err
 	}
+	existingRigs := make(map[string]RigSiteBinding, len(existing.Rigs))
+	for _, rig := range existing.Rigs {
+		name := strings.TrimSpace(rig.Name)
+		if name == "" {
+			continue
+		}
+		rig.Name = name
+		rig.Path = strings.TrimSpace(rig.Path)
+		existingRigs[name] = rig
+	}
 	declaredNames := make(map[string]struct{}, len(rigs))
 	binding := SiteBinding{
 		WorkspaceName:   strings.TrimSpace(existing.WorkspaceName),
@@ -311,15 +327,19 @@ func persistRigSiteBindings(fs fsys.FS, cityRoot string, rigs []Rig, removedRigN
 			continue
 		}
 		declaredNames[name] = struct{}{}
-		if path == "" {
+		siteRig := RigSiteBinding{Name: name, Path: path}
+		if existingRig, ok := existingRigs[name]; ok {
+			siteRig.Suspended = existingRig.Suspended
+		}
+		if siteRig.Path == "" && siteRig.Suspended == nil {
 			continue
 		}
-		binding.Rigs = append(binding.Rigs, RigSiteBinding{Name: name, Path: path})
+		binding.Rigs = append(binding.Rigs, siteRig)
 	}
 	for _, rig := range existing.Rigs {
 		name := strings.TrimSpace(rig.Name)
 		path := strings.TrimSpace(rig.Path)
-		if name == "" || path == "" {
+		if name == "" || (path == "" && rig.Suspended == nil) {
 			continue
 		}
 		if _, removed := removedRigNames[name]; removed {
@@ -328,7 +348,7 @@ func persistRigSiteBindings(fs fsys.FS, cityRoot string, rigs []Rig, removedRigN
 		if _, ok := declaredNames[name]; ok {
 			continue
 		}
-		binding.Rigs = append(binding.Rigs, RigSiteBinding{Name: name, Path: path})
+		binding.Rigs = append(binding.Rigs, RigSiteBinding{Name: name, Path: path, Suspended: rig.Suspended})
 	}
 	sort.Slice(binding.Rigs, func(i, j int) bool {
 		if binding.Rigs[i].Name != binding.Rigs[j].Name {
@@ -337,6 +357,57 @@ func persistRigSiteBindings(fs fsys.FS, cityRoot string, rigs []Rig, removedRigN
 		return binding.Rigs[i].Path < binding.Rigs[j].Path
 	})
 
+	return persistSiteBinding(fs, cityRoot, binding)
+}
+
+// PersistRigSuspensionOverride writes the operator/runtime suspended override
+// for a rig into .gc/site.toml. Authored city.toml suspended defaults remain
+// source-owned; this machine-local override is merged only for runtime loads.
+// If path is non-empty, it is stored alongside the runtime override so legacy
+// city.toml rig paths continue migrating into the machine-local binding layer.
+func PersistRigSuspensionOverride(fs fsys.FS, cityRoot, name, path string, suspended bool) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("persisting rig suspension override: empty rig name")
+	}
+	path = strings.TrimSpace(path)
+	existing, err := LoadSiteBinding(fs, cityRoot)
+	if err != nil {
+		return err
+	}
+	binding := SiteBinding{
+		WorkspaceName:   strings.TrimSpace(existing.WorkspaceName),
+		WorkspacePrefix: strings.TrimSpace(existing.WorkspacePrefix),
+		Rigs:            make([]RigSiteBinding, 0, len(existing.Rigs)+1),
+	}
+	found := false
+	for _, rig := range existing.Rigs {
+		rig.Name = strings.TrimSpace(rig.Name)
+		rig.Path = strings.TrimSpace(rig.Path)
+		if rig.Name == "" {
+			continue
+		}
+		if rig.Name == name {
+			if path != "" {
+				rig.Path = path
+			}
+			rig.Suspended = &suspended
+			found = true
+		}
+		if rig.Path == "" && rig.Suspended == nil {
+			continue
+		}
+		binding.Rigs = append(binding.Rigs, rig)
+	}
+	if !found {
+		binding.Rigs = append(binding.Rigs, RigSiteBinding{Name: name, Path: path, Suspended: &suspended})
+	}
+	sort.Slice(binding.Rigs, func(i, j int) bool {
+		if binding.Rigs[i].Name != binding.Rigs[j].Name {
+			return binding.Rigs[i].Name < binding.Rigs[j].Name
+		}
+		return binding.Rigs[i].Path < binding.Rigs[j].Path
+	})
 	return persistSiteBinding(fs, cityRoot, binding)
 }
 

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -227,6 +227,125 @@ path = "/site/frontend"
 	}
 }
 
+func TestLoadWithIncludes_AppliesRigSuspensionSiteBinding(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "frontend"
+`)
+	fs.Files[SiteBindingPath("/city")] = []byte(`
+[[rig]]
+name = "frontend"
+path = "/site/frontend"
+suspended = true
+`)
+
+	cfg, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	if !cfg.Rigs[0].Suspended {
+		t.Fatalf("Suspended = false, want runtime site binding override")
+	}
+	if cfg.Rigs[0].Path != "/site/frontend" {
+		t.Fatalf("Path = %q, want site binding path", cfg.Rigs[0].Path)
+	}
+	if len(prov.Warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", prov.Warnings)
+	}
+}
+
+func TestApplySiteBindingsForEdit_DoesNotApplyRigSuspensionOverride(t *testing.T) {
+	fs := fsys.NewFake()
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Rigs:      []Rig{{Name: "frontend", Path: "/legacy/frontend"}},
+	}
+	fs.Files[SiteBindingPath("/city")] = []byte(`
+[[rig]]
+name = "frontend"
+suspended = true
+`)
+
+	warnings, err := ApplySiteBindingsForEdit(fs, "/city", cfg)
+	if err != nil {
+		t.Fatalf("ApplySiteBindingsForEdit: %v", err)
+	}
+	if cfg.Rigs[0].Suspended {
+		t.Fatalf("Suspended = true, want edit loads to keep source-authored suspended value")
+	}
+	if cfg.Rigs[0].Path != "/legacy/frontend" {
+		t.Fatalf("Path = %q, want legacy edit path preserved", cfg.Rigs[0].Path)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+}
+
+func TestPersistRigSuspensionOverridePreservesSiteBindingPath(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files[SiteBindingPath("/city")] = []byte(`
+workspace_name = "site-city"
+
+[[rig]]
+name = "frontend"
+path = "/site/frontend"
+`)
+
+	if err := PersistRigSuspensionOverride(fs, "/city", "frontend", "", true); err != nil {
+		t.Fatalf("PersistRigSuspensionOverride: %v", err)
+	}
+
+	binding, err := LoadSiteBinding(fs, "/city")
+	if err != nil {
+		t.Fatalf("LoadSiteBinding: %v", err)
+	}
+	if binding.WorkspaceName != "site-city" {
+		t.Fatalf("WorkspaceName = %q, want preserved site-city", binding.WorkspaceName)
+	}
+	if len(binding.Rigs) != 1 {
+		t.Fatalf("binding.Rigs = %+v, want one rig", binding.Rigs)
+	}
+	rig := binding.Rigs[0]
+	if rig.Name != "frontend" || rig.Path != "/site/frontend" {
+		t.Fatalf("binding.Rigs[0] = %+v, want frontend path preserved", rig)
+	}
+	if rig.Suspended == nil || !*rig.Suspended {
+		t.Fatalf("Suspended = %v, want true override", rig.Suspended)
+	}
+}
+
+func TestPersistRigSiteBindingsPreservesRigSuspensionOverride(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files[SiteBindingPath("/city")] = []byte(`
+[[rig]]
+name = "frontend"
+suspended = true
+`)
+
+	if err := PersistRigSiteBindings(fs, "/city", []Rig{{Name: "frontend", Path: "/site/frontend"}}); err != nil {
+		t.Fatalf("PersistRigSiteBindings: %v", err)
+	}
+
+	binding, err := LoadSiteBinding(fs, "/city")
+	if err != nil {
+		t.Fatalf("LoadSiteBinding: %v", err)
+	}
+	if len(binding.Rigs) != 1 {
+		t.Fatalf("binding.Rigs = %+v, want one rig", binding.Rigs)
+	}
+	rig := binding.Rigs[0]
+	if rig.Path != "/site/frontend" {
+		t.Fatalf("Path = %q, want updated site path", rig.Path)
+	}
+	if rig.Suspended == nil || !*rig.Suspended {
+		t.Fatalf("Suspended = %v, want preserved true override", rig.Suspended)
+	}
+}
+
 func TestLoadWithIncludes_AppliesWorkspaceIdentitySiteBinding(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -599,18 +599,41 @@ func removeLocalDiscoveredAgentConfig(fs fsys.FS, cityRoot string, agent config.
 	return nil
 }
 
-// SuspendRig suspends a rig by setting suspended=true in city.toml.
+// SuspendRig suspends a rig by setting a machine-local runtime override.
 func (e *Editor) SuspendRig(name string) error {
-	return e.Edit(func(cfg *config.City) error {
-		return SetRigSuspended(cfg, name, true)
-	})
+	return e.setRigSuspensionOverride(name, true)
 }
 
-// ResumeRig resumes a rig by clearing suspended in city.toml.
+// ResumeRig resumes a rig by setting a machine-local runtime override.
 func (e *Editor) ResumeRig(name string) error {
-	return e.Edit(func(cfg *config.City) error {
-		return SetRigSuspended(cfg, name, false)
-	})
+	return e.setRigSuspensionOverride(name, false)
+}
+
+func (e *Editor) setRigSuspensionOverride(name string, suspended bool) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	cfg, err := e.loadForEdit()
+	if err != nil {
+		return err
+	}
+	rigPath := ""
+	found := false
+	for i := range cfg.Rigs {
+		if cfg.Rigs[i].Name == name {
+			rigPath = cfg.Rigs[i].Path
+			cfg.Rigs[i].Suspended = suspended
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("%w: rig %q", ErrNotFound, name)
+	}
+	if err := validateCityForEdit(cfg); err != nil {
+		return err
+	}
+	return config.PersistRigSuspensionOverride(e.fs, filepath.Dir(e.tomlPath), name, rigPath, suspended)
 }
 
 // SuspendCity sets workspace.suspended = true.

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -857,9 +857,20 @@ func TestSuspendRig(t *testing.T) {
 		t.Fatalf("SuspendRig: %v", err)
 	}
 
-	cfg := readTOML(t, path)
+	raw := readTOML(t, path)
+	if raw.Rigs[0].Suspended {
+		t.Error("expected city.toml rig suspended default to remain false")
+	}
+	cfg := readEffectiveTOML(t, path)
 	if !cfg.Rigs[0].Suspended {
-		t.Error("expected my-rig to be suspended")
+		t.Error("expected effective my-rig to be suspended")
+	}
+	binding := readSiteBinding(t, dir)
+	if len(binding.Rigs) != 1 || binding.Rigs[0].Suspended == nil || !*binding.Rigs[0].Suspended {
+		t.Fatalf("site binding should contain suspended=true override, got %+v", binding.Rigs)
+	}
+	if binding.Rigs[0].Path != "/tmp/my-rig" {
+		t.Fatalf("site binding path = %q, want preserved path", binding.Rigs[0].Path)
 	}
 }
 
@@ -880,9 +891,17 @@ suspended = true
 		t.Fatalf("ResumeRig: %v", err)
 	}
 
-	cfg := readTOML(t, path)
+	raw := readTOML(t, path)
+	if !raw.Rigs[0].Suspended {
+		t.Error("expected city.toml authored suspended default to remain true")
+	}
+	cfg := readEffectiveTOML(t, path)
 	if cfg.Rigs[0].Suspended {
-		t.Error("expected my-rig to not be suspended")
+		t.Error("expected effective my-rig to not be suspended")
+	}
+	binding := readSiteBinding(t, dir)
+	if len(binding.Rigs) != 1 || binding.Rigs[0].Suspended == nil || *binding.Rigs[0].Suspended {
+		t.Fatalf("site binding should contain suspended=false override, got %+v", binding.Rigs)
 	}
 }
 

--- a/test/acceptance/rig_test.go
+++ b/test/acceptance/rig_test.go
@@ -116,16 +116,23 @@ func TestRigLifecycle(t *testing.T) {
 			t.Fatalf("gc rig suspend %s: %v\n%s", rigName, err, out)
 		}
 
-		// Verify suspended state in config.
-		toml := c.ReadFile("city.toml")
-		if !strings.Contains(toml, "suspended") {
-			t.Error("city.toml should contain 'suspended' after rig suspend")
+		cityToml := c.ReadFile("city.toml")
+		if strings.Contains(cityToml, "suspended") {
+			t.Errorf("city.toml should not contain runtime suspension state after rig suspend:\n%s", cityToml)
+		}
+		siteToml := c.ReadFile(".gc/site.toml")
+		if !strings.Contains(siteToml, "suspended = true") {
+			t.Errorf(".gc/site.toml should contain runtime suspended override after rig suspend:\n%s", siteToml)
 		}
 
 		// Resume.
 		out, err = c.GC("rig", "resume", rigName)
 		if err != nil {
 			t.Fatalf("gc rig resume %s: %v\n%s", rigName, err, out)
+		}
+		siteToml = c.ReadFile(".gc/site.toml")
+		if !strings.Contains(siteToml, "suspended = false") {
+			t.Errorf(".gc/site.toml should contain runtime resumed override after rig resume:\n%s", siteToml)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Move operational `gc rig suspend` / `gc rig resume` state into `.gc/site.toml` instead of rewriting source-owned `city.toml`.
- Preserve authored `[[rigs]].suspended` defaults in `city.toml` while allowing the local runtime override to win for effective loads.
- Include `.gc/site.toml` in config revision snapshots and watcher inputs so `gc reload` and a running controller converge when site-bound workspace or rig settings change.
- Keep `.gc` runtime churn ignored by the config watcher while allowing the `site.toml` binding file through, avoiding reload loops from runtime traces/state.
- Keep edit flows from leaking `.gc/site.toml` runtime overrides back into `city.toml`, and preserve existing rig path bindings when writing the override.

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
- [x] `go test ./internal/config -run 'Test(LoadWithIncludes_AppliesRigSuspensionSiteBinding|ApplySiteBindingsForEdit_DoesNotApplyRigSuspensionOverride|PersistRigSuspensionOverridePreservesSiteBindingPath|PersistRigSiteBindingsPreservesRigSuspensionOverride|LoadWithIncludes_AppliesSiteBindings|ApplySiteBindingsForEdit_KeepsLegacyPath)' -count=1`
- [x] `go test ./internal/configedit -run 'Test(SuspendRig|ResumeRig|SetRigSuspended)' -count=1`
- [x] `go test ./cmd/gc -run 'TestDoRig(Suspend|Resume)|TestRigAnywhere_CmdRig(Suspend|Resume)FromRigDir|TestControllerStateMutationsPokeController|TestDoRigListShowsSuspended' -count=1`
- [x] `go test -tags acceptance_a ./test/acceptance -run 'TestRigLifecycle' -count=1`
- [x] `git diff --check HEAD~1..HEAD`
- [x] `go test ./internal/config -run 'TestRevision_UsesLoadedSiteBindingSnapshot|TestRevision_ChangesWhenSiteBindingAppears|TestWatchTargets_IncludesSiteBindingDirWhenPresent' -count=1`
- [x] `go test ./cmd/gc -run 'TestWatchConfigDirs_RuntimeSiteBindingWritesDirty|TestProbeLiveSessions_TimesOut' -count=1`
- [x] `go test ./internal/config ./cmd/gc -run 'TestRevision_UsesLoadedSiteBindingSnapshot|TestRevision_ChangesWhenSiteBindingAppears|TestWatchTargets_IncludesSiteBindingDirWhenPresent|TestWatchConfigDirs_RuntimeSiteBindingWritesDirty' -count=1`
- [x] `go test ./internal/config -count=1`
- [x] `go test ./cmd/gc -count=1` passed on the downstream fork candidate containing the same reload/revision patch.
- [x] `git diff --check upstream/main..HEAD`

Hook caveat: the local pre-commit `scripts/test-local-parallel fast` run was attempted and failed in unrelated baseline areas outside this patch, including macOS `/private/tmp` path canonicalization in transcript tests, unrelated git-ref formula tests, an events exec temp-provider fixture, and a parallel timing miss in `TestProbeLiveSessions_TimesOut`. The isolated `TestProbeLiveSessions_TimesOut` rerun passed, and the focused reload/revision tests plus full `internal/config` and full `cmd/gc` package runs passed as listed above.

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No separate issue: this is a narrow bug fix for the existing source-vs-site state boundary. The PR includes regression coverage for CLI/API mutation paths, effective config loading, config revision detection, and watcher behavior.

Migration notes: existing authored `suspended = true` rig defaults remain supported. New `gc rig suspend` / `gc rig resume` calls write machine-local overrides to `.gc/site.toml`, so source-controlled `city.toml` stays stable for Git-backed city definitions. Existing `.gc/site.toml` users do not need to migrate; this update makes reload/controller convergence account for that existing machine-local file.


<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2140 — implements the rig slice of the proposed configured-vs-operational suspension split: keeps the authored `[[rigs]].suspended` default in source-owned `city.toml` while moving operational `gc rig suspend`/`resume` state to a machine-local `.gc/site.toml` override.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
