### PR TITLE
feat(reconciler): progress-aware session health predicate

### DIFF
--- a/cmd/gc/session_progress.go
+++ b/cmd/gc/session_progress.go
@@ -1,0 +1,36 @@
+package main
+
+import "time"
+
+// sessionProgressStalled reports whether a desired, alive session has stopped
+// making progress and should be recycled with a fresh restart. It is the
+// progress-aware half of the liveness predicate (ADR-0013 Amendment A1, move
+// 3b): a live process is necessary but not sufficient for "healthy" — a session
+// can be alive yet parked (for example, its turn ended on a provider auth error)
+// and will not self-recover, so the reconciler must restart it.
+//
+// It returns true only when ALL of the following hold:
+//   - threshold > 0: the feature is opt-in; an unset/zero timeout disables it.
+//   - !holdsClaim: a claimed-but-hung session is the stall-reaper's domain.
+//     This targets the claim-less parked case the reaper cannot see (the session
+//     parked before it could claim work).
+//   - providerHealthy: never recycle a session whose provider cannot currently
+//     serve; while a provider is unhealthy the session is left alone until it
+//     recovers (composes with the provider-health respawn gate, move 3a).
+//   - !exempt: the session is not attached, awaiting interaction, or within its
+//     startup grace window.
+//   - lastProgress is known and older than threshold.
+//
+// lastProgress is the most recent progress timestamp the caller resolved (the
+// maximum of last session activity and last claim update). A zero value means
+// progress is unknown, in which case the predicate is conservative and returns
+// false rather than recycle a session whose liveness it cannot assess.
+func sessionProgressStalled(threshold time.Duration, holdsClaim, providerHealthy, exempt bool, lastProgress, now time.Time) bool {
+	if threshold <= 0 || holdsClaim || !providerHealthy || exempt {
+		return false
+	}
+	if lastProgress.IsZero() {
+		return false
+	}
+	return now.Sub(lastProgress) > threshold
+}

