### PR TITLE
fix(config): surface self-assigned epic wisps in default work_query assigned tiers

### DIFF
--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -715,7 +715,7 @@ max = 5
 		t.Fatalf("stdout = %q, want GC_RIG_ROOT=%q", out, rigDir)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, "args=list --include-ephemeral --status in_progress --assignee=host-session --exclude-type=epic --json --limit=1") {
+	if !strings.Contains(out, "args=list --include-ephemeral --status in_progress --assignee=host-session --json --limit=1") {
 		t.Fatalf("stdout = %q, want pool work_query args", out)
 	}
 }
@@ -1030,7 +1030,7 @@ max = 5
 		t.Fatalf("stdout = %q, want command to run from rig root %q", out, rigDir)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, "args=list --include-ephemeral --status in_progress --assignee=host-session --exclude-type=epic --json --limit=1") {
+	if !strings.Contains(out, "args=list --include-ephemeral --status in_progress --assignee=host-session --json --limit=1") {
 		t.Fatalf("stdout = %q, want pool template work_query args", out)
 	}
 }
@@ -1098,7 +1098,7 @@ name = "worker"
 		t.Fatalf("stdout = %q, want GC_SESSION_NAME=host-session", out)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, `args=list --include-ephemeral --status in_progress --assignee=host-session --exclude-type=epic --json --limit=1`) {
+	if !strings.Contains(out, `args=list --include-ephemeral --status in_progress --assignee=host-session --json --limit=1`) {
 		t.Fatalf("stdout = %q, want metadata-routed work query", out)
 	}
 }
