### PR TITLE
fix(config): tolerate named_session with a missing backing template

### DIFF
--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -122,6 +122,9 @@ func isNonFatalLoadConfigWarning(warning string) bool {
 	if config.IsLegacyV1SurfaceWarning(warning) {
 		return true
 	}
+	if config.IsDisabledNamedSessionWarning(warning) {
+		return true
+	}
 	if config.IsLegacyWorkspaceFieldWarning(warning) {
 		return true
 	}

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -217,6 +217,54 @@ schema = 2
 	}
 }
 
+func TestLoadCityConfigFSToleratesMissingNamedSessionTemplate(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Dirs["/city/pk"] = true
+	fs.Files["/city/pk/pack.toml"] = []byte(`[pack]
+name = "pk"
+schema = 1
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`)
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+name = "test-city"
+
+[imports.pk]
+source = "pk"
+
+[[named_session]]
+template = "pk.mayor"
+
+[[named_session]]
+name = "rizato"
+template = "pk.ghost"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`[pack]
+name = "test-city"
+schema = 2
+`)
+
+	var stderr bytes.Buffer
+	cfg, err := loadCityConfigFS(fs, "/city/city.toml", &stderr)
+	if err != nil {
+		t.Fatalf("loadCityConfigFS: %v; a single broken named session must not brick config load", err)
+	}
+	if cfg == nil {
+		t.Fatal("loadCityConfigFS returned nil config")
+	}
+	// The valid sibling still resolves.
+	if config.FindNamedSession(cfg, "pk.mayor") == nil {
+		t.Fatal("FindNamedSession(pk.mayor) = nil, want the valid session to survive")
+	}
+	// The broken one is reported as a non-fatal warning on stderr.
+	if !strings.Contains(stderr.String(), `"rizato"`) ||
+		!strings.Contains(stderr.String(), "named session disabled until its template resolves") {
+		t.Fatalf("expected disabled-named-session warning on stderr, got %q", stderr.String())
+	}
+}
+
 func TestLoadCityConfigFSEmitsMigrationWarningsAcrossCalls(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`[workspace]

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -619,9 +619,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// Validate named session declarations after pack expansion and site
 	// binding resolution so stamped identities and deterministic runtime
 	// names reflect the effective workspace identity.
-	if err := ValidateNamedSessions(root); err != nil {
+	namedSessionWarnings, err := ValidateNamedSessions(root)
+	if err != nil {
 		return nil, nil, err
 	}
+	prov.Warnings = append(prov.Warnings, namedSessionWarnings...)
 
 	if err := ValidateGitHubPRMonitors(root); err != nil {
 		return nil, nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3625,16 +3625,24 @@ func ValidateAgents(agents []Agent) error {
 }
 
 // ValidateNamedSessions checks named session declarations after pack expansion.
-func ValidateNamedSessions(cfg *City) error {
+// It returns non-fatal warnings (e.g. a named session whose backing template
+// did not resolve) alongside any fatal structural error.
+func ValidateNamedSessions(cfg *City) (warnings []string, err error) {
 	return validateNamedSessions(cfg, true)
 }
 
 // validateNamedSessions checks named session declarations for structural
-// errors. When requireBackingTemplate is true, it also requires every named
-// session to resolve to an expanded backing agent template.
-func validateNamedSessions(cfg *City, requireBackingTemplate bool) error {
+// errors. When requireBackingTemplate is true, a named session whose backing
+// agent template does not resolve after pack expansion is reported as a
+// non-fatal warning and the session is skipped, rather than failing the whole
+// config load. This keeps one broken named session from bricking every command
+// (a typo'd template should not stop `gc session attach <other>`). The session
+// still errors clearly when a command actually targets it, at materialization
+// time. Genuine structural problems (duplicate identity, invalid scope/mode,
+// name collisions, capacity overflow) remain fatal.
+func validateNamedSessions(cfg *City, requireBackingTemplate bool) (warnings []string, err error) {
 	if cfg == nil || len(cfg.NamedSessions) == 0 {
-		return nil
+		return nil, nil
 	}
 	type sessionKey struct{ dir, identity string }
 	seen := make(map[sessionKey]bool, len(cfg.NamedSessions))
@@ -3644,53 +3652,56 @@ func validateNamedSessions(cfg *City, requireBackingTemplate bool) error {
 	for i := range cfg.NamedSessions {
 		s := &cfg.NamedSessions[i]
 		if s.Template == "" {
-			return fmt.Errorf("named_session[%d]: template is required", i)
+			return nil, fmt.Errorf("named_session[%d]: template is required", i)
 		}
 		if !validNamedSessionTemplate.MatchString(s.Template) {
-			return fmt.Errorf("named_session[%d]: template %q must match [a-zA-Z0-9][a-zA-Z0-9_-]* or binding.agent", i, s.Template)
+			return nil, fmt.Errorf("named_session[%d]: template %q must match [a-zA-Z0-9][a-zA-Z0-9_-]* or binding.agent", i, s.Template)
 		}
 		if s.Name != "" && !validAgentName.MatchString(s.Name) {
-			return fmt.Errorf("named_session[%d]: name %q must match [a-zA-Z0-9][a-zA-Z0-9_-]*", i, s.Name)
+			return nil, fmt.Errorf("named_session[%d]: name %q must match [a-zA-Z0-9][a-zA-Z0-9_-]*", i, s.Name)
 		}
 		switch s.Scope {
 		case "", "city", "rig":
 			// valid
 		default:
-			return fmt.Errorf("named_session %q: scope must be \"city\", \"rig\", or empty, got %q", s.QualifiedName(), s.Scope)
+			return nil, fmt.Errorf("named_session %q: scope must be \"city\", \"rig\", or empty, got %q", s.QualifiedName(), s.Scope)
 		}
 		switch s.ModeOrDefault() {
 		case "on_demand", "always":
 			// valid
 		default:
-			return fmt.Errorf("named_session %q: mode must be \"on_demand\", \"always\", or empty, got %q", s.QualifiedName(), s.Mode)
+			return nil, fmt.Errorf("named_session %q: mode must be \"on_demand\", \"always\", or empty, got %q", s.QualifiedName(), s.Mode)
 		}
 		key := sessionKey{dir: s.Dir, identity: s.IdentityName()}
 		if seen[key] {
-			return fmt.Errorf("named_session %q: duplicate identity", s.QualifiedName())
+			return nil, fmt.Errorf("named_session %q: duplicate identity", s.QualifiedName())
 		}
 		seen[key] = true
 		agent := FindAgent(cfg, s.TemplateQualifiedName())
-		if agent == nil {
-			if requireBackingTemplate {
-				return fmt.Errorf("named_session %q: referenced template not found after pack expansion", s.QualifiedName())
-			}
+		if agent == nil && requireBackingTemplate {
+			// Non-fatal: a named session whose backing template did not
+			// resolve is skipped, not a hard error. Skipping here also
+			// keeps it out of the name-reservation and always-mode capacity
+			// bookkeeping below, since a disabled session holds no slot.
+			warnings = append(warnings, disabledNamedSessionWarning(s))
+			continue
 		}
 		identity := s.QualifiedName()
 		sessionName := NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, identity)
 		if other, ok := reservedAliases[sessionName]; ok && other != identity {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"named_session %q: reserved alias collides with deterministic session_name for %q (%q)",
 				identity, other, sessionName,
 			)
 		}
 		if other, ok := reservedSessionNames[identity]; ok && other != identity {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"named_session %q: reserved alias collides with deterministic session_name for %q (%q)",
 				identity, other, identity,
 			)
 		}
 		if other, ok := reservedSessionNames[sessionName]; ok && other != identity {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"named_session %q: deterministic session_name %q collides with configured named session %q",
 				identity, sessionName, other,
 			)
@@ -3700,21 +3711,44 @@ func validateNamedSessions(cfg *City, requireBackingTemplate bool) error {
 		if s.ModeOrDefault() == "always" && agent != nil {
 			alwaysByTemplate[agent.QualifiedName()]++
 			if maxActive := agent.EffectiveMaxActiveSessions(); maxActive != nil && *maxActive < alwaysByTemplate[agent.QualifiedName()] {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"named_session %q: mode %q exceeds max_active_sessions capacity %d on template %q",
 					s.QualifiedName(), s.ModeOrDefault(), *maxActive, agent.QualifiedName(),
 				)
 			}
 			policy := ResolveSessionSleepPolicy(cfg, agent)
 			if normalized := NormalizeSleepAfterIdle(policy.Value); normalized != "" && normalized != SessionSleepOff {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"named_session %q: mode %q is incompatible with sleep_after_idle=%q on template %q",
 					s.QualifiedName(), s.ModeOrDefault(), normalized, agent.QualifiedName(),
 				)
 			}
 		}
 	}
-	return nil
+	return warnings, nil
+}
+
+// disabledNamedSessionMarker is a stable suffix on the warning emitted when a
+// named session is skipped because its backing template did not resolve after
+// pack expansion. CLI warning classification keys off this marker, so keep it
+// in sync with IsDisabledNamedSessionWarning.
+const disabledNamedSessionMarker = "; named session disabled until its template resolves"
+
+// disabledNamedSessionWarning formats the non-fatal warning for a named session
+// whose backing template could not be resolved.
+func disabledNamedSessionWarning(s *NamedSession) string {
+	return fmt.Sprintf(
+		"named_session %q: backing template %q not found after pack expansion%s",
+		s.QualifiedName(), s.TemplateQualifiedName(), disabledNamedSessionMarker,
+	)
+}
+
+// IsDisabledNamedSessionWarning reports whether a load warning is the non-fatal
+// notice that a named session was skipped because its backing template did not
+// resolve. CLI warning filters use this to print the notice and keep it
+// non-fatal in strict mode.
+func IsDisabledNamedSessionWarning(warning string) bool {
+	return strings.HasSuffix(warning, disabledNamedSessionMarker)
 }
 
 // validateDependsOn checks that all depends_on references are valid agent
@@ -3944,7 +3978,7 @@ func Load(fs fsys.FS, path string) (*City, error) {
 	// Load intentionally skips include and pack expansion, so validate the
 	// direct named-session declarations without requiring pack-provided
 	// backing templates to be present yet.
-	if err := validateNamedSessions(cfg, false); err != nil {
+	if _, err := validateNamedSessions(cfg, false); err != nil {
 		return nil, err
 	}
 	if err := ValidateGitHubPRMonitors(cfg); err != nil {

--- a/internal/config/session_sleep_test.go
+++ b/internal/config/session_sleep_test.go
@@ -224,7 +224,7 @@ func TestValidateNamedSessions_RejectsAlwaysWithSleepAfterIdle(t *testing.T) {
 		}},
 	}
 
-	if err := ValidateNamedSessions(cfg); err == nil {
+	if _, err := ValidateNamedSessions(cfg); err == nil {
 		t.Fatal("ValidateNamedSessions() = nil, want error")
 	} else if !strings.Contains(err.Error(), "sleep_after_idle") {
 		t.Fatalf("ValidateNamedSessions() error = %v, want mention of sleep_after_idle", err)
@@ -247,7 +247,7 @@ func TestValidateNamedSessions_RejectsAliasSessionNameCollision(t *testing.T) {
 		},
 	}
 
-	if err := ValidateNamedSessions(cfg); err == nil {
+	if _, err := ValidateNamedSessions(cfg); err == nil {
 		t.Fatal("ValidateNamedSessions() = nil, want collision error")
 	} else if !strings.Contains(err.Error(), "collides with deterministic session_name") {
 		t.Fatalf("ValidateNamedSessions() error = %v, want session_name collision", err)
@@ -266,10 +266,58 @@ func TestValidateNamedSessions_RejectsQualifiedAliasName(t *testing.T) {
 		}},
 	}
 
-	if err := ValidateNamedSessions(cfg); err == nil {
+	if _, err := ValidateNamedSessions(cfg); err == nil {
 		t.Fatal("ValidateNamedSessions() = nil, want error")
 	} else if !strings.Contains(err.Error(), `name "gs.witness"`) {
 		t.Fatalf("ValidateNamedSessions() error = %v, want qualified alias rejection", err)
+	}
+}
+
+func TestValidateNamedSessions_MissingTemplateIsWarningNotFatal(t *testing.T) {
+	// One named session backs a real template; the other references a
+	// template that does not resolve. Validation must succeed (so unrelated
+	// sessions and every other command keep working) and surface the broken
+	// one as a non-fatal warning rather than failing the whole config.
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Agents:    []Agent{{Name: "mayor"}},
+		NamedSessions: []NamedSession{
+			{Template: "mayor"},
+			{Name: "rizato", Template: "ghost"},
+		},
+	}
+
+	warnings, err := ValidateNamedSessions(cfg)
+	if err != nil {
+		t.Fatalf("ValidateNamedSessions() error = %v, want nil (missing template should be non-fatal)", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("ValidateNamedSessions() warnings = %v, want exactly one", warnings)
+	}
+	if !strings.Contains(warnings[0], `"rizato"`) || !strings.Contains(warnings[0], "ghost") {
+		t.Fatalf("warning = %q, want it to name the broken session and its template", warnings[0])
+	}
+	if !IsDisabledNamedSessionWarning(warnings[0]) {
+		t.Fatalf("IsDisabledNamedSessionWarning(%q) = false, want true", warnings[0])
+	}
+}
+
+func TestValidateNamedSessions_StructuralErrorsStayFatal(t *testing.T) {
+	// A duplicate identity is a genuine config error and must remain fatal
+	// even though a missing backing template is now demoted to a warning.
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Agents:    []Agent{{Name: "mayor"}},
+		NamedSessions: []NamedSession{
+			{Template: "mayor"},
+			{Template: "mayor"},
+		},
+	}
+
+	if _, err := ValidateNamedSessions(cfg); err == nil {
+		t.Fatal("ValidateNamedSessions() = nil, want duplicate-identity error")
+	} else if !strings.Contains(err.Error(), "duplicate identity") {
+		t.Fatalf("ValidateNamedSessions() error = %v, want duplicate identity", err)
 	}
 }
 
@@ -289,7 +337,7 @@ func TestValidateNamedSessions_UsesResolvedWorkspaceName(t *testing.T) {
 		},
 	}
 
-	if err := ValidateNamedSessions(cfg); err == nil {
+	if _, err := ValidateNamedSessions(cfg); err == nil {
 		t.Fatal("ValidateNamedSessions() = nil, want collision error")
 	} else if !strings.Contains(err.Error(), "collides with deterministic session_name") {
 		t.Fatalf("ValidateNamedSessions() error = %v, want session_name collision", err)


### PR DESCRIPTION
## Problem

A `named_session` whose backing agent template does not resolve after pack expansion was a **hard error** in `ValidateNamedSessions`, which fails the entire config load. Because nearly every `gc` command loads the city config, one typo'd or transiently-unresolvable `named_session` template **bricked all of them**.

Concretely, `gc session attach mayor` failed with:

```
gc session attach: named_session "yegge-ai/rizato": referenced template not found after pack expansion
```

…solely because an *unrelated* `rizato` named session referenced a template that didn't resolve. Attaching to `mayor` has nothing to do with `rizato`, but the strict config-load gate took everything down with it. `gc agent list`, `gc session attach <anything>`, etc. all failed the same way.

## Fix

Demote this one case to a **non-fatal warning**:

- Skip the broken named session during validation (it holds no name reservation or always-mode capacity slot, so the rest of the bookkeeping stays correct).
- Surface it on stderr via the existing load-warning channel:
  ```
  named_session "yegge-ai/rizato": backing template "yegge-ai/gastown.ghost" not found after pack expansion; named session disabled until its template resolves
  ```
- Unrelated sessions and every other command keep working.
- A command that **actually targets** the broken session still fails clearly, at materialization time (`ensureSessionIDForTemplate` → `FindAgent`).

Genuine structural problems remain **fatal**: duplicate identity, invalid scope/mode, name/alias collisions, `always`-mode capacity overflow, and `sleep_after_idle` conflicts.

### Daemon safety

The controller degrades gracefully too: `buildDesiredState` already skips named sessions whose spec doesn't resolve (`findNamedSessionSpec` → `ok=false`), so a broken `mode="always"` session is never materialized and cannot crash-loop the reconciler. No nil-deref paths were introduced (broken sessions never reach agent-field access).

## API change

`ValidateNamedSessions(cfg) error` → `ValidateNamedSessions(cfg) ([]string, error)` (returns non-fatal warnings). The single production caller (`LoadWithIncludesOptions`) folds the warnings into `Provenance.Warnings`; `cmd/gc` classifies them as non-fatal/printable via the new `config.IsDisabledNamedSessionWarning`.

## Tests

- `internal/config`: `TestValidateNamedSessions_MissingTemplateIsWarningNotFatal` (load succeeds, exactly one warning naming the broken session) and `TestValidateNamedSessions_StructuralErrorsStayFatal` (duplicate identity still fatal).
- `cmd/gc`: `TestLoadCityConfigFSToleratesMissingNamedSessionTemplate` (load succeeds, valid sibling survives, warning reaches stderr).
- Full `internal/config` suite + `cmd/gc` config/desired-state/reconciler suites green; `go vet` and `gofmt` clean.
- Manually verified against a real city: with a deliberately-broken template, `gc agent list` and `gc session attach mayor` now succeed with a warning instead of erroring out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