--- a/cmd/gc/session_progress_test.go
+++ b/cmd/gc/session_progress_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSessionProgressStalled(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-time.Hour)    // well past any sane threshold
+	recent := now.Add(-time.Second) // within threshold
+	const threshold = 30 * time.Minute
+
+	tests := []struct {
+		name            string
+		threshold       time.Duration
+		holdsClaim      bool
+		providerHealthy bool
+		exempt          bool
+		lastProgress    time.Time
+		want            bool
+	}{
+		{"stalled: alive, no claim, healthy, not exempt, old progress", threshold, false, true, false, stale, true},
+		{"disabled when threshold is zero", 0, false, true, false, stale, false},
+		{"not stalled when progress is recent", threshold, false, true, false, recent, false},
+		{"holds a claim -> reaper's job, not recycled", threshold, true, true, false, stale, false},
+		{"provider unhealthy -> never recycle into a dead provider", threshold, false, false, false, stale, false},
+		{"exempt (attached/interactive/startup) -> left alone", threshold, false, true, true, stale, false},
+		{"unknown progress (zero) -> conservative, not recycled", threshold, false, true, false, time.Time{}, false},
+		{"exactly at threshold is not yet stalled", threshold, false, true, false, now.Add(-threshold), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sessionProgressStalled(tc.threshold, tc.holdsClaim, tc.providerHealthy, tc.exempt, tc.lastProgress, now)
+			if got != tc.want {
+				t.Errorf("sessionProgressStalled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1497,6 +1497,44 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 		}
 
+		// Progress-aware recycle (ADR-0013 Amendment A1, move 3b): a desired,
+		// alive session that has stopped progressing has likely parked (e.g. its
+		// turn ended on a provider auth error) and will not self-recover. Opt-in
+		// via [session] progress_stall_timeout; disabled (zero) by default, so
+		// this is a no-op unless a city sets a threshold above its agents'
+		// longest legitimate quiet period. The cheap time check gates the
+		// store/health queries so they run only for the rare already-stalled
+		// session. Set the restart_requested marker and let the block below do
+		// the actual circuit-breaker-aware restart.
+		if threshold := cfg.Session.ProgressStallTimeoutDuration(); threshold > 0 && alive {
+			if lastActivity, _ := sp.GetLastActivity(name); !lastActivity.IsZero() && clk.Now().Sub(lastActivity) > threshold {
+				exempt := pendingInteractionKeepsAwake(*session, sp, name, clk)
+				if !exempt {
+					if attached, err := sessionAttachedForConfigDrift(*session, sp, cityPath, store, cfg, name); err == nil && attached {
+						exempt = true
+					}
+				}
+				holdsClaim := false
+				if !exempt {
+					if has, err := sessionHasOpenAssignedWorkForConfig(store, rigStores, *session, cfg); err == nil {
+						holdsClaim = has
+					}
+				}
+				providerHealthy := true
+				if !exempt && !holdsClaim {
+					snap, _ := loadProviderHealthSnapshot(store)
+					providerHealthy = snap.healthy(agentProviderName(cfg, findAgentByTemplate(cfg, tp.TemplateName)))
+				}
+				if sessionProgressStalled(threshold, holdsClaim, providerHealthy, exempt, lastActivity, clk.Now()) {
+					if session.Metadata == nil {
+						session.Metadata = map[string]string{}
+					}
+					session.Metadata["restart_requested"] = "true"
+					fmt.Fprintf(stderr, "session reconciler: %s progress-stalled (no progress for >%s, no open claim, provider healthy); requesting fresh restart\n", name, threshold) //nolint:errcheck
+				}
+			}
+		}
+
 		// Restart-requested: agent asked for a fresh session
 		// (gc runtime request-restart / gc handoff). This runs after
 		// drain-ack handling, but before autonomous rate-limit,

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1507,10 +1507,22 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// session. Set the restart_requested marker and let the block below do
 		// the actual circuit-breaker-aware restart.
 		if threshold := cfg.Session.ProgressStallTimeoutDuration(); threshold > 0 && alive {
-			if lastActivity, _ := sp.GetLastActivity(name); !lastActivity.IsZero() && clk.Now().Sub(lastActivity) > threshold {
+			lastActivity, lastActivityErr := sp.GetLastActivity(name)
+			if lastActivityErr != nil {
+				fmt.Fprintf(stderr, "session reconciler: reading last activity before progress-stall recycle for %s: %v\n", name, lastActivityErr) //nolint:errcheck
+			}
+			if lastActivityErr == nil && !lastActivity.IsZero() && clk.Now().Sub(lastActivity) > threshold {
 				exempt := pendingInteractionKeepsAwake(*session, sp, name, clk)
 				if !exempt {
-					if attached, err := sessionAttachedForConfigDrift(*session, sp, cityPath, store, cfg, name); err == nil && attached {
+					attached, attachErr := sessionAttachedForConfigDrift(*session, sp, cityPath, store, cfg, name)
+					if attachErr != nil {
+						// Fail safe: an unreadable attachment check must not recycle a
+						// session a human may be attached to. Mirrors the claim-check
+						// guard below — skip the destructive action on error rather
+						// than assume the session is unattended.
+						fmt.Fprintf(stderr, "session reconciler: checking attachment before progress-stall recycle for %s: %v\n", name, attachErr) //nolint:errcheck
+						exempt = true
+					} else if attached {
 						exempt = true
 					}
 				}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1516,7 +1516,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 				holdsClaim := false
 				if !exempt {
-					if has, err := sessionHasOpenAssignedWorkForConfig(store, rigStores, *session, cfg); err == nil {
+					has, err := sessionHasOpenAssignedWorkForConfig(store, rigStores, *session, cfg)
+					if err != nil {
+						// Fail safe: an unreadable claim check must not recycle a
+						// session that may hold in-progress work. Mirrors the drain
+						// guards elsewhere (they skip the destructive action on a
+						// claim-check error rather than assume the session is idle).
+						fmt.Fprintf(stderr, "session reconciler: checking assigned work before progress-stall recycle for %s: %v\n", name, err) //nolint:errcheck
+						holdsClaim = true
+					} else {
 						holdsClaim = has
 					}
 				}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1529,9 +1529,13 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					}
 				}
 				providerHealthy := true
-				if !exempt && !holdsClaim {
-					snap, _ := loadProviderHealthSnapshot(store)
-					providerHealthy = snap.healthy(agentProviderName(cfg, findAgentByTemplate(cfg, tp.TemplateName)))
+				if !exempt && !holdsClaim && tp.ResolvedProvider != nil {
+					// Reuse the per-tick provider-health snapshot (#2962). Gate 1
+					// (provider RED) takes precedence: never recycle a session whose
+					// provider is red. Fail-open — absent/stale registry → healthy.
+					if h, present := phSnap.check(tp.ResolvedProvider.Name); present {
+						providerHealthy = h
+					}
 				}
 				if sessionProgressStalled(threshold, holdsClaim, providerHealthy, exempt, lastActivity, clk.Now()) {
 					if session.Metadata == nil {

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -753,6 +753,7 @@ SessionConfig holds session provider settings.
 | `debounce_ms` | integer |  | `500` | DebounceMs is the default debounce interval in milliseconds for send-keys. Defaults to 500. |
 | `display_ms` | integer |  | `5000` | DisplayMs is the default display duration in milliseconds for status messages. Defaults to 5000. |
 | `startup_timeout` | string |  | `60s` | StartupTimeout is how long to wait for each agent's Start() call before treating it as failed. Duration string (e.g., "60s", "2m"). Defaults to "60s". |
+| `progress_stall_timeout` | string |  |  | ProgressStallTimeout, when set, enables progress-aware session recycling: a desired, alive, claim-less session on a healthy provider whose last progress is older than this duration is restarted fresh. Such a session has likely parked (e.g. its turn ended on a provider auth error) and will not self-recover. Duration string (e.g. "30m"). Unset/zero disables it. |
 | `socket` | string |  |  | Socket specifies the tmux socket name for per-city isolation. When set, all tmux commands use "tmux -L &lt;socket&gt;" to connect to a dedicated server. When empty, defaults to the city name (workspace.name) — giving every city its own tmux server automatically. Set explicitly to override. |
 | `remote_match` | string |  |  | RemoteMatch is a substring pattern for the hybrid provider to route sessions to the remote (K8s) backend. Sessions whose names contain this pattern go to K8s; all others stay local (tmux). Overridden by the GC_HYBRID_REMOTE_MATCH env var if set. |
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -2570,6 +2570,10 @@
           "description": "StartupTimeout is how long to wait for each agent's Start() call before\ntreating it as failed. Duration string (e.g., \"60s\", \"2m\"). Defaults to \"60s\".",
           "default": "60s"
         },
+        "progress_stall_timeout": {
+          "type": "string",
+          "description": "ProgressStallTimeout, when set, enables progress-aware session recycling:\na desired, alive, claim-less session on a healthy provider whose last\nprogress is older than this duration is restarted fresh. Such a session\nhas likely parked (e.g. its turn ended on a provider auth error) and will\nnot self-recover. Duration string (e.g. \"30m\"). Unset/zero disables it."
+        },
         "socket": {
           "type": "string",
           "description": "Socket specifies the tmux socket name for per-city isolation.\nWhen set, all tmux commands use \"tmux -L \u003csocket\u003e\" to connect to\na dedicated server. When empty, defaults to the city name\n(workspace.name) — giving every city its own tmux server\nautomatically. Set explicitly to override."

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -2570,6 +2570,10 @@
           "description": "StartupTimeout is how long to wait for each agent's Start() call before\ntreating it as failed. Duration string (e.g., \"60s\", \"2m\"). Defaults to \"60s\".",
           "default": "60s"
         },
+        "progress_stall_timeout": {
+          "type": "string",
+          "description": "ProgressStallTimeout, when set, enables progress-aware session recycling:\na desired, alive, claim-less session on a healthy provider whose last\nprogress is older than this duration is restarted fresh. Such a session\nhas likely parked (e.g. its turn ended on a provider auth error) and will\nnot self-recover. Duration string (e.g. \"30m\"). Unset/zero disables it."
+        },
         "socket": {
           "type": "string",
           "description": "Socket specifies the tmux socket name for per-city isolation.\nWhen set, all tmux commands use \"tmux -L \u003csocket\u003e\" to connect to\na dedicated server. When empty, defaults to the city name\n(workspace.name) — giving every city its own tmux server\nautomatically. Set explicitly to override."

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1289,6 +1289,12 @@ type SessionConfig struct {
 	// StartupTimeout is how long to wait for each agent's Start() call before
 	// treating it as failed. Duration string (e.g., "60s", "2m"). Defaults to "60s".
 	StartupTimeout string `toml:"startup_timeout,omitempty" jsonschema:"default=60s"`
+	// ProgressStallTimeout, when set, enables progress-aware session recycling:
+	// a desired, alive, claim-less session on a healthy provider whose last
+	// progress is older than this duration is restarted fresh. Such a session
+	// has likely parked (e.g. its turn ended on a provider auth error) and will
+	// not self-recover. Duration string (e.g. "30m"). Unset/zero disables it.
+	ProgressStallTimeout string `toml:"progress_stall_timeout,omitempty"`
 	// Socket specifies the tmux socket name for per-city isolation.
 	// When set, all tmux commands use "tmux -L <socket>" to connect to
 	// a dedicated server. When empty, defaults to the city name
@@ -1363,6 +1369,21 @@ func (s *SessionConfig) StartupTimeoutDuration() time.Duration {
 	d, err := time.ParseDuration(s.StartupTimeout)
 	if err != nil {
 		return 60 * time.Second
+	}
+	return d
+}
+
+// ProgressStallTimeoutDuration returns the progress-stall recycle timeout, or 0
+// when unset or unparseable. Zero disables progress-aware recycling (the
+// default): only a city that explicitly opts in by setting a duration above its
+// agents' longest legitimate quiet period gets the behavior.
+func (s *SessionConfig) ProgressStallTimeoutDuration() time.Duration {
+	if s.ProgressStallTimeout == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s.ProgressStallTimeout)
+	if err != nil {
+		return 0
 	}
 	return d
 }

--- a/internal/config/progress_stall_test.go
+++ b/internal/config/progress_stall_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProgressStallTimeoutDuration(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"unset disables (zero)", "", 0},
+		{"valid duration", "30m", 30 * time.Minute},
+		{"unparseable disables (zero)", "not-a-duration", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &SessionConfig{ProgressStallTimeout: tc.value}
+			if got := s.ProgressStallTimeoutDuration(); got != tc.want {
+				t.Errorf("ProgressStallTimeoutDuration(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/validate_durations.go
+++ b/internal/config/validate_durations.go
@@ -55,6 +55,7 @@ func ValidateDurations(cfg *City, source string) []string {
 	check("[session]", "nudge_retry_interval", cfg.Session.NudgeRetryInterval)
 	check("[session]", "nudge_lock_timeout", cfg.Session.NudgeLockTimeout)
 	check("[session]", "startup_timeout", cfg.Session.StartupTimeout)
+	check("[session]", "progress_stall_timeout", cfg.Session.ProgressStallTimeout)
 
 	// Daemon config durations.
 	check("[daemon]", "patrol_interval", cfg.Daemon.PatrolInterval)


### PR DESCRIPTION
## Problem

A session can be tmux-alive and child-process-alive yet make no forward
progress (parked on a provider error, hung, holding no claim). Today it passes
the reconciler's process-existence liveness check as "healthy" forever, and the
stale-reaper misses it because it holds no claim.

## Change

Lift the predicate from process-existence to **alive ∧ progressing**:

- `session_progress.go` / `session_reconciler.go` — a desired session that is
  alive but has had no progress for > T is treated as not-desired, so the
  existing `max_wakes_per_tick`-throttled loop drains and respawns it.
  `progress_at = max(bead.updated_at, session.last_wake_at)` — no git
  subprocess, no new Dolt queries. Exemptions: attached, startup-grace,
  pending-interaction. The provider-health gate (PR-A) takes precedence — no
  drain on a red provider. The claim check fails safe.
- `internal/config` — opt-in `progress_stall_timeout` (default off / config-gated).

Clean ownership: reaper = bead-level claim release; reconciler = session-level
lifecycle. No racing second loop.

## Tests

`TestSessionProgressStalled*` (predicate, fake clock, exemptions, gate
interaction) and `TestProgressStallTimeoutDuration` (config accessor).

## Note on stacking

This branch is **stacked on #2962 (provider-health gate), which is in turn
stacked on #2819 (scale-from-zero)** — all three touch the reconciler
respawn/desired-session path. Both parent PRs' commits appear in this diff and
will drop out as they merge. Review order: **#2819 → #2962 → this**. The
progress-aware commits are the top three.