### PR TITLE
fix(dolt): measure doctor probe latency in milliseconds, not whole seconds

### DIFF
--- a/examples/dolt/assets/scripts/latency.sh
+++ b/examples/dolt/assets/scripts/latency.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# latency.sh — millisecond-resolution latency measurement for dolt-pack
+# health probes. Sourced by mol-dog-doctor.sh; unit-tested by
+# test/dolt/latency_test.sh.
+#
+# Replaces whole-second 'date +%s' timing, which quantizes a sub-second probe
+# to 0s or 1s depending on whether it straddles a wall-clock second tick —
+# producing false latency WARNs (and MEDIUM advisory mail) at a 1s threshold.
+
+# now_ms — echo the current time in epoch milliseconds.
+# GNU/coreutils date supports %3N (3-digit nanoseconds = milliseconds). On
+# platforms whose date lacks %N (e.g. BSD/macOS without coreutils), fall back
+# to second-resolution * 1000 — no worse than the prior whole-second behavior.
+now_ms() {
+  _now_ms_v=$(date +%s%3N 2>/dev/null)
+  case "$_now_ms_v" in
+    ''|*[!0-9]*) _now_ms_v="" ;;   # %3N printed literally: no ms support
+  esac
+  if [ -n "$_now_ms_v" ] && [ "${#_now_ms_v}" -ge 13 ]; then
+    printf '%s\n' "$_now_ms_v"     # epoch-ms is 13+ digits from 2001..2286
+  else
+    printf '%s\n' "$(( $(date +%s) * 1000 ))"
+  fi
+}
+
+# latency_should_warn ELAPSED_MS THRESHOLD_MS — exit 0 (warn) when measured
+# latency meets or exceeds the threshold, 1 otherwise. Preserves the original
+# '>=' semantics, now in milliseconds.
+latency_should_warn() {
+  [ "${1:-0}" -ge "${2:-0}" ]
+}

--- a/examples/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/dolt/assets/scripts/mol-dog-doctor.sh
@@ -10,11 +10,15 @@ set -euo pipefail
 
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
+. "$PACK_DIR/assets/scripts/latency.sh"
 
 PORT="$GC_DOLT_PORT"
 HOST="${GC_DOLT_HOST:-127.0.0.1}"
 USER="${GC_DOLT_USER:-root}"
-LATENCY_WARN_S="${GC_DOCTOR_LATENCY_WARN_S:-1}"
+# Latency warn threshold in milliseconds. GC_DOCTOR_LATENCY_WARN_MS takes
+# precedence; otherwise derive from the legacy seconds knob (default 1s ->
+# 1000ms) for backward compatibility.
+LATENCY_WARN_MS="${GC_DOCTOR_LATENCY_WARN_MS:-$(( ${GC_DOCTOR_LATENCY_WARN_S:-1} * 1000 ))}"
 CONN_MAX="${GC_DOCTOR_CONN_MAX:-50}"
 CONN_WARN_PCT="${GC_DOCTOR_CONN_WARN_PCT:-80}"
 BACKUP_STALE_S="${GC_DOCTOR_BACKUP_STALE_S:-43200}"  # 2x 6h backup interval
