### PR TITLE
fix(dispatch): seed nested ralph first iteration on outer re-spawn (#2798)

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -742,6 +742,18 @@ func buildNestedControlSeed(child *formula.Step, childID string) ([]formula.Reci
 		},
 	}
 	seed := buildAttemptRecipe(child, synthetic, 1)
+	// buildAttemptRecipe marks the seed's root step with IsRoot=true, but once
+	// these steps are merged into the outer attempt recipe they are no longer
+	// roots — the outer recipe already owns its root at Steps[0]. molecule.Attach
+	// applies the attach-root overrides (Type="molecule", Ref, ParentID) to ANY
+	// IsRoot step and maps it as an attach root, so a leftover IsRoot on the
+	// nested seed would corrupt the iteration bead's type/ref/parent and break
+	// dependency wiring. Clear it on every returned seed step. RootStep() below
+	// returns Steps[0] regardless of the flag, so the blocks dep wiring is
+	// unaffected. See gastownhall/gascity#2798.
+	for i := range seed.Steps {
+		seed.Steps[i].IsRoot = false
+	}
 	deps := append([]formula.RecipeDep{}, seed.Deps...)
 	if root := seed.RootStep(); root != nil {
 		// The inner control blocks on its first iteration, exactly as the

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -597,6 +597,8 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 	}
 	var fanoutSteps []formula.RecipeStep
 	var fanoutDeps []formula.RecipeDep
+	var nestedSeedSteps []formula.RecipeStep
+	var nestedSeedDeps []formula.RecipeDep
 
 	// For steps with children (scoped ralph), add children as sub-steps.
 	// Children may have retry/ralph config — propagate their metadata
@@ -667,6 +669,16 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 				if step := newSpecRecipeStep(childID, child); step != nil {
 					recipe.Steps = append(recipe.Steps, *step)
 				}
