### PR TITLE
Harden required artifact postconditions

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -332,6 +332,15 @@ func isPartialAttemptAttachError(err error) bool {
 	return errors.As(err, &partial)
 }
 
+var errTransientControllerBoundary = errors.New("transient controller boundary error")
+
+func markTransientControllerBoundaryError(err error) error {
+	if err == nil || errors.Is(err, errTransientControllerBoundary) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", errTransientControllerBoundary, err)
+}
+
 // IsTransientControllerError is the dispatch/store transient classifier for
 // control spawn and spawn-state update boundaries. Prefer typed checks when
 // callers expose them; the string fallback covers wrapped Dolt/MySQL/tmux
@@ -341,6 +350,9 @@ func IsTransientControllerError(err error) bool {
 		return false
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, errTransientControllerBoundary) {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
@@ -567,6 +579,7 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 		rootKind = "scope"
 	}
 	rootMeta := make(map[string]string, len(step.Metadata))
+	// Preserve formula-specified retry metadata such as required artifacts.
 	for k, v := range step.Metadata {
 		rootMeta[k] = v
 	}

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -296,7 +296,7 @@ func validateRequiredArtifacts(store beads.Store, subject beads.Bead, stat func(
 		stat = os.Stat
 	}
 	for _, rawPath := range requiredArtifactTemplates(subject.Metadata) {
-		path, reason, err := resolveRequiredArtifactPath(store, subject, rawPath)
+		path, worktree, reason, err := resolveRequiredArtifactPath(store, subject, rawPath)
 		if err != nil {
 			return "", err
 		}
@@ -310,6 +310,13 @@ func validateRequiredArtifacts(store beads.Store, subject beads.Bead, stat func(
 			}
 			return "unreadable_required_artifact", nil
 		}
+		contained, err := requiredArtifactTargetInWorktree(worktree, path)
+		if err != nil {
+			return "", err
+		}
+		if !contained {
+			return "required_artifact_outside_worktree", nil
+		}
 		if info.IsDir() || info.Size() == 0 {
 			return "empty_required_artifact", nil
 		}
@@ -317,6 +324,8 @@ func validateRequiredArtifacts(store beads.Store, subject beads.Bead, stat func(
 	return "", nil
 }
 
+// requiredArtifactTemplates keeps the singular key as one opaque path; only
+// the plural key is parsed as a comma/newline-delimited list.
 func requiredArtifactTemplates(metadata map[string]string) []string {
 	var result []string
 	if raw := strings.TrimSpace(metadata["gc.required_artifact"]); raw != "" {
@@ -336,7 +345,7 @@ func requiredArtifactTemplates(metadata map[string]string) []string {
 	return result
 }
 
-func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath string) (string, string, error) {
+func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath string) (string, string, string, error) {
 	rootID := strings.TrimSpace(subject.Metadata["gc.root_bead_id"])
 	attempt := strings.TrimSpace(subject.Metadata["gc.attempt"])
 	worktree := strings.TrimSpace(subject.Metadata["work_dir"])
@@ -344,15 +353,15 @@ func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath 
 	if worktree == "" {
 		resolvedWorktree, reason, err := resolveRequiredArtifactWorktree(store, rootID)
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 		if reason != "" {
-			return "", reason, nil
+			return "", "", reason, nil
 		}
 		worktree = resolvedWorktree
 	}
 	if worktree == "" {
-		return "", "missing_required_artifact_context", nil
+		return "", "", "missing_required_artifact_context", nil
 	}
 
 	path := rawPath
@@ -361,7 +370,7 @@ func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath 
 	path = strings.ReplaceAll(path, "{root_id}", rootID)
 	path = strings.ReplaceAll(path, "{attempt}", attempt)
 	if strings.Contains(path, "{") || strings.Contains(path, "}") {
-		return "", "unresolved_required_artifact_template", nil
+		return "", "", "unresolved_required_artifact_template", nil
 	}
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(worktree, path)
@@ -369,12 +378,12 @@ func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath 
 	path = filepath.Clean(path)
 	contained, err := requiredArtifactPathInWorktree(worktree, path)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	if !contained {
-		return "", "required_artifact_outside_worktree", nil
+		return "", "", "required_artifact_outside_worktree", nil
 	}
-	return path, "", nil
+	return path, worktree, "", nil
 }
 
 func requiredArtifactPathInWorktree(worktree, path string) (bool, error) {
@@ -393,6 +402,21 @@ func requiredArtifactPathInWorktree(worktree, path string) (bool, error) {
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)), nil
 }
 
+func requiredArtifactTargetInWorktree(worktree, path string) (bool, error) {
+	resolvedWorktree, err := filepath.EvalSymlinks(filepath.Clean(worktree))
+	if err != nil {
+		return false, fmt.Errorf("resolving required artifact worktree symlinks %q: %w", worktree, err)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("resolving required artifact path symlinks %q: %w", path, err)
+	}
+	return requiredArtifactPathInWorktree(resolvedWorktree, resolvedPath)
+}
+
 func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, string, error) {
 	if rootID == "" {
 		return "", "missing_required_artifact_context", nil
@@ -402,7 +426,7 @@ func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, 
 		return "", "missing_required_artifact_context", nil
 	}
 	if err != nil {
-		return "", "", fmt.Errorf("loading required artifact workflow root %s: %w", rootID, err)
+		return "", "", fmt.Errorf("loading required artifact workflow root %s: %w", rootID, markTransientControllerBoundaryError(err))
 	}
 	sourceID := strings.TrimSpace(root.Metadata["gc.source_bead_id"])
 	if sourceID == "" {
@@ -416,7 +440,7 @@ func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, 
 		return "", "missing_required_artifact_context", nil
 	}
 	if err != nil {
-		return "", "", fmt.Errorf("loading required artifact source bead %s: %w", sourceID, err)
+		return "", "", fmt.Errorf("loading required artifact source bead %s: %w", sourceID, markTransientControllerBoundaryError(err))
 	}
 	worktree := strings.TrimSpace(source.Metadata["work_dir"])
 	if worktree == "" {

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -237,6 +237,36 @@ func TestClassifyRetryAttemptWithPostconditionsRequiresArtifact(t *testing.T) {
 	}
 }
 
+func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactSymlinkOutsideWorktree(t *testing.T) {
+	t.Parallel()
+
+	worktree := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "outside.md")
+	if err := os.WriteFile(outsidePath, []byte("outside review\n"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+	linkPath := filepath.Join(worktree, "codex-review.md")
+	if err := os.Symlink(outsidePath, linkPath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got, err := classifyRetryAttemptWithPostconditions(beads.NewMemStore(), beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.required_artifact": "codex-review.md",
+			"work_dir":             worktree,
+		},
+	}, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want nil", err)
+	}
+	want := retryEvalResult{Outcome: "transient", Reason: "required_artifact_outside_worktree"}
+	if got != want {
+		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v", got, want)
+	}
+}
+
 func TestClassifyRetryAttemptWithPostconditionsResolvesReviewArtifactTemplate(t *testing.T) {
 	t.Parallel()
 
@@ -309,6 +339,39 @@ func TestClassifyRetryAttemptWithPostconditionsSurfacesRequiredArtifactStoreErro
 	}, ProcessOptions{})
 	if !errors.Is(err, backendErr) {
 		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want backend error", err)
+	}
+}
+
+func TestClassifyRetryAttemptWithPostconditionsStoreErrorIsTransientControllerError(t *testing.T) {
+	t.Parallel()
+
+	base := beads.NewMemStore()
+	root := mustCreateWorkflowBead(t, base, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	backendErr := errors.New("backend store unavailable")
+	store := failGetStore{
+		Store:  base,
+		failID: root.ID,
+		err:    backendErr,
+	}
+
+	_, err := classifyRetryAttemptWithPostconditions(store, beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.root_bead_id":      root.ID,
+			"gc.required_artifact": "codex-review.md",
+		},
+	}, ProcessOptions{})
+	if !errors.Is(err, backendErr) {
+		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want backend error", err)
+	}
+	if !IsTransientControllerError(err) {
+		t.Fatalf("IsTransientControllerError(%v) = false, want true", err)
 	}
 }
 


### PR DESCRIPTION
Post-merge remediation for #2924 over reviewed range 12e878899b6875ded478d6936b1cee43e57a8c59..8845c27b4f7556e939d821d0c047815864cd4c2f.

Fixes:
- Revalidates required-artifact targets after symlink resolution so an in-worktree symlink to an outside file cannot satisfy the postcondition.
- Wraps required-artifact store lookup faults with a typed controller-transient marker while preserving the original backend error for errors.Is.
- Documents singular/plural required-artifact metadata parsing and retry metadata propagation intent.

Local verification:
- go test ./internal/dispatch -run 'TestClassifyRetryAttemptWithPostconditions(RejectsArtifactSymlinkOutsideWorktree|StoreErrorIsTransientControllerError)'
- go test ./internal/dispatch
- make test-fast-parallel
- go vet ./...
- pre-commit hook: lint-changed, generated docs/schema check, go vet ./..., make test-fast-parallel