### PR TITLE
fix(gastown): make dog formulas claim-first vapor work

### DIFF
--- a/examples/dolt/formulas/mol-dog-backup.toml
+++ b/examples/dolt/formulas/mol-dog-backup.toml
@@ -1,6 +1,20 @@
 description = """
 Sync Dolt database backups to local and offsite storage.
 
+After claiming this vapor wisp, run:
+
+```bash
+gc bd formula show mol-dog-backup --json
+```
+
+Follow the step descriptions in order. When finished, close this bead, then run:
+
+```bash
+gc runtime drain-ack
+```
+
+The drain-ack tells the controller this session is done.
+
 The Backup Dog discovers configured backup remotes for each production
 database, syncs them, then rsyncs the local backup directory to offsite
 storage for replication.
@@ -27,6 +41,7 @@ overwrites the backup destination, but that is the intended behavior.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-backup"
+phase = "vapor"
 
 [vars]
 [vars.databases]

--- a/examples/dolt/formulas/mol-dog-doctor.toml
+++ b/examples/dolt/formulas/mol-dog-doctor.toml
@@ -1,6 +1,20 @@
 description = """
 Probe Dolt server health and inspect resource conditions.
 
+After claiming this vapor wisp, run:
+
+```bash
+gc bd formula show mol-dog-doctor --json
+```
+
+Follow the step descriptions in order. When finished, close this bead, then run:
+
+```bash
+gc runtime drain-ack
+```
+
+The drain-ack tells the controller this session is done.
+
 The Doctor Dog performs comprehensive health checks on the Dolt SQL server:
 connectivity, latency, connection count, disk usage, database count (orphan
 detection), and backup freshness. All checks are read-only — the Doctor
@@ -29,6 +43,7 @@ It only observes and reports.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-doctor"
+phase = "vapor"
 
 [vars]
 [vars.port]

--- a/examples/dolt/formulas/mol-dog-phantom-db.toml
+++ b/examples/dolt/formulas/mol-dog-phantom-db.toml
@@ -1,6 +1,20 @@
 description = """
 Detect unservable databases in .dolt-data/ that can crash or confuse the Dolt server.
 
+After claiming this vapor wisp, run:
+
+```bash
+gc bd formula show mol-dog-phantom-db --json
+```
+
+Follow the step descriptions in order. When finished, close this bead, then run:
+
+```bash
+gc runtime drain-ack
+```
+
+The drain-ack tells the controller this session is done.
+
 A phantom database is a directory in .dolt-data/ that has a .dolt/ subdirectory
 but is missing the noms/manifest file. When Dolt auto-discovers these dirs at
 startup, the broken noms store crashes INFORMATION_SCHEMA and can take down
@@ -39,6 +53,7 @@ happens deliberately with the Dolt server stopped or through Dolt itself.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-phantom-db"
+phase = "vapor"
 
 [vars]
 [vars.data_dir]

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -1,6 +1,20 @@
 description = """
 Detect and clean stale Dolt databases and orphan Dolt processes.
 
+After claiming this vapor wisp, run:
+
+```bash
+gc bd formula show mol-dog-stale-db --json
+```
+
+Follow the step descriptions in order. When finished, close this bead, then run:
+
+```bash
+gc runtime drain-ack
+```
+
+The drain-ack tells the controller this session is done.
+
 This formula shells out to `gc dolt-cleanup --json`, parses the
 `gc.dolt.cleanup.v1` envelope, and emits one summary line per stage
 to `gc events` so operators skimming a long scrollback can spot
