### PR TITLE
Bead leaks: make Dolt compaction report local blockers

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -1392,8 +1392,11 @@ flatten_database() {
   fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
-    printf 'compact: db=%s integrity quarantine marker exists — manual intervention required before compaction or GC\n' \
-      "$db" >&2
+    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
+    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
+    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
+    printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
+      "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
     return 1
   fi
 

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -283,6 +283,8 @@ esac
 # graph-rewrite step.
 lock_host=$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]' | sed 's/^\[\(.*\)\]$/\1/')
 if compact_dolt_host_is_local "$lock_host"; then
+  # Deliberately collapse loopback aliases; over-serializing local endpoints is
+  # safer than allowing two compaction jobs to interleave on one local runtime.
   lock_host="127.0.0.1"
 fi
 lock_key=$(printf '%s-%s' "$lock_host" "$GC_DOLT_PORT" | tr -c 'A-Za-z0-9_.-' '-')
@@ -1999,8 +2001,11 @@ bare_gc_database() {
   fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
-    printf 'compact: db=%s integrity quarantine marker exists — manual intervention required before compaction or GC\n' \
-      "$db" >&2
+    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
+    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
+    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
+    printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
+      "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
     return 1
   fi
 

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -78,6 +78,10 @@
 #   GC_DOLT_COMPACT_ONLY_DBS              (optional) — comma-separated list of
 #                                         database names to compact. When set,
 #                                         all other databases are skipped.
+#   GC_DOLT_MANAGED_LOCAL                 (optional) — 1 for gc-managed local
+#                                         runtime validation; 0 allows explicit
+#                                         loopback host/port targets and skips
+#                                         non-local external targets.
 #   GC_DOLT_REFSPEC_<DB_UPPER>            (optional) — compact remote push
 #                                         refspec in <local>:<remote> form.
 #                                         DB name is uppercased with '-'
@@ -116,10 +120,24 @@ PACK_DIR="${GC_PACK_DIR:-$(unset CDPATH; cd -- "$(dirname "$0")/.." && pwd)}"
 # shellcheck disable=SC1091
 . "$PACK_DIR/assets/scripts/runtime.sh"
 
+explicit_external_local_dolt=0
 case "${GC_DOLT_MANAGED_LOCAL:-}" in
   0|false|FALSE|no|NO)
-    printf 'compact: managed local Dolt runtime is not applicable for this order — skip\n'
-    exit 0
+    if [ -z "$gc_dolt_port_input" ]; then
+      printf 'compact: managed local Dolt runtime is not applicable and GC_DOLT_PORT is empty — skip\n'
+      exit 0
+    fi
+    case "$gc_dolt_host_input" in
+      ''|127.0.0.1|localhost|0.0.0.0|::1|::|'[::1]'|'[::]')
+        GC_DOLT_PORT="$gc_dolt_port_input"
+        explicit_external_local_dolt=1
+        ;;
+      *)
+        printf 'compact: GC_DOLT_HOST=%s is not a local Dolt compaction target — skip\n' \
+          "$gc_dolt_host_input"
+        exit 0
+        ;;
+    esac
     ;;
 esac
 
@@ -139,6 +157,8 @@ if [ "${GC_DOLT_MANAGED_LOCAL:-}" = "1" ]; then
   else
     GC_DOLT_PORT="$gc_dolt_port_input"
   fi
+elif [ "$explicit_external_local_dolt" = "1" ]; then
+  :
 elif [ -n "$gc_dolt_port_input" ]; then
   case "$gc_dolt_host_input" in
     ''|127.0.0.1|localhost|0.0.0.0|::1|::|'[::1]'|'[::]')

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -116,9 +116,30 @@ set -eu
 gc_dolt_port_input="$GC_DOLT_PORT"
 gc_dolt_host_input="${GC_DOLT_HOST:-}"
 
