### PR TITLE
Close generated spec sidecars with workflow roots

### DIFF
--- a/cmd/gc/molecule_autoclose.go
+++ b/cmd/gc/molecule_autoclose.go
@@ -184,7 +184,9 @@ func autocloseRootsForSourceBead(store beads.Store, storeRef string, rec events.
 	}
 	for _, root := range roots {
 		if terminal, _ := subtreeTerminalExcludingRoot(store, root.ID); terminal {
-			announceClosedMolecule(store, rec, root, moleculeSourceAutocloseReason, stdout)
+			if announceClosedMolecule(store, rec, root, moleculeSourceAutocloseReason, stdout) {
+				_, _ = sourceworkflow.CloseSpecSidecarsForRoot(store, root.ID, sourceworkflow.WorkflowSpecSidecarClosedReason)
+			}
 		}
 	}
 }
@@ -205,6 +207,9 @@ func subtreeTerminalExcludingRoot(store beads.Store, rootID string) (terminal bo
 		if b.ID == rootID {
 			continue
 		}
+		if sourceworkflow.IsGeneratedSpecSidecar(b) {
+			continue
+		}
 		descendants++
 		if !convoycore.IsTerminalStatus(b.Status) {
 			return false, descendants
@@ -217,9 +222,9 @@ func subtreeTerminalExcludingRoot(store beads.Store, rootID string) (terminal bo
 // BeadClosed event, and prints the auto-close announcement to stdout. Shared
 // by the step-terminal and source-bead-close triggers. Best-effort: a close
 // failure aborts silently without recording or announcing.
-func announceClosedMolecule(store beads.Store, rec events.Recorder, mol beads.Bead, reason string, stdout io.Writer) {
+func announceClosedMolecule(store beads.Store, rec events.Recorder, mol beads.Bead, reason string, stdout io.Writer) bool {
 	if err := closeMoleculeWithReason(store, mol.ID, reason); err != nil {
-		return
+		return false
 	}
 
 	rec.Record(events.Event{
@@ -229,6 +234,7 @@ func announceClosedMolecule(store beads.Store, rec events.Recorder, mol beads.Be
 	})
 
 	fmt.Fprintf(stdout, "Auto-closed molecule %s %q\n", mol.ID, mol.Title) //nolint:errcheck // best-effort stdout
+	return true
 }
 
 // closeMoleculeWithReason mirrors closeConvoyWithReason: stamps a

--- a/cmd/gc/molecule_autoclose_test.go
+++ b/cmd/gc/molecule_autoclose_test.go
@@ -323,6 +323,42 @@ func TestMoleculeAutocloseClosesWorkflowRootOnSourceBeadClose(t *testing.T) {
 	}
 }
 
+func TestMoleculeAutocloseClosesSpecSidecarsOnSourceBeadClose(t *testing.T) {
+	store := beads.NewMemStore()
+	work, _ := store.Create(beads.Bead{Title: "fix the bug", Type: "task"})
+	root, _ := store.Create(beads.Bead{
+		Title: "mol-focus-review",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   work.ID,
+		},
+	})
+	spec, _ := store.Create(beads.Bead{
+		Title: "generated step spec",
+		Type:  "spec",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": root.ID,
+			"gc.spec_for":     "implement",
+			"gc.spec_for_ref": "implement",
+		},
+	})
+
+	_ = store.Close(work.ID)
+	var out bytes.Buffer
+	doMoleculeAutocloseWith(store, "", events.Discard, work.ID, &out)
+
+	specAfter, _ := store.Get(spec.ID)
+	if specAfter.Status != "closed" {
+		t.Fatalf("spec status = %q, want closed", specAfter.Status)
+	}
+	if got := specAfter.Metadata["close_reason"]; got != sourceworkflow.WorkflowSpecSidecarClosedReason {
+		t.Fatalf("spec close_reason = %q, want %q", got, sourceworkflow.WorkflowSpecSidecarClosedReason)
+	}
+}
+
 // TestMoleculeAutocloseLeavesWorkflowRootOpenWhenStepOpenOnSourceClose asserts
 // the source-bead trigger does NOT close a multi-step workflow root that still
 // has genuine open work (e.g. an un-run review step). Only a root whose entire

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 const mailReadMetadataKey = "mail.read"
@@ -72,6 +73,13 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 	purged := 0
 	var deleteErr error
 	if m.ttl > 0 {
+		closedSpecs, specErr := sourceworkflow.CloseSpecSidecarsForClosedRoots(store, sourceworkflow.WorkflowSpecSidecarClosedReason)
+		if specErr != nil {
+			deleteErr = errors.Join(deleteErr, fmt.Errorf("closing generated spec sidecars for closed workflow roots: %w", specErr))
+		} else if closedSpecs > 0 {
+			log.Printf("wisp gc: closed %d generated spec sidecars for closed workflow roots", closedSpecs)
+		}
+
 		entries, err := closedWispGCEntries(store)
 		if err != nil {
 			return 0, err

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 func TestWispGC_NilSafe(t *testing.T) {
@@ -104,6 +105,68 @@ func TestWispGC_NothingExpired(t *testing.T) {
 	}
 	if len(store.deletedIDs) != 0 {
 		t.Fatalf("deleted = %v, want none", store.deletedIDs)
+	}
+}
+
+func TestWispGC_ClosesOpenSpecSidecarsForClosedWorkflowRoots(t *testing.T) {
+	now := time.Now()
+	store := newGCStore([]beads.Bead{
+		makeGCBeadWithMetadata("closed-workflow", now.Add(-30*time.Minute), "closed", "task", map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		}),
+		makeGCBeadWithMetadata("closed-workflow-spec", now.Add(-30*time.Minute), "open", "spec", map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": "closed-workflow",
+			"gc.spec_for":     "implement",
+		}),
+		makeGCBeadWithMetadata("open-workflow", now.Add(-30*time.Minute), "open", "task", map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		}),
+		makeGCBeadWithMetadata("open-workflow-spec", now.Add(-30*time.Minute), "open", "spec", map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": "open-workflow",
+			"gc.spec_for":     "review",
+		}),
+		makeGCBeadWithMetadata("closed-task", now.Add(-30*time.Minute), "closed", "task", nil),
+		makeGCBeadWithMetadata("closed-task-spec", now.Add(-30*time.Minute), "open", "spec", map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": "closed-task",
+		}),
+	})
+
+	wg := newWispGC(5*time.Minute, time.Hour, 0)
+	purged, err := wg.runGC(store, now)
+	if err != nil {
+		t.Fatalf("runGC: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("purged = %d, want 0; spec repair should not count as purge", purged)
+	}
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deleted = %v, want none", store.deletedIDs)
+	}
+
+	closedSpec, err := store.Get("closed-workflow-spec")
+	if err != nil {
+		t.Fatalf("Get(closed-workflow-spec): %v", err)
+	}
+	if closedSpec.Status != "closed" {
+		t.Fatalf("closed-workflow-spec status = %q, want closed", closedSpec.Status)
+	}
+	if got := closedSpec.Metadata["close_reason"]; got != sourceworkflow.WorkflowSpecSidecarClosedReason {
+		t.Fatalf("close_reason = %q, want %q", got, sourceworkflow.WorkflowSpecSidecarClosedReason)
+	}
+
+	for _, id := range []string{"open-workflow-spec", "closed-task-spec"} {
+		spec, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if spec.Status != "open" {
+			t.Fatalf("%s status = %q, want open", id, spec.Status)
+		}
 	}
 }
 

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -681,6 +681,9 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 		}
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow head: %w", rootID, err))
 	}