@@ -51,6 +65,7 @@ separate agent interactions, so scan, decision, apply, and report state
 must stay inside one shell execution instead of relying on variables to
 cross step boundaries."""
 formula = "mol-dog-stale-db"
+phase = "vapor"
 
 [vars]
 [vars.max_orphans_for_sql]

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -1634,6 +1634,88 @@ func TestGastownWarrantCreateCommandsUseCreateMetadata(t *testing.T) {
 	}
 }
 
+func TestDogAndDigestVaporFormulasHaveNoCompilerRequirement(t *testing.T) {
+	dir := exampleDir()
+	checks := []struct {
+		rel     string
+		formula string
+	}{
+		{"../dolt/formulas/mol-dog-backup.toml", "mol-dog-backup"},
+		{"../dolt/formulas/mol-dog-doctor.toml", "mol-dog-doctor"},
+		{"../dolt/formulas/mol-dog-phantom-db.toml", "mol-dog-phantom-db"},
+		{"../dolt/formulas/mol-dog-stale-db.toml", "mol-dog-stale-db"},
+		{"packs/maintenance/formulas/mol-dog-jsonl.toml", "mol-dog-jsonl"},
+		{"packs/maintenance/formulas/mol-dog-reaper.toml", "mol-dog-reaper"},
+		{"packs/maintenance/formulas/mol-shutdown-dance.toml", "mol-shutdown-dance"},
+		{"packs/gastown/formulas/mol-digest-generate.toml", "mol-digest-generate"},
+	}
+	for _, check := range checks {
+		path := filepath.Join(dir, check.rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", check.rel, err)
+		}
+		body := string(data)
+		var decoded struct {
+			Formula  string            `toml:"formula"`
+			Phase    string            `toml:"phase"`
+			Requires map[string]string `toml:"requires"`
+		}
+		if _, err := toml.Decode(body, &decoded); err != nil {
+			t.Fatalf("decoding %s: %v", check.rel, err)
+		}
+		if decoded.Formula != check.formula {
+			t.Errorf("%s formula = %q, want %q", check.rel, decoded.Formula, check.formula)
+		}
+		if decoded.Phase != "vapor" {
+			t.Errorf("%s phase = %q, want vapor", check.rel, decoded.Phase)
+		}
+		if decoded.Requires["formula_compiler"] != "" || strings.Contains(body, "formula_compiler") {
+			t.Errorf("%s must not require formula_compiler", check.rel)
+		}
+		assertContainsInOrder(t, body,
+			"After claiming this vapor wisp",
+			"gc bd formula show "+check.formula+" --json",
+			"gc runtime drain-ack",
+		)
+	}
+}
+
+func TestDogStartupPromptUsesClaimFirstAssignedReadyPlaceholder(t *testing.T) {
+	dir := exampleDir()
+	checks := []string{
+		"packs/maintenance/agents/dog/prompt.template.md",
+		"packs/maintenance/template-fragments/propulsion.template.md",
+		"packs/gastown/template-fragments/propulsion.template.md",
+	}
+	for _, rel := range checks {
+		data, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("reading %s: %v", rel, err)
+		}
+		body := string(data)
+		if !strings.Contains(body, "{{ .AssignedReadyQuery }}") {
+			t.Errorf("%s missing AssignedReadyQuery placeholder", rel)
+		}
+		if strings.Contains(body, `gc bd ready --assignee="$GC_SESSION_NAME"`) {
+			t.Errorf("%s hardcodes assigned-ready bd command instead of compatibility-aware placeholder", rel)
+		}
+	}
+
+	dogPrompt, err := os.ReadFile(filepath.Join(dir, "packs/maintenance/agents/dog/prompt.template.md"))
+	if err != nil {
+		t.Fatalf("reading dog prompt: %v", err)
+	}
+	assertContainsInOrder(t, string(dogPrompt),
+		"## Startup Protocol",
+		"CLAIM-FIRST INVARIANT",
+		"{{ .AssignedReadyQuery }}",
+		"{{ .WorkQuery }}",
+		"gc bd update <id> --claim",
+		"gc bd show <id> --json",
+	)
+}
+
 func TestGastownRigTargetShellExpressionsRenderForRigAndHQ(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
@@ -1,6 +1,20 @@
 description = """
 Generate activity digest for the mayor.
 
+After claiming this vapor wisp, run:
+
+```bash
+gc bd formula show mol-digest-generate --json
+```
+
+Follow the step descriptions in order. When finished, close this bead, then run:
+
+```bash
+gc runtime drain-ack
+```
+
+The drain-ack tells the controller this session is done.
+
 This is a **periodic formula** — dispatched by the deacon's
 `periodic-formulas` step when the cooldown trigger elapses. Configured
 in `city.toml` under `[formulas]`:
@@ -30,9 +44,7 @@ The digest is mailed to the mayor and archived as a digest bead.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-digest-generate"
-
-[requires]
-formula_compiler = ">=2.0.0"
+phase = "vapor"
 
 [vars]
 [vars.period]

--- a/examples/gastown/packs/gastown/template-fragments/propulsion.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/propulsion.template.md
@@ -191,12 +191,15 @@ stale. Polecats idle. The witness escalates. All because the gearbox seized.
 
 **Your startup behavior:**
 1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
