### PR TITLE
docs: refresh stale version strings and user-first framing (#3015)

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Gas City
-description: Contributor-facing documentation for the Gas City orchestration SDK.
+description: Documentation for engineers who want to run the Gas City orchestration SDK.
 ---
 
 Gas City is an orchestration-builder SDK for multi-agent systems. This docs
-tree is organized so you can get oriented quickly: understand how the system
-fits together, install the toolchain, run a local city, and then find the
-relevant subsystem.
+tree is organized for engineers who want to run Gas City: understand how the
+system fits together, install the toolchain, run a local city, and then find
+the relevant subsystem.
 
 If you are new, start with the
 [Architecture Overview](/concepts/architecture-overview) — it explains what the
@@ -43,5 +43,5 @@ notes), see the `engdocs/` directory in the repository.
 ## Repository Context
 
 Gas City is the open-source SDK extracted from Gas Town. The public docs now
-separate current contributor guidance from historical planning material so new
+separate guidance for running Gas City from historical planning material so new
 readers can get oriented without reading every audit and roadmap first.

--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -22,7 +22,7 @@ $ brew install gascity
 
 ~
 $ gc version
-0.13.4
+1.2.1
 ```
 
 > NOTE: the gascity installation is a great way to get the right dependencies in


### PR DESCRIPTION
Implements #3015 (User Docs Overhaul — Milestone 1, Issue 4 / finding F12).

## What changed (`docs/` only)

1. **Stale version pin** — `docs/tutorials/01-cities-and-rigs.md`: the `gc version` sample output `0.13.4` → `1.2.1` (current release, per `CHANGELOG.md` entry `[1.2.1] - 2026-05-31`).
2. **User-first framing** — `docs/index.mdx`: reframed from contributor-facing to user-first in three places (frontmatter `description`, opening paragraph, and Repository Context), e.g. "organized for engineers who want to run Gas City".
3. **Agent Protocol sweep** — grep for `Agent Protocol` / `AgentProtocol` across `docs/` returned zero hits; no survivors to remove.

## Version strings intentionally left unchanged

The sweep surfaced other `vX.Y.Z` strings that are legitimate references, not stale current-version pins:
- `installation.md` — link to the real `v0.13.3` release notes
- `troubleshooting.md` — "upgrade to v0.13.4 or later" (accurate fix-availability statement)
- `reference/config.md` + `schema/*` — generated tombstone-field docs citing real removal versions (`v0.15.1`, `v0.16`)
- `guides/understanding-packs.md` — sample *pack* version, not the `gc` CLI version
- `concepts/primitives.md` — `--reason "Shipped in v1.1.0"` sample text

## Acceptance criteria

- [x] Tutorial sample output shows `1.2.1`, not `0.13.4`
- [x] Other `docs/` version strings reviewed — only legitimate historical refs remain
- [x] `docs/index.mdx` no longer describes the site as "organized for external contributors first"
- [x] No reference to the removed Agent Protocol primitive in `docs/`
- [x] All changes confined to `docs/`; `engdocs/` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)