### PR TITLE
Fix required artifact symlink containment

### DIFF
--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 func processRetryEval(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, error) {
@@ -386,11 +387,7 @@ func requiredArtifactPathInWorktree(worktree, path string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("resolving required artifact path %q: %w", path, err)
 	}
-	rel, err := filepath.Rel(absWorktree, absPath)
-	if err != nil {
-		return false, fmt.Errorf("checking required artifact path containment for %q: %w", path, err)
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)), nil
+	return pathutil.PathWithin(absWorktree, absPath), nil
 }
 
 func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, string, error) {

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -388,6 +388,36 @@ func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactOutsideWorktreeBef
 	}
 }
 
+func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactSymlinkOutsideWorktree(t *testing.T) {
+	t.Parallel()
+
+	worktree := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "outside.md")
+	if err := os.WriteFile(outsidePath, []byte("review\n"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+	linkPath := filepath.Join(worktree, "review.md")
+	if err := os.Symlink(outsidePath, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	got, err := classifyRetryAttemptWithPostconditions(beads.NewMemStore(), beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.required_artifact": linkPath,
+			"work_dir":             worktree,
+		},
+	}, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want nil", err)
+	}
+	want := retryEvalResult{Outcome: "transient", Reason: "required_artifact_outside_worktree"}
+	if got != want {
+		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v", got, want)
+	}
+}
+
 func TestClassifyRetryAttemptWithPostconditionsUsesRequiredArtifactStatOption(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Follow-up remediation for post-merge review of #2924.\n\nThis change rejects required-artifact paths that are lexically inside the worktree but resolve through a symlink to a file outside the worktree. It reuses the shared path containment utility and adds a regression test with an in-worktree symlink to a nonempty outside file.\n\nVerification:\n- go test ./internal/dispatch -run TestClassifyRetryAttemptWithPostconditionsRejectsArtifactSymlinkOutsideWorktree -count=1 (failed before the fix, passes after)\n- go test ./internal/dispatch -count=1\n- go vet ./internal/dispatch\n- make test-fast-parallel\n- go vet ./...\n- pre-commit hook reran go vet ./... and make test-fast-parallel