### PR TITLE
fix(reaper): close issues with elapsed metadata.expires_at

### DIFF
--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -201,6 +201,7 @@ func TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase(t *testing.T) {
 		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), doltSystemNeedle, 1},
 		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), maintenanceScratchNeedle, 1},
 		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), maintenanceTempNeedle, 1},
+		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), "expires_at", 1},
 		{"dolt", filepath.Join("commands", "list", "run.sh"), doltSystemNeedle, 1},
 		{"dolt", filepath.Join("commands", "cleanup", "run.sh"), doltSystemNeedle, 1},
 		{"dolt", filepath.Join("commands", "health", "run.sh"), doltSystemNeedle, 2},

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3981,6 +3981,173 @@ exit 0
 	}
 }
 
+func TestReaperClosesNudgeBeadWithElapsedExpiresAt(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	// The Step 3 close query is the only one that compares against
+	// UTC_TIMESTAMP(); the gc:nudge-scoped anomaly pre-scan ends in IS NULL.
+	// Returning a row from the close query exercises the positive TTL-expiry
+	// path: an elapsed nudge bead is closed with reason "ttl:expired by reaper"
+	// and counted in the summary as expired:1.
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\ncitydb\n'
+    ;;
+  *"UTC_TIMESTAMP()"*)
+    printf 'id\nga-expired\n'
+    ;;
+  *"gc:nudge"*)
+    printf 'id\n'
+    ;;
+  *"SELECT id FROM "*"citydb"*"issues"*)
+    printf 'id\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	bdLogText := string(bdData)
+	if !strings.Contains(bdLogText, "close ga-expired") {
+		t.Fatalf("reaper did not close elapsed nudge bead:\n%s", bdLogText)
+	}
+	if !strings.Contains(bdLogText, "ttl:expired by reaper") {
+		t.Fatalf("reaper closed nudge bead without ttl:expired reason:\n%s", bdLogText)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "expired:1") {
+		t.Fatalf("reaper summary did not report expired:1:\n%s", gcLogText)
+	}
+}
+
+func TestReaperDoesNotTTLCloseNonNudgeBeadWithElapsedExpiresAt(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	// ga-binding is an expired bead that is NOT labelled gc:nudge (e.g. a
+	// gc:extmsg-binding session binding). The Step 3 queries INNER JOIN on the
+	// gc:nudge label, so they return no rows for it, and the Step 4 stale path
+	// explicitly excludes any bead carrying expires_at. Only a query lacking
+	// both guards would surface ga-binding — which the reaper never issues — so
+	// the bead must never be closed.
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\ncitydb\n'
+    ;;
+  *"gc:nudge"*)
+    printf 'id\n'
+    ;;
+  *"SELECT id FROM "*"citydb"*"issues"*)
+    case "$*" in
+      *"JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) = ''"*)
+        printf 'id\n'
+        ;;
+      *)
+        printf 'id\nga-binding\n'
+        ;;
+    esac
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if strings.Contains(string(bdData), "ga-binding") {
+		t.Fatalf("reaper closed a non-nudge bead with expires_at:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "closed:0") || !strings.Contains(gcLogText, "expired:0") {
+		t.Fatalf("reaper summary reported a close despite no eligible bead:\n%s", gcLogText)
+	}
+}
+
 func TestReaperCityDatabaseUsesGCCityPathFallback(t *testing.T) {
 	cityDir := t.TempDir()
 	writeCityBeadsMetadata(t, cityDir, "citydb")

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4072,7 +4072,7 @@ func TestReaperDoesNotTTLCloseNonNudgeBeadWithElapsedExpiresAt(t *testing.T) {
 	bdLog := filepath.Join(t.TempDir(), "bd.log")
 	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
-	// ga-binding is an expired bead that is NOT labelled gc:nudge (e.g. a
+	// ga-binding is an expired bead that is NOT labeled gc:nudge (e.g. a
 	// gc:extmsg-binding session binding). The Step 3 queries INNER JOIN on the
 	// gc:nudge label, so they return no rows for it, and the Step 4 stale path
 	// explicitly excludes any bead carrying expires_at. Only a query lacking

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3221,6 +3221,10 @@ case "$*" in
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
+    printf 'non-fatal warning from dolt\n' >&2
+    ;;
   *"SELECT id FROM "*"issues"*)
     printf 'id\nga-old\n'
     printf 'non-fatal warning from dolt\n' >&2
@@ -3763,6 +3767,9 @@ case "$*" in
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
+    ;;
   *"SELECT id FROM "*"issues"*)
     printf 'id\nga-old\n'
     ;;
