### PR TITLE
fix(cmd/gc): release orphan pool step beads stuck open after session drain (#2793)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1556,11 +1556,11 @@ func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[
 }
 
 // appendOpenRoutedWorkUnique includes open beads that are still pool-routed
-// AND still carry an assignee. This is the narrow input releaseOrphanedPool
-// Assignments needs to clear step beads abandoned by a dead session
-// (graph.v2 wisps where the root depends on the finalize step, so the
-// root never enters ready and the step assignee remains a long-form
-// dead-session identity invisible to readyAssignedWorkAssignees).
+// AND still carry an assignee. This is the narrow input
+// releaseOrphanedPoolAssignments needs to clear step beads abandoned by a
+// dead session (graph.v2 wisps where the root depends on the finalize
+// step, so the root never enters ready and the step assignee remains a
+// long-form dead-session identity invisible to readyAssignedWorkAssignees).
 func appendOpenRoutedWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -934,6 +934,24 @@ func collectAssignedWorkBeadsWithStores(
 					appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
 				}
 			}
+			// Open pool-routed beads that still carry an assignee. These are
+			// invisible to the in-progress pass (status is "open") and to the
+			// ready-by-assignee pass (the assignee is a dead session's
+			// long-form id, not enumerated by readyAssignedWorkAssignees).
+			// Without this pass, graph.v2 step beads orphaned by a session
+			// drain stay assigned forever and releaseOrphanedPoolAssignments
+			// never sees them — pool demand stays at 0 and the workflow stalls
+			// (issue #2793). The release loop further gates each bead on
+			// openSessionOwnsWork / liveOpenSessionAssignmentExists, so
+			// live-session step beads in the same range are skipped untouched.
+			if openRouted, err := listBothTiersForControllerDemand(source.store, beads.ListQuery{Status: "open"}); err == nil {
+				appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
+			} else {
+				errs = append(errs, fmt.Errorf("List(open): %w", err))
+				if beads.IsPartialResult(err) && len(openRouted) > 0 {
+					appendOpenRoutedWorkUnique(&result, &resultStores, &resultStoreRefs, openRouted, seen, source.store, source.ref)
+				}
+			}
 			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, storeRefs: resultStoreRefs, errs: errs}
 		}()
 	}
@@ -1531,6 +1549,28 @@ func appendInProgressWorkUnique(cfg *config.City, dst *[]beads.Bead, stores *[]b
 func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" {
+			continue
+		}
+		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
+	}
+}
+
+// appendOpenRoutedWorkUnique includes open beads that are still pool-routed
+// AND still carry an assignee. This is the narrow input releaseOrphanedPool
+// Assignments needs to clear step beads abandoned by a dead session
+// (graph.v2 wisps where the root depends on the finalize step, so the
+// root never enters ready and the step assignee remains a long-form
+// dead-session identity invisible to readyAssignedWorkAssignees).
+func appendOpenRoutedWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
+	for _, b := range beadList {
+		if strings.TrimSpace(b.Assignee) == "" {
+			continue
+		}
+		template := strings.TrimSpace(b.Metadata["gc.run_target"])
+		if template == "" {
+			template = strings.TrimSpace(b.Metadata["gc.routed_to"])
+		}
+		if template == "" {
 			continue
 		}
 		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1570,6 +1570,58 @@ func TestCollectAssignedWorkBeads_ExcludesRoutedToMetadataWithoutAssignee(t *tes
 	}
 }
 
