### PR TITLE
fix(build): add system CGO paths for non-standard Linux compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,14 +38,18 @@ endif
 
 # Linux: some non-system compilers (Nix, Flox, etc.) don't search /usr/include
 # or /usr/lib by default. If system ICU headers exist but the compiler doesn't
-# see them, add the system paths explicitly.
+# see them, intentionally let system paths participate in the whole CGO build.
 ifeq ($(shell uname),Linux)
-SYS_USR_INCLUDE := /usr/include
-SYS_USR_LIB := /usr/lib/$(shell dpkg-architecture -q DEB_HOST_MULTIARCH 2>/dev/null || echo "x86_64-linux-gnu")
+SYS_USR_INCLUDE ?= /usr/include
+SYS_USR_LIB_ROOT ?= /usr/lib
+SYS_USR_LIB64_ROOT ?= /usr/lib64
 ifneq ($(wildcard $(SYS_USR_INCLUDE)/unicode/uregex.h),)
-ifeq ($(shell $(CC) -E -Wp,-v -x c /dev/null 2>&1 | grep -q /usr/include && echo yes),)
+ifeq ($(shell $(CC) -E -Wp,-v -x c /dev/null 2>&1 | sed 's/^[[:space:]]*//' | grep -F -x -q "$(SYS_USR_INCLUDE)" && echo yes),)
+SYS_USR_MULTIARCH_CANDIDATES := $(strip $(shell dpkg-architecture -q DEB_HOST_MULTIARCH 2>/dev/null) $(shell $(CC) -print-multiarch 2>/dev/null))
+SYS_USR_LIB_CANDIDATES := $(foreach arch,$(SYS_USR_MULTIARCH_CANDIDATES),$(SYS_USR_LIB_ROOT)/$(arch)) $(SYS_USR_LIB64_ROOT) $(SYS_USR_LIB_ROOT)
+SYS_USR_LIB_DIRS := $(strip $(foreach dir,$(SYS_USR_LIB_CANDIDATES),$(if $(wildcard $(dir)),$(dir))))
 CGO_CPPFLAGS += -I$(SYS_USR_INCLUDE)
-CGO_LDFLAGS += -L$(SYS_USR_LIB)
+CGO_LDFLAGS += $(addprefix -L,$(SYS_USR_LIB_DIRS))
 export CGO_CPPFLAGS
 export CGO_LDFLAGS
 endif

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,22 @@ export CGO_LDFLAGS
 endif
 endif
 
+# Linux: some non-system compilers (Nix, Flox, etc.) don't search /usr/include
+# or /usr/lib by default. If system ICU headers exist but the compiler doesn't
+# see them, add the system paths explicitly.
+ifeq ($(shell uname),Linux)
+SYS_USR_INCLUDE := /usr/include
+SYS_USR_LIB := /usr/lib/$(shell dpkg-architecture -q DEB_HOST_MULTIARCH 2>/dev/null || echo "x86_64-linux-gnu")
+ifneq ($(wildcard $(SYS_USR_INCLUDE)/unicode/uregex.h),)
+ifeq ($(shell $(CC) -E -Wp,-v -x c /dev/null 2>&1 | grep -q /usr/include && echo yes),)
+CGO_CPPFLAGS += -I$(SYS_USR_INCLUDE)
+CGO_LDFLAGS += -L$(SYS_USR_LIB)
+export CGO_CPPFLAGS
+export CGO_LDFLAGS
+endif
+endif
+endif
+
 .PHONY: build check check-all check-bd check-docker check-docs check-dolt check-native-dependency-surface check-routed-test-rows check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-pack-registry-live test-native-doltlite-beads test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev diagrams-excalidraw dashboard-smoke
 
 ## build: compile gc binary with version metadata