@@ -3832,6 +3839,9 @@ case "$*" in
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\nrigdb\n'
     ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
+    ;;
   *"SELECT id FROM "*"citydb"*"issues"*)
     printf 'id\nga-city\n'
     ;;
@@ -3893,6 +3903,84 @@ exit 0
 	}
 }
 
+func TestReaperDoesNotStaleCloseIssueWithFutureExpiresAt(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\ncitydb\n'
+    ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
+    ;;
+  *"SELECT id FROM "*"citydb"*"issues"*)
+    case "$*" in
+      *"JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) = ''"*)
+        printf 'id\n'
+        ;;
+      *)
+        printf 'id\nga-future\n'
+        ;;
+    esac
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if strings.Contains(string(bdData), "close ga-future") {
+		t.Fatalf("reaper stale-closed issue with explicit future expires_at:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "closed:0") || !strings.Contains(gcLogText, "expired:0") {
+		t.Fatalf("reaper summary reported an issue close despite future expires_at:\n%s", gcLogText)
+	}
+}
+
 func TestReaperCityDatabaseUsesGCCityPathFallback(t *testing.T) {
 	cityDir := t.TempDir()
 	writeCityBeadsMetadata(t, cityDir, "citydb")
@@ -3909,6 +3997,9 @@ case "$*" in
     ;;
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\n'
+    ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
     ;;
   *"SELECT id FROM "*"citydb"*"issues"*)
     printf 'id\nga-city\n'
@@ -3993,6 +4084,9 @@ case "$*" in
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\n'
     ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
+    ;;
   *"SELECT id FROM "*"citydb"*"issues"*)
     printf 'id\nga-city\n'
     ;;
@@ -4062,6 +4156,9 @@ case "$*" in
     ;;
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\nwrongdb\n'
+    ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
     ;;
   *"SELECT id FROM "*"citydb"*"issues"*)
     printf 'id\nga-city\n'
@@ -4147,6 +4244,9 @@ case "$*" in
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
+    ;;
   *"SELECT id FROM "*"issues"*)
     printf 'id\nga-old\n'
     ;;
@@ -4220,6 +4320,9 @@ case "$*" in
     ;;
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\n'
+    ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
     ;;
   *"SELECT id FROM "*"citydb"*"issues"*)
     printf 'id\nga-city\n'
@@ -4298,6 +4401,9 @@ case "$*" in
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
+    ;;
   *"SELECT id FROM "*"issues"*)
     printf 'id\nga-old\n'
     ;;
@@ -4367,6 +4473,9 @@ case "$*" in
     ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\nrigdb\n'
+    ;;
+  *"STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at'))"*)
+    printf 'id\n'
     ;;
   *"SELECT id FROM "*"issues"*)
     printf 'id\nga-old\n'

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -126,6 +126,7 @@ TOTAL_MAIL_WISPS=0
 TOTAL_ISSUES_CLOSED=0
 TOTAL_STALE_ISSUES_SKIPPED=0
 TOTAL_EXPIRED_ISSUES_CLOSED=0
+TOTAL_EXPIRED_ISSUES_SKIPPED=0
 TOTAL_SESSIONS_PRUNED=0
 SESSION_PRUNE_ATTEMPTED=0
 ANOMALIES=""
@@ -463,33 +464,57 @@ while IFS= read -r DB; do
         fi
     fi
 
