### PR TITLE
build: auto-detect keg-only icu4c for CGO on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,10 @@ LDFLAGS := -X main.version=$(VERSION) \
 ifeq ($(shell uname),Darwin)
 ICU_PREFIX := $(shell brew --prefix icu4c 2>/dev/null)
 ifneq ($(ICU_PREFIX),)
-export CGO_CPPFLAGS := $(CGO_CPPFLAGS) -I$(ICU_PREFIX)/include
-export CGO_LDFLAGS := $(CGO_LDFLAGS) -L$(ICU_PREFIX)/lib
+CGO_CPPFLAGS += -I$(ICU_PREFIX)/include
+CGO_LDFLAGS += -L$(ICU_PREFIX)/lib
+export CGO_CPPFLAGS
+export CGO_LDFLAGS
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,19 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
+# macOS: icu4c (a transitive Dolt / go-icu-regex CGO build dependency) is
+# keg-only under Homebrew, so its headers/libs are not on the default CGO
+# search path. Point CGO at them when icu4c is present. This is a no-op on
+# Linux and other platforms (where system ICU, e.g. libicu-dev, is found
+# normally) and a no-op on macOS when icu4c is not installed.
+ifeq ($(shell uname),Darwin)
+ICU_PREFIX := $(shell brew --prefix icu4c 2>/dev/null)
+ifneq ($(ICU_PREFIX),)
+export CGO_CPPFLAGS := $(CGO_CPPFLAGS) -I$(ICU_PREFIX)/include
+export CGO_LDFLAGS := $(CGO_LDFLAGS) -L$(ICU_PREFIX)/lib
+endif
+endif
+
 .PHONY: build check check-all check-bd check-docker check-docs check-dolt check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
 
 ## build: compile gc binary with version metadata
@@ -235,6 +248,8 @@ TEST_ENV = env -i \
 	CLAUDE_CODE_EFFORT_LEVEL="$${CLAUDE_CODE_EFFORT_LEVEL-}" \
 	CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="$${CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC-}" \
 	OLLAMA_API_KEY="$${OLLAMA_API_KEY-}" \
+	CGO_CPPFLAGS="$${CGO_CPPFLAGS-}" \
+	CGO_LDFLAGS="$${CGO_LDFLAGS-}" \
 	$(EXTRA_TEST_ENV)
 
 ## test: run fast unit tests (skip integration-tagged and GC_FAST_UNIT-gated process tests)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ brew install gastownhall/gascity/gascity
 gc version
 ```
 
-Or build from source (requires `make` and Go 1.25+):
+Or build from source (requires `make`, Go 1.25+, and ICU for a transitive Dolt
+CGO dependency — `brew install icu4c` on macOS, `apt install libicu-dev` on
+Linux; on macOS the Makefile auto-detects the keg-only `icu4c` paths):
 
 ```bash
 make install


### PR DESCRIPTION
## Summary

The transitive Dolt / go-icu-regex dependency compiles a C++ file that includes ICU headers (<unicode/regex.h>). On macOS, Homebrew's icu4c is keg-only, so its headers/libs aren't on the default CGO search path, and `make install` fails with "'unicode/regex.h' file not found".

Point CGO at the keg-only icu4c when present. The block is Darwin-scoped and a no-op both when icu4c is absent and on all other platforms (where system ICU, e.g. libicu-dev, resolves on the default search path). Also document the ICU build prerequisite in the README's build-from-source instructions.

## Testing

- [ ] make check — builds + lints clean with the ICU fix; the only failure is a pre-existing unparam finding in internal/runtime/proctable/guard.go — untouched by this PR
(fails on plain main too). Likely a local golangci-lint version nit vs the pinned 2.9.0; CI should be green.
- [x] make check-docs — passes: ok github.com/gastownhall/gascity/test/docsync (verified the TEST_ENV passthrough resolves the ICU build under env -i).
- [ ] make test-integration — N/A: build configuration + docs only; no runtime, controller, or workflow behavior change.

Also verified make install builds on macOS with auto-detected icu4c and no manually-set CGO env.

## Checklist

- [x] Linked an issue, or explained why one is not needed — No issue; minor build-portability fix for macOS source builds.
- [ ] Added or updated tests for behavior changes — N/A: Makefile + docs only; verified the build/test targets succeed on macOS and the block no-ops on non-Darwin.
- [x] Updated docs for user-facing changes — README build-from-source prerequisite added.
- [x] Called out breaking changes or migration notes — None; Darwin-scoped, no-op on other platforms / when icu4c is absent.
