### PR TITLE
fix(session): persist wake_mode metadata when value is "resume"

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1076,7 +1076,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if tp.WorkDir != "" {
 				meta["work_dir"] = tp.WorkDir
 			}
-			if tp.WakeMode != "" && tp.WakeMode != "resume" {
+			if tp.WakeMode != "" {
 				meta["wake_mode"] = tp.WakeMode
 			}
 			if isConfiguredNamed {


### PR DESCRIPTION
## Summary

`cmd/gc/session_beads.go` currently omits the `wake_mode` key from session metadata when its value equals `"resume"` (the most common explicit override). The omission is functionally harmless — consumers reading absent `wake_mode` default to `"resume"` anyway, and `shouldBumpContinuationEpoch` (session_wake.go:110) only branches on `"fresh"` — but operators auditing whether an explicit `wake_mode = "resume"` override is actually applied see `metadata: {}` on every affected session and can't distinguish:

1. resume was explicitly configured and the override is live
2. no wake_mode was configured anywhere, defaulting to resume
3. agent template's `wake_mode = "fresh"` was inherited but never overridden (a misconfiguration the operator wants to detect)

This conflation made a real diagnosis materially harder during a fmcity post-incident audit: three subagents had to triangulate live config from `gc config show --json` because the session bead's own metadata was unreliable for this property.

## Change

Drop the `!= "resume"` clause from session_beads.go:1079. wake_mode is one of the more important session properties for post-incident debugging — write it whenever set, regardless of value.

## Existing test alignment

Test fixtures in `cmd/gc/session_wake_test.go` already assert `wake_mode: "resume"` should appear in metadata at lines 245, 435, 1320. Those tests exercise the wake path, not the create path; this change makes the create path consistent with the wake-path expectation.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -run 'TestWake|TestSession|TestUpsert' ./cmd/gc/` clean
- [x] `go test -run 'TestReconciler|TestSyncSession|TestStartSession' ./cmd/gc/` clean
- [ ] Reviewer to confirm there are no downstream consumers that rely on wake_mode being absent for the default case (only one non-test consumer found: `shouldBumpContinuationEpoch` at session_wake.go:110, which only matches `"fresh"` and is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)