### PR TITLE
Prune closed order tracking history

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1334,6 +1334,9 @@ func (cr *CityRuntime) runOrderTrackingSweepWatchdog(now time.Time) {
 	// The staleAfter cutoff still protects in-flight dispatches regardless of
 	// which order they belong to, so a direct all-orders sweep is safe and
 	// recovers the jam without depending on any single order being scheduled.
+	// Closed-history retention is intentionally left to the maintenance exec
+	// order or the gc order sweep-tracking CLI; the watchdog only recovers
+	// stale open tracking beads.
 	result, sweepErr := sweepStaleOrderTrackingAcrossStoresLimit(stores, now, orderTrackingSweepWatchdogStaleAfter, nil, orderTrackingWatchdogMetadataInitiator, false, orderTrackingSweepCloseBudget)
 	if err := errors.Join(storeErr, sweepErr); err != nil {
 		if cr.stderr != nil {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -3158,7 +3158,7 @@ func TestCityRuntimeTick_PrefixesEachJoinedWispGCErrorLine(t *testing.T) {
 		wg: fixedWispGC{err: fmt.Errorf(
 			"%s\n%s",
 			"deleting expired bead \"mol-1\": delete failed",
-			"listing closed order-tracking beads: list failed",
+			"listing closed molecule roots: list failed",
 		)},
 		rec:       events.Discard,
 		logPrefix: "test-city",
@@ -3177,7 +3177,7 @@ func TestCityRuntimeTick_PrefixesEachJoinedWispGCErrorLine(t *testing.T) {
 	got := stderr.String()
 	for _, want := range []string{
 		"test-city: wisp gc: deleting expired bead \"mol-1\": delete failed\n",
-		"test-city: wisp gc: listing closed order-tracking beads: list failed\n",
+		"test-city: wisp gc: listing closed molecule roots: list failed\n",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr = %q, want line %q", got, want)

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -1513,11 +1513,11 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 	}
 	now := time.Now()
 	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, now, staleAfter, onlyOrders, includeWisps)
-	deleted, retentionErr := sweepClosedOrderTrackingRetentionAcrossStores(stores, now, orderTrackingRetentionPolicyForConfig(cfg), onlyOrders)
-	result.trackingDeleted = deleted
+	retentionResult, retentionErr := sweepClosedOrderTrackingRetentionAcrossStores(stores, now, orderTrackingRetentionPolicyForConfig(cfg), onlyOrders)
+	result.trackingDeleted = retentionResult.deleted
 	if err := errors.Join(openErr, sweepErr, retentionErr); err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
-		if result.storesSwept == 0 {
+		if orderTrackingSweepErrorIsFatal(result, retentionResult, retentionErr) {
 			return 1
 		}
 	}
@@ -1533,6 +1533,13 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 		}
 	}
 	return 0
+}
+
+func orderTrackingSweepErrorIsFatal(result orderTrackingSweepResult, retentionResult orderTrackingRetentionSweepResult, retentionErr error) bool {
+	if result.storesSwept == 0 {
+		return true
+	}
+	return retentionErr != nil && retentionResult.storesSwept == 0
 }
 
 func orderTrackingSweepRequiredTargetKeysForOrders(cityPath string, cfg *config.City, onlyOrders map[string]struct{}) (map[string][]string, error) {

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -186,11 +186,14 @@ func newOrderSweepTrackingCmd(stdout, stderr io.Writer) *cobra.Command {
 	quiet := false
 	cmd := &cobra.Command{
 		Use:   "sweep-tracking [order ...]",
-		Short: "Close stale order-tracking beads",
-		Long: `Close stale open order-tracking beads.
+		Short: "Close stale and prune closed order-tracking beads",
+		Long: `Close stale open order-tracking beads and prune expired closed history.
 
 This is intended for maintenance exec orders. It only closes tracking beads
 older than --stale-after so a fresh in-flight order is not interrupted.
+Closed order-tracking history is deleted after
+[beads.policies.order_tracking].delete_after_close, defaulting to 7d, while
+always retaining at least the latest 10 closed tracking beads per order.
 The manual command runs to completion; controller startup and watchdog sweeps
 use bounded cleanup to avoid spending an unbounded tick on stale work.
 
@@ -1490,6 +1493,10 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 		return 1
 	}
 	onlyOrders := orderNameFilter(orderNames)
+	if includeWisps && len(onlyOrders) == 0 {
+		fmt.Fprintln(stderr, "gc order sweep-tracking: include-wisps requires at least one order name") //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	requiredTargets, err := orderTrackingSweepRequiredTargetKeysForOrders(cityPath, cfg, onlyOrders)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1504,8 +1511,11 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 		}
 		return 1
 	}
-	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, time.Now(), staleAfter, onlyOrders, includeWisps)
-	if err := errors.Join(openErr, sweepErr); err != nil {
+	now := time.Now()
+	result, sweepErr := sweepStaleOrderTrackingAcrossStores(stores, now, staleAfter, onlyOrders, includeWisps)
+	deleted, retentionErr := sweepClosedOrderTrackingRetentionAcrossStores(stores, now, orderTrackingRetentionPolicyForConfig(cfg), onlyOrders)
+	result.trackingDeleted = deleted
+	if err := errors.Join(openErr, sweepErr, retentionErr); err != nil {
 		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
 		if result.storesSwept == 0 {
 			return 1
@@ -1517,9 +1527,9 @@ func cmdOrderSweepTracking(staleAfter time.Duration, includeWisps, quiet bool, o
 	}
 	if !quiet {
 		if includeWisps {
-			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), %d stale order wisp bead(s)\n", result.trackingClosed, result.wispClosed) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), %d stale order wisp bead(s), deleted %d closed order-tracking bead(s)\n", result.trackingClosed, result.wispClosed, result.trackingDeleted) //nolint:errcheck // best-effort stdout
 		} else {
-			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s)\n", result.trackingClosed) //nolint:errcheck // best-effort stdout
+			fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s), deleted %d closed order-tracking bead(s)\n", result.trackingClosed, result.trackingDeleted) //nolint:errcheck // best-effort stdout
 		}
 	}
 	return 0

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1343,6 +1343,140 @@ prefix = "ct"
 	}
 }
 