-    # Step 3: Close issues whose metadata.expires_at is in the past.
-    # Nudge beads carry a 24 h TTL stamped in metadata.expires_at, but Step 4's
-    # stale-issue threshold (720 h / 30 days) never reads that field.  Without
-    # this step, expired nudges accumulate for up to 30 days.  Any open issue
-    # with expires_at set and elapsed is closed here; the explicit TTL takes
-    # precedence over the priority and type guards used in Step 4.
+    # Step 3: Close nudge beads whose metadata.expires_at is in the past.
+    # Only beads labelled gc:nudge are candidates — other bead types that stamp
+    # expires_at (e.g. gc:extmsg-binding session bindings) must not be closed
+    # here.  The COALESCE handles both whole-second RFC3339+Z and RFC3339Nano
+    # (fractional seconds); rows where both patterns fail STR_TO_DATE return
+    # NULL and are recorded as anomalies rather than silently skipped.
     DB_EXPIRED_ISSUES_CLOSED=0
-    get_sql_rows "$DB" "expired issue" "
-        SELECT id FROM \`$DB\`.issues
-        WHERE status IN ('open', 'in_progress')
-        AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) IS NOT NULL
-        AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) != ''
-        AND STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%sZ') < UTC_TIMESTAMP()
+    get_sql_rows "$DB" "expired nudge bead with parse anomaly" "
+        SELECT i.id
+        FROM \`$DB\`.issues i
+        INNER JOIN \`$DB\`.labels lbl ON lbl.issue_id = i.id AND lbl.label = 'gc:nudge'
+        WHERE i.status IN ('open', 'in_progress')
+        AND JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')) IS NOT NULL
+        AND JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')) != ''
+        AND COALESCE(
+            STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%s.%fZ'),
+            STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%sZ')
+        ) IS NULL
+    "
+    if [ -n "$SQL_ROWS_RESULT" ]; then
+        while IFS= read -r bad_id; do
+            [ -z "$bad_id" ] && continue
+            record_anomaly "$DB" "nudge bead $bad_id in $DB has unparseable expires_at; skipped by TTL reaper"
+        done <<< "$SQL_ROWS_RESULT"
+    fi
+
+    get_sql_rows "$DB" "expired nudge bead" "
+        SELECT i.id
+        FROM \`$DB\`.issues i
+        INNER JOIN \`$DB\`.labels lbl ON lbl.issue_id = i.id AND lbl.label = 'gc:nudge'
+        WHERE i.status IN ('open', 'in_progress')
+        AND JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')) IS NOT NULL
+        AND JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')) != ''
+        AND COALESCE(
+            STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%s.%fZ'),
+            STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%sZ')
+        ) < UTC_TIMESTAMP()
     "
     EXPIRED_IDS=$SQL_ROWS_RESULT
 
     if [ -n "$EXPIRED_IDS" ] && [ -z "$DRY_RUN" ]; then
         if [ -z "$CITY_DB" ]; then
             if [ "$CITY_DB_ANOMALY_RECORDED" -eq 0 ]; then
-                record_anomaly "city" "city database could not be determined from GC_REAPER_CITY_DATABASE or $CITY/.beads/metadata.json; expired issue close disabled"
+                record_anomaly "city" "city database could not be determined from GC_REAPER_CITY_DATABASE or $CITY/.beads/metadata.json; expired nudge close disabled"
                 CITY_DB_ANOMALY_RECORDED=1
             fi
             SKIPPED_COUNT=$(printf '%s\n' "$EXPIRED_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
-            TOTAL_STALE_ISSUES_SKIPPED=$((TOTAL_STALE_ISSUES_SKIPPED + SKIPPED_COUNT))
+            TOTAL_EXPIRED_ISSUES_SKIPPED=$((TOTAL_EXPIRED_ISSUES_SKIPPED + SKIPPED_COUNT))
         elif [ "$DB" != "$CITY_DB" ]; then
             SKIPPED_COUNT=$(printf '%s\n' "$EXPIRED_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
-            TOTAL_STALE_ISSUES_SKIPPED=$((TOTAL_STALE_ISSUES_SKIPPED + SKIPPED_COUNT))
+            TOTAL_EXPIRED_ISSUES_SKIPPED=$((TOTAL_EXPIRED_ISSUES_SKIPPED + SKIPPED_COUNT))
         else
             while IFS= read -r issue_id; do
                 [ -z "$issue_id" ] && continue
@@ -498,7 +523,7 @@ while IFS= read -r DB; do
                     TOTAL_EXPIRED_ISSUES_CLOSED=$((TOTAL_EXPIRED_ISSUES_CLOSED + 1))
                     DB_MUTATIONS=$((DB_MUTATIONS + 1))
                 else
-                    record_anomaly "$DB" "closing expired issue $issue_id failed for $DB: $(sanitize_output "$CLOSE_OUTPUT")"
+                    record_anomaly "$DB" "closing expired nudge bead $issue_id failed for $DB: $(sanitize_output "$CLOSE_OUTPUT")"
                 fi
             done <<< "$EXPIRED_IDS"
         fi
@@ -656,7 +681,7 @@ if [ -n "$ANOMALIES" ]; then
         -m "$ANOMALIES" 2>/dev/null || true
 fi
 
-SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
+SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, expired_skipped:$TOTAL_EXPIRED_ISSUES_SKIPPED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
 if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS (dry run)"
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -512,6 +512,10 @@ while IFS= read -r DB; do
         AND updated_at < DATE_SUB(NOW(), INTERVAL $STALE_AGE_H HOUR)
         AND priority > 1
         AND issue_type != 'epic'
+        AND (
+            JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) IS NULL
+            OR JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) = ''
+        )
         AND id NOT IN (
             SELECT DISTINCT d.issue_id FROM \`$DB\`.dependencies d
             INNER JOIN \`$DB\`.issues i ON d.depends_on_id = i.id

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# reaper — close stale wisps with closed parents, purge old closed data, auto-close stale issues.
+# reaper — close stale wisps with closed parents, purge old closed data, auto-close stale and TTL-expired issues.
 #
 # Replaces mol-dog-reaper formula. All operations are deterministic:
 # SQL queries with age thresholds, bd close/update commands, count
@@ -125,6 +125,7 @@ TOTAL_PURGED=0
 TOTAL_MAIL_WISPS=0
 TOTAL_ISSUES_CLOSED=0
 TOTAL_STALE_ISSUES_SKIPPED=0
+TOTAL_EXPIRED_ISSUES_CLOSED=0
 TOTAL_SESSIONS_PRUNED=0
 SESSION_PRUNE_ATTEMPTED=0
 ANOMALIES=""
@@ -462,6 +463,47 @@ while IFS= read -r DB; do
         fi
     fi
 
+    # Step 3: Close issues whose metadata.expires_at is in the past.
+    # Nudge beads carry a 24 h TTL stamped in metadata.expires_at, but Step 4's
+    # stale-issue threshold (720 h / 30 days) never reads that field.  Without
+    # this step, expired nudges accumulate for up to 30 days.  Any open issue
+    # with expires_at set and elapsed is closed here; the explicit TTL takes
+    # precedence over the priority and type guards used in Step 4.
+    DB_EXPIRED_ISSUES_CLOSED=0
+    get_sql_rows "$DB" "expired issue" "
+        SELECT id FROM \`$DB\`.issues
+        WHERE status IN ('open', 'in_progress')
+        AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) IS NOT NULL
+        AND JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')) != ''
+        AND STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%sZ') < UTC_TIMESTAMP()
+    "
+    EXPIRED_IDS=$SQL_ROWS_RESULT
+
+    if [ -n "$EXPIRED_IDS" ] && [ -z "$DRY_RUN" ]; then
+        if [ -z "$CITY_DB" ]; then
+            if [ "$CITY_DB_ANOMALY_RECORDED" -eq 0 ]; then
+                record_anomaly "city" "city database could not be determined from GC_REAPER_CITY_DATABASE or $CITY/.beads/metadata.json; expired issue close disabled"
+                CITY_DB_ANOMALY_RECORDED=1
+            fi
+            SKIPPED_COUNT=$(printf '%s\n' "$EXPIRED_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
+            TOTAL_STALE_ISSUES_SKIPPED=$((TOTAL_STALE_ISSUES_SKIPPED + SKIPPED_COUNT))
+        elif [ "$DB" != "$CITY_DB" ]; then
+            SKIPPED_COUNT=$(printf '%s\n' "$EXPIRED_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
+            TOTAL_STALE_ISSUES_SKIPPED=$((TOTAL_STALE_ISSUES_SKIPPED + SKIPPED_COUNT))
+        else
+            while IFS= read -r issue_id; do
+                [ -z "$issue_id" ] && continue
+                if CLOSE_OUTPUT=$(close_city_issue "$issue_id" "ttl:expired by reaper" 2>&1); then
+                    DB_EXPIRED_ISSUES_CLOSED=$((DB_EXPIRED_ISSUES_CLOSED + 1))
+                    TOTAL_EXPIRED_ISSUES_CLOSED=$((TOTAL_EXPIRED_ISSUES_CLOSED + 1))
+                    DB_MUTATIONS=$((DB_MUTATIONS + 1))
+                else
+                    record_anomaly "$DB" "closing expired issue $issue_id failed for $DB: $(sanitize_output "$CLOSE_OUTPUT")"
+                fi
+            done <<< "$EXPIRED_IDS"
+        fi
+    fi
+
     # Step 4: Auto-close stale issues (exclude P0/P1, epics, active deps).
     DB_ISSUES_CLOSED=0
     get_sql_rows "$DB" "stale issue" "
@@ -542,7 +584,7 @@ while IFS= read -r DB; do
     if [ -z "$DRY_RUN" ] && [ "$DB_MUTATIONS" -gt 0 ]; then
         if ! COMMIT_OUTPUT=$(dolt_sql -q "
             USE \`$DB\`;
-            CALL DOLT_COMMIT('-Am', 'reaper: stale_wisps=$STALE_WISP_COUNT closed_wisps=$DB_CLOSED_WISPS purged=$DB_PURGED stale_issues=$DB_ISSUES_CLOSED', '--author', 'reaper <reaper@gastown.local>')
+            CALL DOLT_COMMIT('-Am', 'reaper: stale_wisps=$STALE_WISP_COUNT closed_wisps=$DB_CLOSED_WISPS purged=$DB_PURGED stale_issues=$DB_ISSUES_CLOSED expired_issues=$DB_EXPIRED_ISSUES_CLOSED', '--author', 'reaper <reaper@gastown.local>')
         " 2>&1); then
             case "$COMMIT_OUTPUT" in
                 *"nothing to commit"*|*"Nothing to commit"*)
@@ -610,7 +652,7 @@ if [ -n "$ANOMALIES" ]; then
         -m "$ANOMALIES" 2>/dev/null || true
 fi
 
-SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
+SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
 if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS (dry run)"
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -121,6 +121,7 @@ fi
 TOTAL_STALE_WISPS=0
 TOTAL_CLOSED_WISPS=0
 TOTAL_WOULD_CLOSE_WISPS=0
+TOTAL_WOULD_EXPIRE=0
 TOTAL_PURGED=0
 TOTAL_MAIL_WISPS=0
 TOTAL_ISSUES_CLOSED=0
@@ -467,9 +468,12 @@ while IFS= read -r DB; do
     # Step 3: Close nudge beads whose metadata.expires_at is in the past.
     # Only beads labelled gc:nudge are candidates — other bead types that stamp
     # expires_at (e.g. gc:extmsg-binding session bindings) must not be closed
-    # here.  The COALESCE handles both whole-second RFC3339+Z and RFC3339Nano
-    # (fractional seconds); rows where both patterns fail STR_TO_DATE return
-    # NULL and are recorded as anomalies rather than silently skipped.
+    # here.  The COALESCE handles whole-second RFC3339+Z, microsecond-width
+    # RFC3339 (MySQL %f tops out at 6 fractional digits), and full
+    # RFC3339Nano (7-9 fractional digits) by truncating the fractional part to
+    # whole seconds for parsing — sub-second precision is immaterial for TTL
+    # expiry.  Rows where every pattern fails STR_TO_DATE return NULL and are
+    # recorded as anomalies rather than silently skipped.
     DB_EXPIRED_ISSUES_CLOSED=0
     get_sql_rows "$DB" "expired nudge bead with parse anomaly" "
         SELECT i.id
@@ -480,7 +484,8 @@ while IFS= read -r DB; do
         AND JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')) != ''
         AND COALESCE(
             STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%s.%fZ'),
-            STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%sZ')
+            STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%sZ'),
+            STR_TO_DATE(CONCAT(SUBSTRING_INDEX(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '.', 1), 'Z'), '%Y-%m-%dT%H:%i:%sZ')
         ) IS NULL
     "
     if [ -n "$SQL_ROWS_RESULT" ]; then
@@ -499,10 +504,15 @@ while IFS= read -r DB; do
         AND JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')) != ''
         AND COALESCE(
             STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%s.%fZ'),
-            STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%sZ')
+            STR_TO_DATE(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '%Y-%m-%dT%H:%i:%sZ'),
+            STR_TO_DATE(CONCAT(SUBSTRING_INDEX(JSON_UNQUOTE(JSON_EXTRACT(i.metadata, '$.expires_at')), '.', 1), 'Z'), '%Y-%m-%dT%H:%i:%sZ')
         ) < UTC_TIMESTAMP()
     "
     EXPIRED_IDS=$SQL_ROWS_RESULT
+    if [ -n "$EXPIRED_IDS" ]; then
+        WOULD_EXPIRE_COUNT=$(printf '%s\n' "$EXPIRED_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
+        TOTAL_WOULD_EXPIRE=$((TOTAL_WOULD_EXPIRE + WOULD_EXPIRE_COUNT))
+    fi
 
     if [ -n "$EXPIRED_IDS" ] && [ -z "$DRY_RUN" ]; then
         if [ -z "$CITY_DB" ]; then
@@ -683,7 +693,7 @@ fi
 
 SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, expired:$TOTAL_EXPIRED_ISSUES_CLOSED, expired_skipped:$TOTAL_EXPIRED_ISSUES_SKIPPED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
 if [ -n "$DRY_RUN" ]; then
-    SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS (dry run)"
+    SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS, would_expire:$TOTAL_WOULD_EXPIRE (dry run)"
 fi
 
 gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Step 4 auto-closed stale issues based on `updated_at` age (30 days) but never read `metadata.expires_at`. Nudge beads carry an explicit 24 h TTL in that field, so 198 stale nudges were accumulating for up to 30 days instead of expiring on schedule.
- Add **Step 3** which queries for open issues whose `metadata.expires_at` is set and elapsed (via `JSON_EXTRACT` + `STR_TO_DATE` against `UTC_TIMESTAMP()`) and closes them with reason `ttl:expired by reaper`. Explicit TTL takes precedence over the priority/type guards used in Step 4.
- Add `TOTAL_EXPIRED_ISSUES_CLOSED` counter; include `expired:` in the summary line and `expired_issues=` in the Dolt commit message.
- Add needle test asserting `expires_at` is present in the embedded script.

## Root cause

`reaper.sh` Step 4 selects:
```sql
WHERE updated_at < DATE_SUB(NOW(), INTERVAL 720 HOUR)
```
It never reads `JSON_EXTRACT(metadata, '$.expires_at')`. Nudge beads created by `ensureQueuedNudgeBead` stamp `expires_at = now + 24h` in their metadata, but the reaper was blind to it.

## Test plan

- [ ] `CGO_ENABLED=0 go test ./cmd/gc/... -run TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase` — passes (verifies `expires_at` is in embedded script)
- [ ] `CGO_ENABLED=0 go test ./... -short` — all 39 compilable packages pass; bare `FAIL` at end is pre-existing CGO/ICU linker issue unrelated to this change (confirmed identical on `main`)
- [ ] Dry-run the reaper against the affected city to confirm 198 stale nudges are now eligible for expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)