### PR TITLE
fix(mail): refresh read-message retention purge

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -204,11 +204,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 	it := buildIdleTracker(p.Cfg, p.CityName, p.CityPath, p.SP)
 	mat := buildMaxSessionAgeTracker(p.Cfg, p.CityName, p.SP)
 
-	var wg wispGC
-	if p.Cfg.Daemon.WispGCEnabled() {
-		wg = newWispGC(p.Cfg.Daemon.WispGCIntervalDuration(),
-			p.Cfg.Daemon.WispTTLDuration())
-	}
+	wg := newWispGCForConfig(p.Cfg)
 
 	managedDoltHealth := p.ManagedDoltHealth
 	if managedDoltHealth == nil {
@@ -1677,12 +1673,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	cr.it = buildIdleTracker(nextCfg, cr.cityName, cr.cityPath, nextSp)
 	cr.mat = buildMaxSessionAgeTracker(nextCfg, cr.cityName, nextSp)
 
-	if nextCfg.Daemon.WispGCEnabled() {
-		cr.wg = newWispGC(nextCfg.Daemon.WispGCIntervalDuration(),
-			nextCfg.Daemon.WispTTLDuration())
-	} else {
-		cr.wg = nil
-	}
+	cr.wg = newWispGCForConfig(nextCfg)
 
 	// Drain the outgoing dispatcher before replacing it so in-flight
 	// dispatchOne goroutines persist their tracking-bead outcomes against

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -3,10 +3,14 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
+
+const mailReadMetadataKey = "mail.read"
 
 // wispGC performs mechanical garbage collection of closed molecules that
 // have exceeded their TTL. Follows the nil-guard tracker pattern used by
@@ -24,21 +28,35 @@ type wispGC interface {
 
 // memoryWispGC is the production implementation of wispGC.
 type memoryWispGC struct {
-	interval time.Duration
-	ttl      time.Duration
-	lastRun  time.Time
+	interval         time.Duration
+	ttl              time.Duration
+	mailRetentionTTL time.Duration
+	lastRun          time.Time
 }
 
-// newWispGC creates a wisp GC tracker. Returns nil if disabled (interval or
-// TTL is zero). Callers nil-guard before use.
-func newWispGC(interval, ttl time.Duration) wispGC {
-	if interval <= 0 || ttl <= 0 {
+// newWispGC creates a wisp GC tracker. Returns nil if disabled. The tracker
+// runs when an interval is configured and at least one retention policy is
+// enabled.
+func newWispGC(interval, ttl, mailRetentionTTL time.Duration) wispGC {
+	if interval <= 0 || (ttl <= 0 && mailRetentionTTL <= 0) {
 		return nil
 	}
 	return &memoryWispGC{
-		interval: interval,
-		ttl:      ttl,
+		interval:         interval,
+		ttl:              ttl,
+		mailRetentionTTL: mailRetentionTTL,
 	}
+}
+
+func newWispGCForConfig(cfg *config.City) wispGC {
+	if cfg == nil {
+		return nil
+	}
+	mailRetentionTTL, err := cfg.Mail.RetentionTTLDuration()
+	if err != nil {
+		mailRetentionTTL = 0
+	}
+	return newWispGC(cfg.Daemon.WispGCIntervalDuration(), cfg.Daemon.WispTTLDuration(), mailRetentionTTL)
 }
 
 func (m *memoryWispGC) shouldRun(now time.Time) bool {
@@ -51,21 +69,41 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 		return 0, fmt.Errorf("listing closed molecules: bead store unavailable")
 	}
 
-	entries, err := closedWispGCEntries(store)
-	if err != nil {
-		return 0, err
+	purged := 0
+	var deleteErr error
+	if m.ttl > 0 {
+		entries, err := closedWispGCEntries(store)
+		if err != nil {
+			return 0, err
+		}
+
+		cutoff := now.Add(-m.ttl)
+		closurePurged, closureDeleteErr := purgeExpiredBeadClosures(store, entries, cutoff)
+		purged += closurePurged
+		deleteErr = errors.Join(deleteErr, closureDeleteErr)
+
+		trackEntries, trackErr := store.List(beads.ListQuery{Status: "closed", Label: labelOrderTracking, TierMode: beads.TierBoth})
+		if trackErr == nil {
+			trackPurged, trackDeleteErr := purgeExpiredBeadRoots(store, trackEntries, cutoff)
+			purged += trackPurged
+			deleteErr = errors.Join(deleteErr, trackDeleteErr)
+		} else {
+			deleteErr = errors.Join(deleteErr, fmt.Errorf("listing closed order-tracking beads: %w", trackErr))
+		}
 	}
 
-	cutoff := now.Add(-m.ttl)
-	purged, deleteErr := purgeExpiredBeadClosures(store, entries, cutoff)
-
-	trackEntries, trackErr := store.List(beads.ListQuery{Status: "closed", Label: labelOrderTracking, TierMode: beads.TierBoth})
-	if trackErr == nil {
-		trackPurged, trackDeleteErr := purgeExpiredBeadRoots(store, trackEntries, cutoff)
-		purged += trackPurged
-		deleteErr = errors.Join(deleteErr, trackDeleteErr)
-	} else {
-		deleteErr = errors.Join(deleteErr, fmt.Errorf("listing closed order-tracking beads: %w", trackErr))
+	if m.mailRetentionTTL > 0 {
+		mailEntries, mailErr := readMessageWispGCEntries(store)
+		if mailErr == nil {
+			mailPurged, mailDeleteErr := purgeExpiredBeadRoots(store, mailEntries, now.Add(-m.mailRetentionTTL))
+			purged += mailPurged
+			deleteErr = errors.Join(deleteErr, mailDeleteErr)
+			if mailPurged > 0 {
+				log.Printf("wisp gc: purged %d read message wisps (retention_ttl=%s)", mailPurged, gcRetentionTTLString(m.mailRetentionTTL))
+			}
+		} else {
+			deleteErr = errors.Join(deleteErr, fmt.Errorf("listing read message wisps: %w", mailErr))
+		}
 	}
 
 	return purged, deleteErr
@@ -96,6 +134,19 @@ func closedWispGCEntries(store beads.Store) ([]beads.Bead, error) {
 		return nil, fmt.Errorf("listing closed wisp roots: %w", err)
 	}
 	appendUnique(wisps)
+	return entries, nil
+}
+
+func readMessageWispGCEntries(store beads.Store) ([]beads.Bead, error) {
+	entries, err := store.List(beads.ListQuery{
+		Type:          "message",
+		Metadata:      map[string]string{mailReadMetadataKey: "true"},
+		IncludeClosed: true,
+		TierMode:      beads.TierWisps,
+	})
+	if err != nil {
+		return nil, err
+	}
 	return entries, nil
 }
 
@@ -211,4 +262,11 @@ func collectExpiredBeadClosure(store beads.Store, rootID string) ([]string, erro
 		return nil, err
 	}
 	return ids, nil
+}
+
+func gcRetentionTTLString(d time.Duration) string {
+	if d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	return d.String()
 }

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestWispGC_NilSafe(t *testing.T) {
@@ -18,18 +21,18 @@ func TestWispGC_NilSafe(t *testing.T) {
 }
 
 func TestWispGC_DisabledReturnsNil(t *testing.T) {
-	wg := newWispGC(0, time.Hour)
+	wg := newWispGC(0, time.Hour, 0)
 	if wg != nil {
 		t.Error("zero interval should return nil")
 	}
-	wg = newWispGC(time.Hour, 0)
+	wg = newWispGC(time.Hour, 0, 0)
 	if wg != nil {
 		t.Error("zero TTL should return nil")
 	}
 }
 
 func TestWispGC_ShouldRunRespectsInterval(t *testing.T) {
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	now := time.Now()
 
 	if !wg.shouldRun(now) {
@@ -47,6 +50,24 @@ func TestWispGC_ShouldRunRespectsInterval(t *testing.T) {
 	}
 }
 
+func TestWispGCForConfigUsesMailRetentionTTL(t *testing.T) {
+	cfg := &config.City{}
+	cfg.Daemon.WispGCInterval = "5m"
+	cfg.Mail.RetentionTTL = "1h"
+
+	wg := newWispGCForConfig(cfg)
+	if wg == nil {
+		t.Fatal("newWispGCForConfig returned nil")
+	}
+	memory := wg.(*memoryWispGC)
+	if memory.ttl != 0 {
+		t.Fatalf("ttl = %v, want 0", memory.ttl)
+	}
+	if memory.mailRetentionTTL != time.Hour {
+		t.Fatalf("mailRetentionTTL = %v, want 1h", memory.mailRetentionTTL)
+	}
+}
+
 func TestWispGC_PurgesExpiredMolecules(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
@@ -56,7 +77,7 @@ func TestWispGC_PurgesExpiredMolecules(t *testing.T) {
 		makeGCBead("mol-3", now.Add(-3*time.Hour), "closed", "molecule"),
 	})
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -73,7 +94,7 @@ func TestWispGC_NothingExpired(t *testing.T) {
 		makeGCBead("mol-1", now.Add(-10*time.Minute), "closed", "molecule"),
 	})
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -86,9 +107,94 @@ func TestWispGC_NothingExpired(t *testing.T) {
 	}
 }
 
+func TestWispGC_PurgesExpiredReadMessageRetention(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCMessageWisp("read-old", now.Add(-2*time.Hour), map[string]string{mailReadMetadataKey: "true"}),
+		makeGCMessageWisp("unread-old", now.Add(-2*time.Hour), map[string]string{mailReadMetadataKey: "false"}),
+		makeGCMessageWisp("unset-old", now.Add(-2*time.Hour), nil),
+		makeGCMessageWisp("read-recent", now.Add(-30*time.Minute), map[string]string{mailReadMetadataKey: "true"}),
+		{
+			ID:        "read-main-tier",
+			Status:    "open",
+			Type:      "message",
+			CreatedAt: now.Add(-2 * time.Hour),
+			Metadata:  map[string]string{mailReadMetadataKey: "true"},
+		},
+		{
+			ID:        "read-task-wisp",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			Metadata:  map[string]string{mailReadMetadataKey: "true"},
+			Ephemeral: true,
+		},
+	})
+
+	wg := newWispGC(5*time.Minute, 0, time.Hour)
+	if wg == nil {
+		t.Fatal("mail retention should enable wisp GC when interval is configured")
+	}
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "read-old")
+	for _, id := range []string{"unread-old", "unset-old", "read-recent", "read-main-tier", "read-task-wisp"} {
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("%s should be preserved: %v", id, err)
+		}
+	}
+}
+
+func TestWispGC_ReadMessageRetentionZeroDisablesAndSuppressesLog(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCMessageWisp("read-old", now.Add(-2*time.Hour), map[string]string{mailReadMetadataKey: "true"}),
+	})
+
+	logOutput := captureWispGCLog(t, func() {
+		wg := newWispGC(5*time.Minute, time.Hour, 0)
+		purged, err := wg.runGC(store, now)
+		if err != nil {
+			t.Fatalf("runGC: %v", err)
+		}
+		if purged != 0 {
+			t.Fatalf("purged = %d, want 0", purged)
+		}
+	})
+	if strings.Contains(logOutput, "read message wisps") {
+		t.Fatalf("log output = %q, want no read-message purge log", logOutput)
+	}
+	if _, err := store.Get("read-old"); err != nil {
+		t.Fatalf("read-old should be preserved: %v", err)
+	}
+}
+
+func TestWispGC_ReadMessageRetentionLogsCountAndTTL(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCMessageWisp("read-old", now.Add(-2*time.Hour), map[string]string{mailReadMetadataKey: "true"}),
+	})
+
+	logOutput := captureWispGCLog(t, func() {
+		wg := newWispGC(5*time.Minute, 0, time.Hour)
+		if _, err := wg.runGC(store, now); err != nil {
+			t.Fatalf("runGC: %v", err)
+		}
+	})
+	want := "wisp gc: purged 1 read message wisps (retention_ttl=1h)"
+	if !strings.Contains(logOutput, want) {
+		t.Fatalf("log output = %q, want %q", logOutput, want)
+	}
+}
+
 func TestWispGC_EmptyList(t *testing.T) {
 	store := newGCStore(nil)
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, time.Now())
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -106,7 +212,7 @@ func TestWispGC_DeleteErrorIsSurfacedAndContinues(t *testing.T) {
 	})
 	store.deleteErrors["mol-1"] = fmt.Errorf("delete failed")
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err == nil {
 		t.Fatal("expected delete error to be surfaced")
@@ -146,7 +252,7 @@ func TestWispGC_PurgesExpiredMoleculeChildrenWithRoot(t *testing.T) {
 		t.Fatalf("DepAdd(mol-1.2->mol-1.1): %v", err)
 	}
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -182,7 +288,7 @@ func TestWispGC_DoesNotDeleteExternalDependents(t *testing.T) {
 		t.Fatalf("DepAdd(external-1->mol-1.1): %v", err)
 	}
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -221,7 +327,7 @@ func TestWispGC_PurgesParentChildOwnedDependentsWithoutMetadata(t *testing.T) {
 		t.Fatalf("DepAdd(mol-1.2->mol-1.1): %v", err)
 	}
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -249,7 +355,7 @@ func TestWispGC_LeavesRootWhenChildDeleteFails(t *testing.T) {
 	}
 	store.deleteErrors["mol-1.1"] = fmt.Errorf("delete failed")
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err == nil {
 		t.Fatal("expected child delete error")
@@ -308,7 +414,7 @@ func TestWispGC_PartialChildDeleteRemainsRetryable(t *testing.T) {
 	}
 	store.deleteErrors["mol-1.2"] = fmt.Errorf("delete failed")
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err == nil {
 		t.Fatal("expected first pass child delete error")
@@ -354,7 +460,7 @@ func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
 		makeGCBeadWithLabels("track-open", now.Add(-5*time.Hour), "open", "task", labelOrderTracking),
 	})
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -377,7 +483,7 @@ func TestWispGC_PurgesLegacyIssuesTierTrackingBeads(t *testing.T) {
 		},
 	})
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -396,7 +502,7 @@ func TestWispGC_TrackingListErrorIsSurfacedAndMoleculePurgeContinues(t *testing.
 	})
 	store.listErrors[gcQueryKey{Status: "closed", Label: labelOrderTracking}] = fmt.Errorf("tracking list failed")
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err == nil {
 		t.Fatal("expected tracking list error to be surfaced")
@@ -426,7 +532,7 @@ func TestWispGC_TrackingBeadsDoNotDeleteParentChildDescendants(t *testing.T) {
 		t.Fatalf("DepAdd(track-child->track-old): %v", err)
 	}
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
@@ -444,7 +550,7 @@ func TestWispGC_ListErrorFailsRun(t *testing.T) {
 	store := newGCStore(nil)
 	store.listErrors[gcQueryKey{Status: "closed", Type: "molecule"}] = fmt.Errorf("molecule list failed")
 
-	wg := newWispGC(5*time.Minute, time.Hour)
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	_, err := wg.runGC(store, time.Now())
 	if err == nil {
 		t.Fatal("expected list error")
@@ -520,6 +626,32 @@ func makeGCBeadWithMetadata(id string, createdAt time.Time, status, beadType str
 	bead := makeGCBead(id, createdAt, status, beadType)
 	bead.Metadata = metadata
 	return bead
+}
+
+func makeGCMessageWisp(id string, createdAt time.Time, metadata map[string]string) beads.Bead {
+	return beads.Bead{
+		ID:        id,
+		Status:    "open",
+		Type:      "message",
+		CreatedAt: createdAt,
+		Metadata:  metadata,
+		Ephemeral: true,
+	}
+}
+
+func captureWispGCLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+	}()
+	fn()
+	return buf.String()
 }
 
 func metadataQueryKey(metadata map[string]string) string {

--- a/release-gates/ga-54753d-read-message-retention-purge-gate.md
+++ b/release-gates/ga-54753d-read-message-retention-purge-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: read-message retention purge
+
+- Gate run: 2026-06-01T07:17:40-07:00
+- Deploy bead: ga-54753d
+- Source deploy child: ga-93j6pj.1
+- Review bead: ga-in3cpf
+- Branch: builder/ga-93j6pj-1-retention-purge
+- Input commit: aa621eceb3100c81bd14525e11a34aff81d0ce74
+- Base checked: origin/main at 757d16d25a7100d57c228a44af1733adc2cfeb0d
+- Release criteria source: `docs/PROJECT_MANIFEST.md` is not present in this checkout, so this gate uses the deployer release-gate criteria and the repository guidance in `TESTING.md`.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-in3cpf` is closed and notes contain `REVIEWER VERDICT: PASS (2026-06-01T13:51:58Z)`. Deploy bead `ga-54753d` was routed as reviewed PASS. |
+| 2 | Acceptance criteria met | PASS | Prerequisite retention config slice is merged per `ga-93j6pj.1` notes. Diff from current main contains only `cmd/gc/city_runtime.go`, `cmd/gc/wisp_gc.go`, `cmd/gc/wisp_gc_test.go`, plus this gate artifact. Wisp GC now reads `mail.retention_ttl`, queries only wisp-tier messages with `mail.read=true`, preserves unread/unset/recent/main-tier/non-message beads, disables retention at zero TTL, and logs purge count plus TTL. |
+| 3 | Tests pass | PASS | `make test` passed with observable log `/tmp/gascity-test.jsonl.dm4LbG`. `go vet ./...` passed with no output. |
+| 4 | No high-severity review findings open | PASS | Review notes list two LOW informational findings and no blockers; unresolved HIGH findings count is 0. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` showed a clean feature branch aligned with `origin/builder/ga-93j6pj-1-retention-purge`. This gate file is committed as the branch tip and status is rechecked after commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree HEAD origin/main` exited 0 and produced tree `ef30cb67fa070caca1fb37e48f33561d1c673d9b`. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem and one user-facing behavior: `cmd/gc` wisp GC handling for retained read-message mail cleanup. |
+
+## Acceptance Evidence
+
+- `newWispGCForConfig` wires `cfg.Mail.RetentionTTLDuration()` into the existing daemon wisp GC on startup and reload.
+- `readMessageWispGCEntries` restricts the purge candidate query to `Type: "message"`, `Status: "closed"`, `IncludeClosed: true`, `TierMode: beads.TierWisps`, and metadata `mail.read=true`.
+- `runGC` continues molecule/tracking cleanup and adds the read-message retention purge only when `mail.retention_ttl` is positive.
+- Tests cover config wiring, old read-message purge, zero-retention disable/log suppression, retention count/TTL logging, and the existing molecule/tracking GC paths.
+
+## Diff Scope
+
+`git diff --stat origin/main...HEAD` before this gate artifact:
+
+```text
+cmd/gc/city_runtime.go |  13 +---
+cmd/gc/wisp_gc.go      | 102 +++++++++++++++++++++++-------
+cmd/gc/wisp_gc_test.go | 166 ++++++++++++++++++++++++++++++++++++++++++++-----
+3 files changed, 231 insertions(+), 50 deletions(-)
+```
+
+Final gate result: PASS.


### PR DESCRIPTION
## What this changes

Read message wisps now expire through the normal wisp GC loop when `mail.retention_ttl` is configured. The cleanup is scoped to message beads in the wisp tier with `mail.read=true`, so unread messages, main-tier mail, recent read messages, and non-message wisps are left alone.

The controller builds the wisp GC from the active city config on startup and config reload, so the same daemon interval drives molecule/order-tracking cleanup and retained read-message cleanup without adding a separate scheduler.

## Review notes

- New behavior is enabled only when `mail.retention_ttl` and the existing daemon wisp GC interval are configured.
- The purge query uses `TierMode: beads.TierWisps` and `mail.read=true` metadata to avoid deleting unread or main-tier messages.
- Invalid mail retention durations are still reported by config validation; the GC constructor treats them as disabled.

## Test plan

- [x] `make test`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-54753d-read-message-retention-purge-gate.md`](release-gates/ga-54753d-read-message-retention-purge-gate.md)