### PR TITLE
fix: address graphv2 review findings

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -668,6 +668,14 @@ bead into a sub-workflow at runtime.`,
 								WorkflowIDs:  sourceworkflow.BlockingWorkflowIDs(roots),
 							}
 						}
+						if roots, err := sourceworkflow.ListLiveRoots(store, attach, storeRef, storeRef); err != nil {
+							return fmt.Errorf("checking live workflows for %s: %w", attach, err)
+						} else if len(roots) > 0 {
+							return &sourceworkflow.ConflictError{
+								SourceBeadID: attach,
+								WorkflowIDs:  sourceworkflow.BlockingWorkflowIDs(roots),
+							}
+						}
 						source, err := store.Get(attach)
 						if err != nil {
 							return fmt.Errorf("attach bead %s: %w", attach, err)

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/formulatest"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // TestResolveFormulaScope_RigFlagWins verifies that an explicit --rig flag
@@ -880,5 +881,80 @@ title = "Do work for {{convoy_id}}"
 	}
 	if len(roots) != 2 {
 		t.Fatalf("graph roots = %+v, want two independent roots", roots)
+	}
+}
+
+func TestFormulaCookAttachGraphV2RejectsLiveLegacySourceWorkflow(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	t.Setenv("GC_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "my-city"
+provider = "claude"
+
+[daemon]
+formula_v2 = true
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	formulaDir := filepath.Join(cityDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+formula = "graph-work"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work for {{convoy_id}}"
+`), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	t.Chdir(cityDir)
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "target", Type: "task"})
+	if err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+	legacyRoot, err := store.Create(beads.Bead{
+		Title:  "legacy workflow",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": source.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create legacy root: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := newFormulaCookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"graph-work", "--attach", source.ID, "--json"})
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("formula cook succeeded, want source workflow conflict")
+	}
+	var conflictErr *sourceworkflow.ConflictError
+	if !errors.As(err, &conflictErr) {
+		t.Fatalf("formula cook error = %T %[1]v, want ConflictError", err)
+	}
+	if conflictErr.SourceBeadID != source.ID {
+		t.Fatalf("SourceBeadID = %q, want %q", conflictErr.SourceBeadID, source.ID)
+	}
+	if !reflect.DeepEqual(conflictErr.WorkflowIDs, []string{legacyRoot.ID}) {
+		t.Fatalf("WorkflowIDs = %+v, want [%s]", conflictErr.WorkflowIDs, legacyRoot.ID)
 	}
 }

