### PR TITLE
fix(reconciler): count assigned sessions for active scale slots

### DIFF
--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -200,7 +200,8 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			continue
 		}
 		active := collectActiveBeads(input.SessionBeads, template)
-		filled := 0
+		filled := countAssignedScaleSlots(input.SessionBeads, input.WorkBeads, input.NamedSessions, template)
+		unassignedActiveFilled := 0
 		for _, bead := range active {
 			if filled >= count {
 				break
@@ -210,8 +211,10 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			}
 			desired[bead.SessionName] = "scaled:demand"
 			filled++
+			unassignedActiveFilled++
 		}
 		creating := collectCreatingBeads(input.SessionBeads, template)
+		filled = unassignedActiveFilled
 		for _, bead := range creating {
 			if filled >= count {
 				break
@@ -444,6 +447,22 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	}
 
 	return result
+}
+
+func countAssignedScaleSlots(beads []AwakeSessionBead, workBeads []AwakeWorkBead, named []AwakeNamedSession, template string) int {
+	n := 0
+	for _, bead := range beads {
+		if bead.Template != template || bead.State == "closed" {
+			continue
+		}
+		if bead.NamedIdentity != "" || bead.ConfiguredNamedSession || bead.ManualSession {
+			continue
+		}
+		if sessionHasAssignedWork(workBeads, named, bead) {
+			n++
+		}
+	}
+	return n
 }
 
 func awakeAgentBaseName(name string) string {

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -201,7 +201,6 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 		active := collectActiveBeads(input.SessionBeads, template)
 		filled := countAssignedScaleSlots(input.SessionBeads, input.WorkBeads, input.NamedSessions, template)
-		unassignedActiveFilled := 0
 		for _, bead := range active {
 			if filled >= count {
 				break
@@ -211,10 +210,8 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			}
 			desired[bead.SessionName] = "scaled:demand"
 			filled++
-			unassignedActiveFilled++
 		}
 		creating := collectCreatingBeads(input.SessionBeads, template)
-		filled = unassignedActiveFilled
 		for _, bead := range creating {
 			if filled >= count {
 				break

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -832,6 +832,26 @@ func TestDrained_WithAssignedWork_Wakes(t *testing.T) {
 	assertReason(t, result, "polecat-mc-1", "assigned-work")
 }
 
+func TestScaleDemandCountsAssignedSessionBeforeKeepingIdlePoolSibling(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "gascity/gc.run-operator"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-old", SessionName: "gc__run-operator-mc-old", Template: "gascity/gc.run-operator", State: "active"},
+			{ID: "mc-new", SessionName: "gc__run-operator-mc-new", Template: "gascity/gc.run-operator", State: "active"},
+		},
+		WorkBeads: []AwakeWorkBead{{
+			ID: "ga-work", Assignee: "gc__run-operator-mc-new", Status: "in_progress",
+		}},
+		ScaleCheckCounts: map[string]int{"gascity/gc.run-operator": 1},
+		RunningSessions:  map[string]bool{"gc__run-operator-mc-old": true, "gc__run-operator-mc-new": true},
+		Now:              now,
+	})
+
+	assertAsleep(t, result, "gc__run-operator-mc-old")
+	assertAwake(t, result, "gc__run-operator-mc-new")
+	assertReason(t, result, "gc__run-operator-mc-new", "assigned-work")
+}
+
 func TestDrained_PinnedStaysAsleepUntilUndrained(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -580,7 +580,7 @@ func TestScaled_Demand2_OneActive(t *testing.T) {
 	assertAsleep(t, result, "polecat-mc-2") // asleep ephemerals not reused
 }
 
-func TestScaled_NewDemandDoesNotUseActiveAssignedSessions(t *testing.T) {
+func TestScaled_AssignedSessionsFillScaleSlotsBeforeCreatingSessions(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
 		SessionBeads: []AwakeSessionBead{
@@ -617,8 +617,7 @@ func TestScaled_NewDemandDoesNotUseActiveAssignedSessions(t *testing.T) {
 		suffix := strconv.Itoa(i)
 		assertAwake(t, result, "polecat-assigned-"+suffix)
 		assertReason(t, result, "polecat-assigned-"+suffix, "assigned-work")
-		assertAwake(t, result, "polecat-new-"+suffix)
-		assertReason(t, result, "polecat-new-"+suffix, "scaled:creating")
+		assertAsleep(t, result, "polecat-new-"+suffix)
 	}
 }
 
@@ -848,6 +847,26 @@ func TestScaleDemandCountsAssignedSessionBeforeKeepingIdlePoolSibling(t *testing
 	})
 
 	assertAsleep(t, result, "gc__run-operator-mc-old")
+	assertAwake(t, result, "gc__run-operator-mc-new")
+	assertReason(t, result, "gc__run-operator-mc-new", "assigned-work")
+}
+
+func TestScaleDemandCountsAssignedSessionBeforeKeepingStartPendingPoolSibling(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "gascity/gc.run-operator"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-pending", SessionName: "gc__run-operator-mc-pending", Template: "gascity/gc.run-operator", State: string(sessionpkg.StateStartPending)},
+			{ID: "mc-new", SessionName: "gc__run-operator-mc-new", Template: "gascity/gc.run-operator", State: "active"},
+		},
+		WorkBeads: []AwakeWorkBead{{
+			ID: "ga-work", Assignee: "gc__run-operator-mc-new", Status: "in_progress",
+		}},
+		ScaleCheckCounts: map[string]int{"gascity/gc.run-operator": 1},
+		RunningSessions:  map[string]bool{"gc__run-operator-mc-new": true},
+		Now:              now,
+	})
+
+	assertAsleep(t, result, "gc__run-operator-mc-pending")
 	assertAwake(t, result, "gc__run-operator-mc-new")
 	assertReason(t, result, "gc__run-operator-mc-new", "assigned-work")
 }


### PR DESCRIPTION
## Summary
- count anonymous assigned sessions before preserving idle active scale siblings
- keep existing behavior where assigned sessions do not consume already-creating sessions for new demand
- add a regression for the observed duplicate active run-operator race

## Tests
- go test ./cmd/gc -run 'TestScaleDemandCountsAssignedSessionBeforeKeepingIdlePoolSibling|TestScaled_NewDemandDoesNotUseActiveAssignedSessions|TestScaleCheck_WakesUpToCount|TestDrained_WithAssignedWork_Wakes' -count=1\n- go test ./cmd/gc -run 'Test.*Awake|TestScale|TestScaled|TestDrained|TestHeld|TestManual' -count=1\n- pre-commit hook: lint-changed, go vet ./..., scripts/test-local-parallel fast