### PR TITLE
Emit city suspension events from API path

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -1062,16 +1062,28 @@ func (cs *controllerState) ResumeRig(name string) error {
 
 // SuspendCity sets workspace.suspended = true.
 func (cs *controllerState) SuspendCity() error {
-	return cs.mutateAndPoke(func() error {
+	if err := cs.mutateAndPoke(func() error {
 		return cs.editor.SuspendCity()
-	})
+	}); err != nil {
+		return err
+	}
+	if cs.eventProv != nil {
+		cs.eventProv.Record(events.Event{Type: events.CitySuspended, Actor: "gc"})
+	}
+	return nil
 }
 
 // ResumeCity sets workspace.suspended = false.
 func (cs *controllerState) ResumeCity() error {
-	return cs.mutateAndPoke(func() error {
+	if err := cs.mutateAndPoke(func() error {
 		return cs.editor.ResumeCity()
-	})
+	}); err != nil {
+		return err
+	}
+	if cs.eventProv != nil {
+		cs.eventProv.Record(events.Event{Type: events.CityResumed, Actor: "gc"})
+	}
+	return nil
 }
 
 // CreateAgent adds a new agent to city.toml.

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2713,6 +2713,81 @@ func TestControllerStateMutationsPokeController(t *testing.T) {
 	}
 }
 
+func TestControllerStateCitySuspensionRecordsEvents(t *testing.T) {
+	cases := []struct {
+		name          string
+		initial       func(*config.City)
+		mutate        func(*controllerState) error
+		wantSuspended bool
+		wantEventType string
+	}{
+		{
+			name: "suspend city",
+			mutate: func(cs *controllerState) error {
+				return cs.SuspendCity()
+			},
+			wantSuspended: true,
+			wantEventType: events.CitySuspended,
+		},
+		{
+			name: "resume city",
+			initial: func(cfg *config.City) {
+				cfg.Workspace.Suspended = true
+			},
+			mutate: func(cs *controllerState) error {
+				return cs.ResumeCity()
+			},
+			wantEventType: events.CityResumed,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs, tomlPath := newControllerStateMutationHarness(t)
+			ep := events.NewFake()
+			cs.eventProv = ep
+
+			if tc.initial != nil {
+				cfg, err := config.Load(fsys.OSFS{}, tomlPath)
+				if err != nil {
+					t.Fatalf("load config: %v", err)
+				}
+				tc.initial(cfg)
+				content, err := cfg.Marshal()
+				if err != nil {
+					t.Fatalf("marshal initial config: %v", err)
+				}
+				if err := os.WriteFile(tomlPath, content, 0o644); err != nil {
+					t.Fatalf("write initial config: %v", err)
+				}
+			}
+
+			if err := tc.mutate(cs); err != nil {
+				t.Fatalf("mutation failed: %v", err)
+			}
+
+			gotCfg, err := config.Load(fsys.OSFS{}, tomlPath)
+			if err != nil {
+				t.Fatalf("reload config: %v", err)
+			}
+			if gotCfg.Workspace.Suspended != tc.wantSuspended {
+				t.Fatalf("workspace.suspended = %v, want %v", gotCfg.Workspace.Suspended, tc.wantSuspended)
+			}
+
+			gotEvents, err := ep.List(events.Filter{})
+			if err != nil {
+				t.Fatalf("list events: %v", err)
+			}
+			if len(gotEvents) != 1 {
+				t.Fatalf("recorded events = %+v, want exactly one %s event", gotEvents, tc.wantEventType)
+			}
+			if gotEvents[0].Type != tc.wantEventType {
+				t.Fatalf("recorded event type = %q, want %q", gotEvents[0].Type, tc.wantEventType)
+			}
+		})
+	}
+}
+
 func TestControllerStateMutationErrorDoesNotPokeController(t *testing.T) {
 	cs, _ := newControllerStateMutationHarness(t)
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -2720,6 +2720,7 @@ func TestControllerStateCitySuspensionRecordsEvents(t *testing.T) {
 		mutate        func(*controllerState) error
 		wantSuspended bool
 		wantEventType string
+		wantActor     string
 	}{
 		{
 			name: "suspend city",
@@ -2728,6 +2729,7 @@ func TestControllerStateCitySuspensionRecordsEvents(t *testing.T) {
 			},
 			wantSuspended: true,
 			wantEventType: events.CitySuspended,
+			wantActor:     "gc",
 		},
 		{
 			name: "resume city",
@@ -2738,6 +2740,7 @@ func TestControllerStateCitySuspensionRecordsEvents(t *testing.T) {
 				return cs.ResumeCity()
 			},
 			wantEventType: events.CityResumed,
+			wantActor:     "gc",
 		},
 	}
 
@@ -2783,6 +2786,9 @@ func TestControllerStateCitySuspensionRecordsEvents(t *testing.T) {
 			}
 			if gotEvents[0].Type != tc.wantEventType {
 				t.Fatalf("recorded event type = %q, want %q", gotEvents[0].Type, tc.wantEventType)
+			}
+			if gotEvents[0].Actor != tc.wantActor {
+				t.Fatalf("recorded event actor = %q, want %q", gotEvents[0].Actor, tc.wantActor)
 			}
 		})
 	}

