### PR TITLE
Route beadmail inbox scans through Assignees

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1493,41 +1493,42 @@ func bdListCoversBothTiers(query ListQuery) bool {
 }
 
 func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
-	limit := query.Limit
-	if query.Sort == SortCreatedAsc {
+	serverQuery, clientFilteredAssignees := bdServerQueryForAssignees(query)
+	limit := serverQuery.Limit
+	if serverQuery.Sort == SortCreatedAsc || clientFilteredAssignees {
 		limit = 0
 	}
 	args := []string{"list", "--json"}
-	if query.Label != "" {
-		args = append(args, "--label="+query.Label)
+	if serverQuery.Label != "" {
+		args = append(args, "--label="+serverQuery.Label)
 	}
-	if query.Assignee != "" {
-		args = append(args, "--assignee="+query.Assignee)
+	if serverQuery.Assignee != "" {
+		args = append(args, "--assignee="+serverQuery.Assignee)
 	}
-	if query.Status != "" {
-		args = append(args, "--status="+query.Status)
+	if serverQuery.Status != "" {
+		args = append(args, "--status="+serverQuery.Status)
 	}
-	if query.Type != "" {
-		args = append(args, "--type="+query.Type)
+	if serverQuery.Type != "" {
+		args = append(args, "--type="+serverQuery.Type)
 	}
-	if query.IncludeClosed || query.Status == "closed" {
+	if serverQuery.IncludeClosed || serverQuery.Status == "closed" {
 		args = append(args, "--all")
 	}
-	if !query.CreatedBefore.IsZero() {
-		args = append(args, "--created-before", query.CreatedBefore.Format(time.RFC3339Nano))
+	if !serverQuery.CreatedBefore.IsZero() {
+		args = append(args, "--created-before", serverQuery.CreatedBefore.Format(time.RFC3339Nano))
 	}
 	args = append(args, "--include-infra", "--include-gates", "--limit", fmt.Sprintf("%d", limit))
-	if query.ParentID != "" {
-		args = append(args, "--parent", query.ParentID)
+	if serverQuery.ParentID != "" {
+		args = append(args, "--parent", serverQuery.ParentID)
 	}
-	if len(query.Metadata) > 0 {
-		keys := make([]string, 0, len(query.Metadata))
-		for k := range query.Metadata {
+	if len(serverQuery.Metadata) > 0 {
+		keys := make([]string, 0, len(serverQuery.Metadata))
+		for k := range serverQuery.Metadata {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			args = append(args, "--metadata-field", k+"="+query.Metadata[k])
+			args = append(args, "--metadata-field", k+"="+serverQuery.Metadata[k])
 		}
 	}
 
@@ -1555,20 +1556,40 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 	return filtered, nil
 }
 
+func bdServerQueryForAssignees(query ListQuery) (ListQuery, bool) {
+	serverQuery := query
+	if query.Assignee != "" {
+		return serverQuery, false
+	}
+	switch len(query.Assignees) {
+	case 0:
+		return serverQuery, false
+	case 1:
+		serverQuery.Assignee = query.Assignees[0]
+		serverQuery.Assignees = nil
+		return serverQuery, false
+	default:
+		serverQuery.Assignees = nil
+		serverQuery.AllowScan = true
+		return serverQuery, true
+	}
+}
+
 // listEphemeral reads only the wisps tier using `bd query "ephemeral=true AND
 // <filters>"`. For most bead types, bd query is the canonical way to reach the
 // wisps table (mirrors gastown's internal/beads/beads.go listEphemeral path).
 func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
+	serverQuery, clientFilteredAssignees := bdServerQueryForAssignees(query)
 	clauses := []string{"ephemeral=true"}
-	serverFilteredOnly := true
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "label", query.Label)
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "status", query.Status)
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "type", query.Type)
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "assignee", query.Assignee)
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "parent", query.ParentID)
+	serverFilteredOnly := !clientFilteredAssignees
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "label", serverQuery.Label)
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "status", serverQuery.Status)
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "type", serverQuery.Type)
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "assignee", serverQuery.Assignee)
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "parent", serverQuery.ParentID)
 
 	args := []string{"query", "--json", strings.Join(clauses, " AND ")}
-	if query.IncludeClosed || query.Status == "closed" {
+	if serverQuery.IncludeClosed || serverQuery.Status == "closed" {
 		args = append(args, "--all")
 	}
 	wispsLimit := 0

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3241,6 +3241,113 @@ func TestBdStoreListBothTiersMessageUsesSingleBdListWithoutTierFiltering(t *test
 	}
 }
 
