### PR TITLE
feat(session): clear orphan runtimes before start

### DIFF
--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -117,6 +117,7 @@ func (m *Manager) retryFreshStartAfterStaleKey(
 		return false, fmt.Errorf("fresh start after stale key: resume command could not be stripped")
 	}
 	cfg.Command = freshCmd
+	m.killExistingOrphans(ctx, id)
 	if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 		if unroute != nil {
 			unroute()
@@ -285,6 +286,7 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 	}
 	cfg = runtime.SyncWorkDirEnv(cfg)
 	started := false
+	m.killExistingOrphans(ctx, id)
 	if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 		if errors.Is(err, runtime.ErrSessionDiedDuringStartup) && b.Metadata["session_key"] != "" {
 			retried, err := m.retryFreshStartAfterStaleKey(ctx, id, &b, sessName, resumeCommand, cfg, unroute)
@@ -395,6 +397,7 @@ func (m *Manager) ensureRunningRuntimeOnly(ctx context.Context, id string, b bea
 	}
 	cfg = runtime.SyncWorkDirEnv(cfg)
 	started := false
+	m.killExistingOrphans(ctx, id)
 	if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 		switch {
 		case errors.Is(err, runtime.ErrSessionDiedDuringStartup) && b.Metadata["session_key"] != "":

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -228,6 +228,26 @@ func (m *Manager) persistTransport(id, provider, transport string) {
 	_ = m.store.SetMetadata(id, "transport", transport)
 }
 
+func (m *Manager) killExistingOrphans(ctx context.Context, sessionID string) {
+	_ = ctx
+	scanner, ok := m.sp.(runtime.ProcessTableScanner)
+	if !ok || sessionID == "" {
+		return
+	}
+	found, err := scanner.FindRuntimesBySessionID(sessionID)
+	if err != nil {
+		log.Printf("session: scanning for orphaned runtimes for %s: %v", sessionID, err)
+	}
+	for _, live := range found {
+		if live.IsTracked || live.SessionID != sessionID {
+			continue
+		}
+		if err := scanner.TerminateRuntime(live); err != nil {
+			log.Printf("session: terminating orphaned runtime for %s pid=%d provider_name=%q: %v", sessionID, live.PID, live.ProviderName, err)
+		}
+	}
+}
+
 func (m *Manager) now() time.Time {
 	if m != nil && m.clk != nil {
 		return m.clk.Now()
@@ -509,6 +529,7 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 		cfg = runtime.SyncWorkDirEnv(cfg)
 
 		// Start the runtime session.
+		m.killExistingOrphans(ctx, b.ID)
 		if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 			if runtimeSessionMatchesBead(m.sp, sessName, b.ID, meta["instance_token"]) {
 				if metaErr := m.confirmStartedRuntimeMetadata(b.ID, &b); metaErr != nil {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -26,6 +26,40 @@ type noImmediateProvider struct {
 	runtime.Provider
 }
 
+type providerWithoutProcessScanner struct {
+	runtime.Provider
+}
+
+type orphanScanProvider struct {
+	*runtime.Fake
+	results      []runtime.LiveRuntime
+	findErr      error
+	terminateErr error
+	events       []string
+}
+
+func (p *orphanScanProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	p.events = append(p.events, "start:"+cfg.Env["GC_SESSION_ID"])
+	return p.Fake.Start(ctx, name, cfg)
+}
+
+func (p *orphanScanProvider) FindRuntimesBySessionID(id string) ([]runtime.LiveRuntime, error) {
+	p.events = append(p.events, "find:"+id)
+	out := make([]runtime.LiveRuntime, len(p.results))
+	copy(out, p.results)
+	for i := range out {
+		if out[i].SessionID == "" {
+			out[i].SessionID = id
+		}
+	}
+	return out, p.findErr
+}
+
+func (p *orphanScanProvider) TerminateRuntime(r runtime.LiveRuntime) error {
+	p.events = append(p.events, "terminate:"+r.SessionID)
+	return p.terminateErr
+}
+
 type nonRunningStopRecorder struct {
 	*runtime.Fake
 	stopCalls int
@@ -247,9 +281,17 @@ func TestCreate(t *testing.T) {
 	if b.Metadata["instance_token"] == "" {
 		t.Error("instance_token is empty")
 	}
-	startCall := sp.Calls[0]
-	if startCall.Method != "Start" {
-		t.Fatalf("first runtime call = %q, want Start", startCall.Method)
+	var startCall runtime.Call
+	foundStart := false
+	for _, call := range sp.Calls {
+		if call.Method == "Start" {
+			startCall = call
+			foundStart = true
+			break
+		}
+	}
+	if !foundStart {
+		t.Fatalf("runtime calls = %v, want Start", sp.Calls)
 	}
 	if got := startCall.Config.Env["GC_SESSION_ID"]; got != info.ID {
 		t.Errorf("GC_SESSION_ID = %q, want %q", got, info.ID)
@@ -266,6 +308,132 @@ func TestCreate(t *testing.T) {
 	if got := startCall.Config.Env["GC_DIR"]; got != "/tmp" {
 		t.Errorf("GC_DIR = %q, want %q", got, "/tmp")
 	}
+}
+
+func TestCreateKillsUntrackedOrphanBeforeStart(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &orphanScanProvider{
+		Fake: runtime.NewFake(),
+		results: []runtime.LiveRuntime{{
+			PID:       1234,
+			IsTracked: false,
+		}},
+	}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "my chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	want := []string{"find:" + info.ID, "terminate:" + info.ID, "start:" + info.ID}
+	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v", sp.events, want)
+	}
+}
+
+func TestCreateSkipsTrackedRuntimeBeforeStart(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &orphanScanProvider{
+		Fake: runtime.NewFake(),
+		results: []runtime.LiveRuntime{{
+			PID:       1234,
+			IsTracked: true,
+		}},
+	}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "my chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	want := []string{"find:" + info.ID, "start:" + info.ID}
+	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v", sp.events, want)
+	}
+}
+
+func TestCreateContinuesWhenOrphanCleanupFails(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &orphanScanProvider{
+		Fake:         runtime.NewFake(),
+		findErr:      errors.New("partial scan failed"),
+		terminateErr: errors.New("terminate failed"),
+		results: []runtime.LiveRuntime{{
+			PID:       1234,
+			IsTracked: false,
+		}},
+	}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "my chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !sp.IsRunning(info.SessionName) {
+		t.Fatalf("runtime session %q was not started after cleanup errors", info.SessionName)
+	}
+	want := []string{"find:" + info.ID, "terminate:" + info.ID, "start:" + info.ID}
+	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v", sp.events, want)
+	}
+}
+
+func TestCreateWithProviderWithoutProcessScannerStillStarts(t *testing.T) {
+	store := beads.NewMemStore()
+	fake := runtime.NewFake()
+	mgr := NewManager(store, &providerWithoutProcessScanner{Provider: fake})
+
+	info, err := mgr.Create(context.Background(), "helper", "my chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !fake.IsRunning(info.SessionName) {
+		t.Fatalf("runtime session %q was not started", info.SessionName)
+	}
+}
+
+func TestRuntimeStartCallSitesCleanOrphansFirst(t *testing.T) {
+	tests := []struct {
+		file   string
+		idExpr string
+	}{
+		{file: "manager.go", idExpr: "b.ID"},
+		{file: "chat.go", idExpr: "id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(".", tt.file))
+			if err != nil {
+				t.Fatalf("read %s: %v", tt.file, err)
+			}
+			lines := strings.Split(string(data), "\n")
+			starts := 0
+			for i, line := range lines {
+				if !strings.Contains(line, "m.sp.Start(ctx, sessName, cfg)") {
+					continue
+				}
+				starts++
+				prev := previousNonBlankLine(lines, i)
+				if !strings.Contains(prev, "m.killExistingOrphans(ctx, "+tt.idExpr+")") {
+					t.Errorf("%s:%d Start is not immediately preceded by orphan cleanup using %s; previous line: %q", tt.file, i+1, tt.idExpr, prev)
+				}
+			}
+			if starts == 0 {
+				t.Fatalf("%s contains no m.sp.Start(ctx, sessName, cfg) call sites", tt.file)
+			}
+		})
+	}
+}
+
+func previousNonBlankLine(lines []string, before int) string {
+	for i := before - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return strings.TrimSpace(lines[i])
+		}
+	}
+	return ""
 }
 
 func TestUpdateTemplateOverridesRejectsRunningSessionUnderLock(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add Manager.killExistingOrphans to use runtime.ProcessTableScanner when available.
- Run cleanup immediately before all m.sp.Start(ctx, sessName, cfg) call sites in manager/chat using the bead ID / GC_SESSION_ID.
- Keep non-scanner providers on the existing no-op path and log scan/termination failures without aborting spawn.

Stacked on PR #2837 / branch builder/ga-qmbisj-1-process-scanner.

## Verification
- GOTOOLCHAIN=auto go test ./internal/session -run 'TestCreateKillsUntrackedOrphanBeforeStart|TestCreateSkipsTrackedRuntimeBeforeStart|TestCreateContinuesWhenOrphanCleanupFails|TestCreateWithProviderWithoutProcessScannerStillStarts|TestRuntimeStartCallSitesCleanOrphansFirst' -count=1
- GOTOOLCHAIN=auto go test ./internal/session -count=1
- GOTOOLCHAIN=auto go test ./internal/runtime ./internal/session -count=1
- git diff --check
- GOTOOLCHAIN=auto go vet ./internal/session
- GOTOOLCHAIN=auto go vet ./...
- make test-fast-parallel with Go 1.26.3 toolchain env
- .githooks/pre-commit ran and passed lint-changed, generated checks, go vet, and make test-fast-parallel