### PR TITLE
feat(ci): add SQLite coordination store integration and acceptance job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,33 @@ jobs:
       - name: Run integration shard
         run: ${{ matrix.command }}
 
+  integration-sqlite-coordstore:
+    name: Integration / SQLite coordination store
+    needs:
+      - runner-policy
+      - changes
+    if: needs.changes.outputs.integration == 'true'
+    runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
+    timeout-minutes: 30
+    env:
+      DOLT_VERSION: "2.1.0"
+      BD_VERSION: "v1.0.5"
+      GC_BEADS: sqlite
+      GC_ACCEPTANCE_BEADS_PROVIDER: sqlite
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
+        with:
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "true"
+      - name: Install tools
+        run: make install-tools
+      - name: Integration tests (SQLite coordination store)
+        run: make test-integration-bdstore
+      - name: Acceptance tests (SQLite coordination store, Tier A)
+        run: make test-acceptance
+
   worker-core-claude:
     name: Worker core (Claude)
     needs:

--- a/.github/workflows/scripts/test_ci_suite_coverage.py
+++ b/.github/workflows/scripts/test_ci_suite_coverage.py
@@ -6,6 +6,7 @@ import yaml
 import ci_suite_coverage as cov
 
 CI_YML = Path(__file__).resolve().parents[1] / "ci.yml"
+INTEGRATION_SHARD = Path(__file__).resolve().parents[3] / "scripts" / "test-integration-shard"
 
 # Core substrates whose breakage ripples across every subsystem. Beads is the
 # universal persistence substrate, events the universal observation substrate,
@@ -204,6 +205,48 @@ class AcceptanceScenarioTests(unittest.TestCase):
         # if the integration filter had not matched on its own.
         integration_expr = _load_changes_job()["outputs"]["integration"]
         self.assertIn("shared", integration_expr)
+
+
+class SQLiteCoordinationStoreCoverageTests(unittest.TestCase):
+    def test_ci_runs_bdstore_and_acceptance_against_sqlite_coordination_store(self) -> None:
+        workflow = yaml.safe_load(CI_YML.read_text(encoding="utf-8"))
+        candidates = []
+        for name, job in workflow["jobs"].items():
+            rendered = yaml.safe_dump(job, sort_keys=True)
+            if "test-integration-bdstore" in rendered and "test-acceptance" in rendered:
+                candidates.append((name, rendered))
+
+        self.assertTrue(
+            candidates,
+            "CI must include one SQLite coordination-store job that runs both "
+            "`make test-integration-bdstore` and `make test-acceptance`.",
+        )
+
+        matching = [
+            name
+            for name, rendered in candidates
+            if "GC_BEADS" in rendered
+            and "sqlite" in rendered
+            and "GC_ACCEPTANCE_BEADS_PROVIDER" in rendered
+        ]
+        self.assertTrue(
+            matching,
+            "SQLite coordination-store CI job must pass GC_BEADS=sqlite to "
+            "the integration shard and GC_ACCEPTANCE_BEADS_PROVIDER=sqlite "
+            "to Tier A acceptance; candidates: "
+            + ", ".join(name for name, _ in candidates),
+        )
+
+    def test_integration_shard_preserves_gc_beads_override(self) -> None:
+        script = INTEGRATION_SHARD.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'GC_BEADS="${GC_BEADS-}"',
+            script,
+            "scripts/test-integration-shard scrubs the environment with env -i; "
+            "it must explicitly preserve GC_BEADS so the bdstore shard can run "
+            "against provider=sqlite in CI.",
+        )
 
 
 if __name__ == "__main__":

