### PR TITLE
Bead leaks: reclaim Dolt remote-cache and oldgen storage

### DIFF
--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -668,6 +668,73 @@ fetch_remote() {
   dolt_query "$db" "CALL DOLT_FETCH('$remote')"
 }
 
+repair_missing_git_remote_cache_from_error() {
+  db="$1"
+  err_file="$2"
+  repo_path=$(sed -n "s/.*not a git repository: '\([^']*\/repo\.git\)'.*/\1/p" "$err_file" | sed -n '1p')
+  [ -n "$repo_path" ] || return 1
+
+  cache_root="$DOLT_DATA_DIR/$db/.dolt/git-remote-cache"
+  case "$repo_path" in
+    "$cache_root"/*/repo.git)
+      ;;
+    *)
+      printf 'compact: db=%s git_remote_cache repair refused path=%s outside cache_root=%s\n' \
+        "$db" "$repo_path" "$cache_root" >&2
+      return 1
+      ;;
+  esac
+  if ! command -v git >/dev/null 2>&1; then
+    printf 'compact: db=%s git_remote_cache repair requires git on PATH\n' "$db" >&2
+    return 1
+  fi
+  if [ -e "$repo_path" ] && [ ! -d "$repo_path" ]; then
+    printf 'compact: db=%s git_remote_cache repair refused non-directory path=%s\n' \
+      "$db" "$repo_path" >&2
+    return 1
+  fi
+  repo_parent=${repo_path%/repo.git}
+  if ! mkdir -p "$repo_parent"; then
+    printf 'compact: db=%s git_remote_cache repair failed to create parent=%s\n' \
+      "$db" "$repo_parent" >&2
+    return 1
+  fi
+  if ! git init --bare "$repo_path" >/dev/null 2>&1; then
+    printf 'compact: db=%s git_remote_cache repair failed to initialize path=%s\n' \
+      "$db" "$repo_path" >&2
+    return 1
+  fi
+  if [ ! -f "$repo_path/HEAD" ]; then
+    if ! printf 'ref: refs/heads/main\n' > "$repo_path/HEAD"; then
+      printf 'compact: db=%s git_remote_cache repair failed to write HEAD path=%s\n' \
+        "$db" "$repo_path/HEAD" >&2
+      return 1
+    fi
+  fi
+  printf 'compact: db=%s git_remote_cache=initialized path=%s — retrying fetch\n' \
+    "$db" "$repo_path"
+  return 0
+}
+
+fetch_remote_with_cache_repair() {
+  db="$1"
+  remote="$2"
+  err_file="$3"
+  : > "$err_file"
+  fetch_remote "$db" "$remote" >/dev/null 2>"$err_file" && return 0
+  repair_initial_fetch_rc=$?
+  if repair_missing_git_remote_cache_from_error "$db" "$err_file"; then
+    : > "$err_file"
+    retry_rc=0
+    fetch_remote "$db" "$remote" >/dev/null 2>"$err_file" || retry_rc=$?
+    if [ "$retry_rc" -eq 0 ]; then
+      return 0
+    fi
+    return "$retry_rc"
+  fi
+  return "$repair_initial_fetch_rc"
+}
+
 remote_branch_head() {
   db="$1"
   remote="$2"
@@ -1175,7 +1242,7 @@ push_remote_after_compaction() {
 
   fetch_rc=0
   fetch_err_tmp=$(mktemp)
-  fetch_remote "$db" "$remote" >/dev/null 2>"$fetch_err_tmp" || fetch_rc=$?
+  fetch_remote_with_cache_repair "$db" "$remote" "$fetch_err_tmp" || fetch_rc=$?
   if [ "$fetch_rc" -ne 0 ]; then
     printf 'compact: db=%s remote=%s fetch failed rc=%s before push after local compaction\n' \
       "$db" "$remote" "$fetch_rc" >&2
@@ -1647,7 +1714,7 @@ flatten_database() {
     printf 'compact: db=%s remote=%s — fetching before flatten...\n' "$db" "$remote"
     fetch_rc=0
     fetch_err_tmp=$(mktemp)
-    fetch_remote "$db" "$remote" >/dev/null 2>"$fetch_err_tmp" || fetch_rc=$?
+    fetch_remote_with_cache_repair "$db" "$remote" "$fetch_err_tmp" || fetch_rc=$?
     if [ "$fetch_rc" -ne 0 ]; then
       printf 'compact: db=%s remote=%s fetch failed rc=%s — proceeding from local source of truth\n' \
         "$db" "$remote" "$fetch_rc" >&2

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -14,6 +14,9 @@
 # Running as an exec order gives us direct SQL access via the dolt CLI.
 #
 # Algorithm (flatten mode):
+#   0. Purge Dolt git remote caches. These are rebuildable fetch caches and can
+#      dwarf live table data even when the database is below the flatten
+#      threshold.
 #   1. Pre-flight: record row counts and value hashes for all user tables and
 #      require HEAD to remain stable across a bounded retry loop.
 #   2. Soft-reset to the root commit; all data stays staged.
@@ -885,6 +888,27 @@ oldgen_has_files() {
   [ -n "$(find "$oldgen_dir" -mindepth 1 -print -quit 2>/dev/null)" ]
 }
 
+purge_remote_cache() {
+  db="$1"
+  valid_database_name "$db" || {
+    printf 'compact: db=%s invalid database name for remote-cache purge — fail\n' "$db" >&2
+    return 1
+  }
+  remote_cache_dir="$DOLT_DATA_DIR/$db/.dolt/git-remote-cache"
+  [ -d "$remote_cache_dir" ] || return 0
+  if [ -n "$dry_run" ]; then
+    printf 'compact: db=%s remote_cache=present - dry-run (would purge) path=%s\n' \
+      "$db" "$remote_cache_dir"
+    return 0
+  fi
+  if ! rm -rf -- "$remote_cache_dir"; then
+    printf 'compact: db=%s remote_cache purge failed path=%s\n' \
+      "$db" "$remote_cache_dir" >&2
+    return 1
+  fi
+  printf 'compact: db=%s remote_cache=purged path=%s\n' "$db" "$remote_cache_dir"
+}
+
 compact_marker_path() {
   dir="$1"
   db="$2"
@@ -1370,6 +1394,8 @@ flatten_database() {
         ;;
     esac
   fi
+
+  purge_remote_cache "$db" || return 1
 
   if has_compact_marker "$quarantine_dir" "$db"; then
     printf 'compact: db=%s integrity quarantine marker exists — manual intervention required before compaction or GC\n' \

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -1623,9 +1623,7 @@ flatten_database() {
           ;;
       esac
     fi
-    if [ "$legacy_pending_push_recovered" != "1" ]; then
-      ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
-    fi
+    ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
     if oldgen_has_files "$db"; then
       if [ -n "$dry_run" ]; then
         printf 'compact: db=%s pending_push oldgen_archives=present — dry-run (would run local DOLT_GC --full before remote push retry)\n' "$db"

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -14,9 +14,11 @@
 # Running as an exec order gives us direct SQL access via the dolt CLI.
 #
 # Algorithm (flatten mode):
-#   0. Purge Dolt git remote caches. These are rebuildable fetch caches and can
-#      dwarf live table data even when the database is below the flatten
-#      threshold.
+#   0. Purge Dolt git remote caches when no pending remote repair is in
+#      progress. These are rebuildable fetch caches and can dwarf live table
+#      data even when the database is below the flatten threshold, but the
+#      running SQL server may need an existing cache while retrying a pending
+#      fetch/push repair.
 #   1. Pre-flight: record row counts and value hashes for all user tables and
 #      require HEAD to remain stable across a bounded retry loop.
 #   2. Soft-reset to the root commit; all data stays staged.
@@ -1408,15 +1410,19 @@ flatten_database() {
     esac
   fi
 
-  purge_remote_cache "$db" || return 1
   if [ -n "$remote_cache_only" ]; then
+    purge_remote_cache "$db" || return 1
     printf 'compact: db=%s remote_cache_only=1 — skip compaction state checks\n' "$db"
     return 0
   fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
-    printf 'compact: db=%s integrity quarantine marker exists — manual intervention required before compaction or GC\n' \
-      "$db" >&2
+    purge_remote_cache "$db" || return 1
+    quarantine_marker=$(compact_marker_path "$quarantine_dir" "$db")
+    quarantine_reason=$(compact_marker_value "$quarantine_dir" "$db" reason || true)
+    quarantine_created_at=$(compact_marker_value "$quarantine_dir" "$db" created_at || true)
+    printf 'compact: db=%s integrity quarantine marker exists at %s reason=%s created_at=%s — manual intervention required before compaction or GC\n' \
+      "$db" "$quarantine_marker" "${quarantine_reason:-<unknown>}" "${quarantine_created_at:-<unknown>}" >&2
     return 1
   fi
 
@@ -1556,6 +1562,8 @@ flatten_database() {
     push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head" "$pending_local_branch" "$pending_remote_branch"
     return $?
   fi
+
+  purge_remote_cache "$db" || return 1
 
   if ! count=$(commit_count "$db"); then
     return 1

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -50,7 +50,10 @@
 #
 # Remote push failures are recorded in compact-pending-push markers and do not
 # fail local compaction. Later runs retry those markers before threshold skips,
-# and unverified remote heads must become ancestry-verifiable before push.
+# and unverified remote heads must become ancestry-verifiable before push. If
+# orphaned oldgen archives are present while a pending push blocks normal
+# threshold-based compaction, the retry path runs a local full GC before the
+# remote repair attempt; that reclaims local storage without flattening again.
 # Surgical mode (preserve recent N commits via interactive rebase) is
 # intentionally not implemented; flatten is sufficient for bloat recovery
 # and avoids the rebase-vs-concurrent-write hazards.
@@ -1498,10 +1501,6 @@ flatten_database() {
   fi
 
   if has_compact_marker "$pending_push_dir" "$db"; then
-    if [ -n "$dry_run" ]; then
-      printf 'compact: db=%s pending_push=present — dry-run (would retry remote push)\n' "$db"
-      return 0
-    fi
     pending_remote=$(compact_marker_value "$pending_push_dir" "$db" remote || true)
     pending_expected_remote_head=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head || true)
     pending_expected_remote_head_verified=$(compact_marker_value "$pending_push_dir" "$db" expected_remote_head_verified || true)
@@ -1557,7 +1556,22 @@ flatten_database() {
           ;;
       esac
     fi
-    ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
+    if [ "$legacy_pending_push_recovered" != "1" ]; then
+      ensure_remote_push_retry_fresh "$pending_push_dir" "$db" "pending_push" || return 1
+    fi
+    if oldgen_has_files "$db"; then
+      if [ -n "$dry_run" ]; then
+        printf 'compact: db=%s pending_push oldgen_archives=present — dry-run (would run local DOLT_GC --full before remote push retry)\n' "$db"
+      else
+        printf 'compact: db=%s pending_push oldgen_archives=present — running local DOLT_GC --full before remote push retry\n' "$db"
+        start=$(date +%s)
+        run_full_gc "$db" "pending-push local-GC" "pending-push local-GC" "$start" || return 1
+      fi
+    fi
+    if [ -n "$dry_run" ]; then
+      printf 'compact: db=%s pending_push=present — dry-run (would retry remote push)\n' "$db"
+      return 0
+    fi
     printf 'compact: db=%s pending_push=present — retrying remote push before threshold check\n' "$db"
     push_remote_after_compaction "$db" "$pending_remote" "$pending_expected_remote_head" "${pending_expected_remote_head_verified:-0}" "retry" "$pending_compacted_from_head" "$pending_local_branch" "$pending_remote_branch"
     return $?

--- a/examples/dolt/commands/compact/run.sh
+++ b/examples/dolt/commands/compact/run.sh
@@ -78,6 +78,9 @@
 #   GC_DOLT_COMPACT_DRY_RUN              (optional) — when set, prints
 #                                         what would happen but does not
 #                                         execute any DOLT_RESET / COMMIT.
+#   GC_DOLT_COMPACT_REMOTE_CACHE_ONLY    (optional) — when set, purge
+#                                         rebuildable git remote caches and skip
+#                                         pending push/GC and flatten checks.
 #   GC_DOLT_COMPACT_ONLY_DBS              (optional) — comma-separated list of
 #                                         database names to compact. When set,
 #                                         all other databases are skipped.
@@ -179,6 +182,7 @@ push_timeout="${GC_DOLT_COMPACT_PUSH_TIMEOUT_SECS:-120}"
 pending_push_max_age_secs="${GC_DOLT_COMPACT_PENDING_PUSH_MAX_AGE_SECS:-172800}"
 compact_remote="${GC_DOLT_COMPACT_REMOTE:-}"
 dry_run="${GC_DOLT_COMPACT_DRY_RUN:-}"
+remote_cache_only="${GC_DOLT_COMPACT_REMOTE_CACHE_ONLY:-}"
 only_dbs="${GC_DOLT_COMPACT_ONLY_DBS:-}"
 bare_gc_input="${GC_DOLT_COMPACT_BARE_GC:-}"
 case "$bare_gc_input" in
@@ -192,6 +196,15 @@ case "$bare_gc_input" in
     printf 'compact: invalid GC_DOLT_COMPACT_BARE_GC=%s (must be 1/true/yes or 0/false/no)\n' \
       "$bare_gc_input" >&2
     exit 2
+    ;;
+esac
+
+case "$remote_cache_only" in
+  ''|0|false|FALSE|no|NO)
+    remote_cache_only=""
+    ;;
+  *)
+    remote_cache_only=1
     ;;
 esac
 
@@ -1396,6 +1409,10 @@ flatten_database() {
   fi
 
   purge_remote_cache "$db" || return 1
+  if [ -n "$remote_cache_only" ]; then
+    printf 'compact: db=%s remote_cache_only=1 — skip compaction state checks\n' "$db"
+    return 0
+  fi
 
   if has_compact_marker "$quarantine_dir" "$db"; then
     printf 'compact: db=%s integrity quarantine marker exists — manual intervention required before compaction or GC\n' \

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -369,7 +369,7 @@ set_hash() {
 case "$query" in
   *"SELECT COUNT(*) FROM dolt_remotes WHERE name = 'origin'"*)
     case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
+      remote_success|remote_success_requires_cache|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
         print_cell 1
         ;;
       *)
@@ -391,7 +391,7 @@ case "$query" in
     ;;
   *"SELECT COUNT(*) FROM dolt_remotes"*)
     case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten)
+      remote_success|remote_success_requires_cache|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten)
         print_cell 1
         ;;
       multiple_remotes_with_origin|multiple_remotes_no_origin)
@@ -408,7 +408,7 @@ case "$query" in
     ;;
   *"SELECT name FROM dolt_remotes ORDER BY name LIMIT 1"*)
     case "$mode" in
-      remote_success|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
+      remote_success|remote_success_requires_cache|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
         print_cell origin
         ;;
       explicit_backup_remote)
@@ -421,6 +421,10 @@ case "$query" in
     exit 0
     ;;
   *"DOLT_FETCH('origin')"*)
+    if [ "$mode" = "remote_success_requires_cache" ] && [ ! -f "${GC_DOLT_DATA_DIR:-}/$db/.dolt/git-remote-cache/fetch-required" ]; then
+      printf 'remote cache missing before fetch\n' >&2
+      exit 55
+    fi
     if [ "$mode" = "remote_fetch_failure" ]; then
       printf 'fetch unavailable\n' >&2
       exit 52
@@ -946,6 +950,50 @@ func TestCompactScriptRemoteCacheOnlySkipsPendingPushRetry(t *testing.T) {
 		if strings.Contains(log, forbidden) {
 			t.Fatalf("remote-cache-only must not run %s:\n%s", forbidden, log)
 		}
+	}
+}
+
+func TestCompactScriptPreservesRemoteCacheBeforePendingPushRetry(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	cacheFile := filepath.Join(fixture.dataDir, "beads", ".dolt", "git-remote-cache", "fetch-required")
+	if err := os.MkdirAll(filepath.Dir(cacheFile), 0o755); err != nil {
+		t.Fatalf("mkdir remote cache fixture: %v", err)
+	}
+	if err := os.WriteFile(cacheFile, []byte("fetch needs this live cache"), 0o644); err != nil {
+		t.Fatalf("write remote cache fixture: %v", err)
+	}
+
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if err := os.MkdirAll(filepath.Dir(pendingPush), 0o755); err != nil {
+		t.Fatalf("mkdir pending-push fixture: %v", err)
+	}
+	if err := os.WriteFile(pendingPush, []byte(
+		"db=beads\n"+
+			"reason=flatten and full GC succeeded but remote push failed\n"+
+			"created_at="+time.Now().UTC().Format("2006-01-02T15:04:05Z")+"\n"+
+			"remote=origin\n"+
+			"expected_remote_head=headcommit\n"+
+			"expected_remote_head_verified=1\n"+
+			"compacted_from_head=headcommit\n"+
+			"local_branch=main\n"+
+			"remote_branch=main\n",
+	), 0o600); err != nil {
+		t.Fatalf("write pending-push fixture: %v", err)
+	}
+
+	out, err := fixture.run(t, "remote_success_requires_cache", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("pending-push retry failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "pending_push=present") ||
+		!strings.Contains(out, "pushed compacted main") {
+		t.Fatalf("output missing pending-push retry success:\n%s", out)
+	}
+	if _, err := os.Stat(cacheFile); err != nil {
+		t.Fatalf("pending-push retry must not purge the remote cache before fetch: %v", err)
+	}
+	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
+		t.Fatalf("successful pending-push retry should clear marker, stat err=%v", err)
 	}
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -838,6 +838,58 @@ func TestCompactScriptSkipsBelowThresholdWithoutFlattening(t *testing.T) {
 	}
 }
 
+func TestCompactScriptPurgesRemoteCacheBelowThresholdWithoutFlattening(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	cacheFile := filepath.Join(fixture.dataDir, "beads", ".dolt", "git-remote-cache", "cache", "repo.git", "objects", "pack", "pack.pack")
+	if err := os.MkdirAll(filepath.Dir(cacheFile), 0o755); err != nil {
+		t.Fatalf("mkdir remote cache fixture: %v", err)
+	}
+	if err := os.WriteFile(cacheFile, []byte("cached remote pack"), 0o644); err != nil {
+		t.Fatalf("write remote cache fixture: %v", err)
+	}
+
+	out, err := fixture.run(t, "below_threshold", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("compact failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote_cache=purged") {
+		t.Fatalf("output missing remote-cache purge notice:\n%s", out)
+	}
+	cacheDir := filepath.Join(fixture.dataDir, "beads", ".dolt", "git-remote-cache")
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Fatalf("remote cache should be removed for below-threshold db, stat=%v", err)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Contains(string(data), "DOLT_RESET") || strings.Contains(string(data), "DOLT_COMMIT") {
+		t.Fatalf("remote-cache purge must not require flattening:\n%s", data)
+	}
+}
+
+func TestCompactScriptDryRunReportsRemoteCacheWithoutRemoving(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	cacheFile := filepath.Join(fixture.dataDir, "beads", ".dolt", "git-remote-cache", "cache", "repo.git", "objects", "pack", "pack.pack")
+	if err := os.MkdirAll(filepath.Dir(cacheFile), 0o755); err != nil {
+		t.Fatalf("mkdir remote cache fixture: %v", err)
+	}
+	if err := os.WriteFile(cacheFile, []byte("cached remote pack"), 0o644); err != nil {
+		t.Fatalf("write remote cache fixture: %v", err)
+	}
+
+	out, err := fixture.run(t, "below_threshold", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500", "GC_DOLT_COMPACT_DRY_RUN=1")
+	if err != nil {
+		t.Fatalf("compact dry-run failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote_cache=present - dry-run (would purge)") {
+		t.Fatalf("output missing dry-run remote-cache notice:\n%s", out)
+	}
+	if _, err := os.Stat(cacheFile); err != nil {
+		t.Fatalf("dry-run should leave remote cache in place: %v", err)
+	}
+}
+
 func TestCompactScriptDefaultThresholdIs2000(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	out, err := fixture.run(t, "success")

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -369,7 +369,7 @@ set_hash() {
 case "$query" in
   *"SELECT COUNT(*) FROM dolt_remotes WHERE name = 'origin'"*)
     case "$mode" in
-      remote_success|remote_success_requires_cache|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
+      remote_success|remote_success_requires_cache|remote_missing_cache_once|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
         print_cell 1
         ;;
       *)
@@ -391,7 +391,7 @@ case "$query" in
     ;;
   *"SELECT COUNT(*) FROM dolt_remotes"*)
     case "$mode" in
-      remote_success|remote_success_requires_cache|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten)
+      remote_success|remote_success_requires_cache|remote_missing_cache_once|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten)
         print_cell 1
         ;;
       multiple_remotes_with_origin|multiple_remotes_no_origin)
@@ -408,7 +408,7 @@ case "$query" in
     ;;
   *"SELECT name FROM dolt_remotes ORDER BY name LIMIT 1"*)
     case "$mode" in
-      remote_success|remote_success_requires_cache|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
+      remote_success|remote_success_requires_cache|remote_missing_cache_once|remote_active_branch|remote_invalid_active_branch|remote_ahead|remote_ahead_reconciled|remote_fetch_failure|remote_fetch_failure_once|remote_push_failure|remote_advances_before_push|remote_gc_failure_once|remote_empty_head_push_failure|remote_ancestry_probe_failure|remote_writer_race_before_flatten|multiple_remotes_with_origin)
         print_cell origin
         ;;
       explicit_backup_remote)
@@ -424,6 +424,13 @@ case "$query" in
     if [ "$mode" = "remote_success_requires_cache" ] && [ ! -f "${GC_DOLT_DATA_DIR:-}/$db/.dolt/git-remote-cache/fetch-required" ]; then
       printf 'remote cache missing before fetch\n' >&2
       exit 55
+    fi
+    if [ "$mode" = "remote_missing_cache_once" ]; then
+      repo_path="${GC_DOLT_DATA_DIR:-}/$db/.dolt/git-remote-cache/cachehash/repo.git"
+      if [ ! -d "$repo_path" ]; then
+        printf "failed to read latest version of remote db: fatal: not a git repository: '%%s'\n" "$repo_path" >&2
+        exit 55
+      fi
     fi
     if [ "$mode" = "remote_fetch_failure" ]; then
       printf 'fetch unavailable\n' >&2
@@ -1049,6 +1056,51 @@ func TestCompactScriptRunsLocalFullGCBeforePendingPushRetry(t *testing.T) {
 	}
 	if strings.Contains(log, "DOLT_RESET") || strings.Contains(log, "DOLT_COMMIT") {
 		t.Fatalf("pending-push local full GC must not flatten again:\n%s", log)
+	}
+}
+
+func TestCompactScriptRepairsMissingGitRemoteCacheBeforePendingPushRetry(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if err := os.MkdirAll(filepath.Dir(pendingPush), 0o755); err != nil {
+		t.Fatalf("mkdir pending-push fixture: %v", err)
+	}
+	if err := os.WriteFile(pendingPush, []byte(
+		"db=beads\n"+
+			"reason=flatten and full GC succeeded but remote push failed\n"+
+			"created_at="+time.Now().UTC().Format("2006-01-02T15:04:05Z")+"\n"+
+			"remote=origin\n"+
+			"expected_remote_head=headcommit\n"+
+			"expected_remote_head_verified=1\n"+
+			"compacted_from_head=headcommit\n"+
+			"local_branch=main\n"+
+			"remote_branch=main\n",
+	), 0o600); err != nil {
+		t.Fatalf("write pending-push fixture: %v", err)
+	}
+
+	out, err := fixture.run(t, "remote_missing_cache_once", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("pending-push retry should repair missing git remote cache and push: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "git_remote_cache=initialized") ||
+		!strings.Contains(out, "pushed compacted main") {
+		logData, _ := os.ReadFile(fixture.doltLog)
+		t.Fatalf("output missing remote-cache repair and push success:\n%s\nlog:\n%s", out, logData)
+	}
+	repoPath := filepath.Join(fixture.dataDir, "beads", ".dolt", "git-remote-cache", "cachehash", "repo.git")
+	if _, err := os.Stat(filepath.Join(repoPath, "HEAD")); err != nil {
+		t.Fatalf("expected initialized bare git cache at %s: %v", repoPath, err)
+	}
+	if _, err := os.Stat(pendingPush); !os.IsNotExist(err) {
+		t.Fatalf("successful repaired retry should clear marker, stat err=%v", err)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	if strings.Count(string(logData), "CALL DOLT_FETCH('origin')") < 2 {
+		t.Fatalf("retry should re-run fetch after cache repair:\n%s", logData)
 	}
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -165,6 +165,7 @@ func (f compactScriptFixture) run(t *testing.T, mode string, extraEnv ...string)
 		"GC_DOLT_COMPACT_ONLY_DBS",
 		"GC_DOLT_COMPACT_REMOTE",
 		"GC_DOLT_COMPACT_BARE_GC",
+		"GC_DOLT_COMPACT_REMOTE_CACHE_ONLY",
 		"GC_FAKE_DOLT_COMPACT_MODE",
 		"GC_FAKE_DOLT_COUNT_FILE",
 		"GC_FAKE_DOLT_STATE_FILE",
@@ -887,6 +888,64 @@ func TestCompactScriptDryRunReportsRemoteCacheWithoutRemoving(t *testing.T) {
 	}
 	if _, err := os.Stat(cacheFile); err != nil {
 		t.Fatalf("dry-run should leave remote cache in place: %v", err)
+	}
+}
+
+func TestCompactScriptRemoteCacheOnlySkipsPendingPushRetry(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	cacheFile := filepath.Join(fixture.dataDir, "beads", ".dolt", "git-remote-cache", "cache", "repo.git", "objects", "pack", "pack.pack")
+	if err := os.MkdirAll(filepath.Dir(cacheFile), 0o755); err != nil {
+		t.Fatalf("mkdir remote cache fixture: %v", err)
+	}
+	if err := os.WriteFile(cacheFile, []byte("cached remote pack"), 0o644); err != nil {
+		t.Fatalf("write remote cache fixture: %v", err)
+	}
+
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if err := os.MkdirAll(filepath.Dir(pendingPush), 0o755); err != nil {
+		t.Fatalf("mkdir pending-push fixture: %v", err)
+	}
+	if err := os.WriteFile(pendingPush, []byte(
+		"db=beads\n"+
+			"reason=flatten and full GC succeeded but remote push failed\n"+
+			"created_at="+time.Now().UTC().Format("2006-01-02T15:04:05Z")+"\n"+
+			"remote=origin\n"+
+			"expected_remote_head=headcommit\n"+
+			"expected_remote_head_verified=1\n"+
+			"compacted_from_head=headcommit\n"+
+			"local_branch=main\n"+
+			"remote_branch=main\n",
+	), 0o600); err != nil {
+		t.Fatalf("write pending-push fixture: %v", err)
+	}
+
+	out, err := fixture.run(t, "remote_success",
+		"GC_DOLT_COMPACT_THRESHOLD_COMMITS=500",
+		"GC_DOLT_COMPACT_REMOTE_CACHE_ONLY=1",
+	)
+	if err != nil {
+		t.Fatalf("remote-cache-only compact failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "remote_cache=purged") ||
+		!strings.Contains(out, "remote_cache_only=1") {
+		t.Fatalf("output missing remote-cache-only notices:\n%s", out)
+	}
+	cacheDir := filepath.Join(fixture.dataDir, "beads", ".dolt", "git-remote-cache")
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Fatalf("remote cache should be removed, stat=%v", err)
+	}
+	if _, err := os.Stat(pendingPush); err != nil {
+		t.Fatalf("remote-cache-only must leave pending-push marker for explicit retry: %v", err)
+	}
+	data, err := os.ReadFile(fixture.doltLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(data)
+	for _, forbidden := range []string{"DOLT_PUSH", "DOLT_FETCH", "DOLT_RESET", "DOLT_COMMIT"} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("remote-cache-only must not run %s:\n%s", forbidden, log)
+		}
 	}
 }
 

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -997,6 +997,61 @@ func TestCompactScriptPreservesRemoteCacheBeforePendingPushRetry(t *testing.T) {
 	}
 }
 
+func TestCompactScriptRunsLocalFullGCBeforePendingPushRetry(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	oldgenFile := filepath.Join(fixture.dataDir, "beads", ".dolt", "noms", "oldgen", "archive")
+	if err := os.MkdirAll(filepath.Dir(oldgenFile), 0o755); err != nil {
+		t.Fatalf("mkdir oldgen fixture: %v", err)
+	}
+	if err := os.WriteFile(oldgenFile, []byte("orphaned oldgen data"), 0o644); err != nil {
+		t.Fatalf("write oldgen fixture: %v", err)
+	}
+
+	pendingPush := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-push", "beads")
+	if err := os.MkdirAll(filepath.Dir(pendingPush), 0o755); err != nil {
+		t.Fatalf("mkdir pending-push fixture: %v", err)
+	}
+	if err := os.WriteFile(pendingPush, []byte(
+		"db=beads\n"+
+			"reason=flatten and full GC succeeded but remote push failed\n"+
+			"created_at="+time.Now().UTC().Format("2006-01-02T15:04:05Z")+"\n"+
+			"remote=origin\n"+
+			"expected_remote_head=headcommit\n"+
+			"expected_remote_head_verified=1\n"+
+			"compacted_from_head=headcommit\n"+
+			"local_branch=main\n"+
+			"remote_branch=main\n",
+	), 0o600); err != nil {
+		t.Fatalf("write pending-push fixture: %v", err)
+	}
+
+	out, err := fixture.run(t, "remote_fetch_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err != nil {
+		t.Fatalf("pending-push retry should keep fetch failure recoverable after local GC: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "pending_push oldgen_archives=present") ||
+		!strings.Contains(out, "pending-push local-GC") {
+		t.Fatalf("output missing pending-push local-GC evidence:\n%s", out)
+	}
+	if _, err := os.Stat(oldgenFile); !os.IsNotExist(err) {
+		t.Fatalf("pending-push local full GC should reclaim oldgen fixture, stat=%v", err)
+	}
+	if _, err := os.Stat(pendingPush); err != nil {
+		t.Fatalf("failed remote fetch should keep pending-push marker: %v", err)
+	}
+	logData, err := os.ReadFile(fixture.doltLog)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "CALL DOLT_GC('--full')") {
+		t.Fatalf("pending-push retry should run local full GC before remote repair:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_RESET") || strings.Contains(log, "DOLT_COMMIT") {
+		t.Fatalf("pending-push local full GC must not flatten again:\n%s", log)
+	}
+}
+
 func TestCompactScriptDefaultThresholdIs2000(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	out, err := fixture.run(t, "success")


### PR DESCRIPTION
Refs #2903

## Main Rebase

Rebased onto current `origin/main` (`9bc8ba57d`) on 2026-06-01. The old stack-only `engdocs/contributors/bead-leak-bookkeeping.md` edits are intentionally omitted; #2903 carries the tracker/report evidence.

Merge proof: branch merge-base is `origin/main`; `git diff --check origin/main..HEAD` passed.

## Finding / Cause

Rebuildable `.dolt/git-remote-cache` directories and oldgen archives dominated storage; deleting caches at the wrong point could break pending remote repair.

## Fix

Remote-cache cleanup runs before normal blockers, cache-only mode is available, caches are preserved during pending repair, local full GC runs before pending-push retry when oldgen exists, and missing bare cache repos are rebuilt before one fetch retry.

Main adaptation: this branch intentionally does not import #2910's legacy pending-marker recovery. The remote-cache branch now always runs the existing freshness check, so it is standalone against `origin/main`.

## Verification

- `go test ./examples/dolt -run 'TestCompactScriptPurgesRemoteCacheBelowThresholdWithoutFlattening|TestCompactScriptDryRunReportsRemoteCacheWithoutRemoving|TestCompactScriptRemoteCacheOnlySkipsPendingPushRetry|TestCompactScriptPreservesRemoteCacheBeforePendingPushRetry|TestCompactScriptRunsLocalFullGCBeforePendingPushRetry|TestCompactScriptRepairsMissingGitRemoteCacheBeforePendingPushRetry' -count=1`
