### PR TITLE
test(dispatch): remove duplicate retry artifact test

### DIFF
--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -451,36 +451,6 @@ func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactOutsideWorktreeBef
 	}
 }
 
-func TestClassifyRetryAttemptWithPostconditionsRejectsArtifactSymlinkOutsideWorktree(t *testing.T) {
-	t.Parallel()
-
-	worktree := t.TempDir()
-	outsideDir := t.TempDir()
-	outsidePath := filepath.Join(outsideDir, "outside.md")
-	if err := os.WriteFile(outsidePath, []byte("review\n"), 0o644); err != nil {
-		t.Fatalf("write outside artifact: %v", err)
-	}
-	linkPath := filepath.Join(worktree, "review.md")
-	if err := os.Symlink(outsidePath, linkPath); err != nil {
-		t.Skipf("symlink unavailable: %v", err)
-	}
-
-	got, err := classifyRetryAttemptWithPostconditions(beads.NewMemStore(), beads.Bead{
-		Metadata: map[string]string{
-			"gc.outcome":           "pass",
-			"gc.required_artifact": linkPath,
-			"work_dir":             worktree,
-		},
-	}, ProcessOptions{})
-	if err != nil {
-		t.Fatalf("classifyRetryAttemptWithPostconditions error = %v, want nil", err)
-	}
-	want := retryEvalResult{Outcome: "transient", Reason: "required_artifact_outside_worktree"}
-	if got != want {
-		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v", got, want)
-	}
-}
-
 func TestClassifyRetryAttemptWithPostconditionsUsesRequiredArtifactStatOption(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- remove the second duplicate TestClassifyRetryAttemptWithPostconditionsRejectsArtifactSymlinkOutsideWorktree declaration in internal/dispatch/retry_test.go
- keep the existing symlink-outside-worktree coverage earlier in the file

## CI failure inspected
- CI run 26900213668 / Preflight static checks failed in golangci-lint typecheck because the test function was redeclared
- CI run 26900108053 failed with the same typecheck error, pointing to the shared main branch failure rather than a PR-specific regression

## Local validation
- go test ./internal/dispatch -run '^TestClassifyRetryAttemptWithPostconditions' -count=1
- go test ./internal/dispatch -count=1
- go vet ./internal/dispatch
- .githooks/pre-commit (lint-changed, generation, go vet ./..., make test-fast-parallel)