### PR TITLE
fix(reconciler): fair wake-budget selection to prevent session starvation

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -145,6 +146,32 @@ type startCandidate struct {
 
 func (c startCandidate) name() string {
 	return c.session.Metadata["session_name"]
+}
+
+// wakeFairnessTime is the ordering key for the per-tick wake budget: the time the
+// session was last woken (last_woke_at), falling back to its creation time so a
+// brand-new session does not jump ahead of one that has been waiting for a slot.
+// Oldest sorts first = highest priority.
+func wakeFairnessTime(c startCandidate) time.Time {
+	if c.session != nil && c.session.Metadata != nil {
+		if t, err := time.Parse(time.RFC3339, c.session.Metadata["last_woke_at"]); err == nil {
+			return t
+		}
+	}
+	if c.session != nil && !c.session.CreatedAt.IsZero() {
+		return c.session.CreatedAt
+	}
+	return time.Time{}
+}
+
+// sortCandidatesByWakeFairness orders candidates least-recently-woken first so a
+// budget-limited tick rotates wakes across sessions instead of always deferring
+// the same back-of-order sessions. Stable on the original order for ties. Callers
+// must only sort within a dependency wave (every candidate's deps are satisfied).
+func sortCandidatesByWakeFairness(candidates []startCandidate) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return wakeFairnessTime(candidates[i]).Before(wakeFairnessTime(candidates[j]))
+	})
 }
 
 func (c startCandidate) logicalTemplate(cfg *config.City) string {
@@ -1938,6 +1965,13 @@ func executePlannedStartsTraced(
 			}
 			ready = append(ready, candidate)
 		}