@@ -1159,7 +1159,7 @@ dir = "myrig"
 		t.Fatalf("stdout = %q, want GC_SESSION_NAME=%s", out, wantSession)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, `args=list --include-ephemeral --status in_progress --assignee=host-session --exclude-type=epic --json --limit=1`) {
+	if !strings.Contains(out, `args=list --include-ephemeral --status in_progress --assignee=host-session --json --limit=1`) {
 		t.Fatalf("stdout = %q, want metadata-routed work query", out)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2917,12 +2917,12 @@ func (a *Agent) poolDemandTarget() string {
 func standardAssignedWorkQueryScript() string {
 	return `for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
-		`r=$(bd list --include-ephemeral --status in_progress --assignee="$id" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`r=$(bd list --include-ephemeral --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
-		`r=$(bd ready --include-ephemeral --assignee="$id" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`r=$(bd ready --include-ephemeral --assignee="$id" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; `
 }
@@ -2933,7 +2933,7 @@ func legacyControlAssignedWorkQueryScript() string {
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd list --include-ephemeral --status in_progress --assignee="$cand" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`r=$(bd list --include-ephemeral --status in_progress --assignee="$cand" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; ` +
@@ -2942,7 +2942,7 @@ func legacyControlAssignedWorkQueryScript() string {
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd ready --include-ephemeral --assignee="$cand" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`r=$(bd ready --include-ephemeral --assignee="$cand" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; `
@@ -2966,15 +2966,22 @@ func poolDemandOriginGateScript() string {
 //
 // State priority: in_progress+assigned (crash recovery) >
 // ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool).
-// Formula roots that are themselves executable must be represented as ready()
-// work (for example type=wisp); molecule containers are not routable demand.
+// Executable formula roots are ephemeral epics (mol wisp preserves the
+// template-epic IssueType and marks Ephemeral=true); molecule containers
+// are not routable demand.
 //
-// Parent epics are excluded from every tier (--exclude-type=epic). An epic
-// has no executable spec — its semantic is "all children done" — so a worker
-// claiming an epic does undefined work (gc-udx). Roles that legitimately
-// process epics (oversight, reviewers, closers) opt in by setting an explicit
-// work_query in their agent config; that custom query is returned unchanged
-// above.
+// Parent epics are excluded from the routed (pool) tier only
+// (--exclude-type=epic). An unassigned parent epic has no executable spec —
+// its semantic is "all children done" — so a pool worker claiming one does
+// undefined work (gc-udx; the repro is a routed parent epic, see
+// TestEffectiveWorkQuerySkipsEpicLeafScenario). The assigned tiers do NOT
+// exclude epics: work already assigned to this agent is owned, and the
+// patrol-loop pattern (gastown witness/refinery/deacon) self-assigns an
+// ephemeral epic wisp that the agent must resume after a session restart.
+// Excluding epics there silently stranded those wisps (gc hook exited 1 with
+// empty output). Roles that need different behavior still opt in via an
+// explicit work_query in their agent config; that custom query is returned
+// unchanged above.
 //
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1697,14 +1697,14 @@ func TestEffectiveWorkQueryControlDispatcherClaimsLegacyAssignedWork(t *testing.
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "list --include-ephemeral --status in_progress --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=1"|\
-  "list --include-ephemeral --status in_progress --assignee=gascity/control-dispatcher --exclude-type=epic --json --limit=1"|\
-  "list --include-ephemeral --status in_progress --assignee=gascity--workflow-control --exclude-type=epic --json --limit=1"|\
-  "list --include-ephemeral --status in_progress --assignee=gascity/workflow-control --exclude-type=epic --json --limit=1")
+  "list --include-ephemeral --status in_progress --assignee=gascity--control-dispatcher --json --limit=1"|\
+  "list --include-ephemeral --status in_progress --assignee=gascity/control-dispatcher --json --limit=1"|\
+  "list --include-ephemeral --status in_progress --assignee=gascity--workflow-control --json --limit=1"|\
+  "list --include-ephemeral --status in_progress --assignee=gascity/workflow-control --json --limit=1")
     printf '[]'
     ;;
-  "ready --include-ephemeral --assignee=gascity--workflow-control --exclude-type=epic --json --limit=1"|\
-  "ready --include-ephemeral --assignee=gascity/workflow-control --exclude-type=epic --json --limit=1")
+  "ready --include-ephemeral --assignee=gascity--workflow-control --json --limit=1"|\
+  "ready --include-ephemeral --assignee=gascity/workflow-control --json --limit=1")
     printf '[{"id":"ga-legacy-ready"}]'
     ;;
   *)
@@ -1842,37 +1842,85 @@ func TestEffectiveSlingQueryPoolNameOverride(t *testing.T) {
 func TestEffectiveWorkQueryExcludesEpics(t *testing.T) {
 	a := Agent{Name: "worker", Dir: "hello-world"}
 	got := a.EffectiveWorkQuery()
-	// All three tiers (in_progress assignee, ready assignee, ready routed)
-	// must structurally exclude the epic type.
-	wantSnippets := []string{
-		`bd list --include-ephemeral --status in_progress --assignee="$id" --exclude-type=epic --json`,
-		`bd ready --include-ephemeral --assignee="$id" --exclude-type=epic --json`,
+	// The routed (pool) tier excludes parent epics (gc-udx): an unassigned
+	// routed epic has no executable spec, so a pool worker grabbing one does
+	// undefined work. The assigned tiers do NOT exclude epics — an agent must
+	// resume its own assigned ephemeral epic wisp (the patrol-loop pattern).
+	wantPresent := []string{
+		// routed/pool tier still excludes epics (gc-udx guard)
 		`bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json`,
+		// assigned tiers carry NO epic exclusion
+		`bd list --include-ephemeral --status in_progress --assignee="$id" --json`,
+		`bd ready --include-ephemeral --assignee="$id" --json`,
 		`-- hello-world/worker`,
 	}
-	for _, want := range wantSnippets {
+	for _, want := range wantPresent {
 		if !strings.Contains(got, want) {
-			t.Errorf("EffectiveWorkQuery() missing exclude-type=epic on tier:\n  want substring: %s\n  got: %s", want, got)
+			t.Errorf("EffectiveWorkQuery() missing expected substring:\n  want: %s\n  got: %s", want, got)
 		}
+	}
+	// The assigned tiers must NOT carry --exclude-type=epic, or self-assigned
+	// epic wisps get stranded (gc hook exits 1 with empty output).
+	if bad := `--assignee="$id" --exclude-type=epic`; strings.Contains(got, bad) {
+		t.Errorf("EffectiveWorkQuery() assigned tier must not exclude epics, found: %s\n  got: %s", bad, got)
 	}
 }
 
 // TestEffectiveWorkQueryExcludesEpicsControlDispatcher verifies the
 // control-dispatcher path (which has an extra legacy workflow-control
-// route) also excludes epics on every tier.
+// route) excludes epics on the routed (pool) tier but not the assigned
+// tiers — same scoping as the standard path.
 func TestEffectiveWorkQueryExcludesEpicsControlDispatcher(t *testing.T) {
 	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
 	got := a.EffectiveWorkQuery()
-	wantSnippets := []string{
-		`bd list --include-ephemeral --status in_progress --assignee="$cand" --exclude-type=epic --json`,
-		`bd ready --include-ephemeral --assignee="$cand" --exclude-type=epic --json`,
+	wantPresent := []string{
 		`bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json`,
+		`bd list --include-ephemeral --status in_progress --assignee="$cand" --json`,
+		`bd ready --include-ephemeral --assignee="$cand" --json`,
 		`-- gascity/control-dispatcher gascity/workflow-control`,
 	}
-	for _, want := range wantSnippets {
+	for _, want := range wantPresent {
 		if !strings.Contains(got, want) {
-			t.Errorf("EffectiveWorkQuery() missing exclude-type=epic on control-dispatcher tier:\n  want substring: %s\n  got: %s", want, got)
+			t.Errorf("EffectiveWorkQuery() missing expected substring on control-dispatcher:\n  want: %s\n  got: %s", want, got)
 		}
+	}
+	if bad := `--assignee="$cand" --exclude-type=epic`; strings.Contains(got, bad) {
+		t.Errorf("control-dispatcher assigned tier must not exclude epics, found: %s\n  got: %s", bad, got)
+	}
+}
+
+// TestEffectiveWorkQueryAssignedTierSurfacesEpicWisp verifies that a
+// self-assigned ephemeral epic (a "wisp" — the patrol-loop pattern used
+// by the gastown witness/refinery/deacon) is surfaced by the default
+// work query's assigned tiers. The fake bd here mimics real bd's
+// --exclude-type=epic behavior: it returns the epic wisp for a
+// `ready --assignee` query ONLY when --exclude-type=epic is absent.
+// Before the fix the assigned tier carried --exclude-type=epic and the
+// agent's own open wisp was dropped (gc hook exited 1 with no output);
+// the gc-udx parent-epic guard lives on the routed (Tier 3) query, which
+// still excludes epics — see TestEffectiveWorkQuerySkipsEpicLeafScenario.
+func TestEffectiveWorkQueryAssignedTierSurfacesEpicWisp(t *testing.T) {
+	a := Agent{Name: "witness", Dir: "hello-world"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"GC_SESSION_ID":     "witness-sess",
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$1" in
+  ready)
+    case "$*" in
+      *"--assignee=witness-sess"*"--exclude-type=epic"*)
+        # real bd drops the epic-typed wisp when epics are excluded
+        printf '[]' ;;
+      *"--assignee=witness-sess"*)
+        printf '[{"id":"patrol-wisp","issue_type":"epic","ephemeral":true}]' ;;
+      *) printf '[]' ;;
+    esac ;;
+  *) printf '[]' ;;
+esac
+`)
+	if !strings.Contains(out, "patrol-wisp") {
+		t.Fatalf("EffectiveWorkQuery() did not surface the self-assigned epic wisp (assigned tier still excludes epics?): %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

The default `EffectiveWorkQuery` excludes epics on **all** tiers via
`--exclude-type=epic`, including the two assigned-work tiers (`in_progress`
and `ready`, keyed by `--assignee`). The gastown patrol-loop pattern
(witness / refinery / deacon) self-assigns an **ephemeral epic** "wisp" —
`gc bd mol wisp` preserves the template-epic `IssueType` and marks
`Ephemeral=true` — and relies on those assigned tiers to resurface the wisp
after a fresh session start. Excluding epics there stranded it: `gc hook`
found no ready work and exited 1 with empty stdout/stderr (the documented
no-work path), so the agent could not auto-resume its own assigned, open
wisp.

Observed on the citadel witness; latent for every patrol-wisp oversight
agent in every rig. Not work-stopping (the witness has a manual fallback),
but recurring and silent (exit 1, empty output), and it can leak the
orphaned wisp on each restart.

## Root cause

`--exclude-type=epic` was added to the default work query by #1942 (gc-udx)
to stop **pool workers** claiming **unassigned routed parent epics** — a
container epic (semantic "all children done") has no executable spec, so a
worker grabbing one does undefined work. That protection lives entirely on
the **routed/pool tier** (`--unassigned --exclude-type=epic`); the gc-udx
repro test `TestEffectiveWorkQuerySkipsEpicLeafScenario` routes the parent
epic.

Applying the same exclusion to the **assigned tiers** was collateral
over-reach:

- Assigned work is already owned by the agent — it is resuming its own
  work, not claiming an unowned epic.
- An incomplete container epic is gated/blocked, so `bd ready` omits it
  regardless of type.
- The patrol-loop wisp is a root-only ephemeral epic with an inlined
  executable spec and **no children** — the gc-udx rationale does not apply.

There is no distinct "wisp" `IssueType`; a wisp is `Ephemeral=true` on an
epic, so a type filter cannot tell an executable wisp from a container
epic. The clean discriminator is owned-vs-routed, which the tier structure
already encodes.

## Fix

Drop `--exclude-type=epic` from the two assigned tiers in
`standardAssignedWorkQueryScript` and `legacyControlAssignedWorkQueryScript`;
keep it on the pool-demand tier. Updated the `EffectiveWorkQuery` doc
comment to match.

## Testing

- New regression test `TestEffectiveWorkQueryAssignedTierSurfacesEpicWisp`
  drives the assigned tier through a fake `bd` that mimics real bd's
  exclusion (returns the epic wisp for `ready --assignee` only when
  `--exclude-type=epic` is absent). Fails before the fix, passes after.
- `TestEffectiveWorkQuerySkipsEpicLeafScenario` (the gc-udx guard) still
  passes — no regression; the routed tier keeps excluding epics.
- Updated `TestEffectiveWorkQueryExcludesEpics` /
  `...ExcludesEpicsControlDispatcher` and 4 `cmd_hook_test.go` assertions to
  the corrected tier scoping.
- `go build ./...`, `go vet`, and the `internal/config` + `cmd/gc`
  hook / work-query / convoy suites are green.

**Reproduced on a real dolt store:** an open, assigned, ephemeral epic is
returned by `bd ready --include-ephemeral --assignee=X` but dropped the
moment `--exclude-type=epic` is added.

## Out of scope (flagged)

`workflowServeControlReadyQuery` (`cmd/gc/dispatch_runtime.go`) carries the
identical assigned-tier exclusion on the convoy control-dispatch path. Left
unchanged here — no symptom or reproduction was reported on that path. Same
latent issue if the control-dispatcher ever self-assigns an ephemeral epic
wisp; happy to follow up separately if maintainers want it addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