-2. If work found → EXECUTE immediately (read formula steps)
-3. If nothing → `{{ .WorkQuery }}` to find pool work
-4. If pool work found → Claim it: `gc bd update <id> --claim`
-5. If nothing → Exit (controller will recycle you)
+2. If work found -> EXECUTE immediately (already claimed, no race)
+3. If nothing -> `{{ .AssignedReadyQuery }}`
+4. If still nothing -> `{{ .WorkQuery }}` to find routed pool work
+5. If a candidate appears -> claim immediately: `gc bd update <id> --claim`
+6. After claiming -> verify `assignee` is `$GC_SESSION_NAME` and
+   `metadata.gc.routed_to` is `$GC_TEMPLATE`, then follow the formula
+7. If nothing valid -> `gc runtime drain-ack && exit`
 
-**Find work → Execute → Close → Exit. No waiting.**
+**Find work -> Claim -> Verify -> Execute -> Close -> Exit. No waiting.**
 
 **Who depends on you:** The deacon and witnesses file warrants expecting
 prompt execution. A stuck agent stays stuck until you run the shutdown

--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -22,6 +22,39 @@ queued formula.
 
 {{ template "following-mol" . }}
 
+## Startup Protocol
+
+> **The Universal Propulsion Principle: If your hook/work query finds work, YOU RUN IT.**
+
+> **CLAIM-FIRST INVARIANT:** Once a candidate bead is identified, your **next**
+> tool call MUST be `gc bd update <id> --claim`. Do not read formula details,
+> show metadata, inspect sessions, run diagnostics, or run any other Bash
+> before the claim succeeds. The claim flips bd status to in_progress
+> atomically; without it, the pool reconciler can recycle you mid-read and
+> another dog can race-claim the same bead. Close the window.
+
+```bash
+# Step 1a: Check for assigned in-progress work (already claimed, no race)
+gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress
+
+# Step 1b: If none, check for assigned ready work
+{{ .AssignedReadyQuery }}
+
+# Step 1c: If none, find routed pool work
+{{ .WorkQuery }}
+
+# Step 1d: CLAIM IMMEDIATELY. This is your next tool call, no exceptions.
+gc bd update <id> --claim
+
+# Step 2: AFTER successful claim, verify before doing formula work.
+gc bd show <id> --json
+```
+
+After claiming, verify `assignee` is `$GC_SESSION_NAME` and
+`metadata.gc.routed_to` is `$GC_TEMPLATE`. If either check fails, do not work
+that bead; run the work query again or `gc runtime drain-ack` if no valid work
+is available.
+
 ### Available Formulas
 
 | Formula | Purpose |
@@ -32,10 +65,10 @@ queued formula.
 
 Additional formulas available from included packs (e.g. dolt).
 
-If your wisp names a formula not listed above (one that an included
-pack provides, or one the daemon assigned), read its recipe with
-`gc bd formula show <formula-name>`. **Never** locate formula files
-with whole-filesystem searches (`find /`, `find ~`) — they trigger
+If your wisp names a formula, read its recipe with
+`gc bd formula show <formula-name> --json` and follow the step descriptions in
+order. **Never** locate formula files with whole-filesystem searches (`find /`,
+`find ~`) — they trigger
 macOS TCC permission prompts on protected directories (Documents,
 Desktop, Downloads, removable volumes, network mounts) and produce
 no useful signal a `gc` introspection command can't already provide.
@@ -118,11 +151,13 @@ gc session nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 
 | Want to... | Correct command |
 |------------|----------------|
-| Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
-| Read formula recipe | `gc bd formula show <formula-name>` (NOT `find /`) |
+| Check existing claim | `gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress` |
+| Check assigned ready work | `{{ .AssignedReadyQuery }}` |
+| Read formula ref | `gc bd show <wisp-id>` |
+| Read formula recipe | `gc bd formula show <formula-name> --json` (NOT `find /`) |
 | Find pool work | `{{ .WorkQuery }}` |
-| Claim pool work | `gc bd update <id> --claim` |
-| View work details | `gc bd show <id> --json` |
+| Claim pool work before inspection | `gc bd update <id> --claim` |
+| Verify claimed work | `gc bd show <id> --json` |
 | Close completed work | `gc bd close <id> --reason "..."` |
 | Request target restart | `gc session kill <target>` |
 | List orphan databases | `gc dolt cleanup` |

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
@@ -1,6 +1,20 @@
 description = """
 Export Dolt databases to JSONL and push to git archive.
 
+After claiming this vapor wisp, run:
+
+```bash
+gc bd formula show mol-dog-jsonl --json
+```
+
+Follow the step descriptions in order. When finished, close this bead, then run:
+
+```bash
+gc runtime drain-ack
+```
+
+The drain-ack tells the controller this session is done.
+
 The JSONL Dog exports each production database's issues table (scrubbed of
 ephemeral data) plus supplemental tables to JSONL files, commits them to a
 git repository, and pushes to origin. This provides a human-readable,
@@ -39,6 +53,7 @@ the main codebase.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-jsonl"
+phase = "vapor"
 
 [vars]
 [vars.databases]

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -1,6 +1,20 @@
 description = """
 Reap stale wisps across Dolt databases and close stale issues in the city DB.
 
