### PR TITLE
fix(docs): broken tutorial navigation — readers got raw .md source instead of the rendered page

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -407,7 +407,7 @@ managed city Dolt. Do **not** edit `.beads/dolt-server.port` or
 `bd dolt set port` directly; both self-revert.
 
 See the
-[Managed-city Dolt endpoints runbook](../runbooks/managed-city-endpoints.md)
+[Managed-city Dolt endpoints runbook](/runbooks/managed-city-endpoints)
 for the mental model, the forbidden edits, the sanctioned escape
 hatches (`gc rig set-endpoint --inherit`/`--self --force`/`--external`),
 and an end-to-end recovery recipe.

--- a/docs/troubleshooting/bd-backup-cleanup.md
+++ b/docs/troubleshooting/bd-backup-cleanup.md
@@ -117,7 +117,7 @@ rm -rf ~/qlandia/.beads/backup.old-*
 ### Option C — operator wipe (when the database has shrunk hard)
 
 After running `dolt gc --full` on the source database (see
-[dolt-bloat-recovery.md](dolt-bloat-recovery.md)), the source's noms
+[dolt-bloat-recovery.md](/troubleshooting/dolt-bloat-recovery)), the source's noms
 directory shrinks but the backup remote does not. The full backup
 chain — every chunk ever written — is still on disk in
 `.beads/backup/`.

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -310,9 +310,9 @@ Success! You just dispatched work to an AI agent and gotten results back.
 You've created a city, slung work to agents, added a project as a rig, and slung
 work to that rig. From here:
 
-- **[Agents](./02-agents.md)** — go deeper on agent configuration:
+- **[Agents](/tutorials/02-agents)** — go deeper on agent configuration:
   prompts, sessions, scope, working directories
-- **[Sessions](./03-sessions.md)** — interactive conversations with
+- **[Sessions](/tutorials/03-sessions)** — interactive conversations with
   agents, polecats and crew
-- **[Formulas](./05-formulas.md)** — multi-step workflow templates with
+- **[Formulas](/tutorials/05-formulas)** — multi-step workflow templates with
   dependencies and variables

--- a/docs/tutorials/02-agents.md
+++ b/docs/tutorials/02-agents.md
@@ -4,7 +4,7 @@ sidebarTitle: 02 - Agents
 description: Define agents and use them to execute work.
 ---
 
-In [Tutorial 01](./01-cities-and-rigs.md), you created a city, slung work to an
+In [Tutorial 01](/tutorials/01-cities-and-rigs), you created a city, slung work to an
 implicit agent, and added a rig. The implicit agents (`claude`, `codex`, etc.)
 are convenient, but they have no custom prompt — they're just the raw provider.
 In this tutorial, you'll define your own agents with specific roles and use them
