### PR TITLE
fix(dolt): preserve malformed nested telemetry opt-out

### DIFF
--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -647,6 +647,7 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 	} else {
 		deletions["dolt.user"] = struct{}{}
 	}
+	disableEventFlush := doltDisableEventFlushFallbackValue(data, state)
 
 	lines := strings.Split(string(data), "\n")
 	out := make([]string, 0, len(lines)+len(replacements))
@@ -708,10 +709,9 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		out = append(out, want)
 		changed = true
 	}
-	if !topLevelConfigKeyPresent(out, "dolt") {
-		out = append(out, "dolt:", "  disable-event-flush: "+boolString(doltDisableEventFlushFallbackValue(data, state)))
-		changed = true
-	}
+	var doltChanged bool
+	out, doltChanged = ensureFallbackNestedDoltDisableEventFlush(out, disableEventFlush)
+	changed = doltChanged || changed
 
 	if !changed {
 		return false, nil
@@ -836,6 +836,49 @@ func scanConfigBoolValueFromData(data []byte, prefixes ...string) (bool, bool) {
 	return false, false
 }
 
+func scanNestedConfigBoolValueFromData(data []byte, section string, keys ...string) (bool, bool) {
+	if raw, ok := scanNestedConfigLineValueFromData(data, section, keys...); ok {
+		parsed, err := strconv.ParseBool(raw)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return false, false
+}
+
+func scanNestedConfigLineValueFromData(data []byte, section string, keys ...string) (string, bool) {
+	inSection := false
+	for _, line := range strings.Split(string(data), string(rune(10))) {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.TrimLeft(line, " \t") == line {
+			key, value, ok := topLevelConfigLine(line)
+			inSection = ok && key == section && value == ""
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		key, value, ok := strings.Cut(trimmed, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		for _, want := range keys {
+			if key == want {
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
 func readConfigStateFromData(data []byte) ConfigState {
 	return ConfigState{
 		IssuePrefix:    scanConfigValueFromData(data, "issue_prefix:", "issue-prefix:"),
@@ -879,6 +922,10 @@ func readDoltConfigFromData(data []byte) (DoltConfig, bool) {
 
 func readDoltConfigFromDataOrEmpty(data []byte) DoltConfig {
 	var cfg DoltConfig
+	if value, ok := scanNestedConfigBoolValueFromData(data, "dolt", "disable-event-flush", "disable_event_flush"); ok {
+		cfg.DisableEventFlush = &value
+		return cfg
+	}
 	if value, ok := scanConfigBoolValueFromData(data, "dolt.disable-event-flush:", "dolt.disable_event_flush:"); ok {
 		cfg.DisableEventFlush = &value
 	}
@@ -927,14 +974,75 @@ func topLevelConfigLine(line string) (key, value string, ok bool) {
 	return strings.TrimSpace(key), strings.TrimSpace(value), true
 }
 
-func topLevelConfigKeyPresent(lines []string, want string) bool {
-	for _, line := range lines {
+func ensureFallbackNestedDoltDisableEventFlush(lines []string, value bool) ([]string, bool) {
+	want := "  disable-event-flush: " + boolString(value)
+	sectionIndex := -1
+	for i, line := range lines {
 		key, _, ok := topLevelConfigLine(line)
-		if ok && key == want {
-			return true
+		if ok && key == "dolt" {
+			sectionIndex = i
 		}
 	}
-	return false
+	if sectionIndex == -1 {
+		return append(lines, "dolt:", want), true
+	}
+
+	sectionEnd := len(lines)
+	for i := sectionIndex + 1; i < len(lines); i++ {
+		if _, _, ok := topLevelConfigLine(lines[i]); ok {
+			sectionEnd = i
+			break
+		}
+	}
+
+	out := make([]string, 0, len(lines)+1)
+	out = append(out, lines[:sectionIndex]...)
+	changed := false
+	if strings.TrimSpace(lines[sectionIndex]) != "dolt:" {
+		out = append(out, "dolt:")
+		changed = true
+	} else {
+		out = append(out, lines[sectionIndex])
+	}
+
+	seen := false
+	for _, line := range lines[sectionIndex+1 : sectionEnd] {
+		key, ok := nestedConfigLineKey(line)
+		if ok && (key == "disable-event-flush" || key == "disable_event_flush") {
+			if seen {
+				changed = true
+				continue
+			}
+			seen = true
+			if line != want {
+				out = append(out, want)
+				changed = true
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+	if !seen {
+		out = append(out, want)
+		changed = true
+	}
+	out = append(out, lines[sectionEnd:]...)
+	return out, changed
+}
+
+func nestedConfigLineKey(line string) (string, bool) {
+	if strings.TrimLeft(line, " \t") == line {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return "", false
+	}
+	key, _, ok := strings.Cut(trimmed, ":")
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(key), true
 }
 
 func endpointOriginValue(value string) EndpointOrigin {

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -398,6 +398,55 @@ func TestEnsureCanonicalConfigCanonicalizesFlatDoltDisableEventFlush(t *testing.
 	}
 }
 
+func TestEnsureCanonicalConfigFallbackPreservesFlatDoltDisableEventFlushOptOutInExistingDoltBlock(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue-prefix: gc",
+		"dolt:",
+		"  host: 127.0.0.1",
+		"dolt.disable-event-flush: false",
+		": not yaml",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalConfig() should report changes")
+	}
+
+	dolt, ok, err := ReadDoltConfig(fs, path)
+	if err != nil {
+		t.Fatalf("ReadDoltConfig() error = %v", err)
+	}
+	if !ok || dolt.DisableEventFlush == nil || *dolt.DisableEventFlush {
+		t.Fatalf("ReadDoltConfig() = (%+v, %v), want explicit disable-event-flush false", dolt, ok)
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "dolt:\n  host: 127.0.0.1\n  disable-event-flush: false") {
+		t.Fatalf("config should insert nested Dolt opt-out into existing block:\n%s", text)
+	}
+	if strings.Contains(text, "dolt.disable-event-flush") {
+		t.Fatalf("config should scrub flat Dolt telemetry setting:\n%s", text)
+	}
+}
+
 func TestEnsureCanonicalConfigWritesExternalFields(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()
@@ -1026,6 +1075,33 @@ func TestReadDoltConfig(t *testing.T) {
 				t.Errorf("ReadDoltConfig().DisableEventFlushEnabled() = %v, want %v", got.DisableEventFlushEnabled(), tt.wantValue)
 			}
 		})
+	}
+}
+
+func TestReadDoltConfigFallsBackToNestedDisableEventFlushOnMalformedYAML(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue_prefix: zz",
+		"dolt:",
+		"  disable-event-flush: false",
+		": not yaml",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := ReadDoltConfig(fs, path)
+	if err != nil {
+		t.Fatalf("ReadDoltConfig() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ReadDoltConfig() ok = false, want true")
+	}
+	if got.DisableEventFlush == nil || *got.DisableEventFlush {
+		t.Fatalf("ReadDoltConfig().DisableEventFlush = %v, want explicit false", got.DisableEventFlush)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #3023. Original PR: https://github.com/gastownhall/gascity/pull/3023

## Why

PR #3023 disabled Dolt usage telemetry for managed sql-servers and was merged at `bb40d0ba5db02cf877f0bfa9bfe8cd8a02fb7d7d`. The adoption review found one maintainer-side correctness fix that was approved after the original PR had already merged: malformed YAML fallback handling could ignore an explicit nested `dolt.disable-event-flush: false` opt-out and default managed servers back to `DOLT_DISABLE_EVENT_FLUSH=true`.

This follow-up carries only that maintainer repair on top of current `main`. It does not duplicate the contributor commits from #3023.

## Review And Fix

- Original PR title: `fix(dolt): disable usage telemetry for managed sql-servers`
- Original PR state: `MERGED`
- Configured base: `main`
- Original GitHub base: `main`
- Latest adopted base: `76c7cefea8f41ff4c85c6a822cfbb8225bb9f13d`
- Adoption review: latest attempt 3 approved with no required changes remaining

The fix preserves the resolved telemetry opt-out before removing flat compatibility keys and updates/inserts the nested `dolt.disable-event-flush` value during malformed-config canonicalization.

## Validation

- `git diff --check refs/adopt-pr/ga-iulhk/latest-base..HEAD`
- `go test ./internal/beads/contract`
- `go vet ./internal/beads/contract`

## Workflow

This is the maintainer follow-up merge surface for the already-merged original PR #3023. CI should run against this branch before merge-ready handoff.