### PR TITLE
feat(extmsg): support newest-first transcript lookups

### DIFF
--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -9136,6 +9136,12 @@ export interface operations {
                 parent_conversation_id?: string;
                 /** @description Conversation kind. */
                 kind?: string;
+                /** @description Return entries with sequence greater than this cursor (default 0). */
+                after_sequence?: number;
+                /** @description Maximum number of entries to return (default 100, max 500). */
+                limit?: number;
+                /** @description Sort order by sequence: asc (oldest-first, default) or desc (newest-first). */
+                order?: "asc" | "desc";
             };
             header?: never;
             path: {

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -7771,6 +7771,18 @@ export type GetV0CityByCityNameExtmsgTranscriptData = {
          * Conversation kind.
          */
         kind?: string;
+        /**
+         * Return entries with sequence greater than this cursor (default 0).
+         */
+        after_sequence?: number;
+        /**
+         * Maximum number of entries to return (default 100, max 500).
+         */
+        limit?: number;
+        /**
+         * Sort order by sequence: asc (oldest-first, default) or desc (newest-first).
+         */
+        order?: 'asc' | 'desc';
     };
     url: '/v0/city/{cityName}/extmsg/transcript';
 };

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -18666,6 +18666,42 @@
               "description": "Conversation kind.",
               "type": "string"
             }
