### PR TITLE
feat(coordstore): score heap inuse delta (ga-si3tq.1)

### DIFF
--- a/internal/benchmarks/coordstore/runner.go
+++ b/internal/benchmarks/coordstore/runner.go
@@ -676,7 +676,15 @@ func (m *memSampler) stop() MemReport {
 	if ms.TotalAlloc >= m.startTotalAlloc {
 		m.report.AllocDelta = ms.TotalAlloc - m.startTotalAlloc
 	}
+	m.report.HeapInuseDelta = heapInuseDelta(m.report.HeapInuseBaseline, m.report.HeapInusePeak)
 	return m.report
+}
+
+func heapInuseDelta(baseline, peak uint64) uint64 {
+	if peak >= baseline {
+		return peak - baseline
+	}
+	return 0
 }
 
 // readRSSBytes reads the resident set size from /proc/self/status (VmRSS).

--- a/internal/benchmarks/coordstore/runner_test.go
+++ b/internal/benchmarks/coordstore/runner_test.go
@@ -152,3 +152,40 @@ func (a *purgeTrackingAdapter) RecentScan(context.Context, int) ([]Record, error
 	return nil, nil
 }
 func (a *purgeTrackingAdapter) Stats(context.Context) map[string]int64 { return nil }
+import "testing"
+
+func TestHeapInuseDelta(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseline uint64
+		peak     uint64
+		want     uint64
+	}{
+		{
+			name:     "peak above baseline",
+			baseline: 10,
+			peak:     42,
+			want:     32,
+		},
+		{
+			name:     "peak equal baseline",
+			baseline: 42,
+			peak:     42,
+			want:     0,
+		},
+		{
+			name:     "baseline above peak",
+			baseline: 42,
+			peak:     10,
+			want:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := heapInuseDelta(tt.baseline, tt.peak); got != tt.want {
+				t.Fatalf("heapInuseDelta(%d, %d) = %d, want %d", tt.baseline, tt.peak, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/benchmarks/coordstore/runner_test.go
+++ b/internal/benchmarks/coordstore/runner_test.go
@@ -152,7 +152,6 @@ func (a *purgeTrackingAdapter) RecentScan(context.Context, int) ([]Record, error
 	return nil, nil
 }
 func (a *purgeTrackingAdapter) Stats(context.Context) map[string]int64 { return nil }
-import "testing"
 
 func TestHeapInuseDelta(t *testing.T) {
 	tests := []struct {

--- a/internal/benchmarks/coordstore/scorecard.go
+++ b/internal/benchmarks/coordstore/scorecard.go
@@ -83,6 +83,9 @@ var DiscoveryTargets = []Target{
 // discovery.md §Targets (RAM ≤ 256MB HeapInuse peak).
 const HeapInusePeakTarget = 256 * 1024 * 1024
 
+// HeapInuseDeltaTarget is the maximum workload-induced heap growth allowed.
+const HeapInuseDeltaTarget = 256 * 1024 * 1024
+
 // MemReport captures memory consumption observed during a workload run.
 // Baseline is measured after seeding and before workload execution; peak is
 // sampled during the run; steady is measured after the workload stops.
@@ -95,6 +98,8 @@ type MemReport struct {
 	HeapInusePeak uint64
 	// HeapInuseSteady is runtime.MemStats.HeapInuse after the workload.
 	HeapInuseSteady uint64
+	// HeapInuseDelta is workload-induced heap growth: peak minus baseline.
+	HeapInuseDelta uint64
 	// RSSBaseline is the process resident set size before the workload, in
 	// bytes. Zero if unavailable.
 	RSSBaseline uint64
@@ -139,7 +144,7 @@ type Scorecard struct {
 	Errors int
 	// Mem holds memory consumption observed during the run.
 	Mem MemReport
-	// MemPass reports whether the HeapInusePeak target was met. Only
+	// MemPass reports whether the HeapInuseDelta target was met. Only
 	// meaningful when Mem.Sampled is true.
 	MemPass bool
 }
@@ -203,7 +208,7 @@ func Score(backend, workload string, dur time.Duration, totalOps, totalErrors in
 		TotalOps: totalOps,
 		Errors:   totalErrors,
 		Mem:      mem,
-		MemPass:  !mem.Sampled || mem.HeapInusePeak <= HeapInusePeakTarget,
+		MemPass:  !mem.Sampled || mem.HeapInuseDelta <= HeapInuseDeltaTarget,
 	}
 
 	for _, t := range DiscoveryTargets {
@@ -283,20 +288,32 @@ func (s *Scorecard) PrintTable(w io.Writer) {
 	}
 
 	if s.Mem.Sampled {
-		fmt.Fprintf(w, "\n  Memory:\n") //nolint:errcheck
-		memResult := "PASS"
+		fmt.Fprintf(w, "\n  Memory:\n")                     //nolint:errcheck
+		fmt.Fprintf(w, "  %-*s  %-12s  %-12s  %-12s  %s\n", //nolint:errcheck
+			colW, "Metric", "Baseline", "Peak/Delta", "Steady", "Result")
+
+		deltaResult := "PASS"
 		if !s.MemPass {
-			memResult = fmt.Sprintf("FAIL  ← HeapInuse peak %s > target %s",
-				FormatBytes(s.Mem.HeapInusePeak), FormatBytes(HeapInusePeakTarget))
+			deltaResult = fmt.Sprintf("FAIL  ← delta %s > target %s",
+				FormatBytes(s.Mem.HeapInuseDelta), FormatBytes(HeapInuseDeltaTarget))
 		}
 		fmt.Fprintf(w, "  %-*s  %-12s  %-12s  %-12s  %s\n", //nolint:errcheck
-			colW, "Metric", "Baseline", "Peak", "Steady", "Result")
+			colW, fmt.Sprintf("HeapInuse delta (≤%s)", FormatBytes(HeapInuseDeltaTarget)),
+			FormatBytes(s.Mem.HeapInuseBaseline),
+			FormatBytes(s.Mem.HeapInuseDelta),
+			"-",
+			deltaResult)
+
+		peakNote := fmt.Sprintf("%s peak", FormatBytes(s.Mem.HeapInusePeak))
+		if s.Mem.HeapInusePeak > HeapInusePeakTarget {
+			peakNote += "  ← exceeds " + FormatBytes(HeapInusePeakTarget)
+		}
 		fmt.Fprintf(w, "  %-*s  %-12s  %-12s  %-12s  %s\n", //nolint:errcheck
-			colW, "HeapInuse (≤256MB peak)",
+			colW, "HeapInuse peak (informational)",
 			FormatBytes(s.Mem.HeapInuseBaseline),
 			FormatBytes(s.Mem.HeapInusePeak),
 			FormatBytes(s.Mem.HeapInuseSteady),
-			memResult)
+			peakNote)
 		rssBaseline := "-"
 		if s.Mem.RSSPeak > 0 {
 			rssBaseline = FormatBytes(s.Mem.RSSBaseline)

--- a/internal/benchmarks/coordstore/scorecard_test.go
+++ b/internal/benchmarks/coordstore/scorecard_test.go
@@ -1,0 +1,82 @@
+package coordstore
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScoreMemoryPassUsesHeapInuseDelta(t *testing.T) {
+	mem := MemReport{
+		HeapInuseBaseline: 300 * 1024 * 1024,
+		HeapInusePeak:     600 * 1024 * 1024,
+		HeapInuseSteady:   320 * 1024 * 1024,
+		HeapInuseDelta:    200 * 1024 * 1024,
+		Sampled:           true,
+	}
+
+	sc := Score("backend", "workload", time.Second, 1, 0, nil, nil, mem)
+
+	if !sc.MemPass {
+		t.Fatalf("MemPass = false, want true for delta below target")
+	}
+	if !sc.Passed() {
+		t.Fatalf("Passed = false, want true for delta below target")
+	}
+
+	var out strings.Builder
+	sc.PrintTable(&out)
+	got := out.String()
+	for _, want := range []string{
+		"HeapInuse delta",
+		"HeapInuse peak (informational)",
+		"600.0MiB peak  \u2190 exceeds 256.0MiB",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("PrintTable output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestScoreMemoryFailsWhenHeapInuseDeltaExceedsTarget(t *testing.T) {
+	mem := MemReport{
+		HeapInuseBaseline: 10 * 1024 * 1024,
+		HeapInusePeak:     300 * 1024 * 1024,
+		HeapInuseSteady:   280 * 1024 * 1024,
+		HeapInuseDelta:    320 * 1024 * 1024,
+		Sampled:           true,
+	}
+
+	sc := Score("backend", "workload", time.Second, 1, 0, nil, nil, mem)
+
+	if sc.MemPass {
+		t.Fatalf("MemPass = true, want false for delta above target")
+	}
+	if sc.Passed() {
+		t.Fatalf("Passed = true, want false for delta above target")
+	}
+
+	var out strings.Builder
+	sc.PrintTable(&out)
+	got := out.String()
+	if !strings.Contains(got, "FAIL") || !strings.Contains(got, "delta 320.0MiB > target 256.0MiB") {
+		t.Fatalf("PrintTable output missing delta failure:\n%s", got)
+	}
+}
+
+func TestScoreMemoryUnsampledDoesNotAddMemoryTarget(t *testing.T) {
+	sc := Score("backend", "workload", time.Second, 1, 0, nil, nil, MemReport{})
+
+	if !sc.MemPass {
+		t.Fatalf("MemPass = false, want true when memory is unsampled")
+	}
+	if sc.TotalTargets() != 0 {
+		t.Fatalf("TotalTargets = %d, want 0 for no measured operation or memory targets", sc.TotalTargets())
+	}
+
+	var out strings.Builder
+	sc.PrintTable(&out)
+	if strings.Contains(out.String(), "Memory:") {
+		t.Fatalf("PrintTable output includes memory section for unsampled memory:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `HeapInuseDelta` field to `MemReport`, computed as `peak − baseline` (clamped to zero when baseline exceeds peak)
- `Score()` gates `MemPass` on `HeapInuseDelta <= HeapInuseDeltaTarget` (256 MB) instead of absolute peak
- `PrintTable()` shows delta as the primary memory gate and peak as an informational row
- Adds `runner_test.go` with delta edge-case tests and expands `scorecard_test.go`

**Bead:** ga-si3tq.1  
**Source design:** ga-si3tq  

## Test plan
- [x] `go test ./internal/benchmarks/coordstore/ -count=1` — PASS
- [x] `go vet ./internal/benchmarks/coordstore/` — clean
- [x] Merges cleanly with origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)