### PR TITLE
feat(beads): index multi-assignee HQStore queries

### DIFF
--- a/internal/beads/hqstore_core.go
+++ b/internal/beads/hqstore_core.go
@@ -837,6 +837,15 @@ func (i hqTierIndex) candidateIDs(q ListQuery) hqIDSet {
 	if q.Assignee != "" {
 		candidates = append(candidates, i.assignee[q.Assignee])
 	}
+	if len(q.Assignees) > 0 {
+		union := make(hqIDSet)
+		for _, assignee := range q.Assignees {
+			for id := range i.assignee[assignee] {
+				union[id] = struct{}{}
+			}
+		}
+		candidates = append(candidates, union)
+	}
 	if q.ParentID != "" {
 		candidates = append(candidates, i.parent[q.ParentID])
 	}

--- a/internal/beads/hqstore_core_internal_test.go
+++ b/internal/beads/hqstore_core_internal_test.go
@@ -1,0 +1,40 @@
+package beads
+
+import "testing"
+
+func TestHQTierIndexCandidateIDsUnionsAssignees(t *testing.T) {
+	idx := newHQTierIndex()
+	idx.add(Bead{ID: "route-a-open", Status: "open", Assignee: "rig/route-a"})
+	idx.add(Bead{ID: "route-b-progress", Status: "in_progress", Assignee: "rig/route-b"})
+	idx.add(Bead{ID: "route-c-open", Status: "open", Assignee: "rig/route-c"})
+	idx.add(Bead{ID: "route-a-closed", Status: "closed", Assignee: "rig/route-a"})
+
+	got := idx.candidateIDs(ListQuery{Assignees: []string{"rig/route-a", "rig/route-b"}})
+
+	assertHQIDSet(t, got, []string{"route-a-open", "route-b-progress"})
+}
+
+func TestHQTierIndexCandidateIDsAssigneesEmptyUnionStaysEmpty(t *testing.T) {
+	idx := newHQTierIndex()
+	idx.add(Bead{ID: "route-a-open", Status: "open", Assignee: "rig/route-a"})
+	idx.add(Bead{ID: "route-b-progress", Status: "in_progress", Assignee: "rig/route-b"})
+	idx.add(Bead{ID: "route-c-closed", Status: "closed", Assignee: "rig/route-c"})
+
+	got := idx.candidateIDs(ListQuery{Assignees: []string{"rig/missing"}, Status: "open"})
+	assertHQIDSet(t, got, nil)
+
+	got = idx.candidateIDs(ListQuery{Assignees: []string{"rig/missing"}, IncludeClosed: true})
+	assertHQIDSet(t, got, nil)
+}
+
+func assertHQIDSet(t *testing.T, got hqIDSet, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len(got) = %d, want %d: %v", len(got), len(want), got)
+	}
+	for _, id := range want {
+		if _, ok := got[id]; !ok {
+			t.Fatalf("got missing ID %q: %v", id, got)
+		}
+	}
+}

--- a/release-gates/ga-yinjm2-1-hqstore-assignees-gate.md
+++ b/release-gates/ga-yinjm2-1-hqstore-assignees-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: ga-yinjm2.1 HQStore Assignees Index Union
+
+Date: 2026-06-01
+Bead: ga-yinjm2.1
+Source review bead: ga-kbehsy
+Source commit: 8a6de11d9
+Release branch: release/ga-yinjm2-1-hqstore-assignees
+Release feature commit before this gate: d670cb69d
+Base checked: origin/main b2b659d421ace115fcc47575b202c0a4541ad75a
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses the deployer prompt criteria and the bead acceptance criteria.
+
+## Scope
+
+The release diff from current `origin/main` contains the HQStore Assignees index-union slice only:
+
+| Path | Status | Purpose |
+|---|---:|---|
+| `internal/beads/hqstore_core.go` | M | Union per-assignee HQStore index buckets for `ListQuery.Assignees`. |
+| `internal/beads/hqstore_core_internal_test.go` | A | Cover multi-assignee OR semantics and unknown-assignee empty union behavior. |
+| `release-gates/ga-yinjm2-1-hqstore-assignees-gate.md` | A | Release gate evidence. |
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | Review bead `ga-kbehsy` is closed with close reason `pass`; notes contain `PASS (reviewer: gascity/reviewer)` for source commit `8a6de11d9`. |
+| 2 | Acceptance criteria met | PASS | Dependency PR #2865 is recorded merged at `2026-06-01T05:16:20Z`; current release diff excludes the coordstore/SQLite PR #2738 stack; behavior from `ga-kbehsy` is preserved by code at `internal/beads/hqstore_core.go` and tests in `internal/beads/hqstore_core_internal_test.go`. |
+| 3 | Tests pass | PASS | `go test ./internal/beads -run 'TestHQTierIndexCandidateIDs(AssigneesEmptyUnionStaysEmpty\|UnionsAssignees)' -count=1` PASS; `go test ./internal/beads -count=1` PASS; `go vet ./...` PASS; `make test` PASS with observable log `/tmp/gascity-test.jsonl.i3gzST`. |
+| 4 | No high-severity review findings open | PASS | Review notes report no security concerns and no unresolved HIGH findings; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` before gate write showed no uncommitted feature changes; final clean status is verified after committing this gate. |
+| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main` refreshed current base; cherry-pick onto `origin/main` was clean; `git merge-tree origin/main HEAD` exited 0; `git diff --check origin/main...HEAD` exited 0. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem, `internal/beads`, and implements one behavior: indexed candidate selection for multi-assignee HQStore list queries. |
+
+## Acceptance Notes
+
+- `ListQuery.Assignees` contract dependency is on `origin/main` via PR #2865 before this slice ships.
+- Per-assignee index buckets are OR-unioned when `ListQuery.Assignees` is set.
+- Unknown assignees produce an empty candidate set, including when combined with status filters and when closed beads are included.
+- Singular `Assignee` behavior is unchanged; `ListQuery.Validate()` keeps singular and plural assignee forms mutually exclusive.
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

HQStore can now use its per-assignee index when a `ListQuery` specifies multiple assignees. It builds a candidate set from the union of those assignee buckets and lets the existing filter pipeline apply status, type, parent, and closed-bead constraints. Multi-assignee list queries therefore keep OR semantics across assignees without falling back to a broader scan.

Unknown assignees intentionally produce an empty candidate set, including when the query asks to include closed beads. That prevents a missing assignee filter from widening the result set.

## Review notes

- The code path is limited to `internal/beads` HQStore candidate selection.
- This depends on the `ListQuery.Assignees` API contract already present on `main`.
- No CLI, HTTP API, config, dashboard, schema, or migration changes are included.

## Test plan

- [x] `go test ./internal/beads -run 'TestHQTierIndexCandidateIDs(AssigneesEmptyUnionStaysEmpty|UnionsAssignees)' -count=1`
- [x] `go test ./internal/beads -count=1`
- [x] `go vet ./...`
- [x] `make test`
- [x] Release gate: [`release-gates/ga-yinjm2-1-hqstore-assignees-gate.md`](release-gates/ga-yinjm2-1-hqstore-assignees-gate.md)
