### PR TITLE
Bead leaks: sync reaper stale-wisp alert contract

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2291,6 +2291,26 @@ func TestReaperFormulaSQLReflectsCurrentSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(%s): %v", path, err)
 	}
+	formula := string(data)
+
+	for _, stalePhrase := range []string{
+		"Total open wisps (for alert threshold)",
+		"If total open wisps",
+		"Open wisp count exceeding",
+	} {
+		if strings.Contains(formula, stalePhrase) {
+			t.Errorf("formula still describes total-open-wisp alerting with %q; reaper alerts on stale non-message open wisps", stalePhrase)
+		}
+	}
+	for _, required := range []string{
+		"Stale non-message open wisps (for alert threshold)",
+		"issue_type NOT IN ('message')",
+		"created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)",
+	} {
+		if !strings.Contains(formula, required) {
+			t.Errorf("formula is missing stale-only alert text/query fragment %q", required)
+		}
+	}
 
 	// Extract every ```sql ... ``` fence body and scan only those — prose
 	// warnings about the deprecated patterns are intentional and must not

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -153,9 +153,11 @@ AND id NOT IN (
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
 );
 
--- Total open wisps (for alert threshold)
+-- Stale non-message open wisps (for alert threshold)
 SELECT COUNT(*) FROM wisps
-WHERE status IN ('open', 'hooked', 'in_progress');
+WHERE status IN ('open', 'hooked', 'in_progress')
+AND issue_type NOT IN ('message')
+AND created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR);
 ```
 
 Mail is not a SQL table — do not query it via Dolt. Mail messages are
@@ -163,7 +165,7 @@ beads with Type=message; any mail cleanup goes through `bd`.
 
 **3. Check for anomalies:**
 - Sudden spikes in stale non-closed wisps vs previous cycle
-- Open wisp count exceeding {{alert_threshold}}
+- Stale non-message open wisps exceeding {{alert_threshold}}
 
 **4. Decide whether to proceed:**
 - If no candidates found across all databases, skip remaining steps
@@ -223,8 +225,9 @@ AND id IN (
 - Any errors encountered
 
 **4. Alert check:**
-If total open wisps across all databases exceed {{alert_threshold}},
-log a warning and consider escalating.
+If stale non-message open wisps across all databases exceed
+{{alert_threshold}}, log a warning and consider escalating. Fresh workflow load
+can legitimately exceed the raw open-wisp threshold on busy cities.
 
 **Exit criteria:** Stale non-closed wisps counted; only stale wisps with closed parents closed."""
 
@@ -334,7 +337,7 @@ gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
 
 **3. Signal completion:**
 ```bash
-gc session nudge deacon/ "DOG_DONE: reaper — stale_wisps:<count>, closed_wisps:<count>, purged:<count>, closed:<count>, skipped_non_city_issues:<count>"
+gc session nudge deacon/ "DOG_DONE: reaper — stale_wisps:<count>, closed_wisps:<count>, purged:<count>, sessions-pruned:<count>, closed:<count>, skipped_non_city_issues:<count>, mail_wisps:<count>[, would_close_wisps:<count> (dry run)]"
 ```
 
 **4. Close work and exit:**


### PR DESCRIPTION
Refs #2903

## Finding / Cause

The Mol Dog reaper formula still described its alert threshold as a raw total-open-wisp check. That no longer matches the intended contract: fresh workflow load can legitimately exceed the raw open-wisp threshold, and the alert should track stale non-message open wisps instead.

The plain idle-city nightly probe from the original stacked draft was removed from this PR because that coverage is already upstream via #2911.

## Fix

Updates `mol-dog-reaper.toml` so the alert contract and SQL example count stale non-message open wisps older than the configured max age. Adds formula-level assertions to keep the stale-only wording and query fragments from drifting back to raw-open-wisp alerting.

## Rebase Notes

Rebuilt as a single commit on current `origin/main` (`ca7549a23`). Dropped the deleted bookkeeping report conflict and the already-upstream idle-probe commit.

## Verification

- `go test ./examples/gastown -run 'TestReaperFormulaSQLReflectsCurrentSchema|TestReaperFormulaMatchesScriptDefaults' -count=1`
- `.githooks/pre-commit` ran during commit, including `go vet ./...` and `./scripts/test-local-parallel fast`; all fast jobs passed.