### PR TITLE
feat(doctor): backlog-depth check — true claimable backlog vs control-plane/notification noise (#3021)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -279,6 +279,7 @@ func buildDoctorChecks(cityPath string, cfg *config.City, cfgErr error, opts bui
 		register(doctor.NewBeadsStoreCheck(cityPath, storeFactory))
 		register(newV2RoutedToNamespaceCheck(cfg, cityPath, storeFactory))
 		register(newRunTargetRoutedToBackfillCheck(cfg, cityPath, storeFactory))
+		register(newBacklogDepthCheck(cityPath, storeFactory))
 		register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})
 	}
 	register(newDoctorDoltServerCheck(cityPath, opts.SkipCityDoltCheck))

--- a/cmd/gc/doctor_backlog_depth.go
+++ b/cmd/gc/doctor_backlog_depth.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+// backlogDepthCheck reports the city's true claimable backlog depth by
+// classifying the raw open-bead population into actionable work versus
+// observability noise. `bd ready` (the beads CLI) lists control-plane session
+// beads and short-lived nudge/mail notification chores alongside real work, so
+// raw queue depth reads as a huge backlog even when only one task is actually
+// claimable — the recurring "fleet idle / backlog huge" false alarm
+// (gastownhall/gascity#3021).
+//
+// The check is pure observability: it never mutates beads and never gates
+// (SeverityAdvisory). It does not touch the claiming path — agents' work
+// queries already filter this noise via the Ready-tier contract; the gap it
+// closes is the operator/dashboard view.
+type backlogDepthCheck struct {
+	cityPath string
+	newStore func(string) (beads.Store, error)
+	// now is injectable for tests; the zero value means time.Now().
+	now time.Time
+}
+
+func newBacklogDepthCheck(cityPath string, newStore func(string) (beads.Store, error)) *backlogDepthCheck {
+	return &backlogDepthCheck{cityPath: cityPath, newStore: newStore}
+}
+
+func (c *backlogDepthCheck) Name() string { return "backlog-depth" }
+
+func (c *backlogDepthCheck) CanFix() bool { return false }
+
+func (c *backlogDepthCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+func (c *backlogDepthCheck) WarmupEligible() bool { return false }
+
+// backlogBreakdown is the classified census of the raw open-bead population.
+// The buckets are mutually exclusive and sum to total, so the operator can read
+// the equation raw - control-plane - notification - epic - other = real.
+type backlogBreakdown struct {
+	total        int          // every status=open bead (the "raw" population)
+	controlPlane int          // type=session / gc:session: the session registry
+	notification int          // nudge:/mail: chores, type=message, gc:nudge
+	epic         int          // epic parents: containers, not claimable leaves
+	other        int          // deferred, or other infra/excluded Ready-tier types
+	real         []beads.Bead // genuinely claimable Ready-tier work
+}
+
+// isControlPlaneBacklogBead reports whether a bead is a controller-owned
+// session-registry bead rather than claimable work.
+func isControlPlaneBacklogBead(b beads.Bead) bool {
+	return b.Type == sessionBeadType || hasLabel(b.Labels, sessionBeadLabel)
+}
+
+// isNotificationBacklogBead reports whether a bead is a short-lived delivery
+// chore (nudge or mail) rather than durable backlog. It mirrors the
+// nudge-mail-reaper notification predicate: the nudge:/mail: title prefix, the
+// gc:nudge label, and the mail bead type.
+func isNotificationBacklogBead(b beads.Bead) bool {
+	if b.Type == "message" || hasLabel(b.Labels, nudgeBeadLabel) {
+		return true
+	}
+	title := strings.TrimSpace(b.Title)
+	return strings.HasPrefix(title, "nudge:") || strings.HasPrefix(title, "mail:")
+}
+
+// classifyBacklog partitions the raw open-bead population into one bucket each
+// (first match wins) so the buckets sum to total. "real" is the Ready-tier
+// contract (beads.IsReadyCandidateForTier) minus the noise classes above.
+func classifyBacklog(open []beads.Bead, now time.Time) backlogBreakdown {
+	b := backlogBreakdown{total: len(open)}
+	for _, bead := range open {
+		switch {
+		case isControlPlaneBacklogBead(bead):
+			b.controlPlane++
+		case isNotificationBacklogBead(bead):
+			b.notification++
+		case bead.Type == "epic":
+			b.epic++
+		case beads.IsReadyCandidateForTier(bead, now, beads.TierIssues):
+			b.real = append(b.real, bead)
+		default:
+			b.other++
+		}
+	}
+	return b
+}
+
+func (c *backlogDepthCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	res := &doctor.CheckResult{Name: c.Name(), Severity: doctor.SeverityAdvisory}
+	if c.newStore == nil || strings.TrimSpace(c.cityPath) == "" {
+		res.Status = doctor.StatusWarning
+		res.Message = "backlog depth unknown: no city bead store configured"
+		return res
+	}
+	store, err := c.newStore(c.cityPath)
+	if err != nil {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("backlog depth unknown: opening city bead store: %v", err)
+		return res
+	}
+	open, err := store.ListOpen("open")
+	if err != nil {
+		res.Status = doctor.StatusWarning
+		res.Message = fmt.Sprintf("backlog depth unknown: listing open beads: %v", err)
+		return res
+	}
+
+	now := c.now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	b := classifyBacklog(open, now)
+
+	res.Status = doctor.StatusOK
+	res.Message = fmt.Sprintf(
+		"true backlog: %d claimable (of %d open — %d control-plane, %d notification, %d epic, %d other)",
+		len(b.real), b.total, b.controlPlane, b.notification, b.epic, b.other)
+
+	details := make([]string, 0, len(b.real))
+	for _, bead := range b.real {
+		details = append(details, fmt.Sprintf("claimable: %s %s", bead.ID, strings.TrimSpace(bead.Title)))
+	}
+	sort.Strings(details)
+	res.Details = details
+	return res
+}

--- a/cmd/gc/doctor_backlog_depth_test.go
+++ b/cmd/gc/doctor_backlog_depth_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func TestClassifyBacklog(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	future := now.Add(24 * time.Hour)
+
+	open := []beads.Bead{
+		// control-plane: by type and by label
+		{ID: "S-1", Title: "voxist.planner-1", Type: "session", Status: "open"},
+		{ID: "S-2", Title: "registry", Type: "task", Status: "open", Labels: []string{"gc:session"}},
+		// notification: nudge/mail title prefixes, type=message, gc:nudge label
+		{ID: "N-1", Title: "nudge:abc", Type: "chore", Status: "open"},
+		{ID: "N-2", Title: "mail:welcome", Type: "task", Status: "open"},
+		{ID: "N-3", Title: "some mail", Type: "message", Status: "open"},
+		{ID: "N-4", Title: "labeled nudge", Type: "task", Status: "open", Labels: []string{"gc:nudge"}},
+		// epic parents
+		{ID: "E-1", Title: "EPIC: self-healing", Type: "epic", Status: "open"},
+		// genuinely claimable real work
+		{ID: "R-1", Title: "fix the thing", Type: "task", Status: "open"},
+		{ID: "R-2", Title: "feature work", Type: "feature", Status: "open"},
+		// other: deferred (future), and an infra/excluded type
+		{ID: "O-1", Title: "deferred task", Type: "task", Status: "open", DeferUntil: &future},
+		{ID: "O-2", Title: "workflow container", Type: "molecule", Status: "open"},
+	}
+
+	b := classifyBacklog(open, now)
+
+	if b.total != len(open) {
+		t.Errorf("total = %d, want %d", b.total, len(open))
+	}
+	if b.controlPlane != 2 {
+		t.Errorf("controlPlane = %d, want 2", b.controlPlane)
+	}
+	if b.notification != 4 {
+		t.Errorf("notification = %d, want 4", b.notification)
+	}
+	if b.epic != 1 {
+		t.Errorf("epic = %d, want 1", b.epic)
+	}
+	if b.other != 2 {
+		t.Errorf("other = %d, want 2", b.other)
+	}
+	gotReal := make([]string, 0, len(b.real))
+	for _, r := range b.real {
+		gotReal = append(gotReal, r.ID)
+	}
+	want := []string{"R-1", "R-2"}
+	if strings.Join(gotReal, ",") != strings.Join(want, ",") {
+		t.Errorf("real = %v, want %v", gotReal, want)
+	}
+}
+
+func TestBacklogDepthCheckRunReportsTrueDepth(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	store := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "S-1", Title: "planner-1", Type: "session", Status: "open"},
+		{ID: "N-1", Title: "nudge:abc", Type: "chore", Status: "open"},
+		{ID: "N-2", Title: "nudge:def", Type: "chore", Status: "open"},
+		{ID: "E-1", Title: "EPIC", Type: "epic", Status: "open"},
+		{ID: "R-1", Title: "real work", Type: "task", Status: "open"},
+	}, nil)
+
+	check := newBacklogDepthCheck("/city", func(string) (beads.Store, error) { return store, nil })
+	check.now = now
+
+	res := check.Run(&doctor.CheckContext{})
+	if res.Status != doctor.StatusOK {
+		t.Fatalf("Status = %v, want OK (observability never gates): %#v", res.Status, res)
+	}
+	if res.Severity != doctor.SeverityAdvisory {
+		t.Fatalf("Severity = %v, want Advisory", res.Severity)
+	}
+	// Message must surface the real count (1) distinct from the raw open count (5).
+	for _, want := range []string{"1", "5"} {
+		if !strings.Contains(res.Message, want) {
+			t.Errorf("Message %q missing %q", res.Message, want)
+		}
+	}
+	details := strings.Join(res.Details, "\n")
+	if !strings.Contains(details, "R-1") {
+		t.Errorf("Details should name the real claimable bead R-1:\n%s", details)
+	}
+	for _, noise := range []string{"S-1", "N-1", "E-1"} {
+		if strings.Contains(details, noise) {
+			t.Errorf("Details should not list noise bead %q:\n%s", noise, details)
+		}
+	}
+}
+
+func TestBacklogDepthCheckStoreErrorIsGraceful(t *testing.T) {
+	check := newBacklogDepthCheck("/city", func(string) (beads.Store, error) {
+		return nil, fmt.Errorf("store unreachable")
+	})
+	res := check.Run(&doctor.CheckContext{})
+	// A store read failure must not panic and must stay advisory (observability
+	// only — it never gates dispatch or `gc start`).
+	if res.Severity != doctor.SeverityAdvisory {
+		t.Fatalf("Severity = %v, want Advisory on store error", res.Severity)
+	}
+	if res.Status == doctor.StatusError {
+		t.Fatalf("store error should not be a blocking StatusError: %#v", res)
+	}
+	if !check.CanFix() == false {
+		// CanFix must be false: this is a read-only observability check.
+		t.Errorf("CanFix = %v, want false", check.CanFix())
+	}
+}

