### PR TITLE
fix(kiro): add tools to kiro overlay agent to prevent stuck sessions

### DIFF
--- a/internal/bootstrap/packs/core/overlay/per-provider/kiro/.kiro/agents/gascity.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/kiro/.kiro/agents/gascity.json
@@ -2,6 +2,7 @@
   "name": "gascity",
   "description": "Gas City orchestration agent",
   "prompt": "file://../../AGENTS.md",
+  "tools": ["*"],
   "hooks": {
     "agentSpawn": [
       {


### PR DESCRIPTION
## Summary

The Kiro provider overlay agent (`internal/bootstrap/packs/core/overlay/per-provider/kiro/.kiro/agents/gascity.json`) does not declare a `tools` field. When Gas City renders this agent for a Kiro session, `kiro-cli` ends up with no usable tools and exposes only its built-in `dummy` placeholder. The agent's first turn then fails tool validation:

```
Tool validation failed: No tool with "dummy" is found
```

so supervised sessions get stuck in `creating` and never become active.

This adds `"tools": ["*"]`, matching the trusted orchestration role of the gascity agent (it is launched with `--trust-all-tools`). With the field present, Kiro sessions expose real tools and start normally.

Kiro is the only provider with an overlay agent config, and both city- and rig-scoped Kiro agents render from this same file, so this single change fixes both.

## Testing

- JSON validated (`jq`).
- No fixtures/golden files assert this overlay's content: `internal/runtime/k8s/staging_test.go` builds its own temp fixture, and `cmd/gc/prompt_test.go` only references the `AGENTS.md` path — so existing tests are unaffected.
- Reproduced on a live Kiro-provider city: without the field, supervised sessions hang on the `dummy` tool error; with an equivalent overlay adding the field, sessions reach active and execute tools.

## Checklist

- [ ] `make check` (will run in CI)
- No issue linked: small config-only fix for an obvious provider defect.
- Not a breaking change; no docs/behavior-code changes.
