### PR TITLE
fix(reaper): handle bd dependency schema and dry-run wisp count

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3008,6 +3008,80 @@ exit 0
 	}
 }
 
+func TestReaperDryRunReportsWouldCloseStaleWisps(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"COUNT(DISTINCT w.id)"*)
+    printf 'COUNT(*)\n2\n'
+    ;;
+  *"UPDATE "*"wisps SET status='closed'"*)
+    printf 'dry-run should not update wisps\n' >&2
+    exit 42
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n2\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":     doltLog,
+		"GC_CALL_LOG":       gcLog,
+		"GC_CITY":           cityDir,
+		"GC_CITY_PATH":      cityDir,
+		"GC_DOLT_HOST":      "127.0.0.1",
+		"GC_DOLT_PORT":      "3307",
+		"GC_DOLT_USER":      "root",
+		"GC_DOLT_PASSWORD":  "",
+		"GC_REAPER_DRY_RUN": "1",
+		"PATH":              binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	if strings.Contains(string(logData), "UPDATE `beads`.wisps SET status='closed'") {
+		t.Fatalf("dry-run executed stale-wisp update:\n%s", logData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcText := string(gcData)
+	if !strings.Contains(gcText, "closed_wisps:0") ||
+		!strings.Contains(gcText, "would_close_wisps:2") ||
+		!strings.Contains(gcText, "(dry run)") {
+		t.Fatalf("dry-run summary did not report non-mutating would-close count:\n%s", gcText)
+	}
+}
+
 func TestReaperCountQueriesIgnoreSuccessfulStderrWarnings(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2326,8 +2326,8 @@ func TestReaperFormulaSQLReflectsCurrentSchema(t *testing.T) {
 		if strings.Contains(fence, "parent_id") {
 			t.Errorf("formula sql fence %d references parent_id (column does not exist in wisps):\n%s", i, fence)
 		}
-		if strings.Contains(fence, "depends_on_id") {
-			t.Errorf("formula sql fence %d references dependencies.depends_on_id instead of split target columns:\n%s", i, fence)
+		if strings.Contains(fence, "depends_on_wisp_id") || strings.Contains(fence, "depends_on_issue_id") {
+			t.Errorf("formula sql fence %d references split dependency target columns; bd 1.0.4 uses depends_on_id:\n%s", i, fence)
 		}
 		if strings.Contains(fence, "LEFT JOIN wisps parent ON") {
 			t.Errorf("formula sql fence %d still has the broken parent self-join:\n%s", i, fence)
@@ -2385,7 +2385,7 @@ func TestReaperParentIDIsParentChildDependencyProjection(t *testing.T) {
 	if strings.Contains(script, "parent_id") {
 		t.Fatalf("reaper queried parent_id directly; Dolt ParentID is projected from parent-child dependencies:\n%s", script)
 	}
-	if !strings.Contains(script, "dependencies d") || !strings.Contains(script, "d.type = 'parent-child'") {
+	if !strings.Contains(script, "wisp_dependencies d") || !strings.Contains(script, "d.type = 'parent-child'") {
 		t.Fatalf("reaper does not follow the canonical Dolt parent-child projection:\n%s", script)
 	}
 }
@@ -2429,8 +2429,10 @@ exit 0
 	if strings.Contains(log, "parent_id") {
 		t.Errorf("reaper SQL references parent_id (column does not exist in wisps):\n%s", log)
 	}
-	if strings.Contains(log, "depends_on_id") {
-		t.Errorf("reaper SQL references dependencies.depends_on_id instead of split target columns:\n%s", log)
+	for _, notWant := range []string{"depends_on_wisp_id", "depends_on_issue_id"} {
+		if strings.Contains(log, notWant) {
+			t.Errorf("reaper SQL references split dependency target column %q; bd 1.0.4 uses depends_on_id:\n%s", notWant, log)
+		}
 	}
 	// mail was removed: not a SQL table; messages are beads with type=message.
 	if strings.Contains(log, ".mail") {
@@ -2438,10 +2440,9 @@ exit 0
 	}
 	for _, want := range []string{
 		"SHOW COLUMNS FROM `beads`.dependencies",
-		"SELECT DISTINCT d.depends_on_wisp_id",
-		"d.depends_on_wisp_id IS NOT NULL",
-		"SELECT DISTINCT d.depends_on_issue_id",
-		"d.depends_on_issue_id IS NOT NULL",
+		"SHOW COLUMNS FROM `beads`.wisp_dependencies",
+		"FROM `beads`.wisp_dependencies d",
+		"SELECT DISTINCT d.depends_on_id",
 	} {
 		if !strings.Contains(log, want) {
 			t.Errorf("reaper SQL missing %q:\n%s", want, log)
@@ -2472,7 +2473,7 @@ exit 0
 		purgeSQL := log[purgeIdx:]
 		if !strings.Contains(purgeSQL, "child_wisp.status IN ('open', 'hooked', 'in_progress')") ||
 			!strings.Contains(purgeSQL, "d.type = 'parent-child'") ||
-			!strings.Contains(purgeSQL, "d.depends_on_wisp_id IS NOT NULL") {
+			!strings.Contains(purgeSQL, "SELECT DISTINCT d.depends_on_id") {
 			t.Errorf("reaper purge can delete closed parents with non-closed children:\n%s", purgeSQL)
 		}
 	}
@@ -2486,7 +2487,7 @@ exit 0
 	}
 }
 
-func TestReaperSkipsDependencyQueriesWithoutSplitDependencyTargets(t *testing.T) {
+func TestReaperSkipsDependencyQueriesWithoutGenericDependencyTargets(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
 	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
@@ -2501,7 +2502,7 @@ exit 0
 	env := map[string]string{
 		"DOLT_ARGS_LOG":          doltLog,
 		"DOLT_DBS":               "beads",
-		"DOLT_DEPENDENCY_SCHEMA": "legacy",
+		"DOLT_DEPENDENCY_SCHEMA": "missing-target",
 		"GC_CALL_LOG":            gcLog,
 		"GC_CITY":                cityDir,
 		"GC_CITY_PATH":           cityDir,
@@ -2522,8 +2523,8 @@ exit 0
 	if !strings.Contains(log, "SHOW COLUMNS FROM `beads`.dependencies") {
 		t.Fatalf("reaper did not probe dependency target columns:\n%s", log)
 	}
-	if strings.Contains(log, "FROM `beads`.dependencies d") || strings.Contains(log, "JOIN `beads`.dependencies d") {
-		t.Fatalf("reaper ran dependency-aware queries against legacy dependency schema:\n%s", log)
+	if strings.Contains(log, "FROM `beads`.wisp_dependencies d") || strings.Contains(log, "JOIN `beads`.wisp_dependencies d") {
+		t.Fatalf("reaper ran dependency-aware queries against schema without depends_on_id:\n%s", log)
 	}
 
 	// A silently-skipped DB may make no gc calls at all, so a missing
@@ -2532,8 +2533,57 @@ exit 0
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatalf("ReadFile(gc log): %v", err)
 	}
-	if strings.Contains(string(gcData), "dependencies table lacks split target columns") {
-		t.Errorf("reaper escalated the legacy dependency schema as an anomaly; the split-target gate must skip silently:\n%s", gcData)
+	if strings.Contains(string(gcData), "dependencies table lacks depends_on_id") {
+		t.Errorf("reaper escalated the dependency schema as an anomaly; the target-column gate must skip silently:\n%s", gcData)
+	}
+}
+
+func TestReaperSkipsDependencyQueriesWithoutWispDependencyTable(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":               doltLog,
+		"DOLT_DBS":                    "beads",
+		"DOLT_WISP_DEPENDENCY_SCHEMA": "missing-table",
+		"GC_CALL_LOG":                 gcLog,
+		"GC_CITY":                     cityDir,
+		"GC_CITY_PATH":                cityDir,
+		"GC_DOLT_HOST":                "127.0.0.1",
+		"GC_DOLT_PORT":                "3307",
+		"GC_DOLT_USER":                "root",
+		"GC_DOLT_PASSWORD":            "",
+		"PATH":                        binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "SHOW COLUMNS FROM `beads`.wisp_dependencies") {
+		t.Fatalf("reaper did not probe wisp dependency target columns:\n%s", log)
+	}
+	if strings.Contains(log, "FROM `beads`.wisp_dependencies d") || strings.Contains(log, "JOIN `beads`.wisp_dependencies d") {
+		t.Fatalf("reaper ran dependency-aware queries without a wisp_dependencies table:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if strings.Contains(string(gcData), "wisp_dependencies") {
+		t.Errorf("reaper escalated the missing wisp dependency table as an anomaly; the schema gate must skip silently:\n%s", gcData)
 	}
 }
 
@@ -3248,7 +3298,7 @@ case "$*" in
   *"UPDATE "*"wisps SET status='closed'"*)
     printf 'ROW_COUNT()\n1\n'
     ;;
-  *"COUNT("*"wisps w"*"dependencies d"*)
+  *"COUNT("*"wisps w"*"wisp_dependencies d"*)
     printf 'COUNT(*)\n0\n'
     ;;
   *"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
@@ -3287,7 +3337,7 @@ exit 0
 		t.Fatalf("ReadFile(dolt log): %v", err)
 	}
 	log := string(logData)
-	if strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") && !strings.Contains(log, "dependencies d") {
+	if strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") && !strings.Contains(log, "wisp_dependencies d") {
 		t.Fatalf("reaper closed non-closed wisps by age alone instead of using parent-child dependencies:\n%s", log)
 	}
 
@@ -3319,7 +3369,7 @@ case "$*" in
   *"UPDATE "*"wisps SET status='closed'"*)
     printf 'ROW_COUNT()\n1\n'
     ;;
-  *"COUNT("*"wisps w"*"dependencies d"*)
+  *"COUNT("*"wisps w"*"wisp_dependencies d"*)
     n=0
     if [ -f "$CLOSE_COUNT_STATE" ]; then
       n=$(cat "$CLOSE_COUNT_STATE")
@@ -3377,11 +3427,11 @@ exit 0
 	if !strings.Contains(log, "COUNT(DISTINCT w.id)") {
 		t.Fatalf("reaper stale-wisp close count can be join-multiplied:\n%s", log)
 	}
-	if !strings.Contains(log, "dependencies d") || !strings.Contains(log, "d.type = 'parent-child'") {
+	if !strings.Contains(log, "wisp_dependencies d") || !strings.Contains(log, "d.type = 'parent-child'") {
 		t.Fatalf("reaper stale-wisp close path does not use parent-child dependencies:\n%s", log)
 	}
-	if !strings.Contains(log, "d.depends_on_wisp_id = parent_wisp.id") || !strings.Contains(log, "d.depends_on_issue_id = parent_issue.id") {
-		t.Fatalf("reaper stale-wisp close path does not use split dependency target columns:\n%s", log)
+	if !strings.Contains(log, "d.depends_on_id = parent_wisp.id") || !strings.Contains(log, "d.depends_on_id = parent_issue.id") {
+		t.Fatalf("reaper stale-wisp close path does not use bd 1.0.4 dependency target column:\n%s", log)
 	}
 	if strings.Contains(log, "parent_wisp.id IS NULL AND parent_issue.id IS NULL") {
 		t.Fatalf("reaper closes stale wisps when parent liveness is unresolved:\n%s", log)
@@ -3557,7 +3607,7 @@ case "$*" in
       i=$((i + 1))
     done
     printf '\n'
-    printf 'Error 1105 (HY000): dependencies.depends_on_wisp_id missing from schema\n' >&2
+    printf 'Error 1105 (HY000): wisp_dependencies.depends_on_id missing from schema\n' >&2
     exit 42
     ;;
   *"status = 'closed'"*"closed_at <"*)
@@ -3598,7 +3648,7 @@ exit 0
 	if !strings.Contains(gcLogText, "purging closed wisps failed for beads") {
 		t.Fatalf("reaper did not escalate failed purge:\n%s", gcLogText)
 	}
-	if !strings.Contains(gcLogText, "Error 1105 (HY000): dependencies.depends_on_wisp_id missing from schema") {
+	if !strings.Contains(gcLogText, "Error 1105 (HY000): wisp_dependencies.depends_on_id missing from schema") {
 		t.Fatalf("reaper escalation lost Dolt stderr error tail:\n%s", gcLogText)
 	}
 }
@@ -3626,7 +3676,7 @@ case "$*" in
     printf 'delete failed\n' >&2
     exit 42
     ;;
-  *"COUNT("*"wisps w"*"dependencies d"*)
+  *"COUNT("*"wisps w"*"wisp_dependencies d"*)
     n=0
     if [ -f "$CLOSE_COUNT_STATE" ]; then
       n=$(cat "$CLOSE_COUNT_STATE")
@@ -5033,15 +5083,25 @@ case "$*" in
   ;;
 *"SHOW COLUMNS FROM"*"dependencies"*)
   printf 'Field,Type,Null,Key,Default,Extra\n'
-  if [ "${DOLT_DEPENDENCY_SCHEMA:-split}" = "legacy" ]; then
+  dependency_schema="${DOLT_DEPENDENCY_SCHEMA:-generic}"
+  case "$*" in
+    *"wisp_dependencies"*) dependency_schema="${DOLT_WISP_DEPENDENCY_SCHEMA:-$dependency_schema}" ;;
+  esac
+  if [ "$dependency_schema" = "missing-table" ]; then
+    printf 'table not found\n' >&2
+    exit 42
+  elif [ "$dependency_schema" = "missing-target" ]; then
     printf 'issue_id,varchar,NO,,,\n'
