### PR TITLE
Document public registry advertising blockers

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -138,6 +138,7 @@
           "guides/capabilities-for-coding-agent-users",
           "guides/understanding-packs",
           "guides/shareable-packs",
+          "guides/registry-showcase",
           "guides/gastown-config-recipes",
           "guides/using-json-from-gc",
           "guides/multi-agent-engineering-environment"

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -8,6 +8,7 @@ These guides are task-oriented and current.
 - [Capabilities for Coding Agent Users](/guides/capabilities-for-coding-agent-users)
 - [Understanding Packs](/guides/understanding-packs)
 - [Shareable Packs](/guides/shareable-packs)
+- [Public Registry Packs](/guides/registry-showcase)
 - [Using JSON from the Gas City CLI (`gc`)](/guides/using-json-from-gc)
 - [Using Gas City as a Multi-Agent Engineering Environment](/guides/multi-agent-engineering-environment)
 

--- a/docs/guides/registry-showcase.md
+++ b/docs/guides/registry-showcase.md
@@ -1,16 +1,17 @@
 ---
-title: "Public Registry Packs"
+title: "First-Party Registry Packs"
 description: Find and import the first-party packs published through the public Gas City registry.
 ---
 
-# Public Registry Packs
+# First-Party Registry Packs
 
 Gas City publishes first-party reusable packs through the public
-`gascity-packs` registry. The registry is a catalog for discovery; your
-checked-in `pack.toml` still records durable GitHub tree URLs and optional
-version constraints.
+`gascity-packs` registry. This is Gas City's first-party, or 1P, registry:
+the entries are owned by Gas City and reviewed in the `gascity-packs` repo.
+The registry is a catalog for discovery; your checked-in `pack.toml` still
+records durable GitHub tree URLs and optional version constraints.
 
-## One-Page Setup
+## Use The First-Party Registry
 
 1. Add the public registry locally:
 
@@ -44,7 +45,7 @@ When you decide to use a pack, prefer the exact command printed by
 `gc pack registry show`. It writes a durable `source` URL and optional
 `version`; it does not write the local registry handle into `pack.toml`.
 
-## First-Party Packs
+## First-Party Registry Packs
 
 | Pack | Use it for | Registry source |
 |---|---|---|
@@ -57,6 +58,21 @@ When you decide to use a pack, prefer the exact command printed by
 
 The built-in `core` and `maintenance` packs remain implicit in this wave. Do
 not add an import just to receive standard built-in behavior from `gc`.
+
+## Create Your Own Registry
+
+A registry is a Git repository with a `registry.toml` catalog. To try your own
+pack registry, publish a repo with that catalog, then add it locally under the
+name you want to use:
+
+```bash
+gc pack registry add team https://github.com/example/team-packs.git
+gc pack registry refresh team
+gc pack registry show team:example-pack
+```
+
+Use the first-party `gascity-packs` registry as the reference shape for catalog
+entries, release pins, and pack source URLs.
 
 ## Freshness
 
@@ -82,10 +98,14 @@ GC_REGISTRY_FRESHNESS=1h gc pack registry search gascity
 Invalid, zero, or negative values warn and are ignored for freshness
 calculation.
 
-## Not A Marketplace Yet
+## Registry Scope
 
-This page advertises first-party public registry entries. It is not a
-marketplace or external community curation workflow. Publishing a new registry
-entry is still a registry-repo change: update the catalog, review the change,
-merge it, then refresh local registry caches before searching or showing the
-new entry.
+Registry support is catalog plumbing: add a registry repo you trust, refresh
+its catalog, inspect an entry, and import the GitHub tree URL it advertises.
+A marketplace would add a separate curation layer, such as submission policies,
+moderation, ownership signals, ranking, and discovery across many publishers.
+
+This page only advertises Gas City's first-party entries and the mechanics for
+adding registry repos. Publishing a new first-party entry is still a
+`gascity-packs` repo change: update the catalog, review the change, merge it,
+then refresh local registry caches before searching or showing the new entry.

--- a/docs/guides/registry-showcase.md
+++ b/docs/guides/registry-showcase.md
@@ -1,17 +1,16 @@
 ---
-title: "First-Party Registry Packs"
-description: Find and import the first-party packs published through the public Gas City registry.
+title: "Public Registry Packs"
+description: Find and import Gas City-maintained packs published through the public registry.
 ---
 
-# First-Party Registry Packs
+# Public Registry Packs
 
-Gas City publishes first-party reusable packs through the public
-`gascity-packs` registry. This is Gas City's first-party, or 1P, registry:
-the entries are owned by Gas City and reviewed in the `gascity-packs` repo.
-The registry is a catalog for discovery; your checked-in `pack.toml` still
-records durable GitHub tree URLs and optional version constraints.
+Gas City maintains the public `gascity-packs` registry for reusable packs it
+publishes and reviews in the `gascity-packs` repo. The registry is a catalog
+for discovery; your checked-in `pack.toml` still records durable GitHub tree
+URLs and optional version constraints.
 
-## Use The First-Party Registry
+## Use The Gas City Registry
 
 1. Add the public registry locally:
 
@@ -45,7 +44,7 @@ When you decide to use a pack, prefer the exact command printed by
 `gc pack registry show`. It writes a durable `source` URL and optional
 `version`; it does not write the local registry handle into `pack.toml`.
 
-## First-Party Registry Packs
+## Published Packs
 
 | Pack | Use it for | Registry source |
 |---|---|---|
@@ -71,7 +70,7 @@ gc pack registry refresh team
 gc pack registry show team:example-pack
 ```
 
-Use the first-party `gascity-packs` registry as the reference shape for catalog
+Use the public `gascity-packs` registry as the reference shape for catalog
 entries, release pins, and pack source URLs.
 
 ## Freshness
@@ -105,7 +104,7 @@ its catalog, inspect an entry, and import the GitHub tree URL it advertises.
 A marketplace would add a separate curation layer, such as submission policies,
 moderation, ownership signals, ranking, and discovery across many publishers.
 
-This page only advertises Gas City's first-party entries and the mechanics for
-adding registry repos. Publishing a new first-party entry is still a
+This page only advertises Gas City-maintained entries and the mechanics for
+adding registry repos. Publishing a new Gas City-maintained entry is still a
 `gascity-packs` repo change: update the catalog, review the change, merge it,
 then refresh local registry caches before searching or showing the new entry.

--- a/docs/guides/registry-showcase.md
+++ b/docs/guides/registry-showcase.md
@@ -1,0 +1,75 @@
+---
+title: "Public Registry Packs"
+description: Find and import the first-party packs published through the public Gas City registry.
+---
+
+# Public Registry Packs
+
+Gas City publishes first-party reusable packs through the public
+`gascity-packs` registry. The registry is a catalog for discovery; your
+checked-in `pack.toml` still records durable GitHub tree URLs and optional
+version constraints.
+
+Add the public registry locally:
+
+```bash
+gc pack registry add main https://github.com/gastownhall/gascity-packs.git
+gc pack registry refresh main
+```
+
+Search and inspect entries:
+
+```bash
+gc pack registry search gascity
+gc pack registry show main:gascity
+```
+
+When you decide to use a pack, prefer the import command printed by
+`gc pack registry show`. It writes a durable `source` URL and optional
+`version`; it does not write the local registry handle into `pack.toml`.
+
+## First-Party Packs
+
+| Pack | Use it for | Registry source |
+|---|---|---|
+| `gascity` | Planning and implementation workflow support for Gas City work. | `https://github.com/gastownhall/gascity-packs/tree/main/gascity` |
+| `gastown` | Default Gas Town coding workflow support. | `https://github.com/gastownhall/gascity-packs/tree/main/gastown` |
+| `cass` | Coding Agent Session Search prompt fragments and skill overlays. | `https://github.com/gastownhall/gascity-packs/tree/main/cass` |
+| `discord` | Discord services, commands, and prompt fragments. | `https://github.com/gastownhall/gascity-packs/tree/main/discord` |
+| `github` | GitHub webhook intake services and commands. | `https://github.com/gastownhall/gascity-packs/tree/main/github` |
+| `slack-full` | Slack services, commands, and adapter integration. | `https://github.com/gastownhall/gascity-packs/tree/main/slack-full` |
+
+The built-in `core` and `maintenance` packs remain implicit in this wave. Do
+not add an import just to receive standard built-in behavior from `gc`.
+
+## Freshness
+
+Registry records are cached locally. `gc pack registry search` and
+`gc pack registry show` warn when a cache is older than the freshness window.
+The default window is 24 hours.
+
+Use `--refresh` when you want the command to fetch the latest catalog before
+reading it:
+
+```bash
+gc pack registry search gascity --refresh
+gc pack registry show main:gascity --refresh
+```
+
+Set `GC_REGISTRY_FRESHNESS` to a positive Go duration string when you want a
+different warning window:
+
+```bash
+GC_REGISTRY_FRESHNESS=1h gc pack registry search gascity
+```
+
+Invalid, zero, or negative values warn and are ignored for freshness
+calculation.
+
+## Not A Marketplace Yet
+
+This page advertises first-party public registry entries. It is not a
+marketplace or external community curation workflow. Publishing a new registry
+entry is still a registry-repo change: update the catalog, review the change,
+merge it, then refresh local registry caches before searching or showing the
+new entry.

