### PR TITLE
Update link to Tutorial 01 in quickstart.md

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -56,4 +56,4 @@ bd show <bead-id> --watch
 ```
 
 For a fuller walkthrough of the same path, continue to
-[Tutorial 01](/tutorials/01-cities-and-rigs).
+[Tutorial 01](/docs/tutorials/01-cities-and-rigs.md).


### PR DESCRIPTION
The link was broken found the tutorial in the sidebar

## Summary

The link on the quickstart point to the tutorial was broken

## Testing

- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [ ] Linked an issue, or explained why one is not needed
- [ ] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes
