### PR TITLE
fix(beads): initialize bd rigs under sqlite cities

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -833,7 +833,40 @@ func initBeadsForDir(cityPath, dir, prefix, doltDatabase string) error {
 		}
 		return runProviderOpWithEnv(script, providerEnv, args...)
 	}
+	if shouldInitDefaultRigBdStore(cityPath, dir, provider) {
+		return initDefaultRigBdStore(cityPath, dir, prefix, doltDatabase)
+	}
 	return nil
+}
+
+func shouldInitDefaultRigBdStore(cityPath, dir, provider string) bool {
+	if strings.TrimSpace(cityPath) == "" || strings.TrimSpace(dir) == "" {
+		return false
+	}
+	if samePath(resolveStoreScopeRoot(cityPath, dir), resolveStoreScopeRoot(cityPath, cityPath)) {
+		return false
+	}
+	provider = strings.TrimSpace(provider)
+	return provider != "" && provider != "file" && !strings.HasPrefix(provider, "exec:") && !providerUsesBdStoreContract(provider)
+}
+
+func initDefaultRigBdStore(cityPath, dir, prefix, doltDatabase string) error {
+	canonicalDoltDatabase := strings.TrimSpace(doltDatabase)
+	if canonicalDoltDatabase == "" {
+		canonicalDoltDatabase = canonicalScopeDoltDatabase(cityPath, dir, prefix)
+	}
+	env := map[string]string{
+		"BEADS_DIR": filepath.Join(dir, ".beads"),
+	}
+	applyExportSuppressionEnv(env)
+	args := []string{"init", "--server", "-p", prefix, "--skip-hooks"}
+	if canonicalDoltDatabase != "" {
+		args = append(args, "--database", canonicalDoltDatabase)
+	}
+	if _, err := beads.ExecCommandRunnerWithEnv(env)(dir, "bd", args...); err != nil {
+		return fmt.Errorf("bd init: %w", err)
+	}
+	return finalizeCanonicalBdScopeInit(cityPath, dir, prefix, canonicalDoltDatabase)
 }
 
 func finalizeCanonicalBdScopeInit(cityPath, dir, prefix, doltDatabase string) error {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -2733,6 +2733,106 @@ func TestInitBeadsForDir_fileLegacyRigPreservesSharedCityStore(t *testing.T) {
 	}
 }
 
