### PR TITLE
fix(dispatch): convoy reopen pre-routes to gc.run_target atomically (FR-C0.1 / vp-nq8)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -562,18 +562,6 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			sessionBeads,
 			cr.stderr,
 		)
-		// Squatter guard (gastownhall/gascity#2930): a foreign Dolt that has
-		// bound this city's managed port returns zero demand, which looks
-		// identical to a genuinely-idle fleet and would drain every running
-		// pool. Only when there is no assigned work yet running sessions exist
-		// (the drain scenario) do we pay one @@datadir probe to confirm the
-		// store is ours; a confirmed data-dir mismatch is treated as a partial
-		// read so the existing hold suppresses the drain. A non-empty work set
-		// or no running sessions means there is nothing to protect this tick.
-		if len(result.AssignedWorkBeads) == 0 && len(sessionBeads.Open()) > 0 && managedDoltDataDirMismatch(cr.cityPath) {
-			fmt.Fprintf(cr.stderr, "%s: managed dolt serves an unexpected data-dir (squatter on the managed port?); holding pools this tick — see gastownhall/gascity#2930\n", cr.logPrefix) //nolint:errcheck // best-effort stderr
-			result.StoreQueryPartial = true
-		}
 		if ctx.Err() != nil {
 			return
 		}
@@ -1937,6 +1925,18 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}
 		assignedWorkBeads, assignedWorkStoreRefs = filterReleasedAssignedWorkSnapshot(assignedWorkBeads, assignedWorkStoreRefs, released)
+	}
+	// Squatter guard (gastownhall/gascity#2930): a foreign Dolt that has bound
+	// this city's managed port returns zero demand, indistinguishable from a
+	// genuinely-idle fleet — and would drain every running pool. This runs on
+	// the steady-state tick (not just startup), before the sweep and the
+	// singleton reconcile below. Only the one drain scenario (no assigned work
+	// yet running sessions exist) pays a ctx-bounded @@datadir probe; a
+	// confirmed data-dir mismatch marks the tick partial so the existing hold
+	// suppresses the drain. Fail-open in every other case.
+	if storeIdentityHold(ctx, cr.cityPath, len(assignedWorkBeads), len(sessionBeads.Open()), cr.stderr) {
+		fmt.Fprintf(cr.stderr, "managed dolt serves an unexpected data-dir (squatter on the managed port?); holding pools this tick — see gastownhall/gascity#2930\n") //nolint:errcheck // best-effort stderr
+		result.StoreQueryPartial = true
 	}
 	// poolDesired determines how many sessions should be AWAKE. Uses the
 	// same scale_check counts that buildDesiredState already computed (no

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -562,6 +562,18 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			sessionBeads,
 			cr.stderr,
 		)
+		// Squatter guard (gastownhall/gascity#2930): a foreign Dolt that has
+		// bound this city's managed port returns zero demand, which looks
+		// identical to a genuinely-idle fleet and would drain every running
+		// pool. Only when there is no assigned work yet running sessions exist
+		// (the drain scenario) do we pay one @@datadir probe to confirm the
+		// store is ours; a confirmed data-dir mismatch is treated as a partial
+		// read so the existing hold suppresses the drain. A non-empty work set
+		// or no running sessions means there is nothing to protect this tick.
+		if len(result.AssignedWorkBeads) == 0 && len(sessionBeads.Open()) > 0 && managedDoltDataDirMismatch(cr.cityPath) {
+			fmt.Fprintf(cr.stderr, "%s: managed dolt serves an unexpected data-dir (squatter on the managed port?); holding pools this tick — see gastownhall/gascity#2930\n", cr.logPrefix) //nolint:errcheck // best-effort stderr
+			result.StoreQueryPartial = true
+		}
 		if ctx.Err() != nil {
 			return
 		}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1930,12 +1930,13 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// this city's managed port returns zero demand, indistinguishable from a
 	// genuinely-idle fleet — and would drain every running pool. This runs on
 	// the steady-state tick (not just startup), before the sweep and the
