### PR TITLE
feat(supervisor): merge ${GC_HOME}/secrets.env into service env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The supervisor now merges a machine-local secrets file
+  (`${GC_HOME}/secrets.env`, dotenv syntax) into the launchd plist / systemd
+  unit environment on every service-file regeneration. This fixes provider
+  credentials being dropped when `gc start` runs from a shell that did not
+  export them (e.g. at login or after a reboot), which previously caused
+  silent provider auth failures. Only keys already eligible for the supervisor
+  environment are merged (provider credentials plus `GC_SUPERVISOR_ENV`
+  opt-ins); a value exported in the calling shell still takes precedence, and
+  `GC_SUPERVISOR_OMIT_PROVIDER_CREDS=1` suppresses provider credentials from
+  both sources.
 - `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` configures the SQL-mode push wall-clock
   ceiling for `gc dolt sync` (default 1800s, replacing the prior fixed 120s
   that SIGKILLed large first pushes). Metadata queries keep their own 120s

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -822,6 +822,10 @@ var supervisorServiceFixedEnvKeys = map[string]bool{
 func supervisorServiceExtraEnv() []supervisorServiceEnvVar {
 	env := make(map[string]string)
 	explicitEnvKeys := supervisorServiceExplicitEnvKeys(os.Getenv("GC_SUPERVISOR_ENV"))
+	explicitEnvKeySet := make(map[string]bool, len(explicitEnvKeys))
+	for _, key := range explicitEnvKeys {
+		explicitEnvKeySet[key] = true
+	}
 	for _, entry := range os.Environ() {
 		key, val, ok := strings.Cut(entry, "=")
 		if !ok || val == "" || !shouldPersistSupervisorEnv(key) {
@@ -833,6 +837,29 @@ func supervisorServiceExtraEnv() []supervisorServiceEnvVar {
 		if val := os.Getenv(key); val != "" {
 			env[key] = val
 		}
+	}
+	// Merge a persistent machine-local secrets file (${GC_HOME}/secrets.env)
+	// as a fallback tier. `gc start` snapshots the calling shell's env into
+	// the service file, so a credential that lives only in this file and was
+	// never exported into the invoking shell would otherwise be dropped —
+	// yielding a blank value and a silent provider auth failure. A non-empty
+	// value already in env (from the shell scan or a GC_SUPERVISOR_ENV opt-in)
+	// still takes precedence; the file only fills keys those tiers left unset.
+	// As elsewhere in this function, an empty value counts as unset. A file
+	// entry must clear the same gate the other tiers use — the persist
+	// allowlist or an explicit opt-in — so a stray key cannot bloat the
+	// service env.
+	for key, val := range supervisorSecretsEnvFileEntries() {
+		if val == "" {
+			continue
+		}
+		if _, ok := env[key]; ok {
+			continue
+		}
+		if !shouldPersistSupervisorEnv(key) && !explicitEnvKeySet[key] {
+			continue
+		}
+		env[key] = val
 	}
 	// Fall back to `launchctl getenv` for known-allowlisted keys and
 	// for GC_SUPERVISOR_ENV opt-ins. Without this, launchctl-set
@@ -890,6 +917,40 @@ func shouldPersistSupervisorEnv(key string) bool {
 
 func isProviderCredentialEnv(key string) bool {
 	return processenv.IsProviderCredentialEnv(key)
+}
+
+// supervisorSecretsEnvFileName is the dotenv-style file under GC_HOME that
+// supervisorServiceExtraEnv merges as a persistent, machine-local source of
+// provider credentials and other allowlisted service env.
+const supervisorSecretsEnvFileName = "secrets.env"
+
+// supervisorSecretsEnvFilePath returns the absolute path to the supervisor
+// secrets file (${GC_HOME}/secrets.env).
+func supervisorSecretsEnvFilePath() string {
+	return filepath.Join(supervisor.DefaultHome(), supervisorSecretsEnvFileName)
+}
+
+// supervisorSecretsEnvFileEntries reads ${GC_HOME}/secrets.env and returns its
+// parsed key/value pairs. A missing file is the normal case and yields nil. A
+// present-but-unreadable or malformed file is logged to stderr and ignored so
+// a bad secrets file never blocks supervisor install/start; the caller still
+// gates whatever is returned on the persist allowlist or an explicit
+// GC_SUPERVISOR_ENV opt-in.
+func supervisorSecretsEnvFileEntries() map[string]string {
+	path := supervisorSecretsEnvFilePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "gc: reading supervisor secrets file %q: %v\n", path, err)
+		}
+		return nil
+	}
+	entries, err := processenv.ParseEnvFile(string(data))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gc: parsing supervisor secrets file %q: %v\n", path, err)
+		return nil
+	}
+	return entries
 }
 
 func supervisorServiceExplicitEnvKeys(raw string) []string {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -591,6 +591,143 @@ func supervisorServiceEnvMap(vars []supervisorServiceEnvVar) map[string]string {
 	return m
 }
 
+// writeSupervisorSecretsEnvFile writes dotenv content to ${GC_HOME}/secrets.env,
+// creating GC_HOME if needed. GC_HOME must already be set in the environment.
+func writeSupervisorSecretsEnvFile(t *testing.T, content string) {
+	t.Helper()
+	path := supervisorSecretsEnvFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("creating GC_HOME for secrets file: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing secrets file: %v", err)
+	}
+}
+
+// TestBuildSupervisorServiceDataMergesSecretsEnvFile asserts the durable fix
+// for credentials that live only in ${GC_HOME}/secrets.env: with the secret
+// absent from the calling shell, it still reaches the service env. A
+// non-allowlisted key in the file is dropped; a GC_SUPERVISOR_ENV opt-in key
+// present only in the file is honored.
+func TestBuildSupervisorServiceDataMergesSecretsEnvFile(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("GC_SUPERVISOR_ENV", "CUSTOM_PROVIDER_TOKEN")
+	// Ensure the keys are NOT present in the calling shell's environment.
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("CUSTOM_PROVIDER_TOKEN", "")
+	t.Setenv("UNRELATED_SECRET", "")
+
+	writeSupervisorSecretsEnvFile(t, `# machine-local provider secrets
+ANTHROPIC_AUTH_TOKEN=sk-from-file
+CUSTOM_PROVIDER_TOKEN=custom-from-file
+UNRELATED_SECRET=do-not-persist
+`)
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for key, want := range map[string]string{
+		"ANTHROPIC_AUTH_TOKEN":  "sk-from-file",
+		"CUSTOM_PROVIDER_TOKEN": "custom-from-file",
+	} {
+		if got[key] != want {
+			t.Fatalf("ExtraEnv[%s] = %q, want %q (all env: %#v)", key, got[key], want, got)
+		}
+	}
+	if _, ok := got["UNRELATED_SECRET"]; ok {
+		t.Fatalf("ExtraEnv should not include non-allowlisted UNRELATED_SECRET: %#v", got)
+	}
+}
+
+// TestBuildSupervisorServiceDataShellEnvWinsOverSecretsFile asserts the
+// gap-fill precedence: a value exported in the calling shell takes precedence
+// over the same key in ${GC_HOME}/secrets.env.
+func TestBuildSupervisorServiceDataShellEnvWinsOverSecretsFile(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "sk-from-shell")
+
+	writeSupervisorSecretsEnvFile(t, "ANTHROPIC_AUTH_TOKEN=sk-from-file\n")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+
+	if got := supervisorServiceEnvMap(data.ExtraEnv); got["ANTHROPIC_AUTH_TOKEN"] != "sk-from-shell" {
+		t.Fatalf("ExtraEnv[ANTHROPIC_AUTH_TOKEN] = %q, want shell value %q",
+			got["ANTHROPIC_AUTH_TOKEN"], "sk-from-shell")
+	}
+}
+
+// TestBuildSupervisorServiceDataSecretsFileRespectsOmitProviderCreds asserts
+// that the provider-credential opt-out also suppresses provider keys sourced
+// from the secrets file.
+func TestBuildSupervisorServiceDataSecretsFileRespectsOmitProviderCreds(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv(supervisorOmitProviderCredsEnv, "1")
+
+	writeSupervisorSecretsEnvFile(t, "ANTHROPIC_AUTH_TOKEN=sk-from-file\n")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+
+	if _, ok := supervisorServiceEnvMap(data.ExtraEnv)["ANTHROPIC_AUTH_TOKEN"]; ok {
+		t.Fatalf("ExtraEnv should not include provider key from secrets file when %s=1",
+			supervisorOmitProviderCredsEnv)
+	}
+}
+
+// TestBuildSupervisorServiceDataMissingSecretsFileIsNotAnError asserts that the
+// absence of ${GC_HOME}/secrets.env is the normal case and does not fail.
+func TestBuildSupervisorServiceDataMissingSecretsFileIsNotAnError(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+
+	if _, err := buildSupervisorServiceData(); err != nil {
+		t.Fatalf("buildSupervisorServiceData with no secrets file: %v", err)
+	}
+}
+
+// TestBuildSupervisorServiceDataMalformedSecretsFileDegradesGracefully asserts
+// the documented fail-safe: a malformed secrets file does not block service
+// file generation (no error) and contributes no env — the malformed file is
+// ignored rather than partially applied, so the good first line must not leak
+// through.
+func TestBuildSupervisorServiceDataMalformedSecretsFileDegradesGracefully(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+
+	writeSupervisorSecretsEnvFile(t, "ANTHROPIC_AUTH_TOKEN=sk-from-file\nMALFORMED LINE WITHOUT EQUALS\n")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData with malformed secrets file: %v", err)
+	}
+	if _, ok := supervisorServiceEnvMap(data.ExtraEnv)["ANTHROPIC_AUTH_TOKEN"]; ok {
+		t.Fatalf("ExtraEnv should not include any key from a malformed secrets file")
+	}
+}
+
 // TestBuildSupervisorServiceDataForwardsRepresentativeProviderPrefixes asserts
 // that representative provider-prefix credentials are forwarded into the
 // supervisor's persistent env. internal/processenv owns complete allowlist

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -252,6 +252,46 @@ of a clean version string, upgrade to Gas City v0.13.4 or later. This was a
 bug where remote pack fetches wrote git sideband output to the terminal,
 fixed in [PR #141](https://github.com/gastownhall/gascity/pull/141).
 
+## Provider Credentials Dropped When the Supervisor Starts
+
+Symptom: agents authenticate fine when you launch a city from your normal
+interactive shell, but fail to authenticate (or silently fall back to a
+different provider) when the city is started by the supervisor at login or
+after a reboot.
+
+Cause: the supervisor service file (launchd plist / systemd unit) captures
+provider credentials by snapshotting the environment of the shell that ran
+`gc start` (or `gc supervisor install`). A credential that is only present
+in an interactive shell — for example sourced from an rc file that the login
+service manager never reads — is not in that snapshot, so it never reaches
+the supervised process.
+
+Fix: put the durable credentials in a machine-local secrets file at
+`${GC_HOME}/secrets.env` (defaults to `~/.gc/secrets.env`). On every service
+file regeneration, `gc` merges this file into the supervisor environment, so
+the value survives a reboot regardless of which shell ran `gc start`.
+
+```bash
+# ~/.gc/secrets.env  (chmod 600)
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+```
+
+The file uses dotenv syntax: `KEY=VALUE` per line, `#` comments, blank lines,
+an optional `export ` prefix, and optional surrounding quotes. Only keys that
+are already eligible for the supervisor environment are merged — provider
+credentials (recognized by their standard prefixes such as `ANTHROPIC_`,
+`OPENAI_`, `GEMINI_`) plus any keys you opt in via `GC_SUPERVISOR_ENV`; any
+other key in the file is ignored. A value exported in the calling shell still
+takes precedence over the file, and `GC_SUPERVISOR_OMIT_PROVIDER_CREDS=1`
+suppresses provider credentials from both sources.
+
+Apply the change by regenerating the service file:
+
+```bash
+gc service restart     # restarts the launchd/systemd service
+```
+
 ## JSONL Archive Push Failures
 
 The maintenance pack runs `jsonl-export` every 15 minutes to dump each bead

--- a/internal/processenv/envfile.go
+++ b/internal/processenv/envfile.go
@@ -1,0 +1,55 @@
+package processenv
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseEnvFile parses dotenv-style content into a key/value map. The format is
+// the common EnvironmentFile / docker --env-file subset:
+//
+//   - one KEY=VALUE assignment per line;
+//   - blank lines and lines whose first non-space character is '#' are ignored;
+//   - an optional leading "export " prefix on the key is stripped;
+//   - surrounding whitespace around the key and value is trimmed;
+//   - a value fully wrapped in matching single or double quotes is unquoted,
+//     preserving '=' and '#' characters inside the quotes.
+//
+// Values are treated literally otherwise: there is no variable interpolation
+// and no inline-comment stripping on unquoted values (a '#' mid-value is kept).
+// A line missing '=' or with an empty key is a parse error so a malformed
+// secrets file fails loudly rather than silently dropping a credential. The
+// last assignment wins when a key repeats.
+func ParseEnvFile(content string) (map[string]string, error) {
+	out := make(map[string]string)
+	for i, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("line %d: missing '=' in %q", i+1, raw)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("line %d: empty key in %q", i+1, raw)
+		}
+		out[key] = unquoteEnvValue(strings.TrimSpace(val))
+	}
+	return out, nil
+}
+
+// unquoteEnvValue strips one layer of matching surrounding single or double
+// quotes from a trimmed value; otherwise it returns the value unchanged.
+func unquoteEnvValue(val string) string {
+	if len(val) < 2 {
+		return val
+	}
+	first, last := val[0], val[len(val)-1]
+	if (first == '"' || first == '\'') && last == first {
+		return val[1 : len(val)-1]
+	}
+	return val
+}