--- a/internal/api/handler_formulas.go
+++ b/internal/api/handler_formulas.go
@@ -262,7 +262,7 @@ func buildFormulaDetail(ctx context.Context, store beads.Store, name string, pat
 }
 
 func formulaDetailPreviewVars(ctx context.Context, store beads.Store, name string, paths []string, resolved *formula.Formula, target string, vars map[string]string, validateRuntimeVars bool) (map[string]string, error) {
-	if resolved == nil || !strings.EqualFold(strings.TrimSpace(resolved.Contract), "graph.v2") {
+	if resolved == nil || !formula.UsesGraphCompiler(resolved) {
 		return vars, nil
 	}
 	if !validateRuntimeVars {
@@ -270,6 +270,38 @@ func formulaDetailPreviewVars(ctx context.Context, store beads.Store, name strin
 			return nil, err
 		}
 		out := graphv2.EffectiveRuntimeVars(resolved, vars)
+		parser := formula.NewParser(paths...).SetSource(formula.SourceFromEnv())
+		formulaRequiresTarget, err := formula.GraphV2FormulaReferencesInputConvoyTransitively(resolved, parser)
+		if err != nil {
+			return nil, err
+		}
+		recipe, err := formula.CompileWithoutRuntimeVarValidation(ctx, name, paths, out)
+		if err != nil {
+			return nil, err
+		}
+		recipeRequiresTarget := formula.GraphV2RecipeReferencesInputConvoy(recipe)
+		if !formulaRequiresTarget && !recipeRequiresTarget {
+			if err := formula.ValidateGraphV2RecipeReservedSymbols(recipe, false); err != nil {
+				return nil, err
+			}
+			return out, nil
+		}
+		if strings.TrimSpace(target) == "" {
+			if formulaRequiresTarget {
+				if err := formula.ValidateGraphV2ReservedSymbolsTransitively(resolved, parser, false); err != nil {
+					return nil, err
+				}
+			}
+			if recipeRequiresTarget {
+				if err := formula.ValidateGraphV2RecipeReservedSymbols(recipe, false); err != nil {
+					return nil, err
+				}
+			}
+			return nil, fmt.Errorf("graph.v2 target is required")
+		}
+		if err := formula.ValidateGraphV2RecipeReservedSymbols(recipe, true); err != nil {
+			return nil, err
+		}
 		inputConvoyID, err := graphv2.PreviewInputConvoyID(store, target)
 		if err != nil {
 			return nil, err

--- a/internal/api/handler_formulas_test.go
+++ b/internal/api/handler_formulas_test.go
@@ -723,6 +723,113 @@ title = "Inspect {{convoy_id}}"
 	}
 }
 
+func TestFormulaPreviewRequiresGraphCompilerInjectsTargetConvoy(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "graph-preview", `
+description = "Preview {{convoy_id}}"
+formula = "graph-preview"
+version = 2
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[steps]]
+id = "inspect"
+title = "Inspect {{convoy_id}}"
+`)
+	convoy, err := state.cityBeadStore.Create(beads.Bead{Title: "input", Type: "convoy"})
+	if err != nil {
+		t.Fatalf("Create(convoy): %v", err)
+	}
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/formulas/graph-preview?scope_kind=city&scope_ref=test-city&target="+convoy.ID), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET detail status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var detail formulaDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("Decode(GET detail): %v", err)
+	}
+	if detail.Description != "Preview "+convoy.ID {
+		t.Fatalf("GET description = %q, want injected convoy", detail.Description)
+	}
+	if len(detail.Steps) != 1 || detail.Steps[0].Title != "Inspect "+convoy.ID {
+		t.Fatalf("GET steps = %+v, want substituted graph.v2 detail step", detail.Steps)
+	}
+
+	body := bytes.NewBufferString(fmt.Sprintf(`{"scope_kind":"city","scope_ref":"test-city","target":%q}`, convoy.ID))
+	req = httptest.NewRequest(http.MethodPost, cityURL(state, "/formulas/graph-preview/preview"), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "true")
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST preview status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	detail = formulaDetailResponse{}
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("Decode(POST detail): %v", err)
+	}
+	if detail.Description != "Preview "+convoy.ID {
+		t.Fatalf("POST description = %q, want injected convoy", detail.Description)
+	}
+	if len(detail.Steps) != 1 || detail.Steps[0].Title != "Inspect "+convoy.ID {
+		t.Fatalf("POST steps = %+v, want substituted graph.v2 preview step", detail.Steps)
+	}
+}
+
+func TestFormulaDetailGraphV2TargetlessAcceptsAgentTarget(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	state := newFakeState(t)
+	state.cityBeadStore = beads.NewMemStore()
+	state.cfg.Daemon.FormulaV2 = true
+	formulaDir := t.TempDir()
+	state.cfg.FormulaLayers.City = []string{formulaDir}
+
+	writeTestFormula(t, formulaDir, "graph-detail", `
+description = "Targetless detail"
+formula = "graph-detail"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "inspect"
+title = "Inspect"
+`)
+
+	h := newTestCityHandler(t, state)
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/formulas/graph-detail?scope_kind=city&scope_ref=test-city&target=worker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET detail status = %d, want 200 for agent target on targetless graph.v2 formula: %s", rec.Code, rec.Body.String())
+	}
+	var detail formulaDetailResponse
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("Decode(detail): %v", err)
+	}
+	if detail.Description != "Targetless detail" {
+		t.Fatalf("description = %q, want targetless detail", detail.Description)
+	}
+	if len(detail.Steps) != 1 || detail.Steps[0].Title != "Inspect" {
+		t.Fatalf("steps = %+v, want unsubstituted graph.v2 detail step", detail.Steps)
+	}
+}
+
 func TestFormulaPreviewRejectsMissingRequiredVars(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1866,15 +1866,7 @@ func bdReadyArgs(q ReadyQuery, includeEphemeral bool) []string {
 	if q.Assignee != "" {
 		args = append(args, "--assignee", q.Assignee)
 	}
-	cliLimit := q.Limit
-	if q.TierMode == TierWisps && q.Limit > 0 {
-		cliLimit = 0
-	}
-	if cliLimit > 0 {
-		args = append(args, "--limit", strconv.Itoa(cliLimit))
-	} else {
-		args = append(args, "--limit", "0")
-	}
+	args = append(args, "--limit", "0")
 	return args
 }
 

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1985,7 +1985,7 @@ func TestBdStoreReadyWithAssigneeAndLimit(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd ready --json --assignee worker-1 --limit 3`: {
+		`bd ready --json --assignee worker-1 --limit 0`: {
 			out: []byte(`[
 				{"id":"bd-worker","title":"ready one","status":"open","issue_type":"task","assignee":"worker-1","created_at":"2025-01-15T10:30:00Z"},
 				{"id":"bd-other","title":"wrong assignee","status":"open","issue_type":"task","assignee":"worker-2","created_at":"2025-01-15T10:31:00Z"}
@@ -2039,7 +2039,7 @@ func TestBdStoreReadyDoesNotSpecialCaseSyntheticMetadata(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd ready --json --limit 1`: {
+		`bd ready --json --limit 0`: {
 			out: []byte(`[
 				{"id":"bd-synthetic","title":"synthetic unit","status":"open","issue_type":"convoy","created_at":"2025-01-15T10:29:00Z","metadata":{"gc.synthetic":"true"}},
 				{"id":"bd-task","title":"ready one","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
@@ -2057,6 +2057,32 @@ func TestBdStoreReadyDoesNotSpecialCaseSyntheticMetadata(t *testing.T) {
 	}
 	if got[0].ID != "bd-synthetic" {
 		t.Fatalf("Ready(limit)[0].ID = %q, want bd-synthetic", got[0].ID)
+	}
+}
+
+func TestBdStoreReadyFiltersExcludedLabelsBeforeLimit(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --limit 0`: {
+			out: []byte(`[
+				{"id":"bd-order","title":"order bookkeeping","status":"open","issue_type":"task","labels":["order-tracking"],"created_at":"2025-01-15T10:29:00Z"},
+				{"id":"bd-task","title":"ready one","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
+				{"id":"bd-extra","title":"ready two","status":"open","issue_type":"task","created_at":"2025-01-15T10:31:00Z"}
+			]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.Ready(beads.ReadyQuery{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Ready(limit) returned %d beads, want 1", len(got))
+	}
+	if got[0].ID != "bd-task" {
+		t.Fatalf("Ready(limit)[0].ID = %q, want bd-task after excluded label filtering", got[0].ID)
 	}
 }
 

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -127,6 +127,9 @@ func expandDrain(store beads.Store, bead beads.Bead, opts ProcessOptions) (Contr
 		if row.ItemRootID == "" {
 			rootID, created, err := ensureDrainItemRoot(store, bead, unit, member, len(members), row, itemFormula, parentVars, opts)
 			if err != nil {
+				if errors.Is(err, errDrainInvalidItemFormula) {
+					return closeDrainItemFormulaFailure(store, bead, manifest, err)
+				}
 				return ControlResult{}, err
 			}
 			if created {
@@ -220,8 +223,9 @@ func loadOrBuildDrainManifest(store beads.Store, bead beads.Bead, parentConvoyID
 }
 
 var (
-	errDrainLimitExceeded    = errors.New("drain limit exceeded")
-	errDrainUnresolvedMember = errors.New("drain unresolved member")
+	errDrainLimitExceeded      = errors.New("drain limit exceeded")
+	errDrainInvalidItemFormula = errors.New("invalid drain item formula")
+	errDrainUnresolvedMember   = errors.New("drain unresolved member")
 )
 
 type drainUnresolvedMemberError struct {
@@ -389,6 +393,9 @@ func advanceSharedDrain(store beads.Store, bead beads.Bead, manifest drainManife
 		}
 		created, err := materializeDrainRow(store, bead, manifest.ParentConvoyID, members, row, member, itemFormula, parentVars, opts)
 		if err != nil {
+			if errors.Is(err, errDrainInvalidItemFormula) {
+				return closeDrainItemFormulaFailure(store, bead, manifest, err)
+			}
 			return ControlResult{}, err
 		}
 		if err := persistDrainManifest(store, bead.ID, manifest, map[string]string{
@@ -626,19 +633,19 @@ func ensureDrainItemRoot(store beads.Store, control, unit, member beads.Bead, co
 	vars[graphv2.ConvoyIDVar] = unit.ID
 	recipe, err := formula.CompileWithoutRuntimeVarValidation(context.Background(), itemFormula, opts.FormulaSearchPaths, vars)
 	if err != nil {
-		return "", false, fmt.Errorf("%s: compiling drain item formula %q: %w", control.ID, itemFormula, err)
+		return "", false, fmt.Errorf("%w: %s: compiling drain item formula %q: %w", errDrainInvalidItemFormula, control.ID, itemFormula, err)
 	}
 	if !isGraphV2WorkflowRecipe(recipe) {
-		return "", false, fmt.Errorf("%s: drain item formula %q must declare contract = \"graph.v2\"", control.ID, itemFormula)
+		return "", false, fmt.Errorf("%w: %s: drain item formula %q must declare contract = \"graph.v2\"", errDrainInvalidItemFormula, control.ID, itemFormula)
 	}
 	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{Vars: vars}); err != nil {
-		return "", false, fmt.Errorf("%s: validating drain item formula %q: %w", control.ID, itemFormula, err)
+		return "", false, fmt.Errorf("%w: %s: validating drain item formula %q: %w", errDrainInvalidItemFormula, control.ID, itemFormula, err)
 	}
 	runtimeVars := drainItemRuntimeVars(recipe, vars)
 	stampDrainItemRecipe(recipe, control, unit, member, count, row, itemFormula, runtimeVars)
 	if opts.PrepareRecipe != nil {
 		if err := opts.PrepareRecipe(recipe, control); err != nil {
-			return "", false, fmt.Errorf("%s: preparing drain item formula %q: %w", control.ID, itemFormula, err)
+			return "", false, fmt.Errorf("%w: %s: preparing drain item formula %q: %w", errDrainInvalidItemFormula, control.ID, itemFormula, err)
 		}
 	}
 	result, err := molecule.Instantiate(context.Background(), store, recipe, molecule.Options{
@@ -861,6 +868,54 @@ func closeDrainReservationFailure(store beads.Store, bead beads.Bead, manifest d
 		return ControlResult{}, fmt.Errorf("%s: closing reservation-failed drain after %w: %w", bead.ID, err, closeErr)
 	}
 	return ControlResult{Processed: true, Action: "drain-reservation-failed"}, nil
+}
+
+func closeDrainItemFormulaFailure(store beads.Store, bead beads.Bead, manifest drainManifest, err error) (ControlResult, error) {
+	const failureReason = "invalid_drain_item_formula"
+	if closeErr := closeOpenDrainItemRoots(store, &manifest, failureReason); closeErr != nil {
+		return ControlResult{}, fmt.Errorf("%s: closing partial drain item roots after %w: %w", bead.ID, err, closeErr)
+	}
+	markIncompleteDrainRowsFailed(&manifest, failureReason)
+	data, marshalErr := json.Marshal(manifest)
+	if marshalErr != nil {
+		return ControlResult{}, marshalErr
+	}
+	metadata := map[string]string{
+		"gc.drain_state":         "failed",
+		"gc.outcome":             "fail",
+		"gc.failure_class":       "hard",
+		"gc.failure_reason":      failureReason,
+		drainManifestMetadataKey: string(data),
+	}
+	if manifest.Formula != "" {
+		metadata["gc.failure_subject"] = manifest.Formula
+	}
+	if releaseErr := releaseDrainReservations(store, bead.ID, manifest); releaseErr != nil {
+		return ControlResult{}, fmt.Errorf("%s: releasing reservations after %w: %w", bead.ID, err, releaseErr)
+	}
+	if closeErr := updateMetadataAndClose(store, bead.ID, metadata); closeErr != nil {
+		return ControlResult{}, fmt.Errorf("%s: closing invalid-item-formula drain after %w: %w", bead.ID, err, closeErr)
+	}
+	return ControlResult{Processed: true, Action: "drain-failed"}, nil
+}
+
+func markIncompleteDrainRowsFailed(manifest *drainManifest, failureReason string) {
+	if manifest == nil {
+		return
+	}
+	for i := range manifest.Rows {
+		row := &manifest.Rows[i]
+		if row.Status == "succeeded" || row.OutcomeKind == "pass" {
+			continue
+		}
+		row.Status = "failed"
+		if row.OutcomeKind == "" {
+			row.OutcomeKind = "fail"
+		}
+		if row.Failure == "" {
+			row.Failure = failureReason
+		}
+	}
 }
 
 func closeOpenDrainItemRoots(store beads.Store, manifest *drainManifest, failureReason string) error {

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -56,6 +56,84 @@ func TestProcessDrainSeparateExpandsConvoyIntoUnitRoots(t *testing.T) {
 	}
 }
 
+func TestProcessDrainSeparateSucceedsForEmptyInputConvoy(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store := beads.NewMemStore()
+	parent, err := store.Create(beads.Bead{Title: "empty parent", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := store.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.input_convoy_id":  parent.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drain, err := store.Create(beads.Bead{
+		Title: "drain",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                "drain",
+			"gc.root_bead_id":        root.ID,
+			"gc.drain_context":       "separate",
+			"gc.drain_formula":       "drain-item",
+			"gc.drain_member_access": "read",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(empty drain): %v", err)
+	}
+	if result.Action != "drain-succeeded" {
+		t.Fatalf("Action = %q, want drain-succeeded", result.Action)
+	}
+	drain = mustGetBead(t, store, drain.ID)
+	if drain.Status != "closed" || drain.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("drain = status %q outcome %q, want closed/pass", drain.Status, drain.Metadata["gc.outcome"])
+	}
+	manifest := mustDrainManifest(t, drain)
+	if len(manifest.Rows) != 0 {
+		t.Fatalf("manifest rows = %+v, want none", manifest.Rows)
+	}
+}
+
+func TestProcessDrainSeparateFailsClosedWhenMaxUnitsExceeded(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+	dir := t.TempDir()
+	writeDrainItemFormula(t, dir)
+	store, drain := seedDrainWorkflow(t)
+	if err := store.SetMetadata(drain.ID, "gc.drain_max_units", "1"); err != nil {
+		t.Fatalf("SetMetadata(max units): %v", err)
+	}
+
+	result, err := ProcessControl(store, mustGetBead(t, store, drain.ID), ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(limit exceeded): %v", err)
+	}
+	if result.Action != "drain-limit-exceeded" {
+		t.Fatalf("Action = %q, want drain-limit-exceeded", result.Action)
+	}
+	drain = mustGetBead(t, store, drain.ID)
+	if drain.Status != "closed" || drain.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("drain = status %q outcome %q, want closed/fail", drain.Status, drain.Metadata["gc.outcome"])
+	}
+	if got := drain.Metadata["gc.failure_reason"]; got != "limit_exceeded" {
+		t.Fatalf("gc.failure_reason = %q, want limit_exceeded", got)
+	}
+}
+
 func TestProcessDrainSharedAdvancesOneItemAtATime(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 	dir := t.TempDir()
@@ -772,18 +850,45 @@ func TestEnsureDrainUnitConvoyRepairsExistingTrack(t *testing.T) {
 	}
 }
 
-func TestProcessDrainRejectsNonGraphItemFormula(t *testing.T) {
+func TestProcessDrainExclusiveFailsClosedForInvalidItemFormula(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 	dir := t.TempDir()
 	writeLegacyDrainItemFormula(t, dir)
 	store, drain := seedDrainWorkflow(t)
-
-	_, err := ProcessControl(store, drain, ProcessOptions{FormulaSearchPaths: []string{dir}})
-	if err == nil {
-		t.Fatal("ProcessControl succeeded, want non-graph item formula error")
+	if err := store.SetMetadata(drain.ID, "gc.drain_member_access", "exclusive"); err != nil {
+		t.Fatalf("SetMetadata(exclusive): %v", err)
 	}
-	if !strings.Contains(err.Error(), `must declare contract = "graph.v2"`) {
-		t.Fatalf("error = %q, want graph.v2 contract message", err)
+	root := mustGetBead(t, store, drain.Metadata["gc.root_bead_id"])
+	members, err := convoycore.Members(store, root.Metadata["gc.input_convoy_id"], false)
+	if err != nil {
+		t.Fatalf("Members: %v", err)
+	}
+
+	result, err := ProcessControl(store, mustGetBead(t, store, drain.ID), ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(non-graph item formula): %v", err)
+	}
+	if result.Action != "drain-failed" {
+		t.Fatalf("Action = %q, want drain-failed", result.Action)
+	}
+	drain = mustGetBead(t, store, drain.ID)
+	if drain.Status != "closed" || drain.Metadata["gc.outcome"] != "fail" {
+		t.Fatalf("drain = status %q outcome %q, want closed/fail", drain.Status, drain.Metadata["gc.outcome"])
+	}
+	if got := drain.Metadata["gc.failure_reason"]; got != "invalid_drain_item_formula" {
+		t.Fatalf("gc.failure_reason = %q, want invalid_drain_item_formula", got)
+	}
+	manifest := mustDrainManifest(t, drain)
+	for _, row := range manifest.Rows {
+		if row.Status != "failed" || row.Failure != "invalid_drain_item_formula" {
+			t.Fatalf("row = %+v, want failed invalid item formula", row)
+		}
+	}
+	for _, member := range members {
+		after := mustGetBead(t, store, member.ID)
+		if got := strings.TrimSpace(after.Metadata["gc.exclusive_drain_reservation"]); got != "" {
+			t.Fatalf("member %s reservation = %q, want released", member.ID, got)
+		}
 	}
 }
 

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -72,7 +72,7 @@ func compileFormula(name string, searchPaths []string, vars map[string]string, v
 	if err != nil {
 		return nil, fmt.Errorf("resolving formula %q: %w", name, err)
 	}
-	if declaresGraphV2Contract(resolved) {
+	if UsesGraphCompiler(resolved) {
 		if err := ValidateGraphV2ReservedSymbolsTransitively(resolved, parser, true); err != nil {
 			return nil, err
 		}

--- a/internal/formula/graphv2_validation.go
+++ b/internal/formula/graphv2_validation.go
@@ -53,7 +53,7 @@ func ValidateGraphV2ReservedSymbolsTransitively(f *Formula, parser *Parser, allo
 // ValidateGraphV2ExpandedFormula enforces graph.v2-only constraints after
 // control flow, advice, and expansion templates have been materialized.
 func ValidateGraphV2ExpandedFormula(f *Formula, allowConvoyReference bool) error {
-	if f == nil || !declaresGraphV2Contract(f) {
+	if f == nil || !UsesGraphCompiler(f) {
 		return nil
 	}
 	errs := graphV2ReservedSymbolErrors(f, allowConvoyReference)
@@ -177,7 +177,7 @@ func graphV2StepsHaveDrain(steps []*Step) bool {
 }
 
 func graphV2ReservedSymbolErrors(f *Formula, allowConvoyReference bool) []string {
-	if f == nil || !declaresGraphV2Contract(f) {
+	if f == nil || !UsesGraphCompiler(f) {
 		return nil
 	}
 	var errs []string
@@ -373,6 +373,9 @@ func validateGraphV2RecipeDrainStep(prefix string, step RecipeStep, errs *[]stri
 	}
 	if strings.TrimSpace(step.Assignee) != "" {
 		*errs = append(*errs, fmt.Sprintf("%s: drain cannot be combined with assignee", prefix))
+	}
+	if step.Gate != nil {
+		*errs = append(*errs, fmt.Sprintf("%s: drain cannot be combined with gate", prefix))
 	}
 }
 

--- a/internal/formula/graphv2_validation_test.go
+++ b/internal/formula/graphv2_validation_test.go
@@ -338,6 +338,31 @@ description_file = "does-not-exist.md"
 	}
 }
 
+func TestParseFileReturnsDescriptionFileErrorsForCompilerRequirement(t *testing.T) {
+	dir := t.TempDir()
+	writeGraphV2Formula(t, dir, "missing-desc.formula.toml", `
+formula = "missing-desc"
+version = 1
+type = "workflow"
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[steps]]
+id = "work"
+title = "Work"
+description_file = "does-not-exist.md"
+`)
+
+	_, err := NewParser(dir).LoadByName("missing-desc")
+	if err == nil {
+		t.Fatal("LoadByName succeeded, want description_file error")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist.md") {
+		t.Fatalf("error = %q, want missing path", err)
+	}
+}
+
 func TestParseFileKeepsLegacyDescriptionFileTolerance(t *testing.T) {
 	dir := t.TempDir()
 	writeGraphV2Formula(t, dir, "missing-desc.formula.toml", `
@@ -499,6 +524,35 @@ description_file = "missing-expansion.md"
 	}
 }
 
+func TestCompileRequiresGraphCompilerAcceptsDrain(t *testing.T) {
+	prev := IsFormulaV2Enabled()
+	SetFormulaV2Enabled(true)
+	defer SetFormulaV2Enabled(prev)
+
+	dir := t.TempDir()
+	writeGraphV2Formula(t, dir, "drain-demo.formula.toml", `
+formula = "drain-demo"
+version = 1
+type = "workflow"
+
+[requires]
+formula_compiler = ">=2.0.0"
+
+[[steps]]
+id = "drain"
+title = "Drain"
+
+[steps.drain]
+context = "separate"
+formula = "review-one"
+`)
+
+	_, err := CompileWithoutRuntimeVarValidation(context.Background(), "drain-demo", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("CompileWithoutRuntimeVarValidation: %v", err)
+	}
+}
+
 func TestValidateGraphV2RecipeRejectsZeroDrainMaxUnits(t *testing.T) {
 	recipe := &Recipe{Steps: []RecipeStep{
 		{
@@ -526,6 +580,36 @@ func TestValidateGraphV2RecipeRejectsZeroDrainMaxUnits(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "max_units must be >= 1") {
 		t.Fatalf("error = %q, want zero max_units error", err)
+	}
+}
+
+func TestValidateGraphV2RecipeRejectsDrainWithGate(t *testing.T) {
+	recipe := &Recipe{Steps: []RecipeStep{
+		{
+			ID:     "root",
+			IsRoot: true,
+			Metadata: map[string]string{
+				"gc.formula_contract": "graph.v2",
+			},
+		},
+		{
+			ID: "root.drain",
+			Metadata: map[string]string{
+				"gc.kind":                "drain",
+				"gc.drain_context":       "separate",
+				"gc.drain_formula":       "item",
+				"gc.drain_member_access": "read",
+			},
+			Gate: &RecipeGate{Type: "manual"},
+		},
+	}}
+
+	err := ValidateGraphV2RecipeReservedSymbols(recipe, true)
+	if err == nil {
+		t.Fatal("ValidateGraphV2RecipeReservedSymbols succeeded, want drain gate error")
+	}
+	if !strings.Contains(err.Error(), "drain cannot be combined with gate") {
+		t.Fatalf("error = %q, want drain gate error", err)
 	}
 }
 

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -151,7 +151,7 @@ func (p *Parser) ParseFile(path string) (*Formula, error) {
 	// Graph.v2 formulas fail fast on missing files; legacy formulas keep the
 	// historical best-effort behavior.
 	formulaDir := filepath.Dir(absPath)
-	strictDescriptionFiles := declaresGraphV2Contract(formula)
+	strictDescriptionFiles := UsesGraphCompiler(formula)
 	if err := p.resolveDescriptionFiles(formula.Steps, formulaDir, strictDescriptionFiles); err != nil {
 		return nil, fmt.Errorf("resolve description_file in %s: %w", path, err)
 	}
@@ -742,7 +742,7 @@ func descriptionAssetRelPath(rawPath string) (string, bool) {
 }
 
 func validateResolvedGraphV2DescriptionFiles(f *Formula) error {
-	if !declaresGraphV2Contract(f) {
+	if !UsesGraphCompiler(f) {
 		return nil
 	}
 	if err := rejectUnresolvedDescriptionFiles(f.Steps, "steps"); err != nil {

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -1014,7 +1014,7 @@ func metadataRequiresGraphContract(metadata map[string]string) bool {
 // Validate checks the formula for structural errors.
 func (f *Formula) Validate() error {
 	var errs []string
-	graphV2 := declaresGraphV2Contract(f)
+	graphV2 := UsesGraphCompiler(f)
 
 	if f.Formula == "" {
 		errs = append(errs, "formula: name is required")

--- a/internal/graphv2/invocation.go
+++ b/internal/graphv2/invocation.go
@@ -298,6 +298,9 @@ func ValidateNoReservedUserVars(vars map[string]string) error {
 // it creates a visible system-created one-item convoy tracking targetID.
 func NormalizeInputConvoy(store beads.Store, targetID string) (string, error) {
 	targetID = strings.TrimSpace(targetID)
+	if store == nil {
+		return "", fmt.Errorf("graph.v2 invocation requires a bead store")
+	}
 	if targetID == "" {
 		return "", fmt.Errorf("graph.v2 target is required")
 	}
@@ -324,6 +327,9 @@ func NormalizeInputConvoy(store beads.Store, targetID string) (string, error) {
 // CreateSingleItemInputConvoy creates a system-created one-item convoy for a
 // graph.v2 invocation target.
 func CreateSingleItemInputConvoy(store beads.Store, target beads.Bead) (beads.Bead, error) {
+	if store == nil {
+		return beads.Bead{}, fmt.Errorf("graph.v2 invocation requires a bead store")
+	}
 	if convoycore.IsTerminalStatus(target.Status) {
 		return beads.Bead{}, fmt.Errorf("graph.v2 target %s is %s", target.ID, target.Status)
 	}

--- a/internal/graphv2/invocation_test.go
+++ b/internal/graphv2/invocation_test.go
@@ -7,7 +7,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
@@ -68,6 +71,72 @@ title = "Inspect {{convoy_id}}"
 	}
 	if again.InputConvoy == inv.InputConvoy {
 		t.Fatalf("input convoy was reused: first=%s second=%s", inv.InputConvoy, again.InputConvoy)
+	}
+}
+
+func TestNormalizeInputConvoyRejectsNilStore(t *testing.T) {
+	_, err := NormalizeInputConvoy(nil, "target")
+	if err == nil {
+		t.Fatal("NormalizeInputConvoy succeeded, want nil-store error")
+	}
+	if !strings.Contains(err.Error(), "requires a bead store") {
+		t.Fatalf("error = %q, want nil-store message", err)
+	}
+}
+
+func TestCreateSingleItemInputConvoyRejectsNilStore(t *testing.T) {
+	_, err := CreateSingleItemInputConvoy(nil, beads.Bead{ID: "target", Status: "open"})
+	if err == nil {
+		t.Fatal("CreateSingleItemInputConvoy succeeded, want nil-store error")
+	}
+	if !strings.Contains(err.Error(), "requires a bead store") {
+		t.Fatalf("error = %q, want nil-store message", err)
+	}
+}
+
+func TestRootKeyIgnoresConvoyIDRuntimeVar(t *testing.T) {
+	base := RootKey("convoy-1", "graph-work", map[string]string{
+		ConvoyIDVar: "convoy-1",
+		"mode":      "review",
+	}, "", "")
+	same := RootKey("convoy-1", "graph-work", map[string]string{
+		ConvoyIDVar: "different-preview-value",
+		"mode":      "review",
+	}, "", "")
+	if same != base {
+		t.Fatalf("RootKey changed when only %s changed: %q vs %q", ConvoyIDVar, same, base)
+	}
+	changed := RootKey("convoy-1", "graph-work", map[string]string{
+		ConvoyIDVar: "convoy-1",
+		"mode":      "implement",
+	}, "", "")
+	if changed == base {
+		t.Fatalf("RootKey did not change when non-reserved vars changed: %q", changed)
+	}
+}
+
+func TestLockKeySerializesSameKey(t *testing.T) {
+	var active int32
+	var overlapped int32
+	var wg sync.WaitGroup
+
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unlock := LockKey("same-root-key")
+			defer unlock()
+			if n := atomic.AddInt32(&active, 1); n > 1 {
+				atomic.StoreInt32(&overlapped, 1)
+			}
+			time.Sleep(time.Millisecond)
+			atomic.AddInt32(&active, -1)
+		}()
+	}
+
+	wg.Wait()
+	if atomic.LoadInt32(&overlapped) != 0 {
+		t.Fatal("LockKey allowed concurrent critical sections for the same key")
 	}
 }
 

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -16,6 +16,7 @@ import (
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
@@ -2152,6 +2153,127 @@ func TestSlingAttachGraphFormulaAllowsDifferentLiveBareBeadRoots(t *testing.T) {
 	}
 	if len(liveRoots) != 2 {
 		t.Fatalf("live graph roots = %+v, want two roots %s and %s", liveRoots, first.WorkflowID, second.WorkflowID)
+	}
+}
+
+func TestInstantiateSlingFormulaForceReplacesGraphV2Root(t *testing.T) {
+	formulaDir := t.TempDir()
+	writeGraphV2ConvoyFormula(t, formulaDir)
+	cfg := graphV2SlingTestConfig(t, formulaDir)
+	deps := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	convoy, err := deps.Store.Create(beads.Bead{Title: "input", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vars := map[string]string{"convoy_id": convoy.ID}
+	opts := molecule.Options{Vars: vars}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	first, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps)
+	if err != nil {
+		t.Fatalf("first InstantiateSlingFormula: %v", err)
+	}
+	second, err := InstantiateSlingFormula(context.Background(), "graph-work", []string{formulaDir}, opts, "", "default", "", a, deps, true)
+	if err != nil {
+		t.Fatalf("force InstantiateSlingFormula: %v", err)
+	}
+	if second.RootID == first.RootID {
+		t.Fatalf("force RootID = %q, want fresh root", second.RootID)
+	}
+	oldRoot, err := deps.Store.Get(first.RootID)
+	if err != nil {
+		t.Fatalf("Get(old root): %v", err)
+	}
+	if oldRoot.Status != "closed" {
+		t.Fatalf("old root status = %q, want closed", oldRoot.Status)
+	}
+	if got := oldRoot.Metadata["gc.failure_reason"]; got != "graphv2_force_replaced" {
+		t.Fatalf("old root gc.failure_reason = %q, want graphv2_force_replaced", got)
+	}
+	newRoot, err := deps.Store.Get(second.RootID)
+	if err != nil {
+		t.Fatalf("Get(new root): %v", err)
+	}
+	if newRoot.Status == "closed" {
+		t.Fatalf("new root status = %q, want live", newRoot.Status)
+	}
+}
+
+func TestRollbackGraphV2ReplacementLaunchRestoresReplacedRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	replaced, err := store.Create(beads.Bead{
+		Title:    "old graph root",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "worker-1",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "old child",
+		Type:     "task",
+		Status:   "in_progress",
+		ParentID: replaced.ID,
+		Assignee: "worker-2",
+		Metadata: map[string]string{
+			"gc.root_bead_id": replaced.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshots, err := sourceworkflow.SnapshotOpenWorkflowBeads(store, replaced.ID)
+	if err != nil {
+		t.Fatalf("SnapshotOpenWorkflowBeads: %v", err)
+	}
+	if _, err := sourceworkflow.CloseWorkflowSubtree(store, replaced.ID); err != nil {
+		t.Fatalf("CloseWorkflowSubtree(replaced): %v", err)
+	}
+	replacement, err := store.Create(beads.Bead{
+		Title:  "new graph root",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rollbackGraphV2ReplacementLaunch(store, replacement.ID, graphV2ReplacementSnapshot{
+		rootID:    replaced.ID,
+		snapshots: snapshots,
+	})
+	if err != nil {
+		t.Fatalf("rollbackGraphV2ReplacementLaunch: %v", err)
+	}
+	replacedAfter, err := store.Get(replaced.ID)
+	if err != nil {
+		t.Fatalf("Get(replaced): %v", err)
+	}
+	if replacedAfter.Status != "open" || replacedAfter.Assignee != "worker-1" {
+		t.Fatalf("replaced root after rollback = %+v, want original state", replacedAfter)
+	}
+	childAfter, err := store.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if childAfter.Status != "open" || childAfter.Assignee != "worker-2" {
+		t.Fatalf("child after rollback = %+v, want original state", childAfter)
+	}
+	replacementAfter, err := store.Get(replacement.ID)
+	if err != nil {
+		t.Fatalf("Get(replacement): %v", err)
+	}
+	if replacementAfter.Status != "closed" {
+		t.Fatalf("replacement status = %q, want closed", replacementAfter.Status)
 	}
 }
 

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -672,3 +672,81 @@ func TestCloseWorkflowSubtree_StampsCloseReason(t *testing.T) {
 		}
 	}
 }
+
+func TestSnapshotRestoreWorkflowBeadsRestoresMutableState(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "workflow",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "worker-1",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": "source-1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "child",
+		Type:     "task",
+		Status:   "in_progress",
+		ParentID: root.ID,
+		Assignee: "worker-2",
+		Metadata: map[string]string{
+			"gc.root_bead_id":    root.ID,
+			"gc.outcome":         "pass",
+			"gc.failure_reason":  "old-reason",
+			"close_reason":       "old close reason long enough",
+			"unrelated_metadata": "keep",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshots, err := SnapshotOpenWorkflowBeads(store, root.ID)
+	if err != nil {
+		t.Fatalf("SnapshotOpenWorkflowBeads: %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("snapshots = %+v, want root and child", snapshots)
+	}
+	if _, err := CloseWorkflowSubtree(store, root.ID); err != nil {
+		t.Fatalf("CloseWorkflowSubtree: %v", err)
+	}
+	if err := store.SetMetadata(child.ID, "gc.outcome", "fail"); err != nil {
+		t.Fatalf("SetMetadata(outcome): %v", err)
+	}
+
+	if err := RestoreWorkflowBeads(store, snapshots); err != nil {
+		t.Fatalf("RestoreWorkflowBeads: %v", err)
+	}
+	rootAfter, err := store.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if rootAfter.Status != "open" || rootAfter.Assignee != "worker-1" {
+		t.Fatalf("root after restore = %+v, want original status/assignee", rootAfter)
+	}
+	childAfter, err := store.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if childAfter.Status != "open" || childAfter.Assignee != "worker-2" {
+		t.Fatalf("child after restore = %+v, want original status/assignee", childAfter)
+	}
+	if got := childAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("child gc.outcome = %q, want pass", got)
+	}
+	if got := childAfter.Metadata["gc.failure_reason"]; got != "old-reason" {
+		t.Fatalf("child gc.failure_reason = %q, want old-reason", got)
+	}
+	if got := childAfter.Metadata["close_reason"]; got != "old close reason long enough" {
+		t.Fatalf("child close_reason = %q, want original close reason", got)
+	}
+	if got := childAfter.Metadata["unrelated_metadata"]; got != "keep" {
+		t.Fatalf("child unrelated metadata = %q, want keep", got)
+	}
+}


### PR DESCRIPTION
Maintainer follow-up for https://github.com/gastownhall/gascity/pull/2784.

Original PR:
- URL: https://github.com/gastownhall/gascity/pull/2784
- Title: feat(graphv2): add convoy-first drain support
- State at finalization: MERGED
- Configured workflow base: main
- Original GitHub base: main
- Base mismatch: none

Why this follow-up exists:
- The original PR merged at contributor head `183c2ac908b97e5f07698814ccfe51da4611e84f` before adoption finalization.
- The adoption review approved one maintainer-side fix commit after that original head.
- This branch is based on current `main` and carries only that maintainer fix, preserving the original contribution through the already-merged PR.

Validation:
- Repository pre-commit hook ran during cherry-pick continuation.
- `go vet ./...`
- `scripts/test-local-parallel fast`
- `go test ./internal/beads ./internal/dispatch ./internal/formula ./internal/graphv2 ./internal/api ./internal/sling ./internal/sourceworkflow ./cmd/gc`
- `make dashboard-check`
- Adopt PR approval guard passed after the latest-base repair.

Adopted via `/adopt-pr` workflow.
