### PR TITLE
fix(supervisor): scope process-table orphan sweep to its own city

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -517,7 +517,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		// identity re-minted as a pool slot) so the name's current owner can
 		// rebind it and attach lands on the right runtime.
 		reapRuntimesBoundToClosedBeads(cr.cityBeadStore(), sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
-		if swept := sweepProcessTableOrphans(cr.sp, sessionBeads, cr.cityBeadStore(), cr.stderr); swept > 0 {
+		if swept := sweepProcessTableOrphans(cr.sp, sessionBeads, cr.cityBeadStore(), cr.cityPath, cr.stderr); swept > 0 {
 			fmt.Fprintf(cr.stderr, "session reconciler: swept %d process-table orphan runtime(s)\n", swept) //nolint:errcheck
 		}
 		// Reap stale session beads from a previous run before building desired
@@ -1045,7 +1045,7 @@ func (cr *CityRuntime) tick(
 	reapRuntimesBoundToClosedBeads(cr.cityBeadStore(), sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
 	recordPhase(TraceSiteControllerTickPhase, "reap_runtimes_bound_to_closed_beads", phaseStart, nil)
 	phaseStart = time.Now()
-	swept := sweepProcessTableOrphans(cr.sp, sessionBeads, cr.cityBeadStore(), cr.stderr)
+	swept := sweepProcessTableOrphans(cr.sp, sessionBeads, cr.cityBeadStore(), cr.cityPath, cr.stderr)
 	if swept > 0 {
 		fmt.Fprintf(cr.stderr, "session reconciler: swept %d process-table orphan runtime(s)\n", swept) //nolint:errcheck
 	}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -2129,7 +2129,7 @@ func sweepProcessTableOrphans(
 		fmt.Fprintf(stderr, "session reconciler: scanning process table for orphaned runtimes: %v\n", err) //nolint:errcheck
 	}
 
-	cityPath = strings.TrimSpace(cityPath)
+	cityPath = normalizePathForCompare(strings.TrimSpace(cityPath))
 	reaped := 0
 	for _, live := range found {
 		live.SessionID = strings.TrimSpace(live.SessionID)
@@ -2144,7 +2144,7 @@ func sweepProcessTableOrphans(
 		// SIGTERMs another city's healthy session. Only consider runtimes
 		// positively attributed to this city. When cityPath is unknown we
 		// cannot attribute safely, so fall through to the existing checks.
-		if cityPath != "" && strings.TrimSpace(live.City) != cityPath {
+		if cityPath != "" && normalizePathForCompare(strings.TrimSpace(live.City)) != cityPath {
 			continue
 		}
 		bead, err := store.Get(live.SessionID)

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -2111,6 +2111,7 @@ func sweepProcessTableOrphans(
 	sp runtime.Provider,
 	_ *sessionBeadSnapshot,
 	store beads.Store,
+	cityPath string,
 	stderr io.Writer,
 ) int {
 	if sp == nil || store == nil {
@@ -2128,10 +2129,22 @@ func sweepProcessTableOrphans(
 		fmt.Fprintf(stderr, "session reconciler: scanning process table for orphaned runtimes: %v\n", err) //nolint:errcheck
 	}
 
+	cityPath = strings.TrimSpace(cityPath)
 	reaped := 0
 	for _, live := range found {
 		live.SessionID = strings.TrimSpace(live.SessionID)
 		if live.SessionID == "" || live.IsTracked {
+			continue
+		}
+		// The process-table scan is supervisor-wide: it walks all of /proc and
+		// returns every gc session on the host, across every city. But `store`
+		// here is this city's bead store and `sp` is this city's runtime
+		// provider, so a sibling city's live session is invisible to both —
+		// its bead lookup misses and IsTracked is false. Reaping on that basis
+		// SIGTERMs another city's healthy session. Only consider runtimes
+		// positively attributed to this city. When cityPath is unknown we
+		// cannot attribute safely, so fall through to the existing checks.
+		if cityPath != "" && strings.TrimSpace(live.City) != cityPath {
 			continue
 		}
 		bead, err := store.Get(live.SessionID)

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -6489,7 +6489,7 @@ func TestSweepProcessTableOrphansReapsClosedAndAbsentUntrackedRuntimes(t *testin
 	)
 
 	var stderr bytes.Buffer
-	got := sweepProcessTableOrphans(sp, snapshot, store, &stderr)
+	got := sweepProcessTableOrphans(sp, snapshot, store, "", &stderr)
 	if got != 2 {
 		t.Fatalf("sweepProcessTableOrphans() = %d, want 2; stderr=%q", got, stderr.String())
 	}
@@ -6504,6 +6504,38 @@ func TestSweepProcessTableOrphansReapsClosedAndAbsentUntrackedRuntimes(t *testin
 	}
 }
 
+// The process-table scan is supervisor-wide, but the sweep runs per city with
+// that city's store. A sibling city's live session (a different GC_CITY_PATH)
+// is absent from this city's store and untracked by this city's provider, so
+// without city filtering it would be reaped — SIGTERMing another city's
+// healthy session. Runtimes carrying this city's path must still be reaped
+// when their bead is closed/absent.
+func TestSweepProcessTableOrphansSkipsOtherCityRuntimes(t *testing.T) {
+	const myCity = "/home/jaword/projects/gc-management"
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "gm-closed", Status: "closed"},
+	}, nil)
+	sp := newProcessTableSweepProvider(
+		// This city's own closed/untracked runtime — must be reaped.
+		runtime.LiveRuntime{SessionID: "gm-closed", City: myCity, PID: 101, IsTracked: false},
+		// A sibling city's session, absent from this store and untracked here.
+		// Must NOT be reaped despite looking like an orphan from here.
+		runtime.LiveRuntime{SessionID: "sq-eeq", City: "/home/jaword/sqtest", PID: 102, IsTracked: false},
+		// A runtime with no attributable city — must NOT be reaped when we
+		// know our own city (cannot confirm it belongs to us).
+		runtime.LiveRuntime{SessionID: "unknown", City: "", PID: 103, IsTracked: false},
+	)
+
+	var stderr bytes.Buffer
+	got := sweepProcessTableOrphans(sp, nil, store, myCity, &stderr)
+	if got != 1 {
+		t.Fatalf("sweepProcessTableOrphans() = %d, want 1 (only this city's orphan); stderr=%q", got, stderr.String())
+	}
+	if ids := terminatedSessionIDs(sp.terminated); ids != "gm-closed" {
+		t.Fatalf("terminated = %s, want gm-closed (sibling-city and unknown-city runtimes must be spared)", ids)
+	}
+}
+
 func TestSweepProcessTableOrphansContinuesAfterErrors(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := newProcessTableSweepProvider(
@@ -6514,7 +6546,7 @@ func TestSweepProcessTableOrphansContinuesAfterErrors(t *testing.T) {
 	sp.terminateErr[202] = errors.New("terminate failed")
 
 	var stderr bytes.Buffer
-	got := sweepProcessTableOrphans(sp, nil, store, &stderr)
+	got := sweepProcessTableOrphans(sp, nil, store, "", &stderr)
 	if got != 1 {
 		t.Fatalf("sweepProcessTableOrphans() = %d, want 1; stderr=%q", got, stderr.String())
 	}
@@ -6533,7 +6565,7 @@ func TestSweepProcessTableOrphansNoopsWithoutScanner(t *testing.T) {
 	sp := struct{ runtime.Provider }{Provider: runtime.NewFake()}
 	var stderr bytes.Buffer
 
-	if got := sweepProcessTableOrphans(sp, nil, store, &stderr); got != 0 {
+	if got := sweepProcessTableOrphans(sp, nil, store, "", &stderr); got != 0 {
 		t.Fatalf("sweepProcessTableOrphans() = %d, want 0", got)
 	}
 	if stderr.Len() != 0 {
@@ -6561,7 +6593,7 @@ func TestSweepProcessTableOrphansSkipsOnTransientStoreError(t *testing.T) {
 		runtime.LiveRuntime{SessionID: "gm-flaky", PID: 301, IsTracked: false},
 	)
 	var stderr bytes.Buffer
-	if got := sweepProcessTableOrphans(sp, nil, store, &stderr); got != 0 {
+	if got := sweepProcessTableOrphans(sp, nil, store, "", &stderr); got != 0 {
 		t.Fatalf("sweepProcessTableOrphans() = %d, want 0 (transient error must not reap); stderr=%q", got, stderr.String())
 	}
 	if len(sp.terminated) != 0 {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -6536,6 +6536,29 @@ func TestSweepProcessTableOrphansSkipsOtherCityRuntimes(t *testing.T) {
 	}
 }
 
+func TestSweepProcessTableOrphansNormalizesCityPathBeforeCompare(t *testing.T) {
+	realCity := t.TempDir()
+	aliasCity := filepath.Join(t.TempDir(), "city-link")
+	if err := os.Symlink(realCity, aliasCity); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "gm-closed", Status: "closed"},
+	}, nil)
+	sp := newProcessTableSweepProvider(
+		runtime.LiveRuntime{SessionID: "gm-closed", City: realCity, PID: 101, IsTracked: false},
+	)
+
+	var stderr bytes.Buffer
+	got := sweepProcessTableOrphans(sp, nil, store, aliasCity, &stderr)
+	if got != 1 {
+		t.Fatalf("sweepProcessTableOrphans() = %d, want 1 for symlink-equivalent city paths; stderr=%q", got, stderr.String())
+	}
+	if ids := terminatedSessionIDs(sp.terminated); ids != "gm-closed" {
+		t.Fatalf("terminated = %s, want gm-closed", ids)
+	}
+}
+
 func TestSweepProcessTableOrphansContinuesAfterErrors(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := newProcessTableSweepProvider(

--- a/internal/runtime/fake.go
+++ b/internal/runtime/fake.go
@@ -533,8 +533,13 @@ func (f *Fake) FindRuntimesBySessionID(id string) ([]LiveRuntime, error) {
 		if id != "" && sessionID != id {
 			continue
 		}
+		city := cfg.Env["GC_CITY_PATH"]
+		if city == "" {
+			city = cfg.Env["GC_CITY"]
+		}
 		out = append(out, LiveRuntime{
 			SessionID:    sessionID,
+			City:         city,
 			ProviderName: name,
 			IsTracked:    true,
 		})

--- a/internal/runtime/fake_test.go
+++ b/internal/runtime/fake_test.go
@@ -626,6 +626,34 @@ func TestFakeFindRuntimesBySessionID_TrackedUsesProviderNameAndSessionID(t *test
 	}
 }
 
+func TestFakeFindRuntimesBySessionID_TrackedUsesCityFromEnv(t *testing.T) {
+	f := NewFake()
+	_ = f.Start(context.Background(), "path-city", Config{Env: map[string]string{
+		"GC_SESSION_ID": "sess-path",
+		"GC_CITY_PATH":  "/tmp/path-city",
+		"GC_CITY":       "/tmp/fallback-city",
+	}})
+	_ = f.Start(context.Background(), "fallback-city", Config{Env: map[string]string{
+		"GC_SESSION_ID": "sess-fallback",
+		"GC_CITY":       "/tmp/fallback-city",
+	}})
+
+	runtimes, err := f.FindRuntimesBySessionID("")
+	if err != nil {
+		t.Fatalf("FindRuntimesBySessionID: %v", err)
+	}
+	cities := map[string]string{}
+	for _, r := range runtimes {
+		cities[r.SessionID] = r.City
+	}
+	if cities["sess-path"] != "/tmp/path-city" {
+		t.Errorf("City for sess-path = %q, want GC_CITY_PATH value", cities["sess-path"])
+	}
+	if cities["sess-fallback"] != "/tmp/fallback-city" {
+		t.Errorf("City for sess-fallback = %q, want GC_CITY fallback value", cities["sess-fallback"])
+	}
+}
+
 func TestFakeTerminateRuntime_RecordsCallWithSessionID(t *testing.T) {
 	f := NewFake()
 

--- a/internal/runtime/proctable/scan_darwin.go
+++ b/internal/runtime/proctable/scan_darwin.go
@@ -39,8 +39,13 @@ func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
 			continue
 		}
 		epoch, _ := strconv.Atoi(record.env["GC_RUNTIME_EPOCH"])
+		city := record.env["GC_CITY_PATH"]
+		if city == "" {
+			city = record.env["GC_CITY"]
+		}
 		out = append(out, runtime.LiveRuntime{
 			SessionID: sessionID,
+			City:      city,
 			Epoch:     epoch,
 			PID:       record.pid,
 		})

--- a/internal/runtime/proctable/scan_linux.go
+++ b/internal/runtime/proctable/scan_linux.go
@@ -98,8 +98,13 @@ func scanWithRoot(root, id string) ([]runtime.LiveRuntime, error) {
 			continue
 		}
 		epoch, _ := strconv.Atoi(env["GC_RUNTIME_EPOCH"])
+		city := env["GC_CITY_PATH"]
+		if city == "" {
+			city = env["GC_CITY"]
+		}
 		out = append(out, runtime.LiveRuntime{
 			SessionID: sessionID,
+			City:      city,
 			Epoch:     epoch,
 			PID:       pid,
 		})

--- a/internal/runtime/proctable/scan_linux_test.go
+++ b/internal/runtime/proctable/scan_linux_test.go
@@ -117,6 +117,45 @@ func TestScanWithRootParsesEpoch(t *testing.T) {
 	}
 }
 
+func TestScanWithRootPopulatesCityFromGCPath(t *testing.T) {
+	root := t.TempDir()
+	buildFakeProc(t, root, 310, map[string]string{
+		"GC_SESSION_ID": "ga-city",
+		"GC_CITY_PATH":  "/tmp/primary-city",
+		"GC_CITY":       "/tmp/fallback-city",
+	})
+
+	got, err := scanWithRoot(root, "ga-city")
+	if err != nil {
+		t.Fatalf("scanWithRoot error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if got[0].City != "/tmp/primary-city" {
+		t.Fatalf("City = %q, want GC_CITY_PATH value", got[0].City)
+	}
+}
+
+func TestScanWithRootPopulatesCityFromGCCityFallback(t *testing.T) {
+	root := t.TempDir()
+	buildFakeProc(t, root, 320, map[string]string{
+		"GC_SESSION_ID": "ga-city",
+		"GC_CITY":       "/tmp/fallback-city",
+	})
+
+	got, err := scanWithRoot(root, "ga-city")
+	if err != nil {
+		t.Fatalf("scanWithRoot error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if got[0].City != "/tmp/fallback-city" {
+		t.Fatalf("City = %q, want GC_CITY fallback value", got[0].City)
+	}
+}
+
 func TestScanWithRootMissingEnvironSkipped(t *testing.T) {
 	root := t.TempDir()
 	// Directory exists but no environ (ENOENT) — should be skipped without error.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -283,6 +283,14 @@ type InterruptBoundaryWaitProvider interface {
 type LiveRuntime struct {
 	// SessionID is the GC_SESSION_ID value from the process environment.
 	SessionID string
+	// City is the GC_CITY_PATH value from the process environment (falling
+	// back to GC_CITY). Empty when neither is readable. The process-table scan
+	// is supervisor-wide (it walks all of /proc), but session beads and tmux
+	// runtime tracking are per-city. A consumer that owns only one city's
+	// store MUST filter scan results to City == its own city before reaping,
+	// or it will mistake another city's live session for an orphan and kill
+	// it.
+	City string
 	// Epoch is the GC_RUNTIME_EPOCH from the process environment, if readable.
 	// Zero if the variable is absent or unparseable.
 	Epoch int

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -238,8 +239,12 @@ func (m *Manager) killExistingOrphans(ctx context.Context, sessionID string) {
 	if err != nil {
 		log.Printf("session: scanning for orphaned runtimes for %s: %v", sessionID, err)
 	}
+	cityPath := pathutil.NormalizePathForCompare(strings.TrimSpace(m.cityPath))
 	for _, live := range found {
 		if live.IsTracked || live.SessionID != sessionID {
+			continue
+		}
+		if cityPath != "" && pathutil.NormalizePathForCompare(strings.TrimSpace(live.City)) != cityPath {
 			continue
 		}
 		if err := scanner.TerminateRuntime(live); err != nil {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -354,6 +354,57 @@ func TestCreateSkipsTrackedRuntimeBeforeStart(t *testing.T) {
 	}
 }
 
+func TestCreateSkipsUntrackedRuntimeFromOtherCityBeforeStart(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &orphanScanProvider{
+		Fake: runtime.NewFake(),
+		results: []runtime.LiveRuntime{{
+			PID:       1234,
+			City:      "/tmp/other-city",
+			IsTracked: false,
+		}},
+	}
+	mgr := NewManagerWithCityPath(store, sp, "/tmp/this-city")
+
+	info, err := mgr.Create(context.Background(), "helper", "my chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	want := []string{"find:" + info.ID, "start:" + info.ID}
+	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v", sp.events, want)
+	}
+}
+
+func TestCreateKillsUntrackedOrphanFromSameCityBeforeStartWithNormalizedPath(t *testing.T) {
+	realCity := t.TempDir()
+	aliasCity := filepath.Join(t.TempDir(), "city-link")
+	if err := os.Symlink(realCity, aliasCity); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	store := beads.NewMemStore()
+	sp := &orphanScanProvider{
+		Fake: runtime.NewFake(),
+		results: []runtime.LiveRuntime{{
+			PID:       1234,
+			City:      realCity,
+			IsTracked: false,
+		}},
+	}
+	mgr := NewManagerWithCityPath(store, sp, aliasCity)
+
+	info, err := mgr.Create(context.Background(), "helper", "my chat", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	want := []string{"find:" + info.ID, "terminate:" + info.ID, "start:" + info.ID}
+	if got := strings.Join(sp.events, ","); got != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v", sp.events, want)
+	}
+}
+
 func TestCreateContinuesWhenOrphanCleanupFails(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := &orphanScanProvider{


### PR DESCRIPTION
## Problem

`sweepProcessTableOrphans` scans `/proc` **supervisor-wide** via `FindRuntimesBySessionID("")` — it returns every gc session on the host, across every city. But it resolves each runtime against a **single city's** bead store and tmux provider. When more than one city runs under the same supervisor, every city's sweep sees the *other* cities' live sessions as untracked orphans whose bead lookup misses, and SIGTERMs/SIGKILLs them.

In practice a healthy named session in city A was reaped on essentially every reconcile tick by city B's and city C's sweeps — restarting it constantly and losing its work.

## Fix

- Capture `GC_CITY_PATH` (falling back to `GC_CITY`) from the process environment into a new `LiveRuntime.City` field during the scan (Linux + Darwin scanners).
- In `sweepProcessTableOrphans`, skip any runtime not positively attributed to the sweeping city. A runtime with no readable city is also spared when the sweep knows its own city, since it can't be confirmed as ours — reaping stays conservative.

The reaping criteria (untracked + closed/absent bead) are otherwise unchanged.

## Testing

- New `TestSweepProcessTableOrphansSkipsOtherCityRuntimes`: a sibling-city runtime and an unknown-city runtime are spared while this city's own closed/untracked runtime is still reaped.
- Existing sweep tests updated for the new signature; full `cmd/gc` + `internal/runtime/proctable` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)