### PR TITLE
fix(cmd/gc): auto-close graph-workflow root when its source bead closes

### DIFF
--- a/cmd/gc/molecule_autoclose.go
+++ b/cmd/gc/molecule_autoclose.go
@@ -71,7 +71,22 @@ func doMoleculeAutoclose(beadID string, stdout, stderr io.Writer) {
 		return
 	}
 	rec := openCityRecorderAt(cityPath, stderr)
-	doMoleculeAutocloseWith(store, rec, beadID, stdout)
+	doMoleculeAutocloseWith(store, autocloseStoreRef(storeRoot, cityPath), rec, beadID, stdout)
+}
+
+// autocloseStoreRef resolves the store-ref label ("city:<name>" / "rig:<name>")
+// for the store rooted at storeRoot. The source-bead reverse lookup uses it to
+// scope to roots whose source actually lives in this store: in multi-store
+// deployments bead IDs can collide across stores, so without the ref a close in
+// one store could auto-close a root sourced from a same-ID bead in another
+// store. Best-effort — returns "" when the city config cannot be loaded, which
+// makes the lookup match on bead ID alone (the prior single-store behavior).
+func autocloseStoreRef(storeRoot, cityPath string) string {
+	cfg, err := loadCityConfig(cityPath, io.Discard)
+	if err != nil {
+		return ""
+	}
+	return workflowStoreRefForDir(storeRoot, cityPath, loadedCityName(cfg, cityPath), cfg)
 }
 
 // doMoleculeAutocloseWith finds the molecule root the just-closed bead
