### PR TITLE
feat(config): stage bead policy config surface

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -247,6 +247,15 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `scale_check` | string |  |  | ScaleCheck overrides the command template whose output reports new unassigned session demand for bead-backed reconciliation. Supports the same Go template placeholders as Agent.scale_check. |
 | `option_defaults` | map[string]string |  |  | OptionDefaults adds or overrides provider option defaults for this agent. Keys are option keys, values are choice values. Merges additively (patch keys win over existing agent keys). Example: option_defaults = &#123; model = "sonnet" &#125; |
 
+## BeadPolicyConfig
+
+BeadPolicyConfig holds storage and retention defaults for a named bead use.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `storage` | string |  |  | Storage selects the intended persistence tier: "history", "no_history", or "ephemeral". Creation paths apply this incrementally as they opt in. Enum: `history`, `no_history`, `ephemeral` |
+| `delete_after_close` | string |  |  | DeleteAfterClose deletes matching GC-owned beads after they have been closed for this duration. Accepts Go duration syntax plus whole-day "d" units, e.g. "7d" or "1d12h". Empty means the policy is not GC-managed. |
+
 ## BeadsConfig
 
 BeadsConfig holds bead store settings.
@@ -255,6 +264,8 @@ BeadsConfig holds bead store settings.
 |-------|------|----------|---------|-------------|
 | `provider` | string |  | `bd` | Provider selects the bead store backend: "bd" (default), "file", or "exec:&lt;script&gt;" for a user-supplied script. |
 | `backend` | string |  |  | Backend selects the bd storage engine when Provider is "bd". Empty defaults to "dolt"; T3Code uses "doltlite" for local dev stores. |
+| `event_hooks` | boolean |  | `true` | EventHooks controls installation of the bead event-forwarding hooks (.beads/hooks/on_create,on_update,on_close). Defaults to true. This config surface is staged ahead of the native bead-event support; current hook behavior remains unchanged until lifecycle code opts in. |
+| `policies` | map[string]BeadPolicyConfig |  |  | Policies defines per-bead-use storage and garbage-collection defaults. Policy names are interpreted by higher-level systems; unknown names are preserved so packs can stage future policy classes without breaking load. |
 
 ## ChatSessionsConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -938,6 +938,26 @@
       ],
       "description": "AgentPatch modifies an existing agent identified by (Dir, Name)."
     },