+	if _, err := sourceworkflow.CloseSpecSidecarsForRoot(store, rootID, sourceworkflow.WorkflowSpecSidecarClosedReason); err != nil {
+		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing workflow spec sidecars: %w", rootID, err))
+	}
 	if outcome == "pass" {
 		if err := closeSourceBeadChain(store, rootID, opts); err != nil {
 			return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing source bead chain: %w", rootID, err))

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -1812,6 +1812,58 @@ func TestProcessWorkflowFinalizeClosesWorkflow(t *testing.T) {
 	}
 }
 
+func TestProcessWorkflowFinalizeClosesOpenSpecSidecars(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	spec := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "generated step spec",
+		Type:  "spec",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": workflow.ID,
+			"gc.spec_for":     "implement",
+			"gc.spec_for_ref": "implement",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("workflow result = %+v, want processed workflow-pass", result)
+	}
+
+	specAfter := mustGetBead(t, store, spec.ID)
+	if specAfter.Status != "closed" {
+		t.Fatalf("spec status = %q, want closed", specAfter.Status)
+	}
+	if got := specAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("spec gc.outcome = %q, want pass", got)
+	}
+	if got := specAfter.Metadata["close_reason"]; got != sourceworkflow.WorkflowSpecSidecarClosedReason {
+		t.Fatalf("spec close_reason = %q, want %q", got, sourceworkflow.WorkflowSpecSidecarClosedReason)
+	}
+}
+
 func TestProcessWorkflowFinalizeTreatsQuarantinedControlAsFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -46,6 +46,12 @@ const SourceStoreRefMetadataKey = "gc.source_store_ref"
 // strict stores that require a human-readable close reason accept the cleanup.
 const WorkflowSubtreeClosedReason = "source workflow cleanup: subtree force-closed by CloseWorkflowSubtree"
 
