### PR TITLE
Fix formula requirement diagnostics

### DIFF
--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 )
@@ -626,6 +627,73 @@ start_command = "echo hello"
 			t.Fatalf("stderr = %q, want command-scoped rig diagnostic", got)
 		}
 	})
+}
+
+func TestFormulaCookHonorsFormulaV2DisabledCityBeforeCreatingBeads(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BOOTSTRAP", "skip")
+	t.Cleanup(func() {
+		applyFeatureFlags(&config.City{Daemon: config.DaemonConfig{FormulaV2: true}})
+	})
+
+	cityDir := t.TempDir()
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = false
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	graphFormula := `
+formula = "graph-work"
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--city", cityDir, "formula", "cook", "graph-work"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("gc formula cook = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "formula_v2 is disabled") {
+		t.Fatalf("stderr missing formula_v2 diagnostic:\n%s", stderr.String())
+	}
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	items, err := store.List(beads.ListQuery{
+		AllowScan:     true,
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+	})
+	if err != nil {
+		t.Fatalf("store.List(): %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("created %d bead(s), want none: %#v", len(items), items)
+	}
 }
 
 func writeFormulaTestFile(t *testing.T, dir, name, content string) {

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -954,6 +954,61 @@ func TestOrderRunJSONFormulaSummary(t *testing.T) {
 	}
 }
 
+func TestOrderRunHonorsFormulaV2DisabledCity(t *testing.T) {
+	t.Cleanup(func() {
+		applyFeatureFlags(&config.City{Daemon: config.DaemonConfig{FormulaV2: true}})
+	})
+
+	cityDir := t.TempDir()
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = false
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	graphFormula := `
+formula = "graph-work"
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{
+		{Name: "blocked", Formula: "graph-work", Trigger: "cooldown", Interval: "15m", FormulaLayer: formulaDir},
+	}
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "blocked", "", cityDir, store, nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderRun = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "formula_v2 is disabled") {
+		t.Fatalf("stderr missing formula_v2 diagnostic:\n%s", stderr.String())
+	}
+	results, err := store.ListByLabel("order-run:blocked", 0)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("created %d order-run bead(s), want none: %#v", len(results), results)
+	}
+}
+
 func TestOrderRunJSONRejectsExecWithoutRunning(t *testing.T) {
 	aa := []orders.Order{
 		{Name: "release-exec", Trigger: "manual", Exec: "printf unsafe"},

--- a/internal/doctor/checks_formula_requirements.go
+++ b/internal/doctor/checks_formula_requirements.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // FormulaRequirementsCheck reports formula compiler requirement migration and
@@ -185,23 +186,9 @@ func (i formulaRequirementIssue) dedupeKey() formulaRequirementIssueKey {
 	return formulaRequirementIssueKey{
 		severity: i.severity,
 		formula:  i.formula,
-		path:     canonicalFormulaRequirementPath(i.path),
+		path:     pathutil.NormalizePathForCompare(i.path),
 		message:  i.message,
 	}
-}
-
-func canonicalFormulaRequirementPath(path string) string {
-	if path == "" {
-		return ""
-	}
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return filepath.Clean(path)
-	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved
-	}
-	return filepath.Clean(abs)
 }
 
 func (i formulaRequirementIssue) detail() string {

--- a/internal/doctor/checks_formula_requirements.go
+++ b/internal/doctor/checks_formula_requirements.go
@@ -67,6 +67,15 @@ func (c *FormulaRequirementsCheck) Fix(_ *CheckContext) error { return nil }
 
 func (c *FormulaRequirementsCheck) collectIssues() []formulaRequirementIssue {
 	var issues []formulaRequirementIssue
+	seen := make(map[formulaRequirementIssueKey]struct{})
+	addIssue := func(issue formulaRequirementIssue) {
+		key := issue.dedupeKey()
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		issues = append(issues, issue)
+	}
 	src := formula.SourceFromEnv()
 	for _, scope := range c.formulaScopes() {
 		parser := formula.NewParser(scope.paths...).SetSource(src)
@@ -80,7 +89,7 @@ func (c *FormulaRequirementsCheck) collectIssues() []formulaRequirementIssue {
 			path := winners[name]
 			f, err := parser.ParseFile(path)
 			if err != nil {
-				issues = append(issues, formulaRequirementIssue{
+				addIssue(formulaRequirementIssue{
 					severity: StatusError,
 					scope:    scope.name,
 					formula:  name,
@@ -90,7 +99,7 @@ func (c *FormulaRequirementsCheck) collectIssues() []formulaRequirementIssue {
 				continue
 			}
 			if strings.EqualFold(strings.TrimSpace(f.Contract), "graph.v2") {
-				issues = append(issues, formulaRequirementIssue{
+				addIssue(formulaRequirementIssue{
 					severity: StatusWarning,
 					scope:    scope.name,
 					formula:  f.Formula,
@@ -100,7 +109,7 @@ func (c *FormulaRequirementsCheck) collectIssues() []formulaRequirementIssue {
 			}
 			resolved, err := parser.Resolve(f)
 			if err != nil {
-				issues = append(issues, formulaRequirementIssue{
+				addIssue(formulaRequirementIssue{
 					severity: StatusError,
 					scope:    scope.name,
 					formula:  f.Formula,
@@ -110,7 +119,7 @@ func (c *FormulaRequirementsCheck) collectIssues() []formulaRequirementIssue {
 				continue
 			}
 			if err := formula.ValidateExplicitGraphCompilerRequirement(resolved); err != nil {
-				issues = append(issues, formulaRequirementIssue{
+				addIssue(formulaRequirementIssue{
 					severity: StatusError,
 					scope:    scope.name,
 					formula:  resolved.Formula,
@@ -119,7 +128,7 @@ func (c *FormulaRequirementsCheck) collectIssues() []formulaRequirementIssue {
 				})
 			}
 			if err := formula.ValidateHostRequirements(resolved, c.cfg.Daemon.FormulaV2); err != nil {
-				issues = append(issues, formulaRequirementIssue{
+				addIssue(formulaRequirementIssue{
 					severity: StatusError,
 					scope:    scope.name,
 					formula:  resolved.Formula,
@@ -163,6 +172,36 @@ type formulaRequirementIssue struct {
 	formula  string
 	path     string
 	message  string
+}
+
+type formulaRequirementIssueKey struct {
+	severity CheckStatus
+	formula  string
+	path     string
+	message  string
+}
+
+func (i formulaRequirementIssue) dedupeKey() formulaRequirementIssueKey {
+	return formulaRequirementIssueKey{
+		severity: i.severity,
+		formula:  i.formula,
+		path:     canonicalFormulaRequirementPath(i.path),
+		message:  i.message,
+	}
+}
+
+func canonicalFormulaRequirementPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
 }
 
 func (i formulaRequirementIssue) detail() string {

--- a/internal/doctor/checks_formula_requirements_test.go
+++ b/internal/doctor/checks_formula_requirements_test.go
@@ -145,6 +145,49 @@ title = "Work"
 	}
 }
 
+func TestFormulaRequirementsCheckDeduplicatesCityDiagnosticsInRigLayers(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	writeDoctorFormula(t, cityDir, "shared-missing", `
+formula = "shared-missing"
+
+[[steps]]
+id = "work"
+title = "Work"
+metadata = { "gc.on_fail" = "abort_scope" }
+`)
+	writeDoctorFormula(t, rigDir, "rig-invalid", `
+formula = "rig-invalid"
+
+[requires]
+formula_compiler = "not-a-comparator"
+
+[[steps]]
+id = "work"
+title = "Work"
+`)
+
+	check := NewFormulaRequirementsCheck(&config.City{
+		Daemon: config.DaemonConfig{FormulaV2: true},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityDir},
+			Rigs: map[string][]string{"proj": {cityDir, rigDir}},
+		},
+	}, t.TempDir())
+
+	result := check.Run(&CheckContext{})
+	if result.Status != StatusError {
+		t.Fatalf("Status = %v, want error; details:\n%s", result.Status, strings.Join(result.Details, "\n"))
+	}
+	details := strings.Join(result.Details, "\n")
+	if got := strings.Count(details, `formula "shared-missing"`); got != 1 {
+		t.Fatalf("shared city diagnostic count = %d, want 1; details:\n%s", got, details)
+	}
+	if !strings.Contains(details, `formula "rig-invalid"`) {
+		t.Fatalf("details missing rig-specific diagnostic:\n%s", details)
+	}
+}
+
 func TestFormulaRequirementsCheckReportsGraphConstructMissingCompilerRequirement(t *testing.T) {
 	dir := t.TempDir()
 	writeDoctorFormula(t, dir, "retry-without-requirement", `


### PR DESCRIPTION
Remediates post-merge review findings for gastownhall/gascity#2423.

Summary:
- De-duplicate formula requirement doctor diagnostics when rig formula layers include city formula layers.
- Preserve rig-specific formula diagnostics while counting shared city-layer issues once.
- Add order-run coverage showing disabled formula_v2 cities reject formula-backed durable order runs before creating work.

Validation:
- go test ./internal/doctor -run 'TestFormulaRequirementsCheck' -count=1
- go test ./cmd/gc -run TestOrderRunHonorsFormulaV2DisabledCity -count=1
- GC_FAST_UNIT=0 go test ./cmd/gc -run 'TestTutorial01/formula-show-graph-v2' -count=1
- make test-fast-parallel
- go vet ./...