### PR TITLE
feat(hook): deliver cross-store work to city-scoped agents

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
@@ -14,12 +15,27 @@ func assignedWorkStoreRefForAgent(cityPath string, cfg *config.City, agentCfg *c
 	return configuredRigName(cityPath, agentCfg, cfg.Rigs)
 }
 
+// agentIsCrossStoreEligible reports whether an agent may discover and serve work
+// in ANY store, not just its configured rig. City-scoped agents are cross-store
+// eligible: a city-wide singleton legitimately serves per-rig routed work
+// (vp-kvp — "scope determines discovery breadth"). Rig-scoped agents stay
+// single-store, so their reachability and all existing behavior are unchanged.
+func agentIsCrossStoreEligible(agentCfg *config.Agent) bool {
+	return agentutil.AgentIsCrossStoreEligible(agentCfg)
+}
+
 func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agentCfg *config.Agent, storeRefs []string, index int) bool {
 	if len(storeRefs) == 0 {
 		return true
 	}
 	if index < 0 || index >= len(storeRefs) {
 		return false
+	}
+	// City-scoped agents federate across all stores (vp-kvp): a city-wide
+	// singleton's work may live in any rig store, so gating it to its own
+	// configured rig is the cross-store dead-drop this fixes.
+	if agentIsCrossStoreEligible(agentCfg) {
+		return true
 	}
 	return storeRefs[index] == assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
 }
@@ -97,6 +113,9 @@ func filterAssignedWorkBeadsForSessionWake(
 		return assignedWorkBeads
 	}
 	reachableRefsByAssignee := make(map[string]map[string]struct{})
