### PR TITLE
fix(beads): retry SQLiteStore writes on SQLITE_BUSY contention

### DIFF
--- a/internal/beads/sqlite_store.go
+++ b/internal/beads/sqlite_store.go
@@ -23,6 +23,13 @@ const (
 	sqliteDefaultPrefix               = "gc"
 	sqliteDefaultRetentionPeriod      = 4 * time.Hour
 	sqliteDefaultRetentionSweepPeriod = 30 * time.Second
+
+	// sqliteBusyRetryAttempts is the number of application-level retries after
+	// the per-connection busy_timeout is exhausted. Each retry backs off by
+	// sqliteBusyRetryDelay before re-attempting, giving competing writers time
+	// to release the WAL write lock.
+	sqliteBusyRetryAttempts = 3
+	sqliteBusyRetryDelay    = 150 * time.Millisecond
 )
 
 // SQLiteStoreOptions configures the SQLite bead store.
@@ -53,6 +60,30 @@ func WithSQLiteStoreRetention(period, sweepInterval time.Duration) SQLiteStoreOp
 		o.retentionSweepInterval = sweepInterval
 		o.disableRetentionSweeper = sweepInterval <= 0
 	}
+}
+
+// isSQLiteBusy reports whether err is a SQLite write-contention error.
+// The modernc driver returns "database is locked (5) (SQLITE_BUSY)" when the
+// per-connection busy_timeout expires without acquiring the WAL write lock.
+func isSQLiteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLITE_BUSY") || strings.Contains(msg, "database is locked")
+}
+
+// retryOnBusy retries fn up to sqliteBusyRetryAttempts times when it returns
+// a SQLITE_BUSY error, backing off by sqliteBusyRetryDelay between attempts.
+// The busy_timeout PRAGMA already retries at the C layer for 5 s per call, so
+// each application-level retry is an additional 5 s+ window for the lock.
+func retryOnBusy(fn func() error) error {
+	err := fn()
+	for attempt := 0; attempt < sqliteBusyRetryAttempts && isSQLiteBusy(err); attempt++ {
+		time.Sleep(sqliteBusyRetryDelay)
+		err = fn()
+	}
+	return err
 }
 
 // SQLiteStore is a pure-Go SQLite-backed Store using modernc.org/sqlite.
