### PR TITLE
feat(beads): wire BdStore.List --skip-labels when bd 1.0.5+ is available (ga-z0pc4k)

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1657,6 +1657,9 @@ func (s *BdStore) listViaBDList(query ListQuery) ([]Bead, error) {
 			args = append(args, "--metadata-field", k+"="+serverQuery.Metadata[k])
 		}
 	}
+	if query.SkipLabels && serverQuery.Label == "" {
+		args = append(args, "--skip-labels")
+	}
 
 	out, err := s.runner(s.dir, "bd", args...)
 	if err != nil {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1738,7 +1738,7 @@ func TestBdStoreListEmptyOutputMeansNoBeads(t *testing.T) {
 	}
 }
 
-func TestBdStoreListSkipLabelsDoesNotEmitUnsupportedBd104Flag(t *testing.T) {
+func TestBdStoreListSkipLabelsEmitsFlag(t *testing.T) {
 	var gotCmd string
 	runner := func(_, name string, args ...string) ([]byte, error) {
 		gotCmd = name + " " + strings.Join(args, " ")
@@ -1748,8 +1748,8 @@ func TestBdStoreListSkipLabelsDoesNotEmitUnsupportedBd104Flag(t *testing.T) {
 	if _, err := s.List(beads.ListQuery{AllowScan: true, SkipLabels: true}); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(gotCmd, "--skip-labels") {
-		t.Fatalf("bd list command = %q, --skip-labels is not supported by bd 1.0.4", gotCmd)
+	if !strings.Contains(gotCmd, "--skip-labels") {
+		t.Fatalf("bd list command = %q, want --skip-labels flag", gotCmd)
 	}
 }
 
@@ -1770,8 +1770,8 @@ func TestBdStoreListAcceptsBdListEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(gotCmd, "--skip-labels") {
-		t.Fatalf("bd list command = %q, --skip-labels is not supported by bd 1.0.4", gotCmd)
+	if !strings.Contains(gotCmd, "--skip-labels") {
+		t.Fatalf("bd list command = %q, want --skip-labels flag", gotCmd)
 	}
 	if len(got) != 1 || got[0].ID != "bd-envelope" {
 		t.Fatalf("List() = %+v, want bd-envelope from envelope", got)


### PR DESCRIPTION
## Summary

- bd 1.0.5 ships `--skip-labels` support (be-w3n-1). Wire it in `BdStore.listViaBDList`: when `SkipLabels=true` and no label filter is active, append `--skip-labels` so label hydration is skipped server-side.
- Guard: `--skip-labels` cannot combine with `--label` per bd CLI constraint; omit when `serverQuery.Label != ""`.
- Update tests: rename `TestBdStoreListSkipLabelsDoesNotEmitUnsupportedBd104Flag` → `TestBdStoreListSkipLabelsEmitsFlag` and invert assertions for the two tests that were asserting absence of the flag.
- `TestBdStoreListSkipLabelsOmittedForLabelFilter` continues to pass unchanged (label-filter guard still correct).

Closes ga-z0pc4k. Prerequisite be-w3n-1 confirmed via `bd list --help`: `--skip-labels` is available in bd 1.0.5.

## Test plan

- [x] `go test ./internal/beads -run 'TestBdStoreListSkipLabels|TestBdStoreListAcceptsBdListEnvelope' -count=1 -v` PASS
- [x] `go test ./internal/beads/... -count=1` PASS
- [x] `go vet ./...` PASS
- [x] `make test-fast-parallel` PASS
- [x] `.githooks/pre-commit` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)