### PR TITLE
fix(reconciler): stop per-tick re-stamp of attached config-drift deferral

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2819,11 +2819,48 @@ func hasNonSessionAssignedWork(items []beads.Bead) bool {
 const (
 	namedSessionActivityThreshold                      = 2 * time.Minute
 	namedSessionRecentActivityConfigDriftDeferralLimit = 30 * time.Second
-	sessionAttachedConfigDriftFalseNegativeLimit       = 30 * time.Second
-	namedSessionConfigDriftDeferredAtMetadata          = "config_drift_deferred_at"
-	namedSessionConfigDriftDeferredKeyMetadata         = "config_drift_deferred_key"
-	sessionAttachedConfigDriftDeferredAtMetadata       = "attached_config_drift_deferred_at"
-	sessionAttachedConfigDriftDeferredKeyMetadata      = "attached_config_drift_deferred_key"
+	// sessionAttachedConfigDriftFalseNegativeLimit is how long a recorded
+	// attached-drift deferral keeps suppressing a config-drift drain, measured
+	// from the deferral's stored timestamp (NOT from the last positive
+	// attachment observation — see the refresh-interval note below). It bridges
+	// transient attachment-detection flicker (a probe momentarily reporting
+	// "not attached" between ticks) so a still-attached session is not drained.
+	//
+	// Because the stamp is refreshed at most once per
+	// sessionAttachedConfigDriftRefreshInterval, the GUARANTEED bridge after a
+	// positive observation is the worst case (limit - refreshInterval): a
+	// positive observation can be skipped just after a refresh, then attachment
+	// flickers false, and the deferral lapses limit after the last stored stamp.
+	// With the values below that worst case is 5m - 2m = 3m of flicker
+	// tolerance, which is ample; attachment detection flickers on the order of a
+	// tick, not minutes. Attachment is a reliable signal, so the window is kept
+	// generous and is intentionally decoupled from the re-stamp cadence.
+	//
+	// Tradeoff: raising this from 30s to 5m also raises the worst-case latency
+	// from a GENUINE detach to config-drift handling, since after a real detach
+	// the not-attached branch is gated solely by this window (drift waits it
+	// out, up to ~5m). That is acceptable — config-drift handling is a
+	// reconvergence restart, not a safety kill, and the existing activity
+	// heuristic already tolerates a 2m staleness window — but it is a conscious
+	// cost of removing the per-tick commit churn. The composed safety invariant
+	// (refresh interval + patrol < this limit) is asserted by
+	// TestRecordSessionAttachedConfigDriftDeferral_SurvivesSkippedRefreshThenFlicker.
+	sessionAttachedConfigDriftFalseNegativeLimit = 5 * time.Minute
+	// sessionAttachedConfigDriftRefreshInterval is the minimum age the existing
+	// stamp must reach before record() rewrites it. It is deliberately SEPARATE
+	// from (and smaller than) the false-negative limit: while attached, record()
+	// runs every reconciler tick, so the stamp only needs refreshing rarely —
+	// just often enough that it never ages out of the false-negative window
+	// during a real flicker. Coupling the refresh to the validity limit (the old
+	// "rewrite after limit/2" rule) caused a durable metadata write — and a Dolt
+	// commit — on essentially every tick whenever the patrol interval was >=
+	// limit/2 (e.g. the default 30s patrol with the old 30s limit), flooding the
+	// store with no-op churn for every persistently-attached drifted session.
+	sessionAttachedConfigDriftRefreshInterval     = 2 * time.Minute
+	namedSessionConfigDriftDeferredAtMetadata     = "config_drift_deferred_at"
+	namedSessionConfigDriftDeferredKeyMetadata    = "config_drift_deferred_key"
+	sessionAttachedConfigDriftDeferredAtMetadata  = "attached_config_drift_deferred_at"
+	sessionAttachedConfigDriftDeferredKeyMetadata = "attached_config_drift_deferred_key"
 )
 
 // namedSessionActivelyInUse returns true if a named session is currently
@@ -2930,16 +2967,17 @@ func recordSessionAttachedConfigDriftDeferral(session beads.Bead, store beads.St
 		now = clk.Now().UTC()
 	}
 	// Skip the write when the same drift key is already deferred and the
-	// existing stamp is comfortably within the false-negative TTL window.
-	// Without this guard the reconciler emits a bead.updated event on every
-	// tick (~1.4s) for every attached session with persistent drift.
-	// Refreshing at TTL/2 leaves enough headroom that a paused reconcile
-	// loop cannot accidentally let the deferral expire.
+	// existing stamp is still fresh. While attached, the reconciler calls this
+	// on every tick, so without a throttle it would emit a bead.updated event —
+	// and a durable Dolt commit — every tick for every attached session with
+	// persistent drift. The refresh interval is decoupled from (and well below)
+	// the false-negative limit, so the stamp is rewritten only occasionally yet
+	// can never age out of the validity window between two refreshes.
 	if driftKey != "" && session.Metadata[sessionAttachedConfigDriftDeferredKeyMetadata] == driftKey {
 		if raw := session.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]; raw != "" {
 			if existing, err := time.Parse(time.RFC3339, raw); err == nil &&
 				!existing.After(now) &&
-				now.Sub(existing) < sessionAttachedConfigDriftFalseNegativeLimit/2 {
+				now.Sub(existing) < sessionAttachedConfigDriftRefreshInterval {
 				return nil
 			}
 		}

--- a/cmd/gc/session_reconciler_drift_defer_test.go
+++ b/cmd/gc/session_reconciler_drift_defer_test.go
@@ -5,15 +5,17 @@ import (
 	"time"
 )
 
-// TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL verifies
-// that a second deferral with the same drift key, taken well within the
-// false-negative TTL window, does NOT re-stamp the deferred_at timestamp.
+// TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinRefreshInterval
+// verifies that a second deferral with the same drift key, taken well within
+// the refresh interval, does NOT re-stamp the deferred_at timestamp.
 //
-// On parent (pre-fix), recordSessionAttachedConfigDriftDeferral always writes
-// now() into deferred_at, producing a bead.updated event every reconcile tick
-// (~1.4s) on every attached session bead with persistent drift. This test
+// On parent (pre-fix), recordSessionAttachedConfigDriftDeferral rewrote
+// deferred_at once the existing stamp was older than the 30s validity window /
+// 2 = 15s. Because the patrol interval (30s default) exceeds that, it re-stamped
+// on essentially every reconcile tick, producing a bead.updated event — and a
+// Dolt commit — on every attached session bead with persistent drift. This test
 // fails on parent and passes after the fix.
-func TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL(t *testing.T) {
+func TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinRefreshInterval(t *testing.T) {
 	env := newReconcilerTestEnv()
 	session := env.createSessionBead("worker", "worker")
 	const driftKey = "old-hash:new-hash"
@@ -33,7 +35,7 @@ func TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL(t *tes
 		t.Fatalf("first key = %q, want %q", first.Metadata[sessionAttachedConfigDriftDeferredKeyMetadata], driftKey)
 	}
 
-	// Advance the clock well within TTL/2 (TTL is 30s; advance 5s).
+	// Advance the clock well within the refresh interval (2m; advance 5s).
 	env.clk.Time = env.clk.Time.Add(5 * time.Second)
 
 	if err := recordSessionAttachedConfigDriftDeferral(first, env.store, env.clk, driftKey); err != nil {
@@ -45,7 +47,7 @@ func TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL(t *tes
 	}
 	secondStamp := second.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]
 	if secondStamp != firstStamp {
-		t.Fatalf("deferred_at must not be re-stamped within TTL/2; got %q want unchanged %q",
+		t.Fatalf("deferred_at must not be re-stamped within the refresh interval; got %q want unchanged %q",
 			secondStamp, firstStamp)
 	}
 }
@@ -85,12 +87,18 @@ func TestRecordSessionAttachedConfigDriftDeferral_RewritesWhenKeyChanges(t *test
 	}
 }
 
-// TestRecordSessionAttachedConfigDriftDeferral_RewritesAfterHalfTTL verifies
-// that once the existing stamp is older than TTL/2, the next call refreshes
-// it. This keeps the 30s false-negative TTL semantically intact: the
-// deferral cannot be allowed to age past TTL just because the same key
-// keeps being observed.
-func TestRecordSessionAttachedConfigDriftDeferral_RewritesAfterHalfTTL(t *testing.T) {
+// TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteAcrossManyTicks
+// verifies the churn fix: with the default 30s patrol interval, the deferral
+// is re-observed every tick, but record() must NOT rewrite the stamp on each
+// one. The refresh interval is decoupled from (and much larger than) the
+// patrol interval, so a long run of same-key ticks produces no metadata write
+// (hence no Dolt commit) until the refresh interval elapses.
+//
+// This is the regression guard for the per-tick re-stamp churn: on the buggy
+// version (rewrite once the stamp is older than the 30s validity limit / 2 =
+// 15s), every 30s tick rewrote the stamp. It fails on that version and passes
+// after the fix.
+func TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteAcrossManyTicks(t *testing.T) {
 	env := newReconcilerTestEnv()
 	session := env.createSessionBead("worker", "worker")
 	const driftKey = "old-hash:new-hash"
@@ -104,17 +112,169 @@ func TestRecordSessionAttachedConfigDriftDeferral_RewritesAfterHalfTTL(t *testin
 	}
 	firstStamp := first.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]
 
-	// Advance past TTL/2 (TTL is 30s; advance 16s).
-	env.clk.Time = env.clk.Time.Add(sessionAttachedConfigDriftFalseNegativeLimit/2 + time.Second)
+	// Simulate many reconciler ticks at the default 30s patrol interval, all
+	// well within the refresh interval. None of them may rewrite the stamp.
+	const patrol = 30 * time.Second
+	cur := first
+	for elapsed := patrol; elapsed < sessionAttachedConfigDriftRefreshInterval; elapsed += patrol {
+		env.clk.Time = env.clk.Time.Add(patrol)
+		if err := recordSessionAttachedConfigDriftDeferral(cur, env.store, env.clk, driftKey); err != nil {
+			t.Fatalf("record at +%s: %v", elapsed, err)
+		}
+		cur, err = env.store.Get(session.ID)
+		if err != nil {
+			t.Fatalf("get at +%s: %v", elapsed, err)
+		}
+		if got := cur.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]; got != firstStamp {
+			t.Fatalf("deferred_at re-stamped at +%s (got %q, want unchanged %q) — per-tick churn not eliminated",
+				elapsed, got, firstStamp)
+		}
+	}
 
-	if err := recordSessionAttachedConfigDriftDeferral(first, env.store, env.clk, driftKey); err != nil {
-		t.Fatalf("second record: %v", err)
+	// Once the existing stamp is older than the refresh interval, the next call
+	// refreshes it so the deferral cannot age out of the false-negative window.
+	env.clk.Time = env.clk.Time.Add(sessionAttachedConfigDriftRefreshInterval + time.Second)
+	if err := recordSessionAttachedConfigDriftDeferral(cur, env.store, env.clk, driftKey); err != nil {
+		t.Fatalf("refresh record: %v", err)
 	}
-	second, err := env.store.Get(session.ID)
+	refreshed, err := env.store.Get(session.ID)
 	if err != nil {
-		t.Fatalf("get after second: %v", err)
+		t.Fatalf("get after refresh: %v", err)
 	}
-	if second.Metadata[sessionAttachedConfigDriftDeferredAtMetadata] == firstStamp {
-		t.Fatalf("deferred_at must be refreshed past TTL/2; got unchanged %q", firstStamp)
+	if refreshed.Metadata[sessionAttachedConfigDriftDeferredAtMetadata] == firstStamp {
+		t.Fatalf("deferred_at must be refreshed past the refresh interval; got unchanged %q", firstStamp)
+	}
+}
+
+// TestRecordSessionAttachedConfigDriftDeferral_RefreshKeepsWithinValidityWindow
+// exercises the actual read path (recentlyDeferredSessionAttachedConfigDrift)
+// to prove the decoupling preserves the safety contract: a stamp that record()
+// left un-refreshed because it was younger than the refresh interval must still
+// be treated as valid by the reader. This catches regressions the constant-only
+// invariant check would miss (wrong metadata key, reader still on the old 30s
+// limit, off-by-one at the boundary).
+func TestRecordSessionAttachedConfigDriftDeferral_RefreshKeepsWithinValidityWindow(t *testing.T) {
+	// Structural invariant: the reader's validity window must exceed the
+	// writer's refresh interval, or a just-skipped refresh could read as lapsed.
+	if sessionAttachedConfigDriftRefreshInterval >= sessionAttachedConfigDriftFalseNegativeLimit {
+		t.Fatalf("refresh interval (%s) must be < false-negative limit (%s) or the deferral can lapse between refreshes",
+			sessionAttachedConfigDriftRefreshInterval, sessionAttachedConfigDriftFalseNegativeLimit)
+	}
+
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("worker", "worker")
+	const driftKey = "old-hash:new-hash"
+
+	if err := recordSessionAttachedConfigDriftDeferral(session, env.store, env.clk, driftKey); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	stamped, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	// Just below the refresh interval: record() skips the rewrite. The reader
+	// must still consider the deferral valid (this is the whole point of the
+	// decoupling — a skipped refresh cannot create a false-negative gap).
+	env.clk.Time = env.clk.Time.Add(sessionAttachedConfigDriftRefreshInterval - time.Second)
+	if err := recordSessionAttachedConfigDriftDeferral(stamped, env.store, env.clk, driftKey); err != nil {
+		t.Fatalf("record near refresh boundary: %v", err)
+	}
+	afterSkip, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after skip: %v", err)
+	}
+	if !recentlyDeferredSessionAttachedConfigDrift(afterSkip, env.clk, driftKey) {
+		t.Fatal("deferral must read as valid just below the refresh interval (un-refreshed stamp)")
+	}
+
+	// Just below the validity limit (and a refresh has NOT happened since the
+	// original stamp): the reader must still treat it as valid — proving the
+	// window the reader uses really is the 5m limit, not the old 30s value.
+	env.clk.Time = env.clk.Time.Add(sessionAttachedConfigDriftFalseNegativeLimit - sessionAttachedConfigDriftRefreshInterval - time.Second)
+	stillValid, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get near validity boundary: %v", err)
+	}
+	if !recentlyDeferredSessionAttachedConfigDrift(stillValid, env.clk, driftKey) {
+		t.Fatal("deferral must read as valid just below the false-negative limit")
+	}
+
+	// Past the validity limit with no refresh: the reader must now treat it as
+	// lapsed (so genuine post-detach drift can proceed).
+	env.clk.Time = env.clk.Time.Add(2 * time.Second)
+	lapsed, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get past validity: %v", err)
+	}
+	if recentlyDeferredSessionAttachedConfigDrift(lapsed, env.clk, driftKey) {
+		t.Fatal("deferral must read as lapsed past the false-negative limit")
+	}
+}
+
+// TestRecordSessionAttachedConfigDriftDeferral_SurvivesSkippedRefreshThenFlicker
+// guards the COMPOSED safety invariant that actually keeps an attached session
+// from being drained mid-conversation:
+//
+//	sessionAttachedConfigDriftRefreshInterval + patrol < sessionAttachedConfigDriftFalseNegativeLimit
+//
+// The worst case the validity window must absorb is: record() SKIPS a rewrite
+// because the stamp is just under the refresh interval, and then exactly one
+// patrol tick later attachment detection flickers to "not attached". The reader
+// at that moment sees stamp age = refreshInterval + patrol and must STILL read
+// the deferral as valid, or a still-attached session is drained/restarted in the
+// middle of a live conversation.
+//
+// patrol_interval is operator-configurable (cfg.Daemon.PatrolIntervalDuration,
+// default 30s) with no upper clamp, so this is checked across a range of patrol
+// values. The structural assertion catches a future constant change that shrinks
+// the headroom; the behavioral assertion proves the reader actually honors it.
+func TestRecordSessionAttachedConfigDriftDeferral_SurvivesSkippedRefreshThenFlicker(t *testing.T) {
+	const driftKey = "old-hash:new-hash"
+	// Worst-case stamp age the reader must tolerate is (refreshInterval + patrol):
+	// a rewrite skipped at age just below refreshInterval, then one patrol tick.
+	patrols := []time.Duration{30 * time.Second, 60 * time.Second, 90 * time.Second, 2 * time.Minute}
+	for _, patrol := range patrols {
+		worst := sessionAttachedConfigDriftRefreshInterval + patrol
+		// Structural guard: the composed invariant, not just refresh < validity.
+		if worst >= sessionAttachedConfigDriftFalseNegativeLimit {
+			t.Fatalf("patrol=%s: refreshInterval(%s)+patrol(%s)=%s must be < falseNegativeLimit(%s); "+
+				"a skipped refresh followed by an attachment flicker would drain a still-attached session",
+				patrol, sessionAttachedConfigDriftRefreshInterval, patrol, worst,
+				sessionAttachedConfigDriftFalseNegativeLimit)
+		}
+
+		// Behavioral guard: drive the real reader at exactly the worst-case age.
+		env := newReconcilerTestEnv()
+		session := env.createSessionBead("worker", "worker")
+		if err := recordSessionAttachedConfigDriftDeferral(session, env.store, env.clk, driftKey); err != nil {
+			t.Fatalf("patrol=%s: record: %v", patrol, err)
+		}
+		stamped, err := env.store.Get(session.ID)
+		if err != nil {
+			t.Fatalf("patrol=%s: get: %v", patrol, err)
+		}
+		stamp0 := stamped.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]
+
+		// Tick at age just under the refresh interval: record() must SKIP (stamp unchanged).
+		env.clk.Time = env.clk.Time.Add(sessionAttachedConfigDriftRefreshInterval - time.Second)
+		if err := recordSessionAttachedConfigDriftDeferral(stamped, env.store, env.clk, driftKey); err != nil {
+			t.Fatalf("patrol=%s: record near refresh boundary: %v", patrol, err)
+		}
+		afterSkip, err := env.store.Get(session.ID)
+		if err != nil {
+			t.Fatalf("patrol=%s: get after skip: %v", patrol, err)
+		}
+		if afterSkip.Metadata[sessionAttachedConfigDriftDeferredAtMetadata] != stamp0 {
+			t.Fatalf("patrol=%s: stamp must be unchanged just under the refresh interval", patrol)
+		}
+
+		// One patrol tick later attachment flickers detached: total age is now
+		// (refreshInterval - 1s) + patrol < worst. The reader must still hold.
+		env.clk.Time = env.clk.Time.Add(patrol)
+		if !recentlyDeferredSessionAttachedConfigDrift(afterSkip, env.clk, driftKey) {
+			t.Fatalf("patrol=%s: deferral must read as valid at age refreshInterval+patrol "+
+				"(skipped refresh then flicker) or a still-attached session is drained", patrol)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

When a long-lived session is **attached** and has persistent config drift, the reconciler cannot drain it, so on each tick it records an `attached_config_drift_deferred_at` timestamp on the session bead to suppress the config-drift drain. That marker had a 30s false-negative validity window (`sessionAttachedConfigDriftFalseNegativeLimit`), and the re-stamp guard skipped rewriting **only** when the existing stamp was younger than `window / 2 = 15s`.

The patrol/reconcile interval (`cfg.Daemon.PatrolIntervalDuration`) defaults to 30s — larger than 15s — so by the next tick the stamp is *always* older than `window/2`, and the timestamp is rewritten on **essentially every tick**. Each rewrite is a durable metadata write and a Dolt commit. For any persistently-attached drifted session this produces a commit every ~30s, indefinitely. On a busy coordination database this single re-stamp dominated total write volume (observed: ~92% of commits were this one path on a single attached session), driving continuous storage growth and a steady stream of no-op commits.

The validity window's actual purpose is narrow: bridge **transient attachment-detection flicker** (a probe momentarily reporting "not attached" between two ticks) so a still-attached session isn't drained. Coupling the *re-stamp cadence* to that window (the `window/2` rule) is what caused the churn.

## Fix

Decouple the re-stamp cadence from the validity window:

- Keep a generous validity window — raised `30s → 5m`. Attachment is a reliable signal, so the deferral can safely stay valid longer.
- Gate the re-stamp on a **separate** `sessionAttachedConfigDriftRefreshInterval = 2m`. The stamp is rewritten at most every 2m instead of every tick, while staying comfortably inside the 5m window so the deferral never lapses between refreshes.

For the default 30s patrol this turns a re-stamp every tick into one every ~4th tick at most, and for any patrol below 2m it eliminates the per-tick write entirely.

## Safety

The property that keeps an attached session from being drained mid-conversation is the **composed** invariant:

```
sessionAttachedConfigDriftRefreshInterval + patrol < sessionAttachedConfigDriftFalseNegativeLimit
```

Worst case: a refresh is skipped at stamp-age just under `refreshInterval`, then attachment flickers "not attached" exactly one patrol tick later — the reader then sees age `refreshInterval + patrol` and must still treat the deferral as valid. `patrol_interval` is operator-configurable with no upper clamp, so a regression test asserts this composition across a range of patrol values (30s/60s/90s/2m) and drives the real reader at the worst-case age. With defaults there is 2.5m of headroom.

### Tradeoff (documented at the constant)

Raising the window `30s → 5m` also raises the worst-case latency from a **genuine** detach to config-drift handling (after a real detach, drift waits out the window, up to ~5m). This is bounded and acceptable — config-drift handling is a reconvergence restart, not a safety kill, and the existing activity heuristic already tolerates a 2m staleness window.

## Tests

- `SkipsWriteWithinRefreshInterval` / `SkipsWriteAcrossManyTicks` — re-stamp is skipped within the refresh interval and across many default-patrol ticks; refreshed once past it. (Fails on the pre-fix `window/2` behavior.)
- `RewritesWhenKeyChanges` — a genuinely new drift key still forces an immediate re-stamp.
- `RefreshKeepsWithinValidityWindow` — drives the real reader (`recentlyDeferredSessionAttachedConfigDrift`) across the un-refreshed boundary, the validity boundary, and past lapse.
- `SurvivesSkippedRefreshThenFlicker` — guards the composed `refreshInterval + patrol < window` invariant parametrically and behaviorally.

`go build`, `go vet`, `gofmt`, and the full reconciler / config-drift / phase-0 suites pass.
