### PR TITLE
Add pack registry release tooling

### DIFF
--- a/cmd/gc/cmd_pack.go
+++ b/cmd/gc/cmd_pack.go
@@ -25,6 +25,7 @@ can be pinned to specific git refs.`,
 		},
 	}
 	cmd.AddCommand(newPackRegistryCmd(stdout, stderr))
+	cmd.AddCommand(newPackReleaseCmd(stdout, stderr))
 	cmd.AddCommand(newPackFetchCmd(stdout, stderr))
 	cmd.AddCommand(newPackListCmd(stdout, stderr))
 	return cmd

--- a/cmd/gc/cmd_pack_release.go
+++ b/cmd/gc/cmd_pack_release.go
@@ -1,0 +1,593 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/packregistry"
+	"github.com/gastownhall/gascity/internal/remotesource"
+	"github.com/spf13/cobra"
+)
+
+func newPackReleaseCmd(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "release",
+		Short: "Author pack registry release metadata",
+		Long:  "Author pack registry release metadata, including canonical pack content hashes.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newPackReleaseHashCmd(stdout, stderr))
+	cmd.AddCommand(newPackReleaseVerifyCmd(stdout, stderr))
+	cmd.AddCommand(newPackReleaseStampCmd(stdout, stderr))
+	cmd.AddCommand(newPackReleaseValidateCmd(stdout, stderr))
+	return cmd
+}
+
+func newPackReleaseHashCmd(stdout, stderr io.Writer) *cobra.Command {
+	var packPath string
+	var commit string
+	cmd := &cobra.Command{
+		Use:   "hash <source>",
+		Short: "Compute a pack release content hash",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if doPackReleaseHash(args[0], packPath, commit, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&packPath, "path", "", "pack path inside the source repository")
+	cmd.Flags().StringVar(&commit, "commit", "", "git commit or ref to hash")
+	_ = cmd.MarkFlagRequired("commit")
+	return cmd
+}
+
+func newPackReleaseVerifyCmd(stdout, stderr io.Writer) *cobra.Command {
+	var packPath string
+	var commit string
+	var hash string
+	cmd := &cobra.Command{
+		Use:   "verify <source>",
+		Short: "Verify a pack release content hash",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if doPackReleaseVerify(args[0], packPath, commit, hash, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&packPath, "path", "", "pack path inside the source repository")
+	cmd.Flags().StringVar(&commit, "commit", "", "git commit or ref to verify")
+	cmd.Flags().StringVar(&hash, "hash", "", "expected sha256:<64hex> content hash")
+	_ = cmd.MarkFlagRequired("commit")
+	_ = cmd.MarkFlagRequired("hash")
+	return cmd
+}
+
+type packReleaseStampOptions struct {
+	Version         string
+	Ref             string
+	Commit          string
+	ReleaseDesc     string
+	Source          string
+	PackPath        string
+	PackDescription string
+	Replace         bool
+}
+
+func newPackReleaseStampCmd(stdout, stderr io.Writer) *cobra.Command {
+	var opts packReleaseStampOptions
+	cmd := &cobra.Command{
+		Use:   "stamp <registry.toml> <pack-name>",
+		Short: "Stamp a registry release entry with a computed content hash",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if doPackReleaseStamp(args[0], args[1], opts, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.Version, "version", "", "release version to stamp")
+	cmd.Flags().StringVar(&opts.Ref, "ref", "", "release ref to record")
+	cmd.Flags().StringVar(&opts.Commit, "commit", "", "git commit or ref to hash and record")
+	cmd.Flags().StringVar(&opts.ReleaseDesc, "description", "", "release description")
+	cmd.Flags().StringVar(&opts.Source, "source", "", "pack source; required when creating a new [[pack]]")
+	cmd.Flags().StringVar(&opts.PackPath, "path", "", "pack path inside the source repository")
+	cmd.Flags().StringVar(&opts.PackDescription, "pack-description", "", "pack description; required when creating a new [[pack]]")
+	cmd.Flags().BoolVar(&opts.Replace, "replace", false, "replace an existing release with the same version")
+	_ = cmd.MarkFlagRequired("version")
+	_ = cmd.MarkFlagRequired("ref")
+	_ = cmd.MarkFlagRequired("commit")
+	_ = cmd.MarkFlagRequired("description")
+	return cmd
+}
+
+func newPackReleaseValidateCmd(stdout, stderr io.Writer) *cobra.Command {
+	var packName string
+	var includeWithdrawn bool
+	cmd := &cobra.Command{
+		Use:   "validate <registry.toml>",
+		Short: "Validate registry release content hashes",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if doPackReleaseValidate(args[0], packName, includeWithdrawn, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&packName, "pack", "", "validate only one registry pack")
+	cmd.Flags().BoolVar(&includeWithdrawn, "include-withdrawn", false, "also validate withdrawn releases")
+	return cmd
+}
+
+func doPackReleaseHash(source, packPath, commit string, stdout, stderr io.Writer) int {
+	resolved, err := resolvePackReleaseSource(source, packPath, commit)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc pack release hash: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	hash, err := packregistry.PackContentHash(resolved.RepoDir, resolved.Commit, resolved.PackPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc pack release hash: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintln(stdout, hash) //nolint:errcheck
+	return 0
+}
+
+func doPackReleaseVerify(source, packPath, commit, hash string, stdout, stderr io.Writer) int {
+	resolved, err := resolvePackReleaseSource(source, packPath, commit)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc pack release verify: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	if err := packregistry.VerifyPackContentHash(resolved.RepoDir, resolved.Commit, resolved.PackPath, hash); err != nil {
+		fmt.Fprintf(stderr, "gc pack release verify: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintln(stdout, "ok") //nolint:errcheck
+	return 0
+}
+
+func doPackReleaseStamp(registryPath, packName string, opts packReleaseStampOptions, stdout, stderr io.Writer) int {
+	if err := stampPackRelease(registryPath, packName, opts); err != nil {
+		fmt.Fprintf(stderr, "gc pack release stamp: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintf(stdout, "stamped %s %s in %s\n", packName, opts.Version, registryPath) //nolint:errcheck
+	return 0
+}
+
+func doPackReleaseValidate(registryPath, packName string, includeWithdrawn bool, stdout, stderr io.Writer) int {
+	checked, err := validatePackReleaseHashes(registryPath, packName, includeWithdrawn)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc pack release validate: %v\n", err) //nolint:errcheck
+		return 1
+	}
+	fmt.Fprintf(stdout, "registry release hashes ok (%d checked)\n", checked) //nolint:errcheck
+	return 0
+}
+
+type resolvedPackReleaseSource struct {
+	RepoDir  string
+	PackPath string
+	Commit   string
+}
+
+func resolvePackReleaseSource(source, packPath, commit string) (resolvedPackReleaseSource, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return resolvedPackReleaseSource{}, fmt.Errorf("source is required")
+	}
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return resolvedPackReleaseSource{}, fmt.Errorf("commit is required")
+	}
+	if remotesource.IsRemote(source) {
+		parsed := remotesource.Parse(source)
+		resolvedPackPath, err := normalizePackReleasePath(packPath)
+		if err != nil {
+			return resolvedPackReleaseSource{}, err
+		}
+		if resolvedPackPath == "" {
+			resolvedPackPath, err = normalizePackReleasePath(parsed.Subpath)
+			if err != nil {
+				return resolvedPackReleaseSource{}, err
+			}
+		}
+		repoDir, err := ensurePackReleaseRepoInCache(parsed.CloneURL, commit)
+		if err != nil {
+			return resolvedPackReleaseSource{}, err
+		}
+		resolvedCommit, err := packregistry.ResolveGitCommit(repoDir, commit)
+		if err != nil {
+			return resolvedPackReleaseSource{}, err
+		}
+		return resolvedPackReleaseSource{RepoDir: repoDir, PackPath: resolvedPackPath, Commit: resolvedCommit}, nil
+	}
+	repoDir, inferredPackPath, err := resolveLocalPackReleaseSource(source, packPath)
+	if err != nil {
+		return resolvedPackReleaseSource{}, err
+	}
+	resolvedCommit, err := packregistry.ResolveGitCommit(repoDir, commit)
+	if err != nil {
+		return resolvedPackReleaseSource{}, err
+	}
+	return resolvedPackReleaseSource{RepoDir: repoDir, PackPath: inferredPackPath, Commit: resolvedCommit}, nil
+}
+
+func resolveLocalPackReleaseSource(source, packPath string) (repoDir, resolvedPackPath string, err error) {
+	sourcePath := source
+	if sourcePath == "~" || strings.HasPrefix(sourcePath, "~/") {
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return "", "", fmt.Errorf("resolving home dir: %w", homeErr)
+		}
+		sourcePath = filepath.Join(home, strings.TrimPrefix(sourcePath, "~/"))
+	}
+	absSource, err := filepath.Abs(sourcePath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving source path: %w", err)
+	}
+	repoDir, err = localGitRoot(absSource)
+	if err != nil {
+		return "", "", err
+	}
+	if strings.TrimSpace(packPath) != "" {
+		resolvedPackPath, err := normalizePackReleasePath(packPath)
+		if err != nil {
+			return "", "", err
+		}
+		return repoDir, resolvedPackPath, nil
+	}
+	rel, err := filepath.Rel(repoDir, absSource)
+	if err != nil {
+		return "", "", fmt.Errorf("computing pack path: %w", err)
+	}
+	if rel == "." {
+		return repoDir, "", nil
+	}
+	return repoDir, filepath.ToSlash(rel), nil
+}
+
+func localGitRoot(path string) (string, error) {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolving local git root for %q: %s: %w", path, strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func ensurePackReleaseRepoInCache(cloneURL, commit string) (string, error) {
+	cloneURL = strings.TrimSpace(cloneURL)
+	if cloneURL == "" {
+		return "", fmt.Errorf("remote clone URL is required")
+	}
+	root, err := packReleaseRepoCacheRoot()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return "", fmt.Errorf("creating pack release repo cache: %w", err)
+	}
+	sum := sha256.Sum256([]byte(cloneURL + "\x00" + strings.TrimSpace(commit)))
+	cachePath := filepath.Join(root, fmt.Sprintf("%x", sum[:]))
+	if _, err := os.Stat(filepath.Join(cachePath, ".git")); err == nil {
+		if err := runPackReleaseGitCommand(cachePath, "fetch", "--quiet", "origin"); err != nil {
+			if removeErr := os.RemoveAll(cachePath); removeErr != nil {
+				return "", fmt.Errorf("removing stale pack release repo cache after fetch failure: %w", removeErr)
+			}
+		} else if err := checkoutPackReleaseRepo(cachePath, commit); err == nil {
+			return cachePath, nil
+		} else if removeErr := os.RemoveAll(cachePath); removeErr != nil {
+			return "", fmt.Errorf("removing stale pack release repo cache after checkout failure: %w", removeErr)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("checking pack release repo cache: %w", err)
+	} else if err := os.RemoveAll(cachePath); err != nil {
+		return "", fmt.Errorf("removing invalid pack release repo cache: %w", err)
+	}
+	if err := runPackReleaseGitCommand("", "clone", "--quiet", cloneURL, cachePath); err != nil {
+		return "", fmt.Errorf("cloning %q: %w", cloneURL, err)
+	}
+	if err := checkoutPackReleaseRepo(cachePath, commit); err != nil {
+		return "", err
+	}
+	return cachePath, nil
+}
+
+func checkoutPackReleaseRepo(repoDir, commit string) error {
+	if err := runPackReleaseGitCommand(repoDir, "checkout", "--quiet", commit); err != nil {
+		return fmt.Errorf("checking out %q: %w", commit, err)
+	}
+	if err := runPackReleaseGitCommand(repoDir, "reset", "--hard", "--quiet", commit); err != nil {
+		return fmt.Errorf("resetting pack release repo cache: %w", err)
+	}
+	if err := runPackReleaseGitCommand(repoDir, "clean", "-ffdx", "--quiet"); err != nil {
+		return fmt.Errorf("cleaning pack release repo cache: %w", err)
+	}
+	return nil
+}
+
+func packReleaseRepoCacheRoot() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home dir: %w", err)
+	}
+	return filepath.Join(home, ".gc", "cache", "registry-release-repos"), nil
+}
+
+func runPackReleaseGitCommand(dir string, args ...string) error {
+	cmdArgs := append([]string{
+		"-c", "core.fsmonitor=false",
+		"-c", "core.hooksPath=/dev/null",
+		"-c", "core.untrackedCache=false",
+	}, args...)
+	cmd := exec.Command("git", cmdArgs...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	for _, env := range os.Environ() {
+		key, _, ok := strings.Cut(env, "=")
+		if ok && packReleaseGitEnvBlacklist[key] {
+			continue
+		}
+		cmd.Env = append(cmd.Env, env)
+	}
+	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+var packReleaseGitEnvBlacklist = map[string]bool{
+	"GIT_DIR":                          true,
+	"GIT_WORK_TREE":                    true,
+	"GIT_INDEX_FILE":                   true,
+	"GIT_OBJECT_DIRECTORY":             true,
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
+	"GIT_COMMON_DIR":                   true,
+	"GIT_CEILING_DIRECTORIES":          true,
+	"GIT_DISCOVERY_ACROSS_FILESYSTEM":  true,
+	"GIT_NAMESPACE":                    true,
+	"GIT_CONFIG":                       true,
+	"GIT_CONFIG_GLOBAL":                true,
+	"GIT_CONFIG_SYSTEM":                true,
+	"GIT_CONFIG_NOSYSTEM":              true,
+	"GIT_CONFIG_COUNT":                 true,
+	"GIT_EXEC_PATH":                    true,
+	"GIT_PAGER":                        true,
+}
+
+func normalizePackReleasePath(raw string) (string, error) {
+	raw = strings.TrimSpace(filepath.ToSlash(raw))
+	if raw == "" || raw == "." {
+		return "", nil
+	}
+	if strings.HasPrefix(raw, "/") {
+		return "", fmt.Errorf("pack path %q must be relative", raw)
+	}
+	clean := path.Clean(strings.Trim(raw, "/"))
+	if clean == "." {
+		return "", nil
+	}
+	if clean == ".." || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
+		return "", fmt.Errorf("pack path %q must stay within the repository", raw)
+	}
+	return clean, nil
+}
+
+func stampPackRelease(registryPath, packName string, opts packReleaseStampOptions) error {
+	if err := packregistry.ValidatePackName(packName); err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.Version) == "" {
+		return fmt.Errorf("version is required")
+	}
+	if strings.TrimSpace(opts.Ref) == "" {
+		return fmt.Errorf("ref is required")
+	}
+	if strings.TrimSpace(opts.ReleaseDesc) == "" {
+		return fmt.Errorf("description is required")
+	}
+	catalog, err := readPackReleaseCatalog(registryPath)
+	if err != nil {
+		return err
+	}
+	catalog.Schema = packregistry.CatalogSchema
+	packIndex := -1
+	for i := range catalog.Packs {
+		if catalog.Packs[i].Name == packName {
+			packIndex = i
+			break
+		}
+	}
+	if packIndex == -1 {
+		if strings.TrimSpace(opts.Source) == "" {
+			return fmt.Errorf("source is required when creating pack %q", packName)
+		}
+		if strings.TrimSpace(opts.PackDescription) == "" {
+			return fmt.Errorf("pack-description is required when creating pack %q", packName)
+		}
+		catalog.Packs = append(catalog.Packs, packregistry.CatalogPack{
+			Name:        packName,
+			Description: opts.PackDescription,
+			Source:      opts.Source,
+			SourceKind:  "git",
+		})
+		packIndex = len(catalog.Packs) - 1
+	} else if strings.TrimSpace(opts.Source) != "" {
+		catalog.Packs[packIndex].Source = opts.Source
+	}
+	pack := &catalog.Packs[packIndex]
+	if strings.TrimSpace(pack.SourceKind) == "" {
+		pack.SourceKind = "git"
+	}
+	resolved, err := resolvePackReleaseSource(pack.Source, opts.PackPath, opts.Commit)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.PackPath) != "" {
+		pack.Source = packReleaseCatalogSource(pack.Source, resolved.RepoDir, resolved.PackPath)
+	}
+	actualName, err := packregistry.PackNameAtCommit(resolved.RepoDir, resolved.Commit, resolved.PackPath)
+	if err != nil {
+		return err
+	}
+	if actualName != packName {
+		return fmt.Errorf("pack name %q does not match %s/pack.toml name %q", packName, displayResolvedPackPath(resolved.PackPath), actualName)
+	}
+	hash, err := packregistry.PackContentHash(resolved.RepoDir, resolved.Commit, resolved.PackPath)
+	if err != nil {
+		return err
+	}
+	release := packregistry.CatalogRelease{
+		Version:     strings.TrimSpace(opts.Version),
+		Ref:         strings.TrimSpace(opts.Ref),
+		Commit:      resolved.Commit,
+		Hash:        hash,
+		Description: strings.TrimSpace(opts.ReleaseDesc),
+	}
+	if err := upsertPackRelease(pack, release, opts.Replace); err != nil {
+		return err
+	}
+	if err := packregistry.ValidateCatalog(catalog, false); err != nil {
+		return err
+	}
+	return writePackReleaseCatalog(registryPath, catalog)
+}
+
+func upsertPackRelease(pack *packregistry.CatalogPack, release packregistry.CatalogRelease, replace bool) error {
+	for i, existing := range pack.Releases {
+		if existing.Version != release.Version {
+			continue
+		}
+		if !replace && (existing.Ref != release.Ref || existing.Commit != release.Commit || existing.Hash != release.Hash) {
+			return fmt.Errorf("release %s already exists for pack %q with different immutable metadata; use --replace to rewrite it", release.Version, pack.Name)
+		}
+		release.Withdrawn = existing.Withdrawn
+		release.WithdrawnReason = existing.WithdrawnReason
+		pack.Releases[i] = release
+		return nil
+	}
+	pack.Releases = append(pack.Releases, release)
+	return nil
+}
+
+func packReleaseCatalogSource(source, repoDir, packPath string) string {
+	packPath = strings.Trim(strings.TrimSpace(filepath.ToSlash(packPath)), "/")
+	if packPath == "" {
+		return source
+	}
+	if remotesource.IsRemote(source) {
+		return remotePackReleaseSource(remotesource.Parse(source), packPath)
+	}
+	return filepath.Join(repoDir, filepath.FromSlash(packPath))
+}
+
+func remotePackReleaseSource(parsed remotesource.Parsed, packPath string) string {
+	source := strings.TrimRight(parsed.CloneURL, "/")
+	if strings.TrimSpace(packPath) != "" {
+		source += "//" + strings.Trim(strings.TrimSpace(filepath.ToSlash(packPath)), "/")
+	}
+	if parsed.Ref != "" {
+		source += "#" + parsed.Ref
+	}
+	return source
+}
+
+func validatePackReleaseHashes(registryPath, packName string, includeWithdrawn bool) (int, error) {
+	catalog, err := readPackReleaseCatalog(registryPath)
+	if err != nil {
+		return 0, err
+	}
+	if err := packregistry.ValidateCatalog(catalog, false); err != nil {
+		return 0, err
+	}
+	if strings.TrimSpace(packName) != "" {
+		if err := packregistry.ValidatePackName(packName); err != nil {
+			return 0, err
+		}
+	}
+	checked := 0
+	foundPack := packName == ""
+	for _, pack := range catalog.Packs {
+		if packName != "" && pack.Name != packName {
+			continue
+		}
+		foundPack = true
+		for _, release := range pack.Releases {
+			if release.Withdrawn && !includeWithdrawn {
+				continue
+			}
+			resolved, err := resolvePackReleaseSource(pack.Source, "", release.Commit)
+			if err != nil {
+				return checked, fmt.Errorf("%s %s: %w", pack.Name, release.Version, err)
+			}
+			if err := packregistry.VerifyPackContentHash(resolved.RepoDir, resolved.Commit, resolved.PackPath, release.Hash); err != nil {
+				return checked, fmt.Errorf("%s %s: %w", pack.Name, release.Version, err)
+			}
+			checked++
+		}
+	}
+	if !foundPack {
+		return checked, fmt.Errorf("pack %q not found", packName)
+	}
+	return checked, nil
+}
+
+func readPackReleaseCatalog(registryPath string) (packregistry.Catalog, error) {
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return packregistry.Catalog{Schema: packregistry.CatalogSchema}, nil
+		}
+		return packregistry.Catalog{}, fmt.Errorf("reading %s: %w", registryPath, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return packregistry.Catalog{Schema: packregistry.CatalogSchema}, nil
+	}
+	catalog, err := packregistry.ParseCatalog(data)
+	if err != nil {
+		return packregistry.Catalog{}, err
+	}
+	return catalog, nil
+}
+
+func writePackReleaseCatalog(registryPath string, catalog packregistry.Catalog) error {
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(catalog); err != nil {
+		return fmt.Errorf("encoding registry catalog: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(registryPath), 0o755); err != nil {
+		return fmt.Errorf("creating registry directory: %w", err)
+	}
+	return fsys.WriteFileAtomic(fsys.OSFS{}, registryPath, buf.Bytes(), 0o644)
+}
+
+func displayResolvedPackPath(packPath string) string {
+	if strings.TrimSpace(packPath) == "" {
+		return "."
+	}
+	return packPath
+}

--- a/cmd/gc/cmd_pack_release_test.go
+++ b/cmd/gc/cmd_pack_release_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/packregistry"
+)
+
+func TestPackReleaseHashCommandPrintsContentHash(t *testing.T) {
+	repo, commit := initPackReleaseRepo(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doPackReleaseHash(repo, "packs/demo", commit, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("hash code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	want, err := packregistry.PackContentHash(repo, commit, "packs/demo")
+	if err != nil {
+		t.Fatalf("PackContentHash: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != want {
+		t.Fatalf("hash stdout = %q, want %q", got, want)
+	}
+}
+
+func TestPackReleaseHashRemoteRootWithExplicitPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo, commit := initPackReleaseRepo(t)
+	source := "file://" + repo
+
+	var stdout, stderr bytes.Buffer
+	code := doPackReleaseHash(source, "packs/demo", commit, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("hash code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	want, err := packregistry.PackContentHash(repo, commit, "packs/demo")
+	if err != nil {
+		t.Fatalf("PackContentHash: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != want {
+		t.Fatalf("hash stdout = %q, want %q", got, want)
+	}
+}
+
+func TestPackReleaseStampCreatesAndValidatesRegistryRelease(t *testing.T) {
+	repo, commit := initPackReleaseRepo(t)
+	registryPath := filepath.Join(t.TempDir(), "registry.toml")
+	if err := os.WriteFile(registryPath, []byte("schema = 1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(registry): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	opts := packReleaseStampOptions{
+		Version:         "0.1.0",
+		Ref:             "main",
+		Commit:          commit,
+		ReleaseDesc:     "Initial demo pack release.",
+		Source:          repo,
+		PackPath:        "packs/demo",
+		PackDescription: "Demo pack.",
+	}
+	if code := doPackReleaseStamp(registryPath, "demo", opts, &stdout, &stderr); code != 0 {
+		t.Fatalf("stamp code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stamped demo 0.1.0") {
+		t.Fatalf("stamp stdout = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := doPackReleaseValidate(registryPath, "", false, &stdout, &stderr); code != 0 {
+		t.Fatalf("validate code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "registry release hashes ok") {
+		t.Fatalf("validate stdout = %q", stdout.String())
+	}
+}
+
+func TestPackReleaseValidateRejectsHashMismatch(t *testing.T) {
+	repo, commit := initPackReleaseRepo(t)
+	registryPath := filepath.Join(t.TempDir(), "registry.toml")
+	source := filepath.Join(repo, "packs", "demo")
+	text := `schema = 1
+
+[[pack]]
+name = "demo"
+description = "Demo pack."
+source = "` + source + `"
+source_kind = "git"
+`
+	text += `
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "` + commit + `"
+  hash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  description = "Initial demo pack release."
+`
+	if err := os.WriteFile(registryPath, []byte(text), 0o644); err != nil {
+		t.Fatalf("WriteFile(registry): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doPackReleaseValidate(registryPath, "", false, &stdout, &stderr); code == 0 {
+		t.Fatalf("validate succeeded with bad hash stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "hash mismatch") {
+		t.Fatalf("validate stderr = %q, want hash mismatch", stderr.String())
+	}
+}
+
+func TestPackReleaseValidateSkipsWithdrawnByDefault(t *testing.T) {
+	repo, commit := initPackReleaseRepo(t)
+	registryPath := filepath.Join(t.TempDir(), "registry.toml")
+	source := filepath.Join(repo, "packs", "demo")
+	text := `schema = 1
+
+[[pack]]
+name = "demo"
+description = "Demo pack."
+source = "` + source + `"
+source_kind = "git"
+
+  [[pack.release]]
+  version = "0.1.0"
+  ref = "main"
+  commit = "` + commit + `"
+  hash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  description = "Initial demo pack release."
+  withdrawn = true
+  withdrawn_reason = "bad hash"
+`
+	if err := os.WriteFile(registryPath, []byte(text), 0o644); err != nil {
+		t.Fatalf("WriteFile(registry): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doPackReleaseValidate(registryPath, "", false, &stdout, &stderr); code != 0 {
+		t.Fatalf("validate active code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "(0 checked)") {
+		t.Fatalf("validate stdout = %q, want 0 checked", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := doPackReleaseValidate(registryPath, "", true, &stdout, &stderr); code == 0 {
+		t.Fatalf("validate include withdrawn succeeded stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "hash mismatch") {
+		t.Fatalf("validate include withdrawn stderr = %q, want hash mismatch", stderr.String())
+	}
+}
+
+func initPackReleaseRepo(t *testing.T) (repo string, commit string) {
+	t.Helper()
+	repo = t.TempDir()
+	runPackReleaseGit(t, repo, "init")
+	runPackReleaseGit(t, repo, "config", "user.email", "test@example.com")
+	runPackReleaseGit(t, repo, "config", "user.name", "Test User")
+	writePackReleaseFile(t, repo, "packs/demo/pack.toml", "[pack]\nname = \"demo\"\nschema = 2\n", 0o644)
+	writePackReleaseFile(t, repo, "packs/demo/commands/run.sh", "#!/bin/sh\nexit 0\n", 0o755)
+	runPackReleaseGit(t, repo, "add", ".")
+	runPackReleaseGit(t, repo, "commit", "-m", "add demo pack")
+	commit = strings.TrimSpace(outputPackReleaseGit(t, repo, "rev-parse", "HEAD"))
+	return repo, commit
+}
+
+func writePackReleaseFile(t *testing.T, root, rel, body string, mode os.FileMode) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(body), mode); err != nil {
+		t.Fatalf("WriteFile(%s): %v", rel, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("Chmod(%s): %v", rel, err)
+	}
+}
+
+func runPackReleaseGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	_ = outputPackReleaseGit(t, dir, args...)
+}
+
+func outputPackReleaseGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %s: %v", strings.Join(args, " "), out, err)
+	}
+	return string(out)
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2230,6 +2230,7 @@ gc pack
 | [gc pack fetch](#gc-pack-fetch) | Clone missing and update existing remote packs |
 | [gc pack list](#gc-pack-list) | Show remote pack sources and cache status |
 | [gc pack registry](#gc-pack-registry) | Manage pack registries |
+| [gc pack release](#gc-pack-release) | Author pack registry release metadata |
 
 ## gc pack fetch
 
@@ -2348,6 +2349,80 @@ gc pack registry show <pack-name> [flags]
 |------|------|---------|-------------|
 | `--json` | bool |  | emit JSONL result |
 | `--refresh` | bool |  | refresh catalogs before showing |
+
+## gc pack release
+
+Author pack registry release metadata, including canonical pack content hashes.
+
+```
+gc pack release
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc pack release hash](#gc-pack-release-hash) | Compute a pack release content hash |
+| [gc pack release stamp](#gc-pack-release-stamp) | Stamp a registry release entry with a computed content hash |
+| [gc pack release validate](#gc-pack-release-validate) | Validate registry release content hashes |
+| [gc pack release verify](#gc-pack-release-verify) | Verify a pack release content hash |
+
+## gc pack release hash
+
+Compute a pack release content hash
+
+```
+gc pack release hash <source> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--commit` | string |  | git commit or ref to hash |
+| `--path` | string |  | pack path inside the source repository |
+
+## gc pack release stamp
+
+Stamp a registry release entry with a computed content hash
+
+```
+gc pack release stamp <registry.toml> <pack-name> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--commit` | string |  | git commit or ref to hash and record |
+| `--description` | string |  | release description |
+| `--pack-description` | string |  | pack description; required when creating a new [[pack]] |
+| `--path` | string |  | pack path inside the source repository |
+| `--ref` | string |  | release ref to record |
+| `--replace` | bool |  | replace an existing release with the same version |
+| `--source` | string |  | pack source; required when creating a new [[pack]] |
+| `--version` | string |  | release version to stamp |
+
+## gc pack release validate
+
+Validate registry release content hashes
+
+```
+gc pack release validate <registry.toml> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--include-withdrawn` | bool |  | also validate withdrawn releases |
+| `--pack` | string |  | validate only one registry pack |
+
+## gc pack release verify
+
+Verify a pack release content hash
+
+```
+gc pack release verify <source> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--commit` | string |  | git commit or ref to verify |
+| `--hash` | string |  | expected sha256:&lt;64hex&gt; content hash |
+| `--path` | string |  | pack path inside the source repository |
 
 ## gc prime
 

--- a/internal/packregistry/content_hash.go
+++ b/internal/packregistry/content_hash.go
@@ -1,0 +1,273 @@
+package packregistry
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// PackContentHash returns the canonical sha256 content hash for one pack
+// directory at a git commit. The hash is over a sorted manifest of tracked
+// files containing relative path, executable mode, and file-content hash.
+func PackContentHash(repoDir, commit, packPath string) (string, error) {
+	repoDir = strings.TrimSpace(repoDir)
+	if repoDir == "" {
+		return "", fmt.Errorf("repository path is required")
+	}
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return "", fmt.Errorf("commit is required")
+	}
+	packPath, err := cleanPackContentPath(packPath)
+	if err != nil {
+		return "", err
+	}
+	resolvedCommit, err := ResolveGitCommit(repoDir, commit)
+	if err != nil {
+		return "", err
+	}
+	if err := requirePackToml(repoDir, resolvedCommit, packPath); err != nil {
+		return "", err
+	}
+
+	args := []string{"ls-tree", "-r", "-z", "--full-tree", resolvedCommit}
+	if packPath != "" {
+		args = append(args, "--", packPath)
+	}
+	out, err := runRegistryGitBytes(repoDir, args...)
+	if err != nil {
+		return "", fmt.Errorf("listing pack tree: %w", err)
+	}
+	records := bytes.Split(bytes.TrimSuffix(out, []byte{0}), []byte{0})
+	entries := make([]string, 0, len(records))
+	for _, record := range records {
+		if len(record) == 0 {
+			continue
+		}
+		fields, filePath, ok := bytes.Cut(record, []byte{'\t'})
+		if !ok {
+			return "", fmt.Errorf("unexpected git ls-tree record %q", string(record))
+		}
+		parts := strings.Fields(string(fields))
+		if len(parts) != 3 {
+			return "", fmt.Errorf("unexpected git ls-tree metadata %q", string(fields))
+		}
+		mode, objectType, objectID := parts[0], parts[1], parts[2]
+		if objectType != "blob" {
+			return "", fmt.Errorf("unsupported git object type %q for %s", objectType, filePath)
+		}
+		rel, err := relativePackContentPath(string(filePath), packPath)
+		if err != nil {
+			return "", err
+		}
+		perm, err := gitManifestPerm(mode)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", rel, err)
+		}
+		data, err := runRegistryGitBytes(repoDir, "cat-file", "blob", objectID)
+		if err != nil {
+			return "", fmt.Errorf("reading git blob %s for %s: %w", objectID, rel, err)
+		}
+		sum := sha256.Sum256(data)
+		entries = append(entries, fmt.Sprintf("%s %s %x", rel, perm, sum[:]))
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("pack path %q has no tracked files at %s", displayPackPath(packPath), resolvedCommit)
+	}
+	sort.Strings(entries)
+	sum := sha256.Sum256([]byte(strings.Join(entries, "\n")))
+	return fmt.Sprintf("sha256:%x", sum[:]), nil
+}
+
+// VerifyPackContentHash checks one pack-content hash against the canonical
+// hash for repoDir/commit/packPath.
+func VerifyPackContentHash(repoDir, commit, packPath, expected string) error {
+	expected = strings.TrimSpace(expected)
+	if err := ValidateReleaseHash(expected); err != nil {
+		return err
+	}
+	actual, err := PackContentHash(repoDir, commit, packPath)
+	if err != nil {
+		return err
+	}
+	if actual != expected {
+		return fmt.Errorf("hash mismatch: got %s, want %s", actual, expected)
+	}
+	return nil
+}
+
+// PackNameAtCommit reads [pack].name from pack.toml at repoDir/commit/packPath.
+func PackNameAtCommit(repoDir, commit, packPath string) (string, error) {
+	packPath, err := cleanPackContentPath(packPath)
+	if err != nil {
+		return "", err
+	}
+	resolvedCommit, err := ResolveGitCommit(repoDir, commit)
+	if err != nil {
+		return "", err
+	}
+	packToml := path.Join(packPath, "pack.toml")
+	if packPath == "" {
+		packToml = "pack.toml"
+	}
+	data, err := runRegistryGitBytes(repoDir, "cat-file", "blob", resolvedCommit+":"+packToml)
+	if err != nil {
+		return "", fmt.Errorf("reading %s at %s: %w", packToml, resolvedCommit, err)
+	}
+	var meta struct {
+		Pack struct {
+			Name string `toml:"name"`
+		} `toml:"pack"`
+	}
+	if _, err := toml.Decode(string(data), &meta); err != nil {
+		return "", fmt.Errorf("parsing %s at %s: %w", packToml, resolvedCommit, err)
+	}
+	if strings.TrimSpace(meta.Pack.Name) == "" {
+		return "", fmt.Errorf("%s at %s is missing [pack].name", packToml, resolvedCommit)
+	}
+	return meta.Pack.Name, nil
+}
+
+// ResolveGitCommit resolves commit-ish to a full lowercase git commit SHA.
+func ResolveGitCommit(repoDir, commitish string) (string, error) {
+	out, err := runRegistryGitBytes(repoDir, "rev-parse", "--verify", strings.TrimSpace(commitish)+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolving commit %q: %w", commitish, err)
+	}
+	commit := strings.ToLower(strings.TrimSpace(string(out)))
+	if !commitRE.MatchString(commit) {
+		return "", fmt.Errorf("resolved commit %q is not a full SHA", commit)
+	}
+	return commit, nil
+}
+
+// ValidateReleaseHash validates the registry release hash syntax.
+func ValidateReleaseHash(hash string) error {
+	if !hashRE.MatchString(strings.TrimSpace(hash)) {
+		return fmt.Errorf("hash must be sha256:<64 lowercase hex>")
+	}
+	return nil
+}
+
+// ValidateReleaseCommit validates the registry release commit syntax.
+func ValidateReleaseCommit(commit string) error {
+	if !commitRE.MatchString(strings.TrimSpace(commit)) {
+		return fmt.Errorf("commit must be a full lowercase SHA")
+	}
+	return nil
+}
+
+func requirePackToml(repoDir, commit, packPath string) error {
+	packToml := path.Join(packPath, "pack.toml")
+	if packPath == "" {
+		packToml = "pack.toml"
+	}
+	if _, err := runRegistryGitBytes(repoDir, "cat-file", "-e", commit+":"+packToml); err != nil {
+		return fmt.Errorf("pack path %q does not contain tracked pack.toml at %s", displayPackPath(packPath), commit)
+	}
+	return nil
+}
+
+func cleanPackContentPath(raw string) (string, error) {
+	raw = strings.TrimSpace(filepath.ToSlash(raw))
+	if raw == "" || raw == "." {
+		return "", nil
+	}
+	if strings.HasPrefix(raw, "/") {
+		return "", fmt.Errorf("pack path %q must be relative", raw)
+	}
+	clean := path.Clean(strings.Trim(raw, "/"))
+	if clean == "." {
+		return "", nil
+	}
+	if clean == ".." || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
+		return "", fmt.Errorf("pack path %q must stay within the repository", raw)
+	}
+	return clean, nil
+}
+
+func relativePackContentPath(gitPath, packPath string) (string, error) {
+	gitPath = path.Clean(filepath.ToSlash(gitPath))
+	if packPath == "" {
+		return gitPath, nil
+	}
+	prefix := packPath + "/"
+	if !strings.HasPrefix(gitPath, prefix) {
+		return "", fmt.Errorf("git path %q is outside pack path %q", gitPath, packPath)
+	}
+	rel := strings.TrimPrefix(gitPath, prefix)
+	if rel == "" || rel == "." {
+		return "", fmt.Errorf("empty relative path for %q", gitPath)
+	}
+	return rel, nil
+}
+
+func gitManifestPerm(mode string) (string, error) {
+	switch mode {
+	case "100644":
+		return "0644", nil
+	case "100755":
+		return "0755", nil
+	case "120000":
+		return "0777", nil
+	default:
+		return "", fmt.Errorf("unsupported git file mode %q", mode)
+	}
+}
+
+func displayPackPath(packPath string) string {
+	if packPath == "" {
+		return "."
+	}
+	return packPath
+}
+
+func runRegistryGitBytes(dir string, args ...string) ([]byte, error) {
+	cmdArgs := append([]string{
+		"-c", "core.fsmonitor=false",
+		"-c", "core.hooksPath=/dev/null",
+		"-c", "core.untrackedCache=false",
+	}, args...)
+	cmd := exec.Command("git", cmdArgs...)
+	cmd.Dir = dir
+	for _, env := range os.Environ() {
+		key, _, ok := strings.Cut(env, "=")
+		if ok && registryGitEnvBlacklist[key] {
+			continue
+		}
+		cmd.Env = append(cmd.Env, env)
+	}
+	cmd.Env = append(cmd.Env, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+	}
+	return out, nil
+}
+
+var registryGitEnvBlacklist = map[string]bool{
+	"GIT_DIR":                          true,
+	"GIT_WORK_TREE":                    true,
+	"GIT_INDEX_FILE":                   true,
+	"GIT_OBJECT_DIRECTORY":             true,
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
+	"GIT_COMMON_DIR":                   true,
+	"GIT_CEILING_DIRECTORIES":          true,
+	"GIT_DISCOVERY_ACROSS_FILESYSTEM":  true,
+	"GIT_NAMESPACE":                    true,
+	"GIT_CONFIG":                       true,
+	"GIT_CONFIG_GLOBAL":                true,
+	"GIT_CONFIG_SYSTEM":                true,
+	"GIT_CONFIG_NOSYSTEM":              true,
+	"GIT_CONFIG_COUNT":                 true,
+	"GIT_EXEC_PATH":                    true,
+	"GIT_PAGER":                        true,
+}

--- a/internal/packregistry/content_hash_test.go
+++ b/internal/packregistry/content_hash_test.go
@@ -1,0 +1,104 @@
+package packregistry
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPackContentHashUsesTrackedPackManifest(t *testing.T) {
+	repo := initContentHashRepo(t)
+	writeContentHashFile(t, repo, "packs/demo/pack.toml", "[pack]\nname = \"demo\"\nschema = 2\n", 0o644)
+	writeContentHashFile(t, repo, "packs/demo/commands/run.sh", "#!/bin/sh\nexit 0\n", 0o755)
+	writeContentHashFile(t, repo, "packs/demo/untracked.txt", "ignored\n", 0o644)
+	runContentHashGit(t, repo, "add", "packs/demo/pack.toml", "packs/demo/commands/run.sh")
+	runContentHashGit(t, repo, "commit", "-m", "add demo pack")
+	commit := strings.TrimSpace(outputContentHashGit(t, repo, "rev-parse", "HEAD"))
+
+	got, err := PackContentHash(repo, commit, "packs/demo")
+	if err != nil {
+		t.Fatalf("PackContentHash: %v", err)
+	}
+	want := manifestHash(
+		"commands/run.sh 0755 "+blobHash("#!/bin/sh\nexit 0\n"),
+		"pack.toml 0644 "+blobHash("[pack]\nname = \"demo\"\nschema = 2\n"),
+	)
+	if got != want {
+		t.Fatalf("hash = %q, want %q", got, want)
+	}
+
+	writeContentHashFile(t, repo, "packs/demo/untracked.txt", "changed but ignored\n", 0o644)
+	again, err := PackContentHash(repo, commit, "packs/demo")
+	if err != nil {
+		t.Fatalf("PackContentHash after untracked change: %v", err)
+	}
+	if again != want {
+		t.Fatalf("hash changed after untracked edit: %q != %q", again, want)
+	}
+}
+
+func TestPackContentHashRequiresPackToml(t *testing.T) {
+	repo := initContentHashRepo(t)
+	writeContentHashFile(t, repo, "packs/not-pack/readme.md", "hello\n", 0o644)
+	runContentHashGit(t, repo, "add", ".")
+	runContentHashGit(t, repo, "commit", "-m", "add non-pack")
+	commit := strings.TrimSpace(outputContentHashGit(t, repo, "rev-parse", "HEAD"))
+
+	_, err := PackContentHash(repo, commit, "packs/not-pack")
+	if err == nil || !strings.Contains(err.Error(), "pack.toml") {
+		t.Fatalf("PackContentHash err = %v, want missing pack.toml", err)
+	}
+}
+
+func initContentHashRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runContentHashGit(t, repo, "init")
+	runContentHashGit(t, repo, "config", "user.email", "test@example.com")
+	runContentHashGit(t, repo, "config", "user.name", "Test User")
+	return repo
+}
+
+func writeContentHashFile(t *testing.T, root, rel, body string, mode os.FileMode) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(body), mode); err != nil {
+		t.Fatalf("WriteFile(%s): %v", rel, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("Chmod(%s): %v", rel, err)
+	}
+}
+
+func runContentHashGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	_ = outputContentHashGit(t, dir, args...)
+}
+
+func outputContentHashGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %s: %v", strings.Join(args, " "), out, err)
+	}
+	return string(out)
+}
+
+func blobHash(data string) string {
+	sum := sha256.Sum256([]byte(data))
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func manifestHash(entries ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(entries, "\n")))
+	return fmt.Sprintf("sha256:%x", sum[:])
+}


### PR DESCRIPTION
## Summary
- add `gc pack release hash`, `verify`, `stamp`, and `validate` commands for registry.toml release metadata
- add canonical pack content hashing over tracked git files, relative paths, executable modes, and blob hashes
- validate active registry release hashes by default, with `--include-withdrawn` for historical entries
- regenerate CLI reference docs for the new command surface

## Validation
- `go test ./internal/packregistry -count=1`
- `go test ./cmd/gc -run 'TestCLIDocsFreshness|TestPackRelease|TestPackRegistry|TestPackCommand' -count=1`\n- `go test ./test/docsync -count=1`\n- pre-commit hook passed: `lint-changed`, generated docs/schema checks, `go vet ./...`, `scripts/test-local-parallel fast`, and docsync\n