### PR TITLE
Fix description_file resolution for symlinked formulas

### DIFF
--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -146,11 +146,13 @@ func (p *Parser) ParseFile(path string) (*Formula, error) {
 	// Set source tracing info on all steps (gt-8tmz.18)
 	SetSourceInfo(formula)
 
-	// Resolve description_file references relative to the formula file's
+	// Resolve description_file references relative to the real formula file's
 	// directory, with asset references shadowed through formula layer order.
-	// Graph.v2 formulas fail fast on missing files; legacy formulas keep the
-	// historical best-effort behavior.
-	formulaDir := filepath.Dir(absPath)
+	// Pack formulas may be symlinked into a city's formula directory; relative
+	// prompt files should stay pack-relative, not city-relative. Graph.v2
+	// formulas fail fast on missing files; legacy formulas keep the historical
+	// best-effort behavior.
+	formulaDir := descriptionFileBaseDir(absPath)
 	strictDescriptionFiles := UsesGraphCompiler(formula)
 	if err := p.resolveDescriptionFiles(formula.Steps, formulaDir, strictDescriptionFiles); err != nil {
 		return nil, fmt.Errorf("resolve description_file in %s: %w", path, err)
@@ -165,6 +167,13 @@ func (p *Parser) ParseFile(path string) (*Formula, error) {
 	p.cache[formula.Formula] = formula
 
 	return formula, nil
+}
+
+func descriptionFileBaseDir(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Dir(resolved)
+	}
+	return filepath.Dir(path)
 }
 
 // Parse parses a formula from JSON bytes.

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -183,6 +183,53 @@ description_file = "descriptions/work.md"
 	}
 }
 
+func TestParseFileDescriptionFileResolvesRelativeToSymlinkTarget(t *testing.T) {
+	dir := t.TempDir()
+	packFormulaDir := filepath.Join(dir, "pack", "formulas")
+	packPromptDir := filepath.Join(dir, "pack", "prompts")
+	cityFormulaDir := filepath.Join(dir, "city", "formulas")
+	for _, path := range []string{packFormulaDir, packPromptDir, cityFormulaDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+
+	promptPath := filepath.Join(packPromptDir, "operator.md")
+	if err := os.WriteFile(promptPath, []byte("embedded pack prompt\n"), 0o644); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+
+	formulaPath := filepath.Join(packFormulaDir, "symlink-description.toml")
+	formulaText := `formula = "symlink-description"
+version = 1
+
+[[steps]]
+id = "work"
+title = "Work"
+description_file = "../prompts/operator.md"
+`
+	if err := os.WriteFile(formulaPath, []byte(formulaText), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	linkPath := filepath.Join(cityFormulaDir, "symlink-description.formula.toml")
+	if err := os.Symlink(formulaPath, linkPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	p := NewParser(cityFormulaDir)
+	parsed, err := p.ParseFile(linkPath)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if len(parsed.Steps) != 1 {
+		t.Fatalf("len(Steps) = %d, want 1", len(parsed.Steps))
+	}
+	if got := parsed.Steps[0].Description; got != "embedded pack prompt\n" {
+		t.Fatalf("step description = %q, want embedded pack prompt", got)
+	}
+}
+
 func TestLoadByNameDescriptionFileKeepsFormulaLocalAssetsPath(t *testing.T) {
 	tmp := t.TempDir()
 	coreFormulas := filepath.Join(tmp, "core", "formulas")


### PR DESCRIPTION
## Summary

- Resolve `description_file` paths relative to the symlink target when a formula is materialized into a city via `.beads/formulas` symlinks.
- Add a regression test for pack formulas whose prompts live beside the real formula source, not beside the city symlink.

## Validation

- `go test ./internal/formula -run 'TestParseFileDescriptionFileResolvesRelativeToSymlinkTarget|TestLoadByNameDescriptionFile' -count=1`
- `go test ./internal/formula -count=1`
- branch-local `gc` build loaded symlinked workflow formulas from `/data/projects/gas-city-inc/packs/workflows` in an isolated temp city and embedded prompt text for:
  - `mol-adopt-pr-v2`
  - `mol-pr-post-merge-review-v1`
  - `expansion-review-pr`
- pre-commit hook ran `go vet ./...` and `make test-fast-parallel`; all fast jobs passed
