### PR TITLE
feat(coordstore): add heap_inuse_delta_bytes and live_object_count to JSONL telemetry (ga-si3tq.3)

### DIFF
--- a/internal/benchmarks/coordstore/recorder.go
+++ b/internal/benchmarks/coordstore/recorder.go
@@ -25,14 +25,16 @@ type OpSnapshot struct {
 
 // TelemetrySample is one JSONL row emitted by TimeSeriesRecorder.
 type TelemetrySample struct {
-	Timestamp      time.Time             `json:"timestamp"`
-	HeapAllocBytes uint64                `json:"heap_alloc_bytes"`
-	HeapInuseBytes uint64                `json:"heap_inuse_bytes"`
-	RSSBytes       uint64                `json:"rss_bytes,omitempty"`
-	Goroutines     int                   `json:"goroutines"`
-	StoreSizeBytes int64                 `json:"store_size_bytes"`
-	AdapterStats   map[string]int64      `json:"adapter_stats,omitempty"`
-	Operations     map[string]OpSnapshot `json:"operations,omitempty"`
+	Timestamp           time.Time             `json:"timestamp"`
+	HeapAllocBytes      uint64                `json:"heap_alloc_bytes"`
+	HeapInuseBytes      uint64                `json:"heap_inuse_bytes"`
+	HeapInuseDeltaBytes uint64                `json:"heap_inuse_delta_bytes"`
+	RSSBytes            uint64                `json:"rss_bytes,omitempty"`
+	Goroutines          int                   `json:"goroutines"`
+	StoreSizeBytes      int64                 `json:"store_size_bytes"`
+	LiveObjectCount     int64                 `json:"live_object_count,omitempty"`
+	AdapterStats        map[string]int64      `json:"adapter_stats,omitempty"`
+	Operations          map[string]OpSnapshot `json:"operations,omitempty"`
 }
 
 // TimeSeriesRecorderConfig configures a telemetry JSONL recorder.
@@ -49,10 +51,11 @@ type TimeSeriesRecorderConfig struct {
 type TimeSeriesRecorder struct {
 	cfg TimeSeriesRecorderConfig
 
-	mu     sync.Mutex
-	file   *os.File
-	stopCh chan struct{}
-	doneCh chan struct{}
+	mu                sync.Mutex
+	file              *os.File
+	stopCh            chan struct{}
+	doneCh            chan struct{}
+	heapInuseBaseline uint64 // HeapInuse at Start(); used to compute HeapInuseDeltaBytes
 }
 
 // NewTimeSeriesRecorder returns a recorder for cfg.
@@ -63,14 +66,18 @@ func NewTimeSeriesRecorder(cfg TimeSeriesRecorderConfig) *TimeSeriesRecorder {
 	return &TimeSeriesRecorder{cfg: cfg}
 }
 
-// Start opens the JSONL file, writes an immediate sample, and starts periodic
-// sampling until Stop is called or ctx is canceled.
+// Start opens the JSONL file, records the HeapInuse baseline, writes an
+// immediate sample, and starts periodic sampling until Stop is called or ctx
+// is canceled.
 func (r *TimeSeriesRecorder) Start(ctx context.Context) error {
 	r.mu.Lock()
 	if r.file != nil {
 		r.mu.Unlock()
 		return nil
 	}
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	r.heapInuseBaseline = ms.HeapInuse
 	file, err := openRecorderFile(r.cfg.Path)
 	if err != nil {
 		r.mu.Unlock()
@@ -184,18 +191,27 @@ func (r *TimeSeriesRecorder) sample(ctx context.Context) (TelemetrySample, error
 	if err != nil {
 		return TelemetrySample{}, err
 	}
+	delta := uint64(0)
+	if ms.HeapInuse > r.heapInuseBaseline {
+		delta = ms.HeapInuse - r.heapInuseBaseline
+	}
 	sample := TelemetrySample{
-		Timestamp:      time.Now().UTC(),
-		HeapAllocBytes: ms.HeapAlloc,
-		HeapInuseBytes: ms.HeapInuse,
-		Goroutines:     runtime.NumGoroutine(),
-		StoreSizeBytes: size,
+		Timestamp:           time.Now().UTC(),
+		HeapAllocBytes:      ms.HeapAlloc,
+		HeapInuseBytes:      ms.HeapInuse,
+		HeapInuseDeltaBytes: delta,
+		Goroutines:          runtime.NumGoroutine(),
+		StoreSizeBytes:      size,
 	}
 	if rss, ok := readRSSBytes(); ok {
 		sample.RSSBytes = rss
 	}
 	if r.cfg.Adapter != nil {
-		sample.AdapterStats = copyStats(r.cfg.Adapter.Stats(ctx))
+		adapterStats := r.cfg.Adapter.Stats(ctx)
+		sample.AdapterStats = copyStats(adapterStats)
+		if v, ok := adapterStats["live_objects"]; ok {
+			sample.LiveObjectCount = v
+		}
 	}
 	if r.cfg.HistogramSnapshot != nil {
 		sample.Operations = snapshotOperations(r.cfg.HistogramSnapshot())

--- a/internal/benchmarks/coordstore/recorder_test.go
+++ b/internal/benchmarks/coordstore/recorder_test.go
@@ -1,6 +1,7 @@
 package coordstore
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -80,4 +81,96 @@ type statsOnlyAdapter struct {
 
 func (a statsOnlyAdapter) Stats(context.Context) map[string]int64 {
 	return a.stats
+}
+
+func TestRecorderSampleIncludesHeapInuseDeltaBytes(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ts.jsonl")
+
+	recorder := NewTimeSeriesRecorder(TimeSeriesRecorderConfig{
+		Path: path,
+	})
+	if err := recorder.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Force a second sample so delta has a chance to appear in the record.
+	if err := recorder.RecordOnce(ctx); err != nil {
+		t.Fatalf("RecordOnce: %v", err)
+	}
+	if err := recorder.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if _, ok := raw["heap_inuse_delta_bytes"]; !ok {
+			t.Fatalf("heap_inuse_delta_bytes absent from JSONL sample: %s", line)
+		}
+	}
+}
+
+func TestRecorderSampleLiveObjectCountPresentWhenAdapterReports(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ts.jsonl")
+
+	recorder := NewTimeSeriesRecorder(TimeSeriesRecorderConfig{
+		Path:    path,
+		Adapter: statsOnlyAdapter{stats: map[string]int64{"live_objects": 42, "other": 9}},
+	})
+	if err := recorder.RecordOnce(ctx); err != nil {
+		t.Fatalf("RecordOnce: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	var sample TelemetrySample
+	if err := json.Unmarshal(bytes.TrimSpace(data), &sample); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if sample.LiveObjectCount != 42 {
+		t.Errorf("LiveObjectCount = %d, want 42", sample.LiveObjectCount)
+	}
+	if sample.AdapterStats["other"] != 9 {
+		t.Errorf("AdapterStats[other] = %d, want 9", sample.AdapterStats["other"])
+	}
+}
+
+func TestRecorderSampleLiveObjectCountAbsentWhenAdapterDoesNotReport(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ts.jsonl")
+
+	recorder := NewTimeSeriesRecorder(TimeSeriesRecorderConfig{
+		Path:    path,
+		Adapter: statsOnlyAdapter{stats: map[string]int64{"backend_records": 3}},
+	})
+	if err := recorder.RecordOnce(ctx); err != nil {
+		t.Fatalf("RecordOnce: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(data), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := raw["live_object_count"]; ok {
+		t.Errorf("live_object_count present in JSONL when adapter does not report it")
+	}
 }


### PR DESCRIPTION
## Summary

- `TelemetrySample` gains two new JSONL fields:
  - `heap_inuse_delta_bytes` — HeapInuse growth since `Start()` (always present, zero on first sample)
  - `live_object_count` — lifted from `AdapterStats["live_objects"]` when the adapter reports it; omitted otherwise
- `TimeSeriesRecorder` captures `heapInuseBaseline` at `Start()` and computes the delta per sample
- 3 new tests covering field presence/absence in JSONL output

**Bead:** ga-si3tq.3  
**Source design:** ga-si3tq  

Context: depends on ga-si3tq.2 (PR #2992) for HQStore to populate `live_objects` in `Stats()`. This recorder change is independent and merges cleanly with main on its own.

## Test plan
- [x] `go test ./internal/benchmarks/coordstore/ -run TestRecorder -count=1` — PASS (3 new tests)
- [x] `go test ./internal/benchmarks/coordstore/... -count=1` — PASS
- [x] `go vet ./internal/benchmarks/coordstore/` — clean
- [x] `make test-fast-parallel` — PASS (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)