### PR TITLE
fix(session): release work from confirmed-dead pool worker sessions (ga-7le)

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1899,8 +1899,8 @@ func reapStaleSessionBeads(
 
 func cleanupDeadRuntimeSessionCorpses(
 	store beads.Store,
-	rigStores map[string]beads.Store,
-	cfg *config.City,
+	_ map[string]beads.Store,
+	_ *config.City,
 	sessionBeads *sessionBeadSnapshot,
 	dt *drainTracker,
 	sp runtime.Provider,
@@ -1975,29 +1975,17 @@ func cleanupDeadRuntimeSessionCorpses(
 		// asleep/runtime-missing ghosts on the same slot indefinitely
 		// (gastownhall/gascity#2437).
 		//
-		// Gate the close on a live assigned-work check using the same
-		// predicate as closeSessionBeadIfRuntimeStoppedAndUnassigned —
-		// snapshots can be stale and work can be assigned by bead ID,
-		// runtime session_name, or configured named-session identity
-		// across the primary store and any rig stores. Closing while a
-		// session bead still owns open or in-progress work would
-		// orphan the assignment, remove the session from future
-		// snapshots, and starve the session.stranded diagnostic path
-		// (#1425) and normal wake/recovery flows of the session record
-		// they rely on. The outer `if store != nil` guard tolerates a
-		// nil store so the runtime-Stop side effect still runs in
-		// test contexts that don't wire a real store; closeBead is
-		// idempotent against repeated calls on the same bead.
+		// closeBead now releases any in-progress work assigned to this
+		// session (via releaseWorkFromClosedSessionBead), so closing is
+		// safe even when the session has assigned work. A session whose
+		// runtime has been confirmed dead and stopped cannot be resumed,
+		// so releasing its work is the correct action.
+		//
+		// The outer `if store != nil` guard tolerates a nil store so the
+		// runtime-Stop side effect still runs in test contexts that do not
+		// wire a real store; closeBead is idempotent on already-closed beads.
 		if store != nil {
-			hasAssignedWork, err := sessionHasOpenAssignedWorkForConfig(store, rigStores, b, cfg)
-			switch {
-			case err != nil:
-				fmt.Fprintf(stderr, "session reconciler: dead-runtime close guard for %s: %v\n", b.ID, err) //nolint:errcheck
-			case !hasAssignedWork:
-				closeBead(store, b.ID, "dead-runtime", clk.Now().UTC(), stderr)
-			default:
-				fmt.Fprintf(stderr, "session reconciler: dead runtime session %s retained — open assigned work blocks alias release\n", name) //nolint:errcheck
-			}
+			closeBead(store, b.ID, "dead-runtime", clk.Now().UTC(), stderr)
 		}
 		cleaned++
 	}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -6548,7 +6548,11 @@ func TestCleanupDeadRuntimeSessionCorpsesToleratesNilStore(t *testing.T) {
 // and starve the session.stranded diagnostic path (#1425) and normal
 // wake/recovery flows of the session record they rely on. Runtime-Stop side
 // effect should still run.
-func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenInProgressWorkAssignedByID(t *testing.T) {
+// TestCleanupDeadRuntimeSessionCorpsesClosesBeadWithInProgressWorkAssignedByID
+// verifies that a confirmed-dead session is closed even when it holds
+// in-progress work assigned by bead ID. closeBead releases the work
+// via releaseWorkFromClosedSessionBead, so no orphan results.
+func TestCleanupDeadRuntimeSessionCorpsesClosesBeadWithInProgressWorkAssignedByID(t *testing.T) {
 	store := beads.NewMemStore()
 	sessionBead, err := store.Create(beads.Bead{
 		Type:   sessionBeadType,
@@ -6587,25 +6591,30 @@ func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenInProgressWorkAssignedBy
 		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1 (runtime-Stop should still run); stderr=%q", got, stderr.String())
 	}
 
-	// Bead must NOT be closed (would orphan the in_progress work).
+	// Session bead must be closed and work released.
 	after, err := store.Get(sessionBead.ID)
 	if err != nil {
 		t.Fatalf("re-fetch bead: %v", err)
 	}
-	if after.Status == "closed" {
-		t.Fatalf("bead status = closed; want still open — closing would orphan work %q assigned by ID to %q", work.ID, sessionBead.ID)
+	if after.Status != "closed" {
+		t.Fatalf("bead status = %q, want closed — dead session must be closed so work is released", after.Status)
 	}
-	if !strings.Contains(stderr.String(), "open assigned work blocks alias release") {
-		t.Errorf("stderr = %q, want operator-visible 'open assigned work blocks alias release' warning", stderr.String())
+	gotWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("re-fetch work bead: %v", err)
+	}
+	if gotWork.Assignee != "" {
+		t.Errorf("work assignee = %q, want empty", gotWork.Assignee)
+	}
+	if gotWork.Status != "open" {
+		t.Errorf("work status = %q, want open", gotWork.Status)
 	}
 }
 
-// TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenOpenWorkAssignedBySessionName
-// covers Julian's second regression: assignment by runtime `session_name`
-// (rather than bead ID) must also keep the session bead alive.
-// sessionAssignmentIdentifiersForConfig pulls both the bead ID and the runtime
-// session_name; the assignment-aware close gate must see either.
-func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenOpenWorkAssignedBySessionName(t *testing.T) {
+// TestCleanupDeadRuntimeSessionCorpsesClosesBeadWithOpenWorkAssignedBySessionName
+// verifies that assignment by runtime session_name also results in the bead
+// being closed and the work released when the session is confirmed dead.
+func TestCleanupDeadRuntimeSessionCorpsesClosesBeadWithOpenWorkAssignedBySessionName(t *testing.T) {
 	store := beads.NewMemStore()
 	sessionBead, err := store.Create(beads.Bead{
 		Type:   sessionBeadType,
@@ -6620,11 +6629,12 @@ func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenOpenWorkAssignedBySessio
 		t.Fatalf("create session bead: %v", err)
 	}
 	// Work assigned by session_name, not bead ID.
-	if _, err := store.Create(beads.Bead{
+	work, err := store.Create(beads.Bead{
 		Title:    "queued task",
 		Status:   "open",
 		Assignee: "worker-7",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("create open work: %v", err)
 	}
 
@@ -6644,16 +6654,27 @@ func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenOpenWorkAssignedBySessio
 	if err != nil {
 		t.Fatalf("re-fetch bead: %v", err)
 	}
-	if after.Status == "closed" {
-		t.Fatalf("bead status = closed; want still open — closing would orphan work assigned by session_name %q", "worker-7")
+	if after.Status != "closed" {
+		t.Fatalf("bead status = %q, want closed", after.Status)
+	}
+	gotWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("re-fetch work bead: %v", err)
+	}
+	if gotWork.Assignee != "" {
+		t.Errorf("work assignee = %q, want empty", gotWork.Assignee)
+	}
+	if gotWork.Status != "open" {
+		t.Errorf("work status = %q, want open", gotWork.Status)
 	}
 }
 
-// TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenRigStoreWorkAssigned
-// covers Julian's third regression: assignment in a rig store (not the
-// primary store) must also block the close. The assignment-aware gate must
-// scan all reachable stores, mirroring sessionHasOpenAssignedWorkForConfig.
-func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenRigStoreWorkAssigned(t *testing.T) {
+// TestCleanupDeadRuntimeSessionCorpsesClosesBeadWithRigStoreWorkAssigned
+// verifies that the session bead is closed even when assigned work lives in a
+// rig store. The primary-store work is released immediately via closeBead;
+// rig-store work is released on the next reconcile tick by
+// releaseOrphanedPoolAssignments, which sees the session bead is now closed.
+func TestCleanupDeadRuntimeSessionCorpsesClosesBeadWithRigStoreWorkAssigned(t *testing.T) {
 	store := beads.NewMemStore()
 	rigStore := beads.NewMemStore()
 
@@ -6669,8 +6690,7 @@ func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenRigStoreWorkAssigned(t *
 	if err != nil {
 		t.Fatalf("create session bead: %v", err)
 	}
-	// Open work assigned by session_name lives in the rig store, not the
-	// primary store — same shape as TestCloseSessionBeadIfUnassignedRefusesWhenRigStoreWorkAssignedBySessionName.
+	// Open work in the rig store, not the primary store.
 	if _, err := rigStore.Create(beads.Bead{
 		Title:    "rig-store task",
 		Status:   "open",
@@ -6691,12 +6711,145 @@ func TestCleanupDeadRuntimeSessionCorpsesRetainsBeadWhenRigStoreWorkAssigned(t *
 		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1; stderr=%q", got, stderr.String())
 	}
 
+	// Session bead must be closed regardless of rig-store work.
 	after, err := store.Get(sessionBead.ID)
 	if err != nil {
 		t.Fatalf("re-fetch bead: %v", err)
 	}
-	if after.Status == "closed" {
-		t.Fatalf("bead status = closed; want still open — closing would orphan rig-store work assigned by session_name %q", "worker-9")
+	if after.Status != "closed" {
+		t.Fatalf("bead status = %q, want closed — dead session with rig-store work must still be closed", after.Status)
+	}
+}
+
+// TestCleanupDeadRuntimeSessionCorpsesReleasesWorkOnDeadSession asserts that
+// when a pool-worker session is confirmed dead, any in-progress work bead
+// assigned to it by bead ID is released back to open status so the pool
+// reconciler can assign it to a new worker session.
+//
+// Regression test for ga-7le: dead sessions with assigned work were silently
+// retained, preventing work re-assignment and causing pool stalls.
+func TestCleanupDeadRuntimeSessionCorpsesReleasesWorkOnDeadSession(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "dead-pool-worker",
+			"template":     "worker",
+			"state":        string(session.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "in-flight task",
+		Assignee: sessionBead.ID,
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["dead-pool-worker"] = true
+	sp.dead["dead-pool-worker"] = true
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{sessionBead})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(store, nil, nil, snapshot, nil, sp, nil, &stderr)
+	if got != 1 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1; stderr=%q", got, stderr.String())
+	}
+
+	// Session bead must be closed: a confirmed-dead stopped session has no
+	// recovery path, so closeBead (which now releases orphaned work) is safe.
+	after, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("re-fetch session bead: %v", err)
+	}
+	if after.Status != "closed" {
+		t.Fatalf("session bead status = %q, want closed — dead session must be closed so work can be re-assigned", after.Status)
+	}
+
+	// Work bead must be released: assignee cleared and status reset to open.
+	gotWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("re-fetch work bead: %v", err)
+	}
+	if gotWork.Assignee != "" {
+		t.Errorf("work assignee = %q, want empty — dead session must release work", gotWork.Assignee)
+	}
+	if gotWork.Status != "open" {
+		t.Errorf("work status = %q, want open — dead session must release work", gotWork.Status)
+	}
+}
+
+// TestCleanupDeadRuntimeSessionCorpsesReleasesWorkAssignedBySessionName asserts
+// that work assigned by session_name (not bead ID) is also released when the
+// session is confirmed dead and its bead is closed.
+func TestCleanupDeadRuntimeSessionCorpsesReleasesWorkAssignedBySessionName(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "crashed-worker",
+			"template":     "worker",
+			"state":        string(session.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "routed task",
+		Assignee: "crashed-worker",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["crashed-worker"] = true
+	sp.dead["crashed-worker"] = true
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{sessionBead})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(store, nil, nil, snapshot, nil, sp, nil, &stderr)
+	if got != 1 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1; stderr=%q", got, stderr.String())
+	}
+
+	after, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("re-fetch session bead: %v", err)
+	}
+	if after.Status != "closed" {
+		t.Fatalf("session bead status = %q, want closed", after.Status)
+	}
+
+	gotWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("re-fetch work bead: %v", err)
+	}
+	if gotWork.Assignee != "" {
+		t.Errorf("work assignee = %q, want empty", gotWork.Assignee)
+	}
+	if gotWork.Status != "open" {
+		t.Errorf("work status = %q, want open", gotWork.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Removes the `hasAssignedWork` guard from `cleanupDeadRuntimeSessionCorpses` in `session_beads.go`
- When a pool worker session is confirmed dead (via `IsDeadRuntimeSession` + `sp.Stop`), the reconciler now closes its bead immediately — even if the session has assigned work
- `closeBead` (improved in PR #3054 / a3a3b9fcf) releases orphaned work via `releaseWorkFromClosedSessionBead`, so no work is permanently lost; rig-store work is released on the next reconcile tick by `releaseOrphanedPoolAssignments`

## Problem fixed

Pool workers that die without cleanly closing their beads left `in_progress` work assigned to their dead session indefinitely. The pool reconciler counted those orphaned beads toward `poolCurrent`, preventing new workers from spawning. The only recovery was manual `bd update --assignee '' --status open` per bead.

## Test plan

- [x] `TestCleanupDeadRuntimeSessionCorpsesReleasesWorkOnDeadSession` (new — work assigned by bead ID released)
- [x] `TestCleanupDeadRuntimeSessionCorpsesReleasesWorkAssignedBySessionName` (new — work assigned by session_name released)
- [x] Three existing `Retains*` tests updated to `Closes*` to reflect corrected behavior
- [x] All 15 `TestCleanupDeadRuntimeSessionCorpses*` tests pass
- [x] `go vet ./...` clean
- [x] `make test-fast-parallel` passes (all shards green)

## Scope

The guard is only removed from the **dead-runtime** path (`cleanupDeadRuntimeSessionCorpses`), where the session has been confirmed dead via the process checker and successfully stopped. The guard in `closeSessionBeadIfRuntimeStoppedAndUnassigned` (used for suspended/orphaned/reconfigured sessions) is unchanged — those paths may still have valid recovery routes.

Closes ga-7le.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)