### PR TITLE
Bead leaks: drain stale order wisps and generated specs

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -1791,6 +1791,12 @@ func convoyAutocloseStoreRoot(cwd string) string {
 // supervising process.
 func autocloseCityPathForStoreRoot(storeRoot string) string {
 	if cityPath, err := findCity(storeRoot); err == nil {
+		if _, statErr := os.Stat(filepath.Join(cityPath, "city.toml")); statErr == nil {
+			return cityPath
+		}
+		if explicitCity, ok := resolveExplicitCityPathEnv(); ok {
+			return explicitCity
+		}
 		return cityPath
 	}
 	return cityForStoreDir(storeRoot)

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -1786,9 +1786,12 @@ func convoyAutocloseStoreRoot(cwd string) string {
 }
 
 // autocloseCityPathForStoreRoot resolves the runtime city for bd hook cleanup.
-// The hook-projected store root identifies the bead that just closed, so prefer
-// filesystem discovery from that root over an inherited GC_CITY from the
-// supervising process.
+// Precedence: a city.toml-backed discovery result from the store root wins
+// outright; otherwise a validated explicit GC_CITY from the supervising
+// process is preferred over a legacy `.gc/`-only discovery result (an external
+// rig checkout with runtime state but no city.toml); the legacy runtime root
+// is used when no explicit city is set; cityForStoreDir is the final fallback
+// when discovery fails entirely.
 func autocloseCityPathForStoreRoot(storeRoot string) string {
 	if cityPath, err := findCity(storeRoot); err == nil {
 		if _, statErr := os.Stat(filepath.Join(cityPath, "city.toml")); statErr == nil {

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -186,6 +186,7 @@ name. Use --rig to filter by rig.`,
 func newOrderSweepTrackingCmd(stdout, stderr io.Writer) *cobra.Command {
 	staleAfter := defaultOrderTrackingSweepStaleAfter
 	includeWisps := false
+	dryRun := false
 	quiet := false
 	cmd := &cobra.Command{
 		Use:   "sweep-tracking [order ...]",
@@ -206,7 +207,7 @@ or more scoped order names when --include-wisps is set; wisp recovery is
 order-scoped to avoid scanning unrelated beads.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdOrderSweepTracking(staleAfter, includeWisps, quiet, args, stdout, stderr) != 0 {
+			if cmdOrderSweepTrackingWithOptions(staleAfter, includeWisps, dryRun, quiet, args, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -215,6 +216,7 @@ order-scoped to avoid scanning unrelated beads.`,
 	}
 	cmd.Flags().DurationVar(&staleAfter, "stale-after", defaultOrderTrackingSweepStaleAfter, "minimum age for an open tracking bead to be closed")
 	cmd.Flags().BoolVar(&includeWisps, "include-wisps", false, "also close stale order-run wisp subtrees with open descendants")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "report stale order-tracking and order wisp beads without closing them")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress success output")
 	return cmd
 }
@@ -1470,7 +1472,7 @@ type orderHistoryJSONSummary struct {
 
 // --- gc order sweep-tracking ---
 
-func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, orderNames []string, stdout, stderr io.Writer) int {
+func cmdOrderSweepTrackingWithOptions(staleAfter time.Duration, includeWisps, dryRun, quiet bool, orderNames []string, stdout, stderr io.Writer) int {
 	if staleAfter <= 0 {
 		fmt.Fprintln(stderr, "gc order sweep-tracking: --stale-after must be positive") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1495,7 +1497,7 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	stores, openErr := orderTrackingSweepStoresForConfig(cityPath, cfg)
+	stores, openErr := orderTrackingSweepStoresForConfigTargets(cityPath, cfg, requiredTargets)
 	if len(stores) == 0 {
 		if openErr != nil {
 			fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", openErr) //nolint:errcheck // best-effort stderr
@@ -1505,9 +1507,17 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 		return 1
 	}
 	now := time.Now()
-	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, now, staleAfter, onlyOrders, includeWisps)
-	retentionResult, retentionErr := sweepClosedOrderTrackingRetentionAcrossStores(stores, now, orderTrackingRetentionPolicyForConfig(cfg), onlyOrders)
-	result.trackingDeleted = retentionResult.deleted
+	var result orderTrackingSweepResult
+	var sweepErr error
+	var retentionResult orderTrackingRetentionSweepResult
+	var retentionErr error
+	if dryRun {
+		result, sweepErr = sweepStaleOrderTrackingAcrossStoresDryRun(stores, now, staleAfter, onlyOrders, includeWisps)
+	} else {
+		result, sweepErr = sweepStaleOrderTrackingAcrossStores(stores, now, staleAfter, onlyOrders, includeWisps)
+		retentionResult, retentionErr = sweepClosedOrderTrackingRetentionAcrossStores(stores, now, orderTrackingRetentionPolicyForConfig(cfg), onlyOrders)
+		result.trackingDeleted = retentionResult.deleted
+	}
 	if err := errors.Join(openErr, sweepErr, retentionErr); err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
 		if orderTrackingSweepErrorIsFatal(result, retentionResult, retentionErr) {
@@ -1519,10 +1529,16 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 		return 1
 	}
 	if !quiet {
+		verb := "closed"
+		deletedClause := fmt.Sprintf(", deleted %d closed order-tracking bead(s)", result.trackingDeleted)
+		if dryRun {
+			verb = "would close"
+			deletedClause = ""
+		}
 		if includeWisps {
-			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), %d stale order wisp bead(s), deleted %d closed order-tracking bead(s)\n", result.trackingClosed, result.wispClosed, result.trackingDeleted) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "%s %d stale order-tracking bead(s), %d stale order wisp bead(s)%s\n", verb, result.trackingClosed, result.wispClosed, deletedClause) //nolint:errcheck // best-effort stdout
 		} else {
-			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), deleted %d closed order-tracking bead(s)\n", result.trackingClosed, result.trackingDeleted) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "%s %d stale order-tracking bead(s)%s\n", verb, result.trackingClosed, deletedClause) //nolint:errcheck // best-effort stdout
 		}
 	}
 	return 0

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1186,7 +1186,7 @@ prefix = "fe"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepTracking(time.Nanosecond, false, false, []string{"rig-digest:rig:frontend"}, &stdout, &stderr)
+	code := cmdOrderSweepTrackingWithOptions(time.Nanosecond, false, false, false, []string{"rig-digest:rig:frontend"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdOrderSweepTracking = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1252,7 +1252,7 @@ prefix = "fe"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepTracking(time.Nanosecond, false, false, []string{"cleanup"}, &stdout, &stderr)
+	code := cmdOrderSweepTrackingWithOptions(time.Nanosecond, false, false, false, nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdOrderSweepTracking = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1316,7 +1316,7 @@ prefix = "ct"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepTracking(time.Nanosecond, false, false, nil, &stdout, &stderr)
+	code := cmdOrderSweepTrackingWithOptions(time.Nanosecond, false, false, false, nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdOrderSweepTracking = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1390,7 +1390,7 @@ delete_after_close = "1ns"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepTracking(time.Hour, false, false, nil, &stdout, &stderr)
+	code := cmdOrderSweepTrackingWithOptions(time.Hour, false, false, false, nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdOrderSweepTracking = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1473,7 +1473,7 @@ delete_after_close = "1ns"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepTracking(time.Hour, true, false, nil, &stdout, &stderr)
+	code := cmdOrderSweepTrackingWithOptions(time.Hour, true, false, false, nil, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("cmdOrderSweepTracking = 0, want failure")
 	}
@@ -1489,6 +1489,132 @@ delete_after_close = "1ns"
 		if _, err := reopened.Get(id); err != nil {
 			t.Fatalf("%s should be preserved after invalid command: %v", id, err)
 		}
+	}
+}
+
+func TestCmdOrderSweepTrackingTargetedCityOrderSkipsUnrelatedRigStore(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_CITY_ROOT", cityDir)
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Chdir(cityDir)
+
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+
+[[rigs]]
+name = "frontend"
+path = "frontend"
+prefix = "fe"
+`)
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	stale, err := store.Create(beads.Bead{
+		Title:     "order:cleanup",
+		Labels:    []string{"order-run:cleanup", labelOrderTracking},
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create(stale): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdOrderSweepTrackingWithOptions(time.Nanosecond, false, false, false, []string{"cleanup"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdOrderSweepTracking = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	reopened, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reopen): %v", err)
+	}
+	got, err := reopened.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("Get(stale): %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("city stale tracking status after targeted sweep = %q, want closed", got.Status)
+	}
+	if strings.Contains(stderr.String(), "opening rig \"frontend\" order store") {
+		t.Fatalf("stderr = %q, want targeted city sweep to skip unrelated rig store", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "closed 1 stale order-tracking bead") {
+		t.Fatalf("stdout = %q, want one closed tracking bead", stdout.String())
+	}
+}
+
+func TestCmdOrderSweepTrackingDryRunReportsWithoutClosing(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_CITY_ROOT", cityDir)
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Chdir(cityDir)
+
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+`)
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	stale, err := store.Create(beads.Bead{
+		Title:     "order:cleanup",
+		Labels:    []string{"order-run:cleanup", labelOrderTracking},
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create(stale): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdOrderSweepTrackingWithOptions(time.Nanosecond, false, true, false, []string{"cleanup"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdOrderSweepTrackingWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	reopened, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reopen): %v", err)
+	}
+	got, err := reopened.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("Get(stale): %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("stale tracking status after dry-run = %q, want open", got.Status)
+	}
+	if !strings.Contains(stdout.String(), "would close 1 stale order-tracking bead") {
+		t.Fatalf("stdout = %q, want dry-run tracking candidate", stdout.String())
 	}
 }
 
@@ -1525,7 +1651,7 @@ prefix = "fe"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdOrderSweepTracking(time.Nanosecond, false, false, []string{"rig-digest:rig:frontend"}, &stdout, &stderr)
+	code := cmdOrderSweepTrackingWithOptions(time.Nanosecond, false, false, false, []string{"rig-digest:rig:frontend"}, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("cmdOrderSweepTracking = 0, want failure; stdout: %s stderr: %s", stdout.String(), stderr.String())
 	}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1630,6 +1630,22 @@ func storeHasOpenDescendantsByWalk(store beads.Store, rootID string, skip func(b
 	return false, nil
 }
 
+func orderWispMetadataDescendants(reader beads.LiveReader, rootID string, includeClosed bool) ([]beads.Bead, error) {
+	rootID = strings.TrimSpace(rootID)
+	if rootID == "" {
+		return nil, nil
+	}
+	query := beads.ListQuery{
+		Metadata:      map[string]string{"gc.root_bead_id": rootID},
+		IncludeClosed: includeClosed,
+	}
+	descendants, err := reader.List(query)
+	if err != nil {
+		return nil, fmt.Errorf("listing graph metadata descendants for %s: %w", rootID, err)
+	}
+	return descendants, nil
+}
+
 func orderWispParentChildren(reader beads.LiveReader, parentID string) ([]beads.Bead, error) {
 	return reader.List(beads.ListQuery{
 		ParentID:      parentID,
@@ -1926,6 +1942,14 @@ func sweepStaleOrderTrackingAcrossStores(stores []beads.Store, now time.Time, st
 // order-tracking bead closes. Wisp subtree recovery is operator-scoped by
 // order name and closes complete stale subtrees when explicitly requested.
 func sweepStaleOrderTrackingAcrossStoresLimit(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingAcrossStoresLimitMode(stores, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, limit, false)
+}
+
+func sweepStaleOrderTrackingAcrossStoresDryRun(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, includeWispSubtrees bool) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingAcrossStoresLimitMode(stores, now, staleAfter, onlyOrders, orderTrackingSweepMetadataInitiator, includeWispSubtrees, 0, true)
+}
+
+func sweepStaleOrderTrackingAcrossStoresLimitMode(stores []beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int, dryRun bool) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")
 	}
@@ -1945,7 +1969,7 @@ func sweepStaleOrderTrackingAcrossStoresLimit(stores []beads.Store, now time.Tim
 				break
 			}
 		}
-		partial, err := sweepStaleOrderTrackingWithOptionsLimit(store, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, remainingLimit)
+		partial, err := sweepStaleOrderTrackingWithOptionsLimitMode(store, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, remainingLimit, dryRun)
 		result.trackingClosed += partial.trackingClosed
 		result.wispClosed += partial.wispClosed
 		if err != nil {
@@ -1989,6 +2013,14 @@ func orderTrackingSweepStoreLabel(store beads.Store, index int) string {
 // order-tracking bead closes. Wisp subtree recovery is order-scoped and closes
 // complete stale subtrees when includeWispSubtrees is set.
 func sweepStaleOrderTrackingWithOptionsLimit(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingWithOptionsLimitMode(store, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, limit, false)
+}
+
+func sweepStaleOrderTrackingWithOptionsLimitDryRun(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int) (orderTrackingSweepResult, error) {
+	return sweepStaleOrderTrackingWithOptionsLimitMode(store, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, limit, true)
+}
+
+func sweepStaleOrderTrackingWithOptionsLimitMode(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string, includeWispSubtrees bool, limit int, dryRun bool) (orderTrackingSweepResult, error) {
 	if staleAfter <= 0 {
 		return orderTrackingSweepResult{}, fmt.Errorf("stale-after must be positive")
 	}
@@ -2026,22 +2058,26 @@ func sweepStaleOrderTrackingWithOptionsLimit(store beads.Store, now time.Time, s
 			return result, nil
 		}
 	} else {
-		metadata := map[string]string{
-			"order_tracking_sweep": orderTrackingSweepMetadataReason,
-			"close_reason":         staleOrderTrackingCloseReason,
-		}
-		if initiator != "" {
-			metadata["order_tracking_sweep_by"] = initiator
-		}
-		n, err := closeAndVerifyOrderTrackingBeads(context.Background(), store, ids, metadata)
-		result.trackingClosed = n
-		if err != nil {
-			return result, fmt.Errorf("closing stale order-tracking beads: %w", err)
+		if dryRun {
+			result.trackingClosed = len(ids)
+		} else {
+			metadata := map[string]string{
+				"order_tracking_sweep": orderTrackingSweepMetadataReason,
+				"close_reason":         staleOrderTrackingCloseReason,
+			}
+			if initiator != "" {
+				metadata["order_tracking_sweep_by"] = initiator
+			}
+			n, err := closeAndVerifyOrderTrackingBeads(context.Background(), store, ids, metadata)
+			result.trackingClosed = n
+			if err != nil {
+				return result, fmt.Errorf("closing stale order-tracking beads: %w", err)
+			}
 		}
 	}
 
 	if includeWispSubtrees {
-		n, err := sweepStaleOrderWispSubtrees(store, cutoff, onlyOrders, initiator)
+		n, err := sweepStaleOrderWispSubtreesMode(store, cutoff, onlyOrders, initiator, dryRun)
 		result.wispClosed = n
 		if err != nil {
 			return result, err
@@ -2257,6 +2293,20 @@ func orderTrackingClosedReferenceTime(b beads.Bead) time.Time {
 }
 
 func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string) (int, error) {
+	return sweepStaleOrderWispSubtreesMode(store, cutoff, onlyOrders, initiator, false)
+}
+
+func sweepStaleOrderWispSubtreesMode(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string, dryRun bool) (int, error) {
+	batchIDs, handled, err := staleOrderWispSubtreeBatchCloseIDs(store, cutoff, onlyOrders)
+	if err != nil {
+		return 0, err
+	}
+	if handled {
+		if dryRun || len(batchIDs) == 0 {
+			return len(batchIDs), nil
+		}
+		return closeStaleOrderWispIDs(store, batchIDs, initiator)
+	}
 	roots, err := staleOrderWispRoots(store, cutoff, onlyOrders)
 	if err != nil {
 		return 0, err
@@ -2300,10 +2350,17 @@ func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders
 	if len(ids) == 0 {
 		return 0, nil
 	}
+	if dryRun {
+		return len(ids), nil
+	}
 	ordered, err := closeorder.Order(store, ids)
 	if err != nil {
 		return 0, fmt.Errorf("ordering stale order wisp closes: %w", err)
 	}
+	return closeStaleOrderWispIDs(store, ordered, initiator)
+}
+
+func closeStaleOrderWispIDs(store beads.Store, ids []string, initiator string) (int, error) {
 	metadata := map[string]string{
 		"order_tracking_sweep": orderTrackingSweepMetadataReason,
 		"order_wisp_sweep":     "stale-order-wisp",
@@ -2312,11 +2369,83 @@ func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders
 	if initiator != "" {
 		metadata["order_tracking_sweep_by"] = initiator
 	}
-	n, err := store.CloseAll(ordered, metadata)
+	n, err := store.CloseAll(ids, metadata)
 	if err != nil {
 		return n, fmt.Errorf("closing stale order wisp subtrees: %w", err)
 	}
 	return n, nil
+}
+
+func staleOrderWispSubtreeBatchCloseIDs(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}) ([]string, bool, error) {
+	if len(onlyOrders) == 0 {
+		return nil, false, fmt.Errorf("include-wisps requires at least one order name")
+	}
+	all, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		CreatedBefore: time.Now().Add(24 * time.Hour),
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("listing open wisp candidates for order-wisp batch sweep: %w", err)
+	}
+	if len(all) == 0 {
+		return nil, false, nil
+	}
+
+	descendantsByRoot := make(map[string][]beads.Bead)
+	for _, bead := range all {
+		if bead.ID == "" || bead.Status == "closed" {
+			continue
+		}
+		rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
+		if rootID == "" {
+			continue
+		}
+		descendantsByRoot[rootID] = append(descendantsByRoot[rootID], bead)
+	}
+
+	handled := false
+	ids := make([]string, 0)
+	seenIDs := make(map[string]struct{})
+	for _, root := range all {
+		if root.ID == "" || root.Status == "closed" {
+			continue
+		}
+		if beadLabelsContain(root.Labels, labelOrderTracking) {
+			continue
+		}
+		name, ok := orderNameFromTrackingBead(root)
+		if !ok {
+			continue
+		}
+		if _, ok := onlyOrders[name]; !ok {
+			continue
+		}
+		if root.CreatedAt.IsZero() || !root.CreatedAt.Before(cutoff) {
+			continue
+		}
+		if !isOrderWispRootCandidate(root) {
+			continue
+		}
+		descendants := descendantsByRoot[root.ID]
+		if len(descendants) == 0 && !isOrderRootOnlyWispCandidate(root) {
+			// Legacy graph-v2 wisps may only expose descendants through deps.
+			return nil, false, nil
+		}
+		handled = true
+		subtree := make([]beads.Bead, 0, 1+len(descendants))
+		subtree = append(subtree, root)
+		subtree = append(subtree, descendants...)
+		if !openSubtreeOlderThan(subtree, cutoff) {
+			continue
+		}
+		for _, id := range staleOrderWispSubtreeCloseIDs(subtree) {
+			if _, ok := seenIDs[id]; ok {
+				continue
+			}
+			seenIDs[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	return ids, handled, nil
 }
 
 func staleOrderWispRoots(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}) ([]beads.Bead, error) {
@@ -2342,10 +2471,31 @@ func collectOrderWispSubtree(store beads.Store, root beads.Bead) ([]beads.Bead, 
 	if root.ID == "" {
 		return nil, nil
 	}
+	reader := beads.HandlesFor(store).Live
+	if orderWispMayHaveGraphDependents(root) {
+		metadataDescendants, err := orderWispMetadataDescendants(reader, root.ID, true)
+		if err != nil {
+			return nil, err
+		}
+		if len(metadataDescendants) > 0 {
+			out := []beads.Bead{root}
+			seen := map[string]struct{}{root.ID: {}}
+			for _, descendant := range metadataDescendants {
+				if descendant.ID == "" {
+					continue
+				}
+				if _, ok := seen[descendant.ID]; ok {
+					continue
+				}
+				seen[descendant.ID] = struct{}{}
+				out = append(out, descendant)
+			}
+			return out, nil
+		}
+	}
 	seen := map[string]struct{}{root.ID: {}}
 	out := []beads.Bead{root}
 	queue := []string{root.ID}
-	reader := beads.HandlesFor(store).Live
 	for len(queue) > 0 {
 		parentID := queue[0]
 		queue = queue[1:]

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1636,7 +1636,7 @@ func orderWispMetadataDescendants(reader beads.LiveReader, rootID string, includ
 		return nil, nil
 	}
 	query := beads.ListQuery{
-		Metadata:      map[string]string{"gc.root_bead_id": rootID},
+		Metadata:      map[string]string{beadmeta.RootBeadIDMetadataKey: rootID},
 		IncludeClosed: includeClosed,
 	}
 	descendants, err := reader.List(query)
@@ -2292,8 +2292,8 @@ func orderTrackingClosedReferenceTime(b beads.Bead) time.Time {
 	return b.CreatedAt
 }
 
-func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string) (int, error) {
-	return sweepStaleOrderWispSubtreesMode(store, cutoff, onlyOrders, initiator, false)
+func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}) (int, error) {
+	return sweepStaleOrderWispSubtreesMode(store, cutoff, onlyOrders, orderTrackingSweepMetadataInitiator, false)
 }
 
 func sweepStaleOrderWispSubtreesMode(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string, dryRun bool) (int, error) {
@@ -2360,6 +2360,13 @@ func sweepStaleOrderWispSubtreesMode(store beads.Store, cutoff time.Time, onlyOr
 	return closeStaleOrderWispIDs(store, ordered, initiator)
 }
 
+// closeStaleOrderWispIDs closes ids via Store.CloseAll with the sweep's audit
+// metadata. The legacy path pre-orders ids with closeorder.Order; the batch
+// path passes them unordered and is safe only because BdStore.CloseAll issues
+// `bd close --force`, which closes blocked beads regardless of in-batch order
+// (a non-forced wrong-order batch silently skips blocked beads while exiting
+// 0). That flag, pinned by TestBdCloseArgsAlwaysForce, is what keeps the
+// unordered batch correct on stores that enforce blocks dependencies.
 func closeStaleOrderWispIDs(store beads.Store, ids []string, initiator string) (int, error) {
 	metadata := map[string]string{
 		"order_tracking_sweep": orderTrackingSweepMetadataReason,
@@ -2381,25 +2388,40 @@ func staleOrderWispSubtreeBatchCloseIDs(store beads.Store, cutoff time.Time, onl
 		return nil, false, fmt.Errorf("include-wisps requires at least one order name")
 	}
 	all, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
-		CreatedBefore: time.Now().Add(24 * time.Hour),
+		// The batch sweep deliberately scans every bead once and groups
+		// candidate roots with their descendants in memory, instead of issuing
+		// the per-root queries the walk path needs. Closed beads are included
+		// so the ParentID closure can traverse closed intermediates down to
+		// the open descendants beneath them, matching the walk path's
+		// IncludeClosed per-node queries.
+		AllowScan:     true,
+		IncludeClosed: true,
 	})
 	if err != nil {
-		return nil, false, fmt.Errorf("listing open wisp candidates for order-wisp batch sweep: %w", err)
+		return nil, false, fmt.Errorf("listing wisp candidates for order-wisp batch sweep: %w", err)
 	}
 	if len(all) == 0 {
 		return nil, false, nil
 	}
 
 	descendantsByRoot := make(map[string][]beads.Bead)
+	openStampedByRoot := make(map[string]struct{})
+	childrenByParent := make(map[string][]beads.Bead)
 	for _, bead := range all {
-		if bead.ID == "" || bead.Status == "closed" {
+		if bead.ID == "" {
 			continue
 		}
-		rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
+		if parentID := strings.TrimSpace(bead.ParentID); parentID != "" && parentID != bead.ID {
+			childrenByParent[parentID] = append(childrenByParent[parentID], bead)
+		}
+		rootID := strings.TrimSpace(bead.Metadata[beadmeta.RootBeadIDMetadataKey])
 		if rootID == "" {
 			continue
 		}
 		descendantsByRoot[rootID] = append(descendantsByRoot[rootID], bead)
+		if bead.Status != "closed" {
+			openStampedByRoot[rootID] = struct{}{}
+		}
 	}
 
 	handled := false
@@ -2412,7 +2434,13 @@ func staleOrderWispSubtreeBatchCloseIDs(store beads.Store, cutoff time.Time, onl
 		if beadLabelsContain(root.Labels, labelOrderTracking) {
 			continue
 		}
-		name, ok := orderNameFromTrackingBead(root)
+		// Force-close roots are matched on the order-run:<name> label only,
+		// matching the legacy path's staleOrderWispRoots selection. The
+		// order:<title> fallback in orderNameFromTrackingBead exists for legacy
+		// tracking beads; honoring it here would make a workflow root that was
+		// never order-poured force-closable just because its title collides
+		// with a swept order name.
+		name, ok := orderNameFromOrderRunLabel(root)
 		if !ok {
 			continue
 		}
@@ -2426,7 +2454,7 @@ func staleOrderWispSubtreeBatchCloseIDs(store beads.Store, cutoff time.Time, onl
 			continue
 		}
 		descendants := descendantsByRoot[root.ID]
-		if len(descendants) == 0 && !isOrderRootOnlyWispCandidate(root) {
+		if _, hasOpenStamped := openStampedByRoot[root.ID]; !hasOpenStamped && !isOrderRootOnlyWispCandidate(root) {
 			// Legacy graph-v2 wisps may only expose descendants through deps.
 			return nil, false, nil
 		}
@@ -2434,6 +2462,7 @@ func staleOrderWispSubtreeBatchCloseIDs(store beads.Store, cutoff time.Time, onl
 		subtree := make([]beads.Bead, 0, 1+len(descendants))
 		subtree = append(subtree, root)
 		subtree = append(subtree, descendants...)
+		subtree = appendParentChainDescendants(subtree, childrenByParent)
 		if !openSubtreeOlderThan(subtree, cutoff) {
 			continue
 		}
@@ -2446,6 +2475,44 @@ func staleOrderWispSubtreeBatchCloseIDs(store beads.Store, cutoff time.Time, onl
 		}
 	}
 	return ids, handled, nil
+}
+
+// appendParentChainDescendants unions a metadata-stamped subtree with every
+// bead reachable from it over ParentID edges. Partially-stamped molecules
+// carry open ParentID-only children that the gc.root_bead_id grouping cannot
+// see; without this union a fresh un-stamped child would no longer veto the
+// root's close and a stale one would be stranded open under a closed root —
+// the leak class the sweep drains. Closed children are appended and traversed
+// too: an open un-stamped descendant can hide behind a closed intermediate (a
+// lingering nudge/mail chore parented under an already-closed step is the
+// production shape), and only a closed-inclusive index reaches it — the walk
+// path resolves the identical shape through its IncludeClosed per-node
+// queries. Appending closed beads is safe because openSubtreeOlderThan and
+// staleOrderWispSubtreeCloseIDs both filter on status. The closure walks the
+// in-memory index built from the batch List, so it adds no store round-trips.
+func appendParentChainDescendants(subtree []beads.Bead, childrenByParent map[string][]beads.Bead) []beads.Bead {
+	seen := make(map[string]struct{}, len(subtree))
+	queue := make([]string, 0, len(subtree))
+	for _, b := range subtree {
+		if b.ID == "" {
+			continue
+		}
+		seen[b.ID] = struct{}{}
+		queue = append(queue, b.ID)
+	}
+	for len(queue) > 0 {
+		parentID := queue[0]
+		queue = queue[1:]
+		for _, child := range childrenByParent[parentID] {
+			if _, ok := seen[child.ID]; ok {
+				continue
+			}
+			seen[child.ID] = struct{}{}
+			subtree = append(subtree, child)
+			queue = append(queue, child.ID)
+		}
+	}
+	return subtree
 }
 
 func staleOrderWispRoots(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}) ([]beads.Bead, error) {
@@ -2467,35 +2534,42 @@ func staleOrderWispRoots(store beads.Store, cutoff time.Time, onlyOrders map[str
 	return roots, nil
 }
 
+// collectOrderWispSubtree returns the root plus every descendant the sweep
+// reasons about, as the union of two views: the gc.root_bead_id membership
+// set (stamped members regardless of edge linkage) and the authoritative
+// ParentID/graph walk seeded with those members. Neither view alone is
+// complete — the membership query cannot see the un-stamped ParentID-only
+// children of a partially-stamped molecule (the same gap documented on
+// storeHasOpenDescendants), and the walk cannot see stamped members linked by
+// neither ParentID nor an owned dependency edge. Trusting the metadata set
+// alone would let a fresh un-stamped child slip past the freshness veto and a
+// stale one be stranded open under a closed root, the leak class this sweep
+// drains, so the walk always runs.
 func collectOrderWispSubtree(store beads.Store, root beads.Bead) ([]beads.Bead, error) {
 	if root.ID == "" {
 		return nil, nil
 	}
 	reader := beads.HandlesFor(store).Live
+	seen := map[string]struct{}{root.ID: {}}
+	out := []beads.Bead{root}
+	queue := []string{root.ID}
 	if orderWispMayHaveGraphDependents(root) {
 		metadataDescendants, err := orderWispMetadataDescendants(reader, root.ID, true)
 		if err != nil {
 			return nil, err
 		}
-		if len(metadataDescendants) > 0 {
-			out := []beads.Bead{root}
-			seen := map[string]struct{}{root.ID: {}}
-			for _, descendant := range metadataDescendants {
-				if descendant.ID == "" {
-					continue
-				}
-				if _, ok := seen[descendant.ID]; ok {
-					continue
-				}
-				seen[descendant.ID] = struct{}{}
-				out = append(out, descendant)
+		for _, descendant := range metadataDescendants {
+			if descendant.ID == "" {
+				continue
 			}
-			return out, nil
+			if _, ok := seen[descendant.ID]; ok {
+				continue
+			}
+			seen[descendant.ID] = struct{}{}
+			out = append(out, descendant)
+			queue = append(queue, descendant.ID)
 		}
 	}
-	seen := map[string]struct{}{root.ID: {}}
-	out := []beads.Bead{root}
-	queue := []string{root.ID}
 	for len(queue) > 0 {
 		parentID := queue[0]
 		queue = queue[1:]
@@ -2589,11 +2663,26 @@ func openSubtreeOlderThan(subtree []beads.Bead, cutoff time.Time) bool {
 	return true
 }
 
-func orderNameFromTrackingBead(b beads.Bead) (string, bool) {
+// orderNameFromOrderRunLabel resolves an order name from the order-run:<name>
+// label only. Paths that select beads for destructive action (force-close root
+// matching) must use this instead of orderNameFromTrackingBead so a bead can
+// never be selected on its title alone.
+func orderNameFromOrderRunLabel(b beads.Bead) (string, bool) {
 	for _, label := range b.Labels {
 		if name, ok := strings.CutPrefix(label, "order-run:"); ok && name != "" {
 			return name, true
 		}
+	}
+	return "", false
+}
+
+// orderNameFromTrackingBead resolves an order name from the order-run:<name>
+// label, falling back to the legacy order:<name> title prefix used by old
+// tracking beads. The fallback is for tracking-bead selection and retention
+// bucketing only; force-close root matching uses orderNameFromOrderRunLabel.
+func orderNameFromTrackingBead(b beads.Bead) (string, bool) {
+	if name, ok := orderNameFromOrderRunLabel(b); ok {
+		return name, true
 	}
 	if name, ok := strings.CutPrefix(b.Title, "order:"); ok && name != "" {
 		return name, true

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4707,6 +4707,493 @@ func TestSweepStaleOrderTrackingDryRunUsesRootMetadataDescendants(t *testing.T) 
 	}
 }
 
+// Partial-stamp molecules carry gc.root_bead_id on some steps while sibling
+// ParentID-only steps are un-stamped. The four tests below pin that such
+// un-stamped children take part in both the freshness veto and the close set
+// on the walk path (stamped sibling closed, so the batch path declines) and
+// on the batch path (stamped sibling open, batch handles the store).
+
+func TestSweepStaleOrderTrackingWithWispsPartialStampFreshChildVetoesClose(t *testing.T) {
+	store := &createdAtOverrideStore{Store: beads.NewMemStore()}
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	stampedStep, err := store.Create(beads.Bead{
+		Title: "Stamped finished step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.done",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(stamped step): %v", err)
+	}
+	if err := store.Close(stampedStep.ID); err != nil {
+		t.Fatalf("Close(stamped step): %v", err)
+	}
+	now := wispRoot.CreatedAt.Add(time.Hour)
+	unstampedChild, err := store.Create(beads.Bead{
+		Title:     "Un-stamped live step",
+		Type:      "task",
+		ParentID:  wispRoot.ID,
+		CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("Create(unstamped child): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		now,
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 0 {
+		t.Fatalf("wispClosed = %d, want 0 (fresh un-stamped child must veto)", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, unstampedChild.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status = %q, want open", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsPartialStampClosesStaleChildWithSubtree(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	stampedStep, err := store.Create(beads.Bead{
+		Title: "Stamped finished step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.done",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(stamped step): %v", err)
+	}
+	if err := store.Close(stampedStep.ID); err != nil {
+		t.Fatalf("Close(stamped step): %v", err)
+	}
+	unstampedChild, err := store.Create(beads.Bead{
+		Title:    "Un-stamped stale step",
+		Type:     "task",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(unstamped child): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("wispClosed = %d, want 2 (root and un-stamped child)", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, unstampedChild.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed (un-stamped child must not be stranded)", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingBatchPartialStampFreshChildVetoesClose(t *testing.T) {
+	base := &createdAtOverrideStore{Store: beads.NewMemStore()}
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	stampedStep, err := base.Create(beads.Bead{
+		Title: "Stamped open step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(stamped step): %v", err)
+	}
+	now := wispRoot.CreatedAt.Add(time.Hour)
+	unstampedChild, err := base.Create(beads.Bead{
+		Title:     "Un-stamped live step",
+		Type:      "task",
+		ParentID:  wispRoot.ID,
+		CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("Create(unstamped child): %v", err)
+	}
+
+	// depListFailStore pins that the batch path handles this store: any
+	// fallback to the walk would DepList the root and fail the sweep.
+	store := depListFailStore{Store: base, failID: wispRoot.ID}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		now,
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 0 {
+		t.Fatalf("wispClosed = %d, want 0 (fresh un-stamped child must veto)", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, stampedStep.ID, unstampedChild.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status = %q, want open", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingBatchPartialStampClosesStaleChildWithSubtree(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	stampedStep, err := base.Create(beads.Bead{
+		Title: "Stamped open step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(stamped step): %v", err)
+	}
+	unstampedChild, err := base.Create(beads.Bead{
+		Title:    "Un-stamped stale step",
+		Type:     "task",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(unstamped child): %v", err)
+	}
+	// depListFailStore pins that the batch path handles this store without
+	// close ordering: a walk fallback or closeorder pass would DepList the
+	// root and fail the sweep.
+	store := depListFailStore{Store: base, failID: wispRoot.ID}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 3 {
+		t.Fatalf("wispClosed = %d, want 3 (root, stamped step, un-stamped child)", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, stampedStep.ID, unstampedChild.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed (un-stamped child must not be stranded)", id, got.Status)
+		}
+	}
+}
+
+// The two tests below pin the closed-intermediate shape on the batch path:
+// an open un-stamped grandchild reachable only through a closed ParentID
+// intermediate (the production instance is a lingering nudge/mail chore
+// parented under an already-closed step). The batch path must traverse the
+// closed intermediate exactly like the walk path's IncludeClosed queries do,
+// so a fresh grandchild vetoes the close and a stale one drains with the
+// subtree instead of being stranded.
+
+func TestSweepStaleOrderTrackingBatchFreshGrandchildBehindClosedIntermediateVetoesClose(t *testing.T) {
+	base := &createdAtOverrideStore{Store: beads.NewMemStore()}
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	stampedStep, err := base.Create(beads.Bead{
+		Title: "Stamped open step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(stamped step): %v", err)
+	}
+	intermediate, err := base.Create(beads.Bead{
+		Title:    "Un-stamped finished step",
+		Type:     "task",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(intermediate): %v", err)
+	}
+	now := wispRoot.CreatedAt.Add(time.Hour)
+	grandchild, err := base.Create(beads.Bead{
+		Title:     "Un-stamped live chore",
+		Type:      "task",
+		ParentID:  intermediate.ID,
+		CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("Create(grandchild): %v", err)
+	}
+	if err := base.Close(intermediate.ID); err != nil {
+		t.Fatalf("Close(intermediate): %v", err)
+	}
+
+	// depListFailStore pins that the batch path handles this store: any
+	// fallback to the walk would DepList the root and fail the sweep.
+	store := depListFailStore{Store: base, failID: wispRoot.ID}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		now,
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 0 {
+		t.Fatalf("wispClosed = %d, want 0 (fresh grandchild behind closed intermediate must veto)", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, stampedStep.ID, grandchild.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status = %q, want open", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingBatchClosesStaleGrandchildBehindClosedIntermediate(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	stampedStep, err := base.Create(beads.Bead{
+		Title: "Stamped open step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(stamped step): %v", err)
+	}
+	intermediate, err := base.Create(beads.Bead{
+		Title:    "Un-stamped finished step",
+		Type:     "task",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(intermediate): %v", err)
+	}
+	grandchild, err := base.Create(beads.Bead{
+		Title:    "Un-stamped stale chore",
+		Type:     "task",
+		ParentID: intermediate.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(grandchild): %v", err)
+	}
+	if err := base.Close(intermediate.ID); err != nil {
+		t.Fatalf("Close(intermediate): %v", err)
+	}
+
+	// depListFailStore pins that the batch path handles this store without
+	// close ordering: a walk fallback or closeorder pass would DepList the
+	// root and fail the sweep.
+	store := depListFailStore{Store: base, failID: wispRoot.ID}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 3 {
+		t.Fatalf("wispClosed = %d, want 3 (root, stamped step, grandchild behind closed intermediate)", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, stampedStep.ID, grandchild.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed (grandchild must not be stranded)", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingBatchIgnoresTitleOnlyOrderRoots(t *testing.T) {
+	base := beads.NewMemStore()
+
+	labeledRoot, err := base.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(labeled root): %v", err)
+	}
+	labeledStep, err := base.Create(beads.Bead{
+		Title: "Stamped open step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": labeledRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(labeled step): %v", err)
+	}
+	// A workflow root that was never order-poured: no order-run label, but a
+	// title that collides with the swept order name.
+	titleRoot, err := base.Create(beads.Bead{
+		Title: "order:seth-patrol",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(title root): %v", err)
+	}
+	titleStep, err := base.Create(beads.Bead{
+		Title: "Unrelated workflow step",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": titleRoot.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(title step): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		base,
+		labeledRoot.CreatedAt.Add(time.Hour),
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("wispClosed = %d, want 2 (labeled subtree only)", result.wispClosed)
+	}
+	for _, id := range []string{labeledRoot.ID, labeledStep.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+	}
+	for _, id := range []string{titleRoot.ID, titleStep.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("title-only root subtree %s status = %q, want open (never order-poured)", id, got.Status)
+		}
+	}
+}
+
 func TestSweepStaleOrderTrackingWithoutWispsLeavesOpenWispSubtree(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -4924,7 +5411,7 @@ func TestSweepStaleOrderTrackingWithWispsSkipsFreshOpenDescendant(t *testing.T) 
 	}
 	cutoff := wispRoot.CreatedAt.Add(child.CreatedAt.Sub(wispRoot.CreatedAt) / 2)
 
-	closed, err := sweepStaleOrderWispSubtrees(store, cutoff, orderFilterForTest("digest"), orderTrackingSweepMetadataInitiator)
+	closed, err := sweepStaleOrderWispSubtrees(store, cutoff, orderFilterForTest("digest"))
 	if err != nil {
 		t.Fatalf("sweepStaleOrderWispSubtrees: %v", err)
 	}
@@ -4975,7 +5462,6 @@ func TestSweepStaleOrderTrackingWithWispsClosesGraphDependentSubtree(t *testing.
 		store,
 		step.CreatedAt.Add(time.Minute),
 		orderFilterForTest("digest"),
-		orderTrackingSweepMetadataInitiator,
 	)
 	if err != nil {
 		t.Fatalf("sweepStaleOrderWispSubtrees: %v", err)
@@ -5029,7 +5515,6 @@ func TestSweepStaleOrderTrackingWithWispsClosesSameWorkflowGraphDependencyTypes(
 				store,
 				step.CreatedAt.Add(time.Minute),
 				orderFilterForTest("digest"),
-				orderTrackingSweepMetadataInitiator,
 			)
 			if err != nil {
 				t.Fatalf("sweepStaleOrderWispSubtrees: %v", err)
@@ -5100,7 +5585,6 @@ func TestSweepStaleOrderTrackingWithWispsIgnoresForeignGraphDependents(t *testin
 				store,
 				external.CreatedAt.Add(time.Minute),
 				orderFilterForTest("digest"),
-				orderTrackingSweepMetadataInitiator,
 			)
 			if err != nil {
 				t.Fatalf("sweepStaleOrderWispSubtrees: %v", err)
@@ -5142,7 +5626,6 @@ func TestSweepStaleOrderTrackingWithWispsPropagatesDescendantListError(t *testin
 		store,
 		wispRoot.CreatedAt.Add(time.Minute),
 		orderFilterForTest("digest"),
-		orderTrackingSweepMetadataInitiator,
 	)
 	if err == nil {
 		t.Fatal("sweepStaleOrderWispSubtrees err = nil, want descendant-list error")
@@ -5179,7 +5662,6 @@ func TestSweepStaleOrderTrackingWithWispsPropagatesCloseOrderError(t *testing.T)
 		store,
 		wispRoot.CreatedAt.Add(time.Minute),
 		orderFilterForTest("digest"),
-		orderTrackingSweepMetadataInitiator,
 	)
 	if err == nil {
 		t.Fatal("sweepStaleOrderWispSubtrees err = nil, want close-order error")

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4337,6 +4337,376 @@ func TestSweepStaleOrderTrackingWithWispsClosesOldOpenWispSubtree(t *testing.T) 
 	}
 }
 
+func TestSweepStaleOrderTrackingWithWispsClosesGraphDependentSubtreeViaTrackingSweep(t *testing.T) {
+	store := beads.NewMemStore()
+
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	step, err := store.Create(beads.Bead{
+		Title: "Infrastructure patrol",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.patrol",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(step): %v", err)
+	}
+	if err := store.DepAdd(step.ID, wispRoot.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("wispClosed = %d, want 2", result.wispClosed)
+	}
+
+	for _, id := range []string{wispRoot.ID, step.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+		if got.Metadata["close_reason"] != staleOrderWispCloseReason {
+			t.Fatalf("%s close_reason = %q, want %q", id, got.Metadata["close_reason"], staleOrderWispCloseReason)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsClosesMetadataGraphSubtreeWithoutCloseOrdering(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:     "mol-seth-patrol",
+		Type:      "task",
+		Labels:    []string{"order-run:seth-patrol"},
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	step, err := base.Create(beads.Bead{
+		Title:     "Infrastructure patrol",
+		Type:      "task",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.patrol",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(step): %v", err)
+	}
+	store := depListFailStore{Store: base, failID: wispRoot.ID}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("wispClosed = %d, want 2", result.wispClosed)
+	}
+
+	for _, id := range []string{wispRoot.ID, step.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+		if got.Metadata["close_reason"] != staleOrderWispCloseReason {
+			t.Fatalf("%s close_reason = %q, want %q", id, got.Metadata["close_reason"], staleOrderWispCloseReason)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingWithWispsMixedLegacyGraphClosesOnlyOwnedSubtree(t *testing.T) {
+	store := beads.NewMemStore()
+
+	metadataRoot, err := store.Create(beads.Bead{
+		Title:     "mol-seth-patrol",
+		Type:      "task",
+		Labels:    []string{"order-run:seth-patrol"},
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(metadata root): %v", err)
+	}
+	metadataStep, err := store.Create(beads.Bead{
+		Title:     "Metadata-backed step",
+		Type:      "task",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.root_bead_id": metadataRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.metadata",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(metadata step): %v", err)
+	}
+
+	legacyRoot, err := store.Create(beads.Bead{
+		Title:     "mol-seth-patrol",
+		Type:      "task",
+		Labels:    []string{"order-run:seth-patrol"},
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(legacy root): %v", err)
+	}
+	legacyStep, err := store.Create(beads.Bead{
+		Title:     "Legacy graph step",
+		Type:      "task",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.step_ref": "mol-seth-patrol.legacy",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(legacy step): %v", err)
+	}
+	if err := store.DepAdd(legacyStep.ID, legacyRoot.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(legacy tracks): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptions(
+		store,
+		metadataRoot.CreatedAt.Add(time.Hour),
+		orderFilterForTest("seth-patrol"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptions: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("wispClosed = %d, want 2", result.wispClosed)
+	}
+	for _, id := range []string{metadataRoot.ID, metadataStep.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got.Status)
+		}
+	}
+	// Dep-linked beads without gc.root_bead_id ownership metadata are outside
+	// the sweep's close authority (orderWispGraphDependentOwnedByRoot), so the
+	// legacy subtree is conservatively left open for dep-edge reaping.
+	for _, id := range []string{legacyRoot.ID, legacyStep.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("unowned legacy wisp %s status = %q, want open", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingDryRunCountsGraphSubtreeWithoutClosing(t *testing.T) {
+	store := beads.NewMemStore()
+
+	tracking, err := store.Create(beads.Bead{
+		Title:     "order:seth-patrol",
+		Labels:    []string{"order-run:seth-patrol", labelOrderTracking},
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("Create(tracking): %v", err)
+	}
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-seth-patrol",
+		Type:   "task",
+		Labels: []string{"order-run:seth-patrol"},
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	step, err := store.Create(beads.Bead{
+		Title: "Infrastructure patrol",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.patrol",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(step): %v", err)
+	}
+	if err := store.DepAdd(step.ID, wispRoot.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+
+	result, err := sweepStaleOrderTrackingWithOptionsLimitDryRun(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		time.Minute,
+		orderFilterForTest("seth-patrol"),
+		orderTrackingSweepMetadataInitiator,
+		true,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptionsLimitDryRun: %v", err)
+	}
+	if result.trackingClosed != 1 {
+		t.Fatalf("trackingClosed = %d, want 1 dry-run candidate", result.trackingClosed)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("wispClosed = %d, want 2 dry-run candidates", result.wispClosed)
+	}
+
+	for _, id := range []string{tracking.ID, wispRoot.ID, step.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status after dry-run = %q, want open", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingDryRunSkipsCloseOrdering(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:  "mol-digest-generate",
+		Type:   "molecule",
+		Labels: []string{"order-run:digest"},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	child, err := base.Create(beads.Bead{
+		Title:    "draft-digest",
+		ParentID: wispRoot.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	store := depListFailStore{Store: base, failID: child.ID}
+
+	result, err := sweepStaleOrderTrackingWithOptionsLimitDryRun(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		time.Minute,
+		orderFilterForTest("digest"),
+		orderTrackingSweepMetadataInitiator,
+		true,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptionsLimitDryRun: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("wispClosed = %d, want 2 dry-run candidates", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, child.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status after dry-run = %q, want open", id, got.Status)
+		}
+	}
+}
+
+func TestSweepStaleOrderTrackingDryRunUsesRootMetadataDescendants(t *testing.T) {
+	base := beads.NewMemStore()
+
+	wispRoot, err := base.Create(beads.Bead{
+		Title:     "mol-seth-patrol",
+		Type:      "task",
+		Labels:    []string{"order-run:seth-patrol"},
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(wisp root): %v", err)
+	}
+	step, err := base.Create(beads.Bead{
+		Title:     "Infrastructure patrol",
+		Type:      "task",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.root_bead_id": wispRoot.ID,
+			"gc.step_ref":     "mol-seth-patrol.patrol",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(step): %v", err)
+	}
+	store := depListFailStore{Store: base, failID: wispRoot.ID}
+
+	result, err := sweepStaleOrderTrackingWithOptionsLimitDryRun(
+		store,
+		wispRoot.CreatedAt.Add(time.Hour),
+		time.Minute,
+		orderFilterForTest("seth-patrol"),
+		orderTrackingSweepMetadataInitiator,
+		true,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTrackingWithOptionsLimitDryRun: %v", err)
+	}
+	if result.wispClosed != 2 {
+		t.Fatalf("wispClosed = %d, want 2 dry-run candidates", result.wispClosed)
+	}
+	for _, id := range []string{wispRoot.ID, step.ID} {
+		got, err := base.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if got.Status != "open" {
+			t.Fatalf("%s status after dry-run = %q, want open", id, got.Status)
+		}
+	}
+}
+
 func TestSweepStaleOrderTrackingWithoutWispsLeavesOpenWispSubtree(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -536,8 +536,17 @@ func orderTrackingSweepTargetsForConfig(cityPath string, cfg *config.City) []ord
 	return targets
 }
 
-func orderTrackingSweepStoresForConfig(cityPath string, cfg *config.City) ([]beads.Store, error) {
+func orderTrackingSweepStoresForConfigTargets(cityPath string, cfg *config.City, requiredTargets map[string][]string) ([]beads.Store, error) {
 	targets := orderTrackingSweepTargetsForConfig(cityPath, cfg)
+	if len(requiredTargets) > 0 {
+		filtered := targets[:0]
+		for _, target := range targets {
+			if _, ok := requiredTargets[orderStoreTargetKey(target.target)]; ok {
+				filtered = append(filtered, target)
+			}
+		}
+		targets = filtered
+	}
 	return orderTrackingSweepStoresFromTargets(targets, func(sweepTarget orderTrackingSweepTarget) (beads.Store, error) {
 		return openStoreAtForCity(sweepTarget.target.ScopeRoot, cityPath)
 	})

--- a/cmd/gc/provider_store_resolution_test.go
+++ b/cmd/gc/provider_store_resolution_test.go
@@ -425,6 +425,29 @@ name = "store"
 	}
 }
 
+func TestAutocloseCityPathForStoreRootUsesExplicitCityForExternalRigRuntime(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+
+	envCityDir := t.TempDir()
+	if err := ensureScopedFileStoreLayout(envCityDir); err != nil {
+		t.Fatal(err)
+	}
+	writeProviderAwareTestCity(t, envCityDir, `[workspace]
+name = "ambient"
+`)
+	t.Setenv("GC_CITY", envCityDir)
+
+	rigDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := autocloseCityPathForStoreRoot(rigDir)
+	if canonicalTestPath(got) != canonicalTestPath(envCityDir) {
+		t.Fatalf("autocloseCityPathForStoreRoot(%q) = %q, want explicit city %q", rigDir, got, envCityDir)
+	}
+}
+
 func TestDoWispAutocloseUsesBeadsDirStoreRoot(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_BEADS", "file")

--- a/cmd/gc/wisp_autoclose.go
+++ b/cmd/gc/wisp_autoclose.go
@@ -56,12 +56,16 @@ func doWispAutoclose(beadID string, stdout, _ io.Writer) {
 // preferred, with child traversal as a fallback for legacy data. Called from
 // the bd on_close hook to ensure attached wisps don't outlive their parent work
 // bead. All errors are silently swallowed — this is best-effort infrastructure.
+// Parent lookup and child traversal both read through the Live handle: the
+// hook fires for closed and ephemeral-tier beads that cached or tier-narrow
+// raw reads can miss, and an attachment missed here outlives its parent — the
+// leak class this hook exists to drain.
 func doWispAutocloseWith(store beads.Store, beadID string, stdout io.Writer) {
 	parent, err := beads.HandlesFor(store).Live.Get(beadID)
 	if err != nil {
 		return
 	}
-	attachments, err := collectAttachedBeads(parent, store, store)
+	attachments, err := collectAttachedBeads(parent, store, beads.HandlesFor(store).Live)
 	if err == nil || len(attachments) > 0 {
 		for _, attached := range attachments {
 			closed, err := closeAttachedWispSubtree(store, attached)

--- a/cmd/gc/wisp_autoclose.go
+++ b/cmd/gc/wisp_autoclose.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/sling"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 	"github.com/spf13/cobra"
 )
 
@@ -56,21 +57,28 @@ func doWispAutoclose(beadID string, stdout, _ io.Writer) {
 // the bd on_close hook to ensure attached wisps don't outlive their parent work
 // bead. All errors are silently swallowed — this is best-effort infrastructure.
 func doWispAutocloseWith(store beads.Store, beadID string, stdout io.Writer) {
-	parent, err := store.Get(beadID)
+	parent, err := beads.HandlesFor(store).Live.Get(beadID)
 	if err != nil {
 		return
 	}
 	attachments, err := collectAttachedBeads(parent, store, store)
-	if err != nil && len(attachments) == 0 {
+	if err == nil || len(attachments) > 0 {
+		for _, attached := range attachments {
+			closed, err := closeAttachedWispSubtree(store, attached)
+			if err != nil || closed == 0 {
+				continue
+			}
+			fmt.Fprintf(stdout, "Auto-closed %s %s on %s\n", attachmentLabel(attached), attached.ID, beadID) //nolint:errcheck // best-effort stdout
+		}
+	}
+	if parent.Status != "closed" || !sourceworkflow.IsWorkflowRoot(parent) {
 		return
 	}
-	for _, attached := range attachments {
-		closed, err := closeAttachedWispSubtree(store, attached)
-		if err != nil || closed == 0 {
-			continue
-		}
-		fmt.Fprintf(stdout, "Auto-closed %s %s on %s\n", attachmentLabel(attached), attached.ID, beadID) //nolint:errcheck // best-effort stdout
+	closed, err := sourceworkflow.CloseSpecSidecarsForRoot(store, parent.ID, "")
+	if err != nil || closed == 0 {
+		return
 	}
+	fmt.Fprintf(stdout, "Auto-closed %d generated spec bead(s) on %s\n", closed, beadID) //nolint:errcheck // best-effort stdout
 }
 
 func closeAttachedWispSubtree(store beads.Store, attached beads.Bead) (int, error) {

--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestWispAutocloseClosesOpenMolecule(t *testing.T) {
@@ -106,6 +107,178 @@ func TestWispAutocloseChecksDescendantsWhenAttachedRootAlreadyClosed(t *testing.
 	}
 	if child.Status != "closed" {
 		t.Fatalf("descendant status = %q, want closed", child.Status)
+	}
+}
+
+func TestWispAutocloseClosesGeneratedSpecsForClosedWorkflowRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title: "workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	spec, err := store.Create(beads.Bead{
+		Title: "Step spec for review",
+		Type:  "spec",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": root.ID,
+			"gc.spec_for":     "review",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(spec): %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title: "real workflow work",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	_ = store.Close(root.ID)
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, root.ID, &stdout)
+
+	if !strings.Contains(stdout.String(), "Auto-closed 1 generated spec bead(s) on "+root.ID) {
+		t.Fatalf("stdout = %q, want generated spec cleanup message", stdout.String())
+	}
+	specAfter, err := store.Get(spec.ID)
+	if err != nil {
+		t.Fatalf("Get(spec): %v", err)
+	}
+	if specAfter.Status != "closed" {
+		t.Fatalf("spec status = %q, want closed", specAfter.Status)
+	}
+	workAfter, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get(work): %v", err)
+	}
+	if workAfter.Status != "open" {
+		t.Fatalf("non-spec workflow bead status = %q, want open", workAfter.Status)
+	}
+}
+
+func TestWispAutocloseSkipsGeneratedSpecsForClosedWorkflowChild(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title: "workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title: "workflow child",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	spec, err := store.Create(beads.Bead{
+		Title: "Step spec for review",
+		Type:  "spec",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": root.ID,
+			"gc.spec_for":     "review",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(spec): %v", err)
+	}
+	_ = store.Close(child.ID)
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, child.ID, &stdout)
+
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want no generated spec cleanup message", stdout.String())
+	}
+	specAfter, err := store.Get(spec.ID)
+	if err != nil {
+		t.Fatalf("Get(spec): %v", err)
+	}
+	if specAfter.Status != "open" {
+		t.Fatalf("spec status = %q, want open", specAfter.Status)
+	}
+}
+
+func TestWispAutocloseReadsClosedWorkflowRootFromLiveHandle(t *testing.T) {
+	mem := beads.NewMemStore()
+	root, err := mem.Create(beads.Bead{
+		Title: "workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	spec, err := mem.Create(beads.Bead{
+		Title: "Step spec for review",
+		Type:  "spec",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": root.ID,
+			"gc.spec_for":     "review",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(spec): %v", err)
+	}
+	if err := mem.Close(root.ID); err != nil {
+		t.Fatalf("Close(root): %v", err)
+	}
+	store := wrapStoreWithBeadPolicies(staleCachedWispStore{MemStore: mem}, &config.City{})
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, root.ID, &stdout)
+
+	if !strings.Contains(stdout.String(), "Auto-closed 1 generated spec bead(s) on "+root.ID) {
+		t.Fatalf("stdout = %q, want generated spec cleanup message", stdout.String())
+	}
+	specAfter, err := mem.Get(spec.ID)
+	if err != nil {
+		t.Fatalf("Get(spec): %v", err)
+	}
+	if specAfter.Status != "closed" {
+		t.Fatalf("spec status = %q, want closed", specAfter.Status)
+	}
+}
+
+type staleCachedWispStore struct {
+	*beads.MemStore
+}
+
+func (s staleCachedWispStore) Get(_ string) (beads.Bead, error) {
+	return beads.Bead{}, beads.ErrCacheUnavailable
+}
+
+func (s staleCachedWispStore) Handles() beads.StoreHandles {
+	return beads.StoreHandles{
+		Cached: s,
+		Live:   s.MemStore,
+		Writer: s.MemStore,
 	}
 }
 

--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -282,6 +282,48 @@ func (s staleCachedWispStore) Handles() beads.StoreHandles {
 	}
 }
 
+func TestWispAutocloseTraversesChildrenViaLiveHandle(t *testing.T) {
+	mem := beads.NewMemStore()
+	_, _ = mem.Create(beads.Bead{Title: "work item"})                                // gc-1
+	_, _ = mem.Create(beads.Bead{Title: "wisp", Type: "molecule", ParentID: "gc-1"}) // gc-2
+	_ = mem.Close("gc-1")
+	store := tierNarrowListWispStore{MemStore: mem}
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, "gc-1", &stdout)
+
+	if !strings.Contains(stdout.String(), "Auto-closed molecule gc-2 on gc-1") {
+		t.Fatalf("stdout = %q, want auto-close message for live-listed child", stdout.String())
+	}
+	b, err := mem.Get("gc-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Status != "closed" {
+		t.Fatalf("wisp Status = %q, want closed", b.Status)
+	}
+}
+
+// tierNarrowListWispStore returns no rows from raw List calls while its Live
+// handle reads the full MemStore — the shape of a tier-narrow raw store that
+// cannot see ephemeral-tier attachments. Autoclose child traversal must read
+// through the Live handle to find them.
+type tierNarrowListWispStore struct {
+	*beads.MemStore
+}
+
+func (s tierNarrowListWispStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return nil, nil
+}
+
+func (s tierNarrowListWispStore) Handles() beads.StoreHandles {
+	return beads.StoreHandles{
+		Cached: s,
+		Live:   s.MemStore,
+		Writer: s.MemStore,
+	}
+}
+
 func TestWispAutocloseSkipsAlreadyClosed(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{Title: "work item"})                                // gc-1

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2280,6 +2280,7 @@ gc order sweep-tracking [order ...] [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--dry-run` | bool |  | report stale order-tracking and order wisp beads without closing them |
 | `--include-wisps` | bool |  | also close stale order-run wisp subtrees with open descendants |
 | `--quiet` | bool |  | suppress success output |
 | `--stale-after` | duration | `10m0s` | minimum age for an open tracking bead to be closed |

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1803,11 +1803,9 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 
 	// Set metadata on all beads first (before closing, since some stores
 	// prevent metadata writes on closed beads).
-	for _, id := range ids {
-		if len(metadata) > 0 {
-			if err := s.SetMetadataBatch(id, metadata); err != nil {
-				return 0, err
-			}
+	if len(metadata) > 0 {
+		if err := s.setMetadataBatchAll(ids, metadata); err != nil {
+			return 0, err
 		}
 	}
 
@@ -1832,6 +1830,36 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 		return closed, nil
 	}
 	return len(ids), nil
+}
+
+func (s *BdStore) setMetadataBatchAll(ids []string, kvs map[string]string) error {
+	if len(ids) == 0 || len(kvs) == 0 {
+		return nil
+	}
+	args := []string{"update", "--json"}
+	args = append(args, ids...)
+	keys := make([]string, 0, len(kvs))
+	for k := range kvs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		args = append(args, "--set-metadata", k+"="+kvs[k])
+	}
+	err := s.runBDTransientWrite(args...)
+	if err == nil {
+		return nil
+	}
+	if isBdNotFound(err) {
+		if len(ids) == 1 {
+			return fmt.Errorf("setting metadata on %q: %w", ids[0], ErrNotFound)
+		}
+		return fmt.Errorf("setting metadata on %d beads: %w", len(ids), ErrNotFound)
+	}
+	if len(ids) == 1 {
+		return fmt.Errorf("setting metadata on %q: %w", ids[0], err)
+	}
+	return fmt.Errorf("setting metadata on %d beads: %w", len(ids), err)
 }
 
 // CloseAllWithReason closes multiple beads with one reasoned bd close command

--- a/internal/beads/bdstore_internal_test.go
+++ b/internal/beads/bdstore_internal_test.go
@@ -58,3 +58,43 @@ func TestBdStdoutErrorDetail(t *testing.T) {
 		})
 	}
 }
+
+// TestBdCloseArgsAlwaysForce pins --force in the close arg shape. The stale
+// order-wisp batch sweep (cmd/gc closeStaleOrderWispIDs) closes batches
+// without in-batch blocks ordering; that is safe only because bd closes
+// blocked beads under --force regardless of order, while a non-forced
+// wrong-order batch silently skips blocked beads and exits 0. Removing
+// --force would silently resurface the orphaned-step failure mode (#1420).
+func TestBdCloseArgsAlwaysForce(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		ids    []string
+		want   []string
+	}{
+		{
+			name: "single id no reason",
+			ids:  []string{"bd-1"},
+			want: []string{"close", "--force", "--json", "bd-1"},
+		},
+		{
+			name:   "batch with reason",
+			reason: "stale order wisp sweep",
+			ids:    []string{"bd-1", "bd-2", "bd-3"},
+			want:   []string{"close", "--force", "--json", "--reason", "stale order wisp sweep", "bd-1", "bd-2", "bd-3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bdCloseArgs(tt.reason, tt.ids...)
+			if len(got) != len(tt.want) {
+				t.Fatalf("bdCloseArgs = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("bdCloseArgs = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1311,6 +1311,32 @@ func TestBdStoreCloseAllReturnsMetadataWriteFailure(t *testing.T) {
 	}
 }
 
+func TestBdStoreCloseAllWritesSharedMetadataInSingleBatch(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd update --json bd-1 bd-2 --set-metadata source=wave1`: {
+			out: []byte(`[]`),
+		},
+		`bd close --force --json bd-1 bd-2`: {
+			out: []byte(`[
+				{"id":"bd-1","title":"one","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
+				{"id":"bd-2","title":"two","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}
+			]`),
+		},
+	})
+
+	s := beads.NewBdStore("/city", runner)
+	closed, err := s.CloseAll([]string{"bd-1", "bd-2"}, map[string]string{"source": "wave1"})
+	if err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("closed = %d, want 2", closed)
+	}
+}
+
 func TestBdStoreCloseAllReturnsPartialCountAndErrorOnFallbackFailure(t *testing.T) {
 	batchErr := errors.New("batch close failed")
 	individualErr := errors.New("single close failed")

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -365,11 +365,12 @@ func ListWorkflowBeads(store beads.Store, rootID string) ([]beads.Bead, error) {
 	if store == nil || rootID == "" {
 		return nil, nil
 	}
-	root, err := store.Get(rootID)
+	reader := beads.HandlesFor(store).Live
+	root, err := reader.Get(rootID)
 	if err != nil {
 		return nil, err
 	}
-	descendants, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+	descendants, err := reader.List(beads.ListQuery{
 		IncludeClosed: true,
 		Metadata: map[string]string{
 			beadmeta.RootBeadIDMetadataKey: rootID,

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -558,6 +558,125 @@ func TestCloseWorkflowSubtreeStampsCloseReason(t *testing.T) {
 	}
 }
 
+func TestCloseSpecSidecarsForRootClosesOnlyOpenSpecs(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:  "root",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	spec, err := store.Create(beads.Bead{
+		Title: "Step spec for review",
+		Type:  "spec",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": root.ID,
+			"gc.spec_for":     "review",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(spec): %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title: "real workflow work",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+
+	closed, err := CloseSpecSidecarsForRoot(store, root.ID, "")
+	if err != nil {
+		t.Fatalf("CloseSpecSidecarsForRoot: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("CloseSpecSidecarsForRoot closed %d beads, want 1", closed)
+	}
+	specAfter, err := store.Get(spec.ID)
+	if err != nil {
+		t.Fatalf("Get(spec): %v", err)
+	}
+	if specAfter.Status != "closed" {
+		t.Fatalf("spec status = %q, want closed", specAfter.Status)
+	}
+	if got := specAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("spec gc.outcome = %q, want pass", got)
+	}
+	if got := specAfter.Metadata["close_reason"]; got != WorkflowSpecSidecarClosedReason {
+		t.Fatalf("spec close_reason = %q, want %q", got, WorkflowSpecSidecarClosedReason)
+	}
+	workAfter, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get(work): %v", err)
+	}
+	if workAfter.Status != "open" {
+		t.Fatalf("non-spec workflow bead status = %q, want open", workAfter.Status)
+	}
+}
+
+func TestListWorkflowBeadsQueriesBothTiersForRootOwnedDescendants(t *testing.T) {
+	store := &workflowTierAssertingStore{MemStore: beads.NewMemStore()}
+	root, err := store.Create(beads.Bead{
+		Title: "root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:     "Step spec for review",
+		Type:      "spec",
+		NoHistory: true,
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": root.ID,
+			"gc.spec_for":     "review",
+		},
+	}); err != nil {
+		t.Fatalf("Create(spec): %v", err)
+	}
+
+	matched, err := ListWorkflowBeads(store, root.ID)
+	if err != nil {
+		t.Fatalf("ListWorkflowBeads: %v", err)
+	}
+	if !store.sawRootMetadataQuery {
+		t.Fatal("ListWorkflowBeads did not query gc.root_bead_id descendants")
+	}
+	if len(matched) != 2 {
+		t.Fatalf("ListWorkflowBeads returned %d beads, want root plus spec", len(matched))
+	}
+}
+
+type workflowTierAssertingStore struct {
+	*beads.MemStore
+	sawRootMetadataQuery bool
+}
+
+func (s *workflowTierAssertingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if _, ok := query.Metadata["gc.root_bead_id"]; ok {
+		s.sawRootMetadataQuery = true
+		if query.TierMode != beads.TierBoth {
+			return nil, fmt.Errorf("gc.root_bead_id query tier = %v, want TierBoth", query.TierMode)
+		}
+	}
+	return s.MemStore.List(query)
+}
+
 func workflowIDsOf(bs []beads.Bead) []string {
 	out := make([]string, len(bs))
 	for i, b := range bs {


### PR DESCRIPTION
Refs #2903

## Stack

Draft PR 19 in the bead-leak stack.

- Base: `bead-leaks/18-order-graph-descendants`
- Head: `bead-leaks/19-order-spec-final-drain`

Review this PR against its stacked base branch. The full tracker is #2903.

## Finding / Cause

After the order-dispatch fix, live mc still had a backlog of stale order wisps, including metadata-complete graph roots and legacy graph-only roots. Live ga also had generated spec wisps under already-closed workflow roots because the on-close hook cleaned attachments but not generated spec bookkeeping.

## Fix

Adds order sweep --dry-run, targeted store opening, metadata-batch order-wisp cleanup with legacy graph fallback, batched BdStore CloseAll metadata writes, generated-spec autoclose for closed workflow roots, live-handle preservation through beadPolicyStore, and external-rig autoclose city resolution.

## Verification

Focused cmd/gc, internal/beads, internal/sourceworkflow, CLI docs, go vet, and diff checks passed. Live cleanup closed 569 + 29 + 78 stale order wisps and 429 generated specs; final counts were ga=223, mc=140, gt=0 and order dry-run returned 0 candidates.

## Status

Draft for maintainer review.
