### PR TITLE
Fix proctable scan guard Darwin lint

### DIFF
--- a/internal/runtime/proctable/guard.go
+++ b/internal/runtime/proctable/guard.go
@@ -11,8 +11,8 @@ import (
 // sweep never reaps — the host's real agent processes.
 var scanRoot = "/proc"
 
-// liveScanRoot returns the procfs root to scan, or an error when a `go test`
-// run would scan the live "/proc" without injecting a fake root first.
+// liveScanGuard returns an error when a `go test` run would scan the live
+// "/proc" without injecting a fake root first.
 //
 // Why this guard exists (gastownhall/gascity#2839): the process-table scanner
 // reads the real /proc, and the orphan sweep SIGTERMs any runtime that is not
@@ -23,12 +23,12 @@ var scanRoot = "/proc"
 // fires on a machine running a real fleet. Refusing the live scan under test
 // closes that hole; a test that genuinely needs the scanner must inject a fake
 // procfs via SetScanRootForTesting.
-func liveScanRoot() (string, error) {
+func liveScanGuard() error {
 	if scanRoot == "/proc" && testing.Testing() {
-		return "", fmt.Errorf("proctable: refusing to scan the live /proc under go test; " +
+		return fmt.Errorf("proctable: refusing to scan the live /proc under go test; " +
 			"inject a fake procfs root with SetScanRootForTesting (guards against reaping real agent runtimes — see gastownhall/gascity#2839)")
 	}
-	return scanRoot, nil
+	return nil
 }
 
 // SetScanRootForTesting overrides the procfs root used by ScanBySessionID and

--- a/internal/runtime/proctable/scan_darwin.go
+++ b/internal/runtime/proctable/scan_darwin.go
@@ -16,7 +16,7 @@ import (
 // ScanBySessionID returns live agent root processes whose environment carries
 // GC_SESSION_ID equal to id. Empty id returns all roots with any GC_SESSION_ID.
 func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
-	if _, err := liveScanRoot(); err != nil {
+	if err := liveScanGuard(); err != nil {
 		return []runtime.LiveRuntime{}, err
 	}
 	records, err := psRecords()
@@ -62,7 +62,7 @@ func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
 // IsScanRoot reports whether pid is outside its GC_SESSION_ID parent's
 // envelope and should be treated as an agent root.
 func IsScanRoot(pid int) bool {
-	if _, err := liveScanRoot(); err != nil {
+	if err := liveScanGuard(); err != nil {
 		return false
 	}
 	if pid == 1 {

--- a/internal/runtime/proctable/scan_linux.go
+++ b/internal/runtime/proctable/scan_linux.go
@@ -18,18 +18,16 @@ import (
 // ScanBySessionID returns live agent root processes whose environment carries
 // GC_SESSION_ID equal to id. Empty id returns all roots with any GC_SESSION_ID.
 func ScanBySessionID(id string) ([]runtime.LiveRuntime, error) {
-	root, err := liveScanRoot()
-	if err != nil {
+	if err := liveScanGuard(); err != nil {
 		return []runtime.LiveRuntime{}, err
 	}
-	return scanWithRoot(root, id)
+	return scanWithRoot(scanRoot, id)
 }
 
 // IsScanRoot reports whether pid is outside its GC_SESSION_ID parent's
 // envelope and should be treated as an agent root.
 func IsScanRoot(pid int) bool {
-	root, err := liveScanRoot()
-	if err != nil {
+	if err := liveScanGuard(); err != nil {
 		return false
 	}
 	if pid == 1 {
@@ -41,7 +39,7 @@ func IsScanRoot(pid int) bool {
 	if pid == os.Getpid() {
 		return false
 	}
-	env, err := parseEnvironFile(filepath.Join(root, strconv.Itoa(pid), "environ"))
+	env, err := parseEnvironFile(filepath.Join(scanRoot, strconv.Itoa(pid), "environ"))
 	if err != nil || len(env) == 0 {
 		return false
 	}
@@ -49,7 +47,7 @@ func IsScanRoot(pid int) bool {
 	if sessionID == "" {
 		return false
 	}
-	isRoot, err := isRootWithSessionID(root, pid, sessionID)
+	isRoot, err := isRootWithSessionID(scanRoot, pid, sessionID)
 	return err == nil && isRoot
 }
 

--- a/release-gates/ga-p6dhla-proctable-unparam-gate.md
+++ b/release-gates/ga-p6dhla-proctable-unparam-gate.md
@@ -1,0 +1,29 @@
+# Release Gate: ga-p6dhla proctable unparam
+
+Deploy bead: ga-p6dhla
+Source review bead: ga-1ej9i1
+Reviewed source commit: 9539e5bb2 fix(proctable): rename liveScanRoot to liveScanGuard returning only error
+Release branch commit: 9572b798e fix(proctable): rename liveScanRoot to liveScanGuard returning only error
+
+Branch gated: release/ga-p6dhla-proctable-unparam
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-1ej9i1 is closed with `REVIEW VERDICT: pass` for commit 9539e5bb2. |
+| 2 | Acceptance criteria met | PASS | `internal/runtime/proctable/guard.go` now exposes `liveScanGuard() error` instead of returning the scan-root string. Darwin and Linux scanner call sites compile against the narrower guard contract and read the package-level `scanRoot` directly where needed. The live `/proc` test guard behavior is unchanged. |
+| 3 | Tests pass | PASS | `go test ./internal/runtime/proctable -count=1` PASS. `GOOS=darwin go test -c ./internal/runtime/proctable -o /tmp/proctable-darwin-ga-p6dhla.test` PASS. `make test-fast-parallel` PASS. `go vet ./...` PASS. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for ga-1ej9i1 report `FINDINGS: none`, no security issues, and no blockers. No unresolved HIGH findings are recorded in deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | Release branch was clean before writing this checklist; the only deployer-authored change is this gate file, committed before PR creation. |
+| 6 | Branch diverges cleanly from main | PASS | Release branch was cut from current `origin/main`; `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` produced no conflicts. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and behavior: `internal/runtime/proctable` scan guard API cleanup for the Darwin lint path. |
+
+## Commands Run
+
+```text
+go test ./internal/runtime/proctable -count=1
+GOOS=darwin go test -c ./internal/runtime/proctable -o /tmp/proctable-darwin-ga-p6dhla.test
+make test-fast-parallel
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

The process-table scanner guard now exposes a narrower `liveScanGuard() error` helper instead of returning the scan root string. Linux and Darwin scanner paths continue to read the package-level scan root directly, while the guard still refuses live `/proc` scans under `go test` unless a fake root is injected.

This is not intended to change runtime behavior. It removes the unused return value that trips the Darwin lint path while keeping the real-process safety guard intact.

## Review notes

- Scope is limited to `internal/runtime/proctable`.
- No API, CLI output, config, schema, or dashboard changes are expected.
- This gated release PR supersedes source PR #3091 by adding the release gate file on a clean release branch.
- The release branch is cut from current `origin/main`; the reviewed source commit was cherry-picked onto it.

## Test plan

- [x] `go test ./internal/runtime/proctable -count=1`
- [x] `GOOS=darwin go test -c ./internal/runtime/proctable -o /tmp/proctable-darwin-ga-p6dhla.test`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-p6dhla-proctable-unparam-gate.md`](release-gates/ga-p6dhla-proctable-unparam-gate.md)