### PR TITLE
fix(runtime/proctable): never scan the live /proc under `go test`

### DIFF
--- a/internal/runtime/proctable/guard.go
+++ b/internal/runtime/proctable/guard.go
@@ -1,0 +1,41 @@
+package proctable
+
+import (
+	"fmt"
+	"testing"
+)
+
+// scanRoot is the procfs root enumerated by the Linux scanner. It defaults to
+// the live "/proc". Tests override it with a fake procfs via
+// SetScanRootForTesting so a `go test` run never enumerates — and the orphan
+// sweep never reaps — the host's real agent processes.
+var scanRoot = "/proc"
+
+// liveScanRoot returns the procfs root to scan, or an error when a `go test`
+// run would scan the live "/proc" without injecting a fake root first.
+//
+// Why this guard exists (gastownhall/gascity#2839): the process-table scanner
+// reads the real /proc, and the orphan sweep SIGTERMs any runtime that is not
+// present in its bead store. Under `go test` that store is empty/sandboxed, so
+// on a host actually running gascity EVERY live agent (the mayor and every rig
+// worker) looks like an orphan and gets killed. Dev laptops and CI runners have
+// no live agents, so the orphan-cleanup tests pass there and the footgun only
+// fires on a machine running a real fleet. Refusing the live scan under test
+// closes that hole; a test that genuinely needs the scanner must inject a fake
+// procfs via SetScanRootForTesting.
+func liveScanRoot() (string, error) {
+	if scanRoot == "/proc" && testing.Testing() {
+		return "", fmt.Errorf("proctable: refusing to scan the live /proc under go test; " +
+			"inject a fake procfs root with SetScanRootForTesting (guards against reaping real agent runtimes — see gastownhall/gascity#2839)")
+	}
+	return scanRoot, nil
+}
+
+// SetScanRootForTesting overrides the procfs root used by ScanBySessionID and
+// IsScanRoot, returning a restore function. It exists only so tests can drive
+// the scanner against a controlled, fake procfs tree instead of the host's.
+func SetScanRootForTesting(root string) (restore func()) {
+	prev := scanRoot
+	scanRoot = root
+	return func() { scanRoot = prev }
+}

