### PR TITLE
fix(coordstore): abort soak runs on RSS leak signals

### DIFF
--- a/internal/benchmarks/coordstore/runner.go
+++ b/internal/benchmarks/coordstore/runner.go
@@ -21,6 +21,10 @@ type Runner struct {
 	seed    SeedResult
 	rng     *rand.Rand
 
+	// rssReader overrides the default readRSSBytes function for testing.
+	// When nil, readRSSBytes is used.
+	rssReader func() (uint64, bool)
+
 	seedMu    sync.RWMutex
 	resultsMu sync.Mutex
 	results   map[string]*OperationResult // op name → result
@@ -71,9 +75,18 @@ func (r *Runner) Run(ctx context.Context, w io.Writer) (Scorecard, error) {
 	// Start the memory sampler before the workload so its peak captures the
 	// full run, including the hot working set under load.
 	mem := newMemSampler(200 * time.Millisecond)
+	mem.readRSS = r.rssReader
+	if wl.MaxRSSBytes > 0 || wl.MaxRSSGrowthBytesPerSec > 0 {
+		mem.maxRSSBytes = wl.MaxRSSBytes
+		mem.maxRSSGrowthBytesPerSec = wl.MaxRSSGrowthBytesPerSec
+		mem.abortCh = make(chan string, 1)
+	}
 	mem.start()
 
-	var wg sync.WaitGroup
+	var (
+		leakFinding string
+		wg          sync.WaitGroup
+	)
 	for range wl.Concurrency {
 		seedA := r.rng.Uint64()
 		seedB := r.rng.Uint64()
@@ -107,7 +120,7 @@ func (r *Runner) Run(ctx context.Context, w io.Writer) (Scorecard, error) {
 		}(seedA, seedB)
 	}
 
-	// Progress ticker.
+	// Progress ticker; also drains the memory guard abort channel.
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	start := time.Now()
@@ -115,6 +128,11 @@ progressLoop:
 	for {
 		select {
 		case <-ctx.Done():
+			break progressLoop
+		case finding := <-mem.abortCh:
+			leakFinding = finding
+			fmt.Fprintf(w, "  [LEAK DETECTED] %s — aborting run\n", finding) //nolint:errcheck
+			cancel()
 			break progressLoop
 		case t := <-ticker.C:
 			fmt.Fprintf(w, "  [%s elapsed] ops=%d errors=%d\n", //nolint:errcheck
@@ -149,6 +167,10 @@ progressLoop:
 		int(totalOps.Load()), int(totalErrors.Load()),
 		r.results, throughput, memReport,
 	)
+	if leakFinding != "" {
+		sc.LeakAborted = true
+		sc.LeakFinding = leakFinding
+	}
 
 	fmt.Fprintf(w, "  workload %q done: %d ops in %s, %d errors\n", //nolint:errcheck
 		wl.Name, totalOps.Load(), FormatDuration(dur), totalErrors.Load())
@@ -587,12 +609,32 @@ func opName(op opTag) string {
 	return "unknown"
 }
 
+// memGuardWarmUp is the period after a run starts before the growth-rate
+// watchdog begins checking. This absorbs the initial allocation surge that
+// happens when the store opens and the first batch of ops runs.
+const memGuardWarmUp = 30 * time.Second
+
 // memSampler periodically samples process memory during a workload run and
 // tracks baseline, peak, and steady HeapInuse/RSS plus total bytes allocated.
+// When MaxRSSBytes or MaxRSSGrowthBytesPerSec are set, a breach sends a
+// finding string on abortCh (buffered, capacity 1).
 type memSampler struct {
 	interval time.Duration
 	stopCh   chan struct{}
 	doneCh   chan struct{}
+
+	// readRSS is the RSS reader function. Defaults to readRSSBytes when nil.
+	readRSS func() (uint64, bool)
+
+	// memory guard settings
+	maxRSSBytes             uint64
+	maxRSSGrowthBytesPerSec uint64
+	abortCh                 chan string // non-nil when any guard is active
+
+	// timing state for growth-rate guard
+	startedAt time.Time
+	warmUpAt  time.Time
+	warmUpRSS uint64
 
 	startTotalAlloc uint64
 	report          MemReport
@@ -609,16 +651,25 @@ func newMemSampler(interval time.Duration) *memSampler {
 	}
 }
 
+// rss returns the current RSS using the injected reader or the default.
+func (m *memSampler) rss() (uint64, bool) {
+	if m.readRSS != nil {
+		return m.readRSS()
+	}
+	return readRSSBytes()
+}
+
 // start records the baseline allocation counter and launches the sampling
 // goroutine. The first sample is taken immediately so a fast workload still
 // produces a non-zero peak.
 func (m *memSampler) start() {
+	m.startedAt = time.Now()
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
 	m.startTotalAlloc = ms.TotalAlloc
 	m.report.HeapInuseBaseline = ms.HeapInuse
 	m.report.HeapInusePeak = ms.HeapInuse
-	if rss, ok := readRSSBytes(); ok {
+	if rss, ok := m.rss(); ok {
 		m.report.RSSBaseline = rss
 		m.report.RSSPeak = rss
 	}
@@ -639,17 +690,64 @@ func (m *memSampler) start() {
 	}()
 }
 
-// sampleOnce updates the running peaks from one observation.
+// sampleOnce updates the running peaks from one observation and checks
+// memory guard conditions, sending a finding to abortCh on breach.
 func (m *memSampler) sampleOnce() {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
 	if ms.HeapInuse > m.report.HeapInusePeak {
 		m.report.HeapInusePeak = ms.HeapInuse
 	}
-	if rss, ok := readRSSBytes(); ok && rss > m.report.RSSPeak {
+	rss, rssOK := m.rss()
+	if rssOK && rss > m.report.RSSPeak {
 		m.report.RSSPeak = rss
 	}
 	m.report.Sampled = true
+
+	if m.abortCh == nil || !rssOK {
+		return
+	}
+
+	now := time.Now()
+
+	// Absolute ceiling check.
+	if m.maxRSSBytes > 0 && rss > m.maxRSSBytes {
+		finding := fmt.Sprintf("RSS %s exceeds ceiling %s at T+%s (baseline %s)",
+			FormatBytes(rss), FormatBytes(m.maxRSSBytes),
+			FormatDuration(now.Sub(m.startedAt)),
+			FormatBytes(m.report.RSSBaseline))
+		select {
+		case m.abortCh <- finding:
+		default:
+		}
+		return
+	}
+
+	// Growth-rate check: only active after the warm-up period.
+	if m.maxRSSGrowthBytesPerSec > 0 {
+		// Record the warm-up checkpoint on first sample past the warm-up window.
+		if m.warmUpAt.IsZero() && !m.startedAt.IsZero() && now.Sub(m.startedAt) >= memGuardWarmUp {
+			m.warmUpAt = now
+			m.warmUpRSS = rss
+		}
+		if !m.warmUpAt.IsZero() {
+			elapsed := now.Sub(m.warmUpAt).Seconds()
+			if elapsed > 0 {
+				growthRate := float64(rss-m.warmUpRSS) / elapsed
+				if rss > m.warmUpRSS && growthRate > float64(m.maxRSSGrowthBytesPerSec) {
+					finding := fmt.Sprintf(
+						"RSS growth rate %.1f B/s exceeds limit %s/s at T+%s (warm-up RSS %s, current RSS %s)",
+						growthRate, FormatBytes(m.maxRSSGrowthBytesPerSec),
+						FormatDuration(now.Sub(m.startedAt)),
+						FormatBytes(m.warmUpRSS), FormatBytes(rss))
+					select {
+					case m.abortCh <- finding:
+					default:
+					}
+				}
+			}
+		}
+	}
 }
 
 // stop halts sampling and waits for the sampler goroutine to exit before
@@ -667,7 +765,7 @@ func (m *memSampler) stop() MemReport {
 	if ms.HeapInuse > m.report.HeapInusePeak {
 		m.report.HeapInusePeak = ms.HeapInuse
 	}
-	if rss, ok := readRSSBytes(); ok {
+	if rss, ok := m.rss(); ok {
 		m.report.RSSSteady = rss
 		if rss > m.report.RSSPeak {
 			m.report.RSSPeak = rss

--- a/internal/benchmarks/coordstore/runner.go
+++ b/internal/benchmarks/coordstore/runner.go
@@ -732,9 +732,9 @@ func (m *memSampler) sampleOnce() {
 		}
 		if !m.warmUpAt.IsZero() {
 			elapsed := now.Sub(m.warmUpAt).Seconds()
-			if elapsed > 0 {
+			if elapsed > 0 && rss > m.warmUpRSS {
 				growthRate := float64(rss-m.warmUpRSS) / elapsed
-				if rss > m.warmUpRSS && growthRate > float64(m.maxRSSGrowthBytesPerSec) {
+				if growthRate > float64(m.maxRSSGrowthBytesPerSec) {
 					finding := fmt.Sprintf(
 						"RSS growth rate %.1f B/s exceeds limit %s/s at T+%s (warm-up RSS %s, current RSS %s)",
 						growthRate, FormatBytes(m.maxRSSGrowthBytesPerSec),

--- a/internal/benchmarks/coordstore/runner_leak_test.go
+++ b/internal/benchmarks/coordstore/runner_leak_test.go
@@ -1,0 +1,159 @@
+package coordstore
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMemSamplerAbortOnCeiling verifies that when the injected RSS reader
+// returns a value above MaxRSSBytes, sampleOnce sends on abortCh.
+func TestMemSamplerAbortOnCeiling(t *testing.T) {
+	const ceiling = 100 * 1024 * 1024 // 100 MiB
+
+	callCount := 0
+	fake := func() (uint64, bool) {
+		callCount++
+		if callCount >= 2 {
+			return ceiling + 1, true // exceeds ceiling on second call
+		}
+		return ceiling / 2, true // under ceiling on first call
+	}
+
+	m := newMemSampler(time.Millisecond)
+	m.readRSS = fake
+	m.maxRSSBytes = ceiling
+	m.abortCh = make(chan string, 1)
+	m.startedAt = time.Now()
+
+	// First sample (baseline) — under ceiling.
+	m.sampleOnce()
+	select {
+	case msg := <-m.abortCh:
+		t.Fatalf("unexpected abort on under-ceiling sample: %s", msg)
+	default:
+	}
+
+	// Second sample — over ceiling.
+	m.sampleOnce()
+	select {
+	case msg := <-m.abortCh:
+		if !strings.Contains(msg, "RSS") {
+			t.Fatalf("abort finding should mention RSS, got: %s", msg)
+		}
+		if !strings.Contains(msg, "ceiling") {
+			t.Fatalf("abort finding should mention ceiling, got: %s", msg)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected abort signal but got none")
+	}
+}
+
+// TestMemSamplerAbortOnGrowthRate verifies that sustained RSS growth above
+// MaxRSSGrowthBytesPerSec triggers an abort after the warm-up period.
+func TestMemSamplerAbortOnGrowthRate(t *testing.T) {
+	const growthLimit = 10 * 1024 * 1024 // 10 MiB/s
+
+	rssNow := uint64(50 * 1024 * 1024) // 50 MiB
+	fake := func() (uint64, bool) {
+		return rssNow, true
+	}
+
+	m := newMemSampler(time.Millisecond)
+	m.readRSS = fake
+	m.maxRSSGrowthBytesPerSec = growthLimit
+	m.abortCh = make(chan string, 1)
+
+	// Simulate post-warm-up state: warm-up was 2x the warm-up period ago.
+	// Place warm-up 2s ago so growth rate = (50 MiB - 10 MiB) / 2s = 20 MiB/s > 10 MiB/s limit.
+	m.startedAt = time.Now().Add(-(memGuardWarmUp + 2*time.Second))
+	m.warmUpAt = time.Now().Add(-2 * time.Second)
+	m.warmUpRSS = 10 * 1024 * 1024 // 10 MiB at warm-up
+
+	m.sampleOnce()
+
+	select {
+	case msg := <-m.abortCh:
+		if !strings.Contains(msg, "growth") {
+			t.Fatalf("abort finding should mention growth, got: %s", msg)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected abort signal on growth-rate breach but got none")
+	}
+}
+
+// TestRunnerAbortsOnMemoryCeiling verifies that Runner.Run returns early
+// (before full Duration) and sets LeakAborted+LeakFinding in the Scorecard
+// when the injected RSS reader exceeds MaxRSSBytes.
+func TestRunnerAbortsOnMemoryCeiling(t *testing.T) {
+	ctx := context.Background()
+
+	const ceiling = 1 // 1 byte — always exceeded by any real RSS
+
+	wl := SmokeWorkload
+	wl.Duration = 10 * time.Second // long enough that early abort is noticeable
+	wl.MaxRSSBytes = ceiling
+
+	seed := SeedResult{MainOpenIDs: []string{"main-1"}}
+	runner := NewRunner(&leakTestAdapter{}, wl, seed)
+
+	// Inject a fake RSS reader that immediately exceeds the ceiling.
+	runner.rssReader = func() (uint64, bool) {
+		return ceiling + 1, true
+	}
+
+	start := time.Now()
+	sc, err := runner.Run(ctx, noopWriter{})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Run returned unexpected error: %v", err)
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("Run did not abort early: elapsed=%s, want < 5s", elapsed)
+	}
+	if !sc.LeakAborted {
+		t.Fatal("Scorecard.LeakAborted should be true")
+	}
+	if !strings.Contains(sc.LeakFinding, "RSS") {
+		t.Fatalf("Scorecard.LeakFinding should mention RSS, got: %q", sc.LeakFinding)
+	}
+	if sc.Passed() {
+		t.Fatal("Scorecard.Passed() should be false when LeakAborted")
+	}
+}
+
+// leakTestAdapter is a minimal no-op StoreAdapter for control-flow tests.
+type leakTestAdapter struct{}
+
+func (a *leakTestAdapter) Open(_ context.Context, _ Config) error   { return nil }
+func (a *leakTestAdapter) Close() error                             { return nil }
+func (a *leakTestAdapter) Reset(_ context.Context) error            { return nil }
+func (a *leakTestAdapter) PrimeScan(_ context.Context) (int, error) { return 0, nil }
+func (a *leakTestAdapter) Create(_ context.Context, r Record) (Record, error) {
+	return r, nil
+}
+func (a *leakTestAdapter) Get(_ context.Context, _ string) (Record, error)          { return Record{}, nil }
+func (a *leakTestAdapter) BatchGet(_ context.Context, _ []string) ([]Record, error) { return nil, nil }
+func (a *leakTestAdapter) Update(_ context.Context, _ string, _ Update) error       { return nil }
+func (a *leakTestAdapter) Delete(_ context.Context, _ string) error                 { return nil }
+func (a *leakTestAdapter) SetMetadataBatch(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+func (a *leakTestAdapter) FilterScan(_ context.Context, _ Query) ([]Record, error) { return nil, nil }
+func (a *leakTestAdapter) Ready(_ context.Context, _ ReadyQuery) ([]Record, error) { return nil, nil }
+func (a *leakTestAdapter) RecentScan(_ context.Context, _ int) ([]Record, error)   { return nil, nil }
+func (a *leakTestAdapter) DepAdd(_ context.Context, _, _, _ string) error          { return nil }
+func (a *leakTestAdapter) DepRemove(_ context.Context, _, _ string) error          { return nil }
+func (a *leakTestAdapter) DepList(_ context.Context, _, _ string) ([]Dep, error)   { return nil, nil }
+func (a *leakTestAdapter) PurgeExpired(_ context.Context) (int, error)             { return 0, nil }
+func (a *leakTestAdapter) PurgeTerminal(_ context.Context, _ time.Duration) (int, error) {
+	return 0, nil
+}
+func (a *leakTestAdapter) Stats(_ context.Context) map[string]int64 { return nil }
+
+// noopWriter discards all output.
+type noopWriter struct{}
+
+func (noopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/benchmarks/coordstore/scorecard.go
+++ b/internal/benchmarks/coordstore/scorecard.go
@@ -147,11 +147,19 @@ type Scorecard struct {
 	// MemPass reports whether the HeapInuseDelta target was met. Only
 	// meaningful when Mem.Sampled is true.
 	MemPass bool
+	// LeakAborted is true when the run was canceled by the memory guard.
+	LeakAborted bool
+	// LeakFinding describes what triggered the memory guard abort.
+	// Empty when LeakAborted is false.
+	LeakFinding string
 }
 
 // Passed returns true if all measured targets passed, including the memory
 // target when memory was sampled.
 func (s *Scorecard) Passed() bool {
+	if s.LeakAborted {
+		return false
+	}
 	for _, r := range s.Results {
 		if r.Measured && !r.Pass {
 			return false
@@ -329,6 +337,10 @@ func (s *Scorecard) PrintTable(w io.Writer) {
 		fmt.Fprintf(w, "  %-*s  %-12s  %-12s  %-12s\n", //nolint:errcheck
 			colW, "RSS", rssBaseline, rssPeak, rssSteady)
 		fmt.Fprintf(w, "  %-*s  %-12s\n", colW, "alloc delta (churn)", FormatBytes(s.Mem.AllocDelta)) //nolint:errcheck
+	}
+
+	if s.LeakAborted {
+		fmt.Fprintf(w, "\n  *** LEAK DETECTED — run aborted: %s ***\n", s.LeakFinding) //nolint:errcheck
 	}
 
 	fmt.Fprintln(w) //nolint:errcheck

--- a/internal/benchmarks/coordstore/suite_test.go
+++ b/internal/benchmarks/coordstore/suite_test.go
@@ -424,13 +424,38 @@ func soakConfigFromEnv(t *testing.T, defaultDuration time.Duration) coordstore.S
 		}
 		chaosDuration = parsed
 	}
+
+	// RSS ceiling: default 8 GiB; override with COORDSTORE_SOAK_MAX_RSS_BYTES.
+	const defaultMaxRSSBytes = 8 * 1024 * 1024 * 1024 // 8 GiB
+	maxRSSBytes := uint64(defaultMaxRSSBytes)
+	if raw := os.Getenv("COORDSTORE_SOAK_MAX_RSS_BYTES"); raw != "" {
+		parsed, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			t.Fatalf("invalid COORDSTORE_SOAK_MAX_RSS_BYTES %q: %v", raw, err)
+		}
+		maxRSSBytes = parsed
+	}
+
+	// Growth-rate ceiling: default 50 MiB/s; override with COORDSTORE_SOAK_MAX_RSS_GROWTH_BYTES_PER_SEC.
+	const defaultMaxRSSGrowthBytesPerSec = 50 * 1024 * 1024 // 50 MiB/s
+	maxRSSGrowthBytesPerSec := uint64(defaultMaxRSSGrowthBytesPerSec)
+	if raw := os.Getenv("COORDSTORE_SOAK_MAX_RSS_GROWTH_BYTES_PER_SEC"); raw != "" {
+		parsed, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			t.Fatalf("invalid COORDSTORE_SOAK_MAX_RSS_GROWTH_BYTES_PER_SEC %q: %v", raw, err)
+		}
+		maxRSSGrowthBytesPerSec = parsed
+	}
+
 	return coordstore.SoakConfig{
-		SoakPhase:      coordstore.SoakPhaseA,
-		SoakDuration:   duration,
-		ChaosDuration:  chaosDuration,
-		SampleInterval: sampleInterval,
-		ResultsDir:     resultsDir,
-		ScaleFactor:    scale,
+		SoakPhase:               coordstore.SoakPhaseA,
+		SoakDuration:            duration,
+		ChaosDuration:           chaosDuration,
+		SampleInterval:          sampleInterval,
+		ResultsDir:              resultsDir,
+		ScaleFactor:             scale,
+		MaxRSSBytes:             maxRSSBytes,
+		MaxRSSGrowthBytesPerSec: maxRSSGrowthBytesPerSec,
 	}
 }
 

--- a/internal/benchmarks/coordstore/workload.go
+++ b/internal/benchmarks/coordstore/workload.go
@@ -114,6 +114,17 @@ type WorkloadConfig struct {
 	// Concurrency is the number of concurrent goroutines issuing requests.
 	// Matches the number of concurrent agents in a typical HQ city (~20).
 	Concurrency int
+
+	// MaxRSSBytes is the process RSS ceiling in bytes. When the process RSS
+	// exceeds this value during a run, the runner cancels the workload and
+	// reports a "leak detected" finding. Zero disables the guard (default).
+	MaxRSSBytes uint64
+
+	// MaxRSSGrowthBytesPerSec is the mean RSS growth rate ceiling in bytes/second,
+	// computed after a warm-up period. If the mean growth rate from the
+	// warm-up checkpoint to now exceeds this value, the runner cancels the
+	// workload and reports a "leak detected" finding. Zero disables (default).
+	MaxRSSGrowthBytesPerSec uint64
 }
 
 // SoakPhase identifies a long-running soak benchmark phase.
@@ -148,6 +159,14 @@ type SoakConfig struct {
 	// single-city scale (v1 default); ~10x for future 100-rig calibration run
 	// (empirical, not hard-coded).
 	ScaleFactor float64
+
+	// MaxRSSBytes is the process RSS ceiling for this soak run. When set, it
+	// overrides the workload's MaxRSSBytes. Zero means no override.
+	MaxRSSBytes uint64
+
+	// MaxRSSGrowthBytesPerSec is the growth-rate ceiling for this soak run.
+	// When set, it overrides the workload's MaxRSSGrowthBytesPerSec.
+	MaxRSSGrowthBytesPerSec uint64
 }
 
 // ScaledWorkload returns a copy of base scaled by ScaleFactor.
@@ -177,6 +196,12 @@ func (c SoakConfig) ScaledWorkload(base WorkloadConfig) WorkloadConfig {
 	wl.Concurrency = scaleCount(base.Concurrency, scale)
 	if c.SoakDuration > 0 {
 		wl.Duration = c.SoakDuration
+	}
+	if c.MaxRSSBytes > 0 {
+		wl.MaxRSSBytes = c.MaxRSSBytes
+	}
+	if c.MaxRSSGrowthBytesPerSec > 0 {
+		wl.MaxRSSGrowthBytesPerSec = c.MaxRSSGrowthBytesPerSec
 	}
 	return wl
 }

--- a/internal/benchmarks/coordstore/workload.go
+++ b/internal/benchmarks/coordstore/workload.go
@@ -124,6 +124,7 @@ type WorkloadConfig struct {
 	// computed after a warm-up period. If the mean growth rate from the
 	// warm-up checkpoint to now exceeds this value, the runner cancels the
 	// workload and reports a "leak detected" finding. Zero disables (default).
+	// Inactive for runs shorter than memGuardWarmUp (30 s); intended for long soak runs.
 	MaxRSSGrowthBytesPerSec uint64
 }
 

--- a/release-gates/ga-octzq0-coordstore-soak-rss-guard-gate.md
+++ b/release-gates/ga-octzq0-coordstore-soak-rss-guard-gate.md
@@ -1,0 +1,49 @@
+# Release Gate: Coordstore soak RSS guard
+
+Bead: ga-octzq0 - needs-deploy: coordstore soak RSS guard (from:ga-tcey6d)
+Source bead: ga-pzgem
+Review bead: ga-tcey6d
+Feature branch: builder/ga-pzgem-soak-mem-ceiling
+Head under gate: 145980743c8de6e51ce457fad1eb7b99ed7a0549
+Base checked: origin/main f1365b85d5510f38622034f9cb333ca5fd553f31
+
+Note: docs/PROJECT_MANIFEST.md is not present in this checkout. This gate uses
+the deployer release criteria and the repository testing guidance in TESTING.md.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-tcey6d is closed with `REVIEWER VERDICT: PASS (rev2)` for commit 145980743. |
+| 2 | Acceptance criteria met | PASS | Source bead ga-pzgem required the coordstore soak harness to abort and report memory leaks instead of running to OOM. The branch adds RSS ceiling and growth-rate guards, first-class `Scorecard.LeakAborted` / `LeakFinding` reporting, default soak guard activation, and deterministic guard tests. |
+| 3 | Tests pass | PASS | `go test ./internal/benchmarks/coordstore` passed in 21.571s. `make test-fast-parallel` passed all fast shards. `go vet ./...` passed with no output. |
+| 4 | No high-severity review findings open | PASS | Prior ga-kg17no BLOCKER/HIGH/MEDIUM findings were all resolved in 145980743 and re-reviewed as PASS in ga-tcey6d. No new findings were recorded by the PASS review. |
+| 5 | Final branch is clean | PASS | Before adding this gate file, `git status --short --branch` showed the branch clean at `builder/ga-pzgem-soak-mem-ceiling...origin/builder/ga-pzgem-soak-mem-ceiling`. The only deployer change is this release-gate file, to be committed as the gate evidence. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` exited 0 and produced tree 39a29f033653208b611692f8683f95ae0da0eae6. The branch is 2 commits ahead and 2 commits behind origin/main, with no merge conflicts. |
+| 7 | Single feature theme | PASS | The feature diff from the merge-base touches only `internal/benchmarks/coordstore/{runner.go,runner_leak_test.go,scorecard.go,suite_test.go,workload.go}`. The commit set is one coordstore soak memory-guard theme. |
+
+## Acceptance Evidence
+
+- `internal/benchmarks/coordstore/workload.go` adds `MaxRSSBytes` and
+  `MaxRSSGrowthBytesPerSec` to workload and soak configuration.
+- `internal/benchmarks/coordstore/runner.go` starts the memory sampler with
+  the configured guard values, cancels the run on a guard breach, records the
+  leak finding on the scorecard, and checks `rss > warmUpRSS` before subtracting.
+- `internal/benchmarks/coordstore/suite_test.go` enables production defaults
+  for real soak runs: 8 GiB RSS ceiling and 50 MiB/s RSS growth-rate ceiling,
+  both overrideable by typed environment variables.
+- `internal/benchmarks/coordstore/runner_leak_test.go` covers ceiling abort,
+  growth-rate abort, and runner-level scorecard abort behavior.
+
+## Test Log
+
+```text
+$ go test ./internal/benchmarks/coordstore
+ok  	github.com/gastownhall/gascity/internal/benchmarks/coordstore	21.571s
+
+$ make test-fast-parallel
+All fast jobs passed
+
+$ go vet ./...
+PASS (no output)
+```


### PR DESCRIPTION
## What this changes

Coordstore soak runs now have a memory guard. When process RSS exceeds the configured ceiling, or when sustained post-warmup RSS growth exceeds the configured rate, the runner cancels the workload and records the condition as a leak finding instead of continuing until the host is exhausted.

Real `COORDSTORE_SOAK=1` runs now enable protections by default: an 8 GiB absolute RSS ceiling and a 50 MiB/s RSS growth-rate ceiling. Operators can override those with `COORDSTORE_SOAK_MAX_RSS_BYTES` and `COORDSTORE_SOAK_MAX_RSS_GROWTH_BYTES_PER_SEC`.

The scorecard now carries `LeakAborted` and `LeakFinding`, and a leak abort makes the run fail. The growth-rate guard starts after a 30 second warm-up window so initial allocation spikes do not trip the long-run leak detector.

## Review notes

- Review `internal/benchmarks/coordstore/runner.go` for the cancellation path and scorecard leak reporting.
- Review `internal/benchmarks/coordstore/suite_test.go` for the default soak thresholds and env var parsing.
- Review `internal/benchmarks/coordstore/runner_leak_test.go` for deterministic RSS ceiling, growth-rate, and runner abort coverage.
- This does not change the HTTP API, generated schemas, dashboard assets, or city config schema.

## Test plan

- [x] `go test ./internal/benchmarks/coordstore`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-octzq0-coordstore-soak-rss-guard-gate.md`](release-gates/ga-octzq0-coordstore-soak-rss-guard-gate.md)