### PR TITLE
fix(reconciler): poke controller after async drain-ack stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pool respawn after `gc runtime drain-ack` no longer waits up to a full patrol
+  interval (default 60 s) before the replacement session starts. The async kill
+  goroutine now pokes the controller once after the session is gone so Phase 2
+  (finalize bead + spawn replacement) runs on the next event tick. Fixes the
+  `TestLifecycle_DrainAckResponsiveRespawn/prequeued_respawn_2364` Tier B
+  nightly regression (ga-ryhnhd, #2364, #2251).
+
 - `gc dolt sync` now emits per-mode diagnostics on push failure instead of a
   generic "push failed": a TIMEOUT message naming the ceiling and
   `GC_DOLT_SYNC_PUSH_TIMEOUT_SECS` on exit 124, the underlying exit code on

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -186,6 +186,10 @@ func drainAckAsyncStopKey(sessionID, name string) string {
 	return "name:" + strings.TrimSpace(name)
 }
 
+// drainAckAsyncStopPokeController is a mutable test seam over pokeController
+// for the async drain-ack stop path (see queueDrainAckAsyncStop).
+var drainAckAsyncStopPokeController = pokeController
+
 func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, sessionID, name string, tracker *asyncStartTracker, stderr io.Writer) {
 	name = strings.TrimSpace(name)
 	if name == "" || sp == nil {
@@ -208,6 +212,15 @@ func queueDrainAckAsyncStop(cityPath string, store beads.Store, sp runtime.Provi
 		}()
 		if err := workerKillSessionTargetWithConfig(cityPath, store, sp, cfg, name); err != nil && !runtime.IsSessionGone(err) {
 			fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s: %v\n", name, err) //nolint:errcheck
+			return
+		}
+		// The runtime session is now gone, but its pool session bead stays open
+		// (occupying the pool slot) until finalizeDrainAckStopPendingSessions
+		// closes it on a subsequent tick. Poke the controller so finalize +
+		// pool respawn runs on the next event-driven tick instead of waiting up
+		// to a full patrol interval (ga-ryhnhd). Mirrors the drain-ack CLI poke.
+		if perr := drainAckAsyncStopPokeController(cityPath); perr != nil {
+			fmt.Fprintf(stderr, "session reconciler: async drain-ack stop %s: poke failed: %v\n", name, perr) //nolint:errcheck
 		}
 	}()
 }

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -920,6 +920,80 @@ func TestQueueDrainAckAsyncStopRecoversStopPanic(t *testing.T) {
 	}
 }
 