+// TestCollectAssignedWorkBeads_IncludesOpenPoolRoutedAssignedWork pins the
+// fix for issue #2793: an open step bead carrying both gc.routed_to and a
+// stale (dead-session) assignee must enter assignedWorkBeads so the
+// orphan-release sweep can iterate it. The status=in_progress pass misses
+// it (wrong status) and the Ready(Assignee=...) pass misses it (the
+// assignee identity belongs to a session that no longer exists). Without
+// this pass, the step bead stays assigned forever, pool demand stays 0,
+// and graph.v2 wisps stall after an orphan drain.
+func TestCollectAssignedWorkBeads_IncludesOpenPoolRoutedAssignedWork(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "orphaned step bead",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "rig--pool__coder-dead-session",
+		Metadata: map[string]string{"gc.routed_to": "rig/pool.coder"},
+	})
+	if err != nil {
+		t.Fatalf("create orphaned step bead: %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(&config.City{}, store)
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("collectAssignedWorkBeads = %#v, want [%s]", got, work.ID)
+	}
+}
+
+// TestCollectAssignedWorkBeads_IncludesOpenRunTargetAssignedWork covers the
+// graph.v2 root-step shape: root beads stamp gc.run_target (not
+// gc.routed_to). The third pass must accept either marker so root steps
+// that orphan-release missed are also recoverable.
+func TestCollectAssignedWorkBeads_IncludesOpenRunTargetAssignedWork(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "orphaned root step",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "rig--pool__coder-dead-session",
+		Metadata: map[string]string{"gc.run_target": "rig/pool.coder"},
+	})
+	if err != nil {
+		t.Fatalf("create orphaned root step: %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(&config.City{}, store)
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("collectAssignedWorkBeads = %#v, want [%s]", got, work.ID)
+	}
+}
+
 func TestCollectAssignedWorkBeads_ExcludesSessionBeads(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -180,7 +180,7 @@ func releaseOrphanedPoolAssignments(
 				continue
 			}
 		}