--- a/docs/guides/registry-showcase.md
+++ b/docs/guides/registry-showcase.md
@@ -10,21 +10,37 @@ Gas City publishes first-party reusable packs through the public
 checked-in `pack.toml` still records durable GitHub tree URLs and optional
 version constraints.
 
-Add the public registry locally:
+## One-Page Setup
+
+1. Add the public registry locally:
 
 ```bash
 gc pack registry add main https://github.com/gastownhall/gascity-packs.git
 gc pack registry refresh main
 ```
 
-Search and inspect entries:
+2. Search and inspect entries:
 
 ```bash
 gc pack registry search gascity
 gc pack registry show main:gascity
 ```
 
-When you decide to use a pack, prefer the import command printed by
+3. Use the import command printed by `show`:
+
+```bash
+gc import add https://github.com/gastownhall/gascity-packs/tree/main/gascity --name gascity --version '>=0.1.0'
+```
+
+4. Install and validate the authored import:
+
+```bash
+gc import install
+gc import check
+gc config show --validate
+```
+
+When you decide to use a pack, prefer the exact command printed by
 `gc pack registry show`. It writes a durable `source` URL and optional
 `version`; it does not write the local registry handle into `pack.toml`.
 

--- a/docs/guides/shareable-packs.md
+++ b/docs/guides/shareable-packs.md
@@ -155,8 +155,8 @@ than the freshness window. The default window is 24 hours. Set
 Pass `--refresh` to `gc pack registry search` or `gc pack registry show` when
 you want that command to fetch the latest catalog before reading it.
 
-See [Public Registry Packs](/guides/registry-showcase) for the first-party
-packs currently advertised through the public registry.
+See [Public Registry Packs](/guides/registry-showcase) for the
+Gas City-maintained packs currently advertised through the public registry.
 
 ## City Usage
 

--- a/docs/guides/shareable-packs.md
+++ b/docs/guides/shareable-packs.md
@@ -139,6 +139,25 @@ not the registry handle. Publishing registry content is still a registry-repo
 workflow in this wave: edit the registry catalog, review it, and refresh the
 local registry cache before searching or showing new entries.
 
+The first public registry is the `gascity-packs` catalog:
+
+```text
+gc pack registry add main https://github.com/gastownhall/gascity-packs.git
+gc pack registry refresh main
+gc pack registry search gascity
+gc pack registry show main:gascity
+```
+
+Registry caches are local. Search and show warn when a registry cache is older
+than the freshness window. The default window is 24 hours. Set
+`GC_REGISTRY_FRESHNESS` to a positive Go duration string, such as `1h` or
+`30m`, to change that warning window. Invalid, zero, or negative values warn.
+Pass `--refresh` to `gc pack registry search` or `gc pack registry show` when
+you want that command to fetch the latest catalog before reading it.
+
+See [Public Registry Packs](/guides/registry-showcase) for the first-party
+packs currently advertised through the public registry.
+
 ## City Usage
 
 A city imports packs at the root pack level and declares deployment details in

--- a/docs/guides/understanding-packs.md
+++ b/docs/guides/understanding-packs.md
@@ -421,3 +421,30 @@ state.
 
 This separation keeps local discovery flexible without making shared config
 depend on the names or cache layout of one machine.
