### PR TITLE
fix(bd): don't force-reinit an existing store when Dolt is unreachable

### DIFF
--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -176,8 +176,7 @@ func TestGCBeadsBDScript_InitForcesReinitOverPreSeededMetadata(t *testing.T) {
 	}
 	script := string(data)
 
-	guard := `if [ -f "$dir/.beads/metadata.json" ]; then
-        if ensure_database_registered "$dolt_database"; then`
+	guard := `if [ -f "$dir/.beads/metadata.json" ]; then`
 	if !strings.Contains(script, guard) {
 		t.Fatalf("gc-beads-bd.sh op_init must gate the already-initialized branch on the metadata.json file, not on project_id; " +
 			"gating on project_id leaves --force unset for gc-pre-seeded metadata and bd init aborts")

--- a/cmd/gc/gc_beads_bd_server_reachable_test.go
+++ b/cmd/gc/gc_beads_bd_server_reachable_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// TestServerReachableReflectsDoltExit verifies that server_reachable — the
+// guard introduced so a transiently-unreachable managed Dolt server is not
+// mistaken for a missing/unregistered schema (which would trigger a
+// DESTRUCTIVE --force reinit and abort city init) — succeeds exactly when
+// the dolt client can reach the server and fails when it cannot.
+//
+// Without this guard, a momentary blip (port drift, an exclusive lock held
+// by a stale dolt process, a slow server start) makes bd_runtime_schema_ready
+// / ensure_database_registered return false, and the init path force-reinits
+// a healthy store.
+func TestServerReachableReflectsDoltExit(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+
+	root := repoRootForLint(t)
+	scriptPath := filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	scriptBytes, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	src := string(scriptBytes)
+	serverSQL := extractShellFunction(t, src, "server_sql")
+	serverReachable := extractShellFunction(t, src, "server_reachable")
+
+	cases := []struct {
+		name     string
+		doltExit int
+		wantOK   bool
+	}{
+		{"server_up_exit0_reachable", 0, true},
+		{"server_down_exit1_unreachable", 1, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			writeFakeExitDolt(t, binDir, tc.doltExit)
+
+			// connect_host is overridden so the test exercises only the
+			// reachability decision, not host resolution.
+			script := "connect_host() { printf '127.0.0.1'; }\n" +
+				serverSQL + "\n" +
+				serverReachable + "\n" +
+				"server_reachable\n"
+
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(),
+				"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"DOLT_PORT=42188",
+				"DOLT_USER=root",
+				"DOLT_PASSWORD=",
+			)
+			runErr := cmd.Run()
+			gotOK := runErr == nil
+			if gotOK != tc.wantOK {
+				t.Fatalf("server_reachable ok=%v, want %v (fake dolt exit %d)", gotOK, tc.wantOK, tc.doltExit)
+			}
+		})
+	}
+}
+
+func writeFakeExitDolt(t *testing.T, dir string, exitCode int) {
+	t.Helper()
+	p := filepath.Join(dir, "dolt")
+	body := "#!/bin/sh\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -461,6 +461,16 @@ bd_runtime_schema_ready() {
     server_sql "USE \`$db\`; SELECT 1 FROM config LIMIT 1" >/dev/null 2>&1
 }
 
+# server_reachable reports whether the managed Dolt server answers a
+# trivial query. Used to distinguish a transient connection failure
+# (port drift, an exclusive lock held by a stale dolt, a slow server
+# start) from a genuinely missing schema/registration before deciding to
+# force a destructive reinit. server_sql carries the connect target, so
+# this stays in lockstep with bd_runtime_schema_ready / ensure_database_registered.
+server_reachable() {
+    server_sql "SELECT 1" >/dev/null 2>&1
+}
+
 wait_for_bd_runtime_schema() {
     local db="$1"
     local attempt backoff_ms
@@ -2149,6 +2159,20 @@ op_init() {
     # instead breaks fresh init: gc-pre-seeded metadata has no project_id, so
     # --force is never set and bd init aborts.
     if [ -f "$dir/.beads/metadata.json" ]; then
+        # A pre-existing metadata.json means the store may already be
+        # initialized. Both checks below run SQL against the managed Dolt
+        # server, so a transient server-unreachable blip (port drift, an
+        # exclusive lock held by a stale dolt process, a slow server start)
+        # is indistinguishable from "schema missing" / "not registered" —
+        # and both of those branches react by forcing a DESTRUCTIVE reinit
+        # (--force), which trips bd's remote-history guard and aborts city
+        # init on an otherwise healthy store. Confirm the server actually
+        # answers before trusting a negative result; otherwise fail closed
+        # so the caller's retry loop waits for the server to come up instead
+        # of reinitializing live data.
+        if ! server_reachable; then
+            die "managed Dolt server unreachable while inspecting existing store '$dolt_database'; refusing to force-reinitialize (data-safety). retry once the Dolt server is reachable."
+        fi
         if ensure_database_registered "$dolt_database"; then
             if bd_runtime_schema_ready "$dolt_database"; then
                 # GC owns canonical metadata/config normalization after this backend


### PR DESCRIPTION
## Problem

`gc-beads-bd.sh`'s init path (the `if [ -f "$dir/.beads/metadata.json" ]` branch) treats **any** failure of `bd_runtime_schema_ready` or `ensure_database_registered` as "schema missing" / "not registered" and reacts by setting `bd_init_force="--force"` → a **destructive** reinit.

Both of those checks run SQL against the managed Dolt server. So a **transient unreachable server** is indistinguishable from a genuinely uninitialized store:

- managed Dolt port drift (e.g. a stale `bd dolt start` derived a different port than the city's configured one),
- an exclusive write lock held by a leftover `dolt` process (`database "X" is locked by another dolt process`),
- a slow server start.

When that happens during `startBeadsLifecycle` → `initAndHookDir` → `initBeadsForDir`, the `--force` path then trips bd's remote-history guard (`remote 'origin' already has Dolt history … would orphan-push over the team's data`) and the whole city init aborts in a 20s retry loop (`init failure #N`) that never recovers on its own — the controller never opens `controller.sock`.

It is also genuinely dangerous: a momentary connectivity blip should never escalate to force-reinitializing a live, healthy store.

## Fix

Guard the `metadata.json` branch with a `server_reachable()` probe (a trivial `SELECT 1`). If the server does not answer, **fail closed** (`die`) so the caller's existing retry loop waits for the server to come back up — instead of force-reinitializing live data. Only when the server is confirmed reachable do the schema/registration checks (and the `--force` fallback they gate) run, exactly as before.

This narrows `--force` to the case it was meant for: server up + schema genuinely absent.

## Test

Adds `TestServerReachableReflectsDoltExit` (same stub-`dolt`-on-PATH harness as `TestEnsureDoltIdentityErrorMessages`): `server_reachable` succeeds iff the dolt client exits 0, fails when it exits non-zero. Full `./cmd/gc` script-helper suite green (83 passed).

## Notes

Found while bootstrapping an 18-rig city: repeated manual `bd dolt start`/`stop` left a stale lock-holder + port drift, and the controller force-reinit-looped with a `missing bd schema; re-initializing` warning even though every rig database had a full schema (33 tables). The store was fine; the server was momentarily on the wrong port. This guard turns that failure mode from "silently force-reinit + abort" into "wait for the server."