@@ -83,7 +98,7 @@ func doMoleculeAutoclose(beadID string, stdout, stderr io.Writer) {
 // predate the metadata convention. All errors are silently swallowed;
 // this is called from a bd hook script and must not fail loudly. See
 // gastownhall/gascity#1039.
-func doMoleculeAutocloseWith(store beads.Store, rec events.Recorder, beadID string, stdout io.Writer) {
+func doMoleculeAutocloseWith(store beads.Store, storeRef string, rec events.Recorder, beadID string, stdout io.Writer) {
 	bead, err := store.Get(beadID)
 	if err != nil {
 		return
@@ -98,7 +113,7 @@ func doMoleculeAutocloseWith(store beads.Store, rec events.Recorder, beadID stri
 	// orphans and is re-routed to a fresh worker indefinitely. Reverse-
 	// resolve any live workflow roots whose source bead is this bead and
 	// close them once their own subtree is terminal.
-	autocloseRootsForSourceBead(store, rec, beadID, stdout)
+	autocloseRootsForSourceBead(store, storeRef, rec, beadID, stdout)
 
 	rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
 	if rootID == "" {
@@ -155,8 +170,15 @@ func autocloseMoleculeIfComplete(store beads.Store, rec events.Recorder, mol bea
 // require the root to be issue_type "molecule" (graph.v2 wisps are
 // issue_type "task") nor that it have step descendants. Best-effort: store
 // errors are swallowed so a misbehaving hook never breaks the bd close path.
-func autocloseRootsForSourceBead(store beads.Store, rec events.Recorder, sourceBeadID string, stdout io.Writer) {
-	roots, err := sourceworkflow.ListLiveRoots(store, sourceBeadID, "", "")
+//
+// storeRef is the store-ref of the closing bead's store; it scopes the lookup
+// to roots whose source actually lives in this store (both the source-store and
+// root-store arguments of ListLiveRoots). In multi-store deployments bead IDs
+// can collide across stores, so a root in this store sourced from a same-ID
+// bead elsewhere (a different gc.source_store_ref) must not be closed here. An
+// empty storeRef falls back to matching on bead ID alone (single-store path).
+func autocloseRootsForSourceBead(store beads.Store, storeRef string, rec events.Recorder, sourceBeadID string, stdout io.Writer) {
+	roots, err := sourceworkflow.ListLiveRoots(store, sourceBeadID, storeRef, storeRef)
 	if err != nil {
 		return
 	}

--- a/cmd/gc/molecule_autoclose.go
+++ b/cmd/gc/molecule_autoclose.go
@@ -12,12 +12,20 @@ import (
 	convoycore "github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // moleculeAutocloseReason is the close_reason metadata value stamped on
 // molecule roots auto-closed because all of their step children are
 // terminal. Mirrors convoyAutocloseReason for the convoy path.
 const moleculeAutocloseReason = "molecule autoclose: all step children closed"
+
+// moleculeSourceAutocloseReason is the close_reason stamped on graph-workflow
+// roots auto-closed because the work bead they were slung against
+// (gc.source_bead_id) was closed directly by the worker. Distinct from
+// moleculeAutocloseReason so an operator reading bd show can tell the
+// source-bead-trigger close apart from the all-steps-terminal close.
+const moleculeSourceAutocloseReason = "molecule autoclose: source work bead closed"
 
 // newMoleculeCmd is the parent for molecule lifecycle operations.
 // Hidden — exposed only so the bd close hook can dispatch into it.
@@ -80,6 +88,18 @@ func doMoleculeAutocloseWith(store beads.Store, rec events.Recorder, beadID stri
 	if err != nil {
 		return
 	}
+
+	// Source-bead trigger: when a graph workflow's work bead
+	// (gc.source_bead_id) is closed directly by the worker — via either
+	// `gc bd close` or a bare `bd update --status=closed`, both of which
+	// fire this on_close hook — the workflow root is not itself a step
+	// under that bead, so the step/metadata resolution below never reaches
+	// it. A stepless wisp (graph.v2 root with no expanded steps) then
+	// orphans and is re-routed to a fresh worker indefinitely. Reverse-
+	// resolve any live workflow roots whose source bead is this bead and
+	// close them once their own subtree is terminal.
+	autocloseRootsForSourceBead(store, rec, beadID, stdout)
+
 	rootID := strings.TrimSpace(bead.Metadata["gc.root_bead_id"])
 	if rootID == "" {
 		// Legacy fallback for pre-metadata beads: react only to typed
@@ -111,36 +131,72 @@ func autocloseMoleculeIfComplete(store beads.Store, rec events.Recorder, mol bea
 	if convoycore.IsTerminalStatus(mol.Status) {
 		return
 	}
-
-	// Walk the full transitive subtree (parent-child edges plus the
-	// gc.root_bead_id metadata link) so molecules whose steps fan out
-	// into nested children — formula compiler "epic" steps,
-	// gate-deferred sub-trees — are evaluated by descendant terminality,
-	// not just direct children. Closing on direct-children-only would
-	// either fire too early (descendants still open under a closed
-	// intermediate) or never (nested open child under a closed
-	// intermediate but recorded children look terminal).
-	subtree, err := molecule.ListSubtree(store, mol.ID)
-	if err != nil {
+	terminal, descendants := subtreeTerminalExcludingRoot(store, mol.ID)
+	if !terminal {
 		return
 	}
-	if len(subtree) <= 1 {
+	if descendants == 0 {
 		// Only the root itself was returned — no descendants. The
 		// molecule is either still being instantiated or already-cleaned
 		// scaffolding; either way, closing here would race the
-		// instantiator. Leave it.
+		// instantiator. Leave it. The source-bead trigger
+		// (autocloseRootsForSourceBead) deliberately omits this guard: a
+		// closed source/work bead is a definitive completion signal and
+		// instantiation always precedes worker execution, so a stepless
+		// wisp seen there is genuinely complete.
 		return
 	}
-	for _, b := range subtree {
-		if b.ID == mol.ID {
-			continue
-		}
-		if !convoycore.IsTerminalStatus(b.Status) {
-			return
+	announceClosedMolecule(store, rec, mol, moleculeAutocloseReason, stdout)
+}
+
+// autocloseRootsForSourceBead closes any live graph-workflow roots whose
+// source/work bead (gc.source_bead_id) just closed, once each root's own
+// subtree is fully terminal. Unlike autocloseMoleculeIfComplete it does not
+// require the root to be issue_type "molecule" (graph.v2 wisps are
+// issue_type "task") nor that it have step descendants. Best-effort: store
+// errors are swallowed so a misbehaving hook never breaks the bd close path.
+func autocloseRootsForSourceBead(store beads.Store, rec events.Recorder, sourceBeadID string, stdout io.Writer) {
+	roots, err := sourceworkflow.ListLiveRoots(store, sourceBeadID, "", "")
+	if err != nil {
+		return
+	}
+	for _, root := range roots {
+		if terminal, _ := subtreeTerminalExcludingRoot(store, root.ID); terminal {
+			announceClosedMolecule(store, rec, root, moleculeSourceAutocloseReason, stdout)
 		}
 	}
+}
 
-	if err := closeMoleculeWithReason(store, mol.ID, moleculeAutocloseReason); err != nil {
+// subtreeTerminalExcludingRoot reports whether every transitive descendant of
+// rootID (the root itself excluded) is terminal, and how many descendants were
+// found. It walks the full subtree — parent-child edges plus the
+// gc.root_bead_id metadata link — so roots whose steps fan out into nested
+// children (formula-compiler "epic" steps, gate-deferred sub-trees) are
+// evaluated by descendant terminality rather than direct children. A walk
+// error yields (false, 0) so the caller leaves the root open.
+func subtreeTerminalExcludingRoot(store beads.Store, rootID string) (terminal bool, descendants int) {
+	subtree, err := molecule.ListSubtree(store, rootID)
+	if err != nil {
+		return false, 0
+	}
+	for _, b := range subtree {
+		if b.ID == rootID {
+			continue
+		}
+		descendants++
+		if !convoycore.IsTerminalStatus(b.Status) {
+			return false, descendants
+		}
+	}
+	return true, descendants
+}
+
+// announceClosedMolecule closes mol with the given close_reason, records a
+// BeadClosed event, and prints the auto-close announcement to stdout. Shared
+// by the step-terminal and source-bead-close triggers. Best-effort: a close
+// failure aborts silently without recording or announcing.
+func announceClosedMolecule(store beads.Store, rec events.Recorder, mol beads.Bead, reason string, stdout io.Writer) {
+	if err := closeMoleculeWithReason(store, mol.ID, reason); err != nil {
 		return
 	}
 

--- a/cmd/gc/molecule_autoclose_test.go
+++ b/cmd/gc/molecule_autoclose_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // TestMoleculeAutocloseClosesRootWhenAllStepsClosed is the headline
@@ -23,7 +24,7 @@ func TestMoleculeAutocloseClosesRootWhenAllStepsClosed(t *testing.T) {
 	// Close stepA first — root must NOT close (stepB still open).
 	_ = store.Close(stepA.ID)
 	var out1 bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, stepA.ID, &out1)
+	doMoleculeAutocloseWith(store, "", events.Discard, stepA.ID, &out1)
 	r1, _ := store.Get(root.ID)
 	if r1.Status == "closed" {
 		t.Fatalf("root closed prematurely after first step close: status=%q out=%q", r1.Status, out1.String())
@@ -35,7 +36,7 @@ func TestMoleculeAutocloseClosesRootWhenAllStepsClosed(t *testing.T) {
 	// Close stepB — root MUST now auto-close.
 	_ = store.Close(stepB.ID)
 	var out2 bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, stepB.ID, &out2)
+	doMoleculeAutocloseWith(store, "", events.Discard, stepB.ID, &out2)
 	r2, _ := store.Get(root.ID)
 	if r2.Status != "closed" {
 		t.Fatalf("root not auto-closed after all steps closed: status=%q out=%q", r2.Status, out2.String())
@@ -61,7 +62,7 @@ func TestMoleculeAutocloseIgnoresNonStepCloses(t *testing.T) {
 	_ = store.Close(task.ID)
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, task.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, task.ID, &out)
 
 	r, _ := store.Get(root.ID)
 	if r.Status == "closed" {
@@ -82,7 +83,7 @@ func TestMoleculeAutocloseIgnoresStepWithoutParent(t *testing.T) {
 	_ = store.Close(orphan.ID)
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, orphan.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, orphan.ID, &out)
 	if out.Len() != 0 {
 		t.Fatalf("unexpected stdout for orphan step close: %q", out.String())
 	}
@@ -99,7 +100,7 @@ func TestMoleculeAutocloseIgnoresParentNotMolecule(t *testing.T) {
 	_ = store.Close(step.ID)
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, step.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, step.ID, &out)
 
 	p, _ := store.Get(parent.ID)
 	if p.Status == "closed" {
@@ -119,7 +120,7 @@ func TestMoleculeAutocloseIdempotentOnAlreadyClosedRoot(t *testing.T) {
 	_ = store.Close(root.ID) // pre-close the root directly
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, step.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, step.ID, &out)
 	if out.Len() != 0 {
 		t.Fatalf("unexpected stdout for already-closed root: %q", out.String())
 	}
@@ -136,7 +137,7 @@ func TestMoleculeAutocloseSoleChildClosesRoot(t *testing.T) {
 	_ = store.Close(step.ID)
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, step.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, step.ID, &out)
 	r, _ := store.Get(root.ID)
 	if r.Status != "closed" {
 		t.Fatalf("sole-child molecule did not close: status=%q out=%q", r.Status, out.String())
@@ -162,7 +163,7 @@ func TestMoleculeAutocloseRespectsTombstone(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, stepB.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, stepB.ID, &out)
 	r, _ := store.Get(root.ID)
 	if r.Status != "closed" {
 		t.Fatalf("root not auto-closed when one child closed + one tombstoned: status=%q out=%q", r.Status, out.String())
@@ -197,7 +198,7 @@ func TestMoleculeAutocloseNestedStepUsesRootBeadIDMetadata(t *testing.T) {
 	_ = store.Close(nested.ID)
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, nested.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, nested.ID, &out)
 	r, _ := store.Get(root.ID)
 	if r.Status != "closed" {
 		t.Fatalf("nested-step close did not auto-close molecule root (gc.root_bead_id path or ListSubtree traversal regressed): status=%q out=%q", r.Status, out.String())
@@ -240,7 +241,7 @@ func TestMoleculeAutocloseLeavesOpenWhenNestedDescendantStillOpen(t *testing.T) 
 	_ = nestedOpen // keep open intentionally
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, nestedClosed.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, nestedClosed.ID, &out)
 	r, _ := store.Get(root.ID)
 	if r.Status == "closed" {
 		t.Fatalf("root closed despite nested descendant still open (ListSubtree regressed to direct-children-only): status=%q out=%q", r.Status, out.String())
@@ -308,7 +309,7 @@ func TestMoleculeAutocloseClosesWorkflowRootOnSourceBeadClose(t *testing.T) {
 
 	_ = store.Close(work.ID)
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, work.ID, &out)
 
 	r, _ := store.Get(root.ID)
 	if r.Status != "closed" {
@@ -346,7 +347,7 @@ func TestMoleculeAutocloseLeavesWorkflowRootOpenWhenStepOpenOnSourceClose(t *tes
 
 	_ = store.Close(work.ID)
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, work.ID, &out)
 
 	r, _ := store.Get(root.ID)
 	if r.Status == "closed" {
@@ -381,7 +382,7 @@ func TestMoleculeAutocloseClosesWorkflowRootWithTerminalStepsOnSourceClose(t *te
 
 	_ = store.Close(work.ID)
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, work.ID, &out)
 
 	r, _ := store.Get(root.ID)
 	if r.Status != "closed" {
@@ -397,9 +398,57 @@ func TestMoleculeAutocloseSourceCloseNoMatchingRootIsNoop(t *testing.T) {
 	_ = store.Close(work.ID)
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, work.ID, &out)
 	if out.Len() != 0 {
 		t.Fatalf("unexpected stdout closing a task with no workflow root: %q", out.String())
+	}
+}
+
+// TestMoleculeAutocloseSourceCloseScopesToStoreRef pins the Copilot finding on
+// PR #2972: the source-bead reverse lookup must scope to the closing bead's
+// store-ref. Two stepless workflow roots in one store share the same
+// gc.source_bead_id but were slung from same-ID source beads in different
+// stores (distinguished by gc.source_store_ref). Closing the source bead in
+// store "rig:alpha" must auto-close only the root sourced from "rig:alpha" —
+// the root sourced from "city:test" belongs to a different (colliding) source
+// and must stay open. With an empty store-ref the lookup matched on bead ID
+// alone and would wrongly close both.
+func TestMoleculeAutocloseSourceCloseScopesToStoreRef(t *testing.T) {
+	store := beads.NewMemStore()
+	work, _ := store.Create(beads.Bead{Title: "work", Type: "task"})
+	mine, _ := store.Create(beads.Bead{
+		Title: "root sourced from this store",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.source_bead_id":                      work.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	})
+	other, _ := store.Create(beads.Bead{
+		Title: "root sourced from a colliding bead in another store",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.source_bead_id":                      work.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: "city:test",
+		},
+	})
+
+	_ = store.Close(work.ID)
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, "rig:alpha", events.Discard, work.ID, &out)
+
+	m, _ := store.Get(mine.ID)
+	if m.Status != "closed" {
+		t.Fatalf("root sourced from this store not auto-closed: status=%q out=%q", m.Status, out.String())
+	}
+	o, _ := store.Get(other.ID)
+	if o.Status == "closed" {
+		t.Fatalf("root sourced from a colliding cross-store bead was wrongly closed: status=%q out=%q", o.Status, out.String())
+	}
+	if strings.Contains(out.String(), "Auto-closed molecule "+other.ID) {
+		t.Fatalf("stdout announced close of cross-store root %s: %q", other.ID, out.String())
 	}
 }
 
@@ -421,7 +470,7 @@ func TestMoleculeAutocloseSourceCloseIdempotentOnClosedRoot(t *testing.T) {
 	_ = store.Close(root.ID) // pre-close the root directly
 
 	var out bytes.Buffer
-	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+	doMoleculeAutocloseWith(store, "", events.Discard, work.ID, &out)
 	if out.Len() != 0 {
 		t.Fatalf("unexpected stdout for already-closed workflow root: %q", out.String())
 	}

--- a/cmd/gc/molecule_autoclose_test.go
+++ b/cmd/gc/molecule_autoclose_test.go
@@ -284,3 +284,145 @@ func TestCloseHookScriptIncludesMoleculeAutoclose(t *testing.T) {
 		}
 	}
 }
+
+// TestMoleculeAutocloseClosesWorkflowRootOnSourceBeadClose is the headline
+// regression: a graph.v2 workflow wisp (issue_type "task", not
+// "molecule") with no expanded step children orphans when the worker closes
+// the work bead directly. Closing the source/work bead — via `gc bd close`
+// or a bare `bd update --status=closed`, both of which fire the same on_close
+// hook — must auto-close the workflow root whose gc.source_bead_id points at
+// it. Without the reverse source-bead lookup the root stays open forever and
+// gets re-routed to a fresh worker.
+func TestMoleculeAutocloseClosesWorkflowRootOnSourceBeadClose(t *testing.T) {
+	store := beads.NewMemStore()
+	work, _ := store.Create(beads.Bead{Title: "fix the bug", Type: "task"})
+	root, _ := store.Create(beads.Bead{
+		Title: "mol-focus-review",
+		Type:  "task", // graph.v2 wisps are issue_type "task", not "molecule"
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   work.ID,
+		},
+	})
+
+	_ = store.Close(work.ID)
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+
+	r, _ := store.Get(root.ID)
+	if r.Status != "closed" {
+		t.Fatalf("stepless workflow root not auto-closed on source bead close: status=%q out=%q", r.Status, out.String())
+	}
+	if !strings.Contains(out.String(), "Auto-closed molecule "+root.ID) {
+		t.Fatalf("stdout = %q, want auto-close announcement for %s", out.String(), root.ID)
+	}
+	if got := r.Metadata["close_reason"]; got != moleculeSourceAutocloseReason {
+		t.Errorf("close_reason = %q, want %q", got, moleculeSourceAutocloseReason)
+	}
+}
+
+// TestMoleculeAutocloseLeavesWorkflowRootOpenWhenStepOpenOnSourceClose asserts
+// the source-bead trigger does NOT close a multi-step workflow root that still
+// has genuine open work (e.g. an un-run review step). Only a root whose entire
+// subtree is already terminal may close.
+func TestMoleculeAutocloseLeavesWorkflowRootOpenWhenStepOpenOnSourceClose(t *testing.T) {
+	store := beads.NewMemStore()
+	work, _ := store.Create(beads.Bead{Title: "work", Type: "task"})
+	root, _ := store.Create(beads.Bead{
+		Title: "mol",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": work.ID,
+		},
+	})
+	_, _ = store.Create(beads.Bead{
+		Title:    "open review step",
+		Type:     "step",
+		ParentID: root.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+
+	_ = store.Close(work.ID)
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+
+	r, _ := store.Get(root.ID)
+	if r.Status == "closed" {
+		t.Fatalf("workflow root closed while a step is still open: status=%q out=%q", r.Status, out.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("unexpected stdout while root still has open step: %q", out.String())
+	}
+}
+
+// TestMoleculeAutocloseClosesWorkflowRootWithTerminalStepsOnSourceClose
+// asserts the source-bead trigger closes a multi-step workflow root once both
+// the source bead and every step are terminal.
+func TestMoleculeAutocloseClosesWorkflowRootWithTerminalStepsOnSourceClose(t *testing.T) {
+	store := beads.NewMemStore()
+	work, _ := store.Create(beads.Bead{Title: "work", Type: "task"})
+	root, _ := store.Create(beads.Bead{
+		Title: "mol",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": work.ID,
+		},
+	})
+	step, _ := store.Create(beads.Bead{
+		Title:    "done step",
+		Type:     "step",
+		ParentID: root.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	_ = store.Close(step.ID)
+
+	_ = store.Close(work.ID)
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+
+	r, _ := store.Get(root.ID)
+	if r.Status != "closed" {
+		t.Fatalf("workflow root not closed when source + all steps terminal: status=%q out=%q", r.Status, out.String())
+	}
+}
+
+// TestMoleculeAutocloseSourceCloseNoMatchingRootIsNoop asserts closing a bead
+// that is no workflow's source bead is a silent no-op (no panic, no stdout).
+func TestMoleculeAutocloseSourceCloseNoMatchingRootIsNoop(t *testing.T) {
+	store := beads.NewMemStore()
+	work, _ := store.Create(beads.Bead{Title: "lonely task", Type: "task"})
+	_ = store.Close(work.ID)
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+	if out.Len() != 0 {
+		t.Fatalf("unexpected stdout closing a task with no workflow root: %q", out.String())
+	}
+}
+
+// TestMoleculeAutocloseSourceCloseIdempotentOnClosedRoot asserts that once the
+// workflow root is already closed, a repeat source-bead close is a no-op —
+// ListLiveRoots excludes closed roots, so no double-close announcement fires.
+func TestMoleculeAutocloseSourceCloseIdempotentOnClosedRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	work, _ := store.Create(beads.Bead{Title: "work", Type: "task"})
+	root, _ := store.Create(beads.Bead{
+		Title: "mol",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":           "workflow",
+			"gc.source_bead_id": work.ID,
+		},
+	})
+	_ = store.Close(work.ID)
+	_ = store.Close(root.ID) // pre-close the root directly
+
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, events.Discard, work.ID, &out)
+	if out.Len() != 0 {
+		t.Fatalf("unexpected stdout for already-closed workflow root: %q", out.String())
+	}
+}


### PR DESCRIPTION
## Summary

A graph.v2 workflow root (issue_type `task`, not `molecule`) with no expanded step children was orphaned when the worker closed the work bead directly. The work bead is not a step under the root, so neither the `gc.root_bead_id` path nor the legacy step-parent path in molecule autoclose reached the root, and a stepless root has no finalize step for the control dispatcher to process — so the root stayed `in_progress` and got re-routed to a fresh worker indefinitely.

## Fix

The `on_close` bd hook fires for both `gc bd close` and a bare `bd update --status=closed`, so the fix is symmetric across close paths: reverse-resolve live workflow roots whose `gc.source_bead_id` is the just-closed bead (via `sourceworkflow.ListLiveRoots`) and close each once its own subtree is terminal. A multi-step root with open work is left open (no premature close); the all-steps-terminal and dispatch-finalize source-chain paths are unchanged. The close reason is stamped distinctly (`molecule autoclose: source work bead closed`) so operators can tell the trigger apart.

The change extracts `subtreeTerminalExcludingRoot` and `announceClosedMolecule` as shared helpers used by both the existing all-steps-terminal path and the new source-bead trigger, preserving the original `descendants == 0` instantiation-race guard on the existing path.

## Test plan

- [x] `make build`
- [x] `make check` (full suite, PASS)
- [x] New regression tests cover: close-on-source-close (stepless wisp), open-step-left-open, terminal-steps close, no-matching-root no-op, idempotency on an already-closed root.
