### PR TITLE
feat: stamp gc.session_name + gc.work_dir on graph.v2 run/step beads (#2843)

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2934,6 +2934,9 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		return
 	}
 	sessionByAssignee := buildSessionAssigneeIndex(sessionBeads)
+	// Roots stamped this pass, so a multi-step run's shared root is resolved
+	// once rather than per step.
+	stampedRoots := map[string]struct{}{}
 	for i, wb := range workBeads {
 		if wb.Status != "in_progress" {
 			continue
@@ -2953,6 +2956,9 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		sb := match.bead
 		sessionName := sessionBeadIdentifier(sb)
 		workDir := strings.TrimSpace(sb.Metadata["work_dir"])
+		if sessionName == "" && workDir == "" {
+			continue
+		}
 		patch := map[string]string{}
 		if sessionName != "" && strings.TrimSpace(wb.Metadata["gc.session_name"]) != sessionName {
 			patch["gc.session_name"] = sessionName
@@ -2960,12 +2966,52 @@ func stampRunSessionIdentity(workBeads []beads.Bead, workStores []beads.Store, s
 		if workDir != "" && strings.TrimSpace(wb.Metadata["gc.work_dir"]) != workDir {
 			patch["gc.work_dir"] = workDir
 		}
-		if len(patch) == 0 {
-			continue
+		if len(patch) > 0 {
+			if err := store.SetMetadataBatch(wb.ID, patch); err != nil && stderr != nil {
+				fmt.Fprintf(stderr, "stampRunSessionIdentity: %s: %v\n", wb.ID, err) //nolint:errcheck
+			}
 		}
-		if err := store.SetMetadataBatch(wb.ID, patch); err != nil && stderr != nil {
-			fmt.Fprintf(stderr, "stampRunSessionIdentity: %s: %v\n", wb.ID, err) //nolint:errcheck
-		}
+		// Propagate to the run root. The molecule root (gc.kind=workflow) is a
+		// control-lane bead — never in_progress+assigned — so it is not in
+		// workBeads and route-time stamping skips it for pool agents. The
+		// dashboard's root-only snapshot reads the root's own metadata, so a
+		// worked step back-fills its root via gc.root_bead_id. (#2843)
+		stampRunRootFromStep(store, wb, sessionName, workDir, stampedRoots, stderr)
+	}
+}
+
+// stampRunRootFromStep copies a step's resolved session_name/work_dir onto its
+// workflow root (gc.root_bead_id), once per root per pass. Idempotent: it reads
+// the root and writes only the keys that differ. Best-effort — a root that is
+// in another store, already gone, or already stamped is silently skipped (a
+// cross-store root gets stamped on its own store's reconcile pass).
+func stampRunRootFromStep(store beads.Store, step beads.Bead, sessionName, workDir string, stampedRoots map[string]struct{}, stderr io.Writer) {
+	rootID := strings.TrimSpace(step.Metadata["gc.root_bead_id"])
+	if rootID == "" || rootID == step.ID {
+		return
+	}
+	if _, done := stampedRoots[rootID]; done {
+		return
+	}
+	root, err := store.Get(rootID)
+	if err != nil {
+		// Cross-store / missing / transient — do NOT mark stamped, so a later
+		// step this pass (or a later reconcile) can retry resolving the root.
+		return
+	}
+	stampedRoots[rootID] = struct{}{}
+	patch := map[string]string{}
+	if sessionName != "" && strings.TrimSpace(root.Metadata["gc.session_name"]) != sessionName {
+		patch["gc.session_name"] = sessionName
+	}
+	if workDir != "" && strings.TrimSpace(root.Metadata["gc.work_dir"]) != workDir {
+		patch["gc.work_dir"] = workDir
+	}
+	if len(patch) == 0 {
+		return
+	}
+	if err := store.SetMetadataBatch(rootID, patch); err != nil && stderr != nil {
+		fmt.Fprintf(stderr, "stampRunSessionIdentity root %s: %v\n", rootID, err) //nolint:errcheck
 	}
 }
 

--- a/cmd/gc/build_desired_state_session_stamp_test.go
+++ b/cmd/gc/build_desired_state_session_stamp_test.go
@@ -63,6 +63,41 @@ func TestStampRunSessionIdentityStampsInProgressAssignedBead(t *testing.T) {
 	}
 }
 
+func TestStampRunSessionIdentityPropagatesToRunRoot(t *testing.T) {
+	// #2843: a worked in-progress STEP back-fills its workflow ROOT (which the
+	// dashboard's root-only snapshot reads). The root is a control-lane bead,
+	// never in_progress+assigned, so it is reached only via gc.root_bead_id.
+	const sn = "gascity-packs-polecat-gc-1"
+	const wd = "/home/ds/gascity-packs-worktrees/gascity-packs-polecat-1"
+	root := beads.Bead{ID: "gpk-root", Type: "molecule", Status: "in_progress", Metadata: map[string]string{"gc.kind": "workflow"}}
+	step := beads.Bead{ID: "gpk-step", Type: "step", Status: "in_progress", Assignee: sn, Metadata: map[string]string{"gc.step_ref": "wf.work", "gc.root_bead_id": "gpk-root"}}
+	mem := beads.NewMemStoreFrom(0, []beads.Bead{root, step}, nil)
+	store := &countingStore{Store: mem}
+	sessions := newSessionBeadSnapshot([]beads.Bead{stampTestSession(sn, wd)})
+
+	stampRunSessionIdentity([]beads.Bead{step}, []beads.Store{store}, sessions, io.Discard)
+
+	gotStep, _ := mem.Get("gpk-step")
+	if gotStep.Metadata["gc.session_name"] != sn || gotStep.Metadata["gc.work_dir"] != wd {
+		t.Errorf("step not stamped: session_name=%q work_dir=%q", gotStep.Metadata["gc.session_name"], gotStep.Metadata["gc.work_dir"])
+	}
+	gotRoot, _ := mem.Get("gpk-root")
+	if gotRoot.Metadata["gc.session_name"] != sn {
+		t.Errorf("root gc.session_name = %q, want %q (propagated from step)", gotRoot.Metadata["gc.session_name"], sn)
+	}
+	if gotRoot.Metadata["gc.work_dir"] != wd {
+		t.Errorf("root gc.work_dir = %q, want %q (propagated from step)", gotRoot.Metadata["gc.work_dir"], wd)
+	}
+
+	// Idempotent: a second pass writes nothing (step + root already stamped).
+	stamped, _ := mem.Get("gpk-step")
+	store.writes = 0
+	stampRunSessionIdentity([]beads.Bead{stamped}, []beads.Store{store}, sessions, io.Discard)
+	if store.writes != 0 {
+		t.Errorf("second pass wrote %d times, want 0 (step+root already stamped)", store.writes)
+	}
+}
+
 func TestStampRunSessionIdentityNamedSessionUsesAlias(t *testing.T) {
 	// Named sessions (e.g. mayor) carry an empty session_name; their
 	// resolvable identifier lives in alias / configured_named_identity.

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1180,6 +1180,12 @@ func decorateGraphWorkflowRecipe(recipe *formula.Recipe, routeVars map[string]st
 			// (fixes #2763; gc.run_target retired as a wire field — ga-eld2x).
 			step.Metadata["gc.routed_to"] = routedTo
 			delete(step.Metadata, "gc.run_target")
+			if sessionName != "" {
+				// Mirror graphroute's root #2843 session stamp so this CLI-local
+				// decorator stays in sync. Non-root steps already delegate to
+				// graphroute via assignGraphStepRoute.
+				step.Metadata["gc.session_name"] = sessionName
+			}
 			continue
 		}
 		if sling.IsWorkflowTopologyKind(step.Metadata["gc.kind"]) {

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -135,8 +135,16 @@ func parseGraphStepRouteTarget(step *formula.RecipeStep, routeVars map[string]st
 
 // ApplyGraphRouteBinding sets the routing metadata on a recipe step.
 func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding) {
+	// Clear any prior session back-references so the metadata always matches
+	// the current binding when a step is re-decorated (#2843).
+	delete(step.Metadata, "gc.session_name")
+	delete(step.Metadata, "gc.session_id")
 	if binding.DirectSessionID != "" {
 		delete(step.Metadata, "gc.routed_to")
+		// Durably record the bound session so consumers (e.g. the dashboard
+		// run-detail session/diff views) can resolve the step's session after
+		// the transient Assignee is cleared on close. (#2843)
+		step.Metadata["gc.session_id"] = binding.DirectSessionID
 		step.Assignee = binding.DirectSessionID
 		return
 	}
@@ -144,6 +152,12 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 	if binding.MetadataOnly {
 		step.Assignee = ""
 		return
+	}
+	if binding.SessionName != "" {
+		// Durable session back-reference for single-session agents (#2843).
+		// Pool agents resolve MetadataOnly above and bind a concrete session
+		// only when a slot claims the step — out of scope for route-time.
+		step.Metadata["gc.session_name"] = binding.SessionName
 	}
 	step.Assignee = binding.SessionName
 }
@@ -153,13 +167,19 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 // "work for this config queue"; using it for a named dispatcher would create
 // config-routed work instead of delivering to the known dispatcher session.
 func ApplyGraphControlRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding) {
+	// Clear any prior session back-references so the metadata matches the
+	// current binding when a control step is re-decorated (#2843).
+	delete(step.Metadata, "gc.session_name")
+	delete(step.Metadata, "gc.session_id")
 	if binding.DirectSessionID != "" {
 		delete(step.Metadata, "gc.routed_to")
+		step.Metadata["gc.session_id"] = binding.DirectSessionID
 		step.Assignee = binding.DirectSessionID
 		return
 	}
 	if binding.SessionName != "" {
 		delete(step.Metadata, "gc.routed_to")
+		step.Metadata["gc.session_name"] = binding.SessionName
 		step.Assignee = binding.SessionName
 		return
 	}
@@ -448,6 +468,11 @@ func DecorateGraphWorkflowRecipe(recipe *formula.Recipe, routeVars map[string]st
 			// (fixes #2763; gc.run_target retired as a wire field — ga-eld2x).
 			step.Metadata["gc.routed_to"] = routedTo
 			delete(step.Metadata, "gc.run_target")
+			if sessionName != "" {
+				// Durable session back-reference on the run root for
+				// single-session agents (#2843). Empty for pool agents.
+				step.Metadata["gc.session_name"] = sessionName
+			}
 			if sourceBeadID != "" {
 				step.Metadata["gc.source_bead_id"] = sourceBeadID
 				if rootStoreRef != "" {

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -255,6 +255,11 @@ func TestDecorateGraphWorkflowRecipe_SetsRootMetadata(t *testing.T) {
 	if _, ok := root.Metadata["gc.run_target"]; ok {
 		t.Errorf("root still carries retired gc.run_target = %q", root.Metadata["gc.run_target"])
 	}
+	// #2843: the run root carries a durable session back-reference (the
+	// dashboard root-only snapshot reads this) for single-session agents.
+	if root.Metadata["gc.session_name"] != "test--mayor" {
+		t.Errorf("root gc.session_name = %q, want test--mayor", root.Metadata["gc.session_name"])
+	}
 	if root.Metadata["gc.source_bead_id"] != "src-1" {
 		t.Errorf("root gc.source_bead_id = %q, want src-1", root.Metadata["gc.source_bead_id"])
 	}

--- a/internal/graphroute/session_stamp_test.go
+++ b/internal/graphroute/session_stamp_test.go
@@ -1,0 +1,70 @@
+package graphroute
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+// #2843: run/step beads must carry a durable session back-reference so
+// consumers (the dashboard run-detail session + diff views) can resolve a
+// step's session after the transient Assignee is cleared on close.
+
+func TestApplyGraphRouteBinding_StampsSessionName(t *testing.T) {
+	step := &formula.RecipeStep{ID: "s1", Metadata: map[string]string{}}
+	ApplyGraphRouteBinding(step, GraphRouteBinding{QualifiedName: "worker", SessionName: "polecat-gc-123"})
+
+	if got := step.Metadata["gc.session_name"]; got != "polecat-gc-123" {
+		t.Errorf("gc.session_name = %q, want polecat-gc-123 (durable session back-ref)", got)
+	}
+	if step.Assignee != "polecat-gc-123" {
+		t.Errorf("Assignee = %q, want polecat-gc-123", step.Assignee)
+	}
+	if step.Metadata["gc.routed_to"] != "worker" {
+		t.Errorf("gc.routed_to = %q, want worker", step.Metadata["gc.routed_to"])
+	}
+}
+
+func TestApplyGraphRouteBinding_PoolMetadataOnly_NoSessionName(t *testing.T) {
+	// Pool agents resolve MetadataOnly — no concrete session at route time,
+	// so no gc.session_name (it binds when a slot claims the step).
+	step := &formula.RecipeStep{ID: "s1", Metadata: map[string]string{}}
+	ApplyGraphRouteBinding(step, GraphRouteBinding{QualifiedName: "/home/ds/gascity/polecat", MetadataOnly: true})
+
+	if _, ok := step.Metadata["gc.session_name"]; ok {
+		t.Errorf("pool MetadataOnly step must not carry gc.session_name, got %q", step.Metadata["gc.session_name"])
+	}
+	if step.Assignee != "" {
+		t.Errorf("pool Assignee = %q, want empty", step.Assignee)
+	}
+	if step.Metadata["gc.routed_to"] != "/home/ds/gascity/polecat" {
+		t.Errorf("gc.routed_to = %q, want the pool target", step.Metadata["gc.routed_to"])
+	}
+}
+
+func TestApplyGraphRouteBinding_DirectSession_StampsSessionID(t *testing.T) {
+	step := &formula.RecipeStep{ID: "s1", Metadata: map[string]string{"gc.routed_to": "stale"}}
+	ApplyGraphRouteBinding(step, GraphRouteBinding{DirectSessionID: "gc-abc123"})
+
+	if got := step.Metadata["gc.session_id"]; got != "gc-abc123" {
+		t.Errorf("gc.session_id = %q, want gc-abc123", got)
+	}
+	if step.Assignee != "gc-abc123" {
+		t.Errorf("Assignee = %q, want gc-abc123", step.Assignee)
+	}
+	if _, ok := step.Metadata["gc.routed_to"]; ok {
+		t.Errorf("direct-session step should drop gc.routed_to, still present")
+	}
+}
+
+func TestApplyGraphControlRouteBinding_StampsSessionName(t *testing.T) {
+	step := &formula.RecipeStep{ID: "ctl", Metadata: map[string]string{}}
+	ApplyGraphControlRouteBinding(step, GraphRouteBinding{SessionName: "gascity--control-dispatcher"})
+
+	if got := step.Metadata["gc.session_name"]; got != "gascity--control-dispatcher" {
+		t.Errorf("control gc.session_name = %q, want the dispatcher session", got)
+	}
+	if step.Assignee != "gascity--control-dispatcher" {
+		t.Errorf("control Assignee = %q, want the dispatcher session", step.Assignee)
+	}
+}


### PR DESCRIPTION
Closes #2843.

## Summary

Graph.v2 run/step beads carry no execution metadata, so consumers (the gas-city-dashboard run-detail **session** and **diff** views) can't resolve which session ran a run/step or in which worktree — every run resolves `execution-path: unavailable (missing_cwd_and_rig_root)` and `session: { kind: none }`.

This stamps a durable `gc.session_name` + `gc.work_dir` back-reference, via **two paths matched to where the concrete session actually becomes known**:

- **Single-session agents — route time** (`internal/graphroute/graphroute.go`): `ApplyGraphRouteBinding` stamps `gc.session_name` (and `gc.session_id` for direct-session routing); `ApplyGraphControlRouteBinding` likewise; the run-root branch in `DecorateGraphWorkflowRecipe` stamps `gc.session_name`. `cmd/gc/cmd_sling.go` mirrors the root stamp in its CLI-local decorator. This survives the transient `Assignee` being cleared on close.

- **Pool agents — execution time** (`cmd/gc/build_desired_state.go`): pool steps resolve `MetadataOnly` at routing time (no concrete session yet), so `stampRunSessionIdentity` — which already stamps in-progress assigned step beads from their session bead — now also **back-fills the step's workflow root** (`gc.root_bead_id`) with the same `gc.session_name` + `gc.work_dir`. The molecule root (`gc.kind=workflow`) is a control-lane bead, never `in_progress`+assigned, so it's never stamped at route time for pool runs — but the dashboard's root-only snapshot reads the **root's own** metadata, so a worked step propagates up. Idempotent, deduped per pass, best-effort.

Together these light up the session drill-in and the local-worktree diff (via `gc.work_dir`) with **zero consumer change** — the dashboard already reads both keys (`backend/src/runs/session-link.ts`, `execution-path.ts`).

## Coverage

- Single-session formula runs (named sessions, control-dispatchers) — resolve at route time.
- Pool multi-step molecule runs (`mol-focus-review`, `mol-do-work`) — root stamped as steps execute.
- **Known limitation:** a pool run that opens *and* closes within a single reconcile tick isn't caught (the existing `stampRunSessionIdentity` best-effort bound). Multi-step molecules run long enough; only trivial single-shot runs slip through.

Pairs with / can supersede #2823 for the local-worktree diff case; #2823 remains the path for cross-host diffs.

## Testing

- `internal/graphroute/session_stamp_test.go` (new) — route-time stamp across all binding paths (session-name, MetadataOnly/pool, direct-session, control).
- `internal/graphroute/graphroute_test.go` — root-stamp assertion in `DecorateGraphWorkflowRecipe`.
- `cmd/gc/build_desired_state_session_stamp_test.go` — root propagation from a worked step + idempotency.
- `make build`, `go vet`, `gofumpt`, and the touched-package suites pass; no regression.
