### PR TITLE
Fix required-artifact postcondition store errors

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -61,7 +61,10 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 	}
 
 	attemptNum, _ := strconv.Atoi(attempt.Metadata["gc.attempt"])
-	result := classifyRetryAttempt(attempt)
+	result, err := classifyRetryAttemptWithPostconditions(store, attempt)
+	if err != nil {
+		return ControlResult{}, fmt.Errorf("%s: evaluating retry postconditions for %s: %w", bead.ID, attempt.ID, err)
+	}
 	attemptLog, err := appendAttemptLogValue(bead.Metadata["gc.attempt_log"], attemptNum, result.Outcome, result.Reason)
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -566,7 +566,7 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 	if step.Ralph != nil && len(step.Children) > 0 {
 		rootKind = "scope"
 	}
-	rootMeta := make(map[string]string, len(step.Metadata)+4)
+	rootMeta := make(map[string]string, len(step.Metadata))
 	for k, v := range step.Metadata {
 		rootMeta[k] = v
 	}

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -61,7 +61,7 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 	}
 
 	attemptNum, _ := strconv.Atoi(attempt.Metadata["gc.attempt"])
-	result, err := classifyRetryAttemptWithPostconditions(store, attempt)
+	result, err := classifyRetryAttemptWithPostconditions(store, attempt, opts)
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: evaluating retry postconditions for %s: %w", bead.ID, attempt.ID, err)
 	}
@@ -566,12 +566,14 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 	if step.Ralph != nil && len(step.Children) > 0 {
 		rootKind = "scope"
 	}