+// WorkflowSpecSidecarClosedReason is stamped on generated spec sidecars when
+// their owning workflow root has closed. These beads are topology hints, not
+// executable work, so leaving them open after the root closes makes them appear
+// as leaked work.
+const WorkflowSpecSidecarClosedReason = "workflow cleanup: generated spec sidecar closed with workflow root"
+
 // WorkflowSkippedCloseReason is the canonical close_reason stamped on
 // workflow-subtree beads when they are force-closed via the
 // gc.outcome=skipped cleanup path (gc convoy delete --skip, force-replace
@@ -454,6 +460,146 @@ func CloseWorkflowSubtree(store beads.Store, rootID string) (int, error) {
 		"gc.outcome":   "skipped",
 		"close_reason": WorkflowSubtreeClosedReason,
 	})
+}
+
+// CloseSpecSidecarsForRoot closes open generated spec sidecars owned by the
+// workflow root. It is safe to call after the root has already been closed.
+func CloseSpecSidecarsForRoot(store beads.Store, rootID, reason string) (int, error) {
+	if store == nil {
+		return 0, fmt.Errorf("bead store unavailable")
+	}
+	rootID = strings.TrimSpace(rootID)
+	if rootID == "" {
+		return 0, nil
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = WorkflowSpecSidecarClosedReason
+	}
+
+	matched, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		IncludeClosed: true,
+		Metadata: map[string]string{
+			"gc.root_bead_id": rootID,
+		},
+		TierMode: beads.TierBoth,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing workflow spec sidecars for %s: %w", rootID, err)
+	}
+	ids := make([]string, 0, len(matched))
+	for _, bead := range matched {
+		if bead.ID == "" || bead.Status == "closed" || !IsGeneratedSpecSidecar(bead) {
+			continue
+		}
+		ids = append(ids, bead.ID)
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	slices.Sort(ids)
+	ordered, err := closeorder.Order(store, ids)
+	if err != nil {
+		return 0, fmt.Errorf("ordering workflow spec sidecars for %s: %w", rootID, err)
+	}
+	return store.CloseAll(ordered, map[string]string{
+		"gc.outcome":   "pass",
+		"close_reason": reason,
+	})
+}
+
+// CloseSpecSidecarsForClosedRoots closes generated spec sidecars whose owning
+// workflow root is already closed. It repairs residues left by older workflow
+// finalizers and source-bead close hooks.
+func CloseSpecSidecarsForClosedRoots(store beads.Store, reason string) (int, error) {
+	if store == nil {
+		return 0, fmt.Errorf("bead store unavailable")
+	}
+	specs, err := generatedSpecSidecarCandidates(store)
+	if err != nil {
+		return 0, err
+	}
+	rootIDs := make(map[string]struct{})
+	for _, spec := range specs {
+		rootID := strings.TrimSpace(spec.Metadata["gc.root_bead_id"])
+		if rootID == "" {
+			continue
+		}
+		root, err := store.Get(rootID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
+			return 0, fmt.Errorf("loading workflow root %s for spec %s: %w", rootID, spec.ID, err)
+		}
+		if root.Status == "closed" && IsWorkflowRoot(root) {
+			rootIDs[rootID] = struct{}{}
+		}
+	}
+	if len(rootIDs) == 0 {
+		return 0, nil
+	}
+	orderedRoots := make([]string, 0, len(rootIDs))
+	for rootID := range rootIDs {
+		orderedRoots = append(orderedRoots, rootID)
+	}
+	slices.Sort(orderedRoots)
+
+	closed := 0
+	for _, rootID := range orderedRoots {
+		n, err := CloseSpecSidecarsForRoot(store, rootID, reason)
+		if err != nil {
+			return closed, err
+		}
+		closed += n
+	}
+	return closed, nil
+}
+
+func generatedSpecSidecarCandidates(store beads.Store) ([]beads.Bead, error) {
+	seen := map[string]struct{}{}
+	var out []beads.Bead
+	appendUnique := func(items []beads.Bead) {
+		for _, item := range items {
+			if item.ID == "" || item.Status == "closed" || !IsGeneratedSpecSidecar(item) {
+				continue
+			}
+			if _, ok := seen[item.ID]; ok {
+				continue
+			}
+			seen[item.ID] = struct{}{}
+			out = append(out, item)
+		}
+	}
+
+	typed, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		Type:          "spec",
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing open spec sidecars by type: %w", err)
+	}
+	appendUnique(typed)
+
+	marked, err := beads.HandlesFor(store).Live.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.kind": "spec"},
+		IncludeClosed: true,
+		TierMode:      beads.TierBoth,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing open spec sidecars by metadata: %w", err)
+	}
+	appendUnique(marked)
+
+	return out, nil
+}
+
+// IsGeneratedSpecSidecar reports whether a bead is a generated workflow spec
+// sidecar rather than executable work.
+func IsGeneratedSpecSidecar(bead beads.Bead) bool {
+	return strings.EqualFold(strings.TrimSpace(bead.Metadata["gc.kind"]), "spec") ||
+		strings.EqualFold(strings.TrimSpace(bead.Type), "spec")
 }
 
 // WorkflowBeadSnapshot captures the mutable fields of a workflow subtree


