### PR TITLE
feat: stamp executing session identity on in-progress run beads

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -465,6 +465,14 @@ func buildDesiredStateWithSessionBeads(
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
+		// Durably record which session is executing each in-progress work
+		// bead. The Assignee link is transient (cleared on close), so without
+		// this a completed run carries no session/worktree reference. See
+		// stampRunSessionIdentity. Unlike drain decisions, this is not gated on
+		// storePartial: stamping the beads that WERE collected is always
+		// correct, and any bead missed by a partial query simply gets stamped
+		// on a later tick.
+		stampRunSessionIdentity(assignedWorkBeads, assignedWorkStores, sessionBeads, stderr)
 		scaleCheckCounts, poolScaleCheckPartialTemplates = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		if len(defaultScaleTargets) > 0 {
 			defaultCounts, partialTemplates, errs := defaultScaleCheckCounts(defaultScaleTargets)
@@ -2869,6 +2877,114 @@ func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) 
 		}
 	}
 	return false
+}
+
+// sessionAssigneeMatch is an entry in the assignee-identity index: the session
+// a work bead's Assignee resolves to, or ambiguous=true when more than one open
+// session claims the same identity (a transient duplicate-alias state). An
+// ambiguous identity is skipped, never guessed — the stamp is best-effort and
+// must not attach the wrong session, mirroring the canonical resolver's
+// fail-on-conflict posture (internal/session.ResolveSession) in a non-fatal
+// form.
+type sessionAssigneeMatch struct {
+	bead      beads.Bead
+	ambiguous bool
+}
+
+// buildSessionAssigneeIndex maps every assignment identity an open session can
+// be claimed under to that session, computed once per reconcile. Open() copies
+// the session slice, so resolving per work bead would otherwise cost
+// O(workBeads × openSessions). Identities come from sessionBeadAssigneeIdentities
+// — bead ID, session_name, configured named identity, current alias, AND prior
+// aliases (alias_history) — so a bead assigned under a since-rotated pool alias
+// still resolves. An identity claimed by two different sessions is marked
+// ambiguous.
+func buildSessionAssigneeIndex(sessionBeads *sessionBeadSnapshot) map[string]sessionAssigneeMatch {
+	index := make(map[string]sessionAssigneeMatch)
+	if sessionBeads == nil {
+		return index
+	}
+	for _, sb := range sessionBeads.Open() {
+		for _, identity := range sessionBeadAssigneeIdentities(sb) {
+			if existing, ok := index[identity]; ok {
+				if !existing.ambiguous && existing.bead.ID != sb.ID {
+					index[identity] = sessionAssigneeMatch{ambiguous: true}
+				}
+				continue
+			}
+			index[identity] = sessionAssigneeMatch{bead: sb}
+		}
+	}
+	return index
+}
+
+// sessionBeadIdentifier returns the most resolvable name for a session: its
+// session_name when set (pool workers), else its alias or configured named
+// identity (named sessions carry an empty session_name and identify by alias —
+// e.g. "mayor"). All three appear in the supervisor session-list index that
+// consumers match against, so this is the value to stamp as gc.session_name.
+func sessionBeadIdentifier(sb beads.Bead) string {
+	for _, key := range []string{"session_name", "alias", "configured_named_identity"} {
+		if v := strings.TrimSpace(sb.Metadata[key]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// stampRunSessionIdentity durably records, on each in-progress assigned work
+// bead, the session_name and work_dir of the session executing it.
+//
+// The session↔bead link (Assignee) is transient: it is cleared when the bead
+// closes, so a consumer that reads a completed run (e.g. the dashboard's
+// session-drill-in and per-run diff panels) has no way to resolve which
+// session ran it or in which worktree. Stamping gc.session_name + gc.work_dir
+// at execution time makes that link durable — the existing dashboard resolvers
+// then attach the session and derive the worktree with no consumer changes.
+//
+// Idempotent by design: it writes only when the resolved value differs from
+// what is already on the bead, so steady-state reconciles perform no writes;
+// only a newly claimed (or reassigned) bead triggers a single write. A write
+// failure is logged and skipped — stamping is best-effort observability and
+// must never block reconciliation.
+func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, sessionBeads *sessionBeadSnapshot, stderr io.Writer) {
+	if sessionBeads == nil || len(workBeads) != len(workStores) {
+		return
+	}
+	sessionByAssignee := buildSessionAssigneeIndex(sessionBeads)
+	for i, wb := range workBeads {
+		if wb.Status != "in_progress" {
+			continue
+		}
+		store := workStores[i]
+		if store == nil {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		match, ok := sessionByAssignee[assignee]
+		if !ok || match.ambiguous {
+			continue
+		}
+		sb := match.bead
+		sessionName := sessionBeadIdentifier(sb)
+		workDir := strings.TrimSpace(sb.Metadata["work_dir"])
+		patch := map[string]string{}
+		if sessionName != "" && strings.TrimSpace(wb.Metadata["gc.session_name"]) != sessionName {
+			patch["gc.session_name"] = sessionName
+		}
+		if workDir != "" && strings.TrimSpace(wb.Metadata["gc.work_dir"]) != workDir {
+			patch["gc.work_dir"] = workDir
+		}
+		if len(patch) == 0 {
+			continue
+		}
+		if err := store.SetMetadataBatch(wb.ID, patch); err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "stampRunSessionIdentity: %s: %v\n", wb.ID, err) //nolint:errcheck
+		}
+	}
 }
 
 func selectOrCreateDependencyPoolSessionBead(

--- a/cmd/gc/build_desired_state_session_stamp_test.go
+++ b/cmd/gc/build_desired_state_session_stamp_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"io"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// countingStore wraps a Store and counts SetMetadataBatch calls so a test can
+// assert the stamp is idempotent (no writes once the bead already carries the
+// resolved identity).
+type countingStore struct {
+	beads.Store
+	writes int
+}
+
+func (c *countingStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	c.writes++
+	return c.Store.SetMetadataBatch(id, kvs)
+}
+
+func stampTestSession(name, workDir string) beads.Bead {
+	return beads.Bead{
+		ID:     "sess-" + name,
+		Type:   "session",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": name,
+			"work_dir":     workDir,
+		},
+	}
+}
+
+func TestStampRunSessionIdentityStampsInProgressAssignedBead(t *testing.T) {
+	const sessionName = "codeprobe-worker-gc-1920"
+	const workDir = "/home/ds/projects/codeprobe/codeprobe-worker-1"
+
+	run := beads.Bead{ID: "co-run1", Type: "molecule", Status: "in_progress", Assignee: sessionName}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{run}, nil)
+	store := &countingStore{Store: mem}
+	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession(sessionName, workDir)})
+
+	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+
+	got, err := mem.Get("co-run1")
+	if err != nil {
+		t.Fatalf("Get(co-run1): %v", err)
+	}
+	if got.Metadata["gc.session_name"] != sessionName {
+		t.Errorf("gc.session_name = %q, want %q", got.Metadata["gc.session_name"], sessionName)
+	}
+	if got.Metadata["gc.work_dir"] != workDir {
+		t.Errorf("gc.work_dir = %q, want %q", got.Metadata["gc.work_dir"], workDir)
+	}
+
+	// Idempotent: a second pass over the now-stamped bead writes nothing.
+	stamped, _ := mem.Get("co-run1")
+	store.writes = 0
+	stampRunSessionIdentity([]beads.Bead{stamped}, []beads.Store{store}, sessions, io.Discard)
+	if store.writes != 0 {
+		t.Errorf("second pass wrote %d times, want 0 (stamp must be idempotent)", store.writes)
+	}
+}
+
+func TestStampRunSessionIdentityNamedSessionUsesAlias(t *testing.T) {
+	// Named sessions (e.g. mayor) carry an empty session_name; their
+	// resolvable identifier lives in alias / configured_named_identity.
+	mayor := beads.Bead{
+		ID: "sess-mayor", Type: "session", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "", "alias": "mayor",
+			"configured_named_identity": "mayor", "work_dir": "/home/ds/gas-city",
+		},
+	}
+	run := beads.Bead{ID: "dr-run", Type: "molecule", Status: "in_progress", Assignee: "mayor"}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{run}, nil)
+	store := &countingStore{Store: mem}
+	sessions := newSessionBeadSnapshot([]beads.Bead{mayor})
+
+	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+
+	got, _ := mem.Get("dr-run")
+	if got.Metadata["gc.session_name"] != "mayor" {
+		t.Errorf("gc.session_name = %q, want %q (alias fallback)", got.Metadata["gc.session_name"], "mayor")
+	}
+	if got.Metadata["gc.work_dir"] != "/home/ds/gas-city" {
+		t.Errorf("gc.work_dir = %q, want /home/ds/gas-city", got.Metadata["gc.work_dir"])
+	}
+}
+
+func TestStampRunSessionIdentityResolvesByIDAndAliasHistory(t *testing.T) {
+	cases := map[string]struct {
+		assignee string
+		sess     beads.Bead
+		wantName string
+	}{
+		"by bead ID": {
+			assignee: "sess-pool",
+			sess: beads.Bead{
+				ID: "sess-pool", Type: "session", Status: "open",
+				Metadata: map[string]string{"session_name": "pool-gc-9", "work_dir": "/wt/9"},
+			},
+			wantName: "pool-gc-9",
+		},
+		"by rotated alias_history": {
+			// A pool worker whose alias rotated mid-run: the bead's Assignee is
+			// a prior alias, still a live assignment identity.
+			assignee: "old-alias",
+			sess: beads.Bead{
+				ID: "sess-rot", Type: "session", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "pool-gc-10", "alias": "new-alias",
+					"alias_history": "old-alias", "work_dir": "/wt/10",
+				},
+			},
+			wantName: "pool-gc-10",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run := beads.Bead{ID: "r", Type: "molecule", Status: "in_progress", Assignee: tc.assignee}
+			mem := beads.NewMemStoreFrom(0, []beads.Bead{run}, nil)
+			store := &countingStore{Store: mem}
+			sessions := newSessionBeadSnapshot([]beads.Bead{tc.sess})
+
+			stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+
+			got, _ := mem.Get("r")
+			if got.Metadata["gc.session_name"] != tc.wantName {
+				t.Errorf("gc.session_name = %q, want %q", got.Metadata["gc.session_name"], tc.wantName)
+			}
+		})
+	}
+}
+
+func TestStampRunSessionIdentitySkipsAmbiguousAssignee(t *testing.T) {
+	// Two open sessions claim the same identity ("dupe") — a transient
+	// duplicate-alias state. The stamp must skip rather than guess.
+	a := beads.Bead{ID: "sa", Type: "session", Status: "open", Metadata: map[string]string{"alias": "dupe", "work_dir": "/a"}}
+	b := beads.Bead{ID: "sb", Type: "session", Status: "open", Metadata: map[string]string{"alias": "dupe", "work_dir": "/b"}}
+	run := beads.Bead{ID: "r", Type: "molecule", Status: "in_progress", Assignee: "dupe"}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{run}, nil)
+	store := &countingStore{Store: mem}
+	sessions := newSessionBeadSnapshot([]beads.Bead{a, b})
+
+	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+
+	if store.writes != 0 {
+		t.Errorf("ambiguous assignee must not be stamped, got %d writes", store.writes)
+	}
+}
+
+func TestStampRunSessionIdentityReassignmentRestamps(t *testing.T) {
+	run := beads.Bead{
+		ID: "co-run2", Type: "molecule", Status: "in_progress", Assignee: "worker-b",
+		Metadata: map[string]string{"gc.session_name": "worker-a", "gc.work_dir": "/old"},
+	}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{run}, nil)
+	store := &countingStore{Store: mem}
+	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession("worker-b", "/new")})
+
+	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, sessions, io.Discard)
+
+	got, _ := mem.Get("co-run2")
+	if got.Metadata["gc.session_name"] != "worker-b" || got.Metadata["gc.work_dir"] != "/new" {
+		t.Errorf("reassignment not restamped: session_name=%q work_dir=%q",
+			got.Metadata["gc.session_name"], got.Metadata["gc.work_dir"])
+	}
+}
+
+func TestStampRunSessionIdentitySkipsNonExecuting(t *testing.T) {
+	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession("worker-x", "/wd")})
+
+	cases := map[string]beads.Bead{
+		"closed bead":        {ID: "b1", Status: "closed", Assignee: "worker-x"},
+		"open (not claimed)": {ID: "b2", Status: "open", Assignee: "worker-x"},
+		"no assignee":        {ID: "b3", Status: "in_progress", Assignee: ""},
+		"unknown session":    {ID: "b4", Status: "in_progress", Assignee: "ghost"},
+	}
+	for name, wb := range cases {
+		t.Run(name, func(t *testing.T) {
+			mem := beads.NewMemStoreFrom(0, []beads.Bead{wb}, nil)
+			store := &countingStore{Store: mem}
+			stampRunSessionIdentity([]beads.Bead{wb}, []beads.Store{store}, sessions, io.Discard)
+			if store.writes != 0 {
+				t.Errorf("expected no stamp, got %d writes", store.writes)
+			}
+		})
+	}
+}
+
+func TestStampRunSessionIdentityToleratesLengthMismatchAndNilSnapshot(t *testing.T) {
+	run := beads.Bead{ID: "b", Status: "in_progress", Assignee: "w"}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{run}, nil)
+	store := &countingStore{Store: mem}
+
+	// Mismatched slice lengths must be a no-op, not a panic.
+	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{}, newSessionBeadSnapshot(nil), io.Discard)
+	// Nil snapshot must be a no-op, not a panic.
+	stampRunSessionIdentity([]beads.Bead{run}, []beads.Store{store}, nil, io.Discard)
+	if store.writes != 0 {
+		t.Errorf("expected no writes on degenerate input, got %d", store.writes)
+	}
+}


