### PR TITLE
fix(config): skip node_modules in pack content hash (#2954)

### DIFF
--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2829,8 +2829,13 @@ func isIgnoredPackRuntimePath(path string) bool {
 	case ".beads", ".cache", ".gc", ".git", "state", "tmp":
 		return true
 	}
+	// Language-ecosystem dependency dirs are skipped at ANY depth. Pack
+	// hashing previously walked into node_modules for packs anchored at
+	// monorepo roots, opening tens of thousands of files into the
+	// supervisor every dirty reload (gastownhall/gascity#2954). Matches
+	// the existing __pycache__ precedent for Python ecosystems.
 	for _, part := range parts {
-		if part == "__pycache__" {
+		if part == "__pycache__" || part == "node_modules" {
 			return true
 		}
 	}

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -960,6 +960,13 @@ func TestPackContentHashRecursiveIgnoresRuntimeDirs(t *testing.T) {
 	writeFile(t, dir, ".cache/tool/result.json", `{"cached":true}`)
 	writeFile(t, dir, ".git/HEAD", "ref: refs/heads/main")
 	writeFile(t, dir, "nested/__pycache__/helper.pyc", "compiled")
+	// gastownhall/gascity#2954: node_modules at any depth must be skipped.
+	// Packs anchored at monorepo roots previously dragged tens of thousands
+	// of node_modules files through the supervisor on every dirty reload.
+	writeFile(t, dir, "node_modules/.package-lock.json", `{"name":"x"}`)
+	writeFile(t, dir, "node_modules/lodash/index.js", "module.exports = {}")
+	writeFile(t, dir, "packages/foo/node_modules/lodash/index.js", "module.exports = {}")
+	writeFile(t, dir, "apps/bar/node_modules/.bun/install-cache.bin", "binary")
 	h2 := PackContentHashRecursive(fsys.OSFS{}, dir)
 	if h2 != h1 {
 		t.Fatalf("hash changed after runtime output writes: %q vs %q", h1, h2)


### PR DESCRIPTION
## Summary

Closes #2954. \`isIgnoredPackRuntimePath\` previously skipped \`__pycache__\` at any depth but left \`node_modules\` unfiltered. When a pack is anchored at a monorepo root (e.g. via \`[rigs.imports.<name>] source = \"/path/to/monorepo\"\`), the per-tick config-revision hasher (\`config.Revision\` → \`PackContentHashRecursive\` → \`collectFiles\`) walked the whole tree on every dirty reload and opened tens of thousands of dependency files into the supervisor process — **51k+ open FDs against the rig's \`node_modules\` in the captured reproduction**, never closed for the lifetime of the supervisor.

Add \`node_modules\` to the at-any-depth skip list, mirroring the \`__pycache__\` precedent for the JS/TS ecosystem. Nested \`node_modules\` (e.g. \`packages/*/node_modules\`, \`apps/*/node_modules\`, bun-workspace cache trees) are all covered.

## Diagnosis credit

Issue #2954's author (@elmpp) did the full trace: \`reloadConfigTraced()\` → \`config.Revision()\` → \`writeRevisionDirHash()\` → \`PackContentHashRecursive\` → \`collectFiles()\` → \`isIgnoredPackRuntimePath\` skip list — and named the exact fix site. This PR is the literal patch.

## Behavioral note

Packs that previously had \`node_modules\` contributing to their hash will see a **one-time hash change on the first reload after upgrade**, then stable thereafter. Pack content under non-\`node_modules\` paths still influences the hash unchanged. No config file format changes.

## Test plan

- [x] \`go vet ./internal/config/...\` clean
- [x] \`go test ./internal/config/\` — full package PASS
- [x] **Extended \`TestPackContentHashRecursiveIgnoresRuntimeDirs\`** with new cases:
  - top-level \`node_modules/.package-lock.json\`
  - \`node_modules/lodash/index.js\` (typical package content)
  - \`packages/foo/node_modules/lodash/index.js\` (monorepo workspace)
  - \`apps/bar/node_modules/.bun/install-cache.bin\` (bun-workspace cache, matching the reproduction)
- [x] Sanity-checked: the regression test **FAILS** on \`main\` without the \`node_modules\` skip (\`hash changed after runtime output writes: "24a4…" vs "7211…"\`) and **PASSES** with it.
- [x] Existing \`TestPackContentHashRecursive\` regression test (basic determinism + change detection on non-runtime content) still PASS.