### PR TITLE
Bead leaks: prune legacy drained-asleep sessions

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2505,6 +2505,113 @@ exit 0
 	}
 }
 
+func TestReaperPrunesTerminalSessionStatesWithGcSessionPrune(t *testing.T) {
+	cityDir := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(cityDir); err == nil {
+		cityDir = resolved
+	}
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+case "$*" in
+  "session prune --state drained --before 24h --json")
+    printf '{"action":"prune","count":5}\n'
+    ;;
+esac
+exit 0
+`)
+
+	env := map[string]string{
+		"BD_CALL_LOG":      bdLog,
+		"BD_PRUNE_COUNT":   "7",
+		"DOLT_ARGS_LOG":    doltLog,
+		"DOLT_DBS":         "beads",
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "session prune --state drained --before 24h --json") {
+		t.Fatalf("reaper did not call gc session prune for terminal drained sessions:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "sessions-pruned:12") {
+		t.Fatalf("reaper summary did not include bd and gc session prune counts:\n%s", gcLogText)
+	}
+}
+
+func TestReaperSessionStatePruneFailureEscalates(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeMaintenanceBdStub(t, filepath.Join(binDir, "bd"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+case "$*" in
+  "session prune --state drained --before 24h --json")
+    printf 'session prune exploded\n' >&2
+    exit 42
+    ;;
+esac
+exit 0
+`)
+
+	env := map[string]string{
+		"BD_CALL_LOG":      bdLog,
+		"BD_PRUNE_COUNT":   "0",
+		"DOLT_ARGS_LOG":    doltLog,
+		"DOLT_DBS":         "beads",
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION: Reaper anomalies detected [MEDIUM]") {
+		t.Fatalf("reaper did not send escalation mail for session-state prune failure:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "gm: terminal session-state prune failed: session prune exploded") {
+		t.Fatalf("reaper escalation did not include session-state prune failure details:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "sessions-pruned:0") {
+		t.Fatalf("reaper summary counted failed session-state prune as success:\n%s", gcLogText)
+	}
+}
+
 func TestReaperSessionPruneDryRunOmitsForce(t *testing.T) {
 	cityDir := t.TempDir()
 	writeCityBeadsMetadata(t, cityDir, "beads")
@@ -2559,6 +2666,9 @@ exit 0
 	gcLogText := string(gcData)
 	if !strings.Contains(gcLogText, "sessions-pruned:3") || !strings.Contains(gcLogText, "(dry run)") {
 		t.Fatalf("reaper dry-run summary did not report session prune preview count:\n%s", gcLogText)
+	}
+	if strings.Contains(gcLogText, "session prune ") {
+		t.Fatalf("reaper dry-run called mutating gc session prune:\n%s", gcLogText)
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -24,6 +24,7 @@ MAX_AGE="${GC_REAPER_MAX_AGE:-24h}"
 PURGE_AGE="${GC_REAPER_PURGE_AGE:-168h}"
 STALE_ISSUE_AGE="${GC_REAPER_STALE_ISSUE_AGE:-720h}"
 SESSION_PURGE_AGE="${GC_REAPER_SESSION_PURGE_AGE:-720h}"
+SESSION_STATE_PRUNE_AGE="${GC_REAPER_SESSION_STATE_PRUNE_AGE:-24h}"
 ALERT_THRESHOLD="${GC_REAPER_ALERT_THRESHOLD:-500}"
 MAIL_ALERT_THRESHOLD="${GC_REAPER_MAIL_ALERT_THRESHOLD:-0}"  # 0 = disabled
 DRY_RUN="${GC_REAPER_DRY_RUN:-}"
@@ -566,6 +567,24 @@ if [ -d "$CITY_BEADS_DIR" ] && command -v bd >/dev/null 2>&1; then
     TOTAL_SESSIONS_PRUNED=$PRUNE_COUNT
     if [ "$PRUNE_COUNT" -gt 1000 ]; then
         record_anomaly "gm" "$PRUNE_COUNT closed session beads pruned in one run (threshold: 1000)"
+    fi
+fi
+
+if [ -d "$CITY_BEADS_DIR" ] && [ -z "$DRY_RUN" ] && command -v gc >/dev/null 2>&1; then
+    SESSION_PRUNE_ATTEMPTED=1
+    if SESSION_STATE_PRUNE_JSON=$((
+        cd "$CITY_ABS" && BEADS_DIR="$CITY_BEADS_DIR" gc session prune --state drained --before "$SESSION_STATE_PRUNE_AGE" --json
+    ) 2>&1); then
+        :
+    else
+        record_anomaly "gm" "terminal session-state prune failed: $(sanitize_output "$SESSION_STATE_PRUNE_JSON")"
+        SESSION_STATE_PRUNE_JSON='{"count":0}'
+    fi
+    SESSION_STATE_PRUNE_COUNT=$(printf '%s' "$SESSION_STATE_PRUNE_JSON" | sed -n 's/.*"count"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)
+    [ -z "$SESSION_STATE_PRUNE_COUNT" ] && SESSION_STATE_PRUNE_COUNT=0
+    TOTAL_SESSIONS_PRUNED=$((TOTAL_SESSIONS_PRUNED + SESSION_STATE_PRUNE_COUNT))
+    if [ "$SESSION_STATE_PRUNE_COUNT" -gt 1000 ]; then
+        record_anomaly "gm" "$SESSION_STATE_PRUNE_COUNT terminal session-state beads pruned in one run (threshold: 1000)"
     fi
 fi
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1278,8 +1278,9 @@ func templateOverrideWakeInFlight(metadata map[string]string, state State, now t
 
 // pruneStateTimestamp returns the timestamp that PruneDetailed compares
 // against its cutoff for a session in the given state. Suspended sessions keep
-// the historical CreatedAt fallback for legacy beads; other dormant states must
-// carry their explicit transition timestamp to be pruned.
+// the historical CreatedAt fallback for legacy beads. Asleep sessions normally
+// require slept_at, except legacy drained-asleep beads without slept_at can use
+// the bead update timestamp because sleep_reason=drained is terminal.
 func pruneStateTimestamp(b beads.Bead, state State) (time.Time, bool) {
 	switch state {
 	case StateSuspended:
@@ -1290,7 +1291,22 @@ func pruneStateTimestamp(b beads.Bead, state State) (time.Time, bool) {
 		}
 		return b.CreatedAt, true
 	case StateAsleep:
-		return parsePruneMetadataTimestamp(b.Metadata, "slept_at")
+		if ts, ok := parsePruneMetadataTimestamp(b.Metadata, "slept_at"); ok {
+			return ts, true
+		}
+		if strings.TrimSpace(b.Metadata["slept_at"]) != "" {
+			return time.Time{}, false
+		}
+		if strings.TrimSpace(b.Metadata["sleep_reason"]) != "drained" {
+			return time.Time{}, false
+		}
+		if !b.UpdatedAt.IsZero() {
+			return b.UpdatedAt, true
+		}
+		if !b.CreatedAt.IsZero() {
+			return b.CreatedAt, true
+		}
+		return time.Time{}, false
 	case StateDrained:
 		return parsePruneMetadataTimestamp(b.Metadata, "drain_at")
 	default:
@@ -1325,7 +1341,8 @@ func (m *Manager) Prune(before time.Time) (int, error) {
 // the given cutoff and reports the affected session IDs and queued wait nudges.
 // When no states are supplied it defaults to [StateSuspended] for backward
 // compatibility. Callers may opt in to asleep or drained cleanup by passing
-// StateAsleep or StateDrained.
+// StateAsleep or StateDrained. StateDrained also matches legacy
+// state=asleep/sleep_reason=drained beads.
 func (m *Manager) PruneDetailed(before time.Time, states ...State) (PruneResult, error) {
 	if len(states) == 0 {
 		states = []State{StateSuspended}
@@ -1349,7 +1366,7 @@ func (m *Manager) PruneDetailed(before time.Time, states ...State) (PruneResult,
 			continue // already closed
 		}
 		state := State(b.Metadata["state"])
-		if _, ok := allowed[state]; !ok {
+		if !pruneStateAllowed(state, b.Metadata, allowed) {
 			continue
 		}
 		ts, ok := pruneStateTimestamp(b, state)
@@ -1374,6 +1391,20 @@ func (m *Manager) PruneDetailed(before time.Time, states ...State) (PruneResult,
 		result.SessionIDs = append(result.SessionIDs, b.ID)
 	}
 	return result, nil
+}
+
+func pruneStateAllowed(state State, metadata map[string]string, allowed map[State]struct{}) bool {
+	if _, ok := allowed[state]; ok {
+		return true
+	}
+	if state != StateAsleep {
+		return false
+	}
+	if strings.TrimSpace(metadata["sleep_reason"]) != "drained" {
+		return false
+	}
+	_, ok := allowed[StateDrained]
+	return ok
 }
 
 // Get returns info about a single session.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2875,6 +2875,78 @@ func TestPruneDetailedSkipsAsleepWithoutValidSleptAt(t *testing.T) {
 	}
 }
 
+func TestPruneDetailedAsleepDrainedMissingSleptAtUsesUpdatedAt(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	drained, err := mgr.Create(context.Background(), "default", "Drained Missing SleptAt", "echo d", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadataBatch(drained.ID, map[string]string{
+		"state":        string(StateAsleep),
+		"sleep_reason": "drained",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := store.Get(drained.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	beforeUpdatedAt, err := mgr.PruneDetailed(updated.UpdatedAt, StateAsleep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if beforeUpdatedAt.Count != 0 {
+		t.Fatalf("prune count at UpdatedAt cutoff = %d, want 0; pruned=%v", beforeUpdatedAt.Count, beforeUpdatedAt.SessionIDs)
+	}
+
+	afterUpdatedAt, err := mgr.PruneDetailed(updated.UpdatedAt.Add(time.Nanosecond), StateAsleep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterUpdatedAt.Count != 1 {
+		t.Fatalf("prune count after UpdatedAt cutoff = %d, want 1; pruned=%v", afterUpdatedAt.Count, afterUpdatedAt.SessionIDs)
+	}
+	if len(afterUpdatedAt.SessionIDs) != 1 || afterUpdatedAt.SessionIDs[0] != drained.ID {
+		t.Fatalf("pruned %v, want [%s]", afterUpdatedAt.SessionIDs, drained.ID)
+	}
+}
+
+func TestPruneDetailedDrainedOptInIncludesAsleepDrainedMissingSleptAt(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	drained, err := mgr.Create(context.Background(), "default", "Legacy Drained Asleep", "echo d", "/tmp", "test", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadataBatch(drained.ID, map[string]string{
+		"state":        string(StateAsleep),
+		"sleep_reason": "drained",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := store.Get(drained.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := mgr.PruneDetailed(updated.UpdatedAt.Add(time.Nanosecond), StateDrained)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 1 {
+		t.Fatalf("prune count = %d, want 1; pruned=%v", result.Count, result.SessionIDs)
+	}
+	if len(result.SessionIDs) != 1 || result.SessionIDs[0] != drained.ID {
+		t.Fatalf("pruned %v, want [%s]", result.SessionIDs, drained.ID)
+	}
+}
+
 func TestPruneDetailedDrainedOptInUsesDrainAt(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
Refs #2903

## Main Rebase

Rebased onto current `origin/main` (`9bc8ba57d`) on 2026-06-01. The old stack-only `engdocs/contributors/bead-leak-bookkeeping.md` edits are intentionally omitted; #2903 carries the tracker/report evidence.

Merge proof: branch merge-base is `origin/main`; `git diff --check origin/main..HEAD` passed.

## Finding / Cause

Legacy drained session wisps shaped as `state=asleep` plus `sleep_reason=drained` but missing `slept_at` were skipped indefinitely.

## Fix

Session prune treats legacy drained-asleep rows as drained candidates and falls back to `UpdatedAt` only when `slept_at` is missing.

## Verification

- `go test ./internal/session -run 'TestPruneDetailedAsleepDrainedMissingSleptAtUsesUpdatedAt|TestPruneDetailedDrainedOptInIncludesAsleepDrainedMissingSleptAt|TestPruneDetailedDrainedOptInUsesDrainAt' -count=1`
- `go test ./examples/gastown -run 'TestReaperPrunesTerminalSessionStatesWithGcSessionPrune|TestReaperSessionStatePruneFailureEscalates|TestReaperSessionPruneDryRunOmitsForce|TestReaperSessionPruneAnomalyEscalates' -count=1`
