### PR TITLE
fix(dolt): prove gain+drift row preservation directly (Option A, #2846)

### DIFF
--- a/examples/dolt/assets/scripts/compact-gain-drift-proof.sh
+++ b/examples/dolt/assets/scripts/compact-gain-drift-proof.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# compact-gain-drift-proof.sh — Option A row-preservation proof for the
+# post-flatten gain+drift case (gastownhall/gascity#2846).
+#
+# When verify_counts sees a table gain rows AND its value hash drift, the
+# safety property at stake ("pre-flight rows remain reachable") cannot be
+# inferred from HEAD movement alone: a concurrent writer whose commit is
+# ABSORBED into the flatten commit moves no HEAD, so the HEAD-proven gate
+# misses it and a benign race is hard-quarantined — which then blocks all
+# future GC of a busy DB (the memory-exhaustion failure the code calls out).
+#
+# This proves preservation DIRECTLY: for each gained+drifted table, diff the
+# pre-flight snapshot HEAD against the flatten commit. If the only change is
+# `added` rows (no `removed`/`modified`), every pre-flight row survived and the
+# gain is concurrent-writer data — defer, exactly as the HEAD-proven path does.
+# It is strictly more rigorous than the HEAD proxy: it proves reachability
+# instead of inferring it. Any removed/modified row, or any probe failure,
+# fails closed and falls through to quarantine.
+#
+# Depends on `query_single_cell` and `valid_table_name` from run.sh.
+
+# gain_drift_is_additive_only <db> <from_head> <to_head> <space-separated tables>
+# Returns 0 iff every listed table's <from>..<to> content diff contains only
+# `added` rows. Returns non-zero (fail closed) if either commit endpoint is
+# missing, the table list is empty, a table name is invalid, a diff probe
+# fails or returns a non-numeric result, or any table shows removed/modified
+# rows.
+gain_drift_is_additive_only() {
+  _gd_db="$1"
+  _gd_from="$2"
+  _gd_to="$3"
+  _gd_tables="$4"
+  # Without both commit endpoints there is nothing to diff against — fail closed.
+  [ -n "$_gd_from" ] && [ -n "$_gd_to" ] || return 1
+  _gd_seen=0
+  for _gd_t in $_gd_tables; do
+    _gd_seen=1
+    valid_table_name "$_gd_t" || return 1
+    # Count rows that are NOT purely additive between the pre-flight snapshot
+    # and the flatten commit. Zero means every pre-flight row is reachable
+    # unchanged and only concurrent-writer rows were added.
+    if ! _gd_nonadded=$(query_single_cell "$_gd_db" \
+      "gain+drift preservation diff probe failed for table=$_gd_t" \
+      "SELECT COUNT(*) FROM DOLT_DIFF('$_gd_from', '$_gd_to', '$_gd_t') WHERE diff_type <> 'added'"); then
+      return 1
+    fi
+    case "$_gd_nonadded" in
+      0) ;;                    # only added rows — this table's pre-flight rows preserved
+      ''|*[!0-9]*) return 1 ;; # empty/non-numeric probe result — fail closed
+      *) return 1 ;;           # one or more removed/modified rows — not preservable
+    esac
+  done
+  # An empty table list is not a proof of preservation.
+  [ "$_gd_seen" = "1" ] || return 1
+  return 0
+}

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -162,6 +162,8 @@ esac
 PACK_DIR="${GC_PACK_DIR:-$(unset CDPATH; cd -- "$(dirname "$0")/.." && pwd)}"
 # shellcheck disable=SC1091
 . "$PACK_DIR/assets/scripts/runtime.sh"
+# shellcheck disable=SC1091
+. "$PACK_DIR/assets/scripts/compact-gain-drift-proof.sh"
 
 if [ "${GC_DOLT_MANAGED_LOCAL:-}" = "1" ]; then
   managed_port=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" || true)
