### PR TITLE
fix(reconciler): wake ready wisp control work

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -824,13 +824,13 @@ func collectAssignedWorkBeadsWithStores(
 			var err error
 			var errs []error
 			if len(assignees) == 0 {
-				ready, err = readyForControllerDemandQuery(source.store, beads.ReadyQuery{Limit: assignedWorkReadyLimit(cfg)})
+				ready, err = liveReadyForControllerDemandQuery(source.store, beads.ReadyQuery{Limit: assignedWorkReadyLimit(cfg)})
 				if err != nil {
 					errs = append(errs, fmt.Errorf("Ready(): %w", err))
 				}
 			} else {
 				for _, assignee := range assignees {
-					part, partErr := readyForControllerDemandQuery(source.store, beads.ReadyQuery{Assignee: assignee, Limit: assignedWorkReadyLimit(cfg)})
+					part, partErr := liveReadyForControllerDemandQuery(source.store, beads.ReadyQuery{Assignee: assignee, Limit: assignedWorkReadyLimit(cfg)})
 					if partErr != nil {
 						errs = append(errs, fmt.Errorf("Ready(assignee=%q): %w", assignee, partErr))
 					}
@@ -1334,21 +1334,23 @@ func listBothTiersForControllerDemand(store beads.Store, query beads.ListQuery) 
 }
 
 func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
-	handles := beads.HandlesFor(store)
-	rows, err := handles.Cached.Ready()
-	if errors.Is(err, beads.ErrCacheUnavailable) {
-		return handles.Live.Ready()
-	}
-	return rows, err
+	return readyForControllerDemandQuery(store, beads.ReadyQuery{})
 }
 
 func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([]beads.Bead, error) {
+	query.TierMode = beads.TierBoth
 	handles := beads.HandlesFor(store)
 	rows, err := handles.Cached.Ready(query)
 	if errors.Is(err, beads.ErrCacheUnavailable) {
 		return handles.Live.Ready(query)
 	}
 	return rows, err
+}
+
+func liveReadyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([]beads.Bead, error) {
+	query.TierMode = beads.TierBoth
+	handles := beads.HandlesFor(store)
+	return handles.Live.Ready(query)
 }
 
 // mergeNamedSessionDemand ensures that named-session assignee demand is

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -204,7 +204,7 @@ func (s *controllerDemandPartialStore) Ready(query ...beads.ReadyQuery) ([]beads
 	if err != nil {
 		return nil, err
 	}
-	if len(query) == 0 {
+	if len(query) == 0 || (query[0].Assignee == "" && query[0].Limit == 0) {
 		return rows, &beads.PartialResultError{Op: "bd ready", Err: errors.New("skipped corrupt controller demand bead")}
 	}
 	return rows, nil
@@ -304,8 +304,93 @@ func TestCollectAssignedWorkBeadsIncludesAssignedInProgressWisp(t *testing.T) {
 	}
 }
 
-func TestCollectAssignedWorkBeadsUsesCachedReadyReadModel(t *testing.T) {
-	backing := &readyFailStore{Store: beads.NewMemStore()}
+func TestCollectAssignedWorkBeadsIncludesReadyOpenAssignedWisp(t *testing.T) {
+	store := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+	wisp, err := store.Create(beads.Bead{
+		Title:     "workflow control",
+		Type:      "task",
+		Status:    "open",
+		Assignee:  "control-dispatcher",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.kind": "retry",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wisp work: %v", err)
+	}
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{{
+			Template: "control-dispatcher",
+			Mode:     "on_demand",
+		}},
+	}
+
+	got, partial := collectAssignedWorkBeads(cfg, store)
+
+	if partial {
+		t.Fatal("collectAssignedWorkBeads reported partial results")
+	}
+	if len(got) != 1 || got[0].ID != wisp.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want ready wisp %s", got, wisp.ID)
+	}
+	if len(store.readyQueries) == 0 {
+		t.Fatal("Ready was not queried")
+	}
+	for _, query := range store.readyQueries {
+		if query.TierMode != beads.TierBoth {
+			t.Fatalf("Ready query TierMode = %v, want TierBoth; queries=%#v", query.TierMode, store.readyQueries)
+		}
+	}
+}
+
+func TestCollectAssignedWorkBeadsUsesLiveReadyAfterExternalDependencyClose(t *testing.T) {
+	backing := beads.NewMemStore()
+	blocker, err := backing.Create(beads.Bead{
+		Title:  "first attempt",
+		Type:   "task",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	retry, err := backing.Create(beads.Bead{
+		Title:     "retry controller",
+		Type:      "task",
+		Status:    "open",
+		Assignee:  "control-dispatcher",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.kind": "retry",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create retry: %v", err)
+	}
+	if err := backing.DepAdd(retry.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("add retry blocker: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+	closed := "closed"
+	if err := backing.Update(blocker.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("close blocker outside cache: %v", err)
+	}
+
+	got, partial := collectAssignedWorkBeads(&config.City{}, cache)
+
+	if partial {
+		t.Fatal("collectAssignedWorkBeads reported partial results")
+	}
+	if len(got) != 1 || got[0].ID != retry.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want live-ready retry %s after blocker close", got, retry.ID)
+	}
+}
+
+func TestCollectAssignedWorkBeadsUsesLiveReadyReadModel(t *testing.T) {
+	backing := &readyStaticStore{Store: beads.NewMemStore()}
 	handoff, err := backing.Create(beads.Bead{
 		Title:    "merge me",
 		Type:     "task",
@@ -315,6 +400,7 @@ func TestCollectAssignedWorkBeadsUsesCachedReadyReadModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create handoff bead: %v", err)
 	}
+	backing.ready = []beads.Bead{handoff}
 	cache := beads.NewCachingStoreForTest(backing, nil)
 	if err := cache.PrimeActive(); err != nil {
 		t.Fatalf("PrimeActive: %v", err)
@@ -324,8 +410,8 @@ func TestCollectAssignedWorkBeadsUsesCachedReadyReadModel(t *testing.T) {
 	if len(got) != 1 || got[0].ID != handoff.ID {
 		t.Fatalf("collectAssignedWorkBeads returned %#v, want [%s]", got, handoff.ID)
 	}
-	if backing.readyCalls != 0 {
-		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
+	if backing.readyCalls == 0 {
+		t.Fatal("backing Ready was not called; assigned ready demand must use live state")
 	}
 }
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1756,6 +1756,9 @@ func (s *BdStore) Children(parentID string, opts ...QueryOpt) ([]Bead, error) {
 func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	q := readyQueryFromArgs(query)
 	args := []string{"ready", "--json"}
+	if q.TierMode == TierBoth || q.TierMode == TierWisps {
+		args = append(args, "--include-ephemeral")
+	}
 	if q.Assignee != "" {
 		args = append(args, "--assignee", q.Assignee)
 	}
@@ -1773,7 +1776,7 @@ func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	now := time.Now().UTC()
 	for i := range issues {
 		bead := issues[i].toBead()
-		if !IsReadyCandidate(bead, now) {
+		if !IsReadyCandidateForTier(bead, now, q.TierMode) {
 			continue
 		}
 		if q.Assignee != "" && bead.Assignee != q.Assignee {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -148,12 +148,30 @@ func IsReadyExcludedType(t string) bool {
 	return readyExcludeTypes[t]
 }
 
-// IsReadyCandidate reports whether a bead passes the store-independent Ready
-// filters: open status, main tier, actionable type, and no future defer_until.
-// Dependency and assignee checks are store-specific and happen separately.
+// IsReadyCandidate reports whether a bead passes the store-independent default
+// Ready filters: open status, main tier, actionable type, and no future
+// defer_until. Dependency and assignee checks are store-specific and happen
+// separately.
 func IsReadyCandidate(b Bead, now time.Time) bool {
+	return IsReadyCandidateForTier(b, now, TierIssues)
+}
+
+// IsReadyCandidateForTier reports whether a bead passes the store-independent
+// Ready filters for the requested storage tier.
+func IsReadyCandidateForTier(b Bead, now time.Time, tier TierMode) bool {
+	switch tier {
+	case TierWisps:
+		if !b.Ephemeral {
+			return false
+		}
+	case TierBoth:
+		// no tier filter
+	default: // TierIssues
+		if b.Ephemeral {
+			return false
+		}
+	}
 	return b.Status == "open" &&
-		!b.Ephemeral &&
 		!IsReadyExcludedType(b.Type) &&
 		!IsDeferred(b, now)
 }

--- a/internal/beads/caching_store_handles.go
+++ b/internal/beads/caching_store_handles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 )
 
 // CachedReader is the cache-only eventual-consistency read handle for active
@@ -236,9 +237,10 @@ func (c *CachingStore) cachedReadyOnly(query ReadyQuery) ([]Bead, error) {
 
 	statusByID := make(map[string]string, len(c.beads))
 	openBeads := make([]Bead, 0, len(c.beads))
+	now := time.Now().UTC()
 	for _, b := range c.beads {
 		statusByID[b.ID] = b.Status
-		if b.Status != "open" || b.Ephemeral || IsReadyExcludedType(b.Type) {
+		if !IsReadyCandidateForTier(b, now, query.TierMode) {
 			continue
 		}
 		if query.Assignee != "" && b.Assignee != query.Assignee {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -677,7 +677,7 @@ func TestCachingStoreListBothTiersUsesCachedWispsByDefault(t *testing.T) {
 		ids[bead.ID] = true
 	}
 	if !ids[issue.ID] || !ids[wisp.ID] || len(got) != 2 {
-		t.Fatalf("List(open both tiers) ids = %v rows=%+v, want cached issue %s and wisp %s", ids, got, issue.ID, wisp.ID)
+		t.Fatalf("List(open both tiers) ids = %v rows=%+v, want cached issue %s and cached wisp %s", ids, got, issue.ID, wisp.ID)
 	}
 }
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -359,19 +359,7 @@ func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 
 		var result []Bead
 		for _, b := range openBeads {
-			blocked := false
-			for _, dep := range depsByID[b.ID] {
-				switch dep.Type {
-				case "blocks", "waits-for", "conditional-blocks":
-				default:
-					continue
-				}
-				if status, ok := statusByID[dep.DependsOnID]; ok && status != "closed" {
-					blocked = true
-					break
-				}
-			}
-			if !blocked {
+			if cachedBeadReady(statusByID, depsByID[b.ID]) {
 				result = append(result, cloneBead(b))
 			}
 		}

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -351,6 +351,10 @@ func (s *Store) ListOpen(status ...string) ([]beads.Bead, error) {
 // Ready returns actionable open beads (excluding infrastructure types):
 // script ready
 func (s *Store) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	q := beads.ReadyQuery{}
+	if len(query) > 0 {
+		q = query[0]
+	}
 	out, err := s.run(nil, "ready")
 	if err != nil {
 		return nil, fmt.Errorf("exec beads ready: %w", err)
@@ -362,15 +366,11 @@ func (s *Store) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
 	result := all[:0]
 	now := time.Now().UTC()
 	for _, b := range all {
-		if beads.IsReadyCandidate(b, now) {
+		if beads.IsReadyCandidateForTier(b, now, q.TierMode) {
 			result = append(result, b)
 		}
 	}
-	if len(query) == 0 {
-		return result, nil
-	}
-	q := query[0]
-	return beads.ApplyListQuery(result, beads.ListQuery{Assignee: q.Assignee, Limit: q.Limit}), nil
+	return beads.ApplyListQuery(result, beads.ListQuery{Assignee: q.Assignee, Limit: q.Limit, TierMode: q.TierMode}), nil
 }
 
 // Children returns non-closed beads whose ParentID matches by default:

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -270,7 +270,7 @@ func (m *MemStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	var result []Bead
 	now := time.Now().UTC()
 	for _, b := range m.beads {
-		if !IsReadyCandidate(b, now) {
+		if !IsReadyCandidateForTier(b, now, q.TierMode) {
 			continue
 		}
 		if q.Assignee != "" && b.Assignee != q.Assignee {

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -436,6 +436,9 @@ func (s *NativeDoltStore) Ready(queries ...ReadyQuery) ([]Bead, error) {
 statusLoop:
 	for _, status := range nativeDoltOpenReadyStatuses {
 		filter := beadslib.WorkFilter{Status: status}
+		if q.TierMode == TierBoth || q.TierMode == TierWisps {
+			filter.IncludeEphemeral = true
+		}
 		if q.Assignee != "" {
 			filter.Assignee = &q.Assignee
 		}
@@ -448,7 +451,7 @@ statusLoop:
 			if err != nil {
 				return nil, err
 			}
-			if !IsReadyCandidate(bead, now) || seen[bead.ID] {
+			if !IsReadyCandidateForTier(bead, now, q.TierMode) || seen[bead.ID] {
 				continue
 			}
 			seen[bead.ID] = true

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -103,6 +103,9 @@ func (q ListQuery) Validate() error {
 type ReadyQuery struct {
 	Assignee string
 	Limit    int
+	// TierMode selects the storage tier(s) to read from. Zero value
+	// (TierIssues) preserves Ready's historical main-tier behavior.
+	TierMode TierMode
 }
 
 func readyQueryFromArgs(queries []ReadyQuery) ReadyQuery {

--- a/test/integration/graph_dispatch_test.go
+++ b/test/integration/graph_dispatch_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -153,10 +152,7 @@ func assertControlDispatcherLane(t *testing.T, cityDir string) {
 }
 
 func graphWorkflowCloseTimeout() time.Duration {
-	if runtime.GOOS == "darwin" {
-		return 6 * time.Minute
-	}
-	return 4 * time.Minute
+	return 6 * time.Minute
 }
 
 func setupGraphWorkflowCity(t *testing.T, mode string) string {


### PR DESCRIPTION
## Summary
- include ephemeral/wisp beads in Ready queries via tier-aware ReadyQuery filtering
- use live Ready for assigned-work handoff probes so external dependency closes cannot strand control-dispatcher work behind a stale cached Ready model
- keep cached Ready available for default controller demand where a cache-tolerant read is intentional
- give the graph success-path integration close wait 6m because the now-progressing workflow can complete beyond the old 4m Linux limit under load

## Root Cause
The reconciler assigned-work wake path could observe `assigned_work_bead_count=0` even when `bd ready --include-ephemeral --assignee=control-dispatcher` had ready control work. ReadyQuery could not request wisps, and the assigned handoff probe used cached Ready, so a dependency close made externally could remain invisible to that wake decision.

## Verification
- pre-commit hook: lint-changed, go vet ./..., ./scripts/test-local-parallel fast
- go test ./cmd/gc -run 'TestCollectAssignedWorkBeads|TestSessionHasOpenAssignedWorkInStore|TestDefaultScaleCheckCounts|TestFirstOpenAssignedWorkBead|TestResolveTaskWorkDir' -count=1\n- go test ./internal/beads -run 'TestCachingStoreListBothTiersUsesCachedWispsByDefault|TestCachingStoreHandlesReadLogicalStoreWithoutTierFlags|TestCachingStoreCachedListSupportsActiveTierQueries|TestCachingStoreCachedReady|TestCachingStoreHandles|TestCachingStoreBdPrimeActiveUsesListDependenciesForCachedReady' -count=1\n- GO_TEST_TIMEOUT=10m ./scripts/test-integration-shard review-formulas-recovery\n- GOFLAGS=-count=1 GO_TEST_TIMEOUT=12m ./scripts/test-integration-shard rest-smoke-1-of-2\n- go vet ./...\n