### PR TITLE
fix(orders): per-order gate policy + de-noise so idempotent feeders don't starve (#2893)

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -469,8 +469,9 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			return trackingIndex.hasOpenTracking(storesForGate, storeKeysForGate, scoped)
 		})
 		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
-			continue
+			if m.gateFailClosed(ctx, a, scoped, err) {
+				continue
+			}
 		}
 		if hasOpenTracking {
 			continue
@@ -561,8 +562,9 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			return trackingIndex.hasOpenWork(storesForGate, storeKeysForGate, scoped, m.hasOpenWorkInStoresStrict, true)
 		})
 		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
-			continue
+			if m.gateFailClosed(ctx, a, scoped, err) {
+				continue
+			}
 		}
 		if hasOpenWork {
 			continue
@@ -1410,7 +1412,7 @@ func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName 
 		if isOrderRootOnlyWispCandidate(b) {
 			return true, nil
 		}
-		hasOpenDescendants, err := storeHasOpenDescendants(store, b.ID)
+		hasOpenDescendants, err := storeHasOpenDescendants(store, b.ID, isTransientNotificationBead)
 		if err != nil {
 			return false, fmt.Errorf("checking open descendants of wisp %s: %w", b.ID, err)
 		}
@@ -1432,10 +1434,27 @@ func isOrderRootOnlyWispCandidate(b beads.Bead) bool {
 	return b.Metadata["gc.kind"] == "wisp" && !beads.IsMoleculeType(b.Type)
 }
 
+// isTransientNotificationBead reports whether a bead is a short-lived delivery
+// chore (a nudge or a mail/message) rather than substantive order work. Such
+// beads inherit an order wisp's order-run label via the parent-child graph but
+// are reaped on their own TTL, so they must not keep the single-flight open-work
+// gate "open" and block the order from re-dispatching (vc-6qh1 #3).
+func isTransientNotificationBead(b beads.Bead) bool {
+	if b.Type == "message" {
+		return true
+	}
+	return b.Type == nudgeBeadType && beadLabelsContain(b.Labels, nudgeBeadLabel)
+}
+
 // storeHasOpenDescendants reports whether any transitive child of parentID is
 // non-closed. It includes closed intermediate nodes so nested molecule work
-// remains visible after a direct child step has completed.
-func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
+// remains visible after a direct child step has completed. When skip is
+// non-nil, an open child for which skip returns true is not treated as blocking
+// open work (its subtree is still traversed) — the gate passes
+// isTransientNotificationBead so lingering nudge/mail chores don't wedge it;
+// callers that want the raw descendant view (e.g. the stale-wisp sweeper) pass
+// nil.
+func storeHasOpenDescendants(store beads.Store, parentID string, skip func(beads.Bead) bool) (bool, error) {
 	seen := map[string]struct{}{parentID: {}}
 	queue := []string{parentID}
 	for len(queue) > 0 {
@@ -1458,7 +1477,7 @@ func storeHasOpenDescendants(store beads.Store, parentID string) (bool, error) {
 				continue
 			}
 			seen[c.ID] = struct{}{}
-			if c.Status != "closed" {
+			if c.Status != "closed" && (skip == nil || !skip(c)) {
 				return true, nil
 			}
 			queue = append(queue, c.ID)
@@ -1520,6 +1539,37 @@ func gateOpenWorkBounded(ctx context.Context, timeout time.Duration, scoped stri
 	case <-ctx.Done():
 		return false, fmt.Errorf("open-work gate for %s aborted: %w", scoped, ctx.Err())
 	}
+}
+
+// gateFailClosed decides whether an open-work gate error must block dispatch of
+// this order, and logs the error. The blanket "skip on any gate error" was
+// wrong: idempotent sweep orders (feeders, nudger, route-reclaim) are safe to
+// double-dispatch, so a gate that times out under store contention must not
+// starve them forever (vc-6qh1 #2'). Policy:
+//   - dispatch context done (shutdown / tick deadline): always block — there is
+//     no point dispatching into a canceled context.
+//   - otherwise (a per-order gate timeout): a non-idempotent order fails CLOSED
+//     (block, preserving single-flight); an idempotent order fails OPEN
+//     (dispatch anyway), since its re-run is a no-op.
+//
+// Failing open deliberately relaxes single-flight for idempotent orders: it may
+// dispatch while a prior run is still in flight. That is safe by the
+// idempotent contract (a duplicate run is a no-op) and each dispatch gets its
+// own tracking bead, so there is no shared-bead close race. It is also bounded
+// in practice — the cooldown trigger's rememberLastRun keeps an order from
+// re-firing within its interval, which is far longer than a feeder run — so a
+// genuinely concurrent second dispatch is rare, not per-tick. Re-adding an
+// open-work check here would reintroduce the vc-6qh1 starvation this fixes.
+func (m *memoryOrderDispatcher) gateFailClosed(ctx context.Context, a orders.Order, scoped string, err error) bool {
+	logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
+	if ctx.Err() != nil {
+		return true
+	}
+	if a.Idempotent {
+		logDispatchError(m.stderr, "gc: order dispatch: %s open-work gate failed but order is idempotent; dispatching anyway (vc-6qh1)", scoped)
+		return false
+	}
+	return true
 }
 
 // sweepOrphanedOrderTracking closes any open order-tracking beads left
@@ -1871,7 +1921,7 @@ func sweepStaleOrderWispSubtrees(store beads.Store, cutoff time.Time, onlyOrders
 			continue
 		}
 		if !isOrderRootOnlyWispCandidate(root) {
-			openDescendants, err := storeHasOpenDescendants(store, root.ID)
+			openDescendants, err := storeHasOpenDescendants(store, root.ID, nil)
 			if err != nil {
 				return 0, fmt.Errorf("checking stale wisp descendants of %s: %w", root.ID, err)
 			}

--- a/cmd/gc/order_dispatch_gate_policy_test.go
+++ b/cmd/gc/order_dispatch_gate_policy_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/orders"
+)
+
+// gateTimeoutStore makes the strict open-work gate scan (the
+// `order-run:`-labeled, !IncludeClosed, Limit==0 List that hasOpenWorkStrict
+// issues) block past the per-order gate timeout, reproducing the vc-6qh1 hang
+// where storeHasOpenDescendants exceeds its budget under Dolt contention. Only
+// that exact query shape is delayed; every other read stays fast.
+type gateTimeoutStore struct {
+	beads.Store
+	delay time.Duration
+}
+
+func (s *gateTimeoutStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.HasPrefix(query.Label, "order-run:") && !query.IncludeClosed && query.Limit == 0 {
+		time.Sleep(s.delay)
+	}
+	return s.Store.List(query)
+}
+
+// TestOrderDispatchIdempotentFailsOpenOnGateTimeout is the vc-6qh1 #2'
+// regression test: when the open-work gate exceeds its bound, an order marked
+// idempotent must dispatch anyway (fail open) while a non-idempotent order
+// must still be skipped (fail closed). Before the fix BOTH orders were skipped
+// on gate timeout, starving the feeders fleet-wide.
+func TestOrderDispatchIdempotentFailsOpenOnGateTimeout(t *testing.T) {
+	prev := orderGateTimeout
+	orderGateTimeout = 20 * time.Millisecond
+	defer func() { orderGateTimeout = prev }()
+
+	store := &gateTimeoutStore{Store: beads.NewMemStore(), delay: 300 * time.Millisecond}
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+
+	aa := []orders.Order{
+		{Name: "unrouted-feeder", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: true},
+		{Name: "merge-loop-sweep", Trigger: "cooldown", Interval: "1m", Exec: "true", Idempotent: false},
+	}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	ad.dispatch(context.Background(), t.TempDir(), now)
+	ad.drain(context.Background())
+
+	if got := trackingBeads(t, store, "order-run:unrouted-feeder"); len(got) == 0 {
+		t.Error("idempotent order should fail OPEN on gate timeout and dispatch (no tracking bead created)")
+	}
+	if got := trackingBeads(t, store, "order-run:merge-loop-sweep"); len(got) != 0 {
+		t.Errorf("non-idempotent order should fail CLOSED on gate timeout and skip; got %d tracking beads", len(got))
+	}
+}
+
+// TestGateFailClosed covers the gate-error decision logic directly: a per-order
+// gate timeout fails open only for idempotent orders, but a done dispatch
+// context (shutdown / tick deadline) always blocks, even for idempotent orders.
+func TestGateFailClosed(t *testing.T) {
+	m := &memoryOrderDispatcher{stderr: lockedStderr(&bytes.Buffer{})}
+	gateErr := errors.New("open-work gate for x timed out")
+
+	if m.gateFailClosed(context.Background(), orders.Order{Idempotent: true}, "feeder", gateErr) {
+		t.Error("idempotent order on a live-context gate timeout should fail OPEN (not blocked)")
+	}
+	if !m.gateFailClosed(context.Background(), orders.Order{Idempotent: false}, "sweep", gateErr) {
+		t.Error("non-idempotent order on gate timeout should fail CLOSED (blocked)")
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !m.gateFailClosed(canceledCtx, orders.Order{Idempotent: true}, "feeder", gateErr) {
+		t.Error("a canceled dispatch context must block even idempotent orders (no dispatch into a dead context)")
+	}
+}
+
+// TestStoreHasOpenDescendantsSkipsTransientNotifications covers vc-6qh1 #3: a
+// lingering open nudge/mail descendant must not keep the gate "open", but a real
+// open work descendant still counts, and the nil-skip (sweeper) path keeps the
+// original semantics where any open child counts.
+func TestStoreHasOpenDescendantsSkipsTransientNotifications(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "wisp root", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "nudge:abc",
+		Type:     nudgeBeadType,
+		Status:   "open",
+		ParentID: root.ID,
+		Labels:   []string{nudgeBeadLabel},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Gate semantics (skip notifications): a lone open nudge does not block.
+	if has, err := storeHasOpenDescendants(store, root.ID, isTransientNotificationBead); err != nil {
+		t.Fatal(err)
+	} else if has {
+		t.Error("a lone open nudge descendant must NOT count as open work (vc-6qh1 #3)")
+	}
+
+	// Sweeper semantics (nil skip): the open nudge still counts.
+	if has, err := storeHasOpenDescendants(store, root.ID, nil); err != nil {
+		t.Fatal(err)
+	} else if !has {
+		t.Error("nil skip must preserve original semantics: any open child counts")
+	}
+
+	// A real open work descendant still blocks even with the skip predicate.
+	if _, err := store.Create(beads.Bead{Title: "real work", Type: "task", Status: "open", ParentID: root.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if has, err := storeHasOpenDescendants(store, root.ID, isTransientNotificationBead); err != nil {
+		t.Fatal(err)
+	} else if !has {
+		t.Error("a real open work descendant must still count as open work")
+	}
+}

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -541,6 +541,7 @@ OrderOverride modifies a scanned order's scheduling fields and exec env.
 | `on` | string |  |  | On overrides the event trigger event type. |
 | `pool` | string |  |  | Pool overrides the target session config. |
 | `timeout` | string |  |  | Timeout overrides the per-order timeout. Go duration string. |
+| `idempotent` | boolean |  |  | Idempotent overrides whether the order's dispatch is safe to repeat. Idempotent orders fail open when the open-work gate times out (vc-6qh1). |
 | `env` | map[string]string |  |  | Env adds or overrides environment variables exported into an exec order's child process. |
 
 ## OrdersConfig

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1897,6 +1897,10 @@
           "type": "string",
           "description": "Timeout overrides the per-order timeout. Go duration string."
         },
+        "idempotent": {
+          "type": "boolean",
+          "description": "Idempotent overrides whether the order's dispatch is safe to repeat.\nIdempotent orders fail open when the open-work gate times out (vc-6qh1)."
+        },
         "env": {
           "additionalProperties": {
             "type": "string"

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1897,6 +1897,10 @@
           "type": "string",
           "description": "Timeout overrides the per-order timeout. Go duration string."
         },
+        "idempotent": {
+          "type": "boolean",
+          "description": "Idempotent overrides whether the order's dispatch is safe to repeat.\nIdempotent orders fail open when the open-work gate times out (vc-6qh1)."
+        },
         "env": {
           "additionalProperties": {
             "type": "string"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1751,6 +1751,9 @@ type OrderOverride struct {
 	Pool *string `toml:"pool,omitempty"`
 	// Timeout overrides the per-order timeout. Go duration string.
 	Timeout *string `toml:"timeout,omitempty"`
+	// Idempotent overrides whether the order's dispatch is safe to repeat.
+	// Idempotent orders fail open when the open-work gate times out (vc-6qh1).
+	Idempotent *bool `toml:"idempotent,omitempty"`
 	// Env adds or overrides environment variables exported into an exec
 	// order's child process.
 	Env map[string]string `toml:"env,omitempty"`

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -1408,6 +1408,9 @@ func mergeOrderOverride(dst *config.OrderOverride, src config.OrderOverride) {
 	if src.Timeout != nil {
 		dst.Timeout = src.Timeout
 	}
+	if src.Idempotent != nil {
+		dst.Idempotent = src.Idempotent
+	}
 	if len(src.Env) > 0 {
 		if dst.Env == nil {
 			dst.Env = make(map[string]string, len(src.Env))

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -2432,6 +2432,37 @@ func TestDeleteOrderOverride_NotFound(t *testing.T) {
 	}
 }
 
+func TestMergeOrderOverrideMergesIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, minimalCity())
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	tru := true
+	if err := ed.SetOrderOverride(config.OrderOverride{Name: "unrouted-feeder", Idempotent: &tru}); err != nil {
+		t.Fatalf("SetOrderOverride: %v", err)
+	}
+
+	// A partial merge that does not mention idempotent must PRESERVE it.
+	trig := "cooldown"
+	if err := ed.MergeOrderOverride(config.OrderOverride{Name: "unrouted-feeder", Trigger: &trig}); err != nil {
+		t.Fatalf("MergeOrderOverride: %v", err)
+	}
+	cfg := readTOML(t, path)
+	if got := cfg.Orders.Overrides[0].Idempotent; got == nil || !*got {
+		t.Fatalf("idempotent should be preserved through a partial merge, got %v", got)
+	}
+
+	// An explicit idempotent=false must be APPLIED through the merge.
+	fls := false
+	if err := ed.MergeOrderOverride(config.OrderOverride{Name: "unrouted-feeder", Idempotent: &fls}); err != nil {
+		t.Fatalf("MergeOrderOverride: %v", err)
+	}
+	cfg = readTOML(t, path)
+	if got := cfg.Orders.Overrides[0].Idempotent; got == nil || *got {
+		t.Fatalf("idempotent=false should be applied through merge, got %v", got)
+	}
+}
+
 func TestMergeOrderOverrideNormalizesLegacyGateToTriggerOnWrite(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, minimalCity()+`

--- a/internal/orderdiscovery/discovery.go
+++ b/internal/orderdiscovery/discovery.go
@@ -279,17 +279,18 @@ func overridesFromConfig(cfgOverrides []config.OrderOverride) []orders.Override 
 	out := make([]orders.Override, len(cfgOverrides))
 	for i, override := range cfgOverrides {
 		out[i] = orders.Override{
-			Name:     override.Name,
-			Rig:      override.Rig,
-			Enabled:  override.Enabled,
-			Trigger:  override.Trigger,
-			Interval: override.Interval,
-			Schedule: override.Schedule,
-			Check:    override.Check,
-			On:       override.On,
-			Pool:     override.Pool,
-			Timeout:  override.Timeout,
-			Env:      override.Env,
+			Name:       override.Name,
+			Rig:        override.Rig,
+			Enabled:    override.Enabled,
+			Trigger:    override.Trigger,
+			Interval:   override.Interval,
+			Schedule:   override.Schedule,
+			Check:      override.Check,
+			On:         override.On,
+			Pool:       override.Pool,
+			Timeout:    override.Timeout,
+			Idempotent: override.Idempotent,
+			Env:        override.Env,
 		}
 	}
 	return out

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -48,6 +48,14 @@ type Order struct {
 	Timeout string `toml:"timeout,omitempty"`
 	// Enabled controls whether the order is active. Defaults to true.
 	Enabled *bool `toml:"enabled,omitempty"`
+	// Idempotent marks an order whose dispatch is safe to repeat (a sweep/
+	// feeder whose re-run is a no-op, e.g. routes only unrouted work, or
+	// nudges an idle pool). Such orders fail OPEN when the single-flight /
+	// open-work gate times out under store contention: they dispatch anyway
+	// rather than be starved, since a duplicate run causes no harm
+	// (gastownhall/gascity#2893 / vc-6qh1). Non-idempotent orders (the
+	// default, false) keep failing CLOSED on gate timeout.
+	Idempotent bool `toml:"idempotent,omitempty"`
 	// Env is a map of environment variables exported into an exec
 	// order's child process. Use the `[order.env]` TOML table to
 	// override thresholds (e.g. GC_DOCTOR_LATENCY_WARN_S) without
@@ -88,6 +96,7 @@ type orderDecode struct {
 	Pool        string            `toml:"pool,omitempty"`
 	Timeout     string            `toml:"timeout,omitempty"`
 	Enabled     *bool             `toml:"enabled,omitempty"`
+	Idempotent  bool              `toml:"idempotent,omitempty"`
 	Env         map[string]string `toml:"env,omitempty"`
 }
 
@@ -109,6 +118,7 @@ func (d orderDecode) normalized() Order {
 		Pool:        d.Pool,
 		Timeout:     d.Timeout,
 		Enabled:     d.Enabled,
+		Idempotent:  d.Idempotent,
 		Env:         d.Env,
 	}
 }

--- a/internal/orders/order_test.go
+++ b/internal/orders/order_test.go
@@ -74,6 +74,23 @@ func TestParseInvalid(t *testing.T) {
 	}
 }
 
+func TestParseIdempotent(t *testing.T) {
+	on, err := Parse([]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"1m\"\nidempotent = true\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !on.Idempotent {
+		t.Error("Idempotent = false, want true")
+	}
+	off, err := Parse([]byte("[order]\nexec = \"true\"\ntrigger = \"cooldown\"\ninterval = \"1m\"\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if off.Idempotent {
+		t.Error("Idempotent = true, want false (default)")
+	}
+}
+
 func TestValidateCooldown(t *testing.T) {
 	a := Order{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h"}
 	if err := Validate(a); err != nil {

--- a/internal/orders/override.go
+++ b/internal/orders/override.go
@@ -18,17 +18,18 @@ const RigWildcard = "*"
 // Mirrors config.OrderOverride but lives in the orders package
 // to avoid a circular dependency.
 type Override struct {
-	Name     string
-	Rig      string
-	Enabled  *bool
-	Trigger  *string
-	Interval *string
-	Schedule *string
-	Check    *string
-	On       *string
-	Pool     *string
-	Timeout  *string
-	Env      map[string]string
+	Name       string
+	Rig        string
+	Enabled    *bool
+	Trigger    *string
+	Interval   *string
+	Schedule   *string
+	Check      *string
+	On         *string
+	Pool       *string
+	Timeout    *string
+	Idempotent *bool
+	Env        map[string]string
 }
 
 // ApplyOverrides applies each override to the matching order in aa.
@@ -150,6 +151,9 @@ func applyOverride(a *Order, ov *Override) {
 	}
 	if ov.Timeout != nil {
 		a.Timeout = *ov.Timeout
+	}
+	if ov.Idempotent != nil {
+		a.Idempotent = *ov.Idempotent
 	}
 	if len(ov.Env) > 0 {
 		if a.Env == nil {

--- a/internal/orders/override_test.go
+++ b/internal/orders/override_test.go
@@ -9,6 +9,18 @@ import (
 func boolPtr(b bool) *bool    { return &b }
 func strPtr(s string) *string { return &s }
 
+func TestApplyOverridesIdempotent(t *testing.T) {
+	t.Parallel()
+
+	aa := []Order{{Name: "unrouted-feeder"}}
+	if err := ApplyOverrides(aa, []Override{{Name: "unrouted-feeder", Idempotent: boolPtr(true)}}); err != nil {
+		t.Fatalf("ApplyOverrides: %v", err)
+	}
+	if !aa[0].Idempotent {
+		t.Error("override idempotent=true was not applied to the order")
+	}
+}
+
 func TestApplyOverrides(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes the order-dispatcher feeder-starvation in #2893 / vc-6qh1.

## Problem

The order dispatcher's open-work gate calls `hasOpenWorkStrict` → `storeHasOpenDescendants`, a BFS that issues one store query **per wisp-subtree node**. Under Dolt write contention that O(tree) walk exceeds `orderGateTimeout`, and the bounded gate (#2878) then returns an error so the order is **skipped** (`continue`).

For **idempotent sweep orders** (`unrouted-feeder`, `phase-feeder`, `route-reclaim`, `idle-pool-nudger`) the skip is effectively permanent — the gate keeps timing out — so newly-ready work is never auto-routed and idle pools are never nudged. On the reporting fleet, executors sat at 0 city-wide with `open-work gate … timed out after 8s; skipping this order` on every tick; only a manual `gc order run unrouted-feeder` (which bypasses the dispatch-loop gate) unblocked it.

## Fix

**#2' — per-order gate policy.** New order attribute **`idempotent`** (default `false`). On a gate error, `gateFailClosed` decides:
- dispatch context done (shutdown / tick deadline) → **block** (never dispatch into a dead context);
- else idempotent → **fail open** (dispatch anyway — a duplicate sweep run is a no-op);
- else → **fail closed** (skip, preserving single-flight).

Non-idempotent orders are **byte-for-byte unchanged**. Fail-open deliberately relaxes single-flight for idempotent orders; that's safe by the idempotent contract, each dispatch gets its own tracking bead (no shared-bead close race), and re-firing stays bounded by the cooldown trigger's last-run (far longer than a feeder run), so a genuinely concurrent second dispatch is rare, not per-tick.

**#3 — de-noise the gate.** `storeHasOpenDescendants` takes a `skip` predicate; the gate passes `isTransientNotificationBead` (mail `type=message`; nudge `type=chore` + `gc:nudge` label) so a lingering open nudge/mail descendant no longer wedges the single-flight gate. The stale-wisp sweeper passes `nil` to keep its exact semantics (verified: `skip==nil` reduces to the original condition).

Wired `idempotent` end-to-end: `orders.Order`/`orderDecode`/`normalized`, `orders.Override`/`applyOverride`, `config.OrderOverride`, `orderdiscovery.overridesFromConfig`, and `configedit.mergeOrderOverride` (so it survives API edit flows); schema regenerated.

## Not in this PR (follow-ups)
- **#1' durable root fix:** replace the O(tree) BFS with a flat, indexed `wisp_labels` membership `EXISTS` query (federation-safe, sub-linear). It's larger — it needs the molecule/convoy materializer to stamp the order-run membership label on every descendant (today only the root carries it). `DoltliteReadStore.HasOpenOrderRun` already provides the SQL-EXISTS half. Tracked separately.
- **Pack opt-in:** the consuming pack must set `idempotent = true` on its feeder orders to benefit (the mechanism ships here; the policy is config).

## Tests
- `TestOrderDispatchIdempotentFailsOpenOnGateTimeout` — slow-store forces a real gate timeout; idempotent dispatches, non-idempotent skips (RED before the fix).
- `TestGateFailClosed` — ctx-cancel always blocks; idempotent fails open; non-idempotent fails closed.
- `TestStoreHasOpenDescendantsSkipsTransientNotifications` — a lone open nudge doesn't block; a real open child still does; `nil` skip preserves original semantics.
- `TestParseIdempotent`, `TestApplyOverridesIdempotent`, `TestMergeOrderOverrideMergesIdempotent` — config wiring + edit-merge round-trip.

`golangci-lint` clean; full order-dispatch + orders/config/orderdiscovery/configedit + gendoc-freshness suites green.