@@ -786,6 +788,7 @@ verify_counts() {
   fail=0
   verify_counts_saw_gain=0
   verify_counts_saw_gain_hash_drift=0
+  verify_counts_gain_drift_tables=""
   verify_counts_saw_row_decrease=0
   verify_counts_saw_same_count_hash_drift=0
   verify_counts_saw_table_list_change=0
@@ -863,6 +866,7 @@ verify_counts() {
     if [ "$actual_hash" != "$expected_hash" ]; then
       if [ "$table_gained_rows" = "1" ]; then
         verify_counts_saw_gain_hash_drift=1
+        verify_counts_gain_drift_tables="$verify_counts_gain_drift_tables $t"
         printf 'compact: db=%s table=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
           "$db" "$t" "$expected_hash" "$actual_hash" >&2
         if [ "$fail" -ne 1 ]; then
@@ -1463,6 +1467,7 @@ flatten_database() {
   db="$1"
   verify_counts_saw_gain=0
   verify_counts_saw_gain_hash_drift=0
+  verify_counts_gain_drift_tables=""
   verify_counts_saw_row_decrease=0
   verify_counts_saw_same_count_hash_drift=0
   verify_counts_saw_table_list_change=0
@@ -1929,6 +1934,33 @@ flatten_database() {
       rm -f "$preflight_tmp"
       return 0
     fi
+    # Option A (#2846): HEAD movement is only a proxy for "pre-flight rows
+    # remain reachable". When gain+drift is the only failure category but no
+    # concurrent writer was HEAD-proven — the absorbed-writer race, where the
+    # writer's commit was folded into the flatten and left no HEAD fingerprint
+    # — prove preservation directly by diffing the pre-flight snapshot HEAD
+    # against the flatten commit for each gained+drifted table. Purely additive
+    # (no removed/modified rows) proves every pre-flight row survived; defer
+    # exactly as the HEAD-proven path above does. Any removed/modified row, or
+    # a diff-probe failure, fails closed and falls through to the quarantine.
+    if [ "${verify_counts_saw_gain:-0}" = "1" ] && \
+       [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ] && \
+       [ "${verify_counts_saw_row_decrease:-0}" != "1" ] && \
+       [ "${verify_counts_saw_same_count_hash_drift:-0}" != "1" ] && \
+       [ "${verify_counts_saw_table_list_change:-0}" != "1" ] && \
+       [ "${verify_counts_saw_probe_failure:-0}" != "1" ] && \
+       gain_drift_is_additive_only "$db" "$head" "$flatten_head" "$verify_counts_gain_drift_tables"; then
+      printf 'compact: db=%s gain+drift proven additive-only via DOLT_DIFF(%s..%s) for tables [%s] — pre-flight rows preserved (absorbed-writer race), not corruption; deferring, will retry next run\n' \
+        "$db" "$head" "$flatten_head" "${verify_counts_gain_drift_tables# }" >&2
+      if ! defer_writer_race_after_flatten "$db" "$flatten_head" \
+        "$remote" "$expected_remote_head" "$expected_remote_head_verified" \
+        "${compacted_from_head:-}" "$local_branch" "$remote_branch"; then
+        rm -f "$preflight_tmp"
+        return 1
+      fi
+      rm -f "$preflight_tmp"
+      return 0
+    fi
     if [ "$writer_race_detected" = "1" ] && \
        [ "${verify_counts_saw_gain_hash_drift:-0}" = "1" ]; then
       printf 'compact: db=%s writer race detected during flatten (snapshot_HEAD=%s pre_reset_HEAD=%s flatten_HEAD=%s post_verify_HEAD=%s), but additional integrity failure category prevents defer; quarantine unchanged\n' \
@@ -2021,6 +2053,14 @@ flatten_database() {
         rm -f "$preflight_tmp"
         return 0
       fi
+      # Option A's per-table DOLT_DIFF preservation proof is intentionally NOT
+      # extended to this whole-database value-hash path. It is reachable only
+      # when per-table verify already PASSED (verify_counts_rc==0) yet the
+      # aggregate DB hash drifted with a row gain and no writer was HEAD-proven
+      # — a near-unreachable combination for real appends, since a genuine
+      # per-table row gain would have tripped the per-table gain+drift signal
+      # (proven additive-only and deferred above). Quarantine is the safe
+      # default here; revisit only if a real incident shows this path reachable.
       printf 'compact: db=%s value hash changed with row-count increase before=%s after=%s — quarantine and investigate before GC\n' \
         "$db" "$preflight_hash" "$postflight_hash" >&2
       write_compact_marker "$quarantine_dir" "$db" "post-flatten value hash changed with row-count increase" || {

--- a/test/dolt/compact_gain_drift_proof_test.sh
+++ b/test/dolt/compact_gain_drift_proof_test.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Unit test for gain_drift_is_additive_only (Option A preservation proof, #2846).
+# Lib under test: examples/dolt/assets/scripts/compact-gain-drift-proof.sh
+#
+# Stubs the run.sh-provided dependencies (query_single_cell, valid_table_name)
+# so the additive-only classification is exercised without a live Dolt server.
+# The full flatten path needs a concurrent-writer race that cannot be reproduced
+# deterministically in a unit test (see #2846); this covers the decision logic.
+set -u
+
+HERE=$(unset CDPATH; cd -- "$(dirname "$0")" && pwd)
+LIB="$HERE/../../examples/dolt/assets/scripts/compact-gain-drift-proof.sh"
+[ -f "$LIB" ] || { echo "FAIL: lib not found at $LIB"; exit 1; }
+
+# --- stubs for run.sh-provided helpers --------------------------------------
+# query_single_cell <db> <msg> <query>: extract the table from the DOLT_DIFF
+# query and echo the canned non-added count stub_count_<table> (default 0).
+# STUB_FAIL_TABLE forces a probe failure; STUB_EMPTY_TABLE forces an empty result.
+query_single_cell() {
+  _t=$(printf '%s\n' "$3" | sed -n "s/.*DOLT_DIFF('[^']*', *'[^']*', *'\([^']*\)').*/\1/p")
+  if [ -n "${STUB_FAIL_TABLE:-}" ] && [ "$_t" = "$STUB_FAIL_TABLE" ]; then
+    return 1
+  fi
+  if [ -n "${STUB_EMPTY_TABLE:-}" ] && [ "$_t" = "$STUB_EMPTY_TABLE" ]; then
+    printf ''
+    return 0
+  fi
+  case "$_t" in
+    issues) printf '%s' "${stub_count_issues:-0}" ;;
+    mail) printf '%s' "${stub_count_mail:-0}" ;;
+    *) printf '0' ;;
+  esac
+  return 0
+}
+valid_table_name() {
+  if [ -n "${STUB_INVALID_TABLE:-}" ] && [ "$1" = "$STUB_INVALID_TABLE" ]; then
+    return 1
+  fi
+  return 0
+}
+
+# shellcheck disable=SC1090  # $LIB path is computed from the test's own location
+. "$LIB"
+
+# --- harness ----------------------------------------------------------------
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf 'FAIL - %s\n' "$1"; }
+reset() {
+  unset STUB_FAIL_TABLE STUB_EMPTY_TABLE STUB_INVALID_TABLE \
+    stub_count_issues stub_count_mail 2>/dev/null || true
+}
+
+# 1. single table, purely additive -> preserved (defer)
+reset; stub_count_issues=0
+if gain_drift_is_additive_only db H1 H2 "issues"; then ok "additive-only single table -> defer"; else no "additive-only single table -> defer"; fi
+
+# 2. single table with removed/modified rows -> not preservable (quarantine)
+reset; stub_count_issues=2
+if gain_drift_is_additive_only db H1 H2 "issues"; then no "removed/modified -> quarantine"; else ok "removed/modified -> quarantine"; fi
+
+# 3. two tables, both additive -> preserved
+reset; stub_count_issues=0; stub_count_mail=0
+if gain_drift_is_additive_only db H1 H2 "issues mail"; then ok "two additive tables -> defer"; else no "two additive tables -> defer"; fi
+
+# 4. two tables, one not additive -> not preservable
+reset; stub_count_issues=0; stub_count_mail=5
+if gain_drift_is_additive_only db H1 H2 "issues mail"; then no "mixed tables -> quarantine"; else ok "mixed tables -> quarantine"; fi
+
+# 5. diff probe failure on a table -> fail closed
+reset; stub_count_issues=0; STUB_FAIL_TABLE=mail
+if gain_drift_is_additive_only db H1 H2 "issues mail"; then no "probe failure -> quarantine"; else ok "probe failure -> quarantine"; fi
+
+# 6. empty / non-numeric probe result -> fail closed
+reset; STUB_EMPTY_TABLE=issues
+if gain_drift_is_additive_only db H1 H2 "issues"; then no "empty probe result -> quarantine"; else ok "empty probe result -> quarantine"; fi
+
+# 7. empty table list -> not a proof
+reset
+if gain_drift_is_additive_only db H1 H2 ""; then no "empty table list -> quarantine"; else ok "empty table list -> quarantine"; fi
+
+# 8. missing from-head -> fail closed
+reset; stub_count_issues=0
+if gain_drift_is_additive_only db "" H2 "issues"; then no "missing from-head -> quarantine"; else ok "missing from-head -> quarantine"; fi
+
+# 9. missing to-head -> fail closed
+reset; stub_count_issues=0
+if gain_drift_is_additive_only db H1 "" "issues"; then no "missing to-head -> quarantine"; else ok "missing to-head -> quarantine"; fi
+
+# 10. invalid table name -> fail closed
+reset; stub_count_issues=0; STUB_INVALID_TABLE=issues
+if gain_drift_is_additive_only db H1 H2 "issues"; then no "invalid table name -> quarantine"; else ok "invalid table name -> quarantine"; fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Switches the post-flatten gain+drift handling to the strictly-safe **Option A** from #2846 (this PR previously implemented the bounded-retry Option B), rebased onto current `main`.

## Problem (full write-up in #2846)

`gc dolt compact` permanently quarantines a **gain+drift** post-flatten result (a table gained rows *and* its value hash changed) when no concurrent writer is HEAD-provable. On a busy primary DB the racing writer is usually **absorbed into the flatten commit** (no HEAD fingerprint), so the benign race is misclassified as possible corruption and the permanent quarantine then **blocks all future GC of that db** — the memory-exhaustion failure the code's own comments call out. Real incident: town `hq` stuck at **16,822 commits / 3.9 GB**; after clearing the marker one compaction went **16,822 → 2 commits, 3.9 GB → 898 MB in 23 s, zero data loss**.

## What this does (Option A — prove preservation directly)

HEAD movement is only a proxy for the actual safety property (*"pre-flight rows remain reachable"*). When `verify_counts` flags gain+drift as the **only** failure category, `gain_drift_is_additive_only` diffs the pre-flight snapshot HEAD against the flatten commit for each gained+drifted table:

```sql
SELECT COUNT(*) FROM DOLT_DIFF('<head>', '<flatten_head>', '<table>') WHERE diff_type <> 'added'
```

- **0 non-added rows** (only `added`) → every pre-flight row is preserved → **defer** via the existing `defer_writer_race_after_flatten`, retry next run.
- **Any removed/modified row, or any probe failure** → fail closed → **quarantine** unchanged.

This proves reachability instead of inferring it from HEAD movement, closing the absorbed-writer gap. `row_decrease`, `same_count_hash_drift`, `table_list_change`, and probe failures still quarantine unchanged. **No GC ever runs on an unverified flatten.** The whole-DB value-hash path carries an exclusion comment (near-unreachable; the per-table proof covers real appends).

## Files

- `examples/dolt/assets/scripts/compact-gain-drift-proof.sh` — `gain_drift_is_additive_only`
- `examples/dolt/commands/compact/run.sh` — collect gained+drifted tables in `verify_counts`; run the proof before the gain+drift quarantine; db-level exclusion comment
- `test/dolt/compact_gain_drift_proof_test.sh` — classification unit test (10 assertions)

## Tests / verification

`sh -n` / `bash -n` clean; `shellcheck -s sh` clean on the new lib + test and adds **no new findings** to `run.sh`; the unit test passes 10 assertions (additive-only → defer; removed/modified, mixed-table, probe failure, empty list, missing endpoint, invalid name → quarantine). The live concurrent-writer race can't be reproduced deterministically in a unit test (#2846), so the diff classification plus the real incident cover the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
