### PR TITLE
feat(runtime): wire process scanners into providers

### DIFF
--- a/internal/runtime/subprocess/subprocess.go
+++ b/internal/runtime/subprocess/subprocess.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/runtime/proctable"
 )
 
 // Provider manages agent sessions as child processes.
@@ -54,7 +55,10 @@ type sessionConn struct {
 }
 
 // Compile-time check.
-var _ runtime.Provider = (*Provider)(nil)
+var (
+	_ runtime.Provider            = (*Provider)(nil)
+	_ runtime.ProcessTableScanner = (*Provider)(nil)
+)
 
 // NewProvider returns a subprocess [Provider] that stores socket files in
 // a default temporary directory. Suitable for production use.
@@ -258,6 +262,53 @@ func (p *Provider) ProcessAlive(name string, processNames []string) bool {
 		return true
 	}
 	return p.IsRunning(name)
+}
+
+// FindRuntimesBySessionID implements [runtime.ProcessTableScanner].
+func (p *Provider) FindRuntimesBySessionID(id string) ([]runtime.LiveRuntime, error) {
+	found, scanErr := proctable.ScanBySessionID(id)
+
+	p.mu.Lock()
+	trackedBySessionID := make(map[string]string)
+	for name, sc := range p.procs {
+		if sc == nil || sc.cmd == nil || !sc.alive() {
+			continue
+		}
+		if sessionID := envValue(sc.cmd.Env, "GC_SESSION_ID"); sessionID != "" {
+			trackedBySessionID[sessionID] = name
+		}
+	}
+	p.mu.Unlock()
+
+	for i := range found {
+		if name, ok := trackedBySessionID[found[i].SessionID]; ok {
+			found[i].IsTracked = true
+			found[i].ProviderName = name
+		}
+	}
+	return found, scanErr
+}
+
+// TerminateRuntime implements [runtime.ProcessTableScanner].
+func (p *Provider) TerminateRuntime(r runtime.LiveRuntime) error {
+	if r.PID <= 1 {
+		return fmt.Errorf("subprocess: invalid PID %d for session %s", r.PID, r.SessionID)
+	}
+	if err := proctable.KillByPID(r.PID); err != nil {
+		return fmt.Errorf("subprocess: terminate runtime PID %d for session %s: %w", r.PID, r.SessionID, err)
+	}
+	return nil
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		value := env[i]
+		if strings.HasPrefix(value, prefix) {
+			return value[len(prefix):]
+		}
+	}
+	return ""
 }
 
 // Nudge is not supported by the subprocess provider — there is no

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/overlay"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/runtime/proctable"
 	"github.com/gastownhall/gascity/internal/shellquote"
 )
 
@@ -38,6 +39,7 @@ var (
 	_ runtime.ImmediateNudgeProvider        = (*Provider)(nil)
 	_ runtime.InterruptBoundaryWaitProvider = (*Provider)(nil)
 	_ runtime.InterruptedTurnResetProvider  = (*Provider)(nil)
+	_ runtime.ProcessTableScanner           = (*Provider)(nil)
 )
 
 // NewProvider returns a [Provider] backed by a real tmux installation
@@ -297,6 +299,51 @@ func (p *Provider) ProcessAlive(name string, processNames []string) bool {
 		return true
 	}
 	return p.cache.ProcessAlive(name, processNames)
+}
+
+// FindRuntimesBySessionID implements [runtime.ProcessTableScanner].
+func (p *Provider) FindRuntimesBySessionID(id string) ([]runtime.LiveRuntime, error) {
+	found, scanErr := proctable.ScanBySessionID(id)
+	running, listErr := p.ListRunning("")
+	if listErr != nil {
+		for i := range found {
+			found[i].IsTracked = true
+		}
+		return found, errors.Join(scanErr, fmt.Errorf("tmux list running: %w", listErr))
+	}
+
+	tracked := make(map[string]string)
+	for _, name := range running {
+		sessionID, err := p.GetMeta(name, "GC_SESSION_ID")
+		if err == nil && strings.TrimSpace(sessionID) != "" {
+			tracked[sessionID] = name
+		}
+	}
+	for i := range found {
+		if name, ok := tracked[found[i].SessionID]; ok {
+			found[i].IsTracked = true
+			found[i].ProviderName = name
+		}
+	}
+	return found, scanErr
+}
+
+// TerminateRuntime implements [runtime.ProcessTableScanner].
+func (p *Provider) TerminateRuntime(r runtime.LiveRuntime) error {
+	if r.PID <= 1 {
+		return fmt.Errorf("tmux: invalid PID %d for session %s", r.PID, r.SessionID)
+	}
+	if err := proctable.KillByPID(r.PID); err != nil {
+		return fmt.Errorf("tmux: terminate runtime PID %d for session %s: %w", r.PID, r.SessionID, err)
+	}
+	return nil
+}
+
+// ForgetSession removes provider metadata for name without stopping its tmux
+// process. Tests use this to simulate an OS-live process orphaned from the
+// provider's registry.
+func (p *Provider) ForgetSession(name string) {
+	_ = p.RemoveMeta(name, "GC_SESSION_ID")
 }
 
 // ObserveLiveness reports both pane presence and agent-process presence for a


### PR DESCRIPTION
## Summary
- Implement `runtime.ProcessTableScanner` on tmux and subprocess providers using `internal/runtime/proctable`.
- Mark tracked runtimes by cross-checking provider registries: tmux session metadata and subprocess `p.procs` snapshots.
- Add provider-specific `TerminateRuntime` wrappers and tmux `ForgetSession` for orphan simulation without changing acp/auto/hybrid/exec/t3bridge/k8s.

## Stack
- Stacked on PR #2839 / `builder/ga-9nzf62-1-proctable-scanner`.
- That PR is stacked on PR #2837 / `builder/ga-qmbisj-1-process-scanner`.

## Verification
- `GOTOOLCHAIN=auto go test ./internal/runtime/subprocess ./internal/runtime/tmux -count=1`
- Validator subprocess scanner tests from commit `96c34f953` passed in a disposable worktree.
- Validator tmux integration scanner tests from commit `96c34f953` passed with `-tags integration` in a disposable worktree.
- `GOTOOLCHAIN=auto go vet ./...`
- `PATH=/home/jaword/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.linux-amd64/bin:$PATH GOROOT=/home/jaword/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.linux-amd64 GOTOOLCHAIN=auto make test-fast-parallel`
- pre-commit hook: changed-package lint, generators, `go vet ./...`, `make test-fast-parallel`
- `git diff --check builder/ga-9nzf62-1-proctable-scanner...HEAD`

Bead: `ga-gh892d.1`
