### PR TITLE
fix(reaper): exclude beads_test_bench_* from maintenance database handling

### DIFF
--- a/cmd/gc/dolt_cleanup_drop_planner.go
+++ b/cmd/gc/dolt_cleanup_drop_planner.go
@@ -16,8 +16,9 @@ import "strings"
 //   - beads_pt*: orchestrator patrol_helpers_test.go random prefixes
 //   - beads_vr*: orchestrator mail/router_test.go random prefixes
 //   - beads_t[0-9a-f]*: protocol test random prefixes (t + 8 hex chars)
+//   - beads_test_bench_*: benchmark test fixture databases
 var defaultStaleDatabasePrefixes = []string{
-	"testdb_", "test_guard_", "test_federation_", "doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t",
+	"testdb_", "test_guard_", "test_federation_", "doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t", "beads_test_bench_",
 }
 
 // systemDatabaseNames are the Dolt/MySQL system databases that SHOW

--- a/cmd/gc/dolt_cleanup_drop_planner_test.go
+++ b/cmd/gc/dolt_cleanup_drop_planner_test.go
@@ -190,7 +190,7 @@ func TestDefaultStaleDatabasePrefixes_MirrorsBeadsCleanDatabases(t *testing.T) {
 	// then we mirror beads/cmd/bd/dolt.go:staleDatabasePrefixes.
 	want := []string{
 		"testdb_", "test_guard_", "test_federation_",
-		"doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t",
+		"doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t", "beads_test_bench_",
 	}
 	if !equalStringSlice(defaultStaleDatabasePrefixes, want) {
 		t.Errorf("defaultStaleDatabasePrefixes = %v, want %v", defaultStaleDatabasePrefixes, want)

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -187,7 +187,7 @@ func TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase(t *testing.T) {
 	}
 
 	doltSystemNeedle := "information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe"
-	maintenanceScratchNeedle := "benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*"
+	maintenanceScratchNeedle := "benchdb|testdb_*|beads_pt*|beads_vr*|beads_test_bench_*|doctest_*|doctortest_*"
 	maintenanceTempNeedle := "beads_t[0-9a-f]"
 	for _, tt := range []struct {
 		pack     string

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2115,6 +2115,7 @@ func TestMaintenanceDoltScriptsSkipTestPatternDatabases(t *testing.T) {
 		"beads_t1234abcd9",
 		"beads_ptbaz",
 		"beads_vrqux",
+		"beads_test_bench_1780469138694213039",
 		"doctest_xyz",
 		"doctortest_abc",
 	}

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -715,7 +715,7 @@ retry_pending_spike_alert
 
 is_user_database() {
     case "$1" in
-        information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*)
+        information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|beads_test_bench_*|doctest_*|doctortest_*)
             return 1
             ;;
         beads_t*)
@@ -734,8 +734,8 @@ is_user_database() {
 # Discover databases. Exclude Dolt/MySQL system schemas, Gas City's internal
 # health-probe database, and test-fixture scratch databases (benchdb,
 # testdb_*, lowercase beads_t[0-9a-f]{8,}, beads_pt*, beads_vr*,
-# doctest_*, doctortest_* — matching the Go cleanup planner contract); the
-# remaining databases are expected to be bead stores.
+# beads_test_bench_*, doctest_*, doctortest_* — matching the Go cleanup
+# planner contract); the remaining databases are expected to be bead stores.
 DATABASES=$(
     while IFS= read -r db; do
         if is_user_database "$db"; then

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -83,7 +83,7 @@ PY
 
 is_user_database() {
     case "$1" in
-        information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*)
+        information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|beads_test_bench_*|doctest_*|doctortest_*)
             return 1
             ;;
         beads_t*)
@@ -102,8 +102,8 @@ is_user_database() {
 # Discover databases from Dolt server. Exclude Dolt/MySQL system schemas,
 # Gas City's internal health-probe database, and test-fixture scratch
 # databases (benchdb, testdb_*, lowercase beads_t[0-9a-f]{8,}, beads_pt*,
-# beads_vr*, doctest_*, doctortest_* — matching the Go cleanup planner
-# contract); the remainder are bead stores.
+# beads_vr*, beads_test_bench_*, doctest_*, doctortest_* — matching the Go
+# cleanup planner contract); the remainder are bead stores.
 DATABASES=$(
     while IFS= read -r db; do
         if is_user_database "$db"; then

--- a/release-gates/ga-qwrxtf-beads-test-bench-reaper-gate.md
+++ b/release-gates/ga-qwrxtf-beads-test-bench-reaper-gate.md
@@ -1,0 +1,54 @@
+# Release Gate: ga-qwrxtf beads_test_bench reaper exclusion
+
+Generated: 2026-06-03T23:57:05Z
+
+## Scope
+
+- Deploy bead: ga-qwrxtf
+- Source review bead: ga-t2gq37
+- Feature branch: fix/ga-w9k7fi-beads-test-bench-reaper
+- Base: origin/main 324e33dab8e0f2c555a9d29470d21e599037a5bb
+- Reviewed commit: 44e7e7571
+- Clean branch head before gate commit: 215604c9eb92bc755d91e3ac0fec6523dd8eeb5e
+- Gate criteria source: deployer prompt. `docs/PROJECT_MANIFEST.md` is absent in this checkout.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-t2gq37 is closed with reason `pass`; notes contain `Verdict: PASS` for commit 44e7e7571. |
+| 2 | Acceptance criteria met | PASS | The reviewed change excludes `beads_test_bench_*` in both Gastown maintenance scripts and the Go cleanup planner. Tests cover script filtering, default prefix mirroring, built-in enumerator filtering, and Dolt drop planning. |
+| 3 | Tests pass | PASS | Focused checks passed: `go test ./cmd/gc -run 'TestPlanDoltDrops|TestDefaultStaleDatabasePrefixes|TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase'`; `go test ./examples/gastown -run TestMaintenanceDoltScriptsSkipTestPatternDatabases`. Baseline passed: `make test-fast-parallel`. Static check passed: `go vet ./...`. |
+| 4 | No high-severity review findings open | PASS | Review notes report no blockers and no security concerns. The only observation is a low-priority non-blocking coverage suggestion. |
+| 5 | Final branch is clean | PASS | Before writing this gate file, `git status --short` was empty. This gate file is the only deployer artifact and is committed as the gate commit. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-base --is-ancestor origin/main HEAD` succeeded before the gate commit. The feature branch is a direct one-commit descendant of origin/main. |
+| 7 | Single feature theme | PASS | Diff touches one subsystem: Dolt cleanup/database filtering and the corresponding Gastown maintenance-script tests. No unrelated package or user-facing behavior is bundled. |
+
+## Acceptance Evidence
+
+| Surface | Evidence |
+|---------|----------|
+| `examples/gastown/packs/maintenance/assets/scripts/reaper.sh` | `is_user_database()` excludes `beads_test_bench_*` before the `beads_t*` hex-suffix branch. |
+| `examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh` | Matches the reaper exclusion so JSONL export ignores benchmark fixture databases. |
+| `cmd/gc/dolt_cleanup_drop_planner.go` | `defaultStaleDatabasePrefixes` includes `beads_test_bench_`, keeping Go cleanup planning aligned with the maintenance scripts. |
+| Tests | `TestMaintenanceDoltScriptsSkipTestPatternDatabases`, `TestDefaultStaleDatabasePrefixes_MirrorsBeadsCleanDatabases`, `TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase`, and the `TestPlanDoltDrops_*` suite cover the affected behavior. |
+
+## Test Log Summary
+
+```text
+go test ./cmd/gc -run 'TestPlanDoltDrops|TestDefaultStaleDatabasePrefixes|TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase'
+ok github.com/gastownhall/gascity/cmd/gc 0.244s
+
+go test ./examples/gastown -run TestMaintenanceDoltScriptsSkipTestPatternDatabases
+ok github.com/gastownhall/gascity/examples/gastown 0.462s
+
+make test-fast-parallel
+All fast jobs passed
+
+go vet ./...
+PASS
+```
+
+## Verdict
+
+PASS. Proceed with PR creation and merge-request handoff.


### PR DESCRIPTION
## What this changes

Dolt maintenance now treats benchmark fixture databases named `beads_test_bench_*` as internal test databases instead of live user bead stores.

The Gastown maintenance `reaper.sh` and `jsonl-export.sh` scripts skip that prefix during user-database discovery, and the Go cleanup planner includes the same prefix in its stale test-database contract so script behavior and planner behavior stay aligned.

## Review notes

- The behavior change is limited to Dolt database-name classification in `cmd/gc/dolt_cleanup_drop_planner.go` and the Gastown maintenance scripts.
- There are no config, API, schema, or migration changes.
- `beads_test_bench_*` is treated as an internal test/benchmark fixture prefix by default.
- `docs/PROJECT_MANIFEST.md` was absent in this checkout, so the gate used the deployer prompt criteria.

## Test plan

- [x] `go test ./cmd/gc -run 'TestPlanDoltDrops|TestDefaultStaleDatabasePrefixes|TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase'`
- [x] `go test ./examples/gastown -run TestMaintenanceDoltScriptsSkipTestPatternDatabases`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-qwrxtf-beads-test-bench-reaper-gate.md`](release-gates/ga-qwrxtf-beads-test-bench-reaper-gate.md)

Internal deploy reference: ga-qwrxtf.