### PR TITLE
fix: preserve fresh closed bead metadata in cache events

### DIFF
--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -71,7 +71,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		}
 		verifiedConflict = true
 		verifiedClosedBase = conflictBase
-		if closedEventPayloadOlderThanBacking(patch, fresh) {
+		if closedEventPayloadNeedsBackingRefresh(patch, fresh) {
 			verifiedClosedFresh = fresh
 			verifiedClosedFromBacking = true
 		}
@@ -462,11 +462,30 @@ func (c *CachingStore) cacheClosedEventMatchesBacking(id string) (Bead, bool, er
 	return fresh, fresh.Status == "closed", nil
 }
 
-func closedEventPayloadOlderThanBacking(patch, fresh Bead) bool {
-	if patch.UpdatedAt.IsZero() || fresh.UpdatedAt.IsZero() {
-		return false
+func closedEventPayloadNeedsBackingRefresh(patch Bead, fresh Bead) bool {
+	// Verified close events only need the backing row when the hook payload is
+	// partial and the timestamp is unusable or not newer. Rich close snapshots
+	// should still flow through the normal merge path so they can replace stale
+	// cached fields that the backing row still carries.
+	if patch.UpdatedAt.IsZero() || fresh.UpdatedAt.IsZero() || !patch.UpdatedAt.After(fresh.UpdatedAt) {
+		return !closedEventCarriesRichCloseSnapshot(patch)
 	}
-	return patch.UpdatedAt.Before(fresh.UpdatedAt)
+	return false
+}
+
+func closedEventCarriesRichCloseSnapshot(patch Bead) bool {
+	return patch.Title != "" ||
+		len(patch.Labels) > 0 ||
+		patch.Description != "" ||
+		patch.Assignee != "" ||
+		patch.ParentID != "" ||
+		patch.Ref != "" ||
+		len(patch.Needs) > 0 ||
+		patch.Type != "" ||
+		patch.Priority != nil ||
+		patch.Ephemeral ||
+		patch.NoHistory ||
+		patch.DeferUntil != nil
 }
 
 func cacheEventPatchMatchesBead(current, patch Bead, fields map[string]json.RawMessage) bool {

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -54,10 +54,12 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 
 	verifiedConflict := false
 	var verifiedClosedBase Bead
+	var verifiedClosedFresh Bead
+	verifiedClosedFromBacking := false
 	verifiedRecentLocal := false
 	var verifiedRecentLocalBase Bead
 	if conflictsCached && eventType == "bead.closed" {
-		matchesBacking, verifyErr := c.cacheClosedEventMatchesBacking(patch.ID)
+		fresh, matchesBacking, verifyErr := c.cacheClosedEventMatchesBacking(patch.ID)
 		if verifyErr != nil {
 			c.recordProblem(fmt.Sprintf("verify %s event", eventType), verifyErr)
 			// Drop destructive close events on verification failure; reconciliation
@@ -69,6 +71,10 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		}
 		verifiedConflict = true
 		verifiedClosedBase = conflictBase
+		if closedEventPayloadOlderThanBacking(patch, fresh) {
+			verifiedClosedFresh = fresh
+			verifiedClosedFromBacking = true
+		}
 	}
 	if conflictsCached && eventType != "bead.closed" && locallyMutated && !recentlyLocal && !verifiedConflict {
 		// The bead is flagged locally mutated only because a prior applied
@@ -133,7 +139,10 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 
 	b := patch
 	refreshedFromBacking := false
-	if !cached {
+	if verifiedClosedFromBacking {
+		b = verifiedClosedFresh
+		refreshedFromBacking = true
+	} else if !cached {
 		if fresh, err := c.backing.Get(patch.ID); err == nil {
 			b = fresh
 			refreshedFromBacking = true
@@ -196,7 +205,9 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 				}
 			}
 		}
-		b = mergeCacheEventPatch(current, patch, fields)
+		if eventType != "bead.closed" || !verifiedClosedFromBacking {
+			b = mergeCacheEventPatch(current, patch, fields)
+		}
 	}
 
 	mutated := false
@@ -443,12 +454,19 @@ func (c *CachingStore) cacheEventMatchesBacking(id string, patch Bead, fields ma
 	return cacheEventPatchMatchesBead(fresh, patch, fields), nil
 }
 
-func (c *CachingStore) cacheClosedEventMatchesBacking(id string) (bool, error) {
+func (c *CachingStore) cacheClosedEventMatchesBacking(id string) (Bead, bool, error) {
 	fresh, err := c.backing.Get(id)
 	if err != nil {
-		return false, err
+		return Bead{}, false, err
 	}
-	return fresh.Status == "closed", nil
+	return fresh, fresh.Status == "closed", nil
+}
+
+func closedEventPayloadOlderThanBacking(patch, fresh Bead) bool {
+	if patch.UpdatedAt.IsZero() || fresh.UpdatedAt.IsZero() {
+		return false
+	}
+	return patch.UpdatedAt.Before(fresh.UpdatedAt)
 }
 
 func cacheEventPatchMatchesBead(current, patch Bead, fields map[string]json.RawMessage) bool {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1090,6 +1090,111 @@ func TestCachingStoreClosedEventRefreshesStalePayloadFromBacking(t *testing.T) {
 	}
 }
 
+func TestCachingStoreClosedEventRefreshesBackingForMissingZeroOrEqualUpdatedAt(t *testing.T) {
+	type testCase struct {
+		name    string
+		payload func(t *testing.T, id string, fresh Bead) json.RawMessage
+		wantRef bool
+	}
+
+	cases := []testCase{
+		{
+			name: "missing updated_at",
+			payload: func(t *testing.T, id string, _ Bead) json.RawMessage {
+				t.Helper()
+				return json.RawMessage(fmt.Sprintf(`{"id":%q,"status":"closed"}`, id))
+			},
+			wantRef: true,
+		},
+		{
+			name: "zero updated_at",
+			payload: func(t *testing.T, id string, _ Bead) json.RawMessage {
+				t.Helper()
+				return json.RawMessage(fmt.Sprintf(
+					`{"id":%q,"status":"closed","updated_at":"0001-01-01T00:00:00Z"}`,
+					id,
+				))
+			},
+			wantRef: true,
+		},
+		{
+			name: "equal updated_at",
+			payload: func(t *testing.T, id string, fresh Bead) json.RawMessage {
+				t.Helper()
+				return json.RawMessage(fmt.Sprintf(
+					`{"id":%q,"status":"closed","updated_at":%q}`,
+					id,
+					fresh.UpdatedAt.Format(time.RFC3339Nano),
+				))
+			},
+			wantRef: true,
+		},
+		{
+			name: "newer updated_at",
+			payload: func(t *testing.T, id string, fresh Bead) json.RawMessage {
+				t.Helper()
+				return json.RawMessage(fmt.Sprintf(
+					`{"id":%q,"status":"closed","updated_at":%q,"metadata":{"gc.step_ref":"new"}}`,
+					id,
+					fresh.UpdatedAt.Add(time.Nanosecond).Format(time.RFC3339Nano),
+				))
+			},
+			wantRef: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backing := NewMemStore()
+			bead, err := backing.Create(Bead{Title: "close me", Metadata: map[string]string{"gc.step_ref": "old"}})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			cache := NewCachingStoreForTest(backing, nil)
+			if err := cache.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+
+			status := "closed"
+			if err := backing.Update(bead.ID, UpdateOpts{
+				Status: &status,
+				Metadata: map[string]string{
+					"ci.verdict": "done",
+					"gc.outcome": "pass",
+				},
+			}); err != nil {
+				t.Fatalf("Update backing close metadata: %v", err)
+			}
+			fresh, err := backing.Get(bead.ID)
+			if err != nil {
+				t.Fatalf("Get backing: %v", err)
+			}
+			cache.ApplyEvent("bead.closed", tc.payload(t, bead.ID, fresh))
+
+			got, err := cache.Get(bead.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.Status != "closed" {
+				t.Fatalf("Status after close event = %q, want closed", got.Status)
+			}
+			if tc.wantRef {
+				if got.Metadata["ci.verdict"] != "done" || got.Metadata["gc.outcome"] != "pass" {
+					t.Fatalf("metadata after close event = %#v, want fresh backing metadata", got.Metadata)
+				}
+				return
+			}
+			if got.Metadata["gc.step_ref"] != "new" {
+				t.Fatalf("metadata after newer close event = %#v, want newer payload metadata", got.Metadata)
+			}
+			if _, ok := got.Metadata["ci.verdict"]; ok {
+				t.Fatalf("metadata after newer close event = %#v, want merge path to skip backing refresh", got.Metadata)
+			}
+		})
+	}
+}
+
 type cacheEventVerificationFailStore struct {
 	Store
 	failNextGet bool

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1042,6 +1042,54 @@ func TestCachingStoreRecordsClosedEventVerificationErrorAndPreservesLocalReopen(
 	}
 }
 
+func TestCachingStoreClosedEventRefreshesStalePayloadFromBacking(t *testing.T) {
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "close me", Metadata: map[string]string{"gc.step_ref": "old"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	status := "closed"
+	if err := backing.Update(bead.ID, UpdateOpts{
+		Status: &status,
+		Metadata: map[string]string{
+			"ci.verdict": "done",
+			"gc.outcome": "pass",
+		},
+	}); err != nil {
+		t.Fatalf("Update backing close metadata: %v", err)
+	}
+
+	stalePayload, err := json.Marshal(Bead{
+		ID:        bead.ID,
+		Status:    "closed",
+		UpdatedAt: bead.UpdatedAt,
+		Metadata: map[string]string{
+			"gc.step_ref": "old",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal stale payload: %v", err)
+	}
+	cache.ApplyEvent("bead.closed", stalePayload)
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("Status after close event = %q, want closed", got.Status)
+	}
+	if got.Metadata["ci.verdict"] != "done" || got.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("metadata after stale close event = %#v, want fresh backing metadata", got.Metadata)
+	}
+}
+
 type cacheEventVerificationFailStore struct {
 	Store
 	failNextGet bool

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -277,7 +277,7 @@ func (c *CachingStore) runReconciliation() {
 		freshByID[b.ID] = cloneBead(b)
 	}
 
-	c.recoverMissingFromList(freshByID)
+	confirmedClosed := c.recoverMissingFromList(freshByID)
 
 	depMap, depsComplete, depErr := c.fetchDepsForBeads(freshByID)
 	if depErr != nil {
@@ -355,6 +355,9 @@ func (c *CachingStore) runReconciliation() {
 			if old.Status != "closed" {
 				closed := cloneBead(old)
 				closed.Status = "closed"
+				if freshClosed, ok := confirmedClosed[id]; ok {
+					closed = cloneBead(freshClosed)
+				}
 				notifications = append(notifications, cacheNotification{
 					eventType: "bead.closed",
 					bead:      closed,
@@ -452,6 +455,9 @@ func (c *CachingStore) runReconciliation() {
 			}
 			closed := cloneBead(old)
 			closed.Status = "closed"
+			if freshClosed, ok := confirmedClosed[id]; ok {
+				closed = cloneBead(freshClosed)
+			}
 			notifications = append(notifications, cacheNotification{
 				eventType: "bead.closed",
 				bead:      closed,
@@ -542,11 +548,13 @@ func (c *CachingStore) depsForReconcileLocked(id string, freshBead Bead, depMap 
 // synthesize a spurious bead.closed event for it.
 //
 // On ErrNotFound the bead is left absent so the diff path can emit
-// bead.closed as before. On any other error the cached entry is merged
-// back conservatively, deferring the close to a later scan when the
-// backing store's state is unambiguous. Callers must own freshByID and not
-// access it concurrently while recovery is running.
-func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) {
+// bead.closed as before. When Get confirms a closed bead, the returned map
+// carries that fresh row so the diff path can emit an authoritative close
+// payload instead of a stale cached status flip. On any other error the cached
+// entry is merged back conservatively, deferring the close to a later scan
+// when the backing store's state is unambiguous. Callers must own freshByID
+// and not access it concurrently while recovery is running.
+func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) map[string]Bead {
 	c.mu.RLock()
 	candidates := make(map[string]Bead)
 	for id, b := range c.beads {
@@ -560,8 +568,9 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) {
 	}
 	c.mu.RUnlock()
 	if len(candidates) == 0 {
-		return
+		return nil
 	}
+	var confirmedClosed map[string]Bead
 	var recoveredAlive int64
 	var deferredClose int64
 	for id, cached := range candidates {
@@ -578,6 +587,10 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) {
 				continue
 			}
 			if bead.Status == "closed" {
+				if confirmedClosed == nil {
+					confirmedClosed = make(map[string]Bead)
+				}
+				confirmedClosed[id] = cloneBead(bead)
 				continue
 			}
 			freshByID[id] = cloneBead(bead)
@@ -599,4 +612,5 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) {
 		c.stats.ReconcileCloseDeferrals += deferredClose
 		c.mu.Unlock()
 	}
+	return confirmedClosed
 }

--- a/internal/beads/caching_store_reconcile_recovery_internal_test.go
+++ b/internal/beads/caching_store_reconcile_recovery_internal_test.go
@@ -196,6 +196,55 @@ func TestReconcileEmitsCloseWhenGetReturnsClosed(t *testing.T) {
 	assertNotCached(t, cache, closing.ID)
 }
 
+// TestReconcileEmitsFreshClosePayloadWhenGetReturnsClosed pins the close
+// recovery path that verifies a missing active-list row with backing.Get.
+// The close notification must carry the fresh closed row, not a synthetic
+// status flip built from stale cache contents.
+func TestReconcileEmitsFreshClosePayloadWhenGetReturnsClosed(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	closing, err := mem.Create(Bead{Title: "Closing"})
+	if err != nil {
+		t.Fatalf("Create closing: %v", err)
+	}
+
+	backing := &droppingListStore{Store: mem}
+	var closedPayload Bead
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, payload json.RawMessage) {
+		if eventType != "bead.closed" || beadID != closing.ID {
+			return
+		}
+		if err := json.Unmarshal(payload, &closedPayload); err != nil {
+			t.Fatalf("unmarshal close payload: %v", err)
+		}
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	status := "closed"
+	if err := mem.Update(closing.ID, UpdateOpts{
+		Status: &status,
+		Metadata: map[string]string{
+			"ci.verdict": "done",
+			"gc.outcome": "pass",
+		},
+	}); err != nil {
+		t.Fatalf("Close backing bead with metadata: %v", err)
+	}
+
+	cache.runReconciliation()
+
+	if closedPayload.ID != closing.ID {
+		t.Fatalf("closed payload ID = %q, want %q", closedPayload.ID, closing.ID)
+	}
+	if closedPayload.Metadata["ci.verdict"] != "done" || closedPayload.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("closed payload metadata = %#v, want fresh backing close metadata", closedPayload.Metadata)
+	}
+	assertNotCached(t, cache, closing.ID)
+}
+
 // TestReconcileDefersCloseOnBackingError verifies that a transient backing
 // failure (List omits the bead, Get returns a non-NotFound error) does NOT
 // produce a bead.closed event — the close is deferred until a later scan.


### PR DESCRIPTION
## Summary
- emit fresh backing close payloads when reconcile verifies a missing active bead is actually closed
- refresh timestamp-stale closed events from backing before applying them to the cache
- add regression tests for stale close metadata downgrades

## Tests
- go test ./internal/beads -run 'TestReconcileEmitsFreshClosePayloadWhenGetReturnsClosed|TestCachingStoreClosedEventRefreshesStalePayloadFromBacking' -count=1\n- go test ./internal/beads -run 'TestReconcileEmitsFreshClosePayloadWhenGetReturnsClosed|TestCachingStoreClosedEventRefreshesStalePayloadFromBacking|TestCachingStoreApplyEvent' -count=1\n- go test ./internal/beads -count=1\n- pre-commit hook on PR branch: go vet ./... and fast parallel tests passed