### PR TITLE
fix(dolt): disable usage telemetry for managed sql-servers

### DIFF
--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -15,7 +15,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/pidutil"
 )
 
@@ -380,7 +382,7 @@ func startManagedDoltSQLServer(cityPath, configFile, logFilePath string, logFile
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
 	cmd.SysProcAttr = managedDoltSQLServerSysProcAttr()
-	cmd.Env = doltServerEnv(os.Environ())
+	cmd.Env = doltServerEnv(cityPath, os.Environ())
 	if err := cmd.Start(); err != nil {
 		return managedDoltStartedProcess{}, fmt.Errorf("start dolt sql-server: %w", err)
 	}
@@ -397,7 +399,7 @@ func startManagedDoltSQLServerWithTestWatchdog(cityPath, configFile, logFilePath
 		_ = os.Remove(disarmFile)
 		return managedDoltStartedProcess{}, err
 	}
-	args := []string{managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile}
+	args := []string{managedDoltTestWatchdogArg, managedDoltTestParentPIDString(), configFile, logFilePath, disarmFile, cityPath}
 	var parentPipeRead *os.File
 	var parentPipeWrite *os.File
 	if !managedDoltTestHasExternalParent() {
@@ -411,7 +413,7 @@ func startManagedDoltSQLServerWithTestWatchdog(cityPath, configFile, logFilePath
 	cmd := exec.Command(watchdogExecutable, args...)
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
-	cmd.Env = doltServerEnv(os.Environ())
+	cmd.Env = doltServerEnv(cityPath, os.Environ())
 	if parentPipeRead != nil {
 		cmd.ExtraFiles = []*os.File{parentPipeRead}
 	}
@@ -797,8 +799,8 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 		fmt.Fprintln(stderr, "managed dolt test watchdog is only available in managed Dolt test mode") //nolint:errcheck
 		return 2
 	}
-	if len(args) != 4 && len(args) != 5 {
-		fmt.Fprintf(stderr, "usage: %s <parent-pid> <config-file> <log-file> <disarm-file> [parent-pipe-fd]\n", managedDoltTestWatchdogArg) //nolint:errcheck
+	if len(args) < 4 || len(args) > 6 {
+		fmt.Fprintf(stderr, "usage: %s <parent-pid> <config-file> <log-file> <disarm-file> [city-path] [parent-pipe-fd]\n", managedDoltTestWatchdogArg) //nolint:errcheck
 		return 2
 	}
 	parentPID, err := strconv.Atoi(args[0])
@@ -809,9 +811,22 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 	configFile := args[1]
 	logFilePath := args[2]
 	disarmFile := args[3]
-	var parentDone <-chan struct{}
+	cityPath := ""
+	parentPipeArg := ""
 	if len(args) == 5 {
-		done, closeParentDone, err := managedDoltTestParentDone(args[4])
+		if _, parseErr := strconv.Atoi(args[4]); parseErr == nil {
+			parentPipeArg = args[4]
+		} else {
+			cityPath = args[4]
+		}
+	}
+	if len(args) == 6 {
+		cityPath = args[4]
+		parentPipeArg = args[5]
+	}
+	var parentDone <-chan struct{}
+	if parentPipeArg != "" {
+		done, closeParentDone, err := managedDoltTestParentDone(parentPipeArg)
 		if err != nil {
 			fmt.Fprintf(stderr, "watch parent pipe: %v\n", err) //nolint:errcheck
 			return 2
@@ -836,7 +851,7 @@ func runManagedDoltTestWatchdog(args []string, stdout, stderr *os.File) int {
 	// archive workers) outlive their parent and leak across test runs
 	// (gastownhall/gascity#2313 follow-up M3).
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Env = doltServerEnv(os.Environ())
+	cmd.Env = doltServerEnv(cityPath, os.Environ())
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(stderr, "start dolt sql-server: %v\n", err) //nolint:errcheck
 		return 1
@@ -906,15 +921,28 @@ func managedDoltTestParentDone(rawFD string) (<-chan struct{}, func(), error) {
 
 // doltServerEnv returns the environment applied to every managed dolt
 // sql-server we launch.
-func doltServerEnv(parent []string) []string {
-	env := append([]string(nil), parent...)
-	// Disable Dolt usage telemetry for managed servers. The `dolt send-metrics`
-	// event-flush reporter spawns transient `dolt send-metrics` processes that
-	// were observed burning 80-94% CPU on a busy managed city — a hidden cost
-	// dwarfing the actual query/commit load. This sits alongside the
-	// dolt_stats_enabled / auto_gc_enabled = OFF system variables already set in
-	// the managed dolt config (cmd_dolt_config.go): a managed Gas City server is
-	// not a telemetry source we want phoning home on the hot path.
-	env = append(env, "DOLT_DISABLE_EVENT_FLUSH=true")
+func doltServerEnv(cityPath string, parent []string) []string {
+	env := removeEnvKey(parent, "DOLT_DISABLE_EVENT_FLUSH")
+	if managedDoltDisableEventFlush(cityPath) {
+		// Disable Dolt usage telemetry for managed servers by default. The
+		// `dolt send-metrics` event-flush reporter spawns transient
+		// `dolt send-metrics` processes that were observed burning 80-94% CPU
+		// on a busy managed city. Operators can opt back in with
+		// `.beads/config.yaml`:
+		//   dolt:
+		//     disable-event-flush: false
+		env = append(env, "DOLT_DISABLE_EVENT_FLUSH=true")
+	}
 	return env
+}
+
+func managedDoltDisableEventFlush(cityPath string) bool {
+	if strings.TrimSpace(cityPath) == "" {
+		return true
+	}
+	cfg, _, err := contract.ReadDoltConfig(fsys.OSFS{}, filepath.Join(cityPath, ".beads", "config.yaml"))
+	if err != nil {
+		return true
+	}
+	return cfg.DisableEventFlushEnabled()
 }

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -907,5 +907,14 @@ func managedDoltTestParentDone(rawFD string) (<-chan struct{}, func(), error) {
 // doltServerEnv returns the environment applied to every managed dolt
 // sql-server we launch.
 func doltServerEnv(parent []string) []string {
-	return append([]string(nil), parent...)
+	env := append([]string(nil), parent...)
+	// Disable Dolt usage telemetry for managed servers. The `dolt send-metrics`
+	// event-flush reporter spawns transient `dolt send-metrics` processes that
+	// were observed burning 80-94% CPU on a busy managed city — a hidden cost
+	// dwarfing the actual query/commit load. This sits alongside the
+	// dolt_stats_enabled / auto_gc_enabled = OFF system variables already set in
+	// the managed dolt config (cmd_dolt_config.go): a managed Gas City server is
+	// not a telemetry source we want phoning home on the hot path.
+	env = append(env, "DOLT_DISABLE_EVENT_FLUSH=true")
+	return env
 }

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestDoltServerEnv_DoesNotInjectGCSchedulerDefault(t *testing.T) {
 	parent := []string{"PATH=/usr/bin", "HOME=/home/test"}
-	out := doltServerEnv(parent)
+	out := doltServerEnv("", parent)
 
 	for _, kv := range out {
 		if strings.HasPrefix(kv, "DOLT_GC_SCHEDULER=") {
@@ -43,7 +43,7 @@ func TestDoltServerEnv_DoesNotInjectGCSchedulerDefault(t *testing.T) {
 
 func TestDoltServerEnv_RespectsUserOverride(t *testing.T) {
 	parent := []string{"PATH=/usr/bin", "DOLT_GC_SCHEDULER=LOADAVG", "HOME=/home/test"}
-	out := doltServerEnv(parent)
+	out := doltServerEnv("", parent)
 
 	// User-provided value must be preserved exactly.
 	count := 0
@@ -62,7 +62,7 @@ func TestDoltServerEnv_RespectsUserOverride(t *testing.T) {
 
 func TestDoltServerEnv_PreservesEmptyUserValue(t *testing.T) {
 	parent := []string{"DOLT_GC_SCHEDULER="}
-	out := doltServerEnv(parent)
+	out := doltServerEnv("", parent)
 	// The explicit empty-value parent entry must be preserved exactly, and the
 	// managed-server telemetry disable must be appended.
 	var hasParent, hasTelemetryDisable bool
@@ -79,6 +79,59 @@ func TestDoltServerEnv_PreservesEmptyUserValue(t *testing.T) {
 	}
 	if !hasTelemetryDisable {
 		t.Fatalf("managed Dolt env should disable telemetry event flush: %v", out)
+	}
+}
+
+func TestDoltServerEnv_UsesDoltConfigObjectOptOut(t *testing.T) {
+	cityPath := t.TempDir()
+	beadsDir := filepath.Join(cityPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("dolt:\n  disable-event-flush: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := doltServerEnv(cityPath, []string{
+		"PATH=/usr/bin",
+		"DOLT_DISABLE_EVENT_FLUSH=true",
+	})
+
+	for _, kv := range out {
+		if strings.HasPrefix(kv, "DOLT_DISABLE_EVENT_FLUSH=") {
+			t.Fatalf("config opt-out should remove telemetry-disable env, got %v", out)
+		}
+	}
+}
+
+func TestDoltServerEnv_DefaultsDoltConfigObjectToDisableEventFlush(t *testing.T) {
+	cityPath := t.TempDir()
+	beadsDir := filepath.Join(cityPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("issue_prefix: gc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := doltServerEnv(cityPath, []string{
+		"PATH=/usr/bin",
+		"DOLT_DISABLE_EVENT_FLUSH=false",
+	})
+
+	count := 0
+	for _, kv := range out {
+		if kv == "DOLT_DISABLE_EVENT_FLUSH=true" {
+			count++
+		}
+		if kv == "DOLT_DISABLE_EVENT_FLUSH=false" {
+			t.Fatalf("default disable should replace inherited false env, got %v", out)
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one DOLT_DISABLE_EVENT_FLUSH=true entry, got %d in %v", count, out)
 	}
 }
 

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -63,8 +63,22 @@ func TestDoltServerEnv_RespectsUserOverride(t *testing.T) {
 func TestDoltServerEnv_PreservesEmptyUserValue(t *testing.T) {
 	parent := []string{"DOLT_GC_SCHEDULER="}
 	out := doltServerEnv(parent)
-	if len(out) != 1 || out[0] != "DOLT_GC_SCHEDULER=" {
+	// The explicit empty-value parent entry must be preserved exactly, and the
+	// managed-server telemetry disable must be appended.
+	var hasParent, hasTelemetryDisable bool
+	for _, kv := range out {
+		switch kv {
+		case "DOLT_GC_SCHEDULER=":
+			hasParent = true
+		case "DOLT_DISABLE_EVENT_FLUSH=true":
+			hasTelemetryDisable = true
+		}
+	}
+	if !hasParent {
 		t.Fatalf("explicit empty-value env not preserved: %v", out)
+	}
+	if !hasTelemetryDisable {
+		t.Fatalf("managed Dolt env should disable telemetry event flush: %v", out)
 	}
 }
 

--- a/engdocs/design/beads-dolt-contract-redesign.md
+++ b/engdocs/design/beads-dolt-contract-redesign.md
@@ -661,6 +661,7 @@ Canonical keys owned by GC:
 
 - `issue_prefix`
 - `dolt.auto-start`
+- `dolt.disable-event-flush` (serialized as `dolt: { disable-event-flush: ... }`)
 - `gc.endpoint_origin`
 - `gc.endpoint_status`
 - external-only:
@@ -700,6 +701,8 @@ interoperability.
 issue_prefix: gc
 issue-prefix: gc
 dolt.auto-start: false
+dolt:
+  disable-event-flush: true
 gc.endpoint_origin: managed_city
 gc.endpoint_status: verified
 ```
@@ -723,6 +726,8 @@ gc.endpoint_status: verified
 issue_prefix: gc
 issue-prefix: gc
 dolt.auto-start: false
+dolt:
+  disable-event-flush: true
 gc.endpoint_origin: city_canonical
 gc.endpoint_status: verified
 dolt.host: db.example.com
@@ -749,6 +754,8 @@ dolt.user: root
 issue_prefix: fe
 issue-prefix: fe
 dolt.auto-start: false
+dolt:
+  disable-event-flush: true
 gc.endpoint_origin: inherited_city
 gc.endpoint_status: verified
 ```
@@ -772,6 +779,8 @@ gc.endpoint_status: verified
 issue_prefix: fe
 issue-prefix: fe
 dolt.auto-start: false
+dolt:
+  disable-event-flush: true
 gc.endpoint_origin: inherited_city
 gc.endpoint_status: verified
 dolt.host: db.example.com
@@ -798,6 +807,8 @@ dolt.user: root
 issue_prefix: fe
 issue-prefix: fe
 dolt.auto-start: false
+dolt:
+  disable-event-flush: true
 gc.endpoint_origin: explicit
 gc.endpoint_status: unverified
 dolt.host: rig-db.example.com

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -43,6 +43,21 @@ type ConfigState struct {
 	DoltHost       string
 	DoltPort       string
 	DoltUser       string
+	Dolt           DoltConfig
+}
+
+// DoltConfig is the Dolt-specific subset of .beads/config.yaml that GC owns.
+type DoltConfig struct {
+	DisableEventFlush *bool
+}
+
+// DisableEventFlushEnabled returns whether managed Dolt launches should disable
+// Dolt's event-flush telemetry reporter. Missing config defaults to true.
+func (c DoltConfig) DisableEventFlushEnabled() bool {
+	if c.DisableEventFlush == nil {
+		return true
+	}
+	return *c.DisableEventFlush
 }
 
 // MetadataState is the canonical subset of .beads/metadata.json used by GC.
@@ -208,6 +223,24 @@ func ReadExportAuto(fs fsys.FS, path string) (value bool, ok bool, err error) {
 		return false, false, nil
 	}
 	return false, false, nil
+}
+
+// ReadDoltConfig reads the Dolt-specific GC config object from config.yaml.
+func ReadDoltConfig(fs fsys.FS, path string) (DoltConfig, bool, error) {
+	doc, err := readConfigDoc(fs, path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DoltConfig{}, false, nil
+		}
+		if data, readErr := fs.ReadFile(path); readErr == nil {
+			if cfg, ok := readDoltConfigFromData(data); ok {
+				return cfg, true, nil
+			}
+		}
+		return DoltConfig{}, false, err
+	}
+	cfg := readDoltConfigFromRoot(mappingRoot(doc))
+	return cfg, cfg.hasValues(), nil
 }
 
 // ReadEndpointStatus reads gc.endpoint_status when present.
@@ -437,6 +470,16 @@ func EnsureCanonicalConfig(fs fsys.FS, path string, state ConfigState) (bool, er
 		changed = setString(root, "issue-prefix", prefix) || changed
 	}
 	changed = setBool(root, "dolt.auto-start", false) || changed
+	doltConfig := readDoltConfigFromRoot(root)
+	if state.Dolt.DisableEventFlush != nil {
+		doltConfig.DisableEventFlush = state.Dolt.DisableEventFlush
+	}
+	if doltConfig.DisableEventFlush == nil {
+		enabled := true
+		doltConfig.DisableEventFlush = &enabled
+	}
+	changed = setNestedBool(root, "dolt", "disable-event-flush", *doltConfig.DisableEventFlush) || changed
+	changed = deleteKeys(root, "dolt.disable-event-flush", "dolt.disable_event_flush") || changed
 	// Managed beads are Dolt-backed; issues.jsonl auto-export is redundant and
 	// triggers a re-import cycle that stalls bd writes for minutes on large
 	// datasets. BD_EXPORT_AUTO env-var suppression only covers gc's own calls,
@@ -583,9 +626,11 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 	port := strings.TrimSpace(state.DoltPort)
 	user := strings.TrimSpace(state.DoltUser)
 	deletions := map[string]struct{}{
-		"dolt.password":    {},
-		"dolt_port":        {},
-		"dolt_server_port": {},
+		"dolt.password":            {},
+		"dolt.disable-event-flush": {},
+		"dolt.disable_event_flush": {},
+		"dolt_port":                {},
+		"dolt_server_port":         {},
 	}
 	if host != "" {
 		replacements["dolt.host"] = "dolt.host: " + host
@@ -663,6 +708,10 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		out = append(out, want)
 		changed = true
 	}
+	if !topLevelConfigKeyPresent(out, "dolt") {
+		out = append(out, "dolt:", "  disable-event-flush: "+boolString(doltDisableEventFlushFallbackValue(data, state)))
+		changed = true
+	}
 
 	if !changed {
 		return false, nil
@@ -735,6 +784,24 @@ func configStringValue(root *yaml.Node, keys ...string) (string, bool) {
 	return "", false
 }
 
+func configBoolValue(root *yaml.Node, keys ...string) (bool, bool) {
+	if value, ok := configStringValue(root, keys...); ok {
+		parsed, err := strconv.ParseBool(value)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return false, false
+}
+
+func nestedConfigBoolValue(root *yaml.Node, section string, keys ...string) (bool, bool) {
+	sectionNode := findValue(root, section)
+	if sectionNode == nil || sectionNode.Kind != yaml.MappingNode {
+		return false, false
+	}
+	return configBoolValue(sectionNode, keys...)
+}
+
 func scanConfigLineValue(fs fsys.FS, path string, prefixes ...string) (string, bool) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
@@ -759,6 +826,16 @@ func scanConfigLineValueFromData(data []byte, prefixes ...string) (string, bool)
 	return "", false
 }
 
+func scanConfigBoolValueFromData(data []byte, prefixes ...string) (bool, bool) {
+	if raw, ok := scanConfigLineValueFromData(data, prefixes...); ok {
+		parsed, err := strconv.ParseBool(raw)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return false, false
+}
+
 func readConfigStateFromData(data []byte) ConfigState {
 	return ConfigState{
 		IssuePrefix:    scanConfigValueFromData(data, "issue_prefix:", "issue-prefix:"),
@@ -767,6 +844,7 @@ func readConfigStateFromData(data []byte) ConfigState {
 		DoltHost:       scanConfigValueFromData(data, "dolt.host:"),
 		DoltPort:       scanConfigValueFromData(data, "dolt.port:"),
 		DoltUser:       scanConfigValueFromData(data, "dolt.user:"),
+		Dolt:           readDoltConfigFromDataOrEmpty(data),
 	}
 }
 
@@ -778,7 +856,47 @@ func readConfigStateFromRoot(root *yaml.Node) ConfigState {
 		DoltHost:       configValue(root, "dolt.host"),
 		DoltPort:       configValue(root, "dolt.port"),
 		DoltUser:       configValue(root, "dolt.user"),
+		Dolt:           readDoltConfigFromRoot(root),
 	}
+}
+
+func readDoltConfigFromRoot(root *yaml.Node) DoltConfig {
+	var cfg DoltConfig
+	if value, ok := nestedConfigBoolValue(root, "dolt", "disable-event-flush", "disable_event_flush"); ok {
+		cfg.DisableEventFlush = &value
+		return cfg
+	}
+	if value, ok := configBoolValue(root, "dolt.disable-event-flush", "dolt.disable_event_flush"); ok {
+		cfg.DisableEventFlush = &value
+	}
+	return cfg
+}
+
+func readDoltConfigFromData(data []byte) (DoltConfig, bool) {
+	cfg := readDoltConfigFromDataOrEmpty(data)
+	return cfg, cfg.hasValues()
+}
+
+func readDoltConfigFromDataOrEmpty(data []byte) DoltConfig {
+	var cfg DoltConfig
+	if value, ok := scanConfigBoolValueFromData(data, "dolt.disable-event-flush:", "dolt.disable_event_flush:"); ok {
+		cfg.DisableEventFlush = &value
+	}
+	return cfg
+}
+
+func (c DoltConfig) hasValues() bool {
+	return c.DisableEventFlush != nil
+}
+
+func doltDisableEventFlushFallbackValue(data []byte, state ConfigState) bool {
+	if state.Dolt.DisableEventFlush != nil {
+		return *state.Dolt.DisableEventFlush
+	}
+	if cfg, ok := readDoltConfigFromData(data); ok && cfg.DisableEventFlush != nil {
+		return *cfg.DisableEventFlush
+	}
+	return true
 }
 
 func configValue(root *yaml.Node, keys ...string) string {
@@ -807,6 +925,16 @@ func topLevelConfigLine(line string) (key, value string, ok bool) {
 		return "", "", false
 	}
 	return strings.TrimSpace(key), strings.TrimSpace(value), true
+}
+
+func topLevelConfigKeyPresent(lines []string, want string) bool {
+	for _, line := range lines {
+		key, _, ok := topLevelConfigLine(line)
+		if ok && key == want {
+			return true
+		}
+	}
+	return false
 }
 
 func endpointOriginValue(value string) EndpointOrigin {
@@ -841,8 +969,60 @@ func findValue(root *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
+func setNestedBool(root *yaml.Node, section, key string, value bool) bool {
+	sectionNode := findValue(root, section)
+	changed := false
+	if sectionNode == nil || sectionNode.Kind != yaml.MappingNode {
+		sectionNode = &yaml.Node{Kind: yaml.MappingNode}
+		changed = setMapping(root, section, sectionNode) || changed
+	}
+	return setBool(sectionNode, key, value) || changed
+}
+
+func setMapping(root *yaml.Node, key string, value *yaml.Node) bool {
+	if root == nil || root.Kind != yaml.MappingNode {
+		return false
+	}
+	out := make([]*yaml.Node, 0, len(root.Content))
+	seen := false
+	changed := false
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != key {
+			out = append(out, root.Content[i], root.Content[i+1])
+			continue
+		}
+		if seen {
+			changed = true
+			continue
+		}
+		seen = true
+		if root.Content[i+1] != value {
+			changed = true
+		}
+		out = append(out, root.Content[i], value)
+	}
+	if seen {
+		if changed {
+			root.Content = out
+		}
+		return changed
+	}
+	root.Content = append(root.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		value,
+	)
+	return true
+}
+
 func setString(root *yaml.Node, key, value string) bool {
 	return setScalar(root, key, value, "!!str")
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
 }
 
 func setBool(root *yaml.Node, key string, value bool) bool {

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -114,12 +114,21 @@ func TestEnsureCanonicalConfigCreatesManagedShape(t *testing.T) {
 		"issue-prefix: gc",
 		"dolt.auto-start: false",
 		"export.auto: false",
+		"dolt:",
+		"disable-event-flush: true",
 		"gc.endpoint_origin: managed_city",
 		"gc.endpoint_status: verified",
 	} {
 		if !strings.Contains(text, needle) {
 			t.Fatalf("config missing %q:\n%s", needle, text)
 		}
+	}
+	dolt, ok, err := ReadDoltConfig(fs, path)
+	if err != nil {
+		t.Fatalf("ReadDoltConfig() error = %v", err)
+	}
+	if !ok || dolt.DisableEventFlush == nil || !*dolt.DisableEventFlush {
+		t.Fatalf("ReadDoltConfig() = (%+v, %v), want disable-event-flush true", dolt, ok)
 	}
 	for _, forbidden := range []string{"dolt.host:", "dolt.port:", "dolt.user:"} {
 		if strings.Contains(text, forbidden) {
@@ -306,6 +315,87 @@ func TestEnsureCanonicalConfigForcesAutoExportOff(t *testing.T) {
 			t.Fatalf("config should force export.auto: false:\n%s", text)
 		}
 	})
+}
+
+func TestEnsureCanonicalConfigPreservesDoltDisableEventFlushOptOut(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue-prefix: gc",
+		"dolt:",
+		"  disable-event-flush: false",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalConfig() should report changes for endpoint normalization")
+	}
+
+	dolt, ok, err := ReadDoltConfig(fs, path)
+	if err != nil {
+		t.Fatalf("ReadDoltConfig() error = %v", err)
+	}
+	if !ok || dolt.DisableEventFlush == nil || *dolt.DisableEventFlush {
+		t.Fatalf("ReadDoltConfig() = (%+v, %v), want explicit disable-event-flush false", dolt, ok)
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "dolt:\n  disable-event-flush: false") {
+		t.Fatalf("config should preserve nested Dolt opt-out:\n%s", text)
+	}
+	if strings.Contains(text, "dolt.disable-event-flush") {
+		t.Fatalf("config should not write flat Dolt telemetry key:\n%s", text)
+	}
+}
+
+func TestEnsureCanonicalConfigCanonicalizesFlatDoltDisableEventFlush(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue-prefix: gc",
+		"dolt.disable-event-flush: false",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "dolt:\n  disable-event-flush: false") {
+		t.Fatalf("config should move flat Dolt telemetry setting into object:\n%s", text)
+	}
+	if strings.Contains(text, "dolt.disable-event-flush") {
+		t.Fatalf("config should scrub flat Dolt telemetry setting:\n%s", text)
+	}
 }
 
 func TestEnsureCanonicalConfigWritesExternalFields(t *testing.T) {
@@ -873,6 +963,86 @@ func TestReadExportAutoOnMissingFileReturnsAbsent(t *testing.T) {
 	}
 	if gotValue {
 		t.Errorf("ReadExportAuto() value = true, want false for missing file")
+	}
+}
+
+func TestReadDoltConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantValue bool
+		wantOK    bool
+	}{
+		{
+			name:      "nested explicit false",
+			yaml:      "issue_prefix: zz\ndolt:\n  disable-event-flush: false\n",
+			wantValue: false,
+			wantOK:    true,
+		},
+		{
+			name:      "nested explicit true",
+			yaml:      "issue_prefix: zz\ndolt:\n  disable-event-flush: true\n",
+			wantValue: true,
+			wantOK:    true,
+		},
+		{
+			name:      "flat compatibility false",
+			yaml:      "issue_prefix: zz\ndolt.disable-event-flush: false\n",
+			wantValue: false,
+			wantOK:    true,
+		},
+		{
+			name:      "absent",
+			yaml:      "issue_prefix: zz\n",
+			wantValue: true,
+			wantOK:    false,
+		},
+		{
+			name:      "garbage value returns absent",
+			yaml:      "issue_prefix: zz\ndolt:\n  disable-event-flush: maybe\n",
+			wantValue: true,
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := fsys.OSFS{}
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			if err := fs.WriteFile(path, []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, _, err := ReadDoltConfig(fs, path)
+			if err != nil {
+				t.Fatalf("ReadDoltConfig() error = %v", err)
+			}
+			gotOK := got.DisableEventFlush != nil
+			if gotOK != tt.wantOK {
+				t.Errorf("ReadDoltConfig().DisableEventFlush present = %v, want %v", gotOK, tt.wantOK)
+			}
+			if got.DisableEventFlushEnabled() != tt.wantValue {
+				t.Errorf("ReadDoltConfig().DisableEventFlushEnabled() = %v, want %v", got.DisableEventFlushEnabled(), tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestReadDoltConfigDefaultsDisableEventFlushOnMissingFile(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing.yaml")
+
+	got, ok, err := ReadDoltConfig(fs, path)
+	if err != nil {
+		t.Fatalf("ReadDoltConfig() error = %v, want nil for missing file", err)
+	}
+	if ok {
+		t.Errorf("ReadDoltConfig() ok = true, want false for missing file")
+	}
+	if !got.DisableEventFlushEnabled() {
+		t.Errorf("ReadDoltConfig().DisableEventFlushEnabled() = false, want default true")
 	}
 }
 


### PR DESCRIPTION
## Problem

Dolt's usage telemetry reporter (`dolt send-metrics`, default `grpc` output to `eventsapi.dolthub.com`) spawns a transient process after commands flush events. On a busy managed city — where bd query/commit commands run constantly via the sql-server + CLI — these flush processes were observed burning **80-94% CPU** (transient `dolt send-metrics` processes, parent launchd), a hidden cost dwarfing the actual query/commit load and a large part of what reads as "Dolt pegging the machine."

The cost is amplified when outbound telemetry is firewall-blocked (e.g. Little Snitch): the gRPC client retries/backs off on the blocked connection so the `send-metrics` process spins instead of exiting quickly, and dolt keeps spawning new ones for each event batch — they pile up. Blocking telemetry at the firewall is paradoxically *worse* than letting it through; the right fix is to not emit it.

## Fix

Set `DOLT_DISABLE_EVENT_FLUSH=true` in `doltServerEnv` (cmd/gc/dolt_start_managed.go) — the single env path applied to every managed dolt sql-server launch (and its watchdog). This sits alongside the `dolt_stats_enabled` / `dolt_auto_gc_enabled = OFF` system variables already set in the managed config (cmd_dolt_config.go): a managed Gas City server is not a telemetry source we want phoning home on the hot path.

## Measured

On a live multi-rig city, eliminating `send-metrics` (combined with idle-connection reaping #3022 and a periodic journal GC) took the Dolt server from 100-180% CPU with intermittent 200%+ bursts down to single digits. `send-metrics` processes stayed at 0 after the change.

## Scope

One function, one env var. No functional change — telemetry is opt-out anonymous usage stats; nothing about data, versioning, or sync is affected.