@@ -68,7 +68,7 @@ and execute it.
 ```
 
 The `gc prime` command tells you the prompt an agent is running with. In
-[tutorial 01](./01-cities-and-rigs.md) we learned that slinging work to
+[tutorial 01](/tutorials/01-cities-and-rigs) we learned that slinging work to
 an agent created a bead; the agent's prompt is what tells it how to pick up
 and act on that work. Pass an agent name to inspect a specific agent:
 `gc prime mayor` would print the mayor's prompt;
@@ -155,15 +155,15 @@ No findings.
 This is handy for fire-and-forget kind of work. However, if you'd like to see
 the agent in action or even talk to one directly, you're going to need a
 session. And for that, you'll want to check in on [the next
-tutorial](./03-sessions.md).
+tutorial](/tutorials/03-sessions).
 
 ## What's next
 
 You've defined agents with custom prompts, interacted with them through
 sessions and configured different agents with different providers. From here:
 
-- **[Sessions](./03-sessions.md)** — session lifecycle, sleep/wake,
+- **[Sessions](/tutorials/03-sessions)** — session lifecycle, sleep/wake,
   suspension, named sessions
-- **[Formulas](./05-formulas.md)** — multi-step workflow templates with
+- **[Formulas](/tutorials/05-formulas)** — multi-step workflow templates with
   dependencies and variables
-- **[Beads](./06-beads.md)** — the work tracking system underneath it all
+- **[Beads](/tutorials/06-beads)** — the work tracking system underneath it all

--- a/docs/tutorials/03-sessions.md
+++ b/docs/tutorials/03-sessions.md
@@ -4,7 +4,7 @@ sidebarTitle: 03 - Sessions
 description: See agent output, interact directly with agents, and learn about polecats and crew.
 ---
 
-In [Tutorial 02](./02-agents.md), you worked with agents to produce work,
+In [Tutorial 02](/tutorials/02-agents), you worked with agents to produce work,
 which created sessions with agents that we haven't seen yet. In this tutorial,
 you'll see and talk with agents via sessions as well as see how agents talk to
 each other. You'll also learn the difference between "polecats" (agents spun up
@@ -279,8 +279,8 @@ You've seen how sessions are created on demand for slung work, how named
 sessions keep crew agents alive, and how to peek, attach, nudge, and read logs.
 From here:
 
-- **[Agent-to-Agent Communication](./04-communication.md)** — how agents
+- **[Agent-to-Agent Communication](/tutorials/04-communication)** — how agents
   coordinate through mail, slung work, and hooks
-- **[Formulas](./05-formulas.md)** — multi-step workflow templates with
+- **[Formulas](/tutorials/05-formulas)** — multi-step workflow templates with
   dependencies and variables
-- **[Beads](./06-beads.md)** — the work tracking system underneath it all
+- **[Beads](/tutorials/06-beads)** — the work tracking system underneath it all

--- a/docs/tutorials/04-communication.md
+++ b/docs/tutorials/04-communication.md
@@ -4,7 +4,7 @@ sidebarTitle: 04 - Communication
 description: How agents coordinate through mail, slung work, and hooks — without direct connections.
 ---
 
-In [Tutorial 03](./03-sessions.md), you saw how to peek at agent output in
+In [Tutorial 03](/tutorials/03-sessions), you saw how to peek at agent output in
 polecat sessions, attach to crew sessions, and nudge them with messages. All of
 that was you talking to agents. This tutorial covers how agents talk to _each
 other_.
@@ -170,6 +170,6 @@ Without hooks, you'd have to manually tell each agent to run `gc mail check` and
 You've seen the two coordination mechanisms — mail for messages and slung beads
 for work — and the hook infrastructure that wires it all together. From here:
 
-- **[Formulas](./05-formulas.md)** — multi-step workflow templates with
+- **[Formulas](/tutorials/05-formulas)** — multi-step workflow templates with
   dependencies and variables
-- **[Beads](./06-beads.md)** — the work tracking system underneath it all
+- **[Beads](/tutorials/06-beads)** — the work tracking system underneath it all

--- a/docs/tutorials/05-formulas.md
+++ b/docs/tutorials/05-formulas.md
@@ -508,7 +508,7 @@ and Check.
 
 ## What's next
 
-- **[Beads](./06-beads.md)** — the universal work primitive underneath
+- **[Beads](/tutorials/06-beads)** — the universal work primitive underneath
   formulas, sessions, and everything else
-- **[Orders](./07-orders.md)** — formulas with scheduling triggers for
+- **[Orders](/tutorials/07-orders)** — formulas with scheduling triggers for
   periodic dispatch

--- a/docs/tutorials/06-beads.md
+++ b/docs/tutorials/06-beads.md
@@ -12,7 +12,7 @@ Beads are the universal work primitive in Gas City. Every trackable thing —
 tasks, messages, sessions, molecules, convoys — is a bead in the store. This
 tutorial peels back the layer and shows you what's underneath.
 
-We'll pick up where [Tutorial 03](./03-sessions.md) left off. You
+We'll pick up where [Tutorial 03](/tutorials/03-sessions) left off. You
 should have `my-city` running with `my-project` rigged, and agents for `mayor`
 and `reviewer` (along with the corresponding prompts):
 
@@ -474,5 +474,5 @@ Gas City — sessions, mail, formulas, convoys — is built on top of them.
 
 ## What's next
 
-- **[Orders](./07-orders.md)** — formulas and scripts on autopilot, triggered
+- **[Orders](/tutorials/07-orders)** — formulas and scripts on autopilot, triggered
   by time, schedule, conditions, or events

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -14,7 +14,7 @@ wakes up every 30 seconds (a _tick_), checks the state of the city, and takes
 action. One of the things it does on each tick is evaluate the triggers that
 unblock an order from running. That periodic check is what makes orders work.
 
-We'll pick up where [Tutorial 06](./06-beads.md) left off. You should
+We'll pick up where [Tutorial 06](/tutorials/06-beads) left off. You should
 have `my-city` running with agents and formulas configured.
 
 If you've been dispatching formulas by hand with `gc sling`, orders are the next
@@ -508,7 +508,7 @@ Here's a city with two orders: a frequent lint check (exec, no agent needed) and
 weekly release notes (formula, dispatched to an agent).
 
 Assume you've already created a `worker` agent as in
-[Tutorial 05](./05-formulas.md). The remaining pieces are just the order
+[Tutorial 05](/tutorials/05-formulas). The remaining pieces are just the order
 files and the formula they dispatch.
 
 ```toml

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -12,10 +12,10 @@ workflows.
 
 | Tutorial                     | Description                         |
 | ---------------------------- | ----------------------------------- |
