### PR TITLE
fix(nudge): launch pollers against live sessions

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -119,6 +119,11 @@ func (t nudgeTarget) agentKey() string {
 }
 
 func (t nudgeTarget) pollerKey() string {
+	// Queue items keep alias-oriented Agent values for matching/readability;
+	// poller ownership prefers the concrete session ID so live generations that
+	// share one runtime session name do not reuse each other's sidecar. Keep
+	// the concrete-ID precedence aligned with session.PollerKeyFromBead for
+	// session-bead-derived poller launches.
 	if t.sessionID != "" {
 		return t.sessionID
 	}
@@ -492,7 +497,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 		return 1
 	}
 
-	release, err := acquireNudgePollerLease(target.cityPath, target.sessionName)
+	release, err := acquireNudgePollerLease(target.cityPath, target.sessionName, target.pollerKey())
 	if err != nil {
 		if errors.Is(err, errNudgePollerRunning) {
 			return 0
@@ -684,10 +689,19 @@ func requestManagedNudgeWake(target nudgeTarget, store beads.Store) error {
 
 func workerHandleForNudgeTarget(target nudgeTarget, store beads.Store, sp runtime.Provider) (worker.Handle, error) {
 	if target.sessionName != "" {
-		if target.sessionID != "" {
+		if target.sessionID != "" || target.continuationEpoch != "" {
 			obs, err := workerObserveSessionTargetWithConfig(target.cityPath, store, sp, target.cfg, target.sessionName)
-			if err == nil && !obs.Running {
-				return workerHandleForSessionWithConfig(target.cityPath, store, sp, target.cfg, target.sessionID)
+			if err == nil {
+				matches, matchErr := nudgeTargetLiveGenerationMatches(target, obs, sp)
+				if matchErr != nil {
+					return nil, matchErr
+				}
+				if !matches {
+					return nil, fmt.Errorf("%w: live runtime %q no longer matches session generation %q", runtime.ErrSessionNotFound, target.sessionName, target.pollerKey())
+				}
+				if !obs.Running && target.sessionID != "" {
+					return workerHandleForSessionWithConfig(target.cityPath, store, sp, target.cfg, target.sessionID)
+				}
 			}
 			if err != nil && !errors.Is(err, runtime.ErrSessionNotFound) && !errors.Is(err, session.ErrSessionNotFound) {
 				return nil, err
@@ -727,12 +741,62 @@ func workerHandleForNudgeTarget(target nudgeTarget, store beads.Store, sp runtim
 
 func workerObserveNudgeTarget(target nudgeTarget, store beads.Store, sp runtime.Provider) (worker.LiveObservation, error) {
 	if target.sessionName != "" {
-		return workerObserveSessionTargetWithConfig(target.cityPath, store, sp, target.cfg, target.sessionName)
+		obs, err := workerObserveSessionTargetWithConfig(target.cityPath, store, sp, target.cfg, target.sessionName)
+		if err != nil {
+			return worker.LiveObservation{}, err
+		}
+		matches, err := nudgeTargetLiveGenerationMatches(target, obs, sp)
+		if err != nil {
+			return worker.LiveObservation{}, err
+		}
+		if !matches {
+			obs.Running = false
+			obs.Alive = false
+			obs.Attached = false
+			obs.LastActivity = nil
+		}
+		return obs, nil
 	}
 	if target.sessionID != "" {
 		return workerObserveSessionTargetWithConfig(target.cityPath, store, sp, target.cfg, target.sessionID)
 	}
 	return workerObserveSessionTargetWithConfig(target.cityPath, store, sp, target.cfg, target.sessionName)
+}
+
+func nudgeTargetLiveGenerationMatches(target nudgeTarget, obs worker.LiveObservation, sp runtime.Provider) (bool, error) {
+	if !obs.Running || (target.sessionID == "" && target.continuationEpoch == "") {
+		return true, nil
+	}
+	if target.sessionID != "" {
+		for _, liveID := range []string{obs.SessionID, obs.RuntimeSessionID} {
+			liveID = strings.TrimSpace(liveID)
+			if liveID != "" && liveID != target.sessionID {
+				return false, nil
+			}
+		}
+	}
+	if sp == nil || target.sessionName == "" {
+		return true, nil
+	}
+	if target.sessionID != "" {
+		liveID, err := sp.GetMeta(target.sessionName, "GC_SESSION_ID")
+		if err != nil && !runtime.IsSessionGone(err) {
+			return false, err
+		}
+		if strings.TrimSpace(liveID) != "" && strings.TrimSpace(liveID) != target.sessionID {
+			return false, nil
+		}
+	}
+	if target.continuationEpoch != "" {
+		liveEpoch, err := sp.GetMeta(target.sessionName, "GC_CONTINUATION_EPOCH")
+		if err != nil && !runtime.IsSessionGone(err) {
+			return false, err
+		}
+		if strings.TrimSpace(liveEpoch) != "" && strings.TrimSpace(liveEpoch) != target.continuationEpoch {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func deliverSessionNudgeWithProvider(target nudgeTarget, sp runtime.Provider, mode nudgeDeliveryMode, stdout, stderr io.Writer) int {
@@ -946,6 +1010,10 @@ func parseNudgeDeliveryMode(raw string) (nudgeDeliveryMode, error) {
 }
 
 func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store beads.Store, sp runtime.Provider, quiescence time.Duration, obs worker.LiveObservation) (bool, error) {
+	matches, err := nudgeTargetLiveGenerationMatches(target, obs, sp)
+	if err != nil || !matches {
+		return false, err
+	}
 	if !pollerSessionIdleEnough(target, sp, quiescence, obs) {
 		return false, nil
 	}
@@ -1183,9 +1251,9 @@ func terminalizeBlockedQueuedNudges(cityPath string, blocked map[string][]queued
 }
 
 func ensureNudgePoller(cityPath, agentName, sessionName string) error {
-	pidPath := nudgePollerPIDPath(cityPath, sessionName)
+	pidPath := nudgePollerPIDPath(cityPath, sessionName, agentName)
 	return withNudgePollerPIDLock(pidPath, func() error {
-		if running, _ := existingPollerPID(pidPath, cityPath, sessionName); running {
+		if running, _ := existingPollerPID(pidPath, cityPath, sessionName, agentName); running {
 			return nil
 		}
 		exe, err := os.Executable()
@@ -1905,14 +1973,14 @@ func withNudgeQueueState(cityPath string, fn func(*nudgeQueueState) error) error
 	return nudgequeue.WithState(cityPath, fn)
 }
 
-func nudgePollerPIDPath(cityPath, sessionName string) string {
-	return citylayout.RuntimePath(cityPath, "nudges", "pollers", sessionName+".pid")
+func nudgePollerPIDPath(cityPath, sessionName, agentName string) string {
+	return citylayout.RuntimePath(cityPath, "nudges", "pollers", nudgepoller.PollerFileStem(sessionName, agentName)+".pid")
 }
 
 var errNudgePollerRunning = errors.New("nudge poller already running")
 
-func acquireNudgePollerLease(cityPath, sessionName string) (func(), error) {
-	pidPath := nudgePollerPIDPath(cityPath, sessionName)
+func acquireNudgePollerLease(cityPath, sessionName, agentName string) (func(), error) {
+	pidPath := nudgePollerPIDPath(cityPath, sessionName, agentName)
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		return nil, fmt.Errorf("creating nudge poller dir: %w", err)
 	}
@@ -1932,7 +2000,7 @@ func acquireNudgePollerLease(cityPath, sessionName string) (func(), error) {
 		case err == nil && strings.TrimSpace(string(current)) == strings.TrimSpace(string(pid)):
 			return nil
 		case err == nil:
-			if running, _ := existingPollerPID(pidPath, cityPath, sessionName); running {
+			if running, _ := existingPollerPID(pidPath, cityPath, sessionName, agentName); running {
 				return errNudgePollerRunning
 			}
 		case !errors.Is(err, os.ErrNotExist):
@@ -1946,7 +2014,7 @@ func acquireNudgePollerLease(cityPath, sessionName string) (func(), error) {
 	return release, nil
 }
 
-func existingPollerPID(pidPath, cityPath, sessionName string) (bool, error) {
+func existingPollerPID(pidPath, cityPath, sessionName, agentName string) (bool, error) {
 	data, err := os.ReadFile(pidPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
@@ -1962,10 +2030,10 @@ func existingPollerPID(pidPath, cityPath, sessionName string) (bool, error) {
 	if _, err := fmt.Sscanf(pidText, "%d", &pid); err != nil || pid <= 0 {
 		return false, nil
 	}
-	if cityPath == "" || sessionName == "" {
+	if cityPath == "" || sessionName == "" || agentName == "" {
 		return false, nil
 	}
-	if pidutil.AliveWithCmdline(pid, nudgepoller.CmdlineMatcher(cityPath, sessionName)) {
+	if pidutil.AliveWithCmdline(pid, nudgepoller.CmdlineMatcher(cityPath, sessionName, agentName)) {
 		return true, nil
 	}
 	return false, nil

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -118,6 +118,13 @@ func (t nudgeTarget) agentKey() string {
 	return t.sessionName
 }
 
+func (t nudgeTarget) pollerKey() string {
+	if t.sessionID != "" {
+		return t.sessionID
+	}
+	return t.agentKey()
+}
+
 func (t nudgeTarget) queueKeys() []string {
 	var keys []string
 	seen := map[string]bool{}
@@ -1054,7 +1061,7 @@ func maybeStartNudgePoller(target nudgeTarget) {
 	if target.sessionTransport() == "acp" {
 		return
 	}
-	if err := startNudgePoller(target.cityPath, target.agentKey(), target.sessionName); err != nil {
+	if err := startNudgePoller(target.cityPath, target.pollerKey(), target.sessionName); err != nil {
 		return
 	}
 }

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/nudgepoller"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
+	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/worker"
@@ -1974,7 +1975,7 @@ func TestSendMailNotifyWithProviderStartsClaudePollerWhenQueueingRunningSession(
 	}
 }
 
-func TestSendMailNotifyWithWorkerStartsPollerByAliasForAliasedTarget(t *testing.T) {
+func TestSendMailNotifyWithWorkerStartsPollerBySessionIDForAliasedTarget(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
 	store := openNudgeBeadStore(dir)
@@ -2389,6 +2390,100 @@ func TestTryDeliverQueuedNudgesByPollerDeliversAndAcks(t *testing.T) {
 	}
 	if len(dead) != 0 {
 		t.Fatalf("dead = %d, want 0", len(dead))
+	}
+}
+
+func TestTryDeliverQueuedNudgesByPollerSkipsStaleSessionGeneration(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	now := time.Now().Add(-1 * time.Minute)
+
+	store := openNudgeBeadStore(dir)
+	oldSession, err := store.Create(beads.Bead{
+		Title:  "Old worker",
+		Type:   session.BeadType,
+		Status: "closed",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":              "worker",
+			"session_name":       "sess-worker",
+			"provider":           "codex",
+			"continuation_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create old session: %v", err)
+	}
+	newSession, err := store.Create(beads.Bead{
+		Title:  "New worker",
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":              "worker",
+			"session_name":       "sess-worker",
+			"provider":           "codex",
+			"continuation_epoch": "2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create new session: %v", err)
+	}
+	if err := enqueueQueuedNudge(dir, newQueuedNudgeWithOptions("worker", "old fenced reminder", "session", now, queuedNudgeOptions{
+		SessionID:         oldSession.ID,
+		ContinuationEpoch: "1",
+	})); err != nil {
+		t.Fatalf("enqueueQueuedNudge: %v", err)
+	}
+
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{Env: map[string]string{
+		"GC_SESSION_ID":         newSession.ID,
+		"GC_CONTINUATION_EPOCH": "2",
+	}}); err != nil {
+		t.Fatalf("Start new runtime: %v", err)
+	}
+	if err := fake.SetMeta("sess-worker", "GC_SESSION_ID", newSession.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+	if err := fake.SetMeta("sess-worker", "GC_CONTINUATION_EPOCH", "2"); err != nil {
+		t.Fatalf("SetMeta(GC_CONTINUATION_EPOCH): %v", err)
+	}
+	idleSince := time.Now().Add(-10 * time.Second)
+	fake.SetActivity("sess-worker", idleSince)
+
+	target := nudgeTarget{
+		cityPath:          dir,
+		agent:             config.Agent{Name: "worker"},
+		sessionID:         oldSession.ID,
+		continuationEpoch: "1",
+		resolved:          &config.ResolvedProvider{Name: "codex"},
+		sessionName:       "sess-worker",
+	}
+
+	obs, err := workerObserveNudgeTarget(target, store, fake)
+	if err != nil {
+		t.Fatalf("workerObserveNudgeTarget: %v", err)
+	}
+	if obs.Running {
+		delivered, err := tryDeliverQueuedNudgesByPoller(target, store, fake, 3*time.Second, obs)
+		if err != nil {
+			t.Fatalf("tryDeliverQueuedNudgesByPoller: %v", err)
+		}
+		if delivered {
+			t.Fatal("delivered = true, want stale poller to skip reused runtime session name")
+		}
+	}
+
+	if calls := fake.CountCalls("Nudge", "sess-worker"); calls != 0 {
+		t.Fatalf("Nudge calls = %d, want stale poller not to deliver to new session", calls)
+	}
+	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 1/0/0", len(pending), len(inFlight), len(dead))
 	}
 }
 
@@ -2936,10 +3031,51 @@ func TestFailedQueuedNudge_DeadLettersFenceMismatch(t *testing.T) {
 	}
 }
 
+func TestNudgeTargetPollerKeyFallbackOrder(t *testing.T) {
+	cases := []struct {
+		name   string
+		target nudgeTarget
+		want   string
+	}{
+		{
+			name:   "session id wins over alias",
+			target: nudgeTarget{alias: "alias", sessionID: "session-id", sessionName: "sess-worker"},
+			want:   "session-id",
+		},
+		{
+			name:   "alias fallback",
+			target: nudgeTarget{alias: "alias", sessionName: "sess-worker"},
+			want:   "alias",
+		},
+		{
+			name:   "qualified agent fallback",
+			target: nudgeTarget{agent: config.Agent{Dir: "rig", Name: "worker"}, sessionName: "sess-worker"},
+			want:   "rig/worker",
+		},
+		{
+			name:   "identity fallback",
+			target: nudgeTarget{identity: "identity", sessionName: "sess-worker"},
+			want:   "identity",
+		},
+		{
+			name:   "session name fallback",
+			target: nudgeTarget{sessionName: "sess-worker"},
+			want:   "sess-worker",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.target.pollerKey(); got != tc.want {
+				t.Fatalf("pollerKey() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAcquireNudgePollerLeaseAllowsBootstrapPID(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
-	pidPath := nudgePollerPIDPath(dir, "sess-worker")
+	pidPath := nudgePollerPIDPath(dir, "sess-worker", "session-id")
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2947,7 +3083,7 @@ func TestAcquireNudgePollerLeaseAllowsBootstrapPID(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	release, err := acquireNudgePollerLease(dir, "sess-worker")
+	release, err := acquireNudgePollerLease(dir, "sess-worker", "session-id")
 	if err != nil {
 		t.Fatalf("acquireNudgePollerLease: %v", err)
 	}
@@ -2964,7 +3100,7 @@ func TestExistingPollerPIDRejectsUnrelatedLivePID(t *testing.T) {
 		t.Skip("poller ownership check uses /proc on linux")
 	}
 	dir := t.TempDir()
-	pidPath := nudgePollerPIDPath(dir, "sess-worker")
+	pidPath := nudgePollerPIDPath(dir, "sess-worker", "session-id")
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2972,7 +3108,7 @@ func TestExistingPollerPIDRejectsUnrelatedLivePID(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	running, err := existingPollerPID(pidPath, dir, "sess-worker")
+	running, err := existingPollerPID(pidPath, dir, "sess-worker", "session-id")
 	if err != nil {
 		t.Fatalf("existingPollerPID: %v", err)
 	}
@@ -2987,8 +3123,8 @@ func TestExistingPollerPIDAcceptsMatchingCitySession(t *testing.T) {
 	}
 	cityPath := t.TempDir()
 	sessionName := "sess-worker"
-	pidPath := nudgePollerPIDPath(cityPath, sessionName)
-	cmd := startPollerLikeProcess(t, cityPath, sessionName)
+	pidPath := nudgePollerPIDPath(cityPath, sessionName, "session-id")
+	cmd := startPollerLikeProcess(t, cityPath, "session-id")
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -2996,7 +3132,7 @@ func TestExistingPollerPIDAcceptsMatchingCitySession(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	running, err := existingPollerPID(pidPath, cityPath, sessionName)
+	running, err := existingPollerPID(pidPath, cityPath, sessionName, "session-id")
 	if err != nil {
 		t.Fatalf("existingPollerPID: %v", err)
 	}
@@ -3012,8 +3148,8 @@ func TestExistingPollerPIDRejectsDifferentCitySameSession(t *testing.T) {
 	cityPath := t.TempDir()
 	otherCityPath := t.TempDir()
 	sessionName := "sess-worker"
-	pidPath := nudgePollerPIDPath(cityPath, sessionName)
-	cmd := startPollerLikeProcess(t, otherCityPath, sessionName)
+	pidPath := nudgePollerPIDPath(cityPath, sessionName, "session-id")
+	cmd := startPollerLikeProcess(t, otherCityPath, "session-id")
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -3021,7 +3157,7 @@ func TestExistingPollerPIDRejectsDifferentCitySameSession(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	running, err := existingPollerPID(pidPath, cityPath, sessionName)
+	running, err := existingPollerPID(pidPath, cityPath, sessionName, "session-id")
 	if err != nil {
 		t.Fatalf("existingPollerPID: %v", err)
 	}
@@ -3030,13 +3166,77 @@ func TestExistingPollerPIDRejectsDifferentCitySameSession(t *testing.T) {
 	}
 }
 
-func startPollerLikeProcess(t *testing.T, cityPath, sessionName string) *exec.Cmd {
+func TestExistingPollerPIDRejectsDifferentTargetSameCitySession(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("poller ownership check uses /proc on linux")
+	}
+	cityPath := t.TempDir()
+	sessionName := "sess-worker"
+	pidPath := nudgePollerPIDPath(cityPath, sessionName, "session-id")
+	cmd := startPollerLikeProcess(t, cityPath, "old-alias")
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", cmd.Process.Pid)), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	running, err := existingPollerPID(pidPath, cityPath, sessionName, "session-id")
+	if err != nil {
+		t.Fatalf("existingPollerPID: %v", err)
+	}
+	if running {
+		t.Fatalf("existingPollerPID(%q) = true for same-session poller with different target key", pidPath)
+	}
+}
+
+func TestExistingPollerPIDPreservesSameTargetAfterDifferentTarget(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("poller ownership check uses /proc on linux")
+	}
+	cityPath := t.TempDir()
+	sessionName := "sess-worker"
+	targetA := "session-a"
+	targetB := "session-b"
+	pidPathA := nudgePollerPIDPath(cityPath, sessionName, targetA)
+	pidPathB := nudgePollerPIDPath(cityPath, sessionName, targetB)
+	if pidPathA == pidPathB {
+		t.Fatalf("nudgePollerPIDPath returned the same path for distinct targets: %q", pidPathA)
+	}
+	cmdA := startPollerLikeProcess(t, cityPath, targetA)
+	cmdB := startPollerLikeProcess(t, cityPath, targetB)
+	for _, entry := range []struct {
+		path string
+		pid  int
+	}{
+		{path: pidPathA, pid: cmdA.Process.Pid},
+		{path: pidPathB, pid: cmdB.Process.Pid},
+	} {
+		if err := os.MkdirAll(filepath.Dir(entry.path), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(entry.path, []byte(fmt.Sprintf("%d\n", entry.pid)), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+
+	running, err := existingPollerPID(pidPathA, cityPath, sessionName, targetA)
+	if err != nil {
+		t.Fatalf("existingPollerPID: %v", err)
+	}
+	if !running {
+		t.Fatalf("existingPollerPID(%q) = false for still-running target A after target B started", pidPathA)
+	}
+}
+
+func startPollerLikeProcess(t *testing.T, cityPath, agentName string) *exec.Cmd {
 	t.Helper()
+	const sessionName = "sess-worker"
 	scriptPath := filepath.Join(t.TempDir(), "gc-fake")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nread _hold\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile(fake poller): %v", err)
 	}
-	cmd := exec.Command(scriptPath, nudgepoller.CommandArgs(cityPath, sessionName, "agent")...)
+	cmd := exec.Command(scriptPath, nudgepoller.CommandArgs(cityPath, sessionName, agentName)...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		t.Fatalf("StdinPipe(fake poller): %v", err)
@@ -3050,7 +3250,21 @@ func startPollerLikeProcess(t *testing.T, cityPath, sessionName string) *exec.Cm
 		_ = stdin.Close()
 		_ = cmd.Wait()
 	})
+	waitForPollerCmdline(t, cmd.Process.Pid, cityPath, sessionName, agentName)
 	return cmd
+}
+
+func waitForPollerCmdline(t *testing.T, pid int, cityPath, sessionName, agentName string) {
+	t.Helper()
+	matches := nudgepoller.CmdlineMatcher(cityPath, sessionName, agentName)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if pidutil.AliveWithCmdline(pid, matches) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("poller PID %d did not expose matching command line", pid)
 }
 
 func TestSplitQueuedNudgesForTarget_RejectsFencedNudgesWithoutResolvedSession(t *testing.T) {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -2003,9 +2003,7 @@ func TestSendMailNotifyWithWorkerStartsPollerByAliasForAliasedTarget(t *testing.
 	prev := startNudgePoller
 	startNudgePoller = func(cityPath, agentName, sessionName string) error {
 		called = true
-		// The queued nudge carries the session fence, so the poller registration
-		// key can follow the operator-facing alias.
-		if cityPath != dir || agentName != "mayor" || sessionName != info.SessionName {
+		if cityPath != dir || agentName != info.ID || sessionName != info.SessionName {
 			t.Fatalf("unexpected poller args city=%q agent=%q session=%q", cityPath, agentName, sessionName)
 		}
 		return nil
@@ -2665,8 +2663,8 @@ func TestDeliverSlingNudgeQueuesFencedReminderAndStartsPollerForAsleepSession(t 
 	if pending[0].ContinuationEpoch != "7" {
 		t.Fatalf("queued nudge continuation_epoch = %q, want 7", pending[0].ContinuationEpoch)
 	}
-	if pollerCityPath != dir || pollerAgent != target.agentKey() || pollerSession != target.sessionName {
-		t.Fatalf("startNudgePoller = (%q, %q, %q), want (%q, %q, %q)", pollerCityPath, pollerAgent, pollerSession, dir, target.agentKey(), target.sessionName)
+	if pollerCityPath != dir || pollerAgent != target.sessionID || pollerSession != target.sessionName {
+		t.Fatalf("startNudgePoller = (%q, %q, %q), want (%q, %q, %q)", pollerCityPath, pollerAgent, pollerSession, dir, target.sessionID, target.sessionName)
 	}
 }
 

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -1193,7 +1193,7 @@ func dispatchReadyWaitNudgesWithSnapshot(cityPath string, cfg *config.City, stor
 		// already surface as their built-in family here. The provider
 		// fallback covers sessions created before provider_kind was stamped.
 		if waitNudgeProviderNeedsPoller(sessionBead) && !nudgeDispatcherIsSupervisor(cfg) {
-			if err := startNudgePoller(cityPath, waitNudgeAgent(sessionBead), sessionBead.Metadata["session_name"]); err != nil {
+			if err := startNudgePoller(cityPath, waitNudgePollerKey(sessionBead), sessionBead.Metadata["session_name"]); err != nil {
 				return fmt.Errorf("starting wait nudge poller: %w", err)
 			}
 		}
@@ -1343,6 +1343,10 @@ func waitNudgeAgent(sessionBead beads.Bead) string {
 		return agent
 	}
 	return sessionBead.Metadata["template"]
+}
+
+func waitNudgePollerKey(sessionBead beads.Bead) string {
+	return sessionpkg.PollerKeyFromBead(sessionBead)
 }
 
 // sessionProviderFamily returns the built-in provider family for a session bead.

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -51,6 +51,72 @@ type waitGlobalListLimitStore struct {
 	beads.Store
 }
 
+func TestWaitNudgePollerKeyFallbackOrder(t *testing.T) {
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want string
+	}{
+		{
+			name: "session id wins over agent name",
+			bead: beads.Bead{
+				ID:       "session-id",
+				Metadata: map[string]string{"agent_name": "agent", "template": "template"},
+			},
+			want: "session-id",
+		},
+		{
+			name: "agent name fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"agent_name": "agent", "template": "template", "session_name": "s-test"},
+			},
+			want: "agent",
+		},
+		{
+			name: "alias fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"alias": "alias", "agent_name": "agent", "template": "template", "session_name": "s-test"},
+				Title:    "title",
+			},
+			want: "alias",
+		},
+		{
+			name: "agent name fallback after alias",
+			bead: beads.Bead{
+				Metadata: map[string]string{"agent_name": "agent", "template": "template"},
+			},
+			want: "agent",
+		},
+		{
+			name: "template fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"template": "template"},
+			},
+			want: "template",
+		},
+		{
+			name: "session name fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"session_name": "s-test"},
+				Title:    "title",
+			},
+			want: "s-test",
+		},
+		{
+			name: "title fallback",
+			bead: beads.Bead{Title: "title"},
+			want: "title",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := waitNudgePollerKey(tc.bead); got != tc.want {
+				t.Fatalf("waitNudgePollerKey() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 type waitGlobalListErrorStore struct {
 	beads.Store
 }
@@ -1955,7 +2021,7 @@ func TestDispatchReadyWaitNudges_StartsCodexPoller(t *testing.T) {
 	prev := startNudgePoller
 	startNudgePoller = func(cityPath, agentName, sessionName string) error {
 		called = true
-		if cityPath != dir || agentName != "worker" || sessionName != "worker" {
+		if cityPath != dir || agentName != sessionBead.ID || sessionName != "worker" {
 			t.Fatalf("unexpected poller args city=%q agent=%q session=%q", cityPath, agentName, sessionName)
 		}
 		return nil
@@ -2011,7 +2077,7 @@ func TestDispatchReadyWaitNudges_StartsPiPoller(t *testing.T) {
 	prev := startNudgePoller
 	startNudgePoller = func(cityPath, agentName, sessionName string) error {
 		called = true
-		if cityPath != dir || agentName != "worker" || sessionName != "worker" {
+		if cityPath != dir || agentName != sessionBead.ID || sessionName != "worker" {
 			t.Fatalf("unexpected poller args city=%q agent=%q session=%q", cityPath, agentName, sessionName)
 		}
 		return nil

--- a/internal/nudgepoller/poller.go
+++ b/internal/nudgepoller/poller.go
@@ -1,8 +1,9 @@
-// Package nudgepoller defines the shared per-session nudge poller process
-// contract.
+// Package nudgepoller defines the shared nudge poller process contract.
 package nudgepoller
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/pathutil"
@@ -14,17 +15,18 @@ const (
 	sessionFlag = "--session"
 )
 
-// CommandArgs returns the argv tail for the shared per-session nudge poller.
+// CommandArgs returns the argv tail for a nudge poller.
 func CommandArgs(cityPath, sessionName, agentName string) []string {
 	return []string{"nudge", "poll", cityFlag, cityPath, sessionFlag, sessionName, agentName}
 }
 
-// CmdlineMatcher returns a predicate that recognizes the shared per-session
-// nudge poller command for the supplied city and session.
-func CmdlineMatcher(cityPath, sessionName string) func([]string) bool {
+// CmdlineMatcher returns a predicate that recognizes the nudge poller command
+// for the supplied city, session, and target key.
+func CmdlineMatcher(cityPath, sessionName, agentName string) func([]string) bool {
 	expectedCity := pathutil.NormalizePathForCompare(cityPath)
+	expectedAgent := strings.TrimSpace(agentName)
 	return func(argv []string) bool {
-		if expectedCity == "" || sessionName == "" {
+		if expectedCity == "" || sessionName == "" || expectedAgent == "" {
 			return false
 		}
 		if !pidutil.ArgvContainsSequence(argv, "nudge", "poll") {
@@ -33,8 +35,73 @@ func CmdlineMatcher(cityPath, sessionName string) func([]string) bool {
 		if !argvHasPathFlagValue(argv, cityFlag, expectedCity) {
 			return false
 		}
-		return pidutil.ArgvHasFlagValue(argv, sessionFlag, sessionName)
+		if !pidutil.ArgvHasFlagValue(argv, sessionFlag, sessionName) {
+			return false
+		}
+		return argvHasPollTarget(argv, expectedAgent)
 	}
+}
+
+func argvHasPollTarget(argv []string, expected string) bool {
+	for i := 0; i+1 < len(argv); i++ {
+		if argv[i] != "nudge" || argv[i+1] != "poll" {
+			continue
+		}
+		for j := i + 2; j < len(argv); j++ {
+			arg := argv[j]
+			switch {
+			case arg == cityFlag || arg == sessionFlag || arg == "--interval" || arg == "--quiescence":
+				j++
+			case strings.HasPrefix(arg, cityFlag+"=") ||
+				strings.HasPrefix(arg, sessionFlag+"=") ||
+				strings.HasPrefix(arg, "--interval=") ||
+				strings.HasPrefix(arg, "--quiescence="):
+			case strings.HasPrefix(arg, "-"):
+				if !strings.Contains(arg, "=") && j+1 < len(argv) && !strings.HasPrefix(argv[j+1], "-") {
+					j++
+				}
+			default:
+				return arg == expected
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// PollerFileStem returns the filesystem-safe stem for poller PID and log
+// files owned by a concrete session/target tuple.
+func PollerFileStem(sessionName, agentName string) string {
+	sessionName = strings.TrimSpace(sessionName)
+	agentName = strings.TrimSpace(agentName)
+	digest := sha256.Sum256([]byte(sessionName + "\x00" + agentName))
+	prefix := safeFileStemPart(sessionName)
+	if prefix == "" {
+		prefix = "session"
+	}
+	return prefix + "-" + hex.EncodeToString(digest[:8])
+}
+
+func safeFileStemPart(value string) string {
+	var b strings.Builder
+	for _, r := range strings.TrimSpace(value) {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+		if b.Len() >= 48 {
+			break
+		}
+	}
+	return strings.Trim(b.String(), ".-")
 }
 
 func argvHasPathFlagValue(argv []string, flag, expected string) bool {

--- a/internal/nudgepoller/poller_test.go
+++ b/internal/nudgepoller/poller_test.go
@@ -2,6 +2,7 @@ package nudgepoller
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -11,7 +12,7 @@ func TestCommandArgsMatchCmdlineMatcher(t *testing.T) {
 	agentName := "agent"
 
 	argv := append([]string{"gc"}, CommandArgs(cityPath, sessionName, agentName)...)
-	if !CmdlineMatcher(cityPath, sessionName)(argv) {
+	if !CmdlineMatcher(cityPath, sessionName, agentName)(argv) {
 		t.Fatalf("CmdlineMatcher did not match CommandArgs argv: %v", argv)
 	}
 }
@@ -22,16 +23,19 @@ func TestCmdlineMatcherRejectsWrongOwnership(t *testing.T) {
 		name        string
 		cityPath    string
 		sessionName string
+		agentName   string
 	}{
-		{name: "empty city", cityPath: "", sessionName: "sess-worker"},
-		{name: "empty session", cityPath: "/tmp/gc-city", sessionName: ""},
-		{name: "wrong city", cityPath: "/tmp/other-city", sessionName: "sess-worker"},
-		{name: "wrong session", cityPath: "/tmp/gc-city", sessionName: "other-session"},
+		{name: "empty city", cityPath: "", sessionName: "sess-worker", agentName: "agent"},
+		{name: "empty session", cityPath: "/tmp/gc-city", sessionName: "", agentName: "agent"},
+		{name: "empty target", cityPath: "/tmp/gc-city", sessionName: "sess-worker", agentName: ""},
+		{name: "wrong city", cityPath: "/tmp/other-city", sessionName: "sess-worker", agentName: "agent"},
+		{name: "wrong session", cityPath: "/tmp/gc-city", sessionName: "other-session", agentName: "agent"},
+		{name: "wrong target", cityPath: "/tmp/gc-city", sessionName: "sess-worker", agentName: "session-id"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if CmdlineMatcher(tc.cityPath, tc.sessionName)(argv) {
-				t.Fatalf("CmdlineMatcher(%q, %q) matched %v", tc.cityPath, tc.sessionName, argv)
+			if CmdlineMatcher(tc.cityPath, tc.sessionName, tc.agentName)(argv) {
+				t.Fatalf("CmdlineMatcher(%q, %q, %q) matched %v", tc.cityPath, tc.sessionName, tc.agentName, argv)
 			}
 		})
 	}
@@ -39,29 +43,125 @@ func TestCmdlineMatcherRejectsWrongOwnership(t *testing.T) {
 
 func TestCmdlineMatcherAcceptsFlagEqualsForm(t *testing.T) {
 	argv := []string{"gc", "nudge", "poll", "--session=sess-worker", "--city=/tmp/gc-city", "agent"}
-	if !CmdlineMatcher("/tmp/gc-city", "sess-worker")(argv) {
+	if !CmdlineMatcher("/tmp/gc-city", "sess-worker", "agent")(argv) {
 		t.Fatalf("CmdlineMatcher did not match equals-form flags: %v", argv)
+	}
+}
+
+func TestArgvHasPollTargetEdgeCases(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		{
+			name: "generated target after flags",
+			argv: []string{"gc", "nudge", "poll", "--city", "/tmp/gc-city", "--session", "sess-worker", "agent"},
+			want: true,
+		},
+		{
+			name: "target before flags",
+			argv: []string{"gc", "nudge", "poll", "agent", "--city", "/tmp/gc-city", "--session", "sess-worker"},
+			want: true,
+		},
+		{
+			name: "known space form flags before target",
+			argv: []string{"gc", "nudge", "poll", "--interval", "1s", "--quiescence", "2s", "agent"},
+			want: true,
+		},
+		{
+			name: "known equals form flags before target",
+			argv: []string{"gc", "nudge", "poll", "--interval=1s", "--quiescence=2s", "agent"},
+			want: true,
+		},
+		{
+			name: "unknown space form flag skips value",
+			argv: []string{"gc", "nudge", "poll", "--future", "value", "agent"},
+			want: true,
+		},
+		{
+			name: "unknown equals form flag before target",
+			argv: []string{"gc", "nudge", "poll", "--future=value", "agent"},
+			want: true,
+		},
+		{
+			name: "first positional must be target",
+			argv: []string{"gc", "nudge", "poll", "other", "agent"},
+			want: false,
+		},
+		{
+			name: "no target",
+			argv: []string{"gc", "nudge", "poll", "--city", "/tmp/gc-city"},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := argvHasPollTarget(tc.argv, "agent"); got != tc.want {
+				t.Fatalf("argvHasPollTarget(%v, agent) = %v, want %v", tc.argv, got, tc.want)
+			}
+		})
 	}
 }
 
 func TestCmdlineMatcherNormalizesCityPath(t *testing.T) {
 	cityPath := t.TempDir()
 	argv := []string{"gc", "nudge", "poll", "--city", cityPath, "--session", "sess-worker", "agent"}
-	if !CmdlineMatcher(filepath.Join(cityPath, "."), "sess-worker")(argv) {
+	if !CmdlineMatcher(filepath.Join(cityPath, "."), "sess-worker", "agent")(argv) {
 		t.Fatalf("CmdlineMatcher did not match equivalent city path spelling: %v", argv)
 	}
 }
 
 func TestCmdlineMatcherAcceptsAnyMatchingCityFlag(t *testing.T) {
 	argv := []string{"gc", "nudge", "poll", "--city", "/tmp/other-city", "--city=/tmp/gc-city", "--session", "sess-worker", "agent"}
-	if !CmdlineMatcher("/tmp/gc-city", "sess-worker")(argv) {
+	if !CmdlineMatcher("/tmp/gc-city", "sess-worker", "agent")(argv) {
 		t.Fatalf("CmdlineMatcher did not match later city flag: %v", argv)
+	}
+}
+
+func TestPollerFileStemSanitizesSessionPrefix(t *testing.T) {
+	stem := PollerFileStem(" ../sess worker/one ", "target")
+	if !strings.HasPrefix(stem, "sess-worker-one-") {
+		t.Fatalf("PollerFileStem prefix = %q, want sanitized session prefix", stem)
+	}
+	if strings.ContainsAny(stem, `/\ `) {
+		t.Fatalf("PollerFileStem = %q, want filesystem-safe stem", stem)
+	}
+}
+
+func TestPollerFileStemUsesFallbackPrefixForEmptySession(t *testing.T) {
+	stem := PollerFileStem("   ", "target")
+	if !strings.HasPrefix(stem, "session-") {
+		t.Fatalf("PollerFileStem empty session prefix = %q, want session-*", stem)
+	}
+}
+
+func TestPollerFileStemTruncatesLongSessionPrefix(t *testing.T) {
+	stem := PollerFileStem(strings.Repeat("a", 60), "target")
+	prefix, _, ok := strings.Cut(stem, "-")
+	if !ok {
+		t.Fatalf("PollerFileStem = %q, want prefix and digest", stem)
+	}
+	if len(prefix) != 48 {
+		t.Fatalf("PollerFileStem prefix length = %d, want 48", len(prefix))
+	}
+}
+
+func TestPollerFileStemDistinguishesSessionTargetTuples(t *testing.T) {
+	if PollerFileStem("ab", "c") == PollerFileStem("a", "bc") {
+		t.Fatal("PollerFileStem returned the same stem for distinct session/target tuples")
+	}
+}
+
+func TestSafeFileStemPartTrimsUnsafeEdges(t *testing.T) {
+	if got := safeFileStemPart(" ../worker session/. "); got != "worker-session" {
+		t.Fatalf("safeFileStemPart() = %q, want worker-session", got)
 	}
 }
 
 func TestCmdlineMatcherRequiresNudgePollCommand(t *testing.T) {
 	argv := []string{"gc", "nudge", "--city", "/tmp/gc-city", "poll", "--session", "sess-worker", "agent"}
-	if CmdlineMatcher("/tmp/gc-city", "sess-worker")(argv) {
+	if CmdlineMatcher("/tmp/gc-city", "sess-worker", "agent")(argv) {
 		t.Fatalf("CmdlineMatcher matched non-contiguous nudge poll argv: %v", argv)
 	}
 }

--- a/internal/session/poller_key.go
+++ b/internal/session/poller_key.go
@@ -1,0 +1,28 @@
+package session
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// PollerKeyFromBead returns the concrete nudge-poller ownership key for a
+// session bead, preferring the store-assigned session ID before metadata
+// fallbacks used by older or partially materialized session beads.
+func PollerKeyFromBead(b beads.Bead) string {
+	if id := strings.TrimSpace(b.ID); id != "" {
+		return id
+	}
+	for _, value := range []string{
+		b.Metadata["alias"],
+		b.Metadata["agent_name"],
+		b.Metadata["template"],
+		b.Metadata["session_name"],
+		b.Title,
+	} {
+		if key := strings.TrimSpace(value); key != "" {
+			return key
+		}
+	}
+	return ""
+}

--- a/internal/session/submit.go
+++ b/internal/session/submit.go
@@ -536,7 +536,7 @@ func (m *Manager) enqueueDeferredSubmitLocked(b beads.Bead, sessName, message st
 		return fmt.Errorf("queueing deferred submit: %w", err)
 	}
 	if m.supportsFollowUpLocked(b) {
-		_ = startSessionSubmitPoller(m.cityPath, deferredSubmitAgentKey(b), sessName)
+		_ = startSessionSubmitPoller(m.cityPath, deferredSubmitPollerKey(b), sessName)
 	}
 	return nil
 }
@@ -557,15 +557,19 @@ func deferredSubmitAgentKey(b beads.Bead) string {
 	return b.Title
 }
 
+func deferredSubmitPollerKey(b beads.Bead) string {
+	return PollerKeyFromBead(b)
+}
+
 var (
 	startSessionSubmitPoller      = ensureSessionSubmitPoller
 	sessionSubmitPollerExecutable = os.Executable
 )
 
 func ensureSessionSubmitPoller(cityPath, agentName, sessionName string) error {
-	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName)
+	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName, agentName)
 	return withSessionSubmitPollerPIDLock(pidPath, func() error {
-		if running, _ := existingSessionSubmitPollerPID(pidPath, cityPath, sessionName); running {
+		if running, _ := existingSessionSubmitPollerPID(pidPath, cityPath, sessionName, agentName); running {
 			return nil
 		}
 		exe, err := sessionSubmitPollerExecutable()
@@ -577,7 +581,7 @@ func ensureSessionSubmitPoller(cityPath, agentName, sessionName string) error {
 		}
 		cmd := exec.Command(exe, nudgepoller.CommandArgs(cityPath, sessionName, agentName)...)
 		cmd.Env = os.Environ()
-		logFile, err := os.OpenFile(sessionSubmitPollerLogPath(cityPath, sessionName), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		logFile, err := os.OpenFile(sessionSubmitPollerLogPath(cityPath, sessionName, agentName), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err != nil {
 			return err
 		}
@@ -601,15 +605,15 @@ func isGoTestExecutable(path string) bool {
 	return strings.HasSuffix(filepath.Base(path), ".test")
 }
 
-func sessionSubmitPollerPIDPath(cityPath, sessionName string) string {
-	return citylayout.RuntimePath(cityPath, "nudges", "pollers", sessionName+".pid")
+func sessionSubmitPollerPIDPath(cityPath, sessionName, agentName string) string {
+	return citylayout.RuntimePath(cityPath, "nudges", "pollers", nudgepoller.PollerFileStem(sessionName, agentName)+".pid")
 }
 
-func sessionSubmitPollerLogPath(cityPath, sessionName string) string {
-	return citylayout.RuntimePath(cityPath, "nudges", "pollers", sessionName+".log")
+func sessionSubmitPollerLogPath(cityPath, sessionName, agentName string) string {
+	return citylayout.RuntimePath(cityPath, "nudges", "pollers", nudgepoller.PollerFileStem(sessionName, agentName)+".log")
 }
 
-func existingSessionSubmitPollerPID(pidPath, cityPath, sessionName string) (bool, error) {
+func existingSessionSubmitPollerPID(pidPath, cityPath, sessionName, agentName string) (bool, error) {
 	data, err := os.ReadFile(pidPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
@@ -625,10 +629,10 @@ func existingSessionSubmitPollerPID(pidPath, cityPath, sessionName string) (bool
 	if _, err := fmt.Sscanf(pidText, "%d", &pid); err != nil || pid <= 0 {
 		return false, nil
 	}
-	if cityPath == "" || sessionName == "" {
+	if cityPath == "" || sessionName == "" || agentName == "" {
 		return false, nil
 	}
-	if pidutil.AliveWithCmdline(pid, nudgepoller.CmdlineMatcher(cityPath, sessionName)) {
+	if pidutil.AliveWithCmdline(pid, nudgepoller.CmdlineMatcher(cityPath, sessionName, agentName)) {
 		return true, nil
 	}
 	return false, nil

--- a/internal/session/submit_test.go
+++ b/internal/session/submit_test.go
@@ -394,6 +394,9 @@ func TestSubmitFollowUpQueuesDeferredMessageAndStartsCodexPoller(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	if err := store.SetMetadata(info.ID, "alias", "helper-alias"); err != nil {
+		t.Fatalf("SetMetadata(alias): %v", err)
+	}
 
 	var pollerCalls int
 	origPoller := startSessionSubmitPoller
@@ -430,8 +433,8 @@ func TestSubmitFollowUpQueuesDeferredMessageAndStartsCodexPoller(t *testing.T) {
 	if item.SessionID != info.ID {
 		t.Fatalf("SessionID = %q, want %q", item.SessionID, info.ID)
 	}
-	if item.Agent != info.ID {
-		t.Fatalf("Agent = %q, want %q", item.Agent, info.ID)
+	if item.Agent != "helper-alias" {
+		t.Fatalf("Agent = %q, want helper-alias", item.Agent)
 	}
 	if item.Message != "follow up later" {
 		t.Fatalf("Message = %q, want %q", item.Message, "follow up later")
@@ -458,10 +461,10 @@ func TestEnsureSessionSubmitPollerRejectsGoTestExecutable(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "Go test binary") {
 		t.Fatalf("ensureSessionSubmitPoller error = %v, want Go test binary refusal", err)
 	}
-	if _, statErr := os.Stat(sessionSubmitPollerPIDPath(cityPath, "s-test")); !errors.Is(statErr, os.ErrNotExist) {
+	if _, statErr := os.Stat(sessionSubmitPollerPIDPath(cityPath, "s-test", "agent")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("poller pid file stat error = %v, want not exist", statErr)
 	}
-	if _, statErr := os.Stat(sessionSubmitPollerLogPath(cityPath, "s-test")); !errors.Is(statErr, os.ErrNotExist) {
+	if _, statErr := os.Stat(sessionSubmitPollerLogPath(cityPath, "s-test", "agent")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("poller log file stat error = %v, want not exist", statErr)
 	}
 }
@@ -471,7 +474,7 @@ func TestExistingSessionSubmitPollerPIDRejectsUnrelatedLivePID(t *testing.T) {
 		t.Skip("poller ownership check uses /proc on linux")
 	}
 	cityPath := t.TempDir()
-	pidPath := sessionSubmitPollerPIDPath(cityPath, "s-test")
+	pidPath := sessionSubmitPollerPIDPath(cityPath, "s-test", "session-id")
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -479,7 +482,7 @@ func TestExistingSessionSubmitPollerPIDRejectsUnrelatedLivePID(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	running, err := existingSessionSubmitPollerPID(pidPath, cityPath, "s-test")
+	running, err := existingSessionSubmitPollerPID(pidPath, cityPath, "s-test", "session-id")
 	if err != nil {
 		t.Fatalf("existingSessionSubmitPollerPID: %v", err)
 	}
@@ -494,8 +497,8 @@ func TestExistingSessionSubmitPollerPIDAcceptsMatchingCitySession(t *testing.T) 
 	}
 	cityPath := t.TempDir()
 	sessionName := "s-test"
-	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName)
-	cmd := startSubmitPollerLikeProcess(t, cityPath, sessionName)
+	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName, "session-id")
+	cmd := startSubmitPollerLikeProcess(t, cityPath, sessionName, "session-id")
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -503,7 +506,7 @@ func TestExistingSessionSubmitPollerPIDAcceptsMatchingCitySession(t *testing.T) 
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	running, err := existingSessionSubmitPollerPID(pidPath, cityPath, sessionName)
+	running, err := existingSessionSubmitPollerPID(pidPath, cityPath, sessionName, "session-id")
 	if err != nil {
 		t.Fatalf("existingSessionSubmitPollerPID: %v", err)
 	}
@@ -519,8 +522,8 @@ func TestExistingSessionSubmitPollerPIDRejectsDifferentCitySameSession(t *testin
 	cityPath := t.TempDir()
 	otherCityPath := t.TempDir()
 	sessionName := "s-test"
-	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName)
-	cmd := startSubmitPollerLikeProcess(t, otherCityPath, sessionName)
+	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName, "session-id")
+	cmd := startSubmitPollerLikeProcess(t, otherCityPath, sessionName, "session-id")
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -528,7 +531,7 @@ func TestExistingSessionSubmitPollerPIDRejectsDifferentCitySameSession(t *testin
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	running, err := existingSessionSubmitPollerPID(pidPath, cityPath, sessionName)
+	running, err := existingSessionSubmitPollerPID(pidPath, cityPath, sessionName, "session-id")
 	if err != nil {
 		t.Fatalf("existingSessionSubmitPollerPID: %v", err)
 	}
@@ -537,13 +540,193 @@ func TestExistingSessionSubmitPollerPIDRejectsDifferentCitySameSession(t *testin
 	}
 }
 
-func startSubmitPollerLikeProcess(t *testing.T, cityPath, sessionName string) *exec.Cmd {
+func TestExistingSessionSubmitPollerPIDRejectsDifferentTargetSameCitySession(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("poller ownership check uses /proc on linux")
+	}
+	cityPath := t.TempDir()
+	sessionName := "s-test"
+	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName, "session-id")
+	cmd := startSubmitPollerLikeProcess(t, cityPath, sessionName, "old-alias")
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", cmd.Process.Pid)), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	running, err := existingSessionSubmitPollerPID(pidPath, cityPath, sessionName, "session-id")
+	if err != nil {
+		t.Fatalf("existingSessionSubmitPollerPID: %v", err)
+	}
+	if running {
+		t.Fatalf("existingSessionSubmitPollerPID(%q) = true for same-session poller with different target key", pidPath)
+	}
+}
+
+func TestSessionSubmitPollerPathsScopeSameSessionByTarget(t *testing.T) {
+	cityPath := t.TempDir()
+	sessionName := "s-test"
+	pidPathA := sessionSubmitPollerPIDPath(cityPath, sessionName, "session-a")
+	pidPathB := sessionSubmitPollerPIDPath(cityPath, sessionName, "session-b")
+	logPathA := sessionSubmitPollerLogPath(cityPath, sessionName, "session-a")
+	logPathB := sessionSubmitPollerLogPath(cityPath, sessionName, "session-b")
+	if pidPathA == pidPathB {
+		t.Fatalf("sessionSubmitPollerPIDPath returned the same path for distinct targets: %q", pidPathA)
+	}
+	if logPathA == logPathB {
+		t.Fatalf("sessionSubmitPollerLogPath returned the same path for distinct targets: %q", logPathA)
+	}
+}
+
+func TestDeferredSubmitPollerKeyFallbackOrder(t *testing.T) {
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want string
+	}{
+		{
+			name: "session id wins over alias",
+			bead: beads.Bead{
+				ID:       "session-id",
+				Metadata: map[string]string{"alias": "alias", "template": "template", "session_name": "s-test"},
+				Title:    "title",
+			},
+			want: "session-id",
+		},
+		{
+			name: "alias fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"alias": "alias", "template": "template", "session_name": "s-test"},
+				Title:    "title",
+			},
+			want: "alias",
+		},
+		{
+			name: "template fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"template": "template", "session_name": "s-test"},
+				Title:    "title",
+			},
+			want: "template",
+		},
+		{
+			name: "agent name fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"agent_name": "agent", "template": "template", "session_name": "s-test"},
+				Title:    "title",
+			},
+			want: "agent",
+		},
+		{
+			name: "session name fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"session_name": "s-test"},
+				Title:    "title",
+			},
+			want: "s-test",
+		},
+		{
+			name: "title fallback",
+			bead: beads.Bead{Title: "title"},
+			want: "title",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deferredSubmitPollerKey(tc.bead); got != tc.want {
+				t.Fatalf("deferredSubmitPollerKey() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPollerKeyFromBeadFallbackOrder(t *testing.T) {
+	cases := []struct {
+		name string
+		bead beads.Bead
+		want string
+	}{
+		{
+			name: "session id wins over metadata",
+			bead: beads.Bead{
+				ID: "session-id",
+				Metadata: map[string]string{
+					"alias":        "alias",
+					"agent_name":   "agent",
+					"template":     "template",
+					"session_name": "s-test",
+				},
+				Title: "title",
+			},
+			want: "session-id",
+		},
+		{
+			name: "alias fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{
+					"alias":        "alias",
+					"agent_name":   "agent",
+					"template":     "template",
+					"session_name": "s-test",
+				},
+				Title: "title",
+			},
+			want: "alias",
+		},
+		{
+			name: "agent name fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{
+					"agent_name":   "agent",
+					"template":     "template",
+					"session_name": "s-test",
+				},
+				Title: "title",
+			},
+			want: "agent",
+		},
+		{
+			name: "template fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{
+					"template":     "template",
+					"session_name": "s-test",
+				},
+				Title: "title",
+			},
+			want: "template",
+		},
+		{
+			name: "session name fallback",
+			bead: beads.Bead{
+				Metadata: map[string]string{"session_name": "s-test"},
+				Title:    "title",
+			},
+			want: "s-test",
+		},
+		{
+			name: "title fallback",
+			bead: beads.Bead{Title: "title"},
+			want: "title",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := PollerKeyFromBead(tc.bead); got != tc.want {
+				t.Fatalf("PollerKeyFromBead() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func startSubmitPollerLikeProcess(t *testing.T, cityPath, sessionName, agentName string) *exec.Cmd {
 	t.Helper()
 	scriptPath := filepath.Join(t.TempDir(), "gc-fake")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nread _hold\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile(fake poller): %v", err)
 	}
-	cmd := exec.Command(scriptPath, nudgepoller.CommandArgs(cityPath, sessionName, "agent")...)
+	cmd := exec.Command(scriptPath, nudgepoller.CommandArgs(cityPath, sessionName, agentName)...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		t.Fatalf("StdinPipe(fake poller): %v", err)
@@ -557,13 +740,13 @@ func startSubmitPollerLikeProcess(t *testing.T, cityPath, sessionName string) *e
 		_ = stdin.Close()
 		_ = cmd.Wait()
 	})
-	waitForSubmitPollerCmdline(t, cmd.Process.Pid, cityPath, sessionName)
+	waitForSubmitPollerCmdline(t, cmd.Process.Pid, cityPath, sessionName, agentName)
 	return cmd
 }
 
-func waitForSubmitPollerCmdline(t *testing.T, pid int, cityPath, sessionName string) {
+func waitForSubmitPollerCmdline(t *testing.T, pid int, cityPath, sessionName, agentName string) {
 	t.Helper()
-	matches := nudgepoller.CmdlineMatcher(cityPath, sessionName)
+	matches := nudgepoller.CmdlineMatcher(cityPath, sessionName, agentName)
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if pidutil.AliveWithCmdline(pid, matches) {


### PR DESCRIPTION
## Summary
- Use the resolved live session ID when launching a nudge sidecar poller, falling back to the operator-facing agent key only when no session ID is available.
- Update nudge regression tests so aliased/asleep session pollers are registered against the live session identity.

## Tests
- PASS: `go test ./cmd/gc -run 'TestSendMailNotifyWithWorkerStartsPollerByAliasForAliasedTarget|TestDeliverSlingNudgeQueuesFencedReminderAndStartsPollerForAsleepSession' -count=1`\n- PASS before commit/rebase: `go test ./cmd/gc -run 'Nudge|Poller|MailNotify|Sling' -count=1`\n- Post-rebase broader nudge sweep hit the existing cmd/gc shared temp-root deletion cascade: `TempDir: stat /tmp/gct2055763-1328450183: no such file or directory`.\n- Pre-commit was attempted; lint, generated docs, `go vet ./...`, and unit-core passed before cmd/gc shard 1 hit the same unrelated temp-root deletion failure.