### PR TITLE
test(cmd/gc): cover pre_start RigRoot/AgentBase resolution for city-level rig-scoped agents

### DIFF
--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -218,7 +218,7 @@ func TestResolveTemplateUsesRigScopeBeadsProviderForBdBackedRig(t *testing.T) {
 // {{.AgentBase}} for a city-level rig-scoped agent — one with Scope="rig" whose
 // Dir is not stamped to the rig (its work_dir is a city-level worktree), so the
 // rig association lives only in the qualified-name prefix. The session-setup
-// context flows from workdir.PathContextForQualifiedName, so the #2070
+// context flows from workdirutil.PathContextForQualifiedName, so the #2070
 // qualified-name-prefix fallback reaches pre_start templates too, not just
 // work_dir and the agent env. Without the unified context these would expand
 // empty.

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -213,6 +213,58 @@ func TestResolveTemplateUsesRigScopeBeadsProviderForBdBackedRig(t *testing.T) {
 	}
 }
 
+// TestResolveTemplatePreStartResolvesRigRootForCityLevelRigScopedAgent guards
+// gascity#1940: the pre_start substitution path must resolve {{.RigRoot}} and
+// {{.AgentBase}} for a city-level rig-scoped agent — one with Scope="rig" whose
+// Dir is not stamped to the rig (its work_dir is a city-level worktree), so the
+// rig association lives only in the qualified-name prefix. The session-setup
+// context flows from workdir.PathContextForQualifiedName, so the #2070
+// qualified-name-prefix fallback reaches pre_start templates too, not just
+// work_dir and the agent env. Without the unified context these would expand
+// empty.
+func TestResolveTemplatePreStartResolvesRigRootForCityLevelRigScopedAgent(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	rigRoot := filepath.Join(cityPath, "rigs", "thriva")
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		rigs:       []config.Rig{{Name: "thriva", Path: rigRoot}},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	// No Dir stamp; rig association lives only in the qualified-name prefix and
+	// the work_dir is a city-level worktree outside the rig filesystem.
+	agent := &config.Agent{
+		Name:     "my_impl",
+		Scope:    "rig",
+		WorkDir:  ".gc/worktrees/my_impl",
+		PreStart: []string{"echo rig={{.RigRoot}} base={{.AgentBase}}"},
+	}
+	tp, err := resolveTemplate(params, agent, "thriva/my_impl", nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if len(tp.Hints.PreStart) != 1 {
+		t.Fatalf("PreStart = %v, want one expanded command", tp.Hints.PreStart)
+	}
+	want := "echo rig=" + rigRoot + " base=my_impl"
+	if tp.Hints.PreStart[0] != want {
+		t.Fatalf("PreStart[0] = %q, want %q", tp.Hints.PreStart[0], want)
+	}
+}
+
 func TestResolveTemplateRigScopedEnvCarriesRigRoots(t *testing.T) {
 	cityPath := t.TempDir()
 	writeTemplateResolveCityConfig(t, cityPath, "file")


### PR DESCRIPTION
## What

Adds a regression test for the `pre_start` template-substitution path of city-level rig-scoped agents — an agent with `scope = "rig"` whose `dir` is **not** stamped to the rig (its `work_dir` is a city-level worktree), so its rig association lives only in the qualified-name prefix.

The new test (`TestResolveTemplatePreStartResolvesRigRootForCityLevelRigScopedAgent`) constructs such an agent (`thriva/my_impl`, no `dir`, `work_dir` outside the rig) with a `pre_start` of `echo rig={{.RigRoot}} base={{.AgentBase}}` and asserts the command expands to the rig's absolute root and the agent base name.

## Why

The qualified-name-prefix rig fallback (#2070, landed in #2603) makes `work_dir` and the agent env resolve `RigRoot`/`AgentBase` for these agents. That fallback flows through `sessionSetupContextForAgent` → `workdir.PathContextForQualifiedName`, so it *also* reaches `pre_start` templates — but the `pre_start` path was never covered by a test. #1940 tracks exactly this gap: without the unified setup context, `{{.RigRoot}}` and `{{.AgentBase}}` would expand empty in `pre_start`.

This test exercises the fallback directly (the agent has no `dir`, so the rig resolves *only* via the prefix) and locks in that `pre_start` variables no longer expand empty for these agents. The fix itself shipped in #2603; this adds the missing regression coverage and closes the verification gap.

## Scope

Test-only. No production code changes. `+52 / -0`, one file.

## Test plan

- [x] `make build`
- [x] `make check` (full suite, PASS)
- [x] New test passes in isolation
- [x] `gofmt` / `go vet` clean

Closes #1940