-| [Cities and Rigs](./01-cities-and-rigs.md) | Creating and managing a workspace   |
-| [Agents](./02-agents.md)          | Configuring agent templates         |
-| [Sessions](./03-sessions.md)      | Running and interacting with agents |
-| [Communication](./04-communication.md) | Agent-to-agent coordination    |
-| [Formulas](./05-formulas.md)      | Declarative workflow templates      |
-| [Beads](./06-beads.md)            | The universal work primitive        |
-| [Orders](./07-orders.md)          | Scheduled and event-driven dispatch |
+| [Cities and Rigs](/tutorials/01-cities-and-rigs) | Creating and managing a workspace   |
+| [Agents](/tutorials/02-agents)          | Configuring agent templates         |
+| [Sessions](/tutorials/03-sessions)      | Running and interacting with agents |
+| [Communication](/tutorials/04-communication) | Agent-to-agent coordination    |
+| [Formulas](/tutorials/05-formulas)      | Declarative workflow templates      |
+| [Beads](/tutorials/06-beads)            | The universal work primitive        |
+| [Orders](/tutorials/07-orders)          | Scheduled and event-driven dispatch |


### PR DESCRIPTION
> **⚠️ Every published tutorial shipped with broken in-page navigation.**
> On the live site, clicking a cross-link in a tutorial — e.g. **“Tutorial 06”** on the Orders
> page — did **not** take the reader to the next tutorial. It dumped the raw `.md` source in their
> browser (`text/markdown`). Every tutorial-to-tutorial link was affected.

## Before / after (live site)

Here is exactly what a reader got before vs. after the fix when clicking **"Tutorial 06"** on the Orders tutorial — captured against the live site with Playwright. Before, the link was broken: it served raw markdown instead of the page.