+func TestInitBeadsForDirSqliteCityInitializesRigBdStore(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "tincan")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "sqlite-city"
+prefix = "ga"
+
+[beads]
+provider = "sqlite"
+
+[[rigs]]
+name = "tincan"
+path = "tincan"
+prefix = "tc"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logFile := filepath.Join(t.TempDir(), "bd.log")
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+printf 'pwd=%%s BEADS_DIR=%%s args=%%s\n' "$PWD" "${BEADS_DIR:-}" "$*" >> %q
+case "$1" in
+  init)
+    mkdir -p "${BEADS_DIR:-$PWD/.beads}"
+    exit 0
+    ;;
+  list)
+    printf '[]\n'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, logFile)
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := initBeadsForDir(cityDir, rigDir, "tc", "tc"); err != nil {
+		t.Fatalf("initBeadsForDir: %v", err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	log := string(logData)
+	for _, want := range []string{
+		"pwd=" + rigDir,
+		"BEADS_DIR=" + filepath.Join(rigDir, ".beads"),
+		"init --server -p tc --skip-hooks --database tc",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("bd log missing %q:\n%s", want, log)
+		}
+	}
+	if got := rawBeadsProviderForScope(rigDir, cityDir); got != "bd" {
+		t.Fatalf("rawBeadsProviderForScope(rig) = %q, want bd", got)
+	}
+	if got := rawBeadsProviderForScope(cityDir, cityDir); got != "sqlite" {
+		t.Fatalf("rawBeadsProviderForScope(city) = %q, want sqlite", got)
+	}
+
+	configState, ok, err := contract.ReadConfigState(fsys.OSFS{}, filepath.Join(rigDir, ".beads", "config.yaml"))
+	if err != nil {
+		t.Fatalf("ReadConfigState: %v", err)
+	}
+	if !ok {
+		t.Fatal("ReadConfigState() = !ok, want canonical rig config")
+	}
+	if configState.IssuePrefix != "tc" {
+		t.Fatalf("IssuePrefix = %q, want tc", configState.IssuePrefix)
+	}
+	metaData, err := os.ReadFile(filepath.Join(rigDir, ".beads", "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(metadata): %v", err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		t.Fatalf("Unmarshal(metadata): %v", err)
+	}
+	for key, want := range map[string]string{
+		"database":      "dolt",
+		"backend":       "dolt",
+		"dolt_mode":     "server",
+		"dolt_database": "tc",
+	} {
+		if got := strings.TrimSpace(fmt.Sprint(meta[key])); got != want {
+			t.Fatalf("metadata %s = %q, want %q", key, got, want)
+		}
+	}
+}
+
 func writeMinimalCityToml(t *testing.T, cityDir string) {
 	t.Helper()
 	content := `[workspace]

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -107,6 +107,94 @@ func TestDoRigAdd_Basic(t *testing.T) {
 	}
 }
 
+func TestDoRigAddSqliteCityCreatesBdBackedRig(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(t.TempDir(), "tincan")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "sqlite-city"
+prefix = "ga"
+
+[beads]
+provider = "sqlite"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logFile := filepath.Join(t.TempDir(), "bd.log")
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+printf 'pwd=%%s BEADS_DIR=%%s args=%%s\n' "$PWD" "${BEADS_DIR:-}" "$*" >> %q
+case "$1" in
+  init)
+    mkdir -p "${BEADS_DIR:-$PWD/.beads}"
+    exit 0
+    ;;
+  list)
+    printf '[]\n'
+    exit 0
+    ;;
+  update)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, logFile)
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "tc", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd = %d, want 0; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+	if got := rawBeadsProviderForScope(rigPath, cityPath); got != "bd" {
+		t.Fatalf("rawBeadsProviderForScope(rig) = %q, want bd", got)
+	}
+	if got := rawBeadsProviderForScope(cityPath, cityPath); got != "sqlite" {
+		t.Fatalf("rawBeadsProviderForScope(city) = %q, want sqlite", got)
+	}
+	metaData, err := os.ReadFile(filepath.Join(rigPath, ".beads", "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(metadata): %v", err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		t.Fatalf("Unmarshal(metadata): %v", err)
+	}
+	if got := strings.TrimSpace(fmt.Sprint(meta["dolt_mode"])); got != "server" {
+		t.Fatalf("metadata dolt_mode = %q, want server", got)
+	}
+
+	store, err := openStoreAtForCity(rigPath, cityPath)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	if err := store.SetMetadata("tc-1", "gc.routed_to", "sample/session-a"); err != nil {
+		t.Fatalf("SetMetadata through rig store: %v", err)
+	}
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	log := string(logData)
+	for _, want := range []string{
+		"init --server -p tc --skip-hooks --database tc",
+		"update --json tc-1 --set-metadata gc.routed_to=sample/session-a",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("bd log missing %q:\n%s", want, log)
+		}
+	}
+}
+
 func runGitInTest(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)

--- a/release-gates/ga-4i7lkz-sqlite-bd-rig-gate.md
+++ b/release-gates/ga-4i7lkz-sqlite-bd-rig-gate.md
@@ -1,0 +1,47 @@
+# Release Gate: initialize bd rigs under sqlite cities
+
+Deploy bead: `ga-4i7lkz`
+Source bead: `ga-c26emx`
+Review bead: `ga-q2ox7o`
+Source branch: `builder/ga-c26emx-sqlite-bd-rig`
+Release branch: `release/ga-4i7lkz-sqlite-bd-rig`
+Reviewed commit: `df2d4024af3dd2069d6d8e70c92f09a43993175a`
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate
+uses the deployer release criteria plus the source bead acceptance criteria.
+
+## Gate Summary
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `ga-q2ox7o` is closed with close reason `pass`; reviewer notes include `REVIEW VERDICT: PASS`. |
+| 2 | Acceptance criteria met | PASS | The change initializes fresh rig scopes under sqlite-backed cities with a bd-backed server-mode store and pins `BEADS_DIR` for the rig. Regression coverage exercises both the low-level initialization path and `gc rig add` followed by routing metadata persistence. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestInitBeadsForDirSqliteCityInitializesRigBdStore|TestDoRigAddSqliteCityCreatesBdBackedRig' -count=1` passed; `make test` passed with `observable go test: PASS`; `go vet ./...` produced no findings; `git diff --check origin/main...HEAD` was clean. |
+| 4 | No high-severity review findings open | PASS | Review notes list one INFO finding only; no HIGH findings are open. |
+| 5 | Final branch is clean | PASS | Gate evidence is committed as the branch tip; `git status --short --branch` is clean after the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` succeeded with tree `0bd0c3cd57a16c0d8ff0c8e30c4c6252007e8171`; no merge conflicts were reported. The branch is 2 behind and 1 ahead of `origin/main`, but merge-clean. |
+| 7 | Single feature theme | PASS | Commit set is one reviewed commit touching one subsystem: `cmd/gc` rig/beads initialization and adjacent tests. |
+
+## Acceptance Criteria
+
+| Acceptance criterion | Verdict | Evidence |
+|---------------------|---------|----------|
+| `gc rig add` on a `provider=sqlite` city creates a working bd-tracked rig or documents the required override. | PASS | `cmd/gc/cmd_rig_test.go` adds `TestDoRigAddSqliteCityCreatesBdBackedRig`, covering rig creation under sqlite city config and subsequent bd-backed rig behavior. |
+| The rig dolt is server-mode or `gc` ships `native_embedded`; not the current broken hybrid. | PASS | `cmd/gc/beads_provider_lifecycle.go` now routes non-bd inherited rig scopes to bd-backed rig initialization, avoiding the sqlite-provider hybrid. |
+| `gc sling` persists routing metadata on such a rig without a bd-CLI workaround. | PASS | `TestDoRigAddSqliteCityCreatesBdBackedRig` covers metadata persistence through the rig's bd-backed store after creation. |
+
+## Changed Surface
+
+- `cmd/gc/beads_provider_lifecycle.go`
+- `cmd/gc/beads_provider_lifecycle_test.go`
+- `cmd/gc/cmd_rig_test.go`
+
+## Commands Run
+
+```text
+go test ./cmd/gc -run 'TestInitBeadsForDirSqliteCityInitializesRigBdStore|TestDoRigAddSqliteCityCreatesBdBackedRig' -count=1
+make test
+go vet ./...
+git diff --check origin/main...HEAD
+git merge-tree --write-tree HEAD origin/main
+```


### PR DESCRIPTION
## What this changes

`gc rig add` now gives rigs created under a sqlite-coordination city their own bd-backed issue tracker instead of letting the city-level sqlite provider leak into the rig scope. Fresh rig scopes that would otherwise inherit a non-bd provider are initialized with a server-mode bd store, and the rig's `.beads` path is pinned so later `gc bd` and `gc sling` calls operate on the rig tracker.

This removes the manual `bd init` plus bd-CLI routing workaround needed to run normal factory rigs inside sqlite-backed cities.

## Review notes

- The change is limited to `cmd/gc` rig/beads initialization and regression coverage.
- Existing bd-backed and file-backed city/rig initialization paths are preserved by the new guard.
- No schema, dashboard, API, or migration changes are included.
- Internal tracking: `ga-4i7lkz`.

## Test plan

- [x] `go test ./cmd/gc -run 'TestInitBeadsForDirSqliteCityInitializesRigBdStore|TestDoRigAddSqliteCityCreatesBdBackedRig' -count=1`
- [x] `make test`
- [x] `go vet ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] Release gate: [`release-gates/ga-4i7lkz-sqlite-bd-rig-gate.md`](release-gates/ga-4i7lkz-sqlite-bd-rig-gate.md)