+
+### Registry Freshness
+
+Registry catalogs are cached locally. `gc pack registry search` and
+`gc pack registry show` read that cache unless you pass `--refresh`, and they
+warn when a configured registry cache is older than the freshness window.
+
+By default, a registry cache is considered fresh for 24 hours. Set
+`GC_REGISTRY_FRESHNESS` to a positive Go duration string when you need a
+different window:
+
+```bash
+GC_REGISTRY_FRESHNESS=1h gc pack registry search gascity
+```
+
+Invalid, zero, or negative values produce a warning and leave the command
+without a custom freshness window. Use `--refresh` when you want a command to
+fetch the latest catalog before reading it:
+
+```bash
+gc pack registry search gascity --refresh
+gc pack registry show main:gascity --refresh
+```
+
+Freshness affects discovery, not authored imports. A stale registry cache can
+hide a newly published pack record from search/show output, but shared
+`pack.toml` still stores durable import `source` and `version` values.

--- a/docs/guides/understanding-packs.md
+++ b/docs/guides/understanding-packs.md
@@ -296,6 +296,14 @@ mean.
 Use registry search when you know the kind of capability you want but not the
 exact pack name.
 
+If the public first-party registry is not configured on this machine yet, add
+and refresh it first:
+
+```text
+$ gc pack registry add main https://github.com/gastownhall/gascity-packs.git
+$ gc pack registry refresh main
+```
+
 ```text
 $ gc pack registry search gascity
 ```
@@ -329,11 +337,18 @@ Releases:
   0.1.0 v0.1.0 d3617d1319a
 ```
 
+Release versions and commit pins change as the registry publishes new pack
+releases; use your local `gc pack registry show` output as the current source
+of truth.
+
 The `Import commands` lines are ready to paste. The first command accepts the
 shown release or any newer release that matches the constraint. The second
 command pins exactly the shown release. Both commands write durable import TOML
 using the `Source` line and the selected `version`; the registry handle stays
 out of the file.
+
+For the short community-facing registry path and the current first-party pack
+list, see [Public Registry Packs](/guides/registry-showcase).
 
 ### Install Or Check Imports
 
@@ -410,6 +425,7 @@ state.
 
 | Task | Command or file |
 |---|---|
+| Add the public first-party registry | `gc pack registry add main https://github.com/gastownhall/gascity-packs.git` |
 | See configured catalogs | `gc pack registry list` |
 | Refresh cached catalog records | `gc pack registry refresh` |
 | Search for a reusable pack | `gc pack registry search` |

--- a/docs/guides/understanding-packs.md
+++ b/docs/guides/understanding-packs.md
@@ -101,8 +101,7 @@ pack name, summary, version metadata, and source.
 A registry handle is a short command argument for a pack record. In
 `main:gascity`, `main` is the local registry name on this machine and
 `gascity` is the pack name inside that registry. `main` is not a keyword in
-`pack.toml`; another machine could call the same registry `first-party` or
-`work`.
+`pack.toml`; another machine could call the same registry `team` or `work`.
 
 A source is the durable location written into checked-in TOML. Durable means
 the import does not depend on this machine's registry name or cache layout. The
@@ -296,8 +295,8 @@ mean.
 Use registry search when you know the kind of capability you want but not the
 exact pack name.
 
-If the public first-party registry is not configured on this machine yet, add
-and refresh it first:
+If the public Gas City registry is not configured on this machine yet, add and
+refresh it first:
 
 ```text
 $ gc pack registry add main https://github.com/gastownhall/gascity-packs.git
@@ -347,8 +346,8 @@ command pins exactly the shown release. Both commands write durable import TOML
 using the `Source` line and the selected `version`; the registry handle stays
 out of the file.
 
-For the short community-facing registry path and the current first-party pack
-list, see [Public Registry Packs](/guides/registry-showcase).
+For the short community-facing registry path and the current
+Gas City-maintained pack list, see [Public Registry Packs](/guides/registry-showcase).
 
 ### Install Or Check Imports
 
@@ -425,7 +424,7 @@ state.
 
 | Task | Command or file |
 |---|---|
-| Add the public first-party registry | `gc pack registry add main https://github.com/gastownhall/gascity-packs.git` |
+| Add the public Gas City registry | `gc pack registry add main https://github.com/gastownhall/gascity-packs.git` |
 | See configured catalogs | `gc pack registry list` |
 | Refresh cached catalog records | `gc pack registry refresh` |
 | Search for a reusable pack | `gc pack registry search` |

--- a/docs/specs/pack-spec.md
+++ b/docs/specs/pack-spec.md
@@ -8,7 +8,7 @@ description: Authoritative specification for Gas City pack format and loading se
 | Field | Value |
 |---|---|
 | Status | Authoritative specification |