-	rootMeta := map[string]string{
-		"gc.kind":     rootKind,
-		"gc.attempt":  strconv.Itoa(attemptNum),
-		"gc.step_id":  stepID,
-		"gc.step_ref": attemptPrefix,
+	rootMeta := make(map[string]string, len(step.Metadata)+4)
+	for k, v := range step.Metadata {
+		rootMeta[k] = v
 	}
+	rootMeta["gc.kind"] = rootKind
+	rootMeta["gc.attempt"] = strconv.Itoa(attemptNum)
+	rootMeta["gc.step_id"] = stepID
+	rootMeta["gc.step_ref"] = attemptPrefix
 	if step.OnComplete != nil {
 		rootMeta["gc.output_json_required"] = "true"
 	}

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -144,6 +145,73 @@ func TestProcessRetryControlPassClosesWithSingleFinalMetadataUpdate(t *testing.T
 	}
 	if store.closeUpdateMetadata["gc.attempt_log"] == "" {
 		t.Fatal("close metadata missing gc.attempt_log")
+	}
+}
+
+func TestProcessRetryControlRetriesPassMissingRequiredArtifact(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review",
+		Metadata: map[string]string{
+			"gc.kind":             "retry",
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-test.review",
+			"gc.step_id":          "review",
+			"gc.max_attempts":     "3",
+			"gc.on_exhausted":     "hard_fail",
+			"gc.source_step_spec": `{"id":"review","title":"Review","type":"task","metadata":{"gc.required_artifact":"/tmp/missing-review.md"},"retry":{"max_attempts":3}}`,
+			"gc.control_epoch":    "1",
+		},
+	})
+	missingReview := filepath.Join(t.TempDir(), "codex-review.md")
+	attempt1 := mustCreate(t, store, beads.Bead{
+		Title: "review attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id":      root.ID,
+			"gc.step_ref":          "mol-test.review.attempt.1",
+			"gc.attempt":           "1",
+			"gc.outcome":           "pass",
+			"gc.required_artifact": missingReview,
+		},
+	})
+	mustClose(t, store, attempt1.ID)
+	mustDep(t, store, control.ID, attempt1.ID, "blocks")
+
+	result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	if !result.Processed || result.Action != "retry" {
+		t.Fatalf("result = %+v, want processed retry", result)
+	}
+
+	after := mustGet(t, store, control.ID)
+	if after.Status != "open" {
+		t.Fatalf("control status = %q, want open", after.Status)
+	}
+	if !strings.Contains(after.Metadata["gc.attempt_log"], "missing_required_artifact") {
+		t.Fatalf("attempt log = %q, want missing_required_artifact", after.Metadata["gc.attempt_log"])
+	}
+
+	var foundAttempt2 bool
+	open, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	for _, bead := range open {
+		if bead.Metadata["gc.step_ref"] == "mol-test.review.attempt.2" {
+			foundAttempt2 = true
+			break
+		}
+	}
+	if !foundAttempt2 {
+		t.Fatal("missing retry attempt 2")
 	}
 }
 

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -152,10 +152,22 @@ func TestProcessRetryControlRetriesPassMissingRequiredArtifact(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
 
-	root := mustCreate(t, store, beads.Bead{
-		Title:    "workflow",
-		Metadata: map[string]string{"gc.kind": "workflow"},
+	worktree := t.TempDir()
+	source := mustCreate(t, store, beads.Bead{
+		Title: "source",
+		Type:  "convoy",
+		Metadata: map[string]string{
+			"work_dir": worktree,
+		},
 	})
+	root := mustCreate(t, store, beads.Bead{
+		Title: "workflow",
+		Metadata: map[string]string{
+			"gc.kind":            "workflow",
+			"gc.input_convoy_id": source.ID,
+		},
+	})
+	missingReview := filepath.Join(worktree, "codex-review.md")
 	control := mustCreate(t, store, beads.Bead{
 		Title: "review",
 		Metadata: map[string]string{
@@ -165,11 +177,10 @@ func TestProcessRetryControlRetriesPassMissingRequiredArtifact(t *testing.T) {
 			"gc.step_id":          "review",
 			"gc.max_attempts":     "3",
 			"gc.on_exhausted":     "hard_fail",
-			"gc.source_step_spec": `{"id":"review","title":"Review","type":"task","metadata":{"gc.required_artifact":"/tmp/missing-review.md"},"retry":{"max_attempts":3}}`,
+			"gc.source_step_spec": fmt.Sprintf(`{"id":"review","title":"Review","type":"task","metadata":{"gc.required_artifact":%q},"retry":{"max_attempts":3}}`, missingReview),
 			"gc.control_epoch":    "1",
 		},
 	})
-	missingReview := filepath.Join(t.TempDir(), "codex-review.md")
 	attempt1 := mustCreate(t, store, beads.Bead{
 		Title: "review attempt 1",
 		Metadata: map[string]string{
@@ -199,19 +210,50 @@ func TestProcessRetryControlRetriesPassMissingRequiredArtifact(t *testing.T) {
 		t.Fatalf("attempt log = %q, want missing_required_artifact", after.Metadata["gc.attempt_log"])
 	}
 
-	var foundAttempt2 bool
+	var attempt2 beads.Bead
 	open, err := store.ListOpen()
 	if err != nil {
 		t.Fatalf("ListOpen: %v", err)
 	}
 	for _, bead := range open {
 		if bead.Metadata["gc.step_ref"] == "mol-test.review.attempt.2" {
-			foundAttempt2 = true
+			attempt2 = bead
 			break
 		}
 	}
-	if !foundAttempt2 {
+	if attempt2.ID == "" {
 		t.Fatal("missing retry attempt 2")
+	}
+	if got := attempt2.Metadata["gc.required_artifact"]; got != missingReview {
+		t.Fatalf("attempt2 gc.required_artifact = %q, want %q", got, missingReview)
+	}
+
+	if err := store.SetMetadata(attempt2.ID, "gc.outcome", "pass"); err != nil {
+		t.Fatalf("set attempt2 outcome: %v", err)
+	}
+	mustClose(t, store, attempt2.ID)
+
+	result, err = processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl attempt2: %v", err)
+	}
+	if !result.Processed || result.Action != "retry" {
+		t.Fatalf("attempt2 result = %+v, want processed retry", result)
+	}
+
+	var foundAttempt3 bool
+	open, err = store.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen after attempt2: %v", err)
+	}
+	for _, bead := range open {
+		if bead.Metadata["gc.step_ref"] == "mol-test.review.attempt.3" {
+			foundAttempt3 = true
+			break
+		}
+	}
+	if !foundAttempt3 {
+		t.Fatal("missing retry attempt 3 after attempt2 required artifact miss")
 	}
 }
 

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -2,7 +2,10 @@ package dispatch
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -46,7 +49,10 @@ func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (
 		return ControlResult{}, ErrControlPending
 	}
 
-	result := classifyRetryAttempt(subject)
+	result, err := classifyRetryAttemptWithPostconditions(store, subject)
+	if err != nil {
+		return ControlResult{}, fmt.Errorf("%s: evaluating retry postconditions for %s: %w", bead.ID, subject.ID, err)
+	}
 	if err := persistRetryEvalResult(store, bead.ID, result); err != nil {
 		return ControlResult{}, fmt.Errorf("%s: persisting retry eval result: %w", bead.ID, err)
 	}
@@ -268,6 +274,127 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 	default:
 		return retryEvalResult{Outcome: "transient", Reason: "invalid_outcome_value"}
 	}
+}
+
+func classifyRetryAttemptWithPostconditions(store beads.Store, subject beads.Bead) (retryEvalResult, error) {
+	result := classifyRetryAttempt(subject)
+	if result.Outcome != "pass" {
+		return result, nil
+	}
+	reason, err := validateRequiredArtifacts(store, subject)
+	if err != nil {
+		return retryEvalResult{}, err
+	}
+	if reason != "" {
+		return retryEvalResult{Outcome: "transient", Reason: reason}, nil
+	}
+	return result, nil
+}
+
+func validateRequiredArtifacts(store beads.Store, subject beads.Bead) (string, error) {
+	for _, rawPath := range requiredArtifactTemplates(subject.Metadata) {
+		path, reason, err := resolveRequiredArtifactPath(store, subject, rawPath)
+		if err != nil {
+			return "", err
+		}
+		if reason != "" {
+			return reason, nil
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "missing_required_artifact", nil
+			}
+			return "unreadable_required_artifact", nil
+		}
+		if info.IsDir() || info.Size() == 0 {
+			return "empty_required_artifact", nil
+		}
+	}
+	return "", nil
+}
+
+func requiredArtifactTemplates(metadata map[string]string) []string {
+	var result []string
+	for _, key := range []string{"gc.required_artifact", "gc.required_artifacts"} {
+		raw := strings.TrimSpace(metadata[key])
+		if raw == "" {
+			continue
+		}
+		for _, part := range strings.FieldsFunc(raw, func(r rune) bool {
+			return r == '\n' || r == ','
+		}) {
+			if trimmed := strings.TrimSpace(part); trimmed != "" {
+				result = append(result, trimmed)
+			}
+		}
+	}
+	return result
+}
+
+func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath string) (string, string, error) {
+	rootID := strings.TrimSpace(subject.Metadata["gc.root_bead_id"])
+	attempt := strings.TrimSpace(subject.Metadata["gc.attempt"])
+	worktree := strings.TrimSpace(subject.Metadata["work_dir"])
+
+	if strings.Contains(rawPath, "{worktree}") || (!filepath.IsAbs(rawPath) && worktree == "") {
+		resolvedWorktree, reason, err := resolveRequiredArtifactWorktree(store, rootID)
+		if err != nil {
+			return "", "", err
+		}
+		if reason != "" {
+			return "", reason, nil
+		}
+		worktree = resolvedWorktree
+	}
+
+	path := rawPath
+	path = strings.ReplaceAll(path, "{worktree}", worktree)
+	path = strings.ReplaceAll(path, "{root}", rootID)
+	path = strings.ReplaceAll(path, "{root_id}", rootID)
+	path = strings.ReplaceAll(path, "{attempt}", attempt)
+	if strings.Contains(path, "{") || strings.Contains(path, "}") {
+		return "", "unresolved_required_artifact_template", nil
+	}
+	if !filepath.IsAbs(path) {
+		if worktree == "" {
+			return "", "missing_required_artifact_context", nil
+		}
+		path = filepath.Join(worktree, path)
+	}
+	return filepath.Clean(path), "", nil
+}
+
+func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, string, error) {
+	if rootID == "" {
+		return "", "missing_required_artifact_context", nil
+	}
+	root, err := store.Get(rootID)
+	if errors.Is(err, beads.ErrNotFound) {
+		return "", "missing_required_artifact_context", nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("loading required artifact workflow root %s: %w", rootID, err)
+	}
+	sourceID := strings.TrimSpace(root.Metadata["gc.source_bead_id"])
+	if sourceID == "" {
+		sourceID = strings.TrimSpace(root.Metadata["gc.input_convoy_id"])
+	}
+	if sourceID == "" {
+		return "", "missing_required_artifact_context", nil
+	}
+	source, err := store.Get(sourceID)
+	if errors.Is(err, beads.ErrNotFound) {
+		return "", "missing_required_artifact_context", nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("loading required artifact source bead %s: %w", sourceID, err)
+	}
+	worktree := strings.TrimSpace(source.Metadata["work_dir"])
+	if worktree == "" {
+		return "", "missing_required_artifact_context", nil
+	}
+	return worktree, "", nil
 }
 
 func retryFailureReason(subject beads.Bead) string {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -49,7 +49,7 @@ func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (
 		return ControlResult{}, ErrControlPending
 	}
 
-	result, err := classifyRetryAttemptWithPostconditions(store, subject)
+	result, err := classifyRetryAttemptWithPostconditions(store, subject, opts)
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: evaluating retry postconditions for %s: %w", bead.ID, subject.ID, err)
 	}
