### PR TITLE
Implement agent_defaults provider default

### DIFF
--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -322,7 +322,6 @@ func TestEmitLoadCityConfigWarningsFiltersNonMigrationWarnings(t *testing.T) {
 			`workspace.name redefined by "/city/defaults.toml"`,
 			`/city/pack.toml: [agents] is a deprecated compatibility alias for [agent_defaults]; rewrite the table name to [agent_defaults]`,
 			`/city/pack.toml: both [agent_defaults] and [agents] are present; [agent_defaults] wins on overlapping keys and [agents] only fills gaps`,
-			`/city/pack.toml: "agent_defaults.provider" is not supported in this release wave; keep setting provider per agent in agents/<name>/agent.toml`,
 			`/city/city.toml: workspace.provider is deprecated: Set provider per agent in agents/<name>/agent.toml.`,
 			`gc: warning: attachment-list fields (` + "`skills`, `mcp`, `skills_append`, `mcp_append`, `shared_skills`" + `) are deprecated as of v0.15.1 and ignored.`,
 		},
@@ -337,9 +336,6 @@ func TestEmitLoadCityConfigWarningsFiltersNonMigrationWarnings(t *testing.T) {
 	}
 	if !strings.Contains(output, `both [agent_defaults] and [agents] are present`) {
 		t.Fatalf("expected mixed-table warning, got %q", output)
-	}
-	if !strings.Contains(output, `"agent_defaults.provider" is not supported`) {
-		t.Fatalf("expected unsupported-key warning, got %q", output)
 	}
 	if strings.Contains(output, `workspace.provider is deprecated`) {
 		t.Fatalf("legacy workspace warnings should stay out of generic command stderr, got %q", output)
@@ -530,7 +526,6 @@ func TestStrictFatalLoadConfigWarningsKeepsMixedTableWarningsFatal(t *testing.T)
 	warnings := []string{
 		`/city/pack.toml: [agents] is a deprecated compatibility alias for [agent_defaults]; rewrite the table name to [agent_defaults]`,
 		`/city/pack.toml: both [agent_defaults] and [agents] are present; [agent_defaults] wins on overlapping keys and [agents] only fills gaps`,
-		`/city/pack.toml: "agent_defaults.provider" is not supported in this release wave; keep setting provider per agent in agents/<name>/agent.toml`,
 		`/city/city.toml: workspace.provider is deprecated: Set provider per agent in agents/<name>/agent.toml.`,
 		`workspace.name redefined by "/city/defaults.toml"`,
 	}

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -661,7 +661,7 @@ schema, plus the qualified rows that matter most during migration.
 | `[session_sleep]` | Sleep policy defaults | Keep in `city.toml`. |
 | `[convergence]` | Convergence limits | Keep in `city.toml`. |
 | `[[service]]` | Workspace-owned service declarations | Keep in `city.toml` if they are deployment-owned services. |
-| `[agent_defaults]` | Defaults applied to agents in this city | Lives in both `pack.toml` (pack-wide portable defaults) and `city.toml` (city-level deployment overrides). City layers on top of pack. As of release v0.15.0, the actively-applied defaults are still narrow: `default_sling_formula` plus `[agent_defaults].append_fragments`. |
+| `[agent_defaults]` | Defaults applied to agents in this city | Lives in both `pack.toml` (pack-wide portable defaults) and `city.toml` (city-level deployment overrides). City layers on top of pack. The actively-applied defaults are still narrow: `provider`, `default_sling_formula`, plus `[agent_defaults].append_fragments`. |
 
 > **Schema contract note:** This rollout also changes the generated schema
 > contract: checked-in `city.toml` files and downstream validators must no

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1670,8 +1670,8 @@ gc init
 | `--preserve-existing` | bool |  | keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them |
 | `--provider` | string |  | built-in workspace provider to use for the default mayor config |
 | `--skip-provider-readiness` | bool |  | skip provider login/readiness checks during init and continue startup |
-| `--yes` | bool |  | bypass the cross-city supervisor cycle confirmation prompt (warning is still printed for the audit trail) |
 | `--template` | string |  | config template to use non-interactively (minimal, gastown, custom) |
+| `--yes` | bool |  | bypass the cross-city supervisor cycle confirmation prompt (warning is still printed for the audit trail) |
 
 ## gc lint
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -37,7 +37,7 @@ City is the top-level configuration for a Gas City instance.
 | `maintenance` | MaintenanceConfig |  |  | Maintenance configures periodic store-maintenance loops. |
 | `service` | []Service |  |  | Services declares workspace-owned HTTP services mounted on the controller edge under /svc/&#123;name&#125;. |
 | `github` | GitHubConfig |  |  | GitHub configures GitHub-facing repository monitors. |
-| `agent_defaults` | AgentDefaults |  |  | AgentDefaults provides city-level defaults for agents that don't override them (canonical TOML key: agent_defaults). The runtime currently applies default_sling_formula and append_fragments; the attachment-list fields remain tombstones, and the other fields are parsed/composed but not yet inherited automatically. |
+| `agent_defaults` | AgentDefaults |  |  | AgentDefaults provides city-level defaults for agents that don't override them (canonical TOML key: agent_defaults). The runtime currently applies provider, default_sling_formula, and append_fragments; the attachment-list fields remain tombstones, and the other fields are parsed/composed but not yet inherited automatically. |
 | `pricing` | []ModelPricing |  |  | Pricing holds per-model cost rate overrides keyed by (provider, model). City-level entries override pack-level entries which override the defaults shipped with the pricing package. See internal/pricing for the estimation seam introduced by issue #1255 (1d). |
 
 ## ACPSessionConfig
@@ -127,6 +127,7 @@ AgentDefaults provides city-level agent defaults declared via [agent_defaults] i
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
+| `provider` | string |  |  | Provider is the default provider name for agents that do not set their own provider. It also counts as a configured provider for implicit agent injection. |
 | `model` | string |  |  | Model is the parsed/composed default model name for agents (e.g., "claude-sonnet-4-6"), but it is not yet auto-applied at runtime. Agents with their own model override would take precedence. |
 | `wake_mode` | string |  |  | WakeMode is the parsed/composed default wake mode ("resume" or "fresh"), but it is not yet auto-applied at runtime. Enum: `resume`, `fresh` |
 | `default_sling_formula` | string |  |  | DefaultSlingFormula is the city-level default formula used for agents that inherit [agent_defaults]. Explicit agents only receive this value when agent_defaults.default_sling_formula is set; implicit multi-session configs are seeded with "mol-do-work" elsewhere when no explicit default is set. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -337,6 +337,10 @@
     },
     "AgentDefaults": {
       "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Provider is the default provider name for agents that do not set their\nown provider. It also counts as a configured provider for implicit agent\ninjection."
+        },
         "model": {
           "type": "string",
           "description": "Model is the parsed/composed default model name for agents\n(e.g., \"claude-sonnet-4-6\"), but it is not yet auto-applied at\nruntime. Agents with their own model override would take precedence."
@@ -1082,7 +1086,7 @@
         },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
