### PR TITLE
feat(orders): add city/rig scope to order definitions

### DIFF
--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -298,6 +298,37 @@ max_timeout = "120s"
 
 The effective timeout is the lesser of the per-order timeout and the global cap.
 
+## Order scope
+
+When a pack is imported into more than one rig, its orders are instantiated
+**once per rig** by default — the same way per-rig agents are. That's usually
+what you want for an order that acts on a single rig's work. But some orders are
+city-wide: a sweep or health probe that already iterates over every rig
+internally would then run redundantly, once per rig.
+
+Mark such an order city-scoped so it registers exactly once, no matter how many
+rigs import the pack:
+
+```toml
+[order]
+description = "Sweep merged convoys across the whole city"
+trigger = "cooldown"
+interval = "5m"
+exec = "scripts/convoy-sweep.sh"
+scope = "city"
+```
+
+`scope` accepts `"city"` or `"rig"`. The default (when omitted) is `"rig"`, so
+existing orders are unaffected. A `scope = "city"` order appears once in `gc
+order list` with no rig qualifier; rig-scoped orders appear once per importing
+rig. This mirrors the `scope` field on `[[named_session]]`.
+
+Use `scope = "city"` for orders that live in a **shared pack** imported by
+several rigs — that's where the per-rig duplication it collapses comes from. A
+city-scoped order keeps the formula layer of the pack it was scanned from, so
+its formula must resolve from that pack rather than from any one rig's local
+`orders/` directory.
+
 ## Disabling and skipping orders
 
 An order can be disabled in its own definition:

--- a/internal/orderdiscovery/discovery.go
+++ b/internal/orderdiscovery/discovery.go
@@ -63,7 +63,15 @@ func ScanAll(cityPath string, cfg *config.City, opts ScanOptions) ([]orders.Orde
 		rigNames[rigName] = struct{}{}
 	}
 
-	var rigOrders []orders.Order
+	// City-scoped orders register exactly once regardless of how many rigs
+	// import the pack, so dedup them across the rig loop by name. Seed the set
+	// with city-level orders so a city-local order of the same name wins.
+	cityScopedSeen := make(map[string]bool, len(cityOrders))
+	for _, o := range cityOrders {
+		cityScopedSeen[o.Name] = true
+	}
+
+	var promotedCityOrders, rigOrders []orders.Order
 	for _, rigName := range sortedRigNames(rigNames) {
 		exclusive := RigExclusiveLayers(cfg.FormulaLayers.Rigs[rigName], cityLayers)
 		exclusivePackDirs := cfg.RigPackDirs[rigName]
@@ -81,13 +89,24 @@ func ScanAll(cityPath string, cfg *config.City, opts ScanOptions) ([]orders.Orde
 			return nil, fmt.Errorf("rig %s: %w", rigName, err)
 		}
 		for i := range aa {
+			if aa[i].IsCityScoped() {
+				// Keep the first occurrence (rigs are scanned in deterministic
+				// order) and leave Rig empty so it registers city-wide once.
+				if cityScopedSeen[aa[i].Name] {
+					continue
+				}
+				cityScopedSeen[aa[i].Name] = true
+				promotedCityOrders = append(promotedCityOrders, aa[i])
+				continue
+			}
 			aa[i].Rig = rigName
+			rigOrders = append(rigOrders, aa[i])
 		}
-		rigOrders = append(rigOrders, aa...)
 	}
 
-	allOrders := make([]orders.Order, 0, len(cityOrders)+len(rigOrders))
+	allOrders := make([]orders.Order, 0, len(cityOrders)+len(promotedCityOrders)+len(rigOrders))
 	allOrders = append(allOrders, cityOrders...)