@@ -276,12 +276,12 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 	}
 }
 
-func classifyRetryAttemptWithPostconditions(store beads.Store, subject beads.Bead) (retryEvalResult, error) {
+func classifyRetryAttemptWithPostconditions(store beads.Store, subject beads.Bead, opts ProcessOptions) (retryEvalResult, error) {
 	result := classifyRetryAttempt(subject)
 	if result.Outcome != "pass" {
 		return result, nil
 	}
-	reason, err := validateRequiredArtifacts(store, subject)
+	reason, err := validateRequiredArtifacts(store, subject, opts.RequiredArtifactStat)
 	if err != nil {
 		return retryEvalResult{}, err
 	}
@@ -291,7 +291,10 @@ func classifyRetryAttemptWithPostconditions(store beads.Store, subject beads.Bea
 	return result, nil
 }
 
-func validateRequiredArtifacts(store beads.Store, subject beads.Bead) (string, error) {
+func validateRequiredArtifacts(store beads.Store, subject beads.Bead, stat func(string) (os.FileInfo, error)) (string, error) {
+	if stat == nil {
+		stat = os.Stat
+	}
 	for _, rawPath := range requiredArtifactTemplates(subject.Metadata) {
 		path, reason, err := resolveRequiredArtifactPath(store, subject, rawPath)
 		if err != nil {
@@ -300,7 +303,7 @@ func validateRequiredArtifacts(store beads.Store, subject beads.Bead) (string, e
 		if reason != "" {
 			return reason, nil
 		}
-		info, err := os.Stat(path)
+		info, err := stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return "missing_required_artifact", nil
@@ -316,17 +319,18 @@ func validateRequiredArtifacts(store beads.Store, subject beads.Bead) (string, e
 
 func requiredArtifactTemplates(metadata map[string]string) []string {
 	var result []string
-	for _, key := range []string{"gc.required_artifact", "gc.required_artifacts"} {
-		raw := strings.TrimSpace(metadata[key])
-		if raw == "" {
-			continue
-		}
-		for _, part := range strings.FieldsFunc(raw, func(r rune) bool {
-			return r == '\n' || r == ','
-		}) {
-			if trimmed := strings.TrimSpace(part); trimmed != "" {
-				result = append(result, trimmed)
-			}
+	if raw := strings.TrimSpace(metadata["gc.required_artifact"]); raw != "" {
+		result = append(result, raw)
+	}
+	raw := strings.TrimSpace(metadata["gc.required_artifacts"])
+	if raw == "" {
+		return result
+	}
+	for _, part := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '\n' || r == ','
+	}) {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			result = append(result, trimmed)
 		}
 	}
 	return result
@@ -337,7 +341,7 @@ func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath 
 	attempt := strings.TrimSpace(subject.Metadata["gc.attempt"])
 	worktree := strings.TrimSpace(subject.Metadata["work_dir"])
 
-	if strings.Contains(rawPath, "{worktree}") || (!filepath.IsAbs(rawPath) && worktree == "") {
+	if worktree == "" {
 		resolvedWorktree, reason, err := resolveRequiredArtifactWorktree(store, rootID)
 		if err != nil {
 			return "", "", err
@@ -346,6 +350,9 @@ func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath 
 			return "", reason, nil
 		}
 		worktree = resolvedWorktree
+	}
+	if worktree == "" {
+		return "", "missing_required_artifact_context", nil
 	}
 
 	path := rawPath
@@ -357,12 +364,33 @@ func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath 
 		return "", "unresolved_required_artifact_template", nil
 	}
 	if !filepath.IsAbs(path) {
-		if worktree == "" {
-			return "", "missing_required_artifact_context", nil
-		}
 		path = filepath.Join(worktree, path)
 	}
-	return filepath.Clean(path), "", nil
+	path = filepath.Clean(path)
+	contained, err := requiredArtifactPathInWorktree(worktree, path)
+	if err != nil {
+		return "", "", err
+	}
+	if !contained {
+		return "", "required_artifact_outside_worktree", nil
+	}
+	return path, "", nil
+}
+
+func requiredArtifactPathInWorktree(worktree, path string) (bool, error) {
+	absWorktree, err := filepath.Abs(filepath.Clean(worktree))
+	if err != nil {
+		return false, fmt.Errorf("resolving required artifact worktree path %q: %w", worktree, err)
+	}
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return false, fmt.Errorf("resolving required artifact path %q: %w", path, err)
+	}
+	rel, err := filepath.Rel(absWorktree, absPath)
+	if err != nil {
+		return false, fmt.Errorf("checking required artifact path containment for %q: %w", path, err)
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)), nil
 }
 
 func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, string, error) {

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -2,6 +2,8 @@ package dispatch
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -196,6 +198,147 @@ func TestClassifyRetryAttemptRetriesInvalidRequiredOutputJSON(t *testing.T) {
 	if got != want {
 		t.Fatalf("classifyRetryAttempt() = %+v, want %+v", got, want)
 	}
+}
+
+func TestClassifyRetryAttemptWithPostconditionsRequiresArtifact(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "codex-review.md")
+	store := beads.NewMemStore()
+	subject := beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.required_artifact": path,
+		},
+	}
+
+	got, err := classifyRetryAttemptWithPostconditions(store, subject)
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions: %v", err)
+	}
+	want := retryEvalResult{Outcome: "transient", Reason: "missing_required_artifact"}
+	if got != want {
+		t.Fatalf("missing artifact classify = %+v, want %+v", got, want)
+	}
+
+	if err := os.WriteFile(path, []byte("review\n"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	got, err = classifyRetryAttemptWithPostconditions(store, subject)
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions after artifact write: %v", err)
+	}
+	want = retryEvalResult{Outcome: "pass"}
+	if got != want {
+		t.Fatalf("present artifact classify = %+v, want %+v", got, want)
+	}
+}
+
+func TestClassifyRetryAttemptWithPostconditionsResolvesReviewArtifactTemplate(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	worktree := t.TempDir()
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "source",
+		Type:  "convoy",
+		Metadata: map[string]string{
+			"work_dir": worktree,
+		},
+	})
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":            "workflow",
+			"gc.input_convoy_id": source.ID,
+		},
+	})
+	reviewPath := filepath.Join(worktree, ".gc", "reviews", root.ID, "attempt-2", "codex-review.md")
+	if err := os.MkdirAll(filepath.Dir(reviewPath), 0o755); err != nil {
+		t.Fatalf("mkdir review dir: %v", err)
+	}
+	if err := os.WriteFile(reviewPath, []byte("review\n"), 0o644); err != nil {
+		t.Fatalf("write review artifact: %v", err)
+	}
+
+	got, err := classifyRetryAttemptWithPostconditions(store, beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.root_bead_id":      root.ID,
+			"gc.attempt":           "2",
+			"gc.required_artifact": "{worktree}/.gc/reviews/{root}/attempt-{attempt}/codex-review.md",
+		},
+	})
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions: %v", err)
+	}
+	want := retryEvalResult{Outcome: "pass"}
+	if got != want {
+		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v", got, want)
+	}
+}
+
+func TestClassifyRetryAttemptWithPostconditionsSurfacesRequiredArtifactStoreError(t *testing.T) {
+	t.Parallel()
+
+	base := beads.NewMemStore()
+	root := mustCreateWorkflowBead(t, base, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	backendErr := errors.New("invalid connection: i/o timeout")
+	store := failGetStore{
+		Store:  base,
+		failID: root.ID,
+		err:    backendErr,
+	}
+
+	_, err := classifyRetryAttemptWithPostconditions(store, beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.root_bead_id":      root.ID,
+			"gc.required_artifact": "codex-review.md",
+		},
+	})
+	if !errors.Is(err, backendErr) {
+		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want backend error", err)
+	}
+}
+
+func TestClassifyRetryAttemptWithPostconditionsMissingRequiredArtifactContextStaysTransient(t *testing.T) {
+	t.Parallel()
+
+	got, err := classifyRetryAttemptWithPostconditions(beads.NewMemStore(), beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.root_bead_id":      "missing-root",
+			"gc.required_artifact": "codex-review.md",
+		},
+	})
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want nil", err)
+	}
+	want := retryEvalResult{Outcome: "transient", Reason: "missing_required_artifact_context"}
+	if got != want {
+		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v", got, want)
+	}
+}
+
+type failGetStore struct {
+	beads.Store
+	failID string
+	err    error
+}
+
+func (s failGetStore) Get(id string) (beads.Bead, error) {
+	if id == s.failID {
+		return beads.Bead{}, s.err
+	}
+	return s.Store.Get(id)
 }
 
 func TestProcessRetryEvalTransientAppendErrorStaysOpenForRetry(t *testing.T) {

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -203,16 +204,18 @@ func TestClassifyRetryAttemptRetriesInvalidRequiredOutputJSON(t *testing.T) {
 func TestClassifyRetryAttemptWithPostconditionsRequiresArtifact(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), "codex-review.md")
+	worktree := t.TempDir()
+	path := filepath.Join(worktree, "codex-review.md")
 	store := beads.NewMemStore()
 	subject := beads.Bead{
 		Metadata: map[string]string{
 			"gc.outcome":           "pass",
 			"gc.required_artifact": path,
+			"work_dir":             worktree,
 		},
 	}
 
-	got, err := classifyRetryAttemptWithPostconditions(store, subject)
+	got, err := classifyRetryAttemptWithPostconditions(store, subject, ProcessOptions{})
 	if err != nil {
 		t.Fatalf("classifyRetryAttemptWithPostconditions: %v", err)
 	}
@@ -224,7 +227,7 @@ func TestClassifyRetryAttemptWithPostconditionsRequiresArtifact(t *testing.T) {
 	if err := os.WriteFile(path, []byte("review\n"), 0o644); err != nil {
 		t.Fatalf("write artifact: %v", err)
 	}
-	got, err = classifyRetryAttemptWithPostconditions(store, subject)
+	got, err = classifyRetryAttemptWithPostconditions(store, subject, ProcessOptions{})
 	if err != nil {
 		t.Fatalf("classifyRetryAttemptWithPostconditions after artifact write: %v", err)
 	}
@@ -269,7 +272,7 @@ func TestClassifyRetryAttemptWithPostconditionsResolvesReviewArtifactTemplate(t 
 			"gc.attempt":           "2",
 			"gc.required_artifact": "{worktree}/.gc/reviews/{root}/attempt-{attempt}/codex-review.md",
 		},
-	})
+	}, ProcessOptions{})
 	if err != nil {
 		t.Fatalf("classifyRetryAttemptWithPostconditions: %v", err)
 	}