### PR DESCRIPTION
## Summary

The supervisor correlates a work bead to its executing session every reconcile via the bead's `Assignee`, but that link is transient — `Assignee` is cleared when the bead closes. A consumer reading a **completed** run (e.g. a run-detail view) is then left with no session or worktree reference: the run's beads come back with empty metadata.

This stamps `gc.session_name` and `gc.work_dir` durably onto each in-progress assigned work bead, sourced from the session bead executing it, at the existing reconcile correlation seam in `buildDesiredStateWithSessionBeads`. Once stamped, a completed run stays resolvable to its session and worktree — with no consumer-side change.

## Approach

- `stampRunSessionIdentity` runs in the reconcile right after `collectAssignedWorkBeadsWithStores`, over the `assignedWorkBeads`/`assignedWorkStores` it already computes — no new queries.
- Assignee→session resolution reuses the canonical `sessionBeadAssigneeIdentities` (bead ID, `session_name`, configured named identity, current `alias`, and prior aliases from `alias_history`), so a bead assigned under a since-rotated pool alias still resolves. An **ambiguous** match (>1 open session claims the identity) is skipped, not guessed — mirroring the canonical resolver's fail-on-conflict posture in a non-fatal form.
- The stamped identifier falls back `session_name → alias → configured_named_identity`, so named sessions (which carry an empty `session_name` and identify by alias) resolve.
- **Idempotent**: writes only when the resolved value differs from what's on the bead, so steady-state reconciles perform no writes; only a newly claimed or reassigned bead triggers a single write.
- **Best-effort**: a write failure is logged and never blocks reconciliation. Not gated on `storePartial` — stamping the beads that were collected is always correct, and a bead missed by a partial query is stamped on a later tick.

## Testing

`cmd/gc/build_desired_state_session_stamp_test.go` covers: stamping an in-progress assigned bead; named-session alias fallback; resolve-by-bead-ID and by rotated `alias_history`; reassignment re-stamp; idempotency (zero writes on the second pass); ambiguous-assignee skip; skipping closed/open/unassigned/unknown-session beads; and tolerance of nil snapshot / slice-length mismatch.

`make build`, `go vet ./...`, `gofumpt`, and the `cmd/gc` reconcile/session/assigned-work suite pass with no regression.

## Notes

- Additive `gc.*` metadata, consistent with existing controller-written keys (`gc.routed_to`, `gc.run_target`). No schema or public-contract change.
- Complements run-detail observability — orthogonal to serving per-run diffs over the supervisor API (#2823); this makes the host-side session/worktree link durable so it survives bead close.
