### PR TITLE
fix(coordstore): use short socket path in chaos tests to fix macOS sun_path limit

### DIFF
--- a/internal/benchmarks/coordstore/chaos_process_reexec_test.go
+++ b/internal/benchmarks/coordstore/chaos_process_reexec_test.go
@@ -19,6 +19,23 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// shortSocketPath returns a unix-socket path under a short tmp dir (not
+// t.TempDir(), whose macOS /var/folders path overflows sun_path's 104-byte
+// limit). Registers cleanup.
+func shortSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "cx")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	p := filepath.Join(dir, name)
+	if len(p) >= 104 {
+		t.Fatalf("socket path too long for sun_path: %d >= 104: %s", len(p), p)
+	}
+	return p
+}
+
 func TestChaosProcessReexecKillAndRestart(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -26,7 +43,7 @@ func TestChaosProcessReexecKillAndRestart(t *testing.T) {
 	dir := t.TempDir()
 	process := coordstore.NewChaosProcess(coordstore.ChaosProcessConfig{
 		Backend:         "authorcore",
-		SocketPath:      filepath.Join(dir, "chaos.sock"),
+		SocketPath:      shortSocketPath(t, "chaos.sock"),
 		DataDir:         filepath.Join(dir, "store"),
 		AckedWritesPath: filepath.Join(dir, "acked-writes.jsonl"),
 	})
@@ -77,7 +94,7 @@ func TestChaosClientResetAckLedgerClearsSeedWrites(t *testing.T) {
 	dir := t.TempDir()
 	process := coordstore.NewChaosProcess(coordstore.ChaosProcessConfig{
 		Backend:    "authorcore",
-		SocketPath: filepath.Join(dir, "chaos.sock"),
+		SocketPath: shortSocketPath(t, "chaos.sock"),
 		DataDir:    filepath.Join(dir, "store"),
 	})
 	if err := process.Start(ctx); err != nil {

--- a/internal/benchmarks/coordstore/chaos_protocol_test.go
+++ b/internal/benchmarks/coordstore/chaos_protocol_test.go
@@ -12,11 +12,27 @@ import (
 	"time"
 )
 
+// shortSocketPath returns a unix-socket path under a short tmp dir (not
+// t.TempDir(), whose macOS /var/folders path overflows sun_path's 104-byte
+// limit). Registers cleanup.
+func shortSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "cx")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	p := filepath.Join(dir, name)
+	if len(p) >= 104 {
+		t.Fatalf("socket path too long for sun_path: %d >= 104: %s", len(p), p)
+	}
+	return p
+}
+
 func TestChaosClientForwardsCreateAndPersistsAckBeforeReturn(t *testing.T) {
 	ctx := context.Background()
-	dir := t.TempDir()
-	socketPath := filepath.Join(dir, "chaos.sock")
-	ledgerPath := filepath.Join(dir, "acked-writes.jsonl")
+	socketPath := shortSocketPath(t, "chaos.sock")
+	ledgerPath := filepath.Join(t.TempDir(), "acked-writes.jsonl")
 
 	ln, err := net.Listen("unix", socketPath)
 	if err != nil {
@@ -113,8 +129,7 @@ func assertAckLedgerLine(t *testing.T, path, method, id string) {
 
 func TestChaosClientMapsRemoteNotFoundToErrNotFound(t *testing.T) {
 	ctx := context.Background()
-	dir := t.TempDir()
-	socketPath := filepath.Join(dir, "chaos.sock")
+	socketPath := shortSocketPath(t, "chaos.sock")
 	ln, err := net.Listen("unix", socketPath)
 	if err != nil {
 		t.Fatalf("listen unix: %v", err)


### PR DESCRIPTION
## Summary
- macOS `sockaddr_un.sun_path` is 104 bytes; `t.TempDir()` under `/var/folders` exceeds this limit when combined with `chaos.sock`, causing `bind: invalid argument` on all Mac CI runs since 2026-06-01
- Adds `shortSocketPath(t, name)` helper that uses `/tmp`-based dirs (stays short on both macOS and Linux) with an explicit length guard
- Replaces all 4 chaos socket path sites in `chaos_protocol_test.go` and `chaos_process_reexec_test.go`; data and ledger dirs remain on `t.TempDir()`

## Test plan
- [x] `go test ./internal/benchmarks/coordstore/...` passes on Linux
- [x] All chaos socket paths enforced < 104 chars by helper guard
- [x] `go vet ./internal/benchmarks/coordstore/...` clean
- [ ] Mac Regression "Mac / make test" job goes green (requires macOS runner)

Fixes: ga-akq0rd

🤖 Generated with [Claude Code](https://claude.com/claude-code)