### PR TITLE
fix(session): fall back to a clean fresh start when the resume key diverged

### DIFF
--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -64,6 +64,38 @@ func stripResumeFlag(cmd, resumeFlag, sessionKey string) string {
 	return strings.TrimSpace(result)
 }
 
+// stripResumeFlagArg removes resumeFlag and the single whitespace-delimited
+// token that immediately follows it from cmd, regardless of that token's
+// value. It is the value-agnostic fallback for stripResumeFlag: when the
+// session_key embedded in the resume command at build time has diverged from
+// the bead's current session_key — a concurrent fresh start minted a new key,
+// or a stale store read — the keyed strip is a no-op, and we must still produce
+// a clean fresh-start command rather than wedge the session. Returns cmd
+// unchanged when resumeFlag is not present as a standalone token with a
+// following argument (in which case the command already carries no resume key
+// and is itself a valid fresh-start command).
+func stripResumeFlagArg(cmd, resumeFlag string) string {
+	if resumeFlag == "" {
+		return cmd
+	}
+	needle := resumeFlag + " "
+	idx := strings.Index(cmd, needle)
+	if idx < 0 || (idx > 0 && cmd[idx-1] != ' ') {
+		return cmd
+	}
+	rest := strings.TrimLeft(cmd[idx+len(needle):], " ")
+	if sp := strings.IndexByte(rest, ' '); sp >= 0 {
+		rest = rest[sp+1:]
+	} else {
+		rest = ""
+	}
+	result := strings.TrimRight(cmd[:idx], " ")
+	if rest != "" {
+		result = result + " " + rest
+	}
+	return strings.TrimSpace(result)
+}
+
 func (m *Manager) clearStaleResumeMetadata(id string, b *beads.Bead) error {
 	if err := m.store.SetMetadata(id, "session_key", ""); err != nil {
 		return fmt.Errorf("clearing stale resume metadata session_key: %w", err)
@@ -106,15 +138,20 @@ func (m *Manager) retryFreshStartAfterStaleKey(
 	// An empty resume_flag means the command was never resume-capable
 	// (e.g. a named-always session whose start command carries no
 	// --resume-style flag). stripResumeFlag is intentionally a no-op in
-	// that case, so refusing to retry would leave the session stuck.
-	// Only treat the no-op as an error when resume_flag was non-empty
-	// but the strip still found nothing — that signals an inconsistency
-	// between the bead metadata and the actual resume command.
+	// that case, and the command is already a valid fresh start.
+	//
+	// A non-empty resume_flag whose keyed strip was a no-op means the
+	// session_key embedded in resumeCommand diverged from the bead's
+	// current session_key (a concurrent fresh start minted a new key, or a
+	// stale store read). Fall back to a value-agnostic strip so we still
+	// produce a clean fresh-start command. Refusing to retry here is what
+	// wedged the session into a respawn/SIGTERM loop: the embedded resume
+	// key was always stale, the keyed strip could never match it, and the
+	// dead remain-on-exit pane lingered because we returned before
+	// killExistingOrphans. If even the generic strip finds nothing, the
+	// command carries no resume flag and is itself a fresh-start command.
 	if resumeFlag != "" && freshCmd == resumeCommand {
-		if unroute != nil {
-			unroute()
-		}
-		return false, fmt.Errorf("fresh start after stale key: resume command could not be stripped")
+		freshCmd = stripResumeFlagArg(resumeCommand, resumeFlag)
 	}
 	cfg.Command = freshCmd
 	m.killExistingOrphans(ctx, id)

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -64,36 +64,77 @@ func stripResumeFlag(cmd, resumeFlag, sessionKey string) string {
 	return strings.TrimSpace(result)
 }
 
-// stripResumeFlagArg removes resumeFlag and the single whitespace-delimited
-// token that immediately follows it from cmd, regardless of that token's
-// value. It is the value-agnostic fallback for stripResumeFlag: when the
-// session_key embedded in the resume command at build time has diverged from
-// the bead's current session_key — a concurrent fresh start minted a new key,
-// or a stale store read — the keyed strip is a no-op, and we must still produce
-// a clean fresh-start command rather than wedge the session. Returns cmd
-// unchanged when resumeFlag is not present as a standalone token with a
-// following argument (in which case the command already carries no resume key
-// and is itself a valid fresh-start command).
-func stripResumeFlagArg(cmd, resumeFlag string) string {
+// stripResumeFlagArg removes the generated resume flag/key pair from cmd,
+// regardless of the key's value. It is the value-agnostic fallback for
+// stripResumeFlag: when the session_key embedded in the resume command at build
+// time has diverged from the bead's current session_key — a concurrent fresh
+// start minted a new key, or a stale store read — the keyed strip is a no-op,
+// and we must still produce a clean fresh-start command rather than wedge the
+// session. Returns cmd unchanged when the generated resume shape is not present
+// (in which case the command already carries no generated resume key and is
+// itself a valid fresh-start command).
+func stripResumeFlagArg(cmd, resumeFlag, resumeStyle string) string {
 	if resumeFlag == "" {
 		return cmd
 	}
-	needle := resumeFlag + " "
-	idx := strings.Index(cmd, needle)
-	if idx < 0 || (idx > 0 && cmd[idx-1] != ' ') {
+	if resumeStyle == "subcommand" {
+		return stripInsertedResumeSubcommandArg(cmd, resumeFlag)
+	}
+	return stripTrailingResumeFlagArg(cmd, resumeFlag)
+}
+
+func stripTrailingResumeFlagArg(cmd, resumeFlag string) string {
+	trimmed := strings.TrimRight(cmd, " ")
+	keyStart := strings.LastIndexByte(trimmed, ' ')
+	if keyStart < 0 {
 		return cmd
 	}
-	rest := strings.TrimLeft(cmd[idx+len(needle):], " ")
-	if sp := strings.IndexByte(rest, ' '); sp >= 0 {
-		rest = rest[sp+1:]
-	} else {
-		rest = ""
+	beforeKey := strings.TrimRight(trimmed[:keyStart], " ")
+	flagStart := strings.LastIndexByte(beforeKey, ' ')
+	if flagStart < 0 {
+		return cmd
 	}
-	result := strings.TrimRight(cmd[:idx], " ")
-	if rest != "" {
-		result = result + " " + rest
+	if beforeKey[flagStart+1:] != resumeFlag {
+		return cmd
 	}
-	return strings.TrimSpace(result)
+	return strings.TrimSpace(beforeKey[:flagStart])
+}
+
+func stripInsertedResumeSubcommandArg(cmd, resumeFlag string) string {
+	trimmed := strings.TrimSpace(cmd)
+	binaryEnd := strings.IndexByte(trimmed, ' ')
+	if binaryEnd < 0 {
+		return cmd
+	}
+	binary := trimmed[:binaryEnd]
+	rest := strings.TrimLeft(trimmed[binaryEnd+1:], " ")
+	needle := resumeFlag + " "
+	if !strings.HasPrefix(rest, needle) {
+		return cmd
+	}
+	afterFlag := strings.TrimLeft(rest[len(needle):], " ")
+	keyEnd := strings.IndexByte(afterFlag, ' ')
+	if keyEnd < 0 {
+		return binary
+	}
+	afterKey := strings.TrimLeft(afterFlag[keyEnd+1:], " ")
+	if afterKey == "" {
+		return binary
+	}
+	return strings.TrimSpace(binary + " " + afterKey)
+}
+
+func freshStartCommandFromMetadata(metadata map[string]string, fallback string) string {
+	if metadata == nil {
+		return fallback
+	}
+	if cmd := metadata["command"]; cmd != "" {
+		return cmd
+	}
+	if provider := metadata["provider"]; provider != "" {
+		return provider
+	}
+	return fallback
 }
 
 func (m *Manager) clearStaleResumeMetadata(id string, b *beads.Bead) error {
@@ -151,7 +192,13 @@ func (m *Manager) retryFreshStartAfterStaleKey(
 	// killExistingOrphans. If even the generic strip finds nothing, the
 	// command carries no resume flag and is itself a fresh-start command.
 	if resumeFlag != "" && freshCmd == resumeCommand {
-		freshCmd = stripResumeFlagArg(resumeCommand, resumeFlag)
+		if b.Metadata["resume_command"] != "" {
+			log.Printf("session: resume key for %q diverged from explicit resume_command; falling back to stored start command", id)
+			freshCmd = freshStartCommandFromMetadata(b.Metadata, resumeCommand)
+		} else {
+			log.Printf("session: resume key for %q diverged from bead metadata; falling back to generated resume strip", id)
+			freshCmd = stripResumeFlagArg(resumeCommand, resumeFlag, b.Metadata["resume_style"])
+		}
 	}
 	cfg.Command = freshCmd
 	m.killExistingOrphans(ctx, id)

--- a/internal/session/chat_test.go
+++ b/internal/session/chat_test.go
@@ -114,59 +114,67 @@ func TestStripResumeFlag(t *testing.T) {
 
 func TestStripResumeFlagArg(t *testing.T) {
 	tests := []struct {
-		name       string
-		cmd        string
-		resumeFlag string
-		want       string
+		name        string
+		cmd         string
+		resumeFlag  string
+		resumeStyle string
+		want        string
 	}{
 		{
 			// The diverged-key case: the embedded key differs from the
 			// bead's current session_key, so the keyed strip was a no-op.
-			// The value-agnostic strip must still remove "--resume <key>".
-			name:       "removes resume flag and any key value",
-			cmd:        `claude --settings "x" --resume diverged-key-999`,
-			resumeFlag: "--resume",
-			want:       `claude --settings "x"`,
+			// The value-agnostic strip must still remove the generated
+			// trailing "--resume <key>" suffix.
+			name:        "flag style removes generated trailing resume key",
+			cmd:         `claude --settings "x" --resume diverged-key-999`,
+			resumeFlag:  "--resume",
+			resumeStyle: "flag",
+			want:        `claude --settings "x"`,
 		},
 		{
-			name:       "resume flag at end",
-			cmd:        "claude --resume abc-123",
-			resumeFlag: "--resume",
-			want:       "claude",
+			name:        "flag style preserves earlier resume text",
+			cmd:         `claude --label "--resume keep-me" --resume diverged-key-999`,
+			resumeFlag:  "--resume",
+			resumeStyle: "flag",
+			want:        `claude --label "--resume keep-me"`,
 		},
 		{
-			name:       "resume flag at start of args",
-			cmd:        "--resume abc-123 --model sonnet",
-			resumeFlag: "--resume",
-			want:       "--model sonnet",
+			name:        "flag style preserves non-generated resume flag",
+			cmd:         "claude --resume abc-123 --model sonnet",
+			resumeFlag:  "--resume",
+			resumeStyle: "flag",
+			want:        "claude --resume abc-123 --model sonnet",
 		},
 		{
-			name:       "subcommand-style resume token",
-			cmd:        "codex resume key-abc --model o3",
-			resumeFlag: "resume",
-			want:       "codex --model o3",
+			name:        "subcommand-style resume token",
+			cmd:         "codex resume key-abc --model o3",
+			resumeFlag:  "resume",
+			resumeStyle: "subcommand",
+			want:        "codex --model o3",
 		},
 		{
 			// No resume flag present: command is already a fresh start, so
 			// it must be returned unchanged (callers launch it as-is).
-			name:       "no resume flag returns command unchanged",
-			cmd:        "claude --model sonnet",
-			resumeFlag: "--resume",
-			want:       "claude --model sonnet",
+			name:        "no resume flag returns command unchanged",
+			cmd:         "claude --model sonnet",
+			resumeFlag:  "--resume",
+			resumeStyle: "flag",
+			want:        "claude --model sonnet",
 		},
 		{
-			name:       "empty resume flag returns command unchanged",
-			cmd:        "claude --resume abc-123",
-			resumeFlag: "",
-			want:       "claude --resume abc-123",
+			name:        "empty resume flag returns command unchanged",
+			cmd:         "claude --resume abc-123",
+			resumeFlag:  "",
+			resumeStyle: "flag",
+			want:        "claude --resume abc-123",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := stripResumeFlagArg(tt.cmd, tt.resumeFlag)
+			got := stripResumeFlagArg(tt.cmd, tt.resumeFlag, tt.resumeStyle)
 			if got != tt.want {
-				t.Errorf("stripResumeFlagArg(%q, %q) = %q, want %q",
-					tt.cmd, tt.resumeFlag, got, tt.want)
+				t.Errorf("stripResumeFlagArg(%q, %q, %q) = %q, want %q",
+					tt.cmd, tt.resumeFlag, tt.resumeStyle, got, tt.want)
 			}
 		})
 	}

--- a/internal/session/chat_test.go
+++ b/internal/session/chat_test.go
@@ -112,6 +112,66 @@ func TestStripResumeFlag(t *testing.T) {
 	}
 }
 
+func TestStripResumeFlagArg(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmd        string
+		resumeFlag string
+		want       string
+	}{
+		{
+			// The diverged-key case: the embedded key differs from the
+			// bead's current session_key, so the keyed strip was a no-op.
+			// The value-agnostic strip must still remove "--resume <key>".
+			name:       "removes resume flag and any key value",
+			cmd:        `claude --settings "x" --resume diverged-key-999`,
+			resumeFlag: "--resume",
+			want:       `claude --settings "x"`,
+		},
+		{
+			name:       "resume flag at end",
+			cmd:        "claude --resume abc-123",
+			resumeFlag: "--resume",
+			want:       "claude",
+		},
+		{
+			name:       "resume flag at start of args",
+			cmd:        "--resume abc-123 --model sonnet",
+			resumeFlag: "--resume",
+			want:       "--model sonnet",
+		},
+		{
+			name:       "subcommand-style resume token",
+			cmd:        "codex resume key-abc --model o3",
+			resumeFlag: "resume",
+			want:       "codex --model o3",
+		},
+		{
+			// No resume flag present: command is already a fresh start, so
+			// it must be returned unchanged (callers launch it as-is).
+			name:       "no resume flag returns command unchanged",
+			cmd:        "claude --model sonnet",
+			resumeFlag: "--resume",
+			want:       "claude --model sonnet",
+		},
+		{
+			name:       "empty resume flag returns command unchanged",
+			cmd:        "claude --resume abc-123",
+			resumeFlag: "",
+			want:       "claude --resume abc-123",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripResumeFlagArg(tt.cmd, tt.resumeFlag)
+			if got != tt.want {
+				t.Errorf("stripResumeFlagArg(%q, %q) = %q, want %q",
+					tt.cmd, tt.resumeFlag, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSessionMutationLocksSerializeSameSession(t *testing.T) {
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2033,6 +2033,54 @@ func TestBuildResumeCommand(t *testing.T) {
 	}
 }
 
+func TestStripResumeFlagArgRoundTripsBuildResumeCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		info Info
+	}{
+		{
+			name: "generated flag style",
+			info: Info{
+				Command:     "claude --dangerously-skip-permissions",
+				Provider:    "claude",
+				SessionKey:  "abc-123",
+				ResumeFlag:  "--resume",
+				ResumeStyle: "flag",
+			},
+		},
+		{
+			name: "generated subcommand style",
+			info: Info{
+				Command:     "codex --model o3",
+				Provider:    "codex",
+				SessionKey:  "abc-123",
+				ResumeFlag:  "resume",
+				ResumeStyle: "subcommand",
+			},
+		},
+		{
+			name: "single token subcommand style",
+			info: Info{
+				Command:     "codex",
+				Provider:    "codex",
+				SessionKey:  "abc-123",
+				ResumeFlag:  "resume",
+				ResumeStyle: "subcommand",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resume := BuildResumeCommand(tt.info)
+			got := stripResumeFlagArg(resume, tt.info.ResumeFlag, tt.info.ResumeStyle)
+			if got != tt.info.Command {
+				t.Fatalf("stripResumeFlagArg(BuildResumeCommand()) = %q, want %q", got, tt.info.Command)
+			}
+		})
+	}
+}
+
 func TestCreateWithResumeFlagNoSessionIDFlag(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()
@@ -4310,6 +4358,97 @@ func TestEnsureRunning_RetriesWhenResumeKeyDiverged(t *testing.T) {
 	}
 	if b.Metadata["continuation_reset_pending"] != "true" {
 		t.Errorf("continuation_reset_pending should be set after diverged-key retry, got %q", b.Metadata["continuation_reset_pending"])
+	}
+}
+
+func TestEnsureRunning_RetriesWhenResumeKeyDivergedKeepsEarlierResumeText(t *testing.T) {
+	store := beads.NewMemStore()
+	base := runtime.NewFake()
+
+	sp := &startupDeathProvider{Fake: base}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "worker", "", `claude --label "--resume keep-me"`, "/tmp", "claude", nil, ProviderResume{
+		ResumeFlag:    "--resume",
+		ResumeStyle:   "flag",
+		SessionIDFlag: "--session-id",
+	}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := store.SetMetadata(info.ID, "session_key", "key-B-current"); err != nil {
+		t.Fatalf("SetMetadata session_key: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	sp.armed = true
+
+	resumeCommand := `claude --label "--resume keep-me" --resume key-A-diverged`
+	err = mgr.Send(context.Background(), info.ID, "hello", resumeCommand, runtime.Config{WorkDir: "/tmp"})
+	if err != nil {
+		t.Fatalf("Send should recover via fresh start when resume key diverged, got: %v", err)
+	}
+
+	var retryCommand string
+	for _, call := range base.Calls {
+		if call.Method == "Start" && call.Name == info.SessionName {
+			retryCommand = call.Config.Command
+		}
+	}
+	if retryCommand == "" {
+		t.Fatalf("fresh retry Start call not recorded: %#v", base.Calls)
+	}
+	want := `claude --label "--resume keep-me"`
+	if retryCommand != want {
+		t.Fatalf("fresh retry command = %q, want %q", retryCommand, want)
+	}
+}
+
+func TestEnsureRunning_RetriesExplicitResumeCommandWhenResumeKeyDiverged(t *testing.T) {
+	store := beads.NewMemStore()
+	base := runtime.NewFake()
+
+	sp := &startupDeathProvider{Fake: base}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "worker", "", "claude --dangerously-skip-permissions", "/tmp", "claude", nil, ProviderResume{
+		ResumeFlag:    "--resume",
+		SessionIDFlag: "--session-id",
+		ResumeCommand: "claude --resume {{.SessionKey}} --dangerously-skip-permissions",
+	}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := store.SetMetadata(info.ID, "session_key", "key-B-current"); err != nil {
+		t.Fatalf("SetMetadata session_key: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	sp.armed = true
+
+	resumeCommand := "claude --resume key-A-diverged --dangerously-skip-permissions"
+	err = mgr.Send(context.Background(), info.ID, "hello", resumeCommand, runtime.Config{WorkDir: "/tmp"})
+	if err != nil {
+		t.Fatalf("Send should recover via fresh start when explicit resume_command key diverged, got: %v", err)
+	}
+
+	var retryCommand string
+	for _, call := range base.Calls {
+		if call.Method == "Start" && call.Name == info.SessionName {
+			retryCommand = call.Config.Command
+		}
+	}
+	if retryCommand == "" {
+		t.Fatalf("fresh retry Start call not recorded: %#v", base.Calls)
+	}
+	if want := "claude --dangerously-skip-permissions"; retryCommand != want {
+		t.Fatalf("fresh retry command = %q, want %q", retryCommand, want)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -4197,7 +4197,14 @@ func TestEnsureRunning_RetriesAfterStartupDeathError(t *testing.T) {
 	}
 }
 
-func TestEnsureRunning_StartupDeathWithoutStrippableResumeClearsMetadata(t *testing.T) {
+// When a startup-death recovery's resume command carries no resume flag/key
+// at all (it is already a fresh-start command), retryFreshStartAfterStaleKey
+// must clear the stale metadata and start fresh successfully. Previously it
+// hard-errored ("resume command could not be stripped") because the keyed
+// strip was a no-op — but a command with no --resume token is already fresh,
+// so failing only wedged the session. Same fragile-strip class of bug as the
+// diverged-key case in TestEnsureRunning_RetriesWhenResumeKeyDiverged.
+func TestEnsureRunning_StartupDeathWithoutStrippableResumeRecovers(t *testing.T) {
 	store := beads.NewMemStore()
 	base := runtime.NewFake()
 
@@ -4229,23 +4236,80 @@ func TestEnsureRunning_StartupDeathWithoutStrippableResumeClearsMetadata(t *test
 
 	sp.armed = true
 
+	// The resume command carries no --resume token, so it is already a valid
+	// fresh-start command. Recovery must succeed rather than wedge.
 	err = mgr.Send(context.Background(), info.ID, "hello", "claude --dangerously", runtime.Config{WorkDir: "/tmp"})
-	if err == nil {
-		t.Fatal("Send should fail when stale resume metadata cannot be stripped from the resume command")
+	if err != nil {
+		t.Fatalf("Send should recover via fresh start when resume command has no key to strip, got: %v", err)
+	}
+
+	if !base.IsRunning(info.SessionName) {
+		t.Fatal("session should be running after no-strippable-key fresh retry")
 	}
 
 	b, _ = store.Get(info.ID)
 	if b.Metadata["session_key"] != "" {
-		t.Errorf("session_key should be cleared after unstrippable startup-death fallback, got %q", b.Metadata["session_key"])
+		t.Errorf("session_key should be cleared after startup-death fallback, got %q", b.Metadata["session_key"])
 	}
 	if b.Metadata["started_config_hash"] != "" {
-		t.Errorf("started_config_hash should be cleared after unstrippable startup-death fallback, got %q", b.Metadata["started_config_hash"])
+		t.Errorf("started_config_hash should be cleared after startup-death fallback, got %q", b.Metadata["started_config_hash"])
 	}
 	if b.Metadata["continuation_reset_pending"] != "true" {
-		t.Errorf("continuation_reset_pending should be set after unstrippable startup-death fallback, got %q", b.Metadata["continuation_reset_pending"])
+		t.Errorf("continuation_reset_pending should be set after startup-death fallback, got %q", b.Metadata["continuation_reset_pending"])
 	}
-	if b.Metadata["state"] != string(StateSuspended) {
-		t.Errorf("state should remain suspended after failed unstrippable fallback, got %q", b.Metadata["state"])
+}
+
+// A resume-capable session whose embedded resume key has diverged from the
+// bead's current session_key (e.g. a concurrent fresh start minted a new key,
+// or a stale store read returned a different one) must still recover with a
+// fresh start. Previously retryFreshStartAfterStaleKey hard-errored with
+// "resume command could not be stripped" because the keyed strip could not
+// match the diverged key — wedging the session into a respawn/SIGTERM loop.
+// The fix falls back to a value-agnostic strip so the fresh start proceeds.
+func TestEnsureRunning_RetriesWhenResumeKeyDiverged(t *testing.T) {
+	store := beads.NewMemStore()
+	base := runtime.NewFake()
+
+	sp := &startupDeathProvider{Fake: base}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "worker", "", "claude --dangerously", "/tmp", "claude", nil, ProviderResume{
+		ResumeFlag:    "--resume",
+		SessionIDFlag: "--session-id",
+	}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// The bead's stored session_key is KEY_B...
+	if err := store.SetMetadata(info.ID, "session_key", "key-B-current"); err != nil {
+		t.Fatalf("SetMetadata session_key: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	sp.armed = true
+
+	// ...but the resume command was built with a DIVERGED key (KEY_A). The
+	// keyed strip ("--resume key-B-current") is a no-op against this command;
+	// only the value-agnostic fallback can produce a clean fresh start.
+	resumeCommand := "claude --dangerously --resume key-A-diverged"
+	err = mgr.Send(context.Background(), info.ID, "hello", resumeCommand, runtime.Config{WorkDir: "/tmp"})
+	if err != nil {
+		t.Fatalf("Send should recover via fresh start when resume key diverged, got: %v", err)
+	}
+
+	if !base.IsRunning(info.SessionName) {
+		t.Fatal("session should be running after diverged-key fresh retry")
+	}
+
+	b, _ := store.Get(info.ID)
+	if b.Metadata["session_key"] != "" {
+		t.Errorf("session_key should be cleared after diverged-key retry, got %q", b.Metadata["session_key"])
+	}
+	if b.Metadata["continuation_reset_pending"] != "true" {
+		t.Errorf("continuation_reset_pending should be set after diverged-key retry, got %q", b.Metadata["continuation_reset_pending"])
 	}
 }
 


### PR DESCRIPTION
## Problem

When a resume attempt dies on a stale session key, `retryFreshStartAfterStaleKey` rebuilds a fresh-start command by string-stripping `"<resume_flag> <session_key>"` from the resume command. If the key embedded in that command has **diverged** from the bead's current `session_key` — e.g. a concurrent fresh start minted a new key, or a stale store read returned a different one — the keyed strip is a no-op and the function **hard-errors** (`fresh start after stale key: resume command could not be stripped`).

That wedges the session: the embedded resume key is always stale, the keyed strip can never match it, and because the error returns *before* `killExistingOrphans`, the dead `remain-on-exit` pane lingers and blocks the next attempt — a respawn loop.

## Fix

When the keyed strip is a no-op but a resume flag is configured, fall back to a **value-agnostic** strip: remove the resume flag and the single token that follows it, regardless of its value. A command that carries no resume flag at all is already a valid fresh-start command and is used as-is. The function no longer hard-fails this path.

## Testing

- New `TestStripResumeFlagArg` covering flag-at-end, flag-at-start, subcommand-style, divergent key, and no-flag cases.
- New `TestEnsureRunning_RetriesWhenResumeKeyDiverged`: a resume command built with a different key than the bead's `session_key` now recovers via fresh start instead of erroring.
- `TestEnsureRunning_StartupDeathWithoutStrippableResume…` rewritten to assert recovery (the prior "must fail" behavior was the bug).
- `internal/session` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)