### PR TITLE
fix(workflow): use live bead reads for source workflow lifecycle

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1580,7 +1580,7 @@ func countOpenMatchedBeads(matches []sourceWorkflowStoreMatch) (int, error) {
 	open := 0
 	for _, match := range matches {
 		for _, bead := range match.beads {
-			current, err := match.store.Get(bead.ID)
+			current, err := beads.HandlesFor(match.store).Live.Get(bead.ID)
 			if err != nil {
 				if errors.Is(err, beads.ErrNotFound) {
 					continue
@@ -1768,12 +1768,12 @@ func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {
 		rootIDs = append(rootIDs, root.ID)
 		addBead(root)
 	}
-	if root, err := store.Get(workflowID); err == nil {
+	if root, err := beads.HandlesFor(store).Live.Get(workflowID); err == nil {
 		addRoot(root)
 	}
 	// Query on gc.workflow_id only; the predicate is applied in-memory via
 	// addRoot so we pick up graph.v2-only roots alongside legacy roots.
-	if roots, err := store.List(beads.ListQuery{
+	if roots, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
 		Metadata: map[string]string{
 			"gc.workflow_id": workflowID,
 		},
@@ -1784,7 +1784,7 @@ func findWorkflowBeads(store beads.Store, workflowID string) []beads.Bead {
 		}
 	}
 	for _, rootID := range rootIDs {
-		all, err := store.List(beads.ListQuery{
+		all, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
 			Metadata:      map[string]string{"gc.root_bead_id": rootID},
 			IncludeClosed: true,
 		})

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -148,7 +148,7 @@ func closeOrphanedControl(store beads.Store, bead beads.Bead, opts ProcessOption
 	if rootID == "" || rootStoreRef == "" || rootID == bead.ID {
 		return ControlResult{}, false, nil
 	}
-	if _, err := store.Get(rootID); err == nil {
+	if _, err := beads.HandlesFor(store).Live.Get(rootID); err == nil {
 		return ControlResult{}, false, nil
 	} else if !errors.Is(err, beads.ErrNotFound) {
 		return ControlResult{}, false, fmt.Errorf("%s: loading workflow root %s: %w", bead.ID, rootID, err)
@@ -719,7 +719,7 @@ func walkSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptio
 	resolvedStores := make(map[string]beads.Store)
 	visited := make(map[string]bool)
 	for hop := 0; hop < maxSourceChainHops; hop++ {
-		current, err := currentStore.Get(currentID)
+		current, err := beads.HandlesFor(currentStore).Live.Get(currentID)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				opts.tracef("close-source-chain root=%s stop reason=deleted_current at_id=%s ref=%s", rootID, currentID, sourceChainStoreLabel(currentRef))
@@ -767,7 +767,7 @@ func walkSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptio
 
 		var stopWalk bool
 		loadAndClose := func() error {
-			loaded, err := nextStore.Get(nextID)
+			loaded, err := beads.HandlesFor(nextStore).Live.Get(nextID)
 			if err != nil {
 				if errors.Is(err, beads.ErrNotFound) {
 					opts.tracef("close-source-chain root=%s stop reason=deleted_parent source=%s ref=%s", rootID, nextID, sourceChainStoreLabel(effectiveRef))
@@ -1290,7 +1290,7 @@ func listByWorkflowRoot(store beads.Store, rootID string) ([]beads.Bead, error) 
 
 	result := make([]beads.Bead, 0, len(all)+1)
 	seen := make(map[string]bool, len(all)+1)
-	if root, err := store.Get(rootID); err == nil {
+	if root, err := beads.HandlesFor(store).Live.Get(rootID); err == nil {
 		result = append(result, root)
 		seen[root.ID] = true
 	} else if !errors.Is(err, beads.ErrNotFound) {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -1913,6 +1913,63 @@ func sourceChainFixtureStores(f sourceChainFinalizeFixture) func() ([]SourceWork
 	}
 }
 
+func TestCloseSourceBeadChainUsesLiveSourceState(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	cityCache := beads.NewCachingStoreForTest(f.cityStore, nil)
+	rigCache := beads.NewCachingStoreForTest(f.rigStore, nil)
+	if err := cityCache.PrimeActive(); err != nil {
+		t.Fatalf("city PrimeActive: %v", err)
+	}
+	if err := rigCache.PrimeActive(); err != nil {
+		t.Fatalf("rig PrimeActive: %v", err)
+	}
+	if err := f.rigStore.Close(f.rigLaunch.ID); err != nil {
+		t.Fatalf("Close(rig launch): %v", err)
+	}
+	if err := f.cityStore.Close(f.citySource.ID); err != nil {
+		t.Fatalf("Close(city source): %v", err)
+	}
+
+	resolver := func(ref string) (beads.Store, error) {
+		switch ref {
+		case "city:test":
+			return cityCache, nil
+		case "rig:test":
+			return rigCache, nil
+		default:
+			return nil, fmt.Errorf("unknown store ref: %s", ref)
+		}
+	}
+	var trace bytes.Buffer
+	if err := closeSourceBeadChain(rigCache, f.workflow.ID, ProcessOptions{
+		ResolveStoreRef: resolver,
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{
+				{Store: cityCache, StoreRef: "city:test"},
+				{Store: rigCache, StoreRef: "rig:test"},
+			}, nil
+		},
+		Tracef: func(format string, args ...any) {
+			fmt.Fprintf(&trace, format+"\n", args...) //nolint:errcheck // test buffer
+		},
+	}); err != nil {
+		t.Fatalf("closeSourceBeadChain: %v", err)
+	}
+
+	traceText := trace.String()
+	for _, sourceID := range []string{f.rigLaunch.ID, f.citySource.ID} {
+		want := "skip reason=already_closed source=" + sourceID
+		if !strings.Contains(traceText, want) {
+			t.Fatalf("trace missing %q:\n%s", want, traceText)
+		}
+	}
+	if strings.Contains(traceText, " closed source=") {
+		t.Fatalf("trace shows stale close instead of already_closed skip:\n%s", traceText)
+	}
+}
+
 func TestProcessWorkflowFinalizeRetriesWhenSourceStoreResolverFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -768,7 +768,7 @@ func withSourceWorkflowLaunchLock(ctx context.Context, deps SlingDeps, sourceBea
 	var result SlingResult
 	err := sourceworkflow.WithLock(ctx, deps.CityPath, sourceWorkflowLockScope(deps), sourceBeadID, func() error {
 		previousWorkflowID := ""
-		sourceBead, err := deps.Store.Get(sourceBeadID)
+		sourceBead, err := beads.HandlesFor(deps.Store).Live.Get(sourceBeadID)
 		if err != nil && !errors.Is(err, beads.ErrNotFound) {
 			return fmt.Errorf("get source bead %s: %w", sourceBeadID, err)
 		}
@@ -962,7 +962,7 @@ func sourceWorkflowRootByIDInStore(store beads.Store, sourceBeadID, workflowID, 
 	if store == nil {
 		return sourceWorkflowRoot{}, false, "not_found", nil
 	}
-	root, err := store.Get(workflowID)
+	root, err := beads.HandlesFor(store).Live.Get(workflowID)
 	if err != nil {
 		if errors.Is(err, beads.ErrNotFound) {
 			return sourceWorkflowRoot{}, false, "not_found", nil

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2277,6 +2277,39 @@ func TestRollbackGraphV2ReplacementLaunchRestoresReplacedRoot(t *testing.T) {
 	}
 }
 
+func TestSourceWorkflowRootByIDInStoreUsesLiveRootState(t *testing.T) {
+	backing := beads.NewMemStore()
+	root, err := backing.Create(beads.Bead{
+		Title:  "previous graph root",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.formula_contract":                    "graph.v2",
+			"gc.source_bead_id":                      "BL-42",
+			sourceworkflow.SourceStoreRefMetadataKey: "city:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if err := backing.Close(root.ID); err != nil {
+		t.Fatalf("Close(root): %v", err)
+	}
+
+	_, ok, reason, err := sourceWorkflowRootByIDInStore(cache, "BL-42", root.ID, "city:test", "city:test")
+	if err != nil {
+		t.Fatalf("sourceWorkflowRootByIDInStore: %v", err)
+	}
+	if ok || reason != "closed" {
+		t.Fatalf("sourceWorkflowRootByIDInStore ok=%t reason=%q, want closed root to be non-live", ok, reason)
+	}
+}
+
 func TestDoSlingDefaultGraphFormulaAllowsDifferentLiveBareBeadRoots(t *testing.T) {
 	formulaDir := t.TempDir()
 	writeNamedGraphV2ConvoyFormula(t, formulaDir, "graph-a")

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -358,7 +358,7 @@ func ListWorkflowBeads(store beads.Store, rootID string) ([]beads.Bead, error) {
 	if store == nil || rootID == "" {
 		return nil, nil
 	}
-	root, err := store.Get(rootID)
+	root, err := beads.HandlesFor(store).Live.Get(rootID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -313,6 +313,55 @@ func TestListLiveRootsTreatsLegacyRootAsStoreScoped(t *testing.T) {
 	}
 }
 
+func TestListWorkflowBeadsUsesLiveRootState(t *testing.T) {
+	backing := beads.NewMemStore()
+	root, err := backing.Create(beads.Bead{
+		Title:  "workflow root",
+		Type:   "task",
+		Status: "in_progress",
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := backing.Create(beads.Bead{
+		Title:    "workflow child",
+		Type:     "task",
+		Status:   "open",
+		ParentID: root.ID,
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if err := backing.Close(root.ID); err != nil {
+		t.Fatalf("Close(root): %v", err)
+	}
+	if err := backing.Close(child.ID); err != nil {
+		t.Fatalf("Close(child): %v", err)
+	}
+
+	workflowBeads, err := ListWorkflowBeads(cache, root.ID)
+	if err != nil {
+		t.Fatalf("ListWorkflowBeads: %v", err)
+	}
+	statusByID := map[string]string{}
+	for _, bead := range workflowBeads {
+		statusByID[bead.ID] = bead.Status
+	}
+	if statusByID[root.ID] != "closed" {
+		t.Fatalf("root status = %q, want closed from live backing store", statusByID[root.ID])
+	}
+	if statusByID[child.ID] != "closed" {
+		t.Fatalf("child status = %q, want closed from live backing store", statusByID[child.ID])
+	}
+}
+
 type parentLastCloseStore struct {
 	*beads.MemStore
 }


### PR DESCRIPTION
## Summary
- use explicit live bead reads for source-workflow tree roots, singleton previous-root checks, source-chain finalization, and workflow delete-source verification
- add regressions for cached-open rows after backing close in sourceworkflow, sling, and dispatch finalizer paths

## RCA
The bug was not that live list results needed to mutate the cache. The invariant break was that lifecycle code still used default `store.Get` after cached/live handles were introduced. With a `CachingStore`, `store.Get` can return an active cached row even after the backing store has closed it, so finalizers and singleton checks could treat closed workflow/source beads as open.

## Tests
- `go test ./internal/sourceworkflow ./internal/sling ./internal/dispatch -run 'TestListWorkflowBeadsUsesLiveRootState|TestSourceWorkflowRootByIDInStoreUsesLiveRootState|TestCloseSourceBeadChainUsesLiveSourceState' -count=1`\n- `go test ./internal/sourceworkflow ./internal/sling ./internal/dispatch -count=1`\n- `go test ./cmd/gc -run 'TestCmdWorkflowDeleteSource|TestCmdWorkflowReopenSource|TestRunWorkflowServeProcessesReadyControlBeadsThenExits|TestProcessWorkflowFinalize' -count=1`\n- `.githooks/pre-commit`