### PR TITLE
Bead leaks: archive injected auto-handoff mail

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/spf13/cobra"
@@ -228,7 +229,7 @@ func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRes
 func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps, persistRestart func() error,
 	sessionAddress, sessionName string, args []string, stdout, stderr io.Writer,
 ) handoffOutcome {
-	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "HANDOFF: context cycle", stderr)
+	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "HANDOFF: context cycle", nil, stderr)
 	if !ok {
 		return handoffOutcome{code: 1}
 	}
@@ -271,7 +272,10 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 
 // doHandoffAuto sends handoff mail to self without requesting restart.
 func doHandoffAuto(store beads.Store, rec events.Recorder, sessionAddress string, args []string, hookFormat string, stdout, stderr io.Writer) int {
-	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "context cycle", stderr)
+	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "context cycle", []string{
+		mail.AutoHandoffLabel,
+		mail.ArchiveAfterInjectLabel,
+	}, stderr)
 	if !ok {
 		return 1
 	}
@@ -283,7 +287,7 @@ func doHandoffAuto(store beads.Store, rec events.Recorder, sessionAddress string
 	return 0
 }
 
-func createHandoffMail(store beads.Store, rec events.Recorder, senderAddress, recipientAddress string, args []string, defaultSubject string, stderr io.Writer) (beads.Bead, bool) {
+func createHandoffMail(store beads.Store, rec events.Recorder, senderAddress, recipientAddress string, args []string, defaultSubject string, extraLabels []string, stderr io.Writer) (beads.Bead, bool) {
 	subject := defaultSubject
 	if len(args) > 0 {
 		subject = args[0]
@@ -299,13 +303,15 @@ func createHandoffMail(store beads.Store, rec events.Recorder, senderAddress, re
 	}
 	senderDisplay := mailSenderDisplayFromMetadata(senderAddress, metadata)
 
+	labels := []string{"thread:" + handoffThreadID()}
+	labels = append(labels, extraLabels...)
 	b, err := store.Create(beads.Bead{
 		Title:       subject,
 		Description: message,
 		Type:        "message",
 		Assignee:    recipientAddress,
 		From:        senderDisplay,
-		Labels:      []string{"thread:" + handoffThreadID()},
+		Labels:      labels,
 		Metadata:    metadata,
 		Ephemeral:   true,
 	})
@@ -379,7 +385,7 @@ func clearRestartRequest(store beads.Store, dops drainOps, sessionName string) e
 func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider,
 	sessionName, targetAddress, sender string, args []string, stdout, stderr io.Writer,
 ) int {
-	b, ok := createHandoffMail(store, rec, sender, targetAddress, args, "HANDOFF: context cycle", stderr)
+	b, ok := createHandoffMail(store, rec, sender, targetAddress, args, "HANDOFF: context cycle", nil, stderr)
 	if !ok {
 		return 1
 	}

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -43,6 +44,15 @@ func listOpenMessagesInTier(t *testing.T, store beads.Store, tier beads.TierMode
 		t.Fatalf("List messages in tier %v: %v", tier, err)
 	}
 	return all
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func listOpenBeadsBothTiers(t *testing.T, store beads.Store) []beads.Bead {
@@ -249,6 +259,11 @@ func TestCmdHandoffAutoSendsMailWithoutBlocking(t *testing.T) {
 	}
 	if got := all[0].Type; got != "message" {
 		t.Fatalf("mail type = %q, want message", got)
+	}
+	for _, want := range []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel} {
+		if !hasString(all[0].Labels, want) {
+			t.Fatalf("auto handoff mail labels = %#v, want %q", all[0].Labels, want)
+		}
 	}
 	if strings.Contains(stdout.String(), "requesting restart") {
 		t.Fatalf("stdout = %q, --auto must not request restart", stdout.String())

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -91,9 +91,11 @@ type mailMessageSummary struct {
 
 type mailArchiveSelectOptions struct {
 	Recipient       string
+	AllRecipients   bool
 	From            string
 	SubjectPrefix   string
 	SubjectContains string
+	EmptyBody       bool
 	Limit           int
 	IncludeRead     bool
 	DryRun          bool
@@ -169,8 +171,9 @@ Use this to dismiss messages without reading them. Each message is removed
 and will no longer appear in mail check or inbox results. When multiple IDs
 are passed, they are archived in input order.
 
-For large advisory backlogs, use --to with --subject-prefix, --subject-contains,
-or --from to archive a bounded matching slice without enumerating IDs by hand.`,
+For large advisory backlogs, use --to or --all-recipients with
+--subject-prefix, --subject-contains, or --from to archive a bounded matching
+slice without enumerating IDs by hand.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			code := 0
@@ -194,9 +197,11 @@ or --from to archive a bounded matching slice without enumerating IDs by hand.`,
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
 	cmd.Flags().StringVar(&opts.Recipient, "to", "", "archive matching unread messages addressed to this recipient")
+	cmd.Flags().BoolVar(&opts.AllRecipients, "all-recipients", false, "archive matching messages across all recipients")
 	cmd.Flags().StringVar(&opts.From, "from", "", "archive matching unread messages from this exact sender")
 	cmd.Flags().StringVar(&opts.SubjectPrefix, "subject-prefix", "", "archive matching unread messages whose subject starts with this text")
 	cmd.Flags().StringVar(&opts.SubjectContains, "subject-contains", "", "archive matching unread messages whose subject contains this text")
+	cmd.Flags().BoolVar(&opts.EmptyBody, "empty-body", false, "only archive matching messages whose body is empty")
 	cmd.Flags().IntVar(&opts.Limit, "limit", opts.Limit, "maximum matching messages to archive in this run")
 	cmd.Flags().BoolVar(&opts.IncludeRead, "include-read", false, "include read-but-open messages when selecting by filter")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "list matching messages without archiving them")
@@ -219,9 +224,11 @@ func cmdMailArchiveJSON(args []string, jsonOut bool, stdout, stderr io.Writer) i
 
 func (o mailArchiveSelectOptions) hasSelector() bool {
 	return strings.TrimSpace(o.Recipient) != "" ||
+		o.AllRecipients ||
 		strings.TrimSpace(o.From) != "" ||
 		strings.TrimSpace(o.SubjectPrefix) != "" ||
 		strings.TrimSpace(o.SubjectContains) != "" ||
+		o.EmptyBody ||
 		o.IncludeRead ||
 		o.DryRun
 }
@@ -263,8 +270,12 @@ func doMailArchiveSelectedJSON(mp mail.Provider, rec events.Recorder, args []str
 		return 1
 	}
 	opts.Recipient = strings.TrimSpace(opts.Recipient)
-	if opts.Recipient == "" {
-		fmt.Fprintln(stderr, "gc mail archive: --to is required when using archive filters") //nolint:errcheck // best-effort stderr
+	if opts.Recipient != "" && opts.AllRecipients {
+		fmt.Fprintln(stderr, "gc mail archive: choose either --to or --all-recipients") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if opts.Recipient == "" && !opts.AllRecipients {
+		fmt.Fprintln(stderr, "gc mail archive: --to or --all-recipients is required when using archive filters") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if !opts.hasContentFilter() {
@@ -280,11 +291,16 @@ func doMailArchiveSelectedJSON(mp mail.Provider, rec events.Recorder, args []str
 		fmt.Fprintln(stderr, "gc mail archive: filtered archive requires the beadmail provider") //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	recipients := []string(nil)
+	if !opts.AllRecipients {
+		recipients = []string{opts.Recipient}
+	}
 	filter := beadmail.ArchiveFilter{
-		Recipients:      []string{opts.Recipient},
+		Recipients:      recipients,
 		From:            opts.From,
 		SubjectPrefix:   opts.SubjectPrefix,
 		SubjectContains: opts.SubjectContains,
+		EmptyBody:       opts.EmptyBody,
 		IncludeRead:     opts.IncludeRead,
 		CaseInsensitive: opts.CaseInsensitive,
 		Limit:           opts.Limit,

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -528,14 +528,20 @@ var mailCheckAPIClient = func(cityPath string) (*api.Client, string) {
 	return nil, apiClientFallbackReason(cityPath)
 }
 
-// routeMailCheck dispatches `mail check` to the supervisor API when a
-// controller is up; otherwise falls back to the local mail-provider path.
+// routeMailCheck dispatches non-injecting `mail check` to the supervisor API
+// when a controller is up; otherwise falls back to the local mail-provider path.
+// Injecting hooks always use the local path because provider-backed mail may
+// need to perform delivery side effects after successful injection.
 // Emits exactly one route=... log line per exit path (gated on GC_DEBUG).
 func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *api.Client, nilReason string, stdout, stderr io.Writer) int {
 	const cmdName = "mail check"
 	recipient := defaultMailIdentity()
 	if len(args) > 0 {
 		recipient = strings.TrimSpace(args[0])
+	}
+	if inject {
+		logRoute(stderr, cmdName, "fallback", "inject-local-side-effects")
+		return doMailCheckFallback(args, inject, hookFormat, stdout, stderr)
 	}
 	if c != nil {
 		cr, err := c.ListMailInbox(recipient, "")
@@ -689,7 +695,15 @@ func doMailCheckTargetWithFormat(mp mail.Provider, target resolvedMailTarget, in
 
 	if inject {
 		if len(messages) > 0 {
-			_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatInjectOutput(messages))
+			if err := writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatInjectOutput(messages)); err != nil {
+				fmt.Fprintf(stderr, "gc mail check: writing hook output: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 0
+			}
+			injectedMessages := messages
+			if len(injectedMessages) > mailInjectMaxMessages {
+				injectedMessages = injectedMessages[:mailInjectMaxMessages]
+			}
+			archiveInjectedAutoHandoffMessages(mp, injectedMessages, stderr)
 		}
 		return 0 // --inject always exits 0
 	}
@@ -700,6 +714,24 @@ func doMailCheckTargetWithFormat(mp mail.Provider, target resolvedMailTarget, in
 	}
 	fmt.Fprintf(stdout, "%d unread message(s) for %s\n", len(messages), target.display) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+type injectedAutoHandoffArchiver interface {
+	ArchiveInjectedAutoHandoffs([]string) error
+}
+
+func archiveInjectedAutoHandoffMessages(mp mail.Provider, messages []mail.Message, stderr io.Writer) {
+	archiver, ok := mp.(injectedAutoHandoffArchiver)
+	if !ok {
+		return
+	}
+	ids := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		ids = append(ids, msg.ID)
+	}
+	if err := archiver.ArchiveInjectedAutoHandoffs(ids); err != nil {
+		fmt.Fprintf(stderr, "gc mail check: archiving injected auto handoff mail: %v\n", err) //nolint:errcheck // best-effort stderr
+	}
 }
 
 // formatInjectOutput formats messages as a <system-reminder> block for

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -546,8 +546,9 @@ var mailCheckAPIClient = func(cityPath string) (*api.Client, string) {
 
 // routeMailCheck dispatches non-injecting `mail check` to the supervisor API
 // when a controller is up; otherwise falls back to the local mail-provider path.
-// Injecting hooks always use the local path because provider-backed mail may
-// need to perform delivery side effects after successful injection.
+// Injecting hooks probe the API for degraded-read notices, then use the local
+// path because provider-backed mail may need to perform delivery side effects
+// after successful injection.
 // Emits exactly one route=... log line per exit path (gated on GC_DEBUG).
 func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *api.Client, nilReason string, stdout, stderr io.Writer) int {
 	const cmdName = "mail check"
@@ -556,6 +557,26 @@ func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *
 		recipient = strings.TrimSpace(args[0])
 	}
 	if inject {
+		if c != nil {
+			cr, err := c.ListMailInbox(recipient, "")
+			if err == nil {
+				if mailListHasPartial(cr.Body) {
+					logRoute(stderr, cmdName, "api", "error")
+					notice := formatMailCheckPartialDegradedNotice()
+					if mailListHasStoreSlowPartial(cr.Body) {
+						notice = formatMailCheckDegradedNotice()
+					}
+					_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", notice)
+					return 0
+				}
+			} else if !api.ShouldFallbackForRead(err) {
+				logRoute(stderr, cmdName, "api", "error")
+				if api.IsStoreSlowError(err) {
+					_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatMailCheckDegradedNotice())
+				}
+				return 0
+			}
+		}
 		logRoute(stderr, cmdName, "fallback", "inject-local-side-effects")
 		return doMailCheckFallback(args, inject, hookFormat, stdout, stderr)
 	}
@@ -564,14 +585,6 @@ func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *
 		if err == nil {
 			if mailListHasPartial(cr.Body) {
 				logRoute(stderr, cmdName, "api", "error")
-				if inject {
-					notice := formatMailCheckPartialDegradedNotice()
-					if mailListHasStoreSlowPartial(cr.Body) {
-						notice = formatMailCheckDegradedNotice()
-					}
-					_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", notice)
-					return 0
-				}
 				fmt.Fprintf(stderr, "gc mail check: %s\n", mailListPartialErrorDetail(cr.Body)) //nolint:errcheck // best-effort stderr
 				return 1
 			}
@@ -580,12 +593,6 @@ func routeMailCheck(_ string, args []string, inject bool, hookFormat string, c *
 		}
 		if !api.ShouldFallbackForRead(err) {
 			logRoute(stderr, cmdName, "api", "error")
-			if inject {
-				if api.IsStoreSlowError(err) {
-					_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatMailCheckDegradedNotice())
-				}
-				return 0
-			}
 			fmt.Fprintf(stderr, "gc mail check: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
 		}

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2617,6 +2617,56 @@ func TestMailArchiveSelectedIsFilteredAndBounded(t *testing.T) {
 	}
 }
 
+func TestMailArchiveSelectedAllRecipientsEmptyBody(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	first, err := mp.Send("system", "session-a", "context cycle", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := mp.Send("system", "session-b", "context cycle", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonEmpty, err := mp.Send("system", "session-c", "context cycle", "handoff context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherSubject, err := mp.Send("system", "session-d", "operator note", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailArchiveSelected(mp, events.Discard, mailArchiveSelectOptions{
+		AllRecipients:   true,
+		SubjectPrefix:   "context cycle",
+		EmptyBody:       true,
+		Limit:           10,
+		CaseInsensitive: true,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailArchiveSelected = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	for _, id := range []string{first.ID, second.ID} {
+		if !strings.Contains(stdout.String(), "Archived message "+id) {
+			t.Fatalf("stdout = %q, want archive confirmation for %s", stdout.String(), id)
+		}
+		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
+			t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+		}
+	}
+	for _, id := range []string{nonEmpty.ID, otherSubject.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("message %s status = %q, want open", id, got.Status)
+		}
+	}
+}
+
 // --- gc mail send --notify ---
 
 func TestMailSendNotifySuccess(t *testing.T) {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -3170,6 +3170,80 @@ func TestMailCheckInjectDoesNotCloseBeads(t *testing.T) {
 	}
 }
 
+func TestMailCheckInjectArchivesAutoHandoffMessages(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	ordinary, err := mp.Send("human", "mayor", "ordinary", "still open")
+	if err != nil {
+		t.Fatalf("Send ordinary: %v", err)
+	}
+	auto, err := store.Create(beads.Bead{
+		Title:    "context cycle",
+		Type:     "message",
+		Assignee: "mayor",
+		From:     "mayor",
+		Labels:   []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel},
+	})
+	if err != nil {
+		t.Fatalf("Create auto handoff: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailCheck(mp, "mayor", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailCheck = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), auto.ID) {
+		t.Fatalf("injected output missing auto handoff id %s:\n%s", auto.ID, stdout.String())
+	}
+	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("auto handoff mail should be archived after injection, got err=%v", err)
+	}
+	b, err := store.Get(ordinary.ID)
+	if err != nil {
+		t.Fatalf("ordinary mail should remain: %v", err)
+	}
+	if b.Status != "open" {
+		t.Fatalf("ordinary mail status = %q, want open", b.Status)
+	}
+}
+
+func TestMailCheckInjectLeavesTruncatedAutoHandoffMessages(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	for i := 0; i < mailInjectMaxMessages; i++ {
+		if _, err := mp.Send("human", "mayor", fmt.Sprintf("ordinary-%d", i), "still open"); err != nil {
+			t.Fatalf("Send ordinary %d: %v", i, err)
+		}
+	}
+	auto, err := store.Create(beads.Bead{
+		Title:    "context cycle",
+		Type:     "message",
+		Assignee: "mayor",
+		From:     "mayor",
+		Labels:   []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel},
+	})
+	if err != nil {
+		t.Fatalf("Create auto handoff: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doMailCheck(mp, "mayor", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doMailCheck = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), auto.ID) {
+		t.Fatalf("auto handoff id %s should not appear in truncated injection:\n%s", auto.ID, stdout.String())
+	}
+	b, err := store.Get(auto.ID)
+	if err != nil {
+		t.Fatalf("truncated auto handoff mail should remain: %v", err)
+	}
+	if b.Status != "open" {
+		t.Fatalf("truncated auto handoff status = %q, want open", b.Status)
+	}
+}
+
 func TestMailCheckInjectFiltersCorrectly(t *testing.T) {
 	store := beads.NewMemStore()
 	mp := beadmail.New(store)
@@ -4014,6 +4088,67 @@ func TestRouteMailCheck_StaleBannerOver30s(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "cache age:") {
 		t.Errorf("stdout missing stale banner:\n%s", stdout.String())
+	}
+}
+
+func TestRouteMailCheckInjectUsesLocalPathForArchiveSideEffects(t *testing.T) {
+	clearInheritedBeadsEnv(t)
+	cityPath := t.TempDir()
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_CITY_PATH", cityPath)
+	t.Setenv("GC_DEBUG", "1")
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_NAME", "mayor")
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   "session",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "mayor",
+			"session_name": "mayor",
+		},
+	}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	auto, err := store.Create(beads.Bead{
+		Title:    "context cycle",
+		Type:     "message",
+		Assignee: "mayor",
+		From:     "mayor",
+		Labels:   []string{mail.AutoHandoffLabel, mail.ArchiveAfterInjectLabel},
+	})
+	if err != nil {
+		t.Fatalf("Create auto handoff: %v", err)
+	}
+	srv := httptest.NewServer(okMailCheckHandler(t))
+	defer srv.Close()
+	c := api.NewCityScopedClient(srv.URL, "test-city")
+
+	var stdout, stderr bytes.Buffer
+	if code := routeMailCheck(cityPath, nil, true, "", c, "", &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	assertMailRouteLog(t, stderr.String(), "fallback", "inject-local-side-effects")
+	if !strings.Contains(stdout.String(), auto.ID) {
+		t.Fatalf("injected output missing local auto handoff id %s:\n%s", auto.ID, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "msg-1") {
+		t.Fatalf("inject path used API inbox instead of local provider:\n%s", stdout.String())
+	}
+	if _, err := store.Get(auto.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("auto handoff mail should be archived after local injection, got err=%v", err)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1729,8 +1729,9 @@ Use this to dismiss messages without reading them. Each message is removed
 and will no longer appear in mail check or inbox results. When multiple IDs
 are passed, they are archived in input order.
 
-For large advisory backlogs, use --to with --subject-prefix, --subject-contains,
-or --from to archive a bounded matching slice without enumerating IDs by hand.
+For large advisory backlogs, use --to or --all-recipients with
+--subject-prefix, --subject-contains, or --from to archive a bounded matching
+slice without enumerating IDs by hand.
 
 ```
 gc mail archive <id>... [flags]
@@ -1738,7 +1739,9 @@ gc mail archive <id>... [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--all-recipients` | bool |  | archive matching messages across all recipients |
 | `--dry-run` | bool |  | list matching messages without archiving them |
+| `--empty-body` | bool |  | only archive matching messages whose body is empty |
 | `--from` | string |  | archive matching unread messages from this exact sender |
 | `--include-read` | bool |  | include read-but-open messages when selecting by filter |
 | `--json` | bool |  | emit JSONL result |

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -355,6 +355,35 @@ func (p *Provider) ArchiveMatching(filter ArchiveFilter) ([]mail.Message, []mail
 	return candidates, results, nil
 }
 
+// ArchiveInjectedAutoHandoffs archives auto-handoff messages after they have
+// been injected into a provider hook. Ordinary user mail is left untouched.
+func (p *Provider) ArchiveInjectedAutoHandoffs(ids []string) error {
+	var errs []error
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		b, err := p.store.Get(id)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("loading %s: %w", id, err))
+			continue
+		}
+		if b.Type != "message" ||
+			!hasLabel(b.Labels, mail.AutoHandoffLabel) ||
+			!hasLabel(b.Labels, mail.ArchiveAfterInjectLabel) {
+			continue
+		}
+		if err := p.store.Delete(id); err != nil && !errors.Is(err, beads.ErrNotFound) {
+			errs = append(errs, fmt.Errorf("archiving %s: %w", id, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func archiveExactMatches(value, exact string, insensitive bool) bool {
 	exact = strings.TrimSpace(exact)
 	if exact == "" {

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -255,6 +255,7 @@ type ArchiveFilter struct {
 	From            string
 	SubjectPrefix   string
 	SubjectContains string
+	EmptyBody       bool
 	IncludeRead     bool
 	CaseInsensitive bool
 	Limit           int
@@ -317,6 +318,9 @@ func (p *Provider) ArchiveCandidates(filter ArchiveFilter) ([]mail.Message, erro
 			continue
 		}
 		if !archiveContainsMatches(msg.Subject, filter.SubjectContains, filter.CaseInsensitive) {
+			continue
+		}
+		if filter.EmptyBody && strings.TrimSpace(msg.Body) != "" {
 			continue
 		}
 		matches = append(matches, msg)

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -18,6 +18,12 @@ var ErrAlreadyArchived = errors.New("already archived")
 var ErrNotFound = errors.New("message not found")
 
 const (
+	// AutoHandoffLabel marks mail created by gc handoff --auto for provider
+	// context-cycle delivery.
+	AutoHandoffLabel = "gc:auto-handoff"
+	// ArchiveAfterInjectLabel marks system mail that should be archived after
+	// successful hook injection.
+	ArchiveAfterInjectLabel = "gc:archive-after-inject"
 	// FromSessionIDMetadataKey stores the stable session bead ID used for
 	// reply routing when a message's display sender may later be renamed.
 	FromSessionIDMetadataKey = "mail.from_session_id"


### PR DESCRIPTION
Refs #2903

## Main Rebase

Rebased onto current `origin/main` (`9bc8ba57d`) on 2026-06-01. The old stack-only `engdocs/contributors/bead-leak-bookkeeping.md` edits are intentionally omitted; #2903 carries the tracker/report evidence.

Merge proof: branch merge-base is `origin/main`; `git diff --check origin/main..HEAD` passed.

## Finding / Cause

Auto context handoff opened provider-injection mail but did not archive successfully injected auto-handoff messages; old empty-body context-cycle messages accumulated.

## Fix

Label auto-handoff messages for archive-after-inject, archive only those labels after local injection, and add a bounded legacy archive selector requiring all-recipient intent plus content filters.

## Verification

- `go test ./cmd/gc -run 'TestMailArchiveSelectedAllRecipientsEmptyBody|TestMailCheckInjectArchivesAutoHandoffMessages|TestMailCheckInjectLeavesTruncatedAutoHandoffMessages|TestRouteMailCheckInjectUsesLocalPathForArchiveSideEffects|TestMailCheckInjectFiltersCorrectly|TestHandoffSuccess|TestCmdHandoffAutoHookFormatCodex' -count=1`
- `go test ./internal/mail/... -count=1`
