### PR TITLE
fix(searchpath): include pnpm/npm-global/yarn dirs in probe PATH (#3001)

### DIFF
--- a/internal/searchpath/searchpath.go
+++ b/internal/searchpath/searchpath.go
@@ -86,6 +86,21 @@ func userManagedDirs(homeDir string) []string {
 		filepath.Join(homeDir, ".local", "share", "mise", "shims"),
 		filepath.Join(homeDir, ".local", "share", "rtx", "shims"),
 		filepath.Join(homeDir, ".nodebrew", "current", "bin"),
+		// JS package-manager global install bins. pnpm's default PNPM_HOME
+		// is XDG-relative; newer pnpm layouts symlink under a `bin/`
+		// subdirectory while older layouts symlink directly into PNPM_HOME,
+		// so we include both. npm and yarn each support a user-prefix
+		// global bin separate from the system one. gc init's
+		// provider-readiness probes use this search path (NOT the ambient
+		// PATH), so a CLI installed via `pnpm add -g`, `npm i -g` with a
+		// user prefix, or `yarn global add` was previously reported as
+		// "not installed" even though it was on the shell's PATH
+		// (gastownhall/gascity#3001).
+		filepath.Join(homeDir, ".local", "share", "pnpm"),
+		filepath.Join(homeDir, ".local", "share", "pnpm", "bin"),
+		filepath.Join(homeDir, ".npm-global", "bin"),
+		filepath.Join(homeDir, ".yarn", "bin"),
+		filepath.Join(homeDir, ".config", "yarn", "global", "node_modules", ".bin"),
 	)
 	dirs = append(dirs, globExistingDirs(
 		filepath.Join(homeDir, ".nvm", "versions", "node", "*", "bin"),

--- a/internal/searchpath/searchpath_test.go
+++ b/internal/searchpath/searchpath_test.go
@@ -184,3 +184,58 @@ func TestExpandUserManagedDirsOnlyExisting(t *testing.T) {
 		t.Fatalf("did not expect non-existent %q in dirs: %v", goBin, dirs)
 	}
 }
+
+// TestExpandIncludesJSPackageManagerGlobalBins is a regression test for
+// gastownhall/gascity#3001. CLIs installed via pnpm (XDG-relative PNPM_HOME),
+// npm with a user-prefix global, or yarn global must be discoverable by the
+// provider-readiness probes — they use this deterministic search order
+// instead of the ambient shell PATH.
+func TestExpandIncludesJSPackageManagerGlobalBins(t *testing.T) {
+	home := t.TempDir()
+
+	pnpmBin := filepath.Join(home, ".local", "share", "pnpm", "bin")
+	pnpmHome := filepath.Join(home, ".local", "share", "pnpm")
+	npmGlobalBin := filepath.Join(home, ".npm-global", "bin")
+	yarnBin := filepath.Join(home, ".yarn", "bin")
+	yarnClassicGlobalBin := filepath.Join(home, ".config", "yarn", "global", "node_modules", ".bin")
+
+	for _, dir := range []string{pnpmBin, npmGlobalBin, yarnBin, yarnClassicGlobalBin} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	dirs := Expand(home, "linux", "/usr/bin")
+	for _, want := range []string{pnpmBin, pnpmHome, npmGlobalBin, yarnBin, yarnClassicGlobalBin} {
+		if !slices.Contains(dirs, want) {
+			t.Errorf("expected %q in dirs: %v", want, dirs)
+		}
+	}
+}
+
+// TestExpandJSPackageManagerDirsOnlyWhenExisting verifies the same
+// gating as TestExpandUserManagedDirsOnlyExisting — the new pnpm/npm/yarn
+// entries are included only when the directory actually exists, so we
+// don't pollute the search path with phantom user-managed install locations.
+func TestExpandJSPackageManagerDirsOnlyWhenExisting(t *testing.T) {
+	home := t.TempDir()
+	// Create only the pnpm bin layout; leave npm and yarn absent.
+	pnpmBin := filepath.Join(home, ".local", "share", "pnpm", "bin")
+	if err := os.MkdirAll(pnpmBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dirs := Expand(home, "linux", "/usr/bin")
+	if !slices.Contains(dirs, pnpmBin) {
+		t.Fatalf("expected %q in dirs: %v", pnpmBin, dirs)
+	}
+	for _, absent := range []string{
+		filepath.Join(home, ".npm-global", "bin"),
+		filepath.Join(home, ".yarn", "bin"),
+		filepath.Join(home, ".config", "yarn", "global", "node_modules", ".bin"),
+	} {
+		if slices.Contains(dirs, absent) {
+			t.Errorf("did not expect non-existent %q in dirs: %v", absent, dirs)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3001. \`userManagedDirs\` in \`internal/searchpath/searchpath.go\` already includes language-ecosystem package-manager global install dirs (\`.bun/bin\`, \`.cargo/bin\`, \`.deno/bin\`, \`.volta/bin\`, asdf shims, nvm/fnm version dirs, etc.) but was missing the JS package managers that put global installs under user-prefix paths:

- **pnpm**: \`PNPM_HOME\` defaults to \`~/.local/share/pnpm\`. Older layouts symlink CLIs directly into \`PNPM_HOME\`; newer layouts use a \`bin/\` subdirectory. Both are included — the reporter's \`which codex\` shows \`~/.local/share/pnpm/bin/codex\` on Ubuntu 24.04 (newer layout), and the older layout is still in the wild via legacy installs.
- **npm with \`--prefix=~/.npm-global\`**: the documented sudo-free workaround for \`npm i -g\`. Bin at \`~/.npm-global/bin\`.
- **yarn classic**: \`--global-folder\` default puts shims at \`~/.yarn/bin\`.
- **yarn classic global registry**: \`~/.config/yarn/global/node_modules/.bin\` (catches packages that expose bins via \`package.json:bin\` rather than yarn-managed shims).

The provider-readiness probes (\`probeClaude\`, \`probeCodex\`, \`probeGemini\` in \`internal/api/handler_provider_readiness.go\`) call \`findProbeBinary\` against this **deterministic** search order rather than the ambient shell PATH — so before this fix, a CLI installed via \`pnpm add -g\`, \`npm i -g\` (with a user prefix), or \`yarn global add\` was reported as "not installed" by \`gc init\` even though \`which codex\` resolved it on the shell PATH.

## Reproduction (from #3001)

\`\`\`
$ pnpm install -g @openai/codex
$ which codex
~/.local/share/pnpm/bin/codex
$ codex --version
codex-cli 0.136.0

$ gc init     # select codex
…
Referenced providers not ready:
- Codex CLI: is not installed
  Fix: install Codex CLI
\`\`\`

Author confirmed the same with Claude Code and Gemini.

## Safety

All four new dirs go through the existing \`existingDirs()\` filter, so they're only added when the directory actually exists — no phantom search-path entries for users who don't use those package managers. \`Dedupe\` handles the doubled pnpm root/bin entries cleanly.

## Test plan

- [x] \`go vet ./internal/searchpath/...\` clean
- [x] \`go test ./internal/searchpath/\` — full package PASS
- [x] **\`TestExpandIncludesJSPackageManagerGlobalBins\`**: with all four dirs present (pnpm, .npm-global, .yarn, .config/yarn/global), all four (plus the pnpm root) appear in \`Expand\`'s output.
- [x] **\`TestExpandJSPackageManagerDirsOnlyWhenExisting\`**: only-pnpm setup includes pnpm, leaves npm/yarn absent — verifies the existing-only gating still applies to new entries.
- [x] Sanity-checked the new \`TestExpandIncludesJSPackageManagerGlobalBins\` **FAILS** on main without the fix (all five expected dirs missing from output) and **PASSES** with it.
- [x] Existing \`TestExpandUserManagedDirsOnlyExisting\` and the rest of the searchpath package suite still PASS.
- [x] \`go test ./internal/api/ -run 'TestProbe|TestReadiness|TestFindProbeBinary'\` — provider-readiness probe tests still PASS.