### PR TITLE
Fix cached bead store handle post-merge findings

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -122,9 +122,13 @@ type demandListCountingStore struct {
 	liveInProgressWispLists  int
 	liveOpenMolecules        int
 	livePoolDemand           int
+	fullPrimeLists           int
 }
 
 func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if !query.Live && query.AllowScan && query.SkipLabels && query.TierMode == beads.TierBoth {
+		s.fullPrimeLists++
+	}
 	if query.Live && query.Status == "in_progress" {
 		switch query.TierMode {
 		case beads.TierWisps:
@@ -357,6 +361,9 @@ func TestCollectAssignedWorkBeadsUsesCachedInProgressReadModel(t *testing.T) {
 	}
 	if backing.liveInProgressWispLists != 0 {
 		t.Fatalf("live wisp in_progress list calls = %d, want cached demand read", backing.liveInProgressWispLists)
+	}
+	if backing.fullPrimeLists != 0 {
+		t.Fatalf("full-prime list calls = %d, want controller demand to use PrimeActive snapshot", backing.fullPrimeLists)
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2776,6 +2776,8 @@ func sessionHasOpenAssignedWispWork(store beads.Store, assignee, status string) 
 	if cache, ok := store.(interface {
 		CachedList(beads.ListQuery) ([]beads.Bead, bool)
 	}); ok {
+		// This positive-only probe intentionally keeps the tier-scoped cache
+		// helper: HandlesFor(...).Cached.List reads both tiers by contract.
 		if items, ok := cache.CachedList(query); ok {
 			if hasNonSessionAssignedWork(items) {
 				return true, nil

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -502,14 +502,12 @@ func (c *CachingStore) prime(ctx context.Context) error {
 		nextLocalBeadAt := make(map[string]time.Time)
 		for id, current := range c.beads {
 			if fresh, exists := beadMap[id]; exists {
-				if recentLocalMutation(c.localBeadAt[id], now) {
-					c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
-				}
 				if _, keep := c.recentLocalBeadConflictLocked(id, fresh, now, true); keep {
 					nextBeads[id] = cloneBead(current)
 					if deps, ok := c.deps[id]; ok {
 						nextDeps[id] = cloneDeps(deps)
 					}
+					c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
 				}
 				continue
 			}

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -2,12 +2,16 @@ package beads
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
-// CachedReader is the cache-only eventual-consistency read handle for beads.
-// List reads across both bead tiers regardless of the caller's TierMode; use
-// the underlying Store directly for intentionally tier-scoped list queries.
+// CachedReader is the cache-only eventual-consistency read handle for active
+// beads. Get may return ErrNotFound for closed-but-existing beads because the
+// cache does not retain complete closed history; use Live.Get for closed or
+// historical lookups. List reads across both bead tiers regardless of the
+// caller's TierMode; use the underlying Store directly for intentionally
+// tier-scoped list queries.
 type CachedReader interface {
 	Get(id string) (Bead, error)
 	List(query ListQuery) ([]Bead, error)
@@ -129,6 +133,10 @@ func (r cachedStoreReader) Get(id string) (Bead, error) {
 }
 
 func (r cachedStoreReader) List(query ListQuery) ([]Bead, error) {
+	rows, err := r.store.cachedListOnly(logicalCachedListQuery(query))
+	if err == nil || !errors.Is(err, ErrCacheUnavailable) {
+		return rows, err
+	}
 	if err := r.store.ensureFullPrime(context.Background()); err != nil {
 		return nil, err
 	}

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -241,7 +241,7 @@ func TestCachingStoreHandlesCachedReadsShareFullPrime(t *testing.T) {
 	}
 }
 
-func TestCachingStoreHandlesCachedReadsWaitForFullPrimeAfterPrimeActive(t *testing.T) {
+func TestCachingStoreHandlesCachedListUsesActiveSnapshotAfterPrimeActive(t *testing.T) {
 	t.Parallel()
 
 	mem := NewMemStore()
@@ -269,29 +269,23 @@ func TestCachingStoreHandlesCachedReadsWaitForFullPrimeAfterPrimeActive(t *testi
 	}()
 
 	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
 	case <-backing.started:
-	case err := <-done:
-		t.Fatalf("cached read returned before full prime: %v", err)
-	case <-time.After(time.Second):
-		t.Fatal("cached read did not start full prime after active prime")
-	}
-
-	select {
-	case err := <-done:
-		t.Fatalf("cached read finished while full prime was blocked: %v", err)
+		t.Fatal("cached active List started lazy full prime after PrimeActive")
 	case <-time.After(25 * time.Millisecond):
+		t.Fatal("cached active List did not return promptly from PrimeActive snapshot")
 	}
 
 	close(backing.release)
-	if err := <-done; err != nil {
-		t.Fatal(err)
-	}
-	if got := backing.primeListCalls.Load(); got != 1 {
-		t.Fatalf("total prime list calls = %d, want 1", got)
+	if got := backing.primeListCalls.Load(); got != 0 {
+		t.Fatalf("full-prime list calls = %d, want none for active cached List", got)
 	}
 }
 
-func TestCachingStoreHandlesCachedReadDoesNotWaitForRunningFullPrimeAfterPrimeActive(t *testing.T) {
+func TestCachingStoreHandlesCachedReadUsesActiveSnapshotDuringRunningFullPrimeAfterPrimeActive(t *testing.T) {
 	t.Parallel()
 
 	mem := NewMemStore()
@@ -325,8 +319,8 @@ func TestCachingStoreHandlesCachedReadDoesNotWaitForRunningFullPrimeAfterPrimeAc
 	}()
 	select {
 	case err := <-readDone:
-		if !errors.Is(err, ErrCacheUnavailable) {
-			t.Fatalf("Cached.List error = %v, want ErrCacheUnavailable", err)
+		if err != nil {
+			t.Fatalf("Cached.List error = %v, want active snapshot result", err)
 		}
 	case <-time.After(25 * time.Millisecond):
 		t.Fatal("Cached.List waited for the running full prime")
@@ -2226,7 +2220,7 @@ func TestCachingStoreCloseAllMarksRefreshFailuresDirty(t *testing.T) {
 	}
 }
 
-func TestCachingStoreCachedListReflectsWriteThroughRefreshFailure(t *testing.T) {
+func TestCachingStoreCachedListUnavailableAfterWriteThroughRefreshFailure(t *testing.T) {
 	t.Parallel()
 
 	backing := &refreshFailingStore{Store: NewMemStore()}
@@ -2245,15 +2239,59 @@ func TestCachingStoreCachedListReflectsWriteThroughRefreshFailure(t *testing.T) 
 		t.Fatalf("Update: %v", err)
 	}
 
+	if rows, ok := cache.CachedList(ListQuery{Status: "open"}); ok {
+		t.Fatalf("CachedList returned clean rows after refresh failure: %#v", rows)
+	}
+	if _, err := cache.Handles().Cached.List(ListQuery{Status: "open"}); !errors.Is(err, ErrCacheUnavailable) {
+		t.Fatalf("Cached.List after refresh failure = %v, want ErrCacheUnavailable", err)
+	}
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get after refresh failure: %v", err)
+	}
+	if got.Title != title {
+		t.Fatalf("Get title = %q, want authoritative title %q", got.Title, title)
+	}
 	rows, ok := cache.CachedList(ListQuery{Status: "open"})
 	if !ok {
-		t.Fatal("CachedList returned ok=false after write-through update")
+		t.Fatal("CachedList returned ok=false after authoritative Get refresh")
 	}
-	if len(rows) != 1 || rows[0].ID != bead.ID {
-		t.Fatalf("CachedList = %#v, want row %s", rows, bead.ID)
+	if len(rows) != 1 || rows[0].ID != bead.ID || rows[0].Title != title {
+		t.Fatalf("CachedList after authoritative refresh = %#v, want %s title %q", rows, bead.ID, title)
 	}
-	if rows[0].Title != title {
-		t.Fatalf("CachedList title = %q, want write-through title %q", rows[0].Title, title)
+}
+
+func TestCachingStoreReconciliationClearsDirtyWriteThroughProjection(t *testing.T) {
+	t.Parallel()
+
+	backing := &refreshFailingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "active work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	title := "updated while refresh fails"
+	backing.failNextGet = true
+	if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if rows, ok := cache.CachedList(ListQuery{Status: "open"}); ok {
+		t.Fatalf("CachedList returned clean rows after refresh failure: %#v", rows)
+	}
+
+	cache.runReconciliation()
+
+	rows, ok := cache.CachedList(ListQuery{Status: "open"})
+	if !ok {
+		t.Fatal("CachedList returned ok=false after authoritative reconciliation")
+	}
+	if len(rows) != 1 || rows[0].ID != bead.ID || rows[0].Title != title {
+		t.Fatalf("CachedList after reconciliation = %#v, want %s title %q", rows, bead.ID, title)
 	}
 }
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -9,8 +9,8 @@ import (
 // List returns beads matching the query. Active-bead queries are served from
 // cache when available. IncludeClosed queries merge cached active results with
 // backing-store history when possible, preserving partial backing rows when bd
-// reports corrupt entries and retaining cache-only fallback for transient
-// non-partial bd failures.
+// reports corrupt entries and returning partial-result errors when backing
+// history cannot be fully read.
 func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
@@ -70,7 +70,11 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 		all, err := c.backing.List(liveListQuery(query))
 		if err != nil {
 			if !IsPartialResult(err) {
-				return finish(cached, nil)
+				c.recordProblem("list include closed backing failure", err)
+				return finish(cached, &PartialResultError{
+					Op:  "cache list include closed",
+					Err: err,
+				})
 			}
 		}
 
@@ -97,10 +101,8 @@ func liveListQuery(query ListQuery) ListQuery {
 }
 
 // CachedList returns query results from the in-memory cache only. The boolean
-// reports whether the cache was initialized enough to answer without touching
-// the backing store. Dirty entries are returned from the last observed
-// snapshot; callers must treat this as a read model that may lag writes or
-// reconciliation by one tick.
+// reports whether the cache was initialized and clean enough to answer without
+// touching the backing store.
 func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
 	if query.IncludesClosed() {
 		return nil, false
@@ -110,7 +112,7 @@ func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
 	if c.state != cacheLive && c.state != cachePartial {
 		return nil, false
 	}
-	if c.primePartialErr != nil {
+	if c.primePartialErr != nil || len(c.dirty) > 0 {
 		return nil, false
 	}
 	cached := make([]Bead, 0, len(c.beads))

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -404,12 +404,10 @@ func (c *CachingStore) runReconciliation() {
 	for id, freshBead := range freshByID {
 		beadForCache := freshBead
 		preservedRecentLocal := false
-		if recentLocalMutation(c.localBeadAt[id], now) {
-			c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
-		}
 		if current, keep := c.recentLocalBeadConflictLocked(id, freshBead, now, true); keep {
 			beadForCache = current
 			preservedRecentLocal = true
+			c.carryRecentLocalMutationLocked(id, nextDirty, nextBeadSeq, nextLocalBeadAt)
 		}
 		freshDeps := c.depsForReconcileLocked(id, freshBead, depMap, useFreshDeps)
 		nextBeads[id] = cloneBead(beadForCache)

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -2339,7 +2339,7 @@ func TestCachingStoreListByMetadata(t *testing.T) {
 	}
 }
 
-func TestCachingStoreListIncludeClosedFallsBackToCachedMatches(t *testing.T) {
+func TestCachingStoreListIncludeClosedReturnsPartialErrorOnBackingFailure(t *testing.T) {
 	t.Parallel()
 	backing := &failingIncludeClosedMetadataStore{MemStore: beads.NewMemStore()}
 	match, _ := backing.Create(beads.Bead{Title: "A"})
@@ -2356,8 +2356,9 @@ func TestCachingStoreListIncludeClosedFallsBackToCachedMatches(t *testing.T) {
 		Metadata:      map[string]string{"gc.kind": "workflow"},
 		IncludeClosed: true,
 	})
-	if err != nil {
-		t.Fatalf("List(include closed): %v", err)
+	var partial *beads.PartialResultError
+	if !errors.As(err, &partial) {
+		t.Fatalf("List(include closed) error = %v, want *PartialResultError", err)
 	}
 	if len(results) != 1 || results[0].ID != match.ID {
 		t.Fatalf("results = %v, want only %s", results, match.ID)

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -79,9 +79,8 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 			fresh = applyUpdateOptsToBead(current, opts)
 			c.beads[id] = cloneBead(fresh)
 			c.deps[id] = depsFromBeadFields(fresh)
-			delete(c.dirty, id)
+			c.dirty[id] = struct{}{}
 			delete(c.deletedSeq, id)
-			c.markFreshLocked(time.Now())
 			c.updateStatsLocked()
 			c.mu.Unlock()
 			c.recordProblem("refresh bead after update", fmt.Errorf("%s: %w", id, err))
@@ -560,6 +559,9 @@ func (c *CachingStore) updateMatchesCached(id string, opts UpdateOpts) bool {
 	if c.state != cacheLive && c.state != cachePartial {
 		return false
 	}
+	if _, dirty := c.dirty[id]; dirty {
+		return false
+	}
 	b, ok := c.beads[id]
 	if !ok {
 		return false
@@ -634,6 +636,9 @@ func (c *CachingStore) closeAlreadyMatchesCached(id string) bool {
 	if c.state != cacheLive && c.state != cachePartial {
 		return false
 	}
+	if _, dirty := c.dirty[id]; dirty {
+		return false
+	}
 	b, ok := c.beads[id]
 	if !ok {
 		return false
@@ -653,6 +658,9 @@ func (c *CachingStore) metadataAlreadyMatchesCached(id string, kvs map[string]st
 	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	if _, dirty := c.dirty[id]; dirty {
+		return false
+	}
 	b, ok := c.beads[id]
 	if !ok {
 		return false

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -658,6 +658,9 @@ func (c *CachingStore) metadataAlreadyMatchesCached(id string, kvs map[string]st
 	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return false
+	}
 	if _, dirty := c.dirty[id]; dirty {
 		return false
 	}

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -297,6 +297,78 @@ func TestCachingStoreSetMetadataSkipsBackingWhenCachedValueMatches(t *testing.T)
 	}
 }
 
+func TestCachingStoreSetMetadataFallsThroughWhenCacheStateCannotProveNoop(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state cacheState
+	}{
+		{name: "uninitialized", state: cacheUninitialized},
+		{name: "degraded", state: cacheDegraded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/single", func(t *testing.T) {
+			t.Parallel()
+
+			backing := &countingBackingStore{Store: NewMemStore()}
+			bead := createBeadWithMetadata(t, backing, map[string]string{"foo": "bar"})
+			cache := staleMatchingMetadataCache(backing, bead, tt.state)
+			backing.setMetadataCalls = 0
+
+			if err := cache.SetMetadata(bead.ID, "foo", "bar"); err != nil {
+				t.Fatalf("SetMetadata: %v", err)
+			}
+			if backing.setMetadataCalls != 1 {
+				t.Fatalf("backing.SetMetadata called %d times; want 1", backing.setMetadataCalls)
+			}
+		})
+
+		t.Run(tt.name+"/batch", func(t *testing.T) {
+			t.Parallel()
+
+			backing := &countingBackingStore{Store: NewMemStore()}
+			bead := createBeadWithMetadata(t, backing, map[string]string{"foo": "bar", "baz": "qux"})
+			cache := staleMatchingMetadataCache(backing, bead, tt.state)
+			backing.setMetadataBatchCalls = 0
+
+			if err := cache.SetMetadataBatch(bead.ID, map[string]string{"foo": "bar", "baz": "qux"}); err != nil {
+				t.Fatalf("SetMetadataBatch: %v", err)
+			}
+			if backing.setMetadataBatchCalls != 1 {
+				t.Fatalf("backing.SetMetadataBatch called %d times; want 1", backing.setMetadataBatchCalls)
+			}
+		})
+	}
+}
+
+func createBeadWithMetadata(t *testing.T, backing Store, metadata map[string]string) Bead {
+	t.Helper()
+
+	bead, err := backing.Create(Bead{Title: "test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := backing.SetMetadataBatch(bead.ID, metadata); err != nil {
+		t.Fatalf("seed SetMetadataBatch: %v", err)
+	}
+	bead, err = backing.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	return bead
+}
+
+func staleMatchingMetadataCache(backing Store, bead Bead, state cacheState) *CachingStore {
+	cache := NewCachingStoreForTest(backing, nil)
+	cache.mu.Lock()
+	cache.beads[bead.ID] = cloneBead(bead)
+	cache.state = state
+	cache.mu.Unlock()
+	return cache
+}
+
 // TestCachingStoreSetMetadataFallsThroughOnValueMismatch verifies that a
 // real value change still propagates to the backing store.
 func TestCachingStoreSetMetadataFallsThroughOnValueMismatch(t *testing.T) {


### PR DESCRIPTION
## Summary

Remediates post-merge review findings from #2750.

- Serve active cached list reads from the `PrimeActive` snapshot instead of forcing a lazy full prime.
- Return partial-result errors for closed-inclusive cache list reads when backing history fails.
- Keep write-through update projections dirty after refresh failures until an authoritative get, full prime, or reconciliation confirms them.
- Document the active-only cached `Get` contract and the remaining tier-scoped `CachedList` probe.

## Tests

- `go test ./internal/beads -count=1`
- `go test ./cmd/gc -run 'TestCollectAssignedWorkBeads|TestDefaultScaleCheckCounts|TestSessionHasOpenAssignedWork|TestSessionHasOpenAssignedWorkInStore' -count=1 -timeout 120s`
- `go vet ./...`
- `git diff --check`
