### PR TITLE
feat(runtime): add process table scanner seam

### DIFF
--- a/internal/runtime/fake.go
+++ b/internal/runtime/fake.go
@@ -19,6 +19,7 @@ type Fake struct {
 	meta                    map[string]map[string]string // session → key → value
 	Calls                   []Call                       // recorded calls in order
 	broken                  bool                         // when true, all ops fail
+	OrphanedRuntimes        map[string]LiveRuntime       // session ID → untracked live runtime
 	Zombies                 map[string]bool              // sessions with dead agent processes
 	Attached                map[string]bool              // sessions with attached terminals
 	AttachedSequence        map[string][]bool            // scripted IsAttached results by session
@@ -46,6 +47,8 @@ type Fake struct {
 	// cancellation without relying on wall-clock sleeps.
 	WaitForIdleStarted map[string]chan struct{}
 }
+
+var _ ProcessTableScanner = (*Fake)(nil)
 
 // Call records a single method invocation on [Fake].
 type Call struct {
@@ -80,6 +83,7 @@ func NewFake() *Fake {
 	return &Fake{
 		sessions:                make(map[string]Config),
 		meta:                    make(map[string]map[string]string),
+		OrphanedRuntimes:        make(map[string]LiveRuntime),
 		Zombies:                 make(map[string]bool),
 		Attached:                make(map[string]bool),
 		AttachedSequence:        make(map[string][]bool),
@@ -106,6 +110,7 @@ func NewFailFake() *Fake {
 	return &Fake{
 		sessions:                make(map[string]Config),
 		meta:                    make(map[string]map[string]string),
+		OrphanedRuntimes:        make(map[string]LiveRuntime),
 		Zombies:                 make(map[string]bool),
 		Attached:                make(map[string]bool),
 		StartErrors:             make(map[string]error),
@@ -484,6 +489,62 @@ func (f *Fake) ListRunning(prefix string) ([]string, error) {
 		}
 	}
 	return names, nil
+}
+
+// FindRuntimesBySessionID returns fake tracked and orphaned runtimes matching
+// a GC_SESSION_ID. Empty id returns all runtimes with a session ID.
+func (f *Fake) FindRuntimesBySessionID(id string) ([]LiveRuntime, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Calls = append(f.Calls, Call{Method: "FindRuntimesBySessionID", Name: id})
+	if f.broken {
+		return nil, fmt.Errorf("finding runtimes for session %q: session unavailable", id)
+	}
+
+	var out []LiveRuntime
+	for sid, runtime := range f.OrphanedRuntimes {
+		sessionID := runtime.SessionID
+		if sessionID == "" {
+			sessionID = sid
+		}
+		if sessionID == "" {
+			continue
+		}
+		if id != "" && sessionID != id {
+			continue
+		}
+		runtime.SessionID = sessionID
+		runtime.IsTracked = false
+		out = append(out, runtime)
+	}
+	for name, cfg := range f.sessions {
+		sessionID := cfg.Env["GC_SESSION_ID"]
+		if sessionID == "" {
+			continue
+		}
+		if id != "" && sessionID != id {
+			continue
+		}
+		out = append(out, LiveRuntime{
+			SessionID:    sessionID,
+			ProviderName: name,
+			IsTracked:    true,
+		})
+	}
+	return out, nil
+}
+
+// TerminateRuntime records a process-table termination and removes the fake
+// orphan entry for the runtime's session ID. Missing entries are already gone.
+func (f *Fake) TerminateRuntime(runtime LiveRuntime) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Calls = append(f.Calls, Call{Method: "TerminateRuntime", Name: runtime.SessionID})
+	if f.broken {
+		return fmt.Errorf("terminating runtime %q: session unavailable", runtime.SessionID)
+	}
+	delete(f.OrphanedRuntimes, runtime.SessionID)
+	return nil
 }
 
 // SetActivity sets the canned last activity time for the named session.

--- a/internal/runtime/fake_test.go
+++ b/internal/runtime/fake_test.go
@@ -491,3 +491,186 @@ func TestFakeWaitForIdleGate_MuReleasedWhileBlocked(t *testing.T) {
 
 	close(gate)
 }
+
+func TestFakeFindRuntimesBySessionID_BrokenError(t *testing.T) {
+	f := NewFailFake()
+
+	_, err := f.FindRuntimesBySessionID("sess1")
+	if err == nil {
+		t.Fatal("expected error from broken fake")
+	}
+
+	var found bool
+	for _, c := range f.Calls {
+		if c.Method == "FindRuntimesBySessionID" {
+			found = true
+			if c.Name != "sess1" {
+				t.Errorf("Call.Name = %q, want %q", c.Name, "sess1")
+			}
+		}
+	}
+	if !found {
+		t.Error("FindRuntimesBySessionID call not recorded on broken fake")
+	}
+}
+
+func TestFakeFindRuntimesBySessionID_EmptyIDReturnsAll(t *testing.T) {
+	f := NewFake()
+	f.OrphanedRuntimes["sid-a"] = LiveRuntime{SessionID: "sid-a", PID: 1}
+	f.OrphanedRuntimes["sid-b"] = LiveRuntime{PID: 2} // empty SessionID; map key is used
+	f.OrphanedRuntimes[""] = LiveRuntime{PID: 99}     // both key and SessionID empty; skipped
+	_ = f.Start(context.Background(), "provider-c", Config{Env: map[string]string{"GC_SESSION_ID": "sid-c"}})
+	_ = f.Start(context.Background(), "provider-d", Config{}) // no GC_SESSION_ID; skipped
+
+	runtimes, err := f.FindRuntimesBySessionID("")
+	if err != nil {
+		t.Fatalf("FindRuntimesBySessionID: %v", err)
+	}
+	if len(runtimes) != 3 {
+		t.Fatalf("got %d runtimes, want 3: %+v", len(runtimes), runtimes)
+	}
+}
+
+func TestFakeFindRuntimesBySessionID_FiltersByID(t *testing.T) {
+	f := NewFake()
+	f.OrphanedRuntimes["sid-match"] = LiveRuntime{SessionID: "sid-match"}
+	f.OrphanedRuntimes["sid-other"] = LiveRuntime{SessionID: "sid-other"}
+	_ = f.Start(context.Background(), "provider-match", Config{Env: map[string]string{"GC_SESSION_ID": "sid-match"}})
+	_ = f.Start(context.Background(), "provider-other", Config{Env: map[string]string{"GC_SESSION_ID": "sid-other"}})
+
+	runtimes, err := f.FindRuntimesBySessionID("sid-match")
+	if err != nil {
+		t.Fatalf("FindRuntimesBySessionID: %v", err)
+	}
+	if len(runtimes) != 2 {
+		t.Fatalf("got %d runtimes, want 2: %+v", len(runtimes), runtimes)
+	}
+	for _, r := range runtimes {
+		if r.SessionID != "sid-match" {
+			t.Errorf("returned runtime SessionID = %q, want %q", r.SessionID, "sid-match")
+		}
+	}
+	if f.CountCalls("FindRuntimesBySessionID", "sid-match") != 1 {
+		t.Error("FindRuntimesBySessionID call not recorded")
+	}
+}
+
+func TestFakeFindRuntimesBySessionID_EmptySessionIDsSkipped(t *testing.T) {
+	f := NewFake()
+	f.OrphanedRuntimes[""] = LiveRuntime{PID: 1}                   // both key and SessionID empty; skipped
+	_ = f.Start(context.Background(), "provider-no-sid", Config{}) // no GC_SESSION_ID; skipped
+
+	runtimes, err := f.FindRuntimesBySessionID("")
+	if err != nil {
+		t.Fatalf("FindRuntimesBySessionID: %v", err)
+	}
+	if len(runtimes) != 0 {
+		t.Fatalf("got %d runtimes, want 0: %+v", len(runtimes), runtimes)
+	}
+}
+
+func TestFakeFindRuntimesBySessionID_OrphanForcesIsTrackedFalse(t *testing.T) {
+	f := NewFake()
+	f.OrphanedRuntimes["sid-orphan"] = LiveRuntime{SessionID: "sid-orphan", IsTracked: true}
+
+	runtimes, err := f.FindRuntimesBySessionID("sid-orphan")
+	if err != nil {
+		t.Fatalf("FindRuntimesBySessionID: %v", err)
+	}
+	if len(runtimes) != 1 {
+		t.Fatalf("got %d runtimes, want 1", len(runtimes))
+	}
+	if runtimes[0].IsTracked {
+		t.Error("orphan runtime IsTracked = true, want false")
+	}
+}
+
+func TestFakeFindRuntimesBySessionID_TrackedUsesProviderNameAndSessionID(t *testing.T) {
+	f := NewFake()
+	_ = f.Start(context.Background(), "my-provider", Config{Env: map[string]string{"GC_SESSION_ID": "sess-abc"}})
+
+	runtimes, err := f.FindRuntimesBySessionID("sess-abc")
+	if err != nil {
+		t.Fatalf("FindRuntimesBySessionID: %v", err)
+	}
+	if len(runtimes) != 1 {
+		t.Fatalf("got %d runtimes, want 1", len(runtimes))
+	}
+	r := runtimes[0]
+	if r.SessionID != "sess-abc" {
+		t.Errorf("SessionID = %q, want %q", r.SessionID, "sess-abc")
+	}
+	if r.ProviderName != "my-provider" {
+		t.Errorf("ProviderName = %q, want %q", r.ProviderName, "my-provider")
+	}
+	if !r.IsTracked {
+		t.Error("tracked runtime IsTracked = false, want true")
+	}
+}
+
+func TestFakeTerminateRuntime_RecordsCallWithSessionID(t *testing.T) {
+	f := NewFake()
+
+	if err := f.TerminateRuntime(LiveRuntime{SessionID: "my-session", ProviderName: "some-provider"}); err != nil {
+		t.Fatalf("TerminateRuntime: %v", err)
+	}
+
+	var found bool
+	for _, c := range f.Calls {
+		if c.Method == "TerminateRuntime" {
+			found = true
+			if c.Name != "my-session" {
+				t.Errorf("Call.Name = %q, want %q (SessionID, not ProviderName)", c.Name, "my-session")
+			}
+		}
+	}
+	if !found {
+		t.Error("TerminateRuntime call not recorded")
+	}
+}
+
+func TestFakeTerminateRuntime_RemovesOrphan(t *testing.T) {
+	f := NewFake()
+	f.OrphanedRuntimes["my-session"] = LiveRuntime{SessionID: "my-session", PID: 42}
+
+	if err := f.TerminateRuntime(LiveRuntime{SessionID: "my-session"}); err != nil {
+		t.Fatalf("TerminateRuntime: %v", err)
+	}
+	if _, ok := f.OrphanedRuntimes["my-session"]; ok {
+		t.Error("OrphanedRuntimes still contains entry after TerminateRuntime")
+	}
+}
+
+func TestFakeTerminateRuntime_MissingEntryIsNil(t *testing.T) {
+	f := NewFake()
+
+	if err := f.TerminateRuntime(LiveRuntime{SessionID: "nonexistent"}); err != nil {
+		t.Fatalf("TerminateRuntime on missing entry returned error: %v", err)
+	}
+}
+
+func TestFakeTerminateRuntime_BrokenError(t *testing.T) {
+	f := NewFailFake()
+	f.OrphanedRuntimes["sid"] = LiveRuntime{SessionID: "sid"}
+
+	err := f.TerminateRuntime(LiveRuntime{SessionID: "sid"})
+	if err == nil {
+		t.Fatal("expected error from broken fake")
+	}
+
+	var found bool
+	for _, c := range f.Calls {
+		if c.Method == "TerminateRuntime" {
+			found = true
+			if c.Name != "sid" {
+				t.Errorf("Call.Name = %q, want %q", c.Name, "sid")
+			}
+		}
+	}
+	if !found {
+		t.Error("TerminateRuntime call not recorded on broken fake")
+	}
+	if _, ok := f.OrphanedRuntimes["sid"]; !ok {
+		t.Error("OrphanedRuntimes entry removed despite error from broken fake")
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -278,6 +278,46 @@ type InterruptBoundaryWaitProvider interface {
 	WaitForInterruptBoundary(ctx context.Context, name string, since time.Time, timeout time.Duration) error
 }
 
+// LiveRuntime identifies a single agent runtime process discovered via
+// process-table scan, independent of provider-visible artifacts.
+type LiveRuntime struct {
+	// SessionID is the GC_SESSION_ID value from the process environment.
+	SessionID string
+	// Epoch is the GC_RUNTIME_EPOCH from the process environment, if readable.
+	// Zero if the variable is absent or unparseable.
+	Epoch int
+	// PID is the OS process ID for local providers, or a provider-specific
+	// process identifier for remote infrastructure.
+	PID int
+	// ProviderName is the session name as known to the provider. Empty means
+	// the runtime is not visible in the provider's artifact registry.
+	ProviderName string
+	// IsTracked is true when this runtime also appears in the provider's
+	// registry. False marks a live process that is invisible to the provider.
+	IsTracked bool
+}
+
+// ProcessTableScanner is an optional extension for runtimes that can discover
+// live agent root processes by GC_SESSION_ID independently of provider-visible
+// artifacts.
+//
+// Providers that cannot inspect process tables do not implement this
+// interface. Callers must use a type assertion and continue safely when the
+// provider lacks the capability.
+type ProcessTableScanner interface {
+	// FindRuntimesBySessionID returns live agent root processes carrying
+	// GC_SESSION_ID equal to id. If id is empty, it returns all live agent root
+	// processes with any GC_SESSION_ID set.
+	//
+	// Best-effort implementations may return both partial results and a non-nil
+	// error; callers should proceed with any returned results.
+	FindRuntimesBySessionID(id string) ([]LiveRuntime, error)
+
+	// TerminateRuntime stops the process or infrastructure unit identified by r.
+	// It returns nil when the runtime is already gone.
+	TerminateRuntime(r LiveRuntime) error
+}
+
 // CopyEntry describes a file or directory to stage in the session's
 // working directory before the agent command starts.
 type CopyEntry struct {

--- a/release-gates/ga-17xlnc-process-table-scanner-contract-gate.md
+++ b/release-gates/ga-17xlnc-process-table-scanner-contract-gate.md
@@ -1,0 +1,70 @@
+# Release Gate: ga-17xlnc - process-table scanner contract
+
+Deploy bead: ga-17xlnc
+Source review bead: ga-qiyedo
+Source build bead: ga-qmbisj.1
+Branch: builder/ga-qmbisj-1-process-scanner
+PR: https://github.com/gastownhall/gascity/pull/2837
+Reviewed commit: 4321a48462bf630906dcbb2d31fa22c3548a2eb9
+Final branch head: daa33edad188346e361c3349ba09b5f16fe3a414
+Gate evaluated: 2026-05-31
+
+Note: `docs/PROJECT_MANIFEST.md` is not present in this checkout. This gate
+uses the release criteria from the deployer prompt loaded by `gc prime`, with
+test scope aligned to `TESTING.md`.
+
+## Summary
+
+This change adds the runtime process-table scanner contract without changing
+the core `runtime.Provider` interface. Providers can opt into
+`runtime.ProcessTableScanner`, callers can reason about discovered live
+runtimes through `runtime.LiveRuntime`, and `runtime.Fake` now implements the
+optional scanner seam for tests.
+
+The reviewed implementation commit was followed by a validator-owned,
+test-only commit that adds focused coverage for the fake scanner decision
+branches. No production code changed after the reviewed commit.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-qiyedo` records `Review Verdict: PASS` from `gascity/reviewer` for commit `4321a48462bf630906dcbb2d31fa22c3548a2eb9` on PR #2837. Final head adds only `internal/runtime/fake_test.go` coverage in `daa33edad188346e361c3349ba09b5f16fe3a414`, closing validator follow-up `ga-0hof7r`. |
+| 2 | Acceptance criteria met | PASS | `runtime.LiveRuntime` and optional `runtime.ProcessTableScanner` are added in `internal/runtime/runtime.go`; `runtime.Provider` is unchanged; `runtime.Fake` initializes `OrphanedRuntimes` in `NewFake` and `NewFailFake`; fake scanner methods use `GC_SESSION_ID` from tracked session env; `TerminateRuntime` records by session ID and removes orphan entries; compile-time conformance covers the fake scanner seam; focused tests now exercise the fake scanner branches. |
+| 3 | Tests pass | PASS | `go test ./internal/runtime -count=1` passed; `make test-fast-parallel` completed with `All fast jobs passed`; `go vet ./...` exited 0; `git diff --check origin/main...HEAD` exited 0. GitHub PR checks for #2837 are green at final head. |
+| 4 | No high-severity review findings open | PASS | Review notes for `ga-qiyedo` state `No findings`; the only follow-up was coverage bead `ga-0hof7r`, now closed by the test-only commit. No HIGH findings are recorded in the deploy bead or review notes. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` showed a clean `builder/ga-qmbisj-1-process-scanner` branch aligned with `origin/builder/ga-qmbisj-1-process-scanner`; cleanliness is rechecked after committing this gate before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` exited 0 at final branch head before the gate commit. |
+| 7 | Single feature theme | PASS | The commit set touches one runtime testing seam: `internal/runtime/runtime.go`, `internal/runtime/fake.go`, and focused tests in `internal/runtime/fake_test.go`. It does not bundle unrelated subsystems or user-facing features. |
+
+## Acceptance Evidence
+
+- `runtime.LiveRuntime` carries the observed runtime fields needed by future
+  process-table scanners: session ID, epoch, PID, provider name, and tracked
+  state.
+- `runtime.ProcessTableScanner` is an optional interface, preserving the
+  existing `runtime.Provider` contract for providers that cannot scan the
+  process table.
+- `runtime.Fake` records scanner calls and exposes tracked sessions from
+  `Config.Env["GC_SESSION_ID"]` plus explicit orphan runtimes from
+  `OrphanedRuntimes`.
+- `runtime.Fake.TerminateRuntime` records the session ID, removes orphaned
+  entries, returns nil for missing entries, and returns contextual errors from
+  the broken fake.
+- `internal/runtime/fake_test.go` covers the fake scanner branch behavior added
+  by the implementation.
+
+## Commands
+
+```text
+gh auth status
+git pull --ff-only origin builder/ga-qmbisj-1-process-scanner
+git fetch origin main
+git status --short --branch
+git diff --check origin/main...HEAD
+git merge-tree --write-tree HEAD origin/main
+git diff --stat origin/main...HEAD
+go test ./internal/runtime -count=1
+make test-fast-parallel
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

This adds a typed process-table discovery contract to `internal/runtime` without expanding the required `runtime.Provider` interface. Providers that can inspect live processes may opt into `runtime.ProcessTableScanner`; providers that cannot scan do not need to change.

The new `runtime.LiveRuntime` value describes a discovered runtime by session ID, epoch, PID, provider name, and whether it is already tracked by Gas City. `runtime.Fake` implements the optional scanner seam so session and reconciler code can test orphan-runtime behavior without depending on a real process table.

## Review notes

- `runtime.Provider` remains unchanged; scanner support is deliberately optional via type assertion.
- This PR adds the contract and fake implementation only. It does not enable a production process-table scanner or change session startup behavior.
- The final branch includes a test-only follow-up covering `runtime.Fake` scanner branches after the reviewed implementation commit.

## Test plan

- [x] `go test ./internal/runtime -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] Release gate: [`release-gates/ga-17xlnc-process-table-scanner-contract-gate.md`](release-gates/ga-17xlnc-process-table-scanner-contract-gate.md)
