### PR TITLE
fix(order-dispatch): delete stale closed order-tracking beads

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1320,9 +1320,8 @@ func (cr *CityRuntime) runOrderTrackingSweepWatchdog(now time.Time) {
 			fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 		}
 	}
-	n := result.trackingClosed
-	if n > 0 && cr.stderr != nil {
-		fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog closed %d stale tracking bead(s)\n", cr.logPrefix, n) //nolint:errcheck // best-effort stderr
+	if (result.trackingClosed > 0 || result.trackingDeleted > 0) && cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog closed %d stale tracking bead(s), deleted %d closed tracking bead(s)\n", cr.logPrefix, result.trackingClosed, result.trackingDeleted) //nolint:errcheck // best-effort stderr
 	}
 }
 

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1518,9 +1518,9 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 	}
 	if !quiet {
 		if includeWisps {
-			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), %d stale order wisp bead(s)\n", result.trackingClosed, result.wispClosed) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), deleted %d closed tracking bead(s), %d stale order wisp bead(s)\n", result.trackingClosed, result.trackingDeleted, result.wispClosed) //nolint:errcheck // best-effort stdout
 		} else {
-			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s)\n", result.trackingClosed) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), deleted %d closed tracking bead(s)\n", result.trackingClosed, result.trackingDeleted) //nolint:errcheck // best-effort stdout
 		}
 	}
 	return 0

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -1296,10 +1296,11 @@ func beadLabelsContain(labels []string, want string) bool {
 }
 
 type orderTrackingSweepResult struct {
-	trackingClosed int
-	wispClosed     int
-	storesSwept    int
-	sweptStoreKeys map[string]struct{}
+	trackingClosed  int
+	trackingDeleted int
+	wispClosed      int
+	storesSwept     int
+	sweptStoreKeys  map[string]struct{}
 }
 
 // sweepStaleOrderTracking closes open order-tracking beads whose creation
@@ -1344,6 +1345,7 @@ func sweepStaleOrderTrackingAcrossStoresLimit(stores []beads.Store, now time.Tim
 		}
 		partial, err := sweepStaleOrderTrackingWithOptionsLimit(store, now, staleAfter, onlyOrders, initiator, includeWispSubtrees, remainingLimit)
 		result.trackingClosed += partial.trackingClosed
