### PR TITLE
fix(beads): invalidate stale cached rows after live list

### DIFF
--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -174,6 +174,51 @@ func TestCachingStoreListLiveBypassesCache(t *testing.T) {
 	}
 }
 
+func TestCachingStoreListLiveInvalidatesCachedRowsMissingFromBacking(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{
+		Title:    "work",
+		Assignee: "worker",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if err := backing.Close(bead.ID); err != nil {
+		t.Fatalf("Close backing: %v", err)
+	}
+
+	live, err := cache.List(ListQuery{Status: "open", Assignee: "worker", Live: true})
+	if err != nil {
+		t.Fatalf("List live: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("Live List(open) = %+v, want closed bead omitted", live)
+	}
+
+	cached, err := cache.Handles().Cached.List(ListQuery{Status: "open", Assignee: "worker"})
+	if err != nil {
+		t.Fatalf("Cached List(open): %v", err)
+	}
+	if len(cached) != 0 {
+		t.Fatalf("Cached List(open) after live refresh = %+v, want stale bead invalidated", cached)
+	}
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("Get status after live refresh = %q, want closed", got.Status)
+	}
+}
+
 func TestCachingStoreHandlesCachedReadsShareFullPrime(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -132,6 +132,8 @@ func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
 func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, items []Bead) []Bead {
 	refreshedParents := make(map[string]Bead)
 	removedParents := make(map[string]struct{})
+	refreshedLiveMissing := make(map[string]Bead)
+	removedLiveMissing := make(map[string]struct{})
 	for _, id := range c.staleParentCacheIDs(query.ParentID, items) {
 		fresh, err := c.backing.Get(id)
 		switch {
@@ -143,7 +145,19 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 			c.recordProblem("refresh parent cache during list", fmt.Errorf("%s: %w", id, err))
 		}
 	}
-	if len(items) == 0 && len(refreshedParents) == 0 && len(removedParents) == 0 {
+	for _, id := range c.staleLiveCacheIDs(query, items) {
+		fresh, err := c.backing.Get(id)
+		switch {
+		case err == nil:
+			refreshedLiveMissing[id] = cloneBead(fresh)
+		case errors.Is(err, ErrNotFound):
+			removedLiveMissing[id] = struct{}{}
+		default:
+			c.recordProblem("refresh live cache during list", fmt.Errorf("%s: %w", id, err))
+		}
+	}
+	if len(items) == 0 && len(refreshedParents) == 0 && len(removedParents) == 0 &&
+		len(refreshedLiveMissing) == 0 && len(removedLiveMissing) == 0 {
 		return items
 	}
 	c.mu.Lock()
@@ -222,6 +236,30 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 		delete(c.beadSeq, id)
 		delete(c.localBeadAt, id)
 	}
+	for id, bead := range refreshedLiveMissing {
+		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
+			continue
+		}
+		c.beads[id] = bead
+		if beadCarriesDependencyFields(bead) {
+			c.deps[id] = depsFromBeadFields(bead)
+		}
+		delete(c.dirty, id)
+		delete(c.deletedSeq, id)
+		delete(c.beadSeq, id)
+		delete(c.localBeadAt, id)
+	}
+	for id := range removedLiveMissing {
+		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
+			continue
+		}
+		delete(c.beads, id)
+		delete(c.deps, id)
+		delete(c.dirty, id)
+		delete(c.deletedSeq, id)
+		delete(c.beadSeq, id)
+		delete(c.localBeadAt, id)
+	}
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	return refreshed
@@ -249,6 +287,35 @@ func (c *CachingStore) staleParentCacheIDs(parentID string, fresh []Bead) []stri
 			continue
 		}
 		if _, ok := freshIDs[id]; ok {
+			continue
+		}
+		stale = append(stale, id)
+	}
+	return stale
+}
+
+func (c *CachingStore) staleLiveCacheIDs(query ListQuery, fresh []Bead) []string {
+	if !query.Live || query.Limit > 0 || query.IncludesClosed() {
+		return nil
+	}
+
+	freshIDs := make(map[string]struct{}, len(fresh))
+	for _, item := range fresh {
+		freshIDs[item.ID] = struct{}{}
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return nil
+	}
+
+	var stale []string
+	for id, bead := range c.beads {
+		if _, ok := freshIDs[id]; ok {
+			continue
+		}
+		if !query.Matches(bead) {
 			continue
 		}
 		stale = append(stale, id)

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -240,17 +240,25 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
 			continue
 		}
+		if _, keep := c.recentLocalBeadConflictLocked(id, bead, now, false); keep {
+			continue
+		}
 		c.beads[id] = bead
 		if beadCarriesDependencyFields(bead) {
 			c.deps[id] = depsFromBeadFields(bead)
 		}
 		delete(c.dirty, id)
 		delete(c.deletedSeq, id)
-		delete(c.beadSeq, id)
-		delete(c.localBeadAt, id)
+		if !recentLocalMutation(c.localBeadAt[id], now) {
+			delete(c.beadSeq, id)
+			delete(c.localBeadAt, id)
+		}
 	}
 	for id := range removedLiveMissing {
 		if c.deletedSeq[id] > startSeq || c.beadSeq[id] > startSeq {
+			continue
+		}
+		if current, ok := c.beads[id]; ok && current.Status != "closed" && recentLocalMutation(c.localBeadAt[id], now) {
 			continue
 		}
 		delete(c.beads, id)

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -859,6 +859,117 @@ func TestCachingStoreLiveListDoesNotOverwriteRecentLocalWriteWithStaleBackingRow
 	}
 }
 
