### PR TITLE
fix(tmux): last_active reflects agent turns, not gc's own wake send-keys (#3049)

### DIFF
--- a/internal/runtime/tmux/activity_poke_integration_test.go
+++ b/internal/runtime/tmux/activity_poke_integration_test.go
@@ -1,0 +1,103 @@
+package tmux
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestPokeActivityRealTmux dogfoods the #3049 fix against a REAL, isolated tmux
+// server (its own -L socket, killed on cleanup — it never touches the gc tmux
+// server or any live agent session). TestDiscountPokeActivity already covers the
+// pure decision logic with synthetic times; this proves the real-tmux integration
+// the unit test cannot:
+//
+//   - SendKeysDebounced's poke advances tmux #{window_activity} into the echo
+//     window (within pokeEcho), which is the premise the whole discount rests on;
+//   - recordPoke snapshots the genuine pre-poke activity; and
+//   - genuine pane output AFTER the echo window is NOT discounted (a real turn).
+func TestPokeActivityRealTmux(t *testing.T) {
+	if os.Getenv("GC_TMUX_INTEGRATION") != "1" {
+		t.Skip("set GC_TMUX_INTEGRATION=1 to run this real-tmux dogfood (spins a throwaway tmux server)")
+	}
+	tm := NewTmuxWithConfig(Config{SocketName: "gcdogfood3049"})
+	const sess = "dogfood"
+	_, _ = tm.run("kill-server") // clean slate on this isolated socket; ignore if none
+	if _, err := tm.run("new-session", "-d", "-s", sess, "-x", "80", "-y", "24"); err != nil {
+		t.Skipf("cannot create tmux session (tmux unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _, _ = tm.run("kill-server") })
+
+	// A genuine "turn": pane output. Let #{window_activity} settle.
+	if _, err := tm.run("send-keys", "-t", sess, "-l", "echo genuine-turn"); err != nil {
+		t.Fatalf("send-keys genuine: %v", err)
+	}
+	_, _ = tm.run("send-keys", "-t", sess, "Enter")
+	time.Sleep(2 * time.Second)
+
+	expectedPrior, err := tm.rawSessionActivity(sess)
+	if err != nil {
+		t.Fatalf("rawSessionActivity prior: %v", err)
+	}
+
+	// Space the poke clearly after the genuine turn (no pane activity in between).
+	time.Sleep(2 * time.Second)
+
+	// THE POKE — the gc wake/nudge path. "# ..." is a bash no-op (comment): it
+	// advances #{window_activity} via the keystroke echo but produces no turn,
+	// exactly like a wake landing on a parked agent that never replies.
+	if err := tm.SendKeysDebounced(sess, "# gc-wake", 50); err != nil {
+		t.Fatalf("SendKeysDebounced poke: %v", err)
+	}
+
+	wa, err := tm.rawSessionActivity(sess)
+	if err != nil {
+		t.Fatalf("rawSessionActivity post-poke: %v", err)
+	}
+
+	tm.pokeMu.Lock()
+	pk, ok := tm.pokes[sess]
+	tm.pokeMu.Unlock()
+	if !ok {
+		t.Fatal("SendKeysDebounced did not record a poke")
+	}
+
+	// 1. recordPoke snapshotted the genuine pre-poke activity.
+	if !pk.prior.Equal(expectedPrior) {
+		t.Errorf("pk.prior = %v, want pre-poke activity %v", pk.prior, expectedPrior)
+	}
+	// 2. REAL-DATA PREMISE: the poke advanced #{window_activity} into the echo
+	//    window (allow tmux's 1s timestamp granularity around pokeEcho).
+	if d := wa.Sub(pk.at); d > pokeEcho || d < -pokeEcho {
+		t.Errorf("post-poke window_activity %v is %v from poke %v; want within pokeEcho=%v", wa, d, pk.at, pokeEcho)
+	}
+	// 3. Unanswered poke + grace elapsed -> genuine pre-poke time revealed.
+	if got := discountPokeActivity(wa, pk, pk.at.Add(pokeGrace+time.Second)); !got.Equal(pk.prior) {
+		t.Errorf("unanswered poke after grace = %v, want genuine prior %v (poke leaked through)", got, pk.prior)
+	}
+	// 4. Still in grace -> raw stands (don't prematurely flip a responsive agent).
+	if got := discountPokeActivity(wa, pk, pk.at.Add(pokeGrace/2)); !got.Equal(wa) {
+		t.Errorf("poke still in grace = %v, want raw %v", got, wa)
+	}
+
+	// 5. A genuine turn AFTER the echo window must NOT be discounted.
+	time.Sleep(pokeEcho + 2*time.Second)
+	if _, err := tm.run("send-keys", "-t", sess, "-l", "echo real-post-poke-turn"); err != nil {
+		t.Fatalf("send-keys real turn: %v", err)
+	}
+	_, _ = tm.run("send-keys", "-t", sess, "Enter")
+	time.Sleep(1 * time.Second)
+	wa2, err := tm.rawSessionActivity(sess)
+	if err != nil {
+		t.Fatalf("rawSessionActivity post-turn: %v", err)
+	}
+	if wa2.Sub(pk.at) <= pokeEcho {
+		t.Fatalf("real turn at %v not past poke echo %v (need > pokeEcho=%v)", wa2, pk.at, pokeEcho)
+	}
+	if got := discountPokeActivity(wa2, pk, pk.at.Add(pokeGrace+time.Second)); !got.Equal(wa2) {
+		t.Errorf("genuine post-poke turn was discounted = %v, want raw %v", got, wa2)
+	}
+
+	t.Logf("real-tmux OK: prior=%d poke=%d echo_wa=%d (Δ%v) turn_wa=%d (Δ%v)",
+		pk.prior.Unix(), pk.at.Unix(), wa.Unix(), wa.Sub(pk.at), wa2.Unix(), wa2.Sub(pk.at))
+}

--- a/internal/runtime/tmux/activity_poke_test.go
+++ b/internal/runtime/tmux/activity_poke_test.go
@@ -1,0 +1,69 @@
+package tmux
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDiscountPokeActivity covers the core fix: gc's own send-keys (wakes/nudges)
+// must not make a woken-but-unresponsive agent look active. The agent only
+// "did work" when it produces output AFTER the poke; an unanswered poke, once
+// the grace elapses, must reveal the genuine pre-poke activity.
+func TestDiscountPokeActivity(t *testing.T) {
+	turn := time.Date(2026, 6, 4, 1, 0, 0, 0, time.UTC) // last real turn
+	poke := turn.Add(5 * time.Hour)                     // gc poked 5h after that turn
+
+	tests := []struct {
+		name string
+		wa   time.Time // raw tmux window_activity
+		pk   pokeInfo
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "no poke recorded -> raw stands",
+			wa:   poke,
+			pk:   pokeInfo{},
+			now:  poke.Add(time.Minute),
+			want: poke,
+		},
+		{
+			name: "poke without prior snapshot -> raw stands",
+			wa:   poke,
+			pk:   pokeInfo{at: poke},
+			now:  poke.Add(pokeGrace + time.Second),
+			want: poke,
+		},
+		{
+			name: "echo only + grace elapsed -> prior (unresponsive agent looks idle)",
+			wa:   poke, // window_activity is just the poke's echo
+			pk:   pokeInfo{at: poke, prior: turn},
+			now:  poke.Add(pokeGrace + time.Second),
+			want: turn, // revealed: genuine activity is 5h old
+		},
+		{
+			name: "echo only + still in grace -> raw (give the agent time to reply)",
+			wa:   poke,
+			pk:   pokeInfo{at: poke, prior: turn},
+			now:  poke.Add(pokeGrace / 2),
+			want: poke,
+		},
+		{
+			name: "agent produced output after the poke -> raw (a real turn)",
+			wa:   poke.Add(30 * time.Second), // output well past the echo window
+			pk:   pokeInfo{at: poke, prior: turn},
+			now:  poke.Add(2 * time.Minute),
+			want: poke.Add(30 * time.Second),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := discountPokeActivity(tc.wa, tc.pk, tc.now)
+			if !got.Equal(tc.want) {
+				t.Errorf("discountPokeActivity(wa=%v, pk=%+v, now=%v) = %v, want %v",
+					tc.wa, tc.pk, tc.now, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -215,7 +215,31 @@ type Tmux struct {
 	configureOnce        sync.Once
 	hiddenAttachMu       sync.Mutex
 	hiddenAttachClients  map[string]*hiddenAttachClient
+
+	// pokeMu guards pokes, which tracks gc's own send-keys per session so
+	// GetSessionActivity can discount activity that is only our poke's echo
+	// (see discountPokeActivity).
+	pokeMu sync.Mutex
+	pokes  map[string]pokeInfo
 }
+
+// pokeInfo records a gc-initiated send-keys ("poke", e.g. a wake or nudge) to a
+// session: when it happened, and the genuine session activity observed just
+// before it.
+type pokeInfo struct {
+	at    time.Time // when gc sent the keystrokes
+	prior time.Time // genuine GetSessionActivity immediately before the poke
+}
+
+const (
+	// pokeEcho is the window within which raw tmux activity is treated as the
+	// poke's own keystroke echo rather than agent output.
+	pokeEcho = 3 * time.Second
+	// pokeGrace is how long a just-poked agent still counts as active, so a
+	// responsive agent about to reply is not flipped to idle. After it elapses
+	// with no agent output, the poke is discounted.
+	pokeGrace = 15 * time.Second
+)
 
 type hiddenAttachClient struct {
 	cancel  context.CancelFunc
@@ -1097,6 +1121,10 @@ func (t *Tmux) SendKeys(session, keys string) error {
 // The debounceMs parameter controls how long to wait after paste before sending Enter.
 // This prevents race conditions where Enter arrives before paste is processed.
 func (t *Tmux) SendKeysDebounced(session, keys string, debounceMs int) error {
+	// Record this poke (and the genuine activity just before it) so that
+	// GetSessionActivity can later discount our own keystroke echo for an
+	// agent that never actually responds. See discountPokeActivity.
+	t.recordPoke(session)
 	// Send text using literal mode (-l) to handle special chars
 	if _, err := t.run("send-keys", "-t", session, "-l", keys); err != nil {
 		return err
@@ -1926,13 +1954,37 @@ func (t *Tmux) IsSessionRunning(session string) bool {
 	return !dead
 }
 
-// GetSessionActivity returns the last meaningful activity time for a session.
+// GetSessionActivity returns the last genuine agent activity time for a session.
+//
+// It is built on tmux per-window activity (rawSessionActivity) but discounts
+// activity that is only gc's own send-keys echo. gc wakes/nudges agents by
+// sending keystrokes into the pane, which advances #{window_activity} even when
+// the agent never runs a turn (the park-on-wake loop). Without discounting, a
+// woken-but-unresponsive agent looks perpetually active, misleading last_active
+// and the idle / auto-suspend / reconciler logic keyed off it. See
+// discountPokeActivity. This is LLM-agnostic: purely gc input vs pane output, so
+// it holds for Claude Code, Codex, or any agent CLI running in the pane.
+func (t *Tmux) GetSessionActivity(session string) (time.Time, error) {
+	wa, err := t.rawSessionActivity(session)
+	if err != nil {
+		return time.Time{}, err
+	}
+	t.pokeMu.Lock()
+	pk, ok := t.pokes[session]
+	t.pokeMu.Unlock()
+	if !ok {
+		return wa, nil
+	}
+	return discountPokeActivity(wa, pk, time.Now()), nil
+}
+
+// rawSessionActivity returns the most recent tmux per-window activity timestamp.
 //
 // For detached agent sessions, tmux's #{session_activity} does not advance on
 // pane I/O — it effectively sticks to creation/attach time. Query per-window
 // activity instead and take the most recent timestamp so detached output and
-// send-keys both count as activity.
-func (t *Tmux) GetSessionActivity(session string) (time.Time, error) {
+// send-keys both count.
+func (t *Tmux) rawSessionActivity(session string) (time.Time, error) {
 	out, err := t.run("list-windows", "-t", session, "-F", "#{window_activity}")
 	if err != nil {
 		return time.Time{}, err
@@ -1943,6 +1995,42 @@ func (t *Tmux) GetSessionActivity(session string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return time.Unix(timestamp, 0), nil
+}
+
+// recordPoke snapshots the genuine session activity and timestamps a
+// gc-initiated send-keys ("poke", e.g. a wake/nudge), so a later
+// GetSessionActivity can discount the poke's own keystroke echo.
+func (t *Tmux) recordPoke(session string) {
+	prior, err := t.GetSessionActivity(session)
+	if err != nil {
+		prior = time.Time{}
+	}
+	t.pokeMu.Lock()
+	if t.pokes == nil {
+		t.pokes = make(map[string]pokeInfo)
+	}
+	t.pokes[session] = pokeInfo{at: time.Now(), prior: prior}
+	t.pokeMu.Unlock()
+}
+
+// discountPokeActivity resolves the genuine activity time from the raw tmux
+// window activity (wa), the last recorded gc poke (pk) and the current time.
+//
+// If wa is only the poke's own keystroke echo (within pokeEcho of the poke) AND
+// the grace window has elapsed with no later agent output, it returns the
+// activity seen before the poke — revealing that the agent never actually
+// responded. Otherwise wa stands (a real post-poke turn, or a still-in-grace
+// recent poke). Pure function for testability.
+func discountPokeActivity(wa time.Time, pk pokeInfo, now time.Time) time.Time {
+	if pk.at.IsZero() || pk.prior.IsZero() {
+		return wa
+	}
+	echoOnly := wa.Sub(pk.at).Abs() <= pokeEcho
+	graceElapsed := now.Sub(pk.at) >= pokeGrace
+	if echoOnly && graceElapsed {
+		return pk.prior
+	}
+	return wa
 }
 
 func latestActivityTimestamp(out string) (int64, error) {


### PR DESCRIPTION
Fixes the `last_active` inaccuracy in #3049.

## Problem
`GetSessionActivity` (tmux provider) returns tmux `#{window_activity}`, which advances on **gc's own wake/nudge `send-keys`** — so an agent gc poked but that never ran a turn (the park-on-wake loop) looks perpetually active. This misleads `gc session list`'s `last_active` **and** the idle / auto-suspend / session-sleep / reconciler logic that all key off `GetLastActivity`.

Live evidence: `thriva/gastown.witness` — `last_active` 6 min ago, last real turn (its turn-clock) **5 hours** ago, with `Woke session …` ×4 in between.

## Fix (LLM-agnostic, tmux-layer)
Per the Codex constraint in #3049, this is provider-independent — no transcript/hook assumptions:
- The tmux provider records each `send-keys` (a "poke") with the genuine activity observed just before it (`recordPoke`, called from `SendKeysDebounced`).
- `GetSessionActivity` discounts activity that is **only the poke's own echo** once a short grace elapses with no later agent output — revealing the genuine pre-poke activity (`discountPokeActivity`, a pure, unit-tested function). A real post-poke turn still counts; a just-poked agent stays active during the grace so a responsive agent isn't flipped idle.

Knobs: `pokeEcho = 3s` (echo window), `pokeGrace = 15s` (response grace) — open to tuning.

## Testing
- `go test ./internal/runtime/tmux/ -run TestDiscountPokeActivity` — 5 cases pass (no-poke, no-prior, echo+grace→prior, echo+in-grace→raw, post-poke-output→raw).
- `go build ./internal/runtime/tmux/` + `gofmt` clean.

## Notes
- Recorded on `SendKeysDebounced` (the wake/nudge path); could extend to other `send-keys` entry points.
- The ACP provider already reports turn-based activity; this brings the tmux provider in line.
- Draft — happy to tune the grace semantics or move the recording point per maintainer preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