+				// Seed the nested ralph's first iteration. At compile time
+				// expandNestedRalph seeds iteration.1; the re-spawn path must do
+				// the same so the inner ralph control finds a valid iteration on
+				// every outer iteration, not just the first. Without this seed,
+				// processRalphControl's findLatestAttempt returns empty and fatals
+				// ("no iteration found"), crash-looping all dispatch for the rig.
+				// See gastownhall/gascity#2798.
+				seedSteps, seedDeps := buildNestedControlSeed(child, childID)
+				nestedSeedSteps = append(nestedSeedSteps, seedSteps...)
+				nestedSeedDeps = append(nestedSeedDeps, seedDeps...)
 			}
 			childStep := formula.RecipeStep{
 				ID:          childID,
@@ -705,8 +717,42 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 	applyAttemptRecipeScopeChecks(recipe)
 	recipe.Steps = append(recipe.Steps, fanoutSteps...)
 	recipe.Deps = append(recipe.Deps, fanoutDeps...)
+	// Nested-control seed steps are appended after the outer scope-check pass so
+	// their own scope-checks (already applied by the recursive buildAttemptRecipe
+	// call) are not double-processed against the outer iteration scope.
+	recipe.Steps = append(recipe.Steps, nestedSeedSteps...)
+	recipe.Deps = append(recipe.Deps, nestedSeedDeps...)
 
 	return recipe
+}
+
+// buildNestedControlSeed builds the first-iteration sub-DAG for a nested ralph
+// control re-created during an outer ralph re-spawn. It mirrors the compile-time
+// seeding performed by expandNestedRalph so the inner control starts in a valid
+// state on every outer iteration. childID is the fully namespaced ID of the inner
+// control bead (for example "mol.outer.iteration.2.inner"). The returned steps and
+// deps must be merged after the caller's scope-check pass, since the seed already
+// carries its own scope-checks. See gastownhall/gascity#2798.
+func buildNestedControlSeed(child *formula.Step, childID string) ([]formula.RecipeStep, []formula.RecipeDep) {
+	synthetic := beads.Bead{
+		ID: childID,
+		Metadata: map[string]string{
+			"gc.step_id":  child.ID,
+			"gc.step_ref": childID,
+		},
+	}
+	seed := buildAttemptRecipe(child, synthetic, 1)
+	deps := append([]formula.RecipeDep{}, seed.Deps...)
+	if root := seed.RootStep(); root != nil {
+		// The inner control blocks on its first iteration, exactly as the
+		// compile-time control.Needs wiring does.
+		deps = append(deps, formula.RecipeDep{
+			StepID:      childID,
+			DependsOnID: root.ID,
+			Type:        "blocks",
+		})
+	}
+	return seed.Steps, deps
 }
 
 func buildAttemptRecipeFanoutControl(source formula.RecipeStep, onComplete *formula.OnCompleteSpec) (formula.RecipeStep, formula.RecipeDep, bool) {

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -2085,6 +2085,13 @@ func TestBuildAttemptRecipeSeedsNestedRalphFirstIteration(t *testing.T) {
 	if got := seed.Metadata["gc.step_id"]; got != "inner-loop" {
 		t.Errorf("seed gc.step_id = %q, want inner-loop", got)
 	}
+	// The seed is merged into the outer attempt recipe, which already owns its
+	// root. molecule.Attach maps ANY IsRoot step to the attach root, so the
+	// seed must not carry IsRoot or it corrupts the iteration bead and breaks
+	// wiring. Regression guard for gastownhall/gascity#2798.
+	if seed.IsRoot {
+		t.Error("inner ralph seed iteration must have IsRoot=false")
+	}
 
 	// Inner control must block on its seeded first iteration, exactly as the
 	// compile-time control.Needs wiring does.
@@ -2149,6 +2156,12 @@ func TestBuildAttemptRecipeSeedsNestedRalphWithChildren(t *testing.T) {
 	}
 	if got := scope.Metadata["gc.kind"]; got != "scope" {
 		t.Errorf("inner iteration gc.kind = %q, want scope", got)
+	}
+	// Merged into the outer recipe, the seed scope must not be IsRoot —
+	// molecule.Attach maps any IsRoot step to the attach root, which would
+	// corrupt the iteration bead. Regression guard for gastownhall/gascity#2798.
+	if scope.IsRoot {
+		t.Error("inner ralph seed iteration scope must have IsRoot=false")
 	}
 
 	// Inner iteration members must be seeded under the inner iteration scope.

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -2027,6 +2027,154 @@ func TestBuildAttemptRecipeRalphWithChildren(t *testing.T) {
 	}
 }
 
+func TestBuildAttemptRecipeSeedsNestedRalphFirstIteration(t *testing.T) {
+	t.Parallel()
+
+	// Outer ralph whose body contains an inner ralph (ralph-in-ralph). On outer
+	// iterations >= 2 the re-spawn path must seed the inner ralph's first
+	// iteration, mirroring compile-time expandNestedRalph. Without the seed,
+	// processRalphControl's findLatestAttempt returns empty and fatals
+	// ("no iteration found"), crash-looping all dispatch.
+	// Regression for gastownhall/gascity#2798.
+	inner := &formula.Step{
+		ID:    "inner-loop",
+		Title: "Inner loop",
+		Type:  "task",
+		Ralph: &formula.RalphSpec{
+			MaxAttempts: 3,
+			Check:       &formula.RalphCheckSpec{Mode: "exec", Path: "inner-check.sh"},
+		},
+	}
+	step := &formula.Step{
+		ID:    "outer-loop",
+		Title: "Outer loop",
+		Type:  "task",
+		Ralph: &formula.RalphSpec{
+			MaxAttempts: 5,
+			Check:       &formula.RalphCheckSpec{Mode: "exec", Path: "outer-check.sh"},
+		},
+		Children: []*formula.Step{inner},
+	}
+	control := beads.Bead{
+		ID: "gc-outer",
+		Metadata: map[string]string{
+			"gc.step_id":  "outer-loop",
+			"gc.step_ref": "mol-test.outer-loop",
+		},
+	}
+
+	// Outer iteration 2 — the iteration that crash-looped before the fix.
+	recipe := buildAttemptRecipe(step, control, 2)
+
+	innerControlID := "mol-test.outer-loop.iteration.2.inner-loop"
+	innerIterationID := innerControlID + ".iteration.1"
+
+	if recipe.StepByID(innerControlID) == nil {
+		t.Fatalf("missing inner ralph control %q", innerControlID)
+	}
+	seed := recipe.StepByID(innerIterationID)
+	if seed == nil {
+		t.Fatalf("inner ralph first iteration %q not seeded; deps=%+v", innerIterationID, recipe.Deps)
+	}
+	if got := seed.Metadata["gc.attempt"]; got != "1" {
+		t.Errorf("seed gc.attempt = %q, want 1", got)
+	}
+	if got := seed.Metadata["gc.step_ref"]; got != innerIterationID {
+		t.Errorf("seed gc.step_ref = %q, want %q", got, innerIterationID)
+	}
+	if got := seed.Metadata["gc.step_id"]; got != "inner-loop" {
+		t.Errorf("seed gc.step_id = %q, want inner-loop", got)
+	}
+
+	// Inner control must block on its seeded first iteration, exactly as the
+	// compile-time control.Needs wiring does.
+	found := false
+	for _, dep := range recipe.Deps {
+		if dep.StepID == innerControlID && dep.DependsOnID == innerIterationID && dep.Type == "blocks" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing dep: inner control %q blocks on seed %q; deps=%+v",
+			innerControlID, innerIterationID, recipe.Deps)
+	}
+}
+
+func TestBuildAttemptRecipeSeedsNestedRalphWithChildren(t *testing.T) {
+	t.Parallel()
+
+	// The realistic ralph-in-ralph shape: an outer review/iterate loop whose body
+	// contains an inner bounded fix loop that itself has a body (apply + verify).
+	// On outer re-spawn the inner ralph's first iteration must be seeded as a
+	// scope wrapping its members. Regression for gastownhall/gascity#2798.
+	inner := &formula.Step{
+		ID:    "fix-loop",
+		Title: "Fix loop",
+		Type:  "task",
+		Ralph: &formula.RalphSpec{
+			MaxAttempts: 3,
+			Check:       &formula.RalphCheckSpec{Mode: "exec", Path: "fix-check.sh"},
+		},
+		Children: []*formula.Step{
+			{ID: "apply", Title: "Apply", Type: "task"},
+			{ID: "verify", Title: "Verify", Type: "task", Needs: []string{"apply"}},
+		},
+	}
+	step := &formula.Step{
+		ID:    "review-loop",
+		Title: "Review loop",
+		Type:  "task",
+		Ralph: &formula.RalphSpec{
+			MaxAttempts: 5,
+			Check:       &formula.RalphCheckSpec{Mode: "exec", Path: "review-check.sh"},
+		},
+		Children: []*formula.Step{inner},
+	}
+	control := beads.Bead{
+		ID: "gc-review",
+		Metadata: map[string]string{
+			"gc.step_id":  "review-loop",
+			"gc.step_ref": "mol-test.review-loop",
+		},
+	}
+
+	recipe := buildAttemptRecipe(step, control, 2)
+
+	innerControlID := "mol-test.review-loop.iteration.2.fix-loop"
+	innerIterationID := innerControlID + ".iteration.1"
+
+	scope := recipe.StepByID(innerIterationID)
+	if scope == nil {
+		t.Fatalf("inner ralph first iteration %q not seeded", innerIterationID)
+	}
+	if got := scope.Metadata["gc.kind"]; got != "scope" {
+		t.Errorf("inner iteration gc.kind = %q, want scope", got)
+	}
+
+	// Inner iteration members must be seeded under the inner iteration scope.
+	for _, member := range []string{"apply", "verify"} {
+		memberID := innerIterationID + "." + member
+		m := recipe.StepByID(memberID)
+		if m == nil {
+			t.Fatalf("missing inner iteration member %q", memberID)
+		}
+		if got := m.Metadata["gc.scope_ref"]; got != innerIterationID {
+			t.Errorf("member %q gc.scope_ref = %q, want %q", member, got, innerIterationID)
+		}
+	}
+
+	// Inner control blocks on its seeded first iteration.
+	found := false
+	for _, dep := range recipe.Deps {
+		if dep.StepID == innerControlID && dep.DependsOnID == innerIterationID && dep.Type == "blocks" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing dep: inner control %q blocks on seed %q", innerControlID, innerIterationID)
+	}
+}
+
 func TestBuildAttemptRecipeUsesFullyNamespacedStepRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

