### PR TITLE
fix(api): surface workflow-snapshot SQL fast-path failures instead of swallowing

### DIFF
--- a/internal/api/convoy_sql.go
+++ b/internal/api/convoy_sql.go
@@ -210,6 +210,13 @@ func workflowSQLDepFromRow(issueID, dependsOnID, depType sql.NullString) beads.D
 // tryFullWorkflowSQL does the entire workflow snapshot via SQL — root
 // discovery, bead fetch, dep fetch, and graph build. Falls back to nil
 // error only on full success so the caller can use the slow path on any failure.
+// errNoSQLWorkflowStores is the benign "this deployment has no SQL-backed
+// workflow store to consult" outcome — distinct from a SQL store that exists
+// but could not be reached or did not contain the workflow. The caller
+// (buildWorkflowSnapshot) uses errors.Is to keep the routine no-SQL fallback
+// quiet while still surfacing genuine fast-path failures (gascity#2940).
+var errNoSQLWorkflowStores = errors.New("no sql workflow stores")
+
 func (s *Server) tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScopeRef string, snapshotIndex uint64) (*workflowSnapshotResponse, error) {
 	candidates := workflowSQLCandidatesForWorkflowID(
 		s.state,
@@ -218,7 +225,7 @@ func (s *Server) tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScope
 		fallbackScopeRef,
 	)
 	if len(candidates) == 0 {
-		return nil, fmt.Errorf("no sql workflow stores")
+		return nil, errNoSQLWorkflowStores
 	}
 
 	type sqlWorkflowRootMatch struct {
@@ -226,18 +233,36 @@ func (s *Server) tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScope
 		root      beads.Bead
 	}
 	matches := make([]sqlWorkflowRootMatch, 0, len(candidates))
+	// Retain the first genuine probe failure (Dolt unreachable, query error)
+	// so a fully-failed sweep surfaces the real cause rather than a synthetic
+	// "not found" — that real cause is exactly what the #2940 fallback log
+	// needs to be actionable. A clean miss (ok == false, err == nil) is not a
+	// failure: the workflow simply isn't in that store.
+	var firstProbeErr error
 	for _, candidate := range candidates {
 		host, port, database, user, password, err := resolveDoltConnection(s.state.CityPath(), candidate.path)
 		if err != nil {
+			if firstProbeErr == nil {
+				firstProbeErr = fmt.Errorf("resolve dolt connection for %s: %w", candidate.info.ref, err)
+			}
 			continue
 		}
 		root, ok, err := workflowSQLFindRoot(s.state.Config(), user, password, host, port, database, workflowID)
-		if err != nil || !ok {
+		if err != nil {
+			if firstProbeErr == nil {
+				firstProbeErr = fmt.Errorf("sql find root in %s: %w", candidate.info.ref, err)
+			}
+			continue
+		}
+		if !ok {
 			continue
 		}
 		matches = append(matches, sqlWorkflowRootMatch{candidate: candidate, root: root})
 	}
 	if len(matches) == 0 {
+		if firstProbeErr != nil {
+			return nil, firstProbeErr
+		}
 		return nil, fmt.Errorf("workflow %q not found in sql stores", workflowID)
 	}
 

--- a/internal/api/handler_convoy_dispatch.go
+++ b/internal/api/handler_convoy_dispatch.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"log"
 	"strconv"
 	"strings"
 
@@ -9,6 +10,19 @@ import (
 )
 
 var errWorkflowNotFound = errors.New("workflow not found")
+
+// logWorkflowSQLFallback surfaces a workflow-snapshot SQL fast-path failure
+// before buildWorkflowSnapshot drops to the per-store scan. The SQL path is the
+// ~190ms route; the scan is seconds and grows with rig count, so a silent
+// fallback hides a real perf regression (gascity#2940). The benign
+// "no SQL stores configured" outcome is left quiet so non-SQL deployments,
+// whose steady state IS the scan, do not log on every workflow fetch.
+func logWorkflowSQLFallback(workflowID string, err error) {
+	if err == nil || errors.Is(err, errNoSQLWorkflowStores) {
+		return
+	}
+	log.Printf("gc api: workflow %q SQL fast path failed, falling back to store scan: %v", workflowID, err)
+}
 
 // Response types (workflowSnapshotResponse, workflowBeadResponse,
 // workflowDepResponse, LogicalNode, ScopeGroup) live in
@@ -30,9 +44,11 @@ type workflowRootMatch struct {
 
 func (s *Server) buildWorkflowSnapshot(workflowID, fallbackScopeKind, fallbackScopeRef string, snapshotIndex uint64) (*workflowSnapshotResponse, error) {
 	// Fast path: resolve the correct store and fetch the entire snapshot via SQL.
-	if snap, err := s.tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScopeRef, snapshotIndex); err == nil {
+	snap, sqlErr := s.tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScopeRef, snapshotIndex)
+	if sqlErr == nil {
 		return snap, nil
 	}
+	logWorkflowSQLFallback(workflowID, sqlErr)
 
 	// Slow path: bd subprocess N+1
 	stores := s.workflowStores()

--- a/internal/api/handler_convoy_dispatch_test.go
+++ b/internal/api/handler_convoy_dispatch_test.go
@@ -1,14 +1,17 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -1059,4 +1062,35 @@ func (p *incrementingLatestSeqProvider) Watch(context.Context, uint64) (events.W
 
 func (p *incrementingLatestSeqProvider) Close() error {
 	return nil
+}
+
+// Intentionally NOT t.Parallel(): it redirects the global log writer, so it
+// must not run concurrently with any other test that logs or rebinds output.
+func TestLogWorkflowSQLFallbackSurfacesGenuineFailures(t *testing.T) {
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+	})
+
+	// A deployment with no SQL workflow store runs the per-store scan as its
+	// steady state, not a regression — it must stay quiet so the supervisor
+	// does not log on every workflow fetch (gascity#2940).
+	logWorkflowSQLFallback("wf_quiet", nil)
+	logWorkflowSQLFallback("wf_quiet", errNoSQLWorkflowStores)
+	if buf.Len() != 0 {
+		t.Fatalf("benign SQL fallbacks logged, want quiet: %q", buf.String())
+	}
+
+	// A genuine fast-path failure (Dolt unreachable, workflow absent from the
+	// scope's SQL stores, …) is the perf regression operators need to see.
+	logWorkflowSQLFallback("wf_loud", errors.New("dial tcp 127.0.0.1:3306: connection refused"))
+	out := buf.String()
+	if !strings.Contains(out, "wf_loud") || !strings.Contains(out, "connection refused") {
+		t.Fatalf("genuine SQL fast-path failure not surfaced: %q", out)
+	}
 }


### PR DESCRIPTION
Fixes the diagnostic half of #2940.

## Problem

`buildWorkflowSnapshot` (`internal/api/handler_convoy_dispatch.go`) tries an SQL fast path (`tryFullWorkflowSQL`, ~190ms) and falls back to a per-store scan (seconds, growing with rig count) on any error. The fast-path error was **discarded silently** (`if err == nil { return snap, nil }`), so a deployment whose fast path always fails — Dolt unreachable, or a city-scoped query for a rig-stored workflow that the scope's SQL stores don't contain — silently ate the slow scan on **every** workflow fetch, with no signal. (Observed on a live city: `GET /v0/city/<name>/workflow/<id>` taking 2–8s with `stores_scanned` listing all 16 stores.)

## Change

- `buildWorkflowSnapshot` now logs genuine fast-path failures via a new `logWorkflowSQLFallback` before falling back.
- The benign "no SQL stores configured" outcome becomes a sentinel `errNoSQLWorkflowStores` (matched with `errors.Is`) and stays quiet — non-SQL deployments, whose steady state *is* the scan, don't log on every fetch.
- `tryFullWorkflowSQL`'s candidate loop now **retains the first genuine probe error** (Dolt connection / query failure) and returns it when the whole sweep fails, so the surfaced log shows the real cause instead of a synthetic "not found". A clean miss (`ok == false`, no error) is not treated as a failure.

This is intentionally the **diagnostic** half of #2940. Bounding the fallback scan itself (early-exit / scope-restrict) is left out on purpose: it's entangled with `selectWorkflowRootMatch`'s city-on-rig + cross-store-uniqueness semantics and warrants a separate, reviewed change. Surfacing *why* the fast path fails per-deployment is the prerequisite to restoring the 190ms path.

## Tests

`TestLogWorkflowSQLFallbackSurfacesGenuineFailures`: nil and the benign sentinel stay quiet; a genuine error surfaces with the workflow id and underlying cause.

## Verification

`make build` ✅ · `make check` ✅ (full suite, no regressions). Reviewed multi-model (Claude + Codex) — Codex caught that the candidate loop was masking the real probe error behind a synthetic "not found"; fixed in this branch.

Known minor (follow-up): a city-scoped query for a rig-stored workflow logs per-fetch until the candidate-scoping / scan-bounding half lands.