### PR TITLE
fix(docs): add missing pages to Mintlify navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -131,14 +131,16 @@
           "guides/migrating-to-pack-vnext",
           "guides/understanding-packs",
           "guides/shareable-packs",
-          "guides/using-json-from-gc"
+          "guides/using-json-from-gc",
+          "guides/multi-agent-engineering-environment"
         ]
       },
       {
         "group": "Troubleshooting",
         "pages": [
           "troubleshooting/gc-start-walkthrough",
-          "troubleshooting/dolt-bloat-recovery"
+          "troubleshooting/dolt-bloat-recovery",
+          "runbooks/managed-city-endpoints"
         ]
       },
       {
@@ -152,6 +154,7 @@
           "reference/api",
           "reference/events",
           "schema/index",
+          "reference/system-packs",
           "reference/exec-session-provider",
           "reference/exec-beads-provider"
         ]


### PR DESCRIPTION
## Summary
- Added 3 missing pages to docs.json Mintlify navigation (guides/multi-agent-engineering-environment, reference/system-packs, runbooks/managed-city-endpoints) that were linked from other docs but unreachable on the deployed site.

## Test plan
- [ ] Verify links in docs/getting-started/quickstart.md resolve correctly
- [ ] Confirm the 3 new navigation entries appear in the Mintlify sidebar
- [ ] Check no other dead links remain in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)