### PR TITLE
fix(reaper): USE target db before DML so a transient 'no database selected' can't skip purges

### DIFF
--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -302,7 +302,13 @@ run_sql_change() {
         record_anomaly "$db" "$label failed for $db: could not create stderr capture file"
         return 1
     fi
+    # DML (DELETE/UPDATE) against a database-qualified table still needs an
+    # active database selected, or Dolt can reject it with "no database
+    # selected" (Error 1105) even though the target is fully qualified —
+    # reads (get_sql_count/get_sql_rows) do not. USE the target db first,
+    # mirroring the DOLT_COMMIT block below.
     if ! output=$(dolt_sql -r csv -q "
+USE \`$db\`;
 $query;
 SELECT ROW_COUNT();
     " 2>"$stderr_file"); then


### PR DESCRIPTION
## Problem

The reaper's `run_sql_change` (used for the purge `DELETE` and the stale-wisp `UPDATE`) runs:

```sh
dolt_sql -r csv -q "
$query;
SELECT ROW_COUNT();
"
```

against a database-qualified table with **no active database selected**. Dolt accepts qualified *reads* (`get_sql_count` / `get_sql_rows`) without a current database, but can reject qualified **DML** with `Error 1105 (HY000): no database selected` even though the target is fully qualified.

Observed on 2026-05-31 on the `hq` purge during a transient Dolt wobble:

```
hq: purging closed wisps failed for hq: ... DELETE FROM `hq`.wisps ... : Error 1105 (HY000): no database selected
```

The failure is caught and surfaced as a reaper anomaly, but the purge **silently skips that cycle** — no rows deleted. Under healthy server state the qualified DML succeeds without `USE` (the error did not reproduce afterward), so this is a *transient-window* bug — but it recurs whenever Dolt is briefly degraded, which is exactly when the maintenance loop most needs to be robust.

## Fix

`USE \`$db\`;` before the DML, so `run_sql_change` always has a current database — mirroring the `DOLT_COMMIT` block a few lines below, which already does this for the same reason (its comment: *"have an active database via USE"*).

Defensive and minimal: no behavior change under healthy Dolt; it only closes the transient-failure window. `ROW_COUNT()` still reflects the DML.

## Testing

- `bash -n` clean.
- Verified against the live server that `USE \`db\`; <DML>; SELECT ROW_COUNT()` returns the correct affected-row count (vs. the bare qualified DML which can hit `no database selected` with no current DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
