### PR TITLE
refactor(beads): standardize coordination store provider name on 'sqlite'

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -1191,13 +1191,23 @@ func canonicalCoordStoreDir(scopeRoot string) (string, error) {
 
 func providerIsCoordStore(provider string) bool {
 	switch strings.TrimSpace(provider) {
-	// "sqlite" (pure-Go SQLite via modernc.org/sqlite; also accepts the "sqlite-cgo" alias).
-	// Both resolve to SQLiteStore; "sqlite-cgo" is preserved for operator compatibility.
-	case "sqlite", "sqlite-cgo":
+	case "sqlite", "sqlite-cgo", "coordstore":
 		return true
 	default:
 		return false
 	}
+}
+
+// coordStoreDeprecationWarning returns a non-empty warning message when
+// provider is a deprecated alias for the "sqlite" coordination store.
+func coordStoreDeprecationWarning(provider string) string {
+	switch strings.TrimSpace(provider) {
+	case "sqlite-cgo":
+		return `beads provider "sqlite-cgo" is deprecated; use provider = "sqlite" in city.toml`
+	case "coordstore":
+		return `beads provider "coordstore" is deprecated; use provider = "sqlite" in city.toml`
+	}
+	return ""
 }
 
 func openStoreAtForCity(storePath, cityPath string) (beads.Store, error) {
@@ -1217,8 +1227,11 @@ func openStoreResultAtForCity(storePath, cityPath string) (beads.StoreOpenResult
 	scopeRoot := resolveStoreScopeRoot(runtimeCityPath, storePath)
 	provider := rawBeadsProviderForScope(scopeRoot, runtimeCityPath)
 	if providerIsCoordStore(provider) {
+		if msg := coordStoreDeprecationWarning(provider); msg != "" {
+			fmt.Fprintln(os.Stderr, "WARNING: "+msg)
+		}
 		store, err := openCoordStoreAt(scopeRoot, runtimeCityPath)
-		return beads.StoreOpenResult{Store: wrapStoreWithBeadPolicies(store, cfg), Diagnostic: beads.BeadsDiagnostic{Store: "SQLiteStore"}}, err
+		return beads.StoreOpenResult{Store: wrapStoreWithBeadPolicies(store, cfg), Diagnostic: beads.BeadsDiagnostic{Store: "sqlite"}}, err
 	}
 	if strings.HasPrefix(provider, "exec:") && !providerUsesBdStoreContract(provider) {
 		store, err := openExecStoreAtForCity(provider, scopeRoot, runtimeCityPath)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -262,7 +262,7 @@ BeadsConfig holds bead store settings.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `provider` | string |  | `bd` | Provider selects the bead store backend: "bd" (default), "file", or "exec:&lt;script&gt;" for a user-supplied script. |
+| `provider` | string |  | `bd` | Provider selects the bead store backend: "bd" (default, Dolt-backed), "file", "exec:&lt;script&gt;" for a user-supplied script, or "sqlite" for the built-in coordination store (pure-Go SQLite; use when Dolt is unavailable). "sqlite-cgo" is a deprecated alias for "sqlite". |
 | `backend` | string |  |  | Backend selects the bd storage engine when Provider is "bd". Empty defaults to "dolt"; T3Code uses "doltlite" for local dev stores. |
 | `event_hooks` | boolean |  | `true` | EventHooks controls installation of the bead event-forwarding hooks (.beads/hooks/on_create,on_update,on_close). Defaults to true. This config surface is staged ahead of the native bead-event support; current hook behavior remains unchanged until lifecycle code opts in. |
 | `bd_compatibility` | string |  |  | BDCompatibility selects the bd CLI semantics Gas City may rely on. Empty defaults to "bd-1.0.4", which keeps claimable work history-backed and avoids ready flags whose filtering is incomplete in bd 1.0.4. Enum: `bd-1.0.4`, `bd-1.0.5` |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -962,7 +962,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "Provider selects the bead store backend: \"bd\" (default), \"file\",\nor \"exec:\u003cscript\u003e\" for a user-supplied script.",
+          "description": "Provider selects the bead store backend: \"bd\" (default, Dolt-backed),\n\"file\", \"exec:\u003cscript\u003e\" for a user-supplied script, or \"sqlite\" for\nthe built-in coordination store (pure-Go SQLite; use when Dolt is\nunavailable). \"sqlite-cgo\" is a deprecated alias for \"sqlite\".",
           "default": "bd"
         },
         "backend": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -962,7 +962,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "Provider selects the bead store backend: \"bd\" (default), \"file\",\nor \"exec:\u003cscript\u003e\" for a user-supplied script.",
+          "description": "Provider selects the bead store backend: \"bd\" (default, Dolt-backed),\n\"file\", \"exec:\u003cscript\u003e\" for a user-supplied script, or \"sqlite\" for\nthe built-in coordination store (pure-Go SQLite; use when Dolt is\nunavailable). \"sqlite-cgo\" is a deprecated alias for \"sqlite\".",
           "default": "bd"
         },
         "backend": {

--- a/engdocs/architecture/beads.md
+++ b/engdocs/architecture/beads.md
@@ -47,20 +47,20 @@ storage backend.
 
 ## Architecture
 
-The bead store is a single interface with four implementations, selected
+The bead store is a single interface with five implementations, selected
 at startup by the `[beads].provider` config key or `GC_BEADS` env var.
 
 ```
-                        beads.Store (interface)
-                       /       |        \         \
-                      /        |         \         \
-               BdStore    FileStore   MemStore   exec.Store
-             (bd CLI)   (JSON file)  (in-mem)   (user script)
-                 |            |
-                 |        embeds MemStore
-                 |
-          ExecCommandRunner
-           (with telemetry)
+                           beads.Store (interface)
+                      /       |        \      \        \
+                     /        |         \      \        \
+              BdStore    FileStore   MemStore  exec.Store  SQLiteStore
+            (bd CLI)   (JSON file)  (in-mem) (user script) (coord store)
+                |            |
+                |        embeds MemStore
+                |
+         ExecCommandRunner
+          (with telemetry)
 ```
 
 **Provider resolution** (in `cmd/gc/main.go:openCityStore`):
@@ -69,8 +69,10 @@ at startup by the `[beads].provider` config key or `GC_BEADS` env var.
 2. `[beads].provider` in `city.toml`
 3. Default: `"bd"`
 
-Valid provider values: `"bd"` (BdStore), `"file"` (FileStore),
-`"exec:<script-path>"` (exec.Store).
+Valid provider values: `"bd"` (BdStore, default), `"file"` (FileStore),
+`"exec:<script-path>"` (exec.Store), `"sqlite"` (SQLiteStore — built-in
+coordination store using pure-Go SQLite; use when Dolt is unavailable).
+`"sqlite-cgo"` and `"coordstore"` are deprecated aliases for `"sqlite"`.
 
 ### Data Flow
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1179,8 +1179,10 @@ func (w *Workspace) SetLegacyDefaultRigIncludes(includes []string) {
 
 // BeadsConfig holds bead store settings.
 type BeadsConfig struct {
-	// Provider selects the bead store backend: "bd" (default), "file",
-	// or "exec:<script>" for a user-supplied script.
+	// Provider selects the bead store backend: "bd" (default, Dolt-backed),
+	// "file", "exec:<script>" for a user-supplied script, or "sqlite" for
+	// the built-in coordination store (pure-Go SQLite; use when Dolt is
+	// unavailable). "sqlite-cgo" is a deprecated alias for "sqlite".
 	Provider string `toml:"provider,omitempty" jsonschema:"default=bd"`
 	// Backend selects the bd storage engine when Provider is "bd".
 	// Empty defaults to "dolt"; T3Code uses "doltlite" for local dev stores.

--- a/release-gates/ga-g6nvci-sqlite-naming-standardization-gate.md
+++ b/release-gates/ga-g6nvci-sqlite-naming-standardization-gate.md
@@ -1,0 +1,41 @@
+# Release Gate: SQLite naming standardization
+
+Bead: ga-g6nvci
+Source review bead: ga-05bih7
+Original task bead: ga-32l2qm
+PR: https://github.com/gastownhall/gascity/pull/3094
+Branch: feat/ga-32l2qm-sqlite-naming
+Reviewed commit: a077ca4b5cb50733219fe7f878af83d4a06b3ba6
+Gate worktree: /tmp/gascity-deploy-ga-g6nvci.ojpRsW
+Gate date: 2026-06-04
+
+Note: docs/PROJECT_MANIFEST.md is not present in this checkout. This gate uses
+the release criteria from the deployer role prompt and TESTING.md.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-05bih7 is closed with `REVIEW PASS`; reviewer recorded PR #3094, branch `feat/ga-32l2qm-sqlite-naming`, commit `a077ca4b5cb50733219fe7f878af83d4a06b3ba6`. |
+| 2 | Acceptance criteria met | PASS | ga-32l2qm required one canonical SQLite coordination-store provider name, backward-compatible deprecated aliases, updated diagnostics, and updated docs/schema. The branch accepts `sqlite`, `sqlite-cgo`, and `coordstore`; emits warnings for deprecated aliases; reports `BeadsDiagnostic.Store` as `sqlite`; and updates config docs, generated schema, and architecture docs. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc/` passed. `go test ./internal/config/... -count=1` passed. `make check-schema` regenerated docs/schema and left the worktree clean. `make test-fast-parallel` passed all fast jobs. `go vet ./...` was clean. |
+| 4 | No high-severity review findings open | PASS | ga-05bih7 lists clean style/security/spec compliance and no blocking or HIGH findings. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` reported detached HEAD with no changes. The gate commit will contain only this file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reported clean merged results for `cmd/gc/main.go`, config docs/schema, and architecture docs with no conflict markers. The branch is behind `origin/main`; deployer did not rebase it. |
+| 7 | Single feature theme | PASS | Commit set is one naming/config-docs theme: standardize the SQLite coordination-store provider name on `sqlite` while preserving deprecated aliases. |
+
+## Commands
+
+```text
+go build ./cmd/gc/
+go test ./internal/config/... -count=1
+make check-schema
+make test-fast-parallel
+go vet ./...
+git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
+```
+
+## Decision
+
+PASS. The reviewed code is ready for merge-authority evaluation after the gate
+commit is pushed to the PR branch.


### PR DESCRIPTION
## What this changes

The SQLite coordination-store provider now has one canonical operator-facing name: `sqlite`. Config docs, generated schemas, status diagnostics, and architecture docs use that name consistently so it is clear this is the coordination store provider, not the beads issue-store backend.

Existing configs that use `sqlite-cgo` or `coordstore` still open the SQLite coordination store, but now emit a warning telling operators to move to `provider = "sqlite"`. The default provider remains `bd`; this does not switch any deployment to SQLite by default.

## Review notes

- `cmd/gc/main.go` preserves both deprecated aliases in `providerIsCoordStore` and adds the warning helper at store-open time.
- `BeadsDiagnostic.Store` reports `sqlite` instead of `SQLiteStore`, aligning status/API surfaces with the config value.
- `make check-schema` confirms the generated config reference and schema files are in sync.

## Test plan

- [x] `go build ./cmd/gc/`
- [x] `go test ./internal/config/... -count=1`
- [x] `make check-schema`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-g6nvci-sqlite-naming-standardization-gate.md`](release-gates/ga-g6nvci-sqlite-naming-standardization-gate.md)