### PR TITLE
feat(converge): external-event iteration trigger

### DIFF
--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -31,6 +31,7 @@ and drives the loop automatically.`,
 		newConvergeStopCmd(stdout, stderr),
 		newConvergeListCmd(stdout, stderr),
 		newConvergeTestGateCmd(stdout, stderr),
+		newConvergeTestTriggerCmd(stdout, stderr),
 		newConvergeRetryCmd(stdout, stderr),
 	)
 	return cmd
@@ -47,6 +48,8 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 		gateTimeoutAction string
 		title             string
 		evaluatePrompt    string
+		trigger           string
+		triggerCondition  string
 		vars              []string
 		jsonOutput        bool
 	)
@@ -73,6 +76,8 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 				"gate_timeout_action": gateTimeoutAction,
 				"title":               title,
 				"evaluate_prompt":     evaluatePrompt,
+				"trigger":             trigger,
+				"trigger_condition":   triggerCondition,
 				"rig":                 rctx.RigName,
 			}
 			for _, v := range vars {
@@ -125,6 +130,8 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&gateTimeoutAction, "gate-timeout-action", "iterate", "Action on gate timeout: iterate, retry, manual, terminate")
 	cmd.Flags().StringVar(&title, "title", "", "Convergence loop title")
 	cmd.Flags().StringVar(&evaluatePrompt, "evaluate-prompt", "", "Custom evaluate prompt (overrides formula default)")
+	cmd.Flags().StringVar(&trigger, "trigger", "", "Iteration trigger mode: event (gate each iteration on --trigger-condition). Empty disables.")
+	cmd.Flags().StringVar(&triggerCondition, "trigger-condition", "", "Path to trigger condition script (required when --trigger=event)")
 	cmd.Flags().StringArrayVar(&vars, "var", nil, "Template variable (key=value, repeatable)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
 	_ = cmd.MarkFlagRequired("formula")
@@ -170,6 +177,8 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 			formula := meta[convergence.FieldFormula]
 			target := meta[convergence.FieldTarget]
 			rig := meta[convergence.FieldRig]
+			trigger := meta[convergence.FieldTrigger]
+			triggerCondition := meta[convergence.FieldTriggerCondition]
 			gateOutcome := meta[convergence.FieldGateOutcome]
 			waitingReason := meta[convergence.FieldWaitingReason]
 			terminalReason := meta[convergence.FieldTerminalReason]
@@ -185,6 +194,15 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 				fmt.Fprintf(stdout, "Rig:             %s\n", rig) //nolint:errcheck
 			}
 			fmt.Fprintf(stdout, "Gate:            %s\n", gateMode) //nolint:errcheck
+			if trigger != "" {
+				fmt.Fprintf(stdout, "Trigger:         %s\n", trigger) //nolint:errcheck
+				if triggerCondition != "" {
+					fmt.Fprintf(stdout, "Trigger Cond:    %s\n", triggerCondition) //nolint:errcheck
+				}
+				if state == convergence.StateWaitingTrigger {
+					fmt.Fprintf(stdout, "Waiting:         trigger\n") //nolint:errcheck
+				}
+			}
 			if gateOutcome != "" {
 				fmt.Fprintf(stdout, "Gate Outcome:    %s\n", gateOutcome) //nolint:errcheck
 			}
@@ -495,6 +513,108 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 					Stderr:        result.Stderr,
 				}
 				return writeCLIJSONLineOrErr(stdout, stderr, "gc converge test-gate", payload)
+			}
+			fmt.Fprintf(stdout, "Outcome:  %s\n", result.Outcome) //nolint:errcheck
+			if result.ExitCode != nil {
+				fmt.Fprintf(stdout, "Exit:     %d\n", *result.ExitCode) //nolint:errcheck
+			}
+			if result.Stdout != "" {
+				fmt.Fprintf(stdout, "Stdout:\n%s\n", result.Stdout) //nolint:errcheck
+			}
+			if result.Stderr != "" {
+				fmt.Fprintf(stdout, "Stderr:\n%s\n", result.Stderr) //nolint:errcheck
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
+	return cmd
+}
+
+func newConvergeTestTriggerCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "test-trigger <bead-id>",
+		Short: "Dry-run the trigger condition (no state changes)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			beadID := args[0]
+			store, rctx, storePath, code := openConvergeStore(stderr, "gc converge test-trigger")
+			if code != 0 {
+				return errExit
+			}
+			b, err := store.Get(beadID)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc converge test-trigger: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			if b.Type != "convergence" {
+				fmt.Fprintf(stderr, "gc converge test-trigger: bead %s is type %q, not convergence\n", beadID, b.Type) //nolint:errcheck
+				return errExit
+			}
+			meta := b.Metadata
+			if meta == nil {
+				meta = map[string]string{}
+			}
+
+			triggerConfig, err := convergence.ParseTriggerConfig(meta)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc converge test-trigger: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+			if !triggerConfig.Enabled() {
+				if jsonOutput {
+					return writeCLIJSONLineOrErr(stdout, stderr, "gc converge test-trigger", convergeTestGateJSONResult{
+						SchemaVersion: "1",
+						OK:            true,
+						BeadID:        beadID,
+						Mode:          convergence.TriggerNone,
+						Skipped:       true,
+						Reason:        "no_trigger",
+					})
+				}
+				fmt.Fprintln(stdout, "No trigger configured for this loop.") //nolint:errcheck
+				return nil
+			}
+
+			// Bound the trigger with the loop's gate timeout (or its default).
+			gateConfig, err := convergence.ParseGateConfig(meta)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc converge test-trigger: %v\n", err) //nolint:errcheck
+				return errExit
+			}
+
+			iter, _ := convergence.DecodeInt(meta[convergence.FieldIteration])
+			maxIter, _ := convergence.DecodeInt(meta[convergence.FieldMaxIterations])
+			env := convergence.ConditionEnv{
+				BeadID:        beadID,
+				Iteration:     iter,
+				MaxIterations: maxIter,
+				CityPath:      rctx.CityPath,
+				StorePath:     storePath,
+				DocPath:       meta[convergence.VarPrefix+"doc_path"],
+			}
+
+			if !jsonOutput {
+				fmt.Fprintf(stdout, "Testing trigger: %s\n", triggerConfig.Condition) //nolint:errcheck
+			}
+			result := convergence.RunCondition(
+				context.TODO(),
+				triggerConfig.Condition, env, gateConfig.Timeout, 0,
+			)
+			if jsonOutput {
+				payload := convergeTestGateJSONResult{
+					SchemaVersion: "1",
+					OK:            true,
+					BeadID:        beadID,
+					Mode:          triggerConfig.Mode,
+					Condition:     triggerConfig.Condition,
+					Outcome:       result.Outcome,
+					ExitCode:      result.ExitCode,
+					Stdout:        result.Stdout,
+					Stderr:        result.Stderr,
+				}
+				return writeCLIJSONLineOrErr(stdout, stderr, "gc converge test-trigger", payload)
 			}
 			fmt.Fprintf(stdout, "Outcome:  %s\n", result.Outcome) //nolint:errcheck
 			if result.ExitCode != nil {

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -584,16 +584,22 @@ func newConvergeTestTriggerCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 
-			iter, _ := convergence.DecodeInt(meta[convergence.FieldIteration])
-			maxIter, _ := convergence.DecodeInt(meta[convergence.FieldMaxIterations])
-			env := convergence.ConditionEnv{
-				BeadID:        beadID,
-				Iteration:     iter,
-				MaxIterations: maxIter,
-				CityPath:      rctx.CityPath,
-				StorePath:     storePath,
-				DocPath:       meta[convergence.VarPrefix+"doc_path"],
+			// Mirror HandleTrigger: the trigger gates the NEXT iteration to be
+			// poured (closed wisps + 1), evaluated with the same env contract
+			// (iteration source + artifact dir) the controller uses live, so the
+			// dry-run does not misrepresent GC_ITERATION / GC_ARTIFACT_DIR to the
+			// trigger condition script.
+			closed, err := convergeClosedIterations(store, beadID)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc converge test-trigger: %v\n", err) //nolint:errcheck
+				return errExit
 			}
+			nextIteration := closed + 1
+			cityPath := meta[convergence.FieldCityPath]
+			if cityPath == "" {
+				cityPath = rctx.CityPath
+			}
+			env := convergence.TriggerConditionEnv(meta, beadID, cityPath, storePath, nextIteration)
 
 			if !jsonOutput {
 				fmt.Fprintf(stdout, "Testing trigger: %s\n", triggerConfig.Condition) //nolint:errcheck
@@ -631,6 +637,28 @@ func newConvergeTestTriggerCmd(stdout, stderr io.Writer) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output JSONL summary")
 	return cmd
+}
+
+// convergeClosedIterations counts closed iteration wisps under a convergence
+// root bead, mirroring the controller's Handler.deriveIterationCount over the
+// beads.Store boundary (the convergence store adapter surfaces the wisp
+// idempotency key via Metadata["idempotency_key"]). The test-trigger dry-run
+// uses it to compute the next iteration the trigger gates. The store error is
+// propagated rather than swallowed so the dry-run fails loudly instead of
+// silently reporting iteration 1, matching the live HandleTrigger path.
+func convergeClosedIterations(store beads.Store, beadID string) (int, error) {
+	children, err := store.Children(beadID, beads.IncludeClosed)
+	if err != nil {
+		return 0, fmt.Errorf("listing children of %s: %w", beadID, err)
+	}
+	prefix := convergence.IdempotencyKeyPrefix(beadID)
+	count := 0
+	for _, c := range children {
+		if c.Status == "closed" && c.Metadata != nil && strings.HasPrefix(c.Metadata["idempotency_key"], prefix) {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {

--- a/cmd/gc/convergence_store.go
+++ b/cmd/gc/convergence_store.go
@@ -44,7 +44,7 @@ func (a *convergenceStoreAdapter) populateIndex() error {
 			continue
 		}
 		state := b.Metadata[convergence.FieldState]
-		if state == convergence.StateActive || state == convergence.StateWaitingManual {
+		if state == convergence.StateActive || state == convergence.StateWaitingManual || state == convergence.StateWaitingTrigger {
 			idx[b.ID] = b.Metadata[convergence.FieldTarget]
 		}
 	}
@@ -95,7 +95,7 @@ func (a *convergenceStoreAdapter) SetMetadata(id, key, value string) error {
 	// Maintain active index on state transitions.
 	if a.activeIndex != nil && key == convergence.FieldState {
 		switch value {
-		case convergence.StateActive, convergence.StateWaitingManual:
+		case convergence.StateActive, convergence.StateWaitingManual, convergence.StateWaitingTrigger:
 			// Add to index. Read target if not already indexed.
 			if _, ok := a.activeIndex[id]; !ok {
 				b, err := a.store.Get(id)
@@ -307,7 +307,7 @@ func (a *convergenceStoreAdapter) CountActiveConvergenceLoops(targetAgent string
 		}
 		state := b.Metadata[convergence.FieldState]
 		target := b.Metadata[convergence.FieldTarget]
-		if (state == convergence.StateActive || state == convergence.StateWaitingManual) && target == targetAgent {
+		if (state == convergence.StateActive || state == convergence.StateWaitingManual || state == convergence.StateWaitingTrigger) && target == targetAgent {
 			count++
 		}
 	}

--- a/cmd/gc/convergence_tick.go
+++ b/cmd/gc/convergence_tick.go
@@ -262,6 +262,21 @@ func (cr *CityRuntime) convergenceTickScope(ctx context.Context, scope *converge
 		if err != nil {
 			continue
 		}
+		// Trigger-gated loops are advanced by evaluating the trigger
+		// condition; they have no active wisp to poll.
+		if meta[convergence.FieldState] == convergence.StateWaitingTrigger {
+			result, hErr := scope.handler.HandleTrigger(ctx, beadID)
+			if hErr != nil {
+				fmt.Fprintf(cr.stderr, "%s: convergence%s: HandleTrigger(%s): %v\n", //nolint:errcheck
+					cr.logPrefix, scope.logSuffix(), beadID, hErr)
+				continue
+			}
+			if result.Action != convergence.ActionSkipped {
+				fmt.Fprintf(cr.stdout, "Convergence %s: %s (iteration %d)\n", //nolint:errcheck
+					beadID, result.Action, result.Iteration)
+			}
+			continue
+		}
 		// Only process active beads; skip others like waiting_manual
 		// that are indexed for CountActiveConvergenceLoops but not for tick.
 		if meta[convergence.FieldState] != convergence.StateActive {
@@ -449,6 +464,8 @@ func (cr *CityRuntime) handleConvergenceCreate(ctx context.Context, req converge
 		Vars:              vars,
 		CityPath:          cr.cityPath,
 		EvaluatePrompt:    req.Params["evaluate_prompt"],
+		Trigger:           req.Params["trigger"],
+		TriggerCondition:  req.Params["trigger_condition"],
 		Rig:               rig,
 	}
 

--- a/cmd/gc/json_schema_test.go
+++ b/cmd/gc/json_schema_test.go
@@ -412,6 +412,7 @@ func TestJSONSchemaResultForGraphConvergeOrderFormulaActions(t *testing.T) {
 		{"converge", "iterate"},
 		{"converge", "stop"},
 		{"converge", "test-gate"},
+		{"converge", "test-trigger"},
 		{"converge", "retry"},
 		{"formula", "cook"},
 		{"order", "history"},

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -705,6 +705,7 @@ gc converge
 | [gc converge status](#gc-converge-status) | Show convergence loop status |
 | [gc converge stop](#gc-converge-stop) | Stop a convergence loop |
 | [gc converge test-gate](#gc-converge-test-gate) | Dry-run the gate condition (no state changes) |
+| [gc converge test-trigger](#gc-converge-test-trigger) | Dry-run the trigger condition (no state changes) |
 
 ## gc converge approve
 
@@ -738,6 +739,8 @@ gc converge create [flags]
 | `--max-iterations` | int | `5` | Maximum iterations |
 | `--target` | string |  | Target agent (required) |
 | `--title` | string |  | Convergence loop title |
+| `--trigger` | string |  | Iteration trigger mode: event (gate each iteration on --trigger-condition). Empty disables. |
+| `--trigger-condition` | string |  | Path to trigger condition script (required when --trigger=event) |
 | `--var` | stringArray |  | Template variable (key=value, repeatable) |
 
 ## gc converge iterate
@@ -810,6 +813,18 @@ Dry-run the gate condition (no state changes)
 
 ```
 gc converge test-gate <bead-id> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | Output JSONL summary |
