### PR TITLE
feat(api): surface dolt_version and beads_version on city status

### DIFF
--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -4210,6 +4210,10 @@ export interface components {
             agents: components["schemas"]["StatusAgentCounts"];
             /** @description Bead store selection diagnostic. Omitted when unavailable. */
             beads?: components["schemas"]["BeadsDiagnostic"];
+            /** @description Version of the bd (beads) CLI the supervisor drives. Omitted when the probe failed or the binary is unavailable. */
+            beads_version?: string;
+            /** @description Version of the dolt engine binary the supervisor drives. Omitted when the probe failed or the binary is unavailable. */
+            dolt_version?: string;
             /** @description Mail counts. */
             mail: components["schemas"]["StatusMailCounts"];
             /** @description City name. */

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -2979,6 +2979,14 @@ export type StatusBody = {
      */
     beads?: BeadsDiagnostic;
     /**
+     * Version of the bd (beads) CLI the supervisor drives. Omitted when the probe failed or the binary is unavailable.
+     */
+    beads_version?: string;
+    /**
+     * Version of the dolt engine binary the supervisor drives. Omitted when the probe failed or the binary is unavailable.
+     */
+    dolt_version?: string;
+    /**
      * Mail counts.
      */
     mail: StatusMailCounts;

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -6969,6 +6969,14 @@
             "$ref": "#/components/schemas/BeadsDiagnostic",
             "description": "Bead store selection diagnostic. Omitted when unavailable."
           },
+          "beads_version": {
+            "description": "Version of the bd (beads) CLI the supervisor drives. Omitted when the probe failed or the binary is unavailable.",
+            "type": "string"
+          },
+          "dolt_version": {
+            "description": "Version of the dolt engine binary the supervisor drives. Omitted when the probe failed or the binary is unavailable.",
+            "type": "string"
+          },
           "mail": {
             "$ref": "#/components/schemas/StatusMailCounts",
             "description": "Mail counts."

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -6969,6 +6969,14 @@
             "$ref": "#/components/schemas/BeadsDiagnostic",
             "description": "Bead store selection diagnostic. Omitted when unavailable."
           },
+          "beads_version": {
+            "description": "Version of the bd (beads) CLI the supervisor drives. Omitted when the probe failed or the binary is unavailable.",
+            "type": "string"
+          },
+          "dolt_version": {
+            "description": "Version of the dolt engine binary the supervisor drives. Omitted when the probe failed or the binary is unavailable.",
+            "type": "string"
+          },
           "mail": {
             "$ref": "#/components/schemas/StatusMailCounts",
             "description": "Mail counts."

--- a/internal/api/component_versions.go
+++ b/internal/api/component_versions.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"log"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// componentVersions holds the versions of the external binaries the
+// supervisor drives. A field is empty when the corresponding binary is
+// unavailable or its probe failed; callers surface empty as an absent,
+// omitempty wire field rather than a guessed value.
+type componentVersions struct {
+	Dolt  string
+	Beads string
+}
+
+// resolveComponentVersions returns the dolt engine and bd CLI versions the
+// supervisor drives, probing each binary at most once per process. Binary
+// versions are immutable for the life of the process that launched them, so a
+// single probe is both cheaper than re-probing on the hot status path and
+// semantically correct: the running supervisor keeps driving the binaries it
+// resolved until it restarts. The actual subprocess execution lives in
+// internal/beads (bd/dolt are confined there by architectural rule); this
+// layer only caches the result and logs probe failures server-side.
+func (s *Server) resolveComponentVersions() componentVersions {
+	s.componentVersionsOnce.Do(func() {
+		if s.componentVersionsProbe != nil {
+			s.componentVersionsValue = s.componentVersionsProbe()
+			return
+		}
+		s.componentVersionsValue = probeComponentVersions(beads.ProbeDoltVersion, beads.ProbeBDVersion)
+	})
+	return s.componentVersionsValue
+}
+
+// probeComponentVersions resolves both binary versions. A failed probe leaves
+// that field empty and logs the cause server-side so a missing version is
+// diagnosable rather than mystifying (consistent with the "don't swallow
+// errors" rule). probeDolt/probeBD are injectable for tests.
+func probeComponentVersions(probeDolt, probeBD func() (string, error)) componentVersions {
+	var cv componentVersions
+	if v, err := probeDolt(); err != nil {
+		log.Printf("status: dolt version probe failed: %v", err)
+	} else {
+		cv.Dolt = v
+	}
+	if v, err := probeBD(); err != nil {
+		log.Printf("status: bd version probe failed: %v", err)
+	} else {
+		cv.Beads = v
+	}
+	return cv
+}

--- a/internal/api/component_versions_test.go
+++ b/internal/api/component_versions_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestProbeComponentVersionsParsesBothVersions(t *testing.T) {
+	got := probeComponentVersions(
+		func() (string, error) { return "2.0.7", nil },
+		func() (string, error) { return "1.0.4", nil },
+	)
+	if got.Dolt != "2.0.7" {
+		t.Errorf("Dolt = %q, want 2.0.7", got.Dolt)
+	}
+	if got.Beads != "1.0.4" {
+		t.Errorf("Beads = %q, want 1.0.4", got.Beads)
+	}
+}
+
+func TestProbeComponentVersionsOmitsAndLogsOnFailure(t *testing.T) {
+	var buf bytes.Buffer
+	defer captureLog(t, &buf)()
+
+	got := probeComponentVersions(
+		func() (string, error) { return "", fmt.Errorf("dolt: executable file not found") },
+		func() (string, error) { return "1.0.4", nil },
+	)
+	if got.Dolt != "" {
+		t.Errorf("Dolt = %q, want empty on probe failure", got.Dolt)
+	}
+	if got.Beads != "1.0.4" {
+		t.Errorf("Beads = %q, want 1.0.4", got.Beads)
+	}
+	if !strings.Contains(buf.String(), "dolt version probe failed") {
+		t.Errorf("expected dolt probe failure to be logged, got %q", buf.String())
+	}
+}
+
+func TestResolveComponentVersionsProbesOnce(t *testing.T) {
+	var calls int32
+	s := &Server{componentVersionsProbe: func() componentVersions {
+		atomic.AddInt32(&calls, 1)
+		return componentVersions{Dolt: "2.0.7", Beads: "1.0.4"}
+	}}
+	for i := 0; i < 3; i++ {
+		got := s.resolveComponentVersions()
+		if got.Dolt != "2.0.7" || got.Beads != "1.0.4" {
+			t.Fatalf("resolveComponentVersions() = %+v", got)
+		}
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Errorf("probe called %d times, want 1 (cached for process lifetime)", n)
+	}
+}
+
+func TestBuildStatusBodyIncludesComponentVersions(t *testing.T) {
+	state := newFakeState(t)
+	s := &Server{state: state, componentVersionsProbe: func() componentVersions {
+		return componentVersions{Dolt: "2.0.7", Beads: "1.0.4"}
+	}}
+
+	body := s.buildStatusBody()
+	if body.DoltVersion != "2.0.7" {
+		t.Errorf("DoltVersion = %q, want 2.0.7", body.DoltVersion)
+	}
+	if body.BeadsVersion != "1.0.4" {
+		t.Errorf("BeadsVersion = %q, want 1.0.4", body.BeadsVersion)
+	}
+}
+
+func TestStatusBodyOmitsEmptyComponentVersions(t *testing.T) {
+	out, err := json.Marshal(StatusBody{Name: "c"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, "dolt_version") {
+		t.Errorf("dolt_version present for empty value; want omitted: %s", s)
+	}
+	if strings.Contains(s, "beads_version") {
+		t.Errorf("beads_version present for empty value; want omitted: %s", s)
+	}
+}
+
+// captureLog redirects the standard logger to buf for the duration of a test,
+// returning a restore func.
+func captureLog(t *testing.T, buf *bytes.Buffer) func() {
+	t.Helper()
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(buf)
+	log.SetFlags(0)
+	return func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}
+}

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2826,7 +2826,13 @@ type StatusBody struct {
 	AgentDetails *[]StatusAgentDetail `json:"agent_details,omitempty"`
 	Agents       StatusAgentCounts    `json:"agents"`
 	Beads        *BeadsDiagnostic     `json:"beads,omitempty"`
-	Mail         StatusMailCounts     `json:"mail"`
+
+	// BeadsVersion Version of the bd (beads) CLI the supervisor drives. Omitted when the probe failed or the binary is unavailable.
+	BeadsVersion *string `json:"beads_version,omitempty"`
+
+	// DoltVersion Version of the dolt engine binary the supervisor drives. Omitted when the probe failed or the binary is unavailable.
+	DoltVersion *string          `json:"dolt_version,omitempty"`
+	Mail        StatusMailCounts `json:"mail"`
 
 	// Name City name.
 	Name string `json:"name"`

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -243,11 +243,14 @@ func (s *Server) buildStatusBody() StatusBody {
 	}
 
 	uptime := int(time.Since(s.state.StartedAt()).Seconds())
+	versions := s.resolveComponentVersions()
 
 	return StatusBody{
 		Name:                cityName,
 		Path:                s.state.CityPath(),
 		Version:             s.state.Version(),
+		DoltVersion:         versions.Dolt,
+		BeadsVersion:        versions.Beads,
 		UptimeSec:           uptime,
 		Suspended:           cfg.Workspace.Suspended,
 		AgentCount:          ac.Total,

--- a/internal/api/huma_types_patches.go
+++ b/internal/api/huma_types_patches.go
@@ -168,6 +168,8 @@ type StatusBody struct {
 	Mail                StatusMailCounts           `json:"mail" doc:"Mail counts."`
 	StoreHealth         *StatusStoreHealth         `json:"store_health,omitempty" doc:"Dolt bead store health summary. Omitted when unavailable."`
 	Beads               *beads.BeadsDiagnostic     `json:"beads,omitempty" doc:"Bead store selection diagnostic. Omitted when unavailable."`
+	DoltVersion         string                     `json:"dolt_version,omitempty" doc:"Version of the dolt engine binary the supervisor drives. Omitted when the probe failed or the binary is unavailable."`
+	BeadsVersion        string                     `json:"beads_version,omitempty" doc:"Version of the bd (beads) CLI the supervisor drives. Omitted when the probe failed or the binary is unavailable."`
 	Partial             bool                       `json:"partial,omitempty" doc:"True when one or more status backing reads returned incomplete data."`
 	PartialErrors       []string                   `json:"partial_errors,omitempty" doc:"Human-readable errors from incomplete status backing reads."`
 	AgentDetails        []StatusAgentDetail        `json:"agent_details,omitempty" doc:"Per-agent state (for CLI status views). Empty when none."`

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -6969,6 +6969,14 @@
             "$ref": "#/components/schemas/BeadsDiagnostic",
             "description": "Bead store selection diagnostic. Omitted when unavailable."
           },
+          "beads_version": {
+            "description": "Version of the bd (beads) CLI the supervisor drives. Omitted when the probe failed or the binary is unavailable.",
+            "type": "string"
+          },
+          "dolt_version": {
+            "description": "Version of the dolt engine binary the supervisor drives. Omitted when the probe failed or the binary is unavailable.",
+            "type": "string"
+          },
           "mail": {
             "$ref": "#/components/schemas/StatusMailCounts",
             "description": "Mail counts."

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -84,6 +84,15 @@ type Server struct {
 	storeHealthExpires  time.Time
 	storeHealthComputer func() *StatusStoreHealth
 
+	// componentVersions caches the dolt engine and bd CLI versions the
+	// supervisor drives for /v0/status. Binary versions are immutable for
+	// the process lifetime, so they are resolved once on first read.
+	// componentVersionsProbe overrides the real subprocess probe in tests;
+	// nil uses the PATH-resolved binaries.
+	componentVersionsOnce  sync.Once
+	componentVersionsValue componentVersions
+	componentVersionsProbe func() componentVersions
+
 	// LookPathFunc can be overridden in tests. Defaults to exec.LookPath.
 	LookPathFunc func(string) (string, error)
 

--- a/internal/beads/binary_versions.go
+++ b/internal/beads/binary_versions.go
@@ -1,0 +1,86 @@
+package beads
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/doltversion"
+)
+
+// binaryVersionProbeTimeout bounds each `<binary> version` subprocess so a
+// hung binary cannot stall the caller that resolves versions.
+const binaryVersionProbeTimeout = 5 * time.Second
+
+// ProbeBDVersion runs `bd version` and returns the semantic version token the
+// bd CLI reports (e.g. "1.0.4"). bd subprocess execution is confined to this
+// package by architectural rule (see boundary_test.go), so version probing
+// for operator-facing surfaces lives here rather than in the API layer.
+func ProbeBDVersion() (string, error) {
+	out, err := probeBinaryVersion("bd")
+	if err != nil {
+		return "", err
+	}
+	return parseBDVersion(out)
+}
+
+// ProbeDoltVersion runs `dolt version` and returns the parsed version the dolt
+// engine reports (e.g. "2.0.7"). Dolt is the store engine bd drives, so its
+// version probe is colocated with bd's.
+func ProbeDoltVersion() (string, error) {
+	out, err := probeBinaryVersion("dolt")
+	if err != nil {
+		return "", err
+	}
+	info, err := doltversion.Parse(out)
+	if err != nil {
+		return "", err
+	}
+	return info.Raw, nil
+}
+
+// probeBinaryVersion locates name on PATH — the same resolution used when the
+// binary is driven for real work — and runs `<name> version` under a bounded
+// timeout, returning combined output.
+func probeBinaryVersion(name string) (string, error) {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return "", fmt.Errorf("locate %s: %w", name, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), binaryVersionProbeTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, path, "version").CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return string(out), fmt.Errorf("%s version timed out after %s", name, binaryVersionProbeTimeout)
+	}
+	if err != nil {
+		return string(out), fmt.Errorf("%s version: %w", name, err)
+	}
+	return string(out), nil
+}
+
+// parseBDVersion extracts the semantic version token from `bd version` output
+// (e.g. "bd version 1.0.4 (ce242a879)" -> "1.0.4"). Mirrors doltversion.Parse's
+// leniency: the "bd version " prefix, a leading "v", and any trailing
+// build/commit descriptor are stripped.
+func parseBDVersion(out string) (string, error) {
+	line := strings.TrimSpace(out)
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	line = strings.TrimSpace(line)
+	const prefix = "bd version "
+	if strings.HasPrefix(strings.ToLower(line), prefix) {
+		line = line[len(prefix):]
+	}
+	if i := strings.IndexAny(line, " \t"); i >= 0 {
+		line = line[:i]
+	}
+	line = strings.TrimSpace(strings.TrimPrefix(line, "v"))
+	if line == "" || line[0] < '0' || line[0] > '9' {
+		return "", fmt.Errorf("no version token in bd version output")
+	}
+	return line, nil
+}

--- a/internal/beads/binary_versions_test.go
+++ b/internal/beads/binary_versions_test.go
@@ -1,0 +1,62 @@
+package beads
+
+import "testing"
+
+func TestParseBDVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "version subcommand", in: "bd version 1.0.4 (ce242a879: HEAD@ce242a879678)", want: "1.0.4"},
+		{name: "version flag", in: "bd version 1.0.4 (ce242a879)", want: "1.0.4"},
+		{name: "v prefix", in: "bd version v1.2.0", want: "1.2.0"},
+		{name: "trailing newline", in: "bd version 1.0.4\n", want: "1.0.4"},
+		{name: "multiline takes first", in: "bd version 1.0.4\nschema 7", want: "1.0.4"},
+		{name: "bare token", in: "1.0.4", want: "1.0.4"},
+		{name: "empty", in: "", wantErr: true},
+		{name: "prefix only", in: "bd version ", wantErr: true},
+		{name: "non-version garbage", in: "garbage output with no version", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBDVersion(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseBDVersion(%q) err = nil, want error", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseBDVersion(%q) unexpected err: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseBDVersion(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestProbeVersionsAgainstHostBinaries is a best-effort smoke test: when bd and
+// dolt are on PATH (as in CI and dev shells), the probes return a digit-led
+// version. Skips cleanly when a binary is absent so the suite stays hermetic.
+func TestProbeVersionsAgainstHostBinaries(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		probe func() (string, error)
+	}{
+		{"bd", ProbeBDVersion},
+		{"dolt", ProbeDoltVersion},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := tc.probe()
+			if err != nil {
+				t.Skipf("%s not probeable in this environment: %v", tc.name, err)
+			}
+			if v == "" || v[0] < '0' || v[0] > '9' {
+				t.Errorf("%s version = %q, want a digit-led version string", tc.name, v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds two optional string fields — `dolt_version` and `beads_version` — to the city status response (`StatusBody` / `GET /v0/city/{name}/status`) so remote operators and the dashboard can read the dolt engine and bd CLI versions the supervisor drives, without shelling out to the binaries on their own host.

The supervisor owns and shells both binaries, so it is the authoritative source for which versions are running.

## What changed

- **New `internal/beads` probes** `ProbeBDVersion` / `ProbeDoltVersion` — bd/dolt subprocess execution is confined to `internal/beads` by architectural rule, so the probes live there. `ProbeDoltVersion` reuses `doltversion.Parse`; `ProbeBDVersion` adds a small `parseBDVersion` token extractor for bd's output format. Each probe runs under a 5s timeout.
- **New `internal/api` resolver** `resolveComponentVersions` — caches both versions with `sync.Once` (binary versions are immutable for the process lifetime, so they are resolved once on first read rather than re-probed on the hot status path). The API layer only caches and logs; it does not exec.
- **Status wiring** — `buildStatusBody` populates the two new fields; huma schema (`huma_types_patches.go`) declares them as `omitempty`.
- **Failure handling** — a failed or unavailable probe leaves the field empty (`omitempty` → absent on the wire) and logs the cause server-side, rather than coercing a wrong value or swallowing the error.
- **Regenerated artifacts** — OpenAPI spec (`internal/api/openapi.json`, `docs/schema/openapi.{json,txt}`), Go generated client, and dashboard TS types/schema, all from the huma source of truth.

## Why

Operators and the dashboard need to know which dolt engine and bd CLI versions a remote supervisor is actually driving, but only the supervisor can authoritatively report them. Surfacing them on the existing status endpoint avoids each consumer shelling out to binaries it may not have on its host.

## Test plan

- `make build` — passes.
- `make check` (fmt-check, lint, vet, full test) — passes.
- `make check-docs` (`test/docsync`) — passes; generated schema/clients verified in sync with the huma source.
- New unit tests cover: bd version-string parsing (table-driven, including garbage/empty error cases), probe-once caching, omit-and-log on probe failure, status-body population, and `omitempty` absence for empty values.
- A best-effort host-binary smoke test exercises the real `bd`/`dolt` probes when present and skips hermetically when absent.

Closes #2933
