### PR TITLE
fix(dispatch): bound the order open-work gate to protect later orders

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -461,7 +461,9 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
 		}
 		scoped := a.ScopedName()
-		hasOpenWork, err := m.hasOpenWorkInStoresStrict(storesForGate, scoped)
+		hasOpenWork, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
+			return m.hasOpenWorkInStoresStrict(storesForGate, scoped)
+		})
 		if err != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
 			continue
@@ -549,7 +551,11 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		}
 
 		// Skip dispatch if previous work hasn't been processed yet.
-		hasOpenWork, err = trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.hasOpenWorkInStoresStrict, true)
+		// Bound the wisp-aware open-work gate (#2921) with our per-order
+		// timeout so a slow store can't starve later orders.
+		hasOpenWork, err = gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
+			return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.hasOpenWorkInStoresStrict, true)
+		})
 		if err != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
 			continue
@@ -1448,6 +1454,45 @@ func (m *memoryOrderDispatcher) hasOpenWorkInStoresStrict(stores []beads.Store, 
 		}
 	}
 	return false, nil
+}
+
+// orderGateTimeout bounds a single order's open-work gate. The strict gate
+// walks an order's wisp subtree by spawning synchronous bd subprocesses
+// (storeHasOpenDescendants); under Dolt write contention one heavy order's gate
+// can block for minutes, and because dispatch iterates orders synchronously
+// that stalls every LATER order (feeders, nudger, route-reclaim) on the same
+// tick — the vc-6qh1 hang. Bounding the gate lets a slow order be skipped so
+// the rest of the sweep proceeds. Package-level var so it is tunable and
+// overridable in tests.
+var orderGateTimeout = 8 * time.Second
+
+// gateOpenWorkBounded runs the open-work gate under a per-order timeout that
+// also honors the dispatch context. On timeout (or cancellation) it returns an
+// error so the caller skips THAT order and continues to the rest
+// (fail-closed-but-continue, vc-6qh1 mitigation #2): a heavy gate never starves
+// the feeders. gate is invoked in a goroutine; on timeout that goroutine is
+// left to finish on its own (its result is discarded via the buffered channel)
+// rather than blocking the dispatch loop.
+func gateOpenWorkBounded(ctx context.Context, timeout time.Duration, scoped string, gate func() (bool, error)) (bool, error) {
+	type gateResult struct {
+		has bool
+		err error
+	}
+	done := make(chan gateResult, 1)
+	go func() {
+		has, err := gate()
+		done <- gateResult{has: has, err: err}
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case r := <-done:
+		return r.has, r.err
+	case <-timer.C:
+		return false, fmt.Errorf("open-work gate for %s timed out after %s; skipping this order so later orders still dispatch (see vc-6qh1)", scoped, timeout)
+	case <-ctx.Done():
+		return false, fmt.Errorf("open-work gate for %s aborted: %w", scoped, ctx.Err())
+	}
 }
 
 // sweepOrphanedOrderTracking closes any open order-tracking beads left

