### PR TITLE
test(session): stabilize submit poller pid check

### DIFF
--- a/internal/session/submit_test.go
+++ b/internal/session/submit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/nudgepoller"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
+	"github.com/gastownhall/gascity/internal/pidutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
@@ -556,7 +557,21 @@ func startSubmitPollerLikeProcess(t *testing.T, cityPath, sessionName string) *e
 		_ = stdin.Close()
 		_ = cmd.Wait()
 	})
+	waitForSubmitPollerCmdline(t, cmd.Process.Pid, cityPath, sessionName)
 	return cmd
+}
+
+func waitForSubmitPollerCmdline(t *testing.T, pid int, cityPath, sessionName string) {
+	t.Helper()
+	matches := nudgepoller.CmdlineMatcher(cityPath, sessionName)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if pidutil.AliveWithCmdline(pid, matches) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("poller PID %d did not expose matching command line", pid)
 }
 
 func TestSubmitFollowUpQueuesDeferredMessageForPoolManagedSession(t *testing.T) {


### PR DESCRIPTION
## Summary
- harden the submit-poller PID test fixture by waiting until the fake poller command line is observable through the same matcher used by production
- fixes the flaky main CI failure in `Integration / packages-core-1-of-4` where `TestExistingSessionSubmitPollerPIDAcceptsMatchingCitySession` sometimes checked `/proc/<pid>/cmdline` before argv was visible

## CI failure review
- Real failure: `internal/session` test flake on main run `26933719943`, job `Integration / packages-core-1-of-4`.
- Transient failure: later `rest-full-3-of-16` failed while downloading `github.com/pb33f/libopenapi` from `proxy.golang.org` with HTTP/2 GOAWAY. The same main head also had a green CI run, so no code change was made for that network failure.

## Verification
- `go test ./internal/session -run 'TestExistingSessionSubmitPollerPID(AcceptsMatchingCitySession|RejectsDifferentCitySameSession|RejectsUnrelatedLivePID)' -count=200 -parallel=20`\n- `go test ./internal/session -count=1`\n- `./scripts/test-integration-shard packages-core-1-of-4`\n- `make test-fast-parallel`\n- `go vet ./...`\n- pre-commit hook ran with `.githooks` active\n\nRefs bead `ga-l7uqp`.