### PR TITLE
fix(proctable): rename liveScanRoot to liveScanGuard returning only error

### DIFF
--- a/internal/runtime/proctable/guard.go
+++ b/internal/runtime/proctable/guard.go
@@ -11,8 +11,8 @@ import (
 // sweep never reaps — the host's real agent processes.
 var scanRoot = "/proc"
 
-// liveScanRoot returns the procfs root to scan, or an error when a `go test`
-// run would scan the live "/proc" without injecting a fake root first.
+// liveScanGuard returns an error when a `go test` run would scan the live
+// "/proc" without injecting a fake root first.
 //
 // Why this guard exists (gastownhall/gascity#2839): the process-table scanner
 // reads the real /proc, and the orphan sweep SIGTERMs any runtime that is not
@@ -23,12 +23,12 @@ var scanRoot = "/proc"
 // fires on a machine running a real fleet. Refusing the live scan under test
 // closes that hole; a test that genuinely needs the scanner must inject a fake
 // procfs via SetScanRootForTesting.
-func liveScanRoot() (string, error) {
+func liveScanGuard() error {
 	if scanRoot == "/proc" && testing.Testing() {
-		return "", fmt.Errorf("proctable: refusing to scan the live /proc under go test; " +
+		return fmt.Errorf("proctable: refusing to scan the live /proc under go test; " +
 			"inject a fake procfs root with SetScanRootForTesting (guards against reaping real agent runtimes — see gastownhall/gascity#2839)")
 	}
-	return scanRoot, nil
+	return nil
 }
 
 // SetScanRootForTesting overrides the procfs root used by ScanBySessionID and

--- a/internal/runtime/proctable/scan_darwin.go
+++ b/internal/runtime/proctable/scan_darwin.go
@@ -16,7 +16,7 @@ import (
 // ScanBySessionID returns live agent root processes whose environment carries
 // GC_SESSION_ID equal to id. Empty id returns all roots with any GC_SESSION_ID.
 func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
-	if _, err := liveScanRoot(); err != nil {
+	if err := liveScanGuard(); err != nil {
 		return []runtime.LiveRuntime{}, err
 	}
 	records, err := psRecords()
@@ -62,7 +62,7 @@ func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
 // IsScanRoot reports whether pid is outside its GC_SESSION_ID parent's
 // envelope and should be treated as an agent root.
 func IsScanRoot(pid int) bool {
-	if _, err := liveScanRoot(); err != nil {
+	if err := liveScanGuard(); err != nil {
 		return false
 	}
 	if pid == 1 {

--- a/internal/runtime/proctable/scan_linux.go
+++ b/internal/runtime/proctable/scan_linux.go
@@ -18,18 +18,16 @@ import (
 // ScanBySessionID returns live agent root processes whose environment carries
 // GC_SESSION_ID equal to id. Empty id returns all roots with any GC_SESSION_ID.
 func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
-	root, err := liveScanRoot()
-	if err != nil {
+	if err := liveScanGuard(); err != nil {
 		return []runtime.LiveRuntime{}, err
 	}
-	return scanWithRoot(root, id)
+	return scanWithRoot(scanRoot, id)
 }
 
 // IsScanRoot reports whether pid is outside its GC_SESSION_ID parent's
 // envelope and should be treated as an agent root.
 func IsScanRoot(pid int) bool {
-	root, err := liveScanRoot()
-	if err != nil {
+	if err := liveScanGuard(); err != nil {
 		return false
 	}
 	if pid == 1 {
@@ -41,7 +39,7 @@ func IsScanRoot(pid int) bool {
 	if pid == os.Getpid() {
 		return false
 	}
-	env, err := parseEnvironFile(filepath.Join(root, strconv.Itoa(pid), "environ"))
+	env, err := parseEnvironFile(filepath.Join(scanRoot, strconv.Itoa(pid), "environ"))
 	if err != nil || len(env) == 0 {
 		return false
 	}
@@ -49,7 +47,7 @@ func IsScanRoot(pid int) bool {
 	if sessionID == "" {
 		return false
 	}
-	isRoot, err := isRootWithSessionID(root, pid, sessionID)
+	isRoot, err := isRootWithSessionID(scanRoot, pid, sessionID)
 	return err == nil && isRoot
 }
 


### PR DESCRIPTION
## Summary
- `golangci-lint` (unparam) flags `liveScanRoot() (string, error)` on darwin builds because all darwin callers discard the string return; Linux callers use it but Linux CI compiles `scan_linux.go` where the string IS used — so Mac CI is red, Linux CI is green
- Renames `liveScanRoot` → `liveScanGuard` returning only `error`; Linux callers now read the `scanRoot` package var directly
- Preserves the `#2839` protection behavior identically; no behavior change, no `//nolint` bypass

## Test plan
- [x] `go test ./internal/runtime/proctable/...` passes on Linux (guard still trips under go test)
- [x] `go vet ./internal/runtime/proctable/...` clean
- [ ] `GOOS=darwin golangci-lint run ./internal/runtime/proctable/...` → 0 issues (requires darwin)
- [ ] Mac Regression "Mac / quality" job goes green (requires macOS runner)

Fixes: ga-6n9hio

🤖 Generated with [Claude Code](https://claude.com/claude-code)