### PR TITLE
feat(mail): wire retention ttl into hqstore

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -24,6 +24,13 @@ import (
 
 const initPackSchemaVersion = 2
 
+const initMailRetentionExample = `# [mail]
+# retention_ttl controls how long read messages are retained before purge.
+# 0 disables retention; use "168h" for 7 days.
+# "7d" is not a valid Go duration.
+# retention_ttl = "0"
+`
+
 type initPackMeta struct {
 	Name        string                   `toml:"name"`
 	Version     string                   `toml:"version,omitempty"`
@@ -586,6 +593,21 @@ func isZeroValue(v any) bool {
 	return reflect.ValueOf(v).IsZero()
 }
 
+func withInitMailRetentionExample(content []byte) []byte {
+	text := string(content)
+	if strings.Contains(text, "retention_ttl") {
+		return content
+	}
+	if !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	if !strings.HasSuffix(text, "\n\n") {
+		text += "\n"
+	}
+	text += initMailRetentionExample
+	return []byte(text)
+}
+
 func newInitPackConfig(cityName string) initPackConfig {
 	return initPackConfig{
 		Pack: initPackMeta{
@@ -1012,6 +1034,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	content = withInitMailRetentionExample(content)
 	logInitProgress(stdout, 4, "Writing pack.toml")
 	wrotePack, err := writeInitPackTomlOpts(fs, cityPath, packCfg, preserveExisting)
 	if err != nil {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -2734,6 +2734,12 @@ func TestDoInitWritesExpectedTOML(t *testing.T) {
 
 [daemon]
 formula_v2 = true
+
+# [mail]
+# retention_ttl controls how long read messages are retained before purge.
+# 0 disables retention; use "168h" for 7 days.
+# "7d" is not a valid Go duration.
+# retention_ttl = "0"
 `
 	if got != want {
 		t.Errorf("city.toml content:\ngot:\n%s\nwant:\n%s", got, want)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -450,6 +450,7 @@ MailConfig holds mail provider settings.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `provider` | string |  |  | Provider selects the mail backend: "fake", "fail", "exec:&lt;script&gt;", or "" (default: beadmail). |
+| `retention_ttl` | string |  |  | RetentionTTL is how long read messages are retained before purge. Empty or "0" disables read-message retention. |
 
 ## MaintenanceConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1627,6 +1627,10 @@
         "provider": {
           "type": "string",
           "description": "Provider selects the mail backend: \"fake\", \"fail\",\n\"exec:\u003cscript\u003e\", or \"\" (default: beadmail)."
+        },
+        "retention_ttl": {
+          "type": "string",
+          "description": "RetentionTTL is how long read messages are retained before purge. Empty\nor \"0\" disables read-message retention."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1627,6 +1627,10 @@
         "provider": {
           "type": "string",
           "description": "Provider selects the mail backend: \"fake\", \"fail\",\n\"exec:\u003cscript\u003e\", or \"\" (default: beadmail)."
+        },
+        "retention_ttl": {
+          "type": "string",
+          "description": "RetentionTTL is how long read messages are retained before purge. Empty\nor \"0\" disables read-message retention."
         }
       },
       "additionalProperties": false,

--- a/internal/beads/hqstore.go
+++ b/internal/beads/hqstore.go
@@ -81,6 +81,7 @@ type HQStore struct {
 	ttlDone     chan struct{}
 
 	closedTaskRetention time.Duration
+	mailRetentionTTL    time.Duration
 
 	snapshotInterval time.Duration
 	snapStop         chan struct{}
@@ -96,6 +97,7 @@ type hqStoreOptions struct {
 	prefix           string
 	ttlInterval      time.Duration
 	closedRetention  time.Duration
+	mailRetentionTTL time.Duration
 	snapshotInterval time.Duration
 }
 
@@ -128,6 +130,15 @@ func WithHQStoreClosedTaskRetention(d time.Duration) HQStoreOption {
 	}
 }
 
+// WithHQStoreMailRetentionTTL sets how long read message wisps remain before
+// the TTL sweeper may delete them. A non-positive duration disables
+// read-message retention sweeping.
+func WithHQStoreMailRetentionTTL(d time.Duration) HQStoreOption {
+	return func(o *hqStoreOptions) {
+		o.mailRetentionTTL = d
+	}
+}
+
 // WithHQStoreSnapshotInterval sets the background snapshot cadence. A
 // non-positive interval disables periodic snapshots; Shutdown still flushes a
 // final snapshot so an orderly close is always durable.
@@ -157,6 +168,7 @@ func OpenHQStore(dir string, opts ...HQStoreOption) (*HQStore, error) {
 		prefix:              cfg.prefix,
 		ttlInterval:         cfg.ttlInterval,
 		closedTaskRetention: cfg.closedRetention,
+		mailRetentionTTL:    cfg.mailRetentionTTL,
 		snapshotInterval:    cfg.snapshotInterval,
 	}
 	store.resetCoreLocked()
@@ -167,6 +179,14 @@ func OpenHQStore(dir string, opts ...HQStoreOption) (*HQStore, error) {
 	store.startSnapshotter()
 	store.startTTLSweeper()
 	return store, nil
+}
+
+// MailRetentionTTL returns the configured read-message retention duration.
+func (s *HQStore) MailRetentionTTL() time.Duration {
+	if s == nil {
+		return 0
+	}
+	return s.mailRetentionTTL
 }
 
 // Counters returns the live HQStore entry counters for test and diagnostic

--- a/internal/beads/hqstore_production_test.go
+++ b/internal/beads/hqstore_production_test.go
@@ -232,11 +232,15 @@ func TestHQStoreCoverageMatrix(t *testing.T) {
 func TestHQStoreOptionAndBranchCoverage(t *testing.T) {
 	store, err := beads.OpenHQStore(t.TempDir(),
 		beads.WithHQStoreIDPrefix("custom"),
+		beads.WithHQStoreMailRetentionTTL(2*time.Hour),
 		beads.WithHQStoreTTLInterval(10*time.Millisecond),
 		beads.WithHQStoreSnapshotInterval(0),
 	)
 	if err != nil {
 		t.Fatalf("OpenHQStore: %v", err)
+	}
+	if got := store.MailRetentionTTL(); got != 2*time.Hour {
+		t.Fatalf("MailRetentionTTL() = %v, want 2h", got)
 	}
 	t.Cleanup(func() {
 		if err := store.Shutdown(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1380,6 +1380,26 @@ type MailConfig struct {
 	// Provider selects the mail backend: "fake", "fail",
 	// "exec:<script>", or "" (default: beadmail).
 	Provider string `toml:"provider,omitempty"`
+	// RetentionTTL is how long read messages are retained before purge. Empty
+	// or "0" disables read-message retention.
+	RetentionTTL string `toml:"retention_ttl,omitempty"`
+}
+
+// RetentionTTLDuration parses RetentionTTL as a Go time.Duration. Empty or
+// zero disables read-message retention.
+func (m MailConfig) RetentionTTLDuration() (time.Duration, error) {
+	raw := strings.TrimSpace(m.RetentionTTL)
+	if raw == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("[mail] retention_ttl %q is not a valid Go duration: %w", raw, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("[mail] retention_ttl must not be negative: got %q", raw)
+	}
+	return d, nil
 }
 
 // EventsConfig holds events provider settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4428,6 +4428,39 @@ func TestInstallAgentHooksOmittedWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestMailConfigRetentionTTLDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "empty", raw: "", want: 0},
+		{name: "zero", raw: "0", want: 0},
+		{name: "hours", raw: "168h", want: 168 * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := (MailConfig{RetentionTTL: tt.raw}).RetentionTTLDuration()
+			if err != nil {
+				t.Fatalf("RetentionTTLDuration() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("RetentionTTLDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMailConfigRetentionTTLDurationRejectsInvalid(t *testing.T) {
+	_, err := (MailConfig{RetentionTTL: "7d"}).RetentionTTLDuration()
+	if err == nil {
+		t.Fatal("RetentionTTLDuration() succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "[mail] retention_ttl") || !strings.Contains(err.Error(), "7d") {
+		t.Fatalf("RetentionTTLDuration() error = %q, want field context and bad value", err)
+	}
+}
+
 // --- WispGC config tests ---
 
 func TestDaemonConfig_WispGCDisabledByDefault(t *testing.T) {

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -55,6 +55,9 @@ func ValidateDurations(cfg *City, source string) []string {
 	// Orders config durations.
 	check("[orders]", "max_timeout", cfg.Orders.MaxTimeout)
 
+	// Mail config durations.
+	check("[mail]", "retention_ttl", cfg.Mail.RetentionTTL)
+
 	// Events config durations.
 	check("[events.rotation]", "archive_retain_age", cfg.Events.Rotation.ArchiveRetainAge)
 

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -76,6 +76,25 @@ func TestValidateDurationsBadSessionTimeout(t *testing.T) {
 	}
 }
 
+func TestValidateDurationsBadMailRetentionTTL(t *testing.T) {
+	cfg := &City{
+		Mail: MailConfig{RetentionTTL: "7d"},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "[mail]") {
+		t.Errorf("warning should mention section: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "retention_ttl") {
+		t.Errorf("warning should mention field: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "7d") {
+		t.Errorf("warning should mention bad value: %s", warnings[0])
+	}
+}
+
 func TestValidateDurationsBadDaemonFields(t *testing.T) {
 	cfg := &City{
 		Daemon: DaemonConfig{

--- a/release-gates/ga-b61zh6-mail-retention-ttl-config-gate.md
+++ b/release-gates/ga-b61zh6-mail-retention-ttl-config-gate.md
@@ -1,0 +1,63 @@
+# Release Gate: Mail Retention TTL Config Wiring
+
+Date: 2026-06-01
+Deploy bead: ga-b61zh6
+Source review bead: ga-as3tjd
+PR: https://github.com/gastownhall/gascity/pull/2869
+Branch: builder/ga-a5muun-1-mail-retention-v2
+Reviewed PR head before this gate: 1843e79ffa7170a54f83a048d257020a5d0cc63c
+Base checked: origin/main b2b659d421ace115fcc47575b202c0a4541ad75a
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer prompt criteria and the source bead acceptance checklist.
+
+## Scope
+
+The release diff from current `origin/main` contains one mail retention configuration wiring slice plus this release gate:
+
+| Path | Status | Purpose |
+|---|---:|---|
+| `internal/config/config.go` | M | Adds `[mail].retention_ttl` config storage and duration parsing. |
+| `internal/config/validate_durations.go` | M | Validates non-empty mail retention duration values. |
+| `internal/config/config_test.go` | M | Covers accepted and rejected retention TTL duration forms. |
+| `internal/config/validate_durations_test.go` | M | Covers invalid mail retention duration validation. |
+| `internal/beads/hqstore.go` | M | Threads parsed retention TTL into HQStore options and accessor. |
+| `internal/beads/hqstore_production_test.go` | M | Covers the HQStore option/accessor path. |
+| `cmd/gc/cmd_init.go` | M | Adds the scaffolded retention TTL comment to generated city config. |
+| `cmd/gc/main_test.go` | M | Updates init output expectations. |
+| `docs/reference/config.md` | M | Documents the new mail config field. |
+| `docs/schema/city-schema.json` | M | Updates generated config schema. |
+| `docs/schema/city-schema.txt` | M | Updates generated schema reference text. |
+| `release-gates/ga-b61zh6-mail-retention-ttl-config-gate.md` | A | Release gate evidence. |
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-as3tjd` shows a closed review bead with `REVIEW VERDICT: PASS` for PR #2869 and commit `1843e79f`. |
+| 2 | Acceptance criteria met | PASS | `[mail].retention_ttl` is parsed as a Go duration, invalid values are rejected by duration validation, the parsed duration is available through HQStore options/accessor, init output and schema/docs are updated, and no purge loop is introduced in this config-only slice. |
+| 3 | Tests pass | PASS | Targeted config, HQStore, and init tests passed; `go vet ./...` passed; `make test-fast-parallel` passed with `All fast jobs passed`. |
+| 4 | No high-severity review findings open | PASS | Review notes list informational findings only; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Detached PR-head worktree was clean before gate creation; final clean status is verified after committing this gate. |
+| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main` refreshed current base; `git merge-tree --write-tree origin/main HEAD` exited 0; `git diff --check origin/main...HEAD` exited 0. |
+| 7 | Single feature theme | PASS | Commit set is one mail retention TTL configuration wiring slice across config, HQStore option plumbing, generated schema/docs, and init scaffold tests. |
+
+## Acceptance Evidence
+
+| Source criterion | Result | Evidence |
+|---|---|---|
+| Add `[mail].retention_ttl` config parsing. | PASS | `internal/config/config.go` stores the field and parses it via `time.ParseDuration`. |
+| Reject invalid duration values. | PASS | `ValidateDurations` checks non-empty mail retention TTL values; tests cover invalid `7d` and valid empty, `0`, and `168h` values. |
+| Thread the duration into HQStore without adding purge behavior. | PASS | `WithHQStoreMailRetentionTTL` and `MailRetentionTTL()` expose the parsed value; review confirms the purge loop is intentionally out of scope. |
+| Update generated config scaffold and expectations. | PASS | `cmd/gc/cmd_init.go` adds an idempotent scaffold comment and `cmd/gc/main_test.go` matches the generated TOML. |
+| Update docs and schema. | PASS | `docs/reference/config.md`, `docs/schema/city-schema.json`, and `docs/schema/city-schema.txt` include the new field. |
+
+## Test Evidence
+
+- PASS: `go test ./internal/config -run 'TestMailConfigRetentionTTLDuration|TestValidateDurationsBadMailRetentionTTL' -count=1`
+- PASS: `go test ./internal/beads -run 'TestHQStoreOptionAndBranchCoverage' -count=1`
+- PASS: `go test ./cmd/gc -run 'TestCityInitExactOutput_DefaultScaffold|TestDoInit' -count=1`
+- PASS: `go vet ./...`
+- PASS: `make test-fast-parallel`
+- PASS: `.githooks/pre-commit` is active via `core.hooksPath=.githooks`; commit hook runs `go test ./test/docsync`.
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

This adds `[mail].retention_ttl` to city configuration. Operators can leave it empty, set it to `0`, or provide a Go duration such as `168h`; invalid duration strings are rejected during config validation.

The parsed value is wired into HQStore options and exposed through an accessor so retention behavior can consume it later. This PR intentionally does not add a purge loop or delete any mail.

## Review notes

- New config surface: `[mail].retention_ttl`.
- Duration format is Go `time.ParseDuration` syntax; values like `7d` are rejected.
- `gc init` scaffold output, config reference docs, and generated city schema are updated.
- This is default-off config plumbing only; retention enforcement remains a separate change.

## Test plan

- [x] `go test ./internal/config -run 'TestMailConfigRetentionTTLDuration|TestValidateDurationsBadMailRetentionTTL' -count=1`
- [x] `go test ./internal/beads -run 'TestHQStoreOptionAndBranchCoverage' -count=1`
- [x] `go test ./cmd/gc -run 'TestCityInitExactOutput_DefaultScaffold|TestDoInit' -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-b61zh6-mail-retention-ttl-config-gate.md`](release-gates/ga-b61zh6-mail-retention-ttl-config-gate.md)