--- a/scripts/makefile_cgo_test.go
+++ b/scripts/makefile_cgo_test.go
@@ -1,0 +1,193 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMakefileLinuxCGOPathsIncludeExistingSystemLibLayouts(t *testing.T) {
+	t.Setenv("CGO_CPPFLAGS", "-Iambient")
+	t.Setenv("CGO_LDFLAGS", "-Lambient")
+
+	repoRoot := repoRoot(t)
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	sysInclude := filepath.Join(tmp, "sysinclude")
+	if err := os.MkdirAll(filepath.Join(sysInclude, "unicode"), 0o755); err != nil {
+		t.Fatalf("mkdir unicode include: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sysInclude, "unicode", "uregex.h"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write ICU header: %v", err)
+	}
+	sysLib := filepath.Join(tmp, "syslib")
+	sysLib64 := filepath.Join(tmp, "syslib64")
+	for _, dir := range []string{filepath.Join(sysLib, "riscv64-linux-gnu"), sysLib, sysLib64} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/usr/bin/env sh\necho Linux\n")
+	writeExecutable(t, filepath.Join(binDir, "dpkg-architecture"), "#!/usr/bin/env sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(binDir, "cc"), `#!/usr/bin/env sh
+case " $* " in
+  *" -print-multiarch "*)
+    echo riscv64-linux-gnu
+    exit 0
+    ;;
+esac
+printf '%s\n' '#include <...> search starts here:' ' /nix/store/include' 'End of search list.' >&2
+`)
+
+	out := runMakefileCGOPrintTarget(t, repoRoot, tmp, binDir,
+		"SYS_USR_INCLUDE="+sysInclude,
+		"SYS_USR_LIB_ROOT="+sysLib,
+		"SYS_USR_LIB64_ROOT="+sysLib64,
+		"CC=cc",
+	)
+	assertContains(t, out, "CGO_CPPFLAGS=-I"+sysInclude)
+	assertContains(t, out, "-L"+filepath.Join(sysLib, "riscv64-linux-gnu"))
+	assertContains(t, out, "-L"+sysLib64)
+	assertContains(t, out, "-L"+sysLib)
+	if strings.Contains(out, "x86_64-linux-gnu") {
+		t.Fatalf("CGO paths should not hardcode the x86_64 Debian fallback:\n%s", out)
+	}
+	if strings.Contains(out, "ambient") {
+		t.Fatalf("Makefile CGO tests should not inherit ambient CGO flags:\n%s", out)
+	}
+}
+
+func TestMakefileLinuxCGOPathsTreatNestedIncludeAsMissingSystemRoot(t *testing.T) {
+	repoRoot := repoRoot(t)
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	sysInclude := filepath.Join(tmp, "sysinclude")
+	if err := os.MkdirAll(filepath.Join(sysInclude, "unicode"), 0o755); err != nil {
+		t.Fatalf("mkdir unicode include: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sysInclude, "unicode", "uregex.h"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write ICU header: %v", err)
+	}
+	sysLib := filepath.Join(tmp, "syslib")
+	if err := os.MkdirAll(sysLib, 0o755); err != nil {
+		t.Fatalf("mkdir syslib: %v", err)
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/usr/bin/env sh\necho Linux\n")
+	writeExecutable(t, filepath.Join(binDir, "dpkg-architecture"), "#!/usr/bin/env sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(binDir, "cc"), `#!/usr/bin/env sh
+case " $* " in
+  *" -print-multiarch "*)
+    exit 0
+    ;;
+esac
+printf '%s\n' '#include <...> search starts here:' ' `+sysInclude+`/x86_64-linux-gnu' 'End of search list.' >&2
+`)
+
+	out := runMakefileCGOPrintTarget(t, repoRoot, tmp, binDir,
+		"SYS_USR_INCLUDE="+sysInclude,
+		"SYS_USR_LIB_ROOT="+sysLib,
+		"SYS_USR_LIB64_ROOT="+filepath.Join(tmp, "syslib64"),
+		"CC=cc",
+	)
+	assertContains(t, out, "CGO_CPPFLAGS=-I"+sysInclude)
+	assertContains(t, out, "-L"+sysLib)
+}
+
+func TestMakefileLinuxCGOPathsSkipDetectionWhenICUHeaderMissing(t *testing.T) {
+	repoRoot := repoRoot(t)
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	sysInclude := filepath.Join(tmp, "sysinclude")
+	if err := os.MkdirAll(sysInclude, 0o755); err != nil {
+		t.Fatalf("mkdir sysinclude: %v", err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/usr/bin/env sh\necho Linux\n")
+	writeExecutable(t, filepath.Join(binDir, "dpkg-architecture"), `#!/usr/bin/env sh
+touch "$(dirname "$0")/dpkg.ran"
+echo x86_64-linux-gnu
+`)
+	writeExecutable(t, filepath.Join(binDir, "cc"), `#!/usr/bin/env sh
+touch "$(dirname "$0")/cc.ran"
+exit 0
+`)
+
+	out := runMakefileCGOPrintTarget(t, repoRoot, tmp, binDir,
+		"SYS_USR_INCLUDE="+sysInclude,
+		"SYS_USR_LIB_ROOT="+filepath.Join(tmp, "syslib"),
+		"SYS_USR_LIB64_ROOT="+filepath.Join(tmp, "syslib64"),
+		"CC=cc",
+	)
+	if out != "CGO_CPPFLAGS=\nCGO_LDFLAGS=\n" {
+		t.Fatalf("CGO flags should stay empty when the ICU header is absent:\n%s", out)
+	}
+	for _, name := range []string{"dpkg.ran", "cc.ran"} {
+		if _, err := os.Stat(filepath.Join(binDir, name)); err == nil {
+			t.Fatalf("Makefile should not run %s when the ICU header is absent", strings.TrimSuffix(name, ".ran"))
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+	}
+}
+
+func runMakefileCGOPrintTarget(t *testing.T, repoRoot, tmp, binDir string, args ...string) string {
+	t.Helper()
+	makefile, err := os.ReadFile(filepath.Join(repoRoot, "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	testMakefile := filepath.Join(tmp, "Makefile")
+	makefileContent := string(makefile) + `
+.PHONY: print-cgo-flags
+print-cgo-flags:
+	@printf 'CGO_CPPFLAGS=%s\n' '$(CGO_CPPFLAGS)'
+	@printf 'CGO_LDFLAGS=%s\n' '$(CGO_LDFLAGS)'
+`
+	if err := os.WriteFile(testMakefile, []byte(makefileContent), 0o644); err != nil {
+		t.Fatalf("write test Makefile: %v", err)
+	}
+
+	cmdArgs := append([]string{"--no-print-directory", "-f", testMakefile, "print-cgo-flags"}, args...)
+	cmd := exec.Command("make", cmdArgs...)
+	cmd.Dir = repoRoot
+	cmd.Env = append(filteredMakefileCGOTestEnv(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+filepath.Join(tmp, "home"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make print-cgo-flags failed: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+func filteredMakefileCGOTestEnv() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "CGO_") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Fatalf("output missing %q:\n%s", needle, haystack)
+	}
+}

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -402,7 +402,7 @@ description = "Read and complete {{issue}}."
 	list := liveContractJSON[struct {
 		Items []beads.Bead `json:"items"`
 		Total int          `json:"total"`
-	}](t, baseURL, validator, http.MethodGet, cityBase+"/beads?label=real-world-app-contract&limit=50&rig="+url.QueryEscape(rigName), nil, http.StatusOK)
+	}](t, baseURL, validator, http.MethodGet, cityBase+"/beads?label=real-world-app-contract&limit=50&all=true&rig="+url.QueryEscape(rigName), nil, http.StatusOK)
 	if list.Total < 3 || !beadListContains(list.Items, rootBead.ID) || !beadListContains(list.Items, siblingBead.ID) {
 		t.Fatalf("filtered beads = %+v, want root and sibling", list)
 	}


### PR DESCRIPTION
Some Linux compilers (Nix, Flox, etc.) don't search /usr/include or /usr/lib by default, which breaks CGO builds that need ICU headers (e.g. the Dolt go-icu-regex dependency).

Detect this by checking if /usr/include/unicode/uregex.h exists on the system but the compiler's include paths don't cover /usr/include. When both conditions hold, add /usr/include and /usr/lib/<multiarch> to CGO_CPPFLAGS and CGO_LDFLAGS respectively.

Follows the same pattern as the existing macOS Homebrew icu4c detection above it. No-op on standard Linux toolchains.