+func TestSweepOrderTrackingCommandPrunesClosedTrackingWithConfiguredPolicy(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_CITY_ROOT", cityDir)
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Chdir(cityDir)
+
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+
+[beads.policies.order_tracking]
+delete_after_close = "1ns"
+`)
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	ids := make([]string, 0, minClosedOrderTrackingRetained+2)
+	for i := range minClosedOrderTrackingRetained + 2 {
+		tracking, err := store.Create(beads.Bead{
+			Title:     "order:cleanup",
+			Labels:    []string{"order-run:cleanup", labelOrderTracking},
+			Ephemeral: i%2 == 0,
+		})
+		if err != nil {
+			t.Fatalf("Create(tracking-%d): %v", i, err)
+		}
+		if err := store.Close(tracking.ID); err != nil {
+			t.Fatalf("Close(tracking-%d): %v", i, err)
+		}
+		ids = append(ids, tracking.ID)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdOrderSweepTracking(time.Hour, false, false, nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdOrderSweepTracking = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	reopened, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reopen): %v", err)
+	}
+	remaining := 0
+	for _, id := range ids {
+		if _, err := reopened.Get(id); err == nil {
+			remaining++
+		}
+	}
+	if remaining != minClosedOrderTrackingRetained {
+		t.Fatalf("remaining closed tracking beads = %d, want %d", remaining, minClosedOrderTrackingRetained)
+	}
+	if !strings.Contains(stdout.String(), "deleted 2 closed order-tracking bead") {
+		t.Fatalf("stdout = %q, want closed tracking delete count", stdout.String())
+	}
+}
+
+func TestSweepOrderTrackingCommandIncludeWispsRequiresOrderBeforePruning(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_CITY_ROOT", cityDir)
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Chdir(cityDir)
+
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+prefix = "ct"
+
+[beads.policies.order_tracking]
+delete_after_close = "1ns"
+`)
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	ids := make([]string, 0, minClosedOrderTrackingRetained+2)
+	for i := range minClosedOrderTrackingRetained + 2 {
+		tracking, err := store.Create(beads.Bead{
+			Title:     "order:cleanup",
+			Labels:    []string{"order-run:cleanup", labelOrderTracking},
+			Ephemeral: true,
+		})
+		if err != nil {
+			t.Fatalf("Create(tracking-%d): %v", i, err)
+		}
+		if err := store.Close(tracking.ID); err != nil {
+			t.Fatalf("Close(tracking-%d): %v", i, err)
+		}
+		ids = append(ids, tracking.ID)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdOrderSweepTracking(time.Hour, true, false, nil, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("cmdOrderSweepTracking = 0, want failure")
+	}
+	if !strings.Contains(stderr.String(), "include-wisps requires at least one order name") {
+		t.Fatalf("stderr = %q, want include-wisps error", stderr.String())
+	}
+
+	reopened, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reopen): %v", err)
+	}
+	for _, id := range ids {
+		if _, err := reopened.Get(id); err != nil {
+			t.Fatalf("%s should be preserved after invalid command: %v", id, err)
+		}
+	}
+}
+
 func TestCmdOrderSweepTrackingFailsWhenTargetedRigStoreOpenFails(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -1412,6 +1412,20 @@ delete_after_close = "1ns"
 	}
 }
 