-    printf 'depends_on_id,varchar,NO,,,\n'
     printf 'type,varchar,NO,,,\n'
-  else
+  elif [ "$dependency_schema" = "split" ]; then
     printf 'issue_id,varchar,NO,,,\n'
     printf 'depends_on_issue_id,varchar,YES,,,\n'
     printf 'depends_on_wisp_id,varchar,YES,,,\n'
     printf 'depends_on_external,varchar,YES,,,\n'
+    printf 'type,varchar,NO,,,\n'
+  else
+    printf 'issue_id,varchar,NO,,,\n'
+    printf 'depends_on_id,varchar,NO,,,\n'
     printf 'type,varchar,NO,,,\n'
   fi
   ;;

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -120,6 +120,7 @@ fi
 
 TOTAL_STALE_WISPS=0
 TOTAL_CLOSED_WISPS=0
+TOTAL_WOULD_CLOSE_WISPS=0
 TOTAL_PURGED=0
 TOTAL_MAIL_WISPS=0
 TOTAL_ISSUES_CLOSED=0
@@ -385,7 +386,11 @@ while IFS= read -r DB; do
             )
         "
         CLOSE_WISP_BATCH=$SQL_COUNT_RESULT
-        if [ "$CLOSE_WISP_BATCH" -eq 0 ] || [ -n "$DRY_RUN" ]; then
+        if [ "$CLOSE_WISP_BATCH" -eq 0 ]; then
+            break
+        fi
+        if [ -n "$DRY_RUN" ]; then
+            TOTAL_WOULD_CLOSE_WISPS=$((TOTAL_WOULD_CLOSE_WISPS + CLOSE_WISP_BATCH))
             break
         fi
 
