### PR TITLE
Harden registry source normalization

### DIFF
--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -210,12 +210,12 @@ func TestPackRegistryAddRejectsWindowsRegistrySources(t *testing.T) {
 		{
 			name:    "drive letter",
 			source:  `C:\packs\registry.toml`,
-			wantErr: "Windows drive-letter registry sources are not supported portably",
+			wantErr: "registry source uses a Windows drive-letter path",
 		},
 		{
 			name:    "unc",
 			source:  `\\server\share\registry.toml`,
-			wantErr: "UNC registry sources are not supported portably",
+			wantErr: "registry source uses a UNC path",
 		},
 	}
 	for _, tc := range cases {

--- a/cmd/gc/cmd_pack_registry_test.go
+++ b/cmd/gc/cmd_pack_registry_test.go
@@ -201,6 +201,40 @@ func TestPackRegistryAddFreshHomePreservesDefaultRegistry(t *testing.T) {
 	}
 }
 
+func TestPackRegistryAddRejectsWindowsRegistrySources(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		wantErr string
+	}{
+		{
+			name:    "drive letter",
+			source:  `C:\packs\registry.toml`,
+			wantErr: "Windows drive-letter registry sources are not supported portably",
+		},
+		{
+			name:    "unc",
+			source:  `\\server\share\registry.toml`,
+			wantErr: "UNC registry sources are not supported portably",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("GC_HOME", home)
+			writeEmptyRegistryConfig(t, home)
+
+			var stdout, stderr bytes.Buffer
+			if code := doPackRegistryAdd("local", tc.source, true, false, &stdout, &stderr); code == 0 {
+				t.Fatalf("add succeeded stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantErr) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestPackRegistryRemoveMainFreshHomeWritesExplicitEmptyConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GC_HOME", home)

--- a/internal/packregistry/catalog.go
+++ b/internal/packregistry/catalog.go
@@ -87,6 +87,12 @@ func NormalizeSource(raw string) (Source, error) {
 	if raw == "" {
 		return Source{}, errors.New("registry source is required")
 	}
+	if windowsPathRE.MatchString(raw) {
+		return Source{}, fmt.Errorf("Windows drive-letter registry sources are not supported portably: %q; use an HTTPS URL or a file:// URL with a POSIX-style local path", raw)
+	}
+	if windowsUNCPath.MatchString(raw) {
+		return Source{}, fmt.Errorf("UNC registry sources are not supported portably: %q; use an HTTPS URL or a file:// URL with a POSIX-style local path", raw)
+	}
 	u, err := url.Parse(raw)
 	if err == nil && u.Scheme != "" {
 		switch u.Scheme {

--- a/internal/packregistry/catalog.go
+++ b/internal/packregistry/catalog.go
@@ -88,10 +88,10 @@ func NormalizeSource(raw string) (Source, error) {
 		return Source{}, errors.New("registry source is required")
 	}
 	if windowsPathRE.MatchString(raw) {
-		return Source{}, fmt.Errorf("Windows drive-letter registry sources are not supported portably: %q; use an HTTPS URL or a file:// URL with a POSIX-style local path", raw)
+		return Source{}, fmt.Errorf("registry source uses a Windows drive-letter path, which is not supported portably: %q; use an HTTPS URL or a file:// URL with a POSIX-style local path", raw)
 	}
 	if windowsUNCPath.MatchString(raw) {
-		return Source{}, fmt.Errorf("UNC registry sources are not supported portably: %q; use an HTTPS URL or a file:// URL with a POSIX-style local path", raw)
+		return Source{}, fmt.Errorf("registry source uses a UNC path, which is not supported portably: %q; use an HTTPS URL or a file:// URL with a POSIX-style local path", raw)
 	}
 	u, err := url.Parse(raw)
 	if err == nil && u.Scheme != "" {

--- a/internal/packregistry/catalog_test.go
+++ b/internal/packregistry/catalog_test.go
@@ -182,6 +182,37 @@ func TestNormalizeHTTPSRegistrySourcePaths(t *testing.T) {
 	}
 }
 
+func TestNormalizeSourceRejectsWindowsRegistrySources(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{
+			name:    "drive backslashes",
+			raw:     `C:\packs\registry.toml`,
+			wantErr: "Windows drive-letter registry sources are not supported portably",
+		},
+		{
+			name:    "drive slashes",
+			raw:     `C:/packs/registry.toml`,
+			wantErr: "Windows drive-letter registry sources are not supported portably",
+		},
+		{
+			name:    "unc backslashes",
+			raw:     `\\server\share\registry.toml`,
+			wantErr: "UNC registry sources are not supported portably",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NormalizeSource(tc.raw); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("NormalizeSource(%q) err = %v, want %q", tc.raw, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestLocalCatalogAcceptsWindowsPathSource(t *testing.T) {
 	text := strings.Replace(validCatalog, `source = "https://packages.example/lighthouse.git"`, `source = 'C:\packs\lighthouse.git'`, 1)
 	catalog, err := ParseCatalog([]byte(text))

--- a/internal/packregistry/catalog_test.go
+++ b/internal/packregistry/catalog_test.go
@@ -191,17 +191,17 @@ func TestNormalizeSourceRejectsWindowsRegistrySources(t *testing.T) {
 		{
 			name:    "drive backslashes",
 			raw:     `C:\packs\registry.toml`,
-			wantErr: "Windows drive-letter registry sources are not supported portably",
+			wantErr: "registry source uses a Windows drive-letter path",
 		},
 		{
 			name:    "drive slashes",
 			raw:     `C:/packs/registry.toml`,
-			wantErr: "Windows drive-letter registry sources are not supported portably",
+			wantErr: "registry source uses a Windows drive-letter path",
 		},
 		{
 			name:    "unc backslashes",
 			raw:     `\\server\share\registry.toml`,
-			wantErr: "UNC registry sources are not supported portably",
+			wantErr: "registry source uses a UNC path",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/packregistry/config_test.go
+++ b/internal/packregistry/config_test.go
@@ -47,6 +47,40 @@ func TestLoadConfigValidatesRegistrySources(t *testing.T) {
 	}
 }
 
+func TestLoadConfigRejectsWindowsRegistrySources(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		wantErr string
+	}{
+		{
+			name:    "drive letter",
+			source:  `C:\packs\registry.toml`,
+			wantErr: "Windows drive-letter registry sources are not supported portably",
+		},
+		{
+			name:    "unc",
+			source:  `\\server\share\registry.toml`,
+			wantErr: "UNC registry sources are not supported portably",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.MkdirAll(filepath.Dir(ConfigPath(home)), 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			body := "schema = 1\n\n[[registry]]\nname = \"main\"\nsource = " + tomlQuoteForTest(tc.source) + "\n"
+			if err := os.WriteFile(ConfigPath(home), []byte(body), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if _, err := LoadConfig(home); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("LoadConfig err = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestAddRegistryWithCacheDoesNotConfigureWhenCacheWriteFails(t *testing.T) {
 	home := t.TempDir()
 	saveEmptyConfigForTest(t, home)
@@ -249,4 +283,8 @@ func saveEmptyConfigForTest(t *testing.T, home string) {
 	if err := SaveConfig(home, Config{}); err != nil {
 		t.Fatalf("SaveConfig(empty): %v", err)
 	}
+}
+
+func tomlQuoteForTest(value string) string {
+	return `"` + strings.ReplaceAll(value, `\`, `\\`) + `"`
 }

--- a/internal/packregistry/config_test.go
+++ b/internal/packregistry/config_test.go
@@ -56,12 +56,12 @@ func TestLoadConfigRejectsWindowsRegistrySources(t *testing.T) {
 		{
 			name:    "drive letter",
 			source:  `C:\packs\registry.toml`,
-			wantErr: "Windows drive-letter registry sources are not supported portably",
+			wantErr: "registry source uses a Windows drive-letter path",
 		},
 		{
 			name:    "unc",
 			source:  `\\server\share\registry.toml`,
-			wantErr: "UNC registry sources are not supported portably",
+			wantErr: "registry source uses a UNC path",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- reject Windows drive-letter registry sources before URL parsing
- reject UNC-looking registry sources with explicit diagnostics
- cover normalization, persisted registry config, and `gc pack registry add --no-validate` surfaces

Addresses #2802.

## Verification

- `git diff --check`
- `go test ./internal/packregistry`
- `CGO_ENABLED=0 go test ./cmd/gc -run 'TestPackRegistry'`

## Notes

Plain `go test ./cmd/gc -run 'TestPackRegistry'` requires this machine's Homebrew ICU C++ flags; the CGO-disabled command path above passed and avoids that local toolchain issue.
