### PR TITLE
Bead leaks: recover explicit Dolt pending-push markers safely

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -1088,6 +1088,72 @@ ensure_remote_push_retry_fresh() {
   return 0
 }
 
+recover_legacy_pending_push_contract() {
+  db="$1"
+
+  legacy_remote=$(select_remote "$db") || return 1
+  if [ -z "$legacy_remote" ]; then
+    printf 'compact: db=%s legacy pending_push marker recovery found no remote — manual intervention required\n' \
+      "$db" >&2
+    return 1
+  fi
+  valid_remote_name "$legacy_remote" || {
+    printf 'compact: db=%s legacy pending_push marker recovery found invalid remote=%s — manual intervention required\n' \
+      "$db" "$legacy_remote" >&2
+    return 1
+  }
+
+  legacy_active=$(query_single_cell "$db" "active branch probe failed" "SELECT active_branch()" 2>/dev/null || true)
+  if [ -z "$legacy_active" ] || ! valid_branch_name "$legacy_active"; then
+    printf 'compact: db=%s legacy pending_push marker recovery requires resolved active branch — manual intervention required\n' \
+      "$db" >&2
+    return 1
+  fi
+
+  legacy_override=$(refspec_env_value "$db") || return 1
+  if [ -n "$legacy_override" ]; then
+    legacy_parts=$(refspec_parts "$legacy_override") || {
+      printf 'compact: db=%s legacy pending_push marker recovery found invalid refspec override=%s — manual intervention required\n' \
+        "$db" "$legacy_override" >&2
+      return 1
+    }
+    legacy_local_branch=$(printf '%s\n' "$legacy_parts" | sed -n '1p')
+    legacy_remote_branch=$(printf '%s\n' "$legacy_parts" | sed -n '2p')
+    if [ "$legacy_local_branch" != "$legacy_active" ]; then
+      printf 'compact: db=%s legacy pending_push marker recovery local branch=%s does not match active branch=%s — manual intervention required\n' \
+        "$db" "$legacy_local_branch" "$legacy_active" >&2
+      return 1
+    fi
+  else
+    legacy_local_branch="$legacy_active"
+    legacy_remote_branch="$legacy_active"
+  fi
+
+  legacy_remote_head=$(remote_branch_head "$db" "$legacy_remote" "$legacy_remote_branch") || return 1
+  if [ -z "$legacy_remote_head" ]; then
+    printf 'compact: db=%s legacy pending_push marker recovery requires non-empty remote HEAD — manual intervention required\n' \
+      "$db" >&2
+    return 1
+  fi
+  case "$legacy_remote_head" in
+    *[!A-Za-z0-9]*)
+      printf 'compact: db=%s legacy pending_push marker recovery found invalid remote HEAD=%s — manual intervention required\n' \
+        "$db" "$legacy_remote_head" >&2
+      return 1
+      ;;
+  esac
+
+  legacy_in_local=$(commit_exists_in_local_log "$db" "$legacy_remote_head") || return 1
+  if [ "$legacy_in_local" != "1" ]; then
+    printf 'compact: db=%s legacy pending_push marker recovery requires remote HEAD=%s in local history; got=%s — manual intervention required\n' \
+      "$db" "$legacy_remote_head" "${legacy_in_local:-<empty>}" >&2
+    return 1
+  fi
+
+  printf '%s\n%s\n%s\n%s\n' "$legacy_remote" "$legacy_local_branch" "$legacy_remote_branch" "$legacy_remote_head"
+  return 0
+}
+
 clear_compact_marker() {
   dir="$1"
   db="$2"
@@ -1457,6 +1523,7 @@ flatten_database() {
   fi
 
   if has_compact_marker "$pending_push_dir" "$db"; then
+    legacy_pending_push_recovered=0
     pending_remote=$(compact_marker_value "$pending_push_dir" "$db" remote || true)
     pending_expected_remote_head=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head || true)
     pending_expected_remote_head_verified=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head_verified || true)