+	allOrders = append(allOrders, promotedCityOrders...)
 	allOrders = append(allOrders, rigOrders...)
 	if len(cfg.Orders.Overrides) > 0 {
 		if err := orders.ApplyOverrides(allOrders, overridesFromConfig(cfg.Orders.Overrides)); err != nil {

--- a/internal/orderdiscovery/discovery_test.go
+++ b/internal/orderdiscovery/discovery_test.go
@@ -731,3 +731,63 @@ func writeOrderDiscoveryFile(t *testing.T, dir, name, content string) {
 		t.Fatal(err)
 	}
 }
+
+func TestScanAllCityScopedOrderRegistersOnceAcrossRigs(t *testing.T) {
+	cityPath, cityLayer := orderDiscoveryCity(t)
+	packDir := filepath.Join(t.TempDir(), "mixed-pack")
+	// A scope=city order must register exactly once no matter how many rigs
+	// import the pack.
+	writeOrderDiscoveryFile(t, filepath.Join(packDir, "orders"), "city-sweep", `[order]
+scope = "city"
+exec = "scripts/sweep.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+	// An unscoped (rig-default) order still registers once per importing rig.
+	writeOrderDiscoveryFile(t, filepath.Join(packDir, "orders"), "rig-health", `[order]
+exec = "scripts/health.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+			Rigs: map[string][]string{
+				"alpha": {cityLayer},
+				"beta":  {cityLayer},
+			},
+		},
+		RigPackDirs: map[string][]string{
+			"alpha": {packDir},
+			"beta":  {packDir},
+		},
+	}
+
+	aa, err := ScanAll(cityPath, cfg, ScanOptions{})
+	if err != nil {
+		t.Fatalf("ScanAll returned error: %v", err)
+	}
+
+	citySweepCount := 0
+	citySweepRig := "<unset>"
+	rigHealth := map[string]int{}
+	for _, a := range aa {
+		switch a.Name {
+		case "city-sweep":
+			citySweepCount++
+			citySweepRig = a.Rig
+		case "rig-health":
+			rigHealth[a.Rig]++
+		}
+	}
+	if citySweepCount != 1 {
+		t.Fatalf("city-scoped order registered %d times, want 1: %#v", citySweepCount, aa)
+	}
+	if citySweepRig != "" {
+		t.Fatalf("city-scoped order Rig = %q, want \"\" (city-scoped)", citySweepRig)
+	}
+	if rigHealth["alpha"] != 1 || rigHealth["beta"] != 1 {
+		t.Fatalf("rig-scoped order counts = %v, want one per importing rig", rigHealth)
+	}
+}

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -24,6 +24,11 @@ type Order struct {
 	// Exec is a shell command run directly by the controller, bypassing
 	// the agent pipeline. Mutually exclusive with Formula.
 	Exec string `toml:"exec,omitempty"`
+	// Scope controls how the order is instantiated during pack expansion:
+	// "city" registers the order exactly once regardless of how many rigs
+	// import the pack; "rig" (the default when empty) registers it once per
+	// importing rig. Mirrors [[named_session]].scope.
+	Scope string `toml:"scope,omitempty"`
 	// Trigger is the order scheduler selector: "cooldown", "cron",
 	// "condition", "event", or "manual". This is distinct from the
 	// separate "gate" concepts used elsewhere in the system.
@@ -73,6 +78,7 @@ type orderDecode struct {
 	Description string            `toml:"description,omitempty"`
 	Formula     string            `toml:"formula,omitempty"`
 	Exec        string            `toml:"exec,omitempty"`
+	Scope       string            `toml:"scope,omitempty"`
 	Trigger     string            `toml:"trigger,omitempty"`
 	Gate        string            `toml:"gate,omitempty"`
 	Interval    string            `toml:"interval,omitempty"`
@@ -94,6 +100,7 @@ func (d orderDecode) normalized() Order {
 		Description: d.Description,
 		Formula:     d.Formula,
 		Exec:        d.Exec,
+		Scope:       d.Scope,
 		Trigger:     trigger,
 		Interval:    d.Interval,
 		Schedule:    d.Schedule,
@@ -123,6 +130,13 @@ func (a *Order) IsEnabled() bool {
 // rather than formula (wisp) dispatch.
 func (a *Order) IsExec() bool {
 	return a.Exec != ""
+}
+
+// IsCityScoped reports whether the order is city-scoped, i.e. instantiated
+// exactly once during pack expansion regardless of how many rigs import the
+// pack. The default (empty Scope) is rig-scoped.
+func (a *Order) IsCityScoped() bool {
+	return a.Scope == "city"
 }
 
 // TimeoutOrDefault returns the order's configured timeout, or the
@@ -171,6 +185,12 @@ func Validate(a Order) error {
 		if strings.Contains(key, "=") {
 			return fmt.Errorf("order %q: invalid env key %q: must not contain '='", a.Name, key)
 		}
+	}
+	// Scope, if set, must be a known value. Empty defaults to rig-scoped.
+	switch a.Scope {
+	case "", "city", "rig":
+	default:
+		return fmt.Errorf("order %q: unknown scope %q (want \"city\" or \"rig\")", a.Name, a.Scope)
 	}
 	// Validate timeout if set.
 	if a.Timeout != "" {

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -400,3 +400,74 @@ trigger = "manual"
 		t.Errorf("Env = %v, want empty when absent", a.Env)
 	}
 }
+
+func TestParseScope(t *testing.T) {
+	data := []byte(`
+[order]
+scope = "city"
+exec = "scripts/sweep.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+	a, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if a.Scope != "city" {
+		t.Errorf("Scope = %q, want %q", a.Scope, "city")
+	}
+	if !a.IsCityScoped() {
+		t.Error("IsCityScoped() = false, want true for scope=city")
+	}
+}
+
+func TestParseScopeDefaultsToRig(t *testing.T) {
+	data := []byte(`
+[order]
+exec = "scripts/health.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+	a, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if a.Scope != "" {
+		t.Errorf("Scope = %q, want empty (rig default)", a.Scope)
+	}
+	if a.IsCityScoped() {
+		t.Error("IsCityScoped() = true, want false for unscoped order")
+	}
+}
+
+func TestValidateRejectsUnknownScope(t *testing.T) {
+	a := Order{
+		Name:     "bad-scope",
+		Exec:     "scripts/x.sh",
+		Trigger:  "cooldown",
+		Interval: "5m",
+		Scope:    "global",
+	}
+	err := Validate(a)
+	if err == nil {
+		t.Fatal("Validate succeeded, want unknown-scope rejection")
+	}
+	if !strings.Contains(err.Error(), "scope") {
+		t.Fatalf("Validate error = %q, want scope context", err.Error())
+	}
+}
+
+func TestValidateAcceptsCityAndRigScope(t *testing.T) {
+	for _, scope := range []string{"", "city", "rig"} {
+		a := Order{
+			Name:     "scoped",
+			Exec:     "scripts/x.sh",
+			Trigger:  "cooldown",
+			Interval: "5m",
+			Scope:    scope,
+		}
+		if err := Validate(a); err != nil {
+			t.Errorf("Validate(scope=%q) = %v, want nil", scope, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

A pack imported into multiple rigs instantiates its orders **once per rig**. City-wide orders — sweeps and health probes that already iterate over every rig internally — therefore ran N times redundantly, and there was no config-level way to mark an order city-wide.

This adds a `scope` field to the order definition, mirroring the observable semantics of `[[named_session]].scope`:

- `scope = "city"` registers the order **exactly once** regardless of how many rigs import the pack (its `Rig` is left empty, so it is treated as city-level).
- `scope = "rig"` — the default when omitted — registers it **once per importing rig**, unchanged from today.

`orderdiscovery.ScanAll` dedups city-scoped orders across the per-rig scan by name, seeding the dedup set with city-level orders so a city-local order of the same name wins. `Validate` rejects unknown scope values.

Orders are not on the HTTP/SSE wire (the order response maps fields explicitly), so this needs **no** OpenAPI/schema/dashboard regeneration — `TestOpenAPISpecInSync` stays green and the commit touches no generated files.

City-scope is intended for shared packs; the orders tutorial documents that a city-scoped order resolves its formula from the pack it was scanned from rather than any one rig's local `orders/` directory.

## Testing

- [x] `make check`
- [x] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed — see note below

This is order discovery/config logic with no new runtime surface, covered by unit tests in `internal/orders` and `internal/orderdiscovery` (city-scoped order registers once across two importing rigs while an unscoped order registers per rig; scope parse/default/validate coverage). The full local `make test-integration` suite has a pre-existing, environment-specific `controller was not ready within 15s` failure that reproduces identically on `main` and is unrelated to this change, so it is not checked here.

## Checklist

- [x] Linked an issue, or explained why one is not needed — no upstream tracking issue exists; this is the first in-core item from the Gas City core-stability work (retires the pack-side "split city-wide orders into a separate pack" workaround).
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes (`docs/tutorials/07-orders.md`)
- [x] Called out breaking changes or migration notes — none; absent/unspecified `scope` behaves exactly as before (rig-scoped).
