### PR TITLE
Bead leaks: preserve transient control errors

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -241,14 +241,14 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 
 	result, err := dispatch.ProcessControl(store, bead, opts)
 	if err != nil {
-		if errors.Is(err, dispatch.ErrControlGraphMalformed) {
-			if quarantineErr := quarantineControlGraphBead(store, beadID, err); quarantineErr != nil {
-				return errors.Join(err, quarantineErr)
-			}
-			_, _ = fmt.Fprintf(stderr, "control dispatch: quarantined bead=%s reason=%v\n", beadID, err)
-			return nil
+		if errors.Is(err, dispatch.ErrControlPending) {
+			return err
 		}
-		return err
+		if quarantineErr := quarantineControlFailureBead(store, beadID, err); quarantineErr != nil {
+			return errors.Join(err, quarantineErr)
+		}
+		_, _ = fmt.Fprintf(stderr, "control dispatch: quarantined bead=%s reason=%v\n", beadID, err)
+		return nil
 	}
 	if result.Processed {
 		_, _ = fmt.Fprintf(stdout, "control dispatch: bead=%s action=%s", beadID, result.Action)
@@ -263,8 +263,12 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 	return nil
 }
 
-func quarantineControlGraphBead(store beads.Store, beadID string, cause error) error {
-	reason := controlQuarantineReason(cause, dispatch.ErrControlGraphMalformed.Error())
+func quarantineControlFailureBead(store beads.Store, beadID string, cause error) error {
+	failureReason := "control_dispatch_error"
+	if errors.Is(cause, dispatch.ErrControlGraphMalformed) {
+		failureReason = "malformed_control_graph"
+	}
+	reason := controlQuarantineReason(cause, failureReason)
 	status := "closed"
 	return store.Update(beadID, beads.UpdateOpts{
 		Status: &status,
@@ -272,7 +276,11 @@ func quarantineControlGraphBead(store beads.Store, beadID string, cause error) e
 		Metadata: map[string]string{
 			"gc.outcome":                   "fail",
 			"gc.failure_class":             "hard",
-			"gc.failure_reason":            "malformed_control_graph",
+			"gc.failure_reason":            failureReason,
+			"gc.controller_error":          reason,
+			"gc.controller_error_class":    "hard",
+			"gc.controller_retryable":      "",
+			"gc.final_disposition":         "control_quarantined",
 			"gc.control_quarantined":       "true",
 			"gc.control_quarantine_reason": reason,
 			"gc.control_quarantined_at":    workflowTraceNow().UTC().Format(time.RFC3339),

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -244,6 +244,9 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 		if errors.Is(err, dispatch.ErrControlPending) {
 			return err
 		}
+		if dispatch.IsTransientControllerError(err) {
+			return err
+		}
 		if quarantineErr := quarantineControlFailureBead(store, beadID, err); quarantineErr != nil {
 			return errors.Join(err, quarantineErr)
 		}
@@ -270,7 +273,7 @@ func quarantineControlFailureBead(store beads.Store, beadID string, cause error)
 	}
 	reason := controlQuarantineReason(cause, failureReason)
 	status := "closed"
-	return store.Update(beadID, beads.UpdateOpts{
+	if err := store.Update(beadID, beads.UpdateOpts{
 		Status: &status,
 		Labels: []string{"gc:control-quarantined"},
 		Metadata: map[string]string{
@@ -285,7 +288,11 @@ func quarantineControlFailureBead(store beads.Store, beadID string, cause error)
 			"gc.control_quarantine_reason": reason,
 			"gc.control_quarantined_at":    workflowTraceNow().UTC().Format(time.RFC3339),
 		},
-	})
+	}); err != nil {
+		return err
+	}
+	_, _ = dispatch.ReconcileClosedScopeMember(store, beadID)
+	return nil
 }
 
 func controlQuarantineReason(cause error, fallback string) string {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1844,8 +1844,8 @@ func TestQuarantineControlGraphBeadClosesWithDiagnostics(t *testing.T) {
 		t.Fatalf("create control: %v", err)
 	}
 
-	if err := quarantineControlGraphBead(store, control.ID, fmt.Errorf("bad workflow")); err != nil {
-		t.Fatalf("quarantineControlGraphBead: %v", err)
+	if err := quarantineControlFailureBead(store, control.ID, fmt.Errorf("%w: bad workflow", dispatch.ErrControlGraphMalformed)); err != nil {
+		t.Fatalf("quarantineControlFailureBead: %v", err)
 	}
 
 	got, err := store.Get(control.ID)
@@ -1892,8 +1892,8 @@ func TestQuarantineControlGraphBeadTruncatesReasonAtUTF8Boundary(t *testing.T) {
 	}
 	reason := strings.Repeat("a", maxControlQuarantineReasonMetadata-1) + "é tail"
 
-	if err := quarantineControlGraphBead(store, control.ID, errors.New(reason)); err != nil {
-		t.Fatalf("quarantineControlGraphBead: %v", err)
+	if err := quarantineControlFailureBead(store, control.ID, errors.New(reason)); err != nil {
+		t.Fatalf("quarantineControlFailureBead: %v", err)
 	}
 
 	got, err := store.Get(control.ID)
@@ -3862,6 +3862,57 @@ func TestRunControlDispatcherQuarantinesMalformedFanoutScopeBody(t *testing.T) {
 		t.Fatalf("labels = %#v, want gc:control-quarantined", after.Labels)
 	}
 	if got := stderr.String(); !strings.Contains(got, "control dispatch: quarantined bead="+fanout.ID) {
+		t.Fatalf("stderr = %q, want quarantine message", got)
+	}
+}
+
+func TestRunControlDispatcherQuarantinesGenericControlFailure(t *testing.T) {
+	clearGCEnv(t)
+
+	store := beads.NewMemStore()
+	control, err := store.Create(beads.Bead{
+		Title: "Unsupported control",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind": "unknown-control-kind",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr); err != nil {
+		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
+	}
+
+	after, err := store.Get(control.ID)
+	if err != nil {
+		t.Fatalf("get control: %v", err)
+	}
+	if after.Status != "closed" {
+		t.Fatalf("control status = %q, want closed", after.Status)
+	}
+	if got := after.Metadata["gc.outcome"]; got != "fail" {
+		t.Fatalf("gc.outcome = %q, want fail", got)
+	}
+	if got := after.Metadata["gc.failure_reason"]; got != "control_dispatch_error" {
+		t.Fatalf("gc.failure_reason = %q, want control_dispatch_error", got)
+	}
+	if got := after.Metadata["gc.control_quarantined"]; got != "true" {
+		t.Fatalf("gc.control_quarantined = %q, want true", got)
+	}
+	if got := after.Metadata["gc.controller_error"]; !strings.Contains(got, "unsupported control bead kind") {
+		t.Fatalf("gc.controller_error = %q, want unsupported control bead kind", got)
+	}
+	if got := after.Metadata["gc.final_disposition"]; got != "control_quarantined" {
+		t.Fatalf("gc.final_disposition = %q, want control_quarantined", got)
+	}
+	if !slices.Contains(after.Labels, "gc:control-quarantined") {
+		t.Fatalf("labels = %#v, want gc:control-quarantined", after.Labels)
+	}
+	if got := stderr.String(); !strings.Contains(got, "control dispatch: quarantined bead="+control.ID) {
 		t.Fatalf("stderr = %q, want quarantine message", got)
 	}
 }

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1830,7 +1830,7 @@ func TestRunWorkflowServeReturnsControlErrorWithoutQuarantine(t *testing.T) {
 	}
 }
 
-func TestQuarantineControlGraphBeadClosesWithDiagnostics(t *testing.T) {
+func TestQuarantineControlFailureBeadClosesWithDiagnostics(t *testing.T) {
 	store := beads.NewMemStore()
 	control, err := store.Create(beads.Bead{
 		Title:  "control",
@@ -1864,6 +1864,15 @@ func TestQuarantineControlGraphBeadClosesWithDiagnostics(t *testing.T) {
 	if got.Metadata["gc.failure_reason"] != "malformed_control_graph" {
 		t.Fatalf("failure_reason = %q, want malformed_control_graph", got.Metadata["gc.failure_reason"])
 	}
+	if got.Metadata["gc.controller_error_class"] != "hard" {
+		t.Fatalf("controller_error_class = %q, want hard", got.Metadata["gc.controller_error_class"])
+	}
+	if got.Metadata["gc.final_disposition"] != "control_quarantined" {
+		t.Fatalf("final_disposition = %q, want control_quarantined", got.Metadata["gc.final_disposition"])
+	}
+	if !strings.Contains(got.Metadata["gc.controller_error"], "bad workflow") {
+		t.Fatalf("controller_error = %q, want bad workflow", got.Metadata["gc.controller_error"])
+	}
 	if got.Metadata["gc.control_quarantined"] != "true" {
 		t.Fatalf("control_quarantined = %q, want true", got.Metadata["gc.control_quarantined"])
 	}
@@ -1878,7 +1887,7 @@ func TestQuarantineControlGraphBeadClosesWithDiagnostics(t *testing.T) {
 	}
 }
 
-func TestQuarantineControlGraphBeadTruncatesReasonAtUTF8Boundary(t *testing.T) {
+func TestQuarantineControlFailureBeadTruncatesReasonAtUTF8Boundary(t *testing.T) {
 	store := beads.NewMemStore()
 	control, err := store.Create(beads.Bead{
 		Title:  "control",
@@ -1906,6 +1915,137 @@ func TestQuarantineControlGraphBeadTruncatesReasonAtUTF8Boundary(t *testing.T) {
 	}
 	if !utf8.ValidString(recorded) {
 		t.Fatalf("recorded reason is invalid UTF-8: %q", recorded)
+	}
+}
+
+func TestRunControlDispatcherReturnsTransientControlErrorWithoutQuarantine(t *testing.T) {
+	clearGCEnv(t)
+
+	base := beads.NewMemStore()
+	missingRootID := "gc-missing-root"
+	control, err := base.Create(beads.Bead{
+		Title: "orphan check",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":           "fanout",
+			"gc.root_bead_id":   missingRootID,
+			"gc.root_store_ref": "city:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+	store := transientGetStore{
+		Store:  base,
+		failID: missingRootID,
+		err:    errors.New("bad connection: root lookup timed out"),
+	}
+
+	var stderr bytes.Buffer
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	err = runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr)
+	if err == nil {
+		t.Fatal("runControlDispatcherWithStoreAndConfig error = nil, want transient error")
+	}
+	if !dispatch.IsTransientControllerError(err) {
+		t.Fatalf("runControlDispatcherWithStoreAndConfig error = %v, want transient classifier match", err)
+	}
+
+	after, err := base.Get(control.ID)
+	if err != nil {
+		t.Fatalf("get control: %v", err)
+	}
+	if after.Status != "open" {
+		t.Fatalf("control status = %q, want open", after.Status)
+	}
+	if got := after.Metadata["gc.control_quarantined"]; got != "" {
+		t.Fatalf("gc.control_quarantined = %q, want empty", got)
+	}
+	if got := after.Metadata["gc.final_disposition"]; got != "" {
+		t.Fatalf("gc.final_disposition = %q, want empty", got)
+	}
+	if slices.Contains(after.Labels, "gc:control-quarantined") {
+		t.Fatalf("labels = %#v, want no gc:control-quarantined", after.Labels)
+	}
+}
+
+type transientGetStore struct {
+	beads.Store
+	failID string
+	err    error
+}
+
+func (s transientGetStore) Get(id string) (beads.Bead, error) {
+	if id == s.failID {
+		return beads.Bead{}, s.err
+	}
+	return s.Store.Get(id)
+}
+
+func TestRunControlDispatcherQuarantineReconcilesScopedControlFailure(t *testing.T) {
+	clearGCEnv(t)
+
+	store := beads.NewMemStore()
+	workflow, err := store.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	body, err := store.Create(beads.Bead{
+		Title: "scope body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "review-loop.iteration.1",
+			"gc.scope_role":   "body",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scope body: %v", err)
+	}
+	control, err := store.Create(beads.Bead{
+		Title: "unsupported scoped control",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "unknown-control-kind",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "review-loop.iteration.1",
+			"gc.scope_role":   "member",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	if err := runControlDispatcherWithStoreAndConfig(t.TempDir(), t.TempDir(), store, control, control.ID, cfg, io.Discard, &stderr); err != nil {
+		t.Fatalf("runControlDispatcherWithStoreAndConfig: %v", err)
+	}
+
+	afterControl, err := store.Get(control.ID)
+	if err != nil {
+		t.Fatalf("get control: %v", err)
+	}
+	if afterControl.Status != "closed" {
+		t.Fatalf("control status = %q, want closed", afterControl.Status)
+	}
+	afterBody, err := store.Get(body.ID)
+	if err != nil {
+		t.Fatalf("get scope body: %v", err)
+	}
+	if afterBody.Status != "closed" {
+		t.Fatalf("scope body status = %q, want closed", afterBody.Status)
+	}
+	if got := afterBody.Metadata["gc.outcome"]; got != "fail" {
+		t.Fatalf("scope body gc.outcome = %q, want fail", got)
 	}
 }
 

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -1361,11 +1361,15 @@ func setOutcomeAndClose(store beads.Store, beadID, outcome string) error {
 	})
 }
 
-// reconcileClosedScopeMember re-reads the just-closed bead and delegates to
-// reconcileTerminalScopedMember. Callers invoke it immediately after
+// ReconcileClosedScopeMember re-reads a just-closed bead and delegates to
+// scope reconciliation. Callers invoke it immediately after
 // setOutcomeAndClose, so this relies on the store being read-after-write
 // consistent (true for MemStore today). If a future store becomes eventually
 // consistent, pass the in-memory closed bead directly instead of re-reading.
+func ReconcileClosedScopeMember(store beads.Store, beadID string) (ControlResult, error) {
+	return reconcileClosedScopeMember(store, beadID)
+}
+
 func reconcileClosedScopeMember(store beads.Store, beadID string) (ControlResult, error) {
 	return reconcileClosedScopeMemberWithOptions(store, beadID, ProcessOptions{})
 }


### PR DESCRIPTION
Refs #2903

## Main Rebase

Rebased onto current `origin/main` (`9bc8ba57d`) on 2026-06-01. The old stack-only `engdocs/contributors/bead-leak-bookkeeping.md` edits are intentionally omitted; #2903 carries the tracker/report evidence.

Merge proof: branch merge-base is `origin/main`; `git diff --check origin/main..HEAD` passed.

## Finding / Cause

The control dispatcher wrapper hard-quarantined every `ProcessControl` error except `ErrControlPending`, converting transient store/controller faults into terminal control-bead closure before the serve loop could retry.

## Fix

Recognized pending control errors return to the caller. Deterministic hard failures are still quarantined with explicit diagnostic metadata.

## Verification

- `go test ./cmd/gc -run 'TestRunWorkflowServeReturnsControlErrorWithoutQuarantine|TestQuarantineControlGraphBeadClosesWithDiagnostics|TestQuarantineControlGraphBeadTruncatesReasonAtUTF8Boundary|TestRunControlDispatcherQuarantinesGenericControlFailure' -count=1`