+func TestOrderTrackingSweepErrorIsFatalForRetentionAllStoreFailure(t *testing.T) {
+	retentionErr := fmt.Errorf("retention failed")
+
+	if !orderTrackingSweepErrorIsFatal(orderTrackingSweepResult{storesSwept: 1}, orderTrackingRetentionSweepResult{}, retentionErr) {
+		t.Fatal("retention failure with no successful retention stores should be fatal")
+	}
+	if orderTrackingSweepErrorIsFatal(orderTrackingSweepResult{storesSwept: 1}, orderTrackingRetentionSweepResult{storesSwept: 1}, retentionErr) {
+		t.Fatal("retention failure with at least one successful retention store should remain partial")
+	}
+	if !orderTrackingSweepErrorIsFatal(orderTrackingSweepResult{}, orderTrackingRetentionSweepResult{storesSwept: 1}, nil) {
+		t.Fatal("stale sweep failure with no successful stale stores should be fatal")
+	}
+}
+
 func TestSweepOrderTrackingCommandIncludeWispsRequiresOrderBeforePruning(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -41,6 +41,7 @@ const (
 	defaultOrderTrackingSweepStaleAfter    = 10 * time.Minute
 	defaultOrderTrackingDeleteAfterClose   = 7 * 24 * time.Hour
 	minClosedOrderTrackingRetained         = 10
+	legacyOrderTrackingRetentionBucket     = "\x00legacy-unscoped-order-tracking"
 	orderTrackingSweepWatchdogInterval     = 30 * time.Second
 	orderTrackingSweepWatchdogStaleAfter   = 2 * time.Minute
 	orderTrackingSweepMetadataReason       = "stale-order-tracking"
@@ -1578,6 +1579,11 @@ type orderTrackingSweepResult struct {
 	sweptStoreKeys  map[string]struct{}
 }
 
+type orderTrackingRetentionSweepResult struct {
+	deleted     int
+	storesSwept int
+}
+
 type orderTrackingRetentionPolicy struct {
 	deleteAfterClose time.Duration
 	retainLast       int
@@ -1595,9 +1601,6 @@ func orderTrackingRetentionPolicyForConfig(cfg *config.City) orderTrackingRetent
 		if duration := configured.DeleteAfterCloseDuration(); duration > 0 {
 			policy.deleteAfterClose = duration
 		}
-	}
-	if policy.retainLast < minClosedOrderTrackingRetained {
-		policy.retainLast = minClosedOrderTrackingRetained
 	}
 	return policy
 }
@@ -1747,20 +1750,22 @@ func sweepStaleOrderTrackingWithOptionsLimit(store beads.Store, now time.Time, s
 	return result, nil
 }
 
-func sweepClosedOrderTrackingRetentionAcrossStores(stores []beads.Store, now time.Time, policy orderTrackingRetentionPolicy, onlyOrders map[string]struct{}) (int, error) {
-	deleted := 0
+func sweepClosedOrderTrackingRetentionAcrossStores(stores []beads.Store, now time.Time, policy orderTrackingRetentionPolicy, onlyOrders map[string]struct{}) (orderTrackingRetentionSweepResult, error) {
+	result := orderTrackingRetentionSweepResult{}
 	var errs []error
 	for i, store := range stores {
 		if store == nil {
 			continue
 		}
 		n, err := sweepClosedOrderTrackingRetention(store, now, policy, onlyOrders)
-		deleted += n
+		result.deleted += n
 		if err != nil {
 			errs = append(errs, fmt.Errorf("pruning closed order-tracking %s: %w", orderTrackingSweepStoreLabel(store, i), err))
+			continue
 		}
+		result.storesSwept++
 	}
-	return deleted, errors.Join(errs...)
+	return result, errors.Join(errs...)
 }
 
 func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy orderTrackingRetentionPolicy, onlyOrders map[string]struct{}) (int, error) {
@@ -1770,6 +1775,8 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 	if policy.deleteAfterClose <= 0 {
 		return 0, nil
 	}
+	// retainLast is intentionally package-internal and hardcoded; config can
+	// shorten the TTL but cannot remove the recent-history floor.
 	if policy.retainLast < minClosedOrderTrackingRetained {
 		policy.retainLast = minClosedOrderTrackingRetained
 	}
@@ -1785,14 +1792,14 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 
 	byOrder := make(map[string][]beads.Bead)
 	for _, entry := range entries {
-		scopedName, ok := orderRunNameFromLabels(entry.Labels)
-		if !ok {
-			continue
-		}
+		scopedName, ok := orderTrackingRetentionBucket(entry, onlyOrders)
 		if len(onlyOrders) > 0 {
-			if _, ok := onlyOrders[scopedName]; !ok {
+			if !ok {
 				continue
 			}
+		}
+		if !ok {
+			scopedName = legacyOrderTrackingRetentionBucket
 		}
 		byOrder[scopedName] = append(byOrder[scopedName], entry)
 	}
@@ -1802,10 +1809,12 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 	var deleteErr error
 	for _, entries := range byOrder {
 		sort.Slice(entries, func(i, j int) bool {
-			if entries[i].CreatedAt.Equal(entries[j].CreatedAt) {
+			left := orderTrackingClosedReferenceTime(entries[i])
+			right := orderTrackingClosedReferenceTime(entries[j])
+			if left.Equal(right) {
 				return entries[i].ID > entries[j].ID
 			}
-			return entries[i].CreatedAt.After(entries[j].CreatedAt)
+			return left.After(right)
 		})
 		if len(entries) <= policy.retainLast {
 			continue
@@ -1824,20 +1833,24 @@ func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy 
 	return deleted, deleteErr
 }
 
+func orderTrackingRetentionBucket(entry beads.Bead, onlyOrders map[string]struct{}) (string, bool) {
+	scopedName, ok := orderNameFromTrackingBead(entry)
+	if !ok {
+		return "", false
+	}
+	if len(onlyOrders) > 0 {
+		if _, ok := onlyOrders[scopedName]; !ok {
+			return "", false
+		}
+	}
+	return scopedName, true
+}
+
 func orderTrackingClosedReferenceTime(b beads.Bead) time.Time {
 	if !b.UpdatedAt.IsZero() {
 		return b.UpdatedAt
 	}
 	return b.CreatedAt
-}
-
-func orderRunNameFromLabels(labels []string) (string, bool) {
-	for _, label := range labels {
-		if name, ok := strings.CutPrefix(label, "order-run:"); ok && name != "" {
-			return name, true
-		}
-	}
-	return "", false
 }
 
 func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string) (int, error) {

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -37,7 +37,10 @@ const (
 	labelTriggerEnvFailed = "trigger-env-failed"
 
 	orderTrackingSweepOrder                = "order-tracking-sweep"
+	orderTrackingBeadPolicyName            = "order_tracking"
 	defaultOrderTrackingSweepStaleAfter    = 10 * time.Minute
+	defaultOrderTrackingDeleteAfterClose   = 7 * 24 * time.Hour
+	minClosedOrderTrackingRetained         = 10
 	orderTrackingSweepWatchdogInterval     = 30 * time.Second
 	orderTrackingSweepWatchdogStaleAfter   = 2 * time.Minute
 	orderTrackingSweepMetadataReason       = "stale-order-tracking"
@@ -1568,10 +1571,35 @@ func beadLabelsContain(labels []string, want string) bool {
 }
 
 type orderTrackingSweepResult struct {
-	trackingClosed int
-	wispClosed     int
-	storesSwept    int
-	sweptStoreKeys map[string]struct{}
+	trackingClosed  int
+	wispClosed      int
+	trackingDeleted int
+	storesSwept     int
+	sweptStoreKeys  map[string]struct{}
+}
+
+type orderTrackingRetentionPolicy struct {
+	deleteAfterClose time.Duration
+	retainLast       int
+}
+
+func orderTrackingRetentionPolicyForConfig(cfg *config.City) orderTrackingRetentionPolicy {
+	policy := orderTrackingRetentionPolicy{
+		deleteAfterClose: defaultOrderTrackingDeleteAfterClose,
+		retainLast:       minClosedOrderTrackingRetained,
+	}
+	if cfg == nil {
+		return policy
+	}
+	if configured, ok := cfg.Beads.Policies[orderTrackingBeadPolicyName]; ok {
+		if duration := configured.DeleteAfterCloseDuration(); duration > 0 {
+			policy.deleteAfterClose = duration
+		}
+	}
+	if policy.retainLast < minClosedOrderTrackingRetained {
+		policy.retainLast = minClosedOrderTrackingRetained
+	}
+	return policy
 }
 
 // sweepStaleOrderTracking closes open order-tracking beads whose creation
@@ -1717,6 +1745,99 @@ func sweepStaleOrderTrackingWithOptionsLimit(store beads.Store, now time.Time, s
 		}
 	}
 	return result, nil
+}
+
+func sweepClosedOrderTrackingRetentionAcrossStores(stores []beads.Store, now time.Time, policy orderTrackingRetentionPolicy, onlyOrders map[string]struct{}) (int, error) {
+	deleted := 0
+	var errs []error
+	for i, store := range stores {
+		if store == nil {
+			continue
+		}
+		n, err := sweepClosedOrderTrackingRetention(store, now, policy, onlyOrders)
+		deleted += n
+		if err != nil {
+			errs = append(errs, fmt.Errorf("pruning closed order-tracking %s: %w", orderTrackingSweepStoreLabel(store, i), err))
+		}
+	}
+	return deleted, errors.Join(errs...)
+}
+
+func sweepClosedOrderTrackingRetention(store beads.Store, now time.Time, policy orderTrackingRetentionPolicy, onlyOrders map[string]struct{}) (int, error) {
+	if store == nil {
+		return 0, fmt.Errorf("bead store unavailable")
+	}
+	if policy.deleteAfterClose <= 0 {
+		return 0, nil
+	}
+	if policy.retainLast < minClosedOrderTrackingRetained {
+		policy.retainLast = minClosedOrderTrackingRetained
+	}
+	entries, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		Status:   "closed",
+		Label:    labelOrderTracking,
+		Sort:     beads.SortCreatedDesc,
+		TierMode: beads.TierBoth,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing closed order-tracking beads: %w", err)
+	}
+
+	byOrder := make(map[string][]beads.Bead)
+	for _, entry := range entries {
+		scopedName, ok := orderRunNameFromLabels(entry.Labels)
+		if !ok {
+			continue
+		}
+		if len(onlyOrders) > 0 {
+			if _, ok := onlyOrders[scopedName]; !ok {
+				continue
+			}
+		}
+		byOrder[scopedName] = append(byOrder[scopedName], entry)
+	}
+
+	cutoff := now.Add(-policy.deleteAfterClose)
+	deleted := 0
+	var deleteErr error
+	for _, entries := range byOrder {
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].CreatedAt.Equal(entries[j].CreatedAt) {
+				return entries[i].ID > entries[j].ID
+			}
+			return entries[i].CreatedAt.After(entries[j].CreatedAt)
+		})
+		if len(entries) <= policy.retainLast {
+			continue
+		}
+		for _, entry := range entries[policy.retainLast:] {
+			if !orderTrackingClosedReferenceTime(entry).Before(cutoff) {
+				continue
+			}
+			if err := deleteWorkflowBead(store, entry.ID); err != nil {
+				deleteErr = errors.Join(deleteErr, fmt.Errorf("deleting closed order-tracking bead %q: %w", entry.ID, err))
+				continue
+			}
+			deleted++
+		}
+	}
+	return deleted, deleteErr
+}
+
+func orderTrackingClosedReferenceTime(b beads.Bead) time.Time {
+	if !b.UpdatedAt.IsZero() {
+		return b.UpdatedAt
+	}
+	return b.CreatedAt
+}
+
+func orderRunNameFromLabels(labels []string) (string, bool) {
+	for _, label := range labels {
+		if name, ok := strings.CutPrefix(label, "order-run:"); ok && name != "" {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders map[string]struct{}, initiator string) (int, error) {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -3640,6 +3640,118 @@ func TestSweepClosedOrderTrackingRetentionKeepsLatestTenPerOrderAcrossTiers(t *t
 	}
 }
 
+func TestSweepClosedOrderTrackingRetentionPrunesLegacyUnscopedTracking(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	beadTime := now.Add(-48 * time.Hour)
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+2)
+	for i := range minClosedOrderTrackingRetained + 2 {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("legacy-%02d", i),
+			Title:     "legacy tracking bead",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: beadTime.Add(time.Duration(i) * time.Minute),
+			Labels:    []string{labelOrderTracking},
+			Ephemeral: i%2 == 0,
+		})
+	}
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	deleted, err := sweepClosedOrderTrackingRetention(store, now, orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}, nil)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetention: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+	for _, id := range []string{"legacy-00", "legacy-01"} {
+		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
+			t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+		}
+	}
+	for i := 2; i < minClosedOrderTrackingRetained+2; i++ {
+		id := fmt.Sprintf("legacy-%02d", i)
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("%s should be preserved by legacy retain floor: %v", id, err)
+		}
+	}
+}
+
+func TestSweepClosedOrderTrackingRetentionRanksLatestByClosedReferenceTime(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+2)
+	for i := range minClosedOrderTrackingRetained + 2 {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("ranked-%02d", i),
+			Title:     "order:ranked",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-72*time.Hour + time.Duration(i)*time.Minute),
+			UpdatedAt: now.Add(-72*time.Hour + time.Duration(i)*time.Minute),
+			Labels:    []string{"order-run:ranked", labelOrderTracking},
+			Ephemeral: i%2 == 0,
+		})
+	}
+	seed[0].UpdatedAt = now.Add(-25 * time.Hour)
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	deleted, err := sweepClosedOrderTrackingRetention(store, now, orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}, nil)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetention: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+	if _, err := store.Get("ranked-00"); err != nil {
+		t.Fatalf("ranked-00 should be preserved as a recent close: %v", err)
+	}
+	for _, id := range []string{"ranked-01", "ranked-02"} {
+		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
+			t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+		}
+	}
+}
+
+func TestSweepClosedOrderTrackingRetentionAcrossStoresTracksSuccessfulStores(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+1)
+	for i := range minClosedOrderTrackingRetained + 1 {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("failed-%02d", i),
+			Title:     "order:failed",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-48*time.Hour + time.Duration(i)*time.Minute),
+			Labels:    []string{"order-run:failed", labelOrderTracking},
+			Ephemeral: true,
+		})
+	}
+	store := &failingDeleteStore{
+		MemStore: beads.NewMemStoreFrom(100, seed, nil),
+		failID:   "failed-00",
+	}
+
+	result, err := sweepClosedOrderTrackingRetentionAcrossStores([]beads.Store{store}, now, orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}, nil)
+	if err == nil {
+		t.Fatal("sweepClosedOrderTrackingRetentionAcrossStores err = nil, want delete failure")
+	}
+	if result.storesSwept != 0 {
+		t.Fatalf("storesSwept = %d, want 0 when retention prune failed", result.storesSwept)
+	}
+	if result.deleted != 0 {
+		t.Fatalf("deleted = %d, want 0 after failed delete", result.deleted)
+	}
+}
+
 func TestSweepClosedOrderTrackingRetentionDeletesForAnyConfiguredStorageTarget(t *testing.T) {
 	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	storages := []string{

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -3503,6 +3503,205 @@ func TestSweepStaleOrderTracking_ClosesOnlyOldOpenTrackingBeads(t *testing.T) {
 	}
 }
 
+func TestOrderTrackingRetentionPolicyDefaultsToSevenDays(t *testing.T) {
+	policy := orderTrackingRetentionPolicyForConfig(&config.City{})
+
+	if policy.deleteAfterClose != 7*24*time.Hour {
+		t.Fatalf("deleteAfterClose = %v, want 7d", policy.deleteAfterClose)
+	}
+	if policy.retainLast != minClosedOrderTrackingRetained {
+		t.Fatalf("retainLast = %d, want %d", policy.retainLast, minClosedOrderTrackingRetained)
+	}
+}
+
+func TestOrderTrackingRetentionPolicyUsesConfiguredDeleteAfterClose(t *testing.T) {
+	cfg := &config.City{
+		Beads: config.BeadsConfig{
+			Policies: map[string]config.BeadPolicyConfig{
+				orderTrackingBeadPolicyName: {DeleteAfterClose: "36h"},
+			},
+		},
+	}
+
+	policy := orderTrackingRetentionPolicyForConfig(cfg)
+
+	if policy.deleteAfterClose != 36*time.Hour {
+		t.Fatalf("deleteAfterClose = %v, want 36h", policy.deleteAfterClose)
+	}
+	if policy.retainLast != minClosedOrderTrackingRetained {
+		t.Fatalf("retainLast = %d, want %d", policy.retainLast, minClosedOrderTrackingRetained)
+	}
+}
+
+func TestSweepClosedOrderTrackingRetentionKeepsLatestTenPerOrderAcrossTiers(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	beadTime := now.Add(-48 * time.Hour)
+	seed := make([]beads.Bead, 0, 36)
+	for i := 0; i < 12; i++ {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("alpha-%02d", i),
+			Title:     "order:alpha",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: beadTime.Add(time.Duration(i) * time.Minute),
+			Labels:    []string{"order-run:alpha", labelOrderTracking},
+			Ephemeral: i%2 == 0,
+		})
+	}
+	for i := 0; i < 9; i++ {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("beta-%02d", i),
+			Title:     "order:beta",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: beadTime.Add(time.Duration(i) * time.Minute),
+			Labels:    []string{"order-run:beta", labelOrderTracking},
+			Ephemeral: i%2 == 0,
+		})
+	}
+	for i := 0; i < 12; i++ {
+		seed = append(seed, beads.Bead{
+			ID:        fmt.Sprintf("fresh-%02d", i),
+			Title:     "order:fresh",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: now.Add(-time.Hour).Add(time.Duration(i) * time.Minute),
+			Labels:    []string{"order-run:fresh", labelOrderTracking},
+			Ephemeral: i%2 == 0,
+		})
+	}
+	seed = append(seed,
+		beads.Bead{
+			ID:        "open-old",
+			Title:     "order:alpha",
+			Status:    "open",
+			Type:      "task",
+			CreatedAt: beadTime,
+			Labels:    []string{"order-run:alpha", labelOrderTracking},
+			Ephemeral: true,
+		},
+		beads.Bead{
+			ID:        "unscoped-old",
+			Title:     "tracking without order scope",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: beadTime,
+			Labels:    []string{labelOrderTracking},
+			Ephemeral: true,
+		},
+		beads.Bead{
+			ID:        "title-only-old",
+			Title:     "order:title-only",
+			Status:    "closed",
+			Type:      "task",
+			CreatedAt: beadTime,
+			Labels:    []string{labelOrderTracking},
+			Ephemeral: true,
+		},
+	)
+	store := beads.NewMemStoreFrom(100, seed, nil)
+
+	deleted, err := sweepClosedOrderTrackingRetention(store, now, orderTrackingRetentionPolicy{
+		deleteAfterClose: 24 * time.Hour,
+		retainLast:       minClosedOrderTrackingRetained,
+	}, nil)
+	if err != nil {
+		t.Fatalf("sweepClosedOrderTrackingRetention: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+
+	for _, id := range []string{"alpha-00", "alpha-01"} {
+		if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
+			t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+		}
+	}
+	for _, prefixAndCount := range []struct {
+		prefix string
+		start  int
+		end    int
+	}{
+		{prefix: "alpha", start: 2, end: 12},
+		{prefix: "beta", start: 0, end: 9},
+		{prefix: "fresh", start: 0, end: 12},
+	} {
+		for i := prefixAndCount.start; i < prefixAndCount.end; i++ {
+			id := fmt.Sprintf("%s-%02d", prefixAndCount.prefix, i)
+			if _, err := store.Get(id); err != nil {
+				t.Fatalf("%s should be preserved: %v", id, err)
+			}
+		}
+	}
+	for _, id := range []string{"open-old", "unscoped-old", "title-only-old"} {
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("%s should be preserved: %v", id, err)
+		}
+	}
+}
+
+func TestSweepClosedOrderTrackingRetentionDeletesForAnyConfiguredStorageTarget(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	storages := []string{
+		config.BeadStorageHistory,
+		config.BeadStorageNoHistory,
+		config.BeadStorageEphemeral,
+	}
+
+	for _, storage := range storages {
+		t.Run(storage, func(t *testing.T) {
+			cfg := &config.City{
+				Beads: config.BeadsConfig{
+					Policies: map[string]config.BeadPolicyConfig{
+						orderTrackingBeadPolicyName: {
+							Storage:          storage,
+							DeleteAfterClose: "1h",
+						},
+					},
+				},
+			}
+			policy := orderTrackingRetentionPolicyForConfig(cfg)
+			seed := make([]beads.Bead, 0, minClosedOrderTrackingRetained+2)
+			for i := range minClosedOrderTrackingRetained + 2 {
+				seed = append(seed, beads.Bead{
+					ID:        fmt.Sprintf("%s-%02d", storage, i),
+					Title:     "order:" + storage,
+					Status:    "closed",
+					Type:      "task",
+					CreatedAt: now.Add(-48*time.Hour + time.Duration(i)*time.Minute),
+					Labels:    []string{"order-run:" + storage, labelOrderTracking},
+					Ephemeral: storage == config.BeadStorageEphemeral,
+				})
+			}
+			store := beads.NewMemStoreFrom(100, seed, nil)
+
+			deleted, err := sweepClosedOrderTrackingRetention(store, now, policy, nil)
+			if err != nil {
+				t.Fatalf("sweepClosedOrderTrackingRetention: %v", err)
+			}
+			if deleted != 2 {
+				t.Fatalf("deleted = %d, want 2", deleted)
+			}
+			for _, id := range []string{fmt.Sprintf("%s-00", storage), fmt.Sprintf("%s-01", storage)} {
+				if _, err := store.Get(id); !errors.Is(err, beads.ErrNotFound) {
+					t.Fatalf("Get(%s) err = %v, want ErrNotFound", id, err)
+				}
+			}
+			remaining, err := store.List(beads.ListQuery{
+				Status:   "closed",
+				Label:    labelOrderTracking,
+				TierMode: beads.TierBoth,
+			})
+			if err != nil {
+				t.Fatalf("List(remaining): %v", err)
+			}
+			if len(remaining) != minClosedOrderTrackingRetained {
+				t.Fatalf("remaining = %d, want %d", len(remaining), minClosedOrderTrackingRetained)
+			}
+		})
+	}
+}
+
 type noopCloseAllStore struct {
 	beads.Store
 	closeCalls int

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -81,15 +81,6 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 		closurePurged, closureDeleteErr := purgeExpiredBeadClosures(store, entries, cutoff)
 		purged += closurePurged
 		deleteErr = errors.Join(deleteErr, closureDeleteErr)
-
-		trackEntries, trackErr := store.List(beads.ListQuery{Status: "closed", Label: labelOrderTracking, TierMode: beads.TierBoth})
-		if trackErr == nil {
-			trackPurged, trackDeleteErr := purgeExpiredBeadRoots(store, trackEntries, cutoff)
-			purged += trackPurged
-			deleteErr = errors.Join(deleteErr, trackDeleteErr)
-		} else {
-			deleteErr = errors.Join(deleteErr, fmt.Errorf("listing closed order-tracking beads: %w", trackErr))
-		}
 	}
 
 	if m.mailRetentionTTL > 0 {

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -505,7 +505,7 @@ func TestWispGC_PartialChildDeleteRemainsRetryable(t *testing.T) {
 	}
 }
 