-| Last verified | 2026-05-30 |
+| Last verified | 2026-06-03 |
 | Pack schema | 2 |
 | Primary implementation | `internal/config/pack.go`, `internal/config/config.go`, `internal/config/compose.go` |
 | User-facing guide | `docs/guides/shareable-packs.md` |
@@ -70,7 +70,10 @@ constraints and lockfile resolution, not by a loader comparing `[pack].version`
 directly.
 
 The `requires_gc` field is optional metadata for the minimum compatible `gc`
-version. It is parsed as pack metadata.
+version. It is parsed and preserved as pack metadata. The current loader,
+importer, and doctor surfaces do not enforce the constraint during load,
+import, or validation; enforcement must be introduced by an explicit future
+implementation change before pack authors can rely on it as a hard gate.
 
 ### 0.3. Pack Contents
 
@@ -205,7 +208,7 @@ requires_gc = ">=0.13.0"
 | `name` | string | yes | Pack identifier and provenance label. Must not be empty. |
 | `schema` | integer | yes | Pack format version. Must be `2` for this specification. |
 | `version` | string | no | Pack version metadata. |
-| `requires_gc` | string | no | Minimum compatible `gc` version metadata. |
+| `requires_gc` | string | no | Minimum compatible `gc` version metadata. Parsed and preserved; not currently enforced during load/import/doctor. |
 | `description` | string | no | Human-readable pack summary. |
 | `requires` | array of tables | no | Agent requirements validated after expansion. |
 

--- a/engdocs/design/packv2/README.md
+++ b/engdocs/design/packv2/README.md
@@ -1,5 +1,11 @@
 # PackV2 Engineering Design Notes
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 This directory contains PackV2 engineering design notes, rollout ledgers, and
 historical reconciliation docs. These files are not user-facing product
 documentation and should not be used as the primary source for authoring a new