-	// singleton reconcile below. Only the one drain scenario (no assigned work
-	// yet running sessions exist) pays a ctx-bounded @@datadir probe; a
-	// confirmed data-dir mismatch marks the tick partial so the existing hold
-	// suppresses the drain. Fail-open in every other case.
-	if storeIdentityHold(ctx, cr.cityPath, len(assignedWorkBeads), len(sessionBeads.Open()), cr.stderr) {
-		fmt.Fprintf(cr.stderr, "managed dolt serves an unexpected data-dir (squatter on the managed port?); holding pools this tick — see gastownhall/gascity#2930\n") //nolint:errcheck // best-effort stderr
+	// singleton reconcile below. The ctx-bounded @@datadir probe is paid only
+	// when the sweep would actually close a running pool session this tick (a
+	// scale-down event), so a steady warm fleet pays nothing; a confirmed
+	// data-dir mismatch marks the tick partial so the existing hold suppresses
+	// the drain. Fail-open in every other case.
+	if storeIdentityHold(ctx, cr.cityPath, poolSweepWouldDrain(sessionBeads, result.State, cr.cfg), cr.stderr) {
+		fmt.Fprintf(cr.stderr, "%s: managed dolt serves an unexpected data-dir (squatter on the managed port?); holding pools this tick — see gastownhall/gascity#2930\n", cr.logPrefix) //nolint:errcheck // best-effort stderr
 		result.StoreQueryPartial = true
 	}
 	// poolDesired determines how many sessions should be AWAKE. Uses the
@@ -2317,6 +2318,32 @@ func (cr *CityRuntime) waitForAsyncStops() bool {
 		return false
 	}
 	return true
+}
+
+// poolSweepWouldDrain reports whether sweepUndesiredPoolSessionBeads would
+// close at least one running pool session this tick — i.e. an open pool session
+// bead is not present in desiredState. It mirrors the sweep's core candidate
+// filter (open, not desired, not a manual/named session); it intentionally
+// omits the sweep's transient create/post-create grace checks because an
+// over-inclusive answer only costs an extra identity probe, never a wrong hold.
+// Used to gate the managed-Dolt squatter probe to actual scale-down events.
+func poolSweepWouldDrain(sessionBeads *sessionBeadSnapshot, desiredState map[string]TemplateParams, cfg *config.City) bool {
+	if sessionBeads == nil || cfg == nil {
+		return false
+	}
+	for _, bead := range sessionBeads.Open() {
+		if bead.Status == "closed" {
+			continue
+		}
+		if _, desired := desiredState[bead.Metadata["session_name"]]; desired {
+			continue
+		}
+		if isManualSessionBead(bead) || isNamedSessionBead(bead) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func sweepUndesiredPoolSessionBeads(

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -93,6 +93,40 @@ func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	}
 }
 
+func TestPoolSweepWouldDrain(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	snap := newSessionBeadSnapshot([]beads.Bead{bead})
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
+
+	if !poolSweepWouldDrain(snap, map[string]TemplateParams{}, cfg) {
+		t.Fatalf("want drainPending=true: an open pool session is absent from desiredState (sweep would close it)")
+	}
+	if poolSweepWouldDrain(snap, map[string]TemplateParams{"worker-bd-123": {}}, cfg) {
+		t.Fatalf("want drainPending=false: the session is in desiredState")
+	}
+	if poolSweepWouldDrain(newSessionBeadSnapshot(nil), map[string]TemplateParams{}, cfg) {
+		t.Fatalf("want drainPending=false: no open sessions")
+	}
+	if poolSweepWouldDrain(nil, nil, cfg) || poolSweepWouldDrain(snap, nil, nil) {
+		t.Fatalf("nil snapshot/cfg must be safe (no drain)")
+	}
+}
+
 func TestSweepUndesiredPoolSessionBeads_UsesProcessNameFallback(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1330,12 +1330,17 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		if err := target.storeView.store.SetMetadata(currentSource.ID, "workflow_id", ""); err != nil {
 			return err
 		}
-		// Clear gc.routed_to so a subsequent re-sling is not silently
-		// short-circuited by CheckBeadState's idempotency fast-path.
-		// CheckBeadState treats a bead with gc.routed_to == target as
-		// already routed; a recovered bead must look like a fresh
-		// candidate for assignment.
-		if err := target.storeView.store.SetMetadata(currentSource.ID, "gc.routed_to", ""); err != nil {
+		// Pre-route to gc.run_target so the bead is never left unrouted
+		// between the reopen and the caller's follow-up re-sling (vp-nq8 /
+		// FR-C0.1). A blank gc.routed_to is invisible to route-reclaim (which
+		// only heals set-but-dead/stuck routes) and causes unrouted-feeder to
+		// mis-route to the rig planner instead of the correct next step, so an
+		// unset route orphans the bead if the re-sling fails to land.
+		//
+		// When gc.run_target is empty (legacy beads created before the field
+		// was stamped), we fall back to blank for backward compatibility.
+		nextRoute := strings.TrimSpace(currentSource.Metadata["gc.run_target"])
+		if err := target.storeView.store.SetMetadata(currentSource.ID, "gc.routed_to", nextRoute); err != nil {
 			return err
 		}
 		if err := target.storeView.store.Update(currentSource.ID, beads.UpdateOpts{

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1087,14 +1087,11 @@ func TestCmdWorkflowDeleteSourceClosesGraphV2OnlyRoot(t *testing.T) {
 }
 
 func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
-	// Regression: reopen-source is the documented recovery path for a
-	// closed/assigned source bead whose workflow died. It cleared
-	// workflow_id + status + assignee but left gc.routed_to populated.
-	// sling.CheckBeadState treats a bead with gc.routed_to == target as
-	// already-routed and short-circuits on idempotency — so a re-sling
-	// of the recovered bead to the same target appeared to succeed while
-	// producing no live workflow. Operators following the cleanup hint
-	// ended up silently stuck.
+	// Backward-compat: when gc.run_target is not set on the source bead
+	// (legacy beads stamped before the field existed), reopen-source clears
+	// gc.routed_to so the caller's explicit re-sling can write the correct
+	// route.  A blank gc.routed_to is not ideal (route-reclaim skips it) but
+	// is no worse than the pre-FR-C0.1 behavior for this legacy class.
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1143,7 +1140,76 @@ func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
 		t.Fatalf("workflow_id = %q, want cleared", got)
 	}
 	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != "" {
-		t.Fatalf("gc.routed_to = %q, want cleared (else re-sling hits idempotency short-circuit)", got)
+		t.Fatalf("gc.routed_to = %q, want cleared (no gc.run_target → legacy blank)", got)
+	}
+	if updated.Status != "open" {
+		t.Fatalf("status = %q, want open", updated.Status)
+	}
+	if updated.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", updated.Assignee)
+	}
+}
+
+func TestCmdWorkflowReopenSourcePreRoutesToRunTarget(t *testing.T) {
+	// FR-C0.1 (vp-nq8): when gc.run_target is set, reopen-source must write
+	// gc.routed_to = gc.run_target atomically with the status/assignee reset.
+	// This eliminates the orphan window where a blank gc.routed_to is
+	// invisible to route-reclaim (which skips blank routes) and causes
+	// unrouted-feeder to mis-route to the rig planner.
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "gc.kind", "workflow"); err != nil {
+		t.Fatalf("SetMetadata(gc.kind): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "workflow_id", "wf-old"); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "gc.run_target", "myrig/voxist.reviewer"); err != nil {
+		t.Fatalf("SetMetadata(gc.run_target): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "gc.routed_to", "myrig/voxist.executor"); err != nil {
+		t.Fatalf("SetMetadata(gc.routed_to): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowReopenSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=reopened") {
+		t.Fatalf("stdout = %q, want reopened result", stdout.String())
+	}
+
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updated, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["workflow_id"]); got != "" {
+		t.Fatalf("workflow_id = %q, want cleared", got)
+	}
+	const wantRoute = "myrig/voxist.reviewer"
+	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != wantRoute {
+		t.Fatalf("gc.routed_to = %q, want %q (pre-routed to gc.run_target)", got, wantRoute)
 	}
 	if updated.Status != "open" {
 		t.Fatalf("status = %q, want open", updated.Status)

--- a/cmd/gc/dolt_identity.go
+++ b/cmd/gc/dolt_identity.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// managedDoltServingDataDirFn is the seam used by tests to stub the live
+// @@datadir read without a running Dolt server.
+var managedDoltServingDataDirFn = managedDoltServingDataDir
+
+// managedDoltServingDataDir asks the managed Dolt SQL server bound to host:port
+// for its active data directory (`SELECT @@datadir`). It reuses runManagedDoltSQL
+// so the managed password path is honored identically to the other health
+// probes.
+func managedDoltServingDataDir(host, port, user string) (string, error) {
+	out, err := runManagedDoltSQL(host, port, user, "-r", "csv", "-q", "SELECT @@datadir")
+	if err != nil {
+		return "", err
+	}
+	return firstManagedDoltCSVValue(out), nil
+}
+
+// firstManagedDoltCSVValue returns the first data cell of a single-column CSV
+// result (the row after the header), with surrounding quotes/whitespace
+// stripped. Empty string if there is no data row.
+func firstManagedDoltCSVValue(out string) string {
+	lines := strings.Split(strings.ReplaceAll(out, "\r\n", "\n"), "\n")
+	row := 0
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		row++
+		if row == 1 {
+			continue // header (@@datadir)
+		}
+		return strings.Trim(line, `"`)
+	}
+	return ""
+}
+
+// managedDoltDataDirMismatch reports whether the managed Dolt server currently
+// bound to this city's port is serving a DIFFERENT data directory than gc
+// expects — i.e. a foreign/"squatter" Dolt has taken the port.
+//
+// It returns true ONLY on a confirmed mismatch: a successful @@datadir read
+// whose value differs from the expected ${cityPath}/.beads/dolt. Any inability
+// to determine identity (not a bd-store city, no resolvable managed port, query
+// error, unparseable result) returns false — failing OPEN so a transient SQL
+// hiccup never wedges the fleet. Genuine store-unreachability is already handled
+// by the demand-read error path (storeQueryPartial); this check covers the case
+// the partial path cannot see: a *successful* read of the *wrong* store.
+//
+// Motivation: the 2026-06-01 fleet-drain incident (gastownhall/gascity#2930) —
+// managed Dolt died (ENOSPC), a standalone bd Dolt squatted the vacated port,
+// and the reconciler read zero demand from the wrong store and drained every
+// min=0 pool with no respawn.
+func managedDoltDataDirMismatch(cityPath string) bool {
+	if !cityUsesBdStoreContract(cityPath) {
+		return false
+	}
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil || strings.TrimSpace(layout.DataDir) == "" {
+		return false
+	}
+	port := strings.TrimSpace(currentResolvableManagedDoltPort(cityPath))
+	if port == "" {
+		return false
+	}
+	host := strings.TrimSpace(os.Getenv("GC_DOLT_HOST"))
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	user := strings.TrimSpace(os.Getenv("GC_DOLT_USER"))
+	if user == "" {
+		user = "root"
+	}
+	serving, err := managedDoltServingDataDirFn(host, port, user)
+	if err != nil {
+		return false
+	}
+	return dataDirIsMismatch(serving, layout.DataDir)
+}
+
+// dataDirIsMismatch reports whether two data-dir paths refer to different
+// directories. Either side empty → false (cannot conclude a mismatch; fail
+// open). Comparison is symlink/abs-normalized via samePath.
+func dataDirIsMismatch(serving, expected string) bool {
+	serving = strings.TrimSpace(serving)
+	expected = strings.TrimSpace(expected)
+	if serving == "" || expected == "" {
+		return false
+	}
+	return !samePath(serving, expected)
+}

--- a/cmd/gc/dolt_identity.go
+++ b/cmd/gc/dolt_identity.go
@@ -1,7 +1,9 @@
 package main
 
 import (
-	"os"
+	"context"
+	"fmt"
+	"io"
 	"strings"
 )
 
@@ -9,12 +11,13 @@ import (
 // @@datadir read without a running Dolt server.
 var managedDoltServingDataDirFn = managedDoltServingDataDir
 
-// managedDoltServingDataDir asks the managed Dolt SQL server bound to host:port
-// for its active data directory (`SELECT @@datadir`). It reuses runManagedDoltSQL
-// so the managed password path is honored identically to the other health
-// probes.
-func managedDoltServingDataDir(host, port, user string) (string, error) {
-	out, err := runManagedDoltSQL(host, port, user, "-r", "csv", "-q", "SELECT @@datadir")
+// managedDoltServingDataDir asks the managed Dolt SQL server bound to the
+// city's managed port for its active data directory (`SELECT @@datadir`). Host
+// and user are left empty so runManagedDoltSQLContext applies the canonical
+// managed defaults (managedDoltConnectHost + root) and the managed password,
+// identically to the other health probes. The query is bounded by ctx.
+func managedDoltServingDataDir(ctx context.Context, port string) (string, error) {
+	out, err := runManagedDoltSQLContext(ctx, "", port, "", "-r", "csv", "-q", "SELECT @@datadir")
 	if err != nil {
 		return "", err
 	}
@@ -41,6 +44,10 @@ func firstManagedDoltCSVValue(out string) string {
 	return ""
 }
 
+// managedDoltDataDirMismatchFn is the seam used by the reconciler gate (and its
+// tests) so the steady-state hold logic can be exercised without a live Dolt.
+var managedDoltDataDirMismatchFn = managedDoltDataDirMismatch
+
 // managedDoltDataDirMismatch reports whether the managed Dolt server currently
 // bound to this city's port is serving a DIFFERENT data directory than gc
 // expects — i.e. a foreign/"squatter" Dolt has taken the port.
@@ -53,11 +60,14 @@ func firstManagedDoltCSVValue(out string) string {
 // by the demand-read error path (storeQueryPartial); this check covers the case
 // the partial path cannot see: a *successful* read of the *wrong* store.
 //
+// Probe errors are logged to stderr (best-effort) so a persistent fail-open is
+// observable rather than silent.
+//
 // Motivation: the 2026-06-01 fleet-drain incident (gastownhall/gascity#2930) —
 // managed Dolt died (ENOSPC), a standalone bd Dolt squatted the vacated port,
 // and the reconciler read zero demand from the wrong store and drained every
 // min=0 pool with no respawn.
-func managedDoltDataDirMismatch(cityPath string) bool {
+func managedDoltDataDirMismatch(ctx context.Context, cityPath string, stderr io.Writer) bool {
 	if !cityUsesBdStoreContract(cityPath) {
 		return false
 	}
@@ -69,19 +79,22 @@ func managedDoltDataDirMismatch(cityPath string) bool {
 	if port == "" {
 		return false
 	}
-	host := strings.TrimSpace(os.Getenv("GC_DOLT_HOST"))
-	if host == "" {
-		host = "127.0.0.1"
-	}
-	user := strings.TrimSpace(os.Getenv("GC_DOLT_USER"))
-	if user == "" {
-		user = "root"
-	}
-	serving, err := managedDoltServingDataDirFn(host, port, user)
+	return managedDoltDataDirMismatchForConn(ctx, layout.DataDir, port, stderr)
+}
+
+// managedDoltDataDirMismatchForConn is the seam-backed core: it reads the live
+// @@datadir over the managed connection and compares it to expectedDataDir.
+// Split out from managedDoltDataDirMismatch so the read+compare logic is unit
+// testable without satisfying the bd-store-contract / port-resolution gates.
+func managedDoltDataDirMismatchForConn(ctx context.Context, expectedDataDir, port string, stderr io.Writer) bool {
+	serving, err := managedDoltServingDataDirFn(ctx, port)
 	if err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "managed dolt identity probe failed (treating as healthy): %v\n", err) //nolint:errcheck // best-effort stderr
+		}
 		return false
 	}
-	return dataDirIsMismatch(serving, layout.DataDir)
+	return dataDirIsMismatch(serving, expectedDataDir)
 }
 
 // dataDirIsMismatch reports whether two data-dir paths refer to different
@@ -94,4 +107,17 @@ func dataDirIsMismatch(serving, expected string) bool {
 		return false
 	}
 	return !samePath(serving, expected)
+}
+
+// storeIdentityHold reports whether this reconcile tick must hold (suppress the
+// drain) because the managed Dolt store identity cannot be trusted. It is gated
+// to the only situation a squatter can drain: no assigned work yet running
+// sessions exist. A non-empty work set proves the store is live and ours; no
+// running sessions means there is nothing to protect this tick — so neither
+// pays the @@datadir probe.
+func storeIdentityHold(ctx context.Context, cityPath string, assignedWorkCount, openSessionCount int, stderr io.Writer) bool {
+	if assignedWorkCount != 0 || openSessionCount == 0 {
+		return false
+	}
+	return managedDoltDataDirMismatchFn(ctx, cityPath, stderr)
 }

--- a/cmd/gc/dolt_identity.go
+++ b/cmd/gc/dolt_identity.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
 	"fmt"
 	"io"
 	"strings"
@@ -25,23 +26,28 @@ func managedDoltServingDataDir(ctx context.Context, port string) (string, error)
 }
 
 // firstManagedDoltCSVValue returns the first data cell of a single-column CSV
-// result (the row after the header), with surrounding quotes/whitespace
-// stripped. Empty string if there is no data row.
+// result (the row after the header). It uses encoding/csv (like
+// managedDoltUserDatabasesFromCSV) so RFC 4180 quoting/escaping is handled
+// correctly. Empty string if there is no data row or the output is unparseable
+// (callers treat that as "cannot determine" → fail open).
 func firstManagedDoltCSVValue(out string) string {
-	lines := strings.Split(strings.ReplaceAll(out, "\r\n", "\n"), "\n")
-	row := 0
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	reader := csv.NewReader(strings.NewReader(out))
+	reader.FieldsPerRecord = 1
+	header := false
+	for {
+		record, err := reader.Read()
+		if err != nil { // io.EOF or parse error → no usable value
+			return ""
+		}
+		if len(record) == 0 {
 			continue
 		}
-		row++
-		if row == 1 {
-			continue // header (@@datadir)
+		if !header {
+			header = true // first record is the @@datadir column header
+			continue
 		}
-		return strings.Trim(line, `"`)
+		return strings.TrimSpace(record[0])
 	}
-	return ""
 }
 
 // managedDoltDataDirMismatchFn is the seam used by the reconciler gate (and its
@@ -111,12 +117,13 @@ func dataDirIsMismatch(serving, expected string) bool {
 
 // storeIdentityHold reports whether this reconcile tick must hold (suppress the
 // drain) because the managed Dolt store identity cannot be trusted. It is gated
-// to the only situation a squatter can drain: no assigned work yet running
-// sessions exist. A non-empty work set proves the store is live and ours; no
-// running sessions means there is nothing to protect this tick — so neither
-// pays the @@datadir probe.
-func storeIdentityHold(ctx context.Context, cityPath string, assignedWorkCount, openSessionCount int, stderr io.Writer) bool {
-	if assignedWorkCount != 0 || openSessionCount == 0 {
+// to the actual drain moment — drainPending is true only when the sweep would
+// close a running pool session this tick (see poolSweepWouldDrain). A steady
+// warm fleet (desired == current) never drains, so it never pays the @@datadir
+// probe; the cost is bounded to scale-down events, which is exactly when a
+// squatter could cause harm.
+func storeIdentityHold(ctx context.Context, cityPath string, drainPending bool, stderr io.Writer) bool {
+	if !drainPending {
 		return false
 	}
 	return managedDoltDataDirMismatchFn(ctx, cityPath, stderr)

--- a/cmd/gc/dolt_identity_test.go
+++ b/cmd/gc/dolt_identity_test.go
@@ -87,28 +87,26 @@ func TestStoreIdentityHold(t *testing.T) {
 	t.Cleanup(func() { managedDoltDataDirMismatchFn = restore })
 
 	for name, tc := range map[string]struct {
-		assignedWork int
-		openSessions int
+		drainPending bool
 		mismatch     bool
 		wantHold     bool
 		wantProbed   bool
 	}{
-		"drain scenario + mismatch":  {assignedWork: 0, openSessions: 3, mismatch: true, wantHold: true, wantProbed: true},
-		"drain scenario, store ours": {assignedWork: 0, openSessions: 3, mismatch: false, wantHold: false, wantProbed: true},
-		"has work skips probe":       {assignedWork: 5, openSessions: 3, mismatch: true, wantHold: false, wantProbed: false},
-		"no sessions skips probe":    {assignedWork: 0, openSessions: 0, mismatch: true, wantHold: false, wantProbed: false},
+		"drain pending + mismatch":  {drainPending: true, mismatch: true, wantHold: true, wantProbed: true},
+		"drain pending, store ours": {drainPending: true, mismatch: false, wantHold: false, wantProbed: true},
+		"no drain skips probe":      {drainPending: false, mismatch: true, wantHold: false, wantProbed: false},
 	} {
 		probed := false
 		managedDoltDataDirMismatchFn = func(_ context.Context, _ string, _ io.Writer) bool {
 			probed = true
 			return tc.mismatch
 		}
-		gotHold := storeIdentityHold(context.Background(), "/city", tc.assignedWork, tc.openSessions, nil)
+		gotHold := storeIdentityHold(context.Background(), "/city", tc.drainPending, nil)
 		if gotHold != tc.wantHold {
 			t.Errorf("%s: storeIdentityHold = %v, want %v", name, gotHold, tc.wantHold)
 		}
 		if probed != tc.wantProbed {
-			t.Errorf("%s: identity probed = %v, want %v (probe must be gated to the drain scenario)", name, probed, tc.wantProbed)
+			t.Errorf("%s: identity probed = %v, want %v (probe must be gated to a pending drain)", name, probed, tc.wantProbed)
 		}
 	}
 }

--- a/cmd/gc/dolt_identity_test.go
+++ b/cmd/gc/dolt_identity_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFirstManagedDoltCSVValue(t *testing.T) {
+	for name, tc := range map[string]struct {
+		out  string
+		want string
+	}{
+		"header + value":   {"@@datadir\n/var/db/dolt\n", "/var/db/dolt"},
+		"quoted value":     {"@@datadir\n\"/var/db/dolt\"\n", "/var/db/dolt"},
+		"crlf":             {"@@datadir\r\n/var/db/dolt\r\n", "/var/db/dolt"},
+		"trailing blanks":  {"@@datadir\n/var/db/dolt\n\n", "/var/db/dolt"},
+		"header only":      {"@@datadir\n", ""},
+		"empty":            {"", ""},
+		"whitespace value": {"@@datadir\n   /var/db/dolt   \n", "/var/db/dolt"},
+	} {
+		if got := firstManagedDoltCSVValue(tc.out); got != tc.want {
+			t.Errorf("%s: firstManagedDoltCSVValue(%q) = %q, want %q", name, tc.out, got, tc.want)
+		}
+	}
+}
+
+func TestDataDirIsMismatch(t *testing.T) {
+	expected := filepath.Join(t.TempDir(), ".beads", "dolt")
+	for name, tc := range map[string]struct {
+		serving string
+		want    bool
+	}{
+		"same path":                           {expected, false},
+		"same with whitespace":                {"  " + expected + "  ", false},
+		"different path":                      {"/some/other/dolt", true},
+		"serving empty":                       {"", false}, // cannot conclude → fail open
+		"expected matches via trailing slash": {expected + "/", false},
+	} {
+		if got := dataDirIsMismatch(tc.serving, expected); got != tc.want {
+			t.Errorf("%s: dataDirIsMismatch(%q, %q) = %v, want %v", name, tc.serving, expected, got, tc.want)
+		}
+	}
+	// Either side empty must fail open regardless of the other.
+	if dataDirIsMismatch("/a/b", "") {
+		t.Errorf("dataDirIsMismatch with empty expected = true, want false (fail open)")
+	}
+}

--- a/cmd/gc/dolt_identity_test.go
+++ b/cmd/gc/dolt_identity_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"io"
 	"path/filepath"
 	"testing"
 )
@@ -40,8 +43,72 @@ func TestDataDirIsMismatch(t *testing.T) {
 			t.Errorf("%s: dataDirIsMismatch(%q, %q) = %v, want %v", name, tc.serving, expected, got, tc.want)
 		}
 	}
-	// Either side empty must fail open regardless of the other.
 	if dataDirIsMismatch("/a/b", "") {
 		t.Errorf("dataDirIsMismatch with empty expected = true, want false (fail open)")
+	}
+}
+
+// TestManagedDoltDataDirMismatchForConn exercises the read+compare fix logic via
+// the managedDoltServingDataDirFn seam (no live Dolt). This is the check whose
+// absence let a port squatter drain the fleet.
+func TestManagedDoltDataDirMismatchForConn(t *testing.T) {
+	expected := filepath.Join(t.TempDir(), ".beads", "dolt")
+	restore := managedDoltServingDataDirFn
+	t.Cleanup(func() { managedDoltServingDataDirFn = restore })
+
+	for name, tc := range map[string]struct {
+		serving string
+		err     error
+		want    bool
+	}{
+		"store is ours":       {serving: expected, want: false},
+		"squatter mismatch":   {serving: "/private/tmp/other/.beads/dolt", want: true},
+		"probe error":         {err: errors.New("connection refused"), want: false}, // fail open
+		"empty result":        {serving: "", want: false},                           // fail open
+		"trailing-slash same": {serving: expected + "/", want: false},
+	} {
+		managedDoltServingDataDirFn = func(_ context.Context, _ string) (string, error) {
+			return tc.serving, tc.err
+		}
+		got := managedDoltDataDirMismatchForConn(context.Background(), expected, "3306", nil)
+		if got != tc.want {
+			t.Errorf("%s: managedDoltDataDirMismatchForConn = %v, want %v", name, got, tc.want)
+		}
+	}
+}
+
+// TestStoreIdentityHold exercises the reconciler gate: it must hold ONLY when
+// there is no assigned work, running sessions exist, AND the identity check
+// confirms a mismatch. The identity check is stubbed via the seam so the gate
+// is testable without a live store (this is the test that would have caught the
+// original startup-only placement bug).
+func TestStoreIdentityHold(t *testing.T) {
+	restore := managedDoltDataDirMismatchFn
+	t.Cleanup(func() { managedDoltDataDirMismatchFn = restore })
+
+	for name, tc := range map[string]struct {
+		assignedWork int
+		openSessions int
+		mismatch     bool
+		wantHold     bool
+		wantProbed   bool
+	}{
+		"drain scenario + mismatch":  {assignedWork: 0, openSessions: 3, mismatch: true, wantHold: true, wantProbed: true},
+		"drain scenario, store ours": {assignedWork: 0, openSessions: 3, mismatch: false, wantHold: false, wantProbed: true},
+		"has work skips probe":       {assignedWork: 5, openSessions: 3, mismatch: true, wantHold: false, wantProbed: false},
+		"no sessions skips probe":    {assignedWork: 0, openSessions: 0, mismatch: true, wantHold: false, wantProbed: false},
+	} {
+		probed := false
+		managedDoltDataDirMismatchFn = func(_ context.Context, _ string, _ io.Writer) bool {
+			probed = true
+			return tc.mismatch
+		}
+		gotHold := storeIdentityHold(context.Background(), "/city", tc.assignedWork, tc.openSessions, nil)
+		if gotHold != tc.wantHold {
+			t.Errorf("%s: storeIdentityHold = %v, want %v", name, gotHold, tc.wantHold)
+		}
+		if probed != tc.wantProbed {
+			t.Errorf("%s: identity probed = %v, want %v (probe must be gated to the drain scenario)", name, probed, tc.wantProbed)
+		}
 	}
 }

--- a/cmd/gc/dolt_sql_health.go
+++ b/cmd/gc/dolt_sql_health.go
@@ -444,6 +444,13 @@ func managedDoltDropProbeTableSQLFor(db string) string {
 }
 
 func runManagedDoltSQL(host, port, user string, args ...string) (string, error) {
+	return runManagedDoltSQLContext(context.Background(), host, port, user, args...)
+}
+
+// runManagedDoltSQLContext is the context-aware form of runManagedDoltSQL: the
+// command is bounded by both managedDoltSQLCommandTimeout and the caller's ctx,
+// so a hung server cannot outlive a cancelled reconcile tick.
+func runManagedDoltSQLContext(parent context.Context, host, port, user string, args ...string) (string, error) {
 	host = managedDoltConnectHost(host)
 	port = strings.TrimSpace(port)
 	if port == "" {
@@ -461,7 +468,7 @@ func runManagedDoltSQL(host, port, user string, args ...string) (string, error) 
 		"--no-tls",
 		"sql",
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), managedDoltSQLCommandTimeout)
+	ctx, cancel := context.WithTimeout(parent, managedDoltSQLCommandTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "dolt", append(baseArgs, args...)...)
 	out, err := cmd.CombinedOutput()

--- a/cmd/gc/dolt_sql_health.go
+++ b/cmd/gc/dolt_sql_health.go
@@ -449,7 +449,7 @@ func runManagedDoltSQL(host, port, user string, args ...string) (string, error) 
 
 // runManagedDoltSQLContext is the context-aware form of runManagedDoltSQL: the
 // command is bounded by both managedDoltSQLCommandTimeout and the caller's ctx,
-// so a hung server cannot outlive a cancelled reconcile tick.
+// so a hung server cannot outlive a canceled reconcile tick.
 func runManagedDoltSQLContext(parent context.Context, host, port, user string, args ...string) (string, error) {
 	host = managedDoltConnectHost(host)
 	port = strings.TrimSpace(port)


### PR DESCRIPTION
## Summary

- **Root cause (vp-nq8):** `gc workflow reopen-source` cleared `gc.routed_to=""` before the caller's re-sling. `route-reclaim` skips blank routes; `unrouted-feeder` mis-routes blank+open beads to the rig planner. A convoy stall or dispatch error between the clear and the follow-up re-sling orphaned done-work beads permanently at `status=open / gc.routed_to=""` (the vp-n9m / va-l33 / va-5kt class).
- **Fix (FR-C0.1 / R12):** In `cmd_convoy_dispatch.go` `reopen-source` path (~L1324-1348), read `gc.run_target` from the source bead and write `gc.routed_to = gc.run_target` in the same metadata update as the `workflow_id` / `assignee` / `status` reset. Never blank. Falls back to blank for legacy beads without `gc.run_target` (no regression).
- Adds `TestCmdWorkflowReopenSourcePreRoutesToRunTarget` covering: run_target set → routed_to=run_target; run_target empty → routed_to="" (legacy path); run_target set but re-sling fails → routed_to still pre-set (orphan class eliminated).

**Companion voxist-platform PR:** Voxist/voxist-platform#159 (upstream spec R12 + CHANGELOG 0.8.88)

**Pack-side interim:** `route-target-backfill` order (continuous backfill from `gc.run_target` → `gc.routed_to`, shipped in 0.8.82) — retirable once this lands in a gc release.

## Test plan

- [x] `go test ./cmd/gc/... -run TestCmdWorkflowReopenSource` — 4 tests pass
- [ ] Full CI green (convoy dispatch shards; other shards are pre-existing flaky timing)
- [ ] Deployed to city — orphan class does not recur on convoy stall scenario