### PR TITLE
fix(test): avoid testscript temp root leaks on re-exec

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -169,15 +169,31 @@ func configureFSPressureForTests() {
 }
 
 func TestMain(m *testing.M) {
-	if !isTestscriptCommandInvocation(os.Args[0]) {
-		clearProcessLiveEnvForTests()
+	// testscript re-executes the test binary as "gc" or "bd" for each txtar
+	// command. On that path we must not create a new temp root — the parent
+	// already owns the fixtures. Just configure hooks and forward.
+	if isTestscriptCommandInvocation(os.Args[0]) {
+		configureFSPressureForTests()
+		configureSupervisorHooksForTests()
+		testscript.Main(m, map[string]func(){
+			"gc": func() {
+				configureTestscriptEnvDefaults()
+				os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+			},
+			"bd": bdTestCmd,
+		})
+		return
 	}
+
+	clearProcessLiveEnvForTests()
 	if err := os.Setenv(managedDoltTestModeEnv, "1"); err != nil {
 		panic(err)
 	}
 	if err := os.Setenv(managedDoltTestParentPIDEnv, fmt.Sprintf("%d", os.Getpid())); err != nil {
 		panic(err)
 	}
+	// Sweep stale testTempRoot dirs in system /tmp before creating a new one.
+	sweepOrphanPIDPrefixedDirs(os.TempDir(), testCmdGCTempRootPrefix)
 	testTempRoot, err := os.MkdirTemp("/tmp", pidPrefixedTempPattern(testCmdGCTempRootPrefix))
 	if err != nil {
 		panic(err)

--- a/cmd/gc/test_orphan_sweep_branches_test.go
+++ b/cmd/gc/test_orphan_sweep_branches_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -236,5 +237,75 @@ func TestSweepOrphanAllPrefixesStabilize(t *testing.T) {
 		if _, err := os.Stat(selfDir); os.IsNotExist(err) {
 			t.Errorf("prefix %q: current-PID dir removed on second sweep", pfx)
 		}
+	}
+}
+
+// TestTestscriptCommandInvocationDoesNotLeakTempRoot verifies that re-executing
+// the test binary as "gc" or "bd" (the testscript path) does not create a
+// new /tmp/gct<PID>-* directory — the leak root cause (ga-lh1k9).
+func TestTestscriptCommandInvocationDoesNotLeakTempRoot(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Executable: %v", err)
+	}
+	dir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		wantErr bool
+	}{
+		{name: "gc", command: "gc", args: []string{"version"}},
+		{name: "bd", command: "bd", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commandPath := filepath.Join(dir, tt.command)
+			if err := os.Symlink(self, commandPath); err != nil {
+				t.Fatalf("Symlink: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Remove(commandPath) })
+
+			cmd := exec.Command(commandPath, tt.args...)
+			cmd.Env = append(os.Environ(), "GC_DOLT=skip")
+			err := cmd.Run()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("%s unexpectedly succeeded", tt.command)
+				}
+			} else if err != nil {
+				t.Fatalf("%s %v: %v", tt.command, tt.args, err)
+			}
+
+			pid := cmd.ProcessState.Pid()
+			matches, err := filepath.Glob(filepath.Join("/tmp", fmt.Sprintf("%s%d-*", testCmdGCTempRootPrefix, pid)))
+			if err != nil {
+				t.Fatalf("Glob: %v", err)
+			}
+			for _, match := range matches {
+				t.Cleanup(func() { _ = os.RemoveAll(match) })
+			}
+			if len(matches) > 0 {
+				t.Fatalf("leaked temp root(s) for pid %d: %v", pid, matches)
+			}
+		})
+	}
+}
+
+func TestSweepOrphanRemovesStaleCmdGCTempRootInSystemTmp(t *testing.T) {
+	pid := nonLivePID(t)
+	root := filepath.Join("/tmp", fmt.Sprintf("%s%d-stale-backstop", testCmdGCTempRootPrefix, pid))
+	_ = os.RemoveAll(root)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+
+	sweepOrphanPIDPrefixedDirs("/tmp", testCmdGCTempRootPrefix)
+
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("stale cmd/gc temp root still exists after sweep: %v", err)
 	}
 }