-func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
+func TestWispGC_PreservesOrderTrackingBeads(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
 		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
@@ -519,13 +519,18 @@ func TestWispGC_PurgesExpiredTrackingBeads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
 	}
-	if purged != 2 {
-		t.Fatalf("purged = %d, want 2", purged)
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1", purged)
 	}
-	assertDeletedIDs(t, store.deletedIDs, "mol-1", "track-old")
+	assertDeletedIDs(t, store.deletedIDs, "mol-1")
+	for _, id := range []string{"track-old", "track-new", "track-open"} {
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("%s should be preserved for order-tracking retention: %v", id, err)
+		}
+	}
 }
 
-func TestWispGC_PurgesLegacyIssuesTierTrackingBeads(t *testing.T) {
+func TestWispGC_PreservesLegacyIssuesTierTrackingBeads(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
 		{
@@ -542,13 +547,15 @@ func TestWispGC_PurgesLegacyIssuesTierTrackingBeads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
 	}
-	if purged != 1 {
-		t.Fatalf("purged = %d, want 1", purged)
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0", purged)
 	}
-	assertDeletedIDs(t, store.deletedIDs, "track-legacy")
+	if _, err := store.Get("track-legacy"); err != nil {
+		t.Fatalf("legacy tracking bead should be preserved: %v", err)
+	}
 }
 
-func TestWispGC_TrackingListErrorIsSurfacedAndMoleculePurgeContinues(t *testing.T) {
+func TestWispGC_DoesNotListOrderTrackingBeads(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
 		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
@@ -558,16 +565,16 @@ func TestWispGC_TrackingListErrorIsSurfacedAndMoleculePurgeContinues(t *testing.
 
 	wg := newWispGC(5*time.Minute, time.Hour, 0)
 	purged, err := wg.runGC(store, now)
-	if err == nil {
-		t.Fatal("expected tracking list error to be surfaced")
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
 	}
 	if purged != 1 {
 		t.Fatalf("purged = %d, want 1", purged)
 	}
-	if !strings.Contains(err.Error(), "tracking list failed") {
-		t.Fatalf("err = %v, want tracking list failure to be included", err)
-	}
 	assertDeletedIDs(t, store.deletedIDs, "mol-1")
+	if _, err := store.Get("track-old"); err != nil {
+		t.Fatalf("order-tracking bead should be preserved: %v", err)
+	}
 }
 
 func TestWispGC_TrackingBeadsDoNotDeleteParentChildDescendants(t *testing.T) {
@@ -591,12 +598,16 @@ func TestWispGC_TrackingBeadsDoNotDeleteParentChildDescendants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
 	}
-	if purged != 1 {
-		t.Fatalf("purged = %d, want 1", purged)
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0", purged)
 	}
-	assertDeletedIDs(t, store.deletedIDs, "track-old")
-	if _, err := store.Get("track-child"); err != nil {
-		t.Fatalf("tracking child was deleted: %v", err)
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deleted IDs = %v, want none", store.deletedIDs)
+	}
+	for _, id := range []string{"track-old", "track-child"} {
+		if _, err := store.Get(id); err != nil {
+			t.Fatalf("%s should be preserved: %v", id, err)
+		}
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2099,7 +2099,7 @@ gc order
 | [gc order list](#gc-order-list) | List available orders |
 | [gc order run](#gc-order-run) | Execute an order manually |
 | [gc order show](#gc-order-show) | Show details of an order |
-| [gc order sweep-tracking](#gc-order-sweep-tracking) | Close stale order-tracking beads |
+| [gc order sweep-tracking](#gc-order-sweep-tracking) | Close stale and prune closed order-tracking beads |
 
 ## gc order check
 
@@ -2184,10 +2184,13 @@ gc order show <name> [flags]
 
 ## gc order sweep-tracking
 
-Close stale open order-tracking beads.
+Close stale open order-tracking beads and prune expired closed history.
 
 This is intended for maintenance exec orders. It only closes tracking beads
 older than --stale-after so a fresh in-flight order is not interrupted.
+Closed order-tracking history is deleted after
+[beads.policies.order_tracking].delete_after_close, defaulting to 7d, while
+always retaining at least the latest 10 closed tracking beads per order.
 The manual command runs to completion; controller startup and watchdog sweeps
 use bounded cleanup to avoid spending an unbounded tick on stale work.
 

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -435,12 +435,6 @@ launches. This is what prevents the cooldown trigger from re-firing on the very
 next tick — the trigger checks for recent tracking beads when deciding if the order
 is due.
 
-Closed tracking history is pruned by the maintenance pack's
-`order-tracking-sweep` order after 7 days by default. Set
-`[beads.policies.order_tracking].delete_after_close` in `city.toml` to keep a
-longer or shorter UI history; Gas City still preserves at least the latest 10
-closed tracking beads per order.
-
 ## Duplicate prevention
 
 Before dispatching, the controller checks whether the order already has open

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -435,6 +435,12 @@ launches. This is what prevents the cooldown trigger from re-firing on the very
 next tick — the trigger checks for recent tracking beads when deciding if the order
 is due.
 
+Closed tracking history is pruned by the maintenance pack's
+`order-tracking-sweep` order after 7 days by default. Set
+`[beads.policies.order_tracking].delete_after_close` in `city.toml` to keep a
+longer or shorter UI history; Gas City still preserves at least the latest 10
+closed tracking beads per order.
+
 ## Duplicate prevention
 
 Before dispatching, the controller checks whether the order already has open

--- a/engdocs/architecture/life-of-a-bead.md
+++ b/engdocs/architecture/life-of-a-bead.md
@@ -334,7 +334,11 @@ order fires, a bead is created with label `order-run:<name>`.
 On the next tick, `Store.ListByLabel("order-run:<name>", 1)` finds
 the most recent run. If it is younger than the cooldown period, the
 order is suppressed. The tracking bead's afterlife IS the cooldown
-mechanism.
+mechanism. Closed tracking history beyond
+`[beads.policies.order_tracking].delete_after_close` is pruned by
+`gc order sweep-tracking` and the maintenance exec order, defaulting
+to 7d while always keeping at least the latest 10 closed tracking
+beads per order.
 
 ## State Transition Summary
 

--- a/examples/gastown/packs/maintenance/README.md
+++ b/examples/gastown/packs/maintenance/README.md
@@ -15,7 +15,7 @@ requires per-city configuration.
 | `gate-sweep` | cooldown 30s | Evaluate and close pending gates (timer, GitHub) |
 | `orphan-sweep` | cooldown 5m | Reset beads assigned to dead agents back to the work pool |
 | `cross-rig-deps` | cooldown 5m | Convert satisfied cross-rig `blocks` deps to `related` |
-| `order-tracking-sweep` | cooldown | Close stale order-tracking beads so blocked orders can retry |
+| `order-tracking-sweep` | cooldown | Close stale order-tracking beads and prune expired tracking history |
 | `spawn-storm-detect` | cooldown | Detect beads repeatedly bouncing back to pool |
 | `prune-branches` | cooldown | Clean stale `gc/*` branches from all rigs |
 | `wisp-compact` | cooldown | TTL-based cleanup of expired ephemeral beads (wisps) |

--- a/examples/gastown/packs/maintenance/orders/order-tracking-sweep.toml
+++ b/examples/gastown/packs/maintenance/orders/order-tracking-sweep.toml
@@ -1,8 +1,9 @@
 # Closes stale order tracking beads left behind by crashed or resource-starved
-# exec dispatches. Fresh tracking beads are left alone so in-flight orders keep
-# their normal single-flight protection.
+# exec dispatches, and prunes expired closed tracking history according to
+# [beads.policies.order_tracking].delete_after_close. Fresh tracking beads are
+# left alone so in-flight orders keep their normal single-flight protection.
 [order]
-description = "Close stale order-tracking beads so blocked orders can retry"
+description = "Close stale order-tracking beads and prune expired tracking history"
 trigger = "cooldown"
 interval = "1m"
 exec = "gc order sweep-tracking --stale-after 10m --quiet"


### PR DESCRIPTION
## Summary
- Add closed order-tracking retention to `gc order sweep-tracking` using `[beads.policies.order_tracking].delete_after_close`, defaulting to 7d.
- Preserve at least the latest 10 closed tracking beads per scoped order before deleting expired older rows.
- Query and delete across both persistent and ephemeral bead tiers so configured `history`, `no_history`, and `ephemeral` storage targets are covered by the sweeper.
- Move order-tracking deletion out of generic wisp GC so `daemon.wisp_ttl` cannot bypass the retain-10 floor.
- Update the maintenance order/docs to make the sweep the owner of tracking-history cleanup.

Supersedes #2929.

## Tests
- PASS: `go test ./cmd/gc -run 'Test(OrderTrackingRetentionPolicy|SweepClosedOrderTrackingRetention|SweepOrderTrackingCommandPrunesClosedTracking|SweepOrderTrackingCommandIncludeWispsRequiresOrderBeforePruning|WispGC_)' -count=1`
- PASS: `go vet ./...`
- PASS: `git diff --check`
- PASS: `git config core.hooksPath` -> `.githooks`
- RAN: `.githooks/pre-commit` with `LOCAL_TEST_JOBS=1`; it passed lint/generation/vet, then failed in `make test-fast-parallel` cmd/gc shards 3/4/5. The failing logs show unrelated process-test instability: shard 3 and 4 lose their temp root (`TempDir: stat /tmp/gct...: no such file or directory`) and shard 4 reports a leaked `dolt sql-server`; shard 5 fails `TestRigAnywhere_ResolveRigToContext/local_unregistered_city_ignores_unrelated_registered_load_error_by_name` on a broken registered city parse. The focused retention tests passed.
