### PR TITLE
fix(maintenance): align orphan sweep liveness evidence

### DIFF
--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1886,6 +1886,56 @@ func TestCmdSessionListJSONNoSessionsReturnsEmptyEnvelope(t *testing.T) {
 	}
 }
 
+func TestRenderSessionListFromAPIJSONUsesSnakeCaseSessionFields(t *testing.T) {
+	var stdout bytes.Buffer
+	code := renderSessionListFromAPI(api.CachedRead[[]SessionView]{
+		AgeSeconds: 1.25,
+		Body: []SessionView{
+			{
+				ID:          "gc-abc",
+				Template:    "worker",
+				State:       "active",
+				Reason:      "assigned",
+				Title:       "Worker session",
+				Alias:       "worker-1",
+				SessionName: "worker-gc-abc",
+				CreatedAt:   "2026-04-23T10:00:00Z",
+				LastActive:  "2026-04-23T12:00:00Z",
+				Attached:    true,
+				Running:     true,
+				LastOutput:  "ready",
+			},
+		},
+	}, true, &stdout)
+	if code != 0 {
+		t.Fatalf("renderSessionListFromAPI(--json) = %d, want 0", code)
+	}
+	out := stdout.String()
+	for _, want := range []string{`"id"`, `"session_name"`, `"created_at"`, `"last_active"`, `"last_output"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("API JSON output missing %s:\n%s", want, out)
+		}
+	}
+	for _, oldName := range []string{`"ID"`, `"SessionName"`, `"CreatedAt"`, `"LastActive"`, `"LastOutput"`} {
+		if strings.Contains(out, oldName) {
+			t.Fatalf("API JSON output contains Go field name %s:\n%s", oldName, out)
+		}
+	}
+
+	var got struct {
+		Sessions []map[string]any `json:"sessions"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v; stdout=%q", err, out)
+	}
+	if len(got.Sessions) != 1 {
+		t.Fatalf("sessions length = %d, want 1; stdout=%s", len(got.Sessions), out)
+	}
+	if got.Sessions[0]["session_name"] != "worker-gc-abc" {
+		t.Fatalf("session_name = %#v, want worker-gc-abc; row=%#v", got.Sessions[0]["session_name"], got.Sessions[0])
+	}
+}
+
 // TestCmdSessionList_RendersLastNudgeColumn pins the table rendering of the
 // "LAST NUDGE" column added by the warm-idle ACP nudge fix: the header is
 // emitted, sessions stamped with metadata.last_nudge_delivered_at render as

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -523,7 +523,7 @@ exit 1
 	}
 }
 
