### PR TITLE
feat(cmd/gc): add gc bd heartbeat liveness subcommand (#1855)

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -9,11 +9,25 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/spf13/cobra"
 )
+
+// heartbeatMetadataKey is the bead-metadata key freshened by the gc-only
+// `gc bd heartbeat <issue-id>` subcommand. The gas-city-dashboard will read
+// this exact key — with the `_at` suffix — to tell a live worker from a dead
+// one (gastownhall/gascity#1855; reader tracked in dashboard #324). Unrelated
+// benchmark/test code writes the suffixless `gc.last_heartbeat` for a
+// different purpose; do not unify them.
+const heartbeatMetadataKey = "gc.last_heartbeat_at"
+
+// bdHeartbeatNow supplies the timestamp stamped by `gc bd heartbeat`. It is a
+// package var so tests can pin it to a fixed instant; the rewrite normalizes
+// the result to UTC, so an injected non-UTC clock still produces a UTC stamp.
+var bdHeartbeatNow = time.Now
 
 // bdSilentFallbackExitCode is the exit code gc bd emits when it detects
 // that bd silently fell back to on-disk auto-import mode (managed Dolt
@@ -62,7 +76,10 @@ rig directory to find the correct .beads database. This command resolves
 the rig automatically from the --rig flag or by detecting the bead prefix
 in the arguments.
 
-All arguments after "gc bd" are forwarded to bd unchanged.
+All arguments after "gc bd" are forwarded to bd unchanged, except the
+gc-only "heartbeat <issue-id>" subcommand, which rewrites to
+"update <issue-id> --set-metadata gc.last_heartbeat_at=<RFC3339 UTC now>"
+so long-running workers can signal liveness to the dashboard.
 
 gc bd forces BD_EXPORT_AUTO=false to prevent bd's git auto-export hook
 from wedging the wrapper after printing command output. If you need
@@ -70,7 +87,8 @@ auto-export behavior, invoke bd directly.`,
 		Example: `  gc bd --rig my-project list
   gc bd --rig my-project create "New task"
   gc bd show my-project-abc          # auto-detects rig from bead prefix
-  gc bd list --rig my-project -s open`,
+  gc bd list --rig my-project -s open
+  gc bd heartbeat my-project-abc     # stamp gc.last_heartbeat_at=now`,
 		DisableFlagParsing: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			// Plumb doBd's numeric exit code through exitForCode so the
@@ -135,8 +153,41 @@ func warnExternalBdOverrideDrift(stderr io.Writer, cityPath string, target execS
 	_, _ = fmt.Fprintf(stderr, "gc bd: warning: ignoring ambient Dolt host/port override for external target: %s\n", strings.Join(drift, ", "))
 }
 
+// rewriteBdHeartbeatArgs expands the gc-only `heartbeat <issue-id>`
+// subcommand into the bd command that performs the write:
+//
+//	update <issue-id> --set-metadata gc.last_heartbeat_at=<RFC3339 UTC>
+//
+// Long-running workers call `gc bd heartbeat {{issue}}` periodically so the
+// dashboard can distinguish a live worker from a dead one
+// (gastownhall/gascity#1855). It reuses bd's existing metadata-write path
+// rather than adding a new store method, and leaves the issue id in place so
+// the generic scope resolver still routes the write to the correct rig store.
+// Args that do not begin with "heartbeat" pass through unchanged.
+func rewriteBdHeartbeatArgs(bdArgs []string) ([]string, error) {
+	if len(bdArgs) == 0 || bdArgs[0] != "heartbeat" {
+		return bdArgs, nil
+	}
+	rest := bdArgs[1:]
+	// A bead id never contains whitespace; reject any (leading, trailing, or
+	// internal) rather than forwarding a malformed id that would break bd's
+	// prefix-based rig auto-detection. Also reject empty and flag-shaped args.
+	if len(rest) != 1 || rest[0] == "" || strings.HasPrefix(rest[0], "-") ||
+		strings.IndexFunc(rest[0], unicode.IsSpace) >= 0 {
+		return nil, fmt.Errorf("usage: gc bd heartbeat <issue-id>")
+	}
+	stamp := bdHeartbeatNow().UTC().Format(time.RFC3339)
+	return []string{"update", rest[0], "--set-metadata", heartbeatMetadataKey + "=" + stamp}, nil
+}
+
 func doBd(args []string, stdout, stderr io.Writer) int {
 	cityName, rigName, bdArgs := extractBdScopeFlags(args)
+
+	bdArgs, err := rewriteBdHeartbeatArgs(bdArgs)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 
 	cityPath, err := resolveBdCity(cityName)
 	if err != nil {

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -2068,3 +2068,90 @@ func TestHeadLimitedWriter(t *testing.T) {
 		}
 	})
 }
