### PR TITLE
fix(beads): invalidate stale cached rows after live list

### DIFF
--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -174,6 +174,51 @@ func TestCachingStoreListLiveBypassesCache(t *testing.T) {
 	}
 }
 
+func TestCachingStoreListLiveInvalidatesCachedRowsMissingFromBacking(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{
+		Title:    "work",
+		Assignee: "worker",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if err := backing.Close(bead.ID); err != nil {
+		t.Fatalf("Close backing: %v", err)
+	}
+
+	live, err := cache.List(ListQuery{Status: "open", Assignee: "worker", Live: true})
+	if err != nil {
+		t.Fatalf("List live: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("Live List(open) = %+v, want closed bead omitted", live)
+	}
+
+	cached, err := cache.Handles().Cached.List(ListQuery{Status: "open", Assignee: "worker"})
+	if err != nil {
+		t.Fatalf("Cached List(open): %v", err)
+	}
+	if len(cached) != 0 {
+		t.Fatalf("Cached List(open) after live refresh = %+v, want stale bead invalidated", cached)
+	}
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("Get status after live refresh = %q, want closed", got.Status)
+	}
+}
+
 func TestCachingStoreHandlesCachedReadsShareFullPrime(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -132,6 +132,8 @@ func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
 func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, items []Bead) []Bead {
 	refreshedParents := make(map[string]Bead)
 	removedParents := make(map[string]struct{})
+	refreshedLiveMissing := make(map[string]Bead)
+	removedLiveMissing := make(map[string]struct{})
 	for _, id := range c.staleParentCacheIDs(query.ParentID, items) {
 		fresh, err := c.backing.Get(id)
 		switch {
@@ -143,7 +145,19 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 			c.recordProblem("refresh parent cache during list", fmt.Errorf("%s: %w", id, err))
 		}
 	}
-	if len(items) == 0 && len(refreshedParents) == 0 && len(removedParents) == 0 {
+	for _, id := range c.staleLiveCacheIDs(query, items) {
+		fresh, err := c.backing.Get(id)
+		switch {
+		case err == nil:
+			refreshedLiveMissing[id] = cloneBead(fresh)
+		case errors.Is(err, ErrNotFound):
+			removedLiveMissing[id] = struct{}{}
+		default:
+			c.recordProblem("refresh live cache during list", fmt.Errorf("%s: %w", id, err))
+		}
+	}
+	if len(items) == 0 && len(refreshedParents) == 0 && len(removedParents) == 0 &&
+		len(refreshedLiveMissing) == 0 && len(removedLiveMissing) == 0 {
 		return items
 	}
 	c.mu.Lock()
@@ -222,6 +236,30 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 		delete(c.beadSeq, id)
 		delete(c.localBeadAt, id)
 	}
+	for id, bead := range refreshedLiveMissing {
+		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
+			continue
+		}
+		c.beads[id] = bead
+		if beadCarriesDependencyFields(bead) {
+			c.deps[id] = depsFromBeadFields(bead)
+		}
+		delete(c.dirty, id)
+		delete(c.deletedSeq, id)
+		delete(c.beadSeq, id)
+		delete(c.localBeadAt, id)
+	}
+	for id := range removedLiveMissing {
+		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
+			continue
+		}
+		delete(c.beads, id)
+		delete(c.deps, id)
+		delete(c.dirty, id)
+		delete(c.deletedSeq, id)
+		delete(c.beadSeq, id)
+		delete(c.localBeadAt, id)
+	}
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	return refreshed
@@ -249,6 +287,35 @@ func (c *CachingStore) staleParentCacheIDs(parentID string, fresh []Bead) []stri
 			continue
 		}
 		if _, ok := freshIDs[id]; ok {
+			continue
+		}
+		stale = append(stale, id)
+	}
+	return stale
+}
+
+func (c *CachingStore) staleLiveCacheIDs(query ListQuery, fresh []Bead) []string {
+	if !query.Live || query.Limit > 0 || query.IncludesClosed() {
+		return nil
+	}
+
+	freshIDs := make(map[string]struct{}, len(fresh))
+	for _, item := range fresh {
+		freshIDs[item.ID] = struct{}{}
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return nil
+	}
+
+	var stale []string
+	for id, bead := range c.beads {
+		if _, ok := freshIDs[id]; ok {
+			continue
+		}
+		if !query.Matches(bead) {
 			continue
 		}
 		stale = append(stale, id)


### PR DESCRIPTION
## Summary

Fixes a cache invariant break in `CachingStore.List(... Live: true)`: a successful complete live active query could return the correct backing result while leaving cached rows that previously matched the query untouched when they were absent from the backing result.

That means this sequence was possible:

1. cache has bead `X` as `open`
2. backing store closes `X`
3. `List(Status:"open", Live:true)` returns no rows, correctly
4. the cache still returns `X` as `open` through `Cached.List` / `Get`

This is the root cause for seeing active/open bead state after a live close check. It also explains why workflow/reconciler-level patches were not enough: the stale state was being reintroduced by the shared bead cache read model.

## Fix

After a successful unbounded active `Live` list, find cached rows that matched the query but were missing from the backing result. Re-fetch those rows by ID:

- if backing returns the bead, update the cache to that authoritative state, including `closed`
- if backing reports not found, remove it from the cache
- if a newer local mutation happened after the live query started, keep the local mutation

The existing stale-event protections for returned live rows are preserved.

This is separate from #2931, which handles dropped field events in `caching_store_events.go`; this PR fixes successful live list cache invalidation in `caching_store_reads.go`.

## Verification

- New regression test was red before the fix and green after:
  `TestCachingStoreListLiveInvalidatesCachedRowsMissingFromBacking`
- `go test ./internal/beads -run 'TestCachingStoreListLiveInvalidatesCachedRowsMissingFromBacking|TestCachingStoreLiveListDoesNotOverwriteLocalCloseWithStaleActiveRow|TestCachingStoreLocalWriteIgnoresDelayedStaleEventAfterLiveRefresh|TestCachingStoreLiveListDoesNotOverwriteRecentLocalWriteWithStaleBackingRows' -count=1`
- `go test ./internal/beads -count=1`
- `go test ./cmd/gc -run 'TestCollectAssignedWorkBeads|TestLoadSessionBeadSnapshot' -count=1`
- `.githooks/pre-commit` via commit hook: lint-changed, generated artifacts, `go vet ./...`, `make test-fast-parallel`

Note: a manual full `go test ./cmd/gc -count=1` was stopped after ~3 minutes with no failure output; the sharded fast suite from pre-commit completed successfully.
