### PR TITLE
fix(cmd/gc): teardown tmux server after orphan stop

### DIFF
--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -300,6 +300,8 @@ func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr i
 	// not in the current config).
 	stopOrphans(sp, desired, cfg, store, graceTimeout, recorder, stdout, stderr)
 
+	teardownServerForStop(sp, stderr)
+
 	// Stop bead store's backing service after agents.
 	if err := shutdownBeadsProviderForStop(cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -307,6 +309,16 @@ func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr i
 	}
 
 	return code
+}
+
+func teardownServerForStop(sp runtime.Provider, stderr io.Writer) {
+	lifecycle, ok := sp.(runtime.ServerLifecycleProvider)
+	if !ok {
+		return
+	}
+	if err := lifecycle.TeardownServer(); err != nil {
+		fmt.Fprintf(stderr, "gc stop: teardown server: %v\n", err) //nolint:errcheck // best-effort stderr
+	}
 }
 
 func markCityStopSessionSleepReason(store beads.Store, stderr io.Writer) {

--- a/cmd/gc/cmd_stop_server_lifecycle_test.go
+++ b/cmd/gc/cmd_stop_server_lifecycle_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// lifecycleOrderProvider wraps runtime.Fake and additionally implements
+// runtime.ServerLifecycleProvider. It records the order of ListRunning and
+// TeardownServer calls so ordering tests can verify the stop-path sequence.
+type lifecycleOrderProvider struct {
+	*runtime.Fake
+	mu          sync.Mutex
+	events      []string
+	teardownErr error
+}
+
+func (p *lifecycleOrderProvider) ListRunning(prefix string) ([]string, error) {
+	p.mu.Lock()
+	p.events = append(p.events, "ListRunning")
+	p.mu.Unlock()
+	return p.Fake.ListRunning(prefix)
+}
+
+func (p *lifecycleOrderProvider) ConfigureServer() error {
+	return nil
+}
+
+func (p *lifecycleOrderProvider) TeardownServer() error {
+	p.mu.Lock()
+	p.events = append(p.events, "TeardownServer")
+	p.mu.Unlock()
+	return p.teardownErr
+}
+
+// Compile-time assertions: lifecycleOrderProvider satisfies both interfaces.
+var (
+	_ runtime.Provider                = (*lifecycleOrderProvider)(nil)
+	_ runtime.ServerLifecycleProvider = (*lifecycleOrderProvider)(nil)
+)
+
+// TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown is a
+// coordination test that verifies the stop-path ordering contract in
+// cmdStopBody: TeardownServer is called after stopOrphans has run its
+// ListRunning sweep AND before the bead-provider shutdown.
+//
+// Expected sequence: doStop -> stopOrphans (ListRunning) -> TeardownServer -> shutdownBeadsProvider
+func TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "lifecycle-order-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "0s"},
+	}
+	writeStopLifecycleCityConfig(t, cityDir, cfg)
+
+	sp := &lifecycleOrderProvider{Fake: runtime.NewFake()}
+
+	var orderMu sync.Mutex
+	var shutdownCalled bool
+	var eventsAtShutdown []string
+	overrideShutdownBeadsProviderForStop(t, func(string) error {
+		sp.mu.Lock()
+		snapshot := make([]string, len(sp.events))
+		copy(snapshot, sp.events)
+		sp.mu.Unlock()
+
+		orderMu.Lock()
+		shutdownCalled = true
+		eventsAtShutdown = snapshot
+		orderMu.Unlock()
+		return nil
+	})
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	sessionProviderForStopCity = func(*config.City, string) runtime.Provider { return sp }
+
+	var stdout, stderr lockedBuffer
+	code := cmdStopBody(cityDir, cfg, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdStopBody() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	sp.mu.Lock()
+	allProviderEvents := make([]string, len(sp.events))
+	copy(allProviderEvents, sp.events)
+	sp.mu.Unlock()
+
+	orderMu.Lock()
+	called := shutdownCalled
+	snapshot := eventsAtShutdown
+	orderMu.Unlock()
+
+	// TeardownServer must be present.
+	teardownIdx := -1
+	for i, e := range allProviderEvents {
+		if e == "TeardownServer" {
+			teardownIdx = i
+			break
+		}
+	}
+	if teardownIdx < 0 {
+		t.Fatalf("TeardownServer was never called; provider events = %v", allProviderEvents)
+	}
+
+	// TeardownServer must precede the bead-provider shutdown.
+	if called {
+		found := false
+		for _, e := range snapshot {
+			if e == "TeardownServer" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("TeardownServer must occur before bead-provider shutdown; events at shutdown = %v, all provider events = %v",
+				snapshot, allProviderEvents)
+		}
+	}
+
+	// TeardownServer must follow at least one ListRunning (the orphan sweep).
+	listRunningBeforeTeardown := false
+	for _, e := range allProviderEvents[:teardownIdx] {
+		if e == "ListRunning" {
+			listRunningBeforeTeardown = true
+			break
+		}
+	}
+	if !listRunningBeforeTeardown {
+		t.Fatalf("TeardownServer called before any ListRunning (orphan sweep must precede teardown); events = %v", allProviderEvents)
+	}
+}
+
+// TestCmdStopBodySkipsTeardownForNonLifecycleProvider verifies that cmdStopBody
+// completes successfully when the session provider does not implement
+// runtime.ServerLifecycleProvider. The type assertion must yield ok=false and
+// skip teardown silently: no panic, no error in stderr.
+//
+// This is the normal case for non-tmux providers (subprocess, exec, K8s, Fake).
+func TestCmdStopBodySkipsTeardownForNonLifecycleProvider(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "no-lifecycle-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "0s"},
+	}
+	writeStopLifecycleCityConfig(t, cityDir, cfg)
+
+	// Verify that runtime.Fake does NOT implement ServerLifecycleProvider.
+	// This guards against a future change that accidentally adds the interface
+	// to Fake (which would defeat the skip path and change non-tmux behavior).
+	var baseProvider runtime.Provider = runtime.NewFake()
+	if _, ok := baseProvider.(runtime.ServerLifecycleProvider); ok {
+		t.Fatal("runtime.Fake must not implement runtime.ServerLifecycleProvider; " +
+			"non-lifecycle providers must skip teardown via ok=false type assertion")
+	}
+
+	overrideShutdownBeadsProviderForStop(t, func(string) error { return nil })
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	sessionProviderForStopCity = func(*config.City, string) runtime.Provider {
+		return runtime.NewFake()
+	}
+
+	var stdout, stderr lockedBuffer
+	code := cmdStopBody(cityDir, cfg, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdStopBody() = %d, want 0 for non-lifecycle provider; stdout=%q stderr=%q",
+			code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout = %q, want City stopped.", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "teardown server") {
+		t.Fatalf("stderr = %q, unexpected teardown error for non-lifecycle provider", stderr.String())
+	}
+}
+
+// TestCmdStopBodyReportsTeardownErrorWithoutFailing verifies that tmux server
+// teardown is best-effort: a provider error is visible to the operator but does
+// not change the stop exit code.
+func TestCmdStopBodyReportsTeardownErrorWithoutFailing(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "lifecycle-error-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "0s"},
+	}
+	writeStopLifecycleCityConfig(t, cityDir, cfg)
+
+	sp := &lifecycleOrderProvider{
+		Fake:        runtime.NewFake(),
+		teardownErr: errors.New("provider-stop-failed"),
+	}
+
+	overrideShutdownBeadsProviderForStop(t, func(string) error { return nil })
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	sessionProviderForStopCity = func(*config.City, string) runtime.Provider { return sp }
+
+	var stdout, stderr lockedBuffer
+	code := cmdStopBody(cityDir, cfg, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdStopBody() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "City stopped.") {
+		t.Fatalf("stdout = %q, want City stopped.", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "gc stop: teardown server: provider-stop-failed") {
+		t.Fatalf("stderr = %q, want teardown server warning", stderr.String())
+	}
+}
+
+func writeStopLifecycleCityConfig(t *testing.T, cityDir string, cfg *config.City) {
+	t.Helper()
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/release-gates/ga-62zmxp-tmux-server-teardown-gate.md
+++ b/release-gates/ga-62zmxp-tmux-server-teardown-gate.md
@@ -1,0 +1,59 @@
+# Release Gate: tmux Server Teardown After Stop Orphans
+
+Date: 2026-06-01
+Deploy bead: ga-62zmxp
+Source review bead: ga-m64fa4
+Existing stacked PR: https://github.com/gastownhall/gascity/pull/2778
+Branch: release/ga-62zmxp-tmux-server-teardown
+Feature code commit: abe898be1
+Original reviewed commit: 56bf1df7762238df24d854f3f3c1182b5b408148
+Base checked: origin/main 1648f272916eeef0f89b58b6dccf7e41a62c8cba
+
+`docs/PROJECT_MANIFEST.md` is not present in this worktree, so this gate uses
+the deployer prompt criteria and the source review bead checklist.
+
+## Scope
+
+The final release branch was cut fresh from current `origin/main` after PR
+#2774 merged, then cherry-picked only the reviewed stop-teardown commit. This
+drops the already-merged tmux server lifecycle provider commit from the PR
+diff and leaves one feature slice plus this release gate.
+
+| Path | Status | Purpose |
+|---|---:|---|
+| `cmd/gc/cmd_stop.go` | M | Calls optional tmux server teardown after orphan stopping and before bead-provider shutdown. |
+| `cmd/gc/cmd_stop_server_lifecycle_test.go` | A | Covers stop ordering, non-lifecycle provider skip behavior, and best-effort teardown error reporting. |
+| `release-gates/ga-62zmxp-tmux-server-teardown-gate.md` | A | Release gate evidence for deploy bead `ga-62zmxp`. |
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `bd show ga-m64fa4` shows closed review bead with `REVIEW VERDICT: PASS` for PR #2778 and reviewed commit `56bf1df7762238df24d854f3f3c1182b5b408148`. |
+| 2 | Acceptance criteria met | PASS | Final branch preserves the reviewed behavior: `gc stop` calls `runtime.ServerLifecycleProvider.TeardownServer()` after `stopOrphans(...)` and before `shutdownBeadsProviderForStop(...)`; non-lifecycle providers skip teardown; teardown errors are reported on stderr without changing the stop exit code. |
+| 3 | Tests pass | PASS | Focused `cmd/gc` stop tests passed; `go test ./internal/runtime/tmux ./internal/runtime` passed; `go vet ./...` passed; `make test-fast-parallel` passed with `All fast jobs passed`. |
+| 4 | No high-severity review findings open | PASS | Review notes list P0/P1 blockers as none and only advisory/info findings; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` was clean before adding this gate file; final clean status is verified after committing this gate. |
+| 6 | Branch diverges cleanly from main | PASS | `git fetch origin main` refreshed base `1648f2729`; `origin/main` is an ancestor of `HEAD`; `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree `6585fe29fc77323067251948a7f9b2d4b1fff0c5`; `git diff --check origin/main...HEAD` exited 0. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem and one user-facing behavior: `gc stop` tmux server teardown ordering. |
+
+## Acceptance Evidence
+
+| Source criterion | Result | Evidence |
+|---|---|---|
+| Rebase/drop the now-merged PR #2774 runtime lifecycle provider stack. | PASS | Final branch is based on current `origin/main` and contains only the stop-teardown commit plus this gate; diff paths are limited to `cmd/gc/cmd_stop.go`, `cmd/gc/cmd_stop_server_lifecycle_test.go`, and this gate file. |
+| Run teardown after orphan stopping. | PASS | `cmdStopBody` still calls `stopOrphans(...)` first, then `teardownServerForStop(sp, stderr)`. |
+| Run teardown before bead-provider shutdown. | PASS | `teardownServerForStop(...)` is placed before `shutdownBeadsProviderForStop(cityPath)`. `TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown` verifies the observed sequence. |
+| Preserve non-tmux provider compatibility. | PASS | `teardownServerForStop` uses a type assertion to `runtime.ServerLifecycleProvider`; `TestCmdStopBodySkipsTeardownForNonLifecycleProvider` verifies non-lifecycle providers complete without teardown noise. |
+| Keep teardown best-effort and visible. | PASS | `teardownServerForStop` writes `gc stop: teardown server: ...` to stderr on error and does not change `cmdStopBody`'s return code; `TestCmdStopBodyReportsTeardownErrorWithoutFailing` covers this. |
+| Preserve tmux safety. | PASS | This slice does not add a bare tmux cleanup path; teardown delegates through the existing provider lifecycle surface, which uses socket-scoped tmux operations from the merged provider slice. |
+
+## Test Evidence
+
+- PASS: `go test ./cmd/gc -run 'TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown|TestCmdStopBodySkipsTeardownForNonLifecycleProvider|TestCmdStopBodyReportsTeardownErrorWithoutFailing|TestCmdStop'`
+- PASS: `go test ./internal/runtime/tmux ./internal/runtime`
+- PASS: `go vet ./...`
+- PASS: `make test-fast-parallel`
+- PASS: `.githooks/pre-commit` is active via `core.hooksPath=.githooks`; commit hook will run for the staged gate commit.
+
+Gate result: PASS.


### PR DESCRIPTION
## What this changes

`gc stop` now asks session providers with tmux server lifecycle support to tear down their tmux server after the normal session and orphan stop path has run, and before bead storage shutdown begins. Providers that do not implement the lifecycle extension keep the existing behavior.

Teardown is deliberately best-effort: if the tmux server cleanup reports an error, `gc stop` prints it on stderr but does not turn an otherwise successful stop into a failure.

## Review notes

- This is the clean current-main replacement for the older stacked PR #2778; the tmux server lifecycle provider dependency is already on `main`, so this branch contains only the stop-path wiring, focused tests, and gate evidence.
- No config, API, dashboard, OpenAPI, or generated type changes are included.
- The teardown remains provider-scoped and socket-scoped through the existing tmux lifecycle provider; there is no bare default-server cleanup path.

## Test plan

- [x] `go test ./cmd/gc -run 'TestCmdStopBodyTeardownRunsAfterStopOrphansBeforeBeadsShutdown|TestCmdStopBodySkipsTeardownForNonLifecycleProvider|TestCmdStopBodyReportsTeardownErrorWithoutFailing|TestCmdStop'`
- [x] `go test ./internal/runtime/tmux ./internal/runtime`
- [x] `go vet ./...`
- [x] `make test-fast-parallel`
- [x] Release gate: [`release-gates/ga-62zmxp-tmux-server-teardown-gate.md`](release-gates/ga-62zmxp-tmux-server-teardown-gate.md)
