### PR TITLE
Preserve bead updated_at through store round trips

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -453,6 +453,7 @@ type bdIssue struct {
 	IssueType    string       `json:"issue_type"`
 	Priority     *int         `json:"priority,omitempty"`
 	CreatedAt    time.Time    `json:"created_at"`
+	UpdatedAt    time.Time    `json:"updated_at"`
 	Assignee     string       `json:"assignee"`
 	From         string       `json:"from"`
 	ParentID     string       `json:"parent"`
@@ -580,6 +581,7 @@ func (b *bdIssue) toBead() Bead {
 		Type:         b.IssueType,
 		Priority:     cloneIntPtr(b.Priority),
 		CreatedAt:    b.CreatedAt.Truncate(time.Second),
+		UpdatedAt:    b.UpdatedAt.Truncate(time.Second),
 		Assignee:     b.Assignee,
 		From:         from,
 		ParentID:     parentID,

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2347,6 +2347,40 @@ func TestBdStoreListInfersParentFromParentChildDependency(t *testing.T) {
 	}
 }
 
+func TestBdStoreListMapsUpdatedAt(t *testing.T) {
+	created := time.Date(2026, 5, 30, 6, 52, 8, 0, time.UTC)
+	updated := time.Date(2026, 5, 30, 23, 52, 11, 0, time.UTC)
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --all --include-infra --include-gates --limit 0`: {
+			out: []byte(`[
+				{
+					"id":"ga-updated",
+					"title":"updated bead",
+					"status":"closed",
+					"issue_type":"task",
+					"created_at":"` + created.Format(time.RFC3339) + `",
+					"updated_at":"` + updated.Format(time.RFC3339) + `"
+				}
+			]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+
+	got, err := s.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("List returned %d beads, want 1", len(got))
+	}
+	if !got[0].UpdatedAt.Equal(updated) {
+		t.Fatalf("UpdatedAt = %s, want %s", got[0].UpdatedAt, updated)
+	}
+}
+
 func TestBdStoreCreateNoLabelsNoParent(t *testing.T) {
 	var gotArgs []string
 	runner := func(_, _ string, args ...string) ([]byte, error) {

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -165,6 +165,7 @@ func (w *beadWire) toBead() beads.Bead {
 		Type:        w.Type,
 		Priority:    priority,
 		CreatedAt:   w.CreatedAt,
+		UpdatedAt:   w.UpdatedAt,
 		Assignee:    w.Assignee,
 		From:        w.From,
 		ParentID:    w.ParentID,

--- a/internal/beads/exec/exec_test.go
+++ b/internal/beads/exec/exec_test.go
@@ -1003,6 +1003,29 @@ esac
 	}
 }
 
+func TestGet_updatedAtRoundTripsFromJSON(t *testing.T) {
+	dir := t.TempDir()
+
+	script := writeScript(t, dir, `
+case "$1" in
+  get)
+    echo '{"id":"EX-1","title":"test","status":"open","type":"task","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T03:04:05Z"}'
+    ;;
+  *) exit 2 ;;
+esac
+`)
+	s := NewStore(script)
+
+	got, err := s.Get("EX-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	if !got.UpdatedAt.Equal(want) {
+		t.Fatalf("UpdatedAt = %s, want %s", got.UpdatedAt, want)
+	}
+}
+
 func TestList_numericMetadataValuesCoercedToStrings(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/beads/exec/json.go
+++ b/internal/beads/exec/json.go
@@ -57,6 +57,7 @@ type beadWire struct {
 	Type        string                     `json:"type"`
 	Priority    *int                       `json:"priority,omitempty"`
 	CreatedAt   time.Time                  `json:"created_at"`
+	UpdatedAt   time.Time                  `json:"updated_at"`
 	Assignee    string                     `json:"assignee"`
 	From        string                     `json:"from"`
 	ParentID    string                     `json:"parent_id"`

--- a/release-gates/ga-t40ugi-updated-at-roundtrip-gate.md
+++ b/release-gates/ga-t40ugi-updated-at-roundtrip-gate.md
@@ -1,0 +1,52 @@
+# Release Gate: updated_at round-trip
+
+Date: 2026-06-01
+Deployer: gascity/deployer
+Primary deploy bead: ga-t40ugi.3
+Reviewer deploy notice: ga-vhbycp
+Source review bead: ga-2g6fhh
+Feature branch: builder/ga-t40ugi-1-clean-updated-at-roundtrip
+Base: origin/main @ 8ee549d40596362d8bee152f6cf9a75afd8b046f
+Gate input HEAD: 7c2fcfaa6d8d5e4b2f093d9fbc073f2f296a5167
+
+## Scope
+
+This branch preserves bead `updated_at` timestamps when bead data moves through
+the bd-backed store and the exec-backed store. The change mirrors the existing
+`created_at` decoding paths and adds regressions for both stores.
+
+Changed files relative to `origin/main`:
+
+```text
+internal/beads/bdstore.go
+internal/beads/bdstore_test.go
+internal/beads/exec/exec.go
+internal/beads/exec/exec_test.go
+internal/beads/exec/json.go
+```
+
+Commits:
+
+```text
+6afb2b0f1 fix(beads): round-trip exec updated_at
+7c2fcfaa6 fix(beads): preserve bd updated_at
+```
+
+## Gate Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-2g6fhh is closed with `REVIEW VERDICT: PASS`. Reviewer deploy notice ga-vhbycp also records reviewed and passed status for commit 7c2fcfaa6. |
+| 2 | Acceptance criteria met | PASS | Clean branch uses `builder/ga-t40ugi-1-clean-updated-at-roundtrip`, not the rejected broad branch. Diff scope is limited to the five expected `internal/beads` files. `bdstore.go` maps `updated_at` into `Bead.UpdatedAt`; `exec/json.go` and `exec.go` map the exec-store `updated_at` wire field into `Bead.UpdatedAt`; tests cover both round trips. |
+| 3 | Tests pass | PASS | `go test ./internal/beads ./internal/beads/exec -run 'TestBdStoreListMapsUpdatedAt|TestGet_updatedAtRoundTripsFromJSON' -count=1` passed. `make test-fast-parallel` passed: all fast jobs passed. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | ga-2g6fhh records no blocking findings and no security concerns. No HIGH findings are present in the review notes. |
+| 5 | Final branch is clean | PASS | Clean detached release worktree had no uncommitted changes before gate-file creation. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 with tree `0d413bc98aad4b099673216af8ab78b02690485b`. `git diff --check origin/main...HEAD` passed. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem, `internal/beads`, and one behavior: preserving `updated_at` through bead store deserialization. |
+
+## Additional Notes
+
+- `docs/PROJECT_MANIFEST.md` is not present in this worktree or on `origin/main`; this gate uses the release criteria in the deployer role instructions.
+- `gh auth status` is green for account `quad341`.
+- `git push --dry-run origin HEAD:refs/heads/builder/ga-t40ugi-1-clean-updated-at-roundtrip` succeeded, so `origin` is the push remote.
+- No open PR existed for `builder/ga-t40ugi-1-clean-updated-at-roundtrip` before this deploy gate.


### PR DESCRIPTION
## What this changes

Bead data loaded through the bd-backed store now preserves the bead's `updated_at` timestamp instead of leaving `Bead.UpdatedAt` empty. The exec-backed store also accepts `updated_at` in its JSON wire shape and maps it into the same domain field.

This makes freshness-sensitive callers see the actual last update time regardless of whether bead data came from the bd CLI path or an exec store script. The implementation follows the existing `created_at` mapping pattern in each store; bd timestamps are truncated to second precision to match the existing bd-store timestamp behavior.

## Review notes

- The change is limited to `internal/beads` store deserialization and matching tests.
- There are no new config fields, endpoints, CLI flags, migrations, or generated artifacts.
- The omitted coordstore-specific regression from the earlier broad branch is intentionally not included because current `main` does not have the coordstore import helpers that test depended on; the current branch covers the equivalent store-level behavior directly.

## Test plan

- [x] `go test ./internal/beads ./internal/beads/exec -run 'TestBdStoreListMapsUpdatedAt|TestGet_updatedAtRoundTripsFromJSON' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] `git merge-tree --write-tree origin/main HEAD`
- [x] Release gate: [`release-gates/ga-t40ugi-updated-at-roundtrip-gate.md`](release-gates/ga-t40ugi-updated-at-roundtrip-gate.md)