+After claiming this vapor wisp, run:
+
+```bash
+gc bd formula show mol-dog-reaper --json
+```
+
+Follow the step descriptions in order. When finished, close this bead, then run:
+
+```bash
+gc runtime drain-ack
+```
+
+The drain-ack tells the controller this session is done.
+
 The Reaper Dog closes stale non-closed wisps only when parent-child
 dependency data proves the parent is closed, purges closed wisps
 older than the purge threshold, and auto-closes stale issues only in the city
@@ -80,9 +94,7 @@ The Dog should watch for and flag:
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-reaper"
-
-[requires]
-formula_compiler = ">=2.0.0"
+phase = "vapor"
 
 [vars]
 [vars.max_age]

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
@@ -1,6 +1,20 @@
 description = """
 Shutdown dance — due process for stuck agents.
 
+After claiming this vapor wisp, run:
+
+```bash
+gc bd formula show mol-shutdown-dance --json
+```
+
+Follow the step descriptions in order. When finished, close this bead, then run:
+
+```bash
+gc runtime drain-ack
+```
+
+The drain-ack tells the controller this session is done.
+
 Dispatched by filing a warrant bead routed to the dog pool:
 
 ```bash
@@ -46,6 +60,7 @@ recovery mechanism for all stuck agents.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-shutdown-dance"
+phase = "vapor"
 
 [vars]
 [vars.warrant_id]

--- a/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
@@ -5,6 +5,13 @@ Your formula defines your work as a sequence of steps. Steps are NOT
 materialized as individual beads — they exist in the formula definition.
 Read the step descriptions and work through them in order.
 
+If your claimed bead is a formula wisp, `gc bd show <wisp-id>` gives you the
+formula reference. Read the full recipe with:
+
+```bash
+gc bd formula show <formula-name> --json
+```
+
 **THE RULE**: Execute one step at a time. Verify completion. Move to next.
 Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 

--- a/examples/gastown/packs/maintenance/template-fragments/propulsion.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/propulsion.template.md
@@ -206,13 +206,16 @@ idle. The witness escalates. All because the gearbox seized.
 Gas Town is a steam engine. You are a piston that fires when called.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
-2. If work found -> EXECUTE immediately
-3. If nothing -> `{{ .WorkQuery }}` to find pool work
-4. If pool work found -> Claim it: `gc bd update <id> --claim`
-5. If nothing -> Exit (controller will recycle you)
+1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+2. If work found -> EXECUTE immediately (already claimed, no race)
+3. If nothing -> `{{ .AssignedReadyQuery }}`
+4. If still nothing -> `{{ .WorkQuery }}` to find routed pool work
+5. If a candidate appears -> claim immediately: `gc bd update <id> --claim`
+6. After claiming -> verify `assignee` is `$GC_SESSION_NAME` and
+   `metadata.gc.routed_to` is `$GC_TEMPLATE`, then follow the formula
+7. If nothing valid -> `gc runtime drain-ack && exit`
 
-**Find work -> Execute -> Close -> Exit. No waiting.**
+**Find work -> Claim -> Verify -> Execute -> Close -> Exit. No waiting.**
 
 **Who depends on you:** The deacon and witnesses file warrants expecting
 prompt execution. A stuck agent stays stuck until you run the shutdown


### PR DESCRIPTION
## Summary
- cherry-pick only the dog prompt/formula repair from f3533eafb on repair/storage-policy-phase1-20260602
- mark dog and digest maintenance formulas as vapor work that must be claimed before inspection
- add Gastown regression coverage for the vapor formula contract and dog startup claim-first guidance

## Why this branch
The source branch contains unrelated storage-policy commits, so this PR carries only the missing dog prompt/formula commit against current origin/main.

## Local validation
- go test ./examples/gastown -count=1
- .githooks/pre-commit (lint-changed, generation, go vet ./..., make test-fast-parallel, docs sync)