-PACK_DIR="${GC_PACK_DIR:-$(unset CDPATH; cd -- "$(dirname "$0")/.." && pwd)}"
-# shellcheck disable=SC1091
-. "$PACK_DIR/assets/scripts/runtime.sh"
+compact_dolt_host_is_local() (
+  compact_host=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$compact_host" in
+    ''|localhost|0.0.0.0|::1|::|'[::1]'|'[::]')
+      return 0
+      ;;
+    127.*.*.*)
+      IFS=.
+      set -- $compact_host
+      [ "$#" -eq 4 ] || return 1
+      [ "$1" = "127" ] || return 1
+      for compact_octet in "$2" "$3" "$4"; do
+        case "$compact_octet" in
+          ''|*[!0-9]*)
+            return 1
+            ;;
+        esac
+        [ "$compact_octet" -le 255 ] 2>/dev/null || return 1
+      done
+      return 0
+      ;;
+  esac
+  return 1
+)
 
 explicit_external_local_dolt=0
 case "${GC_DOLT_MANAGED_LOCAL:-}" in
@@ -127,19 +148,20 @@ case "${GC_DOLT_MANAGED_LOCAL:-}" in
       printf 'compact: managed local Dolt runtime is not applicable and GC_DOLT_PORT is empty — skip\n'
       exit 0
     fi
-    case "$gc_dolt_host_input" in
-      ''|127.0.0.1|localhost|0.0.0.0|::1|::|'[::1]'|'[::]')
-        GC_DOLT_PORT="$gc_dolt_port_input"
-        explicit_external_local_dolt=1
-        ;;
-      *)
-        printf 'compact: GC_DOLT_HOST=%s is not a local Dolt compaction target — skip\n' \
-          "$gc_dolt_host_input"
-        exit 0
-        ;;
-    esac
+    if compact_dolt_host_is_local "$gc_dolt_host_input"; then
+      GC_DOLT_PORT="$gc_dolt_port_input"
+      explicit_external_local_dolt=1
+    else
+      printf 'compact: GC_DOLT_HOST=%s is not a local Dolt compaction target — skip\n' \
+        "$gc_dolt_host_input"
+      exit 0
+    fi
     ;;
 esac
+
+PACK_DIR="${GC_PACK_DIR:-$(unset CDPATH; cd -- "$(dirname "$0")/.." && pwd)}"
+# shellcheck disable=SC1091
+. "$PACK_DIR/assets/scripts/runtime.sh"
 
 if [ "${GC_DOLT_MANAGED_LOCAL:-}" = "1" ]; then
   managed_port=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" || true)
@@ -160,15 +182,11 @@ if [ "${GC_DOLT_MANAGED_LOCAL:-}" = "1" ]; then
 elif [ "$explicit_external_local_dolt" = "1" ]; then
   :
 elif [ -n "$gc_dolt_port_input" ]; then
-  case "$gc_dolt_host_input" in
-    ''|127.0.0.1|localhost|0.0.0.0|::1|::|'[::1]'|'[::]')
-      ;;
-    *)
-      printf 'compact: GC_DOLT_HOST=%s is not a local managed Dolt host — skip\n' \
-        "$gc_dolt_host_input"
-      exit 0
-      ;;
-  esac
+  if ! compact_dolt_host_is_local "$gc_dolt_host_input"; then
+    printf 'compact: GC_DOLT_HOST=%s is not a local managed Dolt host — skip\n' \
+      "$gc_dolt_host_input"
+    exit 0
+  fi
   managed_port=$(managed_runtime_port "$DOLT_STATE_FILE" "$DOLT_DATA_DIR" || true)
   if [ -z "$managed_port" ] || [ "$gc_dolt_port_input" != "$managed_port" ]; then
     printf 'compact: GC_DOLT_PORT=%s does not match managed runtime port=%s for data_dir=%s — skip\n' \
