### PR TITLE
fix(dispatch): convoy reopen pre-routes to gc.run_target atomically

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -1330,12 +1330,17 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		if err := target.storeView.store.SetMetadata(currentSource.ID, "workflow_id", ""); err != nil {
 			return err
 		}
-		// Clear gc.routed_to so a subsequent re-sling is not silently
-		// short-circuited by CheckBeadState's idempotency fast-path.
-		// CheckBeadState treats a bead with gc.routed_to == target as
-		// already routed; a recovered bead must look like a fresh
-		// candidate for assignment.
-		if err := target.storeView.store.SetMetadata(currentSource.ID, "gc.routed_to", ""); err != nil {
+		// Pre-route to gc.run_target so the bead is never left unrouted
+		// between the reopen and the caller's follow-up re-sling (vp-nq8 /
+		// FR-C0.1). A blank gc.routed_to is invisible to route-reclaim (which
+		// only heals set-but-dead/stuck routes) and causes unrouted-feeder to
+		// mis-route to the rig planner instead of the correct next step, so an
+		// unset route orphans the bead if the re-sling fails to land.
+		//
+		// When gc.run_target is empty (legacy beads created before the field
+		// was stamped), we fall back to blank for backward compatibility.
+		nextRoute := strings.TrimSpace(currentSource.Metadata["gc.run_target"])
+		if err := target.storeView.store.SetMetadata(currentSource.ID, "gc.routed_to", nextRoute); err != nil {
 			return err
 		}
 		if err := target.storeView.store.Update(currentSource.ID, beads.UpdateOpts{

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1087,14 +1087,11 @@ func TestCmdWorkflowDeleteSourceClosesGraphV2OnlyRoot(t *testing.T) {
 }
 
 func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
-	// Regression: reopen-source is the documented recovery path for a
-	// closed/assigned source bead whose workflow died. It cleared
-	// workflow_id + status + assignee but left gc.routed_to populated.
-	// sling.CheckBeadState treats a bead with gc.routed_to == target as
-	// already-routed and short-circuits on idempotency — so a re-sling
-	// of the recovered bead to the same target appeared to succeed while
-	// producing no live workflow. Operators following the cleanup hint
-	// ended up silently stuck.
+	// Backward-compat: when gc.run_target is not set on the source bead
+	// (legacy beads stamped before the field existed), reopen-source clears
+	// gc.routed_to so the caller's explicit re-sling can write the correct
+	// route.  A blank gc.routed_to is not ideal (route-reclaim skips it) but
+	// is no worse than the pre-FR-C0.1 behavior for this legacy class.
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1143,7 +1140,76 @@ func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
 		t.Fatalf("workflow_id = %q, want cleared", got)
 	}
 	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != "" {
-		t.Fatalf("gc.routed_to = %q, want cleared (else re-sling hits idempotency short-circuit)", got)
+		t.Fatalf("gc.routed_to = %q, want cleared (no gc.run_target → legacy blank)", got)
+	}
+	if updated.Status != "open" {
+		t.Fatalf("status = %q, want open", updated.Status)
+	}
+	if updated.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", updated.Assignee)
+	}
+}
+
+func TestCmdWorkflowReopenSourcePreRoutesToRunTarget(t *testing.T) {
+	// FR-C0.1 (vp-nq8): when gc.run_target is set, reopen-source must write
+	// gc.routed_to = gc.run_target atomically with the status/assignee reset.
+	// This eliminates the orphan window where a blank gc.routed_to is
+	// invisible to route-reclaim (which skips blank routes) and causes
+	// unrouted-feeder to mis-route to the rig planner.
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity: %v", err)
+	}
+	source, err := store.Create(beads.Bead{Title: "Source", Type: "task", Status: "closed"})
+	if err != nil {
+		t.Fatalf("Create(source): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "gc.kind", "workflow"); err != nil {
+		t.Fatalf("SetMetadata(gc.kind): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "workflow_id", "wf-old"); err != nil {
+		t.Fatalf("SetMetadata(workflow_id): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "gc.run_target", "myrig/voxist.reviewer"); err != nil {
+		t.Fatalf("SetMetadata(gc.run_target): %v", err)
+	}
+	if err := store.SetMetadata(source.ID, "gc.routed_to", "myrig/voxist.executor"); err != nil {
+		t.Fatalf("SetMetadata(gc.routed_to): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdWorkflowReopenSource(source.ID, sourceWorkflowStoreSelector{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowReopenSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=reopened") {
+		t.Fatalf("stdout = %q, want reopened result", stdout.String())
+	}
+
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(reload): %v", err)
+	}
+	updated, err := reloaded.Get(source.ID)
+	if err != nil {
+		t.Fatalf("Get(source): %v", err)
+	}
+	if got := strings.TrimSpace(updated.Metadata["workflow_id"]); got != "" {
+		t.Fatalf("workflow_id = %q, want cleared", got)
+	}
+	const wantRoute = "myrig/voxist.reviewer"
+	if got := strings.TrimSpace(updated.Metadata["gc.routed_to"]); got != wantRoute {
+		t.Fatalf("gc.routed_to = %q, want %q (pre-routed to gc.run_target)", got, wantRoute)
 	}
 	if updated.Status != "open" {
 		t.Fatalf("status = %q, want open", updated.Status)


### PR DESCRIPTION
Cherry-picks the actual convoy reopen routing fix from #3053 without the rest of that stack.

Attribution:
- Original author: @bourgois / `bourgois <karel@voxist.com>`
- Source commit: f0a6201e36f9d136aadc9e357a07c848e9aae182
- Applied with `git cherry-pick -x`, preserving the original author and source trailer.

Verification:
- `GC_FAST_UNIT=1 go test ./cmd/gc -run 'TestCmdWorkflowReopenSource(ClearsRoutedToForResling|PreRoutesToRunTarget|ConflictsWhenLiveRootExists|RejectsLiveRootInDifferentStore)$|TestRunWorkflowReopenSourceConflictPropagatesExitCode$' -count=1`
- `go vet ./...`

Also attempted `make test-fast-parallel`; `unit-core` passed, but all `cmd/gc` shards failed after their shared `/tmp/gct...` roots disappeared, including shards unrelated to this two-file cherry-pick.