+          },
+          {
+            "description": "Return entries with sequence greater than this cursor (default 0).",
+            "explode": false,
+            "in": "query",
+            "name": "after_sequence",
+            "schema": {
+              "description": "Return entries with sequence greater than this cursor (default 0).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of entries to return (default 100, max 500).",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "description": "Maximum number of entries to return (default 100, max 500).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by sequence: asc (oldest-first, default) or desc (newest-first).",
+            "explode": false,
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "description": "Sort order by sequence: asc (oldest-first, default) or desc (newest-first).",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -18666,6 +18666,42 @@
               "description": "Conversation kind.",
               "type": "string"
             }
+          },
+          {
+            "description": "Return entries with sequence greater than this cursor (default 0).",
+            "explode": false,
+            "in": "query",
+            "name": "after_sequence",
+            "schema": {
+              "description": "Return entries with sequence greater than this cursor (default 0).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of entries to return (default 100, max 500).",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "description": "Maximum number of entries to return (default 100, max 500).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by sequence: asc (oldest-first, default) or desc (newest-first).",
+            "explode": false,
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "description": "Sort order by sequence: asc (oldest-first, default) or desc (newest-first).",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -276,6 +276,24 @@ func (e GetV0CityByCityNameAgentsParamsRunning) Valid() bool {
 	}
 }
 
+// Defines values for GetV0CityByCityNameExtmsgTranscriptParamsOrder.
+const (
+	Asc  GetV0CityByCityNameExtmsgTranscriptParamsOrder = "asc"
+	Desc GetV0CityByCityNameExtmsgTranscriptParamsOrder = "desc"
+)
+
+// Valid indicates whether the value is a known member of the GetV0CityByCityNameExtmsgTranscriptParamsOrder enum.
+func (e GetV0CityByCityNameExtmsgTranscriptParamsOrder) Valid() bool {
+	switch e {
+	case Asc:
+		return true
+	case Desc:
+		return true
+	default:
+		return false
+	}
+}
+
 // AdapterCapabilities defines model for AdapterCapabilities.
 type AdapterCapabilities struct {
 	MaxMessageLength           int64 `json:"MaxMessageLength"`
@@ -5104,7 +5122,19 @@ type GetV0CityByCityNameExtmsgTranscriptParams struct {
 
 	// Kind Conversation kind.
 	Kind *string `form:"kind,omitempty" json:"kind,omitempty"`
+
+	// AfterSequence Return entries with sequence greater than this cursor (default 0).
+	AfterSequence *int64 `form:"after_sequence,omitempty" json:"after_sequence,omitempty"`
+
+	// Limit Maximum number of entries to return (default 100, max 500).
+	Limit *int64 `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Order Sort order by sequence: asc (oldest-first, default) or desc (newest-first).
+	Order *GetV0CityByCityNameExtmsgTranscriptParamsOrder `form:"order,omitempty" json:"order,omitempty"`
 }
+
+// GetV0CityByCityNameExtmsgTranscriptParamsOrder defines parameters for GetV0CityByCityNameExtmsgTranscript.
+type GetV0CityByCityNameExtmsgTranscriptParamsOrder string
 
 // PostV0CityByCityNameExtmsgTranscriptAckParams defines parameters for PostV0CityByCityNameExtmsgTranscriptAck.
 type PostV0CityByCityNameExtmsgTranscriptAckParams struct {
@@ -16760,6 +16790,54 @@ func NewGetV0CityByCityNameExtmsgTranscriptRequest(server string, cityName strin
 		if params.Kind != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "kind", *params.Kind, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.AfterSequence != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "after_sequence", *params.AfterSequence, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Order != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "order", *params.Order, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/internal/api/huma_handlers_extmsg.go
+++ b/internal/api/huma_handlers_extmsg.go
@@ -351,8 +351,11 @@ func (s *Server) humaHandleExtMsgTranscriptList(ctx context.Context, input *ExtM
 
 	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "api"}
 	entries, err := svc.Transcript.List(ctx, extmsg.ListTranscriptInput{
-		Caller:       caller,
-		Conversation: ref,
+		Caller:        caller,
+		Conversation:  ref,
+		AfterSequence: input.AfterSequence,
+		Limit:         input.Limit,
+		Order:         extmsg.TranscriptOrder(input.Order),
 	})
 	if err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())

--- a/internal/api/huma_types_extmsg.go
+++ b/internal/api/huma_types_extmsg.go
@@ -155,6 +155,9 @@ type ExtMsgTranscriptListInput struct {
 	ConversationID       string `query:"conversation_id" required:"false" doc:"Conversation ID."`
 	ParentConversationID string `query:"parent_conversation_id" required:"false" doc:"Parent conversation ID."`
 	Kind                 string `query:"kind" required:"false" doc:"Conversation kind."`
+	AfterSequence        int64  `query:"after_sequence" required:"false" doc:"Return entries with sequence greater than this cursor (default 0)."`
+	Limit                int    `query:"limit" required:"false" doc:"Maximum number of entries to return (default 100, max 500)."`
+	Order                string `query:"order" required:"false" enum:"asc,desc" doc:"Sort order by sequence: asc (oldest-first, default) or desc (newest-first)."`
 }
 
 // ExtMsgTranscriptAckInput is the Huma input for POST /v0/city/{cityName}/extmsg/transcript/ack.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -18666,6 +18666,42 @@
               "description": "Conversation kind.",
               "type": "string"
             }
+          },
+          {
+            "description": "Return entries with sequence greater than this cursor (default 0).",
+            "explode": false,
+            "in": "query",
+            "name": "after_sequence",
+            "schema": {
+              "description": "Return entries with sequence greater than this cursor (default 0).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of entries to return (default 100, max 500).",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "description": "Maximum number of entries to return (default 100, max 500).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by sequence: asc (oldest-first, default) or desc (newest-first).",
+            "explode": false,
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "description": "Sort order by sequence: asc (oldest-first, default) or desc (newest-first).",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/internal/extmsg/extmsg_test.go
+++ b/internal/extmsg/extmsg_test.go
@@ -3,6 +3,7 @@ package extmsg
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strconv"
 	"sync"
@@ -1094,6 +1095,87 @@ func TestTranscriptServiceAppendDedupeAndList(t *testing.T) {
 	}
 	if got[0].ProviderMessageID != "msg-1" || got[1].ProviderMessageID != "msg-2" {
 		t.Fatalf("List provider_message_ids = %#v, want msg-1,msg-2", []string{got[0].ProviderMessageID, got[1].ProviderMessageID})
+	}
+}
+
+func TestTranscriptServiceListOrderLimitAndCursor(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewServices(store).Transcript
+	ref := testConversationRef()
+
+	const total = 5
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("msg-%d", i+1)
+		if _, err := svc.Append(context.Background(), AppendTranscriptInput{
+			Caller:            testAdapterCaller(),
+			Conversation:      ref,
+			Kind:              TranscriptMessageInbound,
+			Provenance:        TranscriptProvenanceLive,
+			ProviderMessageID: id,
+			Text:              id,
+			CreatedAt:         testNow().Add(time.Duration(i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("Append(%s): %v", id, err)
+		}
+	}
+
+	providerIDs := func(records []ConversationTranscriptRecord) []string {
+		ids := make([]string, len(records))
+		for i, r := range records {
+			ids[i] = r.ProviderMessageID
+		}
+		return ids
+	}
+
+	// Descending + limit returns the newest entries, newest-first.
+	desc, err := svc.List(context.Background(), ListTranscriptInput{
+		Caller:       testControllerCaller(),
+		Conversation: ref,
+		Limit:        2,
+		Order:        TranscriptOrderDesc,
+	})
+	if err != nil {
+		t.Fatalf("List(desc): %v", err)
+	}
+	if got := providerIDs(desc); len(got) != 2 || got[0] != "msg-5" || got[1] != "msg-4" {
+		t.Fatalf("List(desc) = %#v, want [msg-5 msg-4]", got)
+	}
+
+	// Empty order defaults to ascending (backwards compatible).
+	asc, err := svc.List(context.Background(), ListTranscriptInput{
+		Caller:       testControllerCaller(),
+		Conversation: ref,
+		Limit:        2,
+	})
+	if err != nil {
+		t.Fatalf("List(default asc): %v", err)
+	}
+	if got := providerIDs(asc); len(got) != 2 || got[0] != "msg-1" || got[1] != "msg-2" {
+		t.Fatalf("List(default asc) = %#v, want [msg-1 msg-2]", got)
+	}
+
+	// AfterSequence cursor is an exclusive lower bound under both orders.
+	descAfter, err := svc.List(context.Background(), ListTranscriptInput{
+		Caller:        testControllerCaller(),
+		Conversation:  ref,
+		AfterSequence: 3,
+		Order:         TranscriptOrderDesc,
+	})
+	if err != nil {
+		t.Fatalf("List(desc, after=3): %v", err)
+	}
+	if got := providerIDs(descAfter); len(got) != 2 || got[0] != "msg-5" || got[1] != "msg-4" {
+		t.Fatalf("List(desc, after=3) = %#v, want [msg-5 msg-4]", got)
+	}
+
+	// Invalid order is rejected.
+	if _, err := svc.List(context.Background(), ListTranscriptInput{
+		Caller:       testControllerCaller(),
+		Conversation: ref,
+		Order:        TranscriptOrder("sideways"),
+	}); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("List(invalid order) err = %v, want ErrInvalidInput", err)
 	}
 }
 

--- a/internal/extmsg/transcript_service.go
+++ b/internal/extmsg/transcript_service.go
@@ -155,6 +155,10 @@ func (s *transcriptService) List(ctx context.Context, input ListTranscriptInput)
 		after = 0
 	}
 	limit := clampTranscriptLimit(input.Limit)
+	order, err := normalizeTranscriptOrder(input.Order)
+	if err != nil {
+		return nil, err
+	}
 	var out []ConversationTranscriptRecord
 	err = withBindingLock(s.locks, ref, func() error {
 		state, err := s.findStateLocked(ref)
@@ -165,7 +169,7 @@ func (s *transcriptService) List(ctx context.Context, input ListTranscriptInput)
 			out = nil
 			return nil
 		}
-		out, err = s.listTranscriptLocked(ref, after, limit)
+		out, err = s.listTranscriptLocked(ref, after, limit, order)
 		return err
 	})
 	return out, err
@@ -548,7 +552,7 @@ func (s *transcriptService) ListBackfill(ctx context.Context, input ListBackfill
 		if after == 0 && membership.BackfillPolicy == MembershipBackfillSinceJoin {
 			after = membership.JoinedSequence
 		}
-		out, err = s.listTranscriptLocked(ref, after, limit)
+		out, err = s.listTranscriptLocked(ref, after, limit, TranscriptOrderAsc)
 		return err
 	})
 	return out, err
@@ -817,7 +821,7 @@ func (s *transcriptService) findActiveMembershipLocked(ref ConversationRef, sess
 	return out, nil
 }
 
-func (s *transcriptService) listTranscriptLocked(ref ConversationRef, after int64, limit int) ([]ConversationTranscriptRecord, error) {
+func (s *transcriptService) listTranscriptLocked(ref ConversationRef, after int64, limit int, order TranscriptOrder) ([]ConversationTranscriptRecord, error) {
 	state, err := s.ensureStateLocked(ref)
 	if err != nil {
 		return nil, err
@@ -835,11 +839,12 @@ func (s *transcriptService) listTranscriptLocked(ref ConversationRef, after int6
 	}
 	startBucket := transcriptBucket(startSeq)
 	endBucket := transcriptBucket(endSeq)
+	descending := order == TranscriptOrderDesc
 	records := make([]ConversationTranscriptRecord, 0, limit)
-	for bucket := startBucket; bucket <= endBucket && len(records) < limit; bucket++ {
+	appendBucket := func(bucket int64) error {
 		items, err := s.store.List(beads.ListQuery{Label: transcriptBucketLabel(ref, bucket)})
 		if err != nil {
-			return nil, fmt.Errorf("list transcript bucket %d: %w", bucket, err)
+			return fmt.Errorf("list transcript bucket %d: %w", bucket, err)
 		}
 		bucketRecords := make([]ConversationTranscriptRecord, 0, len(items))
 		for _, item := range items {
@@ -848,31 +853,61 @@ func (s *transcriptService) listTranscriptLocked(ref ConversationRef, after int6
 			}
 			record, err := decodeTranscriptBead(item)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			if !sameConversationRef(record.Conversation, ref) || record.Sequence <= after {
 				continue
 			}
 			bucketRecords = append(bucketRecords, record)
 		}
-		slices.SortFunc(bucketRecords, func(a, b ConversationTranscriptRecord) int {
-			switch {
-			case a.Sequence < b.Sequence:
-				return -1
-			case a.Sequence > b.Sequence:
-				return 1
-			default:
-				return strings.Compare(a.ID, b.ID)
-			}
-		})
+		sortTranscriptRecords(bucketRecords, descending)
 		for _, record := range bucketRecords {
 			if len(records) >= limit {
 				break
 			}
 			records = append(records, record)
 		}
+		return nil
+	}
+	// Descending walks newest bucket first so the most recent entries are
+	// collected without scanning the entire stream on busy conversations.
+	if descending {
+		for bucket := endBucket; bucket >= startBucket && len(records) < limit; bucket-- {
+			if err := appendBucket(bucket); err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		for bucket := startBucket; bucket <= endBucket && len(records) < limit; bucket++ {
+			if err := appendBucket(bucket); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return records, nil
+}
+
+// sortTranscriptRecords orders records by sequence (ID as tiebreaker),
+// ascending by default or descending when newest-first is requested.
+func sortTranscriptRecords(records []ConversationTranscriptRecord, descending bool) {
+	slices.SortFunc(records, func(a, b ConversationTranscriptRecord) int {
+		cmp := compareTranscriptRecords(a, b)
+		if descending {
+			return -cmp
+		}
+		return cmp
+	})
+}
+
+func compareTranscriptRecords(a, b ConversationTranscriptRecord) int {
+	switch {
+	case a.Sequence < b.Sequence:
+		return -1
+	case a.Sequence > b.Sequence:
+		return 1
+	default:
+		return strings.Compare(a.ID, b.ID)
+	}
 }
 
 func decodeTranscriptBead(b beads.Bead) (ConversationTranscriptRecord, error) {
@@ -1138,6 +1173,19 @@ func requireControllerCaller(caller Caller) error {
 		return ErrUnauthorized
 	}
 	return nil
+}
+
+// normalizeTranscriptOrder validates the requested order, defaulting empty to
+// ascending (oldest-first) for backwards compatibility.
+func normalizeTranscriptOrder(order TranscriptOrder) (TranscriptOrder, error) {
+	switch order {
+	case "", TranscriptOrderAsc:
+		return TranscriptOrderAsc, nil
+	case TranscriptOrderDesc:
+		return TranscriptOrderDesc, nil
+	default:
+		return "", fmt.Errorf("%w: invalid transcript order %q", ErrInvalidInput, order)
+	}
 }
 
 func clampTranscriptLimit(limit int) int {

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -478,12 +478,27 @@ type RemoveMembershipInput struct {
 	Now          time.Time
 }
 
+// TranscriptOrder controls the sort order of listed transcript entries by sequence.
+type TranscriptOrder string
+
+const (
+	// TranscriptOrderAsc returns entries oldest-first (ascending sequence). Default.
+	TranscriptOrderAsc TranscriptOrder = "asc"
+	// TranscriptOrderDesc returns entries newest-first (descending sequence),
+	// letting callers fetch the most recent entries without walking the whole
+	// stream on busy conversations.
+	TranscriptOrderDesc TranscriptOrder = "desc"
+)
+
 // ListTranscriptInput is the input for listing transcript entries.
 type ListTranscriptInput struct {
 	Caller        Caller
 	Conversation  ConversationRef
 	AfterSequence int64
 	Limit         int
+	// Order controls newest-first vs oldest-first traversal. Empty defaults to
+	// TranscriptOrderAsc for backwards compatibility.
+	Order TranscriptOrder
 }
 
 // ListBackfillInput is the input for listing backfill entries for a member.


### PR DESCRIPTION
## Summary

`GET /v0/extmsg/transcript` always returned the oldest-first stream with no pagination, so consumers hunting for the most recent inbound message bailed after a fixed window on busy conversations and fell back to a stale result.

The service-layer `ListTranscriptInput` already carried `AfterSequence`/`Limit`, but the Huma endpoint exposed neither. This wires them through end-to-end and adds a typed `Order` (asc/desc) field with descending bucket traversal that collects the newest entries without scanning the whole stream.

## Changes
- New optional query params on the transcript-list endpoint: `order` (asc/desc), `limit` (default 100, max 500), `after_sequence` (exclusive cursor).
- `order=desc` walks transcript buckets newest-first so `limit=1` answers "what is the latest entry?" without paging history; empty `order` defaults to `asc`, so existing callers are unaffected.
- Invalid `order` is rejected (`ErrInvalidInput`) rather than silently coerced.
- Regenerated OpenAPI spec + Go gen-client (`client_gen.go`) to match.

## Tests
- `TestTranscriptServiceListOrderLimitAndCursor`: desc+limit returns newest entries newest-first; empty order stays ascending; `after_sequence` is an exclusive lower bound under desc; invalid order rejected.

## Compatibility
Wire change is purely additive — all three params are new and optional; existing transcript-list consumers are unchanged.
