### PR TITLE
feat(controller): cross-store cold-wake for no-scale_check rig pools

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -493,7 +493,29 @@ func buildDesiredStateWithSessionBeads(
 		// new unassigned demand while assigned work drives resume requests.
 		poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
 		if store != nil && !hasCustomScaleCheck {
-			defaultScaleTargets = append(defaultScaleTargets, defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores))
+			ownTarget := defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores)
+			defaultScaleTargets = append(defaultScaleTargets, ownTarget)
+			// Cross-store cold-wake (FR-S0.1 / vp-s37): a cold rig pool's routed
+			// demand may live in the city store (vp-kvp cross-store delivery),
+			// which the own-rig probe above cannot see while the pool sleeps —
+			// so a sleeping rig pool would never wake to discover it. Add a
+			// city-store probe for cold rig pools so their demand reflects
+			// routed work in either store. No clamp: unlike a custom-scale_check
+			// pool — where the probe is clamped so it cannot override the custom
+			// count (see coldWakeTemplates below) — the default probe IS the
+			// authoritative count, so it scales to total routed demand (bounded
+			// by max_active and the daemon's max_wakes_per_tick), matching the
+			// retired cold-pool-spawner's scale-to-want. A city-scoped pool's
+			// own target is already the city store, so it needs no extra probe.
+			//
+			// Gated on a healthy own rig store: when the rig store is missing or
+			// errored we stay partial and do NOT wake on cross-store demand —
+			// a rig executor cannot do its work while its rig store is
+			// unreachable, and the partial flag must keep suppressing drain
+			// decisions rather than be overridden by a spurious city-store wake.
+			if isCold && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil {
+				defaultScaleTargets = append(defaultScaleTargets, defaultScaleCheckTarget{template: template, store: store, storeKey: "city"})
+			}
 			continue
 		}
 		if store != nil && isCold {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -513,7 +513,14 @@ func buildDesiredStateWithSessionBeads(
 			// a rig executor cannot do its work while its rig store is
 			// unreachable, and the partial flag must keep suppressing drain
 			// decisions rather than be overridden by a spurious city-store wake.
-			if isCold && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil {
+			//
+			// ownTarget.store != store guards the case where the rig store
+			// aliases the city store (an unbound rig falling back to the city
+			// scope): a separate "city" group over the same store would
+			// double-count the same beads, since defaultScaleCheckCounts dedups
+			// per group, not across groups. Current store-map builders skip
+			// such rigs, so this is defense-in-depth against future callers.
+			if isCold && ownTarget.storeKey != "city" && ownTarget.store != nil && ownTarget.err == nil && ownTarget.store != store {
 				defaultScaleTargets = append(defaultScaleTargets, defaultScaleCheckTarget{template: template, store: store, storeKey: "city"})
 			}
 			continue

--- a/cmd/gc/scale_from_zero_no_scalecheck_test.go
+++ b/cmd/gc/scale_from_zero_no_scalecheck_test.go
@@ -174,3 +174,32 @@ func TestBuildDesiredState_ScaleFromZero_NoScaleCheck_MissingRigStoreNoCrossWake
 		t.Errorf("template should be marked partial when its rig store is missing")
 	}
 }
+
+// TestBuildDesiredState_ScaleFromZero_NoScaleCheck_AliasedRigStoreNoDoubleCount
+// guards the alias defense: if a rig store aliases the city store (the same
+// store object), the cross-store city probe must be skipped so the one routed
+// bead is counted once, not twice (defaultScaleCheckCounts dedups per group,
+// not across groups).
+func TestBuildDesiredState_ScaleFromZero_NoScaleCheck_AliasedRigStoreNoDoubleCount(t *testing.T) {
+	cfg, cityStore, _, qualified := newNoScaleCheckRigPoolCity(t)
+
+	if _, err := cityStore.Create(beads.Bead{
+		ID:       "shared-1",
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": qualified},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rig store IS the city store (aliased).
+	aliased := map[string]beads.Store{"rig-A": cityStore}
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		cityStore, aliased, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 1 {
+		t.Errorf("aliased-store demand = %d, want 1 (must not double-count the same bead)", got)
+	}
+}

--- a/cmd/gc/scale_from_zero_no_scalecheck_test.go
+++ b/cmd/gc/scale_from_zero_no_scalecheck_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// newNoScaleCheckRigPoolCity builds a city with a single rig pool agent that
+// has min=0 and NO custom scale_check (the default-probe path). Voxist's
+// executor and every specialist pool are shaped exactly this way.
+func newNoScaleCheckRigPoolCity(t *testing.T) (cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store, qualified string) {
+	t.Helper()
+	rigPath := t.TempDir() + "/rigs/rig-A"
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	maxSess := 5
+	minSess := 0
+	cfg = &config.City{
+		Agents: []config.Agent{
+			{
+				Name:              "executor",
+				MaxActiveSessions: &maxSess,
+				MinActiveSessions: &minSess,
+				// No ScaleCheck: default-probe pool.
+				Dir:      "rig-A",
+				Provider: "mock",
+			},
+		},
+		Rigs:      []config.Rig{{Name: "rig-A", Path: rigPath}},
+		Providers: map[string]config.ProviderSpec{"mock": {Command: "true"}},
+	}
+	cityStore = beads.NewMemStore()
+	rigStores = map[string]beads.Store{"rig-A": beads.NewMemStore()}
+	return cfg, cityStore, rigStores, "rig-A/executor"
+}
+
+// TestBuildDesiredState_ScaleFromZero_NoScaleCheck_CrossStore is the regression
+// guard for vp-s37 / the fleet-wide min=0 cold-spawn P1. A cold rig pool with
+// no custom scale_check must still cold-wake from routed demand that lives in
+// the CITY store (the vp-kvp cross-store delivery model) — not only from demand
+// in its own rig store. Before the fix the default probe read only the rig
+// store and this returned demand 0, so the pool never woke.
+func TestBuildDesiredState_ScaleFromZero_NoScaleCheck_CrossStore(t *testing.T) {
+	cfg, cityStore, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+	if _, err := cityStore.Create(beads.Bead{
+		ID:       "bead-city-1",
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": qualified},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		cityStore, rigStores, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 1 {
+		t.Errorf("cross-store cold-wake demand = %d, want 1 (city-store routed bead must wake the cold no-scale_check pool)", got)
+	}
+	if len(result.State) != 1 {
+		t.Errorf("desired sessions = %d, want 1", len(result.State))
+	}
+}
+
+// TestBuildDesiredState_ScaleFromZero_NoScaleCheck_OwnRigStillWakes guards that
+// the existing own-rig-store wake path is preserved by the change.
+func TestBuildDesiredState_ScaleFromZero_NoScaleCheck_OwnRigStillWakes(t *testing.T) {
+	cfg, cityStore, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+	if _, err := rigStores["rig-A"].Create(beads.Bead{
+		ID:       "bead-rig-1",
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": qualified},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		cityStore, rigStores, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 1 {
+		t.Errorf("own-rig cold-wake demand = %d, want 1", got)
+	}
+}
+
+// TestBuildDesiredState_ScaleFromZero_NoScaleCheck_NoDemandNoWake guards that
+// the cross-store probe does not spuriously wake a cold pool when there is no
+// routed demand anywhere — a min=0 pool with no ready work must stay at zero.
+func TestBuildDesiredState_ScaleFromZero_NoScaleCheck_NoDemandNoWake(t *testing.T) {
+	cfg, cityStore, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		cityStore, rigStores, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 0 {
+		t.Errorf("no-demand cold pool demand = %d, want 0 (must not spuriously wake)", got)
+	}
+	if len(result.State) != 0 {
+		t.Errorf("desired sessions = %d, want 0", len(result.State))
+	}
+}
+
+// TestBuildDesiredState_ScaleFromZero_NoScaleCheck_ScalesToCrossStoreWant guards
+// that a no-scale_check pool scales to the full routed-bead count (bounded by
+// max_active), not just 1. Unlike a custom-scale_check pool — where the probe
+// is clamped so it cannot override the custom count — the default probe IS the
+// authoritative count, so it scales to total routed demand across own-rig +
+// city, matching the retired cold-pool-spawner's scale-to-want behavior.
+func TestBuildDesiredState_ScaleFromZero_NoScaleCheck_ScalesToCrossStoreWant(t *testing.T) {
+	cfg, cityStore, rigStores, qualified := newNoScaleCheckRigPoolCity(t)
+
+	for _, id := range []string{"c1", "c2", "c3"} {
+		if _, err := cityStore.Create(beads.Bead{
+			ID:       id,
+			Status:   "open",
+			Type:     "task",
+			Metadata: map[string]string{"gc.routed_to": qualified},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		cityStore, rigStores, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 3 {
+		t.Errorf("cross-store demand = %d, want 3 (scale-to-want, bounded by max_active=5)", got)
+	}
+}
+
+// TestBuildDesiredState_ScaleFromZero_NoScaleCheck_MissingRigStoreNoCrossWake
+// guards the reconciliation with the missing-rig-store contract: when a cold
+// rig pool's own rig store is unreachable, cross-store (city) demand must NOT
+// wake it — a rig executor cannot do its work without its rig store, and the
+// partial flag must keep suppressing drain rather than be overridden by a
+// spurious city-store wake.
+func TestBuildDesiredState_ScaleFromZero_NoScaleCheck_MissingRigStoreNoCrossWake(t *testing.T) {
+	cfg, cityStore, _, qualified := newNoScaleCheckRigPoolCity(t)
+
+	if _, err := cityStore.Create(beads.Bead{
+		ID:       "bead-city-1",
+		Status:   "open",
+		Type:     "task",
+		Metadata: map[string]string{"gc.routed_to": qualified},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rig store absent (nil map): the own-rig target is unavailable.
+	result := buildDesiredStateWithSessionBeads(
+		"test-city", t.TempDir(), time.Now(), cfg, &localMockProvider{},
+		cityStore, nil, &sessionBeadSnapshot{}, nil, os.Stderr,
+	)
+
+	if got := result.ScaleCheckCounts[qualified]; got != 0 {
+		t.Errorf("demand = %d, want 0 (missing rig store must not cross-store-wake)", got)
+	}
+	if !result.ScaleCheckPartialTemplates[qualified] {
+		t.Errorf("template should be marked partial when its rig store is missing")
+	}
+}


### PR DESCRIPTION
## Problem

FR-S0.1 (#2819) added cross-store cold-wake, but **only for pools with a custom `scale_check`**. A rig pool with *no* `scale_check` uses the own-rig-only default probe (`defaultScaleCheckTargetForAgent` → single rig store). So routed demand queued in the **city store** (the cross-store delivery model — vp-kvp) never wakes a sleeping rig pool, because the probe can't see it while the pool is asleep.

This bit a live fleet hard: its `executor` and **every** specialist pool are `scope=rig` / `min=0` / **no `scale_check`**. Retiring the pack-side `cold-pool-spawner` (which *did* do cross-store want-counting) left every cold pool dead fleet-wide whenever its demand was cross-store. The order had to be re-activated as a stopgap.

## Fix

For a **cold** (`runningSessions==0 && min==0`) no-`scale_check` rig pool, add a **city-store** probe target alongside the own-rig target, so its demand reflects routed work in either store.

- **No clamp.** Unlike a custom-`scale_check` pool — where the probe is clamped to 1 so it can't override the custom count — the default probe *is* the authoritative count, so it scales to total routed demand (bounded by `max_active` and the daemon's `max_wakes_per_tick`), matching `cold-pool-spawner`'s scale-to-want.
- **Gated on a healthy own rig store.** When the rig store is missing/errored, the pool stays *partial* and is **not** cross-store-woken — a rig executor can't do its work while its rig store is unreachable, and the partial flag must keep suppressing drain rather than be overridden by a spurious city-store wake. (Preserves `TestBuildDesiredStateDefaultScaleCheckMissingRigStoreReportsZeroDemand`.)
- **Scope:** own-rig + city only (not all rigs). The routing key (`gc.routed_to`) is globally unique, and a rig pool's work realistically lives only in its own rig or the city dispatcher's store.

## Architecture note

This encodes invariant **(i)**: routed-work demand is discovered over the bead primitive across reachable stores — it's SDK infrastructure, not a per-role config concern. The rejected alternative (give each cold pool a custom `scale_check`) would re-create `cold-pool-spawner` in pack shell and violate SDK self-sufficiency (correct cold-wake must not require opt-in config). Once warm, the pool self-feeds cross-store via `gc hook` (#2877) + assigned-work resume.

**Deferred (phase 2):** cross-store scale-*up* while warm. The warm-path own-rig probe still doesn't see city-store demand, so cross-store work drains via the hook loop rather than parallelizing. Not needed to fix the wake regression.

This is the cross-store **wake** path; **#2877** is the cross-store **claim** path — together they make cross-store an SDK-owned capability. It lets `cold-pool-spawner` be retired again (the original vp-kbp intent).

## Tests
- cross-store wake (city-store routed bead → cold pool wakes)
- own-rig still wakes (regression guard)
- no demand → no wake (no spurious wake)
- scale-to-want (3 city beads → demand 3, bounded by `max_active`)
- missing rig store → no cross-store wake (reconciliation with the partial-store contract)

`golangci-lint` clean; full `BuildDesiredState|ScaleCheck|ScaleFromZero|DesiredState` suite green.
