### PR TITLE
ci: run full suite when cross-cutting core paths change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,23 @@ jobs:
     needs: runner-policy
     runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
     outputs:
-      mail: ${{ steps.filter.outputs.mail }}
-      docker: ${{ steps.filter.outputs.docker }}
-      k8s: ${{ steps.filter.outputs.k8s }}
+      # Gated outputs fold in the `shared` filter: a change to a cross-cutting
+      # core path runs the full suite (union run) even when the path-scoped
+      # filter would not match on its own. This closes the path-filter
+      # asymmetry where a subtle change in shared code skips the jobs it could
+      # break. Downstream consumers read these outputs unchanged.
+      mail: ${{ steps.filter.outputs.mail == 'true' || steps.filter.outputs.shared == 'true' }}
+      docker: ${{ steps.filter.outputs.docker == 'true' || steps.filter.outputs.shared == 'true' }}
+      k8s: ${{ steps.filter.outputs.k8s == 'true' || steps.filter.outputs.shared == 'true' }}
       beads: ${{ steps.filter.outputs.beads }}
-      packs: ${{ steps.filter.outputs.packs }}
-      worker: ${{ steps.filter.outputs.worker }}
-      worker_phase2: ${{ steps.filter.outputs.worker_phase2 }}
-      cmd_gc_process: ${{ steps.filter.outputs.cmd_gc_process }}
-      integration: ${{ steps.filter.outputs.integration }}
+      packs: ${{ steps.filter.outputs.packs == 'true' || steps.filter.outputs.shared == 'true' }}
+      worker: ${{ steps.filter.outputs.worker == 'true' || steps.filter.outputs.shared == 'true' }}
+      worker_phase2: ${{ steps.filter.outputs.worker_phase2 == 'true' || steps.filter.outputs.shared == 'true' }}
+      cmd_gc_process: ${{ steps.filter.outputs.cmd_gc_process == 'true' || steps.filter.outputs.shared == 'true' }}
+      integration: ${{ steps.filter.outputs.integration == 'true' || steps.filter.outputs.shared == 'true' }}
+      # Raw cross-cutting signal and per-run coverage classification (metric).
+      shared: ${{ steps.filter.outputs.shared }}
+      suite_mode: ${{ steps.coverage.outputs.suite_mode }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
@@ -127,6 +135,24 @@ jobs:
               - 'scripts/test-go-test-shard'
               - 'scripts/go-test-observable'
               - 'examples/gastown/packs/**'
+            # Cross-cutting core paths. A change here is folded into every
+            # gated output above, forcing a full union run. Beads is the
+            # universal persistence substrate, events the universal observation
+            # substrate, config the universal activation mechanism; build,
+            # dependency, and CI-config files affect every job.
+            shared:
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - '.github/workflows/**'
+              - 'internal/beads/**'
+              - 'internal/events/**'
+              - 'internal/config/**'
+      - name: Classify suite coverage
+        id: coverage
+        env:
+          SHARED_FILTER_RESULT: ${{ steps.filter.outputs.shared }}
+        run: python3 .github/workflows/scripts/ci_suite_coverage.py classify "$SHARED_FILTER_RESULT"
 
   preflight-static:
     name: Preflight / static checks

--- a/.github/workflows/scripts/ci_suite_coverage.py
+++ b/.github/workflows/scripts/ci_suite_coverage.py
@@ -38,8 +38,10 @@ Usage:
 
 from __future__ import annotations
 
+import functools
 import json
 import os
+import re
 import sys
 from typing import Iterable, Mapping
 
@@ -59,23 +61,61 @@ def classify_mode(shared_matched: bool) -> str:
     return FULL if shared_matched else FILTERED
 
 
-def _match_one(path: str, pattern: str) -> bool:
-    """Match a single repo-relative path against one dorny-style glob.
+def _glob_to_regex_body(pattern: str) -> str:
+    """Translate one dorny-style glob into an (unanchored) regex body.
 
-    Supports the pattern shapes used by the CI filters: a ``prefix/**``
-    directory glob, a ``**/*.ext`` suffix glob, and a literal path. This is a
-    deterministic subset of picomatch sufficient to mirror dorny's behavior for
-    the filters in ``ci.yml``; it is not a general glob engine.
+    Mirrors the picomatch semantics dorny/paths-filter relies on, covering
+    every glob shape the ``ci.yml`` filters actually use:
+
+      * ``*`` matches any run of characters within a single path segment
+        (it never crosses ``/``) — e.g. ``cmd/gc/session_*`` or the mid-path
+        ``cmd/gc/template_resolve*.go``.
+      * ``**`` matches across path segments.
+      * A leading ``**/`` collapses to zero-or-more segments, so ``**/*.go``
+        matches both ``main.go`` at the repo root and nested ``a/b/c.go``.
+      * A trailing ``/**`` matches the directory itself and everything under
+        it, so ``internal/beads/**`` covers ``internal/beads/store.go``.
     """
     if pattern.endswith("/**"):
-        prefix = pattern[: -len("/**")]
-        return path == prefix or path.startswith(prefix + "/")
-    if pattern.startswith("**/"):
-        suffix = pattern[len("**/") :]
-        if suffix.startswith("*"):
-            return path.endswith(suffix[1:])
-        return path == suffix or path.endswith("/" + suffix)
-    return path == pattern
+        return _glob_to_regex_body(pattern[: -len("/**")]) + r"(?:/.*)?"
+
+    parts: list[str] = []
+    i, n = 0, len(pattern)
+    while i < n:
+        char = pattern[i]
+        if char == "*":
+            if i + 1 < n and pattern[i + 1] == "*":
+                # ``**`` globstar; ``**/`` collapses to optional leading segments.
+                if i + 2 < n and pattern[i + 2] == "/":
+                    parts.append(r"(?:.*/)?")
+                    i += 3
+                    continue
+                parts.append(r".*")
+                i += 2
+                continue
+            parts.append(r"[^/]*")
+            i += 1
+            continue
+        parts.append(re.escape(char))
+        i += 1
+    return "".join(parts)
+
+
+@functools.lru_cache(maxsize=None)
+def _glob_to_regex(pattern: str) -> "re.Pattern[str]":
+    """Compile a dorny-style glob into a fully anchored regex.
+
+    Translating to a regex (rather than hand-casing a few prefixes) keeps the
+    simulator faithful to dorny for the full set of shapes, closing the
+    silent-under-fire gap where a real glob like ``cmd/gc/template_resolve*.go``
+    matched nothing.
+    """
+    return re.compile(_glob_to_regex_body(pattern) + r"\Z")
+
+
+def _match_one(path: str, pattern: str) -> bool:
+    """Match a single repo-relative path against one dorny-style glob."""
+    return _glob_to_regex(pattern).match(path) is not None
 
 
 def paths_match(changed_files: Iterable[str], globs: Iterable[str]) -> bool:

--- a/.github/workflows/scripts/ci_suite_coverage.py
+++ b/.github/workflows/scripts/ci_suite_coverage.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+r"""CI suite-coverage classification and aggregation.
+
+Companion to the ``changes`` job in ``.github/workflows/ci.yml``. That job
+gates downstream jobs on dorny/paths-filter outputs, so a change confined to
+one filter group skips jobs in other groups. A subtle cross-cutting change
+(e.g. an ``internal/beads`` edit that breaks a worker test) can therefore land
+without the affected jobs ever running. The ``shared`` filter closes that gap:
+when a cross-cutting core path changes it is folded into every gated output, so
+all downstream jobs run as a union ("full suite") regardless of their own
+filter result.
+
+This module is the deterministic mechanism behind that wiring and the metric
+that measures it. No semantic judgement lives here — callers pass the
+already-computed filter result (a boolean string) and these functions only do
+arithmetic and string matching:
+
+  * ``classify_mode`` — label a run ``full`` or ``filtered``.
+  * ``paths_match`` — dorny-compatible glob matching, used by the wiring test
+    to simulate which filters a changed-file set triggers.
+  * ``aggregate`` — compute the share of runs that took each path.
+
+Usage:
+
+  # In CI (the ``changes`` job), record this run's classification:
+  #   python3 ci_suite_coverage.py classify "$SHARED_FILTER_RESULT"
+  # Writes ``suite_mode`` to $GITHUB_OUTPUT and a row to $GITHUB_STEP_SUMMARY.
+
+  # Aggregate the metric across recent main-branch merges. Collect the
+  # per-run modes (emitted by the classify step as ``ci_suite_mode=<mode>``
+  # notices) and pipe them in, one token per line:
+  #   gh run list --workflow=CI --branch=main --json databaseId --jq '.[].databaseId' \
+  #     | while read -r id; do \
+  #         gh run view "$id" --log 2>/dev/null | sed -n 's/.*ci_suite_mode=\([a-z]*\).*/\1/p' | head -n1; \
+  #       done \
+  #     | python3 ci_suite_coverage.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Iterable, Mapping
+
+FULL = "full"
+FILTERED = "filtered"
+
+# Values dorny/paths-filter writes for a matched/unmatched filter.
+TRUE = "true"
+
+
+def classify_mode(shared_matched: bool) -> str:
+    """Return the suite mode for a run.
+
+    ``full`` means a cross-cutting core path changed, so every gated job ran.
+    ``filtered`` means only path-scoped jobs ran.
+    """
+    return FULL if shared_matched else FILTERED
+
+
+def _match_one(path: str, pattern: str) -> bool:
+    """Match a single repo-relative path against one dorny-style glob.
+
+    Supports the pattern shapes used by the CI filters: a ``prefix/**``
+    directory glob, a ``**/*.ext`` suffix glob, and a literal path. This is a
+    deterministic subset of picomatch sufficient to mirror dorny's behavior for
+    the filters in ``ci.yml``; it is not a general glob engine.
+    """
+    if pattern.endswith("/**"):
+        prefix = pattern[: -len("/**")]
+        return path == prefix or path.startswith(prefix + "/")
+    if pattern.startswith("**/"):
+        suffix = pattern[len("**/") :]
+        if suffix.startswith("*"):
+            return path.endswith(suffix[1:])
+        return path == suffix or path.endswith("/" + suffix)
+    return path == pattern
+
+
+def paths_match(changed_files: Iterable[str], globs: Iterable[str]) -> bool:
+    """Return True if any changed file matches any glob in the filter."""
+    globs = list(globs)
+    return any(_match_one(path, glob) for path in changed_files for glob in globs)
+
+
+def aggregate(modes: Iterable[str]) -> Mapping[str, object]:
+    """Summarize a sequence of run modes into coverage percentages."""
+    modes = list(modes)
+    total = len(modes)
+    full = sum(1 for mode in modes if mode == FULL)
+    filtered = sum(1 for mode in modes if mode == FILTERED)
+    unknown = total - full - filtered
+
+    def pct(count: int) -> float:
+        return round(100.0 * count / total, 1) if total else 0.0
+
+    return {
+        "total": total,
+        "full": full,
+        "filtered": filtered,
+        "unknown": unknown,
+        "full_pct": pct(full),
+        "filtered_pct": pct(filtered),
+    }
+
+
+def _emit_classification(shared_result: str) -> None:
+    """Record this run's suite mode for the metric.
+
+    Writes the ``suite_mode`` job output and a human-readable row to the step
+    summary, and prints a grep-able ``ci_suite_mode=<mode>`` notice that the
+    aggregation step harvests from run logs.
+    """
+    mode = classify_mode(shared_result.strip().lower() == TRUE)
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"suite_mode={mode}\n")
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as handle:
+            handle.write("## CI Suite Coverage\n\n")
+            handle.write(f"- mode: `{mode}`\n")
+            handle.write(f"- cross-cutting core path changed: `{shared_result}`\n")
+
+    # A workflow notice annotation, also grep-able from `gh run view --log`.
+    print(f"::notice title=CI suite coverage::ci_suite_mode={mode}")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 2 and argv[1] == "classify":
+        if len(argv) != 3:
+            print("usage: ci_suite_coverage.py classify <shared-filter-result>", file=sys.stderr)
+            return 2
+        _emit_classification(argv[2])
+        return 0
+
+    # Default: aggregate mode tokens read from stdin, one per line.
+    modes = [line.strip() for line in sys.stdin if line.strip()]
+    print(json.dumps(aggregate(modes), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/scripts/test_ci_suite_coverage.py
+++ b/.github/workflows/scripts/test_ci_suite_coverage.py
@@ -1,0 +1,147 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+import ci_suite_coverage as cov
+
+CI_YML = Path(__file__).resolve().parents[1] / "ci.yml"
+
+# Core substrates whose breakage ripples across every subsystem. Beads is the
+# universal persistence substrate, events the universal observation substrate,
+# config the universal activation mechanism (see AGENTS.md); build/dependency/CI
+# files affect every job. The `shared` filter must cover all of these.
+EXPECTED_SHARED_PATHS = {
+    "go.mod",
+    "go.sum",
+    "Makefile",
+    ".github/workflows/**",
+    "internal/beads/**",
+    "internal/events/**",
+    "internal/config/**",
+}
+
+# Outputs of the `changes` job that gate a downstream job. Each must fold the
+# `shared` filter into its value so a cross-cutting change runs the full suite.
+GATED_OUTPUTS = {
+    "mail",
+    "docker",
+    "k8s",
+    "packs",
+    "worker",
+    "worker_phase2",
+    "cmd_gc_process",
+    "integration",
+}
+
+
+def _load_changes_job():
+    workflow = yaml.safe_load(CI_YML.read_text(encoding="utf-8"))
+    return workflow["jobs"]["changes"]
+
+
+def _filter_globs():
+    """Return {filter_name: [globs]} parsed from the dorny filter block."""
+    changes = _load_changes_job()
+    for step in changes["steps"]:
+        if step.get("id") == "filter":
+            return yaml.safe_load(step["with"]["filters"])
+    raise AssertionError("filter step not found in changes job")
+
+
+class ClassifyModeTests(unittest.TestCase):
+    def test_shared_match_is_full(self) -> None:
+        self.assertEqual(cov.classify_mode(True), cov.FULL)
+
+    def test_no_shared_match_is_filtered(self) -> None:
+        self.assertEqual(cov.classify_mode(False), cov.FILTERED)
+
+
+class PathsMatchTests(unittest.TestCase):
+    def test_directory_glob_matches_nested_file(self) -> None:
+        self.assertTrue(cov.paths_match(["internal/beads/store.go"], ["internal/beads/**"]))
+
+    def test_directory_glob_does_not_match_sibling(self) -> None:
+        self.assertFalse(cov.paths_match(["internal/beadsx/store.go"], ["internal/beads/**"]))
+
+    def test_suffix_glob_matches_any_go_file(self) -> None:
+        self.assertTrue(cov.paths_match(["cmd/gc/main.go"], ["**/*.go"]))
+
+    def test_literal_path_matches_exactly(self) -> None:
+        self.assertTrue(cov.paths_match(["go.mod"], ["go.mod"]))
+        self.assertFalse(cov.paths_match(["go.sum"], ["go.mod"]))
+
+
+class AggregateTests(unittest.TestCase):
+    def test_percentages(self) -> None:
+        result = cov.aggregate([cov.FULL, cov.FILTERED, cov.FILTERED, cov.FULL])
+        self.assertEqual(result["total"], 4)
+        self.assertEqual(result["full"], 2)
+        self.assertEqual(result["filtered"], 2)
+        self.assertEqual(result["full_pct"], 50.0)
+        self.assertEqual(result["filtered_pct"], 50.0)
+
+    def test_empty_is_zero_not_division_error(self) -> None:
+        result = cov.aggregate([])
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["full_pct"], 0.0)
+
+    def test_unknown_tokens_counted_separately(self) -> None:
+        result = cov.aggregate([cov.FULL, "weird"])
+        self.assertEqual(result["unknown"], 1)
+
+
+class WiringTests(unittest.TestCase):
+    """Assert the option-A union wiring is present and correct in ci.yml."""
+
+    def test_shared_filter_covers_core_substrates(self) -> None:
+        filters = _filter_globs()
+        self.assertIn("shared", filters, "changes job must define a `shared` filter")
+        shared = set(filters["shared"])
+        missing = EXPECTED_SHARED_PATHS - shared
+        self.assertFalse(missing, f"shared filter missing core paths: {sorted(missing)}")
+
+    def test_gated_outputs_fold_in_shared(self) -> None:
+        outputs = _load_changes_job()["outputs"]
+        for name in GATED_OUTPUTS:
+            self.assertIn(name, outputs, f"missing changes output: {name}")
+            expr = outputs[name]
+            self.assertIn(
+                "shared",
+                expr,
+                f"output `{name}` must fold in the shared filter so cross-cutting "
+                f"changes run the full suite; got: {expr!r}",
+            )
+
+    def test_changes_job_exposes_shared_and_suite_mode(self) -> None:
+        outputs = _load_changes_job()["outputs"]
+        self.assertIn("shared", outputs, "raw `shared` output drives the coverage metric")
+        self.assertIn("suite_mode", outputs, "`suite_mode` output records the metric per run")
+
+
+class AcceptanceScenarioTests(unittest.TestCase):
+    """Acceptance scenario: cross-cutting change forces the full suite.
+
+    A PR that only touches cmd/gc/foo.go AND modifies a shared type used by
+    integration tests must run the integration job, not skip it.
+    """
+
+    def test_cmd_gc_plus_shared_core_change_runs_full_suite(self) -> None:
+        filters = _filter_globs()
+        changed = ["cmd/gc/foo.go", "internal/beads/widget.go"]
+
+        shared_fires = cov.paths_match(changed, filters["shared"])
+        self.assertTrue(shared_fires, "a core-substrate edit must trigger the shared filter")
+
+        mode = cov.classify_mode(shared_fires)
+        self.assertEqual(mode, cov.FULL, "cross-cutting change must classify as a full-suite run")
+
+        # The integration output folds shared in, so the integration-shards job
+        # gate (`needs.changes.outputs.integration == 'true'`) is satisfied even
+        # if the integration filter had not matched on its own.
+        integration_expr = _load_changes_job()["outputs"]["integration"]
+        self.assertIn("shared", integration_expr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/scripts/test_ci_suite_coverage.py
+++ b/.github/workflows/scripts/test_ci_suite_coverage.py
@@ -71,6 +71,69 @@ class PathsMatchTests(unittest.TestCase):
         self.assertTrue(cov.paths_match(["go.mod"], ["go.mod"]))
         self.assertFalse(cov.paths_match(["go.sum"], ["go.mod"]))
 
+    def test_trailing_wildcard_matches_within_segment(self) -> None:
+        # `cmd/gc/session_*` and `contrib/session-scripts/gc-session-k8s*`
+        self.assertTrue(cov.paths_match(["cmd/gc/session_pool.go"], ["cmd/gc/session_*"]))
+        self.assertTrue(
+            cov.paths_match(
+                ["contrib/session-scripts/gc-session-k8s-runner"],
+                ["contrib/session-scripts/gc-session-k8s*"],
+            )
+        )
+
+    def test_trailing_wildcard_does_not_cross_slash(self) -> None:
+        # `*` must not match a path separator, mirroring picomatch/dorny.
+        self.assertFalse(cov.paths_match(["cmd/gc/session_sub/extra.go"], ["cmd/gc/session_*"]))
+
+    def test_mid_path_wildcard_with_suffix(self) -> None:
+        # `cmd/gc/template_resolve*.go`
+        self.assertTrue(
+            cov.paths_match(
+                ["cmd/gc/template_resolve_t3bridge.go"],
+                ["cmd/gc/template_resolve*.go"],
+            )
+        )
+        self.assertFalse(
+            cov.paths_match(
+                ["cmd/gc/template_resolve_t3bridge.txt"], ["cmd/gc/template_resolve*.go"]
+            )
+        )
+
+    def test_embedded_globstar(self) -> None:
+        # `test/**worker**` matches any test path containing "worker".
+        self.assertTrue(
+            cov.paths_match(["test/integration/session_worker_test.go"], ["test/**worker**"])
+        )
+        self.assertFalse(cov.paths_match(["test/integration/mail_test.go"], ["test/**worker**"]))
+
+    def test_root_file_matches_leading_globstar_suffix(self) -> None:
+        # `**/*.go` must match a repo-root file, not only nested ones.
+        self.assertTrue(cov.paths_match(["main.go"], ["**/*.go"]))
+
+    def test_simulator_handles_every_glob_shape_in_ci_yml(self) -> None:
+        """Regression guard: a representative path for each real ci.yml glob
+        must match its glob. Catches a filter glob whose shape the simulator
+        silently fails to match (the under-fire failure mode this module
+        exists to detect)."""
+        # One sample path constructed to match each glob shape present in the
+        # ci.yml filters. Globstar/literal shapes are exercised above; this
+        # pins the trailing/mid-path single-star shapes against the live globs.
+        samples = {
+            "cmd/gc/template_resolve*.go": "cmd/gc/template_resolve_t3bridge.go",
+            "cmd/gc/session_*": "cmd/gc/session_pool.go",
+            "contrib/session-scripts/gc-session-k8s*": (
+                "contrib/session-scripts/gc-session-k8s-runner"
+            ),
+            "test/**worker**": "test/integration/session_worker_test.go",
+        }
+        all_globs = {glob for globs in _filter_globs().values() for glob in globs}
+        for glob, sample in samples.items():
+            self.assertIn(glob, all_globs, f"sample glob no longer present in ci.yml: {glob}")
+            self.assertTrue(
+                cov.paths_match([sample], [glob]),
+                f"simulator fails to match {sample!r} against live ci.yml glob {glob!r}",
+            )
+
 
 class AggregateTests(unittest.TestCase):
     def test_percentages(self) -> None:


### PR DESCRIPTION
## Summary
CI gates downstream jobs on `dorny/paths-filter` outputs, so a change confined to one filter group skips jobs in other groups. A subtle cross-cutting change (e.g. an `internal/beads` edit that breaks a worker test) can land without the affected jobs ever running, surfacing later on an unrelated PR that happens to touch those paths. This closes that path-filter asymmetry and adds a metric to measure how often it mattered.

## What changed
- Add a `shared` filter in the `changes` job covering cross-cutting core paths: `go.mod`, `go.sum`, `Makefile`, `.github/workflows/**`, and the three universal substrates — `internal/beads/**` (persistence), `internal/events/**` (observation), `internal/config/**` (activation).
- Fold `shared` into every *gated* output (`mail`, `docker`, `k8s`, `packs`, `worker`, `worker_phase2`, `cmd_gc_process`, `integration`) as `<filter> == 'true' || shared == 'true'`. A change to any shared path now forces a full union run. Downstream consumers read the outputs unchanged, so the worker fan-in summary stays correct with no per-job edits.
- Add a suite-coverage metric: a `Classify suite coverage` step labels each run `full` or `filtered`, writes it to the step summary and a grep-able notice, and exposes `suite_mode`. `ci_suite_coverage.py aggregate` computes the share of full-suite runs across merges so the coverage gap is measurable over time.

## Why
Path-scoped CI is fast but lets cross-cutting regressions slip through the gaps between filter groups. Routing shared-substrate changes through the full suite restores correctness for the changes most likely to ripple, while the metric makes the previously-invisible coverage gap observable.

## Test plan
- [x] `make build` — passes
- [x] `make check` (fmt-check, lint, vet, check-routed-test-rows, full Go suite) — passes, lint 0 issues
- [x] `python3 -m pytest test_ci_suite_coverage.py` — 13 passed (classify, glob matching, aggregate incl. empty-input, and `ci.yml` wiring assertions)
- [x] `ci.yml` parses as valid YAML; `classify` and `aggregate` CLI paths verified by hand
- [ ] Confirm on a real PR that a `shared`-path change flips `suite_mode` to `full` and runs the previously-skipped jobs
