### PR TITLE
fix(beads): adopt already-initialized rig stores

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -659,7 +659,7 @@ func shouldRetryExecBdInit(err error) bool {
 	return strings.Contains(err.Error(), "bd schema not visible")
 }
 
-func isExecBeadsAlreadyInitializedError(err error) bool {
+func isBdAlreadyInitializedError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -810,7 +810,7 @@ func initBeadsForDir(cityPath, dir, prefix, doltDatabase string) error {
 				return err
 			}
 			if err := runProviderOpWithEnv(script, env, args...); err != nil {
-				if isExecBeadsAlreadyInitializedError(err) {
+				if isBdAlreadyInitializedError(err) {
 					return nil
 				}
 				return err
@@ -840,6 +840,9 @@ func initBeadsForDir(cityPath, dir, prefix, doltDatabase string) error {
 			}
 			env := overlayEnvEntries(baseEnv, overrides)
 			if err := runProviderOpWithEnv(script, env, args...); err != nil {
+				if isBdAlreadyInitializedError(err) {
+					return finalizeCanonicalBdScopeInit(cityPath, dir, prefix, canonicalDoltDatabase)
+				}
 				if shouldRetryExecBdInit(err) {
 					for attempt := 0; attempt < 3; attempt++ {
 						time.Sleep(time.Second)
@@ -927,6 +930,9 @@ func initDefaultRigBdStore(cityPath, dir, prefix, doltDatabase string) error {
 		args = append(args, "--database", canonicalDoltDatabase)
 	}
 	if _, err := beads.ExecCommandRunnerWithEnv(env)(dir, "bd", args...); err != nil {
+		if isBdAlreadyInitializedError(err) {
+			return finalizeCanonicalBdScopeInit(cityPath, dir, prefix, canonicalDoltDatabase)
+		}
 		return fmt.Errorf("bd init: %w", err)
 	}
 	return finalizeCanonicalBdScopeInit(cityPath, dir, prefix, canonicalDoltDatabase)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -5210,6 +5210,118 @@ exit 99
 	}
 }
 
+func TestInitAndHookDirAdoptsAlreadyInitializedDefaultRigBdStore(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "tincan")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"tincan"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initArgsFile := filepath.Join(t.TempDir(), "bd-init-args")
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+case "${1:-}" in
+  init)
+    printf '%%s\n' "$@" > %q
+    echo "Found existing Dolt database 'tincan' for this workspace. This workspace is already initialized; just run bd commands normally. Aborting." >&2
+    exit 1
+    ;;
+  list)
+    printf '[]\n'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, initArgsFile)
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_BEADS", "sqlite")
+	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
+
+	if err := initAndHookDir(cityPath, rigPath, "tc"); err != nil {
+		t.Fatalf("initAndHookDir should adopt existing initialized rig store: %v", err)
+	}
+	if _, err := os.Stat(initArgsFile); err != nil {
+		t.Fatalf("expected bd init attempt, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); err != nil {
+		t.Fatalf("expected hooks installed for adopted rig: %v", err)
+	}
+}
+
+func TestInitAndHookDirAdoptsAlreadyInitializedCanonicalExecBdStore(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "rigs", "tincan")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"tincan"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeBd := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(fakeBd, []byte("#!/bin/sh\nif [ \"${1:-}\" = list ]; then printf '[]\\n'; fi\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	providerArgsFile := filepath.Join(t.TempDir(), "provider-init-args")
+	providerScript := filepath.Join(t.TempDir(), "gc-beads-bd")
+	providerBody := fmt.Sprintf(`#!/bin/sh
+set -eu
+case "${1:-}" in
+  init)
+    printf '%%s\n' "$@" > %q
+    echo "Found existing Dolt database 'tincan' for this workspace. This workspace is already initialized; just run bd commands normally. Aborting." >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, providerArgsFile)
+	if err := os.WriteFile(providerScript, []byte(providerBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	setScopedBeadsProviderForTest(t, cityPath, "exec:"+providerScript)
+	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
+
+	if err := initAndHookDir(cityPath, rigPath, "tc"); err != nil {
+		t.Fatalf("initAndHookDir should adopt existing initialized canonical exec rig store: %v", err)
+	}
+	if _, err := os.Stat(providerArgsFile); err != nil {
+		t.Fatalf("expected provider init attempt, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rigPath, ".beads", "hooks", "on_create")); err != nil {
+		t.Fatalf("expected hooks installed for adopted rig: %v", err)
+	}
+}
+
 func TestSeedDeferredManagedBeadsSkipsDoltMetadataForInheritedCityPostgresRigWithEmptyMetadata(t *testing.T) {
 	cityPath, rigPath, metadataPath := writeInheritedCityPostgresRigFixture(t, `{"database":"beads"}`)
 

--- a/release-gates/ga-7z0hku-1-modernc-adoption-clean-gate.md
+++ b/release-gates/ga-7z0hku-1-modernc-adoption-clean-gate.md
@@ -1,0 +1,109 @@
+# Release Gate: ga-7z0hku.1
+
+Bead: ga-7z0hku.1 - Deploy clean modernc restart-init adoption branch from current main
+Branch: release/ga-7z0hku-1-modernc-adoption-clean
+Base: origin/main @ fb0df821cb764d65f2b71611781e8c812a70c6c4
+Head before gate commit: b32e1fdaa0b00c9d3affde68cbf11b88ce3ec361
+
+## Source Context
+
+- Source bug bead: ga-spy4rw.
+- Review bead: ga-wtuuwv, closed with `### Verdict: PASS`.
+- Prior deploy bead ga-7z0hku failed because the earlier branch bundled independent order-dispatch / broader modernc cutover work and conflicted with current main.
+- `docs/PROJECT_MANIFEST.md` is not present on this branch; this gate uses the active deployer criteria plus the bead acceptance criteria.
+
+## Gate Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-wtuuwv` contains `## Review: gascity/reviewer - PASS` and `### Verdict: PASS`; reviewed commits were `f7dff357b` and `c94a02794`. |
+| 2 | Acceptance criteria met | PASS | Fresh branch cut from current `origin/main`; cherry-picked only `f7dff357b` then `c94a02794`; diff is limited to `cmd/gc/beads_provider_lifecycle.go` and `cmd/gc/beads_provider_lifecycle_test.go`. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc`, focused cmd/gc regression test, `make test-fast-parallel`, `go vet ./...`, and isolated restart-init smoke all passed. |
+| 4 | No high-severity review findings open | PASS | Review notes contain no HIGH findings; only a cosmetic rename note and an out-of-scope pre-existing broad matcher note. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed only `## release/ga-7z0hku-1-modernc-adoption-clean...origin/main [ahead 2]`. Re-check after committing this file is required before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree `5c153f9f63e53a673ce74ab18531f16c9c7d17c5`. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem and one behavior: adopting already-initialized bd/Dolt rig stores during init/start lifecycle. No order-dispatch, `cmd/gc/main.go`, `internal/beads/sqlite_store*`, or broader modernc cutover files are present. |
+
+## Acceptance Evidence
+
+Cherry-picks:
+
+| Source SHA | New SHA | Purpose |
+|------------|---------|---------|
+| f7dff357b | 61d7a762a | Regression tests for already-initialized rig adoption. |
+| c94a02794 | b32e1fdaa | Lifecycle fix to adopt already-initialized rig stores after validation/finalization. |
+
+Diff scope:
+
+```text
+cmd/gc/beads_provider_lifecycle.go
+cmd/gc/beads_provider_lifecycle_test.go
+```
+
+Forbidden paths absent:
+
+```text
+cmd/gc/order_dispatch.go
+cmd/gc/order_dispatch_test.go
+cmd/gc/main.go
+internal/beads/sqlite_store.go
+internal/beads/sqlite_store_test.go
+```
+
+## Test Evidence
+
+Automated gates:
+
+```text
+go build ./cmd/gc
+go test ./cmd/gc -run "TestInitAndHookDirAdoptsAlreadyInitialized(DefaultRigBdStore|CanonicalExecBdStore)" -count=1
+make test-fast-parallel
+go vet ./...
+```
+
+Results:
+
+```text
+go build ./cmd/gc: PASS
+focused cmd/gc regression: ok github.com/gastownhall/gascity/cmd/gc 0.332s
+make test-fast-parallel: All fast jobs passed
+go vet ./...: PASS
+```
+
+Restart-init smoke:
+
+```text
+Scratch root: /tmp/gascity-ga-7z0hku-smoke.ZcX0U6
+Branch binary: /tmp/gascity-deploy-ga-7z0hku-1-modernc-adoption-clean/gc
+Dolt used for smoke: /tmp/gascity-ga-7z0hku-smoke.ZcX0U6/dolt210/dolt version 2.1.0
+Isolated GC_HOME: /tmp/gascity-ga-7z0hku-smoke.ZcX0U6/gchome
+Isolated supervisor port: 18372
+City: /tmp/gascity-ga-7z0hku-smoke.ZcX0U6/city3
+Rig: /tmp/gascity-ga-7z0hku-smoke.ZcX0U6/tincan3
+```
+
+Smoke steps:
+
+```text
+gc init --template minimal --providers codex --default-provider codex --skip-provider-readiness --yes <city>
+gc supervisor start
+gc rig add <rig> --city <city> --name tincan --prefix tc --start-suspended
+gc start <city> --no-auto-restart
+gc rig status tincan --city <city>
+```
+
+Smoke result:
+
+```text
+gc start <city> --no-auto-restart: exit 0; City started under supervisor.
+gc rig status tincan: exit 0; rig is suspended; control-dispatcher stopped.
+Rig metadata: backend=dolt, database=dolt, dolt_mode=server, dolt_database=tc.
+Rig hooks present: on_create, on_update, on_close.
+Log search found no already-initialized fatal, abort, or init-rig failure.
+```
+
+Notes:
+
+- The previously registered `/home/jaword/sqltest-dolt` and `/home/jaword/sqtest` fixtures could not be used directly because their city configs are stale and missing current provider aliases.
+- A first scratch attempt without isolated `GC_HOME` registered `city2` in the default supervisor registry; it was removed with `gc unregister /tmp/gascity-ga-7z0hku-smoke.ZcX0U6/city2`.
+- The isolated supervisor was stopped after the smoke.


### PR DESCRIPTION
## What this changes

Restarting or starting a city no longer fatals when a rig already has a healthy bd/Dolt `.beads` store and the backing `bd init` reports that the workspace is already initialized. Instead, `gc` treats that response as an adoption path: it runs the canonical finalization/readiness checks, then installs the normal bead hooks.

This covers both the default rig bd lifecycle and the canonical exec bd provider path, which are the two startup paths that can see an already-initialized rig store during supervisor restart.

## Review notes

- The implementation is limited to `cmd/gc/beads_provider_lifecycle.go` and its regression tests.
- The adoption path does not silently swallow `bd init` failures; it only proceeds through the existing canonical finalization and readiness probe.
- No broader modernc cutover, order-dispatch, SQLite store, or config changes are included.

## Test plan

- [x] `go build ./cmd/gc`
- [x] `go test ./cmd/gc -run "TestInitAndHookDirAdoptsAlreadyInitialized(DefaultRigBdStore|CanonicalExecBdStore)" -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Isolated restart-init smoke with a suspended scratch rig backed by bd/Dolt metadata.
- [x] Release gate: [`release-gates/ga-7z0hku-1-modernc-adoption-clean-gate.md`](release-gates/ga-7z0hku-1-modernc-adoption-clean-gate.md)
