### PR TITLE
Bead leaks: safely close stale inactive workflow roots

### DIFF
--- a/engdocs/contributors/bead-leak-bookkeeping.md
+++ b/engdocs/contributors/bead-leak-bookkeeping.md
@@ -41,6 +41,14 @@ edges and no issue-level dependencies. Those rows are stranded before graph
 wiring completes, so the reaper now closes only that isolated generated-spec
 shape. Ordinary no-edge wisps remain report-only.
 
+Stale workflow roots have a separate safe-close path. The reaper now matches
+only non-message roots carrying workflow metadata (`gc.kind=workflow` or
+`gc.formula_contract=graph.v2`), requires both old `created_at` and old
+`updated_at`, requires no assignee, rejects roots with active non-message
+dependents, and rejects any unresolved outgoing wisp or issue dependency edge.
+Dry-run includes these roots in `would_close_wisps`; live mode closes only that
+guarded root shape. This is intentionally not a generic age-only root closer.
+
 Live inspection found another boundedness gap in session beads. Several old
 session wisps were `state=asleep` with `sleep_reason=drained` but lacked
 `slept_at`, so `gc session prune --state asleep` skipped them forever.
@@ -184,7 +192,7 @@ still refuses to create arbitrary paths from a malformed error message.
 
 | Path | Beads opened | Bookkeeping owner |
 | --- | --- | --- |
-| `internal/molecule/graph_apply.go` graph workflow instantiation | Wisp root plus logical/step wisps. Non-root graph steps are linked to the root with `tracks`; explicit ordering uses `blocks`; legacy containment uses `parent-child`. | Normal workflow execution closes runnable steps. `molecule.CloseSubtree` closes owned descendants during explicit cleanup. `reaper.sh` now closes stale leftovers when all reaper-owned dependency targets are closed. |
+| `internal/molecule/graph_apply.go` graph workflow instantiation | Wisp root plus logical/step wisps. Non-root graph steps are linked to the root with `tracks`; explicit ordering uses `blocks`; legacy containment uses `parent-child`. | Normal workflow execution closes runnable steps. `molecule.CloseSubtree` closes owned descendants during explicit cleanup. `reaper.sh` now closes stale step leftovers when all reaper-owned dependency targets are closed, and closes stale inactive workflow roots only when root-specific dependency/dependent guards prove there is no live graph pressure. |
 | `cmd/gc/order_dispatch.go` order dispatch | Ephemeral order-tracking bead labeled `gc:order-tracking`; wisp orders also create a molecule/wisp root via `molecule.Instantiate`. | `dispatchOne` defers `closeOrderTrackingBead`. Wisp roots are intentionally not auto-closed solely because descendants finish; the reaper handles stale roots/steps only when dependency evidence proves closure is safe. |
 | `cmd/gc/dispatch_runtime.go` control-dispatcher serve loop | Graph-v2 control beads such as `check`, `drain`, `fanout`, `retry`, `retry-eval`, `scope-check`, and `workflow-finalize` drive workflow progression and may appear in the controller work query. | Routed control work now always reaches `runControlDispatcherWithStoreAndConfig`. Unsupported or misrouted kinds are quarantined with explicit `gc.control_quarantined` metadata; legacy oversized attempt-log failures return a visible serve error instead of masquerading as idle. |
 | Graph-v2 helper paths in `internal/graphv2/invocation.go`, `internal/dispatch/drain.go`, `internal/dispatch/retry.go`, and `internal/dispatch/ralph.go` | Synthetic input convoys, drain-unit convoys, retry attempt/eval beads, and cloned ralph retry/check beads. | Control dispatch owns normal progression and terminal metadata. The synthetic convoys are linked with `tracks` so convoy close/check paths can close completed units; retry and ralph clones remain graph-owned work and fall under graph-v2 finalization plus stale dependency-edge cleanup if stranded. |
