### PR TITLE
fix(pool): address imported city singletons by bare role, not binding-qualified alias

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1972,7 +1972,7 @@ func desiredHasCanonicalNonExpandingPoolSession(desired map[string]TemplateParam
 	if !cfgAgent.UsesCanonicalSingletonPoolIdentity() {
 		return false
 	}
-	canonical := cfgAgent.QualifiedName()
+	canonical := cfgAgent.CanonicalPoolIdentity()
 	for _, existing := range desired {
 		if existing.TemplateName != template {
 			continue
@@ -2186,9 +2186,8 @@ func realizePoolDesiredSessions(
 }
 
 func poolDesiredRequestIdentity(cfgAgent *config.Agent, slot int) (*config.Agent, string, int) {
-	qualifiedName := cfgAgent.QualifiedName()
 	if cfgAgent.UsesCanonicalSingletonPoolIdentity() {
-		return cfgAgent, qualifiedName, 0
+		return cfgAgent, cfgAgent.CanonicalPoolIdentity(), 0
 	}
 	instanceName := poolInstanceName(cfgAgent.Name, slot, cfgAgent)
 	qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
@@ -2245,7 +2244,7 @@ func normalizeNonExpandingPoolSessionBead(
 	if bp == nil || bp.beadStore == nil || !cfgAgent.UsesCanonicalSingletonPoolIdentity() || isManualSessionBeadForAgent(sessionBead, cfgAgent) || isNamedSessionBead(sessionBead) || sessionBead.ID == "" {
 		return sessionBead, nil
 	}
-	canonical := cfgAgent.QualifiedName()
+	canonical := cfgAgent.CanonicalPoolIdentity()
 	metadata := map[string]string{}
 	aliasNeedsUpdate := false
 	clearAliasConflictMetadata := func() {
@@ -2253,10 +2252,10 @@ func normalizeNonExpandingPoolSessionBead(
 	}
 	alias := strings.TrimSpace(sessionBead.Metadata["alias"])
 	deferredAlias := strings.TrimSpace(sessionBead.Metadata[poolAliasConflictMetadataKey])
-	if nonExpandingPoolIdentitySlot(cfgAgent, sessionBeadAgentName(sessionBead)) > 0 && strings.TrimSpace(sessionBead.Metadata["agent_name"]) != canonical {
+	if nonCanonicalSingletonPoolIdentity(cfgAgent, sessionBeadAgentName(sessionBead)) && strings.TrimSpace(sessionBead.Metadata["agent_name"]) != canonical {
 		metadata["agent_name"] = canonical
 	}
-	if (nonExpandingPoolIdentitySlot(cfgAgent, alias) > 0 && alias != canonical) || (alias == "" && deferredAlias == canonical) {
+	if (nonCanonicalSingletonPoolIdentity(cfgAgent, alias) && alias != canonical) || (alias == "" && deferredAlias == canonical) {
 		for key, value := range session.UpdatedAliasMetadata(sessionBead.Metadata, canonical) {
 			metadata[key] = value
 		}
@@ -2271,7 +2270,7 @@ func normalizeNonExpandingPoolSessionBead(
 	}
 
 	var title *string
-	if nonExpandingPoolIdentitySlot(cfgAgent, sessionBead.Title) > 0 && strings.TrimSpace(sessionBead.Title) != canonical {
+	if nonCanonicalSingletonPoolIdentity(cfgAgent, sessionBead.Title) && strings.TrimSpace(sessionBead.Title) != canonical {
 		normalizedTitle := canonical
 		title = &normalizedTitle
 	}
@@ -2280,7 +2279,7 @@ func normalizeNonExpandingPoolSessionBead(
 	hasCanonicalAgentLabel := containsString(sessionBead.Labels, "agent:"+canonical)
 	for _, label := range sessionBead.Labels {
 		label = strings.TrimSpace(label)
-		if strings.HasPrefix(label, "agent:") && nonExpandingPoolIdentitySlot(cfgAgent, strings.TrimPrefix(label, "agent:")) > 0 {
+		if strings.HasPrefix(label, "agent:") && nonCanonicalSingletonPoolIdentity(cfgAgent, strings.TrimPrefix(label, "agent:")) {
 			removeLabels = append(removeLabels, label)
 		}
 	}
@@ -2381,6 +2380,33 @@ func nonExpandingPoolIdentitySlot(cfgAgent *config.Agent, identity string) int {
 	// Accept any numeric -N suffix, not only configured pool bounds: these
 	// beads are stale singleton artifacts and may have been written externally.
 	return resolvePersistedPoolIdentitySlot(cfgAgent, true, identity)
+}
+
+// nonCanonicalSingletonPoolIdentity reports whether identity is a non-canonical identity
+// form for cfgAgent's singleton that normalization should rewrite to the canonical
+// pool identity. Two forms qualify:
+//   - a synthesized slot identity such as "mayor-1" (see nonExpandingPoolIdentitySlot), and
+//   - the legacy import-binding-qualified identity "gastown.mayor", which predates
+//     CanonicalPoolIdentity() stripping the binding for city-scoped singletons.
+//
+// Recognizing the legacy form lets an existing "gastown.mayor" session bead migrate
+// to the bare "mayor" alias in place on the next reconcile, through the same
+// alias-rewrite path as slot normalization (no session restart). The legacy clause
+// is limited to imported city-scoped singletons (Dir == "", BindingName != "")
+// where the binding-qualified and canonical forms differ.
+func nonCanonicalSingletonPoolIdentity(cfgAgent *config.Agent, identity string) bool {
+	if cfgAgent == nil || !cfgAgent.UsesCanonicalSingletonPoolIdentity() {
+		return false
+	}
+	if nonExpandingPoolIdentitySlot(cfgAgent, identity) > 0 {
+		return true
+	}
+	identity = strings.TrimSpace(identity)
+	return identity != "" &&
+		cfgAgent.Dir == "" &&
+		cfgAgent.BindingName != "" &&
+		identity == cfgAgent.BindingQualifiedName() &&
+		identity != cfgAgent.CanonicalPoolIdentity()
 }
 
 func setTemplateEnvIdentity(tp *TemplateParams, identity string) {
@@ -2908,7 +2934,7 @@ func findReusableCanonicalNonExpandingPoolSessionBead(
 	if bp == nil || bp.sessionBeads == nil || !cfgAgent.UsesCanonicalSingletonPoolIdentity() {
 		return beads.Bead{}, false
 	}
-	canonical := cfgAgent.QualifiedName()
+	canonical := cfgAgent.CanonicalPoolIdentity()
 	for _, bead := range reusablePoolSessionBeads(bp, cfgAgent, template, used) {
 		if strings.TrimSpace(bead.Metadata["session_name"]) == "" {
 			continue
@@ -2959,7 +2985,7 @@ func recordDeferredNonExpandingPoolAliasConflict(
 ) (beads.Bead, error) {
 	// The store write is authoritative; callers must use the returned bead
 	// rather than re-reading bp.sessionBeads for this ID in the same tick.
-	canonical := cfgAgent.QualifiedName()
+	canonical := cfgAgent.CanonicalPoolIdentity()
 	count := 0
 	if existing, err := strconv.Atoi(strings.TrimSpace(sessionBead.Metadata[poolAliasConflictCountMetadataKey])); err == nil && existing > 0 {
 		count = existing
@@ -3316,7 +3342,7 @@ func findReusableCanonicalNonExpandingDependencyPoolSessionBead(
 	if bp == nil || bp.sessionBeads == nil || !cfgAgent.UsesCanonicalSingletonPoolIdentity() {
 		return beads.Bead{}, false
 	}
-	canonical := cfgAgent.QualifiedName()
+	canonical := cfgAgent.CanonicalPoolIdentity()
 	for _, bead := range reusableDependencyPoolSessionBeads(bp, template) {
 		if staleNonExpandingPoolSessionBead(cfgAgent, bead) {
 			continue

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3957,6 +3957,105 @@ func TestNormalizeNonExpandingPoolSessionBeadReclaimsDeferredAlias(t *testing.T)
 	}
 }
 
+// nonCanonicalSingletonPoolIdentity recognizes both the synthesized slot form
+// ("mayor-1") and the legacy import-binding-qualified form ("gastown.mayor"),
+// but the legacy clause fires only for imported city-scoped singletons where the
+// binding-qualified form differs from the bare canonical identity.
+func TestNonCanonicalSingletonPoolIdentity(t *testing.T) {
+	cityMayor := &config.Agent{Name: "mayor", BindingName: "gastown", MaxActiveSessions: intPtr(1)}
+	rigMayor := &config.Agent{Name: "mayor", Dir: "hello-world", BindingName: "gastown", MaxActiveSessions: intPtr(1)}
+	pool := &config.Agent{Name: "worker", MaxActiveSessions: intPtr(3)}
+
+	cases := []struct {
+		desc     string
+		agent    *config.Agent
+		identity string
+		want     bool
+	}{
+		{"city singleton legacy binding-qualified form is non-canonical", cityMayor, "gastown.mayor", true},
+		{"city singleton slot form is binding-prefixed and non-canonical", cityMayor, "gastown.mayor-1", true},
+		{"city singleton bare slot form is not this agent's identity", cityMayor, "mayor-1", false},
+		{"city singleton bare canonical form is canonical", cityMayor, "mayor", false},
+		{"city singleton unrelated identity", cityMayor, "deacon", false},
+		{"rig singleton qualified form is its own canonical, not legacy-stale", rigMayor, "gastown.mayor", false},
+		{"non-singleton pool agent is never matched", pool, "gastown.worker", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := nonCanonicalSingletonPoolIdentity(tc.agent, tc.identity); got != tc.want {
+				t.Errorf("nonCanonicalSingletonPoolIdentity(%q) = %v, want %v", tc.identity, got, tc.want)
+			}
+		})
+	}
+}
+
+// An existing city-singleton session bead stamped with the legacy
+// binding-qualified identity ("gastown.mayor") must migrate to the bare role
+// ("mayor") in place — the same alias-rewrite path that already normalizes slot
+// forms — so mail addressed to "mayor" reaches the live session with no restart.
+// The template key must stay binding-qualified; only the alias/identity moves.
+func TestNormalizeNonExpandingPoolSessionBeadMigratesLegacyBindingQualifiedIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	legacy, err := store.Create(beads.Bead{
+		Title:  "gastown.mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gastown.mayor", "template:gastown.mayor"},
+		Metadata: map[string]string{
+			"template":             "gastown.mayor",
+			"agent_name":           "gastown.mayor",
+			"alias":                "gastown.mayor",
+			"session_name":         "s-mayor-legacy",
+			"state":                "awake",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			BindingName:       "gastown",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+	var stderr bytes.Buffer
+	bp := newAgentBuildParams("test-city", cityPath, cfg, runtime.NewFake(), time.Now().UTC(), store, &stderr)
+
+	result, err := normalizeNonExpandingPoolSessionBead(bp, &cfg.Agents[0], legacy)
+	if err != nil {
+		t.Fatalf("normalizeNonExpandingPoolSessionBead: %v", err)
+	}
+	if got := result.Metadata["alias"]; got != "mayor" {
+		t.Fatalf("result alias = %q, want bare canonical \"mayor\"", got)
+	}
+	stored, err := store.Get(legacy.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", legacy.ID, err)
+	}
+	if got := stored.Metadata["alias"]; got != "mayor" {
+		t.Errorf("stored alias = %q, want \"mayor\"", got)
+	}
+	if got := stored.Metadata["agent_name"]; got != "mayor" {
+		t.Errorf("stored agent_name = %q, want \"mayor\"", got)
+	}
+	if got := strings.TrimSpace(stored.Title); got != "mayor" {
+		t.Errorf("stored title = %q, want \"mayor\"", got)
+	}
+	if !containsString(stored.Labels, "agent:mayor") {
+		t.Errorf("stored labels = %v, want canonical agent:mayor", stored.Labels)
+	}
+	if containsString(stored.Labels, "agent:gastown.mayor") {
+		t.Errorf("stored labels = %v, must not retain legacy agent:gastown.mayor", stored.Labels)
+	}
+	if got := stored.Metadata["template"]; got != "gastown.mayor" {
+		t.Errorf("stored template = %q, want unchanged binding-qualified \"gastown.mayor\"", got)
+	}
+}
+
 func TestReconcilerClosesUnselectedCanonicalSingletonBeforeAliasReclaim(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,6 +138,30 @@ func (a *Agent) QualifiedInstanceName(instanceName string) string {
 	return a.Dir + "/" + name
 }
 
+// CanonicalPoolIdentity returns the identity the pool layer uses to address an
+// agent's canonical singleton session (see UsesCanonicalSingletonPoolIdentity).
+//
+// For a CITY-scoped singleton (Dir == "") it is the bare role name ("mayor"),
+// NOT the import-binding-qualified name ("gastown.mayor"): such an agent is the
+// unique holder of its role in the city, and mail/coordination address it by the
+// bare role, so the pool alias must match or routing splits across two inboxes
+// (one for "mayor", one for the live "gastown.mayor"). For a RIG-scoped singleton
+// (Dir != "") the dir qualifier is retained so it stays unambiguous across rigs.
+//
+// This is deliberately NOT folded into QualifiedName(): QualifiedName() is also
+// the template key written into session beads and used for store/config lookups,
+// which must remain binding-qualified. Only singleton alias/identity derivation
+// should use this; template-key call sites keep using QualifiedName().
+func (a *Agent) CanonicalPoolIdentity() string {
+	if a == nil {
+		return ""
+	}
+	if a.Dir == "" {
+		return a.Name
+	}
+	return a.QualifiedName()
+}
+
 // AgentMatchesIdentity returns true if the agent's qualified name matches
 // the given identity string. Handles both V1 format ("dir/name") and V2
 // format ("dir/binding.name", "binding.name"). This is the canonical way

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4730,6 +4730,55 @@ func TestQualifiedName(t *testing.T) {
 	}
 }
 
+func TestCanonicalPoolIdentity(t *testing.T) {
+	tests := []struct {
+		desc        string
+		agent       Agent
+		want        string
+		matchesQual bool // CanonicalPoolIdentity should equal QualifiedName here
+	}{
+		{
+			desc:        "imported city singleton drops the binding to the bare role",
+			agent:       Agent{Name: "mayor", Dir: "", BindingName: "gastown"},
+			want:        "mayor",
+			matchesQual: false, // QualifiedName is "gastown.mayor" — this is the routing-split fix
+		},
+		{
+			desc:        "non-imported city singleton is already bare",
+			agent:       Agent{Name: "mayor", Dir: ""},
+			want:        "mayor",
+			matchesQual: true,
+		},
+		{
+			desc:        "imported rig singleton keeps its dir qualifier",
+			agent:       Agent{Name: "mayor", Dir: "hello-world", BindingName: "gastown"},
+			want:        "hello-world/gastown.mayor",
+			matchesQual: true,
+		},
+		{
+			desc:        "non-imported rig singleton keeps its dir qualifier",
+			agent:       Agent{Name: "worker", Dir: "backend"},
+			want:        "backend/worker",
+			matchesQual: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := tt.agent.CanonicalPoolIdentity()
+			if got != tt.want {
+				t.Errorf("CanonicalPoolIdentity() = %q, want %q", got, tt.want)
+			}
+			qual := tt.agent.QualifiedName()
+			switch {
+			case tt.matchesQual && got != qual:
+				t.Errorf("CanonicalPoolIdentity() = %q diverged from QualifiedName() = %q; expected them to match", got, qual)
+			case !tt.matchesQual && got == qual:
+				t.Errorf("CanonicalPoolIdentity() = %q should differ from QualifiedName() = %q for an imported city singleton", got, qual)
+			}
+		})
+	}
+}
+
 func TestParseQualifiedName(t *testing.T) {
 	tests := []struct {
 		input   string


### PR DESCRIPTION
Fixes #3104.

## Problem

An imported city singleton (`gastown.mayor`/`boot`/`deacon`, provided by the `gastown` stdlib binding) gets its pool **alias/identity** from `QualifiedName()` (`gastown.mayor`), but mail and coordination address it by its **bare role** (`mayor`). Coordinator mail to `mayor` and the live `gastown.mayor` session split across two inboxes.

## Root cause

`QualifiedName()` does double duty: the **addressable identity** *and* the **session-bead template key** (a bead's `template` metadata, resolved back via `findAgentByTemplate`). They coincide for non-imported agents but must diverge for an imported city singleton — alias bare (`mayor`), template key binding-qualified (`gastown.mayor`).

## Fix

Add `Agent.CanonicalPoolIdentity()`:
- city-scoped singleton (`Dir == ""`) → bare role (`mayor`)
- rig-scoped singleton (`Dir != ""`) → dir-qualified (unchanged)

It differs from `QualifiedName()` **only** for imported city singletons (`Dir=="" && BindingName!=""`) — exactly the bug case. The six singleton-only **alias/identity derivation** sites switch to it; the two **template-key** sites keep `QualifiedName()`. `QualifiedName()` itself is intentionally untouched — changing it would orphan every existing session bead, since the `template` key would no longer resolve via `findAgentByTemplate`.

## Migration — in place, no restart

A derivation-only change is **inert on a running deployment**: the reconciler reuses the existing `gastown.mayor` bead by template match (`reusablePoolSessionBead` → `resolvedSessionTemplate == "gastown.mayor"`), and the singleton normalizer only rewrites *slot* forms (`mayor-1`). So this PR also extends the normalizer's `nonCanonicalSingletonPoolIdentity` predicate to recognize the legacy binding-qualified form as non-canonical alongside slot forms. On the next reconcile the existing bead re-aliases to the bare role **through the same alias-rewrite path that already migrates `mayor-1` → `mayor`** — no kill/respawn.

The stale-bead *discard* detector (`staleNonExpandingPoolSessionBead`) is deliberately left slot-form-only, so the legacy bead is **reused and rewritten**, not orphaned and respawned.

## Blast radius

City-scoped singletons only: `mayor`, `boot`, `deacon`. Rig singletons, multi-session pools, named sessions, and non-imported agents are unaffected — `CanonicalPoolIdentity() == QualifiedName()` for all of them.

## Tests

- `TestCanonicalPoolIdentity` — bare for imported city singleton, qualified otherwise; asserts divergence from `QualifiedName()` *only* in the imported-city case.
- `TestNonCanonicalSingletonPoolIdentity` — slot + legacy recognition with city/rig/non-singleton guards (incl. that an imported singleton's slot form is binding-prefixed, `gastown.mayor-1`).
- `TestNormalizeNonExpandingPoolSessionBeadMigratesLegacyBindingQualifiedIdentity` — end-to-end: a `gastown.mayor` session bead migrates to `mayor` (alias, agent_name, title, label) while the `template` key stays `gastown.mayor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