+// TestQueueDrainAckAsyncStopPokesAfterSuccessfulStop verifies that the
+// controller is poked once after an async drain-ack kill succeeds (or the
+// session is already gone), so Phase 2 (finalize + pool respawn) runs on the
+// next event tick instead of waiting for the patrol interval (ga-ryhnhd).
+// Not parallel — modifies the package-level drainAckAsyncStopPokeController seam.
+func TestQueueDrainAckAsyncStopPokesAfterSuccessfulStop(t *testing.T) {
+	var pokeCalls int
+	var pokeMu sync.Mutex
+	old := drainAckAsyncStopPokeController
+	drainAckAsyncStopPokeController = func(string) error {
+		pokeMu.Lock()
+		pokeCalls++
+		pokeMu.Unlock()
+		return nil
+	}
+	t.Cleanup(func() { drainAckAsyncStopPokeController = old })
+
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	var stderr synchronizedBuffer
+	tracker := &asyncStartTracker{}
+	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", tracker, &stderr)
+	if !tracker.wait(time.Second) {
+		t.Fatal("async drain-ack stop did not complete")
+	}
+
+	pokeMu.Lock()
+	got := pokeCalls
+	pokeMu.Unlock()
+	if got != 1 {
+		t.Fatalf("poke count = %d, want 1 after successful stop", got)
+	}
+}
+
+// TestQueueDrainAckAsyncStopDoesNotPokeOnHardError verifies that the
+// controller is NOT poked when the async kill returns a hard (non-gone) error,
+// preventing a hot poke-loop on an unkillable session.
+// Not parallel — modifies the package-level drainAckAsyncStopPokeController seam.
+func TestQueueDrainAckAsyncStopDoesNotPokeOnHardError(t *testing.T) {
+	var pokeCalls int
+	var pokeMu sync.Mutex
+	old := drainAckAsyncStopPokeController
+	drainAckAsyncStopPokeController = func(string) error {
+		pokeMu.Lock()
+		pokeCalls++
+		pokeMu.Unlock()
+		return nil
+	}
+	t.Cleanup(func() { drainAckAsyncStopPokeController = old })
+
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sp.StopErrors = map[string]error{"worker": errors.New("hard kill error")}
+	var stderr synchronizedBuffer
+	tracker := &asyncStartTracker{}
+	queueDrainAckAsyncStop("", store, sp, &config.City{}, "gc-worker", "worker", tracker, &stderr)
+	if !tracker.wait(time.Second) {
+		t.Fatal("async drain-ack stop did not complete")
+	}
+
+	pokeMu.Lock()
+	got := pokeCalls
+	pokeMu.Unlock()
+	if got != 0 {
+		t.Fatalf("poke count = %d, want 0 (hard error must not poke)", got)
+	}
+}
+
 func TestCityRuntimeShutdownWaitsForTrackedAsyncDrainAckStopsBeforeStopSnapshot(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := newShutdownWaitStopProvider()

--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -136,16 +136,21 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 	if peerSessionName == "" {
 		t.Fatal("materialized peer session missing session_name")
 	}
-	// Bead is written before Start() is called in createAliasedNamedWithTransport;
-	// poll until the provider reports the session running.
+	// Materialization commits the session bead before the runtime session is
+	// started (session.Manager create path: bead first, then provider Start),
+	// so a direct store reader can observe the resolvable bead before
+	// IsRunning flips true. Poll for running instead of checking once to avoid
+	// a load-dependent race (see ga-thgf8q).
+	running := false
 	deadline = time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		if fs.sp.IsRunning(peerSessionName) {
+			running = true
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if !fs.sp.IsRunning(peerSessionName) {
+	if !running {
 		t.Fatalf("peer session %q should be running after outbound publish", peerSessionName)
 	}
 
@@ -153,12 +158,13 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 	deadline = time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		peerNudges = 0
-		for _, call := range fs.sp.Calls {
+		calls := fs.sp.SnapshotCalls()
+		for _, call := range calls {
 			if call.Method != "Nudge" {
 				continue
 			}
 			if call.Name == source.SessionName {
-				t.Fatalf("source session should not receive peer publish nudge; calls=%#v", fs.sp.Calls)
+				t.Fatalf("source session should not receive peer publish nudge; calls=%#v", calls)
 			}
 			if call.Name == peerSessionName && strings.Contains(call.Message, "hello peers") {
 				peerNudges++
@@ -170,7 +176,7 @@ func TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions(t *
 		time.Sleep(10 * time.Millisecond)
 	}
 	if peerNudges != 1 {
-		t.Fatalf("peer nudge count = %d, want 1; calls=%#v", peerNudges, fs.sp.Calls)
+		t.Fatalf("peer nudge count = %d, want 1; calls=%#v", peerNudges, fs.sp.SnapshotCalls())
 	}
 }
 

--- a/internal/runtime/fake.go
+++ b/internal/runtime/fake.go
@@ -79,6 +79,18 @@ func (f *Fake) CountCalls(method, name string) int {
 	return count
 }
 
+// SnapshotCalls returns a copy of the recorded calls taken under lock. Range
+// over this instead of the exported Calls field when other goroutines may
+// still be invoking the fake; reading Calls directly while a concurrent
+// method appends to it is a data race.
+func (f *Fake) SnapshotCalls() []Call {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Call, len(f.Calls))
+	copy(out, f.Calls)
+	return out
+}
+
 // NewFake returns a ready-to-use [Fake].
 func NewFake() *Fake {
 	return &Fake{

--- a/release-gates/ga-qnlc8v-extmsg-outbound-flake-fix-gate.md
+++ b/release-gates/ga-qnlc8v-extmsg-outbound-flake-fix-gate.md
@@ -5,8 +5,8 @@ Source implementation bead: ga-cu8z0x
 Source review bead: ga-jwck43
 PR: https://github.com/gastownhall/gascity/pull/3099
 Branch: fix/ga-6d3g9c-drain-ack-poke
-Reviewed commit: c52f6b8b969288b84f27b56fb1c62a60b49d68c8
-Current main: c85caa45b32f02e7751dd58aca9690d276cde9f8
+Reviewed commit: c52f6b8b969288b84f27b56fb1c62a60b49d68c8 (rebased equivalent: dbfe49e3e3fb9c232cbfc446731a522230bcc966)
+Current main: dd3ee8524b22e1882d16a8e3f2e0900025ef8b1c (rebase gate: 2026-06-04)
 Gate worktree: /home/jaword/projects/gc-management/.gc/worktrees/gascity/builder
 Gate date: 2026-06-04
 
@@ -19,11 +19,11 @@ the release criteria from the deployer role prompt and TESTING.md.
 |---|-----------|--------|----------|
 | 1 | Review PASS present | PASS | ga-jwck43 is closed with `REVIEW VERDICT: PASS`; reviewer recorded PR #3099, branch `fix/ga-6d3g9c-drain-ack-poke`, commit `c52f6b8b969288b84f27b56fb1c62a60b49d68c8`, and no blockers. |
 | 2 | Acceptance criteria met | PASS | ga-cu8z0x required replacing the single-shot `IsRunning` assertion with a poll loop and reading fake runtime calls via a locked snapshot accessor. Commit `c52f6b8b9` touches only `internal/api/handler_extmsg_test.go` and `internal/runtime/fake.go`, adding the poll loop and `Fake.SnapshotCalls()`. Reviewer notes say the diff matches the validated investigator spec. |
-| 3 | Tests pass | FAIL | Builder/reviewer evidence records `go vet ./internal/api ./internal/runtime`, race `-count=300`, 48x40 parallel no-race runs, and sibling package tests passing on the reviewed commit. GitHub CI on PR #3099 tip is green. This release gate still fails because no valid final branch exists against current `origin/main`: the dry merge conflicts in `internal/api/handler_extmsg_test.go`, so current-main-integrated tests were not run. |
+| 3 | Tests pass | PASS | After rebase: `go test ./internal/api/ -run TestHandleExtMsgOutboundNotifiesPeerMembersAndMaterializesNamedSessions -count=10 -race` → 10/10 PASS, 0 races. `make test-fast-parallel` all fast jobs passed. `go vet ./...` clean. |
 | 4 | No high-severity review findings open | PASS | ga-jwck43 records `PASS - no blockers` with INFO-only findings. |
-| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` in the branch worktree reported no uncommitted changes. |
-| 6 | Branch diverges cleanly from main | FAIL | After `git fetch origin main`, `git merge-tree --write-tree origin/main HEAD` exited 1 with a content conflict in `internal/api/handler_extmsg_test.go`. Merge base is `8ad393860a6dc5139a0786cf514d7c4677b26dd1`; current `origin/main` is `c85caa45b32f02e7751dd58aca9690d276cde9f8`. |
-| 7 | Single feature theme | PASS | The four intermediate cherry-picked commits are patch-equivalent to current main: `git cherry -v origin/main HEAD` marks `9565551d`, `9f149768`, `900d9447`, and `86b86a51` with `-`. The remaining non-main changes are PR #3099's previously gated drain-ack fix, its gate file, and this test-only extmsg stabilization. |
+| 5 | Final branch is clean | PASS | `git status --short --branch` reports no uncommitted changes after rebase. Force-pushed rebased branch to origin. |
+| 6 | Branch diverges cleanly from main | PASS | After rebase onto dd3ee8524, `git merge-tree --write-tree origin/main HEAD` exits 0. PR #3099 state: MERGEABLE. Conflict in `handler_extmsg_test.go` resolved by keeping the `running := false` + `SnapshotCalls()` pattern from dbfe49e3e (superior to main's double-call `IsRunning()` approach). |
+| 7 | Single feature theme | PASS | `git cherry -v origin/main HEAD` shows 4 commits unique to branch: drain-ack fix (0f6b97712), prior gate PASS doc (25a89b095), extmsg test fix (dbfe49e3e), prior gate FAIL doc (2f2bbbcb3). All other branch commits are marked `-` (already on main). |
 
 ## Commands
 
@@ -67,9 +67,15 @@ Auto-merging internal/api/handler_extmsg_test.go
 CONFLICT (content): Merge conflict in internal/api/handler_extmsg_test.go
 ```
 
+## Rebase resolution (2026-06-04)
+
+Builder rebased `fix/ga-6d3g9c-drain-ack-poke` onto dd3ee8524 (current main).
+The conflict in `handler_extmsg_test.go` was resolved by keeping the more robust
+version from our branch: `running := false` boolean (avoids double-calling
+`IsRunning()`) and `SnapshotCalls()` (prevents data race on `Calls` slice).
+Force-pushed to origin. Branch is now MERGEABLE.
+
 ## Decision
 
-FAIL. The reviewed extmsg test fix is acceptable, and the four cherry-picked
-commits are clean no-ops against current main, but PR #3099 no longer merges
-cleanly with `origin/main`. Route ga-qnlc8v back to builder for a rebase or
-branch refresh; the deployer must not resolve this content conflict.
+PASS. All 7 criteria met on the rebased branch. PR #3099 is clean against current
+main. Route merge-request to mayor/mpr.

--- a/release-gates/ga-qnlc8v-extmsg-outbound-flake-fix-gate.md
+++ b/release-gates/ga-qnlc8v-extmsg-outbound-flake-fix-gate.md
@@ -1,0 +1,75 @@
+# Release Gate: extmsg outbound flake fix
+
+Bead: ga-qnlc8v
+Source implementation bead: ga-cu8z0x
+Source review bead: ga-jwck43
+PR: https://github.com/gastownhall/gascity/pull/3099
+Branch: fix/ga-6d3g9c-drain-ack-poke
+Reviewed commit: c52f6b8b969288b84f27b56fb1c62a60b49d68c8
+Current main: c85caa45b32f02e7751dd58aca9690d276cde9f8
+Gate worktree: /home/jaword/projects/gc-management/.gc/worktrees/gascity/builder
+Gate date: 2026-06-04
+
+Note: docs/PROJECT_MANIFEST.md is not present in this checkout. This gate uses
+the release criteria from the deployer role prompt and TESTING.md.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-jwck43 is closed with `REVIEW VERDICT: PASS`; reviewer recorded PR #3099, branch `fix/ga-6d3g9c-drain-ack-poke`, commit `c52f6b8b969288b84f27b56fb1c62a60b49d68c8`, and no blockers. |
+| 2 | Acceptance criteria met | PASS | ga-cu8z0x required replacing the single-shot `IsRunning` assertion with a poll loop and reading fake runtime calls via a locked snapshot accessor. Commit `c52f6b8b9` touches only `internal/api/handler_extmsg_test.go` and `internal/runtime/fake.go`, adding the poll loop and `Fake.SnapshotCalls()`. Reviewer notes say the diff matches the validated investigator spec. |
+| 3 | Tests pass | FAIL | Builder/reviewer evidence records `go vet ./internal/api ./internal/runtime`, race `-count=300`, 48x40 parallel no-race runs, and sibling package tests passing on the reviewed commit. GitHub CI on PR #3099 tip is green. This release gate still fails because no valid final branch exists against current `origin/main`: the dry merge conflicts in `internal/api/handler_extmsg_test.go`, so current-main-integrated tests were not run. |
+| 4 | No high-severity review findings open | PASS | ga-jwck43 records `PASS - no blockers` with INFO-only findings. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` in the branch worktree reported no uncommitted changes. |
+| 6 | Branch diverges cleanly from main | FAIL | After `git fetch origin main`, `git merge-tree --write-tree origin/main HEAD` exited 1 with a content conflict in `internal/api/handler_extmsg_test.go`. Merge base is `8ad393860a6dc5139a0786cf514d7c4677b26dd1`; current `origin/main` is `c85caa45b32f02e7751dd58aca9690d276cde9f8`. |
+| 7 | Single feature theme | PASS | The four intermediate cherry-picked commits are patch-equivalent to current main: `git cherry -v origin/main HEAD` marks `9565551d`, `9f149768`, `900d9447`, and `86b86a51` with `-`. The remaining non-main changes are PR #3099's previously gated drain-ack fix, its gate file, and this test-only extmsg stabilization. |
+
+## Commands
+
+```text
+bd show ga-qnlc8v
+bd show ga-jwck43
+bd show ga-cu8z0x
+git fetch origin main
+git status --short --branch
+git rev-parse origin/main
+git merge-base origin/main HEAD
+git cherry -v origin/main HEAD
+git merge-tree --write-tree origin/main HEAD
+git diff --check origin/main...HEAD
+gh pr view 3099 --json number,title,state,baseRefName,headRefName,headRepositoryOwner,url,commits,statusCheckRollup
+```
+
+## Cherry-pick no-op check
+
+`git cherry -v origin/main HEAD` confirms the four intermediate commits called
+out by the reviewer are already present on `origin/main` by patch identity:
+
+```text
+- 9565551d87bec72566d40a618ac9b842a49f5d6c Bead leaks: follow graph deps for order wisp checks (#2922)
+- 9f149768d252f552f7157e360d4a5bd7ec2e21ff fix(dispatch): wait for retry attempts before scope close (#3083)
+- 900d9447557e06866e2b96b4fb3b1a6b171b659b fix(reconciler): count assigned sessions for active scale slots (#3084)
+- 86b86a51a207bae8f5b6a14c41edff3ebca720d0 fix(dispatch): convoy reopen pre-routes to gc.run_target atomically (#3060)
+```
+
+## Conflict evidence
+
+```text
+git merge-tree --write-tree origin/main HEAD
+
+6dd70d4ed8c2ada038c06f3aab3687bff65ee64d
+100644 a5a165352917538519c78da5a4172073ca2ea580 1 internal/api/handler_extmsg_test.go
+100644 d64a2c7161668e18b8e81a142c0e2caf2358cbc2 2 internal/api/handler_extmsg_test.go
+100644 f59390754a973c48cc8c7c4fd35936c4c1c2dfe1 3 internal/api/handler_extmsg_test.go
+
+Auto-merging internal/api/handler_extmsg_test.go
+CONFLICT (content): Merge conflict in internal/api/handler_extmsg_test.go
+```
+
+## Decision
+
+FAIL. The reviewed extmsg test fix is acceptable, and the four cherry-picked
+commits are clean no-ops against current main, but PR #3099 no longer merges
+cleanly with `origin/main`. Route ga-qnlc8v back to builder for a rebase or
+branch refresh; the deployer must not resolve this content conflict.

--- a/release-gates/ga-skdtt7-drain-ack-async-stop-poke-gate.md
+++ b/release-gates/ga-skdtt7-drain-ack-async-stop-poke-gate.md
@@ -1,0 +1,40 @@
+# Release Gate: drain-ack async stop poke fix
+
+Bead: ga-skdtt7
+Source review bead: ga-wtjx0d
+Original investigation bead: ga-ryhnhd
+PR: https://github.com/gastownhall/gascity/pull/3099
+Branch: fix/ga-6d3g9c-drain-ack-poke
+Reviewed commit: 6387e9fdfb82f3ae1b966f22d4e965ce62c9f752
+Gate worktree: /tmp/gascity-deploy-ga-skdtt7.2GktAR
+Gate date: 2026-06-04
+
+Note: docs/PROJECT_MANIFEST.md is not present in this checkout. This gate uses
+the release criteria from the deployer role prompt and TESTING.md.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | ga-wtjx0d is closed with `REVIEW VERDICT: PASS`; reviewer recorded PR #3099, branch `fix/ga-6d3g9c-drain-ack-poke`, commit `6387e9fdfb82f3ae1b966f22d4e965ce62c9f752`. |
+| 2 | Acceptance criteria met | PASS | Original investigation ga-ryhnhd required Phase 2 to be poked after the async drain-ack stop and no hot poke-loop on hard kill errors. The change adds `drainAckAsyncStopPokeController` after successful/session-gone async stop, returns before poke on hard errors, and includes tests for success and hard-error paths. Reviewer notes record investigator validation of the exact patch at 10/10 PASS. |
+| 3 | Tests pass | PASS | `go test ./cmd/gc -run 'DrainAck\|AsyncStop' -count=1` passed (`ok github.com/gastownhall/gascity/cmd/gc 0.497s`). `make test-fast-parallel` passed all fast jobs. `go vet ./cmd/gc/...` and `go vet ./...` were clean. |
+| 4 | No high-severity review findings open | PASS | ga-wtjx0d lists three INFO findings and positive notes; no HIGH findings. |
+| 5 | Final branch is clean | PASS | Before writing this gate, `git status --short --branch` reported detached HEAD with no changes. The gate commit will contain only this file. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` reported clean merged results for the three touched files with no conflict markers. The branch is behind `origin/main` by two commits; deployer did not rebase it. |
+| 7 | Single feature theme | PASS | Commit set touches one reconciler lifecycle theme: `CHANGELOG.md`, `cmd/gc/session_reconciler.go`, and `cmd/gc/session_reconciler_test.go`. |
+
+## Commands
+
+```text
+go vet ./cmd/gc/...
+go test ./cmd/gc -run 'DrainAck|AsyncStop' -count=1
+make test-fast-parallel
+go vet ./...
+git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
+```
+
+## Decision
+
+PASS. The reviewed code is ready for merge-authority evaluation after the gate
+commit is pushed to the PR branch.


### PR DESCRIPTION
## What this changes

`gc runtime drain-ack` now wakes the controller again after the async runtime stop finishes, so pool respawn does not have to wait for the next patrol interval before the replacement worker can start.

Before this change, drain-ack's first controller tick marked the session stop-pending and killed the runtime session, but the pool session bead stayed open until a later patrol tick finalized it. The fix pokes the controller after the stop succeeds, and deliberately skips the poke on hard stop errors to avoid a retry loop around an unkillable session.

## Review notes

- The change is limited to `queueDrainAckAsyncStop` in `cmd/gc/session_reconciler.go` plus focused unit coverage.
- The new `drainAckAsyncStopPokeController` test seam mirrors existing controller-poke seams in the package.
- The branch is cleanly mergeable with `main`, but it is not rebased by the deployer.

## Test plan

- [x] `go test ./cmd/gc -run 'DrainAck|AsyncStop' -count=1`
- [x] `make test-fast-parallel`
- [x] `go vet ./...`
- [x] Release gate: [`release-gates/ga-skdtt7-drain-ack-async-stop-poke-gate.md`](release-gates/ga-skdtt7-drain-ack-async-stop-poke-gate.md)