@@ -1466,9 +1533,16 @@ flatten_database() {
     [ -n "$pending_local_branch" ] || pending_local_branch="main"
     [ -n "$pending_remote_branch" ] || pending_remote_branch="$pending_local_branch"
     if [ -z "$pending_remote" ]; then
-      printf 'compact: db=%s pending_push marker is missing remote — manual intervention required\n' \
-        "$db" >&2
-      return 1
+      legacy_contract=$(recover_legacy_pending_push_contract "$db") || return 1
+      pending_remote=$(printf '%s\n' "$legacy_contract" | sed -n '1p')
+      pending_local_branch=$(printf '%s\n' "$legacy_contract" | sed -n '2p')
+      pending_remote_branch=$(printf '%s\n' "$legacy_contract" | sed -n '3p')
+      pending_expected_remote_head=$(printf '%s\n' "$legacy_contract" | sed -n '4p')
+      pending_expected_remote_head_verified=1
+      pending_compacted_from_head=""
+      legacy_pending_push_recovered=1
+      printf 'compact: db=%s legacy pending_push marker recovered remote=%s local_branch=%s remote_branch=%s expected_remote_head=%s — retrying with live remote verification\n' \
+        "$db" "$pending_remote" "$pending_local_branch" "$pending_remote_branch" "$pending_expected_remote_head"
     fi
     if ! valid_branch_name "$pending_local_branch"; then
       printf 'compact: db=%s pending_push marker has invalid local_branch=%s — manual intervention required\n' \
@@ -1512,7 +1586,9 @@ flatten_database() {
           ;;
       esac
     fi
-    ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
+    if [ "$legacy_pending_push_recovered" != "1" ]; then
+      ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
+    fi
     if [ -n "$dry_run" ]; then
       printf 'compact: db=%s pending_push=present — dry-run (would retry remote push)\n' "$db"
       return 0

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -436,6 +436,14 @@ discover_database_names() {
       emit_database_name "$db"
     done
   fi
+
+  if [ -n "$only_dbs" ]; then
+    printf '%s\n' "$only_dbs" | tr ',' '\n' | while IFS= read -r db; do
+      db=$(printf '%s' "$db" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      [ -n "$db" ] || continue
+      emit_database_name "$db"
+    done
+  fi
 }
 
 # dolt_query — wrapper that runs a single SQL statement against the
@@ -1449,10 +1457,6 @@ flatten_database() {
   fi
 
   if has_compact_marker "$pending_push_dir" "$db"; then
-    if [ -n "$dry_run" ]; then
-      printf 'compact: db=%s pending_push=present — dry-run (would retry remote push)\n' "$db"
-      return 0
-    fi
     pending_remote=$(compact_marker_value "$pending_push_dir" "$db" remote || true)
     pending_expected_remote_head=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head || true)
     pending_expected_remote_head_verified=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head_verified || true)
@@ -1509,6 +1513,10 @@ flatten_database() {
       esac
     fi
     ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
+    if [ -n "$dry_run" ]; then
+      printf 'compact: db=%s pending_push=present — dry-run (would retry remote push)\n' "$db"
+      return 0
+    fi
     printf 'compact: db=%s pending_push=present — retrying remote push before threshold check\n' "$db"
     push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head" "$pending_local_branch" "$pending_remote_branch"
     return $?

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -1575,6 +1575,38 @@ func TestCompactScriptBlocksStalePendingPushRetryBeforeForcePush(t *testing.T) {
 	}
 }
 
+func TestCompactScriptDryRunReportsStalePendingPushMarker(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("first compact should succeed locally despite remote push failure: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	replaceCompactMarkerCreatedAt(t, pendingPush, "1970-01-01T00:00:00Z")
+
+	dryRunOut, err := fixture.run(t, "remote_success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_DRY_RUN=1",
+	)
+	if err == nil {
+		t.Fatalf("dry-run stale pending-push retry succeeded without manual review:\n%s", dryRunOut)
+	}
+	if !strings.Contains(dryRunOut, "pending_push marker is stale") ||
+		!strings.Contains(dryRunOut, "manual review required") {
+		t.Fatalf("dry-run missing stale-marker manual-review explanation:\n%s", dryRunOut)
+	}
+	if strings.Contains(dryRunOut, "would retry remote push") {
+		t.Fatalf("dry-run should not claim it would retry a stale pending push:\n%s", dryRunOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Count(string(logData), "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") != 1 {
+		t.Fatalf("dry-run stale pending-push retry must not attempt another force push:\n%s", logData)
+	}
+}
+
 func TestCompactScriptFailsRetryWhenPendingPushRemoteHeadChangesAgain(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	firstOut, err := fixture.run(t, "remote_advances_before_push", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
@@ -2806,6 +2838,34 @@ func TestCompactScriptOnlyDBsAllowlistFiltersDatabases(t *testing.T) {
 	}
 	if !strings.Contains(log, "db=beads query=") {
 		t.Fatalf("allowlisted database was not queried:\n%s", log)
+	}
+}
+
+func TestCompactScriptOnlyDBsCanTargetUndiscoveredDatabase(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_ONLY_DBS=ga",
+		"GC_DOLT_COMPACT_DRY_RUN=1",
+	)
+	if err != nil {
+		t.Fatalf("explicit allowlisted compact failed:\n%s", out)
+	}
+	if !strings.Contains(out, "db=beads not in GC_DOLT_COMPACT_ONLY_DBS") ||
+		!strings.Contains(out, "db=ga commits=") ||
+		!strings.Contains(out, "dry-run") {
+		t.Fatalf("output missing explicit allowlist target or discovered-db skip:\n%s", out)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "db=beads query=") {
+		t.Fatalf("non-allowlisted discovered database should not receive dolt queries:\n%s", log)
+	}
+	if !strings.Contains(log, "db=ga query=") {
+		t.Fatalf("explicit allowlisted database was not queried:\n%s", log)
 	}
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -230,6 +230,17 @@ func compactMarkerValue(t *testing.T, markerPath, key string) string {
 	return ""
 }
 
+func rewriteLegacyPendingPushMarker(t *testing.T, markerPath, createdAt string) {
+	t.Helper()
+	if err := os.WriteFile(markerPath, []byte(
+		"db=beads\n"+
+			"reason=flatten and full GC succeeded but remote push failed\n"+
+			"created_at="+createdAt+"\n",
+	), 0o600); err != nil {
+		t.Fatalf("rewrite legacy pending-push marker: %v", err)
+	}
+}
+
 func writeBSDOnlyDate(t *testing.T, binDir string) {
 	t.Helper()
 	writeExecutable(t, filepath.Join(binDir, "date"), `#!/bin/sh
@@ -1604,6 +1615,72 @@ func TestCompactScriptDryRunReportsStalePendingPushMarker(t *testing.T) {
 	}
 	if strings.Count(string(logData), "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") != 1 {
 		t.Fatalf("dry-run stale pending-push retry must not attempt another force push:\n%s", logData)
+	}
+}
+
+func TestCompactScriptRecoversLegacyPendingPushMarkerWhenRemoteHeadIsLocal(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("first compact should succeed locally despite remote push failure: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	rewriteLegacyPendingPushMarker(t, pendingPush, "1970-01-01T00:00:00Z")
+
+	secondOut, err := fixture.run(t, "remote_ahead_reconciled", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("legacy pending-push retry should recover from current remote state: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "legacy pending_push marker recovered") ||
+		!strings.Contains(secondOut, "pushed compacted main") {
+		t.Fatalf("retry missing legacy-marker recovery explanation:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Count(log, "DOLT_RESET") != 1 {
+		t.Fatalf("legacy pending-push retry must not flatten again:\n%s", log)
+	}
+	if strings.Count(log, "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") < 2 {
+		t.Fatalf("legacy pending-push retry should attempt the deferred remote push:\n%s", log)
+	}
+	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
+		t.Fatalf("successful legacy retry should clear marker, stat err=%v", err)
+	}
+}
+
+func TestCompactScriptLegacyPendingPushMarkerRequiresRemoteHeadInLocalHistory(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	firstOut, err := fixture.run(t, "remote_push_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("first compact should succeed locally despite remote push failure: %v\n%s", err, firstOut)
+	}
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	rewriteLegacyPendingPushMarker(t, pendingPush, "1970-01-01T00:00:00Z")
+
+	secondOut, err := fixture.run(t, "remote_ahead", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("legacy pending-push retry succeeded with unverified remote HEAD:\n%s", secondOut)
+	}
+	if !strings.Contains(secondOut, "legacy pending_push marker recovery requires remote HEAD") ||
+		!strings.Contains(secondOut, "manual intervention required") {
+		t.Fatalf("retry missing legacy-marker verification failure:\n%s", secondOut)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if strings.Count(log, "DOLT_RESET") != 1 {
+		t.Fatalf("legacy pending-push retry must not flatten again:\n%s", log)
+	}
+	if strings.Count(log, "CALL DOLT_PUSH('--force', '--set-upstream', 'origin', 'main')") != 1 {
+		t.Fatalf("unverified legacy pending-push retry must not attempt another force push:\n%s", log)
+	}
+	if _, err := os.Stat(pendingPush); err != nil {
+		t.Fatalf("failed legacy retry should keep pending-push marker: %v", err)
 	}
 }
 


### PR DESCRIPTION
Refs #2903

## Main Rebase

Rebased onto current `origin/main` (`9bc8ba57d`) on 2026-06-01. The old stack-only `engdocs/contributors/bead-leak-bookkeeping.md` edits are intentionally omitted; #2903 carries the tracker/report evidence.

Merge proof: branch merge-base is `origin/main`; `git diff --check origin/main..HEAD` passed.

## Finding / Cause

Pending-push dry-runs could claim they would retry incomplete legacy markers, and explicit database targets could be missed when rig discovery timed out.

## Fix

Seed discovery from `GC_DOLT_COMPACT_ONLY_DBS`; validate marker shape/freshness; self-heal legacy markers only when remote/ref/branch/head reachability can be proven.

## Verification

- `go test ./examples/dolt -run 'TestCompactScriptDryRunReportsStalePendingPushMarker|TestCompactScriptRecoversLegacyPendingPushMarkerWhenRemoteHeadIsLocal|TestCompactScriptLegacyPendingPushMarkerRequiresRemoteHeadInLocalHistory|TestCompactScriptFailsRetryWhenPendingPushRemoteHeadChangesAgain|TestCompactScriptOnlyDBsCanTargetUndiscoveredDatabase|TestCompactScriptTableNameDoesNotClobberDatabaseName' -count=1`
