### PR TITLE
fix(pool-worker): stop on lost claim CAS to prevent duplicate execution

### DIFF
--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -23,20 +23,28 @@ bd ready --assignee="$GC_SESSION_NAME"
 # Step 3: If still nothing, check the routed queue
 gc hook
 
-# Step 4: Claim it
-bd update <id> --claim
+# Step 4: Claim it ATOMICALLY — and STOP if you lost the race.
+# `bd update --claim` is a dolt-layer CAS (assignee IS NULL -> you); a
+# sibling pool session may have claimed this bead first. On a lost claim
+# the CLI exits NON-ZERO (gastownhall/gascity#1052). Never proceed on a
+# failed claim — that is the duplicate-execution bug.
+if ! bd update <id> --claim; then
+  # Lost the race. Do NOT work this bead. Return to the hook for the next
+  # unclaimed item (restart from Step 3); drain if none remains. Do NOT
+  # continue to Step 5/6 for this <id>.
+  gc hook   # or: gc runtime drain-ack  (no valid work left)
+else
+  # Step 5: Verify the claim actually landed on you before doing work. If
+  # assignee != $GC_SESSION_NAME (or routed_to != $GC_TEMPLATE), do NOT
+  # work it — re-enter at Step 3 (gc hook) or drain.
+  bd show <id> --json   # assignee must be $GC_SESSION_NAME; routed_to == $GC_TEMPLATE
 
-# Step 5: Verify the claim before doing work
-bd show <id> --json
-
-# Step 6: Read the bead and check for molecule_id in METADATA
-bd show <id>
+  # Step 6: Read the bead and check for molecule_id in METADATA
+  bd show <id>
+fi
 ```
 
 If nothing is available, run `gc runtime drain-ack` to end your session.
-After claiming, verify `assignee` is `$GC_SESSION_NAME` and
-`metadata.gc.routed_to` is `$GC_TEMPLATE`. If either check fails, do not work
-that bead; run `gc hook` again or drain if no valid work is available.
 
 ## Following Your Formula
 


### PR DESCRIPTION
## What & why

`pool-worker.md` (the pool-worker agent prompt) had a linear Step 4–6: `bd update <id> --claim`, then verify, then read and work. `bd update --claim` is a Dolt-layer CAS (`assignee IS NULL -> you`); when sibling pool sessions race for the same bead, the loser's CLI exits non-zero. With the linear flow the loser fell through to Step 5/6 and worked the bead anyway — the duplicate-execution behavior in #1052.

## Change

Step 4 becomes a hard branch on the claim exit code:

```sh
if ! bd update <id> --claim; then
  # Lost the race -> back to the hook (restart Step 3), or drain if none left.
  gc hook
else
  # Step 5: verify the claim landed (assignee == $GC_SESSION_NAME,
  #         routed_to == $GC_TEMPLATE)
  # Step 6: read the bead
fi
```

- A lost (or otherwise failed) claim returns to the hook; Step 5/6 run only on a won claim.
- The existing "verify assignee/routed_to before working" directive is preserved, folded into the won-claim branch (covers the won-but-wrong-owner case).
- The redundant trailing verify paragraph is removed so the stop is unambiguous.

Prompt-only, no Go change. One file: `internal/bootstrap/packs/core/assets/prompts/pool-worker.md` (+19/-11).

## Scope vs. #845 / #1085

This is the **prompt-layer** mitigation for #1052 — a low-cost belt for workers that still follow the prompt's claim step. It does **not** claim to fix #1052:

- The **mechanical** fix is #845 (spawn-time claim-or-drain in the SDK), and #1085 (pre_launch hooks) implements that acquisition path. Those own the structural resolution.
- This PR only hardens the prompt, so a worker reaching the claim step stops deterministically on a lost CAS until the mechanical path is everywhere. It touches none of #1085's files.

**Supersession:** once #845 / #1085 make the prompt-level claim step redundant, this can be closed.

## Verification

Prompt asset only — no code path or test surface; `make check` is unaffected. All three claim outcomes traced (won → proceed; lost → stop; transient error → stop, bead stays open and is re-dispatched): no path reaches duplicate execution.
