### PR TITLE
fix(refinery): refuse close-as-merged for a 0-diff branch (#3048)

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -8,6 +8,7 @@ package gastown_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -439,6 +440,153 @@ func TestRefineryFormulaChainsMergeMetadataWithClose(t *testing.T) {
 		"--unset-metadata rejection_reason &&",
 		`gc bd close $WORK --reason "Pull request ready: $PR_URL"`,
 	)
+}
+
+// TestRefineryFormulaRefusesZeroDiffMerge guards the false-completion
+// fix (gco-hu0p / upstream #3048): nothing previously stopped the refinery
+// from recording a 0-commit / no-diff branch as close-as-merged, producing
+// a false completion and silent work loss (seen as a session-starved
+// polecat handing off 0 commits). The merge-push step now defines ONE
+// shared predicate, branch_has_real_change (git merge-base + git diff
+// --quiet + >=1 commit), and calls it from BOTH terminal handoffs — the
+// direct close-as-merged AND the mr/pr publication that also closes the
+// bead — halting-and-escalating (never silent retry) on an empty branch.
+//
+// The guard must run BEFORE each handoff's bead-closing command, so a
+// regression that drops or reorders it can never close an empty branch.
+func TestRefineryFormulaRefusesZeroDiffMerge(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery formula: %v", err)
+	}
+	body := string(data)
+
+	// ONE shared predicate, defined exactly once, using the authoritative
+	// diff check (commit-count alone is a weaker proxy).
+	if count := strings.Count(body, "branch_has_real_change() {"); count != 1 {
+		t.Fatalf("expected exactly one branch_has_real_change definition, found %d", count)
+	}
+	assertContainsInOrder(t, body,
+		"branch_has_real_change() {",
+		`bhrc_base=$(git merge-base "$bhrc_target" "$bhrc_branch"`,
+		`git diff --quiet "$bhrc_base" "$bhrc_branch"`,
+		`0) return 1 ;;`, // no diff -> empty -> refuse
+		`*) return 2 ;;`, // git diff errored -> suspect -> refuse (fail closed)
+	)
+
+	// Halt-and-escalate, never silent retry: blocked + structured note +
+	// mayor/witness nudges, defined once.
+	if count := strings.Count(body, "halt_false_completion() {"); count != 1 {
+		t.Fatalf("expected exactly one halt_false_completion definition, found %d", count)
+	}
+	assertContainsInOrder(t, body,
+		"halt_false_completion() {",
+		"--status=blocked",
+		`--set-metadata false_completion_suspected="branch $fc_branch no verified change vs $fc_base; refused merge-close"`,
+		"gc session nudge mayor",
+		"{{binding_prefix}}witness",
+		"gc runtime drain-ack",
+	)
+
+	// Both terminal handoffs call the shared predicate before closing.
+	if count := strings.Count(body, `branch_has_real_change "origin/$TARGET" temp ||`); count != 2 {
+		t.Fatalf("expected the guard at both the direct-merge and mr/pr handoff sites, found %d call sites", count)
+	}
+
+	// Direct close-as-merged path: guard precedes the merge and the close.
+	assertContainsInOrder(t, body,
+		`**If MERGE_STRATEGY = "direct" (default):**`,
+		`branch_has_real_change "origin/$TARGET" temp ||`,
+		"git merge --ff-only temp",
+		`gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"`,
+	)
+
+	// mr/pr publication path: guard precedes the push and the close.
+	assertContainsInOrder(t, body,
+		`**If MERGE_STRATEGY = "mr":**`,
+		`branch_has_real_change "origin/$TARGET" temp ||`,
+		"git push origin HEAD:$BRANCH --force-with-lease",
+		`gc bd close $WORK --reason "Pull request ready: $PR_URL"`,
+	)
+}
+
+// TestRefineryBranchHasRealChangeExec runs the extracted predicate against
+// real git repositories — the production code path, not just its formula
+// text (the static assertions above lock structure; this proves behavior).
+// It certifies the contract the #3048 guard depends on: diff is the
+// authority (a net-zero branch carrying commits is still "empty"), and a
+// tool error fails closed (exit 2) rather than reading as "safe to merge".
+func TestRefineryBranchHasRealChangeExec(t *testing.T) {
+	fn := extractBetween(t, refineryMergePushDescription(t),
+		"branch_has_real_change() {", "\nhalt_false_completion() {")
+
+	repo := t.TempDir()
+	git := func(args ...string) {
+		runCmd(t, repo, "git", append([]string{"-C", repo}, args...)...)
+	}
+	commit := func(msg string) {
+		git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", msg)
+	}
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	git("init", "-q", "-b", "main")
+	write("base.txt", "base\n")
+	git("add", "base.txt")
+	commit("base")
+
+	// empty: no commits beyond main -> no diff.
+	git("branch", "empty")
+
+	// real: one commit that adds a file -> a real diff.
+	git("checkout", "-q", "-b", "real", "main")
+	write("f.txt", "x\n")
+	git("add", "f.txt")
+	commit("add f")
+
+	// netzero: two commits that cancel -> commits exist, but the diff vs
+	// main is empty. Diff must win over commit-count.
+	git("checkout", "-q", "-b", "netzero", "main")
+	write("g.txt", "y\n")
+	git("add", "g.txt")
+	commit("add g")
+	git("rm", "-q", "g.txt")
+	commit("remove g")
+
+	git("checkout", "-q", "main")
+
+	cases := []struct {
+		name, base, branch string
+		want               int
+	}{
+		{"empty_refuses", "main", "empty", 1},
+		{"real_allows", "main", "real", 0},
+		{"netzero_refuses", "main", "netzero", 1},
+		{"uncomputable_base_refuses", "does-not-exist", "real", 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			script := fn + "\nbranch_has_real_change \"" + c.base + "\" \"" + c.branch + "\"\n"
+			cmd := exec.Command("sh", "-c", script)
+			cmd.Dir = repo
+			got := 0
+			if err := cmd.Run(); err != nil {
+				var ee *exec.ExitError
+				if !errors.As(err, &ee) {
+					t.Fatalf("running predicate: %v", err)
+				}
+				got = ee.ExitCode()
+			}
+			if got != c.want {
+				t.Fatalf("branch_has_real_change %q %q exit=%d, want %d", c.base, c.branch, got, c.want)
+			}
+		})
+	}
 }
 
 // TestRefineryPromptRejectionFlowEnforcesClearOnMerge guards against

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -470,6 +470,53 @@ Target: $TARGET"
   exit 1
 }
 
