### PR TITLE
feat(hook): gc hook should query the rig store for rig-scoped agents

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -167,15 +167,21 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 	// A cross-store-eligible (city-scoped) agent federates its work query across
 	// all stores — its own first, then every rig store — matched on its own
 	// identity (vp-kvp stage iii). A rig-scoped agent ("<rig>/<name>") instead
-	// adds just its own <rig> store: its routed work lives there, but its
+	// queries its own <rig> store FIRST: its routed work lives there, but its
 	// city-scoped work-query env does not reach it, so without this the hook
-	// returns empty and the spawned session exits with nothing to do. This
+	// returns empty and the spawned session exits with nothing to do. The rig
+	// store goes first (as the primary entry, not a best-effort federated
+	// extra) so a rig-store work-query timeout still surfaces to the reconciler
+	// via firstStoreWithWork's emit-on-timeout contract — the agent's
+	// (work-less) city-scoped env stays as a best-effort secondary. This
 	// extends the #2877 city-scoped cross-store delivery to rig-scoped agents.
 	stores := []hookStore{{dir: workDir, env: queryEnv}}
 	if agentIsCrossStoreEligible(&a) {
 		stores = appendRigHookStores(stores, cityPath, cfg, &a, overrides)
 	} else if rig := rigScopedHookRig(cfg, agentForQuery); rig != "" {
-		stores = appendOneRigHookStore(stores, cityPath, cfg, &a, rig, overrides)
+		if rigStores := appendOneRigHookStore(nil, cityPath, cfg, &a, rig, overrides); len(rigStores) > 0 {
+			stores = append(rigStores, stores...)
+		}
 	}
 
 	runner := func(command, _ string) (string, error) {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -166,11 +166,16 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 
 	// A cross-store-eligible (city-scoped) agent federates its work query across
 	// all stores — its own first, then every rig store — matched on its own
-	// identity (vp-kvp stage iii). Rig agents get a single-entry list, so their
-	// behavior is byte-for-byte unchanged.
+	// identity (vp-kvp stage iii). A rig-scoped agent ("<rig>/<name>") instead
+	// adds just its own <rig> store: its routed work lives there, but its
+	// city-scoped work-query env does not reach it, so without this the hook
+	// returns empty and the spawned session exits with nothing to do. This
+	// extends the #2877 city-scoped cross-store delivery to rig-scoped agents.
 	stores := []hookStore{{dir: workDir, env: queryEnv}}
 	if agentIsCrossStoreEligible(&a) {
 		stores = appendRigHookStores(stores, cityPath, cfg, &a, overrides)
+	} else if rig := rigScopedHookRig(cfg, agentForQuery); rig != "" {
+		stores = appendOneRigHookStore(stores, cityPath, cfg, &a, rig, overrides)
 	}
 
 	runner := func(command, _ string) (string, error) {

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -36,27 +36,72 @@ func appendRigHookStores(stores []hookStore, cityPath string, cfg *config.City, 
 		return stores
 	}
 	for i := range cfg.Rigs {
-		rigName := strings.TrimSpace(cfg.Rigs[i].Name)
-		if rigName == "" {
-			continue
-		}
-		view := *a
-		view.Dir = rigName
-		rigEnv, err := hookQueryEnv(cityPath, cfg, &view)
-		if err != nil || rigEnv == nil {
-			continue
-		}
-		for _, k := range hookIdentityEnvKeys {
-			if v, ok := identityOverrides[k]; ok {
-				rigEnv[k] = v
-			}
-		}
-		stores = append(stores, hookStore{
-			dir: agentCommandDir(cityPath, &view, cfg.Rigs),
-			env: mergeRuntimeEnv(os.Environ(), rigEnv),
-		})
+		stores = appendOneRigHookStore(stores, cityPath, cfg, a, cfg.Rigs[i].Name, identityOverrides)
 	}
 	return stores
+}
+
+// appendOneRigHookStore appends the hookStore for a single named rig, reusing
+// the per-rig env machinery (a per-rig agent view whose store env points bd at
+// that rig, with the agent's identity overrides preserved so the query still
+// matches work routed/assigned to this agent). Best-effort: returns stores
+// unchanged if the rig is unknown or its env cannot be built — the agent's own
+// store is always queried first by the caller. Shared by appendRigHookStores
+// (city-scoped read federation, #2877) and the rig-scoped hook path.
+func appendOneRigHookStore(stores []hookStore, cityPath string, cfg *config.City, a *config.Agent, rigName string, identityOverrides map[string]string) []hookStore {
+	rigName = strings.TrimSpace(rigName)
+	if cfg == nil || a == nil || rigName == "" {
+		return stores
+	}
+	known := false
+	for i := range cfg.Rigs {
+		if strings.TrimSpace(cfg.Rigs[i].Name) == rigName {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return stores
+	}
+	view := *a
+	view.Dir = rigName
+	rigEnv, err := hookQueryEnv(cityPath, cfg, &view)
+	if err != nil || rigEnv == nil {
+		return stores
+	}
+	for _, k := range hookIdentityEnvKeys {
+		if v, ok := identityOverrides[k]; ok {
+			rigEnv[k] = v
+		}
+	}
+	return append(stores, hookStore{
+		dir: agentCommandDir(cityPath, &view, cfg.Rigs),
+		env: mergeRuntimeEnv(os.Environ(), rigEnv),
+	})
+}
+
+// rigScopedHookRig returns the rig whose store a rig-scoped agent must ALSO
+// query, or "" if none applies. A rig-scoped agent's identity is "<rig>/<name>"
+// (its GC_AGENT) and its routed work lives in the <rig> store, which the agent's
+// own (city-scoped) work-query env never reaches — so without this the hook
+// returns empty, the session spawns, finds nothing, and exits (churn).
+// Returns "" for a city-scoped identity (no "/") or an unknown rig, so a caller
+// only adds a real rig store. City-scoped agents already federate every rig via
+// appendRigHookStores and must not use this path.
+func rigScopedHookRig(cfg *config.City, agentIdentity string) string {
+	if cfg == nil {
+		return ""
+	}
+	rig, _, ok := strings.Cut(strings.TrimSpace(agentIdentity), "/")
+	if !ok || rig == "" {
+		return ""
+	}
+	for i := range cfg.Rigs {
+		if strings.TrimSpace(cfg.Rigs[i].Name) == rig {
+			return rig
+		}
+	}
+	return ""
 }
 
 // firstStoreWithWork runs command against each store in order and returns the

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -45,9 +45,10 @@ func appendRigHookStores(stores []hookStore, cityPath string, cfg *config.City, 
 // the per-rig env machinery (a per-rig agent view whose store env points bd at
 // that rig, with the agent's identity overrides preserved so the query still
 // matches work routed/assigned to this agent). Best-effort: returns stores
-// unchanged if the rig is unknown or its env cannot be built — the agent's own
-// store is always queried first by the caller. Shared by appendRigHookStores
-// (city-scoped read federation, #2877) and the rig-scoped hook path.
+// unchanged if the rig is unknown or its env cannot be built. Shared by
+// appendRigHookStores (city-scoped read federation, #2877, which keeps the
+// agent's own store first) and the rig-scoped hook path (which puts the rig
+// store first, as the agent's primary store).
 func appendOneRigHookStore(stores []hookStore, cityPath string, cfg *config.City, a *config.Agent, rigName string, identityOverrides map[string]string) []hookStore {
 	rigName = strings.TrimSpace(rigName)
 	if cfg == nil || a == nil || rigName == "" {

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -3,9 +3,69 @@ package main
 import (
 	"errors"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 var errTestStoreTimeout = errors.New("store timed out")
+
+// TestRigScopedHookRig is the core of the rig-scope hook fix: a rig-scoped agent
+// ("<rig>/<name>") must resolve to its own rig so the hook also queries that
+// rig's store, where its routed work lives. City-scoped identities (no "/") and
+// unknown rigs resolve to "" so no spurious store is added.
+func TestRigScopedHookRig(t *testing.T) {
+	cfg := &config.City{Rigs: []config.Rig{{Name: "voxist-web"}, {Name: "voxist-api"}}}
+	cases := []struct {
+		name     string
+		identity string
+		want     string
+	}{
+		{"rig-scoped known rig", "voxist-web/voxist.executor", "voxist-web"},
+		{"rig-scoped other known rig", "voxist-api/voxist.reviewer", "voxist-api"},
+		{"rig-scoped unknown rig", "hq/voxist.executor", ""},
+		{"city-scoped (no slash)", "voxist.architect", ""},
+		{"empty identity", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rigScopedHookRig(cfg, tc.identity); got != tc.want {
+				t.Fatalf("rigScopedHookRig(%q) = %q, want %q", tc.identity, got, tc.want)
+			}
+		})
+	}
+	if got := rigScopedHookRig(nil, "voxist-web/x"); got != "" {
+		t.Fatalf("rigScopedHookRig(nil, ...) = %q, want \"\"", got)
+	}
+}
+
+// TestAppendOneRigHookStoreSkipsUnknownInput guards the best-effort contract:
+// an unknown rig, empty rig, or nil cfg/agent must leave the store list
+// unchanged (and must not reach hookQueryEnv), so a stray GC_AGENT prefix can
+// never add a bogus store or wedge the hook.
+func TestAppendOneRigHookStoreSkipsUnknownInput(t *testing.T) {
+	cfg := &config.City{Rigs: []config.Rig{{Name: "voxist-web"}}}
+	a := &config.Agent{Name: "voxist.executor"}
+	base := []hookStore{{dir: "own"}}
+
+	for _, tc := range []struct {
+		name    string
+		cfg     *config.City
+		agent   *config.Agent
+		rigName string
+	}{
+		{"unknown rig", cfg, a, "nope"},
+		{"empty rig", cfg, a, ""},
+		{"nil cfg", nil, a, "voxist-web"},
+		{"nil agent", cfg, nil, "voxist-web"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appendOneRigHookStore(base, t.TempDir(), tc.cfg, tc.agent, tc.rigName, nil)
+			if len(got) != len(base) {
+				t.Fatalf("appendOneRigHookStore added a store for %s: len=%d, want %d", tc.name, len(got), len(base))
+			}
+		})
+	}
+}
 
 func TestFirstStoreWithWorkReturnsFirstStoreThatHasWork(t *testing.T) {
 	stores := []hookStore{{dir: "city"}, {dir: "riga"}, {dir: "rigb"}}


### PR DESCRIPTION
## Problem

A rig-scoped agent's identity is `<rig>/<name>`, and its routed work lives in
that **rig's** bd store. But `gc hook` only queries the agent's own
work-query env, which resolves to the **city** store — it never reaches the
rig store. Result: the hook returns empty, the pool still spawns the session
(scale-from-zero / cold-wake), the session finds nothing on its hook, and
exits. That's churn, and rig-store-routed work is never picked up.

This is the rig-scoped counterpart to #2877 ("deliver cross-store work to
city-scoped agents"), which already federates a city-scoped agent's hook query
across every rig store. Rig-scoped agents were left on the single (city) store.

## Change

When the agent identity (`GC_AGENT`) carries a `<rig>/` prefix for a configured
rig, the hook adds that one rig's store to its query list (the agent's own
store is still queried first). Reuses the exact per-rig env + identity-override
machinery from #2877.

- Factor `appendRigHookStores`' per-rig builder into `appendOneRigHookStore`,
  so the rig-scoped path and the city-scoped federation share one code path.
  Best-effort: a no-op for an unknown rig or an env that can't be built.
- `rigScopedHookRig` resolves the rig from the agent identity, returning `""`
  for city-scoped identities (no `/`) or unknown rigs.

### Scope / safety

- **City-scoped agents: unchanged** — they take the `agentIsCrossStoreEligible`
  branch and federate every rig exactly as before.
- **Claim/write path: unchanged** — only the hook's read query-store list is
  affected. A rig-scoped agent claiming its own rig-store bead needs no
  redirect (it already writes to that store), so the `crossStoreClaimDir`
  byte-for-byte-unchanged guarantee for rig agents still holds.
- Additive: if `GC_AGENT` lacks a rig prefix or names an unknown rig, behavior
  is identical to today.

## Tests

- `TestRigScopedHookRig` — rig resolution across known rig / other known rig /
  unknown rig / city-scoped (no slash) / empty / nil cfg.
- `TestAppendOneRigHookStoreSkipsUnknownInput` — best-effort no-op guards
  (unknown rig, empty rig, nil cfg, nil agent) never reach `hookQueryEnv`.
- Existing cross-store, `firstStoreWithWork`, and rig-agent claim tests pass
  unchanged.