### PR TITLE
feat: add bead storage policy tiers

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -145,7 +145,8 @@ func newControllerState(
 // wrapWithCachingStore wraps a Store with a CachingStore that primes
 // and starts a background reconciler.
 func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Provider) beads.Store {
-	if store == nil {
+	baseStore, policyStore, policyWrapped := unwrapBeadPolicyStore(store)
+	if baseStore == nil {
 		return nil
 	}
 	if ctx == nil {
@@ -165,7 +166,7 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 			})
 		}
 	}
-	cs := beads.NewCachingStore(store, onChange)
+	cs := beads.NewCachingStore(baseStore, onChange)
 	// Pre-prime active beads synchronously (~1-2s, indexed queries).
 	// Loads open + in_progress beads — enough for the startup path
 	// (adoption, session snapshot, desired state) so the city can
@@ -174,6 +175,9 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 		log.Printf("caching-store: pre-prime failed: %v", err)
 	}
 	if ctx.Done() == nil {
+		if policyWrapped {
+			return wrapStoreWithBeadPolicies(cs, policyStore.cfg)
+		}
 		return cs
 	}
 	// Full prime runs async — backfills remaining beads for List()
@@ -189,6 +193,9 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 		}
 		cs.StartReconciler(ctx, beads.WithStaggerAuto(), os.Getenv("GC_AGENT"))
 	}()
+	if policyWrapped {
+		return wrapStoreWithBeadPolicies(cs, policyStore.cfg)
+	}
 	return cs
 }
 
@@ -204,7 +211,7 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 	if cityProvider == "file" && !fileStoreUsesScopedRoots(cs.cityPath) {
 		store, err := openCompatibleFileStore(cs.cityPath, cs.cityPath)
 		if err == nil {
-			sharedLegacyFileStore = store
+			sharedLegacyFileStore = wrapStoreWithBeadPolicies(store, cfg)
 		}
 	}
 
@@ -261,14 +268,14 @@ func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix strin
 		if err != nil {
 			return unavailableStore{err: fmt.Errorf("open exec rig store %s: %w", scopeRoot, err)}
 		}
-		return store
+		return wrapStoreWithBeadPolicies(store, cfg)
 	}
 	if provider == "file" {
 		store, err := openCompatibleFileStore(scopeRoot, cs.cityPath)
 		if err != nil {
 			return unavailableStore{err: fmt.Errorf("open file rig store %s: %w", scopeRoot, err)}
 		}
-		return store
+		return wrapStoreWithBeadPolicies(store, cfg)
 	}
 	result, err := controllerStateOpenRigStoreAtForCity(context.Background(), beads.StoreOpenOptions{
 		ScopeRoot:        scopeRoot,
@@ -297,7 +304,7 @@ func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix strin
 	if err != nil {
 		return unavailableStore{err: fmt.Errorf("open rig store %s: %w", scopeRoot, err)}
 	}
-	return result.Store
+	return wrapStoreWithBeadPolicies(result.Store, cfg)
 }
 
 // startBeadEventWatcher subscribes to the event bus and feeds bead events

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -530,6 +530,9 @@ func closeBeadStoreHandle(store beads.Store) error {
 	if store == nil {
 		return nil
 	}
+	if base, _, ok := unwrapBeadPolicyStore(store); ok {
+		return closeBeadStoreHandle(base)
+	}
 	if cached, ok := store.(*beads.CachingStore); ok {
 		cached.StopReconciler()
 		return closeBeadStoreHandle(cached.Backing())

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -1565,6 +1565,19 @@ func TestControllerStateUpdateClosesReplacedRigStores(t *testing.T) {
 	waitForCloseStoreSpy(t, oldStore)
 }
 
+func TestCloseBeadStoreHandleUnwrapsPolicyWrappedCachingStore(t *testing.T) {
+	backing := &closeStoreSpy{Store: beads.NewMemStore()}
+	cache := beads.NewCachingStore(backing, nil)
+	wrapped := wrapStoreWithBeadPolicies(cache, &config.City{})
+
+	if err := closeBeadStoreHandle(wrapped); err != nil {
+		t.Fatalf("closeBeadStoreHandle: %v", err)
+	}
+	if backing.closeCount() != 1 {
+		t.Fatalf("backing CloseStore calls = %d, want 1", backing.closeCount())
+	}
+}
+
 func TestControllerStateUpdateKeepsStaleRigStoreUsableDuringReload(t *testing.T) {
 	prevOpen := newControllerStateOpenCityStore
 	t.Cleanup(func() { newControllerStateOpenCityStore = prevOpen })

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2210,9 +2210,10 @@ provider = "file"
 	if !factoryCalled {
 		t.Fatal("buildStores did not route bd-backed rig through store factory")
 	}
-	cached, ok := stores["frontend"].(*beads.CachingStore)
+	frontendStore := underlyingPolicyStoreForTest(stores["frontend"])
+	cached, ok := frontendStore.(*beads.CachingStore)
 	if !ok {
-		t.Fatalf("frontend store = %T, want caching store", stores["frontend"])
+		t.Fatalf("frontend store = %T, want caching store", frontendStore)
 	}
 	if cached.Backing() != nativeBacking {
 		t.Fatalf("frontend backing = %T, want native factory backing", cached.Backing())

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -1686,7 +1686,7 @@ prefix = "fe"
 	if result.Diagnostic.Store != "BdStore" {
 		t.Fatalf("beads_store = %q, want BdStore", result.Diagnostic.Store)
 	}
-	store := result.Store
+	store := underlyingPolicyStoreForTest(result.Store)
 	if _, ok := store.(*beads.BdStore); !ok {
 		t.Fatalf("openStoreAtForCity(rig) returned %T, want *beads.BdStore", store)
 	}
@@ -1719,6 +1719,7 @@ prefix = "fe"
 	if err != nil {
 		t.Fatalf("openStoreAtForCity(rig): %v", err)
 	}
+	store = underlyingPolicyStoreForTest(store)
 	if _, ok := store.(*beads.FileStore); !ok {
 		t.Fatalf("openStoreAtForCity(rig) returned %T, want *beads.FileStore", store)
 	}
@@ -1985,6 +1986,7 @@ exit 0
 	if err != nil {
 		t.Fatalf("openStoreAtForCity: %v", err)
 	}
+	store = underlyingPolicyStoreForTest(store)
 	bdStore, ok := store.(*beads.BdStore)
 	if !ok {
 		t.Fatalf("openStoreAtForCity returned %T, want *beads.BdStore", store)
@@ -2683,6 +2685,7 @@ func TestOpenCityStoreAtUsesExplicitCityOverGCCity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openCityStoreAt(%q): %v", explicitCity, err)
 	}
+	store = underlyingPolicyStoreForTest(store)
 	bdStore, ok := store.(*beads.BdStore)
 	if !ok {
 		t.Fatalf("openCityStoreAt(%q) returned %T, want *beads.BdStore", explicitCity, store)

--- a/cmd/gc/bead_policy_store.go
+++ b/cmd/gc/bead_policy_store.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+const (
+	beadStorageHistory   = config.BeadStorageHistory
+	beadStorageNoHistory = config.BeadStorageNoHistory
+	beadStorageEphemeral = config.BeadStorageEphemeral
+
+	beadPolicyWisp          = "wisp"
+	beadPolicyWorkflow      = "workflow"
+	beadPolicyOrderTracking = "order_tracking"
+	beadPolicySession       = "session"
+	beadPolicyWait          = "wait"
+	beadPolicyNudge         = "nudge"
+)
+
+type beadPolicyStore struct {
+	beads.Store
+	cfg *config.City
+
+	mu               sync.Mutex
+	wispRootStorage  map[string]string
+	wispRootPolicies map[string]string
+}
+
+type beadPolicyGraphStore struct {
+	*beadPolicyStore
+	applier beads.GraphApplyStore
+}
+
+func wrapStoreWithBeadPolicies(store beads.Store, cfg *config.City) beads.Store {
+	if store == nil {
+		return nil
+	}
+	policyStore := &beadPolicyStore{
+		Store:            store,
+		cfg:              cfg,
+		wispRootStorage:  make(map[string]string),
+		wispRootPolicies: make(map[string]string),
+	}
+	if applier, ok := store.(beads.GraphApplyStore); ok {
+		return &beadPolicyGraphStore{
+			beadPolicyStore: policyStore,
+			applier:         applier,
+		}
+	}
+	return policyStore
+}
+
+func unwrapBeadPolicyStore(store beads.Store) (beads.Store, *beadPolicyStore, bool) {
+	switch s := store.(type) {
+	case *beadPolicyGraphStore:
+		return s.Store, s.beadPolicyStore, true
+	case *beadPolicyStore:
+		return s.Store, s, true
+	default:
+		return store, nil, false
+	}
+}
+
+func (s *beadPolicyStore) Create(b beads.Bead) (beads.Bead, error) {
+	policyName, storage := s.policyForCreate(b)
+	created, err := createWithStoragePolicy(s.Store, b, storage)
+	if err != nil {
+		return created, err
+	}
+	if policyName == beadPolicyWisp && created.ID != "" {
+		s.mu.Lock()
+		s.wispRootStorage[created.ID] = storage
+		s.wispRootPolicies[created.ID] = policyName
+		s.mu.Unlock()
+	}
+	return created, nil
+}
+
+func (s *beadPolicyStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	query = expandPolicyReadTier(query)
+	return s.Store.List(query)
+}
+
+func (s *beadPolicyStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	q := beads.ReadyQuery{}
+	if len(query) > 0 {
+		q = query[0]
+	}
+	if q.TierMode == beads.TierIssues {
+		q.TierMode = beads.TierBoth
+	}
+	return s.Store.Ready(q)
+}
+
+func (s *beadPolicyStore) Children(parentID string, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	return s.List(beads.ListQuery{
+		ParentID:      parentID,
+		IncludeClosed: beads.HasOpt(opts, beads.IncludeClosed),
+		Sort:          beads.SortCreatedAsc,
+		TierMode:      policyTierFromOpts(opts),
+	})
+}
+
+func (s *beadPolicyStore) ListByLabel(label string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	return s.List(beads.ListQuery{
+		Label:         label,
+		Limit:         limit,
+		IncludeClosed: beads.HasOpt(opts, beads.IncludeClosed),
+		TierMode:      policyTierFromOpts(opts),
+	})
+}
+
+func (s *beadPolicyStore) ListByAssignee(assignee, status string, limit int) ([]beads.Bead, error) {
+	return s.List(beads.ListQuery{
+		Assignee: assignee,
+		Status:   status,
+		Limit:    limit,
+		TierMode: beads.TierBoth,
+	})
+}
+
+func (s *beadPolicyStore) ListByMetadata(filters map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	return s.List(beads.ListQuery{
+		Metadata:      filters,
+		Limit:         limit,
+		IncludeClosed: beads.HasOpt(opts, beads.IncludeClosed),
+		TierMode:      policyTierFromOpts(opts),
+	})
+}
+
+func (s *beadPolicyStore) ListOpen(status ...string) ([]beads.Bead, error) {
+	wantStatus := "open"
+	if len(status) > 0 && strings.TrimSpace(status[0]) != "" {
+		wantStatus = status[0]
+	}
+	return s.List(beads.ListQuery{
+		Status:    wantStatus,
+		AllowScan: true,
+		TierMode:  beads.TierBoth,
+	})
+}
+
+func (s *beadPolicyStore) policyForCreate(b beads.Bead) (string, string) {
+	if rootID := strings.TrimSpace(b.Metadata["gc.root_bead_id"]); rootID != "" {
+		s.mu.Lock()
+		storage := s.wispRootStorage[rootID]
+		policyName := s.wispRootPolicies[rootID]
+		s.mu.Unlock()
+		if storage != "" {
+			return policyName, storage
+		}
+	}
+	policyName := policyNameForBead(b)
+	if policyName == "" {
+		return "", ""
+	}
+	return policyName, effectiveBeadStorage(s.cfg, policyName)
+}
+
+func (s *beadPolicyGraphStore) ApplyGraphPlan(ctx context.Context, plan *beads.GraphApplyPlan) (*beads.GraphApplyResult, error) {
+	if plan == nil {
+		return s.applier.ApplyGraphPlan(ctx, plan)
+	}
+	policyName := policyNameForGraphPlan(plan)
+	if policyName == "" {
+		return s.applier.ApplyGraphPlan(ctx, plan)
+	}
+	storage := effectiveBeadStorage(s.cfg, policyName)
+	if storageApplier, ok := s.applier.(beads.StorageGraphApplyStore); ok {
+		return storageApplier.ApplyGraphPlanWithStorage(ctx, plan, beadStorageClass(storage))
+	}
+	return s.applier.ApplyGraphPlan(ctx, plan)
+}
+
+func policyNameForGraphPlan(plan *beads.GraphApplyPlan) string {
+	for _, node := range plan.Nodes {
+		if isWispPolicyMetadata(node.Metadata) || hasBeadLabel(node.Labels, "gc:wisp") || hasBeadLabel(node.Labels, "wisp") {
+			return beadPolicyWisp
+		}
+	}
+	for _, node := range plan.Nodes {
+		if isWorkflowPolicyMetadata(node.Metadata) || isWorkflowPolicyMetadata(node.MetadataRefs) {
+			return beadPolicyWorkflow
+		}
+	}
+	return ""
+}
+
+func policyNameForBead(b beads.Bead) string {
+	switch {
+	case isWispPolicyMetadata(b.Metadata) || b.Type == "wisp" || hasBeadLabel(b.Labels, "gc:wisp") || hasBeadLabel(b.Labels, "wisp"):
+		return beadPolicyWisp
+	case hasBeadLabel(b.Labels, labelOrderTracking):
+		return beadPolicyOrderTracking
+	case hasBeadLabel(b.Labels, session.LabelSession) || b.Type == session.BeadType:
+		return beadPolicySession
+	case hasBeadLabel(b.Labels, session.WaitBeadLabel):
+		return beadPolicyWait
+	case hasBeadLabel(b.Labels, nudgeBeadLabel):
+		return beadPolicyNudge
+	case isWorkflowPolicyMetadata(b.Metadata):
+		return beadPolicyWorkflow
+	default:
+		return ""
+	}
+}
+
+func isWispPolicyMetadata(metadata map[string]string) bool {
+	return metadata["gc.kind"] == "wisp"
+}
+
+func isWorkflowPolicyMetadata(metadata map[string]string) bool {
+	if metadata == nil {
+		return false
+	}
+	return metadata["gc.kind"] == "workflow" ||
+		metadata["gc.formula_contract"] == "graph.v2" ||
+		strings.TrimSpace(metadata["gc.root_bead_id"]) != ""
+}
+
+func effectiveBeadStorage(cfg *config.City, policyName string) string {
+	if cfg != nil {
+		if policy, ok := cfg.Beads.Policies[policyName]; ok {
+			if storage := normalizeBeadStorage(policy.Storage); storage != "" {
+				if config.ValidBeadPolicyStorage(storage) && compatibleBeadPolicyStorage(cfg.Beads, policyName, storage) {
+					return storage
+				}
+				return defaultBeadStorage(cfg.Beads, policyName)
+			}
+		}
+		return defaultBeadStorage(cfg.Beads, policyName)
+	}
+	return defaultBeadStorage(config.BeadsConfig{}, policyName)
+}
+
+func defaultBeadStorage(beadsCfg config.BeadsConfig, policyName string) string {
+	if beadsCfg.UsesBD105ReadySemantics() {
+		switch policyName {
+		case beadPolicyWisp:
+			return beadStorageEphemeral
+		case beadPolicyWorkflow:
+			return beadStorageNoHistory
+		case beadPolicySession, beadPolicyWait, beadPolicyNudge, beadPolicyOrderTracking:
+			return beadStorageNoHistory
+		default:
+			return ""
+		}
+	}
+	switch policyName {
+	case beadPolicySession, beadPolicyWait, beadPolicyNudge, beadPolicyOrderTracking:
+		return beadStorageNoHistory
+	case beadPolicyWisp, beadPolicyWorkflow:
+		return beadStorageHistory
+	default:
+		return ""
+	}
+}
+
+func compatibleBeadPolicyStorage(beadsCfg config.BeadsConfig, policyName, storage string) bool {
+	if beadsCfg.UsesBD105ReadySemantics() {
+		switch policyName {
+		case beadPolicyWisp:
+			return storage == beadStorageEphemeral || storage == beadStorageNoHistory || storage == beadStorageHistory
+		case beadPolicyWorkflow:
+			return storage == beadStorageNoHistory || storage == beadStorageHistory
+		case beadPolicySession, beadPolicyWait, beadPolicyNudge, beadPolicyOrderTracking:
+			return storage == beadStorageNoHistory || storage == beadStorageHistory
+		default:
+			return true
+		}
+	}
+	switch policyName {
+	case beadPolicyWisp, beadPolicyWorkflow:
+		return storage == beadStorageHistory
+	case beadPolicySession, beadPolicyWait, beadPolicyNudge, beadPolicyOrderTracking:
+		return storage == beadStorageNoHistory || storage == beadStorageHistory
+	default:
+		return true
+	}
+}
+
+func normalizeBeadStorage(storage string) string {
+	return config.NormalizeBeadPolicyStorage(storage)
+}
+
+func createWithStoragePolicy(store beads.Store, b beads.Bead, storage string) (beads.Bead, error) {
+	if storage == "" {
+		return store.Create(b)
+	}
+	if storageStore, ok := store.(beads.StorageCreateStore); ok {
+		return storageStore.CreateWithStorage(b, beadStorageClass(storage))
+	}
+	return store.Create(applyBeadStorage(b, storage))
+}
+
+func beadStorageClass(storage string) beads.StorageClass {
+	switch normalizeBeadStorage(storage) {
+	case beadStorageEphemeral:
+		return beads.StorageEphemeral
+	case beadStorageNoHistory:
+		return beads.StorageNoHistory
+	case beadStorageHistory:
+		return beads.StorageHistory
+	default:
+		return beads.StorageDefault
+	}
+}
+
+func applyBeadStorage(b beads.Bead, storage string) beads.Bead {
+	switch beadStorageClass(storage) {
+	case beads.StorageEphemeral:
+		b.Ephemeral = true
+		b.NoHistory = false
+	case beads.StorageNoHistory:
+		b.Ephemeral = false
+		b.NoHistory = true
+	case beads.StorageHistory:
+		b.Ephemeral = false
+		b.NoHistory = false
+	}
+	return b
+}
+
+func expandPolicyReadTier(query beads.ListQuery) beads.ListQuery {
+	if query.TierMode == beads.TierIssues {
+		query.TierMode = beads.TierBoth
+	}
+	return query
+}
+
+func policyTierFromOpts(opts []beads.QueryOpt) beads.TierMode {
+	tier := beads.TierModeFromOpts(opts)
+	if tier == beads.TierIssues {
+		return beads.TierBoth
+	}
+	return tier
+}
+
+func hasBeadLabel(labels []string, label string) bool {
+	return slices.Contains(labels, label)
+}

--- a/cmd/gc/bead_policy_store.go
+++ b/cmd/gc/bead_policy_store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -27,10 +26,6 @@ const (
 type beadPolicyStore struct {
 	beads.Store
 	cfg *config.City
-
-	mu               sync.Mutex
-	wispRootStorage  map[string]string
-	wispRootPolicies map[string]string
 }
 
 type beadPolicyGraphStore struct {
@@ -43,12 +38,10 @@ func wrapStoreWithBeadPolicies(store beads.Store, cfg *config.City) beads.Store 
 		return nil
 	}
 	policyStore := &beadPolicyStore{
-		Store:            store,
-		cfg:              cfg,
-		wispRootStorage:  make(map[string]string),
-		wispRootPolicies: make(map[string]string),
+		Store: store,
+		cfg:   cfg,
 	}
-	if applier, ok := store.(beads.GraphApplyStore); ok {
+	if applier, ok := beads.GraphApplyFor(store); ok {
 		return &beadPolicyGraphStore{
 			beadPolicyStore: policyStore,
 			applier:         applier,
@@ -69,18 +62,8 @@ func unwrapBeadPolicyStore(store beads.Store) (beads.Store, *beadPolicyStore, bo
 }
 
 func (s *beadPolicyStore) Create(b beads.Bead) (beads.Bead, error) {
-	policyName, storage := s.policyForCreate(b)
-	created, err := createWithStoragePolicy(s.Store, b, storage)
-	if err != nil {
-		return created, err
-	}
-	if policyName == beadPolicyWisp && created.ID != "" {
-		s.mu.Lock()
-		s.wispRootStorage[created.ID] = storage
-		s.wispRootPolicies[created.ID] = policyName
-		s.mu.Unlock()
-	}
-	return created, nil
+	_, storage := s.policyForCreate(b)
+	return createWithStoragePolicy(s.Store, b, storage)
 }
 
 func (s *beadPolicyStore) List(query beads.ListQuery) ([]beads.Bead, error) {
@@ -89,14 +72,39 @@ func (s *beadPolicyStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 }
 
 func (s *beadPolicyStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
-	q := beads.ReadyQuery{}
-	if len(query) > 0 {
-		q = query[0]
-	}
-	if q.TierMode == beads.TierIssues {
-		q.TierMode = beads.TierBoth
-	}
-	return s.Store.Ready(q)
+	return s.Store.Ready(expandPolicyReadyQuery(query...))
+}
+
+func (s *beadPolicyStore) Handles() beads.StoreHandles {
+	handles := beads.HandlesFor(s.Store)
+	handles.Cached = beadPolicyCachedReader{CachedReader: handles.Cached}
+	handles.Live = beadPolicyLiveReader{LiveReader: handles.Live}
+	handles.Writer = s
+	return handles
+}
+
+type beadPolicyCachedReader struct {
+	beads.CachedReader
+}
+
+func (r beadPolicyCachedReader) List(query beads.ListQuery) ([]beads.Bead, error) {
+	return r.CachedReader.List(expandPolicyReadTier(query))
+}
+
+func (r beadPolicyCachedReader) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return r.CachedReader.Ready(expandPolicyReadyQuery(query...))
+}
+
+type beadPolicyLiveReader struct {
+	beads.LiveReader
+}
+
+func (r beadPolicyLiveReader) List(query beads.ListQuery) ([]beads.Bead, error) {
+	return r.LiveReader.List(expandPolicyReadTier(query))
+}
+
+func (r beadPolicyLiveReader) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	return r.LiveReader.Ready(expandPolicyReadyQuery(query...))
 }
 
 func (s *beadPolicyStore) Children(parentID string, opts ...beads.QueryOpt) ([]beads.Bead, error) {
@@ -149,12 +157,9 @@ func (s *beadPolicyStore) ListOpen(status ...string) ([]beads.Bead, error) {
 
 func (s *beadPolicyStore) policyForCreate(b beads.Bead) (string, string) {
 	if rootID := strings.TrimSpace(b.Metadata["gc.root_bead_id"]); rootID != "" {
-		s.mu.Lock()
-		storage := s.wispRootStorage[rootID]
-		policyName := s.wispRootPolicies[rootID]
-		s.mu.Unlock()
-		if storage != "" {
-			return policyName, storage
+		root, err := s.Get(rootID)
+		if err == nil && policyNameForBead(root) == beadPolicyWisp {
+			return beadPolicyWisp, storageFromPersistedWispRoot(root)
 		}
 	}
 	policyName := policyNameForBead(b)
@@ -162,6 +167,17 @@ func (s *beadPolicyStore) policyForCreate(b beads.Bead) (string, string) {
 		return "", ""
 	}
 	return policyName, effectiveBeadStorage(s.cfg, policyName)
+}
+
+func storageFromPersistedWispRoot(root beads.Bead) string {
+	switch {
+	case root.Ephemeral:
+		return beadStorageEphemeral
+	case root.NoHistory:
+		return beadStorageNoHistory
+	default:
+		return beadStorageHistory
+	}
 }
 
 func (s *beadPolicyGraphStore) ApplyGraphPlan(ctx context.Context, plan *beads.GraphApplyPlan) (*beads.GraphApplyResult, error) {
@@ -333,6 +349,17 @@ func expandPolicyReadTier(query beads.ListQuery) beads.ListQuery {
 		query.TierMode = beads.TierBoth
 	}
 	return query
+}
+
+func expandPolicyReadyQuery(query ...beads.ReadyQuery) beads.ReadyQuery {
+	q := beads.ReadyQuery{}
+	if len(query) > 0 {
+		q = query[0]
+	}
+	if q.TierMode == beads.TierIssues {
+		q.TierMode = beads.TierBoth
+	}
+	return q
 }
 
 func policyTierFromOpts(opts []beads.QueryOpt) beads.TierMode {

--- a/cmd/gc/bead_policy_store_conformance_test.go
+++ b/cmd/gc/bead_policy_store_conformance_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+type recordingPolicyReadStore struct {
+	*beads.MemStore
+	listQueries  []beads.ListQuery
+	readyQueries []beads.ReadyQuery
+}
+
+func (s *recordingPolicyReadStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.listQueries = append(s.listQueries, query)
+	return s.MemStore.List(query)
+}
+
+func (s *recordingPolicyReadStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	q := beads.ReadyQuery{}
+	if len(query) > 0 {
+		q = query[0]
+	}
+	s.readyQueries = append(s.readyQueries, q)
+	return s.MemStore.Ready(q)
+}
+
+func TestBeadPolicyStoreReadHelperTierConformance(t *testing.T) {
+	backing := &recordingPolicyReadStore{MemStore: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+
+	parent, err := backing.Create(beads.Bead{Title: "parent", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+	if _, err := backing.Create(beads.Bead{
+		Title:    "child",
+		ParentID: parent.ID,
+		Labels:   []string{"scope"},
+		Assignee: "worker",
+		Metadata: map[string]string{"route": "a"},
+	}); err != nil {
+		t.Fatalf("seed child: %v", err)
+	}
+
+	listCases := []struct {
+		name string
+		run  func() error
+		want func(beads.ListQuery) error
+	}{
+		{
+			name: "List expands default issues tier to both tiers",
+			run: func() error {
+				_, err := store.List(beads.ListQuery{Label: "scope"})
+				return err
+			},
+			want: func(q beads.ListQuery) error {
+				if q.Label != "scope" || q.TierMode != beads.TierBoth {
+					return fmt.Errorf("query = %#v, want label scope and TierBoth", q)
+				}
+				return nil
+			},
+		},
+		{
+			name: "List preserves explicit wisps tier",
+			run: func() error {
+				_, err := store.List(beads.ListQuery{Label: "scope", TierMode: beads.TierWisps})
+				return err
+			},
+			want: func(q beads.ListQuery) error {
+				if q.Label != "scope" || q.TierMode != beads.TierWisps {
+					return fmt.Errorf("query = %#v, want label scope and TierWisps", q)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Children expands default issues tier to both tiers",
+			run: func() error {
+				_, err := store.Children(parent.ID)
+				return err
+			},
+			want: func(q beads.ListQuery) error {
+				if q.ParentID != parent.ID || q.Sort != beads.SortCreatedAsc || q.TierMode != beads.TierBoth {
+					return fmt.Errorf("query = %#v, want parent, created asc, and TierBoth", q)
+				}
+				return nil
+			},
+		},
+		{
+			name: "ListByLabel expands default issues tier to both tiers",
+			run: func() error {
+				_, err := store.ListByLabel("scope", 7)
+				return err
+			},
+			want: func(q beads.ListQuery) error {
+				if q.Label != "scope" || q.Limit != 7 || q.TierMode != beads.TierBoth {
+					return fmt.Errorf("query = %#v, want label scope, limit 7, and TierBoth", q)
+				}
+				return nil
+			},
+		},
+		{
+			name: "ListByAssignee expands default issues tier to both tiers",
+			run: func() error {
+				_, err := store.ListByAssignee("worker", "open", 3)
+				return err
+			},
+			want: func(q beads.ListQuery) error {
+				if q.Assignee != "worker" || q.Status != "open" || q.Limit != 3 || q.TierMode != beads.TierBoth {
+					return fmt.Errorf("query = %#v, want assignee/status/limit and TierBoth", q)
+				}
+				return nil
+			},
+		},
+		{
+			name: "ListByMetadata expands default issues tier to both tiers",
+			run: func() error {
+				_, err := store.ListByMetadata(map[string]string{"route": "a"}, 4)
+				return err
+			},
+			want: func(q beads.ListQuery) error {
+				if q.Metadata["route"] != "a" || q.Limit != 4 || q.TierMode != beads.TierBoth {
+					return fmt.Errorf("query = %#v, want metadata route=a, limit 4, and TierBoth", q)
+				}
+				return nil
+			},
+		},
+		{
+			name: "ListOpen expands default issues tier to both tiers",
+			run: func() error {
+				_, err := store.ListOpen()
+				return err
+			},
+			want: func(q beads.ListQuery) error {
+				if q.Status != "open" || !q.AllowScan || q.TierMode != beads.TierBoth {
+					return fmt.Errorf("query = %#v, want open scan and TierBoth", q)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range listCases {
+		t.Run(tc.name, func(t *testing.T) {
+			backing.listQueries = nil
+			if err := tc.run(); err != nil {
+				t.Fatalf("read helper: %v", err)
+			}
+			if len(backing.listQueries) != 1 {
+				t.Fatalf("captured list queries = %#v, want exactly one", backing.listQueries)
+			}
+			if err := tc.want(backing.listQueries[0]); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+	readyCases := []struct {
+		name string
+		run  func() error
+		want beads.TierMode
+	}{
+		{
+			name: "Ready expands default issues tier to both tiers",
+			run: func() error {
+				_, err := store.Ready()
+				return err
+			},
+			want: beads.TierBoth,
+		},
+		{
+			name: "Ready preserves explicit wisps tier",
+			run: func() error {
+				_, err := store.Ready(beads.ReadyQuery{TierMode: beads.TierWisps})
+				return err
+			},
+			want: beads.TierWisps,
+		},
+	}
+
+	for _, tc := range readyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			backing.readyQueries = nil
+			if err := tc.run(); err != nil {
+				t.Fatalf("ready helper: %v", err)
+			}
+			if len(backing.readyQueries) != 1 {
+				t.Fatalf("captured ready queries = %#v, want exactly one", backing.readyQueries)
+			}
+			if backing.readyQueries[0].TierMode != tc.want {
+				t.Fatalf("Ready TierMode = %v, want %v", backing.readyQueries[0].TierMode, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/gc/bead_policy_store_conformance_test.go
+++ b/cmd/gc/bead_policy_store_conformance_test.go
@@ -197,3 +197,77 @@ func TestBeadPolicyStoreReadHelperTierConformance(t *testing.T) {
 		})
 	}
 }
+
+func TestBeadPolicyStoreHandleReadsArePolicyAware(t *testing.T) {
+	backing := &recordingPolicyReadStore{MemStore: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+	handles := beads.HandlesFor(store)
+
+	handleCases := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "cached list",
+			run: func() error {
+				_, err := handles.Cached.List(beads.ListQuery{Status: "open"})
+				return err
+			},
+		},
+		{
+			name: "live list",
+			run: func() error {
+				_, err := handles.Live.List(beads.ListQuery{Status: "open"})
+				return err
+			},
+		},
+	}
+	for _, tc := range handleCases {
+		t.Run(tc.name, func(t *testing.T) {
+			backing.listQueries = nil
+			if err := tc.run(); err != nil {
+				t.Fatalf("handle list: %v", err)
+			}
+			if len(backing.listQueries) != 1 {
+				t.Fatalf("captured list queries = %#v, want exactly one", backing.listQueries)
+			}
+			if backing.listQueries[0].TierMode != beads.TierBoth {
+				t.Fatalf("handle List TierMode = %v, want TierBoth", backing.listQueries[0].TierMode)
+			}
+		})
+	}
+
+	readyHandleCases := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "cached ready",
+			run: func() error {
+				_, err := handles.Cached.Ready()
+				return err
+			},
+		},
+		{
+			name: "live ready",
+			run: func() error {
+				_, err := handles.Live.Ready()
+				return err
+			},
+		},
+	}
+	for _, tc := range readyHandleCases {
+		t.Run(tc.name, func(t *testing.T) {
+			backing.readyQueries = nil
+			if err := tc.run(); err != nil {
+				t.Fatalf("handle ready: %v", err)
+			}
+			if len(backing.readyQueries) != 1 {
+				t.Fatalf("captured ready queries = %#v, want exactly one", backing.readyQueries)
+			}
+			if backing.readyQueries[0].TierMode != beads.TierBoth {
+				t.Fatalf("handle Ready TierMode = %v, want TierBoth", backing.readyQueries[0].TierMode)
+			}
+		})
+	}
+}

--- a/cmd/gc/bead_policy_store_test.go
+++ b/cmd/gc/bead_policy_store_test.go
@@ -1,0 +1,546 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+type captureCreateStore struct {
+	beads.Store
+	created  []beads.Bead
+	storages []beads.StorageClass
+}
+
+func (s *captureCreateStore) Create(b beads.Bead) (beads.Bead, error) {
+	s.created = append(s.created, b)
+	s.storages = append(s.storages, beads.StorageDefault)
+	return s.Store.Create(b)
+}
+
+func (s *captureCreateStore) CreateWithStorage(b beads.Bead, storage beads.StorageClass) (beads.Bead, error) {
+	s.created = append(s.created, b)
+	s.storages = append(s.storages, storage)
+	return s.Store.Create(b)
+}
+
+type captureGraphStore struct {
+	beads.Store
+	plan    *beads.GraphApplyPlan
+	storage beads.StorageClass
+}
+
+func underlyingPolicyStoreForTest(store beads.Store) beads.Store {
+	base, _, _ := unwrapBeadPolicyStore(store)
+	return base
+}
+
+func (s *captureGraphStore) ApplyGraphPlan(_ context.Context, plan *beads.GraphApplyPlan) (*beads.GraphApplyResult, error) {
+	next := *plan
+	s.plan = &next
+	ids := make(map[string]string, len(plan.Nodes))
+	for _, node := range plan.Nodes {
+		ids[node.Key] = "bd-" + node.Key
+	}
+	return &beads.GraphApplyResult{IDs: ids}, nil
+}
+
+func (s *captureGraphStore) ApplyGraphPlanWithStorage(_ context.Context, plan *beads.GraphApplyPlan, storage beads.StorageClass) (*beads.GraphApplyResult, error) {
+	s.storage = storage
+	return s.ApplyGraphPlan(context.Background(), plan)
+}
+
+func TestBeadPolicyStoreAppliesDefaultStorageForAllowlistedCreates(t *testing.T) {
+	backing := &captureCreateStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want string
+	}{
+		{
+			name: "session",
+			bead: beads.Bead{Title: "session", Type: session.BeadType, Labels: []string{session.LabelSession}},
+			want: beadStorageNoHistory,
+		},
+		{
+			name: "wait",
+			bead: beads.Bead{Title: "wait", Type: session.WaitBeadType, Labels: []string{session.WaitBeadLabel}},
+			want: beadStorageNoHistory,
+		},
+		{
+			name: "nudge",
+			bead: beads.Bead{Title: "nudge", Type: nudgeBeadType, Labels: []string{nudgeBeadLabel}},
+			want: beadStorageNoHistory,
+		},
+		{
+			name: "order tracking",
+			bead: beads.Bead{Title: "order:daily", Labels: []string{"order-run:daily", labelOrderTracking}},
+			want: beadStorageNoHistory,
+		},
+		{
+			name: "workflow root",
+			bead: beads.Bead{Title: "workflow", Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+			}},
+			want: beadStorageHistory,
+		},
+		{
+			name: "workflow child",
+			bead: beads.Bead{Title: "workflow child", Metadata: map[string]string{
+				"gc.root_bead_id": "bd-root",
+			}},
+			want: beadStorageHistory,
+		},
+		{
+			name: "wisp root",
+			bead: beads.Bead{Title: "wisp", Metadata: map[string]string{"gc.kind": "wisp"}},
+			want: beadStorageHistory,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			backing.created = nil
+			backing.storages = nil
+			if _, err := store.Create(tt.bead); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if len(backing.created) != 1 {
+				t.Fatalf("captured creates = %d, want 1", len(backing.created))
+			}
+			assertStorageClass(t, backing.storages[0], tt.want)
+		})
+	}
+}
+
+func TestBeadPolicyStoreBD105OptInUsesFastDefaultStorage(t *testing.T) {
+	backing := &captureCreateStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{
+		Beads: config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105},
+	})
+
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want string
+	}{
+		{
+			name: "wisp root",
+			bead: beads.Bead{Title: "wisp", Metadata: map[string]string{"gc.kind": "wisp"}},
+			want: beadStorageEphemeral,
+		},
+		{
+			name: "workflow graph work",
+			bead: beads.Bead{Title: "workflow", Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+			}},
+			want: beadStorageNoHistory,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			backing.created = nil
+			backing.storages = nil
+			if _, err := store.Create(tt.bead); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if len(backing.storages) != 1 {
+				t.Fatalf("captured storages = %d, want 1", len(backing.storages))
+			}
+			assertStorageClass(t, backing.storages[0], tt.want)
+		})
+	}
+}
+
+func TestBeadPolicyStoreLeavesOrdinaryWorkInHistory(t *testing.T) {
+	backing := &captureCreateStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+
+	if _, err := store.Create(beads.Bead{
+		Title: "source work",
+		Type:  "task",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(backing.storages) != 1 {
+		t.Fatalf("captured storages = %d, want 1", len(backing.storages))
+	}
+	if backing.storages[0] != beads.StorageDefault {
+		t.Fatalf("ordinary work storage = %q, want default history path", backing.storages[0])
+	}
+}
+
+func TestBeadPolicyStoreStorageOverrides(t *testing.T) {
+	backing := &captureCreateStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{
+		Beads: config.BeadsConfig{Policies: map[string]config.BeadPolicyConfig{
+			beadPolicySession:       {Storage: beadStorageHistory},
+			beadPolicyOrderTracking: {Storage: beadStorageHistory},
+			beadPolicyWorkflow:      {Storage: beadStorageHistory},
+			beadPolicyWisp:          {Storage: beadStorageHistory},
+		}},
+	})
+
+	if _, err := store.Create(beads.Bead{
+		Title:     "session",
+		Type:      session.BeadType,
+		Labels:    []string{session.LabelSession},
+		Ephemeral: true,
+	}); err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+	assertStorageClass(t, backing.storages[0], beadStorageHistory)
+
+	if _, err := store.Create(beads.Bead{
+		Title:  "order:daily",
+		Labels: []string{"order-run:daily", labelOrderTracking},
+	}); err != nil {
+		t.Fatalf("Create(order tracking): %v", err)
+	}
+	assertStorageClass(t, backing.storages[1], beadStorageHistory)
+
+	if _, err := store.Create(beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow", "gc.formula_contract": "graph.v2"},
+	}); err != nil {
+		t.Fatalf("Create(workflow): %v", err)
+	}
+	assertStorageClass(t, backing.storages[2], beadStorageHistory)
+
+	if _, err := store.Create(beads.Bead{
+		Title:    "wisp",
+		Metadata: map[string]string{"gc.kind": "wisp"},
+	}); err != nil {
+		t.Fatalf("Create(wisp): %v", err)
+	}
+	assertStorageClass(t, backing.storages[3], beadStorageHistory)
+}
+
+func TestBeadPolicyStoreAppliesWispRootStorageToSequentialChildren(t *testing.T) {
+	backing := &captureCreateStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+
+	root, err := store.Create(beads.Bead{Title: "root", Metadata: map[string]string{"gc.kind": "wisp"}})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "child",
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	}); err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+
+	if len(backing.created) != 2 {
+		t.Fatalf("captured creates = %d, want 2", len(backing.created))
+	}
+	assertStorageClass(t, backing.storages[0], beadStorageHistory)
+	assertStorageClass(t, backing.storages[1], beadStorageHistory)
+}
+
+func TestBeadPolicyGraphStoreAppliesWispStorageToGraphPlan(t *testing.T) {
+	backing := &captureGraphStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+	applier, ok := store.(beads.GraphApplyStore)
+	if !ok {
+		t.Fatal("wrapped graph store does not implement GraphApplyStore")
+	}
+
+	_, err := applier.ApplyGraphPlan(context.Background(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{
+			{Key: "root", Title: "Root", Metadata: map[string]string{"gc.kind": "wisp"}},
+			{Key: "child", Title: "Child", MetadataRefs: map[string]string{"gc.root_bead_id": "root"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyGraphPlan: %v", err)
+	}
+	if backing.plan == nil {
+		t.Fatal("graph plan was not captured")
+	}
+	assertStorageClass(t, backing.storage, beadStorageHistory)
+}
+
+func TestBeadPolicyGraphStoreAppliesWorkflowStorageToGraphPlan(t *testing.T) {
+	backing := &captureGraphStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+	applier, ok := store.(beads.GraphApplyStore)
+	if !ok {
+		t.Fatal("wrapped graph store does not implement GraphApplyStore")
+	}
+
+	_, err := applier.ApplyGraphPlan(context.Background(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{
+			{Key: "root", Title: "Root", Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+			}},
+			{Key: "child", Title: "Child", MetadataRefs: map[string]string{"gc.root_bead_id": "root"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyGraphPlan: %v", err)
+	}
+	if backing.plan == nil {
+		t.Fatal("graph plan was not captured")
+	}
+	assertStorageClass(t, backing.storage, beadStorageHistory)
+}
+
+func TestBeadPolicyGraphStoreAppliesWorkflowStorageToFragmentGraphPlan(t *testing.T) {
+	backing := &captureGraphStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{})
+	applier, ok := store.(beads.GraphApplyStore)
+	if !ok {
+		t.Fatal("wrapped graph store does not implement GraphApplyStore")
+	}
+
+	_, err := applier.ApplyGraphPlan(context.Background(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{
+			{Key: "child", Title: "Child", Metadata: map[string]string{"gc.root_bead_id": "bd-root"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyGraphPlan: %v", err)
+	}
+	if backing.plan == nil {
+		t.Fatal("graph plan was not captured")
+	}
+	assertStorageClass(t, backing.storage, beadStorageHistory)
+}
+
+func TestBeadPolicyGraphStoreBD105OptInUsesFastDefaultStorage(t *testing.T) {
+	tests := []struct {
+		name string
+		plan *beads.GraphApplyPlan
+		want string
+	}{
+		{
+			name: "wisp graph",
+			plan: &beads.GraphApplyPlan{
+				Nodes: []beads.GraphApplyNode{
+					{Key: "root", Title: "Root", Metadata: map[string]string{"gc.kind": "wisp"}},
+					{Key: "child", Title: "Child", MetadataRefs: map[string]string{"gc.root_bead_id": "root"}},
+				},
+			},
+			want: beadStorageEphemeral,
+		},
+		{
+			name: "workflow graph",
+			plan: &beads.GraphApplyPlan{
+				Nodes: []beads.GraphApplyNode{
+					{Key: "root", Title: "Root", Metadata: map[string]string{
+						"gc.kind":             "workflow",
+						"gc.formula_contract": "graph.v2",
+					}},
+					{Key: "child", Title: "Child", MetadataRefs: map[string]string{"gc.root_bead_id": "root"}},
+				},
+			},
+			want: beadStorageNoHistory,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backing := &captureGraphStore{Store: beads.NewMemStore()}
+			store := wrapStoreWithBeadPolicies(backing, &config.City{
+				Beads: config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105},
+			})
+			applier, ok := store.(beads.GraphApplyStore)
+			if !ok {
+				t.Fatal("wrapped graph store does not implement GraphApplyStore")
+			}
+
+			_, err := applier.ApplyGraphPlan(context.Background(), tt.plan)
+			if err != nil {
+				t.Fatalf("ApplyGraphPlan: %v", err)
+			}
+			if backing.plan == nil {
+				t.Fatal("graph plan was not captured")
+			}
+			assertStorageClass(t, backing.storage, tt.want)
+		})
+	}
+}
+
+func TestBeadPolicyGraphStoreRejectsNoHistoryWispOverride(t *testing.T) {
+	backing := &captureGraphStore{Store: beads.NewMemStore()}
+	store := wrapStoreWithBeadPolicies(backing, &config.City{
+		Beads: config.BeadsConfig{Policies: map[string]config.BeadPolicyConfig{
+			beadPolicyWisp: {Storage: beadStorageNoHistory},
+		}},
+	})
+	applier, ok := store.(beads.GraphApplyStore)
+	if !ok {
+		t.Fatal("wrapped graph store does not implement GraphApplyStore")
+	}
+
+	_, err := applier.ApplyGraphPlan(context.Background(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{
+			{Key: "root", Title: "Root", Metadata: map[string]string{"gc.kind": "wisp"}},
+			{Key: "child", Title: "Child", MetadataRefs: map[string]string{"gc.root_bead_id": "root"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyGraphPlan: %v", err)
+	}
+	assertStorageClass(t, backing.storage, beadStorageHistory)
+}
+
+func TestBeadPolicyStoreIgnoresUnsafeStorageOverrides(t *testing.T) {
+	tests := []struct {
+		name       string
+		policyName string
+		storage    string
+		bead       beads.Bead
+		want       string
+	}{
+		{
+			name:       "wisp cannot be forced no-history under bd 1.0.4",
+			policyName: beadPolicyWisp,
+			storage:    beadStorageNoHistory,
+			bead:       beads.Bead{Title: "wisp", Metadata: map[string]string{"gc.kind": "wisp"}},
+			want:       beadStorageHistory,
+		},
+		{
+			name:       "wisp cannot be forced ephemeral under bd 1.0.4",
+			policyName: beadPolicyWisp,
+			storage:    beadStorageEphemeral,
+			bead:       beads.Bead{Title: "wisp", Metadata: map[string]string{"gc.kind": "wisp"}},
+			want:       beadStorageHistory,
+		},
+		{
+			name:       "session cannot be forced ephemeral",
+			policyName: beadPolicySession,
+			storage:    beadStorageEphemeral,
+			bead:       beads.Bead{Title: "session", Type: session.BeadType, Labels: []string{session.LabelSession}},
+			want:       beadStorageNoHistory,
+		},
+		{
+			name:       "order tracking cannot be forced ephemeral",
+			policyName: beadPolicyOrderTracking,
+			storage:    beadStorageEphemeral,
+			bead:       beads.Bead{Title: "order:daily", Labels: []string{"order-run:daily", labelOrderTracking}},
+			want:       beadStorageNoHistory,
+		},
+		{
+			name:       "workflow cannot be forced no-history under bd 1.0.4",
+			policyName: beadPolicyWorkflow,
+			storage:    beadStorageNoHistory,
+			bead: beads.Bead{Title: "workflow", Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+			}},
+			want: beadStorageHistory,
+		},
+		{
+			name:       "workflow cannot be forced ephemeral",
+			policyName: beadPolicyWorkflow,
+			storage:    beadStorageEphemeral,
+			bead: beads.Bead{Title: "workflow", Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+			}},
+			want: beadStorageHistory,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backing := &captureCreateStore{Store: beads.NewMemStore()}
+			store := wrapStoreWithBeadPolicies(backing, &config.City{
+				Beads: config.BeadsConfig{Policies: map[string]config.BeadPolicyConfig{
+					tt.policyName: {Storage: tt.storage},
+				}},
+			})
+
+			if _, err := store.Create(tt.bead); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if len(backing.storages) != 1 {
+				t.Fatalf("captured storage count = %d, want 1", len(backing.storages))
+			}
+			assertStorageClass(t, backing.storages[0], tt.want)
+		})
+	}
+}
+
+func TestPolicyReadPathsIncludeHistoryAndNoHistoryRows(t *testing.T) {
+	runner := func(_ string, name string, args ...string) ([]byte, error) {
+		cmd := name + " " + strings.Join(args, " ")
+		switch cmd {
+		case "bd list --json --type=session --include-infra --include-gates --limit 0",
+			"bd list --json --label=gc:session --include-infra --include-gates --limit 0":
+			return []byte(`[
+				{"id":"bd-old-session","title":"old session","status":"open","issue_type":"session","created_at":"2026-05-01T00:00:00Z","labels":["gc:session"],"metadata":{"session_name":"old"}},
+				{"id":"bd-new-session","title":"new session","status":"open","issue_type":"session","created_at":"2026-05-01T00:00:01Z","labels":["gc:session"],"metadata":{"session_name":"new"},"no_history":true}
+			]`), nil
+		case "bd list --json --label=gc:wait --include-infra --include-gates --limit 0",
+			"bd list --json --label=gc:wait --include-infra --include-gates --limit 1001":
+			return []byte(`[
+				{"id":"bd-old-wait","title":"old wait","status":"open","issue_type":"gate","created_at":"2026-05-01T00:00:00Z","labels":["gc:wait"],"metadata":{"session_id":"s1"}},
+				{"id":"bd-new-wait","title":"new wait","status":"open","issue_type":"gate","created_at":"2026-05-01T00:00:01Z","labels":["gc:wait"],"metadata":{"session_id":"s2"},"no_history":true}
+			]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: %s", cmd)
+		}
+	}
+	store := beads.NewBdStore("/city", runner)
+
+	sessions, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("sessions = %+v, want history and no-history rows", sessions)
+	}
+	if !sessions[1].NoHistory {
+		t.Fatalf("new session row = %+v, want no_history parsed", sessions[1])
+	}
+
+	waits, err := loadWaitBeads(store)
+	if err != nil {
+		t.Fatalf("loadWaitBeads: %v", err)
+	}
+	if len(waits) != 2 {
+		t.Fatalf("waits = %+v, want history and no-history rows", waits)
+	}
+	foundNoHistoryWait := false
+	for _, wait := range waits {
+		if wait.ID == "bd-new-wait" {
+			foundNoHistoryWait = wait.NoHistory
+			break
+		}
+	}
+	if !foundNoHistoryWait {
+		t.Fatalf("waits = %+v, want bd-new-wait with no_history parsed", waits)
+	}
+}
+
+func assertStorageClass(t *testing.T, got beads.StorageClass, want string) {
+	t.Helper()
+	var wantClass beads.StorageClass
+	switch want {
+	case beadStorageHistory:
+		wantClass = beads.StorageHistory
+	case beadStorageEphemeral:
+		wantClass = beads.StorageEphemeral
+	case beadStorageNoHistory:
+		wantClass = beads.StorageNoHistory
+	default:
+		t.Fatalf("unknown expected storage %q", want)
+	}
+	if got != wantClass {
+		t.Fatalf("storage = %q, want %q", got, wantClass)
+	}
+}

--- a/cmd/gc/bead_policy_store_test.go
+++ b/cmd/gc/bead_policy_store_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -373,6 +375,32 @@ func TestBeadPolicyGraphStoreBD105OptInUsesFastDefaultStorage(t *testing.T) {
 	}
 }
 
+func TestBeadPolicyGraphStorePreservesGraphApplyThroughCachingStore(t *testing.T) {
+	backing := &captureGraphStore{Store: beads.NewMemStore()}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	store := wrapStoreWithBeadPolicies(cache, &config.City{
+		Beads: config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105},
+	})
+	applier, ok := store.(beads.GraphApplyStore)
+	if !ok {
+		t.Fatal("policy-wrapped cached graph store does not implement GraphApplyStore")
+	}
+
+	_, err := applier.ApplyGraphPlan(context.Background(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{
+			{Key: "root", Title: "Root", Metadata: map[string]string{"gc.kind": "wisp"}},
+			{Key: "child", Title: "Child", MetadataRefs: map[string]string{"gc.root_bead_id": "root"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyGraphPlan: %v", err)
+	}
+	if backing.plan == nil {
+		t.Fatal("graph plan was not captured")
+	}
+	assertStorageClass(t, backing.storage, beadStorageEphemeral)
+}
+
 func TestBeadPolicyGraphStoreRejectsNoHistoryWispOverride(t *testing.T) {
 	backing := &captureGraphStore{Store: beads.NewMemStore()}
 	store := wrapStoreWithBeadPolicies(backing, &config.City{
@@ -525,6 +553,60 @@ func TestPolicyReadPathsIncludeHistoryAndNoHistoryRows(t *testing.T) {
 	if !foundNoHistoryWait {
 		t.Fatalf("waits = %+v, want bd-new-wait with no_history parsed", waits)
 	}
+}
+
+func TestOpenStoreResultAtForCityWrapsSQLiteWithBeadPolicies(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "sqlite-policy-city"
+prefix = "ga"
+
+[beads]
+provider = "sqlite"
+bd_compatibility = "bd-1.0.5"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := openStoreResultAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreResultAtForCity: %v", err)
+	}
+	base, _, wrapped := unwrapBeadPolicyStore(result.Store)
+	if !wrapped {
+		t.Fatalf("openStoreResultAtForCity(sqlite) returned %T, want bead policy wrapper", result.Store)
+	}
+	defer func() {
+		if c, ok := base.(interface{ CloseStore() error }); ok {
+			c.CloseStore() //nolint:errcheck
+		}
+	}()
+
+	created, err := result.Store.Create(beads.Bead{
+		Title: "workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(workflow): %v", err)
+	}
+	if !created.NoHistory {
+		t.Fatalf("created workflow = %+v, want policy-applied no_history storage", created)
+	}
+
+	ready, err := result.Store.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	for _, bead := range ready {
+		if bead.ID == created.ID {
+			return
+		}
+	}
+	t.Fatalf("Ready() = %+v, missing policy-created SQLite workflow %s", ready, created.ID)
 }
 
 func assertStorageClass(t *testing.T, got beads.StorageClass, want string) {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -424,7 +424,7 @@ func buildDesiredStateWithSessionBeads(
 			}
 		}
 
-		sp := scaleParamsFor(&cfg.Agents[i])
+		sp := scaleParamsForBeads(&cfg.Agents[i], cfg.Beads)
 		// Expand {{.Rig}}/{{.AgentBase}} before the scale_check enters the
 		// controller probe pool so rig-scoped agents query their own rig.
 		sp.Check = expandAgentCommandTemplate(cityPath, cityName, &cfg.Agents[i], cfg.Rigs, "scale_check", sp.Check, stderr)
@@ -1185,6 +1185,7 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 		// only if a task-shaped routed bead also happens to carry the
 		// flag) is counted exactly once per template.
 		counted := make(map[string]struct{})
+		liveReader := beads.HandlesFor(group.store).Live
 
 		// Source 1: Ready()/CachedReady() iteration. Surfaces actionable
 		// work (task, etc.) from both durable and ephemeral tiers matched
@@ -1234,8 +1235,10 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 		// otherwise stretch demand observation by an unbounded number of
 		// reconcile ticks. Mirrors openSessionBeadExists in
 		// adoption_barrier.go, which uses Live: true for the same
-		// cross-process freshness reason.
-		demand, demandErr := group.store.List(beads.ListQuery{
+		// cross-process freshness reason. Dependency checks below use the
+		// same live reader so blocked pool-order wisps do not create pool
+		// sessions while sibling processes are still mutating the graph.
+		demand, demandErr := liveReader.List(beads.ListQuery{
 			Status:   "open",
 			Metadata: poolDemandMetadataPair(),
 			Live:     true,
@@ -1260,6 +1263,15 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			if _, ok := group.templates[template]; !ok {
 				continue
 			}
+			depsReady, depErr := poolDemandDependenciesReady(liveReader, b.ID)
+			if depErr != nil {
+				errs = append(errs, fmt.Errorf("default scale_check %s template=%s bead=%s: dependencies: %w", key, template, b.ID, depErr))
+				partialTemplates = markScaleCheckPartialTemplate(partialTemplates, template)
+				continue
+			}
+			if !depsReady {
+				continue
+			}
 			if _, dup := counted[b.ID]; dup {
 				continue
 			}
@@ -1268,6 +1280,33 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 		}
 	}
 	return counts, partialTemplates, errs
+}
+
+func poolDemandDependenciesReady(reader beads.LiveReader, beadID string) (bool, error) {
+	deps, err := reader.DepList(beadID, "down")
+	if err != nil {
+		return false, err
+	}
+	for _, dep := range deps {
+		if !beads.IsReadyBlockingDependencyType(dep.Type) {
+			continue
+		}
+		blockerID := strings.TrimSpace(dep.DependsOnID)
+		if blockerID == "" {
+			return false, nil
+		}
+		blocker, err := reader.Get(blockerID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				return false, nil
+			}
+			return false, fmt.Errorf("getting blocker %q: %w", blockerID, err)
+		}
+		if blocker.Status != "closed" {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.City, cityName string) (map[string]bool, map[string]bool, []error) {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1002,6 +1002,50 @@ func TestDefaultScaleCheckCountsIgnoresFutureDeferredCronPoolDemand(t *testing.T
 	}
 }
 
+func TestDefaultScaleCheckCountsIgnoresBlockedCronPoolDemand(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	blocker, err := backing.Create(beads.Bead{
+		Title:  "open prerequisite",
+		Type:   "task",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	wisp, err := backing.Create(beads.Bead{
+		Title:     "blocked pool-order wisp",
+		Type:      "molecule",
+		Status:    "open",
+		Metadata:  poolWispMetadata("cat"),
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("create blocked pool-order wisp: %v", err)
+	}
+	if err := backing.DepAdd(wisp.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "cat",
+		storeKey: "city",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["cat"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0 for dependency-blocked gc.pool_demand wisp", "cat", got)
+	}
+	if backing.livePoolDemand == 0 {
+		t.Fatalf("livePoolDemand list calls = 0, want >0")
+	}
+}
+
 // poolWispMetadata builds the metadata map a pool-order wisp carries —
 // gc.routed_to + the poolDemandMetadataPair pair — for fixture use.
 // Mirrors the production composition in cmd/gc/cmd_order.go and

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1046,6 +1046,51 @@ func TestDefaultScaleCheckCountsIgnoresBlockedCronPoolDemand(t *testing.T) {
 	}
 }
 
+func TestDefaultScaleCheckCountsUsesLiveDepsThroughPolicyWrappedCache(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	blocker, err := backing.Create(beads.Bead{
+		Title:  "open prerequisite",
+		Type:   "task",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	wisp, err := backing.Create(beads.Bead{
+		Title:     "blocked pool-order wisp",
+		Type:      "molecule",
+		Status:    "open",
+		Metadata:  poolWispMetadata("cat"),
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("create blocked pool-order wisp: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if err := backing.DepAdd(wisp.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd after cache prime: %v", err)
+	}
+
+	store := wrapStoreWithBeadPolicies(cache, &config.City{})
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "cat",
+		storeKey: "city",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["cat"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts[%q] = %d, want 0 for dependency added after cache prime", "cat", got)
+	}
+	if backing.livePoolDemand == 0 {
+		t.Fatalf("livePoolDemand list calls = 0, want >0")
+	}
+}
+
 // poolWispMetadata builds the metadata map a pool-order wisp carries —
 // gc.routed_to + the poolDemandMetadataPair pair — for fixture use.
 // Mirrors the production composition in cmd/gc/cmd_order.go and

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -507,7 +507,7 @@ func agentListItems(cfg *config.City) []AgentListItem {
 			Provider:             a.Provider,
 			Session:              a.Session,
 			Suspended:            a.Suspended,
-			WorkQuery:            a.EffectiveWorkQuery(),
+			WorkQuery:            a.EffectiveWorkQueryForBeads(cfg.Beads),
 			SlingQuery:           a.EffectiveSlingQuery(),
 			ConfiguredWorkQuery:  a.WorkQuery,
 			ConfiguredSlingQuery: a.SlingQuery,

--- a/cmd/gc/cmd_bd_store_bridge_test.go
+++ b/cmd/gc/cmd_bd_store_bridge_test.go
@@ -324,7 +324,10 @@ func TestBdStoreBridgeListCommandForwardsFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(args): %v", err)
 	}
-	for _, want := range []string{"list", "--json", "--status=open", "--assignee=mayor", "--type=message", "--include-infra", "--include-gates", "--limit", "7"} {
+	// BdStore may need to merge and filter policy tiers client-side, so it
+	// requests all server-side candidates and applies the requested limit after
+	// parsing.
+	for _, want := range []string{"list", "--json", "--status=open", "--assignee=mayor", "--type=message", "--include-infra", "--include-gates", "--limit", "0"} {
 		if !strings.Contains(string(argsText), want) {
 			t.Fatalf("list args missing %q: %s", want, string(argsText))
 		}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -2777,9 +2777,9 @@ func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
 		t.Fatalf("workflowServeControlReadyQuery should disable bd auto-export: %q", query)
 	}
 	for _, want := range []string{
-		`bd --readonly --sandbox ready --include-ephemeral --assignee="$cand" --exclude-type=epic --json --limit=20`,
-		`bd --readonly --sandbox ready --include-ephemeral --metadata-field "gc.run_target=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
-		`bd --readonly --sandbox ready --include-ephemeral --metadata-field "gc.routed_to=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
+		`bd --readonly --sandbox ready --assignee="$cand" --exclude-type=epic --json --limit=20`,
+		`bd --readonly --sandbox ready --metadata-field "gc.run_target=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
+		`bd --readonly --sandbox ready --metadata-field "gc.routed_to=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
 		`routed_ready "$GC_CONTROL_TARGET"`,
 		`routed_ready "${GC_CONTROL_LEGACY_TARGET:-}"`,
 	} {
@@ -2789,6 +2789,25 @@ func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
 	}
 	if !strings.Contains(query, `--limit=20`) {
 		t.Fatalf("workflowServeControlReadyQuery missing scan limit: %q", query)
+	}
+	if strings.Contains(query, "--include-ephemeral") {
+		t.Fatalf("workflowServeControlReadyQuery default must stay bd 1.0.4-compatible: %q", query)
+	}
+}
+
+func TestWorkflowServeControlReadyQueryBD105IncludesEphemeral(t *testing.T) {
+	query := workflowServeControlReadyQueryForBeads(
+		config.Agent{Name: config.ControlDispatcherAgentName},
+		config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105},
+	)
+	for _, want := range []string{
+		`bd --readonly --sandbox ready --include-ephemeral --assignee="$cand" --exclude-type=epic --json --limit=20`,
+		`bd --readonly --sandbox ready --include-ephemeral --metadata-field "gc.run_target=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
+		`bd --readonly --sandbox ready --include-ephemeral --metadata-field "gc.routed_to=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=20`,
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("workflowServeControlReadyQueryForBeads(bd-1.0.5) missing %q in %q", want, query)
+		}
 	}
 }
 
@@ -2807,10 +2826,10 @@ case "$*" in
   "--readonly --sandbox ready --assignee=gascity--control-dispatcher --json --limit=20")
     printf '[{"id":"ga-epic-leak"}]'
     ;;
-  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
     printf '[{"id":"ga-ready"}]'
     ;;
-  "--readonly --sandbox ready --include-ephemeral --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
+  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
     printf '[{"id":"ga-routed"}]'
     ;;
   *)
@@ -2829,10 +2848,10 @@ func TestWorkflowServeControlReadyQueryIncludesMetadataRoutedWorkAfterAssignedPe
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
     printf '[{"id":"ga-pending","metadata":{"gc.kind":"retry"}}]'
     ;;
-  "--readonly --sandbox ready --include-ephemeral --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
+  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
     printf '[{"id":"ga-ready","metadata":{"gc.kind":"scope-check"}}]'
     ;;
   *)
@@ -2851,13 +2870,13 @@ func TestWorkflowServeControlReadyQueryPreservesQueryPriorityWhenMerging(t *test
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
     printf '[{"id":"ga-z-assigned"},{"id":"ga-dup","source":"assigned"}]'
     ;;
-  "--readonly --sandbox ready --include-ephemeral --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
+  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
     printf '[{"id":"ga-a-routed"},{"id":"ga-route-dup","source":"run-target"}]'
     ;;
-  "--readonly --sandbox ready --include-ephemeral --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
+  "--readonly --sandbox ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json --sort oldest --limit=20")
     printf '[{"id":"ga-route-dup","source":"routed-to"}]'
     ;;
   *)
@@ -2881,7 +2900,7 @@ func TestWorkflowServeControlReadyQueryUsesConfiguredRuntimeNameWhenEnvIsManualS
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
     printf '[{"id":"ga-control-ready"}]'
     ;;
   *)
@@ -2945,7 +2964,7 @@ func TestWorkflowServeControlReadyQueryKeepsSuccessfulBDStderrOutOfJSON(t *testi
 set -eu
 printf '%s\n' "$*" >> "$BD_LOG"
 case "$*" in
-  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
     printf '[{"id":"ga-control-ready"}]'
     printf 'notice: refreshed export metadata\n' >&2
     ;;
@@ -2978,7 +2997,7 @@ func TestWorkflowServeControlReadyQueryFailsOnMalformedBDJSON(t *testing.T) {
 	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
 set -eu
 case "$*" in
-  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
     printf 'not-json'
     ;;
   *)
@@ -3014,7 +3033,7 @@ set -eu
 }
 printf '%s\n' "$*" >> "$BD_LOG"
 case "$*" in
-  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
     printf '[{"id":"ga-control-ready"}]'
     ;;
   *)
@@ -3041,7 +3060,7 @@ esac
 		t.Fatalf("read bd log: %v", err)
 	}
 	firstCall, _, _ := strings.Cut(strings.TrimSpace(string(logData)), "\n")
-	if want := "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20"; firstCall != want {
+	if want := "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20"; firstCall != want {
 		t.Fatalf("first bd call = %q, want %q; all calls:\n%s", firstCall, want, string(logData))
 	}
 }
@@ -3058,7 +3077,7 @@ func TestWorkflowServeControlReadyQueryDeduplicatesAssigneeProbes(t *testing.T) 
 set -eu
 printf '%s\n' "$*" >> "$BD_LOG"
 case "$*" in
-  "--readonly --sandbox ready --include-ephemeral --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=20")
     printf '[{"id":"ga-control-ready"}]'
     ;;
   *)
@@ -3099,19 +3118,18 @@ func TestWorkflowServeControlReadyQueryQuotesMetadataFallbackTarget(t *testing.T
 		"BD_MATCHED_ARGS": argsPath,
 	}, `#!/bin/sh
 set -eu
-if [ "$#" -eq 12 ] &&
+if [ "$#" -eq 11 ] &&
    [ "$1" = "--readonly" ] &&
    [ "$2" = "--sandbox" ] &&
    [ "$3" = "ready" ] &&
-   [ "$4" = "--include-ephemeral" ] &&
-   [ "$5" = "--metadata-field" ] &&
-   [ "$6" = "gc.run_target=my rig/control-dispatcher" ] &&
-   [ "$7" = "--unassigned" ] &&
-   [ "$8" = "--exclude-type=epic" ] &&
-   [ "$9" = "--json" ] &&
-   [ "${10}" = "--sort" ] &&
-   [ "${11}" = "oldest" ] &&
-   [ "${12}" = "--limit=20" ]; then
+   [ "$4" = "--metadata-field" ] &&
+   [ "$5" = "gc.run_target=my rig/control-dispatcher" ] &&
+   [ "$6" = "--unassigned" ] &&
+   [ "$7" = "--exclude-type=epic" ] &&
+   [ "$8" = "--json" ] &&
+   [ "$9" = "--sort" ] &&
+   [ "${10}" = "oldest" ] &&
+   [ "${11}" = "--limit=20" ]; then
   printf '%s\n' "$@" > "$BD_MATCHED_ARGS"
   printf '[{"id":"ga-routed"}]'
   exit 0
@@ -3124,7 +3142,7 @@ printf '[]'
 		t.Fatalf("read matched args: %v", err)
 	}
 	gotArgs := strings.Split(strings.TrimSpace(string(argsData)), "\n")
-	wantArgs := []string{"--readonly", "--sandbox", "ready", "--include-ephemeral", "--metadata-field", "gc.run_target=my rig/control-dispatcher", "--unassigned", "--exclude-type=epic", "--json", "--sort", "oldest", "--limit=20"}
+	wantArgs := []string{"--readonly", "--sandbox", "ready", "--metadata-field", "gc.run_target=my rig/control-dispatcher", "--unassigned", "--exclude-type=epic", "--json", "--sort", "oldest", "--limit=20"}
 	if !slices.Equal(gotArgs, wantArgs) {
 		t.Fatalf("matched bd args = %#v, want %#v", gotArgs, wantArgs)
 	}
@@ -3139,7 +3157,7 @@ func TestWorkflowServeControlReadyQueryUsesLegacyRouteForNamedSessions(t *testin
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "--readonly --sandbox ready --include-ephemeral --metadata-field gc.run_target=gascity/workflow-control --unassigned --exclude-type=epic --json --sort oldest --limit=20")
+  "--readonly --sandbox ready --metadata-field gc.run_target=gascity/workflow-control --unassigned --exclude-type=epic --json --sort oldest --limit=20")
     printf '[{"id":"ga-legacy-route"}]'
     ;;
   *)
@@ -3436,6 +3454,7 @@ func TestOpenControlStoreAtForCityPreservesFileAndExecProviderStores(t *testing.
 		if err != nil {
 			t.Fatalf("openControlStoreAtForCity(file): %v", err)
 		}
+		store = underlyingPolicyStoreForTest(store)
 		if _, ok := store.(*beads.FileStore); !ok {
 			t.Fatalf("control store = %T, want *beads.FileStore for file provider", store)
 		}

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -114,7 +114,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 	}
 
 	cityName := loadedCityName(cfg, cityPath)
-	workQuery := a.EffectiveWorkQuery()
+	workQuery := a.EffectiveWorkQueryForBeads(cfg.Beads)
 	// Expand {{.Rig}}/{{.AgentBase}} in user-supplied work_query so agent-side
 	// hook invocation sees the same rig substitution as the controller-side
 	// probes in build_desired_state.go / session_reconcile.go. #793.

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -715,7 +715,7 @@ max = 5
 		t.Fatalf("stdout = %q, want GC_RIG_ROOT=%q", out, rigDir)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, "args=list --include-ephemeral --status in_progress --assignee=host-session --json --limit=1") {
+	if !strings.Contains(out, "args=list --status in_progress --assignee=host-session --json --limit=1") {
 		t.Fatalf("stdout = %q, want pool work_query args", out)
 	}
 }
@@ -1030,7 +1030,7 @@ max = 5
 		t.Fatalf("stdout = %q, want command to run from rig root %q", out, rigDir)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, "args=list --include-ephemeral --status in_progress --assignee=host-session --json --limit=1") {
+	if !strings.Contains(out, "args=list --status in_progress --assignee=host-session --json --limit=1") {
 		t.Fatalf("stdout = %q, want pool template work_query args", out)
 	}
 }
@@ -1098,7 +1098,7 @@ name = "worker"
 		t.Fatalf("stdout = %q, want GC_SESSION_NAME=host-session", out)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, `args=list --include-ephemeral --status in_progress --assignee=host-session --json --limit=1`) {
+	if !strings.Contains(out, `args=list --status in_progress --assignee=host-session --json --limit=1`) {
 		t.Fatalf("stdout = %q, want metadata-routed work query", out)
 	}
 }
@@ -1159,7 +1159,7 @@ dir = "myrig"
 		t.Fatalf("stdout = %q, want GC_SESSION_NAME=%s", out, wantSession)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, `args=list --include-ephemeral --status in_progress --assignee=host-session --json --limit=1`) {
+	if !strings.Contains(out, `args=list --status in_progress --assignee=host-session --json --limit=1`) {
 		t.Fatalf("stdout = %q, want metadata-routed work query", out)
 	}
 }

--- a/cmd/gc/cmd_lint.go
+++ b/cmd/gc/cmd_lint.go
@@ -372,6 +372,7 @@ func lintPromptContext(packDir string, agentCfg config.Agent, providers map[stri
 		Branch:              "feature/lint",
 		DefaultBranch:       "main",
 		WorkQuery:           agentCfg.EffectiveWorkQuery(),
+		AssignedReadyQuery:  assignedReadyQueryForBeads(config.BeadsConfig{}),
 		SlingQuery:          agentCfg.EffectiveSlingQuery(),
 		ProviderKey:         providerKey,
 		ProviderDisplayName: providerDisplayNameFor(providerKey, providers),

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -763,7 +763,7 @@ func doOrderRunExecTracked(a orders.Order, cityPath string, cfg *config.City, st
 	tracking, err := store.Create(beads.Bead{
 		Title:     "order:" + scoped,
 		Labels:    []string{"order-run:" + scoped, labelOrderTracking},
-		Ephemeral: true,
+		NoHistory: true,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order run: creating exec tracking bead for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1063,8 +1063,8 @@ name = "test-city"
 	if len(results) != 1 {
 		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
 	}
-	if !results[0].Ephemeral {
-		t.Fatalf("tracking bead Ephemeral = false, want true")
+	if results[0].Ephemeral || !results[0].NoHistory {
+		t.Fatalf("tracking bead storage = Ephemeral:%v NoHistory:%v, want no-history only", results[0].Ephemeral, results[0].NoHistory)
 	}
 	for _, want := range []string{"order:release-exec", fmt.Sprintf("seq:%d", headSeq), "exec"} {
 		if !slicesContain(results[0].Labels, want) {
@@ -1127,8 +1127,8 @@ on = "bead.closed"
 	if len(results) != 1 {
 		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
 	}
-	if !results[0].Ephemeral {
-		t.Fatalf("tracking bead Ephemeral = false, want true")
+	if results[0].Ephemeral || !results[0].NoHistory {
+		t.Fatalf("tracking bead storage = Ephemeral:%v NoHistory:%v, want no-history only", results[0].Ephemeral, results[0].NoHistory)
 	}
 	for _, want := range []string{"order:release-exec", fmt.Sprintf("seq:%d", headSeq), "exec"} {
 		if !slicesContain(results[0].Labels, want) {

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -300,7 +300,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		}
 		var ctx PromptContext
 		if a.PromptTemplate != "" || hookMode || sessionTemplateContext {
-			ctx = buildPrimeContext(cityPath, cityName, &a, cfg.Rigs, stderr)
+			ctx = buildPrimeContextForBeads(cityPath, cityName, &a, cfg.Rigs, cfg.Beads, stderr)
 			ctx.ProviderKey, ctx.ProviderDisplayName = providerInfoForAgent(&a, &cfg.Workspace, cfg.Providers)
 			ctx.InstructionsFile = instructionsFileForAgent(&a, &cfg.Workspace, cfg.Providers)
 		}
@@ -609,6 +609,10 @@ func findAgentByName(cfg *config.City, name string) (config.Agent, bool) {
 // environment variables when running inside a managed session, falls back
 // to currentRigContext when run manually.
 func buildPrimeContext(cityPath, cityName string, a *config.Agent, rigs []config.Rig, stderr io.Writer) PromptContext {
+	return buildPrimeContextForBeads(cityPath, cityName, a, rigs, config.BeadsConfig{}, stderr)
+}
+
+func buildPrimeContextForBeads(cityPath, cityName string, a *config.Agent, rigs []config.Rig, beadsCfg config.BeadsConfig, stderr io.Writer) PromptContext {
 	ctx := PromptContext{
 		CityRoot:      cityPath,
 		TemplateName:  a.Name,
@@ -647,7 +651,8 @@ func buildPrimeContext(cityPath, cityName string, a *config.Agent, rigs []config
 
 	ctx.Branch = os.Getenv("GC_BRANCH")
 	ctx.DefaultBranch = defaultBranchForRig(ctx.RigName, rigs, ctx.WorkDir)
-	ctx.WorkQuery = expandAgentCommandTemplate(cityPath, cityName, a, rigs, "work_query", a.EffectiveWorkQuery(), stderr)
+	ctx.WorkQuery = expandAgentCommandTemplate(cityPath, cityName, a, rigs, "work_query", a.EffectiveWorkQueryForBeads(beadsCfg), stderr)
+	ctx.AssignedReadyQuery = assignedReadyQueryForBeads(beadsCfg)
 	ctx.SlingQuery = expandAgentCommandTemplate(cityPath, cityName, a, rigs, "sling_query", a.EffectiveSlingQuery(), stderr)
 	return ctx
 }

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -45,8 +45,25 @@ func TestBuildPrimeContextExpandsTemplateCommands(t *testing.T) {
 	if ctx.WorkQuery != "echo demo-city demo worker" {
 		t.Fatalf("WorkQuery = %q, want %q", ctx.WorkQuery, "echo demo-city demo worker")
 	}
+	if ctx.AssignedReadyQuery != `gc bd ready --assignee="$GC_SESSION_NAME"` {
+		t.Fatalf("AssignedReadyQuery = %q, want bd-1.0.4-compatible default", ctx.AssignedReadyQuery)
+	}
 	if ctx.SlingQuery != "dispatch {} --route=demo/worker --city=demo-city" {
 		t.Fatalf("SlingQuery = %q, want %q", ctx.SlingQuery, "dispatch {} --route=demo/worker --city=demo-city")
+	}
+}
+
+func TestBuildPrimeContextUsesBD105ReadyCompatibility(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "demo-city")
+	ctx := buildPrimeContextForBeads(cityPath, "", &config.Agent{
+		Name: "worker",
+	}, nil, config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105}, nil)
+
+	if ctx.AssignedReadyQuery != `gc bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"` {
+		t.Fatalf("AssignedReadyQuery = %q, want bd-1.0.5-compatible assigned ready query", ctx.AssignedReadyQuery)
+	}
+	if !strings.Contains(ctx.WorkQuery, "bd ready --include-ephemeral") {
+		t.Fatalf("WorkQuery = %q, want bd-1.0.5-compatible ready probes", ctx.WorkQuery)
 	}
 }
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1787,6 +1787,8 @@ func installCaptureBdRunner(t *testing.T) *[]bdInvocation {
 				return nil, fmt.Errorf("issue not found")
 			case len(args) >= 2 && args[0] == "list" && args[1] == "--json":
 				return []byte(`[]`), nil
+			case len(args) >= 2 && args[0] == "query" && args[1] == "--json":
+				return []byte(`[]`), nil
 			default:
 				t.Errorf("unexpected bd subcommand args=%v — fake must be extended if sling now invokes this", args)
 				return nil, fmt.Errorf("unexpected bd subcommand args=%v", args)

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -144,7 +144,7 @@ func computePoolDeathHandlers(cfg *config.City, cityName, cityPath string, sp ru
 		for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, st, sp) {
 			_, instanceName := config.ParseQualifiedName(qualifiedInstance)
 			instance := deepCopyAgent(&a, instanceName, a.Dir)
-			cmd := instance.EffectiveOnDeath()
+			cmd := instance.EffectiveOnDeathForBeads(cfg.Beads)
 			if cmd == "" {
 				continue
 			}

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2235,6 +2235,7 @@ export interface components {
                 [key: string]: string;
             };
             needs?: string[] | null;
+            no_history?: boolean;
             parent?: string;
             /** Format: int64 */
             priority?: number;

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -268,6 +268,7 @@ export type Bead = {
         [key: string]: string;
     };
     needs?: Array<string> | null;
+    no_history?: boolean;
     parent?: string;
     priority?: number;
     ref?: string;

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -325,9 +325,9 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	// Expand {{.Rig}}/{{.AgentBase}} once so the long-poll drain reuses the
 	// rig-scoped command instead of passing the literal template to the shell
 	// on every iteration. #793.
-	workQuery := expandAgentCommandTemplate(cityPath, cityName, &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQuery(), stderr)
+	workQuery := expandAgentCommandTemplate(cityPath, cityName, &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQueryForBeads(cfg.Beads), stderr)
 	if agentCfg.WorkQuery == "" && isWorkflowServeControlDispatcherAgent(agentCfg) {
-		workQuery = workflowServeControlReadyQuery(agentCfg, config.NamedSessionRuntimeName(cityName, cfg.Workspace, agentCfg.QualifiedName()))
+		workQuery = workflowServeControlReadyQueryForBeads(agentCfg, cfg.Beads, config.NamedSessionRuntimeName(cityName, cfg.Workspace, agentCfg.QualifiedName()))
 	}
 	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
 	if !follow {
@@ -663,11 +663,19 @@ func isWorkflowServeControlDispatcherAgent(agentCfg config.Agent) bool {
 }
 
 func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames ...string) string {
+	return workflowServeControlReadyQueryForBeads(agentCfg, config.BeadsConfig{}, controlSessionNames...)
+}
+
+func workflowServeControlReadyQueryForBeads(agentCfg config.Agent, beadsCfg config.BeadsConfig, controlSessionNames ...string) string {
 	target := strings.TrimSpace(agentCfg.QualifiedName())
 	if target == "" {
 		target = config.ControlDispatcherAgentName
 	}
 	limit := fmt.Sprintf("%d", workflowServeScanLimit)
+	includeEphemeral := ""
+	if beadsCfg.UsesBD105ReadySemantics() {
+		includeEphemeral = " --include-ephemeral"
+	}
 	queryPrefix := `BD_EXPORT_AUTO=false GC_CONTROL_TARGET=` + shellquote.Quote(target)
 	for _, name := range controlSessionNames {
 		name = strings.TrimSpace(name)
@@ -685,10 +693,10 @@ func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames .
 		`tmp=$(mktemp); seen="$tmp.seen"; err="$tmp.err"; : > "$seen"; trap "rm -f \"$tmp\" \"$seen\" \"$err\"" EXIT; ` +
 		`emit_ready() { r=$("$@" 2>"$err") || { status=$?; [ -n "$r" ] && printf "%s\n" "$r" >&2; cat "$err" >&2; return "$status"; }; [ -n "$r" ] && [ "$r" != "[]" ] && printf "%s\n" "$r" >> "$tmp"; return 0; }; ` +
 		`assignee_ready() { cand="$1"; [ -z "$cand" ] && return 0; if grep -Fxq "$cand" "$seen"; then return 0; fi; printf "%s\n" "$cand" >> "$seen"; ` +
-		`emit_ready bd --readonly --sandbox ready --include-ephemeral --assignee="$cand" --exclude-type=epic --json --limit=` + limit + `; }; ` +
+		`emit_ready bd --readonly --sandbox ready` + includeEphemeral + ` --assignee="$cand" --exclude-type=epic --json --limit=` + limit + `; }; ` +
 		`routed_ready() { route="$1"; [ -z "$route" ] && return 0; ` +
-		`emit_ready bd --readonly --sandbox ready --include-ephemeral --metadata-field "gc.run_target=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=` + limit + `; ` +
-		`emit_ready bd --readonly --sandbox ready --include-ephemeral --metadata-field "gc.routed_to=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=` + limit + `; ` +
+		`emit_ready bd --readonly --sandbox ready` + includeEphemeral + ` --metadata-field "gc.run_target=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=` + limit + `; ` +
+		`emit_ready bd --readonly --sandbox ready` + includeEphemeral + ` --metadata-field "gc.routed_to=$route" --unassigned --exclude-type=epic --json --sort oldest --limit=` + limit + `; ` +
 		`}; ` +
 		`for id in "$GC_CONTROL_SESSION_NAME" "$GC_SESSION_NAME" "$GC_ALIAS" "$GC_CONTROL_TARGET" "$GC_SESSION_ID"; do ` +
 		`[ -z "$id" ] && continue; ` +

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -439,6 +439,29 @@ func TestIsStaleCmdGCTestConfigPathUsesCurrentGCTOwnerPID(t *testing.T) {
 	}
 }
 
+func TestIsStaleCmdGCTestConfigPathUsesShardOwnerPID(t *testing.T) {
+	ownerPID := 12345
+	root := filepath.Join("/tmp", fmt.Sprintf("%s%d-current", testCmdGCShardTempRootPrefix, ownerPID))
+	configPath := filepath.Join(root, "TestCase", "001", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+
+	if isStaleCmdGCTestConfigPathWithPIDCheck(configPath, nil, "/tmp", func(pid int) bool {
+		if pid != ownerPID {
+			t.Fatalf("pidAlive called with pid %d, want %d", pid, ownerPID)
+		}
+		return true
+	}) {
+		t.Fatalf("live shard cmd/gc owner config path %q classified as stale", configPath)
+	}
+	if !isStaleCmdGCTestConfigPathWithPIDCheck(configPath, nil, "/tmp", func(pid int) bool {
+		if pid != ownerPID {
+			t.Fatalf("pidAlive called with pid %d, want %d", pid, ownerPID)
+		}
+		return false
+	}) {
+		t.Fatalf("dead shard cmd/gc owner config path %q not classified as stale", configPath)
+	}
+}
+
 func TestIsTestConfigPathRetainsLegacyGCTestAllowlistOnly(t *testing.T) {
 	legacyConfig := filepath.Join("/tmp", "gctest-legacy", "TestCase", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
 	currentConfig := filepath.Join("/tmp", fmt.Sprintf("%s%d-current", testCmdGCTempRootPrefix, os.Getpid()), "TestCase", ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1218,7 +1218,7 @@ func openStoreResultAtForCity(storePath, cityPath string) (beads.StoreOpenResult
 	provider := rawBeadsProviderForScope(scopeRoot, runtimeCityPath)
 	if providerIsCoordStore(provider) {
 		store, err := openCoordStoreAt(scopeRoot, runtimeCityPath)
-		return beads.StoreOpenResult{Store: store, Diagnostic: beads.BeadsDiagnostic{Store: "SQLiteStore"}}, err
+		return beads.StoreOpenResult{Store: wrapStoreWithBeadPolicies(store, cfg), Diagnostic: beads.BeadsDiagnostic{Store: "SQLiteStore"}}, err
 	}
 	if strings.HasPrefix(provider, "exec:") && !providerUsesBdStoreContract(provider) {
 		store, err := openExecStoreAtForCity(provider, scopeRoot, runtimeCityPath)

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1213,6 +1213,7 @@ func openStoreResultAtForCity(storePath, cityPath string) (beads.StoreOpenResult
 	if runtimeCityPath == "" {
 		runtimeCityPath = cityForStoreDir(storePath)
 	}
+	cfg, _ := loadCityConfig(runtimeCityPath, io.Discard)
 	scopeRoot := resolveStoreScopeRoot(runtimeCityPath, storePath)
 	provider := rawBeadsProviderForScope(scopeRoot, runtimeCityPath)
 	if providerIsCoordStore(provider) {
@@ -1221,7 +1222,7 @@ func openStoreResultAtForCity(storePath, cityPath string) (beads.StoreOpenResult
 	}
 	if strings.HasPrefix(provider, "exec:") && !providerUsesBdStoreContract(provider) {
 		store, err := openExecStoreAtForCity(provider, scopeRoot, runtimeCityPath)
-		return beads.StoreOpenResult{Store: store, Diagnostic: beads.ExecStoreDiagnostic()}, err
+		return beads.StoreOpenResult{Store: wrapStoreWithBeadPolicies(store, cfg), Diagnostic: beads.ExecStoreDiagnostic()}, err
 	}
 	result, err := beads.OpenStoreAtForCity(context.Background(), beads.StoreOpenOptions{
 		ScopeRoot:        scopeRoot,
@@ -1252,6 +1253,7 @@ func openStoreResultAtForCity(storePath, cityPath string) (beads.StoreOpenResult
 	if err != nil {
 		return beads.StoreOpenResult{}, err
 	}
+	result.Store = wrapStoreWithBeadPolicies(result.Store, cfg)
 	return result, nil
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -193,9 +193,15 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	// Sweep stale testTempRoot dirs in system /tmp before creating a new one.
-	sweepOrphanPIDPrefixedDirs(os.TempDir(), testCmdGCTempRootPrefix)
-	testTempRoot, err := os.MkdirTemp("/tmp", pidPrefixedTempPattern(testCmdGCTempRootPrefix))
+	// Sharded cmd/gc runs use a separate prefix so concurrent worktrees with
+	// older test harnesses cannot remove this package's active root.
+	testTempRootPrefix := cmdGCTestTempRootPrefix()
+	sweepOrphanPIDPrefixedDirs(os.TempDir(), testTempRootPrefix)
+	testTempRoot, err := os.MkdirTemp("/tmp", pidPrefixedTempPattern(testTempRootPrefix))
 	if err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(filepath.Join(testTempRoot, testActiveTempRootMarker), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o644); err != nil {
 		panic(err)
 	}
 	if err := os.Setenv("TMPDIR", testTempRoot); err != nil {

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -506,7 +506,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			trackingBead, createErr := store.Create(beads.Bead{
 				Title:     "order:" + scoped,
 				Labels:    []string{"order-run:" + scoped, labelOrderTracking, labelTriggerEnvFailed},
-				Ephemeral: true,
+				NoHistory: true,
 			})
 			if createErr != nil {
 				logDispatchError(m.stderr, "gc: order dispatch: creating trigger env failure tracking bead for %s: %v", scoped, createErr)
@@ -569,7 +569,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		trackingBead, err := store.Create(beads.Bead{
 			Title:     "order:" + scoped,
 			Labels:    []string{"order-run:" + scoped, labelOrderTracking},
-			Ephemeral: true,
+			NoHistory: true,
 		})
 		if err != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v", scoped, err)

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -7220,10 +7220,10 @@ func TestLockedStderrWrapsNonNil(t *testing.T) {
 	}
 }
 
-// TestOrderDispatchTrackingBeadIsEphemeral asserts the dispatcher routes the
-// tracking bead to the wisps tier (Ephemeral=true), so each cooldown cycle
-// does not produce a full Dolt commit on the permanent issues tier.
-func TestOrderDispatchTrackingBeadIsEphemeral(t *testing.T) {
+// TestOrderDispatchTrackingBeadIsNoHistory asserts the dispatcher routes the
+// tracking bead to the no-history tier, so each cooldown cycle avoids a full
+// Dolt commit while remaining visible to normal issue-tier reads.
+func TestOrderDispatchTrackingBeadIsNoHistory(t *testing.T) {
 	store := beads.NewMemStore()
 
 	aa := []orders.Order{{
@@ -7253,33 +7253,40 @@ func TestOrderDispatchTrackingBeadIsEphemeral(t *testing.T) {
 	if tb == nil {
 		t.Fatal("no tracking bead found")
 	}
-	if !tb.Ephemeral {
-		t.Errorf("tracking bead Ephemeral = false, want true")
+	if tb.Ephemeral || !tb.NoHistory {
+		t.Errorf("tracking bead storage = Ephemeral:%v NoHistory:%v, want no-history only", tb.Ephemeral, tb.NoHistory)
 	}
-	// Tracking bead must NOT be visible to issues-tier-only queries —
-	// that is the whole point of routing it to the wisps tier.
+	// No-history beads remain visible to issue-tier reads, which keeps
+	// bd 1.0.4 ready/list compatibility while avoiding Dolt history pressure.
 	issuesOnly, err := store.ListByLabel("order-run:wisp-order", 0, beads.IncludeClosed)
 	if err != nil {
 		t.Fatal(err)
 	}
+	found := false
 	for _, b := range issuesOnly {
 		if strings.HasPrefix(b.Title, "order:") {
-			t.Errorf("ephemeral tracking bead leaked into issues-tier query: %+v", b)
+			found = true
+			if b.Ephemeral || !b.NoHistory {
+				t.Errorf("issue-tier tracking bead storage = Ephemeral:%v NoHistory:%v, want no-history only", b.Ephemeral, b.NoHistory)
+			}
 		}
+	}
+	if !found {
+		t.Errorf("no-history tracking bead was not visible to issues-tier query")
 	}
 }
 
-// TestOrderDispatchSingleFlightLockSeesEphemeralTracker is the regression
+// TestOrderDispatchSingleFlightLockSeesNoHistoryTracker is the regression
 // guard for the single-flight lock (`hasOpenWorkInStoresStrict`) after the
-// tracking bead moved to the wisps tier. If the lock query were not
+// tracking bead moved out of history. If the lock query were not
 // tier-aware, the dispatcher would re-fire the same cooldown order on the
 // next tick.
-func TestOrderDispatchSingleFlightLockSeesEphemeralTracker(t *testing.T) {
+func TestOrderDispatchSingleFlightLockSeesNoHistoryTracker(t *testing.T) {
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{
 		Title:     "order:double-fire",
 		Labels:    []string{"order-run:double-fire", labelOrderTracking},
-		Ephemeral: true,
+		NoHistory: true,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -7290,7 +7297,7 @@ func TestOrderDispatchSingleFlightLockSeesEphemeralTracker(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !hasOpen {
-		t.Fatal("single-flight lock missed ephemeral tracking bead — would dispatch again")
+		t.Fatal("single-flight lock missed no-history tracking bead; would dispatch again")
 	}
 }
 
@@ -7303,7 +7310,7 @@ func TestOrderDispatchSingleFlightLockSeesBackingOnlyCachedTracker(t *testing.T)
 	if _, err := backing.Create(beads.Bead{
 		Title:     "order:double-fire",
 		Labels:    []string{"order-run:double-fire", labelOrderTracking},
-		Ephemeral: true,
+		NoHistory: true,
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -252,11 +252,14 @@ func isStaleCmdGCTestConfigPathWithPIDCheck(configPath string, activeRoots []str
 }
 
 func cmdGCTestConfigOwnerPID(configPath string, tempParent string) (int, bool) {
-	root, ok := activeTestRootUnder(filepath.Clean(configPath), filepath.Clean(tempParent), []string{testCmdGCTempRootPrefix})
-	if !ok {
-		return 0, false
+	for _, prefix := range []string{testCmdGCTempRootPrefix, testCmdGCShardTempRootPrefix} {
+		root, ok := activeTestRootUnder(filepath.Clean(configPath), filepath.Clean(tempParent), []string{prefix})
+		if !ok {
+			continue
+		}
+		return pidFromPrefixedDirName(filepath.Base(root), prefix)
 	}
-	return pidFromPrefixedDirName(filepath.Base(root), testCmdGCTempRootPrefix)
+	return 0, false
 }
 
 func snapshotDoltProcessesForConfigRoot(enumerate func() ([]DoltProcInfo, error), root string) (map[int]DoltProcInfo, error) {

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -108,9 +108,13 @@ type scaleParams struct {
 // decisions and worker claim decisions structurally symmetric. See
 // engdocs/architecture/dispatch.md "scale_check ↔ work_query correspondence".
 func scaleParamsFor(a *config.Agent) scaleParams {
+	return scaleParamsForBeads(a, config.BeadsConfig{})
+}
+
+func scaleParamsForBeads(a *config.Agent, beadsCfg config.BeadsConfig) scaleParams {
 	sp := scaleParams{
 		Min:   a.EffectiveMinActiveSessions(),
-		Check: a.EffectivePoolDemandQuery(),
+		Check: a.EffectivePoolDemandQueryForBeads(beadsCfg),
 	}
 	if m := a.EffectiveMaxActiveSessions(); m != nil {
 		sp.Max = *m

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -377,7 +377,7 @@ func runPoolOnBoot(cfg *config.City, cityPath string, runner ScaleCheckRunner, s
 		if !a.SupportsInstanceExpansion() || a.Implicit {
 			continue
 		}
-		cmd := a.EffectiveOnBoot()
+		cmd := a.EffectiveOnBootForBeads(cfg.Beads)
 		if cmd == "" {
 			continue
 		}

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -36,7 +36,10 @@ type PromptContext struct {
 	Branch        string
 	DefaultBranch string // e.g. "main" — from git symbolic-ref origin/HEAD
 	WorkQuery     string // command to find available work (from Agent.EffectiveWorkQuery)
-	SlingQuery    string // command template to route work to this agent (from Agent.EffectiveSlingQuery)
+	// AssignedReadyQuery is the storage-compatibility-aware command for
+	// pre-assigned ready work in agent-facing startup instructions.
+	AssignedReadyQuery string
+	SlingQuery         string // command template to route work to this agent (from Agent.EffectiveSlingQuery)
 	// ProviderKey is the resolved provider name for this agent (e.g. "claude",
 	// "codex", or a custom provider name from the city's [providers] section).
 	// Templates can branch on this via {{ .ProviderKey }} or feed it to
@@ -329,6 +332,7 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	m["Branch"] = ctx.Branch
 	m["DefaultBranch"] = ctx.DefaultBranch
 	m["WorkQuery"] = ctx.WorkQuery
+	m["AssignedReadyQuery"] = ctx.AssignedReadyQuery
 	m["SlingQuery"] = ctx.SlingQuery
 	m["ProviderKey"] = ctx.ProviderKey
 	m["ProviderDisplayName"] = ctx.ProviderDisplayName

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -477,17 +477,18 @@ func TestRenderPromptWorkQuery(t *testing.T) {
 
 func TestBuildTemplateData(t *testing.T) {
 	ctx := PromptContext{
-		CityRoot:      "/city",
-		AgentName:     "a/b",
-		TemplateName:  "b",
-		BindingName:   "dep",
-		BindingPrefix: "dep.",
-		RigName:       "a",
-		WorkDir:       "/city/a",
-		IssuePrefix:   "te-",
-		Branch:        "main",
-		DefaultBranch: "main",
-		Env:           map[string]string{"Custom": "val", "CityRoot": "override"},
+		CityRoot:           "/city",
+		AgentName:          "a/b",
+		TemplateName:       "b",
+		BindingName:        "dep",
+		BindingPrefix:      "dep.",
+		RigName:            "a",
+		WorkDir:            "/city/a",
+		IssuePrefix:        "te-",
+		Branch:             "main",
+		DefaultBranch:      "main",
+		AssignedReadyQuery: `gc bd ready --assignee="$GC_SESSION_NAME"`,
+		Env:                map[string]string{"Custom": "val", "CityRoot": "override"},
 	}
 	data := buildTemplateData(ctx)
 	// SDK vars override Env.
@@ -508,6 +509,9 @@ func TestBuildTemplateData(t *testing.T) {
 	}
 	if data["DefaultBranch"] != "main" {
 		t.Errorf("DefaultBranch = %q, want %q", data["DefaultBranch"], "main")
+	}
+	if data["AssignedReadyQuery"] != `gc bd ready --assignee="$GC_SESSION_NAME"` {
+		t.Errorf("AssignedReadyQuery = %q", data["AssignedReadyQuery"])
 	}
 }
 

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -809,6 +809,50 @@ func TestFormulaFilesystemSearchGuidanceCoversPromptSources(t *testing.T) {
 	}
 }
 
+func TestCoreWorkerPromptsUseAssignedReadyQueryTemplate(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("filepath.Abs(repo root): %v", err)
+	}
+
+	for _, rel := range []string{
+		"internal/bootstrap/packs/core/assets/prompts/pool-worker.md",
+		"internal/bootstrap/packs/core/assets/prompts/graph-worker.md",
+	} {
+		t.Run(rel, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(repoRoot, rel))
+			if err != nil {
+				t.Fatalf("ReadFile(%s): %v", rel, err)
+			}
+			text := string(data)
+			if !strings.Contains(text, "{{ .AssignedReadyQuery }}") {
+				t.Fatalf("%s missing AssignedReadyQuery placeholder", rel)
+			}
+			if strings.Contains(text, "bd ready --include-ephemeral --assignee") {
+				t.Fatalf("%s hardcodes bd ready --include-ephemeral instead of AssignedReadyQuery", rel)
+			}
+		})
+	}
+
+	for _, rel := range []string{
+		"internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md",
+		"internal/bootstrap/packs/core/skills/gc-work/SKILL.md",
+		"examples/gastown/packs/gastown/agents/mayor/prompt.template.md",
+		"examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md",
+		"examples/swarm/packs/swarm/agents/coder/prompt.template.md",
+	} {
+		t.Run(rel, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(repoRoot, rel))
+			if err != nil {
+				t.Fatalf("ReadFile(%s): %v", rel, err)
+			}
+			if strings.Contains(string(data), "bd ready --include-ephemeral") {
+				t.Fatalf("%s hardcodes bd ready --include-ephemeral in static prompt guidance", rel)
+			}
+		})
+	}
+}
+
 func TestMergeFragmentLists(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -738,7 +738,7 @@ func TestComputeWorkSet_RunsWorkQuery(t *testing.T) {
 	}
 
 	runner := func(command, _ string, _ map[string]string) (string, error) {
-		if strings.Contains(command, `bd ready --include-ephemeral --metadata-field "gc.routed_to=$target"`) && strings.Contains(command, "-- worker") {
+		if strings.Contains(command, `bd ready --metadata-field "gc.routed_to=$target"`) && strings.Contains(command, "-- worker") {
 			return `[{"id":"BL-42"}]`, nil
 		}
 		return "", nil // empty = no work for idle's custom query

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -309,6 +309,10 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	if p.city != nil {
 		packDirs = p.city.PackDirsForRig(rigName)
 	}
+	beadsCfg := config.BeadsConfig{}
+	if p.city != nil {
+		beadsCfg = p.city.Beads
+	}
 	prompt = renderPrompt(p.fs, p.cityPath, p.cityName, cfgAgent.PromptTemplate, PromptContext{
 		CityRoot:            p.cityPath,
 		AgentName:           qualifiedName,
@@ -320,7 +324,8 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		WorkDir:             workDir,
 		IssuePrefix:         findRigPrefix(rigName, p.rigs),
 		DefaultBranch:       defaultBranchForRig(rigName, p.rigs, workDir),
-		WorkQuery:           expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "work_query", cfgAgent.EffectiveWorkQuery(), p.stderr),
+		WorkQuery:           expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "work_query", cfgAgent.EffectiveWorkQueryForBeads(beadsCfg), p.stderr),
+		AssignedReadyQuery:  assignedReadyQueryForBeads(beadsCfg),
 		SlingQuery:          expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "sling_query", cfgAgent.EffectiveSlingQuery(), p.stderr),
 		ProviderKey:         providerKey,
 		ProviderDisplayName: providerDisplayName,
@@ -597,6 +602,13 @@ func suppressStartupPromptForAgent(cfgAgent *config.Agent) bool {
 		cfgAgent.Implicit &&
 		strings.TrimSpace(cfgAgent.StartCommand) != "" &&
 		strings.TrimSpace(cfgAgent.Provider) == ""
+}
+
+func assignedReadyQueryForBeads(beadsCfg config.BeadsConfig) string {
+	if beadsCfg.UsesBD105ReadySemantics() {
+		return `gc bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"`
+	}
+	return `gc bd ready --assignee="$GC_SESSION_NAME"`
 }
 
 func sessionBackendEnvWithError(cityPath, rigRoot string, rigs []config.Rig) (map[string]string, error) {

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -748,7 +748,7 @@ func TestResolveTemplateKeepsConcreteProviderForOverlays(t *testing.T) {
 func TestResolveTemplateExpandsPromptCommandTemplates(t *testing.T) {
 	cityPath := filepath.Join(t.TempDir(), "demo-city")
 	fs := fsys.NewFake()
-	fs.Files[cityPath+"/prompts/worker.template.md"] = []byte("Work={{ .WorkQuery }}\nSling={{ .SlingQuery }}")
+	fs.Files[cityPath+"/prompts/worker.template.md"] = []byte("Work={{ .WorkQuery }}\nAssigned={{ .AssignedReadyQuery }}\nSling={{ .SlingQuery }}")
 
 	params := &agentBuildParams{
 		fs:              fs,
@@ -779,8 +779,47 @@ func TestResolveTemplateExpandsPromptCommandTemplates(t *testing.T) {
 	if !strings.Contains(tp.Prompt, "Work=echo demo-city demo worker") {
 		t.Fatalf("Prompt missing expanded WorkQuery: %q", tp.Prompt)
 	}
+	if !strings.Contains(tp.Prompt, `Assigned=gc bd ready --assignee="$GC_SESSION_NAME"`) {
+		t.Fatalf("Prompt missing bd-1.0.4 assigned ready query: %q", tp.Prompt)
+	}
+	if strings.Contains(tp.Prompt, `Assigned=gc bd ready --include-ephemeral`) {
+		t.Fatalf("Prompt default assigned ready query should omit --include-ephemeral: %q", tp.Prompt)
+	}
 	if !strings.Contains(tp.Prompt, "Sling=dispatch {} --route=demo/worker --city=demo-city") {
 		t.Fatalf("Prompt missing expanded SlingQuery: %q", tp.Prompt)
+	}
+}
+
+func TestResolveTemplateAssignedReadyQueryUsesBD105Compatibility(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "demo-city")
+	fs := fsys.NewFake()
+	fs.Files[cityPath+"/prompts/worker.template.md"] = []byte("Assigned={{ .AssignedReadyQuery }}")
+
+	params := &agentBuildParams{
+		city:            &config.City{Beads: config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105}},
+		fs:              fs,
+		cityName:        "",
+		cityPath:        cityPath,
+		workspace:       &config.Workspace{Provider: "opencode"},
+		providers:       config.BuiltinProviders(),
+		lookPath:        func(string) (string, error) { return "/usr/bin/opencode", nil },
+		beaconTime:      testBeaconTime,
+		sessionTemplate: "",
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+	}
+	agent := &config.Agent{
+		Name:           "worker",
+		PromptTemplate: "prompts/worker.template.md",
+		Provider:       "opencode",
+	}
+
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if !strings.Contains(tp.Prompt, `Assigned=gc bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"`) {
+		t.Fatalf("Prompt missing bd-1.0.5 assigned ready query: %q", tp.Prompt)
 	}
 }
 

--- a/cmd/gc/test_orphan_sweep_branches_test.go
+++ b/cmd/gc/test_orphan_sweep_branches_test.go
@@ -36,6 +36,24 @@ func TestCmdGCTempRootPrefixKeepsControllerSocketLegacy(t *testing.T) {
 	}
 }
 
+func TestCmdGCTestTempRootPrefixDefaultsToLegacy(t *testing.T) {
+	t.Setenv(testShardIndexEnv, "")
+	t.Setenv(testShardTotalEnv, "")
+
+	if got := cmdGCTestTempRootPrefix(); got != testCmdGCTempRootPrefix {
+		t.Fatalf("cmdGCTestTempRootPrefix() = %q, want %q", got, testCmdGCTempRootPrefix)
+	}
+}
+
+func TestCmdGCTestTempRootPrefixUsesShardPrefix(t *testing.T) {
+	t.Setenv(testShardIndexEnv, "2")
+	t.Setenv(testShardTotalEnv, "6")
+
+	if got := cmdGCTestTempRootPrefix(); got != testCmdGCShardTempRootPrefix {
+		t.Fatalf("cmdGCTestTempRootPrefix() = %q, want %q", got, testCmdGCShardTempRootPrefix)
+	}
+}
+
 func TestSweepOrphanSkipsNonDirectories(t *testing.T) {
 	root := t.TempDir()
 	// A regular file whose name matches the prefix+PID pattern must not be removed.
@@ -155,6 +173,22 @@ func TestSweepOrphanRemovesStalePIDDirectory(t *testing.T) {
 	}
 }
 
+func TestSweepOrphanSkipsMarkedActiveRoot(t *testing.T) {
+	root := t.TempDir()
+	pid := nonLivePID(t)
+	dir := pidPrefixedTestDir(root, "pfx", pid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, testActiveTempRootMarker), []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sweepOrphanPIDPrefixedDirs(root, "pfx")
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Errorf("sweepOrphanPIDPrefixedDirs removed marked active root for stale PID %d", pid)
+	}
+}
+
 func TestSweepOrphanToleratesMissingRoot(t *testing.T) {
 	// ReadDir on a non-existent root must not panic.
 	sweepOrphanPIDPrefixedDirs(filepath.Join(t.TempDir(), "no-such-dir"), "pfx")
@@ -191,6 +225,7 @@ func TestSweepOrphanAllPrefixesStabilize(t *testing.T) {
 	prefixes := []string{
 		testGCBinaryDirPrefix,
 		testCmdGCTempRootPrefix,
+		testCmdGCShardTempRootPrefix,
 		testSharedFixtureDirPrefix,
 		testSlingFormulaDirPrefix,
 		testSlingCityDirPrefix,
@@ -280,30 +315,33 @@ func TestTestscriptCommandInvocationDoesNotLeakTempRoot(t *testing.T) {
 			}
 
 			pid := cmd.ProcessState.Pid()
-			matches, err := filepath.Glob(filepath.Join("/tmp", fmt.Sprintf("%s%d-*", testCmdGCTempRootPrefix, pid)))
-			if err != nil {
-				t.Fatalf("Glob: %v", err)
-			}
-			for _, match := range matches {
-				t.Cleanup(func() { _ = os.RemoveAll(match) })
-			}
-			if len(matches) > 0 {
-				t.Fatalf("leaked temp root(s) for pid %d: %v", pid, matches)
+			for _, prefix := range []string{testCmdGCTempRootPrefix, testCmdGCShardTempRootPrefix} {
+				matches, err := filepath.Glob(filepath.Join("/tmp", fmt.Sprintf("%s%d-*", prefix, pid)))
+				if err != nil {
+					t.Fatalf("Glob: %v", err)
+				}
+				for _, match := range matches {
+					t.Cleanup(func() { _ = os.RemoveAll(match) })
+				}
+				if len(matches) > 0 {
+					t.Fatalf("leaked temp root(s) for pid %d with prefix %q: %v", pid, prefix, matches)
+				}
 			}
 		})
 	}
 }
 
 func TestSweepOrphanRemovesStaleCmdGCTempRootInSystemTmp(t *testing.T) {
+	prefix := fmt.Sprintf("%s%d-test-", testCmdGCTempRootPrefix, os.Getpid())
 	pid := nonLivePID(t)
-	root := filepath.Join("/tmp", fmt.Sprintf("%s%d-stale-backstop", testCmdGCTempRootPrefix, pid))
+	root := filepath.Join("/tmp", fmt.Sprintf("%s%d-stale-backstop", prefix, pid))
 	_ = os.RemoveAll(root)
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(root) })
 
-	sweepOrphanPIDPrefixedDirs("/tmp", testCmdGCTempRootPrefix)
+	sweepOrphanPIDPrefixedDirs("/tmp", prefix)
 
 	if _, err := os.Stat(root); !os.IsNotExist(err) {
 		t.Fatalf("stale cmd/gc temp root still exists after sweep: %v", err)

--- a/cmd/gc/test_orphan_sweep_test.go
+++ b/cmd/gc/test_orphan_sweep_test.go
@@ -8,18 +8,29 @@ import (
 )
 
 const (
-	testGCBinaryDirPrefix      = "gc-test-binary-pid"
-	testCmdGCTempRootPrefix    = "gct"
-	testSharedFixtureDirPrefix = "gascity-gc-test-fixtures-pid"
-	testSlingFormulaDirPrefix  = "gc-sling-test-formulas-pid"
-	testSlingCityDirPrefix     = "gc-sling-test-city-pid"
-	testGCHomeDirPrefix        = "gascity-gc-home-pid"
-	testRuntimeDirPrefix       = "gascity-runtime-pid"
-	testProviderStubDirPrefix  = "gascity-provider-stubs-pid"
+	testGCBinaryDirPrefix        = "gc-test-binary-pid"
+	testCmdGCTempRootPrefix      = "gct"
+	testCmdGCShardTempRootPrefix = "gcx"
+	testShardIndexEnv            = "GC_TEST_SHARD_INDEX"
+	testShardTotalEnv            = "GC_TEST_SHARD_TOTAL"
+	testActiveTempRootMarker     = ".gc-test-active-root"
+	testSharedFixtureDirPrefix   = "gascity-gc-test-fixtures-pid"
+	testSlingFormulaDirPrefix    = "gc-sling-test-formulas-pid"
+	testSlingCityDirPrefix       = "gc-sling-test-city-pid"
+	testGCHomeDirPrefix          = "gascity-gc-home-pid"
+	testRuntimeDirPrefix         = "gascity-runtime-pid"
+	testProviderStubDirPrefix    = "gascity-provider-stubs-pid"
 )
 
 func pidPrefixedTempPattern(prefix string) string {
 	return prefix + strconv.Itoa(os.Getpid()) + "-*"
+}
+
+func cmdGCTestTempRootPrefix() string {
+	if strings.TrimSpace(os.Getenv(testShardIndexEnv)) != "" || strings.TrimSpace(os.Getenv(testShardTotalEnv)) != "" {
+		return testCmdGCShardTempRootPrefix
+	}
+	return testCmdGCTempRootPrefix
 }
 
 func pidFromPrefixedDirName(name, prefix string) (int, bool) {
@@ -65,6 +76,10 @@ func sweepOrphanPIDPrefixedDirs(root, prefix string) {
 		if pidAlive(pid) {
 			continue
 		}
-		_ = os.RemoveAll(filepath.Join(root, e.Name()))
+		path := filepath.Join(root, e.Name())
+		if _, err := os.Stat(filepath.Join(path, testActiveTempRootMarker)); err == nil {
+			continue
+		}
+		_ = os.RemoveAll(path)
 	}
 }

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -124,12 +124,12 @@ func closedWispGCEntries(store beads.Store) ([]beads.Bead, error) {
 			entries = append(entries, item)
 		}
 	}
-	molecules, err := store.List(beads.ListQuery{Status: "closed", Type: "molecule"})
+	molecules, err := store.List(beads.ListQuery{Status: "closed", Type: "molecule", TierMode: beads.TierBoth})
 	if err != nil {
 		return nil, fmt.Errorf("listing closed molecule roots: %w", err)
 	}
 	appendUnique(molecules)
-	wisps, err := store.List(beads.ListQuery{Status: "closed", Metadata: map[string]string{"gc.kind": "wisp"}})
+	wisps, err := store.List(beads.ListQuery{Status: "closed", Metadata: map[string]string{"gc.kind": "wisp"}, TierMode: beads.TierBoth})
 	if err != nil {
 		return nil, fmt.Errorf("listing closed wisp roots: %w", err)
 	}
@@ -198,6 +198,7 @@ func collectExpiredBeadClosure(store beads.Store, rootID string) ([]string, erro
 	related, err := store.List(beads.ListQuery{
 		Metadata:      map[string]string{"gc.root_bead_id": rootID},
 		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list workflow-owned beads for %s: %w", rootID, err)
@@ -232,7 +233,7 @@ func collectExpiredBeadClosure(store beads.Store, rootID string) ([]string, erro
 		// beads are linked only by ParentID / parent-child deps and do not carry
 		// gc.root_bead_id metadata, so GC must follow those ownership edges while
 		// still ignoring non-ownership deps such as blocks or waits-for.
-		children, err := store.Children(id, beads.IncludeClosed)
+		children, err := store.Children(id, beads.IncludeClosed, beads.WithBothTiers)
 		if err != nil {
 			return fmt.Errorf("list children for %s: %w", id, err)
 		}

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -268,6 +268,60 @@ func TestWispGC_PurgesExpiredMoleculeChildrenWithRoot(t *testing.T) {
 	}
 }
 
+func TestWispGC_PurgesExpiredClosureAcrossStorageTiers(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		{
+			ID:        "wisp-root",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			Metadata:  map[string]string{"gc.kind": "wisp"},
+			Ephemeral: true,
+		},
+		{
+			ID:        "metadata-child",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			Metadata:  map[string]string{"gc.root_bead_id": "wisp-root"},
+			Ephemeral: true,
+		},
+		{
+			ID:        "parent-child",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "wisp-root",
+			Ephemeral: true,
+		},
+		{
+			ID:        "no-history-child",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: now.Add(-2 * time.Hour),
+			ParentID:  "metadata-child",
+			NoHistory: true,
+		},
+	})
+	if err := store.DepAdd("parent-child", "wisp-root", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(parent-child->wisp-root): %v", err)
+	}
+	if err := store.DepAdd("no-history-child", "metadata-child", "parent-child"); err != nil {
+		t.Fatalf("DepAdd(no-history-child->metadata-child): %v", err)
+	}
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 root purge accounting", purged)
+	}
+	assertDeletedIDs(t, store.deletedIDs, "wisp-root", "metadata-child", "parent-child", "no-history-child")
+}
+
 func TestWispGC_DoesNotDeleteExternalDependents(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
@@ -603,12 +657,12 @@ func makeGCBead(id string, createdAt time.Time, status, beadType string) beads.B
 }
 
 func makeGCBeadWithLabels(id string, createdAt time.Time, status, beadType string, labels ...string) beads.Bead {
-	// Order-tracking beads live in the ephemeral (wisps) tier in production;
+	// Order-tracking beads live in the no-history tier in production;
 	// mirror that here so wisp_gc's tier-aware queries see them.
-	ephemeral := false
+	noHistory := false
 	for _, l := range labels {
 		if l == labelOrderTracking {
-			ephemeral = true
+			noHistory = true
 			break
 		}
 	}
@@ -618,7 +672,7 @@ func makeGCBeadWithLabels(id string, createdAt time.Time, status, beadType strin
 		Type:      beadType,
 		CreatedAt: createdAt,
 		Labels:    labels,
-		Ephemeral: ephemeral,
+		NoHistory: noHistory,
 	}
 }
 

--- a/cmd/gc/work_query_probe.go
+++ b/cmd/gc/work_query_probe.go
@@ -143,12 +143,18 @@ func prefixedWorkQueryForProbeWithEnv(
 	if agentCfg == nil {
 		return ""
 	}
-	command := strings.TrimSpace(agentCfg.EffectiveWorkQuery())
+	beadsCfg := config.BeadsConfig{}
+	var rigs []config.Rig
+	if cfg != nil {
+		beadsCfg = cfg.Beads
+		rigs = cfg.Rigs
+	}
+	command := strings.TrimSpace(agentCfg.EffectiveWorkQueryForBeads(beadsCfg))
 	// Expand {{.Rig}}/{{.AgentBase}} so rig-scoped agents probe with
 	// rig-specific metadata. Mirrors the scale_check expansion in
 	// build_desired_state.go; #793. Malformed templates are logged to
 	// stderr (when supplied) and fall back to the raw command.
-	command = expandAgentCommandTemplate(cityPath, cityName, agentCfg, cfg.Rigs, "work_query", command, stderr)
+	command = expandAgentCommandTemplate(cityPath, cityName, agentCfg, rigs, "work_query", command, stderr)
 	if command == "" || agentCfg.SupportsMultipleSessions() {
 		return prefixShellEnv(queryEnv, command)
 	}

--- a/cmd/gc/work_query_probe_test.go
+++ b/cmd/gc/work_query_probe_test.go
@@ -31,7 +31,7 @@ func TestPrefixedWorkQueryForProbe_UsesNamedSessionRuntimeName(t *testing.T) {
 	}
 
 	command := prefixedWorkQueryForProbe(cfg, cityPath, "test-city", nil, nil, &cfg.Agents[0], nil)
-	if !strings.Contains(command, `bd ready --include-ephemeral --metadata-field "gc.routed_to=$target"`) || !strings.Contains(command, "-- demo/witness") {
+	if !strings.Contains(command, `bd ready --metadata-field "gc.routed_to=$target"`) || !strings.Contains(command, "-- demo/witness") {
 		t.Fatalf("prefixedWorkQueryForProbe() = %q, want demo/witness route argument", command)
 	}
 }

--- a/cmd/gc/work_query_probe_test.go
+++ b/cmd/gc/work_query_probe_test.go
@@ -36,6 +36,19 @@ func TestPrefixedWorkQueryForProbe_UsesNamedSessionRuntimeName(t *testing.T) {
 	}
 }
 
+func TestPrefixedWorkQueryForProbeUsesBD105WorkQuery(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Beads:     config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105},
+		Agents:    []config.Agent{{Name: "worker"}},
+	}
+
+	command := prefixedWorkQueryForProbeWithEnv(nil, cfg, t.TempDir(), cfg.Workspace.Name, nil, nil, &cfg.Agents[0], nil)
+	if !strings.Contains(command, "bd ready --include-ephemeral") {
+		t.Fatalf("prefixedWorkQueryForProbeWithEnv() = %q, want bd-1.0.5 ephemeral-ready probe", command)
+	}
+}
+
 func TestControllerQueryRuntimeEnvInheritedRigUsesCityStorePassword(t *testing.T) {
 	cityPath, rigDir, cfg := newControllerProbeFixture(t)
 	writeCanonicalScopeConfig(t, rigDir, contract.ConfigState{

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -265,6 +265,7 @@ BeadsConfig holds bead store settings.
 | `provider` | string |  | `bd` | Provider selects the bead store backend: "bd" (default), "file", or "exec:&lt;script&gt;" for a user-supplied script. |
 | `backend` | string |  |  | Backend selects the bd storage engine when Provider is "bd". Empty defaults to "dolt"; T3Code uses "doltlite" for local dev stores. |
 | `event_hooks` | boolean |  | `true` | EventHooks controls installation of the bead event-forwarding hooks (.beads/hooks/on_create,on_update,on_close). Defaults to true. This config surface is staged ahead of the native bead-event support; current hook behavior remains unchanged until lifecycle code opts in. |
+| `bd_compatibility` | string |  |  | BDCompatibility selects the bd CLI semantics Gas City may rely on. Empty defaults to "bd-1.0.4", which keeps claimable work history-backed and avoids ready flags whose filtering is incomplete in bd 1.0.4. Enum: `bd-1.0.4`, `bd-1.0.5` |
 | `policies` | map[string]BeadPolicyConfig |  |  | Policies defines per-bead-use storage and garbage-collection defaults. Policy names are interpreted by higher-level systems; unknown names are preserved so packs can stage future policy classes without breaking load. |
 
 ## ChatSessionsConfig

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -974,6 +974,14 @@
           "description": "EventHooks controls installation of the bead event-forwarding hooks\n(.beads/hooks/on_create,on_update,on_close). Defaults to true.\nThis config surface is staged ahead of the native bead-event support;\ncurrent hook behavior remains unchanged until lifecycle code opts in.",
           "default": true
         },
+        "bd_compatibility": {
+          "type": "string",
+          "enum": [
+            "bd-1.0.4",
+            "bd-1.0.5"
+          ],
+          "description": "BDCompatibility selects the bd CLI semantics Gas City may rely on.\nEmpty defaults to \"bd-1.0.4\", which keeps claimable work history-backed\nand avoids ready flags whose filtering is incomplete in bd 1.0.4."
+        },
         "policies": {
           "additionalProperties": {
             "$ref": "#/$defs/BeadPolicyConfig"

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -974,6 +974,14 @@
           "description": "EventHooks controls installation of the bead event-forwarding hooks\n(.beads/hooks/on_create,on_update,on_close). Defaults to true.\nThis config surface is staged ahead of the native bead-event support;\ncurrent hook behavior remains unchanged until lifecycle code opts in.",
           "default": true
         },
+        "bd_compatibility": {
+          "type": "string",
+          "enum": [
+            "bd-1.0.4",
+            "bd-1.0.5"
+          ],
+          "description": "BDCompatibility selects the bd CLI semantics Gas City may rely on.\nEmpty defaults to \"bd-1.0.4\", which keeps claimable work history-backed\nand avoids ready flags whose filtering is incomplete in bd 1.0.4."
+        },
         "policies": {
           "additionalProperties": {
             "$ref": "#/$defs/BeadPolicyConfig"

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -869,6 +869,9 @@
               "null"
             ]
           },
+          "no_history": {
+            "type": "boolean"
+          },
           "parent": {
             "type": "string"
           },

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -869,6 +869,9 @@
               "null"
             ]
           },
+          "no_history": {
+            "type": "boolean"
+          },
           "parent": {
             "type": "string"
           },

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2345,7 +2345,7 @@ func TestReaperParentIDIsParentChildDependencyProjection(t *testing.T) {
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		call := name + " " + strings.Join(args, " ")
 		switch call {
-		case "bd list --json --label=parent-projection --include-infra --include-gates --limit 50":
+		case "bd list --json --label=parent-projection --include-infra --include-gates --limit 0":
 			return []byte(`[
 				{
 					"id":"ga-child",

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -28,7 +28,7 @@ gc sling "$POLECAT_TARGET" <bead-id>                     # dispatch to polecat p
 
 **Pool dispatch leaves the assignee empty.** The polecat that picks the bead up sets the
 assignee on claim. If you set `--assignee` yourself, the supervisor's scale_check
-(`bd ready --metadata-field gc.routed_to=<canonical> --unassigned`) won't count the bead as
+(`bd ready --include-ephemeral --metadata-field gc.routed_to=<canonical> --unassigned`) won't count the bead as
 pool demand and no session will spawn. Set `gc.routed_to` only.
 
 **Why this is the default:**

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -27,9 +27,9 @@ gc sling "$POLECAT_TARGET" <bead-id>                     # dispatch to polecat p
 ```
 
 **Pool dispatch leaves the assignee empty.** The polecat that picks the bead up sets the
-assignee on claim. If you set `--assignee` yourself, the supervisor's scale_check
-(`bd ready --include-ephemeral --metadata-field gc.routed_to=<canonical> --unassigned`) won't count the bead as
-pool demand and no session will spawn. Set `gc.routed_to` only.
+assignee on claim. If you set `--assignee` yourself, the supervisor's
+storage-aware scale_check query will not count the bead as pool demand and no
+session will spawn. Set `gc.routed_to` only.
 
 **Why this is the default:**
 - Every polecat completion is a ledger entry — transparent, auditable work

--- a/examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md
+++ b/examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md
@@ -17,7 +17,7 @@ Run `gc prime` to check your hook for assigned work.
 
 If `gc prime` shows no assigned beads, run:
 ```
-gc bd ready --label=pool:worker --unassigned --limit=1 --json
+gc bd ready --include-ephemeral --label=pool:worker --unassigned --limit=1 --json
 ```
 Claim the first result with `gc bd update <id> --claim`, close it, then `gc runtime drain-ack` and `exit`.
 

--- a/examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md
+++ b/examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md
@@ -17,7 +17,7 @@ Run `gc prime` to check your hook for assigned work.
 
 If `gc prime` shows no assigned beads, run:
 ```
-gc bd ready --include-ephemeral --label=pool:worker --unassigned --limit=1 --json
+gc bd ready --label=pool:worker --unassigned --limit=1 --json
 ```
 Claim the first result with `gc bd update <id> --claim`, close it, then `gc runtime drain-ack` and `exit`.
 

--- a/examples/swarm/packs/swarm/agents/coder/agent.toml
+++ b/examples/swarm/packs/swarm/agents/coder/agent.toml
@@ -1,5 +1,5 @@
 scope = "rig"
-nudge = "Run gc bd ready --unassigned, check mail, then claim and work on a task."
+nudge = "Run gc bd ready --include-ephemeral --unassigned, check mail, then claim and work on a task."
 idle_timeout = "2h"
 min_active_sessions = 1
 max_active_sessions = 5

--- a/examples/swarm/packs/swarm/agents/coder/agent.toml
+++ b/examples/swarm/packs/swarm/agents/coder/agent.toml
@@ -1,5 +1,5 @@
 scope = "rig"
-nudge = "Run gc bd ready --include-ephemeral --unassigned, check mail, then claim and work on a task."
+nudge = "Run gc bd ready --unassigned, check mail, then claim and work on a task."
 idle_timeout = "2h"
 min_active_sessions = 1
 max_active_sessions = 5

--- a/examples/swarm/packs/swarm/agents/coder/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/coder/prompt.template.md
@@ -11,7 +11,7 @@ boss — you and the other coders are equals. You self-organize through beads
 ## Startup
 
 1. Check mail: `gc mail check`
-2. Find work: `gc bd ready --unassigned` — shows open tasks with no blockers and
+2. Find work: `gc bd ready --include-ephemeral --unassigned` — shows open tasks with no blockers and
    no assignee.
 3. Claim work: `gc bd update <id> --claim` — atomic compare-and-swap. If another
    coder claimed it first, the command fails. Pick the next task.
@@ -23,7 +23,7 @@ boss — you and the other coders are equals. You self-organize through beads
 2. Mark it done: `gc bd close <id>`
 3. Announce: `gc mail send --all "Done with <id>: <summary>"`
 4. Check mail for announcements from other coders.
-5. Find the next task: `gc bd ready --unassigned`
+5. Find the next task: `gc bd ready --include-ephemeral --unassigned`
 6. Repeat.
 
 ## File Coordination
@@ -60,7 +60,7 @@ If you can't finish a task or hit a conflict:
 
 1. Release it: `gc bd reopen <id>`
 2. Announce: `gc mail send --all "Releasing <id>: <reason>"`
-3. Pick something else: `gc bd ready --unassigned`
+3. Pick something else: `gc bd ready --include-ephemeral --unassigned`
 
 ## Communication
 

--- a/examples/swarm/packs/swarm/agents/coder/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/coder/prompt.template.md
@@ -11,7 +11,7 @@ boss — you and the other coders are equals. You self-organize through beads
 ## Startup
 
 1. Check mail: `gc mail check`
-2. Find work: `gc bd ready --include-ephemeral --unassigned` — shows open tasks with no blockers and
+2. Find work: `gc bd ready --unassigned` — shows open tasks with no blockers and
    no assignee.
 3. Claim work: `gc bd update <id> --claim` — atomic compare-and-swap. If another
    coder claimed it first, the command fails. Pick the next task.
@@ -23,7 +23,7 @@ boss — you and the other coders are equals. You self-organize through beads
 2. Mark it done: `gc bd close <id>`
 3. Announce: `gc mail send --all "Done with <id>: <summary>"`
 4. Check mail for announcements from other coders.
-5. Find the next task: `gc bd ready --include-ephemeral --unassigned`
+5. Find the next task: `gc bd ready --unassigned`
 6. Repeat.
 
 ## File Coordination
@@ -60,7 +60,7 @@ If you can't finish a task or hit a conflict:
 
 1. Release it: `gc bd reopen <id>`
 2. Announce: `gc mail send --all "Releasing <id>: <reason>"`
-3. Pick something else: `gc bd ready --include-ephemeral --unassigned`
+3. Pick something else: `gc bd ready --unassigned`
 
 ## Communication
 

--- a/examples/swarm/packs/swarm/agents/mayor/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/mayor/prompt.template.md
@@ -31,12 +31,12 @@ Check what's happening across the swarm:
 
 - `gc bd list --status=open` — all open work
 - `gc bd list --status=in_progress` — what coders are working on
-- `gc bd ready --unassigned` — unclaimed work
+- `gc bd ready --include-ephemeral --unassigned` — unclaimed work
 - `gc mail inbox` — messages from coders
 
 ## Communication
 
-- **Broadcast**: `gc mail send --all "New tasks filed — check gc bd ready"`
+- **Broadcast**: `gc mail send --all "New tasks filed — check gc bd ready --include-ephemeral"`
 - **Direct**: `gc mail send <rig>/<agent> "Priority shift: focus on auth"`
 - **Check mail**: `gc mail check`
 

--- a/examples/swarm/packs/swarm/agents/mayor/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/mayor/prompt.template.md
@@ -31,12 +31,12 @@ Check what's happening across the swarm:
 
 - `gc bd list --status=open` — all open work
 - `gc bd list --status=in_progress` — what coders are working on
-- `gc bd ready --include-ephemeral --unassigned` — unclaimed work
+- `gc bd ready --unassigned` — unclaimed work
 - `gc mail inbox` — messages from coders
 
 ## Communication
 
-- **Broadcast**: `gc mail send --all "New tasks filed — check gc bd ready --include-ephemeral"`
+- **Broadcast**: `gc mail send --all "New tasks filed - check gc bd ready --unassigned"`
 - **Direct**: `gc mail send <rig>/<agent> "Priority shift: focus on auth"`
 - **Check mail**: `gc mail check`
 

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -531,6 +531,7 @@ type Bead struct {
 	Labels       *[]string          `json:"labels,omitempty"`
 	Metadata     *map[string]string `json:"metadata,omitempty"`
 	Needs        *[]string          `json:"needs,omitempty"`
+	NoHistory    *bool              `json:"no_history,omitempty"`
 	Parent       *string            `json:"parent,omitempty"`
 	Priority     *int64             `json:"priority,omitempty"`
 	Ref          *string            `json:"ref,omitempty"`

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -869,6 +869,9 @@
               "null"
             ]
           },
+          "no_history": {
+            "type": "boolean"
+          },
           "parent": {
             "type": "string"
           },

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -464,6 +464,7 @@ type bdIssue struct {
 	Metadata     StringMap    `json:"metadata,omitempty"`
 	Dependencies []bdIssueDep `json:"dependencies,omitempty"`
 	Ephemeral    bool         `json:"ephemeral,omitempty"`
+	NoHistory    bool         `json:"no_history,omitempty"`
 	DeferUntil   *time.Time   `json:"defer_until,omitempty"`
 }
 
@@ -614,6 +615,7 @@ func (b *bdIssue) toBead() Bead {
 		Metadata:     b.Metadata,
 		Dependencies: deps,
 		Ephemeral:    b.Ephemeral,
+		NoHistory:    b.NoHistory,
 		DeferUntil:   cloneTimePtr(b.DeferUntil),
 	}
 }
@@ -677,6 +679,19 @@ func mapBdStatus(s string) string {
 
 // Create persists a new bead via bd create.
 func (s *BdStore) Create(b Bead) (Bead, error) {
+	return s.CreateWithStorage(b, StorageDefault)
+}
+
+// CreateWithStorage persists a new bead via bd create using a storage tier
+// selected by policy middleware.
+func (s *BdStore) CreateWithStorage(b Bead, storage StorageClass) (Bead, error) {
+	effectiveEphemeral, effectiveNoHistory, err := effectiveStorageFlags(b, storage)
+	if err != nil {
+		return Bead{}, fmt.Errorf("bd create: %w", err)
+	}
+	if effectiveEphemeral && effectiveNoHistory {
+		return Bead{}, fmt.Errorf("bd create: ephemeral and no-history storage are mutually exclusive")
+	}
 	typ := b.Type
 	if typ == "" {
 		typ = "task"
@@ -705,8 +720,11 @@ func (s *BdStore) Create(b Bead) (Bead, error) {
 	if b.ParentID != "" {
 		args = append(args, "--parent", b.ParentID)
 	}
-	if b.Ephemeral {
+	if effectiveEphemeral {
 		args = append(args, "--ephemeral")
+	}
+	if effectiveNoHistory {
+		args = append(args, "--no-history")
 	}
 	if b.DeferUntil != nil {
 		args = append(args, "--defer", b.DeferUntil.Format(time.RFC3339))
@@ -750,7 +768,28 @@ func (s *BdStore) Create(b Bead) (Bead, error) {
 			created.Metadata = maps.Clone(metadata)
 		}
 	}
+	if effectiveEphemeral {
+		created.Ephemeral = true
+	}
+	if effectiveNoHistory {
+		created.NoHistory = true
+	}
 	return created, nil
+}
+
+func effectiveStorageFlags(b Bead, storage StorageClass) (ephemeral bool, noHistory bool, err error) {
+	switch storage {
+	case StorageDefault:
+		return b.Ephemeral, b.NoHistory, nil
+	case StorageHistory:
+		return false, false, nil
+	case StorageNoHistory:
+		return false, true, nil
+	case StorageEphemeral:
+		return true, false, nil
+	default:
+		return false, false, fmt.Errorf("unknown storage class %q", storage)
+	}
 }
 
 // Get retrieves a bead by ID via bd show.
@@ -1565,28 +1604,13 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("bd list: %w", ErrQueryRequiresScan)
 	}
-
-	switch query.TierMode {
-	case TierWisps:
-		return s.listEphemeral(query)
-	case TierBoth:
-		if bdListCoversBothTiers(query) {
-			return s.listViaBDList(query)
-		}
-		return s.listBothTiers(query)
-	}
-
 	return s.listViaBDList(query)
-}
-
-func bdListCoversBothTiers(query ListQuery) bool {
-	return query.Type == "message"
 }
 
 func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 	serverQuery, clientFilteredAssignees := bdServerQueryForAssignees(query)
 	limit := serverQuery.Limit
-	if bdListRequiresClientLimit(serverQuery, clientFilteredAssignees) {
+	if bdListRequiresClientLimit(query, serverQuery, clientFilteredAssignees) {
 		limit = 0
 	}
 	args := []string{"list", "--json"}
@@ -1609,6 +1633,9 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 		args = append(args, "--created-before", serverQuery.CreatedBefore.Format(time.RFC3339Nano))
 	}
 	args = append(args, "--include-infra", "--include-gates")
+	if query.TierMode == TierWisps || query.TierMode == TierBoth {
+		args = append(args, "--include-templates")
+	}
 	args = append(args, "--limit", fmt.Sprintf("%d", limit))
 	if serverQuery.ParentID != "" {
 		args = append(args, "--parent", serverQuery.ParentID)
@@ -1648,11 +1675,14 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 	return filtered, nil
 }
 
-func bdListRequiresClientLimit(serverQuery ListQuery, clientFilteredAssignees bool) bool {
+func bdListRequiresClientLimit(query, serverQuery ListQuery, clientFilteredAssignees bool) bool {
+	if query.TierMode == TierIssues || query.TierMode == TierWisps {
+		return true
+	}
 	if serverQuery.Sort == SortCreatedAsc || clientFilteredAssignees {
 		return true
 	}
-	if !serverQuery.UpdatedBefore.IsZero() {
+	if len(serverQuery.Metadata) > 0 || !serverQuery.CreatedBefore.IsZero() || !serverQuery.UpdatedBefore.IsZero() {
 		return true
 	}
 	return false
@@ -1675,150 +1705,6 @@ func bdServerQueryForAssignees(query ListQuery) (ListQuery, bool) {
 		serverQuery.AllowScan = true
 		return serverQuery, true
 	}
-}
-
-// listEphemeral reads only the wisps tier using `bd query "ephemeral=true AND
-// <filters>"`. For most bead types, bd query is the canonical way to reach the
-// wisps table (mirrors gastown's internal/beads/beads.go listEphemeral path).
-func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
-	serverQuery, clientFilteredAssignees := bdServerQueryForAssignees(query)
-	clauses := []string{"ephemeral=true"}
-	serverFilteredOnly := !clientFilteredAssignees
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "label", serverQuery.Label)
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "status", serverQuery.Status)
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "type", serverQuery.Type)
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "assignee", serverQuery.Assignee)
-	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "parent", serverQuery.ParentID)
-
-	args := []string{"query", "--json", strings.Join(clauses, " AND ")}
-	if serverQuery.IncludeClosed || serverQuery.Status == "closed" {
-		args = append(args, "--all")
-	}
-	wispsLimit := 0
-	if query.Limit > 0 && serverFilteredOnly && canApplyWispsServerLimit(query) {
-		wispsLimit = query.Limit
-	}
-	args = append(args, "--limit", strconv.Itoa(wispsLimit))
-
-	out, err := s.runner(s.dir, "bd", args...)
-	if err != nil {
-		return nil, fmt.Errorf("bd query (wisps): %w", err)
-	}
-	issues, parseErr := parseIssuesTolerant(extractJSON(out))
-	result := make([]Bead, len(issues))
-	for i := range issues {
-		result[i] = issues[i].toBead()
-		// bd query against wisps returns ephemeral beads; tolerate older bd
-		// versions that omit the ephemeral field in JSON.
-		result[i].Ephemeral = true
-	}
-	// Re-apply filters client-side (defense in depth against bd-query DSL
-	// drift) and re-cap Limit after client-only filters/sorts.
-	filtered := applyListQuery(result, query)
-	if parseErr != nil {
-		if len(filtered) > 0 {
-			return filtered, &PartialResultError{Op: "bd query", Err: parseErr}
-		}
-		return filtered, fmt.Errorf("bd query: %w", parseErr)
-	}
-	return filtered, nil
-}
-
-func canApplyWispsServerLimit(query ListQuery) bool {
-	return (query.Sort == SortDefault || query.Sort == SortCreatedDesc) &&
-		query.CreatedBefore.IsZero() &&
-		len(query.Metadata) == 0
-}
-
-func appendBdQueryClause(clauses []string, serverFilteredOnly bool, field, value string) ([]string, bool) {
-	if value == "" {
-		return clauses, serverFilteredOnly
-	}
-	if !isBareBdQueryValue(value) {
-		return clauses, false
-	}
-	return append(clauses, field+"="+value), serverFilteredOnly
-}
-
-// isBareBdQueryValue reports whether value can be emitted unquoted into the bd
-// query DSL. Values outside this narrow token set are filtered client-side.
-func isBareBdQueryValue(value string) bool {
-	upper := strings.ToUpper(value)
-	if upper == "AND" || upper == "OR" || upper == "NOT" {
-		return false
-	}
-	for _, r := range value {
-		switch {
-		case r >= 'a' && r <= 'z':
-		case r >= 'A' && r <= 'Z':
-		case r >= '0' && r <= '9':
-		case r == '_' || r == '-' || r == ':' || r == '.':
-		default:
-			return false
-		}
-	}
-	return true
-}
-
-// listBothTiers unions the issues and wisps tiers in a single logical query.
-// Each tier is queried with its own TierMode; results are deduped by ID and
-// re-sorted under the caller-supplied Sort.
-//
-// Partial failure: if exactly one tier errors, the other tier's rows are
-// returned along with a non-nil error so callers can decide whether to
-// degrade or fail. When survivor rows exist, the error is a PartialResultError
-// so controller demand paths can retain those rows while still reporting the
-// incomplete read. Silently swallowing the failure would let dispatch paths see
-// "no in-flight work" and double-fire.
-func (s *BdStore) listBothTiers(query ListQuery) ([]Bead, error) {
-	issuesQ := query
-	issuesQ.TierMode = TierIssues
-	issuesResult, issuesErr := s.List(issuesQ)
-
-	wispsQ := query
-	wispsQ.TierMode = TierWisps
-	wispsResult, wispsErr := s.List(wispsQ)
-
-	if issuesErr != nil && wispsErr != nil {
-		return nil, errors.Join(issuesErr, wispsErr)
-	}
-
-	merged := make([]Bead, 0, len(issuesResult)+len(wispsResult))
-	seen := make(map[string]struct{}, len(issuesResult)+len(wispsResult))
-	for _, b := range issuesResult {
-		if _, ok := seen[b.ID]; ok {
-			continue
-		}
-		seen[b.ID] = struct{}{}
-		merged = append(merged, b)
-	}
-	for _, b := range wispsResult {
-		if _, ok := seen[b.ID]; ok {
-			continue
-		}
-		seen[b.ID] = struct{}{}
-		merged = append(merged, b)
-	}
-	sortBeadsForQuery(merged, query.Sort)
-	if query.Limit > 0 && len(merged) > query.Limit {
-		merged = merged[:query.Limit]
-	}
-
-	// Surface single-tier failure so callers don't mistake a partial
-	// result for a complete one.
-	switch {
-	case issuesErr != nil:
-		if len(merged) > 0 {
-			return merged, &PartialResultError{Op: "bd list both tiers", Err: fmt.Errorf("issues tier: %w", issuesErr)}
-		}
-		return merged, fmt.Errorf("bd list both tiers: issues tier: %w", issuesErr)
-	case wispsErr != nil:
-		if len(merged) > 0 {
-			return merged, &PartialResultError{Op: "bd list both tiers", Err: fmt.Errorf("wisps tier: %w", wispsErr)}
-		}
-		return merged, fmt.Errorf("bd list both tiers: wisps tier: %w", wispsErr)
-	}
-	return merged, nil
 }
 
 // ListOpen returns non-closed beads via bd list. Pass a status to filter further.
@@ -1920,7 +1806,11 @@ func bdReadyArgs(q ReadyQuery, includeEphemeral bool) []string {
 	if q.Assignee != "" {
 		args = append(args, "--assignee", q.Assignee)
 	}
-	args = append(args, "--limit", "0")
+	limit := 0
+	if q.Assignee != "" && q.TierMode == TierBoth {
+		limit = q.Limit
+	}
+	args = append(args, "--limit", strconv.Itoa(limit))
 	return args
 }
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1604,6 +1604,13 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("bd list: %w", ErrQueryRequiresScan)
 	}
+
+	switch query.TierMode {
+	case TierWisps:
+		return s.listWispsTier(query)
+	case TierBoth:
+		return s.listBothTiers(query)
+	}
 	return s.listViaBDList(query)
 }
 
@@ -1633,7 +1640,7 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 		args = append(args, "--created-before", serverQuery.CreatedBefore.Format(time.RFC3339Nano))
 	}
 	args = append(args, "--include-infra", "--include-gates")
-	if query.TierMode == TierWisps || query.TierMode == TierBoth {
+	if bdListShouldIncludeTemplates(query) {
 		args = append(args, "--include-templates")
 	}
 	args = append(args, "--limit", fmt.Sprintf("%d", limit))
@@ -1688,6 +1695,10 @@ func bdListRequiresClientLimit(query, serverQuery ListQuery, clientFilteredAssig
 	return false
 }
 
+func bdListShouldIncludeTemplates(query ListQuery) bool {
+	return query.TierMode == TierWisps || (query.TierMode == TierBoth && query.Type != "message")
+}
+
 func bdServerQueryForAssignees(query ListQuery) (ListQuery, bool) {
 	serverQuery := query
 	if query.Assignee != "" {
@@ -1704,6 +1715,167 @@ func bdServerQueryForAssignees(query ListQuery) (ListQuery, bool) {
 		serverQuery.Assignees = nil
 		serverQuery.AllowScan = true
 		return serverQuery, true
+	}
+}
+
+func (s *BdStore) listWispsTier(query ListQuery) ([]Bead, error) {
+	listQ := query
+	listQ.TierMode = TierWisps
+	listResult, listErr := s.listViaBDList(listQ)
+
+	ephemeralQ := query
+	ephemeralQ.TierMode = TierWisps
+	ephemeralResult, ephemeralErr := s.listEphemeral(ephemeralQ)
+
+	return mergeListTierResults(query, "bd list wisps tier", listResult, listErr, ephemeralResult, ephemeralErr)
+}
+
+// listEphemeral reads only ephemeral rows using `bd query "ephemeral=true AND
+// <filters>"`. The installed bd list surface does not expose ephemeral rows, so
+// TierWisps and TierBoth must union this path with bd list results.
+func (s *BdStore) listEphemeral(query ListQuery) ([]Bead, error) {
+	serverQuery, clientFilteredAssignees := bdServerQueryForAssignees(query)
+	clauses := []string{"ephemeral=true"}
+	serverFilteredOnly := !clientFilteredAssignees
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "label", serverQuery.Label)
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "status", serverQuery.Status)
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "type", serverQuery.Type)
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "assignee", serverQuery.Assignee)
+	clauses, serverFilteredOnly = appendBdQueryClause(clauses, serverFilteredOnly, "parent", serverQuery.ParentID)
+
+	args := []string{"query", "--json", strings.Join(clauses, " AND ")}
+	if serverQuery.IncludeClosed || serverQuery.Status == "closed" {
+		args = append(args, "--all")
+	}
+	wispsLimit := 0
+	if query.Limit > 0 && serverFilteredOnly && canApplyWispsServerLimit(query) {
+		wispsLimit = query.Limit
+	}
+	args = append(args, "--limit", strconv.Itoa(wispsLimit))
+
+	out, err := s.runner(s.dir, "bd", args...)
+	if err != nil {
+		if isBdQueryUnsupported(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("bd query (wisps): %w", err)
+	}
+	issues, parseErr := parseIssuesTolerant(extractJSON(out))
+	result := make([]Bead, len(issues))
+	for i := range issues {
+		result[i] = issues[i].toBead()
+		result[i].Ephemeral = true
+		result[i].NoHistory = false
+	}
+	filtered := applyListQuery(result, query)
+	if parseErr != nil {
+		if len(filtered) > 0 {
+			return filtered, &PartialResultError{Op: "bd query", Err: parseErr}
+		}
+		return filtered, fmt.Errorf("bd query: %w", parseErr)
+	}
+	return filtered, nil
+}
+
+func isBdQueryUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "unknown subcommand \"query\"") ||
+		strings.Contains(text, "unknown command \"query\"") ||
+		strings.Contains(text, "unknown subcommand query") ||
+		strings.Contains(text, "unknown command query")
+}
+
+func canApplyWispsServerLimit(query ListQuery) bool {
+	return (query.Sort == SortDefault || query.Sort == SortCreatedDesc) &&
+		query.CreatedBefore.IsZero() &&
+		query.UpdatedBefore.IsZero() &&
+		len(query.Metadata) == 0
+}
+
+func appendBdQueryClause(clauses []string, serverFilteredOnly bool, field, value string) ([]string, bool) {
+	if value == "" {
+		return clauses, serverFilteredOnly
+	}
+	if !isBareBdQueryValue(value) {
+		return clauses, false
+	}
+	return append(clauses, field+"="+value), serverFilteredOnly
+}
+
+func isBareBdQueryValue(value string) bool {
+	upper := strings.ToUpper(value)
+	if upper == "AND" || upper == "OR" || upper == "NOT" {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-' || r == ':' || r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (s *BdStore) listBothTiers(query ListQuery) ([]Bead, error) {
+	listQ := query
+	listQ.TierMode = TierBoth
+	listResult, listErr := s.listViaBDList(listQ)
+
+	ephemeralQ := query
+	ephemeralQ.TierMode = TierWisps
+	ephemeralResult, ephemeralErr := s.listEphemeral(ephemeralQ)
+
+	return mergeListTierResults(query, "bd list both tiers", listResult, listErr, ephemeralResult, ephemeralErr)
+}
+
+func mergeListTierResults(query ListQuery, op string, primary []Bead, primaryErr error, ephemeral []Bead, ephemeralErr error) ([]Bead, error) {
+	if primaryErr != nil && ephemeralErr != nil {
+		return nil, errors.Join(primaryErr, ephemeralErr)
+	}
+
+	merged := make([]Bead, 0, len(primary)+len(ephemeral))
+	seen := make(map[string]int, len(primary)+len(ephemeral))
+	add := func(b Bead) {
+		if idx, ok := seen[b.ID]; ok {
+			if b.Ephemeral && !merged[idx].Ephemeral {
+				merged[idx] = b
+			}
+			return
+		}
+		seen[b.ID] = len(merged)
+		merged = append(merged, b)
+	}
+	for _, b := range primary {
+		add(b)
+	}
+	for _, b := range ephemeral {
+		add(b)
+	}
+	sortBeadsForQuery(merged, query.Sort)
+	if query.Limit > 0 && len(merged) > query.Limit {
+		merged = merged[:query.Limit]
+	}
+
+	switch {
+	case primaryErr != nil:
+		if len(merged) > 0 {
+			return merged, &PartialResultError{Op: op, Err: fmt.Errorf("bd list: %w", primaryErr)}
+		}
+		return merged, fmt.Errorf("%s: bd list: %w", op, primaryErr)
+	case ephemeralErr != nil:
+		if len(merged) > 0 {
+			return merged, &PartialResultError{Op: op, Err: fmt.Errorf("bd query: %w", ephemeralErr)}
+		}
+		return merged, fmt.Errorf("%s: bd query: %w", op, ephemeralErr)
+	default:
+		return merged, nil
 	}
 }
 
@@ -1806,11 +1978,7 @@ func bdReadyArgs(q ReadyQuery, includeEphemeral bool) []string {
 	if q.Assignee != "" {
 		args = append(args, "--assignee", q.Assignee)
 	}
-	limit := 0
-	if q.Assignee != "" && q.TierMode == TierBoth {
-		limit = q.Limit
-	}
-	args = append(args, "--limit", strconv.Itoa(limit))
+	args = append(args, "--limit", "0")
 	return args
 }
 

--- a/internal/beads/bdstore_graph_apply.go
+++ b/internal/beads/bdstore_graph_apply.go
@@ -10,9 +10,19 @@ import (
 
 // ApplyGraphPlan creates a bead graph via a single hidden bd command so the
 // full graph becomes visible only after the underlying transaction commits.
-func (s *BdStore) ApplyGraphPlan(_ context.Context, plan *GraphApplyPlan) (*GraphApplyResult, error) {
+func (s *BdStore) ApplyGraphPlan(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyResult, error) {
+	return s.ApplyGraphPlanWithStorage(ctx, plan, StorageDefault)
+}
+
+// ApplyGraphPlanWithStorage creates a bead graph in a storage tier selected by
+// policy middleware.
+func (s *BdStore) ApplyGraphPlanWithStorage(_ context.Context, plan *GraphApplyPlan, storage StorageClass) (*GraphApplyResult, error) {
 	if plan == nil {
 		return nil, fmt.Errorf("graph apply plan is nil")
+	}
+	ephemeral, noHistory, err := graphStorageFlags(storage)
+	if err != nil {
+		return nil, fmt.Errorf("bd create --graph: %w", err)
 	}
 
 	data, err := json.Marshal(plan)
@@ -40,7 +50,14 @@ func (s *BdStore) ApplyGraphPlan(_ context.Context, plan *GraphApplyPlan) (*Grap
 		return nil, fmt.Errorf("closing graph apply temp file: %w", err)
 	}
 
-	out, err := s.runner(s.dir, "bd", "create", "--graph", tmpPath, "--json")
+	args := []string{"create", "--graph", tmpPath, "--json"}
+	if ephemeral {
+		args = append(args, "--ephemeral")
+	}
+	if noHistory {
+		args = append(args, "--no-history")
+	}
+	out, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
 		return nil, fmt.Errorf("bd create --graph: %w", err)
 	}
@@ -53,4 +70,23 @@ func (s *BdStore) ApplyGraphPlan(_ context.Context, plan *GraphApplyPlan) (*Grap
 		return nil, fmt.Errorf("bd create --graph: %w", err)
 	}
 	return &result, nil
+}
+
+func graphStorageFlags(storage StorageClass) (ephemeral bool, noHistory bool, err error) {
+	switch storage {
+	case StorageDefault, StorageHistory:
+		return false, false, nil
+	case StorageNoHistory:
+		return false, true, nil
+	case StorageEphemeral:
+		return true, false, nil
+	default:
+		return false, false, fmt.Errorf("unknown storage class %q", storage)
+	}
+}
+
+// SupportsEphemeralGraphApply reports whether this store can apply a whole
+// graph directly into ephemeral storage.
+func (s *BdStore) SupportsEphemeralGraphApply() bool {
+	return true
 }

--- a/internal/beads/bdstore_storage_conformance_test.go
+++ b/internal/beads/bdstore_storage_conformance_test.go
@@ -1,0 +1,510 @@
+package beads_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestBdStoreCreateStorageFlagConformance(t *testing.T) {
+	cases := []struct {
+		name             string
+		input            beads.Bead
+		storage          beads.StorageClass
+		wantEphemeral    bool
+		wantNoHistory    bool
+		wantCreatedFlags string
+	}{
+		{
+			name:  "default history",
+			input: beads.Bead{Title: "plain"},
+		},
+		{
+			name:             "default honors legacy ephemeral field",
+			input:            beads.Bead{Title: "legacy ephemeral", Ephemeral: true},
+			wantEphemeral:    true,
+			wantCreatedFlags: "ephemeral",
+		},
+		{
+			name:             "default honors legacy no-history field",
+			input:            beads.Bead{Title: "legacy no-history", NoHistory: true},
+			wantNoHistory:    true,
+			wantCreatedFlags: "no-history",
+		},
+		{
+			name:    "policy history clears caller storage hints",
+			input:   beads.Bead{Title: "forced history", Ephemeral: true, NoHistory: true},
+			storage: beads.StorageHistory,
+		},
+		{
+			name:             "policy no-history overrides caller ephemeral hint",
+			input:            beads.Bead{Title: "forced no-history", Ephemeral: true},
+			storage:          beads.StorageNoHistory,
+			wantNoHistory:    true,
+			wantCreatedFlags: "no-history",
+		},
+		{
+			name:             "policy ephemeral overrides caller no-history hint",
+			input:            beads.Bead{Title: "forced ephemeral", NoHistory: true},
+			storage:          beads.StorageEphemeral,
+			wantEphemeral:    true,
+			wantCreatedFlags: "ephemeral",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotArgs []string
+			runner := func(_, name string, args ...string) ([]byte, error) {
+				if name != "bd" {
+					t.Fatalf("runner name = %q, want bd", name)
+				}
+				gotArgs = append([]string(nil), args...)
+				payload := fmt.Sprintf(
+					`{"id":"bd-x","title":%q,"status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","ephemeral":%t,"no_history":%t}`,
+					tc.input.Title,
+					tc.wantEphemeral,
+					tc.wantNoHistory,
+				)
+				return []byte(payload), nil
+			}
+			store := beads.NewBdStore("/city", runner)
+
+			created, err := store.CreateWithStorage(tc.input, tc.storage)
+			if err != nil {
+				t.Fatalf("CreateWithStorage: %v", err)
+			}
+
+			assertArgPresence(t, gotArgs, "--ephemeral", tc.wantEphemeral)
+			assertArgPresence(t, gotArgs, "--no-history", tc.wantNoHistory)
+			if created.Ephemeral != tc.wantEphemeral || created.NoHistory != tc.wantNoHistory {
+				t.Fatalf("created storage = ephemeral:%v no_history:%v, want ephemeral:%v no_history:%v",
+					created.Ephemeral, created.NoHistory, tc.wantEphemeral, tc.wantNoHistory)
+			}
+			switch tc.wantCreatedFlags {
+			case "":
+				if created.Ephemeral || created.NoHistory {
+					t.Fatalf("created storage flags = ephemeral:%v no_history:%v, want history", created.Ephemeral, created.NoHistory)
+				}
+			case "ephemeral":
+				if !created.Ephemeral || created.NoHistory {
+					t.Fatalf("created storage flags = ephemeral:%v no_history:%v, want ephemeral only", created.Ephemeral, created.NoHistory)
+				}
+			case "no-history":
+				if created.Ephemeral || !created.NoHistory {
+					t.Fatalf("created storage flags = ephemeral:%v no_history:%v, want no-history only", created.Ephemeral, created.NoHistory)
+				}
+			default:
+				t.Fatalf("unknown expected created flags %q", tc.wantCreatedFlags)
+			}
+		})
+	}
+}
+
+func TestBdStoreCreateFullFlagConformance(t *testing.T) {
+	deferUntil := time.Date(2026, 6, 1, 12, 30, 0, 0, time.UTC)
+	priority := 1
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		return []byte(`{
+			"id":"gc-explicit",
+			"title":"full create",
+			"status":"open",
+			"issue_type":"feature",
+			"priority":1,
+			"created_at":"2026-05-01T00:00:00Z",
+			"assignee":"worker",
+			"parent":"bd-parent",
+			"description":"body",
+			"labels":["alpha","beta"],
+			"needs":["bd-dep","validates:bd-check"],
+			"metadata":{"from":"sender","gc.kind":"session","route":"a/b"},
+			"defer_until":"2026-06-01T12:30:00Z",
+			"no_history":true
+		}`), nil
+	}
+	store := beads.NewBdStore("/city", runner)
+
+	created, err := store.CreateWithStorage(beads.Bead{
+		ID:          "gc-explicit",
+		Title:       "full create",
+		Type:        "feature",
+		Priority:    &priority,
+		Description: "body",
+		Assignee:    "worker",
+		Needs:       []string{"bd-dep", "validates:bd-check"},
+		Labels:      []string{"alpha", "beta"},
+		ParentID:    "bd-parent",
+		From:        "sender",
+		Metadata:    map[string]string{"gc.kind": "session", "route": "a/b"},
+		DeferUntil:  &deferUntil,
+	}, beads.StorageNoHistory)
+	if err != nil {
+		t.Fatalf("CreateWithStorage: %v", err)
+	}
+
+	wantPairs := map[string]string{
+		"--id":          "gc-explicit",
+		"-t":            "feature",
+		"--priority":    "1",
+		"--description": "body",
+		"--assignee":    "worker",
+		"--deps":        "bd-dep,validates:bd-check",
+		"--labels":      "alpha,beta",
+		"--parent":      "bd-parent",
+		"--defer":       deferUntil.Format(time.RFC3339),
+	}
+	for flag, value := range wantPairs {
+		assertArgPair(t, gotArgs, flag, value)
+	}
+	assertArgPresence(t, gotArgs, "--no-history", true)
+	assertArgPresence(t, gotArgs, "--ephemeral", false)
+
+	metadata := metadataArg(t, gotArgs)
+	if metadata["from"] != "sender" || metadata["gc.kind"] != "session" || metadata["route"] != "a/b" {
+		t.Fatalf("metadata arg = %#v, want from/gc.kind/route preserved", metadata)
+	}
+	if !created.NoHistory || created.Ephemeral {
+		t.Fatalf("created storage = ephemeral:%v no_history:%v, want no-history", created.Ephemeral, created.NoHistory)
+	}
+}
+
+func TestBdStoreCreateStorageRejectsInvalidConformance(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   beads.Bead
+		storage beads.StorageClass
+		want    string
+	}{
+		{
+			name:  "default rejects mutually exclusive caller flags",
+			input: beads.Bead{Title: "bad", Ephemeral: true, NoHistory: true},
+			want:  "mutually exclusive",
+		},
+		{
+			name:    "unknown policy storage class",
+			input:   beads.Bead{Title: "bad"},
+			storage: beads.StorageClass("archive"),
+			want:    "unknown storage class",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			store := beads.NewBdStore("/city", func(_, _ string, _ ...string) ([]byte, error) {
+				called = true
+				return nil, errors.New("runner should not be called")
+			})
+			_, err := store.CreateWithStorage(tc.input, tc.storage)
+			if err == nil {
+				t.Fatal("CreateWithStorage error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("CreateWithStorage error = %q, want substring %q", err, tc.want)
+			}
+			if called {
+				t.Fatal("runner was called after invalid storage validation")
+			}
+		})
+	}
+}
+
+func TestBdStoreApplyGraphPlanStorageFlagConformance(t *testing.T) {
+	cases := []struct {
+		name          string
+		storage       beads.StorageClass
+		wantEphemeral bool
+		wantNoHistory bool
+	}{
+		{name: "default history"},
+		{name: "explicit history", storage: beads.StorageHistory},
+		{name: "no-history", storage: beads.StorageNoHistory, wantNoHistory: true},
+		{name: "ephemeral", storage: beads.StorageEphemeral, wantEphemeral: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			var gotArgs []string
+			var capturedPlan beads.GraphApplyPlan
+			runner := func(cmdDir, name string, args ...string) ([]byte, error) {
+				if cmdDir != dir {
+					t.Fatalf("runner dir = %q, want %q", cmdDir, dir)
+				}
+				if name != "bd" {
+					t.Fatalf("runner name = %q, want bd", name)
+				}
+				gotArgs = append([]string(nil), args...)
+				data, err := os.ReadFile(args[2])
+				if err != nil {
+					t.Fatalf("reading graph plan: %v", err)
+				}
+				if err := json.Unmarshal(data, &capturedPlan); err != nil {
+					t.Fatalf("unmarshal graph plan: %v", err)
+				}
+				return []byte(`{"ids":{"root":"bd-root","child":"bd-child"}}`), nil
+			}
+			store := beads.NewBdStore(dir, runner)
+
+			result, err := store.ApplyGraphPlanWithStorage(t.Context(), &beads.GraphApplyPlan{
+				Nodes: []beads.GraphApplyNode{
+					{Key: "root", Title: "Root", Metadata: map[string]string{"gc.kind": "wisp"}},
+					{Key: "child", Title: "Child", ParentKey: "root"},
+				},
+			}, tc.storage)
+			if err != nil {
+				t.Fatalf("ApplyGraphPlanWithStorage: %v", err)
+			}
+
+			if result.IDs["root"] != "bd-root" || result.IDs["child"] != "bd-child" {
+				t.Fatalf("result IDs = %#v, want root and child IDs", result.IDs)
+			}
+			if len(gotArgs) < 4 || gotArgs[0] != "create" || gotArgs[1] != "--graph" || gotArgs[3] != "--json" {
+				t.Fatalf("graph args = %#v, want bd create --graph <file> --json", gotArgs)
+			}
+			assertArgPresence(t, gotArgs, "--ephemeral", tc.wantEphemeral)
+			assertArgPresence(t, gotArgs, "--no-history", tc.wantNoHistory)
+			graphJSON := mustJSON(t, capturedPlan)
+			if strings.Contains(graphJSON, "ephemeral") || strings.Contains(graphJSON, "no_history") {
+				t.Fatalf("graph plan JSON = %s, storage must be transported as bd flags only", graphJSON)
+			}
+		})
+	}
+}
+
+func TestBdStoreGetUsesDirectShowForEphemeralRows(t *testing.T) {
+	var calls []string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		cmd := name + " " + strings.Join(args, " ")
+		calls = append(calls, cmd)
+		switch cmd {
+		case "bd show --json bd-wisp":
+			return []byte(`[{"id":"bd-wisp","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","ephemeral":true}]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: %s", cmd)
+		}
+	}
+	store := beads.NewBdStore("/city", runner)
+
+	got, err := store.Get("bd-wisp")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != "bd-wisp" || !got.Ephemeral {
+		t.Fatalf("Get = %+v, want ephemeral row bd-wisp", got)
+	}
+	wantCalls := []string{
+		"bd show --json bd-wisp",
+	}
+	if fmt.Sprint(calls) != fmt.Sprint(wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+	}
+}
+
+func TestBdStoreListStorageTierConformance(t *testing.T) {
+	rows := `[
+		{"id":"bd-history","title":"history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["scope"]},
+		{"id":"bd-no-history","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","labels":["scope"],"no_history":true},
+		{"id":"bd-ephemeral","title":"ephemeral","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","labels":["scope"],"ephemeral":true}
+	]`
+	cases := []struct {
+		name                  string
+		query                 beads.ListQuery
+		wantIDs               []string
+		wantIncludeTemplates  bool
+		wantUnlimitedPrelimit bool
+	}{
+		{
+			name:    "issues tier keeps history and no-history rows",
+			query:   beads.ListQuery{Label: "scope"},
+			wantIDs: []string{"bd-history", "bd-no-history"},
+		},
+		{
+			name:                  "issues tier applies limit after client storage filtering",
+			query:                 beads.ListQuery{Label: "scope", Limit: 1},
+			wantIDs:               []string{"bd-history"},
+			wantUnlimitedPrelimit: true,
+		},
+		{
+			name:                  "wisps tier keeps no-history and ephemeral rows",
+			query:                 beads.ListQuery{Label: "scope", TierMode: beads.TierWisps},
+			wantIDs:               []string{"bd-no-history", "bd-ephemeral"},
+			wantIncludeTemplates:  true,
+			wantUnlimitedPrelimit: true,
+		},
+		{
+			name:                 "both tiers keeps all storage rows",
+			query:                beads.ListQuery{Label: "scope", TierMode: beads.TierBoth},
+			wantIDs:              []string{"bd-history", "bd-no-history", "bd-ephemeral"},
+			wantIncludeTemplates: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotCmd string
+			runner := func(_, name string, args ...string) ([]byte, error) {
+				gotCmd = name + " " + strings.Join(args, " ")
+				return []byte(rows), nil
+			}
+			store := beads.NewBdStore("/city", runner)
+			got, err := store.List(tc.query)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			assertCommandContains(t, gotCmd, "--include-ephemeral", false)
+			assertCommandContains(t, gotCmd, "--include-templates", tc.wantIncludeTemplates)
+			if tc.query.Limit > 0 {
+				assertCommandContains(t, gotCmd, "--limit 0", tc.wantUnlimitedPrelimit)
+			}
+			if gotIDs := beadIDs(got); fmt.Sprint(gotIDs) != fmt.Sprint(tc.wantIDs) {
+				t.Fatalf("List IDs = %v, want %v", gotIDs, tc.wantIDs)
+			}
+		})
+	}
+}
+
+func TestBdStoreListBothTiersUsesSingleListConformance(t *testing.T) {
+	var calls []string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		cmd := name + " " + strings.Join(args, " ")
+		calls = append(calls, cmd)
+		if strings.Contains(cmd, "--include-ephemeral") {
+			t.Fatalf("bd list command = %q, --include-ephemeral is only valid for bd ready", cmd)
+		}
+		return []byte(`[
+			{"id":"bd-history","title":"history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["scope"]},
+			{"id":"bd-no-history","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","labels":["scope"],"no_history":true},
+			{"id":"bd-ephemeral","title":"ephemeral","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","labels":["scope"],"ephemeral":true}
+		]`), nil
+	}
+	store := beads.NewBdStore("/city", runner)
+
+	got, err := store.List(beads.ListQuery{Label: "scope", TierMode: beads.TierBoth, Sort: beads.SortCreatedAsc})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %#v, want one bd list read", calls)
+	}
+	wantIDs := []string{"bd-history", "bd-no-history", "bd-ephemeral"}
+	if gotIDs := beadIDs(got); fmt.Sprint(gotIDs) != fmt.Sprint(wantIDs) {
+		t.Fatalf("List IDs = %v, want %v", gotIDs, wantIDs)
+	}
+}
+
+func TestBdStoreReadyStorageTierConformance(t *testing.T) {
+	// Verified against the official bd 1.0.4 release binary: plain `bd ready`
+	// returns history rows only. `--include-ephemeral` adds ephemeral rows, but
+	// not no-history rows, which is why bd-1.0.4-compatible claimable work must
+	// remain history-backed.
+	defaultRows := `[
+		{"id":"bd-history","title":"history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z"}
+	]`
+	includeEphemeralRows := `[
+		{"id":"bd-history","title":"history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z"},
+		{"id":"bd-ephemeral","title":"ephemeral","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","ephemeral":true}
+	]`
+	cases := []struct {
+		name                 string
+		query                beads.ReadyQuery
+		wantIDs              []string
+		wantIncludeEphemeral bool
+	}{
+		{
+			name:    "issues tier matches bd ready default history-only release behavior",
+			wantIDs: []string{"bd-history"},
+		},
+		{
+			name:                 "wisps tier keeps ephemeral ready work returned by bd 1.0.4",
+			query:                beads.ReadyQuery{TierMode: beads.TierWisps},
+			wantIDs:              []string{"bd-ephemeral"},
+			wantIncludeEphemeral: true,
+		},
+		{
+			name:                 "both tiers keeps history and ephemeral ready work returned by bd 1.0.4",
+			query:                beads.ReadyQuery{TierMode: beads.TierBoth},
+			wantIDs:              []string{"bd-history", "bd-ephemeral"},
+			wantIncludeEphemeral: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotCmd string
+			runner := func(_, name string, args ...string) ([]byte, error) {
+				gotCmd = name + " " + strings.Join(args, " ")
+				if strings.Contains(gotCmd, "--include-ephemeral") {
+					return []byte(includeEphemeralRows), nil
+				}
+				return []byte(defaultRows), nil
+			}
+			store := beads.NewBdStore("/city", runner)
+			got, err := store.Ready(tc.query)
+			if err != nil {
+				t.Fatalf("Ready: %v", err)
+			}
+			assertCommandContains(t, gotCmd, "--include-ephemeral", tc.wantIncludeEphemeral)
+			if gotIDs := beadIDs(got); fmt.Sprint(gotIDs) != fmt.Sprint(tc.wantIDs) {
+				t.Fatalf("Ready IDs = %v, want %v", gotIDs, tc.wantIDs)
+			}
+		})
+	}
+}
+
+func assertArgPresence(t *testing.T, args []string, flag string, want bool) {
+	t.Helper()
+	got := slices.Contains(args, flag)
+	if got != want {
+		t.Fatalf("args = %#v, presence of %s = %v, want %v", args, flag, got, want)
+	}
+}
+
+func assertArgPair(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return
+		}
+	}
+	t.Fatalf("args = %#v, want %s %s", args, flag, value)
+}
+
+func metadataArg(t *testing.T, args []string) map[string]string {
+	t.Helper()
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--metadata" {
+			var metadata map[string]string
+			if err := json.Unmarshal([]byte(args[i+1]), &metadata); err != nil {
+				t.Fatalf("unmarshal metadata arg %q: %v", args[i+1], err)
+			}
+			return metadata
+		}
+	}
+	t.Fatalf("args = %#v, want --metadata", args)
+	return nil
+}
+
+func assertCommandContains(t *testing.T, command, fragment string, want bool) {
+	t.Helper()
+	got := strings.Contains(command, fragment)
+	if got != want {
+		t.Fatalf("command = %q, contains %q = %v, want %v", command, fragment, got, want)
+	}
+}
+
+func beadIDs(items []beads.Bead) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}

--- a/internal/beads/bdstore_storage_conformance_test.go
+++ b/internal/beads/bdstore_storage_conformance_test.go
@@ -310,9 +310,11 @@ func TestBdStoreGetUsesDirectShowForEphemeralRows(t *testing.T) {
 }
 
 func TestBdStoreListStorageTierConformance(t *testing.T) {
-	rows := `[
+	listRows := `[
 		{"id":"bd-history","title":"history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["scope"]},
-		{"id":"bd-no-history","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","labels":["scope"],"no_history":true},
+		{"id":"bd-no-history","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","labels":["scope"],"no_history":true}
+	]`
+	ephemeralRows := `[
 		{"id":"bd-ephemeral","title":"ephemeral","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","labels":["scope"],"ephemeral":true}
 	]`
 	cases := []struct {
@@ -321,6 +323,7 @@ func TestBdStoreListStorageTierConformance(t *testing.T) {
 		wantIDs               []string
 		wantIncludeTemplates  bool
 		wantUnlimitedPrelimit bool
+		wantEphemeralQuery    bool
 	}{
 		{
 			name:    "issues tier keeps history and no-history rows",
@@ -339,31 +342,48 @@ func TestBdStoreListStorageTierConformance(t *testing.T) {
 			wantIDs:               []string{"bd-no-history", "bd-ephemeral"},
 			wantIncludeTemplates:  true,
 			wantUnlimitedPrelimit: true,
+			wantEphemeralQuery:    true,
 		},
 		{
 			name:                 "both tiers keeps all storage rows",
 			query:                beads.ListQuery{Label: "scope", TierMode: beads.TierBoth},
 			wantIDs:              []string{"bd-history", "bd-no-history", "bd-ephemeral"},
 			wantIncludeTemplates: true,
+			wantEphemeralQuery:   true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var gotCmd string
+			var calls []string
 			runner := func(_, name string, args ...string) ([]byte, error) {
-				gotCmd = name + " " + strings.Join(args, " ")
-				return []byte(rows), nil
+				cmd := name + " " + strings.Join(args, " ")
+				calls = append(calls, cmd)
+				switch {
+				case strings.HasPrefix(cmd, "bd list "):
+					return []byte(listRows), nil
+				case strings.HasPrefix(cmd, "bd query "):
+					return []byte(ephemeralRows), nil
+				default:
+					return nil, fmt.Errorf("unexpected command: %s", cmd)
+				}
 			}
 			store := beads.NewBdStore("/city", runner)
 			got, err := store.List(tc.query)
 			if err != nil {
 				t.Fatalf("List: %v", err)
 			}
-			assertCommandContains(t, gotCmd, "--include-ephemeral", false)
-			assertCommandContains(t, gotCmd, "--include-templates", tc.wantIncludeTemplates)
+			listCmd := firstCallWithPrefix(calls, "bd list ")
+			if listCmd == "" {
+				t.Fatalf("calls = %#v, want bd list call", calls)
+			}
+			assertCommandContains(t, listCmd, "--include-ephemeral", false)
+			assertCommandContains(t, listCmd, "--include-templates", tc.wantIncludeTemplates)
 			if tc.query.Limit > 0 {
-				assertCommandContains(t, gotCmd, "--limit 0", tc.wantUnlimitedPrelimit)
+				assertCommandContains(t, listCmd, "--limit 0", tc.wantUnlimitedPrelimit)
+			}
+			if gotQuery := firstCallWithPrefix(calls, "bd query "); (gotQuery != "") != tc.wantEphemeralQuery {
+				t.Fatalf("bd query presence = %v, want %v; calls = %#v", gotQuery != "", tc.wantEphemeralQuery, calls)
 			}
 			if gotIDs := beadIDs(got); fmt.Sprint(gotIDs) != fmt.Sprint(tc.wantIDs) {
 				t.Fatalf("List IDs = %v, want %v", gotIDs, tc.wantIDs)
@@ -372,7 +392,7 @@ func TestBdStoreListStorageTierConformance(t *testing.T) {
 	}
 }
 
-func TestBdStoreListBothTiersUsesSingleListConformance(t *testing.T) {
+func TestBdStoreListBothTiersUnionsEphemeralQueryConformance(t *testing.T) {
 	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		cmd := name + " " + strings.Join(args, " ")
@@ -380,11 +400,19 @@ func TestBdStoreListBothTiersUsesSingleListConformance(t *testing.T) {
 		if strings.Contains(cmd, "--include-ephemeral") {
 			t.Fatalf("bd list command = %q, --include-ephemeral is only valid for bd ready", cmd)
 		}
-		return []byte(`[
-			{"id":"bd-history","title":"history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["scope"]},
-			{"id":"bd-no-history","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","labels":["scope"],"no_history":true},
-			{"id":"bd-ephemeral","title":"ephemeral","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","labels":["scope"],"ephemeral":true}
-		]`), nil
+		switch {
+		case strings.HasPrefix(cmd, "bd list "):
+			return []byte(`[
+				{"id":"bd-history","title":"history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["scope"]},
+				{"id":"bd-no-history","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","labels":["scope"],"no_history":true}
+			]`), nil
+		case strings.HasPrefix(cmd, "bd query "):
+			return []byte(`[
+				{"id":"bd-ephemeral","title":"ephemeral","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","labels":["scope"],"ephemeral":true}
+			]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: %s", cmd)
+		}
 	}
 	store := beads.NewBdStore("/city", runner)
 
@@ -392,8 +420,11 @@ func TestBdStoreListBothTiersUsesSingleListConformance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if len(calls) != 1 {
-		t.Fatalf("calls = %#v, want one bd list read", calls)
+	if len(calls) != 2 {
+		t.Fatalf("calls = %#v, want bd list plus bd query reads", calls)
+	}
+	if firstCallWithPrefix(calls, "bd query ") == "" {
+		t.Fatalf("calls = %#v, want bd query ephemeral read", calls)
 	}
 	wantIDs := []string{"bd-history", "bd-no-history", "bd-ephemeral"}
 	if gotIDs := beadIDs(got); fmt.Sprint(gotIDs) != fmt.Sprint(wantIDs) {
@@ -499,6 +530,15 @@ func assertCommandContains(t *testing.T, command, fragment string, want bool) {
 	if got != want {
 		t.Fatalf("command = %q, contains %q = %v, want %v", command, fragment, got, want)
 	}
+}
+
+func firstCallWithPrefix(calls []string, prefix string) string {
+	for _, call := range calls {
+		if strings.HasPrefix(call, prefix) {
+			return call
+		}
+	}
+	return ""
 }
 
 func beadIDs(items []beads.Bead) []string {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2060,20 +2060,21 @@ func TestBdStoreReadyWithAssigneeAndLimit(t *testing.T) {
 	}
 }
 
-func TestBdStoreReadyWithTierBothAssigneeUsesBoundedLimit(t *testing.T) {
+func TestBdStoreReadyWithTierBothAssigneeAppliesLimitAfterClientFilter(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte
 		err error
 	}{
-		`bd ready --json --include-ephemeral --assignee worker-1 --limit 3`: {
+		`bd ready --json --include-ephemeral --assignee worker-1 --limit 0`: {
 			out: []byte(`[
+				{"id":"bd-session","title":"session marker","status":"open","issue_type":"task","assignee":"worker-1","created_at":"2025-01-15T10:29:00Z","labels":["gc:session"]},
 				{"id":"bd-worker","title":"ready one","status":"open","issue_type":"task","assignee":"worker-1","created_at":"2025-01-15T10:30:00Z"},
 				{"id":"bd-wisp","title":"ready wisp","status":"open","issue_type":"task","assignee":"worker-1","created_at":"2025-01-15T10:31:00Z","ephemeral":true}
 			]`),
 		},
 	})
 	s := beads.NewBdStore("/city", runner)
-	got, err := s.Ready(beads.ReadyQuery{Assignee: "worker-1", Limit: 3, TierMode: beads.TierBoth})
+	got, err := s.Ready(beads.ReadyQuery{Assignee: "worker-1", Limit: 2, TierMode: beads.TierBoth})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3486,13 +3487,18 @@ func TestBdStoreCreateOmitsEphemeralFlagByDefault(t *testing.T) {
 }
 
 func TestBdStoreListWispsUsesBdListWithClientTierFilter(t *testing.T) {
-	var gotCmd string
+	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
-		gotCmd = name + " " + strings.Join(args, " ")
+		gotCmd := name + " " + strings.Join(args, " ")
+		calls = append(calls, gotCmd)
+		if strings.HasPrefix(gotCmd, "bd query ") {
+			return []byte(`[
+				{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","ephemeral":true,"labels":["order-tracking"]}
+			]`), nil
+		}
 		return []byte(`[
 			{"id":"bd-i","title":"issue","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["order-tracking"]},
-			{"id":"bd-nh","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","no_history":true,"labels":["order-tracking"]},
-			{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","ephemeral":true,"labels":["order-tracking"]}
+			{"id":"bd-nh","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","no_history":true,"labels":["order-tracking"]}
 		]`), nil
 	}
 	s := beads.NewBdStore("/city", runner)
@@ -3500,6 +3506,7 @@ func TestBdStoreListWispsUsesBdListWithClientTierFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	gotCmd := firstCommandWithPrefix(calls, "bd list ")
 	if !strings.HasPrefix(gotCmd, "bd list --json ") {
 		t.Fatalf("cmd = %q, want bd list prefix", gotCmd)
 	}
@@ -3512,15 +3519,19 @@ func TestBdStoreListWispsUsesBdListWithClientTierFilter(t *testing.T) {
 	if !strings.Contains(gotCmd, "--label=order-tracking") {
 		t.Fatalf("cmd = %q, want label flag", gotCmd)
 	}
+	if queryCmd := firstCommandWithPrefix(calls, "bd query "); !strings.Contains(queryCmd, "ephemeral=true AND label=order-tracking") {
+		t.Fatalf("calls = %#v, want matching bd query ephemeral read", calls)
+	}
 	if len(got) != 2 || got[0].ID != "bd-nh" || got[1].ID != "bd-w" || !got[0].NoHistory || !got[1].Ephemeral {
 		t.Fatalf("got = %+v, want no-history and ephemeral rows only", got)
 	}
 }
 
 func TestBdStoreListWispsRequestsUnlimitedResultsByDefault(t *testing.T) {
-	var gotCmd string
+	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
-		gotCmd = name + " " + strings.Join(args, " ")
+		gotCmd := name + " " + strings.Join(args, " ")
+		calls = append(calls, gotCmd)
 		var b strings.Builder
 		b.WriteByte('[')
 		for i := 0; i < 55; i++ {
@@ -3537,6 +3548,7 @@ func TestBdStoreListWispsRequestsUnlimitedResultsByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	gotCmd := firstCommandWithPrefix(calls, "bd list ")
 	if !strings.Contains(gotCmd, "--limit 0") {
 		t.Fatalf("cmd = %q, want explicit --limit 0 so bd list does not apply its default page size", gotCmd)
 	}
@@ -3546,9 +3558,10 @@ func TestBdStoreListWispsRequestsUnlimitedResultsByDefault(t *testing.T) {
 }
 
 func TestBdStoreListWispsAppliesMetadataBeforeClientLimit(t *testing.T) {
-	var gotCmd string
+	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
-		gotCmd = name + " " + strings.Join(args, " ")
+		gotCmd := name + " " + strings.Join(args, " ")
+		calls = append(calls, gotCmd)
 		if !strings.Contains(gotCmd, "--limit 0") {
 			return []byte(`[{"id":"bd-new","title":"wrong first page","status":"closed","issue_type":"task","created_at":"2026-05-03T00:00:00Z","ephemeral":true,"labels":["order-run:o"],"metadata":{"phase":"skip"}}]`), nil
 		}
@@ -3568,6 +3581,7 @@ func TestBdStoreListWispsAppliesMetadataBeforeClientLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	gotCmd := firstCommandWithPrefix(calls, "bd list ")
 	if !strings.Contains(gotCmd, "--limit 0") {
 		t.Fatalf("wisps query = %q, want --limit 0 before client-side metadata filtering", gotCmd)
 	}
@@ -3587,6 +3601,7 @@ func TestBdStoreListWispsReturnsPartialRowsWithErrorOnCorruptEntries(t *testing.
 				{"id":"bd-bad","title":"bad","status":"open","issue_type":"task","created_at":"not-a-time","ephemeral":true}
 			]`),
 		},
+		`bd query --json ephemeral=true --limit 0`: {out: []byte(`[]`)},
 	})
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.List(beads.ListQuery{AllowScan: true, TierMode: beads.TierWisps})
@@ -3597,12 +3612,12 @@ func TestBdStoreListWispsReturnsPartialRowsWithErrorOnCorruptEntries(t *testing.
 	if !errors.As(err, &partial) {
 		t.Fatalf("List(wisps) error = %v, want *beads.PartialResultError", err)
 	}
-	if partial.Op != "bd list" {
-		t.Errorf("PartialResultError.Op = %q, want %q", partial.Op, "bd list")
+	if partial.Op != "bd list wisps tier" {
+		t.Errorf("PartialResultError.Op = %q, want %q", partial.Op, "bd list wisps tier")
 	}
 }
 
-func TestBdStoreListBothTiersUsesSingleBdList(t *testing.T) {
+func TestBdStoreListBothTiersUnionsBdListAndEphemeralQuery(t *testing.T) {
 	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		full := name + " " + strings.Join(args, " ")
@@ -3610,12 +3625,16 @@ func TestBdStoreListBothTiersUsesSingleBdList(t *testing.T) {
 		if strings.Contains(full, "--include-ephemeral") {
 			t.Fatalf("bd list command = %q, --include-ephemeral is only valid for bd ready", full)
 		}
+		if strings.HasPrefix(full, "bd query ") {
+			return []byte(`[
+				{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-02T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}
+			]`), nil
+		}
 		if !strings.HasPrefix(full, "bd list ") {
 			return nil, fmt.Errorf("unexpected: %s", full)
 		}
 		return []byte(`[
-			{"id":"bd-i","title":"issue","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["order-run:o"]},
-			{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-02T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}
+			{"id":"bd-i","title":"issue","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["order-run:o"]}
 		]`), nil
 	}
 	s := beads.NewBdStore("/city", runner)
@@ -3623,8 +3642,8 @@ func TestBdStoreListBothTiersUsesSingleBdList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(calls) != 1 {
-		t.Fatalf("got %d runner calls, want 1: %v", len(calls), calls)
+	if len(calls) != 2 {
+		t.Fatalf("got %d runner calls, want 2: %v", len(calls), calls)
 	}
 	if len(got) != 2 {
 		t.Fatalf("got %d beads, want 2: %+v", len(got), got)
@@ -3636,12 +3655,15 @@ func TestBdStoreListBothTiersUsesSingleBdList(t *testing.T) {
 
 func TestBdStoreListBothTiersAppliesCreatedBeforeBeforeMergedLimit(t *testing.T) {
 	before := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
-	var queryCmd string
+	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		full := name + " " + strings.Join(args, " ")
-		queryCmd = full
+		calls = append(calls, full)
 		if strings.Contains(full, "--include-ephemeral") {
 			t.Fatalf("bd list command = %q, --include-ephemeral is only valid for bd ready", full)
+		}
+		if strings.HasPrefix(full, "bd query ") {
+			return []byte(`[]`), nil
 		}
 		if !strings.HasPrefix(full, "bd list ") {
 			return nil, fmt.Errorf("unexpected: %s", full)
@@ -3666,6 +3688,7 @@ func TestBdStoreListBothTiersAppliesCreatedBeforeBeforeMergedLimit(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
+	queryCmd := firstCommandWithPrefix(calls, "bd list ")
 	if !strings.Contains(queryCmd, "--limit 0") {
 		t.Fatalf("bd list query = %q, want unlimited --limit 0 before CreatedBefore client filtering", queryCmd)
 	}
@@ -3674,11 +3697,14 @@ func TestBdStoreListBothTiersAppliesCreatedBeforeBeforeMergedLimit(t *testing.T)
 	}
 }
 
-func TestBdStoreListBothTiersMessageUsesSingleBdListWithoutTierFiltering(t *testing.T) {
+func TestBdStoreListBothTiersMessageUnionsEphemeralQueryWithoutTierFiltering(t *testing.T) {
 	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		full := name + " " + strings.Join(args, " ")
 		calls = append(calls, full)
+		if strings.HasPrefix(full, "bd query ") {
+			return []byte(`[]`), nil
+		}
 		if strings.HasPrefix(full, "bd list ") {
 			return []byte(`[{"id":"bd-msg","title":"message","status":"open","issue_type":"message","assignee":"mayor","created_at":"2026-05-01T00:00:00Z","ephemeral":true}]`), nil
 		}
@@ -3689,8 +3715,8 @@ func TestBdStoreListBothTiersMessageUsesSingleBdListWithoutTierFiltering(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(calls) != 1 {
-		t.Fatalf("got %d runner calls, want 1: %v", len(calls), calls)
+	if len(calls) != 2 {
+		t.Fatalf("got %d runner calls, want 2: %v", len(calls), calls)
 	}
 	if strings.Contains(calls[0], "--include-templates") {
 		t.Fatalf("bd list command = %q, message TierBoth fast path must not include template rows", calls[0])
@@ -3754,9 +3780,10 @@ func TestBdStoreListAssigneesMultipleFallsBackToClientFilter(t *testing.T) {
 }
 
 func TestBdStoreListWispsAssigneesSingleUsesAssigneeClause(t *testing.T) {
-	var gotCmd string
+	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
-		gotCmd = name + " " + strings.Join(args, " ")
+		gotCmd := name + " " + strings.Join(args, " ")
+		calls = append(calls, gotCmd)
 		return []byte(`[{"id":"bd-wisp-a","title":"message","status":"open","issue_type":"message","assignee":"route-a","created_at":"2026-05-01T00:00:00Z","ephemeral":true}]`), nil
 	}
 	s := beads.NewBdStore("/city", runner)
@@ -3764,8 +3791,9 @@ func TestBdStoreListWispsAssigneesSingleUsesAssigneeClause(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(gotCmd, "--assignee=route-a") {
-		t.Fatalf("cmd = %q, want single Assignees value mapped to --assignee", gotCmd)
+	gotCmd := firstCommandWithPrefix(calls, "bd query ")
+	if !strings.Contains(gotCmd, "assignee=route-a") {
+		t.Fatalf("cmd = %q, want single Assignees value mapped to query assignee clause", gotCmd)
 	}
 	if len(got) != 1 || got[0].ID != "bd-wisp-a" {
 		t.Fatalf("got = %+v, want bd-wisp-a", got)
@@ -3825,6 +3853,15 @@ func TestBdStoreListIssuesTierDoesNotIssueQuery(t *testing.T) {
 	}
 }
 
+func firstCommandWithPrefix(calls []string, prefix string) string {
+	for _, call := range calls {
+		if strings.HasPrefix(call, prefix) {
+			return call
+		}
+	}
+	return ""
+}
+
 func TestBdStoreListBothTiersReturnsWholeReadError(t *testing.T) {
 	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
@@ -3849,8 +3886,46 @@ func TestBdStoreListBothTiersReturnsWholeReadError(t *testing.T) {
 	if got != nil {
 		t.Fatalf("got = %+v, want nil rows on whole-read failure", got)
 	}
-	if len(calls) != 1 {
-		t.Fatalf("calls = %#v, want one bd list call", calls)
+	if len(calls) != 2 {
+		t.Fatalf("calls = %#v, want bd list and bd query calls", calls)
+	}
+}
+
+func TestBdStoreListWispAwareTiersTolerateAdaptersWithoutBdQuery(t *testing.T) {
+	cases := []struct {
+		name string
+		tier beads.TierMode
+		want string
+	}{
+		{name: "wisps", tier: beads.TierWisps, want: "bd-no-history"},
+		{name: "both", tier: beads.TierBoth, want: "bd-history"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls []string
+			runner := func(_, name string, args ...string) ([]byte, error) {
+				full := name + " " + strings.Join(args, " ")
+				calls = append(calls, full)
+				if strings.HasPrefix(full, "bd query ") {
+					return nil, fmt.Errorf("bd: unknown subcommand \"query\"")
+				}
+				return []byte(`[
+					{"id":"bd-history","title":"history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z"},
+					{"id":"bd-no-history","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","no_history":true}
+				]`), nil
+			}
+			s := beads.NewBdStore("/city", runner)
+			got, err := s.List(beads.ListQuery{Status: "open", TierMode: tc.tier})
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if firstCommandWithPrefix(calls, "bd query ") == "" {
+				t.Fatalf("calls = %#v, want bd query attempt for wisp-aware tier", calls)
+			}
+			if len(got) == 0 || got[0].ID != tc.want {
+				t.Fatalf("got = %+v, want first row %s", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -3881,12 +3956,10 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var gotCmd string
+			var calls []string
 			runner := func(_, name string, args ...string) ([]byte, error) {
-				gotCmd = name + " " + strings.Join(args, " ")
-				if strings.HasPrefix(gotCmd, "bd query ") {
-					t.Fatalf("wisps read used bd query instead of bd list: %s", gotCmd)
-				}
+				gotCmd := name + " " + strings.Join(args, " ")
+				calls = append(calls, gotCmd)
 				return []byte(`[
 					{"id":"bd-match-assignee","title":"message","status":"open","issue_type":"message","assignee":"gascity/workflows.codex-max","created_at":"2026-05-01T00:00:00Z","ephemeral":true},
 					{"id":"bd-match-label","title":"label","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","ephemeral":true,"labels":["order tracking"]},
@@ -3899,6 +3972,7 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 			if err != nil {
 				t.Fatalf("List: %v", err)
 			}
+			gotCmd := firstCommandWithPrefix(calls, "bd list ")
 			if !strings.Contains(gotCmd, "bd list --json") {
 				t.Fatalf("cmd = %q, want wisps bd list", gotCmd)
 			}
@@ -3907,6 +3981,21 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 			}
 			if !strings.Contains(gotCmd, "--include-templates") {
 				t.Fatalf("cmd = %q, want --include-templates for wisp-aware list", gotCmd)
+			}
+			queryCmd := firstCommandWithPrefix(calls, "bd query ")
+			switch tc.name {
+			case "slash assignee":
+				if strings.Contains(queryCmd, "gascity/workflows.codex-max") {
+					t.Fatalf("query cmd = %q, unsafe slash assignee must be client-filtered", queryCmd)
+				}
+			case "label with space":
+				if strings.Contains(queryCmd, "order tracking") {
+					t.Fatalf("query cmd = %q, unsafe label must be client-filtered", queryCmd)
+				}
+			case "type reserved token":
+				if strings.Contains(queryCmd, "type=or") {
+					t.Fatalf("query cmd = %q, reserved type token must be client-filtered", queryCmd)
+				}
 			}
 			if len(got) != 1 || got[0].ID != tc.want {
 				t.Fatalf("List() = %+v, want only %s after client filtering", got, tc.want)

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -2060,6 +2060,31 @@ func TestBdStoreReadyWithAssigneeAndLimit(t *testing.T) {
 	}
 }
 
+func TestBdStoreReadyWithTierBothAssigneeUsesBoundedLimit(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --include-ephemeral --assignee worker-1 --limit 3`: {
+			out: []byte(`[
+				{"id":"bd-worker","title":"ready one","status":"open","issue_type":"task","assignee":"worker-1","created_at":"2025-01-15T10:30:00Z"},
+				{"id":"bd-wisp","title":"ready wisp","status":"open","issue_type":"task","assignee":"worker-1","created_at":"2025-01-15T10:31:00Z","ephemeral":true}
+			]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.Ready(beads.ReadyQuery{Assignee: "worker-1", Limit: 3, TierMode: beads.TierBoth})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Ready(TierBoth, assignee) returned %d beads, want 2", len(got))
+	}
+	if got[1].ID != "bd-wisp" {
+		t.Fatalf("Ready(TierBoth, assignee)[1].ID = %q, want bd-wisp", got[1].ID)
+	}
+}
+
 func TestBdStoreReadyWispsAppliesLimitAfterTierFilter(t *testing.T) {
 	var gotCmd string
 	runner := func(_, name string, args ...string) ([]byte, error) {
@@ -2645,7 +2670,7 @@ func TestBdStoreListInfersParentFromParentChildDependency(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --label=real-world-app-contract --include-infra --include-gates --limit 50`: {
+		`bd list --json --label=real-world-app-contract --include-infra --include-gates --limit 0`: {
 			out: []byte(`[
 				{
 					"id":"bd-child",
@@ -2883,7 +2908,7 @@ func TestBdStoreListByLabel(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --label=order-run:digest --include-infra --include-gates --limit 5`: {
+		`bd list --json --label=order-run:digest --include-infra --include-gates --limit 0`: {
 			out: []byte(`[{"id":"bd-aaa","title":"digest wisp","status":"open","issue_type":"task","created_at":"2026-02-27T10:00:00Z","labels":["order-run:digest"]}]`),
 		},
 	})
@@ -2906,7 +2931,7 @@ func TestBdStoreListByLabel(t *testing.T) {
 func TestBdStoreListCreatedBeforeForwardsFilter(t *testing.T) {
 	before := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 	wantCmd := `bd list --json --label=order-run:digest --all --created-before ` +
-		before.Format(time.RFC3339Nano) + ` --include-infra --include-gates --limit 1`
+		before.Format(time.RFC3339Nano) + ` --include-infra --include-gates --limit 0`
 	runner := fakeRunner(map[string]struct {
 		out []byte
 		err error
@@ -2936,7 +2961,7 @@ func TestBdStoreListByLabelEmpty(t *testing.T) {
 		out []byte
 		err error
 	}{
-		`bd list --json --label=order-run:none --include-infra --include-gates --limit 1`: {out: []byte(`[]`)},
+		`bd list --json --label=order-run:none --include-infra --include-gates --limit 0`: {out: []byte(`[]`)},
 	})
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.ListByLabel("order-run:none", 1)
@@ -3333,6 +3358,55 @@ func TestBdStoreApplyGraphPlan(t *testing.T) {
 	}
 }
 
+func TestBdStoreApplyGraphPlanWithStorageNoHistory(t *testing.T) {
+	dir := t.TempDir()
+	var capturedPlan beads.GraphApplyPlan
+	var gotArgs []string
+	runner := func(cmdDir, name string, args ...string) ([]byte, error) {
+		if cmdDir != dir {
+			t.Fatalf("runner dir = %q, want %q", cmdDir, dir)
+		}
+		if name != "bd" {
+			t.Fatalf("runner name = %q, want bd", name)
+		}
+		gotArgs = append([]string(nil), args...)
+		graphPath := args[2]
+		data, err := os.ReadFile(graphPath)
+		if err != nil {
+			t.Fatalf("reading plan file: %v", err)
+		}
+		if err := json.Unmarshal(data, &capturedPlan); err != nil {
+			t.Fatalf("unmarshal plan file: %v", err)
+		}
+		return []byte(`{"ids":{"root":"bd-1"}}`), nil
+	}
+
+	s := beads.NewBdStore(dir, runner)
+	result, err := s.ApplyGraphPlanWithStorage(t.Context(), &beads.GraphApplyPlan{
+		Nodes: []beads.GraphApplyNode{{Key: "root", Title: "Root"}},
+	}, beads.StorageNoHistory)
+	if err != nil {
+		t.Fatalf("ApplyGraphPlan: %v", err)
+	}
+	if got := result.IDs["root"]; got != "bd-1" {
+		t.Fatalf("result ID = %q, want bd-1", got)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--no-history") {
+		t.Fatalf("args = %q, want --no-history graph flag", args)
+	}
+	if data := mustJSON(t, capturedPlan); strings.Contains(data, "no_history") || strings.Contains(data, "ephemeral") {
+		t.Fatalf("captured graph JSON = %s, storage must travel as CLI flags only", data)
+	}
+}
+
+func TestBdStoreSupportsEphemeralGraphApply(t *testing.T) {
+	store := beads.NewBdStore(t.TempDir(), nil)
+	if !store.SupportsEphemeralGraphApply() {
+		t.Fatal("SupportsEphemeralGraphApply() = false, want true")
+	}
+}
+
 func TestBdStoreApplyGraphPlanRejectsMissingIDs(t *testing.T) {
 	dir := t.TempDir()
 	runner := func(string, string, ...string) ([]byte, error) {
@@ -3376,6 +3450,26 @@ func TestBdStoreCreatePassesEphemeralFlag(t *testing.T) {
 	}
 }
 
+func TestBdStoreCreateWithStoragePassesNoHistoryFlag(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`{"id":"bd-x","title":"test","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","no_history":true}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	created, err := s.CreateWithStorage(beads.Bead{Title: "test"}, beads.StorageNoHistory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--no-history") {
+		t.Fatalf("args = %q, want --no-history flag", args)
+	}
+	if created.Ephemeral || !created.NoHistory {
+		t.Fatalf("created storage = ephemeral:%v no_history:%v, want no-history", created.Ephemeral, created.NoHistory)
+	}
+}
+
 func TestBdStoreCreateOmitsEphemeralFlagByDefault(t *testing.T) {
 	var gotArgs []string
 	runner := func(_, _ string, args ...string) ([]byte, error) {
@@ -3391,28 +3485,35 @@ func TestBdStoreCreateOmitsEphemeralFlagByDefault(t *testing.T) {
 	}
 }
 
-func TestBdStoreListWispsUsesQueryWithEphemeralPredicate(t *testing.T) {
+func TestBdStoreListWispsUsesBdListWithClientTierFilter(t *testing.T) {
 	var gotCmd string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		gotCmd = name + " " + strings.Join(args, " ")
-		return []byte(`[{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","ephemeral":true,"labels":["order-tracking"]}]`), nil
+		return []byte(`[
+			{"id":"bd-i","title":"issue","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["order-tracking"]},
+			{"id":"bd-nh","title":"no-history","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:01Z","no_history":true,"labels":["order-tracking"]},
+			{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:02Z","ephemeral":true,"labels":["order-tracking"]}
+		]`), nil
 	}
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.List(beads.ListQuery{Label: "order-tracking", TierMode: beads.TierWisps})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(gotCmd, "bd query --json ") {
-		t.Fatalf("cmd = %q, want bd query prefix", gotCmd)
+	if !strings.HasPrefix(gotCmd, "bd list --json ") {
+		t.Fatalf("cmd = %q, want bd list prefix", gotCmd)
 	}
-	if !strings.Contains(gotCmd, "ephemeral=true") {
-		t.Fatalf("cmd = %q, want ephemeral=true clause", gotCmd)
+	if strings.Contains(gotCmd, "--include-ephemeral") {
+		t.Fatalf("cmd = %q, bd list does not support --include-ephemeral", gotCmd)
 	}
-	if !strings.Contains(gotCmd, "label=order-tracking") {
-		t.Fatalf("cmd = %q, want label clause", gotCmd)
+	if !strings.Contains(gotCmd, "--include-templates") {
+		t.Fatalf("cmd = %q, want --include-templates for wisp-aware list", gotCmd)
 	}
-	if len(got) != 1 || got[0].ID != "bd-w" || !got[0].Ephemeral {
-		t.Fatalf("got = %+v, want one ephemeral bead bd-w", got)
+	if !strings.Contains(gotCmd, "--label=order-tracking") {
+		t.Fatalf("cmd = %q, want label flag", gotCmd)
+	}
+	if len(got) != 2 || got[0].ID != "bd-nh" || got[1].ID != "bd-w" || !got[0].NoHistory || !got[1].Ephemeral {
+		t.Fatalf("got = %+v, want no-history and ephemeral rows only", got)
 	}
 }
 
@@ -3437,7 +3538,7 @@ func TestBdStoreListWispsRequestsUnlimitedResultsByDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(gotCmd, "--limit 0") {
-		t.Fatalf("cmd = %q, want explicit --limit 0 so bd query does not apply its default page size", gotCmd)
+		t.Fatalf("cmd = %q, want explicit --limit 0 so bd list does not apply its default page size", gotCmd)
 	}
 	if len(got) != 55 {
 		t.Fatalf("got %d wisps, want all 55 rows", len(got))
@@ -3480,7 +3581,7 @@ func TestBdStoreListWispsReturnsPartialRowsWithErrorOnCorruptEntries(t *testing.
 		out []byte
 		err error
 	}{
-		`bd query --json ephemeral=true --limit 0`: {
+		`bd list --json --include-infra --include-gates --include-templates --limit 0`: {
 			out: []byte(`[
 				{"id":"bd-good","title":"good","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","ephemeral":true},
 				{"id":"bd-bad","title":"bad","status":"open","issue_type":"task","created_at":"not-a-time","ephemeral":true}
@@ -3496,31 +3597,34 @@ func TestBdStoreListWispsReturnsPartialRowsWithErrorOnCorruptEntries(t *testing.
 	if !errors.As(err, &partial) {
 		t.Fatalf("List(wisps) error = %v, want *beads.PartialResultError", err)
 	}
-	if partial.Op != "bd query" {
-		t.Errorf("PartialResultError.Op = %q, want %q", partial.Op, "bd query")
+	if partial.Op != "bd list" {
+		t.Errorf("PartialResultError.Op = %q, want %q", partial.Op, "bd list")
 	}
 }
 
-func TestBdStoreListBothTiersMergesAndDedupes(t *testing.T) {
+func TestBdStoreListBothTiersUsesSingleBdList(t *testing.T) {
 	var calls []string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		full := name + " " + strings.Join(args, " ")
 		calls = append(calls, full)
-		switch {
-		case strings.HasPrefix(full, "bd list "):
-			return []byte(`[{"id":"bd-i","title":"issue","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["order-run:o"]}]`), nil
-		case strings.HasPrefix(full, "bd query "):
-			return []byte(`[{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-02T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}]`), nil
+		if strings.Contains(full, "--include-ephemeral") {
+			t.Fatalf("bd list command = %q, --include-ephemeral is only valid for bd ready", full)
 		}
-		return nil, fmt.Errorf("unexpected: %s", full)
+		if !strings.HasPrefix(full, "bd list ") {
+			return nil, fmt.Errorf("unexpected: %s", full)
+		}
+		return []byte(`[
+			{"id":"bd-i","title":"issue","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["order-run:o"]},
+			{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-02T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}
+		]`), nil
 	}
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.List(beads.ListQuery{Label: "order-run:o", TierMode: beads.TierBoth, Sort: beads.SortCreatedDesc})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(calls) != 2 {
-		t.Fatalf("got %d runner calls, want 2: %v", len(calls), calls)
+	if len(calls) != 1 {
+		t.Fatalf("got %d runner calls, want 1: %v", len(calls), calls)
 	}
 	if len(got) != 2 {
 		t.Fatalf("got %d beads, want 2: %+v", len(got), got)
@@ -3535,20 +3639,20 @@ func TestBdStoreListBothTiersAppliesCreatedBeforeBeforeMergedLimit(t *testing.T)
 	var queryCmd string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		full := name + " " + strings.Join(args, " ")
-		switch {
-		case strings.HasPrefix(full, "bd list "):
-			return []byte(`[]`), nil
-		case strings.HasPrefix(full, "bd query "):
-			queryCmd = full
-			if !strings.Contains(full, "--limit 0") {
-				return []byte(`[{"id":"bd-new","title":"newer","status":"closed","issue_type":"task","created_at":"2026-05-03T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}]`), nil
-			}
-			return []byte(`[
-				{"id":"bd-new","title":"newer","status":"closed","issue_type":"task","created_at":"2026-05-03T00:00:00Z","ephemeral":true,"labels":["order-run:o"]},
-				{"id":"bd-old","title":"older","status":"closed","issue_type":"task","created_at":"2026-05-01T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}
-			]`), nil
+		queryCmd = full
+		if strings.Contains(full, "--include-ephemeral") {
+			t.Fatalf("bd list command = %q, --include-ephemeral is only valid for bd ready", full)
 		}
-		return nil, fmt.Errorf("unexpected: %s", full)
+		if !strings.HasPrefix(full, "bd list ") {
+			return nil, fmt.Errorf("unexpected: %s", full)
+		}
+		if !strings.Contains(full, "--limit 0") {
+			return []byte(`[{"id":"bd-new","title":"newer","status":"closed","issue_type":"task","created_at":"2026-05-03T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}]`), nil
+		}
+		return []byte(`[
+			{"id":"bd-new","title":"newer","status":"closed","issue_type":"task","created_at":"2026-05-03T00:00:00Z","ephemeral":true,"labels":["order-run:o"]},
+			{"id":"bd-old","title":"older","status":"closed","issue_type":"task","created_at":"2026-05-01T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}
+		]`), nil
 	}
 	s := beads.NewBdStore("/city", runner)
 	got, err := s.List(beads.ListQuery{
@@ -3563,7 +3667,7 @@ func TestBdStoreListBothTiersAppliesCreatedBeforeBeforeMergedLimit(t *testing.T)
 		t.Fatal(err)
 	}
 	if !strings.Contains(queryCmd, "--limit 0") {
-		t.Fatalf("wisps query = %q, want unlimited --limit 0 before CreatedBefore client filtering", queryCmd)
+		t.Fatalf("bd list query = %q, want unlimited --limit 0 before CreatedBefore client filtering", queryCmd)
 	}
 	if len(got) != 1 || got[0].ID != "bd-old" {
 		t.Fatalf("got = %+v, want only older wisp after CreatedBefore then Limit", got)
@@ -3575,11 +3679,8 @@ func TestBdStoreListBothTiersMessageUsesSingleBdListWithoutTierFiltering(t *test
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		full := name + " " + strings.Join(args, " ")
 		calls = append(calls, full)
-		switch {
-		case strings.HasPrefix(full, "bd list "):
+		if strings.HasPrefix(full, "bd list ") {
 			return []byte(`[{"id":"bd-msg","title":"message","status":"open","issue_type":"message","assignee":"mayor","created_at":"2026-05-01T00:00:00Z","ephemeral":true}]`), nil
-		case strings.HasPrefix(full, "bd query "):
-			t.Fatalf("message TierBoth list issued bd query: %v", calls)
 		}
 		return nil, fmt.Errorf("unexpected: %s", full)
 	}
@@ -3663,8 +3764,8 @@ func TestBdStoreListWispsAssigneesSingleUsesAssigneeClause(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(gotCmd, "assignee=route-a") {
-		t.Fatalf("cmd = %q, want single Assignees value mapped to assignee clause", gotCmd)
+	if !strings.Contains(gotCmd, "--assignee=route-a") {
+		t.Fatalf("cmd = %q, want single Assignees value mapped to --assignee", gotCmd)
 	}
 	if len(got) != 1 || got[0].ID != "bd-wisp-a" {
 		t.Fatalf("got = %+v, want bd-wisp-a", got)
@@ -3675,8 +3776,8 @@ func TestBdStoreListWispsAssigneesMultipleFallsBackToClientFilter(t *testing.T) 
 	var gotCmd string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		gotCmd = name + " " + strings.Join(args, " ")
-		if strings.Contains(gotCmd, "assignee=") {
-			t.Fatalf("cmd = %q, multi-route Assignees must not emit one assignee clause", gotCmd)
+		if strings.Contains(gotCmd, "--assignee=") {
+			t.Fatalf("cmd = %q, multi-route Assignees must not emit one --assignee", gotCmd)
 		}
 		if strings.Contains(gotCmd, "--limit 1") {
 			return []byte(`[{"id":"bd-wisp-c","title":"message","status":"open","issue_type":"message","assignee":"route-c","created_at":"2026-05-01T00:00:00Z","ephemeral":true}]`), nil
@@ -3724,84 +3825,38 @@ func TestBdStoreListIssuesTierDoesNotIssueQuery(t *testing.T) {
 	}
 }
 
-// TestBdStoreListBothTiersReturnsPartialRowsWithErrorOnTierFailure pins the
-// contract that listBothTiers returns rows from the surviving tier together
-// with a non-nil error. Silent partial-success would let safety-critical
-// callers (e.g. order dispatch's hasOpenWorkStrict) see "no in-flight work"
-// when the wisps tier is actually unreachable, leading to double-fire.
-func TestBdStoreListBothTiersReturnsPartialRowsWithErrorOnTierFailure(t *testing.T) {
-	t.Run("wisps tier fails", func(t *testing.T) {
-		runner := func(_, name string, args ...string) ([]byte, error) {
-			full := name + " " + strings.Join(args, " ")
-			switch {
-			case strings.HasPrefix(full, "bd list "):
-				return []byte(`[{"id":"bd-i","title":"issue","status":"open","issue_type":"task","created_at":"2026-05-01T00:00:00Z","labels":["order-run:o"]}]`), nil
-			case strings.HasPrefix(full, "bd query "):
-				return nil, fmt.Errorf("simulated wisps tier outage")
-			}
-			return nil, fmt.Errorf("unexpected: %s", full)
+func TestBdStoreListBothTiersReturnsWholeReadError(t *testing.T) {
+	var calls []string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		full := name + " " + strings.Join(args, " ")
+		calls = append(calls, full)
+		if strings.Contains(full, "--include-ephemeral") {
+			t.Fatalf("bd list command = %q, --include-ephemeral is only valid for bd ready", full)
 		}
-		s := beads.NewBdStore("/city", runner)
-		got, err := s.List(beads.ListQuery{Label: "order-run:o", TierMode: beads.TierBoth})
-		if err == nil {
-			t.Fatalf("err = nil, want non-nil partial-failure error")
-		}
-		if !beads.IsPartialResult(err) {
-			t.Fatalf("err = %v, want PartialResultError so survivor rows are retainable", err)
-		}
-		if !strings.Contains(err.Error(), "wisps tier") {
-			t.Fatalf("err = %v, want wisps tier in message", err)
-		}
-		if len(got) != 1 || got[0].ID != "bd-i" {
-			t.Fatalf("got = %+v, want surviving issues row bd-i", got)
-		}
-	})
-
-	t.Run("issues tier fails", func(t *testing.T) {
-		runner := func(_, name string, args ...string) ([]byte, error) {
-			full := name + " " + strings.Join(args, " ")
-			switch {
-			case strings.HasPrefix(full, "bd list "):
-				return nil, fmt.Errorf("simulated issues tier outage")
-			case strings.HasPrefix(full, "bd query "):
-				return []byte(`[{"id":"bd-w","title":"wisp","status":"open","issue_type":"task","created_at":"2026-05-02T00:00:00Z","ephemeral":true,"labels":["order-run:o"]}]`), nil
-			}
-			return nil, fmt.Errorf("unexpected: %s", full)
-		}
-		s := beads.NewBdStore("/city", runner)
-		got, err := s.List(beads.ListQuery{Label: "order-run:o", TierMode: beads.TierBoth})
-		if err == nil {
-			t.Fatalf("err = nil, want non-nil partial-failure error")
-		}
-		if !beads.IsPartialResult(err) {
-			t.Fatalf("err = %v, want PartialResultError so survivor rows are retainable", err)
-		}
-		if !strings.Contains(err.Error(), "issues tier") {
-			t.Fatalf("err = %v, want issues tier in message", err)
-		}
-		if len(got) != 1 || got[0].ID != "bd-w" {
-			t.Fatalf("got = %+v, want surviving wisps row bd-w", got)
-		}
-	})
-
-	t.Run("both tiers fail", func(t *testing.T) {
-		runner := func(_, _ string, _ ...string) ([]byte, error) {
-			return nil, fmt.Errorf("simulated total outage")
-		}
-		s := beads.NewBdStore("/city", runner)
-		got, err := s.List(beads.ListQuery{Label: "order-run:o", TierMode: beads.TierBoth})
-		if err == nil {
-			t.Fatalf("err = nil, want joined error from both tiers")
-		}
-		if got != nil {
-			t.Fatalf("got = %+v, want nil rows on total failure", got)
-		}
-	})
+		return nil, fmt.Errorf("simulated bd list outage")
+	}
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.List(beads.ListQuery{Label: "order-run:o", TierMode: beads.TierBoth})
+	if err == nil {
+		t.Fatalf("err = nil, want bd list error")
+	}
+	if beads.IsPartialResult(err) {
+		t.Fatalf("err = %v, want whole-read failure, not PartialResultError", err)
+	}
+	if !strings.Contains(err.Error(), "bd list") {
+		t.Fatalf("err = %v, want bd list context", err)
+	}
+	if got != nil {
+		t.Fatalf("got = %+v, want nil rows on whole-read failure", got)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %#v, want one bd list call", calls)
+	}
 }
 
 // TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues pins the
-// bd-query DSL safety guard: values outside the supported bare-token subset
-// are filtered client-side instead of being emitted into a malformed query.
+// bd list storage-tier contract: bd list has no ephemeral-only flag, so wisp
+// reads use normal list flags and then filter the storage tier client-side.
 func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -3829,10 +3884,8 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 			var gotCmd string
 			runner := func(_, name string, args ...string) ([]byte, error) {
 				gotCmd = name + " " + strings.Join(args, " ")
-				if strings.Contains(gotCmd, "assignee=gascity/workflows.codex-max") ||
-					strings.Contains(gotCmd, "label=order tracking") ||
-					strings.Contains(gotCmd, "type=or") {
-					t.Fatalf("unsafe value leaked into bd query: %s", gotCmd)
+				if strings.HasPrefix(gotCmd, "bd query ") {
+					t.Fatalf("wisps read used bd query instead of bd list: %s", gotCmd)
 				}
 				return []byte(`[
 					{"id":"bd-match-assignee","title":"message","status":"open","issue_type":"message","assignee":"gascity/workflows.codex-max","created_at":"2026-05-01T00:00:00Z","ephemeral":true},
@@ -3846,8 +3899,14 @@ func TestBdStoreListWispsFallsBackToClientFilteringForUnsafeQueryValues(t *testi
 			if err != nil {
 				t.Fatalf("List: %v", err)
 			}
-			if !strings.Contains(gotCmd, "bd query --json ephemeral=true") {
-				t.Fatalf("cmd = %q, want wisps query", gotCmd)
+			if !strings.Contains(gotCmd, "bd list --json") {
+				t.Fatalf("cmd = %q, want wisps bd list", gotCmd)
+			}
+			if strings.Contains(gotCmd, "--include-ephemeral") {
+				t.Fatalf("cmd = %q, bd list does not support --include-ephemeral", gotCmd)
+			}
+			if !strings.Contains(gotCmd, "--include-templates") {
+				t.Fatalf("cmd = %q, want --include-templates for wisp-aware list", gotCmd)
 			}
 			if len(got) != 1 || got[0].ID != tc.want {
 				t.Fatalf("List() = %+v, want only %s after client filtering", got, tc.want)

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -48,6 +48,9 @@ type Bead struct {
 	// garbage collection. Reads must opt in via ListQuery.TierMode (or the
 	// WithEphemeral/WithBothTiers QueryOpts on the legacy label helpers).
 	Ephemeral bool `json:"ephemeral,omitempty"`
+	// NoHistory routes the bead to durable no-history storage on Create. These
+	// rows are visible in normal durable reads but do not add Dolt history.
+	NoHistory bool `json:"no_history,omitempty"`
 	// DeferUntil hides the bead from ready/claimable views until this time,
 	// mirroring bd's defer_until column (a future value means "not yet ready";
 	// nil or past means ready). Create paths preserve it; UpdateOpts does not
@@ -148,6 +151,12 @@ var readyBlockingDependencyTypes = map[string]bool{
 	"conditional-blocks": true,
 }
 
+// IsReadyBlockingDependencyType reports whether a dependency type blocks a
+// bead from Ready() until the dependency target closes.
+func IsReadyBlockingDependencyType(t string) bool {
+	return readyBlockingDependencyTypes[t]
+}
+
 // IsReadyExcludedType reports whether the bead type is excluded from
 // Ready() results by default.
 func IsReadyExcludedType(t string) bool {
@@ -167,7 +176,7 @@ func IsReadyCandidate(b Bead, now time.Time) bool {
 func IsReadyCandidateForTier(b Bead, now time.Time, tier TierMode) bool {
 	switch tier {
 	case TierWisps:
-		if !b.Ephemeral {
+		if !b.Ephemeral && !b.NoHistory {
 			return false
 		}
 	case TierBoth:
@@ -205,7 +214,7 @@ func IsDeferred(b Bead, now time.Time) bool {
 }
 
 func isReadyBlockingDependencyType(t string) bool {
-	return readyBlockingDependencyTypes[t]
+	return IsReadyBlockingDependencyType(t)
 }
 
 // Dep represents a dependency relationship between two beads. The IssueID
@@ -353,6 +362,35 @@ type Store interface {
 	// query: "down" returns what this bead depends on (default),
 	// "up" returns what depends on this bead.
 	DepList(id, direction string) ([]Dep, error)
+}
+
+// StorageClass selects the physical bead storage tier for adapters that
+// support table-specific creates. It is adapter plumbing, not a domain-level
+// behavior knob; normal callers should use Store.Create and let the policy
+// wrapper classify semantic beads from config.
+type StorageClass string
+
+const (
+	// StorageDefault lets the concrete store use its normal create behavior.
+	StorageDefault StorageClass = ""
+	// StorageHistory stores a bead in the normal history-tracked issues table.
+	StorageHistory StorageClass = "history"
+	// StorageNoHistory stores a bead in durable no-history storage.
+	StorageNoHistory StorageClass = "no_history"
+	// StorageEphemeral stores a bead in ephemeral wisp storage.
+	StorageEphemeral StorageClass = "ephemeral"
+)
+
+// StorageCreateStore is an optional adapter capability for create calls whose
+// physical storage tier has already been selected by policy middleware.
+type StorageCreateStore interface {
+	CreateWithStorage(b Bead, storage StorageClass) (Bead, error)
+}
+
+// StorageGraphApplyStore is an optional adapter capability for graph creates
+// whose physical storage tier has already been selected by policy middleware.
+type StorageGraphApplyStore interface {
+	ApplyGraphPlanWithStorage(ctx context.Context, plan *GraphApplyPlan, storage StorageClass) (*GraphApplyResult, error)
 }
 
 // ParentProjectionWaiter is an optional capability for stores whose

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -109,6 +109,11 @@ func TestIsReadyCandidate(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "no-history task remains durable ready work",
+			bead: Bead{Status: "open", Type: "task", NoHistory: true},
+			want: true,
+		},
+		{
 			name: "excluded type",
 			bead: Bead{Status: "open", Type: "message"},
 			want: false,
@@ -136,6 +141,35 @@ func TestIsReadyCandidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTierWispsIncludesNoHistoryRows(t *testing.T) {
+	items := []Bead{
+		{ID: "issue", Title: "issue", Status: "open", Type: "task"},
+		{ID: "no-history", Title: "no-history", Status: "open", Type: "task", NoHistory: true},
+		{ID: "ephemeral", Title: "ephemeral", Status: "open", Type: "task", Ephemeral: true},
+	}
+
+	wisps := ApplyListQuery(items, ListQuery{TierMode: TierWisps, AllowScan: true})
+	if got := idsOf(wisps); got != "no-history,ephemeral" {
+		t.Fatalf("TierWisps IDs = %s, want no-history,ephemeral", got)
+	}
+
+	issues := ApplyListQuery(items, ListQuery{TierMode: TierIssues, AllowScan: true})
+	if got := idsOf(issues); got != "issue,no-history" {
+		t.Fatalf("TierIssues IDs = %s, want issue,no-history", got)
+	}
+}
+
+func idsOf(items []Bead) string {
+	out := ""
+	for i, item := range items {
+		if i > 0 {
+			out += ","
+		}
+		out += item.ID
+	}
+	return out
 }
 
 func TestListQueryCreatedBeforeFiltersBeforeLimit(t *testing.T) {

--- a/internal/beads/caching_store_graph_apply.go
+++ b/internal/beads/caching_store_graph_apply.go
@@ -1,0 +1,124 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// GraphApplyHandle returns a cache-coherent graph-apply handle when the
+// backing store supports graph apply.
+func (c *CachingStore) GraphApplyHandle() (GraphApplyStore, bool) {
+	applier, ok := GraphApplyFor(c.backing)
+	if !ok {
+		return nil, false
+	}
+	if storageApplier, ok := applier.(StorageGraphApplyStore); ok {
+		return cachingStorageGraphApplyStore{
+			cachingGraphApplyStore: cachingGraphApplyStore{cache: c, applier: applier},
+			storageApplier:         storageApplier,
+		}, true
+	}
+	return cachingGraphApplyStore{cache: c, applier: applier}, true
+}
+
+type cachingGraphApplyStore struct {
+	cache   *CachingStore
+	applier GraphApplyStore
+}
+
+func (s cachingGraphApplyStore) ApplyGraphPlan(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyResult, error) {
+	result, err := s.applier.ApplyGraphPlan(ctx, plan)
+	if err != nil {
+		return result, err
+	}
+	s.cache.refreshGraphAppliedBeads(result)
+	return result, nil
+}
+
+func (s cachingGraphApplyStore) SupportsEphemeralGraphApply() bool {
+	if supporter, ok := s.applier.(EphemeralGraphApplyStore); ok {
+		return supporter.SupportsEphemeralGraphApply()
+	}
+	return false
+}
+
+type cachingStorageGraphApplyStore struct {
+	cachingGraphApplyStore
+	storageApplier StorageGraphApplyStore
+}
+
+func (s cachingStorageGraphApplyStore) ApplyGraphPlanWithStorage(ctx context.Context, plan *GraphApplyPlan, storage StorageClass) (*GraphApplyResult, error) {
+	result, err := s.storageApplier.ApplyGraphPlanWithStorage(ctx, plan, storage)
+	if err != nil {
+		return result, err
+	}
+	s.cache.refreshGraphAppliedBeads(result)
+	return result, nil
+}
+
+func (c *CachingStore) refreshGraphAppliedBeads(result *GraphApplyResult) {
+	if result == nil || len(result.IDs) == 0 {
+		return
+	}
+	ids := uniqueGraphAppliedIDs(result)
+	refreshed := make([]txTouchedBead, 0, len(ids))
+	var refreshErr error
+	for _, id := range ids {
+		fresh, deps, ok := c.refreshBeadWithDepsAfterWrite(id, "refresh bead after graph apply")
+		item := txTouchedBead{id: id}
+		if ok {
+			item.bead = fresh
+			item.bead.Dependencies = cloneDeps(deps)
+			item.found = true
+		} else {
+			item.err = ErrNotFound
+			refreshErr = errors.Join(refreshErr, fmt.Errorf("refresh bead after graph apply %s: %w", id, ErrNotFound))
+		}
+		refreshed = append(refreshed, item)
+	}
+
+	notifications := make([]cacheNotification, 0, len(refreshed))
+	now := time.Now()
+	c.mu.Lock()
+	c.noteLocalMutationLocked(ids...)
+	if refreshErr != nil {
+		c.recordProblemLocked("graph apply refresh", refreshErr)
+	}
+	for _, item := range refreshed {
+		if item.found {
+			fresh := cloneBead(item.bead)
+			c.beads[item.id] = fresh
+			c.deps[item.id] = cloneDeps(item.bead.Dependencies)
+			delete(c.dirty, item.id)
+			delete(c.deletedSeq, item.id)
+			notifications = append(notifications, cacheNotification{
+				eventType: "bead.created",
+				bead:      fresh,
+			})
+			continue
+		}
+		c.dirty[item.id] = struct{}{}
+	}
+	c.markFreshLocked(now)
+	c.updateStatsLocked()
+	c.mu.Unlock()
+	c.notifyChanges(notifications)
+}
+
+func uniqueGraphAppliedIDs(result *GraphApplyResult) []string {
+	seen := make(map[string]struct{}, len(result.IDs))
+	ids := make([]string, 0, len(result.IDs))
+	for _, id := range result.IDs {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -45,6 +45,51 @@ func TestCachingStoreRunReconciliationDetectsLabelContentChanges(t *testing.T) {
 	}
 }
 
+func TestCachingStoreCreateWithStorageForwardsPolicyStorageAndCachesResult(t *testing.T) {
+	backing := &storageCreateRecordingStore{Store: NewMemStore()}
+	cache := NewCachingStoreForTest(backing, nil)
+
+	created, err := cache.CreateWithStorage(Bead{Title: "session"}, StorageNoHistory)
+	if err != nil {
+		t.Fatalf("CreateWithStorage: %v", err)
+	}
+
+	if backing.storage != StorageNoHistory {
+		t.Fatalf("backing storage = %q, want %q", backing.storage, StorageNoHistory)
+	}
+	if !created.NoHistory || created.Ephemeral {
+		t.Fatalf("created storage = ephemeral:%v no_history:%v, want no-history", created.Ephemeral, created.NoHistory)
+	}
+	cached, err := cache.Get(created.ID)
+	if err != nil {
+		t.Fatalf("cache Get: %v", err)
+	}
+	if cached.ID != created.ID || !cached.NoHistory || cached.Ephemeral {
+		t.Fatalf("cached bead = %+v, want no-history created bead %s", cached, created.ID)
+	}
+}
+
+type storageCreateRecordingStore struct {
+	Store
+	storage StorageClass
+}
+
+func (s *storageCreateRecordingStore) CreateWithStorage(b Bead, storage StorageClass) (Bead, error) {
+	s.storage = storage
+	switch storage {
+	case StorageNoHistory:
+		b.NoHistory = true
+		b.Ephemeral = false
+	case StorageEphemeral:
+		b.Ephemeral = true
+		b.NoHistory = false
+	case StorageHistory:
+		b.Ephemeral = false
+		b.NoHistory = false
+	}
+	return s.Create(b)
+}
+
 func TestCachingStoreRunReconciliationSkipLabelsSuppressesLabelOnlyUpdates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -69,6 +69,43 @@ func TestCachingStoreCreateWithStorageForwardsPolicyStorageAndCachesResult(t *te
 	}
 }
 
+func TestCachingStoreGraphApplyHandleForwardsStorageAndCachesResult(t *testing.T) {
+	backing := &storageGraphApplyRecordingStore{Store: NewMemStore()}
+	cache := NewCachingStoreForTest(backing, nil)
+	applier, ok := GraphApplyFor(cache)
+	if !ok {
+		t.Fatal("GraphApplyFor(cache) = false, want graph handle from backing store")
+	}
+	storageApplier, ok := applier.(StorageGraphApplyStore)
+	if !ok {
+		t.Fatal("GraphApplyFor(cache) did not preserve StorageGraphApplyStore")
+	}
+
+	result, err := storageApplier.ApplyGraphPlanWithStorage(t.Context(), &GraphApplyPlan{
+		Nodes: []GraphApplyNode{{Key: "root", Title: "Root"}},
+	}, StorageEphemeral)
+	if err != nil {
+		t.Fatalf("ApplyGraphPlanWithStorage: %v", err)
+	}
+	if backing.storage != StorageEphemeral {
+		t.Fatalf("backing storage = %q, want %q", backing.storage, StorageEphemeral)
+	}
+	cached, err := cache.Get(result.IDs["root"])
+	if err != nil {
+		t.Fatalf("cache Get(graph root): %v", err)
+	}
+	if !cached.Ephemeral || cached.NoHistory {
+		t.Fatalf("cached graph root storage = ephemeral:%v no_history:%v, want ephemeral", cached.Ephemeral, cached.NoHistory)
+	}
+}
+
+func TestGraphApplyForCachingStoreWithoutGraphBackingReturnsFalse(t *testing.T) {
+	cache := NewCachingStoreForTest(NewMemStore(), nil)
+	if _, ok := GraphApplyFor(cache); ok {
+		t.Fatal("GraphApplyFor(cache with plain backing) = true, want false")
+	}
+}
+
 type storageCreateRecordingStore struct {
 	Store
 	storage StorageClass
@@ -88,6 +125,38 @@ func (s *storageCreateRecordingStore) CreateWithStorage(b Bead, storage StorageC
 		b.NoHistory = false
 	}
 	return s.Create(b)
+}
+
+type storageGraphApplyRecordingStore struct {
+	Store
+	storage StorageClass
+}
+
+func (s *storageGraphApplyRecordingStore) ApplyGraphPlan(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyResult, error) {
+	return s.ApplyGraphPlanWithStorage(ctx, plan, StorageDefault)
+}
+
+func (s *storageGraphApplyRecordingStore) ApplyGraphPlanWithStorage(_ context.Context, plan *GraphApplyPlan, storage StorageClass) (*GraphApplyResult, error) {
+	s.storage = storage
+	ids := make(map[string]string, len(plan.Nodes))
+	for _, node := range plan.Nodes {
+		metadata := make(map[string]string, len(node.Metadata))
+		for key, value := range node.Metadata {
+			metadata[key] = value
+		}
+		created, err := s.Create(Bead{
+			Title:     node.Title,
+			Type:      node.Type,
+			Metadata:  metadata,
+			Ephemeral: storage == StorageEphemeral,
+			NoHistory: storage == StorageNoHistory,
+		})
+		if err != nil {
+			return nil, err
+		}
+		ids[node.Key] = created.ID
+	}
+	return &GraphApplyResult{IDs: ids}, nil
 }
 
 func TestCachingStoreRunReconciliationSkipLabelsSuppressesLabelOnlyUpdates(t *testing.T) {

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -8,7 +8,25 @@ import (
 
 // Create passes through to the backing store and updates the cache.
 func (c *CachingStore) Create(b Bead) (Bead, error) {
-	created, err := c.backing.Create(b)
+	return c.createWith(func() (Bead, error) {
+		return c.backing.Create(b)
+	})
+}
+
+// CreateWithStorage passes through a policy-selected storage class to backing
+// stores that support table-specific creates, then updates the cache.
+func (c *CachingStore) CreateWithStorage(b Bead, storage StorageClass) (Bead, error) {
+	storageBacking, ok := c.backing.(StorageCreateStore)
+	if !ok {
+		return c.Create(b)
+	}
+	return c.createWith(func() (Bead, error) {
+		return storageBacking.CreateWithStorage(b, storage)
+	})
+}
+
+func (c *CachingStore) createWith(create func() (Bead, error)) (Bead, error) {
+	created, err := create()
 	if err != nil {
 		return created, err
 	}

--- a/internal/beads/graph_apply.go
+++ b/internal/beads/graph_apply.go
@@ -20,6 +20,12 @@ type GraphApplyPlan struct {
 	Edges         []GraphApplyEdge `json:"edges,omitempty"`
 }
 
+// EphemeralGraphApplyStore reports whether a GraphApplyStore can create an
+// entire graph in ephemeral storage.
+type EphemeralGraphApplyStore interface {
+	SupportsEphemeralGraphApply() bool
+}
+
 // GraphApplyNode describes a single bead to create.
 type GraphApplyNode struct {
 	Key               string            `json:"key"`

--- a/internal/beads/graph_apply.go
+++ b/internal/beads/graph_apply.go
@@ -12,6 +12,28 @@ type GraphApplyStore interface {
 	ApplyGraphPlan(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyResult, error)
 }
 
+// GraphApplyHandleProvider exposes a graph-apply handle for stores whose
+// capability depends on wrapped runtime state.
+type GraphApplyHandleProvider interface {
+	GraphApplyHandle() (GraphApplyStore, bool)
+}
+
+// GraphApplyFor returns the graph-apply capability for store when one is
+// available. It preserves ordinary GraphApplyStore implementations and lets
+// wrappers expose a delegated handle without claiming the interface globally.
+func GraphApplyFor(store Store) (GraphApplyStore, bool) {
+	if store == nil {
+		return nil, false
+	}
+	if applier, ok := store.(GraphApplyStore); ok {
+		return applier, true
+	}
+	if provider, ok := store.(GraphApplyHandleProvider); ok {
+		return provider.GraphApplyHandle()
+	}
+	return nil, false
+}
+
 // GraphApplyPlan describes a symbolic bead graph to create atomically.
 // Keys are caller-defined stable identifiers (for example recipe step IDs).
 type GraphApplyPlan struct {

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -322,6 +322,7 @@ func (m *MemStore) Children(parentID string, opts ...QueryOpt) ([]Bead, error) {
 		ParentID:      parentID,
 		IncludeClosed: HasOpt(opts, IncludeClosed),
 		Sort:          SortCreatedAsc,
+		TierMode:      TierModeFromOpts(opts),
 	})
 }
 

--- a/internal/beads/memstore_test.go
+++ b/internal/beads/memstore_test.go
@@ -150,6 +150,45 @@ func TestMemStoreChildrenExcludeClosedByDefault(t *testing.T) {
 	}
 }
 
+func TestMemStoreChildrenHonorTierOptions(t *testing.T) {
+	s := beads.NewMemStore()
+
+	parent, err := s.Create(beads.Bead{Title: "parent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	historyChild, err := s.Create(beads.Bead{Title: "history", ParentID: parent.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	noHistoryChild, err := s.Create(beads.Bead{Title: "no-history", ParentID: parent.ID, NoHistory: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ephemeralChild, err := s.Create(beads.Bead{Title: "ephemeral", ParentID: parent.ID, Ephemeral: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Children(parent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMemStoreIDs(t, got, historyChild.ID, noHistoryChild.ID)
+
+	got, err = s.Children(parent.ID, beads.WithEphemeral)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMemStoreIDs(t, got, noHistoryChild.ID, ephemeralChild.ID)
+
+	got, err = s.Children(parent.ID, beads.WithBothTiers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMemStoreIDs(t, got, historyChild.ID, noHistoryChild.ID, ephemeralChild.ID)
+}
+
 func TestMemStoreListByLabelRequiresIncludeClosed(t *testing.T) {
 	s := beads.NewMemStore()
 
@@ -179,6 +218,22 @@ func TestMemStoreListByLabelRequiresIncludeClosed(t *testing.T) {
 	}
 	if len(got) != 2 {
 		t.Fatalf("ListByLabel(IncludeClosed) = %d items, want 2", len(got))
+	}
+}
+
+func assertMemStoreIDs(t *testing.T, got []beads.Bead, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d beads (%v), want %v", len(got), got, want)
+	}
+	seen := make(map[string]bool, len(got))
+	for _, bead := range got {
+		seen[bead.ID] = true
+	}
+	for _, id := range want {
+		if !seen[id] {
+			t.Fatalf("got %v, want id %s", got, id)
+		}
 	}
 }
 

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -119,7 +119,12 @@ type NativeDoltStore struct {
 	idPrefix string
 }
 
-var _ Store = (*NativeDoltStore)(nil)
+var (
+	_ Store                    = (*NativeDoltStore)(nil)
+	_ GraphApplyStore          = (*NativeDoltStore)(nil)
+	_ StorageGraphApplyStore   = (*NativeDoltStore)(nil)
+	_ EphemeralGraphApplyStore = (*NativeDoltStore)(nil)
+)
 
 func newNativeDoltStoreWithStorage(storage beadslib.Storage, actor string) *NativeDoltStore {
 	if actor == "" {
@@ -201,6 +206,177 @@ func (s *NativeDoltStore) CloseStore() error {
 		return nil
 	}
 	return storage.Close()
+}
+
+// ApplyGraphPlan creates a bead graph atomically through the native beads
+// storage layer.
+func (s *NativeDoltStore) ApplyGraphPlan(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyResult, error) {
+	return s.ApplyGraphPlanWithStorage(ctx, plan, StorageDefault)
+}
+
+// ApplyGraphPlanWithStorage creates a bead graph atomically in the selected
+// storage tier through the native beads storage layer.
+func (s *NativeDoltStore) ApplyGraphPlanWithStorage(parent context.Context, plan *GraphApplyPlan, storageClass StorageClass) (*GraphApplyResult, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("graph apply plan is nil")
+	}
+	ephemeral, noHistory, err := graphStorageFlags(storageClass)
+	if err != nil {
+		return nil, fmt.Errorf("native graph apply: %w", err)
+	}
+	if err := validateNativeGraphApplyPlan(plan); err != nil {
+		return nil, fmt.Errorf("native graph apply: %w", err)
+	}
+
+	storage, release, err := s.acquireStorage()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	ctx, cancel := nativeDoltOperationContext(parent)
+	defer cancel()
+
+	keyToID := make(map[string]string, len(plan.Nodes))
+	commitMsg := plan.CommitMessage
+	if commitMsg == "" {
+		commitMsg = fmt.Sprintf("gc: graph-apply %d nodes", len(plan.Nodes))
+	}
+
+	if err := storage.RunInTransaction(ctx, commitMsg, func(tx beadslib.Transaction) error {
+		issues := make([]*beadslib.Issue, 0, len(plan.Nodes))
+		pendingAssignees := make(map[int]string)
+
+		for i, node := range plan.Nodes {
+			metadata, err := metadataRawFromMap(node.Metadata)
+			if err != nil {
+				return fmt.Errorf("node %q: marshaling metadata: %w", node.Key, err)
+			}
+			issueType := beadslib.IssueType(node.Type)
+			if issueType == "" {
+				issueType = beadslib.TypeTask
+			}
+			priority := 2
+			if node.Priority != nil {
+				priority = *node.Priority
+			}
+			issue := &beadslib.Issue{
+				Title:       node.Title,
+				Description: node.Description,
+				Status:      beadslib.StatusOpen,
+				Priority:    priority,
+				IssueType:   issueType,
+				Sender:      node.From,
+				Labels:      append([]string(nil), node.Labels...),
+				Metadata:    metadata,
+				Ephemeral:   ephemeral,
+				NoHistory:   noHistory,
+			}
+			if node.Assignee != "" {
+				if node.AssignAfterCreate {
+					pendingAssignees[i] = node.Assignee
+				} else {
+					issue.Assignee = node.Assignee
+				}
+			}
+			issues = append(issues, issue)
+		}
+
+		if err := tx.CreateIssues(ctx, issues, s.actor); err != nil {
+			return fmt.Errorf("batch create: %w", err)
+		}
+		for i, node := range plan.Nodes {
+			keyToID[node.Key] = issues[i].ID
+		}
+
+		for i, node := range plan.Nodes {
+			if len(node.MetadataRefs) == 0 {
+				continue
+			}
+			mergedMeta, err := metadataMapFromNative(issues[i].Metadata)
+			if err != nil {
+				return fmt.Errorf("node %q: re-parsing metadata: %w", node.Key, err)
+			}
+			if mergedMeta == nil {
+				mergedMeta = make(map[string]string, len(node.MetadataRefs))
+			}
+			for metaKey, refKey := range node.MetadataRefs {
+				mergedMeta[metaKey] = keyToID[refKey]
+			}
+			raw, err := metadataRawFromMap(mergedMeta)
+			if err != nil {
+				return fmt.Errorf("node %q: marshaling updated metadata: %w", node.Key, err)
+			}
+			if err := tx.UpdateIssue(ctx, issues[i].ID, map[string]interface{}{"metadata": raw}, s.actor); err != nil {
+				return fmt.Errorf("node %q: updating metadata refs: %w", node.Key, err)
+			}
+		}
+
+		parentDepPairs := nativeGraphApplyParentDepPairs(plan.Nodes, keyToID)
+		for i, edge := range plan.Edges {
+			fromID := nativeGraphApplyResolveRef(edge.FromKey, edge.FromID, keyToID)
+			toID := nativeGraphApplyResolveRef(edge.ToKey, edge.ToID, keyToID)
+			depType := nativeGraphApplyDependencyType(edge.Type)
+			if parentDepPairs[nativeGraphApplyDepPairKey(fromID, toID)] {
+				if depType == beadslib.DepParentChild {
+					continue
+				}
+				return fmt.Errorf("edge %d %s->%s duplicates a parent-child relationship with dependency type %q", i, fromID, toID, depType)
+			}
+			if parentDepPairs[nativeGraphApplyDepPairKey(toID, fromID)] && nativeGraphApplyCycleRelevantDependencyType(depType) {
+				return fmt.Errorf("edge %d %s->%s creates a blocking reverse of a parent-child relationship", i, fromID, toID)
+			}
+			dep := &beadslib.Dependency{
+				IssueID:     fromID,
+				DependsOnID: toID,
+				Type:        depType,
+				Metadata:    edge.Metadata,
+			}
+			if err := tx.AddDependency(ctx, dep, s.actor); err != nil {
+				return fmt.Errorf("adding edge %s->%s: %w", fromID, toID, err)
+			}
+		}
+
+		for i, node := range plan.Nodes {
+			parentID := node.ParentID
+			if node.ParentKey != "" {
+				parentID = keyToID[node.ParentKey]
+			}
+			if parentID == "" {
+				continue
+			}
+			dep := &beadslib.Dependency{
+				IssueID:     issues[i].ID,
+				DependsOnID: parentID,
+				Type:        beadslib.DepParentChild,
+			}
+			if err := tx.AddDependency(ctx, dep, s.actor); err != nil {
+				return fmt.Errorf("node %q: adding parent-child dep: %w", node.Key, err)
+			}
+		}
+
+		for i, assignee := range pendingAssignees {
+			if err := tx.UpdateIssue(ctx, issues[i].ID, map[string]interface{}{"assignee": assignee}, s.actor); err != nil {
+				return fmt.Errorf("node %q: setting assignee: %w", plan.Nodes[i].Key, err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	result := &GraphApplyResult{IDs: keyToID}
+	if err := ValidateGraphApplyResult(plan, result); err != nil {
+		return nil, fmt.Errorf("native graph apply: %w", err)
+	}
+	return result, nil
+}
+
+// SupportsEphemeralGraphApply reports whether this store can apply a whole
+// graph directly into ephemeral storage.
+func (s *NativeDoltStore) SupportsEphemeralGraphApply() bool {
+	return true
 }
 
 // Create persists a new bead through the upstream beads storage layer.
@@ -901,6 +1077,93 @@ func nativeBeadIDPrefix(id string) string {
 	return normalizeIDPrefix(before)
 }
 
+func validateNativeGraphApplyPlan(plan *GraphApplyPlan) error {
+	if len(plan.Nodes) == 0 {
+		return fmt.Errorf("plan has no nodes")
+	}
+	knownKeys := make(map[string]bool, len(plan.Nodes))
+	for i, node := range plan.Nodes {
+		if strings.TrimSpace(node.Key) == "" {
+			return fmt.Errorf("node %d has empty key", i)
+		}
+		if knownKeys[node.Key] {
+			return fmt.Errorf("duplicate node key %q", node.Key)
+		}
+		knownKeys[node.Key] = true
+		if strings.TrimSpace(node.Title) == "" {
+			return fmt.Errorf("node %q has empty title", node.Key)
+		}
+	}
+	for _, node := range plan.Nodes {
+		for metaKey, refKey := range node.MetadataRefs {
+			if !knownKeys[refKey] {
+				return fmt.Errorf("node %q: metadata ref %q references unknown key %q", node.Key, metaKey, refKey)
+			}
+		}
+		if node.ParentKey != "" && !knownKeys[node.ParentKey] {
+			return fmt.Errorf("node %q: parent key %q not found in plan", node.Key, node.ParentKey)
+		}
+	}
+	for i, edge := range plan.Edges {
+		if edge.FromKey != "" && !knownKeys[edge.FromKey] {
+			return fmt.Errorf("edge %d: from key %q not found in plan", i, edge.FromKey)
+		}
+		if edge.ToKey != "" && !knownKeys[edge.ToKey] {
+			return fmt.Errorf("edge %d: to key %q not found in plan", i, edge.ToKey)
+		}
+		if edge.FromKey == "" && edge.FromID == "" {
+			return fmt.Errorf("edge %d: must specify from_key or from_id", i)
+		}
+		if edge.ToKey == "" && edge.ToID == "" {
+			return fmt.Errorf("edge %d: must specify to_key or to_id", i)
+		}
+		if depType := nativeGraphApplyDependencyType(edge.Type); !depType.IsValid() {
+			return fmt.Errorf("edge %d: invalid dependency type %q", i, edge.Type)
+		}
+	}
+	return nil
+}
+
+func nativeGraphApplyDependencyType(depType string) beadslib.DependencyType {
+	if depType == "" {
+		return beadslib.DepBlocks
+	}
+	return beadslib.DependencyType(depType)
+}
+
+func nativeGraphApplyCycleRelevantDependencyType(depType beadslib.DependencyType) bool {
+	return depType == beadslib.DepBlocks || depType == beadslib.DepConditionalBlocks
+}
+
+func nativeGraphApplyParentDepPairs(nodes []GraphApplyNode, keyToID map[string]string) map[string]bool {
+	pairs := make(map[string]bool)
+	for _, node := range nodes {
+		childID := keyToID[node.Key]
+		parentID := node.ParentID
+		if node.ParentKey != "" {
+			parentID = keyToID[node.ParentKey]
+		}
+		if childID != "" && parentID != "" {
+			pairs[nativeGraphApplyDepPairKey(childID, parentID)] = true
+		}
+	}
+	return pairs
+}
+
+func nativeGraphApplyDepPairKey(issueID, dependsOnID string) string {
+	return issueID + "\x00" + dependsOnID
+}
+
+func nativeGraphApplyResolveRef(key, id string, keyToID map[string]string) string {
+	if id != "" {
+		return id
+	}
+	if key != "" {
+		return keyToID[key]
+	}
+	return ""
+}
+
 func cloneNativeDependencies(deps []*beadslib.Dependency) []*beadslib.Dependency {
 	if len(deps) == 0 {
 		return nil
@@ -936,6 +1199,7 @@ func nativeIssueFromBead(b Bead) (*beadslib.Issue, error) {
 		CreatedAt:   b.CreatedAt,
 		Labels:      append([]string(nil), b.Labels...),
 		Ephemeral:   b.Ephemeral,
+		NoHistory:   b.NoHistory,
 		DeferUntil:  cloneTimePtr(b.DeferUntil),
 	}
 	if b.Priority != nil {
@@ -999,6 +1263,7 @@ func beadFromNativeIssue(issue *beadslib.Issue) (Bead, error) {
 		Labels:      append([]string(nil), issue.Labels...),
 		Metadata:    metadata,
 		Ephemeral:   issue.Ephemeral,
+		NoHistory:   issue.NoHistory,
 		DeferUntil:  cloneTimePtr(issue.DeferUntil),
 	}
 	for _, dep := range issue.Dependencies {

--- a/internal/beads/native_dolt_store.go
+++ b/internal/beads/native_dolt_store.go
@@ -1296,7 +1296,7 @@ func nativePriorityFromIssue(issue *beadslib.Issue) *int {
 
 func nativeIssueFilterFromListQuery(query ListQuery) beadslib.IssueFilter {
 	limit := query.Limit
-	if query.Sort != SortDefault {
+	if query.Sort != SortDefault || query.TierMode == TierWisps {
 		limit = 0
 	}
 	filter := beadslib.IssueFilter{
@@ -1307,8 +1307,9 @@ func nativeIssueFilterFromListQuery(query ListQuery) beadslib.IssueFilter {
 	}
 	switch query.TierMode {
 	case TierWisps:
-		ephemeral := true
-		filter.Ephemeral = &ephemeral
+		// Upstream can filter only ephemeral rows, while Gas City's wisp tier
+		// includes both ephemeral and no-history rows. Let ApplyListQuery apply
+		// the final tier filter after all candidates are returned.
 	case TierBoth:
 		// no tier filter
 	default:

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -101,6 +101,32 @@ func TestNativeDoltStoreCreateGetPreservesDeferUntil(t *testing.T) {
 	}
 }
 
+func TestNativeDoltStoreCreateGetPreservesNoHistory(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+
+	created, err := store.Create(Bead{Title: "native no history", NoHistory: true})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !created.NoHistory {
+		t.Fatalf("created.NoHistory = false, want true")
+	}
+	if created.Ephemeral {
+		t.Fatalf("created.Ephemeral = true, want false for no-history bead")
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.NoHistory {
+		t.Fatalf("got.NoHistory = false, want true")
+	}
+	if got.Ephemeral {
+		t.Fatalf("got.Ephemeral = true, want false for no-history bead")
+	}
+}
+
 func TestNativeDoltStoreCreatePropagatesUpstreamError(t *testing.T) {
 	wantErr := errors.New("create failed")
 	storage := &nativeDoltStorageSpy{
@@ -1392,6 +1418,87 @@ func TestCachingStoreCreateWithNativeDoltStoreHydratesDependencies(t *testing.T)
 	assertNativeDependency(t, created.Dependencies, child.ID, blocker.ID, "blocks")
 }
 
+func TestNativeDoltStoreApplyGraphPlanWithStorageEphemeral(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+
+	result, err := store.ApplyGraphPlanWithStorage(t.Context(), &GraphApplyPlan{
+		CommitMessage: "gc: native ephemeral graph",
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Metadata: map[string]string{"gc.kind": "wisp"}},
+			{Key: "blocker", Title: "Blocker"},
+			{
+				Key:               "child",
+				Title:             "Child",
+				ParentKey:         "root",
+				Assignee:          "gascity/worker",
+				AssignAfterCreate: true,
+				MetadataRefs:      map[string]string{"gc.root_bead_id": "root", "gc.blocker_id": "blocker"},
+			},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "child", ToKey: "blocker"},
+		},
+	}, StorageEphemeral)
+	if err != nil {
+		t.Fatalf("ApplyGraphPlanWithStorage: %v", err)
+	}
+
+	root, err := store.Get(result.IDs["root"])
+	if err != nil {
+		t.Fatalf("Get root: %v", err)
+	}
+	blocker, err := store.Get(result.IDs["blocker"])
+	if err != nil {
+		t.Fatalf("Get blocker: %v", err)
+	}
+	child, err := store.Get(result.IDs["child"])
+	if err != nil {
+		t.Fatalf("Get child: %v", err)
+	}
+
+	for _, bead := range []Bead{root, blocker, child} {
+		if !bead.Ephemeral {
+			t.Fatalf("bead %s Ephemeral = false, want true", bead.ID)
+		}
+		if bead.NoHistory {
+			t.Fatalf("bead %s NoHistory = true, want false", bead.ID)
+		}
+	}
+	if child.Assignee != "gascity/worker" {
+		t.Fatalf("child.Assignee = %q, want gascity/worker", child.Assignee)
+	}
+	if child.Metadata["gc.root_bead_id"] != root.ID || child.Metadata["gc.blocker_id"] != blocker.ID {
+		t.Fatalf("child metadata refs = %#v, want root/blocker IDs", child.Metadata)
+	}
+	if child.ParentID != root.ID {
+		t.Fatalf("child.ParentID = %q, want %q", child.ParentID, root.ID)
+	}
+	assertNativeDependency(t, child.Dependencies, child.ID, root.ID, string(beadslib.DepParentChild))
+	assertNativeDependency(t, child.Dependencies, child.ID, blocker.ID, string(beadslib.DepBlocks))
+}
+
+func TestNativeDoltStoreApplyGraphPlanWithStorageNoHistory(t *testing.T) {
+	store := newNativeDoltStoreForTest(newNativeDoltMemStorage())
+
+	result, err := store.ApplyGraphPlanWithStorage(t.Context(), &GraphApplyPlan{
+		Nodes: []GraphApplyNode{{Key: "node", Title: "No-history graph node"}},
+	}, StorageNoHistory)
+	if err != nil {
+		t.Fatalf("ApplyGraphPlanWithStorage: %v", err)
+	}
+
+	got, err := store.Get(result.IDs["node"])
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.NoHistory {
+		t.Fatalf("NoHistory = false, want true")
+	}
+	if got.Ephemeral {
+		t.Fatalf("Ephemeral = true, want false")
+	}
+}
+
 func assertNativeDependency(t *testing.T, deps []Dep, issueID, dependsOnID, depType string) {
 	t.Helper()
 	for _, dep := range deps {
@@ -1403,6 +1510,7 @@ func assertNativeDependency(t *testing.T, deps []Dep, issueID, dependsOnID, depT
 }
 
 type nativeDoltTransactionTestStorage interface {
+	CreateIssues(context.Context, []*beadslib.Issue, string) error
 	GetIssue(context.Context, string) (*beadslib.Issue, error)
 	UpdateIssue(context.Context, string, map[string]interface{}, string) error
 	AddLabel(context.Context, string, string, string) error
@@ -1415,6 +1523,10 @@ type nativeDoltTransactionTestStorage interface {
 type nativeDoltTransactionForTest struct {
 	beadslib.Transaction
 	storage nativeDoltTransactionTestStorage
+}
+
+func (tx nativeDoltTransactionForTest) CreateIssues(ctx context.Context, issues []*beadslib.Issue, actor string) error {
+	return tx.storage.CreateIssues(ctx, issues, actor)
 }
 
 func (tx nativeDoltTransactionForTest) GetIssue(ctx context.Context, id string) (*beadslib.Issue, error) {
@@ -1448,6 +1560,7 @@ func (tx nativeDoltTransactionForTest) GetDependencyRecords(ctx context.Context,
 type nativeDoltStorageSpy struct {
 	beadslib.Storage
 	createIssue                 func(context.Context, *beadslib.Issue, string) error
+	createIssues                func(context.Context, []*beadslib.Issue, string) error
 	getIssue                    func(context.Context, string) (*beadslib.Issue, error)
 	updateIssue                 func(context.Context, string, map[string]interface{}, string) error
 	runInTransaction            func(context.Context, string, func(beadslib.Transaction) error) error
@@ -1472,6 +1585,18 @@ func (s *nativeDoltStorageSpy) CreateIssue(ctx context.Context, issue *beadslib.
 		return nil
 	}
 	return s.createIssue(ctx, issue, actor)
+}
+
+func (s *nativeDoltStorageSpy) CreateIssues(ctx context.Context, issues []*beadslib.Issue, actor string) error {
+	if s.createIssues != nil {
+		return s.createIssues(ctx, issues, actor)
+	}
+	for _, issue := range issues {
+		if err := s.CreateIssue(ctx, issue, actor); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *nativeDoltStorageSpy) GetIssue(ctx context.Context, id string) (*beadslib.Issue, error) {
@@ -1643,6 +1768,15 @@ func (s *nativeDoltMemStorage) CreateIssue(_ context.Context, issue *beadslib.Is
 		return err
 	}
 	*issue = *converted
+	return nil
+}
+
+func (s *nativeDoltMemStorage) CreateIssues(ctx context.Context, issues []*beadslib.Issue, actor string) error {
+	for _, issue := range issues {
+		if err := s.CreateIssue(ctx, issue, actor); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/beads/native_dolt_store_test.go
+++ b/internal/beads/native_dolt_store_test.go
@@ -784,6 +784,37 @@ func TestNativeDoltStoreListDoesNotPushLimitBeforeLocalSort(t *testing.T) {
 	}
 }
 
+func TestNativeDoltStoreListTierWispsIncludesNoHistoryAndEphemeralRows(t *testing.T) {
+	issues, err := nativeIssuesFromBeads([]Bead{
+		{ID: "gc-history", Title: "history-backed row"},
+		{ID: "gc-no-history", Title: "no-history wisp", NoHistory: true},
+		{ID: "gc-ephemeral", Title: "ephemeral wisp", Ephemeral: true},
+	})
+	if err != nil {
+		t.Fatalf("nativeIssuesFromBeads: %v", err)
+	}
+	storage := &nativeDoltStorageSpy{
+		searchIssues: func(_ context.Context, _ string, filter beadslib.IssueFilter) ([]*beadslib.Issue, error) {
+			return filterNativeIssuesForTest(issues, filter), nil
+		},
+	}
+	store := newNativeDoltStoreForTest(storage)
+
+	got, err := store.List(ListQuery{AllowScan: true, TierMode: TierWisps, Limit: 2})
+	if err != nil {
+		t.Fatalf("List(TierWisps): %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "gc-no-history" || got[1].ID != "gc-ephemeral" {
+		t.Fatalf("List(TierWisps) = %+v, want no-history and ephemeral rows", got)
+	}
+	if !got[0].NoHistory || got[0].Ephemeral {
+		t.Fatalf("first row storage = ephemeral:%v no_history:%v, want no-history", got[0].Ephemeral, got[0].NoHistory)
+	}
+	if !got[1].Ephemeral || got[1].NoHistory {
+		t.Fatalf("second row storage = ephemeral:%v no_history:%v, want ephemeral", got[1].Ephemeral, got[1].NoHistory)
+	}
+}
+
 func TestNativeDoltStoreSetMetadataBatchRejectsInvalidExistingMetadata(t *testing.T) {
 	updateCalled := false
 	storage := &nativeDoltStorageSpy{

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -24,16 +24,22 @@ const (
 // TierMode selects which storage tier(s) a List query reads from.
 // The zero value is TierIssues.
 //
-// TierIssues is the permanent tier and filters out Ephemeral rows when a store
-// returns them to the caller. TierBoth is a logical union; implementations may
-// satisfy it through a single backend query when the backing store exposes a
-// supported union surface for the requested bead type.
+// TierIssues is the permanent logical tier and filters out Ephemeral rows when
+// a store returns them to the caller. NoHistory rows remain visible to list
+// filters in TierIssues because they are durable work without Dolt history.
+// Raw bd ready defaults are narrower than the logical union surface. In bd
+// 1.0.4, ready queries cannot expose no-history rows with the full ready
+// filter semantics, so compatibility policy keeps claimable work history-backed
+// in that mode. TierBoth is a logical union; implementations may satisfy it
+// through a single backend query when the backing store exposes a supported
+// union surface for the requested bead type.
 type TierMode int
 
 const (
 	// TierIssues reads only the permanent (issues) tier. Default.
 	TierIssues TierMode = iota
-	// TierWisps reads only the ephemeral (wisps) tier.
+	// TierWisps reads only the wisp-backed tier, including ephemeral and
+	// no-history rows.
 	TierWisps
 	// TierBoth unions the issues and wisps tiers, deduping by ID and
 	// preserving the query's sort.
@@ -104,7 +110,10 @@ type ReadyQuery struct {
 	Assignee string
 	Limit    int
 	// TierMode selects the storage tier(s) to read from. Zero value
-	// (TierIssues) preserves Ready's historical main-tier behavior.
+	// (TierIssues) preserves raw Ready's historical main-tier behavior.
+	// Policy-aware callers should use the policy store wrapper, which expands
+	// default Ready reads to TierBoth so no-history and ephemeral policy rows
+	// remain reachable under bd 1.0.4.
 	TierMode TierMode
 }
 
@@ -137,7 +146,7 @@ func (q ListQuery) IncludesClosed() bool {
 func (q ListQuery) Matches(b Bead) bool {
 	switch q.TierMode {
 	case TierWisps:
-		if !b.Ephemeral {
+		if !b.Ephemeral && !b.NoHistory {
 			return false
 		}
 	case TierBoth:

--- a/internal/beads/sqlite_store.go
+++ b/internal/beads/sqlite_store.go
@@ -572,10 +572,17 @@ func (s *SQLiteStore) List(query ListQuery) ([]Bead, error) {
 		if err != nil {
 			return nil, fmt.Errorf("listing sqlite beads: %w", err)
 		}
+		if !query.Matches(b) {
+			continue
+		}
 		result = append(result, b)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("listing sqlite beads: %w", err)
+	}
+	sortBeadsForQuery(result, query.Sort)
+	if query.Limit > 0 && len(result) > query.Limit {
+		result = result[:query.Limit]
 	}
 	return result, nil
 }
@@ -585,7 +592,8 @@ func sqliteListSQL(q ListQuery) (string, []any) {
 	args := []any{}
 	switch q.TierMode {
 	case TierWisps:
-		where = append(where, "tier='wisp'")
+		// NoHistory rows live in SQLite's main tier but remain part of the
+		// logical wisp tier, so final tier filtering happens after decode.
 	case TierBoth:
 	default:
 		where = append(where, "tier='main'")
@@ -634,7 +642,7 @@ func sqliteListSQL(q ListQuery) (string, []any) {
 	case SortCreatedDesc:
 		sqlText += " ORDER BY created_at DESC, id DESC"
 	}
-	if q.Limit > 0 {
+	if q.Limit > 0 && q.TierMode != TierWisps {
 		sqlText += fmt.Sprintf(" LIMIT %d", q.Limit)
 	}
 	return sqlText, args
@@ -649,27 +657,36 @@ func (s *SQLiteStore) ListOpen(status ...string) ([]Bead, error) {
 	return s.List(query)
 }
 
-// Ready returns open, unblocked actionable main-tier beads.
+// Ready returns open, unblocked actionable beads from the requested tier.
 func (s *SQLiteStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	q := readyQueryFromArgs(query)
 	args := []any{}
-	sqlText := `SELECT b.bead_json FROM beads b
-		WHERE b.tier='main'
-		  AND b.status='open'
-		  AND b.issue_type NOT IN ('merge-request','gate','molecule','step','message','session','agent','role','rig')
-		  AND NOT EXISTS (
+	where := []string{
+		"b.status='open'",
+		`b.issue_type NOT IN ('merge-request','gate','molecule','step','message','session','agent','role','rig')`,
+		`NOT EXISTS (
 			SELECT 1 FROM deps d
 			LEFT JOIN beads blocker ON blocker.id=d.depends_on_id
 			WHERE d.issue_id=b.id
 			  AND d.dep_type IN ('blocks','waits-for','conditional-blocks')
 			  AND COALESCE(blocker.status, '') <> 'closed'
-		  )`
+		  )`,
+	}
+	switch q.TierMode {
+	case TierWisps:
+		// Filter after decode so NoHistory rows in SQLite's main tier are still
+		// visible to logical wisp-tier reads.
+	case TierBoth:
+	default:
+		where = append(where, "b.tier='main'")
+	}
+	sqlText := `SELECT b.bead_json FROM beads b WHERE ` + strings.Join(where, " AND ")
 	if q.Assignee != "" {
 		sqlText += " AND b.assignee=?"
 		args = append(args, q.Assignee)
 	}
 	sqlText += " ORDER BY b.created_at ASC, b.id ASC"
-	if q.Limit > 0 {
+	if q.Limit > 0 && q.TierMode != TierWisps {
 		sqlText += fmt.Sprintf(" LIMIT %d", q.Limit)
 	}
 	rows, err := s.readDB.QueryContext(context.Background(), sqlText, args...)
@@ -678,12 +695,19 @@ func (s *SQLiteStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	}
 	defer rows.Close() //nolint:errcheck
 	var result []Bead
+	now := time.Now().UTC()
 	for rows.Next() {
 		b, err := scanSQLiteBead(rows)
 		if err != nil {
 			return nil, err
 		}
+		if !IsReadyCandidateForTier(b, now, q.TierMode) {
+			continue
+		}
 		result = append(result, b)
+		if q.Limit > 0 && len(result) >= q.Limit {
+			break
+		}
 	}
 	return result, rows.Err()
 }

--- a/internal/beads/sqlite_store_test.go
+++ b/internal/beads/sqlite_store_test.go
@@ -88,6 +88,65 @@ func TestSQLiteStoreReady(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreReadyHonorsTierMode(t *testing.T) {
+	s, err := OpenSQLiteStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() {
+		if c, ok := s.(interface{ CloseStore() error }); ok {
+			c.CloseStore() //nolint:errcheck
+		}
+	}()
+
+	history, err := s.Create(Bead{Title: "history", Type: "task"})
+	if err != nil {
+		t.Fatalf("create history: %v", err)
+	}
+	noHistory, err := s.Create(Bead{Title: "no history", Type: "task", NoHistory: true})
+	if err != nil {
+		t.Fatalf("create no history: %v", err)
+	}
+	ephemeral, err := s.Create(Bead{Title: "ephemeral", Type: "task", Ephemeral: true})
+	if err != nil {
+		t.Fatalf("create ephemeral: %v", err)
+	}
+
+	defaultReady, err := s.Ready()
+	if err != nil {
+		t.Fatalf("Ready(default): %v", err)
+	}
+	if readyIDs(defaultReady)[ephemeral.ID] {
+		t.Fatalf("Ready(default) included ephemeral row %q: %+v", ephemeral.ID, defaultReady)
+	}
+	if !readyIDs(defaultReady)[history.ID] || !readyIDs(defaultReady)[noHistory.ID] {
+		t.Fatalf("Ready(default) = %+v, want history and no-history rows", defaultReady)
+	}
+
+	wisps, err := s.Ready(ReadyQuery{TierMode: TierWisps})
+	if err != nil {
+		t.Fatalf("Ready(TierWisps): %v", err)
+	}
+	wispIDs := readyIDs(wisps)
+	if wispIDs[history.ID] {
+		t.Fatalf("Ready(TierWisps) included history row %q: %+v", history.ID, wisps)
+	}
+	if !wispIDs[noHistory.ID] || !wispIDs[ephemeral.ID] {
+		t.Fatalf("Ready(TierWisps) = %+v, want no-history and ephemeral rows", wisps)
+	}
+
+	both, err := s.Ready(ReadyQuery{TierMode: TierBoth})
+	if err != nil {
+		t.Fatalf("Ready(TierBoth): %v", err)
+	}
+	bothIDs := readyIDs(both)
+	for _, id := range []string{history.ID, noHistory.ID, ephemeral.ID} {
+		if !bothIDs[id] {
+			t.Fatalf("Ready(TierBoth) = %+v, missing %s", both, id)
+		}
+	}
+}
+
 func TestSQLiteStoreCloseStore(t *testing.T) {
 	settle := func() {
 		runtime.GC()
@@ -163,4 +222,12 @@ func TestSQLiteStoreNoLeakOnDiscard(t *testing.T) {
 	if residual > 5 {
 		t.Fatalf("SQLiteStore CloseStore did not release resources: residual goroutines=%d after %d open+close cycles (want <=5)", residual, n)
 	}
+}
+
+func readyIDs(rows []Bead) map[string]bool {
+	ids := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		ids[row.ID] = true
+	}
+	return ids
 }

--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -18,7 +18,7 @@ through explicit beads; you execute the ready bead currently assigned to you.
 bd list --assignee="$GC_SESSION_NAME" --status=in_progress --json
 
 # Step 2: If nothing in-progress, check for assigned ready work
-bd ready --include-ephemeral --assignee="$GC_SESSION_NAME" --json --limit=1
+{{ .AssignedReadyQuery }} --json --limit=1
 
 # Step 3: If still nothing, check the routed queue (multi-session configs only)
 gc hook
@@ -70,7 +70,7 @@ gc runtime drain-ack
    ```
 10. After closing, check for more assigned work:
    ```bash
-   bd ready --include-ephemeral --assignee="$GC_SESSION_NAME" --json --limit=1
+   {{ .AssignedReadyQuery }} --json --limit=1
    ```
 11. If more work exists, go to step 2. If not, poll briefly (see below).
 
@@ -113,7 +113,7 @@ for the same config (`--unassigned` filtering).
 
 ## Polling Before Drain
 
-After closing a bead, if `bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"` returns
+After closing a bead, if `{{ .AssignedReadyQuery }}` returns
 nothing, do NOT drain immediately. The workflow controller may need a few
 seconds to process control beads and unlock your next step.
 
@@ -121,7 +121,7 @@ Poll up to 60 seconds (6 attempts, 10 seconds apart):
 
 ```bash
 for i in $(seq 1 6); do
-  NEXT=$(bd ready --include-ephemeral --assignee="$GC_SESSION_NAME" --json --limit=1 2>/dev/null)
+  NEXT=$({{ .AssignedReadyQuery }} --json --limit=1 2>/dev/null)
   if [ -n "$NEXT" ] && [ "$NEXT" != "[]" ]; then
     # Found work — continue working
     break

--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -18,7 +18,7 @@ through explicit beads; you execute the ready bead currently assigned to you.
 bd list --assignee="$GC_SESSION_NAME" --status=in_progress --json
 
 # Step 2: If nothing in-progress, check for assigned ready work
-bd ready --assignee="$GC_SESSION_NAME" --json --limit=1
+bd ready --include-ephemeral --assignee="$GC_SESSION_NAME" --json --limit=1
 
 # Step 3: If still nothing, check the routed queue (multi-session configs only)
 gc hook
@@ -70,7 +70,7 @@ gc runtime drain-ack
    ```
 10. After closing, check for more assigned work:
    ```bash
-   bd ready --assignee="$GC_SESSION_NAME" --json --limit=1
+   bd ready --include-ephemeral --assignee="$GC_SESSION_NAME" --json --limit=1
    ```
 11. If more work exists, go to step 2. If not, poll briefly (see below).
 
@@ -113,7 +113,7 @@ for the same config (`--unassigned` filtering).
 
 ## Polling Before Drain
 
-After closing a bead, if `bd ready --assignee="$GC_SESSION_NAME"` returns
+After closing a bead, if `bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"` returns
 nothing, do NOT drain immediately. The workflow controller may need a few
 seconds to process control beads and unlock your next step.
 
@@ -121,7 +121,7 @@ Poll up to 60 seconds (6 attempts, 10 seconds apart):
 
 ```bash
 for i in $(seq 1 6); do
-  NEXT=$(bd ready --assignee="$GC_SESSION_NAME" --json --limit=1 2>/dev/null)
+  NEXT=$(bd ready --include-ephemeral --assignee="$GC_SESSION_NAME" --json --limit=1 2>/dev/null)
   if [ -n "$NEXT" ] && [ "$NEXT" != "[]" ]; then
     # Found work — continue working
     break

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -18,7 +18,7 @@ more work arrives.
 bd list --assignee="$GC_SESSION_NAME" --status=in_progress
 
 # Step 2: If nothing in-progress, check for assigned ready work
-bd ready --assignee="$GC_SESSION_NAME"
+bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"
 
 # Step 3: If still nothing, check the routed queue
 gc hook
@@ -93,7 +93,7 @@ the bead description directly.
 
 ## Your Tools
 
-- `bd ready --assignee="$GC_SESSION_NAME"` — find pre-assigned work
+- `bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"` — find pre-assigned work
 - `gc hook` — find routed pool work through the configured hook
 - `bd update <id> --claim` — claim a work item
 - `bd show <id>` — see details of a work item or step
@@ -105,7 +105,7 @@ the bead description directly.
 
 ## How to Work
 
-1. Find work: `bd list --assignee="$GC_SESSION_NAME" --status=in_progress` or `bd ready --assignee="$GC_SESSION_NAME"` or `gc hook`
+1. Find work: `bd list --assignee="$GC_SESSION_NAME" --status=in_progress` or `bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"` or `gc hook`
 2. Claim if unclaimed: `bd update <id> --claim`
 3. Verify the claimed bead is assigned to `$GC_SESSION_NAME` and routed to `$GC_TEMPLATE`
 4. **Check for molecule:** `bd show <id>` — look for `molecule_id` in METADATA

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -18,7 +18,7 @@ more work arrives.
 bd list --assignee="$GC_SESSION_NAME" --status=in_progress
 
 # Step 2: If nothing in-progress, check for assigned ready work
-bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"
+{{ .AssignedReadyQuery }}
 
 # Step 3: If still nothing, check the routed queue
 gc hook
@@ -93,7 +93,7 @@ the bead description directly.
 
 ## Your Tools
 
-- `bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"` — find pre-assigned work
+- `{{ .AssignedReadyQuery }}` — find pre-assigned work
 - `gc hook` — find routed pool work through the configured hook
 - `bd update <id> --claim` — claim a work item
 - `bd show <id>` — see details of a work item or step
@@ -105,7 +105,7 @@ the bead description directly.
 
 ## How to Work
 
-1. Find work: `bd list --assignee="$GC_SESSION_NAME" --status=in_progress` or `bd ready --include-ephemeral --assignee="$GC_SESSION_NAME"` or `gc hook`
+1. Find work: `bd list --assignee="$GC_SESSION_NAME" --status=in_progress` or `{{ .AssignedReadyQuery }}` or `gc hook`
 2. Claim if unclaimed: `bd update <id> --claim`
 3. Verify the claimed bead is assigned to `$GC_SESSION_NAME` and routed to `$GC_TEMPLATE`
 4. **Check for molecule:** `bd show <id>` — look for `molecule_id` in METADATA

--- a/internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md
+++ b/internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md
@@ -31,6 +31,6 @@ check for and claim new work from the queue.
 - `gc nudge drain --inject` — drain queued nudges
 - `gc mail check --inject` — check for inter-agent messages
 - `gc hook` — check for and claim available work
-- `bd ready` — list ready beads (tasks)
+- `bd ready --include-ephemeral` — list ready beads (tasks)
 - `bd show <id>` — show bead details
 - `bd close <id>` — mark a bead as done

--- a/internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md
+++ b/internal/bootstrap/packs/core/overlay/per-provider/kiro/AGENTS.md
@@ -31,6 +31,6 @@ check for and claim new work from the queue.
 - `gc nudge drain --inject` — drain queued nudges
 - `gc mail check --inject` — check for inter-agent messages
 - `gc hook` — check for and claim available work
-- `bd ready --include-ephemeral` — list ready beads (tasks)
+- `bd ready` — list ready beads (add `--include-ephemeral` only in bd 1.0.5+ cities)
 - `bd show <id>` — show bead details
 - `bd close <id>` — mark a bead as done

--- a/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
@@ -37,8 +37,8 @@ gc bd create "title" --label priority=high  # Create with labels
 ```
 gc bd list                                # List beads in current .beads/
 gc bd list --rig <rigname>                # List beads in a specific rig
-gc bd ready                               # List beads available for claiming
-gc bd ready --label role:worker           # Filter by label
+gc bd ready --include-ephemeral           # List beads available for claiming
+gc bd ready --include-ephemeral --label role:worker # Filter by label
 gc bd show <id>                           # Show bead details
 ```
 

--- a/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
@@ -37,8 +37,8 @@ gc bd create "title" --label priority=high  # Create with labels
 ```
 gc bd list                                # List beads in current .beads/
 gc bd list --rig <rigname>                # List beads in a specific rig
-gc bd ready --include-ephemeral           # List beads available for claiming
-gc bd ready --include-ephemeral --label role:worker # Filter by label
+gc bd ready                               # List beads available for claiming
+gc bd ready --label role:worker           # Filter by label
 gc bd show <id>                           # Show bead details
 ```
 

--- a/internal/config/bead_policy_validation.go
+++ b/internal/config/bead_policy_validation.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var bd104CompatiblePolicyStorage = map[string][]string{
+	"session":        {BeadStorageNoHistory, BeadStorageHistory},
+	"wait":           {BeadStorageNoHistory, BeadStorageHistory},
+	"nudge":          {BeadStorageNoHistory, BeadStorageHistory},
+	"order_tracking": {BeadStorageNoHistory, BeadStorageHistory},
+	"workflow":       {BeadStorageHistory},
+	"wisp":           {BeadStorageHistory},
+}
+
+var bd105CompatiblePolicyStorage = map[string][]string{
+	"session":        {BeadStorageNoHistory, BeadStorageHistory},
+	"wait":           {BeadStorageNoHistory, BeadStorageHistory},
+	"nudge":          {BeadStorageNoHistory, BeadStorageHistory},
+	"order_tracking": {BeadStorageNoHistory, BeadStorageHistory},
+	"workflow":       {BeadStorageNoHistory, BeadStorageHistory},
+	"wisp":           {BeadStorageEphemeral, BeadStorageNoHistory, BeadStorageHistory},
+}
+
+// ValidateBeadPolicyStorageCompatibility rejects known policy/storage pairs
+// that can strand or incorrectly collect Gas City beads under the configured
+// bd compatibility mode.
+func ValidateBeadPolicyStorageCompatibility(cfg *City, source string) error {
+	if cfg == nil || len(cfg.Beads.Policies) == 0 {
+		return nil
+	}
+	compatibility := cfg.Beads.NormalizedBDCompatibility()
+	compatibleStorage := bd104CompatiblePolicyStorage
+	if compatibility == BeadsBDCompatibility105 {
+		compatibleStorage = bd105CompatiblePolicyStorage
+	}
+	names := make([]string, 0, len(cfg.Beads.Policies))
+	for name := range cfg.Beads.Policies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		policy := cfg.Beads.Policies[name]
+		storage := policy.NormalizedStorage()
+		if storage == "" || !ValidBeadPolicyStorage(storage) {
+			continue
+		}
+		allowed, ok := compatibleStorage[name]
+		if !ok || stringInSlice(storage, allowed) {
+			continue
+		}
+		return fmt.Errorf("%s: [beads.policies.%s] storage = %q is not %s-compatible; allowed storage: %s",
+			source, name, storage, compatibility, strings.Join(allowed, ", "))
+	}
+	return nil
+}
+
+func stringInSlice(value string, values []string) bool {
+	for _, candidate := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -642,6 +642,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// Validate all duration strings in the fully-merged config.
 	prov.Warnings = append(prov.Warnings, ValidateDurations(root, path)...)
 	prov.Warnings = append(prov.Warnings, ValidateEventsRotation(root)...)
+	if err := ValidateBeadPolicyStorageCompatibility(root, path); err != nil {
+		return nil, nil, err
+	}
 
 	// Reject negative durations that parse cleanly but are silently
 	// destructive at runtime (e.g. a negative dolt_stop_timeout collapses

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3166,6 +3166,47 @@ func poolDemandMigrationFilterJQ(limit int) string {
 	return shellquote.Join([]string{"jq", filter})
 }
 
+func bdQueryEphemeralStatusShell(status string) string {
+	return `bd query --json ` + shellquote.Quote("ephemeral=true AND status="+status) + ` --limit=0`
+}
+
+func bdQueryEphemeralStatusQuietShell(status string) string {
+	return bdQueryEphemeralStatusShell(status) + ` 2>/dev/null`
+}
+
+func legacyEphemeralReadyFilterJQ(selector string, limit int) string {
+	filter := `[.[] | ` + selector +
+		` | select(((.issue_type // .type // "") != "epic"))` +
+		` | select(([ (.dependencies // [])[]` +
+		` | select((.type // .dep_type // "") as $t | ($t == "blocks" or $t == "waits-for" or $t == "conditional-blocks"))` +
+		` | select((.status // .depends_on_status // "") != "closed") ] | length) == 0)]` +
+		` | sort_by(.created_at // "")`
+	if limit > 0 {
+		filter += ` | .[:` + strconv.Itoa(limit) + `]`
+	}
+	return filter
+}
+
+func legacyEphemeralPoolDemandShell(limit int, includeEphemeralReady, quiet bool) string {
+	if includeEphemeralReady {
+		return `printf "[]"`
+	}
+	filter := legacyEphemeralReadyFilterJQ(
+		`select((.assignee // "") == "")`+
+			` | select(((.metadata["gc.routed_to"] // "") == $target) or (((.metadata["gc.routed_to"] // "") == "") and ((.metadata["gc.run_target"] // "") == $target) and ((.metadata["gc.kind"] // "") == "workflow")))`,
+		limit,
+	)
+	query := bdQueryEphemeralStatusShell("open")
+	if quiet {
+		query = bdQueryEphemeralStatusQuietShell("open")
+	}
+	jqStderr := ""
+	if quiet {
+		jqStderr = ` 2>/dev/null`
+	}
+	return `{ ` + query + ` | jq --arg target "$target" ` + shellquote.Quote(filter) + jqStderr + `; } || printf "[]"`
+}
+
 // poolDemandFirstRowFunctionScript emits the work_query Tier 3 function: it
 // reads the first ready, unassigned, routed bead for the supplied target,
 // prints it, and exits 0. The caller appends a terminal fallthrough
@@ -3178,6 +3219,9 @@ func poolDemandFirstRowFunctionScript(includeEphemeralReady bool) string {
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`legacy_candidates=$(` + bdReadyPoolDemandMigrationShell("--limit=20", includeEphemeralReady) + ` 2>/dev/null); ` +
 		`r=$(printf "%s" "$legacy_candidates" | ` + poolDemandMigrationFilterJQ(1) + ` 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`legacy_ephemeral_candidates=$(` + legacyEphemeralPoolDemandShell(20, includeEphemeralReady, true) + `); ` +
+		`r=$(printf "%s" "$legacy_ephemeral_candidates" | jq '.[0:1]' 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`return 1; ` +
 		`}; `
@@ -3205,7 +3249,8 @@ func poolDemandCountShell(target string, includeEphemeralReady bool) string {
 		`ready_json=$(` + bdReadyPoolDemandShell("--limit 0", includeEphemeralReady) + `) || exit $?; ` +
 		`legacy_candidates=$(` + bdReadyPoolDemandMigrationShell("--limit 0", includeEphemeralReady) + `) || exit $?; ` +
 		`legacy_json=$(printf "%s" "$legacy_candidates" | ` + poolDemandMigrationFilterJQ(0) + `) || exit $?; ` +
-		`printf "%s\n%s\n" "$ready_json" "$legacy_json" | jq -s "(add // []) | unique_by(.id) | length"`
+		`legacy_ephemeral_json=$(` + legacyEphemeralPoolDemandShell(0, includeEphemeralReady, false) + `); ` +
+		`printf "%s\n%s\n%s\n" "$ready_json" "$legacy_json" "$legacy_ephemeral_json" | jq -s "(add // []) | unique_by(.id) | length"`
 	return shellquote.Join([]string{"sh", "-c", script, "--", target})
 }
 
@@ -3218,26 +3263,30 @@ func (a *Agent) poolDemandTarget() string {
 }
 
 func standardAssignedWorkQueryScript(includeEphemeralReady bool) string {
-	return `for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
+	script := `for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
 		`r=$(bd list --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		ephemeralAssignedInProgressProbeScript("id", includeEphemeralReady) +
 		`done; ` +
 		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
 		`r=$(bd ready` + bdReadyIncludeEphemeralArg(includeEphemeralReady) + ` --assignee="$id" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		ephemeralAssignedReadyProbeScript("id", includeEphemeralReady) +
 		`done; `
+	return script
 }
 
 func legacyControlAssignedWorkQueryScript(includeEphemeralReady bool) string {
-	return `for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
+	script := `for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
 		`r=$(bd list --status in_progress --assignee="$cand" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		ephemeralAssignedInProgressProbeScript("cand", includeEphemeralReady) +
 		`done; ` +
 		`done; ` +
 		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
@@ -3247,8 +3296,27 @@ func legacyControlAssignedWorkQueryScript(includeEphemeralReady bool) string {
 		`[ -z "$cand" ] && continue; ` +
 		`r=$(bd ready` + bdReadyIncludeEphemeralArg(includeEphemeralReady) + ` --assignee="$cand" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		ephemeralAssignedReadyProbeScript("cand", includeEphemeralReady) +
 		`done; ` +
 		`done; `
+	return script
+}
+
+func ephemeralAssignedInProgressProbeScript(shellVar string, includeEphemeralReady bool) string {
+	_ = includeEphemeralReady
+	return `r=$(` + bdQueryEphemeralStatusQuietShell("in_progress") + ` | ` +
+		`jq --arg id "$` + shellVar + `" '[.[] | select((.assignee // "") == $id)] | .[:1]' 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; `
+}
+
+func ephemeralAssignedReadyProbeScript(shellVar string, includeEphemeralReady bool) string {
+	if includeEphemeralReady {
+		return ""
+	}
+	filter := legacyEphemeralReadyFilterJQ(`select((.assignee // "") == $id)`, 1)
+	return `r=$(` + bdQueryEphemeralStatusQuietShell("open") + ` | ` +
+		`jq --arg id "$` + shellVar + `" ` + shellquote.Quote(filter) + ` 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; `
 }
 
 func poolDemandOriginGateScript() string {
@@ -3570,6 +3638,16 @@ func (a *Agent) ResolvedMaxActiveSessions(cfg *City) *int {
 // If OnDeath is set, returns it. Otherwise returns the default recovery hook
 // that unclaims in-progress work assigned to this concrete agent identity.
 func (a *Agent) EffectiveOnDeath() string {
+	return a.effectiveOnDeath(false)
+}
+
+// EffectiveOnDeathForBeads returns the default on_death command using the bd
+// compatibility semantics configured for the city.
+func (a *Agent) EffectiveOnDeathForBeads(beads BeadsConfig) string {
+	return a.effectiveOnDeath(beads.UsesBD105ReadySemantics())
+}
+
+func (a *Agent) effectiveOnDeath(includeEphemeralInProgress bool) string {
 	if a.OnDeath != "" {
 		return a.OnDeath
 	}
@@ -3577,15 +3655,21 @@ func (a *Agent) EffectiveOnDeath() string {
 	if a.PoolName != "" {
 		route = a.PoolName
 	}
+	_ = includeEphemeralInProgress
+	ephemeralRead := bdQueryEphemeralStatusQuietShell("in_progress") + ` | ` +
+		`jq -r --arg assignee ` + shellquote.Quote(a.QualifiedName()) + ` '.[] | select((.assignee // "") == $assignee) | [.id, (.metadata["gc.run_target"] // ""), (.metadata["gc.routed_to"] // "")] | @tsv' 2>/dev/null; `
 	// Reset both assignee and status: clearing assignee alone leaves the bead
 	// invisible to every work_query tier (Tier 1 needs assignee match, Tiers
 	// 2/3 only match "ready" status). The next worker re-claims via Tier 3.
 	// If routed metadata is missing entirely, backfill the canonical
 	// gc.run_target route so reopened direct-assigned work does not stay
 	// invisible.
-	return `bd list --assignee=` + a.QualifiedName() +
+	return `{ ` +
+		`bd list --assignee=` + a.QualifiedName() +
 		` --status=in_progress --json 2>/dev/null | ` +
-		`jq -r '.[] | [.id, (.metadata["gc.run_target"] // ""), (.metadata["gc.routed_to"] // "")] | @tsv' 2>/dev/null | ` +
+		`jq -r '.[] | [.id, (.metadata["gc.run_target"] // ""), (.metadata["gc.routed_to"] // "")] | @tsv' 2>/dev/null; ` +
+		ephemeralRead +
+		`} | ` +
 		`while IFS="$(printf '\t')" read -r id run_target routed_to; do ` +
 		`[ -z "$id" ] && continue; ` +
 		`if [ -n "$run_target" ] || [ -n "$routed_to" ]; then ` +
@@ -3599,6 +3683,16 @@ func (a *Agent) EffectiveOnDeath() string {
 // If OnBoot is set, returns it. Otherwise returns the default recovery hook
 // that unclaims in-progress work routed to this backing config.
 func (a *Agent) EffectiveOnBoot() string {
+	return a.effectiveOnBoot(false)
+}
+
+// EffectiveOnBootForBeads returns the default on_boot command using the bd
+// compatibility semantics configured for the city.
+func (a *Agent) EffectiveOnBootForBeads(beads BeadsConfig) string {
+	return a.effectiveOnBoot(beads.UsesBD105ReadySemantics())
+}
+
+func (a *Agent) effectiveOnBoot(includeEphemeralInProgress bool) string {
 	if a.OnBoot != "" {
 		return a.OnBoot
 	}
@@ -3606,12 +3700,16 @@ func (a *Agent) EffectiveOnBoot() string {
 	if a.PoolName != "" {
 		template = a.PoolName
 	}
+	_ = includeEphemeralInProgress
+	ephemeralRead := bdQueryEphemeralStatusQuietShell("in_progress") + ` | ` +
+		`jq -r --arg template "$template" '.[] | select((.assignee // "") == "") | select(((.metadata["gc.routed_to"] // "") == $template) or (((.metadata["gc.routed_to"] // "") == "") and ((.metadata["gc.run_target"] // "") == $template) and ((.metadata["gc.kind"] // "") == "workflow"))) | .id' 2>/dev/null; `
 	return `template=` + shellquote.Quote(template) + `; ` +
 		`{ ` +
 		`bd list --metadata-field "gc.routed_to=$template" --status=in_progress --no-assignee --json 2>/dev/null | ` +
 		`jq -r '.[].id' 2>/dev/null; ` +
 		`bd list --metadata-field "gc.run_target=$template" --metadata-field "gc.kind=workflow" --status=in_progress --no-assignee --json 2>/dev/null | ` +
 		`jq -r '.[] | select((.metadata["gc.routed_to"] // "") == "") | .id' 2>/dev/null; ` +
+		ephemeralRead +
 		`} | awk 'NF && !seen[$0]++' | ` +
 		`xargs -rI{} bd update {} --status open 2>/dev/null`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1190,6 +1190,10 @@ type BeadsConfig struct {
 	// This config surface is staged ahead of the native bead-event support;
 	// current hook behavior remains unchanged until lifecycle code opts in.
 	EventHooks *bool `toml:"event_hooks,omitempty" jsonschema:"default=true"`
+	// BDCompatibility selects the bd CLI semantics Gas City may rely on.
+	// Empty defaults to "bd-1.0.4", which keeps claimable work history-backed
+	// and avoids ready flags whose filtering is incomplete in bd 1.0.4.
+	BDCompatibility string `toml:"bd_compatibility,omitempty" jsonschema:"enum=bd-1.0.4,enum=bd-1.0.5"`
 	// Policies defines per-bead-use storage and garbage-collection defaults.
 	// Policy names are interpreted by higher-level systems; unknown names are
 	// preserved so packs can stage future policy classes without breaking load.
@@ -1200,6 +1204,34 @@ type BeadsConfig struct {
 // Unset preserves the current default of enabled hooks.
 func (b BeadsConfig) EventHooksEnabled() bool {
 	return b.EventHooks == nil || *b.EventHooks
+}
+
+const (
+	// BeadsBDCompatibility104 preserves behavior supported by installed bd
+	// 1.0.4, where ready filtering is reliable only for history-backed rows.
+	BeadsBDCompatibility104 = "bd-1.0.4"
+	// BeadsBDCompatibility105 opts into bd 1.0.5 ready/storage semantics.
+	BeadsBDCompatibility105 = "bd-1.0.5"
+)
+
+// NormalizedBDCompatibility returns the configured bd compatibility mode.
+// Empty and unknown values are treated as bd 1.0.4 by runtime code; validation
+// reports unknown values separately when loading user config.
+func (b BeadsConfig) NormalizedBDCompatibility() string {
+	switch b.BDCompatibility {
+	case "", BeadsBDCompatibility104:
+		return BeadsBDCompatibility104
+	case BeadsBDCompatibility105:
+		return BeadsBDCompatibility105
+	default:
+		return BeadsBDCompatibility104
+	}
+}
+
+// UsesBD105ReadySemantics reports whether generated bd ready commands may use
+// flags whose complete filter semantics require bd 1.0.5 or newer.
+func (b BeadsConfig) UsesBD105ReadySemantics() bool {
+	return b.NormalizedBDCompatibility() == BeadsBDCompatibility105
 }
 
 // BeadPolicyConfig holds storage and retention defaults for a named bead use.
@@ -3103,8 +3135,15 @@ func (a *Agent) AttachEnabled() bool {
 // target is passed as a positional argument to the outer sh -c command, not
 // interpolated into the nested shell body. That keeps routes containing shell
 // metacharacters as data instead of executable syntax.
-func bdReadyPoolDemandShell(limitFlag string) string {
-	return `bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json ` + limitFlag
+func bdReadyIncludeEphemeralArg(includeEphemeralReady bool) string {
+	if includeEphemeralReady {
+		return " --include-ephemeral"
+	}
+	return ""
+}
+
+func bdReadyPoolDemandShell(limitFlag string, includeEphemeralReady bool) string {
+	return `bd ready` + bdReadyIncludeEphemeralArg(includeEphemeralReady) + ` --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json ` + limitFlag
 }
 
 // bdReadyPoolDemandMigrationShell is a temporary raw compatibility probe for
@@ -3115,8 +3154,8 @@ func bdReadyPoolDemandShell(limitFlag string) string {
 // visible once a root carries gc.routed_to. This retirement-window fallback
 // requires jq in the default worker/reconciler environment; remove it with the
 // Go-side legacy candidates after the backfill completion tracked by ga-dhf44.
-func bdReadyPoolDemandMigrationShell(limitFlag string) string {
-	return `bd ready --include-ephemeral --metadata-field "gc.run_target=$target" --metadata-field "gc.kind=workflow" --unassigned --exclude-type=epic --json --sort oldest ` + limitFlag
+func bdReadyPoolDemandMigrationShell(limitFlag string, includeEphemeralReady bool) string {
+	return `bd ready` + bdReadyIncludeEphemeralArg(includeEphemeralReady) + ` --metadata-field "gc.run_target=$target" --metadata-field "gc.kind=workflow" --unassigned --exclude-type=epic --json --sort oldest ` + limitFlag
 }
 
 func poolDemandMigrationFilterJQ(limit int) string {
@@ -3131,23 +3170,23 @@ func poolDemandMigrationFilterJQ(limit int) string {
 // reads the first ready, unassigned, routed bead for the supplied target,
 // prints it, and exits 0. The caller appends a terminal fallthrough
 // (printf "[]") for the empty case.
-func poolDemandFirstRowFunctionScript() string {
+func poolDemandFirstRowFunctionScript(includeEphemeralReady bool) string {
 	return `probe_pool_demand() { ` +
 		`target="$1"; ` +
 		`[ -z "$target" ] && return 1; ` +
-		`r=$(` + routedReadyTierCommand() + `); ` +
+		`r=$(` + routedReadyTierCommand(includeEphemeralReady) + `); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
-		`legacy_candidates=$(` + bdReadyPoolDemandMigrationShell("--limit=20") + ` 2>/dev/null); ` +
+		`legacy_candidates=$(` + bdReadyPoolDemandMigrationShell("--limit=20", includeEphemeralReady) + ` 2>/dev/null); ` +
 		`r=$(printf "%s" "$legacy_candidates" | ` + poolDemandMigrationFilterJQ(1) + ` 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`return 1; ` +
 		`}; `
 }
 
-func routedReadyTierCommand() string {
+func routedReadyTierCommand(includeEphemeralReady bool) string {
 	// The shared predicate stays order-free so the count-form does no wasted
 	// sorting; the worker first-row path asks bd for the oldest candidate.
-	return bdReadyPoolDemandShell("--sort oldest --limit=1") + ` 2>/dev/null`
+	return bdReadyPoolDemandShell("--sort oldest --limit=1", includeEphemeralReady) + ` 2>/dev/null`
 }
 
 // poolDemandCountShell emits the reconciler count-form for target: it counts
@@ -3161,10 +3200,10 @@ func routedReadyTierCommand() string {
 // masquerade as "no demand", which would silently stop the pool from spawning.
 // The && chain ensures any non-zero bd exit short-circuits the whole expression
 // (TestEffectiveScaleCheckUsesReadyOnly).
-func poolDemandCountShell(target string) string {
+func poolDemandCountShell(target string, includeEphemeralReady bool) string {
 	script := `target="$1"; ` +
-		`ready_json=$(` + bdReadyPoolDemandShell("--limit 0") + `) || exit $?; ` +
-		`legacy_candidates=$(` + bdReadyPoolDemandMigrationShell("--limit 0") + `) || exit $?; ` +
+		`ready_json=$(` + bdReadyPoolDemandShell("--limit 0", includeEphemeralReady) + `) || exit $?; ` +
+		`legacy_candidates=$(` + bdReadyPoolDemandMigrationShell("--limit 0", includeEphemeralReady) + `) || exit $?; ` +
 		`legacy_json=$(printf "%s" "$legacy_candidates" | ` + poolDemandMigrationFilterJQ(0) + `) || exit $?; ` +
 		`printf "%s\n%s\n" "$ready_json" "$legacy_json" | jq -s "(add // []) | unique_by(.id) | length"`
 	return shellquote.Join([]string{"sh", "-c", script, "--", target})
@@ -3178,26 +3217,26 @@ func (a *Agent) poolDemandTarget() string {
 	return target
 }
 
-func standardAssignedWorkQueryScript() string {
+func standardAssignedWorkQueryScript(includeEphemeralReady bool) string {
 	return `for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
-		`r=$(bd list --include-ephemeral --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); ` +
+		`r=$(bd list --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
-		`r=$(bd ready --include-ephemeral --assignee="$id" --json --limit=1 2>/dev/null); ` +
+		`r=$(bd ready` + bdReadyIncludeEphemeralArg(includeEphemeralReady) + ` --assignee="$id" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; `
 }
 
-func legacyControlAssignedWorkQueryScript() string {
+func legacyControlAssignedWorkQueryScript(includeEphemeralReady bool) string {
 	return `for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 		`[ -z "$id" ] && continue; ` +
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd list --include-ephemeral --status in_progress --assignee="$cand" --json --limit=1 2>/dev/null); ` +
+		`r=$(bd list --status in_progress --assignee="$cand" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; ` +
@@ -3206,7 +3245,7 @@ func legacyControlAssignedWorkQueryScript() string {
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd ready --include-ephemeral --assignee="$cand" --json --limit=1 2>/dev/null); ` +
+		`r=$(bd ready` + bdReadyIncludeEphemeralArg(includeEphemeralReady) + ` --assignee="$cand" --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; `
@@ -3230,9 +3269,10 @@ func poolDemandOriginGateScript() string {
 //
 // State priority: in_progress+assigned (crash recovery) >
 // ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool).
-// Executable formula roots are ephemeral epics (mol wisp preserves the
-// template-epic IssueType and marks Ephemeral=true); molecule containers
-// are not routable demand.
+// Executable formula roots can be epic-typed; the bead storage policy decides
+// whether those roots are history-backed, no-history, or ephemeral for the
+// configured bd compatibility mode. Molecule containers are not routable
+// demand.
 //
 // Parent epics are excluded from the routed (pool) tier only
 // (--exclude-type=epic). An unassigned parent epic has no executable spec —
@@ -3240,12 +3280,12 @@ func poolDemandOriginGateScript() string {
 // undefined work (gc-udx; the repro is a routed parent epic, see
 // TestEffectiveWorkQuerySkipsEpicLeafScenario). The assigned tiers do NOT
 // exclude epics: work already assigned to this agent is owned, and the
-// patrol-loop pattern (gastown witness/refinery/deacon) self-assigns an
-// ephemeral epic wisp that the agent must resume after a session restart.
-// Excluding epics there silently stranded those wisps (gc hook exited 1 with
-// empty output). Roles that need different behavior still opt in via an
-// explicit work_query in their agent config; that custom query is returned
-// unchanged above.
+// patrol-loop pattern (gastown witness/refinery/deacon) can self-assign an
+// epic wisp that the agent must resume after a session restart. Excluding
+// epics there silently stranded those wisps (gc hook exited 1 with empty
+// output). Roles that need different behavior still opt in via an explicit
+// work_query in their agent config; that custom query is returned unchanged
+// above.
 //
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only
@@ -3255,22 +3295,32 @@ func poolDemandOriginGateScript() string {
 // EffectivePoolDemandQuery so reconciler spawn decisions and worker claim
 // decisions stay symmetric.
 func (a *Agent) EffectiveWorkQuery() string {
+	return a.effectiveWorkQuery(false)
+}
+
+// EffectiveWorkQueryForBeads returns the default work query using the bd
+// compatibility semantics configured for the city.
+func (a *Agent) EffectiveWorkQueryForBeads(beads BeadsConfig) string {
+	return a.effectiveWorkQuery(beads.UsesBD105ReadySemantics())
+}
+
+func (a *Agent) effectiveWorkQuery(includeEphemeralReady bool) string {
 	if a.WorkQuery != "" {
 		return a.WorkQuery
 	}
 	target := a.poolDemandTarget()
 	legacyTarget := legacyWorkflowControlQualifiedName(target)
 	if legacyTarget == "" {
-		script := standardAssignedWorkQueryScript() +
+		script := standardAssignedWorkQueryScript(includeEphemeralReady) +
 			poolDemandOriginGateScript() +
-			poolDemandFirstRowFunctionScript() +
+			poolDemandFirstRowFunctionScript(includeEphemeralReady) +
 			`probe_pool_demand "$1"; ` +
 			`printf "[]"`
 		return shellquote.Join([]string{"sh", "-c", script, "--", target})
 	}
-	script := legacyControlAssignedWorkQueryScript() +
+	script := legacyControlAssignedWorkQueryScript(includeEphemeralReady) +
 		poolDemandOriginGateScript() +
-		poolDemandFirstRowFunctionScript() +
+		poolDemandFirstRowFunctionScript(includeEphemeralReady) +
 		`probe_pool_demand "$1"; ` +
 		`probe_pool_demand "$2"; ` +
 		`printf "[]"`
@@ -3352,11 +3402,21 @@ func (a *Agent) DrainTimeoutDuration() time.Duration {
 // correspondence" and the protocol-mismatch class regression addressed
 // by PR #1516.
 func (a *Agent) EffectivePoolDemandQuery() string {
+	return a.effectivePoolDemandQuery(false)
+}
+
+// EffectivePoolDemandQueryForBeads returns the count-form demand query using
+// the bd compatibility semantics configured for the city.
+func (a *Agent) EffectivePoolDemandQueryForBeads(beads BeadsConfig) string {
+	return a.effectivePoolDemandQuery(beads.UsesBD105ReadySemantics())
+}
+
+func (a *Agent) effectivePoolDemandQuery(includeEphemeralReady bool) string {
 	if a.ScaleCheck != "" {
 		return a.ScaleCheck
 	}
 	target := a.poolDemandTarget()
-	return poolDemandCountShell(target)
+	return poolDemandCountShell(target, includeEphemeralReady)
 }
 
 // EffectiveScaleCheck returns the scale check command for this agent.
@@ -3523,7 +3583,7 @@ func (a *Agent) EffectiveOnDeath() string {
 	// If routed metadata is missing entirely, backfill the canonical
 	// gc.run_target route so reopened direct-assigned work does not stay
 	// invisible.
-	return `bd list --include-ephemeral --assignee=` + a.QualifiedName() +
+	return `bd list --assignee=` + a.QualifiedName() +
 		` --status=in_progress --json 2>/dev/null | ` +
 		`jq -r '.[] | [.id, (.metadata["gc.run_target"] // ""), (.metadata["gc.routed_to"] // "")] | @tsv' 2>/dev/null | ` +
 		`while IFS="$(printf '\t')" read -r id run_target routed_to; do ` +
@@ -3548,9 +3608,9 @@ func (a *Agent) EffectiveOnBoot() string {
 	}
 	return `template=` + shellquote.Quote(template) + `; ` +
 		`{ ` +
-		`bd list --include-ephemeral --metadata-field "gc.routed_to=$template" --status=in_progress --no-assignee --json 2>/dev/null | ` +
+		`bd list --metadata-field "gc.routed_to=$template" --status=in_progress --no-assignee --json 2>/dev/null | ` +
 		`jq -r '.[].id' 2>/dev/null; ` +
-		`bd list --include-ephemeral --metadata-field "gc.run_target=$template" --metadata-field "gc.kind=workflow" --status=in_progress --no-assignee --json 2>/dev/null | ` +
+		`bd list --metadata-field "gc.run_target=$template" --metadata-field "gc.kind=workflow" --status=in_progress --no-assignee --json 2>/dev/null | ` +
 		`jq -r '.[] | select((.metadata["gc.routed_to"] // "") == "") | .id' 2>/dev/null; ` +
 		`} | awk 'NF && !seen[$0]++' | ` +
 		`xargs -rI{} bd update {} --status open 2>/dev/null`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1755,6 +1755,77 @@ func TestEffectiveWorkQueryBD105CompatibilityOptIn(t *testing.T) {
 	}
 }
 
+func TestEffectiveWorkQueryBD104SurfacesLegacyEphemeralRoutedWork(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "foundations"}
+	bdScript := `#!/bin/sh
+set -eu
+case "$1" in
+  list)
+    printf '[]'
+    ;;
+  ready)
+    printf '[]'
+    ;;
+  query)
+    case "$*" in
+      *"ephemeral=true AND status=open"*)
+        printf '[{"id":"ga-legacy-wisp","issue_type":"task","status":"open","ephemeral":true,"created_at":"2026-05-01T00:00:00Z","metadata":{"gc.routed_to":"foundations/worker"}}]'
+        ;;
+      *)
+        printf '[]'
+        ;;
+    esac
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`
+
+	out := runEffectiveWorkQuery(t, a, nil, bdScript)
+	if !strings.Contains(out, "ga-legacy-wisp") {
+		t.Fatalf("EffectiveWorkQuery() = %q, want legacy ephemeral routed work", out)
+	}
+
+	demandOut := strings.TrimSpace(runShellWithFakeBd(t, a.EffectivePoolDemandQuery(), nil, bdScript))
+	if demandOut == "0" {
+		t.Fatalf("EffectivePoolDemandQuery() = %q, want legacy ephemeral routed demand counted", demandOut)
+	}
+}
+
+func TestEffectiveWorkQueryBD105SurfacesEphemeralInProgressAssignedWork(t *testing.T) {
+	a := Agent{Name: "dog", Dir: "hello-world"}
+	out := runEffectiveWorkQueryForBeads(t, a, BeadsConfig{BDCompatibility: BeadsBDCompatibility105}, map[string]string{
+		"GC_SESSION_NAME": "hello-world/dog",
+	}, `#!/bin/sh
+set -eu
+case "$1" in
+  list)
+    printf '[]'
+    ;;
+  query)
+    case "$*" in
+      *"ephemeral=true AND status=in_progress"*)
+        printf '[{"id":"ga-ephemeral-progress","assignee":"hello-world/dog","status":"in_progress","ephemeral":true}]'
+        ;;
+      *)
+        printf '[]'
+        ;;
+    esac
+    ;;
+  ready)
+    printf '[]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if !strings.Contains(out, "ga-ephemeral-progress") {
+		t.Fatalf("EffectiveWorkQueryForBeads(bd-1.0.5) did not surface assigned ephemeral in-progress work: %q", out)
+	}
+}
+
 func TestEffectiveWorkQueryCustom(t *testing.T) {
 	a := Agent{Name: "mayor", WorkQuery: "bd ready --label=pool:polecats"}
 	got := a.EffectiveWorkQuery()
@@ -5566,6 +5637,76 @@ esac
 	}
 }
 
+func TestEffectiveOnDeathForBeadsBD105ReopensEphemeralInProgressWork(t *testing.T) {
+	a := Agent{
+		Name:              "dog-1",
+		Dir:               "hello-world",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
+		PoolName: "hello-world/dog",
+	}
+
+	log := runLifecycleHookCommand(t, a.EffectiveOnDeathForBeads(BeadsConfig{BDCompatibility: BeadsBDCompatibility105}), `#!/bin/sh
+set -eu
+case "$1" in
+  list)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    printf '[]'
+    ;;
+  query)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    printf '[{"id":"ga-ephemeral-death","assignee":"hello-world/dog-1","status":"in_progress","ephemeral":true,"metadata":{}}]'
+    ;;
+  update)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`)
+	if !strings.Contains(log, "query --json ephemeral=true AND status=in_progress --limit=0") {
+		t.Fatalf("hook log = %q, want ephemeral in-progress query", log)
+	}
+	if !strings.Contains(log, "update ga-ephemeral-death --assignee  --status open --set-metadata gc.run_target=hello-world/dog") {
+		t.Fatalf("hook log = %q, want ephemeral in-progress work reopened with fallback route", log)
+	}
+}
+
+func TestEffectiveOnDeathDefaultReopensLegacyEphemeralInProgressWork(t *testing.T) {
+	a := Agent{
+		Name:              "dog-1",
+		Dir:               "hello-world",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
+		PoolName: "hello-world/dog",
+	}
+
+	log := runLifecycleHookCommand(t, a.EffectiveOnDeath(), `#!/bin/sh
+set -eu
+case "$1" in
+  list)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    printf '[]'
+    ;;
+  query)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    printf '[{"id":"ga-legacy-ephemeral-death","assignee":"hello-world/dog-1","status":"in_progress","ephemeral":true,"metadata":{}}]'
+    ;;
+  update)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`)
+	if !strings.Contains(log, "query --json ephemeral=true AND status=in_progress --limit=0") {
+		t.Fatalf("hook log = %q, want legacy ephemeral in-progress query", log)
+	}
+	if !strings.Contains(log, "update ga-legacy-ephemeral-death --assignee  --status open --set-metadata gc.run_target=hello-world/dog") {
+		t.Fatalf("hook log = %q, want legacy ephemeral in-progress work reopened with fallback route", log)
+	}
+}
+
 func TestEffectiveOnBootDefault(t *testing.T) {
 	a := Agent{
 		Name:              "dog",
@@ -5668,6 +5809,76 @@ esac
 	}
 	if !strings.Contains(log, "update ga-run-target --status open") {
 		t.Fatalf("hook log = %q, want ownerless run_target wisp reopened", log)
+	}
+}
+
+func TestEffectiveOnBootForBeadsBD105ReopensOwnerlessEphemeralRoutedWork(t *testing.T) {
+	a := Agent{
+		Name:              "dog-1",
+		Dir:               "hello-world",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
+		PoolName: "hello-world/dog",
+	}
+
+	log := runLifecycleHookCommand(t, a.EffectiveOnBootForBeads(BeadsConfig{BDCompatibility: BeadsBDCompatibility105}), `#!/bin/sh
+set -eu
+case "$1" in
+  list)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    printf '[]'
+    ;;
+  query)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    printf '[{"id":"ga-ephemeral-boot","status":"in_progress","ephemeral":true,"metadata":{"gc.routed_to":"hello-world/dog"}}]'
+    ;;
+  update)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`)
+	if !strings.Contains(log, "query --json ephemeral=true AND status=in_progress --limit=0") {
+		t.Fatalf("hook log = %q, want ephemeral in-progress query", log)
+	}
+	if !strings.Contains(log, "update ga-ephemeral-boot --status open") {
+		t.Fatalf("hook log = %q, want ownerless ephemeral routed work reopened", log)
+	}
+}
+
+func TestEffectiveOnBootDefaultReopensLegacyOwnerlessEphemeralRoutedWork(t *testing.T) {
+	a := Agent{
+		Name:              "dog-1",
+		Dir:               "hello-world",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
+		PoolName: "hello-world/dog",
+	}
+
+	log := runLifecycleHookCommand(t, a.EffectiveOnBoot(), `#!/bin/sh
+set -eu
+case "$1" in
+  list)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    printf '[]'
+    ;;
+  query)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    printf '[{"id":"ga-legacy-ephemeral-boot","status":"in_progress","ephemeral":true,"metadata":{"gc.routed_to":"hello-world/dog"}}]'
+    ;;
+  update)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`)
+	if !strings.Contains(log, "query --json ephemeral=true AND status=in_progress --limit=0") {
+		t.Fatalf("hook log = %q, want legacy ephemeral in-progress query", log)
+	}
+	if !strings.Contains(log, "update ga-legacy-ephemeral-boot --status open") {
+		t.Fatalf("hook log = %q, want ownerless legacy ephemeral routed work reopened", log)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -684,7 +684,7 @@ storage = "no_history"
 delete_after_close = "1d12h"
 
 [beads.policies.workflow]
-storage = "ephemeral"
+storage = "no_history"
 
 [[agent]]
 name = "mayor"
@@ -707,8 +707,8 @@ name = "mayor"
 		t.Errorf("control.DeleteAfterCloseDuration() = %v, want 36h", got)
 	}
 	workflow := cfg.Beads.Policies["workflow"]
-	if got := workflow.NormalizedStorage(); got != BeadStorageEphemeral {
-		t.Errorf("workflow.NormalizedStorage() = %q, want %q", got, BeadStorageEphemeral)
+	if got := workflow.NormalizedStorage(); got != BeadStorageNoHistory {
+		t.Errorf("workflow.NormalizedStorage() = %q, want %q", got, BeadStorageNoHistory)
 	}
 }
 
@@ -1722,13 +1722,16 @@ func TestEffectiveWorkQueryDefault(t *testing.T) {
 	// Tiered query: tier 3 routes via gc.routed_to, with a temporary
 	// gc.run_target migration fallback for pre-backfill workflow roots, and
 	// tiers 1-2 resolve by assignee.
-	if !strings.Contains(got, `bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json --sort oldest --limit=1`) {
+	if strings.Contains(got, `--include-ephemeral`) {
+		t.Errorf("EffectiveWorkQuery() default must be bd 1.0.4-compatible without --include-ephemeral: %q", got)
+	}
+	if !strings.Contains(got, `bd ready --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json --sort oldest --limit=1`) {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 pool-demand probe: %q", got)
 	}
 	if !strings.Contains(got, "-- mayor") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 target argument: %q", got)
 	}
-	if !strings.Contains(got, `bd ready --include-ephemeral --metadata-field "gc.run_target=$target" --metadata-field "gc.kind=workflow" --unassigned --exclude-type=epic --json --sort oldest --limit=20`) {
+	if !strings.Contains(got, `bd ready --metadata-field "gc.run_target=$target" --metadata-field "gc.kind=workflow" --unassigned --exclude-type=epic --json --sort oldest --limit=20`) {
 		t.Errorf("EffectiveWorkQuery() missing run_target migration fallback: %q", got)
 	}
 	for _, want := range []string{`.metadata`, `.[:1]`} {
@@ -1738,6 +1741,17 @@ func TestEffectiveWorkQueryDefault(t *testing.T) {
 	}
 	if !strings.Contains(got, `"$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"`) {
 		t.Errorf("EffectiveWorkQuery() missing multi-identifier resolution: %q", got)
+	}
+}
+
+func TestEffectiveWorkQueryBD105CompatibilityOptIn(t *testing.T) {
+	a := Agent{Name: "mayor"}
+	got := a.EffectiveWorkQueryForBeads(BeadsConfig{BDCompatibility: BeadsBDCompatibility105})
+	if !strings.Contains(got, `bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json --sort oldest --limit=1`) {
+		t.Errorf("EffectiveWorkQueryForBeads(bd-1.0.5) missing include-ephemeral routed probe: %q", got)
+	}
+	if !strings.Contains(got, `bd ready --include-ephemeral --assignee="$id" --json --limit=1`) {
+		t.Errorf("EffectiveWorkQueryForBeads(bd-1.0.5) missing include-ephemeral assigned probe: %q", got)
 	}
 }
 
@@ -1848,11 +1862,11 @@ func TestEffectiveWorkQueryControlDispatcherClaimsLegacyAssignedWork(t *testing.
 	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
 	got := a.EffectiveWorkQuery()
 	for _, want := range []string{
-		`bd list --include-ephemeral --status in_progress --assignee="$cand"`,
-		`bd ready --include-ephemeral --assignee="$cand"`,
+		`bd list --status in_progress --assignee="$cand"`,
+		`bd ready --assignee="$cand"`,
 	} {
 		if !strings.Contains(got, want) {
-			t.Fatalf("EffectiveWorkQuery() = %q, want ephemeral-aware legacy assigned tier %q", got, want)
+			t.Fatalf("EffectiveWorkQuery() = %q, want storage-aware legacy assigned tier %q", got, want)
 		}
 	}
 	out := runEffectiveWorkQuery(t, a, map[string]string{
@@ -1861,14 +1875,14 @@ func TestEffectiveWorkQueryControlDispatcherClaimsLegacyAssignedWork(t *testing.
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "list --include-ephemeral --status in_progress --assignee=gascity--control-dispatcher --json --limit=1"|\
-  "list --include-ephemeral --status in_progress --assignee=gascity/control-dispatcher --json --limit=1"|\
-  "list --include-ephemeral --status in_progress --assignee=gascity--workflow-control --json --limit=1"|\
-  "list --include-ephemeral --status in_progress --assignee=gascity/workflow-control --json --limit=1")
+  "list --status in_progress --assignee=gascity--control-dispatcher --json --limit=1"|\
+  "list --status in_progress --assignee=gascity/control-dispatcher --json --limit=1"|\
+  "list --status in_progress --assignee=gascity--workflow-control --json --limit=1"|\
+  "list --status in_progress --assignee=gascity/workflow-control --json --limit=1")
     printf '[]'
     ;;
-  "ready --include-ephemeral --assignee=gascity--workflow-control --json --limit=1"|\
-  "ready --include-ephemeral --assignee=gascity/workflow-control --json --limit=1")
+  "ready --assignee=gascity--workflow-control --json --limit=1"|\
+  "ready --assignee=gascity/workflow-control --json --limit=1")
     printf '[{"id":"ga-legacy-ready"}]'
     ;;
   *)
@@ -1889,7 +1903,10 @@ case "$*" in
   *"ready --include-ephemeral"*"--metadata-field gc.routed_to=gascity/control-dispatcher"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
     printf '[]'
     ;;
-  *"ready --include-ephemeral"*"--metadata-field gc.routed_to=gascity/workflow-control"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
+  *"ready --metadata-field gc.routed_to=gascity/control-dispatcher"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
+    printf '[]'
+    ;;
+  *"ready --metadata-field gc.routed_to=gascity/workflow-control"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
     printf '[{"id":"ga-legacy-route"}]'
     ;;
   *)
@@ -1906,11 +1923,11 @@ func TestEffectiveWorkQueryRoutedQueueUsesNativeOldestSortAcrossReadyTiers(t *te
 	a := Agent{Name: "worker", Dir: "hello-world"}
 	got := a.EffectiveWorkQuery()
 	for _, want := range []string{
-		`bd list --include-ephemeral --status in_progress --assignee="$id"`,
-		`bd ready --include-ephemeral --assignee="$id"`,
+		`bd list --status in_progress --assignee="$id"`,
+		`bd ready --assignee="$id"`,
 	} {
 		if !strings.Contains(got, want) {
-			t.Fatalf("EffectiveWorkQuery() = %q, want ephemeral-aware assigned tier %q", got, want)
+			t.Fatalf("EffectiveWorkQuery() = %q, want storage-aware assigned tier %q", got, want)
 		}
 	}
 	out := runEffectiveWorkQuery(t, a, map[string]string{
@@ -1918,7 +1935,7 @@ func TestEffectiveWorkQueryRoutedQueueUsesNativeOldestSortAcrossReadyTiers(t *te
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "ready --include-ephemeral --metadata-field gc.routed_to=hello-world/worker --unassigned --exclude-type=epic --json --sort oldest --limit=1")
+  "ready --metadata-field gc.routed_to=hello-world/worker --unassigned --exclude-type=epic --json --sort oldest --limit=1")
     printf '[{"id":"older-no-history","priority":2,"created_at":"2026-05-20T06:09:30Z","no_history":true}]'
     ;;
   *)
@@ -1934,6 +1951,28 @@ esac
 	}
 }
 
+func TestGeneratedBdReadCommandsStayBd104StorageCompatible(t *testing.T) {
+	a := Agent{
+		Name:              "dog-1",
+		Dir:               "hello-world",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
+		PoolName: "hello-world/dog",
+	}
+	commands := map[string]string{
+		"work_query": a.EffectiveWorkQuery(),
+		"on_death":   a.EffectiveOnDeath(),
+		"on_boot":    a.EffectiveOnBoot(),
+	}
+	for name, command := range commands {
+		if strings.Contains(command, "list --include-ephemeral") || strings.Contains(command, "bd list --include-ephemeral") {
+			t.Fatalf("%s command uses bd 1.0.4-incompatible list flag: %s", name, command)
+		}
+	}
+	if strings.Contains(commands["work_query"], "bd ready --include-ephemeral") {
+		t.Fatalf("work query = %q, default must stay bd 1.0.4-compatible and omit --include-ephemeral", commands["work_query"])
+	}
+}
+
 func TestEffectiveWorkQueryRoutedQueueUsesOldestBeforePriority(t *testing.T) {
 	a := Agent{Name: "worker", Dir: "hello-world"}
 	out := runEffectiveWorkQuery(t, a, map[string]string{
@@ -1941,7 +1980,7 @@ func TestEffectiveWorkQueryRoutedQueueUsesOldestBeforePriority(t *testing.T) {
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  *"ready --include-ephemeral"*"--metadata-field gc.routed_to=hello-world/worker"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
+  *"ready --metadata-field gc.routed_to=hello-world/worker"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
     printf '[{"id":"older-p2","priority":2,"created_at":"2026-05-20T06:09:30Z"}]'
     ;;
   *)
@@ -1964,10 +2003,10 @@ func TestEffectiveWorkQueryRoutedFallbackUsesNativeOldestSort(t *testing.T) {
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  *"ready --include-ephemeral"*"--metadata-field gc.routed_to=hello-world/worker"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
+  *"ready --metadata-field gc.routed_to=hello-world/worker"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=1"*)
     printf '[]'
     ;;
-  *"ready --include-ephemeral"*"--metadata-field gc.run_target=hello-world/worker"*"--metadata-field gc.kind=workflow"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=20"*)
+  *"ready --metadata-field gc.run_target=hello-world/worker"*"--metadata-field gc.kind=workflow"*"--unassigned"*"--exclude-type=epic"*"--json"*"--sort oldest"*"--limit=20"*)
     printf '[{"id":"older-fallback","priority":2,"created_at":"2026-05-20T06:09:30Z","metadata":{"gc.kind":"workflow","gc.run_target":"hello-world/worker"}}]'
     ;;
   *)
@@ -2012,10 +2051,10 @@ func TestEffectiveWorkQueryExcludesEpics(t *testing.T) {
 	// resume its own assigned ephemeral epic wisp (the patrol-loop pattern).
 	wantPresent := []string{
 		// routed/pool tier still excludes epics (gc-udx guard)
-		`bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json`,
+		`bd ready --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json`,
 		// assigned tiers carry NO epic exclusion
-		`bd list --include-ephemeral --status in_progress --assignee="$id" --json`,
-		`bd ready --include-ephemeral --assignee="$id" --json`,
+		`bd list --status in_progress --assignee="$id" --json`,
+		`bd ready --assignee="$id" --json`,
 		`-- hello-world/worker`,
 	}
 	for _, want := range wantPresent {
@@ -2038,9 +2077,9 @@ func TestEffectiveWorkQueryExcludesEpicsControlDispatcher(t *testing.T) {
 	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
 	got := a.EffectiveWorkQuery()
 	wantPresent := []string{
-		`bd ready --include-ephemeral --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json`,
-		`bd list --include-ephemeral --status in_progress --assignee="$cand" --json`,
-		`bd ready --include-ephemeral --assignee="$cand" --json`,
+		`bd ready --metadata-field "gc.routed_to=$target" --unassigned --exclude-type=epic --json`,
+		`bd list --status in_progress --assignee="$cand" --json`,
+		`bd ready --assignee="$cand" --json`,
 		`-- gascity/control-dispatcher gascity/workflow-control`,
 	}
 	for _, want := range wantPresent {
@@ -2065,7 +2104,7 @@ func TestEffectiveWorkQueryExcludesEpicsControlDispatcher(t *testing.T) {
 // still excludes epics — see TestEffectiveWorkQuerySkipsEpicLeafScenario.
 func TestEffectiveWorkQueryAssignedTierSurfacesEpicWisp(t *testing.T) {
 	a := Agent{Name: "witness", Dir: "hello-world"}
-	out := runEffectiveWorkQuery(t, a, map[string]string{
+	out := runEffectiveWorkQueryForBeads(t, a, BeadsConfig{BDCompatibility: BeadsBDCompatibility105}, map[string]string{
 		"GC_SESSION_ID":     "witness-sess",
 		"GC_SESSION_ORIGIN": "ephemeral",
 	}, `#!/bin/sh
@@ -2076,7 +2115,7 @@ case "$1" in
       *"--assignee=witness-sess"*"--exclude-type=epic"*)
         # real bd drops the epic-typed wisp when epics are excluded
         printf '[]' ;;
-      *"--assignee=witness-sess"*)
+      *"ready --include-ephemeral"*"--assignee=witness-sess"*)
         printf '[{"id":"patrol-wisp","issue_type":"epic","ephemeral":true}]' ;;
       *) printf '[]' ;;
     esac ;;
@@ -2361,11 +2400,11 @@ func TestPoolDemandPredicateSharedWithWorkQuery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wq := tt.agent.EffectiveWorkQuery()
 			demand := tt.agent.EffectivePoolDemandQuery()
-			workPredicate := bdReadyPoolDemandShell("--sort oldest --limit=1")
+			workPredicate := bdReadyPoolDemandShell("--sort oldest --limit=1", false)
 			if !strings.Contains(wq, workPredicate) {
 				t.Errorf("EffectiveWorkQuery() missing shared predicate %q in %q", workPredicate, wq)
 			}
-			migrationWorkPredicate := bdReadyPoolDemandMigrationShell("--limit=20")
+			migrationWorkPredicate := bdReadyPoolDemandMigrationShell("--limit=20", false)
 			if !strings.Contains(wq, migrationWorkPredicate) {
 				t.Errorf("EffectiveWorkQuery() missing shared migration predicate %q in %q", migrationWorkPredicate, wq)
 			}
@@ -2374,11 +2413,11 @@ func TestPoolDemandPredicateSharedWithWorkQuery(t *testing.T) {
 					t.Errorf("EffectiveWorkQuery() missing migration filter fragment %q in %q", want, wq)
 				}
 			}
-			countPredicate := bdReadyPoolDemandShell("--limit 0")
+			countPredicate := bdReadyPoolDemandShell("--limit 0", false)
 			if !strings.Contains(demand, countPredicate) {
 				t.Errorf("EffectivePoolDemandQuery() missing shared predicate %q in %q", countPredicate, demand)
 			}
-			migrationCountPredicate := bdReadyPoolDemandMigrationShell("--limit 0")
+			migrationCountPredicate := bdReadyPoolDemandMigrationShell("--limit 0", false)
 			if !strings.Contains(demand, migrationCountPredicate) {
 				t.Errorf("EffectivePoolDemandQuery() missing shared migration predicate %q in %q", migrationCountPredicate, demand)
 			}
@@ -2509,7 +2548,7 @@ func TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			bdScript := `#!/bin/sh
 case "$*" in
-  *"ready --include-ephemeral"*"--metadata-field gc.routed_to=` + tc.target + `"*"--unassigned"*"--exclude-type=epic"*)
+  *"ready --metadata-field gc.routed_to=` + tc.target + `"*"--unassigned"*"--exclude-type=epic"*)
     printf '%s' '` + tc.bdReadyOutput + `'
     ;;
   *)
@@ -4983,6 +5022,11 @@ func runEffectiveWorkQuery(t *testing.T, a Agent, env map[string]string, bdScrip
 	return runShellWithFakeBd(t, a.EffectiveWorkQuery(), env, bdScript)
 }
 
+func runEffectiveWorkQueryForBeads(t *testing.T, a Agent, beads BeadsConfig, env map[string]string, bdScript string) string {
+	t.Helper()
+	return runShellWithFakeBd(t, a.EffectiveWorkQueryForBeads(beads), env, bdScript)
+}
+
 // runShellWithFakeBd executes shellCmd with a fake `bd` script on PATH so
 // shared-predicate tests can exercise EffectiveWorkQuery and
 // EffectivePoolDemandQuery against the same simulated bd state.
@@ -5395,7 +5439,7 @@ func TestEffectiveOnDeathDefault(t *testing.T) {
 		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
 	}
 	got := a.EffectiveOnDeath()
-	for _, want := range []string{"bd list --include-ephemeral --assignee=myrig/dog", "--status=in_progress", `--assignee "" --status open`, "--set-metadata 'gc.run_target=myrig/dog'"} {
+	for _, want := range []string{"bd list --assignee=myrig/dog", "--status=in_progress", `--assignee "" --status open`, "--set-metadata 'gc.run_target=myrig/dog'"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnDeath() = %q, want %q", got, want)
 		}
@@ -5416,7 +5460,7 @@ func TestEffectiveOnDeathCustom(t *testing.T) {
 func TestEffectiveOnDeathFixedAgent(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveOnDeath()
-	for _, want := range []string{"bd list --include-ephemeral --assignee=mayor", "--status=in_progress", `--assignee "" --status open`, "--set-metadata 'gc.run_target=mayor'"} {
+	for _, want := range []string{"bd list --assignee=mayor", "--status=in_progress", `--assignee "" --status open`, "--set-metadata 'gc.run_target=mayor'"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnDeath() = %q, want %q", got, want)
 		}
@@ -5446,8 +5490,8 @@ case "$1" in
     ;;
 esac
 `)
-	if !strings.Contains(log, "list --include-ephemeral --assignee=hello-world/dog-1 --status=in_progress --json") {
-		t.Fatalf("hook log = %q, want ephemeral-aware list query", log)
+	if !strings.Contains(log, "list --assignee=hello-world/dog-1 --status=in_progress --json") {
+		t.Fatalf("hook log = %q, want storage-spanning list query", log)
 	}
 	if !strings.Contains(log, "--status open") {
 		t.Fatalf("hook log = %q, want reopened status", log)
@@ -5480,8 +5524,8 @@ case "$1" in
     ;;
 esac
 `)
-	if !strings.Contains(log, "list --include-ephemeral --assignee=hello-world/dog-1 --status=in_progress --json") {
-		t.Fatalf("hook log = %q, want ephemeral-aware list query", log)
+	if !strings.Contains(log, "list --assignee=hello-world/dog-1 --status=in_progress --json") {
+		t.Fatalf("hook log = %q, want storage-spanning list query", log)
 	}
 	if !strings.Contains(log, "--status open") {
 		t.Fatalf("hook log = %q, want reopened status", log)
@@ -5585,8 +5629,8 @@ case "$1" in
     ;;
 esac
 `)
-	if !strings.Contains(log, "list --include-ephemeral --metadata-field gc.routed_to=hello-world/dog --status=in_progress --no-assignee --json") {
-		t.Fatalf("hook log = %q, want ephemeral-aware routed list query", log)
+	if !strings.Contains(log, "list --metadata-field gc.routed_to=hello-world/dog --status=in_progress --no-assignee --json") {
+		t.Fatalf("hook log = %q, want storage-spanning routed list query", log)
 	}
 	if !strings.Contains(log, "update ga-wisp --status open") {
 		t.Fatalf("hook log = %q, want ownerless wisp reopened", log)
@@ -5619,8 +5663,8 @@ case "$1" in
     ;;
 esac
 `)
-	if !strings.Contains(log, "list --include-ephemeral --metadata-field gc.run_target=hello-world/dog --metadata-field gc.kind=workflow --status=in_progress --no-assignee --json") {
-		t.Fatalf("hook log = %q, want ephemeral-aware run_target list query", log)
+	if !strings.Contains(log, "list --metadata-field gc.run_target=hello-world/dog --metadata-field gc.kind=workflow --status=in_progress --no-assignee --json") {
+		t.Fatalf("hook log = %q, want storage-spanning run_target list query", log)
 	}
 	if !strings.Contains(log, "update ga-run-target --status open") {
 		t.Fatalf("hook log = %q, want ownerless run_target wisp reopened", log)

--- a/internal/config/session_model_phase0_spec_test.go
+++ b/internal/config/session_model_phase0_spec_test.go
@@ -81,7 +81,7 @@ func TestPhase0ConfigDefaults_WorkQueryIsOriginAware(t *testing.T) {
 	if !strings.Contains(got, "ephemeral") {
 		t.Fatalf("EffectiveWorkQuery() = %q, want origin-specific ephemeral generic queue tier", got)
 	}
-	if !strings.Contains(got, `bd ready --include-ephemeral --metadata-field "gc.routed_to=$target"`) || !strings.Contains(got, "-- myrig/worker") {
+	if !strings.Contains(got, `bd ready --metadata-field "gc.routed_to=$target"`) || !strings.Contains(got, "-- myrig/worker") {
 		t.Fatalf("EffectiveWorkQuery() = %q, want qualified config route argument", got)
 	}
 }
@@ -113,7 +113,7 @@ func TestPhase0ConfigDefaults_OnDeathUnclaimsAssignedWorkByDefault(t *testing.T)
 
 	got := a.EffectiveOnDeath()
 	for _, want := range []string{
-		"bd list --include-ephemeral --assignee=myrig/worker",
+		"bd list --assignee=myrig/worker",
 		"--status=in_progress",
 		"--assignee \"\"",
 	} {

--- a/internal/config/validate_durations_test.go
+++ b/internal/config/validate_durations_test.go
@@ -197,6 +197,96 @@ func TestValidateDurationsRejectsNonCanonicalBeadPolicyStorage(t *testing.T) {
 	}
 }
 
+func TestValidateBeadPolicyStorageCompatibilityAllowsBD104SafePolicies(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			Policies: map[string]BeadPolicyConfig{
+				"session":        {Storage: BeadStorageNoHistory},
+				"wait":           {Storage: BeadStorageNoHistory},
+				"nudge":          {Storage: BeadStorageNoHistory},
+				"order_tracking": {Storage: BeadStorageNoHistory},
+				"workflow":       {Storage: BeadStorageHistory},
+				"wisp":           {Storage: BeadStorageHistory},
+			},
+		},
+	}
+	if err := ValidateBeadPolicyStorageCompatibility(cfg, "city.toml"); err != nil {
+		t.Fatalf("ValidateBeadPolicyStorageCompatibility: %v", err)
+	}
+
+	cfg.Beads.Policies["session"] = BeadPolicyConfig{Storage: BeadStorageHistory}
+	cfg.Beads.Policies["wait"] = BeadPolicyConfig{Storage: BeadStorageHistory}
+	cfg.Beads.Policies["nudge"] = BeadPolicyConfig{Storage: BeadStorageHistory}
+	cfg.Beads.Policies["order_tracking"] = BeadPolicyConfig{Storage: BeadStorageHistory}
+	cfg.Beads.Policies["workflow"] = BeadPolicyConfig{Storage: BeadStorageHistory}
+	cfg.Beads.Policies["wisp"] = BeadPolicyConfig{Storage: BeadStorageHistory}
+	if err := ValidateBeadPolicyStorageCompatibility(cfg, "city.toml"); err != nil {
+		t.Fatalf("ValidateBeadPolicyStorageCompatibility with history overrides: %v", err)
+	}
+}
+
+func TestValidateBeadPolicyStorageCompatibilityAllowsBD105SafePolicies(t *testing.T) {
+	cfg := &City{
+		Beads: BeadsConfig{
+			BDCompatibility: BeadsBDCompatibility105,
+			Policies: map[string]BeadPolicyConfig{
+				"session":        {Storage: BeadStorageNoHistory},
+				"wait":           {Storage: BeadStorageNoHistory},
+				"nudge":          {Storage: BeadStorageNoHistory},
+				"order_tracking": {Storage: BeadStorageNoHistory},
+				"workflow":       {Storage: BeadStorageNoHistory},
+				"wisp":           {Storage: BeadStorageEphemeral},
+			},
+		},
+	}
+	if err := ValidateBeadPolicyStorageCompatibility(cfg, "city.toml"); err != nil {
+		t.Fatalf("ValidateBeadPolicyStorageCompatibility: %v", err)
+	}
+
+	cfg.Beads.Policies["wisp"] = BeadPolicyConfig{Storage: BeadStorageNoHistory}
+	if err := ValidateBeadPolicyStorageCompatibility(cfg, "city.toml"); err != nil {
+		t.Fatalf("ValidateBeadPolicyStorageCompatibility with no-history wisp override: %v", err)
+	}
+}
+
+func TestValidateBeadPolicyStorageCompatibilityRejectsBD104UnsafeOverrides(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  string
+		storage string
+	}{
+		{name: "wisp no-history", policy: "wisp", storage: BeadStorageNoHistory},
+		{name: "wisp ephemeral", policy: "wisp", storage: BeadStorageEphemeral},
+		{name: "session ephemeral", policy: "session", storage: BeadStorageEphemeral},
+		{name: "wait ephemeral", policy: "wait", storage: BeadStorageEphemeral},
+		{name: "nudge ephemeral", policy: "nudge", storage: BeadStorageEphemeral},
+		{name: "order tracking ephemeral", policy: "order_tracking", storage: BeadStorageEphemeral},
+		{name: "workflow no-history", policy: "workflow", storage: BeadStorageNoHistory},
+		{name: "workflow ephemeral", policy: "workflow", storage: BeadStorageEphemeral},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &City{
+				Beads: BeadsConfig{
+					Policies: map[string]BeadPolicyConfig{
+						tt.policy: {Storage: tt.storage},
+					},
+				},
+			}
+			err := ValidateBeadPolicyStorageCompatibility(cfg, "city.toml")
+			if err == nil {
+				t.Fatal("ValidateBeadPolicyStorageCompatibility = nil, want error")
+			}
+			msg := err.Error()
+			for _, want := range []string{"city.toml", "[beads.policies." + tt.policy + "]", tt.storage, BeadsBDCompatibility104} {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("error = %q, want substring %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateDurationsBadPoolDrainTimeout(t *testing.T) {
 	cfg := &City{
 		Agents: []Agent{

--- a/internal/dispatch/drain.go
+++ b/internal/dispatch/drain.go
@@ -547,7 +547,7 @@ func buildDrainManifest(bead beads.Bead, parentConvoyID, itemFormula string, mem
 func ensureDrainUnitConvoy(store beads.Store, control beads.Bead, parentConvoyID string, count int, row drainManifestRow, member beads.Bead) (beads.Bead, bool, error) {
 	unlock := graphv2.LockKey(row.UnitKey)
 	defer unlock()
-	existing, err := store.ListByMetadata(map[string]string{"gc.drain_unit_key": row.UnitKey}, 1)
+	existing, err := store.ListByMetadata(map[string]string{"gc.drain_unit_key": row.UnitKey}, 1, beads.WithBothTiers)
 	if err != nil {
 		return beads.Bead{}, false, fmt.Errorf("%s: looking up unit convoy for member %s: %w", control.ID, member.ID, err)
 	}
@@ -611,7 +611,7 @@ func ensureDrainItemRoot(store beads.Store, control, unit, member beads.Bead, co
 	if err := closeFailedDrainItemRoots(store, control.ID, row.ItemRootKey); err != nil {
 		return "", false, err
 	}
-	existing, err := store.ListByMetadata(map[string]string{"gc.item_root_key": row.ItemRootKey}, 0, beads.IncludeClosed)
+	existing, err := store.ListByMetadata(map[string]string{"gc.item_root_key": row.ItemRootKey}, 0, beads.IncludeClosed, beads.WithBothTiers)
 	if err != nil {
 		return "", false, fmt.Errorf("%s: looking up item root %s: %w", control.ID, row.ItemRootKey, err)
 	}
@@ -687,7 +687,7 @@ func closeFailedDrainItemRoots(store beads.Store, controlID, itemRootKey string)
 	if store == nil || itemRootKey == "" {
 		return nil
 	}
-	matches, err := store.ListByMetadata(map[string]string{"gc.item_root_key": itemRootKey}, 0)
+	matches, err := store.ListByMetadata(map[string]string{"gc.item_root_key": itemRootKey}, 0, beads.WithBothTiers)
 	if err != nil {
 		return fmt.Errorf("%s: looking up failed drain item roots for key %s: %w", controlID, itemRootKey, err)
 	}

--- a/internal/dispatch/drain_test.go
+++ b/internal/dispatch/drain_test.go
@@ -850,6 +850,47 @@ func TestEnsureDrainUnitConvoyRepairsExistingTrack(t *testing.T) {
 	}
 }
 
+type recordingDrainUnitStore struct {
+	beads.Store
+	listMetadataOpts [][]beads.QueryOpt
+}
+
+func (s *recordingDrainUnitStore) ListByMetadata(filters map[string]string, limit int, opts ...beads.QueryOpt) ([]beads.Bead, error) {
+	s.listMetadataOpts = append(s.listMetadataOpts, opts)
+	return s.Store.ListByMetadata(filters, limit, opts...)
+}
+
+func TestEnsureDrainUnitConvoyLooksAcrossBothTiers(t *testing.T) {
+	store := &recordingDrainUnitStore{Store: beads.NewMemStore()}
+	control, err := store.Create(beads.Bead{Title: "drain", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent, err := store.Create(beads.Bead{Title: "parent", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := store.Create(beads.Bead{Title: "member", Type: "task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := drainManifestRow{
+		Index:    0,
+		MemberID: member.ID,
+		UnitKey:  "drain-unit:test:0:" + member.ID,
+	}
+
+	if _, _, err := ensureDrainUnitConvoy(store, control, parent.ID, 1, row, member); err != nil {
+		t.Fatalf("ensureDrainUnitConvoy: %v", err)
+	}
+	if len(store.listMetadataOpts) == 0 {
+		t.Fatal("ListByMetadata was not called")
+	}
+	if got := beads.TierModeFromOpts(store.listMetadataOpts[0]); got != beads.TierBoth {
+		t.Fatalf("ListByMetadata tier = %v, want TierBoth", got)
+	}
+}
+
 func TestProcessDrainExclusiveFailsClosedForInvalidItemFormula(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 	dir := t.TempDir()

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -390,7 +390,7 @@ func appendRalphRetry(store beads.Store, logicalID string, prevSubject, prevChec
 	}
 	cfg := loadAttemptRouteConfig(opts.CityPath)
 	if molecule.IsGraphApplyEnabled() {
-		if applier, ok := store.(beads.GraphApplyStore); ok {
+		if applier, ok := beads.GraphApplyFor(store); ok {
 			return appendRalphRetryViaGraphApply(store, applier, logicalID, prevSubject, prevCheck, attemptSet, oldAttempt, nextAttempt, oldScopeRef, newScopeRef, cfg, opts)
 		}
 	}

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -713,7 +713,10 @@ func (p *Provider) recipientSessionMatchesByCurrentAddress(recipient string, clo
 }
 
 func (p *Provider) recipientSessionMatchesByMetadata(key, recipient, status string) ([]beads.Bead, error) {
-	query := beads.ListQuery{Metadata: map[string]string{key: recipient}}
+	query := beads.ListQuery{
+		Metadata: map[string]string{key: recipient},
+		TierMode: beads.TierBoth,
+	}
 	if status != "" {
 		query.Status = status
 	}

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -282,7 +282,7 @@ func TestCheckDoesNotUseMessageLabelSupplement(t *testing.T) {
 			return []byte(`[]`), nil
 		}
 		if strings.Contains(cmd, "bd query --json") {
-			t.Fatalf("mail check used supplemental wisp query: %s", cmd)
+			return []byte(`[]`), nil
 		}
 		if strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=message") && strings.Contains(cmd, "--status=open") {
 			return []byte(`[{"id":"msg-1","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"mayor","from":"human","created_at":"2026-01-02T03:04:05Z","ephemeral":true,"labels":["gc:message"]}]`), nil
@@ -319,7 +319,10 @@ func TestCheckUsesSingleAssigneeMessageScanForSlashRecipient(t *testing.T) {
 			messageListCalls++
 			return []byte(`[{"id":"msg-w","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"gascity/workflows.codex-max","from":"human","created_at":"2026-01-02T03:04:05Z","ephemeral":true}]`), nil
 		case strings.Contains(cmd, "bd query --json"):
-			t.Fatalf("slash recipient used supplemental wisp query: %s", cmd)
+			if strings.Contains(cmd, recipient) {
+				t.Fatalf("slash recipient leaked into supplemental wisp query: %s", cmd)
+			}
+			return []byte(`[]`), nil
 		}
 		return nil, errors.New("unexpected command: " + cmd)
 	}
@@ -349,7 +352,7 @@ func TestCheckUsesSingleBothTierBdMessageScan(t *testing.T) {
 		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=session"):
 			return []byte(`[]`), nil
 		case strings.Contains(cmd, "bd query --json"):
-			t.Fatalf("mail check used supplemental bd query: %s", cmd)
+			return []byte(`[]`), nil
 		case strings.Contains(cmd, "bd list --json") && strings.Contains(cmd, "--type=message") && strings.Contains(cmd, "--status=open"):
 			messageListCalls++
 			return []byte(`[{"id":"msg-1","title":"hello","description":"body","status":"open","issue_type":"message","assignee":"mayor","from":"human","created_at":"2026-01-02T03:04:05Z","ephemeral":true}]`), nil

--- a/internal/materialize/mcp_runtime.go
+++ b/internal/materialize/mcp_runtime.go
@@ -51,8 +51,10 @@ func MCPTemplateData(
 		}
 	}
 	var rigs []config.Rig
+	beadsCfg := config.BeadsConfig{}
 	if cfg != nil {
 		rigs = cfg.Rigs
+		beadsCfg = cfg.Beads
 	}
 	rigName := workdirutil.ConfiguredRigName(cityPath, *agent, rigs)
 	rigRoot := workdirutil.RigRootForName(rigName, rigs)
@@ -77,7 +79,7 @@ func MCPTemplateData(
 	data["IssuePrefix"] = mcpRigPrefix(rigName, rigs)
 	data["Branch"] = branch
 	data["DefaultBranch"] = branch
-	data["WorkQuery"] = agent.EffectiveWorkQuery()
+	data["WorkQuery"] = agent.EffectiveWorkQueryForBeads(beadsCfg)
 	data["SlingQuery"] = agent.EffectiveSlingQuery()
 	return data
 }

--- a/internal/materialize/mcp_test.go
+++ b/internal/materialize/mcp_test.go
@@ -248,6 +248,20 @@ func TestMCPTemplateDataUsesPoolNameForPoolInstances(t *testing.T) {
 	}
 }
 
+func TestMCPTemplateDataUsesBD105WorkQuery(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.City{
+		Beads: config.BeadsConfig{BDCompatibility: config.BeadsBDCompatibility105},
+	}
+	agent := &config.Agent{Name: "worker"}
+
+	got := MCPTemplateData(cfg, "/tmp/city", agent, "worker", "/tmp/work")
+	if !strings.Contains(got["WorkQuery"], "bd ready --include-ephemeral") {
+		t.Fatalf("WorkQuery = %q, want bd-1.0.5 ephemeral-ready probe", got["WorkQuery"])
+	}
+}
+
 func TestMCPTemplateDataPreservesBranchAlias(t *testing.T) {
 	t.Parallel()
 

--- a/internal/molecule/attach_test.go
+++ b/internal/molecule/attach_test.go
@@ -484,6 +484,56 @@ func TestAttachIdempotency(t *testing.T) {
 	}
 }
 
+func TestAttachIdempotencyFindsEphemeralExistingRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	root := setupWorkflow(t, store)
+	control := setupWorkflowChild(t, store, root.ID, "Control")
+	existingRoot, err := store.Create(beads.Bead{
+		Title:     "attempt",
+		Type:      "task",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.kind":            "workflow",
+			"gc.idempotency_key": "attempt:1",
+			"gc.root_bead_id":    root.ID,
+			"gc.step_ref":        "attempt",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create existing ephemeral root: %v", err)
+	}
+	existingRun, err := store.Create(beads.Bead{
+		Title:     "run",
+		Type:      "task",
+		Ephemeral: true,
+		ParentID:  existingRoot.ID,
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "attempt.run",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create existing ephemeral child: %v", err)
+	}
+
+	result, err := Attach(context.Background(), store, makeWorkflowRecipe("attempt", "run"), control.ID, AttachOptions{
+		IdempotencyKey: "attempt:1",
+	})
+	if err != nil {
+		t.Fatalf("Attach duplicate: %v", err)
+	}
+	if !result.Duplicate {
+		t.Fatal("Attach duplicate should report Duplicate for ephemeral existing root")
+	}
+	if result.RootID != existingRoot.ID {
+		t.Fatalf("RootID = %q, want existing ephemeral root %q", result.RootID, existingRoot.ID)
+	}
+	if result.IDMapping["attempt"] != existingRoot.ID || result.IDMapping["attempt.run"] != existingRun.ID {
+		t.Fatalf("IDMapping = %#v, want existing ephemeral root and child", result.IDMapping)
+	}
+	assertBlockingDep(t, store, control.ID, existingRoot.ID)
+}
+
 // Test 13: Different idempotency keys create separate sub-DAGs
 func TestAttachDifferentKeysCreateSeparate(t *testing.T) {
 	store := beads.NewMemStore()

--- a/internal/molecule/cleanup.go
+++ b/internal/molecule/cleanup.go
@@ -34,7 +34,7 @@ func ListSubtree(store beads.Store, rootID string) ([]beads.Bead, error) {
 	out := []beads.Bead{root}
 	queue := []string{root.ID}
 
-	logicalMembers, err := store.ListByMetadata(map[string]string{"gc.root_bead_id": root.ID}, 0, beads.IncludeClosed)
+	logicalMembers, err := store.ListByMetadata(map[string]string{"gc.root_bead_id": root.ID}, 0, beads.IncludeClosed, beads.WithBothTiers)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func ListSubtree(store beads.Store, rootID string) ([]beads.Bead, error) {
 		parentID := queue[0]
 		queue = queue[1:]
 
-		children, err := store.Children(parentID, beads.IncludeClosed)
+		children, err := store.Children(parentID, beads.IncludeClosed, beads.WithBothTiers)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/molecule/cleanup_test.go
+++ b/internal/molecule/cleanup_test.go
@@ -142,6 +142,58 @@ func TestCloseSubtreeClosesLogicalRootMembersAndTheirChildren(t *testing.T) {
 	}
 }
 
+func TestCloseSubtreeClosesLogicalMembersAcrossStorageTiers(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	detached, err := store.Create(beads.Bead{
+		Title:     "ephemeral detached control",
+		Ephemeral: true,
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create detached: %v", err)
+	}
+	ephemeralChild, err := store.Create(beads.Bead{
+		Title:     "ephemeral child",
+		ParentID:  detached.ID,
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("create ephemeral child: %v", err)
+	}
+	noHistoryChild, err := store.Create(beads.Bead{
+		Title:     "no-history child",
+		ParentID:  ephemeralChild.ID,
+		NoHistory: true,
+	})
+	if err != nil {
+		t.Fatalf("create no-history child: %v", err)
+	}
+
+	closed, err := CloseSubtree(store, root.ID)
+	if err != nil {
+		t.Fatalf("CloseSubtree: %v", err)
+	}
+	if closed != 4 {
+		t.Fatalf("CloseSubtree closed %d beads, want 4", closed)
+	}
+
+	for _, id := range []string{root.ID, detached.ID, ephemeralChild.ID, noHistoryChild.ID} {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if b.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, b.Status)
+		}
+	}
+}
+
 // TestCloseSubtreeOrdersBlockersBeforeBlocked models the typical
 // formula step subtree: a molecule root with N child step beads chained
 // by depends_on. CloseSubtree must emit closes in topological

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -318,6 +318,7 @@ func findExistingAttach(store beads.Store, recipe *formula.Recipe, rootBeadID, a
 			"gc.idempotency_key": key,
 			"gc.root_bead_id":    rootBeadID,
 		},
+		TierMode: beads.TierBoth,
 	})
 	if err != nil {
 		return nil, err
@@ -402,6 +403,7 @@ func existingAttachIDMapping(store beads.Store, recipe *formula.Recipe, rootBead
 	}
 	all, err := store.List(beads.ListQuery{
 		Metadata: map[string]string{"gc.root_bead_id": rootBeadID},
+		TierMode: beads.TierBoth,
 	})
 	if err != nil {
 		return nil, err
@@ -461,7 +463,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 		return nil, fmt.Errorf("recipe %q has no steps", recipe.Name)
 	}
 	if !opts.DeferAssignees && IsGraphApplyEnabled() {
-		if applier, ok := store.(beads.GraphApplyStore); ok {
+		if applier, ok := beads.GraphApplyFor(store); ok {
 			result, err := instantiateViaGraphApply(ctx, applier, recipe, opts)
 			if err == nil {
 				return result, nil
@@ -714,7 +716,7 @@ func InstantiateFragment(ctx context.Context, store beads.Store, recipe *formula
 		priorityOverride = clonePriority(root.Priority)
 	}
 	if IsGraphApplyEnabled() {
-		if applier, ok := store.(beads.GraphApplyStore); ok {
+		if applier, ok := beads.GraphApplyFor(store); ok {
 			opts.PriorityOverride = priorityOverride
 			return instantiateFragmentViaGraphApply(ctx, store, applier, recipe, opts)
 		}
@@ -1234,6 +1236,7 @@ func trimAttemptSuffix(id, suffix string) (string, bool) {
 func existingLogicalBeadIDIndex(store beads.Store, rootID string) (map[string]string, error) {
 	all, err := store.List(beads.ListQuery{
 		Metadata: map[string]string{"gc.root_bead_id": rootID},
+		TierMode: beads.TierBoth,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -1340,7 +1340,7 @@ func snapshotGraphV2ReplacementRoot(store beads.Store, formulaName string, vars 
 	if err := closeFailedGraphV2RootsByKey(store, key); err != nil {
 		return graphV2ReplacementSnapshot{}, err
 	}
-	matches, err := store.ListByMetadata(map[string]string{"gc.graphv2_root_key": key}, 2)
+	matches, err := store.ListByMetadata(map[string]string{"gc.graphv2_root_key": key}, 2, beads.WithBothTiers)
 	if err != nil {
 		return graphV2ReplacementSnapshot{}, fmt.Errorf("looking up graph.v2 root key %s: %w", key, err)
 	}
@@ -1392,7 +1392,7 @@ func closeFailedGraphV2Roots(store beads.Store, recipe *formula.Recipe) error {
 }
 
 func closeFailedGraphV2RootsByKey(store beads.Store, key string) error {
-	matches, err := store.ListByMetadata(map[string]string{"gc.graphv2_root_key": key}, 0)
+	matches, err := store.ListByMetadata(map[string]string{"gc.graphv2_root_key": key}, 0, beads.WithBothTiers)
 	if err != nil {
 		return fmt.Errorf("looking up failed graph.v2 roots for key %s: %w", key, err)
 	}
@@ -1445,7 +1445,7 @@ func existingGraphV2Root(store beads.Store, recipe *formula.Recipe) (*molecule.R
 	if key == "" {
 		return nil, nil
 	}
-	matches, err := store.ListByMetadata(map[string]string{"gc.graphv2_root_key": key}, 2)
+	matches, err := store.ListByMetadata(map[string]string{"gc.graphv2_root_key": key}, 2, beads.WithBothTiers)
 	if err != nil {
 		return nil, fmt.Errorf("looking up graph.v2 root key %s: %w", key, err)
 	}

--- a/scripts/test-go-test-shard
+++ b/scripts/test-go-test-shard
@@ -68,6 +68,8 @@ run_go_test() {
     GOVCS="${GOVCS-}" \
     GOWORK="${GOWORK-}" \
     GC_FAST_UNIT="${GC_FAST_UNIT:-0}"
+    GC_TEST_SHARD_INDEX="${shard_index}" \
+    GC_TEST_SHARD_TOTAL="${shard_total}"
   )
   if (( ${#extra_env[@]} > 0 )); then
     env -i "${base_env[@]}" "${extra_env[@]}" go test "$@"


### PR DESCRIPTION
## Summary
- add configurable bead storage policy tiers, defaulting to bd 1.0.4-safe history-backed claimable work
- add bd 1.0.5 opt-in semantics for no-history/ephemeral workflow storage and policy-aware bd ready/list behavior
- keep raw bd command arguments compatible with the verified 1.0.4 flag surface; bd ready supports --include-ephemeral and --metadata-field, while bd list --ready does not support --include-ephemeral or --skip-labels
- harden cmd/gc sharded tests so parallel worktrees do not delete each other's /tmp roots

## Verification
- pre-commit hook: lint-changed, generated docs/schema, go vet ./..., test-fast-parallel, docsync, dashboard build/typecheck/dashboard tests
- go test ./cmd/gc -run 'TestWorkflowServeControlReadyQuery' -count=1\n- go test ./cmd/gc -run 'Test(CmdGCTestTempRootPrefix|SweepOrphan|TestscriptCommandInvocationDoesNotLeakTempRoot|IsStaleCmdGCTestConfigPath)' -count=1\n