### PR TITLE
feat(gc): sweep process-table orphan runtimes

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -517,6 +517,9 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		// identity re-minted as a pool slot) so the name's current owner can
 		// rebind it and attach lands on the right runtime.
 		reapRuntimesBoundToClosedBeads(cr.cityBeadStore(), sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
+		if swept := sweepProcessTableOrphans(cr.sp, sessionBeads, cr.cityBeadStore(), cr.stderr); swept > 0 {
+			fmt.Fprintf(cr.stderr, "session reconciler: swept %d process-table orphan runtime(s)\n", swept) //nolint:errcheck
+		}
 		// Reap stale session beads from a previous run before building desired
 		// state, so desired state does not reference already-closed beads (#742).
 		if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
@@ -1041,6 +1044,12 @@ func (cr *CityRuntime) tick(
 	phaseStart = time.Now()
 	reapRuntimesBoundToClosedBeads(cr.cityBeadStore(), sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
 	recordPhase(TraceSiteControllerTickPhase, "reap_runtimes_bound_to_closed_beads", phaseStart, nil)
+	phaseStart = time.Now()
+	swept := sweepProcessTableOrphans(cr.sp, sessionBeads, cr.cityBeadStore(), cr.stderr)
+	if swept > 0 {
+		fmt.Fprintf(cr.stderr, "session reconciler: swept %d process-table orphan runtime(s)\n", swept) //nolint:errcheck
+	}
+	recordPhase(TraceSiteControllerTickPhase, "sweep_process_table_orphans", phaseStart, map[string]any{"reaped": swept})
 	phaseStart = time.Now()
 	reaped := reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr)
 	recordPhase(TraceSiteControllerTickPhase, "reap_stale_session_beads", phaseStart, map[string]any{"reaped": reaped})

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -2075,12 +2076,15 @@ func sweepProcessTableOrphans(
 			continue
 		}
 		bead, err := store.Get(live.SessionID)
-		if err == nil && bead.Status != "closed" {
+		switch {
+		case err == nil && bead.Status != "closed":
+			continue // bead still open — leave the runtime alone
+		case err != nil && !errors.Is(err, beads.ErrNotFound):
+			// transient/unreadable store error — do not destroy a live runtime on uncertainty
+			fmt.Fprintf(stderr, "session reconciler: looking up process-table orphan session bead %s pid=%d: %v\n", live.SessionID, live.PID, err) //nolint:errcheck
 			continue
 		}
-		if err != nil {
-			fmt.Fprintf(stderr, "session reconciler: looking up process-table orphan session bead %s pid=%d: %v\n", live.SessionID, live.PID, err) //nolint:errcheck
-		}
+		// here: bead is closed, or confirmed absent (ErrNotFound) — reap below
 		if err := scanner.TerminateRuntime(live); err != nil {
 			fmt.Fprintf(stderr, "session reconciler: terminating process-table orphan pid=%d session=%s: %v\n", live.PID, live.SessionID, err) //nolint:errcheck
 			continue

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -2047,6 +2047,50 @@ func reapRuntimesBoundToClosedBeads(
 	return reaped
 }
 
+func sweepProcessTableOrphans(
+	sp runtime.Provider,
+	_ *sessionBeadSnapshot,
+	store beads.Store,
+	stderr io.Writer,
+) int {
+	if sp == nil || store == nil {
+		return 0
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	scanner, ok := sp.(runtime.ProcessTableScanner)
+	if !ok {
+		return 0
+	}
+	found, err := scanner.FindRuntimesBySessionID("")
+	if err != nil {
+		fmt.Fprintf(stderr, "session reconciler: scanning process table for orphaned runtimes: %v\n", err) //nolint:errcheck
+	}
+
+	reaped := 0
+	for _, live := range found {
+		live.SessionID = strings.TrimSpace(live.SessionID)
+		if live.SessionID == "" || live.IsTracked {
+			continue
+		}
+		bead, err := store.Get(live.SessionID)
+		if err == nil && bead.Status != "closed" {
+			continue
+		}
+		if err != nil {
+			fmt.Fprintf(stderr, "session reconciler: looking up process-table orphan session bead %s pid=%d: %v\n", live.SessionID, live.PID, err) //nolint:errcheck
+		}
+		if err := scanner.TerminateRuntime(live); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: terminating process-table orphan pid=%d session=%s: %v\n", live.PID, live.SessionID, err) //nolint:errcheck
+			continue
+		}
+		fmt.Fprintf(stderr, "session reconciler: reaped process-table orphan pid=%d session=%s\n", live.PID, live.SessionID) //nolint:errcheck
+		reaped++
+	}
+	return reaped
+}
+
 func closeSessionBeadIfRuntimeStoppedAndUnassigned(
 	store beads.Store,
 	rigStores map[string]beads.Store,

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -6212,6 +6212,37 @@ func TestSweepProcessTableOrphansNoopsWithoutScanner(t *testing.T) {
 	}
 }
 
+type flakyGetStore struct {
+	beads.Store
+	failID  string
+	failErr error
+}
+
+func (s *flakyGetStore) Get(id string) (beads.Bead, error) {
+	if id == s.failID {
+		return beads.Bead{}, s.failErr
+	}
+	return s.Store.Get(id)
+}
+
+func TestSweepProcessTableOrphansSkipsOnTransientStoreError(t *testing.T) {
+	inner := beads.NewMemStore()
+	store := &flakyGetStore{Store: inner, failID: "gm-flaky", failErr: errors.New("dolt: connection reset")}
+	sp := newProcessTableSweepProvider(
+		runtime.LiveRuntime{SessionID: "gm-flaky", PID: 301, IsTracked: false},
+	)
+	var stderr bytes.Buffer
+	if got := sweepProcessTableOrphans(sp, nil, store, &stderr); got != 0 {
+		t.Fatalf("sweepProcessTableOrphans() = %d, want 0 (transient error must not reap); stderr=%q", got, stderr.String())
+	}
+	if len(sp.terminated) != 0 {
+		t.Fatalf("terminated %v on transient store error, want none", sp.terminated)
+	}
+	if !strings.Contains(stderr.String(), "dolt: connection reset") {
+		t.Fatalf("stderr = %q, want transient error logged", stderr.String())
+	}
+}
+
 func TestControllerRuntimeSweepsProcessTableOrphansAfterClosedBeadReap(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(".", "city_runtime.go"))
 	if err != nil {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"syscall"
 	"testing"
@@ -67,6 +68,45 @@ type deadRuntimeArtifactProvider struct {
 	listErr   error
 	stopped   []string
 	stopCalls map[string]int
+}
+
+type processTableSweepProvider struct {
+	*runtime.Fake
+	runtimes     []runtime.LiveRuntime
+	findErr      error
+	terminateErr map[int]error
+	terminated   []runtime.LiveRuntime
+}
+
+func newProcessTableSweepProvider(runtimes ...runtime.LiveRuntime) *processTableSweepProvider {
+	return &processTableSweepProvider{
+		Fake:         runtime.NewFake(),
+		runtimes:     runtimes,
+		terminateErr: make(map[int]error),
+	}
+}
+
+func (p *processTableSweepProvider) FindRuntimesBySessionID(id string) ([]runtime.LiveRuntime, error) {
+	if id != "" {
+		var filtered []runtime.LiveRuntime
+		for _, live := range p.runtimes {
+			if live.SessionID == id {
+				filtered = append(filtered, live)
+			}
+		}
+		return filtered, p.findErr
+	}
+	out := make([]runtime.LiveRuntime, len(p.runtimes))
+	copy(out, p.runtimes)
+	return out, p.findErr
+}
+
+func (p *processTableSweepProvider) TerminateRuntime(live runtime.LiveRuntime) error {
+	if err := p.terminateErr[live.PID]; err != nil {
+		return err
+	}
+	p.terminated = append(p.terminated, live)
+	return nil
 }
 
 func newDeadRuntimeArtifactProvider() *deadRuntimeArtifactProvider {
@@ -6103,6 +6143,118 @@ func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenRigStoreWorkAssigned(t *
 	if after.Status == "closed" {
 		t.Fatalf("bead status = closed; want still open — closing would orphan rig-store work assigned by session_name %q", "worker-9")
 	}
+}
+
+func TestSweepProcessTableOrphansReapsClosedAndAbsentUntrackedRuntimes(t *testing.T) {
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "gm-open", Status: "open"},
+		{ID: "gm-closed", Status: "closed"},
+		{ID: "gm-tracked-closed", Status: "closed"},
+	}, nil)
+	snapshot := newSessionBeadSnapshot([]beads.Bead{{ID: "gm-open", Status: "open"}})
+	sp := newProcessTableSweepProvider(
+		runtime.LiveRuntime{SessionID: "gm-open", PID: 101, IsTracked: false},
+		runtime.LiveRuntime{SessionID: "gm-closed", PID: 102, IsTracked: false},
+		runtime.LiveRuntime{SessionID: "gm-missing", PID: 103, IsTracked: false},
+		runtime.LiveRuntime{SessionID: "gm-tracked-closed", PID: 104, IsTracked: true},
+	)
+
+	var stderr bytes.Buffer
+	got := sweepProcessTableOrphans(sp, snapshot, store, &stderr)
+	if got != 2 {
+		t.Fatalf("sweepProcessTableOrphans() = %d, want 2; stderr=%q", got, stderr.String())
+	}
+	if got := terminatedSessionIDs(sp.terminated); got != "gm-closed,gm-missing" {
+		t.Fatalf("terminated = %s, want gm-closed,gm-missing", got)
+	}
+	if after, err := store.Get("gm-open"); err != nil || after.Status != "open" {
+		t.Fatalf("open bead mutated: bead=%+v err=%v", after, err)
+	}
+	if after, err := store.Get("gm-closed"); err != nil || after.Status != "closed" {
+		t.Fatalf("closed bead mutated: bead=%+v err=%v", after, err)
+	}
+}
+
+func TestSweepProcessTableOrphansContinuesAfterErrors(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := newProcessTableSweepProvider(
+		runtime.LiveRuntime{SessionID: "gm-reaped", PID: 201, IsTracked: false},
+		runtime.LiveRuntime{SessionID: "gm-term-fails", PID: 202, IsTracked: false},
+	)
+	sp.findErr = errors.New("partial scan failed")
+	sp.terminateErr[202] = errors.New("terminate failed")
+
+	var stderr bytes.Buffer
+	got := sweepProcessTableOrphans(sp, nil, store, &stderr)
+	if got != 1 {
+		t.Fatalf("sweepProcessTableOrphans() = %d, want 1; stderr=%q", got, stderr.String())
+	}
+	if got := terminatedSessionIDs(sp.terminated); got != "gm-reaped" {
+		t.Fatalf("terminated = %s, want gm-reaped", got)
+	}
+	for _, want := range []string{"partial scan failed", "gm-reaped", "gm-term-fails", "terminate failed"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestSweepProcessTableOrphansNoopsWithoutScanner(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := struct{ runtime.Provider }{Provider: runtime.NewFake()}
+	var stderr bytes.Buffer
+
+	if got := sweepProcessTableOrphans(sp, nil, store, &stderr); got != 0 {
+		t.Fatalf("sweepProcessTableOrphans() = %d, want 0", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestControllerRuntimeSweepsProcessTableOrphansAfterClosedBeadReap(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".", "city_runtime.go"))
+	if err != nil {
+		t.Fatalf("read city_runtime.go: %v", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	reapCalls := 0
+	for i, line := range lines {
+		if !strings.Contains(line, "reapRuntimesBoundToClosedBeads(") {
+			continue
+		}
+		reapCalls++
+		sweepLine := nextLineContaining(lines, i, "sweepProcessTableOrphans(")
+		staleReapLine := nextLineContaining(lines, i, "reapStaleSessionBeads(")
+		if sweepLine == -1 {
+			t.Errorf("city_runtime.go:%d closed-bead reap is not followed by process-table orphan sweep", i+1)
+			continue
+		}
+		if staleReapLine != -1 && sweepLine > staleReapLine {
+			t.Errorf("city_runtime.go:%d process-table orphan sweep runs after stale session reap; sweep line=%d stale reap line=%d", i+1, sweepLine+1, staleReapLine+1)
+		}
+	}
+	if reapCalls == 0 {
+		t.Fatal("city_runtime.go contains no reapRuntimesBoundToClosedBeads calls")
+	}
+}
+
+func terminatedSessionIDs(runtimes []runtime.LiveRuntime) string {
+	ids := make([]string, 0, len(runtimes))
+	for _, live := range runtimes {
+		ids = append(ids, live.SessionID)
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
+}
+
+func nextLineContaining(lines []string, after int, needle string) int {
+	for i := after + 1; i < len(lines); i++ {
+		if strings.Contains(lines[i], needle) {
+			return i
+		}
+	}
+	return -1
 }
 
 // TestReapRuntimesBoundToClosedBeadsStopsLiveRuntime reproduces the alias


### PR DESCRIPTION
## Summary
- Add sweepProcessTableOrphans to reap untracked process-table runtimes whose GC_SESSION_ID bead is closed or absent.
- Skip tracked runtimes and open beads; log scan, lookup, and termination errors while continuing partial results.
- Run the sweep after reapRuntimesBoundToClosedBeads in controller startup and tick paths, with a trace phase for tick reconciliation.

Stacked on PR #2837 / branch builder/ga-qmbisj-1-process-scanner.

## Verification
- GOTOOLCHAIN=auto go test ./cmd/gc -run 'TestReapRuntimesBoundToClosedBeads|TestSweepProcessTableOrphans' -count=1
- GOTOOLCHAIN=auto go test ./cmd/gc -run 'TestSweepProcessTableOrphans|TestControllerRuntimeSweepsProcessTableOrphansAfterClosedBeadReap|TestReapRuntimesBoundToClosedBeads' -count=1
- git diff --check
- GOTOOLCHAIN=auto go vet ./cmd/gc
- GOTOOLCHAIN=auto go vet ./...
- make test-fast-parallel with Go 1.26.3 toolchain env
- .githooks/pre-commit ran and passed lint-changed, generated checks, go vet, and make test-fast-parallel