@@ -208,7 +216,7 @@ session aliases already covered by the session row (`adoption_barrier`,
 
 | Path | Responsibility | Current status |
 | --- | --- | --- |
-| `examples/gastown/packs/maintenance/assets/scripts/reaper.sh` | Close stale non-closed wisps with closed dependency targets; close isolated generated step-spec debris; purge old closed wisps; auto-close stale city issues; prune closed `gm-*` session beads; prune terminal drained session-state beads; escalate only stale non-message open-wisp backlog. | Patched for `parent-child`/`tracks`/`blocks` closure and purge protection through `wisp_dependencies`, plus a narrow unassigned `Step spec for ...` no-edge cleanup, a `gc session prune --state drained` pass for legacy drained-asleep session rows, and a stale-only alert query so fresh workflow load is not reported as a reaper leak. |
+| `examples/gastown/packs/maintenance/assets/scripts/reaper.sh` | Close stale non-closed wisps with closed dependency targets; close isolated generated step-spec debris; close stale inactive workflow roots with no live dependency pressure; purge old closed wisps; auto-close stale city issues; prune closed `gm-*` session beads; prune terminal drained session-state beads; escalate only stale non-message open-wisp backlog. | Patched for `parent-child`/`tracks`/`blocks` closure and purge protection through `wisp_dependencies`, plus a narrow unassigned `Step spec for ...` no-edge cleanup, guarded workflow-root cleanup, a `gc session prune --state drained` pass for legacy drained-asleep session rows, and a stale-only alert query so fresh workflow load is not reported as a reaper leak. |
 | `examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh` | Promote old non-closed ephemeral beads for stuck detection and delete expired closed wisps. | Still separate from the safe-close decision. It must not become an age-only closer. |
 | `internal/molecule/cleanup.go` | Close molecule subtrees by ownership metadata and parent-child descendants. | Handles explicit teardown, not abandoned workflow drift. |
 | `cmd/gc/wisp_gc.go` / `wisp autoclose` | Close attached workflow roots and owned workflow beads from CLI-driven cleanup. Purge expired closed wisps, order-tracking beads, and closed graph-v2 workflow-root closures. | Patched to include workflow-root closure GC through indexed metadata queries guarded by `sourceworkflow.IsWorkflowRoot`. |
@@ -222,8 +230,14 @@ session aliases already covered by the session row (`adoption_barrier`,
 
 ## Verification Snapshot
 
-- `go test ./examples/gastown -count=1` passed for the reaper and wisp-GC
-  changes and the deacon patrol burn-before-backoff regression.
+- `go test ./examples/gastown -run 'TestReaper(ClosesStaleInactiveWorkflowRoots|DryRunReportsWouldCloseStaleWorkflowRoots)$' -count=1`
+  failed before the guarded workflow-root cleanup because the reaper emitted no
+  root candidate query/update and dry-run reported `would_close_wisps:0`; it
+  passed after the root-safe cleanup path was added.
+- `go test ./examples/gastown -run 'TestReaper' -count=1` passed for the full
+  reaper maintenance-script regression set.
+- `go test ./examples/gastown -count=1` passed for the reaper, wisp-GC, and
+  deacon patrol burn-before-backoff regressions.
 - `go test ./examples/gastown -run TestDeaconPatrolNextIterationBurnsCurrentBeforeBackoff -count=1`
   failed before the `mol-deacon-patrol` version 15 change and passed after it.
 - `go test ./internal/session -count=1` passed for the session prune timestamp
@@ -365,14 +379,12 @@ session aliases already covered by the session row (`adoption_barrier`,
   continues to support the stale-only reaper alert boundary. This is not enough
   to close `ga-k5ds4` because its AC explicitly asks for raw open wisps below
   500 in both `ga` and `mc`.
-- Stale stuck-root follow-up boundary for `ga-k5ds4`: do not add a bare
-  age-only root closer. A safe implementation needs dry-run-first reporting and
-  should close only old workflow/root wisps that have no open non-message
-  dependents, no active hook/assignee evidence, no recent `updated_at`, and no
-  unresolved dependency edge; it should leave mail backlog and active workflow
-  pressure out of the reaper-safe closure set. This remains the path for
-  satisfying the raw-count AC without turning the reaper into a generic
-  age-based work closer.
+- Stale stuck-root cleanup for `ga-k5ds4` is now implemented in the branch
+  reaper, but it has not yet been applied to the live `/data/projects/maintainer-city`
+  Dolt server. Remaining proof is a branch dry-run/live run followed by raw
+  open-wisp remeasurement. Keep `ga-k5ds4` open until `ga` and `mc` are below
+  the literal raw `<500` AC, or the AC is explicitly revised to the stale
+  non-message invariant.
 - Live route-key inspection and repair at 2026-06-01T10:58:02Z found `139`
   `ga.wisps` workflow roots with `gc.run_target` and missing `gc.routed_to`:
   `129` closed, `6` in progress, and `4` open. A later all-database scan at

--- a/engdocs/contributors/bead-leak-bookkeeping.md
+++ b/engdocs/contributors/bead-leak-bookkeeping.md
@@ -397,6 +397,15 @@ session aliases already covered by the session row (`adoption_barrier`,
 - Branch reaper dry-run on the same live server after the stale-only alert
   patch reported `stale_wisps:115`, `mail_wisps:134`, `would_close_wisps:0`,
   and made no escalation mail call with `GC_REAPER_ALERT_THRESHOLD=500`.
+- Branch reaper dry-run after the guarded stale workflow-root cleanup patch
+  ran on 2026-06-01T13:37:24Z against the same live server with explicit
+  `GC_DOLT_PORT=3307`. Direct read-only SQL found zero guarded workflow-root
+  candidates in `ga`, `mc`, `gt`, `my_db`, `bd`, `gp`, `gg`, and `rig`; the
+  script dry-run matched that with `stale_wisps:115`, `mail_wisps:156`, and
+  `would_close_wisps:0`. Raw `status='open'` counts were still `ga=619` and
+  `mc=730`, while stale non-message counts stayed bounded at `ga=13` and
+  `mc=24`. No live reaper mutation was run because the new root path had no
+  safe candidates to close.
 - Dolt compaction remains blocked for `mc` by
   `/data/projects/maintainer-city/.gc/runtime/packs/dolt/compact-quarantine/mc`
   (`post-flatten value hash changed without row-count increase`,
@@ -461,3 +470,15 @@ session aliases already covered by the session row (`adoption_barrier`,
   `2od9635iqrpmfvs92gthl4bftgacr28j`. Local Dolt storage dropped to about
   `1.2G` total, with `ga=521M` and `mc=516M`; no `.dolt/git-remote-cache`
   directories remained.
+- Current Dolt retention dry-run on 2026-06-01T13:37:24Z used the branch
+  compactor with `GC_DOLT_COMPACT_ONLY_DBS=ga,mc`,
+  `GC_DOLT_DATA_DIR=/data/services/gascity-local-dolt`, explicit loopback
+  `127.0.0.1:3307`, and `GC_PACK_DIR` pinned to the branch Dolt pack. It
+  reached both remaining guardrails and stopped without mutation:
+  `mc` still has the integrity quarantine marker from
+  `2026-05-20T11:14:29Z`, and `ga` still has the upgraded pending-push marker
+  from `2026-05-16T18:03:26Z`, now rejected as stale by the marker age guard
+  before any remote push retry. Current local Dolt storage was about `1.4G`
+  total (`ga=653M`, `mc=545M`, `gt=33M`, `bd=34M`, `gp=50M`,
+  `my_db=59M`). These are explicit manual-review blockers, not remaining
+  compactor code paths.

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3593,6 +3593,193 @@ exit 0
 	}
 }
 
+func TestReaperClosesStaleInactiveWorkflowRoots(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SHOW COLUMNS FROM"*"wisp_dependencies"*)
+    printf 'Field,Type,Null,Key,Default,Extra\n'
+    printf 'issue_id,varchar,NO,,,\n'
+    printf 'depends_on_issue_id,varchar,YES,,,\n'
+    printf 'depends_on_wisp_id,varchar,YES,,,\n'
+    printf 'depends_on_external,varchar,YES,,,\n'
+    printf 'type,varchar,NO,,,\n'
+    ;;
+  *"COUNT(DISTINCT w.id)"*"d.type IN ('parent-child', 'tracks', 'blocks')"*"NOT EXISTS"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"COUNT("*"issue_type = 'spec'"*"Step spec for %"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"COUNT(id)"*"JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')"*"workflow"*)
+    printf 'COUNT(id)\n1\n'
+    ;;
+  *"UPDATE "*"wisps SET status='closed'"*"JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')"*"workflow"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") {
+		t.Fatalf("reaper did not close stale inactive workflow roots:\n%s", log)
+	}
+	for _, want := range []string{
+		"JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')",
+		"JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')",
+		"COALESCE(w.updated_at, w.created_at) < DATE_SUB",
+		"COALESCE(w.assignee, '') = ''",
+		"d.depends_on_wisp_id = w.id",
+		"child_wisp.status IN ('open', 'hooked', 'in_progress')",
+		"COALESCE(child_wisp.issue_type, '') != 'message'",
+		"d.issue_id = w.id",
+		"target_wisp.status IS NULL OR target_wisp.status != 'closed'",
+		"target_issue.status IS NULL OR target_issue.status != 'closed'",
+		"dependencies d",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("workflow-root close query missing %q:\n%s", want, log)
+		}
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "closed_wisps:1") {
+		t.Fatalf("reaper summary did not report closed stale workflow root:\n%s", gcData)
+	}
+}
+
+func TestReaperDryRunReportsWouldCloseStaleWorkflowRoots(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SHOW COLUMNS FROM"*"wisp_dependencies"*)
+    printf 'Field,Type,Null,Key,Default,Extra\n'
+    printf 'issue_id,varchar,NO,,,\n'
+    printf 'depends_on_issue_id,varchar,YES,,,\n'
+    printf 'depends_on_wisp_id,varchar,YES,,,\n'
+    printf 'depends_on_external,varchar,YES,,,\n'
+    printf 'type,varchar,NO,,,\n'
+    ;;
+  *"COUNT(DISTINCT w.id)"*"d.type IN ('parent-child', 'tracks', 'blocks')"*"NOT EXISTS"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"COUNT("*"issue_type = 'spec'"*"Step spec for %"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"COUNT(id)"*"JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')"*"workflow"*)
+    printf 'COUNT(id)\n1\n'
+    ;;
+  *"UPDATE "*"wisps SET status='closed'"*)
+    printf 'dry-run should not update wisps\n' >&2
+    exit 42
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":     doltLog,
+		"GC_CALL_LOG":       gcLog,
+		"GC_CITY":           cityDir,
+		"GC_CITY_PATH":      cityDir,
+		"GC_DOLT_HOST":      "127.0.0.1",
+		"GC_DOLT_PORT":      "3307",
+		"GC_DOLT_USER":      "root",
+		"GC_DOLT_PASSWORD":  "",
+		"GC_REAPER_DRY_RUN": "1",
+		"PATH":              binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	if strings.Contains(string(logData), "UPDATE `beads`.wisps SET status='closed'") {
+		t.Fatalf("dry-run executed stale workflow-root update:\n%s", logData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcText := string(gcData)
+	if !strings.Contains(gcText, "closed_wisps:0") || !strings.Contains(gcText, "would_close_wisps:1") || !strings.Contains(gcText, "(dry run)") {
+		t.Fatalf("dry-run summary did not report stale workflow-root would-close count:\n%s", gcText)
+	}
+}
+
 func TestReaperEscalatesDoltCommitFailure(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -521,6 +521,116 @@ while IFS= read -r DB; do
         fi
     fi
 
+    # Workflow roots are expected to stand alone, so they cannot use the
+    # dependency-target rule above. Close only old, inactive roots with no
+    # active non-message dependents and no unresolved dependency edges.
+    get_sql_count "$DB" "stale inactive workflow root wisp" "
+        SELECT COUNT(id) FROM (
+            SELECT w.id FROM \`$DB\`.wisps w
+            WHERE w.status IN ('open', 'hooked', 'in_progress')
+            AND COALESCE(w.issue_type, '') != 'message'
+            AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+            AND COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+            AND COALESCE(w.assignee, '') = ''
+            AND (
+                LOWER(COALESCE(JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')), '')) = 'workflow'
+                OR LOWER(COALESCE(JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')), '')) = 'graph.v2'
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM \`$DB\`.wisp_dependencies d
+                INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
+                WHERE d.depends_on_wisp_id = w.id
+                AND d.type IN ('parent-child', 'tracks', 'blocks')
+                AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+                AND COALESCE(child_wisp.issue_type, '') != 'message'
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM \`$DB\`.wisp_dependencies d
+                LEFT JOIN \`$DB\`.wisps target_wisp ON d.depends_on_wisp_id = target_wisp.id
+                LEFT JOIN \`$DB\`.issues target_issue ON d.depends_on_issue_id = target_issue.id
+                WHERE d.issue_id = w.id
+                AND d.type IN ('parent-child', 'tracks', 'blocks')
+                AND (
+                    (d.depends_on_wisp_id IS NOT NULL AND (target_wisp.status IS NULL OR target_wisp.status != 'closed'))
+                    OR (d.depends_on_issue_id IS NOT NULL AND (target_issue.status IS NULL OR target_issue.status != 'closed'))
+                    OR (d.depends_on_wisp_id IS NULL AND d.depends_on_issue_id IS NULL)
+                )
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM \`$DB\`.dependencies d
+                LEFT JOIN \`$DB\`.issues target_issue ON d.depends_on_issue_id = target_issue.id
+                WHERE d.issue_id = w.id
+                AND (target_issue.status IS NULL OR target_issue.status != 'closed')
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM \`$DB\`.dependencies d
+                INNER JOIN \`$DB\`.issues child_issue ON d.issue_id = child_issue.id
+                WHERE d.depends_on_issue_id = w.id
+                AND child_issue.status IN ('open', 'in_progress')
+            )
+        ) reaper_workflow_root_candidates
+    "
+    WORKFLOW_ROOT_COUNT=$SQL_COUNT_RESULT
+    if [ "$WORKFLOW_ROOT_COUNT" -gt 0 ] && [ -n "$DRY_RUN" ]; then
+        TOTAL_WOULD_CLOSE_WISPS=$((TOTAL_WOULD_CLOSE_WISPS + WORKFLOW_ROOT_COUNT))
+    fi
+    if [ "$WORKFLOW_ROOT_COUNT" -gt 0 ] && [ -z "$DRY_RUN" ]; then
+        if run_sql_change "$DB" "closing stale inactive workflow roots" "
+            UPDATE \`$DB\`.wisps SET status='closed', closed_at=NOW()
+            WHERE id IN (
+                SELECT id FROM (
+                    SELECT w.id FROM \`$DB\`.wisps w
+                    WHERE w.status IN ('open', 'hooked', 'in_progress')
+                    AND COALESCE(w.issue_type, '') != 'message'
+                    AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+                    AND COALESCE(w.updated_at, w.created_at) < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+                    AND COALESCE(w.assignee, '') = ''
+                    AND (
+                        LOWER(COALESCE(JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.kind\"')), '')) = 'workflow'
+                        OR LOWER(COALESCE(JSON_UNQUOTE(JSON_EXTRACT(w.metadata, '$.\"gc.formula_contract\"')), '')) = 'graph.v2'
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM \`$DB\`.wisp_dependencies d
+                        INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
+                        WHERE d.depends_on_wisp_id = w.id
+                        AND d.type IN ('parent-child', 'tracks', 'blocks')
+                        AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+                        AND COALESCE(child_wisp.issue_type, '') != 'message'
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM \`$DB\`.wisp_dependencies d
+                        LEFT JOIN \`$DB\`.wisps target_wisp ON d.depends_on_wisp_id = target_wisp.id
+                        LEFT JOIN \`$DB\`.issues target_issue ON d.depends_on_issue_id = target_issue.id
+                        WHERE d.issue_id = w.id
+                        AND d.type IN ('parent-child', 'tracks', 'blocks')
+                        AND (
+                            (d.depends_on_wisp_id IS NOT NULL AND (target_wisp.status IS NULL OR target_wisp.status != 'closed'))
+                            OR (d.depends_on_issue_id IS NOT NULL AND (target_issue.status IS NULL OR target_issue.status != 'closed'))
+                            OR (d.depends_on_wisp_id IS NULL AND d.depends_on_issue_id IS NULL)
+                        )
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM \`$DB\`.dependencies d
+                        LEFT JOIN \`$DB\`.issues target_issue ON d.depends_on_issue_id = target_issue.id
+                        WHERE d.issue_id = w.id
+                        AND (target_issue.status IS NULL OR target_issue.status != 'closed')
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM \`$DB\`.dependencies d
+                        INNER JOIN \`$DB\`.issues child_issue ON d.issue_id = child_issue.id
+                        WHERE d.depends_on_issue_id = w.id
+                        AND child_issue.status IN ('open', 'in_progress')
+                    )
+                ) reaper_workflow_root_candidates
+            )
+        "; then
+            WORKFLOW_ROOT_ROWS=$SQL_CHANGE_ROWS_RESULT
+            DB_CLOSED_WISPS=$((DB_CLOSED_WISPS + WORKFLOW_ROOT_ROWS))
+            TOTAL_CLOSED_WISPS=$((TOTAL_CLOSED_WISPS + WORKFLOW_ROOT_ROWS))
+            DB_MUTATIONS=$((DB_MUTATIONS + WORKFLOW_ROOT_ROWS))
+        fi
+    fi
+
     # Step 2: Purge — delete closed wisps past purge_age.
     get_sql_count "$DB" "closed wisp purge" "
         SELECT COUNT(*) FROM \`$DB\`.wisps


### PR DESCRIPTION
Refs #2903

## Stack

Draft PR 14 in the bead-leak stack.

- Base: `bead-leaks/13-bookkeeping-report-audit`
- Head: `bead-leaks/14-stale-workflow-roots`

Review this PR against its stacked base branch. The full tracker is #2903.

## Finding / Cause

Some workflow roots could remain open after useful graph pressure was gone, but generic age-only root closure would be unsafe.

## Fix

The reaper now closes only old non-message workflow roots with workflow metadata, no assignee, old created_at and updated_at, no active non-message dependents, and no unresolved outgoing wisp or issue dependency edges. Dry-run reports these in would_close_wisps.

## Verification

Reaper stale-root dry-run tests failed before this path and passed after it. Live dry-run found no safe root candidates, so no root mutation was run.

## Status

Draft for maintainer review.