--- a/internal/processenv/envfile_test.go
+++ b/internal/processenv/envfile_test.go
@@ -1,0 +1,70 @@
+package processenv
+
+import "testing"
+
+func TestParseEnvFileParsesCoreSyntax(t *testing.T) {
+	content := `# leading comment
+ANTHROPIC_AUTH_TOKEN=sk-live-123
+
+export OPENAI_API_KEY=sk-openai-456
+GC_DOLT_PASSWORD = secret with spaces
+QUOTED_DOUBLE="value with = and # inside"
+QUOTED_SINGLE='single value'
+   # indented comment
+EMPTY_VALUE=
+TRAILING_INLINE=keep#notacomment
+`
+	got, err := ParseEnvFile(content)
+	if err != nil {
+		t.Fatalf("ParseEnvFile returned error: %v", err)
+	}
+	want := map[string]string{
+		"ANTHROPIC_AUTH_TOKEN": "sk-live-123",
+		"OPENAI_API_KEY":       "sk-openai-456",
+		"GC_DOLT_PASSWORD":     "secret with spaces",
+		"QUOTED_DOUBLE":        "value with = and # inside",
+		"QUOTED_SINGLE":        "single value",
+		"EMPTY_VALUE":          "",
+		"TRAILING_INLINE":      "keep#notacomment",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ParseEnvFile returned %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for key, wantVal := range want {
+		if got[key] != wantVal {
+			t.Errorf("ParseEnvFile()[%q] = %q, want %q", key, got[key], wantVal)
+		}
+	}
+}
+
+func TestParseEnvFileEmptyContentReturnsEmptyMap(t *testing.T) {
+	got, err := ParseEnvFile("")
+	if err != nil {
+		t.Fatalf("ParseEnvFile returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ParseEnvFile(\"\") = %v, want empty map", got)
+	}
+}
+
+func TestParseEnvFileRejectsMalformedLines(t *testing.T) {
+	for name, content := range map[string]string{
+		"missing equals":       "ANTHROPIC_AUTH_TOKEN sk-live-123",
+		"empty key":            "=value",
+		"empty key after trim": "   =value",
+	} {
+		if _, err := ParseEnvFile(content); err == nil {
+			t.Errorf("ParseEnvFile(%s) = nil error, want error", name)
+		}
+	}
+}
+
+func TestParseEnvFileLastDuplicateWins(t *testing.T) {
+	got, err := ParseEnvFile("KEY=first\nKEY=second\n")
+	if err != nil {
+		t.Fatalf("ParseEnvFile returned error: %v", err)
+	}
+	if got["KEY"] != "second" {
+		t.Errorf("ParseEnvFile duplicate KEY = %q, want %q", got["KEY"], "second")
+	}
+}


### PR DESCRIPTION
## Problem

`gc start` / `gc supervisor install` build the launchd plist / systemd unit's
environment by snapshotting the environment of the shell that invoked them. A
provider credential that lives in a persistent machine-local source but was
never exported into the invoking shell — for example when the supervisor is
(re)started at login or after a reboot by the OS service manager rather than
from an interactive shell that sourced an rc file — is absent from that
snapshot. The supervised process then runs with a blank/missing token, which
surfaces as a provider authentication failure (or a silent fall-back to a
different provider) that does not reproduce when the same city is launched by
hand.

## Fix

Add an `EnvironmentFile`-style fallback tier. On every service-file
regeneration, the supervisor merges `${GC_HOME}/secrets.env` (defaults to
`~/.gc/secrets.env`) into the service environment.

- **Bounded by the existing allowlist.** Only keys already eligible for the
  supervisor environment are merged: provider credentials (recognized by their
  standard prefixes, e.g. `ANTHROPIC_`, `OPENAI_`, `GEMINI_`) plus any keys
  opted in via `GC_SUPERVISOR_ENV`. Any other key in the file is ignored, so a
  stray entry cannot bloat the service env.
- **Gap-fill precedence.** A value exported in the calling shell still takes
  precedence over the file; the file only fills keys the shell did not provide.
  Existing behavior is unchanged when the credential is already in the shell.
- **Opt-out honored.** `GC_SUPERVISOR_OMIT_PROVIDER_CREDS=1` suppresses
  provider credentials from the file as well as the shell.
- **Fail-safe I/O.** A missing file is the normal case (no error). A
  present-but-unreadable or malformed file is logged to stderr and ignored so a
  bad secrets file never blocks supervisor install/start.

The file uses the common dotenv subset (`KEY=VALUE` per line, `#` comments,
blank lines, optional `export ` prefix, optional surrounding quotes), parsed by
a new provider-agnostic `processenv.ParseEnvFile`.

## Tests

- `processenv.ParseEnvFile`: core syntax, quoting, empty/duplicate keys,
  malformed-line errors.
- `buildSupervisorServiceData`: a secret present only in the file reaches the
  service env; shell value wins over the file; `GC_SUPERVISOR_OMIT_PROVIDER_CREDS`
  suppresses file-sourced provider creds; a missing file is not an error.

Docs: new troubleshooting section plus a CHANGELOG entry.