### PR TITLE
fix: scope continuation group claims to workflow root

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -6861,6 +6861,15 @@ max = -1
 	if !strings.Contains(out, "Do not start work with `bd update --status in_progress`") {
 		t.Fatalf("graph-worker prompt missing guard against unassigned in_progress work:\n%s", out)
 	}
+	if !strings.Contains(out, `ROOT_ID=$(bd show <id> --json | jq -r '.[0].metadata["gc.root_bead_id"] // empty')`) {
+		t.Fatalf("graph-worker prompt missing continuation-group root lookup:\n%s", out)
+	}
+	if !strings.Contains(out, `--metadata-field gc.root_bead_id=$ROOT_ID`) {
+		t.Fatalf("graph-worker prompt continuation-group sibling claim is not root-scoped:\n%s", out)
+	}
+	if !strings.Contains(out, `if [ -n "$GROUP" ] && [ -n "$ROOT_ID" ]; then`) {
+		t.Fatalf("graph-worker prompt should require group and root before preassigning siblings:\n%s", out)
+	}
 }
 
 func materializeBuiltinPrompts(cityPath string) error {

--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -91,10 +91,12 @@ with you when they become ready:
 ```bash
 # After claiming your first bead, read its continuation group
 GROUP=$(bd show <id> --json | jq -r '.[0].metadata["gc.continuation_group"] // empty')
+ROOT_ID=$(bd show <id> --json | jq -r '.[0].metadata["gc.root_bead_id"] // empty')
 
-if [ -n "$GROUP" ]; then
-  # Find all open beads in the same group and pre-assign them
+if [ -n "$GROUP" ] && [ -n "$ROOT_ID" ]; then
+  # Find all open beads in the same workflow group and pre-assign them
   SIBLINGS=$(bd list --metadata-field gc.routed_to=$GC_TEMPLATE \
+    --metadata-field gc.root_bead_id=$ROOT_ID \
     --metadata-field gc.continuation_group=$GROUP \
     --status=open --json 2>/dev/null \
     | jq -r '.[].id' 2>/dev/null)


### PR DESCRIPTION
## Summary
- require both continuation group and workflow root metadata before pre-assigning continuation siblings
- add the workflow root metadata filter to graph-worker sibling lookup instructions
- extend the prompt regression to catch unscoped continuation-group claims

## Tests
- go test ./cmd/gc -run TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork -count=1
- git diff --check HEAD~1..HEAD