### PR TITLE
feat: add mol-polecat-report formula for investigation-only work (ga-16q)

### DIFF
--- a/cmd/gc/polecat_report_formula_test.go
+++ b/cmd/gc/polecat_report_formula_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/formula"
+)
+
+func coreFormulaDir(t *testing.T) string {
+	t.Helper()
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "internal", "bootstrap", "packs", "core", "formulas")
+}
+
+// TestPolecatReportFormulaParsesAndHasNoGHPRCreate verifies that the
+// mol-polecat-report formula parses without error, contains a write-report
+// terminal step, and never instructs the agent to call gh pr create or
+// git push in any step description.
+func TestPolecatReportFormulaParsesAndHasNoGHPRCreate(t *testing.T) {
+	dir := coreFormulaDir(t)
+	path := filepath.Join(dir, "mol-polecat-report.toml")
+
+	parser := formula.NewParser(dir)
+	f, err := parser.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile mol-polecat-report.toml: %v", err)
+	}
+
+	var hasWriteReport, hasWriteNotes, hasClose, hasDrainAck bool
+	for _, step := range f.Steps {
+		if strings.Contains(step.Description, "gh pr create") {
+			t.Errorf("step %q must not invoke 'gh pr create'", step.ID)
+		}
+		if strings.Contains(step.Description, "git push") {
+			t.Errorf("step %q must not invoke 'git push'", step.ID)
+		}
+		if step.ID == "write-report" {
+			hasWriteReport = true
+			if strings.Contains(step.Description, "bd update {{issue}} --notes") {
+				hasWriteNotes = true
+			}
+			if strings.Contains(step.Description, "bd close {{issue}}") {
+				hasClose = true
+			}
+			if strings.Contains(step.Description, "gc runtime drain-ack") {
+				hasDrainAck = true
+			}
+		}
+	}
+	if !hasWriteReport {
+		t.Error("mol-polecat-report formula missing 'write-report' step")
+	}
+	if !hasWriteNotes {
+		t.Error("write-report step must write findings with 'bd update {{issue}} --notes'")
+	}
+	if !hasClose {
+		t.Error("write-report step must close the bead with 'bd close {{issue}}'")
+	}
+	if !hasDrainAck {
+		t.Error("write-report step must signal the reconciler with 'gc runtime drain-ack'")
+	}
+}

--- a/cmd/gc/polecat_report_formula_test.go
+++ b/cmd/gc/polecat_report_formula_test.go
@@ -29,13 +29,23 @@ func TestPolecatReportFormulaParsesAndHasNoGHPRCreate(t *testing.T) {
 		t.Fatalf("ParseFile mol-polecat-report.toml: %v", err)
 	}
 