A `ralph` step nested inside another `ralph`'s body was only seeded on the outer loop's **first** iteration. The compile path (`expandNestedRalph`) seeds the inner ralph's `iteration.1`, but the re-spawn path (`buildAttemptRecipe`) re-created the inner control + spec bead **without** seeding its first iteration.

On outer iterations >= 2 the inner ralph control had no iteration: `processRalphControl`'s `findLatestAttempt` returned empty and raised a fatal `no iteration found`, which propagated to the serve loop and **crash-looped all dispatch for the rig** until manual intervention.

Refs #2798.

## Fix

Seed the nested ralph's first iteration during re-spawn by recursively building its attempt-1 sub-DAG, mirroring the compile-time seeding. The inner control blocks on the seeded iteration exactly as the compile-time `control.Needs` wiring does. Deep nesting is handled for free by the recursion. Existing formulas without nested ralph-in-ralph are unaffected.

`internal/dispatch/control.go` +46 · `internal/dispatch/control_test.go` +148.

## Scope

This is the bounded primary fix (hence `Refs #2798`, not `Fixes`). Deliberately deferred to follow-ups:
- Quarantine hardening — make `findLatestAttempt`-empty non-fatal as defense-in-depth.
- The symmetric latent gap on the nested-`retry`-in-ralph re-spawn sibling path (`buildAttemptRecipe` child `Retry` seeds no `attempt.1`).
- Architecture-docs note.

## Test plan

- [x] 2 new regression tests verified RED on the unpatched tree, GREEN after the fix.
- [x] `go build` / `go vet` / race-enabled unit tests green.
- [x] Idempotence, seed-ID alignment with the runtime `findLatestAttempt` lookup, and blocks-dependency direction independently verified.
- [ ] Maintainer: confirm the deferred follow-ups land as separate issues.
