### PR TITLE
feat(api): expose city max_active_sessions on GET /v0/config (#2822)

### DIFF
--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -6676,6 +6676,8 @@ export interface components {
         WorkspaceResponse: {
             declared_name?: string;
             declared_prefix?: string;
+            /** Format: int64 */
+            max_active_sessions?: number;
             name: string;
             prefix?: string;
             provider?: string;

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -5393,6 +5393,7 @@ export type WorkflowSnapshotResponse = {
 export type WorkspaceResponse = {
     declared_name?: string;
     declared_prefix?: string;
+    max_active_sessions?: number;
     name: string;
     prefix?: string;
     provider?: string;

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -13769,6 +13769,10 @@
           "declared_prefix": {
             "type": "string"
           },
+          "max_active_sessions": {
+            "format": "int64",
+            "type": "integer"
+          },
           "name": {
             "type": "string"
           },

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -13769,6 +13769,10 @@
           "declared_prefix": {
             "type": "string"
           },
+          "max_active_sessions": {
+            "format": "int64",
+            "type": "integer"
+          },
           "name": {
             "type": "string"
           },

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -4690,13 +4690,14 @@ type WorkflowSnapshotResponse struct {
 
 // WorkspaceResponse defines model for WorkspaceResponse.
 type WorkspaceResponse struct {
-	DeclaredName    *string `json:"declared_name,omitempty"`
-	DeclaredPrefix  *string `json:"declared_prefix,omitempty"`
-	Name            string  `json:"name"`
-	Prefix          *string `json:"prefix,omitempty"`
-	Provider        *string `json:"provider,omitempty"`
-	SessionTemplate *string `json:"session_template,omitempty"`
-	Suspended       bool    `json:"suspended"`
+	DeclaredName      *string `json:"declared_name,omitempty"`
+	DeclaredPrefix    *string `json:"declared_prefix,omitempty"`
+	MaxActiveSessions *int64  `json:"max_active_sessions,omitempty"`
+	Name              string  `json:"name"`
+	Prefix            *string `json:"prefix,omitempty"`
+	Provider          *string `json:"provider,omitempty"`
+	SessionTemplate   *string `json:"session_template,omitempty"`
+	Suspended         bool    `json:"suspended"`
 }
 
 // PostV0CityParams defines parameters for PostV0City.

--- a/internal/api/handler_config.go
+++ b/internal/api/handler_config.go
@@ -24,6 +24,12 @@ type workspaceResponse struct {
 	Provider        string `json:"provider,omitempty"`
 	Suspended       bool   `json:"suspended"`
 	SessionTemplate string `json:"session_template,omitempty"`
+	// MaxActiveSessions is the city-wide cap on total concurrent sessions,
+	// mirrored from config.Workspace.MaxActiveSessions. The tri-state is
+	// preserved: nil = unset (no city-level cap declared), -1 = unlimited,
+	// any other value = the explicit cap. Agents and rigs inherit this when
+	// they don't declare their own.
+	MaxActiveSessions *int `json:"max_active_sessions,omitempty"`
 }
 
 type configAgentResponse struct {

--- a/internal/api/handler_config_test.go
+++ b/internal/api/handler_config_test.go
@@ -65,6 +65,59 @@ func TestHandleConfigGet(t *testing.T) {
 	}
 }
 
+func TestHandleConfigGet_ExposesWorkspaceMaxActiveSessions(t *testing.T) {
+	// The city-level cap is a *int tri-state: nil = unset (field omitted),
+	// -1 = unlimited, any other value = the explicit cap. The handler must
+	// pass the pointer through verbatim — never coerce nil/-1 to 0.
+	cases := []struct {
+		name        string
+		cap         *int
+		wantPresent bool
+		wantValue   int
+	}{
+		{name: "unset", cap: nil, wantPresent: false},
+		{name: "explicit cap", cap: intPtr(5), wantPresent: true, wantValue: 5},
+		{name: "unlimited", cap: intPtr(-1), wantPresent: true, wantValue: -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newFakeState(t)
+			fs.cfg.Workspace.MaxActiveSessions = tc.cap
+			h := newTestCityHandler(t, fs)
+
+			req := httptest.NewRequest("GET", cityURL(fs, "/config"), nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+			}
+			body := w.Body.String()
+
+			var resp configResponse
+			json.NewDecoder(strings.NewReader(body)).Decode(&resp) //nolint:errcheck
+
+			if !tc.wantPresent {
+				if resp.Workspace.MaxActiveSessions != nil {
+					t.Errorf("workspace.max_active_sessions = %v, want nil", *resp.Workspace.MaxActiveSessions)
+				}
+				if strings.Contains(body, "max_active_sessions") {
+					t.Errorf("expected max_active_sessions omitted from JSON, got body = %s", body)
+				}
+				return
+			}
+
+			if resp.Workspace.MaxActiveSessions == nil {
+				t.Fatalf("workspace.max_active_sessions = nil, want %d", tc.wantValue)
+			}
+			if got := *resp.Workspace.MaxActiveSessions; got != tc.wantValue {
+				t.Errorf("workspace.max_active_sessions = %d, want %d", got, tc.wantValue)
+			}
+		})
+	}
+}
+
 func TestHandleConfigGet_UsesEffectiveWorkspaceIdentity(t *testing.T) {
 	fs := newFakeState(t)
 	fs.cityName = "machine-alias"

--- a/internal/api/huma_handlers_config.go
+++ b/internal/api/huma_handlers_config.go
@@ -56,13 +56,14 @@ func (s *Server) humaHandleConfigGet(_ context.Context, _ *ConfigGetInput) (*Ind
 
 	resp := configResponse{
 		Workspace: workspaceResponse{
-			Name:            name,
-			Prefix:          prefix,
-			DeclaredName:    strings.TrimSpace(cfg.Workspace.Name),
-			DeclaredPrefix:  strings.TrimSpace(cfg.Workspace.Prefix),
-			Provider:        cfg.Workspace.Provider,
-			Suspended:       cfg.Workspace.Suspended,
-			SessionTemplate: cfg.Workspace.SessionTemplate,
+			Name:              name,
+			Prefix:            prefix,
+			DeclaredName:      strings.TrimSpace(cfg.Workspace.Name),
+			DeclaredPrefix:    strings.TrimSpace(cfg.Workspace.Prefix),
+			Provider:          cfg.Workspace.Provider,
+			Suspended:         cfg.Workspace.Suspended,
+			SessionTemplate:   cfg.Workspace.SessionTemplate,
+			MaxActiveSessions: cfg.Workspace.MaxActiveSessions,
 		},
 		Agents:    agents,
 		Rigs:      rigs,

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -13769,6 +13769,10 @@
           "declared_prefix": {
             "type": "string"
           },
+          "max_active_sessions": {
+            "format": "int64",
+            "type": "integer"
+          },
           "name": {
             "type": "string"
           },


### PR DESCRIPTION
## Problem

City-level `max_active_sessions` is not exposed on the HTTP API, so dashboards and operators must parse `city.toml` off the host to learn the cap (the headline `maxAgents` is unavailable).

Fixes #2822.

## Fix

Expose city-level `max_active_sessions` on `GET /v0/config`, so consumers read the cap from the API instead of the on-host config file. Single focused commit.

## Test plan

- [x] `go build ./...`, `go vet`, `go test -race` green.
- [x] `/gascity-ship` full review (simplify → multi-model review → 29-rule contributor check): READY, no warnings.
