### PR TITLE
fix(dolt): scope projected beads credentials

### DIFF
--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2857,6 +2857,40 @@ dolt.user: canonical-user
 	}
 }
 
+func TestBdRuntimeEnvIgnoresAmbientBeadsPasswordWithoutScopedSecret(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "")
+	t.Setenv("GC_DOLT_PORT", "")
+	t.Setenv("GC_DOLT_USER", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "external-rig-secret")
+	t.Setenv("BEADS_CREDENTIALS_FILE", "")
+
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: city_canonical
+gc.endpoint_status: verified
+dolt.auto-start: false
+dolt.host: city-db.example.com
+dolt.port: 3307
+dolt.user: canonical-user
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := mustBdRuntimeEnv(t, cityPath)
+	if got := env["GC_DOLT_PASSWORD"]; got != "" {
+		t.Fatalf("GC_DOLT_PASSWORD = %q, want empty without scoped secret", got)
+	}
+	if got := env["BEADS_DOLT_PASSWORD"]; got != "" {
+		t.Fatalf("BEADS_DOLT_PASSWORD = %q, want empty without scoped secret", got)
+	}
+}
+
 func TestSessionDoltEnvInheritedRigUsesCityStorePassword(t *testing.T) {
 	t.Setenv("GC_DOLT_HOST", "")
 	t.Setenv("GC_DOLT_PORT", "")

--- a/cmd/gc/dolt_auth.go
+++ b/cmd/gc/dolt_auth.go
@@ -10,7 +10,7 @@ func applyResolvedDoltAuthEnv(env map[string]string, authScopeRoot, fallbackUser
 	if env == nil {
 		return
 	}
-	auth := doltauth.ResolveFromEnv(authScopeRoot, fallbackUser, env)
+	auth := doltauth.ResolveScopedFromEnv(authScopeRoot, fallbackUser, env)
 	applyResolvedAuthValue(env, "GC_DOLT_USER", auth.User)
 	applyResolvedAuthValue(env, "GC_DOLT_PASSWORD", auth.Password)
 	applyResolvedAuthValue(env, "BEADS_CREDENTIALS_FILE", auth.CredentialsFileOverride)

--- a/internal/doltauth/auth.go
+++ b/internal/doltauth/auth.go
@@ -46,6 +46,18 @@ func Resolve(scopeRoot, fallbackUser, host string, port int) Resolved {
 // Projected BEADS_DOLT_PASSWORD is treated like an already-resolved fallback;
 // callers that switch auth scopes must clear stale projected passwords first.
 func ResolveFromEnv(scopeRoot, fallbackUser string, env map[string]string) Resolved {
+	return resolveFromEnv(scopeRoot, fallbackUser, env, true)
+}
+
+// ResolveScopedFromEnv returns effective Dolt auth for a GC-selected scope.
+// Unlike ResolveFromEnv, it does not fall back to ambient BEADS_DOLT_PASSWORD;
+// scoped GC projections must not let one external rig password contaminate
+// another scope's managed city/HQ connection.
+func ResolveScopedFromEnv(scopeRoot, fallbackUser string, env map[string]string) Resolved {
+	return resolveFromEnv(scopeRoot, fallbackUser, env, false)
+}
+
+func resolveFromEnv(scopeRoot, fallbackUser string, env map[string]string, allowAmbientBeadsPassword bool) Resolved {
 	host := strings.TrimSpace(env["GC_DOLT_HOST"])
 	port, ok := projectedPort(env)
 	if host == "" && ok {
@@ -61,7 +73,7 @@ func ResolveFromEnv(scopeRoot, fallbackUser string, env map[string]string) Resol
 	envPass := strings.TrimSpace(env["BEADS_DOLT_PASSWORD"])
 	return Resolved{
 		User:                    resolveUser(fallbackUser),
-		Password:                resolvePasswordWithEnv(envPass, scopeRoot, host, port, overridePath),
+		Password:                resolvePasswordWithEnv(envPass, scopeRoot, host, port, overridePath, allowAmbientBeadsPassword),
 		CredentialsFileOverride: overridePath,
 	}
 }
@@ -74,10 +86,10 @@ func resolveUser(fallbackUser string) string {
 }
 
 func resolvePassword(scopeRoot, host string, port int, overridePath string) string {
-	return resolvePasswordWithEnv("", scopeRoot, host, port, overridePath)
+	return resolvePasswordWithEnv("", scopeRoot, host, port, overridePath, true)
 }
 
-func resolvePasswordWithEnv(envPass, scopeRoot, host string, port int, overridePath string) string {
+func resolvePasswordWithEnv(envPass, scopeRoot, host string, port int, overridePath string, allowAmbientBeadsPassword bool) string {
 	if pass := strings.TrimSpace(os.Getenv("GC_DOLT_PASSWORD")); pass != "" {
 		return pass
 	}
@@ -87,8 +99,10 @@ func resolvePasswordWithEnv(envPass, scopeRoot, host string, port int, overrideP
 	if envPass != "" {
 		return envPass
 	}
-	if pass := strings.TrimSpace(os.Getenv("BEADS_DOLT_PASSWORD")); pass != "" {
-		return pass
+	if allowAmbientBeadsPassword {
+		if pass := strings.TrimSpace(os.Getenv("BEADS_DOLT_PASSWORD")); pass != "" {
+			return pass
+		}
 	}
 	host = strings.TrimSpace(host)
 	if host == "" || port <= 0 {

--- a/internal/doltauth/auth_test.go
+++ b/internal/doltauth/auth_test.go
@@ -123,6 +123,19 @@ func TestResolveFromEnvUsesAmbientBeadsDoltPassword(t *testing.T) {
 	}
 }
 
+func TestResolveScopedFromEnvIgnoresAmbientBeadsDoltPassword(t *testing.T) {
+	scopeRoot := t.TempDir()
+	t.Setenv("GC_DOLT_USER", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "operator-secret")
+	t.Setenv("BEADS_CREDENTIALS_FILE", "")
+
+	resolved := ResolveScopedFromEnv(scopeRoot, "fallback-user", map[string]string{})
+	if resolved.Password != "" {
+		t.Fatalf("Password = %q, want empty without scoped secret", resolved.Password)
+	}
+}
+
 func TestResolveFromEnvUsesProjectedBeadsDoltPassword(t *testing.T) {
 	scopeRoot := t.TempDir()
 	t.Setenv("GC_DOLT_USER", "")

--- a/test/integration/tutorial_path_test.go
+++ b/test/integration/tutorial_path_test.go
@@ -39,6 +39,7 @@ func TestCleanInstallTutorialPath(t *testing.T) {
 	env := newIsolatedCommandEnv(t, true)
 	cityName := uniqueCityName()
 	cityDir := filepath.Join(t.TempDir(), cityName)
+	registerIntegrationDoltSQLServerCleanup(t, cityDir)
 
 	// --- Step 1: gc init (clean install, no --file) ---
 	out, err := runGCDoltWithEnv(env, "", "init",


### PR DESCRIPTION
## Summary

- Scope Gas City-projected Dolt auth so an ambient `BEADS_DOLT_PASSWORD` from one Beads scope does not leak into another GC-selected scope.
- Add regressions covering scoped auth resolution and `bd` runtime env projection without a scoped secret.
- Keep the endpoint metadata contract unchanged: `.beads/config.yaml` remains the canonical endpoint source of truth.

## Testing

- [ ] `make check`
  - Ran in Docker `golang:1.26.3` with host certs and `libicu-dev`.
  - `golangci-lint fmt`, `golangci-lint run`, `go vet`, and `scripts/check-routed-test-rows.sh` passed.
  - Fast test phase failed at `TestRunProviderOpKillsProcessGroupOnTimeout` in `./cmd/gc`; the same test also fails on pristine `origin/main` under the same Docker profile with `provider child pid ... survived provider op cancellation`, so this does not appear branch-introduced.
- [ ] `make check-docs` if docs, navigation, or links changed
  - Not run; no docs, navigation, or link files changed.
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed
  - Not run; this is a narrow auth/env projection change with focused unit coverage, and the branch is currently blocked by the baseline-reproduced fast-suite process-group test above.

Additional focused validation:

- `make build` passed in Docker `golang:1.26.3` with host certs and `libicu-dev`.
- `git diff --check origin/main...HEAD` passed.
- gofmt check passed for `cmd/gc/bd_env_test.go`, `cmd/gc/dolt_auth.go`, `internal/doltauth/auth.go`, and `internal/doltauth/auth_test.go`.
- `go test ./internal/doltauth -count=1` passed.
- `GC_FAST_UNIT=1 go test ./cmd/gc` with scoped auth/recovery-related test regex passed.

## Checklist

- [x] Linked an issue, or explained why one is not needed
  - Internal tracking: `codex-prompts-lau.17`.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
  - Not applicable; no user-facing docs changed.
- [x] Called out breaking changes or migration notes
  - No breaking changes expected.