@@ -85,7 +89,7 @@ send_mayor_mail() {
 
 # --- Step 1: Probe connectivity and measure latency ---
 
-PROBE_START=$(date +%s)
+PROBE_START_MS=$(now_ms)
 if ! dolt_sql -q "SELECT active_branch()" >/dev/null 2>&1; then
     if send_mayor_mail \
         -s "ESCALATION: Dolt server unreachable on port $PORT [CRITICAL]" \
@@ -98,11 +102,11 @@ if ! dolt_sql -q "SELECT active_branch()" >/dev/null 2>&1; then
     fi
     exit 0
 fi
-PROBE_END=$(date +%s)
-LATENCY_S=$((PROBE_END - PROBE_START))
+PROBE_END_MS=$(now_ms)
+LATENCY_MS=$((PROBE_END_MS - PROBE_START_MS))
 LATENCY_WARN=""
-if [ "$LATENCY_S" -ge "$LATENCY_WARN_S" ]; then
-    LATENCY_WARN=" [WARN: latency ${LATENCY_S}s >= threshold ${LATENCY_WARN_S}s]"
+if latency_should_warn "$LATENCY_MS" "$LATENCY_WARN_MS"; then
+    LATENCY_WARN=" [WARN: latency ${LATENCY_MS}ms >= threshold ${LATENCY_WARN_MS}ms]"
 fi
 
 # --- Step 2: Check resource conditions ---
@@ -175,7 +179,7 @@ WARNINGS="${LATENCY_WARN}${CONN_WARN}${ORPHAN_WARN}${BACKUP_STALE}"
 if [ -n "$WARNINGS" ]; then
     if ! send_mayor_mail \
         -s "Dolt health advisory [MEDIUM]" \
-        -m "Latency: ${LATENCY_S}s${LATENCY_WARN}
+        -m "Latency: ${LATENCY_MS}ms${LATENCY_WARN}
 Connections: ${CONN_COUNT}/${CONN_MAX}${CONN_WARN}
 Disk: ${DISK_USAGE}
 Orphan DBs: ${ORPHAN_COUNT}${ORPHAN_WARN}${BACKUP_STALE}"; then
@@ -183,6 +187,6 @@ Orphan DBs: ${ORPHAN_COUNT}${ORPHAN_WARN}${BACKUP_STALE}"; then
     fi
 fi
 
-SUMMARY="doctor — server: ok, latency: ${LATENCY_S}s, conns: ${CONN_COUNT}/${CONN_MAX}, disk: ${DISK_USAGE}, orphans: ${ORPHAN_COUNT}"
+SUMMARY="doctor — server: ok, latency: ${LATENCY_MS}ms, conns: ${CONN_COUNT}/${CONN_MAX}, disk: ${DISK_USAGE}, orphans: ${ORPHAN_COUNT}"
 gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "doctor: $SUMMARY"

--- a/test/dolt/latency_test.sh
+++ b/test/dolt/latency_test.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Unit test for examples/dolt/assets/scripts/latency.sh.
+#
+# Proves the fix for the whole-second latency bug in mol-dog-doctor.sh:
+# (a) now_ms has sub-second resolution, (b) the warn decision does not
+# false-trip on a fast (sub-second) probe but still fires on real slowness.
+#
+# Run: sh test/dolt/latency_test.sh
+set -u
+HERE=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+LATENCY_LIB="${LATENCY_LIB:-$HERE/../../examples/dolt/assets/scripts/latency.sh}"
+
+if [ ! -f "$LATENCY_LIB" ]; then
+  echo "FAIL: latency helper not found at $LATENCY_LIB"
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$LATENCY_LIB"
+
+fail=0
+pass() { echo "PASS: $1"; }
+bad()  { echo "FAIL: $1"; fail=1; }
+
+command -v now_ms >/dev/null 2>&1 || { echo "FAIL: now_ms not defined"; exit 1; }
+command -v latency_should_warn >/dev/null 2>&1 || { echo "FAIL: latency_should_warn not defined"; exit 1; }
+
+# now_ms has sub-second resolution. A 50ms sleep must measure in a sub-second
+# band; a whole-second clock yields 0 or 1000 — both fail this.
+s=$(now_ms); sleep 0.05; e=$(now_ms); d=$((e - s))
+if [ "$d" -ge 5 ] && [ "$d" -le 800 ]; then
+  pass "now_ms sub-second resolution (${d}ms for a 50ms sleep)"
+else
+  bad "now_ms resolution: got ${d}ms, want 5..800 (whole-second clock yields 0 or 1000)"
+fi
+
+# A fast probe does NOT warn at the default 1000ms threshold.
+if latency_should_warn 50 1000; then bad "50ms probe warned at 1000ms threshold (false positive)"; else pass "50ms probe -> no warn"; fi
+
+# A genuinely slow probe warns.
+if latency_should_warn 1500 1000; then pass "1500ms probe -> warn"; else bad "1500ms probe did not warn"; fi
+
+# Boundary equality warns (>= semantics preserved).
+if latency_should_warn 1000 1000; then pass "1000ms == threshold -> warn"; else bad "boundary 1000ms did not warn"; fi
+
+# Regression of the original bug — 30 fast probes must NEVER false-warn.
+i=0; warned=0
+while [ "$i" -lt 30 ]; do
+  s=$(now_ms); sleep 0.02; e=$(now_ms)
+  if latency_should_warn $((e - s)) 1000; then warned=$((warned + 1)); fi
+  i=$((i + 1))
+done
+if [ "$warned" -eq 0 ]; then pass "30 fast probes -> 0 false warns"; else bad "$warned/30 fast probes false-warned"; fi
+
+echo "----"
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "FAILURES PRESENT"; fi
+exit "$fail"


### PR DESCRIPTION
## Problem

`examples/dolt/assets/scripts/mol-dog-doctor.sh` (the `mol-dog-doctor` order, 5-minute interval) times its Dolt health probe at **whole-second** resolution:

```sh
PROBE_START=$(date +%s)
... probe ...
PROBE_END=$(date +%s)
LATENCY_S=$((PROBE_END - PROBE_START))
if [ "$LATENCY_S" -ge "$LATENCY_WARN_S" ]; then   # default threshold: 1
```

A probe that actually takes tens-to-hundreds of ms reads `0s` normally, but `1s` whenever it straddles a wall-clock second tick. With the default `GC_DOCTOR_LATENCY_WARN_S=1` and `>=`, **every straddle trips a MEDIUM "Dolt health advisory"** mailed to the Mayor — a false positive that reflects clock quantization, not server health. (The deacon's own health rubric treats `> 5s` as the real concern.)

### Observed impact
On an idle, healthy city this produced **67 false advisories over 2 days**, flooding the Mayor's inbox and inflating JSONL export growth.

## Fix

Measure latency in **milliseconds**. New `examples/dolt/assets/scripts/latency.sh`:
- `now_ms` — epoch ms via `date +%s%3N`, with a fallback to second-resolution × 1000 on platforms whose `date` lacks `%N` (e.g. BSD/macOS without coreutils) — no worse than current behavior there.
- `latency_should_warn ELAPSED_MS THRESHOLD_MS` — preserves the original `>=` semantics, in ms.

`mol-dog-doctor.sh` sources the helper and decides the warn in ms. **Backward compatible**: the legacy `GC_DOCTOR_LATENCY_WARN_S` knob still works (1s → 1000ms); a new `GC_DOCTOR_LATENCY_WARN_MS` takes precedence. A genuine ≥1s probe still warns; a 200ms probe no longer does.

## Proof

**Unit test** (`test/dolt/latency_test.sh`, new) — sub-second resolution + warn decision:
```
PASS: now_ms sub-second resolution (63ms for a 50ms sleep)
PASS: 50ms probe -> no warn
PASS: 1500ms probe -> warn
PASS: 1000ms == threshold -> warn
PASS: 30 fast probes -> 0 false warns
```

**Live before/after** against a real Dolt server (same probes, both timing methods side by side):
```
probe  3: OLD=1s->WARN   NEW=178ms->ok
probe  9: OLD=1s->WARN   NEW=238ms->ok
probe 13: OLD=1s->WARN   NEW=180ms->ok
...
OLD whole-second method: 3/16 probes -> false advisory
NEW millisecond method:  0/16 probes -> no warn
```
True probe latencies were 87–323ms; the OLD method read "1s" only on the three that straddled a tick.

## Notes
- `shellcheck` isn't available in my environment, so I couldn't run it locally; `bash -n` / `sh -n` pass on all three files.
- Diff is 99 insertions / 8 deletions across the helper, the doctor patch, and the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