+func TestCachingStoreLiveListDoesNotOverwriteRecentLocalWriteWhenBackingOmitsRow(t *testing.T) {
+	mem := beads.NewMemStore()
+	original, err := mem.Create(beads.Bead{
+		Title:    "claimed work",
+		Assignee: "worker",
+		Status:   "open",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	store := &omittingLiveListGetStore{Store: mem}
+	cs := beads.NewCachingStoreForTest(store, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	status := "in_progress"
+	if err := cs.Update(original.ID, beads.UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update local status: %v", err)
+	}
+	store.omitLiveListOnce()
+	store.returnStaleGetOnce(original)
+
+	if _, err := cs.List(beads.ListQuery{Status: "in_progress", Assignee: "worker", Live: true}); err != nil {
+		t.Fatalf("Live list refresh: %v", err)
+	}
+	cs.ApplyEvent("bead.updated", json.RawMessage(`{"id":"`+original.ID+`","status":"open"}`))
+
+	got, err := cs.Get(original.ID)
+	if err != nil {
+		t.Fatalf("Get after omitted live row: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status after omitted live row = %q, want in_progress", got.Status)
+	}
+}
+
+func TestCachingStoreLiveListRemovesDeletedRowsMissingFromBacking(t *testing.T) {
+	mem := beads.NewMemStore()
+	original, err := mem.Create(beads.Bead{
+		Title:    "delete me",
+		Assignee: "worker",
+		Status:   "open",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cs := beads.NewCachingStoreForTest(mem, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if err := mem.Delete(original.ID); err != nil {
+		t.Fatalf("Delete backing: %v", err)
+	}
+
+	live, err := cs.List(beads.ListQuery{Status: "open", Assignee: "worker", Live: true})
+	if err != nil {
+		t.Fatalf("Live list refresh: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("live list after backing delete = %+v, want no rows", live)
+	}
+
+	cached, err := cs.Handles().Cached.List(beads.ListQuery{Status: "open", Assignee: "worker"})
+	if err != nil {
+		t.Fatalf("Cached List after backing delete: %v", err)
+	}
+	if len(cached) != 0 {
+		t.Fatalf("cached list after backing delete = %+v, want no rows", cached)
+	}
+	if got, err := cs.Get(original.ID); !errors.Is(err, beads.ErrNotFound) {
+		t.Fatalf("Get after backing delete = (%+v, %v), want ErrNotFound", got, err)
+	}
+}
+
+func TestCachingStoreLiveListDoesNotRemoveRecentLocalWriteWhenBackingReportsNotFound(t *testing.T) {
+	mem := beads.NewMemStore()
+	original, err := mem.Create(beads.Bead{
+		Title:    "claimed work",
+		Assignee: "worker",
+		Status:   "open",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	store := &omittingLiveListGetStore{Store: mem}
+	cs := beads.NewCachingStoreForTest(store, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	status := "in_progress"
+	if err := cs.Update(original.ID, beads.UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update local status: %v", err)
+	}
+	store.omitLiveListOnce()
+	store.returnNotFoundGetOnce(original.ID)
+
+	if _, err := cs.List(beads.ListQuery{Status: "in_progress", Assignee: "worker", Live: true}); err != nil {
+		t.Fatalf("Live list refresh: %v", err)
+	}
+
+	cached, err := cs.Handles().Cached.List(beads.ListQuery{Status: "in_progress", Assignee: "worker"})
+	if err != nil {
+		t.Fatalf("Cached List after omitted live row: %v", err)
+	}
+	if len(cached) != 1 || cached[0].ID != original.ID {
+		t.Fatalf("cached list after omitted live row = %+v, want locally updated row %s", cached, original.ID)
+	}
+}
+
 func TestCachingStoreUpdateDoesNotDuplicateAuthoritativeLabels(t *testing.T) {
 	mem := beads.NewMemStore()
 	original, err := mem.Create(beads.Bead{
@@ -1009,6 +1120,64 @@ func (s *staleListAfterUpdateStore) List(query beads.ListQuery) ([]beads.Bead, e
 	}
 	s.mu.Unlock()
 	return s.Store.List(query)
+}
+
+type omittingLiveListGetStore struct {
+	beads.Store
+	mu               sync.Mutex
+	omitLiveCount    int
+	staleGet         beads.Bead
+	staleGetCount    int
+	notFoundGetID    string
+	notFoundGetCount int
+}
+
+func (s *omittingLiveListGetStore) omitLiveListOnce() {
+	s.mu.Lock()
+	s.omitLiveCount = 1
+	s.mu.Unlock()
+}
+
+func (s *omittingLiveListGetStore) returnStaleGetOnce(stale beads.Bead) {
+	s.mu.Lock()
+	s.staleGet = stale
+	s.staleGetCount = 1
+	s.mu.Unlock()
+}
+
+func (s *omittingLiveListGetStore) returnNotFoundGetOnce(id string) {
+	s.mu.Lock()
+	s.notFoundGetID = id
+	s.notFoundGetCount = 1
+	s.mu.Unlock()
+}
+
+func (s *omittingLiveListGetStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.mu.Lock()
+	if s.omitLiveCount > 0 && query.Live {
+		s.omitLiveCount--
+		s.mu.Unlock()
+		return nil, nil
+	}
+	s.mu.Unlock()
+	return s.Store.List(query)
+}
+
+func (s *omittingLiveListGetStore) Get(id string) (beads.Bead, error) {
+	s.mu.Lock()
+	if s.staleGetCount > 0 && id == s.staleGet.ID {
+		s.staleGetCount--
+		stale := s.staleGet
+		s.mu.Unlock()
+		return stale, nil
+	}
+	if s.notFoundGetCount > 0 && id == s.notFoundGetID {
+		s.notFoundGetCount--
+		s.mu.Unlock()
+		return beads.Bead{}, beads.ErrNotFound
+	}
+	s.mu.Unlock()
+	return s.Store.Get(id)
 }
 
 type nonBdCachingBacking struct {


### PR DESCRIPTION
Follow-up to #2953.

This is the maintainer adoption merge surface for the closed, unmerged original PR:

- Original PR: https://github.com/gastownhall/gascity/pull/2953
- Original title: fix(beads): invalidate stale cached rows after live list
- Original state: CLOSED, unmerged
- Configured workflow base: main
- Original GitHub base: main
- Base refresh: rebased cleanly from 381586593e7fa44962fded41b52ded6e4fce4e2b to a1962d2ad9f0ec572f837d9a5c704cb80b48d298 with stable patch-id preserved

The contributor change fixes stale cached bead rows after successful unbounded active `Live` list queries. The maintainer fixup keeps recent local cache mutations from being overwritten or removed while reconciling live-missing rows.

Contributor commits are preserved in this follow-up branch, with one maintainer fixup added by the adoption workflow.

Local verification on the refreshed head:

- `go test ./internal/beads -count=1`
- `go vet ./internal/beads`
- `git diff --check refs/adopt-pr/ga-ptsr9/upstream-base..HEAD`

Adopted via `/adopt-pr` workflow from #2953.