![before/after](https://gist.githubusercontent.com/idvorkin-ai-tools/7b396a44d59818c2b609907d59f8ec21/raw/ba-combined.png)

- **Before:** the link `[Tutorial 06](./06-beads.md)` resolves to `/tutorials/06-beads.md`, which Mintlify serves as **raw markdown** (`text/markdown`).
- **After:** it resolves to `/tutorials/06-beads`, the **rendered page** (`text/html`).

_(The local `mint dev` preview hides this — the docs.json `.md` redirect returns 307 there — but on production the redirect doesn't fire, so the raw-markdown response above is what ships today.)_

---

## Problem

Internal cross-page links in the docs use relative `.md` targets, e.g. in `docs/tutorials/07-orders.md`:

```markdown
We'll pick up where [Tutorial 06](./06-beads.md) left off.
```

Mintlify renders that href verbatim, so on the published site it points at `/tutorials/06-beads.md`. That path hits Mintlify's built-in **markdown route** (the `.md` copy it serves for LLMs), which returns `text/markdown` — so a reader who clicks the link gets raw page source instead of the rendered page.

```console
$ curl -sI https://docs.gascityhall.com/tutorials/06-beads.md  | grep -i content-type
content-type: text/markdown; charset=utf-8          # ❌ raw source

$ curl -sI https://docs.gascityhall.com/tutorials/06-beads     | grep -i content-type
content-type: text/html; charset=utf-8              # ✅ rendered page
```

The `/tutorials/*.md` redirects added in 9da60e5 don't help: Mintlify's `.md` route precedes user-defined redirects, so `GET /tutorials/07-orders.md` still returns `200 text/markdown` with no redirect.

## Fix

Switch the affected links to **root-absolute, extensionless** form (`/tutorials/06-beads`). This:

- serves the rendered HTML page (verified above),
- matches the `/tutorials/05-formulas` link **already present** in `07-orders.md`, and
- still passes the `test/docsync` link-checker, which resolves absolute links against `docs/` and accepts extensionless targets (`localLinkExists` tries `path + ".md"`).

31 links across 10 files: all 7 tutorials + `tutorials/index.md`, plus two non-tutorial cross-links that point at published pages (`getting-started/troubleshooting.md` → runbook, `troubleshooting/bd-backup-cleanup.md` → `dolt-bloat-recovery`).

## Out of scope (intentionally untouched)

- The two `../../engdocs/design/...md` links in `docs/runbooks/managed-city-endpoints.md` point **outside** the published `docs/` tree (engdocs isn't published — those URLs 404 on the live site). Making them extensionless wouldn't help; they need a different fix (link to GitHub source), so I left them.
- The dead `/tutorials/*.md` redirects in `docs/docs.json` are now unused. I left them in place rather than bundle a config deletion, but they can be removed — they don't fire.

## How this was verified

**1. Ran the docs locally** with the repo's own preview server — `./mint.sh dev` (Mintlify `mint dev`, Node 22) — pointed at this branch, then clicked through every tutorial cross-link. Each now lands on a rendered HTML page, and the in-page hrefs are emitted extensionless (`/tutorials/06-beads`, not `…/06-beads.md`):

```console
$ for p in 01-cities-and-rigs 02-agents 03-sessions 04-communication 05-formulas 06-beads 07-orders index; do
    code=$(curl -so /dev/null -w '%{http_code} %{content_type}' http://localhost:3000/tutorials/$p)
    echo "$code  /tutorials/$p"
  done
200 text/html; charset=utf-8  /tutorials/01-cities-and-rigs
200 text/html; charset=utf-8  /tutorials/02-agents
...                            (all eight → 200 text/html)
```

I also **previewed the rendered pages visually with Playwright** — driving a real browser and capturing the screenshots above — to confirm they actually *look* correct, not just that they return `200`. On `/tutorials/07-orders` the "Tutorial 06" link reports `href="/tutorials/06-beads"`, and clicking it renders the page titled *"Tutorial 06 - Beads"* (the "after" panel above).

**2. Ran the repo link-checker** — `test/docsync` resolves every doc link and passes:

```console
$ go test ./test/docsync/ -run 'Link|DocDir|Schema' -count=1
ok  	github.com/gastownhall/gascity/test/docsync	2.502s
```

No code or tests outside `docs/` reference the old link strings.

> Note: the broken raw-markdown response only reproduces on **production**. The local `mint dev` preview applies the docs.json `.md` → extensionless redirect (HTTP 307), so it *hides* the bug — which is why the "before" panel above was captured against the live site, not localhost.


