### PR TITLE
docs: add documentation badge and live docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/gastownhall/gascity/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/gastownhall/gascity/ci.yml?branch=main&label=Build&style=for-the-badge" alt="Build status"></a>
+  <a href="https://docs.gascityhall.com"><img src="https://img.shields.io/badge/Docs-latest-c9a84c.svg?style=for-the-badge" alt="Documentation"></a>
   <a href="https://github.com/gastownhall/gascity/releases"><img src="https://img.shields.io/github/v/release/gastownhall/gascity?include_prereleases&style=for-the-badge" alt="GitHub release"></a>
   <a href="https://discord.gg/xHpUGUzZp2"><img src="https://img.shields.io/discord/1462817445562814505?label=Discord&logo=discord&logoColor=white&color=5865F2&style=for-the-badge" alt="Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
@@ -100,6 +101,8 @@ For the longer walkthrough, start with
 [Tutorial 01](docs/tutorials/01-cities-and-rigs.md).
 
 ## Documentation
+
+📖 **Read the docs online: [docs.gascityhall.com](https://docs.gascityhall.com)**
 
 The docs now use a Mintlify structure rooted in [`docs/`](docs/README.md).
 


### PR DESCRIPTION
## Summary

Adds a **Docs** badge to the README badge row and a live docs link to the Documentation section.

- New `Docs · latest` badge (matches the existing `for-the-badge` style, Gas City gold `#c9a84c`) linking to the published site: https://docs.gascityhall.com
- A prominent **Read the docs online** link at the top of the `## Documentation` section, which previously only linked to in-repo files.

Opened as a **draft** for review.

## Test plan

Verification:

- ✅ Docs badge renders in the README badge row (gold `DOCS · latest`) and links to https://docs.gascityhall.com — confirmed against the GitHub-rendered README on the PR branch (screenshot below).
- ✅ The `## Documentation` section's **Read the docs online** link resolves to https://docs.gascityhall.com — confirmed in the rendered README (screenshot below).
- ✅ `curl -sI https://docs.gascityhall.com` → **HTTP/2 200** (live site reachable).

Captured from GitHub's rendered view of the PR branch (`idvorkin-ai-tools/gascity@docs/readme-doc-badge`); the new badge/link show as diff additions in the rich diff.

### Rendered badge row

The new gold `DOCS · latest` badge, rendered in the README header row:

![Rendered README badge row showing the new gold Docs · latest badge](https://raw.githubusercontent.com/idvorkin-ai-tools/gascity/pr-assets/doc-badge/pr-assets/gascity-pr3007-badges.png)

### Documentation section

The new **Read the docs online: docs.gascityhall.com** live link at the top of the `## Documentation` section:

![Rendered Documentation section showing the new live docs link](https://raw.githubusercontent.com/idvorkin-ai-tools/gascity/pr-assets/doc-badge/pr-assets/gascity-pr3007-docs-section.png)

### Rich diff

GitHub's "Display the rich diff" view of the README change — the added badge and live-docs link are marked as additions (green left bar):

![GitHub rich diff of the README showing the badge and docs link as additions](https://raw.githubusercontent.com/idvorkin-ai-tools/gascity/pr-assets/doc-badge/pr-assets/gascity-pr3007-richdiff.png)

---

_Screenshots are hosted on the fork branch `pr-assets/doc-badge` to keep the `docs/readme-doc-badge` PR diff clean (README change only)._

— Keeping my human friend @idvorkin in the loop!