--- a/cmd/gc/order_dispatch_gate_test.go
+++ b/cmd/gc/order_dispatch_gate_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGateOpenWorkBoundedTimesOutSoLaterOrdersDispatch(t *testing.T) {
+	// vc-6qh1 #2: a gate that exceeds its bound must return an error so the
+	// dispatch loop skips THAT order and continues to the rest (the existing
+	// `if err != nil { continue }` is fail-closed-but-continue). Without the
+	// bound a wedged gate blocks every later order on the tick.
+	started := make(chan struct{})
+	_, err := gateOpenWorkBounded(context.Background(), 10*time.Millisecond, "order:heavy", func() (bool, error) {
+		close(started)
+		time.Sleep(500 * time.Millisecond)
+		return false, nil
+	})
+	if err == nil {
+		t.Fatal("gate exceeding the bound must return a timeout error so the order is skipped")
+	}
+	<-started // the gate did run (and is left to finish on its own).
+}
+
+func TestGateOpenWorkBoundedReturnsFastResult(t *testing.T) {
+	has, err := gateOpenWorkBounded(context.Background(), time.Second, "order:x", func() (bool, error) {
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("fast gate must not error: %v", err)
+	}
+	if !has {
+		t.Fatal("fast gate must return the real has-open-work result")
+	}
+}
+
+func TestGateOpenWorkBoundedHonorsDispatchContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := gateOpenWorkBounded(ctx, time.Second, "order:x", func() (bool, error) {
+		time.Sleep(100 * time.Millisecond)
+		return false, nil
+	})
+	if err == nil {
+		t.Fatal("a cancelled dispatch context must abort the gate (skip + continue)")
+	}
+}
+
+func TestGateOpenWorkBoundedPropagatesGateError(t *testing.T) {
+	wantErr := context.DeadlineExceeded
+	_, err := gateOpenWorkBounded(context.Background(), time.Second, "order:x", func() (bool, error) {
+		return false, wantErr
+	})
+	if err != wantErr {
+		t.Fatalf("gate error must propagate unchanged: got %v, want %v", err, wantErr)
+	}
+}

--- a/cmd/gc/order_dispatch_gate_test.go
+++ b/cmd/gc/order_dispatch_gate_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -43,7 +44,7 @@ func TestGateOpenWorkBoundedHonorsDispatchContext(t *testing.T) {
 		return false, nil
 	})
 	if err == nil {
-		t.Fatal("a cancelled dispatch context must abort the gate (skip + continue)")
+		t.Fatal("a canceled dispatch context must abort the gate (skip + continue)")
 	}
 }
 
@@ -52,7 +53,7 @@ func TestGateOpenWorkBoundedPropagatesGateError(t *testing.T) {
 	_, err := gateOpenWorkBounded(context.Background(), time.Second, "order:x", func() (bool, error) {
 		return false, wantErr
 	})
-	if err != wantErr {
+	if !errors.Is(err, wantErr) {
 		t.Fatalf("gate error must propagate unchanged: got %v, want %v", err, wantErr)
 	}
 }


### PR DESCRIPTION
## Summary

The order-dispatch loop iterates orders synchronously and, per order, calls the
strict open-work gate (`hasOpenWorkInStoresStrict`) twice. That gate walks an
order's wisp subtree by spawning **synchronous `bd` subprocesses**
(`storeHasOpenDescendants` → `store.List` per node). Under store write
contention a single heavy order's gate can block for minutes, and because the
loop is synchronous that **stalls every later order on the same tick** —
scheduled feeders, nudgers, and reclaimers stop firing, so newly-ready work is
never routed and idle pools are never woken. A restart does not durably fix it:
the store re-accumulates subtrees within minutes.

## Change

This is the cheapest high-impact mitigation: **bound the gate**.
`gateOpenWorkBounded` runs the gate under a per-order timeout that also honors
the dispatch context; on timeout (or cancellation) it returns an error so the
caller skips **that** order and continues to the rest
(fail-closed-but-continue). A heavy gate can no longer starve the feeders.

- `gateOpenWorkBounded(ctx, timeout, scoped, gate)`: goroutine + timer + ctx
  `select`; the gate goroutine is left to finish on its own (buffered channel)
  rather than blocking the loop.
- Called at both gate sites (pre- and post-trigger).
- `orderGateTimeout` (8s) is a package var so it stays tunable / test-overridable.

The durable root fix (eliminate the O(tree) subprocess BFS on the hot path) and
the amplifier fix (stop materializing transient nudge/mail beads in the
open-work store) are follow-ups, not in this PR.

## Testing

- Unit tests: timeout skips the order, fast result passes through, a cancelled
  dispatch context aborts, and a gate error propagates unchanged.
- Local `go build`/`go test` on macOS is blocked by the Dolt `go-icu-regex` CGO
  dependency; verified on an Ubuntu runner (build + vet + the new tests, green).
  gofmt-clean.