--- a/cmd/gc/testdata/doctor_check_names.golden
+++ b/cmd/gc/testdata/doctor_check_names.golden
@@ -50,6 +50,7 @@ bd-split-store
 beads-store
 v2-routed-to-namespace
 run-target-routed-to-backfill
+backlog-depth
 session-model
 dolt-server
 dolt-noms-size


### PR DESCRIPTION
## What

Implements **Option B** of #3021: a `gc doctor` check (`backlog-depth`) that reports the city's *true* claimable backlog depth, separating real work from observability noise.

`bd ready` lists control-plane session beads and short-lived `nudge:`/`mail:` notification chores alongside real work, so raw queue depth reads as a huge backlog even when only one task is actually claimable — the recurring "fleet idle / backlog huge" false alarm. Agents' work-queries already filter this via the Ready-tier contract; the gap is the operator/dashboard view.

## How

The check classifies the raw `status=open` population into mutually-exclusive buckets (first match wins, so they sum to total):

- **control-plane** — `type=session` or `gc:session` label (the session registry)
- **notification** — `nudge:`/`mail:` title prefix, `type=message`, or `gc:nudge` label (mirrors the nudge-mail-reaper notification predicate)
- **epic** — `type=epic` parents (containers, not claimable leaves)
- **other** — deferred / other infra Ready-tier–excluded types
- **real** — genuinely claimable work via `beads.IsReadyCandidateForTier` (reuses the existing Ready-tier contract; no parallel logic)