@@ -269,26 +300,33 @@ func (s *SQLiteStore) CloseStore() error {
 
 // Create persists a new bead.
 func (s *SQLiteStore) Create(b Bead) (Bead, error) {
-	ctx := context.Background()
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return Bead{}, fmt.Errorf("sqlite create: begin tx: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-	stored := s.normalizeCreate(b)
-	if err := s.ensureCreateDoesNotExist(ctx, tx, stored.ID); err != nil {
-		return Bead{}, err
-	}
-	if err := s.upsertBeadTx(ctx, tx, stored); err != nil {
-		return Bead{}, err
-	}
-	for _, dep := range depsFromBeadFields(stored) {
-		if err := s.depAddTx(ctx, tx, dep.IssueID, dep.DependsOnID, dep.Type); err != nil {
-			return Bead{}, err
+	var stored Bead
+	err := retryOnBusy(func() error {
+		ctx := context.Background()
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("sqlite create: begin tx: %w", err)
 		}
-	}
-	if err := tx.Commit(); err != nil {
-		return Bead{}, fmt.Errorf("sqlite create: commit: %w", err)
+		defer tx.Rollback() //nolint:errcheck
+		stored = s.normalizeCreate(b)
+		if err := s.ensureCreateDoesNotExist(ctx, tx, stored.ID); err != nil {
+			return err
+		}
+		if err := s.upsertBeadTx(ctx, tx, stored); err != nil {
+			return err
+		}
+		for _, dep := range depsFromBeadFields(stored) {
+			if err := s.depAddTx(ctx, tx, dep.IssueID, dep.DependsOnID, dep.Type); err != nil {
+				return err
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("sqlite create: commit: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return Bead{}, err
 	}
 	return cloneBead(stored), nil
 }
@@ -435,66 +473,68 @@ func scanSQLiteBead(row sqliteScanner) (Bead, error) {
 
 // Update modifies fields of an existing bead.
 func (s *SQLiteStore) Update(id string, opts UpdateOpts) error {
-	ctx := context.Background()
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("sqlite update: begin tx: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-	b, err := s.getTx(ctx, tx, id)
-	if err != nil {
-		return err
-	}
-	if opts.Title != nil {
-		b.Title = *opts.Title
-	}
-	if opts.Status != nil {
-		b.Status = *opts.Status
-	}
-	if opts.Type != nil {
-		b.Type = *opts.Type
-	}
-	if opts.Priority != nil {
-		b.Priority = cloneIntPtr(opts.Priority)
-	}
-	if opts.Description != nil {
-		b.Description = *opts.Description
-	}
-	if opts.ParentID != nil {
-		b.ParentID = *opts.ParentID
-	}
-	if opts.Assignee != nil {
-		b.Assignee = *opts.Assignee
-	}
-	if len(opts.Metadata) > 0 {
-		if b.Metadata == nil {
-			b.Metadata = make(map[string]string, len(opts.Metadata))
+	return retryOnBusy(func() error {
+		ctx := context.Background()
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("sqlite update: begin tx: %w", err)
 		}
-		for k, v := range opts.Metadata {
-			b.Metadata[k] = v
+		defer tx.Rollback() //nolint:errcheck
+		b, err := s.getTx(ctx, tx, id)
+		if err != nil {
+			return err
 		}
-	}
-	if len(opts.Labels) > 0 {
-		b.Labels = append(b.Labels, opts.Labels...)
-	}
-	if len(opts.RemoveLabels) > 0 {
-		remove := make(map[string]bool, len(opts.RemoveLabels))
-		for _, label := range opts.RemoveLabels {
-			remove[label] = true
+		if opts.Title != nil {
+			b.Title = *opts.Title
 		}
-		filtered := b.Labels[:0]
-		for _, label := range b.Labels {
-			if !remove[label] {
-				filtered = append(filtered, label)
+		if opts.Status != nil {
+			b.Status = *opts.Status
+		}
+		if opts.Type != nil {
+			b.Type = *opts.Type
+		}
+		if opts.Priority != nil {
+			b.Priority = cloneIntPtr(opts.Priority)
+		}
+		if opts.Description != nil {
+			b.Description = *opts.Description
+		}
+		if opts.ParentID != nil {
+			b.ParentID = *opts.ParentID
+		}
+		if opts.Assignee != nil {
+			b.Assignee = *opts.Assignee
+		}
+		if len(opts.Metadata) > 0 {
+			if b.Metadata == nil {
+				b.Metadata = make(map[string]string, len(opts.Metadata))
+			}
+			for k, v := range opts.Metadata {
+				b.Metadata[k] = v
 			}
 		}
-		b.Labels = filtered
-	}
-	b.UpdatedAt = time.Now()
-	if err := s.upsertBeadTx(ctx, tx, b); err != nil {
-		return err
-	}
-	return tx.Commit()
+		if len(opts.Labels) > 0 {
+			b.Labels = append(b.Labels, opts.Labels...)
+		}
+		if len(opts.RemoveLabels) > 0 {
+			remove := make(map[string]bool, len(opts.RemoveLabels))
+			for _, label := range opts.RemoveLabels {
+				remove[label] = true
+			}
+			filtered := b.Labels[:0]
+			for _, label := range b.Labels {
+				if !remove[label] {
+					filtered = append(filtered, label)
+				}
+			}
+			b.Labels = filtered
+		}
+		b.UpdatedAt = time.Now()
+		if err := s.upsertBeadTx(ctx, tx, b); err != nil {
+			return err
+		}
+		return tx.Commit()
+	})
 }
 
 func (s *SQLiteStore) getTx(ctx context.Context, tx *sql.Tx, id string) (Bead, error) {
@@ -776,35 +816,39 @@ func (s *SQLiteStore) Tx(_ string, fn func(tx Tx) error) error {
 
 // Delete permanently removes a bead and its indexed rows.
 func (s *SQLiteStore) Delete(id string) error {
-	tx, err := s.db.BeginTx(context.Background(), nil)
-	if err != nil {
-		return fmt.Errorf("sqlite delete: begin tx: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-	res, err := tx.Exec(`DELETE FROM beads WHERE id=?`, id)
-	if err != nil {
-		return fmt.Errorf("deleting bead %q: %w", id, err)
-	}
-	if n, _ := res.RowsAffected(); n == 0 {
-		return fmt.Errorf("deleting bead %q: %w", id, ErrNotFound)
-	}
-	if _, err := tx.Exec(`DELETE FROM deps WHERE issue_id=? OR depends_on_id=?`, id, id); err != nil {
-		return fmt.Errorf("deleting bead %q deps: %w", id, err)
-	}
-	return tx.Commit()
+	return retryOnBusy(func() error {
+		tx, err := s.db.BeginTx(context.Background(), nil)
+		if err != nil {
+			return fmt.Errorf("sqlite delete: begin tx: %w", err)
+		}
+		defer tx.Rollback() //nolint:errcheck
+		res, err := tx.Exec(`DELETE FROM beads WHERE id=?`, id)
+		if err != nil {
+			return fmt.Errorf("deleting bead %q: %w", id, err)
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return fmt.Errorf("deleting bead %q: %w", id, ErrNotFound)
+		}
+		if _, err := tx.Exec(`DELETE FROM deps WHERE issue_id=? OR depends_on_id=?`, id, id); err != nil {
+			return fmt.Errorf("deleting bead %q deps: %w", id, err)
+		}
+		return tx.Commit()
+	})
 }
 
 // DepAdd records a dependency edge.
 func (s *SQLiteStore) DepAdd(issueID, dependsOnID, depType string) error {
-	tx, err := s.db.BeginTx(context.Background(), nil)
-	if err != nil {
-		return fmt.Errorf("sqlite dep add: begin tx: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-	if err := s.depAddTx(context.Background(), tx, issueID, dependsOnID, depType); err != nil {
-		return err
-	}
-	return tx.Commit()
+	return retryOnBusy(func() error {
+		tx, err := s.db.BeginTx(context.Background(), nil)
+		if err != nil {
+			return fmt.Errorf("sqlite dep add: begin tx: %w", err)
+		}
+		defer tx.Rollback() //nolint:errcheck
+		if err := s.depAddTx(context.Background(), tx, issueID, dependsOnID, depType); err != nil {
+			return err
+		}
+		return tx.Commit()
+	})
 }
 
 func (s *SQLiteStore) depAddTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID, depType string) error {
@@ -823,8 +867,10 @@ func (s *SQLiteStore) depAddTx(ctx context.Context, tx *sql.Tx, issueID, depends
 
 // DepRemove removes a dependency edge.
 func (s *SQLiteStore) DepRemove(issueID, dependsOnID string) error {
-	_, err := s.db.ExecContext(context.Background(), `DELETE FROM deps WHERE issue_id=? AND depends_on_id=?`, issueID, dependsOnID)
-	return err
+	return retryOnBusy(func() error {
+		_, err := s.db.ExecContext(context.Background(), `DELETE FROM deps WHERE issue_id=? AND depends_on_id=?`, issueID, dependsOnID)
+		return err
+	})
 }
 
 // DepList returns dependency edges for a bead.

--- a/internal/beads/sqlite_store_test.go
+++ b/internal/beads/sqlite_store_test.go
@@ -1,6 +1,8 @@
 package beads
 
 import (
+	"errors"
+	"fmt"
 	"runtime"
 	"testing"
 	"time"
@@ -230,4 +232,86 @@ func readyIDs(rows []Bead) map[string]bool {
 		ids[row.ID] = true
 	}
 	return ids
+}
+
+func TestIsSQLiteBusy(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("some other error"), false},
+		{errors.New("database is locked (5) (SQLITE_BUSY)"), true},
+		{errors.New("SQLITE_BUSY (5)"), true},
+		{errors.New("database is locked"), true},
+		{fmt.Errorf("sqlite update: begin tx: %w", errors.New("database is locked (5) (SQLITE_BUSY)")), true},
+	}
+	for _, tc := range cases {
+		if got := isSQLiteBusy(tc.err); got != tc.want {
+			t.Errorf("isSQLiteBusy(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestRetryOnBusy(t *testing.T) {
+	t.Run("succeeds_immediately", func(t *testing.T) {
+		calls := 0
+		err := retryOnBusy(func() error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("retries_on_busy_then_succeeds", func(t *testing.T) {
+		calls := 0
+		busyErr := errors.New("database is locked (5) (SQLITE_BUSY)")
+		err := retryOnBusy(func() error {
+			calls++
+			if calls < 3 {
+				return busyErr
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("expected 3 calls, got %d", calls)
+		}
+	})
+
+	t.Run("exhausts_retries_and_returns_busy_error", func(t *testing.T) {
+		calls := 0
+		busyErr := errors.New("database is locked (5) (SQLITE_BUSY)")
+		err := retryOnBusy(func() error {
+			calls++
+			return busyErr
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if calls != 1+sqliteBusyRetryAttempts {
+			t.Fatalf("expected %d calls, got %d", 1+sqliteBusyRetryAttempts, calls)
+		}
+	})
+
+	t.Run("does_not_retry_non_busy_error", func(t *testing.T) {
+		calls := 0
+		err := retryOnBusy(func() error {
+			calls++
+			return errors.New("something else went wrong")
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 call, got %d", calls)
+		}
+	})
 }

--- a/release-gates/ga-qz1z1o-sqlite-busy-retry-gate.md
+++ b/release-gates/ga-qz1z1o-sqlite-busy-retry-gate.md
@@ -1,0 +1,40 @@
+# Release Gate: SQLite write-contention retry fix
+
+Bead: ga-qz1z1o
+Source review bead: ga-8hiqq8
+Original bug bead: ga-8fxkvd
+PR: https://github.com/gastownhall/gascity/pull/3098
+Branch: fix/ga-8fxkvd-sqlite-busy-retry
+Reviewed commit: 6d4eb8fe23f8406d5426ba328503eef74e3c934b
+Gate worktree: /tmp/gascity-deploy-ga-qz1z1o.k1YWk0
+Gate date: 2026-06-04
+
+Note: docs/PROJECT_MANIFEST.md is not present in this checkout. This gate uses
+the release criteria from the deployer role prompt and TESTING.md.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-8hiqq8 is closed with `REVIEW VERDICT: PASS`; reviewer recorded PR #3098, branch `fix/ga-8fxkvd-sqlite-busy-retry`, commit `6d4eb8fe23f8406d5426ba328503eef74e3c934b`. |
+| 2 | Acceptance criteria met | PASS | ga-8fxkvd required SQLite write operations to tolerate `SQLITE_BUSY` / `database is locked` contention. The change adds `isSQLiteBusy` and `retryOnBusy`, wraps SQLiteStore write paths (`Create`, `Update`, `Delete`, `DepAdd`, `DepRemove`; delegation covers related close/metadata paths), and adds helper/store tests. |
+| 3 | Tests pass | PASS | `go test ./internal/beads/... -run 'TestIsSQLiteBusy\|TestRetryOnBusy\|TestSQLiteStore' -count=1` passed. `make test-fast-parallel` passed all fast jobs. `go vet ./internal/beads/...` and `go vet ./...` were clean. |
+| 4 | No high-severity review findings open | PASS | ga-8hiqq8 lists two LOW findings and one INFO finding; no HIGH findings. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` reported detached HEAD with no changes. The gate commit will contain only this file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reported clean merged results for the touched SQLite store files with no conflict markers. The branch is behind `origin/main`; deployer did not rebase it. |
+| 7 | Single feature theme | PASS | Commit set touches one subsystem and theme: SQLiteStore write-contention retry behavior in `internal/beads/sqlite_store.go` and tests. |
+
+## Commands
+
+```text
+go vet ./internal/beads/...
+go test ./internal/beads/... -run 'TestIsSQLiteBusy|TestRetryOnBusy|TestSQLiteStore' -count=1
+make test-fast-parallel
+go vet ./...
+git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
+```
+
+## Decision
+
+PASS. The reviewed code is ready for merge-authority evaluation after the gate
+commit is pushed to the PR branch.


### PR DESCRIPTION
## What this changes

SQLiteStore writes now retry briefly when SQLite reports `SQLITE_BUSY` / `database is locked` after the connection-level busy timeout expires. This gives maintenance-order tracking writes and factory writes another chance to acquire the WAL write lock instead of leaving intermittent open tracking beads under write contention.

The retry is applied around the store write methods that are safe to retry as whole operations: `Create`, `Update`, `Delete`, `DepAdd`, and `DepRemove`. Read paths are unchanged, and transaction callbacks are not retried because caller-provided functions may not be idempotent.

## Review notes

- The implementation is limited to `internal/beads/sqlite_store.go` and its tests.
- `isSQLiteBusy` recognizes the current modernc SQLite error strings; the reviewer noted a future typed-error check would be more robust.
- `Create` can skip sequence numbers if a retry happens after an auto-generated ID, which is harmless because IDs are opaque and gaps are allowed.

## Test plan

- [x] `go test ./internal/beads/... -run 'TestIsSQLiteBusy|TestRetryOnBusy|TestSQLiteStore' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-qz1z1o-sqlite-busy-retry-gate.md`](release-gates/ga-qz1z1o-sqlite-busy-retry-gate.md)