+branch_has_real_change() {
+  # Shared false-completion predicate (0-diff/0-commit guard). Does
+  # <branch-ref> introduce a real change vs its merge-base with
+  # <target-ref>? Diff is authoritative — commit-count alone is a weaker
+  # proxy because a branch can carry commits that net-zero — so we use
+  # `git diff --quiet` and ALSO require >=1 commit beyond the base.
+  #   exit 0 = real change (safe to merge / open PR)
+  #   exit 1 = empty: no diff, or no commits, vs base (REFUSE close-as-merged)
+  #   exit 2 = base/diff could not be computed: merge-base failed OR `git diff`
+  #           itself errored (exit >1). Fail closed — a tool error is a suspect,
+  #           not a licence to merge — so the caller halts, never improvises.
+  bhrc_target="$1"
+  bhrc_branch="$2"
+  bhrc_base=$(git merge-base "$bhrc_target" "$bhrc_branch" 2>/dev/null) || return 2
+  git diff --quiet "$bhrc_base" "$bhrc_branch"
+  case "$?" in
+    0) return 1 ;;  # no diff -> empty -> refuse
+    1) : ;;         # diff present -> fall through to the commit-count check
+    *) return 2 ;;  # git diff errored -> suspect -> refuse (fail closed)
+  esac
+  [ "$(git rev-list --count "$bhrc_base..$bhrc_branch" 2>/dev/null || echo 0)" -ge 1 ] || return 1
+  return 0
+}
+
+halt_false_completion() {
+  # branch_has_real_change tripped: a close-as-merged would assert "work was
+  # merged" for a branch that merges to a no-op, which is definitionally
+  # false. Halt-and-escalate (NEVER silent retry): leave the bead blocked
+  # with a structured note, hand to human, nudge mayor + witness, then stop.
+  # This surfaces the transient cause (e.g. session starvation -> 0-commit
+  # polecat) instead of masking it.
+  fc_branch="$1"
+  fc_base="$2"
+  gc bd update $WORK \
+    --status=blocked \
+    --assignee="" \
+    --set-metadata merge_result=refused_false_completion \
+    --set-metadata gc.routed_to=human \
+    --set-metadata false_completion_suspected="branch $fc_branch no verified change vs $fc_base; refused merge-close"
+  gc session nudge mayor "FALSE-COMPLETION HALT: $WORK — branch $fc_branch no verified change vs $fc_base; refused close-as-merged. Bead left blocked; NEVER silent retry."
+  gc session nudge "${GC_RIG:+$GC_RIG/}{{binding_prefix}}witness" "FALSE-COMPLETION HALT: $WORK — branch $fc_branch no verified change vs $fc_base; refused close-as-merged."
+  echo "REFUSED close-as-merged: $WORK branch $fc_branch introduces no real change vs $fc_base."
+  echo "STOP. Bead left blocked + escalated to mayor/witness. NEVER silent retry."
+  gc runtime drain-ack
+  exit 1
+}
+
 pr_lookup_missing() {
   case "$1" in
     *"Could not resolve to a PullRequest"*|*"could not resolve to a PullRequest"*|*"no pull requests found"*|*"Not Found"*|*"not found"*|*"404"*) return 0 ;;
