### PR TITLE
fix(config): discover pack.toml from rig.path when no includes set (ga-dil)

### DIFF
--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -114,7 +114,22 @@ func expandPacks(cfg *City, fs fsys.FS, cityRoot string, rigFormulaDirs map[stri
 		cache := &packLoadCache{results: make(map[string]*packLoadResult)}
 		topoRefs := rig.Includes
 		if len(topoRefs) == 0 && len(rig.Imports) == 0 {
-			continue
+			// When a rig has only a path (no explicit includes/imports), treat
+			// the path directory itself as an implicit include if it contains a
+			// pack.toml. This supports the packV2 convention where a rig root
+			// can carry a pack.toml with agents/ directories.
+			if p := strings.TrimSpace(rig.Path); p != "" {
+				packPath := p
+				if !filepath.IsAbs(packPath) {
+					packPath = filepath.Join(cityRoot, packPath)
+				}
+				if _, sErr := fs.Stat(filepath.Join(packPath, packFile)); sErr == nil {
+					topoRefs = []string{packPath}
+				}
+			}
+			if len(topoRefs) == 0 {
+				continue
+			}
 		}
 
 		var rigAgents []Agent
@@ -2902,9 +2917,14 @@ func decodePackName(data []byte) (string, error) {
 }
 
 // HasPackRigs reports whether any rig in the config uses a pack.
+// Rigs with only a path are included because expandPacks auto-discovers
+// their root pack.toml (if present) as an implicit include.
 func HasPackRigs(rigs []Rig) bool {
 	for _, r := range rigs {
 		if len(r.Includes) > 0 || len(r.Imports) > 0 {
+			return true
+		}
+		if strings.TrimSpace(r.Path) != "" {
 			return true
 		}
 	}

--- a/internal/config/pack_discovery_integration_test.go
+++ b/internal/config/pack_discovery_integration_test.go
@@ -596,3 +596,99 @@ name = "test-city"
 		t.Fatalf("got %d PackDoctors, want 0", len(cfg.PackDoctors))
 	}
 }
+
+// TestExpandPacks_RigPathConventionAgentsRegistered asserts that convention-
+// based agents (agents/<name>/ dirs, no [[agent]] block) in a rig's root
+// pack.toml directory are discovered when the rig is defined with only
+// `path` and no explicit `includes`.
+//
+// Regression test for ga-dil: packV2 migration creates agents/<name>/ dirs
+// inside a rig's root directory but gc sling / gc status didn't find them
+// because expandPacks skipped rigs with no includes/imports.
+func TestExpandPacks_RigPathConventionAgentsRegistered(t *testing.T) {
+	dir := t.TempDir()
+	rigDir := filepath.Join(dir, "rigroot")
+	agentDir := filepath.Join(rigDir, "agents", "helper")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestFile(t, rigDir, "pack.toml", `
+[pack]
+name = "mrig-pack"
+schema = 1
+`)
+	writeTestFile(t, agentDir, "prompt.md", "You are the helper agent.\n")
+
+	cityDir := filepath.Join(dir, "city")
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "mrig"
+path = "`+rigDir+`"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	// Convention agent from the rig's path/pack.toml must appear in cfg.Agents.
+	explicit := explicitAgents(cfg.Agents)
+	for _, a := range explicit {
+		if a.Name == "helper" && a.Dir == "mrig" {
+			return // found: registered as mrig/helper
+		}
+	}
+	names := make([]string, 0, len(explicit))
+	for _, a := range explicit {
+		names = append(names, a.Dir+"/"+a.Name)
+	}
+	t.Fatalf("mrig/helper not found in cfg.Agents; got %v", names)
+}
+
+// TestExpandPacks_RigPathInlineAgentsRegistered asserts that explicit [[agent]]
+// blocks in a rig's path/pack.toml are registered when no includes is set.
+func TestExpandPacks_RigPathInlineAgentsRegistered(t *testing.T) {
+	dir := t.TempDir()
+	rigDir := filepath.Join(dir, "rigroot")
+
+	writeTestFile(t, rigDir, "pack.toml", `
+[pack]
+name = "mrig-pack"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "rig"
+`)
+
+	cityDir := filepath.Join(dir, "city")
+	writeTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test"
+
+[[rigs]]
+name = "myrig"
+path = "`+rigDir+`"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	explicit := explicitAgents(cfg.Agents)
+	for _, a := range explicit {
+		if a.Name == "worker" && a.Dir == "myrig" {
+			return
+		}
+	}
+	names := make([]string, 0, len(explicit))
+	for _, a := range explicit {
+		names = append(names, a.Dir+"/"+a.Name)
+	}
+	t.Fatalf("myrig/worker not found in cfg.Agents; got %v", names)
+}

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -1302,8 +1302,14 @@ func TestHasPackRigs(t *testing.T) {
 	if HasPackRigs(nil) {
 		t.Error("nil rigs should return false")
 	}
-	if HasPackRigs([]Rig{{Name: "a", Path: "/a"}}) {
-		t.Error("rig without pack should return false")
+	if HasPackRigs([]Rig{{Name: "a"}}) {
+		t.Error("rig with no path and no includes should return false")
+	}
+	// A rig with only a path is treated as potentially having a pack (expandPacks
+	// will discover the root pack.toml if present). This enables the packV2
+	// convention where a rig root carries agents/ directories directly.
+	if !HasPackRigs([]Rig{{Name: "a", Path: "/a"}}) {
+		t.Error("rig with path should return true (may have root pack.toml)")
 	}
 	if !HasPackRigs([]Rig{{Name: "a", Path: "/a", Includes: []string{"topo"}}}) {
 		t.Error("rig with includes should return true")


### PR DESCRIPTION
## Summary

- **Bug:** `expandPacks` skipped rigs whose `[[rigs]]` block had only `path=` (no `includes=` or `imports=`). A rig root carrying a `pack.toml` with `agents/<name>/` convention dirs was never loaded, so `gc sling <rig>/agent` and `gc status` found nothing — the agents weren't in `cfg.Agents` at all.
- **Root cause (two-part):** (1) `HasPackRigs` returned `false` for path-only rigs, so `expandPacks` was never called; (2) inside `expandPacks`, the early-`continue` fired before reaching the pack loader.
- **Fix:** When a rig has no `includes`/`imports` but `path` points to a directory that contains a `pack.toml`, treat `path` as an implicit include. `HasPackRigs` updated to return `true` for path-only rigs so `expandPacks` is invoked at all. Rigs whose path has no `pack.toml` are still skipped (unchanged behavior).

## Test plan

- [ ] `TestExpandPacks_RigPathConventionAgentsRegistered` — new test: convention-based agents (`agents/<name>/` dirs, no `[[agent]]` block) in a path-only rig are discovered
- [ ] `TestExpandPacks_RigPathInlineAgentsRegistered` — new test: explicit `[[agent]]` blocks in a path-only rig's `pack.toml` are discovered
- [ ] `TestHasPackRigs` — updated to assert path-only rigs return `true`
- [ ] Full `internal/config/...` suite passes (`ok` in CI)
- [ ] Pre-commit fast-parallel shards all passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)