### PR TITLE
fix: prefer current agent provider for worker runtime

### DIFF
--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -544,7 +544,7 @@ func resolvedWorkerRuntimeWithConfigAndMetadata(cityPath string, cfg *config.Cit
 	return &worker.ResolvedRuntime{
 		Command:    command,
 		WorkDir:    workDir,
-		Provider:   firstNonEmptyGCString(info.Provider, resolved.Name),
+		Provider:   resolvedWorkerRuntimeProviderLabel(resolved, transport, info),
 		SessionEnv: sessionEnv,
 		Hints: runtime.Config{
 			WorkDir:                workDir,
@@ -565,6 +565,13 @@ func resolvedWorkerRuntimeWithConfigAndMetadata(cityPath string, cfg *config.Cit
 			SessionIDFlag: resolved.SessionIDFlag,
 		},
 	}, nil
+}
+
+func resolvedWorkerRuntimeProviderLabel(resolved *config.ResolvedProvider, transport string, info session.Info) string {
+	if strings.TrimSpace(configuredWorkerRuntimeCommand(resolved, transport)) != "" {
+		return firstNonEmptyGCString(resolved.Name, info.Provider)
+	}
+	return firstNonEmptyGCString(info.Provider, resolved.Name)
 }
 
 func resolvedWorkerRuntimeCommandForTransport(cityPath string, resolved *config.ResolvedProvider, transport, storedCommand, fallbackProvider string, metadata map[string]string) string {

--- a/cmd/gc/worker_handle_test.go
+++ b/cmd/gc/worker_handle_test.go
@@ -895,6 +895,43 @@ func TestResolveWorkerRuntimeProviderWithConfigMetadataIdentifiesProviderSession
 	}
 }
 
+func TestResolvedWorkerRuntimeWithConfigUsesCurrentAgentProviderOverStaleSessionProvider(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "myrig", Provider: "agent-provider"},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"stale-provider": {
+				Command: "true",
+				Args:    []string{"stale"},
+			},
+			"agent-provider": {
+				Command: "true",
+				Args:    []string{"agent"},
+			},
+		},
+	}
+
+	resolved, err := resolvedWorkerRuntimeWithConfigAndMetadata("", cfg, session.Info{
+		Template: "myrig/worker",
+		Provider: "stale-provider",
+		WorkDir:  "/tmp/work",
+	}, "", map[string]string{
+		"session_origin": "ephemeral",
+		"agent_name":     "myrig/worker",
+	})
+	if err != nil {
+		t.Fatalf("resolvedWorkerRuntimeWithConfigAndMetadata: %v", err)
+	}
+	if resolved == nil {
+		t.Fatal("resolvedWorkerRuntimeWithConfigAndMetadata() = nil")
+	}
+	if got := resolved.Provider; got != "agent-provider" {
+		t.Fatalf("resolved.Provider = %q, want agent-provider", got)
+	}
+}
+
 func TestResolvedWorkerRuntimeWithConfigKeepsDefaultTransportWithoutExplicitACPTemplate(t *testing.T) {
 	cityDir := t.TempDir()
 	writePhase0InterfaceCity(t, cityDir, `[workspace]


### PR DESCRIPTION
## Summary
- prefer the current agent's resolved provider label when current config can supply the runtime command
- preserve persisted provider labels for incomplete current provider config fallback paths
- add regression coverage for stale session provider metadata

## Tests
- go test ./cmd/gc -run 'TestResolvedWorkerRuntimeWithConfigUsesCurrentAgentProviderOverStaleSessionProvider|TestWorkerSessionRuntimeResolverWithConfigFallsBackToPersistedRuntimeOnIncompleteResolvedConfig|TestWorkerSessionRuntimeResolverWithConfigFallsBackToPersistedProviderWhenCommandMissing' -count=1
- pre-commit hook: go vet ./... and ./scripts/test-local-parallel fast