+func TestBdStoreListAssigneesSingleUsesAssigneeFlag(t *testing.T) {
+	var gotCmd string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		return []byte(`[{"id":"bd-route-a","title":"message","status":"open","issue_type":"message","assignee":"route-a","created_at":"2026-05-01T00:00:00Z"}]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{Assignees: []string{"route-a"}, Type: "message", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotCmd, "--assignee=route-a") {
+		t.Fatalf("cmd = %q, want single Assignees value mapped to --assignee", gotCmd)
+	}
+	if len(got) != 1 || got[0].ID != "bd-route-a" {
+		t.Fatalf("got = %+v, want bd-route-a", got)
+	}
+}
+
+func TestBdStoreListAssigneesMultipleFallsBackToClientFilter(t *testing.T) {
+	var gotCmd string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		if strings.Contains(gotCmd, "--assignee=") {
+			t.Fatalf("cmd = %q, multi-route Assignees must not emit a single --assignee", gotCmd)
+		}
+		if strings.Contains(gotCmd, "--limit 1") {
+			return []byte(`[{"id":"bd-route-c","title":"message","status":"open","issue_type":"message","assignee":"route-c","created_at":"2026-05-01T00:00:00Z"}]`), nil
+		}
+		return []byte(`[
+			{"id":"bd-route-c","title":"message","status":"open","issue_type":"message","assignee":"route-c","created_at":"2026-05-01T00:00:00Z"},
+			{"id":"bd-route-b","title":"message","status":"open","issue_type":"message","assignee":"route-b","created_at":"2026-05-01T00:00:01Z"},
+			{"id":"bd-route-a","title":"message","status":"open","issue_type":"message","assignee":"route-a","created_at":"2026-05-01T00:00:02Z"}
+		]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{
+		Assignees: []string{"route-a", "route-b"},
+		Type:      "message",
+		Status:    "open",
+		Limit:     1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotCmd, "--limit 0") {
+		t.Fatalf("cmd = %q, want unlimited server query before multi-Assignees client filtering", gotCmd)
+	}
+	if len(got) != 1 || got[0].ID != "bd-route-b" {
+		t.Fatalf("got = %+v, want first matching route after client filter", got)
+	}
+}
+
+func TestBdStoreListWispsAssigneesSingleUsesAssigneeClause(t *testing.T) {
+	var gotCmd string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		return []byte(`[{"id":"bd-wisp-a","title":"message","status":"open","issue_type":"message","assignee":"route-a","created_at":"2026-05-01T00:00:00Z","ephemeral":true}]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{Assignees: []string{"route-a"}, Type: "message", Status: "open", TierMode: beads.TierWisps})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotCmd, "assignee=route-a") {
+		t.Fatalf("cmd = %q, want single Assignees value mapped to assignee clause", gotCmd)
+	}
+	if len(got) != 1 || got[0].ID != "bd-wisp-a" {
+		t.Fatalf("got = %+v, want bd-wisp-a", got)
+	}
+}
+
+func TestBdStoreListWispsAssigneesMultipleFallsBackToClientFilter(t *testing.T) {
+	var gotCmd string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		if strings.Contains(gotCmd, "assignee=") {
+			t.Fatalf("cmd = %q, multi-route Assignees must not emit one assignee clause", gotCmd)
+		}
+		if strings.Contains(gotCmd, "--limit 1") {
+			return []byte(`[{"id":"bd-wisp-c","title":"message","status":"open","issue_type":"message","assignee":"route-c","created_at":"2026-05-01T00:00:00Z","ephemeral":true}]`), nil
+		}
+		return []byte(`[
+			{"id":"bd-wisp-c","title":"message","status":"open","issue_type":"message","assignee":"route-c","created_at":"2026-05-01T00:00:00Z","ephemeral":true},
+			{"id":"bd-wisp-b","title":"message","status":"open","issue_type":"message","assignee":"route-b","created_at":"2026-05-01T00:00:01Z","ephemeral":true},
+			{"id":"bd-wisp-a","title":"message","status":"open","issue_type":"message","assignee":"route-a","created_at":"2026-05-01T00:00:02Z","ephemeral":true}
+		]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{
+		Assignees: []string{"route-a", "route-b"},
+		Type:      "message",
+		Status:    "open",
+		Limit:     1,
+		TierMode:  beads.TierWisps,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotCmd, "--limit 0") {
+		t.Fatalf("cmd = %q, want unlimited server query before multi-Assignees client filtering", gotCmd)
+	}
+	if len(got) != 1 || got[0].ID != "bd-wisp-b" {
+		t.Fatalf("got = %+v, want first matching wisp after client filter", got)
+	}
+}
+
 func TestBdStoreListIssuesTierDoesNotIssueQuery(t *testing.T) {
 	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -818,13 +818,18 @@ func (p *Provider) messageCandidatesForRoutes(routes []string) ([]beads.Bead, er
 // messages. Live reads are required so command-visible mail sees fresh wisps
 // even when the active store cache was primed earlier.
 func (p *Provider) messageCandidatesAll(routes []string) ([]beads.Bead, error) {
-	all, err := p.store.List(beads.ListQuery{
-		Type:      "message",
-		Status:    "open",
-		TierMode:  beads.TierBoth,
-		AllowScan: true,
-		Live:      true,
-	})
+	query := beads.ListQuery{
+		Type:     "message",
+		Status:   "open",
+		TierMode: beads.TierBoth,
+		Live:     true,
+	}
+	if len(routes) > 0 {
+		query.Assignees = routes
+	} else {
+		query.AllowScan = true
+	}
+	all, err := p.store.List(query)
 	if err != nil {
 		return nil, fmt.Errorf("scanning message beads: %w", err)
 	}
@@ -833,6 +838,8 @@ func (p *Provider) messageCandidatesAll(routes []string) ([]beads.Bead, error) {
 	}
 	out := make([]beads.Bead, 0, len(all))
 	for _, b := range all {
+		// matchesRecipientRoute is defense-in-depth: HQStore returns exact
+		// matches from the index; BdStore multi-route fallback may return excess.
 		if matchesRecipientRoute(routes, b.Assignee) {
 			out = append(out, b)
 		}

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -2,6 +2,7 @@ package beadmail
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -137,8 +138,9 @@ func TestInboxUsesSingleBothTierMessageScanAcrossRoutes(t *testing.T) {
 		t.Fatalf("message query count = %d, want 1; queries=%+v", len(store.messageQueries), store.messageQueries)
 	}
 	query := store.messageQueries[0]
-	if query.TierMode != beads.TierBoth || !query.AllowScan || query.Type != "message" || query.Status != "open" || query.Assignee != "" {
-		t.Fatalf("message query = %+v, want one both-tier message scan without per-route assignee", query)
+	wantRoutes := []string{"sky", sessionBead.ID, "runtime-sky", "mayor", "witness"}
+	if query.TierMode != beads.TierBoth || query.AllowScan || query.Type != "message" || query.Status != "open" || query.Assignee != "" || !slices.Equal(query.Assignees, wantRoutes) {
+		t.Fatalf("message query = %+v, want one both-tier Assignees scan for %v", query, wantRoutes)
 	}
 	if !query.Live {
 		t.Fatalf("message query = %+v, want live read for command-visible mail freshness", query)
@@ -298,7 +300,7 @@ func TestCheckDoesNotUseMessageLabelSupplement(t *testing.T) {
 	}
 }
 
-func TestCheckUsesSingleBothTierScanForSlashRecipient(t *testing.T) {
+func TestCheckUsesSingleAssigneeMessageScanForSlashRecipient(t *testing.T) {
 	recipient := "gascity/workflows.codex-max"
 	var messageListCalls int
 	runner := func(_ string, name string, args ...string) ([]byte, error) {
@@ -311,8 +313,8 @@ func TestCheckUsesSingleBothTierScanForSlashRecipient(t *testing.T) {
 		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=session"):
 			return []byte(`[]`), nil
 		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=message") && strings.Contains(cmd, "--status=open"):
-			if strings.Contains(cmd, "--assignee=") {
-				t.Fatalf("slash recipient used per-assignee message query: %s", cmd)
+			if !strings.Contains(cmd, "--assignee="+recipient) {
+				t.Fatalf("slash recipient message query = %s, want single --assignee filter", cmd)
 			}
 			messageListCalls++
 			return []byte(`[{"id":"msg-w","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"gascity/workflows.codex-max","from":"human","created_at":"2026-01-02T03:04:05Z","ephemeral":true}]`), nil

--- a/release-gates/ga-ga91go-1-beadmail-assignees-gate.md
+++ b/release-gates/ga-ga91go-1-beadmail-assignees-gate.md
@@ -1,0 +1,46 @@
+# Release Gate: ga-ga91go.1 beadmail Assignees routing
+
+Bead: ga-ga91go.1
+Branch: release/ga-ga91go-1-beadmail-assignees
+Base: origin/main c5bd4f713e2d194b6c602caf0d84bcbb8e5fc9eb
+Code head before gate artifact: 3f71a97da71bb1e4a0f1dcfb59e18d4789fdc81e
+Source commit: 7bd1edc8ffa50f77c83501da6a58fd06c308c5a3
+
+Note: docs/PROJECT_MANIFEST.md is not present in this repository checkout. This gate uses the deployer release-gate criteria from the role instructions plus the bead acceptance criteria.
+
+## Summary
+
+PASS. The release branch cherry-picks only the reviewed beadmail Assignees routing commit onto current origin/main. The diff is limited to the approved beadmail and bdstore files plus this gate artifact, preserves the reviewer-approved behavior, and passes the targeted package tests, the fast sharded baseline, and go vet.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-ic4wqg is closed with `REVIEW VERDICT: PASS` for source commit 7bd1edc8f. |
+| 2 | Acceptance criteria met | PASS | Prerequisite ga-tftexi.1 is closed with PR https://github.com/gastownhall/gascity/pull/2865 recorded. Only 7bd1edc8f was cherry-picked; excluded commits 8a6de11d9, d2f2e8bb9, and 64aa34ed0 are not ancestors of HEAD. Diff before this gate artifact contains only internal/beads/bdstore.go, internal/beads/bdstore_test.go, internal/mail/beadmail/beadmail.go, and internal/mail/beadmail/beadmail_test.go. |
+| 3 | Tests pass | PASS | `go test ./internal/mail/beadmail ./internal/beads -run 'TestInboxUsesSingleBothTierMessageScanAcrossRoutes\|TestCheckUsesSingleAssigneeMessageScanForSlashRecipient\|TestBdStoreList(Assignees\|WispsAssignees)' -count=1` passed. `go test ./internal/mail/beadmail ./internal/beads -count=1` passed. `make test-fast-parallel` passed all 8 fast jobs. `go vet ./...` passed. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes on ga-ic4wqg list one LOW/nit finding only; no HIGH findings are present. |
+| 5 | Final branch is clean | PASS | Working tree was clean after the cherry-pick and before writing this gate artifact; final cleanliness is rechecked after committing the gate. |
+| 6 | Branch diverges cleanly from main | PASS | Branch was created from origin/main c5bd4f713 and the cherry-pick applied without conflicts. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem theme: beadmail inbox routing through ListQuery.Assignees with the BdStore support and tests needed for that route. |
+
+## Acceptance Detail
+
+| Acceptance item | Result | Evidence |
+|-----------------|--------|----------|
+| ga-tftexi.1 completed first | PASS | `bd show ga-tftexi.1` reports CLOSED and records PR #2865. |
+| Cherry-pick only 7bd1edc8f | PASS | `git log origin/main..HEAD` contains only `3f71a97da feat(mail): route inbox scans through assignees`, produced by cherry-picking 7bd1edc8f. |
+| Exclude 8a6de11d9, d2f2e8bb9, 64aa34ed0 | PASS | `git merge-base --is-ancestor <sha> HEAD` returned non-zero for each excluded SHA. |
+| Approved diff scope | PASS | `git diff --name-only origin/main...HEAD` before adding the gate artifact listed only the four approved code/test files. |
+| Inbox routing uses Assignees | PASS | `messageCandidatesAll` sets `ListQuery.Assignees` when route candidates are present and only uses `AllowScan` for no-route scans. |
+| Scan gate behavior not weakened | PASS | `ListQuery.Assignees` remains a filter; no-route scans still require explicit `AllowScan`. |
+| DSL injection guards active | PASS | BdStore query construction continues through `appendBdQueryClause`, preserving `isBareBdQueryValue` validation for server-side query clauses. |
+
+## Commands Run
+
+```text
+go test ./internal/mail/beadmail ./internal/beads -run 'TestInboxUsesSingleBothTierMessageScanAcrossRoutes|TestCheckUsesSingleAssigneeMessageScanForSlashRecipient|TestBdStoreList(Assignees|WispsAssignees)' -count=1
+go test ./internal/mail/beadmail ./internal/beads -count=1
+make test-fast-parallel
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

Beadmail inbox and check reads now pass the recipient routes they already know into `ListQuery.Assignees` instead of forcing every routed inbox read through an unrestricted message scan. For a single route, `BdStore` sends the filter down to `bd list --assignee`; for multiple routes, it fetches the live message set without a limit and applies the existing route match locally so no route is silently dropped.

No-route mail reads still require the explicit `AllowScan` path. The change is limited to the beadmail/BdStore read path and its tests; it does not add config, API, schema, HQStore, or dashboard changes.

## Review notes

- Check `internal/mail/beadmail/beadmail.go` for the route-to-`Assignees` handoff and the no-route scan fallback.
- Check `internal/beads/bdstore.go` for the single-assignee server filter and multi-assignee client-filter fallback.
- The existing query-clause validation remains in the BdStore path for server-side query construction.

## Test plan

- [x] `go test ./internal/mail/beadmail ./internal/beads -run 'TestInboxUsesSingleBothTierMessageScanAcrossRoutes|TestCheckUsesSingleAssigneeMessageScanForSlashRecipient|TestBdStoreList(Assignees|WispsAssignees)' -count=1`
- [x] `go test ./internal/mail/beadmail ./internal/beads -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-ga91go-1-beadmail-assignees-gate.md`](release-gates/ga-ga91go-1-beadmail-assignees-gate.md)