--- a/release-gates/ga-hzqeky-sqlite-ci-gates-gate.md
+++ b/release-gates/ga-hzqeky-sqlite-ci-gates-gate.md
@@ -1,0 +1,41 @@
+# Release Gate: SQLite coordination-store CI gates
+
+Bead: ga-hzqeky
+Source review bead: ga-2gstsc
+Original task bead: ga-v0mlen
+PR: https://github.com/gastownhall/gascity/pull/3095
+Branch: feat/ga-v0mlen-sqlite-ci-gates
+Reviewed commit: 8a044b8c26966e77f403ce4b1d122bf1ead08e2c
+Gate worktree: /tmp/gascity-deploy-ga-hzqeky.iCDBI5
+Gate date: 2026-06-04
+
+Note: docs/PROJECT_MANIFEST.md is not present in this checkout. This gate uses
+the release criteria from the deployer role prompt and TESTING.md.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-2gstsc is closed with `REVIEW PASS`; reviewer recorded PR #3095, branch `feat/ga-v0mlen-sqlite-ci-gates`, commit `8a044b8c26966e77f403ce4b1d122bf1ead08e2c`. |
+| 2 | Acceptance criteria met | PASS | ga-v0mlen required CI coverage for the SQLite coordination-store provider. The branch adds `integration-sqlite-coordstore`, preserves `GC_BEADS` through `scripts/test-integration-shard`, and lets Tier A acceptance helpers honor `GC_ACCEPTANCE_BEADS_PROVIDER=sqlite` while defaulting to `file`. |
+| 3 | Tests pass | PASS | `go build ./cmd/gc/` passed. `go test ./test/acceptance/helpers -run 'TestNewEnv(Default\|UsesAcceptance)' -count=1` passed. `python3 -m pytest .github/workflows/scripts/test_ci_suite_coverage.py` passed 21 tests. `make test-fast-parallel` passed all fast jobs. `go vet ./...` was clean. |
+| 4 | No high-severity review findings open | PASS | ga-2gstsc lists no blocking findings and explicitly calls the prior finding a false positive. No HIGH findings are open. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` reported detached HEAD with no changes. The gate commit will contain only this file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reported clean merged results for `.github/workflows/ci.yml`, workflow coverage tests, integration shard env preservation, and acceptance-helper files with no conflict markers. The branch is behind `origin/main`; deployer did not rebase it. |
+| 7 | Single feature theme | PASS | Commit set is one CI coverage theme: running integration and Tier A acceptance against the SQLite coordination-store provider. |
+
+## Commands
+
+```text
+go build ./cmd/gc/
+go test ./test/acceptance/helpers -run 'TestNewEnv(Default|UsesAcceptance)' -count=1
+python3 -m pytest .github/workflows/scripts/test_ci_suite_coverage.py
+make test-fast-parallel
+go vet ./...
+git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
+```
+
+## Decision
+
+PASS. The reviewed code is ready for merge-authority evaluation after the gate
+commit is pushed to the PR branch.

--- a/scripts/test-integration-shard
+++ b/scripts/test-integration-shard
@@ -47,6 +47,7 @@ run_go_test() {
     GOINSECURE="${GOINSECURE-}" \
     GOVCS="${GOVCS-}" \
     GOWORK="${GOWORK-}" \
+    GC_BEADS="${GC_BEADS-}" \
     GC_FAST_UNIT=0 \
     go test "$@"
 }

--- a/test/acceptance/helpers/env.go
+++ b/test/acceptance/helpers/env.go
@@ -91,7 +91,11 @@ func NewEnv(gcBinary, gcHome, runtimeDir string) *Env {
 	// tmuxtest.ConfigureProcessEnv with this same root before building Env.
 	e.vars["TMUX_TMPDIR"] = tmuxTmpDir
 	e.vars["GC_DOLT"] = "skip"
-	e.vars["GC_BEADS"] = "file"
+	beadsProvider := "file"
+	if override := os.Getenv("GC_ACCEPTANCE_BEADS_PROVIDER"); override != "" {
+		beadsProvider = override
+	}
+	e.vars["GC_BEADS"] = beadsProvider
 	e.vars["GC_SESSION"] = "subprocess"
 
 	return e

--- a/test/acceptance/helpers/env_test.go
+++ b/test/acceptance/helpers/env_test.go
@@ -29,3 +29,23 @@ func TestNewEnvInheritsClaudeGatewayVariables(t *testing.T) {
 		}
 	}
 }
+
+func TestNewEnvDefaultsBeadsProviderToFile(t *testing.T) {
+	t.Setenv("GC_ACCEPTANCE_BEADS_PROVIDER", "")
+
+	env := NewEnv("", t.TempDir(), t.TempDir())
+
+	if got := env.Get("GC_BEADS"); got != "file" {
+		t.Fatalf("NewEnv() GC_BEADS = %q, want %q", got, "file")
+	}
+}
+
+func TestNewEnvUsesAcceptanceBeadsProviderOverride(t *testing.T) {
+	t.Setenv("GC_ACCEPTANCE_BEADS_PROVIDER", "sqlite")
+
+	env := NewEnv("", t.TempDir(), t.TempDir())
+
+	if got := env.Get("GC_BEADS"); got != "sqlite" {
+		t.Fatalf("NewEnv() GC_BEADS = %q, want %q", got, "sqlite")
+	}
+}


### PR DESCRIPTION
## What this changes

CI now has a dedicated SQLite coordination-store job that runs the integration bdstore suite and Tier A acceptance suite with `GC_BEADS=sqlite` / `GC_ACCEPTANCE_BEADS_PROVIDER=sqlite`. That gives the SQLite provider an end-to-end CI path before it is used more broadly.

The branch also fixes the test harness plumbing needed for that job: `scripts/test-integration-shard` preserves `GC_BEADS` through its scrubbed environment, and acceptance helper `NewEnv()` still defaults to the file provider unless `GC_ACCEPTANCE_BEADS_PROVIDER` is set.

## Review notes

- The new workflow job is gated behind the existing integration change filter and uses the existing Ubuntu Gas City setup action.
- `GC_ACCEPTANCE_BEADS_PROVIDER` only controls the acceptance test environment; production city config is unchanged.
- The workflow contract is covered by `.github/workflows/scripts/test_ci_suite_coverage.py`, including the env preservation requirement.

## Test plan

- [x] `go build ./cmd/gc/`
- [x] `go test ./test/acceptance/helpers -run 'TestNewEnv(Default|UsesAcceptance)' -count=1`
- [x] `python3 -m pytest .github/workflows/scripts/test_ci_suite_coverage.py`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-hzqeky-sqlite-ci-gates-gate.md`](release-gates/ga-hzqeky-sqlite-ci-gates-gate.md)