@@ -630,6 +677,17 @@ fi
 
 **If MERGE_STRATEGY = "direct" (default):**
 
+**0. Refuse a 0-diff branch (false-completion guard):**
+
+A close-as-merged asserts "work was merged"; a branch that introduces no
+change vs its merge-base merging is definitionally false. Refuse it before
+touching `$TARGET`. Legit no-op resolutions MUST use wontfix/duplicate/
+not-planned, never merged — so this never blocks a real merge.
+```bash
+branch_has_real_change "origin/$TARGET" temp || \
+  halt_false_completion "$BRANCH" "$(git merge-base "origin/$TARGET" temp 2>/dev/null || printf '%s' "origin/$TARGET")"
+```
+
 **1. Merge and push target branch:**
 ```bash
 git checkout $TARGET
@@ -677,6 +735,17 @@ If delete_merged_branches = "true": `git push origin --delete $BRANCH`
 
 Refinery does NOT land the branch directly. Instead it publishes a pull
 request and treats PR creation as the terminal handoff for this work bead.
+
+**0. Refuse a 0-diff branch (false-completion guard):**
+
+The same predicate covers the empty-PR / 0-commit concern: do not publish a
+pull request for a branch that introduces no change vs its merge-base. The
+PR handoff closes the bead, so an empty PR is the same false completion as
+an empty direct merge.
+```bash
+branch_has_real_change "origin/$TARGET" temp || \
+  halt_false_completion "$BRANCH" "$(git merge-base "origin/$TARGET" temp 2>/dev/null || printf '%s' "origin/$TARGET")"
+```
 
 **1. Push the rebased branch back to origin:**
 ```bash


### PR DESCRIPTION
Closes #3048.

## Problem

The refinery merge/done path asserted "work was merged" but never checked
the branch changes anything, so a 0-commit / no-diff branch (e.g. a
session-starved worker handing off 0 commits) was recorded as merged — a
false completion and silent work loss.

## Fix

Add one shared predicate, `branch_has_real_change` (`git merge-base` +
`git diff --quiet`, and require ≥1 commit beyond the base; diff is the
authority since commits can net to zero), and call it from both terminal
handoffs that close the bead: the direct ff-only merge and the mr/PR
publication.

The predicate fails closed — an uncomputable merge-base OR a `git diff`
tool error returns "suspect", so the caller halts rather than improvising
a merge. On an empty branch, `halt_false_completion` leaves the bead
blocked with a structured note and escalates instead of silently retrying,
surfacing the transient cause.

Legit no-op resolutions must use wontfix/duplicate/not-planned (never
merged), so the guard never blocks a real merge.

## Tests

- `TestRefineryFormulaRefusesZeroDiffMerge` — formula wiring: predicate
  defined once, ordered before each bead-closing command, present at both
  handoff sites.
- `TestRefineryBranchHasRealChangeExec` — runs the extracted predicate
  against real git repos: empty refuses, real allows, net-zero refuses
  (diff wins over commit-count), uncomputable base fails closed.