### PR TITLE
Bound status backend reads

### DIFF
--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -24,6 +23,8 @@ type (
 	workCounts  = StatusWorkCounts
 	mailCounts  = StatusMailCounts
 )
+
+var statusStoreReadTimeout = time.Second
 
 // StatusInput is the Huma input for GET /v0/status.
 type StatusInput struct {
@@ -65,7 +66,6 @@ func (s *Server) humaHandleStatus(ctx context.Context, input *StatusInput) (*Ind
 func (s *Server) buildStatusBody() StatusBody {
 	cfg := s.state.Config()
 	sp := s.state.SessionProvider()
-	store := s.state.CityBeadStore()
 	cityName := s.state.CityName()
 	sessTmpl := cfg.Workspace.SessionTemplate
 	sessionSnapshot := s.statusSessionSnapshot()
@@ -182,7 +182,7 @@ func (s *Server) buildStatusBody() StatusBody {
 			continue
 		}
 		seenStores[key] = true
-		list, err := store.List(beads.ListQuery{AllowScan: true})
+		list, err := statusListStoreWithTimeout(store, beads.ListQuery{AllowScan: true})
 		if err != nil {
 			partialErrors = append(partialErrors, fmt.Sprintf("rig %s work: %v", rigName, err))
 			if !beads.IsPartialResult(err) || len(list) == 0 {
@@ -214,9 +214,11 @@ func (s *Server) buildStatusBody() StatusBody {
 			continue
 		}
 		seenProvs[key] = true
-		if total, unread, err := mp.Count(""); err == nil {
+		if total, unread, err := statusMailCountWithTimeout(mp); err == nil {
 			mc.Total += total
 			mc.Unread += unread
+		} else {
+			partialErrors = append(partialErrors, fmt.Sprintf("mail: %v", err))
 		}
 	}
 
@@ -225,7 +227,7 @@ func (s *Server) buildStatusBody() StatusBody {
 	for _, ns := range cfg.NamedSessions {
 		identity := ns.QualifiedName()
 		mode := ns.ModeOrDefault()
-		status := s.namedSessionStatus(cfg, store, cityName, identity, mode, suspendedRigs)
+		status := s.namedSessionStatus(cfg, sessionSnapshot, cityName, identity, mode, suspendedRigs)
 		namedSessionDetails = append(namedSessionDetails, StatusNamedSessionDetail{
 			Identity: identity,
 			Status:   status,
@@ -235,8 +237,8 @@ func (s *Server) buildStatusBody() StatusBody {
 
 	// Session counts: walk the city bead store for session beads.
 	var sessionCounts *StatusSessionCountsDetail
-	if store != nil {
-		active, suspended := s.countSessions(store)
+	if len(sessionSnapshot.bySessionName) > 0 {
+		active, suspended := s.countSessions(sessionSnapshot)
 		if active > 0 || suspended > 0 {
 			sessionCounts = &StatusSessionCountsDetail{Active: active, Suspended: suspended}
 		}
@@ -312,7 +314,7 @@ func poolScaleLabel(a config.Agent) string {
 // session's state metadata when a bead is present.
 func (s *Server) namedSessionStatus(
 	cfg *config.City,
-	store beads.Store,
+	snapshot statusSessionSnapshot,
 	cityName, identity, mode string,
 	suspendedRigs map[string]bool,
 ) string {
@@ -322,26 +324,18 @@ func (s *Server) namedSessionStatus(
 			status = "degraded blocked"
 		}
 	}
-	if store == nil {
-		return status
-	}
 
 	runtimeName := config.NamedSessionRuntimeName(cityName, cfg.Workspace, identity)
-	id, err := session.ResolveSessionIDAllowClosed(store, runtimeName)
-	if err != nil {
-		if errors.Is(err, session.ErrSessionNotFound) {
-			return status
+	if info, ok := snapshot.bySessionName[runtimeName]; ok {
+		if info.state != "" {
+			return string(info.state)
 		}
-		return "lookup error: " + err.Error()
+		return "materialized"
 	}
-	bead, err := store.Get(id)
-	if err != nil {
-		return "lookup error: " + err.Error()
+	if len(snapshot.partialErrors) > 0 {
+		return "lookup error: " + strings.Join(snapshot.partialErrors, "; ")
 	}
-	if state := strings.TrimSpace(bead.Metadata["state"]); state != "" {
-		return state
-	}
-	return "materialized"
+	return status
 }
 
 // namedSessionTemplateBlocked reports whether a named-session's target
@@ -375,19 +369,13 @@ func namedSessionTemplateBlocked(cfg *config.City, ns *config.NamedSession, susp
 	return false
 }
 
-// countSessions walks the city bead store and tallies active / suspended
-// session beads. Errors from the underlying List are silently swallowed —
-// partial counts are better than a full read failure for a status endpoint.
-func (s *Server) countSessions(store beads.Store) (active, suspended int) {
-	list, err := store.List(beads.ListQuery{Type: "session", IncludeClosed: false, AllowScan: true})
-	if err != nil {
-		return 0, 0
-	}
-	for _, b := range list {
-		switch strings.TrimSpace(b.Metadata["state"]) {
-		case string(session.StateActive):
+// countSessions tallies active / suspended sessions from the status snapshot.
+func (s *Server) countSessions(snapshot statusSessionSnapshot) (active, suspended int) {
+	for _, info := range snapshot.bySessionName {
+		switch info.state {
+		case session.StateActive:
 			active++
-		case string(session.StateSuspended):
+		case session.StateSuspended:
 			suspended++
 		}
 	}
@@ -417,7 +405,30 @@ func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
 		return snapshot
 	}
 
-	rows, partialErrors, err := sessionReadModelRows(store)
+	type snapshotResult struct {
+		rows          []beads.Bead
+		partialErrors []string
+		err           error
+	}
+	done := make(chan snapshotResult, 1)
+	go func() {
+		rows, partialErrors, err := sessionReadModelRows(store)
+		done <- snapshotResult{rows: rows, partialErrors: partialErrors, err: err}
+	}()
+
+	var rows []beads.Bead
+	var partialErrors []string
+	var err error
+	select {
+	case result := <-done:
+		rows = result.rows
+		partialErrors = result.partialErrors
+		err = result.err
+	case <-time.After(statusStoreReadTimeout):
+		snapshot.partialErrors = []string{fmt.Sprintf("sessions: loading session snapshot timed out after %s", statusStoreReadTimeout)}
+		return snapshot
+	}
+
 	if err != nil {
 		snapshot.partialErrors = []string{fmt.Sprintf("sessions: %v", err)}
 		return snapshot
@@ -453,6 +464,52 @@ func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
 		}
 	}
 	return snapshot
+}
+
+func statusListStoreWithTimeout(store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
+	if store == nil {
+		return nil, nil
+	}
+	type listResult struct {
+		rows []beads.Bead
+		err  error
+	}
+	done := make(chan listResult, 1)
+	go func() {
+		rows, err := store.List(query)
+		done <- listResult{rows: rows, err: err}
+	}()
+	select {
+	case result := <-done:
+		return result.rows, result.err
+	case <-time.After(statusStoreReadTimeout):
+		return nil, fmt.Errorf("list timed out after %s", statusStoreReadTimeout)
+	}
+}
+
+func statusMailCountWithTimeout(mp interface {
+	Count(string) (total int, unread int, err error)
+},
+) (int, int, error) {
+	if mp == nil {
+		return 0, 0, nil
+	}
+	type countResult struct {
+		total  int
+		unread int
+		err    error
+	}
+	done := make(chan countResult, 1)
+	go func() {
+		total, unread, err := mp.Count("")
+		done <- countResult{total: total, unread: unread, err: err}
+	}()
+	select {
+	case result := <-done:
+		return result.total, result.unread, result.err
+	case <-time.After(statusStoreReadTimeout):
+		return 0, 0, fmt.Errorf("count timed out after %s", statusStoreReadTimeout)
+	}
 }
 
 func appendUnlimitedPoolSessionBeads(expanded []expandedAgent, a config.Agent, cityName, sessTmpl string, snapshot statusSessionSnapshot) []expandedAgent {

--- a/internal/api/handler_status_test.go
+++ b/internal/api/handler_status_test.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -295,6 +298,80 @@ func TestHandleStatusUsesPartialSessionRows(t *testing.T) {
 	}
 }
 
+func TestHandleStatusDegradesWhenReadModelStoreStalls(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	state := newFakeState(t)
+	stallingStore := &delayedListStore{
+		Store: beads.NewMemStore(),
+		delay: 750 * time.Millisecond,
+	}
+	state.cityBeadStore = stallingStore
+	state.stores["myrig"] = stallingStore
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	h.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("status handler took %s, want bounded degraded response", elapsed)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Partial {
+		t.Fatalf("Partial = false, want true for stalled read model")
+	}
+	if !statusPartialErrorsContain(resp.PartialErrors, "timed out") {
+		t.Fatalf("PartialErrors = %#v, want timeout diagnostic", resp.PartialErrors)
+	}
+}
+
+func TestHandleStatusDegradesWhenMailCountStalls(t *testing.T) {
+	oldTimeout := statusStoreReadTimeout
+	statusStoreReadTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { statusStoreReadTimeout = oldTimeout })
+
+	state := newFakeState(t)
+	state.cityMailProv = &delayedMailCountProvider{
+		Provider: state.cityMailProv,
+		delay:    750 * time.Millisecond,
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	h.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("status handler took %s, want bounded degraded response", elapsed)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Partial {
+		t.Fatalf("Partial = false, want true for stalled mail count")
+	}
+	if !statusPartialErrorsContain(resp.PartialErrors, "mail: count timed out") {
+		t.Fatalf("PartialErrors = %#v, want mail count timeout diagnostic", resp.PartialErrors)
+	}
+}
+
 func TestHandleStatusUsesNewestSessionBeadForDuplicateSessionName(t *testing.T) {
 	state := newFakeState(t)
 	store := beads.NewMemStore()
@@ -495,4 +572,33 @@ func TestHandleStatusOnlyUsesProviderLiveness(t *testing.T) {
 	if resp.Running != 1 {
 		t.Fatalf("Running = %d, want 1", resp.Running)
 	}
+}
+
+type delayedListStore struct {
+	beads.Store
+	delay time.Duration
+}
+
+func (s *delayedListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	time.Sleep(s.delay)
+	return s.Store.List(query)
+}
+
+type delayedMailCountProvider struct {
+	mail.Provider
+	delay time.Duration
+}
+
+func (p *delayedMailCountProvider) Count(recipient string) (int, int, error) {
+	time.Sleep(p.delay)
+	return p.Provider.Count(recipient)
+}
+
+func statusPartialErrorsContain(errors []string, substr string) bool {
+	for _, err := range errors {
+		if strings.Contains(err, substr) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/store_health.go
+++ b/internal/api/store_health.go
@@ -79,7 +79,7 @@ func countBeadStoreRows(store beads.Store) int {
 	if store == nil {
 		return 0
 	}
-	list, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	list, err := statusListStoreWithTimeout(store, beads.ListQuery{AllowScan: true, IncludeClosed: true})
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
## Summary

- Bound slow backend reads while building `/v0/status` so the API returns a degraded response instead of blocking indefinitely.
- Reuse the session snapshot for named-session and session-count status paths to avoid extra direct store scans.
- Add regression coverage for stalled read-model store scans and stalled mail count calls.

## Test Plan

- `env CGO_CPPFLAGS=-I/opt/homebrew/opt/icu4c@78/include CGO_LDFLAGS=-L/opt/homebrew/opt/icu4c@78/lib go test ./internal/api -run 'TestHandleStatus|TestBuildStatusBodyIncludesStoreHealth|TestCachedStoreHealth|TestComputeStoreHealth' -count=1`
- `env CGO_CPPFLAGS=-I/opt/homebrew/opt/icu4c@78/include CGO_LDFLAGS=-L/opt/homebrew/opt/icu4c@78/lib go test ./internal/api`
- `env CGO_CPPFLAGS=-I/opt/homebrew/opt/icu4c@78/include CGO_LDFLAGS=-L/opt/homebrew/opt/icu4c@78/lib go test ./cmd/gc -run 'Test.*Status|Test.*StoreHealth|TestSupervisorCityAPIClientRequiresRunning' -count=1`

Note: the ICU flags were needed locally after rebasing onto the refreshed upstream `main`, because `go-icu-regex` could not otherwise find Homebrew's `unicode/regex.h`.