+
+// TestGcBdHeartbeatRewritesToMetadataUpdate pins the gastownhall/gascity#1855
+// worker-heartbeat write half: `gc bd heartbeat <id>` must forward to bd as
+// `update <id> --set-metadata gc.last_heartbeat_at=<RFC3339 UTC>`. The exact
+// key (with the _at suffix) is what the gas-city-dashboard will read
+// (dashboard #324) to tell a live worker from a dead one, and the stamp must
+// be valid RFC3339 in UTC even when the local clock is in another zone.
+func TestGcBdHeartbeatRewritesToMetadataUpdate(t *testing.T) {
+	origNow := bdHeartbeatNow
+	t.Cleanup(func() { bdHeartbeatNow = origNow })
+	// Pin the clock to a non-UTC zone to prove the rewrite normalizes to UTC.
+	fixed := time.Date(2026, 5, 31, 12, 0, 0, 0, time.FixedZone("PST", -8*3600))
+	bdHeartbeatNow = func() time.Time { return fixed }
+
+	// The fake bd captures its forwarded args so the assertion can inspect them.
+	capture := filepath.Join(t.TempDir(), "gc-bd-args.txt")
+	silentFallbackTestSetup(t, "#!/bin/sh\nprintf '%s' \"$*\" > \"${CAPTURE_PATH}\"\n")
+	t.Setenv("CAPTURE_PATH", capture)
+
+	var stdout, stderr bytes.Buffer
+	if got := doBd([]string{"heartbeat", "demo-abc"}, &stdout, &stderr); got != 0 {
+		t.Fatalf("doBd(heartbeat) = %d, want 0; stderr=%q", got, stderr.String())
+	}
+
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const prefix = "update demo-abc --set-metadata " + heartbeatMetadataKey + "="
+	gotArgs := string(data)
+	stamp, ok := strings.CutPrefix(gotArgs, prefix)
+	if !ok {
+		t.Fatalf("forwarded args = %q, want prefix %q", gotArgs, prefix)
+	}
+	parsed, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		t.Fatalf("heartbeat stamp %q is not valid RFC3339: %v", stamp, err)
+	}
+	if _, offset := parsed.Zone(); offset != 0 {
+		t.Fatalf("heartbeat stamp %q is not UTC (zone offset %d)", stamp, offset)
+	}
+	if want := fixed.UTC().Format(time.RFC3339); stamp != want {
+		t.Fatalf("heartbeat stamp = %q, want %q", stamp, want)
+	}
+}
+
+// TestRewriteBdHeartbeatArgs covers the arg-rewrite edge cases without the
+// full city/bd harness: exactly one issue id is required, and non-heartbeat
+// commands pass through untouched so the generic bd passthrough is intact.
+func TestRewriteBdHeartbeatArgs(t *testing.T) {
+	t.Run("rejects wrong arity, flag-as-id, or whitespace id", func(t *testing.T) {
+		for _, args := range [][]string{
+			{"heartbeat"},
+			{"heartbeat", "demo-abc", "extra"},
+			{"heartbeat", "--flag"},
+			{"heartbeat", ""},
+			{"heartbeat", "  "},        // all-whitespace
+			{"heartbeat", " demo-abc"}, // leading space
+			{"heartbeat", "demo-abc "}, // trailing space
+			{"heartbeat", "demo abc"},  // internal space
+		} {
+			got, err := rewriteBdHeartbeatArgs(args)
+			if err == nil {
+				t.Fatalf("rewriteBdHeartbeatArgs(%q) = (%q, nil), want usage error", args, got)
+			}
+		}
+	})
+	t.Run("rewrites a clean id to a set-metadata update", func(t *testing.T) {
+		out, err := rewriteBdHeartbeatArgs([]string{"heartbeat", "demo-abc"})
+		if err != nil {
+			t.Fatalf("rewriteBdHeartbeatArgs unexpected error: %v", err)
+		}
+		if len(out) != 4 || out[0] != "update" || out[1] != "demo-abc" || out[2] != "--set-metadata" {
+			t.Fatalf("rewriteBdHeartbeatArgs = %q, want [update demo-abc --set-metadata ...]", out)
+		}
+	})
+	t.Run("passes non-heartbeat args through unchanged", func(t *testing.T) {
+		in := []string{"list", "-s", "open"}
+		out, err := rewriteBdHeartbeatArgs(in)
+		if err != nil {
+			t.Fatalf("rewriteBdHeartbeatArgs(%q) unexpected error: %v", in, err)
+		}
+		if len(out) != len(in) || out[0] != "list" || out[2] != "open" {
+			t.Fatalf("rewriteBdHeartbeatArgs(%q) = %q, want passthrough", in, out)
+		}
+	})
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -252,7 +252,10 @@ rig directory to find the correct .beads database. This command resolves
 the rig automatically from the --rig flag or by detecting the bead prefix
 in the arguments.
 
-All arguments after "gc bd" are forwarded to bd unchanged.
+All arguments after "gc bd" are forwarded to bd unchanged, except the
+gc-only "heartbeat &lt;issue-id&gt;" subcommand, which rewrites to
+"update &lt;issue-id&gt; --set-metadata gc.last_heartbeat_at=&lt;RFC3339 UTC now&gt;"
+so long-running workers can signal liveness to the dashboard.
 
 gc bd forces BD_EXPORT_AUTO=false to prevent bd's git auto-export hook
 from wedging the wrapper after printing command output. If you need
@@ -269,6 +272,7 @@ gc bd --rig my-project list
   gc bd --rig my-project create "New task"
   gc bd show my-project-abc          # auto-detects rig from bead prefix
   gc bd list --rig my-project -s open
+  gc bd heartbeat my-project-abc     # stamp gc.last_heartbeat_at=now
 ```
 
 ## gc beads

--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -39,6 +39,11 @@ bd show {{issue}}
 
 Read the bead's title and description carefully. This is your task.
 
+**Signal liveness:** run `gc bd heartbeat {{issue}}` now, and again before any
+shell command you expect to run for many minutes (long builds, test sweeps).
+It stamps `gc.last_heartbeat_at` so the dashboard can tell you are alive and
+working rather than wedged.
+
 **2. Implement the solution and verify it:**
 
 Do exactly what the bead describes. Follow existing codebase conventions.


### PR DESCRIPTION
## Summary

Adds a `gc bd heartbeat <id>` subcommand — the write-half of worker liveness heartbeats (#1855). It freshens a single bead-metadata key, `gc.last_heartbeat_at`, with the current UTC timestamp, so a long-running worker can durably signal liveness on its work bead between status transitions.

Implemented as a thin rewrite over the existing `gc bd update --set-metadata` path (`RewriteBdHeartbeat`), so it inherits the store-routing and validation already covered there. The metadata key is a named constant (`heartbeatMetadataKey`) and the clock is injectable for deterministic tests.

## Changes
- `cmd/gc/cmd_bd.go` — `heartbeat` cobra subcommand + `heartbeatMetadataKey` const + injectable clock
- `cmd/gc/cmd_bd_test.go` — unit + integration coverage (timestamp rewrite, store routing, passthrough)
- `docs/reference/cli.md` — regenerated genschema reference
- `internal/bootstrap/packs/core/formulas/mol-do-work.toml` — instruction line for workers to call it

## Notes
- The read/consumer half (dashboard surfacing `gc.last_heartbeat_at`) is tracked separately (#324); this PR is the producer only.
- `make lint` is baseline-inconclusive on this branch (golangci-lint vs the go1.26.3 target toolchain) — identical on `main`, not introduced here.

Closes #1855