+		result.trackingDeleted += partial.trackingDeleted
 		result.wispClosed += partial.wispClosed
 		if err != nil {
 			errs = append(errs, fmt.Errorf("sweeping order-tracking %s: %w", orderTrackingSweepStoreLabel(store, i), err))
@@ -1399,6 +1401,19 @@ func sweepStaleOrderTrackingWithOptionsLimit(store beads.Store, now time.Time, s
 
 	cutoff := now.Add(-staleAfter)
 	result := orderTrackingSweepResult{}
+
+	// Delete stale CLOSED tracking beads first. This sweep otherwise only closes
+	// stale OPEN beads and never removes the closed ones, so every completed
+	// order leaves a closed tracking bead behind — ~37k accumulated in one
+	// production city's hq store, bloating every bead query. The query is bounded
+	// so a large historical backlog drains gradually across sweep cycles; doing
+	// it before the close pass avoids deleting a bead the same run it is closed.
+	deleted, err := deleteStaleClosedOrderTracking(store, cutoff, onlyOrders)
+	if err != nil {
+		return result, fmt.Errorf("deleting stale order-tracking beads: %w", err)
+	}
+	result.trackingDeleted = deleted
+
 	var ids []string
 	for _, b := range all {
 		if len(onlyOrders) > 0 {
@@ -1445,6 +1460,95 @@ func sweepStaleOrderTrackingWithOptionsLimit(store beads.Store, now time.Time, s
 		}
 	}
 	return result, nil
+}
+
+// maxClosedOrderTrackingDeletesPerSweep bounds how many stale closed tracking
+// beads a single sweep queries and deletes, so a large historical backlog
+// drains gradually across sweep cycles and the sweep never scans the whole
+// (potentially bloated) closed-tracking set in one run.
+const maxClosedOrderTrackingDeletesPerSweep = 500
+
+// orderTrackingBeadInScope reports whether a tracking bead belongs to one of
+// the requested orders. An empty onlyOrders set matches every tracking bead.
+func orderTrackingBeadInScope(b beads.Bead, onlyOrders map[string]struct{}) bool {
+	if len(onlyOrders) == 0 {
+		return true
+	}
+	name, ok := orderNameFromTrackingBead(b)
+	if !ok {
+		return false
+	}
+	_, ok = onlyOrders[name]
+	return ok
+}
+
+// batchDeleter is implemented by stores that can remove many beads in one
+// operation (BdStore issues a single `bd delete`). The order-tracking sweep
+// uses it to drain large closed-tracking backlogs without one subprocess per
+// bead; stores without it fall back to sequential Delete.
+type batchDeleter interface {
+	DeleteAll(ids []string) (int, error)
+}
+
+// deleteStaleClosedOrderTracking deletes a bounded batch of closed tracking
+// beads older than cutoff. The Limit keeps each sweep cheap no matter how large
+// the closed-tracking backlog is — the query never returns the whole set.
+func deleteStaleClosedOrderTracking(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}) (int, error) {
+	if store == nil {
+		return 0, fmt.Errorf("order-tracking delete: nil store")
+	}
+	closed, err := store.List(beads.ListQuery{
+		Label:  labelOrderTracking,
+		Status: "closed",
+		Limit:  maxClosedOrderTrackingDeletesPerSweep,
+		Sort:   beads.SortCreatedDesc,
+		// Issues tier only. The leaked tracking beads are non-ephemeral; closed
+		// ephemeral (wisp-tier) tracking beads are already reclaimed by
+		// wisp-compact's TTL. Including wisps here would also let a stream of
+		// fresh closed wisps crowd out the bounded limit and stall draining the
+		// issues-tier backlog.
+		TierMode: beads.TierIssues,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing closed order-tracking beads: %w", err)
+	}
+	var ids []string
+	for _, b := range closed {
+		if !orderTrackingBeadInScope(b, onlyOrders) {
+			continue
+		}
+		if b.CreatedAt.IsZero() || b.CreatedAt.After(cutoff) {
+			continue
+		}
+		ids = append(ids, b.ID)
+	}
+	return deleteOrderTrackingBeads(store, ids)
+}
+
+// deleteOrderTrackingBeads permanently removes the given (already-closed)
+// tracking beads, batching when the store supports it. ErrNotFound is treated
+// as already-drained.
+func deleteOrderTrackingBeads(store beads.Store, ids []string) (int, error) {
+	ids = uniqueNonEmptyOrderTrackingIDs(ids)
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	if batch, ok := store.(batchDeleter); ok {
+		return batch.DeleteAll(ids)
+	}
+	deleted := 0
+	var errs []error
+	for _, id := range ids {
+		switch err := store.Delete(id); {
+		case err == nil:
+			deleted++
+		case errors.Is(err, beads.ErrNotFound):
+			// already drained
+		default:
+			errs = append(errs, fmt.Errorf("deleting order-tracking bead %s: %w", id, err))
+		}
+	}
+	return deleted, errors.Join(errs...)
 }
 
 func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string) (int, error) {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -3330,6 +3330,112 @@ func TestSweepOrphanedOrderTracking_OnlyClosedBeads(t *testing.T) {
 	}
 }
 
+func TestSweepStaleOrderTracking_DeletesClosedStaleTrackingBeads(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// The leak: a tracking bead that completed (closed) long ago. The sweep
+	// otherwise never lists or deletes closed tracking beads, so it lingers
+	// forever — ~37k accumulated in one production city's hq store.
+	oldClosed, err := store.Create(beads.Bead{
+		Title:  "order:beads-health",
+		Labels: []string{"order-run:beads-health", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(oldClosed): %v", err)
+	}
+	if err := store.Close(oldClosed.ID); err != nil {
+		t.Fatalf("Close(oldClosed): %v", err)
+	}
+
+	// An old OPEN tracking bead — must still be closed (so a blocked order can
+	// retry), not deleted outright.
+	oldOpen, err := store.Create(beads.Bead{
+		Title:  "order:gate-sweep",
+		Labels: []string{"order-run:gate-sweep", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(oldOpen): %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	// A freshly-closed tracking bead — within retention, must be retained.
+	freshClosed, err := store.Create(beads.Bead{
+		Title:  "order:dispatch-tick",
+		Labels: []string{"order-run:dispatch-tick", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(freshClosed): %v", err)
+	}
+	if err := store.Close(freshClosed.ID); err != nil {
+		t.Fatalf("Close(freshClosed): %v", err)
+	}
+
+	if _, err := sweepStaleOrderTracking(store, time.Now(), 100*time.Millisecond, nil, orderTrackingSweepMetadataInitiator); err != nil {
+		t.Fatalf("sweepStaleOrderTracking: %v", err)
+	}
+
+	if _, err := store.Get(oldClosed.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Errorf("old closed tracking bead %s: Get err = %v, want ErrNotFound (should be deleted)", oldClosed.ID, err)
+	}
+	gotOpen, err := store.Get(oldOpen.ID)
+	if err != nil {
+		t.Errorf("old open tracking bead should be closed-not-deleted: Get err = %v", err)
+	} else if gotOpen.Status != "closed" {
+		t.Errorf("old open tracking bead status = %q, want closed", gotOpen.Status)
+	}
+	if _, err := store.Get(freshClosed.ID); err != nil {
+		t.Errorf("fresh closed tracking bead should be retained: Get err = %v, want nil", err)
+	}
+}
+
+func TestSweepStaleOrderTracking_BoundsDeletesPerSweep(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// A backlog larger than the per-run bound — the sweep must drain it across
+	// multiple cycles, never querying or deleting the whole set in one run.
+	const backlog = maxClosedOrderTrackingDeletesPerSweep + 25
+	for i := 0; i < backlog; i++ {
+		b, err := store.Create(beads.Bead{
+			Title:  "order:beads-health",
+			Labels: []string{"order-run:beads-health", labelOrderTracking},
+		})
+		if err != nil {
+			t.Fatalf("Create(%d): %v", i, err)
+		}
+		if err := store.Close(b.ID); err != nil {
+			t.Fatalf("Close(%d): %v", i, err)
+		}
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	result, err := sweepStaleOrderTrackingWithOptionsLimit(store, time.Now(), 100*time.Millisecond, nil, orderTrackingSweepMetadataInitiator, false, 0)
+	if err != nil {
+		t.Fatalf("first sweep: %v", err)
+	}
+	if result.trackingDeleted != maxClosedOrderTrackingDeletesPerSweep {
+		t.Fatalf("first sweep trackingDeleted = %d, want %d (bounded)", result.trackingDeleted, maxClosedOrderTrackingDeletesPerSweep)
+	}
+
+	remaining, err := store.List(beads.ListQuery{Label: labelOrderTracking, Status: "closed"})
+	if err != nil {
+		t.Fatalf("List remaining: %v", err)
+	}
+	if len(remaining) != backlog-maxClosedOrderTrackingDeletesPerSweep {
+		t.Fatalf("remaining closed tracking beads = %d, want %d", len(remaining), backlog-maxClosedOrderTrackingDeletesPerSweep)
+	}
+
+	// A second sweep drains the remainder.
+	result, err = sweepStaleOrderTrackingWithOptionsLimit(store, time.Now(), 100*time.Millisecond, nil, orderTrackingSweepMetadataInitiator, false, 0)
+	if err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	if result.trackingDeleted != backlog-maxClosedOrderTrackingDeletesPerSweep {
+		t.Fatalf("second sweep trackingDeleted = %d, want %d", result.trackingDeleted, backlog-maxClosedOrderTrackingDeletesPerSweep)
+	}
+}
+
 func TestSweepStaleOrderTracking_ClosesOnlyOldOpenTrackingBeads(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1469,6 +1469,45 @@ func (s *BdStore) Delete(id string) error {
 	return nil
 }
 
+// bdDeleteBatchSize bounds how many ids go into a single `bd delete`
+// invocation, keeping command lines comfortably under ARG_MAX.
+const bdDeleteBatchSize = 256
+
+// DeleteAll permanently removes multiple beads using bd's native batch delete
+// (`bd delete <ids...> --force`), one invocation per chunk instead of one per
+// id. Returns the number of ids deleted; an id that is already gone counts as
+// deleted. Beads should be closed first.
+func (s *BdStore) DeleteAll(ids []string) (int, error) {
+	deleted := 0
+	for start := 0; start < len(ids); start += bdDeleteBatchSize {
+		end := start + bdDeleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+		args := append([]string{"delete", "--force", "--json"}, chunk...)
+		if _, err := s.runner(s.dir, "bd", args...); err != nil {
+			if !isBdNotFound(err) {
+				return deleted, fmt.Errorf("batch deleting %d beads: %w", len(chunk), err)
+			}
+			// One or more ids already gone — fall back to per-id so the rest
+			// of the chunk still drains.
+			for _, id := range chunk {
+				switch e := s.Delete(id); {
+				case e == nil:
+					deleted++
+				case errors.Is(e, ErrNotFound):
+				default:
+					return deleted, e
+				}
+			}
+			continue
+		}
+		deleted += len(chunk)
+	}
+	return deleted, nil
+}
+
 // List returns beads matching the query via bd list and bd query.
 func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -41,6 +41,33 @@ func mustJSON(t *testing.T, v any) string {
 	return string(data)
 }
 
+// --- DeleteAll ---
+
+func TestBdStoreDeleteAllBatchesIntoSingleCommand(t *testing.T) {
+	var calls [][]string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return []byte(`{}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+
+	n, err := s.DeleteAll([]string{"bd-1", "bd-2", "bd-3"})
+	if err != nil {
+		t.Fatalf("DeleteAll: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("deleted = %d, want 3", n)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1 (batched into a single bd delete)", len(calls))
+	}
+	got := strings.Join(calls[0], " ")
+	want := "bd delete --force --json bd-1 bd-2 bd-3"
+	if got != want {
+		t.Errorf("call = %q, want %q", got, want)
+	}
+}
+
 // --- Create ---
 
 func TestBdStoreCreate(t *testing.T) {


### PR DESCRIPTION
## Summary

The order-tracking sweep only ever **closes** stale *open* tracking beads — it never deletes the **closed** ones. A tracking bead's single-flight purpose ends when it closes, so every completed order leaves a closed `order-tracking` bead behind permanently.

In one production city these accumulated to **~37,700 closed rows** in the city (`hq`) bead store — the `issues` table grew to ~39.5k rows, ~95% of them dead `order:*` tracking beads (`order:beads-health` ×5.6k, `order:dolt-health` ×5.2k, `order:gate-sweep` ×5.1k, …). Routine control-plane bead reads then became full scans of a bloated table at ~1k queries/sec, pinning the Dolt sql-server at **~2.4 cores**. Across all stores the backlog was ~51k beads.

## Root cause

`sweepStaleOrderTrackingWithOptionsLimit` lists tracking beads via `ListByLabel(labelOrderTracking, …)` **without** `IncludeClosed`, so closed tracking beads are invisible to it, and it only calls `closeAndVerifyOrderTrackingBeads`. Once a tracking bead is closed (normal completion), nothing ever removes it.

## Fix

The sweep now **deletes** stale *closed* tracking beads, as a natural effect of the periodic `order-tracking-sweep` (no manual cleanup):

- A **bounded** query (`ListQuery{Status:"closed", Limit, Sort}`) on the **issues tier** — never lists the whole (potentially bloated) closed-tracking set, so a large historical backlog drains gradually across sweep cycles. The leaked beads are non-ephemeral; closed *ephemeral* (wisp-tier) tracking beads are already reclaimed by wisp-compact's TTL, and including them would let a stream of fresh closed wisps crowd out the bounded limit and stall draining the backlog.
- **Delete-before-close** ordering, so a bead is not deleted the same run it is closed.
- Deletion uses a new `BdStore.DeleteAll` (one `bd delete <ids…> --force` per chunk) behind an optional `batchDeleter` interface; stores without it fall back to sequential `Delete`.
- The across-stores aggregator now sums `trackingDeleted`, and the sweep CLI + watchdog report the deleted count.

Existing close behavior (closing stale *open* beads, the `limit` budget, wisp-subtree recovery) is unchanged.

## Tests

- `TestSweepStaleOrderTracking_DeletesClosedStaleTrackingBeads` — a stale closed tracking bead is deleted; a stale *open* one is still only closed (not deleted); a freshly-closed one is retained.
- `TestSweepStaleOrderTracking_BoundsDeletesPerSweep` — a backlog larger than the per-run bound drains across multiple sweeps, never in one oversized batch.
- `TestBdStoreDeleteAllBatchesIntoSingleCommand` — `DeleteAll` issues a single batched `bd delete`.

`go test ./internal/beads/ ./cmd/gc/ -run 'Order|Sweep|Tracking|Dispatch'` and `go vet` pass.

## Validation

Built and run against the affected production stores: the bounded issues-tier query returns its limit in ~3.5s and the sweep drains 500 closed tracking beads per store per run (verified hq/thriva/cd each −500/run). The deletion rate is dominated by per-bead Dolt work (label/event/dep cleanup), so a large one-time backlog drains over many sweep cycles; steady-state the sweep deletes only a handful per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