+	// crossStore identities belong to city-scoped (cross-store-eligible) agents
+	// and are reachable from ANY store (vp-kvp). They bypass the per-ref match.
+	crossStore := make(map[string]struct{})
 	add := func(identifier, storeRef string) {
 		identifier = strings.TrimSpace(identifier)
 		if identifier == "" {
@@ -116,6 +135,10 @@ func filterAssignedWorkBeadsForSessionWake(
 		if !ok {
 			continue
 		}
+		if agentIsCrossStoreEligible(spec.Agent) {
+			crossStore[strings.TrimSpace(identity)] = struct{}{}
+			continue
+		}
 		add(identity, assignedWorkStoreRefForAgent(cityPath, cfg, spec.Agent))
 	}
 	for _, sb := range sessionBeads {
@@ -128,6 +151,13 @@ func filterAssignedWorkBeadsForSessionWake(
 		}
 		agentCfg := findAgentByTemplate(cfg, template)
 		if agentCfg == nil {
+			continue
+		}
+		if agentIsCrossStoreEligible(agentCfg) {
+			for _, id := range sessionBeadAssigneeIdentities(sb) {
+				crossStore[strings.TrimSpace(id)] = struct{}{}
+			}
+			crossStore[strings.TrimSpace(template)] = struct{}{}
 			continue
 		}
 		storeRef := assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
@@ -144,6 +174,11 @@ func filterAssignedWorkBeadsForSessionWake(
 		}
 		assignee := strings.TrimSpace(wb.Assignee)
 		if assignee == "" {
+			continue
+		}
+		if _, ok := crossStore[assignee]; ok {
+			// City-scoped assignee: reachable from any store (vp-kvp).
+			filtered = append(filtered, wb)
 			continue
 		}
 		if refs := reachableRefsByAssignee[assignee]; refs != nil {

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -52,6 +52,39 @@ func TestFilterAssignedWorkBeadsForSessionWakeKeepsOnlyReachableAssigneeSources(
 	}
 }
 
+func TestFilterAssignedWorkBeadsForSessionWakeCityScopedAgentIsCrossStoreEligible(t *testing.T) {
+	// vp-kvp: a city-scoped singleton legitimately serves per-rig routed work.
+	// Its assigned work may live in ANY store, so reachability must federate
+	// across stores — gating it to its own configured rig is the cross-store
+	// dead-drop this fixes. Rig-scoped agents stay single-store (unchanged).
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:  "auditor",
+			Scope: "city",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "auditor",
+			Scope:    "city",
+			Mode:     "on_demand",
+		}},
+	}
+	identity := cfg.NamedSessions[0].QualifiedName()
+	work := []beads.Bead{
+		{ID: "city-work", Status: "open", Assignee: identity},
+		{ID: "rig-work", Status: "open", Assignee: identity},
+	}
+	storeRefs := []string{"", "riga"} // city store + rig store
+
+	got := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, nil, work, storeRefs)
+
+	if len(got) != 2 {
+		t.Fatalf("city-scoped %q must be reachable from BOTH stores; got %d: %#v", identity, len(got), got)
+	}
+}
+
 func TestFilterAssignedWorkBeadsForPoolDemandKeepsDirectAssigneeAfterTemplateFallback(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{{

--- a/cmd/gc/claim_cross_store.go
+++ b/cmd/gc/claim_cross_store.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/sling"
+)
+
+// crossStoreClaimDir resolves the working directory a cross-store-eligible
+// agent's bd write (claim / update) must run in so it targets the bead's OWN
+// store rather than the agent's default store. This is the WRITE counterpart to
+// the gc-hook read federation (vp-kvp stage iii): a city-scoped singleton sees
+// rig-store work via the federated work query, so its claim must land in that
+// rig store.
+//
+// Returns ("", false) when no redirection applies — a rig-scoped agent
+// (byte-for-byte unchanged), or a bead whose prefix does not resolve to a
+// configured rig (HQ/city-owned work stays in the agent's own store). The pure
+// signature keeps the per-bead routing decision unit-testable; the impure
+// store-env edge lives in agentScriptCrossStoreBeadEnv.
+func crossStoreClaimDir(cfg *config.City, agentCfg *config.Agent, beadID string) (string, bool) {
+	if cfg == nil || !agentIsCrossStoreEligible(agentCfg) {
+		return "", false
+	}
+	rigDir := sling.RigDirForBead(cfg, strings.TrimSpace(beadID))
+	if rigDir == "" {
+		return "", false
+	}
+	return rigDir, true
+}
+
+// agentScriptCrossStoreBeadEnv is the impure edge wired into the agent-script
+// bd_claim / bd_update path: it resolves the current agent identity and city
+// config from the environment and, for a cross-store-eligible runner, returns
+// the rig store directory + bd subprocess env a write against beadID must use.
+// Best-effort — any resolution failure returns ok=false so the write falls back
+// to the default (inherited) environment, preserving rig-agent behavior.
+func agentScriptCrossStoreBeadEnv(beadID string) (string, []string, bool) {
+	beadID = strings.TrimSpace(beadID)
+	if beadID == "" {
+		return "", nil, false
+	}
+	cityPath, err := resolveCity()
+	if err != nil {
+		return "", nil, false
+	}
+	cfg, err := loadCityConfig(cityPath, io.Discard)
+	if err != nil {
+		return "", nil, false
+	}
+	// Normalize relative rig paths to absolute so RigDirForBead returns a usable
+	// command dir, matching cmd_hook's resolveRigPaths call after loadCityConfig.
+	resolveRigPaths(cityPath, cfg.Rigs)
+
+	agentName := strings.TrimSpace(os.Getenv("GC_ALIAS"))
+	if agentName == "" {
+		agentName = strings.TrimSpace(os.Getenv("GC_AGENT"))
+	}
+	if agentName == "" {
+		return "", nil, false
+	}
+	a, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
+	if !ok {
+		return "", nil, false
+	}
+	rigDir, ok := crossStoreClaimDir(cfg, &a, beadID)
+	if !ok {
+		return "", nil, false
+	}
+	overrides, err := bdRuntimeEnvForRigWithError(cityPath, cfg, rigDir)
+	if err != nil {
+		return "", nil, false
+	}
+	return rigDir, mergeRuntimeEnv(os.Environ(), overrides), true
+}

--- a/cmd/gc/claim_cross_store_test.go
+++ b/cmd/gc/claim_cross_store_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestCrossStoreClaimDirRedirectsCityAgentToBeadOwningRig(t *testing.T) {
+	// vp-kvp stage iii (write half): a city-scoped singleton discovers rig-store
+	// work through the federated gc-hook read, so its bd update --claim must land
+	// in that rig store rather than its own (city) store.
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "voxist-web")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "voxist-web", Path: rigPath, Prefix: "vw"}},
+	}
+	cityAgent := &config.Agent{Name: "platform-architect", Scope: "city"}
+
+	dir, ok := crossStoreClaimDir(cfg, cityAgent, "vw-123")
+	if !ok {
+		t.Fatal("city-scoped agent claiming a rig-store bead must redirect to the rig store")
+	}
+	if dir != rigPath {
+		t.Fatalf("redirect dir = %q, want %q", dir, rigPath)
+	}
+}
+
+func TestCrossStoreClaimDirLeavesRigAgentUnchanged(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "voxist-web")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "voxist-web", Path: rigPath, Prefix: "vw"}},
+	}
+	rigAgent := &config.Agent{Name: "reviewer", Dir: "voxist-web"}
+
+	if _, ok := crossStoreClaimDir(cfg, rigAgent, "vw-123"); ok {
+		t.Fatal("rig-scoped agent must be byte-for-byte unchanged (no claim redirect)")
+	}
+}
+
+func TestCrossStoreClaimDirNoRedirectForCityOwnedBead(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "voxist-web")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "voxist-web", Path: rigPath, Prefix: "vw"}},
+	}
+	cityAgent := &config.Agent{Name: "platform-architect", Scope: "city"}
+
+	// A bead whose prefix does not resolve to a configured rig (HQ/city-owned)
+	// stays in the agent's own store: no redirect.
+	if _, ok := crossStoreClaimDir(cfg, cityAgent, "hq-9"); ok {
+		t.Fatal("city-owned bead must not redirect")
+	}
+}
+
+func TestRunBDForBeadRedirectsCrossStoreWrite(t *testing.T) {
+	var inStoreDir string
+	var inStoreArgs []string
+	var fellBack bool
+	exec := agentScriptExecutor{
+		runCommand: func(_ string, _ ...string) error {
+			fellBack = true
+			return nil
+		},
+		runCommandInStore: func(dir string, _ []string, name string, args ...string) error {
+			inStoreDir = dir
+			inStoreArgs = append([]string{name}, args...)
+			return nil
+		},
+		resolveBeadStore: func(beadID string) (string, []string, bool) {
+			if beadID == "vw-1" {
+				return "/rigs/voxist-web", []string{"BEADS_DIR=/rigs/voxist-web/.beads"}, true
+			}
+			return "", nil, false
+		},
+	}
+
+	if err := exec.runBDForBead("vw-1", "update", "vw-1", "--claim"); err != nil {
+		t.Fatalf("runBDForBead cross-store: %v", err)
+	}
+	if fellBack {
+		t.Fatal("cross-store bead must route through runCommandInStore, not the default runCommand")
+	}
+	if inStoreDir != "/rigs/voxist-web" {
+		t.Fatalf("in-store dir = %q, want /rigs/voxist-web", inStoreDir)
+	}
+	if len(inStoreArgs) == 0 || inStoreArgs[0] != "bd" {
+		t.Fatalf("in-store args = %v, want bd ...", inStoreArgs)
+	}
+
+	// A bead the resolver does not redirect falls back to the default runner.
+	fellBack = false
+	if err := exec.runBDForBead("hq-9", "update", "hq-9", "--claim"); err != nil {
+		t.Fatalf("runBDForBead fallback: %v", err)
+	}
+	if !fellBack {
+		t.Fatal("non-redirected bead must fall back to the default runCommand")
+	}
+}
+
+func TestCrossStoreClaimDirNilCfgOrAgent(t *testing.T) {
+	rigAgent := &config.Agent{Name: "reviewer", Dir: "voxist-web"}
+	if _, ok := crossStoreClaimDir(nil, rigAgent, "vw-1"); ok {
+		t.Fatal("nil cfg must not redirect")
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "voxist-web", Path: "/x", Prefix: "vw"}}}
+	if _, ok := crossStoreClaimDir(cfg, nil, "vw-1"); ok {
+		t.Fatal("nil agent must not redirect")
+	}
+}