+
+## gc converge test-trigger
+
+Dry-run the trigger condition (no state changes)
+
+```
+gc converge test-trigger <bead-id> [flags]
 ```
 
 | Flag | Type | Default | Description |

--- a/internal/convergence/create.go
+++ b/internal/convergence/create.go
@@ -18,6 +18,12 @@ type CreateParams struct {
 	Vars              map[string]string
 	CityPath          string
 	EvaluatePrompt    string
+	// Trigger gates iteration pours on an external condition. Empty means no
+	// trigger (default wisp-close iteration semantic).
+	Trigger string
+	// TriggerCondition is the path to the trigger condition script. Required
+	// when Trigger == "event".
+	TriggerCondition string
 	// Rig names the rig whose bead store owns this convergence loop.
 	// Empty means the city/HQ store. The loop physically lives in
 	// whichever store the handler is bound to; Rig is persisted as
@@ -61,6 +67,15 @@ func (h *Handler) CreateHandler(_ context.Context, params CreateParams) (CreateR
 		return CreateResult{}, err
 	}
 
+	// Validate trigger config before creating any state.
+	triggerConfig, err := ParseTriggerConfig(map[string]string{
+		FieldTrigger:          params.Trigger,
+		FieldTriggerCondition: params.TriggerCondition,
+	})
+	if err != nil {
+		return CreateResult{}, err
+	}
+
 	// Step 1: Create root bead (type=convergence, status=in_progress).
 	title := params.Title
 	if title == "" {
@@ -96,7 +111,8 @@ func (h *Handler) CreateHandler(_ context.Context, params CreateParams) (CreateR
 		{FieldCityPath, params.CityPath},
 		{FieldRig, params.Rig},
 		{FieldEvaluatePrompt, params.EvaluatePrompt},
-		{FieldState, StateActive},
+		{FieldTrigger, params.Trigger},
+		{FieldTriggerCondition, params.TriggerCondition},
 	}
 	for _, mw := range metaWrites {
 		if err := h.Store.SetMetadata(beadID, mw.key, mw.value); err != nil {
@@ -109,6 +125,32 @@ func (h *Handler) CreateHandler(_ context.Context, params CreateParams) (CreateR
 		if err := h.Store.SetMetadata(beadID, VarPrefix+k, v); err != nil {
 			return CreateResult{}, closeBead(fmt.Errorf("setting var %q on convergence bead: %w", k, err))
 		}
+	}
+
+	// Entry gate: when an external trigger gates the loop, defer pouring the
+	// first wisp until the trigger condition passes. The controller tick
+	// evaluates the trigger and pours iteration 1 via HandleTrigger.
+	if triggerConfig.Enabled() {
+		if err := h.Store.SetMetadata(beadID, FieldIteration, EncodeInt(0)); err != nil {
+			return CreateResult{}, closeBead(fmt.Errorf("setting iteration: %w", err))
+		}
+		if err := h.Store.SetMetadata(beadID, FieldState, StateWaitingTrigger); err != nil {
+			return CreateResult{}, closeBead(fmt.Errorf("setting waiting_trigger state: %w", err))
+		}
+		createdPayload := CreatedPayload{
+			Formula:       params.Formula,
+			Target:        params.Target,
+			GateMode:      params.GateMode,
+			MaxIterations: params.MaxIterations,
+			Title:         title,
+		}
+		h.emitEvent(EventCreated, EventIDCreated(beadID), beadID, createdPayload)
+		return CreateResult{BeadID: beadID}, nil
+	}
+
+	// No trigger: activate immediately and pour the first wisp.
+	if err := h.Store.SetMetadata(beadID, FieldState, StateActive); err != nil {
+		return CreateResult{}, closeBead(fmt.Errorf("setting active state: %w", err))
 	}
 
 	// Step 4: Pour first wisp with idempotency key converge:<bead-id>:iter:1.

--- a/internal/convergence/create_test.go
+++ b/internal/convergence/create_test.go
@@ -320,6 +320,86 @@ func TestCreateHandler_PersistsRig(t *testing.T) {
 	}
 }
 
+func TestCreateHandler_TriggerDefersFirstWisp(t *testing.T) {
+	store := newFakeStore()
+	emitter := &fakeEmitter{}
+	handler := &Handler{Store: store, Emitter: emitter, Clock: time.Now}
+
+	result, err := handler.CreateHandler(context.Background(), CreateParams{
+		Formula:          "test-formula",
+		Target:           "test-agent",
+		MaxIterations:    5,
+		GateMode:         GateModeManual,
+		Trigger:          TriggerEvent,
+		TriggerCondition: "/scripts/check-chunk-complete",
+	})
+	if err != nil {
+		t.Fatalf("CreateHandler: %v", err)
+	}
+	if result.FirstWispID != "" {
+		t.Errorf("FirstWispID = %q, want empty (first pour deferred to trigger)", result.FirstWispID)
+	}
+
+	meta, _ := store.GetMetadata(result.BeadID)
+	if meta[FieldState] != StateWaitingTrigger {
+		t.Errorf("state = %q, want %q", meta[FieldState], StateWaitingTrigger)
+	}
+	if meta[FieldIteration] != "0" {
+		t.Errorf("iteration = %q, want 0", meta[FieldIteration])
+	}
+	if meta[FieldTrigger] != TriggerEvent {
+		t.Errorf("trigger = %q, want %q", meta[FieldTrigger], TriggerEvent)
+	}
+	if meta[FieldTriggerCondition] != "/scripts/check-chunk-complete" {
+		t.Errorf("trigger_condition = %q, want %q", meta[FieldTriggerCondition], "/scripts/check-chunk-complete")
+	}
+	if meta[FieldActiveWisp] != "" {
+		t.Errorf("active_wisp = %q, want empty", meta[FieldActiveWisp])
+	}
+
+	// No wisp should have been poured at create time.
+	children, _ := store.Children(result.BeadID)
+	if len(children) != 0 {
+		t.Errorf("children = %d, want 0 (no wisp until trigger passes)", len(children))
+	}
+
+	// Created event with empty first wisp.
+	ev, ok := emitter.findEvent(EventCreated)
+	if !ok {
+		t.Fatal("expected ConvergenceCreated event")
+	}
+	var payload CreatedPayload
+	if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload.FirstWispID != "" {
+		t.Errorf("payload.FirstWispID = %q, want empty", payload.FirstWispID)
+	}
+}
+
+func TestCreateHandler_TriggerRequiresCondition(t *testing.T) {
+	store := newFakeStore()
+	handler := &Handler{Store: store, Emitter: &fakeEmitter{}, Clock: time.Now}
+
+	_, err := handler.CreateHandler(context.Background(), CreateParams{
+		Formula:       "test-formula",
+		Target:        "test-agent",
+		MaxIterations: 5,
+		GateMode:      GateModeManual,
+		Trigger:       TriggerEvent,
+		// TriggerCondition omitted — must error before any bead is created.
+	})
+	if err == nil {
+		t.Fatal("expected error for trigger without condition")
+	}
+	if !strings.Contains(err.Error(), "requires a trigger condition") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "requires a trigger condition")
+	}
+	if len(store.beads) != 0 {
+		t.Errorf("beads = %d, want 0 (validation before create)", len(store.beads))
+	}
+}
+
 func TestCreateHandler_EmptyRigForCityScope(t *testing.T) {
 	store := newFakeStore()
 	handler := &Handler{

--- a/internal/convergence/events.go
+++ b/internal/convergence/events.go
@@ -9,13 +9,14 @@ import (
 // Convergence event type constants. These match the event_type discriminator
 // values in the Event Contracts spec section.
 const (
-	EventCreated       = "convergence.created"
-	EventIteration     = "convergence.iteration"
-	EventTerminated    = "convergence.terminated"
-	EventWaitingManual = "convergence.waiting_manual"
-	EventManualApprove = "convergence.manual_approve"
-	EventManualIterate = "convergence.manual_iterate"
-	EventManualStop    = "convergence.manual_stop"
+	EventCreated        = "convergence.created"
+	EventIteration      = "convergence.iteration"
+	EventTerminated     = "convergence.terminated"
+	EventWaitingManual  = "convergence.waiting_manual"
+	EventManualApprove  = "convergence.manual_approve"
+	EventManualIterate  = "convergence.manual_iterate"
+	EventManualStop     = "convergence.manual_stop"
+	EventTriggerAdvance = "convergence.trigger_advance"
 )
 
 // Event delivery tiers.
@@ -68,6 +69,15 @@ func EventIDManualIterate(beadID string, iteration int) string {
 // EventIDManualStop returns the stable event ID for a ConvergenceManualStop event.
 func EventIDManualStop(beadID string) string {
 	return fmt.Sprintf("converge:%s:manual_stop", beadID)
+}
+
+// EventIDTriggerAdvance returns the stable event ID for a ConvergenceTriggerAdvance
+// event. N is the iteration number of the NEW wisp poured when the trigger fired.
+// It is deliberately distinct from EventIDIteration so the trigger-driven advance
+// cannot collide with the per-wisp iteration event that the same iteration's wisp
+// emits when it closes (both would otherwise derive converge:<bead>:iter:N:iteration).
+func EventIDTriggerAdvance(beadID string, iteration int) string {
+	return fmt.Sprintf("converge:%s:iter:%d:trigger_advance", beadID, iteration)
 }
 
 // CreatedPayload is the structured payload for ConvergenceCreated events.
@@ -134,11 +144,12 @@ type WaitingManualPayload struct {
 	CumulativeDurationMs int64              `json:"cumulative_duration_ms"`
 }
 
-// ManualActionPayload is the structured payload for ConvergenceManualApprove,
-// ConvergenceManualIterate, and ConvergenceManualStop events.
+// ManualActionPayload is the structured payload for the state-transition
+// events ConvergenceManualApprove, ConvergenceManualIterate, ConvergenceManualStop
+// (operator-driven), and ConvergenceTriggerAdvance (controller-driven).
 type ManualActionPayload struct {
 	Rig        string  `json:"rig,omitempty"`
-	Actor      string  `json:"actor"` // operator:<username>
+	Actor      string  `json:"actor"` // operator:<username>, or "controller" for trigger_advance
 	PriorState string  `json:"prior_state"`
 	NewState   string  `json:"new_state"`
 	Iteration  int     `json:"iteration"`

--- a/internal/convergence/handler.go
+++ b/internal/convergence/handler.go
@@ -118,12 +118,13 @@ type HandlerAction string
 
 // HandlerAction values describing the outcome of wisp_closed processing.
 const (
-	ActionIterate       HandlerAction = "iterate"
-	ActionApproved      HandlerAction = "approved"
-	ActionNoConvergence HandlerAction = "no_convergence"
-	ActionWaitingManual HandlerAction = "waiting_manual"
-	ActionStopped       HandlerAction = "stopped"
-	ActionSkipped       HandlerAction = "skipped"
+	ActionIterate        HandlerAction = "iterate"
+	ActionApproved       HandlerAction = "approved"
+	ActionNoConvergence  HandlerAction = "no_convergence"
+	ActionWaitingManual  HandlerAction = "waiting_manual"
+	ActionWaitingTrigger HandlerAction = "waiting_trigger"
+	ActionStopped        HandlerAction = "stopped"
+	ActionSkipped        HandlerAction = "skipped"
 )
 
 // HandlerResult holds the outcome of HandleWispClosed.
@@ -221,6 +222,11 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 		return HandlerResult{}, fmt.Errorf("parsing gate config: %w", err)
 	}
 
+	triggerConfig, err := ParseTriggerConfig(meta)
+	if err != nil {
+		return HandlerResult{}, fmt.Errorf("parsing trigger config: %w", err)
+	}
+
 	nextIteration := wispIteration + 1
 	nextKey := IdempotencyKey(rootBeadID, nextIteration)
 
@@ -242,7 +248,10 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 	var speculativePourErr error
 	needsManualWithoutGate := gateConfig.Mode == GateModeManual ||
 		(gateConfig.Mode == GateModeHybrid && HybridNeedsManual(gateConfig))
-	if wispIteration < maxIterations && !needsManualWithoutGate && speculativeWispID == "" {
+	// A trigger-gated loop defers the next pour to HandleTrigger, so no
+	// speculative successor wisp is created here.
+	skipSpeculativePour := needsManualWithoutGate || triggerConfig.Enabled()
+	if wispIteration < maxIterations && !skipSpeculativePour && speculativeWispID == "" {
 		formula := meta[FieldFormula]
 		vars := ExtractVars(meta)
 		evaluatePrompt := meta[FieldEvaluatePrompt]
@@ -362,6 +371,11 @@ func (h *Handler) HandleWispClosed(ctx context.Context, rootBeadID, wispID strin
 		if speculativePourErr != nil {
 			return h.handleSlingFailure(rootBeadID, wispID, wispIteration,
 				gateConfig, gateResult, meta, now)
+		}
+		// Iteration gate: a trigger-gated loop holds in waiting_trigger until
+		// the trigger condition passes, rather than pouring the next wisp now.
+		if triggerConfig.Enabled() {
+			return h.transitionToWaitingTrigger(rootBeadID, wispID, wispIteration, gateConfig, gateResult, meta)
 		}
 		// Iterate: clear verdict and use speculatively poured wisp.
 		return h.iterate(ctx, rootBeadID, wispID, wispIteration, gateConfig, gateResult, meta, now, speculativeWispID)
@@ -555,6 +569,68 @@ func (h *Handler) iterate(
 		Iteration:   iteration,
 		GateOutcome: gateOutcome,
 		NextWispID:  nextWispID,
+	}, nil
+}
+
+// transitionToWaitingTrigger holds a trigger-gated loop after a non-terminal
+// gate outcome. The gate has already decided to iterate; the loop now waits in
+// waiting_trigger until HandleTrigger observes the trigger condition pass and
+// pours the next wisp. No successor wisp is poured here (the speculative pour
+// was skipped for trigger-gated loops).
+func (h *Handler) transitionToWaitingTrigger(
+	rootBeadID, wispID string,
+	iteration int,
+	gateConfig GateConfig,
+	gateResult GateResult,
+	meta map[string]string,
+) (HandlerResult, error) {
+	// Clear the verdict consumed by this iteration's gate so it cannot leak
+	// into the next wisp (which HandleTrigger pours fresh).
+	if meta[FieldAgentVerdictWisp] == wispID {
+		if err := h.Store.SetMetadata(rootBeadID, FieldAgentVerdict, ""); err != nil {
+			return HandlerResult{}, fmt.Errorf("clearing agent verdict: %w", err)
+		}
+		if err := h.Store.SetMetadata(rootBeadID, FieldAgentVerdictWisp, ""); err != nil {
+			return HandlerResult{}, fmt.Errorf("clearing agent verdict wisp: %w", err)
+		}
+	}
+
+	iterDur, cumDur := h.computeDurations(rootBeadID, wispID)
+	verdict := ""
+	if meta[FieldAgentVerdictWisp] == wispID {
+		verdict = NormalizeVerdict(meta[FieldAgentVerdict])
+	}
+
+	// Step 8: Emit ConvergenceIteration event recording the hold.
+	iterPayload := IterationPayload{
+		Iteration:            iteration,
+		WispID:               wispID,
+		AgentVerdict:         verdict,
+		GateMode:             gateConfig.Mode,
+		GateOutcome:          NullableString(gateResult.Outcome),
+		GateResult:           GateResultToPayload(gateResult),
+		GateRetryCount:       gateResult.RetryCount,
+		Action:               string(ActionWaitingTrigger),
+		IterationDurationMs:  iterDur.Milliseconds(),
+		CumulativeDurationMs: cumDur.Milliseconds(),
+	}
+	h.emitEvent(EventIteration, EventIDIteration(rootBeadID, iteration), rootBeadID, iterPayload)
+
+	// Step 9: Commit point. Write last_processed_wisp LAST (dedup marker).
+	if err := h.Store.SetMetadata(rootBeadID, FieldActiveWisp, ""); err != nil {
+		return HandlerResult{}, fmt.Errorf("clearing active wisp: %w", err)
+	}
+	if err := h.Store.SetMetadata(rootBeadID, FieldState, StateWaitingTrigger); err != nil {
+		return HandlerResult{}, fmt.Errorf("setting state to waiting_trigger: %w", err)
+	}
+	if err := h.Store.SetMetadata(rootBeadID, FieldLastProcessedWisp, wispID); err != nil {
+		return HandlerResult{}, fmt.Errorf("setting last processed wisp: %w", err)
+	}
+
+	return HandlerResult{
+		Action:      ActionWaitingTrigger,
+		Iteration:   iteration,
+		GateOutcome: gateResult.Outcome,
 	}, nil
 }
 

--- a/internal/convergence/manual.go
+++ b/internal/convergence/manual.go
@@ -254,11 +254,11 @@ func (h *Handler) StopHandler(ctx context.Context, beadID, username, _ string) (
 		}, nil
 	}
 
-	// Must be active or waiting_manual.
-	if state != StateActive && state != StateWaitingManual {
+	// Must be active, waiting_manual, or waiting_trigger.
+	if state != StateActive && state != StateWaitingManual && state != StateWaitingTrigger {
 		return HandlerResult{}, fmt.Errorf(
-			"cannot stop bead %q: state is %q, expected %q or %q",
-			beadID, state, StateActive, StateWaitingManual,
+			"cannot stop bead %q: state is %q, expected %q, %q, or %q",
+			beadID, state, StateActive, StateWaitingManual, StateWaitingTrigger,
 		)
 	}
 

--- a/internal/convergence/metadata.go
+++ b/internal/convergence/metadata.go
@@ -39,6 +39,8 @@ const (
 	FieldGateDurationMs    = "convergence.gate_duration_ms"
 	FieldGateTruncated     = "convergence.gate_truncated"
 	FieldPendingNextWisp   = "convergence.pending_next_wisp"
+	FieldTrigger           = "convergence.trigger"
+	FieldTriggerCondition  = "convergence.trigger_condition"
 )
 
 // VarPrefix is the metadata key prefix for template variables.
@@ -46,10 +48,18 @@ const VarPrefix = "var."
 
 // State values for convergence.state.
 const (
-	StateCreating      = "creating" // set immediately after bead creation; reconciler terminates partial creations
-	StateActive        = "active"
-	StateWaitingManual = "waiting_manual"
-	StateTerminated    = "terminated"
+	StateCreating       = "creating" // set immediately after bead creation; reconciler terminates partial creations
+	StateActive         = "active"
+	StateWaitingManual  = "waiting_manual"
+	StateWaitingTrigger = "waiting_trigger" // entry/iteration gated on an external trigger condition
+	StateTerminated     = "terminated"
+)
+
+// Trigger mode values for convergence.trigger. The empty string means no
+// trigger: the loop uses the default wisp-close-driven iteration semantic.
+const (
+	TriggerNone  = ""      // default: no external trigger
+	TriggerEvent = "event" // gate iterations on a trigger condition evaluated as beads change
 )
 
 // GateMode values for convergence.gate_mode.

--- a/internal/convergence/reconcile.go
+++ b/internal/convergence/reconcile.go
@@ -88,6 +88,12 @@ func (r *Reconciler) reconcileBead(ctx context.Context, beadID string) Reconcile
 		// Path 3: state=waiting_manual.
 		return r.reconcileWaitingManual(beadID, meta)
 
+	case StateWaitingTrigger:
+		// Path 3t: state=waiting_trigger. No wisp is in flight while waiting
+		// on the external trigger, so recovery only completes an interrupted
+		// stop; otherwise the controller tick re-evaluates the trigger.
+		return r.reconcileWaitingTrigger(beadID, meta)
+
 	case StateActive:
 		// Path 4: state=active.
 		return r.reconcileActive(ctx, beadID, meta)
@@ -362,6 +368,19 @@ func (r *Reconciler) reconcileWaitingManual(beadID string, meta map[string]strin
 		return ReconcileDetail{BeadID: beadID, Action: "repaired_state"}
 	}
 
+	return ReconcileDetail{BeadID: beadID, Action: "no_action"}
+}
+
+// --- Path 3t: state=waiting_trigger ---
+
+func (r *Reconciler) reconcileWaitingTrigger(beadID string, meta map[string]string) ReconcileDetail {
+	// A stop requested while waiting on the trigger may have crashed before
+	// the terminal transition completed.
+	if meta[FieldTerminalReason] != "" {
+		return r.completeTerminalTransition(beadID, meta)
+	}
+	// Otherwise nothing to repair: no wisp is in flight and the controller
+	// tick re-evaluates the trigger condition.
 	return ReconcileDetail{BeadID: beadID, Action: "no_action"}
 }
 

--- a/internal/convergence/reconcile_test.go
+++ b/internal/convergence/reconcile_test.go
@@ -25,6 +25,57 @@ func setupReconciler(t *testing.T) (*Reconciler, *fakeStore, *fakeEmitter) {
 	return &Reconciler{Handler: handler}, store, emitter
 }
 
+// --- Path 3t: waiting_trigger ---
+
+func TestReconcile_WaitingTrigger_NoAction(t *testing.T) {
+	rec, store, _ := setupReconciler(t)
+	store.addBead("root-1", "in_progress", "", "", map[string]string{
+		FieldState:            StateWaitingTrigger,
+		FieldFormula:          "test-formula",
+		FieldMaxIterations:    "5",
+		FieldTarget:           "test-agent",
+		FieldTrigger:          TriggerEvent,
+		FieldTriggerCondition: "/scripts/check",
+	})
+
+	report, err := rec.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(report.Details) != 1 || report.Details[0].Action != "no_action" {
+		t.Errorf("action = %+v, want no_action", report.Details)
+	}
+	// State must be preserved so the tick re-evaluates the trigger.
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateWaitingTrigger {
+		t.Errorf("state = %q, want %q", meta[FieldState], StateWaitingTrigger)
+	}
+}
+
+func TestReconcile_WaitingTrigger_CompletesInterruptedStop(t *testing.T) {
+	rec, store, _ := setupReconciler(t)
+	store.addBead("root-1", "in_progress", "", "", map[string]string{
+		FieldState:          StateWaitingTrigger,
+		FieldFormula:        "test-formula",
+		FieldMaxIterations:  "5",
+		FieldTarget:         "test-agent",
+		FieldTrigger:        TriggerEvent,
+		FieldTerminalReason: TerminalStopped,
+	})
+
+	report, err := rec.ReconcileBeads(context.Background(), []string{"root-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(report.Details) != 1 || report.Details[0].Action != "completed_terminal" {
+		t.Errorf("action = %+v, want completed_terminal", report.Details)
+	}
+	info, _ := store.GetBead("root-1")
+	if info.Status != "closed" {
+		t.Errorf("status = %q, want closed", info.Status)
+	}
+}
+
 // --- Path 1: Missing state ---
 
 func TestReconcile_MissingState_NoWisps_PoursFirst(t *testing.T) {

--- a/internal/convergence/trigger.go
+++ b/internal/convergence/trigger.go
@@ -1,0 +1,162 @@
+package convergence
+
+import (
+	"context"
+	"fmt"
+)
+
+// TriggerConfig holds the external-trigger configuration for a convergence
+// loop. A trigger gates *when* iterations are poured: the entry (iteration 1)
+// and every subsequent iteration wait until the trigger condition exits 0.
+// This lets converge replace out-of-band sweepers that poll for an external
+// precondition between passes.
+type TriggerConfig struct {
+	Mode      string // "" (none) or "event"
+	Condition string // path to trigger condition script (required when Mode=="event")
+}
+
+// Enabled reports whether an external trigger gates this loop.
+func (tc TriggerConfig) Enabled() bool {
+	return tc.Mode == TriggerEvent
+}
+
+// ParseTriggerConfig extracts trigger configuration from convergence metadata.
+// An empty trigger mode is valid and means "no trigger" (default wisp-close
+// iteration semantic). When the mode is "event", a condition path is required.
+func ParseTriggerConfig(meta map[string]string) (TriggerConfig, error) {
+	mode := meta[FieldTrigger]
+	condition := meta[FieldTriggerCondition]
+
+	switch mode {
+	case TriggerNone:
+		return TriggerConfig{Mode: TriggerNone}, nil
+	case TriggerEvent:
+		if condition == "" {
+			return TriggerConfig{}, fmt.Errorf("parsing trigger config: trigger mode %q requires a trigger condition path", TriggerEvent)
+		}
+		return TriggerConfig{Mode: TriggerEvent, Condition: condition}, nil
+	default:
+		return TriggerConfig{}, fmt.Errorf("parsing trigger config: invalid trigger mode %q", mode)
+	}
+}
+
+// HandleTrigger evaluates the trigger condition for a loop sitting in the
+// waiting_trigger state and, when the condition exits 0, advances the loop by
+// pouring and activating the next iteration's wisp. A non-zero exit (or
+// timeout/error) keeps the loop waiting; the controller re-evaluates on the
+// next tick as beads change.
+//
+// This is the tick-side counterpart to HandleWispClosed. Like that handler it
+// assumes single-writer-per-bead concurrency, which the controller event loop
+// provides.
+func (h *Handler) HandleTrigger(ctx context.Context, rootBeadID string) (HandlerResult, error) {
+	meta, err := h.Store.GetMetadata(rootBeadID)
+	if err != nil {
+		return HandlerResult{}, fmt.Errorf("reading root bead metadata: %w", err)
+	}
+
+	// Guard: only act on loops genuinely waiting on a trigger.
+	if meta[FieldState] != StateWaitingTrigger {
+		return HandlerResult{Action: ActionSkipped}, nil
+	}
+
+	triggerConfig, err := ParseTriggerConfig(meta)
+	if err != nil {
+		return HandlerResult{}, fmt.Errorf("parsing trigger config: %w", err)
+	}
+	if !triggerConfig.Enabled() {
+		return HandlerResult{}, fmt.Errorf("bead %q is in %s but has no trigger configured", rootBeadID, StateWaitingTrigger)
+	}
+
+	// Evaluate the trigger condition with the same sandboxed env contract as
+	// gate conditions. The gate timeout (or its default) bounds the trigger.
+	gateConfig, err := ParseGateConfig(meta)
+	if err != nil {
+		return HandlerResult{}, fmt.Errorf("parsing gate config: %w", err)
+	}
+	closedIterations, err := h.deriveIterationCount(rootBeadID)
+	if err != nil {
+		return HandlerResult{}, fmt.Errorf("deriving iteration count: %w", err)
+	}
+
+	cityPath := meta[FieldCityPath]
+	nextIteration := closedIterations + 1
+
+	// Defense in depth: a healthy loop only enters waiting_trigger when the
+	// gate already confirmed iteration < max_iterations, so this is
+	// unreachable in normal flow. Refuse loudly rather than pour an
+	// over-limit wisp if corrupt state ever lands here.
+	if maxIter, ok := DecodeInt(meta[FieldMaxIterations]); ok && maxIter > 0 && nextIteration > maxIter {
+		return HandlerResult{}, fmt.Errorf("trigger-gated loop %q at iteration %d exceeds max_iterations %d; refusing to advance", rootBeadID, nextIteration, maxIter)
+	}
+
+	env := ConditionEnv{
+		BeadID:      rootBeadID,
+		Iteration:   nextIteration,
+		CityPath:    cityPath,
+		StorePath:   h.StorePath,
+		DocPath:     meta[VarPrefix+"doc_path"],
+		ArtifactDir: ArtifactDirFor(cityPath, rootBeadID, nextIteration),
+	}
+	if maxIter, ok := DecodeInt(meta[FieldMaxIterations]); ok {
+		env.MaxIterations = maxIter
+	}
+
+	result := RunCondition(ctx, triggerConfig.Condition, env, gateConfig.Timeout, 0)
+	if result.Outcome != GatePass {
+		// Trigger not satisfied — keep waiting. Re-evaluated next tick.
+		return HandlerResult{Action: ActionSkipped}, nil
+	}
+
+	return h.advanceFromTrigger(rootBeadID, meta, nextIteration)
+}
+
+// advanceFromTrigger pours and activates the next iteration's wisp after the
+// trigger condition passes, transitioning the loop back to the active state.
+// The next wisp's idempotency key makes the pour crash-safe: a re-pour after a
+// crash returns the existing wisp rather than duplicating it.
+func (h *Handler) advanceFromTrigger(rootBeadID string, meta map[string]string, nextIteration int) (HandlerResult, error) {
+	nextKey := IdempotencyKey(rootBeadID, nextIteration)
+	formula := meta[FieldFormula]
+	vars := ExtractVars(meta)
+	evaluatePrompt := meta[FieldEvaluatePrompt]
+
+	nextWispID, err := h.Store.PourWisp(rootBeadID, formula, nextKey, vars, evaluatePrompt)
+	if err != nil {
+		existingID, found, lookupErr := h.Store.FindByIdempotencyKey(nextKey)
+		if lookupErr == nil && found {
+			nextWispID = existingID
+		} else {
+			return HandlerResult{}, fmt.Errorf("pouring wisp for iteration %d: %w", nextIteration, err)
+		}
+	}
+	if err := h.Store.ActivateWisp(nextWispID); err != nil {
+		return HandlerResult{}, fmt.Errorf("activating wisp %q: %w", nextWispID, err)
+	}
+
+	if err := h.Store.SetMetadata(rootBeadID, FieldIteration, EncodeInt(nextIteration)); err != nil {
+		return HandlerResult{}, fmt.Errorf("setting iteration: %w", err)
+	}
+	if err := h.Store.SetMetadata(rootBeadID, FieldActiveWisp, nextWispID); err != nil {
+		return HandlerResult{}, fmt.Errorf("setting active wisp: %w", err)
+	}
+	if err := h.Store.SetMetadata(rootBeadID, FieldState, StateActive); err != nil {
+		return HandlerResult{}, fmt.Errorf("setting state to active: %w", err)
+	}
+
+	// Emit a ConvergenceIteration event recording the trigger-driven advance.
+	iterPayload := IterationPayload{
+		Iteration:  nextIteration,
+		WispID:     meta[FieldLastProcessedWisp],
+		GateMode:   meta[FieldGateMode],
+		Action:     string(ActionIterate),
+		NextWispID: NullableString(nextWispID),
+	}
+	h.emitEvent(EventIteration, EventIDIteration(rootBeadID, nextIteration), rootBeadID, iterPayload)
+
+	return HandlerResult{
+		Action:     ActionIterate,
+		Iteration:  nextIteration,
+		NextWispID: nextWispID,
+	}, nil
+}

--- a/internal/convergence/trigger.go
+++ b/internal/convergence/trigger.go
@@ -90,17 +90,7 @@ func (h *Handler) HandleTrigger(ctx context.Context, rootBeadID string) (Handler
 		return HandlerResult{}, fmt.Errorf("trigger-gated loop %q at iteration %d exceeds max_iterations %d; refusing to advance", rootBeadID, nextIteration, maxIter)
 	}
 
-	env := ConditionEnv{
-		BeadID:      rootBeadID,
-		Iteration:   nextIteration,
-		CityPath:    cityPath,
-		StorePath:   h.StorePath,
-		DocPath:     meta[VarPrefix+"doc_path"],
-		ArtifactDir: ArtifactDirFor(cityPath, rootBeadID, nextIteration),
-	}
-	if maxIter, ok := DecodeInt(meta[FieldMaxIterations]); ok {
-		env.MaxIterations = maxIter
-	}
+	env := TriggerConditionEnv(meta, rootBeadID, cityPath, h.StorePath, nextIteration)
 
 	result := RunCondition(ctx, triggerConfig.Condition, env, gateConfig.Timeout, 0)
 	if result.Outcome != GatePass {
@@ -109,6 +99,27 @@ func (h *Handler) HandleTrigger(ctx context.Context, rootBeadID string) (Handler
 	}
 
 	return h.advanceFromTrigger(rootBeadID, meta, nextIteration)
+}
+
+// TriggerConditionEnv builds the ConditionEnv used to evaluate a trigger
+// condition for nextIteration — the iteration the trigger gates and pours when
+// it passes. HandleTrigger (live controller evaluation) and the
+// `gc converge test-trigger` dry-run both call this so the dry-run cannot drift
+// from production: same iteration source (closed wisps + 1, computed by the
+// caller), same artifact dir, same doc-path and max-iterations wiring.
+func TriggerConditionEnv(meta map[string]string, beadID, cityPath, storePath string, nextIteration int) ConditionEnv {
+	env := ConditionEnv{
+		BeadID:      beadID,
+		Iteration:   nextIteration,
+		CityPath:    cityPath,
+		StorePath:   storePath,
+		DocPath:     meta[VarPrefix+"doc_path"],
+		ArtifactDir: ArtifactDirFor(cityPath, beadID, nextIteration),
+	}
+	if maxIter, ok := DecodeInt(meta[FieldMaxIterations]); ok {
+		env.MaxIterations = maxIter
+	}
+	return env
 }
 
 // advanceFromTrigger pours and activates the next iteration's wisp after the
@@ -144,15 +155,22 @@ func (h *Handler) advanceFromTrigger(rootBeadID string, meta map[string]string, 
 		return HandlerResult{}, fmt.Errorf("setting state to active: %w", err)
 	}
 
-	// Emit a ConvergenceIteration event recording the trigger-driven advance.
-	iterPayload := IterationPayload{
+	// Emit a ConvergenceTriggerAdvance event recording the trigger-driven
+	// waiting_trigger -> active transition. This mirrors the manual_iterate
+	// event for the waiting_manual -> active transition (manual.go): a distinct
+	// event type and ID so it cannot collide with the per-wisp iteration event
+	// that the newly poured wisp emits when it closes (both would otherwise
+	// derive EventIDIteration(rootBeadID, nextIteration)). WispID is the prior
+	// (last processed) wisp and is null on the entry-gated first iteration.
+	advancePayload := ManualActionPayload{
+		Actor:      "controller",
+		PriorState: StateWaitingTrigger,
+		NewState:   StateActive,
 		Iteration:  nextIteration,
-		WispID:     meta[FieldLastProcessedWisp],
-		GateMode:   meta[FieldGateMode],
-		Action:     string(ActionIterate),
+		WispID:     NullableString(meta[FieldLastProcessedWisp]),
 		NextWispID: NullableString(nextWispID),
 	}
-	h.emitEvent(EventIteration, EventIDIteration(rootBeadID, nextIteration), rootBeadID, iterPayload)
+	h.emitEvent(EventTriggerAdvance, EventIDTriggerAdvance(rootBeadID, nextIteration), rootBeadID, advancePayload)
 
 	return HandlerResult{
 		Action:     ActionIterate,

--- a/internal/convergence/trigger_test.go
+++ b/internal/convergence/trigger_test.go
@@ -140,8 +140,67 @@ func TestHandleTrigger_EntryPoursFirstWispOnPass(t *testing.T) {
 		t.Errorf("wisp key = %q, want %q", wispInfo.IdempotencyKey, IdempotencyKey("root-1", 1))
 	}
 
-	if _, ok := emitter.findEvent(EventIteration); !ok {
-		t.Error("expected ConvergenceIteration event")
+	// The trigger-driven advance emits a distinct ConvergenceTriggerAdvance
+	// event, NOT a ConvergenceIteration event: the latter is reserved for the
+	// per-wisp completion event the poured wisp emits when it closes. Emitting
+	// EventIteration here would collide with that event on EventIDIteration.
+	if _, ok := emitter.findEvent(EventIteration); ok {
+		t.Error("trigger advance must not emit ConvergenceIteration (collides with the per-wisp event id)")
+	}
+	advEv, ok := emitter.findEvent(EventTriggerAdvance)
+	if !ok {
+		t.Fatal("expected ConvergenceTriggerAdvance event")
+	}
+	if advEv.EventID != EventIDTriggerAdvance("root-1", 1) {
+		t.Errorf("event_id = %q, want %q", advEv.EventID, EventIDTriggerAdvance("root-1", 1))
+	}
+	if advEv.EventID == EventIDIteration("root-1", 1) {
+		t.Error("trigger-advance event id collides with the per-wisp iteration event id")
+	}
+	var advPayload ManualActionPayload
+	if err := json.Unmarshal(advEv.Payload, &advPayload); err != nil {
+		t.Fatalf("unmarshal trigger-advance payload: %v", err)
+	}
+	if advPayload.Iteration != 1 {
+		t.Errorf("payload iteration = %d, want 1", advPayload.Iteration)
+	}
+	// Entry-gated first iteration has no prior wisp: wisp_id must be null,
+	// not an empty/ambiguous string.
+	if advPayload.WispID != nil {
+		t.Errorf("payload wisp_id = %v, want nil on entry-gated iteration 1", *advPayload.WispID)
+	}
+	if advPayload.NextWispID == nil || *advPayload.NextWispID != result.NextWispID {
+		t.Errorf("payload next_wisp_id = %v, want %q", advPayload.NextWispID, result.NextWispID)
+	}
+}
+
+func TestTriggerConditionEnv_MirrorsNextIteration(t *testing.T) {
+	cityPath := "/city"
+	meta := map[string]string{
+		FieldMaxIterations:     "5",
+		VarPrefix + "doc_path": "/docs/spec.md",
+	}
+	env := TriggerConditionEnv(meta, "root-9", cityPath, "/store", 3)
+
+	// Iteration is the NEXT iteration the trigger gates (caller passes
+	// closed+1), not the stored convergence.iteration counter — this is the
+	// fidelity contract HandleTrigger and the test-trigger dry-run share.
+	if env.Iteration != 3 {
+		t.Errorf("Iteration = %d, want 3", env.Iteration)
+	}
+	// ArtifactDir must be populated so GC_ARTIFACT_DIR is exported to the
+	// trigger condition exactly as it is in the live controller path.
+	if env.ArtifactDir != ArtifactDirFor(cityPath, "root-9", 3) {
+		t.Errorf("ArtifactDir = %q, want %q", env.ArtifactDir, ArtifactDirFor(cityPath, "root-9", 3))
+	}
+	if env.MaxIterations != 5 {
+		t.Errorf("MaxIterations = %d, want 5", env.MaxIterations)
+	}
+	if env.DocPath != "/docs/spec.md" {
+		t.Errorf("DocPath = %q, want /docs/spec.md", env.DocPath)
+	}
+	if env.BeadID != "root-9" || env.CityPath != cityPath || env.StorePath != "/store" {
+		t.Errorf("env identity mismatch: %+v", env)
 	}
 }
 

--- a/internal/convergence/trigger_test.go
+++ b/internal/convergence/trigger_test.go
@@ -1,0 +1,286 @@
+package convergence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTriggerScript writes an executable script that exits with the given
+// code and returns its absolute path.
+func writeTriggerScript(t *testing.T, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "trigger.sh")
+	body := fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatalf("writing trigger script: %v", err)
+	}
+	return script
+}
+
+func TestParseTriggerConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		meta      map[string]string
+		wantMode  string
+		wantEnab  bool
+		wantError string
+	}{
+		{
+			name:     "no trigger (default)",
+			meta:     map[string]string{},
+			wantMode: TriggerNone,
+			wantEnab: false,
+		},
+		{
+			name:     "event with condition",
+			meta:     map[string]string{FieldTrigger: TriggerEvent, FieldTriggerCondition: "/path/to/check"},
+			wantMode: TriggerEvent,
+			wantEnab: true,
+		},
+		{
+			name:      "event without condition",
+			meta:      map[string]string{FieldTrigger: TriggerEvent},
+			wantError: "requires a trigger condition",
+		},
+		{
+			name:      "invalid mode",
+			meta:      map[string]string{FieldTrigger: "cron"},
+			wantError: "invalid trigger mode",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc, err := ParseTriggerConfig(tt.meta)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("error = %v, want to contain %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.Mode != tt.wantMode {
+				t.Errorf("Mode = %q, want %q", tc.Mode, tt.wantMode)
+			}
+			if tc.Enabled() != tt.wantEnab {
+				t.Errorf("Enabled() = %v, want %v", tc.Enabled(), tt.wantEnab)
+			}
+		})
+	}
+}
+
+// setupTriggerHandler builds a handler with a single waiting_trigger root bead.
+func setupTriggerHandler(t *testing.T, condition string, extraMeta map[string]string) (*Handler, *fakeStore, *fakeEmitter) {
+	t.Helper()
+	store := newFakeStore()
+	emitter := &fakeEmitter{}
+	rootMeta := map[string]string{
+		FieldState:            StateWaitingTrigger,
+		FieldIteration:        "0",
+		FieldMaxIterations:    "5",
+		FieldFormula:          "test-formula",
+		FieldTarget:           "test-agent",
+		FieldGateMode:         GateModeCondition,
+		FieldGateCondition:    "/gate/ignored-in-trigger-tests",
+		FieldGateTimeout:      "60s",
+		FieldTrigger:          TriggerEvent,
+		FieldTriggerCondition: condition,
+		FieldCityPath:         t.TempDir(),
+	}
+	for k, v := range extraMeta {
+		rootMeta[k] = v
+	}
+	store.addBead("root-1", "in_progress", "", "", rootMeta)
+	handler := &Handler{Store: store, Emitter: emitter, Clock: time.Now}
+	return handler, store, emitter
+}
+
+func TestHandleTrigger_EntryPoursFirstWispOnPass(t *testing.T) {
+	handler, store, emitter := setupTriggerHandler(t, writeTriggerScript(t, 0), nil)
+
+	result, err := handler.HandleTrigger(context.Background(), "root-1")
+	if err != nil {
+		t.Fatalf("HandleTrigger: %v", err)
+	}
+	if result.Action != ActionIterate {
+		t.Errorf("Action = %q, want %q", result.Action, ActionIterate)
+	}
+	if result.Iteration != 1 {
+		t.Errorf("Iteration = %d, want 1", result.Iteration)
+	}
+	if result.NextWispID == "" {
+		t.Fatal("expected NextWispID to be set")
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateActive {
+		t.Errorf("state = %q, want %q", meta[FieldState], StateActive)
+	}
+	if meta[FieldActiveWisp] != result.NextWispID {
+		t.Errorf("active_wisp = %q, want %q", meta[FieldActiveWisp], result.NextWispID)
+	}
+	if meta[FieldIteration] != "1" {
+		t.Errorf("iteration = %q, want 1", meta[FieldIteration])
+	}
+
+	// The poured wisp must carry the iteration-1 idempotency key.
+	wispInfo, err := store.GetBead(result.NextWispID)
+	if err != nil {
+		t.Fatalf("GetBead: %v", err)
+	}
+	if wispInfo.IdempotencyKey != IdempotencyKey("root-1", 1) {
+		t.Errorf("wisp key = %q, want %q", wispInfo.IdempotencyKey, IdempotencyKey("root-1", 1))
+	}
+
+	if _, ok := emitter.findEvent(EventIteration); !ok {
+		t.Error("expected ConvergenceIteration event")
+	}
+}
+
+func TestHandleTrigger_WaitsWhenConditionFails(t *testing.T) {
+	handler, store, _ := setupTriggerHandler(t, writeTriggerScript(t, 1), nil)
+
+	result, err := handler.HandleTrigger(context.Background(), "root-1")
+	if err != nil {
+		t.Fatalf("HandleTrigger: %v", err)
+	}
+	if result.Action != ActionSkipped {
+		t.Errorf("Action = %q, want %q", result.Action, ActionSkipped)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateWaitingTrigger {
+		t.Errorf("state = %q, want %q (should keep waiting)", meta[FieldState], StateWaitingTrigger)
+	}
+	if meta[FieldActiveWisp] != "" {
+		t.Errorf("active_wisp = %q, want empty (no wisp poured)", meta[FieldActiveWisp])
+	}
+	// No wisp should have been poured.
+	children, _ := store.Children("root-1")
+	if len(children) != 0 {
+		t.Errorf("children = %d, want 0 (no wisp poured while waiting)", len(children))
+	}
+}
+
+func TestHandleTrigger_IterationGateAdvance(t *testing.T) {
+	handler, store, _ := setupTriggerHandler(t, writeTriggerScript(t, 0), map[string]string{
+		FieldIteration:         "1",
+		FieldLastProcessedWisp: "wisp-iter-1",
+	})
+	// One closed wisp already exists (iteration 1).
+	store.addBead("wisp-iter-1", "closed", "root-1", IdempotencyKey("root-1", 1), nil)
+
+	result, err := handler.HandleTrigger(context.Background(), "root-1")
+	if err != nil {
+		t.Fatalf("HandleTrigger: %v", err)
+	}
+	if result.Action != ActionIterate {
+		t.Errorf("Action = %q, want %q", result.Action, ActionIterate)
+	}
+	if result.Iteration != 2 {
+		t.Errorf("Iteration = %d, want 2", result.Iteration)
+	}
+	wispInfo, err := store.GetBead(result.NextWispID)
+	if err != nil {
+		t.Fatalf("GetBead: %v", err)
+	}
+	if wispInfo.IdempotencyKey != IdempotencyKey("root-1", 2) {
+		t.Errorf("wisp key = %q, want %q", wispInfo.IdempotencyKey, IdempotencyKey("root-1", 2))
+	}
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateActive {
+		t.Errorf("state = %q, want %q", meta[FieldState], StateActive)
+	}
+}
+
+func TestHandleTrigger_SkipsWhenNotWaiting(t *testing.T) {
+	handler, _, _ := setupTriggerHandler(t, writeTriggerScript(t, 0), map[string]string{
+		FieldState: StateActive,
+	})
+	result, err := handler.HandleTrigger(context.Background(), "root-1")
+	if err != nil {
+		t.Fatalf("HandleTrigger: %v", err)
+	}
+	if result.Action != ActionSkipped {
+		t.Errorf("Action = %q, want %q", result.Action, ActionSkipped)
+	}
+}
+
+func TestHandleTrigger_RefusesToExceedMaxIterations(t *testing.T) {
+	// Corrupt state: waiting_trigger with closed iterations already at max.
+	handler, store, _ := setupTriggerHandler(t, writeTriggerScript(t, 0), map[string]string{
+		FieldMaxIterations:     "1",
+		FieldIteration:         "1",
+		FieldLastProcessedWisp: "wisp-iter-1",
+	})
+	store.addBead("wisp-iter-1", "closed", "root-1", IdempotencyKey("root-1", 1), nil)
+
+	_, err := handler.HandleTrigger(context.Background(), "root-1")
+	if err == nil {
+		t.Fatal("expected error when advancing past max_iterations")
+	}
+	if !strings.Contains(err.Error(), "exceeds max_iterations") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "exceeds max_iterations")
+	}
+	// No over-limit wisp should have been poured.
+	children, _ := store.Children("root-1")
+	if len(children) != 1 {
+		t.Errorf("children = %d, want 1 (no over-limit pour)", len(children))
+	}
+}
+
+func TestHandleWispClosed_TriggerGatesIteration(t *testing.T) {
+	// Gate outcome is fail (would iterate) and a trigger gates the loop, so
+	// instead of pouring the next wisp the loop holds in waiting_trigger.
+	handler, store, emitter := setupBasicHandler(t, map[string]string{
+		FieldGateOutcomeWisp:  "wisp-iter-1",
+		FieldGateOutcome:      GateFail,
+		FieldTrigger:          TriggerEvent,
+		FieldTriggerCondition: "/some/trigger/check",
+	})
+
+	result, err := handler.HandleWispClosed(context.Background(), "root-1", "wisp-iter-1")
+	if err != nil {
+		t.Fatalf("HandleWispClosed: %v", err)
+	}
+	if result.Action != ActionWaitingTrigger {
+		t.Errorf("Action = %q, want %q", result.Action, ActionWaitingTrigger)
+	}
+
+	meta, _ := store.GetMetadata("root-1")
+	if meta[FieldState] != StateWaitingTrigger {
+		t.Errorf("state = %q, want %q", meta[FieldState], StateWaitingTrigger)
+	}
+	if meta[FieldActiveWisp] != "" {
+		t.Errorf("active_wisp = %q, want empty (no next wisp poured)", meta[FieldActiveWisp])
+	}
+	if meta[FieldLastProcessedWisp] != "wisp-iter-1" {
+		t.Errorf("last_processed_wisp = %q, want wisp-iter-1", meta[FieldLastProcessedWisp])
+	}
+
+	// No successor wisp should exist: only the original closed wisp.
+	children, _ := store.Children("root-1")
+	if len(children) != 1 {
+		t.Errorf("children = %d, want 1 (no speculative/next wisp)", len(children))
+	}
+
+	ev, ok := emitter.findEvent(EventIteration)
+	if !ok {
+		t.Fatal("expected ConvergenceIteration event")
+	}
+	var payload IterationPayload
+	if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Action != string(ActionWaitingTrigger) {
+		t.Errorf("event action = %q, want %q", payload.Action, ActionWaitingTrigger)
+	}
+}

--- a/schemas/converge/test-trigger/result.schema.json
+++ b/schemas/converge/test-trigger/result.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["schema_version", "ok", "bead_id", "mode"],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "ok": { "const": true },
+    "bead_id": { "type": "string" },
+    "mode": { "type": "string" },
+    "condition": { "type": "string" },
+    "outcome": { "type": "string" },
+    "exit_code": { "type": "integer" },
+    "stdout": { "type": "string" },
+    "stderr": { "type": "string" },
+    "skipped": { "type": "boolean" },
+    "reason": { "type": "string" }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary

Adds an optional external trigger to convergence loops so they can replace out-of-band sweepers that poll for a precondition between passes. A trigger gates *when* iterations are poured: the entry (iteration 1) and every subsequent iteration wait until a trigger condition script exits 0.

```
gc converge create --formula ... --target ... \
    --trigger event --trigger-condition .gc/scripts/check-chunk-complete
```

Fully gated behind the flag — without `--trigger`, behavior is unchanged.

## What changed

- New `waiting_trigger` state and `convergence.trigger` / `convergence.trigger_condition` metadata fields.
- `create` defers the first pour to the trigger (entry-gate); the iterate path of `HandleWispClosed` holds in `waiting_trigger` instead of pouring (N+1 gate).
- New `HandleTrigger` (tick-side counterpart to `HandleWispClosed`): evaluates the trigger via the same sandboxed `ConditionEnv`/`RunCondition` contract as gate conditions. Exit 0 pours and activates the next wisp and returns the loop to active; non-zero keeps it waiting, re-evaluated next tick.
- No speculative successor wisp is poured while trigger-gated; `max_iterations` is still enforced by the gate before any `waiting_trigger` transition, with a defense-in-depth refusal in `HandleTrigger`.
- `waiting_trigger` beads are indexed for the tick, reconciled on restart, and stoppable; `status` shows the trigger and waiting state.
- New `gc converge test-trigger` dry-runs the trigger (parallels `test-gate`), with its result schema.
- Docs (`cli.md`) regenerated.

## Why

Convergence is tick-driven (the controller polls active loops each tick; even wisp-close is detected by polling, not event subscription). An external trigger lets a loop pace its iterations on an out-of-band precondition — e.g. wait for an upstream chunk to finish — without a separate sweeper process polling and re-dispatching. The trigger evaluation reuses the existing gate-condition sandbox, so it inherits the same timeout, env, and security model.

## Test plan

- [x] `make build`
- [x] `make check` (lint + full test suite, PASS)
- [x] `make check-docs` (docsync PASS)
- [x] Unit: `ParseTriggerConfig` (valid / missing-condition / invalid-mode)
- [x] Integration: `HandleTrigger` entry-pour, wait-on-fail, iteration-gate advance, skip-when-not-waiting, refuse-past-max
- [x] `HandleWispClosed` holds in `waiting_trigger` when gate is non-terminal and a trigger is configured
- [x] Reconcile recovery path for `waiting_trigger`