-func TestOrphanSweepPreservesRigScopedLiveEphemeralSessionAssignees(t *testing.T) {
+func TestOrphanSweepPreservesRigScopedLiveEphemeralSessionAssigneesFromCurrentSchema(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
@@ -557,7 +557,8 @@ EOF
       if [ "$rig" = "project" ]; then
         cat <<'EOF'
 {"sessions":[
-  {"id":"mc-live-rig","session_name":"project__worker-gc-rig123","alias":"project/worker-1","agent_name":"project/worker","closed":false}
+  {"id":"mc-live-rig","name":"project/worker-1","template":"project/worker","state":"active","session_name":"project__worker-gc-rig123","alias":"project/worker-1","agent_name":"project/worker","closed":false},
+  {"id":"mc-live-rig-asleep","name":"project/worker-2","template":"project/worker","state":"asleep","session_name":"project__worker-gc-asleep","alias":"project/worker-2","agent_name":"project/worker","closed":false}
 ],"summary":{},"filters":{},"schema_version":"1"}
 EOF
         exit 0
@@ -571,7 +572,9 @@ EOF
       if [ "$4" = "project" ]; then
         cat <<'EOF'
 [
-  {"id":"ga-rig-live","status":"in_progress","assignee":"project__worker-gc-rig123"},
+  {"id":"ga-rig-live-by-session-name","status":"in_progress","assignee":"project__worker-gc-rig123"},
+  {"id":"ga-rig-live-by-id","status":"in_progress","assignee":"mc-live-rig-asleep"},
+  {"id":"ga-rig-closed-default-filtered","status":"in_progress","assignee":"project__worker-gc-closed"},
   {"id":"ga-rig-orphan","status":"in_progress","assignee":"missing-rig-session"}
 ]
 EOF
@@ -602,7 +605,7 @@ exit 1
 	if err != nil {
 		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
 	}
-	if !strings.Contains(string(out), "orphan-sweep: reset 1 orphaned beads") {
+	if !strings.Contains(string(out), "orphan-sweep: reset 2 orphaned beads") {
 		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
 	}
 
@@ -617,12 +620,17 @@ exit 1
 	if !strings.Contains(log, "bd update ga-rig-orphan --status=open --assignee=") {
 		t.Fatalf("rig orphan bead was not reset:\n%s", log)
 	}
-	if strings.Contains(log, "bd update ga-rig-live ") {
-		t.Fatalf("rig live ephemeral session assignee was reset:\n%s", log)
+	if !strings.Contains(log, "bd update ga-rig-closed-default-filtered --status=open --assignee=") {
+		t.Fatalf("closed/default-filtered session assignee was not reset:\n%s", log)
+	}
+	for _, preserved := range []string{"ga-rig-live-by-session-name", "ga-rig-live-by-id"} {
+		if strings.Contains(log, "bd update "+preserved+" ") {
+			t.Fatalf("rig live ephemeral session assignee %s was reset:\n%s", preserved, log)
+		}
 	}
 }
 
-func TestOrphanSweepPreservesPascalCaseLiveSessionIdentities(t *testing.T) {
+func TestOrphanSweepPreservesPascalCaseLiveSessionIdentitiesAsForwardCompat(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
@@ -657,8 +665,6 @@ EOF
         cat <<'EOF'
 {"sessions":[
   {"ID":"vgc-live-id","SessionName":"project__worker-vgc-live-name","Alias":"project/worker-1","Template":"project/worker","State":"active","Closed":false},
-  {"ID":"vgc-stopped","SessionName":"project__worker-vgc-stopped","State":"stopped","Closed":false},
-  {"ID":"vgc-swept","SessionName":"project__worker-vgc-swept","State":"gc_swept","Closed":false},
   {"ID":"vgc-closed","SessionName":"project__worker-vgc-closed","State":"closed","Closed":true}
 ],"summary":{},"filters":{},"schema_version":"1"}
 EOF
@@ -675,8 +681,6 @@ EOF
 [
   {"id":"ga-live-by-id","status":"in_progress","assignee":"vgc-live-id"},
   {"id":"ga-live-by-session-name","status":"in_progress","assignee":"project__worker-vgc-live-name"},
-  {"id":"ga-stopped-session","status":"in_progress","assignee":"vgc-stopped"},
-  {"id":"ga-swept-session","status":"in_progress","assignee":"project__worker-vgc-swept"},
   {"id":"ga-closed-session","status":"in_progress","assignee":"vgc-closed"},
   {"id":"ga-missing-session","status":"in_progress","assignee":"missing-session"}
 ]
@@ -708,7 +712,7 @@ exit 1
 	if err != nil {
 		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
 	}
-	if !strings.Contains(string(out), "orphan-sweep: reset 4 orphaned beads") {
+	if !strings.Contains(string(out), "orphan-sweep: reset 2 orphaned beads") {
 		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
 	}
 
@@ -719,10 +723,10 @@ exit 1
 	log := string(logData)
 	for _, preserved := range []string{"ga-live-by-id", "ga-live-by-session-name"} {
 		if strings.Contains(log, "bd update "+preserved+" ") {
-			t.Fatalf("live PascalCase session assignee %s was reset:\n%s", preserved, log)
+			t.Fatalf("forward-compatible PascalCase session assignee %s was reset:\n%s", preserved, log)
 		}
 	}
-	for _, reset := range []string{"ga-stopped-session", "ga-swept-session", "ga-closed-session", "ga-missing-session"} {
+	for _, reset := range []string{"ga-closed-session", "ga-missing-session"} {
 		if !strings.Contains(log, "bd update "+reset+" --status=open --assignee=") {
 			t.Fatalf("expected %s to be reset:\n%s", reset, log)
 		}

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -113,34 +113,47 @@ if [ -z "$AGENTS" ]; then
     exit 0
 fi
 
-# Step 2b: Parse identities of every live (non-closed) session so that
-# pool-spawned ephemeral assignees (e.g. gastown__polekitten-gc-q9j0om) are
-# treated as known. The Go-side releaseOrphanedPoolAssignments path validates
-# these via liveOpenSessionAssignmentExists, but this shell sweep ran without
-# that guard — an ephemeral assignee whose template-stripped form did not
-# match any agent name was incorrectly reset, racing against active polekitten
-# work and producing the false-orphan loop tracked in ga-nvx.
+# Step 2b: Parse identities of every session row that `gc session list --json`
+# reports as open so that pool-spawned ephemeral assignees (e.g.
+# gastown__polekitten-gc-q9j0om) are treated as known. The Go-side
+# releaseOrphanedPoolAssignments path validates these from session beads via
+# liveOpenSessionAssignmentExists, but this shell sweep only has the CLI JSON
+# contract available. That means it protects the exposed wire identities below;
+# it cannot see bead-only fields such as configured_named_identity or
+# alias_history unless the CLI starts exporting them.
+#
+# The default CLI path already omits closed sessions. The closed/state guards
+# below keep explicit or future session-list producers from making terminal
+# rows live while preserving any non-closed row the CLI reports.
+#
+# This shell sweep ran without a live-session guard before ga-nvx: an ephemeral
+# assignee whose template-stripped form did not match any agent name was
+# incorrectly reset, racing against active polekitten work and producing a
+# false-orphan loop.
 # Two bugs the chronic strip pattern (gastownhall/gascity#2363) revealed:
 # (1) The JSON shape is {"sessions":[...], "summary":..., "filters":..., "schema_version":...},
 #     so `.[]` iterated four top-level scalar keys instead of session objects.
-# (2) Field names vary by runtime/API path. Accept both snake_case
-#     (.closed/.id/.session_name/.alias/.agent_name) and PascalCase
-#     (.Closed/.ID/.SessionName/.Alias/.Template) so a schema casing change
-#     cannot make LIVE_SESSION_IDS empty and strip active pool claims.
+# (2) Field names vary by runtime/API path. The current CLI emits snake_case
+#     (.closed/.id/.session_name/.alias/.agent_name); PascalCase is accepted
+#     only as forward-compatible hardening so a casing change cannot make
+#     LIVE_SESSION_IDS empty and strip active pool claims.
 LIVE_SESSION_IDS=$(jq -r -s '
+    def pick($snake; $pascal; $default):
+      if has($snake) and .[$snake] != null then .[$snake]
+      elif has($pascal) and .[$pascal] != null then .[$pascal]
+      else $default end;
     .[] | .sessions[]?
     | select(
-        ((.closed // .Closed // false) == false)
-        and (((.state // .State // "") | ascii_downcase) != "closed")
-        and (((.state // .State // "") | ascii_downcase) != "stopped")
-        and (((.state // .State // "") | ascii_downcase) != "gc_swept")
+        (pick("closed"; "Closed"; false) == false)
+        and ((pick("state"; "State"; "") | ascii_downcase) != "closed")
       )
     | [
-        (.id // .ID),
-        (.session_name // .SessionName),
-        (.alias // .Alias),
-        (.agent_name // .AgentName // .template // .Template),
-        (.name // .Name)
+        pick("id"; "ID"; null),
+        pick("session_name"; "SessionName"; null),
+        pick("alias"; "Alias"; null),
+        pick("agent_name"; "AgentName"; null),
+        pick("template"; "Template"; null),
+        pick("name"; "Name"; null)
       ]
     | .[]
     | select(. != null and . != "")

--- a/internal/api/decode_sessions.go
+++ b/internal/api/decode_sessions.go
@@ -7,18 +7,18 @@ import "github.com/gastownhall/gascity/internal/api/genclient"
 // sessionResponse fields that the CLI formatter reads so cmd/gc/ never
 // imports genclient directly.
 type SessionView struct {
-	ID          string
-	Template    string
-	State       string
-	Reason      string
-	Title       string
-	Alias       string
-	SessionName string
-	CreatedAt   string
-	LastActive  string
-	Attached    bool
-	Running     bool
-	LastOutput  string
+	ID          string `json:"id"`
+	Template    string `json:"template"`
+	State       string `json:"state"`
+	Reason      string `json:"reason"`
+	Title       string `json:"title"`
+	Alias       string `json:"alias"`
+	SessionName string `json:"session_name"`
+	CreatedAt   string `json:"created_at"`
+	LastActive  string `json:"last_active"`
+	Attached    bool   `json:"attached"`
+	Running     bool   `json:"running"`
+	LastOutput  string `json:"last_output"`
 }
 
 // sessionViewFromGen translates one genclient.SessionResponse into a


### PR DESCRIPTION
Post-merge follow-up for #2712.

This applies the required review remediation from the post-merge review:

- documents that the shell orphan sweep uses the `gc session list --json` wire contract rather than full Go-side session bead parity
- treats only closed rows as terminal, preserving every non-closed session row returned by the CLI
- uses current snake_case session-list fields as the primary contract, with PascalCase as forward-compatible hardening only
- updates orphan-sweep tests to cover current snake_case rows, default closed-session exclusion, non-closed asleep rows, and PascalCase fallback behavior
- pins API-backed `gc session list --json` rows to snake_case JSON tags so the API and fallback CLI paths agree on casing
- adds a regression test proving API-backed session-list JSON emits `session_name`, `created_at`, `last_active`, and `last_output` instead of Go field names

Verification:

- `go test ./cmd/gc ./internal/api ./examples/gastown -run 'Test(RenderSessionListFromAPIJSONUsesSnakeCaseSessionFields|SessionsFromGenList|OrphanSweep)' -count=1` passed
- `make dashboard-check` passed
- `go vet ./...` passed
- `make test-fast-parallel` passed on the rebased branch
- `.githooks/pre-commit` ran during commit and passed
- `git diff --check origin/main..HEAD` passed