### PR TITLE
Fix coordstore chaos socket paths on macOS

### DIFF
--- a/internal/benchmarks/coordstore/chaos_process_reexec_test.go
+++ b/internal/benchmarks/coordstore/chaos_process_reexec_test.go
@@ -19,6 +19,23 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// shortSocketPath returns a unix-socket path under a short tmp dir (not
+// t.TempDir(), whose macOS /var/folders path overflows sun_path's 104-byte
+// limit). Registers cleanup.
+func shortSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "cx")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	p := filepath.Join(dir, name)
+	if len(p) >= 104 {
+		t.Fatalf("socket path too long for sun_path: %d >= 104: %s", len(p), p)
+	}
+	return p
+}
+
 func TestChaosProcessReexecKillAndRestart(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -26,7 +43,7 @@ func TestChaosProcessReexecKillAndRestart(t *testing.T) {
 	dir := t.TempDir()
 	process := coordstore.NewChaosProcess(coordstore.ChaosProcessConfig{
 		Backend:         "authorcore",
-		SocketPath:      filepath.Join(dir, "chaos.sock"),
+		SocketPath:      shortSocketPath(t, "chaos.sock"),
 		DataDir:         filepath.Join(dir, "store"),
 		AckedWritesPath: filepath.Join(dir, "acked-writes.jsonl"),
 	})
@@ -77,7 +94,7 @@ func TestChaosClientResetAckLedgerClearsSeedWrites(t *testing.T) {
 	dir := t.TempDir()
 	process := coordstore.NewChaosProcess(coordstore.ChaosProcessConfig{
 		Backend:    "authorcore",
-		SocketPath: filepath.Join(dir, "chaos.sock"),
+		SocketPath: shortSocketPath(t, "chaos.sock"),
 		DataDir:    filepath.Join(dir, "store"),
 	})
 	if err := process.Start(ctx); err != nil {

--- a/internal/benchmarks/coordstore/chaos_protocol_test.go
+++ b/internal/benchmarks/coordstore/chaos_protocol_test.go
@@ -12,11 +12,27 @@ import (
 	"time"
 )
 
+// shortSocketPath returns a unix-socket path under a short tmp dir (not
+// t.TempDir(), whose macOS /var/folders path overflows sun_path's 104-byte
+// limit). Registers cleanup.
+func shortSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "cx")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	p := filepath.Join(dir, name)
+	if len(p) >= 104 {
+		t.Fatalf("socket path too long for sun_path: %d >= 104: %s", len(p), p)
+	}
+	return p
+}
+
 func TestChaosClientForwardsCreateAndPersistsAckBeforeReturn(t *testing.T) {
 	ctx := context.Background()
-	dir := t.TempDir()
-	socketPath := filepath.Join(dir, "chaos.sock")
-	ledgerPath := filepath.Join(dir, "acked-writes.jsonl")
+	socketPath := shortSocketPath(t, "chaos.sock")
+	ledgerPath := filepath.Join(t.TempDir(), "acked-writes.jsonl")
 
 	ln, err := net.Listen("unix", socketPath)
 	if err != nil {
@@ -113,8 +129,7 @@ func assertAckLedgerLine(t *testing.T, path, method, id string) {
 
 func TestChaosClientMapsRemoteNotFoundToErrNotFound(t *testing.T) {
 	ctx := context.Background()
-	dir := t.TempDir()
-	socketPath := filepath.Join(dir, "chaos.sock")
+	socketPath := shortSocketPath(t, "chaos.sock")
 	ln, err := net.Listen("unix", socketPath)
 	if err != nil {
 		t.Fatalf("listen unix: %v", err)

--- a/release-gates/ga-i7l0r4-chaos-socket-path-gate.md
+++ b/release-gates/ga-i7l0r4-chaos-socket-path-gate.md
@@ -1,0 +1,31 @@
+# Release Gate: ga-i7l0r4 chaos socket path
+
+Deploy bead: ga-i7l0r4
+Source review bead: ga-wo4rp5
+Reviewed source commit: 9e3c5d659 fix(coordstore): use short socket path in chaos tests to fix macOS sun_path limit
+Release branch commit: 7a90774d5 fix(coordstore): use short socket path in chaos tests to fix macOS sun_path limit
+
+Branch gated: release/ga-i7l0r4-chaos-socket-path
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-wo4rp5 is closed with `REVIEW VERDICT: pass` for commit 9e3c5d659. |
+| 2 | Acceptance criteria met | PASS | Both affected chaos test files now allocate Unix socket paths under a short `/tmp/cx*` directory instead of `t.TempDir()`, guard `sun_path` length with `len(p) >= 104`, and register cleanup through `t.Cleanup`. This fixes the macOS socket-path overflow while keeping each test package self-contained. |
+| 3 | Tests pass | PASS | `go test ./internal/benchmarks/coordstore -run 'TestChaos(ClientForwardsCreateAndPersistsAckBeforeReturn\|ClientMapsRemoteNotFoundToErrNotFound\|ProcessReexecKillAndRestart\|ClientResetAckLedgerClearsSeedWrites)' -count=1` PASS. `GOOS=darwin go test -c ./internal/benchmarks/coordstore -o /tmp/coordstore-chaos-darwin-ga-i7l0r4.test` PASS. First `make test-fast-parallel` hit a transient unrelated `internal/runtime/tmux` assertion; the exact failed test passed on rerun, and a second full `make test-fast-parallel` PASSed. `go vet ./...` PASS. |
+| 4 | No high-severity review findings open | PASS | Reviewer notes for ga-wo4rp5 report no blockers. The only finding is LOW/style, explicitly marked necessary duplication because the two files are in different Go packages. No unresolved HIGH findings are recorded in deploy or review bead notes. |
+| 5 | Final branch is clean | PASS | Release branch was clean before writing this checklist; the only deployer-authored change is this gate file, committed before PR creation. |
+| 6 | Branch diverges cleanly from main | PASS | Release branch was cut from current `origin/main`; `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` produced no conflicts. |
+| 7 | Single feature theme | PASS | The commit set touches one subsystem and behavior: coordstore chaos tests use short Unix socket paths that fit macOS `sun_path`. |
+
+## Commands Run
+
+```text
+go test ./internal/benchmarks/coordstore -run 'TestChaos(ClientForwardsCreateAndPersistsAckBeforeReturn|ClientMapsRemoteNotFoundToErrNotFound|ProcessReexecKillAndRestart|ClientResetAckLedgerClearsSeedWrites)' -count=1
+GOOS=darwin go test -c ./internal/benchmarks/coordstore -o /tmp/coordstore-chaos-darwin-ga-i7l0r4.test
+make test-fast-parallel
+go test ./internal/runtime/tmux -run TestDoStartSession_TreatsDeadlineAfterReadyAsSuccessWhenSessionAlive -count=1 -v
+make test-fast-parallel
+go vet ./...
+```


### PR DESCRIPTION
## What this changes

Coordstore chaos tests now create Unix socket paths under a short `/tmp/cx*` directory instead of `t.TempDir()`. That avoids macOS `sun_path` overflows from long `/var/folders/...` temp paths while keeping each test responsible for cleanup.

The helper fails fast if a generated socket path would still exceed the platform limit. Runtime coordstore behavior is unchanged; this is test infrastructure for the chaos client and process reexec tests.

## Review notes

- Scope is limited to `internal/benchmarks/coordstore` chaos tests.
- The short socket helper is duplicated in two files because those tests live in different Go packages in the same directory.
- No API, CLI, config, schema, dashboard, or production runtime changes are expected.
- This gated release PR supersedes source PR #3090 by adding the release gate file on a clean release branch.
- The release branch is cut from current `origin/main`; the reviewed source commit was cherry-picked onto it.

## Test plan

- [x] `go test ./internal/benchmarks/coordstore -run 'TestChaos(ClientForwardsCreateAndPersistsAckBeforeReturn|ClientMapsRemoteNotFoundToErrNotFound|ProcessReexecKillAndRestart|ClientResetAckLedgerClearsSeedWrites)' -count=1`\n- [x] `GOOS=darwin go test -c ./internal/benchmarks/coordstore -o /tmp/coordstore-chaos-darwin-ga-i7l0r4.test`\n- [x] `make test-fast-parallel` after rerun; first run hit an unrelated transient tmux test failure, and the exact failed test passed on rerun\n- [x] `go vet ./...`\n- [x] Release gate: [`release-gates/ga-i7l0r4-chaos-socket-path-gate.md`](release-gates/ga-i7l0r4-chaos-socket-path-gate.md)