### PR TITLE
Fix retry graph edge conflict

### DIFF
--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -251,6 +251,9 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 			if node.Key == rootKey {
 				continue
 			}
+			if graphApplyPlanHasEdgeFromKeyToTarget(plan.Edges, node.Key, rootKey, "") {
+				continue
+			}
 			plan.Edges = append(plan.Edges, beads.GraphApplyEdge{
 				FromKey: node.Key,
 				ToKey:   rootKey,
@@ -287,6 +290,21 @@ func ensureGraphNodeMetadata(node *beads.GraphApplyNode) {
 	if node.Metadata == nil {
 		node.Metadata = make(map[string]string, 1)
 	}
+}
+
+func graphApplyPlanHasEdgeFromKeyToTarget(edges []beads.GraphApplyEdge, fromKey, toKey, toID string) bool {
+	for _, edge := range edges {
+		if edge.FromKey != fromKey {
+			continue
+		}
+		if toKey != "" && edge.ToKey == toKey {
+			return true
+		}
+		if toID != "" && edge.ToID == toID {
+			return true
+		}
+	}
+	return false
 }
 
 func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, opts FragmentOptions) (*beads.GraphApplyPlan, error) {
@@ -397,6 +415,9 @@ func buildFragmentApplyPlan(store beads.Store, recipe *formula.FragmentRecipe, o
 	// dependency graph without introducing artificial blockers.
 	if opts.RootID != "" {
 		for _, node := range plan.Nodes {
+			if graphApplyPlanHasEdgeFromKeyToTarget(plan.Edges, node.Key, "", opts.RootID) {
+				continue
+			}
 			plan.Edges = append(plan.Edges, beads.GraphApplyEdge{
 				FromKey: node.Key,
 				ToID:    opts.RootID,

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -76,6 +76,113 @@ func TestBuildRecipeApplyPlanBugReportFlowV2(t *testing.T) {
 	}
 }
 
+func TestBuildRecipeApplyPlanSkipsRootTrackWhenExplicitRootEdgeExists(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name: "wf.review.attempt.2",
+		Steps: []formula.RecipeStep{
+			{
+				ID:     "wf.review.attempt.2",
+				Title:  "Review attempt",
+				Type:   "task",
+				IsRoot: true,
+				Metadata: map[string]string{
+					"gc.attempt":  "2",
+					"gc.step_ref": "wf.review.attempt.2",
+				},
+			},
+			{
+				ID:    "wf.review.attempt.2-scope-check",
+				Title: "Finalize scope for Review attempt",
+				Type:  "task",
+				Metadata: map[string]string{
+					"gc.kind":        "scope-check",
+					"gc.control_for": "wf.review.attempt.2",
+					"gc.scope_role":  "control",
+					"gc.step_ref":    "wf.review.attempt.2-scope-check",
+				},
+			},
+		},
+		Deps: []formula.RecipeDep{
+			{
+				StepID:      "wf.review.attempt.2-scope-check",
+				DependsOnID: "wf.review.attempt.2",
+				Type:        "blocks",
+			},
+		},
+	}
+
+	plan, graphWorkflow, rootKey, err := buildRecipeApplyPlan(recipe, Options{PreserveRootType: true})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+	if !graphWorkflow {
+		t.Fatal("graphWorkflow = false, want true for retry attempt recipe")
+	}
+	if rootKey != "wf.review.attempt.2" {
+		t.Fatalf("rootKey = %q, want retry attempt root", rootKey)
+	}
+
+	assertGraphPlanEdgeCount(t, plan, "wf.review.attempt.2-scope-check", "wf.review.attempt.2", "", "blocks", 1)
+	assertGraphPlanEdgeCount(t, plan, "wf.review.attempt.2-scope-check", "wf.review.attempt.2", "", "tracks", 0)
+}
+
+func TestBuildFragmentApplyPlanSkipsRootTrackWhenExternalRootEdgeExists(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	fragment := &formula.FragmentRecipe{
+		Name: "review-fragment",
+		Steps: []formula.RecipeStep{
+			{
+				ID:    "review-fragment.item",
+				Title: "Review fragment item",
+				Type:  "task",
+			},
+		},
+	}
+
+	plan, err := buildFragmentApplyPlan(store, fragment, FragmentOptions{
+		RootID: root.ID,
+		ExternalDeps: []ExternalDep{
+			{
+				StepID:      "review-fragment.item",
+				DependsOnID: root.ID,
+				Type:        "blocks",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildFragmentApplyPlan: %v", err)
+	}
+
+	assertGraphPlanEdgeCount(t, plan, "review-fragment.item", "", root.ID, "blocks", 1)
+	assertGraphPlanEdgeCount(t, plan, "review-fragment.item", "", root.ID, "tracks", 0)
+}
+
+func assertGraphPlanEdgeCount(t *testing.T, plan *beads.GraphApplyPlan, fromKey, toKey, toID, depType string, want int) {
+	t.Helper()
+
+	got := 0
+	for _, edge := range plan.Edges {
+		if edge.FromKey == fromKey && edge.ToKey == toKey && edge.ToID == toID && edge.Type == depType {
+			got++
+		}
+	}
+	if got != want {
+		t.Fatalf("edge count from=%q toKey=%q toID=%q type=%q = %d, want %d; edges=%+v", fromKey, toKey, toID, depType, got, want, plan.Edges)
+	}
+}
+
 func TestBuildRecipeApplyPlanReviewQuorumSubstitutesSynthesisTarget(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 


### PR DESCRIPTION
## Summary
- skip synthesized root `tracks` edges when an explicit edge already connects the same graph node to the workflow root
- cover retry attempt scope-check plans that already have `blocks` to the attempt root
- cover dynamic fragment plans with external root dependencies

## Root cause
Retry attempt materialization can generate a scope-check child with an explicit `blocks` edge to the attempt root. Graph apply then synthesized an ownership `tracks` edge for the same source/target pair, and `bd create --graph` rejects duplicate source/target edges with different dependency types. This is a latent graph.v2/control regression, not a convoy issue.

## Tests
- `go test ./internal/molecule -run 'TestBuild(Recipe|Fragment)ApplyPlanSkipsRootTrackWhen' -count=1`\n- `go test ./internal/molecule -count=1`\n- `go test ./internal/dispatch -count=1`\n- `go test ./internal/beads -run 'Test.*Graph' -count=1`\n- `make test-fast-parallel`\n- `go vet ./...`\n- `.githooks/pre-commit`\n