+    "BeadPolicyConfig": {
+      "properties": {
+        "storage": {
+          "type": "string",
+          "enum": [
+            "history",
+            "no_history",
+            "ephemeral"
+          ],
+          "description": "Storage selects the intended persistence tier: \"history\", \"no_history\",\nor \"ephemeral\". Creation paths apply this incrementally as they opt in."
+        },
+        "delete_after_close": {
+          "type": "string",
+          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". Empty means the policy is not GC-managed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "BeadPolicyConfig holds storage and retention defaults for a named bead use."
+    },
     "BeadsConfig": {
       "properties": {
         "provider": {
@@ -948,6 +968,18 @@
         "backend": {
           "type": "string",
           "description": "Backend selects the bd storage engine when Provider is \"bd\".\nEmpty defaults to \"dolt\"; T3Code uses \"doltlite\" for local dev stores."
+        },
+        "event_hooks": {
+          "type": "boolean",
+          "description": "EventHooks controls installation of the bead event-forwarding hooks\n(.beads/hooks/on_create,on_update,on_close). Defaults to true.\nThis config surface is staged ahead of the native bead-event support;\ncurrent hook behavior remains unchanged until lifecycle code opts in.",
+          "default": true
+        },
+        "policies": {
+          "additionalProperties": {
+            "$ref": "#/$defs/BeadPolicyConfig"
+          },
+          "type": "object",
+          "description": "Policies defines per-bead-use storage and garbage-collection defaults.\nPolicy names are interpreted by higher-level systems; unknown names are\npreserved so packs can stage future policy classes without breaking load."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -938,6 +938,26 @@
       ],
       "description": "AgentPatch modifies an existing agent identified by (Dir, Name)."
     },
+    "BeadPolicyConfig": {
+      "properties": {
+        "storage": {
+          "type": "string",
+          "enum": [
+            "history",
+            "no_history",
+            "ephemeral"
+          ],
+          "description": "Storage selects the intended persistence tier: \"history\", \"no_history\",\nor \"ephemeral\". Creation paths apply this incrementally as they opt in."
+        },
+        "delete_after_close": {
+          "type": "string",
+          "description": "DeleteAfterClose deletes matching GC-owned beads after they have been\nclosed for this duration. Accepts Go duration syntax plus whole-day \"d\"\nunits, e.g. \"7d\" or \"1d12h\". Empty means the policy is not GC-managed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "BeadPolicyConfig holds storage and retention defaults for a named bead use."
+    },
     "BeadsConfig": {
       "properties": {
         "provider": {
@@ -948,6 +968,18 @@
         "backend": {
           "type": "string",
           "description": "Backend selects the bd storage engine when Provider is \"bd\".\nEmpty defaults to \"dolt\"; T3Code uses \"doltlite\" for local dev stores."
+        },
+        "event_hooks": {
+          "type": "boolean",
+          "description": "EventHooks controls installation of the bead event-forwarding hooks\n(.beads/hooks/on_create,on_update,on_close). Defaults to true.\nThis config surface is staged ahead of the native bead-event support;\ncurrent hook behavior remains unchanged until lifecycle code opts in.",
+          "default": true
+        },
+        "policies": {
+          "additionalProperties": {
+            "$ref": "#/$defs/BeadPolicyConfig"
+          },
+          "type": "object",
+          "description": "Policies defines per-bead-use storage and garbage-collection defaults.\nPolicy names are interpreted by higher-level systems; unknown names are\npreserved so packs can stage future policy classes without breaking load."
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1219,9 +1219,11 @@ const (
 	BeadStorageEphemeral = "ephemeral"
 )
 
-// NormalizeBeadPolicyStorage canonicalizes a bead policy storage value.
+// NormalizeBeadPolicyStorage returns the configured bead policy storage value.
+// Storage spellings are intentionally canonical so runtime validation matches
+// the generated schema enum.
 func NormalizeBeadPolicyStorage(storage string) string {
-	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(storage)), "-", "_")
+	return storage
 }
 
 // ValidBeadPolicyStorage reports whether storage is one of the supported bead
@@ -1247,7 +1249,7 @@ func (p BeadPolicyConfig) DeleteAfterCloseDuration() time.Duration {
 		return 0
 	}
 	dur, err := parseConfigDurationWithDays(p.DeleteAfterClose)
-	if err != nil {
+	if err != nil || dur <= 0 {
 		return 0
 	}
 	return dur
@@ -2333,15 +2335,16 @@ func parseConfigDurationWithDays(raw string) (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
+	dayDuration := time.Duration(days) * 24 * time.Hour
 	rest := raw[dayIdx+1:]
 	if rest == "" {
-		return time.Duration(days) * 24 * time.Hour, nil
+		return dayDuration, nil
 	}
 	dur, err := time.ParseDuration(rest)
 	if err != nil {
 		return 0, err
 	}
-	return time.Duration(days)*24*time.Hour + dur, nil
+	return addConfigDurations(dayDuration, dur)
 }
 
 func parsePositiveDurationDays(raw string) (int64, error) {
@@ -2353,14 +2356,29 @@ func parsePositiveDurationDays(raw string) (int64, error) {
 			return 0, fmt.Errorf("invalid day count %q", raw)
 		}
 	}
-	days, err := strconv.ParseInt(raw, 10, 32)
+	days, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
 		return 0, err
 	}
 	if days <= 0 {
 		return 0, fmt.Errorf("day count must be positive")
 	}
+	if days > maxConfigDurationDays {
+		return 0, fmt.Errorf("day count %q exceeds maximum %d", raw, maxConfigDurationDays)
+	}
 	return days, nil
+}
+
+const maxConfigDurationDays = int64(1<<63-1) / int64(24*time.Hour)
+
+func addConfigDurations(a, b time.Duration) (time.Duration, error) {
+	if b > 0 && a > time.Duration(1<<63-1)-b {
+		return 0, fmt.Errorf("duration exceeds maximum")
+	}
+	if b < 0 && a < time.Duration(-1<<63)-b {
+		return 0, fmt.Errorf("duration is below minimum")
+	}
+	return a + b, nil
 }
 
 // FormulasDir returns the formulas directory, defaulting to "formulas".

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1181,6 +1181,76 @@ type BeadsConfig struct {
 	// Backend selects the bd storage engine when Provider is "bd".
 	// Empty defaults to "dolt"; T3Code uses "doltlite" for local dev stores.
 	Backend string `toml:"backend,omitempty"`
+	// EventHooks controls installation of the bead event-forwarding hooks
+	// (.beads/hooks/on_create,on_update,on_close). Defaults to true.
+	// This config surface is staged ahead of the native bead-event support;
+	// current hook behavior remains unchanged until lifecycle code opts in.
+	EventHooks *bool `toml:"event_hooks,omitempty" jsonschema:"default=true"`
+	// Policies defines per-bead-use storage and garbage-collection defaults.
+	// Policy names are interpreted by higher-level systems; unknown names are
+	// preserved so packs can stage future policy classes without breaking load.
+	Policies map[string]BeadPolicyConfig `toml:"policies,omitempty"`
+}
+
+// EventHooksEnabled reports whether bead event hooks should be installed.
+// Unset preserves the current default of enabled hooks.
+func (b BeadsConfig) EventHooksEnabled() bool {
+	return b.EventHooks == nil || *b.EventHooks
+}
+
+// BeadPolicyConfig holds storage and retention defaults for a named bead use.
+type BeadPolicyConfig struct {
+	// Storage selects the intended persistence tier: "history", "no_history",
+	// or "ephemeral". Creation paths apply this incrementally as they opt in.
+	Storage string `toml:"storage,omitempty" jsonschema:"enum=history,enum=no_history,enum=ephemeral"`
+	// DeleteAfterClose deletes matching GC-owned beads after they have been
+	// closed for this duration. Accepts Go duration syntax plus whole-day "d"
+	// units, e.g. "7d" or "1d12h". Empty means the policy is not GC-managed.
+	DeleteAfterClose string `toml:"delete_after_close,omitempty"`
+}
+
+const (
+	// BeadStorageHistory stores beads in the normal history-tracked table.
+	BeadStorageHistory = "history"
+	// BeadStorageNoHistory stores beads without Dolt history while keeping
+	// non-ephemeral semantics.
+	BeadStorageNoHistory = "no_history"
+	// BeadStorageEphemeral stores beads as ephemeral wisps.
+	BeadStorageEphemeral = "ephemeral"
+)
+
+// NormalizeBeadPolicyStorage canonicalizes a bead policy storage value.
+func NormalizeBeadPolicyStorage(storage string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(storage)), "-", "_")
+}
+
+// ValidBeadPolicyStorage reports whether storage is one of the supported bead
+// storage classes. Empty storage is valid and means use the default.
+func ValidBeadPolicyStorage(storage string) bool {
+	switch NormalizeBeadPolicyStorage(storage) {
+	case "", BeadStorageHistory, BeadStorageNoHistory, BeadStorageEphemeral:
+		return true
+	default:
+		return false
+	}
+}
+
+// NormalizedStorage returns the canonical storage class for this policy.
+func (p BeadPolicyConfig) NormalizedStorage() string {
+	return NormalizeBeadPolicyStorage(p.Storage)
+}
+
+// DeleteAfterCloseDuration returns DeleteAfterClose as a duration. It accepts
+// ordinary Go durations plus a whole-day "d" unit, e.g. "7d" and "1d12h".
+func (p BeadPolicyConfig) DeleteAfterCloseDuration() time.Duration {
+	if p.DeleteAfterClose == "" {
+		return 0
+	}
+	dur, err := parseConfigDurationWithDays(p.DeleteAfterClose)
+	if err != nil {
+		return 0
+	}
+	return dur
 }
 
 // SessionConfig holds session provider settings.
@@ -2245,6 +2315,52 @@ func (d *DaemonConfig) WispTTLDuration() time.Duration {
 // and wisp_ttl must be set to non-zero durations.
 func (d *DaemonConfig) WispGCEnabled() bool {
 	return d.WispGCIntervalDuration() > 0 && d.WispTTLDuration() > 0
+}
+
+// parseConfigDurationWithDays extends time.ParseDuration with a whole-day "d"
+// unit. It accepts ordinary Go durations unchanged and supports one leading day
+// component such as "7d" or "1d12h".
+func parseConfigDurationWithDays(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	dayIdx := strings.IndexByte(raw, 'd')
+	if dayIdx < 0 {
+		return time.ParseDuration(raw)
+	}
+	days, err := parsePositiveDurationDays(raw[:dayIdx])
+	if err != nil {
+		return 0, err
+	}
+	rest := raw[dayIdx+1:]
+	if rest == "" {
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	dur, err := time.ParseDuration(rest)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(days)*24*time.Hour + dur, nil
+}
+
+func parsePositiveDurationDays(raw string) (int64, error) {
+	if raw == "" {
+		return 0, fmt.Errorf("missing day count")
+	}
+	for _, r := range raw {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("invalid day count %q", raw)
+		}
+	}
+	days, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	if days <= 0 {
+		return 0, fmt.Errorf("day count must be positive")
+	}
+	return days, nil
 }
 
 // FormulasDir returns the formulas directory, defaulting to "formulas".

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -607,7 +607,7 @@ name = "test-city"
 event_hooks = false
 
 [beads.policies.control]
-storage = "no-history"
+storage = "no_history"
 delete_after_close = "1d12h"
 
 [beads.policies.workflow]
@@ -3490,6 +3490,48 @@ func TestValidateNonNegativeDurationsRejectsNegativeDoltStartAddressInUseRetryWi
 		!strings.Contains(err.Error(), "must not be negative") ||
 		!strings.Contains(err.Error(), `"-2s"`) {
 		t.Errorf("ValidateNonNegativeDurations() error = %q, want it to name the field, the constraint, and the value", err)
+	}
+}
+
+func TestValidateNonNegativeDurationsRejectsInvalidBeadPolicyDeleteAfterClose(t *testing.T) {
+	tests := []string{"-1h", "0s", "1d-48h", "200000d", "forever-ish"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			cfg := &City{
+				Beads: BeadsConfig{
+					Policies: map[string]BeadPolicyConfig{
+						"control": {DeleteAfterClose: value},
+					},
+				},
+			}
+			err := ValidateNonNegativeDurations(cfg, "city.toml")
+			if err == nil {
+				t.Fatal("ValidateNonNegativeDurations() = nil, want error for invalid delete_after_close")
+			}
+			msg := err.Error()
+			for _, want := range []string{"city.toml", "[beads.policies.control]", "delete_after_close", value} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("ValidateNonNegativeDurations() error = %q, want substring %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateNonNegativeDurationsAllowsPositiveBeadPolicyDeleteAfterClose(t *testing.T) {
+	for _, value := range []string{"", "1h", "1d", "1d12h"} {
+		t.Run(value, func(t *testing.T) {
+			cfg := &City{
+				Beads: BeadsConfig{
+					Policies: map[string]BeadPolicyConfig{
+						"control": {DeleteAfterClose: value},
+					},
+				},
+			}
+			if err := ValidateNonNegativeDurations(cfg, "city.toml"); err != nil {
+				t.Errorf("ValidateNonNegativeDurations(delete_after_close=%q) = %v, want nil", value, err)
+			}
+		})
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -543,6 +543,8 @@ name = "test-city"
 
 [beads]
 provider = "file"
+backend = "doltlite"
+event_hooks = false
 
 [[agent]]
 name = "mayor"
@@ -553,6 +555,12 @@ name = "mayor"
 	}
 	if cfg.Beads.Provider != "file" {
 		t.Errorf("Beads.Provider = %q, want %q", cfg.Beads.Provider, "file")
+	}
+	if cfg.Beads.Backend != "doltlite" {
+		t.Errorf("Beads.Backend = %q, want %q", cfg.Beads.Backend, "doltlite")
+	}
+	if cfg.Beads.EventHooks == nil || *cfg.Beads.EventHooks {
+		t.Errorf("Beads.EventHooks = %v, want false", cfg.Beads.EventHooks)
 	}
 }
 
@@ -571,6 +579,12 @@ name = "mayor"
 	if cfg.Beads.Provider != "" {
 		t.Errorf("Beads.Provider = %q, want empty", cfg.Beads.Provider)
 	}
+	if cfg.Beads.EventHooks != nil {
+		t.Errorf("Beads.EventHooks = %v, want nil", cfg.Beads.EventHooks)
+	}
+	if cfg.Beads.Policies != nil {
+		t.Errorf("Beads.Policies = %v, want nil", cfg.Beads.Policies)
+	}
 }
 
 func TestMarshalOmitsEmptyBeadsSection(t *testing.T) {
@@ -581,6 +595,83 @@ func TestMarshalOmitsEmptyBeadsSection(t *testing.T) {
 	}
 	if strings.Contains(string(data), "[beads]") {
 		t.Errorf("Marshal output should not contain '[beads]' when empty:\n%s", data)
+	}
+}
+
+func TestParseBeadsPoliciesSection(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[beads]
+event_hooks = false
+
+[beads.policies.control]
+storage = "no-history"
+delete_after_close = "1d12h"
+
+[beads.policies.workflow]
+storage = "ephemeral"
+
+[[agent]]
+name = "mayor"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.Beads.EventHooks == nil || *cfg.Beads.EventHooks {
+		t.Fatalf("Beads.EventHooks = %v, want false", cfg.Beads.EventHooks)
+	}
+	if len(cfg.Beads.Policies) != 2 {
+		t.Fatalf("len(Beads.Policies) = %d, want 2", len(cfg.Beads.Policies))
+	}
+	control := cfg.Beads.Policies["control"]
+	if got := control.NormalizedStorage(); got != BeadStorageNoHistory {
+		t.Errorf("control.NormalizedStorage() = %q, want %q", got, BeadStorageNoHistory)
+	}
+	if got := control.DeleteAfterCloseDuration(); got != 36*time.Hour {
+		t.Errorf("control.DeleteAfterCloseDuration() = %v, want 36h", got)
+	}
+	workflow := cfg.Beads.Policies["workflow"]
+	if got := workflow.NormalizedStorage(); got != BeadStorageEphemeral {
+		t.Errorf("workflow.NormalizedStorage() = %q, want %q", got, BeadStorageEphemeral)
+	}
+}
+
+func TestBeadsConfigRoundTripPreservesStagedFields(t *testing.T) {
+	disabled := false
+	c := City{
+		Workspace: Workspace{Name: "test"},
+		Beads: BeadsConfig{
+			Provider:   "bd",
+			Backend:    "doltlite",
+			EventHooks: &disabled,
+			Policies: map[string]BeadPolicyConfig{
+				"control": {
+					Storage:          BeadStorageNoHistory,
+					DeleteAfterClose: "48h",
+				},
+			},
+		},
+		Agents: []Agent{{Name: "mayor"}},
+	}
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse(Marshal output): %v\n%s", err, data)
+	}
+	if got.Beads.EventHooks == nil || *got.Beads.EventHooks {
+		t.Errorf("round-tripped EventHooks = %v, want false", got.Beads.EventHooks)
+	}
+	if got.Beads.Backend != "doltlite" {
+		t.Errorf("round-tripped Backend = %q, want doltlite", got.Beads.Backend)
+	}
+	if got.Beads.Policies["control"].DeleteAfterClose != "48h" {
+		t.Errorf("round-tripped policy = %#v, want delete_after_close=48h", got.Beads.Policies["control"])
 	}
 }
 

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -200,6 +200,7 @@ func knownTOMLKeys() []string {
 		reflect.TypeOf(AgentPatch{}),
 		reflect.TypeOf(AgentOverride{}),
 		reflect.TypeOf(BeadsConfig{}),
+		reflect.TypeOf(BeadPolicyConfig{}),
 		reflect.TypeOf(SessionConfig{}),
 		reflect.TypeOf(MailConfig{}),
 		reflect.TypeOf(EventsConfig{}),

--- a/internal/config/undecoded_test.go
+++ b/internal/config/undecoded_test.go
@@ -157,6 +157,38 @@ func TestKnownTOMLKeysNotEmpty(t *testing.T) {
 	}
 }
 
+func TestCheckUndecodedKeysSuggestsBeadPolicyKey(t *testing.T) {
+	input := `
+[workspace]
+name = "test"
+
+[beads.policies.control]
+delete_after_cloes = "1d"
+`
+	var cfg City
+	md, err := toml.Decode(input, &cfg)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	warnings := CheckUndecodedKeys(md, "city.toml")
+	if len(warnings) == 0 {
+		t.Fatal("expected warning for bead policy typo")
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "delete_after_cloes") {
+			found = true
+			if !strings.Contains(w, `did you mean "delete_after_close"`) {
+				t.Errorf("warning should suggest delete_after_close, got: %s", w)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no warning about delete_after_cloes in: %v", warnings)
+	}
+}
+
 func TestParseWithMetaWarnings(t *testing.T) {
 	input := `
 [workspace]

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -21,6 +21,16 @@ func ValidateDurations(cfg *City, source string) []string {
 				source, context, field, value, err))
 		}
 	}
+	checkWithDays := func(context, field, value string) {
+		if value == "" {
+			return
+		}
+		if _, err := parseConfigDurationWithDays(value); err != nil {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s: %s %s = %q is not a valid duration: %v",
+				source, context, field, value, err))
+		}
+	}
 	checkSleep := func(context, field, value string) {
 		if value == "" {
 			return
@@ -60,6 +70,15 @@ func ValidateDurations(cfg *City, source string) []string {
 
 	// Events config durations.
 	check("[events.rotation]", "archive_retain_age", cfg.Events.Rotation.ArchiveRetainAge)
+
+	for name, policy := range cfg.Beads.Policies {
+		checkWithDays(fmt.Sprintf("[beads.policies.%s]", name), "delete_after_close", policy.DeleteAfterClose)
+		if !ValidBeadPolicyStorage(policy.Storage) {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s: [beads.policies.%s] storage = %q is not valid: must be one of %q, %q, or %q",
+				source, name, policy.Storage, BeadStorageHistory, BeadStorageNoHistory, BeadStorageEphemeral))
+		}
+	}
 
 	// Chat sessions config durations.
 	check("[chat_sessions]", "idle_timeout", cfg.ChatSessions.IdleTimeout)

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -21,14 +21,21 @@ func ValidateDurations(cfg *City, source string) []string {
 				source, context, field, value, err))
 		}
 	}
-	checkWithDays := func(context, field, value string) {
+	checkPositiveWithDays := func(context, field, value string) {
 		if value == "" {
 			return
 		}
-		if _, err := parseConfigDurationWithDays(value); err != nil {
+		dur, err := parseConfigDurationWithDays(value)
+		if err != nil {
 			warnings = append(warnings, fmt.Sprintf(
 				"%s: %s %s = %q is not a valid duration: %v",
 				source, context, field, value, err))
+			return
+		}
+		if dur <= 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s: %s %s = %q must be a positive duration",
+				source, context, field, value))
 		}
 	}
 	checkSleep := func(context, field, value string) {
@@ -72,7 +79,7 @@ func ValidateDurations(cfg *City, source string) []string {
 	check("[events.rotation]", "archive_retain_age", cfg.Events.Rotation.ArchiveRetainAge)
 
 	for name, policy := range cfg.Beads.Policies {
-		checkWithDays(fmt.Sprintf("[beads.policies.%s]", name), "delete_after_close", policy.DeleteAfterClose)
+		checkPositiveWithDays(fmt.Sprintf("[beads.policies.%s]", name), "delete_after_close", policy.DeleteAfterClose)
 		if !ValidBeadPolicyStorage(policy.Storage) {
 			warnings = append(warnings, fmt.Sprintf(
 				"%s: [beads.policies.%s] storage = %q is not valid: must be one of %q, %q, or %q",
@@ -115,8 +122,9 @@ func ValidateDurations(cfg *City, source string) []string {
 	return warnings
 }
 
-// ValidateNonNegativeDurations checks duration fields that must not be
-// negative and returns a hard error for the first violation. Unlike
+// ValidateNonNegativeDurations checks duration fields that must not be negative
+// and retention fields that must be positive, returning a hard error for the
+// first violation. Unlike
 // ValidateDurations (which only warns on unparseable typos), a negative
 // duration that parses cleanly is silently destructive — e.g. a negative
 // dolt_stop_timeout collapses the managed-dolt SIGTERM→SIGKILL grace to an
@@ -144,11 +152,34 @@ func ValidateNonNegativeDurations(cfg *City, source string) error {
 		}
 		return nil
 	}
+	checkPositiveWithDays := func(context, field, value string) error {
+		if value == "" {
+			return nil
+		}
+		dur, err := parseConfigDurationWithDays(value)
+		if err != nil {
+			return fmt.Errorf("%s: %s %s = %q is not a valid duration: %w",
+				source, context, field, value, err)
+		}
+		if dur <= 0 {
+			return fmt.Errorf("%s: %s %s must be a positive duration: got %q",
+				source, context, field, value)
+		}
+		return nil
+	}
 
 	if err := checkNonNegative("[daemon]", "dolt_stop_timeout", cfg.Daemon.DoltStopTimeout); err != nil {
 		return err
 	}
-	return checkNonNegative("[daemon]", "dolt_start_address_in_use_retry_window", cfg.Daemon.DoltStartAddressInUseRetryWindow)
+	if err := checkNonNegative("[daemon]", "dolt_start_address_in_use_retry_window", cfg.Daemon.DoltStartAddressInUseRetryWindow); err != nil {
+		return err
+	}
+	for name, policy := range cfg.Beads.Policies {
+		if err := checkPositiveWithDays(fmt.Sprintf("[beads.policies.%s]", name), "delete_after_close", policy.DeleteAfterClose); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ValidateEventsRotation returns non-fatal warnings for risky but intentional

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -130,6 +130,30 @@ func TestValidateDurationsBadBeadPolicyDuration(t *testing.T) {
 	}
 }
 
+func TestValidateDurationsRejectsUnsafeBeadPolicyDuration(t *testing.T) {
+	tests := []string{"-1h", "0s", "1d-48h", "200000d"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			cfg := &City{
+				Beads: BeadsConfig{
+					Policies: map[string]BeadPolicyConfig{
+						"control": {DeleteAfterClose: value},
+					},
+				},
+			}
+			warnings := ValidateDurations(cfg, "city.toml")
+			if len(warnings) != 1 {
+				t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+			}
+			for _, want := range []string{"[beads.policies.control]", "delete_after_close", value} {
+				if !strings.Contains(warnings[0], want) {
+					t.Errorf("warning = %q, want substring %q", warnings[0], want)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateDurationsBadBeadPolicyStorage(t *testing.T) {
 	cfg := &City{
 		Beads: BeadsConfig{
@@ -146,6 +170,30 @@ func TestValidateDurationsBadBeadPolicyStorage(t *testing.T) {
 		if !strings.Contains(warnings[0], want) {
 			t.Errorf("warning = %q, want substring %q", warnings[0], want)
 		}
+	}
+}
+
+func TestValidateDurationsRejectsNonCanonicalBeadPolicyStorage(t *testing.T) {
+	tests := []string{"no-history", "EPHEMERAL"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			cfg := &City{
+				Beads: BeadsConfig{
+					Policies: map[string]BeadPolicyConfig{
+						"control": {Storage: value},
+					},
+				},
+			}
+			warnings := ValidateDurations(cfg, "city.toml")
+			if len(warnings) != 1 {
+				t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+			}
+			for _, want := range []string{"[beads.policies.control]", "storage", value} {
+				if !strings.Contains(warnings[0], want) {
+					t.Errorf("warning = %q, want substring %q", warnings[0], want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -111,6 +111,44 @@ func TestValidateDurationsBadDaemonFields(t *testing.T) {
 	}
 }
 
+func TestValidateDurationsBadBeadPolicyDuration(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				"control": {DeleteAfterClose: "7days"},
+			},
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	for _, want := range []string{"[beads.policies.control]", "delete_after_close", "7days"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Errorf("warning = %q, want substring %q", warnings[0], want)
+		}
+	}
+}
+
+func TestValidateDurationsBadBeadPolicyStorage(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				"control": {Storage: "forever-ish"},
+			},
+		},
+	}
+	warnings := ValidateDurations(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	for _, want := range []string{"[beads.policies.control]", "storage", "forever-ish"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Errorf("warning = %q, want substring %q", warnings[0], want)
+		}
+	}
+}
+
 func TestValidateDurationsBadPoolDrainTimeout(t *testing.T) {
 	cfg := &City{
 		Agents: []Agent{


### PR DESCRIPTION
## Summary

Adds an inert config base for the bead support that is still landing upstream:

- `[beads].event_hooks` parses and round-trips as an optional boolean, defaulting to enabled when unset.
- `[beads.policies.*]` parses and round-trips named bead policy config for storage and retention.
- bead policy storage is normalized to canonical values: `history`, `no_history`, and `ephemeral`; hyphenated `no-history` is accepted on input.
- `delete_after_close` validation accepts normal Go durations plus whole-day `d` units such as `7d` and `1d12h`.
- generated city config schema and config reference docs include the staged fields.

## Intentional non-goals

This PR does not wire runtime behavior yet. Current hook lifecycle and bead storage behavior remain unchanged until the bead support branches land and opt into these config values.

Specifically excluded here:

- hook install/remove behavior changes
- default work-query `--include-ephemeral` behavior
- graph apply, molecule storage, or bd store behavior changes
- runtime application of bead policies

## Base / conflict proof

Rebased cleanly onto current `origin/main` at `6dd109068` (`Back-merge v1.2.1 into main (#2932)`). The final diff is one commit touching only config parsing/validation tests plus generated city config docs/schema.

## Verification

- `go test ./internal/config -run 'Test(ParseBeadsSection|ParseNoBeadsSection|MarshalOmitsEmptyBeadsSection|ParseBeadsPoliciesSection|BeadsConfigRoundTripPreservesStagedFields|ValidateDurationsBadBeadPolicy)' -count=1`
- `go test ./internal/config -count=1`
- `make check-schema`
- `go vet ./...`
- `make test-fast-parallel`
- `.githooks/pre-commit` passed on the staged patch before final rebase; the full gates above were rerun after rebasing onto `origin/main`.

Local bead tracker: `ga-i6fab`.
