### PR TITLE
Bead leaks: follow graph deps for order wisp checks

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1432,25 +1432,45 @@ func isOrderRootOnlyWispCandidate(b beads.Bead) bool {
 	return b.Metadata["gc.kind"] == "wisp" && !beads.IsMoleculeType(b.Type)
 }
 
-// storeHasOpenDescendants reports whether any transitive descendant of parentID
+// storeHasOpenDescendants reports whether any transitive descendant of rootID
 // is non-closed. It includes closed intermediate nodes so nested molecule work
 // remains visible after a direct child step has completed. Graph-v2 workflows
 // can link children with dependency edges instead of ParentID, so descendants
 // include parent-child/tracks/blocks dependents too.
-func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
-	seen := map[string]struct{}{parentID: {}}
-	queue := []string{parentID}
+func storeHasOpenDescendants(store beads.Store, rootID string) (bool, error) {
+	seen := map[string]struct{}{rootID: {}}
+	queue := []string{rootID}
+	// ParentID queries and closed intermediate traversal require live reads:
+	// CachingStore does not retain a complete closed-history parent view.
 	reader := beads.HandlesFor(store).Live
 	for len(queue) > 0 {
 		parentID := queue[0]
 		queue = queue[1:]
 
-		children, err := orderWispDescendantChildren(reader, parentID)
+		children, err := orderWispParentChildren(reader, parentID)
 		if err != nil {
 			return false, err
 		}
 		for _, c := range children {
-			if c.ID == "" {
+			if c.ID == "" || c.ID == rootID {
+				continue
+			}
+			if _, ok := seen[c.ID]; ok {
+				continue
+			}
+			seen[c.ID] = struct{}{}
+			if c.Status != "closed" {
+				return true, nil
+			}
+			queue = append(queue, c.ID)
+		}
+
+		children, err = orderWispGraphDependentChildren(reader, rootID, parentID)
+		if err != nil {
+			return false, err
+		}
+		for _, c := range children {
+			if c.ID == "" || c.ID == rootID {
 				continue
 			}
 			if _, ok := seen[c.ID]; ok {
@@ -1466,33 +1486,50 @@ func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
 	return false, nil
 }
 
-func orderWispDescendantChildren(reader beads.LiveReader, parentID string) ([]beads.Bead, error) {
-	children, err := reader.List(beads.ListQuery{
+func orderWispParentChildren(reader beads.LiveReader, parentID string) ([]beads.Bead, error) {
+	return reader.List(beads.ListQuery{
 		ParentID:      parentID,
 		IncludeClosed: true,
 		TierMode:      beads.TierBoth,
 	})
+}
+
+// Order-wisp traversal follows structural ParentID children and graph.v2
+// ownership dependents because orders gate and close executable workflow work.
+// This is intentionally narrower than generic dependency closure: molecule
+// cleanup uses molecule metadata/ParentID, while wisp GC follows its own
+// ownership policy for runtime garbage collection.
+func orderWispDescendantChildren(reader beads.LiveReader, rootID, parentID string) ([]beads.Bead, error) {
+	children, err := orderWispParentChildren(reader, parentID)
 	if err != nil {
 		return nil, err
 	}
+	graphChildren, err := orderWispGraphDependentChildren(reader, rootID, parentID)
+	if err != nil {
+		return nil, err
+	}
+	return append(children, graphChildren...), nil
+}
 
+func orderWispGraphDependentChildren(reader beads.LiveReader, rootID, parentID string) ([]beads.Bead, error) {
 	parent, err := reader.Get(parentID)
 	if errors.Is(err, beads.ErrNotFound) {
-		return children, nil
+		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("getting graph parent %s: %w", parentID, err)
 	}
 	if !orderWispMayHaveGraphDependents(parent) {
-		return children, nil
+		return nil, nil
 	}
 
 	deps, err := reader.DepList(parentID, "up")
 	if err != nil {
 		return nil, fmt.Errorf("listing graph dependents for %s: %w", parentID, err)
 	}
+	children := make([]beads.Bead, 0, len(deps))
 	for _, dep := range deps {
-		if dep.IssueID == "" || dep.DependsOnID != parentID {
+		if dep.IssueID == "" {
 			continue
 		}
 		if !isOrderWispDescendantDepType(dep.Type) {
@@ -1505,9 +1542,19 @@ func orderWispDescendantChildren(reader beads.LiveReader, parentID string) ([]be
 		if err != nil {
 			return nil, fmt.Errorf("getting graph dependent %s: %w", dep.IssueID, err)
 		}
+		if !orderWispGraphDependentOwnedByRoot(child, rootID) {
+			continue
+		}
 		children = append(children, child)
 	}
 	return children, nil
+}
+
+func orderWispGraphDependentOwnedByRoot(child beads.Bead, rootID string) bool {
+	if child.ID == rootID {
+		return true
+	}
+	return child.Metadata["gc.root_bead_id"] == rootID
 }
 
 func orderWispMayHaveGraphDependents(bead beads.Bead) bool {
@@ -2015,7 +2062,7 @@ func collectOrderWispSubtree(store beads.Store, root beads.Bead) ([]beads.Bead, 
 		parentID := queue[0]
 		queue = queue[1:]
 
-		children, err := orderWispDescendantChildren(reader, parentID)
+		children, err := orderWispDescendantChildren(reader, root.ID, parentID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1432,21 +1432,20 @@ func isOrderRootOnlyWispCandidate(b beads.Bead) bool {
 	return b.Metadata["gc.kind"] == "wisp" && !beads.IsMoleculeType(b.Type)
 }
 
-// storeHasOpenDescendants reports whether any transitive child of parentID is
-// non-closed. It includes closed intermediate nodes so nested molecule work
-// remains visible after a direct child step has completed.
+// storeHasOpenDescendants reports whether any transitive descendant of parentID
+// is non-closed. It includes closed intermediate nodes so nested molecule work
+// remains visible after a direct child step has completed. Graph-v2 workflows
+// can link children with dependency edges instead of ParentID, so descendants
+// include parent-child/tracks/blocks dependents too.
 func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
 	seen := map[string]struct{}{parentID: {}}
 	queue := []string{parentID}
+	reader := beads.HandlesFor(store).Live
 	for len(queue) > 0 {
 		parentID := queue[0]
 		queue = queue[1:]
 
-		children, err := store.List(beads.ListQuery{
-			ParentID:      parentID,
-			IncludeClosed: true,
-			TierMode:      beads.TierBoth,
-		})
+		children, err := orderWispDescendantChildren(reader, parentID)
 		if err != nil {
 			return false, err
 		}
@@ -1465,6 +1464,75 @@ func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func orderWispDescendantChildren(reader beads.LiveReader, parentID string) ([]beads.Bead, error) {
+	children, err := reader.List(beads.ListQuery{
+		ParentID:      parentID,
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	parent, err := reader.Get(parentID)
+	if errors.Is(err, beads.ErrNotFound) {
+		return children, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting graph parent %s: %w", parentID, err)
+	}
+	if !orderWispMayHaveGraphDependents(parent) {
+		return children, nil
+	}
+
+	deps, err := reader.DepList(parentID, "up")
+	if err != nil {
+		return nil, fmt.Errorf("listing graph dependents for %s: %w", parentID, err)
+	}
+	for _, dep := range deps {
+		if dep.IssueID == "" || dep.DependsOnID != parentID {
+			continue
+		}
+		if !isOrderWispDescendantDepType(dep.Type) {
+			continue
+		}
+		child, err := reader.Get(dep.IssueID)
+		if errors.Is(err, beads.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("getting graph dependent %s: %w", dep.IssueID, err)
+		}
+		children = append(children, child)
+	}
+	return children, nil
+}
+
+func orderWispMayHaveGraphDependents(bead beads.Bead) bool {
+	if isOrderWispRootCandidate(bead) {
+		return true
+	}
+	if bead.Metadata["gc.root_bead_id"] != "" {
+		return true
+	}
+	if bead.Metadata["gc.step_ref"] != "" {
+		return true
+	}
+	if bead.Metadata["gc.logical_bead_id"] != "" {
+		return true
+	}
+	return false
+}
+
+func isOrderWispDescendantDepType(depType string) bool {
+	switch depType {
+	case "parent-child", "tracks", "blocks":
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *memoryOrderDispatcher) hasOpenWorkInStoresStrict(stores []beads.Store, scopedName string) (bool, error) {
@@ -1942,15 +2010,12 @@ func collectOrderWispSubtree(store beads.Store, root beads.Bead) ([]beads.Bead, 
 	seen := map[string]struct{}{root.ID: {}}
 	out := []beads.Bead{root}
 	queue := []string{root.ID}
+	reader := beads.HandlesFor(store).Live
 	for len(queue) > 0 {
 		parentID := queue[0]
 		queue = queue[1:]
 
-		children, err := store.List(beads.ListQuery{
-			ParentID:      parentID,
-			IncludeClosed: true,
-			TierMode:      beads.TierBoth,
-		})
+		children, err := orderWispDescendantChildren(reader, parentID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4584,6 +4584,133 @@ func TestSweepStaleOrderTrackingWithWispsClosesGraphDependentSubtree(t *testing.
 	}
 }
 
+func TestSweepStaleOrderTrackingWithWispsClosesSameWorkflowGraphDependencyTypes(t *testing.T) {
+	for _, depType := range []string{"blocks", "parent-child"} {
+		t.Run(depType, func(t *testing.T) {
+			store := beads.NewMemStore()
+
+			wispRoot, err := store.Create(beads.Bead{
+				Title:  "graph-workflow-digest",
+				Type:   "task",
+				Labels: []string{"order-run:digest"},
+				Metadata: map[string]string{
+					"gc.kind":             "workflow",
+					"gc.formula_contract": "graph.v2",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create(wisp root): %v", err)
+			}
+			step, err := store.Create(beads.Bead{
+				Title: "draft-digest",
+				Metadata: map[string]string{
+					"gc.root_bead_id": wispRoot.ID,
+					"gc.step_ref":     "draft",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create(graph step): %v", err)
+			}
+			if err := store.DepAdd(step.ID, wispRoot.ID, depType); err != nil {
+				t.Fatalf("DepAdd(%s): %v", depType, err)
+			}
+
+			closed, err := sweepStaleOrderWispSubtrees(
+				store,
+				step.CreatedAt.Add(time.Minute),
+				orderFilterForTest("digest"),
+				orderTrackingSweepMetadataInitiator,
+			)
+			if err != nil {
+				t.Fatalf("sweepStaleOrderWispSubtrees: %v", err)
+			}
+			if closed != 2 {
+				t.Fatalf("closed = %d, want root and graph step closed", closed)
+			}
+			for _, id := range []string{wispRoot.ID, step.ID} {
+				got, err := store.Get(id)
+				if err != nil {
+					t.Fatalf("Get(%s): %v", id, err)
+				}
+				if got.Status != "closed" {
+					t.Fatalf("%s status = %q, want closed", id, got.Status)
+				}
+			}
+		})
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsIgnoresForeignGraphDependents(t *testing.T) {
+	tests := []struct {
+		name     string
+		depType  string
+		metadata map[string]string
+	}{
+		{
+			name:    "external convoy tracks edge",
+			depType: "tracks",
+		},
+		{
+			name:    "unrelated downstream blocks edge",
+			depType: "blocks",
+			metadata: map[string]string{
+				"gc.root_bead_id": "other-workflow-root",
+				"gc.step_ref":     "external",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+
+			wispRoot, err := store.Create(beads.Bead{
+				Title:  "graph-workflow-digest",
+				Type:   "task",
+				Labels: []string{"order-run:digest"},
+				Metadata: map[string]string{
+					"gc.kind":             "workflow",
+					"gc.formula_contract": "graph.v2",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create(wisp root): %v", err)
+			}
+			external, err := store.Create(beads.Bead{
+				Title:    "external-dependent",
+				Metadata: tt.metadata,
+			})
+			if err != nil {
+				t.Fatalf("Create(external): %v", err)
+			}
+			if err := store.DepAdd(external.ID, wispRoot.ID, tt.depType); err != nil {
+				t.Fatalf("DepAdd(%s): %v", tt.depType, err)
+			}
+
+			closed, err := sweepStaleOrderWispSubtrees(
+				store,
+				external.CreatedAt.Add(time.Minute),
+				orderFilterForTest("digest"),
+				orderTrackingSweepMetadataInitiator,
+			)
+			if err != nil {
+				t.Fatalf("sweepStaleOrderWispSubtrees: %v", err)
+			}
+			if closed != 0 {
+				t.Fatalf("closed = %d, want foreign dependent ignored", closed)
+			}
+			for _, id := range []string{wispRoot.ID, external.ID} {
+				got, err := store.Get(id)
+				if err != nil {
+					t.Fatalf("Get(%s): %v", id, err)
+				}
+				if got.Status != "open" {
+					t.Fatalf("%s status = %q, want open", id, got.Status)
+				}
+			}
+		})
+	}
+}
+
 func TestSweepStaleOrderTrackingWithWispsPropagatesDescendantListError(t *testing.T) {
 	base := beads.NewMemStore()
 
@@ -6822,6 +6949,107 @@ func TestHasOpenWorkStrictBlocksOnGraphWorkflowTracksDependent(t *testing.T) {
 	}
 }
 
+func TestHasOpenWorkStrictBlocksOnSameWorkflowGraphDependencyTypes(t *testing.T) {
+	for _, depType := range []string{"blocks", "parent-child"} {
+		t.Run(depType, func(t *testing.T) {
+			store := beads.NewMemStore()
+
+			wispRoot, err := store.Create(beads.Bead{
+				Title:  "graph-workflow-digest",
+				Type:   "task",
+				Labels: []string{"order-run:digest"},
+				Metadata: map[string]string{
+					"gc.kind":             "workflow",
+					"gc.formula_contract": "graph.v2",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			step, err := store.Create(beads.Bead{
+				Title: "draft-digest",
+				Metadata: map[string]string{
+					"gc.root_bead_id": wispRoot.ID,
+					"gc.step_ref":     "draft",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.DepAdd(step.ID, wispRoot.ID, depType); err != nil {
+				t.Fatal(err)
+			}
+
+			ad := &memoryOrderDispatcher{}
+			has, err := ad.hasOpenWorkStrict(store, "digest")
+			if err != nil {
+				t.Fatalf("hasOpenWorkStrict: %v", err)
+			}
+			if !has {
+				t.Fatalf("graph workflow wisp with an open %s dependent must count as in-flight work", depType)
+			}
+		})
+	}
+}
+
+func TestHasOpenWorkStrictIgnoresForeignGraphDependents(t *testing.T) {
+	tests := []struct {
+		name     string
+		depType  string
+		metadata map[string]string
+	}{
+		{
+			name:    "external convoy tracks edge",
+			depType: "tracks",
+		},
+		{
+			name:    "unrelated downstream blocks edge",
+			depType: "blocks",
+			metadata: map[string]string{
+				"gc.root_bead_id": "other-workflow-root",
+				"gc.step_ref":     "external",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+
+			wispRoot, err := store.Create(beads.Bead{
+				Title:  "graph-workflow-digest",
+				Type:   "task",
+				Labels: []string{"order-run:digest"},
+				Metadata: map[string]string{
+					"gc.kind":             "workflow",
+					"gc.formula_contract": "graph.v2",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			external, err := store.Create(beads.Bead{
+				Title:    "external-dependent",
+				Metadata: tt.metadata,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.DepAdd(external.ID, wispRoot.ID, tt.depType); err != nil {
+				t.Fatal(err)
+			}
+
+			ad := &memoryOrderDispatcher{}
+			has, err := ad.hasOpenWorkStrict(store, "digest")
+			if err != nil {
+				t.Fatalf("hasOpenWorkStrict: %v", err)
+			}
+			if has {
+				t.Fatalf("foreign %s dependent must not count as in-flight order work", tt.depType)
+			}
+		})
+	}
+}
+
 func TestHasOpenWorkStrictBlocksOnRootOnlyWisp(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -6924,6 +7152,37 @@ func TestHasOpenWorkStrictPropagatesWispChildListError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "checking open descendants of wisp") {
 		t.Fatalf("hasOpenWorkStrict err = %q, want wisp descendant context", err)
+	}
+}
+
+func TestStoreHasOpenDescendantsShortCircuitsOpenParentChildBeforeGraphReads(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title: "graph-workflow-digest",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := base.Create(beads.Bead{
+		Title:    "direct-open-step",
+		ParentID: wispRoot.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := depListFailStore{Store: base, failID: wispRoot.ID}
+	has, err := storeHasOpenDescendants(store, wispRoot.ID)
+	if err != nil {
+		t.Fatalf("storeHasOpenDescendants: %v", err)
+	}
+	if !has {
+		t.Fatal("direct open ParentID child must count as an open descendant")
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4532,6 +4532,58 @@ func TestSweepStaleOrderTrackingWithWispsSkipsFreshOpenDescendant(t *testing.T) 
 	}
 }
 
+func TestSweepStaleOrderTrackingWithWispsClosesGraphDependentSubtree(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "graph-workflow-digest",
+		Type:   "task",
+		Labels: []string{"order-run:digest"},
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	step, err := store.Create(beads.Bead{
+		Title: "draft-digest",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "draft",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(graph step): %v", err)
+	}
+	if err := store.DepAdd(step.ID, wispRoot.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+
+	closed, err := sweepStaleOrderWispSubtrees(
+		store,
+		step.CreatedAt.Add(time.Minute),
+		orderFilterForTest("digest"),
+		orderTrackingSweepMetadataInitiator,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderWispSubtrees: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("closed = %d, want root and graph step closed", closed)
+	}
+	for _, id := range []string{wispRoot.ID, step.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+	}
+}
+
 func TestSweepStaleOrderTrackingWithWispsPropagatesDescendantListError(t *testing.T) {
 	base := beads.NewMemStore()
 
@@ -6728,6 +6780,45 @@ func TestHasOpenWorkStrictBlocksOnGraphWorkflowWispWithOpenDescendant(t *testing
 	}
 	if !has {
 		t.Fatal("graph workflow wisp with an open nested descendant must count as in-flight work")
+	}
+}
+
+func TestHasOpenWorkStrictBlocksOnGraphWorkflowTracksDependent(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "graph-workflow-digest",
+		Type:   "task",
+		Labels: []string{"order-run:digest"},
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	step, err := store.Create(beads.Bead{
+		Title: "draft-digest",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "draft",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DepAdd(step.ID, wispRoot.ID, "tracks"); err != nil {
+		t.Fatal(err)
+	}
+
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "digest")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if !has {
+		t.Fatal("graph workflow wisp with an open tracks dependent must count as in-flight work")
 	}
 }
 


### PR DESCRIPTION
Refs #2903

## Scope

Standalone rebuild of the order graph descendant gate against `origin/main`.

- Base: `main`
- Head: `bead-leaks/18-order-graph-descendants`
- Local rebuild commit: `d9b568e4a`

## Finding / Cause

Order dispatch strict open-work checks and stale order-wisp cleanup only treated direct `ParentID` children as descendants. Some live order wisps are graph-shaped: their step/work beads are attached through graph-v2 dependencies such as `parent-child`, `tracks`, or `blocks`, with order metadata like `gc.root_bead_id`, `gc.step_ref`, and `gc.logical_bead_id`. Those graph descendants were invisible to the order gate, so open graph-dependent work could fail to block redispatch and stale-root cleanup could leave dependent work stranded.

## Fix

The order descendant traversal now goes through the live bead reader and includes both direct `ParentID` children and graph-v2 dependents. It limits graph expansion to order-wisp-shaped beads and accepted descendant dependency types, preserving existing parent-child behavior while making graph-shaped order wisps visible to the strict gate and cleanup path.

## Main Rebase Proof

The branch was rebuilt from current `origin/main` (`071700978c64db85254a26f8a3f1c04dc8a01aee`). Locally, `git merge-base HEAD origin/main` equals that same commit, and GitHub reports the PR as `MERGEABLE` after the push.

## Verification

The new graph-dependent regression tests failed before the traversal change and pass after it.

- `go test ./cmd/gc -run 'Test(SweepStaleOrderTrackingWithWispsClosesGraphDependentSubtree|HasOpenWorkStrictBlocksOnGraphWorkflowTracksDependent)$' -count=1`
- `go test ./cmd/gc -run 'Test(SweepStaleOrderTrackingWithWisps|HasOpenWorkStrict|OrderDispatchOpenWispWithOpenStepsBlocksRedispatch|OrderDispatchClosedOrderTrackingHistoryStillChecksOpenWispWork)' -count=1`
- `go vet ./cmd/gc`
- `git diff --check`
- pre-commit hook: `.githooks/pre-commit` ran `go vet ./...` and `./scripts/test-local-parallel fast`; all fast shards passed
