### PR TITLE
test(api): avoid Claude CLI dependency in provider family test

### DIFF
--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -2804,7 +2804,7 @@ func TestMaterializeNamedSessionStampsProviderFamilyMetadata(t *testing.T) {
 		MaxActiveSessions: intPtr(1),
 	}}
 	fs.cfg.Providers = map[string]config.ProviderSpec{
-		"claude-max": {Base: &base},
+		"claude-max": {Base: &base, PathCheck: "true"},
 	}
 	srv := New(fs)
 


### PR DESCRIPTION
## Summary
- Fixes the named-session provider-family metadata test so it no longer depends on a real `claude` binary being installed on PATH.
- Keeps the fixture inheriting from `builtin:claude`, but sets `PathCheck: "true"` for the custom provider, matching existing API test patterns.

## CI failure reviewed
- Linked run: https://github.com/gastownhall/gascity/actions/runs/26888517247/job/79307630049
- Failing test: `TestMaterializeNamedSessionStampsProviderFamilyMetadata`
- Failure: `provider not found in PATH: provider "claude-max" command "claude"`
- The failed push changed only a pool-worker prompt in #2985, so this appears to be an independent/hermeticity issue in an API test fixture, not caused by that work.

## Local validation
- `PATH=/usr/local/go/bin:/usr/bin:/bin go test ./internal/api -run '^TestMaterializeNamedSessionStampsProviderFamilyMetadata$' -count=1`
- `go test ./internal/api -run '^TestMaterializeNamedSession' -count=1`
- `go vet ./internal/api`
- `.githooks/pre-commit` (includes `go vet ./...` and `make test-fast-parallel`)
- Commit hook reran and passed the same pre-commit gate.