### PR TITLE
doltlite: integrate embedded DoltLite bead store backend

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -482,14 +482,16 @@ func normalizeCanonicalBdScopeFilesForInit(cityPath, dir, prefix, doltDatabase s
 		// Preserve legacy probe metadata during startup normalization so old
 		// scopes can still boot and migrate deliberately. New init paths still
 		// reject this reserved name when it is not already pinned in metadata.
+		if cityUsesDoltliteBeadsBackend(cityPath) {
+			return ensureCanonicalDoltliteScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase)
+		}
 		return ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase)
+	}
+	if cityUsesDoltliteBeadsBackend(cityPath) {
+		return enforceCanonicalDoltliteScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase)
 	}
 	return enforceCanonicalScopeMetadataForInit(fsys.OSFS{}, dir, doltDatabase)
 }
-
-// initAndHookDir is the atomic unit of bead store initialization:
-// init the directory, then install event hooks. The ordering matters
-// because init (bd init) may recreate .beads/ and wipe existing hooks.
 func initAndHookDir(cityPath, dir, prefix string) error {
 	if usesPostgres, err := scopeUsesPostgresBackendForInit(cityPath, dir); err != nil {
 		return err
@@ -509,7 +511,7 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 	if err := normalizeCanonicalBdScopeFilesForInit(cityPath, dir, prefix, doltDatabase); err != nil {
 		return err
 	}
-	if cityUsesBdStoreContract(cityPath) && currentResolvableManagedDoltPort(cityPath) != "" {
+	if cityUsesBdStoreContract(cityPath) && !cityUsesDoltliteBeadsBackend(cityPath) && currentResolvableManagedDoltPort(cityPath) != "" {
 		if err := syncManagedDoltPortMirrors(cityPath); err != nil {
 			return fmt.Errorf("sync managed dolt port mirrors after init: %w", err)
 		}
@@ -1473,6 +1475,11 @@ func ensureCanonicalScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase str
 //nolint:unparam // keep fs seam for future testable FS injection
 func ensureCanonicalDoltliteScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase string) error {
 	return ensureCanonicalDoltliteScopeMetadata(fs, scopeRoot, doltDatabase, true)
+}
+
+//nolint:unparam // keep fs seam for future testable FS injection
+func enforceCanonicalDoltliteScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase string) error {
+	return ensureCanonicalDoltliteScopeMetadata(fs, scopeRoot, doltDatabase, false)
 }
 
 //nolint:unparam // keep fs seam for future testable FS injection

--- a/cmd/gc/cityinit_exact_output_test.go
+++ b/cmd/gc/cityinit_exact_output_test.go
@@ -45,7 +45,7 @@ func TestCityInitExactOutput_CommandProviderSkipReadiness(t *testing.T) {
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
 
 	var stdout, stderr bytes.Buffer
-	code := cmdInitWithOptions([]string{filepath.Join(t.TempDir(), "bright-lights")}, "codex", "", "", &stdout, &stderr, true, false)
+	code := cmdInitWithOptions([]string{filepath.Join(t.TempDir(), "bright-lights")}, "codex", "", "", "", &stdout, &stderr, true, false)
 
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions code = %d, want 0", code)

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -76,6 +76,7 @@ type wizardConfig struct {
 	provider         string // built-in provider key, or "" if startCommand set
 	startCommand     string // custom start command (workspace-level)
 	bootstrapProfile string // hosted bootstrap profile, or "" for local defaults
+	beadsBackend     string // bead store backend: "dolt" or "doltlite", "" = default
 }
 
 // defaultWizardConfig returns a non-interactive wizardConfig that produces
@@ -146,11 +147,13 @@ func runWizard(stdin io.Reader, stdout io.Writer) wizardConfig {
 		fmt.Fprintf(stdout, "Unknown template %q, using minimal.\n", configChoice) //nolint:errcheck // best-effort stdout
 	}
 
-	// Custom config → skip agent question, return minimal config.
+	// Custom config → skip agent question, return after backend choice.
 	if configName == "custom" {
+		beadsBackend := askBeadsBackend(stdin, stdout)
 		return wizardConfig{
 			interactive: true,
 			configName:  "custom",
+			beadsBackend: beadsBackend,
 		}
 	}
 
@@ -190,11 +193,40 @@ func runWizard(stdin io.Reader, stdout io.Writer) wizardConfig {
 		}
 	}
 
+	beadsBackend := askBeadsBackend(stdin, stdout)
+
 	return wizardConfig{
 		interactive:  true,
 		configName:   configName,
 		provider:     provider,
 		startCommand: startCommand,
+		beadsBackend: beadsBackend,
+	}
+}
+
+// askBeadsBackend presents the bead store backend choice to the user.
+// Returns "doltlite" or "" (default = "dolt").
+func askBeadsBackend(stdin io.Reader, stdout io.Writer) string {
+	if stdin == nil {
+		return ""
+	}
+	br := bufio.NewReader(stdin)
+
+	fmt.Fprintln(stdout, "")                                              //nolint:errcheck // best-effort stdout
+	fmt.Fprintln(stdout, "Choose your bead store backend:")                    //nolint:errcheck // best-effort stdout
+	fmt.Fprintln(stdout, "  1. dolt      — managed Dolt SQL server (default)")        //nolint:errcheck // best-effort stdout
+	fmt.Fprintln(stdout, "  2. doltlite  — embedded DoltLite, no server process")     //nolint:errcheck // best-effort stdout
+	fmt.Fprintf(stdout, "Backend [1]: ")                                  //nolint:errcheck // best-effort stdout
+
+	choice := readLine(br)
+	switch choice {
+	case "", "1", "dolt":
+		return ""
+	case "2", "doltlite":
+		return "doltlite"
+	default:
+		fmt.Fprintf(stdout, "Unknown backend %q, using dolt.\n", choice) //nolint:errcheck // best-effort stdout
+		return ""
 	}
 }
 
@@ -245,6 +277,7 @@ func newInitCmd(stdout, stderr io.Writer) *cobra.Command {
 	var templateFlag string
 	var providerFlag string
 	var bootstrapProfileFlag string
+	var beadsBackendFlag string
 	var skipProviderReadiness bool
 	var preserveExisting bool
 	var jsonOut bool
@@ -262,12 +295,18 @@ existing TOML config file.
 
 Pass --preserve-existing to keep any pre-authored pack.toml, city.toml, or
 agent prompt files in the target directory (useful when bootstrapping a
-committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
+committed workspace — e.g. from a bootstrap.sh shipped in the repo).
+
+Use --beads-backend to configure the bead store backend. "dolt" uses the
+managed Dolt SQL server (default). "doltlite" uses embedded DoltLite
+databases — no server process required, suitable for local dev.`,
 		Example: `  gc init
   gc init ~/my-city
   gc init --provider codex ~/my-city
   gc init --template gastown --provider codex ~/my-city
   gc init --provider codex --bootstrap-profile k8s-cell /city
+  gc init --beads-backend doltlite ~/my-city
+  gc init --template gastown --beads-backend doltlite ~/my-city
   gc init --name my-city
   gc init --from ~/elan --name elan /city
   gc init --file examples/gastown.toml ~/bright-lights
@@ -294,7 +333,7 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 			} else if providerFlag != "" || bootstrapProfileFlag != "" {
 				mode = "provider"
 			}
-			code := cmdInitWithOptionsInternal(args, templateFlag, providerFlag, bootstrapProfileFlag, nameFlag, out, stderr, skipProviderReadiness, preserveExisting, jsonOut)
+			code := cmdInitWithOptionsInternal(args, templateFlag, providerFlag, bootstrapProfileFlag, beadsBackendFlag, nameFlag, out, stderr, skipProviderReadiness, preserveExisting, jsonOut)
 			return writeInitJSONOrExit(code, jsonOut, args, nameFlag, templateFlag, providerFlag, bootstrapProfileFlag, mode, stdout)
 		},
 	}
