### PR TITLE
fix(dispatch): keep ready-query stderr out of JSON

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2933,6 +2933,71 @@ exit 1
 	}
 }
 
+func TestWorkflowServeControlReadyQueryKeepsSuccessfulBDStderrOutOfJSON(t *testing.T) {
+	query := workflowServeControlReadyQuery(
+		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
+		"gascity--control-dispatcher",
+	)
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "bd.log")
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$BD_LOG"
+case "$*" in
+  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+    printf '[{"id":"ga-control-ready"}]'
+    printf 'notice: refreshed export metadata\n' >&2
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	out, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
+		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"BD_LOG=" + logPath,
+		"GC_SESSION_NAME=gascity--control-dispatcher",
+		"GC_ALIAS=gascity/control-dispatcher",
+	})
+	if err != nil {
+		t.Fatalf("run workflow serve query: %v", err)
+	}
+	assertJSONEqual(t, out, `[{"id":"ga-control-ready"}]`)
+}
+
+func TestWorkflowServeControlReadyQueryFailsOnMalformedBDJSON(t *testing.T) {
+	query := workflowServeControlReadyQuery(
+		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
+		"gascity--control-dispatcher",
+	)
+	tmp := t.TempDir()
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
+set -eu
+case "$*" in
+  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+    printf 'not-json'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	_, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
+		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"GC_SESSION_NAME=gascity--control-dispatcher",
+		"GC_ALIAS=gascity/control-dispatcher",
+	})
+	if err == nil {
+		t.Fatal("workflow serve query succeeded with malformed bd JSON")
+	}
+}
+
 func TestWorkflowServeControlReadyQueryPrioritizesConfiguredRuntimeName(t *testing.T) {
 	query := workflowServeControlReadyQuery(
 		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -682,8 +682,8 @@ func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames .
 	}
 	query := queryPrefix + ` sh -c '` +
 		`set -e; ` +
-		`tmp=$(mktemp); seen="$tmp.seen"; : > "$seen"; trap "rm -f \"$tmp\" \"$seen\"" EXIT; ` +
-		`emit_ready() { r=$("$@" 2>&1) || { status=$?; printf "%s\n" "$r" >&2; return "$status"; }; [ -n "$r" ] && [ "$r" != "[]" ] && printf "%s\n" "$r" >> "$tmp"; return 0; }; ` +
+		`tmp=$(mktemp); seen="$tmp.seen"; err="$tmp.err"; : > "$seen"; trap "rm -f \"$tmp\" \"$seen\" \"$err\"" EXIT; ` +
+		`emit_ready() { r=$("$@" 2>"$err") || { status=$?; [ -n "$r" ] && printf "%s\n" "$r" >&2; cat "$err" >&2; return "$status"; }; [ -n "$r" ] && [ "$r" != "[]" ] && printf "%s\n" "$r" >> "$tmp"; return 0; }; ` +
 		`assignee_ready() { cand="$1"; [ -z "$cand" ] && return 0; if grep -Fxq "$cand" "$seen"; then return 0; fi; printf "%s\n" "$cand" >> "$seen"; ` +
 		`emit_ready bd --readonly --sandbox ready --include-ephemeral --assignee="$cand" --exclude-type=epic --json --limit=` + limit + `; }; ` +
 		`routed_ready() { route="$1"; [ -z "$route" ] && return 0; ` +
@@ -700,7 +700,7 @@ func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames .
 		`done; ` +
 		`routed_ready "$GC_CONTROL_TARGET"; ` +
 		`routed_ready "${GC_CONTROL_LEGACY_TARGET:-}"; ` +
-		`[ -s "$tmp" ] && jq -s "reduce add[] as \$item ([]; if any(.[]; .id == \$item.id) then . else . + [\$item] end)" "$tmp" || printf "[]"` + `'`
+		`if [ -s "$tmp" ]; then jq -s "reduce add[] as \$item ([]; if any(.[]; .id == \$item.id) then . else . + [\$item] end)" "$tmp"; else printf "[]"; fi` + `'`
 	return query
 }
 

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -368,6 +368,9 @@ func IsTransientControllerError(err error) bool {
 		"too many connections",
 		"lock wait timeout",
 		"deadlock found",
+		"database is locked",
+		"database table is locked",
+		"sqlite_busy",
 	}
 	for _, needle := range transientNeedles {
 		if strings.Contains(msg, needle) {

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -1384,6 +1384,8 @@ func TestIsTransientControllerError(t *testing.T) {
 		{name: "dolt invalid connection timeout", err: errors.New("failed to check for dependency cycle: invalid connection: i/o timeout"), want: true},
 		{name: "mysql lock timeout", err: errors.New("Error 1205 (HY000): lock wait timeout exceeded; try restarting transaction"), want: true},
 		{name: "mysql deadlock", err: errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction"), want: true},
+		{name: "sqlite locked", err: errors.New("listing sqlite ready beads: database is locked (5) (SQLITE_BUSY)"), want: true},
+		{name: "sqlite table locked", err: errors.New("listing sqlite ready beads: database table is locked"), want: true},
 		{name: "bad step spec", err: errors.New("deserializing step spec: invalid character 'n'"), want: false},
 	}
 

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -237,7 +237,7 @@ func TestClassifyRetryAttemptWithPostconditionsRequiresArtifact(t *testing.T) {
 	}
 }
 
-func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactSymlinkOutsideWorktree(t *testing.T) {
+func TestClassifyRetryAttemptWithPostconditionsRejectsRelativeArtifactSymlinkOutsideWorktree(t *testing.T) {
 	t.Parallel()
 
 	worktree := t.TempDir()
@@ -451,7 +451,7 @@ func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactOutsideWorktreeBef
 	}
 }
 
-func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactSymlinkOutsideWorktree(t *testing.T) {
+func TestClassifyRetryAttemptWithPostconditionsRejectsAbsoluteArtifactSymlinkOutsideWorktree(t *testing.T) {
 	t.Parallel()
 
 	worktree := t.TempDir()


### PR DESCRIPTION
Follow-up to #2959.

## Summary

PR #2959 was merged at the original contributor head before the adoption workflow finalized its approved maintainer fixup. This follow-up carries only the maintainer-side changes from the approved adoption review onto current `main`:

- keep successful `bd ready` stderr out of the JSON aggregation path while still surfacing stderr on failed probes
- let malformed successful `bd` JSON fail instead of being converted to `[]`
- add regression coverage for successful stderr and malformed JSON cases
- preserve the SQLite transient-controller classification added during review
- repair current-base test compilation by giving the relative and absolute artifact-symlink cases distinct test names

## Original PR

- Original PR: #2959
- Original title: `fix(dispatch): fail fast on control ready query errors`
- Original state at finalization: merged
- Configured workflow base: `main`
- Original GitHub base: `main`

## Verification

- `git diff --check origin/main..HEAD`
- `go test ./cmd/gc -run 'TestWorkflowServeControlReadyQueryKeepsSuccessfulBDStderrOutOfJSON|TestWorkflowServeControlReadyQueryFailsOnMalformedBDJSON|TestWorkflowServeControlReadyQueryFailsFastOnBDReadyError|TestWorkflowServeControlReadyQueryDeduplicatesAssigneeProbes|TestShellWorkQuery'`
- `go test ./internal/dispatch -run 'TestIsTransientControllerError|TestClassifyRetryAttemptWithPostconditionsRejectsRelativeArtifactSymlinkOutsideWorktree|TestClassifyRetryAttemptWithPostconditionsRejectsAbsoluteArtifactSymlinkOutsideWorktree'`
- pre-commit hook: `go vet ./...` and `scripts/test-local-parallel fast`
