### PR TITLE
fix(reconciler): reserve create-budget for min-floor pools so cold pools spawn

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -122,27 +122,58 @@ func fairPoolSessionCreateShares(states []PoolDesiredState, limit int, seed uint
 	type demand struct {
 		template string
 		count    int
+		floor    bool
 	}
 	var demands []demand
 	for _, state := range states {
 		count := 0
+		floor := false
 		for _, request := range state.Requests {
 			// Requests with a session bead ID represent in-flight capacity and
 			// should not reserve fresh-create budget for this template.
 			if request.Tier == "new" && request.SessionBeadID == "" {
 				count++
+				if request.FloorGuarantee {
+					floor = true
+				}
 			}
 		}
 		if count > 0 {
-			demands = append(demands, demand{template: state.Template, count: count})
+			demands = append(demands, demand{template: state.Template, count: count, floor: floor})
 		}
 	}
 	if len(demands) <= 1 {
 		return nil, 0
 	}
 	shares := make(map[string]int, len(demands))
-	start := int(seed % uint64(len(demands)))
 	remaining := limit
+	// start rotates the per-tick allocation by seed so neither the floor
+	// reservation (Phase 1) nor the elastic round-robin (Phase 2) deterministically
+	// favors the same (e.g. alphabetically-first) templates every tick. Without
+	// this rotation, when floor-bearing templates exceed the budget the same
+	// late-order floor templates would be starved on every tick and never spawn
+	// their floor (the starvation pattern fixed in fair wake-budget selection).
+	start := int(seed % uint64(len(demands)))
+	// Phase 1: guarantee one create token per floor-bearing template
+	// (min_active_sessions floor) before elastic scale-check demand competes for
+	// the budget. Without this, a cold pool's lone floor request loses the
+	// round-robin to a warm pool's large demand and its floor never spawns.
+	// Reserved in seed-rotated order; if floor-bearing templates exceed the
+	// budget, a different subset is prioritized each tick so none is permanently
+	// starved.
+	for off := 0; off < len(demands); off++ {
+		if remaining <= 0 {
+			break
+		}
+		d := demands[(start+off)%len(demands)]
+		if d.floor {
+			shares[d.template]++
+			remaining--
+		}
+	}
+	// Phase 2: round-robin the remaining budget across all demand, capped at
+	// each template's request count (a reserved floor token counts toward that
+	// cap, so a floor-only template is not topped up further here).
 	for remaining > 0 {
 		progressed := false
 		for offset := 0; offset < len(demands) && remaining > 0; offset++ {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -154,24 +154,65 @@ func fairPoolSessionCreateShares(states []PoolDesiredState, limit int, seed uint
 	// late-order floor templates would be starved on every tick and never spawn
 	// their floor (the starvation pattern fixed in fair wake-budget selection).
 	start := int(seed % uint64(len(demands)))
+	// Reserve a slice of the budget for elastic (non-floor) demand so a large
+	// floor set can't consume the whole budget in Phase 1 and starve elastic
+	// pools to zero. Without this, when floor-bearing demand >= the budget, an
+	// elastic pool with real demand (e.g. a high-queue rig executor sitting
+	// behind ~budget floor pools) gets zero create tokens every tick and never
+	// spawns a single session. Floors keep priority (3/4 of the budget) but the
+	// reserve guarantees elastic progress; for tiny budgets (< 4) the reserve is
+	// 0, preserving the original floor-first behavior.
+	elasticDemand := 0
+	for _, d := range demands {
+		if !d.floor {
+			elasticDemand += d.count
+		}
+	}
+	elasticReserve := limit / 4
+	if elasticReserve > elasticDemand {
+		elasticReserve = elasticDemand
+	}
+	floorBudget := limit - elasticReserve
 	// Phase 1: guarantee one create token per floor-bearing template
 	// (min_active_sessions floor) before elastic scale-check demand competes for
 	// the budget. Without this, a cold pool's lone floor request loses the
 	// round-robin to a warm pool's large demand and its floor never spawns.
-	// Reserved in seed-rotated order; if floor-bearing templates exceed the
-	// budget, a different subset is prioritized each tick so none is permanently
-	// starved.
+	// Reserved in seed-rotated order, capped at floorBudget so floors can't zero
+	// the elastic reserve; if floor-bearing templates exceed floorBudget, a
+	// different subset is prioritized each tick so none is permanently starved.
+	floorUsed := 0
 	for off := 0; off < len(demands); off++ {
-		if remaining <= 0 {
+		if floorUsed >= floorBudget {
 			break
 		}
 		d := demands[(start+off)%len(demands)]
 		if d.floor {
 			shares[d.template]++
 			remaining--
+			floorUsed++
 		}
 	}
-	// Phase 2: round-robin the remaining budget across all demand, capped at
+	// Phase 2a: hand the reserved elastic slice to elastic (non-floor) demand
+	// before the general round-robin, so floors deferred out of Phase 1 can't
+	// reclaim it. Seed-rotated, capped at each template's request count.
+	elasticGiven := 0
+	for elasticGiven < elasticReserve && remaining > 0 {
+		progressed := false
+		for offset := 0; offset < len(demands) && remaining > 0 && elasticGiven < elasticReserve; offset++ {
+			d := demands[(start+offset)%len(demands)]
+			if d.floor || shares[d.template] >= d.count {
+				continue
+			}
+			shares[d.template]++
+			remaining--
+			elasticGiven++
+			progressed = true
+		}
+		if !progressed {
+			break
+		}
+	}
+	// Phase 2b: round-robin the remaining budget across all demand, capped at
 	// each template's request count (a reserved floor token counts toward that
 	// cap, so a floor-only template is not topped up further here).
 	for remaining > 0 {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3721,6 +3721,39 @@ func TestFairPoolSessionCreateSharesReservesFloorFirst(t *testing.T) {
 	}
 }
 
+// TestFairPoolSessionCreateSharesReservesElasticSliceFromFloorSaturation guards
+// against the inverse of the floor guarantee: when floor-bearing demand meets or
+// exceeds the budget, the Phase-1 floor reservation must NOT consume the whole
+// budget and zero out elastic pools. A high-demand elastic pool (e.g. a rig
+// executor with a full rig-store queue, min=0) sitting behind ~budget floor pools
+// would otherwise get zero create tokens every tick and never spawn — the
+// voxist-city vw-executor starvation. The elastic reserve (limit/4) guarantees it
+// a share for every seed.
+func TestFairPoolSessionCreateSharesReservesElasticSliceFromFloorSaturation(t *testing.T) {
+	var states []PoolDesiredState
+	for i := 0; i < 8; i++ {
+		states = append(states, PoolDesiredState{
+			Template: fmt.Sprintf("rig%d/reviewer", i),
+			Requests: []SessionRequest{{Tier: "new", FloorGuarantee: true}},
+		})
+	}
+	// One elastic pool (no floor) with demand 6, like a backed-up rig executor.
+	elastic := PoolDesiredState{Template: "voxist-web/executor"}
+	for j := 0; j < 6; j++ {
+		elastic.Requests = append(elastic.Requests, SessionRequest{Tier: "new"})
+	}
+	states = append(states, elastic)
+
+	const budget = 8 // floors (8) >= budget: Phase 1 alone would consume it all.
+	wantReserve := budget / 4
+	for seed := uint64(0); seed < uint64(len(states)); seed++ {
+		shares, _ := fairPoolSessionCreateShares(states, budget, seed)
+		if got := shares["voxist-web/executor"]; got < wantReserve {
+			t.Fatalf("seed=%d: elastic pool starved by floor saturation (got %d), want >= %d (reserved elastic slice)", seed, got, wantReserve)
+		}
+	}
+}
+
 // TestFairPoolSessionCreateSharesRotatesFloorReservation guards the Phase-1 floor
 // reservation against deterministic starvation: when floor-bearing templates
 // exceed the budget, the seed must rotate which floors are reserved so that no

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3683,6 +3683,77 @@ func TestBuildDesiredStateFairSharesFreshPoolCreatesAcrossPools(t *testing.T) {
 	}
 }
 
+// TestFairPoolSessionCreateSharesReservesFloorFirst guards against cold-pool
+// floor starvation: a cold pool's min_active_sessions floor request must get a
+// create-budget token before
+// a warm pool's larger elastic scale-check demand, regardless of the round-robin
+// seed. Before the fix the floor competed equally in the round-robin and was
+// starved (cold pools never spawned their floor).
+func TestFairPoolSessionCreateSharesReservesFloorFirst(t *testing.T) {
+	// "alpha" sorts first and has large elastic demand; "zulu" sorts last and
+	// has only a single floor-guarantee request. With budget=1 the floor must
+	// still win for every seed.
+	states := []PoolDesiredState{
+		{Template: "alpha", Requests: []SessionRequest{{Tier: "new"}, {Tier: "new"}, {Tier: "new"}}},
+		{Template: "zulu", Requests: []SessionRequest{{Tier: "new", FloorGuarantee: true}}},
+	}
+	for seed := uint64(0); seed < 5; seed++ {
+		shares, _ := fairPoolSessionCreateShares(states, 1, seed)
+		if shares["zulu"] != 1 {
+			t.Errorf("seed=%d: floor pool zulu got %d budget, want 1 (floor reserved before elastic)", seed, shares["zulu"])
+		}
+		if shares["alpha"] != 0 {
+			t.Errorf("seed=%d: elastic alpha got %d budget, want 0 (budget consumed by floor)", seed, shares["alpha"])
+		}
+	}
+
+	// Surplus budget beyond the reserved floor still flows to elastic demand,
+	// and a floor-only template is not topped up past its single request.
+	shares, spare := fairPoolSessionCreateShares(states, 3, 0)
+	if shares["zulu"] != 1 {
+		t.Errorf("floor pool zulu got %d, want 1 (not topped up past its single request)", shares["zulu"])
+	}
+	if shares["alpha"] != 2 {
+		t.Errorf("elastic alpha got %d of surplus, want 2", shares["alpha"])
+	}
+	if spare != 0 {
+		t.Errorf("spare=%d, want 0 (all budget allocated)", spare)
+	}
+}
+
+// TestFairPoolSessionCreateSharesRotatesFloorReservation guards the Phase-1 floor
+// reservation against deterministic starvation: when floor-bearing templates
+// exceed the budget, the seed must rotate which floors are reserved so that no
+// (e.g. alphabetically-late) floor template is permanently starved across ticks.
+func TestFairPoolSessionCreateSharesRotatesFloorReservation(t *testing.T) {
+	// Three floor-bearing templates, budget 1 -> only one floor reserved per tick.
+	// Over rotating seeds every template must be reserved at least once.
+	states := []PoolDesiredState{
+		{Template: "alpha", Requests: []SessionRequest{{Tier: "new", FloorGuarantee: true}}},
+		{Template: "mike", Requests: []SessionRequest{{Tier: "new", FloorGuarantee: true}}},
+		{Template: "zulu", Requests: []SessionRequest{{Tier: "new", FloorGuarantee: true}}},
+	}
+	reserved := map[string]bool{}
+	for seed := uint64(0); seed < 6; seed++ {
+		shares, _ := fairPoolSessionCreateShares(states, 1, seed)
+		total := 0
+		for tmpl, n := range shares {
+			if n > 0 {
+				reserved[tmpl] = true
+				total += n
+			}
+		}
+		if total != 1 {
+			t.Errorf("seed=%d: total floor reservations=%d, want 1 (budget=1)", seed, total)
+		}
+	}
+	for _, tmpl := range []string{"alpha", "mike", "zulu"} {
+		if !reserved[tmpl] {
+			t.Errorf("floor template %q never reserved across seeds (deterministic starvation)", tmpl)
+		}
+	}
+}
+
 func TestBuildDesiredStateFairShareIgnoresInFlightPoolCreates(t *testing.T) {
 	maxWakes := 2
 	store := beads.NewMemStore()

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -19,6 +19,13 @@ type SessionRequest struct {
 	Tier          string
 	SessionBeadID string // concrete session to preserve for resume or in-flight new demand
 	WorkBeadID    string // the work bead driving this request
+	// FloorGuarantee marks a "new" request created to satisfy an agent's
+	// min_active_sessions floor (as opposed to elastic scale-check demand).
+	// The per-tick create-budget allocator reserves a token for each
+	// floor-bearing template before round-robining the remainder, so a cold
+	// pool's floor spawn cannot be starved by a warm pool's large elastic
+	// demand (follow-up to #2893).
+	FloorGuarantee bool
 }
 
 func beadPriority(b beads.Bead) int {
@@ -357,8 +364,9 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *session
 		minSess := agent.EffectiveMinActiveSessions()
 		for usage.agentCount[template] < minSess {
 			req := SessionRequest{
-				Template: template,
-				Tier:     "new",
+				Template:       template,
+				Tier:           "new",
+				FloorGuarantee: true,
 			}
 			if _, _, _, rejected := usage.rejection(req, limits); rejected {
 				break


### PR DESCRIPTION
Follow-up to #2893 — pool-reconciler create-budget fairness.

## Problem

The per-tick pool create budget (`fairPoolSessionCreateShares`) round-robins all
"new" session requests equally. A cold pool's lone `min_active_sessions` floor
request competes against a warm pool's large elastic scale-check demand; when the
total "new" demand across contending templates exceeds the budget (default
`max_wakes_per_tick`), the floor loses the rotation and never gets a token — the
pool computes `poolDesired >= 1` but the floor session never materializes (cold
pools stay empty while a warm high-demand pool consumes the budget).

## Change

- Add `FloorGuarantee` to `SessionRequest`, set on the min-floor fill request in
  `applyNestedCaps` (`pool_desired_state.go`).
- In `fairPoolSessionCreateShares` (`build_desired_state.go`), reserve one
  create-budget token per floor-bearing template **before** round-robining the
  remainder across elastic demand.

Floors are guaranteed regardless of the round-robin seed/contention; elastic
demand still gets the surplus; a floor-only template is not topped up past its
single request; the reservation is in stable template order and bounded by the
budget (floor-bearing templates exceeding the budget defer to a later tick, so
warm elastic demand is never fully starved).

## Tests

Seed-independent unit test (`TestFairPoolSessionCreateSharesReservesFloorFirst`):
a floor pool wins a budget token over larger elastic demand at budget=1; surplus
flows to elastic at budget=3. Existing fair-share tests unchanged.
