### PR TITLE
Enable live pack registry smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -927,6 +927,20 @@ jobs:
         run: make install-tools
       - name: Pack compatibility tests
         run: make test-acceptance
+      - name: Live registry smoke
+        timeout-minutes: 12
+        run: |
+          for attempt in 1 2 3; do
+            if make test-pack-registry-live; then
+              exit 0
+            fi
+            if [ "$attempt" = "3" ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+        env:
+          GC_TEST_GASCITY_PACKS_REGISTRY: main
     env:
       DOLT_VERSION: "2.1.0"
       BD_VERSION: "v1.0.5"

--- a/Makefile
+++ b/Makefile
@@ -268,8 +268,10 @@ test-pack-registry-live:
 		echo "Example: GC_TEST_GASCITY_PACKS_REGISTRY=main make test-pack-registry-live"; \
 		exit 2; \
 	fi
-	$(TEST_ENV) GC_TEST_GASCITY_PACKS_REGISTRY="$${GC_TEST_GASCITY_PACKS_REGISTRY}" go test ./cmd/gc -run '^TestPackRegistryLiveGascityPacksCatalog$$' -count=1
-	$(TEST_ENV) GC_TEST_GASCITY_PACKS_REGISTRY="$${GC_TEST_GASCITY_PACKS_REGISTRY}" go test -tags acceptance_a -timeout 10m ./test/acceptance -run '^TestPackRegistryLiveImportsEveryCatalogPack$$' -count=1
+	@# Keep the live canary portable on runners and local machines that do not
+	@# have the optional ICU C headers needed by the default CGO build path.
+	$(TEST_ENV) CGO_ENABLED=0 GC_TEST_GASCITY_PACKS_REGISTRY="$${GC_TEST_GASCITY_PACKS_REGISTRY}" go test ./cmd/gc -run '^TestPackRegistryLiveGascityPacksCatalog$$' -count=1
+	$(TEST_ENV) CGO_ENABLED=0 GC_TEST_GASCITY_PACKS_REGISTRY="$${GC_TEST_GASCITY_PACKS_REGISTRY}" go test -tags acceptance_a -timeout 10m ./test/acceptance -run '^TestPackRegistryLiveImportsEveryCatalogPack$$' -count=1
 
 ## test-native-doltlite-beads: compile and run the native DoltLite read-store suite
 test-native-doltlite-beads:

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -525,13 +525,14 @@ func TestPackRegistryLiveGascityPacksCatalog(t *testing.T) {
 		t.Fatalf("search gascity-packs registry code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
 	searchOutput := stdout.String()
-	for _, name := range []string{"gascity", "gastown", "discord", "github-intake", "slack"} {
+	canaryPacks := []string{"gascity", "gastown", "discord", "github", "slack-full"}
+	for _, name := range canaryPacks {
 		if !strings.Contains(searchOutput, name) {
 			t.Fatalf("search output missing %q:\n%s", name, searchOutput)
 		}
 	}
 
-	for _, name := range []string{"gascity", "gastown", "discord", "github-intake", "slack"} {
+	for _, name := range canaryPacks {
 		stdout.Reset()
 		stderr.Reset()
 		if code := doPackRegistryShow("main:"+name, false, false, &stdout, &stderr); code != 0 {


### PR DESCRIPTION
## Summary
- run the live gascity-packs registry smoke target from the pack compatibility gate
- keep the live target portable with CGO_ENABLED=0
- update the live catalog canary to current public handles and remove duplicate pack-name lists

## Stacking
Draft until gastownhall/gascity-packs#55 lands. The CI step intentionally points at the public main registry, so it should become ready only after #55 refreshes the registry release pins.

## Validation
- GC_TEST_GASCITY_PACKS_REGISTRY=/tmp/gascity-packs-registry-fix/registry.toml make test-pack-registry-live
- Also observed failure against current public main before #55: cass release commit was stale and missing cass/pack.toml, which is the drift this gate is meant to catch.

## Claude review
- Medium: external live check could be flaky; addressed with three attempts and a 12-minute timeout while preserving a hard gate.
- Low: document CGO_ENABLED=0; addressed in Makefile.
- Low: verify current public handles and avoid duplicate lists; addressed in cmd_pack_registry_test.go.

Depends on gastownhall/gascity-packs#55.