@@ -304,6 +343,7 @@ committed workspace — e.g. from a bootstrap.sh shipped in the repo).`,
 	cmd.Flags().StringVar(&templateFlag, "template", "", "config template to use non-interactively (minimal, gastown, custom)")
 	cmd.Flags().StringVar(&providerFlag, "provider", "", "built-in workspace provider to use for the default mayor config")
 	cmd.Flags().StringVar(&bootstrapProfileFlag, "bootstrap-profile", "", "bootstrap profile to apply for hosted/container defaults")
+	cmd.Flags().StringVar(&beadsBackendFlag, "beads-backend", "", "bead store backend: \"dolt\" (managed Dolt server) or \"doltlite\" (embedded DoltLite); default: dolt")
 	cmd.Flags().BoolVar(&skipProviderReadiness, "skip-provider-readiness", false, "skip provider login/readiness checks during init and continue startup")
 	cmd.Flags().BoolVar(&preserveExisting, "preserve-existing", false, "keep any pre-authored pack.toml, city.toml, or agent prompt files instead of overwriting them")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON summary")
@@ -364,14 +404,14 @@ func initTargetPath(args []string) (string, error) {
 // Creates the runtime scaffold and city.toml. If the bead provider is "bd", also
 // runs bd init.
 func cmdInit(args []string, providerFlag, bootstrapProfileFlag string, stdout, stderr io.Writer) int {
-	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, "", stdout, stderr, false, false)
+	return cmdInitWithOptions(args, providerFlag, bootstrapProfileFlag, "", "", stdout, stderr, false, false)
 }
 
-func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
-	return cmdInitWithOptionsInternal(args, "", providerFlag, bootstrapProfileFlag, nameOverride, stdout, stderr, skipProviderReadiness, preserveExisting, false)
+func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, beadsBackendFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool) int {
+	return cmdInitWithOptionsInternal(args, "", providerFlag, bootstrapProfileFlag, beadsBackendFlag, nameOverride, stdout, stderr, skipProviderReadiness, preserveExisting, false)
 }
 
-func cmdInitWithOptionsInternal(args []string, templateFlag, providerFlag, bootstrapProfileFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool, forceDefaultWizard bool) int {
+func cmdInitWithOptionsInternal(args []string, templateFlag, providerFlag, bootstrapProfileFlag, beadsBackendFlag, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness, preserveExisting bool, forceDefaultWizard bool) int {
 	var cityPath string
 	if len(args) > 0 {
 		var err error
@@ -407,6 +447,9 @@ func cmdInitWithOptionsInternal(args []string, templateFlag, providerFlag, boots
 		maybePrintWizardProviderGuidance(wiz, stdout)
 	default:
 		wiz = defaultWizardConfig()
+	}
+	if beadsBackendFlag != "" {
+		wiz.beadsBackend = strings.TrimSpace(beadsBackendFlag)
 	}
 	if code := doInit(fsys.OSFS{}, cityPath, wiz, nameOverride, stdout, stderr, preserveExisting); code != 0 {
 		return code
@@ -998,6 +1041,9 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	}
 
 	// Create directory structure.
+	if exe, err := os.Executable(); err == nil {
+		fmt.Fprintf(stdout, "%s (%s) %s (commit: %s)\n", filepath.Base(exe), exe, version, commit) //nolint:errcheck // best-effort stdout
+	}
 	logInitProgress(stdout, 1, "Creating runtime scaffold")
 	if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1029,6 +1075,9 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 		cfg = config.DefaultCity(cityName)
 	}
 	applyBootstrapProfile(&cfg, wiz.bootstrapProfile)
+	if strings.TrimSpace(wiz.beadsBackend) != "" {
+		cfg.Beads.Backend = strings.TrimSpace(wiz.beadsBackend)
+	}
 	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
 
 	// Write prompt files only for the agents declared by the init template.

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -547,8 +547,9 @@ var initRunVersion = func(binary string) (string, error) {
 
 // Minimum versions for beads-provider binaries.
 const (
-	doltMinVersion = doltversion.ManagedMin // sql-server features used by gc-beads-bd
-	bdMinVersion   = "1.0.4"                // BdStore shell-out interface, including bd create --id
+	doltMinVersion     = doltversion.ManagedMin // sql-server features used by gc-beads-bd
+	bdMinVersion       = "1.0.4"                // BdStore shell-out interface, including bd create --id
+	bdDoltliteMinVersion = "1.0.3"              // DoltLite bd fork minimum version
 )
 
 // checkHardDependencies verifies that all required binaries are available
@@ -566,6 +567,12 @@ func checkHardDependencies(cityPath string) []missingDep {
 	}
 
 	needsBd := initNeedsBdTooling(cityPath)
+	needsDolt := needsBd && !cityUsesDoltliteBeadsBackend(cityPath)
+
+	bdMin := bdMinVersion
+	if needsBd && cityUsesDoltliteBeadsBackend(cityPath) {
+		bdMin = bdDoltliteMinVersion
+	}
 
 	deps := []dep{
 		{
@@ -584,12 +591,12 @@ func checkHardDependencies(cityPath string) []missingDep {
 			name:        "dolt",
 			installHint: "https://github.com/dolthub/dolt/releases",
 			minVersion:  doltMinVersion,
-			condition:   func() bool { return needsBd },
+			condition:   func() bool { return needsDolt },
 		},
 		{
 			name:        "bd",
 			installHint: "https://github.com/gastownhall/beads/releases",
-			minVersion:  bdMinVersion,
+			minVersion:  bdMin,
 			condition:   func() bool { return needsBd },
 		},
 		{
@@ -693,6 +700,9 @@ func checkDoltAuthorIdentity(cityPath string) doltAuthorIdentityStatus {
 
 func initNeedsLocalDoltIdentity(cityPath string) bool {
 	if gcDoltSkip() {
+		return false
+	}
+	if cityUsesDoltliteBeadsBackend(cityPath) {
 		return false
 	}
 

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -781,7 +781,7 @@ func TestCmdInitSkipProviderReadinessBypassesBlockedProvider(t *testing.T) {
 	t.Cleanup(func() { registerCityWithSupervisorTestHook = oldRegister })
 
 	var stdout, stderr bytes.Buffer
-	code = cmdInitWithOptions([]string{cityPath}, "", "", "", &stdout, &stderr, true, false)
+	code = cmdInitWithOptions([]string{cityPath}, "", "", "", "", &stdout, &stderr, true, false)
 	if code != 0 {
 		t.Fatalf("cmdInitWithOptions = %d, want 0: %s", code, stderr.String())
 	}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2222,10 +2222,10 @@ doltlite_bd_schema_ready() {
 run_bd_doltlite_init() {
     local dir="$1" prefix="$2" database="$3" reinit="${4:-false}"
     if [ "$reinit" = true ]; then
-        run_bd_doltlite "$dir" init --reinit-local --quiet -p "$prefix" --database "$database" --skip-hooks --skip-agents || die "bd doltlite init failed for $dir"
+        run_bd_doltlite "$dir" init --backend doltlite --reinit-local --quiet -p "$prefix" --database "$database" --skip-hooks --skip-agents || die "bd doltlite init failed for $dir"
         return 0
     fi
-    run_bd_doltlite "$dir" init --quiet -p "$prefix" --database "$database" --skip-hooks --skip-agents || die "bd doltlite init failed for $dir"
+    run_bd_doltlite "$dir" init --backend doltlite --quiet -p "$prefix" --database "$database" --skip-hooks --skip-agents || die "bd doltlite init failed for $dir"
 }
 
 ensure_doltlite_bd_schema() {

--- a/examples/beads-doltlite/assets/scripts/runtime.sh
+++ b/examples/beads-doltlite/assets/scripts/runtime.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# doltlite runtime utilities — shared functions for doltlite maintenance ops.
+# The doltlite backend stores data via the bd CLI with BEADS_BACKEND=doltlite.
+# The actual database is at .beads/doltlite/<database>.db (SQLite with Dolt VC API).
+set -euo pipefail
+
+doltlite_scope_dir() {
+  local beads_dir="${1:-${BEADS_DIR:-${GC_CITY_PATH:-.}/.beads}}"
+  echo "${beads_dir%/.*}"
+}
+
+run_bd_doltlite() {
+  local dir="$1"
+  shift
+  cd "$dir" || die "cannot enter $dir"
+  export BEADS_BACKEND=doltlite GC_BEADS_BACKEND=doltlite BD_NON_INTERACTIVE=1
+  bd "$@"
+}

--- a/examples/beads-doltlite/commands/flatten/command.toml
+++ b/examples/beads-doltlite/commands/flatten/command.toml
@@ -1,0 +1,1 @@
+description = "Compact the doltlite SQLite database (VACUUM and WAL checkpoint)"

--- a/examples/beads-doltlite/commands/flatten/run.sh
+++ b/examples/beads-doltlite/commands/flatten/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# doltlite flatten — compact the doltlite database via bd flatten.
+set -euo pipefail
+
+BEADS_DIR="${BEADS_DIR:-${GC_CITY_PATH:-.}/.beads}"
+SCOPE_DIR="${BEADS_DIR%/.*}"
+
+if command -v bd >/dev/null 2>&1; then
+  cd "$SCOPE_DIR" || exit 1
+  export BEADS_BACKEND=doltlite GC_BEADS_BACKEND=doltlite BD_NON_INTERACTIVE=1
+  bd flatten --force --json 2>&1 || echo '{"reclaimed_bytes":0,"error":"bd flatten failed"}'
+else
+  echo '{"reclaimed_bytes":0,"error":"bd CLI not found"}'
+fi

--- a/examples/beads-doltlite/commands/gc/command.toml
+++ b/examples/beads-doltlite/commands/gc/command.toml
@@ -1,0 +1,1 @@
+description = "Remove deleted beads from the doltlite database (compact deleted rows)"

--- a/examples/beads-doltlite/commands/gc/run.sh
+++ b/examples/beads-doltlite/commands/gc/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# doltlite gc — remove deleted beads via bd gc.
+set -euo pipefail
+
+BEADS_DIR="${BEADS_DIR:-${GC_CITY_PATH:-.}/.beads}"
+SCOPE_DIR="${BEADS_DIR%/.*}"
+
+if command -v bd >/dev/null 2>&1; then
+  cd "$SCOPE_DIR" || exit 1
+  export BEADS_BACKEND=doltlite GC_BEADS_BACKEND=doltlite BD_NON_INTERACTIVE=1
+  bd gc --skip-decay --force --json 2>&1 || echo '{"deleted_beads_removed":0,"error":"bd gc failed"}'
+else
+  echo '{"deleted_beads_removed":0,"error":"bd CLI not found"}'
+fi

--- a/examples/beads-doltlite/commands/health/command.toml
+++ b/examples/beads-doltlite/commands/health/command.toml
@@ -1,0 +1,1 @@
+description = "Check doltlite database health (schema integrity, storage stats)"

--- a/examples/beads-doltlite/commands/health/run.sh
+++ b/examples/beads-doltlite/commands/health/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# doltlite health — check doltlite database integrity and stats via bd.
+set -euo pipefail
+
+BEADS_DIR="${BEADS_DIR:-${GC_CITY_PATH:-.}/.beads}"
+SCOPE_DIR="${BEADS_DIR%/.*}"
+
+if command -v bd >/dev/null 2>&1; then
+  cd "$SCOPE_DIR" || exit 1
+  export BEADS_BACKEND=doltlite GC_BEADS_BACKEND=doltlite BD_NON_INTERACTIVE=1
+  bd status --json 2>&1 || echo '{"ok":false,"error":"bd status failed"}'
+else
+  echo '{"ok":false,"error":"bd CLI not found"}'
+fi

--- a/examples/beads-doltlite/doctor/check-sqlite3/doctor.toml
+++ b/examples/beads-doltlite/doctor/check-sqlite3/doctor.toml
@@ -1,0 +1,1 @@
+description = "Verify sqlite3 CLI is available for doltlite maintenance"

--- a/examples/beads-doltlite/doctor/check-sqlite3/run.sh
+++ b/examples/beads-doltlite/doctor/check-sqlite3/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required for doltlite bead store maintenance"
+  exit 1
+fi
+
+echo "sqlite3 available: $(sqlite3 --version 2>&1 | head -1)"
+exit 0

--- a/examples/beads-doltlite/embed.go
+++ b/examples/beads-doltlite/embed.go
@@ -1,0 +1,6 @@
+package beadsdoltlite
+
+import "embed"
+
+//go:embed pack.toml doctor commands formulas orders all:assets
+var PackFS embed.FS

--- a/examples/beads-doltlite/formulas/mol-doltlite-maintenance.toml
+++ b/examples/beads-doltlite/formulas/mol-doltlite-maintenance.toml
@@ -1,0 +1,60 @@
+description = """
+Run doltlite maintenance: flatten (VACUUM, WAL checkpoint) and gc (purge
+deleted beads) on the SQLite bead store.
+
+This is an infrastructure formula run by the dog pool. It performs:
+1. Health check (integrity, bead count, storage stats)
+2. Flatten (compact the SQLite database)
+3. GC (remove soft-deleted beads)
+4. Report findings
+
+## Dog Contract
+
+This is infrastructure work. You:
+1. Run `gc doltlite health --json` to assess current state.
+2. Run `gc doltlite flatten --json` to compact.
+3. Run `gc doltlite gc --json` to purge deleted beads.
+4. Emit reporting events and return to kennel.
+"""
+formula = "mol-doltlite-maintenance"
+
+[[steps]]
+id = "maintenance"
+title = "Run doltlite health, flatten, and gc"
+description = """
+Run this as one shell script:
+
+```bash
+set -euo pipefail
+
+WORK_BEAD="${GC_BEAD_ID:?GC_BEAD_ID required; aborting}"
+
+run_or_warn() {
+  local label="$1"
+  shift
+  if ! "$@"; then
+    echo "${label} failed" >&2
+  fi
+}
+
+HEALTH=$(gc doltlite health --json 2>&1 || echo '{"ok":false}')
+echo "$HEALTH"
+
+FLATTEN=$(gc doltlite flatten --json 2>&1 || echo '{"reclaimed_bytes":0}')
+echo "$FLATTEN"
+
+GC=$(gc doltlite gc --json 2>&1 || echo '{"deleted_beads_removed":0}')
+echo "$GC"
+
+RECLAIMED=$(echo "$FLATTEN" | jq -r '.reclaimed_bytes // 0')
+DELETED=$(echo "$GC" | jq -r '.deleted_beads_removed // 0')
+
+run_or_warn "emit maintenance event" gc event emit mol-doltlite-maintenance.done \
+  --message "reclaimed ${RECLAIMED} bytes, removed ${DELETED} deleted beads"
+
+bd close "$WORK_BEAD" --reason "DoltLite maintenance complete: reclaimed ${RECLAIMED} bytes, removed ${DELETED} deleted beads"
+exit
+```
+
+**Exit criteria:** Health report collected, flatten and gc applied, event
+emitted, work bead closed, dog returned to kennel."""

--- a/examples/beads-doltlite/orders/doltlite-health.toml
+++ b/examples/beads-doltlite/orders/doltlite-health.toml
@@ -1,0 +1,5 @@
+[order]
+description = "Check doltlite database health periodically"
+trigger = "cooldown"
+interval = "60s"
+exec = "gc doltlite health --json"

--- a/examples/beads-doltlite/orders/doltlite-maintenance.toml
+++ b/examples/beads-doltlite/orders/doltlite-maintenance.toml
@@ -1,0 +1,5 @@
+[order]
+description = "Run doltlite maintenance (flatten + gc) periodically"
+trigger = "cooldown"
+interval = "1h"
+exec = "gc doltlite flatten --json && gc doltlite gc --json"

--- a/examples/beads-doltlite/pack.toml
+++ b/examples/beads-doltlite/pack.toml
@@ -1,0 +1,26 @@
+# Beads DoltLite — embedded DoltLite beads provider pack.
+#
+# Provides the DoltLite backend (embedded Dolt) as an alternative to the
+# managed Dolt SQL server. Sets [beads].backend = "doltlite" so the city
+# uses embedded DoltLite databases instead of a managed Dolt server process.
+#
+# DoltLite stores each bead scope as a standalone embedded database under
+# .beads/embeddeddolt/ — no server process, no port management, no TCP
+# health probes. Suitable for local dev, single-host deployments, and
+# environments where running a separate database server is undesirable.
+#
+# This pack imports the bd pack (which supplies the gc-beads-bd.sh provider
+# script with doltlite backend support) and adds doltlite-specific
+# maintenance operations: flatten (compact the SQLite WAL), gc (remove
+# deleted beads), and health (schema integrity check).
+#
+# The doltlite backend in gc-beads-bd.sh uses sqlite3 CLI for schema
+# initialization and bd CLI for bead operations. Both must be in PATH.
+
+[pack]
+name = "beads-doltlite"
+schema = 2
+
+[imports.bd]
+source = "../bd"
+export = true

--- a/internal/beads/contract/preflight_checker.go
+++ b/internal/beads/contract/preflight_checker.go
@@ -47,7 +47,7 @@ func (c PreflightChecker) Check(scope string) (PreflightResult, error) {
 		c.checkBDContextAgreement(metadata, bdCtx, bdCtxErr),
 		c.checkDoltModeSafe(metadata, bdCtx, bdCtxErr),
 		c.checkIdentityMatch(scope, metadata),
-		c.checkVersionCompat(bdCtx, bdCtxErr),
+		c.checkVersionCompat(metadata, bdCtx, bdCtxErr),
 		c.checkContractShape(metadata),
 	}
 	verdict := preflightVerdictForChecks(checks)
@@ -122,6 +122,8 @@ func (c PreflightChecker) checkMetadataBackend(metadata preflightMetadata) Prefl
 	switch metadata.Backend {
 	case "dolt":
 		return NewPreflightCheckResult(PreflightCheckMetadataBackend, PreflightCheckPass, "Metadata backend is dolt", details)
+	case "doltlite":
+		return NewPreflightCheckResult(PreflightCheckMetadataBackend, PreflightCheckPass, "Metadata backend is doltlite", details)
 	case "postgres":
 		if hasDSN && !hasSplit {
 			return NewPreflightCheckResult(PreflightCheckMetadataBackend, PreflightCheckWarn, "Metadata backend is postgres (postgres_dsn form)", details)
@@ -187,6 +189,9 @@ func (c PreflightChecker) checkIdentityMatch(scope string, metadata preflightMet
 	if metadata.ProjectID == "" {
 		return NewPreflightCheckResult(PreflightCheckIdentityMatch, PreflightCheckFail, "metadata project_id is missing", details)
 	}
+	if metadata.Backend == "doltlite" {
+		return NewPreflightCheckResult(PreflightCheckIdentityMatch, PreflightCheckPass, "identity match not required for doltlite backend", details)
+	}
 	if c.DatabaseProjectID == nil {
 		return NewPreflightCheckResult(PreflightCheckIdentityMatch, PreflightCheckWarn, "database project_id reader is not configured", details)
 	}
@@ -201,7 +206,7 @@ func (c PreflightChecker) checkIdentityMatch(scope string, metadata preflightMet
 	return NewPreflightCheckResult(PreflightCheckIdentityMatch, PreflightCheckPass, "project_id matches", details)
 }
 
-func (c PreflightChecker) checkVersionCompat(ctx PreflightBDContext, err error) PreflightCheckResult {
+func (c PreflightChecker) checkVersionCompat(metadata preflightMetadata, ctx PreflightBDContext, err error) PreflightCheckResult {
 	libraryVersion := strings.TrimPrefix(strings.TrimSpace(c.BeadsLibraryVersion), "v")
 	if libraryVersion == "" {
 		libraryVersion = strings.TrimPrefix(beadsModuleVersion(), "v")
@@ -219,6 +224,12 @@ func (c PreflightChecker) checkVersionCompat(ctx PreflightBDContext, err error) 
 	}
 	if ctx.BDVersion == "" || libraryVersion == "" || libraryVersion == "(devel)" {
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckWarn, "bd/beads version compatibility could not be confirmed", details)
+	}
+	if metadata.Backend == "doltlite" {
+		if compareVersionStrings(strings.TrimPrefix(ctx.BDVersion, "v"), "1.0.3") >= 0 {
+			return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckPass, "bd and doltlite versions compatible", details)
+		}
+		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckFail, "bd version too old for doltlite (need >= 1.0.3)", details)
 	}
 	if strings.TrimPrefix(ctx.BDVersion, "v") != libraryVersion {
 		return NewPreflightCheckResult(PreflightCheckVersionCompat, PreflightCheckFail, "bd version differs from linked beads library version", details)
@@ -249,6 +260,11 @@ func (c PreflightChecker) checkContractShape(metadata preflightMetadata) Preflig
 			return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckFail, "dolt metadata contains postgres fields", details)
 		}
 		return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckPass, "Metadata uses dolt shape", details)
+	case "doltlite":
+		if hasDSN || hasSplit {
+			return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckFail, "doltlite metadata contains postgres fields", details)
+		}
+		return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckPass, "Metadata uses doltlite shape", details)
 	case "postgres":
 		if hasDSN {
 			return NewPreflightCheckResult(PreflightCheckContractShape, PreflightCheckWarn, "postgres_dsn present; Gas City expects split fields", details)
@@ -292,6 +308,27 @@ func beadsModuleVersion() string {
 		}
 	}
 	return ""
+}
+
+func compareVersionStrings(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := 0; i < len(aParts) || i < len(bParts); i++ {
+		var ai, bi int
+		if i < len(aParts) {
+			fmt.Sscanf(aParts[i], "%d", &ai)
+		}
+		if i < len(bParts) {
+			fmt.Sscanf(bParts[i], "%d", &bi)
+		}
+		if ai < bi {
+			return -1
+		}
+		if ai > bi {
+			return 1
+		}
+	}
+	return 0
 }
 
 type preflightMetadata struct {

--- a/internal/beads/factory.go
+++ b/internal/beads/factory.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -116,7 +117,7 @@ func OpenStoreAtForCity(ctx context.Context, opts StoreOpenOptions) (StoreOpenRe
 		return opts.openBdFallback(provider, diag)
 	}
 
-	if scopeHasExecutableBdHooks(opts.ScopeRoot) {
+	if !scopeBackendIsDoltlite(opts.ScopeRoot) && scopeHasExecutableBdHooks(opts.ScopeRoot) {
 		diag := BeadsDiagnostic{
 			Store:               storeNameBdStore,
 			NativeStoreEligible: false,
@@ -124,6 +125,16 @@ func OpenStoreAtForCity(ctx context.Context, opts StoreOpenOptions) (StoreOpenRe
 			PreflightReason:     "bd hooks are installed; remove .beads/hooks/on_create,on_update,on_close after confirming controller cache events cover this deployment",
 		}
 		logNativeUnavailable(opts.Logger, opts.ScopeRoot, diag.PreflightGate, diag.PreflightReason)
+		return opts.openBdFallback(provider, diag)
+	}
+
+	if scopeBackendIsDoltlite(opts.ScopeRoot) {
+		diag := BeadsDiagnostic{
+			Store:               storeNameBdStore,
+			NativeStoreEligible: false,
+			PreflightGate:       "doltlite_fallback",
+			PreflightReason:     "doltlite backend uses bd CLI shell-out",
+		}
 		return opts.openBdFallback(provider, diag)
 	}
 
@@ -207,6 +218,20 @@ func scopeHasExecutableBdHooks(scopeRoot string) bool {
 		}
 	}
 	return false
+}
+
+func scopeBackendIsDoltlite(scopeRoot string) bool {
+	data, err := os.ReadFile(filepath.Join(scopeRoot, ".beads", "metadata.json"))
+	if err != nil {
+		return false
+	}
+	var meta struct {
+		Backend string `json:"backend"`
+	}
+	if json.Unmarshal(data, &meta) != nil {
+		return false
+	}
+	return meta.Backend == "doltlite"
 }
 
 func forceNativeFallback() bool {

--- a/internal/builtinpacks/registry.go
+++ b/internal/builtinpacks/registry.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/examples/bd"
+	beadsdoltlite "github.com/gastownhall/gascity/examples/beads-doltlite"
 	"github.com/gastownhall/gascity/examples/dolt"
 	"github.com/gastownhall/gascity/examples/gastown/packs/gastown"
 	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
@@ -53,6 +54,7 @@ func All() []Pack {
 		{Name: "core", Subpath: "internal/bootstrap/packs/core", FS: core.PackFS},
 		{Name: "bd", Subpath: "examples/bd", FS: bd.PackFS},
 		{Name: "dolt", Subpath: "examples/dolt", FS: dolt.PackFS},
+		{Name: "beads-doltlite", Subpath: "examples/beads-doltlite", FS: beadsdoltlite.PackFS},
 		{Name: "maintenance", Subpath: "examples/gastown/packs/maintenance", FS: maintenance.PackFS},
 		{Name: "gastown", Subpath: "examples/gastown/packs/gastown", FS: gastown.PackFS},
 	}

--- a/internal/builtinpacks/registry_test.go
+++ b/internal/builtinpacks/registry_test.go
@@ -23,6 +23,7 @@ func TestAllAndSourceAreDeterministic(t *testing.T) {
 		"core=internal/bootstrap/packs/core",
 		"bd=examples/bd",
 		"dolt=examples/dolt",
+		"beads-doltlite=examples/beads-doltlite",
 		"maintenance=examples/gastown/packs/maintenance",
 		"gastown=examples/gastown/packs/gastown",
 	}


### PR DESCRIPTION
Adds embedded DoltLite bead store backend support to Gas City. DoltLite (dolthub/doltlite (https://github.com/dolthub/doltlite)) is a fork of SQLite that provides Git-style version control (branching, merging, cherry-pick, history) as SQL functions — all built into libdoltlite, a drop-in replacement for libsqlite3. No separate Dolt SQL server process is required.
This PR makes gc init --beads-backend doltlite a first-class path, wiring DoltLite through the entire city lifecycle: init, startup, bead operations, rig management, maintenance, and the native store preflight system.
Motivation
Full Dolt requires a managed SQL server process (dolt sql-server) per city — ports, health probes, lifecycle locks, TCP connections, credential management. For local development, single-host deployments, and environments where a separate database server is undesirable, DoltLite provides the same bead store API (bd CLI) backed by a SQLite file at .beads/doltlite/<database>.db.
Key benefits:
- No server process — embedded SQLite, no ports, no TCP health probes, no dolt sql-server lifecycle
- Same bead API — bd create, bd list, bd close, bd ready, gc convoy, bd gate all work identically
- Version control — branches, commits, merges, cherry-pick, diffs, history all available via dolt_* SQL functions
- DB file portability — a single .db file, portable across machines without Dolt server setup
Changes
1. gc init — Interactive + flag-based doltlite selection
cmd/gc/cmd_init.go — The init wizard now asks a new question after provider selection:
Choose your bead store backend:
  1. dolt      — managed Dolt SQL server (default)
  2. doltlite  — embedded DoltLite, no server process
Backend [1]:
Selecting 2 or doltlite sets [beads] backend = "doltlite" in the generated city.toml. Non-interactive init uses --beads-backend doltlite:
gc init --beads-backend doltlite ~/my-city
gc init --template gastown --beads-backend doltlite ~/my-city
The wizardConfig struct and cmdInitWithOptionsInternal are threaded through to pass the backend selection to doInit(), where cfg.Beads.Backend = "doltlite" is written into city.toml.
2. DoltLite beads pack
New examples/beads-doltlite/ builtin pack provides:
Resource	Purpose
pack.toml	Pack definition, imports bd pack (which imports dolt)
commands/flatten/	gc doltlite flatten — SQLite VACUUM + WAL checkpoint via bd flatten
commands/gc/	gc doltlite gc — Remove soft-deleted beads via bd gc --skip-decay
commands/health/	gc doltlite health — SQLite integrity check, disk usage, WAL stats
orders/doltlite-maintenance.toml	Hourly cooldown-triggered flatten && gc
orders/doltlite-health.toml	Periodic health check
formulas/mol-doltlite-maintenance.toml	Agent-guided health → flatten → gc sequence
doctor/check-sqlite3/	Verify sqlite3 CLI is available
assets/scripts/runtime.sh	Shared DoltLite helper functions
Registered as a builtin pack in internal/builtinpacks/registry.go.
3. Preflight check system — doltlite-aware gates
internal/beads/contract/preflight_checker.go — Five gates now accept doltlite:
Gate	Dolt behavior	DoltLite behavior
metadata_backend	Must be "dolt"	Accepts "doltlite"
contract_shape	Must use dolt shape	Accepts doltlite shape (no postgres fields)
version_compat	Exact match: bd version must equal linked steveyegge/beads library version	Range check: bd version >= 1.0.3
identity_match	metadata.json project_id must match _project_id in Dolt database	Bypassed (SQLite has no MySQL metadata table)
bd_context_agreement	bd context --json must agree with metadata	Same mechanism (now works via companion bd fix)
A new compareVersionStrings helper enables semver range comparison.
4. Native store bypass for doltlite
internal/beads/factory.go — Two changes prevent the native embedded-Dolt store from opening against a doltlite database:
- Hook gate bypass: scopeBackendIsDoltlite() reads .beads/metadata.json to check the backend. If doltlite, the bd-hook-installed gate is skipped (hooks are always installed by the controller).
- Explicit doltlite fallback: Before attempting openNativeStore() (which would try embeddeddolt.New()), doltlite scopes immediately fall back to the BD shell-out path with diagnostic gate doltlite_fallback. This prevents the native store from trying to open a Dolt-style embeddeddolt directory against a SQLite doltlite database.
5. Managed Dolt lifecycle bypass
cmd/gc/beads_provider_lifecycle.go — Three guard points:
- Scope metadata init: enforceCanonicalDoltliteScopeMetadataForInit() / ensureCanonicalDoltliteScopeMetadataForInit() write doltlite-canonical metadata (backend: "doltlite", dolt_mode: "embedded") instead of the Dolt-server form.
- Managed Dolt port wait skip: initAndHookDir() skips the managed-Dolt-port readiness wait for doltlite scopes (!cityUsesDoltliteBeadsBackend(cityPath)). Without this, startup blocks waiting for a Dolt server that doesn't exist.
6. Provider script — --backend doltlite flag
examples/bd/assets/scripts/gc-beads-bd.sh — run_bd_doltlite_init() now passes --backend doltlite to bd init, ensuring the bead store initializes as doltlite rather than full Dolt. Both fresh init and reinit paths updated.
7. Dependency readiness — version floor for doltlite
cmd/gc/init_provider_readiness.go — gc start validates binary versions before handing off:
- bd minimum version: 1.0.3 for doltlite, 1.0.4 for full Dolt
- dolt dependency: Skipped entirely for doltlite cities (no Dolt SQL server needed)
- dolt identity probe: Returns false for doltlite (no dolt config to probe)
- managed-dolt-needs-bd fix: dolt dep condition gates on needsDolt (false for doltlite) instead of needsBd (always true with BD provider)
8. beads-doltlite bd context fix (separate repo, companion PR)
beads-doltlite/cmd/bd/context_cmd.go — bd context --json now reads backend from metadata.json instead of hardcoding "dolt". Fixes the bd_context_agreement preflight gate.
Testing
Verified on a live city with three doltlite-backed scopes (HQ, beads-doltlite rig, gascity rig):
- City lifecycle: gc init --beads-backend doltlite → gc start → gc stop — zero preflight warnings
- Bead CRUD: bd create, bd list, bd show, bd update --claim, bd close — all functional
- Version control: bd branch, bd flatten (86→1 commits), bd gc (compact + dolt_gc), bd diff
- Gates: bd gate create --type timer (auto-resolved), bd gate create --type human (manual resolve)
- Convoys: gc convoy create, gc convoy check auto-closes when all beads closed
- Cross-rig: cross-rig:<rig>:<id> dependencies, prefix-based routing via routes.jsonl
- Maintenance: gc doltlite flatten && gc doltlite gc — 18MB → 7.5MB (58% reduction)
- Controller trace: Session reconciliation across all 3 rigs, orders dispatching, demand snapshots — zero errors
Backward compatibility
Fully backward-compatible. All changes are gated behind [beads] backend = "doltlite" in city.toml. Cities without this config use the existing managed-Dolt path unchanged. The builtin pack does not auto-activate.