### PR TITLE
test(cmd/gc): drain instead of sleep for worker sync in order-dispatch tests

### DIFF
--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -374,7 +374,7 @@ func TestOrderDispatchResolvesPackBindingForPool(t *testing.T) {
 	}
 
 	m.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	m.drain(context.Background())
 
 	work := workBeadByOrderLabel(t, store, "order-run:mol-dog-doctor")
 	if got := work.Metadata["gc.routed_to"]; got != "maintenance.dog" {
@@ -416,7 +416,7 @@ func TestOrderDispatchPrefersCityShadowForPool(t *testing.T) {
 	}
 
 	m.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	m.drain(context.Background())
 
 	work := workBeadByOrderLabel(t, store, "order-run:mol-dog-doctor")
 	if got := work.Metadata["gc.routed_to"]; got != "dog" {
@@ -1762,7 +1762,7 @@ description = "Target: {{target_id}}, workspace: {{workspace}}"
 	mad.rec = &rec
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(100 * time.Millisecond)
+	ad.drain(context.Background())
 
 	all := trackingBeads(t, store, "order-run:fail-formula-vars")
 	hasFailed := false
@@ -6030,7 +6030,7 @@ func TestOrderDispatchSkipsOpenTrackingBeadForConditionOrder(t *testing.T) {
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
 
 	ad.dispatch(context.Background(), t.TempDir(), time.Now())
-	time.Sleep(50 * time.Millisecond)
+	ad.drain(context.Background())
 
 	if ran {
 		t.Error("exec should not have run while an order-tracking bead is open")


### PR DESCRIPTION
## Summary

Replaces `time.Sleep`-as-synchronization with the dispatcher's existing `drain()` happens-before signal in four order-dispatch tests, eliminating a timing-dependent test data race.

## What changed

Four tests in `cmd/gc/order_dispatch_test.go` dispatch an order (spawning a worker goroutine via `dispatchOne`) and then read shared state — exec callbacks, tracking-bead mutations — from the test goroutine. They previously relied on a fixed `time.Sleep(50–100ms)` to let the worker finish, which is a data race: under load the sleep can lose, the read races the write, and `-race` or a slow CI runner can flake.

Each site now calls `ad.drain(ctx)` / `m.drain(ctx)`, which blocks on the `inflightDone` channel that `dispatchOne` closes in its deferred cleanup (after the tracking-bead `Close`). This is a real happens-before edge, not a timeout — `context.Background()` is passed, so it waits for actual completion.

Tests updated:
- `TestOrderDispatchResolvesPackBindingForPool`
- `TestOrderDispatchPrefersCityShadowForPool`
- `TestOrderDispatchReportsAllMissingRequiredVarsAtOnce`
- `TestOrderDispatchSkipsOpenTrackingBeadForConditionOrder`

This matches the dominant convention already used throughout this file (60+ existing `drain()` call sites). The remaining four `time.Sleep` calls are intentionally left: a poll-until-deadline backoff and three wall-clock gaps that space successive `store.Create` `CreatedAt` timestamps (no worker goroutine involved).

+4 / -4, test-only.

## Why

`time.Sleep` as the sole synchronization between a goroutine's writes and a test goroutine's reads is a data race and a flake source. Draining on the real completion signal makes the tests deterministic without changing any product behavior.

## Test plan

- `make build` — pass
- `make check` (fmt, lint, vet, routed-test-rows matrix, full `cmd/gc` suite) — pass
- Flake check: the four affected tests under `go test -race -count=10 ./cmd/gc/` — pass, no races
- The `-race` failures elsewhere in `cmd/gc` (city-runtime / reload / city-status) reproduce identically on `main` and are unrelated to this change (different files; `make check` non-race is green).
