### PR TITLE
fix(dispatch): control-dispatcher survives transient work-query timeout

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3952,6 +3953,54 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 	}
 	if !slices.Equal(waitCalls, want) {
 		t.Fatalf("wait calls = %#v, want %#v", waitCalls, want)
+	}
+}
+
+// TestRunWorkflowServeFollowSurvivesTransientWorkQueryTimeout is the
+// regression guard for the bug where a single transient work-query timeout
+// (the bead store briefly saturated) killed the entire control-dispatcher
+// --follow loop, leaving the rig un-dispatched while its session bead still
+// reported "active". The loop must survive transient failures and only exit on
+// genuinely fatal ones.
+func TestRunWorkflowServeFollowSurvivesTransientWorkQueryTimeout(t *testing.T) {
+	eventsDir := t.TempDir()
+	ep := newTestProvider(t, eventsDir)
+
+	prevList := workflowServeList
+	prevProvider := workflowServeOpenEventsProvider
+	prevWait := workflowServeWaitForWake
+	t.Cleanup(func() {
+		workflowServeList = prevList
+		workflowServeOpenEventsProvider = prevProvider
+		workflowServeWaitForWake = prevWait
+	})
+
+	workflowServeOpenEventsProvider = func(io.Writer) (events.Provider, error) { return ep, nil }
+	workflowServeWaitForWake = func(_ <-chan workflowWatchResult, _ time.Duration, _ int) (bool, error) {
+		return false, nil
+	}
+
+	// Drain 1 hits a transient work-query timeout (wraps DeadlineExceeded) — the
+	// loop must survive it. Drain 2 returns a genuinely fatal error — the loop
+	// must exit on that.
+	transientErr := fmt.Errorf("querying control work: running work query %q: timed out after 30s: %w", "bd ready", context.DeadlineExceeded)
+	fatalErr := errors.New("malformed work query: jq: command not found")
+	calls := 0
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		calls++
+		if calls == 1 {
+			return nil, transientErr
+		}
+		return nil, fatalErr
+	}
+
+	agent := config.Agent{Name: "control-dispatcher"}
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	if !errors.Is(err, fatalErr) {
+		t.Fatalf("runWorkflowServeFollow err = %v, want fatal error after surviving the transient timeout", err)
+	}
+	if calls != 2 {
+		t.Fatalf("workflowServeList calls = %d, want 2 (survive transient, then exit on fatal)", calls)
 	}
 }
 

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -236,11 +236,17 @@ func shellWorkQueryWithEnv(command, dir string, env []string) (string, error) {
 	cmd.Env = workQueryEnvForDir(env, dir)
 	out, err := cmd.Output()
 	if ctx.Err() == context.DeadlineExceeded {
+		// Wrap context.DeadlineExceeded so callers can classify the timeout as
+		// transient (dispatch.IsTransientControllerError / errors.Is). Without
+		// this, a work-query timeout reads as an opaque fatal error and kills
+		// long-running consumers like the control-dispatcher --follow loop even
+		// though the timeout is just transient bead-store load. The human-facing
+		// "timed out after" text is preserved.
 		msg := strings.TrimSpace(string(out))
 		if msg != "" {
-			return string(out), fmt.Errorf("running work query %q: timed out after %s with partial stdout %q", command, hookWorkQueryTimeout, msg)
+			return string(out), fmt.Errorf("running work query %q: timed out after %s with partial stdout %q: %w", command, hookWorkQueryTimeout, msg, context.DeadlineExceeded)
 		}
-		return "", fmt.Errorf("running work query %q: timed out after %s", command, hookWorkQueryTimeout)
+		return "", fmt.Errorf("running work query %q: timed out after %s: %w", command, hookWorkQueryTimeout, context.DeadlineExceeded)
 	}
 	if err != nil {
 		return "", fmt.Errorf("running work query %q: %w", command, err)

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,8 +12,36 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/dispatch"
 	"github.com/gastownhall/gascity/internal/events"
 )
+
+// TestShellWorkQueryTimeoutClassifiesTransient guards the contract the
+// control-dispatcher --follow loop depends on: a work-query timeout must be
+// classifiable as a transient store error (wrapping context.DeadlineExceeded)
+// so the loop retries instead of dying when the bead store is briefly loaded.
+func TestShellWorkQueryTimeoutClassifiesTransient(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	prev := hookWorkQueryTimeout
+	hookWorkQueryTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { hookWorkQueryTimeout = prev })
+
+	_, err := shellWorkQueryWithEnv("sleep 5", "", nil)
+	if err == nil {
+		t.Fatal("shellWorkQueryWithEnv err = nil, want timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out after") {
+		t.Fatalf("err = %v, want human-facing timed-out message preserved", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want errors.Is(err, context.DeadlineExceeded)", err)
+	}
+	if !dispatch.IsTransientControllerError(err) {
+		t.Fatalf("dispatch.IsTransientControllerError(%v) = false, want true", err)
+	}
+}
 
 func TestCmdHookQueryKillEmitsCurrentSessionTemplate(t *testing.T) {
 	clearGCEnv(t)

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -556,7 +556,20 @@ func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuer
 	for {
 		drainResult, err := drainWorkflowServeWork(agentCfg, cityPath, storePath, workQuery, workEnv, stderr)
 		if err != nil {
-			return err
+			// A transient work-query/store failure — most commonly the
+			// work-query timeout (hookWorkQueryTimeout) when the bead store is
+			// briefly saturated — must NOT terminate this long-running serve
+			// loop. drainWorkflowServeWork already surfaced the failure on the
+			// event bus for reconciler visibility (#1496/#1497); returning here
+			// kills the dispatcher process (pane exits non-zero) and leaves the
+			// rig un-dispatched while its session bead still reports "active".
+			// Downgrade to a no-progress sweep so the idle backoff retries it;
+			// only genuinely fatal errors end the loop.
+			if !dispatch.IsTransientControllerError(err) {
+				return err
+			}
+			workflowTracef("serve drain-transient-retry agent=%s err=%v", agentCfg.QualifiedName(), err)
+			drainResult = workflowServeDrainResult{}
 		}
 		if drainResult.processedAny || drainResult.pendingAny {
 			idleSweeps = 0


### PR DESCRIPTION
## Problem

The control-dispatcher `--follow` loop (`runWorkflowServeFollow`) returns on **any** error from `drainWorkflowServeWork`:

```go
drainResult, err := drainWorkflowServeWork(...)
if err != nil {
    return err   // kills the long-running dispatcher process
}
```

So a single **transient work-query timeout** — the `bd ready` work query exceeding `hookWorkQueryTimeout` (30s) while the bead store is briefly saturated — terminates the entire dispatcher. The pane exits non-zero, but the session bead still reports `active` (state-lie), and the rig goes **un-dispatched**: nothing routes ready work to pools, so `in_progress` stays at 0.

Observed on a busy multi-rig city: every Dolt-load spike (restart storms, GC, large scans) killed all control-dispatchers, and the reconciler couldn't recover them because it believed they were still up.

## Root cause

Three individually-reasonable changes left a gap:

1. **#2002** bounded the work query with a 30s timeout — creating the timeout failure mode. The timeout error was built with a plain `fmt.Errorf`, **not** wrapping `context.DeadlineExceeded`, so it can't be classified as transient.
2. The transient-retry added in `09db8d0a0` only covered the control-bead **processing** error path (inside `drainWorkflowServeWork`), not the **work-query** error path.
3. **#1496 / #2417** made a killed/timed-out work query **observable** (emit a `SessionWorkQueryFailed` event) but explicitly accepted that the session dies — never made the loop survive it.

No test exercised a **work-query error in follow mode** — work-query errors were only tested via the non-follow single-drain path (where returning the error is correct), so the gap stayed green.

## Fix

- **`cmd_hook.go`**: wrap `context.DeadlineExceeded` in the work-query timeout error (human-facing `timed out after` text preserved) so callers can classify it via `dispatch.IsTransientControllerError` / `errors.Is`.
- **`dispatch_runtime.go`**: in `runWorkflowServeFollow`, retry transient drain failures (downgrade to a no-progress sweep so the existing idle backoff applies) instead of returning. Only genuinely fatal errors end the loop. The failure is still emitted on the event bus for reconciler visibility.

Control-bead *processing* errors are unaffected — `drainWorkflowServeWork` already converts transient ones to "pending" internally, so only non-transient processing errors reach the loop and still propagate.

## Tests

- `TestShellWorkQueryTimeoutClassifiesTransient` — the work-query timeout is now `errors.Is(context.DeadlineExceeded)` and classified transient.
- `TestRunWorkflowServeFollowSurvivesTransientWorkQueryTimeout` — the follow loop survives a transient timeout and exits only on a subsequent fatal error.