--- a/internal/runtime/proctable/guard_test.go
+++ b/internal/runtime/proctable/guard_test.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package proctable
+
+import "testing"
+
+// TestScanBySessionID_RefusesLiveProcUnderTest is the regression guard for
+// gastownhall/gascity#2839. Under `go test` the scanner must NOT enumerate the
+// live /proc: the orphan sweep SIGTERMs any runtime missing from its (empty,
+// under-test) bead store, so on a host running a live fleet every real agent —
+// the mayor and every rig worker — would be reaped. Dev laptops and CI runners
+// have no live agents, so the orphan-cleanup tests pass there and the footgun
+// only ever fired on a machine actually running gascity. This test fails if the
+// guard regresses.
+func TestScanBySessionID_RefusesLiveProcUnderTest(t *testing.T) {
+	if _, err := ScanBySessionID(""); err == nil {
+		t.Fatal("ScanBySessionID(\"\") enumerated the live /proc under `go test`; the safety guard did not fire (regression of #2839)")
+	}
+}
+
+func TestIsScanRoot_RefusesLiveProcUnderTest(t *testing.T) {
+	if IsScanRoot(2) {
+		t.Fatal("IsScanRoot consulted the live /proc under `go test`; expected the safety guard to short-circuit to false")
+	}
+}
+
+// TestSetScanRootForTesting_InjectsFakeRoot proves the escape hatch: a test that
+// genuinely needs the scanner injects a fake procfs root, which disables the
+// live-/proc refusal and confines the scan to the fake tree.
+func TestSetScanRootForTesting_InjectsFakeRoot(t *testing.T) {
+	restore := SetScanRootForTesting(t.TempDir())
+	defer restore()
+
+	got, err := ScanBySessionID("")
+	if err != nil {
+		t.Fatalf("with an injected fake procfs root the scan must not be refused: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("an empty fake procfs must yield zero runtimes, got %d", len(got))
+	}
+}

--- a/internal/runtime/proctable/scan_darwin.go
+++ b/internal/runtime/proctable/scan_darwin.go
@@ -16,6 +16,9 @@ import (
 // ScanBySessionID returns live agent root processes whose environment carries
 // GC_SESSION_ID equal to id. Empty id returns all roots with any GC_SESSION_ID.
 func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
+	if _, err := liveScanRoot(); err != nil {
+		return []runtime.LiveRuntime{}, err
+	}
 	records, err := psRecords()
 	if err != nil {
 		return []runtime.LiveRuntime{}, err
@@ -54,6 +57,9 @@ func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
 // IsScanRoot reports whether pid is outside its GC_SESSION_ID parent's
 // envelope and should be treated as an agent root.
 func IsScanRoot(pid int) bool {
+	if _, err := liveScanRoot(); err != nil {
+		return false
+	}
 	if pid == 1 {
 		return true
 	}

--- a/internal/runtime/proctable/scan_linux.go
+++ b/internal/runtime/proctable/scan_linux.go
@@ -18,12 +18,20 @@ import (
 // ScanBySessionID returns live agent root processes whose environment carries
 // GC_SESSION_ID equal to id. Empty id returns all roots with any GC_SESSION_ID.
 func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
-	return scanWithRoot("/proc", id)
+	root, err := liveScanRoot()
+	if err != nil {
+		return []runtime.LiveRuntime{}, err
+	}
+	return scanWithRoot(root, id)
 }
 
 // IsScanRoot reports whether pid is outside its GC_SESSION_ID parent's
 // envelope and should be treated as an agent root.
 func IsScanRoot(pid int) bool {
+	root, err := liveScanRoot()
+	if err != nil {
+		return false
+	}
 	if pid == 1 {
 		return true
 	}
@@ -33,7 +41,7 @@ func IsScanRoot(pid int) bool {
 	if pid == os.Getpid() {
 		return false
 	}
-	env, err := parseEnvironFile(filepath.Join("/proc", strconv.Itoa(pid), "environ"))
+	env, err := parseEnvironFile(filepath.Join(root, strconv.Itoa(pid), "environ"))
 	if err != nil || len(env) == 0 {
 		return false
 	}
@@ -41,8 +49,8 @@ func IsScanRoot(pid int) bool {
 	if sessionID == "" {
 		return false
 	}
-	root, err := isRootWithSessionID("/proc", pid, sessionID)
-	return err == nil && root
+	isRoot, err := isRootWithSessionID(root, pid, sessionID)
+	return err == nil && isRoot
 }
 
 func scanWithRoot(root, id string) ([]runtime.LiveRuntime, error) {


### PR DESCRIPTION
## The bug

The process-table scanner added in #2839 reads the **real `/proc`**, and the orphan sweep (`sweepProcessTableOrphans` → `FindRuntimesBySessionID("")`) sends `SIGTERM` to any runtime not present in its bead store.

Under `go test` that store is empty/sandboxed, so on a host that is **actually running gascity**, every live agent process — the mayor and every rig worker, plus their `node`/`codex`/`python` children — matches the "orphan" criteria and gets **killed mid-work**. A single `go test ./...` run on a live-fleet host SIGTERMs the entire fleet; the supervisor respawns them and they get reaped again on the next test that hits the sweep.

## Why it passed everywhere

Dev laptops and CI runners have **no live `GC_SESSION_ID`-tagged agents**, so `ScanBySessionID` finds nothing to reap and the orphan-cleanup tests go green. The footgun only arms on a machine running a real fleet — exactly where it must never fire — so neither local runs nor CI could ever catch it.

## The fix

Route both real-`/proc` entry points — `ScanBySessionID` and `IsScanRoot`, on linux and darwin — through a new `liveScanRoot()` guard that **refuses to scan the live `/proc` when `testing.Testing()` is true**. Tests that legitimately need the scanner inject a fake procfs via `SetScanRootForTesting`. **Production behavior is unchanged** (the guard is a no-op outside `go test`).

## Tests

- `TestScanBySessionID_RefusesLiveProcUnderTest` / `TestIsScanRoot_RefusesLiveProcUnderTest` — assert the live scan is refused under test (these fail without the guard, i.e. they reproduce the regression).
- `TestSetScanRootForTesting_InjectsFakeRoot` — the fake-root escape hatch works.

Verified by re-running the previously-detonating tests (`TestControllerRuntimeSweepsProcessTableOrphansAfterClosedBeadReap`, the session-manager orphan-cleanup tests, the subprocess scanner tests) on a live-fleet host with a kernel signal tracer attached: **zero `.test`-sourced SIGTERMs to agent processes**, all green.

## Follow-up (not in this PR)

Worth a separate look at whether the orphan-sweep feature needs the unscoped `FindRuntimesBySessionID("")` machine-wide enumeration at all, or should be scoped to the controller's own city.

🤖 Generated with [Claude Code](https://claude.com/claude-code)