### PR TITLE
fix(gc): reduce bd list pressure during startup

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -461,14 +461,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
 		}
 		scoped := a.ScopedName()
-		hasOpenWork, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
-			return m.hasOpenWorkInStoresStrict(storesForGate, scoped)
+		hasOpenTracking, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
+			return trackingIndex.hasOpenTracking(storesForGate, storeKeysForGate, scoped)
 		})
 		if err != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
 			continue
 		}
-		if hasOpenWork {
+		if hasOpenTracking {
 			continue
 		}
 
@@ -553,7 +553,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		// Skip dispatch if previous work hasn't been processed yet.
 		// Bound the wisp-aware open-work gate (#2921) with our per-order
 		// timeout so a slow store can't starve later orders.
-		hasOpenWork, err = gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
+		hasOpenWork, err := gateOpenWorkBounded(ctx, orderGateTimeout, scoped, func() (bool, error) {
 			return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.hasOpenWorkInStoresStrict, true)
 		})
 		if err != nil {
@@ -667,6 +667,29 @@ func newOrderDispatchTrackingIndex() *orderDispatchTrackingIndex {
 		entries: make(map[string]map[string]orderTrackingSummary),
 		errs:    make(map[string]error),
 	}
+}
+
+func (idx *orderDispatchTrackingIndex) hasOpenTracking(
+	stores []beads.Store,
+	storeKeys []string,
+	scopedName string,
+) (bool, error) {
+	if idx == nil {
+		return false, nil
+	}
+	for i, store := range stores {
+		if store == nil {
+			continue
+		}
+		entries, err := idx.entriesForStore(store, indexStoreKey(storeKeys, i))
+		if err != nil {
+			return false, err
+		}
+		if entries[scopedName].openTracking {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (idx *orderDispatchTrackingIndex) hasOpenWork(

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1224,6 +1224,51 @@ func TestOrderDispatchCooldownNotDue(t *testing.T) {
 	}
 }
 
+type strictOpenWorkListCountingStore struct {
+	beads.Store
+
+	strictOpenWorkLists int
+}
+
+func (s *strictOpenWorkListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.HasPrefix(query.Label, "order-run:") && !query.IncludeClosed && query.Limit == 0 {
+		s.strictOpenWorkLists++
+		return nil, fmt.Errorf("strict open-work scan should only run for due orders")
+	}
+	return s.Store.List(query)
+}
+
+func TestOrderDispatchCooldownNotDueSkipsStrictOpenWorkScan(t *testing.T) {
+	store := &strictOpenWorkListCountingStore{Store: beads.NewMemStore()}
+	now := time.Date(2026, 6, 3, 4, 40, 0, 0, time.UTC)
+
+	if _, err := store.Create(beads.Bead{
+		Title:     "recent run",
+		Labels:    []string{"order-run:test-order"},
+		CreatedAt: now.Add(-5 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:     "test-order",
+		Trigger:  "cooldown",
+		Interval: "1h",
+		Exec:     "true",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	if store.strictOpenWorkLists != 0 {
+		t.Fatalf("strict open-work scans = %d, want 0 for not-due order", store.strictOpenWorkLists)
+	}
+}
+
 func TestOrderDispatchMultiple(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -5455,8 +5500,8 @@ func TestOrderDispatchSkipsRigCooldownWhenLegacyOpenWorkReadFails(t *testing.T) 
 	if len(rigRuns) != 0 {
 		t.Fatalf("rig store has %d new run bead(s), want 0 when legacy last-run state cannot be read", len(rigRuns))
 	}
-	if !strings.Contains(stderr.String(), "checking open work") {
-		t.Fatalf("stderr missing open-work gate error:\n%s", stderr.String())
+	if !strings.Contains(stderr.String(), "reading last run") {
+		t.Fatalf("stderr missing last-run gate error:\n%s", stderr.String())
 	}
 }
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1609,9 +1609,6 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 		args = append(args, "--created-before", serverQuery.CreatedBefore.Format(time.RFC3339Nano))
 	}
 	args = append(args, "--include-infra", "--include-gates")
-	if query.TierMode == TierWisps || query.TierMode == TierBoth {
-		args = append(args, "--include-templates")
-	}
 	args = append(args, "--limit", fmt.Sprintf("%d", limit))
 	if serverQuery.ParentID != "" {
 		args = append(args, "--parent", serverQuery.ParentID)

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -512,15 +512,16 @@ func IsPartialResult(err error) bool {
 	return errors.As(err, &partial)
 }
 
-// parseIssuesTolerant unmarshals a JSON array of bdIssue objects, skipping
-// any entries that fail to parse (e.g. corrupt metadata with non-string values).
+// parseIssuesTolerant unmarshals bd list output, skipping any entries that
+// fail to parse (e.g. corrupt metadata with non-string values). bd 1.0.4 emits
+// a top-level array; bd 1.0.5 may emit an object envelope with an issues array.
 // This prevents a single bad bead from breaking all list operations.
 func parseIssuesTolerant(data []byte) ([]bdIssue, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
 		return nil, nil
 	}
-	var raw []json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
+	raw, err := bdListIssueRows(data)
+	if err != nil {
 		// Include a snippet of the raw bd output so the failure surface is
 		// diagnosable. Historical case (gascity #1726): bd returned the
 		// literal string "None" and the unwrapped error was the opaque
@@ -554,6 +555,27 @@ func parseIssuesTolerant(data []byte) ([]bdIssue, error) {
 		return result, fmt.Errorf("skipped %d corrupt %s: %w", skipped, beadNoun, parseErr)
 	}
 	return result, nil
+}
+
+func bdListIssueRows(data []byte) ([]json.RawMessage, error) {
+	var raw []json.RawMessage
+	arrayErr := json.Unmarshal(data, &raw)
+	if arrayErr == nil {
+		return raw, nil
+	}
+
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, arrayErr
+	}
+	rawIssues, ok := envelope["issues"]
+	if !ok {
+		return nil, fmt.Errorf("JSON object missing issues field")
+	}
+	if err := json.Unmarshal(rawIssues, &raw); err != nil {
+		return nil, fmt.Errorf("issues field: %w", err)
+	}
+	return raw, nil
 }
 
 // toBead converts a bdIssue to a Gas City Bead. CreatedAt is truncated to
@@ -1564,7 +1586,7 @@ func bdListCoversBothTiers(query ListQuery) bool {
 func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 	serverQuery, clientFilteredAssignees := bdServerQueryForAssignees(query)
 	limit := serverQuery.Limit
-	if serverQuery.Sort == SortCreatedAsc || clientFilteredAssignees {
+	if bdListRequiresClientLimit(serverQuery, clientFilteredAssignees) {
 		limit = 0
 	}
 	args := []string{"list", "--json"}
@@ -1586,7 +1608,11 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 	if !serverQuery.CreatedBefore.IsZero() {
 		args = append(args, "--created-before", serverQuery.CreatedBefore.Format(time.RFC3339Nano))
 	}
-	args = append(args, "--include-infra", "--include-gates", "--limit", fmt.Sprintf("%d", limit))
+	args = append(args, "--include-infra", "--include-gates")
+	if query.TierMode == TierWisps || query.TierMode == TierBoth {
+		args = append(args, "--include-templates")
+	}
+	args = append(args, "--limit", fmt.Sprintf("%d", limit))
 	if serverQuery.ParentID != "" {
 		args = append(args, "--parent", serverQuery.ParentID)
 	}
@@ -1623,6 +1649,16 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 		return filtered, &PartialResultError{Op: "bd list", Err: parseErr}
 	}
 	return filtered, nil
+}
+
+func bdListRequiresClientLimit(serverQuery ListQuery, clientFilteredAssignees bool) bool {
+	if serverQuery.Sort == SortCreatedAsc || clientFilteredAssignees {
+		return true
+	}
+	if !serverQuery.UpdatedBefore.IsZero() {
+		return true
+	}
+	return false
 }
 
 func bdServerQueryForAssignees(query ListQuery) (ListQuery, bool) {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1738,6 +1738,61 @@ func TestBdStoreListEmptyOutputMeansNoBeads(t *testing.T) {
 	}
 }
 
+func TestBdStoreListSkipLabelsDoesNotEmitUnsupportedBd104Flag(t *testing.T) {
+	var gotCmd string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		return []byte(`[]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.List(beads.ListQuery{AllowScan: true, SkipLabels: true}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(gotCmd, "--skip-labels") {
+		t.Fatalf("bd list command = %q, --skip-labels is not supported by bd 1.0.4", gotCmd)
+	}
+}
+
+func TestBdStoreListAcceptsBdListEnvelope(t *testing.T) {
+	var gotCmd string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		return []byte(`{
+			"issues": [
+				{"id":"bd-envelope","title":"from envelope","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}
+			],
+			"meta": {"count": 1, "skip_labels": true},
+			"schema_version": 1
+		}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{AllowScan: true, SkipLabels: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(gotCmd, "--skip-labels") {
+		t.Fatalf("bd list command = %q, --skip-labels is not supported by bd 1.0.4", gotCmd)
+	}
+	if len(got) != 1 || got[0].ID != "bd-envelope" {
+		t.Fatalf("List() = %+v, want bd-envelope from envelope", got)
+	}
+}
+
+func TestBdStoreListSkipLabelsOmittedForLabelFilter(t *testing.T) {
+	var gotCmd string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		gotCmd = name + " " + strings.Join(args, " ")
+		return []byte(`[]`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.List(beads.ListQuery{Label: "order-tracking", SkipLabels: true}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(gotCmd, "--skip-labels") {
+		t.Fatalf("bd list command = %q, --skip-labels cannot combine with label filters", gotCmd)
+	}
+}
+
 func TestBdStoreListError(t *testing.T) {
 	runner := func(_, _ string, _ ...string) ([]byte, error) {
 		return nil, fmt.Errorf("exit status 1")

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -3591,6 +3591,9 @@ func TestBdStoreListBothTiersMessageUsesSingleBdListWithoutTierFiltering(t *test
 	if len(calls) != 1 {
 		t.Fatalf("got %d runner calls, want 1: %v", len(calls), calls)
 	}
+	if strings.Contains(calls[0], "--include-templates") {
+		t.Fatalf("bd list command = %q, message TierBoth fast path must not include template rows", calls[0])
+	}
 	if len(got) != 1 || got[0].ID != "bd-msg" || !got[0].Ephemeral {
 		t.Fatalf("got = %+v, want TierBoth bd message row bd-msg with Ephemeral=true", got)
 	}


### PR DESCRIPTION
## Summary
- avoid strict open-work scans when order cooldown has not elapsed
- add a lightweight order tracking history index for startup dispatch gates
- parse bd list object envelopes while retaining bd 1.0.4-compatible command flags
- keep `ListQuery.SkipLabels` from emitting `bd list --skip-labels`, because bd 1.0.4 does not support that flag

## Verification
- built bd v1.0.4 from tag `v1.0.4` and verified `bd list` supports `--include-infra`, `--include-gates`, `--include-templates`, `--limit`, and `--ready`
- verified bd v1.0.4 `bd ready` supports `--include-ephemeral`, `--metadata-field`, and `--has-metadata-key`
- verified bd v1.0.4 rejects `bd list --skip-labels`; this PR intentionally does not emit it
- `go test ./internal/beads -run 'TestBdStoreList(InfersParentFromParentChildDependency|ByLabel|CreatedBeforeForwardsFilter|ByLabelEmpty|SkipLabelsDoesNotEmitUnsupportedBd104Flag|AcceptsBdListEnvelope|SkipLabelsOmittedForLabelFilter)' -count=1`\n- `go test ./examples/gastown -run TestReaperParentIDIsParentChildDependencyProjection -count=1`\n- `go test ./cmd/gc -run TestOrderDispatchCooldownNotDueSkipsStrictOpenWorkScan -count=1`\n- pre-commit hook passed on retry: changed-package lint, generated-doc sync, `go vet ./...`, and `./scripts/test-local-parallel fast`\n\nNote: first pre-commit attempt failed from the known `TempDir: stat /tmp/gct... no such file or directory` shard-temp-root cascade; retry passed all shards without code changes.