-          "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies default_sling_formula and append_fragments; the\nattachment-list fields remain tombstones, and the other fields are\nparsed/composed but not yet inherited automatically."
+          "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies provider, default_sling_formula, and\nappend_fragments; the attachment-list fields remain tombstones, and\nthe other fields are parsed/composed but not yet inherited\nautomatically."
         },
         "pricing": {
           "items": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -337,6 +337,10 @@
     },
     "AgentDefaults": {
       "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Provider is the default provider name for agents that do not set their\nown provider. It also counts as a configured provider for implicit agent\ninjection."
+        },
         "model": {
           "type": "string",
           "description": "Model is the parsed/composed default model name for agents\n(e.g., \"claude-sonnet-4-6\"), but it is not yet auto-applied at\nruntime. Agents with their own model override would take precedence."
@@ -1082,7 +1086,7 @@
         },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
-          "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies default_sling_formula and append_fragments; the\nattachment-list fields remain tombstones, and the other fields are\nparsed/composed but not yet inherited automatically."
+          "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies provider, default_sling_formula, and\nappend_fragments; the attachment-list fields remain tombstones, and\nthe other fields are parsed/composed but not yet inherited\nautomatically."
         },
         "pricing": {
           "items": {

--- a/docs/specs/pack-spec.md
+++ b/docs/specs/pack-spec.md
@@ -882,8 +882,11 @@ If a patch target does not exist when the patch runs, loading fails.
 `pack.toml` table.
 
 The current default application step actively applies
+`agent_defaults.provider` to agents whose `provider` is still unset and
 `agent_defaults.default_sling_formula` to agents whose `default_sling_formula`
-is still unset. It skips the control-dispatcher infrastructure agent.
+is still unset. `agent_defaults.provider` also counts as a configured provider
+for implicit provider-agent injection. The default application step skips the
+control-dispatcher infrastructure agent.
 
 The current runtime also applies shared attachment defaults for
 `append_fragments`. Attachment-list fields such as `skills` and `mcp` are

--- a/engdocs/design/packv2/doc-agent-v2.md
+++ b/engdocs/design/packv2/doc-agent-v2.md
@@ -113,11 +113,13 @@ default_sling_formula = "mol-do-work"
 append_fragments = ["operational-awareness"]
 ```
 
-As of release v0.15.0, the actively-applied defaults are still narrow:
-`default_sling_formula` plus `[agent_defaults].append_fragments` during
-prompt rendering. Other `AgentDefaults` fields are parsed and composed,
-but are not yet auto-inherited at runtime. Per-agent fields such as
-`provider` and `scope` still live in `agents/<name>/agent.toml`.
+As of the current implementation, the actively-applied defaults are still
+narrow: `provider`, `default_sling_formula`, and
+`[agent_defaults].append_fragments` during prompt rendering. `provider`
+fills agents that do not set their own provider and also seeds implicit
+provider-agent injection. Other `AgentDefaults` fields are parsed and
+composed, but are not yet auto-inherited at runtime. Per-agent fields such as
+`scope` still live in `agents/<name>/agent.toml`.
 
 Individual agents override in their own `agent.toml`:
 

--- a/engdocs/design/packv2/doc-conformance-matrix.md
+++ b/engdocs/design/packv2/doc-conformance-matrix.md
@@ -61,6 +61,7 @@ These are settled enough, and implemented enough, to block CI now.
 | Template fragments | `template-fragments/` and `agents/<name>/template-fragments/` are discovered and rendered into template prompts | Unit + testscript | `cmd/gc/prompt.go` |
 | Agent-local auto-append bridge | `append_fragments` declared on an agent applies only to `.template.md` prompts and does nothing to plain `.md` prompts | Unit + testscript | `cmd/gc/prompt.go` |
 | `[agent_defaults]` auto-append bridge | `[agent_defaults].append_fragments` composes and auto-appends only for `.template.md` prompts | Unit + testscript | `internal/config/compose.go`, `cmd/gc/prompt.go` |
+| `[agent_defaults] provider` defaults | `agent_defaults.provider` is parsed, merged, fills agents that do not set `provider`, and counts as a configured provider for implicit agent injection | Unit | `internal/config/config.go` |
 | Agent defaults layering | `[agent_defaults]` is legal in both `pack.toml` and `city.toml`, with city winning on merge; runtime inheritance is gated only for fields the implementation actually applies today | Unit | `internal/config/compose.go`, `internal/config/config.go` |
 | Qualified patch targeting | imported agents can be targeted by qualified name in `[[patches.agent]]` | Unit | `internal/config/patch.go` |
 | Patch prompt template gating | An explicitly patched `prompt_template` path follows the same `.template.` rule as agent prompt files: `.template.md` renders, plain `.md` stays inert | Unit | `internal/config/patch.go`, `cmd/gc/prompt.go` |
@@ -98,7 +99,6 @@ unsettled to be reliable release gates.
 | Area | Current status | Why it is non-gating for now |
 |---|---|---|
 | `[defaults.rig.imports.<binding>]` loader support | documented intent, not implemented | Migration tooling may write it, but the loader does not yet honor it |
-| `[agent_defaults] provider` driving runtime provider selection | migration target is documented, but runtime behavior is not aligned enough to gate | Current implementation still resolves runtime defaults through `workspace.provider` / `ResolveProvider`; locking in the future rule now would create false failures |
 | `patches/` directory convention for imported prompt replacements | documented in v.next docs, not implemented | Current implementation still relies on explicit patch fields rather than full loader-discovered patch files |
 | Pack `skills/` discovery | documented, not implemented | First slice is current-city-pack only with list-only visibility; imported-pack catalogs are later |
 | `mcp/` TOML abstraction | documented, not implemented | Same first-slice scope as skills: current-city-pack only, list-only visibility first, provider projection later |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3281,13 +3281,13 @@ func (a *Agent) EffectiveOnBoot() string {
 
 // InjectImplicitAgents adds on-demand agents for each configured provider at
 // both city scope and each rig scope. A provider is "configured" if it
-// appears in cfg.Providers OR is named by cfg.Workspace.Provider — so the
-// common single-provider case (workspace.provider = "claude") works without
-// a redundant [providers.claude] section. Unconfigured built-in providers
-// are skipped. Pool min=0, max=-1 (unlimited) so they are available as
-// sling targets without an explicit [[agent]] entry. Explicit agents always
-// win — if city.toml defines [[agent]] name="claude" (or a rig-scoped
-// equivalent), no implicit agent is added for that scope.
+// appears in cfg.Providers, cfg.AgentDefaults.Provider, or
+// cfg.Workspace.Provider, so the common single-provider cases work without a
+// redundant [providers.claude] section. Unconfigured built-in providers are
+// skipped. Pool min=0, max=-1 (unlimited) so they are available as sling
+// targets without an explicit [[agent]] entry. Explicit agents always win: if
+// city.toml defines [[agent]] name="claude" (or a rig-scoped equivalent), no
+// implicit agent is added for that scope.
 // agentKey identifies an agent by its rig directory and name.
 type agentKey struct{ dir, name string }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -230,9 +230,10 @@ type City struct {
 	GitHub GitHubConfig `toml:"github,omitempty"`
 	// AgentDefaults provides city-level defaults for agents that don't
 	// override them (canonical TOML key: agent_defaults). The runtime
-	// currently applies default_sling_formula and append_fragments; the
-	// attachment-list fields remain tombstones, and the other fields are
-	// parsed/composed but not yet inherited automatically.
+	// currently applies provider, default_sling_formula, and
+	// append_fragments; the attachment-list fields remain tombstones, and
+	// the other fields are parsed/composed but not yet inherited
+	// automatically.
 	AgentDefaults AgentDefaults `toml:"agent_defaults,omitempty"`
 	// AgentsDefaults is a temporary compatibility alias for [agent_defaults].
 	// Parse/load normalize it into AgentDefaults and prefer [agent_defaults]
@@ -2284,10 +2285,14 @@ func (c *City) PackDirsForRig(rigName string) []string {
 }
 
 // AgentDefaults provides city-level agent defaults declared via
-// [agent_defaults] in city.toml. The runtime currently applies
-// default_sling_formula and append_fragments; the remaining fields are
+// [agent_defaults] in city.toml. The runtime currently applies provider,
+// default_sling_formula, and append_fragments; the remaining fields are
 // parsed and composed but are not yet inherited onto agents automatically.
 type AgentDefaults struct {
+	// Provider is the default provider name for agents that do not set their
+	// own provider. It also counts as a configured provider for implicit agent
+	// injection.
+	Provider string `toml:"provider,omitempty"`
 	// Model is the parsed/composed default model name for agents
 	// (e.g., "claude-sonnet-4-6"), but it is not yet auto-applied at
 	// runtime. Agents with their own model override would take precedence.
@@ -2326,6 +2331,9 @@ type AgentDefaults struct {
 }
 
 func mergeAgentDefaultsAliasPreferCanonical(dst *AgentDefaults, src AgentDefaults, meta toml.MetaData) {
+	if !meta.IsDefined("agent_defaults", "provider") {
+		dst.Provider = src.Provider
+	}
 	if !meta.IsDefined("agent_defaults", "model") {
 		dst.Model = src.Model
 	}
@@ -3352,6 +3360,18 @@ func InjectImplicitAgents(cfg *City) {
 func ApplyAgentDefaults(cfg *City) {
 	applyAgentSharedAttachmentDefaults(cfg.Agents, cfg.AgentDefaults)
 
+	provider := cfg.AgentDefaults.Provider
+	if provider != "" {
+		for i := range cfg.Agents {
+			if cfg.Agents[i].Name == ControlDispatcherAgentName {
+				continue
+			}
+			if cfg.Agents[i].Provider == "" {
+				cfg.Agents[i].Provider = provider
+			}
+		}
+	}
+
 	formula := cfg.AgentDefaults.DefaultSlingFormula
 	if formula != "" {
 		for i := range cfg.Agents {
@@ -3439,6 +3459,12 @@ func hasDeprecatedAttachmentFields(cfg *City) bool {
 // mergeAgentDefaults merges src into dst using later-layer precedence for
 // scalars and additive append semantics for list fields.
 func mergeAgentDefaults(dst *AgentDefaults, src AgentDefaults, label string, prov *Provenance) {
+	if src.Provider != "" {
+		if prov != nil && dst.Provider != "" && dst.Provider != src.Provider {
+			prov.Warnings = append(prov.Warnings, fmt.Sprintf("agent_defaults.provider redefined by %q", label))
+		}
+		dst.Provider = src.Provider
+	}
 	if src.Model != "" {
 		if prov != nil && dst.Model != "" && dst.Model != src.Model {
 			prov.Warnings = append(prov.Warnings, fmt.Sprintf("agent_defaults.model redefined by %q", label))
@@ -3531,25 +3557,32 @@ func newControlDispatcherAgent(dir string) Agent {
 }
 
 // configuredProviders returns the merged set of providers that are explicitly
-// configured: the union of cfg.Providers keys and cfg.Workspace.Provider.
-// workspace.provider is only included if it names a built-in provider or one
-// already defined in cfg.Providers — a non-builtin workspace.provider without
-// a matching [providers.X] section is ignored (it would create an implicit
-// agent that fails at resolution time).
+// configured: the union of cfg.Providers keys, cfg.AgentDefaults.Provider, and
+// cfg.Workspace.Provider. Scalar provider defaults are only included if they
+// name a built-in provider or one already defined in cfg.Providers — a
+// non-builtin scalar default without a matching [providers.X] section is
+// ignored because it would create an implicit agent that fails at resolution
+// time.
 func configuredProviders(cfg *City) map[string]ProviderSpec {
 	merged := make(map[string]ProviderSpec, len(cfg.Providers)+1)
 	for k, v := range cfg.Providers {
 		merged[k] = v
 	}
-	if wp := cfg.Workspace.Provider; wp != "" {
-		if _, ok := merged[wp]; !ok {
-			// Only promote workspace.provider if it's a known builtin.
-			if _, builtin := BuiltinProviders()[wp]; builtin {
-				merged[wp] = ProviderSpec{}
-			}
-		}
-	}
+	addScalarProviderDefault(merged, cfg.AgentDefaults.Provider)
+	addScalarProviderDefault(merged, cfg.Workspace.Provider)
 	return merged
+}
+
+func addScalarProviderDefault(merged map[string]ProviderSpec, name string) {
+	if name == "" {
+		return
+	}
+	if _, ok := merged[name]; ok {
+		return
+	}
+	if _, builtin := BuiltinProviders()[name]; builtin {
+		merged[name] = ProviderSpec{}
+	}
 }
 
 // configuredProviderOrder returns provider names from the map in a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5910,6 +5910,36 @@ func TestAgentDefaultsProvider_ControlDispatcherSkipped(t *testing.T) {
 	t.Fatal("control-dispatcher agent not found")
 }
 
+func TestAgentDefaultsProvider_BeatsWorkspaceProviderForExplicitAgent(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "demo"
+provider = "claude"
+
+[agent_defaults]
+provider = "codex"
+
+[[agent]]
+name = "worker"
+`)
+
+	cfg, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	for _, a := range cfg.Agents {
+		if a.Name == "worker" {
+			if got := a.Provider; got != "codex" {
+				t.Fatalf("worker Provider = %q, want agent_defaults codex", got)
+			}
+			return
+		}
+	}
+	t.Fatal("worker agent not found")
+}
+
 func TestAgentDefaultsSlingFormula_ImplicitAgents(t *testing.T) {
 	// When agent_defaults.default_sling_formula is set, implicit agents
 	// should use it instead of the hardcoded "mol-do-work".

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5837,6 +5837,79 @@ func TestInjectImplicitAgents_RigInjection(t *testing.T) {
 // agent_defaults.default_sling_formula
 // ---------------------------------------------------------------------------
 
+func TestAgentDefaultsProvider_ExplicitAgentInherits(t *testing.T) {
+	cfg := &City{
+		Agents: []Agent{
+			{Name: "worker"},
+		},
+		AgentDefaults: AgentDefaults{
+			Provider: "codex",
+		},
+	}
+	ApplyAgentDefaults(cfg)
+
+	if got := cfg.Agents[0].Provider; got != "codex" {
+		t.Fatalf("Provider = %q, want codex", got)
+	}
+}
+
+func TestAgentDefaultsProvider_ExplicitOverrideWins(t *testing.T) {
+	cfg := &City{
+		Agents: []Agent{
+			{Name: "worker", Provider: "claude"},
+		},
+		AgentDefaults: AgentDefaults{
+			Provider: "codex",
+		},
+	}
+	ApplyAgentDefaults(cfg)
+
+	if got := cfg.Agents[0].Provider; got != "claude" {
+		t.Fatalf("Provider = %q, want explicit claude", got)
+	}
+}
+
+func TestAgentDefaultsProvider_InjectImplicitAgents(t *testing.T) {
+	cfg := &City{
+		AgentDefaults: AgentDefaults{
+			Provider: "codex",
+		},
+	}
+	InjectImplicitAgents(cfg)
+	ApplyAgentDefaults(cfg)
+
+	for _, a := range cfg.Agents {
+		if a.Name == "codex" && a.Implicit {
+			if got := a.Provider; got != "codex" {
+				t.Fatalf("implicit codex Provider = %q, want codex", got)
+			}
+			return
+		}
+	}
+	t.Fatal("implicit codex agent not found")
+}
+
+func TestAgentDefaultsProvider_ControlDispatcherSkipped(t *testing.T) {
+	cfg := &City{
+		Daemon: DaemonConfig{FormulaV2: true},
+		AgentDefaults: AgentDefaults{
+			Provider: "codex",
+		},
+	}
+	InjectImplicitAgents(cfg)
+	ApplyAgentDefaults(cfg)
+
+	for _, a := range cfg.Agents {
+		if a.Name == ControlDispatcherAgentName {
+			if a.Provider != "" {
+				t.Fatalf("control-dispatcher Provider = %q, want empty", a.Provider)
+			}
+			return
+		}
+	}
+	t.Fatal("control-dispatcher agent not found")
+}
+
 func TestAgentDefaultsSlingFormula_ImplicitAgents(t *testing.T) {
 	// When agent_defaults.default_sling_formula is set, implicit agents
 	// should use it instead of the hardcoded "mol-do-work".

--- a/internal/config/legacy_workspace_warnings.go
+++ b/internal/config/legacy_workspace_warnings.go
@@ -14,7 +14,7 @@ type legacyWorkspaceFieldRule struct {
 var legacyWorkspaceFieldRules = []legacyWorkspaceFieldRule{
 	{
 		field:      "provider",
-		suggestion: "Set provider per agent in agents/<name>/agent.toml.",
+		suggestion: "Use `[agent_defaults] provider` for a city-wide default, or set provider per agent in agents/<name>/agent.toml.",
 		defined: func(ws Workspace, _ map[string]string) bool {
 			return ws.Provider != ""
 		},

--- a/internal/config/legacy_workspace_warnings_test.go
+++ b/internal/config/legacy_workspace_warnings_test.go
@@ -20,7 +20,7 @@ func TestDetectLegacyWorkspaceFields(t *testing.T) {
 			name:      "provider populated",
 			workspace: Workspace{Provider: "claude"},
 			wantField: "workspace.provider",
-			wantHint:  "provider per agent in agents/<name>/agent.toml",
+			wantHint:  "[agent_defaults] provider",
 		},
 		{
 			name:      "start_command populated",

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -12,6 +12,7 @@ import (
 const agentsAliasWarning = "[agents] is a deprecated compatibility alias for [agent_defaults]; rewrite the table name to [agent_defaults]"
 
 var agentDefaultsCompatibilityOverlapKeys = []string{
+	"provider",
 	"model",
 	"wake_mode",
 	"default_sling_formula",
@@ -124,8 +125,6 @@ func agentDefaultsTablesOverlap(md toml.MetaData) bool {
 
 func specializedUndecodedWarning(source, key string) (string, bool) {
 	switch key {
-	case "agent_defaults.provider", "agents.provider":
-		return fmt.Sprintf("%s: %q is not supported in this release wave; keep setting provider per agent in agents/<name>/agent.toml", source, key), true
 	case "agent_defaults.scope", "agents.scope":
 		return fmt.Sprintf("%s: %q is not supported in this release wave; keep setting scope per agent in agents/<name>/agent.toml", source, key), true
 	case "agent_defaults.install_agent_hooks", "agents.install_agent_hooks":

--- a/internal/config/undecoded_test.go
+++ b/internal/config/undecoded_test.go
@@ -302,10 +302,10 @@ func TestParseWithMetaSkipsMixedTableWarningWhenOverlapIsOnlyUnsupportedFutureKe
 name = "test"
 
 [agent_defaults]
-provider = "claude"
+scope = "rig"
 
 [agents]
-provider = "codex"
+scope = "city"
 `
 	_, _, warnings, err := parseWithMeta([]byte(input), "test.toml")
 	if err != nil {
@@ -319,11 +319,11 @@ provider = "codex"
 	foundUnsupported := false
 	foundAlias := false
 	for _, w := range warnings {
-		if strings.Contains(w, `keep setting provider per agent in agents/<name>/agent.toml`) {
+		if strings.Contains(w, `keep setting scope per agent in agents/<name>/agent.toml`) {
 			foundUnsupported = true
 		}
-		if strings.Contains(w, `workspace.provider`) {
-			t.Fatalf("unsupported-key guidance should not point back to deprecated workspace.provider: %v", warnings)
+		if strings.Contains(w, `workspace.scope`) {
+			t.Fatalf("unsupported-key guidance should not point back to workspace.scope: %v", warnings)
 		}
 		if strings.Contains(w, agentsAliasWarning) {
 			foundAlias = true
@@ -343,17 +343,6 @@ func TestParseWithMetaWarnsOnUnsupportedAgentDefaultsMigrationKeys(t *testing.T)
 		input string
 		want  string
 	}{
-		{
-			name: "provider",
-			input: `
-[workspace]
-name = "test"
-
-[agent_defaults]
-provider = "claude"
-`,
-			want: `keep setting provider per agent in agents/<name>/agent.toml`,
-		},
 		{
 			name: "scope",
 			input: `
@@ -406,24 +395,67 @@ install_agent_hooks = ["hooks/gascity.json"]
 	}
 }
 
+func TestParseWithMetaAcceptsAgentDefaultsProvider(t *testing.T) {
+	input := `
+[workspace]
+name = "test"
+
+[agent_defaults]
+provider = "codex"
+`
+	cfg, _, warnings, err := parseWithMeta([]byte(input), "test.toml")
+	if err != nil {
+		t.Fatalf("parseWithMeta: %v", err)
+	}
+	if got := cfg.AgentDefaults.Provider; got != "codex" {
+		t.Fatalf("AgentDefaults.Provider = %q, want codex", got)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w, "agent_defaults.provider") || strings.Contains(w, "unknown field") {
+			t.Fatalf("provider should be a supported agent default, got warnings: %v", warnings)
+		}
+	}
+}
+
+func TestParseWithMetaAgentDefaultsProviderAliasPrefersCanonical(t *testing.T) {
+	input := `
+[workspace]
+name = "test"
+
+[agent_defaults]
+provider = "codex"
+
+[agents]
+provider = "claude"
+`
+	cfg, _, warnings, err := parseWithMeta([]byte(input), "test.toml")
+	if err != nil {
+		t.Fatalf("parseWithMeta: %v", err)
+	}
+	if got := cfg.AgentDefaults.Provider; got != "codex" {
+		t.Fatalf("AgentDefaults.Provider = %q, want canonical codex", got)
+	}
+
+	foundOverlap := false
+	for _, w := range warnings {
+		if strings.Contains(w, "both [agent_defaults] and [agents] are present") {
+			foundOverlap = true
+		}
+		if strings.Contains(w, "agent_defaults.provider") || strings.Contains(w, "unknown field") {
+			t.Fatalf("provider should be a supported agent default, got warnings: %v", warnings)
+		}
+	}
+	if !foundOverlap {
+		t.Fatalf("expected mixed-table warning, got: %v", warnings)
+	}
+}
+
 func TestParsePackConfigWithMetaWarnsOnPackLocalUnsupportedAgentDefaultsKeys(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
 		want  string
 	}{
-		{
-			name: "provider",
-			input: `
-[pack]
-name = "test"
-schema = 2
-
-[agent_defaults]
-provider = "claude"
-`,
-			want: `keep setting provider per agent in agents/<name>/agent.toml`,
-		},
 		{
 			name: "install_agent_hooks",
 			input: `

--- a/internal/config/validate_semantics.go
+++ b/internal/config/validate_semantics.go
@@ -43,6 +43,15 @@ func ValidateSemantics(cfg *City, source string) []string {
 		}
 	}
 
+	// Check agent default provider.
+	if p := cfg.AgentDefaults.Provider; p != "" {
+		if !knownProviders[p] {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s: [agent_defaults] provider %q is not a built-in or city-defined provider",
+				source, p))
+		}
+	}
+
 	// Check agent session field.
 	for _, a := range cfg.Agents {
 		if !IsValidSessionTransport(a.Session) {

--- a/internal/config/validate_semantics_test.go
+++ b/internal/config/validate_semantics_test.go
@@ -65,6 +65,35 @@ func TestValidateSemanticsUnknownWorkspaceProvider(t *testing.T) {
 	}
 }
 
+func TestValidateSemanticsUnknownAgentDefaultsProvider(t *testing.T) {
+	cfg := &City{
+		AgentDefaults: AgentDefaults{Provider: "cdoex"},
+	}
+	warnings := ValidateSemantics(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "[agent_defaults]") {
+		t.Errorf("warning should mention agent_defaults: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "cdoex") {
+		t.Errorf("warning should mention bad provider: %s", warnings[0])
+	}
+}
+
+func TestValidateSemanticsAgentDefaultsCustomProviderOK(t *testing.T) {
+	cfg := &City{
+		AgentDefaults: AgentDefaults{Provider: "local-llm"},
+		Providers: map[string]ProviderSpec{
+			"local-llm": {Command: "local-llm"},
+		},
+	}
+	warnings := ValidateSemantics(cfg, "city.toml")
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for custom agent default provider, got: %v", warnings)
+	}
+}
+
 func TestValidateSemanticsStartCommandSkipsProviderCheck(t *testing.T) {
 	cfg := &City{
 		Agents: []Agent{

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -389,6 +389,9 @@ func normalizedPackAgentDefaults(packCfg packFile) config.AgentDefaults {
 }
 
 func mergeAgentDefaultsAliasForMigration(dst *config.AgentDefaults, src config.AgentDefaults, meta toml.MetaData) {
+	if !meta.IsDefined("agent_defaults", "provider") {
+		dst.Provider = src.Provider
+	}
 	if !meta.IsDefined("agent_defaults", "model") {
 		dst.Model = src.Model
 	}
@@ -416,6 +419,9 @@ func mergeAgentDefaultsAliasForMigration(dst *config.AgentDefaults, src config.A
 }
 
 func mergeMigratedAgentDefaults(dst *config.AgentDefaults, src config.AgentDefaults) {
+	if dst.Provider == "" {
+		dst.Provider = src.Provider
+	}
 	if dst.Model == "" {
 		dst.Model = src.Model
 	}
@@ -433,7 +439,8 @@ func mergeMigratedAgentDefaults(dst *config.AgentDefaults, src config.AgentDefau
 }
 
 func isZeroAgentDefaults(defaults config.AgentDefaults) bool {
-	return defaults.Model == "" &&
+	return defaults.Provider == "" &&
+		defaults.Model == "" &&
 		defaults.WakeMode == "" &&
 		defaults.DefaultSlingFormula == "" &&
 		len(defaults.AllowOverlay) == 0 &&

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -447,6 +447,116 @@ provider = "local"
 	}
 }
 
+func TestMigrateMovesPackAgentDefaultsProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		pack string
+		want []string
+	}{
+		{
+			name: "canonical provider only",
+			pack: `
+[agent_defaults]
+provider = "codex"
+`,
+			want: []string{
+				"[agent_defaults]",
+				`provider = "codex"`,
+			},
+		},
+		{
+			name: "canonical provider mixed with model",
+			pack: `
+[agent_defaults]
+provider = "codex"
+model = "gpt-5"
+`,
+			want: []string{
+				`provider = "codex"`,
+				`model = "gpt-5"`,
+			},
+		},
+		{
+			name: "legacy agents provider only",
+			pack: `
+[agents]
+provider = "claude"
+`,
+			want: []string{
+				"[agent_defaults]",
+				`provider = "claude"`,
+			},
+		},
+		{
+			name: "legacy agents provider fills canonical defaults",
+			pack: `
+[agent_defaults]
+model = "gpt-5"
+
+[agents]
+provider = "claude"
+`,
+			want: []string{
+				`provider = "claude"`,
+				`model = "gpt-5"`,
+			},
+		},
+		{
+			name: "canonical provider beats legacy agents alias",
+			pack: `
+[agent_defaults]
+provider = "codex"
+
+[agents]
+provider = "claude"
+wake_mode = "resume"
+`,
+			want: []string{
+				`provider = "codex"`,
+				`wake_mode = "resume"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cityDir := t.TempDir()
+			writeFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+			writeFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+`+tt.pack)
+
+			if _, err := Apply(cityDir, Options{}); err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+
+			cityToml := readFile(t, filepath.Join(cityDir, "city.toml"))
+			for _, want := range tt.want {
+				if !strings.Contains(cityToml, want) {
+					t.Fatalf("city.toml missing migrated provider default %q:\n%s", want, cityToml)
+				}
+			}
+
+			packToml := readFile(t, filepath.Join(cityDir, "pack.toml"))
+			for _, forbidden := range []string{"[agent_defaults]", "[agents]"} {
+				if strings.Contains(packToml, forbidden) {
+					t.Fatalf("pack.toml still contains %s after migration:\n%s", forbidden, packToml)
+				}
+			}
+		})
+	}
+}
+
 func TestMigrateCreatesFreshBindingWhenExistingImportHasNonDefaultSemantics(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add city-level `agent_defaults.provider` parsing, merge, and provenance behavior
- apply it to agents with no explicit provider and include it in implicit provider-agent injection
- update migration/spec docs, generated config schema docs, and unsupported-key warnings

## Tests
- `make test`
- `go vet ./...`
- focused `internal/config` provider/defaulting tests
- `.githooks/pre-commit` run twice; both reached `test-fast-parallel` and failed in `unit-cmd-gc-4-of-6` on `TestRunSupervisorSIGTERMPreservesSessionsEndToEnd`, while the exact test passed when rerun directly (`go test ./cmd/gc -run ^TestRunSupervisorSIGTERMPreservesSessionsEndToEnd -count=1`)
