### PR TITLE
test(config): cover resolved pack read dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching `gc mail send`. Operators should use `gc mail` commands or
   explicit both-tier/wisp-aware bead queries for mail visibility; default
   issue-tier `bd list` output and git sync do not include wisp-tier messages.
-- Built-in pack auto-includes now skip packs already reachable from rig pack
-  graphs, preventing duplicate maintenance agents when a rig pack imports a
-  built-in pack transitively.
+- Built-in pack auto-include graph traversal now avoids redundant pack reads
+  while preserving non-transitive import boundaries and later transitive
+  expansion of shallow-seen packs.
 
 ## [1.2.0] - 2026-05-25
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1585,6 +1585,8 @@ func resolvedPackNames(includes []string, imports map[string]Import, sysFS fsys.
 				return
 			}
 		} else {
+			// Shallow visits record the pack name but must not block a later
+			// transitive visit from expanding the pack's children.
 			if seenShallowDirs[absDir] || expandedDirs[absDir] {
 				return
 			}

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -21,6 +21,24 @@ func writeFile(t *testing.T, dir, name, content string) {
 	}
 }
 
+type readCountingFS struct {
+	fsys.OSFS
+	reads map[string]int
+}
+
+func newReadCountingFS() *readCountingFS {
+	return &readCountingFS{reads: make(map[string]int)}
+}
+
+func (f *readCountingFS) ReadFile(name string) ([]byte, error) {
+	f.reads[filepath.Clean(name)]++
+	return f.OSFS.ReadFile(name)
+}
+
+func (f *readCountingFS) ReadCount(name string) int {
+	return f.reads[filepath.Clean(name)]
+}
+
 func TestExpandPacks_Basic(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gastown/pack.toml", `
@@ -3321,6 +3339,81 @@ source = "../middle"
 			t.Fatalf("includes %v did not resolve transitive maintenance after shallow visit: names=%v", includes, names)
 		}
 	}
+}
+
+func TestResolvedPackNames_AvoidsRedundantPackReads(t *testing.T) {
+	t.Run("repeated shallow imports", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeFile(t, dir, "packs/shared/pack.toml", `
+[pack]
+name = "shared"
+schema = 2
+`)
+
+		transitiveFalse := false
+		countingFS := newReadCountingFS()
+		names := resolvedPackNames(nil, map[string]Import{
+			"shared_a": {Source: "packs/shared", Transitive: &transitiveFalse},
+			"shared_b": {Source: "packs/shared", Transitive: &transitiveFalse},
+		}, countingFS, dir)
+
+		if !names["shared"] {
+			t.Fatalf("shared missing from repeated shallow imports: names=%v", names)
+		}
+		if got := countingFS.ReadCount(filepath.Join(dir, "packs/shared/pack.toml")); got != 1 {
+			t.Fatalf("shared pack.toml read count = %d, want 1", got)
+		}
+	})
+
+	t.Run("diamond transitive imports", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeFile(t, dir, "packs/shared/pack.toml", `
+[pack]
+name = "shared"
+schema = 2
+`)
+		writeFile(t, dir, "packs/left/pack.toml", `
+[pack]
+name = "left"
+schema = 2
+
+[imports.shared]
+source = "../shared"
+`)
+		writeFile(t, dir, "packs/right/pack.toml", `
+[pack]
+name = "right"
+schema = 2
+
+[imports.shared]
+source = "../shared"
+`)
+		writeFile(t, dir, "packs/root/pack.toml", `
+[pack]
+name = "root"
+schema = 2
+
+[imports.left]
+source = "../left"
+
+[imports.right]
+source = "../right"
+`)
+
+		countingFS := newReadCountingFS()
+		names := resolvedPackNames([]string{"packs/root"}, nil, countingFS, dir)
+
+		for _, name := range []string{"root", "left", "right", "shared"} {
+			if !names[name] {
+				t.Fatalf("%s missing from diamond imports: names=%v", name, names)
+			}
+		}
+		if got := countingFS.ReadCount(filepath.Join(dir, "packs/shared/pack.toml")); got != 1 {
+			t.Fatalf("shared pack.toml read count = %d, want 1", got)
+		}
+	})
 }
 
 // agentNamesOf is a small test helper for readable failure messages.


### PR DESCRIPTION
Follow-up for post-merge review of #2818.

## Summary
- Add a read-counting filesystem wrapper for `resolvedPackNames` tests.
- Cover repeated shallow imports so the same pack is not read more than once.
- Cover diamond transitive imports so an already-expanded pack is not read again.
- Reframe the changelog entry and document why shallow visits must not block later transitive expansion.

## Verification
- `GOTOOLCHAIN=auto go test ./internal/config -run TestResolvedPackNames_AvoidsRedundantPackReads -count=1`
- `GOTOOLCHAIN=auto go test ./internal/config -count=1`
- `GOTOOLCHAIN=auto go vet ./...`
- `.githooks/pre-commit` ran through lint/generation/vet, then failed in the sharded `cmd/gc` fast baseline on existing formula fixture lookup failures (`formula ... not found in search paths`, `ReadFile(test-formula): no such file or directory`). Representative failed tests passed when rerun directly with `GOTOOLCHAIN=auto go test ./cmd/gc -run 'TestOrderRunJSONFormulaSummary|TestDoSlingFormulaWithTitle|TestOrderDispatchCooldownDue' -count=1`.