--- a/release-gates/ga-gsljgf-suspend-resume-events-gate.md
+++ b/release-gates/ga-gsljgf-suspend-resume-events-gate.md
@@ -1,0 +1,33 @@
+# Release Gate: ga-gsljgf suspend/resume API events
+
+Bead: ga-gsljgf
+Source bead: ga-4qo2xw
+Reviewed commits:
+- c52113665 fix(api): emit city.suspended and city.resumed events via API path
+- a0370f05c test(cmd/gc): cover city suspension event emission
+
+Branch gated: release/ga-gsljgf-suspend-resume-events
+Reviewed commit tip: a0370f05c
+
+Note: the original feature branch `fix/ga-ttpt2-suspend-resume-events` has advanced to 5f592af1b after review. This gate uses a release branch cut at the reviewed commit tip so unreviewed branch-tip changes are not included.
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-4qo2xw is closed with `Review: PASS` and explicitly lists both reviewed commits. Earlier deploy bead ga-vscud9 covered c52113665 only and is superseded by this two-commit review. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/api_state.go` emits `events.CitySuspended` after successful `SuspendCity()` mutation and `events.CityResumed` after successful `ResumeCity()` mutation. Both events use `Actor: "gc"` and existing `events.Event` envelope timestamps. `cmd/gc/api_state_test.go` verifies suspend/resume config mutation plus exactly one emitted event of the expected type. Event types are present in `events.KnownEventTypes` and registered with `events.NoPayload` in `internal/api/event_payloads.go`; this change does not add a reason payload. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestControllerStateCitySuspensionRecordsEvents\|TestControllerStateMutationsPokeController\|TestSuspendResume'` PASS. `go test ./internal/api -run TestEveryKnownEventTypeHasRegisteredPayload -count=1` PASS. `make test-fast-parallel` PASS. `go vet ./...` PASS. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for ga-4qo2xw report no blockers and no security concerns. No unresolved HIGH findings are recorded in the deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | Gate branch was clean before writing this checklist; the only deployer-authored change is this gate file, committed as the branch tip before PR creation. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` produced no conflicts for the reviewed commits. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and behavior: `cmd/gc` controller state suspend/resume event emission and its regression test. |
+
+## Commands Run
+
+```text
+go test ./cmd/gc -run 'TestControllerStateCitySuspensionRecordsEvents|TestControllerStateMutationsPokeController|TestSuspendResume'
+go test ./internal/api -run TestEveryKnownEventTypeHasRegisteredPayload -count=1
+make test-fast-parallel
+go vet ./...
+```

--- a/release-gates/ga-gsljgf-suspend-resume-events-gate.md
+++ b/release-gates/ga-gsljgf-suspend-resume-events-gate.md
@@ -1,25 +1,37 @@
-# Release Gate: ga-gsljgf suspend/resume API events
+# Release Gate: suspend/resume API events
 
-Bead: ga-gsljgf
-Source bead: ga-4qo2xw
-Reviewed commits:
+Deploy beads:
+- ga-gsljgf
+- ga-mar94u
+
+Source review beads:
+- ga-4qo2xw
+- ga-q6l40u
+
+Reviewed source commits:
 - c52113665 fix(api): emit city.suspended and city.resumed events via API path
 - a0370f05c test(cmd/gc): cover city suspension event emission
+- 5f592af1b test(cmd/gc): assert city suspension event actor
+
+Release branch commits:
+- c52113665 fix(api): emit city.suspended and city.resumed events via API path
+- a0370f05c test(cmd/gc): cover city suspension event emission
+- 616954f26 test(cmd/gc): assert city suspension event actor
 
 Branch gated: release/ga-gsljgf-suspend-resume-events
-Reviewed commit tip: a0370f05c
+Reviewed feature tip: 5f592af1b
 
-Note: the original feature branch `fix/ga-ttpt2-suspend-resume-events` has advanced to 5f592af1b after review. This gate uses a release branch cut at the reviewed commit tip so unreviewed branch-tip changes are not included.
+Note: the original feature branch `fix/ga-ttpt2-suspend-resume-events` advanced after the first deploy bead. The follow-up actor assertion was reviewed under ga-q6l40u and is included here as a cherry-pick on the existing release branch.
 
 ## Gate Checklist
 
 | # | Criterion | Result | Evidence |
 |---|-----------|--------|----------|
-| 1 | Review PASS present | PASS | Review bead ga-4qo2xw is closed with `Review: PASS` and explicitly lists both reviewed commits. Earlier deploy bead ga-vscud9 covered c52113665 only and is superseded by this two-commit review. |
-| 2 | Acceptance criteria met | PASS | `cmd/gc/api_state.go` emits `events.CitySuspended` after successful `SuspendCity()` mutation and `events.CityResumed` after successful `ResumeCity()` mutation. Both events use `Actor: "gc"` and existing `events.Event` envelope timestamps. `cmd/gc/api_state_test.go` verifies suspend/resume config mutation plus exactly one emitted event of the expected type. Event types are present in `events.KnownEventTypes` and registered with `events.NoPayload` in `internal/api/event_payloads.go`; this change does not add a reason payload. |
+| 1 | Review PASS present | PASS | Review bead ga-4qo2xw is closed with `Review: PASS` for c52113665 and a0370f05c. Review bead ga-q6l40u is closed with `REVIEW VERDICT: pass` for 5f592af1b. Earlier deploy bead ga-vscud9 covered c52113665 only and is superseded by this PR. |
+| 2 | Acceptance criteria met | PASS | `cmd/gc/api_state.go` emits `events.CitySuspended` after successful `SuspendCity()` mutation and `events.CityResumed` after successful `ResumeCity()` mutation. Both events use `Actor: "gc"` and existing `events.Event` envelope timestamps. `cmd/gc/api_state_test.go` verifies suspend/resume config mutation, exactly one emitted event of the expected type, and the `gc` actor for both operations. Event types are present in `events.KnownEventTypes` and registered with `events.NoPayload` in `internal/api/event_payloads.go`; this change does not add a reason payload. |
 | 3 | Tests pass | PASS | `go test ./cmd/gc -run 'TestControllerStateCitySuspensionRecordsEvents\|TestControllerStateMutationsPokeController\|TestSuspendResume'` PASS. `go test ./internal/api -run TestEveryKnownEventTypeHasRegisteredPayload -count=1` PASS. `make test-fast-parallel` PASS. `go vet ./...` PASS. |
-| 4 | No high-severity review findings open | PASS | Reviewer notes for ga-4qo2xw report no blockers and no security concerns. No unresolved HIGH findings are recorded in the deploy or review bead notes. |
-| 5 | Final branch is clean | PASS | Gate branch was clean before writing this checklist; the only deployer-authored change is this gate file, committed as the branch tip before PR creation. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for ga-4qo2xw and ga-q6l40u report no blockers, no findings, and no security concerns. No unresolved HIGH findings are recorded in the deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | Gate branch was clean before updating this checklist; the only deployer-authored changes are gate file commits, committed before PR update. |
 | 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` produced no conflicts for the reviewed commits. |
 | 7 | Single feature theme | PASS | The commit set touches one subsystem and behavior: `cmd/gc` controller state suspend/resume event emission and its regression test. |
 


### PR DESCRIPTION
## What this changes

City suspend and resume mutations that run through the API-backed controller now record `city.suspended` and `city.resumed` events after the config mutation succeeds. Operators get the same audit signal for API/supervisor-driven suspension changes that they already expect when investigating `workspace.suspended` through `gc events`.

The events use the existing typed event registry and event envelope: actor is `gc`, timestamps come from the event provider, and the payload remains `NoPayload`. Regression coverage now verifies the mutation result, emitted event type, event count, and actor for both suspend and resume.

## Review notes

- Main behavior is in `cmd/gc/api_state.go`; regression coverage is in `cmd/gc/api_state_test.go`.
- No OpenAPI, dashboard, config, or generated type changes are expected.
- This PR includes the reviewed follow-up actor assertion as a cherry-pick on the release branch.
- This does not add a reason field to suspend/resume events.

## Test plan

- [x] `go test ./cmd/gc -run 'TestControllerStateCitySuspensionRecordsEvents|TestControllerStateMutationsPokeController|TestSuspendResume'`
- [x] `go test ./internal/api -run TestEveryKnownEventTypeHasRegisteredPayload -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-gsljgf-suspend-resume-events-gate.md`](release-gates/ga-gsljgf-suspend-resume-events-gate.md)