### PR TITLE
fix(cmd/gc): align open routed work collection

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1555,8 +1555,8 @@ func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[
 	}
 }
 
-// appendOpenRoutedWorkUnique includes open beads that are still pool-routed
-// AND still carry an assignee. This is the narrow input
+// appendOpenRoutedWorkUnique includes open beads that are still releasably
+// pool-routed AND still carry an assignee. This is the narrow input
 // releaseOrphanedPoolAssignments needs to clear step beads abandoned by a
 // dead session (graph.v2 wisps where the root depends on the finalize
 // step, so the root never enters ready and the step assignee remains a
@@ -1566,11 +1566,7 @@ func appendOpenRoutedWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeR
 		if strings.TrimSpace(b.Assignee) == "" {
 			continue
 		}
-		template := strings.TrimSpace(b.Metadata["gc.run_target"])
-		if template == "" {
-			template = strings.TrimSpace(b.Metadata["gc.routed_to"])
-		}
-		if template == "" {
+		if routedToOrLegacyWorkflowTarget(b) == "" {
 			continue
 		}
 		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1581,6 +1581,10 @@ func TestCollectAssignedWorkBeads_ExcludesRoutedToMetadataWithoutAssignee(t *tes
 func TestCollectAssignedWorkBeads_IncludesOpenPoolRoutedAssignedWork(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
+	blocker, err := store.Create(beads.Bead{Title: "workflow finalize", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("create blocker bead: %v", err)
+	}
 	work, err := store.Create(beads.Bead{
 		Title:    "orphaned step bead",
 		Type:     "task",
@@ -1591,6 +1595,9 @@ func TestCollectAssignedWorkBeads_IncludesOpenPoolRoutedAssignedWork(t *testing.
 	if err != nil {
 		t.Fatalf("create orphaned step bead: %v", err)
 	}
+	if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("block orphaned step bead: %v", err)
+	}
 
 	got, _ := collectAssignedWorkBeads(&config.City{}, store)
 	if len(got) != 1 || got[0].ID != work.ID {
@@ -1599,26 +1606,66 @@ func TestCollectAssignedWorkBeads_IncludesOpenPoolRoutedAssignedWork(t *testing.
 }
 
 // TestCollectAssignedWorkBeads_IncludesOpenRunTargetAssignedWork covers the
-// graph.v2 root-step shape: root beads stamp gc.run_target (not
-// gc.routed_to). The third pass must accept either marker so root steps
-// that orphan-release missed are also recoverable.
+// legacy workflow root shape: workflow beads stamp gc.run_target (not
+// gc.routed_to). The third pass accepts that marker only for the same
+// workflow-kind beads that releaseOrphanedPoolAssignments can release.
 func TestCollectAssignedWorkBeads_IncludesOpenRunTargetAssignedWork(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
+	blocker, err := store.Create(beads.Bead{Title: "workflow finalize", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("create blocker bead: %v", err)
+	}
 	work, err := store.Create(beads.Bead{
 		Title:    "orphaned root step",
 		Type:     "task",
 		Status:   "open",
 		Assignee: "rig--pool__coder-dead-session",
-		Metadata: map[string]string{"gc.run_target": "rig/pool.coder"},
+		Metadata: map[string]string{
+			"gc.kind":       "workflow",
+			"gc.run_target": "rig/pool.coder",
+		},
 	})
 	if err != nil {
 		t.Fatalf("create orphaned root step: %v", err)
+	}
+	if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("block orphaned root step: %v", err)
 	}
 
 	got, _ := collectAssignedWorkBeads(&config.City{}, store)
 	if len(got) != 1 || got[0].ID != work.ID {
 		t.Fatalf("collectAssignedWorkBeads = %#v, want [%s]", got, work.ID)
+	}
+}
+
+func TestCollectAssignedWorkBeads_ExcludesOpenNonWorkflowRunTargetAssignedWork(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+	blocker, err := store.Create(beads.Bead{Title: "workflow finalize", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("create blocker bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "control retry bead",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "gascity--control-dispatcher",
+		Metadata: map[string]string{
+			"gc.kind":       "retry",
+			"gc.run_target": "gascity/gc.implementation-worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create control retry bead: %v", err)
+	}
+	if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("block control retry bead: %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(&config.City{}, store)
+	if len(got) != 0 {
+		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0 for non-workflow gc.run_target", len(got))
 	}
 }
 

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -1091,6 +1091,10 @@ func TestReleaseOrphanedPoolAssignments_ReopensUnassignedInProgressPoolWork(t *t
 // demand stayed at 0 across reconcile ticks.
 func TestCollectAndReleaseOrphanPoolStepBead_Issue2793(t *testing.T) {
 	store := beads.NewMemStore()
+	blocker, err := store.Create(beads.Bead{Title: "workflow finalize", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create blocker bead: %v", err)
+	}
 	work, err := store.Create(beads.Bead{
 		Title:    "graph.v2 step bead orphaned by dead session",
 		Type:     "task",
@@ -1100,6 +1104,9 @@ func TestCollectAndReleaseOrphanPoolStepBead_Issue2793(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Create orphaned step bead: %v", err)
+	}
+	if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("Block orphaned step bead: %v", err)
 	}
 
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
@@ -1127,6 +1134,106 @@ func TestCollectAndReleaseOrphanPoolStepBead_Issue2793(t *testing.T) {
 	}
 	if got.Assignee != "" {
 		t.Fatalf("assignee = %q, want empty after release", got.Assignee)
+	}
+}
+
+func TestCollectAndReleaseOrphanWorkflowRunTargetBead(t *testing.T) {
+	store := beads.NewMemStore()
+	blocker, err := store.Create(beads.Bead{Title: "workflow finalize", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create blocker bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "legacy workflow root orphaned by dead session",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "rig--pool__coder-gc-session-deadbeef",
+		Metadata: map[string]string{
+			"gc.kind":       "workflow",
+			"gc.run_target": "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create workflow run-target bead: %v", err)
+	}
+	if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("Block workflow run-target bead: %v", err)
+	}
+
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
+
+	found, foundStores, foundStoreRefs, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	if len(found) != 1 || found[0].ID != work.ID {
+		t.Fatalf("collect missed the workflow run-target bead: got %#v, want [%s]", found, work.ID)
+	}
+
+	released := releaseOrphanedPoolAssignments(store, cfg, "", nil, found, foundStores, foundStoreRefs, nil)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get workflow run-target bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty after release", got.Assignee)
+	}
+}
+
+func TestCollectAndReleaseNonWorkflowRunTargetBeadStaysAssigned(t *testing.T) {
+	store := beads.NewMemStore()
+	blocker, err := store.Create(beads.Bead{Title: "workflow finalize", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create blocker bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "control retry bead",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "gascity--control-dispatcher",
+		Metadata: map[string]string{
+			"gc.kind":       "retry",
+			"gc.run_target": "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create non-workflow run-target bead: %v", err)
+	}
+	if err := store.DepAdd(work.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("Block non-workflow run-target bead: %v", err)
+	}
+
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
+
+	found, foundStores, foundStoreRefs, partial := collectAssignedWorkBeadsWithStores(cfg, store, nil, nil, nil)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	if len(found) != 0 {
+		t.Fatalf("collectAssignedWorkBeadsWithStores returned %#v, want none for non-workflow gc.run_target", found)
+	}
+
+	released := releaseOrphanedPoolAssignments(store, cfg, "", nil, found, foundStores, foundStoreRefs, nil)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none for non-workflow gc.run_target", released)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get non-workflow run-target bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Assignee != "gascity--control-dispatcher" {
+		t.Fatalf("assignee = %q, want original control dispatcher", got.Assignee)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #2831 after the original contributor PR was merged before adoption finalization completed.

## Context

- Original PR: https://github.com/gastownhall/gascity/pull/2831
- Original title: fix(cmd/gc): release orphan pool step beads stuck open after session drain (#2793)
- Original state at finalization: MERGED
- Configured base: main
- Original GitHub base: main
- Base mismatch: none

## Maintainer follow-up

This carries the adoption-review fix that remained after #2831 landed: align `appendOpenRoutedWorkUnique` with the release path's `routedToOrLegacyWorkflowTarget` semantics so open `gc.run_target` beads are collected only when they are releasable workflow-kind work, not arbitrary control-lane beads.

It also adds focused regression coverage for workflow `gc.run_target` release and non-workflow `gc.run_target` exclusion.

## Validation

- `git diff --check refs/adopt-pr/ga-zsypb/latest-base..HEAD`
- `go test ./cmd/gc -run 'TestCollectAssignedWorkBeads_(IncludesOpenPoolRoutedAssignedWork|IncludesOpenRunTargetAssignedWork|ExcludesOpenNonWorkflowRunTargetAssignedWork)|TestCollectAndRelease(OrphanPoolStepBead_Issue2793|OrphanWorkflowRunTargetBead|NonWorkflowRunTargetBeadStaysAssigned)|TestReleaseOrphanedPoolAssignments_SkipsWorkReassignedAfterCandidateSnapshot'`

Both passed locally before opening this follow-up PR.