@@ -609,7 +614,7 @@ fi
 
 SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, sessions-pruned:$TOTAL_SESSIONS_PRUNED, closed:$TOTAL_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED, mail_wisps:$TOTAL_MAIL_WISPS"
 if [ -n "$DRY_RUN" ]; then
-    SUMMARY="$SUMMARY (dry run)"
+    SUMMARY="$SUMMARY, would_close_wisps:$TOTAL_WOULD_CLOSE_WISPS (dry run)"
 fi
 
 gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -256,13 +256,14 @@ get_sql_rows() {
     SQL_ROWS_RESULT=$(printf '%s\n' "$output" | tail -n +2 | tr -d '\r')
 }
 
-has_split_dependency_target_columns() {
+has_dependency_target_column() {
     local db="$1"
+    local table="$2"
     local output
     local fields
 
-    if ! output=$(dolt_sql -r csv -q "SHOW COLUMNS FROM \`$db\`.dependencies" 2>/dev/null); then
-        return 0
+    if ! output=$(dolt_sql -r csv -q "SHOW COLUMNS FROM \`$db\`.$table" 2>/dev/null); then
+        return 1
     fi
 
     fields=$(printf '%s\n' "$output" | tail -n +2 | cut -d, -f1 | tr -d '\r')
@@ -270,8 +271,8 @@ has_split_dependency_target_columns() {
         return 0
     fi
 
-    printf '%s\n' "$fields" | grep -qx 'depends_on_issue_id' || return 1
-    printf '%s\n' "$fields" | grep -qx 'depends_on_wisp_id' || return 1
+    printf '%s\n' "$fields" | grep -qx 'issue_id' || return 1
+    printf '%s\n' "$fields" | grep -qx 'depends_on_id' || return 1
 }
 
 SQL_CHANGE_ROWS_RESULT=0
@@ -344,10 +345,10 @@ while IFS= read -r DB; do
         # server into noise. See gastownhall/gascity#1816.
         continue
     fi
-    if ! has_split_dependency_target_columns "$DB"; then
-        # Legacy dependency schema (pre-#2399). Skip silently like the
-        # has_wisps_table gate above; the only fix is the schema migration,
-        # which the reaper cannot perform. See gastownhall/gascity#2456.
+    if ! has_dependency_target_column "$DB" "dependencies" || ! has_dependency_target_column "$DB" "wisp_dependencies"; then
+        # Older or incompatible dependency schema. Skip silently like the
+        # has_wisps_table gate above; the only fix is a bead-store schema
+        # migration, which the reaper cannot perform.
         continue
     fi
 
@@ -373,11 +374,11 @@ while IFS= read -r DB; do
     while [ "$STALE_WISP_COUNT" -gt 0 ] && [ "$CLOSE_WISP_COUNT" -lt "$STALE_WISP_COUNT" ]; do
         get_sql_count "$DB" "schema-safe stale wisp" "
             SELECT COUNT(DISTINCT w.id) FROM \`$DB\`.wisps w
-            INNER JOIN \`$DB\`.dependencies d
+            INNER JOIN \`$DB\`.wisp_dependencies d
                 ON d.issue_id = w.id
                 AND d.type = 'parent-child'
-            LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
-            LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_issue_id = parent_issue.id
+            LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
+            LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
             WHERE w.status IN ('open', 'hooked', 'in_progress')
             AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
             AND (
@@ -401,11 +402,11 @@ while IFS= read -r DB; do
             AND id IN (
                 SELECT id FROM (
                     SELECT w.id FROM \`$DB\`.wisps w
-                    INNER JOIN \`$DB\`.dependencies d
+                    INNER JOIN \`$DB\`.wisp_dependencies d
                         ON d.issue_id = w.id
                         AND d.type = 'parent-child'
-                    LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
-                    LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_issue_id = parent_issue.id
+                    LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
+                    LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
                     WHERE w.status IN ('open', 'hooked', 'in_progress')
                     AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
                     AND (
@@ -434,10 +435,9 @@ while IFS= read -r DB; do
         WHERE status = 'closed'
         AND closed_at < DATE_SUB(NOW(), INTERVAL $PURGE_AGE_H HOUR)
         AND id NOT IN (
-            SELECT DISTINCT d.depends_on_wisp_id FROM \`$DB\`.dependencies d
+            SELECT DISTINCT d.depends_on_id FROM \`$DB\`.wisp_dependencies d
             INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
             WHERE d.type = 'parent-child'
-            AND d.depends_on_wisp_id IS NOT NULL
             AND child_wisp.status IN ('open', 'hooked', 'in_progress')
         )
     "
@@ -449,10 +449,9 @@ while IFS= read -r DB; do
             WHERE status = 'closed'
             AND closed_at < DATE_SUB(NOW(), INTERVAL $PURGE_AGE_H HOUR)
             AND id NOT IN (
-                SELECT DISTINCT d.depends_on_wisp_id FROM \`$DB\`.dependencies d
+                SELECT DISTINCT d.depends_on_id FROM \`$DB\`.wisp_dependencies d
                 INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
                 WHERE d.type = 'parent-child'
-                AND d.depends_on_wisp_id IS NOT NULL
                 AND child_wisp.status IN ('open', 'hooked', 'in_progress')
             )
         "; then
@@ -473,13 +472,12 @@ while IFS= read -r DB; do
         AND issue_type != 'epic'
         AND id NOT IN (
             SELECT DISTINCT d.issue_id FROM \`$DB\`.dependencies d
-            INNER JOIN \`$DB\`.issues i ON d.depends_on_issue_id = i.id
+            INNER JOIN \`$DB\`.issues i ON d.depends_on_id = i.id
             WHERE i.status IN ('open', 'in_progress')
             UNION
-            SELECT DISTINCT d.depends_on_issue_id FROM \`$DB\`.dependencies d
+            SELECT DISTINCT d.depends_on_id FROM \`$DB\`.dependencies d
             INNER JOIN \`$DB\`.issues i ON d.issue_id = i.id
             WHERE i.status IN ('open', 'in_progress')
-            AND d.depends_on_issue_id IS NOT NULL
         )
     "
     STALE_IDS=$SQL_ROWS_RESULT

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -20,10 +20,11 @@ Mail is NOT a SQL table — mail messages are beads (Type=message). Any
 mail cleanup must go through `bd`, never Dolt. BD-backed mail retention is
 tracked separately as `ga-w9jfl5`; until that lands, Reaper intentionally does
 not delete mail. Wisp parentage is no longer carried on the wisps row; it
-lives in `dependencies` rows with `type='parent-child'`. For the Dolt-backed
-bead store, `ParentID` is a projection from those parent-child dependencies,
-not a separate `parent_id` column for Reaper to query. Non-closed wisps without
-that parentage signal are reported only; they are not closed by age alone.
+lives in `wisp_dependencies` rows with `type='parent-child'` and a
+`depends_on_id` target column in the bd 1.0.4 schema. For the Dolt-backed bead
+store, `ParentID` is a projection from those parent-child dependencies, not a
+separate `parent_id` column for Reaper to query. Non-closed wisps without that
+parentage signal are reported only; they are not closed by age alone.
 Legacy `mail_delete_age` overrides do not apply to Reaper and should be
 removed or moved to the BD-backed mail cleanup tool. Legacy `databases`
 overrides from earlier formula drafts are also no longer accepted; the script
@@ -127,11 +128,11 @@ AND created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR);
 
 -- Schema-safe close candidates: stale child wisps with closed parent
 SELECT COUNT(DISTINCT w.id) FROM wisps w
-INNER JOIN dependencies d
+INNER JOIN wisp_dependencies d
   ON d.issue_id = w.id
   AND d.type = 'parent-child'
-LEFT JOIN wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
-LEFT JOIN issues parent_issue ON d.depends_on_issue_id = parent_issue.id
+LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
+LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
 WHERE w.status IN ('open', 'hooked', 'in_progress')
 AND w.created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
 AND (
@@ -146,10 +147,9 @@ SELECT COUNT(*) FROM wisps
 WHERE status = 'closed'
 AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
 AND id NOT IN (
-  SELECT DISTINCT d.depends_on_wisp_id FROM dependencies d
+  SELECT DISTINCT d.depends_on_id FROM wisp_dependencies d
   INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
   WHERE d.type = 'parent-child'
-  AND d.depends_on_wisp_id IS NOT NULL
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
 );
 
@@ -182,9 +182,10 @@ Report wisps past max_age and close only the schema-safe subset whose
 parent-child dependency points to a closed parent.
 
 Wisp parentage no longer lives on the wisps row (the schema has no
-`parent_id` column); parentage is in `dependencies` rows with
-`type='parent-child'`. The SDK `ParentID` field is projected from those rows
-for Dolt-backed beads. Do not close non-closed wisps by age alone.
+`parent_id` column); parentage is in `wisp_dependencies` rows with
+`type='parent-child'` and `depends_on_id`. The SDK `ParentID` field is
+projected from those rows for Dolt-backed beads. Do not close non-closed wisps
+by age alone.
 `wisp-compact.sh` promotes non-closed wisps past TTL for stuck detection.
 The close step repeats until no schema-safe candidates remain, so a stale
 multi-level child chain whose root is closed converges in one reaper run.
@@ -204,11 +205,11 @@ AND created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
 AND id IN (
   SELECT id FROM (
     SELECT w.id FROM wisps w
-    INNER JOIN dependencies d
+    INNER JOIN wisp_dependencies d
       ON d.issue_id = w.id
       AND d.type = 'parent-child'
-    LEFT JOIN wisps parent_wisp ON d.depends_on_wisp_id = parent_wisp.id
-    LEFT JOIN issues parent_issue ON d.depends_on_issue_id = parent_issue.id
+    LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
+    LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
     WHERE w.status IN ('open', 'hooked', 'in_progress')
     AND w.created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
     AND (
@@ -244,10 +245,9 @@ DELETE FROM wisps
 WHERE status = 'closed'
 AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
 AND id NOT IN (
-  SELECT DISTINCT d.depends_on_wisp_id FROM dependencies d
+  SELECT DISTINCT d.depends_on_id FROM wisp_dependencies d
   INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
   WHERE d.type = 'parent-child'
-  AND d.depends_on_wisp_id IS NOT NULL
   AND child_wisp.status IN ('open', 'hooked', 'in_progress')
 );
 ```
@@ -289,13 +289,12 @@ AND issue_type != 'epic'
 AND id NOT IN (
   -- Exclude issues with active dependencies
   SELECT DISTINCT d.issue_id FROM dependencies d
-  INNER JOIN issues i ON d.depends_on_issue_id = i.id
+  INNER JOIN issues i ON d.depends_on_id = i.id
   WHERE i.status IN ('open', 'in_progress')
   UNION
-  SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
+  SELECT DISTINCT d.depends_on_id FROM dependencies d
   INNER JOIN issues i ON d.issue_id = i.id
   WHERE i.status IN ('open', 'in_progress')
-  AND d.depends_on_issue_id IS NOT NULL
 )
 ```
 


### PR DESCRIPTION
Refs #2903

## Cause

The reaper fix spans two related issues in the wisp cleanup path:

- Dry-run close candidates were counted internally but not surfaced as `would_close_wisps`, so dry-run output could not tell reviewers/operators how many stale wisps would be closed.
- The stale-wisp parent lookup had drifted from the actual bd 1.0.4 schema. bd 1.0.4 stores ephemeral dependency edges in `wisp_dependencies` with a generic `depends_on_id` target column; it does not use split `depends_on_wisp_id` / `depends_on_issue_id` columns.

## Fix

- Report non-mutating dry-run close candidates as `would_close_wisps:<count>`.
- Use `wisp_dependencies.depends_on_id` for stale child-wisp parent-child edges and closed-parent purge protection.
- Use durable `dependencies.depends_on_id` for stale issue dependency exclusions.
- Gate incompatible dependency schemas before dependency-aware cleanup queries.
- Update the formula docs and tests to match the bd 1.0.4 dependency schema.

## Verification

- Rebased cleanly onto current `origin/main` (`dded3b863`).
- `go test ./examples/gastown -run 'TestReaper(ParentIDIsParentChildDependencyProjection|SQLReflectsCurrentSchema|SkipsDependencyQueriesWithoutGenericDependencyTargets|SkipsDependencyQueriesWithoutWispDependencyTable|DoesNotCloseNonClosedWispsByAgeOnly|ClosesStaleWispsOnlyWithClosedParent|DryRunReportsWouldCloseStaleWisps|FormulaSQLReflectsCurrentSchema|FormulaMatchesScriptDefaults|FailureAnomalyPreservesDoltErrorTail|CommitReportsOnlySuccessfulPurgeRows)' -count=1`
- `go test ./examples/gastown -count=1`
- Real disposable bd 1.0.4 + real Dolt SQL server smoke: bd created `tst-child -> tst-parent` as `type=parent-child` in `wisp_dependencies(issue_id, depends_on_id, type)`, reaper reported `stale_wisps:1, closed_wisps:1`, and readback showed both `tst-child` and `tst-parent` closed.
- `git diff --check`

Local `.githooks/pre-commit` did run: changed-package lint and `go vet ./...` passed. The broad `make test-fast-parallel` hook phase failed in unrelated `cmd/gc` shards with fixture/environment failures (`formula "..." not found in search paths`, `Error: no beads database found`, `/tmp/gct...` TempDir missing, and Dolt leak guard failures). Logs from the retry are under `/data/tmp/gc-local-tests.ksmf3o`.