### PR TITLE
feat(reconciler): gate pool respawn on provider health

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -87,6 +87,12 @@ type agentBuildParams struct {
 	// etc.). Used by the skill materialization integration to decide
 	// stage-2 eligibility.
 	sessionProvider string
+
+	// providerHealth is the per-provider health snapshot read once at the
+	// start of this build. The pool fresh-create path consults it to defer
+	// respawning a session onto a provider that is currently unhealthy
+	// (gate-on-green). Nil/empty means all providers healthy (fail-open).
+	providerHealth providerHealthSnapshot
 }
 
 // newAgentBuildParams constructs agentBuildParams from the common startup values.
@@ -116,6 +122,14 @@ func newAgentBuildParams(cityName, cityPath string, cfg *config.City, sp runtime
 	}
 	if store != nil {
 		params.poolSessionCreateBudget = newPoolSessionCreateBudget(cfg.Daemon.MaxWakesPerTickOrDefault())
+		// Provider health is fail-open: loadProviderHealthSnapshot returns an
+		// all-healthy snapshot even on read error, so a failing signal can
+		// never wedge respawns. Log the error but use the snapshot regardless.
+		snap, err := loadProviderHealthSnapshot(store)
+		if err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "buildDesiredState: provider-health read failed: %v (treating all providers healthy)\n", err) //nolint:errcheck // best-effort stderr
+		}
+		params.providerHealth = snap
 	}
 	// Load the shared skill catalog once per build cycle. Transient load
 	// failures (filesystem race during dolt sync / heavy I/O) used to

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1992,6 +1992,11 @@ func realizePoolDesiredSessions(
 				// provider unhealthy owns clearing it; until then the demand
 				// stays queued and is materialized on a later tick once healthy.
 				if provider := agentProviderName(bp.city, cfgAgent); !bp.providerHealth.healthy(provider) {
+					// selectOrPlanPoolSessionBead already reserved a fresh-create
+					// budget slot for this plan. Release it on the deferral so a
+					// gated (unhealthy) pool does not consume the tick's create
+					// budget and starve other, healthy pools of their fair share.
+					bp.releasePoolSessionCreate()
 					fmt.Fprintf(stderr, "buildDesiredState: pool %q: provider %q unhealthy; deferring fresh session create\n", qualifiedName, provider) //nolint:errcheck // best-effort stderr
 					item.skip = true
 					return item

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1984,6 +1984,18 @@ func realizePoolDesiredSessions(
 				return item
 			}
 			if plan != nil {
+				// Gate-on-green: defer a fresh respawn when this agent's
+				// provider is currently unhealthy. Existing-session reuse (the
+				// branch below) is untouched — only brand-new creates are held
+				// back, so a provider outage cannot trigger a respawn storm into
+				// a provider that cannot serve. The consumer that marked the
+				// provider unhealthy owns clearing it; until then the demand
+				// stays queued and is materialized on a later tick once healthy.
+				if provider := agentProviderName(bp.city, cfgAgent); !bp.providerHealth.healthy(provider) {
+					fmt.Fprintf(stderr, "buildDesiredState: pool %q: provider %q unhealthy; deferring fresh session create\n", qualifiedName, provider) //nolint:errcheck // best-effort stderr
+					item.skip = true
+					return item
+				}
 				item.plan = plan
 				item.slot = plan.poolSlot
 				return item

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3340,6 +3340,84 @@ func TestRealizePoolDesiredSessionsLimitsFreshCreatesToWakeBudget(t *testing.T) 
 	}
 }
 
+func TestRealizePoolDesiredSessionsGatesFreshCreatesOnUnhealthyProvider(t *testing.T) {
+	store := beads.NewMemStore()
+	// The consumer layer marks the agent's provider unhealthy by writing a
+	// provider-health bead. The reconciler must then defer fresh respawns.
+	if _, err := store.Create(beads.Bead{
+		Title:  "provider health",
+		Status: "open",
+		Labels: []string{providerHealthLabel},
+		Metadata: map[string]string{
+			providerHealthProviderKey: "claude",
+			providerHealthStatusKey:   providerHealthStatusUnhealthy,
+		},
+	}); err != nil {
+		t.Fatalf("seed health bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Provider:          "claude",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	var stderr bytes.Buffer
+	bp := newAgentBuildParams("test-city", t.TempDir(), cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+	bp.sessionBeads = &sessionBeadSnapshot{}
+	desired := map[string]TemplateParams{}
+
+	realizePoolDesiredSessions(bp, &cfg.Agents[0], PoolDesiredState{
+		Template: "worker",
+		Requests: []SessionRequest{{Template: "worker", Tier: "new"}, {Template: "worker", Tier: "new"}},
+	}, desired, &stderr)
+
+	if got := len(bp.sessionBeads.Open()); got != 0 {
+		t.Fatalf("unhealthy provider should defer all fresh creates, got %d; stderr=%q", got, stderr.String())
+	}
+	if got := len(desired); got != 0 {
+		t.Fatalf("unhealthy provider should yield no desired sessions, got %d", got)
+	}
+	if !strings.Contains(stderr.String(), "unhealthy; deferring fresh session create") {
+		t.Fatalf("stderr = %q, want unhealthy-defer diagnostic", stderr.String())
+	}
+}
+
+func TestRealizePoolDesiredSessionsAllowsFreshCreatesWhenProviderHealthy(t *testing.T) {
+	// No provider-health bead: the provider is healthy (fail-open), so fresh
+	// creates proceed exactly as they would without the gate.
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Provider:          "claude",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	var stderr bytes.Buffer
+	bp := newAgentBuildParams("test-city", t.TempDir(), cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+	bp.sessionBeads = &sessionBeadSnapshot{}
+	desired := map[string]TemplateParams{}
+
+	realizePoolDesiredSessions(bp, &cfg.Agents[0], PoolDesiredState{
+		Template: "worker",
+		Requests: []SessionRequest{{Template: "worker", Tier: "new"}, {Template: "worker", Tier: "new"}},
+	}, desired, &stderr)
+
+	if got := len(desired); got != 2 {
+		t.Fatalf("healthy provider should create both fresh sessions, got %d; stderr=%q", got, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "deferring fresh session create") {
+		t.Fatalf("healthy provider should not log a defer; stderr=%q", stderr.String())
+	}
+}
+
 func TestRealizePoolDesiredSessionsBudgetExhaustionStillAllowsLaterReuse(t *testing.T) {
 	maxWakes := 1
 	store := beads.NewMemStore()

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3418,6 +3418,55 @@ func TestRealizePoolDesiredSessionsAllowsFreshCreatesWhenProviderHealthy(t *test
 	}
 }
 
+func TestRealizePoolDesiredSessionsReleasesBudgetWhenProviderUnhealthy(t *testing.T) {
+	// With a single create slot this tick, gating alpha (unhealthy provider)
+	// must RELEASE its reserved slot so zulu (healthy) still gets created. If
+	// the gate leaked the budget, zulu would be starved and desired would be
+	// empty.
+	maxWakes := 1
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Status: "open",
+		Labels: []string{providerHealthLabel},
+		Metadata: map[string]string{
+			providerHealthProviderKey: "down-prov",
+			providerHealthStatusKey:   providerHealthStatusUnhealthy,
+		},
+	}); err != nil {
+		t.Fatalf("seed health bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Daemon:    config.DaemonConfig{MaxWakesPerTick: &maxWakes},
+		Agents: []config.Agent{
+			{Name: "alpha", Provider: "down-prov", StartCommand: "true", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(10)},
+			{Name: "zulu", Provider: "up-prov", StartCommand: "true", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(10)},
+		},
+	}
+	var stderr bytes.Buffer
+	bp := newAgentBuildParams("test-city", t.TempDir(), cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+	bp.sessionBeads = &sessionBeadSnapshot{}
+	desired := map[string]TemplateParams{}
+
+	realizePoolDesiredSessions(bp, &cfg.Agents[0], PoolDesiredState{
+		Template: "alpha",
+		Requests: []SessionRequest{{Template: "alpha", Tier: "new"}},
+	}, desired, &stderr)
+	realizePoolDesiredSessions(bp, &cfg.Agents[1], PoolDesiredState{
+		Template: "zulu",
+		Requests: []SessionRequest{{Template: "zulu", Tier: "new"}},
+	}, desired, &stderr)
+
+	if got := len(desired); got != 1 {
+		t.Fatalf("desired sessions = %d, want zulu created after alpha's gated slot was released; desired=%v stderr=%q", got, desired, stderr.String())
+	}
+	for _, tp := range desired {
+		if tp.TemplateName != "zulu" {
+			t.Fatalf("created template = %q, want zulu; stderr=%q", tp.TemplateName, stderr.String())
+		}
+	}
+}
+
 func TestRealizePoolDesiredSessionsBudgetExhaustionStillAllowsLaterReuse(t *testing.T) {
 	maxWakes := 1
 	store := beads.NewMemStore()

--- a/cmd/gc/provider_health.go
+++ b/cmd/gc/provider_health.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"sort"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// Provider-health is a generic, bead-backed signal that lets the reconciler
+// avoid respawning sessions onto a provider that is currently unable to serve
+// requests (for example, a provider whose credentials have been revoked). The
+// SDK does NOT detect provider health itself — detection is provider-specific
+// and belongs to the consumer layer, which publishes health by writing a
+// provider-health bead through the normal bead API. The reconciler only reads
+// that bead and gates fresh respawns on it. This keeps all provider-specific
+// behavior out of the SDK while still letting the controller protect the fleet
+// from a thundering respawn into a dead provider.
+//
+// Contract (consumer-written, SDK-read):
+//   - Label:    providerHealthLabel on every provider-health bead.
+//   - Metadata: providerHealthProviderKey = the provider name (matching the
+//     agent's configured provider), providerHealthStatusKey = one of
+//     providerHealthStatusHealthy / providerHealthStatusUnhealthy.
+//   - A bead whose status is closed is treated as resolved (healthy again).
+//
+// The signal is fail-open: a provider is considered unhealthy ONLY when an open
+// bead positively marks it so. Unknown providers, an empty store, or a read
+// error all resolve to healthy, so a missing or misconfigured signal can never
+// wedge respawns.
+const (
+	providerHealthLabel           = "gc.provider-health"
+	providerHealthProviderKey     = "gc.provider"
+	providerHealthStatusKey       = "gc.health"
+	providerHealthStatusHealthy   = "healthy"
+	providerHealthStatusUnhealthy = "unhealthy"
+)
+
+// providerHealthLister is the narrow slice of beads.Store that the
+// provider-health snapshot needs. Narrowing the dependency keeps the loader
+// trivially testable with a stub and documents that it only reads.
+type providerHealthLister interface {
+	ListByLabel(label string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error)
+}
+
+// providerHealthSnapshot maps a provider name to its current health. A provider
+// absent from the map is healthy (fail-open); see loadProviderHealthSnapshot.
+type providerHealthSnapshot map[string]bool
+
+// healthy reports whether sessions may be respawned onto the named provider.
+// The empty provider name and any provider with no recorded signal are healthy,
+// so the gate only ever blocks providers positively marked unhealthy.
+func (s providerHealthSnapshot) healthy(provider string) bool {
+	if provider == "" {
+		return true
+	}
+	h, ok := s[provider]
+	if !ok {
+		return true
+	}
+	return h
+}
+
+// loadProviderHealthSnapshot reads every provider-health bead once and projects
+// the latest state per provider. When multiple beads exist for one provider the
+// most recently updated wins (falling back to creation time), matching the
+// consumer overwriting a single per-provider bead as health flips. A nil lister
+// or a read error yields an all-healthy snapshot so respawns are never wedged by
+// a missing or failing signal.
+func loadProviderHealthSnapshot(lister providerHealthLister) (providerHealthSnapshot, error) {
+	snap := providerHealthSnapshot{}
+	if lister == nil {
+		return snap, nil
+	}
+	healthBeads, err := lister.ListByLabel(providerHealthLabel, 0)
+	if err != nil {
+		return snap, err
+	}
+	// Newest-first so the first bead seen for each provider is authoritative.
+	sort.SliceStable(healthBeads, func(i, j int) bool {
+		return providerHealthBeadTime(healthBeads[i]).After(providerHealthBeadTime(healthBeads[j]))
+	})
+	for i := range healthBeads {
+		bead := healthBeads[i]
+		provider := bead.Metadata[providerHealthProviderKey]
+		if provider == "" {
+			continue
+		}
+		if _, seen := snap[provider]; seen {
+			continue
+		}
+		// A closed bead means the consumer resolved the condition: healthy.
+		unhealthy := bead.Status != "closed" &&
+			bead.Metadata[providerHealthStatusKey] == providerHealthStatusUnhealthy
+		snap[provider] = !unhealthy
+	}
+	return snap, nil
+}
+
+// providerHealthBeadTime returns the bead's most recent timestamp for ordering,
+// falling back to CreatedAt when UpdatedAt is zero (legacy beads).
+func providerHealthBeadTime(b beads.Bead) time.Time {
+	if !b.UpdatedAt.IsZero() {
+		return b.UpdatedAt
+	}
+	return b.CreatedAt
+}

--- a/cmd/gc/provider_health.go
+++ b/cmd/gc/provider_health.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // Provider-health is a generic, bead-backed signal that lets the reconciler
@@ -104,4 +105,28 @@ func providerHealthBeadTime(b beads.Bead) time.Time {
 		return b.UpdatedAt
 	}
 	return b.CreatedAt
+}
+
+// agentProviderName returns the provider preset an agent resolves to,
+// following config precedence: the agent's own provider, then its pack-inherited
+// default, then the city-level [agent_defaults] and [workspace] defaults. The
+// result is the key the provider-health snapshot is consulted with. Empty when
+// no provider is configured anywhere, in which case the health gate is a no-op
+// (fail-open).
+func agentProviderName(cfg *config.City, a *config.Agent) string {
+	if a != nil {
+		if a.Provider != "" {
+			return a.Provider
+		}
+		if a.InheritedProvider != "" {
+			return a.InheritedProvider
+		}
+	}
+	if cfg != nil {
+		if cfg.AgentDefaults.Provider != "" {
+			return cfg.AgentDefaults.Provider
+		}
+		return cfg.Workspace.Provider
+	}
+	return ""
 }

--- a/cmd/gc/provider_health_test.go
+++ b/cmd/gc/provider_health_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// stubProviderHealthLister returns canned beads (and optional error) for
+// ListByLabel, isolating loadProviderHealthSnapshot from any real store.
+type stubProviderHealthLister struct {
+	beads []beads.Bead
+	err   error
+	calls int
+}
+
+func (s *stubProviderHealthLister) ListByLabel(label string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	if label != providerHealthLabel {
+		return nil, nil
+	}
+	return s.beads, nil
+}
+
+func healthBead(provider, status string, updated time.Time) beads.Bead {
+	return beads.Bead{
+		Status:    "open",
+		Labels:    []string{providerHealthLabel},
+		UpdatedAt: updated,
+		Metadata: map[string]string{
+			providerHealthProviderKey: provider,
+			providerHealthStatusKey:   status,
+		},
+	}
+}
+
+func TestProviderHealthSnapshotHealthyFailsOpen(t *testing.T) {
+	// A nil lister, unknown providers, and the empty provider name all resolve
+	// to healthy so a missing signal can never wedge respawns.
+	snap, err := loadProviderHealthSnapshot(nil)
+	if err != nil {
+		t.Fatalf("nil lister: unexpected error: %v", err)
+	}
+	if !snap.healthy("") {
+		t.Error("empty provider name should be healthy")
+	}
+	if !snap.healthy("unknown-provider") {
+		t.Error("unknown provider should be healthy (fail-open)")
+	}
+}
+
+func TestProviderHealthSnapshotReadErrorFailsOpen(t *testing.T) {
+	lister := &stubProviderHealthLister{err: errors.New("store down")}
+	snap, err := loadProviderHealthSnapshot(lister)
+	if err == nil {
+		t.Fatal("expected the read error to surface")
+	}
+	if !snap.healthy("anything") {
+		t.Error("read error should yield an all-healthy (fail-open) snapshot")
+	}
+}
+
+func TestProviderHealthSnapshotMarksUnhealthy(t *testing.T) {
+	now := time.Now()
+	lister := &stubProviderHealthLister{beads: []beads.Bead{
+		healthBead("red-provider", providerHealthStatusUnhealthy, now),
+		healthBead("green-provider", providerHealthStatusHealthy, now),
+	}}
+	snap, err := loadProviderHealthSnapshot(lister)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.healthy("red-provider") {
+		t.Error("red-provider marked unhealthy should not be healthy")
+	}
+	if !snap.healthy("green-provider") {
+		t.Error("green-provider marked healthy should be healthy")
+	}
+}
+
+func TestProviderHealthSnapshotLatestWins(t *testing.T) {
+	old := time.Now().Add(-time.Hour)
+	recent := time.Now()
+	// Out-of-order input: the stale unhealthy bead precedes the fresh healthy
+	// one. The newest timestamp must win regardless of slice order.
+	lister := &stubProviderHealthLister{beads: []beads.Bead{
+		healthBead("p", providerHealthStatusUnhealthy, old),
+		healthBead("p", providerHealthStatusHealthy, recent),
+	}}
+	snap, err := loadProviderHealthSnapshot(lister)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !snap.healthy("p") {
+		t.Error("most recent bead (healthy) should win over the stale unhealthy one")
+	}
+}
+
+func TestProviderHealthSnapshotClosedBeadIsHealthy(t *testing.T) {
+	now := time.Now()
+	closed := healthBead("p", providerHealthStatusUnhealthy, now)
+	closed.Status = "closed"
+	lister := &stubProviderHealthLister{beads: []beads.Bead{closed}}
+	snap, err := loadProviderHealthSnapshot(lister)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !snap.healthy("p") {
+		t.Error("a closed unhealthy bead means the condition resolved: healthy")
+	}
+}

--- a/cmd/gc/provider_health_test.go
+++ b/cmd/gc/provider_health_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 // stubProviderHealthLister returns canned beads (and optional error) for
@@ -98,6 +99,46 @@ func TestProviderHealthSnapshotLatestWins(t *testing.T) {
 	}
 	if !snap.healthy("p") {
 		t.Error("most recent bead (healthy) should win over the stale unhealthy one")
+	}
+}
+
+func TestAgentProviderName(t *testing.T) {
+	cfg := &config.City{}
+	cfg.AgentDefaults.Provider = "agent-default-prov"
+	cfg.Workspace.Provider = "workspace-prov"
+
+	tests := []struct {
+		name  string
+		agent *config.Agent
+		want  string
+	}{
+		{"agent's own provider wins", &config.Agent{Provider: "own"}, "own"},
+		{"pack-inherited default next", &config.Agent{InheritedProvider: "inherited"}, "inherited"},
+		{"own beats inherited", &config.Agent{Provider: "own", InheritedProvider: "inherited"}, "own"},
+		{"falls back to [agent_defaults]", &config.Agent{}, "agent-default-prov"},
+		{"nil agent falls back to city default", nil, "agent-default-prov"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := agentProviderName(cfg, tc.agent); got != tc.want {
+				t.Errorf("effectiveProviderName = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// With no [agent_defaults] provider, [workspace] provider is the last resort.
+	noAgentDefaults := &config.City{}
+	noAgentDefaults.Workspace.Provider = "workspace-prov"
+	if got := agentProviderName(noAgentDefaults, &config.Agent{}); got != "workspace-prov" {
+		t.Errorf("workspace fallback = %q, want %q", got, "workspace-prov")
+	}
+
+	// Nothing configured anywhere → empty (gate is a no-op / fail-open).
+	if got := agentProviderName(&config.City{}, &config.Agent{}); got != "" {
+		t.Errorf("no provider configured = %q, want empty", got)
+	}
+	if got := agentProviderName(nil, nil); got != "" {
+		t.Errorf("nil cfg and agent = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The session reconciler's liveness check (`observeRuntimeProviderLiveness`) tests
process existence only. When a provider's auth goes red (e.g. a fleet-wide token
expiry), the reconciler keeps respawning sessions onto that still-failing
provider — a thundering-401-herd that burns the create budget and never
recovers on its own.

## Change

Add a generic, **fail-open** provider-health signal and gate the pool
fresh-create chokepoint on it:

- `provider_health.go` — a bead-backed provider-health projection (label
  `gc.provider-health`, metadata `gc.provider`/`gc.health`). Detection is
  **consumer-owned** (a pack writes the bead); the SDK only *reads* it. Absent
  registry / read error ⇒ healthy (fail-open), so this is a no-op until a
  detector is present.
- `build_desired_state.go` — wire a once-per-build provider-health snapshot into
  `agentBuildParams` and gate fresh creates in `realizePoolDesiredSessions`:
  an unhealthy provider **defers** fresh creates (gate-on-green); existing
  session reuse is untouched. The deferral releases the reserved create-budget
  slot so a gated pool can't starve healthy pools.
- `agentProviderName` — config-precedence provider resolver (agent → pack
  default → `[agent_defaults]` → city default).

No new event type, no `map[string]any` on the wire, no role names, no status
files (health is read as a reconciled bead fact).

## Tests

`TestProviderHealthSnapshot*` (reader, fail-open, latest-wins, closed-bead),
`TestAgentProviderName` (precedence), and
`TestRealizePoolDesiredSessionsGatesFreshCreatesOnUnhealthyProvider` /
`...AllowsFreshCreatesWhenProviderHealthy` (integration).

## Note on stacking

This branch is **stacked on #2819** (scale pools from zero) because both modify
`realizePoolDesiredSessions`. The scale-from-zero commit therefore appears in
this diff; it will drop out once #2819 merges and this is rebased onto `main`.
Please review #2819 first. The provider-health commits are the top three.