and reports:

```
true backlog: 1 claimable (of 33 open — 17 control-plane, 11 notification, 2 epic, 2 other)
```

with the claimable bead IDs in `--verbose` details.

## Properties

- **Pure observability.** `SeverityAdvisory` (never gates dispatch / `gc start` / exit codes) and `CanFix() == false` (never mutates beads). It does not touch the claiming path.
- **DRY.** Reuses `beads.IsReadyCandidateForTier`, `hasLabel`, and the existing session/nudge label+type constants rather than re-deriving them.

## Design note for reviewers

The issue suggests *"WARN if real backlog > 0 and all sessions idle."* I deliberately kept this check **informational (always OK / advisory)** rather than warning on `real > 0`: a non-zero real backlog is the normal healthy state (there's queued work), so warning on it would be exactly the kind of false alarm this is meant to *kill*. The meaningful escalation is the `real > 0 ∧ sessions idle` correlation, which couples doctor to live session-liveness state — happy to add that as a follow-up (or here) if you'd prefer. Flagging the choice explicitly.

## Tests

- `TestClassifyBacklog` — bucket classification across all five classes (incl. deferred + excluded types).
- `TestBacklogDepthCheckRunReportsTrueDepth` — end-to-end via a `MemStore`; asserts OK/advisory, the real-vs-raw counts in the message, and that noise beads are excluded from details.
- `TestBacklogDepthCheckStoreErrorIsGraceful` — store-read failure stays advisory, never panics, never blocks.
- Golden `doctor_check_names.golden` updated for the new registration.

`golangci-lint` clean; `go vet` clean. Tracked city-side as `vc-tuu6u` (closed) / `vp-ds6`.