@@ -303,7 +306,7 @@ func TestClassifyRetryAttemptWithPostconditionsSurfacesRequiredArtifactStoreErro
 			"gc.root_bead_id":      root.ID,
 			"gc.required_artifact": "codex-review.md",
 		},
-	})
+	}, ProcessOptions{})
 	if !errors.Is(err, backendErr) {
 		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want backend error", err)
 	}
@@ -318,7 +321,7 @@ func TestClassifyRetryAttemptWithPostconditionsMissingRequiredArtifactContextSta
 			"gc.root_bead_id":      "missing-root",
 			"gc.required_artifact": "codex-review.md",
 		},
-	})
+	}, ProcessOptions{})
 	if err != nil {
 		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want nil", err)
 	}
@@ -327,6 +330,161 @@ func TestClassifyRetryAttemptWithPostconditionsMissingRequiredArtifactContextSta
 		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v", got, want)
 	}
 }
+
+func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactOutsideWorktreeBeforeStat(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	worktree := t.TempDir()
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "source",
+		Type:  "convoy",
+		Metadata: map[string]string{
+			"work_dir": worktree,
+		},
+	})
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.input_convoy_id": source.ID,
+		},
+	})
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "relative traversal", path: "../outside.md"},
+		{name: "absolute outside", path: filepath.Join(filepath.Dir(worktree), "outside.md")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var statCalls int
+			got, err := classifyRetryAttemptWithPostconditions(store, beads.Bead{
+				Metadata: map[string]string{
+					"gc.outcome":           "pass",
+					"gc.root_bead_id":      root.ID,
+					"gc.required_artifact": tc.path,
+				},
+			}, ProcessOptions{
+				RequiredArtifactStat: func(string) (os.FileInfo, error) {
+					statCalls++
+					return fakeFileInfo{size: 10}, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want nil", err)
+			}
+			want := retryEvalResult{Outcome: "transient", Reason: "required_artifact_outside_worktree"}
+			if got != want {
+				t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v", got, want)
+			}
+			if statCalls != 0 {
+				t.Fatalf("artifact stat calls = %d, want 0", statCalls)
+			}
+		})
+	}
+}
+
+func TestClassifyRetryAttemptWithPostconditionsUsesRequiredArtifactStatOption(t *testing.T) {
+	t.Parallel()
+
+	worktree := t.TempDir()
+	path := filepath.Join(worktree, "review.md")
+	var statPath string
+	got, err := classifyRetryAttemptWithPostconditions(beads.NewMemStore(), beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.required_artifact": path,
+			"work_dir":             worktree,
+		},
+	}, ProcessOptions{
+		RequiredArtifactStat: func(path string) (os.FileInfo, error) {
+			statPath = path
+			return fakeFileInfo{size: 10}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want nil", err)
+	}
+	if got != (retryEvalResult{Outcome: "pass"}) {
+		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want pass", got)
+	}
+	if statPath != path {
+		t.Fatalf("stat path = %q, want %q", statPath, path)
+	}
+}
+
+func TestClassifyRetryAttemptWithPostconditionsRequiredArtifactEdgeReasons(t *testing.T) {
+	t.Parallel()
+
+	worktree := t.TempDir()
+	emptyPath := filepath.Join(worktree, "empty.md")
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty artifact: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		path   string
+		reason string
+	}{
+		{name: "empty file", path: emptyPath, reason: "empty_required_artifact"},
+		{name: "directory", path: worktree, reason: "empty_required_artifact"},
+		{name: "unresolved template", path: "{worktree}/{step}/review.md", reason: "unresolved_required_artifact_template"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := classifyRetryAttemptWithPostconditions(beads.NewMemStore(), beads.Bead{
+				Metadata: map[string]string{
+					"gc.outcome":           "pass",
+					"gc.required_artifact": tc.path,
+					"work_dir":             worktree,
+				},
+			}, ProcessOptions{})
+			if err != nil {
+				t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want nil", err)
+			}
+			want := retryEvalResult{Outcome: "transient", Reason: tc.reason}
+			if got != want {
+				t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestRequiredArtifactTemplatesTreatsSingularAsOnePath(t *testing.T) {
+	t.Parallel()
+
+	got := requiredArtifactTemplates(map[string]string{
+		"gc.required_artifact":  "dir/file,with-comma.md",
+		"gc.required_artifacts": "first.md, second.md\nthird.md",
+	})
+	want := []string{"dir/file,with-comma.md", "first.md", "second.md", "third.md"}
+	if len(got) != len(want) {
+		t.Fatalf("requiredArtifactTemplates() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("requiredArtifactTemplates()[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+type fakeFileInfo struct {
+	size  int64
+	isDir bool
+}
+
+func (f fakeFileInfo) Name() string       { return "artifact" }
+func (f fakeFileInfo) Size() int64        { return f.size }
+func (f fakeFileInfo) Mode() os.FileMode  { return 0o644 }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return f.isDir }
+func (f fakeFileInfo) Sys() any           { return nil }
 
 type failGetStore struct {
 	beads.Store

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -40,6 +41,9 @@ type ProcessOptions struct {
 	PrepareFragment    func(*formula.FragmentRecipe, beads.Bead) error
 	PrepareRecipe      func(*formula.Recipe, beads.Bead) error
 	RecycleSession     func(beads.Bead) error
+	// RequiredArtifactStat checks required-artifact files. When nil, the
+	// dispatcher uses os.Stat.
+	RequiredArtifactStat func(path string) (os.FileInfo, error)
 	// ResolveStoreRef opens the bead store identified by a gc.source_store_ref
 	// value (e.g. "city:foo", "rig:alpha"). Used by processWorkflowFinalize to
 	// propagate successful workflow completion across store boundaries: when


### PR DESCRIPTION
Refs #2903

## Stack

Draft PR for remaining report work `ga-ksno8`.

- Base: `ga-ksno8/base-required-artifact-postconditions` (`a2c0364e0`)
- Head: `fix/required-artifact-store-errors-ga-ksno8`

This is intentionally stacked on the detached base where the required-artifact postcondition code exists, so the PR diff is limited to the store-error fix.

## Finding / Cause

`resolveRequiredArtifactWorktree` treated every `store.Get` error as `missing_required_artifact_context`. That collapsed real backend faults such as Dolt/MySQL timeouts, lock waits, connection resets, or bad connections into the same work-transient lane as a genuinely absent root/source/worktree.

That result flowed through `validateRequiredArtifacts` and `classifyRetryAttemptWithPostconditions`, consumed retry attempts, and could false hard-fail work at exhaustion even though the attempt itself had passed and only controller storage lookup failed.

## Fix

The required-artifact postcondition chain now returns `(result, error)` rather than only a transient reason. `resolveRequiredArtifactWorktree` treats only `errors.Is(err, beads.ErrNotFound)` as benign missing context. Any other root/source `store.Get` error is wrapped and propagated to `processRetryEval` / `processRetryControl` as a controller error.

Genuinely missing root/source/worktree context still returns the existing `missing_required_artifact_context` transient reason, preserving the intended retry behavior for real absence.

## Verification

- Red test added first: `TestClassifyRetryAttemptWithPostconditionsSurfacesRequiredArtifactStoreError` failed before the signature/error propagation change.
- Added regression preserving missing context: `TestClassifyRetryAttemptWithPostconditionsMissingRequiredArtifactContextStaysTransient`.
- `go test ./internal/dispatch -run 'TestClassifyRetryAttemptWithPostconditions(SurfacesRequiredArtifactStoreError|MissingRequiredArtifactContextStaysTransient|RequiresArtifact|ResolvesReviewArtifactTemplate)$' -count=1` passed.
- `go test ./internal/dispatch -count=1` passed.
- `go vet ./internal/dispatch` passed.
- `.githooks/pre-commit` passed changed-package lint, generated docs/schema, `go vet ./...`, and all cmd/gc shards; it failed `unit-core` because this dirty root worktree contains nested `.gc/bugs/...` and `worktrees/...` source trees that boundary tests scan. Log: `/data/tmp/gc-local-tests.Ny06KM`.

## Status

Draft for maintainer review.
