### PR TITLE
fix(beads): mark dirty on a dropped field event so CachedReady declines the stale row

### DIFF
--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -88,6 +88,25 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			return
 		}
 		if !matchesBacking {
+			// A field-changing event that could not be confirmed against the
+			// backing store is either genuinely stale, or real but not yet
+			// visible to this process's backing read — a write-through race
+			// after a cross-process gc sling/kickoff stamps gc.routed_to or
+			// claims the bead. Dropping it outright leaves a stale cached row
+			// that CachedReady still serves with ok=true, so the demand path
+			// counts the bead off the stale row and strands it (no routed_to /
+			// wrong status) until the next full reconcile
+			// (gastownhall/gascity#2927). Mark the bead dirty so the cached
+			// ready model declines for it and the demand path falls back to the
+			// authoritative ReadyLive query; reconciliation clears the flag once
+			// cache and backing reconverge. A dependency-only conflict is left
+			// untouched: dependency snapshots routinely arrive ahead of the
+			// backing and are intentionally tolerated without declining.
+			if fieldConflictCached {
+				c.mu.Lock()
+				c.dirty[patch.ID] = struct{}{}
+				c.mu.Unlock()
+			}
 			return
 		}
 		verifiedRecentLocal = true

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -254,6 +254,54 @@ func TestCachingStoreIgnoresStaleUpdateEventAfterLocalUpdate(t *testing.T) {
 	}
 }
 
+// TestCachingStoreCachedReadyDeclinesAfterDroppedRoutingEvent reproduces the
+// cold-pool strand (gastownhall/gascity#2927). A bead flagged locally mutated
+// by a prior applied event (present in beadSeq, no recent local write) takes
+// the #2210 verify-then-apply branch when a conflicting event arrives; if the
+// backing read loses a write-through race the event is dropped, leaving a
+// stale open ready-candidate row in the cache. CachedReady must then decline
+// (ok=false) so the demand path falls back to the authoritative ReadyLive
+// query rather than counting pool demand off the stale row. Before the fix
+// CachedReady answered ok=true carrying the stale row, stranding the bead
+// until the next full reconcile.
+func TestCachingStoreCachedReadyDeclinesAfterDroppedRoutingEvent(t *testing.T) {
+	backing := &staleReadsAfterUpdateStore{Store: beads.NewMemStore()}
+	cs := beads.NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// A worker bead arrives via a remote bead.created event carrying a complete
+	// snapshot (title/status/created_at/type), so the cache keeps depsComplete
+	// true and lands the bead as an open ready candidate, flagged locally
+	// mutated (beadSeq) with no local write (recentLocalMutation false).
+	created, err := backing.Create(beads.Bead{Title: "route me"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	openSnapshot := created
+	cs.ApplyEvent("bead.created", json.RawMessage(`{"id":"`+created.ID+`","title":"route me","status":"open","created_at":"2026-01-01T00:00:00Z","type":"task"}`))
+	if ready, ok := cs.CachedReady(); !ok || !containsBeadID(ready, created.ID) {
+		t.Fatalf("precondition: CachedReady should answer with the fresh candidate (ok=%v, present=%v)", ok, containsBeadID(ready, created.ID))
+	}
+
+	// The claim lands in the backing (open -> in_progress); the matching
+	// bead.updated event then arrives, but the verify read loses the
+	// write-through race and sees the pre-claim row, so the #2210 branch cannot
+	// confirm the event. The demand path queries CachedReady directly (no
+	// intervening Get), so the stale row is what the scale-check would see.
+	if err := backing.Update(created.ID, beads.UpdateOpts{Status: strPtr("in_progress")}); err != nil {
+		t.Fatalf("Update backing: %v", err)
+	}
+	backing.stale = openSnapshot
+	backing.staleReadCount = 1
+	cs.ApplyEvent("bead.updated", json.RawMessage(`{"id":"`+created.ID+`","status":"in_progress"}`))
+
+	if _, ok := cs.CachedReady(); ok {
+		t.Fatal("CachedReady answered from a stale ready-candidate row (ok=true); want ok=false to force the authoritative ReadyLive fallback")
+	}
+}
+
 func TestCachingStoreIgnoresStaleClosedEventAfterLocalReopen(t *testing.T) {
 	mem := beads.NewMemStore()
 	created, err := mem.Create(beads.Bead{Title: "reopen me"})


### PR DESCRIPTION
## Summary

The #2210 verify-then-apply branch drops a conflicting field event when its backing read cannot confirm it. That read can lose a write-through race after a cross-process `gc sling`/kickoff stamps `gc.routed_to` or claims a bead (open → in_progress): the event is real but not yet visible to this process's backing read, so it is dropped and the cache keeps a stale row.

`CachedReady` gates trust only on the global `c.dirty` set, which a dropped *remote* event never touches, so it serves the stale row with `ok=true`. `readyForControllerDemand` then counts the bead off that stale row — wrong status / missing `gc.routed_to` — and strands it with zero pool demand until the next full reconcile rebuilds the cache (observed ~9.5 min on a routed worker bead).

Closes #2927 — full diagnosis and `file:line` trace are there.

## Fix

When the #2210 branch cannot confirm a **field-changing** event against the backing, mark the bead dirty before dropping, so the cached ready model declines for it and the demand path falls back to the authoritative `ReadyLive` query. Reconciliation clears the flag once cache and backing reconverge.

Dependency-only conflicts are left untouched — dependency snapshots routinely arrive ahead of the backing and are intentionally tolerated without declining (`TestCachingStoreCachedReadyIgnoresStaleDependencyEventsAfterEventMutation`). The fix reuses the existing decline-on-dirty path the local-write path already relies on; there is no flush-dirty-to-backing path, so marking dirty only forces a re-read, never a write.

## Test

`TestCachingStoreCachedReadyDeclinesAfterDroppedRoutingEvent` drives a remote create, then a claim event whose verify read loses the race (via the existing `staleReadsAfterUpdateStore` harness). It is red before the fix (CachedReady serves the stale open candidate with `ok=true`) and green after.

## Test plan

- `go test ./internal/beads/...` — green, including the new test red → green
- `go test ./...` — green
- `go build ./...`, `go vet ./internal/beads/...` — clean

## Relationship to prior work

Same `CachedReady`-vs-`Live` divergence family as #2698 (staleness / under-count) and #2729 (defer completeness); this PR addresses the dropped-field-event facet.
