### PR TITLE
fix(tmux): detect current Claude Code busy spinner in idle check (#733 follow-up)

### DIFF
--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -2772,14 +2772,26 @@ func codexTranscriptTailContainsTurnAborted(tail string) bool {
 	return false
 }
 
-// paneContainsBusyIndicator checks captured pane lines for signs that the
-// agent is actively processing. Claude Code displays "esc to interrupt" in
-// the status bar while running tools or generating responses.
+// claudeBusySpinnerRe matches Claude Code's live "working" spinner footer: an
+// elapsed timer with a token-stream / interrupt suffix in parentheses, e.g.
+// "(2m 28s · ↓ 10.9k tokens)" or "(28m 11s • esc to interrupt)". Current Claude
+// Code (notably bypass-permissions mode) shows this spinner instead of a bare
+// "esc to interrupt" string while busy. Anchored on "(<digits><m|s>" before the
+// "·"/"•" separator so it does NOT match idle chrome — "(ctrl+o to expand)",
+// "(main)", "⏱️ Jun 4 02:57:04", or the "✻ Worked for 3m 38s" done marker.
+var claudeBusySpinnerRe = regexp.MustCompile(`\([0-9]+[ms][^)]*[·•]`)
+
+// paneContainsBusyIndicator checks captured pane lines for signs that the agent
+// is actively processing. Agent TUIs surface this differently: older Claude Code
+// and Codex show "esc to interrupt"; current Claude Code shows a live spinner
+// with an elapsed timer + token stream (claudeBusySpinnerRe); Gemini shows its
+// own cancel / shell-tool strings.
 func paneContainsBusyIndicator(lines []string) bool {
 	for _, line := range lines {
 		if strings.Contains(line, "esc to interrupt") ||
 			strings.Contains(line, "Press Esc or Ctrl+C to cancel") ||
-			strings.Contains(line, "[current working directory ") {
+			strings.Contains(line, "[current working directory ") ||
+			claudeBusySpinnerRe.MatchString(line) {
 			return true
 		}
 	}

--- a/internal/runtime/tmux/tmux_test.go
+++ b/internal/runtime/tmux/tmux_test.go
@@ -2402,6 +2402,18 @@ func TestPaneContainsBusyIndicator(t *testing.T) {
 		{"gemini auth spinner", []string{"Waiting for authentication... (Press Esc or Ctrl+C to cancel)"}, true},
 		{"gemini shell tool panel", []string{"│ ?  Shell sleep 12 [current working directory /tmp/city] (Sleep … │"}, true},
 		{"no indicator", []string{"some output", "building..."}, false},
+		// Current Claude Code (bypass mode) shows a live spinner with an elapsed
+		// timer + token stream, not "esc to interrupt", while working.
+		{"claude busy spinner token footer", []string{"· Boogieing… (2m 28s · ↓ 10.9k tokens)"}, true},
+		{"claude busy spinner long turn", []string{"✶ Investigating… (31m 40s · ↓ 108.6k tokens)"}, true},
+		{"claude busy spinner thinking", []string{"✢ Clauding… (56s · ↓ 1.7k tokens · thinking with max effort)"}, true},
+		{"codex busy spinner bullet", []string{"◦ Working (2m 48s • esc to interrupt)"}, true},
+		// Idle/done markers and status chrome must NOT read as busy — a false
+		// positive makes WaitForIdle never return, so the agent is never nudged.
+		{"claude done marker", []string{"✻ Worked for 1m 49s", "❯ "}, false},
+		{"claude status bar time", []string{"🧠 Sonnet 4.6 | 📁 witness | ⏱️  Jun 3 20:10:09"}, false},
+		{"scrollback truncation parens", []string{"  … +9 lines (ctrl+o to expand)"}, false},
+		{"git branch in status bar", []string{"  🚀 Opus 4.8 | 📁 thriva | (main) | ⏱️  Jun 4 02:57:04"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

`paneContainsBusyIndicator` (used by `WaitForIdle` to avoid nudging an agent mid-turn) matches only `esc to interrupt`, `Press Esc or Ctrl+C to cancel`, and `[current working directory `. **Current Claude Code — notably bypass-permissions mode — shows none of those while busy.** It renders a live spinner with an elapsed timer + token stream:

```
· Boogieing… (2m 28s · ↓ 10.9k tokens)
✶ Investigating… (31m 40s · ↓ 108.6k tokens)
```

So a **busy Claude session reads as idle**, and the controller's idle nudger delivers its message mid-turn (it queues behind the running turn). That is the regression of #733 (*idle nudger interrupts active Claude Code sessions while they are thinking*), which the `esc to interrupt` heuristic originally fixed for Claude Code v2.1.109 — the UI has since changed.

## Fix

Also match the spinner footer: a parenthesized elapsed timer followed by a `·`/`•` separator — `claudeBusySpinnerRe = \([0-9]+[ms][^)]*[·•]`. It is anchored on `(<digits><m|s>` so it does **not** match idle chrome: `(ctrl+o to expand)`, `(main)`, the status-bar clock, or the `✻ Worked for 3m 38s` done marker. A false positive is the dangerous direction — it would make `WaitForIdle` never return, so the agent would never be nudged. Codex still matches via the existing `esc to interrupt` string.

## Test

Extends `TestPaneContainsBusyIndicator` with real pane captures: three Claude busy spinners (token-footer / long-turn / thinking) → busy; codex bullet → busy; and four must-not-match idle/chrome lines (done marker, status-bar clock, scrollback-truncation parens, git branch) → not busy. The Claude spinner cases fail before this change and pass after; the idle cases pass throughout.

## Validation

- `go test -tags integration ./internal/runtime/tmux/` (incl. `TestWaitForIdle`): green, no regressions.
- Dogfooded against a live fleet: the new pattern flags the real Claude busy spinner (`· Boogieing… (2m 28s · ↓ tokens)`) that the old strings missed, while every idle agent (done-marker / bare prompt) and every codex agent classified correctly — **zero false positives**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