### PR DESCRIPTION
## Cause

Generated workflow spec sidecars are topology beads: dispatch and routing intentionally skip them as executable work. The workflow root close paths did not consistently close those sidecars, so a workflow root could be closed while its generated `gc.kind=spec` beads remained open and visible as leaked work. The source-bead autoclose path also counted open spec sidecars as unfinished descendants, which could prevent stepless workflow roots from closing in the first place.

## Fix

- Add `sourceworkflow` helpers that identify generated spec sidecars, close root-owned sidecars after a workflow root is closed, and repair sidecars whose owning workflow root is already closed.
- Invoke the cleanup from workflow-finalize after the root close, from source-bead autoclose after the root close, and from wisp GC for existing closed-root residue.
- Exclude generated spec sidecars from source-bead autoclose terminality checks so topology beads do not block root closure.

## Verification

- `.githooks/pre-commit` ran successfully during commit, including `go vet ./...` and `./scripts/test-local-parallel fast`.
- Focused checks also passed:
  - `go test ./internal/sourceworkflow`
  - `go test ./internal/dispatch -run 'TestProcessWorkflowFinalizeClosesOpenSpecSidecars|TestProcessWorkflowFinalizeClosesWorkflow|TestProcessScopeCheckIgnoresOpenSpecBeadsWhenCompletingScope|TestProcessScopeCheckDoesNotSkipOpenSpecBeadsWhenFailingScope'`
  - `go test ./cmd/gc -run 'TestMoleculeAutocloseClosesWorkflowRootOnSourceBeadClose|TestMoleculeAutocloseClosesSpecSidecarsOnSourceBeadClose|TestWispGC_ClosesOpenSpecSidecarsForClosedWorkflowRoots|TestWispGC_NothingExpired'`