--- a/cmd/gc/cmd_agent_script.go
+++ b/cmd/gc/cmd_agent_script.go
@@ -103,6 +103,27 @@ type agentScriptExecutor struct {
 	stderr     io.Writer
 	runCommand func(name string, args ...string) error
 	runShell   func(command string, env []string) error
+	// runCommandInStore runs a command in a specific working dir + env so a
+	// cross-store-eligible runner's bd write lands in the bead's own store
+	// (vp-kvp stage iii write half). Nil in tests/legacy paths → falls back to
+	// runCommand, leaving rig-agent behavior byte-for-byte unchanged.
+	runCommandInStore func(dir string, env []string, name string, args ...string) error
+	// resolveBeadStore returns the dir + env a bd write against beadID must use
+	// (ok=true) when the current runner must claim/update across stores; ok=false
+	// runs the write in the default (inherited) environment.
+	resolveBeadStore func(beadID string) (dir string, env []string, ok bool)
+}
+
+// runBDForBead runs a bd subprocess against beadID, redirecting it to the bead's
+// owning store when the runner is cross-store-eligible (vp-kvp stage iii write
+// half). Falls back to the default environment otherwise.
+func (e agentScriptExecutor) runBDForBead(beadID string, args ...string) error {
+	if e.resolveBeadStore != nil && e.runCommandInStore != nil {
+		if dir, env, ok := e.resolveBeadStore(strings.TrimSpace(beadID)); ok {
+			return e.runCommandInStore(dir, env, "bd", args...)
+		}
+	}
+	return e.runCommand("bd", args...)
 }
 
 func runAgentScript(scriptPath string, stdout, stderr io.Writer) int {
@@ -112,6 +133,10 @@ func runAgentScript(scriptPath string, stdout, stderr io.Writer) int {
 		runCommand: func(name string, args ...string) error {
 			return runAgentScriptCommand(stdout, stderr, name, args...)
 		},
+		runCommandInStore: func(dir string, env []string, name string, args ...string) error {
+			return runAgentScriptCommandInStore(stdout, stderr, dir, env, name, args...)
+		},
+		resolveBeadStore: agentScriptCrossStoreBeadEnv,
 	}
 	executor.runShell = executor.runShellCommand
 	return runAgentScriptWithRuntime(scriptPath, stdout, stderr, executor, agentScriptHookBead)
@@ -278,13 +303,17 @@ func (e agentScriptExecutor) runAction(action agentScriptAction, ctx agentScript
 			if actor := agentScriptClaimActor(); actor != "" {
 				args = append(args, "--actor", actor)
 			}
-			return nil, e.runCommand("bd", args...)
+			return nil, e.runBDForBead(id, args...)
 		case "bd_update":
 			args, err := agentScriptBDUpdateArgs(arg, ctx)
 			if err != nil {
 				return nil, err
 			}
-			return nil, e.runCommand("bd", args...)
+			beadID := ""
+			if len(args) >= 2 {
+				beadID = args[1]
+			}
+			return nil, e.runBDForBead(beadID, args...)
 		case "exit":
 			code, err := agentScriptIntArg(name, arg)
 			if err != nil {
@@ -700,11 +729,25 @@ func (e agentScriptExecutor) runShellCommand(command string, env []string) error
 }
 
 func runAgentScriptCommand(stdout, stderr io.Writer, name string, args ...string) error {
+	return runAgentScriptCommandInStore(stdout, stderr, "", nil, name, args...)
+}
+
+// runAgentScriptCommandInStore runs a command like runAgentScriptCommand but, when
+// dir/env are supplied, points the subprocess at a specific store so a
+// cross-store claim/update lands in the bead's own store (vp-kvp stage iii). An
+// empty dir / nil env preserves the inherited working dir and environment.
+func runAgentScriptCommandInStore(stdout, stderr io.Writer, dir string, env []string, name string, args ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), agentScriptActionTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.WaitDelay = 2 * time.Second
 	prepareProviderOpCommand(cmd)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if env != nil {
+		cmd.Env = workQueryEnvForDir(env, dir)
+	}
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -163,8 +163,18 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 	}
 	queryEnv := mergeRuntimeEnv(os.Environ(), overrides)
 	failureTemplate, emitFailureEvent := hookWorkQueryFailureTemplate(len(args) > 0, sessionTemplateContext, a.QualifiedName())
-	runner := func(command, dir string) (string, error) {
-		out, err := shellWorkQueryWithEnv(command, dir, queryEnv)
+
+	// A cross-store-eligible (city-scoped) agent federates its work query across
+	// all stores — its own first, then every rig store — matched on its own
+	// identity (vp-kvp stage iii). Rig agents get a single-entry list, so their
+	// behavior is byte-for-byte unchanged.
+	stores := []hookStore{{dir: workDir, env: queryEnv}}
+	if agentIsCrossStoreEligible(&a) {
+		stores = appendRigHookStores(stores, cityPath, cfg, &a, overrides)
+	}
+
+	runner := func(command, _ string) (string, error) {
+		out, err := firstStoreWithWork(command, stores, shellWorkQueryWithEnv)
 		if err != nil && emitFailureEvent {
 			// A killed/timed-out work query strands the session with no
 			// output and no cause on the event bus; emit one so the

--- a/cmd/gc/cross_store_pipeline_test.go
+++ b/cmd/gc/cross_store_pipeline_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestCrossStorePipeline_ReadThenClaim verifies the composition of the
+// cross-store read half (firstStoreWithWork) and the write half
+// (crossStoreClaimDir): a bead ID surfaced by federation from a rig store
+// must be correctly redirected to that same rig store by the claim path.
+//
+// Uses the same injectable-runner approach as TestFirstStoreWithWork so no
+// real Dolt or gc subprocess is needed.
+func TestCrossStorePipeline_ReadThenClaim(t *testing.T) {
+	rigPath := t.TempDir()
+	cityPath := t.TempDir()
+	rigName := "voxist-api"
+
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: rigName, Path: rigPath, Prefix: "va"}},
+	}
+	cityAgent := &config.Agent{Name: "platform-architect", Scope: "city"}
+
+	// Step 1: READ — city store is empty; rig store has one ready bead.
+	stores := []hookStore{
+		{dir: cityPath, env: nil},
+		{dir: rigPath, env: nil},
+	}
+	run := func(_, dir string, _ []string) (string, error) {
+		if filepath.Clean(dir) == filepath.Clean(rigPath) {
+			return `[{"id":"va-1","status":"open","issue_type":"task"}]`, nil
+		}
+		return `[]`, nil
+	}
+
+	out, err := firstStoreWithWork("fake-query", stores, run)
+	if err != nil {
+		t.Fatalf("firstStoreWithWork: %v", err)
+	}
+
+	// Parse the bead ID from the output (same parse the agent/host would do).
+	var beads []struct {
+		ID string `json:"id"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &beads); jsonErr != nil || len(beads) == 0 {
+		t.Fatalf("could not parse bead from output %q: %v", out, jsonErr)
+	}
+	beadID := beads[0].ID
+	if beadID != "va-1" {
+		t.Fatalf("parsed bead ID = %q, want va-1", beadID)
+	}
+
+	// Step 2: CLAIM — the bead ID from the read output must redirect to the rig store.
+	claimDir, ok := crossStoreClaimDir(cfg, cityAgent, beadID)
+	if !ok {
+		t.Fatalf("crossStoreClaimDir(%q): no redirect — city-scoped agent claiming a rig-store bead must redirect", beadID)
+	}
+	if filepath.Clean(claimDir) != filepath.Clean(rigPath) {
+		t.Fatalf("claim dir = %q, want %q (rig store)", claimDir, rigPath)
+	}
+}
+
+// TestCrossStorePipeline_CityBeadNoRedirect confirms that city-owned work
+// (HQ store bead, unrecognized prefix) does not get redirected — the claim
+// stays in the agent's own store.
+func TestCrossStorePipeline_CityBeadNoRedirect(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "voxist-api", Path: t.TempDir(), Prefix: "va"}},
+	}
+	cityAgent := &config.Agent{Name: "platform-architect", Scope: "city"}
+
+	// An HQ/city-owned bead (vc-* or unknown prefix) must not redirect.
+	if _, ok := crossStoreClaimDir(cfg, cityAgent, "vc-123"); ok {
+		t.Fatal("city-owned (vc-*) bead must not redirect to any rig store")
+	}
+}
+
+// TestCrossStorePipeline_RigAgentByteForByteUnchanged confirms the rig-agent
+// isolation guarantee: a rig-scoped agent is NEVER redirected regardless of
+// bead prefix.
+func TestCrossStorePipeline_RigAgentByteForByteUnchanged(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "voxist-api", Path: t.TempDir(), Prefix: "va"}},
+	}
+	rigAgent := &config.Agent{Name: "executor", Dir: "voxist-api"}
+
+	if _, ok := crossStoreClaimDir(cfg, rigAgent, "va-1"); ok {
+		t.Fatal("rig-scoped agent must be byte-for-byte unchanged (no claim redirect)")
+	}
+}

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// hookStore is one store the hook work_query runs against: a working dir and
+// the rig/city-scoped subprocess env that points bd at that store.
+type hookStore struct {
+	dir string
+	env []string
+}
+
+// hookIdentityEnvKeys are the identity overrides that must stay constant across
+// every federated store attempt — the query always matches the agent's OWN
+// identity (gc.routed_to / assignee == this identity) regardless of which store
+// it reads.
+var hookIdentityEnvKeys = []string{
+	"GC_AGENT", "GC_SESSION_NAME", "GC_ALIAS",
+	"GC_SESSION_ID", "GC_SESSION_ORIGIN", "GC_TEMPLATE",
+}
+
+// appendRigHookStores adds one hookStore per rig for a cross-store-eligible
+// (city-scoped) agent — vp-kvp stage iii read federation. Each entry reuses the
+// rig's store env (built the same way controller probes build it, via a per-rig
+// agent view) while keeping the city agent's identity overrides, so the query
+// reads the RIG store but still matches work routed/assigned to the city agent.
+// Best-effort: a rig whose env cannot be built is skipped (the agent's own store
+// is always queried first by the caller).
+func appendRigHookStores(stores []hookStore, cityPath string, cfg *config.City, a *config.Agent, identityOverrides map[string]string) []hookStore {
+	if cfg == nil || a == nil {
+		return stores
+	}
+	for i := range cfg.Rigs {
+		rigName := strings.TrimSpace(cfg.Rigs[i].Name)
+		if rigName == "" {
+			continue
+		}
+		view := *a
+		view.Dir = rigName
+		rigEnv, err := hookQueryEnv(cityPath, cfg, &view)
+		if err != nil || rigEnv == nil {
+			continue
+		}
+		for _, k := range hookIdentityEnvKeys {
+			if v, ok := identityOverrides[k]; ok {
+				rigEnv[k] = v
+			}
+		}
+		stores = append(stores, hookStore{
+			dir: agentCommandDir(cityPath, &view, cfg.Rigs),
+			env: mergeRuntimeEnv(os.Environ(), rigEnv),
+		})
+	}
+	return stores
+}
+
+// firstStoreWithWork runs command against each store in order and returns the
+// output of the FIRST store that reports ready work (applying the same
+// normalize + unready-filter that doHook uses, so a store with only
+// deferred/blocked rows is not treated as a hit). run is injectable for tests.
+//
+// When no store has ready work, an error on the agent's OWN store (the first
+// entry) is surfaced so emitCityWorkQueryFailure can classify it — preserving
+// the single-store emit-on-timeout contract (a work-query timeout must reach
+// the reconciler, not be silently downgraded to "no work"). Errors from
+// federated rig stores are best-effort discovery (like appendRigHookStores)
+// and are not surfaced, so one flaky rig store can't wedge the hook.
+func firstStoreWithWork(command string, stores []hookStore, run func(command, dir string, env []string) (string, error)) (string, error) {
+	var lastOut string
+	var ownStoreOut string
+	var ownStoreErr error
+	for i, st := range stores {
+		out, err := run(command, st.dir, st.env)
+		if err == nil {
+			ready := filterUnreadyHookCandidates(normalizeWorkQueryOutput(strings.TrimSpace(out)), time.Now())
+			if workQueryHasReadyWork(ready) {
+				return out, nil
+			}
+			lastOut = out
+			continue
+		}
+		if i == 0 {
+			ownStoreOut, ownStoreErr = out, err
+		}
+	}
+	if ownStoreErr != nil {
+		return ownStoreOut, ownStoreErr
+	}
+	return lastOut, nil
+}

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+var errTestStoreTimeout = errors.New("store timed out")
+
+func TestFirstStoreWithWorkReturnsFirstStoreThatHasWork(t *testing.T) {
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}, {dir: "rigb"}}
+	var calls []string
+	run := func(_, dir string, _ []string) (string, error) {
+		calls = append(calls, dir)
+		if dir == "riga" {
+			return `[{"id":"va-1"}]`, nil
+		}
+		return `[]`, nil
+	}
+	out, err := firstStoreWithWork("q", stores, run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != `[{"id":"va-1"}]` {
+		t.Fatalf("out = %q, want riga work", out)
+	}
+	// Stops at the first store with work — does not query rigb.
+	if len(calls) != 2 || calls[0] != "city" || calls[1] != "riga" {
+		t.Fatalf("calls = %v, want [city riga]", calls)
+	}
+}
+
+func TestFirstStoreWithWorkReturnsLastWhenNoneHasWork(t *testing.T) {
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	run := func(_, _ string, _ []string) (string, error) { return `[]`, nil }
+	out, err := firstStoreWithWork("q", stores, run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != `[]` {
+		t.Fatalf("out = %q, want []", out)
+	}
+}
+
+func TestFirstStoreWithWorkSurfacesOwnStoreErrorWhenNoWork(t *testing.T) {
+	// The agent's own store (first) timing out must be surfaced even if a
+	// federated rig store returns no work — otherwise emitCityWorkQueryFailure
+	// never fires and a transient timeout is silently downgraded to "no work".
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	run := func(_, dir string, _ []string) (string, error) {
+		if dir == "city" {
+			return "", errTestStoreTimeout
+		}
+		return `[]`, nil
+	}
+	if _, err := firstStoreWithWork("q", stores, run); !errors.Is(err, errTestStoreTimeout) {
+		t.Fatalf("own-store error must be surfaced when no store has work; got %v", err)
+	}
+}
+
+func TestFirstStoreWithWorkIgnoresRigStoreErrorWhenOwnStoreHasNoWork(t *testing.T) {
+	// A flaky federated rig store must not wedge the hook: when the agent's own
+	// store is healthy (no work), a rig-store error is best-effort and dropped.
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	run := func(_, dir string, _ []string) (string, error) {
+		if dir == "city" {
+			return `[]`, nil
+		}
+		return "", errTestStoreTimeout
+	}
+	out, err := firstStoreWithWork("q", stores, run)
+	if err != nil {
+		t.Fatalf("rig-store error must not surface when own store is healthy; got %v", err)
+	}
+	if out != `[]` {
+		t.Fatalf("out = %q, want city store's no-work output", out)
+	}
+}
+
+func TestFirstStoreWithWorkSkipsStoreWithOnlyUnreadyRows(t *testing.T) {
+	// A store whose only row is dep-blocked is NOT a hit; federation moves on.
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	run := func(_, dir string, _ []string) (string, error) {
+		if dir == "city" {
+			return `[{"id":"x","blocked_by":[{"status":"open"}]}]`, nil
+		}
+		return `[{"id":"va-2"}]`, nil
+	}
+	out, err := firstStoreWithWork("q", stores, run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != `[{"id":"va-2"}]` {
+		t.Fatalf("out = %q, want riga work (city row was unready)", out)
+	}
+}

--- a/internal/agentutil/resolve.go
+++ b/internal/agentutil/resolve.go
@@ -239,11 +239,29 @@ func AgentReachesWorkflowStore(storeRef string, agentCfg *config.Agent, cityPath
 	if cfg == nil || agentCfg == nil {
 		return true
 	}
+	// City-scoped agents are cross-store eligible: a city-wide singleton
+	// legitimately serves work in ANY store (vp-kvp). Without this exemption the
+	// cross-store route guard (validateBuiltInRouteStoreReachable) would
+	// false-positive on a legitimate route to a city-scoped target and refuse
+	// it — the very dead-drop stages ii/iii exist to remove. Rig-scoped agents
+	// stay single-store, so all existing reachability is unchanged.
+	if AgentIsCrossStoreEligible(agentCfg) {
+		return true
+	}
 	agentRig := workdirutil.ConfiguredRigName(cityPath, *agentCfg, cfg.Rigs)
 	if agentRig == "" {
 		return strings.HasPrefix(storeRef, "city:")
 	}
 	return storeRef == "rig:"+agentRig
+}
+
+// AgentIsCrossStoreEligible reports whether an agent may discover and serve
+// work in ANY store, not just its configured rig. City-scoped agents are
+// cross-store eligible: a city-wide singleton legitimately serves per-rig
+// routed work (vp-kvp — "scope determines discovery breadth"). Centralized
+// here so domain packages and the CLI share one definition.
+func AgentIsCrossStoreEligible(agentCfg *config.Agent) bool {
+	return agentCfg != nil && strings.TrimSpace(agentCfg.Scope) == "city"
 }
 
 // AgentReachableStoreLabel returns the workflow store ref an agent's

--- a/internal/agentutil/resolve_test.go
+++ b/internal/agentutil/resolve_test.go
@@ -252,3 +252,44 @@ func TestNormalizePoolRouteTargetNilConfig(t *testing.T) {
 		t.Errorf("NormalizePoolRouteTarget(nil) = %q, want unchanged", got)
 	}
 }
+
+func TestAgentReachesWorkflowStoreCityScopedReachesAnyStore(t *testing.T) {
+	// vp-kvp stage i: the cross-store route guard
+	// (validateBuiltInRouteStoreReachable) must NOT refuse a route to a
+	// city-scoped (cross-store-eligible) target — it legitimately serves any
+	// store. Before this exemption, AgentReachesWorkflowStore gated city-scoped
+	// agents (no Dir) to "city:" stores only, so routing rig-store work to the
+	// city singleton failed loud as a false positive, blocking stages ii/iii.
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "voxist-web", Path: "/c/voxist-web", Prefix: "vw"}},
+	}
+	cityAgent := &config.Agent{Name: "platform-architect", Scope: "city"}
+
+	if !AgentReachesWorkflowStore("rig:voxist-web", cityAgent, "/c", cfg) {
+		t.Fatal("city-scoped agent must reach a rig store (cross-store eligible)")
+	}
+	if !AgentReachesWorkflowStore("city:test-city", cityAgent, "/c", cfg) {
+		t.Fatal("city-scoped agent must still reach the city store")
+	}
+
+	// Rig-scoped agents are byte-for-byte unchanged: still single-store.
+	rigAgent := &config.Agent{Name: "reviewer", Dir: "voxist-web"}
+	if AgentReachesWorkflowStore("city:test-city", rigAgent, "/c", cfg) {
+		t.Fatal("rig-scoped agent must not reach the city store")
+	}
+	if !AgentReachesWorkflowStore("rig:voxist-web", rigAgent, "/c", cfg) {
+		t.Fatal("rig-scoped agent must reach its own rig store")
+	}
+}
+
+func TestAgentIsCrossStoreEligible(t *testing.T) {
+	if !AgentIsCrossStoreEligible(&config.Agent{Scope: "city"}) {
+		t.Fatal("scope=city must be cross-store eligible")
+	}
+	if AgentIsCrossStoreEligible(&config.Agent{Dir: "voxist-web"}) {
+		t.Fatal("rig-scoped agent must not be cross-store eligible")
+	}
+	if AgentIsCrossStoreEligible(nil) {
+		t.Fatal("nil agent must not be cross-store eligible")
+	}
+}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -1829,6 +1829,26 @@ func crossStoreSlingFixture(t *testing.T, assignee string) (SlingOpts, SlingDeps
 	return opts, deps, router, bead
 }
 
+func TestValidateBuiltInRouteStoreReachableAllowsCityScopedTarget(t *testing.T) {
+	// vp-kvp stage i: the fail-loud cross-store route guard must refuse a
+	// rig-scoped target that cannot reach the bead's store, but must NOT
+	// false-positive on a city-scoped (cross-store-eligible) target, which
+	// legitimately serves any store. Before the exemption the city singleton was
+	// refused, blocking cross-store work delivery (stages ii/iii).
+	deps, _, rigTarget := crossStoreSlingDeps(t) // deps.StoreRef = "city:test-city"
+
+	if err := validateBuiltInRouteStoreReachable(deps, "RW-1", rigTarget); err == nil {
+		t.Fatal("rig-scoped target routing a city-store bead must be refused (fail loud)")
+	} else {
+		requireCrossStoreRouteError(t, err)
+	}
+
+	cityTarget := config.Agent{Name: "platform-architect", Scope: "city", MaxActiveSessions: intPtr(1)}
+	if err := validateBuiltInRouteStoreReachable(deps, "RW-1", cityTarget); err != nil {
+		t.Fatalf("city-scoped target must not be refused as cross-store: %v", err)
+	}
+}
+
 func requireCrossStoreRouteError(t *testing.T, err error) {
 	t.Helper()
 	var crossStoreErr *CrossStoreRouteError


### PR DESCRIPTION
## Summary

A city-scoped singleton legitimately serves per-rig work, but several
single-store assumptions made work routed to it **silently dead-drop** when the
bead lives in a rig store — the agent never sees it, never claims it, and stays
idle with no error. This PR delivers cross-store work **end to end** for
cross-store-eligible (`scope == "city"`) agents. Rig-scoped agents take the
existing single-store path and are byte-for-byte unchanged.

Eligibility is **derived from scope** (no new config field):
`agentutil.AgentIsCrossStoreEligible` is the one shared definition.

## Changes

- **Wake** (`cmd/gc/assigned_work_scope.go`): a city-scoped agent's assigned
  work is reachable from any store, so pool-demand / session-wake reachability
  no longer gates it to its configured rig.
- **Read** (`cmd/gc/hook_cross_store.go`, `cmd_hook.go`): `gc hook` federates
  the `work_query` across stores — its own first, then each rig store — matched
  on the agent's own identity, returning the first store with ready work. The
  per-store decision is a pure, unit-tested function (`firstStoreWithWork`).
- **Write / claim** (`cmd/gc/claim_cross_store.go`, `cmd_agent_script.go`): the
  agent-script `bd_claim` / `bd_update` path resolves the bead's owning store
  from its ID prefix (`sling.RigDirForBead`) and runs the `bd` write there, so a
  claim lands in the bead's store, not the agent's default store.
- **Guard** (`internal/agentutil/resolve.go`): the existing cross-store route
  guard (`validateBuiltInRouteStoreReachable`, #2633) gated reachability through
  `AgentReachesWorkflowStore`, which predates cross-store eligibility and would
  false-positive on a legitimate route to a city-scoped target. Adds the
  cross-store-eligible exemption so the guard stops refusing valid routes while
  still failing loud on a genuinely unreachable rig→rig route.

## Testing

- Unit tests for each half: wake reachability, federated-read first-with-work
  (incl. unready-skip), claim-store routing + executor wiring, and guard
  exemption vs. refusal. All assert rig-agent behavior is unchanged.
- Local `go build`/`go test` on macOS is blocked by the Dolt `go-icu-regex` CGO
  dependency (`unicode/regex.h`); verified instead on an Ubuntu runner
  (build + vet + the new unit tests, all green). gofmt-clean. Upstream CI will
  run the full suite.

## Notes

Builds on #2633 (cross-store route refusal). The capability activates only for
agents already classified `scope == "city"`; no behavior change for rig-scoped
agents.
