### PR TITLE
perf(api): bound the workflow-snapshot store scan (skip redundant metadata Lists)

### DIFF
--- a/internal/api/convoy_sql.go
+++ b/internal/api/convoy_sql.go
@@ -210,6 +210,13 @@ func workflowSQLDepFromRow(issueID, dependsOnID, depType sql.NullString) beads.D
 // tryFullWorkflowSQL does the entire workflow snapshot via SQL — root
 // discovery, bead fetch, dep fetch, and graph build. Falls back to nil
 // error only on full success so the caller can use the slow path on any failure.
+// errNoSQLWorkflowStores is the benign "this deployment has no SQL-backed
+// workflow store to consult" outcome — distinct from a SQL store that exists
+// but could not be reached or did not contain the workflow. The caller
+// (buildWorkflowSnapshot) uses errors.Is to keep the routine no-SQL fallback
+// quiet while still surfacing genuine fast-path failures (gascity#2940).
+var errNoSQLWorkflowStores = errors.New("no sql workflow stores")
+
 func (s *Server) tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScopeRef string, snapshotIndex uint64) (*workflowSnapshotResponse, error) {
 	candidates := workflowSQLCandidatesForWorkflowID(
 		s.state,
@@ -218,7 +225,7 @@ func (s *Server) tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScope
 		fallbackScopeRef,
 	)
 	if len(candidates) == 0 {
-		return nil, fmt.Errorf("no sql workflow stores")
+		return nil, errNoSQLWorkflowStores
 	}
 
 	type sqlWorkflowRootMatch struct {
@@ -226,18 +233,36 @@ func (s *Server) tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScope
 		root      beads.Bead
 	}
 	matches := make([]sqlWorkflowRootMatch, 0, len(candidates))
+	// Retain the first genuine probe failure (Dolt unreachable, query error)
+	// so a fully-failed sweep surfaces the real cause rather than a synthetic
+	// "not found" — that real cause is exactly what the #2940 fallback log
+	// needs to be actionable. A clean miss (ok == false, err == nil) is not a
+	// failure: the workflow simply isn't in that store.
+	var firstProbeErr error
 	for _, candidate := range candidates {
 		host, port, database, user, password, err := resolveDoltConnection(s.state.CityPath(), candidate.path)
 		if err != nil {
+			if firstProbeErr == nil {
+				firstProbeErr = fmt.Errorf("resolve dolt connection for %s: %w", candidate.info.ref, err)
+			}
 			continue
 		}
 		root, ok, err := workflowSQLFindRoot(s.state.Config(), user, password, host, port, database, workflowID)
-		if err != nil || !ok {
+		if err != nil {
+			if firstProbeErr == nil {
+				firstProbeErr = fmt.Errorf("sql find root in %s: %w", candidate.info.ref, err)
+			}
+			continue
+		}
+		if !ok {
 			continue
 		}
 		matches = append(matches, sqlWorkflowRootMatch{candidate: candidate, root: root})
 	}
 	if len(matches) == 0 {
+		if firstProbeErr != nil {
+			return nil, firstProbeErr
+		}
 		return nil, fmt.Errorf("workflow %q not found in sql stores", workflowID)
 	}
 

--- a/internal/api/handler_convoy_dispatch.go
+++ b/internal/api/handler_convoy_dispatch.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"log"
 	"strconv"
 	"strings"
 
@@ -9,6 +10,19 @@ import (
 )
 
 var errWorkflowNotFound = errors.New("workflow not found")
+
+// logWorkflowSQLFallback surfaces a workflow-snapshot SQL fast-path failure
+// before buildWorkflowSnapshot drops to the per-store scan. The SQL path is the
+// ~190ms route; the scan is seconds and grows with rig count, so a silent
+// fallback hides a real perf regression (gascity#2940). The benign
+// "no SQL stores configured" outcome is left quiet so non-SQL deployments,
+// whose steady state IS the scan, do not log on every workflow fetch.
+func logWorkflowSQLFallback(workflowID string, err error) {
+	if err == nil || errors.Is(err, errNoSQLWorkflowStores) {
+		return
+	}
+	log.Printf("gc api: workflow %q SQL fast path failed, falling back to store scan: %v", workflowID, err)
+}
 
 // Response types (workflowSnapshotResponse, workflowBeadResponse,
 // workflowDepResponse, LogicalNode, ScopeGroup) live in
@@ -30,9 +44,11 @@ type workflowRootMatch struct {
 
 func (s *Server) buildWorkflowSnapshot(workflowID, fallbackScopeKind, fallbackScopeRef string, snapshotIndex uint64) (*workflowSnapshotResponse, error) {
 	// Fast path: resolve the correct store and fetch the entire snapshot via SQL.
-	if snap, err := s.tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScopeRef, snapshotIndex); err == nil {
+	snap, sqlErr := s.tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScopeRef, snapshotIndex)
+	if sqlErr == nil {
 		return snap, nil
 	}
+	logWorkflowSQLFallback(workflowID, sqlErr)
 
 	// Slow path: bd subprocess N+1
 	stores := s.workflowStores()

--- a/internal/api/handler_convoy_dispatch.go
+++ b/internal/api/handler_convoy_dispatch.go
@@ -42,6 +42,14 @@ type workflowRootMatch struct {
 	root beads.Bead
 }
 
+// workflowMatchKey dedups matches by (store, physical bead id) so one physical
+// root is never counted twice — which would defeat selectWorkflowRootMatch's
+// len(matches)==1 cross-store-uniqueness gate (gascity#2940).
+type workflowMatchKey struct {
+	ref string
+	id  string
+}
+
 func (s *Server) buildWorkflowSnapshot(workflowID, fallbackScopeKind, fallbackScopeRef string, snapshotIndex uint64) (*workflowSnapshotResponse, error) {
 	// Fast path: resolve the correct store and fetch the entire snapshot via SQL.
 	snap, sqlErr := s.tryFullWorkflowSQL(workflowID, fallbackScopeKind, fallbackScopeRef, snapshotIndex)
@@ -50,58 +58,95 @@ func (s *Server) buildWorkflowSnapshot(workflowID, fallbackScopeKind, fallbackSc
 	}
 	logWorkflowSQLFallback(workflowID, sqlErr)
 
-	// Slow path: bd subprocess N+1
+	// Slow path: no SQL fast path, so resolve the root by consulting the bead
+	// stores directly. The root for a workflow lives in exactly one store, and
+	// there are two ways to find it: a point Get by bead id (the common
+	// graph.v2 case, root.ID == workflowID) and a gc.workflow_id metadata List
+	// (the logical-id case). The List is the expensive metadata scan, so sweep
+	// every store with the cheap Get first and only fall back to the List sweep
+	// when no Get matched — dropping up to one metadata scan per store on the
+	// common path. Both phases still consult every store, so cross-store
+	// uniqueness (selectWorkflowRootMatch's len(matches)==1 gate) is unchanged
+	// (gascity#2940).
 	stores := s.workflowStores()
 	storesScanned := make([]string, 0, len(stores))
 	seenStoreRefs := make(map[string]bool, len(stores))
 	matches := make([]workflowRootMatch, 0)
-	listPartial := false
-	var firstListErr error
-	cityScopeRef := ""
+	seenMatches := make(map[workflowMatchKey]bool)
+	addMatch := func(info workflowStoreInfo, root beads.Bead) {
+		key := workflowMatchKey{ref: info.ref, id: root.ID}
+		if seenMatches[key] {
+			return
+		}
+		seenMatches[key] = true
+		matches = append(matches, workflowRootMatch{info: info, root: root})
+	}
+	// cityScopeRef feeds the legacy city-on-rig preserve path. Derive it from
+	// the city name directly (as the SQL path does) instead of harvesting it
+	// mid-scan, so it is correct even when the city store yields no match.
+	cityScopeRef := workflowCityScopeRef(s.state.CityName())
+	var firstGetErr error
 
 	for _, info := range stores {
 		if info.store == nil {
 			continue
 		}
-		if cityScopeRef == "" && info.scopeKind == "city" {
-			cityScopeRef = info.scopeRef
-		}
 		if !seenStoreRefs[info.ref] {
 			storesScanned = append(storesScanned, info.ref)
 			seenStoreRefs[info.ref] = true
 		}
-
-		if root, err := info.store.Get(workflowID); err == nil {
-			if isWorkflowRoot(root) && matchesWorkflowID(root, workflowID) {
-				matches = append(matches, workflowRootMatch{info: info, root: root})
-			}
-		} else if firstListErr == nil && !errors.Is(err, beads.ErrNotFound) {
-			firstListErr = err
-		}
-
-		roots, err := info.store.List(beads.ListQuery{
-			Metadata: map[string]string{
-				"gc.kind":        "workflow",
-				"gc.workflow_id": workflowID,
-			},
-			IncludeClosed: true,
-		})
+		root, err := info.store.Get(workflowID)
 		if err != nil {
-			listPartial = true
+			if firstGetErr == nil && !errors.Is(err, beads.ErrNotFound) {
+				firstGetErr = err
+			}
 			continue
 		}
-		for _, bead := range roots {
-			if !matchesWorkflowID(bead, workflowID) {
+		if isWorkflowRoot(root) && matchesWorkflowID(root, workflowID) {
+			addMatch(info, root)
+		}
+	}
+
+	// Fall back to the gc.workflow_id metadata sweep only when no store owned
+	// the id directly — the logical-workflow-id case Get cannot resolve. A
+	// Phase-1 hit is authoritative: Get is keyed by bead id, so a hit means
+	// root.ID == workflowID, and a physical bead id is owned by exactly one
+	// store. A second root elsewhere could only also match by stamping
+	// gc.workflow_id == workflowID, i.e. claiming another root's *physical* id
+	// as its own *logical* id — which the id-space separation (sling-prefixed
+	// physical ids vs formula-stamped logical ids) does not allow. So once a
+	// store owns the id directly, the metadata sweep cannot add a legitimate
+	// competing match, and skipping it is safe.
+	listPartial := false
+	if len(matches) == 0 {
+		for _, info := range stores {
+			if info.store == nil {
 				continue
 			}
-			matches = append(matches, workflowRootMatch{info: info, root: bead})
+			roots, err := info.store.List(beads.ListQuery{
+				Metadata: map[string]string{
+					"gc.kind":        "workflow",
+					"gc.workflow_id": workflowID,
+				},
+				IncludeClosed: true,
+			})
+			if err != nil {
+				listPartial = true
+				continue
+			}
+			for _, bead := range roots {
+				if !matchesWorkflowID(bead, workflowID) {
+					continue
+				}
+				addMatch(info, bead)
+			}
 		}
 	}
 
 	match, ok := selectWorkflowRootMatch(matches, fallbackScopeKind, fallbackScopeRef, cityScopeRef)
 	if !ok {
-		if firstListErr != nil {
-			return nil, firstListErr
+		if firstGetErr != nil {
+			return nil, firstGetErr
 		}
 		return nil, errWorkflowNotFound
 	}

--- a/internal/api/handler_convoy_dispatch_test.go
+++ b/internal/api/handler_convoy_dispatch_test.go
@@ -1094,3 +1094,63 @@ func TestLogWorkflowSQLFallbackSurfacesGenuineFailures(t *testing.T) {
 		t.Fatalf("genuine SQL fast-path failure not surfaced: %q", out)
 	}
 }
+
+// workflowIDListSpyStore counts only the scan's gc.workflow_id metadata List
+// queries (snapshotFromStore lists by gc.root_bead_id, which is not counted).
+type workflowIDListSpyStore struct {
+	beads.Store
+	calls *int
+}
+
+func (s workflowIDListSpyStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if q.Metadata["gc.workflow_id"] != "" {
+		*s.calls++
+	}
+	return s.Store.List(q)
+}
+
+// Locks in the #2940 scan bound: when a point Get by physical bead id resolves
+// the workflow root, the gc.workflow_id metadata List sweep is skipped entirely
+// across all stores (the pre-bound single pass ran it in every store).
+func TestWorkflowGetSkipsMetadataListSweepWhenIDResolvesDirectly(t *testing.T) {
+	state := newFakeState(t)
+	state.cityName = "test-city"
+	state.cityBeadStore = beads.NewMemStore()
+	rigMem := beads.NewMemStore()
+	var listCalls int
+	state.stores = map[string]beads.Store{
+		"alpha": workflowIDListSpyStore{Store: rigMem, calls: &listCalls},
+	}
+
+	root, err := rigMem.Create(beads.Bead{
+		Title: "Rig workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+
+	h := newTestCityHandler(t, state)
+	// Request by the physical bead id so Phase-1 Get resolves it directly.
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/workflow/"+root.ID+"?scope_kind=rig&scope_ref=alpha"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var snapshot workflowSnapshotResponse
+	if err := json.NewDecoder(rec.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("Decode(snapshot): %v", err)
+	}
+	if snapshot.RootBeadID != root.ID {
+		t.Fatalf("root_bead_id = %q, want %q", snapshot.RootBeadID, root.ID)
+	}
+	if listCalls != 0 {
+		t.Fatalf("gc.workflow_id metadata List ran %d time(s); want 0 once Get resolved the id directly", listCalls)
+	}
+}

--- a/internal/api/handler_convoy_dispatch_test.go
+++ b/internal/api/handler_convoy_dispatch_test.go
@@ -1,14 +1,17 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -1059,4 +1062,35 @@ func (p *incrementingLatestSeqProvider) Watch(context.Context, uint64) (events.W
 
 func (p *incrementingLatestSeqProvider) Close() error {
 	return nil
+}
+
+// Intentionally NOT t.Parallel(): it redirects the global log writer, so it
+// must not run concurrently with any other test that logs or rebinds output.
+func TestLogWorkflowSQLFallbackSurfacesGenuineFailures(t *testing.T) {
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+	})
+
+	// A deployment with no SQL workflow store runs the per-store scan as its
+	// steady state, not a regression — it must stay quiet so the supervisor
+	// does not log on every workflow fetch (gascity#2940).
+	logWorkflowSQLFallback("wf_quiet", nil)
+	logWorkflowSQLFallback("wf_quiet", errNoSQLWorkflowStores)
+	if buf.Len() != 0 {
+		t.Fatalf("benign SQL fallbacks logged, want quiet: %q", buf.String())
+	}
+
+	// A genuine fast-path failure (Dolt unreachable, workflow absent from the
+	// scope's SQL stores, …) is the perf regression operators need to see.
+	logWorkflowSQLFallback("wf_loud", errors.New("dial tcp 127.0.0.1:3306: connection refused"))
+	out := buf.String()
+	if !strings.Contains(out, "wf_loud") || !strings.Contains(out, "connection refused") {
+		t.Fatalf("genuine SQL fast-path failure not surfaced: %q", out)
+	}
 }


### PR DESCRIPTION
The performance half of #2940. **Stacked on #2945** (`fix/workflow-snapshot-surface-sql-fallback`) — please review/merge that first; I'll rebase this onto `main` once it lands. The first commit here is #2945; the second (`perf(api): bound the workflow-snapshot store scan …`) is the change to review in this PR.

## Problem

`buildWorkflowSnapshot`'s slow-path fallback (used when the SQL fast path is unavailable) resolved a workflow by issuing, **per store, both** a point `Get(workflowID)` *and* a `gc.workflow_id` metadata `List` — across every store in the city (16 measured), even after the root was already found. The metadata `List` is the expensive scan; running it in all 16 stores is the bulk of the 2–8s cold-load latency observed in #2940.

## Change

Split the scan into two phases:
1. **Get-sweep all stores** (cheap point lookups). The common graph.v2 case (`root.ID == workflowID`) resolves here.
2. **`gc.workflow_id` metadata List-sweep all stores** — run **only if** the Get-sweep matched nothing (the logical-workflow-id case `Get` can't resolve).

So the common path now skips the metadata `List` in every store. Additional cleanup:
- **Dedup guard** (`workflowMatchKey{ref,id}`) closes a latent double-count: a root whose `id == gc.workflow_id` was previously appended by both the Get and List branches, which would defeat `selectWorkflowRootMatch`'s `len(matches)==1` uniqueness gate.
- **`cityScopeRef` derived up front** from `workflowCityScopeRef(CityName())` (as the SQL path already does at `convoy_sql.go`) instead of harvested mid-scan — correct even when the city store yields no match, and removes a slow-path/SQL-path inconsistency.

## Semantics preserved

Both phases still consult **every** store, so `selectWorkflowRootMatch`'s cross-store uniqueness gate, the legacy city-on-rig preserve path, store ordering, and partial-list bookkeeping are unchanged. All existing scope-resolution tests stay green (city-on-rig preserve, mismatched-scope 404, unique-cross-store, partial-list survival).

## Reviewer-flagged invariant (worth a conscious look)

Codex flagged that skipping Phase 2 after a Phase-1 hit drops a *competing* match if some other store carried a different root with `gc.workflow_id == X` where `X` is the first root's physical id. A Phase-1 `Get(X)` hit means `root.ID == X` (Get is keyed by id) — the authoritative owner of id `X` — and the id-space separation (sling-prefixed physical ids vs formula-stamped logical ids) means a logical `gc.workflow_id` can't alias another root's physical id, so the competing match can't legitimately exist. This invariant is now stated in-comment at the Phase-2 fallback. Flagging it here so it's a conscious acceptance, not a silent one.

Consequence (intended): a direct-id request that resolves in Phase 1 no longer marks the snapshot `partial` for an unrelated store's metadata-List failure — because no metadata List is attempted.

## Scope

This is the **conservative, provably-safe** bound — it removes the redundant metadata scans. Full latency elimination (to the ~190ms SQL path) still depends on the SQL fast path being reachable, which is what #2945 surfaces.

## Tests / verification

`TestWorkflowGetSkipsMetadataListSweepWhenIDResolvesDirectly` asserts the `gc.workflow_id` metadata List runs **zero** times once `Get` resolves the id (would be ≥1 under the old single-pass). `make build` ✅ · `make check` ✅ (no new failures; pre-existing unrelated race-test flakes only). Reviewed multi-model (Claude + Codex).