### PR TITLE
feat(beads): add multi-assignee list query

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -111,6 +111,40 @@ func TestListQueryHasFilterIncludesUpdatedBefore(t *testing.T) {
 	}
 }
 
+func TestListQueryHasFilterIncludesAssignees(t *testing.T) {
+	query := ListQuery{Assignees: []string{"rig/builder", "rig/validator"}}
+
+	if !query.HasFilter() {
+		t.Fatal("HasFilter() = false, want true for Assignees")
+	}
+}
+
+func TestListQueryMatchesAnyAssignee(t *testing.T) {
+	query := ListQuery{Assignees: []string{"rig/builder", "rig/validator"}}
+
+	if !query.Matches(Bead{ID: "match", Assignee: "rig/validator"}) {
+		t.Fatal("Matches() = false, want true for listed assignee")
+	}
+	if query.Matches(Bead{ID: "miss", Assignee: "rig/reviewer"}) {
+		t.Fatal("Matches() = true, want false for unlisted assignee")
+	}
+}
+
+func TestListQueryValidateRejectsAssigneeAndAssignees(t *testing.T) {
+	query := ListQuery{
+		Assignee:  "rig/builder",
+		Assignees: []string{"rig/validator"},
+	}
+
+	err := query.Validate()
+	if err == nil {
+		t.Fatal("Validate() = nil, want error")
+	}
+	if got, want := err.Error(), "ListQuery: Assignee and Assignees are mutually exclusive"; got != want {
+		t.Fatalf("Validate() error = %q, want %q", got, want)
+	}
+}
+
 func TestListQueryUpdatedBeforeMatchesReferenceTimestampBoundaries(t *testing.T) {
 	cutoff := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 	tests := []struct {

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -58,10 +58,13 @@ func TierModeFromOpts(opts []QueryOpt) TierMode {
 // Queries are conjunctive: every populated field must match. A zero-value query
 // is rejected unless AllowScan is true.
 type ListQuery struct {
-	Status        string
-	Type          string
-	Label         string
-	Assignee      string
+	Status   string
+	Type     string
+	Label    string
+	Assignee string
+	// Assignees matches beads assigned to any listed assignee.
+	// It is mutually exclusive with Assignee; call Validate to enforce that contract.
+	Assignees     []string
 	ParentID      string
 	Metadata      map[string]string
 	CreatedBefore time.Time
@@ -86,6 +89,14 @@ type ListQuery struct {
 	TierMode TierMode
 }
 
+// Validate returns an error when the query contains contradictory selectors.
+func (q ListQuery) Validate() error {
+	if q.Assignee != "" && len(q.Assignees) > 0 {
+		return errors.New("ListQuery: Assignee and Assignees are mutually exclusive")
+	}
+	return nil
+}
+
 // ReadyQuery describes optional filters for ready-work lookup. A zero-value
 // query preserves Ready's historical behavior: all open, unblocked actionable
 // work.
@@ -107,6 +118,7 @@ func (q ListQuery) HasFilter() bool {
 		q.Type != "" ||
 		q.Label != "" ||
 		q.Assignee != "" ||
+		len(q.Assignees) > 0 ||
 		q.ParentID != "" ||
 		len(q.Metadata) > 0 ||
 		!q.CreatedBefore.IsZero() ||
@@ -147,6 +159,18 @@ func (q ListQuery) Matches(b Bead) bool {
 	}
 	if q.Assignee != "" && b.Assignee != q.Assignee {
 		return false
+	}
+	if len(q.Assignees) > 0 {
+		matched := false
+		for _, assignee := range q.Assignees {
+			if b.Assignee == assignee {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
 	}
 	if q.ParentID != "" && b.ParentID != q.ParentID {
 		return false

--- a/release-gates/ga-tftexi-1-listquery-assignees-gate.md
+++ b/release-gates/ga-tftexi-1-listquery-assignees-gate.md
@@ -1,0 +1,93 @@
+# Release Gate: ga-tftexi.1 - ListQuery.Assignees contract
+
+Deploy bead: `ga-tftexi.1` - `Deploy isolated ListQuery.Assignees contract slice`
+Parent deploy bead: `ga-tftexi`
+Source review bead: `ga-km7pwx`
+Reviewed commit: `105d0224d` on `builder/ga-2znrco.1-listquery-assignees`
+Release branch: `release/ga-tftexi-1-listquery-assignees-v7`
+Release commit before gate: `d84cfaa4125edc4c0824988c514699286ad957e6`
+Base: `origin/main` at `882955678403fc4327ac57422bbbf668ac0231de`
+Evaluated: `2026-06-01T04:33:21Z`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses
+the release criteria from the active deployer instructions plus the repository
+testing guidance in `TESTING.md`.
+
+## Scope
+
+The original parent deploy bead failed scope because
+`builder/ga-2znrco.1-listquery-assignees` was stacked on unrelated
+coordstore/SQLite work. PM split this isolated child bead with a contamination
+guard. This release branch was cut fresh from current `origin/main` and
+cherry-picked only the reviewed ListQuery commit.
+
+The resulting code diff before this gate file contains exactly:
+
+- `internal/beads/query.go`
+- `internal/beads/beads_test.go`
+
+It does not include coordstore/SQLite PR #2738 work or any release-gate/doc
+artifacts from the stacked builder branch.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `ga-km7pwx` is closed with `PASS (reviewer: gascity/reviewer)` for commit `105d0224d`; parent `ga-tftexi` records the reviewed PASS and PM split into this isolated deploy child. |
+| 2 | Acceptance criteria met | PASS | `ListQuery.Assignees` is mutually exclusive with `Assignee` via `Validate`, participates in `HasFilter`, and `Matches` accepts any listed assignee. Tests cover all three behaviors, including the exact mutual-exclusion error. |
+| 3 | Tests pass | PASS | Focused `TestListQuery` passed; `internal/beads` and `internal/beads/exec` passed; `make test-fast-parallel` passed all fast shards; `go vet ./...` exited clean. |
+| 4 | No high-severity review findings open | PASS | The review notes on `ga-km7pwx` state security clean and list no HIGH findings. Unresolved HIGH count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty after the cherry-pick and before writing this release-gate file. This file is the only deployer-authored addition and is committed with the gate. |
+| 6 | Branch diverges cleanly from main | PASS | Branch was created from current `origin/main`; `git merge-base origin/main HEAD` equals `882955678403fc4327ac57422bbbf668ac0231de`. `git merge-tree --write-tree HEAD origin/main` exited 0 and produced tree `348ff661fe99d977218aa35f8a07f63ac31ac96d`. |
+| 7 | Single feature theme | PASS | The release branch touches one subsystem theme: adding a multi-assignee selector to the beads `ListQuery` contract. The diff is limited to the query contract and its tests. |
+
+## Acceptance Evidence
+
+- `git diff --stat origin/main...HEAD` before this gate showed only two
+  `internal/beads` files and 62 insertions / 4 deletions.
+- `git diff --check origin/main...HEAD` exited 0.
+- `rg -n "Assignees|Validate\(" internal/beads` found the new field,
+  validation guard, filter/match logic, and tests only in `internal/beads`.
+- `TestListQueryHasFilterIncludesAssignees` verifies `HasFilter`.
+- `TestListQueryMatchesAnyAssignee` verifies any-listed-assignee matching.
+- `TestListQueryValidateRejectsAssigneeAndAssignees` verifies mutual exclusion
+  with the exact error message.
+
+## Commands
+
+```text
+gh auth status
+git fetch origin main
+git worktree add -b release/ga-tftexi-1-listquery-assignees-v7 /tmp/gascity-deploy-ga-tftexi-1-v7 origin/main
+git cherry-pick 105d0224d
+git status --short --branch
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+git merge-tree --write-tree HEAD origin/main
+rg -n "Assignees|Validate\(" internal/beads
+GOTOOLCHAIN=auto go test ./internal/beads -run TestListQuery -count=1
+GOTOOLCHAIN=auto go test ./internal/beads ./internal/beads/exec -count=1
+GOTOOLCHAIN=auto make test-fast-parallel
+GOTOOLCHAIN=auto go vet ./...
+git config core.hooksPath
+```
+
+## Test Summary
+
+```text
+go test ./internal/beads -run TestListQuery -count=1
+ok  	github.com/gastownhall/gascity/internal/beads	0.040s
+
+go test ./internal/beads ./internal/beads/exec -count=1
+ok  	github.com/gastownhall/gascity/internal/beads	5.936s
+ok  	github.com/gastownhall/gascity/internal/beads/exec	7.155s
+
+make test-fast-parallel
+All fast jobs passed
+
+go vet ./...
+clean
+
+git config core.hooksPath
+.githooks
+```


### PR DESCRIPTION
## What this changes

`ListQuery` now has an `Assignees` selector for callers that need beads assigned to any one of several sessions or agents. The existing `Assignee` field remains the single-assignee selector; `Assignees` adds OR matching without making callers run multiple queries and union the results themselves.

The query contract also gains `Validate`, which rejects using `Assignee` and `Assignees` together, and `HasFilter` now treats a non-empty assignee list as an active filter.

## Review notes

- The branch is intentionally limited to the beads object-model query contract and tests in `internal/beads`.
- `Assignees` is any-match semantics. It does not change default zero-value query behavior.
- This PR does not include the coordstore/SQLite stack from the original builder branch; the release gate records the isolation check.

## Test plan

- [x] `GOTOOLCHAIN=auto go test ./internal/beads -run TestListQuery -count=1`
- [x] `GOTOOLCHAIN=auto go test ./internal/beads ./internal/beads/exec -count=1`
- [x] `GOTOOLCHAIN=auto make test-fast-parallel`
- [x] `GOTOOLCHAIN=auto go vet ./...`
- [x] Release gate: [`release-gates/ga-tftexi-1-listquery-assignees-gate.md`](release-gates/ga-tftexi-1-listquery-assignees-gate.md)
