### PR TITLE
fix(beads): remove direct mattn sqlite dependency

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1191,6 +1191,8 @@ func canonicalCoordStoreDir(scopeRoot string) (string, error) {
 
 func providerIsCoordStore(provider string) bool {
 	switch strings.TrimSpace(provider) {
+	// "sqlite" (pure-Go SQLite via modernc.org/sqlite; also accepts the "sqlite-cgo" alias).
+	// Both resolve to SQLiteStore; "sqlite-cgo" is preserved for operator compatibility.
 	case "sqlite", "sqlite-cgo":
 		return true
 	default:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/invopop/jsonschema v0.13.0
 	github.com/lib/pq v1.10.9
-	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/pb33f/libopenapi v0.36.1
 	github.com/pb33f/libopenapi-validator v0.13.4

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -1019,6 +1019,7 @@ func parseTimeString(s string) time.Time {
 	for _, layout := range []string{
 		time.RFC3339Nano,
 		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999 -0700 MST", // time.Time.String() — modernc default write format
 		"2006-01-02 15:04:05.999999999",
 		"2006-01-02 15:04:05",
 	} {

--- a/internal/beads/doltlite_read_store.go
+++ b/internal/beads/doltlite_read_store.go
@@ -1,4 +1,4 @@
-//go:build cgo && gascity_native_beads
+//go:build gascity_native_beads
 
 package beads
 
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite" // pure-Go SQLite driver, CGO_ENABLED=0 safe
 )
 
 // DoltliteReadStore serves hot read paths in-process for bd/doltlite stores.
@@ -131,7 +131,7 @@ func NewDoltliteReadStore(dir string, backing *BdStore) (*DoltliteReadStore, err
 	if _, err := os.Stat(dbPath); err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro&_busy_timeout=10000")
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_busy_timeout=10000")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/beads/doltlite_read_store_test.go
+++ b/internal/beads/doltlite_read_store_test.go
@@ -1,4 +1,4 @@
-//go:build cgo && gascity_native_beads
+//go:build gascity_native_beads
 
 package beads
 
@@ -651,7 +651,7 @@ func TestDoltliteReadStoreMetadataFilterFindsMatchBehindLimit(t *testing.T) {
 }
 
 func TestDoltliteMetadataFilterPredicatesMatchStringValues(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -808,7 +808,7 @@ func newTestDoltliteReadStore(t *testing.T) (*DoltliteReadStore, func()) {
 		t.Fatalf("mkdir doltlite dir: %v", err)
 	}
 	dbPath := filepath.Join(dbDir, "hq.db")
-	db, err := sql.Open("sqlite3", dbPath+"?_busy_timeout=10000")
+	db, err := sql.Open("sqlite", dbPath+"?_busy_timeout=10000")
 	if err != nil {
 		t.Fatalf("open doltlite fixture db: %v", err)
 	}
@@ -1170,7 +1170,7 @@ func openTestDoltliteWriter(t *testing.T, readDB *sql.DB) *sql.DB {
 		t.Fatal("main database path not found")
 	}
 
-	writer, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=rw&_busy_timeout=10000")
+	writer, err := sql.Open("sqlite", "file:"+dbPath+"?mode=rw&_busy_timeout=10000")
 	if err != nil {
 		t.Fatalf("open writable doltlite db: %v", err)
 	}

--- a/internal/beads/doltlite_read_store_test.go
+++ b/internal/beads/doltlite_read_store_test.go
@@ -411,7 +411,16 @@ func TestDoltliteReadStoreHandlesNullDescription(t *testing.T) {
 	}
 }
 
-func TestDoltliteReadStoreBeforeFiltersUseDriverNativeTimestamps(t *testing.T) {
+// TestDoltliteReadStoreBeforeFiltersRespectCutoff verifies that the CreatedBefore
+// and UpdatedBefore list filters return only rows whose timestamps precede the
+// cutoff. Timestamps are seeded in the store's canonical SQLite text format
+// (doltliteSQLiteTime) because the before-filters compare with SQLite julianday()
+// and parse with parseTimeString, both of which require ISO-8601 text. Binding a
+// raw time.Time instead delegates formatting to the SQL driver:
+// github.com/mattn/go-sqlite3 emitted ISO text, but modernc.org/sqlite emits
+// time.Time.String() (e.g. "2026-06-01 07:00:00 +0000 UTC"), which julianday()
+// cannot parse — the filter would then drop every row. See ga-p7ipsu.
+func TestDoltliteReadStoreBeforeFiltersRespectCutoff(t *testing.T) {
 	store, closeStore := newTestDoltliteReadStore(t)
 	defer closeStore()
 	writer := openTestDoltliteWriter(t, store.db)
@@ -430,7 +439,7 @@ func TestDoltliteReadStoreBeforeFiltersUseDriverNativeTimestamps(t *testing.T) {
 			id, title, status, issue_type, priority, created_at, updated_at,
 			assignee, description, design, acceptance_criteria, notes, metadata
 		) VALUES (?, ?, 'open', 'task', 2, ?, ?, 'rig/native-time', '', '', '', '', '{}')`,
-			issue.id, issue.id, issue.createdAt, issue.updatedAt); err != nil {
+			issue.id, issue.id, doltliteSQLiteTime(issue.createdAt), doltliteSQLiteTime(issue.updatedAt)); err != nil {
 			t.Fatalf("insert native timestamp issue %s: %v", issue.id, err)
 		}
 	}

--- a/release-gates/ga-mtgtv7-2-1-sqlite-cgo-cleanup-clean-gate.md
+++ b/release-gates/ga-mtgtv7-2-1-sqlite-cgo-cleanup-clean-gate.md
@@ -1,0 +1,98 @@
+# Release Gate: ga-mtgtv7.2.1
+
+Bead: ga-mtgtv7.2.1 - Deploy corrected SQLite CGO cleanup split unit from current main
+Branch: release/ga-mtgtv7-2-1-sqlite-cgo-cleanup-clean
+Base: origin/main @ fb0df821cb764d65f2b71611781e8c812a70c6c4
+Head before gate commit: 2c87ec2ee6a5adbc4896530966957d6ee4271772
+
+## Source Context
+
+- Architecture decision: ga-4q6sgc.1, Unit B - SQLite CGO migration.
+- Review bead: ga-jrcs88, closed with `REVIEWER VERDICT: PASS`.
+- Prior deploy bead ga-mtgtv7.2 failed because the acceptance gate was too strict for the retained `go.sum` checksum residue and the `cmd/gc/main.go` compatibility comment.
+- `docs/PROJECT_MANIFEST.md` is not present on this branch; this gate uses the active deployer criteria plus the bead acceptance criteria.
+
+## Gate Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | PASS | `bd show ga-jrcs88` contains `REVIEWER VERDICT: PASS`; reviewed source head was `396be53ce`, with follow-up commits included by the architecture split. |
+| 2 | Acceptance criteria met | PASS | Fresh branch cut from current `origin/main`; cherry-picked only `396be53ce`, `cb4d5140a`, and `717935724` in that order; diff is limited to `cmd/gc/main.go`, `go.mod`, `internal/beads/doltlite_read_store.go`, and `internal/beads/doltlite_read_store_test.go`. |
+| 3 | Tests pass | PASS | `CGO_ENABLED=0 go build ./...`, `go test ./internal/beads/ -count=1`, `make test-fast-parallel`, and `go vet ./...` all passed. |
+| 4 | No high-severity review findings open | PASS | Review notes contain non-blocking observations only; no HIGH findings are open. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short --branch` showed only `## release/ga-mtgtv7-2-1-sqlite-cgo-cleanup-clean...origin/main [ahead 3]`. Re-check after committing this file is required before push. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` succeeded and produced tree `2f230690b70d2fbfb2a6539d6b9f40a9605edc7e`. |
+| 7 | Single feature theme | PASS | Commit set touches one behavior: removing direct mattn/go-sqlite3 CGO usage from the doltlite read path while preserving the `sqlite-cgo` operator alias. No reaper, event, config, API/schema, generated dashboard, or benchmark files are present. |
+
+## Acceptance Evidence
+
+Cherry-picks:
+
+| Source SHA | New SHA | Purpose |
+|------------|---------|---------|
+| 396be53ce | 42759588a | Remove direct mattn/go-sqlite3 dependency and switch doltlite read store to modernc. |
+| cb4d5140a | b6a0a2572 | Seed before-filter test timestamps in canonical SQLite format. |
+| 717935724 | 2c87ec2ee | Add modernc `time.Time.String()` layout to `parseTimeString`. |
+
+Diff scope:
+
+```text
+cmd/gc/main.go
+go.mod
+internal/beads/doltlite_read_store.go
+internal/beads/doltlite_read_store_test.go
+```
+
+Forbidden paths absent:
+
+```text
+internal/benchmarks/
+internal/events/
+internal/config/
+docs/schema/
+internal/api/
+cmd/gc/dashboard/web/src/generated/
+```
+
+`cmd/gc/main.go` diff is limited to the `sqlite` / `sqlite-cgo` compatibility comment above `providerIsCoordStore`.
+
+## mattn/go-sqlite3 Evidence
+
+`github.com/mattn/go-sqlite3` is absent from `go.mod`.
+
+Direct import check:
+
+```text
+rg -n '^[[:space:]]*(import[[:space:]]+)?(_[[:space:]]+)?"github\.com/mattn/go-sqlite3"' --glob '*.go'
+```
+
+Result: no matches.
+
+Remaining `go.sum` entries:
+
+```text
+go.sum:799:github.com/mattn/go-sqlite3 v1.14.8 h1:gDp86IdQsN/xWjIEmr9MF6o9mpksUgh0fu+9ByFxzIU=
+go.sum:800:github.com/mattn/go-sqlite3 v1.14.8/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+```
+
+`go mod why -m github.com/mattn/go-sqlite3` shows the retained checksum residue is transitive/test-only through `github.com/steveyegge/beads` -> `github.com/dolthub/driver` -> `github.com/gocraft/dbr/v2.test` -> `github.com/mattn/go-sqlite3`.
+
+## Test Evidence
+
+Automated gates:
+
+```text
+CGO_ENABLED=0 go build ./...
+go test ./internal/beads/ -count=1
+make test-fast-parallel
+go vet ./...
+```
+
+Results:
+
+```text
+CGO_ENABLED=0 go build ./...: PASS
+go test ./internal/beads/ -count=1: ok github.com/gastownhall/gascity/internal/beads 4.430s
+make test-fast-parallel: All fast jobs passed
+go vet ./...: PASS
+```


### PR DESCRIPTION
## What this changes

The doltlite read store now uses the pure-Go `modernc.org/sqlite` driver instead of importing `github.com/mattn/go-sqlite3`, and its build tag no longer requires CGO. This lets `CGO_ENABLED=0 go build ./...` pass without carrying a direct mattn SQLite dependency through Gas City's code.

The existing `sqlite-cgo` coordstore provider alias remains accepted for operator compatibility, but it resolves to the same pure-Go SQLite path. The timestamp parsing and before-filter test fixtures were adjusted for modernc's `time.Time` formatting behavior.

## Review notes

- The functional changes are limited to `internal/beads/doltlite_read_store.go` and its tests.
- `cmd/gc/main.go` only documents that `sqlite` and `sqlite-cgo` are compatibility aliases for the pure-Go store.
- `github.com/mattn/go-sqlite3` is absent from `go.mod` and direct Go imports. `go.sum` still contains checksum residue through a transitive test dependency in `github.com/steveyegge/beads` / `github.com/gocraft/dbr/v2.test`.
- No worktree reaper, event, config, API/schema, dashboard, or benchmark files are included.

## Test plan

- [x] `CGO_ENABLED=0 go build ./...`
- [x] `go test ./internal/beads/ -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-mtgtv7-2-1-sqlite-cgo-cleanup-clean-gate.md`](release-gates/ga-mtgtv7-2-1-sqlite-cgo-cleanup-clean-gate.md)