@@ -264,11 +282,9 @@ esac
 # and a second compactor running concurrently would race on the
 # graph-rewrite step.
 lock_host=$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]' | sed 's/^\[\(.*\)\]$/\1/')
-case "$lock_host" in
-  ''|127.0.0.1|localhost|0.0.0.0|::1|::)
-    lock_host="127.0.0.1"
-    ;;
-esac
+if compact_dolt_host_is_local "$lock_host"; then
+  lock_host="127.0.0.1"
+fi
 lock_key=$(printf '%s-%s' "$lock_host" "$GC_DOLT_PORT" | tr -c 'A-Za-z0-9_.-' '-')
 lock_root="/tmp/gc-dolt-compact"
 old_umask=$(umask)

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -2784,6 +2784,69 @@ func TestCompactScriptDryRunSkipsMutations(t *testing.T) {
 	}
 }
 
+func TestCompactScriptAllowsExplicitLocalExternalEndpointWithoutManagedState(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	externalRoot := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "external-target")
+	if err := os.MkdirAll(filepath.Join(externalRoot, "beads", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir external target db: %v", err)
+	}
+
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_MANAGED_LOCAL=0",
+		"GC_DOLT_DATA_DIR="+externalRoot,
+		"GC_DOLT_STATE_FILE="+filepath.Join(externalRoot, "dolt-state.json"),
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_DRY_RUN=1",
+	)
+	if err != nil {
+		t.Fatalf("dry-run compact against explicit local external endpoint failed:\n%s", out)
+	}
+	for _, unwanted := range []string{
+		"managed local Dolt runtime is not applicable",
+		"does not match managed runtime port",
+	} {
+		if strings.Contains(out, unwanted) {
+			t.Fatalf("explicit local endpoint should not be treated as inactive managed runtime:\n%s", out)
+		}
+	}
+	if !strings.Contains(out, "dry-run") {
+		t.Fatalf("dry-run output missing explanation:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if !strings.Contains(string(logData), "db=beads query=") {
+		t.Fatalf("explicit local endpoint did not query discovered database:\n%s", logData)
+	}
+}
+
+func TestCompactScriptSkipsNonLocalExternalEndpoint(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_MANAGED_LOCAL=0",
+		"GC_DOLT_HOST=external.example.internal",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_DRY_RUN=1",
+	)
+	if err != nil {
+		t.Fatalf("non-local external endpoint skip should exit cleanly:\n%s", out)
+	}
+	if !strings.Contains(out, "GC_DOLT_HOST=external.example.internal is not a local Dolt compaction target") {
+		t.Fatalf("output missing non-local external skip:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.TrimSpace(string(logData)) != "" {
+		t.Fatalf("non-local external endpoint should not be queried:\n%s", logData)
+	}
+}
+
 func TestCompactScriptOnlyDBsAllowlistFiltersDatabases(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	if err := os.MkdirAll(filepath.Join(fixture.dataDir, "cache", ".dolt"), 0o755); err != nil {

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -2832,6 +2832,7 @@ func TestCompactScriptSkipsNonLocalExternalEndpoint(t *testing.T) {
 	out, err := fixture.run(t, "success",
 		"GC_DOLT_MANAGED_LOCAL=0",
 		"GC_DOLT_HOST=external.example.internal",
+		"GC_DOLT_PORT=3307",
 		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
 		"GC_DOLT_COMPACT_DRY_RUN=1",
 	)
@@ -3041,6 +3042,11 @@ func TestCompactScriptBareGCRefusesQuarantinedDatabase(t *testing.T) {
 	}
 	if !strings.Contains(out, "integrity quarantine marker exists") {
 		t.Fatalf("bare-gc output missing quarantine explanation:\n%s", out)
+	}
+	if !strings.Contains(out, quarantineMarker) ||
+		!strings.Contains(out, "reason=test") ||
+		!strings.Contains(out, "created_at=2026-05-01T00:00:00Z") {
+		t.Fatalf("bare-gc output missing quarantine marker details:\n%s", out)
 	}
 	// Quarantine refusal exits before any dolt query, so the fake dolt log
 	// may not exist. Tolerate that and assert only on presence.

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -2798,6 +2798,7 @@ func TestCompactScriptAllowsExplicitLocalExternalEndpointWithoutManagedState(t *
 
 	out, err := fixture.run(t, "success",
 		"GC_DOLT_MANAGED_LOCAL=0",
+		"GC_DOLT_HOST=127.0.0.2",
 		"GC_DOLT_DATA_DIR="+externalRoot,
 		"GC_DOLT_STATE_FILE="+filepath.Join(externalRoot, "dolt-state.json"),
 		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
@@ -2849,6 +2850,43 @@ func TestCompactScriptSkipsNonLocalExternalEndpoint(t *testing.T) {
 	}
 	if strings.TrimSpace(string(logData)) != "" {
 		t.Fatalf("non-local external endpoint should not be queried:\n%s", logData)
+	}
+}
+
+func TestCompactScriptSkipsNonLocalExternalEndpointWithoutPort(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	externalRoot := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "external-target")
+	if err := os.MkdirAll(externalRoot, 0o755); err != nil {
+		t.Fatalf("mkdir external target root: %v", err)
+	}
+
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_MANAGED_LOCAL=0",
+		"GC_DOLT_HOST=external.example.internal",
+		"GC_DOLT_PORT=",
+		"GC_DOLT_DATA_DIR="+externalRoot,
+		"GC_DOLT_STATE_FILE="+filepath.Join(externalRoot, "dolt-state.json"),
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_DRY_RUN=1",
+	)
+	if err != nil {
+		t.Fatalf("non-local external endpoint without a port should skip cleanly:\n%s", out)
+	}
+	if !strings.Contains(out, "GC_DOLT_PORT is empty") {
+		t.Fatalf("output missing empty-port external skip:\n%s", out)
+	}
+	if strings.Contains(out, "cannot resolve runtime port") {
+		t.Fatalf("runtime port resolution should not run before external skip:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.TrimSpace(string(logData)) != "" {
+		t.Fatalf("non-local external endpoint without a port should not be queried:\n%s", logData)
 	}
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -2754,6 +2754,11 @@ func TestCompactScriptQuarantineBlocksSecondCycleAfterRowCountDecrease(t *testin
 	if !strings.Contains(secondOut, "integrity quarantine marker exists") {
 		t.Fatalf("second compact missing quarantine explanation:\n%s", secondOut)
 	}
+	quarantine := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-quarantine", "beads")
+	if !strings.Contains(secondOut, quarantine) ||
+		!strings.Contains(secondOut, "reason=post-flatten row count decreased") {
+		t.Fatalf("second compact missing quarantine marker details:\n%s", secondOut)
+	}
 	logData, err := os.ReadFile(fixture.doltLog)
 	if err != nil {
 		t.Fatalf("read dolt log: %v", err)


### PR DESCRIPTION
Refs #2903

## Main Rebase

Rebased onto current `origin/main` (`9bc8ba57d`) on 2026-06-01. The old stack-only `engdocs/contributors/bead-leak-bookkeeping.md` edits are intentionally omitted; #2903 carries the tracker/report evidence.

Merge proof: branch merge-base is `origin/main`; `git diff --check origin/main..HEAD` passed.

## Finding / Cause

The Dolt compactor skipped explicit local loopback Dolt endpoints that were operator-managed rather than `gc start` managed, and quarantine markers lacked actionable output.

## Fix

Allow explicit local external Dolt endpoints for compaction and report quarantine marker details.

## Verification

- `go test ./examples/dolt -run 'TestCompactScriptAllowsExplicitLocalExternalEndpointWithoutManagedState|TestCompactScriptSkipsNonLocalExternalEndpoint|TestCompactScriptOnlyDBsAllowlistFiltersDatabases' -count=1`