--- a/engdocs/design/packv2/doc-agent-v2.md
+++ b/engdocs/design/packv2/doc-agent-v2.md
@@ -1,5 +1,11 @@
 # Agent Definition v.next
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 **GitHub Issue:** [gastownhall/gascity#356](https://github.com/gastownhall/gascity/issues/356)
 
 Title: `feat: Agent Definition v.next — agents as directories`

--- a/engdocs/design/packv2/doc-agent-v2.md
+++ b/engdocs/design/packv2/doc-agent-v2.md
@@ -1,4 +1,4 @@
-# Agent Definition v.next
+# Agent Definitions As Directories
 
 > **Historical PackV2 design note.** This page preserves design history and
 > rollout rationale. For current pack authoring guidance, use
@@ -8,7 +8,7 @@
 
 **GitHub Issue:** [gastownhall/gascity#356](https://github.com/gastownhall/gascity/issues/356)
 
-Title: `feat: Agent Definition v.next — agents as directories`
+Title: `feat: agent definitions as directories`
 
 This is a companion to [doc-pack-v2.md](doc-pack-v2.md), which covers the pack/city model redesign.
 
@@ -24,7 +24,7 @@ This is a companion to [doc-pack-v2.md](doc-pack-v2.md), which covers the pack/c
 ## Problem
 
 Agent definitions are split across `[[agent]]` TOML tables and filesystem assets (prompts, overlays, scripts) scattered in separate directory trees. This creates six problems:
-v
+
 1. **Scattered identity.** There's no single place to understand what an agent is. Adding an agent means editing city.toml *and* creating files in multiple directories (`prompts/`, `overlay/`, `scripts/`).
 
 2. **Invisible prompt injection.** Every `.md` file is secretly a Go template. Fragments get injected via `global_fragments` and `inject_fragments` without appearing in the prompt file itself. You can't read a prompt and know what the agent actually sees.

--- a/engdocs/design/packv2/doc-commands.md
+++ b/engdocs/design/packv2/doc-commands.md
@@ -1,5 +1,11 @@
 # Pack Commands v.next
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 > **Status:** design note / rationale only. This file is not the release-gating
 > authority for the shipped command or doctor surface.
 >

--- a/engdocs/design/packv2/doc-conformance-matrix.md
+++ b/engdocs/design/packv2/doc-conformance-matrix.md
@@ -1,5 +1,11 @@
 # Pack/City v2 Conformance Matrix
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 This document turns the reconciled pack/city v.next docs into an
 executable conformance plan for the current Pack/City v2 rollout.
 

--- a/engdocs/design/packv2/doc-consistency-audit.md
+++ b/engdocs/design/packv2/doc-consistency-audit.md
@@ -1,5 +1,11 @@
 # Consistency Audit: Directory Conventions and TOML Structure — RETIRED
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 > **Status: Retired.** All findings have been folded into the canonical spec docs:
 > - Orders → top-level `orders/` (doc-directory-conventions.md, doc-pack-v2.md, doc-loader-v2.md)
 > - `[formulas].dir` → fixed convention (doc-directory-conventions.md, doc-pack-v2.md)

--- a/engdocs/design/packv2/doc-directory-conventions.md
+++ b/engdocs/design/packv2/doc-directory-conventions.md
@@ -1,5 +1,11 @@
 # Pack Structure v.next
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 **GitHub Issue:** TBD
 
 Title: `feat: Pack structure v.next — principles and standard directory layout for packs and cities`

--- a/engdocs/design/packv2/doc-loader-v2.md
+++ b/engdocs/design/packv2/doc-loader-v2.md
@@ -1,5 +1,11 @@
 # V2 Loader & Pack Composition — Design
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 > **Status:** Design description of the v.next loader as proposed in
 > [doc-pack-v2.md](doc-pack-v2.md) ([gastownhall/gascity#360](https://github.com/gastownhall/gascity/issues/360)).
 > Companion to the current release-branch loader behavior and to the v.next

--- a/engdocs/design/packv2/doc-pack-v2.md
+++ b/engdocs/design/packv2/doc-pack-v2.md
@@ -1,5 +1,11 @@
 # Pack/City Model v.next
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 **GitHub Issue:** [gastownhall/gascity#360](https://github.com/gastownhall/gascity/issues/360) (supersedes [#159](https://github.com/gastownhall/gascity/issues/159))
 
 Title: `feat: Pack/City Model v.next — cities as packs, import model, managed state`

--- a/engdocs/design/packv2/doc-packman.md
+++ b/engdocs/design/packv2/doc-packman.md
@@ -1,5 +1,11 @@
 # City/Pack Import Management
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 **GitHub Issue:** TBD
 
 Title: `feat: gc import — import management for schema-2 Gas City packs`

--- a/engdocs/design/packv2/doc-rig-binding-phases.md
+++ b/engdocs/design/packv2/doc-rig-binding-phases.md
@@ -1,5 +1,11 @@
 # Rig Binding Phases
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 Doc state: transition truth
 
 GitHub issues:

--- a/engdocs/design/packv2/skew-analysis.md
+++ b/engdocs/design/packv2/skew-analysis.md
@@ -1,5 +1,11 @@
 # Spec vs. Implementation Skew Analysis — Current Pack/City v2 Desired State
 
+> **Historical PackV2 design note.** This page preserves design history and
+> rollout rationale. For current pack authoring guidance, use
+> `docs/specs/pack-spec.md` and `docs/guides/shareable-packs.md`.
+> When this note disagrees with shipped behavior, prefer the current docs,
+> generated reference, code, and tests.
+
 > Generated 2026-04-12 by comparing `docs/reference/config.md` (as-built
 > from the release branch Go structs) against the reconciled pack v2 specs.
 > Revised through field-by-field walkthrough to reflect the **current


### PR DESCRIPTION
## Summary

- add a Public Registry Packs guide for the first-party `gascity-packs` registry
- document registry cache freshness / `GC_REGISTRY_FRESHNESS` and `--refresh` behavior
- clarify current `[pack].requires_gc` behavior as parsed/preserved metadata, not an enforced gate
- add historical banners to PackV2 design notes so launch traffic lands on current docs

Addresses the safe docs launch blockers from #2120: #2805, #2806, #2137, and #813.

## Verification

- `make check-docs EXTRA_TEST_ENV="CGO_CPPFLAGS=-I/opt/homebrew/opt/icu4c@78/include CGO_CXXFLAGS=-I/opt/homebrew/opt/icu4c@78/include CGO_CFLAGS=-I/opt/homebrew/opt/icu4c@78/include CGO_LDFLAGS=-L/opt/homebrew/opt/icu4c@78/lib PKG_CONFIG_PATH=/opt/homebrew/opt/icu4c@78/lib/pkgconfig"`
- `git diff --check`

## Notes

This PR does not change the hard registry gates: `gascity-packs` #55 still needs to land before #3006 can pass the live public registry smoke gate. It also does not decide #2122 example/tutorial policy.