-	var hasWriteReport, hasWriteNotes, hasClose, hasDrainAck bool
+	var hasWriteReport, hasWriteNotes, hasClose, hasDrainAck, hasImplement bool
 	for _, step := range f.Steps {
 		if strings.Contains(step.Description, "gh pr create") {
 			t.Errorf("step %q must not invoke 'gh pr create'", step.ID)
 		}
 		if strings.Contains(step.Description, "git push") {
 			t.Errorf("step %q must not invoke 'git push'", step.ID)
+		}
+		if strings.Contains(step.Description, "git checkout -- .") {
+			t.Errorf("step %q must not run destructive 'git checkout -- .' in a shared checkout", step.ID)
+		}
+		if step.ID == "implement" {
+			hasImplement = true
+			desc := strings.ToLower(step.Description)
+			if !strings.Contains(desc, "no code changes") && !strings.Contains(desc, "analysis only") {
+				t.Errorf("implement step must forbid code changes (expected 'no code changes' or 'analysis only'), got: %q", step.Description)
+			}
 		}
 		if step.ID == "write-report" {
 			hasWriteReport = true
@@ -49,6 +59,9 @@ func TestPolecatReportFormulaParsesAndHasNoGHPRCreate(t *testing.T) {
 				hasDrainAck = true
 			}
 		}
+	}
+	if !hasImplement {
+		t.Error("mol-polecat-report formula missing 'implement' step override")
 	}
 	if !hasWriteReport {
 		t.Error("mol-polecat-report formula missing 'write-report' step")

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-report.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-report.toml
@@ -68,6 +68,23 @@ Close this step immediately and proceed to implement.
 **Exit criteria:** (immediate — no action required)"""
 
 [[steps]]
+id = "implement"
+title = "Investigate (no code changes)"
+needs = ["preflight-tests"]
+description = """
+Investigate the issue. This is analysis only — you produce findings, not
+code changes.
+
+- Read the relevant sources, traces, logs, and configuration in place.
+- Gather concrete evidence: file paths, line numbers, command output.
+- Identify the root cause, or state clearly that it is unknown.
+- Do NOT edit, create, or delete any files. If you discover a code fix is
+  required, do NOT attempt it here — mail Witness and drain-ack so the
+  operator can re-pour with mol-polecat-commit or mol-polecat-pr.
+
+**Exit criteria:** Investigation complete, evidence gathered, no files modified."""
+
+[[steps]]
 id = "self-review"
 title = "Self-review: verify investigation is complete"
 needs = ["implement"]
@@ -88,11 +105,12 @@ Review your findings before writing the final report.
 git status
 ```
 
-There must be NO uncommitted code changes. If you made any accidental
-edits, discard them:
-```bash
-git checkout -- .
-```
+There must be NO uncommitted code changes. If `git status` shows any
+modifications, STOP — do not run a broad `git checkout`. This is a shared,
+non-isolated checkout, so a blanket discard can wipe unrelated local work.
+Mail Witness, note the unexpected dirty state, and drain-ack so the
+operator can inspect. Only revert files you are certain you touched, by
+explicit path (e.g. `git checkout -- path/to/file`).
 
 This formula produces ZERO code changes. All output is bead notes.
 

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-report.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-report.toml
@@ -1,0 +1,154 @@
+description = """
+Polecat report-only variant — investigates an issue and writes findings
+as bead notes, without creating a branch or opening a pull request.
+
+Extends mol-polecat-base with a lightweight workspace (no git checkout, no
+isolated worktree) and a write-report terminal step instead of commit+push.
+Designed for tasks that produce analysis, recommendations, or investigation
+results — not code changes.
+
+## Polecat Contract (Report-Only Model)
+
+1. Receive work (molecule poured with this formula, assigned to you)
+2. Follow steps in order (read descriptions, execute, move to next)
+3. Write findings to bead notes, close bead, exit
+4. You are GONE — no branch, no PR, no push
+
+**No code changes.** Investigation results land as bead notes. Zero calls
+to `git push` or `gh pr create`.
+
+## Failure Modes
+
+| Situation | Action |
+|-----------|--------|
+| Investigation blocked | Mail Witness, mark yourself stuck |
+| Blocked on external | Mail Witness, mark yourself stuck |
+| Context filling | `gc runtime request-restart` (blocks until controller kills you) |
+| Unsure what to do | Mail Witness, don't guess |"""
+formula = "mol-polecat-report"
+extends = ["mol-polecat-base"]
+
+[[steps]]
+id = "workspace-setup"
+title = "Verify assignment (report-only, no worktree)"
+needs = ["load-context"]
+description = """
+No code changes are expected in this formula. Confirm the scope and
+verify the investigation environment is ready.
+
+**No git checkout, no isolated worktree.** You investigate with existing
+sources in place. If you discover the issue requires a code fix, do NOT
+attempt it here — mail Witness and drain-ack so the operator can
+re-pour with `mol-polecat-commit` or `mol-polecat-pr`.
+
+**1. Confirm scope:**
+
+Re-read the issue with fresh eyes:
+```bash
+bd show {{issue}}
+```
+
+**2. Prime environment:**
+```bash
+gc prime
+bd prime
+```
+
+**Exit criteria:** Scope confirmed as investigation/analysis only."""
+
+[[steps]]
+id = "preflight-tests"
+title = "Skip pre-flights (no code changes)"
+needs = ["workspace-setup"]
+description = """
+No pre-flights needed — this formula produces no code changes.
+
+Close this step immediately and proceed to implement.
+
+**Exit criteria:** (immediate — no action required)"""
+
+[[steps]]
+id = "self-review"
+title = "Self-review: verify investigation is complete"
+needs = ["implement"]
+description = """
+Review your findings before writing the final report.
+
+**1. Verify completeness:**
+
+- Does the investigation answer every question in the issue description?
+- Are findings specific (file paths, line numbers, concrete observations)?
+- Are open questions or unresolved ambiguities noted?
+- Is the root cause identified (or clearly stated as unknown)?
+- Are recommended next steps actionable?
+
+**2. Check for accidental code changes:**
+
+```bash
+git status
+```
+
+There must be NO uncommitted code changes. If you made any accidental
+edits, discard them:
+```bash
+git checkout -- .
+```
+
+This formula produces ZERO code changes. All output is bead notes.
+
+**Exit criteria:** Findings complete, git status clean."""
+
+[[steps]]
+id = "write-report"
+title = "Write report to bead notes and close"
+needs = ["self-review"]
+description = """
+Write your investigation findings to the bead and close it. No branch,
+no push, no PR. You cease to exist after this step.
+
+**1. Format and write the report:**
+
+Compose a clear summary of your findings. Include:
+- Root cause (or "unknown — further investigation required")
+- Supporting evidence (file paths, line numbers, log snippets)
+- Recommended next steps
+- Any open questions or caveats
+
+```bash
+REPORT="$(cat <<'ENDREPORT'
+## Findings
+
+<root cause or "unknown — further investigation required">
+
+## Evidence
+
+<specific evidence: file:line, log snippet, command output>
+
+## Recommended next steps
+
+<actionable items>
+
+## Open questions
+
+<unresolved items, caveats>
+ENDREPORT
+)"
+bd update {{issue}} --notes "$REPORT"
+```
+
+**2. Close the bead:**
+```bash
+bd close {{issue}}
+```
+
+**3. Signal reconciler and exit.**
+```bash
+gc runtime drain-ack
+exit
+```
+
+`gc runtime drain-ack` tells the reconciler to kill this session. The
+reconciler only restarts you if the pool check command finds more work.
+You are GONE. Done means gone. There is no idle state.
+
+**Exit criteria:** Report written to bead notes, bead closed, session exited."""

--- a/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
@@ -99,10 +99,19 @@ For small installations where merge review is unnecessary.
 gc sling <agent> <bead-id> --on mol-polecat-commit
 ```
 
+**mol-polecat-report** — Report-only variant. No git checkout, no feature
+branch, no push, no PR. The agent investigates, writes findings as bead
+notes, and exits. Use for analysis or investigation tasks where the output
+is a written report, not a code change.
+
+```
+gc sling <agent> <bead-id> --on mol-polecat-report
+```
+
 **mol-polecat-base** — Shared base for polecat work formulas. Defines
 the common steps (load context, preflight, implement, self-review) that
 variant formulas extend. Not typically used directly — use a variant
-like mol-polecat-commit or mol-polecat-work instead.
+like mol-polecat-commit, mol-polecat-report, or mol-polecat-work instead.
 
 ### Gastown pack formulas (work variants)
 


### PR DESCRIPTION
## Problem

`mol-polecat-pr` always opens a pull request, even when the task is
investigation/analysis rather than a code change. This pollutes the PR queue
with agent-generated reports that should be bead notes, not PRs.

## Solution

New `mol-polecat-report` formula that extends `mol-polecat-base` with a
report-only contract:

- **No git checkout, no feature branch, no push, no `gh pr create`**
- Overrides `workspace-setup` (lightweight — verify scope only)
- Overrides `preflight-tests` (skip — no code changes)
- Overrides `self-review` (verify findings completeness, not a git diff)
- Adds `write-report` terminal step: `bd update --notes`, `bd close`, `gc runtime drain-ack`

Investigation results land as bead notes. The formula is part of the core
SDK bootstrap pack so it's available in all cities without pack configuration.

## Files

- `internal/bootstrap/packs/core/formulas/mol-polecat-report.toml` — formula
- `internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md` — documents the new variant
- `cmd/gc/polecat_report_formula_test.go` — parse test: verifies no `gh pr create` in any step, write-report step exists with correct terminal actions

## Testing

`TestPolecatReportFormulaParsesAndHasNoGHPRCreate` passes. All fast pre-commit tests pass.

Functional behavior tests (molecule cook → wisp with notes, zero PR calls) filed as `needs-tests` for the validator.

Closes ga-16q.