--- a/release-gates/ga-utet5c-testscript-temp-root-leak-gate.md
+++ b/release-gates/ga-utet5c-testscript-temp-root-leak-gate.md
@@ -1,0 +1,38 @@
+# Release Gate: testscript temp root leak fix
+
+- Deploy bead: ga-utet5c
+- Source bug: ga-lh1k9
+- Review bead: ga-wdz76d
+- PR: https://github.com/gastownhall/gascity/pull/2996
+- Feature branch: builder/ga-lh1k9-testscript-temp-leak
+- Source commit: 6161bb8ec3c2698351fb59a06d7fa2ccd72f7301
+- Base checked: origin/main at 5a9a2e26061495ab2d133e62b755d2409f82c744
+
+## Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-wdz76d` is closed with reason `pass`; notes contain `VERDICT: PASS` for commit `6161bb8ec3c2698351fb59a06d7fa2ccd72f7301`. |
+| 2 | Acceptance criteria met | PASS | Source bug `ga-lh1k9` identified leaked `/tmp/gct<PID>-*` roots from testscript re-exec paths. The commit moves `testscript.Main` behind an early return before temp-root setup, adds stale-root sweep coverage, and adds `TestTestscriptCommandInvocationDoesNotLeakTempRoot` to assert re-exec invocations do not leave `/tmp/gct<PID>-*` roots. |
+| 3 | Tests pass | PASS | `make test-fast-parallel` passed: fsys darwin compile, unit-core, and all six `cmd/gc` unit shards. `go vet ./...` passed. PR #2996 GitHub checks are green for required CI, CodeQL, integration shards, dashboard, and worker phase 2. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for `ga-wdz76d` report `BLOCKERS: None`; no unresolved high-severity findings were listed. |
+| 5 | Final branch is clean | PASS | Clean deploy worktree was created from `origin/builder/ga-lh1k9-testscript-temp-leak`; `git status --short --branch` was clean before writing this gate. Final cleanliness was rechecked after committing the gate file. |
+| 6 | Branch diverges cleanly from main | PASS | PR #2996 reports `mergeStateStatus: CLEAN`; `git merge-tree --write-tree --quiet origin/main HEAD` exited 0 before the gate commit. |
+| 7 | Single feature theme | PASS | One source commit touches only `cmd/gc/main_test.go` and `cmd/gc/test_orphan_sweep_branches_test.go`; both changes address the same testscript temp-root leak in test infrastructure. |
+
+## Commands Run
+
+```text
+gh pr view 2996 --json number,title,state,isDraft,url,baseRefName,headRefName,headRepositoryOwner,headRepository,mergeStateStatus,statusCheckRollup,commits,files,body
+bd show ga-wdz76d
+bd show ga-lh1k9
+git diff --stat origin/main...HEAD
+git log --oneline --decorate origin/main..HEAD
+git merge-tree --write-tree --quiet origin/main HEAD
+make test-fast-parallel
+go vet ./...
+```
+
+## Notes
+
+`docs/PROJECT_MANIFEST.md` is not present in this repository checkout; this gate applies the deployer release criteria supplied in the agent instructions.


### PR DESCRIPTION
## What this changes

Testscript re-executes the test binary as `gc` or `bd` for txtar commands. The test harness now detects those re-exec invocations before creating the per-process Gas City temp root and hands directly to `testscript.Main`, which stops each testscript command from leaving `/tmp/gct<PID>-*` trees behind on tmpfs-backed `/tmp`.

Test startup also sweeps stale `gct<PID>-*` directories for processes that are no longer live. That keeps old crash artifacts from accumulating while leaving active test roots alone.

## Review notes

- Test infrastructure only; production `gc` runtime behavior is unchanged.
- The main review surface is `cmd/gc/TestMain` ordering: the early return happens before temp-root setup because `testscript.Main` exits the re-exec path directly.
- The stale-root sweep is intentionally scoped to the `gct` prefix and skips live PIDs, including the current process.

## Test plan

- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Commit hook: `go test ./test/docsync`
- [x] Release gate: [`release-gates/ga-utet5c-testscript-temp-root-leak-gate.md`](release-gates/ga-utet5c-testscript-temp-root-leak-gate.md)