-		if !liveWorkAssignmentStillReleasable(ownerStore, wb.ID, assignee) {
+		if !liveWorkAssignmentStillReleasable(ownerStore, wb.ID, wb.Status, assignee) {
 			continue
 		}
 		allowsRelease, clearDetached := detachedProbeAllowsOrphanRelease(wb)
@@ -417,13 +417,22 @@ func directSessionBeadIDCandidates(assignee string) []string {
 	return candidates
 }
 
-func liveWorkAssignmentStillReleasable(store beads.Store, id, assignee string) bool {
+// liveWorkAssignmentStillReleasable confirms the snapshot is not stale
+// before clearing assignee. The expectedStatus must match the snapshot
+// status the caller observed: if the bead has since transitioned (e.g. a
+// concurrent claim moved open→in_progress, or another release moved
+// in_progress→open) the snapshot's release decision is no longer safe.
+// Open status is required for the issue #2793 path — graph.v2 step
+// beads stuck on a dead session's long-form assignee are status=open,
+// not in_progress.
+func liveWorkAssignmentStillReleasable(store beads.Store, id, expectedStatus, assignee string) bool {
 	id = strings.TrimSpace(id)
-	if store == nil || id == "" {
+	expectedStatus = strings.TrimSpace(expectedStatus)
+	if store == nil || id == "" || expectedStatus == "" {
 		return false
 	}
 	work, err := store.List(beads.ListQuery{
-		Status:   "in_progress",
+		Status:   expectedStatus,
 		Live:     true,
 		TierMode: beads.TierBoth,
 	})

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1081,6 +1081,55 @@ func TestReleaseOrphanedPoolAssignments_ReopensUnassignedInProgressPoolWork(t *t
 	}
 }
 
+// TestCollectAndReleaseOrphanPoolStepBead_Issue2793 pins the end-to-end fix
+// for issue #2793: a graph.v2 step bead that is status=open with a
+// dead-session long-form assignee (e.g. "<rig>--<pool>__coder...") and
+// gc.routed_to=<pool template> must flow from collectAssignedWorkBeads
+// into releaseOrphanedPoolAssignments and have its assignee cleared.
+// Before the fix, collect's two passes (in_progress / Ready by live
+// assignee) both missed the bead, so release never saw it and pool
+// demand stayed at 0 across reconcile ticks.
+func TestCollectAndReleaseOrphanPoolStepBead_Issue2793(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "graph.v2 step bead orphaned by dead session",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "rig--pool__coder-gc-session-deadbeef",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create orphaned step bead: %v", err)
+	}
+
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
+
+	found, foundStores, foundStoreRefs, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	if len(found) != 1 || found[0].ID != work.ID {
+		t.Fatalf("collect missed the orphaned step bead: got %#v, want [%s]", found, work.ID)
+	}
+
+	// Empty openSessionBeads — the assignee's session is dead.
+	released := releaseOrphanedPoolAssignments(store, cfg, "", nil, found, foundStores, foundStoreRefs, nil)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty after release", got.Assignee)
+	}
+}
+
 func TestCollectAssignedWorkBeadsIncludesUnassignedInProgressPoolWorkForRecovery(t *testing.T) {
 	store := beads.NewMemStore()
 	work, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Summary

Fixes #2793.

After a session orphan-drain in a graph.v2 workflow, `releaseOrphanedPoolAssignments` cleared only the routed root bead — the N step beads in the same wisp chain kept the dead session's long-form assignee (`<rig>--<pool>__coder…`) and stayed `status=open`. Pool demand stayed at 0 across reconcile ticks and the workflow stalled until manual intervention.

## Root cause (two compounding gaps)

1. `collectAssignedWorkBeads` built `assignedWorkBeads` from only two passes — `ListQuery{Status: "in_progress"}` (misses status=open step beads) and `ReadyQuery{Assignee: <live-session-identity>}` (misses long-form dead-session ids; `readyAssignedWorkAssignees` enumerates only live-session identities). Orphaned step beads were structurally invisible to the snapshot, so the release loop never iterated them.

2. Even if a step bead had entered the snapshot, the `liveWorkAssignmentStillReleasable` gate did `List(Status: "in_progress", Live: true)` — a `status=open` bead is not in that list, so the gate returned false and release was skipped. This second gap was not visible in the original report but blocks the fix end-to-end.

## Fix

- `cmd/gc/build_desired_state.go`: add a third per-store pass inside the existing fan-out goroutine that lists `Status: "open"` and feeds a new `appendOpenRoutedWorkUnique` filter. The filter keeps beads with `Assignee != ""` AND (`gc.run_target != ""` OR `gc.routed_to != ""`), scoping the new pass narrowly to the bug class. The pass shares the per-goroutine `seen` map so beads already added by pass 1 are not re-added.

- `cmd/gc/pool_session_name.go`: pass the snapshot's observed status to `liveWorkAssignmentStillReleasable` and query that status instead of hard-coding `in_progress`. The gate still detects `open→in_progress` / `in_progress→open` transitions between snapshot and release as "stale snapshot, skip", preserving the `_SkipsWorkReassignedAfterCandidateSnapshot` invariant.

The release loop's existing dead-session gates (`openSessionOwnsWork` / `liveOpenSessionAssignmentExists` / `assigneePreservesNamedSessionRoute`) still apply, so live-session step beads in the same range are skipped untouched.

## Regression tests

- `TestCollectAssignedWorkBeads_IncludesOpenPoolRoutedAssignedWork` — open step bead with `gc.routed_to=<template>` + dead-session assignee enters the snapshot.
- `TestCollectAssignedWorkBeads_IncludesOpenRunTargetAssignedWork` — same for the graph.v2 root-step `gc.run_target` shape.
- `TestCollectAndReleaseOrphanPoolStepBead_Issue2793` — end-to-end: `collectAssignedWorkBeadsWithStores` → `releaseOrphanedPoolAssignments` clears the dead-session assignee on an open step bead and leaves status=open.
- Existing `TestReleaseOrphanedPoolAssignments_SkipsWorkReassignedAfterCandidateSnapshot` still passes with the new signature, pinning the stale-snapshot guard.

## Test plan

- [x] `go build ./cmd/gc/...` clean
- [x] `go vet ./cmd/gc/...` clean
- [x] Targeted `cmd/gc` tests around `TestCollectAssignedWork*` / `TestReleaseOrphanedPoolAssignments*` / `TestCollectAndReleaseOrphanPoolStepBead_Issue2793` green
- [x] `make check` (fmt + lint + vet + check-routed-test-rows + `test-fast-parallel`) green via pre-commit hook (`LOCAL_TEST_JOBS=1`)