+		// Fairness: spend a budget-limited tick on the least-recently-woken
+		// candidates first. The wave order is a stable dependency topo-sort, so
+		// without this the same back-of-order sessions are deferred_by_wake_budget
+		// every tick (a routine pool/infra wake starves a devpipeline agent that
+		// topo-sorts behind it). Sorting within the dependency wave is safe: every
+		// candidate here already has its dependencies satisfied.
+		sortCandidatesByWakeFairness(ready)
 		for offset := 0; offset < len(ready); {
 			if wakeCount >= maxWakes {
 				for _, candidate := range ready[offset:] {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -151,7 +151,7 @@ func (c startCandidate) name() string {
 // wakeFairnessTime is the ordering key for the per-tick wake budget: the time the
 // session was last woken (last_woke_at), falling back to its creation time so a
 // brand-new session does not jump ahead of one that has been waiting for a slot.
-// Oldest sorts first = highest priority.
+// Oldest sorts first so the longest-waiting candidates spend the budget first.
 func wakeFairnessTime(c startCandidate) time.Time {
 	if c.session != nil && c.session.Metadata != nil {
 		if t, err := time.Parse(time.RFC3339, c.session.Metadata["last_woke_at"]); err == nil {
@@ -1968,8 +1968,7 @@ func executePlannedStartsTraced(
 		// Fairness: spend a budget-limited tick on the least-recently-woken
 		// candidates first. The wave order is a stable dependency topo-sort, so
 		// without this the same back-of-order sessions are deferred_by_wake_budget
-		// every tick (a routine pool/infra wake starves a devpipeline agent that
-		// topo-sorts behind it). Sorting within the dependency wave is safe: every
+		// every tick. Sorting within the dependency wave is safe: every
 		// candidate here already has its dependencies satisfied.
 		sortCandidatesByWakeFairness(ready)
 		for offset := 0; offset < len(ready); {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -1239,8 +1239,7 @@ func TestReconcileSessionBeads_DaemonMaxWakesPerTickOverride(t *testing.T) {
 // candidate, the least-recently-woken (longest-waiting) session must win a slot
 // rather than being starved behind more-recently-woken siblings that sort ahead
 // of it in the stable dependency/topo order. Without fairness the same
-// back-of-order agents (e.g. devpipeline agents that topo-sort after the infra
-// they depend on) are deferred_by_wake_budget every tick.
+// back-of-order sessions are deferred_by_wake_budget every tick.
 func TestExecutePlannedStarts_WakeBudgetPrioritizesLeastRecentlyWoken(t *testing.T) {
 	sp := runtime.NewFake()
 	store := beads.NewMemStore()

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -1234,6 +1234,92 @@ func TestReconcileSessionBeads_DaemonMaxWakesPerTickOverride(t *testing.T) {
 	}
 }
 
+// TestExecutePlannedStarts_WakeBudgetPrioritizesLeastRecentlyWoken proves the
+// per-tick wake budget is FAIR. When the budget cannot cover every ready
+// candidate, the least-recently-woken (longest-waiting) session must win a slot
+// rather than being starved behind more-recently-woken siblings that sort ahead
+// of it in the stable dependency/topo order. Without fairness the same
+// back-of-order agents (e.g. devpipeline agents that topo-sort after the infra
+// they depend on) are deferred_by_wake_budget every tick.
+func TestExecutePlannedStarts_WakeBudgetPrioritizesLeastRecentlyWoken(t *testing.T) {
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 6, 4, 3, 30, 0, 0, time.UTC)}
+	budget := 2
+	cfg := &config.City{Daemon: config.DaemonConfig{MaxWakesPerTick: &budget}}
+
+	mkTP := func(name string) TemplateParams {
+		return TemplateParams{
+			Command:      "claude",
+			SessionName:  name,
+			TemplateName: name,
+			ResolvedProvider: &config.ResolvedProvider{
+				Name:          "claude",
+				Command:       "claude",
+				PromptMode:    "arg",
+				ResumeFlag:    "--resume",
+				ResumeStyle:   "flag",
+				SessionIDFlag: "--session-id",
+			},
+		}
+	}
+
+	// "starved" is LAST in slice/topo order (the stable order would defer it),
+	// but it was woken longest ago, so a fair budget must still wake it.
+	specs := []struct{ name, lastWoke string }{
+		{"front-1", "2026-06-04T03:29:00Z"},
+		{"front-2", "2026-06-04T03:29:00Z"},
+		{"starved", "2020-01-01T00:00:00Z"},
+	}
+	desired := map[string]TemplateParams{}
+	var candidates []startCandidate
+	for i, s := range specs {
+		sess, err := store.Create(beads.Bead{
+			Title:  s.name,
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"session_name":   s.name,
+				"agent_name":     s.name,
+				"template":       s.name,
+				"state":          "creating",
+				"generation":     "1",
+				"instance_token": "test-token",
+				"live_hash":      runtime.LiveFingerprint(runtime.Config{Command: "test-cmd"}),
+				"last_woke_at":   s.lastWoke,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Create(%s): %v", s.name, err)
+		}
+		sCopy := sess
+		tp := mkTP(s.name)
+		desired[s.name] = tp
+		candidates = append(candidates, startCandidate{session: &sCopy, tp: tp, order: i})
+	}
+
+	woken := executePlannedStarts(
+		context.Background(),
+		candidates,
+		cfg,
+		desired,
+		sp,
+		store,
+		"",
+		clk,
+		events.Discard,
+		5*time.Second,
+		ioDiscard{},
+		ioDiscard{},
+	)
+	if woken != budget {
+		t.Fatalf("woken = %d, want %d", woken, budget)
+	}
+	if !sp.IsRunning("starved") {
+		t.Fatal("least-recently-woken 'starved' was deferred behind recently-woken siblings — wake budget is not fair (starvation)")
+	}
+}
+
 func TestPrepareStartCandidate_NoneModeInitialMessageStaysInNudge(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Problem

The reconciler's per-tick wake budget (`daemon.max_wakes_per_tick`, default 5) chooses which sessions to start from a **stable dependency topological order** (`topoOrder`), then spends the budget **front-to-back** with no fairness (`executePlannedStarts`). When wake demand exceeds the budget, the **same back-of-order sessions are deferred (`deferred_by_wake_budget`) every tick** and never start until demand drops or an operator manually revives them.

Worse, because the order is a *dependency* sort, agents that depend on infrastructure sort **last** — so a routine pool worker or the control-dispatcher wakes ahead of a pipeline agent holding a P1. Lowering the budget for CPU relief moves the cutoff earlier and amplifies the starvation.

Observed in production (supervisor log): with `max_wakes_per_tick=4`, a wave of 6 candidates repeatedly woke `control-dispatcher` + two pool `dog`s + `documentation_manager` and **deferred `architect` and `reviewer` every tick** — the same agents, indefinitely, until manual revive (which bypasses the budgeted path).

## Fix

Within each dependency wave, sort the ready candidates **least-recently-woken first** (`last_woke_at`, falling back to the session's `CreatedAt`) before spending the budget. A budget-limited tick now **rotates** wakes across sessions; winning a wake updates `last_woke_at` (via `PreWakePatch`), pushing the winner to the back next tick → no permanent starvation. Sorting *within* a wave is safe — every candidate there already has its dependencies satisfied, so dependency ordering across waves is preserved. A brand-new session (no `last_woke_at`) falls back to its `CreatedAt`, so it does not jump ahead of an agent that has been waiting for a slot.

## Test

`TestExecutePlannedStarts_WakeBudgetPrioritizesLeastRecentlyWoken` — three candidates, budget 2, the least-recently-woken one last in slice order. **Fails before** the fix (it is deferred behind the recently-woken siblings); **passes after**.

## Validation

- `go test ./cmd/gc/` scheduling/reconciler/topo/lifecycle/wake/budget suite: green, no regressions.
- Dogfooded against a real fleet: confirmed `last_woke_at` is populated and varied on live session beads and is updated on each wake (so the rotation has a real signal); it is cleared on death/churn and then falls back to the varied `CreatedAt`.
- Full `cmd/gc` binary links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
