### PR TITLE
fix(gastown): use split queries in startup prompts

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -1794,6 +1794,182 @@ func TestDogStartupPromptUsesSplitClaimFirstQueries(t *testing.T) {
 	}
 }
 
+func TestNonDogStartupPromptsUseAssignedInProgressQuery(t *testing.T) {
+	dir := exampleDir()
+	checks := []struct {
+		rel     string
+		start   string
+		end     string
+		want    string
+		forbid  []string
+		render  bool
+		agent   string
+		tmpl    string
+		rig     string
+		binding string
+	}{
+		{
+			rel:    "packs/gastown/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-mayor" }}`,
+			end:    `{{ define "propulsion-crew" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee="$GC_ALIAS" --status=in_progress`},
+		},
+		{
+			rel:    "packs/gastown/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-crew" }}`,
+			end:    `{{ define "propulsion-deacon" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`},
+		},
+		{
+			rel:    "packs/gastown/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-deacon" }}`,
+			end:    `{{ define "propulsion-witness" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee="$GC_ALIAS" --status=in_progress`},
+		},
+		{
+			rel:    "packs/gastown/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-witness" }}`,
+			end:    `{{ define "propulsion-polecat" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee="$GC_ALIAS" --status=in_progress`},
+		},
+		{
+			rel:    "packs/gastown/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-polecat" }}`,
+			end:    `{{ define "propulsion-refinery" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`},
+		},
+		{
+			rel:    "packs/gastown/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-refinery" }}`,
+			end:    `{{ define "propulsion-dog" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee="$GC_ALIAS" --status=in_progress`},
+		},
+		{
+			rel:    "packs/maintenance/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-mayor" }}`,
+			end:    `{{ define "propulsion-crew" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee=$GC_AGENT --status=in_progress`},
+		},
+		{
+			rel:    "packs/maintenance/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-crew" }}`,
+			end:    `{{ define "propulsion-deacon" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee=$GC_AGENT --status=in_progress`},
+		},
+		{
+			rel:    "packs/maintenance/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-deacon" }}`,
+			end:    `{{ define "propulsion-witness" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee=$GC_AGENT --status=in_progress`},
+		},
+		{
+			rel:    "packs/maintenance/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-witness" }}`,
+			end:    `{{ define "propulsion-polecat" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee=$GC_AGENT --status=in_progress`},
+		},
+		{
+			rel:    "packs/maintenance/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-polecat" }}`,
+			end:    `{{ define "propulsion-refinery" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee=$GC_AGENT --status=in_progress`},
+		},
+		{
+			rel:    "packs/maintenance/template-fragments/propulsion.template.md",
+			start:  `{{ define "propulsion-refinery" }}`,
+			end:    `{{ define "propulsion-dog" }}`,
+			want:   "{{ .AssignedInProgressQuery }}",
+			forbid: []string{`gc bd list --assignee=$GC_AGENT --status=in_progress`},
+		},
+		{
+			rel:     "packs/gastown/agents/polecat/prompt.template.md",
+			start:   "## Startup Protocol",
+			end:     "## Context Exhaustion",
+			want:    "{{ .AssignedInProgressQuery }}",
+			forbid:  []string{`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`},
+			render:  true,
+			agent:   "gastown/polecat",
+			tmpl:    "polecat",
+			rig:     "gastown",
+			binding: "gastown.",
+		},
+		{
+			rel:     "packs/gastown/agents/deacon/prompt.template.md",
+			start:   "## Startup Protocol",
+			end:     "**Hook ->",
+			want:    "{{ .AssignedInProgressQuery }}",
+			forbid:  []string{`gc bd list --assignee="$GC_ALIAS" --status=in_progress`},
+			render:  true,
+			agent:   "gastown/deacon",
+			tmpl:    "deacon",
+			rig:     "gastown",
+			binding: "gastown.",
+		},
+		{
+			rel:     "packs/gastown/agents/witness/prompt.template.md",
+			start:   "## Startup Protocol",
+			end:     "**Hook ->",
+			want:    "{{ .AssignedInProgressQuery }}",
+			forbid:  []string{`gc bd list --assignee="$GC_ALIAS" --status=in_progress`},
+			render:  true,
+			agent:   "gastown/witness",
+			tmpl:    "witness",
+			rig:     "gastown",
+			binding: "gastown.",
+		},
+		{
+			rel:     "packs/gastown/agents/refinery/prompt.template.md",
+			start:   "# Step 1: Check for an in-progress patrol wisp",
+			end:     "Then follow the formula.",
+			want:    "{{ .AssignedInProgressQuery }}",
+			forbid:  []string{`gc bd list --assignee="$GC_AGENT" --status=in_progress`},
+			render:  true,
+			agent:   "gastown/refinery",
+			tmpl:    "refinery",
+			rig:     "gastown",
+			binding: "gastown.",
+		},
+	}
+	for _, check := range checks {
+		t.Run(check.rel+"/"+check.start, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, check.rel))
+			if err != nil {
+				t.Fatalf("reading %s: %v", check.rel, err)
+			}
+			body := sectionBetween(t, string(data), check.start, check.end)
+			if !strings.Contains(body, check.want) {
+				t.Fatalf("%s section %q missing %q", check.rel, check.start, check.want)
+			}
+			for _, forbidden := range check.forbid {
+				if strings.Contains(body, forbidden) {
+					t.Fatalf("%s section %q hardcodes %q", check.rel, check.start, forbidden)
+				}
+			}
+			if !check.render {
+				return
+			}
+			rendered := renderGastownPromptForPack(t, check.rel, check.agent, check.tmpl, "demo", check.rig, check.binding)
+			if strings.Contains(rendered, check.want) {
+				t.Fatalf("%s rendered prompt still contains %q", check.rel, check.want)
+			}
+			if !strings.Contains(rendered, `bd list --include-ephemeral --status in_progress --assignee="$GC_SESSION_ID"`) {
+				t.Fatalf("%s rendered prompt missing compatibility-aware in-progress query: %q", check.rel, rendered)
+			}
+		})
+	}
+}
+
 func TestGastownRigTargetShellExpressionsRenderForRigAndHQ(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -55,7 +55,7 @@ Your formula: `mol-deacon-patrol`
 
 ```bash
 # Step 1: Check for assigned work
-gc bd list --assignee="$GC_ALIAS" --status=in_progress
+{{ .AssignedInProgressQuery }}
 
 # Step 2: Nothing? Check mail for attached work
 gc mail inbox

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -33,7 +33,7 @@ Stay in your worktree. Install deps there if needed (`npm install`). Commit and 
 
 Every commit must land on a per-bead branch named `polecat/<bead-id>`,
 created from `origin/<base_branch>`. The refinery finds work by bead
-assignment (`gc bd list --assignee=...`) and merges the branch recorded
+assignment and merges the branch recorded
 in the bead's `metadata.branch`, which must follow the `polecat/<bead-id>`
 convention. Commit on anything else (your agent home branch, a stray
 local checkout) and the handoff contract is broken — `metadata.branch`
@@ -135,7 +135,7 @@ Your formula: `mol-polecat-work`
 
 ```bash
 # Step 1a: Check for assigned in-progress work (already claimed — no race)
-gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress
+{{ .AssignedInProgressQuery }}
 
 # Step 1b: If none, find pool work
 {{ .WorkQuery }}

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -174,7 +174,7 @@ for ORPHAN in $ORPHANS; do
 done
 
 # Step 1: Check for an in-progress patrol wisp
-gc bd list --assignee="$GC_AGENT" --status=in_progress
+{{ .AssignedInProgressQuery }}
 
 # If none found, pour one (root-only — no child step beads) and assign it
 WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -154,7 +154,7 @@ Your formula: `mol-witness-patrol`
 
 ```bash
 # Step 1: Check for assigned work
-gc bd list --assignee="$GC_ALIAS" --status=in_progress
+{{ .AssignedInProgressQuery }}
 
 # Step 2: Nothing? Check mail for attached work
 gc mail inbox

--- a/examples/gastown/packs/gastown/template-fragments/propulsion.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/propulsion.template.md
@@ -43,7 +43,7 @@ The human assigned you work because they trust the engine. Honor that trust.
 As Mayor, you're the main drive shaft — if you stall, the whole town stalls.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. If work is hooked → EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty → `{{ .WorkQuery }}` to find new work
 4. Still nothing → **Process inbox to zero unread**, then wait for user instructions
@@ -78,7 +78,7 @@ waits.
 ## Your Role: A Piston
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. If work is hooked → EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty → `{{ .WorkQuery }}` to find new work
 4. Still nothing → Check mail, then wait for assignment
@@ -94,7 +94,7 @@ filed. The refinery can't merge branches you haven't pushed.
 ## Your Role: The Flywheel
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. If patrol wisp assigned → EXECUTE immediately (read formula steps)
 3. If nothing assigned → Create patrol wisp and execute
 
@@ -116,7 +116,7 @@ heartbeat stopped.
 ## Your Role: The Pressure Gauge
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. If patrol wisp assigned → EXECUTE immediately (read formula steps)
 3. If nothing assigned → Create patrol wisp and execute
 
@@ -138,7 +138,7 @@ agent. The pool thinks it's full. New work can't be dispatched.
 ## Your Role: A Piston
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. Work MUST be assigned (polecats always have work) → EXECUTE immediately
 3. If nothing assigned → ERROR: escalate to Witness
 
@@ -167,7 +167,7 @@ Work flows in as branches. Work flows out as merged commits on the target
 branch. Your throughput determines how fast the team's work becomes real.
 
 **Your startup behavior:**
-1. Check for an in-progress patrol wisp (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for an in-progress patrol wisp (`{{ .AssignedInProgressQuery }}`)
 2. If found → Resume where you left off (read formula steps, determine current position)
 3. If none → Pour a new wisp and assign it to yourself
 

--- a/examples/gastown/packs/maintenance/template-fragments/propulsion.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/propulsion.template.md
@@ -15,7 +15,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When you (or the human) assign work to yourself, the contract is:
 1. You will find it on your hook
-2. You will understand what it is (`gc bd list --assignee=$GC_AGENT --status=in_progress` / `gc bd show`)
+2. You will understand what it is (`{{ .AssignedInProgressQuery }}` / `gc bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -30,7 +30,7 @@ drive shaft - if you stall, the whole town stalls.
 - Work sits idle. Witnesses wait. Polecats idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for user instructions
@@ -63,7 +63,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When someone assigns work to you (or you assign to yourself), they trust that:
 1. You will find it on your hook
-2. You will understand what it is (`gc bd list --assignee=$GC_AGENT --status=in_progress` / `gc bd show`)
+2. You will understand what it is (`{{ .AssignedInProgressQuery }}` / `gc bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -77,7 +77,7 @@ run on politeness - they run on pistons firing. You are the piston.
 - Work sits idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for assignment
@@ -102,7 +102,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. If patrol wisp hooked -> EXECUTE immediately
 3. If hook empty -> Create patrol wisp and execute
 
@@ -127,7 +127,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. If patrol wisp hooked -> EXECUTE immediately
 3. If hook empty -> Create patrol wisp and execute
 
@@ -153,12 +153,12 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **The handoff contract:**
 When you were spawned, a molecule was hooked for you:
-1. You will find it via `gc bd list --assignee=$GC_AGENT --status=in_progress`
+1. You will find it via `{{ .AssignedInProgressQuery }}`
 2. You will understand the work (`gc bd show <issue>`)
 3. You will BEGIN IMMEDIATELY
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ .AssignedInProgressQuery }}`)
 2. Work MUST be assigned (polecats always have work) -> EXECUTE immediately
 3. If nothing assigned -> ERROR: escalate to Witness
 
@@ -183,7 +183,7 @@ Work flows in as branches. Work flows out as merged commits on the target
 branch. Your throughput determines how fast the team's work becomes real.
 
 **Your startup behavior:**
-1. Check for an in-progress patrol wisp (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for an in-progress patrol wisp (`{{ .AssignedInProgressQuery }}`)
 2. If found -> Resume where you left off
 3. If none -> Pour a new wisp and assign it to yourself
 


### PR DESCRIPTION
Post-merge follow-up for #3041.\n\nThis updates Gas Town startup prompt guidance so non-dog propulsion and agent-specific startup blocks use the compatibility-aware assigned in-progress query placeholder instead of hardcoded single-identifier bd probes. It also adds regression coverage for the affected prompt sections.\n\nVerification:\n- go test ./examples/gastown\n- go vet ./examples/gastown\n- git diff --check\n- pre-commit hook: go vet ./..., fast parallel tests, test/docsync\n\nBase: 15d3cc56520e43a3b198eae5caf9e2b67cbbb9f5\nHead: bfb8b053c1a8722444c0a7b18a24fcf2908f0217